### PR TITLE
chore(nauro-core): source __version__ from package metadata

### DIFF
--- a/packages/nauro-core/src/nauro_core/__init__.py
+++ b/packages/nauro-core/src/nauro_core/__init__.py
@@ -3,7 +3,7 @@
 Re-export facade — public API symbols from all modules.
 """
 
-__version__ = "0.5.0"
+from importlib.metadata import version
 
 from nauro_core.constants import (
     DECISION_HASHES_FILE as DECISION_HASHES_FILE,
@@ -203,3 +203,5 @@ from nauro_core.validation import (
 from nauro_core.validation import (
     screen_structural as screen_structural,
 )
+
+__version__ = version("nauro-core")


### PR DESCRIPTION
## Why
`__version__` in `packages/nauro-core/src/nauro_core/__init__.py:6` drifted from `pyproject.toml` during the 0.6.0 release — the literal stayed at `"0.5.0"` while package metadata bumped to `0.6.0`. Any caller introspecting `nauro_core.__version__` saw the stale value. mcp-server doesn't read it (grep clean), but the drift is a footgun for future releases.

## Approach
Replace the literal with `importlib.metadata.version("nauro-core")` so the source is computed from the installed package metadata. The single source of truth becomes `pyproject.toml`.

`importlib.metadata` is stdlib (Python 3.8+) — no new dependency for a package that ships with zero runtime deps.

## What changed
- `packages/nauro-core/src/nauro_core/__init__.py`: drop literal, import `version` from `importlib.metadata`, assign `__version__ = version("nauro-core")` at the bottom of the module so isort stays clean.

## What to review
- The pattern works only when `nauro-core` is installed as a distribution (PyPI wheel, editable install, etc.). Running the source directly without installation (e.g., sys.path hacks) would raise `PackageNotFoundError`. Not a supported usage shape.

## What's deferred
Nothing.

## Test plan
- [x] `uv run python -c "import nauro_core; print(nauro_core.__version__)"` → `0.6.0` (matches `pyproject.toml`).
- [x] `uv run pytest packages/nauro-core/tests/` → 249 passed.
- [x] `uv run pytest packages/nauro/tests/ -m "not integration"` → 660 passed.
- [x] `uv run ruff check packages/ && uv run ruff format --check packages/` → clean.
- [ ] CI green.