### PR TITLE
phase 1b: CLI events + nauro telemetry subcommand (D117)

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/init.py
+++ b/packages/nauro/src/nauro/cli/commands/init.py
@@ -24,7 +24,11 @@ from pathlib import Path
 import typer
 
 from nauro.cli.commands.auth import DEFAULT_API_URL
-from nauro.constants import REPO_CONFIG_MODE_CLOUD, REPO_CONFIG_MODE_LOCAL
+from nauro.constants import (
+    REGISTRY_SCHEMA_VERSION_V2,
+    REPO_CONFIG_MODE_CLOUD,
+    REPO_CONFIG_MODE_LOCAL,
+)
 from nauro.store.registry import (
     add_repo_v2,
     find_projects_by_name_v2,
@@ -33,6 +37,8 @@ from nauro.store.registry import (
 )
 from nauro.store.repo_config import save_repo_config
 from nauro.sync.cloud_projects import CloudProjectError, create_project
+from nauro.telemetry import capture
+from nauro.telemetry.events import project_created
 from nauro.templates.scaffolds import scaffold_project_store
 
 logger = logging.getLogger("nauro.cli.init")
@@ -112,6 +118,7 @@ def init(
         except ValueError as exc:
             typer.echo(f"Error: {exc}", err=True)
             raise typer.Exit(code=1)
+        capture("project.created", project_created(REGISTRY_SCHEMA_VERSION_V2))
         for rp in repo_paths:
             save_repo_config(
                 rp,
@@ -141,6 +148,7 @@ def init(
     except ValueError as exc:
         typer.echo(f"Error: {exc}", err=True)
         raise typer.Exit(code=1)
+    capture("project.created", project_created(REGISTRY_SCHEMA_VERSION_V2))
     for rp in repo_paths:
         save_repo_config(
             rp,

--- a/packages/nauro/src/nauro/cli/commands/telemetry.py
+++ b/packages/nauro/src/nauro/cli/commands/telemetry.py
@@ -1,0 +1,85 @@
+"""nauro telemetry — manage anonymous usage telemetry state.
+
+Subcommands let users inspect, opt in, opt out, or rotate their analytics
+identity without hand-editing ~/.nauro/config.json. NAURO_TELEMETRY=0 always
+overrides config-level state at read time and is reported by ``status``.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+
+import typer
+
+from nauro.constants import NAURO_TELEMETRY_ENV, TELEMETRY_CONSENT_VERSION
+from nauro.store.config import get_telemetry_config, load_config, save_config
+from nauro.telemetry import _rotate_anonymous_id
+
+telemetry_app = typer.Typer(
+    help="Manage anonymous usage telemetry.",
+    no_args_is_help=True,
+)
+
+
+def _format_bool_or_null(value: bool | None) -> str:
+    if value is None:
+        return "null (not yet recorded)"
+    return "true" if value else "false"
+
+
+@telemetry_app.command()
+def status() -> None:
+    """Show current telemetry state, including any NAURO_TELEMETRY env override."""
+    cfg = get_telemetry_config()
+    data = load_config()
+    section = data.get("telemetry") or {}
+    raw_enabled = section.get("enabled")
+    env_value = os.environ.get(NAURO_TELEMETRY_ENV)
+    env_overrides = env_value == "0"
+
+    typer.echo(f"anonymous_id:        {cfg.anonymous_id}")
+    typer.echo(f"enabled (config):    {_format_bool_or_null(raw_enabled)}")
+    typer.echo(f"enabled (effective): {_format_bool_or_null(cfg.enabled)}")
+    consent_version_text = cfg.consent_version if cfg.consent_version is not None else "null"
+    typer.echo(f"consent_version:     {consent_version_text}")
+    typer.echo(f"consented_at:        {cfg.consented_at or 'not yet recorded'}")
+    if env_value is None:
+        typer.echo(f"{NAURO_TELEMETRY_ENV} override:  not set")
+    else:
+        typer.echo(
+            f"{NAURO_TELEMETRY_ENV} override:  "
+            f"{env_value!r}" + (" (disables telemetry)" if env_overrides else "")
+        )
+
+
+def _persist_enabled(enabled: bool) -> None:
+    data = load_config()
+    section = data.get("telemetry") or {}
+    section["enabled"] = enabled
+    section["consent_version"] = TELEMETRY_CONSENT_VERSION
+    section["consented_at"] = datetime.now(UTC).isoformat()
+    data["telemetry"] = section
+    save_config(data)
+
+
+@telemetry_app.command()
+def enable() -> None:
+    """Opt in to telemetry. Records consent_version and consented_at."""
+    _persist_enabled(True)
+    typer.echo("Telemetry enabled.")
+
+
+@telemetry_app.command()
+def disable() -> None:
+    """Opt out of telemetry. Suppresses future events; anonymous_id is preserved."""
+    _persist_enabled(False)
+    typer.echo("Telemetry disabled.")
+
+
+@telemetry_app.command()
+def reset() -> None:
+    """Rotate anonymous_id to a fresh UUID4. Consent state is preserved."""
+    new_id = _rotate_anonymous_id()
+    typer.echo(f"Rotated anonymous_id. New id: {new_id}")
+    typer.echo("Consent state preserved (run 'nauro telemetry status' to verify).")

--- a/packages/nauro/src/nauro/cli/main.py
+++ b/packages/nauro/src/nauro/cli/main.py
@@ -1,13 +1,15 @@
 """Nauro CLI — Typer app entry point.
 
 This module defines the top-level Typer application and registers
-all subcommands: init, note, sync, log, diff, import, extract, hook, serve, config, auth.
+all subcommands: init, note, sync, log, diff, import, extract, hook, serve,
+config, auth, telemetry.
 """
 
 import typer
 
 from nauro.store.config import apply_config_to_env
 from nauro.telemetry import consent
+from nauro.telemetry.cli_wrapper import instrument_app
 
 
 def _version_callback(value: bool) -> None:
@@ -20,7 +22,10 @@ def _version_callback(value: bool) -> None:
 
 app = typer.Typer(
     name="nauro",
-    help="Set your project's direction once; every connected AI agent inherits it.",
+    help=(
+        "Set your project's direction once; every connected AI agent inherits it."
+        "\n\nRun 'nauro telemetry --help' to manage anonymous usage telemetry."
+    ),
     no_args_is_help=True,
 )
 
@@ -58,6 +63,7 @@ def _register_commands() -> None:
         setup,
         status,
         sync,
+        telemetry,
         validate,
     )
 
@@ -77,9 +83,11 @@ def _register_commands() -> None:
     app.add_typer(config.config_app, name="config")
     app.add_typer(validate.validate_app, name="validate")
     app.add_typer(auth.auth_app, name="auth")
+    app.add_typer(telemetry.telemetry_app, name="telemetry")
 
 
 _register_commands()
+instrument_app(app)
 apply_config_to_env()
 
 if __name__ == "__main__":

--- a/packages/nauro/src/nauro/telemetry/__init__.py
+++ b/packages/nauro/src/nauro/telemetry/__init__.py
@@ -10,10 +10,11 @@ from __future__ import annotations
 
 import logging
 import os
+import uuid
 from typing import Any
 
 from nauro.constants import NAURO_TELEMETRY_ENV
-from nauro.store.config import get_telemetry_config
+from nauro.store.config import get_telemetry_config, load_config, save_config
 from nauro.telemetry.client import _resolve_project_key, get_client
 
 logger = logging.getLogger("nauro.telemetry")
@@ -61,6 +62,23 @@ def capture(event_name: str, properties: dict[str, Any] | None = None) -> None:
         )
     except Exception:
         logger.debug("telemetry capture failed", exc_info=True)
+
+
+def _rotate_anonymous_id() -> str:
+    """Mint a fresh UUID4 anonymous_id, persist it, leave consent fields untouched.
+
+    Used by ``nauro telemetry reset`` and (in Phase 1c) by identify_logout(). The
+    rotation is application-side only — PostHog's Python SDK is stateless w.r.t.
+    identity, so subsequent capture() calls will pick up the new id via
+    _get_distinct_id() without any SDK reset.
+    """
+    new_id = str(uuid.uuid4())
+    data = load_config()
+    section = data.get("telemetry") or {}
+    section["anonymous_id"] = new_id
+    data["telemetry"] = section
+    save_config(data)
+    return new_id
 
 
 def identify_login(user_id: str) -> None:

--- a/packages/nauro/src/nauro/telemetry/cli_wrapper.py
+++ b/packages/nauro/src/nauro/telemetry/cli_wrapper.py
@@ -1,0 +1,114 @@
+"""Typer command instrumentation for cli.command_invoked telemetry.
+
+instrument_app() walks a Typer app's registered_commands and registered_groups
+recursively and wraps every command callback with a timing/success-tracking
+shim that emits exactly one cli.command_invoked event per invocation.
+
+Wrapping happens once at app construction (in cli/main.py) so individual
+command modules stay free of telemetry imports — no per-command code per
+the T1.4 spec.
+"""
+
+from __future__ import annotations
+
+import functools
+import platform
+import time
+from collections.abc import Callable
+from importlib import metadata
+from typing import Any
+
+import typer
+
+from nauro.telemetry import capture
+from nauro.telemetry.events import cli_command_invoked
+
+_DURATION_BUCKETS: tuple[tuple[float, str], ...] = (
+    (0.010, "<10ms"),
+    (0.100, "10-100ms"),
+    (1.000, "100ms-1s"),
+    (10.000, "1-10s"),
+)
+_LARGEST_BUCKET = ">10s"
+
+
+def _bucket(elapsed: float) -> str:
+    for threshold, label in _DURATION_BUCKETS:
+        if elapsed < threshold:
+            return label
+    return _LARGEST_BUCKET
+
+
+def _resolve_version() -> str:
+    try:
+        return metadata.version("nauro")
+    except metadata.PackageNotFoundError:
+        return "0.0.0+unknown"
+
+
+_NAURO_VERSION = _resolve_version()
+_OS = platform.system()
+
+
+def instrument(func: Callable[..., Any], *, command_path: str) -> Callable[..., Any]:
+    """Wrap a Typer command callback to emit cli.command_invoked exactly once.
+
+    Idempotent: returns ``func`` unchanged if it has already been wrapped.
+    """
+    if getattr(func, "_nauro_instrumented", False):
+        return func
+
+    @functools.wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        start = time.perf_counter()
+        success = True
+        try:
+            return func(*args, **kwargs)
+        except typer.Exit as exc:
+            success = exc.exit_code == 0
+            raise
+        except SystemExit as exc:
+            code = exc.code if isinstance(exc.code, int) else 1
+            success = code == 0
+            raise
+        except BaseException:
+            success = False
+            raise
+        finally:
+            try:
+                capture(
+                    "cli.command_invoked",
+                    cli_command_invoked(
+                        command=command_path,
+                        success=success,
+                        duration_bucket=_bucket(time.perf_counter() - start),
+                        nauro_version=_NAURO_VERSION,
+                        os_name=_OS,
+                    ),
+                )
+            except Exception:
+                pass
+
+    wrapper._nauro_instrumented = True  # type: ignore[attr-defined]
+    return wrapper
+
+
+def instrument_app(app: typer.Typer, *, prefix: tuple[str, ...] = ()) -> None:
+    """Recursively wrap every registered command in ``app`` and its sub-Typers.
+
+    The dotted command path (e.g. ``"telemetry.disable"``) is captured at
+    registration time and passed into ``instrument`` as a closure argument.
+    """
+    for cmd_info in app.registered_commands:
+        if cmd_info.callback is None:
+            continue
+        name = cmd_info.name or cmd_info.callback.__name__.replace("_", "-")
+        cmd_info.callback = instrument(
+            cmd_info.callback,
+            command_path=".".join((*prefix, name)),
+        )
+    for group_info in app.registered_groups:
+        sub = group_info.typer_instance
+        if sub is None or group_info.name is None:
+            continue
+        instrument_app(sub, prefix=(*prefix, group_info.name))

--- a/packages/nauro/tests/test_cli_command_invoked.py
+++ b/packages/nauro/tests/test_cli_command_invoked.py
@@ -1,0 +1,255 @@
+"""Tests for cli.command_invoked telemetry instrumentation (T1.4)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+_EXPECTED_KEYS = {"command", "success", "duration_bucket", "nauro_version", "os"}
+_DISALLOWED_KEYS = {"args", "argv", "cwd", "env", "exit_code"}
+
+
+class FakeClient:
+    def __init__(self) -> None:
+        self.events: list[dict[str, Any]] = []
+
+    def capture(
+        self,
+        event: str,
+        distinct_id: str,
+        properties: dict[str, Any],
+    ) -> None:
+        self.events.append({"event": event, "distinct_id": distinct_id, "properties": properties})
+
+
+@pytest.fixture
+def nauro_home(tmp_path, monkeypatch):
+    home = tmp_path / "user_home"
+    home.mkdir()
+    monkeypatch.setenv("NAURO_HOME", str(home))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.chdir(repo)
+    return home
+
+
+@pytest.fixture
+def telemetry_key(monkeypatch):
+    monkeypatch.setenv("NAURO_POSTHOG_KEY", "phc_test_key_for_unit_tests")
+
+
+@pytest.fixture
+def fake_posthog(monkeypatch):
+    import nauro.telemetry.client as client_mod
+
+    fake = FakeClient()
+    client_mod._client = fake
+    yield fake
+    client_mod._client = None
+
+
+def _seed_consented_config(home, *, enabled: bool) -> str:
+    aid = "11111111-1111-4111-8111-111111111111"
+    (home / "config.json").write_text(
+        json.dumps(
+            {
+                "telemetry": {
+                    "anonymous_id": aid,
+                    "enabled": enabled,
+                    "consent_version": 1,
+                    "consented_at": "2026-04-30T00:00:00Z",
+                }
+            }
+        )
+    )
+    return aid
+
+
+def _command_events(fake: FakeClient) -> list[dict[str, Any]]:
+    return [e for e in fake.events if e["event"] == "cli.command_invoked"]
+
+
+def _build_isolated_app(callback) -> typer.Typer:
+    """Build a one-command Typer app with the given callback already instrumented.
+
+    Typer treats a single-command app as the default command, so invoke with [].
+    """
+    from nauro.telemetry.cli_wrapper import instrument
+
+    app = typer.Typer()
+    app.command()(instrument(callback, command_path="run"))
+    return app
+
+
+def test_emits_one_event_on_success(nauro_home, telemetry_key, fake_posthog):
+    _seed_consented_config(nauro_home, enabled=True)
+
+    from nauro.cli.main import app
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["init", "testproj"])
+    assert result.exit_code == 0, result.output
+
+    events = _command_events(fake_posthog)
+    assert len(events) == 1
+    props = events[0]["properties"]
+    assert props["command"] == "init"
+    assert props["success"] is True
+    assert props["duration_bucket"] in {"<10ms", "10-100ms", "100ms-1s", "1-10s", ">10s"}
+    assert isinstance(props["nauro_version"], str)
+    assert isinstance(props["os"], str)
+
+
+def test_emits_one_event_on_typer_exit_nonzero(nauro_home, telemetry_key, fake_posthog):
+    _seed_consented_config(nauro_home, enabled=True)
+
+    def _fail() -> None:
+        raise typer.Exit(code=1)
+
+    app = _build_isolated_app(_fail)
+    runner = CliRunner()
+    result = runner.invoke(app, [])
+    assert result.exit_code == 1
+
+    events = _command_events(fake_posthog)
+    assert len(events) == 1
+    assert events[0]["properties"]["command"] == "run"
+    assert events[0]["properties"]["success"] is False
+
+
+def test_emits_one_event_on_typer_exit_zero(nauro_home, telemetry_key, fake_posthog):
+    _seed_consented_config(nauro_home, enabled=True)
+
+    def _early_exit() -> None:
+        raise typer.Exit()  # default code=0
+
+    app = _build_isolated_app(_early_exit)
+    runner = CliRunner()
+    result = runner.invoke(app, [])
+    assert result.exit_code == 0
+
+    events = _command_events(fake_posthog)
+    assert len(events) == 1
+    assert events[0]["properties"]["success"] is True
+
+
+def test_emits_one_event_on_unexpected_exception(nauro_home, telemetry_key, fake_posthog):
+    _seed_consented_config(nauro_home, enabled=True)
+
+    def _boom() -> None:
+        raise RuntimeError("boom")
+
+    app = _build_isolated_app(_boom)
+    runner = CliRunner()
+    result = runner.invoke(app, [])
+    assert result.exit_code != 0
+
+    events = _command_events(fake_posthog)
+    assert len(events) == 1
+    assert events[0]["properties"]["command"] == "run"
+    assert events[0]["properties"]["success"] is False
+
+
+def test_dotted_subcommand_path(nauro_home, telemetry_key, fake_posthog):
+    _seed_consented_config(nauro_home, enabled=True)
+
+    from nauro.cli.main import app
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["telemetry", "status"])
+    assert result.exit_code == 0, result.output
+
+    events = _command_events(fake_posthog)
+    assert len(events) == 1
+    assert events[0]["properties"]["command"] == "telemetry.status"
+    assert events[0]["properties"]["success"] is True
+
+
+def test_no_event_when_enabled_false(nauro_home, telemetry_key, fake_posthog):
+    _seed_consented_config(nauro_home, enabled=False)
+
+    from nauro.cli.main import app
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["init", "testproj"])
+    assert result.exit_code == 0, result.output
+
+    assert fake_posthog.events == []
+
+
+def test_no_event_when_env_var_zero(nauro_home, telemetry_key, fake_posthog, monkeypatch):
+    monkeypatch.setenv("NAURO_TELEMETRY", "0")
+    _seed_consented_config(nauro_home, enabled=True)
+
+    from nauro.cli.main import app
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["init", "testproj"])
+    assert result.exit_code == 0, result.output
+
+    assert fake_posthog.events == []
+
+
+def test_event_keys_exhaustive_no_disallowed(nauro_home, telemetry_key, fake_posthog):
+    _seed_consented_config(nauro_home, enabled=True)
+
+    from nauro.cli.main import app
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["init", "testproj"])
+    assert result.exit_code == 0
+
+    events = _command_events(fake_posthog)
+    assert len(events) == 1
+    keys = set(events[0]["properties"].keys())
+    assert keys == _EXPECTED_KEYS
+    assert keys.isdisjoint(_DISALLOWED_KEYS)
+
+
+def test_bucket_classification():
+    from nauro.telemetry.cli_wrapper import _bucket
+
+    assert _bucket(0.005) == "<10ms"
+    assert _bucket(0.05) == "10-100ms"
+    assert _bucket(0.5) == "100ms-1s"
+    assert _bucket(5.0) == "1-10s"
+    assert _bucket(50.0) == ">10s"
+
+
+def test_version_flag_does_not_emit(nauro_home, telemetry_key, fake_posthog):
+    _seed_consented_config(nauro_home, enabled=True)
+
+    from nauro.cli.main import app
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["--version"])
+    assert result.exit_code == 0
+
+    assert _command_events(fake_posthog) == []
+
+
+def test_help_flag_does_not_emit(nauro_home, telemetry_key, fake_posthog):
+    _seed_consented_config(nauro_home, enabled=True)
+
+    from nauro.cli.main import app
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+
+    assert _command_events(fake_posthog) == []
+
+
+def test_instrument_is_idempotent():
+    from nauro.telemetry.cli_wrapper import instrument
+
+    def _f() -> None:
+        return None
+
+    once = instrument(_f, command_path="once")
+    twice = instrument(once, command_path="once")
+    assert once is twice

