### PR TITLE
Auto-resolve project_id + tighten check_decision (nauro-core 0.5.0)

### DIFF
--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro-core"
-version = "0.4.0"
+version = "0.5.0"
 description = "Shared pure-Python logic for Nauro: parsing, validation, context assembly, constants."
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/nauro-core/src/nauro_core/__init__.py
+++ b/packages/nauro-core/src/nauro_core/__init__.py
@@ -3,7 +3,7 @@
 Re-export facade — public API symbols from all modules.
 """
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 
 from nauro_core.constants import (
     DECISION_HASHES_FILE as DECISION_HASHES_FILE,

--- a/packages/nauro-core/src/nauro_core/constants.py
+++ b/packages/nauro-core/src/nauro_core/constants.py
@@ -73,12 +73,14 @@ new decisions as you make them.
 
 ## When to check decisions
 
-Before adopting any technical approach — architecture, library choice, \
-API design, data model, infrastructure — call `check_decision` with a \
-description of what you're considering. This includes when the user asks \
-"should we...", "what if we...", "can we...", or "check if...". \
-The tool surfaces conflicts with past decisions so you don't repeat \
-rejected approaches.
+Before responding to any technical change request — architecture, \
+library choice, API design, data model, infrastructure, vendor swap — \
+call `check_decision` with a description of what's being proposed. \
+This includes "should we...", "what if we...", "can we...", "check if..." \
+framings, and applies even when you intend to push back or refuse. \
+Your first-principles reasoning is not a substitute for project history; \
+`check_decision` is a precondition, not an option. The tool surfaces \
+conflicts with past decisions so you don't repeat rejected approaches.
 
 ## When to propose decisions
 

--- a/packages/nauro-core/src/nauro_core/instructions.py
+++ b/packages/nauro-core/src/nauro_core/instructions.py
@@ -1,9 +1,14 @@
 """Per-user composition of MCP server instructions.
 
 The static instructional block (MCP_INSTRUCTIONS_STATIC) is project-agnostic.
-Remote callers append a small section listing the user's projects so Claude
-can pick a project_id without a discovery roundtrip. For users with no
-projects, WELCOME_NO_PROJECT replaces the project list with onboarding copy.
+Remote callers append a per-user section that depends on how many projects
+the caller has access to:
+
+- 0 projects: WELCOME_NO_PROJECT onboarding copy.
+- 1 project: a single orientation line naming the project — no project_id
+  rendered, since tools auto-resolve to it.
+- 2+ projects: a disambiguation list with full ULIDs (or a list_projects
+  pointer when the count exceeds MAX_INLINE_PROJECTS).
 """
 
 from __future__ import annotations
@@ -21,8 +26,8 @@ WELCOME_NO_PROJECT = (
     "3. Or, if a teammate already created a cloud project, run "
     "`nauro attach <project_id>` to connect this machine to it.\n"
     "\n"
-    "Once a project exists, every tool call (except list_projects) requires "
-    "its project_id."
+    "Once a project exists, tools auto-resolve to it — you do not need to "
+    "pass a project_id."
 )
 
 
@@ -36,28 +41,43 @@ def build_remote_instructions(
     and 'name' (str).
 
     - Empty list: append WELCOME_NO_PROJECT.
-    - 1..MAX_INLINE_PROJECTS: append "Your projects:" with each rendered as
-      `name — {project_id[:8]}`, sorted by (name.lower(), project_id).
+    - Exactly 1 project: append one orientation line with the project name.
+      No project_id is rendered — tools auto-resolve to the only project.
+    - 2..MAX_INLINE_PROJECTS: append a "You have N projects:" list with each
+      project rendered as `name — {full project_id}`, sorted by
+      (name.lower(), project_id). Tools require an explicit project_id when
+      multiple exist.
     - More than MAX_INLINE_PROJECTS: append a count + hint to call
       list_projects, without enumerating each one.
     """
     if not projects:
         return f"{static_block}\n\n{WELCOME_NO_PROJECT}"
 
