### PR TITLE
framing: D118 amendment — tagline → 'Set the direction once'; README tightening

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # Nauro
 
-Set the vision once. Every agent inherits it.
+Decide once. Every agent inherits it.
 
-Set your project's direction once — goals, decisions, rejected paths — and every connected agent inherits it. When an agent proposes an approach that conflicts with a past decision, Nauro catches the drift before it ships. Works with Claude, Perplexity, ChatGPT, Cursor, and any MCP client.
+Every project decision — what you chose, what you rejected, and why — is inherited by every connected agent. When an agent proposes an approach that conflicts with a past decision, Nauro catches the drift before it ships. Works with Claude, Perplexity, ChatGPT, Cursor, and any MCP client.
 
 ## The problem
 
-Agents don't see what you've already decided or rejected. Approaches that failed last month look reasonable in isolation and get proposed again. The context resets; the drift doesn't.
+New session. The agent knows nothing. You re-explain the architecture, re-surface decisions, correct suggestions you already ruled out. Or worse, with multiple agents running in parallel, nobody catches the drift at all.
+
+Approaches that failed last month look reasonable in isolation and get proposed again. The context resets; the drift doesn't.
 
 ## Install
 
@@ -20,16 +22,11 @@ Requires Python 3.11+.
 
 ### Try the demo locally (2 minutes, no account)
 
-```bash
-nauro init --demo
-nauro setup claude-code   # writes the MCP entry to ~/.claude/settings.json
-```
+1. `nauro init --demo` — scaffold a sample project with 7 decisions, project state, and open questions.
+2. `nauro setup claude-code` — write the MCP entry to `~/.claude/settings.json`.
+3. Open Claude Code and ask: *"Check if we should add a WebSocket endpoint for live task updates"*
 
-Open Claude Code and ask:
-
-> "Check if we should add a WebSocket endpoint for live task updates"
-
-The demo creates a sample project with 7 decisions, project state, and open questions. `check_decision` surfaces a conflict: the team already chose SSE over WebSocket because persistent connections weren't released during ECS rolling deploys. No account needed.
+`check_decision` surfaces a conflict: the team already chose SSE over WebSocket because persistent connections weren't released during ECS rolling deploys. No account needed.
 
 ### Use with your project
 
@@ -55,9 +52,11 @@ nauro sync
 
 Then add `mcp.nauro.ai` as a remote MCP connector in your tool's settings. Ask the same question, same answers, different surface.
 
-## Why Nauro?
+## How it compares
 
 Memory tools record what agents saw and said. Nauro captures what you decided and rejected, then checks every session against those decisions before they drift.
+
+Nauro is the only context tool that gates new proposals against past rejections — across any MCP client.
 
 | Approach | Cross-tool | Validates against past decisions | Versioned |
 |---|---|---|---|
@@ -66,11 +65,15 @@ Memory tools record what agents saw and said. Nauro captures what you decided an
 | Cursor Rules | Cursor only | No | No |
 | ADRs in-repo | Tools with repo access | Manual | Git history only |
 
-The `check_decision` → `propose_decision` → `confirm_decision` pipeline catches conflicts before they're written, across any connected surface. Decisions made in Claude Code are validated in Perplexity. No platform vendor owns your context.
+The `check_decision` → `propose_decision` → `confirm_decision` pipeline catches conflicts before they're written, across any connected surface. Decisions made in Claude Code are validated in Perplexity. Your decisions stay yours, not your platform's.
 
 ## How it works
 
-Agents propose decisions through MCP during sessions. You can also log decisions from the terminal with `nauro note` or bootstrap from git history with `nauro extract`. Everything is stored as flat markdown in `~/.nauro/projects/` and validated against existing decisions (structural screening, BM25 retrieval, LLM evaluation). Cloud sync replicates the local store to S3 for cross-device and remote MCP access.
+Agents propose decisions through MCP during sessions. You can also log decisions from the terminal with `nauro note` or bootstrap from git history with `nauro extract`. Open questions are tracked too, so agents surface unresolved tensions before they become assumptions.
+
+One project spans many repos — the store lives in `~/.nauro/`, not inside any repo, so context follows the project across the whole codebase.
+
+Everything is stored as flat markdown in `~/.nauro/projects/` and validated against existing decisions (structural screening, BM25 retrieval, LLM evaluation). Cloud sync replicates the local store to S3 for cross-device and remote MCP access.
 
 ```
 ~/.nauro/projects/<name>/
@@ -94,18 +97,7 @@ All content is plain markdown. No database, no proprietary format.
 
 ## Pricing
 
-Free: unlimited local usage, unlimited projects, 5,000 remote MCP calls/month. See [nauro.ai/pricing](https://nauro.ai/pricing) for hosted tiers.
-
-## Packages
-
-This repo contains two packages:
-
-| Package | Path | PyPI |
-|---|---|---|
-| `nauro` | `packages/nauro/` | `pip install nauro` |
-| `nauro-core` | `packages/nauro-core/` | `pip install nauro-core` |
-
-`nauro-core` contains the pure-Python parsing, validation, and context assembly logic shared between the CLI and the hosted remote MCP server. Minimal dependencies (BM25 search only) so it can be used independently by third-party tools that want to read or write the Nauro decision format.
+Free: unlimited local usage, unlimited projects, 5,000 remote MCP calls/month. A typical agent session uses 10–30 calls, so the free tier covers roughly 200+ sessions a month. See [nauro.ai/pricing](https://nauro.ai/pricing) for hosted tiers.
 
 ## MCP tool surface
 
@@ -134,6 +126,17 @@ uv sync --all-packages --all-extras
 uv run pytest packages/nauro-core/tests/ -x -q
 uv run pytest packages/nauro/tests/ -x -q -m "not integration"
 ```
