### PR TITLE
chore: strip personal paths and internal labels from public surfaces

### DIFF
--- a/.agents/skills/nauro-adopt/SKILL.md
+++ b/.agents/skills/nauro-adopt/SKILL.md
@@ -12,7 +12,7 @@ The agent helps the user seed Nauro with context from the current repo. Before t
 The agent's behaviour depends on whether the surface can read the repo directly.
 
 - **Filesystem-capable surfaces** (Claude Code, Cursor, Codex CLI). The agent runs Steps 1–11 in full. Docs are read for rationale in Step 3; code, config, tests, manifests, and recent git history are inspected for evidence in Step 4; targeted probes in Step 6b turn evidence into rationale by asking the user.
-- **Chat surfaces** (Claude.ai, ChatGPT, Perplexity). The agent has no shell. It operates only on content the user pastes into the chat (Step 3b), and only against an already-adopted project per D127 (verified in Step 2). The code-evidence path (Step 4) and the Step 6b probes are unavailable; the agent does not ask the user to paste code in lieu of running shell commands. The skill skips from Step 3b directly to Step 5.
+- **Chat surfaces** (Claude.ai, ChatGPT, Perplexity). The agent has no shell. It operates only on content the user pastes into the chat (Step 3b), and only against an already-adopted project (verified in Step 2). The code-evidence path (Step 4) and the Step 6b probes are unavailable; the agent does not ask the user to paste code in lieu of running shell commands. The skill skips from Step 3b directly to Step 5.
 
 ## Step 1 — Detect repo root
 
@@ -109,13 +109,13 @@ Languages, frameworks, package managers, license, lint tooling, and similar fact
 
 ## Step 7 — Write loop
 
-For each kept candidate from 6a and each rationale-supplied 6b answer, the agent runs the full D131 / D133 protocol:
+For each kept candidate from 6a and each rationale-supplied 6b answer, the agent runs the full propose/confirm protocol:
 
 1. Call `check_decision(proposed_approach=<title or short description>, project_id=...)`. `check_decision` returns related decisions via BM25 retrieval and a deterministic assessment. It does NOT judge conflicts.
 2. When the response lists related decisions, call `get_decision` on each one before proposing — the relevance, supersession status, and full rationale live in those bodies, not in the assessment string. Call signature: `get_decision(number=N, project_id=...)`.
 3. Classify the operation:
     - **add** (default; new ground, no existing decision covers it).
-    - **update** when the candidate augments an existing decision's rationale only. Per D133 the server consumes only `rationale` on update; `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, and `rejected` are rejected at the boundary — use supersede if any of those must change.
+    - **update** when the candidate augments an existing decision's rationale only. The server consumes only `rationale` on update; `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, and `rejected` are rejected at the boundary — use supersede if any of those must change.
     - **supersede** when the title or other metadata must change, or the candidate replaces or contradicts an existing decision. Pass the full new body and set `affected_decision_id`.
     - **skip** when the candidate is a duplicate (e.g. matches `001-initial-setup` or a candidate already seeded earlier in this same adopt run).
 4. Call `propose_decision` using the call signature for the chosen operation — these are operation-specific by design so an agent copying the template cannot accidentally send a field the server will reject:
@@ -123,7 +123,7 @@ For each kept candidate from 6a and each rationale-supplied 6b answer, the agent
       ```
       propose_decision(project_id=..., title=..., rationale=..., operation="add", rejected=..., confidence=...)
       ```
-    - For **update** (rationale-only — D133 rejects every other field at the boundary):
+    - For **update** (rationale-only — the server rejects every other field at the boundary):
       ```
       propose_decision(project_id=..., rationale=..., operation="update", affected_decision_id=...)
       ```
@@ -136,7 +136,7 @@ For each kept candidate from 6a and each rationale-supplied 6b answer, the agent
 5. Call `confirm_decision(confirm_id, project_id=...)`:
     - `add` + no conflicts → auto-confirm.
     - `add` + conflicts → surface the assessment verbatim, ask `confirm-anyway / edit / skip`; confirm only on user 'confirm'.
-    - `update` or `supersede` → always pending per D131. Surface the assessment first; confirm only on explicit user 'confirm'.
+    - `update` or `supersede` → always pending. Surface the assessment first; confirm only on explicit user 'confirm'.
 
 One propose+confirm per candidate. No batching.
 

--- a/.claude/skills/nauro-adopt/SKILL.md
+++ b/.claude/skills/nauro-adopt/SKILL.md
@@ -12,7 +12,7 @@ The agent helps the user seed Nauro with context from the current repo. Before t
 The agent's behaviour depends on whether the surface can read the repo directly.
 
 - **Filesystem-capable surfaces** (Claude Code, Cursor, Codex CLI). The agent runs Steps 1–11 in full. Docs are read for rationale in Step 3; code, config, tests, manifests, and recent git history are inspected for evidence in Step 4; targeted probes in Step 6b turn evidence into rationale by asking the user.
