### PR TITLE
feat(operations): cut list_decisions over to nauro_core kernel

### DIFF
--- a/packages/nauro-core/src/nauro_core/operations/__init__.py
+++ b/packages/nauro-core/src/nauro_core/operations/__init__.py
@@ -10,21 +10,27 @@ from nauro_core.operations._in_memory_store import InMemoryStore as InMemoryStor
 from nauro_core.operations.check_decision import check_decision as check_decision
 from nauro_core.operations.get_decision import get_decision as get_decision
 from nauro_core.operations.get_raw_file import get_raw_file as get_raw_file
+from nauro_core.operations.list_decisions import list_decisions as list_decisions
 from nauro_core.operations.results import CheckDecisionResult as CheckDecisionResult
+from nauro_core.operations.results import DecisionSummary as DecisionSummary
 from nauro_core.operations.results import GetDecisionResult as GetDecisionResult
 from nauro_core.operations.results import GetRawFileResult as GetRawFileResult
+from nauro_core.operations.results import ListDecisionsResult as ListDecisionsResult
 from nauro_core.operations.store import Store as Store
 
 from . import results as results
 
 __all__ = [
     "CheckDecisionResult",
+    "DecisionSummary",
     "GetDecisionResult",
     "GetRawFileResult",
     "InMemoryStore",
+    "ListDecisionsResult",
     "Store",
     "check_decision",
     "get_decision",
     "get_raw_file",
+    "list_decisions",
     "results",
 ]

--- a/packages/nauro-core/src/nauro_core/operations/list_decisions.py
+++ b/packages/nauro-core/src/nauro_core/operations/list_decisions.py
@@ -1,0 +1,63 @@
+"""``list_decisions`` — return decision summaries, sorted by number descending.
+
+Cross-transport implementation: every transport adapter calls this
+function with the same arguments and receives the same
+:class:`ListDecisionsResult`. Each adapter wraps the call to add
+transport-specific framing (``store`` field, telemetry emission); the
+listing, filtering, and projection live here.
+
+Status filtering belongs to this operation, not to ``get_decision``:
+callers asking for "the active decision history" use the
+``include_superseded=False`` default; ``get_decision`` always resolves
+the body of a specific number regardless of status so superseded
+rationale stays inspectable.
+"""
+
+from __future__ import annotations
+
+from nauro_core.decision_model import DecisionStatus, parse_decision
+from nauro_core.operations.results import DecisionSummary, ListDecisionsResult
+from nauro_core.operations.store import Store
+
+
+def list_decisions(
+    store: Store,
+    limit: int = 20,
+    include_superseded: bool = False,
+) -> ListDecisionsResult:
+    """Return decision summaries sorted by number descending.
+
+    Args:
+        store: Storage adapter providing ``list_decisions`` / ``read_decision``.
+        limit: Maximum number of rows to return.
+        include_superseded: When ``False`` (default), drop rows whose
+            status is ``superseded``; when ``True``, retain them.
+
+    Returns:
+        :class:`ListDecisionsResult` with ``decisions`` populated. Rows
+        are sorted by decision number descending and sliced to ``limit``.
+    """
+    decisions = []
+    for stem in store.list_decisions():
+        body = store.read_decision(stem)
+        if body is None:
+            continue
+        decisions.append(parse_decision(body, f"{stem}.md"))
+
+    if not include_superseded:
+        decisions = [d for d in decisions if d.status is DecisionStatus.active]
+
+    decisions.sort(key=lambda d: d.num, reverse=True)
+
+    rows = [
+        DecisionSummary(
+            number=d.num,
+            title=d.title,
+            date=d.date.isoformat() if d.date else None,
+            status=d.status.value,
+            type=d.decision_type.value if d.decision_type else None,
+            confidence=d.confidence.value,
+        )
+        for d in decisions[:limit]
+    ]
+    return ListDecisionsResult(decisions=rows)

--- a/packages/nauro-core/src/nauro_core/operations/results.py
+++ b/packages/nauro-core/src/nauro_core/operations/results.py
@@ -95,3 +95,38 @@ class GetRawFileResult(BaseModel):
 
     content: str | None = None
     error: ErrorPayload | None = None
