### PR TITLE
test: unify NAURO_HOME test convention on bare tmp_path

### DIFF
--- a/packages/nauro/tests/conftest.py
+++ b/packages/nauro/tests/conftest.py
@@ -19,11 +19,11 @@ def _isolate_cwd(tmp_path, monkeypatch):
 
 @pytest.fixture(autouse=True)
 def _isolate_nauro_home(tmp_path, monkeypatch):
-    """Point NAURO_HOME at a tmp subdirectory so tests never see the dev's real store.
+    """Point NAURO_HOME at tmp_path so tests never see the dev's real store.
 
     Mirrors the isolation rationale of ``_isolate_cwd``: a stray NAURO_HOME in
     the dev's shell would leak the real ``~/.nauro/`` into the suite. Tests that
-    need a different layout (e.g. ``NAURO_HOME=tmp_path``) override on the same
-    monkeypatch instance; the later setenv wins.
+    need a different layout override on the same monkeypatch instance; the
+    later setenv wins.
     """
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
+    monkeypatch.setenv("NAURO_HOME", str(tmp_path))

--- a/packages/nauro/tests/test_adopt.py
+++ b/packages/nauro/tests/test_adopt.py
@@ -16,7 +16,6 @@ runner = CliRunner()
 
 def _adopt_env(monkeypatch, tmp_path: Path) -> Path:
     """Set up an isolated NAURO_HOME + HOME for adopt tests."""
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
     monkeypatch.setenv("HOME", str(tmp_path))  # diverts ~/.claude, ~/.codex, ~/.agents
     repo = tmp_path / "myrepo"
     repo.mkdir()
@@ -67,7 +66,6 @@ def test_adopt_aborts_when_repo_already_adopted(tmp_path: Path, monkeypatch):
 
 def test_adopt_aborts_on_same_name_collision(tmp_path: Path, monkeypatch):
     """Pre-check fires when the v2 registry has a same-name project at a different repo."""
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
     monkeypatch.setenv("HOME", str(tmp_path))
     other_repo = tmp_path / "other-repo"
     other_repo.mkdir()
@@ -87,7 +85,6 @@ def test_adopt_aborts_on_same_name_collision(tmp_path: Path, monkeypatch):
 
 def test_collision_message_picks_first_repo_deterministically(tmp_path: Path, monkeypatch):
     """When the colliding project has multiple registered repos, the surfaced path is stable."""
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
     monkeypatch.setenv("HOME", str(tmp_path))
     repo_a = tmp_path / "repo-a"
     repo_b = tmp_path / "repo-b"
@@ -110,7 +107,6 @@ def test_collision_message_picks_first_repo_deterministically(tmp_path: Path, mo
 
 
 def test_adopt_print_prompt_outputs_canonical_body(tmp_path: Path, monkeypatch):
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
     monkeypatch.chdir(tmp_path)
 
     result = runner.invoke(app, ["adopt", "--print-prompt"])
@@ -120,7 +116,6 @@ def test_adopt_print_prompt_outputs_canonical_body(tmp_path: Path, monkeypatch):
 
 
 def test_adopt_print_prompt_conflicts_with_other_flags(tmp_path: Path, monkeypatch):
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
     monkeypatch.chdir(tmp_path)
 
     result = runner.invoke(app, ["adopt", "--print-prompt", "--name", "x"])
@@ -160,7 +155,6 @@ def test_adopt_materializes_skills_across_surfaces(tmp_path: Path, monkeypatch):
 
 
 def test_adopt_aborts_on_nonexistent_repo(tmp_path: Path, monkeypatch):
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
 
     result = runner.invoke(app, ["adopt", "--repo", str(tmp_path / "missing")])
     assert result.exit_code != 0

--- a/packages/nauro/tests/test_agents_md.py
+++ b/packages/nauro/tests/test_agents_md.py
@@ -159,7 +159,6 @@ def test_manual_section_preserved_across_regenerations(tmp_path: Path):
 
 
 def test_sync_writes_agents_md(tmp_path: Path, monkeypatch):
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
     from nauro.store.registry import register_project
 
     repo = tmp_path / "repo"
@@ -181,7 +180,6 @@ def test_sync_writes_agents_md(tmp_path: Path, monkeypatch):
 
 
 def test_sync_multi_repo(tmp_path: Path, monkeypatch):
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
     from nauro.store.registry import register_project
 
     repo1 = tmp_path / "repo1"
@@ -201,7 +199,6 @@ def test_sync_multi_repo(tmp_path: Path, monkeypatch):
 
 
 def test_sync_skips_missing_repo(tmp_path: Path, monkeypatch):
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
     from nauro.store.registry import register_project
 
     real_repo = tmp_path / "real"
@@ -219,7 +216,6 @@ def test_sync_skips_missing_repo(tmp_path: Path, monkeypatch):
 
 
 def test_sync_preserves_manual_section(tmp_path: Path, monkeypatch):
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
     from nauro.store.registry import register_project
 
     repo = tmp_path / "repo"

--- a/packages/nauro/tests/test_attach.py
+++ b/packages/nauro/tests/test_attach.py
@@ -24,7 +24,6 @@ EXAMPLE_PID = "01KQ6AZGNA0B3QBF67NBXP3S45"
 
 
 def _seed_token(monkeypatch, tmp_path):
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
     save_config({"auth": {"access_token": "test-token", "sub": "auth0|test"}})
 
 
@@ -67,7 +66,7 @@ def test_attach_happy_path(tmp_path, monkeypatch):
     assert cfg["id"] == EXAMPLE_PID
     assert cfg["name"] == "team-proj"
 
-    store_path = tmp_path / "nauro_home" / "projects" / EXAMPLE_PID
+    store_path = tmp_path / "projects" / EXAMPLE_PID
     assert store_path.is_dir()
 
 
@@ -86,4 +85,4 @@ def test_attach_non_member_writes_nothing(tmp_path, monkeypatch):
     assert "not found among your cloud projects" in result.output
     assert registry.get_project_v2(EXAMPLE_PID) is None
     assert not (tmp_path / ".nauro" / "config.json").exists()
-    assert not (tmp_path / "nauro_home" / "projects" / EXAMPLE_PID).exists()
+    assert not (tmp_path / "projects" / EXAMPLE_PID).exists()

--- a/packages/nauro/tests/test_auth.py
+++ b/packages/nauro/tests/test_auth.py
@@ -369,7 +369,7 @@ class TestAuthLogout:
                 }
             }
         )
-        config_path = tmp_path / "nauro_home" / "config.json"
+        config_path = tmp_path / "config.json"
         mode = os.stat(config_path).st_mode & 0o777
         assert mode == 0o600
 

--- a/packages/nauro/tests/test_check_command.py
+++ b/packages/nauro/tests/test_check_command.py
@@ -39,7 +39,6 @@ def demo_repo(tmp_path, monkeypatch):
     Returns (project_name, project_id, store_path, repo_path). The cwd is
     moved into the repo so resolve_target_project picks the right project.
     """
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
     repo = tmp_path / "repo"
     repo.mkdir()
     pid, store_path = register_project_v2("demo-project", [repo], mode=REPO_CONFIG_MODE_LOCAL)
