### PR TITLE
fix(adopt): lazy-import anthropic + smoke-test wired binary

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/adopt.py
+++ b/packages/nauro/src/nauro/cli/commands/adopt.py
@@ -24,11 +24,12 @@ seeding the Nauro store via the existing MCP write tools.
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
 import typer
 
-from nauro.cli.commands.setup import setup_all_surfaces
+from nauro.cli.commands.setup import _find_nauro_command, setup_all_surfaces
 from nauro.constants import REGISTRY_SCHEMA_VERSION_V2, REPO_CONFIG_MODE_LOCAL
 from nauro.skills import load_adopt_body
 from nauro.store.registry import find_projects_by_name_v2, register_project_v2
@@ -41,6 +42,48 @@ from nauro.templates.scaffolds import scaffold_project_store
 def _resolve_repo_root(repo_arg: Path | None) -> Path:
     """Return the absolute path of the repo root to adopt."""
     return (repo_arg if repo_arg is not None else Path.cwd()).resolve()
+
+
+def _smoke_test_wired_binary(nauro_cmd: str, timeout: float = 1.5) -> str | None:
+    """Boot ``<nauro_cmd> serve --stdio`` briefly to verify it doesn't crash on import.
+
+    A healthy stdio server either exits cleanly on stdin EOF (returncode 0) or
+    keeps running waiting for an MCP handshake (we kill it after ``timeout``).
+    Either outcome is "healthy". The failure mode we care about is the binary
+    crashing on import — that surfaces as a non-zero exit before the timeout.
+
+    Returns a multi-line warning string on detected failure, otherwise None.
+    """
+    try:
+        proc = subprocess.run(
+            [nauro_cmd, "serve", "--stdio"],
+            input="",
+            timeout=timeout,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return None
+    except FileNotFoundError:
+        return (
+            f"WARNING: could not run `{nauro_cmd} serve --stdio` — binary not found.\n"
+            f"  /nauro-adopt and other MCP-driven flows will not work until this is fixed."
+        )
+
+    if proc.returncode == 0:
+        return None
+
+    first_err = next(
+        (line for line in (proc.stderr or "").splitlines() if line.strip()),
+        "(no stderr captured)",
+    )
+    return (
+        f"\nWARNING: `{nauro_cmd} serve --stdio` failed to start (exit {proc.returncode}): "
+        f"{first_err}\n"
+        f"  Run `{nauro_cmd} serve --stdio` manually to see the full traceback.\n"
+        f"  /nauro-adopt and other MCP-driven flows will not work until this is fixed."
+    )
 
 
 def _check_collision(name: str, repo_root: Path) -> str | None:
@@ -154,6 +197,10 @@ def adopt(
         typer.echo("\nWiring MCP and installing skills across surfaces:")
         for line in setup_all_surfaces([repo_root], remove=False):
             typer.echo(line)
+
+        warning = _smoke_test_wired_binary(_find_nauro_command())
+        if warning:
+            typer.echo(warning, err=True)
 
     typer.echo(
         "\nNext: restart your agent and invoke /nauro-adopt to seed context "

--- a/packages/nauro/src/nauro/extraction/anthropic_provider.py
+++ b/packages/nauro/src/nauro/extraction/anthropic_provider.py
@@ -9,11 +9,6 @@ from __future__ import annotations
 import logging
 import os
 
-try:
-    import anthropic
-except ImportError:
-    raise ImportError("anthropic package required for extraction: pip install nauro[extraction]")
-
 from nauro.constants import DEFAULT_EXTRACTION_MODEL, NAURO_EXTRACTION_MODEL_ENV
 from nauro.extraction.prompts import (
     EXTRACTION_SYSTEM_PROMPT,
@@ -45,6 +40,13 @@ class AnthropicProvider:
         """Extract structured context from a commit diff using Anthropic Haiku."""
         if not self._has_api_key():
             return ExtractionSkipped(reason="no_api_key")
+
+        try:
+            import anthropic
+        except ImportError as e:
+            raise ImportError(
+                "anthropic package required for extraction: pip install nauro[extraction]"
+            ) from e
 
         try:
             client = anthropic.Anthropic(api_key=self._api_key)

--- a/packages/nauro/src/nauro/extraction/session_extractor.py
+++ b/packages/nauro/src/nauro/extraction/session_extractor.py
@@ -11,11 +11,6 @@ import logging
 import os
 from pathlib import Path
 
-try:
-    import anthropic
-except ImportError:
-    raise ImportError("anthropic package required for extraction: pip install nauro[extraction]")
-
 from nauro.constants import (
     DEFAULT_EXTRACTION_MODEL,
     NAURO_EXTRACTION_MODEL_ENV,
@@ -63,6 +58,13 @@ def extract_from_compaction(
 
     if not compaction_summary or not compaction_summary.strip():
         return skip_result
+
+    try:
+        import anthropic
+    except ImportError as e:
+        raise ImportError(
+            "anthropic package required for extraction: pip install nauro[extraction]"
+        ) from e
 
     try:
         client = anthropic.Anthropic(api_key=api_key)
@@ -264,6 +266,14 @@ def _extract_from_chunk(chunk: str, api_key: str | None = None) -> dict:
         return _make_no_api_key_result()
 
     skip_result = _make_skip_result()
+
+    try:
+        import anthropic
+    except ImportError as e:
+        raise ImportError(
+            "anthropic package required for extraction: pip install nauro[extraction]"
+        ) from e
+
     try:
         client = anthropic.Anthropic(api_key=api_key)
         model = os.environ.get(NAURO_EXTRACTION_MODEL_ENV, DEFAULT_EXTRACTION_MODEL)

--- a/packages/nauro/src/nauro/validation/tier3.py
+++ b/packages/nauro/src/nauro/validation/tier3.py
@@ -10,13 +10,21 @@ import logging
 import os
 from pathlib import Path
 
-try:
-    import anthropic
-except ImportError:
-    raise ImportError("anthropic package required for validation: pip install nauro[extraction]")
-
 from nauro.constants import DEFAULT_EXTRACTION_MODEL, NAURO_EXTRACTION_MODEL_ENV
 from nauro.store.reader import _list_decisions
+
+_ANTHROPIC_INSTALL_HINT = (
+    "anthropic package required for tier-3 validation: pip install nauro[extraction]"
+)
+
+
+def _require_anthropic():
+    try:
+        import anthropic
+    except ImportError as e:
+        raise ImportError(_ANTHROPIC_INSTALL_HINT) from e
+    return anthropic
+
 
 logger = logging.getLogger("nauro.validation.tier3")
 
@@ -172,6 +180,8 @@ def evaluate_with_llm(
         "## Most Similar Existing Decisions\n\n" + "\n\n---\n\n".join(similar_content)
     )
 
+    anthropic = _require_anthropic()
+
     try:
         client = anthropic.Anthropic(api_key=api_key)
         model = os.environ.get(NAURO_EXTRACTION_MODEL_ENV, DEFAULT_EXTRACTION_MODEL)
@@ -241,6 +251,8 @@ def check_conflicts_with_llm(
     if context:
         user_prompt += f"**Context:** {context}\n\n"
     user_prompt += "## Relevant Existing Decisions\n\n" + "\n\n---\n\n".join(similar_content)
+
+    anthropic = _require_anthropic()
 
     try:
         client = anthropic.Anthropic(api_key=api_key)

--- a/packages/nauro/tests/conftest.py
+++ b/packages/nauro/tests/conftest.py
@@ -5,6 +5,22 @@ so integration tests can use credentials configured via `nauro config set`
 without requiring explicit env var injection.
 """
 
+import pytest
+
 from nauro.store.config import apply_config_to_env
 
 apply_config_to_env()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cwd(tmp_path, monkeypatch):
+    """Chdir every test into tmp_path so CWD walk-up resolution doesn't leak.
+
+    Several store/resolution paths walk up from `Path.cwd()` looking for
+    ``.nauro/config.json``. If pytest is run from inside an adopted repo
+    (e.g. the nauro repo dogfood-adopting itself), that walk finds a real
+    config and trips ID-mismatch errors in tests that pass project= directly.
+    Tests that need a specific CWD use monkeypatch.chdir themselves; their
+    later override wins on the same monkeypatch instance.
+    """
+    monkeypatch.chdir(tmp_path)

--- a/packages/nauro/tests/test_extraction.py
+++ b/packages/nauro/tests/test_extraction.py
@@ -853,7 +853,7 @@ def _make_new_format_result(
 class TestExtractFromCommit:
     """Test extract_from_commit with mocked Anthropic client."""
 
-    @patch("nauro.extraction.anthropic_provider.anthropic.Anthropic")
+    @patch("anthropic.Anthropic")
     def test_returns_parsed_tool_result(self, mock_cls):
         expected = _make_new_format_result(
             decisions=[{"title": "Switch to Postgres", "confidence": "high"}],
@@ -876,7 +876,7 @@ class TestExtractFromCommit:
         assert result.signal.architectural_significance == 0.9
         assert result.reasoning == "Test reasoning"
 
-    @patch("nauro.extraction.anthropic_provider.anthropic.Anthropic")
+    @patch("anthropic.Anthropic")
     def test_returns_skip_on_api_error(self, mock_cls):
         mock_cls.return_value.messages.create.side_effect = Exception("API down")
 
@@ -884,7 +884,7 @@ class TestExtractFromCommit:
         assert isinstance(result, ExtractionSkipped)
         assert result.reason == "error"
 
-    @patch("nauro.extraction.anthropic_provider.anthropic.Anthropic")
+    @patch("anthropic.Anthropic")
     def test_returns_skip_when_no_tool_use_block(self, mock_cls):
         text_block = MagicMock()
         text_block.type = "text"
@@ -896,7 +896,7 @@ class TestExtractFromCommit:
         assert isinstance(result, ExtractionSkipped)
         assert result.reason == "no_tool_use"
 
-    @patch("nauro.extraction.anthropic_provider.anthropic.Anthropic")
+    @patch("anthropic.Anthropic")
     def test_defaults_missing_keys(self, mock_cls):
         mock_cls.return_value.messages.create.return_value = _make_mock_response(
             {"composite_score": 0.5, "skip": False}
@@ -910,7 +910,7 @@ class TestExtractFromCommit:
         assert result.signal is not None
         assert result.reasoning == ""
 
-    @patch("nauro.extraction.anthropic_provider.anthropic.Anthropic")
+    @patch("anthropic.Anthropic")
     def test_recomputes_composite_when_zero_with_decisions(self, mock_cls):
         """If model returns skip=false, real decisions, but composite_score=0.0,
         the pipeline should recompute from signal dimensions."""
@@ -939,7 +939,7 @@ class TestExtractFromCommit:
         assert result.signal.composite_score == pytest.approx(0.68)
         assert result.skip is False
 
-    @patch("nauro.extraction.anthropic_provider.anthropic.Anthropic")
+    @patch("anthropic.Anthropic")
     def test_no_recompute_when_skip_true(self, mock_cls):
         """Don't recompute if skip=true — 0.0 is correct for skipped results."""
         mock_cls.return_value.messages.create.return_value = _make_mock_response(
@@ -964,7 +964,7 @@ class TestExtractFromCommit:
         assert isinstance(result, ExtractionResult)
         assert result.signal.composite_score == 0.0
 
-    @patch("nauro.extraction.anthropic_provider.anthropic.Anthropic")
+    @patch("anthropic.Anthropic")
     def test_no_recompute_when_composite_nonzero(self, mock_cls):
         """Don't recompute if model already provided a nonzero composite."""
         mock_cls.return_value.messages.create.return_value = _make_mock_response(

--- a/packages/nauro/tests/test_lazy_imports.py
+++ b/packages/nauro/tests/test_lazy_imports.py
@@ -1,0 +1,113 @@
+"""Regression tests for lazy-import of `anthropic` + post-adopt smoke check.
+
+The 2026-05-09 dogfood blocker was a top-level `import anthropic` guard in
+`validation/tier3.py` that fired at module load time, making `anthropic` an
+unconditional runtime dep for `nauro serve --stdio`.
+"""
+
+from __future__ import annotations
+
+import importlib
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+# Setting sys.modules[name] = None makes Python's import machinery treat
+# `import name` as a previously-failed import and raise ImportError, even
+# when the package is actually installed. monkeypatch auto-restores on
+# teardown so other tests in the session are unaffected.
+def _block_anthropic(monkeypatch) -> None:
+    monkeypatch.setitem(sys.modules, "anthropic", None)
+
+
+def test_stdio_server_imports_without_anthropic(monkeypatch):
+    """The stdio entry path must not require anthropic at module-load time."""
+    _block_anthropic(monkeypatch)
+    # Drop cached nauro.* modules so re-importing actually re-runs top-level
+    # statements (otherwise Python returns the cached module and a regression
+    # slips by). monkeypatch.delitem auto-restores on teardown.
+    for name in [n for n in list(sys.modules) if n == "nauro" or n.startswith("nauro.")]:
+        monkeypatch.delitem(sys.modules, name, raising=False)
+
+    importlib.import_module("nauro.mcp.stdio_server")
+
+
+def test_evaluate_with_llm_raises_with_install_hint(monkeypatch, tmp_path: Path):
+    """tier3's LLM functions sit inside a fail-closed try/except. The lazy
+    import must run BEFORE that block so ImportError isn't swallowed."""
+    _block_anthropic(monkeypatch)
+    from nauro.validation.tier3 import evaluate_with_llm
+
+    with pytest.raises(ImportError, match=r"pip install nauro\[extraction\]"):
+        evaluate_with_llm(
+            proposal={"title": "x", "rationale": "y"},
+            similar_decisions=[],
+            project_path=tmp_path,
+            api_key="test-key",
+        )
+
+
+# ── Fix 4: post-adopt smoke-test of the wired binary ─────────────────────
+
+
+class _FakeCompletedProcess:
+    def __init__(self, returncode: int, stderr: str = "") -> None:
+        self.returncode = returncode
+        self.stderr = stderr
+
+
+def test_smoke_silent_when_serve_stdio_exits_clean(monkeypatch):
+    from nauro.cli.commands import adopt as adopt_mod
+
+    monkeypatch.setattr(
+        adopt_mod.subprocess,
+        "run",
+        lambda *a, **kw: _FakeCompletedProcess(returncode=0),
+    )
+    assert adopt_mod._smoke_test_wired_binary("nauro-fake") is None
+
+
+def test_smoke_silent_when_serve_stdio_times_out(monkeypatch):
+    """A healthy stdio server may block on stdin; timeout must be treated
+    as success, NOT a crash. This is the bug the original prompt would
+    have shipped."""
+    from nauro.cli.commands import adopt as adopt_mod
+
+    def fake_run(*a, **kw):
+        raise subprocess.TimeoutExpired(cmd=a[0] if a else "nauro", timeout=1.5)
+
+    monkeypatch.setattr(adopt_mod.subprocess, "run", fake_run)
+    assert adopt_mod._smoke_test_wired_binary("nauro-fake") is None
+
+
+def test_smoke_warns_when_serve_stdio_crashes(monkeypatch):
+    from nauro.cli.commands import adopt as adopt_mod
+
+    crash_stderr = (
+        "Traceback (most recent call last):\nModuleNotFoundError: No module named 'anthropic'\n"
+    )
+    monkeypatch.setattr(
+        adopt_mod.subprocess,
+        "run",
+        lambda *a, **kw: _FakeCompletedProcess(returncode=1, stderr=crash_stderr),
+    )
+    warning = adopt_mod._smoke_test_wired_binary("nauro-fake")
+    assert warning is not None
+    assert "failed to start" in warning
+    assert "Traceback" in warning  # surfaces first non-empty stderr line
+    assert "MCP-driven flows" in warning
+
+
+def test_smoke_warns_when_binary_not_found(monkeypatch):
+    from nauro.cli.commands import adopt as adopt_mod
+
+    def fake_run(*a, **kw):
+        raise FileNotFoundError("nauro-fake")
+
+    monkeypatch.setattr(adopt_mod.subprocess, "run", fake_run)
+    warning = adopt_mod._smoke_test_wired_binary("nauro-fake")
+    assert warning is not None
+    assert "binary not found" in warning

--- a/packages/nauro/tests/test_session_extraction/test_session_extractor.py
+++ b/packages/nauro/tests/test_session_extraction/test_session_extractor.py
@@ -66,7 +66,7 @@ def _make_extraction_result(**overrides):
 
 
 class TestExtractFromCompaction:
-    @patch("nauro.extraction.session_extractor.anthropic.Anthropic")
+    @patch("anthropic.Anthropic")
     def test_basic_extraction(self, mock_cls, store):
         expected = _make_extraction_result(
             decisions=[
@@ -102,7 +102,7 @@ class TestExtractFromCompaction:
         assert result["decisions"][0]["title"] == "Use FastAPI for MCP server"
         assert result["composite_score"] == 0.65
 
-    @patch("nauro.extraction.session_extractor.anthropic.Anthropic")
+    @patch("anthropic.Anthropic")
     def test_sets_source_on_decisions(self, mock_cls, store):
         expected = _make_extraction_result(
             decisions=[{"title": "Test", "confidence": "medium"}],
@@ -119,7 +119,7 @@ class TestExtractFromCompaction:
         result = extract_from_compaction("", store, api_key="test")
         assert result["skip"] is True
 
-    @patch("nauro.extraction.session_extractor.anthropic.Anthropic")
+    @patch("anthropic.Anthropic")
     def test_api_error_returns_skip(self, mock_cls, store):
         mock_cls.return_value.messages.create.side_effect = Exception("API error")
         result = extract_from_compaction("summary", store, api_key="test")
@@ -136,7 +136,7 @@ class TestExtractFromSessionJsonl:
         lines = [json.dumps(m) for m in messages]
         path.write_text("\n".join(lines))
 
-    @patch("nauro.extraction.session_extractor.anthropic.Anthropic")
+    @patch("anthropic.Anthropic")
     def test_basic_jsonl_extraction(self, mock_cls, store, tmp_path):
         session_path = tmp_path / "session.jsonl"
         self._write_session(
@@ -163,7 +163,7 @@ class TestExtractFromSessionJsonl:
         result = extract_from_session_jsonl(tmp_path / "missing.jsonl", store)
         assert result["skip"] is True
 
-    @patch("nauro.extraction.session_extractor.anthropic.Anthropic")
+    @patch("anthropic.Anthropic")
     def test_deduplicates_across_chunks(self, mock_cls, store, tmp_path):
         """Decisions with the same title across chunks are deduplicated."""
         session_path = tmp_path / "session.jsonl"

--- a/packages/nauro/tests/test_validation/test_pipeline.py
+++ b/packages/nauro/tests/test_validation/test_pipeline.py
@@ -253,7 +253,7 @@ class TestFailClosedBehavior:
         return store_path
 
     @patch("nauro.validation.pipeline.check_similarity")
-    @patch("nauro.validation.tier3.anthropic.Anthropic")
+    @patch("anthropic.Anthropic")
     def test_auto_confirm_path_holds_when_llm_fails(
         self, mock_anthropic_cls, mock_check_similarity, tmp_path
     ):
@@ -293,7 +293,7 @@ class TestFailClosedBehavior:
         )
 
     @patch("nauro.validation.pipeline.check_similarity")
-    @patch("nauro.validation.tier3.anthropic.Anthropic")
+    @patch("anthropic.Anthropic")
     def test_mcp_path_queues_for_confirmation_when_llm_fails(
         self, mock_anthropic_cls, mock_check_similarity, tmp_path
     ):

--- a/packages/nauro/tests/test_validation/test_tier3.py
+++ b/packages/nauro/tests/test_validation/test_tier3.py
@@ -37,7 +37,7 @@ def _make_mock_response(tool_name: str, tool_input: dict):
 
 
 class TestEvaluateWithLlm:
-    @patch("nauro.validation.tier3.anthropic.Anthropic")
+    @patch("anthropic.Anthropic")
     def test_add_operation(self, mock_anthropic_cls, store):
         mock_client = MagicMock()
         mock_anthropic_cls.return_value = mock_client
@@ -61,7 +61,7 @@ class TestEvaluateWithLlm:
         assert result["operation"] == "add"
         assert result["conflicts"] == []
 
-    @patch("nauro.validation.tier3.anthropic.Anthropic")
+    @patch("anthropic.Anthropic")
     def test_supersede_operation(self, mock_anthropic_cls, store):
         mock_client = MagicMock()
         mock_anthropic_cls.return_value = mock_client
@@ -91,7 +91,7 @@ class TestEvaluateWithLlm:
         assert result["affected_decision_id"] == "decision-002"
         assert len(result["conflicts"]) == 1
 
-    @patch("nauro.validation.tier3.anthropic.Anthropic")
+    @patch("anthropic.Anthropic")
     def test_update_operation(self, mock_anthropic_cls, store):
         mock_client = MagicMock()
         mock_anthropic_cls.return_value = mock_client
@@ -118,7 +118,7 @@ class TestEvaluateWithLlm:
         assert result["operation"] == "update"
         assert result["affected_decision_id"] == "decision-002"
 
-    @patch("nauro.validation.tier3.anthropic.Anthropic")
+    @patch("anthropic.Anthropic")
     def test_noop_operation(self, mock_anthropic_cls, store):
         mock_client = MagicMock()
         mock_anthropic_cls.return_value = mock_client
@@ -139,7 +139,7 @@ class TestEvaluateWithLlm:
         )
         assert result["operation"] == "noop"
 
-    @patch("nauro.validation.tier3.anthropic.Anthropic")
+    @patch("anthropic.Anthropic")
     def test_returns_hold_on_api_failure(self, mock_anthropic_cls, store):
         """When LLM call fails, operation is 'hold' — not 'add' (fail-closed)."""
         mock_client = MagicMock()
@@ -158,7 +158,7 @@ class TestEvaluateWithLlm:
         )
         assert "unavailable" in result["assessment"].lower()
 
-    @patch("nauro.validation.tier3.anthropic.Anthropic")
+    @patch("anthropic.Anthropic")
     def test_api_key_forwarded_to_anthropic_client(self, mock_anthropic_cls, store):
         """Explicit api_key must be passed to Anthropic() constructor."""
         mock_client = MagicMock()
@@ -179,7 +179,7 @@ class TestEvaluateWithLlm:
 
 
 class TestCheckConflicts:
-    @patch("nauro.validation.tier3.anthropic.Anthropic")
+    @patch("anthropic.Anthropic")
     def test_finds_conflicts(self, mock_anthropic_cls, store):
         mock_client = MagicMock()
         mock_anthropic_cls.return_value = mock_client
@@ -207,7 +207,7 @@ class TestCheckConflicts:
         assert len(result["potential_conflicts"]) == 1
         assert "MySQL" in result["potential_conflicts"][0]["conflict"]
 
-    @patch("nauro.validation.tier3.anthropic.Anthropic")
+    @patch("anthropic.Anthropic")
     def test_returns_empty_on_api_failure(self, mock_anthropic_cls, store):
         mock_client = MagicMock()
         mock_anthropic_cls.return_value = mock_client


### PR DESCRIPTION
## Why

The 2026-05-09 re-dogfood of `nauro adopt` (post-PR #31) aborted at pre-flight. PR #31's wiring fix landed correctly — `.mcp.json` was written, `claude mcp list` showed the entry — but the wired binary failed to start with:

    ModuleNotFoundError: No module named 'anthropic'
    nauro/validation/tier3.py:14

A top-level `import anthropic` guard at module load made `anthropic` an unconditional runtime dep for `nauro serve --stdio`, despite being declared optional via the `[extraction]` extra. The stdio boot path (`serve.py → stdio_server.py → mcp/tools.py → validation/pipeline.py → tier3.py`) hit it before any tool call ran, so `mcp__nauro__*` tools never registered. This blocked F1 + F2 from the dogfood gate and would have polluted production if the user had proceeded — `/nauro-adopt` would have written via cloud auto-resolve.

Two latent same-shape guards in `extraction/` were one careless top-level import away from the same trap.

## Approach

Lazy-import `anthropic` inside the functions that actually use it. Tier-3 LLM validation runs on ~5% of writes per its docstring; the other 95% (tier 1+2 + every read) shouldn't pull anthropic at boot.

Two design choices worth flagging:

1. **The lazy import sits BEFORE tier3's existing fail-closed `try/except`, not inside it.** Both LLM functions wrap their call in `except Exception` and degrade to "hold". Putting the import inside that block would silently swallow the install hint and degrade `evaluate_with_llm` to "LLM unavailable" — wrong: anthropic-not-installed is a config error, not a runtime LLM failure. Placement before the try block lets the friendly ImportError propagate.

2. **The post-adopt smoke test treats `TimeoutExpired` as healthy.** The MCP stdio server blocks on stdin awaiting an `initialize` JSON-RPC message — it doesn't exit on EOF in 1.5s. An earlier draft only checked for `returncode != 0 AND "Traceback" in stderr`, which would have raised an unhandled `TimeoutExpired` on every healthy install. Now: timeout = "didn't crash on import" = healthy; non-zero exit = surface stderr + reproduce hint.

Rejected alternatives:
- Promote `anthropic` from `[extraction]` extra to default runtime dep — would make installs heavier for users who don't run extraction.
- Move `tier3` itself out of the boot path — bigger surgery; the lazy-import fix is local and surgical.

## What changed

**Source — lazy-import refactor:**
- `validation/tier3.py` — `_require_anthropic()` helper called inside both LLM functions, before their fail-closed try/except.
- `extraction/anthropic_provider.py` and `extraction/session_extractor.py` — same shape (latent — not on the stdio boot path today).

**Source — Fix 4 (defense-in-depth):**
- `cli/commands/adopt.py` — `_smoke_test_wired_binary()` runs after `setup_all_surfaces`. Boots `<nauro_cmd> serve --stdio` with closed stdin and a 1.5s timeout. Treats timeout as healthy, returncode-only failure detection, surfaces first non-empty stderr line on crash, handles `FileNotFoundError`. Future "wired binary won't start" bugs surface at adopt time rather than in a downstream session.

**Tests:**
- New `tests/test_lazy_imports.py` — 6 tests: stdio boot-path import without anthropic; tier3 friendly-error propagation; 4 smoke-test paths (clean exit, timeout, crash with stderr, missing binary).
- 22 existing `@patch("nauro.X.anthropic.Anthropic")` decorators rewritten to `@patch("anthropic.Anthropic")` across 4 test files. `anthropic` is no longer a module-level attribute; patching the actual module works the same — the lazy import binds the local name to `sys.modules['anthropic']`, where `mock.patch` has already replaced `Anthropic`.

**Test-infra fix (separate commit, same PR per scoping decision):**
- `tests/conftest.py` — autouse `_isolate_cwd` fixture that chdirs every test into `tmp_path`. Pre-existing rot: store-resolution paths walk up from `Path.cwd()` looking for `.nauro/config.json`. If pytest runs from inside an adopted repo (e.g. the nauro repo dogfood-adopting itself), the walk finds that config and trips ID-mismatch errors in tests that pass `project=` directly. CI is unaffected (clean checkouts); every dev who self-adopts nauro for dogfood will hit it.

## What to review

- **`tier3.py` placement of `_require_anthropic()` calls** — both must be before the existing `try/except Exception` block, or ImportError gets swallowed and degrades to "LLM unavailable". The new `test_evaluate_with_llm_raises_with_install_hint` locks this in.
- **`adopt.py:_smoke_test_wired_binary` timeout semantics** — the rationale (stdio server blocks awaiting handshake) is the non-obvious bit. If the server's EOF behavior changes upstream, the right adjustment is in the helper's docstring, not the `timeout=` value.
- **Patch-decorator rewrite (22 sites)** — mechanical but easy to misread. Each `@patch("nauro.<module>.anthropic.Anthropic")` became `@patch("anthropic.Anthropic")`. Existing positive-path coverage in `test_extraction.py`, `test_session_extraction/`, and `test_validation/` confirms the lazy-import refactor doesn't break the happy path.
- **`conftest.py` autouse fixture** — runs before per-test `monkeypatch.chdir(...)` calls; later chdirs on the same `monkeypatch` instance win, so `test_adopt.py`'s explicit `chdir(repo)` still takes effect.

## What's deferred

- **Re-dogfood post-merge** — manual gate the user runs to confirm F1 + F2 from the 2026-05-08 plan close end-to-end. This PR unblocks but doesn't replace that gate.
- **Trust-prompt UX hint** — adopt's closing message could mention the Claude Code "Trust this MCP server?" prompt on first session. Separate follow-up.
- **`nauro unadopt` CLI** — scope gap surfaced during dogfood; separate PR.
- **nauro-core 0.5.0 PyPI publish + dep-pin bump from `>=0.2.0,<0.3` to `>=0.5.0,<0.6`** — release coordination, separate workflow. Will not affect this fix (the missing dep is `anthropic`, not nauro-core version).

## Test plan

- `uv run pytest packages/nauro/tests/` — **796 passed, 0 failed** (locally, after the conftest CWD-isolation fix; pre-fix, 33 of those were failing due to the dev-machine `.nauro/` walk-up issue, all unrelated to the lazy-import work).
- `uv run pytest packages/nauro-core/tests/` — **238 passed**.
- `uv run ruff check packages/` and `ruff format --check packages/` — clean.
- **Manual repro of the original bug:** in a venv with `anthropic` blocked, `import nauro.mcp.stdio_server` raises `ImportError: anthropic package required for validation: pip install nauro[extraction]` on `a75e053` (main); imports cleanly post-fix.