+
+
+class DecisionSummary(BaseModel):
+    """One row in :class:`ListDecisionsResult`.
+
+    Carries the same row fields the pre-cutover ``tool_list_decisions``
+    envelope exposed (``number``, ``title``, ``date``, ``status``,
+    ``type``, ``confidence``). ``date`` and ``type`` stay optional so
+    decisions written without those frontmatter fields still serialize;
+    the adapter's ``exclude_none=True`` template choice drops the keys
+    when they are unset.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    number: int
+    title: str
+    date: str | None = None
+    status: str
+    type: str | None = None
+    confidence: str
+
+
+class ListDecisionsResult(BaseModel):
+    """Return shape for :func:`nauro_core.operations.list_decisions`.
+
+    ``decisions`` carries the projected rows, sorted by decision number
+    descending and truncated to the caller-supplied ``limit``. The
+    ``store`` field is not part of the model; transport adapters add it
+    back at serialization time.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    decisions: list[DecisionSummary] = Field(default_factory=list)

--- a/packages/nauro-core/tests/operations/test_list_decisions.py
+++ b/packages/nauro-core/tests/operations/test_list_decisions.py
@@ -1,0 +1,172 @@
+"""Kernel-level tests for ``operations.list_decisions`` against ``InMemoryStore``.
+
+Each test seeds an ``InMemoryStore`` and asserts on the typed
+:class:`ListDecisionsResult` directly. Surface-level wiring tests live in
+each transport's own suite.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+from nauro_core.decision_model import (
+    Decision,
+    DecisionConfidence,
+    DecisionStatus,
+    DecisionType,
+    format_decision,
+)
+from nauro_core.operations import (
+    DecisionSummary,
+    InMemoryStore,
+    ListDecisionsResult,
+    list_decisions,
+)
+
+
+def _seed_decision(
+    num: int,
+    title: str,
+    rationale: str = "Test rationale.",
+    *,
+    status: DecisionStatus = DecisionStatus.active,
+    confidence: DecisionConfidence = DecisionConfidence.medium,
+    decision_type: DecisionType | None = None,
+    decision_date: date | None = date(2026, 1, 1),
+    stem: str | None = None,
+) -> tuple[str, str]:
+    """Return (file_stem, formatted_markdown) for a minimal v2 decision."""
+    superseded_by = "999" if status is DecisionStatus.superseded else None
+    decision = Decision(
+        date=decision_date,
+        confidence=confidence,
+        status=status,
+        superseded_by=superseded_by,
+        decision_type=decision_type,
+        num=num,
+        title=title,
+        rationale=rationale,
+    )
+    if stem is None:
+        slug = title.lower().replace(" ", "-")
+        stem = f"{num:03d}-{slug}"
+    return stem, format_decision(decision)
+
+
+def _store_with(*decisions: tuple[str, str]) -> InMemoryStore:
+    return InMemoryStore(decisions=dict(decisions))
+
+
+def test_returns_result_type() -> None:
+    result = list_decisions(InMemoryStore())
+    assert isinstance(result, ListDecisionsResult)
+
+
+def test_empty_store_returns_empty_decisions() -> None:
+    result = list_decisions(InMemoryStore())
+    assert result == ListDecisionsResult(decisions=[])
+    assert result.decisions == []
+
+
+def test_single_decision_returns_single_row_with_correct_fields() -> None:
+    stem, body = _seed_decision(
+        7,
+        "Adopt Redis",
+        "Use Redis for session cache.",
+        decision_type=DecisionType.infrastructure,
+        confidence=DecisionConfidence.high,
+    )
+    store = _store_with((stem, body))
+    result = list_decisions(store)
+    assert len(result.decisions) == 1
+    row = result.decisions[0]
+    assert row.number == 7
+    assert row.title == "Adopt Redis"
+    assert row.date == "2026-01-01"
+    assert row.status == "active"
+    assert row.type == "infrastructure"
+    assert row.confidence == "high"
+
+
+def test_multiple_decisions_sorted_descending_by_number() -> None:
+    seeded = [
+        _seed_decision(1, "First"),
+        _seed_decision(2, "Second"),
+        _seed_decision(3, "Third"),
+    ]
+    store = _store_with(*seeded)
+    result = list_decisions(store)
+    numbers = [row.number for row in result.decisions]
+    assert numbers == [3, 2, 1]
+
+
+def test_limit_truncates_to_requested_size() -> None:
+    seeded = [_seed_decision(i, f"Decision {i}") for i in range(1, 11)]
+    store = _store_with(*seeded)
+    result = list_decisions(store, limit=5)
+    assert len(result.decisions) == 5
+    # The five highest numbers come back, sorted descending.
+    assert [row.number for row in result.decisions] == [10, 9, 8, 7, 6]
+
+
+def test_include_superseded_false_filters_out_superseded_rows() -> None:
+    active = _seed_decision(1, "Active one")
+    superseded = _seed_decision(2, "Old one", status=DecisionStatus.superseded)
+    store = _store_with(active, superseded)
+    result = list_decisions(store)
+    numbers = [row.number for row in result.decisions]
+    assert numbers == [1]
+    assert all(row.status == "active" for row in result.decisions)
+
+
+def test_include_superseded_true_retains_superseded_rows() -> None:
+    active = _seed_decision(1, "Active one")
+    superseded = _seed_decision(2, "Old one", status=DecisionStatus.superseded)
+    store = _store_with(active, superseded)
+    result = list_decisions(store, include_superseded=True)
+    numbers = [row.number for row in result.decisions]
+    assert numbers == [2, 1]
+    statuses = {row.status for row in result.decisions}
+    assert statuses == {"active", "superseded"}
+
+
+def test_exclude_none_strips_unset_type_on_row() -> None:
+    """A row whose underlying ``decision_type`` is unset omits ``type`` on dump."""
+    stem, body = _seed_decision(5, "No type set", decision_type=None)
+    store = _store_with((stem, body))
+    result = list_decisions(store)
+    row = result.decisions[0]
+    assert row.type is None
+    dumped = row.model_dump(mode="json", exclude_none=True)
+    assert "type" not in dumped
+    assert dumped == {
+        "number": 5,
+        "title": "No type set",
+        "date": "2026-01-01",
+        "status": "active",
+        "confidence": "medium",
+    }
+
+
+def test_exclude_none_on_summary_with_no_date() -> None:
+    """A summary built with both optionals unset serializes without them."""
+    row = DecisionSummary(
+        number=9,
+        title="Hand-built",
+        status="active",
+        confidence="medium",
+    )
+    dumped = row.model_dump(mode="json", exclude_none=True)
+    assert dumped == {
+        "number": 9,
+        "title": "Hand-built",
+        "status": "active",
+        "confidence": "medium",
+    }
+
+
+def test_store_field_absent_from_result_model_dump() -> None:
+    """Transports own the ``store`` field; the kernel never emits it."""
+    result = list_decisions(InMemoryStore())
+    dumped = result.model_dump(mode="json")
+    assert "store" not in dumped

--- a/packages/nauro-core/tests/operations/test_results.py
+++ b/packages/nauro-core/tests/operations/test_results.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
-from nauro_core.operations.results import ErrorPayload, GetDecisionResult, RelatedDecision
+from nauro_core.operations.results import (
+    DecisionSummary,
+    ErrorPayload,
+    GetDecisionResult,
+    ListDecisionsResult,
+    RelatedDecision,
+)
 
 
 def test_related_decision_model_dump_shape() -> None:
@@ -87,3 +93,84 @@ def test_get_decision_result_is_frozen() -> None:
     result = GetDecisionResult(content="body")
     with pytest.raises(ValidationError):
         result.content = "reassigned"
+
+
+def test_decision_summary_full_row_shape() -> None:
+    row = DecisionSummary(
+        number=42,
+        title="Adopt PostgreSQL",
+        date="2026-01-01",
+        status="active",
+        type="infrastructure",
+        confidence="high",
+    )
+    assert row.model_dump(mode="json") == {
+        "number": 42,
+        "title": "Adopt PostgreSQL",
+        "date": "2026-01-01",
+        "status": "active",
+        "type": "infrastructure",
+        "confidence": "high",
+    }
+
+
+def test_decision_summary_rejects_unknown_fields() -> None:
+    with pytest.raises(ValidationError):
+        DecisionSummary(
+            number=1,
+            title="x",
+            status="active",
+            confidence="medium",
+            unexpected_field="value",
+        )
+
+
+def test_decision_summary_is_frozen() -> None:
+    row = DecisionSummary(number=1, title="x", status="active", confidence="medium")
+    with pytest.raises(ValidationError):
+        row.title = "reassigned"
+
+
+def test_decision_summary_exclude_none_strips_unset_optional_fields() -> None:
+    row = DecisionSummary(number=1, title="x", status="active", confidence="medium")
+    assert row.model_dump(mode="json", exclude_none=True) == {
+        "number": 1,
+        "title": "x",
+        "status": "active",
+        "confidence": "medium",
+    }
+
+
+def test_list_decisions_result_default_empty() -> None:
+    result = ListDecisionsResult()
+    assert result.decisions == []
+    assert result.model_dump(mode="json", exclude_none=True) == {"decisions": []}
+
+
+def test_list_decisions_result_holds_summaries() -> None:
+    row = DecisionSummary(number=1, title="x", status="active", confidence="medium")
+    result = ListDecisionsResult(decisions=[row])
+    dumped = result.model_dump(mode="json", exclude_none=True)
+    assert dumped == {
+        "decisions": [
+            {
+                "number": 1,
+                "title": "x",
+                "status": "active",
+                "confidence": "medium",
+            }
+        ]
+    }
+
+
+def test_list_decisions_result_rejects_unknown_fields() -> None:
+    with pytest.raises(ValidationError):
+        ListDecisionsResult(decisions=[], unexpected_field="value")
+
+
+def test_list_decisions_result_is_frozen() -> None:
+    result = ListDecisionsResult()
+    with pytest.raises(ValidationError):
+        result.decisions = [
+            DecisionSummary(number=1, title="x", status="active", confidence="medium")
+        ]

--- a/packages/nauro/src/nauro/mcp/tools.py
+++ b/packages/nauro/src/nauro/mcp/tools.py
@@ -19,10 +19,10 @@ from nauro_core.constants import (
     MAX_TITLE_LENGTH,
     STATE_CURRENT_FILENAME,
 )
-from nauro_core.decision_model import DecisionStatus
 from nauro_core.operations import check_decision as _check_decision_op
 from nauro_core.operations import get_decision as _get_decision_op
 from nauro_core.operations import get_raw_file as _get_raw_file_op
+from nauro_core.operations import list_decisions as _list_decisions_op
 from nauro_core.protocol import (
     CHECK_DECISION_RETURNS,
     GET_DECISION_BEFORE_PROPOSING,
@@ -38,12 +38,11 @@ from nauro.onboarding import (
 )
 from nauro.store.filesystem_store import FilesystemStore
 from nauro.store.reader import (
-    _list_decisions,
-    resolve_decision_id,
-    search_decisions,
+    diff_since_last_session as _diff_since_last_session,
 )
 from nauro.store.reader import (
-    diff_since_last_session as _diff_since_last_session,
+    resolve_decision_id,
+    search_decisions,
 )
 from nauro.store.snapshot import capture_snapshot
 from nauro.store.writer import append_question
@@ -419,23 +418,8 @@ def tool_list_decisions(
     guidance = _check_store_exists(store_path)
     if guidance:
         return {"store": "local", "status": "error", "guidance": guidance}
-    decisions = _list_decisions(store_path)
-    if not include_superseded:
-        decisions = [d for d in decisions if d.status is DecisionStatus.active]
-    decisions.sort(key=lambda d: d.num, reverse=True)
-    items = []
-    for d in decisions[:limit]:
-        items.append(
-            {
-                "number": d.num,
-                "title": d.title,
-                "date": d.date.isoformat() if d.date else None,
-                "status": str(d.status.value),
-                "type": str(d.decision_type.value) if d.decision_type else None,
-                "confidence": str(d.confidence.value),
-            }
-        )
-    return {"store": "local", "decisions": items}
+    result = _list_decisions_op(FilesystemStore(store_path), limit, include_superseded)
+    return {"store": "local", **result.model_dump(mode="json", exclude_none=True)}
 
 
 @mcp_tool("get_decision")

--- a/packages/nauro/tests/test_list_decisions_cross_surface.py
+++ b/packages/nauro/tests/test_list_decisions_cross_surface.py
@@ -1,0 +1,144 @@
+"""Layer-3 cross-surface parity for ``list_decisions``.
+
+The surface-level parity test (``test_list_decisions_parity``) covers
+the local adapters against the same ``FilesystemStore``. This file goes
+one layer deeper: the same kernel call against ``FilesystemStore`` and
+``mcp_server.store.cloud_store.CloudStore`` must produce the same
+:class:`ListDecisionsResult` for the same fixed inputs. That is the
+no-drift-by-construction guarantee the operations-kernel doctrine
+commits to.
+
+CloudStore is consumed by other transports and is not always
+installed in the same environment as ``nauro``. When this test runs
+from inside the nauro workspace alone, ``mcp_server`` is unavailable
+and the test skips at module load via ``pytest.importorskip``.
+Engineers who have both packages on a single ``PYTHONPATH`` exercise
+it locally to catch local-vs-cloud envelope drift before merge.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+cloud_store_module = pytest.importorskip(
+    "mcp_server.store.cloud_store",
+    reason="CloudStore is consumed by other transports; not always installed alongside nauro.",
+)
+boto3 = pytest.importorskip("boto3", reason="boto3 needed to seed a moto S3 bucket.")
+moto = pytest.importorskip("moto", reason="moto needed for in-memory S3.")
+
+# Imports below ``importorskip`` deliberately run only when both packages are
+# installed; ruff E402 does not apply here.
+from nauro_core.decision_model import (  # noqa: E402
+    Decision,
+    DecisionConfidence,
+    DecisionStatus,
+    format_decision,
+)
+from nauro_core.operations import list_decisions  # noqa: E402
+
+from nauro.store.filesystem_store import FilesystemStore  # noqa: E402
+
+CloudStore = cloud_store_module.CloudStore
+
+TEST_BUCKET = "nauro-cross-surface-test"
+TEST_USER_ID = "01TEST" + "0" * 20
+TEST_PROJECT_ID = "01TESTPROJECT00000000000"
+
+# Fixed seed: one active and one superseded decision so the
+# include_superseded toggle has something to filter. The exact strings
+# are mirrored into both stores so the input envelope is identical by
+# construction; any envelope drift between the two surfaces is then a
+# real bug, not a fixture mismatch.
+SEED_DECISIONS: dict[str, str] = {
+    "001-adopt-postgresql": format_decision(
+        Decision(
+            num=1,
+            title="Adopt PostgreSQL",
+            rationale=(
+                "Use PostgreSQL for ACID transactional semantics across the "
+                "platform; replaces the original document-store plan."
+            ),
+            confidence=DecisionConfidence.high,
+            status=DecisionStatus.active,
+        )
+    ),
+    "002-adopt-rest-endpoints": format_decision(
+        Decision(
+            num=2,
+            title="Adopt REST endpoints",
+            rationale="Initial transport choice, later replaced by gRPC.",
+            confidence=DecisionConfidence.medium,
+            status=DecisionStatus.superseded,
+            superseded_by="3",
+        )
+    ),
+}
+
+
+def _seed_filesystem_store(root: Path) -> FilesystemStore:
+    decisions_dir = root / "decisions"
+    decisions_dir.mkdir(parents=True, exist_ok=True)
+    for stem, body in SEED_DECISIONS.items():
+        (decisions_dir / f"{stem}.md").write_text(body)
+    return FilesystemStore(root)
+
+
+def _seed_cloud_store(s3_client) -> CloudStore:
+    prefix = f"users/{TEST_USER_ID}/projects/{TEST_PROJECT_ID}"
+    for stem, body in SEED_DECISIONS.items():
+        s3_client.put_object(
+            Bucket=TEST_BUCKET,
+            Key=f"{prefix}/decisions/{stem}.md",
+            Body=body.encode(),
+        )
+    return CloudStore(user_id=TEST_USER_ID, project_id=TEST_PROJECT_ID)
+
+
+@pytest.fixture
+def both_stores(tmp_path, monkeypatch):
+    """Yield a (FilesystemStore, CloudStore) pair seeded with identical decisions.
+
+    The cloud half lives inside a moto-mocked S3 + an env-pointed bucket so
+    the test never touches AWS. ``NAURO_S3_BUCKET`` is monkey-patched onto
+    the environment because :class:`CloudStore` reads it lazily.
+    """
+    monkeypatch.setenv("NAURO_S3_BUCKET", TEST_BUCKET)
+
+    with moto.mock_aws():
+        s3_client = boto3.client("s3", region_name="us-east-1")
+        s3_client.create_bucket(Bucket=TEST_BUCKET)
+
+        fs_store = _seed_filesystem_store(tmp_path)
+        cloud = _seed_cloud_store(s3_client)
+        yield fs_store, cloud
+
+
+def test_list_decisions_result_matches_across_stores_default(both_stores):
+    fs_store, cloud = both_stores
+
+    fs_result = list_decisions(fs_store, limit=20, include_superseded=False)
+    cloud_result = list_decisions(cloud, limit=20, include_superseded=False)
+
+    assert fs_result.model_dump(mode="json", exclude_none=True) == cloud_result.model_dump(
+        mode="json", exclude_none=True
+    )
+    # Default toggle filters out the superseded row.
+    numbers = [row.number for row in fs_result.decisions]
+    assert numbers == [1]
+
+
+def test_list_decisions_result_matches_across_stores_include_superseded(both_stores):
+    fs_store, cloud = both_stores
+
+    fs_result = list_decisions(fs_store, limit=20, include_superseded=True)
+    cloud_result = list_decisions(cloud, limit=20, include_superseded=True)
+
+    assert fs_result.model_dump(mode="json", exclude_none=True) == cloud_result.model_dump(
+        mode="json", exclude_none=True
+    )
+    # With the toggle on, both rows come back, sorted descending.
+    numbers = [row.number for row in fs_result.decisions]
+    assert numbers == [2, 1]

