### PR TITLE
feat(questions): sequential Q identifier scheme for open-questions.md

### DIFF
--- a/.agents/skills/nauro/SKILL.md
+++ b/.agents/skills/nauro/SKILL.md
@@ -17,7 +17,7 @@ When the user proposes — or the agent considers proposing — an architectural
 
 This includes "should we…", "what if we…", "can we…", and "check if…" framings, and applies even when the agent intends to push back or refuse. First-principles reasoning is not a substitute for project history.
 
-When a proposal closes one of `get_context`'s open questions, include the question's `[YYYY-MM-DD HH:MM UTC]` timestamp in `resolves_questions`. The named entries move under `## Resolved` with a back-reference to the new decision on confirm; unknown ids reject at the boundary.
+When a proposal closes one of `get_context`'s open questions, include the question's `[Q###]` id in `resolves_questions`. Legacy `[YYYY-MM-DD HH:MM UTC]` ids are still accepted for entries that predate the Q-form rollout. The named entries move under `## Resolved` with a back-reference to the new decision on confirm; unknown or ambiguous ids reject at the boundary.
 
 ## After meaningful progress — call update_state
 

--- a/.claude/skills/nauro/SKILL.md
+++ b/.claude/skills/nauro/SKILL.md
@@ -17,7 +17,7 @@ When the user proposes — or the agent considers proposing — an architectural
 
 This includes "should we…", "what if we…", "can we…", and "check if…" framings, and applies even when the agent intends to push back or refuse. First-principles reasoning is not a substitute for project history.
 
-When a proposal closes one of `get_context`'s open questions, include the question's `[YYYY-MM-DD HH:MM UTC]` timestamp in `resolves_questions`. The named entries move under `## Resolved` with a back-reference to the new decision on confirm; unknown ids reject at the boundary.
+When a proposal closes one of `get_context`'s open questions, include the question's `[Q###]` id in `resolves_questions`. Legacy `[YYYY-MM-DD HH:MM UTC]` ids are still accepted for entries that predate the Q-form rollout. The named entries move under `## Resolved` with a back-reference to the new decision on confirm; unknown or ambiguous ids reject at the boundary.
 
 ## After meaningful progress — call update_state
 

--- a/.cursor/rules/nauro.mdc
+++ b/.cursor/rules/nauro.mdc
@@ -17,7 +17,7 @@ When the user proposes — or the agent considers proposing — an architectural
 
 This includes "should we…", "what if we…", "can we…", and "check if…" framings, and applies even when the agent intends to push back or refuse. First-principles reasoning is not a substitute for project history.
 
-When a proposal closes one of `get_context`'s open questions, include the question's `[YYYY-MM-DD HH:MM UTC]` timestamp in `resolves_questions`. The named entries move under `## Resolved` with a back-reference to the new decision on confirm; unknown ids reject at the boundary.
+When a proposal closes one of `get_context`'s open questions, include the question's `[Q###]` id in `resolves_questions`. Legacy `[YYYY-MM-DD HH:MM UTC]` ids are still accepted for entries that predate the Q-form rollout. The named entries move under `## Resolved` with a back-reference to the new decision on confirm; unknown or ambiguous ids reject at the boundary.
 
 ## After meaningful progress — call update_state
 

