### PR TITLE
phase 1a: telemetry module + consent prompt (D117/D120)

### DIFF
--- a/packages/nauro/src/nauro/cli/main.py
+++ b/packages/nauro/src/nauro/cli/main.py
@@ -7,6 +7,7 @@ all subcommands: init, note, sync, log, diff, import, extract, hook, serve, conf
 import typer
 
 from nauro.store.config import apply_config_to_env
+from nauro.telemetry import consent
 
 
 def _version_callback(value: bool) -> None:
@@ -36,6 +37,7 @@ def main(
     ),
 ) -> None:
     """Set your project's direction once; every connected AI agent inherits it."""
+    consent.maybe_prompt()
 
 
 def _register_commands() -> None:

--- a/packages/nauro/src/nauro/constants.py
+++ b/packages/nauro/src/nauro/constants.py
@@ -99,6 +99,9 @@ HOOK_END_MARKER = "# --- nauro post-commit hook end ---"
 # ── Schema versioning ──
 SCHEMA_VERSION = 1
 
+# ── Telemetry ──
+TELEMETRY_CONSENT_VERSION = 1
+
 # ── Repo-local config (.nauro/config.json inside each repo) ──
 REPO_CONFIG_DIR = ".nauro"
 REPO_CONFIG_FILENAME = "config.json"

