### PR TITLE
Deliver tool guidance via MCP protocol instead of CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,35 +155,3 @@ packages/nauro-core/
     validation.py          # structural validation
   tests/
 ```
-
-<!-- NAURO:START — managed by nauro, do not edit -->
-
-## Nauro — project context
-
-This project uses Nauro for persistent context. The MCP server is
-auto-started by Claude Code. Project context has been injected at
-session start via AGENTS.md.
-
----
-
-## When to propose a decision
-
-Call `propose_decision` when you choose between two or more approaches,
-replace or remove a dependency, establish a new pattern, or cut
-something from scope. Do not wait until the end of the session —
-log decisions at the moment they are made. Use `check_decision` first
-for advisory conflict checks, then `confirm_decision` after reviewing
-validation results.
-
-Examples that warrant a decision:
-- Choosing FastAPI over Flask for the MCP server
-- Deciding to defer multi-repo sync to v2
-- Establishing that all store writes go through writer.py, never direct
-- Removing Redis as a dependency by switching to procrastinate
-
-Examples that do not:
-- Fixing a bug with an obvious solution
-- Adding a test for existing behavior
-- Renaming a variable
-
-<!-- NAURO:END -->

--- a/packages/nauro-core/src/nauro_core/__init__.py
+++ b/packages/nauro-core/src/nauro_core/__init__.py
@@ -54,6 +54,9 @@ from nauro_core.constants import (
     MAX_TITLE_LENGTH as MAX_TITLE_LENGTH,
 )
 from nauro_core.constants import (
+    MCP_INSTRUCTIONS as MCP_INSTRUCTIONS,
+)
+from nauro_core.constants import (
     MIN_RATIONALE_LENGTH as MIN_RATIONALE_LENGTH,
 )
 from nauro_core.constants import (
@@ -118,6 +121,15 @@ from nauro_core.format import (
 )
 from nauro_core.format import (
     parse_title as parse_title,
+)
+from nauro_core.mcp_tools import (
+    ALL_TOOLS as ALL_TOOLS,
+)
+from nauro_core.mcp_tools import (
+    ToolSpec as ToolSpec,
+)
+from nauro_core.mcp_tools import (
+    get_tool_spec as get_tool_spec,
 )
 from nauro_core.parsing import (
     decisions_summary_lines as decisions_summary_lines,

--- a/packages/nauro-core/src/nauro_core/constants.py
+++ b/packages/nauro-core/src/nauro_core/constants.py
@@ -60,3 +60,44 @@ MAX_DELTA_LENGTH = 5_000
 MAX_QUESTION_LENGTH = 2_000
 MAX_CONTEXT_LENGTH = 5_000
 MAX_APPROACH_LENGTH = 5_000
+
+# ── MCP server instructions ──
+# Delivered via the MCP `initialize` response to every connected client.
+# Single source of truth — both local (stdio) and remote (HTTP) servers
+# should reference this constant.
+MCP_INSTRUCTIONS = """\
+Nauro is the project's decision memory. Use it to check past decisions \
+before committing to an approach, and to record new decisions as you make them.
+
+## When to check decisions
+
+Before adopting any technical approach — architecture, library choice, \
+API design, data model, infrastructure — call `check_decision` with a \
+description of what you're considering. This includes when the user asks \
+"should we...", "what if we...", "can we...", or "check if...". \
+The tool surfaces conflicts with past decisions so you don't repeat \
+rejected approaches.
+
+## When to propose decisions
+
+Call `propose_decision` when you choose between two or more approaches, \
+replace or remove a dependency, establish a new pattern, or cut scope. \
+Do it at the moment the decision is made, not at the end of the session. \
+Always include what was rejected and why.
+
+Do NOT propose decisions for obvious bug fixes, adding tests for existing \
+behavior, or renaming variables.
+
+## When to get context
+
+Call `get_context` at the start of a session or when you need to \
+understand the project's current state, goals, and constraints. \
+L0 includes the last 10 decisions — do not call `list_decisions` \
+after `get_context` unless you need older or superseded decisions.
+
+## When to update state
+
+Call `update_state` when you complete a meaningful unit of work — \
+a feature, a refactor, a bug fix — so the next session starts with \
+current context.\
+"""

--- a/packages/nauro-core/src/nauro_core/mcp_tools.py
+++ b/packages/nauro-core/src/nauro_core/mcp_tools.py
@@ -1,0 +1,462 @@
+"""Centralized MCP tool metadata — single source of truth for both servers.
+
+Each entry contains the name, human-readable title, description, behavioral
+annotations (readOnlyHint, destructiveHint, idempotentHint, openWorldHint),
+and JSON Schema for the tool's input. Both the local stdio server and the
+remote HTTP server read from this registry so descriptions and annotations
+stay in sync.
+
+The local (FastMCP) server derives input schemas from Python type hints, so
+it consumes `title`, `description`, and `annotations` here; the function
+signature must match `input_schema` by convention.
+
+The remote (JSON-RPC) server consumes the whole entry directly.
+"""
+
+from __future__ import annotations
+
+from typing import Any, TypedDict
+
+
+class ToolAnnotations(TypedDict, total=False):
+    """Behavioral hints for MCP clients. All fields optional."""
+
+    readOnlyHint: bool
+    destructiveHint: bool
+    idempotentHint: bool
+    openWorldHint: bool
+
+
+class ToolSpec(TypedDict):
+    """Complete metadata for a single MCP tool."""
+
+    name: str
+    title: str
+    description: str
+    annotations: ToolAnnotations
+    input_schema: dict[str, Any]
+
+
+# ── Shared parameter fragments ──
+
+_PROJECT_PARAM: dict[str, Any] = {
+    "type": "string",
+    "description": "Project name. If omitted, auto-discovered from cwd (local) or S3 (remote).",
+}
+
+# Every tool is closed-world (operates only on the local/remote Nauro store)
+# and non-destructive (writes are additive — nothing is ever deleted).
+_READ_ANNOTATIONS: ToolAnnotations = {
+    "readOnlyHint": True,
+    "openWorldHint": False,
+}
+
+_WRITE_ANNOTATIONS: ToolAnnotations = {
+    "readOnlyHint": False,
+    "destructiveHint": False,
+    "openWorldHint": False,
+}
+
+# ── Tool specs ──
+
+GET_CONTEXT: ToolSpec = {
+    "name": "get_context",
+    "title": "Get project context",
+    "description": (
+        "Return project context at the requested detail level.\n"
+        "\n"
+        "L0 (concise) includes project summary, current state, top open "
+        "questions, and the last 10 active decisions with titles and dates. "
+        "L1 (working set) adds full decision bodies for recent decisions. "
+        "L2 (full dump) includes everything in the store.\n"
+        "\n"
+        "Call this at session start or when you need to understand the "
+        "project's goals, constraints, and recent history. Do NOT call "
+        "list_decisions after get_context unless you need decisions beyond "
+        "the last 10 or need the include_superseded filter."
+    ),
+    "annotations": {**_READ_ANNOTATIONS, "idempotentHint": True},
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "level": {
+                "type": "string",
+                "enum": ["L0", "L1", "L2"],
+                "default": "L0",
+                "description": "Detail level: L0 (concise), L1 (working set), L2 (full dump).",
+            },
+            "project": _PROJECT_PARAM,
+        },
+    },
+}
+
+GET_RAW_FILE: ToolSpec = {
+    "name": "get_raw_file",
+    "title": "Read raw store file",
+    "description": (
+        "Return the raw markdown content of any file in the Nauro project store.\n"
+        "\n"
+        "Valid paths include: project.md, state.md, stack.md, open-questions.md, "
+        "decisions/042-some-decision.md\n"
+        "\n"
+        "This is a low-level escape hatch. For most use cases, prefer:\n"
+        "- get_context for project overview, state, questions, recent decisions\n"
+        "- get_decision for a specific decision by number\n"
+        "- search_decisions for finding decisions by topic"
+    ),
+    "annotations": {**_READ_ANNOTATIONS, "idempotentHint": True},
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "path": {
+                "type": "string",
+                "description": (
+                    "File path relative to project store root "
+                    "(e.g., 'project.md', 'decisions/001-initial-architecture.md')."
+                ),
+            },
+            "project": _PROJECT_PARAM,
+        },
+        "required": ["path"],
+    },
+}
+
+LIST_DECISIONS: ToolSpec = {
+    "name": "list_decisions",
+    "title": "List decision history",
+    "description": (
+        "Browse the full decision history. Use when you need decisions beyond "
+        "the last 10 included in get_context, or when you need the "
+        "include_superseded filter. For topical lookups, prefer search_decisions."
+    ),
+    "annotations": {**_READ_ANNOTATIONS, "idempotentHint": True},
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "limit": {
+                "type": "integer",
+                "default": 20,
+                "description": "Maximum decisions to return.",
+            },
+            "include_superseded": {
+                "type": "boolean",
+                "default": False,
+                "description": "Include superseded decisions in the result.",
+            },
+            "project": _PROJECT_PARAM,
+        },
+    },
+}
+
+GET_DECISION: ToolSpec = {
+    "name": "get_decision",
+    "title": "Get decision by number",
+    "description": (
+        "Return the full markdown content of a specific decision by its number. "
+        "Includes metadata, rationale, and rejected alternatives."
+    ),
+    "annotations": {**_READ_ANNOTATIONS, "idempotentHint": True},
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "number": {
+                "type": "integer",
+                "description": "Decision number (e.g., 23).",
+            },
+            "project": _PROJECT_PARAM,
+        },
+        "required": ["number"],
+    },
+}
+
+DIFF_SINCE_LAST_SESSION: ToolSpec = {
+    "name": "diff_since_last_session",
+    "title": "Diff since last session",
+    "description": (
+        "Show what changed in the project context since the last snapshot.\n"
+        "\n"
+        "When days is omitted, diffs the two most recent snapshots "
+        "(session-scoped). When days is provided, finds the nearest snapshot "
+        "to N days ago and diffs against the current state. Useful for "
+        "catching up on changes made in other sessions or on other machines."
+    ),
+    "annotations": {**_READ_ANNOTATIONS, "idempotentHint": True},
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "days": {
+                "type": "integer",
+                "description": (
+                    "Optional: number of days to look back. Finds the nearest "
+                    "snapshot to N days ago and diffs against the latest."
+                ),
+            },
+            "project": _PROJECT_PARAM,
+        },
+    },
+}
+
+SEARCH_DECISIONS: ToolSpec = {
+    "name": "search_decisions",
+    "title": "Search decisions",
+    "description": (
+        "Search across all project decisions using BM25 relevance ranking "
+        "against titles and rationale. Includes both active and superseded "
+        "decisions.\n"
+        "\n"
+        "Use when you need to find decisions about a specific topic rather "
+        "than browsing the full list. More token-efficient than list_decisions "
+        "for targeted lookups.\n"
+        "\n"
+        'Example: search_decisions("authentication") returns all decisions '
+        "related to auth, OAuth, JWT, etc.\n"
+        "\n"
+        "Returns decision number, title, date, status, and a relevance "
+        "snippet from the matching rationale. Requires a non-empty query."
+    ),
+    "annotations": {**_READ_ANNOTATIONS, "idempotentHint": True},
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "Search text (required, non-empty).",
+            },
+            "limit": {
+                "type": "integer",
+                "default": 10,
+                "description": "Maximum results to return.",
+            },
+            "project": _PROJECT_PARAM,
+        },
+        "required": ["query"],
+    },
+}
+
+CHECK_DECISION: ToolSpec = {
+    "name": "check_decision",
+    "title": "Check decision for conflicts",
+    "description": (
+        "Check whether a proposed approach conflicts with existing decisions "
+        "WITHOUT writing anything. Returns related decisions (via BM25 "
+        "retrieval) and an LLM-based conflict assessment when an API key is "
+        "available.\n"
+        "\n"
+        "Use this to consult the project's decision history before committing "
+        'to an approach — especially when the user asks "should we...", '
+        '"what if we...", "can we...", or "check if...". If check_decision '
+        "shows no conflicts and you want to record the choice, call "
+        "propose_decision next with skip_validation=true to avoid "
+        "redundant work."
+    ),
+    "annotations": {**_READ_ANNOTATIONS, "idempotentHint": True},
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "proposed_approach": {
+                "type": "string",
+                "description": "Description of the approach you're considering.",
+            },
+            "context": {
+                "type": "string",
+                "description": (
+                    "Optional additional context about why you're considering this approach."
+                ),
+            },
+            "project": _PROJECT_PARAM,
+        },
+        "required": ["proposed_approach"],
+    },
+}
+
+PROPOSE_DECISION: ToolSpec = {
+    "name": "propose_decision",
+    "title": "Propose a decision",
+    "description": (
+        "Propose a new architectural decision for validation and recording.\n"
+        "\n"
+        "Runs a validation pipeline before writing:\n"
+        "- Tier 1: Structural validation (required fields, length limits)\n"
+        "- Tier 2: BM25 similarity check against existing decisions\n"
+        "- Tier 3: LLM-based conflict detection (when API key available)\n"
+        "\n"
+        "Returns validation results (similar decisions, potential conflicts, "
+        "assessment) and a confirm_id. The decision is NOT written until "
+        "confirm_decision is called with the returned confirm_id.\n"
+        "\n"
+        "If you already called check_decision for this approach and saw no "
+        "conflicts, pass skip_validation=true to skip redundant tier-2/tier-3 "
+        "matching. Tier-1 structural validation always runs regardless.\n"
+        "\n"
+        "Call this when you choose between two or more approaches, replace or "
+        "remove a dependency, establish a new pattern, or cut scope. Always "
+        "include what was rejected and why."
+    ),
+    "annotations": {**_WRITE_ANNOTATIONS, "idempotentHint": False},
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "title": {
+                "type": "string",
+                "description": "Short title for the decision.",
+            },
+            "rationale": {
+                "type": "string",
+                "description": (
+                    "Why this decision was made, including constraints and tradeoffs."
+                ),
+            },
+            "rejected": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "alternative": {"type": "string"},
+                        "reason": {"type": "string"},
+                    },
+                },
+                "description": "Alternatives considered and rejected, each with reason.",
+            },
+            "confidence": {
+                "type": "string",
+                "enum": ["high", "medium", "low"],
+                "default": "medium",
+            },
+            "decision_type": {
+                "type": "string",
+                "enum": [
+                    "architecture",
+                    "library_choice",
+                    "pattern",
+                    "refactor",
+                    "api_design",
+                    "infrastructure",
+                    "data_model",
+                ],
+            },
+            "reversibility": {
+                "type": "string",
+                "enum": ["easy", "moderate", "hard"],
+            },
+            "files_affected": {"type": "array", "items": {"type": "string"}},
+            "skip_validation": {
+                "type": "boolean",
+                "default": False,
+                "description": (
+                    "Skip tier-2/tier-3 validation (tier-1 always runs). "
+                    "Use when you already called check_decision."
+                ),
+            },
+            "project": _PROJECT_PARAM,
+        },
+        "required": ["title", "rationale"],
+    },
+}
+
+CONFIRM_DECISION: ToolSpec = {
+    "name": "confirm_decision",
+    "title": "Confirm proposed decision",
+    "description": (
+        "Confirm a previously proposed decision, committing it to the store.\n"
+        "\n"
+        "Only needed when propose_decision returns status=pending_confirmation. "
+        "The confirm_id expires after 10 minutes — if it has expired, call "
+        "propose_decision again to get a fresh id. Calling confirm_decision "
+        "twice with the same id is safe; only the first call writes."
+    ),
+    "annotations": {**_WRITE_ANNOTATIONS, "idempotentHint": True},
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "confirm_id": {
+                "type": "string",
+                "description": "The confirm_id returned by propose_decision.",
+            },
+            "project": _PROJECT_PARAM,
+        },
+        "required": ["confirm_id"],
+    },
+}
+
+FLAG_QUESTION: ToolSpec = {
+    "name": "flag_question",
+    "title": "Flag open question",
+    "description": (
+        "Flag an unresolved question for human review. Appends to "
+        "open-questions.md in the project store.\n"
+        "\n"
+        "Before writing, checks whether the question is already addressed by "
+        "an existing decision — if so, the response includes a hint pointing "
+        "to that decision (the question is still logged).\n"
+        "\n"
+        "Use when you encounter an ambiguity a human should weigh in on: "
+        "architectural trade-offs, unclear requirements, or scope boundaries."
+    ),
+    "annotations": {**_WRITE_ANNOTATIONS, "idempotentHint": False},
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "question": {
+                "type": "string",
+                "description": "The question to flag.",
+            },
+            "context": {
+                "type": "string",
+                "description": "Optional context about why this question matters.",
+            },
+            "project": _PROJECT_PARAM,
+        },
+        "required": ["question"],
+    },
+}
+
+UPDATE_STATE: ToolSpec = {
+    "name": "update_state",
+    "title": "Update project state",
+    "description": (
+        "Update the project's current state with a progress delta and trigger "
+        "a snapshot. Before writing, checks for potential contradictions with "
+        "recent state entries and returns a warning if found (the update is "
+        "still applied).\n"
+        "\n"
+        "Use when you complete a meaningful unit of work — a feature, a "
+        "refactor, a bug fix — so the next session starts with current context."
+    ),
+    "annotations": {**_WRITE_ANNOTATIONS, "idempotentHint": False},
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "delta": {
+                "type": "string",
+                "description": 'Description of what changed (e.g. "Deployed v0.2.0 to staging").',
+            },
+            "project": _PROJECT_PARAM,
+        },
+        "required": ["delta"],
+    },
+}
+
+# ── Registry ──
+
+ALL_TOOLS: tuple[ToolSpec, ...] = (
+    GET_CONTEXT,
+    GET_RAW_FILE,
+    LIST_DECISIONS,
+    GET_DECISION,
+    DIFF_SINCE_LAST_SESSION,
+    SEARCH_DECISIONS,
+    CHECK_DECISION,
+    PROPOSE_DECISION,
+    CONFIRM_DECISION,
+    FLAG_QUESTION,
+    UPDATE_STATE,
+)
+
+_BY_NAME: dict[str, ToolSpec] = {spec["name"]: spec for spec in ALL_TOOLS}
+
+
+def get_tool_spec(name: str) -> ToolSpec:
+    """Look up a tool spec by name."""
+    if name not in _BY_NAME:
+        raise KeyError(f"Unknown tool: {name}")
+    return _BY_NAME[name]

--- a/packages/nauro-core/tests/test_mcp_tools.py
+++ b/packages/nauro-core/tests/test_mcp_tools.py
@@ -1,0 +1,111 @@
+"""Tests for the centralized MCP tool registry."""
+
+import pytest
+
+from nauro_core.mcp_tools import ALL_TOOLS, get_tool_spec
+
+EXPECTED_TOOL_NAMES = {
+    "get_context",
+    "get_raw_file",
+    "list_decisions",
+    "get_decision",
+    "diff_since_last_session",
+    "search_decisions",
+    "check_decision",
+    "propose_decision",
+    "confirm_decision",
+    "flag_question",
+    "update_state",
+}
+
+READ_TOOLS = {
+    "get_context",
+    "get_raw_file",
+    "list_decisions",
+    "get_decision",
+    "diff_since_last_session",
+    "search_decisions",
+    "check_decision",
+}
+
+WRITE_TOOLS = {"propose_decision", "confirm_decision", "flag_question", "update_state"}
+
+
+class TestRegistry:
+    def test_eleven_tools(self):
+        assert len(ALL_TOOLS) == 11
+
+    def test_all_expected_names(self):
+        names = {spec["name"] for spec in ALL_TOOLS}
+        assert names == EXPECTED_TOOL_NAMES
+
+    def test_unique_names(self):
+        names = [spec["name"] for spec in ALL_TOOLS]
+        assert len(names) == len(set(names))
+
+
+class TestSpecShape:
+    @pytest.mark.parametrize("spec", ALL_TOOLS, ids=lambda s: s["name"])
+    def test_required_fields(self, spec):
+        assert spec["name"]
+        assert spec["title"]
+        assert spec["description"]
+        assert spec["annotations"]
+        assert spec["input_schema"]
+
+    @pytest.mark.parametrize("spec", ALL_TOOLS, ids=lambda s: s["name"])
+    def test_input_schema_is_object(self, spec):
+        assert spec["input_schema"]["type"] == "object"
+        assert "properties" in spec["input_schema"]
+
+    @pytest.mark.parametrize("spec", ALL_TOOLS, ids=lambda s: s["name"])
+    def test_project_param_present(self, spec):
+        """Every tool must accept an optional `project` parameter."""
+        props = spec["input_schema"]["properties"]
+        assert "project" in props, f"{spec['name']} is missing `project`"
+        # And it must not be in required — always optional.
+        required = spec["input_schema"].get("required", [])
+        assert "project" not in required
+
+    @pytest.mark.parametrize("spec", ALL_TOOLS, ids=lambda s: s["name"])
+    def test_closed_world(self, spec):
+        """All Nauro tools operate on the local/remote store, not the open web."""
+        assert spec["annotations"].get("openWorldHint") is False
+
+
+class TestReadWriteAnnotations:
+    @pytest.mark.parametrize("name", sorted(READ_TOOLS))
+    def test_read_tools_are_readonly(self, name):
+        spec = get_tool_spec(name)
+        assert spec["annotations"].get("readOnlyHint") is True
+
+    @pytest.mark.parametrize("name", sorted(WRITE_TOOLS))
+    def test_write_tools_not_readonly(self, name):
+        spec = get_tool_spec(name)
+        assert spec["annotations"].get("readOnlyHint") is False
+
+    @pytest.mark.parametrize("name", sorted(WRITE_TOOLS))
+    def test_write_tools_not_destructive(self, name):
+        """Nauro writes are additive — no tool ever deletes data."""
+        spec = get_tool_spec(name)
+        assert spec["annotations"].get("destructiveHint") is False
+
+
+class TestLookup:
+    def test_get_tool_spec_by_name(self):
+        spec = get_tool_spec("check_decision")
+        assert spec["name"] == "check_decision"
+
+    def test_get_tool_spec_unknown_raises(self):
+        with pytest.raises(KeyError):
+            get_tool_spec("not_a_tool")
+
+
+class TestGetContextLevel:
+    """Regression: level must be the string enum, not int, to match remote."""
+
+    def test_level_is_string_enum(self):
+        spec = get_tool_spec("get_context")
+        level = spec["input_schema"]["properties"]["level"]
+        assert level["type"] == "string"
+        assert level["enum"] == ["L0", "L1", "L2"]

--- a/packages/nauro/CLAUDE.md
+++ b/packages/nauro/CLAUDE.md
@@ -98,35 +98,3 @@ src/nauro/
 tests/
   fixtures/              # pre-scaffolded stores, extraction test cases
 ```
