### PR TITLE
feat: upgrade search to BM25 (D93)

### DIFF
--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -19,6 +19,10 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
+dependencies = [
+    "bm25s>=0.2",
+    "PyStemmer>=2.2",
+]
 
 [project.optional-dependencies]
 dev = ["pytest", "ruff", "import-linter"]

--- a/packages/nauro-core/src/nauro_core/__init__.py
+++ b/packages/nauro-core/src/nauro_core/__init__.py
@@ -152,6 +152,12 @@ from nauro_core.parsing import (
 from nauro_core.pending import (
     PendingStore as PendingStore,
 )
+from nauro_core.search import (
+    bm25_retrieve as bm25_retrieve,
+)
+from nauro_core.search import (
+    bm25_search as bm25_search,
+)
 from nauro_core.state import (
     StateUpdateResult as StateUpdateResult,
 )

--- a/packages/nauro-core/src/nauro_core/search.py
+++ b/packages/nauro-core/src/nauro_core/search.py
@@ -1,0 +1,113 @@
+"""BM25 search over decisions (D93).
+
+Builds an in-memory BM25 index per call using bm25s + PyStemmer.
+Index text: title + rationale for each decision.
+"""
+
+from __future__ import annotations
+
+import re
+
+import bm25s
+import Stemmer
+
+from nauro_core.parsing import extract_relevance_snippet
+
+_stemmer = Stemmer.Stemmer("english")
+
+
+def bm25_search(
+    decisions: list[dict],
+    query: str,
+    limit: int = 10,
+) -> list[dict]:
+    """Rank decisions by BM25 relevance to query.
+
+    Returns list of result dicts sorted by BM25 score descending.
+    Only results with score > 0 are included.
+    """
+    if not decisions or not query or not query.strip():
+        return []
+
+    corpus = [f"{d['title']} {d['rationale']}" for d in decisions]
+    corpus_tokens = bm25s.tokenize(corpus, stopwords="en", stemmer=_stemmer)
+
+    retriever = bm25s.BM25()
+    retriever.index(corpus_tokens)
+
+    k = min(limit, len(decisions))
+    query_tokens = bm25s.tokenize([query], stopwords="en", stemmer=_stemmer)
+    results, scores = retriever.retrieve(query_tokens, k=k)
+
+    query_words = query.strip().split()
+    ranked = []
+    for i in range(results.shape[1]):
+        idx = int(results[0, i])
+        score = float(scores[0, i])
+        if score <= 0:
+            break
+
+        d = decisions[idx]
+        snippet = extract_relevance_snippet(d["rationale"], query_words)
+        if not snippet and d["rationale"]:
+            first_sentence = re.split(r"[.!?]\s", d["rationale"], maxsplit=1)[0]
+            snippet = first_sentence[:100].strip()
+            if len(first_sentence) > 100:
+                snippet += "..."
+
+        ranked.append(
+            {
+                "number": d["num"],
+                "title": d["title"],
+                "date": d.get("date"),
+                "status": d.get("status", "active"),
+                "relevance_snippet": snippet,
+                "score": round(score, 3),
+            }
+        )
+
+    return ranked[:limit]
+
+
+def bm25_retrieve(
+    decisions: list[dict],
+    query_text: str,
+    top_k: int = 5,
+) -> list[dict]:
+    """Retrieve top-k related active decisions for conflict checking.
+
+    Returns list of dicts sorted by BM25 score descending.
+    Only active decisions are considered; results with score <= 0 are excluded.
+    """
+    active = [d for d in decisions if d.get("status", "active") == "active"]
+    if not active or not query_text or not query_text.strip():
+        return []
+
+    corpus = [f"{d['title']} {d['rationale']}" for d in active]
+    corpus_tokens = bm25s.tokenize(corpus, stopwords="en", stemmer=_stemmer)
+
+    retriever = bm25s.BM25()
+    retriever.index(corpus_tokens)
+
+    k = min(top_k, len(active))
+    query_tokens = bm25s.tokenize([query_text], stopwords="en", stemmer=_stemmer)
+    results, scores = retriever.retrieve(query_tokens, k=k)
+
+    related = []
+    for i in range(results.shape[1]):
+        idx = int(results[0, i])
+        score = float(scores[0, i])
+        if score <= 0:
+            break
+
+        d = active[idx]
+        related.append(
+            {
+                "number": d["num"],
+                "title": d["title"],
+                "similarity": round(score, 3),
+                "rationale_preview": d["rationale"][:200] if d["rationale"] else "",
+            }
+        )
+
+    return related

--- a/packages/nauro-core/tests/test_search.py
+++ b/packages/nauro-core/tests/test_search.py
@@ -1,0 +1,115 @@
+"""Tests for BM25 search (D93)."""
+
+from nauro_core.search import bm25_retrieve, bm25_search
+
+
+def _make_decision(num: int, title: str, rationale: str, status: str = "active") -> dict:
+    return {
+        "num": num,
+        "title": title,
+        "rationale": rationale,
+        "date": "2026-04-07",
+        "status": status,
+    }
+
+
+DECISIONS = [
+    _make_decision(
+        1,
+        "Use Auth0 for authentication",
+        "Auth0 provides OAuth 2.1 support and handles JWT validation.",
+    ),
+    _make_decision(
+        2,
+        "Chose Memcached for session state",
+        "Memcached is simpler than Redis for session caching. "
+        "Lower operational overhead and sufficient for our read-heavy workload.",
+    ),
+    _make_decision(
+        3,
+        "Use FastAPI for MCP server",
+        "FastAPI provides async support and automatic OpenAPI docs. "
+        "Works well with Mangum for Lambda deployment.",
+    ),
+    _make_decision(
+        4,
+        "Defer multi-repo sync to v2",
+        "Current scope is single-repo. Multi-repo sync adds complexity "
+        "that is not justified at launch.",
+        status="superseded",
+    ),
+]
+
+
+class TestBm25Search:
+    def test_basic_match(self):
+        results = bm25_search(DECISIONS, "authentication")
+        assert len(results) >= 1
+        assert results[0]["title"] == "Use Auth0 for authentication"
+
+    def test_stemming_matches_vocabulary_variants(self):
+        """'deploying' should match 'deployment' via stemming."""
+        results = bm25_search(DECISIONS, "deploying Lambda")
+        assert any("FastAPI" in r["title"] for r in results)
+
+    def test_vocabulary_mismatch_case(self):
+        """The Redis/Memcached case from D93 motivation."""
+        results = bm25_search(DECISIONS, "Use Redis for session caching")
+        assert any("Memcached" in r["title"] for r in results)
+
+    def test_no_match_returns_empty(self):
+        results = bm25_search(DECISIONS, "quantum computing blockchain")
+        assert results == []
+
+    def test_empty_corpus(self):
+        assert bm25_search([], "test") == []
+
+    def test_empty_query(self):
+        assert bm25_search(DECISIONS, "") == []
+        assert bm25_search(DECISIONS, "   ") == []
+
+    def test_limit(self):
+        results = bm25_search(DECISIONS, "session authentication server", limit=2)
+        assert len(results) <= 2
+
+    def test_score_ordering(self):
+        results = bm25_search(DECISIONS, "session caching Memcached")
+        if len(results) >= 2:
+            assert results[0]["score"] >= results[1]["score"]
+
+    def test_includes_superseded(self):
+        results = bm25_search(DECISIONS, "multi-repo sync")
+        assert any(r["status"] == "superseded" for r in results)
+
+    def test_result_has_snippet(self):
+        results = bm25_search(DECISIONS, "Mangum")
+        assert len(results) >= 1
+        assert results[0]["relevance_snippet"]
+
+
+class TestBm25Retrieve:
+    def test_returns_related(self):
+        related = bm25_retrieve(DECISIONS, "authentication OAuth provider")
+        assert len(related) >= 1
+        assert related[0]["title"] == "Use Auth0 for authentication"
+
+    def test_active_only(self):
+        """Superseded decisions are excluded from retrieval."""
+        related = bm25_retrieve(DECISIONS, "multi-repo sync defer")
+        numbers = [r["number"] for r in related]
+        assert 4 not in numbers
+
+    def test_rationale_preview_populated(self):
+        related = bm25_retrieve(DECISIONS, "session caching")
+        assert len(related) >= 1
+        assert related[0]["rationale_preview"]
+
+    def test_empty_decisions(self):
+        assert bm25_retrieve([], "test") == []
+
+    def test_empty_query(self):
+        assert bm25_retrieve(DECISIONS, "") == []
+
+    def test_top_k(self):
+        related = bm25_retrieve(DECISIONS, "server session authentication", top_k=1)
+        assert len(related) <= 1

--- a/packages/nauro/src/nauro/cli/commands/validate.py
+++ b/packages/nauro/src/nauro/cli/commands/validate.py
@@ -1,32 +1,10 @@
-"""nauro validate — Manage validation indexes."""
+"""nauro validate — Validation diagnostics."""
 
 from __future__ import annotations
 
 import typer
 
-from nauro.cli.utils import resolve_target_project
-
-validate_app = typer.Typer(help="Manage validation indexes.")
-
-
-@validate_app.command(name="rebuild-index")
-def rebuild_index(
-    project: str | None = typer.Option(
-        None,
-        "--project",
-        help="Target project name.",
-    ),
-) -> None:
-    """Rebuild the embedding index from all existing decisions."""
-    project_name, store_path = resolve_target_project(project)
-
-    from nauro.validation.tier2 import rebuild_embedding_index
-
-    typer.echo(f"Rebuilding embedding index for {project_name}...")
-    result = rebuild_embedding_index(store_path)
-    typer.echo(
-        f"Done. Indexed: {result['indexed']}, Failed: {result['failed']}, Model: {result['model']}"
-    )
+validate_app = typer.Typer(help="Validation diagnostics.")
 
 
 @validate_app.command(name="status")
@@ -37,31 +15,15 @@ def status(
         help="Target project name.",
     ),
 ) -> None:
