### PR TITLE
chore: clear ruff B/SIM/RUF backlog (mechanical sweep)

### DIFF
--- a/packages/nauro-core/src/nauro_core/parsing.py
+++ b/packages/nauro-core/src/nauro_core/parsing.py
@@ -84,7 +84,7 @@ def extract_stack_summary(stack_content: str) -> str:
         stripped = line.strip()
         if stripped.startswith("# ") or stripped.startswith("<!--"):
             continue
-        if stripped.startswith("- ") and not line.startswith("  ") or stripped.startswith("## "):
+        if (stripped.startswith("- ") and not line.startswith("  ")) or stripped.startswith("## "):
             lines.append(stripped)
     return "\n".join(lines)
 

--- a/packages/nauro-core/src/nauro_core/validation.py
+++ b/packages/nauro-core/src/nauro_core/validation.py
@@ -35,7 +35,7 @@ TIER2_TOP_K = 5
 # positives are added, not a speculative blanket of generic verbs. Add
 # more only when a concrete failure case justifies it, and add a test to
 # lock the case in.
-TIER2_STOPWORDS = list(STOPWORDS_EN) + ["use"]
+TIER2_STOPWORDS = [*list(STOPWORDS_EN), "use"]
 
 # The scaffold-seeded "Initial project setup" decision is Nauro's own
 # bookkeeping — it records that the store was initialized, not a choice the

--- a/packages/nauro-core/tests/test_validation.py
+++ b/packages/nauro-core/tests/test_validation.py
@@ -221,13 +221,13 @@ class TestScreenStructural:
     def test_title_dedup_case_insensitive(self):
         proposal = self._proposal()
         recent = [{"title": "use fastapi for mcp server", "num": 42}]
-        action, reason = screen_structural(proposal, set(), recent)
+        action, _reason = screen_structural(proposal, set(), recent)
         assert action == "reject"
 
     def test_default_confidence_accepted(self):
         proposal = self._proposal()
         del proposal["confidence"]
-        action, reason = screen_structural(proposal, set(), [])
+        action, _reason = screen_structural(proposal, set(), [])
         assert action == "pass"
 
     def test_none_title(self):

--- a/packages/nauro/src/nauro/cli/commands/adopt.py
+++ b/packages/nauro/src/nauro/cli/commands/adopt.py
@@ -107,13 +107,14 @@ def _check_collision(name: str, repo_root: Path) -> str | None:
     return None
 
 
+_Opt_repo = typer.Option(None, "--repo", help="Repo root (default: current working directory).")
+
+
 def adopt(
     name: str | None = typer.Option(
         None, "--name", help="Project name (default: repo directory basename)."
     ),
-    repo: Path | None = typer.Option(
-        None, "--repo", help="Repo root (default: current working directory)."
-    ),
+    repo: Path | None = _Opt_repo,
     print_prompt: bool = typer.Option(
         False,
         "--print-prompt",

--- a/packages/nauro/src/nauro/cli/commands/attach.py
+++ b/packages/nauro/src/nauro/cli/commands/attach.py
@@ -25,14 +25,16 @@ from nauro.store.registry import (
 from nauro.store.repo_config import save_repo_config
 from nauro.sync.cloud_projects import CloudProjectError, list_projects
 
+_Opt_repo_path = typer.Option(
+    None,
+    "--repo",
+    help="Repo directory to attach. Defaults to cwd.",
+)
+
 
 def attach(
     project_id: str = typer.Argument(..., help="Cloud project_id (ULID)."),
-    repo_path: Path | None = typer.Option(
-        None,
-        "--repo",
-        help="Repo directory to attach. Defaults to cwd.",
-    ),
+    repo_path: Path | None = _Opt_repo_path,
 ) -> None:
     """Attach the current repo to an existing cloud project."""
     repo_path = repo_path if repo_path is not None else Path.cwd()
@@ -40,7 +42,7 @@ def attach(
         projects = list_projects()
     except CloudProjectError as exc:
         typer.echo(f"Error: {exc}", err=True)
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=1) from exc
 
     match = next((p for p in projects if p["project_id"] == project_id), None)
     if match is None:

--- a/packages/nauro/src/nauro/cli/commands/auth.py
+++ b/packages/nauro/src/nauro/cli/commands/auth.py
@@ -238,7 +238,7 @@ class _CallbackHandler(BaseHTTPRequestHandler):
         html = f"<html><body><h2>{message}</h2></body></html>"
         self.wfile.write(html.encode())
 
-    def log_message(self, format, *args):  # noqa: A002
+    def log_message(self, format, *args):
         """Suppress default stderr logging."""
         pass
 
@@ -317,7 +317,7 @@ def login() -> None:
         token_resp.raise_for_status()
     except httpx.HTTPError as exc:
         typer.echo(f"Token exchange failed: {exc}", err=True)
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=1) from exc
 
     body = token_resp.json()
 
@@ -335,7 +335,7 @@ def login() -> None:
         sub = payload["sub"]
     except (ValueError, KeyError) as exc:
         typer.echo(f"Failed to decode access token: {exc}", err=True)
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=1) from exc
 
     sanitized_sub = _sanitize_sub(sub)
 
@@ -380,10 +380,7 @@ def login() -> None:
             or me_body.get("email")
             or ""
         )
