### PR TITLE
README: structural reorder + cloud-upgrade flow correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ Give every AI agent your project's theory: the decisions, rationale, and rejecte
 
 Nauro maintains versioned project context and delivers it to Claude, Perplexity, ChatGPT, Cursor, and any MCP client. When an agent proposes an approach that conflicts with a past decision, Nauro catches it before the drift happens.
 
-Named for Peter Naur, whose 1985 paper argued the real program is the theory in the programmer's mind, not the code. Every fresh agent session is the equivalent of losing that programmer.
+## The problem
+
+Agents don't see what you've already decided or rejected. Approaches that failed last month look reasonable in isolation and get proposed again. The context resets; the drift doesn't.
 
 ## Install
 
@@ -16,11 +18,11 @@ Requires Python 3.11+.
 
 ## Quickstart
 
-### Try the demo locally (2 minutes)
+### Try the demo locally (2 minutes, no account)
 
 ```bash
 nauro init --demo
-nauro setup claude-code
+nauro setup claude-code   # writes the MCP entry to ~/.claude/settings.json
 ```
 
 Open Claude Code and ask:
@@ -28,17 +30,6 @@ Open Claude Code and ask:
 > "Check if we should add a WebSocket endpoint for live task updates"
 
 The demo creates a sample project with 7 decisions, project state, and open questions. `check_decision` surfaces a conflict: the team already chose SSE over WebSocket because persistent connections weren't released during ECS rolling deploys. No account needed.
-
-### Try it across surfaces
-
-To access the same project context from Claude AI, Perplexity, or ChatGPT:
-
-```bash
-nauro auth login
-nauro sync
-```
-
-Then add `mcp.nauro.ai` as a remote MCP connector in your tool's settings. Ask the same question, same answers, different surface.
 
 ### Use with your project
 
@@ -48,18 +39,32 @@ nauro note "All processing stays in the request path, no background workers. Asy
 nauro setup claude-code
 ```
 
-Agents can also propose decisions directly through MCP during sessions. To bootstrap from existing git history, set an API key and run `nauro extract`.
+`nauro init` writes a small `.nauro/config.json` into your repo (commit it — it links the repo to the project so any `nauro` command you run from inside this repo knows which project to use). To start with cloud sync from day one, use `nauro init --cloud my-project` instead.
+
+Agents can also propose decisions directly through MCP during sessions. To bootstrap from existing git history, set `ANTHROPIC_API_KEY` and run `nauro extract`.
+
+### Try it across surfaces
+
+Cross-surface access requires authenticating to the hosted MCP — your decisions live in your own S3 prefix so any tool can reach them.
+
+```bash
+nauro auth login
+nauro link --cloud   # one-time: promote local project to cloud
+nauro sync
+```
+
+Then add `mcp.nauro.ai` as a remote MCP connector in your tool's settings. Ask the same question, same answers, different surface.
 
 ## Why Nauro?
 
 Memory tools record what agents saw and said. Nauro captures what you decided and rejected, then checks every session against those decisions before they drift.
 
-| Approach | Cross-tool | Decisions validated | Versioned | Format |
-|---|---|---|---|---|
-| **Nauro** | All MCP clients | Yes (`check_decision`) | Snapshots + diffs | Portable markdown |
-| AGENTS.md (manual) | Tools with repo access | No | Git history only | Markdown |
-| Cursor Rules | Cursor only | No | No | Proprietary |
-| Claude Memory | Claude only | No | No | Proprietary |
+| Approach | Cross-tool | Validates against past decisions | Versioned |
+|---|---|---|---|
+| **Nauro** | Any MCP client | Yes (`check_decision`) | Snapshots + diffs |
+| AGENTS.md (manual) | Tools with repo access | No | Git history only |
+| Cursor Rules | Cursor only | No | No |
+| ADRs in-repo | Tools with repo access | Manual | Git history only |
 
 The `propose_decision` → `confirm_decision` → `check_decision` pipeline catches conflicts across any connected surface. Decisions made in Claude Code are validated in Perplexity. No platform vendor owns your context.
 
@@ -68,7 +73,7 @@ The `propose_decision` → `confirm_decision` → `check_decision` pipeline catc
 Agents propose decisions through MCP during sessions. You can also log decisions from the terminal with `nauro note` or bootstrap from git history with `nauro extract`. Everything is stored as flat markdown in `~/.nauro/projects/` and validated against existing decisions (structural screening, BM25 retrieval, LLM evaluation). Cloud sync replicates the local store to S3 for cross-device and remote MCP access.
 
 ```