--- a/packages/nauro-core/src/nauro_core/protocol.py
+++ b/packages/nauro-core/src/nauro_core/protocol.py
@@ -58,10 +58,11 @@ NO_INVENT_RATIONALE = (
 
 RESOLVES_OPEN_QUESTIONS = (
     "When a proposal closes one of `get_context`'s open questions, include "
-    "the question's `[YYYY-MM-DD HH:MM UTC]` timestamp in "
-    "`resolves_questions`. The named entries move under `## Resolved` with a "
-    "back-reference to the new decision on confirm; unknown ids reject at "
-    "the boundary."
+    "the question's `[Q###]` id in `resolves_questions`. Legacy "
+    "`[YYYY-MM-DD HH:MM UTC]` ids are still accepted for entries that "
+    "predate the Q-form rollout. The named entries move under "
+    "`## Resolved` with a back-reference to the new decision on confirm; "
+    "unknown or ambiguous ids reject at the boundary."
 )
 
 CANONICAL_FRAGMENTS: dict[str, str] = {

--- a/packages/nauro-core/src/nauro_core/questions.py
+++ b/packages/nauro-core/src/nauro_core/questions.py
@@ -4,12 +4,16 @@ The authoritative shape for parsed open-questions.md content. Mirrors
 ``decision_model.Decision``: ``OpenQuestionsFile.parse`` reads markdown,
 ``format`` writes it back, and validation lives on the model.
 
-A question entry is identified by the UTC timestamp inside its
-``[YYYY-MM-DD HH:MM UTC]`` prefix — the same id ``flag_question`` writes.
-Resolution sets ``resolved_by`` on the matching :class:`EntryBlock`;
-``format`` then re-emits it with the ``[Resolved by Dnn on
-YYYY-MM-DD]`` prefix. ``parse_questions`` (in :mod:`nauro_core.parsing`)
-already filters the ``## Resolved`` subsection out of L0 reads.
+A question entry is identified by its ``[Q###]`` prefix (sequential int
+minted by the writer as ``max(num) + 1`` against the existing store).
+The parser also accepts the legacy ``[YYYY-MM-DD HH:MM UTC]`` form so
+entries written before the Q-form rollout keep round-tripping without
+rewrite. The discriminator is which of ``num`` / ``timestamp`` is set on
+:class:`QuestionEntry`. Resolution sets ``resolved_by`` on the matching
+:class:`EntryBlock`; ``format`` then re-emits it with the ``[Resolved by
+Dnn on YYYY-MM-DD]`` prefix. ``parse_questions`` (in
+:mod:`nauro_core.parsing`) already filters the ``## Resolved`` subsection
+out of L0 reads.
 
 The internal shape is a flat ``blocks`` list. Each markdown line maps to
 exactly one block (``HeaderBlock``, ``ProseBlock``, ``EntryBlock``,
@@ -26,7 +30,7 @@ from datetime import date as _date
 from datetime import datetime
 from typing import Annotated, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 _TIMESTAMP_FMT = "%Y-%m-%d %H:%M UTC"
 _RESOLVED_HEADER = "## Resolved"
@@ -47,19 +51,34 @@ class ResolvedRef(BaseModel):
 class QuestionEntry(BaseModel):
     """A single question entry.
 
-    Open when ``resolved_by`` is None; resolved otherwise. The timestamp
-    doubles as the entry's stable id (``id`` property).
+    Open when ``resolved_by`` is None; resolved otherwise. Exactly one of
+    ``num`` (Q-form, the canonical id) or ``timestamp`` (legacy form,
+    accepted on parse so older entries round-trip without rewrite) must
+    be set; the validator below enforces this.
     """
 
     model_config = ConfigDict(extra="forbid")
 
-    timestamp: datetime
+    num: int | None = Field(default=None, ge=1)
+    timestamp: datetime | None = None
     body: str
     continuation: list[str] = Field(default_factory=list)
     resolved_by: ResolvedRef | None = None
 
+    @model_validator(mode="after")
+    def exactly_one_id(self) -> QuestionEntry:
+        if (self.num is None) == (self.timestamp is None):
+            raise ValueError(
+                "QuestionEntry requires exactly one of num or timestamp to be set; "
+                f"got num={self.num!r}, timestamp={self.timestamp!r}."
+            )
+        return self
+
     @property
     def id(self) -> str:
+        if self.num is not None:
+            return f"Q{self.num}"
+        assert self.timestamp is not None  # exactly_one_id validator
         return self.timestamp.strftime(_TIMESTAMP_FMT)
 
     def render(self) -> list[str]:
@@ -163,11 +182,16 @@ class ResolveResult:
             achieved).
         unknown_ids: Ids absent from the file. The caller decides whether
             to surface this as a hard rejection.
+        ambiguous_ids: Ids that matched more than one EntryBlock. When
+            non-empty no blocks were mutated — the input file is returned
+            unchanged. Defensive guard for callers that bypassed the
+            pipeline's ambiguity gate.
     """
 
     file: OpenQuestionsFile
     moved_ids: tuple[str, ...]
     unknown_ids: tuple[str, ...]
+    ambiguous_ids: tuple[str, ...] = ()
 
 
 class OpenQuestionsFile(BaseModel):
@@ -302,23 +326,53 @@ class OpenQuestionsFile(BaseModel):
                 known.add(b.embedded_id)
         return known
 
+    @property
+    def ambiguous_ids(self) -> dict[str, int]:
+        """EntryBlock ids that appear more than once in the file (id -> count).
+
+        Legacy timestamp ids can collide when two questions were logged
+        in the same minute. Q-form ids should be unique by construction,
+        but the property reports any collision so the boundary can reject
+        before mutation.
+        """
+        counts: dict[str, int] = {}
+        for b in self.blocks:
+            if isinstance(b, EntryBlock):
+                counts[b.entry.id] = counts.get(b.entry.id, 0) + 1
+        return {k: v for k, v in counts.items() if v > 1}
+
     def resolve(
         self,
         ids: list[str],
         decision_num: int,
         date: _date,
     ) -> ResolveResult:
-        """Mark entries with the given timestamp ids as resolved by ``decision_num``.
+        """Mark entries with the given ids as resolved by ``decision_num``.
 
         Blocks are flipped in place — they are never reordered. An entry
         physically under ``## Resolved`` stays where it is. When no
         ``## Resolved`` divider exists yet and at least one pre-divider
         entry was flipped, a divider is appended after the existing blocks.
+
+        If any requested id matches more than one EntryBlock, no blocks
+        are mutated and ``ResolveResult.ambiguous_ids`` reports the
+        offending ids. Defense in depth — the validation pipeline should
+        reject ambiguous ids before this call.
         """
         if not ids:
             return ResolveResult(file=self, moved_ids=(), unknown_ids=())
 
         requested = list(dict.fromkeys(ids))
+        ambiguous_map = self.ambiguous_ids
+        ambiguous_requested = tuple(i for i in requested if i in ambiguous_map)
+        if ambiguous_requested:
+            return ResolveResult(
+                file=self,
+                moved_ids=(),
+                unknown_ids=(),
+                ambiguous_ids=ambiguous_requested,
+            )
+
         ref = ResolvedRef(decision_num=decision_num, date=date)
         requested_set = set(requested)
         entry_ids = {b.entry.id for b in self.blocks if isinstance(b, EntryBlock)}
@@ -395,16 +449,19 @@ def _parse_entry(lines: list[str], start: int) -> tuple[QuestionEntry | None, in
         second_close = after_first.find("]")
         if second_close < 1:
             return None, 1
-        timestamp_str = after_first[1:second_close]
+        id_str = after_first[1:second_close]
         body = after_first[second_close + 1 :].lstrip()
     else:
-        timestamp_str = first_inside
+        id_str = first_inside
         body = after_first
 
-    try:
-        timestamp = datetime.strptime(timestamp_str, _TIMESTAMP_FMT)
-    except ValueError:
-        return None, 1
+    num = _parse_q_id(id_str)
+    timestamp: datetime | None = None
+    if num is None:
+        try:
+            timestamp = datetime.strptime(id_str, _TIMESTAMP_FMT)
+        except ValueError:
+            return None, 1
 
     continuation: list[str] = []
     j = start + 1
@@ -414,6 +471,7 @@ def _parse_entry(lines: list[str], start: int) -> tuple[QuestionEntry | None, in
 
     return (
         QuestionEntry(
+            num=num,
             timestamp=timestamp,
             body=body,
             continuation=continuation,
@@ -421,6 +479,26 @@ def _parse_entry(lines: list[str], start: int) -> tuple[QuestionEntry | None, in
         ),
         j - start,
     )
+
+
+def _parse_q_id(text: str) -> int | None:
+    """Parse a ``Q\\d+`` id string into the integer num, or None.
+
+    Plain string ops — file style avoids regex per ``_extract_embedded_id``.
+    Mirrors :class:`QuestionEntry`'s ``num`` ``ge=1`` constraint at the
+    parse layer so a literal ``[Q0]`` line degrades to ``UnparsableBlock``
+    via the strptime fallback rather than raising ``ValidationError`` out
+    of ``_parse_entry``.
+    """
+    if len(text) < 2 or text[0] != "Q":
+        return None
+    digits = text[1:]
+    if not digits.isdigit():
+        return None
+    num = int(digits)
+    if num < 1:
+        return None
+    return num
 
 
 def _parse_resolved_prefix(text: str) -> ResolvedRef | None:
@@ -440,10 +518,10 @@ def _parse_resolved_prefix(text: str) -> ResolvedRef | None:
 
 
 def _extract_embedded_id(line: str) -> str | None:
-    """Find a ``[YYYY-MM-DD HH:MM UTC]`` substring in ``line`` and return its id text.
+    """Find a ``[Q###]`` or ``[YYYY-MM-DD HH:MM UTC]`` substring in ``line``.
 
-    Uses plain string ops (no regex). Returns the inner timestamp text if
-    parseable as the canonical format, else None.
+    Returns the inner id text if either grammar parses, else None. Plain
+    string ops (no regex).
     """
     start = line.find("[")
     while start != -1:
@@ -451,6 +529,8 @@ def _extract_embedded_id(line: str) -> str | None:
         if end == -1:
             return None
         candidate = line[start + 1 : end]
+        if _parse_q_id(candidate) is not None:
+            return candidate
         try:
             datetime.strptime(candidate, _TIMESTAMP_FMT)
             return candidate

--- a/packages/nauro-core/tests/test_questions.py
+++ b/packages/nauro-core/tests/test_questions.py
@@ -1,8 +1,9 @@
 """Tests for nauro_core.questions."""
 
-from datetime import date
+from datetime import date, datetime
 
 import pytest
+from pydantic import ValidationError
 
 from nauro_core.questions import (
     EntryBlock,
@@ -396,3 +397,203 @@ class TestBlockTypes:
         assert EntryBlock is not None
         assert TripleHashBlock is not None
         assert UnparsableBlock is not None
+
+
+class TestQuestionEntryIdValidator:
+    def test_requires_one_of_num_or_timestamp(self):
+        with pytest.raises(ValidationError):
+            QuestionEntry(body="missing both")
+
+    def test_rejects_both_num_and_timestamp(self):
+        with pytest.raises(ValidationError):
+            QuestionEntry(num=1, timestamp=datetime(2026, 5, 19, 22, 13), body="both")
+
+    def test_num_only_renders_q_form(self):
+        entry = QuestionEntry(num=17, body="qbody")
+        assert entry.id == "Q17"
+        assert entry.render() == ["- [Q17] qbody"]
+
+    def test_timestamp_only_renders_legacy_form(self):
+        entry = QuestionEntry(timestamp=datetime(2026, 5, 19, 22, 13), body="qbody")
+        assert entry.id == "2026-05-19 22:13 UTC"
+        assert entry.render() == ["- [2026-05-19 22:13 UTC] qbody"]
+
+    def test_resolved_prefix_keeps_q_form(self):
+        entry = QuestionEntry(
+            num=42,
+            body="qbody",
+            resolved_by=ResolvedRef(decision_num=7, date=date(2026, 5, 19)),
+        )
+        assert entry.render() == ["- [Resolved by D7 on 2026-05-19] [Q42] qbody"]
+
+
+class TestParseQForm:
+    def test_parse_q_form_open(self):
+        content = "# Open Questions\n\n- [Q1] new id body\n"
+        file = OpenQuestionsFile.parse(content)
+        assert file.open_ids == ["Q1"]
+        entry_blocks = [b for b in file.blocks if isinstance(b, EntryBlock)]
+        assert entry_blocks[0].entry.num == 1
+        assert entry_blocks[0].entry.timestamp is None
+
+    def test_parse_q_form_resolved(self):
+        content = "# Open Questions\n\n## Resolved\n\n- [Resolved by D7 on 2026-05-19] [Q3] body\n"
+        file = OpenQuestionsFile.parse(content)
+        assert file.resolved_ids == ["Q3"]
+        entry_blocks = [b for b in file.blocks if isinstance(b, EntryBlock)]
+        assert entry_blocks[0].entry.num == 3
+        assert entry_blocks[0].entry.resolved_by == ResolvedRef(
+            decision_num=7, date=date(2026, 5, 19)
+        )
+
+    def test_parse_q_form_round_trip_byte_identical(self):
+        content = (
+            "# Open Questions\n"
+            "\n"
+            "- [Q1] first\n"
+            "- [Q17] seventeenth\n"
+            "\n"
+            "## Resolved\n"
+            "\n"
+            "- [Resolved by D7 on 2026-05-19] [Q2] resolved q\n"
+        )
+        assert OpenQuestionsFile.parse(content).format() == content
+
+    def test_mixed_grammar_parse(self):
+        """Both id forms parse from a single file."""
+        content = (
+            "# Open Questions\n\n- [Q1] new-form open\n- [2026-05-12 20:18 UTC] legacy-form open\n"
+        )
+        file = OpenQuestionsFile.parse(content)
+        assert file.open_ids == ["Q1", "2026-05-12 20:18 UTC"]
+
+    def test_mixed_grammar_round_trip_byte_identical(self):
+        """Any input not touched by resolve must round-trip verbatim."""
+        content = (
+            "# Open Questions\n"
+            "\n"
+            "- [Q5] new-form open\n"
+            "- [2026-05-12 20:18 UTC] legacy-form open\n"
+            "\n"
+            "## Resolved\n"
+            "\n"
+            "- [Resolved by D11 on 2026-05-14] [Q2] new-form resolved\n"
+            "- [Resolved by D12 on 2026-05-01] [2026-04-30 10:00 UTC] legacy-form resolved\n"
+        )
+        assert OpenQuestionsFile.parse(content).format() == content
+
+    def test_known_question_ids_includes_both_forms(self):
+        content = "# Open Questions\n\n- [Q1] new\n- [2026-05-12 20:18 UTC] legacy\n"
+        file = OpenQuestionsFile.parse(content)
+        assert file.known_question_ids == {"Q1", "2026-05-12 20:18 UTC"}
+
+    def test_extract_embedded_id_accepts_q_form(self):
+        """### topic heads may embed Q-form ids; boundary validation needs them."""
+        content = "# Open Questions\n\n### [Q9] Topic with Q-form id\nnarrative\n"
+        file = OpenQuestionsFile.parse(content)
+        triple = next(b for b in file.blocks if isinstance(b, TripleHashBlock))
+        assert triple.embedded_id == "Q9"
+        assert "Q9" in file.known_question_ids
+
+    def test_parse_q_zero_degrades_to_unparsable_block(self):
+        """`[Q0]` must not raise: ``num`` carries ``ge=1`` and a Q-id of 0
+        would crash the whole file. The parser treats it as malformed
+        Q-grammar and lands the line in UnparsableBlock, preserving the
+        round-trip-for-unmodified-blocks contract."""
+        content = "# Open Questions\n\n- [Q0] body\n"
+        file = OpenQuestionsFile.parse(content)
+        kinds = [type(b).__name__ for b in file.blocks]
+        assert "UnparsableBlock" in kinds
+        unparsable = next(b for b in file.blocks if isinstance(b, UnparsableBlock))
+        assert unparsable.lines == ("- [Q0] body",)
+
+    def test_parse_q_zero_round_trip_byte_identical(self):
+        content = "# Open Questions\n\n- [Q0] body\n"
+        assert OpenQuestionsFile.parse(content).format() == content
+
+    @pytest.mark.parametrize(
+        "head",
+        ["[Q-3]", "[Q]", "[Qabc]", "[Q1.5]", "[Q 5]"],
+    )
+    def test_parse_malformed_q_grammar_falls_through_to_unparsable(self, head):
+        """Anything that's not a strictly-positive integer after ``Q`` is
+        not a Q-id. The strptime fallback also fails, so the line lands
+        in UnparsableBlock and the file round-trips verbatim."""
+        content = f"# Open Questions\n\n- {head} body\n"
+        file = OpenQuestionsFile.parse(content)
+        kinds = [type(b).__name__ for b in file.blocks]
+        assert "UnparsableBlock" in kinds
+        assert file.format() == content
+
+
+class TestResolveQForm:
+    def test_resolve_by_q_id(self):
+        file = OpenQuestionsFile.parse("# Open Questions\n\n- [Q1] body\n")
+        result = file.resolve(["Q1"], 7, date(2026, 5, 19))
+        assert result.moved_ids == ("Q1",)
+        assert result.unknown_ids == ()
+        assert result.ambiguous_ids == ()
+        rendered = result.file.format()
+        assert "- [Resolved by D7 on 2026-05-19] [Q1] body" in rendered
+
+    def test_resolve_legacy_id_still_works(self):
+        """Dual-grammar acceptance: legacy timestamp ids must keep resolving."""
+        file = OpenQuestionsFile.parse("# Open Questions\n\n- [2026-05-12 20:18 UTC] legacy\n")
+        result = file.resolve(["2026-05-12 20:18 UTC"], 7, date(2026, 5, 19))
+        assert result.moved_ids == ("2026-05-12 20:18 UTC",)
+        assert result.ambiguous_ids == ()
+
+    def test_resolve_mixed_request(self):
+        file = OpenQuestionsFile.parse(
+            "# Open Questions\n\n- [Q1] new\n- [2026-05-12 20:18 UTC] legacy\n"
+        )
+        result = file.resolve(["Q1", "2026-05-12 20:18 UTC"], 7, date(2026, 5, 19))
+        assert set(result.moved_ids) == {"Q1", "2026-05-12 20:18 UTC"}
+
+
+class TestResolveRejectsAmbiguous:
+    """Same-minute timestamp collision must not silently move both
+    entries under one back-reference."""
+
+    def _collision_file(self) -> OpenQuestionsFile:
+        # Two legacy entries sharing the same id — the production bug shape.
+        content = (
+            "# Open Questions\n"
+            "\n"
+            "- [2026-05-12 20:18 UTC] first colliding question\n"
+            "- [2026-05-12 20:18 UTC] second colliding question\n"
+        )
+        return OpenQuestionsFile.parse(content)
+
+    def test_ambiguous_ids_property_reports_collision(self):
+        assert self._collision_file().ambiguous_ids == {"2026-05-12 20:18 UTC": 2}
+
+    def test_ambiguous_ids_empty_when_unique(self):
+        file = OpenQuestionsFile.parse("# Open Questions\n\n- [Q1] one\n- [Q2] two\n")
+        assert file.ambiguous_ids == {}
+
+    def test_resolve_rejects_ambiguous_without_mutation(self):
+        file = self._collision_file()
+        before = file.format()
+        result = file.resolve(["2026-05-12 20:18 UTC"], 7, date(2026, 5, 19))
+        assert result.ambiguous_ids == ("2026-05-12 20:18 UTC",)
+        assert result.moved_ids == ()
+        assert result.unknown_ids == ()
+        # No mutation: identical file returned.
+        assert result.file.format() == before
+
+    def test_resolve_returns_unchanged_file_when_one_id_ambiguous(self):
+        """Even a partial-ambiguity request rejects entirely — defense in
+        depth means we never partial-mutate when ambiguity is detected."""
+        file = OpenQuestionsFile.parse(
+            "# Open Questions\n"
+            "\n"
+            "- [Q1] unambiguous\n"
+            "- [2026-05-12 20:18 UTC] dup\n"
+            "- [2026-05-12 20:18 UTC] dup again\n"
+        )
+        before = file.format()
+        result = file.resolve(["Q1", "2026-05-12 20:18 UTC"], 7, date(2026, 5, 19))
+        assert result.ambiguous_ids == ("2026-05-12 20:18 UTC",)
+        assert result.moved_ids == ()
+        assert result.file.format() == before

--- a/packages/nauro/src/nauro/demo/__init__.py
+++ b/packages/nauro/src/nauro/demo/__init__.py
@@ -225,8 +225,8 @@ with refresh tokens and RBAC.
 
 OPEN_QUESTIONS_MD = """\
 # Open Questions
-- [2026-03-14 10:00 UTC] Should we add rate limiting at the API gateway or application layer?
-- [2026-03-13 15:30 UTC] Redis vs in-memory caching for session storage?
+- [Q1] Should we add rate limiting at the API gateway or application layer?
+- [Q2] Redis vs in-memory caching for session storage?
 """
 
 PROJECT_MD = """\

--- a/packages/nauro/src/nauro/store/writer.py
+++ b/packages/nauro/src/nauro/store/writer.py
@@ -28,7 +28,7 @@ from nauro_core.decision_model import (
     Reversibility,
     format_decision,
 )
-from nauro_core.questions import OpenQuestionsFile, ResolveResult
+from nauro_core.questions import EntryBlock, OpenQuestionsFile, ResolveResult
 from nauro_core.state import migrate_legacy_state, prepare_state_update
 
 from nauro.constants import (
@@ -252,27 +252,40 @@ def update_decision(
 
 
 def append_question(store_path: Path, question: str) -> None:
-    """Append a question to open-questions.md with timestamp."""
+    """Append a question to open-questions.md with a sequential ``Q###`` id.
+
+    Holds a FileLock on ``open-questions.md.lock`` while parsing the
+    current file and minting ``next_num = max(existing) + 1``. New entries
+    always use the Q-form; the parser still accepts legacy timestamp ids
+    on existing entries for round-trip preservation.
+    """
     oq_path = store_path / OPEN_QUESTIONS_MD
-    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
-    entry = f"- [{timestamp}] {question}\n"
+    lock_path = oq_path.with_name(oq_path.name + ".lock")
 
-    content = oq_path.read_text() if oq_path.exists() else "# Open Questions\n"
+    with FileLock(str(lock_path)):
+        content = oq_path.read_text() if oq_path.exists() else "# Open Questions\n"
+        existing_nums = [
+            b.entry.num
+            for b in OpenQuestionsFile.parse(content).blocks
+            if isinstance(b, EntryBlock) and b.entry.num is not None
+        ]
+        next_num = max(existing_nums, default=0) + 1
+        entry = f"- [Q{next_num}] {question}"
 
-    lines = content.split("\n")
-    insert_idx = 1
-    for i, line in enumerate(lines):
-        if line.startswith("# "):
-            insert_idx = i + 1
-            break
+        lines = content.split("\n")
+        insert_idx = 1
+        for i, line in enumerate(lines):
+            if line.startswith("# "):
+                insert_idx = i + 1
+                break
 
-    while insert_idx < len(lines) and (
-        lines[insert_idx].strip() == "" or lines[insert_idx].startswith("<!--")
-    ):
-        insert_idx += 1
+        while insert_idx < len(lines) and (
+            lines[insert_idx].strip() == "" or lines[insert_idx].startswith("<!--")
+        ):
+            insert_idx += 1
 
-    lines.insert(insert_idx, entry.rstrip())
-    oq_path.write_text("\n".join(lines))
+        lines.insert(insert_idx, entry)
+        oq_path.write_text("\n".join(lines))
 
 
 def resolve_questions_in_file(

--- a/packages/nauro/src/nauro/validation/pipeline.py
+++ b/packages/nauro/src/nauro/validation/pipeline.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 from nauro_core import extract_decision_number
 from nauro_core.constants import MIN_RATIONALE_LENGTH, OPEN_QUESTIONS_MD
-from nauro_core.questions import OpenQuestionsFile
+from nauro_core.questions import EntryBlock, OpenQuestionsFile
 
 from nauro.store.snapshot import capture_snapshot
 from nauro.store.writer import (
@@ -116,25 +116,45 @@ def validate_proposed_write(
             log_validation(project_path, proposal, result.to_dict())
             return result
 
-    # --- reject unknown resolves_questions ids at the boundary ---
+    # --- reject unknown / ambiguous resolves_questions ids at the boundary ---
     # Validate every supplied id exists in open-questions.md (either open
     # or already-resolved). Unknown ids reject before Tier 1 so the
     # assessment names the offending ids rather than slipping past the
-    # gate and failing on the write side.
+    # gate and failing on the write side. Ambiguous ids (two entries
+    # sharing one legacy timestamp id, e.g. logged in the same minute)
+    # also reject — silently moving both entries under one back-reference
+    # is the bug class this branch closes.
     requested_resolves = list(proposal.get("resolves_questions") or [])
     if requested_resolves:
-        unknown = _unknown_question_ids(requested_resolves, project_path)
+        questions_file = _load_questions_file(project_path)
+        unknown = _unknown_question_ids(requested_resolves, questions_file)
         if unknown:
             result = ValidationResult(
                 status="rejected",
                 tier=0,
                 operation=operation,
                 assessment=(
-                    "resolves_questions contains unknown timestamp id(s): "
+                    "resolves_questions contains unknown id(s): "
                     + ", ".join(repr(x) for x in unknown)
                     + ". Call get_context (L0 lists every open question) to "
                     "see the canonical ids in open-questions.md."
                 ),
+            )
+            log_validation(project_path, proposal, result.to_dict())
+            return result
+
+        ambiguous = _ambiguous_question_ids(requested_resolves, questions_file)
+        if ambiguous:
+            offenders = "; ".join(
+                f"{requested!r} matches {len(counterparts)} entries — disambiguate "
+                f"to one of: {', '.join(counterparts)}"
+                for requested, counterparts in ambiguous.items()
+            )
+            result = ValidationResult(
+                status="rejected",
+                tier=0,
+                operation=operation,
+                assessment=("resolves_questions contains ambiguous id(s): " + offenders + "."),
             )
             log_validation(project_path, proposal, result.to_dict())
             return result
@@ -386,11 +406,48 @@ def _apply_question_resolves(
     return result.moved_ids
 
 
-def _unknown_question_ids(ids: list[str], project_path: Path) -> list[str]:
-    """Return any caller-supplied ids absent from open-questions.md."""
+def _load_questions_file(project_path: Path) -> OpenQuestionsFile | None:
+    """Parse open-questions.md once; return None when the file is missing."""
     oq_path = project_path / OPEN_QUESTIONS_MD
     if not oq_path.exists():
+        return None
+    return OpenQuestionsFile.parse(oq_path.read_text())
+
+
+def _unknown_question_ids(ids: list[str], questions_file: OpenQuestionsFile | None) -> list[str]:
+    """Return any caller-supplied ids absent from open-questions.md."""
+    if questions_file is None:
         return list(ids)
-    file = OpenQuestionsFile.parse(oq_path.read_text())
-    known = file.known_question_ids
+    known = questions_file.known_question_ids
     return [tid for tid in ids if tid not in known]
+
+
+def _ambiguous_question_ids(
+    ids: list[str], questions_file: OpenQuestionsFile | None
+) -> dict[str, list[str]]:
+    """Return caller-supplied ids that match more than one EntryBlock.
+
+    Maps each ambiguous id to a list of disambiguating Q### counterparts —
+    one slot per colliding EntryBlock. Slots that don't have a Q### id
+    are reported as ``<no-Q-id>`` so the caller sees how many entries
+    collide and which (if any) are addressable by Q### today. Silent
+    multi-move under one back-reference is the bug being closed; reject
+    at the boundary so the caller has to disambiguate before write.
+    """
+    if questions_file is None:
+        return {}
+    collisions = questions_file.ambiguous_ids
+    requested_ambiguous = [tid for tid in ids if tid in collisions]
+    if not requested_ambiguous:
+        return {}
+
+    # Walk the blocks once to gather per-id counterparts in document order.
+    counterparts: dict[str, list[str]] = {tid: [] for tid in requested_ambiguous}
+    for block in questions_file.blocks:
+        if not isinstance(block, EntryBlock):
+            continue
+        eid = block.entry.id
+        if eid in counterparts:
+            slot = f"Q{block.entry.num}" if block.entry.num is not None else "<no-Q-id>"
+            counterparts[eid].append(slot)
+    return counterparts

--- a/packages/nauro/tests/test_stdio_server.py
+++ b/packages/nauro/tests/test_stdio_server.py
@@ -176,12 +176,12 @@ class TestProposeDecisionResolvesQuestions:
     """
 
     def _seed_question(self, store: Path) -> str:
-        """Write one question with a deterministic timestamp; return its id."""
-        ts = "2026-05-12 20:18 UTC"
+        """Write one question with a Q-form id; return its id."""
+        qid = "Q1"
         (store / "open-questions.md").write_text(
-            f"# Open Questions\n\n- [{ts}] should we ship D139?\n"
+            f"# Open Questions\n\n- [{qid}] should we ship D139?\n"
         )
-        return ts
+        return qid
 
     def test_known_id_moves_to_resolved(self, store: Path):
         question_id = self._seed_question(store)

--- a/packages/nauro/tests/test_store.py
+++ b/packages/nauro/tests/test_store.py
@@ -181,17 +181,20 @@ def test_question_append(store: Path):
     append_question(store, "Should we use GraphQL?")
     content = (store / "open-questions.md").read_text()
     assert "Should we use GraphQL?" in content
-    assert "UTC]" in content
+    assert "[Q1]" in content
 
 
 def test_question_multiple(store: Path):
     append_question(store, "First question?")
     append_question(store, "Second question?")
     content = (store / "open-questions.md").read_text()
-    lines = [line for line in content.split("\n") if line.startswith("- [") and "UTC]" in line]
+    lines = [line for line in content.split("\n") if line.startswith("- [Q")]
     assert len(lines) == 2
-    # Newest first (inserted at top)
+    # Newest first (inserted at top); ids increment sequentially.
+    assert "[Q2]" in lines[0]
     assert "Second question?" in lines[0]
+    assert "[Q1]" in lines[1]
+    assert "First question?" in lines[1]
 
 
 # --- State update tests ---

--- a/packages/nauro/tests/test_validation/test_pipeline.py
+++ b/packages/nauro/tests/test_validation/test_pipeline.py
@@ -357,7 +357,9 @@ class TestD133UpdateRejectsMetadata:
 
 class TestD139ResolvesQuestions:
     """D139: propose_decision can pass `resolves_questions` to move named
-    open-questions.md entries under ``## Resolved`` on confirm.
+    open-questions.md entries under ``## Resolved`` on confirm. Q-form
+    ids are the canonical scheme; legacy timestamp ids remain accepted
+    for entries that predate the Q-form rollout.
     """
 
     RATIONALE = (
@@ -367,8 +369,20 @@ class TestD139ResolvesQuestions:
 
     @pytest.fixture
     def store_with_questions(self, tmp_path: Path) -> Path:
+        """Q-form fixture — the canonical id scheme."""
         store_path = tmp_path / "projects" / "d139"
         scaffold_project_store("d139", store_path)
+        oq = store_path / "open-questions.md"
+        oq.write_text("# Open Questions\n\n- [Q1] q-one body text\n- [Q2] q-two body text\n")
+        return store_path
+
+    @pytest.fixture
+    def store_with_legacy_questions(self, tmp_path: Path) -> Path:
+        """Legacy timestamp fixture — kept so the reject-path and
+        dual-grammar acceptance tests can still target the legacy id
+        grammar that older stores may carry forward."""
+        store_path = tmp_path / "projects" / "d139-legacy"
+        scaffold_project_store("d139-legacy", store_path)
         oq = store_path / "open-questions.md"
         oq.write_text(
             "# Open Questions\n"
@@ -378,19 +392,21 @@ class TestD139ResolvesQuestions:
         )
         return store_path
 
-    def test_unknown_id_rejects_at_boundary(self, store_with_questions: Path) -> None:
+    def test_unknown_id_rejects_at_boundary(self, store_with_legacy_questions: Path) -> None:
         proposal = {
             "title": "A decision that names a bogus question",
             "rationale": self.RATIONALE,
             "resolves_questions": ["2099-01-01 00:00 UTC"],
         }
-        result = validate_proposed_write(proposal, store_with_questions)
+        result = validate_proposed_write(proposal, store_with_legacy_questions)
         assert result.status == "rejected"
         assert result.tier == 0
         assert "2099-01-01 00:00 UTC" in result.assessment
         assert "resolves_questions" in result.assessment
 
-    def test_unknown_id_rejection_lists_every_offender(self, store_with_questions: Path) -> None:
+    def test_unknown_id_rejection_lists_every_offender(
+        self, store_with_legacy_questions: Path
+    ) -> None:
         proposal = {
             "title": "A decision that names two bogus questions",
             "rationale": self.RATIONALE,
@@ -400,7 +416,7 @@ class TestD139ResolvesQuestions:
                 "2026-05-12 20:18 UTC",  # this one IS valid
             ],
         }
-        result = validate_proposed_write(proposal, store_with_questions)
+        result = validate_proposed_write(proposal, store_with_legacy_questions)
         assert result.status == "rejected"
         for bad in ("2099-01-01 00:00 UTC", "2099-02-02 00:00 UTC"):
             assert bad in result.assessment
@@ -409,24 +425,40 @@ class TestD139ResolvesQuestions:
         proposal = {
             "title": "A decision that closes the first open question",
             "rationale": self.RATIONALE,
-            "resolves_questions": ["2026-05-12 20:18 UTC"],
+            "resolves_questions": ["Q1"],
         }
         result = validate_proposed_write(proposal, store_with_questions)
         assert result.status == "confirmed"
-        assert result.resolved_questions == ("2026-05-12 20:18 UTC",)
+        assert result.resolved_questions == ("Q1",)
         oq_content = (store_with_questions / "open-questions.md").read_text()
         assert "## Resolved" in oq_content
         # Resolved entry carries the back-ref prefix.
         assert "[Resolved by D" in oq_content
+        assert "[Q1] q-one body text" in oq_content
+        # Q2 stays open (no prefix).
+        assert "- [Q2] q-two body text" in oq_content
+
+    def test_legacy_timestamp_id_still_accepted(self, store_with_legacy_questions: Path) -> None:
+        """Dual-grammar acceptance: entries that predate the Q-form
+        rollout keep their legacy timestamp ids and resolves_questions
+        must still move them."""
+        proposal = {
+            "title": "A decision that closes a legacy-id question",
+            "rationale": self.RATIONALE,
+            "resolves_questions": ["2026-05-12 20:18 UTC"],
+        }
+        result = validate_proposed_write(proposal, store_with_legacy_questions)
+        assert result.status == "confirmed"
+        assert result.resolved_questions == ("2026-05-12 20:18 UTC",)
+        oq_content = (store_with_legacy_questions / "open-questions.md").read_text()
+        assert "## Resolved" in oq_content
         assert "[2026-05-12 20:18 UTC] q-one body text" in oq_content
-        # q-two stays open (no prefix).
-        assert "- [2026-05-11 15:29 UTC] q-two body text" in oq_content
 
     def test_resolves_through_pending_confirm(self, store_with_questions: Path) -> None:
         proposal = {
             "title": "A decision that closes via the pending path",
             "rationale": self.RATIONALE,
-            "resolves_questions": ["2026-05-12 20:18 UTC"],
+            "resolves_questions": ["Q1"],
         }
         result = validate_proposed_write(proposal, store_with_questions, skip_validation=True)
         assert result.status == "pending_confirmation"
@@ -437,7 +469,7 @@ class TestD139ResolvesQuestions:
 
         confirm_response = confirm_write(result.confirm_id, store_with_questions)
         assert confirm_response["status"] == "confirmed"
-        assert confirm_response.get("resolved_questions") == ["2026-05-12 20:18 UTC"]
+        assert confirm_response.get("resolved_questions") == ["Q1"]
         oq_after = (store_with_questions / "open-questions.md").read_text()
         assert "## Resolved" in oq_after
 
@@ -446,21 +478,21 @@ class TestD139ResolvesQuestions:
         oq.write_text(
             "# Open Questions\n"
             "\n"
-            "- [2026-05-11 15:29 UTC] q-two\n"
+            "- [Q2] q-two\n"
             "\n"
             "## Resolved\n"
             "\n"
-            "- [Resolved by D100 on 2026-05-01] [2026-04-30 10:00 UTC] q-old\n"
+            "- [Resolved by D100 on 2026-05-01] [Q1] q-old\n"
         )
         proposal = {
             "title": "A decision that names an already-resolved question",
             "rationale": self.RATIONALE,
-            "resolves_questions": ["2026-04-30 10:00 UTC"],
+            "resolves_questions": ["Q1"],
         }
         result = validate_proposed_write(proposal, store_with_questions)
         # Should NOT reject — already-resolved counts as known.
         assert result.status == "confirmed"
-        assert result.resolved_questions == ("2026-04-30 10:00 UTC",)
+        assert result.resolved_questions == ("Q1",)
         # And the resolved-section back-ref to D100 is preserved.
         assert "[Resolved by D100 on 2026-05-01]" in oq.read_text()
 
@@ -487,7 +519,7 @@ class TestD139ResolvesQuestions:
         proposal = {
             "title": "Supersedes the seed and closes a question",
             "rationale": self.RATIONALE,
-            "resolves_questions": ["2026-05-12 20:18 UTC"],
+            "resolves_questions": ["Q1"],
         }
         decisions = sorted(
             (store_with_questions / "decisions").glob("*.md"),
@@ -507,6 +539,60 @@ class TestD139ResolvesQuestions:
         confirm = confirm_write(result.confirm_id, store_with_questions)
         assert confirm["status"] == "confirmed"
         assert confirm["operation"] == "supersede"
-        assert confirm.get("resolved_questions") == ["2026-05-12 20:18 UTC"]
+        assert confirm.get("resolved_questions") == ["Q1"]
         oq_content = (store_with_questions / "open-questions.md").read_text()
         assert "## Resolved" in oq_content
+
+
+class TestAmbiguousResolvesQuestionsRejected:
+    """Silent multi-move under one back-reference is the bug being
+    closed. Two entries sharing the same id (e.g. same-minute legacy
+    timestamps) must reject at the boundary instead of being moved
+    together.
+    """
+
+    RATIONALE = (
+        "A sufficiently long rationale that comfortably exceeds the structural "
+        "minimum length so the ambiguity branch is what is exercised."
+    )
+
+    @pytest.fixture
+    def store_with_colliding_questions(self, tmp_path: Path) -> Path:
+        store_path = tmp_path / "projects" / "ambiguous"
+        scaffold_project_store("ambiguous", store_path)
+        oq = store_path / "open-questions.md"
+        # Two questions logged in the same minute share the legacy
+        # timestamp id — the original bug shape.
+        oq.write_text(
+            "# Open Questions\n"
+            "\n"
+            "- [2026-05-12 20:18 UTC] first colliding question\n"
+            "- [2026-05-12 20:18 UTC] second colliding question\n"
+        )
+        return store_path
+
+    def test_ambiguous_id_rejects_at_boundary(self, store_with_colliding_questions: Path) -> None:
+        proposal = {
+            "title": "A decision that names a duplicated id",
+            "rationale": self.RATIONALE,
+            "resolves_questions": ["2026-05-12 20:18 UTC"],
+        }
+        result = validate_proposed_write(proposal, store_with_colliding_questions)
+        assert result.status == "rejected"
+        assert result.tier == 0
+        assert "2026-05-12 20:18 UTC" in result.assessment
+        assert "ambiguous" in result.assessment
+        # Two colliding legacy entries, neither has a Q### counterpart yet.
+        assert "<no-Q-id>" in result.assessment
+        assert "disambiguate" in result.assessment
+
+    def test_ambiguous_id_does_not_mutate_file(self, store_with_colliding_questions: Path) -> None:
+        oq_before = (store_with_colliding_questions / "open-questions.md").read_text()
+        proposal = {
+            "title": "A decision that names a duplicated id",
+            "rationale": self.RATIONALE,
+            "resolves_questions": ["2026-05-12 20:18 UTC"],
+        }
+        validate_proposed_write(proposal, store_with_colliding_questions)
+        oq_after = (store_with_colliding_questions / "open-questions.md").read_text()
+        assert oq_after == oq_before


### PR DESCRIPTION
## Why

Open-questions.md used the `[YYYY-MM-DD HH:MM UTC]` timestamp inside the entry head as the entry's stable id. Minute resolution + identifier-as-event-metadata produces a same-minute collision when two questions are logged inside one minute. A production incident hit this case: two questions shared one id, `propose_decision(resolves_questions=[<that timestamp>])` silently moved both under a single back-reference, and the second back-reference had to be corrected by hand. Any subsequent occurrence corrupts back-refs the same way and requires manual repair.

## Approach

Replace the timestamp-as-id scheme with sequential `[Q###]` allocation: a writer-side mint of `max(num) + 1` under a FileLock, with the parse layer accepting BOTH grammars so older entries continue to round-trip byte-identical without rewrite. The boundary additionally rejects any `resolves_questions` id that matches more than one EntryBlock, so the silent multi-move case is closed regardless of id scheme.

Alternatives considered: finer-resolution timestamps (treats the symptom, not the class — automated loops can still hit it); ULID per entry (adds a runtime dep to nauro-core, breaks the visual symmetry of `D###` / `Q###`); content hash (edits silently break back-refs); positional suffix on duplicates (institutionalises the two-tier grammar at the L0 surface); boundary-reject ambiguous ids without a new id grammar (half-fix — strands the caller with no remedy when timestamps are the only ids).

## What changed

- **`nauro_core.questions`** — `QuestionEntry` gains optional `num: int | None`, makes `timestamp` optional, adds a `model_validator(mode="after")` that asserts exactly one is set. `id` returns `f"Q{num}"` when num is set, else the legacy timestamp string. `_parse_entry` tries the `[Q\d+]` form first (no regex per file style) then falls back to `strptime`; `_parse_q_id` mirrors the model's `ge=1` constraint at the parse layer so `[Q0]` and other malformed Q-grammar degrade to `UnparsableBlock`. `_extract_embedded_id` accepts both grammars. `OpenQuestionsFile.ambiguous_ids` reports id-to-count for any id appearing more than once; `resolve` short-circuits without mutation when any requested id collides, surfacing the offenders via `ResolveResult.ambiguous_ids`.
- **`nauro.store.writer.append_question`** — Takes a FileLock on `open-questions.md.lock`, parses the current file, mints `next_num = max(existing) + 1`, and inserts `- [Q{n}] body`. The strftime path is gone; new mints are always Q-form.
- **`nauro.validation.pipeline`** — Adds `_ambiguous_question_ids` returning each ambiguous requested id mapped to a list of disambiguating Q### counterparts (or `<no-Q-id>` slots when no entry in the collision set has a Q### id yet). `validate_proposed_write` rejects ambiguous ids after the unknown-id branch, sharing one `OpenQuestionsFile.parse` between the two checks.
- **Protocol fragment** — `RESOLVES_OPEN_QUESTIONS` updated to name `[Q###]` as canonical and document the legacy timestamp form as accepted. Session dogfood files at `.claude/skills/nauro/SKILL.md`, `.cursor/rules/nauro.mdc`, `.agents/skills/nauro/SKILL.md` regenerated.
- **Demo** — `OPEN_QUESTIONS_MD` flipped to `[Q1]` / `[Q2]`.
- **Tests** — +29 new tests in `test_questions.py` and `test_pipeline.py` covering the Q-form parse / render / resolve paths, dual-grammar acceptance, ambiguity rejection, and malformed-Q-grammar degradation (`[Q0]`, `[Q-3]`, `[Q]`, `[Qabc]`, `[Q1.5]`, `[Q 5]`). Accept-path fixtures flipped to Q-form; reject-path fixtures kept the legacy timestamp grammar.

## What to review

- `nauro_core/questions.py` — the `QuestionEntry.exactly_one_id` validator and `resolve`'s short-circuit run before any block mutation, so the defense-in-depth claim holds even if a future caller bypasses the pipeline. `_parse_q_id`'s `num < 1` check mirrors the model's `ge=1` constraint at the parse layer.
- `validation/pipeline.py` — `_ambiguous_question_ids` walks the block list once and returns ordered counterparts; verify the slot order reads sanely in the assessment message.
- `writer.py` — `append_question`'s lock path is `open-questions.md.lock` (next to the file, not under a `.lock` subdir like decisions). FileLock is already a runtime dep — no new dependencies introduced.
- The disambiguation message uses `<no-Q-id>` markers for legacy entries that don't have a Q### counterpart yet (the common case until a migrate command lands). Once entries are migrated to Q-form, real Q### ids will appear in those slots instead.

## What's deferred

- **`_renumber_question_if_collision` in `sync/hooks.py`** — Cross-machine Q-form collision repair on pull. The FileLock covers the single-machine dominant case; cross-machine collisions are rarer and follow the same pattern as the existing decision-renumber-on-pull logic.
- **`nauro questions migrate` CLI** — One-shot rewrite of legacy timestamp entries to Q-form. Dual-grammar parse makes this purely cosmetic; deferred to keep this PR scoped.

## Test plan

- `uv run ruff check packages/` and `uv run ruff format --check packages/` clean.
- `uv run pytest packages/` — 1326 tests pass (+29 vs main).
- Smoke test: `NAURO_HOME=<tmp> nauro init q-smoke <repo>` followed by `nauro note "..." --question` produces `- [Q1] ...` in `open-questions.md`; a second invocation produces `- [Q2] ...`. Verified.