### PR TITLE
chore: paraphrase internal decision-number citations in public-repo content

### DIFF
--- a/packages/nauro-core/src/nauro_core/decision_model.py
+++ b/packages/nauro-core/src/nauro_core/decision_model.py
@@ -130,8 +130,7 @@ class Decision(BaseModel):
     def _validate_supersession_ref(cls, v: str | None) -> str | None:
         """Enforce plain integer string: "70", not "070" or "070-slug" or "D70".
 
-        Canonicalizes the format that ``writer.supersede_decision`` writes and
-        that the prior session's D69/D70/D105 backfill standardized on.
+        Canonicalizes the format that ``writer.supersede_decision`` writes.
         """
         if v is None:
             return v

--- a/packages/nauro-core/src/nauro_core/search.py
+++ b/packages/nauro-core/src/nauro_core/search.py
@@ -1,4 +1,4 @@
-"""BM25 search over decisions (D93).
+"""BM25 search over decisions.
 
 Builds an in-memory BM25 index per call using bm25s + PyStemmer.
 Index text: title + rationale for each decision.

--- a/packages/nauro-core/src/nauro_core/validation.py
+++ b/packages/nauro-core/src/nauro_core/validation.py
@@ -64,7 +64,7 @@ def check_bm25_similarity(
     top_k: int = TIER2_TOP_K,
     stopwords: list[str] | None = None,
 ) -> tuple[str, list[dict]]:
-    """Tier-2 BM25 similarity check (D93). Shared by local and remote surfaces.
+    """Tier-2 BM25 similarity check. Shared by local and remote surfaces.
 
     Filters the scaffold-seed decision (bookkeeping, not a user choice) and
     delegates retrieval to ``nauro_core.search.bm25_retrieve``, which also

--- a/packages/nauro-core/tests/test_constants.py
+++ b/packages/nauro-core/tests/test_constants.py
@@ -98,13 +98,13 @@ class TestMcpInstructions:
         assert "vendor swap" in MCP_INSTRUCTIONS_STATIC
 
     def test_propose_decision_operations_not_in_static(self) -> None:
-        """D151: relocated to the propose_decision.operation parameter so the
+        """Relocated to the propose_decision.operation parameter so the
         static block stays small enough for the per-user project section the
         remote server prepends to survive client-side truncation of the
         ``initialize.instructions`` field."""
         assert PROPOSE_DECISION_OPERATIONS not in MCP_INSTRUCTIONS_STATIC
 
     def test_resolves_open_questions_not_in_static(self) -> None:
-        """D151: relocated to the propose_decision.resolves_questions
-        parameter description, same budget reason as the operations fragment."""
+        """Relocated to the propose_decision.resolves_questions parameter
+        description, same budget reason as the operations fragment."""
         assert RESOLVES_OPEN_QUESTIONS not in MCP_INSTRUCTIONS_STATIC

--- a/packages/nauro-core/tests/test_decision_model.py
+++ b/packages/nauro-core/tests/test_decision_model.py
@@ -63,7 +63,7 @@ MINIMAL_V2_FILENAME = "042-use-a-shared-helper-for-slug-generation.md"
 
 
 # Fixture 2 — multiple rejected alternatives, names include an em-dash and a
-# colon (the kind of content D98 carries in the real store).
+# colon.
 RICH_V2 = """\
 ---
 date: 2026-04-16
@@ -478,10 +478,9 @@ class TestDecisionConstruction:
 class TestSupersessionRefValidator:
     """The supersedes / superseded_by validator: plain integer string only.
 
-    Convention is "70", not "070" or "070-some-slug" or "D70". The prior
-    session's D69/D70/D105 backfill standardized on this form, and
-    writer.supersede_decision now canonicalizes filename stems before
-    writing. The model-level validator is the backstop.
+    Convention is "70", not "070" or "070-some-slug" or "D70" — the canonical
+    writer canonicalizes filename stems before writing, and the model-level
+    validator is the backstop.
     """
 
     def test_plain_integer_accepted(self) -> None:

--- a/packages/nauro-core/tests/test_mcp_tools.py
+++ b/packages/nauro-core/tests/test_mcp_tools.py
@@ -169,8 +169,8 @@ class TestBuildRemoteInstructions:
         assert WELCOME_NO_PROJECT in result
 
     def test_zero_projects_welcome_before_static(self):
-        """D151: the per-user section must precede the static block so it
-        survives client-side truncation of ``initialize.instructions``."""
+        """The per-user section must precede the static block so it survives
+        client-side truncation of ``initialize.instructions``."""
         result = build_remote_instructions(STATIC, [])
         assert result.index(WELCOME_NO_PROJECT) < result.index(STATIC)
 
@@ -190,7 +190,7 @@ class TestBuildRemoteInstructions:
         assert "Pass the matching project_id" not in result
 
     def test_one_project_orientation_before_static(self):
-        """D151: orientation line must precede the static block."""
+        """Orientation line must precede the static block."""
         projects = [{"project_id": ULID_ALPHA, "name": "nauro"}]
         result = build_remote_instructions(STATIC, projects)
         assert result.index("Connected to project") < result.index(STATIC)
@@ -217,7 +217,7 @@ class TestBuildRemoteInstructions:
         assert "Call list_projects" not in result
 
     def test_two_projects_list_before_static(self):