+    if len(projects) == 1:
+        name = projects[0]["name"]
+        return (
+            f"{static_block}\n\n"
+            f"Connected to project '{name}' — tools auto-resolve, "
+            "you do not need to pass a project_id."
+        )
+
     if len(projects) <= MAX_INLINE_PROJECTS:
         ordered = sorted(
             projects,
             key=lambda p: (p["name"].lower(), p["project_id"]),
         )
-        lines = ["Your projects:"]
+        lines = [f"You have {len(projects)} projects:"]
         for p in ordered:
-            lines.append(f"- {p['name']} — {p['project_id'][:8]}")
-        lines.append("\nPass the matching project_id to every tool call (except list_projects).")
+            lines.append(f"- {p['name']} — {p['project_id']}")
+        lines.append(
+            "\nTools require an explicit project_id when multiple exist; "
+            "pass one of the IDs above."
+        )
         return f"{static_block}\n\n" + "\n".join(lines)
 
     return (
         f"{static_block}\n\n"
         f"You have {len(projects)} projects. "
-        "Call list_projects to see them all and pick a project_id; "
-        "every tool call except list_projects requires one."
+        "Tools require an explicit project_id when multiple exist — "
+        "call list_projects to see them all and pick one."
     )

--- a/packages/nauro-core/src/nauro_core/mcp_tools.py
+++ b/packages/nauro-core/src/nauro_core/mcp_tools.py
@@ -42,8 +42,9 @@ class ToolSpec(TypedDict):
 _PROJECT_PARAM: dict[str, Any] = {
     "type": "string",
     "description": (
-        "Project ID (ULID). Required for every tool except list_projects. "
-        "Call list_projects to discover the IDs available to the current user."
+        "Optional. If you have one project, the server resolves it "
+        "automatically. Pass explicitly if you have multiple — call "
+        "list_projects to discover the IDs available to the current user."
     ),
 }
 
@@ -90,7 +91,7 @@ GET_CONTEXT: ToolSpec = {
             },
             "project_id": _PROJECT_PARAM,
         },
-        "required": ["project_id"],
+        "required": [],
     },
 }
 
@@ -121,7 +122,7 @@ GET_RAW_FILE: ToolSpec = {
             },
             "project_id": _PROJECT_PARAM,
         },
-        "required": ["path", "project_id"],
+        "required": ["path"],
     },
 }
 
@@ -149,7 +150,7 @@ LIST_DECISIONS: ToolSpec = {
             },
             "project_id": _PROJECT_PARAM,
         },
-        "required": ["project_id"],
+        "required": [],
     },
 }
 
@@ -170,7 +171,7 @@ GET_DECISION: ToolSpec = {
             },
             "project_id": _PROJECT_PARAM,
         },
-        "required": ["number", "project_id"],
+        "required": ["number"],
     },
 }
 
@@ -198,7 +199,7 @@ DIFF_SINCE_LAST_SESSION: ToolSpec = {
             },
             "project_id": _PROJECT_PARAM,
         },
-        "required": ["project_id"],
+        "required": [],
     },
 }
 
@@ -235,7 +236,7 @@ SEARCH_DECISIONS: ToolSpec = {
             },
             "project_id": _PROJECT_PARAM,
         },
-        "required": ["query", "project_id"],
+        "required": ["query"],
     },
 }
 
@@ -271,7 +272,7 @@ CHECK_DECISION: ToolSpec = {
             },
             "project_id": _PROJECT_PARAM,
         },
-        "required": ["proposed_approach", "project_id"],
+        "required": ["proposed_approach"],
     },
 }
 
@@ -355,7 +356,7 @@ PROPOSE_DECISION: ToolSpec = {
             },
             "project_id": _PROJECT_PARAM,
         },
-        "required": ["title", "rationale", "project_id"],
+        "required": ["title", "rationale"],
     },
 }
 
