### PR TITLE
fix(init,mcp): refuse cwd config overwrite; typed resolve_store errors (D136)

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/init.py
+++ b/packages/nauro/src/nauro/cli/commands/init.py
@@ -35,13 +35,75 @@ from nauro.store.registry import (
     get_store_path_v2,
     register_project_v2,
 )
-from nauro.store.repo_config import save_repo_config
+from nauro.store.repo_config import (
+    RepoConfigSchemaError,
+    load_repo_config,
+    repo_config_path,
+    save_repo_config,
+)
 from nauro.sync.cloud_projects import CloudProjectError, create_project
 from nauro.telemetry import capture
 from nauro.telemetry.events import project_created
 from nauro.templates.scaffolds import scaffold_project_store
 
 logger = logging.getLogger("nauro.cli.init")
+
+
+def _check_config_overwrite(
+    rp: Path,
+    expected_id: str | None,
+    expected_name: str,
+    force: bool,
+) -> None:
+    """Refuse to overwrite an existing ``.nauro/config.json`` whose project
+    differs from the one being initialized. Per D136, this closes the
+    silent-overwrite footgun where ``nauro init <new-name>`` (or
+    ``nauro init --demo``) would replace a real project's cwd config
+    without warning, breaking every subsequent cwd-walk-up resolution.
+
+    No-op when no existing config is present, when the existing config
+    advertises the same project *id* as ``expected_id`` (idempotent
+    re-write — applies to ``--add-repo`` where the pid is known up front),
+    or when ``force`` is set. Aborts via :class:`typer.Exit` with a
+    diagnostic message naming the existing project otherwise. For a fresh
+    init where ``expected_id`` is ``None``, no id match can short-circuit,
+    so any existing config triggers the refusal — name match alone is not
+    a safe idempotency signal because v2 allows duplicate names with
+    distinct ids.
+    """
+    config_file = repo_config_path(rp)
+    if not config_file.is_file():
+        return
+    try:
+        existing = load_repo_config(rp)
+    except RepoConfigSchemaError:
+        # Existing file is structurally invalid — let save_repo_config
+        # replace it; there is no trustworthy state to preserve.
+        return
+    except (OSError, ValueError):
+        return
+    existing_id = existing.get("id")
+    existing_name = existing.get("name")
+    # Idempotent: --add-repo against the same project id is a re-statement,
+    # not a conflict. We only short-circuit on id match — name match is
+    # insufficient because v2 allows duplicate names with distinct ids.
+    if expected_id is not None and existing_id == expected_id:
+        return
+    if force:
+        return
+    typer.echo(
+        f"Refusing to overwrite existing .nauro/config.json in {rp.resolve()}\n"
+        f"  Existing: {existing_name!r} (id: {existing_id})\n"
+        f"  New:      {expected_name!r}\n"
+        "\n"
+        "Options:\n"
+        "  - Re-run with --force to replace the existing config.\n"
+        "  - cd into a different directory and re-run nauro init.\n"
+        f"  - If you meant to associate this repo with {existing_name!r},\n"
+        f"    run: nauro init {existing_name!r} --add-repo {rp.resolve()}",
+        err=True,
+    )
+    raise typer.Exit(code=1)
 
 
 def init(
@@ -60,6 +122,15 @@ def init(
         False,
         "--cloud",
         help="Create a cloud-scoped project on the remote MCP server.",
+    ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help=(
+            "Overwrite an existing .nauro/config.json in the target repo. "
+            "Without this flag init refuses to replace a config pointing at "
+            "a different project."
+        ),
     ),
 ) -> None:
     """Initialize a new Nauro project store and register it.
@@ -90,6 +161,9 @@ def init(
                 )
                 raise typer.Exit(code=1)
             store_path = get_store_path_v2(pid)
+            # Pre-check every target repo before any state changes (D136).
+            for rp in repo_paths:
+                _check_config_overwrite(rp, pid, name, force)
             added = []
             for rp in repo_paths:
                 add_repo_v2(pid, rp)
@@ -112,6 +186,16 @@ def init(
             return
 
     # ── New project: cloud or local ────────────────────────────────────────
+    # Pre-check every target repo before allocating a new id (D136). For a
+    # fresh init we have no pid to compare against; any existing config is
+    # treated as a potential conflict and refused without --force. v2 allows
+    # duplicate names with distinct ids, so name-match alone cannot be a
+    # safe idempotency signal — silently coalescing 'nauro init projA' from
+    # a cwd already linked to a different projA would lose the user's
+    # existing project association.
+    for rp in repo_paths:
+        _check_config_overwrite(rp, None, name, force)
+
     if cloud:
         try:
             view = create_project(name)

--- a/packages/nauro/src/nauro/mcp/server.py
+++ b/packages/nauro/src/nauro/mcp/server.py
@@ -27,17 +27,13 @@ from nauro.mcp.tools import (
     tool_propose_decision,
     tool_update_state,
 )
-from nauro.store.registry import (
-    find_projects_by_name_v2,
-    get_store_path,
-    get_store_path_v2,
-    resolve_project,
-    resolve_v2_from_path,
-)
-from nauro.store.repo_config import (
-    RepoConfigSchemaError,
-    find_repo_config,
-    load_repo_config,
+from nauro.store.resolution import (
+    MultipleProjectsError,
+    NoProjectError,
+    ProjectIdMismatchError,
+    ProjectNotFoundError,
+    StoreMissingError,
+    resolve_store,
 )
 
 logger = logging.getLogger("nauro.mcp")
@@ -110,86 +106,23 @@ class UpdateStateRequest(BaseModel):
 # --- Helpers ---
 
 
-def _resolve_via_repo_config(start: Path | None) -> tuple[str, Path] | None:
-    """Walk up from ``start`` (or cwd) looking for ``.nauro/config.json``."""
-    config_path = find_repo_config(start=start)
-    if config_path is None:
-        return None
-    repo_root = config_path.parent.parent
-    try:
-        cfg = load_repo_config(repo_root)
-    except RepoConfigSchemaError:
-        return None
-    return cfg["id"], get_store_path_v2(cfg["id"])
-
-
 def _resolve_store(project_id: str | None, cwd: str | None) -> Path:
-    """Resolve project id/name to a store path, raising 404 on failure.
+    """Resolve project id/name to a store path, raising HTTP errors on failure.
 
-    Same priority order as the stdio server's ``_resolve_store``: repo
-    config first, then explicit project handle (v2 → v1), then cwd-based
-    legacy fallback.
+    Delegates to :func:`nauro.store.resolution.resolve_store` and translates
+    each typed :class:`StoreResolutionError` subclass into an appropriate
+    HTTP status code so existing callers keep their 4xx contracts. Per
+    D136 the mapping is: ``NoProjectError`` / ``ProjectNotFoundError`` /
+    ``StoreMissingError`` → 404 (resource not present);
+    ``ProjectIdMismatchError`` / ``MultipleProjectsError`` → 400 (caller
+    supplied an ambiguous or contradictory handle).
     """
