### PR TITLE
Cut CLI sync over to manifest + presign endpoints

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/auth.py
+++ b/packages/nauro/src/nauro/cli/commands/auth.py
@@ -16,7 +16,7 @@ import re
 import secrets
 import threading
 import webbrowser
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from urllib.parse import parse_qs, urlencode, urlparse
 
@@ -41,6 +41,10 @@ REDIRECT_URI = f"http://localhost:{REDIRECT_PORT}/callback"
 
 class PartialAuthConfigError(Exception):
     """Raised when Auth0 domain/client_id are partially set at a single layer."""
+
+
+class AuthRefreshError(Exception):
+    """Raised when an Auth0 refresh-token exchange fails."""
 
 
 def _resolve_auth_config(
@@ -82,6 +86,98 @@ def _resolve_auth_config(
         or DEFAULT_AUTH0_AUDIENCE
     )
     return domain, client_id, api_url, audience
+
+
+def load_access_token() -> str | None:
+    """Read the OAuth bearer token written by ``nauro auth login``.
+
+    Returns ``None`` when no token is present. Callers that need to fail loudly
+    should render the "run nauro auth login" guidance themselves.
+    """
+    auth = load_config().get("auth") or {}
+    if not isinstance(auth, dict):
+        return None
+    token = auth.get("access_token")
+    return str(token) if token else None
+
+
+def refresh_access_token() -> str:
+    """Exchange the stored refresh token for a fresh access token.
+
+    Persists the new access token (and the new refresh token, if Auth0 rotates
+    it). Stored tokens are left intact on failure so the user can retry without
+    losing state.
+    """
+    config = load_config()
+    auth = config.get("auth") or {}
+    if not isinstance(auth, dict):
+        auth = {}
+    refresh_token = auth.get("refresh_token")
+    if not refresh_token:
+        raise AuthRefreshError("No refresh token stored. Run 'nauro auth login' to authenticate.")
+
+    try:
+        domain, client_id, _api_url, _audience = _resolve_auth_config(os.environ, config)
+    except PartialAuthConfigError as exc:
+        raise AuthRefreshError(str(exc)) from exc
+
+    try:
+        response = httpx.post(
+            f"https://{domain}/oauth/token",
+            json={
+                "grant_type": "refresh_token",
+                "client_id": client_id,
+                "refresh_token": refresh_token,
+            },
+            timeout=15.0,
+        )
+    except httpx.HTTPError as exc:
+        raise AuthRefreshError(f"Network error contacting Auth0: {exc}") from exc
+
+    if response.status_code != 200:
+        try:
+            detail = response.json().get("error_description") or response.text
+        except (ValueError, AttributeError):
+            detail = response.text
+        raise AuthRefreshError(f"Refresh failed ({response.status_code}): {detail}")
+
+    try:
+        body = response.json()
+    except ValueError as exc:
+        raise AuthRefreshError(f"Auth0 returned non-JSON on refresh: {exc}") from exc
+
+    new_access_token = body.get("access_token")
+    if not isinstance(new_access_token, str) or not new_access_token:
+        raise AuthRefreshError("Auth0 refresh response did not include an access_token.")
+
+    auth["access_token"] = new_access_token
+    rotated_refresh = body.get("refresh_token")
+    if isinstance(rotated_refresh, str) and rotated_refresh:
+        auth["refresh_token"] = rotated_refresh
+    config["auth"] = auth
+    save_config(config)
+
+    return new_access_token
+
+
+def with_token_refresh(call: Callable[[str], httpx.Response]) -> httpx.Response:
+    """Run ``call(access_token)`` and refresh once on 401.
+
+    The first 401 triggers a refresh and a single retry. A second 401 (or any
+    other status) is returned to the caller — there is no infinite loop. A
+    failed refresh propagates as ``AuthRefreshError`` so the caller can guide
+    the user to ``nauro auth login``.
+    """
+    token = load_access_token()
+    if token is None:
+        raise AuthRefreshError("Not authenticated. Run 'nauro auth login' to authenticate.")
+
+    response = call(token)
+    if response.status_code != 401:
+        return response
+
+    new_token = refresh_access_token()
+    return call(new_token)
 
 
 def _sanitize_sub(sub: str) -> str:

--- a/packages/nauro/src/nauro/cli/commands/link.py
+++ b/packages/nauro/src/nauro/cli/commands/link.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import typer
 
-from nauro.cli.commands.auth import DEFAULT_API_URL
+from nauro.cli.commands.auth import DEFAULT_API_URL, load_access_token
 from nauro.constants import (
     REPO_CONFIG_MODE_CLOUD,
     REPO_CONFIG_MODE_LOCAL,
@@ -30,7 +30,6 @@ from nauro.store.repo_config import (
     save_repo_config,
 )
 from nauro.sync.cloud_projects import CloudProjectError, create_project
-from nauro.sync.config import load_sync_config
 
 
 def link(
@@ -83,16 +82,11 @@ def link(
         )
         raise typer.Exit(code=1)
 
-    # This guard is removed in Tier 2 PR B once presigned URLs ship.
-    if not load_sync_config().enabled:
+    if not load_access_token():
         typer.echo(
-            f"Cannot link '{name}' to the cloud: CLI sync credentials are not configured.\n"
+            f"Cannot link '{name}' to the cloud: not authenticated.\n"
             "\n"
-            "Cloud sync currently requires AWS credentials that a Nauro administrator "
-            "provisions during onboarding. Expected order:\n"
-            "  1. Administrator hands you bucket name + access keys.\n"
-            "  2. You run 'nauro sync --cloud-setup' to configure them.\n"
-            "  3. You run 'nauro link --cloud'.",
+            "Run 'nauro auth login' first.",
             err=True,
         )
         raise typer.Exit(code=1)

--- a/packages/nauro/src/nauro/cli/commands/sync.py
+++ b/packages/nauro/src/nauro/cli/commands/sync.py
@@ -116,9 +116,149 @@ def sync(
 
 
 def _pull_from_cloud(project_name: str, store_path: Path) -> int:
-    """Pull remote changes from S3 before a local sync. Skip silently if not configured.
+    """Pull remote changes from the server before a local sync.
 
-    Returns the number of files merged/pulled, or 0 if nothing changed.
+    Dispatches on which transport is configured. Auth0 token wins over static
+    IAM credentials when both are present — that is the migration ramp for
+    installs created during the static-IAM era. Returns the number of files
+    merged/pulled, or 0 if nothing changed (or nothing is configured).
+    """
+    from nauro.cli.commands.auth import load_access_token
+
+    if load_access_token():
+        # Manifest/presign requires a server-side project record; local-mode
+        # projects have none, so silently no-op.
+        if _project_mode(project_name) != REPO_CONFIG_MODE_CLOUD:
+            return 0
+        return _pull_via_presign(project_name, store_path)
+
+    return _pull_via_static_s3(project_name, store_path)
+
+
+def _pull_via_presign(project_id: str, store_path: Path) -> int:
+    """New transport: GET /sync/manifest → POST /sync/presign → S3 GETs."""
+    from datetime import datetime, timezone
+
+    from nauro.cli.commands.auth import AuthRefreshError
+    from nauro.sync.merge import detect_conflict, resolve_conflict, should_skip
+    from nauro.sync.remote import (
+        PresignError,
+        fetch_manifest,
+        fetch_via_presigned_url,
+        get_via_presigned_url,
+        request_presigned_urls,
+    )
+    from nauro.sync.state import (
+        compute_sha256,
+        file_changed_locally,
+        file_changed_remotely,
+        load_state,
+        save_state,
+        update_file_state,
+    )
+
+    typer.echo("Pulling from remote...")
+
+    try:
+        manifest = fetch_manifest(project_id)
+    except AuthRefreshError as exc:
+        typer.echo(f"  {exc}", err=True)
+        return 0
+    except PresignError as exc:
+        logger.exception("Failed to fetch manifest")
+        typer.echo(f"  Warning: could not reach remote ({exc})", err=True)
+        return 0
+
+    state = load_state(store_path)
+
+    pulls: list[tuple[str, str]] = []
+    conflicts: list[tuple[str, str]] = []
+    for entry in manifest:
+        rel = entry.get("path", "") if isinstance(entry, dict) else ""
+        if not rel or should_skip(rel):
+            continue
+        remote_etag = entry.get("etag", "")
+        if not file_changed_remotely(remote_etag, rel, state):
+            continue
+
+        local_file = store_path / rel
+        local_changed = file_changed_locally(store_path, rel, state)
+
+        if not local_changed:
+            pulls.append((rel, remote_etag))
+            continue
+
+        local_sha = compute_sha256(local_file) if local_file.exists() else ""
+        if detect_conflict(rel, state, local_sha, remote_etag):
+            conflicts.append((rel, remote_etag))
+
+    if not pulls and not conflicts:
+        state.last_full_sync = datetime.now(timezone.utc).isoformat()
+        save_state(store_path, state)
+        typer.echo("  No remote changes")
+        return 0
+
+    operations = [{"verb": "GET", "path": rel} for rel, _etag in pulls + conflicts]
+    try:
+        urls = request_presigned_urls(project_id, operations)
+    except AuthRefreshError as exc:
+        typer.echo(f"  {exc}", err=True)
+        return 0
+    except PresignError as exc:
+        logger.exception("Failed to request presigned URLs")
+        typer.echo(f"  Warning: presign request failed ({exc})", err=True)
+        return 0
+
+    url_by_path = {
+        entry["path"]: entry["url"]
+        for entry in urls
+        if isinstance(entry, dict) and entry.get("verb") == "GET"
+    }
+    merged = 0
+
+    for rel, remote_etag in pulls:
+        url = url_by_path.get(rel)
+        if not url:
+            continue
+        local_file = store_path / rel
+        try:
+            get_via_presigned_url(url, local_file)
+            local_sha = compute_sha256(local_file)
+            update_file_state(state, rel, local_sha, remote_etag)
+            merged += 1
+        except PresignError:
+            logger.exception("Error pulling %s", rel)
+
+    for rel, remote_etag in conflicts:
+        url = url_by_path.get(rel)
+        if not url:
+            continue
+        local_file = store_path / rel
+        try:
+            remote_content = fetch_via_presigned_url(url)
+            merged_content = resolve_conflict(store_path, local_file, remote_content, rel, state)
+            local_file.write_bytes(merged_content)
+            local_sha = compute_sha256(local_file)
+            update_file_state(state, rel, local_sha, remote_etag)
+            merged += 1
+        except PresignError:
+            logger.exception("Error resolving conflict for %s", rel)
+
+    state.last_full_sync = datetime.now(timezone.utc).isoformat()
+    save_state(store_path, state)
+
+    if merged:
+        typer.echo(f"  Merged {merged} file(s) from remote")
+    else:
+        typer.echo("  No remote changes")
+
+    return merged
+
+
+def _pull_via_static_s3(project_name: str, store_path: Path) -> int:
+    """Legacy transport: direct S3 with static IAM credentials.
+
+    Removed in PR C (2026-08-15) once the install population has migrated.
     """
     try:
         from nauro.sync.config import AuthRequiredError, load_sync_config, require_auth, s3_prefix
@@ -214,17 +354,100 @@ def _pull_from_cloud(project_name: str, store_path: Path) -> int:
 
 
 def _push_to_cloud(project_name: str, store_path: Path) -> bool:
-    """Push all store files to S3 after a local sync.
+    """Push store changes after a local sync.
 
     Returns True when the project is local-only (nothing to push is not an
     error) or when the upload succeeded. Returns False only when the project
-    is cloud-mode but the CLI has no sync credentials configured — in that
-    case the user is warned and the caller should treat the sync as a
-    partial success.
+    is cloud-mode but the CLI has no transport configured — in that case the
+    user is warned and the caller treats the sync as a partial success.
+
+    Auth0 token wins over static IAM credentials when both are present.
     """
     if _project_mode(project_name) != REPO_CONFIG_MODE_CLOUD:
         return True
 
+    from nauro.cli.commands.auth import load_access_token
+
+    if load_access_token():
+        return _push_via_presign(project_name, store_path)
+
+    return _push_via_static_s3(project_name, store_path)
+
+
+def _push_via_presign(project_id: str, store_path: Path) -> bool:
+    """New transport: POST /sync/presign for changed files → S3 PUTs."""
+    from nauro.cli.commands.auth import AuthRefreshError
+    from nauro.sync.merge import should_skip
+    from nauro.sync.remote import (
+        PresignError,
+        put_via_presigned_url,
+        request_presigned_urls,
+    )
+    from nauro.sync.state import compute_sha256, load_state, save_state, update_file_state
+
+    state = load_state(store_path)
+
+    changed: list[tuple[str, str, Path]] = []
+    for local_file in store_path.rglob("*"):
+        if not local_file.is_file():
+            continue
+        try:
+            rel = str(local_file.relative_to(store_path))
+        except ValueError:
+            continue
+        if should_skip(rel) or rel.startswith(".conflict-backup") or rel.startswith("__pycache__"):
+            continue
+
+        local_sha = compute_sha256(local_file)
+        fs = state.files.get(rel)
+        if fs is None or fs.local_sha256 != local_sha:
+            changed.append((rel, local_sha, local_file))
+
+    if not changed:
+        save_state(store_path, state)
+        return True
+
+    operations = [{"verb": "PUT", "path": rel} for rel, _sha, _path in changed]
+    try:
+        urls = request_presigned_urls(project_id, operations)
+    except AuthRefreshError as exc:
+        typer.echo(f"  {exc}", err=True)
+        return False
+    except PresignError as exc:
+        logger.exception("Failed to request presigned PUT URLs")
+        typer.echo(f"  Warning: presign request failed ({exc})", err=True)
+        return False
+
+    url_by_path = {
+        entry["path"]: entry["url"]
+        for entry in urls
+        if isinstance(entry, dict) and entry.get("verb") == "PUT"
+    }
+
+    pushed = 0
+    for rel, local_sha, local_file in changed:
+        url = url_by_path.get(rel)
+        if not url:
+            continue
+        try:
+            new_etag = put_via_presigned_url(url, local_file)
+            if new_etag:
+                update_file_state(state, rel, local_sha, new_etag)
+                pushed += 1
+        except PresignError:
+            logger.exception("Failed to push %s", rel)
+
+    save_state(store_path, state)
+    if pushed:
+        typer.echo(f"  Pushed {pushed} file(s) to S3")
+    return True
+
+
+def _push_via_static_s3(project_name: str, store_path: Path) -> bool:
+    """Legacy transport: direct S3 with static IAM credentials.
+
+    Removed in PR C (2026-08-15) once the install population has migrated.
+    """
     try:
         from nauro.sync.config import AuthRequiredError, load_sync_config, require_auth, s3_prefix
         from nauro.sync.merge import should_skip
@@ -234,7 +457,7 @@ def _push_to_cloud(project_name: str, store_path: Path) -> bool:
         typer.echo(
             "  Warning: this is a cloud-mode project but CLI sync credentials are not configured.\n"
             "  Your local snapshot is captured, but nothing was uploaded.\n"
-            "  Run 'nauro sync --cloud-setup' to configure credentials.",
+            "  Run 'nauro auth login' or 'nauro sync --cloud-setup' to configure credentials.",
             err=True,
         )
         return False
@@ -244,7 +467,7 @@ def _push_to_cloud(project_name: str, store_path: Path) -> bool:
         typer.echo(
             "  Warning: this is a cloud-mode project but CLI sync credentials are not configured.\n"
             "  Your local snapshot is captured, but nothing was uploaded.\n"
-            "  Run 'nauro sync --cloud-setup' to configure credentials.",
+            "  Run 'nauro auth login' or 'nauro sync --cloud-setup' to configure credentials.",
             err=True,
         )
         return False
@@ -359,23 +582,32 @@ def _cloud_setup_wizard() -> None:
 
 def _show_status(project_flag: str | None) -> None:
     """Show cloud sync status."""
-    # TODO(Tier 2 PR B): after presign endpoints ship, _show_status should report:
-    #   (a) which sync path this install uses (legacy direct-S3 vs presign)
-    #   (b) last successful sync time (from server response or local snapshot trailer)
-    # Today it only reads local config; neither field above is available.
+    from nauro.cli.commands.auth import load_access_token
     from nauro.sync.config import load_sync_config
 
+    access_token = load_access_token()
     config = load_sync_config()
 
-    if not config.enabled:
-        typer.echo("Cloud sync: disabled")
-        typer.echo("Run 'nauro sync --cloud-setup' to configure.")
+    if access_token:
+        sync_path_label = "presign"
+    elif config.enabled:
+        sync_path_label = "legacy direct-S3"
+    else:
+        sync_path_label = "not configured"
+
+    typer.echo(f"Sync path: {sync_path_label}")
+
+    if sync_path_label == "not configured":
+        typer.echo(
+            "Run 'nauro auth login' to authenticate, "
+            "or 'nauro sync --cloud-setup' for legacy direct-S3."
+        )
         return
 
-    typer.echo("Cloud sync: enabled")
-    typer.echo(f"  Bucket: {config.bucket_name}")
-    typer.echo(f"  Region: {config.region}")
-    typer.echo(f"  Poll interval: {config.sync_interval}s")
+    if config.enabled:
+        typer.echo(f"  Bucket: {config.bucket_name}")
+        typer.echo(f"  Region: {config.region}")
+        typer.echo(f"  Poll interval: {config.sync_interval}s")
 
     # Show project-specific status if we can resolve one
     try:
@@ -390,7 +622,7 @@ def _show_status(project_flag: str | None) -> None:
 
     typer.echo(f"\nProject: {project_name}")
     typer.echo(f"  Files tracked: {len(state.files)}")
-    typer.echo(f"  Last full sync: {state.last_full_sync or 'never'}")
+    typer.echo(f"  Last successful sync: {state.last_full_sync or 'never'}")
 
     # Check for pending local changes
     from nauro.sync.state import file_changed_locally
@@ -409,34 +641,39 @@ def _show_status(project_flag: str | None) -> None:
     else:
         typer.echo("  Pending local changes: none")
 
-    # Check for pending remote changes
-    try:
-        from nauro.sync.config import s3_prefix
-        from nauro.sync.remote import create_client, list_remote
-        from nauro.sync.state import file_changed_remotely
+    # Remote-side enumeration is only meaningful for the legacy path; the
+    # presign path lists via /sync/manifest at sync time and does not expose
+    # the same read-only listing here. Keep the legacy probe for installs
+    # still on static IAM creds; PR C removes this block alongside the
+    # legacy transport.
+    if not access_token and config.enabled:
+        try:
+            from nauro.sync.config import s3_prefix
+            from nauro.sync.remote import create_client, list_remote
+            from nauro.sync.state import file_changed_remotely
 
-        client = create_client(config)
-        if not (config.user_id or config.sanitized_sub):
-            typer.echo("  Remote status unavailable: run 'nauro auth login' first", err=True)
-            return 0
-        user_key = config.user_id or config.sanitized_sub
-        prefix = s3_prefix(user_key, project_key)
-        remote_files = list_remote(client, config.bucket_name, prefix)
+            client = create_client(config)
+            if not (config.user_id or config.sanitized_sub):
+                typer.echo("  Remote status unavailable: run 'nauro auth login' first", err=True)
+                return
+            user_key = config.user_id or config.sanitized_sub
+            prefix = s3_prefix(user_key, project_key)
+            remote_files = list_remote(client, config.bucket_name, prefix)
 
-        pending_remote = []
-        for rf in remote_files:
-            rel = rf["key"].removeprefix(prefix)
-            if rel and file_changed_remotely(rf["etag"], rel, state):
-                pending_remote.append(rel)
+            pending_remote = []
+            for rf in remote_files:
+                rel = rf["key"].removeprefix(prefix)
+                if rel and file_changed_remotely(rf["etag"], rel, state):
+                    pending_remote.append(rel)
 
-        if pending_remote:
-            typer.echo(f"  Pending remote changes: {len(pending_remote)}")
-            for p in pending_remote[:5]:
-                typer.echo(f"    - {p}")
-        else:
-            typer.echo("  Pending remote changes: none")
-    except Exception as e:
-        typer.echo(f"  Remote check failed: {e}", err=True)
+            if pending_remote:
+                typer.echo(f"  Pending remote changes: {len(pending_remote)}")
+                for p in pending_remote[:5]:
+                    typer.echo(f"    - {p}")
+            else:
+                typer.echo("  Pending remote changes: none")
+        except Exception as e:
+            typer.echo(f"  Remote check failed: {e}", err=True)
 
     # Check for conflict backups
     backup_dir = store_path / ".conflict-backup"

--- a/packages/nauro/src/nauro/cli/commands/sync.py
+++ b/packages/nauro/src/nauro/cli/commands/sync.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import typer
 
 from nauro.cli.utils import resolve_target_project
-from nauro.constants import REPO_CONFIG_MODE_CLOUD
+from nauro.constants import REPO_CONFIG_MODE_CLOUD, REPO_CONFIG_MODE_LOCAL
 from nauro.store.registry import (
     RegistrySchemaError,
     get_project_v2,
@@ -118,21 +118,29 @@ def sync(
 def _pull_from_cloud(project_name: str, store_path: Path) -> int:
     """Pull remote changes from the server before a local sync.
 
-    Dispatches on which transport is configured. Auth0 token wins over static
-    IAM credentials when both are present — that is the migration ramp for
-    installs created during the static-IAM era. Returns the number of files
-    merged/pulled, or 0 if nothing changed (or nothing is configured).
+    Dispatches on registry mode and which transport is configured:
+
+    * v2-local                              → no-op
+    * v2-cloud + Auth0 token                → presign path
+    * v2-cloud (no token), or v1 with static IAM creds → legacy direct-S3
+    * v1 with no static IAM creds           → no-op (preserves pre-PR-B behavior)
+
+    The v1+static-creds fall-through is load-bearing: a v1 user with both
+    an Auth0 token and static IAM creds must keep getting their data
+    pulled until they re-register through v2 (link --cloud or fresh init).
+    The presign path can't help — it requires a server-side ULID record.
     """
     from nauro.cli.commands.auth import load_access_token
+    from nauro.sync.config import load_sync_config
 
-    if load_access_token():
-        # Manifest/presign requires a server-side project record; local-mode
-        # projects have none, so silently no-op.
-        if _project_mode(project_name) != REPO_CONFIG_MODE_CLOUD:
-            return 0
+    mode = _project_mode(project_name)
+    if mode == REPO_CONFIG_MODE_LOCAL:
+        return 0
+    if mode == REPO_CONFIG_MODE_CLOUD and load_access_token():
         return _pull_via_presign(project_name, store_path)
-
-    return _pull_via_static_s3(project_name, store_path)
+    if mode == REPO_CONFIG_MODE_CLOUD or load_sync_config().enabled:
+        return _pull_via_static_s3(project_name, store_path)
+    return 0
 
 
 def _pull_via_presign(project_id: str, store_path: Path) -> int:
@@ -177,6 +185,11 @@ def _pull_via_presign(project_id: str, store_path: Path) -> int:
         rel = entry.get("path", "") if isinstance(entry, dict) else ""
         if not rel or should_skip(rel):
             continue
+        # Defense in depth — the server validates per-op on presign, but the
+        # manifest itself is currently trusted. Drop suspicious entries here.
+        if ".." in Path(rel).parts or rel.startswith("/"):
+            logger.warning("Skipping manifest entry with suspicious path: %r", rel)
+            continue
         remote_etag = entry.get("etag", "")
         if not file_changed_remotely(remote_etag, rel, state):
             continue
@@ -208,6 +221,9 @@ def _pull_via_presign(project_id: str, store_path: Path) -> int:
         logger.exception("Failed to request presigned URLs")
         typer.echo(f"  Warning: presign request failed ({exc})", err=True)
         return 0
+
+    if len(urls) < len(operations):
+        logger.warning("Presign returned %d URLs for %d ops", len(urls), len(operations))
 
     url_by_path = {
         entry["path"]: entry["url"]
@@ -356,22 +372,28 @@ def _pull_via_static_s3(project_name: str, store_path: Path) -> int:
 def _push_to_cloud(project_name: str, store_path: Path) -> bool:
     """Push store changes after a local sync.
 
-    Returns True when the project is local-only (nothing to push is not an
-    error) or when the upload succeeded. Returns False only when the project
-    is cloud-mode but the CLI has no transport configured — in that case the
-    user is warned and the caller treats the sync as a partial success.
+    Mirrors the pull dispatch:
 
-    Auth0 token wins over static IAM credentials when both are present.
+    * v2-local                              → True (nothing to push)
+    * v2-cloud + Auth0 token                → presign path
+    * v2-cloud (no token)                   → legacy direct-S3 (warns + False if no creds)
+    * v1 with static IAM creds              → legacy direct-S3
+    * v1 with no static IAM creds           → True (preserves pre-PR-B behavior)
+
+    The v1+static-creds fall-through prevents silent push-loss for users
+    still on the pre-v2 registry layout.
     """
-    if _project_mode(project_name) != REPO_CONFIG_MODE_CLOUD:
-        return True
-
     from nauro.cli.commands.auth import load_access_token
+    from nauro.sync.config import load_sync_config
 
-    if load_access_token():
+    mode = _project_mode(project_name)
+    if mode == REPO_CONFIG_MODE_LOCAL:
+        return True
+    if mode == REPO_CONFIG_MODE_CLOUD and load_access_token():
         return _push_via_presign(project_name, store_path)
-
-    return _push_via_static_s3(project_name, store_path)
+    if mode == REPO_CONFIG_MODE_CLOUD or load_sync_config().enabled:
+        return _push_via_static_s3(project_name, store_path)
+    return True
 
 
 def _push_via_presign(project_id: str, store_path: Path) -> bool:
@@ -417,6 +439,9 @@ def _push_via_presign(project_id: str, store_path: Path) -> bool:
         logger.exception("Failed to request presigned PUT URLs")
         typer.echo(f"  Warning: presign request failed ({exc})", err=True)
         return False
+
+    if len(urls) < len(operations):
+        logger.warning("Presign returned %d URLs for %d ops", len(urls), len(operations))
 
     url_by_path = {
         entry["path"]: entry["url"]

--- a/packages/nauro/src/nauro/sync/config.py
+++ b/packages/nauro/src/nauro/sync/config.py
@@ -43,6 +43,22 @@ def require_auth(config: SyncConfig) -> str:
     return user_key
 
 
+def sync_is_configured() -> bool:
+    """Return True if either sync transport has credentials available.
+
+    The presign transport needs an Auth0 access token; the legacy direct-S3
+    transport needs static IAM credentials. ``SyncConfig.enabled`` only
+    reports the latter — this predicate covers both so callers (notably
+    ``_show_status``) can distinguish "not configured" from "configured but
+    via a specific transport".
+    """
+    from nauro.cli.commands.auth import load_access_token
+
+    if load_access_token():
+        return True
+    return load_sync_config().enabled
+
+
 def load_sync_config() -> SyncConfig:
     """Load sync config from ~/.nauro/config.json under the 'sync' key.
 

--- a/packages/nauro/src/nauro/sync/remote.py
+++ b/packages/nauro/src/nauro/sync/remote.py
@@ -1,14 +1,55 @@
-"""S3 remote client for cloud sync."""
+"""S3 remote client for cloud sync.
+
+Two transports coexist here during the cutover:
+
+* The legacy direct-S3 helpers (``create_client``, ``push_file``, ``pull_file``,
+  ``list_remote``) use the user's static IAM credentials.
+* The new presign helpers (``fetch_manifest``, ``request_presigned_urls``,
+  ``put_via_presigned_url``, ``get_via_presigned_url``) talk to the remote MCP
+  server with an Auth0 bearer token. The server mints short-lived presigned
+  URLs, then the CLI does the bulk transfer directly against S3.
+
+The legacy path stays callable until PR C removes it (2026-08-15).
+"""
 
 import logging
+import os
 from pathlib import Path
+from typing import Any
 
 import boto3
+import httpx
 from botocore.exceptions import ClientError
 
+from nauro.cli.commands.auth import (
+    DEFAULT_API_URL,
+    AuthRefreshError,
+    with_token_refresh,
+)
+from nauro.store.config import load_config
 from nauro.sync.config import SyncConfig
 
 logger = logging.getLogger("nauro.sync")
+
+_DEFAULT_API_TIMEOUT = 15.0
+_DEFAULT_TRANSFER_TIMEOUT = 60.0
+
+
+class PresignError(Exception):
+    """Raised for unrecoverable failures hitting the manifest/presign endpoints."""
+
+
+def _resolve_api_url() -> str:
+    """Resolve the remote MCP server base URL.
+
+    Mirrors ``nauro.sync.cloud_projects._resolve_api_url`` — env var first,
+    then ``api_url`` in user config, then the public default.
+    """
+    env_url = os.environ.get("NAURO_API_URL")
+    if env_url:
+        return env_url
+    config_url = str(load_config().get("api_url") or "")
+    return (config_url or DEFAULT_API_URL).rstrip("/")
 
 
 class ConflictError(Exception):
@@ -83,3 +124,142 @@ def list_remote(client, bucket: str, prefix: str) -> list[dict]:
                 }
             )
     return results
+
+
+# Presign transport — Auth0 bearer + remote MCP server.
+# The server batches up to 200 ops per /sync/presign call (see mcp-server
+# _PRESIGN_OPS_BATCH_LIMIT); the CLI chunks larger diffs to match.
+_PRESIGN_BATCH_LIMIT = 200
+
+
+def fetch_manifest(project_id: str) -> list[dict]:
+    """Return every server-side file entry for ``project_id``.
+
+    Each entry mirrors the server payload: ``{"path", "etag", "size",
+    "last_modified"}`` where ``path`` is project-root relative.
+    Pagination is collapsed for the caller — the cursor stays internal.
+    """
+    api_url = _resolve_api_url()
+    files: list[dict] = []
+    cursor: str | None = None
+
+    while True:
+        params: dict[str, str] = {"project_id": project_id}
+        if cursor:
+            params["cursor"] = cursor
+
+        def _call(token: str, params=params) -> httpx.Response:
+            return httpx.get(
+                f"{api_url}/sync/manifest",
+                params=params,
+                headers={"Authorization": f"Bearer {token}"},
+                timeout=_DEFAULT_API_TIMEOUT,
+            )
+
+        response = with_token_refresh(_call)
+        if response.status_code != 200:
+            raise PresignError(
+                f"GET /sync/manifest failed ({response.status_code}): {response.text}"
+            )
+
+        try:
+            body = response.json()
+        except ValueError as exc:
+            raise PresignError(f"Manifest response was not JSON: {exc}") from exc
+
+        page_files = body.get("files") if isinstance(body, dict) else None
+        if not isinstance(page_files, list):
+            raise PresignError(f"Unexpected manifest shape: {body!r}")
+        files.extend(page_files)
+
+        next_cursor = body.get("next_cursor") if isinstance(body, dict) else None
+        if not next_cursor:
+            return files
+        cursor = str(next_cursor)
+
+
+def request_presigned_urls(
+    project_id: str, operations: list[dict[str, str]]
+) -> list[dict[str, Any]]:
+    """Mint presigned URLs for a batch of GET/PUT operations.
+
+    ``operations`` items are ``{"verb": "GET"|"PUT", "path": "..."}``. The
+    server caps each request at 200 ops; this helper chunks transparently
+    so the caller can pass an arbitrary diff.
+    """
+    if not operations:
+        return []
+
+    api_url = _resolve_api_url()
+    all_urls: list[dict[str, Any]] = []
+
+    for start in range(0, len(operations), _PRESIGN_BATCH_LIMIT):
+        chunk = operations[start : start + _PRESIGN_BATCH_LIMIT]
+
+        def _call(token: str, chunk=chunk) -> httpx.Response:
+            return httpx.post(
+                f"{api_url}/sync/presign",
+                json={"project_id": project_id, "operations": chunk},
+                headers={"Authorization": f"Bearer {token}"},
+                timeout=_DEFAULT_API_TIMEOUT,
+            )
+
+        response = with_token_refresh(_call)
+        if response.status_code != 200:
+            raise PresignError(
+                f"POST /sync/presign failed ({response.status_code}): {response.text}"
+            )
+
+        try:
+            body = response.json()
+        except ValueError as exc:
+            raise PresignError(f"Presign response was not JSON: {exc}") from exc
+
+        urls = body.get("urls") if isinstance(body, dict) else None
+        if not isinstance(urls, list):
+            raise PresignError(f"Unexpected presign shape: {body!r}")
+        all_urls.extend(urls)
+
+    return all_urls
+
+
+def fetch_via_presigned_url(url: str) -> bytes:
+    """GET ``url`` and return the body bytes (no local write)."""
+    response = httpx.get(url, timeout=_DEFAULT_TRANSFER_TIMEOUT)
+    if response.status_code != 200:
+        raise PresignError(f"Presigned GET failed ({response.status_code})")
+    return response.content
+
+
+def get_via_presigned_url(url: str, local_path: Path) -> bytes:
+    """GET ``url`` and write the body to ``local_path``. Returns the bytes."""
+    content = fetch_via_presigned_url(url)
+    local_path.parent.mkdir(parents=True, exist_ok=True)
+    local_path.write_bytes(content)
+    return content
+
+
+def put_via_presigned_url(url: str, local_path: Path) -> str:
+    """PUT the bytes at ``local_path`` to ``url``. Returns the new ETag."""
+    data = local_path.read_bytes()
+    response = httpx.put(url, content=data, timeout=_DEFAULT_TRANSFER_TIMEOUT)
+    if response.status_code not in (200, 204):
+        raise PresignError(f"Presigned PUT failed ({response.status_code}) for {local_path}")
+    return response.headers.get("ETag", "")
+
+
+__all__ = [
+    "AuthRefreshError",
+    "ConflictError",
+    "PresignError",
+    "check_etag",
+    "create_client",
+    "fetch_manifest",
+    "fetch_via_presigned_url",
+    "get_via_presigned_url",
+    "list_remote",
+    "pull_file",
+    "push_file",
+    "put_via_presigned_url",
+    "request_presigned_urls",
+]

--- a/packages/nauro/tests/test_auth_refresh.py
+++ b/packages/nauro/tests/test_auth_refresh.py
@@ -1,0 +1,207 @@
+"""Tests for nauro auth refresh helpers — refresh_access_token + with_token_refresh.
+
+The refresh path is exercised on every 401 from the new sync endpoints, so
+the contract here is load-bearing for the entire Tier 2 cutover. The two
+behaviors that get repeated through the suite:
+
+* On a 200 from Auth0, the access token (and rotated refresh token, if
+  present) are persisted before returning.
+* On any failure, stored tokens are left intact so the user can retry
+  ``nauro auth login`` without losing state.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from nauro.cli.commands.auth import (
+    AuthRefreshError,
+    refresh_access_token,
+    with_token_refresh,
+)
+from nauro.store.config import load_config, save_config
+
+
+def _seed_auth(refresh_token: str = "refresh_orig", access_token: str = "access_orig") -> None:
+    save_config(
+        {
+            "auth": {
+                "sub": "auth0|test",
+                "access_token": access_token,
+                "refresh_token": refresh_token,
+            }
+        }
+    )
+
+
+def _mock_post(status_code: int = 200, payload: dict | None = None):
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = status_code
+    response.json.return_value = payload or {}
+    response.text = str(payload or "")
+    return response
+
+
+# --- refresh_access_token ---
+
+
+class TestRefreshAccessToken:
+    def test_refresh_success_persists_new_access_token(self):
+        _seed_auth(refresh_token="refresh_orig", access_token="access_orig")
+
+        with patch(
+            "nauro.cli.commands.auth.httpx.post",
+            return_value=_mock_post(200, {"access_token": "access_new"}),
+        ):
+            new_token = refresh_access_token()
+
+        assert new_token == "access_new"
+        auth = load_config()["auth"]
+        assert auth["access_token"] == "access_new"
+        # Refresh token preserved when the server doesn't rotate it
+        assert auth["refresh_token"] == "refresh_orig"
+
+    def test_refresh_rotates_refresh_token_when_returned(self):
+        _seed_auth(refresh_token="refresh_orig")
+
+        with patch(
+            "nauro.cli.commands.auth.httpx.post",
+            return_value=_mock_post(
+                200, {"access_token": "access_new", "refresh_token": "refresh_rotated"}
+            ),
+        ):
+            refresh_access_token()
+
+        auth = load_config()["auth"]
+        assert auth["access_token"] == "access_new"
+        assert auth["refresh_token"] == "refresh_rotated"
+
+    def test_refresh_preserves_old_refresh_token_when_absent_in_response(self):
+        _seed_auth(refresh_token="refresh_orig")
+
+        with patch(
+            "nauro.cli.commands.auth.httpx.post",
+            return_value=_mock_post(200, {"access_token": "access_new"}),
+        ):
+            refresh_access_token()
+
+        auth = load_config()["auth"]
+        assert auth["refresh_token"] == "refresh_orig"
+
+    def test_refresh_failure_invalid_grant_leaves_tokens_intact(self):
+        _seed_auth(refresh_token="refresh_orig", access_token="access_orig")
+
+        bad = _mock_post(
+            400,
+            {"error": "invalid_grant", "error_description": "refresh token expired"},
+        )
+        with patch("nauro.cli.commands.auth.httpx.post", return_value=bad):
+            with pytest.raises(AuthRefreshError):
+                refresh_access_token()
+
+        auth = load_config()["auth"]
+        # Both tokens must survive a failed refresh — the user might retry.
+        assert auth["access_token"] == "access_orig"
+        assert auth["refresh_token"] == "refresh_orig"
+
+    def test_refresh_network_error_leaves_tokens_intact(self):
+        _seed_auth(refresh_token="refresh_orig", access_token="access_orig")
+
+        with patch(
+            "nauro.cli.commands.auth.httpx.post",
+            side_effect=httpx.ConnectError("dns failure"),
+        ):
+            with pytest.raises(AuthRefreshError):
+                refresh_access_token()
+
+        auth = load_config()["auth"]
+        assert auth["access_token"] == "access_orig"
+        assert auth["refresh_token"] == "refresh_orig"
+
+    def test_refresh_without_stored_refresh_token_raises(self):
+        save_config({"auth": {"sub": "auth0|test", "access_token": "access_orig"}})
+
+        with pytest.raises(AuthRefreshError, match="No refresh token"):
+            refresh_access_token()
+
+
+# --- with_token_refresh ---
+
+
+class TestWithTokenRefresh:
+    def test_first_call_succeeds_no_refresh(self):
+        _seed_auth(access_token="access_orig")
+
+        ok = MagicMock(spec=httpx.Response)
+        ok.status_code = 200
+        call = MagicMock(return_value=ok)
+
+        with patch("nauro.cli.commands.auth.httpx.post") as mock_post:
+            result = with_token_refresh(call)
+
+        assert result.status_code == 200
+        assert call.call_count == 1
+        assert call.call_args.args == ("access_orig",)
+        mock_post.assert_not_called()
+
+    def test_401_triggers_refresh_then_retry_succeeds(self):
+        _seed_auth(refresh_token="refresh_orig", access_token="access_orig")
+
+        unauthorized = MagicMock(spec=httpx.Response)
+        unauthorized.status_code = 401
+        ok = MagicMock(spec=httpx.Response)
+        ok.status_code = 200
+        call = MagicMock(side_effect=[unauthorized, ok])
+
+        refresh_response = _mock_post(200, {"access_token": "access_new"})
+        with patch("nauro.cli.commands.auth.httpx.post", return_value=refresh_response):
+            result = with_token_refresh(call)
+
+        assert result is ok
+        assert call.call_count == 2
+        # Retry uses the refreshed token, not the original
+        assert call.call_args_list[0].args == ("access_orig",)
+        assert call.call_args_list[1].args == ("access_new",)
+
+    def test_401_then_refresh_failure_propagates(self):
+        _seed_auth(refresh_token="refresh_orig", access_token="access_orig")
+
+        unauthorized = MagicMock(spec=httpx.Response)
+        unauthorized.status_code = 401
+        call = MagicMock(return_value=unauthorized)
+
+        bad_refresh = _mock_post(400, {"error": "invalid_grant"})
+        with patch("nauro.cli.commands.auth.httpx.post", return_value=bad_refresh):
+            with pytest.raises(AuthRefreshError):
+                with_token_refresh(call)
+
+        # Stored tokens preserved despite the failed refresh attempt.
+        auth = load_config()["auth"]
+        assert auth["access_token"] == "access_orig"
+        assert auth["refresh_token"] == "refresh_orig"
+
+    def test_persistent_401_returns_response_no_infinite_loop(self):
+        _seed_auth(refresh_token="refresh_orig", access_token="access_orig")
+
+        unauthorized = MagicMock(spec=httpx.Response)
+        unauthorized.status_code = 401
+        call = MagicMock(return_value=unauthorized)
+
+        refresh_response = _mock_post(200, {"access_token": "access_new"})
+        with patch("nauro.cli.commands.auth.httpx.post", return_value=refresh_response):
+            result = with_token_refresh(call)
+
+        assert result.status_code == 401
+        # Exactly two calls: initial + one retry. No further retries.
+        assert call.call_count == 2
+
+    def test_without_stored_token_raises(self):
+        save_config({})
+
+        call = MagicMock()
+        with pytest.raises(AuthRefreshError, match="Not authenticated"):
+            with_token_refresh(call)
+        call.assert_not_called()

--- a/packages/nauro/tests/test_link_cloud.py
+++ b/packages/nauro/tests/test_link_cloud.py
@@ -120,6 +120,32 @@ def test_link_cloud_on_already_cloud_repo_errors(tmp_path, monkeypatch):
     assert "already cloud-mode" in result.output
 
 
+def test_link_cloud_succeeds_with_only_auth_token(tmp_path, monkeypatch):
+    """After softening the Tier 1 1.3 guard, an Auth0 token alone is enough —
+    static IAM creds are no longer required to link.
+    """
+    save_config(
+        {
+            "auth": {"access_token": "test-token", "sub": "auth0|test"},
+        }
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("NAURO_API_URL", "https://example.test")
+
+    init_result = runner.invoke(app, ["init", "auth-only-link"])
+    assert init_result.exit_code == 0, init_result.output
+
+    with patch.object(
+        cloud_projects.httpx, "request", side_effect=_create_response("auth-only-link")
+    ):
+        result = runner.invoke(app, ["link", "--cloud"])
+
+    assert result.exit_code == 0, result.output
+    new_entry = registry.get_project_v2(CLOUD_PID)
+    assert new_entry is not None
+    assert new_entry["mode"] == "cloud"
+
+
 def test_link_cloud_with_no_repo_config_errors(tmp_path, monkeypatch):
     """No `.nauro/config.json` above cwd → clear error, no network call."""
     _seed_token(monkeypatch, tmp_path)

--- a/packages/nauro/tests/test_sync/test_sync_command.py
+++ b/packages/nauro/tests/test_sync/test_sync_command.py
@@ -282,32 +282,27 @@ class TestSyncHonesty:
         assert "Warning: this is a cloud-mode project" not in combined
 
 
-class TestLinkCloudRefusesWithoutCreds:
-    """`nauro link --cloud` must refuse when CLI sync credentials are missing
-    instead of minting a cloud id the user cannot upload to."""
+class TestLinkCloudRefusesWithoutAuth:
+    """`nauro link --cloud` must refuse when the install has no Auth0 token —
+    presigned URLs are minted server-side from the bearer, so without one we
+    cannot upload, regardless of whether static IAM creds happen to be set.
+    """
 
-    def test_link_cloud_refuses_when_sync_disabled(self, tmp_path, monkeypatch):
-        """A local-mode repo + no sync creds → refusal, no network call."""
+    def test_link_cloud_refuses_when_not_authenticated(self, tmp_path, monkeypatch):
+        """A local-mode repo + no Auth0 token → refusal, no network call."""
         from nauro.store.config import save_config
 
-        # Bring up a local-only project from scratch in the isolated NAURO_HOME.
-        save_config({"auth": {"access_token": "test-token", "sub": "auth0|test"}})
+        # Empty config — no auth section means no access_token.
+        save_config({})
         monkeypatch.chdir(tmp_path)
         monkeypatch.setenv("NAURO_API_URL", "https://example.test")
 
         init_result = runner.invoke(app, ["init", "blockedlink"])
         assert init_result.exit_code == 0, init_result.output
 
-        # Ensure no sync creds leak in from the environment.
-        for var in (
-            "NAURO_SYNC_BUCKET_NAME",
-            "NAURO_SYNC_ACCESS_KEY_ID",
-            "NAURO_SYNC_SECRET_ACCESS_KEY",
-        ):
-            monkeypatch.delenv(var, raising=False)
-
         result = runner.invoke(app, ["link", "--cloud"])
         combined = result.output + (result.stderr or "")
 
         assert result.exit_code == 1, combined
         assert "Cannot link 'blockedlink' to the cloud" in combined
+        assert "Run 'nauro auth login'" in combined

--- a/packages/nauro/tests/test_sync/test_sync_presign.py
+++ b/packages/nauro/tests/test_sync/test_sync_presign.py
@@ -1,0 +1,578 @@
+"""Tests for the new manifest + presign sync transport.
+
+Three concerns, three sections:
+
+* Mode detection (Auth0 token wins over static IAM creds when both are present).
+* Pull flow (manifest pagination, diff against state, presign GETs, conflict).
+* Push flow (SHA diff, presign PUTs, 401 refresh).
+
+All HTTP is mocked at the module's ``httpx`` import, matching the existing
+``test_link_cloud`` and ``test_auth`` patterns — moto would not catch this
+layer (the CLI never talks to S3 directly on the new path).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from nauro.constants import REPO_CONFIG_MODE_CLOUD
+from nauro.store.config import save_config
+from nauro.store.registry import register_project_v2
+from nauro.sync.state import (
+    FileState,
+    SyncState,
+    compute_sha256,
+    load_state,
+    save_state,
+)
+from nauro.templates.scaffolds import scaffold_project_store
+
+CLOUD_PID = "01KQ6AZGNA0B3QBF67NBXP3S45"
+
+
+def _scaffolded_cloud_project(name: str, repo_path: Path, project_id: str = CLOUD_PID) -> Path:
+    _pid, store = register_project_v2(
+        name,
+        [repo_path],
+        mode=REPO_CONFIG_MODE_CLOUD,
+        server_url="https://example.test",
+        project_id=project_id,
+    )
+    scaffold_project_store(name, store)
+    return store
+
+
+def _ok(status: int, payload: dict) -> httpx.Response:
+    return httpx.Response(
+        status,
+        content=json.dumps(payload).encode("utf-8"),
+        headers={"content-type": "application/json"},
+    )
+
+
+def _seed_token(access_token: str = "tok_orig", refresh_token: str = "refresh_orig") -> None:
+    save_config(
+        {
+            "auth": {
+                "sub": "auth0|test",
+                "access_token": access_token,
+                "refresh_token": refresh_token,
+            }
+        }
+    )
+
+
+# --- mode detection ---
+
+
+class TestModeDetection:
+    """The dispatch table from the prompt:
+
+    * auth.access_token set         → new (presign)
+    * only sync.access_key_id       → legacy direct-S3
+    * both set                      → new (presign) — Auth0 wins
+    * neither + cloud-mode project  → warn + return False
+    * neither + local-mode project  → return 0 silently
+    """
+
+    def test_auth_token_picks_new_path(self, tmp_path, monkeypatch):
+        store = _scaffolded_cloud_project("authproj", tmp_path)
+        _seed_token()
+
+        with (
+            patch(
+                "nauro.sync.remote.httpx.get",
+                return_value=_ok(200, {"files": [], "next_cursor": None}),
+            ) as mock_get,
+            patch("nauro.sync.remote.httpx.post") as mock_post,
+            patch("nauro.sync.remote.boto3.client") as mock_boto,
+        ):
+            from nauro.cli.commands.sync import _pull_from_cloud
+
+            _pull_from_cloud(store.name, store)
+
+        # Hit the manifest endpoint, not boto3.
+        called_urls = [c.args[0] for c in mock_get.call_args_list]
+        assert any("/sync/manifest" in url for url in called_urls)
+        mock_boto.assert_not_called()
+        mock_post.assert_not_called()
+
+    def test_static_creds_only_uses_legacy_path(self, tmp_path, monkeypatch):
+        store = _scaffolded_cloud_project("staticproj", tmp_path)
+        save_config(
+            {
+                "sync": {
+                    "bucket_name": "b",
+                    "region": "us-east-1",
+                    "access_key_id": "k",
+                    "secret_access_key": "s",
+                },
+                "auth": {"sanitized_sub": "test-sub"},
+            }
+        )
+
+        mock_client = MagicMock()
+        mock_client.get_paginator.return_value.paginate.return_value = []
+
+        with (
+            patch("nauro.sync.remote.boto3.client", return_value=mock_client) as mock_boto,
+            patch("nauro.sync.remote.httpx.get") as mock_get,
+        ):
+            from nauro.cli.commands.sync import _pull_from_cloud
+
+            _pull_from_cloud(store.name, store)
+
+        mock_boto.assert_called_once()
+        # New path never touched.
+        manifest_calls = [c for c in mock_get.call_args_list if "/sync/manifest" in c.args[0]]
+        assert manifest_calls == []
+
+    def test_both_credentials_auth0_wins(self, tmp_path, monkeypatch):
+        store = _scaffolded_cloud_project("bothproj", tmp_path)
+        save_config(
+            {
+                "auth": {
+                    "sub": "auth0|test",
+                    "access_token": "tok_orig",
+                    "refresh_token": "refresh_orig",
+                },
+                "sync": {
+                    "bucket_name": "b",
+                    "region": "us-east-1",
+                    "access_key_id": "k",
+                    "secret_access_key": "s",
+                },
+            }
+        )
+
+        with (
+            patch(
+                "nauro.sync.remote.httpx.get",
+                return_value=_ok(200, {"files": [], "next_cursor": None}),
+            ) as mock_get,
+            patch("nauro.sync.remote.boto3.client") as mock_boto,
+        ):
+            from nauro.cli.commands.sync import _pull_from_cloud
+
+            _pull_from_cloud(store.name, store)
+
+        called_urls = [c.args[0] for c in mock_get.call_args_list]
+        assert any("/sync/manifest" in url for url in called_urls)
+        mock_boto.assert_not_called()
+
+    def test_neither_cred_cloud_project_warns_and_fails(self, tmp_path, monkeypatch):
+        store = _scaffolded_cloud_project("strandedproj", tmp_path)
+        save_config({})
+        for var in (
+            "NAURO_SYNC_BUCKET_NAME",
+            "NAURO_SYNC_ACCESS_KEY_ID",
+            "NAURO_SYNC_SECRET_ACCESS_KEY",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+        from nauro.cli.commands.sync import _push_to_cloud
+
+        ok = _push_to_cloud(store.name, store)
+        assert ok is False
+
+
+# --- pull flow ---
+
+
+class TestPullViaPresign:
+    @pytest.fixture()
+    def cloud_store(self, tmp_path):
+        store = _scaffolded_cloud_project("pullproj", tmp_path, project_id=CLOUD_PID)
+        _seed_token()
+        return store
+
+    def _manifest_response(
+        self, files: list[dict], next_cursor: str | None = None
+    ) -> httpx.Response:
+        return _ok(200, {"files": files, "next_cursor": next_cursor})
+
+    def _presign_response(self, ops: list[dict]) -> httpx.Response:
+        return _ok(
+            200,
+            {
+                "urls": [
+                    {
+                        "verb": op["verb"],
+                        "path": op["path"],
+                        "url": f"https://s3.example/{op['verb']}/{op['path']}",
+                        "expires_at": "2026-05-16T13:00:00Z",
+                    }
+                    for op in ops
+                ]
+            },
+        )
+
+    def test_manifest_pagination_two_pages_collapse(self, cloud_store):
+        """The CLI must walk ``next_cursor`` until the server returns None."""
+        page_one = self._manifest_response(
+            [{"path": "decisions/001.md", "etag": '"e1"', "size": 1, "last_modified": "x"}],
+            next_cursor="cursor_abc",
+        )
+        page_two = self._manifest_response(
+            [{"path": "decisions/002.md", "etag": '"e2"', "size": 1, "last_modified": "x"}],
+            next_cursor=None,
+        )
+
+        def fake_get(url, **kwargs):
+            if "/sync/manifest" in url:
+                params = kwargs.get("params") or {}
+                if params.get("cursor") == "cursor_abc":
+                    return page_two
+                return page_one
+            return httpx.Response(200, content=b"file body")
+
+        from nauro.sync import remote
+
+        with (
+            patch.object(remote.httpx, "get", side_effect=fake_get),
+            patch.object(
+                remote.httpx,
+                "post",
+                return_value=self._presign_response(
+                    [
+                        {"verb": "GET", "path": "decisions/001.md"},
+                        {"verb": "GET", "path": "decisions/002.md"},
+                    ]
+                ),
+            ),
+        ):
+            from nauro.cli.commands.sync import _pull_from_cloud
+
+            merged = _pull_from_cloud(cloud_store.name, cloud_store)
+
+        # Both files came back through the diff.
+        assert merged == 2
+
+    def test_manifest_match_no_presign_call(self, cloud_store):
+        """Manifest entries that already match local state → no presign call."""
+        rel = "decisions/037-test.md"
+        target = cloud_store / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("# 037\nremote content\n")
+
+        state = SyncState()
+        state.files[rel] = FileState(
+            local_sha256=compute_sha256(target),
+            remote_etag='"e1"',
+            last_sync="2026-05-16T00:00:00Z",
+        )
+        save_state(cloud_store, state)
+
+        manifest = self._manifest_response(
+            [{"path": rel, "etag": '"e1"', "size": 1, "last_modified": "x"}],
+            next_cursor=None,
+        )
+
+        from nauro.sync import remote
+
+        with (
+            patch.object(remote.httpx, "get", return_value=manifest),
+            patch.object(remote.httpx, "post") as mock_post,
+        ):
+            from nauro.cli.commands.sync import _pull_from_cloud
+
+            merged = _pull_from_cloud(cloud_store.name, cloud_store)
+
+        assert merged == 0
+        mock_post.assert_not_called()
+
+    def test_etag_mismatch_triggers_presign_get_and_writes_file(self, cloud_store):
+        rel = "decisions/099-remote.md"
+        manifest = self._manifest_response(
+            [{"path": rel, "etag": '"new"', "size": 1, "last_modified": "x"}],
+            next_cursor=None,
+        )
+        presign = self._presign_response([{"verb": "GET", "path": rel}])
+
+        def fake_get(url, **kwargs):
+            if "/sync/manifest" in url:
+                return manifest
+            return httpx.Response(200, content=b"# 099\nfresh remote body\n")
+
+        from nauro.sync import remote
+
+        with (
+            patch.object(remote.httpx, "get", side_effect=fake_get),
+            patch.object(remote.httpx, "post", return_value=presign) as mock_post,
+        ):
+            from nauro.cli.commands.sync import _pull_from_cloud
+
+            merged = _pull_from_cloud(cloud_store.name, cloud_store)
+
+        # Presign request: payload carries project_id and the GET op.
+        assert mock_post.call_count == 1
+        sent = mock_post.call_args.kwargs["json"]
+        assert sent["project_id"] == CLOUD_PID
+        assert sent["operations"] == [{"verb": "GET", "path": rel}]
+
+        # Server payload landed in the local file and state updated.
+        pulled = cloud_store / rel
+        assert pulled.read_bytes() == b"# 099\nfresh remote body\n"
+        state = load_state(cloud_store)
+        assert state.files[rel].remote_etag == '"new"'
+        assert merged == 1
+
+    def test_conflict_path_runs_resolve_conflict(self, cloud_store):
+        """When local + remote both moved, resolve_conflict is called and
+        the result is written. last-write-wins keeps the local body."""
+        rel = "stack.md"  # non-append-only → last-write-wins
+        local = cloud_store / rel
+        # local already exists from scaffold; rewrite it to a known local body
+        local.write_text("local sprint plan\n")
+        local_sha = compute_sha256(local)
+
+        state = SyncState()
+        state.files[rel] = FileState(
+            local_sha256="old_sha",
+            remote_etag='"old_etag"',
+            last_sync="2026-05-16T00:00:00Z",
+        )
+        save_state(cloud_store, state)
+
+        manifest = self._manifest_response(
+            [{"path": rel, "etag": '"new_etag"', "size": 1, "last_modified": "x"}],
+            next_cursor=None,
+        )
+        presign = self._presign_response([{"verb": "GET", "path": rel}])
+
+        def fake_get(url, **kwargs):
+            if "/sync/manifest" in url:
+                return manifest
+            return httpx.Response(200, content=b"remote sprint plan\n")
+
+        from nauro.sync import remote
+
+        with (
+            patch.object(remote.httpx, "get", side_effect=fake_get),
+            patch.object(remote.httpx, "post", return_value=presign),
+        ):
+            from nauro.cli.commands.sync import _pull_from_cloud
+
+            merged = _pull_from_cloud(cloud_store.name, cloud_store)
+
+        assert merged == 1
+        # last-write-wins kept the local body — verify by sha
+        assert compute_sha256(local) == local_sha
+        # Backup of the remote losing version should exist.
+        backups = list((cloud_store / ".conflict-backup").iterdir())
+        assert any("stack.md" in b.name for b in backups)
+
+    def test_manifest_401_refresh_then_retry_succeeds(self, cloud_store):
+        manifest_ok = self._manifest_response(
+            [{"path": "decisions/001.md", "etag": '"e1"', "size": 1, "last_modified": "x"}],
+            next_cursor=None,
+        )
+        unauthorized = httpx.Response(401, content=b'{"error":"unauthorized"}')
+        presign_response = self._presign_response([{"verb": "GET", "path": "decisions/001.md"}])
+        refresh_response = _ok(200, {"access_token": "tok_new"})
+
+        manifest_responses = iter([unauthorized, manifest_ok])
+
+        def fake_get(url, **kwargs):
+            if "/sync/manifest" in url:
+                return next(manifest_responses)
+            return httpx.Response(200, content=b"body")
+
+        def fake_post(url, **kwargs):
+            if "/oauth/token" in url:
+                return refresh_response
+            return presign_response
+
+        from nauro.sync import remote
+
+        with (
+            patch.object(remote.httpx, "get", side_effect=fake_get) as mock_get,
+            patch.object(remote.httpx, "post", side_effect=fake_post) as mock_post,
+        ):
+            from nauro.cli.commands.sync import _pull_from_cloud
+
+            merged = _pull_from_cloud(cloud_store.name, cloud_store)
+
+        assert merged == 1
+        # The 401 forced a refresh and a retry of the manifest call.
+        manifest_calls = [c for c in mock_get.call_args_list if "/sync/manifest" in c.args[0]]
+        refresh_calls = [c for c in mock_post.call_args_list if "/oauth/token" in c.args[0]]
+        assert len(manifest_calls) == 2
+        assert len(refresh_calls) == 1
+
+    def test_presign_401_refresh_then_retry_succeeds(self, cloud_store):
+        manifest = self._manifest_response(
+            [{"path": "decisions/001.md", "etag": '"e1"', "size": 1, "last_modified": "x"}],
+            next_cursor=None,
+        )
+        unauthorized = httpx.Response(401, content=b'{"error":"unauthorized"}')
+        presign_ok = self._presign_response([{"verb": "GET", "path": "decisions/001.md"}])
+        refresh_response = _ok(200, {"access_token": "tok_new"})
+
+        post_responses = iter([unauthorized, presign_ok])
+
+        def fake_get(url, **kwargs):
+            if "/sync/manifest" in url:
+                return manifest
+            return httpx.Response(200, content=b"body")
+
+        def fake_post(url, **kwargs):
+            if "/oauth/token" in url:
+                return refresh_response
+            return next(post_responses)
+
+        from nauro.sync import remote
+
+        with (
+            patch.object(remote.httpx, "get", side_effect=fake_get),
+            patch.object(remote.httpx, "post", side_effect=fake_post) as mock_post,
+        ):
+            from nauro.cli.commands.sync import _pull_from_cloud
+
+            merged = _pull_from_cloud(cloud_store.name, cloud_store)
+
+        assert merged == 1
+        presign_calls = [c for c in mock_post.call_args_list if "/sync/presign" in c.args[0]]
+        refresh_calls = [c for c in mock_post.call_args_list if "/oauth/token" in c.args[0]]
+        assert len(presign_calls) == 2
+        assert len(refresh_calls) == 1
+
+
+# --- push flow ---
+
+
+class TestPushViaPresign:
+    @pytest.fixture()
+    def cloud_store(self, tmp_path):
+        store = _scaffolded_cloud_project("pushproj", tmp_path, project_id=CLOUD_PID)
+        _seed_token()
+        return store
+
+    def _seed_synced_state(self, store: Path) -> None:
+        """Record every existing file as already in sync — push diff is empty."""
+        state = SyncState()
+        for f in store.rglob("*"):
+            if not f.is_file():
+                continue
+            rel = str(f.relative_to(store))
+            state.files[rel] = FileState(
+                local_sha256=compute_sha256(f),
+                remote_etag='"e0"',
+                last_sync="2026-05-16T00:00:00Z",
+            )
+        save_state(store, state)
+
+    def _presign_response(self, ops: list[dict]) -> httpx.Response:
+        return _ok(
+            200,
+            {
+                "urls": [
+                    {
+                        "verb": op["verb"],
+                        "path": op["path"],
+                        "url": f"https://s3.example/PUT/{op['path']}",
+                        "expires_at": "2026-05-16T13:00:00Z",
+                    }
+                    for op in ops
+                ]
+            },
+        )
+
+    def test_modified_file_minted_via_presign_and_uploaded(self, cloud_store):
+        self._seed_synced_state(cloud_store)
+        # Touch one file to look modified vs state.
+        modified = cloud_store / "stack.md"
+        modified.write_text("entirely new stack picks\n")
+        new_sha = compute_sha256(modified)
+
+        put_response = MagicMock(spec=httpx.Response)
+        put_response.status_code = 200
+        put_response.headers = {"ETag": '"e_pushed"'}
+
+        def fake_post(url, **kwargs):
+            return self._presign_response(kwargs["json"]["operations"])
+
+        from nauro.sync import remote
+
+        with (
+            patch.object(remote.httpx, "post", side_effect=fake_post) as mock_post,
+            patch.object(remote.httpx, "put", return_value=put_response) as mock_put,
+        ):
+            from nauro.cli.commands.sync import _push_to_cloud
+
+            ok = _push_to_cloud(cloud_store.name, cloud_store)
+
+        assert ok is True
+        # Presign payload carries project_id + a single PUT op for the modified path.
+        body = mock_post.call_args.kwargs["json"]
+        assert body["project_id"] == CLOUD_PID
+        assert body["operations"] == [{"verb": "PUT", "path": "stack.md"}]
+
+        # The PUT used the file's bytes.
+        assert mock_put.call_count == 1
+        assert mock_put.call_args.kwargs["content"] == b"entirely new stack picks\n"
+
+        # State recorded the new sha + the server-returned etag.
+        state = load_state(cloud_store)
+        assert state.files["stack.md"].local_sha256 == new_sha
+        assert state.files["stack.md"].remote_etag == '"e_pushed"'
+
+    def test_no_local_changes_no_presign_call(self, cloud_store):
+        self._seed_synced_state(cloud_store)
+
+        from nauro.sync import remote
+
+        with (
+            patch.object(remote.httpx, "post") as mock_post,
+            patch.object(remote.httpx, "put") as mock_put,
+        ):
+            from nauro.cli.commands.sync import _push_to_cloud
+
+            ok = _push_to_cloud(cloud_store.name, cloud_store)
+
+        assert ok is True
+        mock_post.assert_not_called()
+        mock_put.assert_not_called()
+
+    def test_presign_401_triggers_refresh(self, cloud_store):
+        self._seed_synced_state(cloud_store)
+        (cloud_store / "stack.md").write_text("modified\n")
+
+        unauthorized = httpx.Response(401, content=b'{"error":"unauthorized"}')
+        presign_ok = self._presign_response([{"verb": "PUT", "path": "stack.md"}])
+        refresh_ok = _ok(200, {"access_token": "tok_new"})
+
+        post_responses = iter([unauthorized, presign_ok])
+
+        def fake_post(url, **kwargs):
+            if "/oauth/token" in url:
+                return refresh_ok
+            return next(post_responses)
+
+        put_response = MagicMock(spec=httpx.Response)
+        put_response.status_code = 200
+        put_response.headers = {"ETag": '"e_pushed"'}
+
+        # remote.httpx and auth.httpx are the same module — patching either
+        # routes both module's calls through the same mock.
+        from nauro.sync import remote
+
+        with (
+            patch.object(remote.httpx, "post", side_effect=fake_post) as mock_post,
+            patch.object(remote.httpx, "put", return_value=put_response),
+        ):
+            from nauro.cli.commands.sync import _push_to_cloud
+
+            ok = _push_to_cloud(cloud_store.name, cloud_store)
+
+        assert ok is True
+        # Initial 401 + retry against /sync/presign, plus one /oauth/token refresh.
+        presign_calls = [c for c in mock_post.call_args_list if "/sync/presign" in c.args[0]]
+        refresh_calls = [c for c in mock_post.call_args_list if "/oauth/token" in c.args[0]]
+        assert len(presign_calls) == 2
+        assert len(refresh_calls) == 1

--- a/packages/nauro/tests/test_sync/test_sync_presign.py
+++ b/packages/nauro/tests/test_sync/test_sync_presign.py
@@ -22,7 +22,7 @@ import pytest
 
 from nauro.constants import REPO_CONFIG_MODE_CLOUD
 from nauro.store.config import save_config
-from nauro.store.registry import register_project_v2
+from nauro.store.registry import register_project, register_project_v2
 from nauro.sync.state import (
     FileState,
     SyncState,
@@ -179,6 +179,54 @@ class TestModeDetection:
 
         ok = _push_to_cloud(store.name, store)
         assert ok is False
+
+    def test_v1_registry_entry_with_auth_token_falls_through_to_legacy(self, tmp_path, monkeypatch):
+        """v1 registry entries have no ``mode`` field; ``_project_mode`` returns
+        ``None`` for them. A v1 user with both an Auth0 token and static IAM
+        credentials must keep getting their data pushed via the legacy path —
+        the presign path can't address a project that has no server-side ULID
+        record.
+        """
+        # v1 register_project lives outside the v2 registry, so _project_mode
+        # returns None for this project_name.
+        store = register_project("v1proj", [tmp_path])
+        scaffold_project_store("v1proj", store)
+
+        save_config(
+            {
+                "auth": {
+                    "sub": "auth0|test",
+                    "sanitized_sub": "auth0-test",
+                    "access_token": "tok_orig",
+                    "refresh_token": "refresh_orig",
+                },
+                "sync": {
+                    "bucket_name": "b",
+                    "region": "us-east-1",
+                    "access_key_id": "k",
+                    "secret_access_key": "s",
+                },
+            }
+        )
+
+        mock_client = MagicMock()
+
+        with (
+            patch("nauro.sync.remote.boto3.client", return_value=mock_client) as mock_boto,
+            patch("nauro.sync.remote.httpx.post") as mock_post,
+            patch("nauro.sync.remote.push_file", return_value='"e_static"') as mock_push_file,
+        ):
+            from nauro.cli.commands.sync import _push_to_cloud
+
+            ok = _push_to_cloud(store.name, store)
+
+        assert ok is True
+        # Legacy path: a boto3 client was created and push_file was invoked.
+        mock_boto.assert_called()
+        assert mock_push_file.called
+        # Presign endpoint never touched.
+        presign_calls = [c for c in mock_post.call_args_list if "/sync/presign" in c.args[0]]
+        assert presign_calls == []
 
 
 # --- pull flow ---

--- a/packages/nauro/tests/test_sync/test_sync_status.py
+++ b/packages/nauro/tests/test_sync/test_sync_status.py
@@ -1,0 +1,116 @@
+"""Tests for ``nauro sync --status`` reporting after the manifest+presign cutover.
+
+Closes the Tier 1 1.6 TODO in ``_show_status``: the command must now report
+which transport is configured and the last successful sync time.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from typer.testing import CliRunner
+
+from nauro.cli.main import app
+from nauro.store.config import save_config
+from nauro.store.registry import register_project
+from nauro.sync.state import SyncState, save_state
+from nauro.templates.scaffolds import scaffold_project_store
+
+runner = CliRunner()
+
+
+def _scaffold(name: str = "statusproj", *, repo):
+    store = register_project(name, [repo])
+    scaffold_project_store(name, store)
+    return store
+
+
+class TestSyncPathReporting:
+    def test_auth_token_reports_presign(self, tmp_path, monkeypatch):
+        _scaffold(repo=tmp_path)
+        save_config(
+            {
+                "auth": {
+                    "sub": "auth0|test",
+                    "access_token": "tok_orig",
+                    "refresh_token": "refresh_orig",
+                }
+            }
+        )
+        monkeypatch.chdir(tmp_path)
+
+        result = runner.invoke(app, ["sync", "--status"])
+        assert result.exit_code == 0, result.output
+        assert "Sync path: presign" in result.output
+
+    def test_static_creds_only_reports_legacy(self, tmp_path, monkeypatch):
+        _scaffold(repo=tmp_path)
+        save_config(
+            {
+                "sync": {
+                    "bucket_name": "b",
+                    "region": "us-east-1",
+                    "access_key_id": "k",
+                    "secret_access_key": "s",
+                },
+            }
+        )
+        monkeypatch.chdir(tmp_path)
+
+        result = runner.invoke(app, ["sync", "--status"])
+        assert result.exit_code == 0, result.output
+        assert "Sync path: legacy direct-S3" in result.output
+
+    def test_no_credentials_reports_not_configured(self, tmp_path, monkeypatch):
+        save_config({})
+        monkeypatch.chdir(tmp_path)
+        for var in (
+            "NAURO_SYNC_BUCKET_NAME",
+            "NAURO_SYNC_ACCESS_KEY_ID",
+            "NAURO_SYNC_SECRET_ACCESS_KEY",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+        result = runner.invoke(app, ["sync", "--status"])
+        assert result.exit_code == 0, result.output
+        assert "Sync path: not configured" in result.output
+
+
+class TestLastSyncTime:
+    def test_reports_last_full_sync_when_present(self, tmp_path, monkeypatch):
+        store = _scaffold(repo=tmp_path)
+        save_config(
+            {
+                "auth": {
+                    "sub": "auth0|test",
+                    "access_token": "tok_orig",
+                    "refresh_token": "refresh_orig",
+                }
+            }
+        )
+        monkeypatch.chdir(tmp_path)
+
+        stamp = datetime(2026, 5, 16, 12, 0, 0, tzinfo=timezone.utc).isoformat()
+        state = SyncState(last_full_sync=stamp)
+        save_state(store, state)
+
+        result = runner.invoke(app, ["sync", "--status"])
+        assert result.exit_code == 0, result.output
+        assert stamp in result.output
+
+    def test_reports_never_when_absent(self, tmp_path, monkeypatch):
+        _scaffold(repo=tmp_path)
+        save_config(
+            {
+                "auth": {
+                    "sub": "auth0|test",
+                    "access_token": "tok_orig",
+                    "refresh_token": "refresh_orig",
+                }
+            }
+        )
+        monkeypatch.chdir(tmp_path)
+
+        result = runner.invoke(app, ["sync", "--status"])
+        assert result.exit_code == 0, result.output
+        assert "Last successful sync: never" in result.output


### PR DESCRIPTION
## Why

The CLI's direct-S3 sync requires admin-provisioned static IAM keys,
which means every new user needs a Nauro administrator to onboard them.
The server-side `/sync/manifest` and `/sync/presign` endpoints landed
previously; this PR cuts authenticated users over so admin coordination
drops out of the loop. Once this merges, any install with an Auth0 token
migrates to the new path on its next sync.

## Approach

Mode detection at the top of pull/push picks the transport. When both
an Auth0 token and static IAM creds are present, the Auth0 token wins;
that is the migration ramp. Final dispatch:

* v2-local                                       → no-op
* v2-cloud + Auth0 token                         → presign path
* v2-cloud (no token), or v1 with static creds   → legacy direct-S3
* v1 with no static creds                        → preserve pre-cutover silent no-op

Token refresh is a single retry on 401, no backoff. Matches Auth0's
usage guidance. A failed refresh leaves stored tokens intact so the
user can retry `nauro auth login` without losing state.

Briefly rejected:

* **Hard cutover removing legacy now** — rejected. A follow-up PR
  handles removal after the install population has migrated.
* **Exponential backoff on refresh** — rejected as speculative
  infrastructure; one retry is enough.
* **Always-PUT for backward compatibility** — rejected. See *Push
  semantics shift* under What to review.

## What changed

* **`auth.py`** — `load_access_token`, `refresh_access_token`,
  `with_token_refresh`, `AuthRefreshError`. The refresh helper persists
  the new access token (and the rotated refresh token, if returned).
* **`sync/remote.py`** — `fetch_manifest` (collapses cursor pagination),
  `request_presigned_urls` (chunks at the server's 200-op limit),
  `fetch_via_presigned_url` / `get_via_presigned_url` /
  `put_via_presigned_url`, `PresignError`. Both API helpers wire
  through `with_token_refresh`, which is the context the diff doesn't
  show on its own.
* **`sync/config.py`** — parallel `sync_is_configured()` predicate so
  `_show_status` can distinguish "configured via a specific transport"
  from `SyncConfig.enabled` (which still means static-IAM only).
* **`cli/commands/sync.py`** — `_pull_from_cloud` / `_push_to_cloud`
  dispatch on transport; new `_pull_via_presign` / `_push_via_presign`;
  legacy bodies preserved as `_pull_via_static_s3` /
  `_push_via_static_s3`. `_show_status` now reports the active sync
  path and the last successful sync time.
* **`cli/commands/link.py`** — `link --cloud` guard softened from
  "requires CLI sync credentials" to "requires Auth0 token".

## What to review

* **Mode-detection precedence.** Auth0 wins for v2-cloud; v1 entries
  fall through to legacy when (and only when) static IAM creds are
  configured. The v1+no-creds branch deliberately preserves the
  pre-cutover silent no-op so existing local-style v1 users don't
  start seeing "Warning: this is a cloud-mode project" out of nowhere.
* **Token-refresh failure path.** `refresh_access_token` raises
  `AuthRefreshError` and does *not* clear stored tokens on failure —
  callers render the "run nauro auth login" guidance and exit. Worth
  confirming: the user can retry login without losing state.
* **No-infinite-loop on persistent 401.** `with_token_refresh` retries
  exactly once; a second 401 propagates as the response, not as
  another refresh attempt.
* **Conflict path's extra presign call.** Both pulls and conflicts are
  batched into a single `/sync/presign` request — no second call is
  needed in the common case. The `fetch_via_presigned_url` variant
  returns bytes without writing to disk so `resolve_conflict` can run
  against the remote content.
* **Manifest path-traversal guard.** Defense in depth — the server
  validates per-op on presign, but the manifest itself is currently
  trusted. Suspicious entries (`..` segment or absolute path) are
  skipped with a warning.
* **Push semantics shift.** The new presign push uploads only files
  whose `local_sha256` differs from `state.files[rel]`; the legacy
  direct-S3 push re-PUTs everything. Win: avoids egress on unchanged
  decisions. Cost: an S3-side drift the state file doesn't know about
  (manual deletion, prior failed push not recorded) won't self-heal.
  Acceptable for the current install population; revisit if drift
  becomes empirical.

## What's deferred

* Removal of the legacy direct-S3 path and its supporting config —
  scheduled for a follow-up PR after the install population has
  migrated. The legacy path stays callable until then so installs
  created during the static-IAM era keep working without action.
* Cursor 400 handling and presign audit log — captured as follow-ups
  on the server side; out of scope here.

## Test plan

949 tests pass; 31 new. `ruff format` and `ruff check` clean.

New tests by group:

* **Token refresh + retry** (11) — refresh success, rotation,
  preservation when not rotated, invalid_grant, network failure,
  no-stored-token. `with_token_refresh` 200 path,
  401→refresh→retry, refresh-failure propagation, persistent-401
  termination, no-token guard.
* **Pull (new flow)** (6) — manifest pagination across two pages,
  manifest match (no presign call), etag-mismatch triggers GET +
  write + state update, conflict path runs `resolve_conflict`, 401
  on manifest retries, 401 on presign retries.
* **Push (new flow)** (3) — modified file triggers presign PUT and
  records the new etag, no-changes skips the call, 401 on presign
  triggers refresh + retry.
* **Mode detection** (5) — Auth0 token picks presign, static creds
  only use legacy, both creds set → Auth0 wins, neither cred +
  cloud-mode → warn + fail, v1 registry entry + auth + static creds
  → falls through to legacy (presign untouched).
* **`_show_status`** (5) — auth token reports `presign`, static creds
  report `legacy direct-S3`, no creds reports `not configured`,
  `last_full_sync` echoed when present, "never" when absent.
* **`link --cloud`** (1) — softened guard passes with only an Auth0
  token; existing happy-path test stays green.