### PR TITLE
feat(skills): code-aware /nauro-adopt per D125 v2

### DIFF
--- a/.agents/skills/nauro-adopt/SKILL.md
+++ b/.agents/skills/nauro-adopt/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nauro-adopt
-description: Seeds Nauro's project store from an existing repo. Use after the user has run `nauro adopt` locally. On filesystem-capable surfaces (Claude Code, Cursor, Codex CLI), reads docs (README, manifests, ADRs, Memory-Bank) for rationale and inspects code, config, tests, lockfiles, and recent git history for evidence, then surfaces targeted probes that turn evidence into rationale. On chat surfaces, reads pasted content against an already-adopted project. Writes decisions, state, and open questions via existing MCP write tools.
+description: Seeds Nauro's project store from an existing repo. Use after `nauro adopt` has run locally. On filesystem-capable surfaces, reads docs (README, manifests, ADRs, Memory-Bank) for rationale and inspects code, config, tests, lockfiles, and recent git history for evidence, then surfaces targeted probes that turn evidence into rationale. On chat surfaces, operates on pasted content against an already-adopted project.
 ---
 
 # Nauro adopt skill
@@ -118,7 +118,21 @@ For each kept candidate from 6a and each rationale-supplied 6b answer, the agent
     - **update** when the candidate augments an existing decision's rationale only. Per D133 the server consumes only `rationale` on update; `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, and `rejected` are rejected at the boundary — use supersede if any of those must change.
     - **supersede** when the title or other metadata must change, or the candidate replaces or contradicts an existing decision. Pass the full new body and set `affected_decision_id`.
     - **skip** when the candidate is a duplicate (e.g. matches `001-initial-setup` or a candidate already seeded earlier in this same adopt run).
-4. Call `propose_decision(project_id=..., title=..., rationale=..., operation=<op>, affected_decision_id=<N when update or supersede>, rejected=<…>, confidence=<…>)`. `rationale` is drawn from explicit Step 3 source text (6a) or the user's probe answer (6b). `confidence` defaults to `medium`; use `high` only when a source explicitly says "accepted" or "approved". Include rejected alternatives only when the source names them or the user supplies them in the probe answer.
+4. Call `propose_decision` using the call signature for the chosen operation — these are operation-specific by design so an agent copying the template cannot accidentally send a field the server will reject:
+    - For **add** (new decisions):
+      ```
+      propose_decision(project_id=..., title=..., rationale=..., operation="add", rejected=..., confidence=...)
+      ```
+    - For **update** (rationale-only — D133 rejects every other field at the boundary):
+      ```
+      propose_decision(project_id=..., rationale=..., operation="update", affected_decision_id=...)
+      ```
+    - For **supersede** (replace a decision or change metadata; pass the full new body):
+      ```
+      propose_decision(project_id=..., title=..., rationale=..., operation="supersede", affected_decision_id=..., rejected=..., confidence=...)
+      ```
+
+   `rationale` is drawn from explicit Step 3 source text (6a) or the user's probe answer (6b). `confidence` defaults to `medium`; use `high` only when a source explicitly says "accepted" or "approved". Include rejected alternatives only when the source names them or the user supplies them in the probe answer.
 5. Call `confirm_decision(confirm_id, project_id=...)`:
     - `add` + no conflicts → auto-confirm.
     - `add` + conflicts → surface the assessment verbatim, ask `confirm-anyway / edit / skip`; confirm only on user 'confirm'.

--- a/.agents/skills/nauro-adopt/SKILL.md
+++ b/.agents/skills/nauro-adopt/SKILL.md
@@ -1,11 +1,18 @@
 ---
 name: nauro-adopt
-description: Seeds Nauro's project store from an existing repo's documentation. Use after the user has run `nauro adopt` locally — reads README, manifests, ADRs, and Memory-Bank files, surfaces decision candidates for triage, and writes them to Nauro via existing MCP write tools.
+description: Seeds Nauro's project store from an existing repo. Use after the user has run `nauro adopt` locally. On filesystem-capable surfaces (Claude Code, Cursor, Codex CLI), reads docs (README, manifests, ADRs, Memory-Bank) for rationale and inspects code, config, tests, lockfiles, and recent git history for evidence, then surfaces targeted probes that turn evidence into rationale. On chat surfaces, reads pasted content against an already-adopted project. Writes decisions, state, and open questions via existing MCP write tools.
 ---
 
 # Nauro adopt skill
 
-The agent helps the user seed Nauro with context from the current repo. Before this skill runs, the user has run `nauro adopt` from the repo root, which created the project, wired MCP across surfaces, and installed this skill into the agent's surface directory. The agent's job here is to read the repo's documentation (README, manifests, ADRs, Memory-Bank) and seed the Nauro store via MCP write tools. The agent records facts that source documents explicitly state — it does not invent decisions from prose. On chat surfaces (Claude.ai, ChatGPT) without filesystem access, the agent uses paste-content mode (Step 3b); chat-paste mode requires the project to already exist (run `nauro adopt` locally first).
+The agent helps the user seed Nauro with context from the current repo. Before this skill runs, the user has run `nauro adopt` from the repo root, which created the project, wired MCP across surfaces, and installed this skill into the agent's surface directory. The agent's job here is to seed the Nauro store via MCP write tools: docs supply the rationale for documented decisions, code and config and tests and manifests and recent git history supply evidence, and the user supplies the "why" via targeted probes when only evidence is present. The agent records decisions that source documents explicitly state, or that the user confirms in response to a probe — it does not invent rationale from code or prose.
+
+## Surface modes
+
+The agent's behaviour depends on whether the surface can read the repo directly.
+
+- **Filesystem-capable surfaces** (Claude Code, Cursor, Codex CLI). The agent runs Steps 1–11 in full. Docs are read for rationale in Step 3; code, config, tests, manifests, and recent git history are inspected for evidence in Step 4; targeted probes in Step 6b turn evidence into rationale by asking the user.
+- **Chat surfaces** (Claude.ai, ChatGPT, Perplexity). The agent has no shell. It operates only on content the user pastes into the chat (Step 3b), and only against an already-adopted project per D127 (verified in Step 2). The code-evidence path (Step 4) and the Step 6b probes are unavailable; the agent does not ask the user to paste code in lieu of running shell commands. The skill skips from Step 3b directly to Step 5.
 
 ## Step 1 — Detect repo root
 
@@ -22,11 +29,11 @@ If the file is missing, try two fallbacks before aborting:
 
 Abort only when both fallbacks miss, with: "This repo is not adopted yet. Run 'nauro adopt' from the repo root, restart this agent, then invoke /nauro-adopt again."
 
-Pass `id` as the `project_id` argument on every subsequent MCP call (`propose_decision`, `confirm_decision`, `update_state`, `flag_question`, `get_context`, `list_decisions`). Do not omit `project_id` even though the tool descriptions say it's optional — auto-resolve routes to the user's default project, which is **not** the project this skill is seeding when both local-mode and cloud-mode projects coexist.
+Pass `id` as the `project_id` argument on every subsequent MCP call (`propose_decision`, `confirm_decision`, `update_state`, `flag_question`, `get_context`, `list_decisions`, `check_decision`, `get_decision`). Do not omit `project_id` even though the tool descriptions say it's optional — auto-resolve routes to the user's default project, which is **not** the project this skill is seeding when both local-mode and cloud-mode projects coexist.
 
-## Step 3 — Read source files
+## Step 3 — Read documentation
 
-The agent reads the first match found per category, with the manifest workspace exception below. Files larger than 256KB are flagged to the user before reading. If the README category yields no match, surface "No README found; reading manifest only." to the user once and continue — manifest-only repos are still adoptable.
+Docs are the rationale source. The agent reads the first match found per category, with the manifest workspace exception below. Files larger than 256KB are flagged to the user before reading. If the README category yields no match, surface "No README found; reading manifest only." to the user once and continue — manifest-only repos are still adoptable.
 
 - **README**: `README.md`, `README.rst`, `README` (first found)
 - **Manifest**: `pyproject.toml`, `package.json`, `Cargo.toml`, `go.mod`, `Gemfile`, `pom.xml`, `build.gradle`, `composer.json`, `requirements*.txt`. Read the root manifest. If it declares a workspace, also read each member manifest. Workspace declarations to recognise:
@@ -40,8 +47,6 @@ The agent reads the first match found per category, with the manifest workspace 
 - **ADR directory**: `docs/adr/`, `docs/decisions/`, `architecture/decisions/`, `adr/` — every `.md` except templates and index files (`0000-template.md`, `README.md`)
 - **Memory Bank**: `.context/`, `memory-bank/`, `cline_docs/` — `projectBrief.md`, `activeContext.md`, `techContext.md`, `decisionLog.md`, `progress.md`
 
-The agent does not read source code, tests, IaC templates, or git history during adopt. Those surfaces are out of scope on purpose — every recorded fact must trace back to an explicit source document so the refusal contract in Step 9 holds.
-
 ### Step 3b — Chat-surface paste branch
 
 When filesystem read is unavailable (chat surfaces), the agent first verifies the project exists by asking:
@@ -52,35 +57,76 @@ If the user cannot confirm an adopted project, the agent surfaces "Run `nauro ad
 
 > This skill needs source content. Paste the contents of any of: README, manifest (pyproject.toml/package.json/etc.), ADRs, Memory-Bank files. Send each as a separate message labelled with the filename.
 
-Chat-paste mode does not create projects.
+Chat-paste mode does not create projects, and chat surfaces skip Step 4 — code evidence is shell-bound and the agent does not ask the user to paste code in lieu of running commands.
 
-## Step 4 — Call get_context
+## Step 4 — Read code evidence
 
-The agent calls `get_context` (MCP) to surface what the scaffold already wrote — `001-initial-setup.md` and bracketed-prompt placeholders in `project.md` / `stack.md`. The agent uses this to (a) avoid duplicating the scaffold's first decision, (b) confirm the project resolved correctly.
+Filesystem-capable surfaces only. After Step 3, the agent inspects repo state to identify architectural facts that docs may not name. Each finding is held as an **observation** keyed by file path — never proposed as a decision on its own. Observations drive Step 6b's targeted probes; the user (or a Step 3 doc) must supply the rationale before anything flows into the decision log.
 
-## Step 5 — Build candidate list, surface FIRST
+Categories to inspect (the goal is enough evidence to ask the right probes, not a full inventory):
 
-The agent triages the source content into two lists.
+- **Source-tree layout.** `ls` the repo root and any workspace member directories. Note monorepo vs single-package shape, `src/`-layout vs flat, service-per-directory vs library-per-package.
+- **CI / CD config.** `.github/workflows/`, `.gitlab-ci.yml`, `.circleci/config.yml`, `azure-pipelines.yml`. Note the version matrix (which Python / Node / Rust versions are tested), required checks, and deployment targets.
+- **Test layout.** Test directory location (`tests/`, `__tests__/`, `*_test.go`), framework signals (pytest / jest / cargo test / go test), fixture conventions, and any integration vs unit split.
+- **Lint and format config.** `ruff.toml`, `.eslintrc*`, `.prettierrc*`, `mypy.ini`, `pyrightconfig.json`, `rustfmt.toml`, `.golangci.yml`.
+- **Infrastructure as code.** `Dockerfile`, `docker-compose.yml`, `terraform/`, `cdk.json`, `serverless.yml`, `sam/template.yaml`, `pulumi/`.
+- **Lockfiles and pinned versions.** Presence of `poetry.lock`, `uv.lock`, `package-lock.json`, `pnpm-lock.yaml`, `Cargo.lock`, `go.sum`. Note which package manager is canonical; do not enumerate every dependency.
+- **Recent git history.** `git log --oneline -n 30 --no-merges` to see what's active, when activity slowed, and which areas of the tree are touched most.
 
-**Step 5a — Clear decisions.** Candidates where the source explicitly states acceptance and rationale (and, when applicable, rejected alternatives). Each entry: number, title (≤60 chars), one-line summary (≤140 chars), source location. A candidate also qualifies as a clear decision when the rule is stated in one explicit source document and the rationale is stated in a *different* explicit source document — cite both source locations in the entry (e.g. "rule: CLAUDE.md §Conventions; rationale: README §How it works"). The agent does not invent the second source to make a candidate fit; if rationale is absent from every source the candidate goes to Step 5b. The agent prints the full list as one message:
+Step 4 ends with a list of observations, not a list of candidate decisions. Promotion into a candidate happens in Step 6b, after the user answers a probe.
+
+## Step 5 — Call get_context
+
+The agent calls `get_context` (MCP) to surface what the scaffold already wrote — `001-initial-setup.md` and bracketed-prompt placeholders in `project.md` / `stack.md`. The agent uses this to (a) avoid duplicating the scaffold's first decision, (b) confirm the project resolved correctly, and (c) learn what `check_decision` will treat as the existing baseline in Step 7.
+
+## Step 6 — Triage candidates
+
+Every candidate the agent surfaces lands in one of five buckets: **documented decision** (Step 6a), **code-evidenced fact needing rationale** (Step 6b, filesystem-capable only), **stack inventory** (Step 6c), **open question** (Step 9), or **ignore** (Step 10 refusal contract). The agent walks 6a → 6b → 6c in order, surfacing one list per substep and waiting for user input before continuing.
+
+### Step 6a — Documented decisions
+
+Candidates where a Step 3 source explicitly states acceptance and rationale (and, when applicable, rejected alternatives). Each entry: number, title (≤60 chars), one-line summary (≤140 chars), source location. A candidate also qualifies as documented when the rule is stated in one explicit source document and the rationale is stated in a *different* explicit source document — cite both source locations in the entry (e.g. "rule: CLAUDE.md §Conventions; rationale: README §How it works"). Code is never the rationale half of a cross-source pair; if rationale is absent from every doc the candidate falls to 6b or 6c. The agent prints the full list as one message:
 
 > Reply 'keep N' / 'edit N: <new title>' / 'skip N' per item. Or 'keep all' to accept everything. Reply 'done' when finished.
 
-**Step 5b — Boundary candidates.** Facts that *might* be decisions but where the source does not state rationale verbatim. Stack inventory (languages, frameworks, package managers, license, lint tooling) lives here unless a source frames the choice with rationale. Surfaced after the user finishes Step 5a:
+### Step 6b — Code-evidenced facts needing rationale
 
-> The agent thinks these might be decisions but couldn't extract rationale verbatim from the source. Each is opt-in only — reply 'opt N: <rationale>' to record any of them with rationale you provide; otherwise they are skipped.
+Filesystem-capable surfaces only. For each Step 4 observation that points at a real architectural choice (workspace shape, framework pick, test-layout convention, CI matrix, IaC target, …), the agent emits one targeted probe per observation, using this template verbatim:
 
-## Step 6 — Iterate kept items
+> I see X in file/path; was Y considered; what pushed you toward X?
 
-For each kept item from 5a (and each opt-in from 5b):
+Substitute `X` with the observed fact, `file/path` with the source it came from, and `Y` with a credible alternative the agent inferred (or "an alternative" if none is obvious). Probes are batched into one message; the user replies per item:
 
-1. Call `propose_decision(title=..., rationale=..., operation="add", rejected=..., confidence=...)`. Adopt seeds the store from source documents, so it normally uses `operation="add"` and does not set `affected_decision_id`. `rationale` is drawn from explicit source text or user-provided opt-ins. `confidence` defaults to `medium`; use `high` only when the source explicitly says "accepted" or "approved". Include rejected alternatives only when the source names them.
-2. **If `propose_decision` returns no conflicts**: call `confirm_decision(confirm_id)` automatically — no further user prompt.
-3. **If `propose_decision` returns conflicts**: surface the conflict text verbatim, ask `confirm-anyway / edit / skip`. On user 'confirm' → `confirm_decision(confirm_id)`.
+> Reply 'rationale N: <why>' to record it as a decision (it flows into the Step 7 write loop), 'inventory N' to drop it to stack inventory (6c), 'question N' to flag it as an open question (Step 9), or 'skip N' to drop it entirely.
 
-One propose+confirm per decision. No batching.
+When the user supplies rationale, the candidate is promoted into the Step 7 write loop with `operation="add"` by default — Step 7 step 3 reclassifies to `update` or `supersede` if `check_decision` surfaces an overlap.
 