--- a/packages/nauro/tests/test_project_created_event.py
+++ b/packages/nauro/tests/test_project_created_event.py
@@ -1,0 +1,158 @@
+"""Tests for project.created funnel-anchor event (T1.6)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+
+class FakeClient:
+    def __init__(self) -> None:
+        self.events: list[dict[str, Any]] = []
+
+    def capture(
+        self,
+        event: str,
+        distinct_id: str,
+        properties: dict[str, Any],
+    ) -> None:
+        self.events.append({"event": event, "distinct_id": distinct_id, "properties": properties})
+
+
+@pytest.fixture
+def nauro_home(tmp_path, monkeypatch):
+    home = tmp_path / "user_home"
+    home.mkdir()
+    monkeypatch.setenv("NAURO_HOME", str(home))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.chdir(repo)
+    return home
+
+
+@pytest.fixture
+def telemetry_key(monkeypatch):
+    monkeypatch.setenv("NAURO_POSTHOG_KEY", "phc_test_key_for_unit_tests")
+
+
+@pytest.fixture
+def fake_posthog(monkeypatch):
+    import nauro.telemetry.client as client_mod
+
+    fake = FakeClient()
+    client_mod._client = fake
+    yield fake
+    client_mod._client = None
+
+
+def _seed_consented_config(home, *, enabled: bool) -> str:
+    aid = "11111111-1111-4111-8111-111111111111"
+    (home / "config.json").write_text(
+        json.dumps(
+            {
+                "telemetry": {
+                    "anonymous_id": aid,
+                    "enabled": enabled,
+                    "consent_version": 1,
+                    "consented_at": "2026-04-30T00:00:00Z",
+                }
+            }
+        )
+    )
+    return aid
+
+
+def _events_named(fake: FakeClient, name: str) -> list[dict[str, Any]]:
+    return [e for e in fake.events if e["event"] == name]
+
+
+def test_init_success_emits_project_created_with_schema_version(
+    nauro_home, telemetry_key, fake_posthog
+):
+    _seed_consented_config(nauro_home, enabled=True)
+
+    from nauro.cli.main import app
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["init", "testproj"])
+    assert result.exit_code == 0, result.output
+
+    project_events = _events_named(fake_posthog, "project.created")
+    assert len(project_events) == 1
+    assert project_events[0]["properties"] == {"schema_version": 2}
+
+    cli_events = _events_named(fake_posthog, "cli.command_invoked")
+    assert len(cli_events) == 1
+    assert cli_events[0]["properties"]["command"] == "init"
+    assert cli_events[0]["properties"]["success"] is True
+
+
+def test_add_repo_branch_does_not_emit_project_created(
+    nauro_home, telemetry_key, fake_posthog, tmp_path
+):
+    _seed_consented_config(nauro_home, enabled=True)
+
+    from nauro.cli.main import app
+
+    runner = CliRunner()
+    # First, register the project (this DOES emit project.created)
+    result = runner.invoke(app, ["init", "testproj"])
+    assert result.exit_code == 0
+    assert len(_events_named(fake_posthog, "project.created")) == 1
+
+    # Reset events and run --add-repo against the existing project
+    fake_posthog.events.clear()
+    extra_repo = tmp_path / "extra"
+    extra_repo.mkdir()
+    result = runner.invoke(app, ["init", "testproj", "--add-repo", str(extra_repo)])
+    assert result.exit_code == 0, result.output
+
+    assert _events_named(fake_posthog, "project.created") == []
+    assert len(_events_named(fake_posthog, "cli.command_invoked")) == 1
+
+
+def test_init_failure_does_not_emit_project_created(
+    nauro_home, telemetry_key, fake_posthog, tmp_path
+):
+    """--add-repo against a nonexistent multi-match scenario isn't reachable in v2;
+    instead simulate failure by making register_project_v2 raise."""
+    _seed_consented_config(nauro_home, enabled=True)
+
+    import nauro.cli.commands.init as init_module
+
+    def _raise(*args, **kwargs):
+        raise ValueError("simulated failure")
+
+    # Patch only for the duration of this test.
+    original = init_module.register_project_v2
+    init_module.register_project_v2 = _raise  # type: ignore[assignment]
+    try:
+        from nauro.cli.main import app
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["init", "testproj"])
+        assert result.exit_code == 1
+    finally:
+        init_module.register_project_v2 = original  # type: ignore[assignment]
+
+    assert _events_named(fake_posthog, "project.created") == []
+    cli_events = _events_named(fake_posthog, "cli.command_invoked")
+    assert len(cli_events) == 1
+    assert cli_events[0]["properties"]["success"] is False
+
+
+def test_project_created_keys_are_exhaustive(nauro_home, telemetry_key, fake_posthog):
+    _seed_consented_config(nauro_home, enabled=True)
+
+    from nauro.cli.main import app
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["init", "testproj"])
+    assert result.exit_code == 0
+
+    project_events = _events_named(fake_posthog, "project.created")
+    assert len(project_events) == 1
+    assert set(project_events[0]["properties"].keys()) == {"schema_version"}

--- a/packages/nauro/tests/test_telemetry_subcommand.py
+++ b/packages/nauro/tests/test_telemetry_subcommand.py
@@ -1,0 +1,216 @@
+"""Tests for nauro telemetry subcommand (T1.9)."""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+_UUID4_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$")
+
+
+class FakeClient:
+    def __init__(self) -> None:
+        self.events: list[dict[str, Any]] = []
+
+    def capture(
+        self,
+        event: str,
+        distinct_id: str,
+        properties: dict[str, Any],
+    ) -> None:
+        self.events.append({"event": event, "distinct_id": distinct_id, "properties": properties})
+
+
+@pytest.fixture
+def nauro_home(tmp_path, monkeypatch):
+    home = tmp_path / "user_home"
+    home.mkdir()
+    monkeypatch.setenv("NAURO_HOME", str(home))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.chdir(repo)
+    return home
+
+
+@pytest.fixture
+def telemetry_key(monkeypatch):
+    monkeypatch.setenv("NAURO_POSTHOG_KEY", "phc_test_key_for_unit_tests")
+
+
+@pytest.fixture
+def fake_posthog(monkeypatch):
+    import nauro.telemetry.client as client_mod
+
+    fake = FakeClient()
+    client_mod._client = fake
+    yield fake
+    client_mod._client = None
+
+
+def _seed_config(home, *, enabled, consent_version, consented_at, anonymous_id) -> None:
+    (home / "config.json").write_text(
+        json.dumps(
+            {
+                "telemetry": {
+                    "anonymous_id": anonymous_id,
+                    "enabled": enabled,
+                    "consent_version": consent_version,
+                    "consented_at": consented_at,
+                }
+            }
+        )
+    )
+
+
+def test_status_fresh_config(nauro_home):
+    from nauro.cli.main import app
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["telemetry", "status"])
+    assert result.exit_code == 0, result.output
+
+    out = result.stdout
+    assert "enabled (config):    null" in out
+    assert "consented_at:        not yet recorded" in out
+    # anonymous_id was generated on first read
+    line = next(line for line in out.splitlines() if line.startswith("anonymous_id:"))
+    aid = line.split(":", 1)[1].strip()
+    assert _UUID4_RE.match(aid), f"expected UUID4, got {aid!r}"
+
+
+def test_disable_persists_and_blocks_emit(nauro_home, telemetry_key):
+    _seed_config(
+        nauro_home,
+        enabled=True,
+        consent_version=1,
+        consented_at="2026-04-30T00:00:00Z",
+        anonymous_id="11111111-1111-4111-8111-111111111111",
+    )
+
+    from nauro.cli.main import app
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["telemetry", "disable"])
+    assert result.exit_code == 0, result.output
+    assert "Telemetry disabled." in result.stdout
+
+    data = json.loads((nauro_home / "config.json").read_text())
+    assert data["telemetry"]["enabled"] is False
+    assert data["telemetry"]["consented_at"] is not None
+
+    from nauro.telemetry import _should_emit
+
+    assert _should_emit() is False
+
+
+def test_enable_persists_and_allows_emit(nauro_home, telemetry_key, monkeypatch):
+    monkeypatch.delenv("NAURO_TELEMETRY", raising=False)
+    _seed_config(
+        nauro_home,
+        enabled=False,
+        consent_version=1,
+        consented_at="2026-04-30T00:00:00Z",
+        anonymous_id="11111111-1111-4111-8111-111111111111",
+    )
+
+    from nauro.cli.main import app
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["telemetry", "enable"])
+    assert result.exit_code == 0, result.output
+    assert "Telemetry enabled." in result.stdout
+
+    data = json.loads((nauro_home / "config.json").read_text())
+    assert data["telemetry"]["enabled"] is True
+    assert data["telemetry"]["consent_version"] == 1
+    assert data["telemetry"]["consented_at"] is not None
+
+    from nauro.telemetry import _should_emit
+
+    assert _should_emit() is True
+
+
+def test_reset_rotates_anonymous_id_preserves_consent(nauro_home):
+    original_aid = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+    _seed_config(
+        nauro_home,
+        enabled=True,
+        consent_version=1,
+        consented_at="2026-04-30T00:00:00Z",
+        anonymous_id=original_aid,
+    )
+
+    from nauro.cli.main import app
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["telemetry", "reset"])
+    assert result.exit_code == 0, result.output
+    assert "Rotated anonymous_id." in result.stdout
+    assert "Consent state preserved" in result.stdout
+
+    data = json.loads((nauro_home / "config.json").read_text())
+    new_aid = data["telemetry"]["anonymous_id"]
+    assert new_aid != original_aid
+    assert _UUID4_RE.match(new_aid)
+    # Consent fields untouched
+    assert data["telemetry"]["enabled"] is True
+    assert data["telemetry"]["consent_version"] == 1
+    assert data["telemetry"]["consented_at"] == "2026-04-30T00:00:00Z"
+
+
+def test_status_shows_env_override_active(nauro_home, monkeypatch):
+    monkeypatch.setenv("NAURO_TELEMETRY", "0")
+
+    from nauro.cli.main import app
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["telemetry", "status"])
+    assert result.exit_code == 0, result.output
+
+    out = result.stdout
+    assert "NAURO_TELEMETRY override:" in out
+    assert "'0'" in out
+    assert "disables telemetry" in out
+    assert "enabled (effective): false" in out
+
+
+def test_rotate_anonymous_id_helper_unit(nauro_home):
+    _seed_config(
+        nauro_home,
+        enabled=True,
+        consent_version=1,
+        consented_at="2026-04-30T00:00:00Z",
+        anonymous_id="11111111-1111-4111-8111-111111111111",
+    )
+
+    from nauro.telemetry import _rotate_anonymous_id
+
+    new_id_1 = _rotate_anonymous_id()
+    new_id_2 = _rotate_anonymous_id()
+    assert uuid.UUID(new_id_1).version == 4
+    assert uuid.UUID(new_id_2).version == 4
+    assert new_id_1 != new_id_2
+
+    data = json.loads((nauro_home / "config.json").read_text())
+    assert data["telemetry"]["anonymous_id"] == new_id_2
+    assert data["telemetry"]["enabled"] is True
+    assert data["telemetry"]["consent_version"] == 1
+    assert data["telemetry"]["consented_at"] == "2026-04-30T00:00:00Z"
+
+
+def test_telemetry_no_args_shows_help(nauro_home):
+    from nauro.cli.main import app
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["telemetry"])
+    # Typer raises Exit(2) for no_args_is_help on subcommand groups, but newer
+    # Typer versions return 0; just assert help text is present in either case.
+    assert "status" in result.stdout
+    assert "enable" in result.stdout
+    assert "disable" in result.stdout
+    assert "reset" in result.stdout


### PR DESCRIPTION
## Why

Phase 1a (telemetry module + consent prompt, #18) shipped the foundation but emits nothing. This PR wires the first real product-analytics events so D117's funnel question — *is anyone using Nauro and where do they drop off?* — can finally be answered.

Decisions: [D117](https://nauro.ai) (event taxonomy + opt-in) and [D120](https://nauro.ai) (PostHog SDK init contract — already enforced by Phase 1a, this PR is just call sites).

## Approach

Three concerns, three call sites, no per-command code:

- **`cli.command_invoked`** — single `instrument_app()` walker recurses through `app.registered_commands` and `app.registered_groups[*].typer_instance`, replacing each `CommandInfo.callback` with a wrapped version. Dotted command path (`telemetry.disable`, `auth.login`) captured at registration time as a closure argument. Emits exactly one event per invocation regardless of success/failure path.
- **`project.created`** — fired once after a successful `register_project_v2()` call inside `cli/commands/init.py`. Property: `schema_version=2`. Doesn't fire on the `--add-repo` branch, doesn't fire on registry-write failure.
- **`nauro telemetry`** — new sub-Typer with `status`, `enable`, `disable`, `reset`. `reset` rotates `anonymous_id` via `_rotate_anonymous_id()` — a shared helper that Phase 1c's `identify_logout()` will reuse. `status` reports both config-level and effective-level enabled state plus the `NAURO_TELEMETRY` env override.

## What changed

- `packages/nauro/src/nauro/telemetry/cli_wrapper.py` (new) — `instrument()` decorator + `instrument_app()` walker. Idempotent via `_nauro_instrumented` sentinel. Module-level cached version + OS to keep per-invocation cost negligible.
- `packages/nauro/src/nauro/cli/commands/telemetry.py` (new) — four subcommands.
- `packages/nauro/src/nauro/telemetry/__init__.py` — adds `_rotate_anonymous_id()`.
- `packages/nauro/src/nauro/cli/main.py` — registers `telemetry_app`, calls `instrument_app(app)` after `_register_commands()`, mentions `nauro telemetry` in top-level help.
- `packages/nauro/src/nauro/cli/commands/init.py` — emits `project.created` after both cloud and local-only registry writes succeed.

## What to review

- **`success` semantics in the wrapper** (`cli_wrapper.py`): `typer.Exit(0)` → success=True; `typer.Exit(N>0)` → False; any other exception (including `KeyboardInterrupt`) → False. Re-raises unchanged.
- **`project.created` placement in `init.py`**: deliberately inside the existing `try` block, immediately after `register_project_v2()` returns, so it never fires on registry-write failure.
- **No raw durations**: `_bucket()` maps `time.perf_counter()` deltas to one of five buckets per D117 (cardinality + fingerprinting protection).
- **Property exhaustiveness**: tests assert `set(props.keys()) == {"command","success","duration_bucket","nauro_version","os"}` — new properties cannot drift in without a new decision.
- **`nauro --version` and `nauro --help` do NOT emit** — they short-circuit before any command callback runs. Verified by tests.
- **Test fixtures** isolate `NAURO_HOME` from cwd (`user_home/` vs `repo/`) — early version had `save_repo_config` overwriting the seeded user config and silently masking the wrapper's emission.

## What's deferred

- **Phase 1c** (`identify_login`/`identify_logout`, D119) — stubs still raise `NotImplementedError`. `_rotate_anonymous_id()` is positioned for reuse there.
- **Live PostHog smoke test** against the `nauro-dev` project (PostHog UI verification of `project.created` + `cli.command_invoked` shapes) — to run before merging.
- Other event types in the D117 taxonomy (`mcp.tool_called`, `hook.extraction_run`, `sync.completed`) — separate PRs.

## Test plan

- [x] `uv run pytest packages/nauro/tests/test_cli_command_invoked.py packages/nauro/tests/test_project_created_event.py packages/nauro/tests/test_telemetry_subcommand.py -x -q` (23 new tests pass)
- [x] `uv run pytest packages/nauro/tests/ -x -q -m "not integration"` (716 pass)
- [x] `uv run pytest packages/nauro-core/tests/ -x -q` (232 pass)
- [x] `uv run ruff check packages/ && uv run ruff format --check packages/` (clean)
- [x] Live PostHog smoke test against `nauro-dev` (set `NAURO_POSTHOG_KEY=<dev-key>`):
  - `nauro init test-telemetry-1b` → expect one `project.created` (schema_version=2) + one `cli.command_invoked` (command="init", success=true)
  - `nauro telemetry disable` then `nauro init test-2` → expect NO new events
  - `nauro telemetry status|enable|disable` → expect three `cli.command_invoked` with dotted command paths
  - `NAURO_TELEMETRY=0 nauro telemetry status` → expect no events; output mentions env override