### PR TITLE
Fix `nauro auth login` on fresh installs; ship Auth0 defaults

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ All files are freeform markdown. No database. No JSON for content — JSON only 
 User config lives at `~/.nauro/config.json` (created by `nauro config set`):
 - `api_key` → sets `ANTHROPIC_API_KEY` env var
 - `sync.bucket_name`, `sync.region`, `sync.access_key_id`, `sync.secret_access_key` → S3 sync credentials
-- Auth0 domain, client ID, and API URL are configured via environment variables (`NAURO_AUTH0_DOMAIN`, `NAURO_AUTH0_CLIENT_ID`, `NAURO_API_URL`)
+- Auth0 domain, client ID, API URL, and audience ship as defaults in `cli/commands/auth.py`; env vars (`NAURO_AUTH0_*`, `NAURO_API_URL`) or config keys override (domain + client_id must be set as a pair)
 - `NAURO_HOME` env var overrides `~/.nauro/` for testing
 
 ## Stack

--- a/packages/nauro/src/nauro/cli/commands/auth.py
+++ b/packages/nauro/src/nauro/cli/commands/auth.py
@@ -16,6 +16,7 @@ import re
 import secrets
 import threading
 import webbrowser
+from collections.abc import Mapping
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from urllib.parse import parse_qs, urlencode, urlparse
 
@@ -28,12 +29,59 @@ logger = logging.getLogger("nauro.auth")
 
 auth_app = typer.Typer(help="Manage authentication for remote sync.")
 
-AUTH0_DOMAIN = os.environ.get("NAURO_AUTH0_DOMAIN", "")
-AUTH0_CLIENT_ID = os.environ.get("NAURO_AUTH0_CLIENT_ID", "")
-AUTH0_AUDIENCE = os.environ.get("NAURO_AUTH0_AUDIENCE", "https://mcp.nauro.ai/mcp")
+# Public OAuth identifiers — safe to ship; not secrets. Do not strip.
+DEFAULT_AUTH0_DOMAIN = "dev-q1kuoa1a154u26iw.us.auth0.com"
+DEFAULT_AUTH0_CLIENT_ID = "FoVl59QaztJou17Xqr3e2QYOupAr1Ke3"
+DEFAULT_API_URL = "https://mcp.nauro.ai"
+DEFAULT_AUTH0_AUDIENCE = "https://mcp.nauro.ai/mcp"
 AUTH0_SCOPES = "openid profile offline_access read:context write:context"
 REDIRECT_PORT = 18457
 REDIRECT_URI = f"http://localhost:{REDIRECT_PORT}/callback"
+
+
+class PartialAuthConfigError(Exception):
+    """Raised when Auth0 domain/client_id are partially set at a single layer."""
+
+
+def _resolve_auth_config(
+    env: Mapping[str, str], config: Mapping[str, object]
+) -> tuple[str, str, str, str]:
+    """Resolve (domain, client_id, api_url, audience).
+
+    (domain, client_id) must come from the same source — mixing tenants produces
+    confusing Auth0 errors. A partial env pair (one of the two set without the
+    other) raises rather than falling through to config or defaults; a stale
+    shell export is usually the cause and silent fall-through would hide it.
+    api_url and audience resolve independently.
+    """
+    env_d = env.get("NAURO_AUTH0_DOMAIN") or ""
+    env_c = env.get("NAURO_AUTH0_CLIENT_ID") or ""
+    cfg_d = str(config.get("auth0_domain") or "")
+    cfg_c = str(config.get("auth0_client_id") or "")
+
+    if env_d and env_c:
+        domain, client_id = env_d, env_c
+    elif env_d or env_c:
+        raise PartialAuthConfigError(
+            "Partial Auth0 config: NAURO_AUTH0_DOMAIN and NAURO_AUTH0_CLIENT_ID "
+            "must be set together."
+        )
+    elif cfg_d and cfg_c:
+        domain, client_id = cfg_d, cfg_c
+    elif cfg_d or cfg_c:
+        raise PartialAuthConfigError(
+            "Partial Auth0 config: auth0_domain and auth0_client_id must be set together in config."
+        )
+    else:
+        domain, client_id = DEFAULT_AUTH0_DOMAIN, DEFAULT_AUTH0_CLIENT_ID
+
+    api_url = env.get("NAURO_API_URL") or str(config.get("api_url") or "") or DEFAULT_API_URL
+    audience = (
+        env.get("NAURO_AUTH0_AUDIENCE")
+        or str(config.get("auth0_audience") or "")
+        or DEFAULT_AUTH0_AUDIENCE
+    )
+    return domain, client_id, api_url, audience
 
 
 def _sanitize_sub(sub: str) -> str:
@@ -102,13 +150,11 @@ class _CallbackHandler(BaseHTTPRequestHandler):
 @auth_app.command()
 def login() -> None:
     """Authenticate with Auth0 using Authorization Code + PKCE."""
-    if not AUTH0_DOMAIN or not AUTH0_CLIENT_ID:
-        typer.echo(
-            "Auth0 not configured. Set NAURO_AUTH0_DOMAIN and NAURO_AUTH0_CLIENT_ID "
-            "environment variables, or run: nauro config set auth0_domain <domain>",
-            err=True,
-        )
-        raise typer.Exit(1)
+    try:
+        domain, client_id, api_url, audience = _resolve_auth_config(os.environ, load_config())
+    except PartialAuthConfigError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=1) from exc
 
     code_verifier, code_challenge = _generate_pkce()
     state = secrets.token_urlsafe(32)
@@ -126,17 +172,17 @@ def login() -> None:
     auth_params = urlencode(
         {
             "response_type": "code",
-            "client_id": AUTH0_CLIENT_ID,
+            "client_id": client_id,
             "redirect_uri": REDIRECT_URI,
             "scope": AUTH0_SCOPES,
-            "audience": AUTH0_AUDIENCE,
+            "audience": audience,
             "state": state,
             "code_challenge": code_challenge,
             "code_challenge_method": "S256",
             "prompt": "login",
         }
     )
-    auth_url = f"https://{AUTH0_DOMAIN}/authorize?{auth_params}"
+    auth_url = f"https://{domain}/authorize?{auth_params}"
 
     typer.echo("\nOpening browser to authenticate...\n")
     typer.echo(f"If the browser doesn't open, visit:\n  {auth_url}\n")