+
+## Packages
+
+This repo contains two packages:
+
+| Package | Path | PyPI |
+|---|---|---|
+| `nauro` | `packages/nauro/` | `pip install nauro` |
+| `nauro-core` | `packages/nauro-core/` | `pip install nauro-core` |
+
+`nauro-core` contains the pure-Python parsing, validation, and context assembly logic shared between the CLI and the hosted remote MCP server. Minimal dependencies (BM25 search only) so it can be used independently by third-party tools that want to read or write the Nauro decision format.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Nauro
 
-Decide once. Every agent inherits it.
+Set the direction once. Every agent inherits it.
 
-Every project decision — what you chose, what you rejected, and why — is inherited by every connected agent. When an agent proposes an approach that conflicts with a past decision, Nauro catches the drift before it ships. Works with Claude, Perplexity, ChatGPT, Cursor, and any MCP client.
+Your project's direction — goals, decisions, rejected paths — is inherited by every connected agent. When an agent proposes an approach that conflicts with a past decision, Nauro catches the drift before it ships. Works with Claude, Perplexity, ChatGPT, Cursor, and any MCP client.
 
 ## The problem
 

--- a/packages/nauro/README.md
+++ b/packages/nauro/README.md
@@ -1,8 +1,8 @@
 # Nauro
 
-Set the vision once. Every agent inherits it.
+Decide once. Every agent inherits it.
 
-Set your project's direction once — goals, decisions, rejected paths — and every connected agent inherits it. When an agent proposes an approach that conflicts with a past decision, Nauro catches the drift before it ships. Works with Claude, Perplexity, ChatGPT, Cursor, and any MCP client.
+Every project decision — what you chose, what you rejected, and why — is inherited by every connected agent. When an agent proposes an approach that conflicts with a past decision, Nauro catches the drift before it ships. Works with Claude, Perplexity, ChatGPT, Cursor, and any MCP client.
 
 ## Install
 

--- a/packages/nauro/README.md
+++ b/packages/nauro/README.md
@@ -1,8 +1,8 @@
 # Nauro
 
-Decide once. Every agent inherits it.
+Set the direction once. Every agent inherits it.
 
-Every project decision — what you chose, what you rejected, and why — is inherited by every connected agent. When an agent proposes an approach that conflicts with a past decision, Nauro catches the drift before it ships. Works with Claude, Perplexity, ChatGPT, Cursor, and any MCP client.
+Your project's direction — goals, decisions, rejected paths — is inherited by every connected agent. When an agent proposes an approach that conflicts with a past decision, Nauro catches the drift before it ships. Works with Claude, Perplexity, ChatGPT, Cursor, and any MCP client.
 
 ## Install
 

--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "nauro"
 version = "0.1.1"
-description = "Local CLI + MCP server: set your project's direction once, every connected AI agent inherits it."
+description = "Local CLI + MCP server: decide once, every connected AI agent inherits it."
 readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.11"

--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "nauro"
 version = "0.1.1"
-description = "Local CLI + MCP server: decide once, every connected AI agent inherits it."
+description = "Local CLI + MCP server: set your project's direction once, every connected AI agent inherits it."
 readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Why