-    """Show embedding index health."""
-    import json
+    """Show validation search status."""
+    from nauro.cli.utils import resolve_target_project
+    from nauro.store.reader import _list_decisions
 
     project_name, store_path = resolve_target_project(project)
-
-    from nauro.validation.tier2 import EMBEDDING_INDEX_FILE
-
-    index_path = store_path / EMBEDDING_INDEX_FILE
-    if not index_path.exists():
-        typer.echo("No embedding index found. Run 'nauro validate rebuild-index' to create one.")
-        return
-
-    try:
-        index = json.loads(index_path.read_text())
-    except (json.JSONDecodeError, OSError):
-        typer.echo("Embedding index is corrupted. Run 'nauro validate rebuild-index'.")
-        return
-
-    model = index.get("model", "unknown")
-    decisions = index.get("decisions", {})
-    total = len(decisions)
-    with_embedding = sum(1 for d in decisions.values() if d.get("embedding"))
+    decisions = _list_decisions(store_path)
+    active = [d for d in decisions if d.get("status", "active") == "active"]
 
     typer.echo(f"Project: {project_name}")
-    typer.echo(f"Model: {model}")
-    typer.echo(f"Decisions indexed: {total}")
-    typer.echo(f"With embeddings: {with_embedding}")
-    typer.echo(f"Without embeddings (Jaccard fallback): {total - with_embedding}")
+    typer.echo(f"Total decisions: {len(decisions)}")
+    typer.echo(f"Active decisions: {len(active)}")
+    typer.echo("Search: BM25 (bm25s + PyStemmer, built on-the-fly per query)")