-## Step 7 — State composition (one update_state call)
+### Step 6c — Stack inventory
+
+Languages, frameworks, package managers, license, lint tooling, and similar facts visible in the manifest or a "Stack" section without verbatim rationale. Stack inventory is folded into Step 8's `update_state` delta as a short summary — never written as decisions on its own. The only exception is a stack choice promoted into 6a via cross-doc stitching (rule in manifest, rationale in a separate doc). The agent prints the inventory list as one message:
+
+> The agent will fold these into the project state summary in Step 8. Reply 'drop N' to remove any, 'edit N: <new wording>' to rewrite, or 'done' to accept.
+
+## Step 7 — Write loop
+
+For each kept candidate from 6a and each rationale-supplied 6b answer, the agent runs the full D131 / D133 protocol:
+
+1. Call `check_decision(proposed_approach=<title or short description>, project_id=...)`. The tool returns related decisions via BM25 retrieval and a deterministic assessment.
+2. For each related decision in the response, call `get_decision(number=N, project_id=...)`. `check_decision` does not judge conflicts — the agent reads the decision bodies to decide what the right action is.
+3. Classify the operation:
+    - **add** (default; new ground, no existing decision covers it).
+    - **update** when the candidate augments an existing decision's rationale only. Per D133 the server consumes only `rationale` on update; `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, and `rejected` are rejected at the boundary — use supersede if any of those must change.
+    - **supersede** when the title or other metadata must change, or the candidate replaces or contradicts an existing decision. Pass the full new body and set `affected_decision_id`.
+    - **skip** when the candidate is a duplicate (e.g. matches `001-initial-setup` or a candidate already seeded earlier in this same adopt run).
+4. Call `propose_decision(project_id=..., title=..., rationale=..., operation=<op>, affected_decision_id=<N when update or supersede>, rejected=<…>, confidence=<…>)`. `rationale` is drawn from explicit Step 3 source text (6a) or the user's probe answer (6b). `confidence` defaults to `medium`; use `high` only when a source explicitly says "accepted" or "approved". Include rejected alternatives only when the source names them or the user supplies them in the probe answer.
+5. Call `confirm_decision(confirm_id, project_id=...)`:
+    - `add` + no conflicts → auto-confirm.
+    - `add` + conflicts → surface the assessment verbatim, ask `confirm-anyway / edit / skip`; confirm only on user 'confirm'.
+    - `update` or `supersede` → always pending per D131. Surface the assessment first; confirm only on explicit user 'confirm'.
+
+One propose+confirm per candidate. No batching.
+
+## Step 8 — State composition (one update_state call)
 
 The agent reads `activeContext.md` body and `progress.md` items, then composes one delta:
 
@@ -93,30 +139,44 @@ The agent reads `activeContext.md` body and `progress.md` items, then composes o
 - ...
 ```
 
-If only one source is present, the corresponding section is omitted. If neither is present, `update_state` is skipped entirely. **The agent does not call `update_state` per progress item** — `update_state` archives prior state to history, and the L0 payload ignores history.
+If Step 6c produced inventory items, append a short trailing section:
 
-## Step 8 — Flag open questions
+```
 
-Sources: explicit `## Open Questions` sections, lines beginning `Q:` or `TODO:` in CONTRIBUTING/ARCHITECTURE docs, user-noted gaps from Steps 5–6 ("we never decided X"). Per candidate: surface, ask `keep / edit / skip`. On keep → `flag_question(question, context)`.
+## Stack
+- {inventory_item_1}
+- {inventory_item_2}
+- ...
+```
 
-## Step 9 — Refusal contract
+If only one of activeContext / progress / inventory is present, the corresponding sections are omitted. If none is present, `update_state` is skipped entirely. **The agent does not call `update_state` per progress item or per inventory entry** — `update_state` archives prior state to history, and the L0 payload ignores history.
 
-The agent records facts that source documents explicitly state. The agent does not infer rationale from prose, does not invent rejected alternatives, does not assume `confidence=high` from tone, does not summarize a paragraph into a "decision" the source never called a decision. Three specific traps to avoid:
+## Step 9 — Flag open questions
+
+Sources: explicit `## Open Questions` sections, lines beginning `Q:` or `TODO:` in CONTRIBUTING / ARCHITECTURE docs, user-noted gaps from 6a / 6b / 6c dialogue ("we never decided X"), and Step 6b probes the user routed to `question N` or answered with "I don't know". Per candidate: surface, ask `keep / edit / skip`. On keep → `flag_question(question, context, project_id=...)`.
+
+## Step 10 — Refusal contract
+
+The agent records facts that source documents explicitly state, or that the user supplies in response to a Step 6b probe. The agent does not infer rationale from prose, does not invent rejected alternatives, does not assume `confidence=high` from tone, does not summarize a paragraph into a "decision" the source never called a decision. Five specific traps to avoid:
 
 - **Demo prose.** Decision-shaped statements inside README quickstart examples, illustrative scenarios, hypothetical user prompts, comparison tables, or product-demo narratives are false positives unless an independent source (CLAUDE.md, ADR, ARCHITECTURE.md, manifest, Memory-Bank) names the same fact as an actual project decision. In that case the independent source is the citation, not the demo prose.
-- **Stack inventory.** Languages, frameworks, package managers, license, and lint tooling listed in a manifest or a "Stack" section are inventory, not decisions, unless the source frames the choice with rationale (in which case Step 5a applies, possibly via cross-doc stitching).
-- **Cross-doc stitching is not inference.** When Step 5a stitches a rule from one source with rationale from another, both source locations must be explicit. The agent never fills in a missing rationale itself, and never treats two restatements of the same rule as "rule + rationale".
+- **Stack inventory is not decisions.** Languages, frameworks, package managers, license, and lint tooling listed in a manifest or a "Stack" section are inventory (6c) — they go into the Step 8 delta, not the decision log. Cross-doc stitching is the only path that promotes inventory into 6a.
+- **Cross-doc stitching is not inference.** When 6a stitches a rule from one source with rationale from another, both source locations must be explicit and both must be docs. The agent never fills in a missing rationale itself, never treats two restatements of the same rule as "rule + rationale", and never uses code as the rationale half.
+- **Code evidence is not rationale.** Source code, config files, tests, IaC templates, lockfiles, and git history are evidence of *what* — they tell you a stack was picked, a pattern is present, a CI matrix exists. They do not state *why*. The agent does not propose decisions from code alone; it asks a Step 6b probe and only records the decision once the user (or a Step 3 doc) supplies rationale.
+- **No code-only dependency decisions.** Dependency choices visible in `pyproject.toml`, `package.json`, lockfiles, or similar manifests never become decisions on their own. They land in 6c (stack inventory, folded into Step 8 state) or surface as 6b probes when a particular pick looks load-bearing enough to warrant a rationale.
 
-Boundary cases go to Step 5b (opt-in only — write rationale yourself), not into the clear-decisions list.
+Boundary cases go to 6b (probe → opt-in rationale) or 6c (inventory roll-up). They never flow into 6a without an explicit source.
 
-## Step 10 — Summary
+## Step 11 — Summary
 
 The agent prints one block:
 
 - Project: `<name>` (id: `<pid>`, store: `<store-path>`)
-- Sources read: `<comma-separated list>`
-- Decisions created: N (titles)
-- Decisions skipped: M (titles)
-- State updated: yes/no
-- Open questions flagged: K
+- Sources read: `<comma-separated list of docs from Step 3>`
+- Code evidence inspected: `<comma-separated list of Step 4 categories, or "skipped — chat surface">`
+- Code-evidence probes asked: `P` / answered: `A`
+- Decisions created: `N` (titles)
+- Decisions skipped: `M` (titles)
+- State updated: `yes`/`no`
+- Open questions flagged: `K`
 - Next: run `nauro sync` from the repo to capture a snapshot.

--- a/.claude/skills/nauro-adopt/SKILL.md
+++ b/.claude/skills/nauro-adopt/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nauro-adopt
-description: Seeds Nauro's project store from an existing repo. Use after the user has run `nauro adopt` locally. On filesystem-capable surfaces (Claude Code, Cursor, Codex CLI), reads docs (README, manifests, ADRs, Memory-Bank) for rationale and inspects code, config, tests, lockfiles, and recent git history for evidence, then surfaces targeted probes that turn evidence into rationale. On chat surfaces, reads pasted content against an already-adopted project. Writes decisions, state, and open questions via existing MCP write tools.
+description: Seeds Nauro's project store from an existing repo. Use after `nauro adopt` has run locally. On filesystem-capable surfaces, reads docs (README, manifests, ADRs, Memory-Bank) for rationale and inspects code, config, tests, lockfiles, and recent git history for evidence, then surfaces targeted probes that turn evidence into rationale. On chat surfaces, operates on pasted content against an already-adopted project.
 ---
 
 # Nauro adopt skill
@@ -118,7 +118,21 @@ For each kept candidate from 6a and each rationale-supplied 6b answer, the agent
     - **update** when the candidate augments an existing decision's rationale only. Per D133 the server consumes only `rationale` on update; `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, and `rejected` are rejected at the boundary — use supersede if any of those must change.
     - **supersede** when the title or other metadata must change, or the candidate replaces or contradicts an existing decision. Pass the full new body and set `affected_decision_id`.
     - **skip** when the candidate is a duplicate (e.g. matches `001-initial-setup` or a candidate already seeded earlier in this same adopt run).
-4. Call `propose_decision(project_id=..., title=..., rationale=..., operation=<op>, affected_decision_id=<N when update or supersede>, rejected=<…>, confidence=<…>)`. `rationale` is drawn from explicit Step 3 source text (6a) or the user's probe answer (6b). `confidence` defaults to `medium`; use `high` only when a source explicitly says "accepted" or "approved". Include rejected alternatives only when the source names them or the user supplies them in the probe answer.
+4. Call `propose_decision` using the call signature for the chosen operation — these are operation-specific by design so an agent copying the template cannot accidentally send a field the server will reject:
+    - For **add** (new decisions):
+      ```
+      propose_decision(project_id=..., title=..., rationale=..., operation="add", rejected=..., confidence=...)
+      ```
+    - For **update** (rationale-only — D133 rejects every other field at the boundary):
+      ```
+      propose_decision(project_id=..., rationale=..., operation="update", affected_decision_id=...)
+      ```
+    - For **supersede** (replace a decision or change metadata; pass the full new body):
+      ```
+      propose_decision(project_id=..., title=..., rationale=..., operation="supersede", affected_decision_id=..., rejected=..., confidence=...)
+      ```
+
+   `rationale` is drawn from explicit Step 3 source text (6a) or the user's probe answer (6b). `confidence` defaults to `medium`; use `high` only when a source explicitly says "accepted" or "approved". Include rejected alternatives only when the source names them or the user supplies them in the probe answer.
 5. Call `confirm_decision(confirm_id, project_id=...)`:
     - `add` + no conflicts → auto-confirm.
     - `add` + conflicts → surface the assessment verbatim, ask `confirm-anyway / edit / skip`; confirm only on user 'confirm'.

--- a/.claude/skills/nauro-adopt/SKILL.md
+++ b/.claude/skills/nauro-adopt/SKILL.md
@@ -1,11 +1,18 @@
 ---
 name: nauro-adopt
-description: Seeds Nauro's project store from an existing repo's documentation. Use after the user has run `nauro adopt` locally — reads README, manifests, ADRs, and Memory-Bank files, surfaces decision candidates for triage, and writes them to Nauro via existing MCP write tools.
+description: Seeds Nauro's project store from an existing repo. Use after the user has run `nauro adopt` locally. On filesystem-capable surfaces (Claude Code, Cursor, Codex CLI), reads docs (README, manifests, ADRs, Memory-Bank) for rationale and inspects code, config, tests, lockfiles, and recent git history for evidence, then surfaces targeted probes that turn evidence into rationale. On chat surfaces, reads pasted content against an already-adopted project. Writes decisions, state, and open questions via existing MCP write tools.
 ---
 
 # Nauro adopt skill
 
-The agent helps the user seed Nauro with context from the current repo. Before this skill runs, the user has run `nauro adopt` from the repo root, which created the project, wired MCP across surfaces, and installed this skill into the agent's surface directory. The agent's job here is to read the repo's documentation (README, manifests, ADRs, Memory-Bank) and seed the Nauro store via MCP write tools. The agent records facts that source documents explicitly state — it does not invent decisions from prose. On chat surfaces (Claude.ai, ChatGPT) without filesystem access, the agent uses paste-content mode (Step 3b); chat-paste mode requires the project to already exist (run `nauro adopt` locally first).
+The agent helps the user seed Nauro with context from the current repo. Before this skill runs, the user has run `nauro adopt` from the repo root, which created the project, wired MCP across surfaces, and installed this skill into the agent's surface directory. The agent's job here is to seed the Nauro store via MCP write tools: docs supply the rationale for documented decisions, code and config and tests and manifests and recent git history supply evidence, and the user supplies the "why" via targeted probes when only evidence is present. The agent records decisions that source documents explicitly state, or that the user confirms in response to a probe — it does not invent rationale from code or prose.
+
+## Surface modes
+
+The agent's behaviour depends on whether the surface can read the repo directly.
+
+- **Filesystem-capable surfaces** (Claude Code, Cursor, Codex CLI). The agent runs Steps 1–11 in full. Docs are read for rationale in Step 3; code, config, tests, manifests, and recent git history are inspected for evidence in Step 4; targeted probes in Step 6b turn evidence into rationale by asking the user.
+- **Chat surfaces** (Claude.ai, ChatGPT, Perplexity). The agent has no shell. It operates only on content the user pastes into the chat (Step 3b), and only against an already-adopted project per D127 (verified in Step 2). The code-evidence path (Step 4) and the Step 6b probes are unavailable; the agent does not ask the user to paste code in lieu of running shell commands. The skill skips from Step 3b directly to Step 5.
 
 ## Step 1 — Detect repo root
 
@@ -22,11 +29,11 @@ If the file is missing, try two fallbacks before aborting:
 
 Abort only when both fallbacks miss, with: "This repo is not adopted yet. Run 'nauro adopt' from the repo root, restart this agent, then invoke /nauro-adopt again."
 
-Pass `id` as the `project_id` argument on every subsequent MCP call (`propose_decision`, `confirm_decision`, `update_state`, `flag_question`, `get_context`, `list_decisions`). Do not omit `project_id` even though the tool descriptions say it's optional — auto-resolve routes to the user's default project, which is **not** the project this skill is seeding when both local-mode and cloud-mode projects coexist.
+Pass `id` as the `project_id` argument on every subsequent MCP call (`propose_decision`, `confirm_decision`, `update_state`, `flag_question`, `get_context`, `list_decisions`, `check_decision`, `get_decision`). Do not omit `project_id` even though the tool descriptions say it's optional — auto-resolve routes to the user's default project, which is **not** the project this skill is seeding when both local-mode and cloud-mode projects coexist.
 
-## Step 3 — Read source files
+## Step 3 — Read documentation
 
-The agent reads the first match found per category, with the manifest workspace exception below. Files larger than 256KB are flagged to the user before reading. If the README category yields no match, surface "No README found; reading manifest only." to the user once and continue — manifest-only repos are still adoptable.
+Docs are the rationale source. The agent reads the first match found per category, with the manifest workspace exception below. Files larger than 256KB are flagged to the user before reading. If the README category yields no match, surface "No README found; reading manifest only." to the user once and continue — manifest-only repos are still adoptable.
 
 - **README**: `README.md`, `README.rst`, `README` (first found)
 - **Manifest**: `pyproject.toml`, `package.json`, `Cargo.toml`, `go.mod`, `Gemfile`, `pom.xml`, `build.gradle`, `composer.json`, `requirements*.txt`. Read the root manifest. If it declares a workspace, also read each member manifest. Workspace declarations to recognise:
@@ -40,8 +47,6 @@ The agent reads the first match found per category, with the manifest workspace 
 - **ADR directory**: `docs/adr/`, `docs/decisions/`, `architecture/decisions/`, `adr/` — every `.md` except templates and index files (`0000-template.md`, `README.md`)
 - **Memory Bank**: `.context/`, `memory-bank/`, `cline_docs/` — `projectBrief.md`, `activeContext.md`, `techContext.md`, `decisionLog.md`, `progress.md`
 
