### PR TITLE
Port event-driven sync hooks to the presign transport

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/init.py
+++ b/packages/nauro/src/nauro/cli/commands/init.py
@@ -18,7 +18,6 @@ repo instead.
 
 from __future__ import annotations
 
-import logging
 from pathlib import Path
 
 import typer
@@ -45,8 +44,6 @@ from nauro.sync.cloud_projects import CloudProjectError, create_project
 from nauro.telemetry import capture
 from nauro.telemetry.events import project_created
 from nauro.templates.scaffolds import scaffold_project_store
-
-logger = logging.getLogger("nauro.cli.init")
 
 
 def _check_config_overwrite(
@@ -274,8 +271,6 @@ def init(
         typer.echo(f"  Project id: {pid}")
         typer.echo(f"  Store: {store_path}")
         typer.echo("  Includes: 7 decisions, project state, open questions, and a snapshot")
-
-        _try_demo_sync(name, store_path)
     else:
         scaffold_project_store(name, store_path)
         typer.echo(f"Initialized project '{name}'")
@@ -284,20 +279,3 @@ def init(
         for rp in repo_paths:
             typer.echo(f"  Repo:  {rp.resolve()}")
         typer.echo("  Next: run 'nauro sync' to capture the first snapshot")
-
-
-def _try_demo_sync(project_name: str, store_path: Path) -> None:
-    """Best-effort push demo project to S3 if auth is configured."""
-    try:
-        from nauro.sync.config import load_sync_config
-
-        config = load_sync_config()
-        if not config.enabled or not (config.user_id or config.sanitized_sub):
-            return
-
-        from nauro.sync.hooks import push_after_write
-
-        push_after_write(project_name, store_path)
-        typer.echo("  Synced to remote")
-    except Exception:
-        logger.debug("Demo sync failed (auth not configured?)", exc_info=True)

--- a/packages/nauro/src/nauro/cli/commands/status.py
+++ b/packages/nauro/src/nauro/cli/commands/status.py
@@ -28,34 +28,26 @@ def _format_time_ago(iso_timestamp: str) -> str:
 def _count_remote_decisions(project_id: str) -> int | None:
     """Count decisions in the remote store via the manifest endpoint.
 
-    Returns None when not authenticated, the project is not v2 cloud-mode,
-    or the manifest fetch fails. The caller already renders None as
-    "could not reach remote".
+    Returns None when the manifest fetch fails. Callers must gate on
+    auth + cloud-mode before invoking this — the function does not
+    re-check, and a failed call against the wrong endpoint is the
+    caller's bug.
     """
     try:
-        from nauro.cli.commands.auth import load_access_token
-        from nauro.sync.hooks import _project_is_cloud
-
-        if not load_access_token():
-            return None
-        if not _project_is_cloud(project_id):
-            return None
-
         from nauro.sync.remote import PresignError, fetch_manifest
 
-        try:
-            manifest = fetch_manifest(project_id)
-        except PresignError:
-            return None
-        return sum(
-            1
-            for entry in manifest
-            if isinstance(entry, dict)
-            and entry.get("path", "").startswith("decisions/")
-            and entry.get("path", "").endswith(".md")
-        )
+        manifest = fetch_manifest(project_id)
+    except PresignError:
+        return None
     except Exception:
         return None
+    return sum(
+        1
+        for entry in manifest
+        if isinstance(entry, dict)
+        and entry.get("path", "").startswith("decisions/")
+        and entry.get("path", "").endswith(".md")
+    )
 
 
 def status(
@@ -76,22 +68,19 @@ def status(
 
     # Sync — gated on auth token + v2 cloud-mode (matches hooks.py semantics).
     # ``store_path.name`` is the project_id for v2; v1 entries pass their name
-    # here and silent-no-op inside _project_is_cloud.
+    # here and silent-no-op inside is_cloud_project.
     project_id = store_path.name
-    sync_enabled = False
-    try:
-        from nauro.cli.commands.auth import load_access_token
-        from nauro.sync.hooks import _project_is_cloud
+    from nauro.cli.commands.auth import load_access_token
+    from nauro.store.registry import is_cloud_project
 
-        if load_access_token() and _project_is_cloud(project_id):
-            sync_enabled = True
-            typer.echo("  Sync          active (event-driven, presign)")
-        elif not load_access_token():
-            typer.echo("  Sync          inactive — run `nauro auth login` to enable")
-        else:
-            typer.echo("  Sync          inactive — this project is local-only")
-    except ImportError:
+    has_token = bool(load_access_token())
+    sync_enabled = has_token and is_cloud_project(project_id)
+    if sync_enabled:
+        typer.echo("  Sync          active (event-driven, presign)")
+    elif not has_token:
         typer.echo("  Sync          inactive — run `nauro auth login` to enable")
+    else:
+        typer.echo("  Sync          inactive — this project is local-only")
 
     # MCP
     typer.echo("  MCP           active")

--- a/packages/nauro/src/nauro/cli/commands/status.py
+++ b/packages/nauro/src/nauro/cli/commands/status.py
@@ -25,21 +25,35 @@ def _format_time_ago(iso_timestamp: str) -> str:
         return ""
 
 
-def _count_remote_decisions(project_name: str) -> int | None:
-    """Count decisions in the remote S3 store. Returns None on failure."""
-    try:
-        from nauro.sync.config import load_sync_config, s3_prefix
-        from nauro.sync.remote import create_client, list_remote
+def _count_remote_decisions(project_id: str) -> int | None:
+    """Count decisions in the remote store via the manifest endpoint.
 
-        config = load_sync_config()
-        if not config.enabled or not (config.user_id or config.sanitized_sub):
+    Returns None when not authenticated, the project is not v2 cloud-mode,
+    or the manifest fetch fails. The caller already renders None as
+    "could not reach remote".
+    """
+    try:
+        from nauro.cli.commands.auth import load_access_token
+        from nauro.sync.hooks import _project_is_cloud
+
+        if not load_access_token():
+            return None
+        if not _project_is_cloud(project_id):
             return None
 
-        client = create_client(config)
-        user_key = config.user_id or config.sanitized_sub
-        prefix = s3_prefix(user_key, project_name) + "decisions/"
-        remote_files = list_remote(client, config.bucket_name, prefix)
-        return sum(1 for f in remote_files if f["key"].endswith(".md"))
+        from nauro.sync.remote import PresignError, fetch_manifest
+
+        try:
+            manifest = fetch_manifest(project_id)
+        except PresignError:
+            return None
+        return sum(
+            1
+            for entry in manifest
+            if isinstance(entry, dict)
+            and entry.get("path", "").startswith("decisions/")
+            and entry.get("path", "").endswith(".md")
+        )
     except Exception:
         return None
 
@@ -60,19 +74,24 @@ def status(
 
     typer.echo(f"Project: {project_name}\n")
 
-    # Sync
+    # Sync — gated on auth token + v2 cloud-mode (matches hooks.py semantics).
+    # ``store_path.name`` is the project_id for v2; v1 entries pass their name
+    # here and silent-no-op inside _project_is_cloud.
+    project_id = store_path.name
     sync_enabled = False
     try:
-        from nauro.sync.config import load_sync_config
+        from nauro.cli.commands.auth import load_access_token
+        from nauro.sync.hooks import _project_is_cloud
 
-        config = load_sync_config()
-        if config.enabled:
+        if load_access_token() and _project_is_cloud(project_id):
             sync_enabled = True
-            typer.echo(f"  Sync          active (event-driven, S3: {config.bucket_name})")
+            typer.echo("  Sync          active (event-driven, presign)")
+        elif not load_access_token():
+            typer.echo("  Sync          inactive — run `nauro auth login` to enable")
         else:
-            typer.echo("  Sync          inactive — run `nauro sync --cloud-setup` to enable")
+            typer.echo("  Sync          inactive — this project is local-only")
     except ImportError:
-        typer.echo("  Sync          inactive — run `nauro sync --cloud-setup` to enable")
+        typer.echo("  Sync          inactive — run `nauro auth login` to enable")
 
     # MCP
     typer.echo("  MCP           active")
@@ -87,7 +106,7 @@ def status(
     local_count = len(local_decisions)
 
     if sync_enabled:
-        remote_count = _count_remote_decisions(project_name)
+        remote_count = _count_remote_decisions(project_id)
         if remote_count is not None:
             if local_count == remote_count:
                 typer.echo(f"\n  Decisions: {local_count} local, {remote_count} remote (in sync)")

--- a/packages/nauro/src/nauro/mcp/stdio_server.py
+++ b/packages/nauro/src/nauro/mcp/stdio_server.py
@@ -377,22 +377,13 @@ def update_state(
 
 
 def _pull_on_startup() -> None:
-    """Pull latest from S3 before accepting tool calls.
+    """Pull latest from remote before accepting tool calls.
 
     Runs synchronously before mcp.run() so the first tool call sees fresh state.
-    Never raises — failures are logged and the server starts with local state.
+    Auth and cloud-mode gating happen inside ``pull_before_session`` — here we
+    only resolve the project key from cwd. Never raises — failures are logged
+    and the server starts with local state.
     """
-    try:
-        from nauro.sync.config import load_sync_config
-
-        config = load_sync_config()
-        if not config.enabled:
-            logger.debug("session-start pull: sync not configured, skipping")
-            return
-    except Exception as e:
-        logger.warning("session-start pull: config load failed: %s", e)
-        return
-
     try:
         cwd = Path(os.getcwd())
         project_key: str | None = None
@@ -424,7 +415,7 @@ def _pull_on_startup() -> None:
         if pulled:
             logger.info("session-start pull: pulled %d file(s) for %s", pulled, project_key)
         else:
-            logger.debug("session-start pull: already up to date (%s)", project_key)
+            logger.debug("session-start pull: nothing to do for %s", project_key)
     except Exception as e:
         logger.warning("session-start pull: failed, continuing with local state: %s", e)
 

--- a/packages/nauro/src/nauro/store/registry.py
+++ b/packages/nauro/src/nauro/store/registry.py
@@ -355,6 +355,23 @@ def get_project_v2(project_id: str) -> dict | None:
     return registry["projects"].get(project_id)  # type: ignore[no-any-return]
 
 
+def is_cloud_project(project_id: str) -> bool:
+    """True iff ``project_id`` is a v2 cloud-mode registry entry.
+
+    v1 entries (no ``mode`` field) and v2 local-mode entries return False.
+    Used by the auto-sync hooks and the status command to gate presign
+    calls — v1 has no server-side ULID and v2 local-mode is not
+    remote-backed, so neither has a presign target.
+    """
+    try:
+        entry = get_project_v2(project_id)
+    except RegistrySchemaError:
+        return False
+    if entry is None:
+        return False
+    return entry.get("mode") == REPO_CONFIG_MODE_CLOUD
+
+
 def find_projects_by_name_v2(name: str) -> list[tuple[str, dict]]:
     """Return every v2 project whose ``name`` field matches ``name``.
 

--- a/packages/nauro/src/nauro/sync/hooks.py
+++ b/packages/nauro/src/nauro/sync/hooks.py
@@ -1,16 +1,52 @@
 """Event-driven sync hooks — pull on session start, push after writes.
 
-Replace the daemon's poll loop. Called by the MCP server after each
-write. Never block or crash — failures are logged only.
+Called by the MCP server (``stdio_server._pull_on_startup`` on entry,
+``mcp/tools._try_push`` after each write). Never block or crash —
+failures are logged only.
+
+Both hooks gate on Auth0 token presence and v2 cloud-mode at entry and
+silent-no-op when either is missing. The two no-op cases are:
+
+* Not authenticated. MCP writes happen on every tool call; nagging
+  ``run nauro auth login`` on every write would be hostile. The user
+  saw the prompt at session start (or onboarding) — here we just skip.
+* Project is not v2 cloud-mode. v1 entries have no server-side ULID
+  and v2 local-mode is not remote-backed. The presign endpoints can
+  address neither.
+
+Token refresh on 401 is handled inside ``request_presigned_urls`` and
+``fetch_manifest`` via ``with_token_refresh``. ``AuthRefreshError``
+escapes here as a swallowed log line.
 """
 
 import logging
 import re
+from datetime import datetime, timezone
 from pathlib import Path
 
 from nauro_core import extract_decision_number
 
+from nauro.cli.commands.auth import AuthRefreshError, load_access_token
+from nauro.constants import REPO_CONFIG_MODE_CLOUD
+from nauro.store.registry import RegistrySchemaError, get_project_v2
+
 logger = logging.getLogger("nauro.sync")
+
+
+def _project_is_cloud(project_id: str) -> bool:
+    """True iff ``project_id`` is a v2 cloud-mode registry entry.
+
+    v1 entries (no ``mode`` field) and v2 local-mode entries return False:
+    the presign transport has no path for either. v1 has no server-side
+    ULID; v2 local-mode is by definition not remote-backed.
+    """
+    try:
+        entry = get_project_v2(project_id)
+    except RegistrySchemaError:
+        return False
+    if entry is None:
+        return False
+    return entry.get("mode") == REPO_CONFIG_MODE_CLOUD
 
 
 def _renumber_decision_if_collision(
@@ -33,11 +69,9 @@ def _renumber_decision_if_collision(
     if not decisions_dir.exists():
         return rel, content
 
-    # Check if this exact filename already exists locally — no collision
     if (decisions_dir / filename).exists():
         return rel, content
 
-    # Check if another file with the same number prefix exists
     collision = False
     for f in decisions_dir.glob("*.md"):
         n = extract_decision_number(f.name)
@@ -48,7 +82,6 @@ def _renumber_decision_if_collision(
     if not collision:
         return rel, content
 
-    # Find next available number
     existing_nums = set()
     for f in decisions_dir.glob("*.md"):
         n = extract_decision_number(f.name)
@@ -61,7 +94,6 @@ def _renumber_decision_if_collision(
     new_filename = f"{next_num:03d}-{slug}"
     new_rel = f"decisions/{new_filename}"
 
-    # Update the heading inside the file content (e.g. "# 075 — Title" → "# 087 — Title")
     text = content.decode("utf-8", errors="replace")
     text = re.sub(
         rf"^# {incoming_num:03d}( [—-])",
@@ -81,16 +113,27 @@ def _renumber_decision_if_collision(
     return new_rel, content
 
 
-def pull_before_session(project_name: str, store_path: Path) -> int:
-    """Pull remote changes from S3 before a session starts.
+def pull_before_session(project_id: str, store_path: Path) -> int:
+    """Pull remote changes from the server before a session starts.
 
-    Returns the number of files pulled/merged, or 0 on failure/no changes.
-    Never raises — failures are logged and swallowed.
+    Silent no-op when not authenticated or when ``project_id`` is not a
+    v2 cloud-mode entry. Returns the number of files pulled/merged, or
+    0 on any swallowed failure. Never raises — auto-pull must not crash
+    session startup.
     """
+    if not load_access_token():
+        return 0
+    if not _project_is_cloud(project_id):
+        return 0
+
     try:
-        from nauro.sync.config import AuthRequiredError, load_sync_config, require_auth, s3_prefix
         from nauro.sync.merge import detect_conflict, resolve_conflict, should_skip
-        from nauro.sync.remote import create_client, list_remote
+        from nauro.sync.remote import (
+            PresignError,
+            fetch_manifest,
+            fetch_via_presigned_url,
+            request_presigned_urls,
+        )
         from nauro.sync.state import (
             compute_sha256,
             file_changed_locally,
@@ -102,114 +145,140 @@ def pull_before_session(project_name: str, store_path: Path) -> int:
     except ImportError:
         return 0
 
-    config = load_sync_config()
-    if not config.enabled:
-        return 0
-
     try:
-        sanitized_sub = require_auth(config)
-    except AuthRequiredError:
-        logger.warning("sync pull: auth not configured — run 'nauro auth login'")
+        manifest = fetch_manifest(project_id)
+    except AuthRefreshError as exc:
+        logger.warning("sync pull: %s", exc)
         return 0
-
-    try:
-        client = create_client(config)
-        prefix = s3_prefix(sanitized_sub, project_name)
-        remote_files = list_remote(client, config.bucket_name, prefix)
-    except Exception:
-        logger.warning("sync pull: could not reach remote for %s", project_name)
+    except PresignError as exc:
+        logger.warning("sync pull: manifest fetch failed: %s", exc)
         return 0
 
     state = load_state(store_path)
-    merged = 0
 
-    for rf in remote_files:
-        rel = rf["key"].removeprefix(prefix)
+    pulls: list[tuple[str, str]] = []
+    conflicts: list[tuple[str, str]] = []
+    for entry in manifest:
+        rel = entry.get("path", "") if isinstance(entry, dict) else ""
         if not rel or should_skip(rel):
             continue
-
-        remote_etag = rf["etag"]
-        remote_changed = file_changed_remotely(remote_etag, rel, state)
-        if not remote_changed:
+        # Server validates per-op on presign, but the manifest itself is
+        # currently trusted — drop suspicious entries before they hit disk.
+        if ".." in Path(rel).parts or rel.startswith("/"):
+            logger.warning("sync pull: skipping suspicious manifest entry %r", rel)
+            continue
+        remote_etag = entry.get("etag", "")
+        if not file_changed_remotely(remote_etag, rel, state):
             continue
 
         local_file = store_path / rel
         local_changed = file_changed_locally(store_path, rel, state)
+        if not local_changed:
+            pulls.append((rel, remote_etag))
+            continue
 
-        if remote_changed and not local_changed:
-            try:
-                # Pull to a temp location first so we can check for decision number collisions
-                response = client.get_object(Bucket=config.bucket_name, Key=prefix + rel)
-                remote_content = response["Body"].read()
-                remote_etag = rf["etag"]
+        local_sha = compute_sha256(local_file) if local_file.exists() else ""
+        if detect_conflict(rel, state, local_sha, remote_etag):
+            conflicts.append((rel, remote_etag))
 
-                actual_rel, remote_content = _renumber_decision_if_collision(
-                    store_path,
-                    rel,
-                    remote_content,
-                )
-                actual_file = store_path / actual_rel
-                actual_file.parent.mkdir(parents=True, exist_ok=True)
-                actual_file.write_bytes(remote_content)
+    if not pulls and not conflicts:
+        state.last_full_sync = datetime.now(timezone.utc).isoformat()
+        save_state(store_path, state)
+        return 0
 
-                local_sha = compute_sha256(actual_file)
-                update_file_state(state, actual_rel, local_sha, remote_etag)
-                merged += 1
-            except Exception:
-                logger.exception("sync pull: error pulling %s", rel)
-        elif remote_changed and local_changed:
-            local_sha = compute_sha256(local_file) if local_file.exists() else ""
-            if detect_conflict(rel, state, local_sha, remote_etag):
-                try:
-                    response = client.get_object(Bucket=config.bucket_name, Key=prefix + rel)
-                    remote_content = response["Body"].read()
+    operations = [{"verb": "GET", "path": rel} for rel, _etag in pulls + conflicts]
+    try:
+        urls = request_presigned_urls(project_id, operations)
+    except AuthRefreshError as exc:
+        logger.warning("sync pull: %s", exc)
+        return 0
+    except PresignError as exc:
+        logger.warning("sync pull: presign request failed: %s", exc)
+        return 0
 
-                    # For decisions, check if this is actually a different decision
-                    # with the same number (not a content conflict on the same file)
-                    actual_rel, remote_content = _renumber_decision_if_collision(
-                        store_path,
-                        rel,
-                        remote_content,
-                    )
-                    if actual_rel != rel:
-                        # It was a number collision, not a true conflict — write as new file
-                        actual_file = store_path / actual_rel
-                        actual_file.parent.mkdir(parents=True, exist_ok=True)
-                        actual_file.write_bytes(remote_content)
-                        local_sha = compute_sha256(actual_file)
-                        update_file_state(state, actual_rel, local_sha, remote_etag)
-                    else:
-                        merged_content = resolve_conflict(
-                            store_path, local_file, remote_content, rel, state
-                        )
-                        local_file.write_bytes(merged_content)
-                        local_sha = compute_sha256(local_file)
-                        update_file_state(state, rel, local_sha, remote_etag)
-                    merged += 1
-                except Exception:
-                    logger.exception("sync pull: error resolving conflict for %s", rel)
+    url_by_path = {
+        entry["path"]: entry["url"]
+        for entry in urls
+        if isinstance(entry, dict) and entry.get("verb") == "GET"
+    }
 
-    from datetime import datetime, timezone
+    merged = 0
+
+    for rel, remote_etag in pulls:
+        url = url_by_path.get(rel)
+        if not url:
+            continue
+        try:
+            remote_content = fetch_via_presigned_url(url)
+        except PresignError:
+            logger.exception("sync pull: error pulling %s", rel)
+            continue
+        actual_rel, remote_content = _renumber_decision_if_collision(
+            store_path, rel, remote_content
+        )
+        actual_file = store_path / actual_rel
+        actual_file.parent.mkdir(parents=True, exist_ok=True)
+        actual_file.write_bytes(remote_content)
+        local_sha = compute_sha256(actual_file)
+        update_file_state(state, actual_rel, local_sha, remote_etag)
+        merged += 1
+
+    for rel, remote_etag in conflicts:
+        url = url_by_path.get(rel)
+        if not url:
+            continue
+        try:
+            remote_content = fetch_via_presigned_url(url)
+        except PresignError:
+            logger.exception("sync pull: error resolving conflict for %s", rel)
+            continue
+        actual_rel, remote_content = _renumber_decision_if_collision(
+            store_path, rel, remote_content
+        )
+        if actual_rel != rel:
+            # Decision-number collision, not a content conflict — write as a new file.
+            actual_file = store_path / actual_rel
+            actual_file.parent.mkdir(parents=True, exist_ok=True)
+            actual_file.write_bytes(remote_content)
+            local_sha = compute_sha256(actual_file)
+            update_file_state(state, actual_rel, local_sha, remote_etag)
+        else:
+            local_file = store_path / rel
+            merged_content = resolve_conflict(store_path, local_file, remote_content, rel, state)
+            local_file.write_bytes(merged_content)
+            local_sha = compute_sha256(local_file)
+            update_file_state(state, rel, local_sha, remote_etag)
+        merged += 1
 
     state.last_full_sync = datetime.now(timezone.utc).isoformat()
     save_state(store_path, state)
 
     if merged:
-        logger.info("sync pull: merged %d file(s) for %s", merged, project_name)
+        logger.info("sync pull: merged %d file(s) for %s", merged, project_id)
 
     return merged
 
 
-def push_after_write(project_name: str, store_path: Path) -> int:
-    """Push store files to S3 after a local write (decision, question, state).
+def push_after_write(project_id: str, store_path: Path) -> int:
+    """Push changed local files after a write (decision, question, state).
 
-    Returns the number of files pushed, or 0 on failure/not configured.
-    Never raises — failures are logged only.
+    Silent no-op when not authenticated or when ``project_id`` is not a
+    v2 cloud-mode entry. Returns the number of files pushed, or 0 on any
+    swallowed failure. Never raises — auto-push must not surface errors
+    on every MCP tool call.
     """
+    if not load_access_token():
+        return 0
+    if not _project_is_cloud(project_id):
+        return 0
+
     try:
-        from nauro.sync.config import AuthRequiredError, load_sync_config, require_auth, s3_prefix
         from nauro.sync.merge import should_skip
-        from nauro.sync.remote import create_client, push_file
+        from nauro.sync.remote import (
+            PresignError,
+            put_via_presigned_url,
+            request_presigned_urls,
+        )
         from nauro.sync.state import (
             compute_sha256,
             file_changed_locally,
@@ -220,26 +289,9 @@ def push_after_write(project_name: str, store_path: Path) -> int:
     except ImportError:
         return 0
 
-    config = load_sync_config()
-    if not config.enabled:
-        return 0
-
-    try:
-        sanitized_sub = require_auth(config)
-    except AuthRequiredError:
-        logger.warning("sync push: auth not configured — run 'nauro auth login'")
-        return 0
-
-    try:
-        client = create_client(config)
-    except Exception:
-        logger.warning("sync push: could not create S3 client for %s", project_name)
-        return 0
-
-    prefix = s3_prefix(sanitized_sub, project_name)
     state = load_state(store_path)
-    pushed = 0
 
+    changed: list[tuple[str, str, Path]] = []
     for local_file in store_path.rglob("*"):
         if not local_file.is_file():
             continue
@@ -249,24 +301,48 @@ def push_after_write(project_name: str, store_path: Path) -> int:
             continue
         if should_skip(rel) or rel.startswith(".conflict-backup") or rel.startswith("__pycache__"):
             continue
-
-        # Skip files that haven't changed since the last push
         if not file_changed_locally(store_path, rel, state):
             continue
+        local_sha = compute_sha256(local_file)
+        changed.append((rel, local_sha, local_file))
 
+    if not changed:
+        save_state(store_path, state)
+        return 0
+
+    operations = [{"verb": "PUT", "path": rel} for rel, _sha, _path in changed]
+    try:
+        urls = request_presigned_urls(project_id, operations)
+    except AuthRefreshError as exc:
+        logger.warning("sync push: %s", exc)
+        return 0
+    except PresignError as exc:
+        logger.warning("sync push: presign request failed: %s", exc)
+        return 0
+
+    url_by_path = {
+        entry["path"]: entry["url"]
+        for entry in urls
+        if isinstance(entry, dict) and entry.get("verb") == "PUT"
+    }
+
+    pushed = 0
+    for rel, local_sha, local_file in changed:
+        url = url_by_path.get(rel)
+        if not url:
+            continue
         try:
-            local_sha = compute_sha256(local_file)
-            remote_key = prefix + rel
-            new_etag = push_file(client, config.bucket_name, local_file, remote_key)
-            if new_etag:
-                update_file_state(state, rel, local_sha, new_etag)
-                pushed += 1
-        except Exception:
+            new_etag = put_via_presigned_url(url, local_file)
+        except PresignError:
             logger.exception("sync push: failed to push %s", rel)
+            continue
+        if new_etag:
+            update_file_state(state, rel, local_sha, new_etag)
+            pushed += 1
 
     save_state(store_path, state)
 
     if pushed:
-        logger.info("sync push: pushed %d file(s) for %s", pushed, project_name)
+        logger.info("sync push: pushed %d file(s) for %s", pushed, project_id)
 
     return pushed

--- a/packages/nauro/src/nauro/sync/hooks.py
+++ b/packages/nauro/src/nauro/sync/hooks.py
@@ -27,26 +27,9 @@ from pathlib import Path
 from nauro_core import extract_decision_number
 
 from nauro.cli.commands.auth import AuthRefreshError, load_access_token
-from nauro.constants import REPO_CONFIG_MODE_CLOUD
-from nauro.store.registry import RegistrySchemaError, get_project_v2
+from nauro.store.registry import is_cloud_project
 
 logger = logging.getLogger("nauro.sync")
-
-
-def _project_is_cloud(project_id: str) -> bool:
-    """True iff ``project_id`` is a v2 cloud-mode registry entry.
-
-    v1 entries (no ``mode`` field) and v2 local-mode entries return False:
-    the presign transport has no path for either. v1 has no server-side
-    ULID; v2 local-mode is by definition not remote-backed.
-    """
-    try:
-        entry = get_project_v2(project_id)
-    except RegistrySchemaError:
-        return False
-    if entry is None:
-        return False
-    return entry.get("mode") == REPO_CONFIG_MODE_CLOUD
 
 
 def _renumber_decision_if_collision(
@@ -123,7 +106,7 @@ def pull_before_session(project_id: str, store_path: Path) -> int:
     """
     if not load_access_token():
         return 0
-    if not _project_is_cloud(project_id):
+    if not is_cloud_project(project_id):
         return 0
 
     try:
@@ -269,7 +252,7 @@ def push_after_write(project_id: str, store_path: Path) -> int:
     """
     if not load_access_token():
         return 0
-    if not _project_is_cloud(project_id):
+    if not is_cloud_project(project_id):
         return 0
 
     try:

--- a/packages/nauro/tests/test_cli_status_divergence.py
+++ b/packages/nauro/tests/test_cli_status_divergence.py
@@ -1,4 +1,13 @@
-"""Tests for status command decision count and sync divergence output."""
+"""Tests for status command decision count and sync divergence output.
+
+After the auto-sync port, ``sync_enabled`` in ``status`` is gated on:
+
+* An Auth0 access token (via ``load_access_token``).
+* A v2 cloud-mode registry entry for the resolved project_id.
+
+Divergence reporting is verified by mocking ``_count_remote_decisions``
+directly — the manifest-fetch internals belong to test_sync_presign/test_hooks.
+"""
 
 import json
 from unittest.mock import patch
@@ -6,60 +15,108 @@ from unittest.mock import patch
 from typer.testing import CliRunner
 
 from nauro.cli.main import app
-from nauro.store.registry import register_project
+from nauro.constants import REPO_CONFIG_MODE_CLOUD, REPO_CONFIG_MODE_LOCAL
+from nauro.store.config import save_config
+from nauro.store.registry import register_project, register_project_v2
 from nauro.templates.scaffolds import scaffold_project_store
 
 runner = CliRunner()
 
+CLOUD_PID = "01KQ6AZGNA0B3QBF67NBXP3S45"
+LOCAL_PID = "01KQ6AZGNA0B3QBF67NBXP3S46"
 
-def _setup_project(tmp_path, monkeypatch):
+
+def _setup_v1_project(tmp_path, monkeypatch):
+    """v1 project (legacy); status falls back to local-only reporting."""
     store = register_project("testproj", [tmp_path])
     scaffold_project_store("testproj", store)
     monkeypatch.chdir(tmp_path)
     return store
 
 
-def test_status_shows_local_decision_count(tmp_path, monkeypatch):
-    """When sync is not configured, show local count only."""
-    _setup_project(tmp_path, monkeypatch)
+def _setup_cloud_project(tmp_path, monkeypatch):
+    """v2 cloud-mode project, with an auth token saved."""
+    _pid, store = register_project_v2(
+        "testproj",
+        [tmp_path],
+        mode=REPO_CONFIG_MODE_CLOUD,
+        project_id=CLOUD_PID,
+        server_url="https://example.test",
+    )
+    scaffold_project_store("testproj", store)
+    save_config(
+        {
+            "auth": {
+                "sub": "auth0|test",
+                "access_token": "tok_orig",
+                "refresh_token": "refresh_orig",
+            }
+        }
+    )
+    monkeypatch.chdir(tmp_path)
+    return store
+
+
+def test_status_shows_local_decision_count_when_unauthenticated(tmp_path, monkeypatch):
+    """Sync inactive (v1 project, no token) → local count only."""
+    _setup_v1_project(tmp_path, monkeypatch)
 
     result = runner.invoke(app, ["status"])
     assert result.exit_code == 0
-    # scaffold creates 001-initial-setup.md
     assert "Decisions: 1 local" in result.output
     assert "remote" not in result.output
 
 
-def test_status_shows_divergence_when_out_of_sync(tmp_path, monkeypatch):
-    """When sync is configured and counts differ, show 'out of sync'."""
-    store = _setup_project(tmp_path, monkeypatch)
+def test_status_shows_local_only_when_project_is_local_mode(tmp_path, monkeypatch):
+    """v2 local-mode + token → sync inactive, local-only message."""
+    _pid, store = register_project_v2(
+        "localproj",
+        [tmp_path],
+        mode=REPO_CONFIG_MODE_LOCAL,
+        project_id=LOCAL_PID,
+    )
+    scaffold_project_store("localproj", store)
+    save_config({"auth": {"access_token": "tok", "sub": "x"}})
+    monkeypatch.chdir(tmp_path)
 
-    # Write sync state with a last_full_sync timestamp
+    result = runner.invoke(app, ["status"])
+    assert result.exit_code == 0
+    assert "this project is local-only" in result.output
+    assert "remote" not in result.output
+
+
+def test_status_prompts_login_when_no_token(tmp_path, monkeypatch):
+    """No auth token → sync inactive, run nauro auth login."""
+    _pid, store = register_project_v2(
+        "cloudproj",
+        [tmp_path],
+        mode=REPO_CONFIG_MODE_CLOUD,
+        project_id=CLOUD_PID,
+        server_url="https://example.test",
+    )
+    scaffold_project_store("cloudproj", store)
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["status"])
+    assert result.exit_code == 0
+    assert "nauro auth login" in result.output
+
+
+def test_status_shows_divergence_when_out_of_sync(tmp_path, monkeypatch):
+    """Authed cloud project + counts differ → 'out of sync'."""
+    store = _setup_cloud_project(tmp_path, monkeypatch)
+
     sync_state = {
         "files": {},
         "last_full_sync": "2026-03-23T18:42:00+00:00",
     }
     (store / ".sync-state.json").write_text(json.dumps(sync_state))
 
-    mock_config = type(
-        "SyncConfig",
-        (),
-        {
-            "enabled": True,
-            "bucket_name": "test-bucket",
-            "region": "us-east-1",
-            "access_key_id": "key",
-            "secret_access_key": "secret",
-        },
-    )()
-
-    with patch("nauro.sync.config.load_sync_config", return_value=mock_config):
-        # Mock _count_remote_decisions to return a different count
-        with patch(
-            "nauro.cli.commands.status._count_remote_decisions",
-            return_value=5,
-        ):
-            result = runner.invoke(app, ["status"])
+    with patch(
+        "nauro.cli.commands.status._count_remote_decisions",
+        return_value=5,
+    ):
+        result = runner.invoke(app, ["status"])
 
     assert result.exit_code == 0
     assert "1 local" in result.output
@@ -70,8 +127,8 @@ def test_status_shows_divergence_when_out_of_sync(tmp_path, monkeypatch):
 
 
 def test_status_shows_in_sync_when_counts_match(tmp_path, monkeypatch):
-    """When sync is configured and counts match, show 'in sync'."""
-    store = _setup_project(tmp_path, monkeypatch)
+    """Authed cloud project + counts match → 'in sync'."""
+    store = _setup_cloud_project(tmp_path, monkeypatch)
 
     sync_state = {
         "files": {},
@@ -79,24 +136,11 @@ def test_status_shows_in_sync_when_counts_match(tmp_path, monkeypatch):
     }
     (store / ".sync-state.json").write_text(json.dumps(sync_state))
 
-    mock_config = type(
-        "SyncConfig",
-        (),
-        {
-            "enabled": True,
-            "bucket_name": "test-bucket",
-            "region": "us-east-1",
-            "access_key_id": "key",
-            "secret_access_key": "secret",
-        },
-    )()
-
-    with patch("nauro.sync.config.load_sync_config", return_value=mock_config):
-        with patch(
-            "nauro.cli.commands.status._count_remote_decisions",
-            return_value=1,
-        ):
-            result = runner.invoke(app, ["status"])
+    with patch(
+        "nauro.cli.commands.status._count_remote_decisions",
+        return_value=1,
+    ):
+        result = runner.invoke(app, ["status"])
 
     assert result.exit_code == 0
     assert "1 local" in result.output
@@ -106,27 +150,14 @@ def test_status_shows_in_sync_when_counts_match(tmp_path, monkeypatch):
 
 
 def test_status_handles_remote_unreachable(tmp_path, monkeypatch):
-    """When remote is unreachable, show local count with a note."""
-    _setup_project(tmp_path, monkeypatch)
+    """Authed cloud project + manifest fetch fails → 'could not reach remote'."""
+    _setup_cloud_project(tmp_path, monkeypatch)
 
-    mock_config = type(
-        "SyncConfig",
-        (),
-        {
-            "enabled": True,
-            "bucket_name": "test-bucket",
-            "region": "us-east-1",
-            "access_key_id": "key",
-            "secret_access_key": "secret",
-        },
-    )()
-
-    with patch("nauro.sync.config.load_sync_config", return_value=mock_config):
-        with patch(
-            "nauro.cli.commands.status._count_remote_decisions",
-            return_value=None,
-        ):
-            result = runner.invoke(app, ["status"])
+    with patch(
+        "nauro.cli.commands.status._count_remote_decisions",
+        return_value=None,
+    ):
+        result = runner.invoke(app, ["status"])
 
     assert result.exit_code == 0
     assert "1 local" in result.output

--- a/packages/nauro/tests/test_registry_v2.py
+++ b/packages/nauro/tests/test_registry_v2.py
@@ -9,11 +9,16 @@ import pytest
 from nauro.constants import (
     REGISTRY_FILENAME,
     REGISTRY_SCHEMA_VERSION_V2,
+    REPO_CONFIG_MODE_CLOUD,
+    REPO_CONFIG_MODE_LOCAL,
 )
 from nauro.store import registry
 from nauro.store.registry import (
     RegistrySchemaError,
+    is_cloud_project,
     load_registry_v2,
+    register_project,
+    register_project_v2,
     save_registry_v2,
 )
 
@@ -79,3 +84,37 @@ def test_v2_save_rejects_non_v2_schema_version(tmp_path, monkeypatch):
     """save_registry_v2 refuses to write anything other than schema_version=2."""
     with pytest.raises(RegistrySchemaError):
         save_registry_v2({"projects": {}, "schema_version": 1})
+
+
+class TestIsCloudProject:
+    """Gate predicate for auto-sync and the status report. The presign
+    transport has no path for v1 entries (no server-side ULID) or v2
+    local-mode entries (not remote-backed), so both must return False."""
+
+    def test_returns_true_for_v2_cloud(self, tmp_path, monkeypatch):
+        pid = "01KQ6AZGNA0B3QBF67NBXP3S45"
+        register_project_v2(
+            "cloudproj",
+            [tmp_path],
+            mode=REPO_CONFIG_MODE_CLOUD,
+            project_id=pid,
+            server_url="https://example.test",
+        )
+        assert is_cloud_project(pid) is True
+
+    def test_returns_false_for_v2_local(self, tmp_path, monkeypatch):
+        pid = "01KQ6AZGNA0B3QBF67NBXP3S46"
+        register_project_v2(
+            "localproj",
+            [tmp_path],
+            mode=REPO_CONFIG_MODE_LOCAL,
+            project_id=pid,
+        )
+        assert is_cloud_project(pid) is False
+
+    def test_returns_false_for_missing_entry(self, tmp_path, monkeypatch):
+        assert is_cloud_project("01KMISSING00000000000000000") is False
+
+    def test_returns_false_for_v1_name(self, tmp_path, monkeypatch):
+        register_project("v1name", [tmp_path])
+        assert is_cloud_project("v1name") is False

--- a/packages/nauro/tests/test_stdio_server.py
+++ b/packages/nauro/tests/test_stdio_server.py
@@ -511,65 +511,32 @@ class TestContentSizeLimits:
 
 
 class TestPullOnStartup:
-    def test_skips_when_sync_not_configured(self, store: Path, monkeypatch):
-        """No pull attempt when sync credentials are absent."""
-        monkeypatch.chdir(store.parent)
+    """Auth and cloud-mode gating moved into hooks.py; stdio_server only
+    resolves the project from cwd and delegates. These tests cover the
+    resolution flow — silent-no-op-when-not-authenticated and
+    silent-no-op-for-non-cloud are exercised in test_sync/test_hooks.py."""
 
-        disabled_config = type("SyncConfig", (), {"enabled": False})()
-        with patch("nauro.sync.config.load_sync_config", return_value=disabled_config):
-            with patch("nauro.sync.hooks.pull_before_session") as mock_pull:
-                _pull_on_startup()
-                mock_pull.assert_not_called()
-
-    def test_calls_pull_when_sync_configured(self, store: Path, monkeypatch, tmp_path):
-        """pull_before_session is called when sync is enabled and project is found."""
-        # cwd must resolve to our registered project
+    def test_calls_pull_when_project_resolves(self, store: Path, monkeypatch, tmp_path):
+        """pull_before_session is invoked unconditionally when a project resolves."""
         repo_dir = tmp_path / "repo"
         repo_dir.mkdir(exist_ok=True)
         monkeypatch.chdir(repo_dir)
 
-        enabled_config = type(
-            "SyncConfig",
-            (),
-            {
-                "enabled": True,
-                "bucket_name": "test-bucket",
-                "region": "us-east-1",
-                "access_key_id": "key",
-                "secret_access_key": "secret",
-            },
-        )()
-
-        with patch("nauro.sync.config.load_sync_config", return_value=enabled_config):
-            with patch("nauro.sync.hooks.pull_before_session", return_value=3) as mock_pull:
-                _pull_on_startup()
-                mock_pull.assert_called_once_with("testproj", store)
+        with patch("nauro.sync.hooks.pull_before_session", return_value=3) as mock_pull:
+            _pull_on_startup()
+            mock_pull.assert_called_once_with("testproj", store)
 
     def test_does_not_raise_on_pull_failure(self, store: Path, monkeypatch, tmp_path):
-        """Server startup continues even if pull throws."""
+        """Server startup continues even if hooks throws."""
         repo_dir = tmp_path / "repo"
         repo_dir.mkdir(exist_ok=True)
         monkeypatch.chdir(repo_dir)
 
-        enabled_config = type(
-            "SyncConfig",
-            (),
-            {
-                "enabled": True,
-                "bucket_name": "test-bucket",
-                "region": "us-east-1",
-                "access_key_id": "key",
-                "secret_access_key": "secret",
-            },
-        )()
-
-        with patch("nauro.sync.config.load_sync_config", return_value=enabled_config):
-            with patch(
-                "nauro.sync.hooks.pull_before_session",
-                side_effect=ConnectionError("S3 unreachable"),
-            ):
-                # Must not raise
-                _pull_on_startup()
+        with patch(
+            "nauro.sync.hooks.pull_before_session",
+            side_effect=ConnectionError("remote unreachable"),
+        ):
+            _pull_on_startup()  # must not raise
 
     def test_skips_when_no_project_in_cwd(self, store: Path, monkeypatch, tmp_path):
         """No pull attempt when cwd maps to no registered project."""
@@ -577,19 +544,6 @@ class TestPullOnStartup:
         unrelated_dir.mkdir()
         monkeypatch.chdir(unrelated_dir)
 
-        enabled_config = type(
-            "SyncConfig",
-            (),
-            {
-                "enabled": True,
-                "bucket_name": "test-bucket",
-                "region": "us-east-1",
-                "access_key_id": "key",
-                "secret_access_key": "secret",
-            },
-        )()
-
-        with patch("nauro.sync.config.load_sync_config", return_value=enabled_config):
-            with patch("nauro.sync.hooks.pull_before_session") as mock_pull:
-                _pull_on_startup()
-                mock_pull.assert_not_called()
+        with patch("nauro.sync.hooks.pull_before_session") as mock_pull:
+            _pull_on_startup()
+            mock_pull.assert_not_called()

--- a/packages/nauro/tests/test_sync/test_hooks.py
+++ b/packages/nauro/tests/test_sync/test_hooks.py
@@ -22,7 +22,6 @@ from nauro.constants import REPO_CONFIG_MODE_CLOUD
 from nauro.store.config import save_config
 from nauro.store.registry import register_project, register_project_v2
 from nauro.sync.hooks import (
-    _project_is_cloud,
     _renumber_decision_if_collision,
     pull_before_session,
     push_after_write,
@@ -100,7 +99,7 @@ class TestSilentNoOpGating:
         mock_post.assert_not_called()
 
     def test_pull_silent_for_v1_project(self, tmp_path):
-        """v1 entries have no v2 registry record → _project_is_cloud False."""
+        """v1 entries have no v2 registry record → is_cloud_project False."""
         store = register_project("v1proj", [tmp_path])
         scaffold_project_store("v1proj", store)
         _seed_token()
@@ -160,34 +159,6 @@ class TestSilentNoOpGating:
 
         assert result == 0
         mock_post.assert_not_called()
-
-
-# --- _project_is_cloud helper ---
-
-
-class TestProjectIsCloud:
-    def test_returns_true_for_v2_cloud(self, tmp_path):
-        _scaffolded_cloud_project("cloudproj", tmp_path)
-        assert _project_is_cloud(CLOUD_PID) is True
-
-    def test_returns_false_for_v2_local(self, tmp_path):
-        from nauro.constants import REPO_CONFIG_MODE_LOCAL
-
-        local_pid = "01KQ6AZGNA0B3QBF67NBXP3S46"
-        register_project_v2(
-            "localproj",
-            [tmp_path],
-            mode=REPO_CONFIG_MODE_LOCAL,
-            project_id=local_pid,
-        )
-        assert _project_is_cloud(local_pid) is False
-
-    def test_returns_false_for_missing_entry(self):
-        assert _project_is_cloud("01KMISSING00000000000000000") is False
-
-    def test_returns_false_for_v1_name(self, tmp_path):
-        register_project("v1name", [tmp_path])
-        assert _project_is_cloud("v1name") is False
 
 
 # --- pull happy path ---

--- a/packages/nauro/tests/test_sync/test_hooks.py
+++ b/packages/nauro/tests/test_sync/test_hooks.py
@@ -1,126 +1,391 @@
-"""Tests for event-driven sync hooks (pull on session start, push after extraction)."""
+"""Tests for event-driven sync hooks (pull on session start, push after write).
 
+After the cutover to presign, ``hooks.py`` gates on:
+
+* Auth0 access token (no token → silent no-op so MCP writes never nag).
+* v2 cloud-mode registry entry (v1 or local-mode → silent no-op).
+
+The happy paths exercise the manifest/presign helpers via httpx mocks
+matching the patterns in ``test_sync_presign.py``.
+"""
+
+from __future__ import annotations
+
+import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 
-from nauro.store.registry import register_project
-from nauro.sync.config import SyncConfig
+from nauro.constants import REPO_CONFIG_MODE_CLOUD
+from nauro.store.config import save_config
+from nauro.store.registry import register_project, register_project_v2
 from nauro.sync.hooks import (
+    _project_is_cloud,
     _renumber_decision_if_collision,
     pull_before_session,
     push_after_write,
 )
+from nauro.sync.state import (
+    FileState,
+    SyncState,
+    compute_sha256,
+    load_state,
+    save_state,
+)
 from nauro.templates.scaffolds import scaffold_project_store
 
-
-@pytest.fixture()
-def project_store(tmp_path: Path, monkeypatch):
-    store = register_project("testproj", [tmp_path])
-    scaffold_project_store("testproj", store)
-    return store
+CLOUD_PID = "01KQ6AZGNA0B3QBF67NBXP3S45"
 
 
-def _mock_sync_config(enabled=True, sanitized_sub="test-user-abc123"):
-    return SyncConfig(
-        bucket_name="test-bucket",
-        region="us-east-1",
-        access_key_id="fake",
-        secret_access_key="fake",
-        enabled=enabled,
-        sanitized_sub=sanitized_sub,
+def _ok(status: int, payload: dict) -> httpx.Response:
+    return httpx.Response(
+        status,
+        content=json.dumps(payload).encode("utf-8"),
+        headers={"content-type": "application/json"},
     )
 
 
-class TestPullBeforeSession:
-    def test_pull_from_s3_before_returning_context(self, project_store):
-        """SessionStart hook should pull from S3."""
-        mock_client = MagicMock()
-        mock_client.get_paginator.return_value.paginate.return_value = [{"Contents": []}]
+def _seed_token() -> None:
+    save_config(
+        {
+            "auth": {
+                "sub": "auth0|test",
+                "access_token": "tok_orig",
+                "refresh_token": "refresh_orig",
+            }
+        }
+    )
+
+
+def _scaffolded_cloud_project(name: str, repo_path: Path, project_id: str = CLOUD_PID) -> Path:
+    _pid, store = register_project_v2(
+        name,
+        [repo_path],
+        mode=REPO_CONFIG_MODE_CLOUD,
+        server_url="https://example.test",
+        project_id=project_id,
+    )
+    scaffold_project_store(name, store)
+    return store
+
+
+# --- gating: silent no-op semantics ---
+
+
+class TestSilentNoOpGating:
+    """The hooks must silent-no-op when not authenticated or when the
+    project is not v2 cloud-mode. Nagging the user on every MCP write
+    would be hostile; v1/local projects have no presign target."""
+
+    def test_pull_silent_when_not_authenticated(self, tmp_path):
+        store = _scaffolded_cloud_project("noauth", tmp_path)
+        # no _seed_token() — load_access_token() returns None
+
+        with patch("nauro.sync.remote.httpx.get") as mock_get:
+            result = pull_before_session(CLOUD_PID, store)
+
+        assert result == 0
+        mock_get.assert_not_called()
+
+    def test_push_silent_when_not_authenticated(self, tmp_path):
+        store = _scaffolded_cloud_project("noauth", tmp_path)
+        # no _seed_token()
+
+        with patch("nauro.sync.remote.httpx.post") as mock_post:
+            result = push_after_write(CLOUD_PID, store)
+
+        assert result == 0
+        mock_post.assert_not_called()
+
+    def test_pull_silent_for_v1_project(self, tmp_path):
+        """v1 entries have no v2 registry record → _project_is_cloud False."""
+        store = register_project("v1proj", [tmp_path])
+        scaffold_project_store("v1proj", store)
+        _seed_token()
+
+        with patch("nauro.sync.remote.httpx.get") as mock_get:
+            result = pull_before_session("v1proj", store)
+
+        assert result == 0
+        mock_get.assert_not_called()
+
+    def test_push_silent_for_v1_project(self, tmp_path):
+        store = register_project("v1proj", [tmp_path])
+        scaffold_project_store("v1proj", store)
+        _seed_token()
+
+        with patch("nauro.sync.remote.httpx.post") as mock_post:
+            result = push_after_write("v1proj", store)
+
+        assert result == 0
+        mock_post.assert_not_called()
+
+    def test_pull_silent_for_v2_local_mode(self, tmp_path):
+        """v2 local-mode projects have no presign target → silent no-op."""
+        from nauro.constants import REPO_CONFIG_MODE_LOCAL
+
+        local_pid = "01KQ6AZGNA0B3QBF67NBXP3S46"
+        _pid, store = register_project_v2(
+            "localproj",
+            [tmp_path],
+            mode=REPO_CONFIG_MODE_LOCAL,
+            project_id=local_pid,
+        )
+        scaffold_project_store("localproj", store)
+        _seed_token()
+
+        with patch("nauro.sync.remote.httpx.get") as mock_get:
+            result = pull_before_session(local_pid, store)
+
+        assert result == 0
+        mock_get.assert_not_called()
+
+    def test_push_silent_for_v2_local_mode(self, tmp_path):
+        from nauro.constants import REPO_CONFIG_MODE_LOCAL
+
+        local_pid = "01KQ6AZGNA0B3QBF67NBXP3S46"
+        _pid, store = register_project_v2(
+            "localproj",
+            [tmp_path],
+            mode=REPO_CONFIG_MODE_LOCAL,
+            project_id=local_pid,
+        )
+        scaffold_project_store("localproj", store)
+        _seed_token()
+
+        with patch("nauro.sync.remote.httpx.post") as mock_post:
+            result = push_after_write(local_pid, store)
+
+        assert result == 0
+        mock_post.assert_not_called()
+
+
+# --- _project_is_cloud helper ---
+
+
+class TestProjectIsCloud:
+    def test_returns_true_for_v2_cloud(self, tmp_path):
+        _scaffolded_cloud_project("cloudproj", tmp_path)
+        assert _project_is_cloud(CLOUD_PID) is True
+
+    def test_returns_false_for_v2_local(self, tmp_path):
+        from nauro.constants import REPO_CONFIG_MODE_LOCAL
+
+        local_pid = "01KQ6AZGNA0B3QBF67NBXP3S46"
+        register_project_v2(
+            "localproj",
+            [tmp_path],
+            mode=REPO_CONFIG_MODE_LOCAL,
+            project_id=local_pid,
+        )
+        assert _project_is_cloud(local_pid) is False
+
+    def test_returns_false_for_missing_entry(self):
+        assert _project_is_cloud("01KMISSING00000000000000000") is False
+
+    def test_returns_false_for_v1_name(self, tmp_path):
+        register_project("v1name", [tmp_path])
+        assert _project_is_cloud("v1name") is False
+
+
+# --- pull happy path ---
+
+
+class TestPullBeforeSessionPresign:
+    @pytest.fixture()
+    def cloud_store(self, tmp_path):
+        store = _scaffolded_cloud_project("pullproj", tmp_path)
+        _seed_token()
+        return store
+
+    def _manifest(self, files, next_cursor=None):
+        return _ok(200, {"files": files, "next_cursor": next_cursor})
+
+    def _presign(self, ops):
+        return _ok(
+            200,
+            {
+                "urls": [
+                    {
+                        "verb": op["verb"],
+                        "path": op["path"],
+                        "url": f"https://s3.example/{op['verb']}/{op['path']}",
+                        "expires_at": "2026-05-16T13:00:00Z",
+                    }
+                    for op in ops
+                ]
+            },
+        )
+
+    def test_empty_manifest_returns_zero_and_updates_last_sync(self, cloud_store):
+        empty = self._manifest([])
 
         with (
-            patch("nauro.sync.config.load_sync_config", return_value=_mock_sync_config()),
-            patch("nauro.sync.remote.create_client", return_value=mock_client),
+            patch("nauro.sync.remote.httpx.get", return_value=empty),
+            patch("nauro.sync.remote.httpx.post") as mock_post,
         ):
-            result = pull_before_session("testproj", project_store)
-
-        assert result == 0  # No remote changes
-        # Verify list_remote was called (via paginator)
-        mock_client.get_paginator.assert_called_once_with("list_objects_v2")
-
-    def test_pull_failure_is_non_blocking(self, project_store):
-        """If S3 pull fails, should return 0 and not raise."""
-        with (
-            patch("nauro.sync.config.load_sync_config", return_value=_mock_sync_config()),
-            patch("nauro.sync.remote.create_client", side_effect=Exception("network error")),
-        ):
-            result = pull_before_session("testproj", project_store)
+            result = pull_before_session(CLOUD_PID, cloud_store)
 
         assert result == 0
+        mock_post.assert_not_called()
+        state = load_state(cloud_store)
+        assert state.last_full_sync != ""
 
-    def test_pull_skips_when_not_configured(self, project_store):
-        """If sync is not configured, pull should be a no-op."""
-        config = _mock_sync_config(enabled=False)
-        with patch("nauro.sync.config.load_sync_config", return_value=config):
-            result = pull_before_session("testproj", project_store)
+    def test_changed_remote_file_is_fetched_and_written(self, cloud_store):
+        rel = "decisions/099-remote.md"
+        manifest = self._manifest(
+            [{"path": rel, "etag": '"new"', "size": 1, "last_modified": "x"}],
+        )
+        presign = self._presign([{"verb": "GET", "path": rel}])
 
-        assert result == 0
-
-    def test_pull_skips_when_auth_missing(self, project_store):
-        """If sanitized_sub is missing, pull should return 0."""
-        config = _mock_sync_config(enabled=True, sanitized_sub="")
-        with patch("nauro.sync.config.load_sync_config", return_value=config):
-            result = pull_before_session("testproj", project_store)
-
-        assert result == 0
-
-
-class TestPushAfterExtraction:
-    def test_push_to_s3_after_writing_decision(self, project_store):
-        """Post-extraction hook should push to S3."""
-        mock_client = MagicMock()
-        mock_client.put_object.return_value = {"ETag": '"newetag"'}
+        def fake_get(url, **kwargs):
+            if "/sync/manifest" in url:
+                return manifest
+            return httpx.Response(200, content=b"# 099\nfresh remote body\n")
 
         with (
-            patch("nauro.sync.config.load_sync_config", return_value=_mock_sync_config()),
-            patch("nauro.sync.remote.create_client", return_value=mock_client),
+            patch("nauro.sync.remote.httpx.get", side_effect=fake_get),
+            patch("nauro.sync.remote.httpx.post", return_value=presign),
         ):
-            result = push_after_write("testproj", project_store)
+            result = pull_before_session(CLOUD_PID, cloud_store)
 
-        assert result > 0  # Should push store files
-        mock_client.put_object.assert_called()
+        assert result == 1
+        assert (cloud_store / rel).read_bytes() == b"# 099\nfresh remote body\n"
+        state = load_state(cloud_store)
+        assert state.files[rel].remote_etag == '"new"'
 
-    def test_push_failure_is_non_blocking(self, project_store):
-        """If S3 push fails, should return 0 and not raise."""
+    def test_pull_swallows_presign_error(self, cloud_store):
+        """A failed manifest fetch logs and returns 0, never raises."""
+        bad_manifest = httpx.Response(500, content=b"server error")
+        with patch("nauro.sync.remote.httpx.get", return_value=bad_manifest):
+            result = pull_before_session(CLOUD_PID, cloud_store)
+        assert result == 0
+
+    def test_pull_swallows_auth_refresh_error(self, cloud_store):
+        """A 401 with no refresh path returns 0, never raises."""
+        unauthorized = httpx.Response(401, content=b'{"error":"unauthorized"}')
+        save_config({"auth": {"access_token": "tok", "sub": "x"}})
+
+        with patch("nauro.sync.remote.httpx.get", return_value=unauthorized):
+            result = pull_before_session(CLOUD_PID, cloud_store)
+
+        assert result == 0
+
+
+# --- push happy path ---
+
+
+class TestPushAfterWritePresign:
+    @pytest.fixture()
+    def cloud_store(self, tmp_path):
+        store = _scaffolded_cloud_project("pushproj", tmp_path)
+        _seed_token()
+        return store
+
+    def _seed_synced_state(self, store: Path) -> None:
+        state = SyncState()
+        for f in store.rglob("*"):
+            if not f.is_file():
+                continue
+            rel = str(f.relative_to(store))
+            state.files[rel] = FileState(
+                local_sha256=compute_sha256(f),
+                remote_etag='"e0"',
+                last_sync="2026-05-16T00:00:00Z",
+            )
+        save_state(store, state)
+
+    def _presign(self, ops):
+        return _ok(
+            200,
+            {
+                "urls": [
+                    {
+                        "verb": op["verb"],
+                        "path": op["path"],
+                        "url": f"https://s3.example/PUT/{op['path']}",
+                        "expires_at": "2026-05-16T13:00:00Z",
+                    }
+                    for op in ops
+                ]
+            },
+        )
+
+    def test_no_local_changes_skips_presign_call(self, cloud_store):
+        self._seed_synced_state(cloud_store)
+
         with (
-            patch("nauro.sync.config.load_sync_config", return_value=_mock_sync_config()),
-            patch("nauro.sync.remote.create_client", side_effect=Exception("network error")),
+            patch("nauro.sync.remote.httpx.post") as mock_post,
+            patch("nauro.sync.remote.httpx.put") as mock_put,
         ):
-            result = push_after_write("testproj", project_store)
+            result = push_after_write(CLOUD_PID, cloud_store)
+
+        assert result == 0
+        mock_post.assert_not_called()
+        mock_put.assert_not_called()
+
+    def test_modified_file_minted_and_uploaded(self, cloud_store):
+        self._seed_synced_state(cloud_store)
+        (cloud_store / "stack.md").write_text("new stack picks\n")
+
+        put_response = MagicMock(spec=httpx.Response)
+        put_response.status_code = 200
+        put_response.headers = {"ETag": '"e_pushed"'}
+
+        def fake_post(url, **kwargs):
+            return self._presign(kwargs["json"]["operations"])
+
+        with (
+            patch("nauro.sync.remote.httpx.post", side_effect=fake_post) as mock_post,
+            patch("nauro.sync.remote.httpx.put", return_value=put_response) as mock_put,
+        ):
+            result = push_after_write(CLOUD_PID, cloud_store)
+
+        assert result == 1
+        body = mock_post.call_args.kwargs["json"]
+        assert body["project_id"] == CLOUD_PID
+        assert body["operations"] == [{"verb": "PUT", "path": "stack.md"}]
+        assert mock_put.call_count == 1
+
+        state = load_state(cloud_store)
+        assert state.files["stack.md"].remote_etag == '"e_pushed"'
+
+    def test_push_swallows_presign_error(self, cloud_store):
+        self._seed_synced_state(cloud_store)
+        (cloud_store / "stack.md").write_text("modified\n")
+
+        bad = httpx.Response(500, content=b"server error")
+        with patch("nauro.sync.remote.httpx.post", return_value=bad):
+            result = push_after_write(CLOUD_PID, cloud_store)
 
         assert result == 0
 
-    def test_push_skips_when_not_configured(self, project_store):
-        """If sync is not configured, push should be a no-op."""
-        config = _mock_sync_config(enabled=False)
-        with patch("nauro.sync.config.load_sync_config", return_value=config):
-            result = push_after_write("testproj", project_store)
+    def test_push_swallows_auth_refresh_error(self, cloud_store):
+        self._seed_synced_state(cloud_store)
+        (cloud_store / "stack.md").write_text("modified\n")
+
+        unauthorized = httpx.Response(401, content=b'{"error":"unauthorized"}')
+        save_config({"auth": {"access_token": "tok", "sub": "x"}})
+
+        with patch("nauro.sync.remote.httpx.post", return_value=unauthorized):
+            result = push_after_write(CLOUD_PID, cloud_store)
 
         assert result == 0
 
-    def test_push_skips_when_auth_missing(self, project_store):
-        """If sanitized_sub is missing, push should return 0."""
-        config = _mock_sync_config(enabled=True, sanitized_sub="")
-        with patch("nauro.sync.config.load_sync_config", return_value=config):
-            result = push_after_write("testproj", project_store)
 
-        assert result == 0
+# --- decision collision renumbering (unchanged from pre-port) ---
 
 
 class TestRenumberDecisionIfCollision:
+    @pytest.fixture()
+    def project_store(self, tmp_path):
+        store = register_project("renumproj", [tmp_path])
+        scaffold_project_store("renumproj", store)
+        return store
+
     def test_no_collision_passes_through(self, project_store):
-        """When no collision exists, rel and content are returned unchanged."""
         decisions_dir = project_store / "decisions"
         decisions_dir.mkdir(exist_ok=True)
         (decisions_dir / "001-existing.md").write_text("# 001 — Existing")
@@ -132,7 +397,6 @@ class TestRenumberDecisionIfCollision:
         assert out == content
 
     def test_collision_renumbers(self, project_store):
-        """When number collides with a different local file, incoming file is renumbered."""
         decisions_dir = project_store / "decisions"
         decisions_dir.mkdir(exist_ok=True)
         (decisions_dir / "003-local-decision.md").write_text("# 003 — Local decision")
@@ -149,7 +413,6 @@ class TestRenumberDecisionIfCollision:
         assert b"Remote content" in out
 
     def test_collision_skips_multiple_taken_numbers(self, project_store):
-        """Renumbering should find the first available number after all existing ones."""
         decisions_dir = project_store / "decisions"
         decisions_dir.mkdir(exist_ok=True)
         (decisions_dir / "005-a.md").write_text("# 005 — A")
@@ -166,7 +429,6 @@ class TestRenumberDecisionIfCollision:
         assert b"# 007 " in out
 
     def test_exact_filename_match_is_not_collision(self, project_store):
-        """If the exact same filename exists locally, it's a content update, not a collision."""
         decisions_dir = project_store / "decisions"
         decisions_dir.mkdir(exist_ok=True)
         (decisions_dir / "003-same-slug.md").write_text("# 003 — Same slug")
@@ -182,7 +444,6 @@ class TestRenumberDecisionIfCollision:
         assert out == content
 
     def test_non_decision_files_pass_through(self, project_store):
-        """Non-decision files should never be renumbered."""
         content = b"some content"
         rel, out = _renumber_decision_if_collision(project_store, "state.md", content)
 


### PR DESCRIPTION
## Why

`hooks.py` was the last consumer of the legacy direct-S3 transport for event-driven sync (pull on MCP session start, push after each MCP write). With the install population on the server-minted presign path for user-driven `nauro sync`, leaving auto-sync on the legacy transport created a divergence — and meant the legacy code couldn't be removed without losing auto-sync.

## Approach

Port `hooks.py` and its four downstream callers to the manifest + presign endpoints, then leave the legacy symbols in place for a separate cleanup PR. Splitting the work keeps the review concerns distinct: this PR is "is the new auto-sync behavior correct?"; the follow-up is "is the delete clean?". Combining them would conflate those questions and make the cleanup PR hard to verify by grep.

Gating moves into `hooks.py`. The two no-op cases are spelled out at entry:

- Not authenticated → silent no-op. MCP writes happen on every tool call; nagging "run nauro auth login" on every write would be hostile.
- Project is not v2 cloud-mode → silent no-op. v1 entries have no server-side ULID, v2 local-mode is by definition not remote-backed, and the presign endpoints address neither.

The cloud-mode predicate lives in `store.registry.is_cloud_project` since it's a registry-layer question; `hooks.py` and `status.py` both import it from there rather than reaching across an underscore boundary. Token refresh on 401 stays handled inside the presign helpers via `with_token_refresh`.

## What changed

- `sync/hooks.py` ported to presign-only. Decision-number collision renumbering is preserved.
- `store/registry.py` gains `is_cloud_project(project_id)` — registry-layer predicate used by hooks and status.
- `mcp/stdio_server._pull_on_startup` drops its `load_sync_config()` probe; it resolves the project from cwd and delegates.
- `cli/commands/status.py` reports "active (presign)", "inactive — run `nauro auth login`", or "inactive — this project is local-only" based on token + cloud-mode. `_count_remote_decisions` calls the manifest endpoint and filters to `decisions/*.md`. The token is loaded once per command invocation.
- `cli/commands/init._try_demo_sync` deleted — demos are local-mode, so hooks would no-op anyway.

The legacy direct-S3 symbols (`create_client`, `push_file`, `list_remote`, `SyncConfig`, `load_sync_config`, `s3_prefix`, `require_auth`, `AuthRequiredError`) remain in place — the `nauro sync` command dispatcher still uses them. They are removed in the follow-up cleanup PR.

## What to review

- The silent-no-op semantics in `hooks.py`. The three cases (not authed, v1 project, v2 local-mode) each have a dedicated consumer-side test in `test_sync/test_hooks.py`; the predicate itself is covered in `test_registry_v2.py::TestIsCloudProject`.
- `_count_remote_decisions` now hits `/sync/manifest` instead of S3 list. The caller is responsible for the auth + cloud-mode gate; the function trusts that and just translates a failed fetch to None.
- `status.py` calls `load_access_token` once per invocation now. Verify the message branches are still reachable for each combination.

## What's deferred

- Removal of the legacy direct-S3 transport (the `nauro sync` command dispatcher, `remote.py` legacy helpers, `config.py` static IAM schema) and the matching infra template. Follow-up PR.

## Test plan

- 960 tests pass (`uv run pytest packages/nauro/tests/ -x -q`).
- `test_sync/test_hooks.py`: 5 silent-no-op + 4 pull + 4 push + 5 renumber.
- `test_registry_v2.py::TestIsCloudProject`: 4 cases for the new predicate (v2 cloud, v2 local, missing id, v1 name).
- `test_stdio_server.TestPullOnStartup` reduced to three resolution tests — auth/cloud gating now lives in hooks. Existing project resolution behavior wasn't changed in this PR.
- `test_cli_status_divergence`: 6 cases covering the new gating and unchanged divergence reporting.
- `uv run ruff check packages/nauro` and `uv run ruff format --check packages/nauro` clean.