### PR TITLE
chore: lower Python floor to 3.10 (D124)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,8 +4,8 @@ Nauro is a versioned project context system for AI coding agents. This is a `uv`
 
 | Package | Path | Python | Purpose |
 |---|---|---|---|
-| `nauro` | `packages/nauro/` | 3.11+ | CLI + local MCP server (stdio). Reads/writes `~/.nauro/projects/` |
-| `nauro-core` | `packages/nauro-core/` | 3.11+ | Shared pure-Python logic: parsing, validation, context assembly, constants. Zero runtime deps. |
+| `nauro` | `packages/nauro/` | 3.10+ | CLI + local MCP server (stdio). Reads/writes `~/.nauro/projects/` |
+| `nauro-core` | `packages/nauro-core/` | 3.10+ | Shared pure-Python logic: parsing, validation, context assembly, constants. Zero runtime deps. |
 
 Each package has its own `CLAUDE.md`, `pyproject.toml`, and test suite. The remote MCP server (`mcp-server/`) lives in a separate private repository.
 
@@ -53,7 +53,7 @@ User config lives at `~/.nauro/config.json` (created by `nauro config set`):
 
 ## Stack
 
-- CLI: Python 3.11+, Typer
+- CLI: Python 3.10+, Typer
 - MCP server: FastAPI + uvicorn, local HTTP only
 - Extraction: Anthropic SDK, Haiku, structured output via tool use
 - Storage: flat markdown + JSON snapshots

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for your interest in contributing to Nauro! This guide covers how to set 
 
 ## Prerequisites
 