--- a/packages/nauro/tests/test_list_decisions_parity.py
+++ b/packages/nauro/tests/test_list_decisions_parity.py
@@ -1,0 +1,173 @@
+"""Surface-level parity for the local ``list_decisions`` adapters.
+
+After the kernel cutover, every local surface that exposes
+``list_decisions`` must produce the same envelope for the same arguments
+against the same store. This file pins that envelope shape across the
+two adapter wirings that exist today.
+
+Two compressions vs. the ``check_decision`` parity test:
+
+* No CLI surface. There is no ``nauro list-decisions`` command. Auto-gen
+  of ``nauro tool <name>`` from MCP ToolSpecs is deferred; adding a
+  hand-written CLI mirror now would be speculative.
+* No FastAPI surface. The local server does not expose a
+  ``/list_decisions`` endpoint. Adding one purely to mirror the parity
+  shape would be speculative infrastructure; the cross-store layer-3
+  test (``test_list_decisions_cross_surface``) covers local-vs-cloud
+  parity once the cloud Store exists.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+from nauro_core.decision_model import (
+    Decision,
+    DecisionConfidence,
+    DecisionStatus,
+    format_decision,
+)
+
+from nauro.constants import REPO_CONFIG_MODE_LOCAL
+from nauro.demo import create_demo_project
+from nauro.mcp.stdio_server import list_decisions as stdio_list_decisions
+from nauro.mcp.tools import tool_list_decisions
+from nauro.onboarding import WELCOME_NO_PROJECT
+from nauro.store.registry import register_project_v2
+from nauro.store.repo_config import save_repo_config
+
+
+@pytest.fixture
+def demo_repo(tmp_path, monkeypatch):
+    """Seed a demo project + chdir into the repo so cwd resolution wins."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    pid, store_path = register_project_v2("parity-project", [repo], mode=REPO_CONFIG_MODE_LOCAL)
+    save_repo_config(repo, {"mode": REPO_CONFIG_MODE_LOCAL, "id": pid, "name": "parity-project"})
+    create_demo_project(store_path)
+    monkeypatch.chdir(repo)
+    return pid, store_path
+
+
+@pytest.fixture
+def empty_repo(tmp_path, monkeypatch):
+    """Register a project with an empty store (no decisions) and chdir in."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    pid, store_path = register_project_v2("empty-project", [repo], mode=REPO_CONFIG_MODE_LOCAL)
+    save_repo_config(repo, {"mode": REPO_CONFIG_MODE_LOCAL, "id": pid, "name": "empty-project"})
+    # Create the store path but no decisions/ subdir.
+    store_path.mkdir(parents=True, exist_ok=True)
+    monkeypatch.chdir(repo)
+    return pid, store_path
+
+
+def _stdio_envelope(pid: str, *, limit: int = 20, include_superseded: bool = False) -> dict:
+    return stdio_list_decisions(project_id=pid, limit=limit, include_superseded=include_superseded)
+
+
+def _tool_envelope(store_path: Path, *, limit: int = 20, include_superseded: bool = False) -> dict:
+    """Direct call to the local tool, no transport wrapper."""
+    return tool_list_decisions(store_path, limit, include_superseded)
+
+
+def test_empty_store_envelope_matches_across_surfaces(empty_repo):
+    pid, store_path = empty_repo
+    stdio = _stdio_envelope(pid)
+    tool = _tool_envelope(store_path)
+    assert stdio == tool
+    assert stdio == {"store": "local", "decisions": []}
+
+
+def test_populated_store_envelope_matches_across_surfaces(demo_repo):
+    pid, store_path = demo_repo
+    stdio = _stdio_envelope(pid)
+    tool = _tool_envelope(store_path)
+    assert stdio == tool
+    # Locked envelope shape: store + decisions list, no error / status keys.
+    assert stdio["store"] == "local"
+    assert isinstance(stdio["decisions"], list)
+    assert stdio["decisions"], "demo project seeds 7 active decisions"
+    # All demo decisions are active and seeded with date + decision_type,
+    # so every row carries the full set of optional keys.
+    for row in stdio["decisions"]:
+        for key in ("number", "title", "date", "status", "type", "confidence"):
+            assert key in row, f"missing field {key!r} in row {row!r}"
+        assert row["status"] == "active"
+
+
+def test_include_superseded_toggle_matches_across_surfaces(demo_repo):
+    pid, store_path = demo_repo
+    stdio_default = _stdio_envelope(pid, include_superseded=False)
+    tool_default = _tool_envelope(store_path, include_superseded=False)
+    assert stdio_default == tool_default
+
+    stdio_with = _stdio_envelope(pid, include_superseded=True)
+    tool_with = _tool_envelope(store_path, include_superseded=True)
+    assert stdio_with == tool_with
+
+    # Demo project has only active decisions, so both toggles return the
+    # same set; the parity assertion is the load-bearing one.
+    assert stdio_default == stdio_with
+
+
+def test_exclude_none_strips_unset_type_across_surfaces(tmp_path, monkeypatch):
+    """A row whose underlying ``decision_type`` is None omits ``type`` on both surfaces.
+
+    Pins the ``exclude_none=True`` serialization contract at the surface
+    layer: demo decisions all carry a ``decision_type``, so the strip
+    direction was previously only covered by the kernel test. This case
+    seeds a decision with no ``decision_type`` into a fresh
+    ``FilesystemStore`` and asserts both the stdio and direct-tool
+    envelopes drop the ``type`` key from that row.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    pid, store_path = register_project_v2("no-type-project", [repo], mode=REPO_CONFIG_MODE_LOCAL)
+    save_repo_config(repo, {"mode": REPO_CONFIG_MODE_LOCAL, "id": pid, "name": "no-type-project"})
+    decisions_dir = store_path / "decisions"
+    decisions_dir.mkdir(parents=True, exist_ok=True)
+    body = format_decision(
+        Decision(
+            date=date(2026, 1, 1),
+            confidence=DecisionConfidence.medium,
+            status=DecisionStatus.active,
+            num=1,
+            title="Decision without a type",
+            rationale="Seeded with decision_type unset to lock the exclude_none surface contract.",
+        )
+    )
+    (decisions_dir / "001-decision-without-a-type.md").write_text(body)
+    monkeypatch.chdir(repo)
+
+    stdio = _stdio_envelope(pid)
+    tool = _tool_envelope(store_path)
+    assert stdio == tool
+    assert len(stdio["decisions"]) == 1
+    row = stdio["decisions"][0]
+    assert "type" not in row
+    assert row == {
+        "number": 1,
+        "title": "Decision without a type",
+        "date": "2026-01-01",
+        "status": "active",
+        "confidence": "medium",
+    }
+
+
+def test_store_missing_guidance_branch_on_tool(tmp_path):
+    """The tool returns the welcome guidance envelope when the store path is absent.
+
+    Stdio cannot exercise this branch with the same envelope: when the
+    caller passes a known ``project_id`` whose store is missing, the
+    resolver raises ``StoreResolutionError`` with its own message before
+    the tool ever runs. The branch covered here is the
+    ``tool_list_decisions`` adapter's own missing-store check, which
+    remote transports (cloud HTTP MCP) also rely on.
+    """
+    missing_store = tmp_path / "no-such-store"
+    assert not missing_store.exists()
+    envelope = _tool_envelope(missing_store)
+    assert envelope == {"store": "local", "status": "error", "guidance": WELCOME_NO_PROJECT}