-- **Chat surfaces** (Claude.ai, ChatGPT, Perplexity). The agent has no shell. It operates only on content the user pastes into the chat (Step 3b), and only against an already-adopted project per D127 (verified in Step 2). The code-evidence path (Step 4) and the Step 6b probes are unavailable; the agent does not ask the user to paste code in lieu of running shell commands. The skill skips from Step 3b directly to Step 5.
+- **Chat surfaces** (Claude.ai, ChatGPT, Perplexity). The agent has no shell. It operates only on content the user pastes into the chat (Step 3b), and only against an already-adopted project (verified in Step 2). The code-evidence path (Step 4) and the Step 6b probes are unavailable; the agent does not ask the user to paste code in lieu of running shell commands. The skill skips from Step 3b directly to Step 5.
 
 ## Step 1 — Detect repo root
 
@@ -109,13 +109,13 @@ Languages, frameworks, package managers, license, lint tooling, and similar fact
 
 ## Step 7 — Write loop
 
-For each kept candidate from 6a and each rationale-supplied 6b answer, the agent runs the full D131 / D133 protocol:
+For each kept candidate from 6a and each rationale-supplied 6b answer, the agent runs the full propose/confirm protocol:
 
 1. Call `check_decision(proposed_approach=<title or short description>, project_id=...)`. `check_decision` returns related decisions via BM25 retrieval and a deterministic assessment. It does NOT judge conflicts.
 2. When the response lists related decisions, call `get_decision` on each one before proposing — the relevance, supersession status, and full rationale live in those bodies, not in the assessment string. Call signature: `get_decision(number=N, project_id=...)`.
 3. Classify the operation:
     - **add** (default; new ground, no existing decision covers it).
-    - **update** when the candidate augments an existing decision's rationale only. Per D133 the server consumes only `rationale` on update; `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, and `rejected` are rejected at the boundary — use supersede if any of those must change.
+    - **update** when the candidate augments an existing decision's rationale only. The server consumes only `rationale` on update; `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, and `rejected` are rejected at the boundary — use supersede if any of those must change.
     - **supersede** when the title or other metadata must change, or the candidate replaces or contradicts an existing decision. Pass the full new body and set `affected_decision_id`.
     - **skip** when the candidate is a duplicate (e.g. matches `001-initial-setup` or a candidate already seeded earlier in this same adopt run).
 4. Call `propose_decision` using the call signature for the chosen operation — these are operation-specific by design so an agent copying the template cannot accidentally send a field the server will reject:
@@ -123,7 +123,7 @@ For each kept candidate from 6a and each rationale-supplied 6b answer, the agent
       ```
       propose_decision(project_id=..., title=..., rationale=..., operation="add", rejected=..., confidence=...)
       ```
-    - For **update** (rationale-only — D133 rejects every other field at the boundary):
+    - For **update** (rationale-only — the server rejects every other field at the boundary):
       ```
       propose_decision(project_id=..., rationale=..., operation="update", affected_decision_id=...)
       ```
@@ -136,7 +136,7 @@ For each kept candidate from 6a and each rationale-supplied 6b answer, the agent
 5. Call `confirm_decision(confirm_id, project_id=...)`:
     - `add` + no conflicts → auto-confirm.
     - `add` + conflicts → surface the assessment verbatim, ask `confirm-anyway / edit / skip`; confirm only on user 'confirm'.
-    - `update` or `supersede` → always pending per D131. Surface the assessment first; confirm only on explicit user 'confirm'.
+    - `update` or `supersede` → always pending. Surface the assessment first; confirm only on explicit user 'confirm'.
 
 One propose+confirm per candidate. No batching.
 

--- a/.cursor/rules/nauro-adopt.mdc
+++ b/.cursor/rules/nauro-adopt.mdc
@@ -12,7 +12,7 @@ The agent helps the user seed Nauro with context from the current repo. Before t
 The agent's behaviour depends on whether the surface can read the repo directly.
 
 - **Filesystem-capable surfaces** (Claude Code, Cursor, Codex CLI). The agent runs Steps 1–11 in full. Docs are read for rationale in Step 3; code, config, tests, manifests, and recent git history are inspected for evidence in Step 4; targeted probes in Step 6b turn evidence into rationale by asking the user.
