### PR TITLE
fix(note): regenerate AGENTS.md after writing decision or question (D143)

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/note.py
+++ b/packages/nauro/src/nauro/cli/commands/note.py
@@ -1,9 +1,34 @@
 """nauro note — Add a decision or question to the project store."""
 
+from pathlib import Path
+
 import typer
 
 from nauro.cli.utils import resolve_target_project
+from nauro.store.registry import (
+    RegistrySchemaError,
+    get_project_v2,
+    load_registry,
+)
 from nauro.store.writer import append_decision, append_question
+from nauro.templates.agents_md import regenerate_agents_md_for_project
+
+
+def _registry_repo_paths(project_key: str) -> list[str]:
+    """Return repo paths for ``project_key`` from v2 (preferred) or v1 registry.
+
+    Local duplicate of the same-named helper in ``cli.commands.sync``. Kept
+    local rather than shared because both call sites are small CLI commands
+    and a cross-command helper for two callers is premature.
+    """
+    try:
+        v2_entry = get_project_v2(project_key)
+    except RegistrySchemaError:
+        v2_entry = None
+    if v2_entry is not None:
+        return list(v2_entry.get("repo_paths", []))
+    registry = load_registry()
+    return list(registry["projects"].get(project_key, {}).get("repo_paths", []))
 
 
 def note(
@@ -57,3 +82,18 @@ def note(
         )
         typer.echo(f"Decision recorded in {project_name}:")
         typer.echo(f"  {filepath}")
+
+    # D143: refresh AGENTS.md so MCP-disconnected agents see the update
+    # without requiring a separate `nauro sync`. Mirrors the warn-then-regen
+    # sequence in `nauro sync` so stale registry paths surface consistently.
+    project_key = store_path.name
+    for repo_str in _registry_repo_paths(project_key):
+        if not Path(repo_str).is_dir():
+            typer.echo(
+                f"  Warning: repo path does not exist, skipping AGENTS.md: {repo_str}\n"
+                f"  Fix: remove from registry or update path in ~/.nauro/registry.json",
+                err=True,
+            )
+    updated_repos = regenerate_agents_md_for_project(project_key, store_path)
+    for repo_path in updated_repos:
+        typer.echo(f"  Updated AGENTS.md: {repo_path}")

--- a/packages/nauro/tests/test_note.py
+++ b/packages/nauro/tests/test_note.py
@@ -1,0 +1,119 @@
+"""Tests for nauro note auto-regen of AGENTS.md (D143).
+
+`nauro note` writes a decision or question to the store and then regenerates
+AGENTS.md in every associated repo so MCP-disconnected agents see the update
+without requiring a separate `nauro sync`. These tests lock in the contract.
+"""
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from nauro.cli.main import app
+from nauro.store.registry import register_project
+from nauro.templates.scaffolds import scaffold_project_store
+
+runner = CliRunner()
+
+
+def test_note_decision_refreshes_agents_md(tmp_path: Path, monkeypatch):
+    """A decision logged via `nauro note` shows up in the repo's AGENTS.md."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    store = register_project("myproj", [repo])
+    scaffold_project_store("myproj", store)
+    monkeypatch.chdir(repo)
+
+    result = runner.invoke(app, ["note", "Use Postgres for v2 storage"])
+    assert result.exit_code == 0, result.output
+
+    agents_md = repo / "AGENTS.md"
+    assert agents_md.exists()
+    content = agents_md.read_text()
+    # The new decision's title appears under Recent Decisions.
+    assert "Use Postgres for v2 storage" in content
+    # Per-repo regen line surfaced in the user's output.
+    assert "Updated AGENTS.md" in result.output
+    assert str(repo) in result.output
+    # Ordering: store-write summary first, then regen lines. Locks in the
+    # output shape so a future refactor that reorders echoes doesn't slip by.
+    assert result.output.index("Decision recorded") < result.output.index("Updated AGENTS.md")
+
+
+def test_note_question_refreshes_agents_md(tmp_path: Path, monkeypatch):
+    """A question logged via `nauro note` shows up under Open Questions."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    store = register_project("myproj", [repo])
+    scaffold_project_store("myproj", store)
+    monkeypatch.chdir(repo)
+
+    result = runner.invoke(app, ["note", "Should we use Postgres or SQLite?"])
+    assert result.exit_code == 0, result.output
+
+    agents_md = repo / "AGENTS.md"
+    assert agents_md.exists()
+    content = agents_md.read_text()
+    assert "Should we use Postgres or SQLite?" in content
+    assert "Updated AGENTS.md" in result.output
+
+
+def test_note_decision_refreshes_all_associated_repos(tmp_path: Path, monkeypatch):
+    """Multi-repo project: every associated repo's AGENTS.md gets refreshed."""
+    repo1 = tmp_path / "repo1"
+    repo2 = tmp_path / "repo2"
+    repo1.mkdir()
+    repo2.mkdir()
+    store = register_project("myproj", [repo1, repo2])
+    scaffold_project_store("myproj", store)
+    monkeypatch.chdir(repo1)
+
+    result = runner.invoke(app, ["note", "Pick GraphQL over REST"])
+    assert result.exit_code == 0, result.output
+
+    for repo in (repo1, repo2):
+        agents_md = repo / "AGENTS.md"
+        assert agents_md.exists(), f"AGENTS.md missing in {repo}"
+        assert "Pick GraphQL over REST" in agents_md.read_text()
+
+
+def test_note_preserves_manual_section_across_regen(tmp_path: Path, monkeypatch):
+    """A `# Manual` section already in AGENTS.md survives the auto-regen."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    store = register_project("myproj", [repo])
+    scaffold_project_store("myproj", store)
+    monkeypatch.chdir(repo)
+
+    # Seed AGENTS.md with a manual block, then trigger a regen via note.
+    (repo / "AGENTS.md").write_text(
+        "# AGENTS.md\n\n# Manual\n\nHand-written guidance the user wrote.\n"
+    )
+
+    result = runner.invoke(app, ["note", "Adopt strict TypeScript"])
+    assert result.exit_code == 0, result.output
+
+    content = (repo / "AGENTS.md").read_text()
+    assert "Adopt strict TypeScript" in content
+    assert "Hand-written guidance the user wrote." in content
+
+
+def test_note_warns_about_missing_repo_paths(tmp_path: Path, monkeypatch):
+    """Stale registry paths trigger the same warning `nauro sync` prints,
+    and AGENTS.md is still written to the repos that do exist."""
+    live_repo = tmp_path / "live"
+    stale_repo = tmp_path / "stale"  # never mkdir'd
+    live_repo.mkdir()
+    store = register_project("myproj", [live_repo, stale_repo])
+    scaffold_project_store("myproj", store)
+    monkeypatch.chdir(live_repo)
+
+    result = runner.invoke(app, ["note", "Move billing to Stripe"])
+    assert result.exit_code == 0, result.output
+
+    # Warning surfaced for the stale path.
+    assert "repo path does not exist" in result.output
+    assert str(stale_repo) in result.output
+    # The live repo still got its AGENTS.md refreshed.
+    assert (live_repo / "AGENTS.md").exists()
+    assert "Move billing to Stripe" in (live_repo / "AGENTS.md").read_text()


### PR DESCRIPTION
## Why

Same user incident that drove D142. After running `nauro note "Food and bar staff included in venue rental"`, the decision landed in `~/.nauro/projects/.../decisions/` but the repo's `AGENTS.md` still showed only the three earlier decisions. With MCP unwired (the D142 silent-skip), AGENTS.md is the only context an agent in that session can see — and `note` wasn't refreshing it.

## Approach

Per D143, `nauro note` calls `regenerate_agents_md_for_project()` after the store write, mirroring the pattern D15 established for the extraction pipeline. Mirrors `nauro sync` in two ways: same warn-then-regen sequence (registry repo paths that no longer exist on disk surface a stderr warning before regen), and same "Updated AGENTS.md: <repo>" per-repo output line. The `_registry_repo_paths` helper is duplicated rather than extracted — D143 v2 documents the natural extraction home (`nauro.store.registry`) for when a third caller appears.

Rejected alternatives in the decision: leave note alone and rely on `nauro sync` (the status quo that produced the bug), extract a shared helper across note + sync (premature for two callers), bundle the MCP write tools in the same change (different code path, different test surface).

## What changed

- `note.py` imports `regenerate_agents_md_for_project`, adds a local `_registry_repo_paths` helper (duplicate of sync's), warns on stale repo paths, regenerates AGENTS.md, prints per-repo updates.
- New test file `test_note.py` covers five cases: decision refresh, question refresh, multi-repo refresh, manual-section preservation, output ordering, and stale-path warning.

## What to review

- `_registry_repo_paths` duplication. Could be extracted to `nauro.store.registry`; chose copy because two CLI callers don't justify the extraction yet. D143 v2 captures the threshold and the natural extraction home.
- Output ordering: store-write summary first, then any warnings (stderr), then regen lines. Locked in by a test (`assert result.output.index("Decision recorded") < result.output.index("Updated AGENTS.md")`).
- Visual density of the new lines: both filepath and "Updated AGENTS.md" sit as indented bullets under "Decision recorded in X:". Considered adding a blank line separator but kept it consistent with `nauro sync`'s output shape. Open to a follow-up readability pass.

## What's deferred

- MCP write tools (`propose_decision`, `confirm_decision`, `flag_question`, `update_state`) have the same gap. Different code path (`packages/nauro/src/nauro/mcp/tools.py`), runs inside the long-lived stdio server, warrants its own decision and PR.
- `state_current.md` scaffold copy fix (says "call update_state" as if it were a CLI command). Paper cut, follow-up.
- `_configure_codex` doesn't yet have the same try/except pattern around `tomllib.load` that D142 added to `_configure_cursor_for_repo`. Separate small PR.

## Test plan

- `pytest packages/nauro/tests/test_note.py -x -q` — 5 passed (new)
- `pytest packages/nauro/tests/ -x -q` — 910 passed (was 905, +5)
- `pytest packages/nauro-core/tests/ -x -q` — 306 passed
- `ruff format` + `ruff check packages/` — clean