-        if isinstance(email_raw, str):
-            email = email_raw.strip().lower()
-        else:
-            email = ""
+        email = email_raw.strip().lower() if isinstance(email_raw, str) else ""
         if user_id and email:
             from nauro.telemetry import identify_login as _telemetry_identify_login
 

--- a/packages/nauro/src/nauro/cli/commands/diff.py
+++ b/packages/nauro/src/nauro/cli/commands/diff.py
@@ -43,7 +43,7 @@ def diff(
     Two arguments: diff between the two specified versions.
     --since Nd: diff between the nearest snapshot to N days ago and the latest.
     """
-    project_name, store_path = resolve_target_project(project)
+    _project_name, store_path = resolve_target_project(project)
 
     if since is not None:
         days = _parse_since(since)
@@ -71,7 +71,7 @@ def diff(
             result = diff_snapshots(store_path, version_a, latest)
         except FileNotFoundError as e:
             typer.echo(f"Error: {e}", err=True)
-            raise typer.Exit(code=1)
+            raise typer.Exit(code=1) from e
         typer.echo(result)
         return
 
@@ -80,5 +80,5 @@ def diff(
         result = diff_snapshots(store_path, version_a, version_b)
     except FileNotFoundError as e:
         typer.echo(str(e), err=True)
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=1) from e
     typer.echo(result)

--- a/packages/nauro/src/nauro/cli/commands/import_cmd.py
+++ b/packages/nauro/src/nauro/cli/commands/import_cmd.py
@@ -301,10 +301,7 @@ def _extract_section(content: str, heading: str) -> str | None:
     start = m.end()
     # Find next ## heading or end of content
     next_heading = re.search(r"^##\s+", content[start:], re.MULTILINE)
-    if next_heading:
-        body = content[start : start + next_heading.start()]
-    else:
-        body = content[start:]
+    body = content[start : start + next_heading.start()] if next_heading else content[start:]
 
     body = body.strip()
     return body if body else None
@@ -337,13 +334,15 @@ def _import_progress(content: str) -> list[str]:
     return items
 
 
+_Opt_memory_bank = typer.Option(
+    None, "--memory-bank", help="Path to a Cline/Roo Code Memory Bank (.context/ directory)."
+)
+_Opt_adr = typer.Option(None, "--adr", help="Path to an Architecture Decision Records directory.")
+
+
 def import_cmd(
-    memory_bank: Path | None = typer.Option(
-        None, "--memory-bank", help="Path to a Cline/Roo Code Memory Bank (.context/ directory)."
-    ),
-    adr: Path | None = typer.Option(
-        None, "--adr", help="Path to an Architecture Decision Records directory."
-    ),
+    memory_bank: Path | None = _Opt_memory_bank,
+    adr: Path | None = _Opt_adr,
     project: str | None = typer.Option(
         None,
         "--project",

--- a/packages/nauro/src/nauro/cli/commands/init.py
+++ b/packages/nauro/src/nauro/cli/commands/init.py
@@ -103,13 +103,16 @@ def _check_config_overwrite(
     raise typer.Exit(code=1)
 
 
+_Opt_add_repo_paths = typer.Option(
+    None,
+    "--add-repo",
+    help="Repo directory to associate (can be repeated). Defaults to cwd.",
+)
+
+
 def init(
     name: str = typer.Argument(default="demo-project", help="Project name."),
-    add_repo_paths: list[Path] | None = typer.Option(
-        None,
-        "--add-repo",
-        help="Repo directory to associate (can be repeated). Defaults to cwd.",
-    ),
+    add_repo_paths: list[Path] | None = _Opt_add_repo_paths,
     demo: bool = typer.Option(
         False,
         "--demo",
@@ -210,7 +213,7 @@ def init(
             view = create_project(name)
         except CloudProjectError as exc:
             typer.echo(f"Error: {exc}", err=True)
-            raise typer.Exit(code=1)
+            raise typer.Exit(code=1) from exc
         try:
             pid, store_path = register_project_v2(
                 name,
@@ -221,7 +224,7 @@ def init(
             )
         except ValueError as exc:
             typer.echo(f"Error: {exc}", err=True)
-            raise typer.Exit(code=1)
+            raise typer.Exit(code=1) from exc
         capture("project.created", project_created(REGISTRY_SCHEMA_VERSION_V2))
         for rp in repo_paths:
             save_repo_config(
@@ -251,7 +254,7 @@ def init(
         )
     except ValueError as exc:
         typer.echo(f"Error: {exc}", err=True)
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=1) from exc
     capture("project.created", project_created(REGISTRY_SCHEMA_VERSION_V2))
     for rp in repo_paths:
         save_repo_config(

--- a/packages/nauro/src/nauro/cli/commands/link.py
+++ b/packages/nauro/src/nauro/cli/commands/link.py
@@ -61,7 +61,7 @@ def link(
         cfg = load_repo_config(repo_root)
     except RepoConfigSchemaError as exc:
         typer.echo(f"Error: {exc}", err=True)
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=1) from exc
 
     if cfg.get("mode") != REPO_CONFIG_MODE_LOCAL:
         typer.echo(
@@ -95,7 +95,7 @@ def link(
         view = create_project(name)
     except CloudProjectError as exc:
         typer.echo(f"Error: {exc}", err=True)
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=1) from exc
     cloud_id = view["project_id"]
 
     try:
@@ -107,7 +107,7 @@ def link(
         )
     except (KeyError, ValueError) as exc:
         typer.echo(f"Error: {exc}", err=True)
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=1) from exc
 
     save_repo_config(
         repo_root,

--- a/packages/nauro/src/nauro/cli/commands/log.py
+++ b/packages/nauro/src/nauro/cli/commands/log.py
@@ -33,7 +33,7 @@ def log(
     ),
 ) -> None:
     """List recent snapshots with version, timestamp, trigger, and change summary."""
-    project_name, store_path = resolve_target_project(project)
+    _project_name, store_path = resolve_target_project(project)
 
     if decisions:
         _show_decisions(store_path, show_all=all_decisions)

--- a/packages/nauro/src/nauro/cli/commands/status.py
+++ b/packages/nauro/src/nauro/cli/commands/status.py
@@ -60,9 +60,9 @@ def status(
     """Show which Nauro capabilities are active or inactive."""
     try:
         project_name, store_path = resolve_target_project(project)
-    except SystemExit:
+    except SystemExit as exc:
         typer.echo("No project found. Run 'nauro init <name>' to get started.", err=True)
-        raise typer.Exit(1)
+        raise typer.Exit(1) from exc
 
     typer.echo(f"Project: {project_name}\n")
 

--- a/packages/nauro/src/nauro/mcp/server.py
+++ b/packages/nauro/src/nauro/mcp/server.py
@@ -119,9 +119,9 @@ def _resolve_store(project_id: str | None, cwd: str | None) -> Path:
     try:
         return resolve_store(project_id, cwd)
     except (NoProjectError, ProjectNotFoundError, StoreMissingError) as exc:
-        raise HTTPException(status_code=404, detail=str(exc))
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
     except (ProjectIdMismatchError, MultipleProjectsError) as exc:
-        raise HTTPException(status_code=400, detail=str(exc))
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 # --- MCP tool endpoints ---
@@ -140,7 +140,7 @@ async def get_context(req: ContextRequest) -> dict:
     try:
         payload = tool_get_context(store_path, req.level)
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=400, detail=str(e)) from e
     return {"level": req.level, "content": payload}
 
 

--- a/packages/nauro/src/nauro/skills/__init__.py
+++ b/packages/nauro/src/nauro/skills/__init__.py
@@ -89,7 +89,7 @@ def _frontmatter(surface: str, skill_name: str) -> str:
     if skill_name not in SKILL_DESCRIPTIONS:
         raise ValueError(f"unknown skill: {skill_name!r}")
     description = SKILL_DESCRIPTIONS[skill_name]
-    if surface == "claude_code" or surface == "codex":
+    if surface in ("claude_code", "codex"):
         return f"---\nname: {skill_name}\ndescription: {description}\n---\n\n"
     if surface == "cursor":
         return f"---\ndescription: {description}\nalwaysApply: false\n---\n\n"
@@ -108,8 +108,8 @@ def render_skill(surface: str, skill_name: str) -> str:
 
 __all__ = [
     "SKILL_DESCRIPTIONS",
-    "Surface",
     "SkillName",
+    "Surface",
     "load_adopt_body",
     "load_session_body",
     "render_skill",

--- a/packages/nauro/src/nauro/store/repo_config.py
+++ b/packages/nauro/src/nauro/store/repo_config.py
@@ -82,11 +82,12 @@ def _validate(data: dict) -> None:
     if not isinstance(data.get("name"), str) or not data["name"]:
         raise RepoConfigSchemaError("Repo config is missing required field 'name'.")
 
-    if mode == REPO_CONFIG_MODE_CLOUD:
-        if not isinstance(data.get("server_url"), str) or not data["server_url"]:
-            raise RepoConfigSchemaError(
-                "Cloud-mode repo config is missing required field 'server_url'."
-            )
+    if mode == REPO_CONFIG_MODE_CLOUD and (
+        not isinstance(data.get("server_url"), str) or not data["server_url"]
+    ):
+        raise RepoConfigSchemaError(
+            "Cloud-mode repo config is missing required field 'server_url'."
+        )
 
 
 def load_repo_config(repo_root: Path) -> dict:

--- a/packages/nauro/src/nauro/store/snapshot.py
+++ b/packages/nauro/src/nauro/store/snapshot.py
@@ -209,13 +209,10 @@ def find_snapshot_near_date(store_path: Path, target: datetime) -> dict | None:
 
     all_snaps.sort(key=lambda s: s["datetime"])
 
-    # Find the most recent snapshot at or before the target
+    # Most recent snapshot at or before the target; falls back to the
+    # oldest snapshot when none predate the target.
     candidates = [s for s in all_snaps if s["datetime"] <= target]
-    if candidates:
-        best = candidates[-1]  # most recent one at or before target
-    else:
-        # No snapshot old enough — return the oldest available
-        best = all_snaps[0]
+    best = candidates[-1] if candidates else all_snaps[0]
 
     return {"version": best["version"], "timestamp": best["timestamp"]}
 

--- a/packages/nauro/src/nauro/store/writer.py
+++ b/packages/nauro/src/nauro/store/writer.py
@@ -257,10 +257,7 @@ def append_question(store_path: Path, question: str) -> None:
     timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
     entry = f"- [{timestamp}] {question}\n"
 
-    if oq_path.exists():
-        content = oq_path.read_text()
-    else:
-        content = "# Open Questions\n"
+    content = oq_path.read_text() if oq_path.exists() else "# Open Questions\n"
 
     lines = content.split("\n")
     insert_idx = 1

--- a/packages/nauro/src/nauro/sync/cloud_projects.py
+++ b/packages/nauro/src/nauro/sync/cloud_projects.py
@@ -168,10 +168,7 @@ def list_projects() -> list[ProjectView]:
             f"Server returned non-JSON for GET /projects: {response.text!r}"
         ) from exc
 
-    if isinstance(payload, dict) and "projects" in payload:
-        items = payload["projects"]
-    else:
-        items = payload
+    items = payload["projects"] if isinstance(payload, dict) and "projects" in payload else payload
 
     if not isinstance(items, list):
         raise CloudProjectError(f"Unexpected /projects response shape (not a list): {items!r}")

--- a/packages/nauro/src/nauro/telemetry/__init__.py
+++ b/packages/nauro/src/nauro/telemetry/__init__.py
@@ -31,9 +31,7 @@ def _should_emit() -> bool:
     if _resolve_project_key() is None:
         return False
     cfg = get_telemetry_config()
-    if cfg.enabled is not True:
-        return False
-    return True
+    return cfg.enabled is True
 
 
 def _get_distinct_id() -> str:

--- a/packages/nauro/src/nauro/telemetry/cli_wrapper.py
+++ b/packages/nauro/src/nauro/telemetry/cli_wrapper.py
@@ -10,6 +10,7 @@ command modules stay free of telemetry imports.
 
 from __future__ import annotations
 
+import contextlib
 import functools
 import platform
 import time
@@ -60,7 +61,7 @@ def instrument(func: Callable[..., Any], *, command_path: str) -> Callable[..., 
             success = False
             raise
         finally:
-            try:
+            with contextlib.suppress(Exception):
                 capture(
                     "cli.command_invoked",
                     cli_command_invoked(
@@ -71,8 +72,6 @@ def instrument(func: Callable[..., Any], *, command_path: str) -> Callable[..., 
                         os_name=_OS,
                     ),
                 )
-            except Exception:
-                pass
 
     wrapper._nauro_instrumented = True  # type: ignore[attr-defined]
     return wrapper

--- a/packages/nauro/src/nauro/telemetry/decorators.py
+++ b/packages/nauro/src/nauro/telemetry/decorators.py
@@ -10,6 +10,7 @@ hardcoded — because the same decorated function services all transports.
 
 from __future__ import annotations
 
+import contextlib
 import functools
 import time
 from collections.abc import Callable
@@ -39,7 +40,7 @@ def mcp_tool(name: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
                 success = False
                 raise
             finally:
-                try:
+                with contextlib.suppress(Exception):
                     capture(
                         "mcp.tool_called",
                         mcp_tool_called(
@@ -49,8 +50,6 @@ def mcp_tool(name: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
                             duration_bucket=bucket(time.perf_counter() - start),
                         ),
                     )
-                except Exception:
-                    pass
 
         return wrapper
 

--- a/packages/nauro/tests/test_auth_refresh.py
+++ b/packages/nauro/tests/test_auth_refresh.py
@@ -98,9 +98,11 @@ class TestRefreshAccessToken:
             400,
             {"error": "invalid_grant", "error_description": "refresh token expired"},
         )
-        with patch("nauro.cli.commands.auth.httpx.post", return_value=bad):
-            with pytest.raises(AuthRefreshError):
-                refresh_access_token()
+        with (
+            patch("nauro.cli.commands.auth.httpx.post", return_value=bad),
+            pytest.raises(AuthRefreshError),
+        ):
+            refresh_access_token()
 
         auth = load_config()["auth"]
         # Both tokens must survive a failed refresh — the user might retry.
@@ -110,12 +112,14 @@ class TestRefreshAccessToken:
     def test_refresh_network_error_leaves_tokens_intact(self):
         _seed_auth(refresh_token="refresh_orig", access_token="access_orig")
 
-        with patch(
-            "nauro.cli.commands.auth.httpx.post",
-            side_effect=httpx.ConnectError("dns failure"),
+        with (
+            patch(
+                "nauro.cli.commands.auth.httpx.post",
+                side_effect=httpx.ConnectError("dns failure"),
+            ),
+            pytest.raises(AuthRefreshError),
         ):
-            with pytest.raises(AuthRefreshError):
-                refresh_access_token()
+            refresh_access_token()
 
         auth = load_config()["auth"]
         assert auth["access_token"] == "access_orig"
@@ -174,9 +178,11 @@ class TestWithTokenRefresh:
         call = MagicMock(return_value=unauthorized)
 
         bad_refresh = _mock_post(400, {"error": "invalid_grant"})
-        with patch("nauro.cli.commands.auth.httpx.post", return_value=bad_refresh):
-            with pytest.raises(AuthRefreshError):
-                with_token_refresh(call)
+        with (
+            patch("nauro.cli.commands.auth.httpx.post", return_value=bad_refresh),
+            pytest.raises(AuthRefreshError),
+        ):
+            with_token_refresh(call)
 
         # Stored tokens preserved despite the failed refresh attempt.
         auth = load_config()["auth"]

--- a/packages/nauro/tests/test_cloud_projects.py
+++ b/packages/nauro/tests/test_cloud_projects.py
@@ -79,9 +79,8 @@ def test_create_project_401_without_refresh_token_raises_auth_login_hint(tmp_pat
     def handler(method, url, **kwargs):
         return httpx.Response(401, json={"detail": "expired"}, request=httpx.Request(method, url))
 
-    with _stub_request(handler):
-        with pytest.raises(CloudProjectError) as exc:
-            create_project("demo")
+    with _stub_request(handler), pytest.raises(CloudProjectError) as exc:
+        create_project("demo")
     msg = str(exc.value)
     assert "Authentication failed" in msg
     assert "nauro auth login" in msg
@@ -130,9 +129,11 @@ def test_create_project_stale_token_refreshed_transparently(tmp_path, monkeypatc
     auth0_response.status_code = 200
     auth0_response.json.return_value = {"access_token": "fresh"}
 
-    with _stub_request(handler):
-        with patch("nauro.cli.commands.auth.httpx.post", return_value=auth0_response):
-            view = create_project("demo")
+    with (
+        _stub_request(handler),
+        patch("nauro.cli.commands.auth.httpx.post", return_value=auth0_response),
+    ):
+        view = create_project("demo")
 
     assert view["project_id"] == "01KQ6AZGNA0B3QBF67NBXP3S45"
     assert len(calls) == 2
@@ -163,10 +164,12 @@ def test_create_project_persistent_401_after_refresh_raises_distinct_message(tmp
     auth0_response.status_code = 200
     auth0_response.json.return_value = {"access_token": "fresh"}
 
-    with _stub_request(handler):
-        with patch("nauro.cli.commands.auth.httpx.post", return_value=auth0_response):
-            with pytest.raises(CloudProjectError) as exc:
-                create_project("demo")
+    with (
+        _stub_request(handler),
+        patch("nauro.cli.commands.auth.httpx.post", return_value=auth0_response),
+        pytest.raises(CloudProjectError) as exc,
+    ):
+        create_project("demo")
 
     msg = str(exc.value)
     assert "401" in msg
@@ -184,9 +187,8 @@ def test_create_project_403_renders_forbidden_message(tmp_path, monkeypatch):
     def handler(method, url, **kwargs):
         return httpx.Response(403, json={"detail": "no access"}, request=httpx.Request(method, url))
 
-    with _stub_request(handler):
-        with pytest.raises(CloudProjectError) as exc:
-            create_project("demo")
+    with _stub_request(handler), pytest.raises(CloudProjectError) as exc:
+        create_project("demo")
     msg = str(exc.value)
     assert "403" in msg
     assert "Forbidden" in msg
@@ -201,9 +203,8 @@ def test_create_project_server_error_renders_message(tmp_path, monkeypatch):
     def handler(method, url, **kwargs):
         return httpx.Response(503, request=httpx.Request(method, url))
 
-    with _stub_request(handler):
-        with pytest.raises(CloudProjectError) as exc:
-            create_project("demo")
+    with _stub_request(handler), pytest.raises(CloudProjectError) as exc:
+        create_project("demo")
     assert "503" in str(exc.value)
 
 
@@ -215,9 +216,8 @@ def test_create_project_network_error_renders_message(tmp_path, monkeypatch):
     def handler(method, url, **kwargs):
         raise httpx.ConnectError("dns failure")
 
-    with _stub_request(handler):
-        with pytest.raises(CloudProjectError) as exc:
-            create_project("demo")
+    with _stub_request(handler), pytest.raises(CloudProjectError) as exc:
+        create_project("demo")
     assert "Network error" in str(exc.value)
 
 
@@ -339,7 +339,6 @@ def test_malformed_project_payload_raises(tmp_path, monkeypatch):
             request=httpx.Request(method, url),
         )
 
-    with _stub_request(handler):
-        with pytest.raises(CloudProjectError) as exc:
-            create_project("demo")
+    with _stub_request(handler), pytest.raises(CloudProjectError) as exc:
+        create_project("demo")
     assert "missing required field" in str(exc.value)

--- a/packages/nauro/tests/test_resolution_v2.py
+++ b/packages/nauro/tests/test_resolution_v2.py
@@ -87,7 +87,7 @@ def test_explicit_project_flag_overrides_repo_config(tmp_path, monkeypatch):
 
     Existing test_cli.py expectation; pinned here against the v2 path.
     """
-    cloud_pid, repo_root = _post_migration_state(tmp_path, monkeypatch)
+    _cloud_pid, repo_root = _post_migration_state(tmp_path, monkeypatch)
     other_pid, _store = registry.register_project_v2(
         "beta",
         [tmp_path / "beta_repo"],
@@ -112,7 +112,7 @@ def test_stdio_resolve_uses_repo_config_when_no_project_passed(tmp_path, monkeyp
 
 def test_stdio_resolve_mismatched_project_id_errors(tmp_path, monkeypatch):
     """When supplied project_id != repo config id, raise rather than silently swap."""
-    cloud_pid, repo_root = _post_migration_state(tmp_path, monkeypatch)
+    _cloud_pid, repo_root = _post_migration_state(tmp_path, monkeypatch)
     monkeypatch.chdir(repo_root)
     with pytest.raises(ValueError, match="does not match"):
         _resolve_store("01KZZZZZZZZZZZZZZZZZZZZZZZ", str(repo_root))

--- a/packages/nauro/tests/test_setup_extended.py
+++ b/packages/nauro/tests/test_setup_extended.py
@@ -32,7 +32,7 @@ def test_setup_cursor_writes_repo_mcp_json(tmp_path: Path, monkeypatch):
     """`nauro setup cursor` writes <repo>/.cursor/mcp.json for each project repo."""
     repo = tmp_path / "myrepo"
     repo.mkdir()
-    pid, store_path = register_project_v2("myproj", [repo])
+    _pid, store_path = register_project_v2("myproj", [repo])
     scaffold_project_store("myproj", store_path)
     monkeypatch.chdir(repo)
 

--- a/packages/nauro/tests/test_store.py
+++ b/packages/nauro/tests/test_store.py
@@ -571,7 +571,7 @@ def test_reader_roundtrip_new_format(store: Path):
         source="commit",
     )
     decisions = _list_decisions(store)
-    d = [d for d in decisions if d.title == "Switch to WebSocket"][0]
+    d = next(d for d in decisions if d.title == "Switch to WebSocket")
     assert d.confidence.value == "high"
     assert d.decision_type is not None
     assert d.decision_type.value == "api_design"

--- a/packages/nauro/tests/test_validation/test_tier1.py
+++ b/packages/nauro/tests/test_validation/test_tier1.py
@@ -28,7 +28,7 @@ class TestSchemaValidation:
 
     def test_rejects_missing_title(self, store):
         proposal = {"rationale": "Some valid rationale here."}
-        action, reason = screen_structural(proposal, store)
+        action, _reason = screen_structural(proposal, store)
         assert action == "reject"
 
     def test_rejects_empty_rationale(self, store):
@@ -70,7 +70,7 @@ class TestMinimumContent:
             "title": "Use Redis",
             "rationale": "Fast in-memory cache with pub/sub support for our needs.",
         }
-        action, reason = screen_structural(proposal, store)
+        action, _reason = screen_structural(proposal, store)
         assert action == "pass"
 
 
@@ -94,7 +94,7 @@ class TestHashDedup:
             "title": "Use Redis",
             "rationale": "For caching and pub/sub functionality.",
         }
