### PR TITLE
docs(readme): restructure for fast onboarding + use nauro check in Quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,76 @@
 
 Set the doctrine once. Every agent inherits it.
 
-Nauro is an open-source system that gives AI agents persistent project context across tools and sessions.
+Nauro is an open-source system that gives AI agents persistent project context across Claude, Perplexity, Cursor, Codex, and any MCP client. It captures decisions, rejected options, rationale, and constraints, then checks every new proposal against that record — so agents stop re-suggesting approaches you already ruled out.
 
-It captures a project's decisions, rejected options, rationale, constraints, current state, and open questions, then makes that context available across Claude, Perplexity, Cursor, Codex, and any MCP client.
+## Install
 
-Nauro is designed for individuals and teams using multiple agents across coding, research, planning, documentation, and product work.
+```bash
+pipx install nauro   # or: pip install nauro
+```
 
-When an agent proposes work that conflicts with a recorded decision, Nauro surfaces the conflict in the session, before it ships.
+Requires Python 3.10+.
+
+## Quickstart
+
+Watch Nauro catch a conflict in 30 seconds — no account, no MCP wiring, no restart:
+
+```bash
+mkdir -p /tmp/nauro-demo && cd /tmp/nauro-demo
+nauro init --demo
+nauro check "Add a WebSocket endpoint for live task updates"
+```
+
+`nauro init --demo` seeds a sample project with 7 architectural decisions. `nauro check` runs the same conflict-detection logic the MCP `check_decision` tool uses, against your local store. You'll see:
+
+```
+store:    local
+project:  demo-project
+approach: Add a WebSocket endpoint for live task updates
+
+Related decisions (5):
+  004-sse-over-websocket  SSE over WebSocket for live task updates  (score 5.0, status active, decided 2026-03-15)
+  002-rest-api-over-graphql  REST API over GraphQL for simplicity  (score 2.4, status active, decided 2026-03-15)
+  006-cursor-based-pagination  Cursor-based pagination, not offset  (score 1.3, status active, decided 2026-03-15)
+  003-monorepo-with-turborepo  Monorepo with Turborepo over polyrepo  (score 1.0, status active, decided 2026-03-15)
+  007-hard-delete-with-audit-log  Hard delete with audit log, no soft deletes  (score 0.5, status active, decided 2026-03-15)
+
+Found 5 related decisions. Top match: D004 "SSE over WebSocket for live task updates" (status active, decided 2026-03-15, BM25 5.0). Call get_decision on each related decision before proposing.
+
+For full rationale, read decision files in ~/.nauro/projects/<project-id>/decisions/, or call the get_decision MCP tool after `nauro setup` + restart.
+```
+
+The team already chose SSE over WebSocket because persistent WebSocket connections weren't released during ECS rolling deploys. Without Nauro, any new agent would happily re-propose WebSocket and waste a session debating it.
+
+That's the demo. To set up Nauro against your actual project, see [Set up Nauro for your project](#set-up-nauro-for-your-project) below — don't run `nauro setup` from `/tmp/nauro-demo` or you'll wire the throwaway demo into your real MCP client.
+
+## For your AI agent
+
+If a user said "set up Nauro" or "show me a demo," pick the matching path:
+
+### "Show me a demo" — current session, no restart
+
+```bash
+pipx install nauro
+mkdir -p /tmp/nauro-demo && cd /tmp/nauro-demo
+nauro init --demo
+nauro check "Add a WebSocket endpoint for live task updates"
+```
+
+`nauro check` is the L1 surface: same retrieval the MCP `check_decision` tool uses, runnable from your current shell with no MCP wiring required. Surface D004 (SSE over WebSocket) to the user and explain it was chosen because persistent WebSocket connections weren't released during ECS rolling deploys. If the user then wants Nauro wired against their actual project (not the throwaway demo), continue to the "Set up Nauro for my project" path below.
+
+### "Set up Nauro for my project" — existing repo with code
+
+```bash
+pipx install nauro
+nauro adopt
+```
+
+`nauro adopt` registers the project, wires MCP across installed agents (Claude Code, Cursor, Codex), and installs a `/nauro-adopt` skill. Tell the user: "Restart your agent and invoke `/nauro-adopt` — I'll read your existing docs and seed Nauro's decision log."
+
+### Chat surfaces (Claude.ai, ChatGPT, Perplexity) — no shell
+
+Have the user run `nauro adopt` from a local terminal first, then point the chat agent at [`docs/adopt-prompt.md`](docs/adopt-prompt.md).
 
 ## Why Nauro
 
