### PR TITLE
fix(setup,scaffolds): gate user-scope teardown on registry + drop bracket-prompt scaffold

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/setup.py
+++ b/packages/nauro/src/nauro/cli/commands/setup.py
@@ -24,6 +24,8 @@ from nauro.store.registry import (
     RegistrySchemaError,
     get_project,
     get_project_v2,
+    load_registry,
+    load_registry_v2,
 )
 from nauro.templates.agents_md import regenerate_agents_md_for_project
 
@@ -70,6 +72,24 @@ def _find_nauro_command() -> str:
     """Find the full path to the nauro binary for the MCP config."""
     path = shutil.which("nauro")
     return path if path else "nauro"
+
+
+def _user_scope_safe_to_clear(current_project_key: str | None) -> bool:
+    """Return True iff no other nauro projects remain in the registry.
+
+    User-scope artifacts (``~/.claude/skills/nauro*``, ``~/.agents/skills/nauro*``,
+    and the ``nauro`` entry in ``~/.codex/config.toml``) are shared by every
+    registered project on the machine, so a per-project teardown must not
+    strip them while other projects still depend on them.
+    """
+    try:
+        registry = load_registry_v2()
+    except RegistrySchemaError:
+        registry = load_registry()
+    keys = set(registry.get("projects", {}).keys())
+    if current_project_key is not None:
+        keys.discard(current_project_key)
+    return not keys
 
 
 def _configure_mcp(repo_path: Path, *, remove: bool = False) -> str:
@@ -295,11 +315,27 @@ def _default_codex_config_path() -> Path:
     return Path.home() / ".codex" / "config.toml"
 
 
-def _configure_codex(*, remove: bool, config_path: Path | None = None) -> str:
-    """Add or remove the Nauro MCP entry in ``~/.codex/config.toml``."""
+def _configure_codex(
+    *,
+    remove: bool,
+    config_path: Path | None = None,
+    clear_user_scope: bool = True,
+) -> str:
+    """Add or remove the Nauro MCP entry in ``~/.codex/config.toml``.
+
+    ``clear_user_scope`` gates the remove path: when False, the codex MCP
+    entry is preserved because other registered nauro projects still depend
+    on it. Defaults to True so direct unit callers and the add path retain
+    their previous behavior.
+    """
     config_path = config_path or _default_codex_config_path()
     nauro_cmd = _find_nauro_command()
     nauro_entry = {"command": nauro_cmd, "args": ["serve", "--stdio"]}
+
+    if remove and not clear_user_scope:
+        return (
+            f"Codex: preserved nauro entry in {config_path} (other nauro projects still registered)"
+        )
 
     if config_path.exists():
         with config_path.open("rb") as f:
@@ -331,7 +367,11 @@ def codex(
     ),
 ) -> None:
     """Configure Codex CLI to use Nauro (writes ``~/.codex/config.toml``)."""
-    typer.echo(_configure_codex(remove=remove))
+    # Standalone codex wiring is user-global, so removing it without first
+    # tearing down the other projects would leave them pointed at a missing
+    # MCP entry. Gate on the registry: only the last project's teardown clears.
+    clear_user_scope = _user_scope_safe_to_clear(None) if remove else True
+    typer.echo(_configure_codex(remove=remove, clear_user_scope=clear_user_scope))
     if not remove:
         typer.echo("\nNext: run a Codex session — it reads ~/.codex/config.toml on start.")
 
@@ -381,11 +421,20 @@ def _remove_skill_file(target: Path, *, stop_above: Path) -> str:
     return f"  removed {target}"
 
 
-def materialize_skills_claude_code(*, remove: bool) -> list[str]:
-    """Install or remove the two Nauro skills under ``~/.claude/skills/``."""
+def materialize_skills_claude_code(*, remove: bool, clear_user_scope: bool = True) -> list[str]:
+    """Install or remove the two Nauro skills under ``~/.claude/skills/``.
+
+    ``clear_user_scope`` gates the remove path: when False, the skill files
+    are preserved because other registered nauro projects still depend on
+    them. Defaults to True so direct unit callers and the add path retain
+    their previous behavior.
+    """
     from nauro.skills import render_skill
 
     base = _claude_skill_dir()
