### PR TITLE
fix: read __version__ from importlib.metadata; bump 0.5.1

### DIFF
--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro"
-version = "0.5.0"
+version = "0.5.1"
 description = "Local CLI + MCP server: set your project's doctrine once, every connected AI agent inherits it."
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/nauro/src/nauro/__init__.py
+++ b/packages/nauro/src/nauro/__init__.py
@@ -1,3 +1,5 @@
 """Nauro — local CLI + MCP server for versioned project context."""
 
-__version__ = "0.2.0"
+from importlib.metadata import version
+
+__version__ = version("nauro")

--- a/packages/nauro/tests/test_cli.py
+++ b/packages/nauro/tests/test_cli.py
@@ -19,6 +19,19 @@ def test_app_shows_help():
     assert "nauro" in result.output.lower()
 
 
+def test_version_flag_matches_package_metadata():
+    """`nauro --version` reports the installed package version.
+
+    Regression guard: prior to 0.5.1 the version was hardcoded in
+    __init__.py and drifted from pyproject.toml across releases.
+    """
+    from importlib.metadata import version
+
+    result = runner.invoke(app, ["--version"])
+    assert result.exit_code == 0
+    assert result.output.strip() == f"nauro {version('nauro')}"
+
+
 def test_init_command(tmp_path: Path, monkeypatch):
     """nauro init should create an id-keyed project store."""
     from nauro.store.registry import find_projects_by_name_v2


### PR DESCRIPTION
## Why

`nauro --version` reported 0.2.0 on a 0.5.0 install. The hardcoded
`__version__` in `nauro/__init__.py` hadn't been touched since the 0.2.0
release while `pyproject.toml` moved on. Surfaced during 0.5.0 release
validation, 2026-05-17.

## Approach

Read from `importlib.metadata.version("nauro")` instead, mirroring the
existing pattern in `nauro-core/__init__.py:246`. The CLI's
`_version_callback` already imports `__version__` from the package, so
nothing else has to change.

Considered alternatives:

- Bumping the literal at release time as part of `chore(release)` PRs.
  Rejected — that's what we did historically and it drifted for three
  minor releases. Reading from metadata makes drift impossible.

## What changed

- `packages/nauro/src/nauro/__init__.py` — hardcoded literal replaced with
  `importlib.metadata.version("nauro")`.
- `packages/nauro/pyproject.toml` — 0.5.0 → 0.5.1.
- `packages/nauro/tests/test_cli.py` — regression test asserting that
  `nauro --version` output equals `f"nauro {version('nauro')}"`. Would
  have caught the bug at any point since 0.3.0.

## What to review

The version read happens at import time of the `nauro` package. That is
fine in a normal install (the package is registered with
`importlib.metadata` via `pyproject.toml`), and tests confirm it in
editable + installed modes.

## What's deferred

The other paper cuts from the validation pass (AGENTS.md duplicate
footer, `nauro init` not refreshing stale tokens, `--project` flag
discoverability, hidden `sync --status` CWD fallback, `get_context` not
rejecting non-enum level values) are out of scope here — they belong in
follow-up PRs scoped per-fix.

## Test plan

- `uv run pytest packages/ -x -q` → 1235 passed (new test included)
- `uv run ruff format --check packages/` + `uv run ruff check packages/` → clean
- Post-merge: tag `nauro-v0.5.1` on the merge commit; `publish-nauro.yml`
  uploads to PyPI.