### PR TITLE
feat(setup): write .mcp.json directly for Claude Code (D142)

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/setup.py
+++ b/packages/nauro/src/nauro/cli/commands/setup.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import json
 import shutil
-import subprocess
 import sys
 from pathlib import Path
 
@@ -99,72 +98,45 @@ def _user_scope_safe_to_clear(current_project_key: str | None) -> bool:
 
 
 def _configure_mcp(repo_path: Path, *, remove: bool = False) -> str:
-    """Add or remove the Nauro MCP entry in Claude Code via the ``claude`` CLI.
+    """Add or remove the Nauro MCP entry in the repo's project-scope ``.mcp.json``.
 
-    Uses ``--scope project`` so the entry is written to ``<repo>/.mcp.json``,
-    making it shareable with collaborators via git — mirroring the Cursor
-    surface model. The shell-out is intentional: Claude Code's per-project
-    config layout has changed before; ``claude mcp add`` is the supported
-    entry point.
+    Writes the file directly. The format is documented in Anthropic's MCP
+    docs as a standardized shape, used by plugins shipping ``.mcp.json`` at
+    their roots and by enterprise ``managed-mcp.json`` deployments. Per D142,
+    this matches how ``_configure_cursor_for_repo`` handles ``.cursor/mcp.json``
+    and ``_configure_codex`` handles ``~/.codex/config.toml``, removing the
+    silent-skip failure mode users hit when the ``claude`` CLI was missing.
 
     Returns a one-line status string (indented for ``setup_all_surfaces``).
     """
-    if shutil.which("claude") is None:
-        if remove:
-            return "Claude Code CLI not found on PATH; nothing to remove."
-        return (
-            "Claude Code CLI not found on PATH; skipping Claude Code wiring "
-            "(run 'nauro setup claude-code' after installing it)."
-        )
-
+    config_path = repo_path / ".mcp.json"
     nauro_cmd = _find_nauro_command()
+    nauro_entry = {"command": nauro_cmd, "args": ["serve", "--stdio"]}
 
-    if remove:
-        # Pre-check the file rather than parse `claude mcp remove` stderr —
-        # stderr wording is unstable across Claude Code versions, but the
-        # project-scope `.mcp.json` shape is the documented contract.
-        mcp_json = repo_path / ".mcp.json"
-        if not mcp_json.is_file():
-            return f"  {repo_path}: no nauro entry to remove"
+    if config_path.exists():
         try:
-            config = json.loads(mcp_json.read_text())
+            config = json.loads(config_path.read_text())
         except json.JSONDecodeError as exc:
             return f"  {repo_path}: could not parse .mcp.json — {exc}"
-        if "nauro" not in config.get("mcpServers", {}):
+    else:
+        config = {}
+
+    if remove:
+        servers = config.get("mcpServers", {})
+        if "nauro" not in servers:
             return f"  {repo_path}: no nauro entry to remove"
+        del servers["nauro"]
+        if not servers:
+            config.pop("mcpServers", None)
+        if config:
+            config_path.write_text(json.dumps(config, indent=2) + "\n")
+        else:
+            config_path.unlink()
+        return f"  {repo_path}: removed nauro from .mcp.json"
 
-        result = subprocess.run(
-            ["claude", "mcp", "remove", "nauro"],
-            cwd=repo_path,
-            check=False,
-            capture_output=True,
-            text=True,
-        )
-        if result.returncode == 0:
-            return f"  {repo_path}: removed nauro from .mcp.json"
-        return f"  {repo_path}: claude mcp remove failed — {(result.stderr or '').strip()}"
-
-    result = subprocess.run(
-        [
-            "claude",
-            "mcp",
-            "add",
-            "--scope",
-            "project",
-            "nauro",
-            "--",
-            nauro_cmd,
-            "serve",
-            "--stdio",
-        ],
-        cwd=repo_path,
-        check=False,
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode == 0:
-        return f"  {repo_path}: wrote nauro to .mcp.json"
-    return f"  {repo_path}: claude mcp add failed — {(result.stderr or '').strip()}"
+    config.setdefault("mcpServers", {})["nauro"] = nauro_entry
+    config_path.write_text(json.dumps(config, indent=2) + "\n")
+    return f"  {repo_path}: wrote nauro to .mcp.json"
 
 
 @setup_app.command(name="claude-code")
@@ -250,7 +222,10 @@ def _configure_cursor_for_repo(repo_path: Path, *, remove: bool) -> str:
     nauro_entry = {"command": nauro_cmd, "args": ["serve", "--stdio"]}
 
     if config_path.exists():
-        config = json.loads(config_path.read_text())
+        try:
+            config = json.loads(config_path.read_text())
+        except json.JSONDecodeError as exc:
+            return f"  {repo_path}: could not parse .cursor/mcp.json — {exc}"
     else:
         config = {}
 
@@ -517,7 +492,7 @@ def setup_all_surfaces(
 
     lines: list[str] = []
 
-    # Claude Code (MCP per-repo via `claude mcp add --scope project` + skills global)
+    # Claude Code (MCP per-repo via direct `.mcp.json` write + skills global)
     for repo in project_repos:
         if not repo.is_dir():
             lines.append(f"  {repo}: repo path missing, skipped")

--- a/packages/nauro/tests/test_setup.py
+++ b/packages/nauro/tests/test_setup.py
@@ -1,7 +1,6 @@
 """Tests for nauro setup claude-code command."""
 
 import json
-import subprocess
 from pathlib import Path
 
 from typer.testing import CliRunner
@@ -25,173 +24,156 @@ def _setup_project(tmp_path: Path, monkeypatch, repo_paths: list[Path] | None = 
     return repo_paths
 
 
-def _mock_claude_cli(monkeypatch, *, on_path: bool = True, returncode: int = 0, stderr: str = ""):
-    """Mock the `claude` CLI for setup tests.
+class TestMCPConfigDirectWrite:
+    """`_configure_mcp` writes ``<repo>/.mcp.json`` directly (per D142).
 
-    Returns a list that captures every (argv, kwargs) call to subprocess.run
-    so individual tests can assert on shape (cwd, scope, etc.).
-    """
-    calls: list[tuple[list[str], dict]] = []
-
-    monkeypatch.setattr(
-        "nauro.cli.commands.setup.shutil.which",
-        lambda cmd: "/usr/local/bin/claude" if (on_path and cmd == "claude") else None,
-    )
-
-    def fake_run(argv, **kwargs):
-        calls.append((list(argv), dict(kwargs)))
-        return subprocess.CompletedProcess(
-            args=argv, returncode=returncode, stdout="", stderr=stderr
-        )
-
-    monkeypatch.setattr("nauro.cli.commands.setup.subprocess.run", fake_run)
-    return calls
-
-
-class TestMCPConfigShellout:
-    """`_configure_mcp` shells out to `claude mcp add/remove` (project scope).
-
-    The original direct-JSON path wrote to `~/.claude/claude_desktop_config.json`
-    (which is Claude *Desktop*); Claude Code reads `~/.claude.json` and per-repo
-    `<repo>/.mcp.json`. These tests lock in the shellout shape so the bug
-    can't regress.
+    The format is the documented Claude Code project-scope shape: an
+    ``mcpServers`` object map keyed by server name. These tests lock in the
+    file contents and merge behavior so the direct-write contract does not
+    silently regress.
     """
 