@@ -57,7 +56,6 @@ def no_decisions_repo(tmp_path, monkeypatch):
     distinct from a scaffolded store (which seeds 001-initial-setup.md and
     therefore has decisions).
     """
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
     repo = tmp_path / "repo"
     repo.mkdir()
     pid, store_path = register_project_v2("bare-project", [repo], mode=REPO_CONFIG_MODE_LOCAL)
@@ -128,7 +126,6 @@ def test_json_output_has_no_pre_header(demo_repo):
 
 
 def test_no_project_resolution_errors(tmp_path, monkeypatch):
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
     monkeypatch.chdir(tmp_path)
     result = runner.invoke(app, ["check", DEMO_PROMPT])
     assert result.exit_code == 1
@@ -171,7 +168,6 @@ def test_rejected_status_exits_nonzero_json(demo_repo):
 
 
 def test_cloud_mode_project_prints_stale_notice(tmp_path, monkeypatch):
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
     repo = tmp_path / "repo"
     repo.mkdir()
     pid, store_path = register_project_v2(
@@ -224,7 +220,6 @@ def fake_posthog(monkeypatch):
 @pytest.fixture
 def telemetry_enabled(tmp_path, monkeypatch):
     """Seed NAURO_HOME with a consented config so capture() actually fires."""
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
     monkeypatch.setenv("NAURO_POSTHOG_KEY", "phc_test_key_for_unit_tests")
     aid = "11111111-1111-4111-8111-111111111111"
     (tmp_path / "config.json").write_text(

--- a/packages/nauro/tests/test_cli.py
+++ b/packages/nauro/tests/test_cli.py
@@ -23,7 +23,6 @@ def test_init_command(tmp_path: Path, monkeypatch):
     """nauro init should create an id-keyed project store."""
     from nauro.store.registry import find_projects_by_name_v2
 
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
     monkeypatch.chdir(tmp_path)
 
     result = runner.invoke(app, ["init", "testproj"])
@@ -40,7 +39,6 @@ def test_init_command(tmp_path: Path, monkeypatch):
 
 def test_note_command(tmp_path: Path, monkeypatch):
     """nauro note should accept a message."""
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
     store = register_project("myproj", [tmp_path])
     scaffold_project_store("myproj", store)
     monkeypatch.chdir(tmp_path)
@@ -54,7 +52,6 @@ def test_note_command(tmp_path: Path, monkeypatch):
 
 def test_sync_command(tmp_path: Path, monkeypatch):
     """nauro sync should capture a snapshot."""
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
     store = register_project("myproj", [tmp_path])
     scaffold_project_store("myproj", store)
     monkeypatch.chdir(tmp_path)
@@ -66,7 +63,6 @@ def test_sync_command(tmp_path: Path, monkeypatch):
 
 def test_log_command(tmp_path: Path, monkeypatch):
     """nauro log should list snapshots."""
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
     store = register_project("myproj", [tmp_path])
     scaffold_project_store("myproj", store)
     monkeypatch.chdir(tmp_path)
@@ -83,7 +79,6 @@ def test_log_command(tmp_path: Path, monkeypatch):
 
 def test_note_with_project_flag_overrides_cwd(tmp_path: Path, monkeypatch):
     """--project flag should resolve the named project regardless of cwd."""
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
     # Register two projects
     store_a = register_project("alpha", [tmp_path / "repo_a"])
     store_b = register_project("beta", [tmp_path / "repo_b"])
@@ -110,7 +105,6 @@ def test_note_with_project_flag_overrides_cwd(tmp_path: Path, monkeypatch):
 
 def test_project_flag_unknown_name_gives_error(tmp_path: Path, monkeypatch):
     """--project with an unknown name should error and list available projects."""
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
     store = register_project("realproj", [tmp_path])
     scaffold_project_store("realproj", store)
     monkeypatch.chdir(tmp_path)
@@ -123,7 +117,6 @@ def test_project_flag_unknown_name_gives_error(tmp_path: Path, monkeypatch):
 
 def test_no_project_flag_no_cwd_match_gives_error(tmp_path: Path, monkeypatch):
     """Missing --project and no cwd match should error with available projects."""
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
     store = register_project("faraway", [tmp_path / "elsewhere"])
     scaffold_project_store("faraway", store)
 
@@ -141,7 +134,6 @@ def test_no_project_flag_no_cwd_match_gives_error(tmp_path: Path, monkeypatch):
 
 def test_no_cwd_match_suggests_project_by_dirname(tmp_path: Path, monkeypatch):
     """When cwd dirname matches a project name, suggest adding the repo path."""
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
     old_repo = tmp_path / "old_location" / "myapp"
     old_repo.mkdir(parents=True)
     store = register_project("myapp", [old_repo])
@@ -160,7 +152,6 @@ def test_no_cwd_match_suggests_project_by_dirname(tmp_path: Path, monkeypatch):
 
 def test_sync_with_project_flag(tmp_path: Path, monkeypatch):
     """nauro sync --project should target the named project."""
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
     store = register_project("myproj", [tmp_path / "repo"])
     scaffold_project_store("myproj", store)
 
@@ -176,7 +167,6 @@ def test_sync_with_project_flag(tmp_path: Path, monkeypatch):
 
 def test_log_with_project_flag(tmp_path: Path, monkeypatch):
     """nauro log --project should target the named project."""
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
     store = register_project("myproj", [tmp_path / "repo"])
     scaffold_project_store("myproj", store)
     capture_snapshot(store, trigger="test")
@@ -192,7 +182,6 @@ def test_log_with_project_flag(tmp_path: Path, monkeypatch):
 
 def test_get_project_returns_entry(tmp_path: Path, monkeypatch):
     """get_project should return the entry dict for a known project."""
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
     register_project("proj", [tmp_path / "repo"])
     entry = get_project("proj")
     assert entry is not None
@@ -201,5 +190,4 @@ def test_get_project_returns_entry(tmp_path: Path, monkeypatch):
 
 def test_get_project_returns_none_for_unknown(tmp_path: Path, monkeypatch):
     """get_project should return None for unknown projects."""
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
     assert get_project("nonexistent") is None

--- a/packages/nauro/tests/test_cli_status.py
+++ b/packages/nauro/tests/test_cli_status.py
@@ -10,7 +10,6 @@ runner = CliRunner()
 
 
 def _setup_project(tmp_path, monkeypatch):
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
     store = register_project("testproj", [tmp_path])
     scaffold_project_store("testproj", store)
     monkeypatch.chdir(tmp_path)

--- a/packages/nauro/tests/test_cli_status_divergence.py
+++ b/packages/nauro/tests/test_cli_status_divergence.py
@@ -13,7 +13,6 @@ runner = CliRunner()
 
 
 def _setup_project(tmp_path, monkeypatch):
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
     store = register_project("testproj", [tmp_path])
     scaffold_project_store("testproj", store)
     monkeypatch.chdir(tmp_path)

--- a/packages/nauro/tests/test_import.py
+++ b/packages/nauro/tests/test_import.py
@@ -165,7 +165,6 @@ def test_import_preserves_existing_decisions(store: Path, full_memory_bank: Path
 
 
 def test_import_nonexistent_directory_cli(tmp_path: Path, monkeypatch):
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
     store = register_project("myproj", [tmp_path])
     scaffold_project_store("myproj", store)
     monkeypatch.chdir(tmp_path)
@@ -176,7 +175,6 @@ def test_import_nonexistent_directory_cli(tmp_path: Path, monkeypatch):
 
 
 def test_import_directory_without_project_brief_cli(tmp_path: Path, monkeypatch):
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
     store = register_project("myproj", [tmp_path])
     scaffold_project_store("myproj", store)
     monkeypatch.chdir(tmp_path)
@@ -193,7 +191,6 @@ def test_import_directory_without_project_brief_cli(tmp_path: Path, monkeypatch)
 
 
 def test_import_cli_full(tmp_path: Path, monkeypatch, full_memory_bank: Path):
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
     store = register_project("myproj", [tmp_path])
     scaffold_project_store("myproj", store)
     monkeypatch.chdir(tmp_path)
@@ -212,7 +209,6 @@ def test_import_cli_full(tmp_path: Path, monkeypatch, full_memory_bank: Path):
 
 
 def test_import_cli_partial(tmp_path: Path, monkeypatch, partial_memory_bank: Path):
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
     store = register_project("myproj", [tmp_path])
     scaffold_project_store("myproj", store)
     monkeypatch.chdir(tmp_path)
@@ -224,7 +220,6 @@ def test_import_cli_partial(tmp_path: Path, monkeypatch, partial_memory_bank: Pa
 
 
 def test_import_cli_no_flags(tmp_path: Path, monkeypatch):
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
     store = register_project("myproj", [tmp_path])
     scaffold_project_store("myproj", store)
     monkeypatch.chdir(tmp_path)
@@ -235,7 +230,6 @@ def test_import_cli_no_flags(tmp_path: Path, monkeypatch):
 
 
 def test_import_cli_with_project_flag(tmp_path: Path, monkeypatch, full_memory_bank: Path):
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
     register_project("proj_a", [tmp_path / "a"])
     store_a = tmp_path / "projects" / "proj_a"
     scaffold_project_store("proj_a", store_a)
@@ -593,7 +587,6 @@ def test_import_adr_empty_directory(store: Path, tmp_path: Path):
 
 def test_import_adr_cli_integration(tmp_path: Path, monkeypatch, madr_directory: Path):
     """Test ADR import via CLI."""
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
     store = register_project("myproj", [tmp_path])
     scaffold_project_store("myproj", store)
     monkeypatch.chdir(tmp_path)

--- a/packages/nauro/tests/test_init_cloud.py
+++ b/packages/nauro/tests/test_init_cloud.py
@@ -57,7 +57,7 @@ def test_init_local_no_network(tmp_path, monkeypatch):
     assert cfg["mode"] == "local"
     assert cfg["id"] == pid
     assert cfg["name"] == "localproj"
-    assert (tmp_path / "nauro_home" / "projects" / pid / "project.md").exists()
+    assert (tmp_path / "projects" / pid / "project.md").exists()
 
 
 # ── cloud mode ────────────────────────────────────────────────────────────────
@@ -99,7 +99,7 @@ def test_init_cloud_uses_server_minted_id(tmp_path, monkeypatch):
     cfg = load_repo_config(tmp_path)
     assert cfg["mode"] == "cloud"
     assert cfg["id"] == server_id
-    assert (tmp_path / "nauro_home" / "projects" / server_id / "project.md").exists()
+    assert (tmp_path / "projects" / server_id / "project.md").exists()
 
 
 def test_init_cloud_renders_server_error(tmp_path, monkeypatch):

--- a/packages/nauro/tests/test_link_cloud.py
+++ b/packages/nauro/tests/test_link_cloud.py
@@ -27,7 +27,6 @@ CLOUD_PID = "01KQ6AZGNA0B3QBF67NBXP3S45"
 
 
 def _seed_token(monkeypatch, tmp_path):
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
     save_config({"auth": {"access_token": "test-token", "sub": "auth0|test"}})
 
 
@@ -60,7 +59,7 @@ def test_link_cloud_promotes_local_project(tmp_path, monkeypatch):
     matches = registry.find_projects_by_name_v2("linkproj")
     assert len(matches) == 1
     local_id, _entry = matches[0]
-    local_store = tmp_path / "nauro_home" / "projects" / local_id
+    local_store = tmp_path / "projects" / local_id
     assert local_store.is_dir()
 
     # Mark the store with a sentinel so we can prove the rename moved its contents
@@ -71,7 +70,7 @@ def test_link_cloud_promotes_local_project(tmp_path, monkeypatch):
         result = runner.invoke(app, ["link", "--cloud"])
     assert result.exit_code == 0, result.output
 
-    new_store = tmp_path / "nauro_home" / "projects" / CLOUD_PID
+    new_store = tmp_path / "projects" / CLOUD_PID
     assert new_store.is_dir()
     assert (new_store / "decisions" / "999-sentinel.md").exists()
     assert not local_store.exists()

--- a/packages/nauro/tests/test_log_diff.py
+++ b/packages/nauro/tests/test_log_diff.py
@@ -205,7 +205,6 @@ class TestDiffSinceLastSession:
 
 class TestLogCommand:
     def test_log_shows_snapshots(self, tmp_path: Path, monkeypatch):
-        monkeypatch.setenv("NAURO_HOME", str(tmp_path))
         from nauro.store.registry import register_project
 
         store = register_project("myproj", [tmp_path])
@@ -223,7 +222,6 @@ class TestLogCommand:
         assert "second sync" in result.output
 
     def test_log_limit(self, tmp_path: Path, monkeypatch):
-        monkeypatch.setenv("NAURO_HOME", str(tmp_path))
         from nauro.store.registry import register_project
 
         store = register_project("myproj", [tmp_path])
@@ -240,7 +238,6 @@ class TestLogCommand:
         assert "v001" not in result.output
 
     def test_log_full(self, tmp_path: Path, monkeypatch):
-        monkeypatch.setenv("NAURO_HOME", str(tmp_path))
         from nauro.store.registry import register_project
 
         store = register_project("myproj", [tmp_path])
@@ -257,7 +254,6 @@ class TestLogCommand:
         assert "decisions/" in result.output
 
     def test_log_no_snapshots(self, tmp_path: Path, monkeypatch):
-        monkeypatch.setenv("NAURO_HOME", str(tmp_path))
         from nauro.store.registry import register_project
 
         store = register_project("myproj", [tmp_path])
@@ -269,7 +265,6 @@ class TestLogCommand:
         assert "No snapshots" in result.output
 
     def test_log_no_project(self, tmp_path: Path, monkeypatch):
-        monkeypatch.setenv("NAURO_HOME", str(tmp_path))
         monkeypatch.chdir(tmp_path)
 
         result = runner.invoke(app, ["log"])
@@ -283,7 +278,6 @@ class TestLogCommand:
 class TestDiffCommand:
     def test_diff_no_args(self, tmp_path: Path, monkeypatch):
         """nauro diff — diff since last session."""
-        monkeypatch.setenv("NAURO_HOME", str(tmp_path))
         from nauro.store.registry import register_project
 
         store = register_project("myproj", [tmp_path])
@@ -301,7 +295,6 @@ class TestDiffCommand:
 
     def test_diff_one_version(self, tmp_path: Path, monkeypatch):
         """nauro diff <version> — diff that version against latest."""
-        monkeypatch.setenv("NAURO_HOME", str(tmp_path))
         from nauro.store.registry import register_project
 
         store = register_project("myproj", [tmp_path])
@@ -321,7 +314,6 @@ class TestDiffCommand:
 
     def test_diff_two_versions(self, tmp_path: Path, monkeypatch):
         """nauro diff <a> <b> — diff between two specific versions."""
-        monkeypatch.setenv("NAURO_HOME", str(tmp_path))
         from nauro.store.registry import register_project
 
         store = register_project("myproj", [tmp_path])
@@ -343,7 +335,6 @@ class TestDiffCommand:
 
     def test_diff_invalid_version(self, tmp_path: Path, monkeypatch):
         """nauro diff with invalid version shows error."""
-        monkeypatch.setenv("NAURO_HOME", str(tmp_path))
         from nauro.store.registry import register_project
 
         store = register_project("myproj", [tmp_path])
@@ -356,7 +347,6 @@ class TestDiffCommand:
         assert result.exit_code == 1
 
     def test_diff_no_project(self, tmp_path: Path, monkeypatch):
-        monkeypatch.setenv("NAURO_HOME", str(tmp_path))
         monkeypatch.chdir(tmp_path)
 
         result = runner.invoke(app, ["diff"])
@@ -365,7 +355,6 @@ class TestDiffCommand:
 
     def test_diff_not_enough_snapshots(self, tmp_path: Path, monkeypatch):
         """nauro diff with < 2 snapshots shows helpful message."""
-        monkeypatch.setenv("NAURO_HOME", str(tmp_path))
         from nauro.store.registry import register_project
 
         store = register_project("myproj", [tmp_path])
@@ -378,7 +367,6 @@ class TestDiffCommand:
 
     def test_diff_same_version(self, tmp_path: Path, monkeypatch):
         """nauro diff <latest> shows message that it's already latest."""
