### PR TITLE
Fix tier-2 false-positive escalation on every propose_decision

### DIFF
--- a/packages/nauro-core/src/nauro_core/search.py
+++ b/packages/nauro-core/src/nauro_core/search.py
@@ -73,24 +73,30 @@ def bm25_retrieve(
     decisions: list[dict],
     query_text: str,
     top_k: int = 5,
+    stopwords: str | list[str] = "en",
 ) -> list[dict]:
     """Retrieve top-k related active decisions for conflict checking.
 
     Returns list of dicts sorted by BM25 score descending.
     Only active decisions are considered; results with score <= 0 are excluded.
+
+    ``stopwords`` is passed through to ``bm25s.tokenize`` and applies to both
+    the corpus and query tokenization. Callers (e.g. tier-2 validation) may
+    pass an extended list to filter domain-generic tokens that bm25s's
+    default English list doesn't cover.
     """
     active = [d for d in decisions if d.get("status", "active") == "active"]
     if not active or not query_text or not query_text.strip():
         return []
 
     corpus = [f"{d['title']} {d['rationale']}" for d in active]
-    corpus_tokens = bm25s.tokenize(corpus, stopwords="en", stemmer=_stemmer)
+    corpus_tokens = bm25s.tokenize(corpus, stopwords=stopwords, stemmer=_stemmer)
 
     retriever = bm25s.BM25()
     retriever.index(corpus_tokens)
 
     k = min(top_k, len(active))
-    query_tokens = bm25s.tokenize([query_text], stopwords="en", stemmer=_stemmer)
+    query_tokens = bm25s.tokenize([query_text], stopwords=stopwords, stemmer=_stemmer)
     results, scores = retriever.retrieve(query_tokens, k=k)
 
     related = []

--- a/packages/nauro/src/nauro/validation/tier2.py
+++ b/packages/nauro/src/nauro/validation/tier2.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
+from bm25s.stopwords import STOPWORDS_EN
 from nauro_core.search import bm25_retrieve
 
 from nauro.store.reader import _list_decisions
@@ -17,6 +18,39 @@ logger = logging.getLogger("nauro.validation.tier2")
 
 TOP_K = 5
 
+# bm25s's default English stopword list is minimal (~30 tokens: a, an, and,
+# are, as, at, be, but, by, for, if, in, into, is, it, no, not, of, on, or,
+# ...). It omits common action verbs that appear in virtually every Nauro
+# decision title ("Use Postgres", "Use Redis", "Use FastAPI", etc.), so a
+# fresh proposal shares the stem ``use`` with most existing decisions and
+# gets a nonzero BM25 score, escalating tier 2 → tier 3 on almost every
+# call. Extending the list with ``use`` collapses those false-positive
+# matches to score 0 (already filtered by bm25_retrieve).
+#
+# This list is intentionally minimal: only tokens with observed false
+# positives are added, not a speculative blanket of generic verbs. Add
+# more only when a concrete failure case justifies it, and update
+# test_tier2.py to lock the case in.
+_TIER2_STOPWORDS = list(STOPWORDS_EN) + ["use"]
+
+# The scaffold-seeded "Initial project setup" decision is Nauro's own
+# bookkeeping — it records that the store was initialized, not a choice the
+# user made. It should not gate validation of user-authored proposals.
+# Including it in the tier-2 corpus causes every new proposal sharing even
+# one weak stem (e.g. "store", "use") with the template text to escalate
+# to tier 3, defeating tier 2's purpose as a cheap pre-filter.
+#
+# Identified by the conventional num+title pair written by
+# ``scaffold_project_store`` via ``FIRST_DECISION_MD``. This is a convention
+# match, not a fuzzy heuristic: the title is hardcoded in the scaffold
+# template and the scaffold is the only path that produces a ``num == 1``
+# decision with this exact title.
+_SCAFFOLD_SEED_TITLE = "Initial project setup"
+
+
+def _is_scaffold_seed(decision: dict) -> bool:
+    return decision.get("num") == 1 and decision.get("title") == _SCAFFOLD_SEED_TITLE
+
 
 def check_similarity(proposal: dict, project_path: Path) -> tuple[str, list[dict]]:
     """Check proposal similarity against existing decisions using BM25.
@@ -24,7 +58,7 @@ def check_similarity(proposal: dict, project_path: Path) -> tuple[str, list[dict
     Returns:
         (action, similar_decisions) where action is "auto_confirm" or "needs_review".
     """
-    decisions = _list_decisions(project_path)
+    decisions = [d for d in _list_decisions(project_path) if not _is_scaffold_seed(d)]
     if not decisions:
         return ("auto_confirm", [])
 
