### PR TITLE
fix(skills): align session/adopt bodies with D124/D129/D130/D131

### DIFF
--- a/.agents/skills/nauro-adopt/SKILL.md
+++ b/.agents/skills/nauro-adopt/SKILL.md
@@ -41,7 +41,7 @@ Chat-paste mode does not create projects.
 
 ## Step 4 — Call get_context
 
-The agent calls `get_context` (MCP) to surface what the scaffold already wrote — `001-initial-setup.md` and bracketed-prompt placeholders in `project.md` / `stack.md` / `state_current.md`. The agent uses this to (a) avoid duplicating the scaffold's first decision, (b) confirm the project resolved correctly.
+The agent calls `get_context` (MCP) to surface what the scaffold already wrote — `001-initial-setup.md` and bracketed-prompt placeholders in `project.md` / `stack.md`. The agent uses this to (a) avoid duplicating the scaffold's first decision, (b) confirm the project resolved correctly.
 
 ## Step 5 — Build candidate list, surface FIRST
 
@@ -59,7 +59,7 @@ The agent triages the source content into two lists.
 
 For each kept item from 5a (and each opt-in from 5b):
 
-1. Call `propose_decision(title, rationale, rejected, confidence)`. `rationale` is drawn from explicit source text (or user-provided for opt-ins). `confidence` defaults to `medium`; `high` only when the source explicitly says "accepted" or "approved". Rejected alternatives are included only when the source names them.
+1. Call `propose_decision(title=..., rationale=..., operation="add", rejected=..., confidence=...)`. Adopt seeds the store from source documents, so it normally uses `operation="add"` and does not set `affected_decision_id`. `rationale` is drawn from explicit source text or user-provided opt-ins. `confidence` defaults to `medium`; use `high` only when the source explicitly says "accepted" or "approved". Include rejected alternatives only when the source names them.
 2. **If `propose_decision` returns no conflicts**: call `confirm_decision(confirm_id)` automatically — no further user prompt.
 3. **If `propose_decision` returns conflicts**: surface the conflict text verbatim, ask `confirm-anyway / edit / skip`. On user 'confirm' → `confirm_decision(confirm_id)`.
 

--- a/.agents/skills/nauro/SKILL.md
+++ b/.agents/skills/nauro/SKILL.md
@@ -13,7 +13,7 @@ The agent calls `get_context` early in the session, before the first user-driven
 
 ## Before any architectural change — call check_decision
 
-When the user proposes — or the agent considers proposing — an architectural change (library swap, API redesign, data model change, infrastructure pick, new pattern), the agent calls `check_decision(proposed_approach)` first. The tool returns related decisions via BM25 retrieval and an LLM-based conflict assessment. If conflicts surface: the agent shows them to the user verbatim before recommending the change. If no conflicts and the choice is real: the agent records it via `propose_decision` + `confirm_decision`.
+When the user proposes — or the agent considers proposing — an architectural change (library swap, API redesign, data model change, infrastructure pick, new pattern), the agent calls `check_decision(proposed_approach)` first. The tool returns related decisions via BM25 retrieval and a deterministic assessment. `check_decision` does not judge conflicts for the agent — when the response lists related decisions, the agent calls `get_decision` on each one before deciding whether to proceed. If conflicts surface: the agent shows them to the user verbatim before recommending the change. If no conflicts and the choice is real: the agent records it via `propose_decision` + `confirm_decision`.
 
 This includes "should we…", "what if we…", "can we…", and "check if…" framings, and applies even when the agent intends to push back or refuse. First-principles reasoning is not a substitute for project history.
 

--- a/.claude/skills/nauro-adopt/SKILL.md
+++ b/.claude/skills/nauro-adopt/SKILL.md
@@ -41,7 +41,7 @@ Chat-paste mode does not create projects.
 
 ## Step 4 — Call get_context
 
-The agent calls `get_context` (MCP) to surface what the scaffold already wrote — `001-initial-setup.md` and bracketed-prompt placeholders in `project.md` / `stack.md` / `state_current.md`. The agent uses this to (a) avoid duplicating the scaffold's first decision, (b) confirm the project resolved correctly.
+The agent calls `get_context` (MCP) to surface what the scaffold already wrote — `001-initial-setup.md` and bracketed-prompt placeholders in `project.md` / `stack.md`. The agent uses this to (a) avoid duplicating the scaffold's first decision, (b) confirm the project resolved correctly.
 
 ## Step 5 — Build candidate list, surface FIRST
 
