### PR TITLE
feat(operations): cut get_raw_file over to nauro_core kernel

### DIFF
--- a/packages/nauro-core/src/nauro_core/operations/__init__.py
+++ b/packages/nauro-core/src/nauro_core/operations/__init__.py
@@ -9,8 +9,10 @@ emit no telemetry; transports own event emission.
 from nauro_core.operations._in_memory_store import InMemoryStore as InMemoryStore
 from nauro_core.operations.check_decision import check_decision as check_decision
 from nauro_core.operations.get_decision import get_decision as get_decision
+from nauro_core.operations.get_raw_file import get_raw_file as get_raw_file
 from nauro_core.operations.results import CheckDecisionResult as CheckDecisionResult
 from nauro_core.operations.results import GetDecisionResult as GetDecisionResult
+from nauro_core.operations.results import GetRawFileResult as GetRawFileResult
 from nauro_core.operations.store import Store as Store
 
 from . import results as results
@@ -18,9 +20,11 @@ from . import results as results
 __all__ = [
     "CheckDecisionResult",
     "GetDecisionResult",
+    "GetRawFileResult",
     "InMemoryStore",
     "Store",
     "check_decision",
     "get_decision",
+    "get_raw_file",
     "results",
 ]

--- a/packages/nauro-core/src/nauro_core/operations/get_raw_file.py
+++ b/packages/nauro-core/src/nauro_core/operations/get_raw_file.py
@@ -1,0 +1,39 @@
+"""``get_raw_file`` — return the raw text of any file in the project store.
+
+Cross-transport implementation: every transport adapter calls this
+function with the same arguments and receives the same
+:class:`GetRawFileResult`. Each adapter wraps the call to add transport-
+specific framing (``store`` field, telemetry emission, path-traversal
+guards on the adapter side, ``available_files`` hints); the file lookup
+itself is shared by construction.
+
+The kernel stays storage-agnostic: it does not inspect ``path`` for
+traversal or backend-specific conventions. Adapters that need to reject
+escapes (e.g. ``FilesystemStore``) own that concern at their boundary
+before they hand the call off here.
+"""
+
+from __future__ import annotations
+
+from nauro_core.operations.results import ErrorPayload, GetRawFileResult
+from nauro_core.operations.store import Store
+
+
+def get_raw_file(store: Store, path: str) -> GetRawFileResult:
+    """Return the text body at ``path``, or a not-found error.
+
+    Args:
+        store: Storage adapter providing ``read_file``.
+        path: Store-relative path to the file.
+
+    Returns:
+        :class:`GetRawFileResult`. On a hit ``content`` holds the file's
+        text body. On a miss ``error`` is populated with ``kind="error"``
+        and a reason that names the requested path.
+    """
+    body = store.read_file(path)
+    if body is None:
+        return GetRawFileResult(
+            error=ErrorPayload(kind="error", reason=f"File not found: {path}"),
+        )
+    return GetRawFileResult(content=body)

--- a/packages/nauro-core/src/nauro_core/operations/results.py
+++ b/packages/nauro-core/src/nauro_core/operations/results.py
@@ -78,3 +78,20 @@ class GetDecisionResult(BaseModel):
 
     content: str | None = None
     error: ErrorPayload | None = None
