### PR TITLE
Remove unnecessary instruction from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Nauro
 
-Set the doctrine once. Every agent inherits it.
-
 Nauro gives AI agents persistent project context across Claude, Cursor, Codex, ChatGPT, and any MCP client. It captures decisions and rejected options, then checks new proposals against them so agents stop re-suggesting approaches you already ruled out.
 
 **Status:** Beta. 1.0 will be the first production release.


### PR DESCRIPTION
Why
The instruction "Set the doctrine once. Every agent inherits it." was redundant and added unnecessary verbosity from the README introduction. The core value proposition is better conveyed by the paragraph that follows.

Approach
Simple documentation cleanup. Removed the redundant introductory line to streamline the README and improve clarity for new users.

What changed
README.md: Removed 2 lines (lines 3-4):
Deleted the redundant instruction about setting the doctrine once
This simplifies the opening section while keeping the core explanation intact
What to review
This is a straightforward documentation change with no code impact. Reviewers should simply verify that:

The README flows naturally without this line
The remaining introduction clearly explains Nauro's purpose
What's deferred
None — this is a complete, minimal change.

Test plan
No testing required. This is a documentation-only change. The README can be visually verified as rendering correctly on GitHub.

