### PR TITLE
feat(setup): extend nauro setup to cover Cursor + Codex, add skill loader

### DIFF
--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -30,6 +30,8 @@ dependencies = [
     "boto3>=1.28",
     "filelock>=3.0",
     "posthog>=7.0,<8.0",
+    "tomli>=2.0; python_version<'3.11'",
+    "tomli-w>=1.0",
 ]
 
 [project.optional-dependencies]

--- a/packages/nauro/src/nauro/cli/commands/setup.py
+++ b/packages/nauro/src/nauro/cli/commands/setup.py
@@ -1,12 +1,16 @@
 """nauro setup — Configure tool integrations.
 
-Currently supports:
+Subcommands:
   nauro setup claude-code  — register MCP server + regenerate AGENTS.md
+  nauro setup cursor       — register MCP server in <repo>/.cursor/mcp.json
+                             for each of the project's repos
+  nauro setup codex        — register MCP server in ~/.codex/config.toml
 """
 
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 
 import typer
@@ -19,6 +23,13 @@ from nauro.store.registry import (
     get_project_v2,
 )
 from nauro.templates.agents_md import regenerate_agents_md_for_project
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
+
+import tomli_w
 
 setup_app = typer.Typer(help="Configure tool integrations.")
 
@@ -180,3 +191,133 @@ def claude_code(
             "\nNext: start a Claude Code session in one of the repos."
             " The MCP server will start automatically."
         )
