### PR TITLE
fix(init): --add-repo against same-name project also writes per-repo config

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/init.py
+++ b/packages/nauro/src/nauro/cli/commands/init.py
@@ -93,6 +93,17 @@ def init(
             added = []
             for rp in repo_paths:
                 add_repo_v2(pid, rp)
+                # Per-repo config is the source of truth for "is this repo
+                # adopted?" (D111). The cloud-mode branch is rejected above,
+                # so all surviving entries here are local-mode.
+                save_repo_config(
+                    rp,
+                    {
+                        "mode": REPO_CONFIG_MODE_LOCAL,
+                        "id": pid,
+                        "name": name,
+                    },
+                )
                 added.append(rp.resolve())
             typer.echo(f"Updated project '{name}'")
             typer.echo(f"  Store: {store_path}")

--- a/packages/nauro/tests/test_registry.py
+++ b/packages/nauro/tests/test_registry.py
@@ -271,6 +271,33 @@ def test_init_cli_add_repo_to_existing(tmp_path, monkeypatch):
     assert pid in raw["projects"]
 
 
+def test_init_add_repo_to_existing_writes_per_repo_config(tmp_path, monkeypatch):
+    """Regression: `--add-repo` against same-name project must write `.nauro/config.json`.
+
+    Per D111 the per-repo config is the source of truth for "is this repo
+    adopted?". Without it, downstream guards (``nauro adopt`` already-adopted
+    check, the /nauro-adopt skill's Step 2) fail to detect the linkage.
+    """
+    _patch_home(monkeypatch, tmp_path)
+    repo1 = tmp_path / "repo1"
+    repo2 = tmp_path / "repo2"
+    repo1.mkdir()
+    repo2.mkdir()
+    runner.invoke(app, ["init", "proj", "--add-repo", str(repo1)])
+    runner.invoke(app, ["init", "proj", "--add-repo", str(repo2)])
+
+    # Both repos have a per-repo config pointing at the same project_id.
+    cfg1 = load_repo_config(repo1)
+    cfg2 = load_repo_config(repo2)
+    assert cfg1["name"] == "proj"
+    assert cfg2["name"] == "proj"
+    assert cfg1["mode"] == "local"
+    assert cfg2["mode"] == "local"
+    assert cfg1["id"] == cfg2["id"]
+    pid, _ = _v2_entry_for_name("proj")
+    assert cfg2["id"] == pid
+
+
 def test_remove_repo(tmp_path, monkeypatch):
     _patch_home(monkeypatch, tmp_path)
     repo = tmp_path / "repo"


### PR DESCRIPTION
## Why
When `nauro init <name> --add-repo <repo>` matched an existing v2 project of the same name, the `--add-repo` branch in `init.py:74-101` called `add_repo_v2` to extend the registry but never called `save_repo_config` — leaving `<repo>/.nauro/config.json` unwritten. Per D111 the per-repo config is the source of truth for "is this repo adopted?", so downstream guards (`nauro adopt`'s already-adopted check, the `/nauro-adopt` skill's Step 2) failed to detect the linkage even though the registry knew about it.

This was tracked as a deferred followup in PR #28's "What's deferred" / D128.

## Approach
Write `save_repo_config` alongside `add_repo_v2` in the existing-name branch, mirroring what the new-project branches already do. The cloud-mode case is rejected earlier in the same branch (`init.py:85-91`), so every surviving entry is local-mode and the per-repo config shape is fully determined.

## What changed
- `packages/nauro/src/nauro/cli/commands/init.py`: 11 lines added — `save_repo_config(rp, {mode: local, id: pid, name: name})` after each `add_repo_v2(pid, rp)` in the `--add-repo`-matches-existing branch.
- `packages/nauro/tests/test_registry.py`: 27-line regression test (`test_init_add_repo_to_existing_writes_per_repo_config`) — runs `nauro init proj --add-repo repo1` then `nauro init proj --add-repo repo2`, asserts both repos have a `.nauro/config.json` pointing at the same project_id as the v2 registry entry.

## What to review
- The fix only writes config for the local-mode path because cloud-mode is rejected at the start of the same branch. If that early-rejection is ever relaxed, the new `save_repo_config` call would need to handle cloud-mode shape too.
- The existing `test_init_cli_add_repo_to_existing` test stays green — it only asserted registry shape, not per-repo config. The new test specifically covers the per-repo config gap.

## What's deferred
- Nothing. This closes the followup deferred from PR #28.

## Test plan
- [x] `pytest packages/nauro/tests/test_registry.py -x -q` (23 passed)
- [x] `pytest packages/nauro/tests/ packages/nauro-core/tests/ -x -q -m "not integration"` (1022 passed)
- [x] `ruff check packages/` (clean)
- [x] `ruff format --check packages/` (clean)

Closes #29.

D111, D128.