### PR TITLE
fix(import): compose Memory Bank state into single update_state call

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/import_cmd.py
+++ b/packages/nauro/src/nauro/cli/commands/import_cmd.py
@@ -12,7 +12,7 @@ from typing import Any
 import typer
 
 from nauro.cli.utils import resolve_target_project
-from nauro.constants import PROJECT_MD, STACK_MD, STATE_MD
+from nauro.constants import PROJECT_MD, STACK_MD
 from nauro.store.snapshot import capture_snapshot
 from nauro.store.writer import append_decision, update_state
 
@@ -21,11 +21,15 @@ def _import_memory_bank(memory_bank: Path, store_path: Path) -> dict[str, int]:
     """Import a Cline/Roo Code Memory Bank (.context/ directory) into the store.
 
     Maps Memory Bank files to Nauro store files:
-      projectBrief.md  → project.md  (appended under ## Imported from Memory Bank)
-      activeContext.md  → state.md   (appended under ## Imported from Memory Bank)
-      techContext.md    → stack.md   (appended under ## Imported from Memory Bank)
+      projectBrief.md  → project.md           (appended under ## Imported from Memory Bank)
+      techContext.md   → stack.md             (appended under ## Imported from Memory Bank)
       decisionLog.md   → decisions/NNN-title.md (one file per ## Decision block)
-      progress.md      → state.md   (recently completed items via update_state)
+      activeContext.md + progress.md → state_current.md (single composed update_state call)
+
+    activeContext.md and progress.md are composed into one delta and written via
+    a single update_state() call. Calling update_state per progress item would
+    archive all but the last to state_history.md, which build_l0 ignores
+    (include_history=False), making the imported state invisible to L0.
 
     Args:
         memory_bank: Path to the .context/ directory.
@@ -49,15 +53,6 @@ def _import_memory_bank(memory_bank: Path, store_path: Path) -> dict[str, int]:
         )
         counts["files_merged"] += 1
 
-    # activeContext.md → state.md
-    active_path = memory_bank / "activeContext.md"
-    if active_path.exists():
-        _append_to_store_file(
-            store_path / STATE_MD,
-            active_path.read_text(),
-        )
-        counts["files_merged"] += 1
-
     # techContext.md → stack.md
     tech_path = memory_bank / "techContext.md"
     if tech_path.exists():
@@ -72,12 +67,59 @@ def _import_memory_bank(memory_bank: Path, store_path: Path) -> dict[str, int]:
     if decision_log.exists():
         counts["decisions"] = _parse_and_import_decisions(decision_log.read_text(), store_path)
 
-    # progress.md → state.md (recently completed items)
+    # activeContext.md + progress.md → state_current.md (one composed update_state)
+    active_body: str | None = None
+    active_path = memory_bank / "activeContext.md"
+    if active_path.exists():
+        active_body = _strip_h1_prefix(active_path.read_text())
+        if active_body:
+            counts["files_merged"] += 1
+
+    progress_items: list[str] = []
     progress_path = memory_bank / "progress.md"
     if progress_path.exists():
-        counts["progress_items"] = _import_progress(progress_path.read_text(), store_path)
+        progress_items = _import_progress(progress_path.read_text())
+    counts["progress_items"] = len(progress_items)
+
+    delta = _compose_state_delta(active_body, progress_items)
+    if delta is not None:
+        update_state(store_path, delta)
 
     return counts
+
+
+def _strip_h1_prefix(content: str) -> str:
+    """Strip a leading H1 header (and trailing blank lines), then strip whitespace.
+
+    activeContext.md typically opens with `# Active Context`, which becomes
+    redundant once composed into a state delta — prepare_state_update wraps
+    the delta in `# Current State` already.
+    """
+    lines = content.split("\n")
+    first = lines[0].strip() if lines else ""
+    if first.startswith("# ") and first[2:].strip():
+        i = 1
+        while i < len(lines) and lines[i].strip() == "":
+            i += 1
+        return "\n".join(lines[i:]).strip()
+    return content.strip()
+
+
+def _compose_state_delta(active_body: str | None, progress_items: list[str]) -> str | None:
+    """Compose activeContext body + progress items into a single state delta.
+
+    Returns None when both inputs are empty (caller skips update_state entirely).
+    """
+    has_active = bool(active_body)
+    has_progress = bool(progress_items)
+    progress_block = "## Recently completed\n" + "\n".join(f"- {item}" for item in progress_items)
+    if has_active and has_progress:
+        return f"{active_body}\n\n{progress_block}"
+    if has_active:
+        return active_body
+    if has_progress:
+        return progress_block
+    return None
 
 
 def _append_to_store_file(target: Path, content: str) -> None:
@@ -279,24 +321,20 @@ def _extract_list_items(text: str) -> list[str]:
     return items
 
 
-def _import_progress(content: str, store_path: Path) -> int:
-    """Extract recently completed items from progress.md and update state.
+def _import_progress(content: str) -> list[str]:
+    """Extract recently completed items from progress.md as a list.
 
-    Looks for lines starting with - (list items) that look like completed work.
-
-    Returns:
-        Number of items imported.
+    Pure parser — composition into a state delta and the single update_state
+    call live in _import_memory_bank.
     """