-- **Chat surfaces** (Claude.ai, ChatGPT, Perplexity). The agent has no shell. It operates only on content the user pastes into the chat (Step 3b), and only against an already-adopted project per D127 (verified in Step 2). The code-evidence path (Step 4) and the Step 6b probes are unavailable; the agent does not ask the user to paste code in lieu of running shell commands. The skill skips from Step 3b directly to Step 5.
+- **Chat surfaces** (Claude.ai, ChatGPT, Perplexity). The agent has no shell. It operates only on content the user pastes into the chat (Step 3b), and only against an already-adopted project (verified in Step 2). The code-evidence path (Step 4) and the Step 6b probes are unavailable; the agent does not ask the user to paste code in lieu of running shell commands. The skill skips from Step 3b directly to Step 5.
 
 ## Step 1 — Detect repo root
 
@@ -109,13 +109,13 @@ Languages, frameworks, package managers, license, lint tooling, and similar fact
 
 ## Step 7 — Write loop
 
-For each kept candidate from 6a and each rationale-supplied 6b answer, the agent runs the full D131 / D133 protocol:
+For each kept candidate from 6a and each rationale-supplied 6b answer, the agent runs the full propose/confirm protocol:
 
 1. Call `check_decision(proposed_approach=<title or short description>, project_id=...)`. `check_decision` returns related decisions via BM25 retrieval and a deterministic assessment. It does NOT judge conflicts.
 2. When the response lists related decisions, call `get_decision` on each one before proposing — the relevance, supersession status, and full rationale live in those bodies, not in the assessment string. Call signature: `get_decision(number=N, project_id=...)`.
 3. Classify the operation:
     - **add** (default; new ground, no existing decision covers it).
-    - **update** when the candidate augments an existing decision's rationale only. Per D133 the server consumes only `rationale` on update; `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, and `rejected` are rejected at the boundary — use supersede if any of those must change.
+    - **update** when the candidate augments an existing decision's rationale only. The server consumes only `rationale` on update; `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, and `rejected` are rejected at the boundary — use supersede if any of those must change.
     - **supersede** when the title or other metadata must change, or the candidate replaces or contradicts an existing decision. Pass the full new body and set `affected_decision_id`.
     - **skip** when the candidate is a duplicate (e.g. matches `001-initial-setup` or a candidate already seeded earlier in this same adopt run).
 4. Call `propose_decision` using the call signature for the chosen operation — these are operation-specific by design so an agent copying the template cannot accidentally send a field the server will reject:
@@ -123,7 +123,7 @@ For each kept candidate from 6a and each rationale-supplied 6b answer, the agent
       ```
       propose_decision(project_id=..., title=..., rationale=..., operation="add", rejected=..., confidence=...)
       ```
-    - For **update** (rationale-only — D133 rejects every other field at the boundary):
+    - For **update** (rationale-only — the server rejects every other field at the boundary):
       ```
       propose_decision(project_id=..., rationale=..., operation="update", affected_decision_id=...)
       ```
@@ -136,7 +136,7 @@ For each kept candidate from 6a and each rationale-supplied 6b answer, the agent
 5. Call `confirm_decision(confirm_id, project_id=...)`:
     - `add` + no conflicts → auto-confirm.
     - `add` + conflicts → surface the assessment verbatim, ask `confirm-anyway / edit / skip`; confirm only on user 'confirm'.
-    - `update` or `supersede` → always pending per D131. Surface the assessment first; confirm only on explicit user 'confirm'.
+    - `update` or `supersede` → always pending. Surface the assessment first; confirm only on explicit user 'confirm'.
 
 One propose+confirm per candidate. No batching.
 

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ build/
 AGENTS.md
 .claude/*
 !.claude/skills/
+**/.claude/settings.local.json

--- a/docs/adopt-prompt.md
+++ b/docs/adopt-prompt.md
@@ -28,7 +28,7 @@ The agent helps the user seed Nauro with context from the current repo. Before t
 The agent's behaviour depends on whether the surface can read the repo directly.
 
 - **Filesystem-capable surfaces** (Claude Code, Cursor, Codex CLI). The agent runs Steps 1–11 in full. Docs are read for rationale in Step 3; code, config, tests, manifests, and recent git history are inspected for evidence in Step 4; targeted probes in Step 6b turn evidence into rationale by asking the user.
-- **Chat surfaces** (Claude.ai, ChatGPT, Perplexity). The agent has no shell. It operates only on content the user pastes into the chat (Step 3b), and only against an already-adopted project per D127 (verified in Step 2). The code-evidence path (Step 4) and the Step 6b probes are unavailable; the agent does not ask the user to paste code in lieu of running shell commands. The skill skips from Step 3b directly to Step 5.
+- **Chat surfaces** (Claude.ai, ChatGPT, Perplexity). The agent has no shell. It operates only on content the user pastes into the chat (Step 3b), and only against an already-adopted project (verified in Step 2). The code-evidence path (Step 4) and the Step 6b probes are unavailable; the agent does not ask the user to paste code in lieu of running shell commands. The skill skips from Step 3b directly to Step 5.
 
 ## Step 1 — Detect repo root
 