+    if remove and not clear_user_scope:
+        return ["  preserved ~/.claude/skills/nauro* (other nauro projects still registered)"]
+
     results: list[str] = []
     for name in SKILL_NAMES:
         target = base / name / "SKILL.md"
@@ -396,11 +445,20 @@ def materialize_skills_claude_code(*, remove: bool) -> list[str]:
     return results
 
 
-def materialize_skills_codex(*, remove: bool) -> list[str]:
-    """Install or remove the two Nauro skills under ``~/.agents/skills/``."""
+def materialize_skills_codex(*, remove: bool, clear_user_scope: bool = True) -> list[str]:
+    """Install or remove the two Nauro skills under ``~/.agents/skills/``.
+
+    ``clear_user_scope`` gates the remove path: when False, the skill files
+    are preserved because other registered nauro projects still depend on
+    them. Defaults to True so direct unit callers and the add path retain
+    their previous behavior.
+    """
     from nauro.skills import render_skill
 
     base = _codex_skill_dir()
+    if remove and not clear_user_scope:
+        return ["  preserved ~/.agents/skills/nauro* (other nauro projects still registered)"]
+
     results: list[str] = []
     for name in SKILL_NAMES:
         target = base / name / "SKILL.md"
@@ -429,12 +487,25 @@ def materialize_skills_cursor_for_repo(repo: Path, *, remove: bool) -> list[str]
 # ─── nauro setup all ────────────────────────────────────────────────────────
 
 
-def setup_all_surfaces(project_repos: list[Path], *, remove: bool = False) -> list[str]:
+def setup_all_surfaces(
+    project_repos: list[Path],
+    *,
+    remove: bool = False,
+    current_project_key: str | None = None,
+) -> list[str]:
     """Wire MCP and materialize skills across Claude Code, Cursor, Codex.
 
     Continues across per-handler errors so partial coverage still reports
     progress. Returns the cumulative status lines.
+
+    ``current_project_key`` is the registry key (v2 id or v1 name) for the
+    project being torn down. When ``remove=True``, it is excluded from the
+    "are there other projects?" check so per-project teardown only clears
+    user-scope artifacts (Claude/Codex skills, ``~/.codex/config.toml``)
+    when this is the last project on the machine.
     """
+    clear_user_scope = _user_scope_safe_to_clear(current_project_key) if remove else True
+
     lines: list[str] = []
 
     # Claude Code (MCP per-repo via `claude mcp add --scope project` + skills global)
@@ -447,7 +518,9 @@ def setup_all_surfaces(project_repos: list[Path], *, remove: bool = False) -> li
         except Exception as exc:
             lines.append(f"Claude Code MCP ({repo}): error — {exc}")
     try:
-        lines.extend(materialize_skills_claude_code(remove=remove))
+        lines.extend(
+            materialize_skills_claude_code(remove=remove, clear_user_scope=clear_user_scope)
+        )
     except Exception as exc:
         lines.append(f"Claude Code skills: error — {exc}")
 
@@ -466,11 +539,11 @@ def setup_all_surfaces(project_repos: list[Path], *, remove: bool = False) -> li
 
     # Codex (MCP global + skills global)
     try:
-        lines.append(_configure_codex(remove=remove))
+        lines.append(_configure_codex(remove=remove, clear_user_scope=clear_user_scope))
     except Exception as exc:
         lines.append(f"Codex MCP: error — {exc}")
     try:
-        lines.extend(materialize_skills_codex(remove=remove))
+        lines.extend(materialize_skills_codex(remove=remove, clear_user_scope=clear_user_scope))
     except Exception as exc:
         lines.append(f"Codex skills: error — {exc}")
 