--- a/packages/nauro/src/nauro/store/reader.py
+++ b/packages/nauro/src/nauro/store/reader.py
@@ -9,9 +9,9 @@ from pathlib import Path
 
 from nauro_core.context import build_l0, build_l1, build_l2
 from nauro_core.parsing import (
-    extract_relevance_snippet,
     parse_decision,
 )
+from nauro_core.search import bm25_search
 
 from nauro.constants import (
     DECISIONS_DIR,
@@ -84,43 +84,13 @@ def search_decisions(
             ),
         }
 
-    query_words = query.strip().split()
     all_decisions = _list_decisions(store_path)
-
-    matches = []
-    for d in all_decisions:
-        title_lower = d["title"].lower()
-        rationale_lower = d["rationale"].lower()
-        combined = title_lower + " " + rationale_lower
-
-        if any(w.lower() in combined for w in query_words):
-            # Build relevance snippet from rationale
-            snippet = extract_relevance_snippet(d["rationale"], query_words)
-            if not snippet and d["rationale"]:
-                # Match was title-only — use first sentence of rationale
-                first_sentence = re.split(r"[.!?]\s", d["rationale"], maxsplit=1)[0]
-                snippet = first_sentence[:100].strip()
-                if len(first_sentence) > 100:
-                    snippet += "..."
-
-            matches.append(
-                {
-                    "number": d["num"],
-                    "title": d["title"],
-                    "date": d.get("date"),
-                    "status": d.get("status", "active"),
-                    "relevance_snippet": snippet,
-                }
-            )
-
-    # Sort by decision number descending
-    matches.sort(key=lambda m: m["number"], reverse=True)
-    total = len(matches)
+    results = bm25_search(all_decisions, query, limit=limit)
 
     return {
         "store": "local",
-        "results": matches[:limit],
-        "total_matches": total,
+        "results": results,
+        "total_matches": len(results),
         "query": query,
     }
 

--- a/packages/nauro/src/nauro/validation/pipeline.py
+++ b/packages/nauro/src/nauro/validation/pipeline.py
@@ -13,7 +13,7 @@ from nauro.store.writer import append_decision, supersede_decision, update_decis
 from nauro.validation.log import log_validation
 from nauro.validation.pending import get_pending, remove_pending, store_pending
 from nauro.validation.tier1 import screen_structural, update_hash_index
-from nauro.validation.tier2 import check_similarity, update_embedding_index
+from nauro.validation.tier2 import check_similarity
 from nauro.validation.tier3 import evaluate_with_llm
 
 
@@ -271,7 +271,6 @@ def _write_proposal(proposal: dict, project_path: Path) -> str:
     title = proposal.get("title", "")
     rationale = proposal.get("rationale", "")
     update_hash_index(title, rationale, decision_id, project_path)