@@ -125,13 +125,13 @@ Languages, frameworks, package managers, license, lint tooling, and similar fact
 
 ## Step 7 — Write loop
 
-For each kept candidate from 6a and each rationale-supplied 6b answer, the agent runs the full D131 / D133 protocol:
+For each kept candidate from 6a and each rationale-supplied 6b answer, the agent runs the full propose/confirm protocol:
 
 1. Call `check_decision(proposed_approach=<title or short description>, project_id=...)`. `check_decision` returns related decisions via BM25 retrieval and a deterministic assessment. It does NOT judge conflicts.
 2. When the response lists related decisions, call `get_decision` on each one before proposing — the relevance, supersession status, and full rationale live in those bodies, not in the assessment string. Call signature: `get_decision(number=N, project_id=...)`.
 3. Classify the operation:
     - **add** (default; new ground, no existing decision covers it).
-    - **update** when the candidate augments an existing decision's rationale only. Per D133 the server consumes only `rationale` on update; `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, and `rejected` are rejected at the boundary — use supersede if any of those must change.
+    - **update** when the candidate augments an existing decision's rationale only. The server consumes only `rationale` on update; `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, and `rejected` are rejected at the boundary — use supersede if any of those must change.
     - **supersede** when the title or other metadata must change, or the candidate replaces or contradicts an existing decision. Pass the full new body and set `affected_decision_id`.
     - **skip** when the candidate is a duplicate (e.g. matches `001-initial-setup` or a candidate already seeded earlier in this same adopt run).
 4. Call `propose_decision` using the call signature for the chosen operation — these are operation-specific by design so an agent copying the template cannot accidentally send a field the server will reject:
@@ -139,7 +139,7 @@ For each kept candidate from 6a and each rationale-supplied 6b answer, the agent
       ```
       propose_decision(project_id=..., title=..., rationale=..., operation="add", rejected=..., confidence=...)
       ```
-    - For **update** (rationale-only — D133 rejects every other field at the boundary):
+    - For **update** (rationale-only — the server rejects every other field at the boundary):
       ```
       propose_decision(project_id=..., rationale=..., operation="update", affected_decision_id=...)
       ```
@@ -152,7 +152,7 @@ For each kept candidate from 6a and each rationale-supplied 6b answer, the agent
 5. Call `confirm_decision(confirm_id, project_id=...)`:
     - `add` + no conflicts → auto-confirm.
     - `add` + conflicts → surface the assessment verbatim, ask `confirm-anyway / edit / skip`; confirm only on user 'confirm'.
-    - `update` or `supersede` → always pending per D131. Surface the assessment first; confirm only on explicit user 'confirm'.
+    - `update` or `supersede` → always pending. Surface the assessment first; confirm only on explicit user 'confirm'.
 
 One propose+confirm per candidate. No batching.
 