-    def test_add_path_argv_and_cwd(self, tmp_path: Path, monkeypatch):
+    def test_add_writes_mcp_json(self, tmp_path: Path):
         repo = tmp_path / "repo"
         repo.mkdir()
-        calls = _mock_claude_cli(monkeypatch)
 
         result = _configure_mcp(repo, remove=False)
 
-        assert len(calls) == 1
-        argv, kwargs = calls[0]
-        assert argv[:6] == ["claude", "mcp", "add", "--scope", "project", "nauro"]
-        assert argv[6] == "--"
-        # argv[7] is the resolved nauro binary path
-        assert argv[8:] == ["serve", "--stdio"]
-        assert kwargs.get("cwd") == repo
-        assert kwargs.get("check") is False
+        config = json.loads((repo / ".mcp.json").read_text())
+        assert "nauro" in config["mcpServers"]
+        entry = config["mcpServers"]["nauro"]
+        assert entry["args"] == ["serve", "--stdio"]
+        assert isinstance(entry["command"], str) and entry["command"]
         assert "wrote nauro to .mcp.json" in result
 
-    def test_remove_path_argv_and_cwd(self, tmp_path: Path, monkeypatch):
+    def test_add_preserves_existing_servers(self, tmp_path: Path):
+        """Existing servers in `.mcp.json` are preserved when we add nauro."""
         repo = tmp_path / "repo"
         repo.mkdir()
