### PR TITLE
refactor: extract auth callback flow and questions header helpers

### DIFF
--- a/packages/nauro-core/src/nauro_core/questions.py
+++ b/packages/nauro-core/src/nauro_core/questions.py
@@ -98,15 +98,8 @@ class OpenQuestionsFile(BaseModel):
     def parse(cls, content: str) -> OpenQuestionsFile:
         """Parse ``open-questions.md`` content into an :class:`OpenQuestionsFile`."""
         lines = content.split("\n")
-        i = 0
         n = len(lines)
-
-        while i < n and not lines[i].strip():
-            i += 1
-        header = _DEFAULT_HEADER
-        if i < n and lines[i].startswith("# ") and not lines[i].startswith("## "):
-            header = lines[i].rstrip()
-            i += 1
+        header, i = _parse_header(lines, 0)
 
         intro: list[str] = []
         entries: list[QuestionEntry] = []
@@ -210,6 +203,22 @@ class OpenQuestionsFile(BaseModel):
             moved_ids=tuple(moved),
             unknown_ids=tuple(unknown),
         )
+
+
+def _parse_header(lines: list[str], i: int) -> tuple[str, int]:
+    """Skip leading blanks and capture the file-level ``# `` header if present.
+
+    Returns ``(header, next_i)``. The ``startswith("# ")`` / not-``startswith("## ")``
+    guard distinguishes the file header from section markers like ``## Resolved``.
+    """
+    n = len(lines)
+    while i < n and not lines[i].strip():
+        i += 1
+    header = _DEFAULT_HEADER
+    if i < n and lines[i].startswith("# ") and not lines[i].startswith("## "):
+        header = lines[i].rstrip()
+        i += 1
+    return header, i
 
 
 def _parse_entry(

--- a/packages/nauro/src/nauro/cli/commands/auth.py
+++ b/packages/nauro/src/nauro/cli/commands/auth.py
@@ -8,6 +8,7 @@ stored in ~/.nauro/config.json under the "auth" key.
 from __future__ import annotations
 
 import base64
+import contextlib
 import hashlib
 import json
 import logging
@@ -243,56 +244,50 @@ class _CallbackHandler(BaseHTTPRequestHandler):
         pass
 
 
-@auth_app.command()
-def login() -> None:
-    """Authenticate with Auth0 using Authorization Code + PKCE."""
-    try:
-        domain, client_id, api_url, audience = _resolve_auth_config(os.environ, load_config())
-    except PartialAuthConfigError as exc:
-        typer.echo(str(exc), err=True)
-        raise typer.Exit(code=1) from exc
+def _run_callback_flow(domain: str, client_id: str, audience: str) -> tuple[str, str]:
+    """Drive the browser-based Auth0 callback flow and return ``(auth_code, code_verifier)``.
 
+    Generates PKCE material, starts a localhost server to receive the redirect,
+    opens the browser, and waits up to 120 seconds for Auth0 to deliver an
+    authorization code. The local server is always closed before returning,
+    even on the timeout/error paths.
+    """
     code_verifier, code_challenge = _generate_pkce()
     state = secrets.token_urlsafe(32)
 
-    # Reset handler state
     _CallbackHandler.auth_code = None
     _CallbackHandler.error = None
 
-    # Start local server to receive callback
     server = HTTPServer(("127.0.0.1", REDIRECT_PORT), _CallbackHandler)
     server_thread = threading.Thread(target=server.handle_request, daemon=True)
     server_thread.start()
 
-    # Build authorization URL
-    auth_params = urlencode(
-        {
-            "response_type": "code",
-            "client_id": client_id,
-            "redirect_uri": REDIRECT_URI,
-            "scope": AUTH0_SCOPES,
-            "audience": audience,
-            "state": state,
-            "code_challenge": code_challenge,
-            "code_challenge_method": "S256",
-            "prompt": "login",
-        }
-    )
-    auth_url = f"https://{domain}/authorize?{auth_params}"
-
-    typer.echo("\nOpening browser to authenticate...\n")
-    typer.echo(f"If the browser doesn't open, visit:\n  {auth_url}\n")
-
     try:
-        webbrowser.open(auth_url)
-    except Exception:
-        pass
+        auth_params = urlencode(
+            {
+                "response_type": "code",
+                "client_id": client_id,
+                "redirect_uri": REDIRECT_URI,
+                "scope": AUTH0_SCOPES,
+                "audience": audience,
+                "state": state,
+                "code_challenge": code_challenge,
+                "code_challenge_method": "S256",
+                "prompt": "login",
+            }
+        )
+        auth_url = f"https://{domain}/authorize?{auth_params}"
 
-    typer.echo("Waiting for authorization...")
+        typer.echo("\nOpening browser to authenticate...\n")
+        typer.echo(f"If the browser doesn't open, visit:\n  {auth_url}\n")
 
-    # Wait for callback (timeout after 120 seconds)
-    server_thread.join(timeout=120)
-    server.server_close()
+        with contextlib.suppress(Exception):
+            webbrowser.open(auth_url)
+
+        typer.echo("Waiting for authorization...")
+        server_thread.join(timeout=120)
+    finally:
+        server.server_close()
 
     if _CallbackHandler.error:
         typer.echo(f"Authorization failed: {_CallbackHandler.error}", err=True)
@@ -302,6 +297,20 @@ def login() -> None:
         typer.echo("Authorization timed out. Please try again.", err=True)
         raise typer.Exit(code=1)
 
+    return _CallbackHandler.auth_code, code_verifier
+
+
+@auth_app.command()
+def login() -> None:
+    """Authenticate with Auth0 using Authorization Code + PKCE."""
+    try:
+        domain, client_id, api_url, audience = _resolve_auth_config(os.environ, load_config())
+    except PartialAuthConfigError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=1) from exc
+
+    auth_code, code_verifier = _run_callback_flow(domain, client_id, audience)
+
     # Exchange code for tokens
     try:
         token_resp = httpx.post(
@@ -309,7 +318,7 @@ def login() -> None:
             json={
                 "grant_type": "authorization_code",
                 "client_id": client_id,
-                "code": _CallbackHandler.auth_code,
+                "code": auth_code,
                 "redirect_uri": REDIRECT_URI,
                 "code_verifier": code_verifier,
             },


### PR DESCRIPTION
## Why

PR #78 cleared the mechanical ruff hits but left three sites that
needed judgment instead of autofix: a `try/except Exception: pass`
around `webbrowser.open`, the C901 on `login` (12 > 10), and the C901
on `OpenQuestionsFile.parse` (11 > 10). Closing these keeps the
remaining C901 list focused on functions that genuinely need
structural splits (`sync/hooks.py`, `store/validator.py`, etc.).

## Approach

Three behavior-preserving edits:

- `contextlib.suppress(Exception)` for the webbrowser swallow — same
  semantics as `try/except Exception: pass`. The prompt above already
  shows the URL to paste manually, so we deliberately don't surface
  `webbrowser.Error` to the user.
- Extract `_run_callback_flow` from `login` along the
  callback-cycle / token-exchange line. The helper owns PKCE through
  the validated `auth_code`; `login` keeps config resolution and the
  token-for-code POST.
- Extract `_parse_header` from `OpenQuestionsFile.parse`. The header
  scan is self-contained (leading-blank skip + single `# ` capture);
  pulling it out drops `parse` under the complexity threshold without
  touching the main loop.

The alternative for `login` and `parse` was `# noqa: C901` with a
one-line justification. Both extractions are clean enough that the
refactor reads better than the suppression.

## What changed

- `packages/nauro/src/nauro/cli/commands/auth.py`
  - Added `import contextlib`.
  - New `_run_callback_flow(domain, client_id, audience) ->
    (auth_code, code_verifier)` owning the OAuth callback cycle:
    PKCE, HTTPServer lifecycle (try/finally so the port closes on
    every exit path), browser open, and the 120-second wait.
  - `login` reduces to: resolve config → call the helper → token
    exchange → persist.

- `packages/nauro-core/src/nauro_core/questions.py`
  - New `_parse_header(lines, i) -> (header, next_i)`. The
    `startswith("# ")` and not-`startswith("## ")` guard is preserved
    bit-for-bit — it's what separates the file header from `##
    Resolved`.
  - `parse` keeps its main loop verbatim.

## What to review

- `_run_callback_flow` is the highest-risk site. `login` has no direct
  pytest coverage; `test_auth_refresh.py` only exercises
  `refresh_access_token` / `with_token_refresh`, so this extraction is
  uncovered by tests and relied on review. Worth a careful read of:
  - The try/finally around the HTTPServer — `server.server_close()`
    must run on both success and the two raise paths.
  - The tuple return `(auth_code, code_verifier)` — `login` needs the
    verifier back for the token exchange.
  - `_CallbackHandler` class-attribute reset happens inside the helper
    before the server starts (same ordering as before).
- `_parse_header`'s guard is load-bearing; verify the docstring's
  description matches the parser's intent.

## What's deferred

The 13 remaining C901 hits need real refactors and are out of scope.
Top offenders: `sync/hooks.py::pull_before_session` (23),
`store/validator.py::validate_store` (21),
`sync/_pull_via_presign` (20), `cli/commands/init.py::init` (19),
`store/resolution.py::resolve_store` (17),
`sync/hooks.py::push_after_write` (17),
`store/snapshot.py::_prune_snapshots` (15),
`sync/_push_via_presign` (15), plus 5 smaller hits (11–13).

## Test plan

- `uv run ruff check packages/` — clean
- `uv run ruff check --select C901 packages/` — 13 hits (down from 15);
  `login` and `parse` no longer listed.
- `uv run ruff format --check packages/` — clean
- `uv run pytest packages/nauro-core/tests/ -x -q` — 306 passed
- `uv run pytest packages/nauro/tests/ -x -q` — 942 passed

The `_CallbackHandler` class-attribute pattern, the 120-second timeout,
the `typer.Exit(code=1)` raises with `from exc` chains, and the
header-detection guard are all preserved.