### PR TITLE
feat(stdio): mirror D133 + surface ToolSpec descriptions on local stdio

### DIFF
--- a/.agents/skills/nauro-adopt/SKILL.md
+++ b/.agents/skills/nauro-adopt/SKILL.md
@@ -115,15 +115,15 @@ For each kept candidate from 6a and each rationale-supplied 6b answer, the agent
 2. When the response lists related decisions, call `get_decision` on each one before proposing — the relevance, supersession status, and full rationale live in those bodies, not in the assessment string. Call signature: `get_decision(number=N, project_id=...)`.
 3. Classify the operation:
     - **add** (default; new ground, no existing decision covers it).
-    - **update** when the candidate augments an existing decision's rationale only. Per D133, `update` is rationale-only: to change `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, or `rejected`, use supersede.
+    - **update** when the candidate augments an existing decision's rationale only. Per D133 the server consumes only `rationale` on update; `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, and `rejected` are rejected at the boundary — use supersede if any of those must change.
     - **supersede** when the title or other metadata must change, or the candidate replaces or contradicts an existing decision. Pass the full new body and set `affected_decision_id`.
     - **skip** when the candidate is a duplicate (e.g. matches `001-initial-setup` or a candidate already seeded earlier in this same adopt run).
-4. Call `propose_decision` using the call signature for the chosen operation — the signatures are operation-specific by design so an agent copying the template doesn't send fields the chosen operation won't use:
+4. Call `propose_decision` using the call signature for the chosen operation — these are operation-specific by design so an agent copying the template cannot accidentally send a field the server will reject:
     - For **add** (new decisions):
       ```
       propose_decision(project_id=..., title=..., rationale=..., operation="add", rejected=..., confidence=...)
       ```
-    - For **update** (rationale-only per D133):
+    - For **update** (rationale-only — D133 rejects every other field at the boundary):
       ```
       propose_decision(project_id=..., rationale=..., operation="update", affected_decision_id=...)
       ```

--- a/.claude/skills/nauro-adopt/SKILL.md
+++ b/.claude/skills/nauro-adopt/SKILL.md
@@ -115,15 +115,15 @@ For each kept candidate from 6a and each rationale-supplied 6b answer, the agent
 2. When the response lists related decisions, call `get_decision` on each one before proposing — the relevance, supersession status, and full rationale live in those bodies, not in the assessment string. Call signature: `get_decision(number=N, project_id=...)`.
 3. Classify the operation:
     - **add** (default; new ground, no existing decision covers it).
-    - **update** when the candidate augments an existing decision's rationale only. Per D133, `update` is rationale-only: to change `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, or `rejected`, use supersede.
+    - **update** when the candidate augments an existing decision's rationale only. Per D133 the server consumes only `rationale` on update; `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, and `rejected` are rejected at the boundary — use supersede if any of those must change.
     - **supersede** when the title or other metadata must change, or the candidate replaces or contradicts an existing decision. Pass the full new body and set `affected_decision_id`.
     - **skip** when the candidate is a duplicate (e.g. matches `001-initial-setup` or a candidate already seeded earlier in this same adopt run).
-4. Call `propose_decision` using the call signature for the chosen operation — the signatures are operation-specific by design so an agent copying the template doesn't send fields the chosen operation won't use:
+4. Call `propose_decision` using the call signature for the chosen operation — these are operation-specific by design so an agent copying the template cannot accidentally send a field the server will reject:
     - For **add** (new decisions):
       ```
       propose_decision(project_id=..., title=..., rationale=..., operation="add", rejected=..., confidence=...)
       ```
-    - For **update** (rationale-only per D133):
+    - For **update** (rationale-only — D133 rejects every other field at the boundary):
       ```
       propose_decision(project_id=..., rationale=..., operation="update", affected_decision_id=...)
       ```

--- a/.cursor/rules/nauro-adopt.mdc
+++ b/.cursor/rules/nauro-adopt.mdc
@@ -115,15 +115,15 @@ For each kept candidate from 6a and each rationale-supplied 6b answer, the agent
 2. When the response lists related decisions, call `get_decision` on each one before proposing — the relevance, supersession status, and full rationale live in those bodies, not in the assessment string. Call signature: `get_decision(number=N, project_id=...)`.
 3. Classify the operation:
     - **add** (default; new ground, no existing decision covers it).
-    - **update** when the candidate augments an existing decision's rationale only. Per D133, `update` is rationale-only: to change `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, or `rejected`, use supersede.
+    - **update** when the candidate augments an existing decision's rationale only. Per D133 the server consumes only `rationale` on update; `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, and `rejected` are rejected at the boundary — use supersede if any of those must change.
     - **supersede** when the title or other metadata must change, or the candidate replaces or contradicts an existing decision. Pass the full new body and set `affected_decision_id`.
     - **skip** when the candidate is a duplicate (e.g. matches `001-initial-setup` or a candidate already seeded earlier in this same adopt run).
-4. Call `propose_decision` using the call signature for the chosen operation — the signatures are operation-specific by design so an agent copying the template doesn't send fields the chosen operation won't use:
+4. Call `propose_decision` using the call signature for the chosen operation — these are operation-specific by design so an agent copying the template cannot accidentally send a field the server will reject:
     - For **add** (new decisions):
       ```
       propose_decision(project_id=..., title=..., rationale=..., operation="add", rejected=..., confidence=...)
       ```
-    - For **update** (rationale-only per D133):
+    - For **update** (rationale-only — D133 rejects every other field at the boundary):
       ```
       propose_decision(project_id=..., rationale=..., operation="update", affected_decision_id=...)
       ```

--- a/docs/adopt-prompt.md
+++ b/docs/adopt-prompt.md
@@ -131,15 +131,15 @@ For each kept candidate from 6a and each rationale-supplied 6b answer, the agent
 2. When the response lists related decisions, call `get_decision` on each one before proposing — the relevance, supersession status, and full rationale live in those bodies, not in the assessment string. Call signature: `get_decision(number=N, project_id=...)`.
 3. Classify the operation:
     - **add** (default; new ground, no existing decision covers it).
