### PR TITLE
feat(skills): ship bundled nauro-ship-task skill behind --with-skills flag

### DIFF
--- a/.agents/skills/nauro-ship-task/SKILL.md
+++ b/.agents/skills/nauro-ship-task/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: nauro-ship-task
+description: Run the full planner -> executor -> reviewer -> tech-lead -> user-confirm -> push chain for a non-trivial code change against Nauro's bundled @nauro-* subagents. Gates on the user whenever the planner or executor will file a Nauro decision; runs @nauro-tech-lead Mode C between reviewer-APPROVE and the push gate to catch doctrine drift the reviewer missed. Invoke explicitly with /nauro-ship-task <description>. Requires `nauro adopt --with-subagents` to have run.
+---
+
+# Nauro ship task skill
+
+Orchestrate a non-trivial code change end-to-end using Nauro's bundled `@nauro-planner`, `@nauro-executor`, `@nauro-reviewer`, and `@nauro-tech-lead` subagents, with Nauro doctrine gates at every architectural choice.
+
+Task: $ARGUMENTS
+
+If $ARGUMENTS is empty, ask the user for a one-paragraph task description and wait for it before proceeding.
+
+## Prerequisites
+
+This skill invokes the bundled `@nauro-*` subagents by name. They install via `nauro adopt --with-subagents` (or `nauro setup all --with-subagents`). If they are missing, the chain cannot run — surface that to the user and stop. The personal-subagent path (`@planner` / `@executor` / `@reviewer` without the `nauro-` prefix) is not a substitute: the bundled subagents call Nauro's MCP tools by design, which is what makes the doctrine gates load-bearing.
+
+## Execute the chain without waiting for the user to prompt each step
+
+Pause only at the two explicit gates marked GATE below.
+
+## Pre-step — Doctrine triage before the planner spins up
+
+Before invoking `@nauro-planner`, the parent session confirms the planner will run `check_decision` first. The planner's contract already requires this, but the chain enforces it explicitly: if the planner returns a RED verdict (proposal directly contradicts an active decision) and drafts a supersede, the chain pauses before the executor sees anything. The user gates the supersede via `confirm_decision`; only on confirmation does the executor see the approved plan. This is the doctrine equivalent of GATE 1 firing early — a RED that the user does not resolve never reaches code.
+
+### 1. Plan
+
+Invoke the `@nauro-planner` subagent with the task description. The planner runs `check_decision` against the proposed approach, classifies as GREEN / AMBER / RED, reads related decision bodies via `get_decision`, investigates the code, and returns a plan in the PR-template shape (Why / Approach / What changes / What's deferred / Test plan), plus the verdict line and any decision number it drafted.
+
+If the planner returns RED with a supersede draft, the chain pauses here. Surface the draft to the user. Only on `confirm_decision` (or an explicit "override RED on the cited decision, proceed") does the chain continue to the executor.
+
+### 2. GATE — plan approval (always when `propose_decision` is in play)
+
+The Nauro chain gates the plan whenever the planner indicates it will file a decision via `propose_decision` for any architectural choice, or whenever the plan records a supersede / update draft. This is stricter than the personal `/ship-task` skill: there is no "low-stakes auto-proceed" path when doctrine writes are pending. The user's judgment is the gate on what enters the decision log.
+
+A change additionally always gates if any of the following apply:
+
+- Touches authentication, credentials, secrets, tokens, signing, or encryption
+- Changes data model, schema, storage format, or existing on-disk / database layout
+- Adds, removes, or renames public surface (CLI commands, public functions, MCP tools, API endpoints, env vars, config keys)
+- Changes the contract between `nauro` and `nauro-core`, or anything `mcp-server` consumes from `nauro-core`
+- Adds, removes, or major-version bumps a dependency
+- Records a Nauro decision with reversibility `hard` or `moderate`
+- Surfaces 2-3 defensible alternatives where the choice is genuinely architectural
+
+**When gating:** surface the plan, surface alternatives as alternatives, wait for explicit user approval. Do not proceed without it. Auto-mode and standing "keep moving" directives do not override this gate — it exists precisely for the cases where the user wants their judgment in.
+
+**When auto-proceeding (no doctrine writes, no high-stakes triggers):** post a one-paragraph summary ("Planner proposes: `<X>`. Auto-proceeding to executor — no doctrine writes, no high-stakes triggers.") and continue. The user can interrupt at any time; if the classification feels wrong, they redirect and the gate fires.
+
+### 3. Execute
+
+Invoke the `@nauro-executor` subagent with the approved plan. Include any confirmed decision number from step 1 in the prompt. The executor implements the plan, commits locally, and does not push (per its contract). Any architectural choice the executor makes that the plan did not pre-record gets filed via `propose_decision` at the moment the choice lands in code — not deferred to the end of the chain.
+
+### 4. Local review (no user pause)
+
+Immediately after the executor returns, invoke the `@nauro-reviewer` subagent in Mode A on the local diff and the drafted PR description. Do not surface "ready to push" to the user before the reviewer has audited.
+
+### 5. Iteration on block
+
+If the reviewer returns BLOCK, hand the hard-rule failures back to the `@nauro-executor` for fix — scoped strictly to what was flagged, no scope expansion. Then re-invoke `@nauro-reviewer`. Cap at 2 fix iterations. If still blocked after 2, surface both verdicts and the unresolved findings to the user.
+
+### 6. Doctrine pass
+
+When the reviewer returns APPROVE or APPROVE WITH NITS, invoke `@nauro-tech-lead` in Mode C on the same local diff. The tech-lead reads decisions, scans the diff for architectural choices, and returns GREEN / AMBER / RED with any drafted supersede or update confirm_ids.
+
+- **GREEN** — proceed to GATE.
+- **AMBER** — surface the constraints to the user alongside the push gate; user decides whether to address before push or document as a follow-up.
+- **RED** — pause. Either redirect the executor (fix the drift, then re-run reviewer + tech-lead) or confirm the drafted supersede first. Do not push past a RED tech-lead verdict without an explicit human override on the cited decision.
+
+The reviewer's bug-finding pass and the tech-lead's doctrine pass are deliberately separate concerns — the reviewer can return APPROVE on a clean diff that the tech-lead later flags for drift.
+
+### 7. GATE — push confirmation (user)
+
+When the reviewer returns APPROVE / APPROVE WITH NITS and the tech-lead returns GREEN (or AMBER with surfaced constraints), surface:
+
+- The drafted PR description (full text)
+- A one-paragraph diff summary
+- The reviewer's verdict and any nits
+- The tech-lead's verdict and any AMBER constraints
+- Any Nauro decisions filed during the chain (numbers + one-line rationale)
+- "Push and open PR?"
+
+Wait for explicit approval.
+
+### 8. Push
+
+On approval, push the branch and open the PR with the drafted description as the body (`gh pr create --body "..."`). Decisions filed during the chain go in the PR's Approach section by paraphrase, not by raw decision number — the public-repo convention is to describe the doctrine move ("the bundled-subagents pattern"), not cite internal D-numbers.
+
+## Rules
+
+- Push and `gh pr create` happen only with explicit user approval at GATE 7.
+- `confirm_decision` happens only with explicit user approval — the planner / executor / tech-lead draft and `propose_decision`, never confirm. Parallel `propose_decision` is safe; parallel `confirm_decision` is not — confirm sequentially.
+- If anything fails or surprises mid-chain (a tool errors, tests fail unexpectedly, a verdict is incoherent), stop and surface to the user rather than recovering silently.
+- The chain is doctrine-aware end-to-end: every architectural choice flows through `check_decision` (at planning), `propose_decision` (when the choice lands), and `confirm_decision` (under user control). Skipping any of those silently is a chain failure, not a shortcut.

--- a/.agents/skills/nauro-ship-task/SKILL.md
+++ b/.agents/skills/nauro-ship-task/SKILL.md
@@ -7,9 +7,7 @@ description: Run the full planner -> executor -> reviewer -> tech-lead -> user-c
 
 Orchestrate a non-trivial code change end-to-end using Nauro's bundled `@nauro-planner`, `@nauro-executor`, `@nauro-reviewer`, and `@nauro-tech-lead` subagents, with Nauro doctrine gates at every architectural choice.
 
-Task: $ARGUMENTS
-
-If $ARGUMENTS is empty, ask the user for a one-paragraph task description and wait for it before proceeding.
+Take the user's task description from the prompt that invoked this skill. If they did not include one, ask for a one-paragraph description and wait for it before proceeding.
 
 ## Prerequisites
 

--- a/.claude/skills/nauro-ship-task/SKILL.md
+++ b/.claude/skills/nauro-ship-task/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: nauro-ship-task
+description: Run the full planner -> executor -> reviewer -> tech-lead -> user-confirm -> push chain for a non-trivial code change against Nauro's bundled @nauro-* subagents. Gates on the user whenever the planner or executor will file a Nauro decision; runs @nauro-tech-lead Mode C between reviewer-APPROVE and the push gate to catch doctrine drift the reviewer missed. Invoke explicitly with /nauro-ship-task <description>. Requires `nauro adopt --with-subagents` to have run.
+---
+
+# Nauro ship task skill
+
+Orchestrate a non-trivial code change end-to-end using Nauro's bundled `@nauro-planner`, `@nauro-executor`, `@nauro-reviewer`, and `@nauro-tech-lead` subagents, with Nauro doctrine gates at every architectural choice.
+
+Task: $ARGUMENTS
+
+If $ARGUMENTS is empty, ask the user for a one-paragraph task description and wait for it before proceeding.
+
+## Prerequisites
+
+This skill invokes the bundled `@nauro-*` subagents by name. They install via `nauro adopt --with-subagents` (or `nauro setup all --with-subagents`). If they are missing, the chain cannot run — surface that to the user and stop. The personal-subagent path (`@planner` / `@executor` / `@reviewer` without the `nauro-` prefix) is not a substitute: the bundled subagents call Nauro's MCP tools by design, which is what makes the doctrine gates load-bearing.
+
+## Execute the chain without waiting for the user to prompt each step
+
+Pause only at the two explicit gates marked GATE below.
+
+## Pre-step — Doctrine triage before the planner spins up
+
+Before invoking `@nauro-planner`, the parent session confirms the planner will run `check_decision` first. The planner's contract already requires this, but the chain enforces it explicitly: if the planner returns a RED verdict (proposal directly contradicts an active decision) and drafts a supersede, the chain pauses before the executor sees anything. The user gates the supersede via `confirm_decision`; only on confirmation does the executor see the approved plan. This is the doctrine equivalent of GATE 1 firing early — a RED that the user does not resolve never reaches code.
+
+### 1. Plan
+
+Invoke the `@nauro-planner` subagent with the task description. The planner runs `check_decision` against the proposed approach, classifies as GREEN / AMBER / RED, reads related decision bodies via `get_decision`, investigates the code, and returns a plan in the PR-template shape (Why / Approach / What changes / What's deferred / Test plan), plus the verdict line and any decision number it drafted.
+
+If the planner returns RED with a supersede draft, the chain pauses here. Surface the draft to the user. Only on `confirm_decision` (or an explicit "override RED on the cited decision, proceed") does the chain continue to the executor.
+
+### 2. GATE — plan approval (always when `propose_decision` is in play)
+
+The Nauro chain gates the plan whenever the planner indicates it will file a decision via `propose_decision` for any architectural choice, or whenever the plan records a supersede / update draft. This is stricter than the personal `/ship-task` skill: there is no "low-stakes auto-proceed" path when doctrine writes are pending. The user's judgment is the gate on what enters the decision log.
+
+A change additionally always gates if any of the following apply:
+
+- Touches authentication, credentials, secrets, tokens, signing, or encryption
+- Changes data model, schema, storage format, or existing on-disk / database layout
+- Adds, removes, or renames public surface (CLI commands, public functions, MCP tools, API endpoints, env vars, config keys)
+- Changes the contract between `nauro` and `nauro-core`, or anything `mcp-server` consumes from `nauro-core`
+- Adds, removes, or major-version bumps a dependency
+- Records a Nauro decision with reversibility `hard` or `moderate`
+- Surfaces 2-3 defensible alternatives where the choice is genuinely architectural
+
+**When gating:** surface the plan, surface alternatives as alternatives, wait for explicit user approval. Do not proceed without it. Auto-mode and standing "keep moving" directives do not override this gate — it exists precisely for the cases where the user wants their judgment in.
+
+**When auto-proceeding (no doctrine writes, no high-stakes triggers):** post a one-paragraph summary ("Planner proposes: `<X>`. Auto-proceeding to executor — no doctrine writes, no high-stakes triggers.") and continue. The user can interrupt at any time; if the classification feels wrong, they redirect and the gate fires.
+
+### 3. Execute
+
+Invoke the `@nauro-executor` subagent with the approved plan. Include any confirmed decision number from step 1 in the prompt. The executor implements the plan, commits locally, and does not push (per its contract). Any architectural choice the executor makes that the plan did not pre-record gets filed via `propose_decision` at the moment the choice lands in code — not deferred to the end of the chain.
+
+### 4. Local review (no user pause)
+
+Immediately after the executor returns, invoke the `@nauro-reviewer` subagent in Mode A on the local diff and the drafted PR description. Do not surface "ready to push" to the user before the reviewer has audited.
+
+### 5. Iteration on block
+
+If the reviewer returns BLOCK, hand the hard-rule failures back to the `@nauro-executor` for fix — scoped strictly to what was flagged, no scope expansion. Then re-invoke `@nauro-reviewer`. Cap at 2 fix iterations. If still blocked after 2, surface both verdicts and the unresolved findings to the user.
+
+### 6. Doctrine pass
+
+When the reviewer returns APPROVE or APPROVE WITH NITS, invoke `@nauro-tech-lead` in Mode C on the same local diff. The tech-lead reads decisions, scans the diff for architectural choices, and returns GREEN / AMBER / RED with any drafted supersede or update confirm_ids.
+
+- **GREEN** — proceed to GATE.
+- **AMBER** — surface the constraints to the user alongside the push gate; user decides whether to address before push or document as a follow-up.
+- **RED** — pause. Either redirect the executor (fix the drift, then re-run reviewer + tech-lead) or confirm the drafted supersede first. Do not push past a RED tech-lead verdict without an explicit human override on the cited decision.
+
+The reviewer's bug-finding pass and the tech-lead's doctrine pass are deliberately separate concerns — the reviewer can return APPROVE on a clean diff that the tech-lead later flags for drift.
+
+### 7. GATE — push confirmation (user)
+
+When the reviewer returns APPROVE / APPROVE WITH NITS and the tech-lead returns GREEN (or AMBER with surfaced constraints), surface:
+
+- The drafted PR description (full text)
+- A one-paragraph diff summary
+- The reviewer's verdict and any nits
+- The tech-lead's verdict and any AMBER constraints
+- Any Nauro decisions filed during the chain (numbers + one-line rationale)
+- "Push and open PR?"
+
+Wait for explicit approval.
+
+### 8. Push
+
+On approval, push the branch and open the PR with the drafted description as the body (`gh pr create --body "..."`). Decisions filed during the chain go in the PR's Approach section by paraphrase, not by raw decision number — the public-repo convention is to describe the doctrine move ("the bundled-subagents pattern"), not cite internal D-numbers.
+
+## Rules
+
+- Push and `gh pr create` happen only with explicit user approval at GATE 7.
+- `confirm_decision` happens only with explicit user approval — the planner / executor / tech-lead draft and `propose_decision`, never confirm. Parallel `propose_decision` is safe; parallel `confirm_decision` is not — confirm sequentially.
+- If anything fails or surprises mid-chain (a tool errors, tests fail unexpectedly, a verdict is incoherent), stop and surface to the user rather than recovering silently.
+- The chain is doctrine-aware end-to-end: every architectural choice flows through `check_decision` (at planning), `propose_decision` (when the choice lands), and `confirm_decision` (under user control). Skipping any of those silently is a chain failure, not a shortcut.

--- a/.claude/skills/nauro-ship-task/SKILL.md
+++ b/.claude/skills/nauro-ship-task/SKILL.md
@@ -7,9 +7,7 @@ description: Run the full planner -> executor -> reviewer -> tech-lead -> user-c
 
 Orchestrate a non-trivial code change end-to-end using Nauro's bundled `@nauro-planner`, `@nauro-executor`, `@nauro-reviewer`, and `@nauro-tech-lead` subagents, with Nauro doctrine gates at every architectural choice.
 
-Task: $ARGUMENTS
-
-If $ARGUMENTS is empty, ask the user for a one-paragraph task description and wait for it before proceeding.
+Take the user's task description from the prompt that invoked this skill. If they did not include one, ask for a one-paragraph description and wait for it before proceeding.
 
 ## Prerequisites
 

--- a/.cursor/rules/nauro-ship-task.mdc
+++ b/.cursor/rules/nauro-ship-task.mdc
@@ -7,9 +7,7 @@ alwaysApply: false
 
 Orchestrate a non-trivial code change end-to-end using Nauro's bundled `@nauro-planner`, `@nauro-executor`, `@nauro-reviewer`, and `@nauro-tech-lead` subagents, with Nauro doctrine gates at every architectural choice.
 
-Task: $ARGUMENTS
-
-If $ARGUMENTS is empty, ask the user for a one-paragraph task description and wait for it before proceeding.
+Take the user's task description from the prompt that invoked this skill. If they did not include one, ask for a one-paragraph description and wait for it before proceeding.
 
 ## Prerequisites
 

--- a/.cursor/rules/nauro-ship-task.mdc
+++ b/.cursor/rules/nauro-ship-task.mdc
@@ -1,0 +1,94 @@
+---
+description: Run the full planner -> executor -> reviewer -> tech-lead -> user-confirm -> push chain for a non-trivial code change against Nauro's bundled @nauro-* subagents. Gates on the user whenever the planner or executor will file a Nauro decision; runs @nauro-tech-lead Mode C between reviewer-APPROVE and the push gate to catch doctrine drift the reviewer missed. Invoke explicitly with /nauro-ship-task <description>. Requires `nauro adopt --with-subagents` to have run.
+alwaysApply: false
+---
+
+# Nauro ship task skill
+
+Orchestrate a non-trivial code change end-to-end using Nauro's bundled `@nauro-planner`, `@nauro-executor`, `@nauro-reviewer`, and `@nauro-tech-lead` subagents, with Nauro doctrine gates at every architectural choice.
+
+Task: $ARGUMENTS
+
+If $ARGUMENTS is empty, ask the user for a one-paragraph task description and wait for it before proceeding.
+
+## Prerequisites
+
+This skill invokes the bundled `@nauro-*` subagents by name. They install via `nauro adopt --with-subagents` (or `nauro setup all --with-subagents`). If they are missing, the chain cannot run — surface that to the user and stop. The personal-subagent path (`@planner` / `@executor` / `@reviewer` without the `nauro-` prefix) is not a substitute: the bundled subagents call Nauro's MCP tools by design, which is what makes the doctrine gates load-bearing.
+
+## Execute the chain without waiting for the user to prompt each step
+
+Pause only at the two explicit gates marked GATE below.
+
+## Pre-step — Doctrine triage before the planner spins up
+
+Before invoking `@nauro-planner`, the parent session confirms the planner will run `check_decision` first. The planner's contract already requires this, but the chain enforces it explicitly: if the planner returns a RED verdict (proposal directly contradicts an active decision) and drafts a supersede, the chain pauses before the executor sees anything. The user gates the supersede via `confirm_decision`; only on confirmation does the executor see the approved plan. This is the doctrine equivalent of GATE 1 firing early — a RED that the user does not resolve never reaches code.
+
+### 1. Plan
+
+Invoke the `@nauro-planner` subagent with the task description. The planner runs `check_decision` against the proposed approach, classifies as GREEN / AMBER / RED, reads related decision bodies via `get_decision`, investigates the code, and returns a plan in the PR-template shape (Why / Approach / What changes / What's deferred / Test plan), plus the verdict line and any decision number it drafted.
+
+If the planner returns RED with a supersede draft, the chain pauses here. Surface the draft to the user. Only on `confirm_decision` (or an explicit "override RED on the cited decision, proceed") does the chain continue to the executor.
+
+### 2. GATE — plan approval (always when `propose_decision` is in play)
+
+The Nauro chain gates the plan whenever the planner indicates it will file a decision via `propose_decision` for any architectural choice, or whenever the plan records a supersede / update draft. This is stricter than the personal `/ship-task` skill: there is no "low-stakes auto-proceed" path when doctrine writes are pending. The user's judgment is the gate on what enters the decision log.
+
+A change additionally always gates if any of the following apply:
+
+- Touches authentication, credentials, secrets, tokens, signing, or encryption
+- Changes data model, schema, storage format, or existing on-disk / database layout
+- Adds, removes, or renames public surface (CLI commands, public functions, MCP tools, API endpoints, env vars, config keys)
+- Changes the contract between `nauro` and `nauro-core`, or anything `mcp-server` consumes from `nauro-core`
+- Adds, removes, or major-version bumps a dependency
+- Records a Nauro decision with reversibility `hard` or `moderate`
+- Surfaces 2-3 defensible alternatives where the choice is genuinely architectural
+
+**When gating:** surface the plan, surface alternatives as alternatives, wait for explicit user approval. Do not proceed without it. Auto-mode and standing "keep moving" directives do not override this gate — it exists precisely for the cases where the user wants their judgment in.
+
+**When auto-proceeding (no doctrine writes, no high-stakes triggers):** post a one-paragraph summary ("Planner proposes: `<X>`. Auto-proceeding to executor — no doctrine writes, no high-stakes triggers.") and continue. The user can interrupt at any time; if the classification feels wrong, they redirect and the gate fires.
+
+### 3. Execute
+
+Invoke the `@nauro-executor` subagent with the approved plan. Include any confirmed decision number from step 1 in the prompt. The executor implements the plan, commits locally, and does not push (per its contract). Any architectural choice the executor makes that the plan did not pre-record gets filed via `propose_decision` at the moment the choice lands in code — not deferred to the end of the chain.
+
+### 4. Local review (no user pause)
+
+Immediately after the executor returns, invoke the `@nauro-reviewer` subagent in Mode A on the local diff and the drafted PR description. Do not surface "ready to push" to the user before the reviewer has audited.
+
+### 5. Iteration on block
+
+If the reviewer returns BLOCK, hand the hard-rule failures back to the `@nauro-executor` for fix — scoped strictly to what was flagged, no scope expansion. Then re-invoke `@nauro-reviewer`. Cap at 2 fix iterations. If still blocked after 2, surface both verdicts and the unresolved findings to the user.
+
+### 6. Doctrine pass
+
+When the reviewer returns APPROVE or APPROVE WITH NITS, invoke `@nauro-tech-lead` in Mode C on the same local diff. The tech-lead reads decisions, scans the diff for architectural choices, and returns GREEN / AMBER / RED with any drafted supersede or update confirm_ids.
+
+- **GREEN** — proceed to GATE.
+- **AMBER** — surface the constraints to the user alongside the push gate; user decides whether to address before push or document as a follow-up.
+- **RED** — pause. Either redirect the executor (fix the drift, then re-run reviewer + tech-lead) or confirm the drafted supersede first. Do not push past a RED tech-lead verdict without an explicit human override on the cited decision.
+
+The reviewer's bug-finding pass and the tech-lead's doctrine pass are deliberately separate concerns — the reviewer can return APPROVE on a clean diff that the tech-lead later flags for drift.
+
+### 7. GATE — push confirmation (user)
+
+When the reviewer returns APPROVE / APPROVE WITH NITS and the tech-lead returns GREEN (or AMBER with surfaced constraints), surface:
+
+- The drafted PR description (full text)
+- A one-paragraph diff summary
+- The reviewer's verdict and any nits
+- The tech-lead's verdict and any AMBER constraints
+- Any Nauro decisions filed during the chain (numbers + one-line rationale)
+- "Push and open PR?"
+
+Wait for explicit approval.
+
+### 8. Push
+
+On approval, push the branch and open the PR with the drafted description as the body (`gh pr create --body "..."`). Decisions filed during the chain go in the PR's Approach section by paraphrase, not by raw decision number — the public-repo convention is to describe the doctrine move ("the bundled-subagents pattern"), not cite internal D-numbers.
+
+## Rules
+
+- Push and `gh pr create` happen only with explicit user approval at GATE 7.
+- `confirm_decision` happens only with explicit user approval — the planner / executor / tech-lead draft and `propose_decision`, never confirm. Parallel `propose_decision` is safe; parallel `confirm_decision` is not — confirm sequentially.
+- If anything fails or surprises mid-chain (a tool errors, tests fail unexpectedly, a verdict is incoherent), stop and surface to the user rather than recovering silently.
+- The chain is doctrine-aware end-to-end: every architectural choice flows through `check_decision` (at planning), `propose_decision` (when the choice lands), and `confirm_decision` (under user control). Skipping any of those silently is a chain failure, not a shortcut.

--- a/packages/nauro/src/nauro/cli/commands/adopt.py
+++ b/packages/nauro/src/nauro/cli/commands/adopt.py
@@ -29,7 +29,11 @@ from pathlib import Path
 
 import typer
 
-from nauro.cli.commands.setup import _find_nauro_command, setup_all_surfaces
+from nauro.cli.commands.setup import (
+    SHIP_TASK_NEEDS_SUBAGENTS_NOTICE,
+    _find_nauro_command,
+    setup_all_surfaces,
+)
 from nauro.constants import REGISTRY_SCHEMA_VERSION_V2, REPO_CONFIG_MODE_LOCAL
 from nauro.skills import load_adopt_body
 from nauro.store.registry import find_projects_by_name_v2, register_project_v2
@@ -148,6 +152,15 @@ def adopt(
             "existing files are preserved."
         ),
     ),
+    with_skills: bool = typer.Option(
+        False,
+        "--with-skills",
+        help=(
+            "Install Nauro's bundled opt-in skills (today: /nauro-ship-task) "
+            "alongside the always-installed /nauro-adopt skill. Independent "
+            "of --with-subagents."
+        ),
+    ),
 ) -> None:
     """Adopt an existing repo into Nauro: register, wire MCP, install skills."""
     if print_prompt:
@@ -157,11 +170,12 @@ def adopt(
             or no_setup_and_skills
             or with_subagents
             or force_overwrite
+            or with_skills
         ):
             typer.echo(
                 "Error: --print-prompt is mutually exclusive with --name, "
-                "--repo, --no-setup-and-skills, --with-subagents, and "
-                "--force-overwrite.",
+                "--repo, --no-setup-and-skills, --with-subagents, "
+                "--force-overwrite, and --with-skills.",
                 err=True,
             )
             raise typer.Exit(code=1)
@@ -227,8 +241,12 @@ def adopt(
             remove=False,
             with_subagents=with_subagents,
             force_overwrite=force_overwrite,
+            with_skills=with_skills,
         ):
             typer.echo(line)
+
+        if with_skills and not with_subagents:
+            typer.echo(f"\n{SHIP_TASK_NEEDS_SUBAGENTS_NOTICE}")
 
         warning = _smoke_test_wired_binary(_find_nauro_command())
         if warning:

--- a/packages/nauro/src/nauro/cli/commands/setup.py
+++ b/packages/nauro/src/nauro/cli/commands/setup.py
@@ -370,8 +370,15 @@ def codex(
 # the user's surface directories. Claude Code and Codex skills are user-global;
 # Cursor skills ship per-project (Cursor's "User Rules" live in the IDE
 # Settings UI, not a file path).
+#
+# ``SKILL_NAMES`` is the always-installed set — the core onboarding skill.
+# ``OPT_IN_SKILL_NAMES`` is materialized only when the caller passes
+# ``with_skills=True``; today that is just ``nauro-ship-task``, which
+# references the bundled ``@nauro-*`` subagents and is opt-in for the same
+# reason those subagents are.
 
 SKILL_NAMES: tuple[str, ...] = ("nauro-adopt",)
+OPT_IN_SKILL_NAMES: tuple[str, ...] = ("nauro-ship-task",)
 
 
 def _claude_skill_dir() -> Path:
@@ -412,22 +419,39 @@ def _remove_skill_file(target: Path, *, stop_above: Path) -> str:
     return f"  removed {target}"
 
 
-def materialize_skills_claude_code(*, remove: bool, clear_user_scope: bool = True) -> list[str]:
+def _resolved_skill_names(with_skills: bool) -> tuple[str, ...]:
+    """Return the union of always-installed skills and opt-in skills.
+
+    ``with_skills=False`` (the default for callers that pre-date the flag)
+    installs only the core onboarding skills in ``SKILL_NAMES``.
+    ``with_skills=True`` extends with ``OPT_IN_SKILL_NAMES`` so future opt-in
+    skills can ride alongside ``nauro-ship-task`` under the same flag.
+    """
+    return SKILL_NAMES + OPT_IN_SKILL_NAMES if with_skills else SKILL_NAMES
+
+
+def materialize_skills_claude_code(
+    *,
+    remove: bool,
+    clear_user_scope: bool = True,
+    with_skills: bool = False,
+) -> list[str]:
     """Install or remove the Nauro skill(s) under ``~/.claude/skills/``.
 
     ``clear_user_scope`` gates the remove path: when False, the skill files
     are preserved because other registered nauro projects still depend on
     them. Defaults to True so direct unit callers and the add path retain
-    their previous behavior.
+    their previous behavior. ``with_skills`` extends the install/remove set
+    with ``OPT_IN_SKILL_NAMES`` (today: ``nauro-ship-task``).
     """
     from nauro.skills import render_skill
 
     base = _claude_skill_dir()
     if remove and not clear_user_scope:
-        return ["  preserved ~/.claude/skills/nauro-adopt (other nauro projects still registered)"]
+        return ["  preserved ~/.claude/skills/nauro-* (other nauro projects still registered)"]
 
     results: list[str] = []
-    for name in SKILL_NAMES:
+    for name in _resolved_skill_names(with_skills):
         target = base / name / "SKILL.md"
         if remove:
             results.append(_remove_skill_file(target, stop_above=base))
@@ -436,22 +460,28 @@ def materialize_skills_claude_code(*, remove: bool, clear_user_scope: bool = Tru
     return results
 
 
-def materialize_skills_codex(*, remove: bool, clear_user_scope: bool = True) -> list[str]:
+def materialize_skills_codex(
+    *,
+    remove: bool,
+    clear_user_scope: bool = True,
+    with_skills: bool = False,
+) -> list[str]:
     """Install or remove the Nauro skill(s) under ``~/.agents/skills/``.
 
     ``clear_user_scope`` gates the remove path: when False, the skill files
     are preserved because other registered nauro projects still depend on
     them. Defaults to True so direct unit callers and the add path retain
-    their previous behavior.
+    their previous behavior. ``with_skills`` extends the install/remove set
+    with ``OPT_IN_SKILL_NAMES`` (today: ``nauro-ship-task``).
     """
     from nauro.skills import render_skill
 
     base = _codex_skill_dir()
     if remove and not clear_user_scope:
-        return ["  preserved ~/.agents/skills/nauro-adopt (other nauro projects still registered)"]
+        return ["  preserved ~/.agents/skills/nauro-* (other nauro projects still registered)"]
 
     results: list[str] = []
-    for name in SKILL_NAMES:
+    for name in _resolved_skill_names(with_skills):
         target = base / name / "SKILL.md"
         if remove:
             results.append(_remove_skill_file(target, stop_above=base))
@@ -460,13 +490,21 @@ def materialize_skills_codex(*, remove: bool, clear_user_scope: bool = True) -> 
     return results
 
 
-def materialize_skills_cursor_for_repo(repo: Path, *, remove: bool) -> list[str]:
-    """Install or remove Cursor rules under ``<repo>/.cursor/rules/``."""
+def materialize_skills_cursor_for_repo(
+    repo: Path,
+    *,
+    remove: bool,
+    with_skills: bool = False,
+) -> list[str]:
+    """Install or remove Cursor rules under ``<repo>/.cursor/rules/``.
+
+    ``with_skills`` extends the install/remove set with ``OPT_IN_SKILL_NAMES``.
+    """
     from nauro.skills import render_skill
 
     base = repo / ".cursor" / "rules"
     results: list[str] = []
-    for name in SKILL_NAMES:
+    for name in _resolved_skill_names(with_skills):
         target = base / f"{name}.mdc"
         if remove:
             results.append(_remove_skill_file(target, stop_above=base))
@@ -574,6 +612,7 @@ def setup_all_surfaces(
     current_project_key: str | None = None,
     with_subagents: bool = False,
     force_overwrite: bool = False,
+    with_skills: bool = False,
 ) -> list[str]:
     """Wire MCP and materialize skills across Claude Code, Cursor, Codex.
 
@@ -592,6 +631,13 @@ def setup_all_surfaces(
     their previous behavior. ``force_overwrite`` is only meaningful when
     ``with_subagents`` is True and ``remove`` is False — it replaces
     locally-modified bundled files instead of preserving them.
+
+    ``with_skills`` opts into installing the bundled opt-in skills (today
+    just ``nauro-ship-task``). Independent of ``with_subagents`` so users
+    can adopt skills and subagents on separate cadences, though
+    ``nauro-ship-task`` references the bundled ``@nauro-*`` subagents in
+    its body — caller surfaces ``with_skills`` without ``with_subagents``
+    should warn the user.
     """
     clear_user_scope = _user_scope_safe_to_clear(current_project_key) if remove else True
 
@@ -608,7 +654,11 @@ def setup_all_surfaces(
             lines.append(f"Claude Code MCP ({repo}): error — {exc}")
     try:
         lines.extend(
-            materialize_skills_claude_code(remove=remove, clear_user_scope=clear_user_scope)
+            materialize_skills_claude_code(
+                remove=remove,
+                clear_user_scope=clear_user_scope,
+                with_skills=with_skills,
+            )
         )
     except Exception as exc:
         lines.append(f"Claude Code skills: error — {exc}")
@@ -635,7 +685,9 @@ def setup_all_surfaces(
         except Exception as exc:
             lines.append(f"Cursor MCP ({repo}): error — {exc}")
         try:
-            lines.extend(materialize_skills_cursor_for_repo(repo, remove=remove))
+            lines.extend(
+                materialize_skills_cursor_for_repo(repo, remove=remove, with_skills=with_skills)
+            )
         except Exception as exc:
             lines.append(f"Cursor skills ({repo}): error — {exc}")
 
@@ -645,11 +697,23 @@ def setup_all_surfaces(
     except Exception as exc:
         lines.append(f"Codex MCP: error — {exc}")
     try:
-        lines.extend(materialize_skills_codex(remove=remove, clear_user_scope=clear_user_scope))
+        lines.extend(
+            materialize_skills_codex(
+                remove=remove,
+                clear_user_scope=clear_user_scope,
+                with_skills=with_skills,
+            )
+        )
     except Exception as exc:
         lines.append(f"Codex skills: error — {exc}")
 
     return lines
+
+
+SHIP_TASK_NEEDS_SUBAGENTS_NOTICE = (
+    "nauro-ship-task references the bundled @nauro-* subagents; pass "
+    "`--with-subagents` to install them too."
+)
 
 
 @setup_app.command(name="all")
@@ -679,6 +743,15 @@ def all_(
             "existing files are preserved."
         ),
     ),
+    with_skills: bool = typer.Option(
+        False,
+        "--with-skills",
+        help=(
+            "Install Nauro's bundled opt-in skills (today: /nauro-ship-task) "
+            "alongside the always-installed /nauro-adopt skill. Independent "
+            "of --with-subagents."
+        ),
+    ),
 ) -> None:
     """Configure Claude Code, Cursor, and Codex CLI in one call."""
     project_name, _store_path = resolve_target_project(project)
@@ -704,8 +777,12 @@ def all_(
         current_project_key=project_key,
         with_subagents=with_subagents,
         force_overwrite=force_overwrite,
+        with_skills=with_skills,
     ):
         typer.echo(line)
+
+    if not remove and with_skills and not with_subagents:
+        typer.echo(f"\n{SHIP_TASK_NEEDS_SUBAGENTS_NOTICE}")
 
     if not remove:
         typer.echo(f"\n{CHECK_HINT_LINE}")

--- a/packages/nauro/src/nauro/skills/__init__.py
+++ b/packages/nauro/src/nauro/skills/__init__.py
@@ -22,7 +22,7 @@ from typing import Literal
 from nauro_core.protocol import substitute_protocol_fragments
 
 Surface = Literal["claude_code", "cursor", "codex"]
-SkillName = Literal["nauro-adopt"]
+SkillName = Literal["nauro-adopt", "nauro-ship-task"]
 
 SKILL_DESCRIPTIONS: dict[str, str] = {
     "nauro-adopt": (
@@ -33,6 +33,15 @@ SKILL_DESCRIPTIONS: dict[str, str] = {
         "evidence, then surfaces targeted probes that turn evidence into "
         "rationale. On chat surfaces, operates on pasted content against an "
         "already-adopted project."
+    ),
+    "nauro-ship-task": (
+        "Run the full planner -> executor -> reviewer -> tech-lead -> "
+        "user-confirm -> push chain for a non-trivial code change against "
+        "Nauro's bundled @nauro-* subagents. Gates on the user whenever the "
+        "planner or executor will file a Nauro decision; runs @nauro-tech-lead "
+        "Mode C between reviewer-APPROVE and the push gate to catch doctrine "
+        "drift the reviewer missed. Invoke explicitly with /nauro-ship-task "
+        "<description>. Requires `nauro adopt --with-subagents` to have run."
     ),
 }
 
@@ -62,9 +71,21 @@ def load_adopt_body() -> str:
     return substitute_protocol_fragments(_strip_template_header(raw))
 
 
+def load_ship_task_body() -> str:
+    """Return the canonical ``/nauro-ship-task`` skill body (no frontmatter).
+
+    The body has no protocol-fragment tokens today, but goes through the same
+    substitution pass so future canonical claims can be added at the source.
+    """
+    raw = resources.files(__package__).joinpath("ship_task_body.md").read_text(encoding="utf-8")
+    return substitute_protocol_fragments(_strip_template_header(raw))
+
+
 def _load_body(skill_name: str) -> str:
     if skill_name == "nauro-adopt":
         return load_adopt_body()
+    if skill_name == "nauro-ship-task":
+        return load_ship_task_body()
     raise ValueError(f"unknown skill: {skill_name!r}")
 
 
@@ -95,5 +116,6 @@ __all__ = [
     "SkillName",
     "Surface",
     "load_adopt_body",
+    "load_ship_task_body",
     "render_skill",
 ]

--- a/packages/nauro/src/nauro/skills/ship_task_body.md
+++ b/packages/nauro/src/nauro/skills/ship_task_body.md
@@ -9,9 +9,7 @@
 
 Orchestrate a non-trivial code change end-to-end using Nauro's bundled `@nauro-planner`, `@nauro-executor`, `@nauro-reviewer`, and `@nauro-tech-lead` subagents, with Nauro doctrine gates at every architectural choice.
 
-Task: $ARGUMENTS
-
-If $ARGUMENTS is empty, ask the user for a one-paragraph task description and wait for it before proceeding.
+Take the user's task description from the prompt that invoked this skill. If they did not include one, ask for a one-paragraph description and wait for it before proceeding.
 
 ## Prerequisites
 

--- a/packages/nauro/src/nauro/skills/ship_task_body.md
+++ b/packages/nauro/src/nauro/skills/ship_task_body.md
@@ -1,0 +1,96 @@
+<!-- Source template. The dogfood files under .claude/, .cursor/, .agents/
+     are the rendered surface. Surface frontmatter is added by render_skill().
+     This body has no protocol-fragment tokens — the chain it describes calls
+     check_decision / propose_decision / confirm_decision by name, but the
+     canonical claims in nauro_core.protocol live on the /nauro-adopt and
+     MCP-instructions surfaces, not here. -->
+
+# Nauro ship task skill
+
+Orchestrate a non-trivial code change end-to-end using Nauro's bundled `@nauro-planner`, `@nauro-executor`, `@nauro-reviewer`, and `@nauro-tech-lead` subagents, with Nauro doctrine gates at every architectural choice.
+
+Task: $ARGUMENTS
+
+If $ARGUMENTS is empty, ask the user for a one-paragraph task description and wait for it before proceeding.
+
+## Prerequisites
+
+This skill invokes the bundled `@nauro-*` subagents by name. They install via `nauro adopt --with-subagents` (or `nauro setup all --with-subagents`). If they are missing, the chain cannot run — surface that to the user and stop. The personal-subagent path (`@planner` / `@executor` / `@reviewer` without the `nauro-` prefix) is not a substitute: the bundled subagents call Nauro's MCP tools by design, which is what makes the doctrine gates load-bearing.
+
+## Execute the chain without waiting for the user to prompt each step
+
+Pause only at the two explicit gates marked GATE below.
+
+## Pre-step — Doctrine triage before the planner spins up
+
+Before invoking `@nauro-planner`, the parent session confirms the planner will run `check_decision` first. The planner's contract already requires this, but the chain enforces it explicitly: if the planner returns a RED verdict (proposal directly contradicts an active decision) and drafts a supersede, the chain pauses before the executor sees anything. The user gates the supersede via `confirm_decision`; only on confirmation does the executor see the approved plan. This is the doctrine equivalent of GATE 1 firing early — a RED that the user does not resolve never reaches code.
+
+### 1. Plan
+
+Invoke the `@nauro-planner` subagent with the task description. The planner runs `check_decision` against the proposed approach, classifies as GREEN / AMBER / RED, reads related decision bodies via `get_decision`, investigates the code, and returns a plan in the PR-template shape (Why / Approach / What changes / What's deferred / Test plan), plus the verdict line and any decision number it drafted.
+
+If the planner returns RED with a supersede draft, the chain pauses here. Surface the draft to the user. Only on `confirm_decision` (or an explicit "override RED on the cited decision, proceed") does the chain continue to the executor.
+
+### 2. GATE — plan approval (always when `propose_decision` is in play)
+
+The Nauro chain gates the plan whenever the planner indicates it will file a decision via `propose_decision` for any architectural choice, or whenever the plan records a supersede / update draft. This is stricter than the personal `/ship-task` skill: there is no "low-stakes auto-proceed" path when doctrine writes are pending. The user's judgment is the gate on what enters the decision log.
+
+A change additionally always gates if any of the following apply:
+
+- Touches authentication, credentials, secrets, tokens, signing, or encryption
+- Changes data model, schema, storage format, or existing on-disk / database layout
+- Adds, removes, or renames public surface (CLI commands, public functions, MCP tools, API endpoints, env vars, config keys)
+- Changes the contract between `nauro` and `nauro-core`, or anything `mcp-server` consumes from `nauro-core`
+- Adds, removes, or major-version bumps a dependency
+- Records a Nauro decision with reversibility `hard` or `moderate`
+- Surfaces 2-3 defensible alternatives where the choice is genuinely architectural
+
+**When gating:** surface the plan, surface alternatives as alternatives, wait for explicit user approval. Do not proceed without it. Auto-mode and standing "keep moving" directives do not override this gate — it exists precisely for the cases where the user wants their judgment in.
+
+**When auto-proceeding (no doctrine writes, no high-stakes triggers):** post a one-paragraph summary ("Planner proposes: `<X>`. Auto-proceeding to executor — no doctrine writes, no high-stakes triggers.") and continue. The user can interrupt at any time; if the classification feels wrong, they redirect and the gate fires.
+
+### 3. Execute
+
+Invoke the `@nauro-executor` subagent with the approved plan. Include any confirmed decision number from step 1 in the prompt. The executor implements the plan, commits locally, and does not push (per its contract). Any architectural choice the executor makes that the plan did not pre-record gets filed via `propose_decision` at the moment the choice lands in code — not deferred to the end of the chain.
+
+### 4. Local review (no user pause)
+
+Immediately after the executor returns, invoke the `@nauro-reviewer` subagent in Mode A on the local diff and the drafted PR description. Do not surface "ready to push" to the user before the reviewer has audited.
+
+### 5. Iteration on block
+
+If the reviewer returns BLOCK, hand the hard-rule failures back to the `@nauro-executor` for fix — scoped strictly to what was flagged, no scope expansion. Then re-invoke `@nauro-reviewer`. Cap at 2 fix iterations. If still blocked after 2, surface both verdicts and the unresolved findings to the user.
+
+### 6. Doctrine pass
+
+When the reviewer returns APPROVE or APPROVE WITH NITS, invoke `@nauro-tech-lead` in Mode C on the same local diff. The tech-lead reads decisions, scans the diff for architectural choices, and returns GREEN / AMBER / RED with any drafted supersede or update confirm_ids.
+
+- **GREEN** — proceed to GATE.
+- **AMBER** — surface the constraints to the user alongside the push gate; user decides whether to address before push or document as a follow-up.
+- **RED** — pause. Either redirect the executor (fix the drift, then re-run reviewer + tech-lead) or confirm the drafted supersede first. Do not push past a RED tech-lead verdict without an explicit human override on the cited decision.
+
+The reviewer's bug-finding pass and the tech-lead's doctrine pass are deliberately separate concerns — the reviewer can return APPROVE on a clean diff that the tech-lead later flags for drift.
+
+### 7. GATE — push confirmation (user)
+
+When the reviewer returns APPROVE / APPROVE WITH NITS and the tech-lead returns GREEN (or AMBER with surfaced constraints), surface:
+
+- The drafted PR description (full text)
+- A one-paragraph diff summary
+- The reviewer's verdict and any nits
+- The tech-lead's verdict and any AMBER constraints
+- Any Nauro decisions filed during the chain (numbers + one-line rationale)
+- "Push and open PR?"
+
+Wait for explicit approval.
+
+### 8. Push
+
+On approval, push the branch and open the PR with the drafted description as the body (`gh pr create --body "..."`). Decisions filed during the chain go in the PR's Approach section by paraphrase, not by raw decision number — the public-repo convention is to describe the doctrine move ("the bundled-subagents pattern"), not cite internal D-numbers.
+
+## Rules
+
+- Push and `gh pr create` happen only with explicit user approval at GATE 7.
+- `confirm_decision` happens only with explicit user approval — the planner / executor / tech-lead draft and `propose_decision`, never confirm. Parallel `propose_decision` is safe; parallel `confirm_decision` is not — confirm sequentially.
+- If anything fails or surprises mid-chain (a tool errors, tests fail unexpectedly, a verdict is incoherent), stop and surface to the user rather than recovering silently.
+- The chain is doctrine-aware end-to-end: every architectural choice flows through `check_decision` (at planning), `propose_decision` (when the choice lands), and `confirm_decision` (under user control). Skipping any of those silently is a chain failure, not a shortcut.

--- a/packages/nauro/tests/test_adopt.py
+++ b/packages/nauro/tests/test_adopt.py
@@ -256,3 +256,98 @@ def test_adopt_print_prompt_conflicts_with_with_subagents(tmp_path: Path, monkey
     result = runner.invoke(app, ["adopt", "--print-prompt", "--with-subagents"])
     assert result.exit_code == 1
     assert "mutually exclusive" in result.output
+
+
+# ─── --with-skills ──────────────────────────────────────────────────────────
+
+
+def _ship_task_paths(home: Path, repo: Path) -> tuple[Path, Path, Path]:
+    """Return the (claude, codex, cursor) target paths for the bundled
+    /nauro-ship-task skill in an isolated HOME."""
+    return (
+        home / ".claude" / "skills" / "nauro-ship-task" / "SKILL.md",
+        home / ".agents" / "skills" / "nauro-ship-task" / "SKILL.md",
+        repo / ".cursor" / "rules" / "nauro-ship-task.mdc",
+    )
+
+
+def test_adopt_default_does_not_install_ship_task_skill(tmp_path: Path, monkeypatch):
+    """Bare ``nauro adopt`` (no ``--with-skills``) leaves nauro-ship-task uninstalled."""
+    repo = _adopt_env(monkeypatch, tmp_path)
+
+    result = runner.invoke(app, ["adopt", "--name", "alpha"])
+    assert result.exit_code == 0, result.output
+
+    claude, codex, cursor = _ship_task_paths(tmp_path, repo)
+    assert not claude.exists()
+    assert not codex.exists()
+    assert not cursor.exists()
+    # And the always-installed /nauro-adopt skill is still present.
+    assert (tmp_path / ".claude" / "skills" / "nauro-adopt" / "SKILL.md").is_file()
+
+
+def test_adopt_with_skills_installs_ship_task_across_surfaces(tmp_path: Path, monkeypatch):
+    """``--with-skills`` materializes nauro-ship-task byte-equal to render_skill()."""
+    from nauro.skills import render_skill
+
+    repo = _adopt_env(monkeypatch, tmp_path)
+
+    result = runner.invoke(app, ["adopt", "--name", "alpha", "--with-skills"])
+    assert result.exit_code == 0, result.output
+
+    claude, codex, cursor = _ship_task_paths(tmp_path, repo)
+    assert claude.is_file()
+    assert codex.is_file()
+    assert cursor.is_file()
+    assert claude.read_text(encoding="utf-8") == render_skill("claude_code", "nauro-ship-task")
+    assert codex.read_text(encoding="utf-8") == render_skill("codex", "nauro-ship-task")
+    assert cursor.read_text(encoding="utf-8") == render_skill("cursor", "nauro-ship-task")
+
+
+def test_adopt_with_skills_without_subagents_emits_notice(tmp_path: Path, monkeypatch):
+    """The skill body references @nauro-* subagents; the install path warns."""
+    _adopt_env(monkeypatch, tmp_path)
+
+    result = runner.invoke(app, ["adopt", "--name", "alpha", "--with-skills"])
+    assert result.exit_code == 0, result.output
+    assert "nauro-ship-task references the bundled @nauro-* subagents" in result.output
+
+
+def test_adopt_with_skills_and_subagents_does_not_emit_notice(tmp_path: Path, monkeypatch):
+    """When both flags are passed, the notice is suppressed — prerequisites met."""
+    _adopt_env(monkeypatch, tmp_path)
+
+    result = runner.invoke(app, ["adopt", "--name", "alpha", "--with-skills", "--with-subagents"])
+    assert result.exit_code == 0, result.output
+    assert "nauro-ship-task references the bundled @nauro-* subagents" not in result.output
+
+
+def test_adopt_remove_clears_ship_task_when_last_project(tmp_path: Path, monkeypatch):
+    """``setup all --remove`` after a ``--with-skills`` install removes the new files too.
+
+    There is no ``nauro adopt --remove`` flag; teardown goes through ``nauro
+    setup all --remove``, which shares ``materialize_skills_*`` with adopt's
+    install path. Verify the round-trip on the new bundled skill.
+    """
+    repo = _adopt_env(monkeypatch, tmp_path)
+
+    install = runner.invoke(app, ["adopt", "--name", "alpha", "--with-skills"])
+    assert install.exit_code == 0, install.output
+    claude, codex, cursor = _ship_task_paths(tmp_path, repo)
+    assert claude.is_file()
+
+    remove = runner.invoke(app, ["setup", "all", "--remove", "--with-skills"])
+    assert remove.exit_code == 0, remove.output
+
+    assert not claude.exists()
+    assert not codex.exists()
+    assert not cursor.exists()
+
+
+def test_adopt_print_prompt_conflicts_with_with_skills(tmp_path: Path, monkeypatch):
+    """``--print-prompt`` plus ``--with-skills`` is rejected as mutually exclusive."""
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["adopt", "--print-prompt", "--with-skills"])
+    assert result.exit_code == 1
+    assert "mutually exclusive" in result.output

--- a/packages/nauro/tests/test_protocol_drift.py
+++ b/packages/nauro/tests/test_protocol_drift.py
@@ -125,7 +125,11 @@ def test_adopt_body_mentions_operation_anchor(anchor: str) -> None:
 
 @pytest.mark.parametrize(
     "surface,skill",
-    [(s, k) for s in ("claude_code", "cursor", "codex") for k in ("nauro-adopt",)],
+    [
+        (s, k)
+        for s in ("claude_code", "cursor", "codex")
+        for k in ("nauro-adopt", "nauro-ship-task")
+    ],
 )
 def test_rendered_skill_has_no_protocol_tokens(surface: str, skill: str) -> None:
     rendered = render_skill(surface, skill)
@@ -149,7 +153,7 @@ def test_docs_adopt_prompt_has_no_protocol_tokens() -> None:
 # Source templates: only known tokens allowed (catches typos at the source)
 # ─────────────────────────────────────────────────────────────────────────────
 
-SOURCE_TEMPLATE_FILES = ("adopt_body.md",)
+SOURCE_TEMPLATE_FILES = ("adopt_body.md", "ship_task_body.md")
 
 
 @pytest.mark.parametrize("template_filename", SOURCE_TEMPLATE_FILES)
@@ -176,6 +180,9 @@ DISTRIBUTION_FILES = (
     ".claude/skills/nauro-adopt/SKILL.md",
     ".cursor/rules/nauro-adopt.mdc",
     ".agents/skills/nauro-adopt/SKILL.md",
+    ".claude/skills/nauro-ship-task/SKILL.md",
+    ".cursor/rules/nauro-ship-task.mdc",
+    ".agents/skills/nauro-ship-task/SKILL.md",
     "docs/adopt-prompt.md",
 )
 

--- a/packages/nauro/tests/test_setup_extended.py
+++ b/packages/nauro/tests/test_setup_extended.py
@@ -579,3 +579,106 @@ def test_setup_all_help_lists_with_subagents():
     output = _strip_ansi(result.output)
     assert "--with-subagents" in output
     assert "--force-overwrite" in output
+    assert "--with-skills" in output
+
+
+# ─── nauro setup all --with-skills ──────────────────────────────────────────
+
+
+def test_setup_all_default_does_not_install_ship_task(tmp_path: Path, monkeypatch):
+    """Off-by-default: ``setup all`` without ``--with-skills`` installs only /nauro-adopt."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    _, store_path = register_project_v2("myproj", [repo])
+    scaffold_project_store("myproj", store_path)
+    monkeypatch.chdir(repo)
+
+    result = runner.invoke(app, ["setup", "all"])
+    assert result.exit_code == 0, result.output
+
+    # nauro-adopt installed everywhere; nauro-ship-task absent everywhere.
+    assert (tmp_path / ".claude" / "skills" / "nauro-adopt" / "SKILL.md").is_file()
+    assert not (tmp_path / ".claude" / "skills" / "nauro-ship-task" / "SKILL.md").exists()
+    assert not (tmp_path / ".agents" / "skills" / "nauro-ship-task" / "SKILL.md").exists()
+    assert not (repo / ".cursor" / "rules" / "nauro-ship-task.mdc").exists()
+
+
+def test_setup_all_with_skills_installs_ship_task_everywhere(tmp_path: Path, monkeypatch):
+    """``--with-skills`` round-trips: install writes, ``--remove --with-skills`` clears."""
+    from nauro.skills import render_skill
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    _, store_path = register_project_v2("myproj", [repo])
+    scaffold_project_store("myproj", store_path)
+    monkeypatch.chdir(repo)
+
+    install = runner.invoke(app, ["setup", "all", "--with-skills"])
+    assert install.exit_code == 0, install.output
+
+    claude = tmp_path / ".claude" / "skills" / "nauro-ship-task" / "SKILL.md"
+    codex = tmp_path / ".agents" / "skills" / "nauro-ship-task" / "SKILL.md"
+    cursor = repo / ".cursor" / "rules" / "nauro-ship-task.mdc"
+    assert claude.read_text(encoding="utf-8") == render_skill("claude_code", "nauro-ship-task")
+    assert codex.read_text(encoding="utf-8") == render_skill("codex", "nauro-ship-task")
+    assert cursor.read_text(encoding="utf-8") == render_skill("cursor", "nauro-ship-task")
+
+    remove = runner.invoke(app, ["setup", "all", "--remove", "--with-skills"])
+    assert remove.exit_code == 0, remove.output
+
+    assert not claude.exists()
+    assert not codex.exists()
+    assert not cursor.exists()
+
+
+def test_setup_all_with_skills_emits_notice_when_subagents_off(tmp_path: Path, monkeypatch):
+    """The body references @nauro-* subagents; the user-facing add path warns."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    _, store_path = register_project_v2("myproj", [repo])
+    scaffold_project_store("myproj", store_path)
+    monkeypatch.chdir(repo)
+
+    result = runner.invoke(app, ["setup", "all", "--with-skills"])
+    assert result.exit_code == 0, result.output
+    assert "nauro-ship-task references the bundled @nauro-* subagents" in result.output
+
+
+def test_setup_all_with_skills_and_subagents_suppresses_notice(tmp_path: Path, monkeypatch):
+    """When both flags are passed, no notice — prerequisites met."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    _, store_path = register_project_v2("myproj", [repo])
+    scaffold_project_store("myproj", store_path)
+    monkeypatch.chdir(repo)
+
+    result = runner.invoke(app, ["setup", "all", "--with-skills", "--with-subagents"])
+    assert result.exit_code == 0, result.output
+    assert "nauro-ship-task references the bundled @nauro-* subagents" not in result.output
+
+
+def test_setup_all_remove_without_with_skills_leaves_ship_task_intact(tmp_path: Path, monkeypatch):
+    """If the user installed ``--with-skills`` and removes without the flag,
+    the opt-in skill files persist — the remove path mirrors the install path's
+    name set so partial cleanups are explicit, not silent."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    _, store_path = register_project_v2("myproj", [repo])
+    scaffold_project_store("myproj", store_path)
+    monkeypatch.chdir(repo)
+
+    runner.invoke(app, ["setup", "all", "--with-skills"])
+    claude = tmp_path / ".claude" / "skills" / "nauro-ship-task" / "SKILL.md"
+    assert claude.is_file()
+
+    remove = runner.invoke(app, ["setup", "all", "--remove"])  # no --with-skills
+    assert remove.exit_code == 0, remove.output
+
+    # nauro-adopt is cleared (the always-installed set), nauro-ship-task is not.
+    assert not (tmp_path / ".claude" / "skills" / "nauro-adopt" / "SKILL.md").exists()
+    assert claude.is_file()

--- a/packages/nauro/tests/test_skills_drift.py
+++ b/packages/nauro/tests/test_skills_drift.py
@@ -13,7 +13,7 @@ from collections.abc import Iterator
 
 import pytest
 
-from nauro.skills import load_adopt_body, render_skill
+from nauro.skills import load_adopt_body, load_ship_task_body, render_skill
 from tests._skill_surfaces import REPO_ROOT, SKILL_SURFACES, load_docs_adopt_prompt
 
 
@@ -34,6 +34,27 @@ def test_load_adopt_body_returns_canonical_bytes():
     for op in ("add", "update", "supersede"):
         assert f'operation="{op}"' in body, f"missing propose_decision variant: {op}"
     assert "Step 11 — Summary" in body
+
+
+def test_load_ship_task_body_returns_canonical_bytes():
+    body = load_ship_task_body()
+    assert body.endswith("\n")
+    assert 1000 < len(body) < 25000
+    # Anchor on key chain markers so a cleanup edit cannot accidentally drop
+    # a load-bearing step heading.
+    assert "## Prerequisites" in body
+    assert "## Pre-step" in body
+    assert "@nauro-planner" in body
+    assert "@nauro-executor" in body
+    assert "@nauro-reviewer" in body
+    assert "@nauro-tech-lead" in body
+    # Nauro-strict gate language must remain — the chain always gates on
+    # propose_decision firing, not the personal /ship-task low-stakes path.
+    assert "propose_decision" in body
+    # Tech-lead Mode C pass sits between reviewer-APPROVE and the push gate.
+    assert "Mode C" in body
+    # Required prerequisite reference to the bundled subagents flag.
+    assert "--with-subagents" in body
 
 
 # --- render_skill produces frontmatter + body ---
@@ -57,6 +78,24 @@ def test_render_skill_cursor_adopt_frontmatter():
     assert body == load_adopt_body()
 
 
+def test_render_skill_claude_code_ship_task_frontmatter():
+    rendered = render_skill("claude_code", "nauro-ship-task")
+    assert rendered.startswith("---\nname: nauro-ship-task\n")
+    assert "description:" in rendered.split("\n---\n", 1)[0]
+    body = rendered.split("\n---\n", 1)[1].lstrip("\n")
+    assert body == load_ship_task_body()
+
+
+def test_render_skill_cursor_ship_task_frontmatter():
+    rendered = render_skill("cursor", "nauro-ship-task")
+    fm = rendered.split("\n---\n", 1)[0]
+    assert "description:" in fm
+    assert "alwaysApply: false" in fm
+    assert "name:" not in fm
+    body = rendered.split("\n---\n", 1)[1].lstrip("\n")
+    assert body == load_ship_task_body()
+
+
 def test_render_skill_unknown_surface_raises():
     with pytest.raises(ValueError):
         render_skill("emacs", "nauro-adopt")
@@ -74,6 +113,9 @@ DOGFOOD_FILES = [
     (".claude/skills/nauro-adopt/SKILL.md", "claude_code", "nauro-adopt"),
     (".cursor/rules/nauro-adopt.mdc", "cursor", "nauro-adopt"),
     (".agents/skills/nauro-adopt/SKILL.md", "codex", "nauro-adopt"),
+    (".claude/skills/nauro-ship-task/SKILL.md", "claude_code", "nauro-ship-task"),
+    (".cursor/rules/nauro-ship-task.mdc", "cursor", "nauro-ship-task"),
+    (".agents/skills/nauro-ship-task/SKILL.md", "codex", "nauro-ship-task"),
 ]
 
 


### PR DESCRIPTION
## Why

Nauro already ships bundled `@nauro-*` workflow subagents (opt-in via `--with-subagents`), but the orchestration that ties them together for a non-trivial code change had to be assembled by hand on every run. A parallel `/ship-task` skill exists at the user level. It lacks the doctrine wiring: it does not gate on `check_decision` / `propose_decision` firing, and never reaches `@nauro-tech-lead` for the doctrine pass between reviewer and push.

## Approach

Add `/nauro-ship-task` as a bundled skill that wraps the `planner → executor → reviewer → tech-lead → user-confirm → push` chain with Nauro-strict gates. The chain always pauses for the user when `propose_decision` will fire (no low-stakes auto-proceed when doctrine writes are pending), and runs `@nauro-tech-lead` in Mode C between reviewer-APPROVE and the push gate to catch doctrine drift the reviewer missed.

The skill owns orchestration. The bundled-subagents pattern (one message in, one message out) cannot shape an interactive multi-gate chain correctly, which is why orchestration lives in the skill body rather than baked into `@nauro-tech-lead`.

Install rides a new `--with-skills` flag on `nauro adopt` and `nauro setup all`, independent of `--with-subagents` so the two product surfaces stay decoupled. The existing `/nauro-adopt` skill stays always-installed; opt-in skills live in `OPT_IN_SKILL_NAMES`.

Alternatives considered and rejected: cascading both flags into one (implicit dependency between decoupled surfaces); per-skill flag (`--with-ship-task`, then `--with-<next>`...) that would balloon the flag matrix; folding into `--with-subagents` (mis-shapes that flag's purpose and help copy).

## What changed

Skill body lives at `packages/nauro/src/nauro/skills/ship_task_body.md` and renders through the existing `render_skill(surface, name)` machinery, with byte-equal dogfood files committed at `.claude/skills/nauro-ship-task/SKILL.md`, `.agents/skills/nauro-ship-task/SKILL.md`, and `.cursor/rules/nauro-ship-task.mdc`. The skills package gains a `load_ship_task_body()` loader and widens `SkillName` / `SKILL_DESCRIPTIONS`.

The setup module gains `OPT_IN_SKILL_NAMES` and a `_resolved_skill_names(with_skills)` helper that the three per-surface materializers consume. `setup_all_surfaces` threads `with_skills` through to all three. `nauro adopt --with-skills` and `nauro setup all --with-skills` both surface a one-line notice when the flag is passed without `--with-subagents`, since the skill body references the bundled subagents by name.

## What to review

- The skill body's pre-step gate: the chain pauses before the executor if the planner returns RED with a supersede draft. That is the doctrine equivalent of GATE 1 firing early.
- Nauro-strict GATE 2 wording. Gates whenever `propose_decision` will fire, with no low-stakes auto-proceed path while doctrine writes are pending.
- The tech-lead Mode C pass between reviewer-APPROVE and the push gate. Verify the AMBER / RED handling reads consistently.
- The `--with-skills` flag is independent of `--with-subagents`. The partial-cleanup case (install with the flag, remove without it) leaves opt-in skills intact by design, covered by `test_setup_all_remove_without_with_skills_leaves_ship_task_intact`.

## What's deferred

- Future bundled skills will ride the same `--with-skills` flag. None planned yet.
- Cursor and Codex surfaces materialize the new skill identically to `/nauro-adopt`. If their slash-command UX diverges later, the per-surface dogfood matrix is the seam to extend.

## Test plan

1,342 existing + 11 new tests pass (978 nauro + 364 nauro-core). Coverage includes:

- Anchor and frontmatter parity for the new skill (`test_skills_drift.py`)
- Three new dogfood files asserted byte-equal to `render_skill(...)` and scanned for raw protocol tokens (`test_protocol_drift.py`)
- `nauro adopt`: default install does NOT install ship-task; `--with-skills` DOES; round-trip removal via `setup all --remove --with-skills` clears it; notice fires when `--with-skills` is passed without `--with-subagents`; notice is suppressed when both flags are passed
- `nauro setup all`: parallel coverage of all the above, plus the partial-cleanup invariant
- `ruff check` and `ruff format --check` clean across `packages/`