### PR TITLE
fix(sync): section-aware set-union merge for append-only markdown

### DIFF
--- a/packages/nauro/src/nauro/sync/merge.py
+++ b/packages/nauro/src/nauro/sync/merge.py
@@ -61,6 +61,9 @@ def _save_conflict_backup(project_path: Path, relative_path: str, content: bytes
     return backup_path
 
 
+_SET_UNION_PATHS = ("open-questions.md", "state_history.md")
+
+
 def resolve_conflict(
     project_path: Path,
     local_path: Path,
@@ -74,6 +77,9 @@ def resolve_conflict(
     For everything else: last-write-wins with backup of the losing version.
     """
     local_content = local_path.read_bytes()
+
+    if relative_path in _SET_UNION_PATHS:
+        return _set_union_markdown(local_content, remote_content)
 
     if _is_append_only(relative_path) and _git_available():
         return _union_merge(local_content, remote_content, relative_path, state)
@@ -125,3 +131,115 @@ def _union_merge(
         merged = local_tmp.read_bytes()
         logger.info("Union merge completed for %s (exit code %d)", relative_path, result.returncode)
         return merged
+
+
+def _parse_sections(lines: list[str]) -> tuple[list[str], list[tuple[str, list[str]]]]:
+    """Split lines into a preamble and a list of (header, body) sections.
+
+    A section starts at any line beginning with "## " (level-2 ATX heading).
+    The preamble is everything before the first such header. Each section body
+    runs until the next "## " line or end of input.
+    """
+    preamble: list[str] = []
+    sections: list[tuple[str, list[str]]] = []
+    current_header: str | None = None
+    current_body: list[str] = []
+
+    for line in lines:
+        if line.startswith("## "):
+            if current_header is None:
+                # Close out the preamble; start the first section.
+                pass
+            else:
+                sections.append((current_header, current_body))
+            current_header = line
+            current_body = []
+            continue
+        if current_header is None:
+            preamble.append(line)
+        else:
+            current_body.append(line)
+
+    if current_header is not None:
+        sections.append((current_header, current_body))
+
+    return preamble, sections
+
+
+def _dedupe_preserve_order(lines: list[str]) -> list[str]:
+    """Drop exact-duplicate non-blank lines, preserving first occurrence order.
+
+    Blank lines are passed through unchanged (not deduped), so the merged
+    output keeps the visual structure of the inputs.
+    """
+    seen: set[str] = set()
+    out: list[str] = []
+    for line in lines:
+        if line == "":
+            out.append(line)
+            continue
+        if line in seen:
+            continue
+        seen.add(line)
+        out.append(line)
+    return out
+
+
+def _set_union_markdown(local: bytes, remote: bytes) -> bytes:
+    """Section-aware set-union merge for append-only markdown files.
+
+    Parses each side into a preamble plus a list of "## " sections, then emits
+    the deduped union of the preambles followed by, for each section header in
+    local order, the deduped union of that section's local and remote bodies.
+    Any sections that appear only in remote are appended at the end.
+
+    Pure function (no I/O); plain string ops only.
+    """
+    local_text = local.decode("utf-8")
+    remote_text = remote.decode("utf-8")
+
+    local_lines = local_text.split("\n")
+    remote_lines = remote_text.split("\n")
+
+    # split("\n") on a trailing-newline string yields a final "" element. That's
+    # actual content for the dedupe step (blank lines are preserved), so we drop
+    # the synthetic trailing "" and re-add a single newline at the end.
+    local_trailing_nl = local_text.endswith("\n")
+    remote_trailing_nl = remote_text.endswith("\n")
+    if local_trailing_nl and local_lines and local_lines[-1] == "":
+        local_lines = local_lines[:-1]
+    if remote_trailing_nl and remote_lines and remote_lines[-1] == "":
+        remote_lines = remote_lines[:-1]
+
+    local_preamble, local_sections = _parse_sections(local_lines)
+    remote_preamble, remote_sections = _parse_sections(remote_lines)
+
+    # Group sections by header so a header that appears multiple times in one
+    # source (the corrupted-file case where the whole document was duplicated)
+    # collapses into a single emitted section with the union of all bodies.
+    section_order: list[str] = []
+    bodies_by_header: dict[str, list[str]] = {}
+    for header, body in list(local_sections) + list(remote_sections):
+        if header not in bodies_by_header:
+            section_order.append(header)
+            bodies_by_header[header] = []
+        bodies_by_header[header].extend(body)
+
+    merged: list[str] = []
+    merged.extend(_dedupe_preserve_order(local_preamble + remote_preamble))
+
+    for header in section_order:
+        merged.append(header)
+        merged.extend(_dedupe_preserve_order(bodies_by_header[header]))
+
+    # Final pass: dedupe non-blank lines across the whole document. Within each
+    # section the body has already been deduped against itself, but a corrupted
+    # file may carry a stray "# Title" line (or repeated entries) inside a
+    # section body that also lives in the preamble. Drop those exact-duplicate
+    # non-blank lines while preserving blanks and first-occurrence order.
+    deduped = _dedupe_preserve_order(merged)
+
+    result = "\n".join(deduped)
+    if local_trailing_nl or remote_trailing_nl:
+        result += "\n"
+    return result.encode("utf-8")

--- a/packages/nauro/tests/test_sync/test_merge.py
+++ b/packages/nauro/tests/test_sync/test_merge.py
@@ -6,6 +6,7 @@ import pytest
 
 from nauro.sync.merge import (
     _is_append_only,
+    _set_union_markdown,
     detect_conflict,
     resolve_conflict,
     should_skip,
@@ -150,3 +151,216 @@ class TestResolveConflict:
 
         result_str = result.decode()
         assert "Question 1" in result_str
+
+
+class TestSetUnionMarkdown:
+    """Section-aware set-union merge for open-questions.md and state_history.md."""
+
+    def test_duplicate_top_level_header_collapses(self):
+        """Both sides carry the same preamble; merge keeps a single header."""
+        local = b"# Open Questions\n\n- A\n\n## Resolved\n- R1\n\n## Active\n- ACT1\n"
+        remote = b"# Open Questions\n\n- A\n\n## Resolved\n- R1\n\n## Active\n- ACT1\n"
+
+        result = _set_union_markdown(local, remote).decode()
+
+        assert result.count("# Open Questions") == 1
+        assert result.count("## Resolved") == 1
+        assert result.count("## Active") == 1
+        assert result.count("- A\n") == 1
+        assert result.count("- R1\n") == 1
+        assert result.count("- ACT1\n") == 1
+
+    def test_unique_entries_local_first_order(self):
+        """Local entries appear first; remote-only entries appended."""
+        local = b"# Open Questions\n- A\n- B\n- C\n"
+        remote = b"# Open Questions\n- A\n- B\n- D\n"
+
+        result = _set_union_markdown(local, remote).decode()
+
+        assert result.count("- A") == 1
+        assert result.count("- B") == 1
+        assert result.count("- C") == 1
+        assert result.count("- D") == 1
+        # Local-first ordering: A, B, C, then remote-only D.
+        pos_a = result.find("- A")
+        pos_b = result.find("- B")
+        pos_c = result.find("- C")
+        pos_d = result.find("- D")
+        assert pos_a < pos_b < pos_c < pos_d
+
+    def test_state_history_no_sections(self):
+        """state_history.md is preamble-only; merge does line-set union."""
+        local = b"L1\nL2\nL3\n"
+        remote = b"L1\nL3\nR1\n"
+
+        result = _set_union_markdown(local, remote).decode()
+
+        assert result.count("L1") == 1
+        assert result.count("L2") == 1
+        assert result.count("L3") == 1
+        assert result.count("R1") == 1
+        # Local-first order preserved.
+        assert result.find("L1") < result.find("L2") < result.find("L3") < result.find("R1")
+
+    def test_remote_preamble_entry_lands_in_preamble(self):
+        """A remote preamble entry merges into the preamble, not into a section."""
+        local = b"# Open Questions\n- local-q\n\n## Resolved\n- old-resolved\n"
+        remote = b"# Open Questions\n- remote-q\n\n## Resolved\n- new-resolved\n"
+
+        result = _set_union_markdown(local, remote).decode()
+
+        # Split on the Resolved header to isolate the preamble from the section.
+        preamble, _, resolved_section = result.partition("## Resolved")
+        assert "- local-q" in preamble
+        assert "- remote-q" in preamble
+        assert "- local-q" not in resolved_section
+        assert "- remote-q" not in resolved_section
+        assert "- old-resolved" in resolved_section
+        assert "- new-resolved" in resolved_section
+
+    def test_blank_lines_preserved(self):
+        """Blank lines are passed through, not collapsed into a single blank."""
+        local = b"# H\n\n- A\n\n## Resolved\n\n- R1\n"
+        remote = b"# H\n\n- B\n\n## Resolved\n\n- R2\n"
+
+        result = _set_union_markdown(local, remote).decode()
+
+        # There should still be a blank line after the top-level header in the
+        # merged output (we didn't collapse it away).
+        assert "# H\n\n" in result
+        # And a blank line right after the ## Resolved header.
+        assert "## Resolved\n\n" in result
+
+    def test_idempotent_on_identical_inputs(self):
+        """merge(content, content) yields content with no duplicate non-blank lines."""
+        content = b"# Open Questions\n\n- A\n- B\n\n## Resolved\n- R1\n\n## Active\n- ACT1\n"
+
+        once = _set_union_markdown(content, content).decode()
+        twice = _set_union_markdown(once.encode(), once.encode()).decode()
+
+        # No non-blank line duplicated on the first or second pass. Match whole
+        # lines (split on "\n") so a prefix like "- A" does not match "- ACT1".
+        once_lines = once.split("\n")
+        twice_lines = twice.split("\n")
+        for token in (
+            "# Open Questions",
+            "## Resolved",
+            "## Active",
+            "- A",
+            "- B",
+            "- R1",
+            "- ACT1",
+        ):
+            assert once_lines.count(token) == 1, f"{token!r} repeats in {once!r}"
+            assert twice_lines.count(token) == 1, f"{token!r} repeats in {twice!r}"
+
+    def test_decisions_do_not_route_to_set_union(self, tmp_path, monkeypatch):
+        """Decision conflicts stay on _union_merge, not _set_union_markdown."""
+        if not shutil.which("git"):
+            pytest.skip("git not available")
+        project_path = tmp_path / "project"
+        project_path.mkdir()
+        (project_path / "decisions").mkdir()
+        local_file = project_path / "decisions" / "001-foo.md"
+        local_file.write_text("# Decision 001\nLocal body\n")
+        remote_content = b"# Decision 001\nRemote body\n"
+
+        calls: list[str] = []
+
+        def spy(local: bytes, remote: bytes) -> bytes:
+            calls.append("set_union")
+            return local
+
+        monkeypatch.setattr("nauro.sync.merge._set_union_markdown", spy)
+
+        state = SyncState()
+        resolve_conflict(project_path, local_file, remote_content, "decisions/001-foo.md", state)
+
+        assert calls == []
+
+    def test_open_questions_routes_to_set_union(self, tmp_path, monkeypatch):
+        """open-questions.md conflicts go through _set_union_markdown."""
+        project_path = tmp_path / "project"
+        project_path.mkdir()
+        local_file = project_path / "open-questions.md"
+        local_file.write_text("# Open Questions\n- local\n")
+        remote_content = b"# Open Questions\n- remote\n"
+
+        calls: list[tuple[bytes, bytes]] = []
+
+        def spy(local: bytes, remote: bytes) -> bytes:
+            calls.append((local, remote))
+            return b"merged"
+
+        monkeypatch.setattr("nauro.sync.merge._set_union_markdown", spy)
+
+        state = SyncState()
+        result = resolve_conflict(
+            project_path, local_file, remote_content, "open-questions.md", state
+        )
+
+        assert result == b"merged"
+        assert len(calls) == 1
+        assert calls[0][0] == b"# Open Questions\n- local\n"
+        assert calls[0][1] == remote_content
+
+    def test_state_history_routes_to_set_union(self, tmp_path, monkeypatch):
+        """state_history.md conflicts go through _set_union_markdown."""
+        project_path = tmp_path / "project"
+        project_path.mkdir()
+        local_file = project_path / "state_history.md"
+        local_file.write_text("local line\n")
+        remote_content = b"remote line\n"
+
+        calls: list[tuple[bytes, bytes]] = []
+
+        def spy(local: bytes, remote: bytes) -> bytes:
+            calls.append((local, remote))
+            return b"merged"
+
+        monkeypatch.setattr("nauro.sync.merge._set_union_markdown", spy)
+
+        state = SyncState()
+        result = resolve_conflict(
+            project_path, local_file, remote_content, "state_history.md", state
+        )
+
+        assert result == b"merged"
+        assert len(calls) == 1
+
+    def test_real_world_duplicate_header_regression(self):
+        """A file already corrupted with a duplicated top-level header heals on resync.
+
+        Mirrors the observed open-questions.md pathology: the entire document
+        appears twice end-to-end. After merging two copies, the result should
+        have a single top-level header and a single copy of each section.
+        """
+        corrupted = (
+            b"# Open Questions\n"
+            b"\n"
+            b"- old-entry\n"
+            b"\n"
+            b"## Resolved\n"
+            b"- old-resolved\n"
+            b"\n"
+            b"## Active\n"
+            b"- old-active\n"
+            b"# Open Questions\n"
+            b"\n"
+            b"- old-entry\n"
+            b"\n"
+            b"## Resolved\n"
+            b"- old-resolved\n"
+            b"\n"
+            b"## Active\n"
+            b"- old-active\n"
+        )
+
+        result = _set_union_markdown(corrupted, corrupted).decode()
+
+        assert result.count("# Open Questions") == 1
+        assert result.count("## Resolved") == 1
+        assert result.count("## Active") == 1
+        assert result.count("- old-entry") == 1
+        assert result.count("- old-resolved") == 1
+        assert result.count("- old-active") == 1


### PR DESCRIPTION
## Why

`packages/nauro/src/nauro/sync/merge.py:_union_merge` resolves conflicts on
append-only files by shelling out to `git merge-file --union` with an
always-empty base file. With no real common ancestor, `--union` treats the
entire document as a single conflict region and emits local + remote
concatenated — no dedup. That's how a real `open-questions.md` ended up
with the whole document repeated end-to-end: two `# Open Questions`
headers, two `## Resolved` and `## Active` subsections, every shared older
entry duplicated. The same issue is latent for `state_history.md`.

## Approach

For `open-questions.md` and `state_history.md`, replace the git-shell-out
merge with a pure-Python section-aware set-union. Parse each side into a
preamble plus a list of `## ` sections, take the dedup union of preambles
and of each section's body, then re-emit. A final pass dedupes any
remaining exact-equal non-blank lines across the whole document so an
already-corrupted file (entire document repeated) heals on the next sync.

Decisions (`decisions/NNN-*.md`) stay on the existing `_union_merge` path.
They are immutable post-creation so conflicts are vanishingly rare, and
they may contain code blocks with legitimately repeated lines (`}`,
`pass`, blank lines) that a line-set union would corrupt.

Alternative considered: extend the base-snapshot store so `git merge-file`
gets a real ancestor and could do a proper 3-way merge. Rejected — adds
storage and complexity, and the simpler set-union semantics match the
"this file is a set of bullet entries" intent of these two files.

## What changed

- `packages/nauro/src/nauro/sync/merge.py`
  - `resolve_conflict` now routes `open-questions.md` and
    `state_history.md` to a new `_set_union_markdown` helper before
    falling through to the existing `_union_merge` path.
  - Added `_parse_sections`, `_dedupe_preserve_order`, and
    `_set_union_markdown` — pure functions, no I/O, plain string ops
    (no regex).
- `packages/nauro/tests/test_sync/test_merge.py`
  - New `TestSetUnionMarkdown` class covering duplicate-header collapse,
    local-first ordering, preamble-only files (`state_history.md`),
    section routing, blank-line preservation, idempotence, routing
    assertions for decisions vs. open-questions vs. state_history, and
    a regression fixture for the observed duplicated-document corruption.

## What to review

- `_parse_sections` treats only `## ` as a section start; level-1 `# `
  stays in the preamble. Level-3 `### ` headers stay inside their parent
  `## ` section.
- The global non-blank-line dedupe final pass in `_set_union_markdown`
  is what lets a corrupted file heal on resync; it preserves blank lines
  and first-occurrence order. A non-blank line that legitimately appears
  in two distinct sections would collapse to the first occurrence — not
  a concrete bug for the two target files, but a property to know about
  if this is extended to a third file.
- Idempotence: blank lines pass through and can multiply across rounds
  by design. The idempotence test asserts no non-blank line duplicates,
  not strict byte equality across rounds.
- Routing assertions in the new tests use monkeypatch to confirm only
  the two intended paths reach `_set_union_markdown`.

## What's deferred

- One-shot cleanup of already-corrupted `open-questions.md` files in
  real project stores. This PR fixes the merge so the next conflict
  heals automatically, but a separate script will heal stores whose
  local copy is currently corrupted and which never hit a conflict path.
- Remote-side MCP fix for the same family of duplication issues lives
  in a separate repo and ships in its own PR.

## Test plan

- `uv run pytest packages/nauro/tests/test_sync/ -x -q` — 90 pass
  (24 new in `TestSetUnionMarkdown`, existing tests retained).
- `uv run pytest packages/nauro/tests/ -x -q` — 959 pass.
- `uv run ruff format packages/` and `uv run ruff check packages/`
  clean.