### PR TITLE
fix(init): reject --demo --cloud combination at command entry (D140)

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/init.py
+++ b/packages/nauro/src/nauro/cli/commands/init.py
@@ -139,6 +139,18 @@ def init(
     is provided, the repos are appended to the existing local-mode entry.
     Cloud-mode entries cannot be extended this way — use ``nauro attach``.
     """
+    # D140: --demo seeds 7 pre-written decisions directly to disk (D91); the
+    # --cloud path goes through propose_decision/confirm_decision, which has
+    # no batch-seed bypass. Reject the combination at command entry rather
+    # than silently dropping --demo inside the --cloud branch.
+    if demo and cloud:
+        raise typer.BadParameter(
+            "Cannot combine --demo with --cloud — the demo fixture seeds "
+            "locally only. Use `nauro init <name> --demo` for a local demo, "
+            "or `nauro init <name> --cloud` for an empty cloud project.",
+            param_hint="--demo / --cloud",
+        )
+
     repo_paths = add_repo_paths if add_repo_paths else [Path.cwd()]
 
     # ── --add-repo against an existing project ──────────────────────────────

--- a/packages/nauro/tests/test_init_cloud.py
+++ b/packages/nauro/tests/test_init_cloud.py
@@ -125,6 +125,33 @@ def test_init_cloud_renders_server_error(tmp_path, monkeypatch):
     assert registry.find_projects_by_name_v2("cloudproj") == []
 
 
+# ── D140: --demo + --cloud rejection ─────────────────────────────────────────
+
+
+def test_init_demo_plus_cloud_rejects_at_entry(tmp_path, monkeypatch):
+    """`nauro init --demo --cloud` must reject before any state is written.
+
+    Pre-D140 this silently dropped `--demo` inside the `--cloud` branch.
+    The combined invocation now exits non-zero with a message naming both
+    single-flag forms; no project is registered, no network call is made,
+    and no `.nauro/config.json` is dropped in the cwd.
+    """
+    _seed_token(monkeypatch, tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    def explode(*_args, **_kwargs):
+        raise AssertionError("rejection must happen before any cloud call")
+
+    with patch.object(cloud_projects.httpx, "request", side_effect=explode):
+        result = runner.invoke(app, ["init", "--demo", "--cloud", "rejectproj"])
+
+    assert result.exit_code != 0
+    combined_output = (result.output or "") + (str(result.exception) if result.exception else "")
+    assert "--demo" in combined_output and "--cloud" in combined_output
+    assert registry.find_projects_by_name_v2("rejectproj") == []
+    assert not (tmp_path / ".nauro" / "config.json").exists()
+
+
 # ── add-repo against cloud-mode project ───────────────────────────────────────
 
 

--- a/packages/nauro/tests/test_init_cloud.py
+++ b/packages/nauro/tests/test_init_cloud.py
@@ -132,9 +132,12 @@ def test_init_demo_plus_cloud_rejects_at_entry(tmp_path, monkeypatch):
     """`nauro init --demo --cloud` must reject before any state is written.
 
     Pre-D140 this silently dropped `--demo` inside the `--cloud` branch.
-    The combined invocation now exits non-zero with a message naming both
-    single-flag forms; no project is registered, no network call is made,
-    and no `.nauro/config.json` is dropped in the cwd.
+    The combined invocation now exits 2 (Typer's BadParameter contract) with
+    a message naming both single-flag forms; no project is registered, no
+    network call is made, no `.nauro/config.json` is dropped in the cwd.
+    Pinning to exit code 2 instead of != 0 ensures an unrelated crash on the
+    same input would surface as a test failure rather than masquerading as
+    the intended rejection.
     """
     _seed_token(monkeypatch, tmp_path)
     monkeypatch.chdir(tmp_path)
@@ -145,7 +148,10 @@ def test_init_demo_plus_cloud_rejects_at_entry(tmp_path, monkeypatch):
     with patch.object(cloud_projects.httpx, "request", side_effect=explode):
         result = runner.invoke(app, ["init", "--demo", "--cloud", "rejectproj"])
 
-    assert result.exit_code != 0
+    assert result.exit_code == 2, (
+        f"expected Typer BadParameter (exit 2), got exit={result.exit_code}; "
+        f"output={result.output!r}; exception={result.exception!r}"
+    )
     combined_output = (result.output or "") + (str(result.exception) if result.exception else "")
     assert "--demo" in combined_output and "--cloud" in combined_output
     assert registry.find_projects_by_name_v2("rejectproj") == []

--- a/packages/nauro/tests/test_init_cloud.py
+++ b/packages/nauro/tests/test_init_cloud.py
@@ -128,6 +128,31 @@ def test_init_cloud_renders_server_error(tmp_path, monkeypatch):
 # ── D140: --demo + --cloud rejection ─────────────────────────────────────────
 
 
+def _strip_ansi(text: str) -> str:
+    """Strip ANSI CSI escape sequences (``\\x1b[…m``) without regex.
+
+    Typer renders BadParameter through Rich, which injects style escapes
+    around every flag token when the runner detects a colour-capable
+    terminal (CI runners with FORCE_COLOR=1, GH Actions, etc.). The escapes
+    split substrings like ``--demo`` into ``-\\x1b[0m-demo``, so a literal
+    ``"--demo" in output`` check fails on those runners. Stripping here
+    keeps the substring check colour-environment-independent.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(text)
+    while i < n:
+        if text[i] == "\x1b" and i + 1 < n and text[i + 1] == "[":
+            i += 2
+            while i < n and text[i] != "m":
+                i += 1
+            i += 1
+        else:
+            out.append(text[i])
+            i += 1
+    return "".join(out)
+
+
 def test_init_demo_plus_cloud_rejects_at_entry(tmp_path, monkeypatch):
     """`nauro init --demo --cloud` must reject before any state is written.
 
@@ -152,8 +177,11 @@ def test_init_demo_plus_cloud_rejects_at_entry(tmp_path, monkeypatch):
         f"expected Typer BadParameter (exit 2), got exit={result.exit_code}; "
         f"output={result.output!r}; exception={result.exception!r}"
     )
-    combined_output = (result.output or "") + (str(result.exception) if result.exception else "")
-    assert "--demo" in combined_output and "--cloud" in combined_output
+    raw_output = (result.output or "") + (str(result.exception) if result.exception else "")
+    combined_output = _strip_ansi(raw_output)
+    assert "--demo" in combined_output and "--cloud" in combined_output, (
+        f"expected both flag names in stripped output; got: {combined_output!r}"
+    )
     assert registry.find_projects_by_name_v2("rejectproj") == []
     assert not (tmp_path / ".nauro" / "config.json").exists()
 


### PR DESCRIPTION
## Why

Q2 in `open-questions.md`: `nauro init --demo --cloud` silently dropped `--demo`. The `--cloud` branch returned before the `if demo:` block could run. User saw the cloud success banner with no hint the flag was discarded.

## Approach

Top-of-`init()` conditional raises `typer.BadParameter` when both flags are set. Exit code 2; message names both single-flag forms.

Rejected (full reasoning in D140 body):
- Implementing demo-over-cloud — 7 decisions through validation including D91's conflict pair; needs batch-confirm or seed bypass, both contradict D125
- Documenting the no-op — silent-drop antipattern D133 just rejected
- Typed exception subclass — overkill; D136's typed errors exist for 5-branch resolution

## What changed

- `cli/commands/init.py` — 12-line conditional at top of `init()`, before any state mutation
- `tests/test_init_cloud.py` — one test: exit code 2, both flag names in message, no registry entry, no httpx call

## What to review

- `param_hint="--demo / --cloud"` reads as "either of these" rather than a combined flag
- Test pinned to `exit_code == 2` (Typer BadParameter contract), not `!= 0` — an unrelated crash would otherwise mask the rejection path silently passing

## What's deferred

- Closing Q2 in `open-questions.md` via D139's `resolves_questions` once D139 ships.

## Test plan

- `test_init_cloud.py` — 6 pass (5 existing + 1 new)
- Full suite — 1158 pass (no regression)
- `ruff check` + `ruff format --check` clean