-    count = 0
+    items: list[str] = []
     for line in content.split("\n"):
-        line = line.strip()
-        # Match markdown list items: - text or * text
-        if re.match(r"^[-*]\s+", line):
-            item = re.sub(r"^[-*]\s+", "", line).strip()
+        stripped = line.strip()
+        if stripped.startswith(("- ", "* ")):
+            item = stripped[2:].strip()
             if item:
-                update_state(store_path, item)
-                count += 1
-    return count
+                items.append(item)
+    return items
 
 
 def import_cmd(

--- a/packages/nauro/tests/test_import.py
+++ b/packages/nauro/tests/test_import.py
@@ -5,8 +5,13 @@ from pathlib import Path
 import pytest
 from typer.testing import CliRunner
 
-from nauro.cli.commands.import_cmd import _import_adrs, _import_memory_bank
+from nauro.cli.commands.import_cmd import (
+    _import_adrs,
+    _import_memory_bank,
+    _import_progress,
+)
 from nauro.cli.main import app
+from nauro.mcp.payloads import build_l0_payload
 from nauro.store.registry import register_project
 from nauro.store.snapshot import list_snapshots
 from nauro.templates.scaffolds import scaffold_project_store
@@ -77,10 +82,13 @@ def test_import_complete_memory_bank(store: Path, full_memory_bank: Path):
     assert "## Imported from Memory Bank" in project_content
     assert "task management" in project_content
 
-    # state.md should have imported context and progress items
-    state_content = (store / "state.md").read_text()
-    assert "## Imported from Memory Bank" in state_content
-    assert "auth module" in state_content
+    # state_current.md should have the composed activeContext + progress
+    # (the legacy "## Imported from Memory Bank" header is no longer added —
+    # active body lands directly under prepare_state_update's "# Current State").
+    state_current = (store / "state_current.md").read_text()
+    assert "auth module" in state_current
+    assert "## Recently completed" in state_current
+    assert "Set up project scaffolding" in state_current
 
     # stack.md should have tech context
     stack_content = (store / "stack.md").read_text()
@@ -263,6 +271,155 @@ def test_import_progress_with_empty_items(store: Path, tmp_path: Path):
 
     counts = _import_memory_bank(ctx, store)
     assert counts["progress_items"] == 1
+
+
+# --- v2 split-state composition (single update_state call) ---
+
+
+def _mb_with(tmp_path: Path, name: str, **files: str) -> Path:
+    """Build a Memory Bank dir with the given files. Always includes projectBrief."""
+    ctx = tmp_path / name
+    ctx.mkdir()
+    (ctx / "projectBrief.md").write_text("# Brief\n\nA test project.\n")
+    for filename, content in files.items():
+        (ctx / filename).write_text(content)
+    return ctx
+
+
+def test_active_context_lands_in_state_current_not_legacy(store: Path, tmp_path: Path):
+    mb = _mb_with(
+        tmp_path,
+        ".context_active_only",
+        **{"activeContext.md": "# Active Context\n\nWiring up Stripe checkout.\n"},
+    )
+    legacy_before = (store / "state.md").read_text()
+
+    _import_memory_bank(mb, store)
+
+    state_current = (store / "state_current.md").read_text()
+    assert "Wiring up Stripe checkout." in state_current
+    # Legacy state.md is the scaffold; never gets the imported activeContext body.
+    assert (store / "state.md").read_text() == legacy_before
+    assert "Wiring up Stripe checkout." not in (store / "state.md").read_text()
+
+
+def test_progress_items_compose_into_recently_completed(store: Path, tmp_path: Path):
+    mb = _mb_with(
+        tmp_path,
+        ".context_progress_only",
+        **{"progress.md": "# Progress\n\n- Item one\n- Item two\n- Item three\n"},
+    )
+
+    _import_memory_bank(mb, store)
+
+    state_current = (store / "state_current.md").read_text()
+    assert "## Recently completed" in state_current
+    assert "- Item one" in state_current
+    assert "- Item two" in state_current
+    assert "- Item three" in state_current
+
+
+def test_active_context_and_progress_compose_into_single_state_current(store: Path, tmp_path: Path):
+    mb = _mb_with(
+        tmp_path,
+        ".context_both",
+        **{
+            "activeContext.md": "# Active Context\n\nReviewing payment flow.\n",
+            "progress.md": "# Progress\n\n- A\n- B\n- C\n",
+        },
+    )
+
+    _import_memory_bank(mb, store)
+
+    state_current = (store / "state_current.md").read_text()
+    assert "Reviewing payment flow." in state_current
+    assert "## Recently completed" in state_current
+    assert "- A" in state_current
+    assert "- B" in state_current
+    assert "- C" in state_current
+
+    # state_history should NOT contain N entries (one per progress item).
+    # update_state was called once, so at most one prior-state archive exists
+    # (the migrated legacy scaffold).
+    history_path = store / "state_history.md"
+    if history_path.exists():
+        # Count `## ` timestamp headers — there should be exactly one (or zero).
+        history = history_path.read_text()
+        timestamp_headers = [line for line in history.split("\n") if line.startswith("## 20")]
+        assert len(timestamp_headers) <= 1
+
+
+def test_build_l0_surfaces_imported_state(store: Path, tmp_path: Path):
+    """Regression: imported activeContext + progress must reach the L0 payload.
+
+    build_l0 passes include_history=False, so anything in state_history.md is
+    invisible. This test fails if update_state is called per-progress-item
+    (most items end up in history).
+    """
+    mb = _mb_with(
+        tmp_path,
+        ".context_l0",
+        **{
+            "activeContext.md": "# Active Context\n\nL0_ACTIVE_MARKER\n",
+            "progress.md": "# Progress\n\n- L0_PROGRESS_MARKER\n",
+        },
+    )
+
+    _import_memory_bank(mb, store)
+
+    payload = build_l0_payload(store)
+    assert "L0_ACTIVE_MARKER" in payload
+    assert "L0_PROGRESS_MARKER" in payload
+
+
+def test_progress_only_no_active_context(store: Path, tmp_path: Path):
+    mb = _mb_with(
+        tmp_path,
+        ".context_progress_no_active",
+        **{"progress.md": "# Progress\n\n- Only progress here\n"},
+    )
+
+    _import_memory_bank(mb, store)
+
+    state_current = (store / "state_current.md").read_text()
+    # State delta starts directly with the section header — no leading body.
+    body_after_wrapper = state_current.split("# Current State", 1)[1].lstrip()
+    assert body_after_wrapper.startswith("## Recently completed")
+
+
+def test_active_only_no_progress(store: Path, tmp_path: Path):
+    mb = _mb_with(
+        tmp_path,
+        ".context_active_no_progress",
+        **{"activeContext.md": "# Active Context\n\nJust active body.\n"},
+    )
+
+    _import_memory_bank(mb, store)
+
+    state_current = (store / "state_current.md").read_text()
+    assert "Just active body." in state_current
+    assert "## Recently completed" not in state_current
+
+
+def test_neither_active_nor_progress_no_state_files_created(store: Path, tmp_path: Path):
+    """Only projectBrief — no update_state call, no state_current.md created.
+
+    Scaffolds today create legacy state.md only (no state_current.md). When
+    neither activeContext nor progress is imported, update_state is skipped
+    entirely, so state_current.md should never come into existence.
+    """
+    legacy_before = (store / "state.md").read_text()
+    mb = _mb_with(tmp_path, ".context_brief_only")  # only projectBrief.md
+
+    _import_memory_bank(mb, store)
+
+    assert not (store / "state_current.md").exists()
+    assert (store / "state.md").read_text() == legacy_before
+
+
+def test_import_progress_returns_parsed_items():
+    items = _import_progress("# Progress\n\n- one\n- two\n- three\n")
+    assert items == ["one", "two", "three"]
 
 
 # ===========================================================================


### PR DESCRIPTION
## Why
`nauro import --memory-bank` routed `activeContext.md` into legacy `state.md` (bypassing the v2 split-state writer) and called `update_state` once per `progress.md` item. Cumulative effect: imported activeContext was invisible to L0 (only `state_current.md` is read), and progress items got archived to `state_history.md` (also invisible to L0 — `build_l0` passes `include_history=False`). Adopters from Cline/Roo Memory Bank ended up with an empty L0 payload despite a successful-looking import.

## Approach
Compose activeContext body + progress items into a single delta and call `update_state` exactly once. `_import_progress` becomes a pure parser; the composition (and the single state-write) live in `_import_memory_bank`.

## What changed
- `packages/nauro/src/nauro/cli/commands/import_cmd.py`: `_import_memory_bank` composes single delta; `_import_progress` returns `list[str]`; new helpers `_strip_h1_prefix` and `_compose_state_delta`. Drops the now-unused `STATE_MD` import.
- `packages/nauro/tests/test_import.py`: 8 new tests covering composition, L0 visibility, and edge cases (active-only, progress-only, neither). Updated `test_import_complete_memory_bank` to assert `state_current.md` (was asserting the legacy `state.md` path).

## What to review
- The composition template (`## Recently completed` header) — fits Nauro's state.md convention?
- `_import_progress` signature change from `(content, store_path) -> int` to `(content) -> list[str]` — verified no other callers.
- `_strip_h1_prefix` on activeContext — is dropping the source's `# Active Context` heading the right call (alternative: keep it as `## Active Context` under the `# Current State` wrapper)?

## What's deferred
- ADR import path (works correctly today, no change here).
- `projectBrief` / `techContext` (still use the legacy append helper; correct for those targets — they map to `project.md` / `stack.md`, not state).

## Test plan
- [x] `pytest packages/nauro/tests/test_import.py -x -q` (25 passed)
- [x] `pytest packages/nauro/tests/ -x -q -m "not integration"` (739 passed)
- [x] `pytest packages/nauro-core/tests/ -x -q` (238 passed)
- [x] `ruff check packages/` (clean)
- [x] `ruff format --check packages/` (clean)
- [ ] Manual: import a Cline `.context/` directory, then `nauro mcp` → `get_context`, confirm activeContext + progress visible in L0.