### PR TITLE
fix(skills): worktree+monorepo+demo guards in /nauro-adopt

### DIFF
--- a/.agents/skills/nauro-adopt/SKILL.md
+++ b/.agents/skills/nauro-adopt/SKILL.md
@@ -13,19 +13,28 @@ The agent runs `git rev-parse --show-toplevel` from the current working director
 
 ## Step 2 — Already-adopted guard
 
-The agent reads `<repo>/.nauro/config.json`. If the file is missing: abort with "This repo is not adopted yet. Run 'nauro adopt' from the repo root, restart this agent, then invoke /nauro-adopt again." If the file exists and parses as JSON: extract `id` and `name` and use these as the project handle for subsequent calls.
+The agent reads `<repo>/.nauro/config.json`. If it exists and parses as JSON: extract `id` and `name` and use them as the project handle.
+
+If the file is missing, try two fallbacks before aborting:
+
+1. **Worktree fallback.** Compare `git rev-parse --git-dir` and `git rev-parse --git-common-dir`. If they differ, the current checkout is a linked worktree, and `.nauro/` may only exist in the main worktree (common when a workspace tool gitignores `.nauro/` per-checkout). Resolve the main worktree path from `git worktree list --porcelain` (the first `worktree` line) and re-read `<main-worktree>/.nauro/config.json`.
+2. **Registry fallback.** Read `~/.nauro/registry.json`. If any project's `repo_paths` contains the current repo root or the resolved main-worktree path, use that project's `id` and `name`.
+
+Abort only when both fallbacks miss, with: "This repo is not adopted yet. Run 'nauro adopt' from the repo root, restart this agent, then invoke /nauro-adopt again."
 
 Pass `id` as the `project_id` argument on every subsequent MCP call (`propose_decision`, `confirm_decision`, `update_state`, `flag_question`, `get_context`, `list_decisions`). Do not omit `project_id` even though the tool descriptions say it's optional — auto-resolve routes to the user's default project, which is **not** the project this skill is seeding when both local-mode and cloud-mode projects coexist.
 
 ## Step 3 — Read source files
 
-The agent reads the first match found per category. Files larger than 256KB are flagged to the user before reading. If the README category yields no match, surface "No README found; reading manifest only." to the user once and continue — manifest-only repos are still adoptable.
+The agent reads the first match found per category, with the manifest workspace exception below. Files larger than 256KB are flagged to the user before reading. If the README category yields no match, surface "No README found; reading manifest only." to the user once and continue — manifest-only repos are still adoptable.
 
 - **README**: `README.md`, `README.rst`, `README` (first found)
-- **Manifest**: `pyproject.toml`, `package.json`, `Cargo.toml`, `go.mod`, `Gemfile`, `pom.xml`, `build.gradle`, `composer.json`, `requirements*.txt`
+- **Manifest**: `pyproject.toml`, `package.json`, `Cargo.toml`, `go.mod`, `Gemfile`, `pom.xml`, `build.gradle`, `composer.json`, `requirements*.txt`. Read the root manifest. If it declares a workspace — `[tool.uv.workspace]` with `members = [...]` in `pyproject.toml`, a top-level `workspaces` array in `package.json` (npm/pnpm/yarn), or `[workspace]` with `members = [...]` in `Cargo.toml` — also read each member manifest at its declared path. Otherwise stop at the root match. The root manifest of a workspace is often a thin shim with no real dependencies; member manifests carry the actual stack.
 - **Top-level docs**: `CONTRIBUTING.md`, `ARCHITECTURE.md`, `DESIGN.md`, `CLAUDE.md`, `AGENTS.md`
 - **ADR directory**: `docs/adr/`, `docs/decisions/`, `architecture/decisions/`, `adr/` — every `.md` except templates and index files (`0000-template.md`, `README.md`)
 - **Memory Bank**: `.context/`, `memory-bank/`, `cline_docs/` — `projectBrief.md`, `activeContext.md`, `techContext.md`, `decisionLog.md`, `progress.md`
+
+The agent does not read source code, tests, IaC templates, or git history during adopt. Those surfaces are out of scope on purpose — every recorded fact must trace back to an explicit source document so the refusal contract in Step 9 holds.
 
 ### Step 3b — Chat-surface paste branch
 
@@ -47,11 +56,11 @@ The agent calls `get_context` (MCP) to surface what the scaffold already wrote �
 
 The agent triages the source content into two lists.
 
-**Step 5a — Clear decisions.** Candidates where the source explicitly states acceptance and rationale (and, when applicable, rejected alternatives). Each entry: number, title (≤60 chars), one-line summary (≤140 chars), source location. The agent prints the full list as one message:
+**Step 5a — Clear decisions.** Candidates where the source explicitly states acceptance and rationale (and, when applicable, rejected alternatives). Each entry: number, title (≤60 chars), one-line summary (≤140 chars), source location. A candidate also qualifies as a clear decision when the rule is stated in one explicit source document and the rationale is stated in a *different* explicit source document — cite both source locations in the entry (e.g. "rule: CLAUDE.md §Conventions; rationale: README §How it works"). The agent does not invent the second source to make a candidate fit; if rationale is absent from every source the candidate goes to Step 5b. The agent prints the full list as one message:
 
 > Reply 'keep N' / 'edit N: <new title>' / 'skip N' per item. Or 'keep all' to accept everything. Reply 'done' when finished.
 
-**Step 5b — Boundary candidates.** Facts that *might* be decisions but where the source does not state rationale verbatim. Surfaced after the user finishes Step 5a:
+**Step 5b — Boundary candidates.** Facts that *might* be decisions but where the source does not state rationale verbatim. Stack inventory (languages, frameworks, package managers, license, lint tooling) lives here unless a source frames the choice with rationale. Surfaced after the user finishes Step 5a:
 
 > The agent thinks these might be decisions but couldn't extract rationale verbatim from the source. Each is opt-in only — reply 'opt N: <rationale>' to record any of them with rationale you provide; otherwise they are skipped.
 
@@ -86,7 +95,13 @@ Sources: explicit `## Open Questions` sections, lines beginning `Q:` or `TODO:` 
 
 ## Step 9 — Refusal contract
 
-The agent records facts that source documents explicitly state. The agent does not infer rationale from prose, does not invent rejected alternatives, does not assume `confidence=high` from tone, does not summarize a paragraph into a "decision" the source never called a decision. Boundary cases go to Step 5b (opt-in only — write rationale yourself), not into the clear-decisions list.
+The agent records facts that source documents explicitly state. The agent does not infer rationale from prose, does not invent rejected alternatives, does not assume `confidence=high` from tone, does not summarize a paragraph into a "decision" the source never called a decision. Three specific traps to avoid:
+
+- **Demo prose.** Decision-shaped statements inside README quickstart examples, illustrative scenarios, hypothetical user prompts, comparison tables, or product-demo narratives are false positives unless an independent source (CLAUDE.md, ADR, ARCHITECTURE.md, manifest, Memory-Bank) names the same fact as an actual project decision. In that case the independent source is the citation, not the demo prose.
+- **Stack inventory.** Languages, frameworks, package managers, license, and lint tooling listed in a manifest or a "Stack" section are inventory, not decisions, unless the source frames the choice with rationale (in which case Step 5a applies, possibly via cross-doc stitching).
+- **Cross-doc stitching is not inference.** When Step 5a stitches a rule from one source with rationale from another, both source locations must be explicit. The agent never fills in a missing rationale itself, and never treats two restatements of the same rule as "rule + rationale".
+
+Boundary cases go to Step 5b (opt-in only — write rationale yourself), not into the clear-decisions list.
 
 ## Step 10 — Summary
 

--- a/.agents/skills/nauro-adopt/SKILL.md
+++ b/.agents/skills/nauro-adopt/SKILL.md
@@ -17,8 +17,8 @@ The agent reads `<repo>/.nauro/config.json`. If it exists and parses as JSON: ex
 
 If the file is missing, try two fallbacks before aborting:
 
