### PR TITLE
Tighten L0 payload: state rotation, stack oneliner, question limit

### DIFF
--- a/packages/nauro-core/src/nauro_core/__init__.py
+++ b/packages/nauro-core/src/nauro_core/__init__.py
@@ -114,10 +114,16 @@ from nauro_core.parsing import (
     decisions_summary_lines as decisions_summary_lines,
 )
 from nauro_core.parsing import (
+    extract_current_state as extract_current_state,
+)
+from nauro_core.parsing import (
     extract_decision_number as extract_decision_number,
 )
 from nauro_core.parsing import (
     extract_relevance_snippet as extract_relevance_snippet,
+)
+from nauro_core.parsing import (
+    extract_stack_oneliner as extract_stack_oneliner,
 )
 from nauro_core.parsing import (
     extract_stack_summary as extract_stack_summary,

--- a/packages/nauro-core/src/nauro_core/constants.py
+++ b/packages/nauro-core/src/nauro_core/constants.py
@@ -6,7 +6,7 @@ defaults, and similarity thresholds.
 """
 
 # ── L0/L1/L2 payload limits ──
-L0_QUESTIONS_LIMIT = 5
+L0_QUESTIONS_LIMIT = 3
 L0_DECISIONS_SUMMARY_LIMIT = 10
 L1_DECISIONS_LIMIT = 10
 L1_DECISIONS_SUMMARY_LIMIT = 10

--- a/packages/nauro-core/src/nauro_core/context.py
+++ b/packages/nauro-core/src/nauro_core/context.py
@@ -14,7 +14,8 @@ from nauro_core.constants import (
 )
 from nauro_core.parsing import (
     decisions_summary_lines,
-    extract_stack_summary,
+    extract_current_state,
+    extract_stack_oneliner,
     parse_questions,
 )
 
@@ -43,12 +44,14 @@ def build_l0(files: dict[str, str], decisions: list[dict]) -> str:
 
     state = files.get("state.md", "")
     if state.strip():
-        sections.append(state.strip())
+        current = extract_current_state(state)
+        if current:
+            sections.append("## Current State\n" + current)
 
     stack = files.get("stack.md", "")
-    summary = extract_stack_summary(stack)
-    if summary:
-        sections.append("## Stack\n" + summary)
+    oneliner = extract_stack_oneliner(stack)
+    if oneliner:
+        sections.append("**Stack:** " + oneliner)
 
     questions_content = files.get("questions.md", "")
     questions = parse_questions(questions_content)

--- a/packages/nauro-core/src/nauro_core/parsing.py
+++ b/packages/nauro-core/src/nauro_core/parsing.py
@@ -127,6 +127,47 @@ def parse_decision(content: str, filename: str) -> dict:
     }
 
 
+def extract_current_state(state_content: str) -> str:
+    """Extract only the ``## Current`` section from state.md content.
+
+    Returns the text between ``## Current`` and the next ``##`` heading
+    (or end of file). Returns empty string if no ``## Current`` section
+    is found, allowing callers to fall back to full content.
+    """
+    lines = state_content.split("\n")
+    in_current = False
+    current_lines: list[str] = []
+    for line in lines:
+        if line.strip().lower() == "## current":
+            in_current = True
+            continue
+        if in_current and line.startswith("## "):
+            break
+        if in_current:
+            current_lines.append(line)
+    return "\n".join(current_lines).strip()
+
+
+def extract_stack_oneliner(stack_content: str) -> str:
+    """Extract a one-line stack summary listing only technology names.
+
+    Parses bold items (``**Name**``) from top-level bullet lines in
+    stack.md and joins them with commas. Returns empty string for
+    empty or placeholder stacks.
+    """
+    if not stack_content.strip() or stack_content.strip() == STACK_EMPTY_MARKER:
+        return ""
+
+    names: list[str] = []
+    for line in stack_content.split("\n"):
+        stripped = line.strip()
+        if stripped.startswith("- ") and not line.startswith("  "):
+            m = re.match(r"-\s+\*\*(.+?)\*\*", stripped)
+            if m:
+                names.append(m.group(1))
+    return ", ".join(names)
+
+
 def extract_stack_summary(stack_content: str) -> str:
     """Extract one-line tech choices from stack.md (no full reasoning)."""
     if not stack_content.strip() or stack_content.strip() == STACK_EMPTY_MARKER:

--- a/packages/nauro-core/tests/test_context.py
+++ b/packages/nauro-core/tests/test_context.py
@@ -18,7 +18,13 @@ def _make_decision(num, title, status="active", date="2026-04-01", rationale="Re
 
 FULL_FILES = {
     "project.md": "# MyProject\nGoal: build something great.",
-    "state.md": "# Current State\n**Focus:** shipping v1",
+    "state.md": (
+        "# State\n\n"
+        "## Current\n"
+        "Shipping v1 — finishing auth module\n\n"
+        "## History\n"
+        "- **2026-03-01:** Set up project scaffolding\n"
+    ),
     "stack.md": (
         "# Stack\n"
         "## Language\n"
@@ -50,12 +56,17 @@ class TestBuildL0:
     def test_full_files(self):
         result = build_l0(FULL_FILES, DECISIONS)
         assert "# MyProject" in result
-        assert "**Focus:** shipping v1" in result
-        assert "## Stack" in result
-        assert "**Python 3.11+**" in result
+        assert "## Current State" in result
+        assert "Shipping v1" in result
+        assert "**Stack:** Python 3.11+" in result
         assert "## Open Questions" in result
         assert "How does auth work?" in result
         assert "## Recent Decisions" in result
+
+    def test_current_state_only(self):
+        result = build_l0(FULL_FILES, DECISIONS)
+        assert "Shipping v1" in result
+        assert "Set up project scaffolding" not in result  # history excluded
 
     def test_decisions_summary_present(self):
         result = build_l0(FULL_FILES, DECISIONS)
@@ -67,16 +78,18 @@ class TestBuildL0:
         result = build_l0(FULL_FILES, DECISIONS)
         assert "Old choice" not in result
 
-    def test_questions_limit_5(self):
+    def test_questions_limit_3(self):
         result = build_l0(FULL_FILES, DECISIONS)
         assert "Sixth question?" not in result
-        assert "Monitoring setup?" in result
+        assert "Deploy strategy?" not in result
+        assert "Monitoring setup?" not in result
+        assert "Redis or Memcached?" in result
 
     def test_missing_project_md(self):
         files = {k: v for k, v in FULL_FILES.items() if k != "project.md"}
         result = build_l0(files, DECISIONS)
         assert "# MyProject" not in result
-        assert "**Focus:** shipping v1" in result
+        assert "Shipping v1" in result
 
     def test_empty_decisions(self):
         result = build_l0(FULL_FILES, [])
@@ -87,16 +100,18 @@ class TestBuildL0:
         result = build_l0({}, [])
         assert result == ""
 
-    def test_stack_summary_not_full(self):
+    def test_stack_oneliner(self):
         result = build_l0(FULL_FILES, [])
-        assert "Chose over Go" not in result  # indented reasoning excluded
+        assert "**Stack:** Python 3.11+, AWS Lambda" in result
+        assert "Chose over Go" not in result
+        assert "## Language" not in result
 
 
 class TestBuildL1:
     def test_canonical_ordering(self):
         result = build_l1(FULL_FILES, DECISIONS)
         project_pos = result.find("# MyProject")
-        state_pos = result.find("**Focus:** shipping v1")
+        state_pos = result.find("# State")
         stack_pos = result.find("# Stack")
         questions_pos = result.find("# Open Questions")
         decisions_pos = result.find("## Decisions")

--- a/packages/nauro-core/tests/test_parsing.py
+++ b/packages/nauro-core/tests/test_parsing.py
@@ -2,7 +2,9 @@
 
 from nauro_core.parsing import (
     decisions_summary_lines,
+    extract_current_state,
     extract_relevance_snippet,
+    extract_stack_oneliner,
     extract_stack_summary,
     parse_decision,
     parse_metadata_field,
@@ -263,3 +265,63 @@ class TestExtractRelevanceSnippet:
         short = extract_relevance_snippet(text, ["target"], length=20)
         long = extract_relevance_snippet(text, ["target"], length=200)
         assert len(short) < len(long)
+
+
+class TestExtractCurrentState:
+    def test_extracts_current_section(self):
+        content = (
+            "# State\n\n"
+            "## Current\n"
+            "Working on auth module\n\n"
+            "## History\n"
+            "- **2026-03-01:** Set up project\n"
+        )
+        result = extract_current_state(content)
+        assert result == "Working on auth module"
+
+    def test_no_current_section(self):
+        content = "# Current State\n**Focus:** shipping v1\n"
+        assert extract_current_state(content) == ""
+
+    def test_empty_current(self):
+        content = "# State\n\n## Current\n\n## History\n- old stuff\n"
+        assert extract_current_state(content) == ""
+
+    def test_multiline_current(self):
+        content = "# State\n\n## Current\nLine one\nLine two\n\n## History\n"
+        result = extract_current_state(content)
+        assert "Line one" in result
+        assert "Line two" in result
+
+    def test_current_at_end_of_file(self):
+        content = "# State\n\n## Current\nDoing things\n"
+        assert extract_current_state(content) == "Doing things"
+
+
+class TestExtractStackOneliner:
+    def test_normal_stack(self):
+        content = (
+            "# Stack\n"
+            "## Language\n"
+            "- **Python 3.11+** \u2014 main language\n"
+            "  - Chose over Go for ecosystem\n"
+            "## Infrastructure\n"
+            "- **AWS Lambda** \u2014 serverless\n"
+        )
+        result = extract_stack_oneliner(content)
+        assert result == "Python 3.11+, AWS Lambda"
+
+    def test_empty_stack(self):
+        content = "# Stack\n<!-- Tech choices with rationale and rejected alternatives -->"
+        assert extract_stack_oneliner(content) == ""
+
+    def test_blank_content(self):
+        assert extract_stack_oneliner("") == ""
+
+    def test_no_bold_items(self):
+        content = "# Stack\n- plain item without bold\n"
+        assert extract_stack_oneliner(content) == ""
+
+    def test_skips_indented_items(self):
+        content = "# Stack\n- **FastAPI** \u2014 web framework\n  - **Not this** \u2014 nested\n"
+        assert extract_stack_oneliner(content) == "FastAPI"

--- a/packages/nauro/src/nauro/constants.py
+++ b/packages/nauro/src/nauro/constants.py
@@ -78,7 +78,6 @@ CHARS_PER_TOKEN = 4  # rough chars-per-token for GPT/Claude family models
 
 # ── Writer limits ──
 SLUG_MAX_LENGTH = 60
-RECENTLY_SHIPPED_LIMIT = 5
 
 # ── Snapshot pruning intervals (days) ──
 PRUNE_KEEP_ALL_DAYS = 7
@@ -88,7 +87,6 @@ PRUNE_WEEKLY_DAYS = 180
 # ── State field patterns (used in parsing and diffing) ──
 STATE_FIELD_LAST_SYNCED_BOLD = r"\*\*Last synced:\*\*\s*(.*)"
 STATE_FIELD_LAST_SYNCED_ITALIC = r"\*Last synced:\s*(.*?)\*"
-STATE_FIELD_RECENTLY_SHIPPED = "**Recently shipped:**"
 STATE_DIFF_FIELDS = ("Sprint", "Focus", "Blockers")
 
 # ── Git hook markers ──

--- a/packages/nauro/src/nauro/demo/__init__.py
+++ b/packages/nauro/src/nauro/demo/__init__.py
@@ -94,18 +94,15 @@ types in sync would slow us down considerably at this team size.
 """
 
 STATE_MD = f"""\
-# Current State
-**Focus:** Implementing user authentication
-**Active tasks:**
-- Building JWT-based auth flow with refresh tokens
-- Setting up role-based access control (RBAC)
-**Blocked on:**
-- Nothing right now
-**Recently shipped:**
-- CI pipeline with GitHub Actions
-- Database schema and migrations
-- Project scaffolding with Turborepo
-*Last synced: {_DEMO_DATE}*
+# State
+
+## Current
+Implementing user authentication \u2014 building JWT-based auth flow \
+with refresh tokens and RBAC.
+
+## History
+- **{_DEMO_DATE}:** Shipped CI pipeline with GitHub Actions, \
+database schema and migrations, project scaffolding with Turborepo.
 """
 
 OPEN_QUESTIONS_MD = """\

--- a/packages/nauro/src/nauro/store/writer.py
+++ b/packages/nauro/src/nauro/store/writer.py
@@ -15,9 +15,7 @@ from nauro_core import extract_decision_number
 from nauro.constants import (
     DECISIONS_DIR,
     OPEN_QUESTIONS_MD,
-    RECENTLY_SHIPPED_LIMIT,
     SLUG_MAX_LENGTH,
-    STATE_FIELD_RECENTLY_SHIPPED,
     STATE_MD,
 )
 
@@ -290,62 +288,75 @@ def append_question(store_path: Path, question: str) -> None:
 
 
 def update_state(store_path: Path, delta: str) -> None:
-    """Update state.md: append delta to 'Recently completed' (keep last 5), update 'Last synced'.
+    """Replace the current state with *delta*, rotating the previous current into history.
+
+    The state.md file uses ``## Current`` and ``## History`` sections.
+    Each call replaces ``## Current`` with the new delta and prepends the
+    old current text (with a timestamp) to ``## History``.
+
+    If state.md uses the legacy format (no ``## Current`` / ``## History``),
+    the entire body is migrated into ``## History`` on first call.
 
     Args:
         store_path: Path to the project store directory.
-        delta: One-sentence description of what was completed.
+        delta: The new current state description.
     """
     state_path = store_path / STATE_MD
-    timestamp = datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC")
-
     if not state_path.exists():
         return
 
     content = state_path.read_text()
+    timestamp = datetime.now(UTC).strftime("%Y-%m-%d")
 
-    # Update "Last synced" line
-    content = re.sub(
-        r"\*Last synced:.*?\*",
-        f"*Last synced: {timestamp}*",
-        content,
-    )
-
-    # Update "Recently completed" section
-    # Find the section and collect existing items
+    # Parse existing sections
     lines = content.split("\n")
-    result = []
-    in_recent = False
-    recent_items: list[str] = []
+    header_lines: list[str] = []
+    current_lines: list[str] = []
+    history_lines: list[str] = []
+    section: str | None = None
 
     for line in lines:
-        if line.startswith(STATE_FIELD_RECENTLY_SHIPPED):
-            in_recent = True
-            result.append(line)
+        low = line.strip().lower()
+        if low == "## current":
+            section = "current"
             continue
+        elif low == "## history":
+            section = "history"
+            continue
+        elif section is None:
+            header_lines.append(line)
+        elif section == "current":
+            current_lines.append(line)
+        elif section == "history":
+            history_lines.append(line)
 
-        if in_recent:
-            if line.startswith("- ") and "none yet" not in line:
-                recent_items.append(line)
-                continue
-            elif line.startswith("- "):
-                # Skip placeholder like "- (none yet)"
-                continue
-            else:
-                # End of recently completed section — inject updated items
-                recent_items.insert(0, f"- {delta}")
-                recent_items = recent_items[:RECENTLY_SHIPPED_LIMIT]
-                result.extend(recent_items)
-                in_recent = False
-                result.append(line)
-                continue
+    old_current = "\n".join(current_lines).strip()
 
-        result.append(line)
+    # Legacy migration: if no ## Current section was found, treat body after
+    # the H1 header as history content.
+    if section is None:
+        body_start = 0
+        for i, line in enumerate(header_lines):
+            if line.startswith("# "):
+                body_start = i + 1
+                break
+        legacy_body = "\n".join(header_lines[body_start:]).strip()
+        header_lines = header_lines[:body_start]
+        if legacy_body:
+            history_lines = [f"- **{timestamp}:** (migrated) {legacy_body}"] + history_lines
 
-    # If we were still in_recent at end of file
-    if in_recent:
-        recent_items.insert(0, f"- {delta}")
-        recent_items = recent_items[:RECENTLY_SHIPPED_LIMIT]
-        result.extend(recent_items)
+    # Rotate old current into history
+    if old_current:
+        history_lines.insert(0, f"- **{timestamp}:** {old_current}")
 
-    state_path.write_text("\n".join(result))
+    # Assemble
+    parts = header_lines
+    parts.append("")
+    parts.append("## Current")
+    parts.append(delta)
+    parts.append("")
+    parts.append("## History")
+    if history_lines:
+        parts.extend(history_lines)
+
+    state_path.write_text("\n".join(parts) + "\n")

--- a/packages/nauro/src/nauro/templates/scaffolds.py
+++ b/packages/nauro/src/nauro/templates/scaffolds.py
@@ -33,15 +33,12 @@ is useful. "Users" is not.]
 """
 
 STATE_MD = """\
