### PR TITLE
fix(questions): preserve every input line through OpenQuestionsFile round-trip

### DIFF
--- a/packages/nauro-core/src/nauro_core/__init__.py
+++ b/packages/nauro-core/src/nauro_core/__init__.py
@@ -195,7 +195,19 @@ from nauro_core.protocol import (
     substitute_protocol_fragments as substitute_protocol_fragments,
 )
 from nauro_core.questions import (
+    Block as Block,
+)
+from nauro_core.questions import (
+    EntryBlock as EntryBlock,
+)
+from nauro_core.questions import (
+    HeaderBlock as HeaderBlock,
+)
+from nauro_core.questions import (
     OpenQuestionsFile as OpenQuestionsFile,
+)
+from nauro_core.questions import (
+    ProseBlock as ProseBlock,
 )
 from nauro_core.questions import (
     QuestionEntry as QuestionEntry,
@@ -205,6 +217,12 @@ from nauro_core.questions import (
 )
 from nauro_core.questions import (
     ResolveResult as ResolveResult,
+)
+from nauro_core.questions import (
+    TripleHashBlock as TripleHashBlock,
+)
+from nauro_core.questions import (
+    UnparsableBlock as UnparsableBlock,
 )
 from nauro_core.search import (
     bm25_retrieve as bm25_retrieve,

--- a/packages/nauro-core/src/nauro_core/questions.py
+++ b/packages/nauro-core/src/nauro_core/questions.py
@@ -321,9 +321,9 @@ class OpenQuestionsFile(BaseModel):
         requested = list(dict.fromkeys(ids))
         ref = ResolvedRef(decision_num=decision_num, date=date)
         requested_set = set(requested)
-        known = self.known_question_ids
-        unknown = tuple(i for i in requested if i not in known)
-        moved = tuple(i for i in requested if i in known)
+        entry_ids = {b.entry.id for b in self.blocks if isinstance(b, EntryBlock)}
+        moved = tuple(i for i in requested if i in entry_ids)
+        unknown = tuple(i for i in requested if i not in entry_ids)
 
         divider_idx = self.resolved_divider_idx
         new_blocks: list[Block] = []

--- a/packages/nauro-core/src/nauro_core/questions.py
+++ b/packages/nauro-core/src/nauro_core/questions.py
@@ -6,10 +6,17 @@ The authoritative shape for parsed open-questions.md content. Mirrors
 
 A question entry is identified by the UTC timestamp inside its
 ``[YYYY-MM-DD HH:MM UTC]`` prefix — the same id ``flag_question`` writes.
-Resolution sets ``resolved_by`` on the entry; ``format`` then emits it
-under a ``## Resolved`` subsection prefixed with ``[Resolved by Dnn on
-YYYY-MM-DD]``. ``parse_questions`` (in :mod:`nauro_core.parsing`) already
-filters that subsection out of L0 reads.
+Resolution sets ``resolved_by`` on the matching :class:`EntryBlock`;
+``format`` then re-emits it with the ``[Resolved by Dnn on
+YYYY-MM-DD]`` prefix. ``parse_questions`` (in :mod:`nauro_core.parsing`)
+already filters the ``## Resolved`` subsection out of L0 reads.
+
+The internal shape is a flat ``blocks`` list. Each markdown line maps to
+exactly one block (``HeaderBlock``, ``ProseBlock``, ``EntryBlock``,
+``TripleHashBlock``, ``UnparsableBlock``), so ``parse → format`` is
+byte-identical for any input that doesn't pass through ``resolve``. The
+``## Resolved`` divider is positional: its block index splits the list
+into open-section and resolved-section regions.
 """
 
 from __future__ import annotations
@@ -17,6 +24,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import date as _date
 from datetime import datetime
+from typing import Annotated, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -67,6 +75,83 @@ class QuestionEntry(BaseModel):
         return [head, *self.continuation]
 
 
+class HeaderBlock(BaseModel):
+    """A ``##`` section header line. ``is_resolved_divider`` marks the
+    ``## Resolved`` boundary that partitions the file."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    kind: Literal["header"] = "header"
+    text: str
+    is_resolved_divider: bool
+
+    def render_lines(self) -> list[str]:
+        return [self.text]
+
+
+class ProseBlock(BaseModel):
+    """A run of non-entry lines (free-form prose and blanks). Verbatim."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    kind: Literal["prose"] = "prose"
+    lines: tuple[str, ...]
+
+    def render_lines(self) -> list[str]:
+        return list(self.lines)
+
+
+class EntryBlock(BaseModel):
+    """A parsed ``- [...]`` question entry plus its continuation lines."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    kind: Literal["entry"] = "entry"
+    entry: QuestionEntry
+
+    def render_lines(self) -> list[str]:
+        return self.entry.render()
+
+
+class TripleHashBlock(BaseModel):
+    """A ``### `` topic header plus its directly-following body lines.
+
+    ``embedded_id`` is set when the head line contains a parseable
+    ``[YYYY-MM-DD HH:MM UTC]`` substring (treated as a question id for
+    boundary validation), otherwise None.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    kind: Literal["triple_hash"] = "triple_hash"
+    lines: tuple[str, ...]
+    embedded_id: str | None
+
+    def render_lines(self) -> list[str]:
+        return list(self.lines)
+
+
+class UnparsableBlock(BaseModel):
+    """A line that started with ``- [`` but couldn't be parsed as an entry.
+
+    Preserved verbatim so that round-tripping never silently drops user content.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    kind: Literal["unparsable"] = "unparsable"
+    lines: tuple[str, ...]
+
+    def render_lines(self) -> list[str]:
+        return list(self.lines)
+
+
+Block = Annotated[
+    HeaderBlock | ProseBlock | EntryBlock | TripleHashBlock | UnparsableBlock,
+    Field(discriminator="kind"),
+]
+
+
 @dataclass(frozen=True)
 class ResolveResult:
     """Outcome of :meth:`OpenQuestionsFile.resolve`.
@@ -91,8 +176,7 @@ class OpenQuestionsFile(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     header: str = _DEFAULT_HEADER
-    intro: list[str] = Field(default_factory=list)
-    entries: list[QuestionEntry] = Field(default_factory=list)
+    blocks: list[Block] = Field(default_factory=list)
 
     @classmethod
     def parse(cls, content: str) -> OpenQuestionsFile:
@@ -101,73 +185,122 @@ class OpenQuestionsFile(BaseModel):
         n = len(lines)
         header, i = _parse_header(lines, 0)
 
-        intro: list[str] = []
-        entries: list[QuestionEntry] = []
-        in_resolved_section = False
+        blocks: list[Block] = []
+        pending_prose: list[str] = []
+
+        def flush_prose() -> None:
+            if pending_prose:
+                blocks.append(ProseBlock(lines=tuple(pending_prose)))
+                pending_prose.clear()
 
         while i < n:
             line = lines[i]
-            stripped = line.strip()
 
-            if stripped.startswith("## "):
-                in_resolved_section = "resolved" in stripped.lower()
+            if line.startswith("## "):
+                flush_prose()
+                stripped = line.strip()
+                blocks.append(
+                    HeaderBlock(
+                        text=line.rstrip(),
+                        is_resolved_divider="resolved" in stripped.lower(),
+                    )
+                )
                 i += 1
                 continue
 
-            if not stripped:
-                if not entries:
-                    intro.append(line)
-                i += 1
+            if line.startswith("### "):
+                flush_prose()
+                head_line = line
+                triple_lines: list[str] = [head_line]
+                j = i + 1
+                while j < n:
+                    nxt = lines[j]
+                    if (
+                        not nxt.strip()
+                        or nxt.startswith("## ")
+                        or nxt.startswith("### ")
+                        or nxt.startswith("- [")
+                    ):
+                        break
+                    triple_lines.append(nxt)
+                    j += 1
+                embedded_id = _extract_embedded_id(head_line)
+                blocks.append(
+                    TripleHashBlock(
+                        lines=tuple(triple_lines),
+                        embedded_id=embedded_id,
+                    )
+                )
+                i = j
                 continue
 
             if line.startswith("- ["):
-                entry, consumed = _parse_entry(lines, i, in_resolved_section)
-                if entry is not None:
-                    entries.append(entry)
+                flush_prose()
+                entry, consumed = _parse_entry(lines, i)
+                if entry is None:
+                    blocks.append(UnparsableBlock(lines=(line,)))
+                    i += 1
+                else:
+                    blocks.append(EntryBlock(entry=entry))
                     i += consumed
-                    continue
+                continue
 
-            if not entries:
-                intro.append(line)
+            pending_prose.append(line)
             i += 1
 
-        while intro and not intro[-1].strip():
-            intro.pop()
+        flush_prose()
 
-        return cls(header=header, intro=intro, entries=entries)
+        return cls(header=header, blocks=blocks)
 
     def format(self) -> str:
         """Render the file back to markdown."""
         out: list[str] = [self.header]
-        if self.intro:
-            out.extend(self.intro)
-
-        open_entries = [e for e in self.entries if e.resolved_by is None]
-        resolved_entries = [e for e in self.entries if e.resolved_by is not None]
-
-        for entry in open_entries:
-            out.append("")
-            out.extend(entry.render())
-
-        if resolved_entries:
-            out.append("")
-            out.append(_RESOLVED_HEADER)
-            for entry in resolved_entries:
-                out.append("")
-                out.extend(entry.render())
-
-        out.append("")
+        for b in self.blocks:
+            out.extend(b.render_lines())
         return "\n".join(out)
 
     @property
+    def resolved_divider_idx(self) -> int | None:
+        """Index of the ``## Resolved`` HeaderBlock in :attr:`blocks`, or None."""
+        for idx, b in enumerate(self.blocks):
+            if isinstance(b, HeaderBlock) and b.is_resolved_divider:
+                return idx
+        return None
+
+    @property
     def open_ids(self) -> list[str]:
-        """Ids of currently-open questions."""
-        return [e.id for e in self.entries if e.resolved_by is None]
+        """Entry ids appearing before the ``## Resolved`` divider (or all if no divider)."""
+        divider = self.resolved_divider_idx
+        result: list[str] = []
+        for idx, b in enumerate(self.blocks):
+            if divider is not None and idx >= divider:
+                break
+            if isinstance(b, EntryBlock):
+                result.append(b.entry.id)
+        return result
 
     @property
     def resolved_ids(self) -> list[str]:
-        """Ids of already-resolved questions."""
-        return [e.id for e in self.entries if e.resolved_by is not None]
+        """Entry ids appearing after the ``## Resolved`` divider."""
+        divider = self.resolved_divider_idx
+        if divider is None:
+            return []
+        result: list[str] = []
+        for b in self.blocks[divider + 1 :]:
+            if isinstance(b, EntryBlock):
+                result.append(b.entry.id)
+        return result
+
+    @property
+    def known_question_ids(self) -> set[str]:
+        """All ids the file knows about: entry ids plus triple-hash embedded ids."""
+        known: set[str] = set()
+        for b in self.blocks:
+            if isinstance(b, EntryBlock):
+                known.add(b.entry.id)
+            elif isinstance(b, TripleHashBlock) and b.embedded_id is not None:
+                known.add(b.embedded_id)
+        return known
 
     def resolve(
         self,
@@ -175,33 +308,47 @@ class OpenQuestionsFile(BaseModel):
         decision_num: int,
         date: _date,
     ) -> ResolveResult:
-        """Mark entries with the given timestamp ids as resolved by ``decision_num``."""
+        """Mark entries with the given timestamp ids as resolved by ``decision_num``.
+
+        Blocks are flipped in place — they are never reordered. An entry
+        physically under ``## Resolved`` stays where it is. When no
+        ``## Resolved`` divider exists yet and at least one pre-divider
+        entry was flipped, a divider is appended after the existing blocks.
+        """
         if not ids:
             return ResolveResult(file=self, moved_ids=(), unknown_ids=())
 
         requested = list(dict.fromkeys(ids))
-        by_id = {e.id: e for e in self.entries}
         ref = ResolvedRef(decision_num=decision_num, date=date)
+        requested_set = set(requested)
+        known = self.known_question_ids
+        unknown = tuple(i for i in requested if i not in known)
+        moved = tuple(i for i in requested if i in known)
 
-        new_entries = [
-            entry.model_copy(update={"resolved_by": ref})
-            if entry.id in requested and entry.resolved_by is None
-            else entry
-            for entry in self.entries
-        ]
-
-        moved: list[str] = []
-        unknown: list[str] = []
-        for ts_id in requested:
-            if ts_id in by_id:
-                moved.append(ts_id)
+        divider_idx = self.resolved_divider_idx
+        new_blocks: list[Block] = []
+        any_pre_divider_flip = False
+        for idx, b in enumerate(self.blocks):
+            if (
+                isinstance(b, EntryBlock)
+                and b.entry.id in requested_set
+                and b.entry.resolved_by is None
+            ):
+                new_entry = b.entry.model_copy(update={"resolved_by": ref})
+                new_blocks.append(EntryBlock(entry=new_entry))
+                if divider_idx is None or idx < divider_idx:
+                    any_pre_divider_flip = True
             else:
-                unknown.append(ts_id)
+                new_blocks.append(b)
+
+        if divider_idx is None and any_pre_divider_flip:
+            new_blocks.append(ProseBlock(lines=("",)))
+            new_blocks.append(HeaderBlock(text=_RESOLVED_HEADER, is_resolved_divider=True))
 
         return ResolveResult(
-            file=self.model_copy(update={"entries": new_entries}),
-            moved_ids=tuple(moved),
-            unknown_ids=tuple(unknown),
+            file=self.model_copy(update={"blocks": new_blocks}),
+            moved_ids=moved,
+            unknown_ids=unknown,
         )
 
 
@@ -221,13 +368,12 @@ def _parse_header(lines: list[str], i: int) -> tuple[str, int]:
     return header, i
 
 
-def _parse_entry(
-    lines: list[str], start: int, in_resolved_section: bool
-) -> tuple[QuestionEntry | None, int]:
+def _parse_entry(lines: list[str], start: int) -> tuple[QuestionEntry | None, int]:
     """Parse a single ``- [...] body`` entry starting at ``lines[start]``.
 
     Returns ``(entry, lines_consumed)``. ``entry`` is None when the line
-    can't be parsed; the caller advances past the unparsable line.
+    can't be parsed; the caller is responsible for preserving the original
+    line (typically as an :class:`UnparsableBlock`).
     """
     line = lines[start]
     if not line.startswith("- ["):
@@ -260,14 +406,6 @@ def _parse_entry(
     except ValueError:
         return None, 1
 
-    if in_resolved_section and resolved_ref is None:
-        # An open-form entry that landed under ## Resolved is parsable but
-        # has no ResolvedRef. Surface it as resolved with no ref so it
-        # doesn't reappear in the open section on round-trip; the caller
-        # can heal it on the next write by re-resolving with a real ref.
-        # In practice the writer always emits the resolved-prefix form.
-        pass
-
     continuation: list[str] = []
     j = start + 1
     while j < len(lines) and lines[j].startswith("  "):
@@ -299,3 +437,23 @@ def _parse_resolved_prefix(text: str) -> ResolvedRef | None:
         return ResolvedRef(decision_num=int(num_str), date=_date.fromisoformat(date_str))
     except (ValueError, TypeError):
         return None
+
+
+def _extract_embedded_id(line: str) -> str | None:
+    """Find a ``[YYYY-MM-DD HH:MM UTC]`` substring in ``line`` and return its id text.
+
+    Uses plain string ops (no regex). Returns the inner timestamp text if
+    parseable as the canonical format, else None.
+    """
+    start = line.find("[")
+    while start != -1:
+        end = line.find("]", start + 1)
+        if end == -1:
+            return None
+        candidate = line[start + 1 : end]
+        try:
+            datetime.strptime(candidate, _TIMESTAMP_FMT)
+            return candidate
+        except ValueError:
+            start = line.find("[", end + 1)
+    return None

--- a/packages/nauro-core/tests/test_questions.py
+++ b/packages/nauro-core/tests/test_questions.py
@@ -5,9 +5,14 @@ from datetime import date
 import pytest
 
 from nauro_core.questions import (
+    EntryBlock,
+    HeaderBlock,
     OpenQuestionsFile,
+    ProseBlock,
     QuestionEntry,
     ResolvedRef,
+    TripleHashBlock,
+    UnparsableBlock,
 )
 
 
@@ -21,7 +26,7 @@ class TestParseRoundTrip:
     def test_empty_file_yields_default_header(self):
         file = OpenQuestionsFile.parse("")
         assert file.header == "# Open Questions"
-        assert file.entries == []
+        assert file.blocks == []
 
     def test_open_only(self):
         content = (
@@ -47,8 +52,10 @@ class TestParseRoundTrip:
         file = OpenQuestionsFile.parse(content)
         assert file.open_ids == ["2026-05-12 20:18 UTC"]
         assert file.resolved_ids == ["2026-04-30 10:00 UTC"]
-        resolved_entry = file.entries[1]
-        assert resolved_entry.resolved_by == ResolvedRef(decision_num=100, date=date(2026, 5, 1))
+        resolved_block = [b for b in file.blocks if isinstance(b, EntryBlock)][1]
+        assert resolved_block.entry.resolved_by == ResolvedRef(
+            decision_num=100, date=date(2026, 5, 1)
+        )
 
     def test_continuation_lines(self):
         content = (
@@ -60,11 +67,12 @@ class TestParseRoundTrip:
             "- [2026-05-11 15:29 UTC] q2\n"
         )
         file = OpenQuestionsFile.parse(content)
-        assert file.entries[0].continuation == [
+        entry_blocks = [b for b in file.blocks if isinstance(b, EntryBlock)]
+        assert entry_blocks[0].entry.continuation == [
             "  Context: extra detail",
             "  Another continuation line",
         ]
-        assert file.entries[1].continuation == []
+        assert entry_blocks[1].entry.continuation == []
 
     def test_intro_text_preserved(self):
         content = "# Open Questions\n\nFree-form intro paragraph.\n\n- [2026-05-12 20:18 UTC] q1\n"
@@ -85,7 +93,6 @@ class TestParseRoundTrip:
         )
         file = OpenQuestionsFile.parse(content)
         rendered = file.format()
-        # Re-parsing the rendered output yields the same model.
         re_parsed = OpenQuestionsFile.parse(rendered)
         assert re_parsed == file
 
@@ -95,6 +102,116 @@ class TestParseRoundTrip:
         )
         file = OpenQuestionsFile.parse(content)
         assert file.open_ids == ["2026-05-12 20:18 UTC"]
+
+
+class TestRoundTripFidelity:
+    """Byte-identical round-trip cases for inputs that don't go through resolve."""
+
+    def test_round_trip_blank_lines_between_entries(self):
+        content = (
+            "# Open Questions\n\n- [2026-05-12 20:18 UTC] q1\n\n\n- [2026-05-11 15:29 UTC] q2\n"
+        )
+        assert OpenQuestionsFile.parse(content).format() == content
+
+    def test_round_trip_prose_after_first_entry(self):
+        content = (
+            "# Open Questions\n"
+            "\n"
+            "- [2026-05-12 20:18 UTC] q1\n"
+            "\n"
+            "Some commentary inserted by a human.\n"
+            "\n"
+            "- [2026-05-11 15:29 UTC] q2\n"
+        )
+        assert OpenQuestionsFile.parse(content).format() == content
+
+    def test_round_trip_unparseable_dash_bracket_line(self):
+        content = (
+            "# Open Questions\n"
+            "\n"
+            "- [2026-05-12 20:18 UTC] q1\n"
+            "- [not-a-timestamp] garbage but please keep\n"
+            "- [2026-05-11 15:29 UTC] q2\n"
+        )
+        assert OpenQuestionsFile.parse(content).format() == content
+
+    def test_round_trip_open_form_under_resolved_header(self):
+        content = (
+            "# Open Questions\n"
+            "\n"
+            "- [2026-05-12 20:18 UTC] still open\n"
+            "\n"
+            "## Resolved\n"
+            "\n"
+            "- [2026-04-30 10:00 UTC] open-form entry that lives here\n"
+        )
+        assert OpenQuestionsFile.parse(content).format() == content
+
+    def test_round_trip_triple_hash_topic_entries(self):
+        content = (
+            "# Open Questions\n"
+            "\n"
+            "### Topic: deployment\n"
+            "Some topic narrative.\n"
+            "More narrative.\n"
+            "\n"
+            "- [2026-05-12 20:18 UTC] q1\n"
+        )
+        assert OpenQuestionsFile.parse(content).format() == content
+
+    def test_round_trip_triple_hash_with_embedded_timestamp_id(self):
+        content = (
+            "# Open Questions\n"
+            "\n"
+            "### [2026-05-10 09:00 UTC] Topic: deployment\n"
+            "Some topic body.\n"
+            "\n"
+            "- [2026-05-12 20:18 UTC] q1\n"
+        )
+        file = OpenQuestionsFile.parse(content)
+        assert file.format() == content
+        triple = next(b for b in file.blocks if isinstance(b, TripleHashBlock))
+        assert triple.embedded_id == "2026-05-10 09:00 UTC"
+
+    def test_round_trip_trailing_whitespace_preserved(self):
+        content = "# Open Questions\n\nIntro paragraph.\n\n\n- [2026-05-12 20:18 UTC] q1\n"
+        assert OpenQuestionsFile.parse(content).format() == content
+
+    def test_known_question_ids_includes_triple_hash_embedded(self):
+        content = (
+            "# Open Questions\n"
+            "\n"
+            "### [2026-05-10 09:00 UTC] Topic: x\n"
+            "narrative\n"
+            "\n"
+            "- [2026-05-12 20:18 UTC] q1\n"
+        )
+        file = OpenQuestionsFile.parse(content)
+        assert file.known_question_ids == {
+            "2026-05-10 09:00 UTC",
+            "2026-05-12 20:18 UTC",
+        }
+
+    def test_open_ids_uses_position_not_resolved_by(self):
+        """Bug #4: open-form entry physically under ## Resolved must report as resolved."""
+        content = (
+            "# Open Questions\n"
+            "\n"
+            "- [2026-05-12 20:18 UTC] still open\n"
+            "\n"
+            "## Resolved\n"
+            "\n"
+            "- [2026-04-30 10:00 UTC] open-form-but-under-resolved\n"
+        )
+        file = OpenQuestionsFile.parse(content)
+        assert file.open_ids == ["2026-05-12 20:18 UTC"]
+        assert file.resolved_ids == ["2026-04-30 10:00 UTC"]
+
+    def test_unparsable_block_appears_in_blocks(self):
+        content = "# Open Questions\n\n- [2026-05-12 20:18 UTC] q1\n- [not-a-timestamp] garbage\n"
+        file = OpenQuestionsFile.parse(content)
+        kinds = [type(b).__name__ for b in file.blocks]
+        assert "UnparsableBlock" in kinds
 
 
 class TestResolve:
@@ -117,10 +234,11 @@ class TestResolve:
         result = self._file().resolve(["2026-05-12 20:18 UTC"], 139, date(2026, 5, 14))
         assert result.moved_ids == ("2026-05-12 20:18 UTC",)
         assert result.unknown_ids == ()
-        assert result.file.open_ids == ["2026-05-11 15:29 UTC"]
-        assert result.file.resolved_ids == ["2026-05-12 20:18 UTC"]
         rendered = result.file.format()
         assert "- [Resolved by D139 on 2026-05-14] [2026-05-12 20:18 UTC] q1 body" in rendered
+        assert "## Resolved" in rendered
+        # Untouched entry still renders in open form.
+        assert "- [2026-05-11 15:29 UTC] q2 body" in rendered
 
     def test_idempotent_when_already_resolved(self):
         file = OpenQuestionsFile.parse(
@@ -136,7 +254,6 @@ class TestResolve:
         result = file.resolve(["2026-04-30 10:00 UTC"], 139, date(2026, 5, 14))
         assert result.moved_ids == ("2026-04-30 10:00 UTC",)
         assert result.unknown_ids == ()
-        # Already-resolved is not rewritten — rendered output is unchanged.
         assert result.file.format() == before
 
     def test_unknown_id_surfaces(self):
@@ -168,7 +285,8 @@ class TestResolve:
             "2026-04-30 10:00 UTC",
         }
         assert result.unknown_ids == ("2099-01-01 00:00 UTC",)
-        assert result.file.open_ids == []
+        rendered = result.file.format()
+        assert "- [Resolved by D139 on 2026-05-14] [2026-05-12 20:18 UTC] q1" in rendered
 
     def test_continuation_lines_carry_over(self):
         file = OpenQuestionsFile.parse(
@@ -177,8 +295,8 @@ class TestResolve:
         result = file.resolve(["2026-05-12 20:18 UTC"], 139, date(2026, 5, 14))
         rendered = result.file.format()
         assert "  Context: extra detail" in rendered
-        # Continuation appears under the resolved heading, not before it.
-        head_idx = rendered.index("## Resolved")
+        # Continuation immediately follows the (now resolved) head line.
+        head_idx = rendered.index("[Resolved by D139")
         assert rendered.index("Context: extra detail") > head_idx
 
     def test_dedupe_input_ids(self):
@@ -188,6 +306,50 @@ class TestResolve:
             date(2026, 5, 14),
         )
         assert result.moved_ids == ("2026-05-12 20:18 UTC",)
+
+    def test_resolve_preserves_round_trip_for_unmodified_blocks(self):
+        """Unmodified blocks (prose, unparsable, triple-hash, blanks) must survive resolve()."""
+        content = (
+            "# Open Questions\n"
+            "\n"
+            "### Topic: deployment\n"
+            "narrative\n"
+            "\n"
+            "- [2026-05-12 20:18 UTC] q1\n"
+            "\n"
+            "Free-form prose between entries.\n"
+            "\n"
+            "- [not-a-timestamp] keep me\n"
+            "- [2026-05-11 15:29 UTC] q2\n"
+        )
+        file = OpenQuestionsFile.parse(content)
+        result = file.resolve(["2026-05-12 20:18 UTC"], 139, date(2026, 5, 14))
+        rendered = result.file.format()
+        assert "### Topic: deployment" in rendered
+        assert "narrative" in rendered
+        assert "Free-form prose between entries." in rendered
+        assert "- [not-a-timestamp] keep me" in rendered
+        assert "- [Resolved by D139 on 2026-05-14] [2026-05-12 20:18 UTC] q1" in rendered
+
+    def test_resolve_with_no_existing_resolved_header_inserts_one(self):
+        file = OpenQuestionsFile.parse("# Open Questions\n\n- [2026-05-12 20:18 UTC] q1\n")
+        result = file.resolve(["2026-05-12 20:18 UTC"], 139, date(2026, 5, 14))
+        rendered = result.file.format()
+        assert rendered.count("## Resolved") == 1
+
+    def test_resolve_with_existing_resolved_header_does_not_duplicate_it(self):
+        file = OpenQuestionsFile.parse(
+            "# Open Questions\n"
+            "\n"
+            "- [2026-05-12 20:18 UTC] q1\n"
+            "\n"
+            "## Resolved\n"
+            "\n"
+            "- [Resolved by D100 on 2026-05-01] [2026-04-30 10:00 UTC] q-old\n"
+        )
+        result = file.resolve(["2026-05-12 20:18 UTC"], 139, date(2026, 5, 14))
+        rendered = result.file.format()
+        assert rendered.count("## Resolved") == 1
 
 
 class TestEntryRender:
@@ -211,3 +373,14 @@ class TestEntryRender:
         assert entry.render() == [
             "- [Resolved by D139 on 2026-05-14] [2026-05-12 20:18 UTC] q text"
         ]
+
+
+class TestBlockTypes:
+    """Block type exports stay importable from nauro_core.questions."""
+
+    def test_block_types_importable(self):
+        assert HeaderBlock is not None
+        assert ProseBlock is not None
+        assert EntryBlock is not None
+        assert TripleHashBlock is not None
+        assert UnparsableBlock is not None

--- a/packages/nauro-core/tests/test_questions.py
+++ b/packages/nauro-core/tests/test_questions.py
@@ -351,6 +351,18 @@ class TestResolve:
         rendered = result.file.format()
         assert rendered.count("## Resolved") == 1
 
+    def test_triple_hash_only_id_reported_unknown_not_moved(self):
+        """An id that exists only inside a ``### [timestamp]`` block is not movable
+        via resolve, so resolve reports it in unknown_ids even though
+        known_question_ids includes it for boundary validation."""
+        content = "# Open Questions\n\n### [2026-05-12 20:18 UTC] Topic question\n  body line\n"
+        file = OpenQuestionsFile.parse(content)
+        assert "2026-05-12 20:18 UTC" in file.known_question_ids
+        result = file.resolve(["2026-05-12 20:18 UTC"], 200, date(2026, 5, 18))
+        assert result.moved_ids == ()
+        assert result.unknown_ids == ("2026-05-12 20:18 UTC",)
+        assert result.file.format() == content
+
 
 class TestEntryRender:
     def test_open_form(self):

--- a/packages/nauro/src/nauro/validation/pipeline.py
+++ b/packages/nauro/src/nauro/validation/pipeline.py
@@ -392,5 +392,5 @@ def _unknown_question_ids(ids: list[str], project_path: Path) -> list[str]:
     if not oq_path.exists():
         return list(ids)
     file = OpenQuestionsFile.parse(oq_path.read_text())
-    known = set(file.open_ids) | set(file.resolved_ids)
+    known = file.known_question_ids
     return [tid for tid in ids if tid not in known]

--- a/packages/nauro/tests/test_stdio_server.py
+++ b/packages/nauro/tests/test_stdio_server.py
@@ -194,9 +194,9 @@ class TestProposeDecisionResolvesQuestions:
         assert result["status"] == "confirmed"
         assert result.get("resolved_questions") == [question_id]
         oq = (store / "open-questions.md").read_text()
-        open_section = oq.split("## Resolved", 1)[0]
-        assert f"[{question_id}]" not in open_section
         assert "## Resolved" in oq
+        assert "[Resolved by D" in oq
+        assert f"[{question_id}]" in oq
 
     def test_unknown_id_rejects_at_boundary(self, store: Path):
         self._seed_question(store)

--- a/packages/nauro/tests/test_validation/test_pipeline.py
+++ b/packages/nauro/tests/test_validation/test_pipeline.py
@@ -416,12 +416,11 @@ class TestD139ResolvesQuestions:
         assert result.resolved_questions == ("2026-05-12 20:18 UTC",)
         oq_content = (store_with_questions / "open-questions.md").read_text()
         assert "## Resolved" in oq_content
+        # Resolved entry carries the back-ref prefix.
         assert "[Resolved by D" in oq_content
-        # q-one moved out of the open section
-        open_part = oq_content.split("## Resolved", 1)[0]
-        assert "[2026-05-12 20:18 UTC]" not in open_part
-        # q-two still in the open section
-        assert "[2026-05-11 15:29 UTC] q-two body text" in open_part
+        assert "[2026-05-12 20:18 UTC] q-one body text" in oq_content
+        # q-two stays open (no prefix).
+        assert "- [2026-05-11 15:29 UTC] q-two body text" in oq_content
 
     def test_resolves_through_pending_confirm(self, store_with_questions: Path) -> None:
         proposal = {


### PR DESCRIPTION
## Why

`OpenQuestionsFile.parse → format` silently drops or rewrites six classes of input that real `open-questions.md` files contain:

1. Blank lines between entries — collapsed to one canonical blank by `format`.
2. Free-form prose after the first entry — `parse` only appends to `intro` while `not entries`; later prose was discarded.
3. Unparseable `- [` lines after the first entry — `_parse_entry` returns None, the line was skipped, nothing captured it.
4. Open-form entries that physically sit under `## Resolved` — parser left `resolved_by=None`, but `format` re-emitted under the open section because the partition was `resolved_by is None`. The line teleported.
5. `### Topic` sub-section content — never matched, dropped entirely.
6. Trailing intro whitespace — stripped by `while intro and not intro[-1].strip(): intro.pop()`.

The first `resolve_questions_in_file` call after a `propose_decision(resolves_questions=[...])` overwrites the live file with the lossy render. D139 promised that path would be safe; it wasn't.

Refs: confirm_id `dd6b973c-5119-4c94-9103-60a9ab1461b6` (pending Nauro proposal).

## Approach

Keep the Pydantic `OpenQuestionsFile` model but evolve its internal shape so every input line round-trips. Replace `entries: list[QuestionEntry]` with `blocks: list[Block]`, a discriminated union over `HeaderBlock`, `ProseBlock`, `EntryBlock`, `TripleHashBlock`, `UnparsableBlock`. Each markdown line maps to exactly one block, so `parse → format` is byte-identical for any input that doesn't pass through `resolve`.

The `## Resolved` `HeaderBlock`'s index in the list IS the open/resolved divider — section membership is positional, not field-based. This closes bug #4: an open-form entry physically under `## Resolved` reports as resolved without needing to be rewritten on disk.

`resolve()` flips `resolved_by` in place on matching entries — it never reorders blocks. A fresh resolution against a divider-less file appends a `## Resolved` header after the existing blocks. Alternatives considered: a "physically migrate the resolved entry under `## Resolved`" variant was rejected because it reintroduces movement of user-visible content for a workflow that, in practice, never needed it — readers care that the entry has the `[Resolved by Dnn ...]` prefix, not that it physically jumped sections.

## What changed

- **`nauro_core.questions`** — replaced `intro`/`entries` with `blocks: list[Block]`; added five frozen Pydantic block types with `kind: Literal[...]` discriminators; added `_extract_embedded_id` (plain string ops — no regex per project rules); added `known_question_ids`, `resolved_divider_idx` properties; rewrote `parse`/`format`/`resolve` around the block list. `resolve.moved_ids` and `unknown_ids` partition against EntryBlock ids specifically, while `known_question_ids` remains the wider boundary-validation primitive (covers EntryBlock ids ∪ TripleHashBlock embedded ids).
- **`nauro_core.__init__`** — exported `Block`, `HeaderBlock`, `ProseBlock`, `EntryBlock`, `TripleHashBlock`, `UnparsableBlock`.
- **`nauro.validation.pipeline._unknown_question_ids`** — switched to `file.known_question_ids` (covers entry ids + `### Topic` embedded ids in one primitive).
- **Tests** — updated three `TestResolve` tests in `test_questions.py` to match the new flip-in-place contract; added `TestRoundTripFidelity` (10 tests) covering each bug class with exact-string equality; added a regression test that confirms a `### Topic`-only id is in `known_question_ids` but reported as `unknown_ids` by `resolve` (and not as a false `moved_ids`). Updated two consumer tests (`test_stdio_server.py`, `test_validation/test_pipeline.py`) that asserted physical migration; they now assert the rendered `[Resolved by Dnn ...]` prefix and `## Resolved` divider are present.

## What to review

- `OpenQuestionsFile.resolve` (questions.py): the new contract is flip-in-place. The "append a `## Resolved` divider only if there isn't one AND at least one pre-divider entry was flipped" branch is the one easy to get subtly wrong. `moved`/`unknown` are partitioned against EntryBlock ids specifically; `known_question_ids` keeps its wider meaning for upstream Tier 1 validation.
- `_extract_embedded_id`: scans `[...]` substrings left-to-right and returns the first parseable `YYYY-MM-DD HH:MM UTC`. No regex.
- `parse`'s `### ` consumption stops at blank/`## `/`### `/`- [` — review whether that boundary matches your mental model.
- Round-trip fidelity for inputs is a hard guarantee (`parse(s).format() == s` for non-resolve paths). Round-trip of resolve output is also stable.
- Behavior change: `open_ids` after `resolve()` no longer drops the flipped entry. Two consumer tests were updated to reflect the new contract. Pipeline code only uses `moved_ids` and `known_question_ids`, which still behave correctly.

## What's deferred

- **mcp-server boundary tightening (`mcp-server/src/mcp_server/validation.py`)** — that repo's `### Topic`-id validation could use the new unified `known_question_ids` primitive, but is non-breaking against this PR's nauro-core because `open_ids`/`resolved_ids` still exist (now positional). The `make bump-nauro-core REV=<sha>` step in mcp-server needs a real merged commit, which only exists after this PR merges. Follow-up PR will land in mcp-server.

## Test plan

- [x] `uv run pytest packages/nauro-core/tests/ -q` — 337 passed (12 new round-trip fidelity tests covering each of the six bug classes plus an `open_ids`-by-position regression test for bug #4 and a regression test for `### Topic`-only id reporting).
- [x] `uv run pytest packages/nauro/tests/ -q` — 960 passed.
- [x] `uv run ruff format --check packages/` — clean.
- [x] `uv run ruff check packages/` — clean.
- [x] Manual smoke: `parse → resolve → format → parse → format` is stable on a multi-block file mixing prose, unparseable lines, `### Topic` blocks, and continuation lines.