### PR TITLE
fix(cloud-projects): refresh stale token through with_token_refresh

### DIFF
--- a/packages/nauro/src/nauro/sync/cloud_projects.py
+++ b/packages/nauro/src/nauro/sync/cloud_projects.py
@@ -1,17 +1,21 @@
 """HTTP client for the remote MCP server's project endpoints.
 
 Wraps ``POST /projects`` and ``GET /projects`` on the Nauro cloud control
-plane. Both endpoints require an OAuth bearer token; the token is loaded
-from ``~/.nauro/config.json`` under the ``auth.access_token`` key — the same
-slot that ``nauro auth login`` writes.
+plane. Both endpoints require an OAuth bearer token; auth is shared with
+the sync transport via ``with_token_refresh`` — a stale access token is
+refreshed transparently on 401 (when a refresh token is available), so a
+session that has only been idle still completes ``nauro init --cloud``
+and ``nauro attach`` without an interactive re-login.
 
 Server URL resolution is shared with the sync transport via
 ``nauro.sync.remote.resolve_api_url`` (``NAURO_API_URL`` env var, then
 ``api_url`` in user config, then the public default).
 
 Failure modes are collapsed into a single ``CloudProjectError`` with a
-human-readable message; both callers (``nauro init --cloud`` and ``nauro attach``,
-landing in 2c-B) just render the message.
+human-readable message; both callers just render the message. The 4xx
+auth branches distinguish ``401 after refresh attempt`` from ``403
+forbidden`` so the remediation hint matches the underlying cause instead
+of always telling the user to log in.
 
 ``created_at`` is passed through verbatim as an ISO 8601 string. No date
 parsing — that just creates timezone-normalization fragility for no caller
@@ -24,7 +28,7 @@ from typing import TypedDict
 
 import httpx
 
-from nauro.store.config import load_config
+from nauro.cli.commands.auth import AuthRefreshError, with_token_refresh
 from nauro.sync.remote import resolve_api_url
 
 _DEFAULT_TIMEOUT = 15.0
@@ -45,21 +49,6 @@ class CloudProjectError(Exception):
     The message is the user-facing rendering. Callers should print it and
     exit; no recovery is attempted at this layer.
     """
-
-
-def _load_access_token() -> str:
-    """Read the OAuth bearer token written by ``nauro auth login``.
-
-    Raises:
-        CloudProjectError: If no token is available.
-    """
-    auth = load_config().get("auth") or {}
-    token = auth.get("access_token") if isinstance(auth, dict) else None
-    if not token:
-        raise CloudProjectError(
-            "Not authenticated. Run 'nauro auth login' before targeting the cloud."
-        )
-    return str(token)
 
 
 def _parse_project(raw: object) -> ProjectView:
@@ -83,27 +72,56 @@ def _parse_project(raw: object) -> ProjectView:
 
 
 def _request(method: str, path: str, *, json_body: dict | None = None) -> httpx.Response:
-    """Issue an authenticated request, translating transport failures."""
+    """Issue an authenticated request, refreshing the token on 401.
+
+    Auth handling is delegated to :func:`with_token_refresh`: a fresh
+    request runs first, and a 401 triggers one refresh + retry before the
+    response surfaces here. Transport errors, refresh failures, and
+    persistent 4xx/5xx responses are all translated into
+    :class:`CloudProjectError` with a remediation hint matched to the
+    actual failure mode.
+    """
     url = f"{resolve_api_url()}{path}"
-    headers = {
-        "Authorization": f"Bearer {_load_access_token()}",
-        "Accept": "application/json",
-    }
-    try:
-        response = httpx.request(
-            method, url, headers=headers, json=json_body, timeout=_DEFAULT_TIMEOUT
+
+    def _call(token: str) -> httpx.Response:
+        return httpx.request(
+            method,
+            url,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/json",
+            },
+            json=json_body,
+            timeout=_DEFAULT_TIMEOUT,
         )
+
+    try:
+        response = with_token_refresh(_call)
+    except AuthRefreshError as exc:
+        # ``AuthRefreshError`` messages already carry the right remediation
+        # for the case they describe (no refresh token / expired refresh /
+        # network failure to Auth0); appending another "run nauro auth
+        # login" line just makes them double-sentence and unclear.
+        raise CloudProjectError(f"Authentication failed: {exc}") from exc
     except httpx.HTTPError as exc:
         raise CloudProjectError(f"Network error contacting {url}: {exc}") from exc
 
