### PR TITLE
docs: correct MCP tool count, trust-model copy, surface nauro adopt

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,9 @@ User config lives at `~/.nauro/config.json` (created by `nauro config set`):
 - `nauro import --memory-bank <path>` — migrate a Cline/Roo Code Memory Bank
 - `nauro import --adr <path>` — migrate Architecture Decision Records
 
-## MCP tools (11 total — 7 read, 4 write)
+## MCP tools (12 total in `nauro_core.mcp_tools` — 8 read, 4 write)
+
+The local stdio server registers 11; `list_projects` is remote-only since local installs auto-resolve to the single project store.
 
 Read:
 - `get_context(project, level)` — L0 concise summary, L1 working set, L2 full dump
@@ -78,6 +80,7 @@ Read:
 - `diff_since_last_session(project, days)` — what changed since last session
 - `search_decisions(project, query, limit)` — keyword search across decisions
 - `check_decision(proposed_approach)` — check for conflicts without writing
+- `list_projects()` — list user's projects (remote-only)
 
 Write:
 - `propose_decision(project, title, rationale, ...)` — propose a decision for validation

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Your project has context. Every agent should inherit it.
 
-Nauro is an open-source MCP server that gives AI agents persistent project context across tools and sessions.
+Nauro is an open-source system that gives AI agents persistent project context across tools and sessions.
 
 It captures a project's decisions, rejected options, rationale, constraints, current state, and open questions, then makes that context available across Claude, Perplexity, Cursor, Codex, and any MCP client.
 
@@ -50,7 +50,17 @@ nauro setup claude-code
 
 `nauro init` writes a small `.nauro/config.json` into your repo (commit it — it links the repo to the project so any `nauro` command you run from inside this repo knows which project to use). To start with cloud sync from day one, use `nauro init --cloud my-project` instead.
 
-Agents propose decisions directly through MCP during sessions. You confirm before anything is written to the store.
+Agents propose decisions directly through MCP during sessions. When a proposal overlaps with existing decisions, you confirm before it's written.
+
+## Adopt an existing repo
+
+For a repo that already has docs — README, ADRs, Memory-Bank files, manifests:
+
+```bash
+nauro adopt
+```
+
+Run from the repo root. `nauro adopt` creates the project, wires MCP across your installed agents (Claude Code, Cursor, Codex), and drops a portable skill into your agent. Invoke `/nauro-adopt` in any connected agent and it reads your existing docs, surfaces decision candidates for you to keep or skip, then seeds the store one decision at a time. The agent does the reading — no API key required server-side.
 
 ## Use across surfaces
 
