### PR TITLE
chore(release): prep nauro-core 0.10.0 and nauro 0.7.0

### DIFF
--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro-core"
-version = "0.9.0"
+version = "0.10.0"
 description = "Shared pure-Python logic for Nauro: parsing, validation, context assembly, constants."
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro"
-version = "0.6.0"
+version = "0.7.0"
 description = "Local CLI + MCP server: set your project's doctrine once, every connected AI agent inherits it."
 readme = "README.md"
 license = "Apache-2.0"
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "nauro-core>=0.9.0,<0.10",
+    "nauro-core>=0.10.0,<0.11",
     "typer>=0.9",
     "fastapi>=0.100",
     "uvicorn>=0.23",


### PR DESCRIPTION
Minor bumps under pre-1.0 semver.

nauro-core 0.9.0 → 0.10.0. Highlights since nauro-core-v0.9.0:
- #94 — Cross-transport operations kernel introduced. New `nauro_core.operations` module shipping the `Store` protocol (5 named primitives: `read_file`, `write_file`, `delete_file`, `list_decisions`, `read_decision`), `InMemoryStore`, the `check_decision` operation, `CheckDecisionResult` + `ErrorPayload` Pydantic models. `NO_DECISIONS_TO_CHECK` moved into `nauro_core.constants` so local and cloud surfaces share the empty-state copy. Closes D141 (cross-store check_decision shape unification) for the first operation; subsequent operations cut over per D175.

nauro 0.6.0 → 0.7.0, with the dependency cap moved to nauro-core>=0.10.0,<0.11. Highlights since nauro-v0.6.0:
- #94 — `tool_check_decision` collapsed to a thin adapter over the kernel; CLI `nauro check` reads typed `CheckDecisionResult` attributes; new `FilesystemStore` in `nauro/store/`; surface-level + layer-3 cross-surface parity tests added.

Refs: D170, D171, D172, D174, D175, D141.