-1. **Worktree fallback.** Compare `git rev-parse --git-dir` and `git rev-parse --git-common-dir`. If they differ, the current checkout is a linked worktree, and `.nauro/` may only exist in the main worktree (common when a workspace tool gitignores `.nauro/` per-checkout). Resolve the main worktree path from `git worktree list --porcelain` (the first `worktree` line) and re-read `<main-worktree>/.nauro/config.json`.
-2. **Registry fallback.** Read `~/.nauro/registry.json`. If any project's `repo_paths` contains the current repo root or the resolved main-worktree path, use that project's `id` and `name`.
+1. **Worktree fallback.** Compare `git rev-parse --git-dir` and `git rev-parse --git-common-dir`. If they differ, the current checkout is a linked worktree, and `.nauro/` may only exist in the main worktree (common when a workspace tool gitignores `.nauro/` per-checkout). The main worktree path is the parent directory of `git rev-parse --path-format=absolute --git-common-dir`. Re-read `<main-worktree>/.nauro/config.json` there.
+2. **Registry fallback.** Read `~/.nauro/registry.json`. Schema v2 keys each project by its id under `projects` — the dict key **is** the project `id`; the entry stores `name`, `mode`, `repo_paths`, etc. If any entry's `repo_paths` contains the current repo root or the resolved main-worktree path, use that dict key as the `id` and the entry's `name` as the project handle.
 
 Abort only when both fallbacks miss, with: "This repo is not adopted yet. Run 'nauro adopt' from the repo root, restart this agent, then invoke /nauro-adopt again."
 
