### PR TITLE
docs: refresh store-layout diagrams and drop dropped pytest marker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,8 @@ The project store lives at `~/.nauro/projects/<project-name>/` — **not** insid
   projects/
     <project-name>/
       project.md                 # stable: goals, non-goals, users, constraints
-      state.md                   # volatile: current sprint, blockers, recent completions
+      state_current.md           # volatile: current sprint, blockers, recent completions
+      state_history.md           # append-only history of completed work
       stack.md                   # tech choices with rationale and rejected alternatives
       open-questions.md          # append-only unresolved threads
       decisions/

--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ Everything is stored as flat markdown in `~/.nauro/projects/` and matched agains
 ~/.nauro/projects/<name>/
   project.md          # goals, constraints
   stack.md            # languages, frameworks, infrastructure
-  state.md            # current focus, blockers
+  state_current.md    # current focus, blockers
+  state_history.md    # append-only history of completed work
   decisions/          # one markdown file per decision
   open-questions.md   # unresolved threads
   snapshots/          # versioned store captures
@@ -197,7 +198,7 @@ Contributions welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instruct
 ```bash
 uv sync --all-packages --all-extras
 uv run pytest packages/nauro-core/tests/ -x -q
-uv run pytest packages/nauro/tests/ -x -q -m "not integration"
+uv run pytest packages/nauro/tests/ -x -q
 ```
 
 ## Packages

--- a/packages/nauro/CLAUDE.md
+++ b/packages/nauro/CLAUDE.md
@@ -12,7 +12,8 @@ The project store lives at `~/.nauro/projects/<project-name>/` — **not** insid
   projects/
     <project-name>/
       project.md                 # stable: goals, non-goals, users, constraints
-      state.md                   # volatile: current sprint, blockers, recent completions
+      state_current.md           # volatile: current sprint, blockers, recent completions
+      state_history.md           # append-only history of completed work
       stack.md                   # tech choices with rationale and rejected alternatives
       open-questions.md          # append-only unresolved threads
       decisions/


### PR DESCRIPTION
## Why

- The Contributing snippet in `README.md` still passed `-m "not integration"` to pytest, but #55 removed the `integration` marker — the flag is a no-op.
- Three store-layout diagrams (`README.md`, top-level `CLAUDE.md`, `packages/nauro/CLAUDE.md`) still showed a single `state.md` row, but #2 split state into `state_current.md` + `state_history.md`.

## What changed

- `README.md` (store-layout diagram): swap the `state.md` row for `state_current.md` + `state_history.md`, terse comment style preserved.
- `README.md` (Contributing pytest invocation): drop ` -m "not integration"`.
- `CLAUDE.md` (top-level store-layout diagram): swap `state.md` for `state_current.md` + `state_history.md`, verbose comment style preserved.
- `packages/nauro/CLAUDE.md` (store-layout diagram): identical swap.

## Test plan

- `grep -n 'not integration\|\bstate\.md\b' README.md CLAUDE.md packages/nauro/CLAUDE.md` returns no hits.
- `uv run ruff check packages/` and `uv run ruff format --check packages/` clean.
- Remaining `state.md` references in `packages/nauro-core/` and `packages/nauro/src/` are intentional — legacy-store handling code and its tests.