### PR TITLE
Bump nauro to 0.1.1

### DIFF
--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro"
-version = "0.1.0"
+version = "0.1.1"
 description = "Local CLI + MCP server that maintains versioned project context for AI coding agents."
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/nauro/src/nauro/__init__.py
+++ b/packages/nauro/src/nauro/__init__.py
@@ -1,3 +1,3 @@
 """Nauro — local CLI + MCP server for versioned project context."""
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"


### PR DESCRIPTION
## Why

Ships PR #10 (Auth0 defaults + config-fallback fix) to PyPI. Without a release, `pip install nauro` still gets 0.1.0 and still hits the "Auth0 not configured" error on first-run `nauro auth login`.

## Approach

Patch bump (0.1.0 → 0.1.1) — bug fix, no API changes, no token invalidation. Merging this PR and then tagging `nauro-v0.1.1` triggers `.github/workflows/publish-nauro.yml` (OIDC trusted publisher, no local token needed).

## What changed

- `packages/nauro/pyproject.toml` — `version = "0.1.1"`
- `packages/nauro/src/nauro/__init__.py` — `__version__ = "0.1.1"`

## What to review

Just that both version strings match and that 0.1.1 is the intended target.

## What's deferred

- The tag push (`nauro-v0.1.1`) after this merges — that's the actual publish trigger.

## Test plan

Existing CI runs on the branch. No functional change; the auth fix that ships here was already verified in PR #10 (616 tests, 0 regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)