### PR TITLE
test: extract NAURO_HOME isolation and pending-state reset to shared fixtures

### DIFF
--- a/packages/nauro/tests/conftest.py
+++ b/packages/nauro/tests/conftest.py
@@ -15,3 +15,15 @@ def _isolate_cwd(tmp_path, monkeypatch):
     later override wins on the same monkeypatch instance.
     """
     monkeypatch.chdir(tmp_path)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_nauro_home(tmp_path, monkeypatch):
+    """Point NAURO_HOME at a tmp subdirectory so tests never see the dev's real store.
+
+    Mirrors the isolation rationale of ``_isolate_cwd``: a stray NAURO_HOME in
+    the dev's shell would leak the real ``~/.nauro/`` into the suite. Tests that
+    need a different layout (e.g. ``NAURO_HOME=tmp_path``) override on the same
+    monkeypatch instance; the later setenv wins.
+    """
+    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))

--- a/packages/nauro/tests/test_auth.py
+++ b/packages/nauro/tests/test_auth.py
@@ -19,10 +19,6 @@ from nauro.store.config import load_config, save_config
 runner = CliRunner()
 
 
-def _patch_home(monkeypatch, tmp_path):
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
-
-
 def _make_jwt(payload: dict) -> str:
     """Build a fake JWT (header.payload.signature) with the given payload."""
     header = base64.urlsafe_b64encode(json.dumps({"alg": "RS256"}).encode()).rstrip(b"=").decode()
@@ -118,7 +114,6 @@ def _simulate_callback_error(error: str = "access_denied"):
 
 class TestAuthLogin:
     def test_login_success(self, tmp_path, monkeypatch):
-        _patch_home(monkeypatch, tmp_path)
         monkeypatch.setenv("NAURO_API_URL", "https://test.api.example.com")
 
         fake_token = _make_jwt({"sub": "auth0|user123"})
@@ -177,7 +172,6 @@ class TestAuthLogin:
         assert config["auth"]["refresh_token"] == "refresh_xyz"
 
     def test_login_callback_error(self, tmp_path, monkeypatch):
-        _patch_home(monkeypatch, tmp_path)
 
         def fake_server_init(self, addr, handler_class):
             pass
@@ -212,7 +206,6 @@ class TestAuthLogin:
         assert "access_denied" in result.output
 
     def test_login_timeout(self, tmp_path, monkeypatch):
-        _patch_home(monkeypatch, tmp_path)
 
         def fake_server_init(self, addr, handler_class):
             pass
@@ -249,7 +242,6 @@ class TestAuthLogin:
         assert "timed out" in result.output
 
     def test_login_token_exchange_failure(self, tmp_path, monkeypatch):
-        _patch_home(monkeypatch, tmp_path)
 
         def fake_post(url, **kwargs):
             raise httpx.HTTPStatusError(
@@ -299,7 +291,6 @@ class TestAuthLogin:
 
 class TestAuthStatus:
     def test_status_authenticated(self, tmp_path, monkeypatch):
-        _patch_home(monkeypatch, tmp_path)
         save_config(
             {
                 "auth": {
@@ -317,13 +308,11 @@ class TestAuthStatus:
         assert "yes" in result.output  # refresh token present
 
     def test_status_not_authenticated(self, tmp_path, monkeypatch):
-        _patch_home(monkeypatch, tmp_path)
         result = runner.invoke(app, ["auth", "status"])
         assert result.exit_code == 1
         assert "Not authenticated" in result.output
 
     def test_status_no_refresh_token(self, tmp_path, monkeypatch):
-        _patch_home(monkeypatch, tmp_path)
         save_config(
             {
                 "auth": {
@@ -343,7 +332,6 @@ class TestAuthStatus:
 
 class TestAuthLogout:
     def test_logout(self, tmp_path, monkeypatch):
-        _patch_home(monkeypatch, tmp_path)
         save_config(
             {
                 "api_key": "sk-keep-this",
@@ -364,7 +352,6 @@ class TestAuthLogout:
         assert config["api_key"] == "sk-keep-this"
 
     def test_logout_not_authenticated(self, tmp_path, monkeypatch):
-        _patch_home(monkeypatch, tmp_path)
         result = runner.invoke(app, ["auth", "logout"])
         assert result.exit_code == 0
         assert "Not authenticated" in result.output
@@ -373,7 +360,6 @@ class TestAuthLogout:
         """Config file should have restricted permissions (0o600) after auth write."""
         import os
 
-        _patch_home(monkeypatch, tmp_path)
         save_config(
             {
                 "auth": {

--- a/packages/nauro/tests/test_cloud_projects.py
+++ b/packages/nauro/tests/test_cloud_projects.py
@@ -17,13 +17,8 @@ from nauro.sync.cloud_projects import (
 )
 
 
-def _patch_home(monkeypatch, tmp_path):
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
-
-
 def _seed_token(monkeypatch, tmp_path, token: str = "test-token") -> None:
     """Write a config.json with an OAuth access token, mirroring `nauro auth login`."""
-    _patch_home(monkeypatch, tmp_path)
     save_config({"auth": {"access_token": token, "sub": "auth0|test"}})
 
 
@@ -119,7 +114,6 @@ def test_create_project_network_error_renders_message(tmp_path, monkeypatch):
 
 def test_no_token_raises_before_request(tmp_path, monkeypatch):
     """Without a stored token, the client refuses to issue a request."""
-    _patch_home(monkeypatch, tmp_path)
     # No save_config call → no auth section.
     with pytest.raises(CloudProjectError) as exc:
         create_project("demo")

--- a/packages/nauro/tests/test_config.py
+++ b/packages/nauro/tests/test_config.py
@@ -11,11 +11,6 @@ from nauro.store.config import (
     unset_config,
 )
 
-
-def _patch_home(monkeypatch, tmp_path):
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
-
-
 runner = CliRunner()
 
 
@@ -23,48 +18,40 @@ runner = CliRunner()
 
 
 def test_load_config_empty(tmp_path, monkeypatch):
-    _patch_home(monkeypatch, tmp_path)
     assert load_config() == {}
 
 
 def test_save_and_load_config(tmp_path, monkeypatch):
-    _patch_home(monkeypatch, tmp_path)
     save_config({"secret_key": "sk-test-123"})
     assert load_config() == {"secret_key": "sk-test-123"}
 
 
 def test_set_and_get_config(tmp_path, monkeypatch):
-    _patch_home(monkeypatch, tmp_path)
     set_config("secret_key", "sk-test-456")
     assert get_config("secret_key") == "sk-test-456"
 
 
 def test_get_config_missing(tmp_path, monkeypatch):
-    _patch_home(monkeypatch, tmp_path)
     assert get_config("nonexistent") is None
 
 
 def test_set_config_overwrites(tmp_path, monkeypatch):
-    _patch_home(monkeypatch, tmp_path)
     set_config("secret_key", "old")
     set_config("secret_key", "new")
     assert get_config("secret_key") == "new"
 
 
 def test_unset_config(tmp_path, monkeypatch):
-    _patch_home(monkeypatch, tmp_path)
     set_config("secret_key", "sk-test")
     assert unset_config("secret_key") is True
     assert get_config("secret_key") is None
 
 
 def test_unset_config_missing(tmp_path, monkeypatch):
-    _patch_home(monkeypatch, tmp_path)
     assert unset_config("nonexistent") is False
 
 
 def test_set_preserves_other_keys(tmp_path, monkeypatch):
-    _patch_home(monkeypatch, tmp_path)
     set_config("secret_key", "sk-test")
     set_config("model", "haiku")
     assert get_config("secret_key") == "sk-test"
@@ -75,7 +62,6 @@ def test_set_preserves_other_keys(tmp_path, monkeypatch):
 
 
 def test_config_get_cli(tmp_path, monkeypatch):
-    _patch_home(monkeypatch, tmp_path)
     set_config("secret_key", "sk-ant-abcd1234efgh5678")
     result = runner.invoke(app, ["config", "get", "secret_key"])
     assert result.exit_code == 0
@@ -85,14 +71,12 @@ def test_config_get_cli(tmp_path, monkeypatch):
 
 
 def test_config_get_missing_cli(tmp_path, monkeypatch):
-    _patch_home(monkeypatch, tmp_path)
     result = runner.invoke(app, ["config", "get", "nonexistent"])
     assert result.exit_code == 1
     assert "(not set)" in result.output
 
 
 def test_config_list_cli(tmp_path, monkeypatch):
-    _patch_home(monkeypatch, tmp_path)
     set_config("secret_key", "sk-ant-abcd1234efgh5678")
     set_config("model", "haiku")
     result = runner.invoke(app, ["config", "list"])
@@ -102,14 +86,12 @@ def test_config_list_cli(tmp_path, monkeypatch):
 
 
 def test_config_list_empty_cli(tmp_path, monkeypatch):
-    _patch_home(monkeypatch, tmp_path)
     result = runner.invoke(app, ["config", "list"])
     assert result.exit_code == 0
     assert "No configuration set" in result.output
 
 
 def test_config_unset_cli(tmp_path, monkeypatch):
-    _patch_home(monkeypatch, tmp_path)
     set_config("secret_key", "sk-test")
     result = runner.invoke(app, ["config", "unset", "secret_key"])
     assert result.exit_code == 0
@@ -119,7 +101,6 @@ def test_config_unset_cli(tmp_path, monkeypatch):
 
 
 def test_config_unset_missing_cli(tmp_path, monkeypatch):
-    _patch_home(monkeypatch, tmp_path)
     result = runner.invoke(app, ["config", "unset", "nonexistent"])
     assert result.exit_code == 1
     assert "(not set)" in result.output

--- a/packages/nauro/tests/test_init_cloud.py
+++ b/packages/nauro/tests/test_init_cloud.py
@@ -26,15 +26,10 @@ from nauro.sync import cloud_projects
 runner = CliRunner()
 
 
-def _patch_home(monkeypatch, tmp_path):
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
-
-
 def _seed_token(monkeypatch, tmp_path):
     """Make cloud_projects believe the user is authenticated."""
     from nauro.store.config import save_config
 
-    _patch_home(monkeypatch, tmp_path)
     save_config({"auth": {"access_token": "test-token", "sub": "auth0|test"}})
 
 
@@ -43,7 +38,6 @@ def _seed_token(monkeypatch, tmp_path):
 
 def test_init_local_no_network(tmp_path, monkeypatch):
     """`nauro init <name>` (no flag) must not contact the cloud."""
-    _patch_home(monkeypatch, tmp_path)
     monkeypatch.chdir(tmp_path)
 
     def explode(*_args, **_kwargs):
@@ -226,7 +220,6 @@ def test_add_repo_to_cloud_project_errors_with_attach_hint(tmp_path, monkeypatch
 
 def test_add_repo_to_local_project_appends(tmp_path, monkeypatch):
     """The legacy --add-repo flow still extends a local-mode project."""
-    _patch_home(monkeypatch, tmp_path)
     monkeypatch.chdir(tmp_path)
     repo1 = tmp_path / "repo1"
     repo1.mkdir()

--- a/packages/nauro/tests/test_registry.py
+++ b/packages/nauro/tests/test_registry.py
@@ -9,23 +9,15 @@ from nauro.store import registry
 from nauro.store.repo_config import load_repo_config
 from nauro.templates.scaffolds import scaffold_project_store
 
-
-def _patch_home(monkeypatch, tmp_path):
-    """Point NAURO_HOME at a temp directory."""
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
-
-
 # --- Registry CRUD ---
 
 
 def test_load_registry_empty(tmp_path, monkeypatch):
-    _patch_home(monkeypatch, tmp_path)
     data = registry.load_registry()
     assert data == {"projects": {}, "schema_version": 1}
 
 
 def test_save_and_load_registry(tmp_path, monkeypatch):
-    _patch_home(monkeypatch, tmp_path)
     data = {"projects": {"myproj": {"repo_paths": ["/tmp/repo"]}}}
     registry.save_registry(data)
     loaded = registry.load_registry()
@@ -34,7 +26,6 @@ def test_save_and_load_registry(tmp_path, monkeypatch):
 
 
 def test_register_project(tmp_path, monkeypatch):
-    _patch_home(monkeypatch, tmp_path)
     repo = tmp_path / "repo"
     repo.mkdir()
     store_path = registry.register_project("proj1", [repo])
@@ -46,7 +37,6 @@ def test_register_project(tmp_path, monkeypatch):
 
 
 def test_register_duplicate_raises(tmp_path, monkeypatch):
-    _patch_home(monkeypatch, tmp_path)
     repo = tmp_path / "repo"
     repo.mkdir()
     registry.register_project("dup", [repo])
@@ -58,7 +48,6 @@ def test_register_duplicate_raises(tmp_path, monkeypatch):
 
 
 def test_add_repo(tmp_path, monkeypatch):
-    _patch_home(monkeypatch, tmp_path)
     repo1 = tmp_path / "repo1"
     repo2 = tmp_path / "repo2"
     repo1.mkdir()
@@ -71,7 +60,6 @@ def test_add_repo(tmp_path, monkeypatch):
 
 
 def test_add_repo_idempotent(tmp_path, monkeypatch):
-    _patch_home(monkeypatch, tmp_path)
     repo = tmp_path / "repo"
     repo.mkdir()
     registry.register_project("proj", [repo])
@@ -81,7 +69,6 @@ def test_add_repo_idempotent(tmp_path, monkeypatch):
 
 
 def test_add_repo_missing_project(tmp_path, monkeypatch):
-    _patch_home(monkeypatch, tmp_path)
     try:
         registry.add_repo("nope", tmp_path)
         assert False, "Expected KeyError"
@@ -93,7 +80,6 @@ def test_add_repo_missing_project(tmp_path, monkeypatch):
 
 
 def test_resolve_project_exact(tmp_path, monkeypatch):
-    _patch_home(monkeypatch, tmp_path)
     repo = tmp_path / "repo"
     repo.mkdir()
     registry.register_project("proj", [repo])
@@ -101,7 +87,6 @@ def test_resolve_project_exact(tmp_path, monkeypatch):
 
 
 def test_resolve_project_nested(tmp_path, monkeypatch):
-    _patch_home(monkeypatch, tmp_path)
     repo = tmp_path / "repo"
     nested = repo / "src" / "pkg"
     nested.mkdir(parents=True)
@@ -110,7 +95,6 @@ def test_resolve_project_nested(tmp_path, monkeypatch):
 
 
 def test_resolve_project_no_match(tmp_path, monkeypatch):
-    _patch_home(monkeypatch, tmp_path)
     repo = tmp_path / "repo"
     repo.mkdir()
     registry.register_project("proj", [repo])
@@ -123,7 +107,6 @@ def test_resolve_project_no_match(tmp_path, monkeypatch):
 
 
 def test_find_stale_paths_none(tmp_path, monkeypatch):
-    _patch_home(monkeypatch, tmp_path)
     repo = tmp_path / "repo"
     repo.mkdir()
     registry.register_project("proj", [repo])
@@ -131,7 +114,6 @@ def test_find_stale_paths_none(tmp_path, monkeypatch):
 
 
 def test_find_stale_paths_detects_missing(tmp_path, monkeypatch):
-    _patch_home(monkeypatch, tmp_path)
     repo = tmp_path / "repo"
     repo.mkdir()
     registry.register_project("proj", [repo])
@@ -145,7 +127,6 @@ def test_find_stale_paths_detects_missing(tmp_path, monkeypatch):
 
 
 def test_suggest_project_matching_dirname(tmp_path, monkeypatch):
-    _patch_home(monkeypatch, tmp_path)
     repo = tmp_path / "myapp"
     repo.mkdir()
     registry.register_project("myapp", [repo])
@@ -156,7 +137,6 @@ def test_suggest_project_matching_dirname(tmp_path, monkeypatch):
 
 
 def test_suggest_project_no_match(tmp_path, monkeypatch):
-    _patch_home(monkeypatch, tmp_path)
     repo = tmp_path / "myapp"
     repo.mkdir()
     registry.register_project("myapp", [repo])
@@ -198,7 +178,6 @@ def _v2_entry_for_name(name: str) -> tuple[str, dict]:
 
 
 def test_init_cli(tmp_path, monkeypatch):
-    _patch_home(monkeypatch, tmp_path)
     monkeypatch.chdir(tmp_path)
     result = runner.invoke(app, ["init", "myproject"])
     assert result.exit_code == 0
@@ -211,7 +190,6 @@ def test_init_cli(tmp_path, monkeypatch):
 
 def test_init_cli_writes_repo_config_local(tmp_path, monkeypatch):
     """`nauro init <name>` writes a local-mode .nauro/config.json into cwd."""
-    _patch_home(monkeypatch, tmp_path)
     monkeypatch.chdir(tmp_path)
     result = runner.invoke(app, ["init", "configproj"])
     assert result.exit_code == 0
@@ -223,7 +201,6 @@ def test_init_cli_writes_repo_config_local(tmp_path, monkeypatch):
 
 
 def test_init_cli_with_add_repo(tmp_path, monkeypatch):
-    _patch_home(monkeypatch, tmp_path)
     repo = tmp_path / "myrepo"
     repo.mkdir()
     result = runner.invoke(app, ["init", "proj2", "--add-repo", str(repo)])
@@ -240,7 +217,6 @@ def test_init_cli_duplicate(tmp_path, monkeypatch):
     --force; the registry-allows-dups invariant is verified by exercising
     each init from its own directory.
     """