-~/.nauro/projects/<n>/
+~/.nauro/projects/<name>/
   project.md          # goals, constraints
   stack.md            # languages, frameworks, infrastructure
   state.md            # current focus, blockers
@@ -78,6 +83,18 @@ Agents propose decisions through MCP during sessions. You can also log decisions
 ```
 
 All content is plain markdown. No database, no proprietary format.
+
+## Your data
+
+**Local usage (free tier):** Everything runs on your machine. If you use `nauro extract`, code diffs go directly to your Anthropic API key. Nauro is never in the data path.
+
+**Cloud sync:** Project context (decisions, state, open questions — not source code) is stored encrypted in AWS S3 (SSE-S3). Each user's data is isolated under a unique prefix.
+
+**Remote MCP:** When connected, your project context is read from S3 and delivered to the AI tool. The AI tool's own data policies apply after delivery.
+
+## Pricing
+
+Free: unlimited local usage, unlimited projects, 5,000 remote MCP calls/month. See [nauro.ai/pricing](https://nauro.ai/pricing) for hosted tiers.
 
 ## Packages
 
@@ -90,7 +107,7 @@ This repo contains two packages:
 
 `nauro-core` contains the pure-Python parsing, validation, and context assembly logic shared between the CLI and the hosted remote MCP server. Minimal dependencies (BM25 search only) so it can be used independently by third-party tools that want to read or write the Nauro decision format.
 
-## MCP tools
+## MCP tool surface
 
 11 tools (7 read, 4 write) exposed to any connected MCP client:
 
@@ -108,18 +125,6 @@ This repo contains two packages:
 - `flag_question` — flag an unresolved question
 - `update_state` — report progress
 
-## Your data
-
-**Local usage (free tier):** Everything runs on your machine. If you use `nauro extract`, code diffs go directly to your Anthropic API key. Nauro is never in the data path.
-
-**Cloud sync:** Project context (decisions, state, open questions — not source code) is stored encrypted in AWS S3 (SSE-S3). Each user's data is isolated under a unique prefix.
-
-**Remote MCP:** When connected, your project context is read from S3 and delivered to the AI tool. The AI tool's own data policies apply after delivery.
-
-## Pricing
-
-Free tier: unlimited local usage, unlimited projects, 5,000 remote MCP calls/month. Pro tier coming soon with unlimited remote MCP and hosted extraction.
-
 ## Contributing
 
 Contributions welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions and [CLAUDE.md](CLAUDE.md) for architecture context.
@@ -130,4 +135,8 @@ uv run pytest packages/nauro-core/tests/ -x -q
 uv run pytest packages/nauro/tests/ -x -q -m "not integration"
 ```
 
+---
+
 Apache 2.0 license.
+
+Named for Peter Naur, whose 1985 paper *Programming as Theory Building* argued the real program is the theory in the programmer's mind, not the code. Every fresh agent session is the equivalent of losing that programmer.


### PR DESCRIPTION
Reorders the README so each section answers the question the reader has at that point (what → install → see it work → use it → use elsewhere → why → architecture → data → cost → reference). Folds in a working-tree edit that's been uncommitted on main since pre-migration (problem section, comparison-table refresh, demo "no account" line, `<n>` → `<name>`, etc.).

**Load-bearing correction:** the "Try it across surfaces" bash block was telling users to run `nauro auth login && nauro sync` to upgrade a local project to cloud. That flow worked pre-migration; post-migration the mode is baked at `init` time and `nauro link --cloud` is the canonical promotion command. Verified via `commands/link.py` and `commands/sync.py` — `sync` reads the config and only does S3 ops if `mode=cloud` is already set, doesn't change the mode itself.

Other moves:

- Naur reference: header → footer. The third paragraph above the fold is too expensive for naming context.
- Quickstart sub-section order: `demo → use-with-your-project → cross-surfaces` instead of `demo → cross-surfaces → use-with-your-project`. Matches what people actually want next after the demo.
- Packages and "MCP tool surface" moved below Pricing — reference material that broke conceptual flow when mid-document.
- New `.nauro/config.json` sentence and `nauro init --cloud` alternative in "Use with your project."

A `## Status` section was drafted (early-stage signal, IAM credential model, STS roadmap) then removed. It would drain energy at the conversion point and reveal roadmap that may shift. Casual readers don't care; security-conscious readers will look at the code.

Best reviewed by reading the rendered README on the PR page.