### PR TITLE
Fold cloud_projects._resolve_api_url into sync.remote.resolve_api_url

### DIFF
--- a/packages/nauro/src/nauro/sync/cloud_projects.py
+++ b/packages/nauro/src/nauro/sync/cloud_projects.py
@@ -5,8 +5,9 @@ plane. Both endpoints require an OAuth bearer token; the token is loaded
 from ``~/.nauro/config.json`` under the ``auth.access_token`` key — the same
 slot that ``nauro auth login`` writes.
 
-The server URL resolution mirrors ``nauro.cli.commands.auth``: ``NAURO_API_URL``
-env var first, then ``api_url`` in user config, then the public default.
+Server URL resolution is shared with the sync transport via
+``nauro.sync.remote.resolve_api_url`` (``NAURO_API_URL`` env var, then
+``api_url`` in user config, then the public default).
 
 Failure modes are collapsed into a single ``CloudProjectError`` with a
 human-readable message; both callers (``nauro init --cloud`` and ``nauro attach``,
@@ -19,13 +20,12 @@ benefit.
 
 from __future__ import annotations
 
-import os
 from typing import TypedDict
 
 import httpx
 
-from nauro.cli.commands.auth import DEFAULT_API_URL
 from nauro.store.config import load_config
+from nauro.sync.remote import resolve_api_url
 
 _DEFAULT_TIMEOUT = 15.0
 
@@ -45,20 +45,6 @@ class CloudProjectError(Exception):
     The message is the user-facing rendering. Callers should print it and
     exit; no recovery is attempted at this layer.
     """
-
-
-def _resolve_api_url() -> str:
-    """Resolve the remote MCP server base URL.
-
-    Precedence: NAURO_API_URL env var → ``api_url`` config key → public default.
-    Mirrors the resolution in ``nauro.cli.commands.auth._resolve_auth_config``
-    so this client and the auth flow agree about which server is in play.
-    """
-    env_url = os.environ.get("NAURO_API_URL")
-    if env_url:
-        return env_url
-    config_url = str(load_config().get("api_url") or "")
-    return config_url or DEFAULT_API_URL
 
 
 def _load_access_token() -> str:
@@ -98,8 +84,7 @@ def _parse_project(raw: object) -> ProjectView:
 
 def _request(method: str, path: str, *, json_body: dict | None = None) -> httpx.Response:
     """Issue an authenticated request, translating transport failures."""
-    api_url = _resolve_api_url().rstrip("/")
-    url = f"{api_url}{path}"
+    url = f"{resolve_api_url()}{path}"
     headers = {
         "Authorization": f"Bearer {_load_access_token()}",
         "Accept": "application/json",

--- a/packages/nauro/src/nauro/sync/remote.py
+++ b/packages/nauro/src/nauro/sync/remote.py
@@ -31,14 +31,13 @@ class PresignError(Exception):
 def resolve_api_url() -> str:
     """Resolve the remote MCP server base URL.
 
-    Mirrors ``nauro.sync.cloud_projects._resolve_api_url`` — env var first,
-    then ``api_url`` in user config, then the public default.
+    Precedence: ``NAURO_API_URL`` env var, then ``api_url`` in user config,
+    then the public default. Trailing slash stripped on every branch so
+    callers can append ``/path`` without doubling the separator.
     """
-    env_url = os.environ.get("NAURO_API_URL")
-    if env_url:
-        return env_url
+    env_url = os.environ.get("NAURO_API_URL") or ""
     config_url = str(load_config().get("api_url") or "")
-    return (config_url or DEFAULT_API_URL).rstrip("/")
+    return (env_url or config_url or DEFAULT_API_URL).rstrip("/")
 
 
 # The server batches up to 200 ops per /sync/presign call (see mcp-server

--- a/packages/nauro/tests/test_sync/test_remote_resolve.py
+++ b/packages/nauro/tests/test_sync/test_remote_resolve.py
@@ -1,0 +1,28 @@
+"""Invariants for ``nauro.sync.remote.resolve_api_url``.
+
+Every caller appends a path like ``/sync/manifest`` to the result, so the
+function must strip trailing slashes regardless of which precedence
+branch supplies the URL.
+"""
+
+from __future__ import annotations
+
+from nauro.store.config import save_config
+from nauro.sync.remote import resolve_api_url
+
+
+def test_strips_trailing_slash_from_env_var(monkeypatch):
+    monkeypatch.setenv("NAURO_API_URL", "https://mcp.example.test/")
+    assert resolve_api_url() == "https://mcp.example.test"
+
+
+def test_strips_trailing_slash_from_config(monkeypatch, tmp_path):
+    monkeypatch.delenv("NAURO_API_URL", raising=False)
+    save_config({"api_url": "https://mcp.example.test/"})
+    assert resolve_api_url() == "https://mcp.example.test"
+
+
+def test_env_var_wins_over_config(monkeypatch, tmp_path):
+    monkeypatch.setenv("NAURO_API_URL", "https://env.example.test")
+    save_config({"api_url": "https://config.example.test"})
+    assert resolve_api_url() == "https://env.example.test"


### PR DESCRIPTION
## Why

The deferred follow-up from #65. Two parallel implementations of the
same env→config→default resolution had drifted on a real edge: the
public ``resolve_api_url`` stripped trailing slashes only on the config/
default branch, while ``NAURO_API_URL`` passed through unstripped.
``cloud_projects._request`` had been papering over this with a call-site
``.rstrip("/")``, but the ``sync.remote`` / ``sync.py`` callers using the
public function already hit the latent doubled-slash bug whenever the
env var ended in ``/``.

Concrete regression that motivated the fix:
``NAURO_API_URL=https://mcp.nauro.ai/`` → ``resolve_api_url()`` returned
``https://mcp.nauro.ai/`` → callers built ``https://mcp.nauro.ai//sync/manifest``.

## What changed

- ``sync/remote.py``: ``resolve_api_url`` strips on every branch. Docstring
  rewritten — no longer "mirrors" ``cloud_projects``, and the new claim
  ("trailing slash stripped on every branch") matches the code.
- ``sync/cloud_projects.py``: imports ``resolve_api_url`` from ``sync.remote``,
  deletes the local ``_resolve_api_url``, drops the now-redundant
  ``.rstrip("/")`` at the ``_request`` call site. Unused ``os`` and
  ``DEFAULT_API_URL`` imports go.
- New ``test_sync/test_remote_resolve.py``: three invariants —
  env-var-with-trailing-slash strip (the regression), config-with-trailing-slash
  strip, and env-over-config precedence.

## Test plan

- 928 tests pass (``uv run pytest packages/nauro/tests/ -x -q``) — +3 new.
- ``uv run ruff check packages/nauro`` and ``uv run ruff format --check packages/nauro`` clean.