@@ -504,5 +577,5 @@ def all_(
     project_repos = [Path(rp) for rp in entry["repo_paths"]]
     action = "Removed" if remove else "Configured"
     typer.echo(f"{action} Nauro for project '{project_name}' across all surfaces:\n")
-    for line in setup_all_surfaces(project_repos, remove=remove):
+    for line in setup_all_surfaces(project_repos, remove=remove, current_project_key=project_key):
         typer.echo(line)

--- a/packages/nauro/src/nauro/templates/scaffolds.py
+++ b/packages/nauro/src/nauro/templates/scaffolds.py
@@ -46,12 +46,9 @@ is useful. "Users" is not.]
 """
 
 STATE_CURRENT_MD = """\
-# State
+# Current State
 
-## Current
-[What you're working on right now — e.g. "Building user auth flow, blocked on Stripe API approval"]
-
-## History
+_(No state recorded yet — call update_state to capture progress.)_
 """
 
 STACK_MD = """\

--- a/packages/nauro/tests/test_setup_extended.py
+++ b/packages/nauro/tests/test_setup_extended.py
@@ -275,3 +275,102 @@ def test_remove_skill_file_preserves_sibling_skills(tmp_path: Path):
     assert not nauro_skill.parent.exists()  # nauro subdir pruned
     assert other_skill.exists()  # other skill untouched
     assert base.is_dir()
+
+
+# ─── multi-project remove gating ────────────────────────────────────────────
+
+
+def test_remove_preserves_user_scope_when_other_projects_exist(tmp_path: Path, monkeypatch):
+    """``setup all --remove`` for one project must not strip the user-scope
+    Claude/Codex skills or the codex MCP entry while another nauro project
+    remains in the registry — those resources are shared."""
+    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo_a = tmp_path / "repo_a"
+    repo_b = tmp_path / "repo_b"
+    repo_a.mkdir()
+    repo_b.mkdir()
+    _, store_a = register_project_v2("proj-a", [repo_a])
+    scaffold_project_store("proj-a", store_a)
+    _, store_b = register_project_v2("proj-b", [repo_b])
+    scaffold_project_store("proj-b", store_b)
+    _mock_claude_cli(monkeypatch)
+
+    monkeypatch.chdir(repo_a)
+    runner.invoke(app, ["setup", "all", "--project", "proj-a"])
+    monkeypatch.chdir(repo_b)
+    runner.invoke(app, ["setup", "all", "--project", "proj-b"])
+
+    monkeypatch.chdir(repo_a)
+    result = runner.invoke(app, ["setup", "all", "--project", "proj-a", "--remove"])
+    assert result.exit_code == 0, result.output
+
+    # User-scope artifacts preserved — proj-b still depends on them.
+    assert (tmp_path / ".claude" / "skills" / "nauro" / "SKILL.md").is_file()
+    assert (tmp_path / ".claude" / "skills" / "nauro-adopt" / "SKILL.md").is_file()
+    assert (tmp_path / ".agents" / "skills" / "nauro" / "SKILL.md").is_file()
+    assert (tmp_path / ".agents" / "skills" / "nauro-adopt" / "SKILL.md").is_file()
+
+    codex_config = tmp_path / ".codex" / "config.toml"
+    assert codex_config.is_file()
+    with codex_config.open("rb") as f:
+        data = tomllib.load(f)
+    assert data["mcp_servers"]["nauro"]["args"] == ["serve", "--stdio"]
+
+    # Per-repo wiring for proj-a still got torn down.
+    assert not (repo_a / ".cursor" / "mcp.json").is_file()
+    assert not (repo_a / ".cursor" / "rules" / "nauro.mdc").is_file()
+    # And proj-b's per-repo wiring stayed put.
+    assert (repo_b / ".cursor" / "mcp.json").is_file()
+    assert (repo_b / ".cursor" / "rules" / "nauro.mdc").is_file()
+
+
+def test_remove_clears_user_scope_when_last_project(tmp_path: Path, monkeypatch):
+    """When removing the last project, the user-scope skill files and the
+    codex MCP entry are fully cleared — nothing depends on them anymore."""
+    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    _, store_path = register_project_v2("solo", [repo])
+    scaffold_project_store("solo", store_path)
+    monkeypatch.chdir(repo)
+    _mock_claude_cli(monkeypatch)
+
+    runner.invoke(app, ["setup", "all"])
+    result = runner.invoke(app, ["setup", "all", "--remove"])
+    assert result.exit_code == 0, result.output
+
+    assert not (tmp_path / ".claude" / "skills" / "nauro" / "SKILL.md").exists()
+    assert not (tmp_path / ".claude" / "skills" / "nauro-adopt" / "SKILL.md").exists()
+    assert not (tmp_path / ".agents" / "skills" / "nauro" / "SKILL.md").exists()
+    assert not (tmp_path / ".agents" / "skills" / "nauro-adopt" / "SKILL.md").exists()
+
+    codex_config = tmp_path / ".codex" / "config.toml"
+    if codex_config.is_file():
+        with codex_config.open("rb") as f:
+            data = tomllib.load(f)
+        assert "nauro" not in data.get("mcp_servers", {})
+
+
+def test_standalone_codex_remove_preserves_when_projects_remain(tmp_path: Path, monkeypatch):
+    """``nauro setup codex --remove`` must not strip ``~/.codex/config.toml``'s
+    nauro entry while any projects remain in the registry. The standalone
+    command is user-global; preservation guards still-active projects."""
+    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    register_project_v2("still-here", [repo])
+
+    runner.invoke(app, ["setup", "codex"])
+    codex_config = tmp_path / ".codex" / "config.toml"
+    assert codex_config.is_file()
+
+    result = runner.invoke(app, ["setup", "codex", "--remove"])
+    assert result.exit_code == 0, result.output
+    assert "preserved nauro entry" in result.output
+
+    with codex_config.open("rb") as f:
+        data = tomllib.load(f)
+    assert data["mcp_servers"]["nauro"]["args"] == ["serve", "--stdio"]


### PR DESCRIPTION
## Why

Two post-PR-#33 dogfood survivors:

- `nauro setup --remove` (and `setup all --remove`) unconditionally cleared `~/.claude/skills/nauro*`, `~/.agents/skills/nauro*`, and the `nauro` entry in `~/.codex/config.toml`. Those user-scope artifacts are shared across every nauro project on the machine, so per-project teardown broke any other still-registered project.
- `scaffolds.py`'s `STATE_CURRENT_MD` shipped `# State / ## Current / [What you're working on right now ...]`, which (1) leaked a bracket prompt into every fresh adopt's L0 payload and (2) didn't match the `# Current State` heading `prepare_state_update` emits.

