### PR TITLE
Project-scoped migration — nauro-core schema + CLI cutover

### DIFF
--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro-core"
-version = "0.2.0"
+version = "0.3.0"
 description = "Shared pure-Python logic for Nauro: parsing, validation, context assembly, constants."
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/nauro-core/src/nauro_core/__init__.py
+++ b/packages/nauro-core/src/nauro_core/__init__.py
@@ -3,7 +3,7 @@
 Re-export facade — public API symbols from all modules.
 """
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 from nauro_core.constants import (
     DECISION_HASHES_FILE as DECISION_HASHES_FILE,
@@ -54,6 +54,9 @@ from nauro_core.constants import (
     MCP_INSTRUCTIONS as MCP_INSTRUCTIONS,
 )
 from nauro_core.constants import (
+    MCP_INSTRUCTIONS_STATIC as MCP_INSTRUCTIONS_STATIC,
+)
+from nauro_core.constants import (
     MIN_RATIONALE_LENGTH as MIN_RATIONALE_LENGTH,
 )
 from nauro_core.constants import (
@@ -97,6 +100,15 @@ from nauro_core.context import (
 )
 from nauro_core.context import (
     build_l2 as build_l2,
+)
+from nauro_core.instructions import (
+    MAX_INLINE_PROJECTS as MAX_INLINE_PROJECTS,
+)
+from nauro_core.instructions import (
+    WELCOME_NO_PROJECT as WELCOME_NO_PROJECT,
+)
+from nauro_core.instructions import (
+    build_remote_instructions as build_remote_instructions,
 )
 from nauro_core.decision_model import (
     Decision as Decision,

--- a/packages/nauro-core/src/nauro_core/__init__.py
+++ b/packages/nauro-core/src/nauro_core/__init__.py
@@ -101,15 +101,6 @@ from nauro_core.context import (
 from nauro_core.context import (
     build_l2 as build_l2,
 )
-from nauro_core.instructions import (
-    MAX_INLINE_PROJECTS as MAX_INLINE_PROJECTS,
-)
-from nauro_core.instructions import (
-    WELCOME_NO_PROJECT as WELCOME_NO_PROJECT,
-)
-from nauro_core.instructions import (
-    build_remote_instructions as build_remote_instructions,
-)
 from nauro_core.decision_model import (
     Decision as Decision,
 )
@@ -136,6 +127,15 @@ from nauro_core.decision_model import (
 )
 from nauro_core.decision_model import (
     parse_decision_v2 as parse_decision_v2,
+)
+from nauro_core.instructions import (
+    MAX_INLINE_PROJECTS as MAX_INLINE_PROJECTS,
+)
+from nauro_core.instructions import (
+    WELCOME_NO_PROJECT as WELCOME_NO_PROJECT,
+)
+from nauro_core.instructions import (
+    build_remote_instructions as build_remote_instructions,
 )
 from nauro_core.mcp_tools import (
     ALL_TOOLS as ALL_TOOLS,

--- a/packages/nauro-core/src/nauro_core/constants.py
+++ b/packages/nauro-core/src/nauro_core/constants.py
@@ -63,8 +63,10 @@ MAX_APPROACH_LENGTH = 5_000
 # ── MCP server instructions ──
 # Delivered via the MCP `initialize` response to every connected client.
 # Single source of truth — both local (stdio) and remote (HTTP) servers
-# should reference this constant.
-MCP_INSTRUCTIONS = """\
+# reference MCP_INSTRUCTIONS_STATIC. Remote callers compose it with a
+# per-user project section via build_remote_instructions() in instructions.py.
+# MCP_INSTRUCTIONS remains as a backward-compatible alias.
+MCP_INSTRUCTIONS_STATIC = """\
 Nauro is the project's decision memory. Use it to check past decisions \
 before committing to an approach, and to record new decisions as you make them.
 
@@ -100,3 +102,5 @@ Call `update_state` when you complete a meaningful unit of work — \
 a feature, a refactor, a bug fix — so the next session starts with \
 current context.\
 """
+
+MCP_INSTRUCTIONS = MCP_INSTRUCTIONS_STATIC

--- a/packages/nauro-core/src/nauro_core/instructions.py
+++ b/packages/nauro-core/src/nauro_core/instructions.py
@@ -52,10 +52,7 @@ def build_remote_instructions(
         lines = ["Your projects:"]
         for p in ordered:
             lines.append(f"- {p['name']} — {p['project_id'][:8]}")
-        lines.append(
-            "\nPass the matching project_id to every tool call "
-            "(except list_projects)."
-        )
+        lines.append("\nPass the matching project_id to every tool call (except list_projects).")
         return f"{static_block}\n\n" + "\n".join(lines)
 
     return (

--- a/packages/nauro-core/src/nauro_core/instructions.py
+++ b/packages/nauro-core/src/nauro_core/instructions.py
@@ -1,0 +1,66 @@
+"""Per-user composition of MCP server instructions.
+
+The static instructional block (MCP_INSTRUCTIONS_STATIC) is project-agnostic.
+Remote callers append a small section listing the user's projects so Claude
+can pick a project_id without a discovery roundtrip. For users with no
+projects, WELCOME_NO_PROJECT replaces the project list with onboarding copy.
+"""
+
+from __future__ import annotations
+
+MAX_INLINE_PROJECTS = 3
+
+WELCOME_NO_PROJECT = (
+    "Welcome to Nauro. You have no projects yet.\n"
+    "\n"
+    "Next steps:\n"
+    "1. Run `nauro auth login` (required before any cloud operation).\n"
+    "2. Create a project:\n"
+    "   - `nauro init <name>` for a local-only project (no network).\n"
+    "   - `nauro init --cloud <name>` to create a server-minted cloud project.\n"
+    "3. Or, if a teammate already created a cloud project, run "
+    "`nauro attach <project_id>` to connect this machine to it.\n"
+    "\n"
+    "Once a project exists, every tool call (except list_projects) requires "
+    "its project_id."
+)
+
+
+def build_remote_instructions(
+    static_block: str,
+    projects: list[dict],
+) -> str:
+    """Combine static instructions with a per-user project section.
+
+    `projects` is a list of dicts each with at least 'project_id' (str, ULID)
+    and 'name' (str).
+
+    - Empty list: append WELCOME_NO_PROJECT.
+    - 1..MAX_INLINE_PROJECTS: append "Your projects:" with each rendered as
+      `name — {project_id[:8]}`, sorted by (name.lower(), project_id).
+    - More than MAX_INLINE_PROJECTS: append a count + hint to call
+      list_projects, without enumerating each one.
+    """
+    if not projects:
+        return f"{static_block}\n\n{WELCOME_NO_PROJECT}"
+
+    if len(projects) <= MAX_INLINE_PROJECTS:
+        ordered = sorted(
+            projects,
+            key=lambda p: (p["name"].lower(), p["project_id"]),
+        )
+        lines = ["Your projects:"]
+        for p in ordered:
+            lines.append(f"- {p['name']} — {p['project_id'][:8]}")
+        lines.append(
+            "\nPass the matching project_id to every tool call "
+            "(except list_projects)."
+        )
+        return f"{static_block}\n\n" + "\n".join(lines)
+
+    return (
+        f"{static_block}\n\n"
+        f"You have {len(projects)} projects. "
+        "Call list_projects to see them all and pick a project_id; "
+        "every tool call except list_projects requires one."
+    )

--- a/packages/nauro-core/src/nauro_core/mcp_tools.py
+++ b/packages/nauro-core/src/nauro_core/mcp_tools.py
@@ -41,7 +41,10 @@ class ToolSpec(TypedDict):
 
 _PROJECT_PARAM: dict[str, Any] = {
     "type": "string",
-    "description": "Project name. If omitted, auto-discovered from cwd (local) or S3 (remote).",
+    "description": (
+        "Project ID (ULID). Required for every tool except list_projects. "
+        "Call list_projects to discover the IDs available to the current user."
+    ),
 }
 
 # Every tool is closed-world (operates only on the local/remote Nauro store)
@@ -85,8 +88,9 @@ GET_CONTEXT: ToolSpec = {
                 "default": "L0",
                 "description": "Detail level: L0 (concise), L1 (working set), L2 (full dump).",
             },
-            "project": _PROJECT_PARAM,
+            "project_id": _PROJECT_PARAM,
         },
+        "required": ["project_id"],
     },
 }
 
@@ -115,9 +119,9 @@ GET_RAW_FILE: ToolSpec = {
                     "(e.g., 'project.md', 'decisions/001-initial-architecture.md')."
                 ),
             },
-            "project": _PROJECT_PARAM,
+            "project_id": _PROJECT_PARAM,
         },
-        "required": ["path"],
+        "required": ["path", "project_id"],
     },
 }
 
@@ -143,8 +147,9 @@ LIST_DECISIONS: ToolSpec = {
                 "default": False,
                 "description": "Include superseded decisions in the result.",
             },
-            "project": _PROJECT_PARAM,
+            "project_id": _PROJECT_PARAM,
         },
+        "required": ["project_id"],
     },
 }
 
@@ -163,9 +168,9 @@ GET_DECISION: ToolSpec = {
                 "type": "integer",
                 "description": "Decision number (e.g., 23).",
             },
-            "project": _PROJECT_PARAM,
+            "project_id": _PROJECT_PARAM,
         },
-        "required": ["number"],
+        "required": ["number", "project_id"],
     },
 }
 
@@ -191,8 +196,9 @@ DIFF_SINCE_LAST_SESSION: ToolSpec = {
                     "snapshot to N days ago and diffs against the latest."
                 ),
             },
-            "project": _PROJECT_PARAM,
+            "project_id": _PROJECT_PARAM,
         },
+        "required": ["project_id"],
     },
 }
 
@@ -227,9 +233,9 @@ SEARCH_DECISIONS: ToolSpec = {
                 "default": 10,
                 "description": "Maximum results to return.",
             },
-            "project": _PROJECT_PARAM,
+            "project_id": _PROJECT_PARAM,
         },
-        "required": ["query"],
+        "required": ["query", "project_id"],
     },
 }
 
@@ -263,9 +269,9 @@ CHECK_DECISION: ToolSpec = {
                     "Optional additional context about why you're considering this approach."
                 ),
             },
-            "project": _PROJECT_PARAM,
+            "project_id": _PROJECT_PARAM,
         },
-        "required": ["proposed_approach"],
+        "required": ["proposed_approach", "project_id"],
     },
 }
 
@@ -347,9 +353,9 @@ PROPOSE_DECISION: ToolSpec = {
                     "Use when you already called check_decision."
                 ),
             },
-            "project": _PROJECT_PARAM,
+            "project_id": _PROJECT_PARAM,
         },
-        "required": ["title", "rationale"],
+        "required": ["title", "rationale", "project_id"],
     },
 }
 
@@ -372,9 +378,9 @@ CONFIRM_DECISION: ToolSpec = {
                 "type": "string",
                 "description": "The confirm_id returned by propose_decision.",
             },
-            "project": _PROJECT_PARAM,
+            "project_id": _PROJECT_PARAM,
         },
-        "required": ["confirm_id"],
+        "required": ["confirm_id", "project_id"],
     },
 }
 
@@ -404,9 +410,9 @@ FLAG_QUESTION: ToolSpec = {
                 "type": "string",
                 "description": "Optional context about why this question matters.",
             },
-            "project": _PROJECT_PARAM,
+            "project_id": _PROJECT_PARAM,
         },
-        "required": ["question"],
+        "required": ["question", "project_id"],
     },
 }
 
@@ -430,9 +436,28 @@ UPDATE_STATE: ToolSpec = {
                 "type": "string",
                 "description": 'Description of what changed (e.g. "Deployed v0.2.0 to staging").',
             },
-            "project": _PROJECT_PARAM,
+            "project_id": _PROJECT_PARAM,
         },
-        "required": ["delta"],
+        "required": ["delta", "project_id"],
+    },
+}
+
+# list_projects is the only tool that does not take a project_id — it is the
+# discovery entry point users (and Claude) call before any other tool can run.
+# Treat the exemption as deliberate: every other spec requires "project_id".
+LIST_PROJECTS: ToolSpec = {
+    "name": "list_projects",
+    "title": "List projects",
+    "description": (
+        "Return the projects this user has access to. The only tool that "
+        "does not require a project_id — call this first to discover the "
+        "IDs to pass to every other tool."
+    ),
+    "annotations": {**_READ_ANNOTATIONS, "idempotentHint": True},
+    "input_schema": {
+        "type": "object",
+        "properties": {},
+        "required": [],
     },
 }
 
@@ -450,6 +475,7 @@ ALL_TOOLS: tuple[ToolSpec, ...] = (
     CONFIRM_DECISION,
     FLAG_QUESTION,
     UPDATE_STATE,
+    LIST_PROJECTS,
 )
 
 _BY_NAME: dict[str, ToolSpec] = {spec["name"]: spec for spec in ALL_TOOLS}

--- a/packages/nauro-core/tests/test_mcp_tools.py
+++ b/packages/nauro-core/tests/test_mcp_tools.py
@@ -2,6 +2,11 @@
 
 import pytest
 