-    if response.status_code in (401, 403):
+    if response.status_code == 401:
+        # Reached only after with_token_refresh already attempted a refresh
+        # and retry; a second 401 means the refreshed token was rejected by
+        # the server (revoked, server-side identity change, or maintenance).
         raise CloudProjectError(
-            f"Authentication failed ({response.status_code}). Run 'nauro auth login' and try again."
+            "Authentication rejected (401) even after refreshing the token. "
+            "Run 'nauro auth login' to re-authenticate."
+        )
+    if response.status_code == 403:
+        raise CloudProjectError(
+            f"Forbidden (403) from {url}. Your account does not have access to this resource."
         )
     if response.status_code >= 500:
         raise CloudProjectError(
             f"Server error ({response.status_code}) from {url}. "
-            f"The cloud control plane may be unavailable; try again shortly."
+            "The cloud control plane may be unavailable; try again shortly."
         )
     if response.status_code >= 400:
         # 4xx other than auth — surface server message verbatim where possible.

--- a/packages/nauro/tests/test_cloud_projects.py
+++ b/packages/nauro/tests/test_cloud_projects.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
@@ -68,8 +68,11 @@ def test_create_project_success_sends_bearer_and_body(tmp_path, monkeypatch):
     }
 
 
-def test_create_project_auth_failure_renders_message(tmp_path, monkeypatch):
-    """A 401 raises CloudProjectError with a clear, user-renderable message."""
+def test_create_project_401_without_refresh_token_raises_auth_login_hint(tmp_path, monkeypatch):
+    """A 401 with no refresh token: ``with_token_refresh`` raises
+    ``AuthRefreshError`` ("No refresh token stored…"), which the cloud
+    client surfaces as ``CloudProjectError`` whose message still points
+    the user at ``nauro auth login``."""
     _seed_token(monkeypatch, tmp_path)
     monkeypatch.setenv("NAURO_API_URL", "https://example.test")
 
@@ -80,8 +83,114 @@ def test_create_project_auth_failure_renders_message(tmp_path, monkeypatch):
         with pytest.raises(CloudProjectError) as exc:
             create_project("demo")
     msg = str(exc.value)
-    assert "401" in msg
+    assert "Authentication failed" in msg
     assert "nauro auth login" in msg
+
+
+def test_create_project_stale_token_refreshed_transparently(tmp_path, monkeypatch):
+    """Stale access token + valid refresh token: first 401 triggers a
+    silent refresh, the retry succeeds, and ``create_project`` returns
+    the new ``ProjectView`` without any user-visible auth error.
+
+    Regression for the D145 narrow-scope gap — before this fix,
+    ``nauro init --cloud`` cold-failed on an expired access token even
+    though the refresh token was still valid."""
+    save_config(
+        {
+            "auth": {
+                "access_token": "stale",
+                "refresh_token": "refresh_orig",
+                "sub": "auth0|test",
+            }
+        }
+    )
+    monkeypatch.setenv("NAURO_API_URL", "https://example.test")
+
+    calls: list[dict] = []
+
+    def handler(method, url, **kwargs):
+        calls.append({"headers": kwargs.get("headers")})
+        # First call: stale token rejected; second call: fresh token accepted.
+        if len(calls) == 1:
+            return httpx.Response(
+                401, json={"detail": "expired"}, request=httpx.Request(method, url)
+            )
+        return httpx.Response(
+            201,
+            json={
+                "project_id": "01KQ6AZGNA0B3QBF67NBXP3S45",
+                "name": "demo",
+                "role": "owner",
+                "created_at": "2026-04-27T10:11:12Z",
+            },
+            request=httpx.Request(method, url),
+        )
+
+    auth0_response = MagicMock(spec=httpx.Response)
+    auth0_response.status_code = 200
+    auth0_response.json.return_value = {"access_token": "fresh"}
+
+    with _stub_request(handler):
+        with patch("nauro.cli.commands.auth.httpx.post", return_value=auth0_response):
+            view = create_project("demo")
+
+    assert view["project_id"] == "01KQ6AZGNA0B3QBF67NBXP3S45"
+    assert len(calls) == 2
+    assert calls[0]["headers"]["Authorization"] == "Bearer stale"
+    assert calls[1]["headers"]["Authorization"] == "Bearer fresh"
+
+
+def test_create_project_persistent_401_after_refresh_raises_distinct_message(tmp_path, monkeypatch):
+    """Stale token + valid refresh + server still returns 401 after retry:
+    the message distinguishes "refresh worked but the new token was
+    rejected" from "refresh itself failed" so the user knows the issue
+    is server-side or revocation, not a missing refresh token."""
+    save_config(
+        {
+            "auth": {
+                "access_token": "stale",
+                "refresh_token": "refresh_orig",
+                "sub": "auth0|test",
+            }
+        }
+    )
+    monkeypatch.setenv("NAURO_API_URL", "https://example.test")
+
+    def handler(method, url, **kwargs):
+        return httpx.Response(401, json={"detail": "rejected"}, request=httpx.Request(method, url))
+
+    auth0_response = MagicMock(spec=httpx.Response)
+    auth0_response.status_code = 200
+    auth0_response.json.return_value = {"access_token": "fresh"}
+
+    with _stub_request(handler):
+        with patch("nauro.cli.commands.auth.httpx.post", return_value=auth0_response):
+            with pytest.raises(CloudProjectError) as exc:
+                create_project("demo")
+
+    msg = str(exc.value)
+    assert "401" in msg
+    assert "even after refreshing" in msg
+    assert "nauro auth login" in msg
+
+
+def test_create_project_403_renders_forbidden_message(tmp_path, monkeypatch):
+    """403 is distinct from 401: the user is authenticated but lacks
+    access to the resource. The error message should reflect that
+    instead of telling them to re-login."""
+    _seed_token(monkeypatch, tmp_path)
+    monkeypatch.setenv("NAURO_API_URL", "https://example.test")
+
+    def handler(method, url, **kwargs):
+        return httpx.Response(403, json={"detail": "no access"}, request=httpx.Request(method, url))
+
+    with _stub_request(handler):
+        with pytest.raises(CloudProjectError) as exc:
+            create_project("demo")
+    msg = str(exc.value)
+    assert "403" in msg
+    assert "Forbidden" in msg
+    assert "nauro auth login" not in msg
 
 
 def test_create_project_server_error_renders_message(tmp_path, monkeypatch):