-    update_embedding_index(decision_id, title, rationale, project_path)
 
     capture_snapshot(project_path, trigger=f"decision: {title}")
     return decision_id
@@ -286,7 +285,6 @@ def _execute_operation(operation: str, proposal: dict, project_path: Path, llm_r
             title = proposal.get("title", "")
             rationale = proposal.get("rationale", "")
             update_hash_index(title, rationale, decision_id, project_path)
-            update_embedding_index(decision_id, title, rationale, project_path)
             capture_snapshot(project_path, trigger=f"supersede {old_id}: {title}")
             return decision_id
         # Fall through to add if no affected_decision_id

--- a/packages/nauro/src/nauro/validation/tier2.py
+++ b/packages/nauro/src/nauro/validation/tier2.py
@@ -1,236 +1,48 @@
-"""Tier 2 validation — embedding similarity.
+"""Tier 2 validation — BM25 similarity (D93).
 
-Checks the proposal against existing decisions using embeddings.
-Falls back to Jaccard text similarity when embedding API is unavailable.
+Checks the proposal against existing decisions using BM25 ranking
+via bm25s + PyStemmer. Replaces the previous embedding/Jaccard approach.
 """
 
 from __future__ import annotations
 
-import json
 import logging
-import math
-import os
 from pathlib import Path
-from typing import Any
+
+from nauro_core.search import bm25_retrieve
 
 from nauro.store.reader import _list_decisions
 
 logger = logging.getLogger("nauro.validation.tier2")
 
-EMBEDDING_INDEX_FILE = ".embedding-index.json"
-EMBEDDING_MODEL = "text-embedding-3-small"
-SIMILARITY_THRESHOLD = 0.65
-JACCARD_THRESHOLD = 0.5
 TOP_K = 5
 
 
 def check_similarity(proposal: dict, project_path: Path) -> tuple[str, list[dict]]:
-    """Check proposal similarity against existing decisions.
+    """Check proposal similarity against existing decisions using BM25.
 
     Returns:
         (action, similar_decisions) where action is "auto_confirm" or "needs_review".
     """
-    index = _load_embedding_index(project_path)
-    if not index.get("decisions"):
-        return ("auto_confirm", [])
-
-    proposal_text = _proposal_to_text(proposal)
-
-    # Try embedding-based similarity
-    try:
-        proposal_embedding = _embed_text(proposal_text)
-        if proposal_embedding:
-            return _compare_embeddings(proposal_embedding, index)
-    except Exception as e:
-        logger.warning("Embedding unavailable, falling back to Jaccard: %s", e)
-
-    # Fallback: Jaccard similarity
-    return _compare_jaccard(proposal_text, project_path)
-
-
-def update_embedding_index(
-    decision_id: str, title: str, rationale: str, project_path: Path
-) -> None:
-    """Add a new decision's embedding to the index."""
-    text = f"{title}. {rationale[:200]}"
-    index = _load_embedding_index(project_path)
-
-    try:
-        embedding = _embed_text(text)
-        if embedding:
-            index.setdefault("decisions", {})[decision_id] = {
-                "embedding": embedding,
-                "title": title,
-            }
-            index["model"] = EMBEDDING_MODEL
-            _save_embedding_index(project_path, index)
-            return
-    except Exception as e:
-        logger.warning("Could not embed decision %s: %s", decision_id, e)
-
-    # Even without embedding, store the title for Jaccard fallback
-    index.setdefault("decisions", {})[decision_id] = {
-        "embedding": None,
-        "title": title,
-    }
-    _save_embedding_index(project_path, index)
-
-
-def rebuild_embedding_index(project_path: Path) -> dict:
-    """Rebuild the entire embedding index from all decisions.
-
-    Returns:
-        Summary dict with count of indexed decisions.
-    """
-    decisions = _list_decisions(project_path)
-    index: dict[str, Any] = {"model": EMBEDDING_MODEL, "decisions": {}}
-
-    indexed = 0
-    failed = 0
-
-    for d in decisions:
-        decision_id = f"decision-{d['num']:03d}"
-        text = f"{d['title']}. {d['rationale'][:200]}"
-
-        try:
-            embedding = _embed_text(text)
-            index["decisions"][decision_id] = {
-                "embedding": embedding,
-                "title": d["title"],
-            }
-            indexed += 1
-        except Exception as e:
-            logger.warning("Failed to embed %s: %s", decision_id, e)
-            index["decisions"][decision_id] = {
-                "embedding": None,
-                "title": d["title"],
-            }
-            failed += 1
-
-    _save_embedding_index(project_path, index)
-    return {"indexed": indexed, "failed": failed, "model": EMBEDDING_MODEL}
-
-
-def _proposal_to_text(proposal: dict) -> str:
-    """Convert proposal to text for similarity comparison."""
-    title = proposal.get("title", "")
-    rationale = proposal.get("rationale", "")
-    return f"{title}. {rationale[:200]}"
-
-
-def _embed_text(text: str) -> list[float] | None:
-    """Embed text using OpenAI text-embedding-3-small.
-
-    Checks NAURO_EMBEDDING_API_KEY, then OPENAI_API_KEY.
-    Returns None if no API key is available.
-    """
-    api_key = os.environ.get("NAURO_EMBEDDING_API_KEY") or os.environ.get("OPENAI_API_KEY")
-    if not api_key:
-        raise RuntimeError("No embedding API key (NAURO_EMBEDDING_API_KEY or OPENAI_API_KEY)")
-
-    try:
-        import openai
-    except ImportError:
-        raise RuntimeError("openai package required for embeddings: pip install nauro[validation]")
-
-    client = openai.OpenAI(api_key=api_key)
-    response = client.embeddings.create(model=EMBEDDING_MODEL, input=text)
-    return response.data[0].embedding
-
-
-def _compare_embeddings(proposal_embedding: list[float], index: dict) -> tuple[str, list[dict]]:
-    """Compare proposal embedding against indexed decisions."""
-    similarities = []
-
-    for decision_id, entry in index.get("decisions", {}).items():
-        emb = entry.get("embedding")
-        if not emb:
-            continue
-        sim = _cosine_similarity(proposal_embedding, emb)
-        similarities.append(
-            {
-                "id": decision_id,
-                "title": entry.get("title", ""),
-                "similarity": round(sim, 3),
-                "rationale_preview": "",  # filled by tier 3 if needed
-            }
-        )
-
-    similarities.sort(key=lambda x: x["similarity"], reverse=True)
-
-    if not similarities or similarities[0]["similarity"] < SIMILARITY_THRESHOLD:
-        return ("auto_confirm", [])
-
-    return ("needs_review", similarities[:TOP_K])
-
-
-def _compare_jaccard(proposal_text: str, project_path: Path) -> tuple[str, list[dict]]:
-    """Fallback: compare using Jaccard similarity on word sets."""
     decisions = _list_decisions(project_path)
     if not decisions:
         return ("auto_confirm", [])
 
-    proposal_words = _word_set(proposal_text)
-    similarities = []
+    title = proposal.get("title", "")
+    rationale = proposal.get("rationale", "")
+    proposal_text = f"{title}. {rationale[:200]}"
 
-    for d in decisions:
-        decision_text = f"{d['title']}. {d['rationale'][:200]}"
-        decision_words = _word_set(decision_text)
-        sim = _jaccard_similarity(proposal_words, decision_words)
-        decision_id = f"decision-{d['num']:03d}"
-        similarities.append(
-            {
-                "id": decision_id,
-                "title": d["title"],
-                "similarity": round(sim, 3),
-                "rationale_preview": d["rationale"][:100] if d["rationale"] else "",
-            }
-        )
-
-    similarities.sort(key=lambda x: x["similarity"], reverse=True)
-
-    if not similarities or similarities[0]["similarity"] < JACCARD_THRESHOLD:
+    related = bm25_retrieve(decisions, proposal_text, top_k=TOP_K)
+    if not related:
         return ("auto_confirm", [])
 
-    return ("needs_review", similarities[:TOP_K])
-
-
-def _cosine_similarity(a: list[float], b: list[float]) -> float:
-    """Compute cosine similarity between two vectors."""
-    dot = sum(x * y for x, y in zip(a, b))
-    norm_a = math.sqrt(sum(x * x for x in a))
-    norm_b = math.sqrt(sum(x * x for x in b))
-    if norm_a == 0 or norm_b == 0:
-        return 0.0
-    return dot / (norm_a * norm_b)
-
-
-def _jaccard_similarity(a: set[str], b: set[str]) -> float:
-    """Compute Jaccard similarity between two word sets."""
-    if not a and not b:
-        return 0.0
-    intersection = a & b
-    union = a | b
-    return len(intersection) / len(union)
-
-
-def _word_set(text: str) -> set[str]:
-    """Extract a set of lowercase words from text."""
-    return {w.lower().strip(".,;:!?()[]{}\"'") for w in text.split() if len(w) > 2}
-
-
-def _load_embedding_index(project_path: Path) -> dict:
-    """Load the embedding index."""
-    path = project_path / EMBEDDING_INDEX_FILE
-    if path.exists():
-        try:
-            return json.loads(path.read_text())  # type: ignore[no-any-return]
-        except (json.JSONDecodeError, OSError):
-            return {"model": EMBEDDING_MODEL, "decisions": {}}
-    return {"model": EMBEDDING_MODEL, "decisions": {}}
-
-
-def _save_embedding_index(project_path: Path, index: dict) -> None:
-    """Save the embedding index."""
-    path = project_path / EMBEDDING_INDEX_FILE
-    path.write_text(json.dumps(index) + "\n")
+    similar = [
+        {
+            "id": f"decision-{r['number']:03d}",
+            "title": r["title"],
+            "similarity": r["similarity"],
+            "rationale_preview": r["rationale_preview"],
+        }
+        for r in related
+    ]
+    return ("needs_review", similar)

--- a/packages/nauro/tests/test_search_decisions.py
+++ b/packages/nauro/tests/test_search_decisions.py
@@ -58,12 +58,11 @@ def test_rationale_match_with_snippet(store: Path):
     assert "Mangum" in hit["relevance_snippet"]
 
 
-def test_case_insensitive_substring(store: Path):
-    """'auth' matches 'Auth0', 'authentication', and 'unauthorized'."""
-    result = search_decisions(store, "auth")
+def test_stemming_matches_variants(store: Path):
+    """'authentication' matches the Auth0 decision via BM25 stemming."""
+    result = search_decisions(store, "authentication")
     titles = [r["title"] for r in result["results"]]
     assert any("Auth0" in t for t in titles)
-    assert any("authentication" in t.lower() for t in titles)
 
 
 def test_multi_word_any_match(store: Path):
@@ -99,8 +98,9 @@ def test_superseded_included_with_status(store: Path):
     assert "superseded" in statuses
 
 
-def test_sorted_descending(store: Path):
-    result = search_decisions(store, "a")
-    numbers = [r["number"] for r in result["results"]]
-    assert len(numbers) >= 2
-    assert numbers == sorted(numbers, reverse=True)
+def test_sorted_by_relevance(store: Path):
+    """Results are sorted by BM25 score, not by decision number."""
+    result = search_decisions(store, "FastAPI Lambda deployment")
+    if len(result["results"]) >= 2:
+        scores = [r["score"] for r in result["results"]]
+        assert scores == sorted(scores, reverse=True)

--- a/packages/nauro/tests/test_validation/test_tier2.py
+++ b/packages/nauro/tests/test_validation/test_tier2.py
@@ -1,21 +1,12 @@
-"""Tests for Tier 2 embedding similarity validation."""
+"""Tests for Tier 2 BM25 similarity validation (D93)."""
 
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 
 from nauro.store.writer import append_decision
 from nauro.templates.scaffolds import scaffold_project_store
-from nauro.validation.tier2 import (
-    EMBEDDING_INDEX_FILE,
-    _cosine_similarity,
-    _jaccard_similarity,
-    _word_set,
-    check_similarity,
-    rebuild_embedding_index,
-    update_embedding_index,
-)
+from nauro.validation.tier2 import check_similarity
 
 
 @pytest.fixture
@@ -25,53 +16,12 @@ def store(tmp_path: Path) -> Path:
     return store_path
 
 
-class TestCosineSimilarity:
-    def test_identical_vectors(self):
-        assert _cosine_similarity([1, 0, 0], [1, 0, 0]) == pytest.approx(1.0)
-
-    def test_orthogonal_vectors(self):
-        assert _cosine_similarity([1, 0, 0], [0, 1, 0]) == pytest.approx(0.0)
-
-    def test_opposite_vectors(self):
-        assert _cosine_similarity([1, 0], [-1, 0]) == pytest.approx(-1.0)
-
-    def test_zero_vector(self):
-        assert _cosine_similarity([0, 0], [1, 0]) == 0.0
-
-
-class TestJaccardSimilarity:
-    def test_identical_sets(self):
-        s = {"hello", "world"}
-        assert _jaccard_similarity(s, s) == 1.0
-
-    def test_disjoint_sets(self):
-        assert _jaccard_similarity({"a", "b"}, {"c", "d"}) == 0.0
-
-    def test_partial_overlap(self):
-        assert _jaccard_similarity({"a", "b", "c"}, {"b", "c", "d"}) == pytest.approx(0.5)
-
-    def test_empty_sets(self):
-        assert _jaccard_similarity(set(), set()) == 0.0
-
-
-class TestWordSet:
-    def test_extracts_words(self):
-        words = _word_set("Use Postgres for JSON support")
-        assert "postgres" in words
-        assert "json" in words
-        # Words with > 2 chars are included
-        assert "use" in words
-        assert "for" in words
-
-    def test_strips_punctuation(self):
-        words = _word_set("Hello, world! (test)")
-        assert "hello" in words
-        assert "world" in words
-        assert "test" in words
-
-
 class TestCheckSimilarity:
-    def test_auto_confirm_empty_index(self, store):
+    def test_auto_confirm_no_decisions(self, store):
+        # Remove scaffold decisions
+        for f in (store / "decisions").glob("*.md"):
+            f.unlink()
+
         proposal = {
             "title": "Use Postgres",
             "rationale": "Better JSON support and mature ecosystem.",
@@ -80,119 +30,65 @@ class TestCheckSimilarity:
         assert action == "auto_confirm"
         assert similar == []
 
-    @patch("nauro.validation.tier2._embed_text")
-    def test_auto_confirm_below_threshold(self, mock_embed, store):
-        """Low similarity → auto_confirm."""
-        mock_embed.return_value = [1.0, 0.0, 0.0]
-
-        # Manually write an embedding index with a dissimilar entry
-        import json
-
-        index = {
-            "model": "text-embedding-3-small",
-            "decisions": {
-                "decision-001": {
-                    "embedding": [0.0, 1.0, 0.0],
-                    "title": "Use DynamoDB",
-                },
-            },
-        }
-        (store / EMBEDDING_INDEX_FILE).write_text(json.dumps(index))
-
+    def test_needs_review_when_similar(self, store):
+        append_decision(
+            store,
+            "Use Postgres for storage",
+            rationale="Better JSON support and mature ecosystem for data persistence.",
+        )
         proposal = {
-            "title": "Use Postgres",
-            "rationale": "Better JSON support.",
-        }
-        action, similar = check_similarity(proposal, store)
-        assert action == "auto_confirm"
-
-    @patch("nauro.validation.tier2._embed_text")
-    def test_needs_review_above_threshold(self, mock_embed, store):
-        """High similarity → needs_review."""
-        mock_embed.return_value = [0.9, 0.1, 0.0]
-
-        import json
-
-        index = {
-            "model": "text-embedding-3-small",
-            "decisions": {
-                "decision-001": {
-                    "embedding": [0.9, 0.1, 0.0],  # identical
-                    "title": "Use Postgres",
-                },
-            },
-        }
-        (store / EMBEDDING_INDEX_FILE).write_text(json.dumps(index))
-
-        proposal = {
-            "title": "Use Postgres for storage",
-            "rationale": "Better JSON support.",
+            "title": "Use MySQL for storage",
+            "rationale": "Better JSON support and ecosystem for data persistence.",
         }
         action, similar = check_similarity(proposal, store)
         assert action == "needs_review"
         assert len(similar) >= 1
-        assert similar[0]["id"] == "decision-001"
+        assert any("Postgres" in s["title"] for s in similar)
 
-    def test_fallback_to_jaccard_on_api_failure(self, store):
-        """When embedding fails, falls back to Jaccard."""
-        # Add decisions with overlapping words
+    def test_auto_confirm_unrelated(self, store):
         append_decision(
             store,
-            "Use Postgres for Storage",
-            rationale="Better JSON support and mature ecosystem for our application needs.",
+            "Use Postgres for storage",
+            rationale="Better JSON support and mature ecosystem.",
         )
-
-        # No API keys set → embedding will fail → Jaccard fallback
-        # Use identical words to trigger Jaccard threshold
         proposal = {
-            "title": "Use Postgres for Storage",
-            "rationale": "Better JSON support and mature ecosystem for our application needs.",
+            "title": "Add dark mode to the UI",
+            "rationale": "Users requested a dark theme for reduced eye strain.",
         }
         action, similar = check_similarity(proposal, store)
-        # Jaccard should find similarity (may be auto_confirm or needs_review
-        # depending on exact word overlap vs full decision corpus)
-        assert action in ("auto_confirm", "needs_review")
-        # At minimum, the function should complete without error (fallback worked)
+        assert action == "auto_confirm"
 
+    def test_vocabulary_mismatch_detected(self, store):
+        """BM25 with stemming catches vocabulary mismatches (D93 motivation)."""
+        append_decision(
+            store,
+            "Chose Memcached for session state",
+            rationale="Memcached is simpler than Redis for session caching. "
+            "Lower operational overhead for our read-heavy workload.",
+        )
+        proposal = {
+            "title": "Use Redis for session caching",
+            "rationale": "Redis provides session state management with persistence.",
+        }
+        action, similar = check_similarity(proposal, store)
+        assert action == "needs_review"
+        assert any("Memcached" in s["title"] for s in similar)
 
-class TestUpdateEmbeddingIndex:
-    @patch("nauro.validation.tier2._embed_text")
-    def test_adds_to_index(self, mock_embed, store):
-        mock_embed.return_value = [0.1, 0.2, 0.3]
-
-        update_embedding_index("decision-002", "Use Redis", "For caching.", store)
-
-        import json
-
-        index = json.loads((store / EMBEDDING_INDEX_FILE).read_text())
-        assert "decision-002" in index["decisions"]
-        assert index["decisions"]["decision-002"]["embedding"] == [0.1, 0.2, 0.3]
-
-    def test_stores_title_without_embedding(self, store):
-        """When embedding fails, still stores the title for Jaccard."""
-        update_embedding_index("decision-002", "Use Redis", "For caching.", store)
-
-        import json
-
-        index = json.loads((store / EMBEDDING_INDEX_FILE).read_text())
-        assert "decision-002" in index["decisions"]
-        assert index["decisions"]["decision-002"]["title"] == "Use Redis"
-
-
-class TestRebuildIndex:
-    @patch("nauro.validation.tier2._embed_text")
-    def test_rebuilds_from_all_decisions(self, mock_embed, store):
-        mock_embed.return_value = [0.5, 0.5, 0.5]
-
-        append_decision(store, "Decision A", rationale="Rationale for decision A in the project.")
-        append_decision(store, "Decision B", rationale="Rationale for decision B in the project.")
-
-        result = rebuild_embedding_index(store)
-        # 2 new + 1 from scaffold (001-initial-setup)
-        assert result["indexed"] >= 2
-        assert result["failed"] == 0
-
-        import json
-
-        index = json.loads((store / EMBEDDING_INDEX_FILE).read_text())
-        assert len(index["decisions"]) >= 3
+    def test_result_format(self, store):
+        append_decision(
+            store,
+            "Use FastAPI for the server",
+            rationale="Async support and automatic OpenAPI documentation.",
+        )
+        proposal = {
+            "title": "Use FastAPI for the API layer",
+            "rationale": "FastAPI provides async and OpenAPI docs.",
+        }
+        action, similar = check_similarity(proposal, store)
+        assert action == "needs_review"
+        hit = similar[0]
+        assert "id" in hit
+        assert hit["id"].startswith("decision-")
+        assert "title" in hit
+        assert "similarity" in hit
+        assert "rationale_preview" in hit


### PR DESCRIPTION
## Why

`search_decisions` uses substring matching and `check_decision` uses keyword overlap (remote) or Jaccard/embedding similarity (local). Both fail on vocabulary mismatches — the canonical example from D93: "Use Redis for session caching" doesn't surface "Chose Memcached for session state" under substring matching. BM25 with stemming handles term frequency, document length normalization, and vocabulary variants that substring matching misses.

## Approach

BM25 via `bm25s` (pure Python, scipy sparse matrices, sub-ms latency) with `PyStemmer` for English stemming. Index is built on-the-fly per call — no persistent index files, no cold-start penalty. At 50-500 decisions this is negligible overhead.

Alternatives considered per D93: ChromaDB/vector embeddings (MemPalace proved simpler approaches win), TF-IDF via scikit-learn (lacks BM25's length normalization), Whoosh (overkill for <500 docs), keeping substring matching (the Redis/Memcached failure case is real).

This deliberately breaks nauro-core's zero-runtime-deps policy — `bm25s` and `PyStemmer` are now required dependencies.

## What changed

- **nauro-core**: New `search.py` module with `bm25_search()` (ranked search with snippets) and `bm25_retrieve()` (active-only retrieval for conflict checking). Added `bm25s>=0.2` and `PyStemmer>=2.2` as runtime deps.
- **nauro (local)**: `reader.py:search_decisions` and `tier2.py:check_similarity` now delegate to nauro-core BM25 functions. Removed embedding index infrastructure (`.embedding-index.json`, `update_embedding_index`, `rebuild_embedding_index`, OpenAI dependency for tier2). Simplified `validate` CLI command.
- **mcp-server (remote)**: `payloads.py:search_decisions_in_store` and `tools_write.py:check_decision` now use BM25. (Will take effect on next Lambda deploy after nauro-core pin update.)

## What to review

- `search.py` BM25 module: score threshold (`> 0` — no arbitrary cutoff), module-level stemmer singleton, snippet generation using unstemmed query words for readability.
- `tier2.py` replacement: the old code had embedding → Jaccard fallback → LLM tier3 pipeline. BM25 replaces the first two steps; tier3 LLM evaluation is unchanged.
- Test changes: `test_case_insensitive_substring` → `test_stemming_matches_variants`, `test_sorted_descending` → `test_sorted_by_relevance`. Both reflect the behavioral shift from substring to BM25.

## What's deferred

- Embedding-based semantic search remains deferred to post-launch per D77.
- mcp-server Lambda redeploy (requires updating pinned nauro-core commit hash).
- Cleanup of `openai` optional dependency from nauro's pyproject.toml (may still be used elsewhere).

## Test plan

- 16 new nauro-core unit tests (`test_search.py`) covering BM25 search, stemming, vocabulary mismatch, empty corpus, score ordering, active-only filtering.
- 9 updated nauro integration tests (`test_search_decisions.py`) adapted for BM25 behavior.
- 5 rewritten tier2 tests (`test_tier2.py`) for BM25-based `check_similarity`.
- 215 total tests pass across nauro-core and nauro packages.
- Manual verification: "Use Redis for session caching" correctly surfaces "Chose Memcached for session state" as top result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)