### PR TITLE
feat(operations): cut update_state over to nauro_core kernel

### DIFF
--- a/packages/nauro-core/src/nauro_core/constants.py
+++ b/packages/nauro-core/src/nauro_core/constants.py
@@ -54,6 +54,17 @@ NO_DECISIONS_TO_CHECK = (
 # ── State field patterns (used in parsing and diffing) ──
 STATE_DIFF_FIELDS = ("Sprint", "Focus", "Blockers")
 
+# ── State keyword-overlap warning (used in update_state) ──
+# Surfaced when an incoming delta heavily mirrors a bullet already in
+# ``state_current.md`` — usually a sign the agent is re-reporting work
+# rather than logging new progress. The stop-word set drops generic
+# connectives so the overlap signal stays meaningful at the three-word
+# threshold.
+STATE_OVERLAP_MIN_KEYWORDS = 3
+STATE_OVERLAP_STOP_WORDS: frozenset[str] = frozenset(
+    {"the", "a", "an", "to", "and", "or", "is", "was", "-"}
+)
+
 # ── Decision types ──
 DECISION_TYPES: tuple[str, ...] = (
     "architecture",

--- a/packages/nauro-core/src/nauro_core/operations/__init__.py
+++ b/packages/nauro-core/src/nauro_core/operations/__init__.py
@@ -26,8 +26,10 @@ from nauro_core.operations.results import GetRawFileResult as GetRawFileResult
 from nauro_core.operations.results import ListDecisionsResult as ListDecisionsResult
 from nauro_core.operations.results import SearchDecisionsResult as SearchDecisionsResult
 from nauro_core.operations.results import SearchHit as SearchHit
+from nauro_core.operations.results import UpdateStateResult as UpdateStateResult
 from nauro_core.operations.search_decisions import search_decisions as search_decisions
 from nauro_core.operations.store import Store as Store
+from nauro_core.operations.update_state import update_state as update_state
 
 from . import results as results
 
@@ -43,6 +45,7 @@ __all__ = [
     "SearchDecisionsResult",
     "SearchHit",
     "Store",
+    "UpdateStateResult",
     "check_decision",
     "diff_since_last_session",
     "get_context",
@@ -51,4 +54,5 @@ __all__ = [
     "list_decisions",
     "results",
     "search_decisions",
+    "update_state",
 ]

--- a/packages/nauro-core/src/nauro_core/operations/results.py
+++ b/packages/nauro-core/src/nauro_core/operations/results.py
@@ -189,6 +189,25 @@ class SearchDecisionsResult(BaseModel):
     error: ErrorPayload | None = None
 
 
+class UpdateStateResult(BaseModel):
+    """Return shape for :func:`nauro_core.operations.update_state`.
+
+    ``status="ok"`` signals the kernel wrote a new ``state_current.md``
+    body (and appended history when a prior body existed). ``status="noop"``
+    signals the store had no existing state file at all — the adapter
+    short-circuits snapshot capture and cloud push on this branch.
+    ``warning`` carries an optional keyword-overlap caution. ``error``
+    stays unset on the kernel path; length validation lives on the
+    adapter side and surfaces through a separate envelope shape.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    status: Literal["ok", "noop"] = "ok"
+    warning: str | None = None
+    error: ErrorPayload | None = None
+
+
 class DiffSinceLastSessionResult(BaseModel):
     """Return shape for :func:`nauro_core.operations.diff_since_last_session`.
 

--- a/packages/nauro-core/src/nauro_core/operations/update_state.py
+++ b/packages/nauro-core/src/nauro_core/operations/update_state.py
@@ -1,0 +1,85 @@
+"""``update_state`` — replace current state with a new delta.
+
+Cross-transport implementation: CLI, local stdio MCP, and remote HTTP MCP
+all call this function with the same arguments and receive the same
+:class:`UpdateStateResult`. The kernel handles the read/migrate/write
+plumbing through the :class:`~nauro_core.operations.store.Store`
+protocol; snapshot capture, cloud-sync push, telemetry, and length
+validation stay on the adapter side.
+
+The kernel uses the migrated pure-function helpers in
+:mod:`nauro_core.state` (``prepare_state_update`` / ``migrate_legacy_state``)
+so the on-disk format is identical to the pre-cutover writer.
+"""
+
+from __future__ import annotations
+
+from nauro_core.constants import (
+    STATE_CURRENT_FILENAME,
+    STATE_HISTORY_FILENAME,
+    STATE_LEGACY_FILENAME,
+    STATE_OVERLAP_MIN_KEYWORDS,
+    STATE_OVERLAP_STOP_WORDS,
+)
+from nauro_core.operations.results import UpdateStateResult
+from nauro_core.operations.store import Store
+from nauro_core.state import migrate_legacy_state, prepare_state_update
+
+
+def update_state(store: Store, delta: str) -> UpdateStateResult:
+    """Replace current state with *delta*, archiving the prior body.
+
+    Args:
+        store: Storage adapter. The kernel reads ``state_current.md`` and
+            falls back to legacy ``state.md`` via :meth:`Store.read_file`;
+            both writes go through :meth:`Store.write_file`.
+        delta: New state body. Length validation lives on the adapter
+            side — the kernel writes whatever the adapter passes through.
+
+    Returns:
+        :class:`UpdateStateResult`. ``status="ok"`` on a successful write,
+        ``status="noop"`` when the store has no existing state file
+        (mirrors the pre-cutover writer's early-return). ``warning``
+        carries a keyword-overlap caution when the delta heavily mirrors
+        an existing bullet in ``state_current.md``.
+    """
+    current_content = store.read_file(STATE_CURRENT_FILENAME)
+    using_legacy = False
+    if current_content is None:
+        legacy_content = store.read_file(STATE_LEGACY_FILENAME)
+        if legacy_content is None:
+            return UpdateStateResult(status="noop")
+        using_legacy = True
+        migrated = migrate_legacy_state(legacy_content)
+        store.write_file(STATE_CURRENT_FILENAME, migrated.current_content)
+        current_content = migrated.current_content
+
+    warning = _overlap_warning(delta, current_content) if not using_legacy else None
+
+    result = prepare_state_update(delta, current_content)
+    store.write_file(STATE_CURRENT_FILENAME, result.current_content)
+
+    if result.history_entry is not None:
+        existing_history = store.read_file(STATE_HISTORY_FILENAME) or ""
+        store.write_file(STATE_HISTORY_FILENAME, existing_history + result.history_entry)
+
+    return UpdateStateResult(status="ok", warning=warning)
+
+
+def _overlap_warning(delta: str, current_content: str) -> str | None:
+    """Return a caution string when *delta* heavily mirrors a current entry.
+
+    Scans the current state body for bullet lines and flags the first one
+    that shares :data:`STATE_OVERLAP_MIN_KEYWORDS` or more non-stop-word
+    tokens with *delta*. Returns ``None`` when no qualifying overlap is
+    found.
+    """
+    delta_words = set(delta.lower().split())
+    for line in current_content.split("\n"):
+        if not line.startswith("- ") or "none yet" in line:
+            continue
+        line_words = set(line.lower().split())
+        overlap = delta_words & line_words - STATE_OVERLAP_STOP_WORDS
+        if len(overlap) >= STATE_OVERLAP_MIN_KEYWORDS:
+            return f"State update shares keywords with existing entry: {line.strip()}"
+    return None

--- a/packages/nauro-core/tests/operations/test_operations_update_state.py
+++ b/packages/nauro-core/tests/operations/test_operations_update_state.py
@@ -1,0 +1,193 @@
+"""Kernel-level tests for ``operations.update_state``.
+
+Each test seeds an :class:`~nauro_core.operations.InMemoryStore` so the
+read/write/migrate plumbing exercises the locked Store protocol without
+any filesystem dependency. Surface-level wiring (snapshot capture, push
+hooks, length validation) lives in the consumer package; the kernel
+must never reach into those primitives.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from nauro_core.constants import (
+    STATE_CURRENT_FILENAME,
+    STATE_HISTORY_FILENAME,
+    STATE_LEGACY_FILENAME,
+)
+from nauro_core.operations import (
+    InMemoryStore,
+    UpdateStateResult,
+    update_state,
+)
+
+
+def test_returns_result_type() -> None:
+    result = update_state(InMemoryStore(), "anything")
+    assert isinstance(result, UpdateStateResult)
+
+
+def test_empty_store_returns_noop_and_writes_nothing() -> None:
+    store = InMemoryStore()
+    result = update_state(store, "Brand new state")
+    assert result.status == "noop"
+    assert result.warning is None
+    assert result.error is None
+    # No write happened — the kernel mirrors the pre-cutover writer's
+    # early-return so the adapter can skip snapshot capture.
+    assert store.read_file(STATE_CURRENT_FILENAME) is None
+    assert store.read_file(STATE_HISTORY_FILENAME) is None
+
+
+def test_current_only_non_overlapping_writes_new_body_and_appends_history() -> None:
+    initial = "# Current State\n\n- Implemented OAuth login flow with PKCE\n"
+    store = InMemoryStore(files={STATE_CURRENT_FILENAME: initial})
+    result = update_state(store, "Reformatted README intro paragraph")
+    assert result.status == "ok"
+    assert result.warning is None
+    new_current = store.read_file(STATE_CURRENT_FILENAME)
+    assert new_current is not None
+    assert "Reformatted README intro paragraph" in new_current
+    assert new_current.startswith("# Current State")
+    # The prior body archived into state_history.md verbatim.
+    history = store.read_file(STATE_HISTORY_FILENAME)
+    assert history is not None
+    assert "Implemented OAuth login flow with PKCE" in history
+
+
+def test_current_only_overlapping_delta_surfaces_warning() -> None:
+    initial = "# Current State\n\n- Implemented OAuth login flow with PKCE\n"
+    store = InMemoryStore(files={STATE_CURRENT_FILENAME: initial})
+    result = update_state(store, "Implemented OAuth refresh logic with PKCE")
+    assert result.status == "ok"
+    assert result.warning is not None
+    assert "keywords" in result.warning.lower()
+    assert "Implemented OAuth login flow with PKCE" in result.warning
+
+
+def test_legacy_state_only_migrates_to_state_current() -> None:
+    legacy_body = "# State\n\n## Current\nLegacy content\n\n## History\n"
+    store = InMemoryStore(files={STATE_LEGACY_FILENAME: legacy_body})
+    result = update_state(store, "Post-upgrade task")
+    assert result.status == "ok"
+    # After migration the new state body is written.
+    current = store.read_file(STATE_CURRENT_FILENAME)
+    assert current is not None
+    assert "Post-upgrade task" in current
+    # The legacy body survives in state_history.md (migration archives the
+    # pre-existing body once the migrated current is replaced).
+    history = store.read_file(STATE_HISTORY_FILENAME)
+    assert history is not None
+    assert "Legacy content" in history
+
+
+def test_history_accumulates_across_repeated_writes() -> None:
+    initial = "# Current State\n\n- Task one\n"
+    store = InMemoryStore(files={STATE_CURRENT_FILENAME: initial})
+    update_state(store, "Task two")
+    update_state(store, "Task three")
+    current = store.read_file(STATE_CURRENT_FILENAME)
+    assert current is not None
+    assert "Task three" in current
+    assert "Task two" not in current
+    history = store.read_file(STATE_HISTORY_FILENAME)
+    assert history is not None
+    assert "Task one" in history
+    assert "Task two" in history
+
+
+def test_noop_result_exclude_none_strips_unset_fields() -> None:
+    result = update_state(InMemoryStore(), "anything")
+    dumped = result.model_dump(mode="json", exclude_none=True)
+    assert dumped == {"status": "noop"}
+
+
+def test_ok_result_exclude_none_strips_unset_warning() -> None:
+    initial = "# Current State\n\n- Task one\n"
+    store = InMemoryStore(files={STATE_CURRENT_FILENAME: initial})
+    result = update_state(store, "Reformat README")
+    dumped = result.model_dump(mode="json", exclude_none=True)
+    assert dumped == {"status": "ok"}
+
+
+def test_ok_result_with_warning_round_trips_in_dump() -> None:
+    initial = "# Current State\n\n- Implemented OAuth login flow with PKCE\n"
+    store = InMemoryStore(files={STATE_CURRENT_FILENAME: initial})
+    result = update_state(store, "Implemented OAuth refresh logic with PKCE")
+    dumped = result.model_dump(mode="json", exclude_none=True)
+    assert dumped["status"] == "ok"
+    assert "warning" in dumped
+
+
+def test_result_is_frozen() -> None:
+    result = update_state(InMemoryStore(), "x")
+    with pytest.raises(ValidationError):
+        result.status = "ok"
+
+
+def test_result_rejects_unknown_fields() -> None:
+    with pytest.raises(ValidationError):
+        UpdateStateResult(status="ok", unexpected_field="value")
+
+
+def test_store_field_absent_from_result_model_dump() -> None:
+    result = update_state(InMemoryStore(), "x")
+    dumped = result.model_dump(mode="json")
+    assert "store" not in dumped
+
+
+# --- Import-graph negative constraint ---
+#
+# The kernel must not depend on snapshot capture, sync hooks, or
+# pathlib — those are transport-side concerns that the locked Store
+# protocol abstracts over. Pinning the constraint as an AST scan keeps
+# the no-drift-by-construction guarantee from accidentally regressing
+# through a casual import.
+
+
+def _kernel_imports() -> set[str]:
+    module_path = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "nauro_core"
+        / "operations"
+        / "update_state.py"
+    )
+    tree = ast.parse(module_path.read_text())
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            for alias in node.names:
+                imported.add(f"{module}.{alias.name}")
+                imported.add(alias.name)
+                imported.add(module)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                imported.add(alias.name)
+    return imported
+
+
+def test_kernel_does_not_import_snapshot_or_sync_or_path() -> None:
+    imported = _kernel_imports()
+    forbidden_names = {
+        "nauro.store.snapshot",
+        "nauro.sync.hooks",
+        "capture_snapshot",
+        "push_after_write",
+        "pull_before_session",
+    }
+    leaked = forbidden_names & imported
+    assert not leaked, (
+        f"kernel imports adapter-side primitives: {leaked}; "
+        "those live on the transport, not in the kernel."
+    )
+    # pathlib stays out of the kernel — paths are strings through the Store.
+    assert "pathlib" not in imported and "pathlib.Path" not in imported, (
+        "kernel imports pathlib; the Store protocol abstracts paths as strings."
+    )

--- a/packages/nauro-core/tests/operations/test_results.py
+++ b/packages/nauro-core/tests/operations/test_results.py
@@ -15,6 +15,7 @@ from nauro_core.operations.results import (
     RelatedDecision,
     SearchDecisionsResult,
     SearchHit,
+    UpdateStateResult,
 )
 
 
@@ -353,3 +354,51 @@ def test_diff_since_last_session_result_is_frozen() -> None:
     result = DiffSinceLastSessionResult(diff="body")
     with pytest.raises(ValidationError):
         result.diff = "reassigned"
+
+
+def test_update_state_result_default_status_ok() -> None:
+    result = UpdateStateResult()
+    assert result.status == "ok"
+    assert result.warning is None
+    assert result.error is None
+
+
+def test_update_state_result_noop_status() -> None:
+    result = UpdateStateResult(status="noop")
+    assert result.status == "noop"
+    assert result.warning is None
+
+
+def test_update_state_result_with_warning() -> None:
+    result = UpdateStateResult(status="ok", warning="overlap caution")
+    assert result.warning == "overlap caution"
+
+
+def test_update_state_result_exclude_none_strips_empties() -> None:
+    noop = UpdateStateResult(status="noop")
+    assert noop.model_dump(mode="json", exclude_none=True) == {"status": "noop"}
+
+    plain = UpdateStateResult(status="ok")
+    assert plain.model_dump(mode="json", exclude_none=True) == {"status": "ok"}
+
+    with_warning = UpdateStateResult(status="ok", warning="careful")
+    assert with_warning.model_dump(mode="json", exclude_none=True) == {
+        "status": "ok",
+        "warning": "careful",
+    }
+
+
+def test_update_state_result_rejects_unknown_fields() -> None:
+    with pytest.raises(ValidationError):
+        UpdateStateResult(status="ok", unexpected_field="value")
+
+
+def test_update_state_result_rejects_invalid_status() -> None:
+    with pytest.raises(ValidationError):
+        UpdateStateResult(status="weird")
+
+
+def test_update_state_result_is_frozen() -> None:
+    result = UpdateStateResult(status="ok")
+    with pytest.raises(ValidationError):
+        result.status = "noop"

--- a/packages/nauro/src/nauro/cli/autogen.py
+++ b/packages/nauro/src/nauro/cli/autogen.py
@@ -28,11 +28,13 @@ from nauro.cli.utils import resolve_target_project
 from nauro.mcp import tools as mcp_tools
 from nauro.telemetry.transport import set_transport
 
-# Read tools that should auto-generate a CLI command. list_projects is
+# Tools that should auto-generate a CLI command. list_projects is
 # excluded — local installs auto-resolve to a single project and do not
-# need a discovery entry point. Any tool name added here must have a
-# matching ``tool_<name>`` adapter in ``nauro.mcp.tools``.
-READ_TOOL_ALLOWLIST: frozenset[str] = frozenset(
+# need a discovery entry point. Write tools opt in explicitly so future
+# additions to ALL_TOOLS cannot reach the CLI through this generator by
+# accident. Any tool name added here must have a matching ``tool_<name>``
+# adapter in ``nauro.mcp.tools``.
+AUTOGEN_ALLOWLIST: frozenset[str] = frozenset(
     {
         "get_context",
         "get_raw_file",
@@ -41,6 +43,7 @@ READ_TOOL_ALLOWLIST: frozenset[str] = frozenset(
         "diff_since_last_session",
         "search_decisions",
         "check_decision",
+        "update_state",
     }
 )
 
@@ -254,21 +257,21 @@ def _make_command(spec: ToolSpec) -> Callable[..., None]:
 
 
 def register_autogen_commands(app: typer.Typer) -> None:
-    """Register one Typer command per allowlisted read tool on ``app``.
+    """Register one Typer command per allowlisted tool on ``app``.
 
     The allowlist is verified against ``ALL_TOOLS`` so a typo in either
     surface fails loudly at import time.
     """
     registry_names = {spec["name"] for spec in ALL_TOOLS}
-    unknown = READ_TOOL_ALLOWLIST - registry_names
+    unknown = AUTOGEN_ALLOWLIST - registry_names
     if unknown:
         raise RuntimeError(
             f"Auto-gen allowlist references unknown tools: {sorted(unknown)}. "
-            "Update READ_TOOL_ALLOWLIST in cli/autogen.py."
+            "Update AUTOGEN_ALLOWLIST in cli/autogen.py."
         )
 
     for spec in ALL_TOOLS:
-        if spec["name"] not in READ_TOOL_ALLOWLIST:
+        if spec["name"] not in AUTOGEN_ALLOWLIST:
             continue
         command_name = _command_name(spec["name"])
         callback = _make_command(spec)

--- a/packages/nauro/src/nauro/cli/commands/import_cmd.py
+++ b/packages/nauro/src/nauro/cli/commands/import_cmd.py
@@ -10,11 +10,13 @@ from pathlib import Path
 from typing import Any
 
 import typer
+from nauro_core.operations import update_state as _update_state_op
 
 from nauro.cli.utils import resolve_target_project
 from nauro.constants import PROJECT_MD, STACK_MD
+from nauro.store.filesystem_store import FilesystemStore
 from nauro.store.snapshot import capture_snapshot
-from nauro.store.writer import append_decision, update_state
+from nauro.store.writer import append_decision
 
 
 def _import_memory_bank(memory_bank: Path, store_path: Path) -> dict[str, int]:
@@ -83,7 +85,7 @@ def _import_memory_bank(memory_bank: Path, store_path: Path) -> dict[str, int]:
 
     delta = _compose_state_delta(active_body, progress_items)
     if delta is not None:
-        update_state(store_path, delta)
+        _update_state_op(FilesystemStore(store_path), delta)
 
     return counts
 

--- a/packages/nauro/src/nauro/mcp/tools.py
+++ b/packages/nauro/src/nauro/mcp/tools.py
@@ -27,6 +27,7 @@ from nauro_core.operations import get_decision as _get_decision_op
 from nauro_core.operations import get_raw_file as _get_raw_file_op
 from nauro_core.operations import list_decisions as _list_decisions_op
 from nauro_core.operations import search_decisions as _search_decisions_op
+from nauro_core.operations import update_state as _update_state_op
 from nauro_core.protocol import (
     CHECK_DECISION_RETURNS,
     GET_DECISION_BEFORE_PROPOSING,
@@ -48,15 +49,11 @@ from nauro.store.snapshot import (
     resolve_diff_snapshots,
 )
 from nauro.store.writer import append_question
-from nauro.store.writer import update_state as _write_state
 from nauro.telemetry.decorators import mcp_tool
 from nauro.validation.pipeline import confirm_write, validate_proposed_write
 from nauro.validation.tier2 import check_similarity
 
 logger = logging.getLogger("nauro.mcp.tools")
-
-# Single source of truth for stop-words used in contradiction checks
-_STOP_WORDS = {"the", "a", "an", "to", "and", "or", "is", "was", "-"}
 
 
 def _reject_if_too_long(value: str, label: str, max_length: int) -> dict | None:
@@ -553,29 +550,20 @@ def tool_update_state(store_path: Path, delta: str) -> dict:
     if guidance:
         return {"store": "local", "status": "error", "guidance": guidance}
 
-    # Content size limits
+    # Length validation stays adapter-side — the kernel writes whatever the
+    # adapter passes through.
     err = _reject_if_too_long(delta, "Delta", MAX_DELTA_LENGTH)
     if err:
         return err
 
-    warning = None
-    state_path = store_path / STATE_CURRENT_FILENAME
-    if state_path.exists():
-        state_content = state_path.read_text()
-        delta_words = set(delta.lower().split())
-        for line in state_content.split("\n"):
-            if line.startswith("- ") and "none yet" not in line:
-                line_words = set(line.lower().split())
-                overlap = delta_words & line_words - _STOP_WORDS
-                if len(overlap) >= 3:
-                    warning = f"State update shares keywords with existing entry: {line.strip()}"
-                    break
+    result = _update_state_op(FilesystemStore(store_path), delta)
+    envelope: dict = {"store": "local", **result.model_dump(mode="json", exclude_none=True)}
 
-    _write_state(store_path, delta)
-    capture_snapshot(store_path, trigger=f"state: {delta}")
+    # Adapter-side side effects only run on the success path. ``noop``
+    # means the kernel had no existing state file to update — skip the
+    # snapshot/push to mirror the pre-cutover early-return semantics.
+    if result.status != "noop":
+        capture_snapshot(store_path, trigger=f"state: {delta}")
+        _try_push(store_path)
 
-    response: dict = {"store": "local", "status": "ok"}
-    if warning:
-        response["warning"] = warning
-    _try_push(store_path)
-    return response
+    return envelope

--- a/packages/nauro/src/nauro/store/writer.py
+++ b/packages/nauro/src/nauro/store/writer.py
@@ -29,15 +29,11 @@ from nauro_core.decision_model import (
     format_decision,
 )
 from nauro_core.questions import EntryBlock, OpenQuestionsFile, ResolveResult
-from nauro_core.state import migrate_legacy_state, prepare_state_update
 
 from nauro.constants import (
     DECISIONS_DIR,
     OPEN_QUESTIONS_MD,
     SLUG_MAX_LENGTH,
-    STATE_CURRENT_FILENAME,
-    STATE_HISTORY_FILENAME,
-    STATE_MD,
 )
 
 
@@ -308,28 +304,3 @@ def resolve_questions_in_file(
     result = file.resolve(ids, decision_num, decision_date)
     oq_path.write_text(result.file.format())
     return result
-
-
-def update_state(store_path: Path, delta: str) -> None:
-    """Replace the current state with *delta*, archiving the previous state."""
-    current_path = store_path / STATE_CURRENT_FILENAME
-    history_path = store_path / STATE_HISTORY_FILENAME
-    legacy_path = store_path / STATE_MD
-
-    current_content: str | None = None
-    if current_path.exists():
-        current_content = current_path.read_text()
-    elif legacy_path.exists():
-        legacy_content = legacy_path.read_text()
-        migrated = migrate_legacy_state(legacy_content)
-        current_path.write_text(migrated.current_content)
-        current_content = migrated.current_content
-    else:
-        return
-
-    result = prepare_state_update(delta, current_content)
-    current_path.write_text(result.current_content)
-
-    if result.history_entry is not None:
-        existing_history = history_path.read_text() if history_path.exists() else ""
-        history_path.write_text(existing_history + result.history_entry)

--- a/packages/nauro/tests/test_cli_autogen.py
+++ b/packages/nauro/tests/test_cli_autogen.py
@@ -20,7 +20,7 @@ import pytest
 from nauro_core.mcp_tools import ALL_TOOLS
 from typer.testing import CliRunner
 
-from nauro.cli.autogen import READ_TOOL_ALLOWLIST
+from nauro.cli.autogen import AUTOGEN_ALLOWLIST
 from nauro.cli.main import app
 from nauro.constants import REPO_CONFIG_MODE_LOCAL
 from nauro.demo import create_demo_project
@@ -62,17 +62,17 @@ def empty_repo(tmp_path: Path, monkeypatch) -> tuple[str, str, Path, Path]:
 
 
 class TestAutogenCoverage:
-    def test_every_read_tool_in_allowlist_is_registered(self) -> None:
+    def test_every_allowlisted_tool_is_registered(self) -> None:
         registered = _registered_command_names()
-        for name in READ_TOOL_ALLOWLIST:
+        for name in AUTOGEN_ALLOWLIST:
             kebab = name.replace("_", "-")
             assert kebab in registered, (
                 f"Auto-gen allowlist references {name!r} but no '{kebab}' command is registered."
             )
 
-    def test_no_write_tool_is_registered_via_autogen(self) -> None:
+    def test_write_tool_only_surfaces_when_explicitly_allowlisted(self) -> None:
         """A write tool added to ALL_TOOLS must NOT surface as an auto-gen
-        CLI command unless explicitly added to READ_TOOL_ALLOWLIST.
+        CLI command unless explicitly added to AUTOGEN_ALLOWLIST.
         """
         registered = _registered_command_names()
         write_tools = {
@@ -80,21 +80,30 @@ class TestAutogenCoverage:
         }
         for name in write_tools:
             kebab = name.replace("_", "-")
-            assert kebab not in registered, (
-                f"Write tool {name!r} surfaced as '{kebab}' — the auto-gen "
-                "allowlist must stay closed."
-            )
+            if name in AUTOGEN_ALLOWLIST:
+                assert kebab in registered, (
+                    f"Allowlisted write tool {name!r} did not surface as '{kebab}'."
+                )
+            else:
+                assert kebab not in registered, (
+                    f"Write tool {name!r} surfaced as '{kebab}' — the auto-gen "
+                    "allowlist must stay closed."
+                )
 
-    def test_allowlist_matches_registry_read_tools_minus_list_projects(self) -> None:
-        """All read-only registry tools except list_projects should be in
-        the allowlist. list_projects is local-resolution-only and excluded
-        intentionally; any other read tool we forgot to allowlist is a bug.
+    def test_allowlist_matches_registry_minus_list_projects(self) -> None:
+        """Every registry tool except ``list_projects`` and the write tools
+        that remain transport-only (``propose_decision``, ``confirm_decision``,
+        ``flag_question``) must be in the allowlist. ``list_projects`` stays
+        out because local installs auto-resolve to a single project.
         """
-        registry_read_tools = {
-            spec["name"] for spec in ALL_TOOLS if spec["annotations"].get("readOnlyHint", False)
+        registry_names = {spec["name"] for spec in ALL_TOOLS}
+        expected = registry_names - {
+            "list_projects",
+            "propose_decision",
+            "confirm_decision",
+            "flag_question",
         }
-        expected = registry_read_tools - {"list_projects"}
-        assert READ_TOOL_ALLOWLIST == expected
+        assert AUTOGEN_ALLOWLIST == expected
 
 
 # ── Per-tool happy + error paths ────────────────────────────────────────────

--- a/packages/nauro/tests/test_log_diff.py
+++ b/packages/nauro/tests/test_log_diff.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 from nauro_core.operations import diff_since_last_session as _diff_since_last_session_op
+from nauro_core.operations import update_state as _update_state_op
 from typer.testing import CliRunner
 
 from nauro.cli.main import app
@@ -17,8 +18,13 @@ from nauro.store.snapshot import (
     find_snapshot_near_date,
     load_snapshot,
 )
-from nauro.store.writer import append_decision, append_question, update_state
+from nauro.store.writer import append_decision, append_question
 from nauro.templates.scaffolds import scaffold_project_store
+
+
+def update_state(store_path: Path, delta: str) -> None:
+    """Thin wrapper preserving the pre-cutover ``writer.update_state`` shape."""
+    _update_state_op(FilesystemStore(store_path), delta)
 
 
 def diff_since_last_session(store_path: Path, days: int | None = None) -> str:

--- a/packages/nauro/tests/test_mcp.py
+++ b/packages/nauro/tests/test_mcp.py
@@ -4,12 +4,19 @@ from pathlib import Path
 
 import pytest
 from httpx import ASGITransport, AsyncClient
+from nauro_core.operations import update_state as _update_state_op
 
 from nauro.mcp.payloads import build_l0_payload, build_l1_payload, build_l2_payload
 from nauro.mcp.server import app
+from nauro.store.filesystem_store import FilesystemStore
 from nauro.store.snapshot import capture_snapshot
-from nauro.store.writer import append_decision, append_question, update_state
+from nauro.store.writer import append_decision, append_question
 from nauro.templates.scaffolds import scaffold_project_store
+
+
+def update_state(store_path: Path, delta: str) -> None:
+    """Thin wrapper preserving the pre-cutover ``writer.update_state`` shape."""
+    _update_state_op(FilesystemStore(store_path), delta)
 
 
 @pytest.fixture

--- a/packages/nauro/tests/test_store.py
+++ b/packages/nauro/tests/test_store.py
@@ -5,21 +5,34 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
+from nauro_core.operations import update_state as _update_state_op
 from typer.testing import CliRunner
 
 from nauro.cli.main import app
 from nauro.mcp.tools import tool_get_context
+from nauro.store.filesystem_store import FilesystemStore
 from nauro.store.reader import (
     _list_decisions,
     resolve_decision_id,
 )
 from nauro.store.snapshot import capture_snapshot, list_snapshots, load_snapshot
 from nauro.store.validator import validate_store
-from nauro.store.writer import append_decision, append_question, update_state
+from nauro.store.writer import append_decision, append_question
 from nauro.templates.scaffolds import (
     get_scaffolds,
     scaffold_project_store,
 )
+
+
+def update_state(store_path: Path, delta: str) -> None:
+    """Thin wrapper around the kernel for the legacy test surface.
+
+    Pre-cutover the tests called ``writer.update_state`` directly; the
+    write path now lives in :mod:`nauro_core.operations.update_state`.
+    Kept as a helper to preserve the test bodies verbatim.
+    """
+    _update_state_op(FilesystemStore(store_path), delta)
+
 
 runner = CliRunner()
 

--- a/packages/nauro/tests/test_sync/test_sync_command.py
+++ b/packages/nauro/tests/test_sync/test_sync_command.py
@@ -73,7 +73,12 @@ class TestSyncPreservesState:
     RICH_STATE = "Sprint 5: shipping feature X.\nBlockers: none.\nNext: write release notes."
 
     def _seed_rich_state(self, store):
-        from nauro.store.writer import update_state
+        from nauro_core.operations import update_state as _update_state_op
+
+        from nauro.store.filesystem_store import FilesystemStore
+
+        def update_state(store_path, delta):
+            _update_state_op(FilesystemStore(store_path), delta)
 
         update_state(store, self.RICH_STATE)
 
@@ -131,7 +136,12 @@ class TestSyncPreservesState:
     def test_legitimate_state_rotation_still_works(self, project_store):
         """Sanity check: update_state() calls between syncs still archive prior
         state into state_history.md — sync just stops doing this itself."""
-        from nauro.store.writer import update_state
+        from nauro_core.operations import update_state as _update_state_op
+
+        from nauro.store.filesystem_store import FilesystemStore
+
+        def update_state(store_path, delta):
+            _update_state_op(FilesystemStore(store_path), delta)
 
         self._seed_rich_state(project_store)
 

--- a/packages/nauro/tests/test_update_state_cross_surface.py
+++ b/packages/nauro/tests/test_update_state_cross_surface.py
@@ -1,0 +1,122 @@
+"""Cross-store parity for ``update_state``.
+
+The surface-level parity test (``test_update_state_parity``) covers the
+local adapters against the same ``FilesystemStore``. This file goes one
+layer deeper: the same kernel call against an identically-seeded store
+must produce the same :class:`UpdateStateResult` regardless of which
+``Store`` implementation is passed in.
+
+The kernel reads ``state_current.md`` (or migrates from legacy
+``state.md``) and writes through :meth:`Store.write_file`. Both
+operations sit on the locked Store protocol, so a ``FilesystemStore``
+and a ``CloudStore`` seeded with the same initial state must produce
+byte-identical results.
+
+``CloudStore`` is consumed by other transports and is not always
+installed alongside ``nauro``. When this test runs from inside the
+nauro workspace alone, the module skips at load via
+``pytest.importorskip``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+cloud_store_module = pytest.importorskip(
+    "mcp_server.store.cloud_store",
+    reason="CloudStore is consumed by other transports; not always installed alongside nauro.",
+)
+boto3 = pytest.importorskip("boto3", reason="boto3 needed to seed a moto S3 bucket.")
+moto = pytest.importorskip("moto", reason="moto needed for in-memory S3.")
+
+# Imports below ``importorskip`` deliberately run only when both packages are
+# installed; ruff E402 does not apply here.
+from nauro_core.constants import (  # noqa: E402
+    STATE_CURRENT_FILENAME,
+    STATE_HISTORY_FILENAME,
+    STATE_LEGACY_FILENAME,
+)
+from nauro_core.operations import update_state  # noqa: E402
+
+from nauro.store.filesystem_store import FilesystemStore  # noqa: E402
+
+CloudStore = cloud_store_module.CloudStore
+
+TEST_BUCKET = "nauro-update-state-cross-surface-test"
+TEST_USER_ID = "01TEST" + "0" * 20
+TEST_PROJECT_ID = "01TESTPROJECT00000000000"
+
+
+@pytest.fixture
+def both_stores(tmp_path, monkeypatch):
+    """Yield a (FilesystemStore, CloudStore) pair backed by separate roots."""
+    monkeypatch.setenv("NAURO_S3_BUCKET", TEST_BUCKET)
+
+    with moto.mock_aws():
+        s3_client = boto3.client("s3", region_name="us-east-1")
+        s3_client.create_bucket(Bucket=TEST_BUCKET)
+
+        fs_store = FilesystemStore(tmp_path)
+        cloud = CloudStore(user_id=TEST_USER_ID, project_id=TEST_PROJECT_ID)
+        yield fs_store, cloud
+
+
+def _seed_current(fs_store: FilesystemStore, cloud: CloudStore, body: str) -> None:
+    fs_store.write_file(STATE_CURRENT_FILENAME, body)
+    cloud.write_file(STATE_CURRENT_FILENAME, body)
+
+
+def _seed_legacy(fs_store: FilesystemStore, cloud: CloudStore, body: str) -> None:
+    fs_store.write_file(STATE_LEGACY_FILENAME, body)
+    cloud.write_file(STATE_LEGACY_FILENAME, body)
+
+
+def _dump(result) -> dict:
+    return result.model_dump(mode="json", exclude_none=True)
+
+
+def test_noop_branch_matches_across_stores(both_stores):
+    fs_store, cloud = both_stores
+
+    fs_result = update_state(fs_store, "anything")
+    cloud_result = update_state(cloud, "anything")
+
+    assert _dump(fs_result) == _dump(cloud_result) == {"status": "noop"}
+
+
+def test_ok_branch_matches_across_stores(both_stores):
+    fs_store, cloud = both_stores
+    _seed_current(fs_store, cloud, "# Current State\n\n- Task one\n")
+
+    fs_result = update_state(fs_store, "Task two")
+    cloud_result = update_state(cloud, "Task two")
+
+    assert _dump(fs_result) == _dump(cloud_result) == {"status": "ok"}
+    # Both stores must hold the same post-write content.
+    assert fs_store.read_file(STATE_CURRENT_FILENAME) == cloud.read_file(STATE_CURRENT_FILENAME)
+    assert fs_store.read_file(STATE_HISTORY_FILENAME) == cloud.read_file(STATE_HISTORY_FILENAME)
+
+
+def test_warning_branch_matches_across_stores(both_stores):
+    fs_store, cloud = both_stores
+    _seed_current(fs_store, cloud, "- Implemented OAuth login flow with PKCE\n")
+
+    fs_result = update_state(fs_store, "Implemented OAuth refresh logic with PKCE")
+    cloud_result = update_state(cloud, "Implemented OAuth refresh logic with PKCE")
+
+    assert _dump(fs_result) == _dump(cloud_result)
+    assert fs_result.warning is not None
+    assert "keywords" in fs_result.warning.lower()
+
+
+def test_legacy_migration_matches_across_stores(both_stores):
+    fs_store, cloud = both_stores
+    _seed_legacy(fs_store, cloud, "# State\n\n## Current\nLegacy content\n")
+
+    fs_result = update_state(fs_store, "Post-upgrade task")
+    cloud_result = update_state(cloud, "Post-upgrade task")
+
+    assert _dump(fs_result) == _dump(cloud_result) == {"status": "ok"}
+    # The migrated current and the archived legacy body must match between stores.
+    assert fs_store.read_file(STATE_CURRENT_FILENAME) == cloud.read_file(STATE_CURRENT_FILENAME)
+    assert fs_store.read_file(STATE_HISTORY_FILENAME) == cloud.read_file(STATE_HISTORY_FILENAME)

--- a/packages/nauro/tests/test_update_state_parity.py
+++ b/packages/nauro/tests/test_update_state_parity.py
@@ -1,0 +1,187 @@
+"""Surface-level parity for the local ``update_state`` adapters.
+
+After the kernel cutover, every local surface that exposes
+``update_state`` must produce the same envelope for the same arguments
+against the same store. Three wirings participate here:
+
+* ``tool_update_state`` — the direct adapter call. Returns the canonical
+  dict envelope every other surface is derived from.
+* ``nauro update-state`` — the CLI auto-gen command. Reaches the adapter
+  through the Typer entry point and prints the envelope as JSON.
+* The stdio MCP ``update_state`` tool — for FastMCP compatibility this
+  surface returns a human-readable string instead of the dict envelope.
+  We assert it matches the canonical string rendered from the tool
+  envelope; it does not participate in dict equality.
+
+The HTTP FastAPI server does not expose an ``/update_state`` endpoint;
+equality across the three surfaces above is the parity guarantee at
+this layer.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+from nauro.cli.main import app as cli_app
+from nauro.constants import REPO_CONFIG_MODE_LOCAL
+from nauro.mcp import tools as mcp_tools
+from nauro.mcp.stdio_server import update_state as stdio_update_state
+from nauro.mcp.tools import tool_update_state
+from nauro.store.registry import register_project_v2
+from nauro.store.repo_config import save_repo_config
+from nauro.templates.scaffolds import scaffold_project_store
+
+
+@pytest.fixture(autouse=True)
+def _no_push(monkeypatch):
+    """Suppress the best-effort cloud push so the parity layer stays local."""
+    monkeypatch.setattr(mcp_tools, "_try_push", lambda _store_path: None)
+
+
+@pytest.fixture
+def seeded_repo(tmp_path, monkeypatch):
+    """Register a project, scaffold the store, and chdir into the repo."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    pid, store_path = register_project_v2(
+        "parity-update-state",
+        [repo],
+        mode=REPO_CONFIG_MODE_LOCAL,
+    )
+    save_repo_config(
+        repo,
+        {"mode": REPO_CONFIG_MODE_LOCAL, "id": pid, "name": "parity-update-state"},
+    )
+    scaffold_project_store("parity-update-state", store_path)
+    monkeypatch.chdir(repo)
+    return pid, store_path
+
+
+@pytest.fixture
+def overlap_repo(tmp_path, monkeypatch):
+    """Repo whose state_current.md carries a bullet primed for keyword overlap."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    pid, store_path = register_project_v2(
+        "parity-update-state-overlap",
+        [repo],
+        mode=REPO_CONFIG_MODE_LOCAL,
+    )
+    save_repo_config(
+        repo,
+        {
+            "mode": REPO_CONFIG_MODE_LOCAL,
+            "id": pid,
+            "name": "parity-update-state-overlap",
+        },
+    )
+    scaffold_project_store("parity-update-state-overlap", store_path)
+    (store_path / "state_current.md").write_text("- Implemented OAuth login flow with PKCE\n")
+    monkeypatch.chdir(repo)
+    return pid, store_path
+
+
+@pytest.fixture
+def missing_store(tmp_path, monkeypatch):
+    """A repo with no associated project store at all."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    nonexistent = tmp_path / "projects" / "nope"
+    monkeypatch.chdir(repo)
+    return nonexistent
+
+
+def _cli_envelope(args: list[str]) -> tuple[int, dict | None, str]:
+    """Invoke the auto-gen CLI command and parse the JSON envelope."""
+    runner = CliRunner()
+    result = runner.invoke(cli_app, ["update-state", *args])
+    envelope: dict | None
+    if result.stdout.strip():
+        try:
+            envelope = json.loads(result.stdout)
+        except json.JSONDecodeError:
+            envelope = None
+    else:
+        envelope = None
+    return result.exit_code, envelope, result.output
+
+
+def _render_stdio_string(envelope: dict) -> str:
+    """Mirror the stdio surface's dict-to-string rendering rule."""
+    if envelope.get("status") == "error":
+        return envelope.get("guidance", "")
+    if envelope.get("warning"):
+        return f"State updated. {envelope['warning']}"
+    return "State updated."
+
+
+def test_ok_envelope_matches_across_tool_and_cli(seeded_repo):
+    pid, store_path = seeded_repo
+
+    tool_envelope = tool_update_state(store_path, "Shipped the parity test")
+    # Each surface mutates the same store, so seed a fresh delta per surface
+    # to keep the envelope shape the same (no warning) and exercise the rotation.
+    exit_code, cli_envelope, output = _cli_envelope(["Shipped the CLI surface"])
+    assert exit_code == 0, output
+    assert tool_envelope == {"store": "local", "status": "ok"}
+    assert cli_envelope == {"store": "local", "status": "ok"}
+
+    stdio_string = stdio_update_state(delta="Shipped the stdio surface", project_id=pid)
+    assert stdio_string == _render_stdio_string({"status": "ok"})
+
+
+def test_warning_envelope_matches_across_tool_and_cli(overlap_repo):
+    pid, store_path = overlap_repo
+
+    tool_envelope = tool_update_state(store_path, "Implemented OAuth refresh logic with PKCE")
+    assert tool_envelope["store"] == "local"
+    assert tool_envelope["status"] == "ok"
+    assert "warning" in tool_envelope
+    assert "keywords" in tool_envelope["warning"].lower()
+
+    # Re-seed the overlap line because the previous tool call rotated it
+    # into state_history.md.
+    (store_path / "state_current.md").write_text("- Implemented OAuth login flow with PKCE\n")
+    exit_code, cli_envelope, output = _cli_envelope(["Implemented OAuth refresh logic with PKCE"])
+    assert exit_code == 0, output
+    assert cli_envelope == tool_envelope
+
+    (store_path / "state_current.md").write_text("- Implemented OAuth login flow with PKCE\n")
+    stdio_string = stdio_update_state(
+        delta="Implemented OAuth refresh logic with PKCE",
+        project_id=pid,
+    )
+    assert stdio_string == _render_stdio_string(tool_envelope)
+
+
+def test_missing_store_guidance_matches_across_surfaces(missing_store):
+    tool_envelope = tool_update_state(missing_store, "anything")
+    assert tool_envelope["store"] == "local"
+    assert tool_envelope["status"] == "error"
+    assert "nauro init" in tool_envelope["guidance"]
+
+    # CLI auto-gen prints the envelope to stdout, then exits 1 with the
+    # guidance routed to stderr.
+    exit_code, cli_envelope, output = _cli_envelope(["anything"])
+    assert exit_code == 1
+    assert "nauro init" in output
+
+
+def test_length_rejection_matches_across_tool_and_cli(seeded_repo):
+    pid, store_path = seeded_repo
+    overlong = "x" * 10_000
+
+    tool_envelope = tool_update_state(store_path, overlong)
+    assert tool_envelope["store"] == "local"
+    assert tool_envelope["status"] == "rejected"
+    assert "exceeds" in tool_envelope["reason"].lower()
+
+    exit_code, cli_envelope, output = _cli_envelope([overlong])
+    # The auto-gen exit-code branch fires on the ``error`` / ``status: "error"``
+    # paths; a length rejection surfaces as ``status: "rejected"`` which exits 0
+    # but still carries the rejection reason in the printed envelope.
+    assert exit_code == 0, output
+    assert cli_envelope == tool_envelope


### PR DESCRIPTION
## Why

The local `update_state` write path lived in `nauro.store.writer.update_state`,
called from `tool_update_state` (which also owned its own keyword-overlap
warning loop) and from `nauro import`. The pre-cutover layout meant the
remote MCP server could not call the same write logic without copy-paste,
and the overlap stop-word set existed only in the local adapter.

## Approach

Move the read / migrate / write plumbing to a kernel `update_state`
operation against the locked `Store` protocol, alongside `check_decision`,
`get_context`, `list_decisions`, `search_decisions`, and the rest of the
already-cutover read operations. The adapter keeps the side effects that
do not belong on the Store protocol: length validation, snapshot capture,
best-effort cloud push. The kernel returns an `UpdateStateResult` with
`status="ok" | "noop"` plus an optional warning string; the adapter wraps
with `{"store": "local", ...}` at serialization time.

The keyword-overlap stop-word set and the three-keyword threshold move to
`nauro_core.constants` so any future remote adapter inherits the same
heuristic without duplication.

`nauro.store.writer.update_state` is deleted in this PR (rather than left
as a shim). The two affected callers — `nauro import` and the test suite —
call the kernel via `FilesystemStore` directly. Leaving a shim would have
preserved a duplicate write path that the rest of the package no longer
needs.

The auto-gen CLI allowlist extends to `update_state`. The constant
renames to `AUTOGEN_ALLOWLIST` to reflect that it now covers a write tool
alongside the existing read tools, and the closed-set test asserts the
registry minus `list_projects` and the three write tools that stay
transport-only (`propose_decision`, `confirm_decision`, `flag_question`).

## What changed

- `nauro_core.operations.update_state` — new kernel module with the
  read / migrate / write loop against the Store protocol.
- `nauro_core.operations.results.UpdateStateResult` — `{status, warning,
  error}` shape; frozen, `extra="forbid"`.
- `nauro_core.constants.STATE_OVERLAP_MIN_KEYWORDS` /
  `STATE_OVERLAP_STOP_WORDS` — promoted from the local adapter.
- `nauro.mcp.tools.tool_update_state` — rewired to the kernel; length
  validation, snapshot capture, and `_try_push` stay adapter-side.
- `nauro.store.writer.update_state` — removed.
- `nauro.cli.commands.import_cmd._import_memory_bank` — rewired to call
  the kernel via `FilesystemStore`.
- `nauro.cli.autogen.AUTOGEN_ALLOWLIST` — renamed from
  `READ_TOOL_ALLOWLIST`; `update_state` added.

## What to review

- The `noop` branch in the kernel: empty store (both `state_current.md`
  and legacy `state.md` missing) returns `status="noop"` without writing
  anything. The adapter checks for this and skips snapshot capture and
  cloud push, mirroring the pre-cutover writer's early return.
- The legacy migration path: when only legacy `state.md` exists, the
  kernel writes `state_current.md` with the migrated body, then
  `prepare_state_update` archives that body into history while writing
  the new delta as current. The overlap warning is intentionally
  suppressed on this branch; the migrated body is the first write into
  the new layout, not yet a peer entry the agent could be re-reporting.
- The stdio parity surface: stdio still returns a string for
  `update_state` (FastMCP write-tool convention shared with
  `flag_question`). The parity test asserts dict equality across the
  direct adapter and the CLI auto-gen surface, and pins the stdio string
  against a canonical render of the same envelope. If we want stdio to
  return a dict for write tools, that's a separate scope.

## What's deferred

- The three other local write tools (`flag_question`, `propose_decision`,
  `confirm_decision`) stay on their pre-cutover wiring. Each gets its
  own cutover PR.
- The remote `mcp-server` side will adopt the kernel `update_state` once
  every local write tool has cut over; bundling the cloud cutover with
  the local writes would couple unrelated review surfaces.
- The stdio write-tool rendering rule (string vs dict) — not in this PR.
- AGENTS.md regeneration content / format — unchanged.

## Test plan

- New kernel coverage: `packages/nauro-core/tests/operations/test_operations_update_state.py`
  (13 tests) — write / migrate / noop / overlap branches against
  `InMemoryStore`, plus an AST-based negative constraint that the kernel
  module does not import `nauro.store.snapshot`, `nauro.sync.hooks`, or
  `pathlib`.
- New surface parity: `packages/nauro/tests/test_update_state_parity.py`
  (4 tests) — dict equality across the direct adapter and `nauro
  update-state` CLI; stdio string asserted against the canonical render.
- New cross-store parity: `packages/nauro/tests/test_update_state_cross_surface.py`
  — `pytest.importorskip("mcp_server.store.cloud_store")` at module
  load; skipped here, exercised on environments with both packages on
  the path.
- `UpdateStateResult` coverage extended in
  `packages/nauro-core/tests/operations/test_results.py`.
- Closed-set auto-gen guard updated in
  `packages/nauro/tests/test_cli_autogen.py`: allowlist == registry
  minus `{list_projects, propose_decision, confirm_decision,
  flag_question}`.
- Full sweep: 1525 passed, 8 skipped across `nauro-core` + `nauro`.
- `ruff check` + `ruff format --check` clean.
