### PR TITLE
feat(mcp): add resolves_questions to propose_decision; move closed questions under ## Resolved (D139)

### DIFF
--- a/.agents/skills/nauro/SKILL.md
+++ b/.agents/skills/nauro/SKILL.md
@@ -17,6 +17,8 @@ When the user proposes — or the agent considers proposing — an architectural
 
 This includes "should we…", "what if we…", "can we…", and "check if…" framings, and applies even when the agent intends to push back or refuse. First-principles reasoning is not a substitute for project history.
 
+When a proposal closes one of `get_context`'s open questions, include the question's `[YYYY-MM-DD HH:MM UTC]` timestamp in `resolves_questions`. The named entries move under `## Resolved` with a back-reference to the new decision on confirm; unknown ids reject at the boundary.
+
 ## After meaningful progress — call update_state
 
 After completing a unit of work (a feature, a refactor, a bug fix that took more than a few changes) the agent calls `update_state(delta)` with a short paragraph describing what was completed. This replaces the project's current state, archiving the prior content to history. The next session's `get_context` call surfaces this update so context flows forward.

--- a/.claude/skills/nauro/SKILL.md
+++ b/.claude/skills/nauro/SKILL.md
@@ -17,6 +17,8 @@ When the user proposes — or the agent considers proposing — an architectural
 
 This includes "should we…", "what if we…", "can we…", and "check if…" framings, and applies even when the agent intends to push back or refuse. First-principles reasoning is not a substitute for project history.
 
+When a proposal closes one of `get_context`'s open questions, include the question's `[YYYY-MM-DD HH:MM UTC]` timestamp in `resolves_questions`. The named entries move under `## Resolved` with a back-reference to the new decision on confirm; unknown ids reject at the boundary.
+
 ## After meaningful progress — call update_state
 
 After completing a unit of work (a feature, a refactor, a bug fix that took more than a few changes) the agent calls `update_state(delta)` with a short paragraph describing what was completed. This replaces the project's current state, archiving the prior content to history. The next session's `get_context` call surfaces this update so context flows forward.

--- a/.cursor/rules/nauro.mdc
+++ b/.cursor/rules/nauro.mdc
@@ -17,6 +17,8 @@ When the user proposes — or the agent considers proposing — an architectural
 
 This includes "should we…", "what if we…", "can we…", and "check if…" framings, and applies even when the agent intends to push back or refuse. First-principles reasoning is not a substitute for project history.
 
+When a proposal closes one of `get_context`'s open questions, include the question's `[YYYY-MM-DD HH:MM UTC]` timestamp in `resolves_questions`. The named entries move under `## Resolved` with a back-reference to the new decision on confirm; unknown ids reject at the boundary.
+
 ## After meaningful progress — call update_state
 
 After completing a unit of work (a feature, a refactor, a bug fix that took more than a few changes) the agent calls `update_state(delta)` with a short paragraph describing what was completed. This replaces the project's current state, archiving the prior content to history. The next session's `get_context` call surfaces this update so context flows forward.