+
+
+# ─── Cursor ─────────────────────────────────────────────────────────────────
+
+
+# Cursor reads MCP servers from `<repo>/.cursor/mcp.json` (per-project).
+# User-global "Rules for AI" live in the IDE Settings UI, not a file path —
+# so MCP wiring is per-project here.
+# Docs: https://cursor.com/docs (checked: 2026-05-07)
+
+
+def _configure_cursor_for_repo(repo_path: Path, *, remove: bool) -> str:
+    """Add or remove the Nauro MCP entry in this repo's ``.cursor/mcp.json``."""
+    cursor_dir = repo_path / ".cursor"
+    config_path = cursor_dir / "mcp.json"
+    nauro_cmd = _find_nauro_command()
+    nauro_entry = {"command": nauro_cmd, "args": ["serve", "--stdio"]}
+
+    if config_path.exists():
+        config = json.loads(config_path.read_text())
+    else:
+        config = {}
+
+    if remove:
+        servers = config.get("mcpServers", {})
+        if "nauro" in servers:
+            del servers["nauro"]
+            if not servers:
+                config.pop("mcpServers", None)
+            if config:
+                config_path.write_text(json.dumps(config, indent=2) + "\n")
+            else:
+                config_path.unlink()
+            return f"  {repo_path}: removed nauro from .cursor/mcp.json"
+        return f"  {repo_path}: no nauro entry to remove"
+
+    config.setdefault("mcpServers", {})["nauro"] = nauro_entry
+    cursor_dir.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(json.dumps(config, indent=2) + "\n")
+    return f"  {repo_path}: wrote nauro to .cursor/mcp.json"
+
+
+@setup_app.command(name="cursor")
+def cursor(
+    project: str | None = typer.Option(
+        None, "--project", help="Project name (default: resolve from cwd)."
+    ),
+    remove: bool = typer.Option(
+        False, "--remove", help="Remove Nauro integration instead of adding it."
+    ),
+) -> None:
+    """Configure Cursor to use Nauro for this project's repos."""
+    project_name, _store_path = resolve_target_project(project)
+    project_key = _store_path.name
+
+    try:
+        entry = get_project_v2(project_key)
+    except RegistrySchemaError:
+        entry = None
+    if entry is None:
+        entry = get_project(project_name)
+
+    if entry is None or not entry.get("repo_paths"):
+        typer.echo(f"Project '{project_name}' has no associated repos.", err=True)
+        raise typer.Exit(code=1)
+
+    action = "Removed" if remove else "Configured"
+    typer.echo(f"{action} Nauro (Cursor) for project '{project_name}':\n")
+    for repo_str in entry["repo_paths"]:
+        repo_path = Path(repo_str)
+        if not repo_path.is_dir():
+            typer.echo(f"  {repo_path}: repo path missing, skipped")
+            continue
+        typer.echo(_configure_cursor_for_repo(repo_path, remove=remove))
+
+    if not remove:
+        typer.echo("\nNext: open this repo in Cursor and start a chat — Nauro MCP will connect.")
+
+
+# ─── Codex CLI ──────────────────────────────────────────────────────────────
+
+
+# Codex reads MCP servers from `~/.codex/config.toml` under `[mcp_servers.<name>]`.
+# This is the user-global Codex CLI config and is shared with the IDE extension.
+# Docs: https://developers.openai.com/codex/mcp (checked: 2026-05-07)
+
+
+def _default_codex_config_path() -> Path:
+    return Path.home() / ".codex" / "config.toml"
+
+
+def _configure_codex(*, remove: bool, config_path: Path | None = None) -> str:
+    """Add or remove the Nauro MCP entry in ``~/.codex/config.toml``."""
+    config_path = config_path or _default_codex_config_path()
+    nauro_cmd = _find_nauro_command()
+    nauro_entry = {"command": nauro_cmd, "args": ["serve", "--stdio"]}
+
+    if config_path.exists():
+        with config_path.open("rb") as f:
+            config = tomllib.load(f)
+    else:
+        config = {}
+
+    servers = config.setdefault("mcp_servers", {})
+
+    if remove:
+        if "nauro" in servers:
+            del servers["nauro"]
+            if not servers:
+                config.pop("mcp_servers", None)
+            config_path.write_bytes(tomli_w.dumps(config).encode("utf-8"))
+            return f"Codex: removed nauro from {config_path}"
+        return f"Codex: no nauro entry to remove in {config_path}"
+
+    servers["nauro"] = nauro_entry
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_bytes(tomli_w.dumps(config).encode("utf-8"))
+    return f"Codex: wrote nauro to {config_path}"
+
+
+@setup_app.command(name="codex")
+def codex(
+    remove: bool = typer.Option(
+        False, "--remove", help="Remove Nauro integration instead of adding it."
+    ),
+) -> None:
+    """Configure Codex CLI to use Nauro (writes ``~/.codex/config.toml``)."""
+    typer.echo(_configure_codex(remove=remove))
+    if not remove:
+        typer.echo("\nNext: run a Codex session — it reads ~/.codex/config.toml on start.")

--- a/packages/nauro/src/nauro/skills/__init__.py
+++ b/packages/nauro/src/nauro/skills/__init__.py
@@ -1,0 +1,24 @@
+"""Skill body loaders.
+
+The canonical Nauro skill bodies live in this package as ``.md`` files.
+Per-surface files (Claude Code SKILL.md, Cursor ``.mdc``, Codex SKILL.md)
+wrap the same canonical body in surface-appropriate frontmatter; drift
+tests assert the wrapped bodies match ``load_*_body()`` exactly.
+"""
+
+from __future__ import annotations
+
+from importlib import resources
+
+
+def load_adopt_body() -> str:
+    """Return the canonical ``/nauro-adopt`` skill body (no frontmatter)."""
+    return resources.files(__package__).joinpath("adopt_body.md").read_text(encoding="utf-8")
+
+
+def load_session_body() -> str:
+    """Return the canonical ``/nauro`` session-time skill body (no frontmatter)."""
+    return resources.files(__package__).joinpath("session_body.md").read_text(encoding="utf-8")
+
+
+__all__ = ["load_adopt_body", "load_session_body"]