D118 was confirmed earlier today and merged via [PR #16](https://github.com/Nauro-AI/nauro/pull/16), locking the tagline *"Set the vision once. Every agent inherits it."*

A fresh-Claude review of both READMEs flagged that the "vision" noun does not survive direct elaboration — the README's own supporting paragraph immediately translates *vision* to *"direction + goals + decisions"*, meaning a reader's first elaboration of the tagline contradicts its own noun.

The fresh review also flagged several pieces missing from the main README that are present in the (stronger) org-profile README: the visceral problem statement, the explicit moat sentence, an inline `check_decision` flag-plant, and the project-spans-repos differentiator.

## Approach

**Tagline amendment** — change to a noun that survives elaboration:

> "Set the vision once. Every agent inherits it."  →  **"Set the direction once. Every agent inherits it."**

Reasoning:
- **Direction is a singular, settable noun.** Fits the "once" cadence — you set the direction, period. Compare to "Decide once" (an earlier candidate in this PR's history, see commit log) which had grammatical-elliptical and continuous-decision-premise issues.
- **Survives direct elaboration.** The supporting paragraph stays on "direction" without translating to a different noun: *"Your project's direction — goals, decisions, rejected paths — is inherited by every connected agent."*
- **Unifies tier 1 and tier 2.** The MCP `instructions` opener in `constants.py` and the CLI top-level help in `main.py` already use **"direction"** as the developer-facing word. The tagline now matches. D118's three-tier audience split simplifies: **tier 1 + tier 2 share "direction"; tier 3 (category noun) remains deferred to gate 2** (still due 2026-06-30 OR launch+60d).
- **Forgettability cost accepted.** The original 2026-04-30 Perplexity scan flagged "direction" as "uncrowded but potentially forgettable." On a fresh read, that cost is preferable to the PM-register cost of "vision" or the structural issues of "decide once". The body copy carries the memorability; the tagline carries the framing.

**Main README content tightening** — five additional changes from the fresh-Claude review's must-fix list, plus four nice-to-haves. See "What changed" below.

Alternatives considered (and rejected, with reasoning in this PR's commit log):
- *Keep "vision" as locked* — the supporting paragraph already exposes the noun's weakness.
- *"Decide once. Every agent inherits it."* — applied earlier in this PR's history (see commit `54c98e1`), then reverted: grammatically elliptical (decide what?) and the "once" cadence implies a single act, which contradicts Nauro's continuous-decision premise.
- *"Set the doctrine once. Every agent runs on it."* — claims a tier-3 category noun, which D118 explicitly defers to a gate-2 follow-up decision.

## What changed

**Tagline amendment + supporting paragraph:**
- `README.md:3` — hero
- `README.md:5` — supporting paragraph (now opens with "Your project's direction — goals, decisions, rejected paths — is inherited by every connected agent.")
- `packages/nauro/README.md` — hero + supporting paragraph
- `packages/nauro/pyproject.toml` — PyPI description

**Main README content tightening (must-fix from fresh review):**
- **Problem statement lifted from org profile.** *"New session. The agent knows nothing. You re-explain the architecture, re-surface decisions, correct suggestions you already ruled out. Or worse, with multiple agents running in parallel, nobody catches the drift at all."* The kicker *"The context resets; the drift doesn't"* is preserved.
- **`check_decision` flag-plant** above the comparison table: *"Nauro is the only context tool that gates new proposals against past rejections — across any MCP client."*
- **Moat sentence** changed from *"No platform vendor owns your context"* to *"Your decisions stay yours, not your platform's"* — more direct, matches the org profile's phrasing.
- **Open questions surfacing** in How it works: *"Open questions are tracked too, so agents surface unresolved tensions before they become assumptions."*
- **Project-spans-repos surfacing** in How it works: *"One project spans many repos — the store lives in `~/.nauro/`, not inside any repo, so context follows the project across the whole codebase."*

**Polish (nice-to-have from fresh review):**
- "## Why Nauro?" → "## How it compares" — better skim header.
- Demo steps numbered 1, 2, 3 instead of implied via bash block.
- Pricing calibration: *"A typical agent session uses 10–30 calls, so the free tier covers roughly 200+ sessions a month."*
- Packages section moved to the bottom (was between Pricing and MCP tool surface — noise for the install-and-try audience).

## What to review

- **The tagline call.** This is a same-day reversal of D118's "vision" lock, then a second amendment from "decide once" to "set the direction once". The reasoning above is the case I find most persuasive; if you read it differently, this PR should not land.
- **The new pricing-calibration numbers** (10–30 calls/session, 200+ sessions/month). I estimated based on typical session patterns; the actual D088 math may be tighter.
- **`How it works` paragraph 2** — the project-spans-repos sentence. Surfaces a meaningful differentiator that's been buried.
- **"How it compares" header rename** — confirm this reads better than "Why Nauro?" for your audience.

## What's deferred

- **The formal D118 amendment as a Nauro decision could not be filed this session** because the Nauro MCP was disconnected mid-session. The amendment, the tier-2-unification rationale, and the supersession scope all need to be filed via `propose_decision` once Nauro MCP is reconnected. The reasoning is captured in the commit messages and this PR description so it can be reconstructed.
- **Asciinema cast / screenshot** — flagged by fresh review as the highest-leverage missing thing. Separate work item.
- **D113 `nauro sync` reconciliation question** — product decision, not a README edit. Open question still gates.
- **HN talking-point defenses** (Python 3.11+ vs 3.10, SSE-S3 vs KMS, ANTHROPIC_API_KEY vs Gemini/GPT, self-host story). Informational; no copy change needed.
- **Org profile README tagline propagation** — handled in [Nauro-AI/.github#1](https://github.com/Nauro-AI/.github/pull/1) (separate repo, separate PR, already updated to match).

## Test plan

- `ruff check packages/` and `ruff format --check packages/` clean (verified locally before each push).
- No tests assert on any of the strings changed (verified in prior session's audit).
- Manual visual check on the rendered README confirms the rewrite reads as a single coherent piece.

## Related

- Supersedes (partially): D118's tagline lock, only on the noun. The audience-tier split, "memory" ban, Naur reference treatment, cross-surface positioning, decisional-depth wedge, and gate-2 deferral are all retained.
- Sibling PR: [Nauro-AI/.github#1](https://github.com/Nauro-AI/.github/pull/1) — org profile README updated to match.
- Gate-2 follow-up: scheduled remote agent fires 2026-06-25 to draft the category-noun decision.