-    _patch_home(monkeypatch, tmp_path)
     cwd1 = tmp_path / "cwd1"
     cwd2 = tmp_path / "cwd2"
     cwd1.mkdir()
@@ -257,7 +233,6 @@ def test_init_cli_refuses_overwrite_without_force(tmp_path, monkeypatch):
     """D136: a second `nauro init <other-name>` from the same cwd refuses
     to overwrite the existing .nauro/config.json without --force, naming
     the existing project so the caller can decide what to do."""
-    _patch_home(monkeypatch, tmp_path)
     monkeypatch.chdir(tmp_path)
     first = runner.invoke(app, ["init", "first"])
     assert first.exit_code == 0
@@ -275,7 +250,6 @@ def test_init_cli_refuses_overwrite_without_force(tmp_path, monkeypatch):
 def test_init_cli_force_overwrites(tmp_path, monkeypatch):
     """D136: --force replaces an existing .nauro/config.json with the new
     project's handle; the registry shows both."""
-    _patch_home(monkeypatch, tmp_path)
     monkeypatch.chdir(tmp_path)
     runner.invoke(app, ["init", "first"])
     result = runner.invoke(app, ["init", "second", "--force"])
@@ -290,7 +264,6 @@ def test_init_cli_add_repo_idempotent_on_same_id(tmp_path, monkeypatch):
     """D136: re-running `nauro init <existing-name> --add-repo <repo>`
     against a repo already pointing at that project succeeds (idempotent),
     because the existing config id matches the project's id."""