@@ -163,10 +209,10 @@ def login() -> None:
     # Exchange code for tokens
     try:
         token_resp = httpx.post(
-            f"https://{AUTH0_DOMAIN}/oauth/token",
+            f"https://{domain}/oauth/token",
             json={
                 "grant_type": "authorization_code",
-                "client_id": AUTH0_CLIENT_ID,
+                "client_id": client_id,
                 "code": _CallbackHandler.auth_code,
                 "redirect_uri": REDIRECT_URI,
                 "code_verifier": code_verifier,
@@ -199,14 +245,6 @@ def login() -> None:
 
     # Fetch canonical user_id from server
     user_id = None
-    api_url = os.environ.get("NAURO_API_URL", "")
-    if not api_url:
-        typer.echo(
-            "API URL not configured. Set NAURO_API_URL environment variable.",
-            err=True,
-        )
-        raise typer.Exit(1)
-
     try:
         me_resp = httpx.get(
             f"{api_url}/me",

--- a/packages/nauro/src/nauro/cli/commands/auth.py
+++ b/packages/nauro/src/nauro/cli/commands/auth.py
@@ -54,21 +54,21 @@ def _resolve_auth_config(
     shell export is usually the cause and silent fall-through would hide it.
     api_url and audience resolve independently.
     """
-    env_d = env.get("NAURO_AUTH0_DOMAIN") or ""
-    env_c = env.get("NAURO_AUTH0_CLIENT_ID") or ""
-    cfg_d = str(config.get("auth0_domain") or "")
-    cfg_c = str(config.get("auth0_client_id") or "")
+    env_domain = env.get("NAURO_AUTH0_DOMAIN") or ""
+    env_client_id = env.get("NAURO_AUTH0_CLIENT_ID") or ""
+    config_domain = str(config.get("auth0_domain") or "")
+    config_client_id = str(config.get("auth0_client_id") or "")
 
-    if env_d and env_c:
-        domain, client_id = env_d, env_c
-    elif env_d or env_c:
+    if env_domain and env_client_id:
+        domain, client_id = env_domain, env_client_id
+    elif env_domain or env_client_id:
         raise PartialAuthConfigError(
             "Partial Auth0 config: NAURO_AUTH0_DOMAIN and NAURO_AUTH0_CLIENT_ID "
             "must be set together."
         )
-    elif cfg_d and cfg_c:
-        domain, client_id = cfg_d, cfg_c
-    elif cfg_d or cfg_c:
+    elif config_domain and config_client_id:
+        domain, client_id = config_domain, config_client_id
+    elif config_domain or config_client_id:
         raise PartialAuthConfigError(
             "Partial Auth0 config: auth0_domain and auth0_client_id must be set together in config."
         )

--- a/packages/nauro/tests/test_auth.py
+++ b/packages/nauro/tests/test_auth.py
@@ -116,17 +116,9 @@ def _simulate_callback_error(error: str = "access_denied"):
     _CallbackHandler.error = error
 
 
-def _patch_auth_config(monkeypatch):
-    """Set auth constants that no longer have hardcoded defaults."""
-    monkeypatch.setattr("nauro.cli.commands.auth.AUTH0_DOMAIN", "test.auth0.com")
-    monkeypatch.setattr("nauro.cli.commands.auth.AUTH0_CLIENT_ID", "test-client-id")
-    monkeypatch.setattr("nauro.cli.commands.auth.AUTH0_AUDIENCE", "https://test.api/mcp")
-
-
 class TestAuthLogin:
     def test_login_success(self, tmp_path, monkeypatch):
         _patch_home(monkeypatch, tmp_path)
-        _patch_auth_config(monkeypatch)
         monkeypatch.setenv("NAURO_API_URL", "https://test.api.example.com")
 
         fake_token = _make_jwt({"sub": "auth0|user123"})
@@ -186,7 +178,6 @@ class TestAuthLogin:
 
     def test_login_callback_error(self, tmp_path, monkeypatch):
         _patch_home(monkeypatch, tmp_path)
-        _patch_auth_config(monkeypatch)
 
         def fake_server_init(self, addr, handler_class):
             pass
@@ -222,7 +213,6 @@ class TestAuthLogin:
 
     def test_login_timeout(self, tmp_path, monkeypatch):
         _patch_home(monkeypatch, tmp_path)
-        _patch_auth_config(monkeypatch)
 
         def fake_server_init(self, addr, handler_class):
             pass
@@ -260,7 +250,6 @@ class TestAuthLogin:
 
     def test_login_token_exchange_failure(self, tmp_path, monkeypatch):
         _patch_home(monkeypatch, tmp_path)
-        _patch_auth_config(monkeypatch)
 
         def fake_post(url, **kwargs):
             raise httpx.HTTPStatusError(
@@ -397,3 +386,121 @@ class TestAuthLogout:
         config_path = tmp_path / "nauro_home" / "config.json"
         mode = os.stat(config_path).st_mode & 0o777
         assert mode == 0o600
+
+
+# --- shipped defaults + resolver (regression lock-in for the empty-defaults bug) ---
+
+
+def test_defaults_are_non_empty():
+    """Trip-wire: a future audit pass must not strip these back to empty strings."""
+    from nauro.cli.commands.auth import (
+        DEFAULT_API_URL,
+        DEFAULT_AUTH0_AUDIENCE,
+        DEFAULT_AUTH0_CLIENT_ID,
+        DEFAULT_AUTH0_DOMAIN,
+    )
+
+    assert DEFAULT_AUTH0_DOMAIN
+    assert DEFAULT_AUTH0_CLIENT_ID
+    assert DEFAULT_API_URL
+    assert DEFAULT_AUTH0_AUDIENCE
+
+
+class TestResolveAuthConfig:
+    """Pure-function resolver tests — no monkeypatching, no tmp_path."""
+
+    def _call(self, env=None, config=None):
+        from nauro.cli.commands.auth import _resolve_auth_config
+
+        return _resolve_auth_config(env or {}, config or {})
+
+    def _defaults(self):
+        from nauro.cli.commands.auth import (
+            DEFAULT_API_URL,
+            DEFAULT_AUTH0_AUDIENCE,
+            DEFAULT_AUTH0_CLIENT_ID,
+            DEFAULT_AUTH0_DOMAIN,
+        )
+
+        return (
+            DEFAULT_AUTH0_DOMAIN,
+            DEFAULT_AUTH0_CLIENT_ID,
+            DEFAULT_API_URL,
+            DEFAULT_AUTH0_AUDIENCE,
+        )
+
+    def test_empty_env_empty_config_returns_defaults(self):
+        domain, client_id, api_url, audience = self._call()
+        assert (domain, client_id, api_url, audience) == self._defaults()
+
+    def test_config_complete_pair_returns_config(self):
+        cfg = {"auth0_domain": "cfg.auth0.com", "auth0_client_id": "cfg-id"}
+        domain, client_id, _, _ = self._call(config=cfg)
+        assert domain == "cfg.auth0.com"
+        assert client_id == "cfg-id"
+
+    def test_config_only_domain_raises(self):
+        from nauro.cli.commands.auth import PartialAuthConfigError
+
+        with pytest.raises(PartialAuthConfigError):
+            self._call(config={"auth0_domain": "cfg.auth0.com"})
+
+    def test_config_only_client_id_raises(self):
+        from nauro.cli.commands.auth import PartialAuthConfigError
+
+        with pytest.raises(PartialAuthConfigError):
+            self._call(config={"auth0_client_id": "cfg-id"})
+
+    def test_env_complete_pair_overrides_config(self):
+        env = {
+            "NAURO_AUTH0_DOMAIN": "env.auth0.com",
+            "NAURO_AUTH0_CLIENT_ID": "env-id",
+        }
+        cfg = {"auth0_domain": "cfg.auth0.com", "auth0_client_id": "cfg-id"}
+        domain, client_id, _, _ = self._call(env=env, config=cfg)
+        assert domain == "env.auth0.com"
+        assert client_id == "env-id"
+
+    def test_env_only_domain_raises(self):
+        from nauro.cli.commands.auth import PartialAuthConfigError
+
+        with pytest.raises(PartialAuthConfigError):
+            self._call(env={"NAURO_AUTH0_DOMAIN": "env.auth0.com"})
+
+    def test_env_only_client_id_raises(self):
+        from nauro.cli.commands.auth import PartialAuthConfigError
+
+        with pytest.raises(PartialAuthConfigError):
+            self._call(env={"NAURO_AUTH0_CLIENT_ID": "env-id"})
+
+    def test_api_url_env_overrides_config_and_default(self):
+        _, _, api_url, _ = self._call(
+            env={"NAURO_API_URL": "https://env.example/"},
+            config={"api_url": "https://cfg.example/"},
+        )
+        assert api_url == "https://env.example/"
+
+    def test_api_url_config_overrides_default(self):
+        _, _, api_url, _ = self._call(config={"api_url": "https://cfg.example/"})
+        assert api_url == "https://cfg.example/"
+
+    def test_api_url_falls_back_to_default(self):
+        _, _, api_url, _ = self._call()
+        _, _, expected, _ = self._defaults()
+        assert api_url == expected
+
+    def test_audience_env_overrides_config_and_default(self):
+        _, _, _, audience = self._call(
+            env={"NAURO_AUTH0_AUDIENCE": "https://env.aud/mcp"},
+            config={"auth0_audience": "https://cfg.aud/mcp"},
+        )
+        assert audience == "https://env.aud/mcp"
+
+    def test_audience_config_overrides_default(self):
+        _, _, _, audience = self._call(config={"auth0_audience": "https://cfg.aud/mcp"})
+        assert audience == "https://cfg.aud/mcp"
+
+    def test_audience_falls_back_to_default(self):
+        _, _, _, audience = self._call()
+        _, _, _, expected = self._defaults()
+        assert audience == expected


### PR DESCRIPTION
## Why

`nauro auth login` is broken on fresh installs. Module-level constants in `auth.py` default Auth0 domain and client_id to `""`, so `pip install nauro && nauro auth login` hits "Auth0 not configured" out of the box. The error message promises a `nauro config set auth0_domain` fallback, but the code never reads those config keys — the promise is a lie for first-run.

A second bug compounds it: `api_url` is resolved properly at the top of `login()` (env → config → `""`), but later in the same function a duplicate `os.environ.get("NAURO_API_URL", "")` read silently shadows the config fallback after token exchange. A user who set `api_url` in config but not in env gets "API URL not configured" *after* a successful login.

The existing test helper is the smoking gun:

```python
def _patch_auth_config(monkeypatch):
    """Set auth constants that no longer have hardcoded defaults."""
```

The pre-open-source hardening pass stripped the defaults deliberately. But Auth0 domain and client_id are public OAuth identifiers — not secrets — safe to ship as binary defaults, like every comparable CLI (gh, supabase, stripe, fly).

## Approach

Bake the production Auth0 values in as `DEFAULT_*` module constants, cross-checked against `mcp-server`'s SAM parameters. Keep env-var and config-file overrides for staging / self-host scenarios. Extract a pure `_resolve_auth_config(env, config)` helper that `login()` calls once at the top; no more module-constant reads mid-flow.

Rejected: a remote discovery endpoint (`.well-known/nauro-config.json`) for future tenant rotation. No canonical CLI ships one; `pip install -U` is the update channel; the forcing function for discovery is a stale install population that isn't this product yet. Revisit only on a concrete incident.

`(domain, client_id)` resolves as an **atomic pair**. If one is set at a layer without the other, we raise `PartialAuthConfigError` rather than falling through to the next layer. Mixing sources (e.g., `NAURO_AUTH0_DOMAIN` from a stale shell export + `auth0_client_id` from config) produces cross-tenant tokens that Auth0 rejects with confusing errors. Partial-env explicitly *does not* fall back to a complete config pair — a stale shell export is usually the cause, and silent fall-through would hide it. `api_url` and `audience` resolve independently.

## What changed

- `packages/nauro/src/nauro/cli/commands/auth.py`:
  - New constants: `DEFAULT_AUTH0_DOMAIN`, `DEFAULT_AUTH0_CLIENT_ID`, `DEFAULT_API_URL`, `DEFAULT_AUTH0_AUDIENCE`. All cross-checked against the prod SAM deployment; `mcp.nauro.ai` verified live via `curl /.well-known/oauth-protected-resource` → HTTP 200.
  - New `PartialAuthConfigError(Exception)` + pure `_resolve_auth_config(env, config)` returning `(domain, client_id, api_url, audience)`.
  - `login()` calls the resolver once, catches `PartialAuthConfigError` at the CLI boundary, and uses local vars throughout — no more module-constant reads.
  - Deleted: the unreachable "Auth0 not configured" branch, the duplicate `NAURO_API_URL` env read, the stale module-level `AUTH0_DOMAIN` / `AUTH0_CLIENT_ID` / `AUTH0_AUDIENCE` globals.
- `packages/nauro/tests/test_auth.py`:
  - New `test_defaults_are_non_empty` — trip-wire for the exact original regression.
  - New `TestResolveAuthConfig` (12 cases) — pure-function precedence and atomic-pair enforcement, no monkeypatching, no `tmp_path`.
  - Deleted `_patch_auth_config` helper and its 4 call sites — shipped defaults make `login()` runnable in tests without patching module state.
- `CLAUDE.md` (line 51): updates the config bullet to reflect that Auth0 config ships as defaults with env-var/config-key overrides, not the other way around. Intent: the next audit pass reads this and understands why the defaults are there.

## What to review

- **Atomic-pair semantics in `_resolve_auth_config`.** The "partial env blocks config fallback" behavior is intentional but not obvious — docstring calls it out. If a reviewer disagrees with this choice, the alternative is silent fall-through, which I'd argue is worse (hides stale-export bugs).
- **`PartialAuthConfigError(Exception)`**, caught at the CLI boundary and rethrown as `typer.Exit(1)`. Earlier iteration used `typer.BadParameter`, but that emits Click "Usage:" scaffolding that doesn't apply outside a param callback.
- **Removal of `_patch_auth_config`.** Four existing `TestAuthLogin` tests previously relied on it. They all still pass because the browser/HTTP/server mocks are unchanged and the shipped defaults make `login()` runnable without patching.
- **`DEFAULT_API_URL = "https://mcp.nauro.ai"`** — DNS is live (CNAME to API Gateway custom domain, not Route 53). Verified end-to-end before baking.

## What's deferred

- **PyPI publish and version bump.** Post-merge ops; out of this PR.
- **Local config cleanup on the maintainer's machine.** Existing `auth0_domain` / `auth0_client_id` keys in `~/.nauro/config.json` match the new baked defaults, so behavior is identical — optional housekeeping.
- **README updates** (problem statement, comparison table tweaks, typo fix, pricing copy). Unrelated logical change from the same session; shipping as a separate PR.
- **Auth0 custom domain (`auth.nauro.ai`) and tenant migration.** Paid-plan feature; revisit if Auth0 for Startups acceptance lands or revenue justifies it. The SAM template already parameterizes the three Auth0 values, so the migration is a console config change + SAM redeploy; no CLI code change needed.

## Test plan

- `uv run pytest packages/nauro/tests/test_auth.py -v` → 36/36 pass (22 existing + 14 new).
- `uv run pytest packages/nauro/tests/ -x -q -m "not integration"` → 616 pass, zero regressions across the package.
- `uv run ruff check` + `uv run ruff format --check` → clean on both changed files.
- Smoke verified: `nauro auth --help` loads; `_resolve_auth_config({}, {})` returns the four expected defaults.
- Live login smoke test (fresh-install simulation: unset env, move config aside, `nauro auth login`) is documented in the plan but not run in CI — modifies the local config, left as manual verification.

Regression trip-wires: strip one `DEFAULT_*` back to `""` → `test_defaults_are_non_empty` fails. Swap the resolver to resolve domain and client_id independently → the partial-pair precedence tests fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)