### PR DESCRIPTION
## Why

`list_decisions` was the next read tool still implementing its listing,
status filtering, sorting, and row projection inside the MCP transport
adapter. Each transport that wants to expose decision history (CLI,
local stdio MCP, cloud HTTP MCP) would otherwise re-derive the same
logic, which is exactly the drift the operations-kernel restructure is
meant to prevent.

## Approach

Move the operation into `nauro_core.operations.list_decisions` as a
pure callable that takes a `Store` and returns a typed
`ListDecisionsResult`. The MCP adapter shrinks to a four-line wrapper
that constructs a `FilesystemStore`, calls the kernel, and tacks the
local `store` envelope field on at the boundary.

This mirrors the get_decision and get_raw_file cutovers — same Store
protocol surface, same `exclude_none=True` serialization template, same
three-layer test architecture (kernel against `InMemoryStore`, local
surfaces against `FilesystemStore`, cross-store against the cloud
`Store` impl in the consumer package).

Rejected: keeping the logic inline in the adapter (would block the
cloud transport from sharing it) and adding `total_count`/`next_page`
sibling fields to the Result (speculative until a client surfaces a
concrete need).

## What changed

* New kernel module `nauro_core.operations.list_decisions` plus
  `DecisionSummary` and `ListDecisionsResult` in `operations.results`.
