### PR TITLE
fix(agents): whitelist both Nauro MCP prefixes in bundled subagents

### DIFF
--- a/packages/nauro/src/nauro/agents/nauro-planner.md
+++ b/packages/nauro/src/nauro/agents/nauro-planner.md
@@ -1,7 +1,7 @@
 ---
 name: nauro-planner
 description: Use to plan a non-trivial change before any code is written. Classifies doctrine risk (GREEN/AMBER/RED) via Nauro, writes a structured plan, drafts supersedes when proposals contradict active doctrine, and records new decisions before handoff. Use proactively when the user asks "should we...", "what if we...", or "how should we approach X". Returns a plan; does not edit files.
-tools: Read, Grep, Glob, WebSearch, WebFetch, Bash, mcp__claude_ai_Nauro__check_decision, mcp__claude_ai_Nauro__propose_decision, mcp__claude_ai_Nauro__get_decision, mcp__claude_ai_Nauro__search_decisions, mcp__claude_ai_Nauro__list_decisions, mcp__claude_ai_Nauro__list_projects
+tools: Read, Grep, Glob, WebSearch, WebFetch, Bash, mcp__claude_ai_Nauro__check_decision, mcp__claude_ai_Nauro__propose_decision, mcp__claude_ai_Nauro__get_decision, mcp__claude_ai_Nauro__search_decisions, mcp__claude_ai_Nauro__list_decisions, mcp__claude_ai_Nauro__list_projects, mcp__nauro__check_decision, mcp__nauro__propose_decision, mcp__nauro__get_decision, mcp__nauro__search_decisions, mcp__nauro__list_decisions, mcp__nauro__list_projects
 model: opus
 ---
 

--- a/packages/nauro/src/nauro/agents/nauro-reviewer.md
+++ b/packages/nauro/src/nauro/agents/nauro-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: nauro-reviewer
 description: Use to review a PR or diff. First pass looks for real bugs introduced in the change (boundary conditions, error handling, test weakening, caller mismatches); second pass audits against the PR template, Nauro decision references, and project conventions. Read-only. Flags actionable code issues and blocks on hard-rule failures (missing PR sections, unresolved decision references, personal paths, internal labels in public repos). Use before merging, or as a second pass after the executor finishes.
-tools: Read, Grep, Glob, Bash, mcp__claude_ai_Nauro__get_decision, mcp__claude_ai_Nauro__search_decisions, mcp__claude_ai_Nauro__list_decisions
+tools: Read, Grep, Glob, Bash, mcp__claude_ai_Nauro__get_decision, mcp__claude_ai_Nauro__search_decisions, mcp__claude_ai_Nauro__list_decisions, mcp__nauro__get_decision, mcp__nauro__search_decisions, mcp__nauro__list_decisions
 model: opus
 ---
 

--- a/packages/nauro/src/nauro/agents/nauro-tech-lead.md
+++ b/packages/nauro/src/nauro/agents/nauro-tech-lead.md
@@ -1,7 +1,7 @@
 ---
 name: nauro-tech-lead
 description: Use to set or maintain project direction. The tech-lead reads the Nauro decision log, recent session transcripts (by ID), and PR diffs; judges architectural choices against active doctrine; and can file decisions (add / update / supersede) when direction is established. Has write authority on Nauro — but every supersede / update routes through `confirm_decision`, so the human keeps the final gate by design. Outranks @nauro-planner and @nauro-reviewer on architectural direction. Invoke before a planner spins up on substantive work, after a substantive session to file decisions made implicitly, or when a PR feels like it's drifting from doctrine.