@@ -68,7 +78,7 @@ Codex users: also add `mcp_oauth_callback_port = 8765` to the top of `~/.codex/c
 
 ## How it works
 
-Agents propose decisions through MCP during sessions. Decisions are proposed in collaboration with your agent and confirmed by you before anything is written — the gate is the boundary between "we discussed it" and "your project's direction has changed." You can also log decisions from the terminal with `nauro note`. Open questions are tracked too, so agents surface unresolved tensions before they become assumptions.
+Agents propose decisions through MCP during sessions. Proposals are drafted in collaboration with your agent; when one overlaps with an existing decision, you confirm before it's written, and updates or replacements of existing decisions always require explicit confirmation. The gate is the boundary between "we discussed it" and "your project's direction has changed." You can also log decisions from the terminal with `nauro note`. Open questions are tracked too, so agents surface unresolved tensions before they become assumptions.
 
 One project spans many repos — the store lives in `~/.nauro/`, not inside any repo, so context follows the project across the whole codebase.
 
@@ -92,12 +102,13 @@ Most memory tools preserve conversation history. Nauro captures what you decided
 
 Nauro is built around a different primitive: checking new proposals against past decisions before they become work you have to undo.
 
-| Approach | Cross-tool | Validates against past decisions | Versioned |
+| Approach | What it captures | Cross-tool reach | Validates against past decisions |
 |---|---|---|---|
-| **Nauro** | Any MCP client | Yes (`check_decision`) | Snapshots + diffs |
-| AGENTS.md (manual) | Tools with repo access | No | Git history only |
-| Cursor Rules | Cursor only | No | No |
-| ADRs in-repo | Tools with repo access | Manual | Git history only |
+| **Nauro** | Decisions with rationale | Any MCP client | Yes (`check_decision`) |
+| AGENTS.md / ADRs (manual) | Decisions, manually maintained | Tools with repo access | No |
+| Cursor Rules | Coding preferences | Cursor only | No |
+| Memory tools (mem0, Letta, Zep) | Conversation history | Per integration | No |
+| Platform memory (Copilot, Windsurf, Claude) | Usage patterns | Single vendor | No |
 
 The `check_decision` → `propose_decision` → `confirm_decision` pipeline surfaces conflicts for you to confirm before they're written, across any connected surface. Decisions made in Claude Code surface in Perplexity. Your decisions stay yours, not your platform's.
 
@@ -115,16 +126,17 @@ Free: unlimited local usage, unlimited projects, 5,000 remote MCP calls/month. A
 
 ## MCP tools
 
-11 tools (7 read, 4 write) exposed to any connected MCP client:
+12 tools (8 read, 4 write) exposed to any connected MCP client:
 
 **Read:**
-- `check_decision` — check a proposed approach for conflicts without writing (the centerpiece — call this before work that could conflict with project direction)
+- `check_decision` — check a proposed approach against existing decisions without writing (the centerpiece; agents are instructed to call this before any architectural change)
 - `get_context` — project summary at three detail levels (L0/L1/L2)
 - `list_decisions` — browse the full decision history
 - `get_decision` — full content of a specific decision by number
 - `search_decisions` — keyword search across decision titles and rationale (BM25)
 - `get_raw_file` — raw markdown content of any store file
 - `diff_since_last_session` — what changed since your last session (or N days ago)
+- `list_projects` — list projects you have access to (only needed when you have multiple — single-project users auto-resolve)
 
 **Write:**
 - `propose_decision` / `confirm_decision` — write decisions with conflict validation

--- a/packages/nauro/CLAUDE.md
+++ b/packages/nauro/CLAUDE.md
@@ -41,7 +41,9 @@ All files are freeform markdown. No database. No JSON for content — JSON only 
 - `nauro import --memory-bank <path>` — migrate a Cline/Roo Code Memory Bank
 - `nauro import --adr <path>` — migrate Architecture Decision Records
 
-## MCP tools (11 total — 7 read, 4 write)
+## MCP tools (12 total in `nauro_core.mcp_tools` — 8 read, 4 write)
+
+The local stdio server registers 11; `list_projects` is remote-only since local installs auto-resolve to the single project store.
 
 Read:
 - `get_context(project, level)` — L0 concise summary, L1 working set, L2 full dump
@@ -51,6 +53,7 @@ Read:
 - `diff_since_last_session(project, days)` — what changed since last session
 - `search_decisions(project, query, limit)` — keyword search across decisions
 - `check_decision(proposed_approach)` — check for conflicts without writing
+- `list_projects()` — list user's projects (remote-only)
 
 Write:
 - `propose_decision(project, title, rationale, ...)` — propose a decision for validation

--- a/packages/nauro/src/nauro/mcp/stdio_server.py
+++ b/packages/nauro/src/nauro/mcp/stdio_server.py
@@ -1,16 +1,20 @@
 """Nauro MCP server — stdio transport for Claude Code integration.
 
 Spawned by Claude Code at session start, communicates over stdin/stdout.
-Same tools as the HTTP server, same store, same payloads.
+Same store and payloads as the HTTP server.
 
 Tool metadata (descriptions, titles, annotations) is centralized in
 `nauro_core.mcp_tools` — edit there, not here — so the local stdio server
 and the remote HTTP server stay in sync.
 
-MCP tools (11 total — 7 read, 4 write):
+MCP tools registered here (11 — 7 read, 4 write):
   get_context, get_raw_file, list_decisions, get_decision,
   diff_since_last_session, search_decisions, check_decision,
   propose_decision, confirm_decision, flag_question, update_state
+
+The shared `nauro_core.mcp_tools.ALL_TOOLS` registry contains 12 tools.
+`list_projects` is remote-only — local installs auto-resolve to the
+single project store, so the discovery tool is not registered here.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

A pitch audit against the current code (post-D130, D131, D125) flagged several stale claims in `README.md` and the `CLAUDE.md` files. This PR brings the docs in line with what the code actually does. No code behavior changes.

- **Tool count.** `nauro_core.mcp_tools.ALL_TOOLS` defines 12 tools (8 read, 4 write). The local stdio server still registers 11 — `list_projects` is remote-only since local installs auto-resolve to the single project store. Updated the top-level `README.md`, both `CLAUDE.md` files, and the `stdio_server.py` docstring to spell this out instead of saying "11 / 7 / 4" globally.
- **Trust-model copy.** "You confirm before anything is written" overclaimed against the actual pipeline: `add` proposals with no BM25 overlap auto-confirm (D130), and the hosted server forces `pending_confirmation` only for `update` / `supersede` (D131). Replaced with operation-aware phrasing in two places in `README.md`.
- **`nauro adopt`.** The existing-repo bootstrap (D125 / D126 / D128) was not surfaced in the README. Added a section between "Use with your project" and "Use across surfaces."
- **Comparison table.** Added rows for memory tools (mem0, Letta, Zep) and platform memory (Copilot, Windsurf, Claude); new "What it captures" column names the decisional-depth moat from D092.
- **`check_decision` description.** Matched the "precondition before any architectural change" framing from `MCP_INSTRUCTIONS_STATIC`.

## Test plan

- [ ] Render `README.md` on GitHub and confirm the new "Adopt an existing repo" section and the updated compare table read cleanly
- [ ] Spot-check the four updated docs for consistency on the 12-tool framing
- [ ] Confirm `nauro adopt` description matches the current behavior of the CLI + skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)