-        action, reason = screen_structural(proposal, store)
+        action, _reason = screen_structural(proposal, store)
         assert action == "pass"
 
     def test_case_insensitive_hash(self, store):
@@ -104,7 +104,7 @@ class TestHashDedup:
             "title": "use postgres",
             "rationale": "better json support.",
         }
-        action, reason = screen_structural(proposal, store)
+        action, _reason = screen_structural(proposal, store)
         assert action == "reject"
 
 
@@ -132,5 +132,5 @@ class TestTemporalDuplicate:
             "title": "Use Redis for Caching",
             "rationale": "Fast in-memory store for session data.",
         }
-        action, reason = screen_structural(proposal, store)
+        action, _reason = screen_structural(proposal, store)
         assert action == "pass"

--- a/packages/nauro/tests/test_validation/test_tier2.py
+++ b/packages/nauro/tests/test_validation/test_tier2.py
@@ -55,7 +55,7 @@ class TestCheckSimilarity:
             "title": "Add dark mode to the UI",
             "rationale": "Users requested a dark theme for reduced eye strain.",
         }
-        action, similar = check_similarity(proposal, store)
+        action, _similar = check_similarity(proposal, store)
         assert action == "auto_confirm"
 
     def test_vocabulary_mismatch_detected(self, store):