-The agent does not read source code, tests, IaC templates, or git history during adopt. Those surfaces are out of scope on purpose — every recorded fact must trace back to an explicit source document so the refusal contract in Step 9 holds.
-
 ### Step 3b — Chat-surface paste branch
 
 When filesystem read is unavailable (chat surfaces), the agent first verifies the project exists by asking:
@@ -52,35 +57,76 @@ If the user cannot confirm an adopted project, the agent surfaces "Run `nauro ad
 
 > This skill needs source content. Paste the contents of any of: README, manifest (pyproject.toml/package.json/etc.), ADRs, Memory-Bank files. Send each as a separate message labelled with the filename.
 
-Chat-paste mode does not create projects.
+Chat-paste mode does not create projects, and chat surfaces skip Step 4 — code evidence is shell-bound and the agent does not ask the user to paste code in lieu of running commands.
 
-## Step 4 — Call get_context
+## Step 4 — Read code evidence
 
-The agent calls `get_context` (MCP) to surface what the scaffold already wrote — `001-initial-setup.md` and bracketed-prompt placeholders in `project.md` / `stack.md`. The agent uses this to (a) avoid duplicating the scaffold's first decision, (b) confirm the project resolved correctly.
+Filesystem-capable surfaces only. After Step 3, the agent inspects repo state to identify architectural facts that docs may not name. Each finding is held as an **observation** keyed by file path — never proposed as a decision on its own. Observations drive Step 6b's targeted probes; the user (or a Step 3 doc) must supply the rationale before anything flows into the decision log.
 
-## Step 5 — Build candidate list, surface FIRST
+Categories to inspect (the goal is enough evidence to ask the right probes, not a full inventory):
 
-The agent triages the source content into two lists.
+- **Source-tree layout.** `ls` the repo root and any workspace member directories. Note monorepo vs single-package shape, `src/`-layout vs flat, service-per-directory vs library-per-package.
+- **CI / CD config.** `.github/workflows/`, `.gitlab-ci.yml`, `.circleci/config.yml`, `azure-pipelines.yml`. Note the version matrix (which Python / Node / Rust versions are tested), required checks, and deployment targets.
+- **Test layout.** Test directory location (`tests/`, `__tests__/`, `*_test.go`), framework signals (pytest / jest / cargo test / go test), fixture conventions, and any integration vs unit split.
+- **Lint and format config.** `ruff.toml`, `.eslintrc*`, `.prettierrc*`, `mypy.ini`, `pyrightconfig.json`, `rustfmt.toml`, `.golangci.yml`.
+- **Infrastructure as code.** `Dockerfile`, `docker-compose.yml`, `terraform/`, `cdk.json`, `serverless.yml`, `sam/template.yaml`, `pulumi/`.
+- **Lockfiles and pinned versions.** Presence of `poetry.lock`, `uv.lock`, `package-lock.json`, `pnpm-lock.yaml`, `Cargo.lock`, `go.sum`. Note which package manager is canonical; do not enumerate every dependency.
+- **Recent git history.** `git log --oneline -n 30 --no-merges` to see what's active, when activity slowed, and which areas of the tree are touched most.
 
-**Step 5a — Clear decisions.** Candidates where the source explicitly states acceptance and rationale (and, when applicable, rejected alternatives). Each entry: number, title (≤60 chars), one-line summary (≤140 chars), source location. A candidate also qualifies as a clear decision when the rule is stated in one explicit source document and the rationale is stated in a *different* explicit source document — cite both source locations in the entry (e.g. "rule: CLAUDE.md §Conventions; rationale: README §How it works"). The agent does not invent the second source to make a candidate fit; if rationale is absent from every source the candidate goes to Step 5b. The agent prints the full list as one message:
+Step 4 ends with a list of observations, not a list of candidate decisions. Promotion into a candidate happens in Step 6b, after the user answers a probe.
+
+## Step 5 — Call get_context
+
+The agent calls `get_context` (MCP) to surface what the scaffold already wrote — `001-initial-setup.md` and bracketed-prompt placeholders in `project.md` / `stack.md`. The agent uses this to (a) avoid duplicating the scaffold's first decision, (b) confirm the project resolved correctly, and (c) learn what `check_decision` will treat as the existing baseline in Step 7.
+
+## Step 6 — Triage candidates
+
+Every candidate the agent surfaces lands in one of five buckets: **documented decision** (Step 6a), **code-evidenced fact needing rationale** (Step 6b, filesystem-capable only), **stack inventory** (Step 6c), **open question** (Step 9), or **ignore** (Step 10 refusal contract). The agent walks 6a → 6b → 6c in order, surfacing one list per substep and waiting for user input before continuing.
+
+### Step 6a — Documented decisions
+
+Candidates where a Step 3 source explicitly states acceptance and rationale (and, when applicable, rejected alternatives). Each entry: number, title (≤60 chars), one-line summary (≤140 chars), source location. A candidate also qualifies as documented when the rule is stated in one explicit source document and the rationale is stated in a *different* explicit source document — cite both source locations in the entry (e.g. "rule: CLAUDE.md §Conventions; rationale: README §How it works"). Code is never the rationale half of a cross-source pair; if rationale is absent from every doc the candidate falls to 6b or 6c. The agent prints the full list as one message:
 
 > Reply 'keep N' / 'edit N: <new title>' / 'skip N' per item. Or 'keep all' to accept everything. Reply 'done' when finished.
 
-**Step 5b — Boundary candidates.** Facts that *might* be decisions but where the source does not state rationale verbatim. Stack inventory (languages, frameworks, package managers, license, lint tooling) lives here unless a source frames the choice with rationale. Surfaced after the user finishes Step 5a:
+### Step 6b — Code-evidenced facts needing rationale
 
-> The agent thinks these might be decisions but couldn't extract rationale verbatim from the source. Each is opt-in only — reply 'opt N: <rationale>' to record any of them with rationale you provide; otherwise they are skipped.
+Filesystem-capable surfaces only. For each Step 4 observation that points at a real architectural choice (workspace shape, framework pick, test-layout convention, CI matrix, IaC target, …), the agent emits one targeted probe per observation, using this template verbatim:
 
-## Step 6 — Iterate kept items
+> I see X in file/path; was Y considered; what pushed you toward X?
 
-For each kept item from 5a (and each opt-in from 5b):
+Substitute `X` with the observed fact, `file/path` with the source it came from, and `Y` with a credible alternative the agent inferred (or "an alternative" if none is obvious). Probes are batched into one message; the user replies per item:
 
-1. Call `propose_decision(title=..., rationale=..., operation="add", rejected=..., confidence=...)`. Adopt seeds the store from source documents, so it normally uses `operation="add"` and does not set `affected_decision_id`. `rationale` is drawn from explicit source text or user-provided opt-ins. `confidence` defaults to `medium`; use `high` only when the source explicitly says "accepted" or "approved". Include rejected alternatives only when the source names them.
-2. **If `propose_decision` returns no conflicts**: call `confirm_decision(confirm_id)` automatically — no further user prompt.
-3. **If `propose_decision` returns conflicts**: surface the conflict text verbatim, ask `confirm-anyway / edit / skip`. On user 'confirm' → `confirm_decision(confirm_id)`.
+> Reply 'rationale N: <why>' to record it as a decision (it flows into the Step 7 write loop), 'inventory N' to drop it to stack inventory (6c), 'question N' to flag it as an open question (Step 9), or 'skip N' to drop it entirely.
 
-One propose+confirm per decision. No batching.
+When the user supplies rationale, the candidate is promoted into the Step 7 write loop with `operation="add"` by default — Step 7 step 3 reclassifies to `update` or `supersede` if `check_decision` surfaces an overlap.
 
-## Step 7 — State composition (one update_state call)
+### Step 6c — Stack inventory
+
+Languages, frameworks, package managers, license, lint tooling, and similar facts visible in the manifest or a "Stack" section without verbatim rationale. Stack inventory is folded into Step 8's `update_state` delta as a short summary — never written as decisions on its own. The only exception is a stack choice promoted into 6a via cross-doc stitching (rule in manifest, rationale in a separate doc). The agent prints the inventory list as one message:
+
+> The agent will fold these into the project state summary in Step 8. Reply 'drop N' to remove any, 'edit N: <new wording>' to rewrite, or 'done' to accept.
+
+## Step 7 — Write loop
+
+For each kept candidate from 6a and each rationale-supplied 6b answer, the agent runs the full D131 / D133 protocol:
+
+1. Call `check_decision(proposed_approach=<title or short description>, project_id=...)`. The tool returns related decisions via BM25 retrieval and a deterministic assessment.
+2. For each related decision in the response, call `get_decision(number=N, project_id=...)`. `check_decision` does not judge conflicts — the agent reads the decision bodies to decide what the right action is.
+3. Classify the operation:
+    - **add** (default; new ground, no existing decision covers it).
+    - **update** when the candidate augments an existing decision's rationale only. Per D133 the server consumes only `rationale` on update; `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, and `rejected` are rejected at the boundary — use supersede if any of those must change.
+    - **supersede** when the title or other metadata must change, or the candidate replaces or contradicts an existing decision. Pass the full new body and set `affected_decision_id`.
+    - **skip** when the candidate is a duplicate (e.g. matches `001-initial-setup` or a candidate already seeded earlier in this same adopt run).
+4. Call `propose_decision(project_id=..., title=..., rationale=..., operation=<op>, affected_decision_id=<N when update or supersede>, rejected=<…>, confidence=<…>)`. `rationale` is drawn from explicit Step 3 source text (6a) or the user's probe answer (6b). `confidence` defaults to `medium`; use `high` only when a source explicitly says "accepted" or "approved". Include rejected alternatives only when the source names them or the user supplies them in the probe answer.
+5. Call `confirm_decision(confirm_id, project_id=...)`:
+    - `add` + no conflicts → auto-confirm.
+    - `add` + conflicts → surface the assessment verbatim, ask `confirm-anyway / edit / skip`; confirm only on user 'confirm'.
+    - `update` or `supersede` → always pending per D131. Surface the assessment first; confirm only on explicit user 'confirm'.
+
+One propose+confirm per candidate. No batching.
+
+## Step 8 — State composition (one update_state call)
 
 The agent reads `activeContext.md` body and `progress.md` items, then composes one delta:
 
@@ -93,30 +139,44 @@ The agent reads `activeContext.md` body and `progress.md` items, then composes o
 - ...
 ```
 
-If only one source is present, the corresponding section is omitted. If neither is present, `update_state` is skipped entirely. **The agent does not call `update_state` per progress item** — `update_state` archives prior state to history, and the L0 payload ignores history.
+If Step 6c produced inventory items, append a short trailing section:
 
-## Step 8 — Flag open questions
+```
 
-Sources: explicit `## Open Questions` sections, lines beginning `Q:` or `TODO:` in CONTRIBUTING/ARCHITECTURE docs, user-noted gaps from Steps 5–6 ("we never decided X"). Per candidate: surface, ask `keep / edit / skip`. On keep → `flag_question(question, context)`.
+## Stack
+- {inventory_item_1}
+- {inventory_item_2}
+- ...
+```
 
-## Step 9 — Refusal contract
+If only one of activeContext / progress / inventory is present, the corresponding sections are omitted. If none is present, `update_state` is skipped entirely. **The agent does not call `update_state` per progress item or per inventory entry** — `update_state` archives prior state to history, and the L0 payload ignores history.
 
-The agent records facts that source documents explicitly state. The agent does not infer rationale from prose, does not invent rejected alternatives, does not assume `confidence=high` from tone, does not summarize a paragraph into a "decision" the source never called a decision. Three specific traps to avoid:
+## Step 9 — Flag open questions
+
+Sources: explicit `## Open Questions` sections, lines beginning `Q:` or `TODO:` in CONTRIBUTING / ARCHITECTURE docs, user-noted gaps from 6a / 6b / 6c dialogue ("we never decided X"), and Step 6b probes the user routed to `question N` or answered with "I don't know". Per candidate: surface, ask `keep / edit / skip`. On keep → `flag_question(question, context, project_id=...)`.
+
+## Step 10 — Refusal contract
+
+The agent records facts that source documents explicitly state, or that the user supplies in response to a Step 6b probe. The agent does not infer rationale from prose, does not invent rejected alternatives, does not assume `confidence=high` from tone, does not summarize a paragraph into a "decision" the source never called a decision. Five specific traps to avoid:
 
 - **Demo prose.** Decision-shaped statements inside README quickstart examples, illustrative scenarios, hypothetical user prompts, comparison tables, or product-demo narratives are false positives unless an independent source (CLAUDE.md, ADR, ARCHITECTURE.md, manifest, Memory-Bank) names the same fact as an actual project decision. In that case the independent source is the citation, not the demo prose.
-- **Stack inventory.** Languages, frameworks, package managers, license, and lint tooling listed in a manifest or a "Stack" section are inventory, not decisions, unless the source frames the choice with rationale (in which case Step 5a applies, possibly via cross-doc stitching).
-- **Cross-doc stitching is not inference.** When Step 5a stitches a rule from one source with rationale from another, both source locations must be explicit. The agent never fills in a missing rationale itself, and never treats two restatements of the same rule as "rule + rationale".
+- **Stack inventory is not decisions.** Languages, frameworks, package managers, license, and lint tooling listed in a manifest or a "Stack" section are inventory (6c) — they go into the Step 8 delta, not the decision log. Cross-doc stitching is the only path that promotes inventory into 6a.
+- **Cross-doc stitching is not inference.** When 6a stitches a rule from one source with rationale from another, both source locations must be explicit and both must be docs. The agent never fills in a missing rationale itself, never treats two restatements of the same rule as "rule + rationale", and never uses code as the rationale half.
+- **Code evidence is not rationale.** Source code, config files, tests, IaC templates, lockfiles, and git history are evidence of *what* — they tell you a stack was picked, a pattern is present, a CI matrix exists. They do not state *why*. The agent does not propose decisions from code alone; it asks a Step 6b probe and only records the decision once the user (or a Step 3 doc) supplies rationale.
+- **No code-only dependency decisions.** Dependency choices visible in `pyproject.toml`, `package.json`, lockfiles, or similar manifests never become decisions on their own. They land in 6c (stack inventory, folded into Step 8 state) or surface as 6b probes when a particular pick looks load-bearing enough to warrant a rationale.
 
-Boundary cases go to Step 5b (opt-in only — write rationale yourself), not into the clear-decisions list.
+Boundary cases go to 6b (probe → opt-in rationale) or 6c (inventory roll-up). They never flow into 6a without an explicit source.
 
-## Step 10 — Summary
+## Step 11 — Summary
 
 The agent prints one block:
 
 - Project: `<name>` (id: `<pid>`, store: `<store-path>`)
-- Sources read: `<comma-separated list>`
-- Decisions created: N (titles)
-- Decisions skipped: M (titles)
-- State updated: yes/no
-- Open questions flagged: K
+- Sources read: `<comma-separated list of docs from Step 3>`
+- Code evidence inspected: `<comma-separated list of Step 4 categories, or "skipped — chat surface">`
+- Code-evidence probes asked: `P` / answered: `A`
+- Decisions created: `N` (titles)
+- Decisions skipped: `M` (titles)
+- State updated: `yes`/`no`
+- Open questions flagged: `K`
 - Next: run `nauro sync` from the repo to capture a snapshot.

--- a/.cursor/rules/nauro-adopt.mdc
+++ b/.cursor/rules/nauro-adopt.mdc
@@ -1,11 +1,18 @@
 ---
-description: Seeds Nauro's project store from an existing repo's documentation. Use after the user has run `nauro adopt` locally — reads README, manifests, ADRs, and Memory-Bank files, surfaces decision candidates for triage, and writes them to Nauro via existing MCP write tools.
+description: Seeds Nauro's project store from an existing repo. Use after the user has run `nauro adopt` locally. On filesystem-capable surfaces (Claude Code, Cursor, Codex CLI), reads docs (README, manifests, ADRs, Memory-Bank) for rationale and inspects code, config, tests, lockfiles, and recent git history for evidence, then surfaces targeted probes that turn evidence into rationale. On chat surfaces, reads pasted content against an already-adopted project. Writes decisions, state, and open questions via existing MCP write tools.
 alwaysApply: false
 ---
 
 # Nauro adopt skill
 