@@ -59,7 +59,7 @@ The agent triages the source content into two lists.
 
 For each kept item from 5a (and each opt-in from 5b):
 
-1. Call `propose_decision(title, rationale, rejected, confidence)`. `rationale` is drawn from explicit source text (or user-provided for opt-ins). `confidence` defaults to `medium`; `high` only when the source explicitly says "accepted" or "approved". Rejected alternatives are included only when the source names them.
+1. Call `propose_decision(title=..., rationale=..., operation="add", rejected=..., confidence=...)`. Adopt seeds the store from source documents, so it normally uses `operation="add"` and does not set `affected_decision_id`. `rationale` is drawn from explicit source text or user-provided opt-ins. `confidence` defaults to `medium`; use `high` only when the source explicitly says "accepted" or "approved". Include rejected alternatives only when the source names them.
 2. **If `propose_decision` returns no conflicts**: call `confirm_decision(confirm_id)` automatically — no further user prompt.
 3. **If `propose_decision` returns conflicts**: surface the conflict text verbatim, ask `confirm-anyway / edit / skip`. On user 'confirm' → `confirm_decision(confirm_id)`.
 

--- a/.claude/skills/nauro/SKILL.md
+++ b/.claude/skills/nauro/SKILL.md
@@ -13,7 +13,7 @@ The agent calls `get_context` early in the session, before the first user-driven
 
 ## Before any architectural change — call check_decision
 
-When the user proposes — or the agent considers proposing — an architectural change (library swap, API redesign, data model change, infrastructure pick, new pattern), the agent calls `check_decision(proposed_approach)` first. The tool returns related decisions via BM25 retrieval and an LLM-based conflict assessment. If conflicts surface: the agent shows them to the user verbatim before recommending the change. If no conflicts and the choice is real: the agent records it via `propose_decision` + `confirm_decision`.
+When the user proposes — or the agent considers proposing — an architectural change (library swap, API redesign, data model change, infrastructure pick, new pattern), the agent calls `check_decision(proposed_approach)` first. The tool returns related decisions via BM25 retrieval and a deterministic assessment. `check_decision` does not judge conflicts for the agent — when the response lists related decisions, the agent calls `get_decision` on each one before deciding whether to proceed. If conflicts surface: the agent shows them to the user verbatim before recommending the change. If no conflicts and the choice is real: the agent records it via `propose_decision` + `confirm_decision`.
 
 This includes "should we…", "what if we…", "can we…", and "check if…" framings, and applies even when the agent intends to push back or refuse. First-principles reasoning is not a substitute for project history.
 

--- a/.cursor/rules/nauro-adopt.mdc
+++ b/.cursor/rules/nauro-adopt.mdc
@@ -41,7 +41,7 @@ Chat-paste mode does not create projects.
 
 ## Step 4 — Call get_context
 
-The agent calls `get_context` (MCP) to surface what the scaffold already wrote — `001-initial-setup.md` and bracketed-prompt placeholders in `project.md` / `stack.md` / `state_current.md`. The agent uses this to (a) avoid duplicating the scaffold's first decision, (b) confirm the project resolved correctly.
+The agent calls `get_context` (MCP) to surface what the scaffold already wrote — `001-initial-setup.md` and bracketed-prompt placeholders in `project.md` / `stack.md`. The agent uses this to (a) avoid duplicating the scaffold's first decision, (b) confirm the project resolved correctly.
 
 ## Step 5 — Build candidate list, surface FIRST
 
@@ -59,7 +59,7 @@ The agent triages the source content into two lists.
 
 For each kept item from 5a (and each opt-in from 5b):
 
-1. Call `propose_decision(title, rationale, rejected, confidence)`. `rationale` is drawn from explicit source text (or user-provided for opt-ins). `confidence` defaults to `medium`; `high` only when the source explicitly says "accepted" or "approved". Rejected alternatives are included only when the source names them.
+1. Call `propose_decision(title=..., rationale=..., operation="add", rejected=..., confidence=...)`. Adopt seeds the store from source documents, so it normally uses `operation="add"` and does not set `affected_decision_id`. `rationale` is drawn from explicit source text or user-provided opt-ins. `confidence` defaults to `medium`; use `high` only when the source explicitly says "accepted" or "approved". Include rejected alternatives only when the source names them.
 2. **If `propose_decision` returns no conflicts**: call `confirm_decision(confirm_id)` automatically — no further user prompt.
 3. **If `propose_decision` returns conflicts**: surface the conflict text verbatim, ask `confirm-anyway / edit / skip`. On user 'confirm' → `confirm_decision(confirm_id)`.
 