### PR DESCRIPTION
## Why

Three months of low-priority ruff hits had accumulated to ~80 findings
in the B/SIM/RUF/C buckets. None individually warranted a PR but the
volume was crowding out real signal — judgment-call sites that need
design discussion were lost in a wall of mechanical noise.

This PR clears the autofix-shaped layer so the next round can focus on
the few sites that actually need a call: the webbrowser exception
swallow in `auth.py`, the `login`/`parse` complexity, and the larger
C901 hits in `sync.py` / `hooks.py` / `setup.py` that need real splits.

## Approach

Strictly mechanical. Rules grouped by safety:

- Pure autofixes via `ruff --fix` (RUF021/022/100, SIM108/117 etc.)
- Unsafe autofixes scoped per-rule and per-file: SIM105 applied only
  to the two telemetry `try/except/pass` sites; `auth.py:286` left
  alone because the webbrowser swallow is a judgment call about
  cross-platform behavior, not boilerplate.
- Hand edits for B904 (`raise ... from exc`), B008 (`typer.Option`
  defaults lifted to module-level singletons), and a few SIM117
  nested-with combinations needing tuple-paren context.

`typer.Option` defaults are lifted as `_Opt_<name>` singletons above
each command rather than inlined; this preserves Typer's introspection
(verified `--add-repo` still resolves as a repeatable `list[Path]`)
and matches ruff's B008 hint. Tests use `CliRunner`, never positional
construction — confirmed via grep.

