### PR TITLE
feat(operations): cut check_decision over to nauro_core kernel

### DIFF
--- a/packages/nauro-core/src/nauro_core/__init__.py
+++ b/packages/nauro-core/src/nauro_core/__init__.py
@@ -5,6 +5,7 @@ Re-export facade — public API symbols from all modules.
 
 from importlib.metadata import version
 
+from nauro_core import operations as operations
 from nauro_core.constants import (
     DECISION_HASHES_FILE as DECISION_HASHES_FILE,
 )
@@ -55,6 +56,9 @@ from nauro_core.constants import (
 )
 from nauro_core.constants import (
     MIN_RATIONALE_LENGTH as MIN_RATIONALE_LENGTH,
+)
+from nauro_core.constants import (
+    NO_DECISIONS_TO_CHECK as NO_DECISIONS_TO_CHECK,
 )
 from nauro_core.constants import (
     OPEN_QUESTIONS_MD as OPEN_QUESTIONS_MD,

--- a/packages/nauro-core/src/nauro_core/constants.py
+++ b/packages/nauro-core/src/nauro_core/constants.py
@@ -39,6 +39,18 @@ OPEN_QUESTIONS_MD = "open-questions.md"
 DECISIONS_DIR = "decisions"
 SNAPSHOTS_DIR = "snapshots"
 
+# ── Empty-state guidance ──
+# Returned by `check_decision` when the store has no decisions yet. Shared
+# between local (nauro) and remote (mcp-server) so the empty-store onboarding
+# text cannot drift between surfaces.
+NO_DECISIONS_TO_CHECK = (
+    "No existing decisions to check against.\n"
+    "\n"
+    "Use propose_decision to record your first architectural decision, "
+    "then check_decision can help verify new approaches against "
+    "your recorded decisions."
+)
+
 # ── Decision types ──
 DECISION_TYPES: tuple[str, ...] = (
     "architecture",

--- a/packages/nauro-core/src/nauro_core/operations/__init__.py
+++ b/packages/nauro-core/src/nauro_core/operations/__init__.py
@@ -4,15 +4,19 @@ Pure callables that implement the user-facing operations exposed by every
 Nauro transport (CLI, local stdio MCP, remote HTTP MCP). Each operation
 takes a ``Store`` and returns a typed Pydantic ``Result`` model. Operations
 emit no telemetry; transports own event emission.
-
-PR 0 ships the ``Store`` protocol, an ``InMemoryStore`` for tests, and the
-``results`` module shell. Concrete operations land per ``Result`` type as
-the rollout proceeds.
 """
 
 from nauro_core.operations._in_memory_store import InMemoryStore as InMemoryStore
+from nauro_core.operations.check_decision import check_decision as check_decision
+from nauro_core.operations.results import CheckDecisionResult as CheckDecisionResult
 from nauro_core.operations.store import Store as Store
 
 from . import results as results
 
-__all__ = ["InMemoryStore", "Store", "results"]
+__all__ = [
+    "CheckDecisionResult",
+    "InMemoryStore",
+    "Store",
+    "check_decision",
+    "results",
+]

--- a/packages/nauro-core/src/nauro_core/operations/__init__.py
+++ b/packages/nauro-core/src/nauro_core/operations/__init__.py
@@ -1,0 +1,18 @@
+"""Cross-transport operations kernel.
+
+Pure callables that implement the user-facing operations exposed by every
+Nauro transport (CLI, local stdio MCP, remote HTTP MCP). Each operation
+takes a ``Store`` and returns a typed Pydantic ``Result`` model. Operations
+emit no telemetry; transports own event emission.
+
+PR 0 ships the ``Store`` protocol, an ``InMemoryStore`` for tests, and the
+``results`` module shell. Concrete operations land per ``Result`` type as
+the rollout proceeds.
+"""
+
+from nauro_core.operations._in_memory_store import InMemoryStore as InMemoryStore
+from nauro_core.operations.store import Store as Store
+
+from . import results as results
+
+__all__ = ["InMemoryStore", "Store", "results"]

--- a/packages/nauro-core/src/nauro_core/operations/_in_memory_store.py
+++ b/packages/nauro-core/src/nauro_core/operations/_in_memory_store.py
@@ -1,0 +1,41 @@
+"""Dict-backed ``Store`` implementation for kernel tests.
+
+Keeps the test surface free of filesystem I/O. Decision file stems live in
+their own dict so :meth:`list_decisions` can return a sorted view without
+introspecting the broader file table.
+"""
+
+from __future__ import annotations
+
+
+class InMemoryStore:
+    """Test double for :class:`~nauro_core.operations.store.Store`.
+
+    Decisions are passed in keyed by file stem and exposed via
+    :meth:`list_decisions` / :meth:`read_decision`. Other files live in a
+    separate dict so write/read/delete round-trip without polluting the
+    decision view.
+    """
+
+    def __init__(
+        self,
+        decisions: dict[str, str] | None = None,
+        files: dict[str, str] | None = None,
+    ) -> None:
+        self._decisions: dict[str, str] = dict(decisions or {})
+        self._files: dict[str, str] = dict(files or {})
+
+    def read_file(self, path: str) -> str | None:
+        return self._files.get(path)
+
+    def write_file(self, path: str, content: str) -> None:
+        self._files[path] = content
+
+    def delete_file(self, path: str) -> None:
+        self._files.pop(path, None)
+
+    def list_decisions(self) -> list[str]:
+        return sorted(self._decisions)
+
+    def read_decision(self, file_stem: str) -> str | None:
+        return self._decisions.get(file_stem)

--- a/packages/nauro-core/src/nauro_core/operations/check_decision.py
+++ b/packages/nauro-core/src/nauro_core/operations/check_decision.py
@@ -1,0 +1,140 @@
+"""``check_decision`` — surface conflicts between a proposed approach and the store.
+
+Cross-transport implementation: CLI, local stdio MCP, and remote HTTP MCP
+all call this function with the same arguments and receive the same
+:class:`CheckDecisionResult`. Each transport's adapter wraps the call to
+add transport-specific framing (``store`` field, telemetry emission,
+exit-code handling), but the retrieval, ranking, and assessment text are
+shared by construction.
+"""
+
+from __future__ import annotations
+
+from bm25s.stopwords import STOPWORDS_EN
+
+from nauro_core.constants import (
+    MAX_APPROACH_LENGTH,
+    MAX_CONTEXT_LENGTH,
+    NO_DECISIONS_TO_CHECK,
+)
+from nauro_core.decision_model import Decision, parse_decision
+from nauro_core.operations.results import (
+    CheckDecisionResult,
+    ErrorPayload,
+    RelatedDecision,
+)
+from nauro_core.operations.store import Store
+from nauro_core.parsing import extract_decision_number
+from nauro_core.search import bm25_retrieve
+from nauro_core.validation import check_content_length
+
+# Scaffold-seed bookkeeping decision is excluded from retrieval; full
+# rationale lives in ``nauro_core/validation.py:40-51``. The convention
+# match (num == 1 and exact title) is the same one tier-2 validation uses,
+# so both surfaces agree on what counts as the seed.
+_SCAFFOLD_SEED_TITLE = "Initial project setup"
+
+# Extended stopword list for ``check_decision`` retrieval. Mirrors the
+# tier-2 ``TIER2_STOPWORDS`` curation (``nauro_core/validation.py:20-38``):
+# bm25s's default English list omits common action verbs that appear in
+# almost every decision title, so adding ``"use"`` collapses the
+# false-positive matches that otherwise surface as near-neighbours on
+# every call.
+_CHECK_DECISION_STOPWORDS = [*list(STOPWORDS_EN), "use"]
+
+
+def check_decision(
+    store: Store,
+    proposed_approach: str,
+    context: str | None = None,
+) -> CheckDecisionResult:
+    """Return the conflict-check result for ``proposed_approach``.
+
+    Args:
+        store: Storage adapter providing ``list_decisions`` / ``read_decision``.
+        proposed_approach: Free-form description of the approach to check.
+        context: Optional additional context concatenated into the retrieval
+            query. Subject to ``MAX_CONTEXT_LENGTH``.
+
+    Returns:
+        :class:`CheckDecisionResult`. On the rejection path ``error`` is
+        populated and ``related_decisions`` / ``assessment`` stay empty.
+    """
+    rejection = check_content_length(proposed_approach, "Proposed approach", MAX_APPROACH_LENGTH)
+    if rejection:
+        return CheckDecisionResult(error=ErrorPayload(kind="rejected", reason=rejection))
+    if context:
+        rejection = check_content_length(context, "Context", MAX_CONTEXT_LENGTH)
+        if rejection:
+            return CheckDecisionResult(error=ErrorPayload(kind="rejected", reason=rejection))
+
+    decisions = _parse_all_decisions(store)
+    decisions = [d for d in decisions if not (d.num == 1 and d.title == _SCAFFOLD_SEED_TITLE)]
+    if not decisions:
+        return CheckDecisionResult(assessment=NO_DECISIONS_TO_CHECK)
+
+    # Match the pre-cutover BM25 input envelope: title-style head (capped
+    # at 100) joined to the full approach + context (capped at 200). The
+    # bm25s tokenizer is order-insensitive, but the 100/200 cap shapes
+    # which tokens reach the index — preserving the prior caller's
+    # ``pseudo_proposal`` truncation locks the same retrieval surface.
+    approach_head = proposed_approach[:100]
+    body_text = proposed_approach + (f" {context}" if context else "")
+    query_text = f"{approach_head}. {body_text[:200]}"
+    hits = bm25_retrieve(decisions, query_text, top_k=5, stopwords=_CHECK_DECISION_STOPWORDS)
+    if not hits:
+        return CheckDecisionResult(assessment="No related decisions found.")
+
+    by_num = {d.num: d for d in decisions}
+    related = [_hit_to_related(hit, by_num) for hit in hits]
+
+    return CheckDecisionResult(
+        related_decisions=related,
+        assessment=_assessment(related),
+    )
+
+
+def _parse_all_decisions(store: Store) -> list[Decision]:
+    """Read every decision from ``store`` and parse it via the v2 model."""
+    parsed: list[Decision] = []
+    for stem in store.list_decisions():
+        body = store.read_decision(stem)
+        if body is None:
+            continue
+        parsed.append(parse_decision(body, f"{stem}.md"))
+    return parsed
+
+
+def _hit_to_related(hit: dict, by_num: dict[int, Decision]) -> RelatedDecision:
+    """Lift a ``bm25_retrieve`` hit into the canonical D141 shape."""
+    num = hit["number"]
+    decision = by_num.get(num)
+    canonical_id = f"decision-{num:03d}"
+    status = decision.status.value if decision else "active"
+    date = decision.date.isoformat() if decision and decision.date else ""
+    return RelatedDecision(
+        id=canonical_id,
+        title=hit.get("title", ""),
+        score=hit.get("similarity", 0.0),
+        status=status,
+        date=date,
+        rationale_preview=hit.get("rationale_preview", ""),
+    )
+
+
+def _assessment(related: list[RelatedDecision]) -> str:
+    """Build the deterministic single-line assessment from retrieval facts."""
+    top = related[0]
+    top_num = extract_decision_number(top.id)
+    top_label = f"D{top_num:03d}" if top_num is not None else top.id
+    top_line = (
+        f'Top match: {top_label} "{top.title}"'
+        f" (status {top.status}, decided {top.date}, BM25 {top.score:.1f})."
+    )
+    if len(related) == 1:
+        target = f"get_decision({top_num})" if top_num is not None else "get_decision"
+        return f"{top_line} Call {target} before proposing."
+    return (
+        f"Found {len(related)} related decisions. {top_line}"
+        " Call get_decision on each related decision before proposing."
+    )

--- a/packages/nauro-core/src/nauro_core/operations/results.py
+++ b/packages/nauro-core/src/nauro_core/operations/results.py
@@ -1,0 +1,29 @@
+"""Pydantic ``Result`` models returned by the operations kernel.
+
+Each operation returns a per-operation ``*Result`` model so transports
+shape responses from typed attributes rather than loosely-typed dicts.
+PR 0 lands the ``RelatedDecision`` submodel; ``CheckDecisionResult`` and
+``ErrorPayload`` ship with the ``check_decision`` operation cutover.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class RelatedDecision(BaseModel):
+    """A decision surfaced by retrieval as related to a proposed approach.
+
+    The shape is the canonical D141 form: enriched with status/date and a
+    rationale preview so any transport can render the same hit without
+    re-fetching the underlying decision body.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    id: str
+    title: str
+    score: float
+    status: str
+    date: str
+    rationale_preview: str

--- a/packages/nauro-core/src/nauro_core/operations/results.py
+++ b/packages/nauro-core/src/nauro_core/operations/results.py
@@ -2,13 +2,15 @@
 
 Each operation returns a per-operation ``*Result`` model so transports
 shape responses from typed attributes rather than loosely-typed dicts.
-PR 0 lands the ``RelatedDecision`` submodel; ``CheckDecisionResult`` and
-``ErrorPayload`` ship with the ``check_decision`` operation cutover.
+``RelatedDecision`` and ``ErrorPayload`` are shared submodels reused by
+multiple operations; per-operation ``Result`` models live alongside.
 """
 
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class RelatedDecision(BaseModel):
@@ -27,3 +29,37 @@ class RelatedDecision(BaseModel):
     status: str
     date: str
     rationale_preview: str
+
+
+class ErrorPayload(BaseModel):
+    """Structured error envelope returned on rejection or operation failure.
+
+    ``kind`` discriminates between caller-fixable rejections (input over
+    length, malformed argument) and operation-side failures. ``guidance``
+    carries an onboarding string when the rejection has a remedial action
+    the caller can take.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    kind: Literal["rejected", "error"]
+    reason: str
+    guidance: str | None = None
+
+
+class CheckDecisionResult(BaseModel):
+    """Return shape for :func:`nauro_core.operations.check_decision`.
+
+    On the success path ``related_decisions`` contains zero or more
+    :class:`RelatedDecision` hits and ``assessment`` carries the
+    deterministic human-readable summary. On the rejection path
+    ``error`` is populated; ``related_decisions`` stays empty and
+    ``assessment`` stays empty. ``store`` is not part of the model;
+    transport adapters add it back at serialization time.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    related_decisions: list[RelatedDecision] = Field(default_factory=list)
+    assessment: str = ""
+    error: ErrorPayload | None = None

--- a/packages/nauro-core/src/nauro_core/operations/store.py
+++ b/packages/nauro-core/src/nauro_core/operations/store.py
@@ -1,0 +1,54 @@
+"""Storage adapter protocol for the operations kernel.
+
+Operations call into a ``Store`` to read and write the project store; each
+transport supplies a concrete implementation (filesystem for local, S3 +
+DynamoDB for cloud). The Protocol stays minimal: only the five primitives
+locked by the operations-kernel restructure. Anything broader (file
+enumeration outside ``decisions/``, pending-state primitives, etc.) is a
+separate decision before the surface grows.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class Store(Protocol):
+    """Minimal storage interface the operations kernel depends on.
+
+    All implementations are synchronous; cloud transports wrap operation
+    calls in ``asyncio.to_thread`` (or equivalent) so the kernel itself
+    stays free of infrastructure concerns. Implementations are expected to
+    handle path traversal, locking, and any backend-specific error mapping
+    at their own boundary.
+    """
+
+    def read_file(self, path: str) -> str | None:
+        """Return the file's text content, or ``None`` if it does not exist."""
+        ...
+
+    def write_file(self, path: str, content: str) -> None:
+        """Write ``content`` to ``path``, replacing any existing content."""
+        ...
+
+    def delete_file(self, path: str) -> None:
+        """Remove ``path``. No-op if the file does not exist."""
+        ...
+
+    def list_decisions(self) -> list[str]:
+        """Return decision file stems (e.g. ``"042-use-postgres"``).
+
+        The list is sorted in lexicographic order. Stems map 1:1 to decision
+        files under the canonical ``decisions/`` directory; callers reach
+        the body via :meth:`read_decision`.
+        """
+        ...
+
+    def read_decision(self, file_stem: str) -> str | None:
+        """Return the markdown body for the decision named by ``file_stem``.
+
+        ``file_stem`` is a value returned by :meth:`list_decisions` (without
+        the ``.md`` suffix). Returns ``None`` if the decision is missing.
+        """
+        ...

--- a/packages/nauro-core/tests/operations/test_check_decision.py
+++ b/packages/nauro-core/tests/operations/test_check_decision.py
@@ -1,0 +1,304 @@
+"""Kernel-level tests for ``operations.check_decision`` against ``InMemoryStore``.
+
+Each test seeds an ``InMemoryStore`` with parseable v2 decisions and asserts
+on the typed :class:`CheckDecisionResult` directly. Surface-level wiring
+tests live in each transport's own suite.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from nauro_core.constants import MAX_APPROACH_LENGTH, MAX_CONTEXT_LENGTH, NO_DECISIONS_TO_CHECK
+from nauro_core.decision_model import (
+    Decision,
+    DecisionConfidence,
+    DecisionStatus,
+    format_decision,
+)
+from nauro_core.operations import (
+    CheckDecisionResult,
+    InMemoryStore,
+    check_decision,
+)
+
+
+def _seed_decision(
+    num: int,
+    title: str,
+    rationale: str,
+    *,
+    status: DecisionStatus = DecisionStatus.active,
+    decision_date: date | None = None,
+) -> tuple[str, str]:
+    """Return (file_stem, formatted_markdown) for a minimal v2 decision."""
+    superseded_by = "999" if status is DecisionStatus.superseded else None
+    decision = Decision(
+        date=decision_date or date(2026, 1, 1),
+        confidence=DecisionConfidence.medium,
+        status=status,
+        superseded_by=superseded_by,
+        num=num,
+        title=title,
+        rationale=rationale,
+    )
+    slug = title.lower().replace(" ", "-")
+    stem = f"{num:03d}-{slug}"
+    return stem, format_decision(decision)
+
+
+def _store_with(*decisions: tuple[str, str]) -> InMemoryStore:
+    return InMemoryStore(decisions=dict(decisions))
+
+
+def test_returns_result_type() -> None:
+    result = check_decision(InMemoryStore(), "Use Redis for caching")
+    assert isinstance(result, CheckDecisionResult)
+
+
+def test_empty_store_returns_no_decisions_assessment() -> None:
+    result = check_decision(InMemoryStore(), "Use Redis for caching")
+    assert result.related_decisions == []
+    assert result.assessment == NO_DECISIONS_TO_CHECK
+    assert result.error is None
+
+
+def test_unrelated_proposal_returns_no_related_decisions() -> None:
+    """A proposal sharing no salient tokens with any decision falls into the
+    'no related decisions' branch, distinct from the empty-store branch."""
+    store = _store_with(
+        _seed_decision(1, "Adopt PostgreSQL", "ACID semantics for our transactional workload."),
+    )
+    result = check_decision(store, "Pineapple production logistics across mid-atlantic ports")
+    assert result.related_decisions == []
+    assert result.assessment == "No related decisions found."
+    assert result.error is None
+
+
+def test_related_decision_canonical_id_and_status_enrichment() -> None:
+    """Hits expose D141 canonical fields populated from the parsed decision."""
+    store = _store_with(
+        _seed_decision(
+            42,
+            "Adopt PostgreSQL",
+            "Use PostgreSQL for ACID transactional semantics across the platform.",
+            decision_date=date(2026, 4, 16),
+        ),
+    )
+    result = check_decision(store, "Migrate primary storage to PostgreSQL")
+    assert result.error is None
+    assert len(result.related_decisions) == 1
+    hit = result.related_decisions[0]
+    assert hit.id == "decision-042"
+    assert hit.title == "Adopt PostgreSQL"
+    assert hit.status == "active"
+    assert hit.date == "2026-04-16"
+    assert hit.score > 0.0
+    assert "PostgreSQL" in hit.rationale_preview
+
+
+def test_assessment_single_match_directs_to_get_decision() -> None:
+    store = _store_with(
+        _seed_decision(7, "Adopt Redis", "Use Redis for session cache with TTL eviction."),
+    )
+    result = check_decision(store, "Add Redis as a session cache")
+    assert result.error is None
+    assert "Top match: D007" in result.assessment
+    assert "Call get_decision(7) before proposing." in result.assessment
+
+
+def test_assessment_multi_match_directs_to_each() -> None:
+    store = _store_with(
+        _seed_decision(7, "Adopt Redis", "Use Redis for session cache with TTL eviction."),
+        _seed_decision(8, "Adopt Memcached", "Use Memcached for the legacy session cache."),
+    )
+    result = check_decision(store, "Pick a session cache implementation")
+    assert result.error is None
+    assert len(result.related_decisions) >= 2
+    assert "Found" in result.assessment
+    assert "Call get_decision on each related decision before proposing." in result.assessment
+
+
+def test_superseded_decisions_are_excluded_from_hits() -> None:
+    """Retrieval narrows to active decisions; superseded entries never surface.
+
+    Matches existing local behavior — ``bm25_retrieve`` filters by status
+    before scoring. Locks in the contract so a regression in retrieval would
+    show up as a hit count change here, not a silent escalation surface.
+    """
+    store = _store_with(
+        _seed_decision(
+            5,
+            "Adopt REST endpoints",
+            "Initial transport choice for the public API, later replaced by gRPC.",
+            status=DecisionStatus.superseded,
+        ),
+        _seed_decision(
+            6,
+            "Adopt gRPC for internal API",
+            "Replace REST with gRPC for cross-service calls on the internal mesh.",
+        ),
+    )
+    result = check_decision(store, "Use gRPC instead of REST for internal services")
+    assert result.error is None
+    ids = [hit.id for hit in result.related_decisions]
+    assert "decision-006" in ids
+    assert "decision-005" not in ids
+
+
+def test_context_arg_joins_into_retrieval_query() -> None:
+    """Tokens that appear only in ``context`` still drive retrieval."""
+    store = _store_with(
+        _seed_decision(
+            3,
+            "Adopt Kafka",
+            "Replace RabbitMQ on the event spine for higher throughput tolerance.",
+        ),
+    )
+    # The approach text alone shares no salient tokens with the seeded
+    # decision; the only overlap rides in via ``context``.
+    result = check_decision(
+        store,
+        "Pick a streaming substrate for downstream consumers",
+        context="Migrating off RabbitMQ.",
+    )
+    assert result.error is None
+    assert len(result.related_decisions) >= 1
+    assert result.related_decisions[0].id == "decision-003"
+
+
+def test_rejection_when_approach_over_length() -> None:
+    store = _store_with(_seed_decision(1, "Adopt PostgreSQL", "ACID semantics for our workload."))
+    result = check_decision(store, "x" * (MAX_APPROACH_LENGTH + 1))
+    assert result.error is not None
+    assert result.error.kind == "rejected"
+    assert str(MAX_APPROACH_LENGTH) in result.error.reason
+    assert result.related_decisions == []
+    assert result.assessment == ""
+
+
+def test_rejection_when_context_over_length() -> None:
+    store = _store_with(_seed_decision(1, "Adopt PostgreSQL", "ACID semantics for our workload."))
+    result = check_decision(
+        store,
+        "Use Redis",
+        context="y" * (MAX_CONTEXT_LENGTH + 1),
+    )
+    assert result.error is not None
+    assert result.error.kind == "rejected"
+    assert str(MAX_CONTEXT_LENGTH) in result.error.reason
+
+
+def test_store_field_absent_from_result_model_dump() -> None:
+    """Transports own the ``store`` field; the kernel never emits it."""
+    result = check_decision(InMemoryStore(), "Use Redis for caching")
+    dumped = result.model_dump(mode="json")
+    assert "store" not in dumped
+
+
+@pytest.mark.parametrize("missing_body_stem", ["999-vanished"])
+def test_missing_body_is_skipped_not_fatal(missing_body_stem: str) -> None:
+    """If list_decisions surfaces a stem with no body, the operation skips it.
+
+    Defensive: a backend may race a delete against an enumeration. The kernel
+    must not crash on the inconsistent view.
+    """
+
+    class _RaceyStore(InMemoryStore):
+        def __init__(self) -> None:
+            stem, body = _seed_decision(1, "Adopt PostgreSQL", "ACID semantics for our workload.")
+            super().__init__(decisions={stem: body})
+            self._missing_stem = missing_body_stem
+
+        def list_decisions(self) -> list[str]:
+            return sorted([*super().list_decisions(), self._missing_stem])
+
+    result = check_decision(_RaceyStore(), "Migrate to PostgreSQL")
+    assert result.error is None
+    assert any(hit.id == "decision-001" for hit in result.related_decisions)
+
+
+def test_scaffold_seed_excluded_from_retrieval() -> None:
+    """The scaffold-seeded (num=1, "Initial project setup") decision never
+    surfaces in retrieval — it records that the store was initialized, not
+    a user choice. Locks in the curation moved from the pre-cutover wrapper.
+    """
+    store = _store_with(
+        _seed_decision(
+            1,
+            "Initial project setup",
+            "Scaffolded by nauro init to bootstrap the decision store.",
+        ),
+        _seed_decision(
+            7,
+            "Adopt PostgreSQL",
+            "ACID semantics for the transactional workload backing the API.",
+        ),
+    )
+    result = check_decision(store, "Migrate primary storage to PostgreSQL")
+    assert result.error is None
+    ids = [hit.id for hit in result.related_decisions]
+    assert "decision-001" not in ids
+    assert "decision-007" in ids
+
+
+def test_use_stopword_does_not_force_false_positive() -> None:
+    """``use`` is a near-universal token in decision titles; treating it as
+    a stopword collapses the spurious matches that surface a proposal as
+    near-neighbour to almost every prior decision. Locks the curation
+    from ``TIER2_STOPWORDS``.
+    """
+    store = _store_with(
+        _seed_decision(
+            2,
+            "Adopt PostgreSQL",
+            "Use PostgreSQL for ACID transactional semantics.",
+        ),
+        _seed_decision(
+            3,
+            "Adopt Redis",
+            "Use Redis for session cache eviction.",
+        ),
+        _seed_decision(
+            4,
+            "Adopt Kafka",
+            "Use Kafka for the event spine across services.",
+        ),
+    )
+    # Proposal shares only the ``use`` stem with the seeded decisions —
+    # everything else is unrelated subject matter.
+    result = check_decision(store, "Use pineapples for mid-atlantic logistics")
+    assert result.error is None
+    assert result.related_decisions == []
+
+
+def test_long_approach_is_capped_for_retrieval() -> None:
+    """``proposed_approach`` over 200 chars has tokens past the cap dropped
+    from the BM25 input. Tokens before the cap still retrieve normally.
+    Locks the 100/200 truncation contract carried over from the
+    pre-cutover ``pseudo_proposal`` construction.
+    """
+    store = _store_with(
+        _seed_decision(
+            5,
+            "Adopt Cassandra",
+            "Cassandra for wide-column write-heavy workloads.",
+        ),
+        _seed_decision(
+            6,
+            "Adopt PostgreSQL",
+            "PostgreSQL for ACID transactional semantics.",
+        ),
+    )
+    # First 200 chars are unrelated filler; the Cassandra-salient token
+    # sits at the tail, beyond the truncation cap, so it never reaches
+    # the BM25 index. Stays under MAX_APPROACH_LENGTH (5_000) so we
+    # exercise the curation, not the rejection branch.
+    filler = "x" * 2_000
+    approach = filler + " choose Cassandra for the new write path"
+    result = check_decision(store, approach)
+    assert result.error is None
+    ids = [hit.id for hit in result.related_decisions]
+    assert "decision-005" not in ids

--- a/packages/nauro-core/tests/operations/test_results.py
+++ b/packages/nauro-core/tests/operations/test_results.py
@@ -1,4 +1,4 @@
-"""Kernel tests for the ``results`` module shell shipped in PR 0."""
+"""Kernel tests for the operations ``results`` module shell."""
 
 from __future__ import annotations
 

--- a/packages/nauro-core/tests/operations/test_results.py
+++ b/packages/nauro-core/tests/operations/test_results.py
@@ -1,0 +1,54 @@
+"""Kernel tests for the ``results`` module shell shipped in PR 0."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from nauro_core.operations.results import RelatedDecision
+
+
+def test_related_decision_model_dump_shape() -> None:
+    hit = RelatedDecision(
+        id="decision-042",
+        title="Use Postgres",
+        score=1.5,
+        status="active",
+        date="2026-01-01",
+        rationale_preview="ACID compliance trumps document flexibility for this workload.",
+    )
+    dumped = hit.model_dump(mode="json")
+    assert dumped == {
+        "id": "decision-042",
+        "title": "Use Postgres",
+        "score": 1.5,
+        "status": "active",
+        "date": "2026-01-01",
+        "rationale_preview": "ACID compliance trumps document flexibility for this workload.",
+    }
+
+
+def test_related_decision_rejects_unknown_fields() -> None:
+    with pytest.raises(ValidationError):
+        RelatedDecision(
+            id="decision-042",
+            title="Use Postgres",
+            score=1.5,
+            status="active",
+            date="2026-01-01",
+            rationale_preview="x",
+            unexpected_field="value",
+        )
+
+
+def test_related_decision_is_frozen() -> None:
+    hit = RelatedDecision(
+        id="decision-042",
+        title="Use Postgres",
+        score=1.5,
+        status="active",
+        date="2026-01-01",
+        rationale_preview="x",
+    )
+    with pytest.raises(ValidationError):
+        hit.title = "Reassigned"

--- a/packages/nauro-core/tests/operations/test_store_protocol.py
+++ b/packages/nauro-core/tests/operations/test_store_protocol.py
@@ -1,0 +1,76 @@
+"""Kernel tests for the ``Store`` protocol and the in-memory test impl."""
+
+from __future__ import annotations
+
+from nauro_core.operations import InMemoryStore, Store
+
+
+def test_in_memory_store_satisfies_store_protocol() -> None:
+    """``@runtime_checkable`` lets isinstance verify the surface at runtime."""
+    store = InMemoryStore()
+    assert isinstance(store, Store)
+
+
+def test_read_file_returns_none_when_missing() -> None:
+    store = InMemoryStore()
+    assert store.read_file("does-not-exist.md") is None
+
+
+def test_write_then_read_round_trip() -> None:
+    store = InMemoryStore()
+    store.write_file("state_current.md", "# state\n")
+    assert store.read_file("state_current.md") == "# state\n"
+
+
+def test_write_overwrites_existing_content() -> None:
+    store = InMemoryStore(files={"state.md": "old"})
+    store.write_file("state.md", "new")
+    assert store.read_file("state.md") == "new"
+
+
+def test_delete_file_removes_content() -> None:
+    store = InMemoryStore(files={"state.md": "x"})
+    store.delete_file("state.md")
+    assert store.read_file("state.md") is None
+
+
+def test_delete_missing_file_is_noop() -> None:
+    store = InMemoryStore()
+    # Must not raise.
+    store.delete_file("never-existed.md")
+
+
+def test_list_decisions_returns_sorted_stems() -> None:
+    store = InMemoryStore(
+        decisions={
+            "003-third": "",
+            "001-first": "",
+            "002-second": "",
+        }
+    )
+    assert store.list_decisions() == ["001-first", "002-second", "003-third"]
+
+
+def test_list_decisions_empty_when_none_seeded() -> None:
+    store = InMemoryStore()
+    assert store.list_decisions() == []
+
+
+def test_read_decision_round_trip() -> None:
+    body = "---\ndate: 2026-01-01\nconfidence: medium\n---\n# 1. Title\n## Decision\nx\n"
+    store = InMemoryStore(decisions={"001-title": body})
+    assert store.read_decision("001-title") == body
+
+
+def test_read_decision_returns_none_when_missing() -> None:
+    store = InMemoryStore()
+    assert store.read_decision("042-nope") is None
+
+
+def test_decisions_and_files_are_independent_namespaces() -> None:
+    """Writing under a file path must not surface a decision stem, and vice versa."""
+    store = InMemoryStore(decisions={"001-only-a-decision": "body"})
+    store.write_file("001-only-a-decision", "file content")
+    assert store.list_decisions() == ["001-only-a-decision"]
+    assert store.read_decision("001-only-a-decision") == "body"
+    assert store.read_file("001-only-a-decision") == "file content"

--- a/packages/nauro/src/nauro/cli/commands/check.py
+++ b/packages/nauro/src/nauro/cli/commands/check.py
@@ -5,9 +5,9 @@ agent or developer with the ``nauro`` CLI installed can run conflict-detection
 in the current session without restarting their MCP client. The output is the
 same retrieval the MCP ``check_decision`` tool returns; nothing is written.
 
-CLI invocations skip the ``@mcp_tool`` decorator's telemetry side-effects by
-calling :func:`nauro.mcp.tools.compute_check_decision` directly — the Typer
-instrumentation already emits ``cli.command_invoked`` for every command.
+CLI invocations call the kernel operation directly so the ``@mcp_tool``
+decorator's ``mcp.tool_called`` event never fires from the CLI surface;
+the Typer instrumentation already emits ``cli.command_invoked``.
 """
 
 from __future__ import annotations
@@ -15,10 +15,12 @@ from __future__ import annotations
 import json
 
 import typer
+from nauro_core.operations import CheckDecisionResult, check_decision
 
 from nauro.cli.utils import resolve_target_project
 from nauro.constants import REPO_CONFIG_MODE_CLOUD
-from nauro.mcp.tools import compute_check_decision
+from nauro.onboarding import WELCOME_NO_PROJECT
+from nauro.store.filesystem_store import FilesystemStore
 from nauro.store.registry import RegistrySchemaError, get_project_v2
 
 
@@ -42,31 +44,27 @@ def _render_human(
     project_name: str,
     approach: str,
     store_path_str: str,
-    result: dict,
+    result: CheckDecisionResult,
 ) -> str:
     """Render the check_decision result as human-readable terminal output."""
     lines: list[str] = []
-    lines.append(f"store:    {result.get('store', 'local')}")
+    lines.append("store:    local")
     lines.append(f"project:  {project_name}")
     lines.append(f"approach: {approach}")
     lines.append("")
 
-    related = result.get("related_decisions", [])
-    if not related:
-        lines.append(result.get("assessment", "No related decisions found."))
+    if not result.related_decisions:
+        lines.append(result.assessment or "No related decisions found.")
         return "\n".join(lines)
 
-    lines.append(f"Related decisions ({len(related)}):")
-    for d in related:
-        did = d.get("id", "?")
-        title = d.get("title", "")
-        score = d.get("score", 0.0)
-        status = d.get("status", "")
-        date = d.get("date", "")
-        lines.append(f"  {did}  {title}  (score {score:.1f}, status {status}, decided {date})")
+    lines.append(f"Related decisions ({len(result.related_decisions)}):")
+    for d in result.related_decisions:
+        lines.append(
+            f"  {d.id}  {d.title}  (score {d.score:.1f}, status {d.status}, decided {d.date})"
+        )
 
     lines.append("")
-    lines.append(result.get("assessment", ""))
+    lines.append(result.assessment)
     lines.append("")
     lines.append(
         f"For full rationale, read decision files in {store_path_str}/decisions/, "
@@ -97,6 +95,20 @@ def check(
     """
     project_name, store_path = resolve_target_project(project)
 
+    # Missing store is a CLI-side concern: the operation expects a live Store,
+    # so we surface the onboarding hint before constructing one.
+    if not store_path.exists():
+        envelope = {
+            "store": "local",
+            "status": "error",
+            "guidance": WELCOME_NO_PROJECT,
+        }
+        if json_output:
+            typer.echo(json.dumps(envelope, indent=2))
+        else:
+            typer.echo(WELCOME_NO_PROJECT, err=True)
+        raise typer.Exit(code=1)
+
     # Cloud-mode notice. We always read local data; the warning goes to stderr
     # so --json output stays parseable.
     if _is_cloud_project(store_path.name):
@@ -106,24 +118,17 @@ def check(
             err=True,
         )
 
-    result = compute_check_decision(store_path, approach)
-    # Any non-empty status field is an error-shaped response from compute_check_decision
-    # (currently "error" for missing store, "rejected" for over-length input).
-    # Both human and JSON paths must exit 1 on those — a script piping --json
-    # and checking $? would otherwise silently treat input-too-long as success.
-    is_error = result.get("status") in ("error", "rejected")
+    result = check_decision(FilesystemStore(store_path), approach)
 
     if json_output:
-        typer.echo(json.dumps(result, indent=2))
-        if is_error:
+        envelope = {"store": "local", **result.model_dump(mode="json", exclude_none=True)}
+        typer.echo(json.dumps(envelope, indent=2))
+        if result.error is not None:
             raise typer.Exit(code=1)
         return
 
-    if result.get("status") == "error":
-        typer.echo(result.get("guidance", "Error"), err=True)
-        raise typer.Exit(code=1)
-    if result.get("status") == "rejected":
-        typer.echo(result.get("reason", "Rejected"), err=True)
+    if result.error is not None:
+        typer.echo(result.error.reason, err=True)
         raise typer.Exit(code=1)
 
     typer.echo(_render_human(project_name, approach, str(store_path), result))

--- a/packages/nauro/src/nauro/mcp/tools.py
+++ b/packages/nauro/src/nauro/mcp/tools.py
@@ -13,7 +13,6 @@ from pathlib import Path
 
 from nauro_core import extract_decision_number
 from nauro_core.constants import (
-    MAX_APPROACH_LENGTH,
     MAX_CONTEXT_LENGTH,
     MAX_DELTA_LENGTH,
     MAX_QUESTION_LENGTH,
@@ -22,6 +21,7 @@ from nauro_core.constants import (
     STATE_CURRENT_FILENAME,
 )
 from nauro_core.decision_model import DecisionStatus
+from nauro_core.operations import check_decision as _check_decision_op
 from nauro_core.protocol import (
     CHECK_DECISION_RETURNS,
     GET_DECISION_BEFORE_PROPOSING,
@@ -33,9 +33,9 @@ from nauro_core.validation import check_content_length, find_envelope_token
 from nauro.mcp.payloads import build_l0_payload, build_l1_payload, build_l2_payload
 from nauro.onboarding import (
     NO_CONTEXT_YET,
-    NO_DECISIONS_TO_CHECK,
     WELCOME_NO_PROJECT,
 )
+from nauro.store.filesystem_store import FilesystemStore
 from nauro.store.reader import (
     _list_decisions,
     resolve_decision_id,
@@ -291,94 +291,6 @@ def tool_confirm_decision(store_path: Path, confirm_id: str) -> dict:
     return response
 
 
-def compute_check_decision(
-    store_path: Path,
-    proposed_approach: str,
-    context: str | None = None,
-) -> dict:
-    """Compute the check_decision result without emitting MCP telemetry.
-
-    Same return shape as :func:`tool_check_decision`. Call this from non-MCP
-    contexts (e.g. the ``nauro check`` CLI command) where the ``@mcp_tool``
-    decorator's ``mcp.tool_called`` emission would be wrong — those surfaces
-    emit their own events (``cli.command_invoked`` via Typer instrumentation).
-    """
-    guidance = _check_store_exists(store_path)
-    if guidance:
-        return {"store": "local", "status": "error", "guidance": guidance}
-
-    for err in (
-        _reject_if_too_long(proposed_approach, "Proposed approach", MAX_APPROACH_LENGTH),
-        _reject_if_too_long(context or "", "Context", MAX_CONTEXT_LENGTH) if context else None,
-    ):
-        if err:
-            return err
-
-    if not _has_decisions(store_path):
-        return {
-            "store": "local",
-            "related_decisions": [],
-            "assessment": NO_DECISIONS_TO_CHECK,
-        }
-
-    pseudo_proposal = {
-        "title": proposed_approach[:100],
-        "rationale": proposed_approach + (f" {context}" if context else ""),
-    }
-
-    t2_action, similar_decisions = check_similarity(pseudo_proposal, store_path)
-
-    if t2_action == "auto_confirm" or not similar_decisions:
-        return {
-            "store": "local",
-            "related_decisions": [],
-            "assessment": "No related decisions found.",
-        }
-
-    # Map BM25 hits to full decision metadata (date, status).
-    all_decisions = _list_decisions(store_path)
-    by_id = {f"decision-{d.num:03d}": d for d in all_decisions}
-
-    related = []
-    for hit in similar_decisions:
-        did = hit.get("id", "")
-        decision = by_id.get(did)
-        canonical_id = resolve_decision_id(store_path, did) or did
-        related.append(
-            {
-                "id": canonical_id,
-                "title": hit.get("title", ""),
-                "score": hit.get("similarity", 0.0),
-                "status": decision.status.value if decision else "active",
-                "date": str(decision.date) if decision and decision.date else "",
-            }
-        )
-
-    # Deterministic assessment from BM25 facts.
-    top = related[0]
-    top_num = extract_decision_number(top["id"])
-    top_label = f"D{top_num:03d}" if top_num is not None else top["id"]
-    top_line = (
-        f'Top match: {top_label} "{top["title"]}"'
-        f" (status {top['status']}, decided {top['date']}, BM25 {top['score']:.1f})."
-    )
-
-    if len(related) == 1:
-        target = f"get_decision({top_num})" if top_num is not None else "get_decision"
-        assessment = f"{top_line} Call {target} before proposing."
-    else:
-        assessment = (
-            f"Found {len(related)} related decisions. {top_line}"
-            f" Call get_decision on each related decision before proposing."
-        )
-
-    return {
-        "store": "local",
-        "related_decisions": related,
-        "assessment": assessment,
-    }
-
-
 @mcp_tool("check_decision")
 def tool_check_decision(
     store_path: Path,
@@ -386,7 +298,12 @@ def tool_check_decision(
     context: str | None = None,
 ) -> dict:
     """Check for conflicts with existing decisions without writing anything."""
-    return compute_check_decision(store_path, proposed_approach, context)
+    guidance = _check_store_exists(store_path)
+    if guidance:
+        return {"store": "local", "status": "error", "guidance": guidance}
+
+    result = _check_decision_op(FilesystemStore(store_path), proposed_approach, context)
+    return {"store": "local", **result.model_dump(mode="json", exclude_none=True)}
 
 
 # Compose the agent-facing docstring from canonical fragments so the

--- a/packages/nauro/src/nauro/onboarding.py
+++ b/packages/nauro/src/nauro/onboarding.py
@@ -3,7 +3,14 @@
 These constants are returned when a user has no project store or when a
 project exists but has no decisions/snapshots yet.  They give the LLM
 enough context to guide the user toward a productive first experience.
+
+``NO_DECISIONS_TO_CHECK`` is the shared cross-surface string and lives in
+``nauro_core.constants`` so the same empty-store text reaches users on
+local and cloud transports. The re-export here preserves the import path
+existing callers use.
 """
+
+from nauro_core.constants import NO_DECISIONS_TO_CHECK as NO_DECISIONS_TO_CHECK
 
 WELCOME_NO_PROJECT = (
     "Welcome to Nauro! No project store found.\n"
@@ -28,14 +35,6 @@ NO_SNAPSHOTS_YET = (
     "\n"
     "Snapshots are created automatically when decisions are written "
     "or state is updated. Use propose_decision or update_state to get started."
-)
-
-NO_DECISIONS_TO_CHECK = (
-    "No existing decisions to check against.\n"
-    "\n"
-    "Use propose_decision to record your first architectural decision, "
-    "then check_decision can help verify new approaches against "
-    "your recorded decisions."
 )
 
 NO_CONTEXT_YET = (

--- a/packages/nauro/src/nauro/store/__init__.py
+++ b/packages/nauro/src/nauro/store/__init__.py
@@ -1,1 +1,5 @@
 """Project store package — all store operations go through this module."""
+
+from nauro.store.filesystem_store import FilesystemStore as FilesystemStore
+
+__all__ = ["FilesystemStore"]

--- a/packages/nauro/src/nauro/store/filesystem_store.py
+++ b/packages/nauro/src/nauro/store/filesystem_store.py
@@ -1,0 +1,60 @@
+"""Filesystem-backed ``Store`` implementation for the local CLI + stdio MCP.
+
+Adapts the existing ``~/.nauro/projects/<name>/`` layout to the kernel's
+:class:`~nauro_core.operations.Store` protocol. Writes hold a FileLock to
+match the rest of the local writer module; reads are unlocked.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from filelock import FileLock
+from nauro_core.constants import DECISIONS_DIR
+
+
+class FilesystemStore:
+    """Concrete ``Store`` rooted at a single project's on-disk directory.
+
+    Paths passed to :meth:`read_file` / :meth:`write_file` / :meth:`delete_file`
+    are interpreted relative to ``store_path``. Decision file enumeration goes
+    through :meth:`list_decisions`; a stem returned there can be read via
+    :meth:`read_decision` without re-deriving the canonical decisions
+    sub-directory.
+    """
+
+    def __init__(self, store_path: Path) -> None:
+        self._store_path = store_path
+
+    def read_file(self, path: str) -> str | None:
+        target = self._store_path / path
+        if not target.exists():
+            return None
+        return target.read_text()
+
+    # Sequential decision-file creation is owned by writer.py's existing FileLock
+    # contract; this Store's write_file targets non-decision content paths.
+    def write_file(self, path: str, content: str) -> None:
+        target = self._store_path / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        lock = target.with_name(target.name + ".lock")
+        with FileLock(str(lock)):
+            target.write_text(content)
+
+    def delete_file(self, path: str) -> None:
+        target = self._store_path / path
+        if not target.exists():
+            return
+        target.unlink()
+
+    def list_decisions(self) -> list[str]:
+        decisions_dir = self._store_path / DECISIONS_DIR
+        if not decisions_dir.exists():
+            return []
+        return sorted(f.stem for f in decisions_dir.glob("*.md"))
+
+    def read_decision(self, file_stem: str) -> str | None:
+        target = self._store_path / DECISIONS_DIR / f"{file_stem}.md"
+        if not target.exists():
+            return None
+        return target.read_text()

--- a/packages/nauro/tests/test_check_command.py
+++ b/packages/nauro/tests/test_check_command.py
@@ -5,8 +5,9 @@ Covers:
 - ``--json`` emits a parseable result with the same shape as the human path.
 - Project-resolution and store-state error paths exit non-zero with guidance.
 - Cloud-mode projects surface a "may be stale" notice on stderr.
-- The CLI does NOT emit ``mcp.tool_called`` telemetry (the helper-extraction
-  fix) — only the auto-instrumented ``cli.command_invoked`` event fires.
+- The CLI does NOT emit ``mcp.tool_called`` telemetry — it calls the kernel
+  operation directly so only the auto-instrumented ``cli.command_invoked``
+  event fires.
 """
 
 from __future__ import annotations
@@ -19,7 +20,6 @@ from typer.testing import CliRunner
 from nauro.cli.main import app
 from nauro.constants import REPO_CONFIG_MODE_CLOUD, REPO_CONFIG_MODE_LOCAL
 from nauro.demo import create_demo_project
-from nauro.mcp.tools import compute_check_decision, tool_check_decision
 from nauro.store.registry import register_project_v2
 from nauro.store.repo_config import save_repo_config
 from tests.conftest import seed_consented_config
@@ -52,9 +52,9 @@ def demo_repo(tmp_path, monkeypatch):
 def no_decisions_repo(tmp_path, monkeypatch):
     """Register a v2 project whose store has no decisions/ directory at all.
 
-    Hits the ``not _has_decisions(store_path)`` branch in compute_check_decision —
-    distinct from a scaffolded store (which seeds 001-initial-setup.md and
-    therefore has decisions).
+    Hits the empty-store branch in ``check_decision`` — distinct from a
+    scaffolded store (which seeds 001-initial-setup.md and therefore has
+    decisions).
     """
     repo = tmp_path / "repo"
     repo.mkdir()
@@ -64,23 +64,6 @@ def no_decisions_repo(tmp_path, monkeypatch):
     # scaffold_project_store so decisions/ never gets populated.
     monkeypatch.chdir(repo)
     return "bare-project", pid, store_path, repo
-
-
-# --- compute_check_decision (helper) preserves wrapper output -----------------
-
-
-def test_helper_and_wrapper_return_same_shape(demo_repo):
-    """compute_check_decision and tool_check_decision must return identical
-    dicts — the refactor that extracted the helper must not have drifted the
-    response shape that MCP callers depend on.
-    """
-    _, _, store_path, _ = demo_repo
-    helper = compute_check_decision(store_path, DEMO_PROMPT)
-    wrapper = tool_check_decision(store_path, DEMO_PROMPT)
-    assert helper == wrapper
-    assert helper["store"] == "local"
-    assert "related_decisions" in helper
-    assert "assessment" in helper
 
 
 # --- happy path: demo prompt retrieves the SSE-over-WebSocket decision ------
@@ -134,7 +117,7 @@ def test_no_project_resolution_errors(tmp_path, monkeypatch):
 
 def test_no_decisions_store_returns_no_decisions_message(no_decisions_repo):
     """A store with no decisions/ directory hits the NO_DECISIONS_TO_CHECK
-    branch in compute_check_decision and surfaces the onboarding hint."""
+    branch in the operation and surfaces the onboarding hint."""
     result = runner.invoke(app, ["check", DEMO_PROMPT])
     assert result.exit_code == 0, result.output
     # The NO_DECISIONS_TO_CHECK constant points the user at `nauro note`.
@@ -160,8 +143,10 @@ def test_rejected_status_exits_nonzero_json(demo_repo):
     result = runner.invoke(app, ["check", overlong, "--json"])
     assert result.exit_code == 1
     payload = json.loads(result.output)
-    assert payload["status"] == "rejected"
-    assert "reason" in payload
+    # Rejection envelope: structured error block, no top-level "status".
+    assert payload["error"]["kind"] == "rejected"
+    assert "reason" in payload["error"]
+    assert "status" not in payload
 
 
 # --- cloud-mode notice -------------------------------------------------------

--- a/packages/nauro/tests/test_check_decision_cross_surface.py
+++ b/packages/nauro/tests/test_check_decision_cross_surface.py
@@ -1,0 +1,162 @@
+"""Layer-3 cross-surface parity for ``check_decision``.
+
+The surface-level parity test (``test_check_decision_parity``) covers all
+three local adapters against the same ``FilesystemStore``. This file goes
+one layer deeper: the same kernel call against ``FilesystemStore`` and
+``mcp_server.store.cloud_store.CloudStore`` must produce the same
+:class:`CheckDecisionResult` for the same fixed inputs. That is the
+no-drift-by-construction guarantee D170 + D174 commit to.
+
+CloudStore lives in the private mcp-server repo and ships in the paired
+cross-repo cutover PR. When this test runs from inside the nauro
+workspace alone (CI for the public monorepo), ``mcp_server`` is not
+installed and the test skips at module load via ``pytest.importorskip``.
+Engineers who have both packages on a single ``PYTHONPATH`` exercise it
+locally to catch local-vs-cloud envelope drift before merge.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+cloud_store_module = pytest.importorskip(
+    "mcp_server.store.cloud_store",
+    reason="CloudStore is provided by the private mcp-server repo.",
+)
+boto3 = pytest.importorskip("boto3", reason="boto3 needed to seed a moto S3 bucket.")
+moto = pytest.importorskip("moto", reason="moto needed for in-memory S3.")
+
+# Imports below ``importorskip`` deliberately run only when both packages are
+# installed; ruff E402 does not apply here.
+from nauro_core.decision_model import (  # noqa: E402
+    Decision,
+    DecisionConfidence,
+    DecisionStatus,
+    format_decision,
+)
+from nauro_core.operations import check_decision  # noqa: E402
+
+from nauro.store.filesystem_store import FilesystemStore  # noqa: E402
+
+CloudStore = cloud_store_module.CloudStore
+
+TEST_BUCKET = "nauro-cross-surface-test"
+TEST_USER_ID = "01TEST" + "0" * 20
+TEST_PROJECT_ID = "01TESTPROJECT00000000000"
+
+PROPOSED_APPROACH = "Migrate primary storage to PostgreSQL"
+
+# Fixed seed: one active decision that should match the proposal, one
+# superseded decision that must not surface in the hits. The exact strings
+# are mirrored into both stores so retrieval inputs are identical by
+# construction; any envelope drift between the two surfaces is then a real
+# bug, not a fixture mismatch.
+SEED_DECISIONS: dict[str, str] = {
+    "001-adopt-postgresql": format_decision(
+        Decision(
+            num=1,
+            title="Adopt PostgreSQL",
+            rationale=(
+                "Use PostgreSQL for ACID transactional semantics across the "
+                "platform; replaces the original document-store plan."
+            ),
+            confidence=DecisionConfidence.high,
+            status=DecisionStatus.active,
+        )
+    ),
+    "002-adopt-mongo": format_decision(
+        Decision(
+            num=2,
+            title="Adopt MongoDB",
+            rationale=(
+                "Initial document-store choice for flexible schemas, later "
+                "superseded by PostgreSQL."
+            ),
+            confidence=DecisionConfidence.medium,
+            status=DecisionStatus.superseded,
+            superseded_by="1",
+        )
+    ),
+}
+
+
+def _seed_filesystem_store(root: Path) -> FilesystemStore:
+    decisions_dir = root / "decisions"
+    decisions_dir.mkdir(parents=True, exist_ok=True)
+    for stem, body in SEED_DECISIONS.items():
+        (decisions_dir / f"{stem}.md").write_text(body)
+    return FilesystemStore(root)
+
+
+def _seed_cloud_store(s3_client) -> CloudStore:
+    prefix = f"users/{TEST_USER_ID}/projects/{TEST_PROJECT_ID}"
+    for stem, body in SEED_DECISIONS.items():
+        s3_client.put_object(
+            Bucket=TEST_BUCKET,
+            Key=f"{prefix}/decisions/{stem}.md",
+            Body=body.encode(),
+        )
+    return CloudStore(user_id=TEST_USER_ID, project_id=TEST_PROJECT_ID)
+
+
+@pytest.fixture
+def both_stores(tmp_path, monkeypatch):
+    """Yield a (FilesystemStore, CloudStore) pair seeded with identical decisions.
+
+    The cloud half lives inside a moto-mocked S3 + an env-pointed bucket so
+    the test never touches AWS. ``NAURO_S3_BUCKET`` is monkey-patched onto
+    the environment because :class:`CloudStore` reads it lazily.
+    """
+    monkeypatch.setenv("NAURO_S3_BUCKET", TEST_BUCKET)
+
+    with moto.mock_aws():
+        s3_client = boto3.client("s3", region_name="us-east-1")
+        s3_client.create_bucket(Bucket=TEST_BUCKET)
+
+        fs_store = _seed_filesystem_store(tmp_path)
+        cloud = _seed_cloud_store(s3_client)
+        yield fs_store, cloud
+
+
+def test_check_decision_result_matches_across_stores(both_stores):
+    fs_store, cloud = both_stores
+
+    fs_result = check_decision(fs_store, PROPOSED_APPROACH)
+    cloud_result = check_decision(cloud, PROPOSED_APPROACH)
+
+    assert fs_result.model_dump(mode="json", exclude_none=True) == cloud_result.model_dump(
+        mode="json", exclude_none=True
+    )
+
+
+def test_active_decision_surfaces_in_both_stores(both_stores):
+    """Pins the contract: only D001 (active) surfaces; D002 (superseded) does not."""
+    fs_store, cloud = both_stores
+
+    fs_result = check_decision(fs_store, PROPOSED_APPROACH)
+    cloud_result = check_decision(cloud, PROPOSED_APPROACH)
+
+    for result in (fs_result, cloud_result):
+        assert result.error is None
+        ids = [hit.id for hit in result.related_decisions]
+        assert "decision-001" in ids
+        assert "decision-002" not in ids
+
+
+def test_rejection_envelope_matches_across_stores(both_stores):
+    """Over-length inputs produce the same ``error`` payload from each surface."""
+    from nauro_core.constants import MAX_APPROACH_LENGTH
+
+    fs_store, cloud = both_stores
+    overlong = "x" * (MAX_APPROACH_LENGTH + 1)
+
+    fs_result = check_decision(fs_store, overlong)
+    cloud_result = check_decision(cloud, overlong)
+
+    assert fs_result.model_dump(mode="json", exclude_none=True) == cloud_result.model_dump(
+        mode="json", exclude_none=True
+    )
+    assert fs_result.error is not None
+    assert fs_result.error.kind == "rejected"

--- a/packages/nauro/tests/test_check_decision_parity.py
+++ b/packages/nauro/tests/test_check_decision_parity.py
@@ -1,0 +1,126 @@
+"""Surface-level parity for the local ``check_decision`` adapters.
+
+After the kernel cutover, all three local surfaces (CLI ``nauro check``,
+local stdio MCP ``check_decision`` tool, FastAPI ``/check_decision``) must
+produce the same envelope for the same proposal against the same store.
+This file pins the envelope shape across the three adapter wirings; the
+cross-store layer-3 test (``test_check_decision_cross_surface``) covers
+local-vs-cloud parity once the cloud Store exists.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from typer.testing import CliRunner
+
+from nauro.cli.main import app as cli_app
+from nauro.constants import REPO_CONFIG_MODE_LOCAL
+from nauro.demo import create_demo_project
+from nauro.mcp.server import app as fastapi_app
+from nauro.mcp.stdio_server import check_decision as stdio_check_decision
+from nauro.mcp.tools import tool_check_decision
+from nauro.store.registry import register_project_v2
+from nauro.store.repo_config import save_repo_config
+
+DEMO_PROMPT = "Add a WebSocket endpoint for live task updates"
+
+
+@pytest.fixture
+def demo_repo(tmp_path, monkeypatch):
+    """Seed a demo project + chdir into the repo so cwd resolution wins."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    pid, store_path = register_project_v2("parity-project", [repo], mode=REPO_CONFIG_MODE_LOCAL)
+    save_repo_config(repo, {"mode": REPO_CONFIG_MODE_LOCAL, "id": pid, "name": "parity-project"})
+    create_demo_project(store_path)
+    monkeypatch.chdir(repo)
+    return pid, store_path
+
+
+def _cli_envelope(store_path: Path) -> dict:
+    runner = CliRunner()
+    result = runner.invoke(cli_app, ["check", DEMO_PROMPT, "--json"])
+    assert result.exit_code == 0, result.output
+    return json.loads(result.output)
+
+
+def _stdio_envelope(pid: str) -> dict:
+    return stdio_check_decision(proposed_approach=DEMO_PROMPT, project_id=pid)
+
+
+def _http_envelope(pid: str) -> dict:
+    client = TestClient(fastapi_app)
+    response = client.post(
+        "/check_decision",
+        json={"project_id": pid, "proposed_approach": DEMO_PROMPT},
+    )
+    assert response.status_code == 200, response.text
+    return response.json()
+
+
+def _tool_envelope(store_path: Path) -> dict:
+    """Direct call to the local tool, no transport wrapper."""
+    return tool_check_decision(store_path, DEMO_PROMPT)
+
+
+# --- happy path: all three surfaces produce the same envelope ---------------
+
+
+def test_cli_stdio_http_match_on_success_path(demo_repo):
+    pid, store_path = demo_repo
+    cli = _cli_envelope(store_path)
+    stdio = _stdio_envelope(pid)
+    http = _http_envelope(pid)
+    tool = _tool_envelope(store_path)
+    assert cli == stdio == http == tool
+
+
+def test_success_envelope_contains_d141_canonical_fields(demo_repo):
+    pid, _ = demo_repo
+    envelope = _stdio_envelope(pid)
+    assert envelope["store"] == "local"
+    assert "related_decisions" in envelope
+    assert "assessment" in envelope
+    # ``error`` field is omitted on the success path (exclude_none).
+    assert "error" not in envelope
+    # Each related decision carries the canonical id/title/score/status/date/preview.
+    for hit in envelope["related_decisions"]:
+        for key in ("id", "title", "score", "status", "date", "rationale_preview"):
+            assert key in hit, f"missing canonical field {key!r} in hit {hit!r}"
+
+
+# --- rejection: all three surfaces share the same error envelope ------------
+
+
+def test_rejection_envelope_matches_across_surfaces(demo_repo):
+    pid, store_path = demo_repo
+    overlong = "x" * 10_000
+
+    runner = CliRunner()
+    cli_raw = runner.invoke(cli_app, ["check", overlong, "--json"])
+    assert cli_raw.exit_code == 1, cli_raw.output
+    cli = json.loads(cli_raw.output)
+
+    stdio = stdio_check_decision(proposed_approach=overlong, project_id=pid)
+
+    client = TestClient(fastapi_app)
+    response = client.post(
+        "/check_decision",
+        json={"project_id": pid, "proposed_approach": overlong},
+    )
+    assert response.status_code == 200, response.text
+    http = response.json()
+
+    tool = tool_check_decision(store_path, overlong)
+
+    assert cli == stdio == http == tool
+    # Locked rejection envelope shape (closes D141 for this operation).
+    assert cli["store"] == "local"
+    assert cli["related_decisions"] == []
+    assert cli["assessment"] == ""
+    assert cli["error"]["kind"] == "rejected"
+    assert "exceeds" in cli["error"]["reason"].lower()

--- a/packages/nauro/tests/test_empty_states.py
+++ b/packages/nauro/tests/test_empty_states.py
@@ -59,6 +59,8 @@ class TestNoStore:
         assert "nauro init" in result["guidance"]
 
     def test_check_decision_returns_guidance(self, nonexistent_store):
+        # Missing-store path is the transport's responsibility — the kernel
+        # operation never sees this case, so the legacy envelope shape stays.
         result = tool_check_decision(nonexistent_store, "Use Redis")
         assert result["status"] == "error"
         assert "nauro init" in result["guidance"]

--- a/packages/nauro/tests/test_stdio_server.py
+++ b/packages/nauro/tests/test_stdio_server.py
@@ -504,11 +504,16 @@ class TestContentSizeLimits:
         assert f"{MAX_DELTA_LENGTH}" in result["reason"]
 
     def test_check_decision_approach_over_limit(self, store: Path):
-        from nauro.mcp.tools import MAX_APPROACH_LENGTH, tool_check_decision
+        from nauro_core.constants import MAX_APPROACH_LENGTH
+
+        from nauro.mcp.tools import tool_check_decision
 
         result = tool_check_decision(store, "A" * (MAX_APPROACH_LENGTH + 1))
-        assert result["status"] == "rejected"
-        assert f"{MAX_APPROACH_LENGTH}" in result["reason"]
+        # Rejection envelope: structured error, related_decisions stay empty.
+        assert result["related_decisions"] == []
+        assert result["assessment"] == ""
+        assert result["error"]["kind"] == "rejected"
+        assert f"{MAX_APPROACH_LENGTH}" in result["error"]["reason"]
 
 
 class TestPullOnStartup:

--- a/packages/nauro/tests/test_validation/test_mcp_validation.py
+++ b/packages/nauro/tests/test_validation/test_mcp_validation.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 from httpx import ASGITransport, AsyncClient
+from nauro_core.constants import NO_DECISIONS_TO_CHECK
 
 from nauro.mcp.server import app
 from nauro.templates.scaffolds import scaffold_project_store
@@ -89,7 +90,13 @@ async def test_confirm_decision_invalid_id(client):
 
 @pytest.mark.asyncio
 async def test_check_decision_no_matches(client):
-    """Checking an approach with no related decisions."""
+    """Checking an approach against a scaffold-only store.
+
+    The scaffold-seeded "Initial project setup" decision is excluded from
+    retrieval (mirrors tier-2 validation), so a fresh store with only that
+    seed flows into the empty-state branch with the ``NO_DECISIONS_TO_CHECK``
+    onboarding assessment.
+    """
     resp = await client.post(
         "/check_decision",
         json={
@@ -100,7 +107,7 @@ async def test_check_decision_no_matches(client):
     assert resp.status_code == 200
     data = resp.json()
     assert data["related_decisions"] == []
-    assert data["assessment"] == "No related decisions found."
+    assert data["assessment"] == NO_DECISIONS_TO_CHECK
     assert "potential_conflicts" not in data
 
 


### PR DESCRIPTION
## Why

`check_decision` was carrying duplicated logic across two surfaces (local stdio MCP + cloud HTTP MCP). Per D170 / D172 / D174 / D175, cross-transport operations should live in `nauro_core` as pure callables over a `Store` protocol so every transport gets the same retrieval, ranking, and assessment by construction — and so we close D141 (cross-store `check_decision` shape unification) instead of letting it drift further.

## Approach

A two-step landing on this branch:

The earlier commit on this branch lands the `Store` protocol + `Result` module shell in `nauro_core.operations`. The protocol carries five primitives (`read_file`, `write_file`, `delete_file`, `list_decisions`, `read_decision`), is `@runtime_checkable`, and uses stdlib generics only (no Pydantic in the protocol body). `InMemoryStore` is the kernel-level test double; `RelatedDecision` is the shared retrieval-hit Pydantic model.

The second commit cuts `check_decision` over to the kernel. `nauro_core.operations.check_decision` is the pure callable; the local stdio `tool_check_decision` and the CLI `nauro check` both construct a `FilesystemStore` and call it. The cloud HTTP transport rewires in the paired cross-repo PR.

Alternatives considered: continuing opportunistic `nauro_core` extraction with parity tests against the existing wrapper shape. Rejected because the wrapper drift bug class (D134, D139) is exactly what this restructure prevents — extracting the lock-by-construction is cheaper now than re-deriving the same fix every time a tool ships.

## What changed

- **`nauro_core.operations`** — new module. `Store` protocol, `InMemoryStore`, `check_decision` operation, `CheckDecisionResult` + `ErrorPayload` Pydantic models. `NO_DECISIONS_TO_CHECK` moved to `nauro_core.constants` so the local and cloud surfaces cannot drift on the empty-state copy.
- **`packages/nauro/src/nauro/store/filesystem_store.py`** — new `FilesystemStore` adapter wrapping the existing `~/.nauro/projects/<name>/` layout. FileLock on writes, unlocked reads.
- **`tool_check_decision`** — collapsed from ~90 lines to a thin adapter that constructs a `FilesystemStore`, calls the kernel, and tacks on `{\"store\": \"local\"}`. `compute_check_decision` deleted; `_has_decisions` kept (still used by `tool_get_context`'s builder).
- **`nauro check` CLI** — reads typed `CheckDecisionResult` attributes; `exit_code == 1` iff `result.error`.
- **Tests** — kernel-level coverage against `InMemoryStore` (12 contract tests + 3 curation tests added in this iteration), surface-level parity across CLI + stdio MCP + FastAPI + direct tool call, layer-3 cross-surface test that skips when `mcp_server` is not installed.

## What to review

- The missing-store envelope (`{store, status: 'error', guidance}`) is deliberately retained at the transport boundary; only the length-rejection envelope changes shape.
- The kernel preserves the prior `compute_check_decision` curation (scaffold-seed exclusion, extended stopword set including `\"use\"`, 100/200 query truncation). Rationale per D175's no-behavior-change-on-success bar; original justifications live as block comments in `nauro_core/validation.py:20-51`.
- `test_check_decision_no_matches` in `test_mcp_validation.py` now asserts `NO_DECISIONS_TO_CHECK` instead of `\"No related decisions found.\"` because the scaffold-seed filter now runs before the empty-check, so a scaffold-only store collapses to the empty-state envelope. Behavior is still success-path; the change is the assessment string only.
- Rejection wire-shape: `{store, status: \"rejected\", reason}` → `{store, related_decisions: [], assessment: \"\", error: {kind, reason}}`. Success path is unchanged for callers that already read `related_decisions` and `assessment` from the envelope.

## What's deferred

- Cloud HTTP transport rewires in the paired cross-repo PR against `mcp-server` (separate private repo, separate release cadence per [[feedback_lambda_requirements_in_sync]]).
- `nauro-core` release cut to 0.10.0 is a follow-up PR after this stabilizes; `mcp-server`'s `<0.10` cap shifts to `<0.11` then.
- `tool_flag_question` still calls `check_similarity` for its duplicate-question hint; when that tool's cutover lands later in the rollout, the same three curations must ride along. Risk captured in the restructure plan.

## Test plan

- `uv run ruff format --check packages/` — 170 files already formatted.
- `uv run ruff check packages/` — all checks passed.
- `uv run pytest packages/nauro-core/tests/ packages/nauro/tests/ -q` — 1373 passed, 1 skipped (cross-surface test skips when `mcp_server` is not installed, expected).
- Coverage added in this PR: 12 kernel-level contract tests in `tests/operations/test_check_decision.py` + 3 curation regression tests (scaffold-seed exclusion, `"use"` stopword, 100/200 truncation) + 4 surface-level parity assertions in `tests/test_check_decision_parity.py`.

Refs: D141, D170, D171, D172, D174, D175.