### PR TITLE
feat(cli): add nauro check for in-session conflict detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,10 @@ Requires Python 3.10+.
 
 Try the demo locally in 2 minutes — no account needed.
 
-1. `nauro init --demo` — scaffold a sample project with 7 decisions, project state, and open questions.
-2. `nauro setup claude-code` — write the MCP entry to `<repo>/.mcp.json`.
-3. Open Claude Code and ask: *"Check if we should add a WebSocket endpoint for live task updates"*
+1. Set up a sandbox: `mkdir -p /tmp/nauro-demo && cd /tmp/nauro-demo` (keeps the demo isolated from any existing project's `.nauro/config.json`).
+2. `nauro init --demo` — scaffold a sample project with 7 decisions, project state, and open questions.
+3. `nauro setup claude-code` — write the MCP entry to `<repo>/.mcp.json`.
+4. Open Claude Code and ask: *"Check if we should add a WebSocket endpoint for live task updates"*
 
 `check_decision` surfaces a conflict: the team already chose SSE over WebSocket because persistent connections weren't released during ECS rolling deploys.
 

--- a/packages/nauro-core/src/nauro_core/search.py
+++ b/packages/nauro-core/src/nauro_core/search.py
@@ -31,14 +31,16 @@ def bm25_search(
         return []
 
     corpus = [f"{d.title} {d.rationale}" for d in decisions]
-    corpus_tokens = bm25s.tokenize(corpus, stopwords="en", stemmer=_stemmer)
+    # show_progress=False — bm25s defaults to True; the tqdm output is invisible
+    # in MCP server stderr but pollutes the `nauro check` CLI surface.
+    corpus_tokens = bm25s.tokenize(corpus, stopwords="en", stemmer=_stemmer, show_progress=False)
 
     retriever = bm25s.BM25()
-    retriever.index(corpus_tokens)
+    retriever.index(corpus_tokens, show_progress=False)
 
     k = min(limit, len(decisions))
-    query_tokens = bm25s.tokenize([query], stopwords="en", stemmer=_stemmer)
-    results, scores = retriever.retrieve(query_tokens, k=k)
+    query_tokens = bm25s.tokenize([query], stopwords="en", stemmer=_stemmer, show_progress=False)
+    results, scores = retriever.retrieve(query_tokens, k=k, show_progress=False)
 
     query_words = query.strip().split()
     ranked = []
@@ -91,14 +93,18 @@ def bm25_retrieve(
         return []
 
     corpus = [f"{d.title} {d.rationale}" for d in active]
-    corpus_tokens = bm25s.tokenize(corpus, stopwords=stopwords, stemmer=_stemmer)
+    corpus_tokens = bm25s.tokenize(
+        corpus, stopwords=stopwords, stemmer=_stemmer, show_progress=False
+    )
 
     retriever = bm25s.BM25()
-    retriever.index(corpus_tokens)
+    retriever.index(corpus_tokens, show_progress=False)
 
     k = min(top_k, len(active))
-    query_tokens = bm25s.tokenize([query_text], stopwords=stopwords, stemmer=_stemmer)
-    results, scores = retriever.retrieve(query_tokens, k=k)
+    query_tokens = bm25s.tokenize(
+        [query_text], stopwords=stopwords, stemmer=_stemmer, show_progress=False
+    )
+    results, scores = retriever.retrieve(query_tokens, k=k, show_progress=False)
 
     related = []
     for i in range(results.shape[1]):

--- a/packages/nauro-core/tests/test_search.py
+++ b/packages/nauro-core/tests/test_search.py
@@ -123,3 +123,24 @@ class TestBm25Retrieve:
     def test_top_k(self):
         related = bm25_retrieve(DECISIONS, "server session authentication", top_k=1)
         assert len(related) <= 1
+
+
+class TestBm25SilencesProgressBars:
+    """Guards the show_progress=False arguments on every bm25s call.
+
+    bm25s defaults show_progress to True, which writes tqdm progress bars to
+    stderr. That's invisible inside an MCP server process but pollutes the
+    `nauro check` CLI surface. A future bm25s upgrade flipping the default
+    back, or a refactor that drops the kwarg, would re-introduce the noise
+    silently without this guard.
+    """
+
+    def test_bm25_search_writes_nothing_to_stderr(self, capsys):
+        bm25_search(DECISIONS, "authentication OAuth provider")
+        captured = capsys.readouterr()
+        assert captured.err == "", f"unexpected stderr: {captured.err!r}"
+
+    def test_bm25_retrieve_writes_nothing_to_stderr(self, capsys):
+        bm25_retrieve(DECISIONS, "session caching")
+        captured = capsys.readouterr()
+        assert captured.err == "", f"unexpected stderr: {captured.err!r}"

--- a/packages/nauro/README.md
+++ b/packages/nauro/README.md
@@ -15,6 +15,7 @@ Requires Python 3.10+.
 ## Quickstart
 
 ```bash
+mkdir -p /tmp/nauro-demo && cd /tmp/nauro-demo
 nauro init --demo
 nauro setup claude-code   # writes the MCP entry to <repo>/.mcp.json
 ```

--- a/packages/nauro/src/nauro/cli/commands/check.py
+++ b/packages/nauro/src/nauro/cli/commands/check.py
@@ -1,0 +1,129 @@
+"""nauro check — Run check_decision from the shell, no MCP wiring required.
+
+This is the L1 surface in the progressive-enhancement onboarding model: an
+agent or developer with the ``nauro`` CLI installed can run conflict-detection
+in the current session without restarting their MCP client. The output is the
+same retrieval the MCP ``check_decision`` tool returns; nothing is written.
+
+CLI invocations skip the ``@mcp_tool`` decorator's telemetry side-effects by
+calling :func:`nauro.mcp.tools.compute_check_decision` directly — the Typer
+instrumentation already emits ``cli.command_invoked`` for every command.
+"""
+
+from __future__ import annotations
+
+import json
+
+import typer
+
+from nauro.cli.utils import resolve_target_project
+from nauro.constants import REPO_CONFIG_MODE_CLOUD
+from nauro.mcp.tools import compute_check_decision
+from nauro.store.registry import RegistrySchemaError, get_project_v2
+
+
+def _is_cloud_project(project_key: str) -> bool:
+    """Return True iff the v2 registry marks this project as cloud-mode.
+
+    Used only to surface a "may be stale" notice — CLI check always reads
+    the local store regardless. v1 projects (no mode field) are treated as
+    local; cloud-mode CLI check is deferred until the local surface settles.
+    """
+    try:
+        entry = get_project_v2(project_key)
+    except RegistrySchemaError:
+        return False
+    if entry is None:
+        return False
+    return entry.get("mode") == REPO_CONFIG_MODE_CLOUD
+
+
+def _render_human(
+    project_name: str,
+    approach: str,
+    store_path_str: str,
+    result: dict,
+) -> str:
+    """Render the check_decision result as human-readable terminal output."""
+    lines: list[str] = []
+    lines.append(f"store:    {result.get('store', 'local')}")
+    lines.append(f"project:  {project_name}")
+    lines.append(f"approach: {approach}")
+    lines.append("")
+
+    related = result.get("related_decisions", [])
+    if not related:
+        lines.append(result.get("assessment", "No related decisions found."))
+        return "\n".join(lines)
+
+    lines.append(f"Related decisions ({len(related)}):")
+    for d in related:
+        did = d.get("id", "?")
+        title = d.get("title", "")
+        score = d.get("score", 0.0)
+        status = d.get("status", "")
+        date = d.get("date", "")
+        lines.append(f"  {did}  {title}  (score {score:.1f}, status {status}, decided {date})")
+
+    lines.append("")
+    lines.append(result.get("assessment", ""))
+    lines.append("")
+    lines.append(
+        f"For full rationale, read decision files in {store_path_str}/decisions/, "
+        "or call the get_decision MCP tool after `nauro setup` + restart."
+    )
+    return "\n".join(lines)
+
+
+def check(
+    approach: str = typer.Argument(..., help="Proposed approach to check."),
+    project: str | None = typer.Option(
+        None,
+        "--project",
+        help="Project name or id (default: resolve from cwd).",
+    ),
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit the raw result dict as JSON instead of human-readable output.",
+    ),
+) -> None:
+    """Check a proposed approach against the project's decision log.
+
+    Returns the same retrieval as the ``check_decision`` MCP tool. Nothing is
+    written. Use this from a shell to demo conflict-detection without first
+    wiring MCP and restarting an agent — the L1 bridge in Nauro's progressive
+    onboarding model.
+    """
+    project_name, store_path = resolve_target_project(project)
+
+    # Cloud-mode notice. We always read local data; the warning goes to stderr
+    # so --json output stays parseable.
+    if _is_cloud_project(store_path.name):
+        typer.echo(
+            f"Note: project '{project_name}' syncs to cloud; CLI check uses "
+            "the local copy. Run `nauro sync` first if it might be stale.",
+            err=True,
+        )
+
+    result = compute_check_decision(store_path, approach)
+    # Any non-empty status field is an error-shaped response from compute_check_decision
+    # (currently "error" for missing store, "rejected" for over-length input).
+    # Both human and JSON paths must exit 1 on those — a script piping --json
+    # and checking $? would otherwise silently treat input-too-long as success.
+    is_error = result.get("status") in ("error", "rejected")
+
+    if json_output:
+        typer.echo(json.dumps(result, indent=2))
+        if is_error:
+            raise typer.Exit(code=1)
+        return
+
+    if result.get("status") == "error":
+        typer.echo(result.get("guidance", "Error"), err=True)
+        raise typer.Exit(code=1)
+    if result.get("status") == "rejected":
+        typer.echo(result.get("reason", "Rejected"), err=True)
+        raise typer.Exit(code=1)
+
+    typer.echo(_render_human(project_name, approach, str(store_path), result))

--- a/packages/nauro/src/nauro/cli/main.py
+++ b/packages/nauro/src/nauro/cli/main.py
@@ -50,6 +50,7 @@ def _register_commands() -> None:
         adopt,
         attach,
         auth,
+        check,
         config,
         diff,
         import_cmd,
@@ -70,6 +71,7 @@ def _register_commands() -> None:
     app.command(name="attach")(attach.attach)
     app.command(name="link")(link.link)
     app.command(name="note")(note.note)
+    app.command(name="check")(check.check)
     app.command(name="sync")(sync.sync)
     app.command(name="log")(log.log)
     app.command(name="diff")(diff.diff)

--- a/packages/nauro/src/nauro/mcp/tools.py
+++ b/packages/nauro/src/nauro/mcp/tools.py
@@ -254,13 +254,18 @@ def tool_confirm_decision(store_path: Path, confirm_id: str) -> dict:
     return response
 
 
-@mcp_tool("check_decision")
-def tool_check_decision(
+def compute_check_decision(
     store_path: Path,
     proposed_approach: str,
     context: str | None = None,
 ) -> dict:
-    """Check for conflicts with existing decisions without writing anything."""
+    """Compute the check_decision result without emitting MCP telemetry.
+
+    Same return shape as :func:`tool_check_decision`. Call this from non-MCP
+    contexts (e.g. the ``nauro check`` CLI command) where the ``@mcp_tool``
+    decorator's ``mcp.tool_called`` emission would be wrong — those surfaces
+    emit their own events (``cli.command_invoked`` via Typer instrumentation).
+    """
     guidance = _check_store_exists(store_path)
     if guidance:
         return {"store": "local", "status": "error", "guidance": guidance}
@@ -335,6 +340,16 @@ def tool_check_decision(
         "related_decisions": related,
         "assessment": assessment,
     }
+
+
+@mcp_tool("check_decision")
+def tool_check_decision(
+    store_path: Path,
+    proposed_approach: str,
+    context: str | None = None,
+) -> dict:
+    """Check for conflicts with existing decisions without writing anything."""
+    return compute_check_decision(store_path, proposed_approach, context)
 
 
 # Compose the agent-facing docstring from canonical fragments so the

--- a/packages/nauro/tests/test_check_command.py
+++ b/packages/nauro/tests/test_check_command.py
@@ -1,0 +1,268 @@
+"""Tests for the ``nauro check`` CLI command.
+
+Covers:
+- The demo prompt retrieves the canonical SSE-over-WebSocket decision (D004).
+- ``--json`` emits a parseable result with the same shape as the human path.
+- Project-resolution and store-state error paths exit non-zero with guidance.
+- Cloud-mode projects surface a "may be stale" notice on stderr.
+- The CLI does NOT emit ``mcp.tool_called`` telemetry (the helper-extraction
+  fix) — only the auto-instrumented ``cli.command_invoked`` event fires.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from nauro.cli.main import app
+from nauro.constants import REPO_CONFIG_MODE_CLOUD, REPO_CONFIG_MODE_LOCAL
+from nauro.demo import create_demo_project
+from nauro.mcp.tools import compute_check_decision, tool_check_decision
+from nauro.store.registry import register_project_v2
+from nauro.store.repo_config import save_repo_config
+
+runner = CliRunner()
+
+
+# Canonical demo prompt — pinned so README references and integration assertions
+# share one source of truth. Used by test_demo_prompt_returns_sse_decision.
+DEMO_PROMPT = "Add a WebSocket endpoint for live task updates"
+
+
+@pytest.fixture
+def demo_repo(tmp_path, monkeypatch):
+    """Register a local-mode v2 demo project rooted at tmp_path/repo.
+
+    Returns (project_name, project_id, store_path, repo_path). The cwd is
+    moved into the repo so resolve_target_project picks the right project.
+    """
+    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    pid, store_path = register_project_v2("demo-project", [repo], mode=REPO_CONFIG_MODE_LOCAL)
+    save_repo_config(repo, {"mode": REPO_CONFIG_MODE_LOCAL, "id": pid, "name": "demo-project"})
+    create_demo_project(store_path)
+    monkeypatch.chdir(repo)
+    return "demo-project", pid, store_path, repo
+
+
+@pytest.fixture
+def no_decisions_repo(tmp_path, monkeypatch):
+    """Register a v2 project whose store has no decisions/ directory at all.
+
+    Hits the ``not _has_decisions(store_path)`` branch in compute_check_decision —
+    distinct from a scaffolded store (which seeds 001-initial-setup.md and
+    therefore has decisions).
+    """
+    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    pid, store_path = register_project_v2("bare-project", [repo], mode=REPO_CONFIG_MODE_LOCAL)
+    save_repo_config(repo, {"mode": REPO_CONFIG_MODE_LOCAL, "id": pid, "name": "bare-project"})
+    # register_project_v2 already created the store dir; deliberately skip
+    # scaffold_project_store so decisions/ never gets populated.
+    monkeypatch.chdir(repo)
+    return "bare-project", pid, store_path, repo
+
+
+# --- compute_check_decision (helper) preserves wrapper output -----------------
+
+
+def test_helper_and_wrapper_return_same_shape(demo_repo):
+    """compute_check_decision and tool_check_decision must return identical
+    dicts — the refactor that extracted the helper must not have drifted the
+    response shape that MCP callers depend on.
+    """
+    _, _, store_path, _ = demo_repo
+    helper = compute_check_decision(store_path, DEMO_PROMPT)
+    wrapper = tool_check_decision(store_path, DEMO_PROMPT)
+    assert helper == wrapper
+    assert helper["store"] == "local"
+    assert "related_decisions" in helper
+    assert "assessment" in helper
+
+
+# --- happy path: demo prompt retrieves D004 ----------------------------------
+
+
+def test_demo_prompt_returns_sse_decision(demo_repo):
+    result = runner.invoke(app, ["check", DEMO_PROMPT])
+    assert result.exit_code == 0, result.output
+    # The canonical demo conflict is D004 (SSE over WebSocket).
+    assert "D004" in result.output
+    assert "SSE over WebSocket" in result.output
+    # Header lines we want users to see.
+    assert "store:" in result.output
+    assert "project:" in result.output
+    assert "approach:" in result.output
+    assert "Related decisions" in result.output
+    # Tail line points at decision files, not a non-existent CLI command.
+    assert "decisions/" in result.output
+    assert "get_decision MCP tool" in result.output
+
+
+def test_demo_prompt_json_output_is_parseable(demo_repo):
+    result = runner.invoke(app, ["check", DEMO_PROMPT, "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["store"] == "local"
+    assert "related_decisions" in payload
+    assert "assessment" in payload
+    titles = [d["title"] for d in payload["related_decisions"]]
+    assert any("SSE over WebSocket" in t for t in titles)
+
+
+def test_json_output_has_no_pre_header(demo_repo):
+    """--json output must be valid JSON from the first character — no human
+    header lines printed before it.
+    """
+    result = runner.invoke(app, ["check", DEMO_PROMPT, "--json"])
+    assert result.exit_code == 0
+    assert result.output.lstrip().startswith("{")
+
+
+# --- error and empty-store paths --------------------------------------------
+
+
+def test_no_project_resolution_errors(tmp_path, monkeypatch):
+    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["check", DEMO_PROMPT])
+    assert result.exit_code == 1
+    assert "No project found" in result.output
+
+
+def test_no_decisions_store_returns_no_decisions_message(no_decisions_repo):
+    """A store with no decisions/ directory hits the NO_DECISIONS_TO_CHECK
+    branch in compute_check_decision and surfaces the onboarding hint."""
+    result = runner.invoke(app, ["check", DEMO_PROMPT])
+    assert result.exit_code == 0, result.output
+    # The NO_DECISIONS_TO_CHECK constant points the user at `nauro note`.
+    assert "nauro note" in result.output or "decisions" in result.output.lower()
+    # Header still emits.
+    assert "store:" in result.output
+    assert "project:" in result.output
+
+
+def test_rejected_status_exits_nonzero_human(demo_repo):
+    """Input over MAX_APPROACH_LENGTH must exit 1 with the rejection reason."""
+    overlong = "x" * 10_000
+    result = runner.invoke(app, ["check", overlong])
+    assert result.exit_code == 1
+    assert "exceeds" in result.output.lower() or "too long" in result.output.lower()
+
+
+def test_rejected_status_exits_nonzero_json(demo_repo):
+    """Same rejection contract as the human path — a script piping --json and
+    checking $? must not see input-too-long as success.
+    """
+    overlong = "x" * 10_000
+    result = runner.invoke(app, ["check", overlong, "--json"])
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert payload["status"] == "rejected"
+    assert "reason" in payload
+
+
+# --- cloud-mode notice -------------------------------------------------------
+
+
+def test_cloud_mode_project_prints_stale_notice(tmp_path, monkeypatch):
+    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    pid, store_path = register_project_v2(
+        "cloud-project",
+        [repo],
+        mode=REPO_CONFIG_MODE_CLOUD,
+        project_id="01H" + "A" * 23,
+        server_url="https://example.invalid",
+    )
+    save_repo_config(
+        repo,
+        {
+            "mode": REPO_CONFIG_MODE_CLOUD,
+            "id": pid,
+            "name": "cloud-project",
+            "server_url": "https://example.invalid",
+        },
+    )
+    create_demo_project(store_path)
+    monkeypatch.chdir(repo)
+
+    result = runner.invoke(app, ["check", DEMO_PROMPT])
+    assert result.exit_code == 0, result.output
+    # Notice goes to stderr but the CliRunner merges streams by default.
+    assert "syncs to cloud" in result.output
+    assert "local copy" in result.output
+
+
+# --- telemetry: no mcp.tool_called from the CLI surface -----------------------
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.events: list[dict[str, Any]] = []
+
+    def capture(self, event: str, distinct_id: str, properties: dict[str, Any]) -> None:
+        self.events.append({"event": event, "properties": properties})
+
+
+@pytest.fixture
+def fake_posthog(monkeypatch):
+    import nauro.telemetry.client as client_mod
+
+    fake = _FakeClient()
+    client_mod._client = fake
+    yield fake
+    client_mod._client = None
+
+
+@pytest.fixture
+def telemetry_enabled(tmp_path, monkeypatch):
+    """Seed NAURO_HOME with a consented config so capture() actually fires."""
+    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
+    monkeypatch.setenv("NAURO_POSTHOG_KEY", "phc_test_key_for_unit_tests")
+    aid = "11111111-1111-4111-8111-111111111111"
+    (tmp_path / "config.json").write_text(
+        json.dumps(
+            {
+                "telemetry": {
+                    "anonymous_id": aid,
+                    "enabled": True,
+                    "consent_version": 1,
+                    "consented_at": "2026-04-30T00:00:00Z",
+                }
+            }
+        )
+    )
+    return aid
+
+
+def test_cli_check_emits_no_mcp_tool_called_event(
+    tmp_path, monkeypatch, telemetry_enabled, fake_posthog
+):
+    """The CLI path skips the @mcp_tool decorator's mcp.tool_called emission.
+
+    Guards the helper-extraction refactor: if a future change reverts the CLI
+    to calling tool_check_decision directly, this test fails.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    pid, store_path = register_project_v2("telem-project", [repo], mode=REPO_CONFIG_MODE_LOCAL)
+    save_repo_config(repo, {"mode": REPO_CONFIG_MODE_LOCAL, "id": pid, "name": "telem-project"})
+    create_demo_project(store_path)
+    monkeypatch.chdir(repo)
+
+    result = runner.invoke(app, ["check", DEMO_PROMPT])
+    assert result.exit_code == 0, result.output
+
+    event_names = [e["event"] for e in fake_posthog.events]
+    assert "mcp.tool_called" not in event_names
+    # The Typer auto-instrumentation should still emit cli.command_invoked.
+    assert "cli.command_invoked" in event_names
+    cli_event = next(e for e in fake_posthog.events if e["event"] == "cli.command_invoked")
+    assert cli_event["properties"]["command"] == "check"


### PR DESCRIPTION
## Why

The current "show me a demo" path ends with "open Claude Code and ask…" — which
doesn't help an agent already running in Claude Code: that agent can't access
the MCP server it just wired until restart. The wow-moment (`check_decision`
surfacing a conflict) only lands after the restart, killing demo momentum.

`nauro check "<approach>"` is the L1 bridge in the progressive-enhancement
onboarding plan: an agent or developer with the CLI installed can run
conflict-detection in the current session, no MCP wiring, no restart. The
output is the same retrieval the MCP `check_decision` tool returns; nothing
is written.

## Approach

Three pieces:

1. **Extract `compute_check_decision` helper** from `tool_check_decision`. The
   CLI calls the helper directly so the `@mcp_tool` decorator's
   `mcp.tool_called` telemetry emission doesn't fire on CLI invocations —
   that surface emits its own `cli.command_invoked` via Typer instrumentation.
   MCP callers see no behavior change; `tool_check_decision` is now a thin
   wrapper.

2. **New `check.py` CLI command.** Resolves the project via the existing
   `resolve_target_project` convention, calls `compute_check_decision`,
   renders human-readable output (or `--json` raw). Cloud-mode projects get
   a stderr notice that CLI check uses the local copy — full cloud-mode CLI
   check is deferred until the local surface settles. JSON and human paths
   share one `is_error` check so a script piping `--json` and checking `$?`
   sees both `error` (missing store) and `rejected` (input over
   `MAX_APPROACH_LENGTH`) as exit 1.

3. **Drive-by fix in `nauro-core/search.py`:** `show_progress=False` on every
   `bm25s` call. The library defaults to True, which prints tqdm progress
   bars to stderr — fine inside an MCP server process but it was leaking
   into `nauro check` CLI output and into agent stderr logs as visual noise.
   Guarded by new `TestBm25SilencesProgressBars` in nauro-core's test_search.

Alternatives considered:

- **Call `tool_check_decision` directly from CLI** — rejected; the
  `@mcp_tool` decorator would emit a misleading `mcp.tool_called` event
  with transport set to whatever `current_transport()` happened to be in
  the CLI context.
- **Refactor `check_decision` into `nauro-core` so local + remote MCP and
  CLI all share one canonical shape** — rejected here; deferred to a
  separate decision per the plan. The response shape isn't fully settled
  (D117/D130 reconciliation was recent), and the drift between local and
  remote isn't currently painful enough to justify cross-repo
  coordination.

## What changed

- `packages/nauro/src/nauro/mcp/tools.py` — new `compute_check_decision`;
  `tool_check_decision` becomes a thin wrapper.
- `packages/nauro/src/nauro/cli/commands/check.py` (new) — Typer command.
- `packages/nauro/src/nauro/cli/main.py` — register `check` between `note`
  and `sync`.
- `packages/nauro-core/src/nauro_core/search.py` — `show_progress=False` on
  every bm25s call in `bm25_search` and `bm25_retrieve`.
- `packages/nauro/tests/test_check_command.py` (new) — 10 tests covering
  helper/wrapper shape parity, demo-prompt retrieval, JSON output and pre-
  header guard, missing project, no-decisions store, cloud-mode notice,
  rejected-status exit code on both human and JSON paths, and the
  telemetry guard.
- `packages/nauro-core/tests/test_search.py` — `TestBm25SilencesProgressBars`
  asserts no stderr output from `bm25_search` / `bm25_retrieve`.
- `README.md`, `packages/nauro/README.md` — demo Quickstart prepends
  `mkdir -p /tmp/nauro-demo && cd /tmp/nauro-demo` to dodge the
  `_check_config_overwrite` guard (D136). Final step ("Open Claude Code and
  ask…") unchanged; the full Quickstart rewrite to use `nauro check`
  directly is PR 3.

## What to review

- The helper/wrapper refactor preserves the dict shape exactly (guarded by
  `test_helper_and_wrapper_return_same_shape`).
- `test_cli_check_emits_no_mcp_tool_called_event` is the load-bearing test
  for the decorator bypass — if a future change reverts the CLI to calling
  `tool_check_decision` directly, this test fails.
- **JSON exit-code branch in `check.py`:** `is_error` is computed once and
  consumed by both `--json` and human paths so the rejection contract
  matches across surfaces. Worth a glance — it's the non-obvious correctness
  path.
- The cloud-mode notice writes to stderr so `--json` output stays parseable
  from the first character (`test_json_output_has_no_pre_header` guards
  this).
- bm25s `show_progress=False` propagated to all four call sites in both
  `bm25_search` and `bm25_retrieve`.
- The Quickstart now has 4 steps where it had 3. Considered keeping it at 3
  with the sandbox inlined into step 1; broke it out instead for
  readability. Easy to revert if preferred.

## What's deferred

- **Cloud-mode `nauro check`** — full remote check against `POST /mcp`
  JSON-RPC. Needs Auth0 JWT, project-id resolution, quota accounting, and
  the remote shape currently differs.
- **README restructure** — Install + Quickstart promoted to top, final step
  rewritten to use `nauro check` directly with literal expected output, the
  `## For your AI agent` section near top. Tracked as PR 3 in the
  progressive-enhancement onboarding plan.
- **Setup discoverability hint** — `nauro setup` claude-code/cursor/all
  success output advertising `nauro check` as the no-restart bridge.
  Tracked as PR 4.
- **Cross-repo unification of `check_decision` response shape**
  (local MCP / remote MCP / CLI). Captured as a separate Nauro decision;
  revisit when cloud-mode CLI ships or a customer reports drift.
- **Windows-friendly demo path** — current Quickstart uses
  `/tmp/nauro-demo` which is Unix-only. Audience for the demo skews
  mac/linux; revisit if a Windows user reports the friction.
- **mcp-server (remote) nauro-core bump** — the tqdm fix lives in
  nauro-core, so a follow-up bump of the remote's nauro-core pin
  propagates the fix to remote `check_decision` stderr. Separate repo,
  separate PR.

## Test plan

- `uv run pytest packages/nauro/tests/ -x -q -m "not integration"` —
  897 passed (887 prior + 10 new minus 1 replaced + change in delta).
- `uv run pytest packages/nauro-core/tests/ -x -q` — 306 passed (304
  prior + 2 new stderr-silence tests).
- `uv run ruff check packages/` — clean.
- `uv run ruff format --check packages/` — clean.
- Manual smoke test from a fresh tmp dir:

  ```
  $ mkdir -p /tmp/nauro-demo-smoke && cd /tmp/nauro-demo-smoke
  $ NAURO_HOME=$(mktemp -d) nauro init --demo
  $ nauro check "Add a WebSocket endpoint for live task updates"
  store:    local
  project:  demo-project
  approach: Add a WebSocket endpoint for live task updates

  Related decisions (5):
    004-sse-over-websocket  SSE over WebSocket for live task updates  (score 5.0, ...)
    002-rest-api-over-graphql  REST API over GraphQL for simplicity  (score 2.4, ...)
    ...

  Found 5 related decisions. Top match: D004 "SSE over WebSocket for live task
  updates" (status active, decided 2026-03-15, BM25 5.0). Call get_decision on
  each related decision before proposing.

  For full rationale, read decision files in <store>/decisions/, or call the
  get_decision MCP tool after `nauro setup` + restart.
  ```

  D004 surfaces at the top with BM25 5.0; no tqdm noise on stderr.