-# Current State
-**Focus:** [What you're building right now in one phrase, e.g. "User auth flow"]
-**Active tasks:**
-- [The thing you'd tell a colleague if they asked "what are you working on?"]
-**Blocked on:**
-- [Nothing right now] or [Specific blocker, e.g. "Waiting on Stripe API approval"]
-**Recently shipped:**
-- [Last thing you finished, e.g. "Database schema and migrations"]
-*Last synced: {created_at}*
+# State
+
+## Current
+[What you're working on right now — e.g. "Building user auth flow, blocked on Stripe API approval"]
+
+## History
 """
 
 STACK_MD = """\
@@ -145,7 +142,7 @@ def scaffold_project_store(project_name: str, store_path: Path) -> None:
     created_at = datetime.now(UTC).strftime("%Y-%m-%d")
 
     (store_path / C.PROJECT_MD).write_text(render_scaffold(PROJECT_MD, project_name=project_name))
-    (store_path / C.STATE_MD).write_text(render_scaffold(STATE_MD, created_at=created_at))
+    (store_path / C.STATE_MD).write_text(render_scaffold(STATE_MD))
     (store_path / C.STACK_MD).write_text(render_scaffold(STACK_MD))
     (store_path / C.OPEN_QUESTIONS_MD).write_text(render_scaffold(OPEN_QUESTIONS_MD))
 

--- a/packages/nauro/tests/test_demo.py
+++ b/packages/nauro/tests/test_demo.py
@@ -64,8 +64,8 @@ class TestDemoProjectStructure:
 
     def test_state_has_content(self, demo_store):
         content = (demo_store / constants.STATE_MD).read_text()
-        assert "Focus:" in content
-        assert "Recently shipped:" in content
+        assert "## Current" in content
+        assert "## History" in content
 
     def test_open_questions_has_content(self, demo_store):
         content = (demo_store / constants.OPEN_QUESTIONS_MD).read_text()

--- a/packages/nauro/tests/test_mcp.py
+++ b/packages/nauro/tests/test_mcp.py
@@ -21,10 +21,10 @@ def store(tmp_path: Path) -> Path:
     # Add stack content
     (store_path / "stack.md").write_text(
         "# Stack\n"
-        "- Python 3.11 — primary language\n"
-        "- FastAPI — HTTP framework\n"
-        "- PostgreSQL — primary database\n"
-        "- Redis — caching layer\n"
+        "- **Python 3.11** \u2014 primary language\n"
+        "- **FastAPI** \u2014 HTTP framework\n"
+        "- **PostgreSQL** \u2014 primary database\n"
+        "- **Redis** \u2014 caching layer\n"
     )
 
     # Add some decisions
@@ -67,25 +67,27 @@ def client(tmp_path: Path, monkeypatch) -> AsyncClient:
 
 
 class TestL0Payload:
-    def test_contains_state(self, store: Path):
+    def test_contains_current_state(self, store: Path):
         payload = build_l0_payload(store)
-        assert "Current State" in payload
+        assert "## Current State" in payload
+        assert "Fixed bug in auth" in payload
 
-    def test_contains_stack_summary(self, store: Path):
+    def test_contains_stack_oneliner(self, store: Path):
         payload = build_l0_payload(store)
+        assert "**Stack:**" in payload
         assert "Python 3.11" in payload
         assert "FastAPI" in payload
 
-    def test_contains_top5_questions(self, store: Path):
+    def test_contains_top3_questions(self, store: Path):
         payload = build_l0_payload(store)
-        # Should have the 5 most recent, not all 7
+        # Should have the 3 most recent, not all 7
         assert "Question 7?" in payload
-        assert "Question 3?" in payload
-        # Check we have exactly 5 question lines in the Open Questions section
+        assert "Question 5?" in payload
+        # Check we have exactly 3 question lines in the Open Questions section
         lines = [
             line for line in payload.split("\n") if "Question" in line and line.startswith("- [")
         ]
-        assert len(lines) == 5
+        assert len(lines) == 3
 
     def test_contains_decisions_summary(self, store: Path):
         payload = build_l0_payload(store)
@@ -95,9 +97,10 @@ class TestL0Payload:
         # Summary uses compact format: D{num} — Title (date)
         assert "D6 —" in payload or "D006 —" in payload or "D6 — Decision 6" in payload
 
-    def test_contains_last_synced(self, store: Path):
+    def test_excludes_history(self, store: Path):
         payload = build_l0_payload(store)
-        assert "Last synced" in payload
+        # History entries should not appear in L0
+        assert "Implemented feature X" not in payload
 
     def test_word_count_budget(self, store: Path):
         payload = build_l0_payload(store)

--- a/packages/nauro/tests/test_stdio_server.py
+++ b/packages/nauro/tests/test_stdio_server.py
@@ -30,7 +30,7 @@ def store(tmp_path: Path, monkeypatch) -> Path:
     scaffold_project_store("testproj", store_path)
 
     (store_path / "stack.md").write_text(
-        "# Stack\n- Python 3.11 — primary language\n- FastAPI — HTTP framework\n"
+        "# Stack\n- **Python 3.11** \u2014 primary language\n- **FastAPI** \u2014 HTTP framework\n"
     )
     append_decision(store_path, "Use FastAPI", rationale="Good async support for our web server.")
     append_question(store_path, "Should we add caching?")
@@ -66,9 +66,9 @@ class TestResolveStore:
 
 
 class TestGetContext:
-    def test_l0_returns_state(self, store: Path):
+    def test_l0_returns_current_state(self, store: Path):
         result = get_context(project="testproj", level=0)
-        assert "Current State" in result
+        assert "## Current State" in result
 
     def test_l1_returns_full_stack(self, store: Path):
         result = get_context(project="testproj", level=1)

--- a/packages/nauro/tests/test_store.py
+++ b/packages/nauro/tests/test_store.py
@@ -185,29 +185,45 @@ def test_question_multiple(store: Path):
 # --- State update tests ---
 
 
-def test_update_state_adds_delta(store: Path):
+def test_update_state_replaces_current(store: Path):
     update_state(store, "Implemented auth module")
     content = (store / "state.md").read_text()
+    assert "## Current" in content
     assert "Implemented auth module" in content
-    assert "(none yet)" not in content
 
 
-def test_update_state_keeps_last_5(store: Path):
-    for i in range(7):
+def test_update_state_rotates_to_history(store: Path):
+    update_state(store, "First task")
+    update_state(store, "Second task")
+    content = (store / "state.md").read_text()
+    # Current should be the latest delta only
+    lines = content.split("\n")
+    in_current = False
+    current_text = []
+    for line in lines:
+        if line.strip().lower() == "## current":
+            in_current = True
+            continue
+        if line.startswith("## ") and in_current:
+            break
+        if in_current:
+            current_text.append(line)
+    current = "\n".join(current_text).strip()
+    assert current == "Second task"
+    # History should contain the first task
+    assert "First task" in content
+    assert "## History" in content
+
+
+def test_update_state_history_accumulates(store: Path):
+    for i in range(5):
         update_state(store, f"Task {i}")
     content = (store / "state.md").read_text()
-    items = [line for line in content.split("\n") if line.startswith("- Task")]
-    assert len(items) == 5
-    # Most recent first
-    assert "Task 6" in items[0]
-
-
-def test_update_state_updates_last_synced(store: Path):
-    update_state(store, "something")
-    content = (store / "state.md").read_text()
-    assert "*Last synced:" in content
-    # Should have a UTC timestamp, not the scaffold date
-    assert "UTC" in content
+    # Current is the last one
+    assert "## Current\nTask 4" in content
+    # All previous tasks are in history
+    for i in range(4):
+        assert f"Task {i}" in content
 
 
 # --- Snapshot tests ---
@@ -508,7 +524,7 @@ def test_validate_unfilled_prompts(store: Path):
 def test_validate_stale_sync(tmp_path: Path):
     store = tmp_path / "projects" / "stale"
     scaffold_project_store("stale", store)
-    # Make Last synced old
+    # Legacy format with old Last synced — validator still detects it
     state = store / "state.md"
     old_date = (datetime.now(UTC) - timedelta(days=10)).strftime("%Y-%m-%d")
     state.write_text(f"# Current State\n*Last synced: {old_date}*\n")
@@ -529,17 +545,14 @@ def test_validate_decision_gap(store: Path):
 
 
 def test_validate_no_warnings_clean_store(tmp_path: Path):
-    """A store with filled prompts and recent sync has no warnings."""
+    """A store with filled prompts and no issues has no warnings."""
     store = tmp_path / "projects" / "clean"
     store.mkdir(parents=True)
     (store / "decisions").mkdir()
     (store / "snapshots").mkdir()
 
-    now = datetime.now(UTC)
     (store / "project.md").write_text("# Clean\n\nA clean project.\n")
-    (store / "state.md").write_text(
-        f"# Current State\n*Last synced: {now.strftime('%Y-%m-%d %H:%M UTC')}*\n"
-    )
+    (store / "state.md").write_text("# State\n\n## Current\nShipping v1\n\n## History\n")
     (store / "stack.md").write_text("# Stack\n- Python 3.11\n")
     (store / "open-questions.md").write_text("# Open Questions\n")
     (store / "decisions" / "001-init.md").write_text("# 001: Init\n")


### PR DESCRIPTION
## Summary

- **State replace-and-rotate:** `update_state` now replaces `## Current` with the new delta and rotates the previous value into `## History` with a timestamp. `build_l0` reads only `## Current`, so L0 cost is always one entry. Legacy state.md files are auto-migrated on first call.
- **Stack oneliner:** L0 now shows a single line like `**Stack:** Python 3.11+, AWS Lambda` instead of the multi-line category summary. Full stack remains at L1.
- **Question limit reduced:** `L0_QUESTIONS_LIMIT` from 5 to 3. Remaining questions available at L1.
- **Cleanup:** Removed unused `RECENTLY_SHIPPED_LIMIT` and `STATE_FIELD_RECENTLY_SHIPPED` constants.

## Test plan

- [x] nauro-core tests pass (148 passed)
- [x] nauro tests pass (605 passed, 20 integration deselected)
- [x] ruff check + format clean
- [ ] Manual: run `nauro init --demo` and verify state.md uses new format
- [ ] Manual: run `nauro status` on existing project with legacy state.md, then `update_state` via MCP to verify migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)