### PR TITLE
chore(release): prep nauro-core 0.8.0 + nauro 0.4.0

### DIFF
--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro-core"
-version = "0.7.0"
+version = "0.8.0"
 description = "Shared pure-Python logic for Nauro: parsing, validation, context assembly, constants."
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro"
-version = "0.3.0"
+version = "0.4.0"
 description = "Local CLI + MCP server: set your project's doctrine once, every connected AI agent inherits it."
 readme = "README.md"
 license = "Apache-2.0"
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "nauro-core>=0.7.0,<0.8",
+    "nauro-core>=0.8.0,<0.9",
     "typer>=0.9",
     "fastapi>=0.100",
     "uvicorn>=0.23",


### PR DESCRIPTION
## Why

Cut PyPI releases for both packages. Eleven PRs of work have landed on `nauro` since `nauro-v0.3.0`, including the three follow-ups from a real user incident (D142, D143, D144) and the `nauro check` CLI command. `nauro-core` picked up `resolves_questions` (D139) and the shared `nauro check` validation logic.

## Approach

Single release-prep PR matching the pattern from #48. Source unchanged. Two version fields bumped, plus `nauro`'s dep pin updated so `nauro 0.4.0` can resolve `nauro-core 0.8.0`.

## What changed

- `packages/nauro-core/pyproject.toml`: `version = "0.7.0"` → `"0.8.0"`.
- `packages/nauro/pyproject.toml`: `version = "0.3.0"` → `"0.4.0"`; dep pin `"nauro-core>=0.7.0,<0.8"` → `"nauro-core>=0.8.0,<0.9"`.

## Semver justification

**nauro-core 0.7.0 → 0.8.0 (minor, pre-1.0):**
- D139 (#49): new `resolves_questions` parameter on `propose_decision`; `## Resolved` section handling added to `nauro_core.questions`. Additive on the public API surface.
- #52: shared validation logic for `nauro check` lives in nauro-core; consumed by the new CLI command and the existing MCP propose path. Additive.

**nauro 0.3.0 → 0.4.0 (minor, pre-1.0):**
- #52: `nauro check` — new CLI surface.
- #58 (D142): `nauro setup claude-code` now writes `.mcp.json` directly (drops the `claude` CLI dependency that was silently failing). Behavioral change for one specific failure mode; no API break.
- #59 (D143): `nauro note` auto-regenerates AGENTS.md after writing a decision/question. Behavioral addition; no API break.
- #60 (D144): scaffold copy cleanup; codex parse-error parity with the JSON handlers from D142.
- #49 (D139): `resolves_questions` wired into the MCP write path.
- #50 (D140), #51, #53, #54, #56, #57: bug fixes, docs, and test refactors.

Full log: `git log nauro-v0.3.0..HEAD -- packages/nauro/`.

## What to review

- Version fields and the dep pin. Three lines of substantive change.
- The dep pin update is required: `nauro 0.4.0` includes `nauro check`, which imports from `nauro_core` features added in 0.8.0. Without the pin bump, `pip install nauro==0.4.0` would resolve against `nauro-core 0.7.x` and the new command would import-error on install.

## Release sequence after merge

1. Tag `nauro-core-v0.8.0` at the merge SHA; push tag → `publish-nauro-core.yml` publishes to PyPI.
2. Wait until `curl -s https://pypi.org/pypi/nauro-core/json | python3 -c "import sys, json; print(json.load(sys.stdin)['info']['version'])"` returns `0.8.0` (PyPI CDN propagation — usually 30-60s).
3. Tag `nauro-v0.4.0` at the same merge SHA; push tag → `publish-nauro.yml` publishes to PyPI.
4. Verify `nauro` on PyPI's JSON API.
5. Follow-up PR in `mcp-server` repo: `make bump-nauro-core REV=nauro-core-v0.8.0` to point the git pin at the new tag and regenerate `src/requirements.txt`.

## Test plan

- `pytest packages/nauro-core/tests/ packages/nauro/tests/ -x -q` — 1220 passed (306 + 914)
- `ruff check packages/` — clean
- `uv lock` reports the workspace dep version updates with no `uv.lock` file change (workspace resolution is local).