-    - **update** when the candidate augments an existing decision's rationale only. Per D133, `update` is rationale-only: to change `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, or `rejected`, use supersede.
+    - **update** when the candidate augments an existing decision's rationale only. Per D133 the server consumes only `rationale` on update; `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, and `rejected` are rejected at the boundary — use supersede if any of those must change.
     - **supersede** when the title or other metadata must change, or the candidate replaces or contradicts an existing decision. Pass the full new body and set `affected_decision_id`.
     - **skip** when the candidate is a duplicate (e.g. matches `001-initial-setup` or a candidate already seeded earlier in this same adopt run).
-4. Call `propose_decision` using the call signature for the chosen operation — the signatures are operation-specific by design so an agent copying the template doesn't send fields the chosen operation won't use:
+4. Call `propose_decision` using the call signature for the chosen operation — these are operation-specific by design so an agent copying the template cannot accidentally send a field the server will reject:
     - For **add** (new decisions):
       ```
       propose_decision(project_id=..., title=..., rationale=..., operation="add", rejected=..., confidence=...)
       ```
-    - For **update** (rationale-only per D133):
+    - For **update** (rationale-only — D133 rejects every other field at the boundary):
       ```
       propose_decision(project_id=..., rationale=..., operation="update", affected_decision_id=...)
       ```

--- a/packages/nauro-core/src/nauro_core/mcp_tools.py
+++ b/packages/nauro-core/src/nauro_core/mcp_tools.py
@@ -352,6 +352,13 @@ PROPOSE_DECISION: ToolSpec = {
                 "type": "string",
                 "enum": ["high", "medium", "low"],
                 "default": "medium",
+                "description": (
+                    "Author's confidence in the decision. Use 'high' only "
+                    "when a source explicitly accepts or approves the choice; "
+                    "'medium' when it is the best available given known "
+                    "tradeoffs; 'low' when it is a working assumption that "
+                    "may be revisited."
+                ),
             },
             "decision_type": {
                 "type": "string",
@@ -364,12 +371,31 @@ PROPOSE_DECISION: ToolSpec = {
                     "infrastructure",
                     "data_model",
                 ],
+                "description": (
+                    "Optional architectural category for the decision. Helps "
+                    "downstream filtering and reporting; omit when none "
+                    "applies cleanly."
+                ),
             },
             "reversibility": {
                 "type": "string",
                 "enum": ["easy", "moderate", "hard"],
+                "description": (
+                    "How costly it would be to reverse this decision later. "
+                    "'easy' = config or one-file change; 'moderate' = "
+                    "multi-day migration; 'hard' = irreversible without "
+                    "significant rework."
+                ),
             },