-    cwd_path = Path(cwd) if cwd else None
-    via_config = _resolve_via_repo_config(cwd_path)
-
-    if project_id and via_config is not None:
-        config_id, store_path = via_config
-        if project_id != config_id:
-            matches = find_projects_by_name_v2(project_id)
-            if not any(pid == config_id for pid, _ in matches):
-                raise HTTPException(
-                    status_code=400,
-                    detail=(
-                        f"Supplied project_id {project_id!r} does not match the "
-                        f"repo config id {config_id!r}."
-                    ),
-                )
-        if not store_path.exists():
-            raise HTTPException(status_code=404, detail=f"Project store not found: {config_id}")
-        return store_path
-
-    if via_config is not None:
-        _pid, store_path = via_config
-        if not store_path.exists():
-            raise HTTPException(status_code=404, detail=f"Project store not found at {store_path}")
-        return store_path
-
-    if project_id:
-        matches = find_projects_by_name_v2(project_id)
-        if len(matches) == 1:
-            pid, _entry = matches[0]
-            store_path = get_store_path_v2(pid)
-            if not store_path.exists():
-                raise HTTPException(
-                    status_code=404, detail=f"Project store not found: {project_id}"
-                )
-            return store_path
-        if len(matches) > 1:
-            raise HTTPException(
-                status_code=400,
-                detail=f"Multiple v2 projects named {project_id!r}; pass project_id instead.",
-            )
-        # v1 legacy
-        store_path = get_store_path(project_id)
-        if not store_path.exists():
-            raise HTTPException(status_code=404, detail=f"Project store not found: {project_id}")
-        return store_path
-
-    if cwd:
-        legacy_name = resolve_project(Path(cwd))
-        if legacy_name:
-            store_path = get_store_path(legacy_name)
-            if store_path.exists():
-                return store_path
-        v2_match = resolve_v2_from_path(Path(cwd))
-        if v2_match is not None:
-            pid, _entry = v2_match
-            store_path = get_store_path_v2(pid)
-            if store_path.exists():
-                return store_path
-
-    raise HTTPException(status_code=404, detail="Could not resolve project.")
+    try:
+        return resolve_store(project_id, cwd)
+    except (NoProjectError, ProjectNotFoundError, StoreMissingError) as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    except (ProjectIdMismatchError, MultipleProjectsError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
 
 
 # --- MCP tool endpoints ---

--- a/packages/nauro/src/nauro/mcp/stdio_server.py
+++ b/packages/nauro/src/nauro/mcp/stdio_server.py
@@ -45,16 +45,16 @@ from nauro.mcp.tools import (
 )
 from nauro.onboarding import WELCOME_NO_PROJECT
 from nauro.store.registry import (
-    find_projects_by_name_v2,
     get_store_path,
     get_store_path_v2,
     resolve_project,
     resolve_v2_from_path,
 )
-from nauro.store.repo_config import (
-    RepoConfigSchemaError,
-    find_repo_config,
-    load_repo_config,
+from nauro.store.resolution import (
+    NoProjectError,
+    StoreResolutionError,
+    resolve_store,
+    resolve_via_repo_config,
 )
 
 logger = logging.getLogger("nauro.stdio")
@@ -98,87 +98,10 @@ def _param_desc(tool_name: str, param: str) -> str:
     return props[param]["description"]
 
 
-def _resolve_via_repo_config(start: Path | None) -> tuple[str, Path] | None:
-    """Walk up from ``start`` (or cwd) looking for ``.nauro/config.json``.
-
-    Returns (project_id, store_path) or None when no repo config is found.
-    """
-    config_path = find_repo_config(start=start)
-    if config_path is None:
-        return None
-    repo_root = config_path.parent.parent
-    try:
-        cfg = load_repo_config(repo_root)
-    except RepoConfigSchemaError:
-        return None
-    return cfg["id"], get_store_path_v2(cfg["id"])
-
-
-def _resolve_store(project_id: str | None, cwd: str | None) -> Path:
-    """Resolve a project to a store path.
-
-    Resolution order matches the CLI:
-      1. cwd's ``.nauro/config.json`` walk-up (id-keyed v2 store).
-      2. ``project_id`` argument matched against v2 registry by name.
-      3. ``project_id`` argument matched against v1 registry by name (legacy).
-      4. ``cwd`` arg → v1 ``resolve_project`` (legacy).
-
-    When ``project_id`` is supplied AND the cwd resolves to a different id via
-    the repo config, the call fails with a mismatch error so tooling cannot
-    silently mask a misconfiguration.
-    """
-    cwd_path = Path(cwd) if cwd else Path.cwd()
-    via_config = _resolve_via_repo_config(cwd_path)
-
-    if project_id and via_config is not None:
-        config_id, store_path = via_config
-        if project_id != config_id:
-            matches = find_projects_by_name_v2(project_id)
-            if not any(pid == config_id for pid, _ in matches):
-                raise ValueError(
-                    f"Supplied project_id {project_id!r} does not match the repo "
-                    f"config id {config_id!r} in {cwd_path}."
-                )
-        if not store_path.exists():
-            raise ValueError(f"Project store not found: {config_id}")
-        return store_path
-
-    if via_config is not None:
-        _pid, store_path = via_config
-        if not store_path.exists():
-            raise ValueError(f"Project store not found at {store_path}")
-        return store_path
-
-    if project_id:
-        matches = find_projects_by_name_v2(project_id)
-        if len(matches) == 1:
-            pid, _entry = matches[0]
-            store_path = get_store_path_v2(pid)
-            if not store_path.exists():
-                raise ValueError(f"Project store not found: {project_id}")
-            return store_path
-        if len(matches) > 1:
-            raise ValueError(f"Multiple v2 projects named {project_id!r}; pass project_id instead.")
-        # v1 legacy fallback
-        store_path = get_store_path(project_id)
-        if not store_path.exists():
-            raise ValueError(f"Project store not found: {project_id}")
-        return store_path
-
-    if cwd:
-        name = resolve_project(Path(cwd))
-        if name:
-            store_path = get_store_path(name)
-            if store_path.exists():
-                return store_path
-        v2_match = resolve_v2_from_path(Path(cwd))
-        if v2_match is not None:
-            pid, _entry = v2_match
-            store_path = get_store_path_v2(pid)
-            if store_path.exists():
-                return store_path
-
-    raise ValueError("Could not resolve project. Pass 'project_id' or 'cwd'.")
+# Back-compat re-exports — tests import these symbols from this module.
+# The resolution logic itself lives in nauro.store.resolution.
+_resolve_store = resolve_store
+_resolve_via_repo_config = resolve_via_repo_config
 
 
 @mcp.tool(**_spec_kwargs("get_context"))
@@ -194,8 +117,10 @@ def get_context(
 ) -> str:
     try:
         store_path = _resolve_store(project_id, cwd)
-    except ValueError:
+    except NoProjectError:
         return WELCOME_NO_PROJECT
+    except StoreResolutionError as exc:
+        return str(exc)
     # tool_get_context accepts both int and string levels.
     return tool_get_context(store_path, level)
 
@@ -210,8 +135,10 @@ def get_raw_file(
 ) -> dict:
     try:
         store_path = _resolve_store(project_id, cwd)
-    except ValueError:
+    except NoProjectError:
         return {"store": "local", "status": "error", "guidance": WELCOME_NO_PROJECT}
+    except StoreResolutionError as exc:
+        return {"store": "local", "status": "error", "guidance": str(exc)}
     return tool_get_raw_file(store_path, path)
 
 
@@ -228,8 +155,10 @@ def list_decisions(
 ) -> dict:
     try:
         store_path = _resolve_store(project_id, cwd)
-    except ValueError:
+    except NoProjectError:
         return {"store": "local", "status": "error", "guidance": WELCOME_NO_PROJECT}
+    except StoreResolutionError as exc:
+        return {"store": "local", "status": "error", "guidance": str(exc)}
     return tool_list_decisions(store_path, limit, include_superseded)
 
 
@@ -243,8 +172,10 @@ def get_decision(
 ) -> dict:
     try:
         store_path = _resolve_store(project_id, cwd)
-    except ValueError:
+    except NoProjectError:
         return {"store": "local", "status": "error", "guidance": WELCOME_NO_PROJECT}
+    except StoreResolutionError as exc:
+        return {"store": "local", "status": "error", "guidance": str(exc)}
     return tool_get_decision(store_path, number)
 
 
@@ -261,8 +192,10 @@ def diff_since_last_session(
 ) -> dict:
     try:
         store_path = _resolve_store(project_id, cwd)
-    except ValueError:
+    except NoProjectError:
         return {"store": "local", "status": "error", "guidance": WELCOME_NO_PROJECT}
+    except StoreResolutionError as exc:
+        return {"store": "local", "status": "error", "guidance": str(exc)}
     return tool_diff_since_last_session(store_path, days)
 
 
@@ -277,8 +210,10 @@ def search_decisions(
 ) -> dict:
     try:
         store_path = _resolve_store(project_id, cwd)
-    except ValueError:
+    except NoProjectError:
         return {"store": "local", "status": "error", "guidance": WELCOME_NO_PROJECT}
+    except StoreResolutionError as exc:
+        return {"store": "local", "status": "error", "guidance": str(exc)}
     return tool_search_decisions(store_path, query, limit)
 
 
@@ -297,8 +232,10 @@ def check_decision(
 ) -> dict:
     try:
         store_path = _resolve_store(project_id, cwd)
-    except ValueError:
+    except NoProjectError:
         return {"store": "local", "status": "error", "guidance": WELCOME_NO_PROJECT}
+    except StoreResolutionError as exc:
+        return {"store": "local", "status": "error", "guidance": str(exc)}
     return tool_check_decision(store_path, proposed_approach, context)
 
 
@@ -355,8 +292,10 @@ def propose_decision(
 ) -> dict:
     try:
         store_path = _resolve_store(project_id, cwd)
-    except ValueError:
+    except NoProjectError:
         return {"store": "local", "status": "error", "guidance": WELCOME_NO_PROJECT}
+    except StoreResolutionError as exc:
+        return {"store": "local", "status": "error", "guidance": str(exc)}
     return tool_propose_decision(
         store_path,
         title=title,
@@ -382,8 +321,10 @@ def confirm_decision(
 ) -> dict:
     try:
         store_path = _resolve_store(project_id, cwd)
-    except ValueError:
+    except NoProjectError:
         return {"store": "local", "status": "error", "guidance": WELCOME_NO_PROJECT}
+    except StoreResolutionError as exc:
+        return {"store": "local", "status": "error", "guidance": str(exc)}
     return tool_confirm_decision(store_path, confirm_id)
 
 
@@ -400,8 +341,10 @@ def flag_question(
 ) -> str:
     try:
         store_path = _resolve_store(project_id, cwd)
-    except ValueError:
+    except NoProjectError:
         return WELCOME_NO_PROJECT
+    except StoreResolutionError as exc:
+        return str(exc)
     result = tool_flag_question(store_path, question, context)
     if result.get("hint"):
         return f"{result['hint']} The question has still been logged."
@@ -418,8 +361,10 @@ def update_state(
 ) -> str:
     try:
         store_path = _resolve_store(project_id, cwd)
-    except ValueError:
+    except NoProjectError:
         return WELCOME_NO_PROJECT
+    except StoreResolutionError as exc:
+        return str(exc)
     result = tool_update_state(store_path, delta)
     if result.get("warning"):
         return f"State updated. {result['warning']}"

--- a/packages/nauro/src/nauro/store/resolution.py
+++ b/packages/nauro/src/nauro/store/resolution.py
@@ -1,0 +1,196 @@
+"""Store-resolution helper + typed exceptions.
+
+Both MCP transports (local stdio FastMCP and local HTTP FastAPI) translate a
+``(project_id, cwd)`` pair into a path under the active ``NAURO_HOME``. The
+resolution rules are shared; the failure-mapping is transport-specific. This
+module owns the rules and surfaces every failure as a typed exception so
+each transport can decide whether to show the welcome screen, return a
+specific error message, or translate to an HTTP status code.
+
+Per D101 + D111 + D136, the resolution order is:
+
+  1. cwd's ``.nauro/config.json`` walk-up (id-keyed v2 store).
+  2. ``project_id`` argument matched against v2 registry by name.
+  3. ``project_id`` argument matched against v1 registry by name (legacy).
+  4. ``cwd`` argument → v1 ``resolve_project`` (legacy).
+
+Before D136 both transports raised a bare ``ValueError`` and the wrappers
+swallowed every failure into the same ``WELCOME_NO_PROJECT`` onboarding
+screen. The typed subclasses below let the wrappers reserve the welcome
+screen for the genuinely-no-project case and surface specific diagnostics
+for the other failure modes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from nauro.store.registry import (
+    find_projects_by_name_v2,
+    get_store_path,
+    get_store_path_v2,
+    resolve_project,
+    resolve_v2_from_path,
+)
+from nauro.store.repo_config import (
+    RepoConfigSchemaError,
+    find_repo_config,
+    load_repo_config,
+)
+
+
+class StoreResolutionError(ValueError):
+    """Base class for store-resolution failures.
+
+    Subclasses each name a failure category so callers can map them to the
+    transport-appropriate output. Inherits ``ValueError`` so callers that
+    catch ``ValueError`` from the pre-D136 surface keep working.
+    """
+
+
+class NoProjectError(StoreResolutionError):
+    """No project resolvable at all — no ``project_id``, no cwd config, no
+    legacy resolution path matched. This is the genuine onboarding case;
+    transports should surface the welcome screen pointing the user at
+    ``nauro init``.
+    """
+
+
+class ProjectNotFoundError(StoreResolutionError):
+    """Caller named a project (by id or name) but no match exists in the
+    registry. Distinguished from :class:`NoProjectError` because the
+    caller supplied a handle — they have the wrong one, not no handle.
+    """
+
+
+class StoreMissingError(StoreResolutionError):
+    """Resolved a ``project_id`` (via cwd config or registry) but its
+    store directory does not exist on disk. Usually means ``NAURO_HOME``
+    was changed between ``nauro init`` and this call.
+    """
+
+
+class ProjectIdMismatchError(StoreResolutionError):
+    """Caller's ``project_id`` does not match the cwd config id. Surface
+    the mismatch so the caller can decide whether the cwd or the handle
+    is stale.
+    """
+
+
+class MultipleProjectsError(StoreResolutionError):
+    """Caller's project name resolves to multiple registry entries. The
+    caller must pass an unambiguous ``project_id`` instead.
+    """
+
+
+def resolve_via_repo_config(start: Path | None) -> tuple[str, Path] | None:
+    """Walk up from ``start`` looking for ``.nauro/config.json``.
+
+    Returns ``(project_id, store_path)`` or ``None`` when no config is found.
+    Mirrors how git locates ``.git`` from anywhere inside a working tree.
+    """
+    config_path = find_repo_config(start=start)
+    if config_path is None:
+        return None
+    repo_root = config_path.parent.parent
+    try:
+        cfg = load_repo_config(repo_root)
+    except RepoConfigSchemaError:
+        return None
+    return cfg["id"], get_store_path_v2(cfg["id"])
+
+
+def resolve_store(project_id: str | None, cwd: str | Path | None) -> Path:
+    """Resolve a ``(project_id, cwd)`` pair to a store path.
+
+    Raises a specific :class:`StoreResolutionError` subclass on every
+    failure mode so callers can map each one to the appropriate response.
+    Callers that just want the welcome screen on any failure can still
+    catch the base class (or :class:`ValueError`) and ignore the subtype.
+    """
+    cwd_path = Path(cwd) if cwd else Path.cwd()
+    via_config = resolve_via_repo_config(cwd_path)
+
+    if project_id and via_config is not None:
+        config_id, store_path = via_config
+        if project_id != config_id:
+            matches = find_projects_by_name_v2(project_id)
+            if not any(pid == config_id for pid, _ in matches):
+                raise ProjectIdMismatchError(
+                    f"Supplied project_id {project_id!r} does not match the "
+                    f"repo config id {config_id!r} in {cwd_path}."
+                )
+        if not store_path.exists():
+            raise StoreMissingError(
+                f"Project store not found for id {config_id!r}. "
+                "The cwd .nauro/config.json resolves but the store is "
+                "missing from NAURO_HOME — was the home changed since init?"
+            )
+        return store_path
+
+    if via_config is not None:
+        _pid, store_path = via_config
+        if not store_path.exists():
+            raise StoreMissingError(
+                f"Project store not found at {store_path}. The cwd "
+                ".nauro/config.json resolves but the store is missing "
+                "from NAURO_HOME — was the home changed since init?"
+            )
+        return store_path
+
+    if project_id:
+        matches = find_projects_by_name_v2(project_id)
+        if len(matches) == 1:
+            pid, _entry = matches[0]
+            store_path = get_store_path_v2(pid)
+            if not store_path.exists():
+                raise StoreMissingError(
+                    f"Project store not found for {project_id!r} (id {pid!r}). "
+                    "The registry resolves but the store is missing from NAURO_HOME."
+                )
+            return store_path
+        if len(matches) > 1:
+            raise MultipleProjectsError(
+                f"Multiple v2 projects named {project_id!r}; pass an "
+                "unambiguous project_id (ULID) instead of the name."
+            )
+        # v1 legacy fallback.
+        store_path = get_store_path(project_id)
+        if not store_path.exists():
+            raise ProjectNotFoundError(
+                f"No project named or keyed {project_id!r} found in the "
+                "registry. Run 'nauro init <name>' to create it, or check "
+                "NAURO_HOME if you expected an existing project."
+            )
+        return store_path
+
+    if cwd:
+        name = resolve_project(cwd_path)
+        if name:
+            store_path = get_store_path(name)
+            if store_path.exists():
+                return store_path
+        v2_match = resolve_v2_from_path(cwd_path)
+        if v2_match is not None:
+            pid, _entry = v2_match
+            store_path = get_store_path_v2(pid)
+            if store_path.exists():
+                return store_path
+
+    raise NoProjectError(
+        "No Nauro project found. Run 'nauro init <name>' in the current "
+        "directory to create one, or pass 'project_id' / 'cwd' to point at "
+        "an existing project."
+    )
+
+
+__all__ = [
+    "MultipleProjectsError",
+    "NoProjectError",
+    "ProjectIdMismatchError",
+    "ProjectNotFoundError",
+    "StoreMissingError",
+    "StoreResolutionError",
+    "resolve_store",
+    "resolve_via_repo_config",
+]

--- a/packages/nauro/tests/test_registry.py
+++ b/packages/nauro/tests/test_registry.py
@@ -234,20 +234,89 @@ def test_init_cli_with_add_repo(tmp_path, monkeypatch):
 
 
 def test_init_cli_duplicate(tmp_path, monkeypatch):
-    """A second `nauro init <same-name>` (no --add-repo) creates a SECOND project.
-
-    v2 allows duplicate names — id is unique. To extend an existing project,
-    callers must pass --add-repo, which is the explicit signal.
+    """v2 allows duplicate names — id is unique. Two `nauro init dup`
+    invocations from separate cwds both succeed and create distinct
+    entries. From the SAME cwd, D136's overwrite guard refuses without
+    --force; the registry-allows-dups invariant is verified by exercising
+    each init from its own directory.
     """
     _patch_home(monkeypatch, tmp_path)
-    monkeypatch.chdir(tmp_path)
+    cwd1 = tmp_path / "cwd1"
+    cwd2 = tmp_path / "cwd2"
+    cwd1.mkdir()
+    cwd2.mkdir()
+    monkeypatch.chdir(cwd1)
     runner.invoke(app, ["init", "dup"])
+    monkeypatch.chdir(cwd2)
     result = runner.invoke(app, ["init", "dup"])
-    # Either succeeds (creates a second, distinct id-keyed entry) or fails with
-    # the clear duplicate-id message; both are acceptable, but the registry
-    # ends up with two entries named 'dup' in the success case.
     assert result.exit_code == 0
     assert len(registry.find_projects_by_name_v2("dup")) == 2
+
+
+def test_init_cli_refuses_overwrite_without_force(tmp_path, monkeypatch):
+    """D136: a second `nauro init <other-name>` from the same cwd refuses
+    to overwrite the existing .nauro/config.json without --force, naming
+    the existing project so the caller can decide what to do."""
+    _patch_home(monkeypatch, tmp_path)
+    monkeypatch.chdir(tmp_path)
+    first = runner.invoke(app, ["init", "first"])
+    assert first.exit_code == 0
+    result = runner.invoke(app, ["init", "second"])
+    assert result.exit_code == 1
+    assert "Refusing to overwrite" in result.output
+    assert "'first'" in result.output
+    assert "'second'" in result.output
+    assert "--force" in result.output
+    # Existing config must be untouched.
+    cfg = load_repo_config(tmp_path)
+    assert cfg["name"] == "first"
+
+
+def test_init_cli_force_overwrites(tmp_path, monkeypatch):
+    """D136: --force replaces an existing .nauro/config.json with the new
+    project's handle; the registry shows both."""
+    _patch_home(monkeypatch, tmp_path)
+    monkeypatch.chdir(tmp_path)
+    runner.invoke(app, ["init", "first"])
+    result = runner.invoke(app, ["init", "second", "--force"])
+    assert result.exit_code == 0
+    cfg = load_repo_config(tmp_path)
+    assert cfg["name"] == "second"
+    assert len(registry.find_projects_by_name_v2("first")) == 1
+    assert len(registry.find_projects_by_name_v2("second")) == 1
+
+
+def test_init_cli_add_repo_idempotent_on_same_id(tmp_path, monkeypatch):
+    """D136: re-running `nauro init <existing-name> --add-repo <repo>`
+    against a repo already pointing at that project succeeds (idempotent),
+    because the existing config id matches the project's id."""
+    _patch_home(monkeypatch, tmp_path)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    first = runner.invoke(app, ["init", "proj", "--add-repo", str(repo)])
+    assert first.exit_code == 0
+    again = runner.invoke(app, ["init", "proj", "--add-repo", str(repo)])
+    assert again.exit_code == 0, again.output
+
+
+def test_init_cli_add_repo_refuses_overwrite_on_different_id(tmp_path, monkeypatch):
+    """D136: --add-repo against a repo already linked to a *different*
+    project refuses without --force, naming both projects."""
+    _patch_home(monkeypatch, tmp_path)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    # Repo already linked to 'alpha'.
+    first = runner.invoke(app, ["init", "alpha", "--add-repo", str(repo)])
+    assert first.exit_code == 0
+    # Attempt to link the same repo to a fresh 'beta' project.
+    runner.invoke(app, ["init", "beta"], catch_exceptions=False)  # creates beta entry
+    again = runner.invoke(app, ["init", "beta", "--add-repo", str(repo)], catch_exceptions=False)
+    assert again.exit_code == 1
+    assert "Refusing to overwrite" in again.output
+    assert "'alpha'" in again.output
+    # Existing config untouched.
+    cfg = load_repo_config(repo)
+    assert cfg["name"] == "alpha"
 
 
 def test_init_cli_add_repo_to_existing(tmp_path, monkeypatch):

--- a/packages/nauro/tests/test_resolution_v2.py
+++ b/packages/nauro/tests/test_resolution_v2.py
@@ -131,7 +131,10 @@ def test_stdio_resolve_no_repo_no_project_errors(tmp_path, monkeypatch):
     isolated = tmp_path / "isolated"
     isolated.mkdir()
     monkeypatch.chdir(isolated)
-    with pytest.raises(ValueError, match="Could not resolve project"):
+    # D136: typed NoProjectError carries the new welcome anchor.
+    from nauro.store.resolution import NoProjectError
+
+    with pytest.raises(NoProjectError, match="No Nauro project found"):
         _resolve_store(None, None)
 
 

--- a/packages/nauro/tests/test_stdio_server.py
+++ b/packages/nauro/tests/test_stdio_server.py
@@ -12,6 +12,7 @@ from nauro.mcp.stdio_server import (
     confirm_decision,
     flag_question,
     get_context,
+    get_raw_file,
     mcp,
     propose_decision,
     update_state,
@@ -57,11 +58,19 @@ class TestResolveStore:
         assert result == store
 
     def test_raises_on_unknown_project(self, store: Path):
-        with pytest.raises(ValueError, match="Project store not found"):
+        # D136: unknown name in v2 falls through to v1 legacy; if also
+        # missing there, ProjectNotFoundError carries the "registry" anchor.
+        from nauro.store.resolution import ProjectNotFoundError
+
+        with pytest.raises(ProjectNotFoundError, match="registry"):
             _resolve_store("nonexistent", None)
 
     def test_raises_on_no_project_or_cwd(self, store: Path):
-        with pytest.raises(ValueError, match="Could not resolve project"):
+        # D136: NoProjectError reserved for the genuinely-no-project case.
+        # Wrapper code maps only this subclass to WELCOME_NO_PROJECT.
+        from nauro.store.resolution import NoProjectError
+
+        with pytest.raises(NoProjectError, match="No Nauro project found"):
             _resolve_store(None, None)
 
 
@@ -157,6 +166,42 @@ class TestProposeDecision:
         )
         # Default behavior — should go through full pipeline
         assert result["status"] in ("confirmed", "pending_confirmation")
+
+
+class TestWelcomeDisambiguation:
+    """D136: WELCOME_NO_PROJECT is reserved for the genuinely-no-project
+    case. Specific failures (bogus project_id, missing store on disk,
+    mismatched cwd config) must surface their own diagnostic instead of
+    the onboarding screen suggesting `nauro init`, which is the wrong
+    remedy when the caller already has a (mis-)configured project."""
+
+    def test_unknown_project_id_surfaces_specific_error(self, store: Path):
+        """Bogus project_id keyword on a dict-returning tool → guidance
+        names the registry, not the welcome screen."""
+        result = get_raw_file(path="project.md", project_id="does-not-exist")
+        assert result["status"] == "error"
+        assert "Welcome to Nauro" not in result["guidance"]
+        # ProjectNotFoundError surfaces the registry-lookup framing.
+        assert "registry" in result["guidance"].lower() or "not found" in result["guidance"].lower()
+
+    def test_unknown_project_id_string_tool_surfaces_specific_error(self, store: Path):
+        """Same disambiguation on a string-returning tool: a non-welcome
+        message is returned for known-bogus handles."""
+        result = update_state(delta="anything", project_id="does-not-exist")
+        assert "Welcome to Nauro" not in result
+        assert "registry" in result.lower() or "not found" in result.lower()
+
+    def test_no_project_resolvable_still_returns_welcome(self, store: Path):
+        """The genuine onboarding case — no project_id, no cwd config —
+        keeps the welcome screen. D136 narrows what counts as the
+        onboarding case; this asserts the narrowing didn't lose it."""
+        # Drop the registry so no project can resolve from cwd or by name.
+        from nauro.store.registry import _registry_file
+
+        _registry_file().write_text('{"projects": {}, "schema_version": 2}\n')
+        result = get_raw_file(path="project.md")
+        assert result["status"] == "error"
+        assert "Welcome to Nauro" in result["guidance"]
 
 
 class TestConfirmDecision:


### PR DESCRIPTION
## Why

Two failure modes from PR #44/#45 product validation share a root: the store-resolution boundary returns generic outputs that hide what actually went wrong.

**Init overwrite footgun.** `nauro init <name>` and `nauro init --demo` call `save_repo_config(rp, ...)` unconditionally for every target repo path. If a repo already has `<repo>/.nauro/config.json` pointing at a different project (id A), running init for project B silently replaces it with B's id. The original association breaks immediately — D111 makes cwd-walk-up the canonical resolution method for local stdio MCP, CLI, and HTTP server, so an overwritten config breaks every subsequent tool call from that repo without any signal. Reproduced during PR #45 validation: a `.nauro/config.json` from an earlier `nauro init demoapp` got replaced by `nauro init --demo` writing the demo-project's id; subsequent stdio MCP calls fell through to `WELCOME_NO_PROJECT` because the demo-project lived in a different `NAURO_HOME` than the active one.

**WELCOME ambiguity.** `_resolve_store` in both `stdio_server.py` and `server.py` raises `ValueError` for at least five distinct failure modes — no project resolvable at all, explicit `project_id` not found in registry, cwd config id resolves but store doesn't exist on disk, supplied `project_id` mismatches cwd config id, multiple projects of the same name — and the wrappers catch the bare `ValueError` and return `WELCOME_NO_PROJECT` for all of them. An agent passing a bogus `project_id` and an agent running in a directory with stale config get identical onboarding screens telling them to "Run: nauro init <project-name>" — the wrong remedy in both cases. The diagnostic context exists in the ValueError's message but never reaches the agent.

## Approach

The two fixes ship together because they touch the same boundary from opposite ends: the resolution path tells the agent what went wrong on read; the init path stops the cwd config from going wrong on write.

**Init overwrite guard.** `nauro init` refuses to replace an existing `.nauro/config.json` without `--force` whenever the new project's id differs from the existing one. The only idempotent path is `--add-repo` against a repo already linked to that exact pid — re-stating the same association is safe. Fresh init has no pid to compare against, so any existing config differs by definition and triggers the refusal regardless of name; this is deliberate, because v2 allows duplicate names with distinct ids, and silently coalescing `nauro init projA` from a cwd already linked to a different `projA` would lose the existing association. The refusal diagnostic names the existing project's name + id and lists three remedies: `--force`, chdir, or `nauro init <existing> --add-repo`. Pre-checks fire before `register_project_v2` so a refusal doesn't leave a dangling registry entry.

**Resolution disambiguation.** A new `nauro.store.resolution` module owns the shared `(project_id, cwd) → Path` logic that both transports duplicated. Five typed exception subclasses (`NoProjectError`, `ProjectNotFoundError`, `StoreMissingError`, `ProjectIdMismatchError`, `MultipleProjectsError`) inherit `StoreResolutionError(ValueError)` so each failure mode is named and addressable. Both transports' `_resolve_store` collapse into thin wrappers: stdio_server maps `NoProjectError` → `WELCOME_NO_PROJECT` and surfaces every other `StoreResolutionError` as `str(exc)` in the guidance/error field; server.py maps `NoProjectError` / `ProjectNotFoundError` / `StoreMissingError` → 404 and `ProjectIdMismatchError` / `MultipleProjectsError` → 400, preserving the existing HTTP contract while sharpening detail strings. The base class inherits `ValueError`, so any caller doing `except ValueError` keeps working.

Rejected: a name-match idempotency short-circuit in the init pre-check (rejected because v2 allows duplicate names with distinct ids; silently coalescing same-name reinit would lose project associations); a flag-less default that always overwrites the cwd config (rejected — that's the footgun being fixed); a single generic exception with discriminating message text (rejected — typed subclasses let each transport map by category cleanly, and existing tests already pattern-matched against error message text which is brittle).

## What changed

- **`packages/nauro/src/nauro/cli/commands/init.py`** — new `--force` flag; new `_check_config_overwrite` helper; pre-check fires before `register_project_v2` in all three write paths.
- **`packages/nauro/src/nauro/store/resolution.py`** (new file) — shared `resolve_store(project_id, cwd) → Path` + 5 typed `StoreResolutionError` subclasses + `resolve_via_repo_config` helper. ~165 lines.
- **`packages/nauro/src/nauro/mcp/stdio_server.py`** — removed duplicated `_resolve_store` + `_resolve_via_repo_config`; aliased the new shared functions as `_resolve_store` / `_resolve_via_repo_config` for back-compat with tests. All 11 wrappers' try/except blocks split `NoProjectError` (→ welcome) from `StoreResolutionError` (→ specific message).
- **`packages/nauro/src/nauro/mcp/server.py`** — removed duplicated `_resolve_store` + `_resolve_via_repo_config`; new thin wrapper translates `StoreResolutionError` subclasses to 4xx HTTPExceptions.

## What to review

- The idempotency rule in `_check_config_overwrite`: short-circuits only on id match (when `expected_id is not None`). Fresh init has `expected_id=None`, so any existing config triggers refusal. The comment above the call site (init.py around line 167 post-edit) explains the v2-allows-dup-names reasoning.
- `nauro.store.resolution` module: the exception hierarchy is the API contract — five named subclasses + base `StoreResolutionError(ValueError)`. Callers can catch the base for the pre-D136 "any failure → welcome" behavior, or branch on subclasses for transport-specific mapping.
- Back-compat aliases in `stdio_server.py` (`_resolve_store = resolve_store`, `_resolve_via_repo_config = resolve_via_repo_config`): kept so external tests + `_pull_on_startup` keep working without import changes. Both modules' duplicated implementations are gone.
- The HTTPException mapping in `server.py:_resolve_store`: NoProject / ProjectNotFound / StoreMissing → 404 (resource not present); ProjectIdMismatch / MultipleProjects → 400 (caller-side ambiguity). Test `test_mcp.py::test_context_missing_project` continues to assert 404 on the "Could not resolve project" case; the assertion still holds because `NoProjectError` maps to 404 and the detail text now reads "No Nauro project found...".

## What's deferred

- nauro.dev landing page audit (separate repo).
- D1 "Initial project setup" pseudo-decision suppression (cosmetic; fresh stores show D1 in `list_decisions` immediately after init).
- HTTP transport rename to `--force` semantics: the HTTP server's request models don't expose an overwrite flag yet because no HTTP caller currently invokes init. If/when added, the same `_check_config_overwrite` helper can be reused from a thin endpoint.

## Test plan

- `uv run ruff format --check packages/` and `uv run ruff check packages/`: clean across all 145 files (new `resolution.py` formatted).
- `uv run pytest packages/ -q -m "not integration"`: **1157 passed** (1150 → 1157, +7 net).
- 4 new init cases in `test_registry.py`: refuses-without-force, force-overwrites, duplicate-name-across-cwds, add-repo-idempotent-on-same-id, add-repo-refuses-on-different-id.
- 3 new disambiguation cases in `test_stdio_server.py::TestWelcomeDisambiguation`: bogus `project_id` on dict-returning tool surfaces specific mismatch detail; same on string-returning tool; genuine no-project still returns the welcome screen.
- 3 existing tests updated for the new typed exceptions + clearer message anchors (`test_stdio_server.py::TestResolveStore`, `test_resolution_v2.py::test_stdio_resolve_no_repo_no_project_errors`).
- Live CLI probe over a throwaway `NAURO_HOME`: `nauro init projB` after `nauro init projA` in the same cwd refuses with the diagnostic naming projA + 3 actionable options; `--force` cleanly overwrites; the cwd `.nauro/config.json` correctly switches to projB's id.
- Live MCP probe over stdio: bogus `project_id` keyword on `check_decision` returns `"Supplied project_id 'bogus-project' does not match the repo config id 'XXX' in /path"` in the guidance, not the welcome screen; genuine no-project case still returns the welcome screen.

Resolves D136.