-
-<!-- NAURO:START — managed by nauro, do not edit -->
-
-## Nauro — project context
-
-This project uses Nauro for persistent context. The MCP server is
-auto-started by Claude Code. Project context has been injected at
-session start via AGENTS.md.
-
----
-
-## When to propose a decision
-
-Call `propose_decision` when you choose between two or more approaches,
-replace or remove a dependency, establish a new pattern, or cut
-something from scope. Do not wait until the end of the session —
-log decisions at the moment they are made. Use `check_decision` first
-for advisory conflict checks, then `confirm_decision` after reviewing
-validation results.
-
-Examples that warrant a decision:
-- Choosing FastAPI over Flask for the MCP server
-- Deciding to defer multi-repo sync to v2
-- Establishing that all store writes go through writer.py, never direct
-- Removing Redis as a dependency by switching to procrastinate
-
-Examples that do not:
-- Fixing a bug with an obvious solution
-- Adding a test for existing behavior
-- Renaming a variable
-
-<!-- NAURO:END -->

--- a/packages/nauro/src/nauro/cli/commands/setup.py
+++ b/packages/nauro/src/nauro/cli/commands/setup.py
@@ -1,8 +1,7 @@
 """nauro setup — Configure tool integrations.
 
 Currently supports:
-  nauro setup claude-code  — inject CLAUDE.md directives + MCP config
-  nauro setup claude-code --hooks — install Claude Code compaction hooks
+  nauro setup claude-code  — register MCP server + regenerate AGENTS.md
 """
 
 from __future__ import annotations
