### PR TITLE
Auto-resolve project_id + tighten check_decision (nauro-core 0.5.0)

### DIFF
--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro-core"
-version = "0.4.0"
+version = "0.5.0"
 description = "Shared pure-Python logic for Nauro: parsing, validation, context assembly, constants."
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/nauro-core/src/nauro_core/__init__.py
+++ b/packages/nauro-core/src/nauro_core/__init__.py
@@ -3,7 +3,7 @@
 Re-export facade — public API symbols from all modules.
 """
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 
 from nauro_core.constants import (
     DECISION_HASHES_FILE as DECISION_HASHES_FILE,

--- a/packages/nauro-core/src/nauro_core/constants.py
+++ b/packages/nauro-core/src/nauro_core/constants.py
@@ -73,12 +73,14 @@ new decisions as you make them.
 
 ## When to check decisions
 
-Before adopting any technical approach — architecture, library choice, \
-API design, data model, infrastructure — call `check_decision` with a \
-description of what you're considering. This includes when the user asks \
-"should we...", "what if we...", "can we...", or "check if...". \
-The tool surfaces conflicts with past decisions so you don't repeat \
-rejected approaches.
+Before responding to any technical change request — architecture, \
+library choice, API design, data model, infrastructure, vendor swap — \
+call `check_decision` with a description of what's being proposed. \
+This includes "should we...", "what if we...", "can we...", "check if..." \
+framings, and applies even when you intend to push back or refuse. \
+Your first-principles reasoning is not a substitute for project history; \
+`check_decision` is a precondition, not an option. The tool surfaces \
+conflicts with past decisions so you don't repeat rejected approaches.
 
 ## When to propose decisions
 

--- a/packages/nauro-core/src/nauro_core/instructions.py
+++ b/packages/nauro-core/src/nauro_core/instructions.py
@@ -2,8 +2,10 @@
 
 The static instructional block (MCP_INSTRUCTIONS_STATIC) is project-agnostic.
 Remote callers append a small section listing the user's projects so Claude
-can pick a project_id without a discovery roundtrip. For users with no
-projects, WELCOME_NO_PROJECT replaces the project list with onboarding copy.
+knows which projects exist. Tools auto-resolve to the user's project when
+they have only one; the per-user section is informational + disambiguation
+hint when they have multiple. For users with no projects, WELCOME_NO_PROJECT
+replaces the project list with onboarding copy.
 """
 
 from __future__ import annotations
@@ -21,8 +23,8 @@ WELCOME_NO_PROJECT = (
     "3. Or, if a teammate already created a cloud project, run "
     "`nauro attach <project_id>` to connect this machine to it.\n"
     "\n"
-    "Once a project exists, every tool call (except list_projects) requires "
-    "its project_id."
+    "Once a project exists, tools auto-resolve to it — you do not need to "
+    "pass a project_id."
 )
 
 