-        # The remove path now pre-checks <repo>/.mcp.json and only invokes
-        # `claude mcp remove` when the nauro entry is actually present.
-        (repo / ".mcp.json").write_text(json.dumps({"mcpServers": {"nauro": {}}}))
-        calls = _mock_claude_cli(monkeypatch)
+        existing = {"mcpServers": {"other": {"command": "/usr/local/bin/other", "args": ["serve"]}}}
+        (repo / ".mcp.json").write_text(json.dumps(existing))
+
+        result = _configure_mcp(repo, remove=False)
+
+        config = json.loads((repo / ".mcp.json").read_text())
+        assert config["mcpServers"]["other"] == existing["mcpServers"]["other"]
+        assert "nauro" in config["mcpServers"]
+        assert "wrote nauro to .mcp.json" in result
+
+    def test_add_overwrites_stale_nauro_entry(self, tmp_path: Path):
+        """A pre-existing `nauro` entry is overwritten with the current command path."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        stale = {"mcpServers": {"nauro": {"command": "/old/path/to/nauro", "args": ["different"]}}}
+        (repo / ".mcp.json").write_text(json.dumps(stale))
+
+        _configure_mcp(repo, remove=False)
+
+        config = json.loads((repo / ".mcp.json").read_text())
+        assert config["mcpServers"]["nauro"]["args"] == ["serve", "--stdio"]
+        assert config["mcpServers"]["nauro"]["command"] != "/old/path/to/nauro"
+
+    def test_add_surfaces_parse_error_without_clobbering(self, tmp_path: Path):
+        """Malformed `.mcp.json` on the add path surfaces a parse error and
+        leaves the existing file untouched."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / ".mcp.json").write_text("{not json")
+
+        result = _configure_mcp(repo, remove=False)
+
+        assert "could not parse .mcp.json" in result
+        assert (repo / ".mcp.json").read_text() == "{not json"
+
+    def test_remove_deletes_nauro_entry_and_unlinks_empty_file(self, tmp_path: Path):
+        """Remove the nauro entry; if mcpServers becomes empty, drop the file."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / ".mcp.json").write_text(
+            json.dumps({"mcpServers": {"nauro": {"command": "/x", "args": []}}})
+        )
 
         result = _configure_mcp(repo, remove=True)
 
-        assert len(calls) == 1
-        argv, kwargs = calls[0]
-        assert argv == ["claude", "mcp", "remove", "nauro"]
-        assert kwargs.get("cwd") == repo
         assert "removed nauro from .mcp.json" in result
+        assert not (repo / ".mcp.json").exists()
 
-    def test_skips_when_claude_not_on_path(self, tmp_path: Path, monkeypatch):
+    def test_remove_preserves_other_servers(self, tmp_path: Path):
+        """Removing nauro keeps other server entries and rewrites the file."""
         repo = tmp_path / "repo"
         repo.mkdir()
-        calls = _mock_claude_cli(monkeypatch, on_path=False)
-
-        result = _configure_mcp(repo, remove=False)
-
-        assert calls == []  # subprocess.run never invoked
-        assert "skipping Claude Code wiring" in result
-
-    def test_remove_when_claude_not_on_path_says_nothing_to_remove(
-        self, tmp_path: Path, monkeypatch
-    ):
-        """On --remove with no `claude` CLI, surface a remove-shaped message
-        rather than telling the user to install Claude Code (which is the
-        add-path hint). Locks in the branched message."""
-        repo = tmp_path / "repo"
-        repo.mkdir()
-        calls = _mock_claude_cli(monkeypatch, on_path=False)
+        (repo / ".mcp.json").write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "nauro": {"command": "/x", "args": []},
+                        "other": {"command": "/y", "args": []},
+                    }
+                }
+            )
+        )
 
         result = _configure_mcp(repo, remove=True)
 
-        assert calls == []
-        assert "nothing to remove" in result
-        assert "skipping Claude Code wiring" not in result
+        assert "removed nauro from .mcp.json" in result
+        config = json.loads((repo / ".mcp.json").read_text())
+        assert "nauro" not in config["mcpServers"]
+        assert "other" in config["mcpServers"]
 
-    def test_non_zero_exit_surfaces_stderr(self, tmp_path: Path, monkeypatch):
+    def test_remove_skips_when_no_mcp_json(self, tmp_path: Path):
+        """No `.mcp.json` at all → no-op."""
         repo = tmp_path / "repo"
         repo.mkdir()
-        _mock_claude_cli(monkeypatch, returncode=1, stderr="some claude error")
-
-        result = _configure_mcp(repo, remove=False)
-
-        assert "some claude error" in result
-        assert "claude mcp add failed" in result
-
-    def test_remove_skips_when_no_mcp_json(self, tmp_path: Path, monkeypatch):
-        """No `.mcp.json` at all → no-op without invoking the CLI."""
-        repo = tmp_path / "repo"
-        repo.mkdir()
-        calls = _mock_claude_cli(monkeypatch)
 
         result = _configure_mcp(repo, remove=True)
 
-        assert calls == []
         assert "no nauro entry to remove" in result
+        assert not (repo / ".mcp.json").exists()
 
-    def test_remove_skips_when_nauro_absent_from_mcp_json(self, tmp_path: Path, monkeypatch):
-        """`.mcp.json` exists but has no nauro entry → no-op without invoking CLI."""
+    def test_remove_skips_when_nauro_absent_from_mcp_json(self, tmp_path: Path):
+        """`.mcp.json` exists but has no nauro entry → no-op, file untouched."""
         repo = tmp_path / "repo"
         repo.mkdir()
-        (repo / ".mcp.json").write_text(json.dumps({"mcpServers": {"other": {}}}))
-        calls = _mock_claude_cli(monkeypatch)
+        original = json.dumps({"mcpServers": {"other": {}}})
+        (repo / ".mcp.json").write_text(original)
 
         result = _configure_mcp(repo, remove=True)
 
-        assert calls == []
         assert "no nauro entry to remove" in result
+        assert (repo / ".mcp.json").read_text() == original
 
-    def test_remove_handles_malformed_mcp_json(self, tmp_path: Path, monkeypatch):
+    def test_remove_handles_malformed_mcp_json(self, tmp_path: Path):
         """Malformed `.mcp.json` surfaces a parse error instead of crashing."""
         repo = tmp_path / "repo"
         repo.mkdir()
         (repo / ".mcp.json").write_text("{not json")
-        calls = _mock_claude_cli(monkeypatch)
 
         result = _configure_mcp(repo, remove=True)
 
-        assert calls == []
         assert "could not parse .mcp.json" in result
 
     def test_setup_all_iterates_per_repo(self, tmp_path: Path, monkeypatch):
-        """Multi-repo project: `setup all` invokes `claude mcp add` once per
-        repo with the matching cwd. Locks in the project-scope iteration that
-        the multi-repo flow depends on."""
+        """Multi-repo project: `setup all` writes `.mcp.json` once per repo."""
         from nauro.cli.commands.setup import setup_all_surfaces
 
         repo1 = tmp_path / "repo1"
         repo2 = tmp_path / "repo2"
         repo1.mkdir()
         repo2.mkdir()
-        # Pretend HOME exists so claude/codex skill dirs are writable.
+        # HOME redirect so claude/codex skill dirs land under tmp_path.
         monkeypatch.setenv("HOME", str(tmp_path))
-        calls = _mock_claude_cli(monkeypatch)
 
         setup_all_surfaces([repo1, repo2], remove=False)
 
-        # Two `claude mcp add` calls — one per repo, each with the right cwd.
-        add_calls = [(argv, kwargs) for argv, kwargs in calls if argv[2] == "add"]
-        assert len(add_calls) == 2
-        cwds = {kwargs.get("cwd") for _, kwargs in add_calls}
-        assert cwds == {repo1, repo2}
+        for repo in (repo1, repo2):
+            config = json.loads((repo / ".mcp.json").read_text())
+            assert "nauro" in config["mcpServers"]
 
 
 class TestAGENTSMD:
     def test_setup_regenerates_agents_md(self, tmp_path: Path, monkeypatch):
         """Setup regenerates AGENTS.md in all repos."""
         repos = _setup_project(tmp_path, monkeypatch)
-
-        # Mock claude CLI as missing — these tests don't care about wiring,
-        # only the surrounding code paths (legacy CLAUDE.md cleanup, AGENTS.md, etc.).
-        _mock_claude_cli(monkeypatch, on_path=False)
 
         result = runner.invoke(app, ["setup", "claude-code", "--project", "testproj"])
         assert result.exit_code == 0
@@ -210,10 +192,6 @@ class TestNoClaudeMDInjection:
         repos = _setup_project(tmp_path, monkeypatch)
         assert not (repos[0] / "CLAUDE.md").exists()
 
-        # Mock claude CLI as missing — these tests don't care about wiring,
-        # only the surrounding code paths (legacy CLAUDE.md cleanup, AGENTS.md, etc.).
-        _mock_claude_cli(monkeypatch, on_path=False)
-
         result = runner.invoke(app, ["setup", "claude-code", "--project", "testproj"])
         assert result.exit_code == 0
         assert not (repos[0] / "CLAUDE.md").exists()
@@ -223,10 +201,6 @@ class TestNoClaudeMDInjection:
         repos = _setup_project(tmp_path, monkeypatch)
         existing = "# My Project\n\nSome existing content.\n"
         (repos[0] / "CLAUDE.md").write_text(existing)
-
-        # Mock claude CLI as missing — these tests don't care about wiring,
-        # only the surrounding code paths (legacy CLAUDE.md cleanup, AGENTS.md, etc.).
-        _mock_claude_cli(monkeypatch, on_path=False)
 
         result = runner.invoke(app, ["setup", "claude-code", "--project", "testproj"])
         assert result.exit_code == 0
@@ -242,10 +216,6 @@ class TestLegacyCleanup:
         content = f"# My Project\n\nKeep this.\n\n{CLAUDE_MD_START}\nold block\n{CLAUDE_MD_END}\n"
         (repos[0] / "CLAUDE.md").write_text(content)
 
-        # Mock claude CLI as missing — these tests don't care about wiring,
-        # only the surrounding code paths (legacy CLAUDE.md cleanup, AGENTS.md, etc.).
-        _mock_claude_cli(monkeypatch, on_path=False)
-
         result = runner.invoke(app, ["setup", "claude-code", "--project", "testproj"])
         assert result.exit_code == 0
 
@@ -260,10 +230,6 @@ class TestLegacyCleanup:
         repos = _setup_project(tmp_path, monkeypatch)
         content = f"{CLAUDE_MD_START}\nold block\n{CLAUDE_MD_END}\n"
         (repos[0] / "CLAUDE.md").write_text(content)
-
-        # Mock claude CLI as missing — these tests don't care about wiring,
-        # only the surrounding code paths (legacy CLAUDE.md cleanup, AGENTS.md, etc.).
-        _mock_claude_cli(monkeypatch, on_path=False)
 
         result = runner.invoke(app, ["setup", "claude-code", "--project", "testproj"])
         assert result.exit_code == 0
@@ -286,10 +252,6 @@ class TestProjectResolution:
 
         monkeypatch.chdir(repo_a)
 
-        # Mock claude CLI as missing — these tests don't care about wiring,
-        # only the surrounding code paths (legacy CLAUDE.md cleanup, AGENTS.md, etc.).
-        _mock_claude_cli(monkeypatch, on_path=False)
-
         result = runner.invoke(app, ["setup", "claude-code", "--project", "proj-b"])
         assert result.exit_code == 0
 
@@ -304,10 +266,6 @@ class TestProjectResolution:
         repo2.mkdir()
 
         _setup_project(tmp_path, monkeypatch, repo_paths=[repo1, repo2])
-
-        # Mock claude CLI as missing — these tests don't care about wiring,
-        # only the surrounding code paths (legacy CLAUDE.md cleanup, AGENTS.md, etc.).
-        _mock_claude_cli(monkeypatch, on_path=False)
 
         result = runner.invoke(app, ["setup", "claude-code", "--project", "testproj"])
         assert result.exit_code == 0

--- a/packages/nauro/tests/test_setup_extended.py
+++ b/packages/nauro/tests/test_setup_extended.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import subprocess
 import sys
 from pathlib import Path
 
@@ -24,20 +23,6 @@ else:
     import tomli as tomllib
 
 runner = CliRunner()
-
-
-def _mock_claude_cli(monkeypatch, *, on_path: bool = True, returncode: int = 0):
-    """Mock the `claude` CLI for any test that exercises the Claude Code path."""
-    monkeypatch.setattr(
-        "nauro.cli.commands.setup.shutil.which",
-        lambda cmd: "/usr/local/bin/claude" if (on_path and cmd == "claude") else None,
-    )
-    monkeypatch.setattr(
-        "nauro.cli.commands.setup.subprocess.run",
-        lambda argv, **kwargs: subprocess.CompletedProcess(
-            args=argv, returncode=returncode, stdout="", stderr=""
-        ),
-    )
 
 
 # ─── nauro setup cursor ─────────────────────────────────────────────────────
@@ -109,6 +94,30 @@ def test_configure_cursor_remove_preserves_other_servers(tmp_path: Path):
     result = json.loads((repo / ".cursor" / "mcp.json").read_text())
     assert "other" in result["mcpServers"]
     assert "nauro" not in result["mcpServers"]
+
+
+def test_configure_cursor_add_surfaces_parse_error_without_clobbering(tmp_path: Path):
+    """Hand-edited / corrupt `.cursor/mcp.json` surfaces a parse error
+    rather than crashing — same contract as `_configure_mcp` for `.mcp.json`."""
+    repo = tmp_path / "repo"
+    (repo / ".cursor").mkdir(parents=True)
+    (repo / ".cursor" / "mcp.json").write_text("{not json")
+
+    msg = _configure_cursor_for_repo(repo, remove=False)
+
+    assert "could not parse .cursor/mcp.json" in msg
+    assert (repo / ".cursor" / "mcp.json").read_text() == "{not json"
+
+
+def test_configure_cursor_remove_surfaces_parse_error(tmp_path: Path):
+    """Same parse-error contract on the `--remove` path."""
+    repo = tmp_path / "repo"
+    (repo / ".cursor").mkdir(parents=True)
+    (repo / ".cursor" / "mcp.json").write_text("{not json")
+
+    msg = _configure_cursor_for_repo(repo, remove=True)
+
+    assert "could not parse .cursor/mcp.json" in msg
 
 
 # ─── nauro setup codex ──────────────────────────────────────────────────────
@@ -190,22 +199,24 @@ def test_setup_top_level_help_lists_new_subcommands():
 
 
 def test_setup_all_writes_claude_cursor_codex_configs(tmp_path: Path, monkeypatch):
-    """`setup all` shells out to `claude mcp add` and writes Cursor + Codex
-    configs and skill files across all three surfaces."""
+    """`setup all` writes `.mcp.json`, `.cursor/mcp.json`, and `~/.codex/config.toml`
+    plus the skill files across all three surfaces."""
     monkeypatch.setenv("HOME", str(tmp_path))
     repo = tmp_path / "myrepo"
     repo.mkdir()
     _, store_path = register_project_v2("myproj", [repo])
     scaffold_project_store("myproj", store_path)
     monkeypatch.chdir(repo)
-    _mock_claude_cli(monkeypatch)
 
     result = runner.invoke(app, ["setup", "all"])
     assert result.exit_code == 0, result.output
 
-    # MCP configs (Claude Code is wired via the mocked `claude mcp add` shellout
-    # — the actual .mcp.json write is the `claude` CLI's responsibility, so the
-    # multi-repo iteration test in test_setup.py covers the argv shape).
+    # Claude Code: project-scope .mcp.json at the repo root (per D142, written
+    # directly rather than via `claude mcp add`).
+    assert (repo / ".mcp.json").is_file()
+    mcp_data = json.loads((repo / ".mcp.json").read_text())
+    assert mcp_data["mcpServers"]["nauro"]["args"] == ["serve", "--stdio"]
+    # Cursor + Codex:
     assert (repo / ".cursor" / "mcp.json").is_file()
     assert (tmp_path / ".codex" / "config.toml").is_file()
 
@@ -225,12 +236,13 @@ def test_setup_all_remove_clears_everything(tmp_path: Path, monkeypatch):
     _, store_path = register_project_v2("myproj", [repo])
     scaffold_project_store("myproj", store_path)
     monkeypatch.chdir(repo)
-    _mock_claude_cli(monkeypatch)
 
     runner.invoke(app, ["setup", "all"])
     result = runner.invoke(app, ["setup", "all", "--remove"])
     assert result.exit_code == 0, result.output
 
+    # MCP configs gone:
+    assert not (repo / ".mcp.json").exists()
     # Skill files gone:
     assert not (tmp_path / ".claude" / "skills" / "nauro-adopt" / "SKILL.md").exists()
     assert not (repo / ".cursor" / "rules" / "nauro-adopt.mdc").exists()
@@ -292,7 +304,6 @@ def test_remove_preserves_user_scope_when_other_projects_exist(tmp_path: Path, m
     scaffold_project_store("proj-a", store_a)
     _, store_b = register_project_v2("proj-b", [repo_b])
     scaffold_project_store("proj-b", store_b)
-    _mock_claude_cli(monkeypatch)
 
     monkeypatch.chdir(repo_a)
     runner.invoke(app, ["setup", "all", "--project", "proj-a"])
@@ -316,9 +327,11 @@ def test_remove_preserves_user_scope_when_other_projects_exist(tmp_path: Path, m
     assert data["mcp_servers"]["nauro"]["args"] == ["serve", "--stdio"]
 
     # Per-repo wiring for proj-a still got torn down.
+    assert not (repo_a / ".mcp.json").is_file()
     assert not (repo_a / ".cursor" / "mcp.json").is_file()
     assert not (repo_a / ".cursor" / "rules" / "nauro.mdc").is_file()
     # And proj-b's per-repo wiring stayed put.
+    assert (repo_b / ".mcp.json").is_file()
     assert (repo_b / ".cursor" / "mcp.json").is_file()
     assert (repo_b / ".cursor" / "rules" / "nauro.mdc").is_file()
 
@@ -332,7 +345,6 @@ def test_remove_clears_user_scope_when_last_project(tmp_path: Path, monkeypatch)
     _, store_path = register_project_v2("solo", [repo])
     scaffold_project_store("solo", store_path)
     monkeypatch.chdir(repo)
-    _mock_claude_cli(monkeypatch)
 
     runner.invoke(app, ["setup", "all"])
     result = runner.invoke(app, ["setup", "all", "--remove"])
@@ -382,7 +394,6 @@ def test_setup_claude_code_advertises_nauro_check(tmp_path: Path, monkeypatch):
     repo.mkdir()
     register_project_v2("myproj", [repo])
     monkeypatch.chdir(repo)
-    _mock_claude_cli(monkeypatch)
 
     result = runner.invoke(app, ["setup", "claude-code"])
     assert result.exit_code == 0, result.output
@@ -396,7 +407,6 @@ def test_setup_claude_code_remove_does_not_advertise_nauro_check(tmp_path: Path,
     repo.mkdir()
     register_project_v2("myproj", [repo])
     monkeypatch.chdir(repo)
-    _mock_claude_cli(monkeypatch)
 
     result = runner.invoke(app, ["setup", "claude-code", "--remove"])
     assert result.exit_code == 0, result.output
@@ -422,7 +432,6 @@ def test_setup_all_advertises_nauro_check(tmp_path: Path, monkeypatch):
     _, store_path = register_project_v2("myproj", [repo])
     scaffold_project_store("myproj", store_path)
     monkeypatch.chdir(repo)
-    _mock_claude_cli(monkeypatch)
 
     result = runner.invoke(app, ["setup", "all"])
     assert result.exit_code == 0, result.output


### PR DESCRIPTION
## Why

A user with the Claude Code VS Code extension installed but no `claude` CLI on PATH ran `nauro setup claude-code` and saw a silent skip: "Configured Nauro" banner, a "skipping Claude Code wiring" line buried between two success messages, exit code 0. She had no signal MCP wasn't wired. On the same surface, the other two handlers (`_configure_cursor_for_repo` and `_configure_codex`) write their config files directly. Only Claude Code shelled out.

## Approach

Per D142, write `.mcp.json` directly and drop the `claude` CLI dependency. Mirrors the existing Cursor handler. Alternatives the decision rejected: keep the shell-out and exit non-zero when the CLI is missing (still requires users to install a second tool to use Nauro), or hybrid shell-out-then-fall-back-to-direct-write (extra complexity for marginal future-proofing).

## What changed

- `_configure_mcp` rewritten: read existing `.mcp.json`, merge nauro into `mcpServers`, write. `--remove` deletes the entry, prunes empty `mcpServers`, unlinks empty files.
- `_configure_cursor_for_repo` gets the same `JSONDecodeError` handler as `_configure_mcp` for symmetric parse-error UX. Two tests added.
- `subprocess` import gone. `shutil.which("claude")` guard gone. The multi-paragraph shell-out justification comment replaced with a D142 reference.
- One-line comment in `setup_all_surfaces` updated.
- `TestMCPConfigShellout` renamed to `TestMCPConfigDirectWrite`. Three obsolete tests dropped (failure modes gone by design), three rewritten to assert file contents, four added covering merge/overwrite/malformed-add/remove-with-others.
- `test_setup_extended.py` shed the `_mock_claude_cli` helper and five callers; `test_setup_all_*` now asserts `.mcp.json` contents.

## What to review

- Merge logic in `_configure_mcp` against `_configure_cursor_for_repo`. Same shape on purpose. Open to extracting a shared helper if that reads better.
- The remove path unlinks `.mcp.json` when `mcpServers` becomes empty after pruning nauro. Cursor does the same; flagging because it's the only behavior change visible to a user with no other MCP servers in the repo.

## What's deferred

- `nauro note` should refresh AGENTS.md after writing. Separate small PR; same user incident surfaced both bugs but bundling hurts review and bisect.
- `state_current.md` scaffold copy fix (mentions `update_state` as if it were a CLI command). Paper cut, follow-up.
- `_configure_codex` uses `tomllib.load` without a parse-error handler. Same UX gap the Cursor handler had pre-PR. Separate small PR.

## Test plan

- `pytest packages/nauro/tests/test_setup.py packages/nauro/tests/test_setup_extended.py -x -q` — 41 passed
- `pytest packages/nauro/tests/ -x -q` — 905 passed (full nauro suite)
- `pytest packages/nauro-core/tests/ -x -q` — 306 passed
- `ruff format` + `ruff check packages/` — clean