-        monkeypatch.setenv("NAURO_HOME", str(tmp_path))
         from nauro.store.registry import register_project
 
         store = register_project("myproj", [tmp_path])
@@ -508,7 +496,6 @@ class TestDiffSinceLastSessionTimeBased:
 
 class TestDiffSinceFlag:
     def test_since_7d(self, tmp_path: Path, monkeypatch):
-        monkeypatch.setenv("NAURO_HOME", str(tmp_path))
         from nauro.store.registry import register_project
 
         store = register_project("myproj", [tmp_path])
@@ -526,7 +513,6 @@ class TestDiffSinceFlag:
         assert "v002" in result.output
 
     def test_since_plain_number(self, tmp_path: Path, monkeypatch):
-        monkeypatch.setenv("NAURO_HOME", str(tmp_path))
         from nauro.store.registry import register_project
 
         store = register_project("myproj", [tmp_path])
@@ -543,7 +529,6 @@ class TestDiffSinceFlag:
         assert "v001" in result.output
 
     def test_since_invalid_value(self, tmp_path: Path, monkeypatch):
-        monkeypatch.setenv("NAURO_HOME", str(tmp_path))
         from nauro.store.registry import register_project
 
         store = register_project("myproj", [tmp_path])

--- a/packages/nauro/tests/test_mcp.py
+++ b/packages/nauro/tests/test_mcp.py
@@ -53,7 +53,6 @@ def store(tmp_path: Path) -> Path:
 @pytest.fixture
 def client(tmp_path: Path, monkeypatch) -> AsyncClient:
     """Async test client with a real project store."""
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
 
     store_path = tmp_path / "projects" / "testproj"
     scaffold_project_store("testproj", store_path)