@@ -37,7 +39,7 @@ def build_remote_instructions(
 
     - Empty list: append WELCOME_NO_PROJECT.
     - 1..MAX_INLINE_PROJECTS: append "Your projects:" with each rendered as
-      `name — {project_id[:8]}`, sorted by (name.lower(), project_id).
+      `name — {full project_id}`, sorted by (name.lower(), project_id).
     - More than MAX_INLINE_PROJECTS: append a count + hint to call
       list_projects, without enumerating each one.
     """
@@ -51,13 +53,16 @@ def build_remote_instructions(
         )
         lines = ["Your projects:"]
         for p in ordered:
-            lines.append(f"- {p['name']} — {p['project_id'][:8]}")
-        lines.append("\nPass the matching project_id to every tool call (except list_projects).")
+            lines.append(f"- {p['name']} — {p['project_id']}")
+        lines.append(
+            "\nTools resolve to your project automatically when you have one; "
+            "pass an explicit project_id only if you have multiple."
+        )
         return f"{static_block}\n\n" + "\n".join(lines)
 
     return (
         f"{static_block}\n\n"
         f"You have {len(projects)} projects. "
-        "Call list_projects to see them all and pick a project_id; "
-        "every tool call except list_projects requires one."
+        "Tools require an explicit project_id when multiple exist — "
+        "call list_projects to see them all and pick one."
     )

--- a/packages/nauro-core/src/nauro_core/mcp_tools.py
+++ b/packages/nauro-core/src/nauro_core/mcp_tools.py
@@ -42,8 +42,9 @@ class ToolSpec(TypedDict):
 _PROJECT_PARAM: dict[str, Any] = {
     "type": "string",
     "description": (
-        "Project ID (ULID). Required for every tool except list_projects. "
-        "Call list_projects to discover the IDs available to the current user."
+        "Optional. If you have one project, the server resolves it "
+        "automatically. Pass explicitly if you have multiple — call "
+        "list_projects to discover the IDs available to the current user."
     ),
 }
 
@@ -90,7 +91,7 @@ GET_CONTEXT: ToolSpec = {
             },
             "project_id": _PROJECT_PARAM,
         },
-        "required": ["project_id"],
+        "required": [],
     },
 }
 
@@ -121,7 +122,7 @@ GET_RAW_FILE: ToolSpec = {
             },
             "project_id": _PROJECT_PARAM,
         },
-        "required": ["path", "project_id"],
+        "required": ["path"],
     },
 }
 
@@ -149,7 +150,7 @@ LIST_DECISIONS: ToolSpec = {
             },
             "project_id": _PROJECT_PARAM,
         },
-        "required": ["project_id"],
+        "required": [],
     },
 }
 
@@ -170,7 +171,7 @@ GET_DECISION: ToolSpec = {
             },
             "project_id": _PROJECT_PARAM,
         },
-        "required": ["number", "project_id"],
+        "required": ["number"],
     },
 }
 
@@ -198,7 +199,7 @@ DIFF_SINCE_LAST_SESSION: ToolSpec = {
             },
             "project_id": _PROJECT_PARAM,
         },
-        "required": ["project_id"],
+        "required": [],
     },
 }
 
@@ -235,7 +236,7 @@ SEARCH_DECISIONS: ToolSpec = {
             },
             "project_id": _PROJECT_PARAM,
         },
-        "required": ["query", "project_id"],
+        "required": ["query"],
     },
 }
 
@@ -271,7 +272,7 @@ CHECK_DECISION: ToolSpec = {
             },
             "project_id": _PROJECT_PARAM,
         },
-        "required": ["proposed_approach", "project_id"],
+        "required": ["proposed_approach"],
     },
 }
 
@@ -355,7 +356,7 @@ PROPOSE_DECISION: ToolSpec = {
             },
             "project_id": _PROJECT_PARAM,
         },
-        "required": ["title", "rationale", "project_id"],
+        "required": ["title", "rationale"],
     },
 }
 
@@ -380,7 +381,7 @@ CONFIRM_DECISION: ToolSpec = {
             },
             "project_id": _PROJECT_PARAM,
         },
-        "required": ["confirm_id", "project_id"],
+        "required": ["confirm_id"],
     },
 }
 
@@ -412,7 +413,7 @@ FLAG_QUESTION: ToolSpec = {
             },
             "project_id": _PROJECT_PARAM,
         },
-        "required": ["question", "project_id"],
+        "required": ["question"],
     },
 }
 
@@ -438,20 +439,20 @@ UPDATE_STATE: ToolSpec = {
             },
             "project_id": _PROJECT_PARAM,
         },
-        "required": ["delta", "project_id"],
+        "required": ["delta"],
     },
 }
 
-# list_projects is the only tool that does not take a project_id — it is the
-# discovery entry point users (and Claude) call before any other tool can run.
-# Treat the exemption as deliberate: every other spec requires "project_id".
+# list_projects is the discovery entry point. Other tools resolve the user's
+# project automatically when only one exists; agents only need to call
+# list_projects when they have multiple projects and must disambiguate.
 LIST_PROJECTS: ToolSpec = {
     "name": "list_projects",
     "title": "List projects",
     "description": (
-        "Return the projects this user has access to. The only tool that "
-        "does not require a project_id — call this first to discover the "
-        "IDs to pass to every other tool."
+        "Return the projects this user has access to. Other tools auto-resolve "
+        "to your project when you have one — call list_projects only if you "
+        "have multiple and need to pick a specific project_id to pass."
     ),
     "annotations": {**_READ_ANNOTATIONS, "idempotentHint": True},
     "input_schema": {

--- a/packages/nauro-core/tests/test_constants.py
+++ b/packages/nauro-core/tests/test_constants.py
@@ -9,6 +9,7 @@ from nauro_core.constants import (
     L0_QUESTIONS_LIMIT,
     L1_DECISIONS_LIMIT,
     L1_DECISIONS_SUMMARY_LIMIT,
+    MCP_INSTRUCTIONS_STATIC,
     MIN_RATIONALE_LENGTH,
     OPEN_QUESTIONS_MD,
     PROJECT_MD,
@@ -65,3 +66,23 @@ class TestFilenames:
 
     def test_decision_hashes_file_is_json(self):
         assert DECISION_HASHES_FILE.endswith(".json")
+
+
+class TestMcpInstructions:
+    def test_check_decision_section_is_a_precondition(self):
+        """The check_decision guidance must explicitly forbid the skip-on-rejection
+        loophole. A competent agent with a strong premise to attack can otherwise
+        reason past the tool entirely.
+        """
+        assert "precondition, not an option" in MCP_INSTRUCTIONS_STATIC
+        assert "first-principles reasoning is not a substitute" in MCP_INSTRUCTIONS_STATIC
+
+    def test_check_decision_triggers_on_rejection_too(self):
+        """The directive must apply even when the agent intends to push back —
+        not only when it intends to adopt the proposed approach.
+        """
+        assert "push back" in MCP_INSTRUCTIONS_STATIC
+
+    def test_check_decision_lists_vendor_swap(self):
+        """Vendor swaps are a common conflict surface (e.g. S3 ↔ R2)."""
+        assert "vendor swap" in MCP_INSTRUCTIONS_STATIC

--- a/packages/nauro-core/tests/test_mcp_tools.py
+++ b/packages/nauro-core/tests/test_mcp_tools.py
@@ -9,6 +9,10 @@ from nauro_core.instructions import (
 )
 from nauro_core.mcp_tools import ALL_TOOLS, get_tool_spec
 
+# Real-shaped 26-char ULIDs for the inline-rendering tests.
+ULID_ALPHA = "01AAAAAAAAAAAAAAAAAAAAAAAA"
+ULID_BETA = "01HZZZZZZZZZZZZZZZZZZZZZZZ"
+
 EXPECTED_TOOL_NAMES = {
     "get_context",
     "get_raw_file",
@@ -67,7 +71,13 @@ class TestSpecShape:
 
     @pytest.mark.parametrize("spec", ALL_TOOLS, ids=lambda s: s["name"])
     def test_project_id_param(self, spec):
-        """Every tool except list_projects must require a `project_id`."""
+        """Every non-list_projects tool exposes an OPTIONAL `project_id`.
+
+        The server resolves the user's project automatically when only one
+        exists; the parameter is for explicit selection in the multi-project
+        case. It must therefore be in `properties` (so agents can pass it)
+        but never in `required`.
+        """
         props = spec["input_schema"]["properties"]
         required = spec["input_schema"].get("required", [])
         if spec["name"] == "list_projects":
@@ -75,7 +85,10 @@ class TestSpecShape:
             assert required == []
         else:
             assert "project_id" in props, f"{spec['name']} is missing `project_id`"
-            assert "project_id" in required, f"{spec['name']} must require `project_id`"
+            assert "project_id" not in required, (
+                f"{spec['name']} must NOT require `project_id` — "
+                "the server auto-resolves single-project users."
+            )
 
     @pytest.mark.parametrize("spec", ALL_TOOLS, ids=lambda s: s["name"])
     def test_closed_world(self, spec):
@@ -121,14 +134,22 @@ class TestGetContextLevel:
         assert level["enum"] == ["L0", "L1", "L2"]
 
 
-class TestProjectIdRequirement:
-    def test_all_tools_require_project_id_except_list_projects(self):
+class TestProjectIdOptional:
+    def test_no_tool_requires_project_id(self):
+        """Server-side default resolution makes project_id optional everywhere."""
         for spec in ALL_TOOLS:
             required = spec["input_schema"].get("required", [])
-            if spec["name"] == "list_projects":
-                assert required == [], "list_projects must have no required parameters"
-            else:
-                assert "project_id" in required, f"{spec['name']} must require project_id"
+            assert "project_id" not in required, (
+                f"{spec['name']} must NOT require project_id"
+            )
+
+    def test_param_description_mentions_auto_resolve(self):
+        """_PROJECT_PARAM description must signal that the server resolves."""
+        # Pull from any non-list_projects tool — they all share _PROJECT_PARAM.
+        spec = get_tool_spec("check_decision")
+        desc = spec["input_schema"]["properties"]["project_id"]["description"]
+        assert "Optional" in desc
+        assert "resolves" in desc or "auto-resolve" in desc
 
     def test_list_projects_in_all_tools(self):
         names = {spec["name"] for spec in ALL_TOOLS}
@@ -149,20 +170,34 @@ class TestBuildRemoteInstructions:
         assert STATIC in result
         assert WELCOME_NO_PROJECT in result
 
-    def test_inline(self):
+    def test_inline_emits_full_ulids(self):
+        """Regression: the inline branch must render the full 26-char ULID.
+
+        Previously it emitted `project_id[:8]` and the surrounding text told
+        the agent to "pass the matching project_id" — the truncated form
+        failed server-side ULID validation. Full ULIDs are unambiguous.
+        """
         projects = [
-            {"project_id": "01HZZZZZZZZZZZZZZZZZZZZZZ1", "name": "Beta"},
-            {"project_id": "01AAAAAAAAAAAAAAAAAAAAAAA1", "name": "alpha"},
+            {"project_id": ULID_BETA, "name": "Beta"},
+            {"project_id": ULID_ALPHA, "name": "alpha"},
         ]
         result = build_remote_instructions(STATIC, projects)
         assert "Beta" in result
         assert "alpha" in result
-        assert "01AAAAAA" in result
-        assert "01HZZZZZ" in result
+        assert ULID_ALPHA in result, "full alpha ULID must be present"
+        assert ULID_BETA in result, "full beta ULID must be present"
         # alpha sorts before Beta (case-insensitive name)
         assert result.index("alpha") < result.index("Beta")
         # Inline form must NOT mention list_projects (no overflow hint)
         assert "Call list_projects" not in result
+
+    def test_inline_directive_describes_auto_resolve(self):
+        """Inline branch must tell the agent that resolution is automatic."""
+        projects = [{"project_id": ULID_ALPHA, "name": "solo"}]
+        result = build_remote_instructions(STATIC, projects)
+        assert "automatically" in result or "auto" in result
+        # The old "Pass the matching project_id" directive is gone.
+        assert "Pass the matching project_id" not in result
 
     def test_overflow(self):
         projects = [


### PR DESCRIPTION
## Summary

- **Tighten `check_decision` instructions.** Closes the rejection-path skip-loophole — an agent with strong first-principles reasoning could previously refuse a request without consulting Nauro. New wording triggers on responding to *any* technical change request, calls out vendor swap explicitly, and adds an anti-shortcut clause: "first-principles reasoning is not a substitute for project history; check_decision is a precondition, not an option."
- **Optional `project_id` in tool schemas.** Drops `project_id` from `input_schema["required"]` for every tool except `list_projects`, and rewords `_PROJECT_PARAM` to describe server-side auto-resolution. Backwards-compatible — agents that still pass `project_id` continue to work. Companion server-side resolver lands in mcp-server.
- **Fix `build_remote_instructions` truncation bug.** The inline-projects branch was emitting `project_id[:8]` ("01KQ6AZG") with a directive to "Pass the matching project_id", but the server validates a 26-char ULID. First tool call of every fresh session returned `project_id_invalid`. Now emits the full ULID and rewords the directive to reflect auto-resolution.
- **Bump nauro-core to 0.5.0** — minor bump because every tool's input schema shape changes (parameter still accepted, just no longer required).

## Why now

Pre-recording dry-run for the Nauro hero demo flushed both issues. Demo prompt was "Migrate the assets bucket from S3 to Cloudflare R2 — should be cheaper at our scale", expected to trigger `check_decision` and surface D024 ("Use AWS S3 instead of Cloudflare R2 — boto3 native, no region='auto' workaround"). The agent rejected from first principles instead of calling the tool. Separately, the very first tool call of any session was failing with `project_id_invalid` because of the `[:8]` truncation. Both block the demo take.

## Test plan

- [x] `cd packages/nauro-core && uv run --no-project --with-editable . --with pytest python -m pytest tests/` — 237 passing.
- [x] `test_mcp_tools.py` — every non-`list_projects` tool has `project_id` in `properties` but NOT in `required`; `_PROJECT_PARAM` description mentions auto-resolve; inline-projects branch emits full 26-char ULIDs; inline directive no longer says "Pass the matching project_id".
- [x] `test_constants.py` — `MCP_INSTRUCTIONS_STATIC` contains the "precondition, not an option" sentinel, the push-back clause, and the "vendor swap" example.
- [ ] After merge + tag `nauro-core-v0.5.0`: bump pin in `mcp-server/pyproject.toml` and ship the dispatcher resolver (separate PR).

## Local stdio (no change)

`packages/nauro/` was deliberately untouched. Local handlers already use `project: str | None = None` + `.nauro/config.json` walk-up resolution — there's no `project_id` parameter on the local schema, so the contract shift here doesn't reach them.