@@ -22,46 +85,29 @@ The context resets. The drift does not.
 
 Nauro gives agents a shared project record, then checks new proposals against the decisions already on file.
 
-## Install
+## Set up Nauro for your project
 
-```bash
-pipx install nauro   # or: pip install nauro
-```
+Pick one path based on what you're starting from.
 
-Requires Python 3.10+.
-
-## Quickstart
-
-Try the demo locally in 2 minutes — no account needed.
-
-1. Set up a sandbox: `mkdir -p /tmp/nauro-demo && cd /tmp/nauro-demo` (keeps the demo isolated from any existing project's `.nauro/config.json`).
-2. `nauro init --demo` — scaffold a sample project with 7 decisions, project state, and open questions.
-3. `nauro setup claude-code` — write the MCP entry to `<repo>/.mcp.json`.
-4. Open Claude Code and ask: *"Check if we should add a WebSocket endpoint for live task updates"*
-
-`check_decision` surfaces a conflict: the team already chose SSE over WebSocket because persistent connections weren't released during ECS rolling deploys.
-
-## Use with your project
+**New project — empty or near-empty repo, you'll capture decisions as you make them:**
 
 ```bash
 nauro init my-project
 nauro note "All processing stays in the request path, no background workers. Async queue added 3 failure modes we couldn't monitor in v1"
-nauro setup claude-code
+nauro setup claude-code   # or: nauro setup all
 ```
 
-`nauro init` writes a small `.nauro/config.json` into your repo (commit it — it links the repo to the project so any `nauro` command you run from inside this repo knows which project to use). To start with cloud sync from day one, use `nauro init --cloud my-project` instead.
+`nauro init` writes a small `.nauro/config.json` into your repo (commit it — it links the repo to the project so any `nauro` command run from inside the repo knows which project to use). To start with cloud sync from day one, use `nauro init --cloud my-project`.
 
-Agents propose decisions directly through MCP during sessions. When a proposal overlaps with existing decisions, you confirm before it's written.
-
-## Adopt an existing repo
-
-For a repo that already has docs — README, ADRs, Memory-Bank files, manifests:
+**Existing repo — already has docs (README, ADRs, Memory-Bank files, manifests) you want to seed Nauro from:**
 
 ```bash
 nauro adopt
 ```
 
-Run from the repo root. `nauro adopt` creates the project, wires MCP across your installed agents (Claude Code, Cursor, Codex), and drops a portable skill into your agent. Invoke `/nauro-adopt` in any connected agent and it reads your existing docs, surfaces decision candidates for you to keep or skip, then seeds the store one decision at a time. The agent does the reading — no API key required server-side.
+`nauro adopt` runs the full setup (project registration, MCP wiring across surfaces, skill installation) in one shot. After it finishes, restart your agent and invoke `/nauro-adopt` — the agent reads your existing docs, surfaces decision candidates for you to keep or skip, then seeds the store one decision at a time. The agent does the reading; no API key required server-side.
+
+Either path: agents propose decisions through MCP during sessions. When a proposal overlaps with existing decisions, you confirm before it's written.
 
 ## Use across surfaces
 
@@ -111,18 +157,6 @@ Nauro is decisional, not observational. Memory tools preserve conversation histo
 
 The `check_decision` → `propose_decision` → `confirm_decision` pipeline surfaces conflicts for you to confirm before they're written, across any connected surface. A decision recorded from one connected tool surfaces in every other one. Your decisions stay yours, not your platform's.
 
-## Your data
-
-**Local usage (free tier):** Everything runs on your machine. The store lives under `~/.nauro/` and never leaves the device unless you turn on cloud sync.
-
-**Cloud sync:** Project context (decisions, state, open questions — not source code) is stored encrypted in AWS S3 (SSE-S3). Each user's data is isolated under a unique prefix.
-
-**Remote MCP:** When connected, your project context is read from S3 and delivered to the AI tool. The AI tool's own data policies apply after delivery.
-
-## Pricing
-
-Free: unlimited local usage, unlimited projects, 5,000 remote MCP calls/month. A typical agent session uses 10–30 calls, so the free tier covers roughly 200+ sessions a month. See [nauro.ai/pricing](https://nauro.ai/pricing) for hosted tiers.
-
 ## MCP tools
 
 12 tools (8 read, 4 write) exposed to any connected MCP client:
@@ -135,12 +169,26 @@ Free: unlimited local usage, unlimited projects, 5,000 remote MCP calls/month. A
 - `search_decisions` — keyword search across decision titles and rationale (BM25)
 - `get_raw_file` — raw markdown content of any store file
 - `diff_since_last_session` — what changed since your last session (or N days ago)
-- `list_projects` — list projects you have access to (only needed when you have multiple — single-project users auto-resolve)
+- `list_projects` — list projects you have access to (remote-only; single-project users auto-resolve)
 
 **Write:**
 - `propose_decision` / `confirm_decision` — write decisions with conflict validation
 - `flag_question` — flag an unresolved question
 - `update_state` — report progress
+
+`nauro check "<approach>"` runs `check_decision` from the shell — useful for in-session demos and scripted conflict checks without MCP wiring.
+
+## Your data
+
+**Local usage (free tier):** Everything runs on your machine. The store lives under `~/.nauro/` and never leaves the device unless you turn on cloud sync.
+
+**Cloud sync:** Project context (decisions, state, open questions — not source code) is stored encrypted in AWS S3 (SSE-S3). Each user's data is isolated under a unique prefix.
+
+**Remote MCP:** When connected, your project context is read from S3 and delivered to the AI tool. The AI tool's own data policies apply after delivery.
+
+## Pricing
+
+Free: unlimited local usage, unlimited projects, 5,000 remote MCP calls/month. A typical agent session uses 10–30 calls, so the free tier covers roughly 200+ sessions a month. See [nauro.ai/pricing](https://nauro.ai/pricing) for hosted tiers.
 
 ## Contributing
 

--- a/packages/nauro/README.md
+++ b/packages/nauro/README.md
@@ -14,19 +14,36 @@ Requires Python 3.10+.
 
 ## Quickstart
 
+Watch Nauro catch a conflict in 30 seconds — no account, no MCP wiring, no restart:
+
 ```bash
 mkdir -p /tmp/nauro-demo && cd /tmp/nauro-demo
 nauro init --demo
-nauro setup claude-code   # writes the MCP entry to <repo>/.mcp.json
+nauro check "Add a WebSocket endpoint for live task updates"
 ```
 
-Open Claude Code and ask:
+You'll see:
 
-> "Check if we should add a WebSocket endpoint for live task updates"
+```
+store:    local
+project:  demo-project
+approach: Add a WebSocket endpoint for live task updates
 
-The demo creates a sample project with 7 decisions, project state, and open questions. `check_decision` surfaces a conflict: the team already chose SSE over WebSocket because persistent connections weren't released during ECS rolling deploys. No account needed.
+Related decisions (5):
+  004-sse-over-websocket  SSE over WebSocket for live task updates  (score 5.0, status active, decided 2026-03-15)
+  002-rest-api-over-graphql  REST API over GraphQL for simplicity  (score 2.4, status active, decided 2026-03-15)
+  006-cursor-based-pagination  Cursor-based pagination, not offset  (score 1.3, status active, decided 2026-03-15)
+  003-monorepo-with-turborepo  Monorepo with Turborepo over polyrepo  (score 1.0, status active, decided 2026-03-15)
+  007-hard-delete-with-audit-log  Hard delete with audit log, no soft deletes  (score 0.5, status active, decided 2026-03-15)
 
-For real-project setup, cross-surface access, MCP tool reference, and architecture details, see the [main project README](https://github.com/nauro-ai/nauro#readme).
+Found 5 related decisions. Top match: D004 "SSE over WebSocket for live task updates" (status active, decided 2026-03-15, BM25 5.0). Call get_decision on each related decision before proposing.
+
+For full rationale, read decision files in ~/.nauro/projects/<project-id>/decisions/, or call the get_decision MCP tool after `nauro setup` + restart.
+```
+
+The demo project ruled out WebSocket because persistent connections weren't released during ECS rolling deploys. Without Nauro, any new agent would happily re-propose it.
+
+For real-project setup (`nauro init` / `nauro adopt`), cross-surface access, MCP tool reference, and architecture details, see the [main project README](https://github.com/nauro-ai/nauro#readme). Don't run `nauro setup` from `/tmp/nauro-demo` — that would wire the throwaway demo into your MCP client.
 
 ## Why Nauro?
 


### PR DESCRIPTION
## Why

The README was optimized for evaluators — "Why Nauro" sat above Install, Quickstart still told the reader to "open Claude Code and ask," and the wow-moment was described in prose ("`check_decision` surfaces a conflict…") rather than shown. None of that helps an agent already running in Claude Code: the agent can't access an MCP server it hasn't wired and restarted into, so the demo path never landed in the current session.

This PR closes that gap by leveraging the `nauro check` CLI shipped in PR 2 (#52) — the L1 surface that runs the same retrieval as the MCP `check_decision` tool, in the current shell, no wiring or restart required.

## Approach

1. **Promote Install + Quickstart to the top.** Trim the hook to one paragraph; move the longer "Why Nauro" narrative below.
2. **Rewrite Quickstart to use `nauro check`** and show its literal output. The output block matches the real CLI line-for-line except the trailing decisions/ path uses `~/.nauro/projects/<project-id>/decisions/` as a placeholder (the actual emission is a per-user absolute path).
3. **New `## For your AI agent` section near the top.** Three paste-and-run blocks (demo / existing-repo / chat-surface) so agents reading the README via WebFetch can pick a path without scanning the human-oriented narrative.

Also:
- Merge "Use with your project" + "Adopt an existing repo" into one `## Set up Nauro for your project` section with explicit new-project / existing-repo signposts so readers know to pick one.
- Move MCP tools reference up to section 10 (was 12) and correct the `list_projects` description to "remote-only" (verified against `packages/nauro/src/nauro/mcp/stdio_server.py` — local stdio doesn't register `tool_list_projects`).
- Drop the "now run `nauro setup all`" line from both demo flows. Following that from inside `/tmp/nauro-demo` would wire the throwaway demo into the user's MCP client. Persistence belongs in the "Set up Nauro for your project" section that immediately follows.

`packages/nauro/README.md` (PyPI page) gets the matching Quickstart rewrite. The Peter Naur attribution at the bottom is preserved (was inadvertently dropped in an earlier rev; restored here).

## What changed

- `README.md` — full restructure plus literal Quickstart output, new `## For your AI agent` section, merged set-up-your-project section, MCP tools moved up.
- `packages/nauro/README.md` — Quickstart rewritten to mirror the root README; Peter Naur attribution intact.

No code changes.

## What to review

- **Quickstart output block in both READMEs.** Compare line-for-line to the actual `nauro check` output (run from `/tmp/nauro-demo` after `nauro init --demo`). Should match byte-for-byte except the trailing decisions/ path, which uses `~/.nauro/projects/<project-id>/decisions/` as a placeholder. The assessment line is a single long line to match the CLI's emission — accept the horizontal scroll over inconsistent hard-wrapping.
- **`/tmp/nauro-demo` handoff.** The demo Quickstart and the agent-block "Show me a demo" both explicitly tell the reader *not* to run `nauro setup` from the demo directory and hand off to the dedicated section. Worth confirming the wording reads naturally.
- **`## For your AI agent` placement.** Putting agent-facing instructions in the README (not just AGENTS.md / CLAUDE.md) is a new pattern with some drift risk against AGENTS.md guidance over time. Reasoning: an agent encountering Nauro via a repo URL hits the README first; AGENTS.md is in-session context, README is the gateway.
- **`list_projects` description correction** (remote-only). Slipped in as a side-effect of touching the MCP tools section; verified against `stdio_server.py:16` and the missing `tool_list_projects` import in the local stdio entry point.

## What's deferred

- A drift test that runs `nauro check` and asserts the README's literal block still matches. Worth doing later; not blocking.
- **Setup discoverability hint** — `nauro setup` claude-code/cursor/all success output advertising `nauro check` as the no-restart bridge. Tracked as PR 4 in the progressive-enhancement onboarding plan.
- **Windows-friendly demo path** — `/tmp/nauro-demo` is still Unix-only; audience for the demo skews mac/linux. Revisit if a Windows user files an issue.

## Test plan

- `uv run pytest packages/nauro/tests/ packages/nauro-core/tests/ -x -q -m "not integration"` — 1203 passed (no test deltas; doc-only PR).
- `uv run ruff check packages/` — clean.
- `uv run ruff format --check packages/` — clean.
- Manual: ran `nauro check "Add a WebSocket endpoint for live task updates"` against a fresh `/tmp/nauro-demo` init; output matches the README block (modulo the placeholder path).