### PR TITLE
fix(scaffolds,setup): drop misleading update_state hint; codex parse-error parity (D144)

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/setup.py
+++ b/packages/nauro/src/nauro/cli/commands/setup.py
@@ -321,8 +321,11 @@ def _configure_codex(
         )
 
     if config_path.exists():
-        with config_path.open("rb") as f:
-            config = tomllib.load(f)
+        try:
+            with config_path.open("rb") as f:
+                config = tomllib.load(f)
+        except tomllib.TOMLDecodeError as exc:
+            return f"Codex: could not parse {config_path} — {exc}"
     else:
         config = {}
 

--- a/packages/nauro/src/nauro/templates/scaffolds.py
+++ b/packages/nauro/src/nauro/templates/scaffolds.py
@@ -48,7 +48,7 @@ is useful. "Users" is not.]
 STATE_CURRENT_MD = """\
 # Current State
 
-_(No state recorded yet — call update_state to capture progress.)_
+_(No state recorded yet.)_
 """
 
 STACK_MD = """\

--- a/packages/nauro/tests/test_scaffolds.py
+++ b/packages/nauro/tests/test_scaffolds.py
@@ -1,0 +1,27 @@
+"""Tests for project store scaffold templates."""
+
+from pathlib import Path
+
+from nauro.templates.scaffolds import STATE_CURRENT_MD, scaffold_project_store
+
+
+def test_state_scaffold_does_not_advertise_cli_update_state():
+    """The empty-state placeholder must not tell users to 'call update_state'.
+
+    Per D144: `update_state` is an MCP write tool, not a CLI command. The
+    earlier scaffold copy ("...— call update_state to capture progress.")
+    flowed into AGENTS.md and led a real user to try `nauro update_state`
+    from the shell, which prints "No such command". This invariant prevents
+    the misleading instruction from coming back.
+    """
+    assert "update_state" not in STATE_CURRENT_MD
+    assert "No state recorded yet" in STATE_CURRENT_MD
+
+
+def test_scaffold_project_store_writes_clean_state_placeholder(tmp_path: Path):
+    """`scaffold_project_store` writes the cleaned-up state placeholder."""
+    scaffold_project_store("testproj", tmp_path)
+
+    state = (tmp_path / "state_current.md").read_text()
+    assert "update_state" not in state
+    assert "No state recorded yet" in state

--- a/packages/nauro/tests/test_setup_extended.py
+++ b/packages/nauro/tests/test_setup_extended.py
@@ -169,6 +169,33 @@ def test_setup_codex_no_op_when_remove_and_no_entry(tmp_path: Path):
     assert "no nauro entry to remove" in msg
 
 
+def test_configure_codex_add_surfaces_parse_error(tmp_path: Path):
+    """Hand-edited / corrupt `~/.codex/config.toml` surfaces a parse error
+    rather than crashing — same contract as the JSON handlers added in D142."""
+    config_path = tmp_path / ".codex" / "config.toml"
+    config_path.parent.mkdir()
+    config_path.write_text("this is not = valid [toml")
+
+    msg = _configure_codex(remove=False, config_path=config_path)
+
+    assert "Codex: could not parse" in msg
+    assert str(config_path) in msg
+    # File left untouched.
+    assert config_path.read_text() == "this is not = valid [toml"
+
+
+def test_configure_codex_remove_surfaces_parse_error(tmp_path: Path):
+    """Same parse-error contract on the `--remove` path."""
+    config_path = tmp_path / ".codex" / "config.toml"
+    config_path.parent.mkdir()
+    config_path.write_text("this is not = valid [toml")
+
+    msg = _configure_codex(remove=True, config_path=config_path)
+
+    assert "Codex: could not parse" in msg
+    assert str(config_path) in msg
+
+
 # ─── claude-code regression ──────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Why

Two paper-cut follow-ups from the user incident that drove D142 and D143. (1) The user read `_(No state recorded yet — call update_state to capture progress.)_` in her editor and tried `nauro update_state` from her terminal. (2) D142's PR body explicitly deferred the parse-error symmetry fix for `_configure_codex`; this cleans that up.

## Approach

(1) Per D144, drop the misleading instruction from the scaffold. AGENTS.md's generated "When to use these tools" section already describes `update_state` to MCP-aware agents — the duplicate instruction in the placeholder created the CLI illusion for users without MCP wired. (2) Mirror the try/except pattern D142 added to `_configure_cursor_for_repo`, catching `tomllib.TOMLDecodeError` and returning a clean parse-error string.

Decision considered and rejected for (1): rewording to make the surface explicit (still half-instructs CLI users without a path forward), or adding a `nauro state` CLI command (real value but its own design call — state's replace semantics under D94 interact non-trivially with what a CLI command should do).

## What changed

- `templates/scaffolds.py`: `STATE_CURRENT_MD` placeholder shortened to `_(No state recorded yet.)_`.
- `cli/commands/setup.py`: `_configure_codex` wraps `tomllib.load` in try/except, returns `f"Codex: could not parse {config_path} — {exc}"`.
- New `tests/test_scaffolds.py` with two invariant tests pinning the cleaned scaffold copy.
- `tests/test_setup_extended.py`: two new tests covering codex parse-error on both add and remove paths.

## What to review

- The scaffold change is a string deletion plus an invariant test. If you'd prefer the placeholder to retain *some* hint (e.g., a generic "agents can update this" line), say the word — D144's rationale argues for the dedicated MCP tool descriptions section to carry that load alone.
- Codex parse-error message shape matches `_configure_mcp` ("could not parse <path> — <exc>") with a "Codex:" prefix matching the other codex messages.

## What's deferred

- `nauro state <delta>` CLI command for users without MCP wired. Real signal from the original incident; deferred for its own design pass (replace semantics, history file, MCP-vs-CLI coexistence).
- MCP write tools auto-regen AGENTS.md (D143's deferred follow-up). Unchanged from prior PRs.

## Test plan

- `pytest packages/nauro/tests/test_scaffolds.py packages/nauro/tests/test_setup_extended.py packages/nauro/tests/test_setup.py -x -q` — 45 passed
- `pytest packages/nauro/tests/ -x -q` — 914 passed (was 910, +4)
- `pytest packages/nauro-core/tests/ -x -q` — 306 passed
- `ruff format` + `ruff check packages/` — clean