@@ -385,7 +384,6 @@ async def test_update_state_endpoint(client, tmp_path):
 @pytest.mark.asyncio
 async def test_context_with_cwd_resolution(tmp_path, monkeypatch):
     """Test resolving project from cwd parameter."""
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
 
     from nauro.store.registry import register_project
 

--- a/packages/nauro/tests/test_registry.py
+++ b/packages/nauro/tests/test_registry.py
@@ -184,7 +184,7 @@ def test_init_cli(tmp_path, monkeypatch):
     assert "Initialized project 'myproject'" in result.output
     assert "Store:" in result.output
     pid, _entry = _v2_entry_for_name("myproject")
-    store = tmp_path / "nauro_home" / "projects" / pid
+    store = tmp_path / "projects" / pid
     assert (store / "project.md").exists()
 
 
@@ -307,7 +307,7 @@ def test_init_cli_add_repo_to_existing(tmp_path, monkeypatch):
     paths = entry["repo_paths"]
     assert str(repo2.resolve()) in paths
     # v2 registry shape
-    raw = json.loads((tmp_path / "nauro_home" / "registry.json").read_text())
+    raw = json.loads((tmp_path / "registry.json").read_text())
     assert raw["schema_version"] == 2
     assert pid in raw["projects"]
 

--- a/packages/nauro/tests/test_registry_v2.py
+++ b/packages/nauro/tests/test_registry_v2.py
@@ -50,7 +50,7 @@ def test_v2_round_trip(tmp_path, monkeypatch):
 def test_v2_save_stamps_schema_version(tmp_path, monkeypatch):
     """save_registry_v2 stamps schema_version=2 when caller omits it."""
     save_registry_v2({"projects": {}})