--- a/packages/nauro/src/nauro/telemetry/__init__.py
+++ b/packages/nauro/src/nauro/telemetry/__init__.py
@@ -1,0 +1,71 @@
+"""Public telemetry API.
+
+Phase 1a: capture() is wired but emits nothing yet (no call sites). Phases 1b/1c
+add the call sites. identify_login/identify_logout are deliberately stubs that
+raise NotImplementedError — silent no-ops would let Phase 1b accidentally depend
+on identity work and silently corrupt analytics.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+from nauro.constants import NAURO_TELEMETRY_ENV
+from nauro.store.config import get_telemetry_config
+from nauro.telemetry.client import _resolve_project_key, get_client
+
+logger = logging.getLogger("nauro.telemetry")
+
+
+def _should_emit() -> bool:
+    """Three guards: opt-out env, missing PostHog key, fresh-install / opt-out consent.
+
+    The anonymous_id-set check from D117 is satisfied by get_telemetry_config()'s
+    contract: it generates and persists a UUID4 on first read, so cfg.anonymous_id
+    is never None by construction.
+    """
+    if os.environ.get(NAURO_TELEMETRY_ENV) == "0":
+        return False
+    if _resolve_project_key() is None:
+        return False
+    cfg = get_telemetry_config()
+    if cfg.enabled is not True:
+        return False
+    return True
+
+
+def _get_distinct_id() -> str:
+    """Phase 1a: anonymous_id only. Phase 1c extends to user_id when logged in (D119)."""
+    cfg = get_telemetry_config()
+    return cfg.anonymous_id
+
+
+def is_enabled() -> bool:
+    return _should_emit()
+
+
+def capture(event_name: str, properties: dict[str, Any] | None = None) -> None:
+    """Send an event if telemetry is enabled. Silent on failure — must never crash the CLI."""
+    if not _should_emit():
+        return
+    try:
+        client = get_client()
+        if client is None:
+            return
+        client.capture(
+            event=event_name,
+            distinct_id=_get_distinct_id(),
+            properties=properties or {},
+        )
+    except Exception:
+        logger.debug("telemetry capture failed", exc_info=True)
+
+
+def identify_login(user_id: str) -> None:
+    raise NotImplementedError("Implemented in Phase 1c per D119")
+
+
+def identify_logout() -> None:
+    raise NotImplementedError("Implemented in Phase 1c per D119")

--- a/packages/nauro/src/nauro/telemetry/client.py
+++ b/packages/nauro/src/nauro/telemetry/client.py
@@ -1,0 +1,83 @@
+"""Lazy PostHog client singleton.
+
+Project key is read from NAURO_POSTHOG_KEY env var only in this PR — T4.1 will
+flip the default to an embedded prod key. Single-PR ownership keeps the
+"placeholder accidentally shipped" failure mode out of Phases 1a–1c.
+
+No atexit handler and no posthog.shutdown() call anywhere: per D120 the CLI
+uses sync_mode=True, so each capture() blocks until sent — there is no daemon
+thread that needs flushing on exit. Adding shutdown would re-introduce the
+background-thread surface that feedback_daemon_removed exists to prevent.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from typing import Any
+
+POSTHOG_KEY_ENV = "NAURO_POSTHOG_KEY"
+POSTHOG_HOST = "https://us.i.posthog.com"
+
+_RESERVED_PREFIXES = ("$ip", "$geoip_", "$user_agent")
+
+_client: Any = None
+_client_lock = threading.Lock()
+
+
+def _resolve_project_key() -> str | None:
+    key = os.environ.get(POSTHOG_KEY_ENV)
+    return key or None
+
+
+def _strip_reserved(properties: dict[str, Any]) -> dict[str, Any]:
+    """Drop any property whose key starts with $ip, $geoip_, or $user_agent.
+
+    Defense-in-depth per D120: PostHog v7 has paths that can re-add these
+    properties even with disable_geoip=True; this filter is the runtime
+    guarantee that the privacy contract holds across SDK upgrades.
+    """
+    return {
+        k: v
+        for k, v in properties.items()
+        if not any(k.startswith(prefix) for prefix in _RESERVED_PREFIXES)
+    }
+
+
+def _before_send(event: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not event:
+        return event
+    props = event.get("properties")
+    if isinstance(props, dict):
+        event["properties"] = _strip_reserved(props)
+    return event
+
+
+def get_client() -> Any | None:
+    """Return the singleton PostHog client, initializing it on first call.
+
+    Returns None when NAURO_POSTHOG_KEY is unset — callers must treat that as
+    "telemetry disabled" and no-op.
+    """
+    global _client
+    if _client is not None:
+        return _client
+
+    key = _resolve_project_key()
+    if key is None:
+        return None
+
+    with _client_lock:
+        if _client is not None:
+            return _client
+        from posthog import Posthog
+
+        _client = Posthog(
+            project_api_key=key,
+            host=POSTHOG_HOST,
+            sync_mode=True,
+            disable_geoip=True,
+            enable_exception_autocapture=False,
+            before_send=_before_send,
+        )
+    return _client

--- a/packages/nauro/src/nauro/telemetry/consent.py
+++ b/packages/nauro/src/nauro/telemetry/consent.py
@@ -1,0 +1,74 @@
+"""First-run telemetry consent prompt.
+
+Idempotent across CLI invocations: once cfg.consent_version matches the current
+TELEMETRY_CONSENT_VERSION the prompt is a no-op. Bumping the constant
+re-triggers the prompt with the user's previous answer pre-selected as default,
+so an unchanged-mind user just presses Enter.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from datetime import UTC, datetime
+
+from nauro.constants import NAURO_TELEMETRY_ENV, TELEMETRY_CONSENT_VERSION
+from nauro.store.config import get_telemetry_config, load_config, save_config
+
+PRIVACY_URL = "https://github.com/Nauro-AI/nauro/blob/main/packages/nauro/PRIVACY.md"
+PROMPT_TEXT = f"Help improve Nauro? Anonymous usage data only. See {PRIVACY_URL}"
+REPROMPT_PREFACE = (
+    "Telemetry events have expanded since you last consented. See PRIVACY.md for what's new."
+)
+
+
+def _persist(enabled: bool) -> None:
+    data = load_config()
+    section = data.get("telemetry") or {}
+    section["enabled"] = enabled
+    section["consent_version"] = TELEMETRY_CONSENT_VERSION
+    section["consented_at"] = datetime.now(UTC).isoformat()
+    data["telemetry"] = section
+    save_config(data)
+
+
+def _parse_answer(raw: str, default_yes: bool) -> bool:
+    answer = raw.strip().lower()
+    if answer in ("y", "yes"):
+        return True
+    if answer in ("n", "no"):
+        return False
+    if answer == "":
+        return default_yes
+    # Unknown input → opposite of default per the behavior matrix.
+    return not default_yes
+
+
+def maybe_prompt() -> None:
+    """Run the first-run / version-bump consent prompt if needed."""
+    if os.environ.get(NAURO_TELEMETRY_ENV) == "0":
+        return
+
+    if not (sys.stdin.isatty() and sys.stdout.isatty()):
+        # Both streams must be a TTY. The post-commit hook backgrounds `nauro extract`
+        # with stdout/stderr redirected (`> /dev/null 2>&1 &`) but inherits stdin from
+        # the user's terminal — checking stdin alone passes the gate, then input() in a
+        # background process triggers SIGTTIN and leaves the extract job suspended.
+        # Skipping here also avoids generating the anonymous_id on non-interactive runs.
+        return
+
+    cfg = get_telemetry_config()
+    if cfg.consent_version == TELEMETRY_CONSENT_VERSION:
+        return
+
+    is_first_run = cfg.consent_version is None
+    if is_first_run:
+        default_yes = True
+    else:
+        default_yes = cfg.enabled is True
+        print(REPROMPT_PREFACE)
+
+    suffix = "[Y/n]" if default_yes else "[y/N]"
+    raw = input(f"{PROMPT_TEXT} {suffix} ")
+    enabled = _parse_answer(raw, default_yes)
+    _persist(enabled)

--- a/packages/nauro/src/nauro/telemetry/events.py
+++ b/packages/nauro/src/nauro/telemetry/events.py
@@ -1,0 +1,68 @@
+"""Typed event constructors for the D117 taxonomy.
+
+Each function returns a property dict — no emission, no side effects. Phase 1b/1c
+call sites pair these with telemetry.capture() so property-key drift cannot
+silently fork between events and the locked taxonomy in PRIVACY.md.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def cli_command_invoked(
+    command: str,
+    success: bool,
+    duration_bucket: str,
+    nauro_version: str,
+    os_name: str,
+) -> dict[str, Any]:
+    return {
+        "command": command,
+        "success": success,
+        "duration_bucket": duration_bucket,
+        "nauro_version": nauro_version,
+        "os": os_name,
+    }
+
+
+def mcp_tool_called(
+    tool_name: str,
+    transport: str,
+    success: bool,
+    duration_bucket: str,
+) -> dict[str, Any]:
+    return {
+        "tool_name": tool_name,
+        "transport": transport,
+        "success": success,
+        "duration_bucket": duration_bucket,
+    }
+
+
+def hook_extraction_run(
+    commits: int,
+    decisions_extracted: int,
+    success: bool,
+) -> dict[str, Any]:
+    return {
+        "commits": commits,
+        "decisions_extracted": decisions_extracted,
+        "success": success,
+    }
+
+
+def sync_completed(
+    snapshot_count: int,
+    duration_bucket: str,
+    bytes_bucket: str,
+) -> dict[str, Any]:
+    return {
+        "snapshot_count": snapshot_count,
+        "duration_bucket": duration_bucket,
+        "bytes_bucket": bytes_bucket,
+    }
+
+
+def project_created(schema_version: int) -> dict[str, Any]:
+    return {"schema_version": schema_version}

--- a/packages/nauro/tests/test_consent_prompt.py
+++ b/packages/nauro/tests/test_consent_prompt.py
@@ -1,0 +1,220 @@
+"""Tests for nauro.telemetry.consent.maybe_prompt."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+
+import pytest
+
+
+@pytest.fixture
+def nauro_home(tmp_path, monkeypatch):
+    home = tmp_path / ".nauro"
+    home.mkdir()
+    monkeypatch.setenv("NAURO_HOME", str(home))
+    return home
+
+
+def _set_tty(monkeypatch, value: bool) -> None:
+    monkeypatch.setattr("sys.stdin.isatty", lambda: value)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: value)
+
+
+def _set_input(monkeypatch, response: str) -> None:
+    monkeypatch.setattr("builtins.input", lambda _prompt="": response)
+
+
+def _read_telemetry(home) -> dict:
+    cf = home / "config.json"
+    if not cf.exists():
+        return {}
+    return json.loads(cf.read_text()).get("telemetry", {})
+
+
+def _seed(home, *, enabled, consent_version) -> None:
+    (home / "config.json").write_text(
+        json.dumps(
+            {
+                "telemetry": {
+                    "anonymous_id": "11111111-1111-4111-8111-111111111111",
+                    "enabled": enabled,
+                    "consent_version": consent_version,
+                    "consented_at": "2026-04-30T00:00:00Z",
+                }
+            }
+        )
+    )
+
+
+def test_non_tty_does_not_fire_prompt(nauro_home, monkeypatch):
+    monkeypatch.delenv("NAURO_TELEMETRY", raising=False)
+    _set_tty(monkeypatch, False)
+    # Make input() error out so a leak is loud.
+    monkeypatch.setattr(
+        "builtins.input", lambda _p="": (_ for _ in ()).throw(AssertionError("input() called"))
+    )
+
+    from nauro.telemetry.consent import maybe_prompt
+
+    maybe_prompt()
+
+    section = _read_telemetry(nauro_home)
+    assert section.get("enabled") is None
+    assert section.get("consent_version") is None
+
+
+def test_redirected_stdout_does_not_fire_prompt(nauro_home, monkeypatch):
+    """Regression: post-commit hook backgrounds `nauro extract > /dev/null 2>&1 &`.
+
+    Stdin is still the user's terminal (isatty=True) but stdout is redirected.
+    Without the stdout TTY check the prompt would call input() and SIGTTIN-suspend
+    the background job — violating the hook's "must never block" contract.
+    """
+    monkeypatch.delenv("NAURO_TELEMETRY", raising=False)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: False)
+    monkeypatch.setattr(
+        "builtins.input", lambda _p="": (_ for _ in ()).throw(AssertionError("input() called"))
+    )
+
+    from nauro.telemetry.consent import maybe_prompt
+
+    maybe_prompt()
+
+    section = _read_telemetry(nauro_home)
+    assert section.get("enabled") is None
+    assert section.get("consent_version") is None
+
+
+def test_env_var_zero_does_not_fire_prompt(nauro_home, monkeypatch):
+    monkeypatch.setenv("NAURO_TELEMETRY", "0")
+    _set_tty(monkeypatch, True)
+    monkeypatch.setattr(
+        "builtins.input", lambda _p="": (_ for _ in ()).throw(AssertionError("input() called"))
+    )
+
+    from nauro.telemetry.consent import maybe_prompt
+
+    maybe_prompt()
+
+    # Config may or may not have been touched by get_telemetry_config (it generates anonymous_id),
+    # but consent fields must remain unset.
+    section = _read_telemetry(nauro_home)
+    assert section.get("enabled") is None
+    assert section.get("consent_version") is None
+
+
+def test_tty_user_enters_y(nauro_home, monkeypatch):
+    monkeypatch.delenv("NAURO_TELEMETRY", raising=False)
+    _set_tty(monkeypatch, True)
+    _set_input(monkeypatch, "y")
+
+    from nauro.telemetry.consent import maybe_prompt
+
+    maybe_prompt()
+
+    section = _read_telemetry(nauro_home)
+    assert section["enabled"] is True
+    assert section["consent_version"] == 1
+    parsed = datetime.fromisoformat(section["consented_at"])
+    assert parsed.tzinfo is not None
+    assert parsed.utcoffset().total_seconds() == 0
+
+
+def test_tty_user_enters_n(nauro_home, monkeypatch):
+    monkeypatch.delenv("NAURO_TELEMETRY", raising=False)
+    _set_tty(monkeypatch, True)
+    _set_input(monkeypatch, "n")
+
+    from nauro.telemetry.consent import maybe_prompt
+
+    maybe_prompt()
+
+    section = _read_telemetry(nauro_home)
+    assert section["enabled"] is False
+    assert section["consent_version"] == 1
+
+
+def test_first_run_empty_input_defaults_to_yes(nauro_home, monkeypatch):
+    monkeypatch.delenv("NAURO_TELEMETRY", raising=False)
+    _set_tty(monkeypatch, True)
+    _set_input(monkeypatch, "")
+
+    from nauro.telemetry.consent import maybe_prompt
+
+    maybe_prompt()
+
+    section = _read_telemetry(nauro_home)
+    assert section["enabled"] is True
+    assert section["consent_version"] == 1
+
+
+def test_consent_version_bump_re_triggers_prompt(nauro_home, monkeypatch):
+    monkeypatch.delenv("NAURO_TELEMETRY", raising=False)
+    _seed(nauro_home, enabled=True, consent_version=1)
+    _set_tty(monkeypatch, True)
+    _set_input(monkeypatch, "n")
+
+    import nauro.telemetry.consent as consent_mod
+
+    monkeypatch.setattr(consent_mod, "TELEMETRY_CONSENT_VERSION", 2)
+
+    consent_mod.maybe_prompt()
+
+    section = _read_telemetry(nauro_home)
+    assert section["consent_version"] == 2
+    assert section["enabled"] is False
+
+
+def test_reprompt_default_preserves_previous_yes(nauro_home, monkeypatch):
+    monkeypatch.delenv("NAURO_TELEMETRY", raising=False)
+    _seed(nauro_home, enabled=True, consent_version=1)
+    _set_tty(monkeypatch, True)
+    _set_input(monkeypatch, "")
+
+    import nauro.telemetry.consent as consent_mod
+
+    monkeypatch.setattr(consent_mod, "TELEMETRY_CONSENT_VERSION", 2)
+
+    consent_mod.maybe_prompt()
+
+    section = _read_telemetry(nauro_home)
+    assert section["consent_version"] == 2
+    assert section["enabled"] is True
+
+
+def test_reprompt_default_preserves_previous_no(nauro_home, monkeypatch):
+    monkeypatch.delenv("NAURO_TELEMETRY", raising=False)
+    _seed(nauro_home, enabled=False, consent_version=1)
+    _set_tty(monkeypatch, True)
+    _set_input(monkeypatch, "")
+
+    import nauro.telemetry.consent as consent_mod
+
+    monkeypatch.setattr(consent_mod, "TELEMETRY_CONSENT_VERSION", 2)
+
+    consent_mod.maybe_prompt()
+
+    section = _read_telemetry(nauro_home)
+    assert section["consent_version"] == 2
+    assert section["enabled"] is False
+
+
+def test_already_consented_at_current_version_does_not_re_prompt(nauro_home, monkeypatch):
+    monkeypatch.delenv("NAURO_TELEMETRY", raising=False)
+    _seed(nauro_home, enabled=True, consent_version=1)
+    _set_tty(monkeypatch, True)
+    monkeypatch.setattr(
+        "builtins.input", lambda _p="": (_ for _ in ()).throw(AssertionError("input() called"))
+    )
+
+    from nauro.telemetry.consent import maybe_prompt
+
+    maybe_prompt()
+
+    section = _read_telemetry(nauro_home)
+    # Untouched: still the seeded values.
+    assert section["enabled"] is True
+    assert section["consent_version"] == 1
+    assert section["consented_at"] == "2026-04-30T00:00:00Z"

--- a/packages/nauro/tests/test_telemetry_module.py
+++ b/packages/nauro/tests/test_telemetry_module.py
@@ -1,0 +1,170 @@
+"""Tests for nauro.telemetry public API and client primitives."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import socket
+import sys
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def nauro_home(tmp_path, monkeypatch):
+    home = tmp_path / ".nauro"
+    home.mkdir()
+    monkeypatch.setenv("NAURO_HOME", str(home))
+    return home
+
+
+@pytest.fixture
+def telemetry_key(monkeypatch):
+    monkeypatch.setenv("NAURO_POSTHOG_KEY", "phc_test_key_for_unit_tests")
+
+
+@pytest.fixture(autouse=True)
+def _reset_client_singleton():
+    """Each test gets a fresh client singleton — protects against leak across tests."""
+    import nauro.telemetry.client as client_mod
+
+    client_mod._client = None
+    yield
+    client_mod._client = None
+
+
+def _seed_consented_config(home, *, enabled: bool) -> str:
+    aid = "11111111-1111-4111-8111-111111111111"
+    (home / "config.json").write_text(
+        json.dumps(
+            {
+                "telemetry": {
+                    "anonymous_id": aid,
+                    "enabled": enabled,
+                    "consent_version": 1,
+                    "consented_at": "2026-04-30T00:00:00Z",
+                }
+            }
+        )
+    )
+    return aid
+
+
+def test_import_does_not_create_socket():
+    for name in [
+        "nauro.telemetry",
+        "nauro.telemetry.client",
+        "nauro.telemetry.events",
+        "nauro.telemetry.consent",
+    ]:
+        sys.modules.pop(name, None)
+
+    with patch.object(socket, "socket") as mock_socket:
+        importlib.import_module("nauro.telemetry")
+        importlib.import_module("nauro.telemetry.client")
+        importlib.import_module("nauro.telemetry.events")
+        importlib.import_module("nauro.telemetry.consent")
+
+    assert not mock_socket.called, "telemetry import must be lazy — no socket creation"
+
+
+def test_should_emit_false_when_enabled_is_none(nauro_home, telemetry_key):
+    from nauro.telemetry import _should_emit
+
+    assert _should_emit() is False
+
+
+def test_should_emit_false_when_enabled_is_false(nauro_home, telemetry_key):
+    _seed_consented_config(nauro_home, enabled=False)
+
+    from nauro.telemetry import _should_emit
+
+    assert _should_emit() is False
+
+
+def test_should_emit_false_when_posthog_key_unset(nauro_home, monkeypatch):
+    monkeypatch.delenv("NAURO_POSTHOG_KEY", raising=False)
+    _seed_consented_config(nauro_home, enabled=True)
+
+    from nauro.telemetry import _should_emit
+
+    assert _should_emit() is False
+
+
+def test_should_emit_true_when_all_conditions_hold(nauro_home, telemetry_key, monkeypatch):
+    monkeypatch.delenv("NAURO_TELEMETRY", raising=False)
+    _seed_consented_config(nauro_home, enabled=True)
+
+    from nauro.telemetry import _should_emit
+
+    assert _should_emit() is True
+
+
+def test_should_emit_false_when_env_var_disables(nauro_home, telemetry_key, monkeypatch):
+    monkeypatch.setenv("NAURO_TELEMETRY", "0")
+    _seed_consented_config(nauro_home, enabled=True)
+
+    from nauro.telemetry import _should_emit
+
+    assert _should_emit() is False
+
+
+def test_strip_reserved_filters_geoip_and_ip_and_user_agent():
+    from nauro.telemetry.client import _strip_reserved
+
+    props = {
+        "$ip": "1.2.3.4",
+        "$geoip_country_code": "US",
+        "$geoip_subdivision_1_name": "California",
+        "$geoip_city_name": "San Francisco",
+        "$user_agent": "curl/8",
+        "command": "init",
+        "success": True,
+    }
+
+    filtered = _strip_reserved(props)
+
+    assert "$ip" not in filtered
+    assert "$geoip_country_code" not in filtered
+    assert "$geoip_subdivision_1_name" not in filtered
+    assert "$geoip_city_name" not in filtered
+    assert "$user_agent" not in filtered
+
+
+def test_strip_reserved_preserves_unrelated_keys():
+    from nauro.telemetry.client import _strip_reserved
+
+    props = {
+        "command": "sync",
+        "success": True,
+        "duration_bucket": "100-500ms",
+        "nauro_version": "0.1.1",
+        "os": "darwin",
+    }
+
+    filtered = _strip_reserved(props)
+
+    assert filtered == props
+
+
+def test_get_distinct_id_returns_anonymous_id(nauro_home):
+    aid = _seed_consented_config(nauro_home, enabled=True)
+
+    from nauro.telemetry import _get_distinct_id
+
+    assert _get_distinct_id() == aid
+
+
+def test_identify_login_raises_not_implemented():
+    from nauro.telemetry import identify_login
+
+    with pytest.raises(NotImplementedError, match="Phase 1c"):
+        identify_login("auth0|123")
+
+
+def test_identify_logout_raises_not_implemented():
+    from nauro.telemetry import identify_logout
+
+    with pytest.raises(NotImplementedError, match="Phase 1c"):
+        identify_logout()


### PR DESCRIPTION
## Why

Phase 0 (#15) landed the telemetry config schema and dependency. Phase 1a is the next vertical slice: stand up the `nauro.telemetry` package, the lazy PostHog client (per [D120](https://nauro.ai/decisions/120)'s locked init contract), and the first-run consent prompt that flips `cfg.enabled` from `None` → `True/False`. Canonical specs: [D117](https://nauro.ai/decisions/117) (taxonomy + privacy contract) and D120 (SDK init flags + CLI sync_mode / Lambda async runtime split).

**No events fire in this PR** — Phase 1b adds `cli.command_invoked` + `project.created`; Phase 1c adds `mcp.tool_called` and the identify() body.

## Approach

Three-task split mirroring the prompt:

- **T1.1 — Telemetry module scaffold.** New `nauro.telemetry` package with the lazy PostHog singleton (all four D120 init flags), `_strip_reserved` defense-in-depth scrubber, and typed event constructors (`events.py`) that return property dicts so Phase 1b call sites cannot drift from the locked taxonomy.
- **T1.2 — First-run consent prompt.** `consent.maybe_prompt()` wired into the Typer `@app.callback()` body so it runs before any subcommand. Behavior matrix: `NAURO_TELEMETRY=0` skips silently; non-interactive (stdin OR stdout not a TTY) skips silently without mutating disk; first-run defaults to Y; consent_version bump re-prompts with the user's previous answer pre-selected as default.
- **T1.3 — No atexit, no posthog.shutdown().** Per D120 the CLI runs `sync_mode=True`, so each capture() blocks until sent — no daemon thread to flush. `client.py` docstring documents the WHY.

## What changed

| File | Change |
|---|---|
| `packages/nauro/src/nauro/constants.py` | + `TELEMETRY_CONSENT_VERSION = 1` |
| `packages/nauro/src/nauro/cli/main.py` | + `consent.maybe_prompt()` in app callback |
| `packages/nauro/src/nauro/telemetry/__init__.py` | New: public API (capture, identify_login/logout stubs, is_enabled, _should_emit, _get_distinct_id) |
| `packages/nauro/src/nauro/telemetry/client.py` | New: lazy PostHog singleton + `_strip_reserved` |
| `packages/nauro/src/nauro/telemetry/events.py` | New: typed event constructors per D117 taxonomy |
| `packages/nauro/src/nauro/telemetry/consent.py` | New: first-run / version-bump consent prompt |
| `packages/nauro/tests/test_telemetry_module.py` | New: 11 cases (import-no-socket, _should_emit guards, _strip_reserved, NotImplementedError stubs, env-var override) |
| `packages/nauro/tests/test_consent_prompt.py` | New: 10 cases (TTY/non-TTY/redirected-stdout/env-var/first-run/re-prompt defaults/idempotence) |

## What to review

- **D120 init flags** — all four are non-negotiable per the decision: `sync_mode=True`, `disable_geoip=True`, `enable_exception_autocapture=False`, `before_send=_strip_reserved`. See `client.py:75-83`.
- **Public-OSS safety** — no embedded PostHog project key (env-var-only via `NAURO_POSTHOG_KEY`); when unset, `_should_emit()` returns False and capture is a silent no-op. T4.1 owns embedding the prod default.
- **Identity stubs raise** — `identify_login` / `identify_logout` deliberately `raise NotImplementedError("Implemented in Phase 1c per D119")` instead of being silent no-ops, so Phase 1b cannot accidentally depend on identity work and silently corrupt analytics.
- **Consent gate uses BOTH stdin and stdout TTY checks** — the post-commit hook backgrounds `nauro extract > /dev/null 2>&1 &`. Stdin alone would still report TTY in that scenario, and `input()` from a background process triggers SIGTTIN. The combined check (and its regression test) prevents stopped extract jobs after a future `TELEMETRY_CONSENT_VERSION` bump.
- **Lazy singleton** — `import nauro.telemetry` opens no socket and spawns no thread; verified by `test_import_does_not_create_socket` patching `socket.socket`.

## What's deferred

- **Phase 1b**: wire `capture()` for `cli.command_invoked` + `project.created` events.
- **Phase 1c**: implement the `identify_login` / `identify_logout` bodies per D119; extend `_get_distinct_id()` to honor login state.
- **T4.1**: embed the prod PostHog project key (currently env-var only — capture is a silent no-op without it).
- **Phase 2**: Lambda Powertools EMF metrics on the muscat side.

## Test plan

- [x] `uv run pytest packages/nauro/tests/test_telemetry_module.py packages/nauro/tests/test_consent_prompt.py -x -q` — 21 passed
- [x] `uv run pytest packages/nauro/tests/ -x -q -m "not integration"` — 693 passed, 20 deselected
- [x] `uv run pytest packages/nauro-core/tests/ -x -q` — 232 passed (untouched)
- [x] `uv run ruff check packages/` — clean
- [x] `uv run ruff format --check packages/` — clean
- [x] Manual smoke: piped stdin (non-TTY) → no prompt, no `config.json` created
- [x] Manual smoke: `NAURO_TELEMETRY=0` → no prompt, no `config.json` created
- [x] Manual smoke: simulated TTY → prompt rendered, default-Y on Enter persists `enabled=true / consent_version=1 / consented_at=<UTC ISO>`
- [x] Manual smoke: 3 consecutive calls → prompt fires only once (idempotent)