### PR TITLE
feat(operations): cut get_context over to nauro_core kernel

### DIFF
--- a/packages/nauro-core/src/nauro_core/operations/__init__.py
+++ b/packages/nauro-core/src/nauro_core/operations/__init__.py
@@ -8,11 +8,13 @@ emit no telemetry; transports own event emission.
 
 from nauro_core.operations._in_memory_store import InMemoryStore as InMemoryStore
 from nauro_core.operations.check_decision import check_decision as check_decision
+from nauro_core.operations.get_context import get_context as get_context
 from nauro_core.operations.get_decision import get_decision as get_decision
 from nauro_core.operations.get_raw_file import get_raw_file as get_raw_file
 from nauro_core.operations.list_decisions import list_decisions as list_decisions
 from nauro_core.operations.results import CheckDecisionResult as CheckDecisionResult
 from nauro_core.operations.results import DecisionSummary as DecisionSummary
+from nauro_core.operations.results import GetContextResult as GetContextResult
 from nauro_core.operations.results import GetDecisionResult as GetDecisionResult
 from nauro_core.operations.results import GetRawFileResult as GetRawFileResult
 from nauro_core.operations.results import ListDecisionsResult as ListDecisionsResult
@@ -26,6 +28,7 @@ from . import results as results
 __all__ = [
     "CheckDecisionResult",
     "DecisionSummary",
+    "GetContextResult",
     "GetDecisionResult",
     "GetRawFileResult",
     "InMemoryStore",
@@ -34,6 +37,7 @@ __all__ = [
     "SearchHit",
     "Store",
     "check_decision",
+    "get_context",
     "get_decision",
     "get_raw_file",
     "list_decisions",

--- a/packages/nauro-core/src/nauro_core/operations/get_context.py
+++ b/packages/nauro-core/src/nauro_core/operations/get_context.py
@@ -1,0 +1,119 @@
+"""``get_context`` — assemble project context at L0/L1/L2 detail levels.
+
+Cross-transport implementation: CLI, local stdio MCP, and remote HTTP MCP
+all call this function with the same arguments and receive the same
+:class:`GetContextResult`. Each transport's adapter wraps the call to add
+transport-specific framing (``store`` field, telemetry emission, onboarding
+sentinels, snapshot-diff trailers); the level dispatch and markdown
+assembly are shared by construction.
+
+Only the five locked Store primitives are used: the snapshot/diff layer
+and the "Last synced" trailer remain adapter concerns since they sit
+outside the kernel's storage protocol.
+"""
+
+from __future__ import annotations
+
+from nauro_core.constants import (
+    OPEN_QUESTIONS_MD,
+    PROJECT_MD,
+    STACK_MD,
+    STATE_CURRENT_FILENAME,
+    STATE_HISTORY_FILENAME,
+    STATE_MD,
+)
+from nauro_core.context import build_l0, build_l1, build_l2
+from nauro_core.decision_model import Decision, parse_decision
+from nauro_core.operations.results import ErrorPayload, GetContextResult
+from nauro_core.operations.store import Store
+
+# build_l0/l1/l2 read questions content from the ``questions.md`` key
+# (a builder-internal convention that predates the ``open-questions.md``
+# on-disk filename). The kernel rebinds the loaded content under that
+# key so the builders find it.
+_QUESTIONS_BUILDER_KEY = "questions.md"
+
+# Builder dispatch keyed by level. Keeping this as a module-level dict
+# rather than an if/elif keeps the level-set check (``level in _BUILDERS``)
+# the single source of truth for valid levels.
+_BUILDERS = {
+    0: build_l0,
+    1: build_l1,
+    2: build_l2,
+}
+
+
+def _load_decisions(store: Store) -> list[Decision]:
+    decisions: list[Decision] = []
+    for stem in store.list_decisions():
+        body = store.read_decision(stem)
+        if body is None:
+            continue
+        decisions.append(parse_decision(body, f"{stem}.md"))
+    return decisions
+
+
+def _load_context_files(store: Store, level: int) -> dict[str, str]:
+    """Load the markdown files the context builders consume.
+
+    L0 deliberately omits ``project.md``: the AGENTS.md surface re-includes
+    that content and rendering it twice would push every L0 caller over its
+    token budget. L1/L2 carry it. Each builder ignores keys it does not
+    use, so the remaining files are loaded unconditionally.
+    """
+    files: dict[str, str] = {}
+    if level != 0:
+        project = store.read_file(PROJECT_MD)
+        if project is not None:
+            files[PROJECT_MD] = project
+
+    stack = store.read_file(STACK_MD)
+    if stack is not None:
+        files[STACK_MD] = stack
+
+    questions = store.read_file(OPEN_QUESTIONS_MD)
+    if questions is not None:
+        files[_QUESTIONS_BUILDER_KEY] = questions
+
+    # Prefer state_current.md; fall back to state.md for pre-upgrade stores.
+    # Truthy check (not ``is not None``) so a migration that left an empty
+    # state_current.md placeholder still falls through to the populated
+    # legacy state.md — matches the pre-cutover ``_load_files`` contract.
+    current = store.read_file(STATE_CURRENT_FILENAME)
+    if current:
+        files[STATE_CURRENT_FILENAME] = current
+    else:
+        legacy = store.read_file(STATE_MD)
+        if legacy is not None:
+            files[STATE_MD] = legacy
+
+    if level == 2:
+        history = store.read_file(STATE_HISTORY_FILENAME)
+        if history is not None:
+            files[STATE_HISTORY_FILENAME] = history
+
+    return files
+
+
+def get_context(store: Store, level: int) -> GetContextResult:
+    """Return assembled project context at the requested level.
+
+    Args:
+        store: Storage adapter providing the five locked primitives.
+        level: Context tier — ``0`` (concise), ``1`` (working set), or
+            ``2`` (full dump).
+
+    Returns:
+        :class:`GetContextResult`. On the success path ``content`` carries
+        the assembled markdown. On the rejection path ``error`` is
+        populated with ``kind="rejected"`` naming the offending level.
+    """
+    builder = _BUILDERS.get(level)
+    if builder is None:
+        return GetContextResult(
+            error=ErrorPayload(kind="rejected", reason=f"Invalid level: {level}"),
+        )
+
+    files = _load_context_files(store, level)
+    decisions = _load_decisions(store)
+    return GetContextResult(content=builder(files, decisions))

--- a/packages/nauro-core/src/nauro_core/operations/results.py
+++ b/packages/nauro-core/src/nauro_core/operations/results.py
@@ -80,6 +80,25 @@ class GetDecisionResult(BaseModel):
     error: ErrorPayload | None = None
 
 
+class GetContextResult(BaseModel):
+    """Return shape for :func:`nauro_core.operations.get_context`.
+
+    On the success path ``content`` holds the assembled L0/L1/L2 markdown
+    payload. On the rejection path ``error`` is populated with
+    ``kind="rejected"`` (invalid level); ``content`` stays unset. The
+    ``store`` field is not part of the model; transport adapters add it
+    back at serialization time. The result intentionally stays a single
+    text field — the kernel-side ``build_l0/l1/l2`` already return
+    assembled markdown, so structured sub-fields would duplicate that
+    work without buying the surface anything.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    content: str | None = None
+    error: ErrorPayload | None = None
+
+
 class GetRawFileResult(BaseModel):
     """Return shape for :func:`nauro_core.operations.get_raw_file`.
 

--- a/packages/nauro-core/tests/operations/test_get_context.py
+++ b/packages/nauro-core/tests/operations/test_get_context.py
@@ -1,0 +1,196 @@
+"""Kernel-level tests for ``operations.get_context`` against ``InMemoryStore``.
+
+Each test seeds an ``InMemoryStore`` and asserts on the typed
+:class:`GetContextResult` directly. Surface-level wiring tests live in
+each transport's own suite. The kernel does not read snapshots, append
+the ``Last synced`` trailer, or emit the ``NO_CONTEXT_YET`` sentinel —
+those decorations belong to the transport adapter and are pinned by the
+surface-layer parity tests instead.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+from nauro_core.decision_model import (
+    Decision,
+    DecisionConfidence,
+    DecisionStatus,
+    format_decision,
+)
+from nauro_core.operations import (
+    GetContextResult,
+    InMemoryStore,
+    get_context,
+)
+
+
+def _seeded_store() -> InMemoryStore:
+    """Build a populated store covering every recognised context file."""
+    body = format_decision(
+        Decision(
+            num=1,
+            title="Adopt Postgres",
+            rationale="ACID compliance trumps document flexibility for this workload.",
+            confidence=DecisionConfidence.high,
+            status=DecisionStatus.active,
+            date=date(2026, 1, 1),
+        )
+    )
+    return InMemoryStore(
+        files={
+            "project.md": "# Project\n\nGoal: build the thing.\n",
+            "state_current.md": "# Current State\n\nShipping v1.\n",
+            "state_history.md": "## 2026-04-01T10:00Z\n\nEarlier note.\n",
+            "stack.md": "# Stack\n- **Python 3.11** — primary language\n",
+            "open-questions.md": "# Open Questions\n- [Q1] Do we cache?\n",
+        },
+        decisions={"001-adopt-postgres": body},
+    )
+
+
+def test_returns_result_type() -> None:
+    result = get_context(InMemoryStore(), 0)
+    assert isinstance(result, GetContextResult)
+
+
+def test_invalid_level_returns_rejected_error() -> None:
+    result = get_context(InMemoryStore(), 7)
+    assert result.content is None
+    assert result.error is not None
+    assert result.error.kind == "rejected"
+    assert result.error.reason == "Invalid level: 7"
+
+
+def test_l0_on_empty_store_returns_empty_string() -> None:
+    result = get_context(InMemoryStore(), 0)
+    assert result.error is None
+    assert result.content == ""
+
+
+def test_l1_on_empty_store_returns_empty_string() -> None:
+    result = get_context(InMemoryStore(), 1)
+    assert result.error is None
+    assert result.content == ""
+
+
+def test_l2_on_empty_store_returns_empty_string() -> None:
+    result = get_context(InMemoryStore(), 2)
+    assert result.error is None
+    assert result.content == ""
+
+
+def test_l0_omits_project_md() -> None:
+    """L0 deliberately drops project.md — AGENTS.md re-includes it."""
+    result = get_context(_seeded_store(), 0)
+    assert result.content is not None
+    assert "Goal: build the thing." not in result.content
+    # L0 still renders state, stack, and decisions.
+    assert "Current State" in result.content
+    assert "Python 3.11" in result.content
+    assert "Adopt Postgres" in result.content
+
+
+def test_l1_includes_project_md_and_full_decisions() -> None:
+    result = get_context(_seeded_store(), 1)
+    assert result.content is not None
+    assert "Goal: build the thing." in result.content
+    # L1 carries the full decision body, including rationale.
+    assert "ACID compliance" in result.content
+
+
+def test_l2_includes_state_history() -> None:
+    result = get_context(_seeded_store(), 2)
+    assert result.content is not None
+    assert "Earlier note." in result.content
+    assert "Adopt Postgres" in result.content
+
+
+def test_legacy_state_md_falls_back_when_state_current_missing() -> None:
+    """Pre-upgrade stores with only state.md still surface state content."""
+    store = InMemoryStore(
+        files={
+            "state.md": "# State\n\n## Current\nLegacy current state.\n",
+            "stack.md": "# Stack\n- Python\n",
+        }
+    )
+    result = get_context(store, 1)
+    assert result.content is not None
+    assert "Legacy current state." in result.content
+
+
+def test_empty_state_current_falls_back_to_legacy_state_md() -> None:
+    """A migration placeholder (empty state_current.md) must not mask state.md.
+
+    Pre-cutover the local reader used a truthy check on ``state_current.md``
+    content, so a store left mid-migration with an empty placeholder still
+    surfaced the populated legacy ``state.md`` body. The kernel preserves
+    that behaviour — pinning it here so the fallback can't regress to
+    ``is not None`` again.
+    """
+    store = InMemoryStore(
+        files={
+            "state_current.md": "",
+            "state.md": "# State\n\n## Current\nLegacy body survives.\n",
+            "stack.md": "# Stack\n- Python\n",
+        }
+    )
+    for level in (0, 1, 2):
+        result = get_context(store, level)
+        assert result.content is not None, f"level {level} returned None content"
+        assert "Legacy body survives." in result.content, (
+            f"level {level} did not fall through to state.md: {result.content!r}"
+        )
+
+
+def test_exclude_none_strips_unset_fields_on_hit() -> None:
+    result = get_context(_seeded_store(), 0)
+    dumped = result.model_dump(mode="json", exclude_none=True)
+    assert "content" in dumped
+    assert "error" not in dumped
+
+
+def test_exclude_none_strips_unset_fields_on_miss() -> None:
+    result = get_context(InMemoryStore(), -1)
+    dumped = result.model_dump(mode="json", exclude_none=True)
+    assert dumped == {
+        "error": {"kind": "rejected", "reason": "Invalid level: -1"},
+    }
+    assert "content" not in dumped
+
+
+def test_store_field_absent_from_result_model_dump() -> None:
+    """Transports own the ``store`` field; the kernel never emits it."""
+    result = get_context(InMemoryStore(), 0)
+    dumped = result.model_dump(mode="json")
+    assert "store" not in dumped
+
+
+def test_no_snapshot_diff_in_l2_content() -> None:
+    """Snapshot reads are outside the locked Store protocol — the kernel
+    never assembles the snapshot-diff trailer; that belongs to the
+    transport adapter."""
+    result = get_context(_seeded_store(), 2)
+    assert result.content is not None
+    assert "Snapshot Diff" not in result.content
+
+
+def test_no_last_synced_trailer_in_l0_content() -> None:
+    """The ``Last synced`` trailer is an adapter-side decoration.
+
+    The state file may itself contain a ``**Last synced:**`` marker (the
+    transport mines that line to render its own italic trailer); the kernel
+    output passes the marker through as-is but never appends the italicised
+    trailer line of its own.
+    """
+    store = InMemoryStore(
+        files={
+            "state_current.md": "# Current State\n\n**Last synced:** 2026-05-21\n",
+            "stack.md": "# Stack\n- Python\n",
+        }
+    )
+    result = get_context(store, 0)
+    assert result.content is not None
+    # The italic trailer ``*Last synced: <value>*`` is appended by the
+    # transport adapter; the kernel content must not carry it.
+    assert "\n\n*Last synced:" not in result.content

--- a/packages/nauro-core/tests/operations/test_results.py
+++ b/packages/nauro-core/tests/operations/test_results.py
@@ -8,6 +8,7 @@ from pydantic import ValidationError
 from nauro_core.operations.results import (
     DecisionSummary,
     ErrorPayload,
+    GetContextResult,
     GetDecisionResult,
     ListDecisionsResult,
     RelatedDecision,
@@ -276,3 +277,38 @@ def test_search_decisions_result_is_frozen() -> None:
     result = SearchDecisionsResult()
     with pytest.raises(ValidationError):
         result.results = [SearchHit(number=1, title="x", status="active", score=0.5)]
+
+
+def test_get_context_result_success_with_content() -> None:
+    result = GetContextResult(content="# Current State\n\nShipping v1.\n")
+    assert result.content == "# Current State\n\nShipping v1.\n"
+    assert result.error is None
+
+
+def test_get_context_result_error_with_payload() -> None:
+    result = GetContextResult(error=ErrorPayload(kind="rejected", reason="Invalid level: 7"))
+    assert result.content is None
+    assert result.error is not None
+    assert result.error.kind == "rejected"
+    assert result.error.reason == "Invalid level: 7"
+
+
+def test_get_context_result_exclude_none_strips_empties() -> None:
+    success = GetContextResult(content="body")
+    assert success.model_dump(mode="json", exclude_none=True) == {"content": "body"}
+
+    miss = GetContextResult(error=ErrorPayload(kind="rejected", reason="Invalid level: 9"))
+    assert miss.model_dump(mode="json", exclude_none=True) == {
+        "error": {"kind": "rejected", "reason": "Invalid level: 9"},
+    }
+
+
+def test_get_context_result_rejects_unknown_fields() -> None:
+    with pytest.raises(ValidationError):
+        GetContextResult(content="body", unexpected_field="value")
+
+
+def test_get_context_result_is_frozen() -> None:
+    result = GetContextResult(content="body")
+    with pytest.raises(ValidationError):
+        result.content = "reassigned"

--- a/packages/nauro/src/nauro/mcp/payloads.py
+++ b/packages/nauro/src/nauro/mcp/payloads.py
@@ -1,23 +1,39 @@
-"""Payload builders for MCP tool responses.
+"""Internal payload builders used by AGENTS.md generation and the store validator.
 
-Thin wrappers around store.reader — all logic lives there.
+The MCP ``get_context`` tool boundary returns the kernel's dict envelope
+(see :func:`nauro.mcp.tools.tool_get_context`); these helpers stay string-
+returning because their callers — AGENTS.md regen, L0 token-budget
+validation — assemble their own surrounding markdown and only need the
+context body.
 """
 
 from pathlib import Path
 
-from nauro.store.reader import read_project_context
+from nauro_core.operations import get_context as _get_context_op
+
+from nauro.store.filesystem_store import FilesystemStore
+
+
+def _context_text(store_path: Path, level: int) -> str:
+    result = _get_context_op(FilesystemStore(store_path), level)
+    # Internal callers (AGENTS.md regen, validator) always pass a valid
+    # level today, so the kernel rejection branch is unreachable. Assert
+    # rather than swallow — surface any future drift loudly instead of
+    # rendering an empty payload into a published markdown file.
+    assert result.error is None, f"unexpected get_context error: {result.error}"
+    return result.content or ""
 
 
 def build_l0_payload(store_path: Path) -> str:
     """Build L0 payload (~2,000-4,000 tokens)."""
-    return read_project_context(store_path, level=0)
+    return _context_text(store_path, 0)
 
 
 def build_l1_payload(store_path: Path) -> str:
     """Build L1 payload (~4,000-6,000 tokens)."""
-    return read_project_context(store_path, level=1)
+    return _context_text(store_path, 1)
 
 
 def build_l2_payload(store_path: Path) -> str:
     """Build L2 payload (full content)."""
-    return read_project_context(store_path, level=2)
+    return _context_text(store_path, 2)

--- a/packages/nauro/src/nauro/mcp/server.py
+++ b/packages/nauro/src/nauro/mcp/server.py
@@ -141,6 +141,11 @@ async def get_context(req: ContextRequest) -> dict:
         payload = tool_get_context(store_path, req.level)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
+    # Kernel-side rejections (invalid level) surface as an ``error`` field
+    # on the envelope; preserve the pre-cutover 400 status by re-raising.
+    error = payload.get("error") if isinstance(payload, dict) else None
+    if error and error.get("kind") == "rejected":
+        raise HTTPException(status_code=400, detail=error.get("reason", "Invalid level"))
     return {"level": req.level, "content": payload}
 
 

--- a/packages/nauro/src/nauro/mcp/stdio_server.py
+++ b/packages/nauro/src/nauro/mcp/stdio_server.py
@@ -114,13 +114,13 @@ def get_context(
         Literal["L0", "L1", "L2"] | int,
         Field(description=_param_desc("get_context", "level")),
     ] = "L0",
-) -> str:
+) -> dict:
     try:
         store_path = _resolve_store(project_id, cwd)
     except NoProjectError:
-        return WELCOME_NO_PROJECT
+        return {"store": "local", "status": "error", "guidance": WELCOME_NO_PROJECT}
     except StoreResolutionError as exc:
-        return str(exc)
+        return {"store": "local", "status": "error", "guidance": str(exc)}
     # tool_get_context accepts both int and string levels.
     return tool_get_context(store_path, level)
 

--- a/packages/nauro/src/nauro/mcp/tools.py
+++ b/packages/nauro/src/nauro/mcp/tools.py
@@ -18,8 +18,10 @@ from nauro_core.constants import (
     MAX_RATIONALE_LENGTH,
     MAX_TITLE_LENGTH,
     STATE_CURRENT_FILENAME,
+    STATE_MD,
 )
 from nauro_core.operations import check_decision as _check_decision_op
+from nauro_core.operations import get_context as _get_context_op
 from nauro_core.operations import get_decision as _get_decision_op
 from nauro_core.operations import get_raw_file as _get_raw_file_op
 from nauro_core.operations import list_decisions as _list_decisions_op
@@ -32,7 +34,6 @@ from nauro_core.protocol import (
 )
 from nauro_core.validation import check_content_length, find_envelope_token
 
-from nauro.mcp.payloads import build_l0_payload, build_l1_payload, build_l2_payload
 from nauro.onboarding import (
     NO_CONTEXT_YET,
     WELCOME_NO_PROJECT,
@@ -44,7 +45,7 @@ from nauro.store.reader import (
 from nauro.store.reader import (
     resolve_decision_id,
 )
-from nauro.store.snapshot import capture_snapshot
+from nauro.store.snapshot import capture_snapshot, list_snapshots, load_snapshot
 from nauro.store.writer import append_question
 from nauro.store.writer import update_state as _write_state
 from nauro.telemetry.decorators import mcp_tool
@@ -125,21 +126,91 @@ def _coerce_level(level: int | str) -> int:
     return level
 
 
+def _last_synced_trailer(store_path: Path) -> str:
+    """Return the italicised ``*Last synced: ...*`` trailer or empty string.
+
+    Mirrors the pre-cutover local-L0 behaviour: scan state_current.md
+    (with legacy state.md fallback) for the ``**Last synced:**`` marker
+    and render the value into an italic line the kernel content can be
+    appended to. No-op when the marker is absent.
+    """
+    state = ""
+    current = store_path / STATE_CURRENT_FILENAME
+    if current.exists():
+        state = current.read_text()
+    else:
+        legacy = store_path / STATE_MD
+        if legacy.exists():
+            state = legacy.read_text()
+    marker = "**Last synced:**"
+    line = next((line for line in state.splitlines() if marker in line), None)
+    if line is None:
+        return ""
+    value = line.split(marker, 1)[1].strip()
+    return f"*Last synced: {value}*"
+
+
+def _snapshot_diff_section(store_path: Path) -> str:
+    """Render the trailing ``## Snapshot Diff (...)`` block, if any.
+
+    Reads the two most recent snapshots and produces a file-level diff
+    summary. Returns the empty string when there are fewer than two
+    snapshots or the diff has no entries.
+    """
+    snapshots = list_snapshots(store_path)
+    if len(snapshots) < 2:
+        return ""
+    prev = load_snapshot(store_path, snapshots[1]["version"])
+    curr = load_snapshot(store_path, snapshots[0]["version"])
+    prev_files = prev.get("files", {})
+    curr_files = curr.get("files", {})
+    lines: list[str] = []
+    for key in sorted(set(prev_files) | set(curr_files)):
+        if key not in prev_files:
+            lines.append(f"+ Added: {key}")
+        elif key not in curr_files:
+            lines.append(f"- Removed: {key}")
+        elif prev_files[key] != curr_files[key]:
+            lines.append(f"~ Modified: {key}")
+    if not lines:
+        return ""
+    header = f"## Snapshot Diff (v{prev['version']:03d} → v{curr['version']:03d})"
+    return header + "\n\n" + "\n".join(lines)
+
+
 @mcp_tool("get_context")
-def tool_get_context(store_path: Path, level: int | str) -> str:
+def tool_get_context(store_path: Path, level: int | str = "L0") -> dict:
     """Return project context at the requested detail level."""
     guidance = _check_store_exists(store_path)
     if guidance:
-        return guidance
+        return {"store": "local", "status": "error", "guidance": guidance}
+
     level_int = _coerce_level(level)
-    builders = {0: build_l0_payload, 1: build_l1_payload, 2: build_l2_payload}
-    builder = builders.get(level_int)
-    if builder is None:
-        raise ValueError(f"Invalid level: {level}. Use 0, 1, 2 or 'L0', 'L1', 'L2'.")
-    result = builder(store_path)
-    if not result.strip() or not _has_decisions(store_path):
-        return (result + "\n\n" + NO_CONTEXT_YET).strip() if result.strip() else NO_CONTEXT_YET
-    return result
+    result = _get_context_op(FilesystemStore(store_path), level_int)
+    envelope: dict = {"store": "local", **result.model_dump(mode="json", exclude_none=True)}
+
+    # Kernel-side rejection (invalid level) flows through unchanged; only
+    # decorate the success path.
+    if result.error is not None:
+        return envelope
+
+    content = result.content or ""
+
+    if level_int == 0:
+        trailer = _last_synced_trailer(store_path)
+        if trailer:
+            content = f"{content}\n\n{trailer}" if content else trailer
+
+    if level_int == 2:
+        diff_section = _snapshot_diff_section(store_path)
+        if diff_section:
+            content = f"{content}\n\n{diff_section}" if content else diff_section
+
+    if not content.strip() or not _has_decisions(store_path):
+        content = (content + "\n\n" + NO_CONTEXT_YET).strip() if content.strip() else NO_CONTEXT_YET
+
+    envelope["content"] = content
+    return envelope
 
 
 @mcp_tool("propose_decision")

--- a/packages/nauro/src/nauro/store/reader.py
+++ b/packages/nauro/src/nauro/store/reader.py
@@ -7,17 +7,13 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from nauro_core import extract_decision_number, parse_decision
-from nauro_core.context import build_l0, build_l1, build_l2
 from nauro_core.decision_model import Decision, DecisionStatus
 
 from nauro.constants import (
     DECISIONS_DIR,
     OPEN_QUESTIONS_MD,
-    PROJECT_MD,
     STACK_MD,
-    STATE_CURRENT_FILENAME,
     STATE_DIFF_FIELDS,
-    STATE_HISTORY_FILENAME,
     STATE_MD,
 )
 from nauro.store.snapshot import find_snapshot_near_date, list_snapshots, load_snapshot
@@ -101,124 +97,6 @@ def get_decision_history(store_path: Path, decision_id: str) -> list[Decision]:
         current = nxt
 
     return chain
-
-
-def read_project_context(store_path: Path, level: int = 0) -> str:
-    """Read and assemble context at the given tier level.
-
-    L0 (concise): state + stack summary + top 5 questions + last 3 decisions
-    L1 (working set): full stack + last 10 decisions + full questions
-    L2 (full): all decisions + full questions + snapshot diff
-
-    Args:
-        store_path: Path to the project store directory.
-        level: Context tier (0, 1, or 2).
-
-    Returns:
-        Assembled context string.
-    """
-    if level == 0:
-        return _build_l0_local(store_path)
-    elif level == 1:
-        return _build_l1_local(store_path)
-    else:
-        return _build_l2_local(store_path)
-
-
-def _load_files(store_path: Path, include_project: bool = True) -> dict[str, str]:
-    """Load store files into a dict for nauro_core context builders.
-
-    Prefers state_current.md; falls back to state.md for pre-upgrade stores.
-    """
-    files: dict[str, str] = {}
-    if include_project:
-        files["project.md"] = _read_file(store_path / PROJECT_MD)
-
-    current_state = _read_file(store_path / STATE_CURRENT_FILENAME)
-    if current_state:
-        files["state_current.md"] = current_state
-    else:
-        files["state.md"] = _read_file(store_path / STATE_MD)
-
-    files["stack.md"] = _read_file(store_path / STACK_MD)
-    files["questions.md"] = _read_file(store_path / OPEN_QUESTIONS_MD)
-    return files
-
-
-def _build_l0_local(store_path: Path) -> str:
-    """Build L0 payload with local-specific behavior.
-
-    Local L0 omits project.md (included via AGENTS.md instead) and
-    appends a "last synced" line from state.md.
-    """
-    files = _load_files(store_path, include_project=False)
-    decisions = _list_decisions(store_path)
-
-    result = build_l0(files, decisions)
-
-    # Local-specific: append "last synced" line from state
-    state = files.get("state_current.md") or files.get("state.md", "")
-    marker = "**Last synced:**"
-    synced_line = next((line for line in state.splitlines() if marker in line), None)
-    if synced_line is not None:
-        value = synced_line.split(marker, 1)[1].strip()
-        result += f"\n\n*Last synced: {value}*"
-
-    return result
-
-
-def _build_l1_local(store_path: Path) -> str:
-    """Build L1 payload — delegates to nauro_core."""
-    files = _load_files(store_path, include_project=True)
-    decisions = _list_decisions(store_path)
-    return build_l1(files, decisions)
-
-
-def _build_l2_local(store_path: Path) -> str:
-    """Build L2 payload with local-specific snapshot diff."""
-    files = _load_files(store_path)
-    # L2 includes state history
-    history = _read_file(store_path / STATE_HISTORY_FILENAME)
-    if history:
-        files["state_history.md"] = history
-    decisions = _list_decisions(store_path)
-
-    result = build_l2(files, decisions)
-
-    # Local-specific: append snapshot diff
-    snapshots = list_snapshots(store_path)
-    if len(snapshots) >= 2:
-        prev = load_snapshot(store_path, snapshots[1]["version"])
-        curr = load_snapshot(store_path, snapshots[0]["version"])
-        diff_lines = _file_level_diff(prev, curr)
-        if diff_lines:
-            diff_section = (
-                f"## Snapshot Diff (v{prev['version']:03d} → v{curr['version']:03d})\n\n"
-                + "\n".join(diff_lines)
-            )
-            if result:
-                result += "\n\n" + diff_section
-            else:
-                result = diff_section
-
-    return result
-
-
-def _file_level_diff(prev: dict, curr: dict) -> list[str]:
-    """Compute a simple file-level diff between two snapshots."""
-    prev_files = prev.get("files", {})
-    curr_files = curr.get("files", {})
-    all_keys = sorted(set(prev_files) | set(curr_files))
-
-    lines = []
-    for key in all_keys:
-        if key not in prev_files:
-            lines.append(f"+ Added: {key}")
-        elif key not in curr_files:
-            lines.append(f"- Removed: {key}")
-        elif prev_files[key] != curr_files[key]:
-            lines.append(f"~ Modified: {key}")
-    return lines
 
 
 def diff_snapshots(store_path: Path, version_a: int, version_b: int) -> str:

--- a/packages/nauro/tests/test_demo.py
+++ b/packages/nauro/tests/test_demo.py
@@ -7,8 +7,14 @@ import pytest
 
 from nauro import constants
 from nauro.demo import create_demo_project
-from nauro.store.reader import _list_decisions, read_project_context
+from nauro.mcp.tools import tool_get_context
+from nauro.store.reader import _list_decisions
 from nauro.store.snapshot import list_snapshots
+
+
+def read_project_context(store_path: Path, level: int = 0) -> str:
+    """Local test helper — keeps the existing assertions using str content."""
+    return tool_get_context(store_path, level)["content"]
 
 
 @pytest.fixture()

--- a/packages/nauro/tests/test_empty_states.py
+++ b/packages/nauro/tests/test_empty_states.py
@@ -45,8 +45,9 @@ def empty_store(tmp_path: Path) -> Path:
 class TestNoStore:
     def test_get_context_returns_guidance(self, nonexistent_store):
         result = tool_get_context(nonexistent_store, 0)
-        assert "nauro init" in result
-        assert "Welcome" in result
+        assert result["status"] == "error"
+        assert "nauro init" in result["guidance"]
+        assert "Welcome" in result["guidance"]
 
     def test_propose_decision_returns_guidance(self, nonexistent_store):
         result = tool_propose_decision(nonexistent_store, title="Test", rationale="Testing")
@@ -82,7 +83,8 @@ class TestNoStore:
 class TestEmptyStore:
     def test_get_context_includes_no_context_guidance(self, empty_store):
         result = tool_get_context(empty_store, 0)
-        assert "no context data yet" in result or "propose_decision" in result
+        content = result["content"]
+        assert "no context data yet" in content or "propose_decision" in content
 
     def test_check_decision_returns_no_decisions_guidance(self, empty_store):
         result = tool_check_decision(empty_store, "Use Redis")

--- a/packages/nauro/tests/test_get_context_cross_surface.py
+++ b/packages/nauro/tests/test_get_context_cross_surface.py
@@ -1,0 +1,131 @@
+"""Layer-3 cross-surface parity for ``get_context``.
+
+The surface-level parity test (``test_get_context_parity``) covers the
+local adapters against the same ``FilesystemStore``. This file goes one
+layer deeper: the same kernel call against ``FilesystemStore`` and
+``mcp_server.store.cloud_store.CloudStore`` must produce the same
+:class:`GetContextResult` for the same fixed inputs. That is the
+no-drift-by-construction guarantee the operations-kernel doctrine commits
+to.
+
+CloudStore is consumed by other transports and is not always installed in
+the same environment as ``nauro``. When this test runs from inside the
+nauro workspace alone, ``mcp_server`` is unavailable and the test skips
+at module load via ``pytest.importorskip``. Engineers who have both
+packages on a single ``PYTHONPATH`` exercise it locally to catch
+local-vs-cloud envelope drift before merge.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+cloud_store_module = pytest.importorskip(
+    "mcp_server.store.cloud_store",
+    reason="CloudStore is consumed by other transports; not always installed alongside nauro.",
+)
+boto3 = pytest.importorskip("boto3", reason="boto3 needed to seed a moto S3 bucket.")
+moto = pytest.importorskip("moto", reason="moto needed for in-memory S3.")
+
+# Imports below ``importorskip`` deliberately run only when both packages are
+# installed; ruff E402 does not apply here.
+from nauro_core.decision_model import (  # noqa: E402
+    Decision,
+    DecisionConfidence,
+    DecisionStatus,
+    format_decision,
+)
+from nauro_core.operations import get_context  # noqa: E402
+
+from nauro.store.filesystem_store import FilesystemStore  # noqa: E402
+
+CloudStore = cloud_store_module.CloudStore
+
+TEST_BUCKET = "nauro-cross-surface-test"
+TEST_USER_ID = "01TEST" + "0" * 20
+TEST_PROJECT_ID = "01TESTPROJECT00000000000"
+
+# Fixed seed: project + state + stack + questions + two active decisions.
+# Mirrored byte-for-byte across both stores so any envelope drift is a
+# real bug rather than a fixture mismatch.
+SEED_FILES: dict[str, str] = {
+    "project.md": "# Project\n\nGoal: cross-store parity.\n",
+    "state_current.md": "# Current State\n\n- Shipped Auth0 cutover\n",
+    "stack.md": "# Stack\n- **Python 3.11** — primary language\n",
+    "open-questions.md": "# Open Questions\n- [Q1] Do we add Redis?\n",
+}
+
+SEED_DECISIONS: dict[str, str] = {
+    "001-use-auth0-for-authentication": format_decision(
+        Decision(
+            num=1,
+            title="Use Auth0 for authentication",
+            rationale=(
+                "Auth0 provides OAuth 2.1 support and handles JWT validation across the platform."
+            ),
+            confidence=DecisionConfidence.high,
+            status=DecisionStatus.active,
+        )
+    ),
+    "002-use-fastapi-for-mcp-server": format_decision(
+        Decision(
+            num=2,
+            title="Use FastAPI for MCP server",
+            rationale=("FastAPI plus Mangum is the canonical Lambda deployment combination."),
+            confidence=DecisionConfidence.medium,
+            status=DecisionStatus.active,
+        )
+    ),
+}
+
+
+def _seed_filesystem_store(root: Path) -> FilesystemStore:
+    root.mkdir(parents=True, exist_ok=True)
+    for name, body in SEED_FILES.items():
+        (root / name).write_text(body)
+    decisions_dir = root / "decisions"
+    decisions_dir.mkdir(parents=True, exist_ok=True)
+    for stem, body in SEED_DECISIONS.items():
+        (decisions_dir / f"{stem}.md").write_text(body)
+    return FilesystemStore(root)
+
+
+def _seed_cloud_store(s3_client) -> CloudStore:
+    prefix = f"users/{TEST_USER_ID}/projects/{TEST_PROJECT_ID}"
+    for name, body in SEED_FILES.items():
+        s3_client.put_object(Bucket=TEST_BUCKET, Key=f"{prefix}/{name}", Body=body.encode())
+    for stem, body in SEED_DECISIONS.items():
+        s3_client.put_object(
+            Bucket=TEST_BUCKET,
+            Key=f"{prefix}/decisions/{stem}.md",
+            Body=body.encode(),
+        )
+    return CloudStore(user_id=TEST_USER_ID, project_id=TEST_PROJECT_ID)
+
+
+@pytest.fixture
+def both_stores(tmp_path, monkeypatch):
+    """Yield a (FilesystemStore, CloudStore) pair seeded with identical content."""
+    monkeypatch.setenv("NAURO_S3_BUCKET", TEST_BUCKET)
+
+    with moto.mock_aws():
+        s3_client = boto3.client("s3", region_name="us-east-1")
+        s3_client.create_bucket(Bucket=TEST_BUCKET)
+
+        fs_store = _seed_filesystem_store(tmp_path)
+        cloud = _seed_cloud_store(s3_client)
+        yield fs_store, cloud
+
+
+@pytest.mark.parametrize("level", [0, 1, 2])
+def test_get_context_result_matches_across_stores(both_stores, level):
+    fs_store, cloud = both_stores
+
+    fs_result = get_context(fs_store, level)
+    cloud_result = get_context(cloud, level)
+
+    assert fs_result.model_dump(mode="json", exclude_none=True) == cloud_result.model_dump(
+        mode="json", exclude_none=True
+    )

--- a/packages/nauro/tests/test_get_context_parity.py
+++ b/packages/nauro/tests/test_get_context_parity.py
@@ -1,0 +1,244 @@
+"""Surface-level parity for the local ``get_context`` adapters.
+
+After the kernel cutover, every local surface that exposes
+``get_context`` must produce the same envelope for the same arguments
+against the same store. The two wirings under test today are the
+``tool_get_context`` direct call and the stdio MCP wrapper that maps
+``project_id``/``cwd`` onto a store path.
+
+Two compressions vs. the ``check_decision`` parity test:
+
+* No CLI surface. There is no ``nauro get-context`` command — auto-gen
+  of ``nauro tool <name>`` from MCP ToolSpecs is deferred; a
+  hand-written CLI mirror now would be speculative.
+* No FastAPI surface as a parity participant. The local server's
+  ``/context`` endpoint wraps the envelope inside a ``{"level": N,
+  "content": <dict>}`` body so the byte-identical envelope assertion
+  belongs to ``test_mcp`` instead; equality across stdio and direct tool
+  is enough at this layer.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+from nauro_core.decision_model import (
+    Decision,
+    DecisionConfidence,
+    DecisionStatus,
+    format_decision,
+)
+
+from nauro.constants import REPO_CONFIG_MODE_LOCAL
+from nauro.mcp.stdio_server import get_context as stdio_get_context
+from nauro.mcp.tools import tool_get_context
+from nauro.store.registry import register_project_v2
+from nauro.store.repo_config import save_repo_config
+
+
+def _seed(store_path: Path, *decisions: Decision) -> None:
+    decisions_dir = store_path / "decisions"
+    decisions_dir.mkdir(parents=True, exist_ok=True)
+    for d in decisions:
+        slug = d.title.lower().replace(" ", "-")
+        (decisions_dir / f"{d.num:03d}-{slug}.md").write_text(format_decision(d))
+
+
+@pytest.fixture
+def seeded_repo(tmp_path, monkeypatch):
+    """Seed a project with two decisions plus the canonical store files."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    pid, store_path = register_project_v2("parity-context", [repo], mode=REPO_CONFIG_MODE_LOCAL)
+    save_repo_config(repo, {"mode": REPO_CONFIG_MODE_LOCAL, "id": pid, "name": "parity-context"})
+    store_path.mkdir(parents=True, exist_ok=True)
+    (store_path / "project.md").write_text("# Project\n\nGoal: ship the thing.\n")
+    (store_path / "state_current.md").write_text("# Current State\n\n- Shipped Postgres adoption\n")
+    (store_path / "stack.md").write_text("# Stack\n- **Python 3.11** — primary language\n")
+    (store_path / "open-questions.md").write_text("# Open Questions\n- [Q1] Should we add Redis?\n")
+    _seed(
+        store_path,
+        Decision(
+            date=date(2026, 1, 1),
+            confidence=DecisionConfidence.high,
+            status=DecisionStatus.active,
+            num=1,
+            title="Use Auth0 for authentication",
+            rationale="Auth0 provides OAuth 2.1 support and handles JWT validation.",
+        ),
+        Decision(
+            date=date(2026, 1, 2),
+            confidence=DecisionConfidence.medium,
+            status=DecisionStatus.active,
+            num=2,
+            title="Use FastAPI for MCP server",
+            rationale="FastAPI plus Mangum is the Lambda deployment combination.",
+        ),
+    )
+    monkeypatch.chdir(repo)
+    return pid, store_path
+
+
+@pytest.fixture
+def empty_repo(tmp_path, monkeypatch):
+    """Register a project whose store has no decision content yet."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    pid, store_path = register_project_v2("empty-context", [repo], mode=REPO_CONFIG_MODE_LOCAL)
+    save_repo_config(repo, {"mode": REPO_CONFIG_MODE_LOCAL, "id": pid, "name": "empty-context"})
+    store_path.mkdir(parents=True, exist_ok=True)
+    monkeypatch.chdir(repo)
+    return pid, store_path
+
+
+@pytest.fixture
+def missing_store(tmp_path, monkeypatch):
+    """A repo with no associated Nauro project store at all."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    nonexistent = tmp_path / "projects" / "nope"
+    monkeypatch.chdir(repo)
+    return nonexistent
+
+
+def _stdio_envelope(pid: str, level) -> dict:
+    return stdio_get_context(project_id=pid, level=level)
+
+
+def _tool_envelope(store_path: Path, level) -> dict:
+    return tool_get_context(store_path, level)
+
+
+@pytest.mark.parametrize("level", ["L0", "L1", "L2"])
+def test_hit_envelope_matches_across_surfaces(seeded_repo, level):
+    pid, store_path = seeded_repo
+    stdio = _stdio_envelope(pid, level)
+    tool = _tool_envelope(store_path, level)
+    assert stdio == tool
+    assert stdio["store"] == "local"
+    assert isinstance(stdio["content"], str)
+    assert "Use Auth0" in stdio["content"]
+
+
+def test_empty_store_envelope_matches_across_surfaces(empty_repo):
+    pid, store_path = empty_repo
+    stdio = _stdio_envelope(pid, "L0")
+    tool = _tool_envelope(store_path, "L0")
+    assert stdio == tool
+    # Empty stores surface the NO_CONTEXT_YET trailer via the content body;
+    # the envelope itself stays the dict shape.
+    assert stdio["store"] == "local"
+    assert "no context data yet" in stdio["content"] or "propose_decision" in stdio["content"]
+
+
+def test_invalid_level_rejection_matches_across_surfaces(seeded_repo):
+    pid, store_path = seeded_repo
+    # Use a numeric level outside {0,1,2} so _coerce_level passes it through
+    # and the kernel surfaces the rejection.
+    stdio = _stdio_envelope(pid, 7)
+    tool = _tool_envelope(store_path, 7)
+    assert stdio == tool
+    assert stdio["store"] == "local"
+    assert stdio["error"]["kind"] == "rejected"
+    assert "Invalid level" in stdio["error"]["reason"]
+
+
+def test_missing_store_guidance_matches_across_surfaces(missing_store):
+    # Direct tool call against a nonexistent store path mirrors the stdio
+    # WELCOME_NO_PROJECT response shape.
+    tool = _tool_envelope(missing_store, "L0")
+    assert tool["store"] == "local"
+    assert tool["status"] == "error"
+    assert "nauro init" in tool["guidance"]
+
+
+# --- Byte-identical content parity against the pre-cutover baseline ---
+#
+# The baseline below is a snapshot of ``tool_get_context`` output taken
+# from ``main`` against the fixture seeded by ``_seed_baseline_store``.
+# Captured from ``tool_get_context`` against the seeded fixture at main
+# commit 3b9cffb (pre-cutover, ``feat(operations): cut search_decisions
+# over to nauro_core kernel``). The kernel + transport rewire must
+# reproduce it character-for-character; any drift indicates either a
+# transport-decoration regression (Last-synced trailer, snapshot diff,
+# NO_CONTEXT_YET sentinel) or a kernel content change.
+
+_BASELINE_L0 = """## Current State
+# Current State
+
+**Sprint:** ship beta
+**Blocker:** none
+
+- Shipped MCP cutovers PR2-5
+
+**Stack:** Python 3.11, FastAPI, PostgreSQL
+
+## Open Questions
+- [Q1] Do we add Redis for caching?
+
+## Recent Decisions
+- D2 — Use FastAPI (2026-01-02)
+- D1 — Adopt Postgres (2026-01-01)"""
+
+
+def _seed_baseline_store(store_path: Path) -> None:
+    store_path.mkdir(parents=True, exist_ok=True)
+    (store_path / "decisions").mkdir(parents=True, exist_ok=True)
+    (store_path / "snapshots").mkdir(parents=True, exist_ok=True)
+    (store_path / "project.md").write_text(
+        "# Project\n\nGoal: ship Nauro CLI v1 with strong opinions.\n"
+    )
+    (store_path / "state_current.md").write_text(
+        "# Current State\n\n"
+        "**Sprint:** ship beta\n"
+        "**Blocker:** none\n"
+        "\n"
+        "- Shipped MCP cutovers PR2-5\n"
+    )
+    (store_path / "stack.md").write_text(
+        "# Stack\n\n"
+        "- **Python 3.11** — primary language\n"
+        "- **FastAPI** — HTTP framework\n"
+        "- **PostgreSQL** — primary store\n"
+    )
+    (store_path / "open-questions.md").write_text(
+        "# Open Questions\n\n- [Q1] Do we add Redis for caching?\n"
+    )
+    (store_path / "state_history.md").write_text("## 2026-04-01T10:00Z\n\nEarlier note.\n\n---\n")
+    for num, title, rationale, conf, iso in (
+        (
+            1,
+            "Adopt Postgres",
+            "ACID compliance trumps document flexibility for this workload.",
+            DecisionConfidence.high,
+            date(2026, 1, 1),
+        ),
+        (
+            2,
+            "Use FastAPI",
+            "FastAPI plus Mangum is the Lambda deployment combination.",
+            DecisionConfidence.medium,
+            date(2026, 1, 2),
+        ),
+    ):
+        body = format_decision(
+            Decision(
+                num=num,
+                title=title,
+                rationale=rationale,
+                confidence=conf,
+                status=DecisionStatus.active,
+                date=iso,
+            )
+        )
+        slug = title.lower().replace(" ", "-")
+        (store_path / "decisions" / f"{num:03d}-{slug}.md").write_text(body)
+
+
+def test_l0_content_matches_main_byte_for_byte(tmp_path):
+    store_path = tmp_path / "store"
+    _seed_baseline_store(store_path)
+    envelope = tool_get_context(store_path, 0)
+    assert envelope["content"] == _BASELINE_L0

--- a/packages/nauro/tests/test_log_diff.py
+++ b/packages/nauro/tests/test_log_diff.py
@@ -9,16 +9,27 @@ from typer.testing import CliRunner
 
 from nauro.cli.main import app
 from nauro.constants import SNAPSHOTS_DIR
+from nauro.mcp.tools import tool_get_context
 from nauro.store.reader import (
     diff_since_last_session,
     diff_snapshots,
-    read_project_context,
 )
 from nauro.store.snapshot import capture_snapshot, find_snapshot_near_date, load_snapshot
 from nauro.store.writer import append_decision, append_question, update_state
 from nauro.templates.scaffolds import scaffold_project_store
 
 runner = CliRunner()
+
+
+def read_project_context(store_path: Path, level: int = 0) -> str:
+    """Local test helper — keeps the existing assertions using str content.
+
+    The MCP boundary now returns a dict envelope; this shim extracts the
+    ``content`` field so the tests below can keep their pre-cutover shape
+    while exercising the same dispatch through ``tool_get_context``.
+    """
+    result = tool_get_context(store_path, level)
+    return result["content"]
 
 
 @pytest.fixture

--- a/packages/nauro/tests/test_mcp.py
+++ b/packages/nauro/tests/test_mcp.py
@@ -148,12 +148,18 @@ class TestL2Payload:
         append_decision(store, "New after snap 1", rationale="Testing diff")
         capture_snapshot(store, trigger="second")
 
-        payload = build_l2_payload(store)
-        assert "Snapshot Diff" in payload
+        # Snapshot-diff trailer is a transport-side decoration; surface it
+        # via tool_get_context, not the internal build_l2_payload helper.
+        from nauro.mcp.tools import tool_get_context
+
+        envelope = tool_get_context(store, 2)
+        assert "Snapshot Diff" in envelope["content"]
 
     def test_no_diff_without_snapshots(self, store: Path):
-        payload = build_l2_payload(store)
-        assert "Snapshot Diff" not in payload
+        from nauro.mcp.tools import tool_get_context
+
+        envelope = tool_get_context(store, 2)
+        assert "Snapshot Diff" not in envelope["content"]
 
 
 # --- Decisions summary tests ---
@@ -287,7 +293,9 @@ async def test_context_l0(client):
     assert resp.status_code == 200
     data = resp.json()
     assert data["level"] == 0
-    assert "content" in data
+    # ``content`` is now the kernel envelope dict, carrying its own ``content`` body.
+    assert data["content"]["store"] == "local"
+    assert isinstance(data["content"]["content"], str)
 
 
 @pytest.mark.asyncio
@@ -296,7 +304,8 @@ async def test_context_l1(client):
     assert resp.status_code == 200
     data = resp.json()
     assert data["level"] == 1
-    assert isinstance(data["content"], str) and len(data["content"]) > 0
+    body = data["content"]["content"]
+    assert isinstance(body, str) and len(body) > 0
 
 
 @pytest.mark.asyncio
@@ -305,7 +314,8 @@ async def test_context_l2(client):
     assert resp.status_code == 200
     data = resp.json()
     assert data["level"] == 2
-    assert isinstance(data["content"], str) and len(data["content"]) > 0
+    body = data["content"]["content"]
+    assert isinstance(body, str) and len(body) > 0
 
 
 @pytest.mark.asyncio

--- a/packages/nauro/tests/test_stdio_server.py
+++ b/packages/nauro/tests/test_stdio_server.py
@@ -76,21 +76,30 @@ class TestResolveStore:
 class TestGetContext:
     def test_l0_returns_current_state(self, store: Path):
         result = get_context(project_id="testproj", level=0)
-        assert "## Current State" in result
+        assert "## Current State" in result["content"]
 
     def test_l1_returns_full_stack(self, store: Path):
         result = get_context(project_id="testproj", level=1)
-        assert "# Stack" in result
-        assert "Python 3.11" in result
+        assert "# Stack" in result["content"]
+        assert "Python 3.11" in result["content"]
 
     def test_l2_returns_full_content(self, store: Path):
         result = get_context(project_id="testproj", level=2)
-        assert "Use FastAPI" in result
-        assert "Should we add caching?" in result
+        assert "Use FastAPI" in result["content"]
+        assert "Should we add caching?" in result["content"]
 
-    def test_invalid_level_raises(self, store: Path):
+    def test_invalid_level_rejection(self, store: Path):
+        # Invalid numeric levels surface as a kernel rejection envelope —
+        # `_coerce_level` rejects strings before reaching the kernel, so the
+        # ValueError path on string input is exercised separately below.
+        result = get_context(project_id="testproj", level=5)
+        assert result["store"] == "local"
+        assert result["error"]["kind"] == "rejected"
+        assert "Invalid level" in result["error"]["reason"]
+
+    def test_invalid_string_level_raises(self, store: Path):
         with pytest.raises(ValueError, match="Invalid level"):
-            get_context(project_id="testproj", level=5)
+            get_context(project_id="testproj", level="L9")
 
 
 class TestProposeDecision:

--- a/packages/nauro/tests/test_store.py
+++ b/packages/nauro/tests/test_store.py
@@ -8,10 +8,9 @@ import pytest
 from typer.testing import CliRunner
 
 from nauro.cli.main import app
+from nauro.mcp.tools import tool_get_context
 from nauro.store.reader import (
     _list_decisions,
-    _load_files,
-    read_project_context,
     resolve_decision_id,
 )
 from nauro.store.snapshot import capture_snapshot, list_snapshots, load_snapshot
@@ -23,6 +22,11 @@ from nauro.templates.scaffolds import (
 )
 
 runner = CliRunner()
+
+
+def read_project_context(store_path: Path, level: int = 0) -> str:
+    """Local test helper — keeps the existing assertions using str content."""
+    return tool_get_context(store_path, level)["content"]
 
 
 @pytest.fixture
@@ -255,27 +259,6 @@ def test_update_state_first_write_empty_store(tmp_path: Path):
 
 
 # --- Reader split-state tests ---
-
-
-def test_load_files_returns_state_current_key(store: Path):
-    """When state_current.md exists, _load_files returns it under that key."""
-    (store / "state_current.md").write_text("# Current State\n\nNew format")
-    files = _load_files(store)
-    assert "state_current.md" in files
-    assert "state.md" not in files
-
-
-def test_load_files_falls_back_to_state_md(tmp_path: Path):
-    """When only legacy state.md exists, _load_files returns it under state.md key."""
-    store = tmp_path / "legacy-store"
-    store.mkdir()
-    (store / "project.md").write_text("# Project\n")
-    (store / "state.md").write_text("# State\n\nLegacy content\n")
-    (store / "stack.md").write_text("# Stack\n")
-    (store / "open-questions.md").write_text("# Questions\n")
-    files = _load_files(store)
-    assert "state.md" in files
-    assert "state_current.md" not in files
 
 
 def test_l2_loads_state_history(store: Path):


### PR DESCRIPTION
## Why

`get_context` is the heaviest read tool in the operations-kernel
restructure: it composes multiple Store reads to assemble L0/L1/L2
markdown, threads transport-side decorations (`NO_CONTEXT_YET` sentinel,
"Last synced" trailer, snapshot diff), and was still living entirely in
`nauro.store.reader`. The local CLI/stdio adapter assembled the content
there, baked the decorations into the same function, and returned a
bare string the stdio handler passed through and the FastAPI handler
wrapped inline. Cloud transports duplicate the content-assembly half of
that work; without a shared kernel each transport drifts on its own.

## Approach

Move the content-assembly half to `nauro_core.operations.get_context`
behind the locked Store protocol; keep the snapshot read, the
`Last synced` trailer, and the `NO_CONTEXT_YET` sentinel as adapter-side
decorations on `tool_get_context`. The kernel returns a single-field
`GetContextResult(content: str | None, error: ErrorPayload | None)` —
considered and rejected was a structured per-section result, since
`build_l0/l1/l2` already produce assembled markdown and a richer model
would duplicate that work without surfacing anything callers actually
project on. Considered and rejected was preserving `tool_get_context`'s
bare-string return — every other cutover tool returns the
`{"store": "local", **dump}` envelope, and keeping `get_context`
inconsistent would block the dict-only batched mcp-server cutover.

`build_l0_payload` / `build_l1_payload` / `build_l2_payload` keep their
`str` return for the two internal callers that templating into wider
markdown (AGENTS.md generator, store validator); they delegate through
the kernel rather than staying separate functions.

## What changed

- **Kernel.** New `operations/get_context.py` doing level dispatch +
  file loading against the Store protocol. `GetContextResult` added to
  `operations/results.py` and re-exported from `operations/__init__.py`.
- **Transport.** `tool_get_context` now returns a dict envelope, applies
  the L0 trailer / L2 snapshot diff / `NO_CONTEXT_YET` sentinel locally,
  and surfaces kernel-side rejections under the standard `error` key.
  Stdio handler and FastAPI `/context` endpoint updated for the new
  shape — the FastAPI body becomes `{"level": N, "content": <dict>}`,
  a deliberate wire-shape change matching the rest of the cutover.
- **Reader.** Dropped `read_project_context`, `_build_l0/l1/l2_local`,
  `_load_files`, `_file_level_diff` from `nauro.store.reader`. Snapshot
  diff plumbing for the L2 trailer now lives in `nauro.mcp.tools`.
- **Tests.** Three layers per the operations-kernel doctrine: kernel
  against `InMemoryStore`, surface parity across stdio + direct tool
  with a byte-identical replay against the pre-cutover output, cross-
  surface against `FilesystemStore` + `CloudStore` (skips when
  `mcp_server` is not installed).

## What to review

- The kernel's L0 project.md omission. The local convention always
  dropped `project.md` from L0 because AGENTS.md re-includes it; the
  kernel encodes that as a feature so the byte-identical replay against
  `main` passes. Cloud transports inherit that omission today — flag if
  cloud should diverge.
- The `_QUESTIONS_BUILDER_KEY` rebind. `build_l0/l1/l2` historically
  read questions content from a `questions.md` key while the on-disk
  filename is `open-questions.md`; the kernel rebinds the loaded body
  to the builder key the same way the legacy `_load_files` did.
- The FastAPI `/context` body. Now nests `{"content": <dict>}` where
  the dict carries its own `content` field — natural consequence of the
  promotion but an HTTP wire-shape change.
- The empty-`state_current.md` legacy fallback. The kernel uses a
  truthy check (not `is not None`) so a migration that left an empty
  placeholder still falls through to a populated `state.md`. Pinned by
  `test_empty_state_current_falls_back_to_legacy_state_md`.

## What's deferred

- mcp-server cutover (batched with the other tools).
- Auto-generating `nauro tool <name>` from MCP ToolSpecs (open Q3 in
  the cutover plan).
- L2 snapshot diff content additions / level semantics — the kernel
  preserves the pre-cutover content byte-for-byte; semantic changes are
  separate decisions.
- FastAPI `/context` body cosmetic cleanup: the new envelope nests
  `{"level": N, "content": {"store": "local", "content": ...}}` with
  `content` at two levels. Functionally correct and tested; a follow-up
  can collapse the outer wrapper or rename the inner field.

## Test plan

- `packages/nauro-core/tests/operations/test_get_context.py` — 15 new
  kernel-level tests against `InMemoryStore`, including a regression
  pin for the empty-`state_current.md` legacy fallback.
- `packages/nauro-core/tests/operations/test_results.py` — 5 new
  `GetContextResult` shape/freeze/exclude_none tests.
- `packages/nauro/tests/test_get_context_parity.py` — surface parity
  across stdio + direct tool. L0 byte-identical replay against the
  captured `main` baseline; L1 and L2 verified via stdio-vs-direct +
  cross-store parity (the kernel composer is the same code path for
  all three levels).
- `packages/nauro/tests/test_get_context_cross_surface.py` — kernel-
  level parity across `FilesystemStore` + `CloudStore`; skips when
  `mcp_server` is not on the path.
- Full suite: 1462 passed, 6 skipped; `ruff check` and
  `ruff format --check` clean.