-    raw = json.loads((tmp_path / "nauro_home" / REGISTRY_FILENAME).read_text())
+    raw = json.loads((tmp_path / REGISTRY_FILENAME).read_text())
     assert raw["schema_version"] == REGISTRY_SCHEMA_VERSION_V2
 
 
@@ -69,9 +69,7 @@ def test_v2_loader_rejects_v1_with_migration_hint(tmp_path, monkeypatch):
 
 def test_v2_loader_rejects_unknown_schema_version(tmp_path, monkeypatch):
     """A future schema_version is rejected with an upgrade hint."""
-    nauro_home = tmp_path / "nauro_home"
-    nauro_home.mkdir()
-    (nauro_home / REGISTRY_FILENAME).write_text(json.dumps({"projects": {}, "schema_version": 99}))
+    (tmp_path / REGISTRY_FILENAME).write_text(json.dumps({"projects": {}, "schema_version": 99}))
     with pytest.raises(RegistrySchemaError) as exc:
         load_registry_v2()
     assert "99" in str(exc.value)

--- a/packages/nauro/tests/test_resolution_v2.py
+++ b/packages/nauro/tests/test_resolution_v2.py
@@ -30,13 +30,11 @@ runner = CliRunner()
 
 def _post_migration_state(tmp_path, monkeypatch):
     """Simulate the post-manual-migration state: v2 registry + cloud repo config."""
-    nauro_home = tmp_path / "nauro_home"
-    nauro_home.mkdir()
     cloud_pid = "01KQ6AZGNA0B3QBF67NBXP3S45"
     repo_root = tmp_path / "cloud_repo"
     repo_root.mkdir()
