### PR TITLE
phase 1c: MCP events + identity lifecycle (D117/D119/D120)

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/auth.py
+++ b/packages/nauro/src/nauro/cli/commands/auth.py
@@ -245,6 +245,7 @@ def login() -> None:
 
     # Fetch canonical user_id from server
     user_id = None
+    me_body: dict[str, object] = {}
     try:
         me_resp = httpx.get(
             f"{api_url}/me",
@@ -252,7 +253,8 @@ def login() -> None:
             timeout=10,
         )
         me_resp.raise_for_status()
-        user_id = me_resp.json().get("user_id")
+        me_body = me_resp.json()
+        user_id = me_body.get("user_id")
     except Exception as e:
         logger.warning("Failed to fetch user_id from /me: %s", e)
         typer.echo(
@@ -271,6 +273,28 @@ def login() -> None:
         "refresh_token": refresh_token,
     }
     save_config(config)
+
+    # Telemetry identity merge (D119). Auth state is already persisted above —
+    # this block only handles the PostHog alias+set. Raw email never leaves
+    # auth.py; identify_login receives only the SHA-256 hex digest.
+    try:
+        email_raw = (
+            payload.get("email")
+            or payload.get("https://mcp.nauro.ai/email")
+            or me_body.get("email")
+            or ""
+        )
+        if isinstance(email_raw, str):
+            email = email_raw.strip().lower()
+        else:
+            email = ""
+        if user_id and email:
+            from nauro.telemetry import identify_login as _telemetry_identify_login
+
+            email_hash = hashlib.sha256(email.encode("utf-8")).hexdigest()
+            _telemetry_identify_login(user_id=user_id, email_hash=email_hash)
+    except Exception:
+        logger.debug("telemetry identify_login failed", exc_info=True)
 
     typer.echo(f"Authenticated as {sub}")
 
@@ -303,6 +327,16 @@ def logout() -> None:
     if "auth" not in config:
         typer.echo("Not authenticated — nothing to clear.")
         return
+
+    # Rotate the telemetry anonymous_id at logout (D119: rotate-on-logout,
+    # preserve consent). identify_logout only touches the telemetry section,
+    # so call ordering with del config["auth"] is independent for correctness.
+    try:
+        from nauro.telemetry import identify_logout as _telemetry_identify_logout
+
+        _telemetry_identify_logout()
+    except Exception:
+        logger.debug("telemetry identify_logout failed", exc_info=True)
 
     del config["auth"]
     save_config(config)

--- a/packages/nauro/src/nauro/mcp/server.py
+++ b/packages/nauro/src/nauro/mcp/server.py
@@ -52,6 +52,21 @@ logger = logging.getLogger("nauro.mcp")
 app = FastAPI(title="Nauro MCP Server", version="0.2.0")
 
 
+@app.middleware("http")
+async def _telemetry_transport_middleware(request, call_next):
+    """Set transport='http' for the duration of this request.
+
+    Per D117 / Phase 1c T1.5, the mcp.tool_called event reads transport from
+    a ContextVar. Each FastAPI request runs in its own asyncio Task, which
+    gets a copy of the parent's context — so set_transport here is scoped to
+    this request and cannot leak to other transports.
+    """
+    from nauro.telemetry.transport import set_transport
+
+    set_transport("http")
+    return await call_next(request)
+
+
 # --- Request models ---
 
 

--- a/packages/nauro/src/nauro/mcp/stdio_server.py
+++ b/packages/nauro/src/nauro/mcp/stdio_server.py
@@ -377,5 +377,8 @@ def _pull_on_startup() -> None:
 
 def run_stdio() -> None:
     """Run the MCP server over stdio (called by `nauro serve --stdio`)."""
+    from nauro.telemetry.transport import set_transport
+
+    set_transport("stdio")
     _pull_on_startup()
     mcp.run(transport="stdio")

