### PR TITLE
chore: scrub internal labels from code comments

### DIFF
--- a/packages/nauro-core/src/nauro_core/protocol.py
+++ b/packages/nauro-core/src/nauro_core/protocol.py
@@ -108,8 +108,8 @@ def protocol_tokens_in(text: str, *, only_unknown: bool = False) -> list[str]:
     """Return the fragment names of every ``<!-- protocol:NAME -->`` in ``text``.
 
     With ``only_unknown=True``, returns names that are not registered in
-    :data:`CANONICAL_FRAGMENTS` — used by source-template tests to catch typos
-    pointing at the source file, not at the rendered output.
+    :data:`CANONICAL_FRAGMENTS` — typos surface against the source file
+    rather than against the rendered output.
     """
     names: list[str] = []
     cursor = 0

--- a/packages/nauro/src/nauro/cli/commands/adopt.py
+++ b/packages/nauro/src/nauro/cli/commands/adopt.py
@@ -1,6 +1,6 @@
 """nauro adopt — Bootstrap a project from an existing repo.
 
-Per D125 + D126 + D128, ``nauro adopt`` does in one shot:
+In one shot it:
 
   1. Detect repo root (or use --repo).
   2. Guard against re-adopting an already-adopted repo.

--- a/packages/nauro/src/nauro/cli/commands/auth.py
+++ b/packages/nauro/src/nauro/cli/commands/auth.py
@@ -370,7 +370,7 @@ def login() -> None:
     }
     save_config(config)
 
-    # Telemetry identity merge (D119). Auth state is already persisted above —
+    # Telemetry identity merge: auth state is already persisted above —
     # this block only handles the PostHog alias+set. Raw email never leaves
     # auth.py; identify_login receives only the SHA-256 hex digest.
     try:
@@ -424,9 +424,9 @@ def logout() -> None:
         typer.echo("Not authenticated — nothing to clear.")
         return
 
-    # Rotate the telemetry anonymous_id at logout (D119: rotate-on-logout,
-    # preserve consent). identify_logout only touches the telemetry section,
-    # so call ordering with del config["auth"] is independent for correctness.
+    # Rotate the telemetry anonymous_id at logout (preserves consent).
+    # identify_logout only touches the telemetry section, so call ordering
+    # with del config["auth"] is independent for correctness.
     try:
         from nauro.telemetry import identify_logout as _telemetry_identify_logout
 

--- a/packages/nauro/src/nauro/cli/commands/init.py
+++ b/packages/nauro/src/nauro/cli/commands/init.py
@@ -53,10 +53,10 @@ def _check_config_overwrite(
     force: bool,
 ) -> None:
     """Refuse to overwrite an existing ``.nauro/config.json`` whose project