-The agent helps the user seed Nauro with context from the current repo. Before this skill runs, the user has run `nauro adopt` from the repo root, which created the project, wired MCP across surfaces, and installed this skill into the agent's surface directory. The agent's job here is to read the repo's documentation (README, manifests, ADRs, Memory-Bank) and seed the Nauro store via MCP write tools. The agent records facts that source documents explicitly state — it does not invent decisions from prose. On chat surfaces (Claude.ai, ChatGPT) without filesystem access, the agent uses paste-content mode (Step 3b); chat-paste mode requires the project to already exist (run `nauro adopt` locally first).
+The agent helps the user seed Nauro with context from the current repo. Before this skill runs, the user has run `nauro adopt` from the repo root, which created the project, wired MCP across surfaces, and installed this skill into the agent's surface directory. The agent's job here is to seed the Nauro store via MCP write tools: docs supply the rationale for documented decisions, code and config and tests and manifests and recent git history supply evidence, and the user supplies the "why" via targeted probes when only evidence is present. The agent records decisions that source documents explicitly state, or that the user confirms in response to a probe — it does not invent rationale from code or prose.
+
+## Surface modes
+
+The agent's behaviour depends on whether the surface can read the repo directly.
+
+- **Filesystem-capable surfaces** (Claude Code, Cursor, Codex CLI). The agent runs Steps 1–11 in full. Docs are read for rationale in Step 3; code, config, tests, manifests, and recent git history are inspected for evidence in Step 4; targeted probes in Step 6b turn evidence into rationale by asking the user.
+- **Chat surfaces** (Claude.ai, ChatGPT, Perplexity). The agent has no shell. It operates only on content the user pastes into the chat (Step 3b), and only against an already-adopted project per D127 (verified in Step 2). The code-evidence path (Step 4) and the Step 6b probes are unavailable; the agent does not ask the user to paste code in lieu of running shell commands. The skill skips from Step 3b directly to Step 5.
 
 ## Step 1 — Detect repo root
 
@@ -22,11 +29,11 @@ If the file is missing, try two fallbacks before aborting:
 
 Abort only when both fallbacks miss, with: "This repo is not adopted yet. Run 'nauro adopt' from the repo root, restart this agent, then invoke /nauro-adopt again."
 
-Pass `id` as the `project_id` argument on every subsequent MCP call (`propose_decision`, `confirm_decision`, `update_state`, `flag_question`, `get_context`, `list_decisions`). Do not omit `project_id` even though the tool descriptions say it's optional — auto-resolve routes to the user's default project, which is **not** the project this skill is seeding when both local-mode and cloud-mode projects coexist.
+Pass `id` as the `project_id` argument on every subsequent MCP call (`propose_decision`, `confirm_decision`, `update_state`, `flag_question`, `get_context`, `list_decisions`, `check_decision`, `get_decision`). Do not omit `project_id` even though the tool descriptions say it's optional — auto-resolve routes to the user's default project, which is **not** the project this skill is seeding when both local-mode and cloud-mode projects coexist.
 
-## Step 3 — Read source files
+## Step 3 — Read documentation
 
-The agent reads the first match found per category, with the manifest workspace exception below. Files larger than 256KB are flagged to the user before reading. If the README category yields no match, surface "No README found; reading manifest only." to the user once and continue — manifest-only repos are still adoptable.
+Docs are the rationale source. The agent reads the first match found per category, with the manifest workspace exception below. Files larger than 256KB are flagged to the user before reading. If the README category yields no match, surface "No README found; reading manifest only." to the user once and continue — manifest-only repos are still adoptable.
 
 - **README**: `README.md`, `README.rst`, `README` (first found)
 - **Manifest**: `pyproject.toml`, `package.json`, `Cargo.toml`, `go.mod`, `Gemfile`, `pom.xml`, `build.gradle`, `composer.json`, `requirements*.txt`. Read the root manifest. If it declares a workspace, also read each member manifest. Workspace declarations to recognise:
@@ -40,8 +47,6 @@ The agent reads the first match found per category, with the manifest workspace 
 - **ADR directory**: `docs/adr/`, `docs/decisions/`, `architecture/decisions/`, `adr/` — every `.md` except templates and index files (`0000-template.md`, `README.md`)
 - **Memory Bank**: `.context/`, `memory-bank/`, `cline_docs/` — `projectBrief.md`, `activeContext.md`, `techContext.md`, `decisionLog.md`, `progress.md`
 
-The agent does not read source code, tests, IaC templates, or git history during adopt. Those surfaces are out of scope on purpose — every recorded fact must trace back to an explicit source document so the refusal contract in Step 9 holds.
-
 ### Step 3b — Chat-surface paste branch
 
 When filesystem read is unavailable (chat surfaces), the agent first verifies the project exists by asking:
@@ -52,35 +57,76 @@ If the user cannot confirm an adopted project, the agent surfaces "Run `nauro ad
 
 > This skill needs source content. Paste the contents of any of: README, manifest (pyproject.toml/package.json/etc.), ADRs, Memory-Bank files. Send each as a separate message labelled with the filename.
 
-Chat-paste mode does not create projects.
+Chat-paste mode does not create projects, and chat surfaces skip Step 4 — code evidence is shell-bound and the agent does not ask the user to paste code in lieu of running commands.
 
-## Step 4 — Call get_context
+## Step 4 — Read code evidence
 
-The agent calls `get_context` (MCP) to surface what the scaffold already wrote — `001-initial-setup.md` and bracketed-prompt placeholders in `project.md` / `stack.md`. The agent uses this to (a) avoid duplicating the scaffold's first decision, (b) confirm the project resolved correctly.
+Filesystem-capable surfaces only. After Step 3, the agent inspects repo state to identify architectural facts that docs may not name. Each finding is held as an **observation** keyed by file path — never proposed as a decision on its own. Observations drive Step 6b's targeted probes; the user (or a Step 3 doc) must supply the rationale before anything flows into the decision log.
 
-## Step 5 — Build candidate list, surface FIRST
+Categories to inspect (the goal is enough evidence to ask the right probes, not a full inventory):
 
-The agent triages the source content into two lists.
+- **Source-tree layout.** `ls` the repo root and any workspace member directories. Note monorepo vs single-package shape, `src/`-layout vs flat, service-per-directory vs library-per-package.
+- **CI / CD config.** `.github/workflows/`, `.gitlab-ci.yml`, `.circleci/config.yml`, `azure-pipelines.yml`. Note the version matrix (which Python / Node / Rust versions are tested), required checks, and deployment targets.
+- **Test layout.** Test directory location (`tests/`, `__tests__/`, `*_test.go`), framework signals (pytest / jest / cargo test / go test), fixture conventions, and any integration vs unit split.
+- **Lint and format config.** `ruff.toml`, `.eslintrc*`, `.prettierrc*`, `mypy.ini`, `pyrightconfig.json`, `rustfmt.toml`, `.golangci.yml`.
+- **Infrastructure as code.** `Dockerfile`, `docker-compose.yml`, `terraform/`, `cdk.json`, `serverless.yml`, `sam/template.yaml`, `pulumi/`.
+- **Lockfiles and pinned versions.** Presence of `poetry.lock`, `uv.lock`, `package-lock.json`, `pnpm-lock.yaml`, `Cargo.lock`, `go.sum`. Note which package manager is canonical; do not enumerate every dependency.
+- **Recent git history.** `git log --oneline -n 30 --no-merges` to see what's active, when activity slowed, and which areas of the tree are touched most.
 
-**Step 5a — Clear decisions.** Candidates where the source explicitly states acceptance and rationale (and, when applicable, rejected alternatives). Each entry: number, title (≤60 chars), one-line summary (≤140 chars), source location. A candidate also qualifies as a clear decision when the rule is stated in one explicit source document and the rationale is stated in a *different* explicit source document — cite both source locations in the entry (e.g. "rule: CLAUDE.md §Conventions; rationale: README §How it works"). The agent does not invent the second source to make a candidate fit; if rationale is absent from every source the candidate goes to Step 5b. The agent prints the full list as one message:
+Step 4 ends with a list of observations, not a list of candidate decisions. Promotion into a candidate happens in Step 6b, after the user answers a probe.
+
+## Step 5 — Call get_context
+
+The agent calls `get_context` (MCP) to surface what the scaffold already wrote — `001-initial-setup.md` and bracketed-prompt placeholders in `project.md` / `stack.md`. The agent uses this to (a) avoid duplicating the scaffold's first decision, (b) confirm the project resolved correctly, and (c) learn what `check_decision` will treat as the existing baseline in Step 7.
+
+## Step 6 — Triage candidates
+
+Every candidate the agent surfaces lands in one of five buckets: **documented decision** (Step 6a), **code-evidenced fact needing rationale** (Step 6b, filesystem-capable only), **stack inventory** (Step 6c), **open question** (Step 9), or **ignore** (Step 10 refusal contract). The agent walks 6a → 6b → 6c in order, surfacing one list per substep and waiting for user input before continuing.
+
+### Step 6a — Documented decisions
+
+Candidates where a Step 3 source explicitly states acceptance and rationale (and, when applicable, rejected alternatives). Each entry: number, title (≤60 chars), one-line summary (≤140 chars), source location. A candidate also qualifies as documented when the rule is stated in one explicit source document and the rationale is stated in a *different* explicit source document — cite both source locations in the entry (e.g. "rule: CLAUDE.md §Conventions; rationale: README §How it works"). Code is never the rationale half of a cross-source pair; if rationale is absent from every doc the candidate falls to 6b or 6c. The agent prints the full list as one message:
 
 > Reply 'keep N' / 'edit N: <new title>' / 'skip N' per item. Or 'keep all' to accept everything. Reply 'done' when finished.
 
-**Step 5b — Boundary candidates.** Facts that *might* be decisions but where the source does not state rationale verbatim. Stack inventory (languages, frameworks, package managers, license, lint tooling) lives here unless a source frames the choice with rationale. Surfaced after the user finishes Step 5a:
+### Step 6b — Code-evidenced facts needing rationale
 
-> The agent thinks these might be decisions but couldn't extract rationale verbatim from the source. Each is opt-in only — reply 'opt N: <rationale>' to record any of them with rationale you provide; otherwise they are skipped.
+Filesystem-capable surfaces only. For each Step 4 observation that points at a real architectural choice (workspace shape, framework pick, test-layout convention, CI matrix, IaC target, …), the agent emits one targeted probe per observation, using this template verbatim:
 
-## Step 6 — Iterate kept items
+> I see X in file/path; was Y considered; what pushed you toward X?
 
-For each kept item from 5a (and each opt-in from 5b):
+Substitute `X` with the observed fact, `file/path` with the source it came from, and `Y` with a credible alternative the agent inferred (or "an alternative" if none is obvious). Probes are batched into one message; the user replies per item:
 
-1. Call `propose_decision(title=..., rationale=..., operation="add", rejected=..., confidence=...)`. Adopt seeds the store from source documents, so it normally uses `operation="add"` and does not set `affected_decision_id`. `rationale` is drawn from explicit source text or user-provided opt-ins. `confidence` defaults to `medium`; use `high` only when the source explicitly says "accepted" or "approved". Include rejected alternatives only when the source names them.
-2. **If `propose_decision` returns no conflicts**: call `confirm_decision(confirm_id)` automatically — no further user prompt.
-3. **If `propose_decision` returns conflicts**: surface the conflict text verbatim, ask `confirm-anyway / edit / skip`. On user 'confirm' → `confirm_decision(confirm_id)`.
+> Reply 'rationale N: <why>' to record it as a decision (it flows into the Step 7 write loop), 'inventory N' to drop it to stack inventory (6c), 'question N' to flag it as an open question (Step 9), or 'skip N' to drop it entirely.
 
-One propose+confirm per decision. No batching.
+When the user supplies rationale, the candidate is promoted into the Step 7 write loop with `operation="add"` by default — Step 7 step 3 reclassifies to `update` or `supersede` if `check_decision` surfaces an overlap.
 
-## Step 7 — State composition (one update_state call)
+### Step 6c — Stack inventory
+
+Languages, frameworks, package managers, license, lint tooling, and similar facts visible in the manifest or a "Stack" section without verbatim rationale. Stack inventory is folded into Step 8's `update_state` delta as a short summary — never written as decisions on its own. The only exception is a stack choice promoted into 6a via cross-doc stitching (rule in manifest, rationale in a separate doc). The agent prints the inventory list as one message:
+
+> The agent will fold these into the project state summary in Step 8. Reply 'drop N' to remove any, 'edit N: <new wording>' to rewrite, or 'done' to accept.
+
+## Step 7 — Write loop
+
+For each kept candidate from 6a and each rationale-supplied 6b answer, the agent runs the full D131 / D133 protocol:
+
+1. Call `check_decision(proposed_approach=<title or short description>, project_id=...)`. The tool returns related decisions via BM25 retrieval and a deterministic assessment.
+2. For each related decision in the response, call `get_decision(number=N, project_id=...)`. `check_decision` does not judge conflicts — the agent reads the decision bodies to decide what the right action is.
+3. Classify the operation:
+    - **add** (default; new ground, no existing decision covers it).
+    - **update** when the candidate augments an existing decision's rationale only. Per D133 the server consumes only `rationale` on update; `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, and `rejected` are rejected at the boundary — use supersede if any of those must change.
+    - **supersede** when the title or other metadata must change, or the candidate replaces or contradicts an existing decision. Pass the full new body and set `affected_decision_id`.
+    - **skip** when the candidate is a duplicate (e.g. matches `001-initial-setup` or a candidate already seeded earlier in this same adopt run).
+4. Call `propose_decision(project_id=..., title=..., rationale=..., operation=<op>, affected_decision_id=<N when update or supersede>, rejected=<…>, confidence=<…>)`. `rationale` is drawn from explicit Step 3 source text (6a) or the user's probe answer (6b). `confidence` defaults to `medium`; use `high` only when a source explicitly says "accepted" or "approved". Include rejected alternatives only when the source names them or the user supplies them in the probe answer.
+5. Call `confirm_decision(confirm_id, project_id=...)`:
+    - `add` + no conflicts → auto-confirm.
+    - `add` + conflicts → surface the assessment verbatim, ask `confirm-anyway / edit / skip`; confirm only on user 'confirm'.
+    - `update` or `supersede` → always pending per D131. Surface the assessment first; confirm only on explicit user 'confirm'.
+
+One propose+confirm per candidate. No batching.
+
+## Step 8 — State composition (one update_state call)
 
 The agent reads `activeContext.md` body and `progress.md` items, then composes one delta:
 
@@ -93,30 +139,44 @@ The agent reads `activeContext.md` body and `progress.md` items, then composes o
 - ...
 ```
 
-If only one source is present, the corresponding section is omitted. If neither is present, `update_state` is skipped entirely. **The agent does not call `update_state` per progress item** — `update_state` archives prior state to history, and the L0 payload ignores history.
+If Step 6c produced inventory items, append a short trailing section:
 
-## Step 8 — Flag open questions
+```
 