## Approach

- New `_user_scope_safe_to_clear(current_project_key)` consults the v2 (or v1 fallback) registry. Threaded as `clear_user_scope` through `materialize_skills_claude_code`, `materialize_skills_codex`, and `_configure_codex`. Computed once inside `setup_all_surfaces` and the standalone `setup codex` command.
- Defaults preserve direct unit-test behavior (`clear_user_scope=True`).
- Per-repo wiring (`<repo>/.mcp.json`, `<repo>/.cursor/...`) is unaffected.
- `STATE_CURRENT_MD` replaced with a neutral placeholder under the matching `# Current State` heading.

## What changed

- `packages/nauro/src/nauro/cli/commands/setup.py` — `_user_scope_safe_to_clear` helper, `clear_user_scope` plumbing, gated removes.
- `packages/nauro/src/nauro/templates/scaffolds.py` — `STATE_CURRENT_MD` rewrite.
- `packages/nauro/tests/test_setup_extended.py` — three new tests.

## What to review

- Whether `_user_scope_safe_to_clear` belongs in `setup.py` or `registry.py` — currently kept local since it's setup-specific safety logic.
- The "preserved …" status line wording on the remove path.

## What's deferred

Remaining post-PR-#33 dogfood survivors: A (skill-body drift), D (sync-staleness state regression), E (S3 supersede atomicity discussion), F (nauro-core 0.6.0 PyPI publish chore).

## Test plan

- [x] \`uv run python -m pytest packages/nauro/tests/ -x -q -m "not integration"\` — 663 passed
- [x] \`uv run python -m pytest packages/nauro-core/tests/ -x -q\` — 249 passed
- [x] \`uv run ruff check packages/\` — clean
- [x] \`uv run ruff format --check packages/\` — clean