### PR TITLE
fix(sync): stop writing snapshot label into state_current.md

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/sync.py
+++ b/packages/nauro/src/nauro/cli/commands/sync.py
@@ -13,7 +13,6 @@ from nauro.store.registry import (
 )
 from nauro.store.snapshot import capture_snapshot
 from nauro.store.validator import print_warnings, validate_store
-from nauro.store.writer import update_state
 from nauro.templates.agents_md import regenerate_agents_md_for_project
 
 logger = logging.getLogger("nauro.sync")
@@ -63,7 +62,6 @@ def sync(
     _pull_from_cloud(project_key, store_path)
 
     version = capture_snapshot(store_path, trigger=trigger)
-    update_state(store_path, f"Snapshot v{version:03d}: {trigger}")
 
     # Warn about missing repo paths before regenerating
     for repo_str in _registry_repo_paths(project_key):

--- a/packages/nauro/src/nauro/cli/commands/sync.py
+++ b/packages/nauro/src/nauro/cli/commands/sync.py
@@ -1,4 +1,4 @@
-"""nauro sync — Capture a snapshot and update state."""
+"""nauro sync — Capture a snapshot and regenerate AGENTS.md in associated repos."""
 
 import logging
 from pathlib import Path
@@ -44,7 +44,12 @@ def sync(
     ),
     status: bool = typer.Option(False, "--status", help="Show sync status."),
 ) -> None:
-    """Capture a snapshot and update the project state."""
+    """Capture a snapshot and regenerate AGENTS.md in each associated repo.
+
+    With cloud sync configured, pulls from S3 first (git-style pull-then-push),
+    then pushes the updated store back. Project state in state_current.md is
+    not touched — use the MCP `update_state` tool to record what changed.
+    """
     if cloud_setup:
         _cloud_setup_wizard()
         return

--- a/packages/nauro/tests/test_sync/test_sync_command.py
+++ b/packages/nauro/tests/test_sync/test_sync_command.py
@@ -120,3 +120,86 @@ class TestSyncPullNoConfig:
 
         result = _pull_from_cloud("testproj", project_store)
         assert result == 0
+
+
+class TestSyncPreservesState:
+    """Regression: sync must not write snapshot labels into state files."""
+
+    RICH_STATE = "Sprint 5: shipping feature X.\nBlockers: none.\nNext: write release notes."
+
+    def _seed_rich_state(self, store):
+        from nauro.store.writer import update_state
+
+        update_state(store, self.RICH_STATE)
+
+    def _read_state_files(self, store):
+        from nauro.constants import STATE_CURRENT_FILENAME, STATE_HISTORY_FILENAME
+
+        current = (store / STATE_CURRENT_FILENAME).read_text()
+        history_path = store / STATE_HISTORY_FILENAME
+        history = history_path.read_text() if history_path.exists() else ""
+        return current, history
+
+    def test_rich_state_survives_repeated_sync(self, project_store):
+        """Repeated `nauro sync` must leave rich state_current.md intact and keep
+        snapshot labels out of state_history.md."""
+        from nauro.store.snapshot import list_snapshots
+
+        self._seed_rich_state(project_store)
+        baseline_snapshots = len(list_snapshots(project_store))
+
+        for _ in range(3):
+            result = runner.invoke(app, ["sync"])
+            assert result.exit_code == 0, result.output
+
+        current, history = self._read_state_files(project_store)
+
+        assert "Sprint 5: shipping feature X." in current
+        assert "Blockers: none." in current
+        assert "Snapshot v" not in current
+        assert "manual sync" not in current
+        assert "Snapshot v" not in history
+        assert "manual sync" not in history
+
+        snapshots = list_snapshots(project_store)
+        assert len(snapshots) - baseline_snapshots == 3
+        assert snapshots[0]["trigger"] == "manual sync"
+
+    def test_custom_message_routes_to_snapshot_only(self, project_store):
+        """`-m <msg>` must land in snapshot metadata, never in state files."""
+        from nauro.store.snapshot import list_snapshots
+
+        self._seed_rich_state(project_store)
+
+        result = runner.invoke(app, ["sync", "-m", "release-prep"])
+        assert result.exit_code == 0, result.output
+
+        current, history = self._read_state_files(project_store)
+
+        assert "Sprint 5: shipping feature X." in current
+        assert "release-prep" not in current
+        assert "release-prep" not in history
+
+        snapshots = list_snapshots(project_store)
+        assert snapshots[0]["trigger"] == "release-prep"
+
+    def test_legitimate_state_rotation_still_works(self, project_store):
+        """Sanity check: update_state() calls between syncs still archive prior
+        state into state_history.md — sync just stops doing this itself."""
+        from nauro.store.writer import update_state
+
+        self._seed_rich_state(project_store)
+
+        result = runner.invoke(app, ["sync"])
+        assert result.exit_code == 0, result.output
+
+        update_state(project_store, "Sprint 6: new sprint.")
+
+        result = runner.invoke(app, ["sync"])
+        assert result.exit_code == 0, result.output
+
+        current, history = self._read_state_files(project_store)
+
+        assert "Sprint 6: new sprint." in current
+        assert "Sprint 5: shipping feature X." in history
+        assert "Snapshot v" not in history