--- a/.cursor/rules/nauro.mdc
+++ b/.cursor/rules/nauro.mdc
@@ -13,7 +13,7 @@ The agent calls `get_context` early in the session, before the first user-driven
 
 ## Before any architectural change — call check_decision
 
-When the user proposes — or the agent considers proposing — an architectural change (library swap, API redesign, data model change, infrastructure pick, new pattern), the agent calls `check_decision(proposed_approach)` first. The tool returns related decisions via BM25 retrieval and an LLM-based conflict assessment. If conflicts surface: the agent shows them to the user verbatim before recommending the change. If no conflicts and the choice is real: the agent records it via `propose_decision` + `confirm_decision`.
+When the user proposes — or the agent considers proposing — an architectural change (library swap, API redesign, data model change, infrastructure pick, new pattern), the agent calls `check_decision(proposed_approach)` first. The tool returns related decisions via BM25 retrieval and a deterministic assessment. `check_decision` does not judge conflicts for the agent — when the response lists related decisions, the agent calls `get_decision` on each one before deciding whether to proceed. If conflicts surface: the agent shows them to the user verbatim before recommending the change. If no conflicts and the choice is real: the agent records it via `propose_decision` + `confirm_decision`.
 
 This includes "should we…", "what if we…", "can we…", and "check if…" framings, and applies even when the agent intends to push back or refuse. First-principles reasoning is not a substitute for project history.
 

--- a/docs/adopt-prompt.md
+++ b/docs/adopt-prompt.md
@@ -57,7 +57,7 @@ Chat-paste mode does not create projects.
 
 ## Step 4 — Call get_context
 
-The agent calls `get_context` (MCP) to surface what the scaffold already wrote — `001-initial-setup.md` and bracketed-prompt placeholders in `project.md` / `stack.md` / `state_current.md`. The agent uses this to (a) avoid duplicating the scaffold's first decision, (b) confirm the project resolved correctly.
+The agent calls `get_context` (MCP) to surface what the scaffold already wrote — `001-initial-setup.md` and bracketed-prompt placeholders in `project.md` / `stack.md`. The agent uses this to (a) avoid duplicating the scaffold's first decision, (b) confirm the project resolved correctly.
 
 ## Step 5 — Build candidate list, surface FIRST
 
@@ -75,7 +75,7 @@ The agent triages the source content into two lists.
 
 For each kept item from 5a (and each opt-in from 5b):
 
-1. Call `propose_decision(title, rationale, rejected, confidence)`. `rationale` is drawn from explicit source text (or user-provided for opt-ins). `confidence` defaults to `medium`; `high` only when the source explicitly says "accepted" or "approved". Rejected alternatives are included only when the source names them.
+1. Call `propose_decision(title=..., rationale=..., operation="add", rejected=..., confidence=...)`. Adopt seeds the store from source documents, so it normally uses `operation="add"` and does not set `affected_decision_id`. `rationale` is drawn from explicit source text or user-provided opt-ins. `confidence` defaults to `medium`; use `high` only when the source explicitly says "accepted" or "approved". Include rejected alternatives only when the source names them.
 2. **If `propose_decision` returns no conflicts**: call `confirm_decision(confirm_id)` automatically — no further user prompt.
 3. **If `propose_decision` returns conflicts**: surface the conflict text verbatim, ask `confirm-anyway / edit / skip`. On user 'confirm' → `confirm_decision(confirm_id)`.
 

--- a/packages/nauro/src/nauro/skills/adopt_body.md
+++ b/packages/nauro/src/nauro/skills/adopt_body.md
@@ -36,7 +36,7 @@ Chat-paste mode does not create projects.
 
 ## Step 4 — Call get_context
 
-The agent calls `get_context` (MCP) to surface what the scaffold already wrote — `001-initial-setup.md` and bracketed-prompt placeholders in `project.md` / `stack.md` / `state_current.md`. The agent uses this to (a) avoid duplicating the scaffold's first decision, (b) confirm the project resolved correctly.
+The agent calls `get_context` (MCP) to surface what the scaffold already wrote — `001-initial-setup.md` and bracketed-prompt placeholders in `project.md` / `stack.md`. The agent uses this to (a) avoid duplicating the scaffold's first decision, (b) confirm the project resolved correctly.
 
 ## Step 5 — Build candidate list, surface FIRST
 