## What changed

- **B904 chain semantics:** 15 `raise ... from exc` updates across
  CLI commands (`attach`, `auth`, `diff`, `init`, `link`, `status`)
  and `mcp/server.py`. Adds context to `__cause__`; no behavior
  change.
- **B008 typer.Option defaults:** module-level `_Opt_*` singletons in
  `adopt`, `attach`, `import_cmd`, `init`.
- **SIM105:** two telemetry `try/except/pass` blocks → `contextlib
  .suppress(Exception)`. `auth.py:286` deliberately skipped.
- **SIM108/SIM117/SIM102/SIM103:** ternary collapses, nested-with
  combinations, single-if compaction across `auth`, `cloud_projects`,
  `store/writer`, `store/snapshot`, `repo_config`, `telemetry`, plus
  test files.
- **RUF005/015/021/022/059/100:** list-spread, `next(iter(...))`,
  precedence parens, `__all__` sort, `_reason` / `_similar` / `_pid`
  unused-unpack renames, unused-noqa removals.
- **Stylistic:** `surface == "claude_code" or surface == "codex"` →
  `surface in (...)` in `skills/__init__.py`.

## What to review

- `_Opt_<name>` singleton placement in `init.py` / `import_cmd.py` /
  `adopt.py` / `attach.py` for readability.
