### PR TITLE
feat(operations): cut get_decision over to nauro_core kernel

### DIFF
--- a/packages/nauro-core/src/nauro_core/operations/__init__.py
+++ b/packages/nauro-core/src/nauro_core/operations/__init__.py
@@ -8,15 +8,19 @@ emit no telemetry; transports own event emission.
 
 from nauro_core.operations._in_memory_store import InMemoryStore as InMemoryStore
 from nauro_core.operations.check_decision import check_decision as check_decision
+from nauro_core.operations.get_decision import get_decision as get_decision
 from nauro_core.operations.results import CheckDecisionResult as CheckDecisionResult
+from nauro_core.operations.results import GetDecisionResult as GetDecisionResult
 from nauro_core.operations.store import Store as Store
 
 from . import results as results
 
 __all__ = [
     "CheckDecisionResult",
+    "GetDecisionResult",
     "InMemoryStore",
     "Store",
     "check_decision",
+    "get_decision",
     "results",
 ]

--- a/packages/nauro-core/src/nauro_core/operations/get_decision.py
+++ b/packages/nauro-core/src/nauro_core/operations/get_decision.py
@@ -1,0 +1,43 @@
+"""``get_decision`` — return the full body of a decision by number.
+
+Cross-transport implementation: CLI, local stdio MCP, and remote HTTP MCP
+all call this function with the same arguments and receive the same
+:class:`GetDecisionResult`. Each transport's adapter wraps the call to
+add transport-specific framing (``store`` field, telemetry emission);
+the lookup itself is shared by construction.
+"""
+
+from __future__ import annotations
+
+from nauro_core.operations.results import ErrorPayload, GetDecisionResult
+from nauro_core.operations.store import Store
+from nauro_core.parsing import extract_decision_number
+
+
+def get_decision(store: Store, number: int) -> GetDecisionResult:
+    """Return the decision body matching ``number``, or a not-found error.
+
+    Status filtering (active vs superseded) belongs to ``list_decisions``;
+    ``get_decision`` resolves the exact number regardless of status so
+    callers can still inspect the rationale of a superseded decision.
+
+    Args:
+        store: Storage adapter providing ``list_decisions`` / ``read_decision``.
+        number: Decision number to resolve. Matched against the leading
+            integer of each decision stem via
+            :func:`nauro_core.parsing.extract_decision_number`.
+
+    Returns:
+        :class:`GetDecisionResult`. On a hit ``content`` holds the markdown
+        body. On a miss ``error`` is populated with ``kind="error"`` and a
+        reason that names the number.
+    """
+    for stem in store.list_decisions():
+        parsed = extract_decision_number(stem)
+        if parsed is not None and parsed == number:
+            body = store.read_decision(stem)
+            if body is not None:
+                return GetDecisionResult(content=body)
+    return GetDecisionResult(
+        error=ErrorPayload(kind="error", reason=f"Decision {number} not found"),
+    )

--- a/packages/nauro-core/src/nauro_core/operations/results.py
+++ b/packages/nauro-core/src/nauro_core/operations/results.py
@@ -63,3 +63,18 @@ class CheckDecisionResult(BaseModel):
     related_decisions: list[RelatedDecision] = Field(default_factory=list)
     assessment: str = ""
     error: ErrorPayload | None = None