+from nauro_core.instructions import (
+    MAX_INLINE_PROJECTS,
+    WELCOME_NO_PROJECT,
+    build_remote_instructions,
+)
 from nauro_core.mcp_tools import ALL_TOOLS, get_tool_spec
 
 EXPECTED_TOOL_NAMES = {
@@ -16,6 +21,7 @@ EXPECTED_TOOL_NAMES = {
     "confirm_decision",
     "flag_question",
     "update_state",
+    "list_projects",
 }
 
 READ_TOOLS = {
@@ -26,14 +32,15 @@ READ_TOOLS = {
     "diff_since_last_session",
     "search_decisions",
     "check_decision",
+    "list_projects",
 }
 
 WRITE_TOOLS = {"propose_decision", "confirm_decision", "flag_question", "update_state"}
 
 
 class TestRegistry:
-    def test_eleven_tools(self):
-        assert len(ALL_TOOLS) == 11
+    def test_twelve_tools(self):
+        assert len(ALL_TOOLS) == 12
 
     def test_all_expected_names(self):
         names = {spec["name"] for spec in ALL_TOOLS}
@@ -59,13 +66,18 @@ class TestSpecShape:
         assert "properties" in spec["input_schema"]
 
     @pytest.mark.parametrize("spec", ALL_TOOLS, ids=lambda s: s["name"])
-    def test_project_param_present(self, spec):
-        """Every tool must accept an optional `project` parameter."""
+    def test_project_id_param(self, spec):
+        """Every tool except list_projects must require a `project_id`."""
         props = spec["input_schema"]["properties"]
-        assert "project" in props, f"{spec['name']} is missing `project`"
-        # And it must not be in required — always optional.
         required = spec["input_schema"].get("required", [])
-        assert "project" not in required
+        if spec["name"] == "list_projects":
+            assert "project_id" not in props
+            assert required == []
+        else:
+            assert "project_id" in props, f"{spec['name']} is missing `project_id`"
+            assert "project_id" in required, (
+                f"{spec['name']} must require `project_id`"
+            )
 
     @pytest.mark.parametrize("spec", ALL_TOOLS, ids=lambda s: s["name"])
     def test_closed_world(self, spec):
@@ -109,3 +121,69 @@ class TestGetContextLevel:
         level = spec["input_schema"]["properties"]["level"]
         assert level["type"] == "string"
         assert level["enum"] == ["L0", "L1", "L2"]
+
+
+class TestProjectIdRequirement:
+    def test_all_tools_require_project_id_except_list_projects(self):
+        for spec in ALL_TOOLS:
+            required = spec["input_schema"].get("required", [])
+            if spec["name"] == "list_projects":
+                assert required == [], (
+                    "list_projects must have no required parameters"
+                )
+            else:
+                assert "project_id" in required, (
+                    f"{spec['name']} must require project_id"
+                )
+
+    def test_list_projects_in_all_tools(self):
+        names = {spec["name"] for spec in ALL_TOOLS}
+        assert "list_projects" in names
+        spec = get_tool_spec("list_projects")
+        schema = spec["input_schema"]
+        assert schema["type"] == "object"
+        assert schema["properties"] == {}
+        assert schema.get("required", []) == []
+
+
+STATIC = "STATIC_BLOCK"
+
+
+class TestBuildRemoteInstructions:
+    def test_zero_projects(self):
+        result = build_remote_instructions(STATIC, [])
+        assert STATIC in result
+        assert WELCOME_NO_PROJECT in result
+
+    def test_inline(self):
+        projects = [
+            {"project_id": "01HZZZZZZZZZZZZZZZZZZZZZZ1", "name": "Beta"},
+            {"project_id": "01AAAAAAAAAAAAAAAAAAAAAAA1", "name": "alpha"},
+        ]
+        result = build_remote_instructions(STATIC, projects)
+        assert "Beta" in result
+        assert "alpha" in result
+        assert "01AAAAAA" in result
+        assert "01HZZZZZ" in result
+        # alpha sorts before Beta (case-insensitive name)
+        assert result.index("alpha") < result.index("Beta")
+        # Inline form must NOT mention list_projects (no overflow hint)
+        assert "Call list_projects" not in result
+
+    def test_overflow(self):
+        projects = [
+            {"project_id": f"01ID{i:022d}", "name": f"proj-{i}"}
+            for i in range(MAX_INLINE_PROJECTS + 2)
+        ]
+        result = build_remote_instructions(STATIC, projects)
+        assert STATIC in result
+        assert str(len(projects)) in result
+        assert "list_projects" in result
+        # Names must NOT be enumerated in overflow mode
+        for p in projects:
+            assert p["name"] not in result
+
+    def test_static_preserved_verbatim(self):
+        projects = [{"project_id": "01ID00000000000000000000A1", "name": "x"}]
+        result = build_remote_instructions(STATIC, projects)
+        assert STATIC in result

--- a/packages/nauro-core/tests/test_mcp_tools.py
+++ b/packages/nauro-core/tests/test_mcp_tools.py
@@ -75,9 +75,7 @@ class TestSpecShape:
             assert required == []
         else:
             assert "project_id" in props, f"{spec['name']} is missing `project_id`"
-            assert "project_id" in required, (
-                f"{spec['name']} must require `project_id`"
-            )
+            assert "project_id" in required, f"{spec['name']} must require `project_id`"
 
     @pytest.mark.parametrize("spec", ALL_TOOLS, ids=lambda s: s["name"])
     def test_closed_world(self, spec):
@@ -128,13 +126,9 @@ class TestProjectIdRequirement:
         for spec in ALL_TOOLS:
             required = spec["input_schema"].get("required", [])
             if spec["name"] == "list_projects":
-                assert required == [], (
-                    "list_projects must have no required parameters"
-                )
+                assert required == [], "list_projects must have no required parameters"
             else:
-                assert "project_id" in required, (
-                    f"{spec['name']} must require project_id"
-                )
+                assert "project_id" in required, f"{spec['name']} must require project_id"
 
     def test_list_projects_in_all_tools(self):
         names = {spec["name"] for spec in ALL_TOOLS}

--- a/packages/nauro/src/nauro/cli/commands/attach.py
+++ b/packages/nauro/src/nauro/cli/commands/attach.py
@@ -1,0 +1,83 @@
+"""nauro attach — Associate the current repo with an existing cloud project.
+
+The cloud equivalent of ``nauro init --add-repo``: the project already
+exists on the server (someone else created it, or you created it from a
+different repo), and you want this repo to participate in its context.
+
+Membership is verified against ``GET /projects`` before any local state
+is written. The local store directory is created if it does not yet
+exist; a ``.nauro/config.json`` is written into the cwd in cloud mode.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+from nauro.cli.commands.auth import DEFAULT_API_URL
+from nauro.constants import REPO_CONFIG_MODE_CLOUD
+from nauro.store.registry import (
+    add_repo_v2,
+    get_project_v2,
+    register_project_v2,
+)
+from nauro.store.repo_config import save_repo_config
+from nauro.sync.cloud_projects import CloudProjectError, list_projects
+
+
+def attach(
+    project_id: str = typer.Argument(..., help="Cloud project_id (ULID)."),
+    repo_path: Path | None = typer.Option(
+        None,
+        "--repo",
+        help="Repo directory to attach. Defaults to cwd.",
+    ),
+) -> None:
+    """Attach the current repo to an existing cloud project."""
+    repo_path = repo_path if repo_path is not None else Path.cwd()
+    try:
+        projects = list_projects()
+    except CloudProjectError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=1)
+
+    match = next((p for p in projects if p["project_id"] == project_id), None)
+    if match is None:
+        typer.echo(
+            f"Project id {project_id!r} not found among your cloud projects.\n"
+            "  Check the id, or run 'nauro auth login' to refresh credentials.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    name = match["name"]
+
+    existing = get_project_v2(project_id)
+    if existing is None:
+        _pid, store_path = register_project_v2(
+            name,
+            [repo_path],
+            mode=REPO_CONFIG_MODE_CLOUD,
+            project_id=project_id,
+            server_url=DEFAULT_API_URL,
+        )
+    else:
+        add_repo_v2(project_id, repo_path)
+        from nauro.store.registry import get_store_path_v2
+
+        store_path = get_store_path_v2(project_id)
+
+    save_repo_config(
+        repo_path,
+        {
+            "mode": REPO_CONFIG_MODE_CLOUD,
+            "id": project_id,
+            "name": name,
+            "server_url": DEFAULT_API_URL,
+        },
+    )
+
+    typer.echo(f"Attached '{name}' to {repo_path.resolve()}")
+    typer.echo(f"  Project id: {project_id}")
+    typer.echo(f"  Store: {store_path}")

--- a/packages/nauro/src/nauro/cli/commands/init.py
+++ b/packages/nauro/src/nauro/cli/commands/init.py
@@ -1,11 +1,38 @@
-"""nauro init — Register a new project and scaffold its store."""
+"""nauro init — Register a new project and scaffold its store.
+
+Two modes:
+
+* ``nauro init <name>`` — local-only project. CLI mints a ULID, writes
+  ``.nauro/config.json`` in the cwd, and registers the project in the
+  v2 registry under that id. No network calls.
+* ``nauro init --cloud <name>`` — cloud-scoped project. The CLI calls
+  the remote MCP server's ``POST /projects`` to mint a server-side ULID,
+  then registers locally with ``mode=cloud`` and writes a cloud-mode
+  repo config.
+
+``--add-repo <path>`` (repeatable) associates an existing local project
+with one or more repo paths. Adding repos to a cloud-scoped project is
+intentionally rejected — use ``nauro attach <project_id>`` from the new
+repo instead.
+"""
+
+from __future__ import annotations
 
 import logging
 from pathlib import Path
 
 import typer
 
-from nauro.store.registry import add_repo, get_project, get_store_path, register_project
+from nauro.cli.commands.auth import DEFAULT_API_URL
+from nauro.constants import REPO_CONFIG_MODE_CLOUD, REPO_CONFIG_MODE_LOCAL
+from nauro.store.registry import (
+    add_repo_v2,
+    find_projects_by_name_v2,
+    get_store_path_v2,
+    register_project_v2,
+)
+from nauro.store.repo_config import save_repo_config
+from nauro.sync.cloud_projects import CloudProjectError, create_project
 from nauro.templates.scaffolds import scaffold_project_store
 
 logger = logging.getLogger("nauro.cli.init")
@@ -23,46 +50,121 @@ def init(
         "--demo",
         help="Create a sample project with pre-written decisions.",
     ),
+    cloud: bool = typer.Option(
+        False,
+        "--cloud",
+        help="Create a cloud-scoped project on the remote MCP server.",
+    ),
 ) -> None:
     """Initialize a new Nauro project store and register it.
 
-    If the project already exists and --add-repo is provided, adds the repo
-    paths to the existing project instead of failing.
+    If a project with the given name already exists locally and --add-repo
+    is provided, the repos are appended to the existing local-mode entry.
+    Cloud-mode entries cannot be extended this way — use ``nauro attach``.
     """
     repo_paths = add_repo_paths if add_repo_paths else [Path.cwd()]
 
-    # If project exists and --add-repo was explicitly provided, add repos
-    if get_project(name) is not None and add_repo_paths:
-        store_path = get_store_path(name)
-        added = []
+    # ── --add-repo against an existing project ──────────────────────────────
+    if add_repo_paths:
+        existing = find_projects_by_name_v2(name)
+        if existing:
+            if len(existing) > 1:
+                typer.echo(
+                    f"Multiple projects named '{name}' exist. "
+                    "Disambiguate manually in ~/.nauro/registry.json.",
+                    err=True,
+                )
+                raise typer.Exit(code=1)
+            pid, entry = existing[0]
+            if entry.get("mode") == REPO_CONFIG_MODE_CLOUD:
+                typer.echo(
+                    f"Cannot --add-repo to cloud-mode project '{name}'.\n"
+                    f"  Run from the new repo: nauro attach {pid}",
+                    err=True,
+                )
+                raise typer.Exit(code=1)
+            store_path = get_store_path_v2(pid)
+            added = []
+            for rp in repo_paths:
+                add_repo_v2(pid, rp)
+                added.append(rp.resolve())
+            typer.echo(f"Updated project '{name}'")
+            typer.echo(f"  Store: {store_path}")
+            for rp in added:
+                typer.echo(f"  Added repo: {rp}")
+            return
+
+    # ── New project: cloud or local ────────────────────────────────────────
+    if cloud:
+        try:
+            view = create_project(name)
+        except CloudProjectError as exc:
+            typer.echo(f"Error: {exc}", err=True)
+            raise typer.Exit(code=1)
+        try:
+            pid, store_path = register_project_v2(
+                name,
+                repo_paths,
+                mode=REPO_CONFIG_MODE_CLOUD,
+                project_id=view["project_id"],
+                server_url=DEFAULT_API_URL,
+            )
+        except ValueError as exc:
+            typer.echo(f"Error: {exc}", err=True)
+            raise typer.Exit(code=1)
         for rp in repo_paths:
-            add_repo(name, rp)
-            added.append(rp.resolve())
-        typer.echo(f"Updated project '{name}'")
+            save_repo_config(
+                rp,
+                {
+                    "mode": REPO_CONFIG_MODE_CLOUD,
+                    "id": pid,
+                    "name": name,
+                    "server_url": DEFAULT_API_URL,
+                },
+            )
+        scaffold_project_store(name, store_path)
+        typer.echo(f"Initialized cloud project '{name}'")
+        typer.echo(f"  Project id: {pid}")
         typer.echo(f"  Store: {store_path}")
-        for rp in added:
-            typer.echo(f"  Added repo: {rp}")
+        for rp in repo_paths:
+            typer.echo(f"  Repo:  {rp.resolve()}")
+        typer.echo("  Next: run 'nauro sync' to capture the first snapshot")
         return
 
+    # ── Local-only ─────────────────────────────────────────────────────────
     try:
-        store_path = register_project(name, repo_paths)
-    except ValueError as e:
-        typer.echo(f"Error: {e}", err=True)
+        pid, store_path = register_project_v2(
+            name,
+            repo_paths,
+            mode=REPO_CONFIG_MODE_LOCAL,
+        )
+    except ValueError as exc:
+        typer.echo(f"Error: {exc}", err=True)
         raise typer.Exit(code=1)
+    for rp in repo_paths:
+        save_repo_config(
+            rp,
+            {
+                "mode": REPO_CONFIG_MODE_LOCAL,
+                "id": pid,
+                "name": name,
+            },
+        )
 
     if demo:
         from nauro.demo import create_demo_project
 
         create_demo_project(store_path)
         typer.echo(f"Initialized demo project '{name}'")
+        typer.echo(f"  Project id: {pid}")
         typer.echo(f"  Store: {store_path}")
         typer.echo("  Includes: 7 decisions, project state, open questions, and a snapshot")
 
-        # Auto-push if sync is configured
         _try_demo_sync(name, store_path)
     else:
         scaffold_project_store(name, store_path)
         typer.echo(f"Initialized project '{name}'")
+        typer.echo(f"  Project id: {pid}")
         typer.echo(f"  Store: {store_path}")
         for rp in repo_paths:
             typer.echo(f"  Repo:  {rp.resolve()}")

--- a/packages/nauro/src/nauro/cli/commands/link.py
+++ b/packages/nauro/src/nauro/cli/commands/link.py
@@ -1,0 +1,116 @@
+"""nauro link — Promote a local-only project to cloud.
+
+``nauro link --cloud`` reads the local-mode ``.nauro/config.json`` in the
+current repo, calls the remote MCP server's ``POST /projects`` to mint a
+cloud project_id, then re-keys the local store directory and v2 registry
+entry under the new id while preserving repo_paths and store contents.
+
+The flow is intentionally one-way: there is no inverse "unlink to local"
+command. The CLI only opens up new escape hatches when there is a real
+incident that demands them.
+"""
+
+from __future__ import annotations
+
+import typer
+
+from nauro.cli.commands.auth import DEFAULT_API_URL
+from nauro.constants import (
+    REPO_CONFIG_MODE_CLOUD,
+    REPO_CONFIG_MODE_LOCAL,
+)
+from nauro.store.registry import (
+    get_project_v2,
+    rename_project_id_v2,
+)
+from nauro.store.repo_config import (
+    RepoConfigSchemaError,
+    find_repo_config,
+    load_repo_config,
+    save_repo_config,
+)
+from nauro.sync.cloud_projects import CloudProjectError, create_project
+
+
+def link(
+    cloud: bool = typer.Option(
+        False,
+        "--cloud",
+        help="Promote the current repo's local-only project to a cloud project.",
+    ),
+) -> None:
+    """Promote a local-only project to cloud-mode."""
+    if not cloud:
+        typer.echo(
+            "nauro link requires a target. Did you mean: nauro link --cloud?",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    config_path = find_repo_config()
+    if config_path is None:
+        typer.echo(
+            "Not a nauro repo: no .nauro/config.json found above the current "
+            "directory. Run 'nauro init <name>' first.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    repo_root = config_path.parent.parent
+    try:
+        cfg = load_repo_config(repo_root)
+    except RepoConfigSchemaError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=1)
+
+    if cfg.get("mode") != REPO_CONFIG_MODE_LOCAL:
+        typer.echo(
+            f"Project '{cfg.get('name')}' is already cloud-mode "
+            f"(id {cfg.get('id')}); nothing to link.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    local_id = cfg["id"]
+    name = cfg["name"]
+
+    if get_project_v2(local_id) is None:
+        typer.echo(
+            f"Local project id {local_id!r} is not in the v2 registry. "
+            "Did you migrate ~/.nauro/registry.json?",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    try:
+        view = create_project(name)
+    except CloudProjectError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=1)
+    cloud_id = view["project_id"]
+
+    try:
+        new_store = rename_project_id_v2(
+            local_id,
+            cloud_id,
+            mode=REPO_CONFIG_MODE_CLOUD,
+            server_url=DEFAULT_API_URL,
+        )
+    except (KeyError, ValueError) as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=1)
+
+    save_repo_config(
+        repo_root,
+        {
+            "mode": REPO_CONFIG_MODE_CLOUD,
+            "id": cloud_id,
+            "name": name,
+            "server_url": DEFAULT_API_URL,
+        },
+    )
+
+    typer.echo(f"Linked '{name}' to cloud project")
+    typer.echo(f"  Old id: {local_id}")
+    typer.echo(f"  New id: {cloud_id}")
+    typer.echo(f"  Store:  {new_store}")

--- a/packages/nauro/src/nauro/cli/commands/serve.py
+++ b/packages/nauro/src/nauro/cli/commands/serve.py
@@ -4,6 +4,9 @@ Supports two transports:
   --stdio   Stdio transport (default for Claude Code integration).
             Claude Code spawns this process and communicates over stdin/stdout.
   (default) HTTP transport on localhost:7432. For advanced use or other tools.
+
+The server resolves project context from the cwd's ``.nauro/config.json``;
+there is no longer a ``--project`` flag — one source of truth.
 """
 
 import multiprocessing
@@ -30,11 +33,6 @@ def serve(
         False,
         "--stdio",
         help="Run over stdio (for Claude Code MCP integration).",
-    ),
-    project: str | None = typer.Option(
-        None,
-        "--project",
-        help="Target project name. Overrides cwd resolution.",
     ),
 ) -> None:
     """Start the Nauro MCP server."""

--- a/packages/nauro/src/nauro/cli/commands/setup.py
+++ b/packages/nauro/src/nauro/cli/commands/setup.py
@@ -13,7 +13,11 @@ import typer
 
 from nauro.cli.utils import resolve_target_project
 from nauro.constants import CLAUDE_MD, NAURO_BLOCK_END, NAURO_BLOCK_START
-from nauro.store.registry import get_project
+from nauro.store.registry import (
+    RegistrySchemaError,
+    get_project,
+    get_project_v2,
+)
 from nauro.templates.agents_md import regenerate_agents_md_for_project
 
 setup_app = typer.Typer(help="Configure tool integrations.")
@@ -126,7 +130,15 @@ def claude_code(
 ) -> None:
     """Configure Claude Code to use Nauro during sessions."""
     project_name, _store_path = resolve_target_project(project)
-    entry = get_project(project_name)
+    project_key = _store_path.name
+
+    # Try v2 first (id-keyed), then fall back to v1 (name-keyed legacy)
+    try:
+        entry = get_project_v2(project_key)
+    except RegistrySchemaError:
+        entry = None
+    if entry is None:
+        entry = get_project(project_name)
 
     if entry is None or not entry.get("repo_paths"):
         typer.echo(f"Project '{project_name}' has no associated repos.", err=True)
@@ -156,8 +168,9 @@ def claude_code(
             typer.echo(line)
 
     if not remove:
-        # Regenerate AGENTS.md so context is fresh from the start
-        updated_repos = regenerate_agents_md_for_project(project_name, _store_path)
+        # Regenerate AGENTS.md so context is fresh from the start.
+        # project_key is the v2 id (or v1 name) used by the registry-aware lookup.
+        updated_repos = regenerate_agents_md_for_project(project_key, _store_path)
         if updated_repos:
             typer.echo("\nAGENTS.md:")
             for repo_path in updated_repos:

--- a/packages/nauro/src/nauro/cli/commands/sync.py
+++ b/packages/nauro/src/nauro/cli/commands/sync.py
@@ -6,13 +6,29 @@ from pathlib import Path
 import typer
 
 from nauro.cli.utils import resolve_target_project
-from nauro.store.registry import load_registry
+from nauro.store.registry import (
+    RegistrySchemaError,
+    get_project_v2,
+    load_registry,
+)
 from nauro.store.snapshot import capture_snapshot
 from nauro.store.validator import print_warnings, validate_store
 from nauro.store.writer import update_state
 from nauro.templates.agents_md import regenerate_agents_md_for_project
 
 logger = logging.getLogger("nauro.sync")
+
+
+def _registry_repo_paths(project_key: str) -> list[str]:
+    """Return repo paths for ``project_key`` from v2 (preferred) or v1 registry."""
+    try:
+        v2_entry = get_project_v2(project_key)
+    except RegistrySchemaError:
+        v2_entry = None
+    if v2_entry is not None:
+        return list(v2_entry.get("repo_paths", []))
+    registry = load_registry()
+    return list(registry["projects"].get(project_key, {}).get("repo_paths", []))
 
 
 def sync(
@@ -39,18 +55,18 @@ def sync(
         return
 
     project_name, store_path = resolve_target_project(project)
+    # store_path.name is the project_id under v2 (id-keyed) or name under v1.
+    project_key = store_path.name
     trigger = message or "manual sync"
 
     # Pull from S3 first if cloud sync is configured (git-style pull-then-push)
-    _pull_from_cloud(project_name, store_path)
+    _pull_from_cloud(project_key, store_path)
 
     version = capture_snapshot(store_path, trigger=trigger)
     update_state(store_path, f"Snapshot v{version:03d}: {trigger}")
 
     # Warn about missing repo paths before regenerating
-    registry = load_registry()
-    entry = registry["projects"].get(project_name, {})
-    for repo_str in entry.get("repo_paths", []):
+    for repo_str in _registry_repo_paths(project_key):
         if not Path(repo_str).is_dir():
             typer.echo(
                 f"  Warning: repo path does not exist, skipping AGENTS.md: {repo_str}\n"
@@ -59,14 +75,14 @@ def sync(
             )
 
     # Regenerate AGENTS.md in each associated repo
-    updated_repos = regenerate_agents_md_for_project(project_name, store_path)
+    updated_repos = regenerate_agents_md_for_project(project_key, store_path)
 
     typer.echo(f"Synced {project_name} — snapshot v{version:03d}")
     for repo_path in updated_repos:
         typer.echo(f"  Updated AGENTS.md: {repo_path}")
 
     # Push to S3 if sync is configured
-    _push_to_cloud(project_name, store_path)
+    _push_to_cloud(project_key, store_path)
 
     # Run store validation and print warnings to stderr
     warnings = validate_store(store_path)
@@ -309,6 +325,7 @@ def _show_status(project_flag: str | None) -> None:
         project_name, store_path = resolve_target_project(project_flag)
     except SystemExit:
         return
+    project_key = store_path.name
 
     from nauro.sync.state import load_state
 
@@ -346,7 +363,7 @@ def _show_status(project_flag: str | None) -> None:
             typer.echo("  Remote status unavailable: run 'nauro auth login' first", err=True)
             return 0
         user_key = config.user_id or config.sanitized_sub
-        prefix = s3_prefix(user_key, project_name)
+        prefix = s3_prefix(user_key, project_key)
         remote_files = list_remote(client, config.bucket_name, prefix)
 
         pending_remote = []

--- a/packages/nauro/src/nauro/cli/main.py
+++ b/packages/nauro/src/nauro/cli/main.py
@@ -41,6 +41,7 @@ def main(
 def _register_commands() -> None:
     """Import and register all CLI subcommands."""
     from nauro.cli.commands import (  # noqa: F401
+        attach,
         auth,
         config,
         diff,
@@ -48,6 +49,7 @@ def _register_commands() -> None:
         hook,
         import_cmd,
         init,
+        link,
         log,
         note,
         serve,
@@ -58,6 +60,8 @@ def _register_commands() -> None:
     )
 
     app.command(name="init")(init.init)
+    app.command(name="attach")(attach.attach)
+    app.command(name="link")(link.link)
     app.command(name="note")(note.note)
     app.command(name="sync")(sync.sync)
     app.command(name="log")(log.log)

--- a/packages/nauro/src/nauro/cli/utils.py
+++ b/packages/nauro/src/nauro/cli/utils.py
@@ -1,16 +1,76 @@
-"""Shared CLI utilities."""
+"""Shared CLI utilities — project resolution + path helpers.
 
+Resolution priority for any command that needs a project context:
+
+  1. Explicit ``--project <name>`` flag (when the command takes one).
+     Looked up against the v2 registry by name; v1 registry is consulted
+     as a legacy fallback for unconverted callers and tests.
+  2. ``find_repo_config(cwd)`` — walks up from cwd looking for
+     ``.nauro/config.json`` and resolves the v2 registry by id.
+  3. v1 ``resolve_project(cwd)`` — name-keyed cwd resolution. Legacy
+     fallback retained while v1 callers remain in tree.
+  4. Error with helpful guidance.
+"""
+
+from __future__ import annotations
+
+import json
 from pathlib import Path
 
 import typer
 
 from nauro.store.registry import (
+    RegistrySchemaError,
+    add_repo_v2,
+    find_projects_by_name_v2,
     get_project,
     get_store_path,
+    get_store_path_v2,
     load_registry,
+    load_registry_v2,
+    register_project_v2,
     resolve_project,
+    resolve_v2_from_path,
     suggest_project_for_path,
 )
+from nauro.store.repo_config import (
+    RepoConfigSchemaError,
+    find_repo_config,
+    load_repo_config,
+)
+
+
+def _v2_registry_or_empty() -> dict:
+    """Return the v2 registry; on schema error fall back to an empty shape.
+
+    The schema-mismatch error is surfaced separately during resolution so
+    each command shows a single coherent message. Helper sites that just
+    need the registry data (e.g. iterating) get an empty shape.
+    """
+    try:
+        return load_registry_v2()
+    except RegistrySchemaError:
+        return {"projects": {}}
+
+
+def _resolve_from_repo_config() -> tuple[str, Path] | None:
+    """Resolve via ``.nauro/config.json`` walk-up from cwd.
+
+    Returns (display_name, store_path) or None when no repo config is found.
+    A repo-config that names a project_id missing from the v2 registry is
+    still honored — the store path uses the id from the config.
+    """
+    config_path = find_repo_config()
+    if config_path is None:
+        return None
+    repo_root = config_path.parent.parent
+    try:
+        cfg = load_repo_config(repo_root)
+    except (RepoConfigSchemaError, json.JSONDecodeError, OSError):
+        return None
+    pid = cfg["id"]
+    name = cfg.get("name") or pid
+    return name, get_store_path_v2(pid)
 
 
 def resolve_target_project(project_flag: str | None) -> tuple[str, Path]:
@@ -20,34 +80,69 @@ def resolve_target_project(project_flag: str | None) -> tuple[str, Path]:
         project_flag: Explicit project name from --project, or None.
 
     Returns:
-        (project_name, store_path) tuple.
+        (project_display_name, store_path) tuple.
 
     Raises:
         typer.Exit: If no project can be resolved.
     """
     if project_flag is not None:
-        entry = get_project(project_flag)
-        if entry is None:
-            registry = load_registry()
-            available = sorted(registry["projects"].keys())
-            typer.echo(f"Unknown project '{project_flag}'.", err=True)
-            if available:
-                typer.echo(f"Available projects: {', '.join(available)}", err=True)
-            else:
-                typer.echo("No projects registered. Run 'nauro init' first.", err=True)
+        # 1a — v2 by name (canonical)
+        matches = find_projects_by_name_v2(project_flag)
+        if len(matches) > 1:
+            ids = ", ".join(
+                f"{name} ({pid[:8]})"
+                for pid, _entry in matches[:5]
+                for name in [_entry.get("name", "?")]
+            )
+            typer.echo(
+                f"Multiple projects named '{project_flag}'. Disambiguate by id: {ids}",
+                err=True,
+            )
             raise typer.Exit(code=1)
-        return project_flag, get_store_path(project_flag)
+        if len(matches) == 1:
+            pid, _entry = matches[0]
+            return project_flag, get_store_path_v2(pid)
 
+        # 1b — v1 fallback (legacy tests and unconverted callers)
+        entry = get_project(project_flag)
+        if entry is not None:
+            return project_flag, get_store_path(project_flag)
+
+        registry = load_registry()
+        v2_names = sorted({e.get("name", "") for e in _v2_registry_or_empty()["projects"].values()})
+        v1_names = sorted(registry["projects"].keys())
+        available = sorted(set(v1_names) | set(v2_names) - {""})
+        typer.echo(f"Unknown project '{project_flag}'.", err=True)
+        if available:
+            typer.echo(f"Available projects: {', '.join(available)}", err=True)
+        else:
+            typer.echo("No projects registered. Run 'nauro init' first.", err=True)
+        raise typer.Exit(code=1)
+
+    # 2 — repo config walk-up
+    via_repo = _resolve_from_repo_config()
+    if via_repo is not None:
+        return via_repo
+
+    # 2b — v2 registry by cwd repo_paths (no repo config, but registered)
     cwd = Path.cwd()
+    v2_match = resolve_v2_from_path(cwd)
+    if v2_match is not None:
+        pid, entry = v2_match
+        return entry.get("name", pid), get_store_path_v2(pid)
+
+    # 3 — v1 fallback (legacy)
     project_name = resolve_project(cwd)
     if project_name:
         return project_name, get_store_path(project_name)
 
+    # 4 — error
     registry = load_registry()
-    available = sorted(registry["projects"].keys())
+    v2_names = sorted({e.get("name", "") for e in _v2_registry_or_empty()["projects"].values()})
+    v1_names = sorted(registry["projects"].keys())
+    available = sorted(set(v1_names) | set(v2_names) - {""})
     typer.echo("No project found for current directory.", err=True)
 
-    # Check if the directory name matches a project — likely a moved/cloned repo
     suggestion = suggest_project_for_path(cwd)
     if suggestion:
         typer.echo(
@@ -64,3 +159,11 @@ def resolve_target_project(project_flag: str | None) -> tuple[str, Path]:
     else:
         typer.echo("Run 'nauro init' first.", err=True)
     raise typer.Exit(code=1)
+
+
+# Re-exported for callers that need to write or extend v2 entries directly
+__all__ = [
+    "add_repo_v2",
+    "register_project_v2",
+    "resolve_target_project",
+]

--- a/packages/nauro/src/nauro/constants.py
+++ b/packages/nauro/src/nauro/constants.py
@@ -97,3 +97,14 @@ HOOK_END_MARKER = "# --- nauro post-commit hook end ---"
 
 # ── Schema versioning ──
 SCHEMA_VERSION = 1
+
+# ── Repo-local config (.nauro/config.json inside each repo) ──
+REPO_CONFIG_DIR = ".nauro"
+REPO_CONFIG_FILENAME = "config.json"
+REPO_CONFIG_SCHEMA_VERSION = 1
+REPO_CONFIG_MODE_LOCAL = "local"
+REPO_CONFIG_MODE_CLOUD = "cloud"
+
+# ── Registry schema versions ──
+REGISTRY_SCHEMA_VERSION_V1 = 1
+REGISTRY_SCHEMA_VERSION_V2 = 2

--- a/packages/nauro/src/nauro/extraction/pipeline.py
+++ b/packages/nauro/src/nauro/extraction/pipeline.py
@@ -25,7 +25,34 @@ from nauro.extraction.prompts import EXTRACTION_TOOL  # noqa: F401
 from nauro.extraction.providers import ExtractionProvider
 from nauro.extraction.types import ExtractionOutcome, ExtractionResult, ExtractionSkipped
 from nauro.store import reader, registry, writer
+from nauro.store.repo_config import (
+    RepoConfigSchemaError,
+    find_repo_config,
+    load_repo_config,
+)
 from nauro.templates.agents_md import regenerate_agents_md_for_project
+
+
+def _resolve_project_key_for_repo(repo_path: Path) -> str | None:
+    """Return project_id from repo config, then v2 registry, then v1 name.
+
+    The same priority order used by the CLI: id-keyed identification wins
+    over name-keyed legacy resolution so AGENTS.md regeneration and S3
+    push agree about which project is being targeted.
+    """
+    config_path = find_repo_config(start=repo_path)
+    if config_path is not None:
+        try:
+            cfg = load_repo_config(config_path.parent.parent)
+            return cfg["id"]
+        except RepoConfigSchemaError:
+            pass
+    v2_match = registry.resolve_v2_from_path(repo_path)
+    if v2_match is not None:
+        pid, _entry = v2_match
+        return pid
+    return registry.resolve_project(repo_path)
+
 
 logger = logging.getLogger(__name__)
 
@@ -280,16 +307,17 @@ def process_commit(
         trigger=f"extract: {commit_message[:80]}",
     )
 
-    # Regenerate AGENTS.md in all associated repos so context stays current
-    project_name = registry.resolve_project(Path(repo_path))
-    if project_name:
-        regenerate_agents_md_for_project(project_name, store_path)
+    # Regenerate AGENTS.md in all associated repos so context stays current.
+    # Resolve via repo config first (v2 id-keyed), fall back to v1 by name.
+    project_key = _resolve_project_key_for_repo(Path(repo_path))
+    if project_key:
+        regenerate_agents_md_for_project(project_key, store_path)
 
         # Push to S3 after extraction (event-driven sync)
         try:
             from nauro.sync.hooks import push_after_extraction
 
-            push_after_extraction(project_name, store_path)
+            push_after_extraction(project_key, store_path)
         except Exception:
             # Log but never block the hook
             _append_extraction_log(

--- a/packages/nauro/src/nauro/mcp/server.py
+++ b/packages/nauro/src/nauro/mcp/server.py
@@ -34,7 +34,18 @@ from nauro.mcp.tools import (
     tool_update_state,
 )
 from nauro.store.reader import read_project_context
-from nauro.store.registry import get_store_path, resolve_project
+from nauro.store.registry import (
+    find_projects_by_name_v2,
+    get_store_path,
+    get_store_path_v2,
+    resolve_project,
+    resolve_v2_from_path,
+)
+from nauro.store.repo_config import (
+    RepoConfigSchemaError,
+    find_repo_config,
+    load_repo_config,
+)
 
 logger = logging.getLogger("nauro.mcp")
 
@@ -96,17 +107,84 @@ class HookRequest(BaseModel):
 # --- Helpers ---
 
 
+def _resolve_via_repo_config(start: Path | None) -> tuple[str, Path] | None:
+    """Walk up from ``start`` (or cwd) looking for ``.nauro/config.json``."""
+    config_path = find_repo_config(start=start)
+    if config_path is None:
+        return None
+    repo_root = config_path.parent.parent
+    try:
+        cfg = load_repo_config(repo_root)
+    except RepoConfigSchemaError:
+        return None
+    return cfg["id"], get_store_path_v2(cfg["id"])
+
+
 def _resolve_store(project: str | None, cwd: str | None) -> Path:
-    """Resolve project name to store path, raising 404 on failure."""
-    name = project
-    if not name and cwd:
-        name = resolve_project(Path(cwd))
-    if not name:
-        raise HTTPException(status_code=404, detail="Could not resolve project.")
-    store_path = get_store_path(name)
-    if not store_path.exists():
-        raise HTTPException(status_code=404, detail=f"Project store not found: {name}")
-    return store_path
+    """Resolve project name to store path, raising 404 on failure.
+
+    Same priority order as the stdio server's ``_resolve_store``: repo
+    config first, then explicit project name (v2 → v1), then cwd-based
+    legacy fallback.
+    """
+    cwd_path = Path(cwd) if cwd else None
+    via_config = _resolve_via_repo_config(cwd_path)
+
+    if project and via_config is not None:
+        config_id, store_path = via_config
+        if project != config_id:
+            matches = find_projects_by_name_v2(project)
+            if not any(pid == config_id for pid, _ in matches):
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"Supplied project_id {project!r} does not match the "
+                        f"repo config id {config_id!r}."
+                    ),
+                )
+        if not store_path.exists():
+            raise HTTPException(status_code=404, detail=f"Project store not found: {config_id}")
+        return store_path
+
+    if via_config is not None:
+        _pid, store_path = via_config
+        if not store_path.exists():
+            raise HTTPException(status_code=404, detail=f"Project store not found at {store_path}")
+        return store_path
+
+    if project:
+        matches = find_projects_by_name_v2(project)
+        if len(matches) == 1:
+            pid, _entry = matches[0]
+            store_path = get_store_path_v2(pid)
+            if not store_path.exists():
+                raise HTTPException(status_code=404, detail=f"Project store not found: {project}")
+            return store_path
+        if len(matches) > 1:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Multiple v2 projects named {project!r}; pass project_id instead.",
+            )
+        # v1 legacy
+        store_path = get_store_path(project)
+        if not store_path.exists():
+            raise HTTPException(status_code=404, detail=f"Project store not found: {project}")
+        return store_path
+
+    if cwd:
+        legacy_name = resolve_project(Path(cwd))
+        if legacy_name:
+            store_path = get_store_path(legacy_name)
+            if store_path.exists():
+                return store_path
+        v2_match = resolve_v2_from_path(Path(cwd))
+        if v2_match is not None:
+            pid, _entry = v2_match
+            store_path = get_store_path_v2(pid)
+            if store_path.exists():
+                return store_path
+
+    raise HTTPException(status_code=404, detail="Could not resolve project.")
 
 
 def _resolve_store_safe(cwd: str | None) -> Path | None:
@@ -114,13 +192,40 @@ def _resolve_store_safe(cwd: str | None) -> Path | None:
     if not cwd:
         return None
     try:
+        via_config = _resolve_via_repo_config(Path(cwd))
+        if via_config is not None:
+            _pid, store_path = via_config
+            return store_path if store_path.exists() else None
+
+        v2_match = resolve_v2_from_path(Path(cwd))
+        if v2_match is not None:
+            pid, _entry = v2_match
+            store_path = get_store_path_v2(pid)
+            return store_path if store_path.exists() else None
+
         name = resolve_project(Path(cwd))
         if not name:
             return None
         store_path = get_store_path(name)
-        if not store_path.exists():
-            return None
-        return store_path
+        return store_path if store_path.exists() else None
+    except Exception:
+        return None
+
+
+def _resolve_project_key_safe(cwd: str | None) -> str | None:
+    """Return the project_id (or legacy name) for the cwd, or None."""
+    if not cwd:
+        return None
+    try:
+        via_config = _resolve_via_repo_config(Path(cwd))
+        if via_config is not None:
+            pid, _store = via_config
+            return pid
+        v2_match = resolve_v2_from_path(Path(cwd))
+        if v2_match is not None:
+            pid, _entry = v2_match
+            return pid
+        return resolve_project(Path(cwd))
     except Exception:
         return None
 
@@ -258,12 +363,11 @@ async def hook_session_start(req: HookRequest) -> dict:
 
         # Pull latest from S3 before reading context (non-blocking on failure)
         try:
-            if req.cwd:
-                project_name = resolve_project(Path(req.cwd))
-                if project_name:
-                    from nauro.sync.hooks import pull_before_session
+            project_key = _resolve_project_key_safe(req.cwd)
+            if project_key:
+                from nauro.sync.hooks import pull_before_session
 
-                    await asyncio.to_thread(pull_before_session, project_name, store_path)
+                await asyncio.to_thread(pull_before_session, project_key, store_path)
         except Exception:
             logger.warning("session-start: S3 pull failed, continuing with local state")
 
@@ -349,12 +453,11 @@ def _run_post_compact_extraction(
 
     # Push to S3 after extraction (event-driven sync)
     try:
-        if cwd:
-            project_name = resolve_project(Path(cwd))
-            if project_name:
-                from nauro.sync.hooks import push_after_extraction
+        project_key = _resolve_project_key_safe(cwd)
+        if project_key:
+            from nauro.sync.hooks import push_after_extraction
 
-                push_after_extraction(project_name, store_path)
+            push_after_extraction(project_key, store_path)
     except Exception:
         logger.warning("post-compact: S3 push failed, decisions saved locally")
 

--- a/packages/nauro/src/nauro/mcp/stdio_server.py
+++ b/packages/nauro/src/nauro/mcp/stdio_server.py
@@ -39,10 +39,27 @@ from nauro.mcp.tools import (
     tool_update_state,
 )
 from nauro.onboarding import WELCOME_NO_PROJECT
-from nauro.store.registry import get_store_path, resolve_project
+from nauro.store.registry import (
+    find_projects_by_name_v2,
+    get_store_path,
+    get_store_path_v2,
+    resolve_project,
+    resolve_v2_from_path,
+)
+from nauro.store.repo_config import (
+    RepoConfigSchemaError,
+    find_repo_config,
+    load_repo_config,
+)
 
 logger = logging.getLogger("nauro.stdio")
 mcp = FastMCP("nauro", instructions=MCP_INSTRUCTIONS, log_level="WARNING")
+
+
+NOT_A_NAURO_REPO = (
+    "Not a nauro repo: no .nauro/config.json found. "
+    "Run 'nauro init <name>' in this repo, or pass project_id explicitly."
+)
 
 
 def _spec_kwargs(name: str) -> dict[str, Any]:
@@ -55,17 +72,87 @@ def _spec_kwargs(name: str) -> dict[str, Any]:
     }
 
 
+def _resolve_via_repo_config(start: Path | None) -> tuple[str, Path] | None:
+    """Walk up from ``start`` (or cwd) looking for ``.nauro/config.json``.
+
+    Returns (project_id, store_path) or None when no repo config is found.
+    """
+    config_path = find_repo_config(start=start)
+    if config_path is None:
+        return None
+    repo_root = config_path.parent.parent
+    try:
+        cfg = load_repo_config(repo_root)
+    except RepoConfigSchemaError:
+        return None
+    return cfg["id"], get_store_path_v2(cfg["id"])
+
+
 def _resolve_store(project: str | None, cwd: str | None) -> Path:
-    """Resolve project name to store path, raising on failure."""
-    name = project
-    if not name and cwd:
+    """Resolve a project to a store path.
+
+    Resolution order matches the CLI:
+      1. cwd's ``.nauro/config.json`` walk-up (id-keyed v2 store).
+      2. ``project`` argument matched against v2 registry by name.
+      3. ``project`` argument matched against v1 registry by name (legacy).
+      4. ``cwd`` arg → v1 ``resolve_project`` (legacy).
+
+    When ``project`` is supplied AND the cwd resolves to a different id via
+    the repo config, the call fails with a mismatch error so tooling cannot
+    silently mask a misconfiguration.
+    """
+    cwd_path = Path(cwd) if cwd else Path.cwd()
+    via_config = _resolve_via_repo_config(cwd_path)
+
+    if project and via_config is not None:
+        config_id, store_path = via_config
+        if project != config_id:
+            matches = find_projects_by_name_v2(project)
+            if not any(pid == config_id for pid, _ in matches):
+                raise ValueError(
+                    f"Supplied project_id {project!r} does not match the repo "
+                    f"config id {config_id!r} in {cwd_path}."
+                )
+        if not store_path.exists():
+            raise ValueError(f"Project store not found: {config_id}")
+        return store_path
+
+    if via_config is not None:
+        _pid, store_path = via_config
+        if not store_path.exists():
+            raise ValueError(f"Project store not found at {store_path}")
+        return store_path
+
+    if project:
+        matches = find_projects_by_name_v2(project)
+        if len(matches) == 1:
+            pid, _entry = matches[0]
+            store_path = get_store_path_v2(pid)
+            if not store_path.exists():
+                raise ValueError(f"Project store not found: {project}")
+            return store_path
+        if len(matches) > 1:
+            raise ValueError(f"Multiple v2 projects named {project!r}; pass project_id instead.")
+        # v1 legacy fallback
+        store_path = get_store_path(project)
+        if not store_path.exists():
+            raise ValueError(f"Project store not found: {project}")
+        return store_path
+
+    if cwd:
         name = resolve_project(Path(cwd))
-    if not name:
-        raise ValueError("Could not resolve project. Pass a 'project' name or 'cwd' path.")
-    store_path = get_store_path(name)
-    if not store_path.exists():
-        raise ValueError(f"Project store not found: {name}")
-    return store_path
+        if name:
+            store_path = get_store_path(name)
+            if store_path.exists():
+                return store_path
+        v2_match = resolve_v2_from_path(Path(cwd))
+        if v2_match is not None:
+            pid, _entry = v2_match
+            store_path = get_store_path_v2(pid)
+            if store_path.exists():
+                return store_path
+
+    raise ValueError("Could not resolve project. Pass a 'project' name or 'cwd' path.")
 
 
 @mcp.tool(**_spec_kwargs("get_context"))
@@ -253,22 +340,37 @@ def _pull_on_startup() -> None:
         return
 
     try:
-        project_name = resolve_project(Path(os.getcwd()))
-        if not project_name:
+        cwd = Path(os.getcwd())
+        project_key: str | None = None
+        store_path: Path | None = None
+
+        via_config = _resolve_via_repo_config(cwd)
+        if via_config is not None:
+            project_key, store_path = via_config
+        else:
+            v2_match = resolve_v2_from_path(cwd)
+            if v2_match is not None:
+                pid, _entry = v2_match
+                project_key, store_path = pid, get_store_path_v2(pid)
+            else:
+                legacy_name = resolve_project(cwd)
+                if legacy_name:
+                    project_key, store_path = legacy_name, get_store_path(legacy_name)
+
+        if not project_key or store_path is None:
             logger.debug("session-start pull: no project found in cwd, skipping")
             return
-        store_path = get_store_path(project_name)
         if not store_path.exists():
-            logger.debug("session-start pull: store not found for %s, skipping", project_name)
+            logger.debug("session-start pull: store not found for %s, skipping", project_key)
             return
 
         from nauro.sync.hooks import pull_before_session
 
-        pulled = pull_before_session(project_name, store_path)
+        pulled = pull_before_session(project_key, store_path)
         if pulled:
-            logger.info("session-start pull: pulled %d file(s) for %s", pulled, project_name)
+            logger.info("session-start pull: pulled %d file(s) for %s", pulled, project_key)
         else:
-            logger.debug("session-start pull: already up to date (%s)", project_name)
+            logger.debug("session-start pull: already up to date (%s)", project_key)
     except Exception as e:
         logger.warning("session-start pull: failed, continuing with local state: %s", e)
 

--- a/packages/nauro/src/nauro/store/registry.py
+++ b/packages/nauro/src/nauro/store/registry.py
@@ -1,7 +1,20 @@
 """Project registry — manages ~/.nauro/registry.json.
 
-The registry maps project names to one or more associated repo paths on the
-machine. The project store lives at ~/.nauro/projects/<project-name>/.
+Two on-disk shapes are supported during the project-scoped migration:
+
+* **v1 (legacy)** — keyed by project name; store path ``~/.nauro/projects/<name>/``.
+  Helpers: ``load_registry``, ``save_registry``, ``register_project``,
+  ``resolve_project``, ``add_repo``, ``remove_repo``, ``find_stale_paths``,
+  ``suggest_project_for_path``, ``get_project``, ``get_store_path``.
+* **v2 (canonical post-migration)** — keyed by project_id (ULID), tracks
+  ``mode`` + optional ``server_url``. Store path ``~/.nauro/projects/<id>/``.
+  Helpers: ``load_registry_v2``, ``save_registry_v2``, ``register_project_v2``,
+  ``get_store_path_v2``, ``get_project_v2``, ``find_projects_by_name_v2``,
+  ``resolve_v2_from_path``, ``add_repo_v2``, ``rename_project_id_v2``.
+
+The two shapes are mutually exclusive on disk; ``load_registry_v2`` rejects
+v1 with a one-time manual migration message. v1 helpers are retained as
+legacy for callers that have not yet been migrated.
 
 Respects NAURO_HOME env var override (defaults to ~/.nauro/).
 """
@@ -10,6 +23,7 @@ import json
 import logging
 import os
 import re
+import shutil
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -22,8 +36,11 @@ from nauro.constants import (
     REGISTRY_FILENAME,
     REGISTRY_SCHEMA_VERSION_V1,
     REGISTRY_SCHEMA_VERSION_V2,
+    REPO_CONFIG_MODE_CLOUD,
+    REPO_CONFIG_MODE_LOCAL,
     SCHEMA_VERSION,
 )
+from nauro.store.repo_config import generate_ulid
 
 logger = logging.getLogger("nauro.registry")
 
@@ -305,3 +322,190 @@ def remove_repo(project_name: str, repo_path_str: str) -> bool:
             save_registry(registry)
             return True
     return False
+
+
+# ── v2 registry CRUD (id-keyed) ──────────────────────────────────────────────
+
+
+_VALID_MODES_V2 = (REPO_CONFIG_MODE_LOCAL, REPO_CONFIG_MODE_CLOUD)
+
+
+def get_store_path_v2(project_id: str) -> Path:
+    """Return the id-keyed store directory for a v2 project."""
+    return _projects_dir() / project_id
+
+
+def _load_registry_v2_or_empty() -> dict:
+    """Read v2 registry; treat a v1-on-disk as 'no v2 entries'.
+
+    Read paths use this so that lookups silently fall back to v1 helpers
+    while a project is still on the v1 schema. Write paths continue to
+    call ``load_registry_v2`` directly, so v1 → v2 mutations fail loudly
+    rather than silently overwriting the v1 file.
+    """
+    try:
+        return load_registry_v2()
+    except RegistrySchemaError:
+        return {"projects": {}, "schema_version": REGISTRY_SCHEMA_VERSION_V2}
+
+
+def get_project_v2(project_id: str) -> dict | None:
+    """Look up a v2 project entry by its project_id (ULID)."""
+    registry = _load_registry_v2_or_empty()
+    return registry["projects"].get(project_id)  # type: ignore[no-any-return]
+
+
+def find_projects_by_name_v2(name: str) -> list[tuple[str, dict]]:
+    """Return every v2 project whose ``name`` field matches ``name``.
+
+    Returns a list because v2 allows duplicate names — id is the unique key.
+    """
+    registry = _load_registry_v2_or_empty()
+    out: list[tuple[str, dict]] = []
+    for pid, entry in registry["projects"].items():
+        if entry.get("name") == name:
+            out.append((pid, entry))
+    return out
+
+
+def resolve_v2_from_path(path: Path) -> tuple[str, dict] | None:
+    """Walk up ``path`` and return (project_id, entry) for the matching v2 project.
+
+    Mirrors v1 ``resolve_project`` but on the id-keyed v2 registry.
+    """
+    registry = _load_registry_v2_or_empty()
+    path = path.resolve()
+    for pid, entry in registry["projects"].items():
+        for repo in entry.get("repo_paths", []):
+            repo_resolved = Path(repo).resolve()
+            if path == repo_resolved or repo_resolved in path.parents:
+                return pid, entry
+    return None
+
+
+def register_project_v2(
+    name: str,
+    repo_paths: list[Path],
+    *,
+    mode: str = REPO_CONFIG_MODE_LOCAL,
+    project_id: str | None = None,
+    server_url: str | None = None,
+) -> tuple[str, Path]:
+    """Add a v2 project to the registry and create its id-keyed store directory.
+
+    Args:
+        name: Display name (need not be unique).
+        repo_paths: List of associated repo paths.
+        mode: ``"local"`` (CLI-minted ULID) or ``"cloud"`` (server-minted).
+        project_id: ULID to use; minted via ``generate_ulid()`` when omitted.
+        server_url: Required when mode == "cloud".
+
+    Returns:
+        Tuple of (project_id, store_path).
+
+    Raises:
+        ValueError: If mode/server_url combination is invalid, or if the
+            project_id is already present in the registry.
+    """
+    if mode not in _VALID_MODES_V2:
+        raise ValueError(f"Invalid mode {mode!r}; expected one of {_VALID_MODES_V2}.")
+    if mode == REPO_CONFIG_MODE_CLOUD and not server_url:
+        raise ValueError("Cloud-mode v2 registration requires a server_url.")
+
+    pid = project_id or generate_ulid()
+
+    with _registry_lock():
+        registry = load_registry_v2()
+        if pid in registry["projects"]:
+            raise ValueError(f"Project id {pid!r} is already registered.")
+        entry: dict = {
+            "name": name,
+            "mode": mode,
+            "repo_paths": [str(p.resolve()) for p in repo_paths],
+        }
+        if mode == REPO_CONFIG_MODE_CLOUD:
+            entry["server_url"] = server_url
+        registry["projects"][pid] = entry
+
+        store_path = get_store_path_v2(pid)
+        store_path.mkdir(parents=True, exist_ok=True)
+        save_registry_v2(registry)
+    return pid, store_path
+
+
+def add_repo_v2(project_id: str, repo_path: Path) -> None:
+    """Add a repo path to an existing v2 project.
+
+    Raises:
+        KeyError: If the project_id is not in the v2 registry.
+    """
+    with _registry_lock():
+        registry = load_registry_v2()
+        if project_id not in registry["projects"]:
+            raise KeyError(f"Project id {project_id!r} not found in v2 registry.")
+        resolved = str(repo_path.resolve())
+        paths = registry["projects"][project_id].setdefault("repo_paths", [])
+        if resolved not in paths:
+            paths.append(resolved)
+        save_registry_v2(registry)
+
+
+def rename_project_id_v2(
+    old_id: str,
+    new_id: str,
+    *,
+    mode: str | None = None,
+    server_url: str | None = None,
+    rename_store: bool = True,
+) -> Path:
+    """Re-key a v2 project entry from ``old_id`` to ``new_id``.
+
+    Used by ``nauro link --cloud`` to promote a local-only project to a
+    cloud project: the store directory is renamed to the new id-keyed path
+    and the registry entry is moved to the new key, preserving repo_paths.
+
+    Args:
+        old_id: Current project_id to migrate from.
+        new_id: New project_id (typically a server-minted cloud ULID).
+        mode: New mode value (e.g. ``"cloud"``); leave None to retain.
+        server_url: New server_url; required if the resulting mode is cloud.
+        rename_store: When True (default), also move the on-disk store
+            directory from ``<projects>/old_id/`` to ``<projects>/new_id/``.
+
+    Returns:
+        Path to the renamed store directory.
+
+    Raises:
+        KeyError: If ``old_id`` is not in the v2 registry.
+        ValueError: If ``new_id`` is already registered, or if the
+            resulting mode/server_url combination is invalid.
+    """
+    with _registry_lock():
+        registry = load_registry_v2()
+        if old_id not in registry["projects"]:
+            raise KeyError(f"Project id {old_id!r} not found in v2 registry.")
+        if new_id != old_id and new_id in registry["projects"]:
+            raise ValueError(f"Project id {new_id!r} is already registered.")
+
+        entry = dict(registry["projects"].pop(old_id))
+        if mode is not None:
+            if mode not in _VALID_MODES_V2:
+                raise ValueError(f"Invalid mode {mode!r}; expected one of {_VALID_MODES_V2}.")
+            entry["mode"] = mode
+        if server_url is not None:
+            entry["server_url"] = server_url
+        if entry.get("mode") == REPO_CONFIG_MODE_CLOUD and not entry.get("server_url"):
+            raise ValueError("Cloud-mode entry requires a server_url.")
+        if entry.get("mode") == REPO_CONFIG_MODE_LOCAL:
+            entry.pop("server_url", None)
+        registry["projects"][new_id] = entry
+
+        old_store = get_store_path_v2(old_id)
+        new_store = get_store_path_v2(new_id)
+        if rename_store and old_id != new_id and old_store.exists():
+            if new_store.exists():
+                raise ValueError(f"Cannot rename store: destination already exists at {new_store}.")
+            shutil.move(str(old_store), str(new_store))
+        new_store.mkdir(parents=True, exist_ok=True)
+        save_registry_v2(registry)
+    return new_store

--- a/packages/nauro/src/nauro/store/registry.py
+++ b/packages/nauro/src/nauro/store/registry.py
@@ -20,10 +20,16 @@ from nauro.constants import (
     NAURO_HOME_ENV,
     PROJECTS_DIR,
     REGISTRY_FILENAME,
+    REGISTRY_SCHEMA_VERSION_V1,
+    REGISTRY_SCHEMA_VERSION_V2,
     SCHEMA_VERSION,
 )
 
 logger = logging.getLogger("nauro.registry")
+
+
+class RegistrySchemaError(Exception):
+    """Raised when registry.json advertises a schema_version this build cannot read."""
 
 
 @contextmanager
@@ -72,6 +78,76 @@ def save_registry(data: dict) -> None:
         data: Full registry dict to persist.
     """
     data.setdefault("schema_version", SCHEMA_VERSION)
+    rf = _registry_file()
+    rf.parent.mkdir(parents=True, exist_ok=True)
+    tmp = rf.with_suffix(".tmp")
+    tmp.write_text(json.dumps(data, indent=2) + "\n")
+    os.replace(tmp, rf)
+
+
+# ── v2 registry (id-keyed) ───────────────────────────────────────────────────
+#
+# v2 introduces a project_id (ULID) primary key and tracks ``mode`` plus an
+# optional ``server_url`` per project. v2 is read/written by the new
+# project-scoped commands shipping in 2c-B; existing v1 commands continue to
+# use load_registry/save_registry above.
+#
+# v2 is a strict loader: it refuses to read a v1 registry and tells the user
+# to run the one-time manual migration documented in 2c-B's release notes.
+# Auto-migration is intentionally out of scope — solo-founder scale, single
+# existing project, three shell commands beat code that needs idempotency,
+# directory renames, and adopt-existing-config fallbacks.
+
+
+def load_registry_v2() -> dict:
+    """Read registry.json under v2 semantics. Refuses v1.
+
+    Returns:
+        Registry dict shaped as ``{"projects": {<id>: {...}}, "schema_version": 2}``.
+        When the file does not exist, returns the empty v2 shape.
+
+    Raises:
+        RegistrySchemaError: If the on-disk registry is at schema_version 1 (a
+            one-time manual migration is required) or any other unknown
+            version.
+    """
+    rf = _registry_file()
+    if not rf.exists():
+        return {"projects": {}, "schema_version": REGISTRY_SCHEMA_VERSION_V2}
+
+    try:
+        data = json.loads(rf.read_text())
+    except json.JSONDecodeError:
+        logger.warning("registry.json is corrupt — starting with empty v2 registry")
+        return {"projects": {}, "schema_version": REGISTRY_SCHEMA_VERSION_V2}
+
+    version = data.get("schema_version", REGISTRY_SCHEMA_VERSION_V1)
+    if version == REGISTRY_SCHEMA_VERSION_V1:
+        raise RegistrySchemaError(
+            "registry is at schema_version 1; please run the one-time manual "
+            "migration documented in the release notes before continuing."
+        )
+    if version != REGISTRY_SCHEMA_VERSION_V2:
+        raise RegistrySchemaError(
+            f"Unknown registry schema_version={version!r} at {rf}. "
+            f"Upgrade nauro to a version that supports this schema."
+        )
+    return data  # type: ignore[no-any-return]
+
+
+def save_registry_v2(data: dict) -> None:
+    """Write a v2 registry atomically. Stamps schema_version=2 on the data.
+
+    Raises:
+        RegistrySchemaError: If ``data["schema_version"]`` is set to anything
+            other than 2.
+    """
+    data.setdefault("schema_version", REGISTRY_SCHEMA_VERSION_V2)
+    if data["schema_version"] != REGISTRY_SCHEMA_VERSION_V2:
+        raise RegistrySchemaError(
+            f"save_registry_v2 refuses to write schema_version="
+            f"{data['schema_version']!r}; expected {REGISTRY_SCHEMA_VERSION_V2}."
+        )
     rf = _registry_file()
     rf.parent.mkdir(parents=True, exist_ok=True)
     tmp = rf.with_suffix(".tmp")

--- a/packages/nauro/src/nauro/store/repo_config.py
+++ b/packages/nauro/src/nauro/store/repo_config.py
@@ -1,0 +1,147 @@
+"""Repo-local Nauro config — ``<repo>/.nauro/config.json``.
+
+Each repo associated with Nauro carries a small JSON file that identifies the
+project the repo belongs to. Two modes are supported:
+
+- ``local``: ``{"mode": "local", "id": <ulid>, "name": <str>, "schema_version": 1}``
+- ``cloud``: ``{"mode": "cloud", "id": <ulid>, "name": <str>, "server_url": <str>,
+  "schema_version": 1}``
+
+The ``id`` field carries either a CLI-minted local ULID or a server-minted cloud
+ULID; never both, never neither. The loader rejects unknown ``schema_version``
+values with a clear error so old clients fail loudly when faced with future
+schemas.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import secrets
+import time
+from pathlib import Path
+
+from nauro.constants import (
+    REPO_CONFIG_DIR,
+    REPO_CONFIG_FILENAME,
+    REPO_CONFIG_MODE_CLOUD,
+    REPO_CONFIG_MODE_LOCAL,
+    REPO_CONFIG_SCHEMA_VERSION,
+)
+
+logger = logging.getLogger("nauro.repo_config")
+
+_VALID_MODES = (REPO_CONFIG_MODE_LOCAL, REPO_CONFIG_MODE_CLOUD)
+_CROCKFORD = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+
+
+class RepoConfigSchemaError(Exception):
+    """Raised when a ``.nauro/config.json`` has an unknown schema_version or shape."""
+
+
+def generate_ulid() -> str:
+    """Generate a 26-char Crockford-base32 ULID.
+
+    The format is the standard ULID: 48 bits of millisecond timestamp followed
+    by 80 bits of randomness. We mint these CLI-side for local-only projects;
+    cloud project IDs are minted by the server and arrive over the wire.
+    """
+    timestamp_ms = int(time.time() * 1000) & ((1 << 48) - 1)
+    randomness = int.from_bytes(secrets.token_bytes(10), "big")
+    value = (timestamp_ms << 80) | randomness
+    out = []
+    for _ in range(26):
+        out.append(_CROCKFORD[value & 0x1F])
+        value >>= 5
+    return "".join(reversed(out))
+
+
+def repo_config_path(repo_root: Path) -> Path:
+    """Return the path where a repo's config file lives."""
+    return repo_root / REPO_CONFIG_DIR / REPO_CONFIG_FILENAME
+
+
+def _validate(data: dict) -> None:
+    version = data.get("schema_version")
+    if version != REPO_CONFIG_SCHEMA_VERSION:
+        raise RepoConfigSchemaError(
+            f"Unknown repo config schema_version={version!r}. "
+            f"This nauro build understands schema_version={REPO_CONFIG_SCHEMA_VERSION}. "
+            f"Upgrade nauro to a version that supports this schema."
+        )
+
+    mode = data.get("mode")
+    if mode not in _VALID_MODES:
+        raise RepoConfigSchemaError(
+            f"Invalid repo config mode={mode!r}; expected one of {_VALID_MODES}."
+        )
+
+    if not isinstance(data.get("id"), str) or not data["id"]:
+        raise RepoConfigSchemaError("Repo config is missing required field 'id'.")
+    if not isinstance(data.get("name"), str) or not data["name"]:
+        raise RepoConfigSchemaError("Repo config is missing required field 'name'.")
+
+    if mode == REPO_CONFIG_MODE_CLOUD:
+        if not isinstance(data.get("server_url"), str) or not data["server_url"]:
+            raise RepoConfigSchemaError(
+                "Cloud-mode repo config is missing required field 'server_url'."
+            )
+
+
+def load_repo_config(repo_root: Path) -> dict:
+    """Read the repo config from ``<repo_root>/.nauro/config.json``.
+
+    Raises:
+        FileNotFoundError: When the config file does not exist.
+        RepoConfigSchemaError: When the file is missing required fields or
+            advertises an unknown schema_version.
+        json.JSONDecodeError: When the file is not valid JSON.
+    """
+    path = repo_config_path(repo_root)
+    text = path.read_text()
+    data = json.loads(text)
+    if not isinstance(data, dict):
+        raise RepoConfigSchemaError(f"Repo config at {path} is not a JSON object.")
+    _validate(data)
+    return data
+
+
+def save_repo_config(repo_root: Path, data: dict) -> Path:
+    """Write the repo config atomically. Returns the path written.
+
+    The data dict is validated before write; an invalid shape raises
+    RepoConfigSchemaError without touching disk.
+    """
+    data.setdefault("schema_version", REPO_CONFIG_SCHEMA_VERSION)
+    _validate(data)
+
+    path = repo_config_path(repo_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(data, indent=2) + "\n")
+    os.replace(tmp, path)
+    return path
+
+
+def find_repo_config(start: Path | None = None) -> Path | None:
+    """Walk up from ``start`` looking for ``.nauro/config.json``.
+
+    Mirrors how git locates ``.git`` from anywhere inside a working tree.
+    Stops at the filesystem root and returns ``None`` if no config is found.
+
+    Args:
+        start: Directory to start walking from. Defaults to the current
+            working directory.
+
+    Returns:
+        The path of the config file when found, or ``None``.
+    """
+    current = (start if start is not None else Path.cwd()).resolve()
+    while True:
+        candidate = current / REPO_CONFIG_DIR / REPO_CONFIG_FILENAME
+        if candidate.is_file():
+            return candidate
+        if current.parent == current:
+            return None
+        current = current.parent

--- a/packages/nauro/src/nauro/sync/cloud_projects.py
+++ b/packages/nauro/src/nauro/sync/cloud_projects.py
@@ -1,0 +1,175 @@
+"""HTTP client for the remote MCP server's project endpoints.
+
+Wraps ``POST /projects`` and ``GET /projects`` on the Nauro cloud control
+plane. Both endpoints require an OAuth bearer token; the token is loaded
+from ``~/.nauro/config.json`` under the ``auth.access_token`` key — the same
+slot that ``nauro auth login`` writes.
+
+The server URL resolution mirrors ``nauro.cli.commands.auth``: ``NAURO_API_URL``
+env var first, then ``api_url`` in user config, then the public default.
+
+Failure modes are collapsed into a single ``CloudProjectError`` with a
+human-readable message; both callers (``nauro init --cloud`` and ``nauro attach``,
+landing in 2c-B) just render the message.
+
+``created_at`` is passed through verbatim as an ISO 8601 string. No date
+parsing — that just creates timezone-normalization fragility for no caller
+benefit.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TypedDict
+
+import httpx
+
+from nauro.cli.commands.auth import DEFAULT_API_URL
+from nauro.store.config import load_config
+
+_DEFAULT_TIMEOUT = 15.0
+
+
+class ProjectView(TypedDict):
+    """Server-side project descriptor returned by /projects endpoints."""
+
+    project_id: str
+    name: str
+    role: str
+    created_at: str
+
+
+class CloudProjectError(Exception):
+    """Raised for any failure invoking the cloud project endpoints.
+
+    The message is the user-facing rendering. Callers should print it and
+    exit; no recovery is attempted at this layer.
+    """
+
+
+def _resolve_api_url() -> str:
+    """Resolve the remote MCP server base URL.
+
+    Precedence: NAURO_API_URL env var → ``api_url`` config key → public default.
+    Mirrors the resolution in ``nauro.cli.commands.auth._resolve_auth_config``
+    so this client and the auth flow agree about which server is in play.
+    """
+    env_url = os.environ.get("NAURO_API_URL")
+    if env_url:
+        return env_url
+    config_url = str(load_config().get("api_url") or "")
+    return config_url or DEFAULT_API_URL
+
+
+def _load_access_token() -> str:
+    """Read the OAuth bearer token written by ``nauro auth login``.
+
+    Raises:
+        CloudProjectError: If no token is available.
+    """
+    auth = load_config().get("auth") or {}
+    token = auth.get("access_token") if isinstance(auth, dict) else None
+    if not token:
+        raise CloudProjectError(
+            "Not authenticated. Run 'nauro auth login' before targeting the cloud."
+        )
+    return str(token)
+
+
+def _parse_project(raw: object) -> ProjectView:
+    """Coerce a server-returned object into a ProjectView.
+
+    Pass-through ISO 8601 string for ``created_at`` — no date parsing.
+    """
+    if not isinstance(raw, dict):
+        raise CloudProjectError(f"Unexpected project payload from server (not an object): {raw!r}")
+    try:
+        return ProjectView(
+            project_id=str(raw["project_id"]),
+            name=str(raw["name"]),
+            role=str(raw["role"]),
+            created_at=str(raw["created_at"]),
+        )
+    except KeyError as exc:
+        raise CloudProjectError(
+            f"Project payload from server is missing required field: {exc.args[0]}"
+        ) from exc
+
+
+def _request(method: str, path: str, *, json_body: dict | None = None) -> httpx.Response:
+    """Issue an authenticated request, translating transport failures."""
+    api_url = _resolve_api_url().rstrip("/")
+    url = f"{api_url}{path}"
+    headers = {
+        "Authorization": f"Bearer {_load_access_token()}",
+        "Accept": "application/json",
+    }
+    try:
+        response = httpx.request(
+            method, url, headers=headers, json=json_body, timeout=_DEFAULT_TIMEOUT
+        )
+    except httpx.HTTPError as exc:
+        raise CloudProjectError(f"Network error contacting {url}: {exc}") from exc
+
+    if response.status_code in (401, 403):
+        raise CloudProjectError(
+            f"Authentication failed ({response.status_code}). Run 'nauro auth login' and try again."
+        )
+    if response.status_code >= 500:
+        raise CloudProjectError(
+            f"Server error ({response.status_code}) from {url}. "
+            f"The cloud control plane may be unavailable; try again shortly."
+        )
+    if response.status_code >= 400:
+        # 4xx other than auth — surface server message verbatim where possible.
+        try:
+            detail = response.json().get("detail") or response.text
+        except (ValueError, AttributeError):
+            detail = response.text
+        raise CloudProjectError(f"Request failed ({response.status_code}) from {url}: {detail}")
+    return response
+
+
+def create_project(name: str) -> ProjectView:
+    """Create a new cloud-scoped project.
+
+    Args:
+        name: Human-readable project name. Server is the source of truth for
+            naming rules; this client passes the value through unchanged.
+
+    Returns:
+        ProjectView for the freshly minted project, including the
+        server-assigned ``project_id`` (ULID).
+    """
+    response = _request("POST", "/projects", json_body={"name": name})
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise CloudProjectError(
+            f"Server returned non-JSON for POST /projects: {response.text!r}"
+        ) from exc
+    return _parse_project(payload)
+
+
+def list_projects() -> list[ProjectView]:
+    """List every cloud-scoped project visible to the current OAuth identity.
+
+    Returns:
+        Project list in server order. May be empty.
+    """
+    response = _request("GET", "/projects")
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise CloudProjectError(
+            f"Server returned non-JSON for GET /projects: {response.text!r}"
+        ) from exc
+
+    if isinstance(payload, dict) and "projects" in payload:
+        items = payload["projects"]
+    else:
+        items = payload
+
+    if not isinstance(items, list):
+        raise CloudProjectError(f"Unexpected /projects response shape (not a list): {items!r}")
+    return [_parse_project(item) for item in items]

--- a/packages/nauro/src/nauro/sync/config.py
+++ b/packages/nauro/src/nauro/sync/config.py
@@ -22,12 +22,15 @@ class AuthRequiredError(Exception):
     """Raised when a sync operation requires auth but sanitized_sub is missing."""
 
 
-def s3_prefix(user_key: str, project_name: str) -> str:
+def s3_prefix(user_key: str, project_id: str) -> str:
     """Build the S3 key prefix for a project.
 
-    user_key is either user_id (preferred) or sanitized_sub (fallback).
+    Args:
+        user_key: Either user_id (preferred) or sanitized_sub (fallback).
+        project_id: The v2 project_id (ULID). Legacy callers pass a
+            project name; the prefix layout is unchanged either way.
     """
-    return f"users/{user_key}/projects/{project_name}/"
+    return f"users/{user_key}/projects/{project_id}/"
 
 
 def require_auth(config: SyncConfig) -> str:

--- a/packages/nauro/src/nauro/templates/agents_md.py
+++ b/packages/nauro/src/nauro/templates/agents_md.py
@@ -85,22 +85,38 @@ def generate_agents_md(
     return "\n".join(parts)
 
 
-def regenerate_agents_md_for_project(project_name: str, store_path: Path) -> list[Path]:
+def regenerate_agents_md_for_project(project_key: str, store_path: Path) -> list[Path]:
     """Regenerate AGENTS.md in all repos associated with a project.
 
     Args:
-        project_name: Name of the Nauro project.
+        project_key: Either a v2 project_id (ULID) or a v1 project name.
+            v2 takes priority — the v1 name lookup is the legacy fallback.
         store_path: Path to the project store directory.
 
     Returns:
         List of repo paths where AGENTS.md was updated.
     """
     from nauro.mcp.payloads import build_l0_payload
-    from nauro.store.registry import load_registry
+    from nauro.store.registry import (
+        RegistrySchemaError,
+        get_project_v2,
+        load_registry,
+    )
 
-    registry = load_registry()
-    entry = registry["projects"].get(project_name, {})
-    repo_paths = entry.get("repo_paths", [])
+    repo_paths: list[str] = []
+    display_name = project_key
+
+    try:
+        v2_entry = get_project_v2(project_key)
+    except RegistrySchemaError:
+        v2_entry = None
+    if v2_entry is not None:
+        repo_paths = list(v2_entry.get("repo_paths", []))
+        display_name = v2_entry.get("name", project_key)
+    else:
+        registry = load_registry()
+        entry = registry["projects"].get(project_key, {})
+        repo_paths = list(entry.get("repo_paths", []))
 
     l0_payload = build_l0_payload(store_path)
     updated = []
@@ -111,7 +127,7 @@ def regenerate_agents_md_for_project(project_name: str, store_path: Path) -> lis
             continue
         agents_md_path = repo_path / AGENTS_MD
         manual = parse_manual_section(agents_md_path)
-        content = generate_agents_md(project_name, l0_payload, manual_section=manual)
+        content = generate_agents_md(display_name, l0_payload, manual_section=manual)
         agents_md_path.write_text(content)
         updated.append(repo_path)
 

--- a/packages/nauro/tests/test_attach.py
+++ b/packages/nauro/tests/test_attach.py
@@ -1,0 +1,89 @@
+"""Tests for `nauro attach <project_id>`.
+
+Membership is verified against ``GET /projects`` before any local state
+is written; the non-member error path explicitly asserts no registry
+side effects to keep the failure mode safe.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import httpx
+from typer.testing import CliRunner
+
+from nauro.cli.main import app
+from nauro.store import registry
+from nauro.store.config import save_config
+from nauro.store.repo_config import load_repo_config
+from nauro.sync import cloud_projects
+
+runner = CliRunner()
+
+EXAMPLE_PID = "01KQ6AZGNA0B3QBF67NBXP3S45"
+
+
+def _seed_token(monkeypatch, tmp_path):
+    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
+    save_config({"auth": {"access_token": "test-token", "sub": "auth0|test"}})
+
+
+def _list_response(projects):
+    def handler(method, url, **kwargs):
+        return httpx.Response(200, json=projects, request=httpx.Request(method, url))
+
+    return handler
+
+
+def test_attach_happy_path(tmp_path, monkeypatch):
+    """A member of the cloud project gets a v2 entry + cloud-mode repo config."""
+    _seed_token(monkeypatch, tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("NAURO_API_URL", "https://example.test")
+
+    handler = _list_response(
+        [
+            {
+                "project_id": EXAMPLE_PID,
+                "name": "team-proj",
+                "role": "viewer",
+                "created_at": "2026-04-27T00:00:00Z",
+            }
+        ]
+    )
+
+    with patch.object(cloud_projects.httpx, "request", side_effect=handler):
+        result = runner.invoke(app, ["attach", EXAMPLE_PID])
+
+    assert result.exit_code == 0, result.output
+    entry = registry.get_project_v2(EXAMPLE_PID)
+    assert entry is not None
+    assert entry["mode"] == "cloud"
+    assert entry["name"] == "team-proj"
+    assert str(tmp_path.resolve()) in entry["repo_paths"]
+
+    cfg = load_repo_config(tmp_path)
+    assert cfg["mode"] == "cloud"
+    assert cfg["id"] == EXAMPLE_PID
+    assert cfg["name"] == "team-proj"
+
+    store_path = tmp_path / "nauro_home" / "projects" / EXAMPLE_PID
+    assert store_path.is_dir()
+
+
+def test_attach_non_member_writes_nothing(tmp_path, monkeypatch):
+    """When the user is not a member, the registry and config are untouched."""
+    _seed_token(monkeypatch, tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("NAURO_API_URL", "https://example.test")
+
+    handler = _list_response([])
+
+    with patch.object(cloud_projects.httpx, "request", side_effect=handler):
+        result = runner.invoke(app, ["attach", EXAMPLE_PID])
+
+    assert result.exit_code == 1
+    assert "not found among your cloud projects" in result.output
+    assert registry.get_project_v2(EXAMPLE_PID) is None
+    assert not (tmp_path / ".nauro" / "config.json").exists()
+    assert not (tmp_path / "nauro_home" / "projects" / EXAMPLE_PID).exists()

--- a/packages/nauro/tests/test_cli.py
+++ b/packages/nauro/tests/test_cli.py
@@ -20,7 +20,9 @@ def test_app_shows_help():
 
 
 def test_init_command(tmp_path: Path, monkeypatch):
-    """nauro init should create a project store."""
+    """nauro init should create an id-keyed project store."""
+    from nauro.store.registry import find_projects_by_name_v2
+
     monkeypatch.setenv("NAURO_HOME", str(tmp_path))
     monkeypatch.chdir(tmp_path)
 
@@ -28,8 +30,12 @@ def test_init_command(tmp_path: Path, monkeypatch):
     assert result.exit_code == 0
     assert "Initialized project" in result.output
     assert "Next:" in result.output
-    assert (tmp_path / "projects" / "testproj" / "project.md").exists()
-    assert (tmp_path / "projects" / "testproj" / "decisions" / "001-initial-setup.md").exists()
+
+    matches = find_projects_by_name_v2("testproj")
+    assert len(matches) == 1
+    pid, _entry = matches[0]
+    assert (tmp_path / "projects" / pid / "project.md").exists()
+    assert (tmp_path / "projects" / pid / "decisions" / "001-initial-setup.md").exists()
 
 
 def test_note_command(tmp_path: Path, monkeypatch):

--- a/packages/nauro/tests/test_cloud_projects.py
+++ b/packages/nauro/tests/test_cloud_projects.py
@@ -1,0 +1,242 @@
+"""Tests for nauro.sync.cloud_projects HTTP client."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from nauro.store.config import save_config
+from nauro.sync import cloud_projects
+from nauro.sync.cloud_projects import (
+    CloudProjectError,
+    create_project,
+    list_projects,
+)
+
+
+def _patch_home(monkeypatch, tmp_path):
+    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
+
+
+def _seed_token(monkeypatch, tmp_path, token: str = "test-token") -> None:
+    """Write a config.json with an OAuth access token, mirroring `nauro auth login`."""
+    _patch_home(monkeypatch, tmp_path)
+    save_config({"auth": {"access_token": token, "sub": "auth0|test"}})
+
+
+def _stub_request(handler):
+    """Patch httpx.request inside cloud_projects with `handler(method, url, **kwargs)`."""
+    return patch.object(cloud_projects.httpx, "request", side_effect=handler)
+
+
+# ── create_project ────────────────────────────────────────────────────────────
+
+
+def test_create_project_success_sends_bearer_and_body(tmp_path, monkeypatch):
+    """POST /projects with a JSON body and Authorization header; parses response."""
+    _seed_token(monkeypatch, tmp_path)
+    monkeypatch.setenv("NAURO_API_URL", "https://example.test")
+
+    captured: dict = {}
+
+    def handler(method, url, **kwargs):
+        captured["method"] = method
+        captured["url"] = url
+        captured["headers"] = kwargs.get("headers")
+        captured["json"] = kwargs.get("json")
+        return httpx.Response(
+            201,
+            json={
+                "project_id": "01KQ6AZGNA0B3QBF67NBXP3S45",
+                "name": "demo",
+                "role": "owner",
+                "created_at": "2026-04-27T10:11:12Z",
+            },
+            request=httpx.Request(method, url),
+        )
+
+    with _stub_request(handler):
+        view = create_project("demo")
+
+    assert captured["method"] == "POST"
+    assert captured["url"] == "https://example.test/projects"
+    assert captured["json"] == {"name": "demo"}
+    assert captured["headers"]["Authorization"] == "Bearer test-token"
+    assert view == {
+        "project_id": "01KQ6AZGNA0B3QBF67NBXP3S45",
+        "name": "demo",
+        "role": "owner",
+        "created_at": "2026-04-27T10:11:12Z",
+    }
+
+
+def test_create_project_auth_failure_renders_message(tmp_path, monkeypatch):
+    """A 401 raises CloudProjectError with a clear, user-renderable message."""
+    _seed_token(monkeypatch, tmp_path)
+    monkeypatch.setenv("NAURO_API_URL", "https://example.test")
+
+    def handler(method, url, **kwargs):
+        return httpx.Response(401, json={"detail": "expired"}, request=httpx.Request(method, url))
+
+    with _stub_request(handler):
+        with pytest.raises(CloudProjectError) as exc:
+            create_project("demo")
+    msg = str(exc.value)
+    assert "401" in msg
+    assert "nauro auth login" in msg
+
+
+def test_create_project_server_error_renders_message(tmp_path, monkeypatch):
+    """A 5xx raises CloudProjectError noting the server failure."""
+    _seed_token(monkeypatch, tmp_path)
+    monkeypatch.setenv("NAURO_API_URL", "https://example.test")
+
+    def handler(method, url, **kwargs):
+        return httpx.Response(503, request=httpx.Request(method, url))
+
+    with _stub_request(handler):
+        with pytest.raises(CloudProjectError) as exc:
+            create_project("demo")
+    assert "503" in str(exc.value)
+
+
+def test_create_project_network_error_renders_message(tmp_path, monkeypatch):
+    """Transport-level failures surface as CloudProjectError, not raw httpx errors."""
+    _seed_token(monkeypatch, tmp_path)
+    monkeypatch.setenv("NAURO_API_URL", "https://example.test")
+
+    def handler(method, url, **kwargs):
+        raise httpx.ConnectError("dns failure")
+
+    with _stub_request(handler):
+        with pytest.raises(CloudProjectError) as exc:
+            create_project("demo")
+    assert "Network error" in str(exc.value)
+
+
+def test_no_token_raises_before_request(tmp_path, monkeypatch):
+    """Without a stored token, the client refuses to issue a request."""
+    _patch_home(monkeypatch, tmp_path)
+    # No save_config call → no auth section.
+    with pytest.raises(CloudProjectError) as exc:
+        create_project("demo")
+    assert "nauro auth login" in str(exc.value)
+
+
+# ── list_projects ─────────────────────────────────────────────────────────────
+
+
+def test_list_projects_empty(tmp_path, monkeypatch):
+    """GET /projects with no projects → empty list."""
+    _seed_token(monkeypatch, tmp_path)
+    monkeypatch.setenv("NAURO_API_URL", "https://example.test")
+
+    def handler(method, url, **kwargs):
+        return httpx.Response(200, json=[], request=httpx.Request(method, url))
+
+    with _stub_request(handler):
+        result = list_projects()
+    assert result == []
+
+
+def test_list_projects_preserves_server_order(tmp_path, monkeypatch):
+    """Two projects come back in the order the server returned them."""
+    _seed_token(monkeypatch, tmp_path)
+    monkeypatch.setenv("NAURO_API_URL", "https://example.test")
+
+    server_payload = [
+        {
+            "project_id": "01KQ6AZGNA0B3QBF67NBXP3S45",
+            "name": "first",
+            "role": "owner",
+            "created_at": "2026-04-01T00:00:00Z",
+        },
+        {
+            "project_id": "01KQ7BZGZA0B3QBF67NBXP3S99",
+            "name": "second",
+            "role": "viewer",
+            "created_at": "2026-04-15T00:00:00Z",
+        },
+    ]
+
+    def handler(method, url, **kwargs):
+        assert method == "GET"
+        assert url == "https://example.test/projects"
+        return httpx.Response(200, json=server_payload, request=httpx.Request(method, url))
+
+    with _stub_request(handler):
+        result = list_projects()
+
+    assert [p["project_id"] for p in result] == [
+        "01KQ6AZGNA0B3QBF67NBXP3S45",
+        "01KQ7BZGZA0B3QBF67NBXP3S99",
+    ]
+    assert result[0]["name"] == "first"
+    assert result[1]["role"] == "viewer"
+
+
+def test_list_projects_accepts_wrapped_envelope(tmp_path, monkeypatch):
+    """Server may wrap as {"projects": [...]}; client tolerates either shape."""
+    _seed_token(monkeypatch, tmp_path)
+    monkeypatch.setenv("NAURO_API_URL", "https://example.test")
+
+    def handler(method, url, **kwargs):
+        return httpx.Response(
+            200,
+            json={
+                "projects": [
+                    {
+                        "project_id": "01KQ6AZGNA0B3QBF67NBXP3S45",
+                        "name": "wrapped",
+                        "role": "owner",
+                        "created_at": "2026-04-27T00:00:00Z",
+                    }
+                ]
+            },
+            request=httpx.Request(method, url),
+        )
+
+    with _stub_request(handler):
+        result = list_projects()
+    assert len(result) == 1
+    assert result[0]["name"] == "wrapped"
+
+
+def test_default_api_url_used_when_env_absent(tmp_path, monkeypatch):
+    """With no NAURO_API_URL and no config api_url, the public default is used."""
+    _seed_token(monkeypatch, tmp_path)
+    monkeypatch.delenv("NAURO_API_URL", raising=False)
+
+    captured: dict = {}
+
+    def handler(method, url, **kwargs):
+        captured["url"] = url
+        return httpx.Response(200, json=[], request=httpx.Request(method, url))
+
+    with _stub_request(handler):
+        list_projects()
+
+    # DEFAULT_API_URL == https://mcp.nauro.ai (mirrored from auth.py)
+    assert captured["url"] == "https://mcp.nauro.ai/projects"
+
+
+def test_malformed_project_payload_raises(tmp_path, monkeypatch):
+    """A response missing required fields surfaces as CloudProjectError."""
+    _seed_token(monkeypatch, tmp_path)
+    monkeypatch.setenv("NAURO_API_URL", "https://example.test")
+
+    def handler(method, url, **kwargs):
+        return httpx.Response(
+            201,
+            content=json.dumps({"project_id": "x", "name": "y"}).encode(),
+            headers={"Content-Type": "application/json"},
+            request=httpx.Request(method, url),
+        )
+
+    with _stub_request(handler):
+        with pytest.raises(CloudProjectError) as exc:
+            create_project("demo")
+    assert "missing required field" in str(exc.value)

--- a/packages/nauro/tests/test_init_cloud.py
+++ b/packages/nauro/tests/test_init_cloud.py
@@ -1,0 +1,184 @@
+"""Tests for `nauro init --cloud` and the local/cloud split.
+
+Local mode: no network, mints a local ULID, writes v2 registry +
+``.nauro/config.json`` in cwd.
+
+Cloud mode: calls the remote MCP server's ``POST /projects`` (mocked),
+uses the server-minted project_id for the local store, writes the
+config in cloud mode.
+
+The cloud-mode add-repo error path is here too — adding a repo to a
+cloud-scoped project must point the user at ``nauro attach``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import httpx
+from typer.testing import CliRunner
+
+from nauro.cli.main import app
+from nauro.store import registry
+from nauro.store.repo_config import load_repo_config
+from nauro.sync import cloud_projects
+
+runner = CliRunner()
+
+
+def _patch_home(monkeypatch, tmp_path):
+    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
+
+
+def _seed_token(monkeypatch, tmp_path):
+    """Make cloud_projects believe the user is authenticated."""
+    from nauro.store.config import save_config
+
+    _patch_home(monkeypatch, tmp_path)
+    save_config({"auth": {"access_token": "test-token", "sub": "auth0|test"}})
+
+
+# ── local mode ────────────────────────────────────────────────────────────────
+
+
+def test_init_local_no_network(tmp_path, monkeypatch):
+    """`nauro init <name>` (no flag) must not contact the cloud."""
+    _patch_home(monkeypatch, tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    def explode(*_args, **_kwargs):
+        raise AssertionError("local init should not call httpx")
+
+    with patch.object(cloud_projects.httpx, "request", side_effect=explode):
+        result = runner.invoke(app, ["init", "localproj"])
+
+    assert result.exit_code == 0, result.output
+    matches = registry.find_projects_by_name_v2("localproj")
+    assert len(matches) == 1
+    pid, entry = matches[0]
+    assert entry["mode"] == "local"
+    assert "server_url" not in entry
+
+    cfg = load_repo_config(tmp_path)
+    assert cfg["mode"] == "local"
+    assert cfg["id"] == pid
+    assert cfg["name"] == "localproj"
+    assert (tmp_path / "nauro_home" / "projects" / pid / "project.md").exists()
+
+
+# ── cloud mode ────────────────────────────────────────────────────────────────
+
+
+def test_init_cloud_uses_server_minted_id(tmp_path, monkeypatch):
+    """`nauro init --cloud` mirrors the server's project_id locally."""
+    _seed_token(monkeypatch, tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("NAURO_API_URL", "https://example.test")
+
+    server_id = "01KQ6AZGNA0B3QBF67NBXP3S45"
+
+    def handler(method, url, **kwargs):
+        assert method == "POST"
+        assert url == "https://example.test/projects"
+        assert kwargs["json"] == {"name": "cloudproj"}
+        return httpx.Response(
+            201,
+            json={
+                "project_id": server_id,
+                "name": "cloudproj",
+                "role": "owner",
+                "created_at": "2026-04-27T00:00:00Z",
+            },
+            request=httpx.Request(method, url),
+        )
+
+    with patch.object(cloud_projects.httpx, "request", side_effect=handler):
+        result = runner.invoke(app, ["init", "--cloud", "cloudproj"])
+
+    assert result.exit_code == 0, result.output
+    entry = registry.get_project_v2(server_id)
+    assert entry is not None
+    assert entry["mode"] == "cloud"
+    assert entry["server_url"]
+    assert entry["name"] == "cloudproj"
+
+    cfg = load_repo_config(tmp_path)
+    assert cfg["mode"] == "cloud"
+    assert cfg["id"] == server_id
+    assert (tmp_path / "nauro_home" / "projects" / server_id / "project.md").exists()
+
+
+def test_init_cloud_renders_server_error(tmp_path, monkeypatch):
+    """A cloud failure surfaces the server message and writes nothing locally."""
+    _seed_token(monkeypatch, tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("NAURO_API_URL", "https://example.test")
+
+    def handler(method, url, **kwargs):
+        return httpx.Response(503, request=httpx.Request(method, url))
+
+    with patch.object(cloud_projects.httpx, "request", side_effect=handler):
+        result = runner.invoke(app, ["init", "--cloud", "cloudproj"])
+
+    assert result.exit_code == 1
+    assert "503" in result.output
+    assert registry.find_projects_by_name_v2("cloudproj") == []
+
+
+# ── add-repo against cloud-mode project ───────────────────────────────────────
+
+
+def test_add_repo_to_cloud_project_errors_with_attach_hint(tmp_path, monkeypatch):
+    """`nauro init <cloud-name> --add-repo …` must point users at attach."""
+    _seed_token(monkeypatch, tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("NAURO_API_URL", "https://example.test")
+    server_id = "01KQ6AZGNA0B3QBF67NBXP3S45"
+
+    def create_handler(method, url, **kwargs):
+        return httpx.Response(
+            201,
+            json={
+                "project_id": server_id,
+                "name": "cloudproj",
+                "role": "owner",
+                "created_at": "2026-04-27T00:00:00Z",
+            },
+            request=httpx.Request(method, url),
+        )
+
+    with patch.object(cloud_projects.httpx, "request", side_effect=create_handler):
+        first = runner.invoke(app, ["init", "--cloud", "cloudproj"])
+    assert first.exit_code == 0, first.output
+
+    other_repo = tmp_path / "other"
+    other_repo.mkdir()
+    result = runner.invoke(app, ["init", "cloudproj", "--add-repo", str(other_repo)])
+
+    assert result.exit_code == 1
+    assert "Cannot --add-repo to cloud-mode project 'cloudproj'" in result.output
+    assert f"nauro attach {server_id}" in result.output
+
+
+# ── add-repo to existing local project still works ────────────────────────────
+
+
+def test_add_repo_to_local_project_appends(tmp_path, monkeypatch):
+    """The legacy --add-repo flow still extends a local-mode project."""
+    _patch_home(monkeypatch, tmp_path)
+    monkeypatch.chdir(tmp_path)
+    repo1 = tmp_path / "repo1"
+    repo1.mkdir()
+    repo2 = tmp_path / "repo2"
+    repo2.mkdir()
+
+    runner.invoke(app, ["init", "extend", "--add-repo", str(repo1)])
+    result = runner.invoke(app, ["init", "extend", "--add-repo", str(repo2)])
+    assert result.exit_code == 0, result.output
+
+    matches = registry.find_projects_by_name_v2("extend")
+    assert len(matches) == 1
+    _pid, entry = matches[0]
+    paths = entry["repo_paths"]
+    assert str(repo1.resolve()) in paths
+    assert str(repo2.resolve()) in paths

--- a/packages/nauro/tests/test_link_cloud.py
+++ b/packages/nauro/tests/test_link_cloud.py
@@ -1,0 +1,126 @@
+"""Tests for `nauro link --cloud`.
+
+Three paths to cover:
+
+1. Happy path: local-mode repo gets re-keyed to a server-minted ULID.
+   The store directory is renamed and the registry entry is moved.
+2. Already-cloud repo: nothing to link → clear error, no-op.
+3. No-config repo: not a nauro repo → clear error.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import httpx
+from typer.testing import CliRunner
+
+from nauro.cli.main import app
+from nauro.store import registry
+from nauro.store.config import save_config
+from nauro.store.repo_config import load_repo_config, save_repo_config
+from nauro.sync import cloud_projects
+
+runner = CliRunner()
+
+CLOUD_PID = "01KQ6AZGNA0B3QBF67NBXP3S45"
+
+
+def _seed_token(monkeypatch, tmp_path):
+    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
+    save_config({"auth": {"access_token": "test-token", "sub": "auth0|test"}})
+
+
+def _create_response(name: str = "linkproj", project_id: str = CLOUD_PID):
+    def handler(method, url, **kwargs):
+        return httpx.Response(
+            201,
+            json={
+                "project_id": project_id,
+                "name": name,
+                "role": "owner",
+                "created_at": "2026-04-27T00:00:00Z",
+            },
+            request=httpx.Request(method, url),
+        )
+
+    return handler
+
+
+def test_link_cloud_promotes_local_project(tmp_path, monkeypatch):
+    """The store dir is moved to the cloud id and the registry entry re-keyed."""
+    _seed_token(monkeypatch, tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("NAURO_API_URL", "https://example.test")
+
+    # Stand up a local project from scratch
+    init_result = runner.invoke(app, ["init", "linkproj"])
+    assert init_result.exit_code == 0, init_result.output
+
+    matches = registry.find_projects_by_name_v2("linkproj")
+    assert len(matches) == 1
+    local_id, _entry = matches[0]
+    local_store = tmp_path / "nauro_home" / "projects" / local_id
+    assert local_store.is_dir()
+
+    # Mark the store with a sentinel so we can prove the rename moved its contents
+    sentinel = local_store / "decisions" / "999-sentinel.md"
+    sentinel.write_text("# 999 — sentinel\n")
+
+    with patch.object(cloud_projects.httpx, "request", side_effect=_create_response()):
+        result = runner.invoke(app, ["link", "--cloud"])
+    assert result.exit_code == 0, result.output
+
+    new_store = tmp_path / "nauro_home" / "projects" / CLOUD_PID
+    assert new_store.is_dir()
+    assert (new_store / "decisions" / "999-sentinel.md").exists()
+    assert not local_store.exists()
+
+    # Registry entry re-keyed under the cloud id, mode flipped, repo_paths preserved
+    assert registry.get_project_v2(local_id) is None
+    new_entry = registry.get_project_v2(CLOUD_PID)
+    assert new_entry is not None
+    assert new_entry["mode"] == "cloud"
+    assert str(tmp_path.resolve()) in new_entry["repo_paths"]
+
+    cfg = load_repo_config(tmp_path)
+    assert cfg["mode"] == "cloud"
+    assert cfg["id"] == CLOUD_PID
+
+
+def test_link_cloud_on_already_cloud_repo_errors(tmp_path, monkeypatch):
+    """A cloud-mode repo cannot be linked again."""
+    _seed_token(monkeypatch, tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("NAURO_API_URL", "https://example.test")
+
+    save_repo_config(
+        tmp_path,
+        {
+            "mode": "cloud",
+            "id": CLOUD_PID,
+            "name": "already",
+            "server_url": "https://example.test",
+        },
+    )
+
+    with patch.object(cloud_projects.httpx, "request", side_effect=AssertionError("no call")):
+        result = runner.invoke(app, ["link", "--cloud"])
+
+    assert result.exit_code == 1
+    assert "already cloud-mode" in result.output
+
+
+def test_link_cloud_with_no_repo_config_errors(tmp_path, monkeypatch):
+    """No `.nauro/config.json` above cwd → clear error, no network call."""
+    _seed_token(monkeypatch, tmp_path)
+    isolated = tmp_path / "isolated"
+    isolated.mkdir()
+    monkeypatch.chdir(isolated)
+    monkeypatch.setenv("NAURO_API_URL", "https://example.test")
+
+    with patch.object(cloud_projects.httpx, "request", side_effect=AssertionError("no call")):
+        result = runner.invoke(app, ["link", "--cloud"])
+
+    assert result.exit_code == 1
+    assert "Not a nauro repo" in result.output

--- a/packages/nauro/tests/test_registry.py
+++ b/packages/nauro/tests/test_registry.py
@@ -1,9 +1,12 @@
 """Tests for nauro.store.registry and nauro init."""
 
+import json
+
 from typer.testing import CliRunner
 
 from nauro.cli.main import app
 from nauro.store import registry
+from nauro.store.repo_config import load_repo_config
 from nauro.templates.scaffolds import scaffold_project_store
 
 
@@ -183,6 +186,16 @@ def test_scaffold_creates_all_files(tmp_path):
 runner = CliRunner()
 
 
+def _v2_entry_for_name(name: str) -> tuple[str, dict]:
+    """Return the single v2 (project_id, entry) matching ``name``.
+
+    Tests assert one entry exists; extracted helper makes the assertions read clean.
+    """
+    matches = registry.find_projects_by_name_v2(name)
+    assert len(matches) == 1, f"expected one v2 entry for {name!r}, got {len(matches)}"
+    return matches[0]
+
+
 def test_init_cli(tmp_path, monkeypatch):
     _patch_home(monkeypatch, tmp_path)
     monkeypatch.chdir(tmp_path)
@@ -190,8 +203,22 @@ def test_init_cli(tmp_path, monkeypatch):
     assert result.exit_code == 0
     assert "Initialized project 'myproject'" in result.output
     assert "Store:" in result.output
-    store = tmp_path / "nauro_home" / "projects" / "myproject"
+    pid, _entry = _v2_entry_for_name("myproject")
+    store = tmp_path / "nauro_home" / "projects" / pid
     assert (store / "project.md").exists()
+
+
+def test_init_cli_writes_repo_config_local(tmp_path, monkeypatch):
+    """`nauro init <name>` writes a local-mode .nauro/config.json into cwd."""
+    _patch_home(monkeypatch, tmp_path)
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["init", "configproj"])
+    assert result.exit_code == 0
+    cfg = load_repo_config(tmp_path)
+    assert cfg["mode"] == "local"
+    assert cfg["name"] == "configproj"
+    pid, _entry = _v2_entry_for_name("configproj")
+    assert cfg["id"] == pid
 
 
 def test_init_cli_with_add_repo(tmp_path, monkeypatch):
@@ -201,15 +228,25 @@ def test_init_cli_with_add_repo(tmp_path, monkeypatch):
     result = runner.invoke(app, ["init", "proj2", "--add-repo", str(repo)])
     assert result.exit_code == 0
     assert str(repo.resolve()) in result.output
+    cfg = load_repo_config(repo)
+    assert cfg["name"] == "proj2"
 
 
 def test_init_cli_duplicate(tmp_path, monkeypatch):
+    """A second `nauro init <same-name>` (no --add-repo) creates a SECOND project.
+
+    v2 allows duplicate names — id is unique. To extend an existing project,
+    callers must pass --add-repo, which is the explicit signal.
+    """
     _patch_home(monkeypatch, tmp_path)
     monkeypatch.chdir(tmp_path)
     runner.invoke(app, ["init", "dup"])
     result = runner.invoke(app, ["init", "dup"])
-    assert result.exit_code == 1
-    assert "already exists" in result.output
+    # Either succeeds (creates a second, distinct id-keyed entry) or fails with
+    # the clear duplicate-id message; both are acceptable, but the registry
+    # ends up with two entries named 'dup' in the success case.
+    assert result.exit_code == 0
+    assert len(registry.find_projects_by_name_v2("dup")) == 2
 
 
 def test_init_cli_add_repo_to_existing(tmp_path, monkeypatch):
@@ -225,9 +262,13 @@ def test_init_cli_add_repo_to_existing(tmp_path, monkeypatch):
     assert result.exit_code == 0
     assert "Updated project" in result.output
     assert "Added repo" in result.output
-    data = registry.load_registry()
-    paths = data["projects"]["proj"]["repo_paths"]
+    pid, entry = _v2_entry_for_name("proj")
+    paths = entry["repo_paths"]
     assert str(repo2.resolve()) in paths
+    # v2 registry shape
+    raw = json.loads((tmp_path / "nauro_home" / "registry.json").read_text())
+    assert raw["schema_version"] == 2
+    assert pid in raw["projects"]
 
 
 def test_remove_repo(tmp_path, monkeypatch):

--- a/packages/nauro/tests/test_registry_v2.py
+++ b/packages/nauro/tests/test_registry_v2.py
@@ -1,0 +1,93 @@
+"""Tests for the v2 registry loader/writer in nauro.store.registry."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from nauro.constants import (
+    REGISTRY_FILENAME,
+    REGISTRY_SCHEMA_VERSION_V2,
+)
+from nauro.store import registry
+from nauro.store.registry import (
+    RegistrySchemaError,
+    load_registry_v2,
+    save_registry_v2,
+)
+
+
+def _patch_home(monkeypatch, tmp_path):
+    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
+
+
+def test_load_v2_empty_when_missing(tmp_path, monkeypatch):
+    """Missing registry.json → empty v2 shape."""
+    _patch_home(monkeypatch, tmp_path)
+    data = load_registry_v2()
+    assert data == {"projects": {}, "schema_version": REGISTRY_SCHEMA_VERSION_V2}
+
+
+def test_v2_round_trip(tmp_path, monkeypatch):
+    """A v2 registry round-trips through save/load with id-keyed entries."""
+    _patch_home(monkeypatch, tmp_path)
+    data = {
+        "projects": {
+            "01KQ6AZGNA0B3QBF67NBXP3S45": {
+                "name": "nauro",
+                "mode": "cloud",
+                "server_url": "https://mcp.nauro.ai",
+                "repo_paths": ["/tmp/nauro"],
+            },
+            "01KQ7BZGZA0B3QBF67NBXP3S99": {
+                "name": "side-project",
+                "mode": "local",
+                "repo_paths": ["/tmp/side"],
+            },
+        },
+        "schema_version": REGISTRY_SCHEMA_VERSION_V2,
+    }
+    save_registry_v2(data)
+    loaded = load_registry_v2()
+    assert loaded == data
+
+
+def test_v2_save_stamps_schema_version(tmp_path, monkeypatch):
+    """save_registry_v2 stamps schema_version=2 when caller omits it."""
+    _patch_home(monkeypatch, tmp_path)
+    save_registry_v2({"projects": {}})
+    raw = json.loads((tmp_path / "nauro_home" / REGISTRY_FILENAME).read_text())
+    assert raw["schema_version"] == REGISTRY_SCHEMA_VERSION_V2
+
+
+def test_v2_loader_rejects_v1_with_migration_hint(tmp_path, monkeypatch):
+    """A v1 registry on disk surfaces the manual-migration message."""
+    _patch_home(monkeypatch, tmp_path)
+    # Write a v1 registry via the legacy writer.
+    registry.save_registry(
+        {"projects": {"oldproj": {"repo_paths": ["/tmp/old"]}}, "schema_version": 1}
+    )
+    with pytest.raises(RegistrySchemaError) as exc:
+        load_registry_v2()
+    msg = str(exc.value)
+    assert "schema_version 1" in msg
+    assert "manual migration" in msg
+
+
+def test_v2_loader_rejects_unknown_schema_version(tmp_path, monkeypatch):
+    """A future schema_version is rejected with an upgrade hint."""
+    _patch_home(monkeypatch, tmp_path)
+    nauro_home = tmp_path / "nauro_home"
+    nauro_home.mkdir()
+    (nauro_home / REGISTRY_FILENAME).write_text(json.dumps({"projects": {}, "schema_version": 99}))
+    with pytest.raises(RegistrySchemaError) as exc:
+        load_registry_v2()
+    assert "99" in str(exc.value)
+
+
+def test_v2_save_rejects_non_v2_schema_version(tmp_path, monkeypatch):
+    """save_registry_v2 refuses to write anything other than schema_version=2."""
+    _patch_home(monkeypatch, tmp_path)
+    with pytest.raises(RegistrySchemaError):
+        save_registry_v2({"projects": {}, "schema_version": 1})

--- a/packages/nauro/tests/test_repo_config.py
+++ b/packages/nauro/tests/test_repo_config.py
@@ -1,0 +1,186 @@
+"""Tests for nauro.store.repo_config — repo-local .nauro/config.json + walk-up."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from nauro.constants import (
+    REPO_CONFIG_DIR,
+    REPO_CONFIG_FILENAME,
+    REPO_CONFIG_SCHEMA_VERSION,
+)
+from nauro.store.repo_config import (
+    RepoConfigSchemaError,
+    find_repo_config,
+    generate_ulid,
+    load_repo_config,
+    repo_config_path,
+    save_repo_config,
+)
+
+# ── ULID generator ────────────────────────────────────────────────────────────
+
+
+def test_generate_ulid_shape():
+    """A ULID is 26 chars of Crockford base32; no I, L, O, U in the alphabet."""
+    ulid = generate_ulid()
+    assert len(ulid) == 26
+    forbidden = set("ILOU")
+    assert not (set(ulid) & forbidden)
+
+
+def test_generate_ulid_uniqueness():
+    """Different invocations produce different ULIDs."""
+    ulids = {generate_ulid() for _ in range(50)}
+    assert len(ulids) == 50
+
+
+# ── Local-mode round-trip ─────────────────────────────────────────────────────
+
+
+def test_local_config_round_trip(tmp_path):
+    """Writing then reading a local-mode config preserves every field."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    cfg_in = {
+        "mode": "local",
+        "id": generate_ulid(),
+        "name": "myproj",
+        "schema_version": REPO_CONFIG_SCHEMA_VERSION,
+    }
+    written_at = save_repo_config(repo, cfg_in)
+    assert written_at == repo / REPO_CONFIG_DIR / REPO_CONFIG_FILENAME
+
+    cfg_out = load_repo_config(repo)
+    assert cfg_out == cfg_in
+
+
+# ── Cloud-mode round-trip ─────────────────────────────────────────────────────
+
+
+def test_cloud_config_round_trip(tmp_path):
+    """Cloud-mode config retains server_url across save/load."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    cfg_in = {
+        "mode": "cloud",
+        "id": "01KQ6AZGNA0B3QBF67NBXP3S45",
+        "name": "nauro",
+        "server_url": "https://mcp.nauro.ai",
+        "schema_version": REPO_CONFIG_SCHEMA_VERSION,
+    }
+    save_repo_config(repo, cfg_in)
+    cfg_out = load_repo_config(repo)
+    assert cfg_out == cfg_in
+
+
+# ── Loader rejection paths ────────────────────────────────────────────────────
+
+
+def test_loader_rejects_unknown_schema_version(tmp_path):
+    """schema_version=99 raises a clear error pointing toward an upgrade path."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    cfg_dir = repo / REPO_CONFIG_DIR
+    cfg_dir.mkdir()
+    (cfg_dir / REPO_CONFIG_FILENAME).write_text(
+        json.dumps(
+            {
+                "mode": "local",
+                "id": generate_ulid(),
+                "name": "x",
+                "schema_version": 99,
+            }
+        )
+    )
+    with pytest.raises(RepoConfigSchemaError) as exc:
+        load_repo_config(repo)
+    assert "schema_version" in str(exc.value)
+
+
+def test_save_rejects_invalid_mode(tmp_path):
+    """Writing an unknown mode is refused before disk is touched."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    with pytest.raises(RepoConfigSchemaError):
+        save_repo_config(
+            repo,
+            {"mode": "magic", "id": generate_ulid(), "name": "x"},
+        )
+    assert not repo_config_path(repo).exists()
+
+
+def test_save_rejects_cloud_without_server_url(tmp_path):
+    """Cloud mode without server_url is rejected up front."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    with pytest.raises(RepoConfigSchemaError):
+        save_repo_config(
+            repo,
+            {"mode": "cloud", "id": generate_ulid(), "name": "x"},
+        )
+
+
+# ── find_repo_config walk-up ──────────────────────────────────────────────────
+
+
+def _seed_config(repo: object) -> object:
+    """Helper: write a minimal valid local-mode config into a repo dir."""
+    save_repo_config(
+        repo,
+        {
+            "mode": "local",
+            "id": generate_ulid(),
+            "name": repo.name,
+        },
+    )
+    return repo_config_path(repo)
+
+
+def test_find_repo_config_at_root(tmp_path):
+    """find_repo_config from the repo root returns the config path."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    config_path = _seed_config(repo)
+    found = find_repo_config(start=repo)
+    assert found == config_path
+
+
+def test_find_repo_config_walks_up_from_nested_dir(tmp_path):
+    """find_repo_config from a nested subdirectory walks up to the root."""
+    repo = tmp_path / "repo"
+    nested = repo / "src" / "pkg" / "deep"
+    nested.mkdir(parents=True)
+    config_path = _seed_config(repo)
+    found = find_repo_config(start=nested)
+    assert found == config_path
+
+
+def test_find_repo_config_returns_none_when_absent(tmp_path):
+    """When no .nauro/config.json exists above start, returns None."""
+    isolated = tmp_path / "no_repo"
+    isolated.mkdir()
+    assert find_repo_config(start=isolated) is None
+
+
+def test_find_repo_config_stops_at_filesystem_root(tmp_path, monkeypatch):
+    """The walk-up terminates at the filesystem root (no infinite loop)."""
+    # Anchor the walk at tmp_path (which has no config above it) and ensure
+    # the call returns rather than spinning. A pytest-imposed timeout would
+    # surface infinite loops, but explicit termination is the assertion.
+    isolated = tmp_path / "deep" / "tree"
+    isolated.mkdir(parents=True)
+    # No config anywhere on the path; expect None and no hang.
+    assert find_repo_config(start=isolated) is None
+
+
+def test_find_repo_config_defaults_to_cwd(tmp_path, monkeypatch):
+    """Omitting start uses the current working directory."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    config_path = _seed_config(repo)
+    monkeypatch.chdir(repo)
+    found = find_repo_config()
+    assert found == config_path

--- a/packages/nauro/tests/test_resolution_v2.py
+++ b/packages/nauro/tests/test_resolution_v2.py
@@ -1,0 +1,176 @@
+"""Tests for the v2 project-resolution flow used by every CLI command.
+
+The CLI's ``resolve_target_project`` and the local MCP servers'
+``_resolve_store`` share the same priority order: explicit ``--project``
+flag → cwd ``.nauro/config.json`` walk-up → v1 legacy fallback. These
+tests pin that behavior end-to-end so a regression cannot silently flip
+the precedence.
+
+Also covers the integration scenario where two projects coexist (one
+cloud-style preconfigured, one freshly created via `nauro init`) and
+each cwd resolves to its own store.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+from nauro.cli.main import app
+from nauro.cli.utils import resolve_target_project
+from nauro.constants import REGISTRY_FILENAME, REGISTRY_SCHEMA_VERSION_V2
+from nauro.mcp.stdio_server import _resolve_store
+from nauro.store import registry
+from nauro.store.repo_config import load_repo_config, save_repo_config
+
+runner = CliRunner()
+
+
+def _patch_home(monkeypatch, tmp_path):
+    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
+
+
+def _post_migration_state(tmp_path, monkeypatch):
+    """Simulate the post-manual-migration state: v2 registry + cloud repo config."""
+    _patch_home(monkeypatch, tmp_path)
+    nauro_home = tmp_path / "nauro_home"
+    nauro_home.mkdir()
+    cloud_pid = "01KQ6AZGNA0B3QBF67NBXP3S45"
+    repo_root = tmp_path / "cloud_repo"
+    repo_root.mkdir()
+    (nauro_home / "projects" / cloud_pid).mkdir(parents=True)
+    (nauro_home / REGISTRY_FILENAME).write_text(
+        json.dumps(
+            {
+                "schema_version": REGISTRY_SCHEMA_VERSION_V2,
+                "projects": {
+                    cloud_pid: {
+                        "name": "nauro",
+                        "mode": "cloud",
+                        "server_url": "https://mcp.nauro.ai",
+                        "repo_paths": [str(repo_root.resolve())],
+                    }
+                },
+            }
+        )
+        + "\n"
+    )
+    save_repo_config(
+        repo_root,
+        {
+            "mode": "cloud",
+            "id": cloud_pid,
+            "name": "nauro",
+            "server_url": "https://mcp.nauro.ai",
+        },
+    )
+    return cloud_pid, repo_root
+
+
+# ── repo config wins over cwd-only registry lookup ───────────────────────────
+
+
+def test_repo_config_resolves_to_id_keyed_store(tmp_path, monkeypatch):
+    cloud_pid, repo_root = _post_migration_state(tmp_path, monkeypatch)
+    monkeypatch.chdir(repo_root)
+    name, store = resolve_target_project(None)
+    assert name == "nauro"
+    assert store == tmp_path / "nauro_home" / "projects" / cloud_pid
+
+
+def test_resolution_walks_up_from_nested_dir(tmp_path, monkeypatch):
+    cloud_pid, repo_root = _post_migration_state(tmp_path, monkeypatch)
+    nested = repo_root / "src" / "pkg"
+    nested.mkdir(parents=True)
+    monkeypatch.chdir(nested)
+    _name, store = resolve_target_project(None)
+    assert store == tmp_path / "nauro_home" / "projects" / cloud_pid
+
+
+def test_explicit_project_flag_overrides_repo_config(tmp_path, monkeypatch):
+    """`--project <other-name>` takes precedence over the cwd config.
+
+    Existing test_cli.py expectation; pinned here against the v2 path.
+    """
+    _patch_home(monkeypatch, tmp_path)
+    cloud_pid, repo_root = _post_migration_state(tmp_path, monkeypatch)
+    other_pid, _store = registry.register_project_v2(
+        "beta",
+        [tmp_path / "beta_repo"],
+        mode="local",
+    )
+    (tmp_path / "beta_repo").mkdir()
+    monkeypatch.chdir(repo_root)
+    name, store = resolve_target_project("beta")
+    assert name == "beta"
+    assert store == tmp_path / "nauro_home" / "projects" / other_pid
+
+
+# ── stdio _resolve_store mirrors the same precedence ─────────────────────────
+
+
+def test_stdio_resolve_uses_repo_config_when_no_project_passed(tmp_path, monkeypatch):
+    cloud_pid, repo_root = _post_migration_state(tmp_path, monkeypatch)
+    monkeypatch.chdir(repo_root)
+    store = _resolve_store(None, None)
+    assert store == tmp_path / "nauro_home" / "projects" / cloud_pid
+
+
+def test_stdio_resolve_mismatched_project_id_errors(tmp_path, monkeypatch):
+    """When supplied project_id != repo config id, raise rather than silently swap."""
+    cloud_pid, repo_root = _post_migration_state(tmp_path, monkeypatch)
+    monkeypatch.chdir(repo_root)
+    with pytest.raises(ValueError, match="does not match"):
+        _resolve_store("01KZZZZZZZZZZZZZZZZZZZZZZZ", str(repo_root))
+
+
+def test_stdio_resolve_no_repo_no_project_errors(tmp_path, monkeypatch):
+    _patch_home(monkeypatch, tmp_path)
+    isolated = tmp_path / "isolated"
+    isolated.mkdir()
+    monkeypatch.chdir(isolated)
+    with pytest.raises(ValueError, match="Could not resolve project"):
+        _resolve_store(None, None)
+
+
+def test_stdio_resolve_explicit_id_matching_config(tmp_path, monkeypatch):
+    cloud_pid, repo_root = _post_migration_state(tmp_path, monkeypatch)
+    monkeypatch.chdir(repo_root)
+    store = _resolve_store(cloud_pid, str(repo_root))
+    assert store == tmp_path / "nauro_home" / "projects" / cloud_pid
+
+
+# ── integration: two projects coexist post-migration ─────────────────────────
+
+
+def test_two_projects_each_resolve_to_own_store(tmp_path, monkeypatch):
+    """Pre-migrated cloud project + a freshly-created local project don't collide."""
+    cloud_pid, cloud_repo = _post_migration_state(tmp_path, monkeypatch)
+
+    other = tmp_path / "other_repo"
+    other.mkdir()
+    monkeypatch.chdir(other)
+    result = runner.invoke(app, ["init", "side"])
+    assert result.exit_code == 0, result.output
+
+    matches = registry.find_projects_by_name_v2("side")
+    assert len(matches) == 1
+    side_pid, _entry = matches[0]
+    assert side_pid != cloud_pid
+
+    # cwd in cloud repo → cloud store
+    monkeypatch.chdir(cloud_repo)
+    _, store = resolve_target_project(None)
+    assert store == tmp_path / "nauro_home" / "projects" / cloud_pid
+
+    # cwd in other repo → side store
+    monkeypatch.chdir(other)
+    _, store = resolve_target_project(None)
+    assert store == tmp_path / "nauro_home" / "projects" / side_pid
+
+    # Cloud-mode config not corrupted by the new local-mode init in a different dir
+    cfg = load_repo_config(cloud_repo)
+    assert cfg["mode"] == "cloud"
+    assert cfg["id"] == cloud_pid

--- a/packages/nauro/tests/test_serve_no_project_flag.py
+++ b/packages/nauro/tests/test_serve_no_project_flag.py
@@ -1,0 +1,30 @@
+"""`nauro serve` no longer accepts --project — one source of truth is the repo config.
+
+Also asserts the s3_prefix shape so the migration's cwd-based prefix
+construction lines up with the cloud Lambda's expectations.
+"""
+
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from nauro.cli.main import app
+from nauro.sync.config import s3_prefix
+
+runner = CliRunner()
+
+
+def test_serve_rejects_project_flag():
+    """The --project flag was removed; passing it is a usage error."""
+    result = runner.invoke(app, ["serve", "--project", "anything"])
+    assert result.exit_code != 0
+    output = result.output + (result.stderr or "")
+    assert "--project" in output or "No such option" in output or "no such option" in output
+
+
+def test_s3_prefix_shape_for_project_id():
+    """s3_prefix renders the canonical users/<user>/projects/<id>/ shape."""
+    assert (
+        s3_prefix("user-abc", "01KQ6AZGNA0B3QBF67NBXP3S45")
+        == "users/user-abc/projects/01KQ6AZGNA0B3QBF67NBXP3S45/"
+    )


### PR DESCRIPTION
## Why

Pre-migration storage was name-scoped (`users/{sub}/projects/{name}/`) with auto-discovery via S3 listing. Names doubled as identifiers and access was implicit in S3 prefix patterns — blocking team scaling and leaving the only audit trail in CloudWatch. The migration introduces server-minted project IDs and explicit DynamoDB membership; this PR carries the shared-package and CLI-side work.

## Approach

Two-pass: nauro-core first (new wire schema, `list_projects` ToolSpec, `build_remote_instructions` template), then CLI (foundations + cutover). nauro-core published to PyPI as v0.3.0 and tagged; mcp-server pins to that tag.

CLI keeps two-mode (`local` + `cloud`) `.nauro/config.json` per the offline-first project constraint. Registry v2 is id-keyed and rejects v1 on read with an error pointing at the manual migration. Multi-repo split: `init --add-repo` for local, `attach <project_id>` for cloud — cloud uses the unambiguous identifier and fits the future team scenario where someone joins via membership rather than via the registry.

Rejected:
- CLI mints all IDs, server adopts → security risk (forging cloud IDs)
- Drop local mode entirely → violates offline-first project constraint
- Auto-migrate v1 → v2 in CLI → over-engineered for current scale (one user, one existing project)

## What changed

**packages/nauro-core (v0.3.0):** wire field rename `project` → `project_id`; new `list_projects` ToolSpec; `build_remote_instructions(static, projects)` template; `WELCOME_NO_PROJECT` moved here from mcp-server; `MAX_INLINE_PROJECTS=3` with `name — {id_prefix}` rendering for collision disambiguation.

**packages/nauro:** repo-config schema/loader + `find_repo_config(cwd)` walk-up; registry v2 alongside v1 helpers; HTTP client (`create_project`, `list_projects`) using existing OAuth token; single `CloudProjectError` for all failure modes. Four new commands: `init` (local), `init --cloud`, `attach <project_id>`, `link --cloud`. Local store path id-keyed (`~/.nauro/projects/<id>/`). Stdio + HTTP MCP servers updated to resolve project via cwd walk-up; `nauro serve --project` flag removed. Rate-limit test fix (locked `time.time` after a bucket-boundary flake exposed by added test runtime).

## What to review

- `packages/nauro-core/src/nauro_core/instructions.py` — template seam between per-user data and the static instructional block.
- `packages/nauro/src/nauro/store/registry.py` — v1/v2 coexistence; v2 read helpers tolerate v1-on-disk during transition.
- `packages/nauro/src/nauro/cli/commands/{init,attach,link}.py` — cross-mode error messages (`init --add-repo` against a cloud project routes to `attach`).
- `packages/nauro/tests/test_resolution_v2.py::test_two_projects_each_resolve_to_own_store` — load-bearing integration test.

## What's deferred

- Sync reconciliation between local registry and cloud project list (open question filed).
- Auth0 PostLogin Action version control + namespaced custom claims (open questions filed).
- Auto-migration code (deliberately scope-cut per logged decision).

## Test plan

- 665 nauro tests pass / 226 nauro-core tests pass.
- 5/5 CI checks green: `lint`, `test-nauro (3.11)`, `test-nauro (3.12)`, `test-nauro-core (3.11)`, `test-nauro-core (3.12)`.
- Production verification: nauro-core v0.3.0 live on PyPI; mcp-server PR #18 deployed and dogfooded with 12 architectural decisions logged via the new wire schema on 2026-04-27.
