### PR TITLE
fix(adopt): close 5 dogfood findings — Claude Code wiring + skill project_id

### DIFF
--- a/.agents/skills/nauro-adopt/SKILL.md
+++ b/.agents/skills/nauro-adopt/SKILL.md
@@ -15,9 +15,11 @@ The agent runs `git rev-parse --show-toplevel` from the current working director
 
 The agent reads `<repo>/.nauro/config.json`. If the file is missing: abort with "This repo is not adopted yet. Run 'nauro adopt' from the repo root, restart this agent, then invoke /nauro-adopt again." If the file exists and parses as JSON: extract `id` and `name` and use these as the project handle for subsequent calls.
 
+Pass `id` as the `project_id` argument on every subsequent MCP call (`propose_decision`, `confirm_decision`, `update_state`, `flag_question`, `get_context`, `list_decisions`). Do not omit `project_id` even though the tool descriptions say it's optional — auto-resolve routes to the user's default project, which is **not** the project this skill is seeding when both local-mode and cloud-mode projects coexist.
+
 ## Step 3 — Read source files
 
-The agent reads the first match found per category. Files larger than 256KB are flagged to the user before reading.
+The agent reads the first match found per category. Files larger than 256KB are flagged to the user before reading. If the README category yields no match, surface "No README found; reading manifest only." to the user once and continue — manifest-only repos are still adoptable.
 
 - **README**: `README.md`, `README.rst`, `README` (first found)
 - **Manifest**: `pyproject.toml`, `package.json`, `Cargo.toml`, `go.mod`, `Gemfile`, `pom.xml`, `build.gradle`, `composer.json`, `requirements*.txt`

--- a/.claude/skills/nauro-adopt/SKILL.md
+++ b/.claude/skills/nauro-adopt/SKILL.md
@@ -15,9 +15,11 @@ The agent runs `git rev-parse --show-toplevel` from the current working director
 
 The agent reads `<repo>/.nauro/config.json`. If the file is missing: abort with "This repo is not adopted yet. Run 'nauro adopt' from the repo root, restart this agent, then invoke /nauro-adopt again." If the file exists and parses as JSON: extract `id` and `name` and use these as the project handle for subsequent calls.
 
+Pass `id` as the `project_id` argument on every subsequent MCP call (`propose_decision`, `confirm_decision`, `update_state`, `flag_question`, `get_context`, `list_decisions`). Do not omit `project_id` even though the tool descriptions say it's optional — auto-resolve routes to the user's default project, which is **not** the project this skill is seeding when both local-mode and cloud-mode projects coexist.
+
 ## Step 3 — Read source files
 
-The agent reads the first match found per category. Files larger than 256KB are flagged to the user before reading.
+The agent reads the first match found per category. Files larger than 256KB are flagged to the user before reading. If the README category yields no match, surface "No README found; reading manifest only." to the user once and continue — manifest-only repos are still adoptable.
 
 - **README**: `README.md`, `README.rst`, `README` (first found)
 - **Manifest**: `pyproject.toml`, `package.json`, `Cargo.toml`, `go.mod`, `Gemfile`, `pom.xml`, `build.gradle`, `composer.json`, `requirements*.txt`

--- a/.cursor/rules/nauro-adopt.mdc
+++ b/.cursor/rules/nauro-adopt.mdc
@@ -15,9 +15,11 @@ The agent runs `git rev-parse --show-toplevel` from the current working director
 
 The agent reads `<repo>/.nauro/config.json`. If the file is missing: abort with "This repo is not adopted yet. Run 'nauro adopt' from the repo root, restart this agent, then invoke /nauro-adopt again." If the file exists and parses as JSON: extract `id` and `name` and use these as the project handle for subsequent calls.
 
+Pass `id` as the `project_id` argument on every subsequent MCP call (`propose_decision`, `confirm_decision`, `update_state`, `flag_question`, `get_context`, `list_decisions`). Do not omit `project_id` even though the tool descriptions say it's optional — auto-resolve routes to the user's default project, which is **not** the project this skill is seeding when both local-mode and cloud-mode projects coexist.
+
 ## Step 3 — Read source files
 
-The agent reads the first match found per category. Files larger than 256KB are flagged to the user before reading.
+The agent reads the first match found per category. Files larger than 256KB are flagged to the user before reading. If the README category yields no match, surface "No README found; reading manifest only." to the user once and continue — manifest-only repos are still adoptable.
 
 - **README**: `README.md`, `README.rst`, `README` (first found)
 - **Manifest**: `pyproject.toml`, `package.json`, `Cargo.toml`, `go.mod`, `Gemfile`, `pom.xml`, `build.gradle`, `composer.json`, `requirements*.txt`

--- a/docs/adopt-prompt.md
+++ b/docs/adopt-prompt.md
@@ -31,9 +31,11 @@ The agent runs `git rev-parse --show-toplevel` from the current working director
 
 The agent reads `<repo>/.nauro/config.json`. If the file is missing: abort with "This repo is not adopted yet. Run 'nauro adopt' from the repo root, restart this agent, then invoke /nauro-adopt again." If the file exists and parses as JSON: extract `id` and `name` and use these as the project handle for subsequent calls.
 
+Pass `id` as the `project_id` argument on every subsequent MCP call (`propose_decision`, `confirm_decision`, `update_state`, `flag_question`, `get_context`, `list_decisions`). Do not omit `project_id` even though the tool descriptions say it's optional — auto-resolve routes to the user's default project, which is **not** the project this skill is seeding when both local-mode and cloud-mode projects coexist.
+
 ## Step 3 — Read source files
 
-The agent reads the first match found per category. Files larger than 256KB are flagged to the user before reading.
+The agent reads the first match found per category. Files larger than 256KB are flagged to the user before reading. If the README category yields no match, surface "No README found; reading manifest only." to the user once and continue — manifest-only repos are still adoptable.
 
 - **README**: `README.md`, `README.rst`, `README` (first found)
 - **Manifest**: `pyproject.toml`, `package.json`, `Cargo.toml`, `go.mod`, `Gemfile`, `pom.xml`, `build.gradle`, `composer.json`, `requirements*.txt`

--- a/packages/nauro/src/nauro/cli/commands/setup.py
+++ b/packages/nauro/src/nauro/cli/commands/setup.py
@@ -88,6 +88,8 @@ def _configure_mcp(repo_path: Path, *, remove: bool = False) -> str:
     Returns a one-line status string (indented for ``setup_all_surfaces``).
     """
     if shutil.which("claude") is None:
+        if remove:
+            return "Claude Code CLI not found on PATH; nothing to remove."
         return (
             "Claude Code CLI not found on PATH; skipping Claude Code wiring "
             "(run 'nauro setup claude-code' after installing it)."

--- a/packages/nauro/src/nauro/cli/commands/setup.py
+++ b/packages/nauro/src/nauro/cli/commands/setup.py
@@ -1,7 +1,8 @@
 """nauro setup — Configure tool integrations.
 
 Subcommands:
-  nauro setup claude-code  — register MCP server + regenerate AGENTS.md
+  nauro setup claude-code  — register MCP server in <repo>/.mcp.json (project scope)
+                             for each of the project's repos
   nauro setup cursor       — register MCP server in <repo>/.cursor/mcp.json
                              for each of the project's repos
   nauro setup codex        — register MCP server in ~/.codex/config.toml
@@ -10,6 +11,8 @@ Subcommands:
 from __future__ import annotations
 
 import json
+import shutil
+import subprocess
 import sys
 from pathlib import Path
 
@@ -63,71 +66,71 @@ def _remove_claude_md(repo_path: Path) -> str | None:
         return f"  {repo_path}: removed legacy Nauro block from {CLAUDE_MD}"
 
 
-def _find_claude_config_path() -> Path | None:
-    """Find the Claude Code MCP config file path."""
-    candidates = [
-        Path.home() / ".claude" / "claude_desktop_config.json",
-        Path.home() / ".config" / "claude" / "claude_desktop_config.json",
-    ]
-    for candidate in candidates:
-        if candidate.exists():
-            return candidate
-    # If neither exists, prefer the first path if its parent exists
-    for candidate in candidates:
-        if candidate.parent.exists():
-            return candidate
-    return None
-
-
 def _find_nauro_command() -> str:
     """Find the full path to the nauro binary for the MCP config."""
-    import shutil
-
     path = shutil.which("nauro")
     return path if path else "nauro"
 
 
-def _configure_mcp(remove: bool = False) -> str:
-    """Add or remove the Nauro MCP entry in Claude Code's config.
+# claude mcp remove emits these on a missing entry — treat as graceful no-op.
+_CLAUDE_REMOVE_NOT_FOUND_MARKERS = ("no mcp server", "not found", "does not exist")
 
-    Uses stdio transport — Claude Code spawns the server process directly.
-    Returns a status string.
+
+def _configure_mcp(repo_path: Path, *, remove: bool = False) -> str:
+    """Add or remove the Nauro MCP entry in Claude Code via the ``claude`` CLI.
+
+    Uses ``--scope project`` so the entry is written to ``<repo>/.mcp.json``,
+    making it shareable with collaborators via git — mirroring the Cursor
+    surface model. The shell-out is intentional: Claude Code's per-project
+    config layout has changed before; ``claude mcp add`` is the supported
+    entry point.
+
+    Returns a one-line status string (indented for ``setup_all_surfaces``).
     """
-    config_path = _find_claude_config_path()
-    nauro_cmd = _find_nauro_command()
-    nauro_entry = {"command": nauro_cmd, "args": ["serve", "--stdio"]}
-
-    if config_path is None:
-        if remove:
-            return "MCP config: no Claude Code config found, nothing to remove"
-        snippet = json.dumps({"mcpServers": {"nauro": nauro_entry}}, indent=2)
+    if shutil.which("claude") is None:
         return (
-            "MCP config: could not find Claude Code config file.\n"
-            "  Add the following to your Claude Code MCP config:\n"
-            f"  {snippet}"
+            "Claude Code CLI not found on PATH; skipping Claude Code wiring "
+            "(run 'nauro setup claude-code' after installing it)."
         )
 
-    if config_path.exists():
-        config = json.loads(config_path.read_text())
-    else:
-        config = {}
+    nauro_cmd = _find_nauro_command()
 
     if remove:
-        servers = config.get("mcpServers", {})
-        if "nauro" in servers:
-            del servers["nauro"]
-            if not servers:
-                del config["mcpServers"]
-            config_path.write_text(json.dumps(config, indent=2) + "\n")
-            return f"MCP config: removed nauro from {config_path}"
-        return f"MCP config: no nauro entry found in {config_path}"
+        result = subprocess.run(
+            ["claude", "mcp", "remove", "nauro"],
+            cwd=repo_path,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            return f"  {repo_path}: removed nauro from .mcp.json"
+        stderr_lower = (result.stderr or "").lower()
+        if any(marker in stderr_lower for marker in _CLAUDE_REMOVE_NOT_FOUND_MARKERS):
+            return f"  {repo_path}: no nauro entry to remove"
+        return f"  {repo_path}: claude mcp remove failed — {(result.stderr or '').strip()}"
 
-    if "mcpServers" not in config:
-        config["mcpServers"] = {}
-    config["mcpServers"]["nauro"] = nauro_entry
-    config_path.parent.mkdir(parents=True, exist_ok=True)
-    config_path.write_text(json.dumps(config, indent=2) + "\n")
-    return f"MCP config: wrote nauro server to {config_path}"
+    result = subprocess.run(
+        [
+            "claude",
+            "mcp",
+            "add",
+            "--scope",
+            "project",
+            "nauro",
+            "--",
+            nauro_cmd,
+            "serve",
+            "--stdio",
+        ],
+        cwd=repo_path,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0:
+        return f"  {repo_path}: wrote nauro to .mcp.json"
+    return f"  {repo_path}: claude mcp add failed — {(result.stderr or '').strip()}"
 
 
 @setup_app.command(name="claude-code")
@@ -158,20 +161,22 @@ def claude_code(
     # Clean up legacy CLAUDE.md blocks (behavioral guidance now delivered
     # via MCP server instructions, so the injected block is no longer needed).
     legacy_results = []
+    mcp_results = []
     for repo_str in entry["repo_paths"]:
         repo_path = Path(repo_str)
         if not repo_path.is_dir():
+            mcp_results.append(f"  {repo_path}: repo path missing, skipped")
             continue
-        result = _remove_claude_md(repo_path)
-        if result:
-            legacy_results.append(result)
-
-    mcp_result = _configure_mcp(remove=remove)
+        legacy = _remove_claude_md(repo_path)
+        if legacy:
+            legacy_results.append(legacy)
+        mcp_results.append(_configure_mcp(repo_path, remove=remove))
 
     # Print summary
     action = "Removed" if remove else "Configured"
     typer.echo(f"{action} Nauro for project '{project_name}':\n")
-    typer.echo(mcp_result)
+    for line in mcp_results:
+        typer.echo(line)
 
     if legacy_results:
         typer.echo("\nLegacy cleanup:")
@@ -424,11 +429,15 @@ def setup_all_surfaces(project_repos: list[Path], *, remove: bool = False) -> li
     """
     lines: list[str] = []
 
-    # Claude Code (MCP global + skills global)
-    try:
-        lines.append(_configure_mcp(remove=remove))
-    except Exception as exc:
-        lines.append(f"Claude Code MCP: error — {exc}")
+    # Claude Code (MCP per-repo via `claude mcp add --scope project` + skills global)
+    for repo in project_repos:
+        if not repo.is_dir():
+            lines.append(f"  {repo}: repo path missing, skipped")
+            continue
+        try:
+            lines.append(_configure_mcp(repo, remove=remove))
+        except Exception as exc:
+            lines.append(f"Claude Code MCP ({repo}): error — {exc}")
     try:
         lines.extend(materialize_skills_claude_code(remove=remove))
     except Exception as exc:
@@ -437,7 +446,6 @@ def setup_all_surfaces(project_repos: list[Path], *, remove: bool = False) -> li
     # Cursor (MCP per-repo + skills per-repo)
     for repo in project_repos:
         if not repo.is_dir():
