### PR TITLE
chore: drop re where plain string ops are clearer

### DIFF
--- a/packages/nauro-core/src/nauro_core/state.py
+++ b/packages/nauro-core/src/nauro_core/state.py
@@ -4,7 +4,6 @@ Pure functions that transform state content without any I/O. Callers are
 responsible for reading/writing files (local filesystem or S3).
 """
 
-import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
 
@@ -33,9 +32,10 @@ def _strip_current_header_footer(content: str) -> str:
     lines = content.split("\n")
     stripped: list[str] = []
     for line in lines:
-        if line.strip().startswith("# Current State"):
+        s = line.strip()
+        if s.startswith("# Current State"):
             continue
-        if re.match(r"^\*Last updated:\s.*\*$", line.strip()):
+        if s.startswith("*Last updated: ") and s.endswith("*"):
             continue
         stripped.append(line)
     return "\n".join(stripped).strip()

--- a/packages/nauro-core/src/nauro_core/validation.py
+++ b/packages/nauro-core/src/nauro_core/validation.py
@@ -8,7 +8,6 @@ in by callers.
 from __future__ import annotations
 
 import hashlib
-import re
 
 from bm25s.stopwords import STOPWORDS_EN
 
@@ -115,7 +114,7 @@ def compute_hash(title: str, rationale: str) -> str:
 
 def _normalize_title(title: str) -> str:
     """Collapse whitespace and lowercase for title comparison."""
-    return re.sub(r"\s+", " ", title.lower().strip())
+    return " ".join(title.lower().split())
 
 
 def screen_structural(

--- a/packages/nauro/src/nauro/cli/commands/diff.py
+++ b/packages/nauro/src/nauro/cli/commands/diff.py
@@ -1,7 +1,5 @@
 """nauro diff — Show changes between context snapshots."""
 
-import re
-
 import typer
 
 from nauro.cli.utils import resolve_target_project
@@ -11,12 +9,14 @@ from nauro.store.snapshot import list_snapshots
 
 def _parse_since(value: str) -> int:
     """Parse a --since value like '7d', '14d', or '30' into days."""
-    m = re.match(r"^(\d+)d?$", value.strip())
-    if not m:
+    v = value.strip()
+    if v.endswith("d"):
+        v = v[:-1]
+    if not v.isdigit():
         raise typer.BadParameter(
             f"Invalid --since value: {value!r}. Use a number or Nd (e.g., 7d)."
         )
-    return int(m.group(1))
+    return int(v)
 
 
 def diff(

--- a/packages/nauro/src/nauro/constants.py
+++ b/packages/nauro/src/nauro/constants.py
@@ -84,8 +84,6 @@ PRUNE_DAILY_DAYS = 30
 PRUNE_WEEKLY_DAYS = 180
 
 # ── State field patterns (used in parsing and diffing) ──
-STATE_FIELD_LAST_SYNCED_BOLD = r"\*\*Last synced:\*\*\s*(.*)"
-STATE_FIELD_LAST_SYNCED_ITALIC = r"\*Last synced:\s*(.*?)\*"
 STATE_DIFF_FIELDS = ("Sprint", "Focus", "Blockers")
 
 # ── Schema versioning ──

--- a/packages/nauro/src/nauro/store/reader.py
+++ b/packages/nauro/src/nauro/store/reader.py
@@ -3,7 +3,6 @@
 All reads from the .nauro/ project store go through this module.
 """
 
-import re
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -19,7 +18,6 @@ from nauro.constants import (
     STACK_MD,
     STATE_CURRENT_FILENAME,
     STATE_DIFF_FIELDS,
-    STATE_FIELD_LAST_SYNCED_BOLD,
     STATE_HISTORY_FILENAME,
     STATE_MD,
 )
@@ -200,9 +198,11 @@ def _build_l0_local(store_path: Path) -> str:
 
     # Local-specific: append "last synced" line from state
     state = files.get("state_current.md") or files.get("state.md", "")
-    synced = re.search(STATE_FIELD_LAST_SYNCED_BOLD, state)
-    if synced:
-        result += f"\n\n*Last synced: {synced.group(1).strip()}*"
+    marker = "**Last synced:**"
+    synced_line = next((line for line in state.splitlines() if marker in line), None)
+    if synced_line is not None:
+        value = synced_line.split(marker, 1)[1].strip()
+        result += f"\n\n*Last synced: {value}*"
 
     return result
 
@@ -364,8 +364,12 @@ def _diff_state(old: str, new: str) -> list[str]:
     changes = []
 
     def extract_field(content: str, field: str) -> str:
-        m = re.search(rf"\*\*{field}:\*\*\s*(.*)", content)
-        return m.group(1).strip() if m else ""
+        marker = f"**{field}:**"
+        for line in content.splitlines():
+            idx = line.find(marker)
+            if idx >= 0:
+                return line[idx + len(marker) :].strip()
+        return ""
 
     for field in STATE_DIFF_FIELDS:
         old_val = extract_field(old, field)

--- a/packages/nauro/src/nauro/store/validator.py
+++ b/packages/nauro/src/nauro/store/validator.py
@@ -13,7 +13,6 @@ from nauro.constants import (
     L0_TOKEN_LIMIT,
     STALE_SYNC_DAYS,
     STATE_CURRENT_FILENAME,
-    STATE_FIELD_LAST_SYNCED_ITALIC,
     STATE_LEGACY_FILENAME,
     VALIDATED_STORE_FILES,
 )
@@ -48,7 +47,14 @@ def validate_store(store_path: Path) -> list[str]:
         unfilled = []
         for m in re.finditer(r"\[([^\]]+)\]", content):
             p = m.group(1)
-            if re.match(r"\d{4}-\d{2}-\d{2}", p):
+            if (
+                len(p) >= 10
+                and p[4] == "-"
+                and p[7] == "-"
+                and p[:4].isdigit()
+                and p[5:7].isdigit()
+                and p[8:10].isdigit()
+            ):
                 continue
             # Check if this bracket is part of a markdown link [text](...)
             end = m.end()
@@ -66,9 +72,13 @@ def validate_store(store_path: Path) -> list[str]:
         state_path = store_path / STATE_LEGACY_FILENAME
     if state_path.exists():
         content = state_path.read_text()
-        sync_match = re.search(STATE_FIELD_LAST_SYNCED_ITALIC, content)
-        if sync_match:
-            synced_str = sync_match.group(1).strip()
+        synced_str: str | None = None
+        for line in content.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("*Last synced:") and stripped.endswith("*"):
+                synced_str = stripped[len("*Last synced:") : -1].strip()
+                break
+        if synced_str is not None:
             try:
                 # Try parsing "YYYY-MM-DD HH:MM UTC" or "YYYY-MM-DD"
                 if "UTC" in synced_str:


### PR DESCRIPTION
## Why
The repo convention is "no regex by default" — reach for `re` only when the
character classes, backreferences, or repetition genuinely earn it. Several
sites were using `re.sub`/`re.match`/`re.search` for what is really a literal
prefix check, an isdigit test, or whitespace collapsing.

## Approach
Audited every `re.*` call across `packages/` and split into three buckets:
clean wins (regex is strictly noisier than the string-op equivalent), judgment
calls (close enough that either is defensible), and explicit keeps (markdown
parsing, character-class substitution, multiline + backreference). Only the
first two are touched here; the keeps stay as regex. ADR-import sites in
`import_cmd.py` are explicitly deferred — markdown extraction is the canonical
place regex pays rent.

## What changed
- nauro_core/validation.py: `re.sub(r"\s+", " ", ...)` → `" ".join(...split())`
- nauro_core/state.py: `re.match` for `*Last updated: ... *` → startswith/endswith
- nauro/cli/commands/diff.py: `re.match(r"^(\d+)d?$", ...)` → strip + isdigit
- nauro/store/reader.py: drop `STATE_FIELD_LAST_SYNCED_BOLD` search and the
  `**Field:**` regex in `extract_field` for line-based scans
- nauro/store/validator.py: drop `STATE_FIELD_LAST_SYNCED_ITALIC` search; replace
  `re.match(YYYY-MM-DD)` on bracket contents with length+slice+isdigit
- nauro/constants.py: drop the two now-unused regex constants

## What to review
- The two "Last synced" rewrites tighten the matcher to whole-line italic
  (`*Last synced: <value>*`) and whole-line bold (`**Last synced:** <value>`).
  Confirm that's the only shape these markers ever take in state files.
- `state.py` _strip_current_header_footer now treats only a space as the
  separator after `*Last updated:` (regex allowed any single whitespace).
  The writer emits a space, so this matches production.
- The YYYY-MM-DD shape check in `validator.py` walks specific indices instead
  of running a regex — worth a quick eyeball.

## What's deferred
- ADR-import regex sites in `cli/commands/import_cmd.py` — markdown heading/
  list extraction is the right tool for regex.
- Markdown parsing in `nauro_core/parsing.py`, sentence boundary split in
  `nauro_core/search.py`, decision-file renumbering in `sync/hooks.py`,
  and slug generation in `store/writer.py` are explicit keeps.

## Test plan
- `uv run pytest packages/nauro-core/tests/ packages/nauro/tests/ -x -q` →
  1242 passed.
- `uv run ruff check packages/` → clean.
- `uv run ruff format --check packages/` → clean.
- No new tests; existing coverage exercises each touched code path.