-Sources: explicit `## Open Questions` sections, lines beginning `Q:` or `TODO:` in CONTRIBUTING/ARCHITECTURE docs, user-noted gaps from Steps 5–6 ("we never decided X"). Per candidate: surface, ask `keep / edit / skip`. On keep → `flag_question(question, context)`.
+## Stack
+- {inventory_item_1}
+- {inventory_item_2}
+- ...
+```
 
-## Step 9 — Refusal contract
+If only one of activeContext / progress / inventory is present, the corresponding sections are omitted. If none is present, `update_state` is skipped entirely. **The agent does not call `update_state` per progress item or per inventory entry** — `update_state` archives prior state to history, and the L0 payload ignores history.
 
-The agent records facts that source documents explicitly state. The agent does not infer rationale from prose, does not invent rejected alternatives, does not assume `confidence=high` from tone, does not summarize a paragraph into a "decision" the source never called a decision. Three specific traps to avoid:
+## Step 9 — Flag open questions
+
+Sources: explicit `## Open Questions` sections, lines beginning `Q:` or `TODO:` in CONTRIBUTING / ARCHITECTURE docs, user-noted gaps from 6a / 6b / 6c dialogue ("we never decided X"), and Step 6b probes the user routed to `question N` or answered with "I don't know". Per candidate: surface, ask `keep / edit / skip`. On keep → `flag_question(question, context, project_id=...)`.
+
+## Step 10 — Refusal contract
+
+The agent records facts that source documents explicitly state, or that the user supplies in response to a Step 6b probe. The agent does not infer rationale from prose, does not invent rejected alternatives, does not assume `confidence=high` from tone, does not summarize a paragraph into a "decision" the source never called a decision. Five specific traps to avoid:
 
 - **Demo prose.** Decision-shaped statements inside README quickstart examples, illustrative scenarios, hypothetical user prompts, comparison tables, or product-demo narratives are false positives unless an independent source (CLAUDE.md, ADR, ARCHITECTURE.md, manifest, Memory-Bank) names the same fact as an actual project decision. In that case the independent source is the citation, not the demo prose.
-- **Stack inventory.** Languages, frameworks, package managers, license, and lint tooling listed in a manifest or a "Stack" section are inventory, not decisions, unless the source frames the choice with rationale (in which case Step 5a applies, possibly via cross-doc stitching).
-- **Cross-doc stitching is not inference.** When Step 5a stitches a rule from one source with rationale from another, both source locations must be explicit. The agent never fills in a missing rationale itself, and never treats two restatements of the same rule as "rule + rationale".
+- **Stack inventory is not decisions.** Languages, frameworks, package managers, license, and lint tooling listed in a manifest or a "Stack" section are inventory (6c) — they go into the Step 8 delta, not the decision log. Cross-doc stitching is the only path that promotes inventory into 6a.
+- **Cross-doc stitching is not inference.** When 6a stitches a rule from one source with rationale from another, both source locations must be explicit and both must be docs. The agent never fills in a missing rationale itself, never treats two restatements of the same rule as "rule + rationale", and never uses code as the rationale half.
+- **Code evidence is not rationale.** Source code, config files, tests, IaC templates, lockfiles, and git history are evidence of *what* — they tell you a stack was picked, a pattern is present, a CI matrix exists. They do not state *why*. The agent does not propose decisions from code alone; it asks a Step 6b probe and only records the decision once the user (or a Step 3 doc) supplies rationale.
+- **No code-only dependency decisions.** Dependency choices visible in `pyproject.toml`, `package.json`, lockfiles, or similar manifests never become decisions on their own. They land in 6c (stack inventory, folded into Step 8 state) or surface as 6b probes when a particular pick looks load-bearing enough to warrant a rationale.
 
-Boundary cases go to Step 5b (opt-in only — write rationale yourself), not into the clear-decisions list.
+Boundary cases go to 6b (probe → opt-in rationale) or 6c (inventory roll-up). They never flow into 6a without an explicit source.
 
-## Step 10 — Summary
+## Step 11 — Summary
 
 The agent prints one block:
 
 - Project: `<name>` (id: `<pid>`, store: `<store-path>`)
-- Sources read: `<comma-separated list>`
-- Decisions created: N (titles)
-- Decisions skipped: M (titles)
-- State updated: yes/no
-- Open questions flagged: K
+- Sources read: `<comma-separated list of docs from Step 3>`
+- Code evidence inspected: `<comma-separated list of Step 4 categories, or "skipped — chat surface">`
+- Code-evidence probes asked: `P` / answered: `A`
+- Decisions created: `N` (titles)
+- Decisions skipped: `M` (titles)
+- State updated: `yes`/`no`
+- Open questions flagged: `K`
 - Next: run `nauro sync` from the repo to capture a snapshot.

--- a/.cursor/rules/nauro-adopt.mdc
+++ b/.cursor/rules/nauro-adopt.mdc
@@ -1,5 +1,5 @@
 ---
-description: Seeds Nauro's project store from an existing repo. Use after the user has run `nauro adopt` locally. On filesystem-capable surfaces (Claude Code, Cursor, Codex CLI), reads docs (README, manifests, ADRs, Memory-Bank) for rationale and inspects code, config, tests, lockfiles, and recent git history for evidence, then surfaces targeted probes that turn evidence into rationale. On chat surfaces, reads pasted content against an already-adopted project. Writes decisions, state, and open questions via existing MCP write tools.
+description: Seeds Nauro's project store from an existing repo. Use after `nauro adopt` has run locally. On filesystem-capable surfaces, reads docs (README, manifests, ADRs, Memory-Bank) for rationale and inspects code, config, tests, lockfiles, and recent git history for evidence, then surfaces targeted probes that turn evidence into rationale. On chat surfaces, operates on pasted content against an already-adopted project.
 alwaysApply: false
 ---
 
@@ -118,7 +118,21 @@ For each kept candidate from 6a and each rationale-supplied 6b answer, the agent
     - **update** when the candidate augments an existing decision's rationale only. Per D133 the server consumes only `rationale` on update; `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, and `rejected` are rejected at the boundary — use supersede if any of those must change.
     - **supersede** when the title or other metadata must change, or the candidate replaces or contradicts an existing decision. Pass the full new body and set `affected_decision_id`.
     - **skip** when the candidate is a duplicate (e.g. matches `001-initial-setup` or a candidate already seeded earlier in this same adopt run).
-4. Call `propose_decision(project_id=..., title=..., rationale=..., operation=<op>, affected_decision_id=<N when update or supersede>, rejected=<…>, confidence=<…>)`. `rationale` is drawn from explicit Step 3 source text (6a) or the user's probe answer (6b). `confidence` defaults to `medium`; use `high` only when a source explicitly says "accepted" or "approved". Include rejected alternatives only when the source names them or the user supplies them in the probe answer.
+4. Call `propose_decision` using the call signature for the chosen operation — these are operation-specific by design so an agent copying the template cannot accidentally send a field the server will reject:
+    - For **add** (new decisions):
+      ```
+      propose_decision(project_id=..., title=..., rationale=..., operation="add", rejected=..., confidence=...)
+      ```
+    - For **update** (rationale-only — D133 rejects every other field at the boundary):
+      ```
+      propose_decision(project_id=..., rationale=..., operation="update", affected_decision_id=...)
+      ```
+    - For **supersede** (replace a decision or change metadata; pass the full new body):
+      ```
+      propose_decision(project_id=..., title=..., rationale=..., operation="supersede", affected_decision_id=..., rejected=..., confidence=...)
+      ```
+
+   `rationale` is drawn from explicit Step 3 source text (6a) or the user's probe answer (6b). `confidence` defaults to `medium`; use `high` only when a source explicitly says "accepted" or "approved". Include rejected alternatives only when the source names them or the user supplies them in the probe answer.
 5. Call `confirm_decision(confirm_id, project_id=...)`:
     - `add` + no conflicts → auto-confirm.
     - `add` + conflicts → surface the assessment verbatim, ask `confirm-anyway / edit / skip`; confirm only on user 'confirm'.

--- a/docs/adopt-prompt.md
+++ b/docs/adopt-prompt.md
@@ -134,7 +134,21 @@ For each kept candidate from 6a and each rationale-supplied 6b answer, the agent
     - **update** when the candidate augments an existing decision's rationale only. Per D133 the server consumes only `rationale` on update; `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, and `rejected` are rejected at the boundary — use supersede if any of those must change.
     - **supersede** when the title or other metadata must change, or the candidate replaces or contradicts an existing decision. Pass the full new body and set `affected_decision_id`.
     - **skip** when the candidate is a duplicate (e.g. matches `001-initial-setup` or a candidate already seeded earlier in this same adopt run).
-4. Call `propose_decision(project_id=..., title=..., rationale=..., operation=<op>, affected_decision_id=<N when update or supersede>, rejected=<…>, confidence=<…>)`. `rationale` is drawn from explicit Step 3 source text (6a) or the user's probe answer (6b). `confidence` defaults to `medium`; use `high` only when a source explicitly says "accepted" or "approved". Include rejected alternatives only when the source names them or the user supplies them in the probe answer.
+4. Call `propose_decision` using the call signature for the chosen operation — these are operation-specific by design so an agent copying the template cannot accidentally send a field the server will reject:
+    - For **add** (new decisions):
+      ```
+      propose_decision(project_id=..., title=..., rationale=..., operation="add", rejected=..., confidence=...)
+      ```
+    - For **update** (rationale-only — D133 rejects every other field at the boundary):
+      ```
+      propose_decision(project_id=..., rationale=..., operation="update", affected_decision_id=...)
+      ```
+    - For **supersede** (replace a decision or change metadata; pass the full new body):
+      ```
+      propose_decision(project_id=..., title=..., rationale=..., operation="supersede", affected_decision_id=..., rejected=..., confidence=...)
+      ```
+
+   `rationale` is drawn from explicit Step 3 source text (6a) or the user's probe answer (6b). `confidence` defaults to `medium`; use `high` only when a source explicitly says "accepted" or "approved". Include rejected alternatives only when the source names them or the user supplies them in the probe answer.
 5. Call `confirm_decision(confirm_id, project_id=...)`:
     - `add` + no conflicts → auto-confirm.
     - `add` + conflicts → surface the assessment verbatim, ask `confirm-anyway / edit / skip`; confirm only on user 'confirm'.

--- a/docs/adopt-prompt.md
+++ b/docs/adopt-prompt.md
@@ -21,7 +21,14 @@ this same body to stdout (without the intro paragraph above).
 
 # Nauro adopt skill
 
-The agent helps the user seed Nauro with context from the current repo. Before this skill runs, the user has run `nauro adopt` from the repo root, which created the project, wired MCP across surfaces, and installed this skill into the agent's surface directory. The agent's job here is to read the repo's documentation (README, manifests, ADRs, Memory-Bank) and seed the Nauro store via MCP write tools. The agent records facts that source documents explicitly state — it does not invent decisions from prose. On chat surfaces (Claude.ai, ChatGPT) without filesystem access, the agent uses paste-content mode (Step 3b); chat-paste mode requires the project to already exist (run `nauro adopt` locally first).
+The agent helps the user seed Nauro with context from the current repo. Before this skill runs, the user has run `nauro adopt` from the repo root, which created the project, wired MCP across surfaces, and installed this skill into the agent's surface directory. The agent's job here is to seed the Nauro store via MCP write tools: docs supply the rationale for documented decisions, code and config and tests and manifests and recent git history supply evidence, and the user supplies the "why" via targeted probes when only evidence is present. The agent records decisions that source documents explicitly state, or that the user confirms in response to a probe — it does not invent rationale from code or prose.
+
+## Surface modes
+
+The agent's behaviour depends on whether the surface can read the repo directly.
+
+- **Filesystem-capable surfaces** (Claude Code, Cursor, Codex CLI). The agent runs Steps 1–11 in full. Docs are read for rationale in Step 3; code, config, tests, manifests, and recent git history are inspected for evidence in Step 4; targeted probes in Step 6b turn evidence into rationale by asking the user.
+- **Chat surfaces** (Claude.ai, ChatGPT, Perplexity). The agent has no shell. It operates only on content the user pastes into the chat (Step 3b), and only against an already-adopted project per D127 (verified in Step 2). The code-evidence path (Step 4) and the Step 6b probes are unavailable; the agent does not ask the user to paste code in lieu of running shell commands. The skill skips from Step 3b directly to Step 5.
 
 ## Step 1 — Detect repo root
 
@@ -38,11 +45,11 @@ If the file is missing, try two fallbacks before aborting:
 
 Abort only when both fallbacks miss, with: "This repo is not adopted yet. Run 'nauro adopt' from the repo root, restart this agent, then invoke /nauro-adopt again."
 
-Pass `id` as the `project_id` argument on every subsequent MCP call (`propose_decision`, `confirm_decision`, `update_state`, `flag_question`, `get_context`, `list_decisions`). Do not omit `project_id` even though the tool descriptions say it's optional — auto-resolve routes to the user's default project, which is **not** the project this skill is seeding when both local-mode and cloud-mode projects coexist.
+Pass `id` as the `project_id` argument on every subsequent MCP call (`propose_decision`, `confirm_decision`, `update_state`, `flag_question`, `get_context`, `list_decisions`, `check_decision`, `get_decision`). Do not omit `project_id` even though the tool descriptions say it's optional — auto-resolve routes to the user's default project, which is **not** the project this skill is seeding when both local-mode and cloud-mode projects coexist.
 
-## Step 3 — Read source files
+## Step 3 — Read documentation
 
-The agent reads the first match found per category, with the manifest workspace exception below. Files larger than 256KB are flagged to the user before reading. If the README category yields no match, surface "No README found; reading manifest only." to the user once and continue — manifest-only repos are still adoptable.
+Docs are the rationale source. The agent reads the first match found per category, with the manifest workspace exception below. Files larger than 256KB are flagged to the user before reading. If the README category yields no match, surface "No README found; reading manifest only." to the user once and continue — manifest-only repos are still adoptable.
 
 - **README**: `README.md`, `README.rst`, `README` (first found)
 - **Manifest**: `pyproject.toml`, `package.json`, `Cargo.toml`, `go.mod`, `Gemfile`, `pom.xml`, `build.gradle`, `composer.json`, `requirements*.txt`. Read the root manifest. If it declares a workspace, also read each member manifest. Workspace declarations to recognise:
@@ -56,8 +63,6 @@ The agent reads the first match found per category, with the manifest workspace 
 - **ADR directory**: `docs/adr/`, `docs/decisions/`, `architecture/decisions/`, `adr/` — every `.md` except templates and index files (`0000-template.md`, `README.md`)
 - **Memory Bank**: `.context/`, `memory-bank/`, `cline_docs/` — `projectBrief.md`, `activeContext.md`, `techContext.md`, `decisionLog.md`, `progress.md`
 
-The agent does not read source code, tests, IaC templates, or git history during adopt. Those surfaces are out of scope on purpose — every recorded fact must trace back to an explicit source document so the refusal contract in Step 9 holds.
-
 ### Step 3b — Chat-surface paste branch
 
 When filesystem read is unavailable (chat surfaces), the agent first verifies the project exists by asking:
@@ -68,35 +73,76 @@ If the user cannot confirm an adopted project, the agent surfaces "Run `nauro ad
 
 > This skill needs source content. Paste the contents of any of: README, manifest (pyproject.toml/package.json/etc.), ADRs, Memory-Bank files. Send each as a separate message labelled with the filename.
 
-Chat-paste mode does not create projects.
+Chat-paste mode does not create projects, and chat surfaces skip Step 4 — code evidence is shell-bound and the agent does not ask the user to paste code in lieu of running commands.
 
-## Step 4 — Call get_context
+## Step 4 — Read code evidence
 
-The agent calls `get_context` (MCP) to surface what the scaffold already wrote — `001-initial-setup.md` and bracketed-prompt placeholders in `project.md` / `stack.md`. The agent uses this to (a) avoid duplicating the scaffold's first decision, (b) confirm the project resolved correctly.
+Filesystem-capable surfaces only. After Step 3, the agent inspects repo state to identify architectural facts that docs may not name. Each finding is held as an **observation** keyed by file path — never proposed as a decision on its own. Observations drive Step 6b's targeted probes; the user (or a Step 3 doc) must supply the rationale before anything flows into the decision log.
 
-## Step 5 — Build candidate list, surface FIRST
+Categories to inspect (the goal is enough evidence to ask the right probes, not a full inventory):
 