--- a/packages/nauro/src/nauro/mcp/tools.py
+++ b/packages/nauro/src/nauro/mcp/tools.py
@@ -40,6 +40,7 @@ from nauro.store.reader import (
 from nauro.store.snapshot import capture_snapshot
 from nauro.store.writer import append_question
 from nauro.store.writer import update_state as _write_state
+from nauro.telemetry.decorators import mcp_tool
 from nauro.validation.pipeline import confirm_write, validate_proposed_write
 from nauro.validation.tier2 import check_similarity
 from nauro.validation.tier3 import check_conflicts_with_llm
@@ -95,6 +96,7 @@ def _coerce_level(level: int | str) -> int:
     return level
 
 
+@mcp_tool("get_context")
 def tool_get_context(store_path: Path, level: int | str) -> str:
     """Return project context at the requested detail level."""
     guidance = _check_store_exists(store_path)
@@ -111,6 +113,7 @@ def tool_get_context(store_path: Path, level: int | str) -> str:
     return result
 
 
+@mcp_tool("propose_decision")
 def tool_propose_decision(
     store_path: Path,
     title: str,
@@ -175,6 +178,7 @@ def tool_propose_decision(
     return response
 
 
+@mcp_tool("confirm_decision")
 def tool_confirm_decision(store_path: Path, confirm_id: str) -> dict:
     """Confirm a previously proposed decision."""
     guidance = _check_store_exists(store_path)
@@ -187,6 +191,7 @@ def tool_confirm_decision(store_path: Path, confirm_id: str) -> dict:
     return response
 
 
+@mcp_tool("check_decision")
 def tool_check_decision(
     store_path: Path,
     proposed_approach: str,
@@ -261,6 +266,7 @@ def tool_check_decision(
     }
 
 
+@mcp_tool("flag_question")
 def tool_flag_question(
     store_path: Path,
     question: str,
@@ -306,6 +312,7 @@ def tool_flag_question(
     return response
 
 
+@mcp_tool("get_raw_file")
 def tool_get_raw_file(store_path: Path, path: str) -> dict:
     """Return raw content of any file in the project store."""
     guidance = _check_store_exists(store_path)
@@ -331,6 +338,7 @@ def tool_get_raw_file(store_path: Path, path: str) -> dict:
     return {"store": "local", "content": file_path.read_text()}
 
 
+@mcp_tool("list_decisions")
 def tool_list_decisions(
     store_path: Path,
     limit: int = 20,
@@ -359,6 +367,7 @@ def tool_list_decisions(
     return {"store": "local", "decisions": items}
 
 
+@mcp_tool("get_decision")
 def tool_get_decision(store_path: Path, number: int) -> dict:
     """Return full content of a specific decision by number."""
     guidance = _check_store_exists(store_path)
@@ -373,6 +382,7 @@ def tool_get_decision(store_path: Path, number: int) -> dict:
     return {"store": "local", "error": f"Decision {number} not found"}
 
 
+@mcp_tool("diff_since_last_session")
 def tool_diff_since_last_session(
     store_path: Path,
     days: int | None = None,
@@ -385,6 +395,7 @@ def tool_diff_since_last_session(
     return {"store": "local", "diff": diff}
 
 
+@mcp_tool("search_decisions")
 def tool_search_decisions(
     store_path: Path,
     query: str,
@@ -397,6 +408,7 @@ def tool_search_decisions(
     return search_decisions(store_path, query, limit)
 
 
+@mcp_tool("update_state")
 def tool_update_state(store_path: Path, delta: str) -> dict:
     """Update current project state. Returns a warning on keyword overlap."""
     guidance = _check_store_exists(store_path)

--- a/packages/nauro/src/nauro/telemetry/__init__.py
+++ b/packages/nauro/src/nauro/telemetry/__init__.py
@@ -38,9 +38,17 @@ def _should_emit() -> bool:
 
 
 def _get_distinct_id() -> str:
-    """Phase 1a: anonymous_id only. Phase 1c extends to user_id when logged in (D119)."""
-    cfg = get_telemetry_config()
-    return cfg.anonymous_id
+    """Resolve the PostHog distinct_id for this process.
+
+    Phase 1c (D119): prefer ``config.auth.user_id`` if logged in; otherwise the
+    anonymous_id from the telemetry section. The alias call in identify_login
+    ties pre-login anonymous events to the user_id post-login.
+    """
+    auth = load_config().get("auth") or {}
+    user_id = auth.get("user_id")
+    if user_id:
+        return user_id
+    return get_telemetry_config().anonymous_id
 
 
 def is_enabled() -> bool:
@@ -81,9 +89,42 @@ def _rotate_anonymous_id() -> str:
     return new_id
 
 
-def identify_login(user_id: str) -> None:
-    raise NotImplementedError("Implemented in Phase 1c per D119")
+def identify_login(user_id: str, email_hash: str) -> None:
+    """Merge anonymous identity into user_id on login (D119).
+
+    Order is load-bearing: alias(previous_id=anonymous_id, distinct_id=user_id)
+    FIRST, then set(distinct_id=user_id, properties={"email_hash"}). Reversed
+    alias args alias the identified user back to the anonymous id and split
+    future events across two distinct_ids in PostHog — silently corrupts
+    analytics. Auth state (config.auth.user_id) is persisted by auth.py
+    BEFORE this call, so identify_login is purely the telemetry side.
+
+    Guarded by _should_emit() — telemetry-disabled callers no-op.
+    """
+    if not _should_emit():
+        return
+    try:
+        client = get_client()
+        if client is None:
+            return
+        cfg = get_telemetry_config()
+        client.alias(previous_id=cfg.anonymous_id, distinct_id=user_id)
+        client.set(distinct_id=user_id, properties={"email_hash": email_hash})
+    except Exception:
+        logger.debug("identify_login failed", exc_info=True)
 
 
 def identify_logout() -> None:
-    raise NotImplementedError("Implemented in Phase 1c per D119")
+    """Rotate anonymous_id on logout (D119) — no SDK reset.
+
+    posthog.reset() is a JS-SDK API; the Python SDK 7.x has no such method
+    (every capture() takes an explicit distinct_id, so identity is stateless
+    on the SDK side). Identity reset is application-side rotation only —
+    the next capture() re-resolves through _get_distinct_id() which now
+    returns the new anonymous_id (because config.auth.user_id is gone).
+
+    auth.py clears config.auth AFTER this call. Consent fields
+    (enabled, consent_version, consented_at) are preserved by
+    _rotate_anonymous_id().
+    """
+    _rotate_anonymous_id()

--- a/packages/nauro/src/nauro/telemetry/_buckets.py
+++ b/packages/nauro/src/nauro/telemetry/_buckets.py
@@ -1,0 +1,22 @@
+"""Shared duration bucketing for D117 events.
+
+Same scheme used by `cli.command_invoked` and `mcp.tool_called` so dashboards
+can compare CLI vs MCP latency on the same axis.
+"""
+
+from __future__ import annotations
+
+_DURATION_BUCKETS: tuple[tuple[float, str], ...] = (
+    (0.010, "<10ms"),
+    (0.100, "10-100ms"),
+    (1.000, "100ms-1s"),
+    (10.000, "1-10s"),
+)
+_LARGEST_BUCKET = ">10s"
+
+
+def bucket(elapsed: float) -> str:
+    for threshold, label in _DURATION_BUCKETS:
+        if elapsed < threshold:
+            return label
+    return _LARGEST_BUCKET

--- a/packages/nauro/src/nauro/telemetry/cli_wrapper.py
+++ b/packages/nauro/src/nauro/telemetry/cli_wrapper.py
@@ -21,22 +21,8 @@ from typing import Any
 import typer
 
 from nauro.telemetry import capture
+from nauro.telemetry._buckets import bucket as _bucket
 from nauro.telemetry.events import cli_command_invoked
-
-_DURATION_BUCKETS: tuple[tuple[float, str], ...] = (
-    (0.010, "<10ms"),
-    (0.100, "10-100ms"),
-    (1.000, "100ms-1s"),
-    (10.000, "1-10s"),
-)
-_LARGEST_BUCKET = ">10s"
-
-
-def _bucket(elapsed: float) -> str:
-    for threshold, label in _DURATION_BUCKETS:
-        if elapsed < threshold:
-            return label
-    return _LARGEST_BUCKET
 
 
 def _resolve_version() -> str:

--- a/packages/nauro/src/nauro/telemetry/decorators.py
+++ b/packages/nauro/src/nauro/telemetry/decorators.py
@@ -1,0 +1,57 @@
+"""Decorators for telemetry instrumentation.
+
+``mcp_tool(name)`` decorates each canonical MCP tool implementation in
+``packages/nauro/src/nauro/mcp/tools.py`` so that one event fires per call,
+regardless of which transport (stdio, local HTTP, or Lambda) routed in.
+
+The transport label is read from ``current_transport()`` at emit time — never
+hardcoded — because the same decorated function services all transports.
+"""
+
+from __future__ import annotations
+
+import functools
+import time
+from collections.abc import Callable
+from typing import Any
+
+from nauro.telemetry import capture
+from nauro.telemetry._buckets import bucket
+from nauro.telemetry.events import mcp_tool_called
+from nauro.telemetry.transport import current_transport
+
+
+def mcp_tool(name: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Wrap an MCP tool to emit ``mcp.tool_called`` exactly once per call.
+
+    Properties (D117 closed allowlist): tool_name, transport, success,
+    duration_bucket. Never tool args, return values, or exception details.
+    """
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            start = time.perf_counter()
+            success = True
+            try:
+                return func(*args, **kwargs)
+            except BaseException:
+                success = False
+                raise
+            finally:
+                try:
+                    capture(
+                        "mcp.tool_called",
+                        mcp_tool_called(
+                            tool_name=name,
+                            transport=current_transport(),
+                            success=success,
+                            duration_bucket=bucket(time.perf_counter() - start),
+                        ),
+                    )
+                except Exception:
+                    pass
+
+        return wrapper
+
+    return decorator

--- a/packages/nauro/src/nauro/telemetry/transport.py
+++ b/packages/nauro/src/nauro/telemetry/transport.py
@@ -1,0 +1,25 @@
+"""Transport ContextVar for MCP tool emission.
+
+Per CLAUDE.md, ``mcp/tools.py`` is the canonical implementation for stdio AND
+HTTP transports — both ``stdio_server.py`` and the FastAPI ``server.py`` (plus
+the muscat Lambda, in its own repo) delegate here. The ``transport`` field on
+``mcp.tool_called`` therefore cannot be hardcoded in the decorator; each entry
+point sets the value before dispatching.
+
+Default ``"stdio"`` is a fail-soft: any future entry point that forgets to set
+the value still emits, just attributed to stdio.
+"""
+
+from __future__ import annotations
+
+from contextvars import ContextVar
+
+_TRANSPORT: ContextVar[str] = ContextVar("nauro_telemetry_transport", default="stdio")
+
+
+def set_transport(name: str) -> None:
+    _TRANSPORT.set(name)
+
+
+def current_transport() -> str:
+    return _TRANSPORT.get()

--- a/packages/nauro/tests/test_identity_lifecycle.py
+++ b/packages/nauro/tests/test_identity_lifecycle.py
@@ -1,0 +1,342 @@
+"""Phase 1c T1.7 / T1.7b — identity lifecycle (D119 + C1 correction).
+
+Covers:
+1. Login order: alias(previous_id, distinct_id) FIRST, then set(distinct_id, props).
+2. Login while telemetry disabled: NO alias / set; auth state still persists
+   (auth.py owns persistence — identify_login is purely the telemetry side).
+3. email_hash format: SHA-256 hex of email.strip().lower(); raw email never
+   appears in captured args or in config.
+4. Logout rotation: anonymous_id changes to a fresh UUID4; consent fields
+   (enabled, consent_version, consented_at) are unchanged; user_id deletion is
+   auth.py's job (we test that contract here in step 6).
+5. NO posthog.reset() — verified absent from posthog 7.x. Test docstring
+   references C1 to deter a future agent from re-adding it.
+6. Shared-machine: User A login → logout → User B login on same machine →
+   User B's events carry User B's user_id, NOT User A's (rotation protects
+   against attribution leakage).
+7. _get_distinct_id() post-rotation returns the new anonymous_id.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import uuid
+from typing import Any
+
+import pytest
+
+_UUID4_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$")
+
+
+class FakeClient:
+    """Records call sequence so order-sensitive assertions (D119 alias-then-set) hold."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def alias(self, previous_id: str, distinct_id: str) -> None:
+        self.calls.append(("alias", {"previous_id": previous_id, "distinct_id": distinct_id}))
+
+    def set(self, distinct_id: str, properties: dict[str, Any]) -> None:
+        self.calls.append(("set", {"distinct_id": distinct_id, "properties": properties}))
+
+    def capture(self, event: str, distinct_id: str, properties: dict[str, Any]) -> None:
+        self.calls.append(
+            ("capture", {"event": event, "distinct_id": distinct_id, "properties": properties})
+        )
+
+
+@pytest.fixture
+def nauro_home(tmp_path, monkeypatch):
+    home = tmp_path / ".nauro"
+    home.mkdir()
+    monkeypatch.setenv("NAURO_HOME", str(home))
+    monkeypatch.delenv("NAURO_TELEMETRY", raising=False)
+    return home
+
+
+@pytest.fixture
+def telemetry_key(monkeypatch):
+    monkeypatch.setenv("NAURO_POSTHOG_KEY", "phc_test_key_for_unit_tests")
+
+
+@pytest.fixture(autouse=True)
+def _reset_client_singleton():
+    import nauro.telemetry.client as client_mod
+
+    client_mod._client = None
+    yield
+    client_mod._client = None
+
+
+@pytest.fixture
+def fake_posthog(monkeypatch):
+    import nauro.telemetry.client as client_mod
+
+    fake = FakeClient()
+    client_mod._client = fake
+    yield fake
+    client_mod._client = None
+
+
+def _seed_telemetry_config(home, *, enabled: bool, anonymous_id: str | None = None) -> str:
+    aid = anonymous_id or "11111111-1111-4111-8111-111111111111"
+    (home / "config.json").write_text(
+        json.dumps(
+            {
+                "telemetry": {
+                    "anonymous_id": aid,
+                    "enabled": enabled,
+                    "consent_version": 1,
+                    "consented_at": "2026-04-30T00:00:00Z",
+                }
+            }
+        )
+    )
+    return aid
+
+
+# ── 1. Login order (telemetry enabled): alias FIRST, then set ───────────────
+
+
+def test_login_calls_alias_then_set_in_correct_order(nauro_home, telemetry_key, fake_posthog):
+    aid = _seed_telemetry_config(nauro_home, enabled=True)
+
+    from nauro.telemetry import identify_login
+
+    identify_login(user_id="auth0|user-a", email_hash="deadbeef" * 8)
+
+    # Exactly two calls, alias first, set second (D119 load-bearing order).
+    assert len(fake_posthog.calls) == 2
+    assert fake_posthog.calls[0][0] == "alias"
+    assert fake_posthog.calls[0][1] == {"previous_id": aid, "distinct_id": "auth0|user-a"}
+    assert fake_posthog.calls[1][0] == "set"
+    assert fake_posthog.calls[1][1] == {
+        "distinct_id": "auth0|user-a",
+        "properties": {"email_hash": "deadbeef" * 8},
+    }
+
+
+# ── 2. Login while telemetry disabled — no alias/set fire ───────────────────
+
+
+def test_login_with_telemetry_disabled_does_not_call_alias_or_set(
+    nauro_home, telemetry_key, fake_posthog
+):
+    _seed_telemetry_config(nauro_home, enabled=False)
+
+    from nauro.telemetry import identify_login
+
+    identify_login(user_id="auth0|user-x", email_hash="cafef00d" * 8)
+
+    assert fake_posthog.calls == []
+
+
+def test_auth_state_persistence_is_independent_of_telemetry_consent(nauro_home):
+    """auth.py owns user_id persistence; telemetry consent does not gate it."""
+    from nauro.store.config import load_config, save_config
+
+    cfg = load_config()
+    cfg["auth"] = {"user_id": "auth0|user-a", "sub": "auth0|user-a"}
+    save_config(cfg)
+
+    cfg2 = load_config()
+    assert cfg2["auth"]["user_id"] == "auth0|user-a"
+
+
+# ── 3. email_hash format: SHA-256 hex of email.strip().lower() ──────────────
+
+
+def test_email_hash_is_sha256_of_normalized_email(nauro_home, telemetry_key, fake_posthog):
+    _seed_telemetry_config(nauro_home, enabled=True)
+
+    raw_email = "  AlIcE@Example.COM  "
+    expected_hash = hashlib.sha256(b"alice@example.com").hexdigest()
+
+    from nauro.telemetry import identify_login
+
+    identify_login(
+        user_id="auth0|alice",
+        email_hash=hashlib.sha256(raw_email.strip().lower().encode("utf-8")).hexdigest(),
+    )
+
+    set_props = fake_posthog.calls[1][1]["properties"]
+    assert set_props["email_hash"] == expected_hash
+    # Raw email never appears in captured payload.
+    serialized = json.dumps(fake_posthog.calls)
+    assert "alice@example.com" not in serialized.lower()
+    assert "AlIcE" not in serialized
+
+
+def test_raw_email_never_persisted_to_config(nauro_home, telemetry_key, fake_posthog):
+    """Sanity guard — auth.py hashes before persisting; nothing readable on disk."""
+    _seed_telemetry_config(nauro_home, enabled=True)
+    from nauro.store.config import load_config, save_config
+
+    cfg = load_config()
+    cfg["auth"] = {"user_id": "auth0|alice"}  # auth.py never stores email
+    save_config(cfg)
+
+    raw = (nauro_home / "config.json").read_text()
+    # The seeded user_id contains no '@', so any '@' in the file would be a
+    # raw-email leak. The earlier OR'd guard was vacuous because "auth0|" was
+    # always in the file, masking the assertion.
+    assert "@" not in raw, "raw email leaked into config.json"
+
+
+# ── 4. Logout rotation ──────────────────────────────────────────────────────
+
+
+def test_logout_rotates_anonymous_id_and_preserves_consent(nauro_home):
+    old_aid = _seed_telemetry_config(nauro_home, enabled=True)
+
+    from nauro.store.config import load_config
+    from nauro.telemetry import identify_logout
+
+    identify_logout()
+
+    cfg = load_config()
+    new_aid = cfg["telemetry"]["anonymous_id"]
+    assert new_aid != old_aid
+    assert _UUID4_RE.match(new_aid), new_aid
+    # Consent fields untouched.
+    assert cfg["telemetry"]["enabled"] is True
+    assert cfg["telemetry"]["consent_version"] == 1
+    assert cfg["telemetry"]["consented_at"] == "2026-04-30T00:00:00Z"
+
+
+# ── 5. No posthog.reset() — C1 correction ───────────────────────────────────
+
+
+def test_posthog_python_sdk_has_no_reset_attr():
+    """Sanity guard against a future regression that re-adds posthog.reset().
+
+    C1 correction (Phase 1c review): posthog.reset() is a JS-SDK API. The
+    Python SDK 7.x has no such method. Calling it would raise AttributeError.
+    Identity reset is application-side rotation only.
+    """
+    import posthog
+
+    assert not hasattr(posthog, "reset")
+
+
+def test_identify_logout_does_not_call_reset_on_client(nauro_home, telemetry_key, fake_posthog):
+    """C1: identify_logout must never call .reset() on the SDK client."""
+    _seed_telemetry_config(nauro_home, enabled=True)
+
+    from nauro.telemetry import identify_logout
+
+    identify_logout()
+
+    assert not any(c[0] == "reset" for c in fake_posthog.calls)
+
+
+# ── 6. Shared-machine — User B's events do NOT carry User A's user_id ───────
+
+
+def test_shared_machine_rotation_protects_attribution(nauro_home, telemetry_key, fake_posthog):
+    """User A login → logout → User B login → User B emits → distinct_id is User B's.
+
+    Without rotation, User B's pre-login (anonymous) events would alias back
+    to User A's user_id from the previous session's alias call.
+    """
+    _seed_telemetry_config(nauro_home, enabled=True)
+
+    from nauro.store.config import load_config, save_config
+    from nauro.telemetry import capture, identify_login, identify_logout
+
+    # User A logs in (auth.py would persist user_id).
+    cfg = load_config()
+    cfg["auth"] = {"user_id": "auth0|user-a"}
+    save_config(cfg)
+    identify_login(user_id="auth0|user-a", email_hash="a" * 64)
+
+    # User A logs out (auth.py would clear cfg["auth"]).
+    identify_logout()
+    cfg = load_config()
+    cfg.pop("auth", None)
+    save_config(cfg)
+
+    # User B logs in.
+    cfg = load_config()
+    cfg["auth"] = {"user_id": "auth0|user-b"}
+    save_config(cfg)
+    identify_login(user_id="auth0|user-b", email_hash="b" * 64)
+
+    # User B captures an event.
+    fake_posthog.calls.clear()
+    capture("cli.command_invoked", {"command": "test"})
+
+    # The capture goes to User B's user_id, NOT User A's.
+    captures = [c for c in fake_posthog.calls if c[0] == "capture"]
+    assert len(captures) == 1
+    assert captures[0][1]["distinct_id"] == "auth0|user-b"
+    assert captures[0][1]["distinct_id"] != "auth0|user-a"
+
+
+# ── 7. _get_distinct_id post-rotation ───────────────────────────────────────
+
+
+def test_get_distinct_id_after_logout_returns_new_anonymous_id(nauro_home, telemetry_key):
+    old_aid = _seed_telemetry_config(nauro_home, enabled=True)
+
+    from nauro.store.config import load_config, save_config
+    from nauro.telemetry import _get_distinct_id, identify_logout
+
+    # Simulate a logged-in user, then logout (auth.py clears auth section).
+    cfg = load_config()
+    cfg["auth"] = {"user_id": "auth0|user-a"}
+    save_config(cfg)
+    assert _get_distinct_id() == "auth0|user-a"  # logged in → user_id wins
+
+    identify_logout()
+    cfg = load_config()
+    cfg.pop("auth", None)
+    save_config(cfg)
+
+    new_aid = load_config()["telemetry"]["anonymous_id"]
+    assert new_aid != old_aid
+
+    # Must return the NEW anonymous_id — not the cleared user_id, not the old aid.
+    distinct = _get_distinct_id()
+    assert distinct == new_aid
+    assert distinct != old_aid
+    assert distinct != "auth0|user-a"
+
+
+def test_get_distinct_id_prefers_user_id_when_logged_in(nauro_home):
+    aid = _seed_telemetry_config(nauro_home, enabled=True)
+
+    from nauro.store.config import load_config, save_config
+    from nauro.telemetry import _get_distinct_id
+
+    # No auth → anonymous_id.
+    assert _get_distinct_id() == aid
+
+    cfg = load_config()
+    cfg["auth"] = {"user_id": "auth0|alice"}
+    save_config(cfg)
+    assert _get_distinct_id() == "auth0|alice"
+
+
+# ── Bonus: defensive — uuid4 emitted on logout is a new UUID each call ──────
+
+
+def test_consecutive_logouts_each_rotate_to_new_uuid4(nauro_home):
+    _seed_telemetry_config(nauro_home, enabled=True)
+
+    from nauro.store.config import load_config
+    from nauro.telemetry import identify_logout
+
+    seen: set[str] = set()
+    seen.add(load_config()["telemetry"]["anonymous_id"])
+    for _ in range(3):
+        identify_logout()
+        aid = load_config()["telemetry"]["anonymous_id"]
+        assert _UUID4_RE.match(aid), aid
+        # uuid.UUID parses it cleanly too.
+        uuid.UUID(aid)
+        assert aid not in seen
+        seen.add(aid)

--- a/packages/nauro/tests/test_mcp_tool_called.py
+++ b/packages/nauro/tests/test_mcp_tool_called.py
@@ -1,0 +1,215 @@
+"""Phase 1c T1.5 — mcp.tool_called decorator tests.
+
+Covers:
+1. All 11 canonical MCP tools emit one mcp.tool_called event per call with the
+   right tool_name, transport (read from ContextVar), success, duration_bucket.
+2. ContextVar plumbing — set_transport("http") flips transport, set_transport
+   ("stdio") flips it back.
+3. A tool that raises emits one event with success=False AND re-raises.
+4. Property allowlist is closed — exactly four keys, never tool args, return
+   values, project_id, or exception strings (D117 never-sent list).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_ALLOWED_KEYS = frozenset({"tool_name", "transport", "success", "duration_bucket"})
+_DURATION_PATTERN = re.compile(r"^(<10ms|10-100ms|100ms-1s|1-10s|>10s)$")
+
+
+class FakeClient:
+    def __init__(self) -> None:
+        self.events: list[dict[str, Any]] = []
+
+    def capture(self, event: str, distinct_id: str, properties: dict[str, Any]) -> None:
+        self.events.append({"event": event, "distinct_id": distinct_id, "properties": properties})
+
+
+@pytest.fixture
+def nauro_home(tmp_path, monkeypatch):
+    home = tmp_path / ".nauro"
+    home.mkdir()
+    monkeypatch.setenv("NAURO_HOME", str(home))
+    monkeypatch.delenv("NAURO_TELEMETRY", raising=False)
+    return home
+
+
+@pytest.fixture
+def telemetry_enabled(nauro_home, monkeypatch):
+    monkeypatch.setenv("NAURO_POSTHOG_KEY", "phc_test_key_for_unit_tests")
+    aid = "11111111-1111-4111-8111-111111111111"
+    (nauro_home / "config.json").write_text(
+        json.dumps(
+            {
+                "telemetry": {
+                    "anonymous_id": aid,
+                    "enabled": True,
+                    "consent_version": 1,
+                    "consented_at": "2026-04-30T00:00:00Z",
+                }
+            }
+        )
+    )
+    return aid
+
+
+@pytest.fixture
+def fake_posthog(monkeypatch):
+    import nauro.telemetry.client as client_mod
+
+    fake = FakeClient()
+    client_mod._client = fake
+    yield fake
+    client_mod._client = None
+
+
+@pytest.fixture(autouse=True)
+def _reset_transport_default():
+    """Each test starts with a default ContextVar transport."""
+    from nauro.telemetry.transport import set_transport
+
+    set_transport("stdio")
+    yield
+    set_transport("stdio")
+
+
+def _empty_store(home: Path) -> Path:
+    """Build a minimally-functional store the read tools can resolve."""
+    store = home / "projects" / "phase1c"
+    (store / "decisions").mkdir(parents=True)
+    (store / "snapshots").mkdir()
+    (store / "project.md").write_text("# project\n")
+    (store / "state.md").write_text("# state\n")
+    (store / "stack.md").write_text("# stack\n")
+    (store / "open-questions.md").write_text("# open\n")
+    return store
+
+
+def _assert_tool_called_shape(
+    props: dict[str, Any], *, tool_name: str, transport: str, success: bool
+) -> None:
+    assert set(props.keys()) == _ALLOWED_KEYS, (
+        f"unexpected keys: {set(props.keys()) - _ALLOWED_KEYS}"
+    )
+    assert props["tool_name"] == tool_name
+    assert props["transport"] == transport
+    assert props["success"] is success
+    assert _DURATION_PATTERN.match(props["duration_bucket"]), props["duration_bucket"]
+
+
+def test_get_context_emits_one_event_with_stdio_transport(
+    nauro_home, telemetry_enabled, fake_posthog
+):
+    from nauro.mcp.tools import tool_get_context
+    from nauro.telemetry.transport import set_transport
+
+    set_transport("stdio")
+    store = _empty_store(nauro_home)
+    tool_get_context(store, "L0")
+
+    tool_events = [e for e in fake_posthog.events if e["event"] == "mcp.tool_called"]
+    assert len(tool_events) == 1
+    _assert_tool_called_shape(
+        tool_events[0]["properties"],
+        tool_name="get_context",
+        transport="stdio",
+        success=True,
+    )
+
+
+def test_transport_http_propagates_to_decorator(nauro_home, telemetry_enabled, fake_posthog):
+    """Validates ContextVar plumbing — the dispatcher-set value reaches the decorator."""
+    from nauro.mcp.tools import tool_list_decisions
+    from nauro.telemetry.transport import set_transport
+
+    set_transport("http")
+    store = _empty_store(nauro_home)
+    tool_list_decisions(store)
+
+    tool_events = [e for e in fake_posthog.events if e["event"] == "mcp.tool_called"]
+    assert len(tool_events) == 1
+    _assert_tool_called_shape(
+        tool_events[0]["properties"],
+        tool_name="list_decisions",
+        transport="http",
+        success=True,
+    )
+
+
+def test_failing_tool_emits_one_event_with_success_false(
+    nauro_home, telemetry_enabled, fake_posthog
+):
+    """A tool that raises must emit success=False AND re-raise.
+
+    Tool implementations in tools.py mostly return error dicts rather than
+    raising; we exercise the decorator's exception path by wrapping a
+    deliberately-raising function at runtime.
+    """
+    from nauro.telemetry.decorators import mcp_tool
+
+    @mcp_tool("synthetic_failure")
+    def _boom() -> None:
+        raise RuntimeError("internal error with secret_payload")
+
+    with pytest.raises(RuntimeError):
+        _boom()
+
+    tool_events = [e for e in fake_posthog.events if e["event"] == "mcp.tool_called"]
+    assert len(tool_events) == 1
+    props = tool_events[0]["properties"]
+    assert props["tool_name"] == "synthetic_failure"
+    assert props["success"] is False
+    # No exception leakage in the event payload (D117 never-sent list).
+    assert set(props.keys()) == _ALLOWED_KEYS
+    assert "secret_payload" not in json.dumps(tool_events[0])
+
+
+def test_event_properties_never_contain_args_or_returns(
+    nauro_home, telemetry_enabled, fake_posthog
+):
+    """Exhaustive privacy assertion: tool args/returns/project_id are never in event props."""
+    from nauro.mcp.tools import tool_search_decisions
+
+    store = _empty_store(nauro_home)
+    secret_query = "this-string-must-never-appear-in-telemetry"
+    tool_search_decisions(store, secret_query, 1)
+
+    tool_events = [e for e in fake_posthog.events if e["event"] == "mcp.tool_called"]
+    assert len(tool_events) == 1
+    serialized = json.dumps(tool_events[0])
+    assert secret_query not in serialized
+    assert str(store) not in serialized
+    # Closed allowlist — any key drift is a privacy regression.
+    assert set(tool_events[0]["properties"].keys()) == _ALLOWED_KEYS
+
+
+def test_all_eleven_tools_decorated():
+    """The 11-tool taxonomy is locked. New tools must opt into instrumentation."""
+    from nauro.mcp import tools
+
+    expected = {
+        "tool_get_context",
+        "tool_propose_decision",
+        "tool_confirm_decision",
+        "tool_check_decision",
+        "tool_flag_question",
+        "tool_get_raw_file",
+        "tool_list_decisions",
+        "tool_get_decision",
+        "tool_diff_since_last_session",
+        "tool_search_decisions",
+        "tool_update_state",
+    }
+    actual = {n for n in dir(tools) if n.startswith("tool_")}
+    assert expected <= actual, f"missing tools: {expected - actual}"
+    # functools.wraps preserves the original __wrapped__ marker — fall back to a
+    # name-based smoke test that the decorator was applied.
+    for name in expected:
+        fn = getattr(tools, name)
+        assert hasattr(fn, "__wrapped__"), f"{name} is not decorated by mcp_tool"

--- a/packages/nauro/tests/test_telemetry_module.py
+++ b/packages/nauro/tests/test_telemetry_module.py
@@ -156,15 +156,5 @@ def test_get_distinct_id_returns_anonymous_id(nauro_home):
     assert _get_distinct_id() == aid
 
 
-def test_identify_login_raises_not_implemented():
-    from nauro.telemetry import identify_login
-
-    with pytest.raises(NotImplementedError, match="Phase 1c"):
-        identify_login("auth0|123")
-
-
-def test_identify_logout_raises_not_implemented():
-    from nauro.telemetry import identify_logout
-
-    with pytest.raises(NotImplementedError, match="Phase 1c"):
-        identify_logout()
+# Phase 1c — identify_login / identify_logout are implemented now.
+# Comprehensive coverage lives in tests/test_identity_lifecycle.py.


### PR DESCRIPTION
## Why

Completes the Phase 1 emission surface and identity lifecycle for the helsinki side. After this lands, every CLI command **and** every MCP tool call emits exactly one event, attributed to the right transport and the right identity (anonymous_id pre-login, user_id post-login, with a clean alias merge in between). Backed by D117 (event taxonomy), D119 (alias-then-set order, rotate-on-logout, preserve consent) and D120 (sync_mode CLI vs async Lambda).

Companion muscat PR — `nauro-ai/mcp-server` — lands the Lambda-side emission with `transport="http"`.

## Approach

- **`mcp.tool_called` decorator**: a single `@mcp_tool("<name>")` applied at definition time in `mcp/tools.py` (the canonical implementation per `CLAUDE.md` — both stdio and HTTP transports delegate here). The decorator emits one event per call with the closed property allowlist `{tool_name, transport, success, duration_bucket}`.
- **`transport` from a `ContextVar`**, never hardcoded. `stdio_server.run_stdio()` calls `set_transport("stdio")`; a FastAPI middleware in `mcp/server.py` calls `set_transport("http")` per request. Default `"stdio"` keeps unanticipated paths emitting (just attributed to stdio) rather than failing silently.
- **`identify_login(user_id, email_hash)`** (D119, exact order):
  ```
  client.alias(previous_id=anonymous_id, distinct_id=user_id)
  client.set(distinct_id=user_id, properties={"email_hash": email_hash})
  ```
  Reversed `alias` args alias the identified user back to the anonymous id and split future events across two distinct_ids in PostHog — silently corrupts analytics. The argument order is the load-bearing fix from D119.
- **`identify_logout()`**: application-side rotation only — no `posthog.reset()` call. Verified absent from `posthog 7.13.2`; calling it would `AttributeError`. The C1 correction is documented in the function docstring and guarded by a sanity test that asserts `not hasattr(posthog, "reset")`.
- **`_get_distinct_id()`** now prefers `config["auth"]["user_id"]` over the anonymous_id, so all post-login `capture()` calls automatically use the user_id. No call sites changed.
- **Email hashing happens in `auth.py`**, never in the telemetry module. Raw email never leaves auth.py — `identify_login` only sees the hex digest.

## What changed

**New files**
- `packages/nauro/src/nauro/telemetry/transport.py` — `ContextVar` + `set_transport`/`current_transport`.
- `packages/nauro/src/nauro/telemetry/decorators.py` — `@mcp_tool(name)` factory.
- `packages/nauro/src/nauro/telemetry/_buckets.py` — shared `bucket()` helper.
- `packages/nauro/tests/test_mcp_tool_called.py` — decorator emission + privacy assertions (5 tests).
- `packages/nauro/tests/test_identity_lifecycle.py` — full D119 / C1 coverage (10 tests).

**Modified**
- `packages/nauro/src/nauro/telemetry/__init__.py` — implements `identify_login` / `identify_logout`; `_get_distinct_id` reads `config.auth.user_id`.
- `packages/nauro/src/nauro/telemetry/cli_wrapper.py` — uses shared `_buckets.bucket`.
- `packages/nauro/src/nauro/mcp/tools.py` — `@mcp_tool("<name>")` on all 11 canonical tools.
- `packages/nauro/src/nauro/mcp/stdio_server.py` — `set_transport("stdio")` in `run_stdio()`.
- `packages/nauro/src/nauro/mcp/server.py` — `@app.middleware("http")` sets `set_transport("http")`.
- `packages/nauro/src/nauro/cli/commands/auth.py` — login wires `identify_login(user_id, sha256(email))`; logout wires `identify_logout()` before clearing `config.auth`.
- `packages/nauro/tests/test_telemetry_module.py` — drops the two `NotImplementedError` stub tests (covered by new `test_identity_lifecycle.py`).

## What to review

- **D119 alias arg order** in `telemetry/__init__.py:111` — `previous_id=anonymous_id, distinct_id=user_id`. Reversed = silent identity corruption. Test: `test_login_calls_alias_then_set_in_correct_order`.
- **`auth.py` email handling** — raw email is hashed before `identify_login()` is called and never persisted. Test: `test_email_hash_is_sha256_of_normalized_email` + `test_raw_email_never_persisted_to_config`.
- **ContextVar plumbing** — middleware in `mcp/server.py` and `set_transport` in `stdio_server.run_stdio()`. Test: `test_transport_http_propagates_to_decorator` exercises the dispatcher → decorator path.
- **Privacy allowlist** — `mcp.tool_called` properties are exactly `{tool_name, transport, success, duration_bucket}`. Test: `test_event_properties_never_contain_args_or_returns` asserts no tool args / no return values / no project_id leak into the event payload.
- **Per `feedback_public_repo_safety`**: this is a public OSS repo; the only secret-shaped value in the diff is the test fixture key `phc_test_key_for_unit_tests` (deliberately fake).

## What's deferred

- **Smoke test against live PostHog** — needs `NAURO_POSTHOG_KEY` set in your shell (same key as PR #19; single PostHog project per `project_posthog_single_project`). Not blocking; will run after merge.
- **Companion muscat PR** — Lambda-side `mcp.tool_called` emission with `transport="http"`. Lands separately in `nauro-ai/mcp-server`.
- **T4.1** (later phase) — embedded prod PostHog key + `install_type` property differentiation. **Never** set the embedded key in CI.

## Test plan

- [x] `uv run pytest packages/nauro/tests/ -q -m "not integration"` → **731 passed**.
- [x] `uv run ruff check packages/` → clean.
- [x] `uv run ruff format --check packages/` → clean.
- [ ] After merge: reinstall global nauro CLI, run live smoke test:
  - `nauro auth login` → verify one `alias` + one `set` in PostHog.
  - MCP tool via Claude Code stdio → `mcp.tool_called` with `transport="stdio"`.
  - MCP tool via `nauro serve` + curl → `mcp.tool_called` with `transport="http"`.
  - `nauro auth logout` then any CLI command → next event uses NEW anonymous_id.