### PR TITLE
chore(release): prep nauro-core 0.9.0 and nauro 0.6.0

### DIFF
--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro-core"
-version = "0.8.0"
+version = "0.9.0"
 description = "Shared pure-Python logic for Nauro: parsing, validation, context assembly, constants."
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro"
-version = "0.5.1"
+version = "0.6.0"
 description = "Local CLI + MCP server: set your project's doctrine once, every connected AI agent inherits it."
 readme = "README.md"
 license = "Apache-2.0"
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "nauro-core>=0.8.0,<0.9",
+    "nauro-core>=0.9.0,<0.10",
     "typer>=0.9",
     "fastapi>=0.100",
     "uvicorn>=0.23",


### PR DESCRIPTION
## Why

mcp-server has a pending branch (\`chore/bump-nauro-core-d152\`) calling the new \`file.known_question_ids\` API that landed in PR #85. The Lambda deploy installs nauro-core from PyPI (D98 — \`--only-binary=:all:\` rules out git installs), so the Lambda cannot ship that branch until nauro-core publishes the new API. Bundling the nauro CLI bump with the nauro-core bump keeps the public CLI install lockstep with the 17-commit backlog of fixes and refactors.

## What changed

Two pyproject.toml lines on packages/nauro-core, two on packages/nauro. No source-code changes.

- nauro-core 0.8.0 → 0.9.0
- nauro 0.5.1 → 0.6.0
- nauro's dep cap nauro-core>=0.8.0,<0.9 → >=0.9.0,<0.10

## Highlights since the last release

**nauro-core 0.9.0** (since v0.8.0):
- #85 — OpenQuestionsFile block-list internal shape; parse/format round-trips byte-identical for inputs untouched by resolve. Adds new \`known_question_ids\` API.
- #86 — Sequential Q identifier scheme for open-questions.md.
- #84 — Per-user section prepended in MCP server-side instructions; static body trimmed.
- #82 — Reject tool-use envelope fragments at the writer boundary.

**nauro 0.6.0** (since v0.5.1):
- #83 — Section-aware set-union merge for append-only markdown sync.
- #72 — Sanitize backslashes and use STATE_CURRENT_FILENAME in update_state.
- #71 — Refresh stale token through with_token_refresh in cloud-projects.
- #70 — Scrub stale attribution footer on AGENTS.md regen.
- #74, #75, #76, #77, #78, #80, #81 — test hardening, internal-label scrub, plain-string refactor, telemetry test dedupe, ruff backlog clear, callback/header helper extraction, store-layout docs.

## Test plan

- \`uv run ruff check packages/\` → all checks passed
- \`uv run ruff format --check packages/\` → 156 files already formatted
- \`uv run --package nauro-core pytest packages/nauro-core/tests/ -x -q\` → 364 passed
- \`uv run --package nauro pytest packages/nauro/tests/ -x -q\` → 920 passed

## What's deferred

- mcp-server bump from commit-pin to tag-pin (\`make bump-nauro-core REV=nauro-core-v0.9.0\`) and staging/prod deploy land in a follow-up mcp-server PR after this merges and the tags publish.