@@ -380,7 +381,7 @@ CONFIRM_DECISION: ToolSpec = {
             },
             "project_id": _PROJECT_PARAM,
         },
-        "required": ["confirm_id", "project_id"],
+        "required": ["confirm_id"],
     },
 }
 
@@ -412,7 +413,7 @@ FLAG_QUESTION: ToolSpec = {
             },
             "project_id": _PROJECT_PARAM,
         },
-        "required": ["question", "project_id"],
+        "required": ["question"],
     },
 }
 
@@ -438,20 +439,20 @@ UPDATE_STATE: ToolSpec = {
             },
             "project_id": _PROJECT_PARAM,
         },
-        "required": ["delta", "project_id"],
+        "required": ["delta"],
     },
 }
 
-# list_projects is the only tool that does not take a project_id — it is the
-# discovery entry point users (and Claude) call before any other tool can run.
-# Treat the exemption as deliberate: every other spec requires "project_id".
+# list_projects is the discovery entry point. Other tools resolve the user's
+# project automatically when only one exists; agents only need to call
+# list_projects when they have multiple projects and must disambiguate.
 LIST_PROJECTS: ToolSpec = {
     "name": "list_projects",
     "title": "List projects",
     "description": (
-        "Return the projects this user has access to. The only tool that "
-        "does not require a project_id — call this first to discover the "
-        "IDs to pass to every other tool."
+        "Return the projects this user has access to. Other tools auto-resolve "
+        "to your project when you have one — call list_projects only if you "
+        "have multiple and need to pick a specific project_id to pass."
     ),
     "annotations": {**_READ_ANNOTATIONS, "idempotentHint": True},
     "input_schema": {

--- a/packages/nauro-core/tests/test_constants.py
+++ b/packages/nauro-core/tests/test_constants.py
@@ -9,6 +9,7 @@ from nauro_core.constants import (
     L0_QUESTIONS_LIMIT,
     L1_DECISIONS_LIMIT,
     L1_DECISIONS_SUMMARY_LIMIT,
+    MCP_INSTRUCTIONS_STATIC,
     MIN_RATIONALE_LENGTH,
     OPEN_QUESTIONS_MD,
     PROJECT_MD,
@@ -65,3 +66,23 @@ class TestFilenames:
 
     def test_decision_hashes_file_is_json(self):
         assert DECISION_HASHES_FILE.endswith(".json")
+
+
+class TestMcpInstructions:
+    def test_check_decision_section_is_a_precondition(self):
+        """The check_decision guidance must explicitly forbid the skip-on-rejection
+        loophole. A competent agent with a strong premise to attack can otherwise
+        reason past the tool entirely.
+        """
+        assert "precondition, not an option" in MCP_INSTRUCTIONS_STATIC
+        assert "first-principles reasoning is not a substitute" in MCP_INSTRUCTIONS_STATIC
+
+    def test_check_decision_triggers_on_rejection_too(self):
+        """The directive must apply even when the agent intends to push back —
+        not only when it intends to adopt the proposed approach.
+        """
+        assert "push back" in MCP_INSTRUCTIONS_STATIC
+
+    def test_check_decision_lists_vendor_swap(self):
+        """Vendor swaps are a common conflict surface (e.g. S3 ↔ R2)."""
+        assert "vendor swap" in MCP_INSTRUCTIONS_STATIC

--- a/packages/nauro-core/tests/test_mcp_tools.py
+++ b/packages/nauro-core/tests/test_mcp_tools.py
@@ -139,9 +139,7 @@ class TestProjectIdOptional:
         """Server-side default resolution makes project_id optional everywhere."""
         for spec in ALL_TOOLS:
             required = spec["input_schema"].get("required", [])
-            assert "project_id" not in required, (
-                f"{spec['name']} must NOT require project_id"
-            )
+            assert "project_id" not in required, f"{spec['name']} must NOT require project_id"
 
     def test_param_description_mentions_auto_resolve(self):
         """_PROJECT_PARAM description must signal that the server resolves."""
@@ -180,9 +178,7 @@ class TestBuildRemoteInstructions:
         result = build_remote_instructions(STATIC, projects)
         assert STATIC in result
         assert "nauro" in result, "project name must appear for orientation"
-        assert ULID_ALPHA not in result, (
-            "single-project rendering must NOT include the ULID"
-        )
+        assert ULID_ALPHA not in result, "single-project rendering must NOT include the ULID"
         assert "auto-resolve" in result or "automatically" in result or "auto" in result
         # The old "Pass the matching project_id" directive is gone.
         assert "Pass the matching project_id" not in result

--- a/packages/nauro-core/tests/test_mcp_tools.py
+++ b/packages/nauro-core/tests/test_mcp_tools.py
@@ -9,6 +9,10 @@ from nauro_core.instructions import (
 )
 from nauro_core.mcp_tools import ALL_TOOLS, get_tool_spec
 
+# Real-shaped 26-char ULIDs for the inline-rendering tests.
+ULID_ALPHA = "01AAAAAAAAAAAAAAAAAAAAAAAA"
+ULID_BETA = "01HZZZZZZZZZZZZZZZZZZZZZZZ"
+
 EXPECTED_TOOL_NAMES = {
     "get_context",
     "get_raw_file",
@@ -67,7 +71,13 @@ class TestSpecShape:
 
     @pytest.mark.parametrize("spec", ALL_TOOLS, ids=lambda s: s["name"])
     def test_project_id_param(self, spec):
-        """Every tool except list_projects must require a `project_id`."""
+        """Every non-list_projects tool exposes an OPTIONAL `project_id`.
+
+        The server resolves the user's project automatically when only one
+        exists; the parameter is for explicit selection in the multi-project
+        case. It must therefore be in `properties` (so agents can pass it)
+        but never in `required`.
+        """
         props = spec["input_schema"]["properties"]
         required = spec["input_schema"].get("required", [])
         if spec["name"] == "list_projects":
@@ -75,7 +85,10 @@ class TestSpecShape:
             assert required == []
         else:
             assert "project_id" in props, f"{spec['name']} is missing `project_id`"
-            assert "project_id" in required, f"{spec['name']} must require `project_id`"
+            assert "project_id" not in required, (
+                f"{spec['name']} must NOT require `project_id` — "
+                "the server auto-resolves single-project users."
+            )
 
     @pytest.mark.parametrize("spec", ALL_TOOLS, ids=lambda s: s["name"])
     def test_closed_world(self, spec):
@@ -121,14 +134,22 @@ class TestGetContextLevel:
         assert level["enum"] == ["L0", "L1", "L2"]
 
 
-class TestProjectIdRequirement:
-    def test_all_tools_require_project_id_except_list_projects(self):
+class TestProjectIdOptional:
+    def test_no_tool_requires_project_id(self):
+        """Server-side default resolution makes project_id optional everywhere."""
         for spec in ALL_TOOLS:
             required = spec["input_schema"].get("required", [])
-            if spec["name"] == "list_projects":
-                assert required == [], "list_projects must have no required parameters"
-            else:
-                assert "project_id" in required, f"{spec['name']} must require project_id"
+            assert "project_id" not in required, (
+                f"{spec['name']} must NOT require project_id"
+            )
+
+    def test_param_description_mentions_auto_resolve(self):
+        """_PROJECT_PARAM description must signal that the server resolves."""
+        # Pull from any non-list_projects tool — they all share _PROJECT_PARAM.
+        spec = get_tool_spec("check_decision")
+        desc = spec["input_schema"]["properties"]["project_id"]["description"]
+        assert "Optional" in desc
+        assert "resolves" in desc or "auto-resolve" in desc
 
     def test_list_projects_in_all_tools(self):
         names = {spec["name"] for spec in ALL_TOOLS}
@@ -149,20 +170,53 @@ class TestBuildRemoteInstructions:
         assert STATIC in result
         assert WELCOME_NO_PROJECT in result
 
-    def test_inline(self):
+    def test_one_project_orientation_only(self):
+        """Single-project users get a name-only orientation line — no ULID.
+
+        Auto-resolve handles dispatch, so rendering the project_id is just
+        noise (and was the source of the historical truncation bug).
+        """
+        projects = [{"project_id": ULID_ALPHA, "name": "nauro"}]
+        result = build_remote_instructions(STATIC, projects)
+        assert STATIC in result
+        assert "nauro" in result, "project name must appear for orientation"
+        assert ULID_ALPHA not in result, (
+            "single-project rendering must NOT include the ULID"
+        )
+        assert "auto-resolve" in result or "automatically" in result or "auto" in result
+        # The old "Pass the matching project_id" directive is gone.
+        assert "Pass the matching project_id" not in result
+
+    def test_two_projects_emits_full_ulids(self):
+        """Regression: the multi-project branch renders full 26-char ULIDs.
+
+        Previously it emitted `project_id[:8]` for every project (including
+        the single-project case) — the truncated form failed server-side
+        ULID validation. Full ULIDs are unambiguous.
+        """
         projects = [
-            {"project_id": "01HZZZZZZZZZZZZZZZZZZZZZZ1", "name": "Beta"},
-            {"project_id": "01AAAAAAAAAAAAAAAAAAAAAAA1", "name": "alpha"},
+            {"project_id": ULID_BETA, "name": "Beta"},
+            {"project_id": ULID_ALPHA, "name": "alpha"},
         ]
         result = build_remote_instructions(STATIC, projects)
         assert "Beta" in result
         assert "alpha" in result
-        assert "01AAAAAA" in result
-        assert "01HZZZZZ" in result
+        assert ULID_ALPHA in result, "full alpha ULID must be present"
+        assert ULID_BETA in result, "full beta ULID must be present"
         # alpha sorts before Beta (case-insensitive name)
         assert result.index("alpha") < result.index("Beta")
         # Inline form must NOT mention list_projects (no overflow hint)
         assert "Call list_projects" not in result
+
+    def test_two_projects_directive_requires_explicit_id(self):
+        """Multi-project rendering must tell the agent disambiguation is required."""
+        projects = [
+            {"project_id": ULID_ALPHA, "name": "alpha"},
+            {"project_id": ULID_BETA, "name": "beta"},
+        ]
+        result = build_remote_instructions(STATIC, projects)
+        assert "explicit project_id" in result
+        assert "Pass the matching project_id" not in result
 
     def test_overflow(self):
         projects = [


### PR DESCRIPTION
## Why

Three issues with the agent-facing contract for Nauro tools:

1. **The `## When to check decisions` instruction had a rejection-path loophole.** The previous wording said "before *adopting* any technical approach…call check_decision." An agent with strong first-principles reasoning could reject a proposed change without ever consulting Nauro — "I'm rejecting, not adopting, so I'll skip" reads as compliant under the old text. Past decisions get bypassed precisely when they're most needed (someone re-litigating a settled question).

2. **`build_remote_instructions` emitted truncated project_ids.** The inline-projects branch rendered `project_id[:8]` ("01KQ6AZG") and told the agent to "Pass the matching project_id." The remote dispatcher validates a 26-char ULID and returns `project_id_invalid` on the truncated form, so the first tool call of every fresh session was failing. Agents recovering by calling `list_projects` was the only path forward.

3. **Single-project users were carrying a 26-char ULID through working context for no reason.** The server already knows `user_id` from the JWT and queries DDB for project membership on every call. The agent passing `project_id` is redundant work for any user with one project — which is everyone today and almost everyone for the foreseeable future.

## Approach

Make `project_id` optional in every tool schema except `list_projects`, and let the server auto-resolve to the user's project when only one exists. Backwards-compatible: the parameter stays in `properties`, agents that still pass it work unchanged. Init-time rendering simplifies — single-project users get a one-line orientation (no ULID), multi-project users get a disambiguation list with full ULIDs. The matching server-side resolver lands in a follow-up mcp-server PR.

Alternatives considered:

- **Just fix the truncation; keep `project_id` required.** Minimal diff, but leaves the underlying redundancy. Single-project users still carry an ID through every tool call. Rejected: the underlying fix is small enough to bundle, and shipping half the change now means revisiting the same files later.
- **Drop `project_id` from the schema entirely.** Multi-project users would lose disambiguation. Rejected: keep the parameter accepted, just not required.

Bumped to **0.5.0** (minor, not patch) because the schema shape changes for every non-`list_projects` tool — even though the parameter is still accepted on the wire.

## What changed

- **`MCP_INSTRUCTIONS_STATIC`** — `## When to check decisions` rewritten to trigger on responding to any technical change request, name "vendor swap" as a category, and add the anti-shortcut clause "your first-principles reasoning is not a substitute for project history; check_decision is a precondition, not an option."
- **Tool schemas** — `project_id` removed from `input_schema["required"]` for all 11 non-`list_projects` tools; `_PROJECT_PARAM` description updated to signal server-side auto-resolve. `LIST_PROJECTS` description rewritten so it no longer claims agents must "call this first to discover the IDs to pass to every other tool" (no longer true).
- **`build_remote_instructions`** — split into four branches: 0 projects (`WELCOME_NO_PROJECT`), exactly 1 (orientation line, no ULID), 2..`MAX_INLINE_PROJECTS` (disambiguation list with full ULIDs), more than MAX (count + `list_projects` pointer). `WELCOME_NO_PROJECT` updated to match the new no-project_id-required reality.
- **Tests** — `test_mcp_tools.py` flipped from "every tool requires `project_id`" to "no tool requires `project_id`"; new tests for the single-project orientation branch and the two-projects-emit-full-ULIDs regression. `test_constants.py` gains sentinel tests for the tightened check_decision wording.
- **Version** — `__init__.py` and `pyproject.toml` to `0.5.0`.

## What to review

- The new `## When to check decisions` wording — about 30% longer than the original. The "precondition, not an option" sentence is the load-bearing line for closing the loophole. If it reads as too prescriptive, it can be softened.
- `_PROJECT_PARAM` description — the agent reads this to decide whether to pass an ID. "If you have one project, the server resolves it automatically" is the key signal.
- The single-project rendering — the orientation line names the project but omits the ULID. Reviewers should sanity-check that this is enough context for the agent on first contact (the next call typically pulls `get_context`, which has the full project info).
- `packages/nauro/` is intentionally untouched — local stdio handlers already use `project: str | None = None` + `.nauro/config.json` walk-up. There's no `project_id` parameter on the local schema for FastMCP to derive. Worth confirming this still holds before merge.

## What's deferred

- **Server-side resolver in mcp-server** — separate PR, gated on this nauro-core PR merging and tagging `nauro-core-v0.5.0`. The wire contract is loosened here without the dispatcher change yet, but the parameter is still accepted, so no consumer breaks.
- **Verification against the live remote endpoint** — happens after the mcp-server PR deploys.

## Test plan

- 238 nauro-core tests passing locally (`uv run --no-project --with-editable . --with pytest python -m pytest tests/`).
- New: `test_one_project_orientation_only` — single-project rendering names the project, omits the ULID, mentions auto-resolve, drops the old "Pass the matching project_id" directive.
- New: `test_two_projects_emits_full_ulids` (regression) — disambiguation branch emits the full 26-char ULID for each project, sorted by case-insensitive name.
- New: `test_two_projects_directive_requires_explicit_id` — multi-project copy tells the agent disambiguation is required.
- Updated: `test_project_id_param` — every non-`list_projects` tool has `project_id` in `properties` but NOT in `required`.
- New: `test_param_description_mentions_auto_resolve`.
- Existing tests cover backwards compatibility — the parameter is still accepted in `properties`, so callers passing `project_id` continue to validate.