### PR TITLE
refactor: dedupe telemetry test fixtures and JSON MCP writer

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/setup.py
+++ b/packages/nauro/src/nauro/cli/commands/setup.py
@@ -97,16 +97,24 @@ def _user_scope_safe_to_clear(current_project_key: str | None) -> bool:
     return not keys
 
 
-def _configure_mcp(repo_path: Path, *, remove: bool = False) -> str:
-    """Add or remove the Nauro MCP entry in the repo's project-scope ``.mcp.json``.
+def _configure_json_mcp(
+    repo_path: Path,
+    *,
+    config_rel_path: str,
+    label: str,
+    remove: bool,
+) -> str:
+    """Add or remove the Nauro MCP entry in a JSON config file at ``repo_path / config_rel_path``.
 
-    Writes the file directly. Mirrors how ``_configure_cursor_for_repo``
-    handles ``.cursor/mcp.json`` and ``_configure_codex`` handles
-    ``~/.codex/config.toml``, so all three surface handlers share one shape.
+    Shared shape behind ``_configure_mcp`` (``.mcp.json``) and
+    ``_configure_cursor_for_repo`` (``.cursor/mcp.json``): load → parse →
+    mutate ``mcpServers["nauro"]`` → write. Both surfaces use the same key
+    name and entry shape, so the only per-surface variation is the relative
+    path and the human-readable ``label`` used in status messages.
 
     Returns a one-line status string (indented for ``setup_all_surfaces``).
     """
-    config_path = repo_path / ".mcp.json"
+    config_path = repo_path / config_rel_path
     nauro_cmd = _find_nauro_command()
     nauro_entry = {"command": nauro_cmd, "args": ["serve", "--stdio"]}
 
@@ -114,7 +122,7 @@ def _configure_mcp(repo_path: Path, *, remove: bool = False) -> str:
         try:
             config = json.loads(config_path.read_text())
         except json.JSONDecodeError as exc:
-            return f"  {repo_path}: could not parse .mcp.json — {exc}"
+            return f"  {repo_path}: could not parse {label} — {exc}"
     else:
         config = {}
 
@@ -129,11 +137,29 @@ def _configure_mcp(repo_path: Path, *, remove: bool = False) -> str:
             config_path.write_text(json.dumps(config, indent=2) + "\n")
         else:
             config_path.unlink()
-        return f"  {repo_path}: removed nauro from .mcp.json"
+        return f"  {repo_path}: removed nauro from {label}"
 
     config.setdefault("mcpServers", {})["nauro"] = nauro_entry
+    config_path.parent.mkdir(parents=True, exist_ok=True)
     config_path.write_text(json.dumps(config, indent=2) + "\n")
-    return f"  {repo_path}: wrote nauro to .mcp.json"
+    return f"  {repo_path}: wrote nauro to {label}"
+
+
+def _configure_mcp(repo_path: Path, *, remove: bool = False) -> str:
+    """Add or remove the Nauro MCP entry in the repo's project-scope ``.mcp.json``.
+
+    Writes the file directly. Mirrors how ``_configure_cursor_for_repo``
+    handles ``.cursor/mcp.json`` and ``_configure_codex`` handles
+    ``~/.codex/config.toml``, so all three surface handlers share one shape.
+
+    Returns a one-line status string (indented for ``setup_all_surfaces``).
+    """
+    return _configure_json_mcp(
+        repo_path,
+        config_rel_path=".mcp.json",
+        label=".mcp.json",
+        remove=remove,
+    )
 
 
 @setup_app.command(name="claude-code")
@@ -213,36 +239,12 @@ def claude_code(
 
 def _configure_cursor_for_repo(repo_path: Path, *, remove: bool) -> str:
     """Add or remove the Nauro MCP entry in this repo's ``.cursor/mcp.json``."""
-    cursor_dir = repo_path / ".cursor"
-    config_path = cursor_dir / "mcp.json"
-    nauro_cmd = _find_nauro_command()
-    nauro_entry = {"command": nauro_cmd, "args": ["serve", "--stdio"]}
-
-    if config_path.exists():
-        try:
-            config = json.loads(config_path.read_text())
-        except json.JSONDecodeError as exc:
-            return f"  {repo_path}: could not parse .cursor/mcp.json — {exc}"
-    else:
-        config = {}
-
-    if remove:
-        servers = config.get("mcpServers", {})
-        if "nauro" in servers:
-            del servers["nauro"]
-            if not servers:
-                config.pop("mcpServers", None)
-            if config:
-                config_path.write_text(json.dumps(config, indent=2) + "\n")
-            else:
-                config_path.unlink()
-            return f"  {repo_path}: removed nauro from .cursor/mcp.json"
-        return f"  {repo_path}: no nauro entry to remove"
-
-    config.setdefault("mcpServers", {})["nauro"] = nauro_entry
-    cursor_dir.mkdir(parents=True, exist_ok=True)
-    config_path.write_text(json.dumps(config, indent=2) + "\n")
-    return f"  {repo_path}: wrote nauro to .cursor/mcp.json"
+    return _configure_json_mcp(
+        repo_path,
+        config_rel_path=".cursor/mcp.json",
+        label=".cursor/mcp.json",
+        remove=remove,
+    )
 
 
 @setup_app.command(name="cursor")