-            lines.append(f"  {repo}: repo path missing, skipped")
             continue
         try:
             lines.append(_configure_cursor_for_repo(repo, remove=remove))

--- a/packages/nauro/src/nauro/cli/commands/setup.py
+++ b/packages/nauro/src/nauro/cli/commands/setup.py
@@ -72,10 +72,6 @@ def _find_nauro_command() -> str:
     return path if path else "nauro"
 
 
-# claude mcp remove emits these on a missing entry — treat as graceful no-op.
-_CLAUDE_REMOVE_NOT_FOUND_MARKERS = ("no mcp server", "not found", "does not exist")
-
-
 def _configure_mcp(repo_path: Path, *, remove: bool = False) -> str:
     """Add or remove the Nauro MCP entry in Claude Code via the ``claude`` CLI.
 
@@ -98,6 +94,19 @@ def _configure_mcp(repo_path: Path, *, remove: bool = False) -> str:
     nauro_cmd = _find_nauro_command()
 
     if remove:
+        # Pre-check the file rather than parse `claude mcp remove` stderr —
+        # stderr wording is unstable across Claude Code versions, but the
+        # project-scope `.mcp.json` shape is the documented contract.
+        mcp_json = repo_path / ".mcp.json"
+        if not mcp_json.is_file():
+            return f"  {repo_path}: no nauro entry to remove"
+        try:
+            config = json.loads(mcp_json.read_text())
+        except json.JSONDecodeError as exc:
+            return f"  {repo_path}: could not parse .mcp.json — {exc}"
+        if "nauro" not in config.get("mcpServers", {}):
+            return f"  {repo_path}: no nauro entry to remove"
+
         result = subprocess.run(
             ["claude", "mcp", "remove", "nauro"],
             cwd=repo_path,
@@ -107,9 +116,6 @@ def _configure_mcp(repo_path: Path, *, remove: bool = False) -> str:
         )
         if result.returncode == 0:
             return f"  {repo_path}: removed nauro from .mcp.json"
-        stderr_lower = (result.stderr or "").lower()
-        if any(marker in stderr_lower for marker in _CLAUDE_REMOVE_NOT_FOUND_MARKERS):
-            return f"  {repo_path}: no nauro entry to remove"
         return f"  {repo_path}: claude mcp remove failed — {(result.stderr or '').strip()}"
 
     result = subprocess.run(

--- a/packages/nauro/src/nauro/constants.py
+++ b/packages/nauro/src/nauro/constants.py
@@ -43,11 +43,21 @@ REGISTRY_FILENAME = "registry.json"
 CONFIG_FILENAME = "config.json"
 PROJECTS_DIR = "projects"
 
-# Files checked for unfilled bracket prompts during validation
-VALIDATED_STORE_FILES = (PROJECT_MD, STATE_MD, STACK_MD)
+# Files checked for unfilled bracket prompts during validation.
+# Includes both state filenames so validation works on fresh stores
+# (state_current.md only) and pre-D94 stores (state.md until first update_state
+# migrates them). Missing files are skipped by the validator, so listing both
+# is safe.
+VALIDATED_STORE_FILES = (PROJECT_MD, STATE_CURRENT_FILENAME, STATE_LEGACY_FILENAME, STACK_MD)
 
 # Files counted toward L0 token estimate
-TOKEN_ESTIMATE_FILES = (PROJECT_MD, STATE_MD, STACK_MD, OPEN_QUESTIONS_MD)
+TOKEN_ESTIMATE_FILES = (
+    PROJECT_MD,
+    STATE_CURRENT_FILENAME,
+    STATE_LEGACY_FILENAME,
+    STACK_MD,
+    OPEN_QUESTIONS_MD,
+)
 
 # ── AGENTS.md ──
 AGENTS_MD = "AGENTS.md"

--- a/packages/nauro/src/nauro/skills/adopt_body.md
+++ b/packages/nauro/src/nauro/skills/adopt_body.md
@@ -10,9 +10,11 @@ The agent runs `git rev-parse --show-toplevel` from the current working director
 
 The agent reads `<repo>/.nauro/config.json`. If the file is missing: abort with "This repo is not adopted yet. Run 'nauro adopt' from the repo root, restart this agent, then invoke /nauro-adopt again." If the file exists and parses as JSON: extract `id` and `name` and use these as the project handle for subsequent calls.
 
+Pass `id` as the `project_id` argument on every subsequent MCP call (`propose_decision`, `confirm_decision`, `update_state`, `flag_question`, `get_context`, `list_decisions`). Do not omit `project_id` even though the tool descriptions say it's optional — auto-resolve routes to the user's default project, which is **not** the project this skill is seeding when both local-mode and cloud-mode projects coexist.
+
 ## Step 3 — Read source files
 
-The agent reads the first match found per category. Files larger than 256KB are flagged to the user before reading.
+The agent reads the first match found per category. Files larger than 256KB are flagged to the user before reading. If the README category yields no match, surface "No README found; reading manifest only." to the user once and continue — manifest-only repos are still adoptable.
 
 - **README**: `README.md`, `README.rst`, `README` (first found)
 - **Manifest**: `pyproject.toml`, `package.json`, `Cargo.toml`, `go.mod`, `Gemfile`, `pom.xml`, `build.gradle`, `composer.json`, `requirements*.txt`

--- a/packages/nauro/src/nauro/store/validator.py
+++ b/packages/nauro/src/nauro/store/validator.py
@@ -83,7 +83,8 @@ def validate_store(store_path: Path) -> list[str]:
                 age = datetime.now(timezone.utc) - synced_date
                 if age.days > STALE_SYNC_DAYS:
                     warnings.append(
-                        f"state.md: Last synced {age.days} days ago — consider running nauro sync"
+                        f"{state_path.name}: Last synced {age.days} days ago — "
+                        "consider running nauro sync"
                     )
             except ValueError:
                 pass

--- a/packages/nauro/src/nauro/store/validator.py
+++ b/packages/nauro/src/nauro/store/validator.py
@@ -12,8 +12,9 @@ from nauro.constants import (
     DECISIONS_DIR,
     L0_TOKEN_LIMIT,
     STALE_SYNC_DAYS,
+    STATE_CURRENT_FILENAME,
     STATE_FIELD_LAST_SYNCED_ITALIC,
-    STATE_MD,
+    STATE_LEGACY_FILENAME,
     VALIDATED_STORE_FILES,
 )
 
@@ -59,8 +60,10 @@ def validate_store(store_path: Path) -> list[str]:
                 f"{filename}: {len(unfilled)} unfilled prompt(s) remaining — e.g. [{unfilled[0]}]"
             )
 
-    # Check Last synced staleness
-    state_path = store_path / STATE_MD
+    # Check Last synced staleness — prefer state_current.md, fall back to legacy state.md.
+    state_path = store_path / STATE_CURRENT_FILENAME
+    if not state_path.exists():
+        state_path = store_path / STATE_LEGACY_FILENAME
     if state_path.exists():
         content = state_path.read_text()
         sync_match = re.search(STATE_FIELD_LAST_SYNCED_ITALIC, content)

--- a/packages/nauro/src/nauro/templates/scaffolds.py
+++ b/packages/nauro/src/nauro/templates/scaffolds.py
@@ -45,7 +45,7 @@ is useful. "Users" is not.]
 - [Technical constraints, e.g. "Must run offline — no cloud dependency in v1"]
 """
 