-tools: Read, Grep, Glob, Bash, mcp__claude_ai_Nauro__get_context, mcp__claude_ai_Nauro__get_decision, mcp__claude_ai_Nauro__search_decisions, mcp__claude_ai_Nauro__list_decisions, mcp__claude_ai_Nauro__list_projects, mcp__claude_ai_Nauro__check_decision, mcp__claude_ai_Nauro__propose_decision, mcp__claude_ai_Nauro__flag_question, mcp__claude_ai_Nauro__update_state
+tools: Read, Grep, Glob, Bash, mcp__claude_ai_Nauro__get_context, mcp__claude_ai_Nauro__get_decision, mcp__claude_ai_Nauro__search_decisions, mcp__claude_ai_Nauro__list_decisions, mcp__claude_ai_Nauro__list_projects, mcp__claude_ai_Nauro__check_decision, mcp__claude_ai_Nauro__propose_decision, mcp__claude_ai_Nauro__flag_question, mcp__claude_ai_Nauro__update_state, mcp__nauro__get_context, mcp__nauro__get_decision, mcp__nauro__search_decisions, mcp__nauro__list_decisions, mcp__nauro__list_projects, mcp__nauro__check_decision, mcp__nauro__propose_decision, mcp__nauro__flag_question, mcp__nauro__update_state
 model: opus
 ---
 


### PR DESCRIPTION
## Why

The bundled `@nauro-planner` / `@nauro-reviewer` / `@nauro-tech-lead` specs whitelist only the `mcp__claude_ai_Nauro__*` prefix on the `tools:` line. When the Nauro MCP server is mounted under the local stdio prefix (`mcp__nauro__*`) — the common shape after `nauro setup` / `nauro init` — Claude Code's subagent harness silently drops every Nauro tool because none of the whitelisted names match the mounted ones. The subagent ends up with just Read/Bash/WebFetch/WebSearch.

Observed symptom: a `@nauro-planner` invocation skipped `check_decision` and fell back to manually verifying against decisions the orchestrator had pre-listed in its brief. That works only when the orchestrator enumerated every relevant decision; the dynamic doctrine check that catches enumeration gaps never fired.

The orchestrator session is unaffected because it inherits every mounted tool without filtering — only subagents are filtered by their frontmatter `tools:` list.

## Approach

Each affected `tools:` line now lists both prefixes (`mcp__claude_ai_Nauro__*` *and* `mcp__nauro__*`) for every Nauro tool the agent uses. Subagents pick up whichever is actually mounted in the session.

Alternative considered: pick one canonical prefix and drop the other. Rejected — the Nauro MCP server has shipped under at least three prefixes over time (`mcp__claude_ai_Nauro__*` claude.ai-hosted, `mcp__claude_ai_Nauro_AI__*` intermediate, `mcp__nauro__*` local stdio), and users may have any of them mounted depending on how they installed. Allowlisting both costs three extra entries per agent and avoids breaking installs we cannot enumerate.

`nauro-executor` is unchanged: it has no `tools:` line, so it already inherits every mounted tool.

## What changed

- `packages/nauro/src/nauro/agents/nauro-planner.md` — `tools:` extended with `mcp__nauro__{check_decision,propose_decision,get_decision,search_decisions,list_decisions,list_projects}`
- `packages/nauro/src/nauro/agents/nauro-reviewer.md` — `tools:` extended with `mcp__nauro__{get_decision,search_decisions,list_decisions}`
- `packages/nauro/src/nauro/agents/nauro-tech-lead.md` — `tools:` extended with the `mcp__nauro__*` peers of every claude.ai-hosted tool it already had

## What to review

- That the added `mcp__nauro__*` entries exactly mirror the existing `mcp__claude_ai_Nauro__*` set for each agent (no asymmetric grants).
- That `nauro-executor` should genuinely stay unaltered (it has no `tools:` line by design; confirming that intent rather than the absence of a change).

## What's deferred

- Consolidating to a single canonical prefix. That belongs with a broader rename / connector-naming decision, not this fix.
- Mirroring the change in any user-installed copies under `~/.claude/agents/`. Those are owned by the user's setup flow (`nauro setup --with-subagents`); the bundled source is the right place to fix once.

## Test plan

- `uv run pytest packages/nauro/tests/test_agents_drift.py -x -q` — 24/24 pass. The drift suite validates frontmatter shape, file-size bounds, and content anchors; the larger `tools:` line stays inside the 1000–30000-byte band the test enforces.
- `uv run ruff check packages/` — clean.
- `uv run ruff format --check packages/` — clean (markdown is not formatter-touched, but ran the gate anyway).