@@ -19,85 +18,23 @@ from nauro.templates.agents_md import regenerate_agents_md_for_project
 
 setup_app = typer.Typer(help="Configure tool integrations.")
 
+# Legacy markers — kept for removal of old CLAUDE.md blocks during --remove.
 CLAUDE_MD_START = NAURO_BLOCK_START
 CLAUDE_MD_END = NAURO_BLOCK_END
 
 
-def _claude_md_block() -> str:
-    """Generate the CLAUDE.md integration block."""
-    return f"""{CLAUDE_MD_START}
+def _remove_claude_md(repo_path: Path) -> str | None:
+    """Remove a legacy Nauro block from CLAUDE.md if present.
 
-## Nauro — project context
-
-This project uses Nauro for persistent context. The MCP server is
-auto-started by Claude Code. Project context has been injected at
-session start via AGENTS.md.
-
----
-
-## When to propose a decision
-
-Call `propose_decision` when you choose between two or more approaches,
-replace or remove a dependency, establish a new pattern, or cut
-something from scope. Do not wait until the end of the session —
-log decisions at the moment they are made. Use `check_decision` first
-for advisory conflict checks, then `confirm_decision` after reviewing
-validation results.
-
-Examples that warrant a decision:
-- Choosing FastAPI over Flask for the MCP server
-- Deciding to defer multi-repo sync to v2
-- Establishing that all store writes go through writer.py, never direct
-- Removing Redis as a dependency by switching to procrastinate
-
-Examples that do not:
-- Fixing a bug with an obvious solution
-- Adding a test for existing behavior
-- Renaming a variable
-
-{CLAUDE_MD_END}"""
-
-
-def _inject_claude_md(repo_path: Path, project_name: str) -> str:
-    """Inject or replace the Nauro block in CLAUDE.md.
-
-    Returns a status string describing what happened.
-    """
-    claude_md = repo_path / CLAUDE_MD
-    block = _claude_md_block()
-
-    if claude_md.exists():
-        content = claude_md.read_text()
-        if CLAUDE_MD_START in content and CLAUDE_MD_END in content:
-            # Replace existing block
-            before = content[: content.index(CLAUDE_MD_START)]
-            after = content[content.index(CLAUDE_MD_END) + len(CLAUDE_MD_END) :]
-            new_content = before + block + after
-            claude_md.write_text(new_content)
-            return f"  {repo_path}: updated existing Nauro block in {CLAUDE_MD}"
-        else:
-            # Append block
-            if not content.endswith("\n"):
-                content += "\n"
-            claude_md.write_text(content + "\n" + block + "\n")
-            return f"  {repo_path}: appended Nauro block to {CLAUDE_MD}"
-    else:
-        claude_md.write_text(block + "\n")
-        return f"  {repo_path}: created {CLAUDE_MD}"
-
-
-def _remove_claude_md(repo_path: Path) -> str:
-    """Remove the Nauro block from CLAUDE.md.
-
-    Returns a status string describing what happened.
+    Returns a status string if a block was removed, or None if no block found.
     """
     claude_md = repo_path / CLAUDE_MD
     if not claude_md.exists():
-        return f"  {repo_path}: no {CLAUDE_MD} found"
+        return None
 
     content = claude_md.read_text()
     if CLAUDE_MD_START not in content:
-        return f"  {repo_path}: no Nauro block found in {CLAUDE_MD}"
+        return None
 
     before = content[: content.index(CLAUDE_MD_START)]
     after = content[content.index(CLAUDE_MD_END) + len(CLAUDE_MD_END) :]
@@ -105,10 +42,10 @@ def _remove_claude_md(repo_path: Path) -> str:
 
     if not remaining:
         claude_md.unlink()
-        return f"  {repo_path}: deleted {CLAUDE_MD} (only contained Nauro block)"
+        return f"  {repo_path}: removed legacy Nauro block (deleted empty {CLAUDE_MD})"
     else:
         claude_md.write_text(remaining + "\n")
-        return f"  {repo_path}: removed Nauro block from {CLAUDE_MD}"
+        return f"  {repo_path}: removed legacy Nauro block from {CLAUDE_MD}"
 
 
 def _find_claude_config_path() -> Path | None:
@@ -195,26 +132,28 @@ def claude_code(
         typer.echo(f"Project '{project_name}' has no associated repos.", err=True)
         raise typer.Exit(code=1)
 
-    repo_results = []
+    # Clean up legacy CLAUDE.md blocks (behavioral guidance now delivered
+    # via MCP server instructions, so the injected block is no longer needed).
+    legacy_results = []
     for repo_str in entry["repo_paths"]:
         repo_path = Path(repo_str)
         if not repo_path.is_dir():
-            repo_results.append(f"  {repo_path}: directory not found, skipped")
             continue
-        if remove:
-            repo_results.append(_remove_claude_md(repo_path))
-        else:
-            repo_results.append(_inject_claude_md(repo_path, project_name))
+        result = _remove_claude_md(repo_path)
+        if result:
+            legacy_results.append(result)
 
     mcp_result = _configure_mcp(remove=remove)
 
     # Print summary
     action = "Removed" if remove else "Configured"
     typer.echo(f"{action} Nauro for project '{project_name}':\n")
-    typer.echo("Repos:")
-    for line in repo_results:
-        typer.echo(line)
-    typer.echo(f"\n{mcp_result}")
+    typer.echo(mcp_result)
+
+    if legacy_results:
+        typer.echo("\nLegacy cleanup:")
+        for line in legacy_results:
+            typer.echo(line)
 
     if not remove:
         # Regenerate AGENTS.md so context is fresh from the start

--- a/packages/nauro/src/nauro/mcp/stdio_server.py
+++ b/packages/nauro/src/nauro/mcp/stdio_server.py
@@ -3,18 +3,14 @@
 Spawned by Claude Code at session start, communicates over stdin/stdout.
 Same tools as the HTTP server, same store, same payloads.
 
+Tool metadata (descriptions, titles, annotations) is centralized in
+`nauro_core.mcp_tools` — edit there, not here — so the local stdio server
+and the remote HTTP server stay in sync.
+
 MCP tools (11 total — 7 read, 4 write):
-  - get_context(project, level)          → Return project context at L0/L1/L2
-  - get_raw_file(project, path)          → Return raw file from project store
-  - list_decisions(project, ...)         → Browse decision history
-  - get_decision(project, number)        → Get full decision by number
-  - diff_since_last_session(project, ..) → Show what changed since last session
-  - search_decisions(project, query)     → Search decisions by keyword
-  - propose_decision(project, ...)       → Propose a decision with validation
-  - confirm_decision(confirm_id)         → Confirm a pending decision
-  - check_decision(proposed_approach)    → Check for conflicts without writing
-  - flag_question(project, ...)          → Flag an open question for human review
-  - update_state(project, ...)           → Update current project state
+  get_context, get_raw_file, list_decisions, get_decision,
+  diff_since_last_session, search_decisions, check_decision,
+  propose_decision, confirm_decision, flag_question, update_state
 """
 
 from __future__ import annotations