-    _patch_home(monkeypatch, tmp_path)
     repo = tmp_path / "repo"
     repo.mkdir()
     first = runner.invoke(app, ["init", "proj", "--add-repo", str(repo)])
@@ -302,7 +275,6 @@ def test_init_cli_add_repo_idempotent_on_same_id(tmp_path, monkeypatch):
 def test_init_cli_add_repo_refuses_overwrite_on_different_id(tmp_path, monkeypatch):
     """D136: --add-repo against a repo already linked to a *different*
     project refuses without --force, naming both projects."""
-    _patch_home(monkeypatch, tmp_path)
     repo = tmp_path / "repo"
     repo.mkdir()
     # Repo already linked to 'alpha'.
@@ -321,7 +293,6 @@ def test_init_cli_add_repo_refuses_overwrite_on_different_id(tmp_path, monkeypat
 
 def test_init_cli_add_repo_to_existing(tmp_path, monkeypatch):
     """nauro init <existing> --add-repo should add repo instead of failing."""
-    _patch_home(monkeypatch, tmp_path)
     repo1 = tmp_path / "repo1"
     repo2 = tmp_path / "repo2"
     repo1.mkdir()
@@ -348,7 +319,6 @@ def test_init_add_repo_to_existing_writes_per_repo_config(tmp_path, monkeypatch)
     adopted?". Without it, downstream guards (``nauro adopt`` already-adopted
     check, the /nauro-adopt skill's Step 2) fail to detect the linkage.
     """
-    _patch_home(monkeypatch, tmp_path)
     repo1 = tmp_path / "repo1"
     repo2 = tmp_path / "repo2"
     repo1.mkdir()
@@ -369,7 +339,6 @@ def test_init_add_repo_to_existing_writes_per_repo_config(tmp_path, monkeypatch)
 
 
 def test_remove_repo(tmp_path, monkeypatch):
-    _patch_home(monkeypatch, tmp_path)
     repo = tmp_path / "repo"
     repo.mkdir()
     registry.register_project("proj", [repo])
@@ -380,7 +349,6 @@ def test_remove_repo(tmp_path, monkeypatch):
 
 
 def test_remove_repo_not_found(tmp_path, monkeypatch):
-    _patch_home(monkeypatch, tmp_path)
     repo = tmp_path / "repo"
     repo.mkdir()
     registry.register_project("proj", [repo])

--- a/packages/nauro/tests/test_registry_v2.py
+++ b/packages/nauro/tests/test_registry_v2.py
@@ -18,20 +18,14 @@ from nauro.store.registry import (
 )
 
 
-def _patch_home(monkeypatch, tmp_path):
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
-
-
 def test_load_v2_empty_when_missing(tmp_path, monkeypatch):
     """Missing registry.json → empty v2 shape."""
-    _patch_home(monkeypatch, tmp_path)
     data = load_registry_v2()
     assert data == {"projects": {}, "schema_version": REGISTRY_SCHEMA_VERSION_V2}
 
 
 def test_v2_round_trip(tmp_path, monkeypatch):
     """A v2 registry round-trips through save/load with id-keyed entries."""
-    _patch_home(monkeypatch, tmp_path)
     data = {
         "projects": {
             "01KQ6AZGNA0B3QBF67NBXP3S45": {
@@ -55,7 +49,6 @@ def test_v2_round_trip(tmp_path, monkeypatch):
 
 def test_v2_save_stamps_schema_version(tmp_path, monkeypatch):
     """save_registry_v2 stamps schema_version=2 when caller omits it."""
-    _patch_home(monkeypatch, tmp_path)
     save_registry_v2({"projects": {}})
     raw = json.loads((tmp_path / "nauro_home" / REGISTRY_FILENAME).read_text())
     assert raw["schema_version"] == REGISTRY_SCHEMA_VERSION_V2
@@ -63,7 +56,6 @@ def test_v2_save_stamps_schema_version(tmp_path, monkeypatch):
 
 def test_v2_loader_rejects_v1_with_migration_hint(tmp_path, monkeypatch):
     """A v1 registry on disk surfaces the manual-migration message."""
-    _patch_home(monkeypatch, tmp_path)
     # Write a v1 registry via the legacy writer.
     registry.save_registry(
         {"projects": {"oldproj": {"repo_paths": ["/tmp/old"]}}, "schema_version": 1}
@@ -77,7 +69,6 @@ def test_v2_loader_rejects_v1_with_migration_hint(tmp_path, monkeypatch):
 
 def test_v2_loader_rejects_unknown_schema_version(tmp_path, monkeypatch):
     """A future schema_version is rejected with an upgrade hint."""
-    _patch_home(monkeypatch, tmp_path)
     nauro_home = tmp_path / "nauro_home"
     nauro_home.mkdir()
     (nauro_home / REGISTRY_FILENAME).write_text(json.dumps({"projects": {}, "schema_version": 99}))
@@ -88,6 +79,5 @@ def test_v2_loader_rejects_unknown_schema_version(tmp_path, monkeypatch):
 
 def test_v2_save_rejects_non_v2_schema_version(tmp_path, monkeypatch):
     """save_registry_v2 refuses to write anything other than schema_version=2."""
-    _patch_home(monkeypatch, tmp_path)
     with pytest.raises(RegistrySchemaError):
         save_registry_v2({"projects": {}, "schema_version": 1})

--- a/packages/nauro/tests/test_resolution_v2.py
+++ b/packages/nauro/tests/test_resolution_v2.py
@@ -28,13 +28,8 @@ from nauro.store.repo_config import load_repo_config, save_repo_config
 runner = CliRunner()
 
 
-def _patch_home(monkeypatch, tmp_path):
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
-
-
 def _post_migration_state(tmp_path, monkeypatch):
     """Simulate the post-manual-migration state: v2 registry + cloud repo config."""
-    _patch_home(monkeypatch, tmp_path)
     nauro_home = tmp_path / "nauro_home"
     nauro_home.mkdir()
     cloud_pid = "01KQ6AZGNA0B3QBF67NBXP3S45"
@@ -94,7 +89,6 @@ def test_explicit_project_flag_overrides_repo_config(tmp_path, monkeypatch):
 
     Existing test_cli.py expectation; pinned here against the v2 path.
     """
-    _patch_home(monkeypatch, tmp_path)
     cloud_pid, repo_root = _post_migration_state(tmp_path, monkeypatch)
     other_pid, _store = registry.register_project_v2(
         "beta",
@@ -127,7 +121,6 @@ def test_stdio_resolve_mismatched_project_id_errors(tmp_path, monkeypatch):
 
 
 def test_stdio_resolve_no_repo_no_project_errors(tmp_path, monkeypatch):
-    _patch_home(monkeypatch, tmp_path)
     isolated = tmp_path / "isolated"
     isolated.mkdir()
     monkeypatch.chdir(isolated)

--- a/packages/nauro/tests/test_validation/conftest.py
+++ b/packages/nauro/tests/test_validation/conftest.py
@@ -1,0 +1,18 @@
+"""Shared fixtures for the validation test subdirectory."""
+
+import pytest
+
+from nauro.validation.pending import clear_all
+
+
+@pytest.fixture(autouse=True)
+def _clear_pending():
+    """Reset the in-process pending-decision registry around every test.
+
+    ``nauro.validation.pending`` is module-global state used by the propose →
+    confirm flow. Without this, a leftover pending entry from one test bleeds
+    into the next and produces non-deterministic failures.
+    """
+    clear_all()
+    yield
+    clear_all()

--- a/packages/nauro/tests/test_validation/test_mcp_validation.py
+++ b/packages/nauro/tests/test_validation/test_mcp_validation.py
@@ -7,7 +7,6 @@ from httpx import ASGITransport, AsyncClient
 
 from nauro.mcp.server import app
 from nauro.templates.scaffolds import scaffold_project_store
-from nauro.validation.pending import clear_all
 
 
 @pytest.fixture
@@ -21,16 +20,8 @@ def store(tmp_path: Path) -> Path:
 @pytest.fixture
 def client(tmp_path: Path, monkeypatch, store) -> AsyncClient:
     monkeypatch.setenv("NAURO_HOME", str(tmp_path))
-    clear_all()
     transport = ASGITransport(app=app)
     return AsyncClient(transport=transport, base_url="http://test")
-
-
-@pytest.fixture(autouse=True)
-def _clear_pending():
-    clear_all()
-    yield
-    clear_all()
 
 
 @pytest.mark.asyncio

--- a/packages/nauro/tests/test_validation/test_pending.py
+++ b/packages/nauro/tests/test_validation/test_pending.py
@@ -2,8 +2,6 @@
 
 from datetime import datetime, timedelta, timezone
 
-import pytest
-
 from nauro.validation.pending import (
     _store,
     clear_all,
@@ -12,13 +10,6 @@ from nauro.validation.pending import (
     remove_pending,
     store_pending,
 )
-
-
-@pytest.fixture(autouse=True)
-def _clean():
-    clear_all()
-    yield
-    clear_all()
 
 
 def test_store_and_retrieve():

--- a/packages/nauro/tests/test_validation/test_pipeline.py
+++ b/packages/nauro/tests/test_validation/test_pipeline.py
@@ -6,7 +6,6 @@ import pytest
 
 from nauro.store.writer import append_decision
 from nauro.templates.scaffolds import scaffold_project_store
-from nauro.validation.pending import clear_all
 from nauro.validation.pipeline import (
     confirm_write,
     validate_proposed_write,
@@ -33,13 +32,6 @@ def store_with_existing(tmp_path: Path) -> Path:
         decision_type="data_model",
     )
     return store_path
-
-
-@pytest.fixture(autouse=True)
-def _clear_pending():
-    clear_all()
-    yield
-    clear_all()
 
 
 class TestTier1Rejection:

--- a/packages/nauro/tests/test_validation/test_validation_is_anthropic_free.py
+++ b/packages/nauro/tests/test_validation/test_validation_is_anthropic_free.py
@@ -17,7 +17,6 @@ import pytest
 
 from nauro.store.writer import append_decision
 from nauro.templates.scaffolds import scaffold_project_store
-from nauro.validation.pending import clear_all
 from nauro.validation.pipeline import validate_proposed_write
 
 
@@ -34,13 +33,6 @@ def store(tmp_path: Path) -> Path:
         decision_type="data_model",
     )
     return store_path
-
-
-@pytest.fixture(autouse=True)
-def _clear_pending():
-    clear_all()
-    yield
-    clear_all()
 
 
 def test_propose_decision_without_anthropic(store, monkeypatch):


### PR DESCRIPTION
## Why

Two patterns of test-fixture duplication, each accumulated over time and ripe for consolidation:

- `_patch_home(monkeypatch, tmp_path)` — a one-line helper setting `NAURO_HOME` was redefined identically in 7 files, called 64 times.
- `_clear_pending` autouse fixture (with one `_clean` alias) — duplicated 4× across `tests/test_validation/` to reset the module-global pending-decision registry.

## Approach

- New autouse `_isolate_nauro_home` in `packages/nauro/tests/conftest.py`, mirroring the existing `_isolate_cwd` precedent. Every test now runs with `NAURO_HOME=tmp_path/nauro_home` by default; the 7 local `_patch_home` definitions plus all 64 callsites are removed.
- New `packages/nauro/tests/test_validation/conftest.py` holds one canonical `_clear_pending` autouse fixture. The four local copies are removed; the `_clean` name in `test_pending.py` is normalized away.

## What changed

- 12 test modules touched, plus 1 new conftest. Net `-99` lines.
- `test_mcp_validation.py` also drops a stale explicit `clear_all()` call (now redundant under the conftest autouse) and the corresponding unused import.

## What to review

- `packages/nauro/tests/conftest.py` — the new autouse changes the default for the **entire** nauro test suite, not just the 7 refactored files. Previously, tests that didn't touch `NAURO_HOME` ran against whatever the dev's shell pointed at. They now run against a clean tmp path. All 902 tests pass, confirming no test depended on the unset path — but reviewers should sanity-check this is the right default.
- Convention split still present: 28 other files explicitly set `monkeypatch.setenv(\"NAURO_HOME\", str(tmp_path))` (bare `tmp_path`, no subdir). The autouse fires first; their later override wins, so behavior is unchanged. **Intentionally out of scope** — folding them in requires per-test path verification (some assert on specific paths under `NAURO_HOME`). Queued as a follow-up.

## What's deferred

- Unifying the bare-`tmp_path` vs `tmp_path/nauro_home` convention across the other 28 files.
- A 5th `_clear_pending` copy in `tests/test_stdio_server.py` (different directory; promoting to workspace conftest would add an implicit `nauro.validation.pending` dep to all 902 tests for a 5-line saving — not worth it).
- Dropping now-unused `monkeypatch` parameters from test signatures.

## Test plan

- `uv run --package nauro pytest packages/nauro/tests/ -q` → 902 passed.
- `uv run --package nauro-core pytest packages/nauro-core/tests/ -q` → 306 passed.
- `uv run ruff check packages/` + `ruff format --check packages/` clean.