### PR TITLE
Unify tier-2 validation on BM25 across local and remote surfaces

### DIFF
--- a/packages/nauro-core/src/nauro_core/__init__.py
+++ b/packages/nauro-core/src/nauro_core/__init__.py
@@ -21,9 +21,6 @@ from nauro_core.constants import (
     EXTRACTION_SOURCES as EXTRACTION_SOURCES,
 )
 from nauro_core.constants import (
-    JACCARD_THRESHOLD as JACCARD_THRESHOLD,
-)
-from nauro_core.constants import (
     L0_DECISIONS_SUMMARY_LIMIT as L0_DECISIONS_SUMMARY_LIMIT,
 )
 from nauro_core.constants import (
@@ -183,20 +180,20 @@ from nauro_core.state import (
     prepare_state_update as prepare_state_update,
 )
 from nauro_core.validation import (
-    check_content_length as check_content_length,
+    TIER2_STOPWORDS as TIER2_STOPWORDS,
 )
 from nauro_core.validation import (
-    check_jaccard_similarity as check_jaccard_similarity,
+    TIER2_TOP_K as TIER2_TOP_K,
+)
+from nauro_core.validation import (
+    check_bm25_similarity as check_bm25_similarity,
+)
+from nauro_core.validation import (
+    check_content_length as check_content_length,
 )
 from nauro_core.validation import (
     compute_hash as compute_hash,
 )
 from nauro_core.validation import (
-    jaccard_similarity as jaccard_similarity,
-)
-from nauro_core.validation import (
     screen_structural as screen_structural,
-)
-from nauro_core.validation import (
-    word_set as word_set,
 )

--- a/packages/nauro-core/src/nauro_core/constants.py
+++ b/packages/nauro-core/src/nauro_core/constants.py
@@ -14,7 +14,6 @@ L1_DECISIONS_SUMMARY_LIMIT = 10
 # ── Validation thresholds ──
 VALID_CONFIDENCES: set[str] = {"high", "medium", "low"}
 MIN_RATIONALE_LENGTH = 20
-JACCARD_THRESHOLD = 0.5
 
 # ── Pending confirmation ──
 EXPIRY_MINUTES = 10

--- a/packages/nauro-core/src/nauro_core/validation.py
+++ b/packages/nauro-core/src/nauro_core/validation.py
@@ -1,4 +1,4 @@
-"""Structural screening, Jaccard similarity, and hash-based deduplication.
+"""Structural screening, similarity, and hash-based deduplication.
 
 Pure validation functions that determine whether a candidate decision should
 be written to the store. No I/O — existing decisions and hashes are passed
@@ -10,11 +10,91 @@ from __future__ import annotations
 import hashlib
 import re
 
+from bm25s.stopwords import STOPWORDS_EN
+
 from nauro_core.constants import (
-    JACCARD_THRESHOLD,
     MIN_RATIONALE_LENGTH,
     VALID_CONFIDENCES,
 )
+from nauro_core.search import bm25_retrieve
+
+# Tier-2 BM25 defaults shared by local (nauro) and remote (mcp-server) surfaces.
+# Both call check_bm25_similarity below so the same proposal produces the same
+# validation outcome on either.
+TIER2_TOP_K = 5
+
+# bm25s's default English stopword list is minimal (~30 tokens: a, an, and,
+# are, as, at, be, but, by, for, if, in, into, is, it, no, not, of, on, or,
+# ...). It omits common action verbs that appear in virtually every Nauro
+# decision title ("Use Postgres", "Use Redis", "Use FastAPI", etc.), so a
+# fresh proposal shares the stem ``use`` with most existing decisions and
+# gets a nonzero BM25 score, escalating tier 2 -> tier 3 on almost every
+# call. Extending the list with ``use`` collapses those false-positive
+# matches to score 0 (already filtered by bm25_retrieve).
+#
+# This list is intentionally minimal: only tokens with observed false
+# positives are added, not a speculative blanket of generic verbs. Add
+# more only when a concrete failure case justifies it, and add a test to
+# lock the case in.
+TIER2_STOPWORDS = list(STOPWORDS_EN) + ["use"]
+
+# The scaffold-seeded "Initial project setup" decision is Nauro's own
+# bookkeeping — it records that the store was initialized, not a choice the
+# user made. It should not gate validation of user-authored proposals.
+# Including it in the tier-2 corpus causes every new proposal sharing even
+# one weak stem (e.g. "store", "use") with the template text to escalate,
+# defeating tier 2's purpose as a cheap pre-filter.
+#
+# Identified by the conventional num+title pair written by the scaffold
+# template. This is a convention match, not a fuzzy heuristic: the title is
+# hardcoded in the scaffold and the scaffold is the only path that produces
+# a ``num == 1`` decision with this exact title.
+_SCAFFOLD_SEED_TITLE = "Initial project setup"
+
+
+def _is_scaffold_seed(decision: dict) -> bool:
+    return decision.get("num") == 1 and decision.get("title") == _SCAFFOLD_SEED_TITLE
+
+
+def check_bm25_similarity(
+    proposal: dict,
+    existing_decisions: list[dict],
+    top_k: int = TIER2_TOP_K,
+    stopwords: list[str] | None = None,
+) -> tuple[str, list[dict]]:
+    """Tier-2 BM25 similarity check (D93). Shared by local and remote surfaces.
+
+    Filters the scaffold-seed decision (bookkeeping, not a user choice) and
+    delegates retrieval to ``nauro_core.search.bm25_retrieve``, which also
+    filters non-active decisions and empty-score matches.
+
+    Args:
+        proposal: Dict with at least "title" and "rationale" keys.
+        existing_decisions: Parsed decision dicts. Each should carry "num",
+            "title", "rationale", and optionally "status".
+        top_k: Maximum number of related decisions to return.
+        stopwords: Override for tokenizer stopwords. Defaults to
+            ``TIER2_STOPWORDS``.
+
+    Returns:
+        (action, related) where action is "auto_confirm" or "needs_review"
+        and related uses the ``bm25_retrieve`` shape:
+        ``{"number", "title", "similarity", "rationale_preview"}``.
+    """
+    candidates = [d for d in existing_decisions if not _is_scaffold_seed(d)]
+    if not candidates:
+        return ("auto_confirm", [])
+
+    proposal_text = f"{proposal.get('title', '')}. {(proposal.get('rationale') or '')[:200]}"
+    related = bm25_retrieve(
+        candidates,
+        proposal_text,
+        top_k=top_k,
+        stopwords=stopwords if stopwords is not None else TIER2_STOPWORDS,
+    )
+    if not related:
+        return ("auto_confirm", [])
+    return ("needs_review", related)
 
 
 def check_content_length(value: str, label: str, max_length: int) -> str | None:
@@ -28,64 +108,6 @@ def compute_hash(title: str, rationale: str) -> str:
     """SHA-256 of normalized title + rationale for exact dedup."""
     content = f"{title.strip().lower()}|{rationale.strip().lower()}"
     return hashlib.sha256(content.encode()).hexdigest()
-
-
-def word_set(text: str) -> set[str]:
-    """Extract a set of lowercase words (len > 2) from text."""
-    return {w.lower().strip(".,;:!?()[]{}\"'") for w in text.split() if len(w) > 2}
-
-
-def jaccard_similarity(a: set[str], b: set[str]) -> float:
-    """Jaccard index between two word sets. Returns 0.0 if both are empty."""
-    if not a and not b:
-        return 0.0
-    return len(a & b) / len(a | b)
-
-
-def check_jaccard_similarity(
-    proposal: dict,
-    existing_decisions: list[dict],
-    threshold: float = JACCARD_THRESHOLD,
-) -> tuple[str, list[dict]]:
-    """Check proposal against existing decisions using Jaccard word-set similarity.
-
-    Args:
-        proposal: Dict with at least "title" and "rationale" keys.
-        existing_decisions: List of parsed decision dicts.
-        threshold: Similarity threshold (default from constants).
-
-    Returns:
-        (action, similar_decisions) where action is "auto_confirm" or "needs_review".
-        similar_decisions is sorted by similarity descending, capped at 5.
-    """
-    if not existing_decisions:
-        return ("auto_confirm", [])
-
-    proposal_text = f"{proposal.get('title', '')}. {(proposal.get('rationale') or '')[:200]}"
-    proposal_words = word_set(proposal_text)
-    if not proposal_words:
-        return ("auto_confirm", [])
-
-    similarities: list[dict] = []
-    for d in existing_decisions:
-        decision_text = f"{d.get('title', '')}. {(d.get('rationale') or '')[:200]}"
-        decision_words = word_set(decision_text)
-        sim = jaccard_similarity(proposal_words, decision_words)
-
-        if sim >= threshold:
-            similarities.append(
-                {
-                    "number": d.get("num", 0),
-                    "title": d.get("title", ""),
-                    "similarity": round(sim, 3),
-                }
-            )
-
-    if not similarities:
-        return ("auto_confirm", [])
-
-    similarities.sort(key=lambda x: x["similarity"], reverse=True)
-    return ("needs_review", similarities[:5])
 
 
 def _normalize_title(title: str) -> str:

--- a/packages/nauro-core/tests/test_constants.py
+++ b/packages/nauro-core/tests/test_constants.py
@@ -5,7 +5,6 @@ from nauro_core.constants import (
     DECISION_TYPES,
     DECISIONS_DIR,
     EXTRACTION_SOURCES,
-    JACCARD_THRESHOLD,
     L0_DECISIONS_SUMMARY_LIMIT,
     L0_QUESTIONS_LIMIT,
     L1_DECISIONS_LIMIT,
@@ -36,11 +35,6 @@ class TestLimits:
 
     def test_min_rationale_length_positive(self):
         assert MIN_RATIONALE_LENGTH > 0
-
-
-class TestThresholds:
-    def test_jaccard_threshold_in_range(self):
-        assert 0.0 < JACCARD_THRESHOLD <= 1.0
 
 
 class TestValidValues:

--- a/packages/nauro-core/tests/test_validation.py
+++ b/packages/nauro-core/tests/test_validation.py
@@ -1,11 +1,9 @@
-"""Tests for nauro_core.validation — structural screening and Jaccard similarity."""
+"""Tests for nauro_core.validation — structural screening and BM25 similarity."""
 
 from nauro_core.validation import (
-    check_jaccard_similarity,
+    check_bm25_similarity,
     compute_hash,
-    jaccard_similarity,
     screen_structural,
-    word_set,
 )
 
 
@@ -36,129 +34,123 @@ class TestComputeHash:
         assert len(h) == 64  # SHA-256 hex
 
 
-class TestWordSet:
-    def test_basic(self):
-        result = word_set("Hello world foo")
-        assert "hello" in result
-        assert "world" in result
-        assert "foo" in result
-
-    def test_strips_punctuation(self):
-        result = word_set("hello, world! (test)")
-        assert "hello" in result
-        assert "world" in result
-        assert "test" in result
-
-    def test_short_words_excluded(self):
-        result = word_set("I am a big cat")
-        assert "big" in result
-        assert "cat" in result
-        assert "am" not in result
-        assert "a" not in result
-
-    def test_empty_string(self):
-        assert word_set("") == set()
-
-    def test_lowercase(self):
-        result = word_set("FastAPI Lambda")
-        assert "fastapi" in result
-        assert "lambda" in result
-
-
-class TestJaccardSimilarity:
-    def test_identical_sets(self):
-        s = {"hello", "world"}
-        assert jaccard_similarity(s, s) == 1.0
-
-    def test_disjoint_sets(self):
-        a = {"hello", "world"}
-        b = {"foo", "bar"}
-        assert jaccard_similarity(a, b) == 0.0
-
-    def test_partial_overlap(self):
-        a = {"hello", "world", "foo"}
-        b = {"hello", "world", "bar"}
-        sim = jaccard_similarity(a, b)
-        assert 0.0 < sim < 1.0
-        # intersection={hello, world}=2, union={hello, world, foo, bar}=4
-        assert sim == 0.5
-
-    def test_both_empty(self):
-        assert jaccard_similarity(set(), set()) == 0.0
-
-    def test_one_empty(self):
-        assert jaccard_similarity({"hello"}, set()) == 0.0
-
-    def test_subset(self):
-        a = {"hello", "world"}
-        b = {"hello", "world", "foo"}
-        sim = jaccard_similarity(a, b)
-        # 2/3
-        assert abs(sim - 2 / 3) < 0.001
-
-
-class TestCheckJaccardSimilarity:
-    def _decision(self, num, title, rationale="Some rationale text here."):
-        return {"num": num, "title": title, "rationale": rationale}
+class TestCheckBm25Similarity:
+    def _decision(self, num, title, rationale="Some rationale text here.", status="active"):
+        return {"num": num, "title": title, "rationale": rationale, "status": status}
 
     def test_no_existing_decisions(self):
         proposal = {"title": "Use FastAPI", "rationale": "Async support is great."}
-        action, similar = check_jaccard_similarity(proposal, [])
+        action, related = check_bm25_similarity(proposal, [])
         assert action == "auto_confirm"
-        assert similar == []
+        assert related == []
 
-    def test_below_threshold(self):
-        proposal = {"title": "Use FastAPI for server", "rationale": "Async support is great."}
-        existing = [self._decision(1, "Choose Redis for caching", "Speed and simplicity.")]
-        action, similar = check_jaccard_similarity(proposal, existing)
-        assert action == "auto_confirm"
-        assert similar == []
-
-    def test_above_threshold(self):
+    def test_only_scaffold_seed_is_excluded(self):
+        # A store containing only the scaffold-seed must never gate user proposals.
+        existing = [self._decision(1, "Initial project setup", "Store was initialized.")]
         proposal = {
-            "title": "Use FastAPI for the MCP server",
-            "rationale": "FastAPI provides async support and type safety for MCP server.",
+            "title": "Use Redis for caching",
+            "rationale": "Fast in-memory store with pub/sub.",
         }
+        action, related = check_bm25_similarity(proposal, existing)
+        assert action == "auto_confirm"
+        assert related == []
+
+    def test_unrelated_proposal_auto_confirms(self):
+        existing = [
+            self._decision(2, "Chose FastAPI for the server", "Async support and automatic docs."),
+        ]
+        proposal = {
+            "title": "Add dark mode to the UI",
+            "rationale": "Users requested a dark theme for reduced eye strain.",
+        }
+        action, related = check_bm25_similarity(proposal, existing)
+        assert action == "auto_confirm"
+        assert related == []
+
+    def test_vocabulary_mismatch_flagged(self):
+        # D93 motivating case: BM25 + stemming catches vocabulary mismatches
+        # that substring and naive word-set matching miss.
         existing = [
             self._decision(
-                1,
-                "Use FastAPI for MCP server",
-                "FastAPI provides async support and type safety for the MCP server.",
+                2,
+                "Chose Memcached for session state",
+                "Memcached is simpler than Redis for session caching. "
+                "Lower operational overhead for our read-heavy workload.",
             )
         ]
-        action, similar = check_jaccard_similarity(proposal, existing)
-        assert action == "needs_review"
-        assert len(similar) >= 1
-        assert similar[0]["number"] == 1
-
-    def test_similarity_value_in_result(self):
         proposal = {
-            "title": "Use FastAPI for server",
-            "rationale": "FastAPI provides async and type safety.",
+            "title": "Use Redis for session caching",
+            "rationale": "Redis provides session state management with persistence.",
         }
-        existing = [
-            self._decision(1, "Use FastAPI for server", "FastAPI provides async and type safety.")
-        ]
-        action, similar = check_jaccard_similarity(proposal, existing)
-        if similar:
-            assert "similarity" in similar[0]
-            assert 0.0 <= similar[0]["similarity"] <= 1.0
+        action, related = check_bm25_similarity(proposal, existing)
+        assert action == "needs_review"
+        assert any("Memcached" in r["title"] for r in related)
 
-    def test_max_five_results(self):
-        proposal = {"title": "common words shared across", "rationale": "common words shared."}
-        existing = [
-            self._decision(i, "common words shared across", "common words shared across all.")
-            for i in range(10)
-        ]
-        action, similar = check_jaccard_similarity(proposal, existing)
-        assert len(similar) <= 5
+    def test_generic_use_verb_does_not_escalate(self):
+        # Shared stopword-extended ``use`` must not produce a match on its own.
+        existing = [self._decision(2, "Use FastAPI", "Good async support.")]
+        proposal = {
+            "title": "Use Redis for caching",
+            "rationale": "Fast in-memory store for session data management.",
+        }
+        action, related = check_bm25_similarity(proposal, existing)
+        assert action == "auto_confirm"
+        assert related == []
 
-    def test_custom_threshold(self):
-        proposal = {"title": "Use FastAPI", "rationale": "Async support."}
-        existing = [self._decision(1, "Use Flask", "Simple and lightweight.")]
-        # Very low threshold should catch even slight overlap
-        action, _ = check_jaccard_similarity(proposal, existing, threshold=0.01)
-        # With such a low threshold, any word overlap triggers review
+    def test_result_shape_matches_bm25_retrieve(self):
+        existing = [
+            self._decision(
+                2,
+                "Use FastAPI for the server",
+                "Async support and automatic OpenAPI documentation.",
+            )
+        ]
+        proposal = {
+            "title": "Use FastAPI for the API layer",
+            "rationale": "FastAPI provides async and OpenAPI docs.",
+        }
+        action, related = check_bm25_similarity(proposal, existing)
+        assert action == "needs_review"
+        hit = related[0]
+        assert "number" in hit
+        assert "title" in hit
+        assert "similarity" in hit
+        assert "rationale_preview" in hit
+
+    def test_respects_top_k(self):
+        existing = [
+            self._decision(
+                n,
+                "Use FastAPI for service",
+                "Async support and automatic OpenAPI documentation.",
+            )
+            for n in range(2, 12)
+        ]
+        proposal = {
+            "title": "Use FastAPI for the API layer",
+            "rationale": "FastAPI provides async and OpenAPI docs.",
+        }
+        _, related = check_bm25_similarity(proposal, existing, top_k=3)
+        assert len(related) <= 3
+
+    def test_superseded_decisions_excluded(self):
+        # bm25_retrieve ignores non-active decisions — shared function inherits
+        # that filter. A superseded near-match must not trigger needs_review.
+        existing = [
+            self._decision(
+                2,
+                "Use FastAPI for the server",
+                "Async support and automatic OpenAPI documentation.",
+                status="superseded",
+            )
+        ]
+        proposal = {
+            "title": "Use FastAPI for the API layer",
+            "rationale": "FastAPI provides async and OpenAPI docs.",
+        }
+        action, related = check_bm25_similarity(proposal, existing)
+        assert action == "auto_confirm"
+        assert related == []
 
 
 class TestScreenStructural:

--- a/packages/nauro/src/nauro/constants.py
+++ b/packages/nauro/src/nauro/constants.py
@@ -14,7 +14,6 @@ from nauro_core.constants import DECISION_TYPES as DECISION_TYPES
 from nauro_core.constants import DECISIONS_DIR as DECISIONS_DIR
 from nauro_core.constants import EXPIRY_MINUTES as EXPIRY_MINUTES
 from nauro_core.constants import EXTRACTION_SOURCES as EXTRACTION_SOURCES
-from nauro_core.constants import JACCARD_THRESHOLD as JACCARD_THRESHOLD
 from nauro_core.constants import L0_DECISIONS_SUMMARY_LIMIT as L0_DECISIONS_SUMMARY_LIMIT
 from nauro_core.constants import L0_QUESTIONS_LIMIT as L0_QUESTIONS_LIMIT
 from nauro_core.constants import L1_DECISIONS_LIMIT as L1_DECISIONS_LIMIT

--- a/packages/nauro/src/nauro/validation/tier2.py
+++ b/packages/nauro/src/nauro/validation/tier2.py
@@ -1,7 +1,10 @@
 """Tier 2 validation — BM25 similarity (D93).
 
-Checks the proposal against existing decisions using BM25 ranking
-via bm25s + PyStemmer. Replaces the previous embedding/Jaccard approach.
+Thin adapter over ``nauro_core.validation.check_bm25_similarity``. The
+filtering, stopword list, and retrieval live in nauro-core so the remote
+MCP surface (mcp-server) gets the same outcome for the same proposal.
+This module only contributes the local I/O (filesystem decision load) and
+the ``id`` reshape that ``tier3`` needs for its lookup.
 """
 
 from __future__ import annotations
@@ -9,47 +12,11 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
-from bm25s.stopwords import STOPWORDS_EN
-from nauro_core.search import bm25_retrieve
+from nauro_core.validation import check_bm25_similarity
 
 from nauro.store.reader import _list_decisions
 
 logger = logging.getLogger("nauro.validation.tier2")
-
-TOP_K = 5
-
-# bm25s's default English stopword list is minimal (~30 tokens: a, an, and,
-# are, as, at, be, but, by, for, if, in, into, is, it, no, not, of, on, or,
-# ...). It omits common action verbs that appear in virtually every Nauro
-# decision title ("Use Postgres", "Use Redis", "Use FastAPI", etc.), so a
-# fresh proposal shares the stem ``use`` with most existing decisions and
-# gets a nonzero BM25 score, escalating tier 2 → tier 3 on almost every
-# call. Extending the list with ``use`` collapses those false-positive
-# matches to score 0 (already filtered by bm25_retrieve).
-#
-# This list is intentionally minimal: only tokens with observed false
-# positives are added, not a speculative blanket of generic verbs. Add
-# more only when a concrete failure case justifies it, and update
-# test_tier2.py to lock the case in.
-_TIER2_STOPWORDS = list(STOPWORDS_EN) + ["use"]
-
-# The scaffold-seeded "Initial project setup" decision is Nauro's own
-# bookkeeping — it records that the store was initialized, not a choice the
-# user made. It should not gate validation of user-authored proposals.
-# Including it in the tier-2 corpus causes every new proposal sharing even
-# one weak stem (e.g. "store", "use") with the template text to escalate
-# to tier 3, defeating tier 2's purpose as a cheap pre-filter.
-#
-# Identified by the conventional num+title pair written by
-# ``scaffold_project_store`` via ``FIRST_DECISION_MD``. This is a convention
-# match, not a fuzzy heuristic: the title is hardcoded in the scaffold
-# template and the scaffold is the only path that produces a ``num == 1``
-# decision with this exact title.
-_SCAFFOLD_SEED_TITLE = "Initial project setup"
-
-
-def _is_scaffold_seed(decision: dict) -> bool:
-    return decision.get("num") == 1 and decision.get("title") == _SCAFFOLD_SEED_TITLE
 
 
 def check_similarity(proposal: dict, project_path: Path) -> tuple[str, list[dict]]:
@@ -58,16 +25,9 @@ def check_similarity(proposal: dict, project_path: Path) -> tuple[str, list[dict
     Returns:
         (action, similar_decisions) where action is "auto_confirm" or "needs_review".
     """
-    decisions = [d for d in _list_decisions(project_path) if not _is_scaffold_seed(d)]
-    if not decisions:
-        return ("auto_confirm", [])
-
-    title = proposal.get("title", "")
-    rationale = proposal.get("rationale", "")
-    proposal_text = f"{title}. {rationale[:200]}"
-
-    related = bm25_retrieve(decisions, proposal_text, top_k=TOP_K, stopwords=_TIER2_STOPWORDS)
-    if not related:
+    decisions = _list_decisions(project_path)
+    action, related = check_bm25_similarity(proposal, decisions)
+    if action == "auto_confirm":
         return ("auto_confirm", [])
 
     similar = [


### PR DESCRIPTION
## Why

The remote MCP surface (Lambda) used Jaccard word-set similarity for tier-2 write validation while the local surface (stdio) used BM25 via bm25s (D93). This meant the same `propose_decision` call could `auto_confirm` on one surface and `needs_review` on the other — a credibility problem for a product that's explicitly cross-surface (D50).

D93 already sanctioned BM25 for both surfaces via shared nauro-core, but the remote never got wired up. `bm25s` is already bundled in the Lambda layer for `search_decisions`, so no infra change is needed.

## Approach

Lifted the shared tier-2 glue (stopword extension, scaffold-seed filter, proposal text construction, `bm25_retrieve` delegation) into a new `nauro_core.validation.check_bm25_similarity()` function. Both surfaces now delegate to it, keeping only their I/O adapter (filesystem vs S3 decision loading) and any surface-specific post-processing.

The alternative — inlining the BM25 call in the remote — would duplicate exactly the constants and filter logic that caused the surfaces to drift in the first place. Rejected in favor of the shared function.

Deleted Jaccard code (`word_set`, `jaccard_similarity`, `check_jaccard_similarity`, `JACCARD_THRESHOLD`): no callers remain after this change, and the package is `0.1.0` alpha with no external consumers of these internal functions.

## What changed

- **nauro-core/validation.py**: Added `check_bm25_similarity()`, `TIER2_TOP_K`, `TIER2_STOPWORDS`, `_is_scaffold_seed`. Removed all Jaccard functions and `JACCARD_THRESHOLD` import.
- **nauro-core/__init__.py**: Swapped Jaccard re-exports for BM25 exports.
- **nauro-core/constants.py**: Removed `JACCARD_THRESHOLD`.
- **nauro/validation/tier2.py**: Reduced from 83 lines to 42 — loads decisions from filesystem, calls the shared function, reshapes to add the `id` field that local-only `tier3` keys on. No change to the `check_similarity()` signature or return shape.
- **nauro/constants.py**: Dropped vestigial `JACCARD_THRESHOLD` re-export.

## What to review

- The `TIER2_STOPWORDS` list and `_is_scaffold_seed` filter were moved verbatim from local tier2.py — verify nothing was lost or subtly changed.
- The `check_bm25_similarity` return shape uses `bm25_retrieve`'s output directly (`{number, title, similarity, rationale_preview}`), not the Jaccard shape (`{number, title, similarity}`). This adds `rationale_preview` to the remote path, which is additive and harmless.

## What's deferred

- The companion mcp-server PR (separate private repo) wires the remote Lambda to this shared function. It depends on this nauro-core update being published.
- `"provides"` and `"support"` are common enough stems to potentially warrant addition to `TIER2_STOPWORDS` — but per the policy, only tokens with observed false positives get added, and no concrete user-facing failure case exists yet.

## Test plan

- 244 nauro-core tests pass (8 new BM25 similarity tests replacing Jaccard suite, covering: empty decisions, scaffold-seed exclusion, vocabulary mismatch detection, unrelated proposal auto-confirm, stopword-only overlap, result shape, top_k, superseded exclusion).
- 602 nauro tests pass (20 integration deselected). Local tier2 tests unchanged — `check_similarity()` signature and response shape preserved.
- Lint clean (ruff check + format).

🤖 Generated with [Claude Code](https://claude.com/claude-code)