--- a/packages/nauro/src/nauro/skills/adopt_body.md
+++ b/packages/nauro/src/nauro/skills/adopt_body.md
@@ -1,0 +1,90 @@
+# Nauro adopt skill
+
+The agent helps the user seed Nauro with context from the current repo. Before this skill runs, the user has run `nauro adopt` from the repo root, which created the project, wired MCP across surfaces, and installed this skill into the agent's surface directory. The agent's job here is to read the repo's documentation (README, manifests, ADRs, Memory-Bank) and seed the Nauro store via MCP write tools. The agent records facts that source documents explicitly state — it does not invent decisions from prose. On chat surfaces (Claude.ai, ChatGPT) without filesystem access, the agent uses paste-content mode (Step 3b); chat-paste mode requires the project to already exist (run `nauro adopt` locally first).
+
+## Step 1 — Detect repo root
+
+The agent runs `git rev-parse --show-toplevel` from the current working directory. On failure: abort with "nauro adopt requires a git repository. Run 'git init' first, then re-run 'nauro adopt'."
+
+## Step 2 — Already-adopted guard
+
+The agent reads `<repo>/.nauro/config.json`. If the file is missing: abort with "This repo is not adopted yet. Run 'nauro adopt' from the repo root, restart this agent, then invoke /nauro-adopt again." If the file exists and parses as JSON: extract `id` and `name` and use these as the project handle for subsequent calls.
+
+## Step 3 — Read source files
+
+The agent reads the first match found per category. Files larger than 256KB are flagged to the user before reading.
+
+- **README**: `README.md`, `README.rst`, `README` (first found)
+- **Manifest**: `pyproject.toml`, `package.json`, `Cargo.toml`, `go.mod`, `Gemfile`, `pom.xml`, `build.gradle`, `composer.json`, `requirements*.txt`
+- **Top-level docs**: `CONTRIBUTING.md`, `ARCHITECTURE.md`, `DESIGN.md`, `CLAUDE.md`, `AGENTS.md`
+- **ADR directory**: `docs/adr/`, `docs/decisions/`, `architecture/decisions/`, `adr/` — every `.md` except templates and index files (`0000-template.md`, `README.md`)
+- **Memory Bank**: `.context/`, `memory-bank/`, `cline_docs/` — `projectBrief.md`, `activeContext.md`, `techContext.md`, `decisionLog.md`, `progress.md`
+
+### Step 3b — Chat-surface paste branch
+
+When filesystem read is unavailable, the agent prompts:
+
+> This skill needs source content. Paste the contents of any of: README, manifest (pyproject.toml/package.json/etc.), ADRs, Memory-Bank files. Send each as a separate message labelled with the filename.
+
+Chat-paste mode does not create projects (no shell access for `nauro adopt`). If `<repo>/.nauro/config.json` was not previously written by a local `nauro adopt`, the agent surfaces "I cannot continue from here; please run `nauro adopt` locally first" and stops.
+
+## Step 4 — Call get_context
+
+The agent calls `get_context` (MCP) to surface what the scaffold already wrote — `001-initial-setup.md` and bracketed-prompt placeholders in `project.md` / `stack.md` / `state_current.md`. The agent uses this to (a) avoid duplicating the scaffold's first decision, (b) confirm the project resolved correctly.
+
+## Step 5 — Build candidate list, surface FIRST
+
+The agent triages the source content into two lists.
+
+**Step 5a — Clear decisions.** Candidates where the source explicitly states acceptance and rationale (and, when applicable, rejected alternatives). Each entry: number, title (≤60 chars), one-line summary (≤140 chars), source location. The agent prints the full list as one message:
+
+> Reply 'keep N' / 'edit N: <new title>' / 'skip N' per item. Or 'keep all' to accept everything. Reply 'done' when finished.
+
+**Step 5b — Boundary candidates.** Facts that *might* be decisions but where the source does not state rationale verbatim. Surfaced after the user finishes Step 5a:
+
+> The agent thinks these might be decisions but couldn't extract rationale verbatim from the source. Each is opt-in only — reply 'opt N: <rationale>' to record any of them with rationale you provide; otherwise they are skipped.
+
+## Step 6 — Iterate kept items
+
+For each kept item from 5a (and each opt-in from 5b):
+
+1. Call `propose_decision(title, rationale, rejected, confidence)`. `rationale` is drawn from explicit source text (or user-provided for opt-ins). `confidence` defaults to `medium`; `high` only when the source explicitly says "accepted" or "approved". Rejected alternatives are included only when the source names them.
+2. **If `propose_decision` returns no conflicts**: call `confirm_decision(confirm_id)` automatically — no further user prompt.
+3. **If `propose_decision` returns conflicts**: surface the conflict text verbatim, ask `confirm-anyway / edit / skip`. On user 'confirm' → `confirm_decision(confirm_id)`.
+
+One propose+confirm per decision. No batching.
+
+## Step 7 — State composition (one update_state call)
+
+The agent reads `activeContext.md` body and `progress.md` items, then composes one delta:
+
+```
+{activeContext_body_with_leading_h1_stripped}
+
+## Recently completed
+- {progress_item_1}
+- {progress_item_2}
+- ...
+```
+
+If only one source is present, the corresponding section is omitted. If neither is present, `update_state` is skipped entirely. **The agent does not call `update_state` per progress item** — `update_state` archives prior state to history, and the L0 payload ignores history.
+
+## Step 8 — Flag open questions
+
+Sources: explicit `## Open Questions` sections, lines beginning `Q:` or `TODO:` in CONTRIBUTING/ARCHITECTURE docs, user-noted gaps from Steps 5–6 ("we never decided X"). Per candidate: surface, ask `keep / edit / skip`. On keep → `flag_question(question, context)`.
+
+## Step 9 — Refusal contract
+
+The agent records facts that source documents explicitly state. The agent does not infer rationale from prose, does not invent rejected alternatives, does not assume `confidence=high` from tone, does not summarize a paragraph into a "decision" the source never called a decision. Boundary cases go to Step 5b (opt-in only — write rationale yourself), not into the clear-decisions list.
+
+## Step 10 — Summary
+
+The agent prints one block:
+
+- Project: `<name>` (id: `<pid>`, store: `<store-path>`)
+- Sources read: `<comma-separated list>`
+- Decisions created: N (titles)
+- Decisions skipped: M (titles)
+- State updated: yes/no
+- Open questions flagged: K
+- Next: run `nauro sync` from the repo to capture a snapshot.