### PR DESCRIPTION
## Why

D145 narrow-scoped the token-refresh wrapper to the presign helpers in `sync/remote.py`. `nauro init --cloud` and `nauro attach` go through `sync/cloud_projects.py`, which read the access token directly and cold-failed on 401 even when a valid refresh token was sitting in `~/.nauro/config.json`. Users with an idle session saw `Authentication failed (401). Run 'nauro auth login' and try again.` instead of having refresh happen transparently like sync does.

Surfaced during 0.5.0 release validation: a 4-day-stale access token broke `nauro init --cloud` while a `nauro sync` from the same session refreshed silently through the wrapped helpers.

## Approach

Route `cloud_projects._request` through `with_token_refresh` so the wrapper handles the 401-and-retry transparently — same pattern `fetch_manifest` and `request_presigned_urls` already use. Translate the wrapper's exceptions and the post-refresh 4xx branches into `CloudProjectError` messages that match the actual failure mode instead of always pointing at `nauro auth login`. The `_load_access_token` helper is gone because `with_token_refresh` loads the token internally and handles the no-token case.

Rejected alternatives:

- **Improve the error message only.** Would leave the cold-fail in place — users still have to manually run `nauro auth login` after every idle gap even when the refresh token is valid. The wrapper exists; the only blocker was inheriting it on this code path.
- **Generic catch-all that re-uses the same "log in" line for every 4xx.** Loses the 403-doesn't-need-login signal: a user who actually lacks access to the resource sees "Run nauro auth login" and tries that repeatedly without effect. Branching by status code is cheap and the wording difference is meaningful.

## What changed

- `sync/cloud_projects.py` — `_request` delegates to `with_token_refresh`; new 4xx branching distinguishes `AuthRefreshError`, persistent 401-after-refresh, 403-forbidden, 5xx, and other 4xx (server detail surfaced verbatim where available). `_load_access_token` removed.
- `tests/test_cloud_projects.py` — 4 new tests: transparent refresh round-trip (stale token + valid refresh → success with the retry carrying the new bearer), 401-without-refresh-token wording, persistent-401-after-refresh wording, and 403-forbidden wording. The existing `test_create_project_auth_failure_renders_message` was renamed and rewritten to match the new contract.

## What to review

- The error-message split between formerly-equivalent paths (no refresh token / persistent 401 / 403). Each says something different now — verify the wording matches what you'd want a user to see in that specific situation.
- The post-refresh 401 branch is reached only when `with_token_refresh` retried and the server still rejected. The wording calls that out explicitly so users don't try `nauro auth login` over and over without realizing the issue may be server-side or a revocation.
- Wrapping `AuthRefreshError`: I deliberately don't append my own "run nauro auth login" tail, because the `AuthRefreshError` messages already carry the right remediation for the case they describe (no refresh token / network failure to Auth0 / invalid_grant). Double-sentence error messages were uglier than letting the inner exception speak.

## What's deferred

Other cloud-touching helpers were audited (`grep` for direct `httpx` calls outside `sync/remote.py`); `cloud_projects.py` was the only path not already wrapped. No further widening needed in this PR.

End-to-end against the production server can be verified after merge by setting an expired access token in `~/.nauro/config.json` (or letting one expire naturally) and running `nauro init --cloud` — pre-fix this surfaced 401 immediately, post-fix it should refresh silently and succeed.

## Test plan

- `uv run pytest packages/nauro/tests/ -x -q` → 934 passed (+4 new, 1 renamed/rewritten)
- `uv run ruff format --check packages/` + `uv run ruff check packages/` → clean
- No dependency changes

Refs: D145