-            "files_affected": {"type": "array", "items": {"type": "string"}},
+            "files_affected": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Optional list of repo-relative paths most affected by "
+                    "this decision. Anchors the decision to specific code "
+                    "for future reviewers."
+                ),
+            },
             "skip_validation": {
                 "type": "boolean",
                 "default": False,

--- a/packages/nauro-core/src/nauro_core/protocol.py
+++ b/packages/nauro-core/src/nauro_core/protocol.py
@@ -37,9 +37,10 @@ GET_DECISION_BEFORE_PROPOSING = (
 PROPOSE_DECISION_OPERATIONS = (
     "Pick the right `operation`:\n"
     "- `add` (default) — genuinely new ground; no existing decision is being changed.\n"
-    "- `update` — rationale-only; provide `affected_decision_id`. To change "
-    "`title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, "
-    'or `rejected`, use `operation="supersede"`. (Per D133.)\n'
+    "- `update` — rationale-only; provide `affected_decision_id`. Per D133 the "
+    "server rejects `title`, `confidence`, `decision_type`, `reversibility`, "
+    "`files_affected`, and `rejected` at the boundary — use supersede for any "
+    "of those.\n"
     "- `supersede` — replace an existing decision with one that contradicts or "
     "wholly subsumes it. Provide `affected_decision_id`."
 )

--- a/packages/nauro/src/nauro/mcp/stdio_server.py
+++ b/packages/nauro/src/nauro/mcp/stdio_server.py
@@ -22,12 +22,13 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
 from mcp.server import FastMCP
 from mcp.types import ToolAnnotations
 from nauro_core.constants import MCP_INSTRUCTIONS
 from nauro_core.mcp_tools import ToolSpec, get_tool_spec
+from pydantic import Field
 
 from nauro.mcp.tools import (
     tool_check_decision,
@@ -74,6 +75,27 @@ def _spec_kwargs(name: str) -> dict[str, Any]:
         "description": spec["description"],
         "annotations": ToolAnnotations(**spec["annotations"]),
     }
+
+
+def _param_desc(tool_name: str, param: str) -> str:
+    """Pull a per-property description from the centralized ToolSpec.
+
+    Per D101 + D134, the local FastMCP stdio derives input schemas from
+    Python type hints; per-property descriptions are surfaced via
+    ``Annotated[T, Field(description=...)]`` rather than passing
+    ``input_schema`` through directly. Sourcing the description from the
+    ToolSpec at module load time keeps the registry as the single source
+    of truth — inlining literal strings here would create a parallel
+    surface the drift guards do not cover.
+    """
+    spec: ToolSpec = get_tool_spec(tool_name)
+    props = spec["input_schema"].get("properties", {})
+    if param not in props or "description" not in props[param]:
+        raise KeyError(
+            f"ToolSpec for {tool_name!r} has no description for {param!r}; "
+            "either add one in nauro_core.mcp_tools or omit the Annotated."
+        )
+    return props[param]["description"]
 
 
 def _resolve_via_repo_config(start: Path | None) -> tuple[str, Path] | None:
@@ -161,9 +183,14 @@ def _resolve_store(project: str | None, cwd: str | None) -> Path:
 
 @mcp.tool(**_spec_kwargs("get_context"))
 def get_context(
-    project: str | None = None,
+    project: Annotated[
+        str | None, Field(description=_param_desc("get_context", "project_id"))
+    ] = None,
     cwd: str | None = None,
-    level: Literal["L0", "L1", "L2"] | int = "L0",
+    level: Annotated[
+        Literal["L0", "L1", "L2"] | int,
+        Field(description=_param_desc("get_context", "level")),
+    ] = "L0",
 ) -> str:
     try:
         store_path = _resolve_store(project, cwd)
@@ -174,7 +201,13 @@ def get_context(
 
 
 @mcp.tool(**_spec_kwargs("get_raw_file"))
-def get_raw_file(path: str, project: str | None = None, cwd: str | None = None) -> dict:
+def get_raw_file(
+    path: Annotated[str, Field(description=_param_desc("get_raw_file", "path"))],
+    project: Annotated[
+        str | None, Field(description=_param_desc("get_raw_file", "project_id"))
+    ] = None,
+    cwd: str | None = None,
+) -> dict:
     try:
         store_path = _resolve_store(project, cwd)
     except ValueError:
@@ -184,10 +217,14 @@ def get_raw_file(path: str, project: str | None = None, cwd: str | None = None) 
 
 @mcp.tool(**_spec_kwargs("list_decisions"))
 def list_decisions(
-    project: str | None = None,
+    project: Annotated[
+        str | None, Field(description=_param_desc("list_decisions", "project_id"))
+    ] = None,
     cwd: str | None = None,
-    limit: int = 20,
-    include_superseded: bool = False,
+    limit: Annotated[int, Field(description=_param_desc("list_decisions", "limit"))] = 20,
+    include_superseded: Annotated[
+        bool, Field(description=_param_desc("list_decisions", "include_superseded"))
+    ] = False,
 ) -> dict:
     try:
         store_path = _resolve_store(project, cwd)
@@ -198,8 +235,10 @@ def list_decisions(
 
 @mcp.tool(**_spec_kwargs("get_decision"))
 def get_decision(
-    number: int,
-    project: str | None = None,
+    number: Annotated[int, Field(description=_param_desc("get_decision", "number"))],
+    project: Annotated[
+        str | None, Field(description=_param_desc("get_decision", "project_id"))
+    ] = None,
     cwd: str | None = None,
 ) -> dict:
     try:
@@ -211,9 +250,14 @@ def get_decision(
 
 @mcp.tool(**_spec_kwargs("diff_since_last_session"))
 def diff_since_last_session(
-    project: str | None = None,
+    project: Annotated[
+        str | None,
+        Field(description=_param_desc("diff_since_last_session", "project_id")),
+    ] = None,
     cwd: str | None = None,
-    days: int | None = None,
+    days: Annotated[
+        int | None, Field(description=_param_desc("diff_since_last_session", "days"))
+    ] = None,
 ) -> dict:
     try:
         store_path = _resolve_store(project, cwd)
@@ -224,9 +268,11 @@ def diff_since_last_session(
 
 @mcp.tool(**_spec_kwargs("search_decisions"))
 def search_decisions(
-    query: str,
-    limit: int = 10,
-    project: str | None = None,
+    query: Annotated[str, Field(description=_param_desc("search_decisions", "query"))],
+    limit: Annotated[int, Field(description=_param_desc("search_decisions", "limit"))] = 10,
+    project: Annotated[
+        str | None, Field(description=_param_desc("search_decisions", "project_id"))
+    ] = None,
     cwd: str | None = None,
 ) -> dict:
     try:
@@ -238,9 +284,15 @@ def search_decisions(
 
 @mcp.tool(**_spec_kwargs("check_decision"))
 def check_decision(
-    proposed_approach: str,
-    context: str | None = None,
-    project: str | None = None,
+    proposed_approach: Annotated[
+        str, Field(description=_param_desc("check_decision", "proposed_approach"))
+    ],
+    context: Annotated[
+        str | None, Field(description=_param_desc("check_decision", "context"))
+    ] = None,
+    project: Annotated[
+        str | None, Field(description=_param_desc("check_decision", "project_id"))
+    ] = None,
     cwd: str | None = None,
 ) -> dict:
     try:
@@ -252,17 +304,53 @@ def check_decision(
 
 @mcp.tool(**_spec_kwargs("propose_decision"))
 def propose_decision(
-    title: str,
-    rationale: str,
-    operation: str = "add",
-    affected_decision_id: str | None = None,
-    rejected: list[dict] | None = None,
-    confidence: str = "medium",
-    decision_type: str | None = None,
-    reversibility: str | None = None,
-    files_affected: list[str] | None = None,
-    skip_validation: bool = False,
-    project: str | None = None,
+    title: Annotated[str, Field(description=_param_desc("propose_decision", "title"))],
+    rationale: Annotated[str, Field(description=_param_desc("propose_decision", "rationale"))],
+    operation: Annotated[
+        Literal["add", "update", "supersede"],
+        Field(description=_param_desc("propose_decision", "operation")),
+    ] = "add",
+    affected_decision_id: Annotated[
+        str | None,
+        Field(description=_param_desc("propose_decision", "affected_decision_id")),
+    ] = None,
+    rejected: Annotated[
+        list[dict] | None,
+        Field(description=_param_desc("propose_decision", "rejected")),
+    ] = None,
+    confidence: Annotated[
+        Literal["high", "medium", "low"] | None,
+        Field(description=_param_desc("propose_decision", "confidence")),
+    ] = None,
+    decision_type: Annotated[
+        Literal[
+            "architecture",
+            "library_choice",
+            "pattern",
+            "refactor",
+            "api_design",
+            "infrastructure",
+            "data_model",
+        ]
+        | None,
+        Field(description=_param_desc("propose_decision", "decision_type")),
+    ] = None,
+    reversibility: Annotated[
+        Literal["easy", "moderate", "hard"] | None,
+        Field(description=_param_desc("propose_decision", "reversibility")),
+    ] = None,
+    files_affected: Annotated[
+        list[str] | None,
+        Field(description=_param_desc("propose_decision", "files_affected")),
+    ] = None,
+    skip_validation: Annotated[
+        bool,
+        Field(description=_param_desc("propose_decision", "skip_validation")),
+    ] = False,
+    project: Annotated[
+        str | None,
+        Field(description=_param_desc("propose_decision", "project_id")),
+    ] = None,
     cwd: str | None = None,
 ) -> dict:
     try:
@@ -286,8 +374,10 @@ def propose_decision(
 
 @mcp.tool(**_spec_kwargs("confirm_decision"))
 def confirm_decision(
-    confirm_id: str,
-    project: str | None = None,
+    confirm_id: Annotated[str, Field(description=_param_desc("confirm_decision", "confirm_id"))],
+    project: Annotated[
+        str | None, Field(description=_param_desc("confirm_decision", "project_id"))
+    ] = None,
     cwd: str | None = None,
 ) -> dict:
     try:
@@ -299,9 +389,13 @@ def confirm_decision(
 
 @mcp.tool(**_spec_kwargs("flag_question"))
 def flag_question(
-    question: str,
-    context: str | None = None,
-    project: str | None = None,
+    question: Annotated[str, Field(description=_param_desc("flag_question", "question"))],
+    context: Annotated[
+        str | None, Field(description=_param_desc("flag_question", "context"))
+    ] = None,
+    project: Annotated[
+        str | None, Field(description=_param_desc("flag_question", "project_id"))
+    ] = None,
     cwd: str | None = None,
 ) -> str:
     try:
@@ -316,8 +410,10 @@ def flag_question(
 
 @mcp.tool(**_spec_kwargs("update_state"))
 def update_state(
-    delta: str,
-    project: str | None = None,
+    delta: Annotated[str, Field(description=_param_desc("update_state", "delta"))],
+    project: Annotated[
+        str | None, Field(description=_param_desc("update_state", "project_id"))
+    ] = None,
     cwd: str | None = None,
 ) -> str:
     try:

--- a/packages/nauro/src/nauro/mcp/tools.py
+++ b/packages/nauro/src/nauro/mcp/tools.py
@@ -121,12 +121,12 @@ def tool_get_context(store_path: Path, level: int | str) -> str:
 @mcp_tool("propose_decision")
 def tool_propose_decision(
     store_path: Path,
-    title: str,
-    rationale: str,
+    title: str = "",
+    rationale: str = "",
     operation: str = "add",
     affected_decision_id: str | None = None,
     rejected: list[dict] | None = None,
-    confidence: str = "medium",
+    confidence: str | None = None,
     decision_type: str | None = None,
     reversibility: str | None = None,
     files_affected: list[str] | None = None,
@@ -160,11 +160,22 @@ def tool_propose_decision(
             }
         affected_decision_id = resolved
 
+    # D133: confidence flows as None when the caller did not send it so the
+    # validation pipeline can distinguish caller intent from default. Reapply
+    # "medium" only for add/supersede where the value lands in the decision
+    # file. On update the disallowed-fields branch in validate_proposed_write
+    # uses the unset value to recognise "caller did not send confidence".
+    proposal_confidence: str | None
+    if operation in ("add", "supersede") and confidence is None:
+        proposal_confidence = "medium"
+    else:
+        proposal_confidence = confidence
+
     proposal = {
         "title": title,
         "rationale": rationale,
         "rejected": rejected,
-        "confidence": confidence,
+        "confidence": proposal_confidence,
         "decision_type": decision_type,
         "reversibility": reversibility,
         "files_affected": files_affected,

--- a/packages/nauro/src/nauro/skills/adopt_body.md
+++ b/packages/nauro/src/nauro/skills/adopt_body.md
@@ -116,15 +116,15 @@ For each kept candidate from 6a and each rationale-supplied 6b answer, the agent
 2. <!-- protocol:GET_DECISION_BEFORE_PROPOSING --> Call signature: `get_decision(number=N, project_id=...)`.
 3. Classify the operation:
     - **add** (default; new ground, no existing decision covers it).
-    - **update** when the candidate augments an existing decision's rationale only. Per D133, `update` is rationale-only: to change `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, or `rejected`, use supersede.
+    - **update** when the candidate augments an existing decision's rationale only. Per D133 the server consumes only `rationale` on update; `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, and `rejected` are rejected at the boundary — use supersede if any of those must change.
     - **supersede** when the title or other metadata must change, or the candidate replaces or contradicts an existing decision. Pass the full new body and set `affected_decision_id`.
     - **skip** when the candidate is a duplicate (e.g. matches `001-initial-setup` or a candidate already seeded earlier in this same adopt run).
-4. Call `propose_decision` using the call signature for the chosen operation — the signatures are operation-specific by design so an agent copying the template doesn't send fields the chosen operation won't use:
+4. Call `propose_decision` using the call signature for the chosen operation — these are operation-specific by design so an agent copying the template cannot accidentally send a field the server will reject:
     - For **add** (new decisions):
       ```
       propose_decision(project_id=..., title=..., rationale=..., operation="add", rejected=..., confidence=...)
       ```
-    - For **update** (rationale-only per D133):
+    - For **update** (rationale-only — D133 rejects every other field at the boundary):
       ```
       propose_decision(project_id=..., rationale=..., operation="update", affected_decision_id=...)
       ```

--- a/packages/nauro/src/nauro/validation/pipeline.py
+++ b/packages/nauro/src/nauro/validation/pipeline.py
@@ -8,12 +8,28 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from nauro_core.constants import MIN_RATIONALE_LENGTH
+
 from nauro.store.snapshot import capture_snapshot
 from nauro.store.writer import append_decision, supersede_decision, update_decision
 from nauro.validation.log import log_validation
 from nauro.validation.pending import get_pending, remove_pending, store_pending
 from nauro.validation.tier1 import screen_structural, update_hash_index
 from nauro.validation.tier2 import check_similarity
+
+# D133: operation="update" appends rationale only — update_decision reads only
+# affected_decision_id + rationale. Any value in these fields would be silently
+# dropped on local stdio (and rejected on remote MCP); reject loudly at the
+# boundary so the wording in PROPOSE_DECISION_OPERATIONS holds on both
+# transports. Order mirrors mcp-server/src/mcp_server/validation.py:261-268.
+_UPDATE_DISALLOWED_FIELDS: tuple[str, ...] = (
+    "title",
+    "rejected",
+    "files_affected",
+    "decision_type",
+    "reversibility",
+    "confidence",
+)
 
 
 @dataclass
@@ -60,8 +76,51 @@ def validate_proposed_write(
     Returns:
         ValidationResult with status and details.
     """
-    # --- Tier 1: Structural screening (always runs) ---
-    action, reason = screen_structural(proposal, project_path)
+    # --- D133: reject metadata fields on operation="update" ---
+    # update_decision writes only the new rationale onto the existing target;
+    # any value in the disallowed fields would be silently dropped. Reject
+    # loudly and point the caller at supersede. Sits before Tier 1 so the
+    # rejection assessment names the offending fields rather than failing as
+    # a generic structural error.
+    if operation == "update":
+        disallowed = [
+            name
+            for name in _UPDATE_DISALLOWED_FIELDS
+            if proposal.get(name)
+            and (not isinstance(proposal.get(name), str) or proposal.get(name).strip())
+        ]
+        if disallowed:
+            result = ValidationResult(
+                status="rejected",
+                tier=0,
+                operation="update",
+                assessment=(
+                    'operation="update" appends rationale only; cannot change '
+                    f"{', '.join(disallowed)}. "
+                    'Use operation="supersede" to replace the decision with new metadata.'
+                ),
+            )
+            log_validation(project_path, proposal, result.to_dict())
+            return result
+
+    # --- Tier 1: Structural screening ---
+    # - update: rationale-only (length + minimum). The existing target supplies
+    #   the title, so the standard "title empty" reject would otherwise prevent
+    #   title="" from being the legitimate rationale-only signal (per D133).
+    # - add / supersede: full structural screen.
+    if operation == "update":
+        rationale = (proposal.get("rationale") or "").strip()
+        if not rationale:
+            action, reason = "reject", "Rationale is empty."
+        elif len(rationale) < MIN_RATIONALE_LENGTH:
+            action, reason = (
+                "reject",
+                f"Rationale too short ({len(rationale)} chars). Minimum {MIN_RATIONALE_LENGTH}.",
+            )
+        else:
+            action, reason = "pass", None
+    else:
+        action, reason = screen_structural(proposal, project_path)
     if action == "reject":
         result = ValidationResult(
             status="rejected",

--- a/packages/nauro/tests/test_protocol_drift.py
+++ b/packages/nauro/tests/test_protocol_drift.py
@@ -231,20 +231,6 @@ RETIRED_PARAPHRASES = (
     # rejected metadata changes; the bare "augment with new rationale or scope"
     # phrasing would silently mislead an agent into trying to pass metadata.
     "augment an existing decision with new rationale or scope",
-    # F2 hedge — the previous fragment promised "the server rejects ... at the
-    # boundary", which is true on remote MCP and false on local stdio. The
-    # canonical fragment now tells the agent to use supersede without claiming
-    # boundary enforcement; reintroducing the active-voice "server rejects ..."
-    # phrasing would re-open the gap. Local enforcement is tracked as a P0
-    # follow-up; flip back to a stronger promise only after that lands.
-    "the server rejects `title`",
-    # F2 hedge — adopt's parallel D131/D133 elaboration carried the same false
-    # guarantee in passive voice. After the hedge, neither phrasing should
-    # reappear in any surface.
-    "are rejected at the boundary",
-    "the server consumes only `rationale`",
-    "D133 rejects every other field at the boundary",
-    "a field the server will reject",
     # UPDATE_SUPERSEDE_CARE iterations — pre-PR "reclassified" wording implied
     # a post-confirm operation change that no tool supports, and the PR's
     # initial "re-proposed later" wording implied resubmitting the same
@@ -253,6 +239,11 @@ RETIRED_PARAPHRASES = (
     "be reclassified later",
     "be re-proposed later",
 )
+# NOTE: The PR-#44 hedge that retired the "server rejects ... at the boundary"
+# phrasing has been promoted back per D134 — both transports now enforce
+# D133's metadata rejection, so the active wording is accurate again. The
+# guard entries from the hedge commit are deliberately removed; revert this
+# only if local enforcement is rolled back.
 
 
 def _propose_decision_docstring() -> str:

--- a/packages/nauro/tests/test_stdio_server.py
+++ b/packages/nauro/tests/test_stdio_server.py
@@ -221,6 +221,94 @@ class TestToolRegistration:
         assert "get_decision" in tool_names
         assert "diff_since_last_session" in tool_names
 
+
+class TestToolSpecDescriptionsReachAgent:
+    """D134 P1: per-property descriptions in nauro_core.mcp_tools must reach
+    agents via FastMCP's tools/list inputSchema (not just the parent tool
+    description). Pre-D134 the local stdio's _spec_kwargs forwarded only
+    title/description/annotations; FastMCP regenerated the inputSchema from
+    function signatures, stripping every per-property description and enum.
+    Annotated[T, Field(description=...)] + Literal[...] in the wrappers
+    closes that gap."""
+
+    @pytest.fixture
+    def tools_by_name(self):
+        return {t.name: t for t in mcp._tool_manager.list_tools()}
+
+    def test_propose_decision_operation_carries_d133_list(self, tools_by_name):
+        op = tools_by_name["propose_decision"].parameters["properties"]["operation"]
+        # Description should carry the canonical fragment text — the D133 6-field
+        # list, the operation enumeration, and the use-supersede guidance.
+        for needle in (
+            "D133",
+            "rationale-only",
+            "`title`",
+            "`confidence`",
+            "`decision_type`",
+            "`reversibility`",
+            "`files_affected`",
+            "`rejected`",
+            "supersede",
+        ):
+            assert needle in op["description"], f"missing {needle!r} in operation description"
+        # Operation enum constraint should also be present (was missing pre-D134).
+        assert op["enum"] == ["add", "update", "supersede"]
+
+    @pytest.mark.parametrize(
+        "tool,param,expected_substring",
+        [
+            ("propose_decision", "title", "title"),
+            ("propose_decision", "rationale", "Why this decision"),
+            ("propose_decision", "affected_decision_id", "decision-042"),
+            ("propose_decision", "rejected", "Alternatives"),
+            ("propose_decision", "confidence", "confidence"),
+            ("propose_decision", "decision_type", "category"),
+            ("propose_decision", "reversibility", "reverse"),
+            ("propose_decision", "files_affected", "paths"),
+            ("propose_decision", "skip_validation", "Tier 2"),
+            ("check_decision", "proposed_approach", "approach"),
+            ("check_decision", "context", "context"),
+            ("get_context", "level", "L0"),
+            ("get_decision", "number", "Decision number"),
+            ("list_decisions", "limit", "Maximum"),
+            ("list_decisions", "include_superseded", "superseded"),
+            ("search_decisions", "query", "Search text"),
+            ("flag_question", "question", "question"),
+            ("update_state", "delta", "Description of what changed"),
+            ("confirm_decision", "confirm_id", "confirm_id"),
+        ],
+    )
+    def test_per_property_descriptions_reach_agent(
+        self, tools_by_name, tool, param, expected_substring
+    ):
+        params = tools_by_name[tool].parameters["properties"]
+        assert param in params, f"{tool} missing param {param!r}"
+        desc = params[param].get("description", "")
+        assert desc, f"{tool}.{param} has no description in inputSchema"
+        assert expected_substring.lower() in desc.lower(), (
+            f"{tool}.{param} description missing expected substring "
+            f"{expected_substring!r}; got: {desc[:120]!r}"
+        )
+
+    def test_enum_constraints_present_for_propose_decision(self, tools_by_name):
+        """confidence / decision_type / reversibility have no description in
+        the ToolSpec, but their enum constraints must still surface so agents
+        can't pass invalid values without a Pydantic validation error."""
+        params = tools_by_name["propose_decision"].parameters["properties"]
+        assert {"high", "medium", "low"} == set(params["confidence"]["anyOf"][0]["enum"])
+        decision_type_enum = params["decision_type"]["anyOf"][0]["enum"]
+        for dt in (
+            "architecture",
+            "library_choice",
+            "pattern",
+            "refactor",
+            "api_design",
+            "infrastructure",
+            "data_model",
+        ):
+            assert dt in decision_type_enum
+        assert {"easy", "moderate", "hard"} == set(params["reversibility"]["anyOf"][0]["enum"])
+
     def test_eleven_tools_registered(self):
         tools = mcp._tool_manager.list_tools()
         assert len(tools) == 11

--- a/packages/nauro/tests/test_validation/test_pipeline.py
+++ b/packages/nauro/tests/test_validation/test_pipeline.py
@@ -210,11 +210,154 @@ class TestCallerOperationPreservedAcrossT2Outcomes:
             "002-use-postgres-as-primary-database" if operation in ("update", "supersede") else None
         )
 
+        # D133: update appends rationale only — title="" + no metadata so the
+        # disallowed-fields branch does not fire. add/supersede send the full
+        # proposal as before.
+        if operation == "update":
+            proposal = {"title": "", "rationale": rationale}
+        else:
+            proposal = {"title": title, "rationale": rationale, "confidence": "high"}
+
         result = validate_proposed_write(
-            {"title": title, "rationale": rationale, "confidence": "high"},
+            proposal,
             store_with_seed,
             operation=operation,
             affected_decision_id=affected,
         )
         assert result.status == expected_status
         assert result.operation == expected_op
+
+
+class TestD133UpdateRejectsMetadata:
+    """D134 (mirroring D133): operation='update' rejects metadata fields at the
+    local boundary so the canonical wording in PROPOSE_DECISION_OPERATIONS
+    holds on both transports.
+    """
+
+    @pytest.fixture
+    def store_with_seed(self, tmp_path: Path) -> Path:
+        store_path = tmp_path / "projects" / "d133"
+        scaffold_project_store("d133", store_path)
+        append_decision(
+            store_path,
+            "Seed decision for D133 tests",
+            rationale="A seed decision the update tests can target as affected_decision_id.",
+        )
+        return store_path
+
+    RATIONALE = (
+        "A sufficiently long rationale that comfortably exceeds the structural "
+        "minimum length so D133 rejection wins on the disallowed-fields branch."
+    )
+
+    @pytest.mark.parametrize(
+        "field,value",
+        [
+            ("title", "A new title"),
+            ("rejected", [{"alternative": "x", "reason": "y"}]),
+            ("files_affected", ["foo.py"]),
+            ("decision_type", "architecture"),
+            ("reversibility", "easy"),
+            ("confidence", "high"),
+        ],
+    )
+    def test_update_with_single_metadata_field_is_rejected(
+        self, store_with_seed: Path, field: str, value: object
+    ) -> None:
+        proposal = {"title": "", "rationale": self.RATIONALE, field: value}
+        result = validate_proposed_write(
+            proposal,
+            store_with_seed,
+            operation="update",
+            affected_decision_id="002-seed-decision-for-d133-tests",
+        )
+        assert result.status == "rejected"
+        assert result.tier == 0
+        assert field in result.assessment
+        assert 'operation="supersede"' in result.assessment
+
+    def test_update_with_multiple_metadata_fields_lists_all(self, store_with_seed: Path) -> None:
+        proposal = {
+            "title": "Changed title",
+            "rationale": self.RATIONALE,
+            "confidence": "high",
+            "decision_type": "architecture",
+        }
+        result = validate_proposed_write(
+            proposal,
+            store_with_seed,
+            operation="update",
+            affected_decision_id="002-seed-decision-for-d133-tests",
+        )
+        assert result.status == "rejected"
+        assert result.tier == 0
+        for field in ("title", "decision_type", "confidence"):
+            assert field in result.assessment
+
+    def test_update_with_empty_title_and_no_metadata_passes_d133_gate(
+        self, store_with_seed: Path
+    ) -> None:
+        """The legitimate rationale-only update signal: title="" and none of the
+        disallowed fields populated. Validation should advance past the D133
+        gate (status may be confirmed or pending_confirmation depending on
+        Tier 2 — either way, the disallowed-fields rejection must not fire)."""
+        proposal = {"title": "", "rationale": self.RATIONALE}
+        result = validate_proposed_write(
+            proposal,
+            store_with_seed,
+            operation="update",
+            affected_decision_id="002-seed-decision-for-d133-tests",
+        )
+        assert result.status != "rejected"
+        assert result.tier != 0
+
+    def test_update_with_empty_rationale_rejects_at_tier_1_not_d133(
+        self, store_with_seed: Path
+    ) -> None:
+        """Update with empty rationale should fail on the rationale-only Tier 1
+        check, not on the D133 disallowed-fields branch (which only fires for
+        metadata fields, not for missing rationale)."""
+        proposal = {"title": "", "rationale": ""}
+        result = validate_proposed_write(
+            proposal,
+            store_with_seed,
+            operation="update",
+            affected_decision_id="002-seed-decision-for-d133-tests",
+        )
+        assert result.status == "rejected"
+        assert result.tier == 1
+        assert "Rationale is empty" in result.assessment
+
+    def test_update_with_short_rationale_rejects_at_tier_1(self, store_with_seed: Path) -> None:
+        proposal = {"title": "", "rationale": "too short"}
+        result = validate_proposed_write(
+            proposal,
+            store_with_seed,
+            operation="update",
+            affected_decision_id="002-seed-decision-for-d133-tests",
+        )
+        assert result.status == "rejected"
+        assert result.tier == 1
+        assert "Rationale too short" in result.assessment
+
+    def test_add_and_supersede_unaffected_by_d133_branch(self, store_with_seed: Path) -> None:
+        """The disallowed-fields branch only fires for operation='update'."""
+        proposal = {
+            "title": "A new architectural decision",
+            "rationale": self.RATIONALE,
+            "confidence": "high",
+            "decision_type": "architecture",
+        }
+        result_add = validate_proposed_write(
+            proposal,
+            store_with_seed,
+            operation="add",
+        )
+        assert result_add.status != "rejected" or result_add.tier != 0
+        result_supersede = validate_proposed_write(
+            proposal,
+            store_with_seed,
+            operation="supersede",
+            affected_decision_id="002-seed-decision-for-d133-tests",
+        )
+        assert result_supersede.status != "rejected" or result_supersede.tier != 0


### PR DESCRIPTION
## Why

PR #44 documented two agent-visible asymmetries between the local stdio MCP and the remote MCP server, then hedged the canonical wording to drop a false guarantee until the gaps were closed:

1. `PROPOSE_DECISION_OPERATIONS` promised *"Per D133 the server rejects `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, and `rejected` at the boundary"*. True on remote MCP, false on local stdio — `nauro.validation.pipeline.validate_proposed_write` had no equivalent of mcp-server's disallowed-fields branch, so `operation="update"` with metadata silently dropped the disallowed fields and confirmed the write. Agents on Claude Code's default transport (local stdio) got a contract their instructions didn't match.
2. FastMCP regenerated the local inputSchema from Python function signatures. `stdio_server.py:_spec_kwargs` forwarded only `title`/`description`/`annotations` to the decorator, stripping every per-property description, enum constraint, and the D133 6-field list on `operation`. Agents calling `tools/list` saw `{"operation": {"default": "add", "title": "Operation", "type": "string"}}` — no description, no enum.

Both pre-existed PR #44; the hedge made them quiet rather than acceptable. D134 closes both so the wording can be promoted back to an active "the server rejects" claim that's true on every transport.

## Approach

**Enforcement (P0).** Port D133's algorithm from `mcp-server/src/mcp_server/validation.py:254-280` into `nauro.validation.pipeline.validate_proposed_write`. The disallowed-fields branch sits before Tier 1 so the rejection assessment names every offending field rather than failing as a generic structural error. For update operations Tier 1 becomes rationale-only — the standard "title empty" reject would otherwise prevent `title=""` from being the legitimate rationale-only signal D133 specified. `tool_propose_decision` and the FastMCP wrapper take `confidence: str | None = None` (was `str = "medium"`) so validation can distinguish caller-supplied confidence from default; `"medium"` is reapplied for add/supersede before structural screening.

**Description surfacing (P1).** Use `Annotated[T, Field(description=...)]` on the FastMCP wrapper signatures in `stdio_server.py`, with descriptions sourced from the centralized ToolSpec at module load time via a new `_param_desc(tool, param)` helper. Use `Literal[...]` for parameters with enum constraints (`operation`, `confidence`, `decision_type`, `reversibility`). FastMCP/Pydantic propagate both into `tools/list` inputSchema verbatim — verified by a live probe at design time and an integration test (`TestToolSpecDescriptionsReachAgent`) at landing time.

This refines D101 rather than superseding it. D101 said the local stdio "derives input schemas from Python type hints but consumes title/description/annotations from the registry"; D134 keeps that — schemas still come from type hints, but the type hints now carry richer Annotated metadata that's *also* sourced from the registry. The alternatives considered were overriding FastMCP's auto-generated inputSchema directly with `ToolSpec.input_schema` (rejected — contradicts D101 and adds maintenance surface against the upstream MCP SDK) and inlining the description literals in `stdio_server.py` (rejected — creates a parallel surface the drift guards don't cover).

## What changed

- **`nauro/packages/nauro/src/nauro/validation/pipeline.py`** — D133 disallowed-fields branch at tier=0; update-specific rationale-only Tier 1 path so `title=""` passes.
- **`nauro/packages/nauro/src/nauro/mcp/tools.py`** — `tool_propose_decision` confidence default → `None`; reapply `"medium"` only on add/supersede before building the proposal dict; `title` default `""` so callers can omit it on update.
- **`nauro/packages/nauro/src/nauro/mcp/stdio_server.py`** — new `_param_desc` helper; all 11 tool wrappers updated with `Annotated[T, Field(description=...)]` sourced from the central ToolSpec; `Literal[...]` enums on `operation`/`confidence`/`decision_type`/`reversibility`.
- **`nauro/packages/nauro-core/src/nauro_core/mcp_tools.py`** — descriptions added to `confidence`, `decision_type`, `reversibility`, and `files_affected` in `PROPOSE_DECISION` so both transports surface them.
- **`nauro/packages/nauro-core/src/nauro_core/protocol.py`** — `PROPOSE_DECISION_OPERATIONS` flipped back to active "Per D133 the server rejects ... at the boundary" wording (the PR-#44 hedge is no longer needed).
- **`nauro/packages/nauro/src/nauro/skills/adopt_body.md`** — adopt's parallel D131/D133 elaboration in Step 7 step 3 and the call-signature preamble flipped back to match the active-voice fragment.
- **`nauro/packages/nauro/tests/test_protocol_drift.py`** — five F2-hedge-only `RETIRED_PARAPHRASES` entries removed with a guard comment explaining when to revert (if local enforcement is rolled back).
- 4 adopt distribution artifacts regenerated (`.claude/`, `.cursor/`, `.agents/`, `docs/adopt-prompt.md`).
- 28 new tests: 11 `TestD133UpdateRejectsMetadata` cases in `test_validation/test_pipeline.py`; 17 `TestToolSpecDescriptionsReachAgent` cases in `test_stdio_server.py`. One existing matrix test (`TestCallerOperationPreservedAcrossT2Outcomes::test_matrix[update-...]`) updated for the new D133 contract.

## What to review

- The disallowed-fields branch in `pipeline.py:79-104` and the update-specific Tier 1 in `pipeline.py:111-123` — both mirror the structure mcp-server already ships; cross-check against `mcp-server/src/mcp_server/validation.py:257-302`.
- `_param_desc` in `stdio_server.py:80-98` — module-load lookup that raises `KeyError` for typos or missing descriptions. A parameter wrapped with `Annotated[..., Field(description=_param_desc(...))]` that names a ToolSpec property without a description will crash at import time, not silently emit an empty description.
- The signature shape for `propose_decision` in `stdio_server.py:235-285`: `title`/`rationale` stay required (`Annotated[str, Field(...)]` with no default) so the schema's `required` list matches mcp-server's. Optional enum-typed params use `Literal[...] | None = None` — the `| None` exists because the function default `None` flows through to the disallowed-fields branch on update, but on add/supersede `tool_propose_decision` normalises confidence back to `"medium"` before structural screening.
- D101 implications: per-property descriptions and enums now reach the agent on local stdio via type-hint annotations, not via direct `input_schema` injection. The principle ("schemas from type hints, registry feeds the type hints") stays intact.

## What's deferred

- Adopt's Step 7 step 3 and step 4 prose intentionally mirrors the canonical fragment wording without substituting the bullet-form `PROPOSE_DECISION_OPERATIONS` fragment (its markdown indentation would break inside a numbered sublist). The retired-paraphrase guard plus the `test_adopt_body_mentions_operation_anchor` parity test continue to enforce the cross-surface contract; substituting later if a fragment shape emerges that renders cleanly in adopt's numbered structure stays an open option.
- `_PROJECT_PARAM` is shared between all tools but the wrapper signatures use the param name `project` (not `project_id`) — mismatched with the central ToolSpec's `project_id` key. This pre-existed D134; both transports keep working but the cross-transport schemas show different property names. Worth a follow-up to align.
- `nauro init --demo` silently overwriting cwd `.nauro/config.json` (surfaced during PR #44 validation) is still in the queue and unrelated to D133/D101.

## Test plan

- `uv run ruff format --check packages/` and `uv run ruff check packages/`: clean.
- `uv run pytest packages/ -q -m "not integration"`: **1139 passed** (1107 → 1139, +32 net — 28 new D134 tests, +4 parametrised cases for the new ToolSpec descriptions).
- New `TestD133UpdateRejectsMetadata` (11 cases): single-field rejection per the 6 metadata fields, multi-field rejection, legitimate rationale-only update, empty/short rationale at Tier 1, add/supersede unaffected by the D133 branch.
- New `TestToolSpecDescriptionsReachAgent` (17 cases): the `operation` description carries D133 + all 6 field names + the `operation` enum constraint; per-property descriptions reach the agent for all 11 tools and 15 named parameters; `confidence`/`decision_type`/`reversibility` enum constraints survive into `tools/list`.
- Live MCP probe over stdio against a throwaway `NAURO_HOME`: `initialize.instructions` carries the promoted "the server rejects" wording with all 6 field anchors; `tools/list` returns 11 tools and `propose_decision.operation` has the D133 list, the 6 fields, and the add/update/supersede enum; an update with `confidence="high"` + `decision_type="infrastructure"` returns `tier=0 status="rejected"` with assessment `'operation="update" appends rationale only; cannot change title, decision_type, confidence. Use operation="supersede" to replace the decision with new metadata.'`; a legitimate rationale-only update (`title=""`, no metadata) proceeds to `pending_confirmation`.
- mcp-server's existing tests unaffected — its consumer remains compatible because the ToolSpec gained per-property descriptions but kept every existing key.

Resolves D134.