-The agent triages the source content into two lists.
+- **Source-tree layout.** `ls` the repo root and any workspace member directories. Note monorepo vs single-package shape, `src/`-layout vs flat, service-per-directory vs library-per-package.
+- **CI / CD config.** `.github/workflows/`, `.gitlab-ci.yml`, `.circleci/config.yml`, `azure-pipelines.yml`. Note the version matrix (which Python / Node / Rust versions are tested), required checks, and deployment targets.
+- **Test layout.** Test directory location (`tests/`, `__tests__/`, `*_test.go`), framework signals (pytest / jest / cargo test / go test), fixture conventions, and any integration vs unit split.
+- **Lint and format config.** `ruff.toml`, `.eslintrc*`, `.prettierrc*`, `mypy.ini`, `pyrightconfig.json`, `rustfmt.toml`, `.golangci.yml`.
+- **Infrastructure as code.** `Dockerfile`, `docker-compose.yml`, `terraform/`, `cdk.json`, `serverless.yml`, `sam/template.yaml`, `pulumi/`.
+- **Lockfiles and pinned versions.** Presence of `poetry.lock`, `uv.lock`, `package-lock.json`, `pnpm-lock.yaml`, `Cargo.lock`, `go.sum`. Note which package manager is canonical; do not enumerate every dependency.
+- **Recent git history.** `git log --oneline -n 30 --no-merges` to see what's active, when activity slowed, and which areas of the tree are touched most.
 
-**Step 5a — Clear decisions.** Candidates where the source explicitly states acceptance and rationale (and, when applicable, rejected alternatives). Each entry: number, title (≤60 chars), one-line summary (≤140 chars), source location. A candidate also qualifies as a clear decision when the rule is stated in one explicit source document and the rationale is stated in a *different* explicit source document — cite both source locations in the entry (e.g. "rule: CLAUDE.md §Conventions; rationale: README §How it works"). The agent does not invent the second source to make a candidate fit; if rationale is absent from every source the candidate goes to Step 5b. The agent prints the full list as one message:
+Step 4 ends with a list of observations, not a list of candidate decisions. Promotion into a candidate happens in Step 6b, after the user answers a probe.
+
+## Step 5 — Call get_context
+
+The agent calls `get_context` (MCP) to surface what the scaffold already wrote — `001-initial-setup.md` and bracketed-prompt placeholders in `project.md` / `stack.md`. The agent uses this to (a) avoid duplicating the scaffold's first decision, (b) confirm the project resolved correctly, and (c) learn what `check_decision` will treat as the existing baseline in Step 7.
+
+## Step 6 — Triage candidates
+
+Every candidate the agent surfaces lands in one of five buckets: **documented decision** (Step 6a), **code-evidenced fact needing rationale** (Step 6b, filesystem-capable only), **stack inventory** (Step 6c), **open question** (Step 9), or **ignore** (Step 10 refusal contract). The agent walks 6a → 6b → 6c in order, surfacing one list per substep and waiting for user input before continuing.
+
+### Step 6a — Documented decisions
+
+Candidates where a Step 3 source explicitly states acceptance and rationale (and, when applicable, rejected alternatives). Each entry: number, title (≤60 chars), one-line summary (≤140 chars), source location. A candidate also qualifies as documented when the rule is stated in one explicit source document and the rationale is stated in a *different* explicit source document — cite both source locations in the entry (e.g. "rule: CLAUDE.md §Conventions; rationale: README §How it works"). Code is never the rationale half of a cross-source pair; if rationale is absent from every doc the candidate falls to 6b or 6c. The agent prints the full list as one message:
 
 > Reply 'keep N' / 'edit N: <new title>' / 'skip N' per item. Or 'keep all' to accept everything. Reply 'done' when finished.
 
-**Step 5b — Boundary candidates.** Facts that *might* be decisions but where the source does not state rationale verbatim. Stack inventory (languages, frameworks, package managers, license, lint tooling) lives here unless a source frames the choice with rationale. Surfaced after the user finishes Step 5a:
+### Step 6b — Code-evidenced facts needing rationale
 
-> The agent thinks these might be decisions but couldn't extract rationale verbatim from the source. Each is opt-in only — reply 'opt N: <rationale>' to record any of them with rationale you provide; otherwise they are skipped.
+Filesystem-capable surfaces only. For each Step 4 observation that points at a real architectural choice (workspace shape, framework pick, test-layout convention, CI matrix, IaC target, …), the agent emits one targeted probe per observation, using this template verbatim:
 
-## Step 6 — Iterate kept items
+> I see X in file/path; was Y considered; what pushed you toward X?
 
-For each kept item from 5a (and each opt-in from 5b):
+Substitute `X` with the observed fact, `file/path` with the source it came from, and `Y` with a credible alternative the agent inferred (or "an alternative" if none is obvious). Probes are batched into one message; the user replies per item:
 
-1. Call `propose_decision(title=..., rationale=..., operation="add", rejected=..., confidence=...)`. Adopt seeds the store from source documents, so it normally uses `operation="add"` and does not set `affected_decision_id`. `rationale` is drawn from explicit source text or user-provided opt-ins. `confidence` defaults to `medium`; use `high` only when the source explicitly says "accepted" or "approved". Include rejected alternatives only when the source names them.
-2. **If `propose_decision` returns no conflicts**: call `confirm_decision(confirm_id)` automatically — no further user prompt.
-3. **If `propose_decision` returns conflicts**: surface the conflict text verbatim, ask `confirm-anyway / edit / skip`. On user 'confirm' → `confirm_decision(confirm_id)`.
+> Reply 'rationale N: <why>' to record it as a decision (it flows into the Step 7 write loop), 'inventory N' to drop it to stack inventory (6c), 'question N' to flag it as an open question (Step 9), or 'skip N' to drop it entirely.
 
-One propose+confirm per decision. No batching.
+When the user supplies rationale, the candidate is promoted into the Step 7 write loop with `operation="add"` by default — Step 7 step 3 reclassifies to `update` or `supersede` if `check_decision` surfaces an overlap.
 
-## Step 7 — State composition (one update_state call)
+### Step 6c — Stack inventory
+
+Languages, frameworks, package managers, license, lint tooling, and similar facts visible in the manifest or a "Stack" section without verbatim rationale. Stack inventory is folded into Step 8's `update_state` delta as a short summary — never written as decisions on its own. The only exception is a stack choice promoted into 6a via cross-doc stitching (rule in manifest, rationale in a separate doc). The agent prints the inventory list as one message:
+
+> The agent will fold these into the project state summary in Step 8. Reply 'drop N' to remove any, 'edit N: <new wording>' to rewrite, or 'done' to accept.
+
+## Step 7 — Write loop
+
+For each kept candidate from 6a and each rationale-supplied 6b answer, the agent runs the full D131 / D133 protocol:
+
+1. Call `check_decision(proposed_approach=<title or short description>, project_id=...)`. The tool returns related decisions via BM25 retrieval and a deterministic assessment.
+2. For each related decision in the response, call `get_decision(number=N, project_id=...)`. `check_decision` does not judge conflicts — the agent reads the decision bodies to decide what the right action is.
+3. Classify the operation:
+    - **add** (default; new ground, no existing decision covers it).
+    - **update** when the candidate augments an existing decision's rationale only. Per D133 the server consumes only `rationale` on update; `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, and `rejected` are rejected at the boundary — use supersede if any of those must change.
+    - **supersede** when the title or other metadata must change, or the candidate replaces or contradicts an existing decision. Pass the full new body and set `affected_decision_id`.
+    - **skip** when the candidate is a duplicate (e.g. matches `001-initial-setup` or a candidate already seeded earlier in this same adopt run).
+4. Call `propose_decision(project_id=..., title=..., rationale=..., operation=<op>, affected_decision_id=<N when update or supersede>, rejected=<…>, confidence=<…>)`. `rationale` is drawn from explicit Step 3 source text (6a) or the user's probe answer (6b). `confidence` defaults to `medium`; use `high` only when a source explicitly says "accepted" or "approved". Include rejected alternatives only when the source names them or the user supplies them in the probe answer.
+5. Call `confirm_decision(confirm_id, project_id=...)`:
+    - `add` + no conflicts → auto-confirm.
+    - `add` + conflicts → surface the assessment verbatim, ask `confirm-anyway / edit / skip`; confirm only on user 'confirm'.
+    - `update` or `supersede` → always pending per D131. Surface the assessment first; confirm only on explicit user 'confirm'.
+
+One propose+confirm per candidate. No batching.
+
+## Step 8 — State composition (one update_state call)
 
 The agent reads `activeContext.md` body and `progress.md` items, then composes one delta:
 
@@ -109,30 +155,44 @@ The agent reads `activeContext.md` body and `progress.md` items, then composes o
 - ...
 ```
 
-If only one source is present, the corresponding section is omitted. If neither is present, `update_state` is skipped entirely. **The agent does not call `update_state` per progress item** — `update_state` archives prior state to history, and the L0 payload ignores history.
+If Step 6c produced inventory items, append a short trailing section:
 
-## Step 8 — Flag open questions
+```
 
-Sources: explicit `## Open Questions` sections, lines beginning `Q:` or `TODO:` in CONTRIBUTING/ARCHITECTURE docs, user-noted gaps from Steps 5–6 ("we never decided X"). Per candidate: surface, ask `keep / edit / skip`. On keep → `flag_question(question, context)`.
+## Stack
+- {inventory_item_1}
+- {inventory_item_2}
+- ...
+```
 
-## Step 9 — Refusal contract
+If only one of activeContext / progress / inventory is present, the corresponding sections are omitted. If none is present, `update_state` is skipped entirely. **The agent does not call `update_state` per progress item or per inventory entry** — `update_state` archives prior state to history, and the L0 payload ignores history.
 
-The agent records facts that source documents explicitly state. The agent does not infer rationale from prose, does not invent rejected alternatives, does not assume `confidence=high` from tone, does not summarize a paragraph into a "decision" the source never called a decision. Three specific traps to avoid:
+## Step 9 — Flag open questions
+
+Sources: explicit `## Open Questions` sections, lines beginning `Q:` or `TODO:` in CONTRIBUTING / ARCHITECTURE docs, user-noted gaps from 6a / 6b / 6c dialogue ("we never decided X"), and Step 6b probes the user routed to `question N` or answered with "I don't know". Per candidate: surface, ask `keep / edit / skip`. On keep → `flag_question(question, context, project_id=...)`.
+
+## Step 10 — Refusal contract
+
+The agent records facts that source documents explicitly state, or that the user supplies in response to a Step 6b probe. The agent does not infer rationale from prose, does not invent rejected alternatives, does not assume `confidence=high` from tone, does not summarize a paragraph into a "decision" the source never called a decision. Five specific traps to avoid:
 
 - **Demo prose.** Decision-shaped statements inside README quickstart examples, illustrative scenarios, hypothetical user prompts, comparison tables, or product-demo narratives are false positives unless an independent source (CLAUDE.md, ADR, ARCHITECTURE.md, manifest, Memory-Bank) names the same fact as an actual project decision. In that case the independent source is the citation, not the demo prose.
-- **Stack inventory.** Languages, frameworks, package managers, license, and lint tooling listed in a manifest or a "Stack" section are inventory, not decisions, unless the source frames the choice with rationale (in which case Step 5a applies, possibly via cross-doc stitching).
-- **Cross-doc stitching is not inference.** When Step 5a stitches a rule from one source with rationale from another, both source locations must be explicit. The agent never fills in a missing rationale itself, and never treats two restatements of the same rule as "rule + rationale".
+- **Stack inventory is not decisions.** Languages, frameworks, package managers, license, and lint tooling listed in a manifest or a "Stack" section are inventory (6c) — they go into the Step 8 delta, not the decision log. Cross-doc stitching is the only path that promotes inventory into 6a.
+- **Cross-doc stitching is not inference.** When 6a stitches a rule from one source with rationale from another, both source locations must be explicit and both must be docs. The agent never fills in a missing rationale itself, never treats two restatements of the same rule as "rule + rationale", and never uses code as the rationale half.
+- **Code evidence is not rationale.** Source code, config files, tests, IaC templates, lockfiles, and git history are evidence of *what* — they tell you a stack was picked, a pattern is present, a CI matrix exists. They do not state *why*. The agent does not propose decisions from code alone; it asks a Step 6b probe and only records the decision once the user (or a Step 3 doc) supplies rationale.
+- **No code-only dependency decisions.** Dependency choices visible in `pyproject.toml`, `package.json`, lockfiles, or similar manifests never become decisions on their own. They land in 6c (stack inventory, folded into Step 8 state) or surface as 6b probes when a particular pick looks load-bearing enough to warrant a rationale.
 
-Boundary cases go to Step 5b (opt-in only — write rationale yourself), not into the clear-decisions list.
+Boundary cases go to 6b (probe → opt-in rationale) or 6c (inventory roll-up). They never flow into 6a without an explicit source.
 
-## Step 10 — Summary
+## Step 11 — Summary
 
 The agent prints one block:
 
 - Project: `<name>` (id: `<pid>`, store: `<store-path>`)
-- Sources read: `<comma-separated list>`
-- Decisions created: N (titles)
-- Decisions skipped: M (titles)
-- State updated: yes/no
-- Open questions flagged: K
+- Sources read: `<comma-separated list of docs from Step 3>`
+- Code evidence inspected: `<comma-separated list of Step 4 categories, or "skipped — chat surface">`
+- Code-evidence probes asked: `P` / answered: `A`
+- Decisions created: `N` (titles)
+- Decisions skipped: `M` (titles)
+- State updated: `yes`/`no`
+- Open questions flagged: `K`
 - Next: run `nauro sync` from the repo to capture a snapshot.