* `operations.__init__` exports the new callable and types.
* `tool_list_decisions` delegates to the kernel; the in-adapter parse +
  filter + sort + projection body is gone. `DecisionStatus` and
  `_list_decisions` are no longer imported here (both are still in use
  elsewhere in the package).
* Layer 1: kernel tests against `InMemoryStore` covering empty store,
  single-row projection, sort-descending, limit truncation,
  `include_superseded` toggle in both directions, per-row
  `exclude_none` semantics, and frozen / extra-forbid invariants on
  both new result models.
* Layer 2: surface-level parity between stdio MCP and the direct tool
  call on empty / populated stores, the `include_superseded` toggle,
  the missing-store guidance branch, and the `exclude_none` strip
  direction (fresh fixture with `decision_type=None`).
* Layer 3: cross-store parity for `FilesystemStore` vs `CloudStore` via
  `pytest.importorskip` (skips in the public workspace, runs locally
  when both packages share a PYTHONPATH).

## What to review

* The `exclude_none=True` serialization is consistent with the previous
  two cutovers, but it's still a contract narrowing: a row whose
  underlying `type` or `date` is `None` now serializes without those
  keys instead of carrying `null`. Unobservable on the demo store and
  the current production store (every decision has both fields set),
  but worth flagging for downstream clients.