-- Python 3.11+
+- Python 3.10+
 - [uv](https://docs.astral.sh/uv/) (recommended) or pip
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Nauro gives agents a shared project record, then checks new proposals against th
 pip install nauro   # or: pipx install nauro
 ```
 
-Requires Python 3.11+.
+Requires Python 3.10+.
 
 ## Quickstart
 

--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -8,13 +8,14 @@ version = "0.5.0"
 description = "Shared pure-Python logic for Nauro: parsing, validation, context assembly, constants."
 readme = "README.md"
 license = "Apache-2.0"
-requires-python = ">= 3.11"
+requires-python = ">= 3.10"
 authors = [
     {name = "Thomas Thomsen"},
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -38,7 +39,7 @@ Issues = "https://github.com/nauro-ai/nauro/issues"
 packages = ["src/nauro_core"]
 
 [tool.ruff]
-target-version = "py311"
+target-version = "py310"
 line-length = 99
 
 [tool.ruff.lint]

--- a/packages/nauro-core/src/nauro_core/decision_model.py
+++ b/packages/nauro-core/src/nauro_core/decision_model.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 import re
 from datetime import date as _date
-from enum import StrEnum
+from enum import Enum
 
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -36,18 +36,18 @@ from nauro_core.parsing import extract_decision_number
 # ── Enums (values match on-disk lowercase tokens verbatim) ──
 
 
-class DecisionStatus(StrEnum):
+class DecisionStatus(str, Enum):
     active = "active"
     superseded = "superseded"
 
 
-class DecisionConfidence(StrEnum):
+class DecisionConfidence(str, Enum):
     high = "high"
     medium = "medium"
     low = "low"
 
 
-class DecisionType(StrEnum):
+class DecisionType(str, Enum):
     architecture = "architecture"
     api_design = "api_design"
     infrastructure = "infrastructure"
@@ -56,13 +56,13 @@ class DecisionType(StrEnum):
     data_model = "data_model"
 
 
-class Reversibility(StrEnum):
+class Reversibility(str, Enum):
     easy = "easy"
     moderate = "moderate"
     hard = "hard"
 
 
-class DecisionSource(StrEnum):
+class DecisionSource(str, Enum):
     mcp = "mcp"
     commit = "commit"
     compaction = "compaction"

--- a/packages/nauro-core/src/nauro_core/pending.py
+++ b/packages/nauro-core/src/nauro_core/pending.py
@@ -8,7 +8,7 @@ pipeline and the remote MCP server's propose/confirm workflow.
 from __future__ import annotations
 
 import uuid
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from nauro_core.constants import EXPIRY_MINUTES
 
@@ -31,7 +31,7 @@ class PendingStore:
         self._pending[confirm_id] = {
             "proposal": proposal,
             "validation_result": validation_result,
-            "created_at": datetime.now(UTC),
+            "created_at": datetime.now(timezone.utc),
         }
         return confirm_id
 
@@ -46,7 +46,7 @@ class PendingStore:
 
     def expire(self) -> None:
         """Remove entries older than EXPIRY_MINUTES."""
-        cutoff = datetime.now(UTC) - timedelta(minutes=EXPIRY_MINUTES)
+        cutoff = datetime.now(timezone.utc) - timedelta(minutes=EXPIRY_MINUTES)
         expired = [k for k, v in self._pending.items() if v["created_at"] < cutoff]
         for k in expired:
             del self._pending[k]

--- a/packages/nauro-core/src/nauro_core/state.py
+++ b/packages/nauro-core/src/nauro_core/state.py
@@ -6,7 +6,7 @@ responsible for reading/writing files (local filesystem or S3).
 
 import re
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 
 
 @dataclass
@@ -25,7 +25,7 @@ class StateUpdateResult:
 
 def _utc_timestamp() -> str:
     """Return current UTC time as ISO 8601 with minute precision."""
-    return datetime.now(UTC).strftime("%Y-%m-%dT%H:%MZ")
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%MZ")
 
 
 def _strip_current_header_footer(content: str) -> str:

--- a/packages/nauro-core/tests/test_pending.py
+++ b/packages/nauro-core/tests/test_pending.py
@@ -1,6 +1,6 @@
 """Tests for nauro_core.pending — PendingStore lifecycle."""
 
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from nauro_core.pending import PendingStore
 
@@ -39,7 +39,7 @@ class TestPendingStore:
         store = PendingStore()
         cid = store.store({"title": "Old"}, {})
         # Backdate the entry
-        store._pending[cid]["created_at"] = datetime.now(UTC) - timedelta(minutes=15)
+        store._pending[cid]["created_at"] = datetime.now(timezone.utc) - timedelta(minutes=15)
         store.expire()
         assert store.get(cid) is None
 
@@ -52,7 +52,7 @@ class TestPendingStore:
     def test_auto_expire_on_store(self):
         store = PendingStore()
         old_cid = store.store({"title": "Old"}, {})
-        store._pending[old_cid]["created_at"] = datetime.now(UTC) - timedelta(minutes=15)
+        store._pending[old_cid]["created_at"] = datetime.now(timezone.utc) - timedelta(minutes=15)
         # Storing a new entry triggers expire
         store.store({"title": "New"}, {})
         assert store.get(old_cid) is None
@@ -60,7 +60,7 @@ class TestPendingStore:
     def test_auto_expire_on_get(self):
         store = PendingStore()
         old_cid = store.store({"title": "Old"}, {})
-        store._pending[old_cid]["created_at"] = datetime.now(UTC) - timedelta(minutes=15)
+        store._pending[old_cid]["created_at"] = datetime.now(timezone.utc) - timedelta(minutes=15)
         # Getting triggers expire
         assert store.get(old_cid) is None
 

--- a/packages/nauro/CLAUDE.md
+++ b/packages/nauro/CLAUDE.md
@@ -25,7 +25,7 @@ All files are freeform markdown. No database. No JSON for content — JSON only 
 
 ## Stack
 
-- CLI: Python 3.11+, Typer
+- CLI: Python 3.10+, Typer
 - MCP server: FastAPI + uvicorn, local HTTP only
 - Extraction: Anthropic SDK, Haiku, structured output via tool use
 - Storage: flat markdown + JSON snapshots

--- a/packages/nauro/README.md
+++ b/packages/nauro/README.md
@@ -10,7 +10,7 @@ Your project's direction — goals, decisions, rejected paths — is inherited b
 pipx install nauro   # or: pip install nauro
 ```
 
-Requires Python 3.11+.
+Requires Python 3.10+.
 
 ## Quickstart
 

--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -8,13 +8,14 @@ version = "0.1.1"
 description = "Local CLI + MCP server: set your project's direction once, every connected AI agent inherits it."
 readme = "README.md"
 license = "Apache-2.0"
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 authors = [
     {name = "Thomas Thomsen"},
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -70,14 +71,14 @@ exclude = ["tests/"]
 nauro-core = { workspace = true }
 
 [tool.ruff]
-target-version = "py311"
+target-version = "py310"
 line-length = 100
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "N", "W", "UP"]
 
 [tool.mypy]
-python_version = "3.11"
+python_version = "3.10"
 warn_return_any = true
 warn_unused_configs = true
 check_untyped_defs = true

--- a/packages/nauro/src/nauro/cli/commands/status.py
+++ b/packages/nauro/src/nauro/cli/commands/status.py
@@ -1,7 +1,7 @@
 """nauro status — Show capability table for the current project."""
 
 import os
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 
 import typer
 
@@ -13,8 +13,8 @@ def _format_time_ago(iso_timestamp: str) -> str:
     try:
         dt = datetime.fromisoformat(iso_timestamp)
         if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=UTC)