- SIM117 hand-edits in `test_auth_refresh.py` / `test_cloud_projects
  .py` — combined `patch` / `pytest.raises` blocks.
- `parsing.py:87` RUF021 — `(a and not b) or c` now explicit, matches
  prior precedence.

## What's deferred

Bucket C (judgment calls, follow-up PR):
- `auth.py:286` webbrowser swallow — needs a decision on whether to
  surface `webbrowser.Error` to the user.
- `auth.py:247` `login` C901 (12 > 10).
- `nauro-core/questions.py:98` `OpenQuestionsFile.parse` C901 (11 > 10).

C901 hits awaiting real refactors (out of scope here): the top
offenders are `sync/hooks.py::pull_before_session` (23),
`store/validator.py::validate_store` (21),
`sync/_pull_via_presign` (20), `cli/commands/init.py::init` (19),
`store/resolution.py::resolve_store` (17), plus 8 smaller hits
(11–15) — to be addressed in a real refactor pass.

## Test plan

- `uv run ruff check packages/` — clean
- `uv run ruff format --check packages/` — clean
- `uv run pytest packages/nauro-core/tests/ -x -q` — 306 passed
- `uv run pytest packages/nauro/tests/ -x -q` — 942 passed

`raise ... from` is a pure `__cause__` metadata change; verified no
test inspects `__cause__` / `__context__`.