--- a/packages/nauro-core/src/nauro_core/protocol.py
+++ b/packages/nauro-core/src/nauro_core/protocol.py
@@ -37,7 +37,7 @@ GET_DECISION_BEFORE_PROPOSING = (
 PROPOSE_DECISION_OPERATIONS = (
     "Pick the right `operation`:\n"
     "- `add` (default) — genuinely new ground; no existing decision is being changed.\n"
-    "- `update` — rationale-only; provide `affected_decision_id`. Per D133 the "
+    "- `update` — rationale-only; provide `affected_decision_id`. The "
     "server rejects `title`, `confidence`, `decision_type`, `reversibility`, "
     "`files_affected`, and `rejected` at the boundary — use supersede for any "
     "of those.\n"

--- a/packages/nauro-core/tests/test_protocol.py
+++ b/packages/nauro-core/tests/test_protocol.py
@@ -37,13 +37,13 @@ class TestFragmentAnchors:
         assert "before proposing" in GET_DECISION_BEFORE_PROPOSING
         assert "supersession status" in GET_DECISION_BEFORE_PROPOSING
 
-    def test_propose_decision_operations_names_all_three_and_d133(self) -> None:
+    def test_propose_decision_operations_names_all_three_and_metadata_rule(self) -> None:
         for op in ("add", "update", "supersede"):
             assert f"`{op}`" in PROPOSE_DECISION_OPERATIONS, op
         assert "`affected_decision_id`" in PROPOSE_DECISION_OPERATIONS
-        # D133: update is rationale-only; metadata changes are rejected
-        assert "D133" in PROPOSE_DECISION_OPERATIONS
+        # Update is rationale-only; metadata changes are rejected at the boundary
         assert "rationale-only" in PROPOSE_DECISION_OPERATIONS
+        assert "server rejects" in PROPOSE_DECISION_OPERATIONS
         for field in (
             "`title`",
             "`confidence`",

--- a/packages/nauro/src/nauro/cli/commands/setup.py
+++ b/packages/nauro/src/nauro/cli/commands/setup.py
@@ -211,7 +211,7 @@ def claude_code(
 # Cursor reads MCP servers from `<repo>/.cursor/mcp.json` (per-project).
 # User-global "Rules for AI" live in the IDE Settings UI, not a file path —
 # so MCP wiring is per-project here.
-# Docs: https://cursor.com/docs (checked: 2026-05-07)
+# Docs: https://cursor.com/docs
 
 
 def _configure_cursor_for_repo(repo_path: Path, *, remove: bool) -> str:
@@ -291,7 +291,7 @@ def cursor(
 
 # Codex reads MCP servers from `~/.codex/config.toml` under `[mcp_servers.<name>]`.
 # This is the user-global Codex CLI config and is shared with the IDE extension.
-# Docs: https://developers.openai.com/codex/mcp (checked: 2026-05-07)
+# Docs: https://developers.openai.com/codex/mcp
 
 
 def _default_codex_config_path() -> Path:

--- a/packages/nauro/src/nauro/skills/adopt_body.md
+++ b/packages/nauro/src/nauro/skills/adopt_body.md
@@ -13,7 +13,7 @@ The agent helps the user seed Nauro with context from the current repo. Before t
 The agent's behaviour depends on whether the surface can read the repo directly.
 
 - **Filesystem-capable surfaces** (Claude Code, Cursor, Codex CLI). The agent runs Steps 1–11 in full. Docs are read for rationale in Step 3; code, config, tests, manifests, and recent git history are inspected for evidence in Step 4; targeted probes in Step 6b turn evidence into rationale by asking the user.
-- **Chat surfaces** (Claude.ai, ChatGPT, Perplexity). The agent has no shell. It operates only on content the user pastes into the chat (Step 3b), and only against an already-adopted project per D127 (verified in Step 2). The code-evidence path (Step 4) and the Step 6b probes are unavailable; the agent does not ask the user to paste code in lieu of running shell commands. The skill skips from Step 3b directly to Step 5.
+- **Chat surfaces** (Claude.ai, ChatGPT, Perplexity). The agent has no shell. It operates only on content the user pastes into the chat (Step 3b), and only against an already-adopted project (verified in Step 2). The code-evidence path (Step 4) and the Step 6b probes are unavailable; the agent does not ask the user to paste code in lieu of running shell commands. The skill skips from Step 3b directly to Step 5.
 
 ## Step 1 — Detect repo root
 
@@ -110,13 +110,13 @@ Languages, frameworks, package managers, license, lint tooling, and similar fact
 
 ## Step 7 — Write loop
 
-For each kept candidate from 6a and each rationale-supplied 6b answer, the agent runs the full D131 / D133 protocol:
+For each kept candidate from 6a and each rationale-supplied 6b answer, the agent runs the full propose/confirm protocol:
 
 1. Call `check_decision(proposed_approach=<title or short description>, project_id=...)`. <!-- protocol:CHECK_DECISION_RETURNS -->
 2. <!-- protocol:GET_DECISION_BEFORE_PROPOSING --> Call signature: `get_decision(number=N, project_id=...)`.
 3. Classify the operation:
     - **add** (default; new ground, no existing decision covers it).
-    - **update** when the candidate augments an existing decision's rationale only. Per D133 the server consumes only `rationale` on update; `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, and `rejected` are rejected at the boundary — use supersede if any of those must change.
+    - **update** when the candidate augments an existing decision's rationale only. The server consumes only `rationale` on update; `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, and `rejected` are rejected at the boundary — use supersede if any of those must change.
     - **supersede** when the title or other metadata must change, or the candidate replaces or contradicts an existing decision. Pass the full new body and set `affected_decision_id`.
     - **skip** when the candidate is a duplicate (e.g. matches `001-initial-setup` or a candidate already seeded earlier in this same adopt run).
 4. Call `propose_decision` using the call signature for the chosen operation — these are operation-specific by design so an agent copying the template cannot accidentally send a field the server will reject:
@@ -124,7 +124,7 @@ For each kept candidate from 6a and each rationale-supplied 6b answer, the agent
       ```
       propose_decision(project_id=..., title=..., rationale=..., operation="add", rejected=..., confidence=...)
       ```
-    - For **update** (rationale-only — D133 rejects every other field at the boundary):
+    - For **update** (rationale-only — the server rejects every other field at the boundary):
       ```
       propose_decision(project_id=..., rationale=..., operation="update", affected_decision_id=...)
       ```
@@ -137,7 +137,7 @@ For each kept candidate from 6a and each rationale-supplied 6b answer, the agent
 5. Call `confirm_decision(confirm_id, project_id=...)`:
     - `add` + no conflicts → auto-confirm.
     - `add` + conflicts → surface the assessment verbatim, ask `confirm-anyway / edit / skip`; confirm only on user 'confirm'.
-    - `update` or `supersede` → always pending per D131. Surface the assessment first; confirm only on explicit user 'confirm'.
+    - `update` or `supersede` → always pending. Surface the assessment first; confirm only on explicit user 'confirm'.
 
 One propose+confirm per candidate. No batching.
 

--- a/packages/nauro/tests/test_adopt.py
+++ b/packages/nauro/tests/test_adopt.py
@@ -1,4 +1,4 @@
-"""Tests for ``nauro adopt`` (PR-B2)."""
+"""Tests for ``nauro adopt``."""
 
 from __future__ import annotations
 

--- a/packages/nauro/tests/test_protocol_drift.py
+++ b/packages/nauro/tests/test_protocol_drift.py
@@ -43,10 +43,10 @@ SURFACE_FRAGMENTS: dict[str, list[str]] = {
     ],
 }
 
-# Adopt's Step 7 step 3 restates D131/D133 operation semantics in its own
-# numbered-step + sub-bullet shape; the bullet-form PROPOSE_DECISION_OPERATIONS
-# fragment cannot be substituted there without breaking markdown indentation.
-# To prevent operation-content drift between MCP and adopt, assert adopt's
+# Adopt's Step 7 step 3 restates operation semantics in its own numbered-step
+# + sub-bullet shape; the bullet-form PROPOSE_DECISION_OPERATIONS fragment
+# cannot be substituted there without breaking markdown indentation. To
+# prevent operation-content drift between MCP and adopt, assert adopt's
 # rendered body still mentions every load-bearing anchor from the fragment.
 ADOPT_OPERATION_ANCHORS: tuple[str, ...] = (
     # The three operation names (backtick-quoted in the fragment; adopt uses
@@ -56,8 +56,6 @@ ADOPT_OPERATION_ANCHORS: tuple[str, ...] = (
     "supersede",
     # The kwarg every mutation requires
     "affected_decision_id",
-    # The decision number that introduced the metadata-rejection rule
-    "D133",
     # The six metadata fields rejected at the boundary on operation=update
     "title",
     "confidence",

--- a/packages/nauro/tests/test_setup_extended.py
+++ b/packages/nauro/tests/test_setup_extended.py
@@ -222,7 +222,7 @@ def test_setup_top_level_help_lists_new_subcommands():
     assert "all" in result.output
 
 
-# ─── nauro setup all (PR-B2) ─────────────────────────────────────────────────
+# ─── nauro setup all ────────────────────────────────────────────────────────
 
 
 def test_setup_all_writes_claude_cursor_codex_configs(tmp_path: Path, monkeypatch):

--- a/packages/nauro/tests/test_skills_drift.py
+++ b/packages/nauro/tests/test_skills_drift.py
@@ -29,9 +29,9 @@ def test_load_adopt_body_returns_canonical_bytes():
     assert "Step 6a — Documented decisions" in body
     assert "Step 6b — Code-evidenced" in body
     assert "was Y considered; what pushed you toward X" in body
-    # All three D131/D133 operation variants must remain present so a
-    # cleanup edit cannot accidentally drop one — the structural test
-    # only validates calls that *are* there, not that all three exist.
+    # All three operation variants must remain present so a cleanup edit
+    # cannot accidentally drop one — the structural test only validates
+    # calls that *are* there, not that all three exist.
     for op in ("add", "update", "supersede"):
         assert f'operation="{op}"' in body, f"missing propose_decision variant: {op}"
     assert "Step 11 — Summary" in body
@@ -114,35 +114,36 @@ def test_docs_adopt_prompt_contains_canonical_body():
 
 # --- Retired phrases must not reappear in skill / docs surfaces ---
 #
-# Anchored to D124/D129/D130/D131 + PR #38. Scanned across every surface
-# in ``SKILL_SURFACES``; dogfood files inherit via the byte-equality test.
+# Each entry pairs a retired phrase with the reason it was retired, scanned
+# across every surface in ``SKILL_SURFACES``; dogfood files inherit via the
+# byte-equality test.
 
 RETIRED_PHRASES = [
-    ("LLM-based", "D130 removed Tier 3 LLM validation"),
-    ("Tier 3", "D130 removed Tier 3 LLM validation"),
-    ("nauro extract", "D129 retired the extract command"),
-    ("[extraction]", "D129 retired the [extraction] extra"),
-    ("Anthropic SDK", "D129 dropped Anthropic SDK as a runtime dep"),
-    ("Python 3.11+", "D124 lowered the Python floor to 3.10"),
+    ("LLM-based", "Tier 3 LLM validation was removed"),
+    ("Tier 3", "Tier 3 LLM validation was removed"),
+    ("nauro extract", "the extract command was retired"),
+    ("[extraction]", "the [extraction] extra was retired"),
+    ("Anthropic SDK", "Anthropic SDK was dropped as runtime dep"),
+    ("Python 3.11+", "the Python floor was lowered to 3.10"),
     (
         "propose_decision(title, rationale, rejected,",
-        "D131 made propose_decision operation-aware; rejected/confidence are no longer positional",
+        "propose_decision became operation-aware; rejected/confidence are no longer positional",
     ),
     (
         "bracketed-prompt placeholders in `project.md` / `stack.md` / `state_current.md`",
-        "PR #38 removed bracket-prompt scaffolding from state_current.md",
+        "bracket-prompt scaffolding was removed from state_current.md",
     ),
     (
         "The agent does not read source code, tests, IaC templates, or git history during adopt",
-        "D125 v2 reverses the docs-only stance — code is evidence on filesystem-capable surfaces",
+        "the docs-only stance was reversed — code is evidence on filesystem-capable surfaces",
     ),
     (
         "Step 5a — Clear decisions",
-        "D125 v2 renamed to Step 6a — Documented decisions",
+        "renamed to Step 6a — Documented decisions",
     ),
     (
         "Step 5b — Boundary candidates",
-        "D125 v2 split this into Step 6b (code-evidenced) + Step 6c (stack inventory)",
+        "split into Step 6b (code-evidenced) + Step 6c (stack inventory)",
     ),
 ]
 

--- a/packages/nauro/tests/test_stdio_server.py
+++ b/packages/nauro/tests/test_stdio_server.py
@@ -342,12 +342,13 @@ class TestToolSpecDescriptionsReachAgent:
     def tools_by_name(self):
         return {t.name: t for t in mcp._tool_manager.list_tools()}
 
-    def test_propose_decision_operation_carries_d133_list(self, tools_by_name):
+    def test_propose_decision_operation_carries_metadata_rejection_list(self, tools_by_name):
         op = tools_by_name["propose_decision"].parameters["properties"]["operation"]
-        # Description should carry the canonical fragment text — the D133 6-field
-        # list, the operation enumeration, and the use-supersede guidance.
+        # Description should carry the canonical fragment text — the 6-field
+        # metadata-rejection list, the operation enumeration, and the
+        # use-supersede guidance.
         for needle in (
-            "D133",
+            "server rejects",
             "rationale-only",
             "`title`",
             "`confidence`",
@@ -358,7 +359,6 @@ class TestToolSpecDescriptionsReachAgent:
             "supersede",
         ):
             assert needle in op["description"], f"missing {needle!r} in operation description"
-        # Operation enum constraint should also be present (was missing pre-D134).
         assert op["enum"] == ["add", "update", "supersede"]
 
     @pytest.mark.parametrize(

--- a/packages/nauro/tests/test_validation/test_validation_is_anthropic_free.py
+++ b/packages/nauro/tests/test_validation/test_validation_is_anthropic_free.py
@@ -1,11 +1,9 @@
 """Baseline test: the validation pipeline never imports anthropic.
 
-After Decision B (extraction retirement) the only Anthropic dependency in
-Nauro was extraction itself; with extraction removed, no production code path
-imports ``anthropic``. This test guards that property by simulating an env
-where ``anthropic`` cannot be imported and exercising propose_decision
-against overlapping titles — the path that originally surfaced the leak in
-the 2026-05-09 dogfood (Finding 1, when Tier 3 still lived).
+Earlier code paths in the validation pipeline imported the Anthropic SDK
+opportunistically; the dependency has since been removed. This test guards
+the property by simulating an environment where ``anthropic`` cannot be
+imported and exercising ``propose_decision`` with overlapping titles.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Why

The repo is public. Internal-only labels (Nauro decision IDs like `D131`/`D133`, roadmap codes like `PR-B2`, dogfood markers like `2026-05-09`/`Finding 1`/`Tier 3 still lived`, and "last-checked" dates in vendor-doc comments) were leaking into committed code and into surfaces shipped to end users (`.claude/skills/`, `.agents/skills/`, `.cursor/rules/`, `docs/adopt-prompt.md`). The MCP server also delivers `MCP_INSTRUCTIONS_STATIC` to every connected agent, and that string carried a `Per D133` token. Nothing in this vocabulary tells a downstream reader anything actionable — the *content* (propose/confirm flow, metadata-rejection rule) is what matters, not the decision number it traces back to.

## Approach

Pure find-and-replace plus one defensive `.gitignore` line and one load-bearing test-anchor removal. No behavior changes. Distribution artifacts (`.claude/skills/`, `.agents/skills/`, `.cursor/rules/`, `docs/adopt-prompt.md`) are regenerated from their canonical source (`packages/nauro/src/nauro/skills/adopt_body.md`); the existing `test_dogfood_file_matches_render_skill` drift test enforces byte-equality so the leaves cannot drift from the source. Considered scrubbing internal-engineer-facing comments in `mcp/tools.py`, `validation/pipeline.py`, and `cli/commands/adopt.py` that also reference D-numbers, but deliberately scoped them out — they're not shipped to end users and the audit didn't flag them. Listed as follow-ups below.

## What changed

- `.gitignore`: defensive `**/.claude/settings.local.json` rule.
- Tests: scrubbed roadmap-code docstrings (`PR-B2`), dogfood-era prose (`Decision B`, `2026-05-09 dogfood`, `Finding 1`, `Tier 3 still lived`), and D-token reason strings inside `RETIRED_PHRASES`. Dropped the `D133` literal-presence anchor from `test_protocol_drift.py::ADOPT_OPERATION_ANCHORS` since the canonical source no longer carries the token. Two nauro-core / stdio tests that asserted `"D133"` in `PROPOSE_DECISION_OPERATIONS` were updated to anchor on the semantic substring (`"server rejects"`) that survives the scrub.
- Source comments in `cli/commands/setup.py`: removed dogfood-era `(checked: 2026-05-07)` parentheticals next to vendor doc URLs.
- Skill canonical body (`adopt_body.md`) + 3 generated dogfood files + `docs/adopt-prompt.md`: scrubbed `D131 / D133 protocol` → `propose/confirm protocol`; `Per D133 the server rejects` → `The server rejects`; `always pending per D131` → `always pending`; and the stray `per D127` chat-surface reference. Meaning preserved.
- `nauro_core/protocol.py`: same `Per D133` → `The` scrub in `PROPOSE_DECISION_OPERATIONS` so `MCP_INSTRUCTIONS_STATIC` delivered to every agent over the wire matches the skill bodies.

## What to review

- The five edited lines in `adopt_body.md` — confirm the prose still teaches the propose/confirm protocol correctly with no D-tokens.
- The byte-equal regeneration of the 3 dogfood files + `docs/adopt-prompt.md`. The drift test catches a missed regen; it's the safety net.
- The dropped `D133` anchor in `test_protocol_drift.py` and the renamed tests in `test_protocol.py` / `test_stdio_server.py` — confirm the remaining anchors still cover operation-semantics drift adequately.

## What's deferred

- D-token references in internal-engineer comments: `packages/nauro/src/nauro/mcp/tools.py`, `packages/nauro/src/nauro/cli/commands/adopt.py`, `packages/nauro/src/nauro/validation/pipeline.py`, plus the `Per D142` comment in `cli/commands/setup.py:105` and the `D69/D70/D105` reference in `nauro_core/decision_model.py:134`. None are shipped to end users; auditor didn't flag them. Worth a separate sweep if a uniform "no internal labels anywhere in committed source" policy is desired.
- Fixture timestamps in test files (e.g. `2026-05-12 20:18 UTC` in `test_pipeline.py`, `test_questions.py`, `test_sync/*`, `test_stdio_server.py`): these are load-bearing parser inputs, not internal labels.

## Test plan

- [x] `uv run ruff check packages/` clean
- [x] `uv run ruff format --check packages/` clean (154 files)
- [x] `uv run pytest packages/nauro-core/tests/ -x -q` passes (306)
- [x] `uv run pytest packages/nauro/tests/ -x -q` passes (936)
- [x] Drift tests prove the regenerated dogfood files match `render_skill()` byte-for-byte
- [x] Spot-grep returns zero D-number / PR-code / dogfood-date hits in shipped surfaces (`packages/nauro/src/nauro/skills/`, `.claude/skills/`, `.agents/skills/`, `.cursor/rules/`, `docs/adopt-prompt.md`, `nauro_core/protocol.py`)