-        delta = datetime.now(UTC) - dt
+            dt = dt.replace(tzinfo=timezone.utc)
+        delta = datetime.now(timezone.utc) - dt
         if delta.days > 0:
             return f"{delta.days} day{'s' if delta.days != 1 else ''} ago"
         hours = delta.seconds // 3600

--- a/packages/nauro/src/nauro/cli/commands/sync.py
+++ b/packages/nauro/src/nauro/cli/commands/sync.py
@@ -175,9 +175,9 @@ def _pull_from_cloud(project_name: str, store_path: Path) -> int:
                 except Exception:
                     logger.exception("Error resolving conflict for %s", rel)
 
-    from datetime import UTC, datetime
+    from datetime import datetime, timezone
 
-    state.last_full_sync = datetime.now(UTC).isoformat()
+    state.last_full_sync = datetime.now(timezone.utc).isoformat()
     save_state(store_path, state)
 
     if merged:

--- a/packages/nauro/src/nauro/cli/commands/telemetry.py
+++ b/packages/nauro/src/nauro/cli/commands/telemetry.py
@@ -8,7 +8,7 @@ overrides config-level state at read time and is reported by ``status``.
 from __future__ import annotations
 
 import os
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 
 import typer
 
@@ -58,7 +58,7 @@ def _persist_enabled(enabled: bool) -> None:
     section = data.get("telemetry") or {}
     section["enabled"] = enabled
     section["consent_version"] = TELEMETRY_CONSENT_VERSION
-    section["consented_at"] = datetime.now(UTC).isoformat()
+    section["consented_at"] = datetime.now(timezone.utc).isoformat()
     data["telemetry"] = section
     save_config(data)
 

--- a/packages/nauro/src/nauro/demo/__init__.py
+++ b/packages/nauro/src/nauro/demo/__init__.py
@@ -9,7 +9,7 @@ real writer output looks like (no template drift).
 """
 
 import json
-from datetime import UTC, date, datetime
+from datetime import date, datetime, timezone
 from pathlib import Path
 
 from nauro_core.decision_model import (
@@ -328,7 +328,7 @@ def create_demo_project(store_path: Path) -> None:
     snapshot = {
         "schema_version": 1,
         "version": 1,
-        "timestamp": datetime.now(UTC).isoformat(),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
         "trigger": "demo project created",
         "trigger_detail": "",
         "token_count": sum(len(v) for v in files.values()) // 4,

--- a/packages/nauro/src/nauro/extraction/pipeline.py
+++ b/packages/nauro/src/nauro/extraction/pipeline.py
@@ -10,7 +10,7 @@ import json
 import logging
 import os
 import subprocess
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from nauro.constants import (
@@ -69,7 +69,7 @@ def _append_extraction_log(store_path: Path, entry: dict) -> None:
     """
     try:
         log_path = store_path / EXTRACTION_LOG_FILENAME