+
+
+class GetRawFileResult(BaseModel):
+    """Return shape for :func:`nauro_core.operations.get_raw_file`.
+
+    On the success path ``content`` holds the file's text body. On the
+    miss path ``error`` is populated with ``kind="error"``. The ``store``
+    field is not part of the model; transport adapters add it back at
+    serialization time. Hints such as ``available_files`` are not part of
+    the kernel result either — they belong to the adapter since the Store
+    protocol does not expose general file enumeration.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    content: str | None = None
+    error: ErrorPayload | None = None

--- a/packages/nauro-core/tests/operations/test_get_raw_file.py
+++ b/packages/nauro-core/tests/operations/test_get_raw_file.py
@@ -1,0 +1,68 @@
+"""Kernel-level tests for ``operations.get_raw_file`` against ``InMemoryStore``.
+
+Each test seeds an ``InMemoryStore`` and asserts on the typed
+:class:`GetRawFileResult` directly. Surface-level wiring tests live in
+each transport's own suite. Path-traversal protection is an adapter-side
+concern; ``InMemoryStore`` has no traversal concept and so it is not
+exercised here.
+"""
+
+from __future__ import annotations
+
+from nauro_core.operations import (
+    GetRawFileResult,
+    InMemoryStore,
+    get_raw_file,
+)
+
+
+def test_returns_result_type() -> None:
+    result = get_raw_file(InMemoryStore(), "project.md")
+    assert isinstance(result, GetRawFileResult)
+
+
+def test_empty_store_returns_not_found_error() -> None:
+    result = get_raw_file(InMemoryStore(), "project.md")
+    assert result.content is None
+    assert result.error is not None
+    assert result.error.kind == "error"
+    assert result.error.reason == "File not found: project.md"
+
+
+def test_existing_file_returns_content() -> None:
+    body = "# Project\nSome body text.\n"
+    store = InMemoryStore(files={"project.md": body})
+    result = get_raw_file(store, "project.md")
+    assert result.error is None
+    assert result.content == body
+
+
+def test_missing_path_reason_is_locked_format() -> None:
+    """Miss-reason format is part of the surface contract."""
+    result = get_raw_file(InMemoryStore(), "notes/missing.md")
+    assert result.error is not None
+    assert result.error.reason == "File not found: notes/missing.md"
+
+
+def test_exclude_none_strips_unset_fields_on_hit() -> None:
+    store = InMemoryStore(files={"project.md": "body"})
+    result = get_raw_file(store, "project.md")
+    dumped = result.model_dump(mode="json", exclude_none=True)
+    assert dumped == {"content": "body"}
+    assert "error" not in dumped
+
+
+def test_exclude_none_strips_unset_fields_on_miss() -> None:
+    result = get_raw_file(InMemoryStore(), "project.md")
+    dumped = result.model_dump(mode="json", exclude_none=True)
+    assert dumped == {
+        "error": {"kind": "error", "reason": "File not found: project.md"},
+    }
+    assert "content" not in dumped
+
+
+def test_store_field_absent_from_result_model_dump() -> None:
+    """Transports own the ``store`` field; the kernel never emits it."""
+    result = get_raw_file(InMemoryStore(), "project.md")
+    dumped = result.model_dump(mode="json")
+    assert "store" not in dumped

--- a/packages/nauro/src/nauro/mcp/tools.py
+++ b/packages/nauro/src/nauro/mcp/tools.py
@@ -22,6 +22,7 @@ from nauro_core.constants import (
 from nauro_core.decision_model import DecisionStatus
 from nauro_core.operations import check_decision as _check_decision_op
 from nauro_core.operations import get_decision as _get_decision_op
+from nauro_core.operations import get_raw_file as _get_raw_file_op
 from nauro_core.protocol import (
     CHECK_DECISION_RETURNS,
     GET_DECISION_BEFORE_PROPOSING,
@@ -377,24 +378,35 @@ def tool_get_raw_file(store_path: Path, path: str) -> dict:
     guidance = _check_store_exists(store_path)
     if guidance:
         return {"store": "local", "status": "error", "guidance": guidance}
-    file_path = store_path / path
-    # Prevent path traversal
+
+    # Adapter-side traversal check. Distinct from the kernel-side
+    # file-not-found case so callers get a clear "Invalid path" signal
+    # before any Store I/O.
+    resolved = (store_path / path).resolve()
     try:
-        file_path.resolve().relative_to(store_path.resolve())
+        resolved.relative_to(store_path.resolve())
     except ValueError:
-        return {"store": "local", "error": f"Invalid path: {path}"}
-    if not file_path.exists():
-        # List available files as a hint
+        return {
+            "store": "local",
+            "error": {"kind": "error", "reason": f"Invalid path: {path}"},
+        }
+
+    result = _get_raw_file_op(FilesystemStore(store_path), path)
+    envelope: dict = {"store": "local", **result.model_dump(mode="json", exclude_none=True)}
+
+    # On miss, build the "available files" hint locally — file
+    # enumeration outside the decisions/ directory is outside the
+    # Store protocol's locked surface. Cap at 20 entries so the miss
+    # envelope stays bounded for stores with many markdown files.
+    if result.error is not None:
         available = []
         for f in sorted(store_path.rglob("*.md")):
             rel = f.relative_to(store_path)
             if not str(rel).startswith("snapshots/"):
                 available.append(str(rel))
-        hint = ""
-        if available:
-            hint = "\n\nAvailable files:\n" + "\n".join(f"- {f}" for f in available[:20])
-        return {"store": "local", "error": f"File not found: {path}{hint}"}
-    return {"store": "local", "content": file_path.read_text()}
+        envelope["available_files"] = available[:20]
+
+    return envelope
 
 
 @mcp_tool("list_decisions")

--- a/packages/nauro/src/nauro/store/filesystem_store.py
+++ b/packages/nauro/src/nauro/store/filesystem_store.py
@@ -27,8 +27,12 @@ class FilesystemStore:
         self._store_path = store_path
 
     def read_file(self, path: str) -> str | None:
-        target = self._store_path / path
-        if not target.exists():
+        target = (self._store_path / path).resolve()
+        try:
+            target.relative_to(self._store_path.resolve())
+        except ValueError:
+            return None
+        if not target.exists() or not target.is_file():
             return None
         return target.read_text()
 

--- a/packages/nauro/tests/test_get_raw_file_cross_surface.py
+++ b/packages/nauro/tests/test_get_raw_file_cross_surface.py
@@ -1,0 +1,119 @@
+"""Layer-3 cross-surface parity for ``get_raw_file``.
+
+The surface-level parity test (``test_get_raw_file_parity``) covers the
+local adapters against the same ``FilesystemStore``. This file goes one
+layer deeper: the same kernel call against ``FilesystemStore`` and
+``mcp_server.store.cloud_store.CloudStore`` must produce the same
+:class:`GetRawFileResult` for the same fixed inputs. That is the
+no-drift-by-construction guarantee the operations-kernel doctrine
+commits to.
+
+CloudStore is consumed by other transports and is not always
+installed in the same environment as ``nauro``. When this test runs
+from inside the nauro workspace alone, ``mcp_server`` is unavailable
+and the test skips at module load via ``pytest.importorskip``.
+Engineers who have both packages on a single ``PYTHONPATH`` exercise
+it locally to catch local-vs-cloud envelope drift before merge.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+cloud_store_module = pytest.importorskip(
+    "mcp_server.store.cloud_store",
+    reason="CloudStore is consumed by other transports; not always installed alongside nauro.",
+)
+boto3 = pytest.importorskip("boto3", reason="boto3 needed to seed a moto S3 bucket.")
+moto = pytest.importorskip("moto", reason="moto needed for in-memory S3.")
+
+# Imports below ``importorskip`` deliberately run only when both packages are
+# installed; ruff E402 does not apply here.
+from nauro_core.operations import get_raw_file  # noqa: E402
+
+from nauro.store.filesystem_store import FilesystemStore  # noqa: E402
+
+CloudStore = cloud_store_module.CloudStore
+
+TEST_BUCKET = "nauro-cross-surface-test"
+TEST_USER_ID = "01TEST" + "0" * 20
+TEST_PROJECT_ID = "01TESTPROJECT00000000000"
+
+EXISTING_PATH = "project.md"
+MISSING_PATH = "does-not-exist.md"
+
+# Fixed seed: a single plain file mirrored into both stores so the
+# input envelope is identical by construction; any envelope drift
+# between the two surfaces is then a real bug, not a fixture mismatch.
+SEED_FILES: dict[str, str] = {
+    EXISTING_PATH: "# Parity Project\n\nA tiny file used by cross-surface parity.\n",
+}
+
+
+def _seed_filesystem_store(root: Path) -> FilesystemStore:
+    root.mkdir(parents=True, exist_ok=True)
+    for path, body in SEED_FILES.items():
+        target = root / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(body)
+    return FilesystemStore(root)
+
+
+def _seed_cloud_store(s3_client) -> CloudStore:
+    prefix = f"users/{TEST_USER_ID}/projects/{TEST_PROJECT_ID}"
+    for path, body in SEED_FILES.items():
+        s3_client.put_object(
+            Bucket=TEST_BUCKET,
+            Key=f"{prefix}/{path}",
+            Body=body.encode(),
+        )
+    return CloudStore(user_id=TEST_USER_ID, project_id=TEST_PROJECT_ID)
+
+
+@pytest.fixture
+def both_stores(tmp_path, monkeypatch):
+    """Yield a (FilesystemStore, CloudStore) pair seeded with identical files.
+
+    The cloud half lives inside a moto-mocked S3 + an env-pointed bucket so
+    the test never touches AWS. ``NAURO_S3_BUCKET`` is monkey-patched onto
+    the environment because :class:`CloudStore` reads it lazily.
+    """
+    monkeypatch.setenv("NAURO_S3_BUCKET", TEST_BUCKET)
+
+    with moto.mock_aws():
+        s3_client = boto3.client("s3", region_name="us-east-1")
+        s3_client.create_bucket(Bucket=TEST_BUCKET)
+
+        fs_store = _seed_filesystem_store(tmp_path)
+        cloud = _seed_cloud_store(s3_client)
+        yield fs_store, cloud
+
+
+def test_get_raw_file_result_matches_across_stores_on_hit(both_stores):
+    fs_store, cloud = both_stores
+
+    fs_result = get_raw_file(fs_store, EXISTING_PATH)
+    cloud_result = get_raw_file(cloud, EXISTING_PATH)
+
+    assert fs_result.model_dump(mode="json", exclude_none=True) == cloud_result.model_dump(
+        mode="json", exclude_none=True
+    )
+    assert fs_result.error is None
+    assert fs_result.content is not None
+
+
+def test_get_raw_file_result_matches_across_stores_on_miss(both_stores):
+    fs_store, cloud = both_stores
+
+    fs_result = get_raw_file(fs_store, MISSING_PATH)
+    cloud_result = get_raw_file(cloud, MISSING_PATH)
+
+    assert fs_result.model_dump(mode="json", exclude_none=True) == cloud_result.model_dump(
+        mode="json", exclude_none=True
+    )
+    assert fs_result.content is None
+    assert fs_result.error is not None
+    assert fs_result.error.kind == "error"
+    assert fs_result.error.reason == f"File not found: {MISSING_PATH}"