-    (nauro_home / "projects" / cloud_pid).mkdir(parents=True)
-    (nauro_home / REGISTRY_FILENAME).write_text(
+    (tmp_path / "projects" / cloud_pid).mkdir(parents=True)
+    (tmp_path / REGISTRY_FILENAME).write_text(
         json.dumps(
             {
                 "schema_version": REGISTRY_SCHEMA_VERSION_V2,
@@ -72,7 +70,7 @@ def test_repo_config_resolves_to_id_keyed_store(tmp_path, monkeypatch):
     monkeypatch.chdir(repo_root)
     name, store = resolve_target_project(None)
     assert name == "nauro"
-    assert store == tmp_path / "nauro_home" / "projects" / cloud_pid
+    assert store == tmp_path / "projects" / cloud_pid
 
 
 def test_resolution_walks_up_from_nested_dir(tmp_path, monkeypatch):
@@ -81,7 +79,7 @@ def test_resolution_walks_up_from_nested_dir(tmp_path, monkeypatch):
     nested.mkdir(parents=True)
     monkeypatch.chdir(nested)
     _name, store = resolve_target_project(None)
-    assert store == tmp_path / "nauro_home" / "projects" / cloud_pid
+    assert store == tmp_path / "projects" / cloud_pid
 
 
 def test_explicit_project_flag_overrides_repo_config(tmp_path, monkeypatch):
@@ -99,7 +97,7 @@ def test_explicit_project_flag_overrides_repo_config(tmp_path, monkeypatch):
     monkeypatch.chdir(repo_root)
     name, store = resolve_target_project("beta")
     assert name == "beta"
-    assert store == tmp_path / "nauro_home" / "projects" / other_pid
+    assert store == tmp_path / "projects" / other_pid
 
 
 # ── stdio _resolve_store mirrors the same precedence ─────────────────────────
@@ -109,7 +107,7 @@ def test_stdio_resolve_uses_repo_config_when_no_project_passed(tmp_path, monkeyp
     cloud_pid, repo_root = _post_migration_state(tmp_path, monkeypatch)
     monkeypatch.chdir(repo_root)
     store = _resolve_store(None, None)
-    assert store == tmp_path / "nauro_home" / "projects" / cloud_pid
+    assert store == tmp_path / "projects" / cloud_pid
 
 
 def test_stdio_resolve_mismatched_project_id_errors(tmp_path, monkeypatch):
@@ -135,7 +133,7 @@ def test_stdio_resolve_explicit_id_matching_config(tmp_path, monkeypatch):
     cloud_pid, repo_root = _post_migration_state(tmp_path, monkeypatch)
     monkeypatch.chdir(repo_root)
     store = _resolve_store(cloud_pid, str(repo_root))
-    assert store == tmp_path / "nauro_home" / "projects" / cloud_pid
+    assert store == tmp_path / "projects" / cloud_pid
 
 
 # ── integration: two projects coexist post-migration ─────────────────────────
@@ -159,12 +157,12 @@ def test_two_projects_each_resolve_to_own_store(tmp_path, monkeypatch):
     # cwd in cloud repo → cloud store
     monkeypatch.chdir(cloud_repo)
     _, store = resolve_target_project(None)
-    assert store == tmp_path / "nauro_home" / "projects" / cloud_pid
+    assert store == tmp_path / "projects" / cloud_pid
 
     # cwd in other repo → side store
     monkeypatch.chdir(other)
     _, store = resolve_target_project(None)
-    assert store == tmp_path / "nauro_home" / "projects" / side_pid
+    assert store == tmp_path / "projects" / side_pid
 
     # Cloud-mode config not corrupted by the new local-mode init in a different dir
     cfg = load_repo_config(cloud_repo)

--- a/packages/nauro/tests/test_setup.py
+++ b/packages/nauro/tests/test_setup.py
@@ -16,7 +16,6 @@ runner = CliRunner()
 
 def _setup_project(tmp_path: Path, monkeypatch, repo_paths: list[Path] | None = None):
     """Helper to create a project with repos."""
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
     if repo_paths is None:
         repo_paths = [tmp_path / "repo"]
         repo_paths[0].mkdir()
@@ -274,7 +273,6 @@ class TestLegacyCleanup:
 class TestProjectResolution:
     def test_project_flag_overrides_cwd(self, tmp_path: Path, monkeypatch):
         """--project flag overrides cwd resolution."""
-        monkeypatch.setenv("NAURO_HOME", str(tmp_path))
 
         repo_a = tmp_path / "repo_a"
         repo_b = tmp_path / "repo_b"

--- a/packages/nauro/tests/test_setup_extended.py
+++ b/packages/nauro/tests/test_setup_extended.py
@@ -45,7 +45,6 @@ def _mock_claude_cli(monkeypatch, *, on_path: bool = True, returncode: int = 0):
 
 def test_setup_cursor_writes_repo_mcp_json(tmp_path: Path, monkeypatch):
     """`nauro setup cursor` writes <repo>/.cursor/mcp.json for each project repo."""
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
     repo = tmp_path / "myrepo"
     repo.mkdir()
     pid, store_path = register_project_v2("myproj", [repo])
@@ -64,7 +63,6 @@ def test_setup_cursor_writes_repo_mcp_json(tmp_path: Path, monkeypatch):
 
 def test_setup_cursor_remove_clears_entry(tmp_path: Path, monkeypatch):
     """`nauro setup cursor --remove` deletes the nauro entry."""
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
     repo = tmp_path / "myrepo"
     repo.mkdir()
     _, store_path = register_project_v2("myproj", [repo])
@@ -167,7 +165,6 @@ def test_setup_codex_no_op_when_remove_and_no_entry(tmp_path: Path):
 
 def test_setup_claude_code_subcommand_unchanged(tmp_path: Path, monkeypatch):
     """The existing `setup claude-code` command stays callable."""
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
     monkeypatch.setenv("HOME", str(tmp_path))  # divert ~/.claude search
     repo = tmp_path / "myrepo"
     repo.mkdir()
@@ -195,7 +192,6 @@ def test_setup_top_level_help_lists_new_subcommands():
 def test_setup_all_writes_claude_cursor_codex_configs(tmp_path: Path, monkeypatch):
     """`setup all` shells out to `claude mcp add` and writes Cursor + Codex
     configs and skill files across all three surfaces."""
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
     monkeypatch.setenv("HOME", str(tmp_path))
     repo = tmp_path / "myrepo"
     repo.mkdir()
@@ -223,7 +219,6 @@ def test_setup_all_writes_claude_cursor_codex_configs(tmp_path: Path, monkeypatc
 
 
 def test_setup_all_remove_clears_everything(tmp_path: Path, monkeypatch):
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
     monkeypatch.setenv("HOME", str(tmp_path))
     repo = tmp_path / "myrepo"
     repo.mkdir()
@@ -288,7 +283,6 @@ def test_remove_preserves_user_scope_when_other_projects_exist(tmp_path: Path, m
     """``setup all --remove`` for one project must not strip the user-scope
     Claude/Codex skills or the codex MCP entry while another nauro project
     remains in the registry — those resources are shared."""
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
     monkeypatch.setenv("HOME", str(tmp_path))
     repo_a = tmp_path / "repo_a"
     repo_b = tmp_path / "repo_b"
@@ -332,7 +326,6 @@ def test_remove_preserves_user_scope_when_other_projects_exist(tmp_path: Path, m
 def test_remove_clears_user_scope_when_last_project(tmp_path: Path, monkeypatch):
     """When removing the last project, the user-scope skill files and the
     codex MCP entry are fully cleared — nothing depends on them anymore."""
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
     monkeypatch.setenv("HOME", str(tmp_path))
     repo = tmp_path / "myrepo"
     repo.mkdir()
@@ -361,7 +354,6 @@ def test_standalone_codex_remove_preserves_when_projects_remain(tmp_path: Path, 
     """``nauro setup codex --remove`` must not strip ``~/.codex/config.toml``'s
     nauro entry while any projects remain in the registry. The standalone
     command is user-global; preservation guards still-active projects."""
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
     monkeypatch.setenv("HOME", str(tmp_path))
     repo = tmp_path / "myrepo"
     repo.mkdir()
@@ -385,7 +377,6 @@ def test_standalone_codex_remove_preserves_when_projects_remain(tmp_path: Path, 
 
 def test_setup_claude_code_advertises_nauro_check(tmp_path: Path, monkeypatch):
     """`setup claude-code` success output points users at the L1 surface."""
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
     monkeypatch.setenv("HOME", str(tmp_path))
     repo = tmp_path / "myrepo"
     repo.mkdir()
@@ -400,7 +391,6 @@ def test_setup_claude_code_advertises_nauro_check(tmp_path: Path, monkeypatch):
 
 def test_setup_claude_code_remove_does_not_advertise_nauro_check(tmp_path: Path, monkeypatch):
     """The hint only fires on the add path — removal output stays minimal."""
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
     monkeypatch.setenv("HOME", str(tmp_path))
     repo = tmp_path / "myrepo"
     repo.mkdir()
@@ -414,7 +404,6 @@ def test_setup_claude_code_remove_does_not_advertise_nauro_check(tmp_path: Path,
 
 
 def test_setup_cursor_advertises_nauro_check(tmp_path: Path, monkeypatch):
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
     repo = tmp_path / "myrepo"
     repo.mkdir()
     _, store_path = register_project_v2("myproj", [repo])
@@ -427,7 +416,6 @@ def test_setup_cursor_advertises_nauro_check(tmp_path: Path, monkeypatch):
 
 
 def test_setup_all_advertises_nauro_check(tmp_path: Path, monkeypatch):
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
     monkeypatch.setenv("HOME", str(tmp_path))
     repo = tmp_path / "myrepo"
     repo.mkdir()
@@ -446,7 +434,6 @@ def test_setup_codex_advertises_nauro_check(tmp_path: Path, monkeypatch):
     knowing they can demo conflict-detection from the shell before opening a
     Codex session.
     """
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
     monkeypatch.setenv("HOME", str(tmp_path))
 
     result = runner.invoke(app, ["setup", "codex"])

--- a/packages/nauro/tests/test_stdio_server.py
+++ b/packages/nauro/tests/test_stdio_server.py
@@ -26,7 +26,6 @@ from nauro.validation.pending import clear_all
 @pytest.fixture
 def store(tmp_path: Path, monkeypatch) -> Path:
     """Pre-scaffolded project store with known content."""
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
     store_path = register_project("testproj", [tmp_path / "repo"])
     scaffold_project_store("testproj", store_path)
 

--- a/packages/nauro/tests/test_store.py
+++ b/packages/nauro/tests/test_store.py
@@ -662,7 +662,6 @@ def _minimal_v2_decision(path: Path, num: int, title: str) -> None:
 
 
 def test_note_decision_cli(tmp_path: Path, monkeypatch):
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
     from nauro.store.registry import register_project
 
     store = register_project("myproj", [tmp_path])
@@ -676,7 +675,6 @@ def test_note_decision_cli(tmp_path: Path, monkeypatch):
 
 
 def test_note_question_auto_detect(tmp_path: Path, monkeypatch):
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
     from nauro.store.registry import register_project
 
     store = register_project("myproj", [tmp_path])
@@ -689,7 +687,6 @@ def test_note_question_auto_detect(tmp_path: Path, monkeypatch):
 
 
 def test_note_question_flag(tmp_path: Path, monkeypatch):
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
     from nauro.store.registry import register_project
 
     store = register_project("myproj", [tmp_path])
@@ -702,7 +699,6 @@ def test_note_question_flag(tmp_path: Path, monkeypatch):
 
 
 def test_note_no_project(tmp_path: Path, monkeypatch):
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
     monkeypatch.chdir(tmp_path)
 
     result = runner.invoke(app, ["note", "something"])
@@ -714,7 +710,6 @@ def test_note_no_project(tmp_path: Path, monkeypatch):
 
 
 def test_sync_cli(tmp_path: Path, monkeypatch):
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
     from nauro.store.registry import register_project
 
     store = register_project("myproj", [tmp_path])
@@ -728,7 +723,6 @@ def test_sync_cli(tmp_path: Path, monkeypatch):
 
 
 def test_sync_with_message(tmp_path: Path, monkeypatch):
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
     from nauro.store.registry import register_project
 
     store = register_project("myproj", [tmp_path])
@@ -744,7 +738,6 @@ def test_sync_with_message(tmp_path: Path, monkeypatch):
 
 
 def test_sync_no_project(tmp_path: Path, monkeypatch):
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
     monkeypatch.chdir(tmp_path)
 
     result = runner.invoke(app, ["sync"])

--- a/packages/nauro/tests/test_sync/test_hooks.py
+++ b/packages/nauro/tests/test_sync/test_hooks.py
@@ -17,7 +17,6 @@ from nauro.templates.scaffolds import scaffold_project_store
 
 @pytest.fixture()
 def project_store(tmp_path: Path, monkeypatch):
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
     store = register_project("testproj", [tmp_path])
     scaffold_project_store("testproj", store)
     return store

--- a/packages/nauro/tests/test_sync/test_sync_command.py
+++ b/packages/nauro/tests/test_sync/test_sync_command.py
@@ -16,7 +16,6 @@ runner = CliRunner()
 @pytest.fixture()
 def project_store(tmp_path: Path, monkeypatch):
     """Set up a project store for testing."""
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
     store = register_project("testproj", [tmp_path])
     scaffold_project_store("testproj", store)
     monkeypatch.chdir(tmp_path)

--- a/packages/nauro/tests/test_tools_store_field.py
+++ b/packages/nauro/tests/test_tools_store_field.py
@@ -13,7 +13,6 @@ from nauro.templates.scaffolds import scaffold_project_store
 
 
 def _setup_store(tmp_path, monkeypatch) -> Path:
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
     store = register_project("testproj", [tmp_path])
     scaffold_project_store("testproj", store)
     return store

--- a/packages/nauro/tests/test_validation/test_mcp_validation.py
+++ b/packages/nauro/tests/test_validation/test_mcp_validation.py
@@ -19,7 +19,6 @@ def store(tmp_path: Path) -> Path:
 
 @pytest.fixture
 def client(tmp_path: Path, monkeypatch, store) -> AsyncClient:
-    monkeypatch.setenv("NAURO_HOME", str(tmp_path))
     transport = ASGITransport(app=app)
     return AsyncClient(transport=transport, base_url="http://test")
 


### PR DESCRIPTION
## Why

PR #56 introduced an autouse fixture isolating `NAURO_HOME` at `tmp_path/nauro_home`, but the majority of the pre-existing suite (61 callsites across 15 files) explicitly overrode it to bare `tmp_path`. The override chain worked, but the documented default conflicted with prevailing usage, and any new test would copy whichever pattern its author encountered first.

## Approach

Flip the autouse default to **bare `tmp_path`** (the 3× more common existing convention), then delete every now-redundant explicit setenv. Rewrite path assertions that hardcoded the `nauro_home/` segment.

Considered the reverse — keep the autouse at `tmp_path/nauro_home` and rewrite the 61 bare-`tmp_path` callsites instead — but that touches more files, requires more assertion rewrites, and aligns the convention against the established direction.

## What changed

- **Autouse fixture** in `packages/nauro/tests/conftest.py`: `tmp_path/nauro_home` → `tmp_path`. Docstring updated.
- **Deleted 61** redundant `monkeypatch.setenv(\"NAURO_HOME\", str(tmp_path))` lines.
- **Deleted 21** explicit `tmp_path/nauro_home` overrides (now redundant under the bare autouse).
- **Rewrote 19** path expressions that hardcoded `tmp_path / \"nauro_home\" / ...` to bare `tmp_path / ...`.
- Dropped two stale `nauro_home.mkdir()` calls where `nauro_home` aliased `tmp_path` (already created by pytest).
- Inlined the now-vacuous `nauro_home = tmp_path` alias in `_post_migration_state` (test_resolution_v2.py).

## What to review

Nine remaining `monkeypatch.setenv(\"NAURO_HOME\", str(home))` callsites are intentional custom overrides — per-file fixtures that build `home = tmp_path / \".nauro\"`. They override the autouse correctly and live in `test_telemetry_*`, `test_consent_prompt`, `test_identity_lifecycle`, `test_mcp_tool_called`, `test_cli_command_invoked`, `test_project_created_event`, and `test_sync/test_config`. Out of scope for this PR; they're internally consistent within their own files.

Awareness note (not introduced here, but the official convention now): `NAURO_HOME == cwd` after both `_isolate_cwd` and `_isolate_nauro_home` autouse fixtures point at `tmp_path`. Nauro's control-plane artifacts (`registry.json`, `projects/`, `config.json`) coexist with test-created repos and `.nauro/` configs in the same directory. Already the pattern in 61 pre-existing tests; this PR doesn't introduce it but makes it canonical.

## What's deferred

- The 5th `_clear_pending` copy in `test_stdio_server.py` (same rationale as PR #56).
- Now-unused `monkeypatch` parameters in test signatures.
- Unifying the 9 `.nauro` per-file fixtures.

## Test plan

- `uv run --package nauro pytest packages/nauro/tests/ -q` → 902 passed.
- `uv run --package nauro-core pytest packages/nauro-core/tests/ -q` → 306 passed.
- `uv run ruff check packages/` + `ruff format --check packages/` clean.