-        entry["timestamp"] = datetime.now(UTC).isoformat()
+        entry["timestamp"] = datetime.now(timezone.utc).isoformat()
         with open(log_path, "a") as f:
             f.write(json.dumps(entry, default=str) + "\n")
     except Exception:

--- a/packages/nauro/src/nauro/store/reader.py
+++ b/packages/nauro/src/nauro/store/reader.py
@@ -4,7 +4,7 @@ All reads from the .nauro/ project store go through this module.
 """
 
 import re
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from nauro_core import extract_decision_number, parse_decision
@@ -450,7 +450,7 @@ def diff_since_last_session(store_path: Path, days: int | None = None) -> str:
         if not snapshots:
             return "No snapshots available."
 
-        target = datetime.now(UTC) - timedelta(days=days)
+        target = datetime.now(timezone.utc) - timedelta(days=days)
         baseline = find_snapshot_near_date(store_path, target)
         if baseline is None:
             return "No snapshots available."

--- a/packages/nauro/src/nauro/store/snapshot.py
+++ b/packages/nauro/src/nauro/store/snapshot.py
@@ -12,7 +12,7 @@ and never pruned (preserves the decision chain).
 """
 
 import json
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from nauro.constants import (
@@ -63,7 +63,7 @@ def capture_snapshot(store_path: Path, trigger: str = "", trigger_detail: str = 
     snapshot = {
         "schema_version": SCHEMA_VERSION,
         "version": next_version,
-        "timestamp": datetime.now(UTC).isoformat(),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
         "trigger": trigger,
         "trigger_detail": trigger_detail,
         "token_count": token_count,
@@ -127,7 +127,7 @@ def _prune_snapshots(snapshots_dir: Path) -> None:
     # Always keep the latest snapshot
     latest = snapshots[-1]["path"]
 
-    now = datetime.now(UTC)
+    now = datetime.now(timezone.utc)
     keep_all_cutoff = now - timedelta(days=PRUNE_KEEP_ALL_DAYS)
     daily_cutoff = now - timedelta(days=PRUNE_DAILY_DAYS)
     weekly_cutoff = now - timedelta(days=PRUNE_WEEKLY_DAYS)

--- a/packages/nauro/src/nauro/store/validator.py
+++ b/packages/nauro/src/nauro/store/validator.py
@@ -2,7 +2,7 @@
 
 import logging
 import re
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from nauro_core import extract_decision_number
@@ -70,12 +70,14 @@ def validate_store(store_path: Path) -> list[str]:
                 # Try parsing "YYYY-MM-DD HH:MM UTC" or "YYYY-MM-DD"
                 if "UTC" in synced_str:
                     synced_date = datetime.strptime(synced_str, "%Y-%m-%d %H:%M UTC").replace(
-                        tzinfo=UTC
+                        tzinfo=timezone.utc
                     )
                 else:
-                    synced_date = datetime.strptime(synced_str, "%Y-%m-%d").replace(tzinfo=UTC)
+                    synced_date = datetime.strptime(synced_str, "%Y-%m-%d").replace(
+                        tzinfo=timezone.utc
+                    )
 
-                age = datetime.now(UTC) - synced_date
+                age = datetime.now(timezone.utc) - synced_date
                 if age.days > STALE_SYNC_DAYS:
                     warnings.append(
                         f"state.md: Last synced {age.days} days ago — consider running nauro sync"

--- a/packages/nauro/src/nauro/store/writer.py
+++ b/packages/nauro/src/nauro/store/writer.py
@@ -12,7 +12,7 @@ templating is gone; the one source of truth for the on-disk format is
 import json
 import re
 from collections.abc import Sequence
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from filelock import FileLock
@@ -125,7 +125,7 @@ def append_decision(
         filepath = decisions_dir / filename
 
         decision = Decision(
-            date=datetime.now(UTC).date(),
+            date=datetime.now(timezone.utc).date(),
             version=1,
             status=DecisionStatus.active,
             confidence=DecisionConfidence(confidence),
@@ -235,7 +235,7 @@ def update_decision(
         return decision_id
 
     decision = parse_decision(target_path.read_text(), target_path.name)
-    date = datetime.now(UTC).strftime("%Y-%m-%d")
+    date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     appended_rationale = (
         f"{decision.rationale.strip()}\n\n"
         f"*Update (v{decision.version + 1}) — {date}:* {additional_rationale.strip()}"
@@ -253,7 +253,7 @@ def update_decision(
 def append_question(store_path: Path, question: str) -> None:
     """Append a question to open-questions.md with timestamp."""
     oq_path = store_path / OPEN_QUESTIONS_MD
-    timestamp = datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC")
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
     entry = f"- [{timestamp}] {question}\n"
 
     if oq_path.exists():

--- a/packages/nauro/src/nauro/sync/hooks.py
+++ b/packages/nauro/src/nauro/sync/hooks.py
@@ -189,9 +189,9 @@ def pull_before_session(project_name: str, store_path: Path) -> int:
                 except Exception:
                     logger.exception("sync pull: error resolving conflict for %s", rel)
 
-    from datetime import UTC, datetime
+    from datetime import datetime, timezone
 
-    state.last_full_sync = datetime.now(UTC).isoformat()
+    state.last_full_sync = datetime.now(timezone.utc).isoformat()
     save_state(store_path, state)
 
     if merged:

--- a/packages/nauro/src/nauro/sync/merge.py
+++ b/packages/nauro/src/nauro/sync/merge.py
@@ -8,7 +8,7 @@ import logging
 import shutil
 import subprocess
 import tempfile
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from nauro.sync.state import SyncState
@@ -51,7 +51,7 @@ def _git_available() -> bool:
 
 def _save_conflict_backup(project_path: Path, relative_path: str, content: bytes) -> Path:
     """Save the losing version to .conflict-backup/."""
-    timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     filename = relative_path.replace("/", "_")
     backup_dir = project_path / ".conflict-backup"
     backup_dir.mkdir(parents=True, exist_ok=True)

--- a/packages/nauro/src/nauro/sync/state.py
+++ b/packages/nauro/src/nauro/sync/state.py
@@ -4,7 +4,7 @@ import hashlib
 import json
 import logging
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 logger = logging.getLogger("nauro.sync")
@@ -93,7 +93,7 @@ def update_file_state(
     state: SyncState, relative_path: str, local_sha256: str, remote_etag: str
 ) -> None:
     """Update the sync state entry for a file."""
-    now = datetime.now(UTC).isoformat()
+    now = datetime.now(timezone.utc).isoformat()
     state.files[relative_path] = FileState(
         local_sha256=local_sha256,
         remote_etag=remote_etag,

--- a/packages/nauro/src/nauro/telemetry/consent.py
+++ b/packages/nauro/src/nauro/telemetry/consent.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import os
 import sys
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 
 from nauro.constants import NAURO_TELEMETRY_ENV, TELEMETRY_CONSENT_VERSION
 from nauro.store.config import get_telemetry_config, load_config, save_config
@@ -27,7 +27,7 @@ def _persist(enabled: bool) -> None:
     section = data.get("telemetry") or {}
     section["enabled"] = enabled
     section["consent_version"] = TELEMETRY_CONSENT_VERSION
-    section["consented_at"] = datetime.now(UTC).isoformat()
+    section["consented_at"] = datetime.now(timezone.utc).isoformat()
     data["telemetry"] = section
     save_config(data)
 

--- a/packages/nauro/src/nauro/templates/agents_md.py
+++ b/packages/nauro/src/nauro/templates/agents_md.py
@@ -7,7 +7,7 @@ the project context. It is regenerated on `nauro sync`.
 Convention: no Jinja2 — use f-strings and string templates only.
 """
 
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from nauro.constants import AGENTS_MD, MANUAL_SECTION_HEADER
@@ -30,7 +30,7 @@ def generate_agents_md(
     Returns:
         Complete AGENTS.md file content.
     """
-    timestamp = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     parts = [
         f"# AGENTS.md\n"

--- a/packages/nauro/src/nauro/templates/scaffolds.py
+++ b/packages/nauro/src/nauro/templates/scaffolds.py
@@ -12,7 +12,7 @@ template, so the one source of truth for the on-disk decision format stays
 in nauro-core.
 """
 
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from nauro_core.decision_model import (
@@ -140,7 +140,7 @@ def scaffold_project_store(project_name: str, store_path: Path) -> None:
     (store_path / C.DECISIONS_DIR).mkdir(exist_ok=True)
     (store_path / C.SNAPSHOTS_DIR).mkdir(exist_ok=True)
 
-    created_at = datetime.now(UTC).strftime("%Y-%m-%d")
+    created_at = datetime.now(timezone.utc).strftime("%Y-%m-%d")
 
     (store_path / C.PROJECT_MD).write_text(render_scaffold(PROJECT_MD, project_name=project_name))
     (store_path / C.STATE_MD).write_text(render_scaffold(STATE_MD))

--- a/packages/nauro/src/nauro/validation/log.py
+++ b/packages/nauro/src/nauro/validation/log.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -20,7 +20,7 @@ def log_validation(project_path: Path, proposal: dict, result: dict) -> None:
     try:
         log_path = project_path / VALIDATION_LOG_FILENAME
         entry = {
-            "timestamp": datetime.now(UTC).isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
             "proposal_title": proposal.get("title", ""),
             "proposal_rationale_preview": (proposal.get("rationale") or "")[:100],
             "tier": result.get("tier"),

--- a/packages/nauro/src/nauro/validation/tier1.py
+++ b/packages/nauro/src/nauro/validation/tier1.py
@@ -7,7 +7,7 @@ Delegates pure validation logic to nauro_core; handles filesystem I/O locally.
 from __future__ import annotations
 
 import json
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from nauro_core import parse_decision
@@ -42,7 +42,7 @@ def _load_recent_decisions(project_path: Path) -> list[Decision]:
     if not decisions_dir.exists():
         return []
 
-    cutoff = (datetime.now(UTC) - timedelta(hours=24)).date()
+    cutoff = (datetime.now(timezone.utc) - timedelta(hours=24)).date()
     recent: list[Decision] = []
 
     for f in sorted(decisions_dir.glob("*.md"), reverse=True):
@@ -82,6 +82,6 @@ def update_hash_index(title: str, rationale: str, decision_id: str, project_path
     index = _load_hash_index(project_path)
     index[content_hash] = {
         "decision_id": decision_id,
-        "timestamp": datetime.now(UTC).isoformat(),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
     }
     _save_hash_index(project_path, index)

--- a/packages/nauro/tests/test_log_diff.py
+++ b/packages/nauro/tests/test_log_diff.py
@@ -1,7 +1,7 @@
 """Tests for nauro log, nauro diff, and store/reader.py."""
 
 import json
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -399,7 +399,7 @@ def _backdate_snapshot(store_path: Path, version: int, days_ago: int) -> None:
     """Rewrite a snapshot's timestamp to be N days ago."""
     snap_path = store_path / SNAPSHOTS_DIR / f"v{version:03d}.json"
     data = load_snapshot(store_path, version)
-    data["timestamp"] = (datetime.now(UTC) - timedelta(days=days_ago)).isoformat()
+    data["timestamp"] = (datetime.now(timezone.utc) - timedelta(days=days_ago)).isoformat()
     snap_path.write_text(json.dumps(data, indent=2) + "\n")
 
 
@@ -430,32 +430,32 @@ def timed_store(store: Path) -> Path:
 
 class TestFindSnapshotNearDate:
     def test_finds_exact_match(self, timed_store: Path):
-        target = datetime.now(UTC) - timedelta(days=7)
+        target = datetime.now(timezone.utc) - timedelta(days=7)
         result = find_snapshot_near_date(timed_store, target)
         assert result is not None
         assert result["version"] == 2
 
     def test_finds_nearest_before(self, timed_store: Path):
         # 10 days ago — should pick v001 (14 days ago), not v002 (7 days ago)
-        target = datetime.now(UTC) - timedelta(days=10)
+        target = datetime.now(timezone.utc) - timedelta(days=10)
         result = find_snapshot_near_date(timed_store, target)
         assert result is not None
         assert result["version"] == 1
 
     def test_falls_back_to_oldest(self, timed_store: Path):
         # 30 days ago — nothing that old, should return oldest (v001)
-        target = datetime.now(UTC) - timedelta(days=30)
+        target = datetime.now(timezone.utc) - timedelta(days=30)
         result = find_snapshot_near_date(timed_store, target)
         assert result is not None
         assert result["version"] == 1
 
     def test_no_snapshots(self, store: Path):
-        result = find_snapshot_near_date(store, datetime.now(UTC))
+        result = find_snapshot_near_date(store, datetime.now(timezone.utc))
         assert result is None
 
     def test_target_in_future(self, timed_store: Path):
         # Future target — should pick latest (v003)
-        target = datetime.now(UTC) + timedelta(days=1)
+        target = datetime.now(timezone.utc) + timedelta(days=1)
         result = find_snapshot_near_date(timed_store, target)
         assert result is not None
         assert result["version"] == 3

--- a/packages/nauro/tests/test_store.py
+++ b/packages/nauro/tests/test_store.py
@@ -1,7 +1,7 @@
 """Tests for store writer, snapshot, and CLI commands (note, sync)."""
 
 import json
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -341,7 +341,7 @@ def test_snapshot_logarithmic_pruning_keeps_correct_per_bucket(tmp_path: Path):
     snapshots_dir.mkdir(parents=True, exist_ok=True)
 
     # Use a fixed midday time so hour/minute offsets never cross day boundaries
-    now = datetime.now(UTC).replace(hour=12, minute=0, second=0, microsecond=0)
+    now = datetime.now(timezone.utc).replace(hour=12, minute=0, second=0, microsecond=0)
 
     version = 0
     snapshots_data = []
@@ -407,7 +407,7 @@ def test_snapshot_decision_adding_never_pruned(tmp_path: Path):
     scaffold_project_store("pintest", store_path)
     snapshots_dir = store_path / "snapshots"
 
-    now = datetime.now(UTC)
+    now = datetime.now(timezone.utc)
 
     # Create old snapshots — some with increasing decision counts
     for i in range(20):
@@ -461,7 +461,7 @@ def test_snapshot_all_pinned_no_excessive_pruning(tmp_path: Path):
     scaffold_project_store("allpin", store_path)
     snapshots_dir = store_path / "snapshots"
 
-    now = datetime.now(UTC)
+    now = datetime.now(timezone.utc)
 
     # Create 15 old snapshots, each with increasing decision count (all pinned)
     for i in range(15):
@@ -587,7 +587,7 @@ def test_validate_stale_sync(tmp_path: Path):
     scaffold_project_store("stale", store)
     # Legacy format with old Last synced — validator still detects it
     state = store / "state.md"
-    old_date = (datetime.now(UTC) - timedelta(days=10)).strftime("%Y-%m-%d")
+    old_date = (datetime.now(timezone.utc) - timedelta(days=10)).strftime("%Y-%m-%d")
     state.write_text(f"# Current State\n*Last synced: {old_date}*\n")
     warnings = validate_store(store)
     stale_warnings = [w for w in warnings if "days ago" in w]

--- a/packages/nauro/tests/test_validation/test_pending.py
+++ b/packages/nauro/tests/test_validation/test_pending.py
@@ -1,6 +1,6 @@
 """Tests for pending confirmation store."""
 
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -46,7 +46,7 @@ def test_remove():
 def test_expire_old_entries():
     confirm_id = store_pending({"title": "Old"}, {})
     # Manually backdate via internal store
-    _store._pending[confirm_id]["created_at"] = datetime.now(UTC) - timedelta(minutes=15)
+    _store._pending[confirm_id]["created_at"] = datetime.now(timezone.utc) - timedelta(minutes=15)
 
     expire_pending()
     assert get_pending(confirm_id) is None

--- a/packages/nauro/tests/test_validation/test_pipeline.py
+++ b/packages/nauro/tests/test_validation/test_pipeline.py
@@ -205,7 +205,7 @@ class TestConfirmWrite:
     @patch("nauro.validation.pipeline.evaluate_with_llm")
     def test_expired_confirm_id(self, mock_llm, mock_sim, store):
         """Expired confirm_ids return error."""
-        from datetime import UTC, datetime, timedelta
+        from datetime import datetime, timedelta, timezone
 
         from nauro.validation.pending import _store
 
@@ -228,7 +228,9 @@ class TestConfirmWrite:
         assert result.confirm_id is not None
 
         # Manually expire it
-        _store._pending[result.confirm_id]["created_at"] = datetime.now(UTC) - timedelta(minutes=15)
+        _store._pending[result.confirm_id]["created_at"] = datetime.now(timezone.utc) - timedelta(
+            minutes=15
+        )
 
         confirm_result = confirm_write(result.confirm_id, store)
         assert "error" in confirm_result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "nauro-workspace"
 version = "0.0.0"
 description = "Nauro monorepo workspace (not published)"
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 
 [tool.uv.workspace]
 members = ["packages/*"]
@@ -11,7 +11,7 @@ members = ["packages/*"]
 nauro-core = { workspace = true }
 
 [tool.ruff]
-target-version = "py311"
+target-version = "py310"
 line-length = 99
 
 [tool.ruff.lint]


### PR DESCRIPTION
## Why

Direct user feedback: a Mac/Window-based devs hit the `>=3.11` install floor.

Recorded as nauro decision D124.

## Approach

Audited the monorepo for 3.11-specific syntax and stdlib usage, then mechanically rewrote the two blockers:

1. **`enum.StrEnum`** → `class X(str, Enum)` mixin. The behavior delta (`str(member)` returns `"Class.member"` instead of the value) doesn't affect any call site — Pydantic serializes via `.value` and the codebase doesn't `str()` these enums for output.
2. **`from datetime import UTC`** → `from datetime import timezone` + `timezone.utc`. Script-driven substitution across 24 files; ruff auto-format fixed two lines that grew past 100 chars.

PEP 604 union syntax (`X | Y`, 213 sites) is fine on 3.10 and was not touched.

## What changed

- `requires-python = ">=3.10"` in 3 pyproject.tomls
- ruff `target-version = "py310"`, mypy `python_version = "3.10"`, added `Python :: 3.10` trove classifier
- CI matrix → `["3.10", "3.11", "3.12"]` for both `test-nauro-core` and `test-nauro`
- `StrEnum` rewrite in `packages/nauro-core/src/nauro_core/decision_model.py` (5 enums)
- `datetime.UTC` rewrite across 24 files (16 source, 8 test)
- Docs: README.md, packages/nauro/README.md, CONTRIBUTING.md, CLAUDE.md, packages/nauro/CLAUDE.md → "3.10+"

34 files, +94 / −88.

## What to review

- `packages/nauro-core/src/nauro_core/decision_model.py` — confirm the `(str, Enum)` mixin is the intended replacement (vs adding `typing_extensions.StrEnum`, which was rejected to keep nauro-core zero-dep per D79)
- `packages/nauro/src/nauro/store/validator.py` and `tests/test_validation/test_pipeline.py` — the only files where ruff format wrapped lines after the substitution; check the wrapping reads cleanly
- CI matrix — confirm we want to actively test 3.10 (vs declaring support without exercising it)

## What's deferred

Going lower than 3.10 (3.9) — Pydantic v2 evaluates the 213 PEP 604 union annotations at runtime, so 3.9 support would require a high-churn rewrite to `Union[X, Y]` / `Optional[X]`. 3.9 is also past upstream EOL (Oct 2025).

mcp-server impact audited separately: zero — it pins `>=3.12` (Lambda) and only uses the affected enums via class-attribute access and identity comparison, never via `str()` or f-string interpolation.

## Test plan

- [x] `uv run --package nauro-core --python 3.10 pytest packages/nauro-core/tests/ -x -q` → 238 passed
- [x] `uv run --package nauro --python 3.10 pytest packages/nauro/tests/ -x -q -m "not integration"` → 731 passed
- [x] Same suites pass under Python 3.11 (no regression)
- [x] `uv run ruff check packages/` → clean
- [x] `uv run ruff format --check packages/` → clean
- [ ] CI matrix runs all three Python versions green