--- a/packages/nauro/tests/test_get_raw_file_parity.py
+++ b/packages/nauro/tests/test_get_raw_file_parity.py
@@ -1,0 +1,106 @@
+"""Surface-level parity for the local ``get_raw_file`` adapters.
+
+After the kernel cutover, every local surface that exposes
+``get_raw_file`` must produce the same envelope for the same path
+against the same store. This file pins that envelope shape across the
+two adapter wirings that exist today.
+
+Two compressions vs. the ``check_decision`` parity test:
+
+* No CLI surface. There is no ``nauro get-raw-file`` command. Auto-gen
+  of ``nauro tool <name>`` from MCP ToolSpecs is deferred; adding a
+  hand-written CLI mirror now would be speculative.
+* No FastAPI surface. The local server does not expose a
+  ``/get_raw_file`` endpoint. Adding one purely to mirror the parity
+  shape would be speculative infrastructure; the cross-store layer-3
+  test (``test_get_raw_file_cross_surface``) covers local-vs-cloud
+  parity once the cloud Store exists.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nauro.constants import REPO_CONFIG_MODE_LOCAL
+from nauro.demo import create_demo_project
+from nauro.mcp.stdio_server import get_raw_file as stdio_get_raw_file
+from nauro.mcp.tools import tool_get_raw_file
+from nauro.store.registry import register_project_v2
+from nauro.store.repo_config import save_repo_config
+
+EXISTING_PATH = "project.md"
+MISSING_PATH = "does-not-exist.md"
+TRAVERSAL_PATH = "../../etc/passwd"
+
+
+@pytest.fixture
+def demo_repo(tmp_path, monkeypatch):
+    """Seed a demo project + chdir into the repo so cwd resolution wins."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    pid, store_path = register_project_v2("parity-project", [repo], mode=REPO_CONFIG_MODE_LOCAL)
+    save_repo_config(repo, {"mode": REPO_CONFIG_MODE_LOCAL, "id": pid, "name": "parity-project"})
+    create_demo_project(store_path)
+    monkeypatch.chdir(repo)
+    return pid, store_path
+
+
+def _stdio_envelope(pid: str, path: str) -> dict:
+    return stdio_get_raw_file(path=path, project_id=pid)
+
+
+def _tool_envelope(store_path: Path, path: str) -> dict:
+    """Direct call to the local tool, no transport wrapper."""
+    return tool_get_raw_file(store_path, path)
+
+
+def test_stdio_and_tool_match_on_success_path(demo_repo):
+    pid, store_path = demo_repo
+    stdio = _stdio_envelope(pid, EXISTING_PATH)
+    tool = _tool_envelope(store_path, EXISTING_PATH)
+    assert stdio == tool
+
+
+def test_success_envelope_carries_content(demo_repo):
+    pid, _ = demo_repo
+    envelope = _stdio_envelope(pid, EXISTING_PATH)
+    assert envelope["store"] == "local"
+    assert "content" in envelope
+    assert envelope["content"]
+    # ``error`` and ``available_files`` are omitted on the success path.
+    assert "error" not in envelope
+    assert "available_files" not in envelope
+
+
+def test_not_found_envelope_matches_across_surfaces(demo_repo):
+    pid, store_path = demo_repo
+    stdio = _stdio_envelope(pid, MISSING_PATH)
+    tool = _tool_envelope(store_path, MISSING_PATH)
+    assert stdio == tool
+    # Locked miss envelope shape.
+    assert stdio["store"] == "local"
+    assert "content" not in stdio
+    assert stdio["error"]["kind"] == "error"
+    assert stdio["error"]["reason"] == f"File not found: {MISSING_PATH}"
+    # Adapter adds the available_files hint as a sibling field, not
+    # inside the error reason — kept structured so clients can render
+    # the hint independently of the error message.
+    assert isinstance(stdio["available_files"], list)
+    assert all(isinstance(p, str) for p in stdio["available_files"])
+    assert EXISTING_PATH in stdio["available_files"]
+
+
+def test_traversal_envelope_matches_across_surfaces(demo_repo):
+    pid, store_path = demo_repo
+    stdio = _stdio_envelope(pid, TRAVERSAL_PATH)
+    tool = _tool_envelope(store_path, TRAVERSAL_PATH)
+    assert stdio == tool
+    # Traversal is rejected by the adapter before any kernel call;
+    # reason text is distinct from the kernel-side "File not found".
+    assert stdio["store"] == "local"
+    assert "content" not in stdio
+    assert "available_files" not in stdio
+    assert stdio["error"]["kind"] == "error"
+    assert stdio["error"]["reason"] == f"Invalid path: {TRAVERSAL_PATH}"