+
+
+class GetDecisionResult(BaseModel):
+    """Return shape for :func:`nauro_core.operations.get_decision`.
+
+    On the success path ``content`` holds the decision's markdown body.
+    On the miss path ``error`` is populated with ``kind="error"``; the
+    ``store`` field is not part of the model and is added by transport
+    adapters at serialization time.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    content: str | None = None
+    error: ErrorPayload | None = None

--- a/packages/nauro-core/tests/operations/test_get_decision.py
+++ b/packages/nauro-core/tests/operations/test_get_decision.py
@@ -1,0 +1,125 @@
+"""Kernel-level tests for ``operations.get_decision`` against ``InMemoryStore``.
+
+Each test seeds an ``InMemoryStore`` and asserts on the typed
+:class:`GetDecisionResult` directly. Surface-level wiring tests live in
+each transport's own suite.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+from nauro_core.decision_model import (
+    Decision,
+    DecisionConfidence,
+    DecisionStatus,
+    format_decision,
+)
+from nauro_core.operations import (
+    GetDecisionResult,
+    InMemoryStore,
+    get_decision,
+)
+
+
+def _seed_decision(
+    num: int,
+    title: str,
+    rationale: str,
+    *,
+    status: DecisionStatus = DecisionStatus.active,
+    stem: str | None = None,
+) -> tuple[str, str]:
+    """Return (file_stem, formatted_markdown) for a minimal v2 decision."""
+    superseded_by = "999" if status is DecisionStatus.superseded else None
+    decision = Decision(
+        date=date(2026, 1, 1),
+        confidence=DecisionConfidence.medium,
+        status=status,
+        superseded_by=superseded_by,
+        num=num,
+        title=title,
+        rationale=rationale,
+    )
+    if stem is None:
+        slug = title.lower().replace(" ", "-")
+        stem = f"{num:03d}-{slug}"
+    return stem, format_decision(decision)
+
+
+def _store_with(*decisions: tuple[str, str]) -> InMemoryStore:
+    return InMemoryStore(decisions=dict(decisions))
+
+
+def test_returns_result_type() -> None:
+    result = get_decision(InMemoryStore(), 1)
+    assert isinstance(result, GetDecisionResult)
+
+
+def test_empty_store_returns_not_found_error() -> None:
+    result = get_decision(InMemoryStore(), 1)
+    assert result.content is None
+    assert result.error is not None
+    assert result.error.kind == "error"
+    assert "1" in result.error.reason
+
+
+def test_existing_decision_returns_full_content() -> None:
+    stem, body = _seed_decision(7, "Adopt Redis", "Use Redis for session cache.")
+    store = _store_with((stem, body))
+    result = get_decision(store, 7)
+    assert result.error is None
+    assert result.content == body
+
+
+def test_missing_number_returns_error_with_reason_naming_number() -> None:
+    stem, body = _seed_decision(7, "Adopt Redis", "Use Redis for session cache.")
+    store = _store_with((stem, body))
+    result = get_decision(store, 42)
+    assert result.content is None
+    assert result.error is not None
+    assert result.error.kind == "error"
+    assert "42" in result.error.reason
+    assert result.error.reason == "Decision 42 not found"
+
+
+def test_number_resolves_from_stem_at_various_pad_widths() -> None:
+    """``extract_decision_number`` accepts both unpadded and padded stems."""
+    stem_5 = "5-short"
+    stem_42 = "42-medium"
+    stem_170 = "170-padded"
+    _, body_5 = _seed_decision(5, "Short", "Test", stem=stem_5)
+    _, body_42 = _seed_decision(42, "Medium", "Test", stem=stem_42)
+    _, body_170 = _seed_decision(170, "Padded", "Test", stem=stem_170)
+    store = _store_with((stem_5, body_5), (stem_42, body_42), (stem_170, body_170))
+
+    for number, expected_body in ((5, body_5), (42, body_42), (170, body_170)):
+        result = get_decision(store, number)
+        assert result.error is None, f"unexpected miss for D{number}"
+        assert result.content == expected_body
+
+
+def test_superseded_decisions_still_resolve() -> None:
+    """Status filtering belongs to ``list_decisions``, not ``get_decision``.
+
+    A caller asking for a specific number must always receive the body
+    when it exists — even if the decision was later superseded — so the
+    rationale stays inspectable.
+    """
+    stem, body = _seed_decision(
+        9,
+        "Adopt REST endpoints",
+        "Initial transport choice, later replaced by gRPC.",
+        status=DecisionStatus.superseded,
+    )
+    store = _store_with((stem, body))
+    result = get_decision(store, 9)
+    assert result.error is None
+    assert result.content == body
+
+
+def test_store_field_absent_from_result_model_dump() -> None:
+    """Transports own the ``store`` field; the kernel never emits it."""
+    result = get_decision(InMemoryStore(), 1)
+    dumped = result.model_dump(mode="json")
+    assert "store" not in dumped

--- a/packages/nauro-core/tests/operations/test_results.py
+++ b/packages/nauro-core/tests/operations/test_results.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
-from nauro_core.operations.results import RelatedDecision
+from nauro_core.operations.results import ErrorPayload, GetDecisionResult, RelatedDecision
 
 
 def test_related_decision_model_dump_shape() -> None:
@@ -52,3 +52,38 @@ def test_related_decision_is_frozen() -> None:
     )
     with pytest.raises(ValidationError):
         hit.title = "Reassigned"
+
+
+def test_get_decision_result_success_with_content() -> None:
+    result = GetDecisionResult(content="# Decision body\n")
+    assert result.content == "# Decision body\n"
+    assert result.error is None
+
+
+def test_get_decision_result_error_with_payload() -> None:
+    result = GetDecisionResult(error=ErrorPayload(kind="error", reason="Decision 42 not found"))
+    assert result.content is None
+    assert result.error is not None
+    assert result.error.kind == "error"
+    assert result.error.reason == "Decision 42 not found"
+
+
+def test_get_decision_result_exclude_none_strips_empties() -> None:
+    success = GetDecisionResult(content="body")
+    assert success.model_dump(mode="json", exclude_none=True) == {"content": "body"}
+
+    miss = GetDecisionResult(error=ErrorPayload(kind="error", reason="Decision 1 not found"))
+    assert miss.model_dump(mode="json", exclude_none=True) == {
+        "error": {"kind": "error", "reason": "Decision 1 not found"},
+    }
+
+
+def test_get_decision_result_rejects_unknown_fields() -> None:
+    with pytest.raises(ValidationError):
+        GetDecisionResult(content="body", unexpected_field="value")
+
+
+def test_get_decision_result_is_frozen() -> None:
+    result = GetDecisionResult(content="body")
+    with pytest.raises(ValidationError):
+        result.content = "reassigned"