--- a/packages/nauro/src/nauro/demo/__init__.py
+++ b/packages/nauro/src/nauro/demo/__init__.py
@@ -214,7 +214,7 @@ DEMO_DECISIONS: list[Decision] = [
 ]
 
 
-STATE_CURRENT_MD = f"""\
+DEMO_STATE_CURRENT_MD = f"""\
 # Current State
 
 Implementing user authentication \u2014 building JWT-based auth flow \
@@ -305,7 +305,7 @@ def create_demo_project(store_path: Path) -> None:
     snapshots_dir.mkdir(exist_ok=True)
 
     (store_path / constants.PROJECT_MD).write_text(PROJECT_MD)
-    (store_path / constants.STATE_CURRENT_FILENAME).write_text(STATE_CURRENT_MD)
+    (store_path / constants.STATE_CURRENT_FILENAME).write_text(DEMO_STATE_CURRENT_MD)
     (store_path / constants.STACK_MD).write_text(STACK_MD)
     (store_path / constants.OPEN_QUESTIONS_MD).write_text(OPEN_QUESTIONS_MD)
 
@@ -319,7 +319,7 @@ def create_demo_project(store_path: Path) -> None:
 
     files = {
         constants.PROJECT_MD: PROJECT_MD,
-        constants.STATE_CURRENT_FILENAME: STATE_CURRENT_MD,
+        constants.STATE_CURRENT_FILENAME: DEMO_STATE_CURRENT_MD,
         constants.STACK_MD: STACK_MD,
         constants.OPEN_QUESTIONS_MD: OPEN_QUESTIONS_MD,
         **decision_files,

--- a/packages/nauro/tests/conftest.py
+++ b/packages/nauro/tests/conftest.py
@@ -1,6 +1,75 @@
-"""Shared pytest configuration."""
+"""Shared pytest configuration and helpers for the nauro test suite."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
 
 import pytest
+
+# Magic UUID4 used by every telemetry test that seeds a consented config.
+# Centralized so a rotation in one file can't drift away from the rest.
+TEST_ANONYMOUS_ID = "11111111-1111-4111-8111-111111111111"
+
+
+class FakeClient:
+    """Capture-only stand-in for ``nauro.telemetry.client._client``.
+
+    Records every ``capture(event, distinct_id, properties)`` call into
+    ``events`` so tests can assert on the emitted payload shape. Tests that
+    need to assert call ordering (alias-then-set semantics) use the
+    ordered-tuple variant in test_identity_lifecycle.py instead.
+    """
+
+    def __init__(self) -> None:
+        self.events: list[dict[str, Any]] = []
+
+    def capture(
+        self,
+        event: str,
+        distinct_id: str,
+        properties: dict[str, Any],
+    ) -> None:
+        self.events.append({"event": event, "distinct_id": distinct_id, "properties": properties})
+
+
+def seed_consented_config(home: Path, *, enabled: bool) -> str:
+    """Write a fully consented telemetry config under ``home/config.json``.
+
+    Returns the seeded anonymous_id so tests that need to compare against the
+    persisted value have a single source of truth.
+    """
+    (home / "config.json").write_text(
+        json.dumps(
+            {
+                "telemetry": {
+                    "anonymous_id": TEST_ANONYMOUS_ID,
+                    "enabled": enabled,
+                    "consent_version": 1,
+                    "consented_at": "2026-04-30T00:00:00Z",
+                }
+            }
+        )
+    )
+    return TEST_ANONYMOUS_ID
+
+
+@pytest.fixture
+def telemetry_key(monkeypatch):
+    """Set the PostHog key env var so ``_should_emit`` returns True for enabled tests."""
+    monkeypatch.setenv("NAURO_POSTHOG_KEY", "phc_test_key_for_unit_tests")
+
+
+@pytest.fixture
+def fake_posthog(monkeypatch):
+    """Swap ``nauro.telemetry.client._client`` for a ``FakeClient`` and reset after."""
+    import nauro.telemetry.client as client_mod
+
+    fake = FakeClient()
+    client_mod._client = fake
+    yield fake
+    client_mod._client = None
 
 
 @pytest.fixture(autouse=True)

--- a/packages/nauro/tests/test_check_command.py
+++ b/packages/nauro/tests/test_check_command.py
@@ -12,7 +12,6 @@ Covers:
 from __future__ import annotations
 
 import json
-from typing import Any
 
 import pytest
 from typer.testing import CliRunner
@@ -23,6 +22,7 @@ from nauro.demo import create_demo_project
 from nauro.mcp.tools import compute_check_decision, tool_check_decision
 from nauro.store.registry import register_project_v2
 from nauro.store.repo_config import save_repo_config
+from tests.conftest import seed_consented_config
 
 runner = CliRunner()
 
@@ -199,42 +199,11 @@ def test_cloud_mode_project_prints_stale_notice(tmp_path, monkeypatch):
 # --- telemetry: no mcp.tool_called from the CLI surface -----------------------
 
 
-class _FakeClient:
-    def __init__(self) -> None:
-        self.events: list[dict[str, Any]] = []
-
-    def capture(self, event: str, distinct_id: str, properties: dict[str, Any]) -> None:
-        self.events.append({"event": event, "properties": properties})
-
-
-@pytest.fixture
-def fake_posthog(monkeypatch):
-    import nauro.telemetry.client as client_mod
-
-    fake = _FakeClient()
-    client_mod._client = fake
-    yield fake
-    client_mod._client = None
-
-
 @pytest.fixture
 def telemetry_enabled(tmp_path, monkeypatch):
     """Seed NAURO_HOME with a consented config so capture() actually fires."""
     monkeypatch.setenv("NAURO_POSTHOG_KEY", "phc_test_key_for_unit_tests")
-    aid = "11111111-1111-4111-8111-111111111111"
-    (tmp_path / "config.json").write_text(
-        json.dumps(
-            {
-                "telemetry": {
-                    "anonymous_id": aid,
-                    "enabled": True,
-                    "consent_version": 1,
-                    "consented_at": "2026-04-30T00:00:00Z",
-                }
-            }
-        )
-    )
-    return aid
+    return seed_consented_config(tmp_path, enabled=True)
 
 
 def test_cli_check_emits_no_mcp_tool_called_event(

--- a/packages/nauro/tests/test_cli_command_invoked.py
+++ b/packages/nauro/tests/test_cli_command_invoked.py
@@ -2,28 +2,16 @@
 
 from __future__ import annotations
 
-import json
 from typing import Any
 
 import pytest
 import typer
 from typer.testing import CliRunner
 
+from tests.conftest import FakeClient, seed_consented_config
+
 _EXPECTED_KEYS = {"command", "success", "duration_bucket", "nauro_version", "os"}
 _DISALLOWED_KEYS = {"args", "argv", "cwd", "env", "exit_code"}
-
-
-class FakeClient:
-    def __init__(self) -> None:
-        self.events: list[dict[str, Any]] = []
-
-    def capture(
-        self,
-        event: str,
-        distinct_id: str,
-        properties: dict[str, Any],
-    ) -> None:
-        self.events.append({"event": event, "distinct_id": distinct_id, "properties": properties})
 
 
 @pytest.fixture
@@ -35,38 +23,6 @@ def nauro_home(tmp_path, monkeypatch):
     repo.mkdir()
     monkeypatch.chdir(repo)
     return home
-
-
-@pytest.fixture
-def telemetry_key(monkeypatch):
-    monkeypatch.setenv("NAURO_POSTHOG_KEY", "phc_test_key_for_unit_tests")
-
-
-@pytest.fixture
-def fake_posthog(monkeypatch):
-    import nauro.telemetry.client as client_mod
-
-    fake = FakeClient()
-    client_mod._client = fake
-    yield fake
-    client_mod._client = None
-
-
-def _seed_consented_config(home, *, enabled: bool) -> str:
-    aid = "11111111-1111-4111-8111-111111111111"
-    (home / "config.json").write_text(
-        json.dumps(
-            {
-                "telemetry": {
-                    "anonymous_id": aid,
-                    "enabled": enabled,
-                    "consent_version": 1,
-                    "consented_at": "2026-04-30T00:00:00Z",
-                }
-            }
-        )
-    )
-    return aid
 
 
 def _command_events(fake: FakeClient) -> list[dict[str, Any]]:
@@ -86,7 +42,7 @@ def _build_isolated_app(callback) -> typer.Typer:
 
 
 def test_emits_one_event_on_success(nauro_home, telemetry_key, fake_posthog):
-    _seed_consented_config(nauro_home, enabled=True)
+    seed_consented_config(nauro_home, enabled=True)
 
     from nauro.cli.main import app
 
@@ -105,7 +61,7 @@ def test_emits_one_event_on_success(nauro_home, telemetry_key, fake_posthog):
 
 
 def test_emits_one_event_on_typer_exit_nonzero(nauro_home, telemetry_key, fake_posthog):
-    _seed_consented_config(nauro_home, enabled=True)
+    seed_consented_config(nauro_home, enabled=True)
 
     def _fail() -> None:
         raise typer.Exit(code=1)
@@ -122,7 +78,7 @@ def test_emits_one_event_on_typer_exit_nonzero(nauro_home, telemetry_key, fake_p
 
 
 def test_emits_one_event_on_typer_exit_zero(nauro_home, telemetry_key, fake_posthog):
-    _seed_consented_config(nauro_home, enabled=True)
+    seed_consented_config(nauro_home, enabled=True)
 
     def _early_exit() -> None:
         raise typer.Exit()  # default code=0
@@ -138,7 +94,7 @@ def test_emits_one_event_on_typer_exit_zero(nauro_home, telemetry_key, fake_post
 
 
 def test_emits_one_event_on_unexpected_exception(nauro_home, telemetry_key, fake_posthog):
-    _seed_consented_config(nauro_home, enabled=True)
+    seed_consented_config(nauro_home, enabled=True)
 
     def _boom() -> None:
         raise RuntimeError("boom")
@@ -156,7 +112,7 @@ def test_emits_one_event_on_unexpected_exception(nauro_home, telemetry_key, fake
 
 
 def test_dotted_subcommand_path(nauro_home, telemetry_key, fake_posthog):
-    _seed_consented_config(nauro_home, enabled=True)
+    seed_consented_config(nauro_home, enabled=True)
 
     from nauro.cli.main import app
 
@@ -171,7 +127,7 @@ def test_dotted_subcommand_path(nauro_home, telemetry_key, fake_posthog):
 
 
 def test_no_event_when_enabled_false(nauro_home, telemetry_key, fake_posthog):
-    _seed_consented_config(nauro_home, enabled=False)
+    seed_consented_config(nauro_home, enabled=False)
 
     from nauro.cli.main import app
 
@@ -184,7 +140,7 @@ def test_no_event_when_enabled_false(nauro_home, telemetry_key, fake_posthog):
 
 def test_no_event_when_env_var_zero(nauro_home, telemetry_key, fake_posthog, monkeypatch):
     monkeypatch.setenv("NAURO_TELEMETRY", "0")
-    _seed_consented_config(nauro_home, enabled=True)
+    seed_consented_config(nauro_home, enabled=True)
 
     from nauro.cli.main import app
 
@@ -196,7 +152,7 @@ def test_no_event_when_env_var_zero(nauro_home, telemetry_key, fake_posthog, mon
 
 
 def test_event_keys_exhaustive_no_disallowed(nauro_home, telemetry_key, fake_posthog):
-    _seed_consented_config(nauro_home, enabled=True)
+    seed_consented_config(nauro_home, enabled=True)
 
     from nauro.cli.main import app
 
@@ -222,7 +178,7 @@ def test_bucket_classification():
 
 
 def test_version_flag_does_not_emit(nauro_home, telemetry_key, fake_posthog):
-    _seed_consented_config(nauro_home, enabled=True)
+    seed_consented_config(nauro_home, enabled=True)
 
     from nauro.cli.main import app
 
@@ -234,7 +190,7 @@ def test_version_flag_does_not_emit(nauro_home, telemetry_key, fake_posthog):
 
 
 def test_help_flag_does_not_emit(nauro_home, telemetry_key, fake_posthog):
-    _seed_consented_config(nauro_home, enabled=True)
+    seed_consented_config(nauro_home, enabled=True)
 
     from nauro.cli.main import app
 

--- a/packages/nauro/tests/test_conftest_helpers.py
+++ b/packages/nauro/tests/test_conftest_helpers.py
@@ -1,0 +1,69 @@
+"""Tests for the shared telemetry-test helpers exposed via conftest.
+
+These helpers were extracted to remove drift across the telemetry test files
+(test_cli_command_invoked, test_mcp_tool_called, test_telemetry_subcommand,
+test_telemetry_module, test_project_created_event, test_check_command). Pin
+the shape here so the next agent who refactors the helpers cannot drop a
+piece without a visible test failure.
+"""
+
+from __future__ import annotations
+
+import json
+
+from tests.conftest import TEST_ANONYMOUS_ID, FakeClient, seed_consented_config
+
+
+def test_test_anonymous_id_is_the_uuid4_used_across_telemetry_tests():
+    """The magic UUID that previously appeared in five test files verbatim."""
+    assert TEST_ANONYMOUS_ID == "11111111-1111-4111-8111-111111111111"
+
+
+def test_fake_client_records_event_distinct_id_and_properties():
+    fake = FakeClient()
+
+    fake.capture("cli.command_invoked", "user-1", {"command": "init", "success": True})
+    fake.capture("project.created", "user-1", {"schema_version": 2})
+
+    assert len(fake.events) == 2
+    assert fake.events[0] == {
+        "event": "cli.command_invoked",
+        "distinct_id": "user-1",
+        "properties": {"command": "init", "success": True},
+    }
+    assert fake.events[1]["event"] == "project.created"
+
+
+def test_seed_consented_config_writes_expected_shape(tmp_path):
+    aid = seed_consented_config(tmp_path, enabled=True)
+
+    assert aid == TEST_ANONYMOUS_ID
+    data = json.loads((tmp_path / "config.json").read_text())
+    assert data["telemetry"]["anonymous_id"] == TEST_ANONYMOUS_ID
+    assert data["telemetry"]["enabled"] is True
+    assert data["telemetry"]["consent_version"] == 1
+    assert data["telemetry"]["consented_at"] == "2026-04-30T00:00:00Z"
+
+
+def test_seed_consented_config_disabled_flag_persists(tmp_path):
+    seed_consented_config(tmp_path, enabled=False)
+
+    data = json.loads((tmp_path / "config.json").read_text())
+    assert data["telemetry"]["enabled"] is False
+
+
+def test_fake_posthog_fixture_swaps_module_singleton_and_resets(fake_posthog):
+    """The fixture must assign FakeClient to nauro.telemetry.client._client
+    for the duration of the test and reset to None after.
+    """
+    import nauro.telemetry.client as client_mod
+
+    assert client_mod._client is fake_posthog
+    assert isinstance(fake_posthog, FakeClient)
+    assert fake_posthog.events == []
+
+
+def test_telemetry_key_fixture_sets_env_var(telemetry_key, monkeypatch):
+    import os
+
+    assert os.environ.get("NAURO_POSTHOG_KEY") == "phc_test_key_for_unit_tests"

--- a/packages/nauro/tests/test_identity_lifecycle.py
+++ b/packages/nauro/tests/test_identity_lifecycle.py
@@ -27,6 +27,8 @@ from typing import Any
 
 import pytest
 
+from tests.conftest import TEST_ANONYMOUS_ID
+
 _UUID4_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$")
 
 
@@ -57,11 +59,6 @@ def nauro_home(tmp_path, monkeypatch):
     return home
 
 
-@pytest.fixture
-def telemetry_key(monkeypatch):
-    monkeypatch.setenv("NAURO_POSTHOG_KEY", "phc_test_key_for_unit_tests")
-
-
 @pytest.fixture(autouse=True)
 def _reset_client_singleton():
     import nauro.telemetry.client as client_mod
@@ -82,7 +79,7 @@ def fake_posthog(monkeypatch):
 
 
 def _seed_telemetry_config(home, *, enabled: bool, anonymous_id: str | None = None) -> str:
-    aid = anonymous_id or "11111111-1111-4111-8111-111111111111"
+    aid = anonymous_id or TEST_ANONYMOUS_ID
     (home / "config.json").write_text(
         json.dumps(
             {

--- a/packages/nauro/tests/test_mcp_tool_called.py
+++ b/packages/nauro/tests/test_mcp_tool_called.py
@@ -19,16 +19,10 @@ from typing import Any
 
 import pytest
 
+from tests.conftest import seed_consented_config
+
 _ALLOWED_KEYS = frozenset({"tool_name", "transport", "success", "duration_bucket"})
 _DURATION_PATTERN = re.compile(r"^(<10ms|10-100ms|100ms-1s|1-10s|>10s)$")
-
-
-class FakeClient:
-    def __init__(self) -> None:
-        self.events: list[dict[str, Any]] = []
-
-    def capture(self, event: str, distinct_id: str, properties: dict[str, Any]) -> None:
-        self.events.append({"event": event, "distinct_id": distinct_id, "properties": properties})
 
 
 @pytest.fixture
@@ -43,30 +37,7 @@ def nauro_home(tmp_path, monkeypatch):
 @pytest.fixture
 def telemetry_enabled(nauro_home, monkeypatch):
     monkeypatch.setenv("NAURO_POSTHOG_KEY", "phc_test_key_for_unit_tests")
-    aid = "11111111-1111-4111-8111-111111111111"
-    (nauro_home / "config.json").write_text(
-        json.dumps(
-            {
-                "telemetry": {
-                    "anonymous_id": aid,
-                    "enabled": True,
-                    "consent_version": 1,
-                    "consented_at": "2026-04-30T00:00:00Z",
-                }
-            }
-        )
-    )
-    return aid
-
-
-@pytest.fixture
-def fake_posthog(monkeypatch):
-    import nauro.telemetry.client as client_mod
-
-    fake = FakeClient()
-    client_mod._client = fake
-    yield fake
-    client_mod._client = None
+    return seed_consented_config(nauro_home, enabled=True)
 
 
 @pytest.fixture(autouse=True)

--- a/packages/nauro/tests/test_project_created_event.py
+++ b/packages/nauro/tests/test_project_created_event.py
@@ -2,24 +2,12 @@
 
 from __future__ import annotations
 
-import json
 from typing import Any
 
 import pytest
 from typer.testing import CliRunner
 
-
-class FakeClient:
-    def __init__(self) -> None:
-        self.events: list[dict[str, Any]] = []
-
-    def capture(
-        self,
-        event: str,
-        distinct_id: str,
-        properties: dict[str, Any],
-    ) -> None:
-        self.events.append({"event": event, "distinct_id": distinct_id, "properties": properties})
+from tests.conftest import FakeClient, seed_consented_config
 
 
 @pytest.fixture
@@ -33,38 +21,6 @@ def nauro_home(tmp_path, monkeypatch):
     return home
 
 
-@pytest.fixture
-def telemetry_key(monkeypatch):
-    monkeypatch.setenv("NAURO_POSTHOG_KEY", "phc_test_key_for_unit_tests")
-
-
-@pytest.fixture
-def fake_posthog(monkeypatch):
-    import nauro.telemetry.client as client_mod
-
-    fake = FakeClient()
-    client_mod._client = fake
-    yield fake
-    client_mod._client = None
-
-
-def _seed_consented_config(home, *, enabled: bool) -> str:
-    aid = "11111111-1111-4111-8111-111111111111"
-    (home / "config.json").write_text(
-        json.dumps(
-            {
-                "telemetry": {
-                    "anonymous_id": aid,
-                    "enabled": enabled,
-                    "consent_version": 1,
-                    "consented_at": "2026-04-30T00:00:00Z",
-                }
-            }
-        )
-    )
-    return aid
-
-
 def _events_named(fake: FakeClient, name: str) -> list[dict[str, Any]]:
     return [e for e in fake.events if e["event"] == name]
 
@@ -72,7 +28,7 @@ def _events_named(fake: FakeClient, name: str) -> list[dict[str, Any]]:
 def test_init_success_emits_project_created_with_schema_version(
     nauro_home, telemetry_key, fake_posthog
 ):
-    _seed_consented_config(nauro_home, enabled=True)
+    seed_consented_config(nauro_home, enabled=True)
 
     from nauro.cli.main import app
 
@@ -93,7 +49,7 @@ def test_init_success_emits_project_created_with_schema_version(
 def test_add_repo_branch_does_not_emit_project_created(
     nauro_home, telemetry_key, fake_posthog, tmp_path
 ):
-    _seed_consented_config(nauro_home, enabled=True)
+    seed_consented_config(nauro_home, enabled=True)
 
     from nauro.cli.main import app
 
@@ -119,7 +75,7 @@ def test_init_failure_does_not_emit_project_created(
 ):
     """--add-repo against a nonexistent multi-match scenario isn't reachable in v2;
     instead simulate failure by making register_project_v2 raise."""
-    _seed_consented_config(nauro_home, enabled=True)
+    seed_consented_config(nauro_home, enabled=True)
 
     import nauro.cli.commands.init as init_module
 
@@ -145,7 +101,7 @@ def test_init_failure_does_not_emit_project_created(
 
 
 def test_project_created_keys_are_exhaustive(nauro_home, telemetry_key, fake_posthog):
-    _seed_consented_config(nauro_home, enabled=True)
+    seed_consented_config(nauro_home, enabled=True)
 
     from nauro.cli.main import app
 

--- a/packages/nauro/tests/test_telemetry_module.py
+++ b/packages/nauro/tests/test_telemetry_module.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import importlib
-import json
 import socket
 import sys
 from unittest.mock import patch
 
 import pytest
+
+from tests.conftest import seed_consented_config
 
 
 @pytest.fixture
@@ -19,11 +20,6 @@ def nauro_home(tmp_path, monkeypatch):
     return home
 
 
-@pytest.fixture
-def telemetry_key(monkeypatch):
-    monkeypatch.setenv("NAURO_POSTHOG_KEY", "phc_test_key_for_unit_tests")
-
-
 @pytest.fixture(autouse=True)
 def _reset_client_singleton():
     """Each test gets a fresh client singleton — protects against leak across tests."""
@@ -32,23 +28,6 @@ def _reset_client_singleton():
     client_mod._client = None
     yield
     client_mod._client = None
-
-
-def _seed_consented_config(home, *, enabled: bool) -> str:
-    aid = "11111111-1111-4111-8111-111111111111"
-    (home / "config.json").write_text(
-        json.dumps(
-            {
-                "telemetry": {
-                    "anonymous_id": aid,
-                    "enabled": enabled,
-                    "consent_version": 1,
-                    "consented_at": "2026-04-30T00:00:00Z",
-                }
-            }
-        )
-    )
-    return aid
 
 
 def test_import_does_not_create_socket():
@@ -76,7 +55,7 @@ def test_should_emit_false_when_enabled_is_none(nauro_home, telemetry_key):
 
 
 def test_should_emit_false_when_enabled_is_false(nauro_home, telemetry_key):
-    _seed_consented_config(nauro_home, enabled=False)
+    seed_consented_config(nauro_home, enabled=False)
 
     from nauro.telemetry import _should_emit
 
@@ -85,7 +64,7 @@ def test_should_emit_false_when_enabled_is_false(nauro_home, telemetry_key):
 
 def test_should_emit_false_when_posthog_key_unset(nauro_home, monkeypatch):
     monkeypatch.delenv("NAURO_POSTHOG_KEY", raising=False)
-    _seed_consented_config(nauro_home, enabled=True)
+    seed_consented_config(nauro_home, enabled=True)
 
     from nauro.telemetry import _should_emit
 
@@ -94,7 +73,7 @@ def test_should_emit_false_when_posthog_key_unset(nauro_home, monkeypatch):
 
 def test_should_emit_true_when_all_conditions_hold(nauro_home, telemetry_key, monkeypatch):
     monkeypatch.delenv("NAURO_TELEMETRY", raising=False)
-    _seed_consented_config(nauro_home, enabled=True)
+    seed_consented_config(nauro_home, enabled=True)
 
     from nauro.telemetry import _should_emit
 
@@ -103,7 +82,7 @@ def test_should_emit_true_when_all_conditions_hold(nauro_home, telemetry_key, mo
 
 def test_should_emit_false_when_env_var_disables(nauro_home, telemetry_key, monkeypatch):
     monkeypatch.setenv("NAURO_TELEMETRY", "0")
-    _seed_consented_config(nauro_home, enabled=True)
+    seed_consented_config(nauro_home, enabled=True)
 
     from nauro.telemetry import _should_emit
 
@@ -149,7 +128,7 @@ def test_strip_reserved_preserves_unrelated_keys():
 
 
 def test_get_distinct_id_returns_anonymous_id(nauro_home):
-    aid = _seed_consented_config(nauro_home, enabled=True)
+    aid = seed_consented_config(nauro_home, enabled=True)
 
     from nauro.telemetry import _get_distinct_id
 

--- a/packages/nauro/tests/test_telemetry_subcommand.py
+++ b/packages/nauro/tests/test_telemetry_subcommand.py
@@ -5,25 +5,11 @@ from __future__ import annotations
 import json
 import re
 import uuid
-from typing import Any
 
 import pytest
 from typer.testing import CliRunner
 
 _UUID4_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$")
-
-
-class FakeClient:
-    def __init__(self) -> None:
-        self.events: list[dict[str, Any]] = []
-
-    def capture(
-        self,
-        event: str,
-        distinct_id: str,
-        properties: dict[str, Any],
-    ) -> None:
-        self.events.append({"event": event, "distinct_id": distinct_id, "properties": properties})
 
 
 @pytest.fixture
@@ -35,21 +21,6 @@ def nauro_home(tmp_path, monkeypatch):
     repo.mkdir()
     monkeypatch.chdir(repo)
     return home
-
-
-@pytest.fixture
-def telemetry_key(monkeypatch):
-    monkeypatch.setenv("NAURO_POSTHOG_KEY", "phc_test_key_for_unit_tests")
-
-
-@pytest.fixture
-def fake_posthog(monkeypatch):
-    import nauro.telemetry.client as client_mod
-
-    fake = FakeClient()
-    client_mod._client = fake
-    yield fake
-    client_mod._client = None
 
 
 def _seed_config(home, *, enabled, consent_version, consented_at, anonymous_id) -> None:


### PR DESCRIPTION
## Why

Six telemetry-adjacent test files had been growing parallel copies of the same
`FakeClient`, magic `TEST_ANONYMOUS_ID` UUID, consent-config seed helper, and
PostHog singleton-swap fixture; the `.mcp.json` writer in `setup.py` was
mirrored by a near-identical `.cursor/mcp.json` writer. Each copy had drifted
slightly (`test_check_command.py`'s `_FakeClient` only recorded `event` +
`properties` and dropped `distinct_id`; cursor's remove branch nested the "no
entry" return inside `if "nauro" in servers`). Hand-mirrored schemas drift,
and the next change touching telemetry events or the MCP entry shape would
have had to chase six call sites.

## Approach

Two surfaces, two extractions:

- **Telemetry test helpers** move to `tests/conftest.py`. Non-fixture pieces
  (`FakeClient`, `TEST_ANONYMOUS_ID`, `seed_consented_config`) are explicit
  imports; `fake_posthog` and `telemetry_key` are auto-discovered fixtures.
  Conftest is the right home rather than a sibling `_helpers.py` because the
  file was 30 lines beforehand and the additions don't bloat it.

- **`_configure_json_mcp(repo_path, *, config_rel_path, label, remove)`**
  absorbs the load → parse → mutate → write shape; `_configure_mcp` and
  `_configure_cursor_for_repo` become thin wrappers that keep their public
  names + signatures (test_setup.py and test_setup_extended.py import them).

Considered and rejected: collapsing the `claude-code` and `cursor` Typer
command bodies into a parameterised helper. They look similar at the top
level but diverge on legacy CLAUDE.md cleanup + AGENTS.md regeneration,
making the parameterized version net-negative on readability.

Also folded in: the demo module's `STATE_CURRENT_MD` constant collides by
name with `templates/scaffolds.STATE_CURRENT_MD` even though they serve
unrelated roles (sample-project content vs empty-state seed). Renamed the
demo one to `DEMO_STATE_CURRENT_MD`; the constant is module-private so the
rename touches only `demo/__init__.py`. Logged as D149 to keep a future
agent from re-proposing collapse.

## What changed

**Phase 1 — shared test fixtures (`tests/conftest.py`, 6 trimmed test files,
new `test_conftest_helpers.py`).** Conftest now exposes `FakeClient`,
`TEST_ANONYMOUS_ID`, `seed_consented_config`, plus the `fake_posthog` and
`telemetry_key` fixtures. `test_cli_command_invoked.py`,
`test_mcp_tool_called.py`, `test_telemetry_subcommand.py`,
`test_telemetry_module.py`, `test_project_created_event.py`, and
`test_check_command.py` drop their local copies and import from conftest.
`test_identity_lifecycle.py` keeps its ordered-tuple `FakeClient` (records
`(method, args)` for alias-then-set ordering assertions) but adopts
`TEST_ANONYMOUS_ID` and the conftest `telemetry_key`. New
`test_conftest_helpers.py` pins the helper contract.

**Phase 2 — JSON MCP writer (`packages/nauro/src/nauro/cli/commands/setup.py`).**
`_configure_json_mcp` is the new shared body; `_configure_mcp` and
`_configure_cursor_for_repo` are now four-line wrappers that pin
`config_rel_path` + `label`. Public names + signatures unchanged. The shared
helper does `parent.mkdir(parents=True, exist_ok=True)` for the write path,
which is a no-op when the parent is the repo root (matches the previous
`.mcp.json` behaviour) and replaces the explicit `cursor_dir.mkdir(...)`
that was in `_configure_cursor_for_repo`.

**Phase 3 — demo constant rename (`packages/nauro/src/nauro/demo/__init__.py`).**
`STATE_CURRENT_MD` → `DEMO_STATE_CURRENT_MD`, plus the two call sites in
the same module.

## What to review

- Does the `from tests.conftest import ...` pattern read cleanly at import
  sites, or would a sibling `_helpers.py` have been less surprising? The
  test directory already uses `from tests._skill_surfaces import ...` so the
  pattern is established here.
- The `_configure_json_mcp(repo_path, *, config_rel_path, label, remove)`
  signature: `config_rel_path` and `label` happen to be the same string in
  both wrappers, but I kept them separate per the planned signature so the
  status message can diverge from the relative path if a third surface
  reuses the helper.
- The `DEMO_STATE_CURRENT_MD` rename touches only `demo/__init__.py` — the
  grep audit confirmed nothing else imports the demo-side constant.
  D149 documents the naming convention.
- `test_identity_lifecycle.py` defines its own `fake_posthog` fixture at
  module scope that shadows the conftest fixture of the same name (pytest's
  nearest-scope rule handles it). Intentional: the shadowing fixture binds
  to the local ordered-tuple `FakeClient` variant required by alias-then-set
  ordering assertions.

## What's deferred

- Consolidating the `claude-code` and `cursor` Typer command bodies (the
  divergence on legacy CLAUDE.md cleanup + AGENTS.md regeneration makes a
  parameterised helper net-negative).
- Migrating `test_identity_lifecycle.py`'s ordered-tuple `FakeClient` into a
  shared spec — its `(method, args)` recording semantics serve assertions
  about call ordering that the capture-only `FakeClient` cannot.

## Test plan

- `uv run pytest packages/nauro/tests/` — 942 passing (936 before + 6 new in
  `test_conftest_helpers.py`).
- `uv run pytest packages/nauro-core/tests/` — 306 passing, unchanged.
- `uv run ruff check packages/` — clean.
- `uv run ruff format --check packages/` — clean.
- All five telemetry test files plus `test_check_command.py`,
  `test_setup.py`, and `test_setup_extended.py` exercised individually to
  confirm no order-dependent breakage from the fixture moves.

Refs: D149