### PR TITLE
README: D118 tagline lock + D122 trust model + pip default

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Nauro
 
-Set the direction once. Every agent inherits it.
+Set the vision once. Every agent inherits it.
 
-Your project's direction — goals, decisions, rejected paths — is inherited by every connected agent. When an agent proposes an approach that conflicts with a past decision, Nauro catches the drift before it ships. Works with Claude, Perplexity, ChatGPT, Cursor, and any MCP client.
+Your goals, decisions, and rejected paths are inherited by every connected agent. When an agent proposes an approach that conflicts with a past decision, Nauro catches the drift before it ships. Works with Claude, Perplexity, ChatGPT, Cursor, and any MCP client.
 
 ## The problem
 
@@ -13,7 +13,7 @@ Approaches that failed last month look reasonable in isolation and get proposed 
 ## Install
 
 ```bash
-pipx install nauro   # or: pip install nauro
+pip install nauro   # or: pipx install nauro
 ```
 
 Requires Python 3.11+.
@@ -69,7 +69,7 @@ The `check_decision` → `propose_decision` → `confirm_decision` pipeline catc
 
 ## How it works
 
-Agents propose decisions through MCP during sessions. You can also log decisions from the terminal with `nauro note` or bootstrap from git history with `nauro extract`. Open questions are tracked too, so agents surface unresolved tensions before they become assumptions.
+Agents propose decisions through MCP during sessions. Decisions are proposed in collaboration with your agent and confirmed by you before anything is written — the gate is the boundary between "we discussed it" and "your project's direction has changed." You can also log decisions from the terminal with `nauro note` or bootstrap from git history with `nauro extract`. Open questions are tracked too, so agents surface unresolved tensions before they become assumptions.
 
 One project spans many repos — the store lives in `~/.nauro/`, not inside any repo, so context follows the project across the whole codebase.
 


### PR DESCRIPTION
## Why
D118 locks "Set the vision once. Every agent inherits it." The README was running an unfiled "direction" amendment; this reverts to the D118 phrase. D122 articulates Nauro's trust model — the "How it works" section was procedural about propose → confirm without naming what the gate is for. Also flips the install line to lead with `pip install nauro` instead of pipx (founder preference).

## What changed
- Hero (line 3): `direction` → `vision`.
- Body paragraph (line 5): rewritten so "vision" and "direction" no longer sit two lines apart with different referents. Earlier drafts hit a "decided/decisions" redundancy; final lands at "Your goals, decisions, and rejected paths are inherited..."
- Install (line 16): `pip install nauro` is the headline; pipx demoted to the alt comment.
- "How it works" (line 72): inserts the D122 gate sentence — "the gate is the boundary between 'we discussed it' and 'your project's direction has changed.'"

Naur footer and comparison table untouched.

## What to review
Read line 5 aloud against the surrounding paragraph — earlier drafts tripped on rhythm or word reuse. The trust-model insertion in line 72 is dense; placement inside a procedural section is the closest call.

## Deferred
- Comparison-table "Memory tools" row landing differentiation against mem0/Letta per D092 — different scope.
- Broader D118 implementation footprint (constants.py, cli/main.py, pyproject.toml, agents_md.py) still pending audit.