### PR DESCRIPTION
## Why

`get_raw_file` was still a transport-coupled implementation inside `packages/nauro/src/nauro/mcp/tools.py`. Every other transport that wants to expose the same operation had to redo the lookup against its own backend, with envelope drift one careless return away. The operations-kernel restructure resolves that by moving each tool's core into `nauro_core.operations` behind a typed Pydantic result, so adapters share one storage-agnostic function. PR 1 and PR 2 cut `check_decision` and `get_decision`; this PR is the third tool in that sequence.

## Approach

The kernel function takes a `Store` and a path, calls `Store.read_file`, and shapes a `GetRawFileResult` — content on a hit, `ErrorPayload(kind="error", reason="File not found: <path>")` on a miss. No I/O outside the Store, no telemetry, no path inspection. The local adapter (`tool_get_raw_file`) keeps three concerns the kernel deliberately doesn't own: telemetry via `@mcp_tool`, path-traversal rejection (`resolve` + `relative_to`), and the `available_files` hint on a miss (which would require enumeration outside the Store protocol's locked five methods).

Two distinct error reasons are preserved by construction: the adapter rejects traversal with `"Invalid path: <path>"` before any kernel call, and the kernel returns `"File not found: <path>"` for a real miss. We rejected folding them into a single reason. Distinct messages keep the user-visible signal sharp and the kernel surface narrow.