-STATE_MD = """\
+STATE_CURRENT_MD = """\
 # State
 
 ## Current
@@ -120,7 +120,7 @@ def get_scaffolds() -> dict[str, str]:
     """
     return {
         C.PROJECT_MD: PROJECT_MD,
-        C.STATE_MD: STATE_MD,
+        C.STATE_CURRENT_FILENAME: STATE_CURRENT_MD,
         C.STACK_MD: STACK_MD,
         C.OPEN_QUESTIONS_MD: OPEN_QUESTIONS_MD,
     }
@@ -129,7 +129,7 @@ def get_scaffolds() -> dict[str, str]:
 def scaffold_project_store(project_name: str, store_path: Path) -> None:
     """Write all template files to the project store directory.
 
-    Creates: project.md, state.md, stack.md, open-questions.md,
+    Creates: project.md, state_current.md, stack.md, open-questions.md,
     decisions/ directory (with 001-initial-setup.md), snapshots/ directory.
 
     Args:
@@ -143,7 +143,7 @@ def scaffold_project_store(project_name: str, store_path: Path) -> None:
     created_at = datetime.now(timezone.utc).strftime("%Y-%m-%d")
 
     (store_path / C.PROJECT_MD).write_text(render_scaffold(PROJECT_MD, project_name=project_name))
-    (store_path / C.STATE_MD).write_text(render_scaffold(STATE_MD))
+    (store_path / C.STATE_CURRENT_FILENAME).write_text(render_scaffold(STATE_CURRENT_MD))
     (store_path / C.STACK_MD).write_text(render_scaffold(STACK_MD))
     (store_path / C.OPEN_QUESTIONS_MD).write_text(render_scaffold(OPEN_QUESTIONS_MD))
 

--- a/packages/nauro/tests/test_import.py
+++ b/packages/nauro/tests/test_import.py
@@ -121,8 +121,8 @@ def test_import_partial_memory_bank(store: Path, partial_memory_bank: Path):
     assert "## Imported from Memory Bank" in project_content
     assert "minimal project" in project_content
 
-    # state.md should NOT have import header (no activeContext.md)
-    state_content = (store / "state.md").read_text()
+    # state_current.md should NOT have import header (no activeContext.md)
+    state_content = (store / "state_current.md").read_text()
     assert "## Imported from Memory Bank" not in state_content
 
 
@@ -287,19 +287,22 @@ def _mb_with(tmp_path: Path, name: str, **files: str) -> Path:
 
 
 def test_active_context_lands_in_state_current_not_legacy(store: Path, tmp_path: Path):
+    """Pre-D94 stores may carry a legacy state.md alongside state_current.md.
+    Verify import writes only to state_current.md, never the legacy file."""
+    legacy_marker = "# Legacy state — should not be touched\n"
+    (store / "state.md").write_text(legacy_marker)
     mb = _mb_with(
         tmp_path,
         ".context_active_only",
         **{"activeContext.md": "# Active Context\n\nWiring up Stripe checkout.\n"},
     )
-    legacy_before = (store / "state.md").read_text()
 
     _import_memory_bank(mb, store)
 
     state_current = (store / "state_current.md").read_text()
     assert "Wiring up Stripe checkout." in state_current
-    # Legacy state.md is the scaffold; never gets the imported activeContext body.
-    assert (store / "state.md").read_text() == legacy_before
+    # Legacy state.md remains untouched.
+    assert (store / "state.md").read_text() == legacy_marker
     assert "Wiring up Stripe checkout." not in (store / "state.md").read_text()
 
 
@@ -401,20 +404,20 @@ def test_active_only_no_progress(store: Path, tmp_path: Path):
     assert "## Recently completed" not in state_current
 
 
-def test_neither_active_nor_progress_no_state_files_created(store: Path, tmp_path: Path):
-    """Only projectBrief — no update_state call, no state_current.md created.
+def test_neither_active_nor_progress_no_state_update(store: Path, tmp_path: Path):
+    """Only projectBrief — no update_state call, scaffolded state_current.md untouched.
 
-    Scaffolds today create legacy state.md only (no state_current.md). When
-    neither activeContext nor progress is imported, update_state is skipped
-    entirely, so state_current.md should never come into existence.
+    When neither activeContext nor progress is imported, update_state is
+    skipped entirely; the placeholder state_current.md from scaffold_project_store
+    must remain unchanged.
     """
-    legacy_before = (store / "state.md").read_text()
+    state_before = (store / "state_current.md").read_text()
     mb = _mb_with(tmp_path, ".context_brief_only")  # only projectBrief.md
 
     _import_memory_bank(mb, store)
 
-    assert not (store / "state_current.md").exists()
-    assert (store / "state.md").read_text() == legacy_before
+    assert (store / "state_current.md").read_text() == state_before
+    assert not (store / "state.md").exists()
 
 
 def test_import_progress_returns_parsed_items():

--- a/packages/nauro/tests/test_log_diff.py
+++ b/packages/nauro/tests/test_log_diff.py
@@ -253,7 +253,7 @@ class TestLogCommand:
         result = runner.invoke(app, ["log", "--full", "--limit", "1"])
         assert result.exit_code == 0
         assert "project.md" in result.output
-        assert "state.md" in result.output
+        assert "state_current.md" in result.output
         assert "decisions/" in result.output
 
     def test_log_no_snapshots(self, tmp_path: Path, monkeypatch):

--- a/packages/nauro/tests/test_registry.py
+++ b/packages/nauro/tests/test_registry.py
@@ -172,7 +172,8 @@ def test_scaffold_creates_all_files(tmp_path):
     store = tmp_path / "store"
     scaffold_project_store("testproj", store)
     assert (store / "project.md").exists()
-    assert (store / "state.md").exists()
+    assert (store / "state_current.md").exists()
+    assert not (store / "state.md").exists()
     assert (store / "stack.md").exists()
     assert (store / "open-questions.md").exists()
     assert (store / "decisions").is_dir()

--- a/packages/nauro/tests/test_setup.py
+++ b/packages/nauro/tests/test_setup.py
@@ -1,5 +1,6 @@
 """Tests for nauro setup claude-code command."""
 
+import json
 import subprocess
 from pathlib import Path
 
@@ -77,6 +78,9 @@ class TestMCPConfigShellout:
     def test_remove_path_argv_and_cwd(self, tmp_path: Path, monkeypatch):
         repo = tmp_path / "repo"
         repo.mkdir()
+        # The remove path now pre-checks <repo>/.mcp.json and only invokes
+        # `claude mcp remove` when the nauro entry is actually present.
+        (repo / ".mcp.json").write_text(json.dumps({"mcpServers": {"nauro": {}}}))
         calls = _mock_claude_cli(monkeypatch)
 
         result = _configure_mcp(repo, remove=True)
@@ -123,18 +127,40 @@ class TestMCPConfigShellout:
         assert "some claude error" in result
         assert "claude mcp add failed" in result
 
-    def test_remove_graceful_when_no_entry(self, tmp_path: Path, monkeypatch):
-        """`claude mcp remove` against a missing entry exits non-zero with a
-        recognizable stderr — the wrapper turns it into a no-op message."""
+    def test_remove_skips_when_no_mcp_json(self, tmp_path: Path, monkeypatch):
+        """No `.mcp.json` at all → no-op without invoking the CLI."""
         repo = tmp_path / "repo"
         repo.mkdir()
-        _mock_claude_cli(monkeypatch, returncode=1, stderr="No MCP server named 'nauro'")
+        calls = _mock_claude_cli(monkeypatch)
 
         result = _configure_mcp(repo, remove=True)
 
+        assert calls == []
         assert "no nauro entry to remove" in result
-        # And the failure-path message is NOT used.
-        assert "claude mcp remove failed" not in result
+
+    def test_remove_skips_when_nauro_absent_from_mcp_json(self, tmp_path: Path, monkeypatch):
+        """`.mcp.json` exists but has no nauro entry → no-op without invoking CLI."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / ".mcp.json").write_text(json.dumps({"mcpServers": {"other": {}}}))
+        calls = _mock_claude_cli(monkeypatch)
+
+        result = _configure_mcp(repo, remove=True)
+
+        assert calls == []
+        assert "no nauro entry to remove" in result
+
+    def test_remove_handles_malformed_mcp_json(self, tmp_path: Path, monkeypatch):
+        """Malformed `.mcp.json` surfaces a parse error instead of crashing."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / ".mcp.json").write_text("{not json")
+        calls = _mock_claude_cli(monkeypatch)
+
+        result = _configure_mcp(repo, remove=True)
+
+        assert calls == []
+        assert "could not parse .mcp.json" in result
 
     def test_setup_all_iterates_per_repo(self, tmp_path: Path, monkeypatch):
         """Multi-repo project: `setup all` invokes `claude mcp add` once per

