### PR TITLE
fix(mcp): prepend per-user section and trim static instructions

### DIFF
--- a/packages/nauro-core/src/nauro_core/constants.py
+++ b/packages/nauro-core/src/nauro_core/constants.py
@@ -9,8 +9,6 @@ from nauro_core.protocol import (
     CHECK_DECISION_RETURNS,
     GET_DECISION_BEFORE_PROPOSING,
     NO_INVENT_RATIONALE,
-    PROPOSE_DECISION_OPERATIONS,
-    RESOLVES_OPEN_QUESTIONS,
     UPDATE_SUPERSEDE_CARE,
 )
 
@@ -74,7 +72,13 @@ MAX_APPROACH_LENGTH = 5_000
 # Canonical claims about check_decision/get_decision/propose_decision live in
 # nauro_core.protocol (imported at the top of this module) and are spliced
 # in below; MCP-specific framing prose (precondition / first-principles /
-# push back / vendor swap) stays inline.
+# push back / vendor swap) stays inline. The PROPOSE_DECISION_OPERATIONS and
+# RESOLVES_OPEN_QUESTIONS fragments are deliberately omitted here — they are
+# bound to the `propose_decision` ToolSpec parameter descriptions instead,
+# where the agent reads them at the moment of use, and keeping them out of
+# the static block trims the budget so the per-user project section the
+# remote server prepends survives client-side truncation of the
+# `initialize.instructions` field.
 # MCP_INSTRUCTIONS remains as a backward-compatible alias.
 MCP_INSTRUCTIONS_STATIC = (
     "Nauro carries this project's doctrine across every agent session. "
@@ -100,14 +104,10 @@ MCP_INSTRUCTIONS_STATIC = (
     "Do it at the moment the decision is made, not at the end of the "
     "session. Always include what was rejected and why.\n"
     "\n"
-    f"{PROPOSE_DECISION_OPERATIONS}\n"
-    "\n"
     f"You own this classification. {UPDATE_SUPERSEDE_CARE}\n"
     "\n"
     f"{NO_INVENT_RATIONALE} Do NOT propose decisions for obvious bug fixes, "
     "adding tests for existing behavior, or renaming variables.\n"
-    "\n"
-    f"{RESOLVES_OPEN_QUESTIONS}\n"
     "\n"
     "## When to get context\n"
     "\n"

--- a/packages/nauro-core/src/nauro_core/instructions.py
+++ b/packages/nauro-core/src/nauro_core/instructions.py
@@ -1,7 +1,7 @@
 """Per-user composition of MCP server instructions.
 
 The static instructional block (MCP_INSTRUCTIONS_STATIC) is project-agnostic.
-Remote callers append a per-user section that depends on how many projects
+Remote callers prepend a per-user section that depends on how many projects
 the caller has access to:
 
 - 0 projects: WELCOME_NO_PROJECT onboarding copy.
@@ -40,25 +40,31 @@ def build_remote_instructions(
     `projects` is a list of dicts each with at least 'project_id' (str, ULID)
     and 'name' (str).
 
-    - Empty list: append WELCOME_NO_PROJECT.
-    - Exactly 1 project: append one orientation line with the project name.
+    The per-user section is prepended before ``static_block`` so it survives
+    client-side truncation of the MCP ``initialize.instructions`` field. The
+    project section is the load-bearing payload for multi-project users (it
+    carries the project_id they must pass); the static block is repeated
+    project-agnostic guidance the agent can recover from other surfaces.
+
+    - Empty list: prepend WELCOME_NO_PROJECT.
+    - Exactly 1 project: prepend one orientation line with the project name.
       No project_id is rendered — tools auto-resolve to the only project.
-    - 2..MAX_INLINE_PROJECTS: append a "You have N projects:" list with each
+    - 2..MAX_INLINE_PROJECTS: prepend a "You have N projects:" list with each
       project rendered as `name — {full project_id}`, sorted by
       (name.lower(), project_id). Tools require an explicit project_id when
       multiple exist.
-    - More than MAX_INLINE_PROJECTS: append a count + hint to call
+    - More than MAX_INLINE_PROJECTS: prepend a count + hint to call
       list_projects, without enumerating each one.
     """
     if not projects:
-        return f"{static_block}\n\n{WELCOME_NO_PROJECT}"
+        return f"{WELCOME_NO_PROJECT}\n\n{static_block}"
 
     if len(projects) == 1:
         name = projects[0]["name"]
         return (
-            f"{static_block}\n\n"
             f"Connected to project '{name}' — tools auto-resolve, "
             "you do not need to pass a project_id."
+            f"\n\n{static_block}"
         )
 
     if len(projects) <= MAX_INLINE_PROJECTS:
@@ -73,11 +79,11 @@ def build_remote_instructions(
             "\nTools require an explicit project_id when multiple exist; "
             "pass one of the IDs above."
         )
-        return f"{static_block}\n\n" + "\n".join(lines)
+        return "\n".join(lines) + f"\n\n{static_block}"
 
     return (
-        f"{static_block}\n\n"
         f"You have {len(projects)} projects. "
         "Tools require an explicit project_id when multiple exist — "
         "call list_projects to see them all and pick one."
+        f"\n\n{static_block}"
     )

--- a/packages/nauro-core/src/nauro_core/mcp_tools.py
+++ b/packages/nauro-core/src/nauro_core/mcp_tools.py
@@ -19,6 +19,7 @@ from typing import Any, TypedDict
 
 from nauro_core.protocol import (
     PROPOSE_DECISION_OPERATIONS,
+    RESOLVES_OPEN_QUESTIONS,
     UPDATE_SUPERSEDE_CARE,
 )
 
@@ -400,15 +401,8 @@ PROPOSE_DECISION: ToolSpec = {
                 "type": "array",
                 "items": {"type": "string"},
                 "description": (
-                    "Optional list of open-question timestamp ids (the "
-                    "'YYYY-MM-DD HH:MM UTC' inside each question's "
-                    "'- [timestamp]' prefix in open-questions.md) that this "
-                    "decision resolves. On confirm, the named questions are "
-                    "moved under a '## Resolved' subsection with a back-ref "
-                    "to this decision. Unknown ids are rejected at the "
-                    "boundary; ids already under '## Resolved' are a no-op. "
-                    "Call get_context (L0 surfaces the open questions) to "
-                    "discover the ids."
+                    f"{RESOLVES_OPEN_QUESTIONS} Call get_context "
+                    "(L0 surfaces the open questions) to discover the ids."
                 ),
             },
             "skip_validation": {

--- a/packages/nauro-core/tests/test_constants.py
+++ b/packages/nauro-core/tests/test_constants.py
@@ -18,6 +18,10 @@ from nauro_core.constants import (
     STATE_MD,
     VALID_CONFIDENCES,
 )
+from nauro_core.protocol import (
+    PROPOSE_DECISION_OPERATIONS,
+    RESOLVES_OPEN_QUESTIONS,
+)
 
 
 class TestLimits:
@@ -92,3 +96,15 @@ class TestMcpInstructions:
     def test_check_decision_lists_vendor_swap(self):
         """Vendor swaps are a common conflict surface (e.g. S3 ↔ R2)."""
         assert "vendor swap" in MCP_INSTRUCTIONS_STATIC
+
+    def test_propose_decision_operations_not_in_static(self) -> None:
+        """D151: relocated to the propose_decision.operation parameter so the
+        static block stays small enough for the per-user project section the
+        remote server prepends to survive client-side truncation of the
+        ``initialize.instructions`` field."""
+        assert PROPOSE_DECISION_OPERATIONS not in MCP_INSTRUCTIONS_STATIC
+
+    def test_resolves_open_questions_not_in_static(self) -> None:
+        """D151: relocated to the propose_decision.resolves_questions
+        parameter description, same budget reason as the operations fragment."""
+        assert RESOLVES_OPEN_QUESTIONS not in MCP_INSTRUCTIONS_STATIC

--- a/packages/nauro-core/tests/test_mcp_tools.py
+++ b/packages/nauro-core/tests/test_mcp_tools.py
@@ -168,6 +168,12 @@ class TestBuildRemoteInstructions:
         assert STATIC in result
         assert WELCOME_NO_PROJECT in result
 
+    def test_zero_projects_welcome_before_static(self):
+        """D151: the per-user section must precede the static block so it
+        survives client-side truncation of ``initialize.instructions``."""
+        result = build_remote_instructions(STATIC, [])
+        assert result.index(WELCOME_NO_PROJECT) < result.index(STATIC)
+
     def test_one_project_orientation_only(self):
         """Single-project users get a name-only orientation line — no ULID.
 
@@ -182,6 +188,12 @@ class TestBuildRemoteInstructions:
         assert "auto-resolve" in result or "automatically" in result or "auto" in result
         # The old "Pass the matching project_id" directive is gone.
         assert "Pass the matching project_id" not in result
+
+    def test_one_project_orientation_before_static(self):
+        """D151: orientation line must precede the static block."""
+        projects = [{"project_id": ULID_ALPHA, "name": "nauro"}]
+        result = build_remote_instructions(STATIC, projects)
+        assert result.index("Connected to project") < result.index(STATIC)
 
     def test_two_projects_emits_full_ulids(self):
         """Regression: the multi-project branch renders full 26-char ULIDs.
@@ -203,6 +215,16 @@ class TestBuildRemoteInstructions:
         assert result.index("alpha") < result.index("Beta")
         # Inline form must NOT mention list_projects (no overflow hint)
         assert "Call list_projects" not in result
+
+    def test_two_projects_list_before_static(self):
+        """D151: the inline project list must precede the static block."""
+        projects = [
+            {"project_id": ULID_ALPHA, "name": "alpha"},
+            {"project_id": ULID_BETA, "name": "Beta"},
+        ]
+        result = build_remote_instructions(STATIC, projects)
+        # "You have N projects" is the heading line that opens the section.
+        assert result.index("You have 2 projects") < result.index(STATIC)
 
     def test_two_projects_directive_requires_explicit_id(self):
         """Multi-project rendering must tell the agent disambiguation is required."""
@@ -226,6 +248,16 @@ class TestBuildRemoteInstructions:
         # Names must NOT be enumerated in overflow mode
         for p in projects:
             assert p["name"] not in result
+
+    def test_overflow_pointer_before_static(self):
+        """D151: the overflow pointer must precede the static block."""
+        projects = [
+            {"project_id": f"01ID{i:022d}", "name": f"proj-{i}"}
+            for i in range(MAX_INLINE_PROJECTS + 2)
+        ]
+        result = build_remote_instructions(STATIC, projects)
+        # The "You have N projects." count line opens the overflow section.
+        assert result.index(f"You have {len(projects)} projects") < result.index(STATIC)
 
     def test_static_preserved_verbatim(self):
         projects = [{"project_id": "01ID00000000000000000000A1", "name": "x"}]

--- a/packages/nauro-core/tests/test_protocol.py
+++ b/packages/nauro-core/tests/test_protocol.py
@@ -10,12 +10,14 @@ from __future__ import annotations
 import pytest
 
 from nauro_core.constants import MCP_INSTRUCTIONS_STATIC
+from nauro_core.mcp_tools import get_tool_spec
 from nauro_core.protocol import (
     CANONICAL_FRAGMENTS,
     CHECK_DECISION_RETURNS,
     GET_DECISION_BEFORE_PROPOSING,
     NO_INVENT_RATIONALE,
     PROPOSE_DECISION_OPERATIONS,
+    RESOLVES_OPEN_QUESTIONS,
     UPDATE_SUPERSEDE_CARE,
     protocol_tokens_in,
     substitute_protocol_fragments,
@@ -167,12 +169,18 @@ class TestProtocolTokensIn:
 
 class TestMcpInstructionsComposition:
     """MCP_INSTRUCTIONS_STATIC must contain every fragment used by the MCP
-    surface verbatim, and must be fully resolved (no leftover tokens)."""
+    surface verbatim, and must be fully resolved (no leftover tokens).
+
+    ``PROPOSE_DECISION_OPERATIONS`` and ``RESOLVES_OPEN_QUESTIONS`` are
+    deliberately omitted from the static block per D151 — they live on the
+    matching ``propose_decision`` ToolSpec parameter descriptions instead,
+    where the agent reads them at the moment of use. The positive splice
+    asserts below pin those relocations.
+    """
 
     REQUIRED_FRAGMENTS = (
         CHECK_DECISION_RETURNS,
         GET_DECISION_BEFORE_PROPOSING,
-        PROPOSE_DECISION_OPERATIONS,
         UPDATE_SUPERSEDE_CARE,
         NO_INVENT_RATIONALE,
     )
@@ -183,3 +191,20 @@ class TestMcpInstructionsComposition:
 
     def test_mcp_static_has_no_unresolved_tokens(self) -> None:
         assert protocol_tokens_in(MCP_INSTRUCTIONS_STATIC) == []
+
+    def test_propose_decision_operations_in_operation_parameter(self) -> None:
+        """Relocation guard (D151): the fragment must appear verbatim on the
+        ``propose_decision.operation`` parameter description so the agent
+        still reads operation semantics at the moment of use."""
+        spec = get_tool_spec("propose_decision")
+        op_desc = spec["input_schema"]["properties"]["operation"]["description"]
+        assert PROPOSE_DECISION_OPERATIONS in op_desc
+
+    def test_resolves_open_questions_in_resolves_questions_parameter(self) -> None:
+        """Relocation guard (D151): the fragment must appear verbatim on the
+        ``propose_decision.resolves_questions`` parameter description so the
+        ids-and-boundary contract stays bound to the parameter the agent
+        actually passes."""
+        spec = get_tool_spec("propose_decision")
+        rq_desc = spec["input_schema"]["properties"]["resolves_questions"]["description"]
+        assert RESOLVES_OPEN_QUESTIONS in rq_desc


### PR DESCRIPTION
## Why

Multi-project users hit `project_id_required` on every initial Nauro MCP call because claude.ai truncates `initialize.instructions` at ~2,023 chars while `MCP_INSTRUCTIONS_STATIC` is ~2,870 chars. The 185-char per-user project section — the only part that carries the project_id agents must pass — was appended after the static block and never reached the agent. Confirmed live in a recorded session.

## Approach

Per D151, two changes restore the per-user section to the truncation window:

1. **Reorder.** `build_remote_instructions` now prepends the per-user section before the static block in all four branches (0/1/2..MAX/overflow). The project section is the load-bearing payload; the static block is repeated guidance the agent can recover from other surfaces (`/nauro` skill, AGENTS.md) if truncation strikes.
2. **Trim.** `PROPOSE_DECISION_OPERATIONS` and `RESOLVES_OPEN_QUESTIONS` move out of `MCP_INSTRUCTIONS_STATIC` and splice verbatim into the matching `propose_decision` ToolSpec parameter descriptions (`operation`, `resolves_questions`). The agent reads them at the moment of use rather than at session start, and the static block shrinks below the truncation threshold.

Rejected alternative: a hard static-length budget assertion. That bakes in a client-specific threshold and would silently misfire if a different client truncates differently or the limit moves.

## What changed

- `instructions.py` — per-user section moved before `static_block` in all branches; module + function docstrings switched from "append" to "prepend" with the truncation-survival rationale.
- `constants.py` — `PROPOSE_DECISION_OPERATIONS` and `RESOLVES_OPEN_QUESTIONS` dropped from imports and from the f-string composition; surrounding section headings ("When to propose decisions" lead-in, "You own this classification.") preserved. Comment block updated to record the relocation and the budget reason.
- `mcp_tools.py` — `resolves_questions` parameter description rewritten as a verbatim splice of `RESOLVES_OPEN_QUESTIONS` plus the existing get_context tail; `operation` already spliced `PROPOSE_DECISION_OPERATIONS` (verified).

## What to review

- The ordering in `build_remote_instructions` — four branches, each places the section *before* the static, separated by `\n\n`. The single-project f-string is the most awkward to read; an explicit per-branch ordering test pins each.
- `mcp_tools.py:resolves_questions` description — the verbatim splice + the "Call get_context (L0 surfaces the open questions) to discover the ids." tail. One detail dropped vs. the prior wording: "ids already under '## Resolved' are a no-op." Not load-bearing; the canonical fragment is now the source of truth.
- Test coverage: positive splice-presence asserts on the ToolSpec parameters (`test_protocol.py`), negative drift guards against the static block (`test_constants.py`), and per-branch ordering asserts (`test_mcp_tools.py`). The combination structurally prevents either fragment from drifting back into the static or the relocation from being undone.

## What's deferred

- A static-length budget assertion — deliberately not added (would bake in a client-specific threshold).
- Skill bodies (`session_body.md`, `adopt_body.md`) — they splice via `<!-- protocol:... -->` tokens and that surface is unchanged. `test_protocol_drift.py` continues to pass via the session skill's existing token.
- `packages/nauro/src/nauro/mcp/tools.py` local stdio docstring splice — out of scope; the local transport doesn't hit the truncation path.
- `mcp-server/` — import-only consumer; picks up the new behavior on the next nauro-core bump.

## Test plan

- `uv run pytest packages/nauro-core/tests/test_protocol.py packages/nauro-core/tests/test_constants.py packages/nauro-core/tests/test_mcp_tools.py packages/nauro/tests/test_protocol_drift.py packages/nauro/tests/test_skills_drift.py -x -q` — 274 passed
- `uv run pytest packages/nauro-core/tests/ packages/nauro/tests/ -x -q` — 1282 passed
- `uv run ruff format --check packages/` — clean
- `uv run ruff check packages/` — clean