@@ -54,7 +54,7 @@ The agent triages the source content into two lists.
 
 For each kept item from 5a (and each opt-in from 5b):
 
-1. Call `propose_decision(title, rationale, rejected, confidence)`. `rationale` is drawn from explicit source text (or user-provided for opt-ins). `confidence` defaults to `medium`; `high` only when the source explicitly says "accepted" or "approved". Rejected alternatives are included only when the source names them.
+1. Call `propose_decision(title=..., rationale=..., operation="add", rejected=..., confidence=...)`. Adopt seeds the store from source documents, so it normally uses `operation="add"` and does not set `affected_decision_id`. `rationale` is drawn from explicit source text or user-provided opt-ins. `confidence` defaults to `medium`; use `high` only when the source explicitly says "accepted" or "approved". Include rejected alternatives only when the source names them.
 2. **If `propose_decision` returns no conflicts**: call `confirm_decision(confirm_id)` automatically — no further user prompt.
 3. **If `propose_decision` returns conflicts**: surface the conflict text verbatim, ask `confirm-anyway / edit / skip`. On user 'confirm' → `confirm_decision(confirm_id)`.
 

--- a/packages/nauro/src/nauro/skills/session_body.md
+++ b/packages/nauro/src/nauro/skills/session_body.md
@@ -8,7 +8,7 @@ The agent calls `get_context` early in the session, before the first user-driven
 
 ## Before any architectural change — call check_decision
 
-When the user proposes — or the agent considers proposing — an architectural change (library swap, API redesign, data model change, infrastructure pick, new pattern), the agent calls `check_decision(proposed_approach)` first. The tool returns related decisions via BM25 retrieval and an LLM-based conflict assessment. If conflicts surface: the agent shows them to the user verbatim before recommending the change. If no conflicts and the choice is real: the agent records it via `propose_decision` + `confirm_decision`.
+When the user proposes — or the agent considers proposing — an architectural change (library swap, API redesign, data model change, infrastructure pick, new pattern), the agent calls `check_decision(proposed_approach)` first. The tool returns related decisions via BM25 retrieval and a deterministic assessment. `check_decision` does not judge conflicts for the agent — when the response lists related decisions, the agent calls `get_decision` on each one before deciding whether to proceed. If conflicts surface: the agent shows them to the user verbatim before recommending the change. If no conflicts and the choice is real: the agent records it via `propose_decision` + `confirm_decision`.
 
 This includes "should we…", "what if we…", "can we…", and "check if…" framings, and applies even when the agent intends to push back or refuse. First-principles reasoning is not a substitute for project history.
 

--- a/packages/nauro/tests/test_skills_drift.py
+++ b/packages/nauro/tests/test_skills_drift.py
@@ -103,3 +103,47 @@ def test_docs_adopt_prompt_contains_canonical_body():
         "docs/adopt-prompt.md does not contain load_adopt_body() — re-append "
         "or update the intro to keep the canonical body in sync."
     )
+
+
+# --- Retired phrases must not reappear in skill / docs surfaces ---
+#
+# Anchored to D124/D129/D130/D131 + PR #38. Scope is narrow on purpose: the two
+# canonical skill bodies plus ``docs/adopt-prompt.md``. The six dogfood files are
+# chained to the source bodies via ``test_dogfood_file_matches_render_skill``.
+
+RETIRED_PHRASES = [
+    ("LLM-based", "D130 removed Tier 3 LLM validation"),
+    ("Tier 3", "D130 removed Tier 3 LLM validation"),
+    ("nauro extract", "D129 retired the extract command"),
+    ("[extraction]", "D129 retired the [extraction] extra"),
+    ("Anthropic SDK", "D129 dropped Anthropic SDK as a runtime dep"),
+    ("Python 3.11+", "D124 lowered the Python floor to 3.10"),
+    (
+        "propose_decision(title, rationale, rejected,",
+        "D131 made propose_decision operation-aware; rejected/confidence are no longer positional",
+    ),
+    (
+        "bracketed-prompt placeholders in `project.md` / `stack.md` / `state_current.md`",
+        "PR #38 removed bracket-prompt scaffolding from state_current.md",
+    ),
+]
+
+
+def _load_docs_adopt_prompt() -> str:
+    return (REPO_ROOT / "docs" / "adopt-prompt.md").read_text(encoding="utf-8")
+
+
+SCANNED_SURFACES = [
+    ("session_body.md", load_session_body),
+    ("adopt_body.md", load_adopt_body),
+    ("docs/adopt-prompt.md", _load_docs_adopt_prompt),
+]
+
+
+@pytest.mark.parametrize("surface_name,loader", SCANNED_SURFACES)
+@pytest.mark.parametrize("phrase,reason", RETIRED_PHRASES)
+def test_skill_surface_has_no_retired_phrases(
+    surface_name: str, loader, phrase: str, reason: str
+) -> None:
+    content = loader()
+    assert phrase not in content, f"retired phrase {phrase!r} found in {surface_name}: {reason}"


