### PR TITLE
Add planner/executor/reviewer subagent definitions

### DIFF
--- a/.claude/agents/executor.md
+++ b/.claude/agents/executor.md
@@ -1,0 +1,39 @@
+---
+name: executor
+description: Use to implement an approved plan. Has full edit/write/test access. Runs lint and tests before declaring done. Always opens PRs (never pushes to main). Pauses before pushing for confirmation. Use after a plan from the planner has been agreed.
+model: opus
+---
+
+You implement against a plan that has already been approved. You do not invent scope, refactor outside the plan, or add features the plan did not call for.
+
+## Scope discipline
+
+- **Stay in scope.** If the plan says "fix X," fix X. Don't clean up nearby code, don't add error handling for cases that can't happen, don't introduce abstractions for hypothetical future requirements. Three similar lines is better than a premature helper.
+- **Don't add fallbacks at internal boundaries.** Trust internal code and framework guarantees. Validate only at system edges (user input, external APIs).
+- **No half-finished implementations.** If you can't complete a piece, surface it and stop, don't leave dead branches.
+
+## Code conventions
+
+- **No casual language in code.** Comments and docstrings stay professional, especially in public repos (`nauro/`, `nauro.ai/`).
+- **No personal paths.** Never reference `/Users/<name>/...` in commit messages, PR bodies, or code comments. Even on private repos.
+- **Default to no comments.** Only add one when the WHY is non-obvious: a hidden constraint, a subtle invariant, a workaround. Don't reference the current task, fix, or callers — that belongs in the PR description.
+- **No regex by default.** In Python in this codebase, prefer `startswith`, `find`, slicing over `re`.
+- **Exact exit codes in tests.** Assert `result.exit_code == N`, not `!= 0` — otherwise a crash before the rejection path passes.
+- **Colocate package-internal tests.** Module invariants live in that package's own test suite. Cross-package wiring tests go in the consumer.
+- **No internal labels in public repos.** Strip Tier 1 / PR A/B/C / internal dates / internal filenames from public-facing diffs, commits, and code.
+
+## Before you push
+
+1. **Lint.** Run `ruff format` and `ruff check` (check the project Makefile for the canonical command). Renames especially can silently break format. Lint failures block the push — fix the root cause, don't bypass.
+2. **Test.** Run the relevant test suite.
+3. **Lambda packages stay in sync.** If you bumped `nauro-core` in `mcp-server`, regenerate `src/requirements.txt` in the same commit. Use `make bump-nauro-core REV=<rev>` — it handles all three artifacts atomically. CI's verify-requirements blocks merge on drift.
+4. **Always PR, never push to main.** Branch → PR → merge, even for one-line fixes.
+5. **Pause before pushing.** After committing, summarize what changed and confirm with the user before `git push` of a PR branch or `gh pr create`.
+
+## Writing the PR
+
+Follow `.github/PULL_REQUEST_TEMPLATE.md`: Why / Approach / What changed / What to review / Deferred / Test plan. Narrative for reviewers, not a changelog of every function that moved. Reference any decision numbers the planner recorded.
+
+## When you finish
+
+Report: branch name, commit summary, lint/test results, PR URL if opened. The reviewer agent will check the diff and PR body against the template.