-    differs from the one being initialized. Per D136, this closes the
-    silent-overwrite footgun where ``nauro init <new-name>`` (or
-    ``nauro init --demo``) would replace a real project's cwd config
-    without warning, breaking every subsequent cwd-walk-up resolution.
+    differs from the one being initialized. Closes the silent-overwrite
+    footgun where ``nauro init <new-name>`` (or ``nauro init --demo``)
+    would replace a real project's cwd config without warning, breaking
+    every subsequent cwd-walk-up resolution.
 
     No-op when no existing config is present, when the existing config
     advertises the same project *id* as ``expected_id`` (idempotent
@@ -136,10 +136,10 @@ def init(
     is provided, the repos are appended to the existing local-mode entry.
     Cloud-mode entries cannot be extended this way — use ``nauro attach``.
     """
-    # D140: --demo seeds 7 pre-written decisions directly to disk (D91); the
-    # --cloud path goes through propose_decision/confirm_decision, which has
-    # no batch-seed bypass. Reject the combination at command entry rather
-    # than silently dropping --demo inside the --cloud branch.
+    # --demo seeds pre-written decisions directly to disk; the --cloud path
+    # goes through propose_decision/confirm_decision, which has no batch-seed
+    # bypass. Reject the combination at command entry rather than silently
+    # dropping --demo inside the --cloud branch.
     if demo and cloud:
         raise typer.BadParameter(
             "Cannot combine --demo with --cloud — the demo fixture seeds "
@@ -170,15 +170,15 @@ def init(
                 )
                 raise typer.Exit(code=1)
             store_path = get_store_path_v2(pid)
-            # Pre-check every target repo before any state changes (D136).
+            # Pre-check every target repo before any state changes.
             for rp in repo_paths:
                 _check_config_overwrite(rp, pid, name, force)
             added = []
             for rp in repo_paths:
                 add_repo_v2(pid, rp)
                 # Per-repo config is the source of truth for "is this repo
-                # adopted?" (D111). The cloud-mode branch is rejected above,
-                # so all surviving entries here are local-mode.
+                # adopted?". The cloud-mode branch is rejected above, so all
+                # surviving entries here are local-mode.
                 save_repo_config(
                     rp,
                     {
@@ -195,9 +195,9 @@ def init(
             return
 
     # ── New project: cloud or local ────────────────────────────────────────
-    # Pre-check every target repo before allocating a new id (D136). For a
-    # fresh init we have no pid to compare against; any existing config is
-    # treated as a potential conflict and refused without --force. v2 allows
+    # Pre-check every target repo before allocating a new id. For a fresh
+    # init we have no pid to compare against; any existing config is treated
+    # as a potential conflict and refused without --force. v2 allows
     # duplicate names with distinct ids, so name-match alone cannot be a
     # safe idempotency signal — silently coalescing 'nauro init projA' from
     # a cwd already linked to a different projA would lose the user's

--- a/packages/nauro/src/nauro/cli/commands/note.py
+++ b/packages/nauro/src/nauro/cli/commands/note.py
@@ -83,9 +83,9 @@ def note(
         typer.echo(f"Decision recorded in {project_name}:")
         typer.echo(f"  {filepath}")
 
-    # D143: refresh AGENTS.md so MCP-disconnected agents see the update
-    # without requiring a separate `nauro sync`. Mirrors the warn-then-regen
-    # sequence in `nauro sync` so stale registry paths surface consistently.
+    # Refresh AGENTS.md so MCP-disconnected agents see the update without
+    # requiring a separate `nauro sync`. Mirrors the warn-then-regen
+    # sequence in `nauro sync`.
     project_key = store_path.name
     for repo_str in _registry_repo_paths(project_key):
         if not Path(repo_str).is_dir():

--- a/packages/nauro/src/nauro/cli/commands/setup.py
+++ b/packages/nauro/src/nauro/cli/commands/setup.py
@@ -44,7 +44,7 @@ CLAUDE_MD_END = NAURO_BLOCK_END
 # Discoverability hint appended to every setup-add success path. `nauro check`
 # (the L1 surface) works from the current shell against the local store, so
 # users don't have to wait for an agent restart to see Nauro do something
-# useful. Imported by test_setup_extended.py to assert placement.
+# useful.
 CHECK_HINT_LINE = 'Try it now from this shell: nauro check "<approach>"'
 
 
@@ -100,12 +100,9 @@ def _user_scope_safe_to_clear(current_project_key: str | None) -> bool:
 def _configure_mcp(repo_path: Path, *, remove: bool = False) -> str:
     """Add or remove the Nauro MCP entry in the repo's project-scope ``.mcp.json``.
 
-    Writes the file directly. The format is documented in Anthropic's MCP
-    docs as a standardized shape, used by plugins shipping ``.mcp.json`` at
-    their roots and by enterprise ``managed-mcp.json`` deployments. Per D142,
-    this matches how ``_configure_cursor_for_repo`` handles ``.cursor/mcp.json``
-    and ``_configure_codex`` handles ``~/.codex/config.toml``, removing the
-    silent-skip failure mode users hit when the ``claude`` CLI was missing.
+    Writes the file directly. Mirrors how ``_configure_cursor_for_repo``
+    handles ``.cursor/mcp.json`` and ``_configure_codex`` handles
+    ``~/.codex/config.toml``, so all three surface handlers share one shape.
 
     Returns a one-line status string (indented for ``setup_all_surfaces``).
     """

--- a/packages/nauro/src/nauro/constants.py
+++ b/packages/nauro/src/nauro/constants.py
@@ -40,11 +40,11 @@ REGISTRY_FILENAME = "registry.json"
 CONFIG_FILENAME = "config.json"
 PROJECTS_DIR = "projects"
 
-# Files checked for unfilled bracket prompts during validation.
-# Includes both state filenames so validation works on fresh stores
-# (state_current.md only) and pre-D94 stores (state.md until first update_state
-# migrates them). Missing files are skipped by the validator, so listing both
-# is safe.
+# Files checked for unfilled bracket prompts during validation. Includes
+# both state filenames so validation works on fresh stores
+# (state_current.md) and legacy stores (state.md until the first
+# update_state migrates them). Missing files are skipped by the validator,
+# so listing both is safe.
 VALIDATED_STORE_FILES = (PROJECT_MD, STATE_CURRENT_FILENAME, STATE_LEGACY_FILENAME, STACK_MD)
 
 # Files counted toward L0 token estimate

--- a/packages/nauro/src/nauro/mcp/server.py
+++ b/packages/nauro/src/nauro/mcp/server.py
@@ -43,12 +43,11 @@ app = FastAPI(title="Nauro MCP Server", version="0.2.0")
 
 @app.middleware("http")
 async def _telemetry_transport_middleware(request, call_next):
-    """Set transport='http' for the duration of this request.
+    """Set transport='http' for this request.
 
-    Per D117 / Phase 1c T1.5, the mcp.tool_called event reads transport from
-    a ContextVar. Each FastAPI request runs in its own asyncio Task, which
-    gets a copy of the parent's context — so set_transport here is scoped to
-    this request and cannot leak to other transports.
+    The mcp.tool_called decorator reads transport from a ContextVar; each
+    FastAPI request runs in its own asyncio Task, so the value is
+    request-scoped and cannot leak to other transports.
     """
     from nauro.telemetry.transport import set_transport
 
@@ -111,11 +110,11 @@ def _resolve_store(project_id: str | None, cwd: str | None) -> Path:
 
     Delegates to :func:`nauro.store.resolution.resolve_store` and translates
     each typed :class:`StoreResolutionError` subclass into an appropriate
-    HTTP status code so existing callers keep their 4xx contracts. Per
-    D136 the mapping is: ``NoProjectError`` / ``ProjectNotFoundError`` /
-    ``StoreMissingError`` → 404 (resource not present);
-    ``ProjectIdMismatchError`` / ``MultipleProjectsError`` → 400 (caller
-    supplied an ambiguous or contradictory handle).
+    HTTP status code so existing callers keep their 4xx contracts.
+    ``NoProjectError`` / ``ProjectNotFoundError`` / ``StoreMissingError`` →
+    404 (resource not present); ``ProjectIdMismatchError`` /
+    ``MultipleProjectsError`` → 400 (caller supplied an ambiguous or
+    contradictory handle).
     """
     try:
         return resolve_store(project_id, cwd)

--- a/packages/nauro/src/nauro/mcp/stdio_server.py
+++ b/packages/nauro/src/nauro/mcp/stdio_server.py
@@ -80,8 +80,8 @@ def _spec_kwargs(name: str) -> dict[str, Any]:
 def _param_desc(tool_name: str, param: str) -> str:
     """Pull a per-property description from the centralized ToolSpec.
 
-    Per D101 + D134, the local FastMCP stdio derives input schemas from
-    Python type hints; per-property descriptions are surfaced via
+    The local FastMCP stdio derives input schemas from Python type hints;
+    per-property descriptions are surfaced via
     ``Annotated[T, Field(description=...)]`` rather than passing
     ``input_schema`` through directly. Sourcing the description from the
     ToolSpec at module load time keeps the registry as the single source

--- a/packages/nauro/src/nauro/mcp/tools.py
+++ b/packages/nauro/src/nauro/mcp/tools.py
@@ -162,11 +162,11 @@ def tool_propose_decision(
             }
         affected_decision_id = resolved
 
-    # D133: confidence flows as None when the caller did not send it so the
-    # validation pipeline can distinguish caller intent from default. Reapply
-    # "medium" only for add/supersede where the value lands in the decision
-    # file. On update the disallowed-fields branch in validate_proposed_write
-    # uses the unset value to recognise "caller did not send confidence".
+    # confidence flows as None when the caller did not send it so the
+    # validation pipeline can distinguish caller intent from default.
+    # Reapply "medium" only for add/supersede where the value lands in the
+    # decision file; on update the disallowed-fields branch uses the unset
+    # value to recognise "caller did not send confidence".
     proposal_confidence: str | None
     if operation in ("add", "supersede") and confidence is None:
         proposal_confidence = "medium"

--- a/packages/nauro/src/nauro/store/config.py
+++ b/packages/nauro/src/nauro/store/config.py
@@ -91,8 +91,8 @@ def get_telemetry_config() -> TelemetryConfig:
 
     anonymous_id = section.get("anonymous_id")
     if not anonymous_id:
-        # anonymous_id is generated and persisted before consent so Phase 1
-        # can attach the consent record to a stable identity that already exists.
+        # anonymous_id is generated and persisted before consent so the
+        # consent record can attach to a stable identity that already exists.
         anonymous_id = str(uuid.uuid4())
         section["anonymous_id"] = anonymous_id
         section.setdefault("enabled", None)

--- a/packages/nauro/src/nauro/store/resolution.py
+++ b/packages/nauro/src/nauro/store/resolution.py
@@ -7,14 +7,14 @@ module owns the rules and surfaces every failure as a typed exception so
 each transport can decide whether to show the welcome screen, return a
 specific error message, or translate to an HTTP status code.
 
-Per D101 + D111 + D136, the resolution order is:
+Resolution order:
 
   1. cwd's ``.nauro/config.json`` walk-up (id-keyed v2 store).
   2. ``project_id`` argument matched against v2 registry by name.
   3. ``project_id`` argument matched against v1 registry by name (legacy).
   4. ``cwd`` argument → v1 ``resolve_project`` (legacy).
 
-Before D136 both transports raised a bare ``ValueError`` and the wrappers
+Previously both transports raised a bare ``ValueError`` and the wrappers
 swallowed every failure into the same ``WELCOME_NO_PROJECT`` onboarding
 screen. The typed subclasses below let the wrappers reserve the welcome
 screen for the genuinely-no-project case and surface specific diagnostics
@@ -44,7 +44,7 @@ class StoreResolutionError(ValueError):
 
     Subclasses each name a failure category so callers can map them to the
     transport-appropriate output. Inherits ``ValueError`` so callers that
-    catch ``ValueError`` from the pre-D136 surface keep working.
+    catch ``ValueError`` from the legacy surface keep working.
     """
 
 

--- a/packages/nauro/src/nauro/telemetry/__init__.py
+++ b/packages/nauro/src/nauro/telemetry/__init__.py
@@ -1,9 +1,8 @@
 """Public telemetry API.
 
-Phase 1a: capture() is wired but emits nothing yet (no call sites). Phases 1b/1c
-add the call sites. identify_login/identify_logout are deliberately stubs that
-raise NotImplementedError — silent no-ops would let Phase 1b accidentally depend
-on identity work and silently corrupt analytics.
+identify_login/identify_logout raise rather than silent-no-op when called
+before the SDK is initialised — silent no-ops would let regressions go
+unnoticed.
 """
 
 from __future__ import annotations
@@ -23,9 +22,9 @@ logger = logging.getLogger("nauro.telemetry")
 def _should_emit() -> bool:
     """Three guards: opt-out env, missing PostHog key, fresh-install / opt-out consent.
 
-    The anonymous_id-set check from D117 is satisfied by get_telemetry_config()'s
-    contract: it generates and persists a UUID4 on first read, so cfg.anonymous_id
-    is never None by construction.
+    The anonymous_id-set check is satisfied by get_telemetry_config()'s
+    contract: it generates and persists a UUID4 on first read, so
+    cfg.anonymous_id is never None by construction.
     """
     if os.environ.get(NAURO_TELEMETRY_ENV) == "0":
         return False
@@ -40,9 +39,10 @@ def _should_emit() -> bool:
 def _get_distinct_id() -> str:
     """Resolve the PostHog distinct_id for this process.
 
-    Phase 1c (D119): prefer ``config.auth.user_id`` if logged in; otherwise the
-    anonymous_id from the telemetry section. The alias call in identify_login
-    ties pre-login anonymous events to the user_id post-login.
+    Prefers ``config.auth.user_id`` when logged in; otherwise the
+    anonymous_id from the telemetry section. The alias call in
+    identify_login ties pre-login anonymous events to the user_id
+    post-login.
     """
     auth = load_config().get("auth") or {}
     user_id = auth.get("user_id")
@@ -75,10 +75,9 @@ def capture(event_name: str, properties: dict[str, Any] | None = None) -> None:
 def _rotate_anonymous_id() -> str:
     """Mint a fresh UUID4 anonymous_id, persist it, leave consent fields untouched.
 
-    Used by ``nauro telemetry reset`` and (in Phase 1c) by identify_logout(). The
-    rotation is application-side only — PostHog's Python SDK is stateless w.r.t.
-    identity, so subsequent capture() calls will pick up the new id via
-    _get_distinct_id() without any SDK reset.
+    The rotation is application-side only — PostHog's Python SDK is
+    stateless w.r.t. identity, so subsequent capture() calls pick up the
+    new id via _get_distinct_id() without any SDK reset.
     """
     new_id = str(uuid.uuid4())
     data = load_config()
@@ -90,7 +89,7 @@ def _rotate_anonymous_id() -> str:
 
 
 def identify_login(user_id: str, email_hash: str) -> None:
-    """Merge anonymous identity into user_id on login (D119).
+    """Merge anonymous identity into user_id on login.
 
     Order is load-bearing: alias(previous_id=anonymous_id, distinct_id=user_id)
     FIRST, then set(distinct_id=user_id, properties={"email_hash"}). Reversed
@@ -115,7 +114,7 @@ def identify_login(user_id: str, email_hash: str) -> None:
 
 
 def identify_logout() -> None:
-    """Rotate anonymous_id on logout (D119) — no SDK reset.
+    """Rotate anonymous_id on logout — no SDK reset.
 
     posthog.reset() is a JS-SDK API; the Python SDK 7.x has no such method
     (every capture() takes an explicit distinct_id, so identity is stateless

--- a/packages/nauro/src/nauro/telemetry/_buckets.py
+++ b/packages/nauro/src/nauro/telemetry/_buckets.py
@@ -1,4 +1,4 @@
-"""Shared duration bucketing for D117 events.
+"""Shared duration bucketing for telemetry events.
 
 Same scheme used by `cli.command_invoked` and `mcp.tool_called` so dashboards
 can compare CLI vs MCP latency on the same axis.

--- a/packages/nauro/src/nauro/telemetry/cli_wrapper.py
+++ b/packages/nauro/src/nauro/telemetry/cli_wrapper.py
@@ -5,8 +5,7 @@ recursively and wraps every command callback with a timing/success-tracking
 shim that emits exactly one cli.command_invoked event per invocation.
 
 Wrapping happens once at app construction (in cli/main.py) so individual
-command modules stay free of telemetry imports — no per-command code per
-the T1.4 spec.
+command modules stay free of telemetry imports.
 """
 
 from __future__ import annotations

--- a/packages/nauro/src/nauro/telemetry/client.py
+++ b/packages/nauro/src/nauro/telemetry/client.py
@@ -1,13 +1,11 @@
 """Lazy PostHog client singleton.
 
-Project key is read from NAURO_POSTHOG_KEY env var only in this PR — T4.1 will
-flip the default to an embedded prod key. Single-PR ownership keeps the
-"placeholder accidentally shipped" failure mode out of Phases 1a–1c.
+Project key is read from the NAURO_POSTHOG_KEY env var.
 
-No atexit handler and no posthog.shutdown() call anywhere: per D120 the CLI
-uses sync_mode=True, so each capture() blocks until sent — there is no daemon
-thread that needs flushing on exit. Adding shutdown would re-introduce the
-background-thread surface that feedback_daemon_removed exists to prevent.
+No atexit handler and no posthog.shutdown() call: the CLI uses
+sync_mode=True, so each capture() blocks until sent and there is no daemon
+thread to flush. Adding shutdown would re-introduce a background-thread
+surface in a short-lived process the user is watching exit.
 """
 
 from __future__ import annotations
@@ -33,9 +31,9 @@ def _resolve_project_key() -> str | None:
 def _strip_reserved(properties: dict[str, Any]) -> dict[str, Any]:
     """Drop any property whose key starts with $ip, $geoip_, or $user_agent.
 
-    Defense-in-depth per D120: PostHog v7 has paths that can re-add these
-    properties even with disable_geoip=True; this filter is the runtime
-    guarantee that the privacy contract holds across SDK upgrades.
+    Defense-in-depth: PostHog v7 has paths that can re-add these even with
+    disable_geoip=True; this filter is the runtime guarantee that the
+    privacy contract holds across SDK upgrades.
     """
     return {
         k: v

--- a/packages/nauro/src/nauro/telemetry/decorators.py
+++ b/packages/nauro/src/nauro/telemetry/decorators.py
@@ -24,8 +24,8 @@ from nauro.telemetry.transport import current_transport
 def mcp_tool(name: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     """Wrap an MCP tool to emit ``mcp.tool_called`` exactly once per call.
 
-    Properties (D117 closed allowlist): tool_name, transport, success,
-    duration_bucket. Never tool args, return values, or exception details.
+    Closed allowlist: tool_name, transport, success, duration_bucket.
+    Never tool args, return values, or exception details.
     """
 
     def decorator(func: Callable[..., Any]) -> Callable[..., Any]:

--- a/packages/nauro/src/nauro/telemetry/events.py
+++ b/packages/nauro/src/nauro/telemetry/events.py
@@ -1,7 +1,7 @@
-"""Typed event constructors for the D117 taxonomy.
+"""Typed event constructors.
 
-Each function returns a property dict — no emission, no side effects. Phase 1b/1c
-call sites pair these with telemetry.capture() so property-key drift cannot
+Each function returns a property dict — no emission, no side effects. Call
+sites pair these with telemetry.capture() so property-key drift cannot
 silently fork between events and the locked taxonomy in PRIVACY.md.
 """
 

--- a/packages/nauro/src/nauro/validation/pipeline.py
+++ b/packages/nauro/src/nauro/validation/pipeline.py
@@ -28,11 +28,11 @@ from nauro.validation.tier2 import check_similarity
 
 logger = logging.getLogger("nauro.validation.pipeline")
 
-# D133: operation="update" appends rationale only — update_decision reads only
-# affected_decision_id + rationale. Any value in these fields would be silently
-# dropped on local stdio (and rejected on remote MCP); reject loudly at the
-# boundary so the wording in PROPOSE_DECISION_OPERATIONS holds on both
-# transports. Order mirrors mcp-server/src/mcp_server/validation.py:261-268.
+# operation="update" appends rationale only — update_decision reads only
+# affected_decision_id + rationale. Any value in these fields would be
+# silently dropped on local stdio (and rejected on remote MCP); reject
+# loudly at the boundary so the wording in PROPOSE_DECISION_OPERATIONS holds
+# on both transports.
 _UPDATE_DISALLOWED_FIELDS: tuple[str, ...] = (
     "title",
     "rejected",
@@ -89,7 +89,7 @@ def validate_proposed_write(
     Returns:
         ValidationResult with status and details.
     """
-    # --- D133: reject metadata fields on operation="update" ---
+    # --- reject metadata fields on operation="update" ---
     # update_decision writes only the new rationale onto the existing target;
     # any value in the disallowed fields would be silently dropped. Reject
     # loudly and point the caller at supersede. Sits before Tier 1 so the
@@ -116,7 +116,7 @@ def validate_proposed_write(
             log_validation(project_path, proposal, result.to_dict())
             return result
 
-    # --- D139: reject unknown resolves_questions ids at the boundary ---
+    # --- reject unknown resolves_questions ids at the boundary ---
     # Validate every supplied id exists in open-questions.md (either open
     # or already-resolved). Unknown ids reject before Tier 1 so the
     # assessment names the offending ids rather than slipping past the
@@ -142,7 +142,7 @@ def validate_proposed_write(
     # --- Tier 1: Structural screening ---
     # - update: rationale-only (length + minimum). The existing target supplies
     #   the title, so the standard "title empty" reject would otherwise prevent
-    #   title="" from being the legitimate rationale-only signal (per D133).
+    #   title="" from being the legitimate rationale-only signal.
     # - add / supersede: full structural screen.
     if operation == "update":
         rationale = (proposal.get("rationale") or "").strip()
@@ -319,8 +319,8 @@ def _execute_operation(
     — see tool_propose_decision). The return value reflects what was
     actually written so callers can echo ground truth.
 
-    Question resolution (D139) is applied best-effort after the decision
-    write — see :func:`_apply_question_resolves` for the failure posture.
+    Question resolution is applied best-effort after the decision write —
+    see :func:`_apply_question_resolves` for the failure posture.
     """
     if operation == "supersede" and affected_decision_id:
         decision_id = supersede_decision(affected_decision_id, proposal, project_path)
@@ -355,7 +355,7 @@ def _apply_question_resolves(
 
     Best-effort: the boundary already rejected unknown ids, so this can only
     fail on file I/O. Failures are logged with ``unresolved_ids`` and the
-    decision write stands — D132's posture for partial writes.
+    decision write stands.
     """
     ids = list(proposal.get("resolves_questions") or [])
     if not ids:


### PR DESCRIPTION
## Why

Several docstrings and inline comments had accumulated internal references —
roadmap-phase labels, sprint task ids, decision-id tags that no longer
carry load-bearing context, and at least one source-comment that named
a test file. None of it serves a reviewer reading the code in this repo,
and the project's no-internal-docs-in-public + WHY-only-comments
conventions say it shouldn't ship.

## Approach

Comment-only sweep across the modules where the debt had concentrated
(telemetry, MCP server + tools, CLI commands, store resolution,
validation pipeline). Three buckets:

- **Pure scrubs of internal phase/task labels** — replace with plain
  language describing what the code does and why.
- **Stale caller-tracking** — drop "Imported by test_X to assert
  placement" style sentences; the test still imports the symbol, the
  source doesn't need to advertise it.
- **Decision-id tags** — at each site, judge whether the tag was
  carrying load (it wasn't) and rewrite the comment so the rationale
  stands on its own without the reference.

No code, signatures, imports, or behavior touched.

## What changed

- `packages/nauro/src/nauro/telemetry/*` — module docstrings, helper
  docstrings, and the allowlist comment on `mcp_tool` rewritten without
  phase / D### tags. Identity-merge ordering rationale preserved.
- `packages/nauro/src/nauro/mcp/` — `server.py` middleware + `_resolve_store`,
  `stdio_server.py` `_param_desc`, `tools.py` confidence-flow comment.
- `packages/nauro/src/nauro/cli/commands/` — `init.py` overwrite-guard
  + cloud/demo branch comments, `note.py` AGENTS.md refresh, `adopt.py`
  module docstring, `setup.py` `_configure_mcp` + hint constant,
  `auth.py` identity-merge comments.
- `packages/nauro/src/nauro/store/resolution.py` — module docstring +
  base-class doc.
- `packages/nauro/src/nauro/store/config.py` — anonymous-id comment.
- `packages/nauro/src/nauro/constants.py` — `VALIDATED_STORE_FILES`
  comment.
- `packages/nauro/src/nauro/validation/pipeline.py` — section headers
  and helper docstrings.
- `packages/nauro-core/src/nauro_core/protocol.py` — one helper
  docstring.

## What to review

The decision-id rewrites are where judgment was applied — each one needed
to preserve enough rationale that a future reader understands *why* the
code is shaped the way it is, without leaning on a decision-id the reader
can't open. Worth a pass:

- `telemetry/__init__.py` identify_login / identify_logout ordering paragraphs
- `mcp/server.py` `_resolve_store` 404/400 mapping rationale
- `store/resolution.py` module docstring (resolution order +
  typed-exception motivation)
- `validation/pipeline.py` `_UPDATE_DISALLOWED_FIELDS` boundary-reject
  header and the `resolves_questions` boundary-reject header
- `cli/commands/init.py` `_check_config_overwrite` docstring

## What's deferred

- Test-file docstrings were not in scope for this pass.
- `mcp-server/` (private repo) was not touched.

## Test plan

- `uv run ruff format --check packages/` — 154 files already formatted
- `uv run ruff check packages/` — All checks passed
- `uv run pytest packages/nauro/tests/ -x -q` — 936 passed
- `uv run pytest packages/nauro-core/tests/ -x -q` — 306 passed