@@ -22,8 +18,12 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
+from typing import Any, Literal
 
 from mcp.server import FastMCP
+from mcp.types import ToolAnnotations
+from nauro_core.constants import MCP_INSTRUCTIONS
+from nauro_core.mcp_tools import ToolSpec, get_tool_spec
 
 from nauro.mcp.tools import (
     tool_check_decision,
@@ -42,7 +42,17 @@ from nauro.onboarding import WELCOME_NO_PROJECT
 from nauro.store.registry import get_store_path, resolve_project
 
 logger = logging.getLogger("nauro.stdio")
-mcp = FastMCP("nauro", log_level="WARNING")
+mcp = FastMCP("nauro", instructions=MCP_INSTRUCTIONS, log_level="WARNING")
+
+
+def _spec_kwargs(name: str) -> dict[str, Any]:
+    """Build FastMCP @tool() decorator kwargs from the shared registry."""
+    spec: ToolSpec = get_tool_spec(name)
+    return {
+        "title": spec["title"],
+        "description": spec["description"],
+        "annotations": ToolAnnotations(**spec["annotations"]),
+    }
 
 
 def _resolve_store(project: str | None, cwd: str | None) -> Path:
@@ -58,43 +68,22 @@ def _resolve_store(project: str | None, cwd: str | None) -> Path:
     return store_path
 
 
-@mcp.tool()
-def get_context(project: str | None = None, cwd: str | None = None, level: int = 0) -> str:
-    """Return project context at the requested detail level.
-
-    L0 includes the last 10 active decisions with titles and dates.
-    Do NOT call list_decisions after get_context unless you need decisions
-    beyond the last 10 or need the include_superseded filter.
-
-    Args:
-        project: Project name (e.g. "nauro"). If omitted, resolved from cwd.
-        cwd: Working directory path for project resolution fallback.
-        level: Detail level — 0 (concise summary), 1 (working set), 2 (full dump).
-    """
+@mcp.tool(**_spec_kwargs("get_context"))
+def get_context(
+    project: str | None = None,
+    cwd: str | None = None,
+    level: Literal["L0", "L1", "L2"] | int = "L0",
+) -> str:
     try:
         store_path = _resolve_store(project, cwd)
     except ValueError:
         return WELCOME_NO_PROJECT
+    # tool_get_context accepts both int and string levels.
     return tool_get_context(store_path, level)
 
 
-@mcp.tool()
+@mcp.tool(**_spec_kwargs("get_raw_file"))
 def get_raw_file(path: str, project: str | None = None, cwd: str | None = None) -> dict:
-    """Returns the raw content of any file in the Nauro project store.
-
-    Paths include: project.md, state.md, questions.md, references.md,
-    decisions/042-some-decision.md
-
-    This is a low-level escape hatch. For most use cases, prefer:
-    - get_context for project overview, state, questions, and recent decisions
-    - get_decision for a specific decision by number
-    - search_decisions for finding decisions by topic
-
-    Args:
-        path: File path relative to project root (e.g., 'project.md').
-        project: Project name (e.g. "nauro"). If omitted, resolved from cwd.
-        cwd: Working directory path for project resolution fallback.
-    """
     try:
         store_path = _resolve_store(project, cwd)
     except ValueError:
@@ -102,24 +91,13 @@ def get_raw_file(path: str, project: str | None = None, cwd: str | None = None) 
     return tool_get_raw_file(store_path, path)
 
 
-@mcp.tool()
+@mcp.tool(**_spec_kwargs("list_decisions"))
 def list_decisions(
     project: str | None = None,
     cwd: str | None = None,
     limit: int = 20,
     include_superseded: bool = False,
 ) -> dict:
-    """Browse the full decision history.
-
-    Use when you need decisions beyond the last 10 included in get_context,
-    or when you need the include_superseded filter.
-
-    Args:
-        project: Project name. If omitted, resolved from cwd.
-        cwd: Working directory path for project resolution fallback.
-        limit: Max decisions to return (default 20).
-        include_superseded: Include superseded decisions (default false).
-    """
     try:
         store_path = _resolve_store(project, cwd)
     except ValueError:
@@ -127,19 +105,12 @@ def list_decisions(
     return tool_list_decisions(store_path, limit, include_superseded)
 
 
-@mcp.tool()
+@mcp.tool(**_spec_kwargs("get_decision"))
 def get_decision(
     number: int,
     project: str | None = None,
     cwd: str | None = None,
 ) -> dict:
-    """Get the full content of a specific decision by number.
-
-    Args:
-        number: Decision number (e.g., 23).
-        project: Project name. If omitted, resolved from cwd.
-        cwd: Working directory path for project resolution fallback.
-    """
     try:
         store_path = _resolve_store(project, cwd)
     except ValueError:
@@ -147,23 +118,12 @@ def get_decision(
     return tool_get_decision(store_path, number)
 
 
-@mcp.tool()
+@mcp.tool(**_spec_kwargs("diff_since_last_session"))
 def diff_since_last_session(
     project: str | None = None,
     cwd: str | None = None,
     days: int | None = None,
 ) -> dict:
-    """Show what changed in the project context since the last snapshot.
-
-    When days is omitted, diffs the two most recent snapshots (session-scoped).
-    When days is provided, finds the nearest snapshot to N days ago and diffs
-    against the current state.
-
-    Args:
-        project: Project name. If omitted, resolved from cwd.
-        cwd: Working directory path for project resolution fallback.
-        days: Optional: number of days to look back.
-    """
     try:
         store_path = _resolve_store(project, cwd)
     except ValueError:
@@ -171,9 +131,36 @@ def diff_since_last_session(
     return tool_diff_since_last_session(store_path, days)
 
 
-@mcp.tool()
+@mcp.tool(**_spec_kwargs("search_decisions"))
+def search_decisions(
+    query: str,
+    limit: int = 10,
+    project: str | None = None,
+    cwd: str | None = None,
+) -> dict:
+    try:
+        store_path = _resolve_store(project, cwd)
+    except ValueError:
+        return {"store": "local", "status": "error", "guidance": WELCOME_NO_PROJECT}
+    return tool_search_decisions(store_path, query, limit)
+
+
+@mcp.tool(**_spec_kwargs("check_decision"))
+def check_decision(
+    proposed_approach: str,
+    context: str | None = None,
+    project: str | None = None,
+    cwd: str | None = None,
+) -> dict:
+    try:
+        store_path = _resolve_store(project, cwd)
+    except ValueError:
+        return {"store": "local", "status": "error", "guidance": WELCOME_NO_PROJECT}
+    return tool_check_decision(store_path, proposed_approach, context)
+
+
+@mcp.tool(**_spec_kwargs("propose_decision"))
 def propose_decision(
-    project: str,
     title: str,
     rationale: str,
     rejected: list[dict] | None = None,
@@ -182,40 +169,11 @@ def propose_decision(
     reversibility: str | None = None,
     files_affected: list[str] | None = None,
     skip_validation: bool = False,
+    project: str | None = None,
+    cwd: str | None = None,
 ) -> dict:
-    """Propose a new architectural decision for validation and recording.
-
-    Runs a validation pipeline before writing:
-    - Tier 1: Structural validation (required fields)
-    - Tier 2: Similarity check against existing decisions
-    - Tier 3: Conflict detection against existing decisions
-
-    Returns validation results (similar decisions, conflicts, assessment)
-    and a confirm_id. The decision is NOT written until confirm_decision
-    is called with this confirm_id.
-
-    If you already called check_decision for this approach, pass
-    skip_validation=true to skip redundant tier-2/tier-3 matching.
-    Tier-1 structural validation always runs regardless.
-
-    Use check_decision first for advisory "would this conflict?" checks.
-    Use propose_decision when ready to write.
-
-    Args:
-        project: Project name.
-        title: Short title for the decision.
-        rationale: Why this decision was made, including constraints and tradeoffs.
-        rejected: Alternatives considered and rejected, each with "alternative" and "reason".
-        confidence: high, medium, or low.
-        decision_type: architecture, library_choice, pattern, refactor,
-            api_design, infrastructure, data_model.
-        reversibility: easy, moderate, or hard.
-        files_affected: Key file paths affected by this decision.
-        skip_validation: Skip tier-2/tier-3 validation. Tier-1 structural
-            checks always run. Use when you already called check_decision.
-    """
     try:
-        store_path = _resolve_store(project, None)
+        store_path = _resolve_store(project, cwd)
     except ValueError:
         return {"store": "local", "status": "error", "guidance": WELCOME_NO_PROJECT}
     return tool_propose_decision(
@@ -231,21 +189,12 @@ def propose_decision(
     )
 
 
-@mcp.tool()
+@mcp.tool(**_spec_kwargs("confirm_decision"))
 def confirm_decision(
     confirm_id: str,
     project: str | None = None,
     cwd: str | None = None,
 ) -> dict:
-    """Confirm a previously proposed decision after reviewing the validation results.
-
-    Only needed when propose_decision returns status=pending_confirmation.
-
-    Args:
-        confirm_id: The confirm_id returned by propose_decision.
-        project: Project name (for store resolution).
-        cwd: Working directory path (fallback for project resolution).
-    """
     try:
         store_path = _resolve_store(project, cwd)
     except ValueError:
@@ -253,83 +202,15 @@ def confirm_decision(
     return tool_confirm_decision(store_path, confirm_id)
 
 
-@mcp.tool()
-def check_decision(
-    proposed_approach: str,
-    context: str | None = None,
-    project: str | None = None,
-    cwd: str | None = None,
-) -> dict:
-    """Check whether a proposed approach conflicts with existing decisions WITHOUT writing anything.
-
-    Use this to consult the project's decision history before committing to an approach.
-
-    Args:
-        proposed_approach: Description of the approach you're considering.
-        context: Optional additional context about why you're considering this approach.
-        project: Project name.
-        cwd: Working directory path (fallback for project resolution).
-    """
-    try:
-        store_path = _resolve_store(project, cwd)
-    except ValueError:
-        return {"store": "local", "status": "error", "guidance": WELCOME_NO_PROJECT}
-    return tool_check_decision(store_path, proposed_approach, context)
-
-
-@mcp.tool()
-def search_decisions(
-    query: str,
-    limit: int = 10,
-    project: str | None = None,
-    cwd: str | None = None,
-) -> dict:
-    """Search across all project decisions by keyword. Returns decisions whose
-    titles or rationale contain the search terms (case-insensitive substring
-    matching). Includes both active and superseded decisions.
-
-    Use when you need to find decisions about a specific topic rather than
-    browsing the full list. More token-efficient than list_decisions for
-    targeted lookups.
-
-    Example: search_decisions("authentication") returns all decisions
-    related to auth, OAuth, JWT, etc.
-
-    Returns: decision number, title, date, status, and a relevance snippet
-    from the matching rationale.
-
-    Requires a non-empty query. Use list_decisions to browse all decisions.
-
-    Args:
-        query: Search text (required, non-empty).
-        limit: Maximum results to return (default 10).
-        project: Project name. If omitted, resolved from cwd.
-        cwd: Working directory path for project resolution fallback.
-    """
-    try:
-        store_path = _resolve_store(project, cwd)
-    except ValueError:
-        return {"store": "local", "status": "error", "guidance": WELCOME_NO_PROJECT}
-    return tool_search_decisions(store_path, query, limit)
-
-
-@mcp.tool()
+@mcp.tool(**_spec_kwargs("flag_question"))
 def flag_question(
-    project: str,
     question: str,
     context: str | None = None,
+    project: str | None = None,
+    cwd: str | None = None,
 ) -> str:
-    """Flag an open question for human review.
-
-    Checks if the question is already addressed by an existing decision.
-
-    Args:
-        project: Project name.
-        question: The question to flag.
-        context: Optional context about why this question matters.
-    """
     try:
-        store_path = _resolve_store(project, None)
+        store_path = _resolve_store(project, cwd)
     except ValueError:
         return WELCOME_NO_PROJECT
     result = tool_flag_question(store_path, question, context)
@@ -338,21 +219,14 @@ def flag_question(
     return "Question flagged."
 
 
-@mcp.tool()
+@mcp.tool(**_spec_kwargs("update_state"))
 def update_state(
-    project: str,
     delta: str,
+    project: str | None = None,
+    cwd: str | None = None,
 ) -> str:
-    """Update current project state with what was completed. Triggers a snapshot.
-
-    Checks for potential contradictions with recent state before writing.
-
-    Args:
-        project: Project name.
-        delta: Description of what changed (e.g. "Deployed v0.2.0 to staging").
-    """
     try:
-        store_path = _resolve_store(project, None)
+        store_path = _resolve_store(project, cwd)
     except ValueError:
         return WELCOME_NO_PROJECT
     result = tool_update_state(store_path, delta)

--- a/packages/nauro/tests/test_setup.py
+++ b/packages/nauro/tests/test_setup.py
@@ -1,5 +1,6 @@
 """Tests for nauro setup claude-code command."""
 
+import json
 from pathlib import Path
 
 from typer.testing import CliRunner
@@ -24,258 +25,223 @@ def _setup_project(tmp_path: Path, monkeypatch, repo_paths: list[Path] | None = 
     return repo_paths
 
 
-def test_inject_into_existing_claude_md(tmp_path: Path, monkeypatch):
-    """Injects into existing CLAUDE.md without clobbering other content."""
-    repos = _setup_project(tmp_path, monkeypatch)
-    existing = "# My Project\n\nSome existing content.\n"
-    (repos[0] / "CLAUDE.md").write_text(existing)
+class TestMCPConfig:
+    def test_mcp_config_merge_preserves_existing(self, tmp_path: Path, monkeypatch):
+        """MCP config merge preserves existing servers."""
+        _setup_project(tmp_path, monkeypatch)
 
-    result = runner.invoke(app, ["setup", "claude-code", "--project", "testproj"])
-    assert result.exit_code == 0
-
-    content = (repos[0] / "CLAUDE.md").read_text()
-    assert "# My Project" in content
-    assert "Some existing content." in content
-    assert CLAUDE_MD_START in content
-    assert CLAUDE_MD_END in content
-    assert "Nauro — project context" in content
-
-
-def test_creates_claude_md_if_missing(tmp_path: Path, monkeypatch):
-    """Creates CLAUDE.md if it doesn't exist."""
-    repos = _setup_project(tmp_path, monkeypatch)
-    assert not (repos[0] / "CLAUDE.md").exists()
-
-    result = runner.invoke(app, ["setup", "claude-code", "--project", "testproj"])
-    assert result.exit_code == 0
-
-    content = (repos[0] / "CLAUDE.md").read_text()
-    assert CLAUDE_MD_START in content
-    assert "Nauro — project context" in content
-    assert "created CLAUDE.md" in result.output
-
-
-def test_idempotent_rerun(tmp_path: Path, monkeypatch):
-    """Re-running replaces existing NAURO block (idempotent)."""
-    repos = _setup_project(tmp_path, monkeypatch)
-    existing = "# My Project\n\nKeep this.\n"
-    (repos[0] / "CLAUDE.md").write_text(existing)
-
-    # Run twice
-    runner.invoke(app, ["setup", "claude-code", "--project", "testproj"])
-    result = runner.invoke(app, ["setup", "claude-code", "--project", "testproj"])
-    assert result.exit_code == 0
-
-    content = (repos[0] / "CLAUDE.md").read_text()
-    # Should only have one block
-    assert content.count(CLAUDE_MD_START) == 1
-    assert content.count(CLAUDE_MD_END) == 1
-    assert "# My Project" in content
-    assert "Keep this." in content
-
-
-def test_remove_strips_block(tmp_path: Path, monkeypatch):
-    """--remove strips block cleanly, leaves other content intact."""
-    repos = _setup_project(tmp_path, monkeypatch)
-    existing = "# My Project\n\nKeep this.\n"
-    (repos[0] / "CLAUDE.md").write_text(existing)
-
-    # Add then remove
-    runner.invoke(app, ["setup", "claude-code", "--project", "testproj"])
-    result = runner.invoke(app, ["setup", "claude-code", "--project", "testproj", "--remove"])
-    assert result.exit_code == 0
-
-    content = (repos[0] / "CLAUDE.md").read_text()
-    assert CLAUDE_MD_START not in content
-    assert CLAUDE_MD_END not in content
-    assert "# My Project" in content
-    assert "Keep this." in content
-
-
-def test_remove_deletes_file_if_only_nauro(tmp_path: Path, monkeypatch):
-    """--remove on CLAUDE.md with only the Nauro block deletes the file."""
-    repos = _setup_project(tmp_path, monkeypatch)
-
-    # Create CLAUDE.md with only Nauro block
-    runner.invoke(app, ["setup", "claude-code", "--project", "testproj"])
-    assert (repos[0] / "CLAUDE.md").exists()
-
-    result = runner.invoke(app, ["setup", "claude-code", "--project", "testproj", "--remove"])
-    assert result.exit_code == 0
-    assert not (repos[0] / "CLAUDE.md").exists()
-    assert "deleted CLAUDE.md" in result.output
-
-
-def test_block_contains_behavioral_instructions(tmp_path: Path, monkeypatch):
-    """Block contains behavioral instructions for logging decisions."""
-    repos = _setup_project(tmp_path, monkeypatch)
-
-    runner.invoke(app, ["setup", "claude-code", "--project", "testproj"])
-    content = (repos[0] / "CLAUDE.md").read_text()
-
-    assert "propose_decision" in content
-    assert "When to propose a decision" in content
-    assert "Examples that warrant a decision:" in content
-
-
-def test_mcp_config_merge_preserves_existing(tmp_path: Path, monkeypatch):
-    """MCP config merge preserves existing servers."""
-    _setup_project(tmp_path, monkeypatch)
-
-    # Create pre-existing MCP config with another server
-    claude_dir = tmp_path / "claude_home"
-    claude_dir.mkdir()
-    config_path = claude_dir / "claude_desktop_config.json"
-    import json
-
-    config_path.write_text(
-        json.dumps({"mcpServers": {"other-tool": {"url": "http://localhost:9999"}}})
-    )
-
-    # Patch _find_claude_config_path to use our test path
-    monkeypatch.setattr(
-        "nauro.cli.commands.setup._find_claude_config_path",
-        lambda: config_path,
-    )
-
-    result = runner.invoke(app, ["setup", "claude-code", "--project", "testproj"])
-    assert result.exit_code == 0
-
-    config = json.loads(config_path.read_text())
-    assert "nauro" in config["mcpServers"]
-    assert config["mcpServers"]["nauro"]["args"] == ["serve", "--stdio"]
-    assert "command" in config["mcpServers"]["nauro"]
-    # Existing server preserved
-    assert "other-tool" in config["mcpServers"]
-    assert config["mcpServers"]["other-tool"]["url"] == "http://localhost:9999"
-
-
-def test_mcp_config_created_from_scratch(tmp_path: Path, monkeypatch):
-    """MCP config created from scratch if missing."""
-    _setup_project(tmp_path, monkeypatch)
-
-    config_path = tmp_path / "claude_home" / "claude_desktop_config.json"
-    (tmp_path / "claude_home").mkdir()
-
-    monkeypatch.setattr(
-        "nauro.cli.commands.setup._find_claude_config_path",
-        lambda: config_path,
-    )
-
-    result = runner.invoke(app, ["setup", "claude-code", "--project", "testproj"])
-    assert result.exit_code == 0
-    assert config_path.exists()
-
-    import json
-
-    config = json.loads(config_path.read_text())
-    assert config["mcpServers"]["nauro"]["args"] == ["serve", "--stdio"]
-    assert "command" in config["mcpServers"]["nauro"]
-
-
-def test_multi_repo_all_updated(tmp_path: Path, monkeypatch):
-    """Multi-repo: all associated repos get updated CLAUDE.md."""
-    repo1 = tmp_path / "repo1"
-    repo2 = tmp_path / "repo2"
-    repo1.mkdir()
-    repo2.mkdir()
-
-    _setup_project(tmp_path, monkeypatch, repo_paths=[repo1, repo2])
-
-    # Patch MCP config to avoid touching real home
-    monkeypatch.setattr(
-        "nauro.cli.commands.setup._find_claude_config_path",
-        lambda: None,
-    )
-
-    result = runner.invoke(app, ["setup", "claude-code", "--project", "testproj"])
-    assert result.exit_code == 0
-
-    assert (repo1 / "CLAUDE.md").exists()
-    assert (repo2 / "CLAUDE.md").exists()
-    assert "Nauro — project context" in (repo1 / "CLAUDE.md").read_text()
-    assert "Nauro — project context" in (repo2 / "CLAUDE.md").read_text()
-
-
-def test_project_flag_overrides_cwd(tmp_path: Path, monkeypatch):
-    """--project flag overrides cwd resolution."""
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
-
-    repo_a = tmp_path / "repo_a"
-    repo_b = tmp_path / "repo_b"
-    repo_a.mkdir()
-    repo_b.mkdir()
-
-    store_a = register_project("proj-a", [repo_a])
-    scaffold_project_store("proj-a", store_a)
-    store_b = register_project("proj-b", [repo_b])
-    scaffold_project_store("proj-b", store_b)
-
-    # cwd is in proj-a's repo, but we target proj-b
-    monkeypatch.chdir(repo_a)
-
-    monkeypatch.setattr(
-        "nauro.cli.commands.setup._find_claude_config_path",
-        lambda: None,
-    )
-
-    result = runner.invoke(app, ["setup", "claude-code", "--project", "proj-b"])
-    assert result.exit_code == 0
-
-    assert (repo_b / "CLAUDE.md").exists()
-    assert "Nauro — project context" in (repo_b / "CLAUDE.md").read_text()
-    # repo_a should NOT have been touched
-    assert not (repo_a / "CLAUDE.md").exists()
-
-
-def test_setup_regenerates_agents_md(tmp_path: Path, monkeypatch):
-    """Setup regenerates AGENTS.md in all repos."""
-    repos = _setup_project(tmp_path, monkeypatch)
-
-    # Patch MCP config to avoid touching real home
-    monkeypatch.setattr(
-        "nauro.cli.commands.setup._find_claude_config_path",
-        lambda: None,
-    )
-
-    result = runner.invoke(app, ["setup", "claude-code", "--project", "testproj"])
-    assert result.exit_code == 0
-
-    agents_md = repos[0] / "AGENTS.md"
-    assert agents_md.exists()
-    content = agents_md.read_text()
-    assert "## Project: testproj" in content
-    assert "When to use these tools" in content
-    assert "regenerated AGENTS.md" in result.output
-
-
-def test_remove_mcp_entry(tmp_path: Path, monkeypatch):
-    """--remove removes the nauro MCP entry from config."""
-    _setup_project(tmp_path, monkeypatch)
-
-    import json
-
-    config_path = tmp_path / "claude_home" / "claude_desktop_config.json"
-    (tmp_path / "claude_home").mkdir()
-    config_path.write_text(
-        json.dumps(
-            {
-                "mcpServers": {
-                    "nauro": {"url": "http://127.0.0.1:7432"},
-                    "other": {"url": "http://localhost:8000"},
-                }
-            }
+        # Create pre-existing MCP config with another server
+        claude_dir = tmp_path / "claude_home"
+        claude_dir.mkdir()
+        config_path = claude_dir / "claude_desktop_config.json"
+        config_path.write_text(
+            json.dumps({"mcpServers": {"other-tool": {"url": "http://localhost:9999"}}})
         )
-    )
 
-    monkeypatch.setattr(
-        "nauro.cli.commands.setup._find_claude_config_path",
-        lambda: config_path,
-    )
+        monkeypatch.setattr(
+            "nauro.cli.commands.setup._find_claude_config_path",
+            lambda: config_path,
+        )
 
-    result = runner.invoke(app, ["setup", "claude-code", "--project", "testproj", "--remove"])
-    assert result.exit_code == 0
+        result = runner.invoke(app, ["setup", "claude-code", "--project", "testproj"])
+        assert result.exit_code == 0
 
-    config = json.loads(config_path.read_text())
-    assert "nauro" not in config["mcpServers"]
-    assert "other" in config["mcpServers"]
+        config = json.loads(config_path.read_text())
+        assert "nauro" in config["mcpServers"]
+        assert config["mcpServers"]["nauro"]["args"] == ["serve", "--stdio"]
+        assert "command" in config["mcpServers"]["nauro"]
+        # Existing server preserved
+        assert "other-tool" in config["mcpServers"]
+        assert config["mcpServers"]["other-tool"]["url"] == "http://localhost:9999"
+
+    def test_mcp_config_created_from_scratch(self, tmp_path: Path, monkeypatch):
+        """MCP config created from scratch if missing."""
+        _setup_project(tmp_path, monkeypatch)
+
+        config_path = tmp_path / "claude_home" / "claude_desktop_config.json"
+        (tmp_path / "claude_home").mkdir()
+
+        monkeypatch.setattr(
+            "nauro.cli.commands.setup._find_claude_config_path",
+            lambda: config_path,
+        )
+
+        result = runner.invoke(app, ["setup", "claude-code", "--project", "testproj"])
+        assert result.exit_code == 0
+        assert config_path.exists()
+
+        config = json.loads(config_path.read_text())
+        assert config["mcpServers"]["nauro"]["args"] == ["serve", "--stdio"]
+        assert "command" in config["mcpServers"]["nauro"]
+
+    def test_remove_mcp_entry(self, tmp_path: Path, monkeypatch):
+        """--remove removes the nauro MCP entry from config."""
+        _setup_project(tmp_path, monkeypatch)
+
+        config_path = tmp_path / "claude_home" / "claude_desktop_config.json"
+        (tmp_path / "claude_home").mkdir()
+        config_path.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "nauro": {"url": "http://127.0.0.1:7432"},
+                        "other": {"url": "http://localhost:8000"},
+                    }
+                }
+            )
+        )
+
+        monkeypatch.setattr(
+            "nauro.cli.commands.setup._find_claude_config_path",
+            lambda: config_path,
+        )
+
+        result = runner.invoke(app, ["setup", "claude-code", "--project", "testproj", "--remove"])
+        assert result.exit_code == 0
+
+        config = json.loads(config_path.read_text())
+        assert "nauro" not in config["mcpServers"]
+        assert "other" in config["mcpServers"]
+
+
+class TestAGENTSMD:
+    def test_setup_regenerates_agents_md(self, tmp_path: Path, monkeypatch):
+        """Setup regenerates AGENTS.md in all repos."""
+        repos = _setup_project(tmp_path, monkeypatch)
+
+        monkeypatch.setattr(
+            "nauro.cli.commands.setup._find_claude_config_path",
+            lambda: None,
+        )
+
+        result = runner.invoke(app, ["setup", "claude-code", "--project", "testproj"])
+        assert result.exit_code == 0
+
+        agents_md = repos[0] / "AGENTS.md"
+        assert agents_md.exists()
+        content = agents_md.read_text()
+        assert "## Project: testproj" in content
+        assert "When to use these tools" in content
+        assert "regenerated AGENTS.md" in result.output
+
+
+class TestNoClaudeMDInjection:
+    def test_setup_does_not_create_claude_md(self, tmp_path: Path, monkeypatch):
+        """Setup no longer creates or modifies CLAUDE.md."""
+        repos = _setup_project(tmp_path, monkeypatch)
+        assert not (repos[0] / "CLAUDE.md").exists()
+
+        monkeypatch.setattr(
+            "nauro.cli.commands.setup._find_claude_config_path",
+            lambda: None,
+        )
+
+        result = runner.invoke(app, ["setup", "claude-code", "--project", "testproj"])
+        assert result.exit_code == 0
+        assert not (repos[0] / "CLAUDE.md").exists()
+
+    def test_setup_does_not_modify_existing_claude_md(self, tmp_path: Path, monkeypatch):
+        """Setup leaves existing CLAUDE.md untouched (no injection)."""
+        repos = _setup_project(tmp_path, monkeypatch)
+        existing = "# My Project\n\nSome existing content.\n"
+        (repos[0] / "CLAUDE.md").write_text(existing)
+
+        monkeypatch.setattr(
+            "nauro.cli.commands.setup._find_claude_config_path",
+            lambda: None,
+        )
+
+        result = runner.invoke(app, ["setup", "claude-code", "--project", "testproj"])
+        assert result.exit_code == 0
+
+        content = (repos[0] / "CLAUDE.md").read_text()
+        assert content == existing
+
+
+class TestLegacyCleanup:
+    def test_removes_legacy_block_from_claude_md(self, tmp_path: Path, monkeypatch):
+        """Setup removes legacy Nauro block from CLAUDE.md."""
+        repos = _setup_project(tmp_path, monkeypatch)
+        content = f"# My Project\n\nKeep this.\n\n{CLAUDE_MD_START}\nold block\n{CLAUDE_MD_END}\n"
+        (repos[0] / "CLAUDE.md").write_text(content)
+
+        monkeypatch.setattr(
+            "nauro.cli.commands.setup._find_claude_config_path",
+            lambda: None,
+        )
+
+        result = runner.invoke(app, ["setup", "claude-code", "--project", "testproj"])
+        assert result.exit_code == 0
+
+        cleaned = (repos[0] / "CLAUDE.md").read_text()
+        assert CLAUDE_MD_START not in cleaned
+        assert "# My Project" in cleaned
+        assert "Keep this." in cleaned
+        assert "Legacy cleanup" in result.output
+
+    def test_deletes_claude_md_if_only_legacy_block(self, tmp_path: Path, monkeypatch):
+        """Deletes CLAUDE.md if it only contained the legacy Nauro block."""
+        repos = _setup_project(tmp_path, monkeypatch)
+        content = f"{CLAUDE_MD_START}\nold block\n{CLAUDE_MD_END}\n"
+        (repos[0] / "CLAUDE.md").write_text(content)
+
+        monkeypatch.setattr(
+            "nauro.cli.commands.setup._find_claude_config_path",
+            lambda: None,
+        )
+
+        result = runner.invoke(app, ["setup", "claude-code", "--project", "testproj"])
+        assert result.exit_code == 0
+        assert not (repos[0] / "CLAUDE.md").exists()
+
+
+class TestProjectResolution:
+    def test_project_flag_overrides_cwd(self, tmp_path: Path, monkeypatch):
+        """--project flag overrides cwd resolution."""
+        monkeypatch.setenv("NAURO_HOME", str(tmp_path))
+
+        repo_a = tmp_path / "repo_a"
+        repo_b = tmp_path / "repo_b"
+        repo_a.mkdir()
+        repo_b.mkdir()
+
+        store_a = register_project("proj-a", [repo_a])
+        scaffold_project_store("proj-a", store_a)
+        store_b = register_project("proj-b", [repo_b])
+        scaffold_project_store("proj-b", store_b)
+
+        monkeypatch.chdir(repo_a)
+
+        monkeypatch.setattr(
+            "nauro.cli.commands.setup._find_claude_config_path",
+            lambda: None,
+        )
+
+        result = runner.invoke(app, ["setup", "claude-code", "--project", "proj-b"])
+        assert result.exit_code == 0
+
+        # AGENTS.md should be generated in proj-b's repo
+        assert (repo_b / "AGENTS.md").exists()
+
+    def test_multi_repo_all_get_agents_md(self, tmp_path: Path, monkeypatch):
+        """Multi-repo: all associated repos get AGENTS.md."""
+        repo1 = tmp_path / "repo1"
+        repo2 = tmp_path / "repo2"
+        repo1.mkdir()
+        repo2.mkdir()
+
+        _setup_project(tmp_path, monkeypatch, repo_paths=[repo1, repo2])
+
+        monkeypatch.setattr(
+            "nauro.cli.commands.setup._find_claude_config_path",
+            lambda: None,
+        )
+
+        result = runner.invoke(app, ["setup", "claude-code", "--project", "testproj"])
+        assert result.exit_code == 0
+
+        assert (repo1 / "AGENTS.md").exists()
+        assert (repo2 / "AGENTS.md").exists()
+        # No CLAUDE.md created
+        assert not (repo1 / "CLAUDE.md").exists()
+        assert not (repo2 / "CLAUDE.md").exists()


### PR DESCRIPTION
## Why

Agents weren't reliably routing questions like "should we use X for Y?" to `check_decision`. The behavioral guidance that tells agents when to call which tool lived in a CLAUDE.md block injected by `nauro setup claude-code` — which only works in Claude Code, only when the file is present, and only when the agent reads it. In other MCP clients (Claude AI, Cursor, Perplexity, ChatGPT) the guidance didn't exist at all.

The MCP spec already has a native mechanism for this: the `instructions` field in the `initialize` response. Every compliant client injects it into its system context automatically — the same mechanism Linear and context7 use. Nauro just wasn't using it.

While investigating this, I also found that tool descriptions had drifted between the local stdio server and the remote HTTP server, and no tool had MCP annotations (`readOnlyHint`, `destructiveHint`, etc.) — which means clients gate read calls behind confirmation prompts unnecessarily.

## Approach

Three coordinated changes:

1. **MCP instructions via protocol.** Added `MCP_INSTRUCTIONS` to `nauro_core.constants` and passed it to `FastMCP("nauro", instructions=...)`. Delivered in the `initialize` handshake to every client.

2. **Centralized tool metadata.** New `nauro_core.mcp_tools` module holds names, titles, descriptions, input schemas, and annotations as the single source of truth. The local stdio server pulls `@mcp.tool(**spec)` kwargs from the registry. (The remote server in the separate mcp-server repo will import from nauro-core once it's on PyPI; until then it mirrors the schemas manually with a TODO pointing at the trigger.)

3. **Stripped `nauro setup claude-code`.** Removed the CLAUDE.md injection entirely — it's redundant with MCP instructions and only worked in one client. Kept MCP config registration (can't be eliminated — someone has to tell the client "connect here") and AGENTS.md regeneration (useful for non-MCP tools). Added automatic cleanup of legacy Nauro blocks from prior installs.

Considered three alternatives for (3): (A) strip to MCP config only, (B) replace with generic `nauro setup` that auto-detects tools, (C) remove the command entirely and document JSON snippets. Went with A — smallest change, preserves onboarding UX, removes the fragile part.

## What changed

**nauro-core:**
- `constants.py` — added `MCP_INSTRUCTIONS` string
- `mcp_tools.py` (new) — 11 `ToolSpec` definitions with titles, descriptions, annotations, input schemas
- `__init__.py` — exported new symbols
- `tests/test_mcp_tools.py` (new) — registry integrity and spec-shape tests

**Local stdio server:**
- Passes `instructions=MCP_INSTRUCTIONS` to `FastMCP`
- `@mcp.tool(**_spec_kwargs(name))` pulls metadata from nauro-core
- `get_context.level` now accepts the string enum `"L0"/"L1"/"L2"` (matches remote); still accepts int internally for backward compat

**Setup command:**
- Removed `_inject_claude_md` and `_claude_md_block`
- `_remove_claude_md` repurposed to auto-clean legacy blocks
- Tests rewritten to assert no CLAUDE.md modification and legacy cleanup works

**CLAUDE.md files** (root + packages/nauro) — auto-cleaned by running the new setup.

## What to review

- `nauro-core/src/nauro_core/mcp_tools.py` — these descriptions are the public API agents see. Worth reading end-to-end to make sure the guidance is accurate.
- `nauro-core/src/nauro_core/constants.py` — `MCP_INSTRUCTIONS` is the system prompt every agent sees. Same scrutiny.
- Annotation choices in `mcp_tools.py` — all read tools are `readOnlyHint + idempotentHint`, all writes are `destructiveHint=false, openWorldHint=false`. `confirm_decision` is additionally `idempotentHint=true` (same confirm_id twice = safe).

## What's deferred

- **Remote MCP server updates** will land in a separate PR on the mcp-server repo. It can't import from nauro-core yet because its git pin predates these additions. The remote changes mirror this PR's schemas with a TODO pointing to the PyPI publish as the trigger for cleanup.
- **`outputSchema` on tools with structured returns** (e.g., `check_decision`, `propose_decision`) — MCP now supports declaring output shapes. Not done here; the description + annotation work was the higher-value change.

## Test plan

- 856 tests pass (791 nauro + 65 new nauro-core registry tests)
- Lint + format clean
- Verified end-to-end: `nauro init --demo` scaffolds correctly; local stdio server registers 11 tools with instructions (1,405 chars) + titles + annotations
- Drift check: cross-compared local and remote tool specs — all titles, descriptions, and annotation flags match exactly (to be reviewed again when the remote PR lands)
- Backward compat: existing stdio tests pass without modification (`get_context` still accepts int levels; `flag_question`/`update_state` still return strings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)