--- a/packages/nauro/src/nauro/skills/session_body.md
+++ b/packages/nauro/src/nauro/skills/session_body.md
@@ -1,0 +1,23 @@
+# Nauro session skill
+
+The agent uses Nauro across the session to keep project context current and surface decision conflicts before they ship. Three calls cover the lifecycle.
+
+## At session start — call get_context
+
+The agent calls `get_context` early in the session, before the first user-driven action where possible. The L0 payload returns the project summary, current state, top open questions, and the last 10 active decisions with titles and dates. This loads the project's intent into the agent's working context so subsequent suggestions align with prior decisions.
+
+## Before any architectural change — call check_decision
+
+When the user proposes — or the agent considers proposing — an architectural change (library swap, API redesign, data model change, infrastructure pick, new pattern), the agent calls `check_decision(proposed_approach)` first. The tool returns related decisions via BM25 retrieval and an LLM-based conflict assessment. If conflicts surface: the agent shows them to the user verbatim before recommending the change. If no conflicts and the choice is real: the agent records it via `propose_decision` + `confirm_decision`.
+
+This includes "should we…", "what if we…", "can we…", and "check if…" framings, and applies even when the agent intends to push back or refuse. First-principles reasoning is not a substitute for project history.
+
+## After meaningful progress — call update_state
+
+After completing a unit of work (a feature, a refactor, a bug fix that took more than a few changes) the agent calls `update_state(delta)` with a short paragraph describing what was completed. This replaces the project's current state, archiving the prior content to history. The next session's `get_context` call surfaces this update so context flows forward.
+
+The agent does not call `update_state` for every commit or every minor change — only at meaningful boundaries. State is a snapshot of "where the project is now," not a changelog.
+
+## Refusal contract
+
+The agent does not invent decisions to record. `propose_decision` is called when a real architectural choice is made — between two or more approaches, replacing a dependency, establishing a new pattern, cutting scope. Bug fixes, renaming, and adding tests for existing behavior are not decisions.