--- a/packages/nauro/src/nauro/mcp/tools.py
+++ b/packages/nauro/src/nauro/mcp/tools.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
-from nauro_core import extract_decision_number
 from nauro_core.constants import (
     MAX_CONTEXT_LENGTH,
     MAX_DELTA_LENGTH,
@@ -22,6 +21,7 @@ from nauro_core.constants import (
 )
 from nauro_core.decision_model import DecisionStatus
 from nauro_core.operations import check_decision as _check_decision_op
+from nauro_core.operations import get_decision as _get_decision_op
 from nauro_core.protocol import (
     CHECK_DECISION_RETURNS,
     GET_DECISION_BEFORE_PROPOSING,
@@ -432,13 +432,8 @@ def tool_get_decision(store_path: Path, number: int) -> dict:
     guidance = _check_store_exists(store_path)
     if guidance:
         return {"store": "local", "status": "error", "guidance": guidance}
-    decisions_dir = store_path / "decisions"
-    if decisions_dir.exists():
-        for f in sorted(decisions_dir.glob("*.md")):
-            n = extract_decision_number(f.name)
-            if n is not None and n == number:
-                return {"store": "local", "content": f.read_text()}
-    return {"store": "local", "error": f"Decision {number} not found"}
+    result = _get_decision_op(FilesystemStore(store_path), number)
+    return {"store": "local", **result.model_dump(mode="json", exclude_none=True)}
 
 
 @mcp_tool("diff_since_last_session")

--- a/packages/nauro/tests/test_get_decision_cross_surface.py
+++ b/packages/nauro/tests/test_get_decision_cross_surface.py
@@ -1,0 +1,136 @@
+"""Layer-3 cross-surface parity for ``get_decision``.
+
+The surface-level parity test (``test_get_decision_parity``) covers the
+local adapters against the same ``FilesystemStore``. This file goes one
+layer deeper: the same kernel call against ``FilesystemStore`` and
+``mcp_server.store.cloud_store.CloudStore`` must produce the same
+:class:`GetDecisionResult` for the same fixed inputs. That is the
+no-drift-by-construction guarantee the operations-kernel doctrine
+commits to.
+
+CloudStore lives in the private mcp-server repo and ships in the paired
+cross-repo cutover PR. When this test runs from inside the nauro
+workspace alone (CI for the public monorepo), ``mcp_server`` is not
+installed and the test skips at module load via ``pytest.importorskip``.
+Engineers who have both packages on a single ``PYTHONPATH`` exercise it
+locally to catch local-vs-cloud envelope drift before merge.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+cloud_store_module = pytest.importorskip(
+    "mcp_server.store.cloud_store",
+    reason="CloudStore is provided by the private mcp-server repo.",
+)
+boto3 = pytest.importorskip("boto3", reason="boto3 needed to seed a moto S3 bucket.")
+moto = pytest.importorskip("moto", reason="moto needed for in-memory S3.")
+
+# Imports below ``importorskip`` deliberately run only when both packages are
+# installed; ruff E402 does not apply here.
+from nauro_core.decision_model import (  # noqa: E402
+    Decision,
+    DecisionConfidence,
+    DecisionStatus,
+    format_decision,
+)
+from nauro_core.operations import get_decision  # noqa: E402
+
+from nauro.store.filesystem_store import FilesystemStore  # noqa: E402
+
+CloudStore = cloud_store_module.CloudStore
+
+TEST_BUCKET = "nauro-cross-surface-test"
+TEST_USER_ID = "01TEST" + "0" * 20
+TEST_PROJECT_ID = "01TESTPROJECT00000000000"
+
+EXISTING_NUMBER = 1
+MISSING_NUMBER = 999
+
+# Fixed seed: a single active decision so both stores resolve number 1 to
+# the same body. The exact strings are mirrored into both stores so the
+# input envelope is identical by construction; any envelope drift between
+# the two surfaces is then a real bug, not a fixture mismatch.
+SEED_DECISIONS: dict[str, str] = {
+    "001-adopt-postgresql": format_decision(
+        Decision(
+            num=1,
+            title="Adopt PostgreSQL",
+            rationale=(
+                "Use PostgreSQL for ACID transactional semantics across the "
+                "platform; replaces the original document-store plan."
+            ),
+            confidence=DecisionConfidence.high,
+            status=DecisionStatus.active,
+        )
+    ),
+}
+
+
+def _seed_filesystem_store(root: Path) -> FilesystemStore:
+    decisions_dir = root / "decisions"
+    decisions_dir.mkdir(parents=True, exist_ok=True)
+    for stem, body in SEED_DECISIONS.items():
+        (decisions_dir / f"{stem}.md").write_text(body)
+    return FilesystemStore(root)
+
+
+def _seed_cloud_store(s3_client) -> CloudStore:
+    prefix = f"users/{TEST_USER_ID}/projects/{TEST_PROJECT_ID}"
+    for stem, body in SEED_DECISIONS.items():
+        s3_client.put_object(
+            Bucket=TEST_BUCKET,
+            Key=f"{prefix}/decisions/{stem}.md",
+            Body=body.encode(),
+        )
+    return CloudStore(user_id=TEST_USER_ID, project_id=TEST_PROJECT_ID)
+
+
+@pytest.fixture
+def both_stores(tmp_path, monkeypatch):
+    """Yield a (FilesystemStore, CloudStore) pair seeded with identical decisions.
+
+    The cloud half lives inside a moto-mocked S3 + an env-pointed bucket so
+    the test never touches AWS. ``NAURO_S3_BUCKET`` is monkey-patched onto
+    the environment because :class:`CloudStore` reads it lazily.
+    """
+    monkeypatch.setenv("NAURO_S3_BUCKET", TEST_BUCKET)
+
+    with moto.mock_aws():
+        s3_client = boto3.client("s3", region_name="us-east-1")
+        s3_client.create_bucket(Bucket=TEST_BUCKET)
+
+        fs_store = _seed_filesystem_store(tmp_path)
+        cloud = _seed_cloud_store(s3_client)
+        yield fs_store, cloud
+
+
+def test_get_decision_result_matches_across_stores_on_hit(both_stores):
+    fs_store, cloud = both_stores
+
+    fs_result = get_decision(fs_store, EXISTING_NUMBER)
+    cloud_result = get_decision(cloud, EXISTING_NUMBER)
+
+    assert fs_result.model_dump(mode="json", exclude_none=True) == cloud_result.model_dump(
+        mode="json", exclude_none=True
+    )
+    assert fs_result.error is None
+    assert fs_result.content is not None
+
+
+def test_get_decision_result_matches_across_stores_on_miss(both_stores):
+    fs_store, cloud = both_stores
+
+    fs_result = get_decision(fs_store, MISSING_NUMBER)
+    cloud_result = get_decision(cloud, MISSING_NUMBER)
+
+    assert fs_result.model_dump(mode="json", exclude_none=True) == cloud_result.model_dump(
+        mode="json", exclude_none=True
+    )
+    assert fs_result.content is None
+    assert fs_result.error is not None
+    assert fs_result.error.kind == "error"
+    assert str(MISSING_NUMBER) in fs_result.error.reason

--- a/packages/nauro/tests/test_get_decision_parity.py
+++ b/packages/nauro/tests/test_get_decision_parity.py
@@ -1,0 +1,84 @@
+"""Surface-level parity for the local ``get_decision`` adapters.
+
+After the kernel cutover, every local surface that exposes
+``get_decision`` must produce the same envelope for the same number
+against the same store. This file pins that envelope shape across the
+two adapter wirings that exist today.
+
+Two compressions vs. the ``check_decision`` parity test:
+
+* No CLI surface. There is no ``nauro get-decision`` command. Auto-gen
+  of ``nauro tool <name>`` from MCP ToolSpecs is deferred; adding a
+  hand-written CLI mirror now would be speculative.
+* No FastAPI surface. The local server does not expose a
+  ``/get_decision`` endpoint. Adding one purely to mirror the parity
+  shape would be speculative infrastructure; the cross-store layer-3
+  test (``test_get_decision_cross_surface``) covers local-vs-cloud
+  parity once the cloud Store exists.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nauro.constants import REPO_CONFIG_MODE_LOCAL
+from nauro.demo import create_demo_project
+from nauro.mcp.stdio_server import get_decision as stdio_get_decision
+from nauro.mcp.tools import tool_get_decision
+from nauro.store.registry import register_project_v2
+from nauro.store.repo_config import save_repo_config
+
+EXISTING_NUMBER = 4
+MISSING_NUMBER = 999
+
+
+@pytest.fixture
+def demo_repo(tmp_path, monkeypatch):
+    """Seed a demo project + chdir into the repo so cwd resolution wins."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    pid, store_path = register_project_v2("parity-project", [repo], mode=REPO_CONFIG_MODE_LOCAL)
+    save_repo_config(repo, {"mode": REPO_CONFIG_MODE_LOCAL, "id": pid, "name": "parity-project"})
+    create_demo_project(store_path)
+    monkeypatch.chdir(repo)
+    return pid, store_path
+
+
+def _stdio_envelope(pid: str, number: int) -> dict:
+    return stdio_get_decision(number=number, project_id=pid)
+
+
+def _tool_envelope(store_path: Path, number: int) -> dict:
+    """Direct call to the local tool, no transport wrapper."""
+    return tool_get_decision(store_path, number)
+
+
+def test_stdio_and_tool_match_on_success_path(demo_repo):
+    pid, store_path = demo_repo
+    stdio = _stdio_envelope(pid, EXISTING_NUMBER)
+    tool = _tool_envelope(store_path, EXISTING_NUMBER)
+    assert stdio == tool
+
+
+def test_success_envelope_carries_content(demo_repo):
+    pid, _ = demo_repo
+    envelope = _stdio_envelope(pid, EXISTING_NUMBER)
+    assert envelope["store"] == "local"
+    assert "content" in envelope
+    assert envelope["content"]
+    # ``error`` field is omitted on the success path (exclude_none).
+    assert "error" not in envelope
+
+
+def test_not_found_envelope_matches_across_surfaces(demo_repo):
+    pid, store_path = demo_repo
+    stdio = _stdio_envelope(pid, MISSING_NUMBER)
+    tool = _tool_envelope(store_path, MISSING_NUMBER)
+    assert stdio == tool
+    # Locked rejection envelope shape.
+    assert stdio["store"] == "local"
+    assert "content" not in stdio
+    assert stdio["error"]["kind"] == "error"
+    assert str(MISSING_NUMBER) in stdio["error"]["reason"]


### PR DESCRIPTION
## Why

Second operation in the operations-kernel restructure. The previous local `tool_get_decision` body globbed `decisions/*.md`, parsed each filename with `extract_decision_number`, and emitted a hand-rolled `{"store", "error": "Decision N not found"}` envelope on miss. Cloud's HTTP MCP carried a near-identical but subtly different implementation. PR 1 cut `check_decision` over to the shared kernel; this PR does the same for `get_decision`, reducing the surface to one shared implementation.

## Approach

Add `get_decision` as a pure callable in `nauro_core.operations`. It takes a `Store` (the locked five-method Protocol from PR 1) plus the requested number, iterates `store.list_decisions()`, resolves each stem via `extract_decision_number`, and returns a typed `GetDecisionResult` Pydantic model. The local stdio MCP adapter constructs a `FilesystemStore` and forwards the call; the cloud transport rewires in the paired private-repo PR.

The plan considered (and rejected) status filtering inside the kernel. Filtering by `active` vs `superseded` belongs to `list_decisions` — a caller that asks for a specific number is usually trying to read the rationale of a superseded decision precisely *because* it was superseded. Kernel-level test pins that contract.

No CLI surface and no FastAPI surface are added. The parity test header documents both compressions: a hand-written `nauro get-decision` command would be a shim the upcoming auto-gen work will replace, and a `/get_decision` FastAPI endpoint would be speculative infra. The layer-3 cross-store parity test still pins local-vs-cloud envelope agreement at the kernel boundary.

## What changed

- `nauro_core.operations.get_decision` — kernel callable; no I/O outside the Store, no telemetry, no transport context.
- `nauro_core.operations.results.GetDecisionResult` — frozen, extra-forbid Pydantic model with `content` (hit) and `error` (miss, `ErrorPayload(kind="error")`).
- `nauro_core.operations.__init__` — exports + `__all__` extended.
- `nauro.mcp.tools.tool_get_decision` — replaced inline glob body with a four-line adapter (`FilesystemStore`, kernel call, `model_dump(mode="json", exclude_none=True)`, prepend `store=local`). Removed the now-unused `extract_decision_number` import in this module (still used by `hooks.py`, `pipeline.py`, `validator.py`, `reader.py`, `writer.py`).
- Kernel tests cover empty store, hit, miss, varying pad widths (`5`, `42`, `170`), and superseded-still-resolves.
- Surface parity test covers stdio MCP + direct tool envelope match on hit and miss.
- Layer-3 cross-surface parity skips at module load when `mcp_server.store.cloud_store` is not installed (public-monorepo CI); engineers running both packages on one `PYTHONPATH` exercise it locally.

## What to review

- **Wire-shape migration on the miss path.** Old: `{"store": "local", "error": "Decision N not found"}` (string). New: `{"store": "local", "error": {"kind": "error", "reason": "Decision N not found"}}` (dict, mirrors `ErrorPayload`). Grep across both packages found no test asserting the old string shape, so the change is callable-only for any consumer that reads `envelope["error"]` as a structured field. The hit path is unchanged: `{"store": "local", "content": "..."}`.
- **`extract_decision_number` import removal in `tools.py`.** Confirmed the only call site in this file was the now-deleted body; other usages live outside `mcp/tools.py`.
- **Superseded-still-resolves test.** Intentional contract: status filtering is `list_decisions`' job. If a future requirement flips this, it's a kernel change with a kernel test alongside.

## What's deferred

- Cloud HTTP MCP rewiring — paired PR against the private `mcp-server` repo.
- `nauro get-decision` CLI surface — waiting on the auto-gen `nauro tool <name>` work.
- `/get_decision` FastAPI endpoint — not adding without a concrete consumer.
- Subsequent operations (`get_raw_file`, `list_decisions`, `search_decisions`, `get_context`, `diff_since_last_session`, `update_state`, `flag_question`, `propose_decision`, `confirm_decision`) cut over in their own PRs.

## Test plan

- `uv run pytest packages/nauro-core/tests/ -x -q` — 405 passed (+8 new: 7 in `test_get_decision`, 5 added to `test_results` for `GetDecisionResult`).
- `uv run pytest packages/nauro/tests/ -x -q` — 983 passed, 2 skipped (+3 new in `test_get_decision_parity`; cross-surface file skips at module load without `mcp_server`).
- `uv run ruff check packages/` — clean.
- `uv run ruff format --check packages/` — 174 files already formatted.
