### PR TITLE
Bump nauro-core to 0.1.1

### DIFF
--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro-core"
-version = "0.1.0"
+version = "0.1.1"
 description = "Shared pure-Python logic for Nauro: parsing, validation, context assembly, constants."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Why

The public API of `nauro-core` changed in #7 — `check_jaccard_similarity` (and its helpers `word_set`, `jaccard_similarity`, `JACCARD_THRESHOLD`) were removed and `check_bm25_similarity` (plus `TIER2_TOP_K`, `TIER2_STOPWORDS`) was added. The version on PyPI is still `0.1.0` with the old API. External consumers (including the nauro CLI) need a published version that matches the source, and the remote mcp-server PR is blocked on its CI resolving the new API from PyPI.

## Approach

Bump `packages/nauro-core/pyproject.toml` to `0.1.1`. On merge, cut a `nauro-core-v0.1.1` tag on `main` — the existing `publish-nauro-core.yml` workflow handles the PyPI publish from there.

Semver: 0.x allows breaking changes on minor bumps, but the project convention so far has been 0.1.x patches. Going with a patch bump.

## What changed

- `packages/nauro-core/pyproject.toml`: `version = "0.1.0"` → `"0.1.1"`.

## What to review

- Whether a minor bump (0.2.0) is preferred over a patch given that this removes public API. Happy to swap if the project convention is different from what I read off the git history.

## What's deferred

- Tag + publish happen after merge.
- The longer-term workflow fix (mcp-server adopts uv + git-ref source for CI so this PyPI round-trip isn't required for every cross-repo change) is planned as a separate mcp-server PR.

## Test plan

- [ ] Merge.
- [ ] Tag `nauro-core-v0.1.1` on `main` and push; verify `publish-nauro-core.yml` completes.
- [ ] `pip index versions nauro-core` shows `0.1.1`.
- [ ] mcp-server CI reruns green against the new version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)