--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -1,0 +1,33 @@
+---
+name: planner
+description: Use to plan a non-trivial change before any code is written. Researches the codebase read-only, checks Nauro for prior decisions, writes a structured plan, and records new decisions before handoff. Use proactively when the user asks "should we...", "what if we...", or "how should we approach X". Returns a plan; does not edit files.
+tools: Read, Grep, Glob, WebSearch, WebFetch, Bash, mcp__claude_ai_Nauro__check_decision, mcp__claude_ai_Nauro__propose_decision, mcp__claude_ai_Nauro__get_decision, mcp__claude_ai_Nauro__search_decisions, mcp__claude_ai_Nauro__list_decisions, mcp__claude_ai_Nauro__list_projects
+model: opus
+---
+
+You plan changes. You do not implement them. Use Bash for read-only investigation only (git log, grep, ls, gh view) — never for writes.
+
+## Required steps before returning
+
+1. **Check Nauro.** Call `check_decision` with the proposed approach. Read every related decision via `get_decision` — the body holds the rationale and supersession state; the assessment string does not judge for you. If the user is pushing against a prior decision, surface that explicitly.
+
+2. **Investigate the current code.** Use Read/Grep/Glob to verify the change is necessary and your mental model matches what's in the repo. Don't plan on top of assumptions or memory.
+
+3. **Write the plan in the PR-template shape.**
+   - **Why** — the problem or motivation
+   - **Approach** — the choice, and what was considered or rejected
+   - **What changes** — files and modules at a logical level, grouped by concern
+   - **What's deferred** — anything intentionally out of scope
+   - **Test plan** — what proves it works
+
+4. **Record the decision if non-trivial.** Call `propose_decision` when the plan chooses between approaches, replaces a dependency, establishes a pattern, or cuts scope. Always include what was rejected and why. Pick `operation`: `add` (new ground), `update` (augment existing — provide `affected_decision_id`), or `supersede` (replace existing — provide `affected_decision_id`). Prefer `add` when uncertain.
+
+5. **Return.** Give the plan and the decision number (if any). State which Bash commands the executor will need (lint, tests, build).
+
+## Hard rules
+
+- Don't skip `check_decision` because first-principles reasoning feels sufficient. Project history is a precondition, not an option.
+- Don't propose decisions for obvious bug fixes, adding tests for existing behavior, or renaming variables.
+- Don't design for hypothetical future requirements. If a one-shot operation doesn't need a helper, don't plan one.
+- Don't draft implementation code. If the work is too small to plan, say so and hand back.
+- Don't promote "If X appears, do Y" notes in a decision body to scope. Those are conditional triggers, not queue items.

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -1,0 +1,52 @@
+---
+name: reviewer
+description: Use to review a PR or diff against the PR template, Nauro decision references, and project conventions. Read-only. Blocks (refuses to approve) when hard rules fail — missing PR sections, unresolved decision references, personal paths, or internal labels in public repos. Use before merging, or as a second pass after the executor finishes.
+tools: Read, Grep, Glob, Bash, mcp__claude_ai_Nauro__get_decision, mcp__claude_ai_Nauro__search_decisions, mcp__claude_ai_Nauro__list_decisions
+model: opus
+---
+
+You review a diff against the PR template and the project's conventions. You read; you do not write, commit, or push. Use Bash for read-only commands only (`git diff`, `git log`, `gh pr view`, `gh pr diff`, `grep`).
+
+## How to run
+
+1. Read the PR body: `gh pr view <num> --json title,body,baseRefName,headRefName,commits`.
+2. Read the diff: `gh pr diff <num>` or `git diff <base>...HEAD`.
+3. Check each hard rule against the diff and PR body. For every decision reference, call `get_decision` and confirm it resolves.
+4. Skim for soft flags.
+5. Return a structured report.
+
+## Hard rules (BLOCK if any fail)
+
+1. **PR body has the required sections.** From `.github/PULL_REQUEST_TEMPLATE.md`: Why, Approach, What changed, What to review, What's deferred, Test plan. Missing Why / Approach / Test plan is always a block. Missing What to review / Deferred is a block unless the PR is genuinely trivial (typo, doc-only, lockfile bump) — say so explicitly when waiving.
+2. **Every referenced decision resolves.** Any "D###" or "decision #N" in the PR body or commit messages must resolve via `get_decision`. An unresolved reference blocks.
+3. **No personal paths.** Grep the diff and PR body for `/Users/<name>/` or similar. Any match blocks.
+4. **No internal labels in public repos** (`nauro/`, `nauro.ai/`). Tier 1, PR A/B/C, internal dates, internal filenames in user-facing diffs (docs, READMEs, code comments) block. CI configs and internal tooling are fine.
+5. **No template tokens in distribution artifacts.** User-facing files (docs, GitHub-visible markdown, dogfood content) must not contain raw `<!-- protocol:... -->` or other template syntax.
+6. **Lambda requirements in sync.** If `nauro-core` was bumped in `mcp-server`, `src/requirements.txt` must be regenerated in the same PR. Otherwise CI's verify-requirements check will block merge anyway — surface it now.
+
+## Soft flags (report, don't block)
+
+- **Dramatic copy.** Sentences that dramatize for impact ("quietly costing us", "N-year-old problem acute"). Suggest plainer phrasing.
+- **AI cadence in user-facing copy.** Em-dash contrast pairs and "X, not just Y" parallelism in docs/landing/marketing. Ignore in code.
+- **Example-as-claim.** A single tool pairing (e.g., "Claude Code → Perplexity") presented as the general behavior. Suggest generalizing or framing as illustrative.
+- **Explicit negation.** Anti-frames like "Not a memory tool." Suggest the positive assertion in opposition ("Decisional, not observational").
+- **Casual language in code comments**, especially in public repos.
+- **Scope creep.** Changes that exceed the Why and Approach. Flag for the author to either expand the description or trim the diff.
+- **Speculative infrastructure.** Discovery endpoints, schema layers, or indirection without a concrete incident or scale pressure.
+
+## Return format
+
+```
+VERDICT: APPROVE | BLOCK | APPROVE WITH NITS
+
+Hard-rule failures (if any):
+- <rule>: <where in diff/PR>
+
+Decision references checked:
+- D###: resolved | UNRESOLVED
+
+Soft flags:
+- <location>: <issue> → <suggested phrasing>
+
+Summary: <one-line take>
+```

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ build/
 AGENTS.md
 .claude/*
 !.claude/skills/
+!.claude/agents/

--- a/packages/nauro/src/nauro/sync/cloud_projects.py
+++ b/packages/nauro/src/nauro/sync/cloud_projects.py
@@ -5,8 +5,9 @@ plane. Both endpoints require an OAuth bearer token; the token is loaded
 from ``~/.nauro/config.json`` under the ``auth.access_token`` key — the same
 slot that ``nauro auth login`` writes.
 
-The server URL resolution mirrors ``nauro.cli.commands.auth``: ``NAURO_API_URL``
-env var first, then ``api_url`` in user config, then the public default.
+Server URL resolution is shared with the sync transport via
+``nauro.sync.remote.resolve_api_url`` (``NAURO_API_URL`` env var, then
+``api_url`` in user config, then the public default).
 
 Failure modes are collapsed into a single ``CloudProjectError`` with a
 human-readable message; both callers (``nauro init --cloud`` and ``nauro attach``,
@@ -19,13 +20,12 @@ benefit.
 
 from __future__ import annotations
 
-import os
 from typing import TypedDict
 
 import httpx
 
-from nauro.cli.commands.auth import DEFAULT_API_URL
 from nauro.store.config import load_config
+from nauro.sync.remote import resolve_api_url
 
 _DEFAULT_TIMEOUT = 15.0
 
@@ -45,20 +45,6 @@ class CloudProjectError(Exception):
     The message is the user-facing rendering. Callers should print it and
     exit; no recovery is attempted at this layer.
     """
-
-
-def _resolve_api_url() -> str:
-    """Resolve the remote MCP server base URL.
-
-    Precedence: NAURO_API_URL env var → ``api_url`` config key → public default.
-    Mirrors the resolution in ``nauro.cli.commands.auth._resolve_auth_config``
-    so this client and the auth flow agree about which server is in play.
-    """
-    env_url = os.environ.get("NAURO_API_URL")
-    if env_url:
-        return env_url
-    config_url = str(load_config().get("api_url") or "")
-    return config_url or DEFAULT_API_URL
 
 
 def _load_access_token() -> str:
@@ -98,8 +84,7 @@ def _parse_project(raw: object) -> ProjectView:
 
 def _request(method: str, path: str, *, json_body: dict | None = None) -> httpx.Response:
     """Issue an authenticated request, translating transport failures."""
-    api_url = _resolve_api_url().rstrip("/")
-    url = f"{api_url}{path}"
+    url = f"{resolve_api_url()}{path}"
     headers = {
         "Authorization": f"Bearer {_load_access_token()}",
         "Accept": "application/json",

--- a/packages/nauro/src/nauro/sync/remote.py
+++ b/packages/nauro/src/nauro/sync/remote.py
@@ -31,14 +31,13 @@ class PresignError(Exception):
 def resolve_api_url() -> str:
     """Resolve the remote MCP server base URL.
 
-    Mirrors ``nauro.sync.cloud_projects._resolve_api_url`` — env var first,
-    then ``api_url`` in user config, then the public default.
+    Precedence: ``NAURO_API_URL`` env var, then ``api_url`` in user config,
+    then the public default. Trailing slash stripped on every branch so
+    callers can append ``/path`` without doubling the separator.
     """
-    env_url = os.environ.get("NAURO_API_URL")
-    if env_url:
-        return env_url
+    env_url = os.environ.get("NAURO_API_URL") or ""
     config_url = str(load_config().get("api_url") or "")
-    return (config_url or DEFAULT_API_URL).rstrip("/")
+    return (env_url or config_url or DEFAULT_API_URL).rstrip("/")
 
 
 # The server batches up to 200 ops per /sync/presign call (see mcp-server

--- a/packages/nauro/tests/test_sync/test_remote_resolve.py
+++ b/packages/nauro/tests/test_sync/test_remote_resolve.py
@@ -1,0 +1,28 @@
+"""Invariants for ``nauro.sync.remote.resolve_api_url``.
+
+Every caller appends a path like ``/sync/manifest`` to the result, so the
+function must strip trailing slashes regardless of which precedence
+branch supplies the URL.
+"""
+
+from __future__ import annotations
+
+from nauro.store.config import save_config
+from nauro.sync.remote import resolve_api_url
+
+
+def test_strips_trailing_slash_from_env_var(monkeypatch):
+    monkeypatch.setenv("NAURO_API_URL", "https://mcp.example.test/")
+    assert resolve_api_url() == "https://mcp.example.test"
+
+
+def test_strips_trailing_slash_from_config(monkeypatch, tmp_path):
+    monkeypatch.delenv("NAURO_API_URL", raising=False)
+    save_config({"api_url": "https://mcp.example.test/"})
+    assert resolve_api_url() == "https://mcp.example.test"
+
+
+def test_env_var_wins_over_config(monkeypatch, tmp_path):
+    monkeypatch.setenv("NAURO_API_URL", "https://env.example.test")
+    save_config({"api_url": "https://config.example.test"})
+    assert resolve_api_url() == "https://env.example.test"


### PR DESCRIPTION
## Why

Formalizes the 3-window Claude Code pattern I was running manually (plan / execute / review across parallel sessions). Coordination lived in my head; network glitches forced me to re-page-in each window's role. The planner's contract also bakes Nauro `check_decision`/`propose_decision` into the workflow itself, so inheritance is visible in the agent file rather than buried in session history.

## Approach

Three `.claude/agents/*.md` files (Claude Code's stable subagent format), authored here in `nauro/` and symlinked into `~/.claude/agents/` for cross-repo coverage (nauro, mcp-server, nauro.ai). Single source of truth.

Rejected alternatives (recorded in D146):
- **Agent Teams** — experimental in May 2026, ~3× token cost from independent contexts per teammate, gives up the human gate that switching windows provides. Revisit when mid-flight cross-session messaging becomes necessary.
- **Per-repo definitions** — three drifting copies of the same file.
- **User-level only** — loses the committed/demoable artifact.

## What changed

- `planner.md` — read-only research, calls Nauro decision tools, returns a PR-template-shaped plan; does not draft code.
- `executor.md` — implements approved plans, lint/test before push, always opens a PR, pauses before push.
- `reviewer.md` — read-only audit; hard-blocks on missing PR sections, unresolved D### references, personal paths, internal labels in public diffs; soft-flags tone issues.
- `.gitignore` — `!.claude/agents/` mirrors the existing `skills/` negation.

## What to review

- **Each agent's hard rules.** They encode my standing preferences (PR template required, lint before push, always PR, etc.). Flag any too strict for everyday work.
- **Reviewer block-vs-flag split.** Hard-blocks on missing required sections + unresolved decision refs; everything else soft-flags. Tighten if review feels too permissive in practice.

## What's deferred

- A slash command that chains the three agents into one pipeline — useful only if manual \`@planner\`/\`@executor\`/\`@reviewer\` invocation feels tedious.
- Agent Teams for cross-session messaging mid-flight.

## Test plan

Manual: invoke \`@planner\`, \`@executor\`, \`@reviewer\` from a fresh Claude Code session in nauro, mcp-server, and an unrelated repo to confirm symlink resolution works across repos. No automated tests — these are agent prompts, not code.

Refs: D146