* The parity test's store-missing case asserts on the tool directly
  rather than against stdio. Stdio takes a different early-return path
  (`StoreResolutionError` with its own message) for a known
  `project_id` whose store is missing, so the surfaces cannot match by
  construction; the branch under test is the adapter's own
  `_check_store_exists` that cloud HTTP MCP will share.
* Row field names (`number`, `title`, `date`, `status`, `type`,
  `confidence`) preserve the pre-cutover envelope verbatim.

## Deferred

* Remote HTTP MCP rewiring lives in the batched cross-repo cutover.
* Auto-gen of `nauro tool <name>` is deferred; no CLI surface for this
  operation, hence no CLI parity layer.
* `total_count` / `next_page` sibling fields on the result.

## Test plan

* `uv run pytest packages/nauro-core/tests/operations/test_list_decisions.py -x -q` (11 passed)
* `uv run pytest packages/nauro-core/tests/operations/ -x -q` (66 passed)
* `uv run pytest packages/nauro/tests/test_list_decisions_parity.py -x -q` (5 passed)
* `uv run pytest packages/nauro/tests/test_list_decisions_cross_surface.py -x -q` (1 skipped — `mcp_server` import unavailable in this workspace; exercised locally when both packages share a PYTHONPATH)
* `uv run pytest packages/nauro/tests/test_mcp_tool_called.py packages/nauro/tests/test_stdio_server.py -x -q` (74 passed)
* `uv run pytest packages/nauro-core/tests/ packages/nauro/tests/ -x -q` (1422 passed, 4 skipped)
* `uv run ruff check packages/` (clean)
* `uv run ruff format --check packages/` (clean)