--- a/packages/nauro/tests/test_setup.py
+++ b/packages/nauro/tests/test_setup.py
@@ -1,11 +1,11 @@
 """Tests for nauro setup claude-code command."""
 
-import json
+import subprocess
 from pathlib import Path
 
 from typer.testing import CliRunner
 
-from nauro.cli.commands.setup import CLAUDE_MD_END, CLAUDE_MD_START
+from nauro.cli.commands.setup import CLAUDE_MD_END, CLAUDE_MD_START, _configure_mcp
 from nauro.cli.main import app
 from nauro.store.registry import register_project
 from nauro.templates.scaffolds import scaffold_project_store
@@ -25,83 +25,122 @@ def _setup_project(tmp_path: Path, monkeypatch, repo_paths: list[Path] | None = 
     return repo_paths
 
 
-class TestMCPConfig:
-    def test_mcp_config_merge_preserves_existing(self, tmp_path: Path, monkeypatch):
-        """MCP config merge preserves existing servers."""
-        _setup_project(tmp_path, monkeypatch)
+def _mock_claude_cli(monkeypatch, *, on_path: bool = True, returncode: int = 0, stderr: str = ""):
+    """Mock the `claude` CLI for setup tests.
 
-        # Create pre-existing MCP config with another server
-        claude_dir = tmp_path / "claude_home"
-        claude_dir.mkdir()
-        config_path = claude_dir / "claude_desktop_config.json"
-        config_path.write_text(
-            json.dumps({"mcpServers": {"other-tool": {"url": "http://localhost:9999"}}})
+    Returns a list that captures every (argv, kwargs) call to subprocess.run
+    so individual tests can assert on shape (cwd, scope, etc.).
+    """
+    calls: list[tuple[list[str], dict]] = []
+
+    monkeypatch.setattr(
+        "nauro.cli.commands.setup.shutil.which",
+        lambda cmd: "/usr/local/bin/claude" if (on_path and cmd == "claude") else None,
+    )
+
+    def fake_run(argv, **kwargs):
+        calls.append((list(argv), dict(kwargs)))
+        return subprocess.CompletedProcess(
+            args=argv, returncode=returncode, stdout="", stderr=stderr
         )
 
-        monkeypatch.setattr(
-            "nauro.cli.commands.setup._find_claude_config_path",
-            lambda: config_path,
-        )
+    monkeypatch.setattr("nauro.cli.commands.setup.subprocess.run", fake_run)
+    return calls
 
-        result = runner.invoke(app, ["setup", "claude-code", "--project", "testproj"])
-        assert result.exit_code == 0
 
-        config = json.loads(config_path.read_text())
-        assert "nauro" in config["mcpServers"]
-        assert config["mcpServers"]["nauro"]["args"] == ["serve", "--stdio"]
-        assert "command" in config["mcpServers"]["nauro"]
-        # Existing server preserved
-        assert "other-tool" in config["mcpServers"]
-        assert config["mcpServers"]["other-tool"]["url"] == "http://localhost:9999"
+class TestMCPConfigShellout:
+    """`_configure_mcp` shells out to `claude mcp add/remove` (project scope).
 
-    def test_mcp_config_created_from_scratch(self, tmp_path: Path, monkeypatch):
-        """MCP config created from scratch if missing."""
-        _setup_project(tmp_path, monkeypatch)
+    The original direct-JSON path wrote to `~/.claude/claude_desktop_config.json`
+    (which is Claude *Desktop*); Claude Code reads `~/.claude.json` and per-repo
+    `<repo>/.mcp.json`. These tests lock in the shellout shape so the bug
+    can't regress.
+    """
 
-        config_path = tmp_path / "claude_home" / "claude_desktop_config.json"
-        (tmp_path / "claude_home").mkdir()
+    def test_add_path_argv_and_cwd(self, tmp_path: Path, monkeypatch):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        calls = _mock_claude_cli(monkeypatch)
 
-        monkeypatch.setattr(
-            "nauro.cli.commands.setup._find_claude_config_path",
-            lambda: config_path,
-        )
+        result = _configure_mcp(repo, remove=False)
 
-        result = runner.invoke(app, ["setup", "claude-code", "--project", "testproj"])
-        assert result.exit_code == 0
-        assert config_path.exists()
+        assert len(calls) == 1
+        argv, kwargs = calls[0]
+        assert argv[:6] == ["claude", "mcp", "add", "--scope", "project", "nauro"]
+        assert argv[6] == "--"
+        # argv[7] is the resolved nauro binary path
+        assert argv[8:] == ["serve", "--stdio"]
+        assert kwargs.get("cwd") == repo
+        assert kwargs.get("check") is False
+        assert "wrote nauro to .mcp.json" in result
 
-        config = json.loads(config_path.read_text())
-        assert config["mcpServers"]["nauro"]["args"] == ["serve", "--stdio"]
-        assert "command" in config["mcpServers"]["nauro"]
+    def test_remove_path_argv_and_cwd(self, tmp_path: Path, monkeypatch):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        calls = _mock_claude_cli(monkeypatch)
 
-    def test_remove_mcp_entry(self, tmp_path: Path, monkeypatch):
-        """--remove removes the nauro MCP entry from config."""
-        _setup_project(tmp_path, monkeypatch)
+        result = _configure_mcp(repo, remove=True)
 
-        config_path = tmp_path / "claude_home" / "claude_desktop_config.json"
-        (tmp_path / "claude_home").mkdir()
-        config_path.write_text(
-            json.dumps(
-                {
-                    "mcpServers": {
-                        "nauro": {"url": "http://127.0.0.1:7432"},
-                        "other": {"url": "http://localhost:8000"},
-                    }
-                }
-            )
-        )
+        assert len(calls) == 1
+        argv, kwargs = calls[0]
+        assert argv == ["claude", "mcp", "remove", "nauro"]
+        assert kwargs.get("cwd") == repo
+        assert "removed nauro from .mcp.json" in result
 
-        monkeypatch.setattr(
-            "nauro.cli.commands.setup._find_claude_config_path",
-            lambda: config_path,
-        )
+    def test_skips_when_claude_not_on_path(self, tmp_path: Path, monkeypatch):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        calls = _mock_claude_cli(monkeypatch, on_path=False)
 
-        result = runner.invoke(app, ["setup", "claude-code", "--project", "testproj", "--remove"])
-        assert result.exit_code == 0
+        result = _configure_mcp(repo, remove=False)
 
-        config = json.loads(config_path.read_text())
-        assert "nauro" not in config["mcpServers"]
-        assert "other" in config["mcpServers"]
+        assert calls == []  # subprocess.run never invoked
+        assert "skipping Claude Code wiring" in result
+
+    def test_non_zero_exit_surfaces_stderr(self, tmp_path: Path, monkeypatch):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _mock_claude_cli(monkeypatch, returncode=1, stderr="some claude error")
+
+        result = _configure_mcp(repo, remove=False)
+
+        assert "some claude error" in result
+        assert "claude mcp add failed" in result
+
+    def test_remove_graceful_when_no_entry(self, tmp_path: Path, monkeypatch):
+        """`claude mcp remove` against a missing entry exits non-zero with a
+        recognizable stderr — the wrapper turns it into a no-op message."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _mock_claude_cli(monkeypatch, returncode=1, stderr="No MCP server named 'nauro'")
+
+        result = _configure_mcp(repo, remove=True)
+
+        assert "no nauro entry to remove" in result
+        # And the failure-path message is NOT used.
+        assert "claude mcp remove failed" not in result
+
+    def test_setup_all_iterates_per_repo(self, tmp_path: Path, monkeypatch):
+        """Multi-repo project: `setup all` invokes `claude mcp add` once per
+        repo with the matching cwd. Locks in the project-scope iteration that
+        the multi-repo flow depends on."""
+        from nauro.cli.commands.setup import setup_all_surfaces
+
+        repo1 = tmp_path / "repo1"
+        repo2 = tmp_path / "repo2"
+        repo1.mkdir()
+        repo2.mkdir()
+        # Pretend HOME exists so claude/codex skill dirs are writable.
+        monkeypatch.setenv("HOME", str(tmp_path))
+        calls = _mock_claude_cli(monkeypatch)
+
+        setup_all_surfaces([repo1, repo2], remove=False)
+
+        # Two `claude mcp add` calls — one per repo, each with the right cwd.
+        add_calls = [(argv, kwargs) for argv, kwargs in calls if argv[2] == "add"]
+        assert len(add_calls) == 2
+        cwds = {kwargs.get("cwd") for _, kwargs in add_calls}
+        assert cwds == {repo1, repo2}
 
 
 class TestAGENTSMD:
@@ -109,10 +148,9 @@ class TestAGENTSMD:
         """Setup regenerates AGENTS.md in all repos."""
         repos = _setup_project(tmp_path, monkeypatch)
 
-        monkeypatch.setattr(
-            "nauro.cli.commands.setup._find_claude_config_path",
-            lambda: None,
-        )
+        # Mock claude CLI as missing — these tests don't care about wiring,
+        # only the surrounding code paths (legacy CLAUDE.md cleanup, AGENTS.md, etc.).
+        _mock_claude_cli(monkeypatch, on_path=False)
 
         result = runner.invoke(app, ["setup", "claude-code", "--project", "testproj"])
         assert result.exit_code == 0
@@ -131,10 +169,9 @@ class TestNoClaudeMDInjection:
         repos = _setup_project(tmp_path, monkeypatch)
         assert not (repos[0] / "CLAUDE.md").exists()
 
-        monkeypatch.setattr(
-            "nauro.cli.commands.setup._find_claude_config_path",
-            lambda: None,
-        )
+        # Mock claude CLI as missing — these tests don't care about wiring,
+        # only the surrounding code paths (legacy CLAUDE.md cleanup, AGENTS.md, etc.).
+        _mock_claude_cli(monkeypatch, on_path=False)
 
         result = runner.invoke(app, ["setup", "claude-code", "--project", "testproj"])
         assert result.exit_code == 0
@@ -146,10 +183,9 @@ class TestNoClaudeMDInjection:
         existing = "# My Project\n\nSome existing content.\n"
         (repos[0] / "CLAUDE.md").write_text(existing)
 
-        monkeypatch.setattr(
-            "nauro.cli.commands.setup._find_claude_config_path",
-            lambda: None,
-        )
+        # Mock claude CLI as missing — these tests don't care about wiring,
+        # only the surrounding code paths (legacy CLAUDE.md cleanup, AGENTS.md, etc.).
+        _mock_claude_cli(monkeypatch, on_path=False)
 
         result = runner.invoke(app, ["setup", "claude-code", "--project", "testproj"])
         assert result.exit_code == 0
@@ -165,10 +201,9 @@ class TestLegacyCleanup:
         content = f"# My Project\n\nKeep this.\n\n{CLAUDE_MD_START}\nold block\n{CLAUDE_MD_END}\n"
         (repos[0] / "CLAUDE.md").write_text(content)
 
-        monkeypatch.setattr(
-            "nauro.cli.commands.setup._find_claude_config_path",
-            lambda: None,
-        )
+        # Mock claude CLI as missing — these tests don't care about wiring,
+        # only the surrounding code paths (legacy CLAUDE.md cleanup, AGENTS.md, etc.).
+        _mock_claude_cli(monkeypatch, on_path=False)
 
         result = runner.invoke(app, ["setup", "claude-code", "--project", "testproj"])
         assert result.exit_code == 0
@@ -185,10 +220,9 @@ class TestLegacyCleanup:
         content = f"{CLAUDE_MD_START}\nold block\n{CLAUDE_MD_END}\n"
         (repos[0] / "CLAUDE.md").write_text(content)
 
-        monkeypatch.setattr(
-            "nauro.cli.commands.setup._find_claude_config_path",
-            lambda: None,
-        )
+        # Mock claude CLI as missing — these tests don't care about wiring,
+        # only the surrounding code paths (legacy CLAUDE.md cleanup, AGENTS.md, etc.).
+        _mock_claude_cli(monkeypatch, on_path=False)
 
         result = runner.invoke(app, ["setup", "claude-code", "--project", "testproj"])
         assert result.exit_code == 0
@@ -212,10 +246,9 @@ class TestProjectResolution:
 
         monkeypatch.chdir(repo_a)
 
-        monkeypatch.setattr(
-            "nauro.cli.commands.setup._find_claude_config_path",
-            lambda: None,
-        )
+        # Mock claude CLI as missing — these tests don't care about wiring,
+        # only the surrounding code paths (legacy CLAUDE.md cleanup, AGENTS.md, etc.).
+        _mock_claude_cli(monkeypatch, on_path=False)
 
         result = runner.invoke(app, ["setup", "claude-code", "--project", "proj-b"])
         assert result.exit_code == 0
@@ -232,10 +265,9 @@ class TestProjectResolution:
 
         _setup_project(tmp_path, monkeypatch, repo_paths=[repo1, repo2])
 
-        monkeypatch.setattr(
-            "nauro.cli.commands.setup._find_claude_config_path",
-            lambda: None,
-        )
+        # Mock claude CLI as missing — these tests don't care about wiring,
+        # only the surrounding code paths (legacy CLAUDE.md cleanup, AGENTS.md, etc.).
+        _mock_claude_cli(monkeypatch, on_path=False)
 
         result = runner.invoke(app, ["setup", "claude-code", "--project", "testproj"])
         assert result.exit_code == 0

--- a/packages/nauro/tests/test_setup.py
+++ b/packages/nauro/tests/test_setup.py
@@ -97,6 +97,22 @@ class TestMCPConfigShellout:
         assert calls == []  # subprocess.run never invoked
         assert "skipping Claude Code wiring" in result
 
+    def test_remove_when_claude_not_on_path_says_nothing_to_remove(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """On --remove with no `claude` CLI, surface a remove-shaped message
+        rather than telling the user to install Claude Code (which is the
+        add-path hint). Locks in the branched message."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        calls = _mock_claude_cli(monkeypatch, on_path=False)
+
+        result = _configure_mcp(repo, remove=True)
+
+        assert calls == []
+        assert "nothing to remove" in result
+        assert "skipping Claude Code wiring" not in result
+
     def test_non_zero_exit_surfaces_stderr(self, tmp_path: Path, monkeypatch):
         repo = tmp_path / "repo"
         repo.mkdir()

--- a/packages/nauro/tests/test_setup_extended.py
+++ b/packages/nauro/tests/test_setup_extended.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import sys
 from pathlib import Path
 
@@ -19,6 +20,20 @@ else:
     import tomli as tomllib
 
 runner = CliRunner()
+
+
+def _mock_claude_cli(monkeypatch, *, on_path: bool = True, returncode: int = 0):
+    """Mock the `claude` CLI for any test that exercises the Claude Code path."""
+    monkeypatch.setattr(
+        "nauro.cli.commands.setup.shutil.which",
+        lambda cmd: "/usr/local/bin/claude" if (on_path and cmd == "claude") else None,
+    )
+    monkeypatch.setattr(
+        "nauro.cli.commands.setup.subprocess.run",
+        lambda argv, **kwargs: subprocess.CompletedProcess(
+            args=argv, returncode=returncode, stdout="", stderr=""
+        ),
+    )
 
 
 # ─── nauro setup cursor ─────────────────────────────────────────────────────
@@ -174,22 +189,23 @@ def test_setup_top_level_help_lists_new_subcommands():
 
 
 def test_setup_all_writes_claude_cursor_codex_configs(tmp_path: Path, monkeypatch):
-    """`setup all` writes MCP config and skill files across all three surfaces."""
+    """`setup all` shells out to `claude mcp add` and writes Cursor + Codex
+    configs and skill files across all three surfaces."""
     monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
     monkeypatch.setenv("HOME", str(tmp_path))
-    # Pre-create ~/.claude/ as a real Claude Code user would have.
-    (tmp_path / ".claude").mkdir()
     repo = tmp_path / "myrepo"
     repo.mkdir()
     _, store_path = register_project_v2("myproj", [repo])
     scaffold_project_store("myproj", store_path)
     monkeypatch.chdir(repo)
+    _mock_claude_cli(monkeypatch)
 
     result = runner.invoke(app, ["setup", "all"])
     assert result.exit_code == 0, result.output
 
-    # MCP configs:
-    assert (tmp_path / ".claude" / "claude_desktop_config.json").is_file()
+    # MCP configs (Claude Code is wired via the mocked `claude mcp add` shellout
+    # — the actual .mcp.json write is the `claude` CLI's responsibility, so the
+    # multi-repo iteration test in test_setup.py covers the argv shape).
     assert (repo / ".cursor" / "mcp.json").is_file()
     assert (tmp_path / ".codex" / "config.toml").is_file()
 
@@ -210,6 +226,7 @@ def test_setup_all_remove_clears_everything(tmp_path: Path, monkeypatch):
     _, store_path = register_project_v2("myproj", [repo])
     scaffold_project_store("myproj", store_path)
     monkeypatch.chdir(repo)
+    _mock_claude_cli(monkeypatch)
 
     runner.invoke(app, ["setup", "all"])
     result = runner.invoke(app, ["setup", "all", "--remove"])

--- a/packages/nauro/tests/test_store.py
+++ b/packages/nauro/tests/test_store.py
@@ -33,7 +33,8 @@ def store(tmp_path: Path) -> Path:
 
 def test_scaffold_creates_all_files(store: Path):
     assert (store / "project.md").exists()
-    assert (store / "state.md").exists()
+    assert (store / "state_current.md").exists()
+    assert not (store / "state.md").exists()
     assert (store / "stack.md").exists()
     assert (store / "open-questions.md").exists()
     assert (store / "decisions").is_dir()
@@ -69,7 +70,8 @@ def test_scaffold_creates_first_decision(store: Path):
 def test_get_scaffolds_returns_dict():
     scaffolds = get_scaffolds()
     assert "project.md" in scaffolds
-    assert "state.md" in scaffolds
+    assert "state_current.md" in scaffolds
+    assert "state.md" not in scaffolds
     assert "stack.md" in scaffolds
     assert "open-questions.md" in scaffolds
 
@@ -191,13 +193,13 @@ def test_question_multiple(store: Path):
 
 
 def test_update_state_creates_state_current(store: Path):
-    """First update_state migrates legacy state.md and creates state_current.md."""
+    """update_state writes to state_current.md (scaffolded directly post-D94)."""
     update_state(store, "Implemented auth module")
     current = (store / "state_current.md").read_text()
     assert "# Current State" in current
     assert "Implemented auth module" in current
-    # Legacy state.md is left untouched
-    assert (store / "state.md").exists()
+    # Scaffold no longer writes a legacy state.md.
+    assert not (store / "state.md").exists()
 
 
 def test_update_state_appends_history(store: Path):
@@ -222,9 +224,12 @@ def test_update_state_history_accumulates(store: Path):
         assert f"Task {i}" in history
 
 
-def test_update_state_migration_preserves_legacy(store: Path):
-    """Migration path: store with only state.md, first update creates state_current.md."""
-    assert (store / "state.md").exists()
+def test_update_state_migration_preserves_legacy(tmp_path: Path):
+    """Pre-D94 stores: state.md only → first update_state migrates to state_current.md."""
+    store = tmp_path / "legacy-store"
+    (store / "decisions").mkdir(parents=True)
+    (store / "snapshots").mkdir()
+    (store / "state.md").write_text("# State\n\n## Current\nLegacy content\n\n## History\n")
     assert not (store / "state_current.md").exists()
     update_state(store, "Post-upgrade task")
     assert (store / "state_current.md").exists()
@@ -252,8 +257,14 @@ def test_load_files_returns_state_current_key(store: Path):
     assert "state.md" not in files
 
 
-def test_load_files_falls_back_to_state_md(store: Path):
-    """When only state.md exists, _load_files returns it under state.md key."""
+def test_load_files_falls_back_to_state_md(tmp_path: Path):
+    """When only legacy state.md exists, _load_files returns it under state.md key."""
+    store = tmp_path / "legacy-store"
+    store.mkdir()
+    (store / "project.md").write_text("# Project\n")
+    (store / "state.md").write_text("# State\n\nLegacy content\n")
+    (store / "stack.md").write_text("# Stack\n")
+    (store / "open-questions.md").write_text("# Questions\n")
     files = _load_files(store)
     assert "state.md" in files
     assert "state_current.md" not in files
@@ -295,7 +306,7 @@ def test_snapshot_capture(store: Path):
     snap = load_snapshot(store, 1)
     assert snap["trigger"] == "test"
     assert "project.md" in snap["files"]
-    assert "state.md" in snap["files"]
+    assert "state_current.md" in snap["files"]
     assert snap["schema_version"] == 1
 
 
@@ -585,8 +596,8 @@ def test_validate_unfilled_prompts(store: Path):
 def test_validate_stale_sync(tmp_path: Path):
     store = tmp_path / "projects" / "stale"
     scaffold_project_store("stale", store)
-    # Legacy format with old Last synced — validator still detects it
-    state = store / "state.md"
+    # Validator prefers state_current.md (post-D94 default) for staleness check.
+    state = store / "state_current.md"
     old_date = (datetime.now(timezone.utc) - timedelta(days=10)).strftime("%Y-%m-%d")
     state.write_text(f"# Current State\n*Last synced: {old_date}*\n")
     warnings = validate_store(store)


### PR DESCRIPTION
## Why

Dogfooding `nauro adopt` against repos in `~/Documents/Munti-Labs/` on 2026-05-08 surfaced five bugs. Two are **critical** and broke `/nauro-adopt` end-to-end:

- `_configure_mcp` was writing Claude *Desktop* config paths (`~/.claude/claude_desktop_config.json`); Claude Code reads `~/.claude.json` and per-repo `<repo>/.mcp.json`. After `nauro adopt`, the MCP entry was invisible to Claude Code.
- The `/nauro-adopt` skill body never told the agent to pass `project_id` on MCP calls. With the auto-resolve change in D121, decisions on users with both a cloud-mode and a local-mode project silently misrouted into the wrong store.

## Approach

Single bug-fix PR; no Nauro decisions proposed (per spec — these are bug fixes, not architectural choices). Closes findings #2, #3 (skill-side), #4, #6, #7 from the 2026-05-08 dogfood.

## What changed

- **Fix 1 (critical):** `_configure_mcp` now shells out to `claude mcp add --scope project` (and `claude mcp remove`) and writes `<repo>/.mcp.json`. Per-repo iteration mirrors Cursor's shareable-artifact model so collaborators inherit wiring via git. Deleted the misnamed `_find_claude_config_path()`. `--scope` was a deliberate choice (see "What to review").
- **Fix 2 (critical):** `/nauro-adopt` Step 2 now instructs the agent to pass `project_id` on every subsequent MCP call. Centralized in Step 2 only — future MCP calls inherit the rule.
- **Fix 3:** Scaffolder writes `state_current.md` directly (template `STATE_MD` → `STATE_CURRENT_MD`). `VALIDATED_STORE_FILES` and `TOKEN_ESTIMATE_FILES` include both filenames so validation works on fresh stores and pre-D94 stores until first `update_state` migrates them. Validator's staleness check prefers `state_current.md`, falls back to legacy.
- **Fix 4:** Skill Step 3 surfaces `"No README found; reading manifest only."` instead of silently continuing.
- **Fix 5:** No doc fix needed — only the dogfood-spec attachment mentioned the wrong wheel path; tracked docs are clean.

Plus the review-feedback follow-up commit:
- Validator warning uses `{state_path.name}` so the named file matches the inspected file.
- `_configure_mcp` branches the "claude not on PATH" message: on `--remove`, says `"nothing to remove"` instead of the add-path install hint.

## What to review

- **Fix 1 subprocess argv shape and the deliberate `--scope project` choice.** The decision was project-scope (shareable per-repo, mirrors Cursor) vs user-scope (one global entry, simpler) vs local-scope (per-cwd, not shared — avoid). Project-scope wins on sharing alignment but costs per-repo iteration plus a `cwd=` plumb. The `setup_all_surfaces` and `claude_code` callers iterate over `entry["repo_paths"]`, mirroring `_configure_cursor_for_repo`'s pattern.
- **Fix 2 paragraph wording in Step 2.** Single source of truth — rule is centralized in Step 2 rather than repeated in Steps 6/7/8.
- **Fix 3 cascade scope.** Scaffolder change forced validator + constants tweaks (validator now prefers `state_current.md`, falls back to legacy `state.md`; both filenames are in `VALIDATED_STORE_FILES`). Several existing tests updated — most renames; a few legacy-migration tests now manually set up `state.md` to keep the migration path under test.

## What's deferred

- Server-side auto-resolve hardening — ships separately in edinburgh repo.
- nauro-core 0.5.0 PyPI publish + nauro CLI dep-pin bump — release coordination, gating items for tagging nauro 0.2.0.
- `nauro unadopt` CLI — separate PR, larger scope.
- **Re-dogfood post-merge.** The dogfood loop is the only thing that catches this class of bug — confirm Fix 1 + Fix 2 actually close the original failure mode against a fresh repo from a fresh Claude Code session.

## Test plan

- [x] `uv run pytest packages/nauro/tests/ -q -m "not integration"` — 788 passed
- [x] `uv run pytest packages/nauro-core/tests/ -q` — 238 passed
- [x] `uv run ruff check packages/` — clean
- [x] `uv run ruff format --check packages/` — clean
- [x] Five new regression tests in `TestMCPConfigShellout` cover argv shape, `cwd=`, claude-not-on-PATH skip (add + remove variants), stderr surfacing on non-zero exit, graceful "no entry to remove" stderr handling, and multi-repo iteration in `setup_all_surfaces`.
- [x] Manual smoke from `/tmp/adopt-smoke` (fresh `git init`): `nauro adopt --name smoke-test` produced `<repo>/.mcp.json` with the right entry, `~/.nauro/projects/<id>/state_current.md` (no `state.md`), `claude mcp list` from inside the repo shows the project-scope entry, and `nauro setup claude-code --remove` clears it.
- [x] `nauro adopt --print-prompt` shows both new paragraphs (project_id rule in Step 2, "No README found" notice in Step 3).