--- a/packages/nauro/tests/test_setup_extended.py
+++ b/packages/nauro/tests/test_setup_extended.py
@@ -1,0 +1,169 @@
+"""Tests for the extended ``nauro setup`` (cursor + codex subcommands)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from nauro.cli.commands.setup import _configure_codex, _configure_cursor_for_repo
+from nauro.cli.main import app
+from nauro.store.registry import register_project_v2
+from nauro.templates.scaffolds import scaffold_project_store
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
+
+runner = CliRunner()
+
+
+# ─── nauro setup cursor ─────────────────────────────────────────────────────
+
+
+def test_setup_cursor_writes_repo_mcp_json(tmp_path: Path, monkeypatch):
+    """`nauro setup cursor` writes <repo>/.cursor/mcp.json for each project repo."""
+    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    pid, store_path = register_project_v2("myproj", [repo])
+    scaffold_project_store("myproj", store_path)
+    monkeypatch.chdir(repo)
+
+    result = runner.invoke(app, ["setup", "cursor"])
+    assert result.exit_code == 0, result.output
+
+    config_path = repo / ".cursor" / "mcp.json"
+    assert config_path.is_file()
+    data = json.loads(config_path.read_text())
+    assert data["mcpServers"]["nauro"]["args"] == ["serve", "--stdio"]
+    assert "command" in data["mcpServers"]["nauro"]
+
+
+def test_setup_cursor_remove_clears_entry(tmp_path: Path, monkeypatch):
+    """`nauro setup cursor --remove` deletes the nauro entry."""
+    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    _, store_path = register_project_v2("myproj", [repo])
+    scaffold_project_store("myproj", store_path)
+    monkeypatch.chdir(repo)
+
+    runner.invoke(app, ["setup", "cursor"])
+    assert (repo / ".cursor" / "mcp.json").is_file()
+
+    result = runner.invoke(app, ["setup", "cursor", "--remove"])
+    assert result.exit_code == 0, result.output
+    # Nauro was the only entry, so the now-empty config file is unlinked.
+    assert not (repo / ".cursor" / "mcp.json").is_file()
+
+
+def test_configure_cursor_preserves_other_mcp_servers(tmp_path: Path):
+    """Adding nauro to .cursor/mcp.json must not clobber other servers."""
+    repo = tmp_path / "repo"
+    (repo / ".cursor").mkdir(parents=True)
+    config = {"mcpServers": {"other": {"command": "other-cmd", "args": []}}}
+    (repo / ".cursor" / "mcp.json").write_text(json.dumps(config))
+
+    _configure_cursor_for_repo(repo, remove=False)
+
+    result = json.loads((repo / ".cursor" / "mcp.json").read_text())
+    assert "other" in result["mcpServers"]
+    assert "nauro" in result["mcpServers"]
+
+
+def test_configure_cursor_remove_preserves_other_servers(tmp_path: Path):
+    """`--remove` should drop only the nauro entry, not the rest."""
+    repo = tmp_path / "repo"
+    (repo / ".cursor").mkdir(parents=True)
+    config = {
+        "mcpServers": {
+            "nauro": {"command": "nauro", "args": ["serve", "--stdio"]},
+            "other": {"command": "other-cmd", "args": []},
+        }
+    }
+    (repo / ".cursor" / "mcp.json").write_text(json.dumps(config))
+
+    _configure_cursor_for_repo(repo, remove=True)
+
+    result = json.loads((repo / ".cursor" / "mcp.json").read_text())
+    assert "other" in result["mcpServers"]
+    assert "nauro" not in result["mcpServers"]
+
+
+# ─── nauro setup codex ──────────────────────────────────────────────────────
+
+
+def test_setup_codex_writes_config_toml(tmp_path: Path):
+    """`_configure_codex` writes ``[mcp_servers.nauro]`` into the target TOML file."""
+    config_path = tmp_path / ".codex" / "config.toml"
+
+    msg = _configure_codex(remove=False, config_path=config_path)
+
+    assert "wrote nauro" in msg
+    assert config_path.is_file()
+    with config_path.open("rb") as f:
+        data = tomllib.load(f)
+    assert data["mcp_servers"]["nauro"]["args"] == ["serve", "--stdio"]
+
+
+def test_setup_codex_remove_clears_entry(tmp_path: Path):
+    config_path = tmp_path / ".codex" / "config.toml"
+    _configure_codex(remove=False, config_path=config_path)
+
+    msg = _configure_codex(remove=True, config_path=config_path)
+
+    assert "removed nauro" in msg
+    with config_path.open("rb") as f:
+        data = tomllib.load(f)
+    assert "mcp_servers" not in data or "nauro" not in data.get("mcp_servers", {})
+
+
+def test_setup_codex_preserves_other_mcp_servers(tmp_path: Path):
+    """Adding nauro must not clobber other [mcp_servers.<name>] entries."""
+    config_path = tmp_path / ".codex" / "config.toml"
+    config_path.parent.mkdir()
+    config_path.write_text('[mcp_servers.other]\ncommand = "other-cmd"\nargs = []\n')
+
+    _configure_codex(remove=False, config_path=config_path)
+
+    with config_path.open("rb") as f:
+        data = tomllib.load(f)
+    assert "other" in data["mcp_servers"]
+    assert "nauro" in data["mcp_servers"]
+
+
+def test_setup_codex_no_op_when_remove_and_no_entry(tmp_path: Path):
+    """`--remove` when no entry exists is idempotent and reports clearly."""
+    config_path = tmp_path / ".codex" / "config.toml"
+    msg = _configure_codex(remove=True, config_path=config_path)
+    assert "no nauro entry to remove" in msg
+
+
+# ─── claude-code regression ──────────────────────────────────────────────────
+
+
+def test_setup_claude_code_subcommand_unchanged(tmp_path: Path, monkeypatch):
+    """The existing `setup claude-code` command stays callable."""
+    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
+    monkeypatch.setenv("HOME", str(tmp_path))  # divert ~/.claude search
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    register_project_v2("myproj", [repo])
+    monkeypatch.chdir(repo)
+
+    result = runner.invoke(app, ["setup", "claude-code"])
+    assert result.exit_code == 0, result.output
+    assert "Configured Nauro" in result.output
+
+
+def test_setup_top_level_help_lists_new_subcommands():
+    """`nauro setup --help` should advertise cursor + codex alongside claude-code."""
+    result = runner.invoke(app, ["setup", "--help"])
+    assert result.exit_code == 0
+    assert "claude-code" in result.output
+    assert "cursor" in result.output
+    assert "codex" in result.output

--- a/packages/nauro/tests/test_skills_drift.py
+++ b/packages/nauro/tests/test_skills_drift.py
@@ -1,0 +1,33 @@
+"""Drift tests for the canonical Nauro skill bodies.
+
+The canonical body lives at ``packages/nauro/src/nauro/skills/{adopt,session}_body.md``.
+``load_adopt_body()`` / ``load_session_body()`` return that body via importlib.resources.
+
+Per-surface dogfood files (Claude Code, Cursor, Codex) and their containment
+tests land in PR-B2 alongside ``nauro adopt`` and the surface materialization
+handlers — there's no point committing surface-discoverable skill files until
+the ``nauro adopt`` command they reference exists.
+"""
+
+from __future__ import annotations
+
+from nauro.skills import load_adopt_body, load_session_body
+
+
+def test_load_adopt_body_returns_canonical_bytes():
+    body = load_adopt_body()
+    assert body.endswith("\n")
+    assert 1000 < len(body) < 20000
+    # Anchor on key step markers — catches accidental empty / corrupted body.
+    assert "Step 1 — Detect repo root" in body
+    assert "Step 5a — Clear decisions" in body
+    assert "Step 10 — Summary" in body
+
+
+def test_load_session_body_returns_canonical_bytes():
+    body = load_session_body()
+    assert body.endswith("\n")
+    assert 500 < len(body) < 5000
+    assert "call get_context" in body
+    assert "call check_decision" in body
+    assert "call update_state" in body


### PR DESCRIPTION
## Why
D126 (recorded this session) ships the CLI side of the skill-driven adopt flow from D125: `nauro adopt` needs MCP wired across all agent surfaces (not just Claude Code) and a canonical skill body that downstream commands can render into per-surface files. This PR is the foundation; PR-B2 layers the `nauro adopt` command on top.

## Approach
Extend `setup_app` Typer sub-app with `cursor` and `codex` siblings to the existing `claude-code` command — additive, no rename, no deprecation. Surface handlers (`_configure_cursor_for_repo`, `_configure_codex`) are extracted as standalone functions so PR-B2's `nauro adopt` can call them in-process. The canonical skill bodies (`adopt_body.md`, `session_body.md`) ship as Python package data with `load_*_body()` loaders.

## What changed
- `packages/nauro/src/nauro/cli/commands/setup.py`: +143 lines — `setup cursor`, `setup codex`, plus their helper functions.
- `packages/nauro/src/nauro/skills/`: new package — `__init__.py` with `load_adopt_body()` / `load_session_body()` via `importlib.resources`, `adopt_body.md` (D125 bootstrap, 10 steps), `session_body.md` (D75 session-time guidance).
- `pyproject.toml`: adds `tomli-w` (+ `tomli` 3.10 fallback) for Codex config writing.
- 12 new tests across `test_skills_drift.py` and `test_setup_extended.py`.

## What to review
- **No surface-discoverable skill files in this PR.** The skill bodies reference `nauro adopt`, which lands in PR-B2. Committing `.claude/skills/`, `.cursor/rules/`, `.agents/skills/` dogfood files here would point any agent running on the nauro repo at a missing command. Both dogfood and materialization (writing skill files into user-global surface dirs at `nauro adopt` time) ship in PR-B2.
- **`setup all` is intentionally deferred to PR-B2.** Shipping it in PR-B1 would mean `setup all` wires MCP but installs no skills.
- **Cursor MCP path is per-project** (`<repo>/.cursor/mcp.json`) — Cursor user-global "Rules for AI" live in the IDE Settings UI, not a file. Documented as a comment in `setup.py` near the Cursor handler.
- **Codex TOML round-trip**: tests assert other `[mcp_servers.<name>]` entries are preserved when adding/removing nauro. Worth a second look at the merge logic in `_configure_codex`.

## What's deferred
- `nauro adopt` CLI command — PR-B2.
- `setup all` aggregator + skill materialization to user-global dirs — PR-B2.
- Surface dogfood files + per-surface drift tests — PR-B2.
- AGENTS.md `## Skills` preservation extension — PR-B2.
- `init.py:74-101` latent bug (followup tracking issue still to open).

## Test plan
- [x] `pytest packages/nauro/tests/test_skills_drift.py packages/nauro/tests/test_setup_extended.py -x -q` (12 passed)
- [x] `pytest packages/nauro/tests/ -x -q -m "not integration"` (751 passed)
- [x] `pytest packages/nauro-core/tests/ -x -q` (238 passed)
- [x] `ruff check packages/` (clean)
- [x] `ruff format --check packages/` (clean)
- [ ] Manual: `nauro setup cursor` against a registered project, verify `<repo>/.cursor/mcp.json` has nauro entry. `nauro setup codex` writes `~/.codex/config.toml`. `nauro setup codex --remove` clears it.