@@ -29,7 +29,13 @@ Pass `id` as the `project_id` argument on every subsequent MCP call (`propose_de
 The agent reads the first match found per category, with the manifest workspace exception below. Files larger than 256KB are flagged to the user before reading. If the README category yields no match, surface "No README found; reading manifest only." to the user once and continue — manifest-only repos are still adoptable.
 
 - **README**: `README.md`, `README.rst`, `README` (first found)
-- **Manifest**: `pyproject.toml`, `package.json`, `Cargo.toml`, `go.mod`, `Gemfile`, `pom.xml`, `build.gradle`, `composer.json`, `requirements*.txt`. Read the root manifest. If it declares a workspace — `[tool.uv.workspace]` with `members = [...]` in `pyproject.toml`, a top-level `workspaces` array in `package.json` (npm/pnpm/yarn), or `[workspace]` with `members = [...]` in `Cargo.toml` — also read each member manifest at its declared path. Otherwise stop at the root match. The root manifest of a workspace is often a thin shim with no real dependencies; member manifests carry the actual stack.
+- **Manifest**: `pyproject.toml`, `package.json`, `Cargo.toml`, `go.mod`, `Gemfile`, `pom.xml`, `build.gradle`, `composer.json`, `requirements*.txt`. Read the root manifest. If it declares a workspace, also read each member manifest. Workspace declarations to recognise:
+    - `pyproject.toml` → `[tool.uv.workspace]` `members = [...]`
+    - `package.json` (npm / Yarn classic) → top-level `workspaces` array
+    - `pnpm-workspace.yaml` → top-level `packages:` list (pnpm does **not** use `package.json` `workspaces`)
+    - `Cargo.toml` → `[workspace]` `members = [...]`
+
+  Member entries are usually globs (`packages/*`, `crates/*`). Expand each glob and read every matched directory's manifest of the same ecosystem. Otherwise stop at the root match. The root manifest of a workspace is often a thin shim with no real dependencies; member manifests carry the actual stack.
 - **Top-level docs**: `CONTRIBUTING.md`, `ARCHITECTURE.md`, `DESIGN.md`, `CLAUDE.md`, `AGENTS.md`
 - **ADR directory**: `docs/adr/`, `docs/decisions/`, `architecture/decisions/`, `adr/` — every `.md` except templates and index files (`0000-template.md`, `README.md`)
 - **Memory Bank**: `.context/`, `memory-bank/`, `cline_docs/` — `projectBrief.md`, `activeContext.md`, `techContext.md`, `decisionLog.md`, `progress.md`

--- a/.claude/skills/nauro-adopt/SKILL.md
+++ b/.claude/skills/nauro-adopt/SKILL.md
@@ -13,19 +13,28 @@ The agent runs `git rev-parse --show-toplevel` from the current working director
 
 ## Step 2 — Already-adopted guard
 
-The agent reads `<repo>/.nauro/config.json`. If the file is missing: abort with "This repo is not adopted yet. Run 'nauro adopt' from the repo root, restart this agent, then invoke /nauro-adopt again." If the file exists and parses as JSON: extract `id` and `name` and use these as the project handle for subsequent calls.
+The agent reads `<repo>/.nauro/config.json`. If it exists and parses as JSON: extract `id` and `name` and use them as the project handle.
+
+If the file is missing, try two fallbacks before aborting:
+
+1. **Worktree fallback.** Compare `git rev-parse --git-dir` and `git rev-parse --git-common-dir`. If they differ, the current checkout is a linked worktree, and `.nauro/` may only exist in the main worktree (common when a workspace tool gitignores `.nauro/` per-checkout). Resolve the main worktree path from `git worktree list --porcelain` (the first `worktree` line) and re-read `<main-worktree>/.nauro/config.json`.
+2. **Registry fallback.** Read `~/.nauro/registry.json`. If any project's `repo_paths` contains the current repo root or the resolved main-worktree path, use that project's `id` and `name`.
+
+Abort only when both fallbacks miss, with: "This repo is not adopted yet. Run 'nauro adopt' from the repo root, restart this agent, then invoke /nauro-adopt again."
 
 Pass `id` as the `project_id` argument on every subsequent MCP call (`propose_decision`, `confirm_decision`, `update_state`, `flag_question`, `get_context`, `list_decisions`). Do not omit `project_id` even though the tool descriptions say it's optional — auto-resolve routes to the user's default project, which is **not** the project this skill is seeding when both local-mode and cloud-mode projects coexist.
 
 ## Step 3 — Read source files
 
-The agent reads the first match found per category. Files larger than 256KB are flagged to the user before reading. If the README category yields no match, surface "No README found; reading manifest only." to the user once and continue — manifest-only repos are still adoptable.
+The agent reads the first match found per category, with the manifest workspace exception below. Files larger than 256KB are flagged to the user before reading. If the README category yields no match, surface "No README found; reading manifest only." to the user once and continue — manifest-only repos are still adoptable.
 
 - **README**: `README.md`, `README.rst`, `README` (first found)
-- **Manifest**: `pyproject.toml`, `package.json`, `Cargo.toml`, `go.mod`, `Gemfile`, `pom.xml`, `build.gradle`, `composer.json`, `requirements*.txt`
+- **Manifest**: `pyproject.toml`, `package.json`, `Cargo.toml`, `go.mod`, `Gemfile`, `pom.xml`, `build.gradle`, `composer.json`, `requirements*.txt`. Read the root manifest. If it declares a workspace — `[tool.uv.workspace]` with `members = [...]` in `pyproject.toml`, a top-level `workspaces` array in `package.json` (npm/pnpm/yarn), or `[workspace]` with `members = [...]` in `Cargo.toml` — also read each member manifest at its declared path. Otherwise stop at the root match. The root manifest of a workspace is often a thin shim with no real dependencies; member manifests carry the actual stack.
 - **Top-level docs**: `CONTRIBUTING.md`, `ARCHITECTURE.md`, `DESIGN.md`, `CLAUDE.md`, `AGENTS.md`
 - **ADR directory**: `docs/adr/`, `docs/decisions/`, `architecture/decisions/`, `adr/` — every `.md` except templates and index files (`0000-template.md`, `README.md`)
 - **Memory Bank**: `.context/`, `memory-bank/`, `cline_docs/` — `projectBrief.md`, `activeContext.md`, `techContext.md`, `decisionLog.md`, `progress.md`
+
+The agent does not read source code, tests, IaC templates, or git history during adopt. Those surfaces are out of scope on purpose — every recorded fact must trace back to an explicit source document so the refusal contract in Step 9 holds.
 
 ### Step 3b — Chat-surface paste branch
 
@@ -47,11 +56,11 @@ The agent calls `get_context` (MCP) to surface what the scaffold already wrote �
 
 The agent triages the source content into two lists.
 
-**Step 5a — Clear decisions.** Candidates where the source explicitly states acceptance and rationale (and, when applicable, rejected alternatives). Each entry: number, title (≤60 chars), one-line summary (≤140 chars), source location. The agent prints the full list as one message:
+**Step 5a — Clear decisions.** Candidates where the source explicitly states acceptance and rationale (and, when applicable, rejected alternatives). Each entry: number, title (≤60 chars), one-line summary (≤140 chars), source location. A candidate also qualifies as a clear decision when the rule is stated in one explicit source document and the rationale is stated in a *different* explicit source document — cite both source locations in the entry (e.g. "rule: CLAUDE.md §Conventions; rationale: README §How it works"). The agent does not invent the second source to make a candidate fit; if rationale is absent from every source the candidate goes to Step 5b. The agent prints the full list as one message:
 
 > Reply 'keep N' / 'edit N: <new title>' / 'skip N' per item. Or 'keep all' to accept everything. Reply 'done' when finished.
 
-**Step 5b — Boundary candidates.** Facts that *might* be decisions but where the source does not state rationale verbatim. Surfaced after the user finishes Step 5a:
+**Step 5b — Boundary candidates.** Facts that *might* be decisions but where the source does not state rationale verbatim. Stack inventory (languages, frameworks, package managers, license, lint tooling) lives here unless a source frames the choice with rationale. Surfaced after the user finishes Step 5a:
 
 > The agent thinks these might be decisions but couldn't extract rationale verbatim from the source. Each is opt-in only — reply 'opt N: <rationale>' to record any of them with rationale you provide; otherwise they are skipped.
 
@@ -86,7 +95,13 @@ Sources: explicit `## Open Questions` sections, lines beginning `Q:` or `TODO:` 
 
 ## Step 9 — Refusal contract
 
-The agent records facts that source documents explicitly state. The agent does not infer rationale from prose, does not invent rejected alternatives, does not assume `confidence=high` from tone, does not summarize a paragraph into a "decision" the source never called a decision. Boundary cases go to Step 5b (opt-in only — write rationale yourself), not into the clear-decisions list.
+The agent records facts that source documents explicitly state. The agent does not infer rationale from prose, does not invent rejected alternatives, does not assume `confidence=high` from tone, does not summarize a paragraph into a "decision" the source never called a decision. Three specific traps to avoid:
+
+- **Demo prose.** Decision-shaped statements inside README quickstart examples, illustrative scenarios, hypothetical user prompts, comparison tables, or product-demo narratives are false positives unless an independent source (CLAUDE.md, ADR, ARCHITECTURE.md, manifest, Memory-Bank) names the same fact as an actual project decision. In that case the independent source is the citation, not the demo prose.
+- **Stack inventory.** Languages, frameworks, package managers, license, and lint tooling listed in a manifest or a "Stack" section are inventory, not decisions, unless the source frames the choice with rationale (in which case Step 5a applies, possibly via cross-doc stitching).
+- **Cross-doc stitching is not inference.** When Step 5a stitches a rule from one source with rationale from another, both source locations must be explicit. The agent never fills in a missing rationale itself, and never treats two restatements of the same rule as "rule + rationale".
+
+Boundary cases go to Step 5b (opt-in only — write rationale yourself), not into the clear-decisions list.
 
 ## Step 10 — Summary
 

--- a/.claude/skills/nauro-adopt/SKILL.md
+++ b/.claude/skills/nauro-adopt/SKILL.md
@@ -17,8 +17,8 @@ The agent reads `<repo>/.nauro/config.json`. If it exists and parses as JSON: ex
 
 If the file is missing, try two fallbacks before aborting:
 
-1. **Worktree fallback.** Compare `git rev-parse --git-dir` and `git rev-parse --git-common-dir`. If they differ, the current checkout is a linked worktree, and `.nauro/` may only exist in the main worktree (common when a workspace tool gitignores `.nauro/` per-checkout). Resolve the main worktree path from `git worktree list --porcelain` (the first `worktree` line) and re-read `<main-worktree>/.nauro/config.json`.
-2. **Registry fallback.** Read `~/.nauro/registry.json`. If any project's `repo_paths` contains the current repo root or the resolved main-worktree path, use that project's `id` and `name`.
+1. **Worktree fallback.** Compare `git rev-parse --git-dir` and `git rev-parse --git-common-dir`. If they differ, the current checkout is a linked worktree, and `.nauro/` may only exist in the main worktree (common when a workspace tool gitignores `.nauro/` per-checkout). The main worktree path is the parent directory of `git rev-parse --path-format=absolute --git-common-dir`. Re-read `<main-worktree>/.nauro/config.json` there.
+2. **Registry fallback.** Read `~/.nauro/registry.json`. Schema v2 keys each project by its id under `projects` — the dict key **is** the project `id`; the entry stores `name`, `mode`, `repo_paths`, etc. If any entry's `repo_paths` contains the current repo root or the resolved main-worktree path, use that dict key as the `id` and the entry's `name` as the project handle.
 
 Abort only when both fallbacks miss, with: "This repo is not adopted yet. Run 'nauro adopt' from the repo root, restart this agent, then invoke /nauro-adopt again."
 
@@ -29,7 +29,13 @@ Pass `id` as the `project_id` argument on every subsequent MCP call (`propose_de
 The agent reads the first match found per category, with the manifest workspace exception below. Files larger than 256KB are flagged to the user before reading. If the README category yields no match, surface "No README found; reading manifest only." to the user once and continue — manifest-only repos are still adoptable.
 
 - **README**: `README.md`, `README.rst`, `README` (first found)
-- **Manifest**: `pyproject.toml`, `package.json`, `Cargo.toml`, `go.mod`, `Gemfile`, `pom.xml`, `build.gradle`, `composer.json`, `requirements*.txt`. Read the root manifest. If it declares a workspace — `[tool.uv.workspace]` with `members = [...]` in `pyproject.toml`, a top-level `workspaces` array in `package.json` (npm/pnpm/yarn), or `[workspace]` with `members = [...]` in `Cargo.toml` — also read each member manifest at its declared path. Otherwise stop at the root match. The root manifest of a workspace is often a thin shim with no real dependencies; member manifests carry the actual stack.
+- **Manifest**: `pyproject.toml`, `package.json`, `Cargo.toml`, `go.mod`, `Gemfile`, `pom.xml`, `build.gradle`, `composer.json`, `requirements*.txt`. Read the root manifest. If it declares a workspace, also read each member manifest. Workspace declarations to recognise:
+    - `pyproject.toml` → `[tool.uv.workspace]` `members = [...]`
+    - `package.json` (npm / Yarn classic) → top-level `workspaces` array
+    - `pnpm-workspace.yaml` → top-level `packages:` list (pnpm does **not** use `package.json` `workspaces`)
+    - `Cargo.toml` → `[workspace]` `members = [...]`
+
+  Member entries are usually globs (`packages/*`, `crates/*`). Expand each glob and read every matched directory's manifest of the same ecosystem. Otherwise stop at the root match. The root manifest of a workspace is often a thin shim with no real dependencies; member manifests carry the actual stack.
 - **Top-level docs**: `CONTRIBUTING.md`, `ARCHITECTURE.md`, `DESIGN.md`, `CLAUDE.md`, `AGENTS.md`
 - **ADR directory**: `docs/adr/`, `docs/decisions/`, `architecture/decisions/`, `adr/` — every `.md` except templates and index files (`0000-template.md`, `README.md`)
 - **Memory Bank**: `.context/`, `memory-bank/`, `cline_docs/` — `projectBrief.md`, `activeContext.md`, `techContext.md`, `decisionLog.md`, `progress.md`

--- a/.cursor/rules/nauro-adopt.mdc
+++ b/.cursor/rules/nauro-adopt.mdc
@@ -13,19 +13,28 @@ The agent runs `git rev-parse --show-toplevel` from the current working director
 
 ## Step 2 — Already-adopted guard
 
-The agent reads `<repo>/.nauro/config.json`. If the file is missing: abort with "This repo is not adopted yet. Run 'nauro adopt' from the repo root, restart this agent, then invoke /nauro-adopt again." If the file exists and parses as JSON: extract `id` and `name` and use these as the project handle for subsequent calls.
+The agent reads `<repo>/.nauro/config.json`. If it exists and parses as JSON: extract `id` and `name` and use them as the project handle.
+
+If the file is missing, try two fallbacks before aborting:
+
+1. **Worktree fallback.** Compare `git rev-parse --git-dir` and `git rev-parse --git-common-dir`. If they differ, the current checkout is a linked worktree, and `.nauro/` may only exist in the main worktree (common when a workspace tool gitignores `.nauro/` per-checkout). Resolve the main worktree path from `git worktree list --porcelain` (the first `worktree` line) and re-read `<main-worktree>/.nauro/config.json`.
+2. **Registry fallback.** Read `~/.nauro/registry.json`. If any project's `repo_paths` contains the current repo root or the resolved main-worktree path, use that project's `id` and `name`.
+
+Abort only when both fallbacks miss, with: "This repo is not adopted yet. Run 'nauro adopt' from the repo root, restart this agent, then invoke /nauro-adopt again."
 
 Pass `id` as the `project_id` argument on every subsequent MCP call (`propose_decision`, `confirm_decision`, `update_state`, `flag_question`, `get_context`, `list_decisions`). Do not omit `project_id` even though the tool descriptions say it's optional — auto-resolve routes to the user's default project, which is **not** the project this skill is seeding when both local-mode and cloud-mode projects coexist.
 
 ## Step 3 — Read source files
 
-The agent reads the first match found per category. Files larger than 256KB are flagged to the user before reading. If the README category yields no match, surface "No README found; reading manifest only." to the user once and continue — manifest-only repos are still adoptable.
+The agent reads the first match found per category, with the manifest workspace exception below. Files larger than 256KB are flagged to the user before reading. If the README category yields no match, surface "No README found; reading manifest only." to the user once and continue — manifest-only repos are still adoptable.
 
 - **README**: `README.md`, `README.rst`, `README` (first found)
-- **Manifest**: `pyproject.toml`, `package.json`, `Cargo.toml`, `go.mod`, `Gemfile`, `pom.xml`, `build.gradle`, `composer.json`, `requirements*.txt`
+- **Manifest**: `pyproject.toml`, `package.json`, `Cargo.toml`, `go.mod`, `Gemfile`, `pom.xml`, `build.gradle`, `composer.json`, `requirements*.txt`. Read the root manifest. If it declares a workspace — `[tool.uv.workspace]` with `members = [...]` in `pyproject.toml`, a top-level `workspaces` array in `package.json` (npm/pnpm/yarn), or `[workspace]` with `members = [...]` in `Cargo.toml` — also read each member manifest at its declared path. Otherwise stop at the root match. The root manifest of a workspace is often a thin shim with no real dependencies; member manifests carry the actual stack.
 - **Top-level docs**: `CONTRIBUTING.md`, `ARCHITECTURE.md`, `DESIGN.md`, `CLAUDE.md`, `AGENTS.md`
 - **ADR directory**: `docs/adr/`, `docs/decisions/`, `architecture/decisions/`, `adr/` — every `.md` except templates and index files (`0000-template.md`, `README.md`)
 - **Memory Bank**: `.context/`, `memory-bank/`, `cline_docs/` — `projectBrief.md`, `activeContext.md`, `techContext.md`, `decisionLog.md`, `progress.md`
+
+The agent does not read source code, tests, IaC templates, or git history during adopt. Those surfaces are out of scope on purpose — every recorded fact must trace back to an explicit source document so the refusal contract in Step 9 holds.
 
 ### Step 3b — Chat-surface paste branch
 
@@ -47,11 +56,11 @@ The agent calls `get_context` (MCP) to surface what the scaffold already wrote �
 
 The agent triages the source content into two lists.
 
-**Step 5a — Clear decisions.** Candidates where the source explicitly states acceptance and rationale (and, when applicable, rejected alternatives). Each entry: number, title (≤60 chars), one-line summary (≤140 chars), source location. The agent prints the full list as one message:
+**Step 5a — Clear decisions.** Candidates where the source explicitly states acceptance and rationale (and, when applicable, rejected alternatives). Each entry: number, title (≤60 chars), one-line summary (≤140 chars), source location. A candidate also qualifies as a clear decision when the rule is stated in one explicit source document and the rationale is stated in a *different* explicit source document — cite both source locations in the entry (e.g. "rule: CLAUDE.md §Conventions; rationale: README §How it works"). The agent does not invent the second source to make a candidate fit; if rationale is absent from every source the candidate goes to Step 5b. The agent prints the full list as one message:
 
 > Reply 'keep N' / 'edit N: <new title>' / 'skip N' per item. Or 'keep all' to accept everything. Reply 'done' when finished.
 
-**Step 5b — Boundary candidates.** Facts that *might* be decisions but where the source does not state rationale verbatim. Surfaced after the user finishes Step 5a:
+**Step 5b — Boundary candidates.** Facts that *might* be decisions but where the source does not state rationale verbatim. Stack inventory (languages, frameworks, package managers, license, lint tooling) lives here unless a source frames the choice with rationale. Surfaced after the user finishes Step 5a:
 
 > The agent thinks these might be decisions but couldn't extract rationale verbatim from the source. Each is opt-in only — reply 'opt N: <rationale>' to record any of them with rationale you provide; otherwise they are skipped.
 
@@ -86,7 +95,13 @@ Sources: explicit `## Open Questions` sections, lines beginning `Q:` or `TODO:` 
 
 ## Step 9 — Refusal contract
 
-The agent records facts that source documents explicitly state. The agent does not infer rationale from prose, does not invent rejected alternatives, does not assume `confidence=high` from tone, does not summarize a paragraph into a "decision" the source never called a decision. Boundary cases go to Step 5b (opt-in only — write rationale yourself), not into the clear-decisions list.
+The agent records facts that source documents explicitly state. The agent does not infer rationale from prose, does not invent rejected alternatives, does not assume `confidence=high` from tone, does not summarize a paragraph into a "decision" the source never called a decision. Three specific traps to avoid:
+
+- **Demo prose.** Decision-shaped statements inside README quickstart examples, illustrative scenarios, hypothetical user prompts, comparison tables, or product-demo narratives are false positives unless an independent source (CLAUDE.md, ADR, ARCHITECTURE.md, manifest, Memory-Bank) names the same fact as an actual project decision. In that case the independent source is the citation, not the demo prose.
+- **Stack inventory.** Languages, frameworks, package managers, license, and lint tooling listed in a manifest or a "Stack" section are inventory, not decisions, unless the source frames the choice with rationale (in which case Step 5a applies, possibly via cross-doc stitching).
+- **Cross-doc stitching is not inference.** When Step 5a stitches a rule from one source with rationale from another, both source locations must be explicit. The agent never fills in a missing rationale itself, and never treats two restatements of the same rule as "rule + rationale".
+
+Boundary cases go to Step 5b (opt-in only — write rationale yourself), not into the clear-decisions list.
 
 ## Step 10 — Summary
 

--- a/.cursor/rules/nauro-adopt.mdc
+++ b/.cursor/rules/nauro-adopt.mdc
@@ -17,8 +17,8 @@ The agent reads `<repo>/.nauro/config.json`. If it exists and parses as JSON: ex
 
 If the file is missing, try two fallbacks before aborting:
 
-1. **Worktree fallback.** Compare `git rev-parse --git-dir` and `git rev-parse --git-common-dir`. If they differ, the current checkout is a linked worktree, and `.nauro/` may only exist in the main worktree (common when a workspace tool gitignores `.nauro/` per-checkout). Resolve the main worktree path from `git worktree list --porcelain` (the first `worktree` line) and re-read `<main-worktree>/.nauro/config.json`.
-2. **Registry fallback.** Read `~/.nauro/registry.json`. If any project's `repo_paths` contains the current repo root or the resolved main-worktree path, use that project's `id` and `name`.
+1. **Worktree fallback.** Compare `git rev-parse --git-dir` and `git rev-parse --git-common-dir`. If they differ, the current checkout is a linked worktree, and `.nauro/` may only exist in the main worktree (common when a workspace tool gitignores `.nauro/` per-checkout). The main worktree path is the parent directory of `git rev-parse --path-format=absolute --git-common-dir`. Re-read `<main-worktree>/.nauro/config.json` there.
+2. **Registry fallback.** Read `~/.nauro/registry.json`. Schema v2 keys each project by its id under `projects` — the dict key **is** the project `id`; the entry stores `name`, `mode`, `repo_paths`, etc. If any entry's `repo_paths` contains the current repo root or the resolved main-worktree path, use that dict key as the `id` and the entry's `name` as the project handle.
 
 Abort only when both fallbacks miss, with: "This repo is not adopted yet. Run 'nauro adopt' from the repo root, restart this agent, then invoke /nauro-adopt again."
 
@@ -29,7 +29,13 @@ Pass `id` as the `project_id` argument on every subsequent MCP call (`propose_de
 The agent reads the first match found per category, with the manifest workspace exception below. Files larger than 256KB are flagged to the user before reading. If the README category yields no match, surface "No README found; reading manifest only." to the user once and continue — manifest-only repos are still adoptable.
 
 - **README**: `README.md`, `README.rst`, `README` (first found)
-- **Manifest**: `pyproject.toml`, `package.json`, `Cargo.toml`, `go.mod`, `Gemfile`, `pom.xml`, `build.gradle`, `composer.json`, `requirements*.txt`. Read the root manifest. If it declares a workspace — `[tool.uv.workspace]` with `members = [...]` in `pyproject.toml`, a top-level `workspaces` array in `package.json` (npm/pnpm/yarn), or `[workspace]` with `members = [...]` in `Cargo.toml` — also read each member manifest at its declared path. Otherwise stop at the root match. The root manifest of a workspace is often a thin shim with no real dependencies; member manifests carry the actual stack.
+- **Manifest**: `pyproject.toml`, `package.json`, `Cargo.toml`, `go.mod`, `Gemfile`, `pom.xml`, `build.gradle`, `composer.json`, `requirements*.txt`. Read the root manifest. If it declares a workspace, also read each member manifest. Workspace declarations to recognise:
+    - `pyproject.toml` → `[tool.uv.workspace]` `members = [...]`
+    - `package.json` (npm / Yarn classic) → top-level `workspaces` array
+    - `pnpm-workspace.yaml` → top-level `packages:` list (pnpm does **not** use `package.json` `workspaces`)
+    - `Cargo.toml` → `[workspace]` `members = [...]`
+
+  Member entries are usually globs (`packages/*`, `crates/*`). Expand each glob and read every matched directory's manifest of the same ecosystem. Otherwise stop at the root match. The root manifest of a workspace is often a thin shim with no real dependencies; member manifests carry the actual stack.
 - **Top-level docs**: `CONTRIBUTING.md`, `ARCHITECTURE.md`, `DESIGN.md`, `CLAUDE.md`, `AGENTS.md`
 - **ADR directory**: `docs/adr/`, `docs/decisions/`, `architecture/decisions/`, `adr/` — every `.md` except templates and index files (`0000-template.md`, `README.md`)
 - **Memory Bank**: `.context/`, `memory-bank/`, `cline_docs/` — `projectBrief.md`, `activeContext.md`, `techContext.md`, `decisionLog.md`, `progress.md`

--- a/docs/adopt-prompt.md
+++ b/docs/adopt-prompt.md
@@ -29,19 +29,28 @@ The agent runs `git rev-parse --show-toplevel` from the current working director
 
 ## Step 2 — Already-adopted guard
 
-The agent reads `<repo>/.nauro/config.json`. If the file is missing: abort with "This repo is not adopted yet. Run 'nauro adopt' from the repo root, restart this agent, then invoke /nauro-adopt again." If the file exists and parses as JSON: extract `id` and `name` and use these as the project handle for subsequent calls.
+The agent reads `<repo>/.nauro/config.json`. If it exists and parses as JSON: extract `id` and `name` and use them as the project handle.
+
+If the file is missing, try two fallbacks before aborting:
+
+1. **Worktree fallback.** Compare `git rev-parse --git-dir` and `git rev-parse --git-common-dir`. If they differ, the current checkout is a linked worktree, and `.nauro/` may only exist in the main worktree (common when a workspace tool gitignores `.nauro/` per-checkout). Resolve the main worktree path from `git worktree list --porcelain` (the first `worktree` line) and re-read `<main-worktree>/.nauro/config.json`.
+2. **Registry fallback.** Read `~/.nauro/registry.json`. If any project's `repo_paths` contains the current repo root or the resolved main-worktree path, use that project's `id` and `name`.
+
+Abort only when both fallbacks miss, with: "This repo is not adopted yet. Run 'nauro adopt' from the repo root, restart this agent, then invoke /nauro-adopt again."
 
 Pass `id` as the `project_id` argument on every subsequent MCP call (`propose_decision`, `confirm_decision`, `update_state`, `flag_question`, `get_context`, `list_decisions`). Do not omit `project_id` even though the tool descriptions say it's optional — auto-resolve routes to the user's default project, which is **not** the project this skill is seeding when both local-mode and cloud-mode projects coexist.
 
 ## Step 3 — Read source files
 
-The agent reads the first match found per category. Files larger than 256KB are flagged to the user before reading. If the README category yields no match, surface "No README found; reading manifest only." to the user once and continue — manifest-only repos are still adoptable.
+The agent reads the first match found per category, with the manifest workspace exception below. Files larger than 256KB are flagged to the user before reading. If the README category yields no match, surface "No README found; reading manifest only." to the user once and continue — manifest-only repos are still adoptable.
 
 - **README**: `README.md`, `README.rst`, `README` (first found)
-- **Manifest**: `pyproject.toml`, `package.json`, `Cargo.toml`, `go.mod`, `Gemfile`, `pom.xml`, `build.gradle`, `composer.json`, `requirements*.txt`
+- **Manifest**: `pyproject.toml`, `package.json`, `Cargo.toml`, `go.mod`, `Gemfile`, `pom.xml`, `build.gradle`, `composer.json`, `requirements*.txt`. Read the root manifest. If it declares a workspace — `[tool.uv.workspace]` with `members = [...]` in `pyproject.toml`, a top-level `workspaces` array in `package.json` (npm/pnpm/yarn), or `[workspace]` with `members = [...]` in `Cargo.toml` — also read each member manifest at its declared path. Otherwise stop at the root match. The root manifest of a workspace is often a thin shim with no real dependencies; member manifests carry the actual stack.
 - **Top-level docs**: `CONTRIBUTING.md`, `ARCHITECTURE.md`, `DESIGN.md`, `CLAUDE.md`, `AGENTS.md`
 - **ADR directory**: `docs/adr/`, `docs/decisions/`, `architecture/decisions/`, `adr/` — every `.md` except templates and index files (`0000-template.md`, `README.md`)
 - **Memory Bank**: `.context/`, `memory-bank/`, `cline_docs/` — `projectBrief.md`, `activeContext.md`, `techContext.md`, `decisionLog.md`, `progress.md`
+
+The agent does not read source code, tests, IaC templates, or git history during adopt. Those surfaces are out of scope on purpose — every recorded fact must trace back to an explicit source document so the refusal contract in Step 9 holds.
 
 ### Step 3b — Chat-surface paste branch
 
@@ -63,11 +72,11 @@ The agent calls `get_context` (MCP) to surface what the scaffold already wrote �
 
 The agent triages the source content into two lists.
 
-**Step 5a — Clear decisions.** Candidates where the source explicitly states acceptance and rationale (and, when applicable, rejected alternatives). Each entry: number, title (≤60 chars), one-line summary (≤140 chars), source location. The agent prints the full list as one message:
+**Step 5a — Clear decisions.** Candidates where the source explicitly states acceptance and rationale (and, when applicable, rejected alternatives). Each entry: number, title (≤60 chars), one-line summary (≤140 chars), source location. A candidate also qualifies as a clear decision when the rule is stated in one explicit source document and the rationale is stated in a *different* explicit source document — cite both source locations in the entry (e.g. "rule: CLAUDE.md §Conventions; rationale: README §How it works"). The agent does not invent the second source to make a candidate fit; if rationale is absent from every source the candidate goes to Step 5b. The agent prints the full list as one message:
 
 > Reply 'keep N' / 'edit N: <new title>' / 'skip N' per item. Or 'keep all' to accept everything. Reply 'done' when finished.
 
-**Step 5b — Boundary candidates.** Facts that *might* be decisions but where the source does not state rationale verbatim. Surfaced after the user finishes Step 5a:
+**Step 5b — Boundary candidates.** Facts that *might* be decisions but where the source does not state rationale verbatim. Stack inventory (languages, frameworks, package managers, license, lint tooling) lives here unless a source frames the choice with rationale. Surfaced after the user finishes Step 5a:
 
 > The agent thinks these might be decisions but couldn't extract rationale verbatim from the source. Each is opt-in only — reply 'opt N: <rationale>' to record any of them with rationale you provide; otherwise they are skipped.
 
@@ -102,7 +111,13 @@ Sources: explicit `## Open Questions` sections, lines beginning `Q:` or `TODO:` 
 
 ## Step 9 — Refusal contract
 
-The agent records facts that source documents explicitly state. The agent does not infer rationale from prose, does not invent rejected alternatives, does not assume `confidence=high` from tone, does not summarize a paragraph into a "decision" the source never called a decision. Boundary cases go to Step 5b (opt-in only — write rationale yourself), not into the clear-decisions list.
+The agent records facts that source documents explicitly state. The agent does not infer rationale from prose, does not invent rejected alternatives, does not assume `confidence=high` from tone, does not summarize a paragraph into a "decision" the source never called a decision. Three specific traps to avoid:
+
+- **Demo prose.** Decision-shaped statements inside README quickstart examples, illustrative scenarios, hypothetical user prompts, comparison tables, or product-demo narratives are false positives unless an independent source (CLAUDE.md, ADR, ARCHITECTURE.md, manifest, Memory-Bank) names the same fact as an actual project decision. In that case the independent source is the citation, not the demo prose.
+- **Stack inventory.** Languages, frameworks, package managers, license, and lint tooling listed in a manifest or a "Stack" section are inventory, not decisions, unless the source frames the choice with rationale (in which case Step 5a applies, possibly via cross-doc stitching).
+- **Cross-doc stitching is not inference.** When Step 5a stitches a rule from one source with rationale from another, both source locations must be explicit. The agent never fills in a missing rationale itself, and never treats two restatements of the same rule as "rule + rationale".
+
+Boundary cases go to Step 5b (opt-in only — write rationale yourself), not into the clear-decisions list.
 
 ## Step 10 — Summary
 

--- a/docs/adopt-prompt.md
+++ b/docs/adopt-prompt.md
@@ -33,8 +33,8 @@ The agent reads `<repo>/.nauro/config.json`. If it exists and parses as JSON: ex
 
 If the file is missing, try two fallbacks before aborting:
 
-1. **Worktree fallback.** Compare `git rev-parse --git-dir` and `git rev-parse --git-common-dir`. If they differ, the current checkout is a linked worktree, and `.nauro/` may only exist in the main worktree (common when a workspace tool gitignores `.nauro/` per-checkout). Resolve the main worktree path from `git worktree list --porcelain` (the first `worktree` line) and re-read `<main-worktree>/.nauro/config.json`.
-2. **Registry fallback.** Read `~/.nauro/registry.json`. If any project's `repo_paths` contains the current repo root or the resolved main-worktree path, use that project's `id` and `name`.
+1. **Worktree fallback.** Compare `git rev-parse --git-dir` and `git rev-parse --git-common-dir`. If they differ, the current checkout is a linked worktree, and `.nauro/` may only exist in the main worktree (common when a workspace tool gitignores `.nauro/` per-checkout). The main worktree path is the parent directory of `git rev-parse --path-format=absolute --git-common-dir`. Re-read `<main-worktree>/.nauro/config.json` there.
+2. **Registry fallback.** Read `~/.nauro/registry.json`. Schema v2 keys each project by its id under `projects` — the dict key **is** the project `id`; the entry stores `name`, `mode`, `repo_paths`, etc. If any entry's `repo_paths` contains the current repo root or the resolved main-worktree path, use that dict key as the `id` and the entry's `name` as the project handle.
 
 Abort only when both fallbacks miss, with: "This repo is not adopted yet. Run 'nauro adopt' from the repo root, restart this agent, then invoke /nauro-adopt again."
 
@@ -45,7 +45,13 @@ Pass `id` as the `project_id` argument on every subsequent MCP call (`propose_de
 The agent reads the first match found per category, with the manifest workspace exception below. Files larger than 256KB are flagged to the user before reading. If the README category yields no match, surface "No README found; reading manifest only." to the user once and continue — manifest-only repos are still adoptable.
 
 - **README**: `README.md`, `README.rst`, `README` (first found)
-- **Manifest**: `pyproject.toml`, `package.json`, `Cargo.toml`, `go.mod`, `Gemfile`, `pom.xml`, `build.gradle`, `composer.json`, `requirements*.txt`. Read the root manifest. If it declares a workspace — `[tool.uv.workspace]` with `members = [...]` in `pyproject.toml`, a top-level `workspaces` array in `package.json` (npm/pnpm/yarn), or `[workspace]` with `members = [...]` in `Cargo.toml` — also read each member manifest at its declared path. Otherwise stop at the root match. The root manifest of a workspace is often a thin shim with no real dependencies; member manifests carry the actual stack.
+- **Manifest**: `pyproject.toml`, `package.json`, `Cargo.toml`, `go.mod`, `Gemfile`, `pom.xml`, `build.gradle`, `composer.json`, `requirements*.txt`. Read the root manifest. If it declares a workspace, also read each member manifest. Workspace declarations to recognise:
+    - `pyproject.toml` → `[tool.uv.workspace]` `members = [...]`
+    - `package.json` (npm / Yarn classic) → top-level `workspaces` array
+    - `pnpm-workspace.yaml` → top-level `packages:` list (pnpm does **not** use `package.json` `workspaces`)
+    - `Cargo.toml` → `[workspace]` `members = [...]`
+
+  Member entries are usually globs (`packages/*`, `crates/*`). Expand each glob and read every matched directory's manifest of the same ecosystem. Otherwise stop at the root match. The root manifest of a workspace is often a thin shim with no real dependencies; member manifests carry the actual stack.
 - **Top-level docs**: `CONTRIBUTING.md`, `ARCHITECTURE.md`, `DESIGN.md`, `CLAUDE.md`, `AGENTS.md`
 - **ADR directory**: `docs/adr/`, `docs/decisions/`, `architecture/decisions/`, `adr/` — every `.md` except templates and index files (`0000-template.md`, `README.md`)
 - **Memory Bank**: `.context/`, `memory-bank/`, `cline_docs/` — `projectBrief.md`, `activeContext.md`, `techContext.md`, `decisionLog.md`, `progress.md`

--- a/packages/nauro/src/nauro/skills/adopt_body.md
+++ b/packages/nauro/src/nauro/skills/adopt_body.md
@@ -8,19 +8,28 @@ The agent runs `git rev-parse --show-toplevel` from the current working director
 
 ## Step 2 — Already-adopted guard
 
-The agent reads `<repo>/.nauro/config.json`. If the file is missing: abort with "This repo is not adopted yet. Run 'nauro adopt' from the repo root, restart this agent, then invoke /nauro-adopt again." If the file exists and parses as JSON: extract `id` and `name` and use these as the project handle for subsequent calls.
+The agent reads `<repo>/.nauro/config.json`. If it exists and parses as JSON: extract `id` and `name` and use them as the project handle.
+
+If the file is missing, try two fallbacks before aborting:
+
+1. **Worktree fallback.** Compare `git rev-parse --git-dir` and `git rev-parse --git-common-dir`. If they differ, the current checkout is a linked worktree, and `.nauro/` may only exist in the main worktree (common when a workspace tool gitignores `.nauro/` per-checkout). Resolve the main worktree path from `git worktree list --porcelain` (the first `worktree` line) and re-read `<main-worktree>/.nauro/config.json`.
+2. **Registry fallback.** Read `~/.nauro/registry.json`. If any project's `repo_paths` contains the current repo root or the resolved main-worktree path, use that project's `id` and `name`.
+
+Abort only when both fallbacks miss, with: "This repo is not adopted yet. Run 'nauro adopt' from the repo root, restart this agent, then invoke /nauro-adopt again."
 
 Pass `id` as the `project_id` argument on every subsequent MCP call (`propose_decision`, `confirm_decision`, `update_state`, `flag_question`, `get_context`, `list_decisions`). Do not omit `project_id` even though the tool descriptions say it's optional — auto-resolve routes to the user's default project, which is **not** the project this skill is seeding when both local-mode and cloud-mode projects coexist.
 
 ## Step 3 — Read source files
 
-The agent reads the first match found per category. Files larger than 256KB are flagged to the user before reading. If the README category yields no match, surface "No README found; reading manifest only." to the user once and continue — manifest-only repos are still adoptable.
+The agent reads the first match found per category, with the manifest workspace exception below. Files larger than 256KB are flagged to the user before reading. If the README category yields no match, surface "No README found; reading manifest only." to the user once and continue — manifest-only repos are still adoptable.
 
 - **README**: `README.md`, `README.rst`, `README` (first found)
-- **Manifest**: `pyproject.toml`, `package.json`, `Cargo.toml`, `go.mod`, `Gemfile`, `pom.xml`, `build.gradle`, `composer.json`, `requirements*.txt`
+- **Manifest**: `pyproject.toml`, `package.json`, `Cargo.toml`, `go.mod`, `Gemfile`, `pom.xml`, `build.gradle`, `composer.json`, `requirements*.txt`. Read the root manifest. If it declares a workspace — `[tool.uv.workspace]` with `members = [...]` in `pyproject.toml`, a top-level `workspaces` array in `package.json` (npm/pnpm/yarn), or `[workspace]` with `members = [...]` in `Cargo.toml` — also read each member manifest at its declared path. Otherwise stop at the root match. The root manifest of a workspace is often a thin shim with no real dependencies; member manifests carry the actual stack.
 - **Top-level docs**: `CONTRIBUTING.md`, `ARCHITECTURE.md`, `DESIGN.md`, `CLAUDE.md`, `AGENTS.md`
 - **ADR directory**: `docs/adr/`, `docs/decisions/`, `architecture/decisions/`, `adr/` — every `.md` except templates and index files (`0000-template.md`, `README.md`)
 - **Memory Bank**: `.context/`, `memory-bank/`, `cline_docs/` — `projectBrief.md`, `activeContext.md`, `techContext.md`, `decisionLog.md`, `progress.md`
+
+The agent does not read source code, tests, IaC templates, or git history during adopt. Those surfaces are out of scope on purpose — every recorded fact must trace back to an explicit source document so the refusal contract in Step 9 holds.
 
 ### Step 3b — Chat-surface paste branch
 
@@ -42,11 +51,11 @@ The agent calls `get_context` (MCP) to surface what the scaffold already wrote �
 
 The agent triages the source content into two lists.
 
-**Step 5a — Clear decisions.** Candidates where the source explicitly states acceptance and rationale (and, when applicable, rejected alternatives). Each entry: number, title (≤60 chars), one-line summary (≤140 chars), source location. The agent prints the full list as one message:
+**Step 5a — Clear decisions.** Candidates where the source explicitly states acceptance and rationale (and, when applicable, rejected alternatives). Each entry: number, title (≤60 chars), one-line summary (≤140 chars), source location. A candidate also qualifies as a clear decision when the rule is stated in one explicit source document and the rationale is stated in a *different* explicit source document — cite both source locations in the entry (e.g. "rule: CLAUDE.md §Conventions; rationale: README §How it works"). The agent does not invent the second source to make a candidate fit; if rationale is absent from every source the candidate goes to Step 5b. The agent prints the full list as one message:
 
 > Reply 'keep N' / 'edit N: <new title>' / 'skip N' per item. Or 'keep all' to accept everything. Reply 'done' when finished.
 
-**Step 5b — Boundary candidates.** Facts that *might* be decisions but where the source does not state rationale verbatim. Surfaced after the user finishes Step 5a:
+**Step 5b — Boundary candidates.** Facts that *might* be decisions but where the source does not state rationale verbatim. Stack inventory (languages, frameworks, package managers, license, lint tooling) lives here unless a source frames the choice with rationale. Surfaced after the user finishes Step 5a:
 
 > The agent thinks these might be decisions but couldn't extract rationale verbatim from the source. Each is opt-in only — reply 'opt N: <rationale>' to record any of them with rationale you provide; otherwise they are skipped.
 
@@ -81,7 +90,13 @@ Sources: explicit `## Open Questions` sections, lines beginning `Q:` or `TODO:` 
 
 ## Step 9 — Refusal contract
 
-The agent records facts that source documents explicitly state. The agent does not infer rationale from prose, does not invent rejected alternatives, does not assume `confidence=high` from tone, does not summarize a paragraph into a "decision" the source never called a decision. Boundary cases go to Step 5b (opt-in only — write rationale yourself), not into the clear-decisions list.
+The agent records facts that source documents explicitly state. The agent does not infer rationale from prose, does not invent rejected alternatives, does not assume `confidence=high` from tone, does not summarize a paragraph into a "decision" the source never called a decision. Three specific traps to avoid:
+
+- **Demo prose.** Decision-shaped statements inside README quickstart examples, illustrative scenarios, hypothetical user prompts, comparison tables, or product-demo narratives are false positives unless an independent source (CLAUDE.md, ADR, ARCHITECTURE.md, manifest, Memory-Bank) names the same fact as an actual project decision. In that case the independent source is the citation, not the demo prose.
+- **Stack inventory.** Languages, frameworks, package managers, license, and lint tooling listed in a manifest or a "Stack" section are inventory, not decisions, unless the source frames the choice with rationale (in which case Step 5a applies, possibly via cross-doc stitching).
+- **Cross-doc stitching is not inference.** When Step 5a stitches a rule from one source with rationale from another, both source locations must be explicit. The agent never fills in a missing rationale itself, and never treats two restatements of the same rule as "rule + rationale".
+
+Boundary cases go to Step 5b (opt-in only — write rationale yourself), not into the clear-decisions list.
 
 ## Step 10 — Summary
 

--- a/packages/nauro/src/nauro/skills/adopt_body.md
+++ b/packages/nauro/src/nauro/skills/adopt_body.md
@@ -12,8 +12,8 @@ The agent reads `<repo>/.nauro/config.json`. If it exists and parses as JSON: ex
 
 If the file is missing, try two fallbacks before aborting:
 
-1. **Worktree fallback.** Compare `git rev-parse --git-dir` and `git rev-parse --git-common-dir`. If they differ, the current checkout is a linked worktree, and `.nauro/` may only exist in the main worktree (common when a workspace tool gitignores `.nauro/` per-checkout). Resolve the main worktree path from `git worktree list --porcelain` (the first `worktree` line) and re-read `<main-worktree>/.nauro/config.json`.
-2. **Registry fallback.** Read `~/.nauro/registry.json`. If any project's `repo_paths` contains the current repo root or the resolved main-worktree path, use that project's `id` and `name`.
+1. **Worktree fallback.** Compare `git rev-parse --git-dir` and `git rev-parse --git-common-dir`. If they differ, the current checkout is a linked worktree, and `.nauro/` may only exist in the main worktree (common when a workspace tool gitignores `.nauro/` per-checkout). The main worktree path is the parent directory of `git rev-parse --path-format=absolute --git-common-dir`. Re-read `<main-worktree>/.nauro/config.json` there.
+2. **Registry fallback.** Read `~/.nauro/registry.json`. Schema v2 keys each project by its id under `projects` — the dict key **is** the project `id`; the entry stores `name`, `mode`, `repo_paths`, etc. If any entry's `repo_paths` contains the current repo root or the resolved main-worktree path, use that dict key as the `id` and the entry's `name` as the project handle.
 
 Abort only when both fallbacks miss, with: "This repo is not adopted yet. Run 'nauro adopt' from the repo root, restart this agent, then invoke /nauro-adopt again."
 
@@ -24,7 +24,13 @@ Pass `id` as the `project_id` argument on every subsequent MCP call (`propose_de
 The agent reads the first match found per category, with the manifest workspace exception below. Files larger than 256KB are flagged to the user before reading. If the README category yields no match, surface "No README found; reading manifest only." to the user once and continue — manifest-only repos are still adoptable.
 
 - **README**: `README.md`, `README.rst`, `README` (first found)
-- **Manifest**: `pyproject.toml`, `package.json`, `Cargo.toml`, `go.mod`, `Gemfile`, `pom.xml`, `build.gradle`, `composer.json`, `requirements*.txt`. Read the root manifest. If it declares a workspace — `[tool.uv.workspace]` with `members = [...]` in `pyproject.toml`, a top-level `workspaces` array in `package.json` (npm/pnpm/yarn), or `[workspace]` with `members = [...]` in `Cargo.toml` — also read each member manifest at its declared path. Otherwise stop at the root match. The root manifest of a workspace is often a thin shim with no real dependencies; member manifests carry the actual stack.
+- **Manifest**: `pyproject.toml`, `package.json`, `Cargo.toml`, `go.mod`, `Gemfile`, `pom.xml`, `build.gradle`, `composer.json`, `requirements*.txt`. Read the root manifest. If it declares a workspace, also read each member manifest. Workspace declarations to recognise:
+    - `pyproject.toml` → `[tool.uv.workspace]` `members = [...]`
+    - `package.json` (npm / Yarn classic) → top-level `workspaces` array
+    - `pnpm-workspace.yaml` → top-level `packages:` list (pnpm does **not** use `package.json` `workspaces`)
+    - `Cargo.toml` → `[workspace]` `members = [...]`
+
+  Member entries are usually globs (`packages/*`, `crates/*`). Expand each glob and read every matched directory's manifest of the same ecosystem. Otherwise stop at the root match. The root manifest of a workspace is often a thin shim with no real dependencies; member manifests carry the actual stack.
 - **Top-level docs**: `CONTRIBUTING.md`, `ARCHITECTURE.md`, `DESIGN.md`, `CLAUDE.md`, `AGENTS.md`
 - **ADR directory**: `docs/adr/`, `docs/decisions/`, `architecture/decisions/`, `adr/` — every `.md` except templates and index files (`0000-template.md`, `README.md`)
 - **Memory Bank**: `.context/`, `memory-bank/`, `cline_docs/` — `projectBrief.md`, `activeContext.md`, `techContext.md`, `decisionLog.md`, `progress.md`


### PR DESCRIPTION
## Why

An empirical trace of `/nauro-adopt` against the nauro monorepo and mcp-server surfaced four concrete failures of the current body:

- **Step 2 aborted in any linked-worktree checkout** even when the canonical repo was already adopted — some workspace setups gitignore `.nauro/` per-checkout, so the worktree never sees the config file.
- **Step 3's "first match" manifest rule read only the workspace stub** at the repo root and missed every `packages/*/pyproject.toml`. For this repo that's the entire stack (Typer, FastAPI, ULIDs, BM25) — none of it visible to the skill.
- **README demo prose looks like real decisions.** Our own README has an "SSE over WebSocket because persistent connections weren't released during ECS rolling deploys" quickstart line. A literal-reading agent would surface it as a candidate; it's marketing fiction.
- **The refusal contract was doc-local.** When a rule is stated in CLAUDE.md and the rationale is stated in the README (a common pattern), the agent had no path to record it as a clear decision — it could only put the candidate in the 5b boundary list and ask the user to retype rationale they'd already written.

## Approach

Doc-only skill, doc-only patches. The trace recommendation was explicit: a small prompt patch, not a redesign — do **not** teach the agent to read source code, tests, IaC, or git history. That would compromise the explicit-source-only refusal contract that makes `/nauro-adopt` safe to run unattended. All four fixes live in the canonical body at `packages/nauro/src/nauro/skills/adopt_body.md`; the three in-repo dogfood files and `docs/adopt-prompt.md` re-render from it through the existing `render_skill()` pipeline.

Rejected: a "code-archaeology" mode that scans source + IaC + git history. Higher candidate yield in theory, but breaks the "every recorded fact must trace to an explicit source document" contract. Sparse-doc repos are better served by a separate structured-interview operation — out of scope here.

## What changed

- `packages/nauro/src/nauro/skills/adopt_body.md` — four patches in one body:
  - **Step 2:** worktree + registry fallback. Detect linked worktrees via `git rev-parse --git-dir` vs `--git-common-dir`, parse `git worktree list --porcelain` for the main worktree path, re-read its `.nauro/config.json`. Failing that, look up the repo root (or canonical main-worktree path) in `~/.nauro/registry.json` `repo_paths` and use the matching project's `id` / `name`. Abort only when both miss.
  - **Step 3:** workspace-aware manifest reading. Recognises `[tool.uv.workspace]` in `pyproject.toml`, top-level `workspaces` in `package.json` (npm/pnpm/yarn), and `[workspace]` in `Cargo.toml` — reads every member manifest in those cases, otherwise stops at the first root match. New paragraph at the bottom of the step states explicitly that source code, tests, IaC, and git history are out of scope (preserves the Step 9 contract).
  - **Step 5a / 5b:** cross-doc rationale stitching is now a clear-decision path provided both source locations are cited; stack inventory belongs in 5b unless the source frames the choice with rationale.
  - **Step 9:** three named traps — *Demo prose* (README quickstart / illustrative / comparison-table statements are FP unless an independent source names the same fact), *Stack inventory* (manifest / "Stack" sections are inventory, not decisions), *Cross-doc stitching is not inference* (two restatements of the same rule ≠ rule + rationale).
- Re-rendered dogfood / docs surfaces (byte-equal to `render_skill(...)` per the existing drift tests):
  - `.claude/skills/nauro-adopt/SKILL.md`
  - `.agents/skills/nauro-adopt/SKILL.md`
  - `.cursor/rules/nauro-adopt.mdc`
  - `docs/adopt-prompt.md` (chat-paste wrapper intro preserved; body replaced)

## What to review

- **Step 2 worktree mechanics.** `git rev-parse --git-dir` / `--git-common-dir` + first `worktree` line of `--porcelain` is correct for standard linked worktrees; submodule and bare-repo edge cases aren't covered, but the fallback is gated behind "config missing" so the worst case is the pre-existing abort.
- **Step 9 tone.** "Cross-doc stitching is not inference" is the densest line in the body. Intent: block the "two paraphrases = rule + rationale" failure mode. Worth a read to check it doesn't trip a careful agent into refusing legitimate stitches.
- **Illustrative citation example** in Step 5a uses `CLAUDE.md §Conventions` and `README §How it works` as filler — generic format, not a prescribed pair. Easy to change if it reads as overfit.
- **No new tests** for the body content itself (it's prose). The existing parametrized `test_skills_drift.py` already enforces byte-parity across all six dogfood files plus `docs/adopt-prompt.md` and scans for retired phrases.

## What's deferred

- A separate operation (`nauro adopt --interview` or a new skill) for sparse-doc repos where the rich context lives in code, IaC, or the user's head. The trace memo flagged this as the better destination for any "code archaeology" behavior.
- `[tool.poetry] packages` and PDM monorepo cases — niche enough to skip; the three major ecosystems (uv, npm/pnpm/yarn, Cargo) are covered.
- Adopt-skill telemetry on how many candidates land in 5a vs 5b vs FP after these patches — would require real-world adopt runs.

## Test plan

- `uv run pytest packages/nauro/tests/test_skills_drift.py packages/nauro/tests/test_adopt.py -x -q` → **48 passed** (16 drift tests + 32 adopt CLI tests).
- `uv run pytest packages/nauro/tests/ packages/nauro-core/tests/ -x -q -m "not integration"` → **939 passed**.
- `uv run ruff check packages/` → clean.
- `uv run ruff format --check packages/` → 139 files already formatted.
- Spot-checked the four rendered surfaces; new Step 2 / Step 3 / Step 5a / Step 9 wording present verbatim, frontmatter unchanged.