-        """D151: the inline project list must precede the static block."""
+        """The inline project list must precede the static block."""
         projects = [
             {"project_id": ULID_ALPHA, "name": "alpha"},
             {"project_id": ULID_BETA, "name": "Beta"},
@@ -250,7 +250,7 @@ class TestBuildRemoteInstructions:
             assert p["name"] not in result
 
     def test_overflow_pointer_before_static(self):
-        """D151: the overflow pointer must precede the static block."""
+        """The overflow pointer must precede the static block."""
         projects = [
             {"project_id": f"01ID{i:022d}", "name": f"proj-{i}"}
             for i in range(MAX_INLINE_PROJECTS + 2)

--- a/packages/nauro-core/tests/test_protocol.py
+++ b/packages/nauro-core/tests/test_protocol.py
@@ -172,10 +172,10 @@ class TestMcpInstructionsComposition:
     surface verbatim, and must be fully resolved (no leftover tokens).
 
     ``PROPOSE_DECISION_OPERATIONS`` and ``RESOLVES_OPEN_QUESTIONS`` are
-    deliberately omitted from the static block per D151 — they live on the
-    matching ``propose_decision`` ToolSpec parameter descriptions instead,
-    where the agent reads them at the moment of use. The positive splice
-    asserts below pin those relocations.
+    deliberately omitted from the static block — they live on the matching
+    ``propose_decision`` ToolSpec parameter descriptions instead, where the
+    agent reads them at the moment of use. The positive splice asserts
+    below pin those relocations.
     """
 
     REQUIRED_FRAGMENTS = (
@@ -193,7 +193,7 @@ class TestMcpInstructionsComposition:
         assert protocol_tokens_in(MCP_INSTRUCTIONS_STATIC) == []
 
     def test_propose_decision_operations_in_operation_parameter(self) -> None:
-        """Relocation guard (D151): the fragment must appear verbatim on the
+        """Relocation guard: the fragment must appear verbatim on the
         ``propose_decision.operation`` parameter description so the agent
         still reads operation semantics at the moment of use."""
         spec = get_tool_spec("propose_decision")
@@ -201,7 +201,7 @@ class TestMcpInstructionsComposition:
         assert PROPOSE_DECISION_OPERATIONS in op_desc
 
     def test_resolves_open_questions_in_resolves_questions_parameter(self) -> None:
-        """Relocation guard (D151): the fragment must appear verbatim on the
+        """Relocation guard: the fragment must appear verbatim on the
         ``propose_decision.resolves_questions`` parameter description so the
         ids-and-boundary contract stays bound to the parameter the agent
         actually passes."""

--- a/packages/nauro-core/tests/test_search.py
+++ b/packages/nauro-core/tests/test_search.py
@@ -1,4 +1,4 @@
-"""Tests for BM25 search (D93)."""
+"""Tests for BM25 search."""
 
 from datetime import date
 
@@ -63,7 +63,7 @@ class TestBm25Search:
         assert any("FastAPI" in r["title"] for r in results)
 
     def test_vocabulary_mismatch_case(self):
-        """The Redis/Memcached case from D93 motivation."""
+        """The Redis/Memcached vocabulary-mismatch case BM25 was introduced for."""
         results = bm25_search(DECISIONS, "Use Redis for session caching")
         assert any("Memcached" in r["title"] for r in results)
 

--- a/packages/nauro-core/tests/test_validation.py
+++ b/packages/nauro-core/tests/test_validation.py
@@ -85,8 +85,8 @@ class TestCheckBm25Similarity:
         assert related == []
 
     def test_vocabulary_mismatch_flagged(self):
-        # D93 motivating case: BM25 + stemming catches vocabulary mismatches
-        # that substring and naive word-set matching miss.
+        # BM25 + stemming catches vocabulary mismatches that substring and
+        # naive word-set matching miss.
         existing = [
             self._decision(
                 2,

--- a/packages/nauro/src/nauro/validation/tier2.py
+++ b/packages/nauro/src/nauro/validation/tier2.py
@@ -1,4 +1,4 @@
-"""Tier 2 validation — BM25 similarity (D93).
+"""Tier 2 validation — BM25 similarity.
 
 Thin adapter over ``nauro_core.validation.check_bm25_similarity``. The
 filtering, stopword list, and retrieval live in nauro-core so the remote

--- a/packages/nauro/tests/test_agents_md_preservation.py
+++ b/packages/nauro/tests/test_agents_md_preservation.py
@@ -137,7 +137,7 @@ def test_regen_with_neither_section_writes_fresh(tmp_path: Path):
 
 
 def test_regen_strips_stale_attribution_footer_from_manual_section(tmp_path: Path):
-    """Regression: a pre-D135 ``nauro.dev`` attribution footer that ended up
+    """Regression: a legacy ``nauro.dev`` attribution footer that ended up
     embedded under ``# Manual`` (because the parser's footer marker was tied
     to the current canonical URL) must not survive regen.
 

--- a/packages/nauro/tests/test_check_command.py
+++ b/packages/nauro/tests/test_check_command.py
@@ -1,7 +1,7 @@
 """Tests for the ``nauro check`` CLI command.
 
 Covers:
-- The demo prompt retrieves the canonical SSE-over-WebSocket decision (D004).
+- The demo prompt retrieves the canonical SSE-over-WebSocket decision.
 - ``--json`` emits a parseable result with the same shape as the human path.
 - Project-resolution and store-state error paths exit non-zero with guidance.
 - Cloud-mode projects surface a "may be stale" notice on stderr.
@@ -83,7 +83,7 @@ def test_helper_and_wrapper_return_same_shape(demo_repo):
     assert "assessment" in helper
 
 
-# --- happy path: demo prompt retrieves D004 ----------------------------------
+# --- happy path: demo prompt retrieves the SSE-over-WebSocket decision ------
 
 
 def test_demo_prompt_returns_sse_decision(demo_repo):

--- a/packages/nauro/tests/test_cloud_projects.py
+++ b/packages/nauro/tests/test_cloud_projects.py
@@ -91,9 +91,8 @@ def test_create_project_stale_token_refreshed_transparently(tmp_path, monkeypatc
     silent refresh, the retry succeeds, and ``create_project`` returns
     the new ``ProjectView`` without any user-visible auth error.
 
-    Regression for the D145 narrow-scope gap — before this fix,
-    ``nauro init --cloud`` cold-failed on an expired access token even
-    though the refresh token was still valid."""
+    Regression: before this fix, ``nauro init --cloud`` cold-failed on an
+    expired access token even though the refresh token was still valid."""
     save_config(
         {
             "auth": {

--- a/packages/nauro/tests/test_identity_lifecycle.py
+++ b/packages/nauro/tests/test_identity_lifecycle.py
@@ -1,4 +1,4 @@
-"""Phase 1c T1.7 / T1.7b — identity lifecycle (D119 + C1 correction).
+"""Telemetry identity lifecycle.
 
 Covers:
 1. Login order: alias(previous_id, distinct_id) FIRST, then set(distinct_id, props).
@@ -33,7 +33,7 @@ _UUID4_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}
 
 
 class FakeClient:
-    """Records call sequence so order-sensitive assertions (D119 alias-then-set) hold."""
+    """Records call sequence so order-sensitive assertions (alias-then-set) hold."""
 
     def __init__(self) -> None:
         self.calls: list[tuple[str, dict[str, Any]]] = []
@@ -105,7 +105,7 @@ def test_login_calls_alias_then_set_in_correct_order(nauro_home, telemetry_key, 
 
     identify_login(user_id="auth0|user-a", email_hash="deadbeef" * 8)
 
-    # Exactly two calls, alias first, set second (D119 load-bearing order).
+    # Exactly two calls, alias first, set second (load-bearing order).
     assert len(fake_posthog.calls) == 2
     assert fake_posthog.calls[0][0] == "alias"
     assert fake_posthog.calls[0][1] == {"previous_id": aid, "distinct_id": "auth0|user-a"}

--- a/packages/nauro/tests/test_import.py
+++ b/packages/nauro/tests/test_import.py
@@ -281,7 +281,7 @@ def _mb_with(tmp_path: Path, name: str, **files: str) -> Path:
 
 
 def test_active_context_lands_in_state_current_not_legacy(store: Path, tmp_path: Path):
-    """Pre-D94 stores may carry a legacy state.md alongside state_current.md.
+    """Legacy stores may carry a state.md alongside state_current.md.
     Verify import writes only to state_current.md, never the legacy file."""
     legacy_marker = "# Legacy state — should not be touched\n"
     (store / "state.md").write_text(legacy_marker)

--- a/packages/nauro/tests/test_init_cloud.py
+++ b/packages/nauro/tests/test_init_cloud.py
@@ -119,7 +119,7 @@ def test_init_cloud_renders_server_error(tmp_path, monkeypatch):
     assert registry.find_projects_by_name_v2("cloudproj") == []
 
 
-# ── D140: --demo + --cloud rejection ─────────────────────────────────────────
+# ── --demo + --cloud rejection ───────────────────────────────────────────────
 
 
 def _strip_ansi(text: str) -> str:
@@ -150,7 +150,7 @@ def _strip_ansi(text: str) -> str:
 def test_init_demo_plus_cloud_rejects_at_entry(tmp_path, monkeypatch):
     """`nauro init --demo --cloud` must reject before any state is written.
 
-    Pre-D140 this silently dropped `--demo` inside the `--cloud` branch.
+    Previously this silently dropped `--demo` inside the `--cloud` branch.
     The combined invocation now exits 2 (Typer's BadParameter contract) with
     a message naming both single-flag forms; no project is registered, no
     network call is made, no `.nauro/config.json` is dropped in the cwd.

--- a/packages/nauro/tests/test_mcp.py
+++ b/packages/nauro/tests/test_mcp.py
@@ -156,7 +156,7 @@ class TestL2Payload:
         assert "Snapshot Diff" not in payload
 
 
-# --- Decisions summary tests (D77) ---
+# --- Decisions summary tests ---
 
 
 class TestL0DecisionsSummary:

--- a/packages/nauro/tests/test_mcp_tool_called.py
+++ b/packages/nauro/tests/test_mcp_tool_called.py
@@ -7,7 +7,7 @@ Covers:
    ("stdio") flips it back.
 3. A tool that raises emits one event with success=False AND re-raises.
 4. Property allowlist is closed — exactly four keys, never tool args, return
-   values, project_id, or exception strings (D117 never-sent list).
+   values, project_id, or exception strings.
 """
 
 from __future__ import annotations
@@ -136,7 +136,7 @@ def test_failing_tool_emits_one_event_with_success_false(
     props = tool_events[0]["properties"]
     assert props["tool_name"] == "synthetic_failure"
     assert props["success"] is False
-    # No exception leakage in the event payload (D117 never-sent list).
+    # No exception leakage in the event payload.
     assert set(props.keys()) == _ALLOWED_KEYS
     assert "secret_payload" not in json.dumps(tool_events[0])
 

--- a/packages/nauro/tests/test_note.py
+++ b/packages/nauro/tests/test_note.py
@@ -1,4 +1,4 @@
-"""Tests for nauro note auto-regen of AGENTS.md (D143).
+"""Tests for nauro note auto-regen of AGENTS.md.
 
 `nauro note` writes a decision or question to the store and then regenerates
 AGENTS.md in every associated repo so MCP-disconnected agents see the update

--- a/packages/nauro/tests/test_protocol_drift.py
+++ b/packages/nauro/tests/test_protocol_drift.py
@@ -227,8 +227,8 @@ RETIRED_PARAPHRASES = (
     "`check_decision` does not judge conflicts — the agent reads the decision bodies",
     # Pre-refactor adopt_body intro wording for NO_INVENT_RATIONALE
     "it does not invent rationale from code or prose",
-    # Pre-D133 update-operation wording — D133 made update rationale-only and
-    # rejected metadata changes; the bare "augment with new rationale or scope"
+    # Retired update-operation wording — update is now rationale-only and
+    # rejects metadata changes; the bare "augment with new rationale or scope"
     # phrasing would silently mislead an agent into trying to pass metadata.
     "augment an existing decision with new rationale or scope",
     # UPDATE_SUPERSEDE_CARE iterations — pre-PR "reclassified" wording implied
@@ -240,8 +240,8 @@ RETIRED_PARAPHRASES = (
     "be re-proposed later",
 )
 # NOTE: The PR-#44 hedge that retired the "server rejects ... at the boundary"
-# phrasing has been promoted back per D134 — both transports now enforce
-# D133's metadata rejection, so the active wording is accurate again. The
+# phrasing has been promoted back — both transports now enforce the metadata
+# rejection at the boundary, so the active wording is accurate again. The
 # guard entries from the hedge commit are deliberately removed; revert this
 # only if local enforcement is rolled back.
 

--- a/packages/nauro/tests/test_registry.py
+++ b/packages/nauro/tests/test_registry.py
@@ -208,7 +208,7 @@ def test_init_cli_with_add_repo(tmp_path, monkeypatch):
 def test_init_cli_duplicate(tmp_path, monkeypatch):
     """v2 allows duplicate names — id is unique. Two `nauro init dup`
     invocations from separate cwds both succeed and create distinct
-    entries. From the SAME cwd, D136's overwrite guard refuses without
+    entries. From the SAME cwd, the overwrite guard refuses without
     --force; the registry-allows-dups invariant is verified by exercising
     each init from its own directory.
     """
@@ -225,9 +225,9 @@ def test_init_cli_duplicate(tmp_path, monkeypatch):
 
 
 def test_init_cli_refuses_overwrite_without_force(tmp_path, monkeypatch):
-    """D136: a second `nauro init <other-name>` from the same cwd refuses
-    to overwrite the existing .nauro/config.json without --force, naming
-    the existing project so the caller can decide what to do."""
+    """A second `nauro init <other-name>` from the same cwd refuses to
+    overwrite the existing .nauro/config.json without --force, naming the
+    existing project so the caller can decide what to do."""
     monkeypatch.chdir(tmp_path)
     first = runner.invoke(app, ["init", "first"])
     assert first.exit_code == 0
@@ -243,7 +243,7 @@ def test_init_cli_refuses_overwrite_without_force(tmp_path, monkeypatch):
 
 
 def test_init_cli_force_overwrites(tmp_path, monkeypatch):
-    """D136: --force replaces an existing .nauro/config.json with the new
+    """--force replaces an existing .nauro/config.json with the new
     project's handle; the registry shows both."""
     monkeypatch.chdir(tmp_path)
     runner.invoke(app, ["init", "first"])
@@ -256,9 +256,9 @@ def test_init_cli_force_overwrites(tmp_path, monkeypatch):
 
 
 def test_init_cli_add_repo_idempotent_on_same_id(tmp_path, monkeypatch):
-    """D136: re-running `nauro init <existing-name> --add-repo <repo>`
-    against a repo already pointing at that project succeeds (idempotent),
-    because the existing config id matches the project's id."""
+    """Re-running `nauro init <existing-name> --add-repo <repo>` against
+    a repo already pointing at that project succeeds (idempotent), because
+    the existing config id matches the project's id."""
     repo = tmp_path / "repo"
     repo.mkdir()
     first = runner.invoke(app, ["init", "proj", "--add-repo", str(repo)])
@@ -268,8 +268,8 @@ def test_init_cli_add_repo_idempotent_on_same_id(tmp_path, monkeypatch):
 
 
 def test_init_cli_add_repo_refuses_overwrite_on_different_id(tmp_path, monkeypatch):
-    """D136: --add-repo against a repo already linked to a *different*
-    project refuses without --force, naming both projects."""
+    """--add-repo against a repo already linked to a *different* project
+    refuses without --force, naming both projects."""
     repo = tmp_path / "repo"
     repo.mkdir()
     # Repo already linked to 'alpha'.
@@ -310,9 +310,9 @@ def test_init_cli_add_repo_to_existing(tmp_path, monkeypatch):
 def test_init_add_repo_to_existing_writes_per_repo_config(tmp_path, monkeypatch):
     """Regression: `--add-repo` against same-name project must write `.nauro/config.json`.
 
-    Per D111 the per-repo config is the source of truth for "is this repo
-    adopted?". Without it, downstream guards (``nauro adopt`` already-adopted
-    check, the /nauro-adopt skill's Step 2) fail to detect the linkage.
+    The per-repo config is the source of truth for "is this repo adopted?".
+    Without it, downstream guards (``nauro adopt`` already-adopted check,
+    the /nauro-adopt skill's Step 2) fail to detect the linkage.
     """
     repo1 = tmp_path / "repo1"
     repo2 = tmp_path / "repo2"

--- a/packages/nauro/tests/test_resolution_v2.py
+++ b/packages/nauro/tests/test_resolution_v2.py
@@ -122,7 +122,7 @@ def test_stdio_resolve_no_repo_no_project_errors(tmp_path, monkeypatch):
     isolated = tmp_path / "isolated"
     isolated.mkdir()
     monkeypatch.chdir(isolated)
-    # D136: typed NoProjectError carries the new welcome anchor.
+    # Typed NoProjectError carries the welcome anchor.
     from nauro.store.resolution import NoProjectError
 
     with pytest.raises(NoProjectError, match="No Nauro project found"):

--- a/packages/nauro/tests/test_scaffolds.py
+++ b/packages/nauro/tests/test_scaffolds.py
@@ -8,11 +8,11 @@ from nauro.templates.scaffolds import STATE_CURRENT_MD, scaffold_project_store
 def test_state_scaffold_does_not_advertise_cli_update_state():
     """The empty-state placeholder must not tell users to 'call update_state'.
 
-    Per D144: `update_state` is an MCP write tool, not a CLI command. The
-    earlier scaffold copy ("...— call update_state to capture progress.")
-    flowed into AGENTS.md and led a real user to try `nauro update_state`
-    from the shell, which prints "No such command". This invariant prevents
-    the misleading instruction from coming back.
+    `update_state` is an MCP write tool, not a CLI command. The earlier
+    scaffold copy ("...— call update_state to capture progress.") flowed
+    into AGENTS.md and led a real user to try `nauro update_state` from
+    the shell, which prints "No such command". This invariant prevents the
+    misleading instruction from coming back.
     """
     assert "update_state" not in STATE_CURRENT_MD
     assert "No state recorded yet" in STATE_CURRENT_MD

--- a/packages/nauro/tests/test_search_decisions.py
+++ b/packages/nauro/tests/test_search_decisions.py
@@ -1,4 +1,4 @@
-"""Tests for search_decisions (D77 step 2)."""
+"""Tests for search_decisions."""
 
 from pathlib import Path
 

--- a/packages/nauro/tests/test_setup.py
+++ b/packages/nauro/tests/test_setup.py
@@ -25,7 +25,7 @@ def _setup_project(tmp_path: Path, monkeypatch, repo_paths: list[Path] | None = 
 
 
 class TestMCPConfigDirectWrite:
-    """`_configure_mcp` writes ``<repo>/.mcp.json`` directly (per D142).
+    """`_configure_mcp` writes ``<repo>/.mcp.json`` directly.
 
     The format is the documented Claude Code project-scope shape: an
     ``mcpServers`` object map keyed by server name. These tests lock in the

--- a/packages/nauro/tests/test_setup_extended.py
+++ b/packages/nauro/tests/test_setup_extended.py
@@ -171,7 +171,7 @@ def test_setup_codex_no_op_when_remove_and_no_entry(tmp_path: Path):
 
 def test_configure_codex_add_surfaces_parse_error(tmp_path: Path):
     """Hand-edited / corrupt `~/.codex/config.toml` surfaces a parse error
-    rather than crashing — same contract as the JSON handlers added in D142."""
+    rather than crashing — same contract as the JSON handlers."""
     config_path = tmp_path / ".codex" / "config.toml"
     config_path.parent.mkdir()
     config_path.write_text("this is not = valid [toml")
@@ -238,7 +238,7 @@ def test_setup_all_writes_claude_cursor_codex_configs(tmp_path: Path, monkeypatc
     result = runner.invoke(app, ["setup", "all"])
     assert result.exit_code == 0, result.output
 
-    # Claude Code: project-scope .mcp.json at the repo root (per D142, written
+    # Claude Code: project-scope .mcp.json at the repo root (written
     # directly rather than via `claude mcp add`).
     assert (repo / ".mcp.json").is_file()
     mcp_data = json.loads((repo / ".mcp.json").read_text())

--- a/packages/nauro/tests/test_skill_tool_signatures.py
+++ b/packages/nauro/tests/test_skill_tool_signatures.py
@@ -27,8 +27,8 @@ The parser is a deliberate naive walker, not a Python parser. It works
 because surfaces follow a narrow convention: positional args are
 parameter-name placeholders (``check_decision(proposed_approach)``),
 kwargs are ``name=opaque_value``. Values are ignored except
-``operation="..."`` so the D133 per-operation required-set exception
-for ``propose_decision`` can be applied.
+``operation="..."`` so the per-operation required-set exception for
+``propose_decision`` can be applied.
 
 The misspelled-tool guard uses a prefix allowlist derived from
 ``ALL_TOOLS`` (``propose_``, ``check_``, …) because a wide-open
@@ -244,7 +244,7 @@ def _kwarg_value(kwargs: dict[str, str], key: str) -> str:
 
 
 def _required_for_call(spec: ToolSpec, kwargs: dict[str, str]) -> set[str]:
-    """Effective required-param set, applying the D133 update exception.
+    """Effective required-param set, applying the update-operation exception.
 
     ``propose_decision(operation="update")`` only accepts ``rationale`` +
     ``affected_decision_id`` at the server boundary, so ``title`` is
@@ -356,10 +356,10 @@ _RETIRED_PROPOSE_DECISION_POSITIONALS: tuple[str, ...] = (
     "confidence",
 )
 
-# D133: propose_decision(operation="update") only accepts a narrow set of
-# fields. title / confidence / decision_type / reversibility /
-# files_affected / rejected are all rejected at the server boundary —
-# use operation="supersede" if any of those must change.
+# propose_decision(operation="update") only accepts a narrow set of fields.
+# title / confidence / decision_type / reversibility / files_affected /
+# rejected are all rejected at the server boundary — use
+# operation="supersede" if any of those must change.
 _UPDATE_ALLOWED_KWARGS: frozenset[str] = frozenset(
     {"project_id", "rationale", "operation", "affected_decision_id", "skip_validation"}
 )
@@ -367,7 +367,7 @@ _UPDATE_ALLOWED_KWARGS: frozenset[str] = frozenset(
 
 @pytest.mark.parametrize("surface_name,loader", _SURFACE_PARAMS)
 def test_no_retired_propose_decision_positional_shape(surface_name: str, loader) -> None:
-    """D131 retired the positional ``(title, rationale, rejected, confidence)`` shape.
+    """The positional ``(title, rationale, rejected, confidence)`` shape is retired.
 
     Detected via the parsed positional list (not a substring match) so
     cosmetic edits to the template still trip the guard. Complements the
@@ -381,8 +381,8 @@ def test_no_retired_propose_decision_positional_shape(surface_name: str, loader)
         if tuple(positional) == _RETIRED_PROPOSE_DECISION_POSITIONALS:
             pytest.fail(
                 f"{_at(surface_name, text, call.offset)}: propose_decision({call.args}) "
-                "uses the retired positional contract — D131 requires the "
-                "operation-aware signature"
+                "uses the retired positional contract — the operation-aware "
+                "signature is required"
             )
 
 
@@ -390,8 +390,9 @@ def test_no_retired_propose_decision_positional_shape(surface_name: str, loader)
 def test_propose_decision_multi_kwarg_calls_specify_operation(surface_name: str, loader) -> None:
     """Every multi-kwarg propose_decision template must include ``operation``.
 
-    Per D131 the agent owns the add/update/supersede classification.
-    Calls with 0 or 1 kwarg are abbreviated references, not full templates.
+    The agent owns the add/update/supersede classification, so every full
+    call must specify it. Calls with 0 or 1 kwarg are abbreviated
+    references, not full templates.
     """
     text = loader()
     for call in _iter_well_formed_calls(text):
@@ -402,13 +403,13 @@ def test_propose_decision_multi_kwarg_calls_specify_operation(surface_name: str,
             continue
         assert "operation" in kwargs, (
             f"{_at(surface_name, text, call.offset)}: propose_decision({call.args}) "
-            "is missing the operation kwarg — D131 requires operation-aware calls"
+            "is missing the operation kwarg — operation-aware calls are required"
         )
 
 
 @pytest.mark.parametrize("surface_name,loader", _SURFACE_PARAMS)
-def test_propose_decision_update_kwargs_within_d133_allowlist(surface_name: str, loader) -> None:
-    """D133: ``propose_decision(operation="update")`` accepts only a narrow set.
+def test_propose_decision_update_kwargs_within_allowlist(surface_name: str, loader) -> None:
+    """``propose_decision(operation="update")`` accepts only a narrow set.
 
     ``title``, ``confidence``, ``decision_type``, ``reversibility``,
     ``files_affected``, ``rejected`` are rejected at the server boundary
@@ -424,7 +425,7 @@ def test_propose_decision_update_kwargs_within_d133_allowlist(surface_name: str,
         extra = set(kwargs) - _UPDATE_ALLOWED_KWARGS
         assert not extra, (
             f"{_at(surface_name, text, call.offset)}: "
-            f"propose_decision({call.args}) includes D133-rejected fields "
+            f"propose_decision({call.args}) includes boundary-rejected fields "
             f'for operation="update": {sorted(extra)}; '
             f"allowed = {sorted(_UPDATE_ALLOWED_KWARGS)}"
         )

--- a/packages/nauro/tests/test_stdio_server.py
+++ b/packages/nauro/tests/test_stdio_server.py
@@ -57,15 +57,15 @@ class TestResolveStore:
         assert result == store
 
     def test_raises_on_unknown_project(self, store: Path):
-        # D136: unknown name in v2 falls through to v1 legacy; if also
-        # missing there, ProjectNotFoundError carries the "registry" anchor.
+        # Unknown name in v2 falls through to v1 legacy; if also missing
+        # there, ProjectNotFoundError carries the "registry" anchor.
         from nauro.store.resolution import ProjectNotFoundError
 
         with pytest.raises(ProjectNotFoundError, match="registry"):
             _resolve_store("nonexistent", None)
 
     def test_raises_on_no_project_or_cwd(self, store: Path):
-        # D136: NoProjectError reserved for the genuinely-no-project case.
+        # NoProjectError is reserved for the genuinely-no-project case.
         # Wrapper code maps only this subclass to WELCOME_NO_PROJECT.
         from nauro.store.resolution import NoProjectError
 
@@ -168,7 +168,7 @@ class TestProposeDecision:
 
 
 class TestProposeDecisionResolvesQuestions:
-    """D139 wired through the stdio FastMCP layer.
+    """propose_decision.resolves_questions wired through the stdio FastMCP layer.
 
     Asserts the Annotated[list[str], ...] wrapper forwards the param into
     tool_propose_decision and the resolved-questions response field is
@@ -179,7 +179,7 @@ class TestProposeDecisionResolvesQuestions:
         """Write one question with a Q-form id; return its id."""
         qid = "Q1"
         (store / "open-questions.md").write_text(
-            f"# Open Questions\n\n- [{qid}] should we ship D139?\n"
+            f"# Open Questions\n\n- [{qid}] should we ship the feature?\n"
         )
         return qid
 
@@ -187,7 +187,7 @@ class TestProposeDecisionResolvesQuestions:
         question_id = self._seed_question(store)
         result = propose_decision(
             project_id="testproj",
-            title="Ship D139",
+            title="Ship the feature",
             rationale="Decision that closes the seeded open question.",
             resolves_questions=[question_id],
         )
@@ -231,11 +231,12 @@ class TestProposeDecisionResolvesQuestions:
 
 
 class TestWelcomeDisambiguation:
-    """D136: WELCOME_NO_PROJECT is reserved for the genuinely-no-project
-    case. Specific failures (bogus project_id, missing store on disk,
-    mismatched cwd config) must surface their own diagnostic instead of
-    the onboarding screen suggesting `nauro init`, which is the wrong
-    remedy when the caller already has a (mis-)configured project."""
+    """WELCOME_NO_PROJECT is reserved for the genuinely-no-project case.
+
+    Specific failures (bogus project_id, missing store on disk, mismatched
+    cwd config) must surface their own diagnostic instead of the onboarding
+    screen suggesting `nauro init`, which is the wrong remedy when the
+    caller already has a (mis-)configured project."""
 
     def test_unknown_project_id_surfaces_specific_error(self, store: Path):
         """Bogus project_id keyword on a dict-returning tool → guidance
@@ -255,8 +256,8 @@ class TestWelcomeDisambiguation:
 
     def test_no_project_resolvable_still_returns_welcome(self, store: Path):
         """The genuine onboarding case — no project_id, no cwd config —
-        keeps the welcome screen. D136 narrows what counts as the
-        onboarding case; this asserts the narrowing didn't lose it."""
+        keeps the welcome screen. This asserts the narrowing of the
+        onboarding case didn't lose the legitimate trigger."""
         # Drop the registry so no project can resolve from cwd or by name.
         from nauro.store.registry import _registry_file
 
@@ -330,9 +331,9 @@ class TestToolRegistration:
 
 
 class TestToolSpecDescriptionsReachAgent:
-    """D134 P1: per-property descriptions in nauro_core.mcp_tools must reach
-    agents via FastMCP's tools/list inputSchema (not just the parent tool
-    description). Pre-D134 the local stdio's _spec_kwargs forwarded only
+    """Per-property descriptions in nauro_core.mcp_tools must reach agents
+    via FastMCP's tools/list inputSchema, not just the parent tool
+    description. Previously the local stdio's _spec_kwargs forwarded only
     title/description/annotations; FastMCP regenerated the inputSchema from
     function signatures, stripping every per-property description and enum.
     Annotated[T, Field(description=...)] + Literal[...] in the wrappers
@@ -437,9 +438,9 @@ class TestToolSpecDescriptionsReachAgent:
         ],
     )
     def test_project_id_property_alignment_with_toolspec(self, tools_by_name, tool):
-        """D135: the local stdio's tools/list must advertise `project_id` as
-        the property name on every tool that takes a project handle —
-        matching the central ToolSpec (and the remote MCP). Pre-rename the
+        """The local stdio's tools/list must advertise `project_id` as the
+        property name on every tool that takes a project handle — matching
+        the central ToolSpec (and the remote MCP). Before the rename the
         wrappers exposed `project`, which produced cross-transport schema
         drift: an agent inspecting tools/list saw different property names
         depending on which transport they connected through."""

--- a/packages/nauro/tests/test_store.py
+++ b/packages/nauro/tests/test_store.py
@@ -201,7 +201,7 @@ def test_question_multiple(store: Path):
 
 
 def test_update_state_creates_state_current(store: Path):
-    """update_state writes to state_current.md (scaffolded directly post-D94)."""
+    """update_state writes to state_current.md (scaffolded directly)."""
     update_state(store, "Implemented auth module")
     current = (store / "state_current.md").read_text()
     assert "# Current State" in current
@@ -233,7 +233,7 @@ def test_update_state_history_accumulates(store: Path):
 
 
 def test_update_state_migration_preserves_legacy(tmp_path: Path):
-    """Pre-D94 stores: state.md only → first update_state migrates to state_current.md."""
+    """Legacy stores: state.md only → first update_state migrates to state_current.md."""
     store = tmp_path / "legacy-store"
     (store / "decisions").mkdir(parents=True)
     (store / "snapshots").mkdir()
@@ -604,7 +604,7 @@ def test_validate_unfilled_prompts(store: Path):
 def test_validate_stale_sync(tmp_path: Path):
     store = tmp_path / "projects" / "stale"
     scaffold_project_store("stale", store)
-    # Validator prefers state_current.md (post-D94 default) for staleness check.
+    # Validator prefers state_current.md (the default) for staleness check.
     state = store / "state_current.md"
     old_date = (datetime.now(timezone.utc) - timedelta(days=10)).strftime("%Y-%m-%d")
     state.write_text(f"# Current State\n*Last synced: {old_date}*\n")

--- a/packages/nauro/tests/test_tool_update_state.py
+++ b/packages/nauro/tests/test_tool_update_state.py
@@ -1,8 +1,7 @@
 """Regression tests for `tool_update_state` keyword-overlap warning.
 
-Post-D94 the current state lives in `state_current.md`; the hardcoded
-`state.md` literal silently disabled the overlap-warning branch on every
-modern store.
+The current state lives in `state_current.md`; the hardcoded `state.md`
+literal silently disabled the overlap-warning branch on every modern store.
 """
 
 from pathlib import Path

--- a/packages/nauro/tests/test_validation/test_pipeline.py
+++ b/packages/nauro/tests/test_validation/test_pipeline.py
@@ -202,9 +202,9 @@ class TestCallerOperationPreservedAcrossT2Outcomes:
             "002-use-postgres-as-primary-database" if operation in ("update", "supersede") else None
         )
 
-        # D133: update appends rationale only — title="" + no metadata so the
-        # disallowed-fields branch does not fire. add/supersede send the full
-        # proposal as before.
+        # update appends rationale only — title="" + no metadata so the
+        # disallowed-fields branch does not fire. add/supersede send the
+        # full proposal as before.
         if operation == "update":
             proposal = {"title": "", "rationale": rationale}
         else:
@@ -220,26 +220,26 @@ class TestCallerOperationPreservedAcrossT2Outcomes:
         assert result.operation == expected_op
 
 
-class TestD133UpdateRejectsMetadata:
-    """D134 (mirroring D133): operation='update' rejects metadata fields at the
-    local boundary so the canonical wording in PROPOSE_DECISION_OPERATIONS
-    holds on both transports.
+class TestUpdateRejectsMetadata:
+    """operation='update' rejects metadata fields at the local boundary so
+    the canonical wording in PROPOSE_DECISION_OPERATIONS holds on both
+    transports.
     """
 
     @pytest.fixture
     def store_with_seed(self, tmp_path: Path) -> Path:
-        store_path = tmp_path / "projects" / "d133"
-        scaffold_project_store("d133", store_path)
+        store_path = tmp_path / "projects" / "update_reject"
+        scaffold_project_store("update_reject", store_path)
         append_decision(
             store_path,
-            "Seed decision for D133 tests",
+            "Seed decision for update rejects metadata tests",
             rationale="A seed decision the update tests can target as affected_decision_id.",
         )
         return store_path
 
     RATIONALE = (
         "A sufficiently long rationale that comfortably exceeds the structural "
-        "minimum length so D133 rejection wins on the disallowed-fields branch."
+        "minimum length so the disallowed-fields rejection wins on the update branch."
     )
 
     @pytest.mark.parametrize(
@@ -261,7 +261,7 @@ class TestD133UpdateRejectsMetadata:
             proposal,
             store_with_seed,
             operation="update",
-            affected_decision_id="002-seed-decision-for-d133-tests",
+            affected_decision_id="002-seed-decision-for-update-rejects-metadata-tests",
         )
         assert result.status == "rejected"
         assert result.tier == 0
@@ -279,42 +279,42 @@ class TestD133UpdateRejectsMetadata:
             proposal,
             store_with_seed,
             operation="update",
-            affected_decision_id="002-seed-decision-for-d133-tests",
+            affected_decision_id="002-seed-decision-for-update-rejects-metadata-tests",
         )
         assert result.status == "rejected"
         assert result.tier == 0
         for field in ("title", "decision_type", "confidence"):
             assert field in result.assessment
 
-    def test_update_with_empty_title_and_no_metadata_passes_d133_gate(
+    def test_update_with_empty_title_and_no_metadata_passes_disallowed_gate(
         self, store_with_seed: Path
     ) -> None:
         """The legitimate rationale-only update signal: title="" and none of the
-        disallowed fields populated. Validation should advance past the D133
-        gate (status may be confirmed or pending_confirmation depending on
-        Tier 2 — either way, the disallowed-fields rejection must not fire)."""
+        disallowed fields populated. Validation should advance past the
+        disallowed-fields gate (status may be confirmed or pending_confirmation
+        depending on Tier 2 — either way, the rejection must not fire)."""
         proposal = {"title": "", "rationale": self.RATIONALE}
         result = validate_proposed_write(
             proposal,
             store_with_seed,
             operation="update",
-            affected_decision_id="002-seed-decision-for-d133-tests",
+            affected_decision_id="002-seed-decision-for-update-rejects-metadata-tests",
         )
         assert result.status != "rejected"
         assert result.tier != 0
 
-    def test_update_with_empty_rationale_rejects_at_tier_1_not_d133(
+    def test_update_with_empty_rationale_rejects_at_tier_1_not_disallowed_branch(
         self, store_with_seed: Path
     ) -> None:
         """Update with empty rationale should fail on the rationale-only Tier 1
-        check, not on the D133 disallowed-fields branch (which only fires for
+        check, not on the disallowed-fields branch (which only fires for
         metadata fields, not for missing rationale)."""
         proposal = {"title": "", "rationale": ""}
         result = validate_proposed_write(
             proposal,
             store_with_seed,
             operation="update",
-            affected_decision_id="002-seed-decision-for-d133-tests",
+            affected_decision_id="002-seed-decision-for-update-rejects-metadata-tests",
         )
         assert result.status == "rejected"
         assert result.tier == 1
@@ -326,13 +326,13 @@ class TestD133UpdateRejectsMetadata:
             proposal,
             store_with_seed,
             operation="update",
-            affected_decision_id="002-seed-decision-for-d133-tests",
+            affected_decision_id="002-seed-decision-for-update-rejects-metadata-tests",
         )
         assert result.status == "rejected"
         assert result.tier == 1
         assert "Rationale too short" in result.assessment
 
-    def test_add_and_supersede_unaffected_by_d133_branch(self, store_with_seed: Path) -> None:
+    def test_add_and_supersede_unaffected_by_disallowed_branch(self, store_with_seed: Path) -> None:
         """The disallowed-fields branch only fires for operation='update'."""
         proposal = {
             "title": "A new architectural decision",
@@ -350,13 +350,13 @@ class TestD133UpdateRejectsMetadata:
             proposal,
             store_with_seed,
             operation="supersede",
-            affected_decision_id="002-seed-decision-for-d133-tests",
+            affected_decision_id="002-seed-decision-for-update-rejects-metadata-tests",
         )
         assert result_supersede.status != "rejected" or result_supersede.tier != 0
 
 
-class TestD139ResolvesQuestions:
-    """D139: propose_decision can pass `resolves_questions` to move named
+class TestResolvesQuestions:
+    """propose_decision can pass `resolves_questions` to move named
     open-questions.md entries under ``## Resolved`` on confirm. Q-form
     ids are the canonical scheme; legacy timestamp ids remain accepted
     for entries that predate the Q-form rollout.
@@ -364,14 +364,14 @@ class TestD139ResolvesQuestions:
 
     RATIONALE = (
         "A sufficiently long rationale that comfortably exceeds the structural "
-        "minimum length so D139 boundary validation is what is exercised."
+        "minimum length so resolves_questions boundary validation is exercised."
     )
 
     @pytest.fixture
     def store_with_questions(self, tmp_path: Path) -> Path:
         """Q-form fixture — the canonical id scheme."""
-        store_path = tmp_path / "projects" / "d139"
-        scaffold_project_store("d139", store_path)
+        store_path = tmp_path / "projects" / "resolves"
+        scaffold_project_store("resolves", store_path)
         oq = store_path / "open-questions.md"
         oq.write_text("# Open Questions\n\n- [Q1] q-one body text\n- [Q2] q-two body text\n")
         return store_path
@@ -381,8 +381,8 @@ class TestD139ResolvesQuestions:
         """Legacy timestamp fixture — kept so the reject-path and
         dual-grammar acceptance tests can still target the legacy id
         grammar that older stores may carry forward."""
-        store_path = tmp_path / "projects" / "d139-legacy"
-        scaffold_project_store("d139-legacy", store_path)
+        store_path = tmp_path / "projects" / "resolves-legacy"
+        scaffold_project_store("resolves-legacy", store_path)
         oq = store_path / "open-questions.md"
         oq.write_text(
             "# Open Questions\n"
@@ -526,7 +526,7 @@ class TestD139ResolvesQuestions:
             key=lambda p: p.name,
         )
         affected = decisions[-1].stem
-        # D131: supersede always returns pending_confirmation.
+        # supersede always returns pending_confirmation.
         result = validate_proposed_write(
             proposal,
             store_with_questions,

--- a/packages/nauro/tests/test_validation/test_tier2.py
+++ b/packages/nauro/tests/test_validation/test_tier2.py
@@ -1,4 +1,4 @@
-"""Tests for Tier 2 BM25 similarity validation (D93)."""
+"""Tests for Tier 2 BM25 similarity validation."""
 
 from pathlib import Path
 
@@ -59,7 +59,7 @@ class TestCheckSimilarity:
         assert action == "auto_confirm"
 
     def test_vocabulary_mismatch_detected(self, store):
-        """BM25 with stemming catches vocabulary mismatches (D93 motivation)."""
+        """BM25 with stemming catches vocabulary mismatches."""
         append_decision(
             store,
             "Chose Memcached for session state",


### PR DESCRIPTION
## Why

Internal Nauro decision numbers (D###) resolve only against the user's local store at `~/.nauro/projects/<id>/decisions/` — they look like external references but point to nothing for any reader of this public repo. The same category as a private Linear issue id leaking into a public PR. PR #86 fixed the citations in files it touched; this follow-up cleans the rest the previous diff surfaced.

## Approach

Walked the full `grep -rnE '\bD[0-9]+\b' packages/` surface and triaged into three categories:

- **Drop the citation in place** — parenthetical attributions in docstrings, comment-leading labels, and test class-name prefixes. The surrounding text already names the behavior; the D-number was bookkeeping for the author, not signal for the reader. Three test classes renamed: `TestD133UpdateRejectsMetadata` → `TestUpdateRejectsMetadata`, `TestD139ResolvesQuestions` → `TestResolvesQuestions`, `TestD169AmbiguousResolvesQuestions` → `TestAmbiguousResolvesQuestionsRejected`. Confirmed no cross-file imports or CI selectors reference the old class names.
- **Inline-describe** — a handful of comments where the citation was the only context (e.g. `"the prior session's D69/D70/D105 backfill standardized on"`) got rewritten with the behavior named directly.
- **Leave as-is** — render-format and demo-fixture identifiers in published artifacts. This covers fixture render strings (`[Resolved by D7 on 2026-05-19] [Q42] qbody`), payload assertions (`D3 — Auth0 for OAuth` in the L0 summary), grammar examples in parsing/validator docstrings (`"D042"`, `"D70"`), and the canonical demo-project decision identifier (`D004`) asserted by check-command tests and shown in README sample output. These exercise the format itself, not citations into the live decision store.

The local Nauro decision store at `~/.nauro/projects/nauro/decisions/` is outside the repo and out of scope.

## What changed

- `nauro-core/src/`: docstring cleanups in `decision_model.py`, `search.py`, `validation.py`.
- `nauro-core/tests/`: comment / docstring cleanups across `test_search.py`, `test_validation.py`, `test_protocol.py`, `test_constants.py`, `test_mcp_tools.py`, `test_decision_model.py`.
- `nauro/src/`: docstring cleanup in `validation/tier2.py`.
- `nauro/tests/`: comment / docstring cleanups across 20 files plus three test-class renames in `test_validation/test_pipeline.py`. The renamed metadata-rejection test class also gets a paraphrased seed-decision title (`"Seed decision for update rejects metadata tests"`), which shifts the file slug — the six `affected_decision_id="002-seed-decision-for-..."` fixtures inside that class were updated in lockstep.

32 files touched, 144 insertions / 146 deletions.

## What to review

- The three test class renames in `packages/nauro/tests/test_validation/test_pipeline.py`. `grep -rnE 'TestD[0-9]+' packages/ .github/ pyproject.toml` returns empty; only the three definitions matched before the rename. No CI selector or import broke.
- The seed-decision title paraphrase in the same file. The slug feeds back into `affected_decision_id` fixture strings; all six call sites were updated in the same commit.
- Render-format and demo-fixture identifiers in published artifacts left as-is: `D004` in the demo fixture + check-command tests + READMEs; `D6/D16/D7` in `test_mcp.py` L0/L1 payload assertions; `D042`/`D70` grammar examples in parser/validator docstrings. These exercise the format itself — changing them would create real divergence between tests, demo, and docs.

## What's deferred

Nothing. The local-store decision files under `~/.nauro/` are by design not in the repo.

## Test plan

- `uv run ruff check packages/` — clean.
- `uv run ruff format --check packages/` — 156 files already formatted.
- `uv run pytest packages/ -q` — 1326 tests pass. Count unchanged (no tests added or removed).
- Final D-ref grep on additions: only the `"D70"` grammar example in the `TestSupersessionRefValidator` docstring remains, by design.