### PR TITLE
fix(mcp): reject tool-use envelope fragments at the writer boundary

### DIFF
--- a/packages/nauro-core/src/nauro_core/validation.py
+++ b/packages/nauro-core/src/nauro_core/validation.py
@@ -180,14 +180,11 @@ def screen_structural(
     return ("pass", None)
 
 
-# Envelope token detection — see PR-A1 / 2026-05-17 incident.
-#
-# Some non-Anthropic agent surfaces emit tool calls as XML and their MCP
-# bridges occasionally fail to extract <parameter> values cleanly, so the
-# envelope tail (</question>, <parameter name="context">, </invoke>, etc.)
-# ends up appended to the string field the server receives. Writers must
-# reject these before they hit disk — we have already seen them persisted
-# in open-questions.md and in D099's rationale.
+# Some agent surfaces emit tool calls as XML and their MCP bridges may
+# fail to extract <parameter> values cleanly, so the envelope tail
+# (</question>, <parameter name="context">, </invoke>, etc.) ends up
+# appended to the string field the server receives. Writers must reject
+# these before they hit disk.
 _ENVELOPE_TOKENS: tuple[str, ...] = (
     "</question>",
     "</rationale>",

--- a/packages/nauro-core/src/nauro_core/validation.py
+++ b/packages/nauro-core/src/nauro_core/validation.py
@@ -178,3 +178,37 @@ def screen_structural(
             )
 
     return ("pass", None)
+
+
+# Envelope token detection — see PR-A1 / 2026-05-17 incident.
+#
+# Some non-Anthropic agent surfaces emit tool calls as XML and their MCP
+# bridges occasionally fail to extract <parameter> values cleanly, so the
+# envelope tail (</question>, <parameter name="context">, </invoke>, etc.)
+# ends up appended to the string field the server receives. Writers must
+# reject these before they hit disk — we have already seen them persisted
+# in open-questions.md and in D099's rationale.
+_ENVELOPE_TOKENS: tuple[str, ...] = (
+    "</question>",
+    "</rationale>",
+    "</context>",
+    "</parameter>",
+    "</invoke>",
+    "<parameter name=",
+    "<invoke name=",
+)
+
+
+def find_envelope_token(text: str) -> str | None:
+    """Return the first envelope token present in *text*, or None.
+
+    The check is a literal substring scan against a small, closed token set
+    — these are tool-use envelope fragments that must never reach the store.
+    Plain string operations only.
+    """
+    if not text:
+        return None
+    for token in _ENVELOPE_TOKENS:
+        if token in text:
+            return token
+    return None

--- a/packages/nauro-core/tests/test_validation.py
+++ b/packages/nauro-core/tests/test_validation.py
@@ -10,6 +10,7 @@ from nauro_core.decision_model import (
 from nauro_core.validation import (
     check_bm25_similarity,
     compute_hash,
+    find_envelope_token,
     screen_structural,
 )
 
@@ -239,3 +240,47 @@ class TestScreenStructural:
         action, reason = screen_structural(self._proposal(rationale=None), set(), [])
         assert action == "reject"
         assert "Rationale is empty" in reason
+
+
+class TestFindEnvelopeToken:
+    def test_empty_string_is_none(self):
+        assert find_envelope_token("") is None
+
+    def test_plain_prose_is_none(self):
+        text = "Should we adopt OpenTelemetry for tracing across the gateway?"
+        assert find_envelope_token(text) is None
+
+    def test_closing_question_tag(self):
+        text = "How should we model tenants?</question>"
+        assert find_envelope_token(text) == "</question>"
+
+    def test_closing_rationale_tag(self):
+        text = "Picked Postgres for ACID guarantees.</rationale>"
+        assert find_envelope_token(text) == "</rationale>"
+
+    def test_closing_context_tag(self):
+        text = "Some context about the choice.</context>"
+        assert find_envelope_token(text) == "</context>"
+
+    def test_closing_parameter_tag(self):
+        text = "value here</parameter>"
+        assert find_envelope_token(text) == "</parameter>"
+
+    def test_closing_invoke_tag(self):
+        text = "trailing junk</invoke>"
+        assert find_envelope_token(text) == "</invoke>"
+
+    def test_opening_parameter_attr(self):
+        text = 'rest of the call <parameter name="context">leaked'
+        assert find_envelope_token(text) == "<parameter name="
+
+    def test_opening_invoke_attr(self):
+        text = 'wrapper <invoke name="propose_decision">'
+        assert find_envelope_token(text) == "<invoke name="
+
+    def test_self_referential_question_about_parameter_still_rejects(self):
+        # Users asking literally about the propose_decision tool's parameter
+        # surface area will trip the check. That's acceptable — they can
+        # rephrase (e.g. "the parameter named 'rationale'") to disambiguate.
+        text = "How should we describe the <parameter name='rationale'> field in docs?"
+        assert find_envelope_token(text) == "<parameter name="

--- a/packages/nauro/src/nauro/mcp/tools.py
+++ b/packages/nauro/src/nauro/mcp/tools.py
@@ -28,7 +28,7 @@ from nauro_core.protocol import (
     PROPOSE_DECISION_OPERATIONS,
     UPDATE_SUPERSEDE_CARE,
 )
-from nauro_core.validation import check_content_length
+from nauro_core.validation import check_content_length, find_envelope_token
 
 from nauro.mcp.payloads import build_l0_payload, build_l1_payload, build_l2_payload
 from nauro.onboarding import (
@@ -63,6 +63,29 @@ def _reject_if_too_long(value: str, label: str, max_length: int) -> dict | None:
     if msg:
         return {"store": "local", "status": "rejected", "reason": msg}
     return None
+
+
+def _reject_if_envelope_token(value: str, field_name: str) -> dict | None:
+    """Return a rejection dict if *value* contains an MCP envelope fragment.
+
+    Some non-Anthropic agent surfaces emit tool calls as XML and their MCP
+    bridges occasionally fail to extract <parameter> values cleanly, so the
+    envelope tail leaks into the string field. Reject before any I/O — see
+    nauro_core.validation.find_envelope_token.
+    """
+    token = find_envelope_token(value)
+    if not token:
+        return None
+    return {
+        "store": "local",
+        "status": "rejected",
+        "reason": (
+            f"{field_name} contains tool-use envelope fragment {token!r}. "
+            "This usually means the client failed to extract the parameter "
+            "value cleanly from an XML tool call. Resend the call with just "
+            "the prose content."
+        ),
+    }
 
 
 def _check_store_exists(store_path: Path) -> str | None:
@@ -143,6 +166,19 @@ def tool_propose_decision(
         _reject_if_too_long(title, "Title", MAX_TITLE_LENGTH),
         _reject_if_too_long(rationale, "Rationale", MAX_RATIONALE_LENGTH),
     ):
+        if err:
+            return err
+
+    # Reject tool-use envelope fragments that leaked from XML-emitting clients.
+    envelope_targets: list[tuple[str, str]] = [
+        ("title", title),
+        ("rationale", rationale),
+    ]
+    for idx, item in enumerate(rejected or []):
+        if isinstance(item, dict):
+            envelope_targets.append((f"rejected[{idx}].reason", item.get("reason", "") or ""))
+    for field_name, value in envelope_targets:
+        err = _reject_if_envelope_token(value, field_name)
         if err:
             return err
 
@@ -382,6 +418,12 @@ def tool_flag_question(
         _reject_if_too_long(question, "Question", MAX_QUESTION_LENGTH),
         _reject_if_too_long(context or "", "Context", MAX_CONTEXT_LENGTH) if context else None,
     ):
+        if err:
+            return err
+
+    # Reject tool-use envelope fragments that leaked from XML-emitting clients.
+    for field_name, value in (("question", question), ("context", context or "")):
+        err = _reject_if_envelope_token(value, field_name)
         if err:
             return err
 

--- a/packages/nauro/tests/test_envelope_rejection.py
+++ b/packages/nauro/tests/test_envelope_rejection.py
@@ -1,0 +1,124 @@
+"""Rejection of tool-use envelope fragments at the writer boundary.
+
+Some non-Anthropic agent surfaces emit MCP tool calls as XML and their
+bridges occasionally fail to extract <parameter> values cleanly, so the
+envelope tail leaks into the string field the server receives. The local
+MCP tools must reject before any I/O — see
+nauro_core.validation.find_envelope_token.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from nauro.mcp.tools import tool_flag_question, tool_propose_decision
+from nauro.store.registry import register_project
+from nauro.templates.scaffolds import scaffold_project_store
+
+OPEN_QUESTIONS = "open-questions.md"
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> Path:
+    """A scaffolded project store registered against tmp_path."""
+    store_path = register_project("testproj", [tmp_path])
+    scaffold_project_store("testproj", store_path)
+    return store_path
+
+
+class TestFlagQuestionRejectsEnvelope:
+    def test_question_with_closing_question_tag_is_rejected(self, store: Path):
+        oq_path = store / OPEN_QUESTIONS
+        before = oq_path.read_text()
+
+        result = tool_flag_question(
+            store,
+            question="Should we adopt OpenTelemetry?</question>",
+        )
+
+        assert result["status"] == "rejected"
+        assert "question contains tool-use envelope fragment" in result["reason"]
+        assert "</question>" in result["reason"]
+        # File must not have been mutated.
+        assert oq_path.read_text() == before
+
+    def test_context_with_opening_parameter_attr_is_rejected(self, store: Path):
+        oq_path = store / OPEN_QUESTIONS
+        before = oq_path.read_text()
+
+        result = tool_flag_question(
+            store,
+            question="Should we adopt OpenTelemetry?",
+            context='leaked envelope <parameter name="rationale">',
+        )
+
+        assert result["status"] == "rejected"
+        assert "context contains tool-use envelope fragment" in result["reason"]
+        assert oq_path.read_text() == before
+
+    def test_clean_inputs_still_write(self, store: Path):
+        with patch("nauro.mcp.tools._try_push"):
+            result = tool_flag_question(
+                store,
+                question="Should we adopt OpenTelemetry for tracing?",
+                context="Affects the gateway and three downstream services.",
+            )
+        assert result["status"] == "ok"
+        content = (store / OPEN_QUESTIONS).read_text()
+        assert "Should we adopt OpenTelemetry for tracing?" in content
+
+
+class TestProposeDecisionRejectsEnvelope:
+    def test_rationale_with_closing_rationale_tag_is_rejected(self, store: Path):
+        result = tool_propose_decision(
+            store,
+            title="Use Postgres for primary storage",
+            rationale=(
+                "ACID guarantees and strong tooling beat the operational cost. </rationale>"
+            ),
+        )
+        assert result["status"] == "rejected"
+        assert "rationale contains tool-use envelope fragment" in result["reason"]
+        assert "</rationale>" in result["reason"]
+
+    def test_title_with_envelope_token_is_rejected(self, store: Path):
+        result = tool_propose_decision(
+            store,
+            title="Use Postgres</invoke>",
+            rationale="ACID guarantees and strong tooling beat operational cost.",
+        )
+        assert result["status"] == "rejected"
+        assert "title contains tool-use envelope fragment" in result["reason"]
+
+    def test_rejected_alternative_reason_envelope_is_rejected(self, store: Path):
+        result = tool_propose_decision(
+            store,
+            title="Use Postgres for primary storage",
+            rationale="ACID guarantees and strong tooling beat operational cost.",
+            rejected=[
+                {
+                    "alternative": "MySQL",
+                    "reason": "Weaker isolation defaults.</parameter>",
+                }
+            ],
+        )
+        assert result["status"] == "rejected"
+        assert "rejected[0].reason contains tool-use envelope fragment" in result["reason"]
+
+    def test_clean_inputs_still_validate(self, store: Path):
+        with patch("nauro.mcp.tools.validate_proposed_write") as mock_validate:
+            mock_validate.return_value.status = "confirmed"
+            mock_validate.return_value._decision_id = "001"
+            mock_validate.return_value.confirm_id = None
+            mock_validate.return_value.tier = "t1"
+            mock_validate.return_value.operation = "add"
+            mock_validate.return_value.similar_decisions = []
+            mock_validate.return_value.assessment = ""
+            mock_validate.return_value.resolved_questions = []
+            result = tool_propose_decision(
+                store,
+                title="Use Postgres for primary storage",
+                rationale="ACID guarantees and strong tooling beat operational cost.",
+            )
+        assert result["status"] == "confirmed"


### PR DESCRIPTION
## Why

Non-Anthropic agent surfaces emit MCP tool calls as XML envelopes, and
their MCP bridges sometimes fail to extract `<parameter>` values
cleanly. When that happens, the envelope tail (`</question>`,
`<parameter name=…>`, `</invoke>`, etc.) gets concatenated onto the
string field the server receives, and writers store it verbatim. We
have seen this persisted in real stores — D099's rationale is one prior
incident of the same class.

## Approach

Reject at the writer boundary. A tiny detector lives in `nauro-core`
(zero-dep, shared library) and the two local-path MCP tools that accept
free-form text call it before any I/O. The detector is a literal
substring scan against a closed set of seven envelope tokens — plain
`str.__contains__`, no regex.

Reject was chosen over sanitize: silently stripping makes the writer
guess at intent and hides the broken client. A rejection with a clear
message tells the agent to resend with just the prose content.

## What changed

- `nauro-core/validation.py` — added `find_envelope_token(text)` and a
  closed token set covering question / rationale / context / parameter
  / invoke closes plus opening `<parameter name=` and `<invoke name=`
  attribute fragments.
- `nauro/mcp/tools.py` — added `_reject_if_envelope_token()` and wired
  it into `tool_flag_question` (question + context) and
  `tool_propose_decision` (title, rationale, each entry's
  `rejected[i].reason`). Placed after length-limit checks, before any
  validation pipeline or I/O.
- Tests colocated by package.

## What to review

- The token set in `validation.py` — additions or omissions here change
  the rejection surface. A test locks in that a question literally about
  the `<parameter ...>` syntax trips the check; users can disambiguate
  by rephrasing.
- The `rejected[i].reason` iteration in `tool_propose_decision` — the
  field-name format `rejected[N].reason` is what surfaces in the
  rejection message.

## What's deferred

- One-shot cleanup of the contaminated historical entries in the
  affected store's `open-questions.md`. Separate follow-up.
- The same rejection on the remote MCP path lives in `mcp-server` and
  will follow once this lands and `nauro-core` is consumed there.

## Test plan

- 316 `nauro-core` tests pass (9 new `find_envelope_token` cases — every
  token, empty string, plain prose, the self-referential `<parameter ...>`
  question).
- 949 `nauro` tests pass (7 new in `test_envelope_rejection.py` covering
  both call sites with file-unchanged assertion on rejection and
  clean-input regression).
- ruff format + check clean.