--- a/packages/nauro/src/nauro/skills/__init__.py
+++ b/packages/nauro/src/nauro/skills/__init__.py
@@ -18,14 +18,13 @@ SkillName = Literal["nauro", "nauro-adopt"]
 
 SKILL_DESCRIPTIONS: dict[str, str] = {
     "nauro-adopt": (
-        "Seeds Nauro's project store from an existing repo. Use after the user "
-        "has run `nauro adopt` locally. On filesystem-capable surfaces (Claude "
-        "Code, Cursor, Codex CLI), reads docs (README, manifests, ADRs, "
-        "Memory-Bank) for rationale and inspects code, config, tests, "
-        "lockfiles, and recent git history for evidence, then surfaces "
-        "targeted probes that turn evidence into rationale. On chat surfaces, "
-        "reads pasted content against an already-adopted project. Writes "
-        "decisions, state, and open questions via existing MCP write tools."
+        "Seeds Nauro's project store from an existing repo. Use after "
+        "`nauro adopt` has run locally. On filesystem-capable surfaces, reads "
+        "docs (README, manifests, ADRs, Memory-Bank) for rationale and "
+        "inspects code, config, tests, lockfiles, and recent git history for "
+        "evidence, then surfaces targeted probes that turn evidence into "
+        "rationale. On chat surfaces, operates on pasted content against an "
+        "already-adopted project."
     ),
     "nauro": (
         "Nauro session-time guidance. Reminds the agent to call get_context "

--- a/packages/nauro/src/nauro/skills/__init__.py
+++ b/packages/nauro/src/nauro/skills/__init__.py
@@ -18,10 +18,14 @@ SkillName = Literal["nauro", "nauro-adopt"]
 
 SKILL_DESCRIPTIONS: dict[str, str] = {
     "nauro-adopt": (
-        "Seeds Nauro's project store from an existing repo's documentation. "
-        "Use after the user has run `nauro adopt` locally — reads README, "
-        "manifests, ADRs, and Memory-Bank files, surfaces decision candidates "
-        "for triage, and writes them to Nauro via existing MCP write tools."
+        "Seeds Nauro's project store from an existing repo. Use after the user "
+        "has run `nauro adopt` locally. On filesystem-capable surfaces (Claude "
+        "Code, Cursor, Codex CLI), reads docs (README, manifests, ADRs, "
+        "Memory-Bank) for rationale and inspects code, config, tests, "
+        "lockfiles, and recent git history for evidence, then surfaces "
+        "targeted probes that turn evidence into rationale. On chat surfaces, "
+        "reads pasted content against an already-adopted project. Writes "
+        "decisions, state, and open questions via existing MCP write tools."
     ),
     "nauro": (
         "Nauro session-time guidance. Reminds the agent to call get_context "

--- a/packages/nauro/src/nauro/skills/adopt_body.md
+++ b/packages/nauro/src/nauro/skills/adopt_body.md
@@ -113,7 +113,21 @@ For each kept candidate from 6a and each rationale-supplied 6b answer, the agent
     - **update** when the candidate augments an existing decision's rationale only. Per D133 the server consumes only `rationale` on update; `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, and `rejected` are rejected at the boundary — use supersede if any of those must change.
     - **supersede** when the title or other metadata must change, or the candidate replaces or contradicts an existing decision. Pass the full new body and set `affected_decision_id`.
     - **skip** when the candidate is a duplicate (e.g. matches `001-initial-setup` or a candidate already seeded earlier in this same adopt run).
-4. Call `propose_decision(project_id=..., title=..., rationale=..., operation=<op>, affected_decision_id=<N when update or supersede>, rejected=<…>, confidence=<…>)`. `rationale` is drawn from explicit Step 3 source text (6a) or the user's probe answer (6b). `confidence` defaults to `medium`; use `high` only when a source explicitly says "accepted" or "approved". Include rejected alternatives only when the source names them or the user supplies them in the probe answer.
+4. Call `propose_decision` using the call signature for the chosen operation — these are operation-specific by design so an agent copying the template cannot accidentally send a field the server will reject:
+    - For **add** (new decisions):
+      ```
+      propose_decision(project_id=..., title=..., rationale=..., operation="add", rejected=..., confidence=...)
+      ```
+    - For **update** (rationale-only — D133 rejects every other field at the boundary):
+      ```
+      propose_decision(project_id=..., rationale=..., operation="update", affected_decision_id=...)
+      ```
+    - For **supersede** (replace a decision or change metadata; pass the full new body):
+      ```
+      propose_decision(project_id=..., title=..., rationale=..., operation="supersede", affected_decision_id=..., rejected=..., confidence=...)
+      ```
+
+   `rationale` is drawn from explicit Step 3 source text (6a) or the user's probe answer (6b). `confidence` defaults to `medium`; use `high` only when a source explicitly says "accepted" or "approved". Include rejected alternatives only when the source names them or the user supplies them in the probe answer.
 5. Call `confirm_decision(confirm_id, project_id=...)`:
     - `add` + no conflicts → auto-confirm.
     - `add` + conflicts → surface the assessment verbatim, ask `confirm-anyway / edit / skip`; confirm only on user 'confirm'.

--- a/packages/nauro/src/nauro/skills/adopt_body.md
+++ b/packages/nauro/src/nauro/skills/adopt_body.md
@@ -1,6 +1,13 @@
 # Nauro adopt skill
 
-The agent helps the user seed Nauro with context from the current repo. Before this skill runs, the user has run `nauro adopt` from the repo root, which created the project, wired MCP across surfaces, and installed this skill into the agent's surface directory. The agent's job here is to read the repo's documentation (README, manifests, ADRs, Memory-Bank) and seed the Nauro store via MCP write tools. The agent records facts that source documents explicitly state — it does not invent decisions from prose. On chat surfaces (Claude.ai, ChatGPT) without filesystem access, the agent uses paste-content mode (Step 3b); chat-paste mode requires the project to already exist (run `nauro adopt` locally first).
+The agent helps the user seed Nauro with context from the current repo. Before this skill runs, the user has run `nauro adopt` from the repo root, which created the project, wired MCP across surfaces, and installed this skill into the agent's surface directory. The agent's job here is to seed the Nauro store via MCP write tools: docs supply the rationale for documented decisions, code and config and tests and manifests and recent git history supply evidence, and the user supplies the "why" via targeted probes when only evidence is present. The agent records decisions that source documents explicitly state, or that the user confirms in response to a probe — it does not invent rationale from code or prose.
+
+## Surface modes
+
+The agent's behaviour depends on whether the surface can read the repo directly.
+
+- **Filesystem-capable surfaces** (Claude Code, Cursor, Codex CLI). The agent runs Steps 1–11 in full. Docs are read for rationale in Step 3; code, config, tests, manifests, and recent git history are inspected for evidence in Step 4; targeted probes in Step 6b turn evidence into rationale by asking the user.
+- **Chat surfaces** (Claude.ai, ChatGPT, Perplexity). The agent has no shell. It operates only on content the user pastes into the chat (Step 3b), and only against an already-adopted project per D127 (verified in Step 2). The code-evidence path (Step 4) and the Step 6b probes are unavailable; the agent does not ask the user to paste code in lieu of running shell commands. The skill skips from Step 3b directly to Step 5.
 
 ## Step 1 — Detect repo root
 
@@ -17,11 +24,11 @@ If the file is missing, try two fallbacks before aborting:
 
 Abort only when both fallbacks miss, with: "This repo is not adopted yet. Run 'nauro adopt' from the repo root, restart this agent, then invoke /nauro-adopt again."
 
-Pass `id` as the `project_id` argument on every subsequent MCP call (`propose_decision`, `confirm_decision`, `update_state`, `flag_question`, `get_context`, `list_decisions`). Do not omit `project_id` even though the tool descriptions say it's optional — auto-resolve routes to the user's default project, which is **not** the project this skill is seeding when both local-mode and cloud-mode projects coexist.
+Pass `id` as the `project_id` argument on every subsequent MCP call (`propose_decision`, `confirm_decision`, `update_state`, `flag_question`, `get_context`, `list_decisions`, `check_decision`, `get_decision`). Do not omit `project_id` even though the tool descriptions say it's optional — auto-resolve routes to the user's default project, which is **not** the project this skill is seeding when both local-mode and cloud-mode projects coexist.
 
-## Step 3 — Read source files
+## Step 3 — Read documentation
 
-The agent reads the first match found per category, with the manifest workspace exception below. Files larger than 256KB are flagged to the user before reading. If the README category yields no match, surface "No README found; reading manifest only." to the user once and continue — manifest-only repos are still adoptable.
+Docs are the rationale source. The agent reads the first match found per category, with the manifest workspace exception below. Files larger than 256KB are flagged to the user before reading. If the README category yields no match, surface "No README found; reading manifest only." to the user once and continue — manifest-only repos are still adoptable.
 
 - **README**: `README.md`, `README.rst`, `README` (first found)
 - **Manifest**: `pyproject.toml`, `package.json`, `Cargo.toml`, `go.mod`, `Gemfile`, `pom.xml`, `build.gradle`, `composer.json`, `requirements*.txt`. Read the root manifest. If it declares a workspace, also read each member manifest. Workspace declarations to recognise:
@@ -35,8 +42,6 @@ The agent reads the first match found per category, with the manifest workspace 
 - **ADR directory**: `docs/adr/`, `docs/decisions/`, `architecture/decisions/`, `adr/` — every `.md` except templates and index files (`0000-template.md`, `README.md`)
 - **Memory Bank**: `.context/`, `memory-bank/`, `cline_docs/` — `projectBrief.md`, `activeContext.md`, `techContext.md`, `decisionLog.md`, `progress.md`
 
-The agent does not read source code, tests, IaC templates, or git history during adopt. Those surfaces are out of scope on purpose — every recorded fact must trace back to an explicit source document so the refusal contract in Step 9 holds.
-
 ### Step 3b — Chat-surface paste branch
 
 When filesystem read is unavailable (chat surfaces), the agent first verifies the project exists by asking:
@@ -47,35 +52,76 @@ If the user cannot confirm an adopted project, the agent surfaces "Run `nauro ad
 
 > This skill needs source content. Paste the contents of any of: README, manifest (pyproject.toml/package.json/etc.), ADRs, Memory-Bank files. Send each as a separate message labelled with the filename.
 
-Chat-paste mode does not create projects.
+Chat-paste mode does not create projects, and chat surfaces skip Step 4 — code evidence is shell-bound and the agent does not ask the user to paste code in lieu of running commands.
 
-## Step 4 — Call get_context
+## Step 4 — Read code evidence
 
-The agent calls `get_context` (MCP) to surface what the scaffold already wrote — `001-initial-setup.md` and bracketed-prompt placeholders in `project.md` / `stack.md`. The agent uses this to (a) avoid duplicating the scaffold's first decision, (b) confirm the project resolved correctly.
+Filesystem-capable surfaces only. After Step 3, the agent inspects repo state to identify architectural facts that docs may not name. Each finding is held as an **observation** keyed by file path — never proposed as a decision on its own. Observations drive Step 6b's targeted probes; the user (or a Step 3 doc) must supply the rationale before anything flows into the decision log.
 
-## Step 5 — Build candidate list, surface FIRST
+Categories to inspect (the goal is enough evidence to ask the right probes, not a full inventory):
 
-The agent triages the source content into two lists.
+- **Source-tree layout.** `ls` the repo root and any workspace member directories. Note monorepo vs single-package shape, `src/`-layout vs flat, service-per-directory vs library-per-package.
+- **CI / CD config.** `.github/workflows/`, `.gitlab-ci.yml`, `.circleci/config.yml`, `azure-pipelines.yml`. Note the version matrix (which Python / Node / Rust versions are tested), required checks, and deployment targets.
+- **Test layout.** Test directory location (`tests/`, `__tests__/`, `*_test.go`), framework signals (pytest / jest / cargo test / go test), fixture conventions, and any integration vs unit split.
+- **Lint and format config.** `ruff.toml`, `.eslintrc*`, `.prettierrc*`, `mypy.ini`, `pyrightconfig.json`, `rustfmt.toml`, `.golangci.yml`.
+- **Infrastructure as code.** `Dockerfile`, `docker-compose.yml`, `terraform/`, `cdk.json`, `serverless.yml`, `sam/template.yaml`, `pulumi/`.
+- **Lockfiles and pinned versions.** Presence of `poetry.lock`, `uv.lock`, `package-lock.json`, `pnpm-lock.yaml`, `Cargo.lock`, `go.sum`. Note which package manager is canonical; do not enumerate every dependency.
+- **Recent git history.** `git log --oneline -n 30 --no-merges` to see what's active, when activity slowed, and which areas of the tree are touched most.
 
-**Step 5a — Clear decisions.** Candidates where the source explicitly states acceptance and rationale (and, when applicable, rejected alternatives). Each entry: number, title (≤60 chars), one-line summary (≤140 chars), source location. A candidate also qualifies as a clear decision when the rule is stated in one explicit source document and the rationale is stated in a *different* explicit source document — cite both source locations in the entry (e.g. "rule: CLAUDE.md §Conventions; rationale: README §How it works"). The agent does not invent the second source to make a candidate fit; if rationale is absent from every source the candidate goes to Step 5b. The agent prints the full list as one message:
+Step 4 ends with a list of observations, not a list of candidate decisions. Promotion into a candidate happens in Step 6b, after the user answers a probe.
+
+## Step 5 — Call get_context
+
+The agent calls `get_context` (MCP) to surface what the scaffold already wrote — `001-initial-setup.md` and bracketed-prompt placeholders in `project.md` / `stack.md`. The agent uses this to (a) avoid duplicating the scaffold's first decision, (b) confirm the project resolved correctly, and (c) learn what `check_decision` will treat as the existing baseline in Step 7.
+
+## Step 6 — Triage candidates
+
+Every candidate the agent surfaces lands in one of five buckets: **documented decision** (Step 6a), **code-evidenced fact needing rationale** (Step 6b, filesystem-capable only), **stack inventory** (Step 6c), **open question** (Step 9), or **ignore** (Step 10 refusal contract). The agent walks 6a → 6b → 6c in order, surfacing one list per substep and waiting for user input before continuing.
+
+### Step 6a — Documented decisions
+
+Candidates where a Step 3 source explicitly states acceptance and rationale (and, when applicable, rejected alternatives). Each entry: number, title (≤60 chars), one-line summary (≤140 chars), source location. A candidate also qualifies as documented when the rule is stated in one explicit source document and the rationale is stated in a *different* explicit source document — cite both source locations in the entry (e.g. "rule: CLAUDE.md §Conventions; rationale: README §How it works"). Code is never the rationale half of a cross-source pair; if rationale is absent from every doc the candidate falls to 6b or 6c. The agent prints the full list as one message:
 
 > Reply 'keep N' / 'edit N: <new title>' / 'skip N' per item. Or 'keep all' to accept everything. Reply 'done' when finished.
 
-**Step 5b — Boundary candidates.** Facts that *might* be decisions but where the source does not state rationale verbatim. Stack inventory (languages, frameworks, package managers, license, lint tooling) lives here unless a source frames the choice with rationale. Surfaced after the user finishes Step 5a:
+### Step 6b — Code-evidenced facts needing rationale
 
-> The agent thinks these might be decisions but couldn't extract rationale verbatim from the source. Each is opt-in only — reply 'opt N: <rationale>' to record any of them with rationale you provide; otherwise they are skipped.
+Filesystem-capable surfaces only. For each Step 4 observation that points at a real architectural choice (workspace shape, framework pick, test-layout convention, CI matrix, IaC target, …), the agent emits one targeted probe per observation, using this template verbatim:
 
-## Step 6 — Iterate kept items
+> I see X in file/path; was Y considered; what pushed you toward X?
 
-For each kept item from 5a (and each opt-in from 5b):
+Substitute `X` with the observed fact, `file/path` with the source it came from, and `Y` with a credible alternative the agent inferred (or "an alternative" if none is obvious). Probes are batched into one message; the user replies per item:
 
-1. Call `propose_decision(title=..., rationale=..., operation="add", rejected=..., confidence=...)`. Adopt seeds the store from source documents, so it normally uses `operation="add"` and does not set `affected_decision_id`. `rationale` is drawn from explicit source text or user-provided opt-ins. `confidence` defaults to `medium`; use `high` only when the source explicitly says "accepted" or "approved". Include rejected alternatives only when the source names them.
-2. **If `propose_decision` returns no conflicts**: call `confirm_decision(confirm_id)` automatically — no further user prompt.
-3. **If `propose_decision` returns conflicts**: surface the conflict text verbatim, ask `confirm-anyway / edit / skip`. On user 'confirm' → `confirm_decision(confirm_id)`.
+> Reply 'rationale N: <why>' to record it as a decision (it flows into the Step 7 write loop), 'inventory N' to drop it to stack inventory (6c), 'question N' to flag it as an open question (Step 9), or 'skip N' to drop it entirely.
 
-One propose+confirm per decision. No batching.
+When the user supplies rationale, the candidate is promoted into the Step 7 write loop with `operation="add"` by default — Step 7 step 3 reclassifies to `update` or `supersede` if `check_decision` surfaces an overlap.
 
-## Step 7 — State composition (one update_state call)
+### Step 6c — Stack inventory
+
+Languages, frameworks, package managers, license, lint tooling, and similar facts visible in the manifest or a "Stack" section without verbatim rationale. Stack inventory is folded into Step 8's `update_state` delta as a short summary — never written as decisions on its own. The only exception is a stack choice promoted into 6a via cross-doc stitching (rule in manifest, rationale in a separate doc). The agent prints the inventory list as one message:
+
+> The agent will fold these into the project state summary in Step 8. Reply 'drop N' to remove any, 'edit N: <new wording>' to rewrite, or 'done' to accept.
+
+## Step 7 — Write loop
+
+For each kept candidate from 6a and each rationale-supplied 6b answer, the agent runs the full D131 / D133 protocol:
+
+1. Call `check_decision(proposed_approach=<title or short description>, project_id=...)`. The tool returns related decisions via BM25 retrieval and a deterministic assessment.
+2. For each related decision in the response, call `get_decision(number=N, project_id=...)`. `check_decision` does not judge conflicts — the agent reads the decision bodies to decide what the right action is.
+3. Classify the operation:
+    - **add** (default; new ground, no existing decision covers it).
+    - **update** when the candidate augments an existing decision's rationale only. Per D133 the server consumes only `rationale` on update; `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, and `rejected` are rejected at the boundary — use supersede if any of those must change.
+    - **supersede** when the title or other metadata must change, or the candidate replaces or contradicts an existing decision. Pass the full new body and set `affected_decision_id`.
+    - **skip** when the candidate is a duplicate (e.g. matches `001-initial-setup` or a candidate already seeded earlier in this same adopt run).
+4. Call `propose_decision(project_id=..., title=..., rationale=..., operation=<op>, affected_decision_id=<N when update or supersede>, rejected=<…>, confidence=<…>)`. `rationale` is drawn from explicit Step 3 source text (6a) or the user's probe answer (6b). `confidence` defaults to `medium`; use `high` only when a source explicitly says "accepted" or "approved". Include rejected alternatives only when the source names them or the user supplies them in the probe answer.
+5. Call `confirm_decision(confirm_id, project_id=...)`:
+    - `add` + no conflicts → auto-confirm.
+    - `add` + conflicts → surface the assessment verbatim, ask `confirm-anyway / edit / skip`; confirm only on user 'confirm'.
+    - `update` or `supersede` → always pending per D131. Surface the assessment first; confirm only on explicit user 'confirm'.
+
+One propose+confirm per candidate. No batching.
+
+## Step 8 — State composition (one update_state call)
 
 The agent reads `activeContext.md` body and `progress.md` items, then composes one delta:
 
@@ -88,30 +134,44 @@ The agent reads `activeContext.md` body and `progress.md` items, then composes o
 - ...
 ```
 
-If only one source is present, the corresponding section is omitted. If neither is present, `update_state` is skipped entirely. **The agent does not call `update_state` per progress item** — `update_state` archives prior state to history, and the L0 payload ignores history.
+If Step 6c produced inventory items, append a short trailing section:
 
-## Step 8 — Flag open questions
+```
 
-Sources: explicit `## Open Questions` sections, lines beginning `Q:` or `TODO:` in CONTRIBUTING/ARCHITECTURE docs, user-noted gaps from Steps 5–6 ("we never decided X"). Per candidate: surface, ask `keep / edit / skip`. On keep → `flag_question(question, context)`.
+## Stack
+- {inventory_item_1}
+- {inventory_item_2}
+- ...
+```
 
-## Step 9 — Refusal contract
+If only one of activeContext / progress / inventory is present, the corresponding sections are omitted. If none is present, `update_state` is skipped entirely. **The agent does not call `update_state` per progress item or per inventory entry** — `update_state` archives prior state to history, and the L0 payload ignores history.
 
-The agent records facts that source documents explicitly state. The agent does not infer rationale from prose, does not invent rejected alternatives, does not assume `confidence=high` from tone, does not summarize a paragraph into a "decision" the source never called a decision. Three specific traps to avoid:
+## Step 9 — Flag open questions
+
+Sources: explicit `## Open Questions` sections, lines beginning `Q:` or `TODO:` in CONTRIBUTING / ARCHITECTURE docs, user-noted gaps from 6a / 6b / 6c dialogue ("we never decided X"), and Step 6b probes the user routed to `question N` or answered with "I don't know". Per candidate: surface, ask `keep / edit / skip`. On keep → `flag_question(question, context, project_id=...)`.
+
+## Step 10 — Refusal contract
+
+The agent records facts that source documents explicitly state, or that the user supplies in response to a Step 6b probe. The agent does not infer rationale from prose, does not invent rejected alternatives, does not assume `confidence=high` from tone, does not summarize a paragraph into a "decision" the source never called a decision. Five specific traps to avoid:
 
 - **Demo prose.** Decision-shaped statements inside README quickstart examples, illustrative scenarios, hypothetical user prompts, comparison tables, or product-demo narratives are false positives unless an independent source (CLAUDE.md, ADR, ARCHITECTURE.md, manifest, Memory-Bank) names the same fact as an actual project decision. In that case the independent source is the citation, not the demo prose.
-- **Stack inventory.** Languages, frameworks, package managers, license, and lint tooling listed in a manifest or a "Stack" section are inventory, not decisions, unless the source frames the choice with rationale (in which case Step 5a applies, possibly via cross-doc stitching).
-- **Cross-doc stitching is not inference.** When Step 5a stitches a rule from one source with rationale from another, both source locations must be explicit. The agent never fills in a missing rationale itself, and never treats two restatements of the same rule as "rule + rationale".
+- **Stack inventory is not decisions.** Languages, frameworks, package managers, license, and lint tooling listed in a manifest or a "Stack" section are inventory (6c) — they go into the Step 8 delta, not the decision log. Cross-doc stitching is the only path that promotes inventory into 6a.
+- **Cross-doc stitching is not inference.** When 6a stitches a rule from one source with rationale from another, both source locations must be explicit and both must be docs. The agent never fills in a missing rationale itself, never treats two restatements of the same rule as "rule + rationale", and never uses code as the rationale half.
+- **Code evidence is not rationale.** Source code, config files, tests, IaC templates, lockfiles, and git history are evidence of *what* — they tell you a stack was picked, a pattern is present, a CI matrix exists. They do not state *why*. The agent does not propose decisions from code alone; it asks a Step 6b probe and only records the decision once the user (or a Step 3 doc) supplies rationale.
+- **No code-only dependency decisions.** Dependency choices visible in `pyproject.toml`, `package.json`, lockfiles, or similar manifests never become decisions on their own. They land in 6c (stack inventory, folded into Step 8 state) or surface as 6b probes when a particular pick looks load-bearing enough to warrant a rationale.
 
-Boundary cases go to Step 5b (opt-in only — write rationale yourself), not into the clear-decisions list.
+Boundary cases go to 6b (probe → opt-in rationale) or 6c (inventory roll-up). They never flow into 6a without an explicit source.
 
-## Step 10 — Summary
+## Step 11 — Summary
 
 The agent prints one block:
 
 - Project: `<name>` (id: `<pid>`, store: `<store-path>`)
-- Sources read: `<comma-separated list>`
-- Decisions created: N (titles)
-- Decisions skipped: M (titles)
-- State updated: yes/no
-- Open questions flagged: K
+- Sources read: `<comma-separated list of docs from Step 3>`
+- Code evidence inspected: `<comma-separated list of Step 4 categories, or "skipped — chat surface">`
+- Code-evidence probes asked: `P` / answered: `A`
+- Decisions created: `N` (titles)
+- Decisions skipped: `M` (titles)
+- State updated: `yes`/`no`
+- Open questions flagged: `K`
 - Next: run `nauro sync` from the repo to capture a snapshot.

--- a/packages/nauro/tests/test_skills_drift.py
+++ b/packages/nauro/tests/test_skills_drift.py
@@ -21,11 +21,15 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 def test_load_adopt_body_returns_canonical_bytes():
     body = load_adopt_body()
     assert body.endswith("\n")
-    assert 1000 < len(body) < 20000
+    assert 1000 < len(body) < 25000
     # Anchor on key step markers — catches accidental empty / corrupted body.
     assert "Step 1 — Detect repo root" in body
-    assert "Step 5a — Clear decisions" in body
-    assert "Step 10 — Summary" in body
+    assert "## Surface modes" in body
+    assert "Step 4 — Read code evidence" in body
+    assert "Step 6a — Documented decisions" in body
+    assert "Step 6b — Code-evidenced" in body
+    assert "was Y considered; what pushed you toward X" in body
+    assert "Step 11 — Summary" in body
 
 
 def test_load_session_body_returns_canonical_bytes():
@@ -125,6 +129,18 @@ RETIRED_PHRASES = [
     (
         "bracketed-prompt placeholders in `project.md` / `stack.md` / `state_current.md`",
         "PR #38 removed bracket-prompt scaffolding from state_current.md",
+    ),
+    (
+        "The agent does not read source code, tests, IaC templates, or git history during adopt",
+        "D125 v2 reverses the docs-only stance — code is evidence on filesystem-capable surfaces",
+    ),
+    (
+        "Step 5a — Clear decisions",
+        "D125 v2 renamed to Step 6a — Documented decisions",
+    ),
+    (
+        "Step 5b — Boundary candidates",
+        "D125 v2 split this into Step 6b (code-evidenced) + Step 6c (stack inventory)",
     ),
 ]
 

--- a/packages/nauro/tests/test_skills_drift.py
+++ b/packages/nauro/tests/test_skills_drift.py
@@ -29,6 +29,9 @@ def test_load_adopt_body_returns_canonical_bytes():
     assert "Step 6a — Documented decisions" in body
     assert "Step 6b — Code-evidenced" in body
     assert "was Y considered; what pushed you toward X" in body
+    # Step 7 has operation-specific propose_decision templates per D133 —
+    # the dedicated update signature must stay distinct from add/supersede.
+    assert 'operation="update"' in body
     assert "Step 11 — Summary" in body
 
 


### PR DESCRIPTION
## Why

**Implements D125 v2 / Workstream F.** D125 v2 was recorded on 2026-05-13; this PR brings the `/nauro-adopt` skill body in line with it — it is not the D125 v2 update itself. With the decision in place, `/nauro-adopt` is now allowed to be code-aware on filesystem-capable surfaces. Today's body explicitly disclaims that (`adopt_body.md:38` — "The agent does not read source code, tests, IaC templates, or git history during adopt"). That stance forfeits high-signal evidence already sitting in the repo and forces probes whose answers are obvious in `pyproject.toml` or the test layout. D125 v2's resolved scope: docs supply rationale, code/config/tests/manifests/git history supply *evidence*, targeted probes turn evidence into rationale via the user.

The skill copy needs to catch up with the decision, the write loop needs to use the current D131/D133 protocol (not the operation-aware-but-doc-only call shape from PR #39), and the phrase-blocklist needs new entries so the docs-only stance can't reappear.

## Approach

Single canonical body, mechanical re-render. The user-facing trigger (`SKILL_DESCRIPTIONS["nauro-adopt"]`) is also updated so agents pick up the broadened scope on first match — without that the new body wouldn't fire on the repos it now handles better.

Three orthogonal changes in one PR because they're a coherent set:

1. **Surface modes section** (new, top of body). Filesystem-capable surfaces (Claude Code, Cursor, Codex CLI) run Steps 1–11 in full. Chat surfaces (Claude.ai, ChatGPT, Perplexity) skip Step 4 per D127 — they have no shell.
2. **Triage with five named buckets** (Step 6 restructure). Every candidate is one of: documented decision (6a), code-evidenced fact needing rationale (6b), stack inventory (6c), open question (Step 9), ignore (Step 10 refusal). The user routes 6b probe answers between buckets explicitly (`rationale N` / `inventory N` / `question N` / `skip N`). Probe template is verbatim: *"I see X in file/path; was Y considered; what pushed you toward X?"*
3. **Write loop on D131 + D133** (Step 7 rewrite). `check_decision` → `get_decision` per related result → classify `add` / `update` / `supersede` / `skip`. `propose_decision` is shown with **three operation-specific call templates** so a skimming agent cannot accidentally copy D133-rejected fields into an update call. Update/supersede always pending per D131; surface the assessment before confirming.

Rejected: a separate `/nauro-adopt-code` skill keyed on surface. Tempting because the surface-mode branch maps to skill identity, but it doubles the trigger-matching surface for marginal clarity gain — agents would have to pick between two skills based on shell availability, which is the surface-mode check the body already does internally.

## What changed

- `packages/nauro/src/nauro/skills/adopt_body.md` — full restructure (10.6KB → 18.2KB). New `## Surface modes`; renamed `Step 3 — Read documentation`; new `Step 4 — Read code evidence` (filesystem-only, observations not candidates); renumbered subsequent steps; Step 6 split into 6a/6b/6c with the five-bucket enumeration; Step 7 rewritten on D131/D133 with three operation-specific `propose_decision` call templates (add / update / supersede) — update intentionally omits `title`, `confidence`, `rejected`, etc. so the boundary reject can't bite a skimming agent; Step 10 refusal contract grows from three to five named traps (adds *Code evidence is not rationale* + *No code-only dependency decisions*); Step 11 summary block grows two lines.
- `packages/nauro/src/nauro/skills/__init__.py` — `SKILL_DESCRIPTIONS["nauro-adopt"]` rewritten so the agent-facing trigger mentions docs-for-rationale + code/config/tests/lockfiles/git-history-for-evidence on filesystem-capable surfaces, and pasted-content fallback on chat surfaces. ~430 chars (substantive triggers kept; surface-name enumeration and trailing MCP-write-tools clause dropped).
- `packages/nauro/tests/test_skills_drift.py` — body size cap bumped (20KB → 25KB); anchors switched to new step titles plus `## Surface modes`, `Step 4 — Read code evidence`, `Step 6b — Code-evidenced`, the verbatim probe substring `was Y considered; what pushed you toward X`, and `operation="update"` (locks in the dedicated D133-aware template so collapsing the three templates back into one fails CI); three new `RETIRED_PHRASES` entries lock out the docs-only stance line, the old `Step 5a — Clear decisions` heading, and the old `Step 5b — Boundary candidates` heading.
- Re-rendered dogfood / docs surfaces (byte-equal to `render_skill(...)` per the existing drift tests):
  - `.claude/skills/nauro-adopt/SKILL.md`
  - `.agents/skills/nauro-adopt/SKILL.md`
  - `.cursor/rules/nauro-adopt.mdc`
  - `docs/adopt-prompt.md` (chat-paste intro preserved; body replaced)
- Three session-skill dogfood files untouched — `session_body.md` already documents the D131 protocol.

## What to review

- **`SKILL_DESCRIPTIONS["nauro-adopt"]` wording.** Trigger string the harness reads — overfit phrasing would either miss intended surfaces or fire on out-of-scope ones. Now ~430 chars; surface-name enumeration dropped, trailing MCP-write-tools clause dropped, substantive triggers (docs / code / probes / chat-pasted-content) kept.
- **Step 4 scope vs Step 10 *Code evidence is not rationale* trap.** Step 4 grants permission to read code; Step 10 says code never supplies rationale. These need to read as complementary, not contradictory.
- **Five-bucket enumeration paragraph at the top of Step 6.** Drift test anchors on this paragraph; worth checking it names every bucket and the user-routing options in 6b are unambiguous.
- **Step 7 operation-specific `propose_decision` templates.** Update template intentionally shows only `project_id` / `rationale` / `operation` / `affected_decision_id` — an agent copying it can't trip D133's boundary reject on `title` / `confidence` / `rejected`. Worth a quick read against D133's exact rejected-fields list to confirm the field omissions match.
- **No new tests for body content itself** (still prose). The existing parametrized `test_skills_drift.py` enforces byte-parity across the six dogfood files + `docs/adopt-prompt.md` and now scans 11 retired phrases × 3 surfaces.

## What's deferred

- **PostHog telemetry on bucket distribution** (how many candidates land in 6a vs 6b vs 6c vs FP). Useful for tuning the probe-vs-inventory threshold but needs real-world adopt runs after this lands.
- **Repeated-adopt UX.** When a user re-runs `/nauro-adopt` against an already-seeded store, Step 7 step 3 will hit `update`/`supersede` more often. The write loop handles this correctly but the user-facing prompts haven't been audited for the repeated-adopt flow specifically.
- **Probe rate-limiting / ranking.** Step 6b emits one probe per Step 4 observation; on a busy repo that could be dozens. No explicit cap — relies on agent judgment to suppress obvious-inventory probes. Worth revisiting once telemetry lands.
- **Session-skill D131 documentation gap.** `session_body.md` documents `check_decision` → `get_decision` → `propose_decision` + `confirm_decision` but doesn't enumerate operation classification or D133 update-only-rationale at the session-skill level. Filed for a later P2 / shared-instruction-core item — session use is overwhelmingly `add` and the MCP tool descriptions cover the picker, so the gap is low-risk in practice.

## Test plan

- `uv run --package nauro --with pytest --with pytest-asyncio pytest packages/nauro/tests/test_skills_drift.py -x -q` → **46 passed** (drift + phrase-blocklist; includes the new `operation="update"` anchor).
- `uv run --package nauro --with pytest --with pytest-asyncio pytest packages/nauro/tests/ -x -q -m "not integration"` → **699 passed**.
- `uv run --with ruff ruff check packages/` → clean.
- `uv run --with ruff ruff format --check packages/` → 139 files already formatted.
- Dry adopt trace against this monorepo: Step 4 surfaces uv-workspace layout, two publish workflows, `uv.lock`, pytest+ruff signals, recent git history of D124/D129/D130/D131 alignment work. Step 6b emits ~5 targeted probes (workspace split, src-layout, publish workflow split, uv pick, Jinja2 absence). Step 7's `check_decision` correctly routes the "Python 3.10+" candidate to `skip` as duplicate of D124. System-reminder block confirms the new frontmatter description is live in the harness — trigger string visible to the matcher on the next session.