--- a/packages/nauro-core/src/nauro_core/__init__.py
+++ b/packages/nauro-core/src/nauro_core/__init__.py
@@ -191,6 +191,18 @@ from nauro_core.protocol import (
 from nauro_core.protocol import (
     substitute_protocol_fragments as substitute_protocol_fragments,
 )
+from nauro_core.questions import (
+    OpenQuestionsFile as OpenQuestionsFile,
+)
+from nauro_core.questions import (
+    QuestionEntry as QuestionEntry,
+)
+from nauro_core.questions import (
+    ResolvedRef as ResolvedRef,
+)
+from nauro_core.questions import (
+    ResolveResult as ResolveResult,
+)
 from nauro_core.search import (
     bm25_retrieve as bm25_retrieve,
 )

--- a/packages/nauro-core/src/nauro_core/__init__.py
+++ b/packages/nauro-core/src/nauro_core/__init__.py
@@ -183,6 +183,9 @@ from nauro_core.protocol import (
     PROPOSE_DECISION_OPERATIONS as PROPOSE_DECISION_OPERATIONS,
 )
 from nauro_core.protocol import (
+    RESOLVES_OPEN_QUESTIONS as RESOLVES_OPEN_QUESTIONS,
+)
+from nauro_core.protocol import (
     UPDATE_SUPERSEDE_CARE as UPDATE_SUPERSEDE_CARE,
 )
 from nauro_core.protocol import (

--- a/packages/nauro-core/src/nauro_core/constants.py
+++ b/packages/nauro-core/src/nauro_core/constants.py
@@ -10,6 +10,7 @@ from nauro_core.protocol import (
     GET_DECISION_BEFORE_PROPOSING,
     NO_INVENT_RATIONALE,
     PROPOSE_DECISION_OPERATIONS,
+    RESOLVES_OPEN_QUESTIONS,
     UPDATE_SUPERSEDE_CARE,
 )
 
@@ -105,6 +106,8 @@ MCP_INSTRUCTIONS_STATIC = (
     "\n"
     f"{NO_INVENT_RATIONALE} Do NOT propose decisions for obvious bug fixes, "
     "adding tests for existing behavior, or renaming variables.\n"
+    "\n"
+    f"{RESOLVES_OPEN_QUESTIONS}\n"
     "\n"
     "## When to get context\n"
     "\n"

--- a/packages/nauro-core/src/nauro_core/mcp_tools.py
+++ b/packages/nauro-core/src/nauro_core/mcp_tools.py
@@ -396,6 +396,21 @@ PROPOSE_DECISION: ToolSpec = {
                     "for future reviewers."
                 ),
             },
+            "resolves_questions": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Optional list of open-question timestamp ids (the "
+                    "'YYYY-MM-DD HH:MM UTC' inside each question's "
+                    "'- [timestamp]' prefix in open-questions.md) that this "
+                    "decision resolves. On confirm, the named questions are "
+                    "moved under a '## Resolved' subsection with a back-ref "
+                    "to this decision. Unknown ids are rejected at the "
+                    "boundary; ids already under '## Resolved' are a no-op. "
+                    "Call get_context (L0 surfaces the open questions) to "
+                    "discover the ids."
+                ),
+            },
             "skip_validation": {
                 "type": "boolean",
                 "default": False,

--- a/packages/nauro-core/src/nauro_core/protocol.py
+++ b/packages/nauro-core/src/nauro_core/protocol.py
@@ -56,12 +56,21 @@ NO_INVENT_RATIONALE = (
     "reasoning that supports it."
 )
 
+RESOLVES_OPEN_QUESTIONS = (
+    "When a proposal closes one of `get_context`'s open questions, include "
+    "the question's `[YYYY-MM-DD HH:MM UTC]` timestamp in "
+    "`resolves_questions`. The named entries move under `## Resolved` with a "
+    "back-reference to the new decision on confirm; unknown ids reject at "
+    "the boundary."
+)
+
 CANONICAL_FRAGMENTS: dict[str, str] = {
     "CHECK_DECISION_RETURNS": CHECK_DECISION_RETURNS,
     "GET_DECISION_BEFORE_PROPOSING": GET_DECISION_BEFORE_PROPOSING,
     "PROPOSE_DECISION_OPERATIONS": PROPOSE_DECISION_OPERATIONS,
     "UPDATE_SUPERSEDE_CARE": UPDATE_SUPERSEDE_CARE,
     "NO_INVENT_RATIONALE": NO_INVENT_RATIONALE,
+    "RESOLVES_OPEN_QUESTIONS": RESOLVES_OPEN_QUESTIONS,
 }
 
 _TOKEN_PREFIX = "<!-- protocol:"
@@ -127,6 +136,7 @@ __all__ = [
     "GET_DECISION_BEFORE_PROPOSING",
     "NO_INVENT_RATIONALE",
     "PROPOSE_DECISION_OPERATIONS",
+    "RESOLVES_OPEN_QUESTIONS",
     "UPDATE_SUPERSEDE_CARE",
     "protocol_tokens_in",
     "substitute_protocol_fragments",

--- a/packages/nauro-core/src/nauro_core/questions.py
+++ b/packages/nauro-core/src/nauro_core/questions.py
@@ -1,0 +1,292 @@
+"""Pydantic model for open-questions.md.
+
+The authoritative shape for parsed open-questions.md content. Mirrors
+``decision_model.Decision``: ``OpenQuestionsFile.parse`` reads markdown,
+``format`` writes it back, and validation lives on the model.
+
+A question entry is identified by the UTC timestamp inside its
+``[YYYY-MM-DD HH:MM UTC]`` prefix — the same id ``flag_question`` writes.
+Resolution sets ``resolved_by`` on the entry; ``format`` then emits it
+under a ``## Resolved`` subsection prefixed with ``[Resolved by Dnn on
+YYYY-MM-DD]``. ``parse_questions`` (in :mod:`nauro_core.parsing`) already
+filters that subsection out of L0 reads.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date as _date
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+_TIMESTAMP_FMT = "%Y-%m-%d %H:%M UTC"
+_RESOLVED_HEADER = "## Resolved"
+_DEFAULT_HEADER = "# Open Questions"
+_RESOLVED_PREFIX_TOKEN = "Resolved by D"
+_RESOLVED_PREFIX_SEP = " on "
+
+
+class ResolvedRef(BaseModel):
+    """Pointer to the decision that resolved a question."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    decision_num: int = Field(ge=1)
+    date: _date
+
+
+class QuestionEntry(BaseModel):
+    """A single question entry.
+
+    Open when ``resolved_by`` is None; resolved otherwise. The timestamp
+    doubles as the entry's stable id (``id`` property).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    timestamp: datetime
+    body: str
+    continuation: list[str] = Field(default_factory=list)
+    resolved_by: ResolvedRef | None = None
+
+    @property
+    def id(self) -> str:
+        return self.timestamp.strftime(_TIMESTAMP_FMT)
+
+    def render(self) -> list[str]:
+        """Return the markdown lines for this entry."""
+        if self.resolved_by is not None:
+            ref = self.resolved_by
+            head = (
+                f"- [Resolved by D{ref.decision_num} on {ref.date.isoformat()}] "
+                f"[{self.id}] {self.body}"
+            )
+        else:
+            head = f"- [{self.id}] {self.body}"
+        return [head, *self.continuation]
+
+
+@dataclass(frozen=True)
+class ResolveResult:
+    """Outcome of :meth:`OpenQuestionsFile.resolve`.
+
+    Attributes:
+        file: A new :class:`OpenQuestionsFile` with the resolutions applied.
+        moved_ids: Ids whose state ended in ``resolved_by`` set. Includes
+            ids that were already resolved (idempotent — desired state
+            achieved).
+        unknown_ids: Ids absent from the file. The caller decides whether
+            to surface this as a hard rejection.
+    """
+
+    file: OpenQuestionsFile
+    moved_ids: tuple[str, ...]
+    unknown_ids: tuple[str, ...]
+
+
+class OpenQuestionsFile(BaseModel):
+    """Parsed ``open-questions.md``. Round-trips through ``parse`` and ``format``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    header: str = _DEFAULT_HEADER
+    intro: list[str] = Field(default_factory=list)
+    entries: list[QuestionEntry] = Field(default_factory=list)
+
+    @classmethod
+    def parse(cls, content: str) -> OpenQuestionsFile:
+        """Parse ``open-questions.md`` content into an :class:`OpenQuestionsFile`."""
+        lines = content.split("\n")
+        i = 0
+        n = len(lines)
+
+        while i < n and not lines[i].strip():
+            i += 1
+        header = _DEFAULT_HEADER
+        if i < n and lines[i].startswith("# ") and not lines[i].startswith("## "):
+            header = lines[i].rstrip()
+            i += 1
+
+        intro: list[str] = []
+        entries: list[QuestionEntry] = []
+        in_resolved_section = False
+
+        while i < n:
+            line = lines[i]
+            stripped = line.strip()
+
+            if stripped.startswith("## "):
+                in_resolved_section = "resolved" in stripped.lower()
+                i += 1
+                continue
+
+            if not stripped:
+                if not entries:
+                    intro.append(line)
+                i += 1
+                continue
+
+            if line.startswith("- ["):
+                entry, consumed = _parse_entry(lines, i, in_resolved_section)
+                if entry is not None:
+                    entries.append(entry)
+                    i += consumed
+                    continue
+
+            if not entries:
+                intro.append(line)
+            i += 1
+
+        while intro and not intro[-1].strip():
+            intro.pop()
+
+        return cls(header=header, intro=intro, entries=entries)
+
+    def format(self) -> str:
+        """Render the file back to markdown."""
+        out: list[str] = [self.header]
+        if self.intro:
+            out.extend(self.intro)
+
+        open_entries = [e for e in self.entries if e.resolved_by is None]
+        resolved_entries = [e for e in self.entries if e.resolved_by is not None]
+
+        for entry in open_entries:
+            out.append("")
+            out.extend(entry.render())
+
+        if resolved_entries:
+            out.append("")
+            out.append(_RESOLVED_HEADER)
+            for entry in resolved_entries:
+                out.append("")
+                out.extend(entry.render())
+
+        out.append("")
+        return "\n".join(out)
+
+    @property
+    def open_ids(self) -> list[str]:
+        """Ids of currently-open questions."""
+        return [e.id for e in self.entries if e.resolved_by is None]
+
+    @property
+    def resolved_ids(self) -> list[str]:
+        """Ids of already-resolved questions."""
+        return [e.id for e in self.entries if e.resolved_by is not None]
+
+    def resolve(
+        self,
+        ids: list[str],
+        decision_num: int,
+        date: _date,
+    ) -> ResolveResult:
+        """Mark entries with the given timestamp ids as resolved by ``decision_num``."""
+        if not ids:
+            return ResolveResult(file=self, moved_ids=(), unknown_ids=())
+
+        requested = list(dict.fromkeys(ids))
+        by_id = {e.id: e for e in self.entries}
+        ref = ResolvedRef(decision_num=decision_num, date=date)
+
+        new_entries = [
+            entry.model_copy(update={"resolved_by": ref})
+            if entry.id in requested and entry.resolved_by is None
+            else entry
+            for entry in self.entries
+        ]
+
+        moved: list[str] = []
+        unknown: list[str] = []
+        for ts_id in requested:
+            if ts_id in by_id:
+                moved.append(ts_id)
+            else:
+                unknown.append(ts_id)
+
+        return ResolveResult(
+            file=self.model_copy(update={"entries": new_entries}),
+            moved_ids=tuple(moved),
+            unknown_ids=tuple(unknown),
+        )
+
+
+def _parse_entry(
+    lines: list[str], start: int, in_resolved_section: bool
+) -> tuple[QuestionEntry | None, int]:
+    """Parse a single ``- [...] body`` entry starting at ``lines[start]``.
+
+    Returns ``(entry, lines_consumed)``. ``entry`` is None when the line
+    can't be parsed; the caller advances past the unparsable line.
+    """
+    line = lines[start]
+    if not line.startswith("- ["):
+        return None, 1
+
+    rest = line[2:]
+    first_close = rest.find("]")
+    if first_close < 1:
+        return None, 1
+
+    first_inside = rest[1:first_close]
+    after_first = rest[first_close + 1 :].lstrip()
+
+    resolved_ref: ResolvedRef | None = None
+    if first_inside.startswith(_RESOLVED_PREFIX_TOKEN):
+        resolved_ref = _parse_resolved_prefix(first_inside)
+        if resolved_ref is None or not after_first.startswith("["):
+            return None, 1
+        second_close = after_first.find("]")
+        if second_close < 1:
+            return None, 1
+        timestamp_str = after_first[1:second_close]
+        body = after_first[second_close + 1 :].lstrip()
+    else:
+        timestamp_str = first_inside
+        body = after_first
+
+    try:
+        timestamp = datetime.strptime(timestamp_str, _TIMESTAMP_FMT)
+    except ValueError:
+        return None, 1
+
+    if in_resolved_section and resolved_ref is None:
+        # An open-form entry that landed under ## Resolved is parsable but
+        # has no ResolvedRef. Surface it as resolved with no ref so it
+        # doesn't reappear in the open section on round-trip; the caller
+        # can heal it on the next write by re-resolving with a real ref.
+        # In practice the writer always emits the resolved-prefix form.
+        pass
+
+    continuation: list[str] = []
+    j = start + 1
+    while j < len(lines) and lines[j].startswith("  "):
+        continuation.append(lines[j])
+        j += 1
+
+    return (
+        QuestionEntry(
+            timestamp=timestamp,
+            body=body,
+            continuation=continuation,
+            resolved_by=resolved_ref,
+        ),
+        j - start,
+    )
+
+
+def _parse_resolved_prefix(text: str) -> ResolvedRef | None:
+    """Parse ``Resolved by Dnn on YYYY-MM-DD`` into a :class:`ResolvedRef`."""
+    if not text.startswith(_RESOLVED_PREFIX_TOKEN):
+        return None
+    rest = text[len(_RESOLVED_PREFIX_TOKEN) :]
+    sep_idx = rest.find(_RESOLVED_PREFIX_SEP)
+    if sep_idx < 1:
+        return None
+    num_str = rest[:sep_idx]
+    date_str = rest[sep_idx + len(_RESOLVED_PREFIX_SEP) :].strip()
+    try:
+        return ResolvedRef(decision_num=int(num_str), date=_date.fromisoformat(date_str))
+    except (ValueError, TypeError):
+        return None

--- a/packages/nauro-core/tests/test_questions.py
+++ b/packages/nauro-core/tests/test_questions.py
@@ -1,0 +1,213 @@
+"""Tests for nauro_core.questions."""
+
+from datetime import date
+
+import pytest
+
+from nauro_core.questions import (
+    OpenQuestionsFile,
+    QuestionEntry,
+    ResolvedRef,
+)
+
+
+class TestResolvedRefValidation:
+    def test_decision_num_must_be_positive(self):
+        with pytest.raises(ValueError):
+            ResolvedRef(decision_num=0, date=date(2026, 5, 14))
+
+
+class TestParseRoundTrip:
+    def test_empty_file_yields_default_header(self):
+        file = OpenQuestionsFile.parse("")
+        assert file.header == "# Open Questions"
+        assert file.entries == []
+
+    def test_open_only(self):
+        content = (
+            "# Open Questions\n"
+            "\n"
+            "- [2026-05-12 20:18 UTC] q1 body\n"
+            "- [2026-05-11 15:29 UTC] q2 body\n"
+        )
+        file = OpenQuestionsFile.parse(content)
+        assert file.open_ids == ["2026-05-12 20:18 UTC", "2026-05-11 15:29 UTC"]
+        assert file.resolved_ids == []
+
+    def test_open_and_resolved_split(self):
+        content = (
+            "# Open Questions\n"
+            "\n"
+            "- [2026-05-12 20:18 UTC] still open\n"
+            "\n"
+            "## Resolved\n"
+            "\n"
+            "- [Resolved by D100 on 2026-05-01] [2026-04-30 10:00 UTC] q-old\n"
+        )
+        file = OpenQuestionsFile.parse(content)
+        assert file.open_ids == ["2026-05-12 20:18 UTC"]
+        assert file.resolved_ids == ["2026-04-30 10:00 UTC"]
+        resolved_entry = file.entries[1]
+        assert resolved_entry.resolved_by == ResolvedRef(decision_num=100, date=date(2026, 5, 1))
+
+    def test_continuation_lines(self):
+        content = (
+            "# Open Questions\n"
+            "\n"
+            "- [2026-05-12 20:18 UTC] q1\n"
+            "  Context: extra detail\n"
+            "  Another continuation line\n"
+            "- [2026-05-11 15:29 UTC] q2\n"
+        )
+        file = OpenQuestionsFile.parse(content)
+        assert file.entries[0].continuation == [
+            "  Context: extra detail",
+            "  Another continuation line",
+        ]
+        assert file.entries[1].continuation == []
+
+    def test_intro_text_preserved(self):
+        content = "# Open Questions\n\nFree-form intro paragraph.\n\n- [2026-05-12 20:18 UTC] q1\n"
+        file = OpenQuestionsFile.parse(content)
+        rendered = file.format()
+        assert "Free-form intro paragraph." in rendered
+
+    def test_round_trip_idempotent(self):
+        content = (
+            "# Open Questions\n"
+            "\n"
+            "- [2026-05-12 20:18 UTC] q1\n"
+            "  Context: detail\n"
+            "\n"
+            "## Resolved\n"
+            "\n"
+            "- [Resolved by D100 on 2026-05-01] [2026-04-30 10:00 UTC] q-old\n"
+        )
+        file = OpenQuestionsFile.parse(content)
+        rendered = file.format()
+        # Re-parsing the rendered output yields the same model.
+        re_parsed = OpenQuestionsFile.parse(rendered)
+        assert re_parsed == file
+
+    def test_malformed_timestamp_skipped(self):
+        content = (
+            "# Open Questions\n\n- [not-a-timestamp] junk line\n- [2026-05-12 20:18 UTC] valid q\n"
+        )
+        file = OpenQuestionsFile.parse(content)
+        assert file.open_ids == ["2026-05-12 20:18 UTC"]
+
+
+class TestResolve:
+    def _file(self) -> OpenQuestionsFile:
+        return OpenQuestionsFile.parse(
+            "# Open Questions\n"
+            "\n"
+            "- [2026-05-12 20:18 UTC] q1 body\n"
+            "- [2026-05-11 15:29 UTC] q2 body\n"
+        )
+
+    def test_empty_ids_unchanged(self):
+        file = self._file()
+        result = file.resolve([], 139, date(2026, 5, 14))
+        assert result.moved_ids == ()
+        assert result.unknown_ids == ()
+        assert result.file == file
+
+    def test_resolve_single_entry(self):
+        result = self._file().resolve(["2026-05-12 20:18 UTC"], 139, date(2026, 5, 14))
+        assert result.moved_ids == ("2026-05-12 20:18 UTC",)
+        assert result.unknown_ids == ()
+        assert result.file.open_ids == ["2026-05-11 15:29 UTC"]
+        assert result.file.resolved_ids == ["2026-05-12 20:18 UTC"]
+        rendered = result.file.format()
+        assert "- [Resolved by D139 on 2026-05-14] [2026-05-12 20:18 UTC] q1 body" in rendered
+
+    def test_idempotent_when_already_resolved(self):
+        file = OpenQuestionsFile.parse(
+            "# Open Questions\n"
+            "\n"
+            "- [2026-05-11 15:29 UTC] still open\n"
+            "\n"
+            "## Resolved\n"
+            "\n"
+            "- [Resolved by D100 on 2026-05-01] [2026-04-30 10:00 UTC] q-old\n"
+        )
+        before = file.format()
+        result = file.resolve(["2026-04-30 10:00 UTC"], 139, date(2026, 5, 14))
+        assert result.moved_ids == ("2026-04-30 10:00 UTC",)
+        assert result.unknown_ids == ()
+        # Already-resolved is not rewritten — rendered output is unchanged.
+        assert result.file.format() == before
+
+    def test_unknown_id_surfaces(self):
+        result = self._file().resolve(["2099-01-01 00:00 UTC"], 139, date(2026, 5, 14))
+        assert result.moved_ids == ()
+        assert result.unknown_ids == ("2099-01-01 00:00 UTC",)
+
+    def test_mixed_move_idempotent_unknown(self):
+        file = OpenQuestionsFile.parse(
+            "# Open Questions\n"
+            "\n"
+            "- [2026-05-12 20:18 UTC] q1\n"
+            "\n"
+            "## Resolved\n"
+            "\n"
+            "- [Resolved by D100 on 2026-05-01] [2026-04-30 10:00 UTC] q-old\n"
+        )
+        result = file.resolve(
+            [
+                "2026-05-12 20:18 UTC",
+                "2026-04-30 10:00 UTC",
+                "2099-01-01 00:00 UTC",
+            ],
+            139,
+            date(2026, 5, 14),
+        )
+        assert set(result.moved_ids) == {
+            "2026-05-12 20:18 UTC",
+            "2026-04-30 10:00 UTC",
+        }
+        assert result.unknown_ids == ("2099-01-01 00:00 UTC",)
+        assert result.file.open_ids == []
+
+    def test_continuation_lines_carry_over(self):
+        file = OpenQuestionsFile.parse(
+            "# Open Questions\n\n- [2026-05-12 20:18 UTC] q1\n  Context: extra detail\n"
+        )
+        result = file.resolve(["2026-05-12 20:18 UTC"], 139, date(2026, 5, 14))
+        rendered = result.file.format()
+        assert "  Context: extra detail" in rendered
+        # Continuation appears under the resolved heading, not before it.
+        head_idx = rendered.index("## Resolved")
+        assert rendered.index("Context: extra detail") > head_idx
+
+    def test_dedupe_input_ids(self):
+        result = self._file().resolve(
+            ["2026-05-12 20:18 UTC", "2026-05-12 20:18 UTC"],
+            139,
+            date(2026, 5, 14),
+        )
+        assert result.moved_ids == ("2026-05-12 20:18 UTC",)
+
+
+class TestEntryRender:
+    def test_open_form(self):
+        from datetime import datetime as _dt
+
+        entry = QuestionEntry(
+            timestamp=_dt(2026, 5, 12, 20, 18),
+            body="q text",
+        )
+        assert entry.render() == ["- [2026-05-12 20:18 UTC] q text"]
+
+    def test_resolved_form(self):
+        from datetime import datetime as _dt
+
+        entry = QuestionEntry(
+            timestamp=_dt(2026, 5, 12, 20, 18),
+            body="q text",
+            resolved_by=ResolvedRef(decision_num=139, date=date(2026, 5, 14)),
+        )
+        assert entry.render() == [
+            "- [Resolved by D139 on 2026-05-14] [2026-05-12 20:18 UTC] q text"
+        ]

--- a/packages/nauro/src/nauro/mcp/stdio_server.py
+++ b/packages/nauro/src/nauro/mcp/stdio_server.py
@@ -280,6 +280,10 @@ def propose_decision(
         list[str] | None,
         Field(description=_param_desc("propose_decision", "files_affected")),
     ] = None,
+    resolves_questions: Annotated[
+        list[str] | None,
+        Field(description=_param_desc("propose_decision", "resolves_questions")),
+    ] = None,
     skip_validation: Annotated[
         bool,
         Field(description=_param_desc("propose_decision", "skip_validation")),
@@ -307,6 +311,7 @@ def propose_decision(
         decision_type=decision_type,
         reversibility=reversibility,
         files_affected=files_affected,
+        resolves_questions=resolves_questions,
         skip_validation=skip_validation,
     )
 

--- a/packages/nauro/src/nauro/mcp/tools.py
+++ b/packages/nauro/src/nauro/mcp/tools.py
@@ -130,6 +130,7 @@ def tool_propose_decision(
     decision_type: str | None = None,
     reversibility: str | None = None,
     files_affected: list[str] | None = None,
+    resolves_questions: list[str] | None = None,
     skip_validation: bool = False,
 ) -> dict:
     """Propose a new decision through the validation pipeline."""
@@ -179,6 +180,7 @@ def tool_propose_decision(
         "decision_type": decision_type,
         "reversibility": reversibility,
         "files_affected": files_affected,
+        "resolves_questions": list(resolves_questions) if resolves_questions else [],
         "source": "mcp",
     }
 
@@ -205,6 +207,8 @@ def tool_propose_decision(
         response["decision_id"] = result._decision_id
     if result.confirm_id:
         response["confirm_id"] = result.confirm_id
+    if result.resolved_questions:
+        response["resolved_questions"] = list(result.resolved_questions)
 
     return response
 

--- a/packages/nauro/src/nauro/skills/session_body.md
+++ b/packages/nauro/src/nauro/skills/session_body.md
@@ -18,6 +18,8 @@ When the user proposes — or the agent considers proposing — an architectural
 
 This includes "should we…", "what if we…", "can we…", and "check if…" framings, and applies even when the agent intends to push back or refuse. First-principles reasoning is not a substitute for project history.
 
+<!-- protocol:RESOLVES_OPEN_QUESTIONS -->
+
 ## After meaningful progress — call update_state
 
 After completing a unit of work (a feature, a refactor, a bug fix that took more than a few changes) the agent calls `update_state(delta)` with a short paragraph describing what was completed. This replaces the project's current state, archiving the prior content to history. The next session's `get_context` call surfaces this update so context flows forward.

--- a/packages/nauro/src/nauro/store/writer.py
+++ b/packages/nauro/src/nauro/store/writer.py
@@ -12,6 +12,7 @@ templating is gone; the one source of truth for the on-disk format is
 import json
 import re
 from collections.abc import Sequence
+from datetime import date as _date
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -27,6 +28,7 @@ from nauro_core.decision_model import (
     Reversibility,
     format_decision,
 )
+from nauro_core.questions import OpenQuestionsFile, ResolveResult
 from nauro_core.state import migrate_legacy_state, prepare_state_update
 
 from nauro.constants import (
@@ -274,6 +276,28 @@ def append_question(store_path: Path, question: str) -> None:
 
     lines.insert(insert_idx, entry.rstrip())
     oq_path.write_text("\n".join(lines))
+
+
+def resolve_questions_in_file(
+    store_path: Path,
+    ids: list[str],
+    decision_num: int,
+    decision_date: _date,
+) -> ResolveResult:
+    """Move named open questions under ``## Resolved`` in open-questions.md.
+
+    Returns the :class:`~nauro_core.questions.ResolveResult` for caller-side
+    response shaping. Empty ``ids`` is a no-op; the file is not read or
+    rewritten.
+    """
+    if not ids:
+        return ResolveResult(file=OpenQuestionsFile(), moved_ids=(), unknown_ids=())
+    oq_path = store_path / OPEN_QUESTIONS_MD
+    content = oq_path.read_text() if oq_path.exists() else ""
+    file = OpenQuestionsFile.parse(content)
+    result = file.resolve(ids, decision_num, decision_date)
+    oq_path.write_text(result.file.format())
+    return result
 
 
 def update_state(store_path: Path, delta: str) -> None:

--- a/packages/nauro/src/nauro/validation/pipeline.py
+++ b/packages/nauro/src/nauro/validation/pipeline.py
@@ -5,17 +5,28 @@ Pipeline: propose → validate (tier 1 → tier 2) → confirm.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
 
-from nauro_core.constants import MIN_RATIONALE_LENGTH
+from nauro_core import extract_decision_number
+from nauro_core.constants import MIN_RATIONALE_LENGTH, OPEN_QUESTIONS_MD
+from nauro_core.questions import OpenQuestionsFile
 
 from nauro.store.snapshot import capture_snapshot
-from nauro.store.writer import append_decision, supersede_decision, update_decision
+from nauro.store.writer import (
+    append_decision,
+    resolve_questions_in_file,
+    supersede_decision,
+    update_decision,
+)
 from nauro.validation.log import log_validation
 from nauro.validation.pending import get_pending, remove_pending, store_pending
 from nauro.validation.tier1 import screen_structural, update_hash_index
 from nauro.validation.tier2 import check_similarity
+
+logger = logging.getLogger("nauro.validation.pipeline")
 
 # D133: operation="update" appends rationale only — update_decision reads only
 # affected_decision_id + rationale. Any value in these fields would be silently
@@ -40,6 +51,7 @@ class ValidationResult:
     assessment: str = ""
     confirm_id: str | None = None
     operation: str = "add"  # "add", "update", "supersede", "reject"
+    resolved_questions: tuple[str, ...] = ()
     _decision_id: str | None = field(default=None, repr=False)
 
     def to_dict(self) -> dict:
@@ -50,6 +62,7 @@ class ValidationResult:
             "assessment": self.assessment,
             "confirm_id": self.confirm_id,
             "operation": self.operation,
+            "resolved_questions": list(self.resolved_questions),
         }
 
 
@@ -98,6 +111,29 @@ def validate_proposed_write(
                     'operation="update" appends rationale only; cannot change '
                     f"{', '.join(disallowed)}. "
                     'Use operation="supersede" to replace the decision with new metadata.'
+                ),
+            )
+            log_validation(project_path, proposal, result.to_dict())
+            return result
+
+    # --- D139: reject unknown resolves_questions ids at the boundary ---
+    # Validate every supplied id exists in open-questions.md (either open
+    # or already-resolved). Unknown ids reject before Tier 1 so the
+    # assessment names the offending ids rather than slipping past the
+    # gate and failing on the write side.
+    requested_resolves = list(proposal.get("resolves_questions") or [])
+    if requested_resolves:
+        unknown = _unknown_question_ids(requested_resolves, project_path)
+        if unknown:
+            result = ValidationResult(
+                status="rejected",
+                tier=0,
+                operation=operation,
+                assessment=(
+                    "resolves_questions contains unknown timestamp id(s): "
+                    + ", ".join(repr(x) for x in unknown)
+                    + ". Call get_context (L0 lists every open question) to "
+                    "see the canonical ids in open-questions.md."
                 ),
             )
             log_validation(project_path, proposal, result.to_dict())
@@ -166,7 +202,7 @@ def validate_proposed_write(
         # Preserves supersede/update intent even when BM25 misses the affected
         # decision; the boundary already validated that affected_decision_id
         # resolves to a real file.
-        decision_id, actual_operation = _execute_operation(
+        decision_id, actual_operation, resolved_ids = _execute_operation(
             operation, proposal, project_path, affected_decision_id
         )
         result = ValidationResult(
@@ -175,6 +211,7 @@ def validate_proposed_write(
             operation=actual_operation,
             assessment="No similar existing decisions found.",
             similar_decisions=[],
+            resolved_questions=resolved_ids,
         )
         result._decision_id = decision_id
         log_validation(project_path, proposal, result.to_dict())
@@ -219,17 +256,20 @@ def confirm_write(confirm_id: str, project_path: Path) -> dict:
     operation = data["operation"]
     affected_decision_id = data["affected_decision_id"]
 
-    decision_id, actual_operation = _execute_operation(
+    decision_id, actual_operation, resolved_ids = _execute_operation(
         operation, proposal, project_path, affected_decision_id
     )
     remove_pending(confirm_id)
 
-    return {
+    response: dict = {
         "status": "confirmed",
         "decision_id": decision_id,
         "title": proposal.get("title", ""),
         "operation": actual_operation,
     }
+    if resolved_ids:
+        response["resolved_questions"] = list(resolved_ids)
+    return response
 
 
 def _write_proposal(proposal: dict, project_path: Path) -> str:
@@ -270,13 +310,17 @@ def _execute_operation(
     proposal: dict,
     project_path: Path,
     affected_decision_id: str | None,
-) -> tuple[str, str]:
-    """Execute the validated operation. Returns (decision_id, actual_operation).
+) -> tuple[str, str, tuple[str, ...]]:
+    """Execute the validated operation.
 
-    The actual operation may differ from the requested one if the boundary
-    let through an update/supersede without affected_decision_id (it should
-    not — see tool_propose_decision). The return value reflects what was
+    Returns ``(decision_id, actual_operation, resolved_question_ids)``. The
+    actual operation may differ from the requested one if the boundary let
+    through an update/supersede without affected_decision_id (it should not
+    — see tool_propose_decision). The return value reflects what was
     actually written so callers can echo ground truth.
+
+    Question resolution (D139) is applied best-effort after the decision
+    write — see :func:`_apply_question_resolves` for the failure posture.
     """
     if operation == "supersede" and affected_decision_id:
         decision_id = supersede_decision(affected_decision_id, proposal, project_path)
@@ -284,7 +328,8 @@ def _execute_operation(
         rationale = proposal.get("rationale", "")
         update_hash_index(title, rationale, decision_id, project_path)
         capture_snapshot(project_path, trigger=f"supersede {affected_decision_id}: {title}")
-        return decision_id, "supersede"
+        resolved = _apply_question_resolves(proposal, project_path, decision_id)
+        return decision_id, "supersede", resolved
 
     if operation == "update" and affected_decision_id:
         additional = proposal.get("rationale", "")
@@ -293,7 +338,59 @@ def _execute_operation(
             project_path,
             trigger=f"update {affected_decision_id}: {proposal.get('title', '')}",
         )
-        return decision_id, "update"
+        resolved = _apply_question_resolves(proposal, project_path, decision_id)
+        return decision_id, "update", resolved
 
     # "add", or fallback for update/supersede without affected_decision_id.
-    return _write_proposal(proposal, project_path), "add"
+    decision_id = _write_proposal(proposal, project_path)
+    resolved = _apply_question_resolves(proposal, project_path, decision_id)
+    return decision_id, "add", resolved
+
+
+def _apply_question_resolves(
+    proposal: dict, project_path: Path, decision_id: str
+) -> tuple[str, ...]:
+    """Apply ``resolves_questions`` to open-questions.md after a successful
+    decision write.
+
+    Best-effort: the boundary already rejected unknown ids, so this can only
+    fail on file I/O. Failures are logged with ``unresolved_ids`` and the
+    decision write stands — D132's posture for partial writes.
+    """
+    ids = list(proposal.get("resolves_questions") or [])
+    if not ids:
+        return ()
+    num = extract_decision_number(decision_id)
+    if num is None:
+        return ()
+    try:
+        result = resolve_questions_in_file(
+            project_path,
+            ids,
+            num,
+            datetime.now(timezone.utc).date(),
+        )
+    except Exception:
+        logger.exception(
+            "question-resolution failed after decision %s wrote; "
+            "decision stands. unresolved_ids=%s",
+            decision_id,
+            ids,
+        )
+        return ()
+    if result.moved_ids:
+        capture_snapshot(
+            project_path,
+            trigger=f"resolved questions via {decision_id}",
+        )
+    return result.moved_ids
+
+
+def _unknown_question_ids(ids: list[str], project_path: Path) -> list[str]:
+    """Return any caller-supplied ids absent from open-questions.md."""
+    oq_path = project_path / OPEN_QUESTIONS_MD
+    if not oq_path.exists():
+        return list(ids)
+    file = OpenQuestionsFile.parse(oq_path.read_text())
+    known = set(file.open_ids) | set(file.resolved_ids)
+    return [tid for tid in ids if tid not in known]

--- a/packages/nauro/tests/test_protocol_drift.py
+++ b/packages/nauro/tests/test_protocol_drift.py
@@ -18,6 +18,7 @@ from nauro_core import (
     CHECK_DECISION_RETURNS,
     GET_DECISION_BEFORE_PROPOSING,
     NO_INVENT_RATIONALE,
+    RESOLVES_OPEN_QUESTIONS,
 )
 from nauro_core.protocol import protocol_tokens_in
 
@@ -33,6 +34,7 @@ SURFACE_FRAGMENTS: dict[str, list[str]] = {
         CHECK_DECISION_RETURNS,
         GET_DECISION_BEFORE_PROPOSING,
         NO_INVENT_RATIONALE,
+        RESOLVES_OPEN_QUESTIONS,
     ],
     "adopt": [
         CHECK_DECISION_RETURNS,

--- a/packages/nauro/tests/test_stdio_server.py
+++ b/packages/nauro/tests/test_stdio_server.py
@@ -168,6 +168,69 @@ class TestProposeDecision:
         assert result["status"] in ("confirmed", "pending_confirmation")
 
 
+class TestProposeDecisionResolvesQuestions:
+    """D139 wired through the stdio FastMCP layer.
+
+    Asserts the Annotated[list[str], ...] wrapper forwards the param into
+    tool_propose_decision and the resolved-questions response field is
+    surfaced back to the caller.
+    """
+
+    def _seed_question(self, store: Path) -> str:
+        """Write one question with a deterministic timestamp; return its id."""
+        ts = "2026-05-12 20:18 UTC"
+        (store / "open-questions.md").write_text(
+            f"# Open Questions\n\n- [{ts}] should we ship D139?\n"
+        )
+        return ts
+
+    def test_known_id_moves_to_resolved(self, store: Path):
+        question_id = self._seed_question(store)
+        result = propose_decision(
+            project_id="testproj",
+            title="Ship D139",
+            rationale="Decision that closes the seeded open question.",
+            resolves_questions=[question_id],
+        )
+        assert result["status"] == "confirmed"
+        assert result.get("resolved_questions") == [question_id]
+        oq = (store / "open-questions.md").read_text()
+        open_section = oq.split("## Resolved", 1)[0]
+        assert f"[{question_id}]" not in open_section
+        assert "## Resolved" in oq
+
+    def test_unknown_id_rejects_at_boundary(self, store: Path):
+        self._seed_question(store)
+        result = propose_decision(
+            project_id="testproj",
+            title="Names a bogus id",
+            rationale="Decision that names a question id that doesn't exist.",
+            resolves_questions=["2099-01-01 00:00 UTC"],
+        )
+        assert result["status"] == "rejected"
+        assessment = result["validation"]["assessment"]
+        assert "2099-01-01 00:00 UTC" in assessment
+        assert "resolves_questions" in assessment
+
+    def test_pending_then_confirm_applies_move(self, store: Path):
+        question_id = self._seed_question(store)
+        result = propose_decision(
+            project_id="testproj",
+            title="Closes via pending path",
+            rationale="Routes through skip_validation→confirm to exercise pending storage.",
+            resolves_questions=[question_id],
+            skip_validation=True,
+        )
+        assert result["status"] == "pending_confirmation"
+        cid = result["confirm_id"]
+        # Question not yet moved.
+        assert "## Resolved" not in (store / "open-questions.md").read_text()
+        confirmed = confirm_decision(confirm_id=cid, project_id="testproj")
+        assert confirmed["status"] == "confirmed"
+        assert confirmed.get("resolved_questions") == [question_id]
+        assert "## Resolved" in (store / "open-questions.md").read_text()
+
+
 class TestWelcomeDisambiguation:
     """D136: WELCOME_NO_PROJECT is reserved for the genuinely-no-project
     case. Specific failures (bogus project_id, missing store on disk,

--- a/packages/nauro/tests/test_validation/test_pipeline.py
+++ b/packages/nauro/tests/test_validation/test_pipeline.py
@@ -361,3 +361,161 @@ class TestD133UpdateRejectsMetadata:
             affected_decision_id="002-seed-decision-for-d133-tests",
         )
         assert result_supersede.status != "rejected" or result_supersede.tier != 0
+
+
+class TestD139ResolvesQuestions:
+    """D139: propose_decision can pass `resolves_questions` to move named
+    open-questions.md entries under ``## Resolved`` on confirm.
+    """
+
+    RATIONALE = (
+        "A sufficiently long rationale that comfortably exceeds the structural "
+        "minimum length so D139 boundary validation is what is exercised."
+    )
+
+    @pytest.fixture
+    def store_with_questions(self, tmp_path: Path) -> Path:
+        store_path = tmp_path / "projects" / "d139"
+        scaffold_project_store("d139", store_path)
+        oq = store_path / "open-questions.md"
+        oq.write_text(
+            "# Open Questions\n"
+            "\n"
+            "- [2026-05-12 20:18 UTC] q-one body text\n"
+            "- [2026-05-11 15:29 UTC] q-two body text\n"
+        )
+        return store_path
+
+    def test_unknown_id_rejects_at_boundary(self, store_with_questions: Path) -> None:
+        proposal = {
+            "title": "A decision that names a bogus question",
+            "rationale": self.RATIONALE,
+            "resolves_questions": ["2099-01-01 00:00 UTC"],
+        }
+        result = validate_proposed_write(proposal, store_with_questions)
+        assert result.status == "rejected"
+        assert result.tier == 0
+        assert "2099-01-01 00:00 UTC" in result.assessment
+        assert "resolves_questions" in result.assessment
+
+    def test_unknown_id_rejection_lists_every_offender(self, store_with_questions: Path) -> None:
+        proposal = {
+            "title": "A decision that names two bogus questions",
+            "rationale": self.RATIONALE,
+            "resolves_questions": [
+                "2099-01-01 00:00 UTC",
+                "2099-02-02 00:00 UTC",
+                "2026-05-12 20:18 UTC",  # this one IS valid
+            ],
+        }
+        result = validate_proposed_write(proposal, store_with_questions)
+        assert result.status == "rejected"
+        for bad in ("2099-01-01 00:00 UTC", "2099-02-02 00:00 UTC"):
+            assert bad in result.assessment
+
+    def test_known_id_moves_to_resolved_on_auto_confirm(self, store_with_questions: Path) -> None:
+        proposal = {
+            "title": "A decision that closes the first open question",
+            "rationale": self.RATIONALE,
+            "resolves_questions": ["2026-05-12 20:18 UTC"],
+        }
+        result = validate_proposed_write(proposal, store_with_questions)
+        assert result.status == "confirmed"
+        assert result.resolved_questions == ("2026-05-12 20:18 UTC",)
+        oq_content = (store_with_questions / "open-questions.md").read_text()
+        assert "## Resolved" in oq_content
+        assert "[Resolved by D" in oq_content
+        # q-one moved out of the open section
+        open_part = oq_content.split("## Resolved", 1)[0]
+        assert "[2026-05-12 20:18 UTC]" not in open_part
+        # q-two still in the open section
+        assert "[2026-05-11 15:29 UTC] q-two body text" in open_part
+
+    def test_resolves_through_pending_confirm(self, store_with_questions: Path) -> None:
+        proposal = {
+            "title": "A decision that closes via the pending path",
+            "rationale": self.RATIONALE,
+            "resolves_questions": ["2026-05-12 20:18 UTC"],
+        }
+        result = validate_proposed_write(proposal, store_with_questions, skip_validation=True)
+        assert result.status == "pending_confirmation"
+        assert result.confirm_id is not None
+        # Question is NOT yet moved (write hasn't happened).
+        oq_before = (store_with_questions / "open-questions.md").read_text()
+        assert "## Resolved" not in oq_before
+
+        confirm_response = confirm_write(result.confirm_id, store_with_questions)
+        assert confirm_response["status"] == "confirmed"
+        assert confirm_response.get("resolved_questions") == ["2026-05-12 20:18 UTC"]
+        oq_after = (store_with_questions / "open-questions.md").read_text()
+        assert "## Resolved" in oq_after
+
+    def test_idempotent_for_already_resolved_id(self, store_with_questions: Path) -> None:
+        oq = store_with_questions / "open-questions.md"
+        oq.write_text(
+            "# Open Questions\n"
+            "\n"
+            "- [2026-05-11 15:29 UTC] q-two\n"
+            "\n"
+            "## Resolved\n"
+            "\n"
+            "- [Resolved by D100 on 2026-05-01] [2026-04-30 10:00 UTC] q-old\n"
+        )
+        proposal = {
+            "title": "A decision that names an already-resolved question",
+            "rationale": self.RATIONALE,
+            "resolves_questions": ["2026-04-30 10:00 UTC"],
+        }
+        result = validate_proposed_write(proposal, store_with_questions)
+        # Should NOT reject — already-resolved counts as known.
+        assert result.status == "confirmed"
+        assert result.resolved_questions == ("2026-04-30 10:00 UTC",)
+        # And the resolved-section back-ref to D100 is preserved.
+        assert "[Resolved by D100 on 2026-05-01]" in oq.read_text()
+
+    def test_empty_list_is_no_op(self, store_with_questions: Path) -> None:
+        proposal = {
+            "title": "A decision with no resolves_questions",
+            "rationale": self.RATIONALE,
+            "resolves_questions": [],
+        }
+        result = validate_proposed_write(proposal, store_with_questions)
+        assert result.status == "confirmed"
+        assert result.resolved_questions == ()
+        oq_content = (store_with_questions / "open-questions.md").read_text()
+        # File is untouched.
+        assert "## Resolved" not in oq_content
+
+    def test_works_for_supersede(self, store_with_questions: Path) -> None:
+        # Seed an extra decision to supersede.
+        append_decision(
+            store_with_questions,
+            "Seed for supersede + resolves_questions",
+            rationale="Pre-existing decision the supersede path targets.",
+        )
+        proposal = {
+            "title": "Supersedes the seed and closes a question",
+            "rationale": self.RATIONALE,
+            "resolves_questions": ["2026-05-12 20:18 UTC"],
+        }
+        decisions = sorted(
+            (store_with_questions / "decisions").glob("*.md"),
+            key=lambda p: p.name,
+        )
+        affected = decisions[-1].stem
+        # D131: supersede always returns pending_confirmation.
+        result = validate_proposed_write(
+            proposal,
+            store_with_questions,
+            operation="supersede",
+            affected_decision_id=affected,
+            skip_validation=True,
+        )
+        assert result.status == "pending_confirmation"
+        assert result.confirm_id is not None
+        confirm = confirm_write(result.confirm_id, store_with_questions)
+        assert confirm["status"] == "confirmed"
+        assert confirm["operation"] == "supersede"
+        assert confirm.get("resolved_questions") == ["2026-05-12 20:18 UTC"]
+        oq_content = (store_with_questions / "open-questions.md").read_text()
+        assert "## Resolved" in oq_content


### PR DESCRIPTION
## Why

`open-questions.md` had no pruning mechanism. The parser filters `## Resolved` from L0, but nothing wrote that header. D94, D132, D133, D134 all said "resolves question X" in their rationale; the entries never moved. Three live questions (Q1, Q2, Q3) are already closed in narrative and still showing in L0.

## Approach

Agent-supplied: `propose_decision` gains `resolves_questions: list[str]`. Each id is the `YYYY-MM-DD HH:MM UTC` timestamp `flag_question` already emits. No schema change.

- Pydantic `OpenQuestionsFile` model, not line-scanning (mirrors `decision_model.Decision`)
- Tier-0 boundary reject for unknown ids (D131/D133/D134 pattern)
- Partial-write: decision write stands; question-move failure logs `unresolved_ids` (D132 pattern)
- New `RESOLVES_OPEN_QUESTIONS` protocol fragment so agents see the field in MCP instructions + session skill, not only the ToolSpec

Rejected (full reasoning in D139 body): server-side BM25 auto-detect, new `resolve_question` tool, hybrid suggest+confirm.

## What changed

**nauro-core**
- `questions.py` (new) — pydantic models, parse/format/resolve
- `mcp_tools.py` — `resolves_questions` added to `PROPOSE_DECISION` ToolSpec
- `protocol.py` + `constants.py` — new canonical fragment spliced into MCP instructions

**nauro**
- `validation/pipeline.py` — boundary check + post-write apply + `ValidationResult.resolved_questions`
- `store/writer.py` — `resolve_questions_in_file` helper
- `mcp/tools.py` + `mcp/stdio_server.py` — param plumbed through
- `skills/session_body.md` — fragment token; dogfood files regenerated

## What to review

- Partial-write semantics in `_apply_question_resolves`
- `OpenQuestionsFile.format` round-trip (asserted for both shapes + continuation lines)
- `resolves_questions` is intentionally allowed on `update` (doesn't change the decision file)
- Fragment lives on session skill, not adopt (adopt seeds into empty stores)

## What's deferred

- mcp-server companion PR: boundary check + S3 write-side + partial-write logging. Waits on nauro-core 0.8.0 PyPI publish.
- Backfilling Q1/Q2/Q3 once the cloud server has D139.

## Test plan

- `uv run pytest packages/ -q -m "not integration"` — **1188 pass** (1158 baseline + 30 new): 17 model + 7 pipeline + 3 stdio + 3 dogfood + parametrized fragment
- `ruff check` + `ruff format --check` clean