### PR TITLE
feat(setup): advertise nauro check as a no-wait shortcut in setup output

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/setup.py
+++ b/packages/nauro/src/nauro/cli/commands/setup.py
@@ -42,6 +42,12 @@ setup_app = typer.Typer(help="Configure tool integrations.")
 CLAUDE_MD_START = NAURO_BLOCK_START
 CLAUDE_MD_END = NAURO_BLOCK_END
 
+# Discoverability hint appended to every setup-add success path. `nauro check`
+# (the L1 surface) works from the current shell against the local store, so
+# users don't have to wait for an agent restart to see Nauro do something
+# useful. Imported by test_setup_extended.py to assert placement.
+CHECK_HINT_LINE = 'Try it now from this shell: nauro check "<approach>"'
+
 
 def _remove_claude_md(repo_path: Path) -> str | None:
     """Remove a legacy Nauro block from CLAUDE.md if present.
@@ -224,6 +230,7 @@ def claude_code(
             "\nNext: start a Claude Code session in one of the repos."
             " The MCP server will start automatically."
         )
+        typer.echo(f"\n{CHECK_HINT_LINE}")
 
 
 # ─── Cursor ─────────────────────────────────────────────────────────────────
@@ -301,6 +308,7 @@ def cursor(
 
     if not remove:
         typer.echo("\nNext: open this repo in Cursor and start a chat — Nauro MCP will connect.")
+        typer.echo(f"\n{CHECK_HINT_LINE}")
 
 
 # ─── Codex CLI ──────────────────────────────────────────────────────────────
@@ -374,6 +382,7 @@ def codex(
     typer.echo(_configure_codex(remove=remove, clear_user_scope=clear_user_scope))
     if not remove:
         typer.echo("\nNext: run a Codex session — it reads ~/.codex/config.toml on start.")
+        typer.echo(f"\n{CHECK_HINT_LINE}")
 
 
 # ─── Skill materialization ──────────────────────────────────────────────────
@@ -579,3 +588,6 @@ def all_(
     typer.echo(f"{action} Nauro for project '{project_name}' across all surfaces:\n")
     for line in setup_all_surfaces(project_repos, remove=remove, current_project_key=project_key):
         typer.echo(line)
+
+    if not remove:
+        typer.echo(f"\n{CHECK_HINT_LINE}")

--- a/packages/nauro/tests/test_setup_extended.py
+++ b/packages/nauro/tests/test_setup_extended.py
@@ -9,7 +9,11 @@ from pathlib import Path
 
 from typer.testing import CliRunner
 
-from nauro.cli.commands.setup import _configure_codex, _configure_cursor_for_repo
+from nauro.cli.commands.setup import (
+    CHECK_HINT_LINE,
+    _configure_codex,
+    _configure_cursor_for_repo,
+)
 from nauro.cli.main import app
 from nauro.store.registry import register_project_v2
 from nauro.templates.scaffolds import scaffold_project_store
@@ -374,3 +378,77 @@ def test_standalone_codex_remove_preserves_when_projects_remain(tmp_path: Path, 
     with codex_config.open("rb") as f:
         data = tomllib.load(f)
     assert data["mcp_servers"]["nauro"]["args"] == ["serve", "--stdio"]
+
+
+# ─── nauro check discoverability hint ───────────────────────────────────────
+
+
+def test_setup_claude_code_advertises_nauro_check(tmp_path: Path, monkeypatch):
+    """`setup claude-code` success output points users at the L1 surface."""
+    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    register_project_v2("myproj", [repo])
+    monkeypatch.chdir(repo)
+    _mock_claude_cli(monkeypatch)
+
+    result = runner.invoke(app, ["setup", "claude-code"])
+    assert result.exit_code == 0, result.output
+    assert CHECK_HINT_LINE in result.output
+
+
+def test_setup_claude_code_remove_does_not_advertise_nauro_check(tmp_path: Path, monkeypatch):
+    """The hint only fires on the add path — removal output stays minimal."""
+    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    register_project_v2("myproj", [repo])
+    monkeypatch.chdir(repo)
+    _mock_claude_cli(monkeypatch)
+
+    result = runner.invoke(app, ["setup", "claude-code", "--remove"])
+    assert result.exit_code == 0, result.output
+    assert CHECK_HINT_LINE not in result.output
+
+
+def test_setup_cursor_advertises_nauro_check(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    _, store_path = register_project_v2("myproj", [repo])
+    scaffold_project_store("myproj", store_path)
+    monkeypatch.chdir(repo)
+
+    result = runner.invoke(app, ["setup", "cursor"])
+    assert result.exit_code == 0, result.output
+    assert CHECK_HINT_LINE in result.output
+
+
+def test_setup_all_advertises_nauro_check(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    _, store_path = register_project_v2("myproj", [repo])
+    scaffold_project_store("myproj", store_path)
+    monkeypatch.chdir(repo)
+    _mock_claude_cli(monkeypatch)
+
+    result = runner.invoke(app, ["setup", "all"])
+    assert result.exit_code == 0, result.output
+    assert CHECK_HINT_LINE in result.output
+
+
+def test_setup_codex_advertises_nauro_check(tmp_path: Path, monkeypatch):
+    """`setup codex` also advertises `nauro check` — a Codex user benefits from
+    knowing they can demo conflict-detection from the shell before opening a
+    Codex session.
+    """
+    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    result = runner.invoke(app, ["setup", "codex"])
+    assert result.exit_code == 0, result.output
+    assert CHECK_HINT_LINE in result.output


### PR DESCRIPTION
## Why

Each `nauro setup` subcommand wires MCP but ends with "Next: start a Claude Code session" (or similar) — that next session is the *next* one, after open/restart. Until then, the user can't actually use the freshly-wired MCP tools. The `nauro check` CLI shipped in PR 2 (#52) fills exactly that gap: same retrieval as the MCP `check_decision` tool, runnable from the current shell.

This PR makes that discoverable. Without the hint, a user finishes `setup claude-code` and has no idea they can do something useful before opening their agent.

## Approach

Append one line to the success output of `setup claude-code`, `setup cursor`, `setup codex`, and `setup all`:

```
Try it now from this shell: nauro check "<approach>"
```

The line is defined once as a module-level `CHECK_HINT_LINE` constant in `setup.py` and reused at every emission site so test assertions share one source of truth with the actual output.

Hint is gated behind `if not remove:` so `--remove` teardown output stays minimal — locked by `test_setup_claude_code_remove_does_not_advertise_nauro_check`. Cursor / Codex / all teardown paths use the same gate; the claude-code negative test guards the pattern.

### Why this wording

Earlier iteration used `Available right now (no restart needed):`. That phrase presupposes a restart the reader hasn't been told about yet — they just installed; nothing is running to restart. "Try it now from this shell:" frames it as an alternative to the "Next: …" line above without invoking a phantom restart.

### Why codex is included

An earlier draft skipped `setup codex` on the grounds that its closing line ("Next: run a Codex session — it reads `~/.codex/config.toml` on start") doesn't carry restart semantics. On reflection, the inclusion of `nauro check` advice is just as useful to a Codex user *before* they open a session — the hint isn't about restarting, it's about doing something useful from the shell. Included with matching wording across all four surfaces.

## What changed

- `packages/nauro/src/nauro/cli/commands/setup.py` — new `CHECK_HINT_LINE` module-level constant; four new `typer.echo(f"\n{CHECK_HINT_LINE}")` lines at the end of `claude_code()`, `cursor()`, `codex()`, and `all_()` success paths.
- `packages/nauro/tests/test_setup_extended.py` — new `nauro check discoverability hint` test section. Five tests:
  - `test_setup_claude_code_advertises_nauro_check`
  - `test_setup_claude_code_remove_does_not_advertise_nauro_check`
  - `test_setup_cursor_advertises_nauro_check`
  - `test_setup_all_advertises_nauro_check`
  - `test_setup_codex_advertises_nauro_check`

  All five assert against the imported `CHECK_HINT_LINE` constant rather than a local string fragment, so a future wording change in `setup.py` propagates to the tests automatically.

## What to review

- **Wording.** `Try it now from this shell: nauro check "<approach>"`. The `<approach>` placeholder is intentional — it's a real positional arg on the L1 command (`packages/nauro/src/nauro/cli/commands/check.py:78`), so the advertised invocation actually parses.
- **Codex inclusion.** Reasoning above; flag for sanity-check.
- **Constant placement.** Module-level next to the existing `CLAUDE_MD_START` / `CLAUDE_MD_END` markers in `setup.py`. The block of three constants reads coherently; alternative would be a dedicated module, but the constant is one line and used only inside `setup.py` + its test.

## What's deferred

- mcp-server (remote) nauro-core bump to propagate PR 2's tqdm-silence fix to remote `check_decision`. Separate repo, separate PR.
- Cross-repo unification of `check_decision` response shape across local MCP, remote MCP, and CLI. Captured as a separate Nauro decision; revisit when cloud-mode CLI ships or a customer reports drift.
- Cloud-mode `nauro check` (full remote check via `POST /mcp` JSON-RPC).

## Test plan

- `uv run pytest packages/nauro/tests/ packages/nauro-core/tests/ -x -q -m "not integration"` — 1208 passed.
- `uv run ruff check packages/` — clean.
- `uv run ruff format --check packages/` — clean.
- Manual: ran `nauro setup claude-code` against a fresh test project; output ends with `Try it now from this shell: nauro check "<approach>"`. Ran with `--remove`; output omits the hint.