@@ -32,7 +66,7 @@ def check_similarity(proposal: dict, project_path: Path) -> tuple[str, list[dict
     rationale = proposal.get("rationale", "")
     proposal_text = f"{title}. {rationale[:200]}"
 
-    related = bm25_retrieve(decisions, proposal_text, top_k=TOP_K)
+    related = bm25_retrieve(decisions, proposal_text, top_k=TOP_K, stopwords=_TIER2_STOPWORDS)
     if not related:
         return ("auto_confirm", [])
 

--- a/packages/nauro/tests/test_validation/test_tier2.py
+++ b/packages/nauro/tests/test_validation/test_tier2.py
@@ -74,6 +74,46 @@ class TestCheckSimilarity:
         assert action == "needs_review"
         assert any("Memcached" in s["title"] for s in similar)
 
+    def test_generic_verb_overlap_does_not_escalate(self, store):
+        """A proposal sharing only a generic action verb (e.g. ``use``)
+        with an existing decision must not escalate to tier 3.
+
+        ``use`` appears in virtually every Nauro decision title and carries
+        no similarity signal. Without filtering it, every new ``Use X`` or
+        ``Use Y`` proposal would escalate and pay for an LLM call.
+        """
+        append_decision(
+            store,
+            "Use FastAPI",
+            rationale="Good async support for our web server.",
+        )
+        proposal = {
+            "title": "Use Redis for Caching",
+            "rationale": "Fast in-memory store for session data management.",
+        }
+        action, similar = check_similarity(proposal, store)
+        assert action == "auto_confirm"
+        assert similar == []
+
+    def test_scaffold_seed_excluded_from_corpus(self, store):
+        """The scaffold-seeded 001-initial-setup decision must not gate
+        validation of user proposals.
+
+        Without this exclusion, a fresh store (containing only the seed)
+        escalates every new proposal that shares even one stem with the
+        template text (e.g. "store" in the seed rationale vs "in-memory
+        store" in a Redis proposal) to tier 3, defeating tier 2's purpose
+        and breaking offline operation on first use.
+        """
+        # Store contains only the scaffold seed — no user decisions.
+        proposal = {
+            "title": "Use Redis for Caching",
+            "rationale": "Fast in-memory store with pub/sub support for session data.",
+        }
+        action, similar = check_similarity(proposal, store)
+        assert action == "auto_confirm"
+        assert similar == []
+
     def test_result_format(self, store):
         append_decision(
             store,


### PR DESCRIPTION
## Why

Tier 2 has been escalating **every** `propose_decision` call to tier 3 (LLM), which means:

- Every first-use `propose_decision` on a freshly scaffolded store pays for an LLM call, even when the proposal has nothing in common with anything in the store.
- Offline / no-key operation is broken: tier 3 fail-closes to `pending_confirmation` or `held`, so agents can't log decisions without a working `ANTHROPIC_API_KEY`.
- CI has been relying on a locally-set key leaking into the test environment — without it, 6 tests fail (`test_new_decision_auto_confirms`, `test_propose_new_decision`, etc.).

The 3-tier design explicitly exists so tier 2 can cheap-filter unrelated proposals before paying for tier 3. Right now tier 2 is a pass-through, so the architecture effectively collapses to "tier 1 → tier 3". That's a real customer bug, not just a test problem.

## Approach

Investigation found **two independent root causes**, each with its own targeted fix. I deliberately avoided magic-number thresholds (tempting but corpus-dependent and fragile — and easy to accuse of "tuning to make tests pass").

**Root cause 1: the scaffold seed pollutes the similarity corpus.**
`scaffold_project_store` writes `001-initial-setup.md` as a bookkeeping record ("we initialized the store"). Its rationale contains the generic word "store", which overlaps with common technical terms ("in-memory store", "data store") in real proposals and produces nonzero BM25 scores — enough to escalate.

**Fix**: exclude the seed from tier-2's corpus. Identified by the `num == 1` + hardcoded-template title convention that existing tests already depend on. The seed is Nauro's own bookkeeping, not a user decision, so it has no business gating validation of user-authored proposals. It stays in listings, search, snapshots, exports — everything else is unchanged.

**Root cause 2: `bm25s`'s default English stopword list is too narrow.**
It contains ~30 tokens (`a, an, and, are, as, at, be, but, by, for, if, in, ...`) and omits common action verbs like `use`. Every Nauro decision title phrased "Use X" shares the `use` stem with every other "Use X" title, giving BM25 score 0.115 — enough to escalate — on pairs with zero actual content overlap (e.g. "Use Redis for Caching" vs "Use FastAPI for the server").

**Fix**: extend the stopword list with `"use"` only, for tier-2's use. `bm25_retrieve` in `nauro-core` now takes an optional `stopwords` parameter (default `"en"`, backward compatible); tier 2 passes `STOPWORDS_EN + ["use"]`. Any pair whose only shared stem was `use` now scores 0 and is filtered by the existing `score <= 0` check in `bm25_retrieve` — no new filter logic needed.

### Alternatives considered and rejected

- **Score threshold** (e.g. `MIN_SIMILARITY_SCORE = 0.5` in tier 2). Tempting — cleanly separates the observed failure at 0.115 from true positives at 1.8+. Rejected: BM25 scores are corpus-dependent, picking the number on small test fixtures is not robust, and it has the "tuned to make tests pass" smell. This was my first instinct; thanks to pushback on it.
- **Stem-overlap count ≥ 2**. Clean and corpus-independent, but kills legitimate short supersede proposals ("Drop Kafka" vs existing "Adopt Kafka" shares only `kafka` — overlap = 1 — but is absolutely a tier-3 case). False negatives in supersede are the worst failure mode (silent store pollution), so this is unacceptable.
- **Removing the scaffold seed entirely**. The cleanest long-term move, but blast radius across ~20 tests and fixtures that depend on `001-initial-setup.md` existing. Deserves its own decision, not a drive-by.
- **Embeddings for tier 2**. D93 explicitly replaced embeddings with BM25. Not re-litigating that here.
- **Blanket of generic verbs in stopwords** (`use`, `add`, `drop`, `switch`, `adopt`, ...). Speculative — only `use` has an observed false positive. YAGNI until more patterns surface; the comment on `_TIER2_STOPWORDS` explicitly invites future additions tied to regression tests.

## What changed

- `packages/nauro-core/src/nauro_core/search.py` — `bm25_retrieve` gains an optional `stopwords` parameter (default `"en"`, passed through to `bm25s.tokenize` for both corpus and query). Backward compatible; only caller outside tests is tier 2.
- `packages/nauro/src/nauro/validation/tier2.py` — excludes the scaffold seed by `num == 1 + title` convention match; passes `STOPWORDS_EN + ["use"]` to `bm25_retrieve`. Both behaviors are documented with the reasoning above in block comments.
- `packages/nauro/tests/test_validation/test_tier2.py` — two regression tests covering the exact failing proposals (`test_scaffold_seed_excluded_from_corpus`, `test_generic_verb_overlap_does_not_escalate`).

No existing tests modified. No changes to the scaffold, `bm25_search`, decision writer, or tier 3.

## What to review

- **`_is_scaffold_seed` in tier2.py** — the convention-match check. Does it feel fragile? The title is hardcoded in `FIRST_DECISION_MD` and existing tests (`test_store.py`, `test_cli.py`, `test_import.py`) already assert on `001-initial-setup.md`, so the convention is already load-bearing — this just makes tier 2 honor it.
- **`_TIER2_STOPWORDS` list** — intentionally minimal (one word). The comment explicitly says "add more only when a concrete failure case justifies it". Do we believe that, or do we want to preemptively add `add`, `drop`, `switch`, etc.? I argued against — speculative filtering risks killing real matches (`add`, `drop`, `switch` are all common in genuine supersede titles) — but worth a second opinion.
- **`bm25_retrieve` parameter addition** — should this live in `nauro-core` (as done here) or should tier 2 do its own tokenization? I chose the former because it keeps tokenization logic in one place and the `stopwords` parameter is a pure pass-through with no behavior change for existing callers.

## What's deferred

- **Removing the scaffold seed entirely.** Still think this is architecturally right long-term — it's bookkeeping masquerading as user content and it pollutes search, listings, AGENTS.md, and exports in addition to tier 2. But it's a user-visible behavior change that cascades across ~20 tests. Belongs in its own PR with its own decision.
- **More domain stopwords** (`add`, `drop`, `switch`, etc.). Add on demand, not preemptively.
- **Normalized / ratio-based BM25 scoring.** More principled than threshold tuning, but also more complex, and the two fixes here cover the observed failure modes.

## Test plan

- [x] `env -u ANTHROPIC_API_KEY uv run pytest packages/nauro/tests/ packages/nauro-core/tests/` — **813 passed, 0 failed** (previously: 6 failed without key)
- [x] All 6 originally-failing tests now pass: `test_new_decision_auto_confirms`, `test_auto_confirm_writes_decision_file`, `test_new_decision_auto_confirms_even_mcp`, `test_propose_decision_new`, `test_propose_new_decision`, `test_propose_triggers_snapshot`
- [x] Existing tier-2 positive cases still escalate correctly: `test_needs_review_when_similar` (Postgres/MySQL, score 2.841), `test_vocabulary_mismatch_detected` (Memcached/Redis, 2.121), `test_result_format` (FastAPI, 1.862)
- [x] Existing tier-2 negative case still auto-confirms: `test_auto_confirm_unrelated` (Postgres + dark mode)
- [x] Two new regression tests (`test_scaffold_seed_excluded_from_corpus`, `test_generic_verb_overlap_does_not_escalate`) lock in the exact failing proposal text
- [x] `uv tool run ruff check packages/` clean
- [x] `uv tool run ruff format --check packages/` clean
- [ ] Nauro-AI/nauro CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)