### PR DESCRIPTION
## Why

`nauro sync` was overwriting rich, user-authored `state_current.md` with a generic snapshot label (e.g. `Snapshot v060: manual sync`) and pushing the prior content into `state_history.md`. Repeated syncs then accumulated `Snapshot vNNN: ...` rows in history. Snapshot triggers are sync metadata, not project state — they belong in the snapshot JSON, not the L0/L1 state surface.

## Approach

Delete the redundant `update_state(...)` call in `sync()`. The trigger is already persisted in `snapshots/vNNN.json` (and exposed via `list_snapshots()`), so it has no second home to occupy. Conflict detection in `sync/merge.py` is unchanged — last-write-wins on `state_current.md` is still correct for genuine concurrent edits; we just stop creating fake "edits" from sync itself. Legitimate state rotation through the MCP `update_state` tool is unchanged.

Rejected alternative: keep the write but make it append-only. That would have papered over the real issue (sync had no business writing state in the first place) and kept the L0 surface polluted with sync metadata.

## What changed

- `packages/nauro/src/nauro/cli/commands/sync.py` — remove the `update_state(store, f"Snapshot v{version:03d}: {trigger}")` call and the now-unused import. Refresh module + `--help` docstrings to drop the "update state" wording and point at the MCP `update_state` tool.
- `packages/nauro/tests/test_sync/test_sync_command.py` — new `TestSyncPreservesState` class with three regression cases (see Test plan).

## What to review

- `sync.py` diff: the deletion is one line; the docstring change is cosmetic. Confirm nothing downstream reads "Snapshot v…" from `state_current.md` (audited: only `update_state` / `list_snapshots` callers found, and `list_snapshots` reads from snapshot JSON).
- The regression test uses delta-based snapshot-count assertions so it survives any future scaffold tweaks that pre-seed snapshots.
- `nauro_core.state.prepare_state_update` is unchanged — replace-then-archive semantics from D094 still hold for the MCP `update_state` path.

## What's deferred

- Cleanup of any historical `Snapshot vNNN: ...` rows users already have in their `state_history.md` (best handled by a one-shot maintenance command if it's worth doing).
- Auditing the rest of the pull/push ordering for unrelated `.conflict-backup` edge cases.
- No change to cloud project-list reconciliation or remote-only pull triggers.

## Test plan

- `uv run pytest packages/nauro/tests/test_sync/ -x -q` → 82 passed (incl. 3 new in `TestSyncPreservesState`).
- `uv run pytest packages/nauro/tests/ -x -q -m "not integration"` → 690 passed.
- `uv run pytest packages/nauro-core/tests/ -x -q` → 249 passed.
- `uv run ruff check packages/` + `uv run ruff format --check packages/` → clean.

New regression cases:
1. **Rich state survives 3× sync** — seed rich state, run sync three times, assert state body intact, no `Snapshot v` / `manual sync` in state files, snapshot count delta == 3, newest trigger == `"manual sync"`.
2. **`-m release-prep` routes to snapshot only** — custom trigger lands in newest snapshot's metadata; does not appear in `state_current.md` or `state_history.md`.
3. **Legitimate state rotation still works** — `update_state` between syncs archives the prior body into `state_history.md`, proving the MCP path is intact.