### PR TITLE
chore(release): prep nauro 0.5.0

### DIFF
--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro"
-version = "0.4.0"
+version = "0.5.0"
 description = "Local CLI + MCP server: set your project's doctrine once, every connected AI agent inherits it."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Why

Five sync-transport PRs (#62–#66) have landed since nauro-v0.4.0; cut a PyPI release so installs pick up D145 (server-minted presign sync, boto3 dropped) and the #62 upload-claim fix.

## What changed

nauro 0.4.0 → 0.5.0. Minor bump under pre-1.0 semver. Source unchanged; only `packages/nauro/pyproject.toml`.

Highlights since nauro-v0.4.0:
- **D145** (#63 / #64 / #65) — CLI sync cut over to server-minted presigned URLs; legacy direct-S3 transport and the `boto3` dependency removed. Manifest + presign endpoints (mcp-server PR #36) now gate every read and write.
- **#66** — Folded `cloud_projects._resolve_api_url` into `sync.remote.resolve_api_url`; one helper for API URL resolution.
- **#62** — Fix: sync no longer claims upload when none happened.

`nauro-core` stays at 0.8.0 (no source change since v0.8.0; PyPI release skipped).

## What to review

Just the version field — this is a release-prep PR, no code changes.

## Test plan

- `uv run pytest packages/nauro/tests/ -x -q` → 928 passed
- `uv run ruff format --check packages/` + `uv run ruff check packages/` → clean
- Post-merge: tag `nauro-v0.5.0` on the merge commit; `publish-nauro.yml` uploads to PyPI.