`FilesystemStore.read_file` picks up a matching `resolve` + `relative_to` guard plus an `is_file()` check so escapes and directory targets both surface as `None`, matching the Store protocol's "or `None`" contract. The kernel still doesn't know about traversal; that's an adapter detail.

## What changed

- `nauro_core.operations.get_raw_file` — new kernel function, plus `GetRawFileResult` in `results.py` and the matching exports.
- `nauro.mcp.tools.tool_get_raw_file` — rewired to call the kernel; envelope changed from a flat string error to the structured `{kind, reason}` payload other operations already use, with `available_files` as a sibling list on the miss path (capped at 20 entries).
- `nauro.store.filesystem_store.FilesystemStore.read_file` — traversal guard + `is_file()` check; both treat the path as missing rather than raising.
- Tests across three layers: kernel against `InMemoryStore`, surface parity for the two local adapters, and cross-store parity gated on availability of the cloud Store.

## What to review

- The two distinct error reasons (`Invalid path` vs `File not found`) — they're load-bearing for callers that route on text and they're locked by the parity test. Confirm the split feels right.
- `FilesystemStore.read_file`'s use of `resolve()` against the unresolved store root: the path is resolved before the relative-to check, and the root is resolved during the comparison. This handles symlinked stores correctly without forcing the caller to resolve upfront.
- The `available_files` enumeration moved out of the error string into a structured list capped at 20 entries; it still excludes `snapshots/` to match the prior behavior.

## What's deferred

- mcp-server cutover and cloud-side rewiring run in the paired cross-repo cutover PR.
- No CLI surface (`nauro get-raw-file`) and no FastAPI `/get_raw_file` endpoint — auto-gen of `nauro tool <name>` is open and adding hand-written mirrors now would be speculative.

## Test plan

- `uv run pytest packages/nauro-core/tests/operations/test_get_raw_file.py -x -q` — 7 new passes (kernel against `InMemoryStore`)
- `uv run pytest packages/nauro-core/tests/ -x -q` — 412 passed
- `uv run pytest packages/nauro/tests/test_get_raw_file_parity.py -x -q` — 4 new passes (hit, success-envelope shape, miss with `available_files` sibling, traversal)
- `uv run pytest packages/nauro/tests/test_get_raw_file_cross_surface.py -x -q` — skipped here (cloud Store not on PYTHONPATH); engineers with both packages installed exercise it locally
- `uv run pytest packages/nauro/tests/ -x -q` — 987 passed, 3 skipped
- `uv run ruff format --check packages/` and `uv run ruff check packages/` — clean