### PR DESCRIPTION
## Why

PR #38's deferred list flagged "A (skill-body drift)" — the canonical session + adopt bodies (and their six rendered dogfood files + `docs/adopt-prompt.md`) still teach behavior that recent decisions superseded:

- **D130** retired Tier 3 LLM validation. `check_decision` returns a deterministic assessment over BM25 hits; the calling agent judges conflicts.
- **D131** made `propose_decision` operation-aware (`operation` + `affected_decision_id`); `rejected` and `confidence` are no longer the 3rd/4th positional args.
- **PR #38** removed bracket-prompt scaffolding from `state_current.md`, so adopt's Step 4 list was stale.

Agents reading the current skills are told two false signatures — exactly the failure mode Nauro is supposed to prevent.

## Approach

Edit the two canonical source bodies, re-render the six dogfood files via the existing `render_skill()` mechanism, and hand-apply the same edits to `docs/adopt-prompt.md`'s embedded body (intro untouched). Add a narrow CI test that scans the three instruction surfaces for specific retired phrases — anchored on the decisions, not broad word patterns, so legitimate test commentary and historical fixtures stay untouched.

Deliberately out of scope: no redesign of the adopt flow, no change to `propose_decision` semantics, no broader phrase-scan across the repo.

## What changed

- `packages/nauro/src/nauro/skills/session_body.md` — `check_decision` paragraph now mirrors `MCP_INSTRUCTIONS_STATIC` (deterministic assessment; agent reads `get_decision` to judge).
- `packages/nauro/src/nauro/skills/adopt_body.md` — Step 4 drops `state_current.md` from the bracket-prompt list; Step 6 propose_decision example uses operation-aware keyword args and explains adopt is additive.
- `.claude/skills/*`, `.cursor/rules/*`, `.agents/skills/*` (6 files) — re-rendered via `render_skill()`.
- `docs/adopt-prompt.md` — same two edits in the embedded body.
- `packages/nauro/tests/test_skills_drift.py` — new `test_skill_surface_has_no_retired_phrases` (24 cases: 8 retired phrases × 3 surfaces).

## What to review

- Wording of the adopt Step 6 example — "Adopt seeds the store from source documents, so it normally uses `operation='add'` …" is intended as guidance, not a hard rule. Push back if it reads as the latter.
- Whether `docs/adopt-prompt.md` belongs in the retired-phrases scan. Including it defends the hand-written intro; the body section is already chained to `load_adopt_body()` via the existing test.
- Phrase list scope: kept narrow (e.g., `"Anthropic SDK"` only scans the three instruction surfaces). Test commentary in `test_validation_is_anthropic_free.py` and historical fixtures in `test_context.py` are intentionally untouched.

## What's deferred

- Store-side drift in `~/.nauro/projects/nauro/stack.md` (Python 3.11+, Anthropic SDK referenced for extraction). Lives outside the repo per the architectural fact; needs a direct edit out-of-band. `update_state` would not fix it — it writes `state_current.md`, not `stack.md`.
- Other PR #38 deferred items (D sync-staleness, E S3 supersede atomicity, F nauro-core 0.6.0 PyPI chore) — unchanged scope.

## Test plan

- [x] `uv run pytest packages/nauro/tests/test_skills_drift.py -x -q` — 37 passed (13 existing + 24 new parametrized)
- [x] `uv run pytest packages/nauro/tests/ -x -q -m "not integration"` — 687 passed
- [x] `uv run ruff check packages/` — clean
- [x] `uv run ruff format --check packages/` — clean
- [x] Manual grep for the 8 retired phrases across `packages/nauro/src/nauro/skills/`, `.claude/`, `.cursor/`, `.agents/`, `docs/adopt-prompt.md` — no matches