### PR TITLE
feat(operations): cut flag_question over to nauro_core kernel

### DIFF
--- a/packages/nauro-core/src/nauro_core/operations/__init__.py
+++ b/packages/nauro-core/src/nauro_core/operations/__init__.py
@@ -11,6 +11,7 @@ from nauro_core.operations.check_decision import check_decision as check_decisio
 from nauro_core.operations.diff_since_last_session import (
     diff_since_last_session as diff_since_last_session,
 )
+from nauro_core.operations.flag_question import flag_question as flag_question
 from nauro_core.operations.get_context import get_context as get_context
 from nauro_core.operations.get_decision import get_decision as get_decision
 from nauro_core.operations.get_raw_file import get_raw_file as get_raw_file
@@ -20,6 +21,7 @@ from nauro_core.operations.results import DecisionSummary as DecisionSummary
 from nauro_core.operations.results import (
     DiffSinceLastSessionResult as DiffSinceLastSessionResult,
 )
+from nauro_core.operations.results import FlagQuestionResult as FlagQuestionResult
 from nauro_core.operations.results import GetContextResult as GetContextResult
 from nauro_core.operations.results import GetDecisionResult as GetDecisionResult
 from nauro_core.operations.results import GetRawFileResult as GetRawFileResult
@@ -37,6 +39,7 @@ __all__ = [
     "CheckDecisionResult",
     "DecisionSummary",
     "DiffSinceLastSessionResult",
+    "FlagQuestionResult",
     "GetContextResult",
     "GetDecisionResult",
     "GetRawFileResult",
@@ -48,6 +51,7 @@ __all__ = [
     "UpdateStateResult",
     "check_decision",
     "diff_since_last_session",
+    "flag_question",
     "get_context",
     "get_decision",
     "get_raw_file",

--- a/packages/nauro-core/src/nauro_core/operations/flag_question.py
+++ b/packages/nauro-core/src/nauro_core/operations/flag_question.py
@@ -1,0 +1,74 @@
+"""``flag_question`` — append an open question with a sequential ``Q###`` id.
+
+Cross-transport implementation: CLI, local stdio MCP, and remote HTTP MCP
+all call this function with the same arguments and receive the same
+:class:`FlagQuestionResult`. The kernel owns the parse/scan/mint/insert
+plumbing through the :class:`~nauro_core.operations.store.Store` protocol;
+length validation, envelope-token rejection, similarity hinting, snapshot
+capture, and cloud-sync push stay on the adapter side.
+
+The insert routine mirrors the pre-cutover writer so the on-disk format
+stays byte-identical: the new entry is placed directly after the file's
+top-level ``# `` header, skipping blank lines and leading HTML comments.
+"""
+
+from __future__ import annotations
+
+from nauro_core.constants import OPEN_QUESTIONS_MD
+from nauro_core.operations.results import FlagQuestionResult
+from nauro_core.operations.store import Store
+from nauro_core.questions import EntryBlock, OpenQuestionsFile
+
+_DEFAULT_FILE_BODY = "# Open Questions\n"
+
+
+def flag_question(
+    store: Store,
+    question: str,
+    context: str | None = None,
+) -> FlagQuestionResult:
+    """Append *question* to ``open-questions.md`` with a fresh ``Q###`` id.
+
+    Args:
+        store: Storage adapter. The kernel reads ``open-questions.md`` via
+            :meth:`Store.read_file` and writes through
+            :meth:`Store.write_file`. The two calls happen back-to-back
+            within the same kernel invocation.
+        question: Composed question body. The adapter is responsible for
+            any caller-side composition (e.g. folding ``context`` into the
+            same line) before reaching the kernel.
+        context: Reserved for future kernel-side composition. Currently
+            unused — the adapter folds context into ``question`` and
+            passes ``None`` here so the on-disk format stays unchanged.
+
+    Returns:
+        :class:`FlagQuestionResult` with ``status="ok"`` and ``num`` set
+        to the newly-minted entry's sequential identifier.
+    """
+    del context  # adapter composes context into question; kernel sees one body.
+
+    content = store.read_file(OPEN_QUESTIONS_MD) or _DEFAULT_FILE_BODY
+    existing_nums = [
+        b.entry.num
+        for b in OpenQuestionsFile.parse(content).blocks
+        if isinstance(b, EntryBlock) and b.entry.num is not None
+    ]
+    next_num = max(existing_nums, default=0) + 1
+    entry = f"- [Q{next_num}] {question}"
+
+    lines = content.split("\n")
+    insert_idx = 1
+    for i, line in enumerate(lines):
+        if line.startswith("# "):
+            insert_idx = i + 1
+            break
+
+    while insert_idx < len(lines) and (
+        lines[insert_idx].strip() == "" or lines[insert_idx].startswith("<!--")
+    ):
+        insert_idx += 1
+
+    lines.insert(insert_idx, entry)
+    store.write_file(OPEN_QUESTIONS_MD, "\n".join(lines))
+
+    return FlagQuestionResult(status="ok", num=next_num)

--- a/packages/nauro-core/src/nauro_core/operations/results.py
+++ b/packages/nauro-core/src/nauro_core/operations/results.py
@@ -208,6 +208,24 @@ class UpdateStateResult(BaseModel):
     error: ErrorPayload | None = None
 
 
+class FlagQuestionResult(BaseModel):
+    """Return shape for :func:`nauro_core.operations.flag_question`.
+
+    ``status="ok"`` signals the kernel appended a new ``Q###`` entry to
+    ``open-questions.md``. ``num`` carries the minted identifier. The
+    error path stays unset on the kernel side; length validation,
+    envelope-token rejection, and similarity hinting live on the adapter
+    and surface through a separate envelope shape. ``store`` is not part
+    of the model; transport adapters add it back at serialization time.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    num: int | None = None
+    error: ErrorPayload | None = None
+
+
 class DiffSinceLastSessionResult(BaseModel):
     """Return shape for :func:`nauro_core.operations.diff_since_last_session`.
 

--- a/packages/nauro-core/tests/operations/test_operations_flag_question.py
+++ b/packages/nauro-core/tests/operations/test_operations_flag_question.py
@@ -1,0 +1,190 @@
+"""Kernel-level tests for ``operations.flag_question``.
+
+Each test seeds an :class:`~nauro_core.operations.InMemoryStore` so the
+scan-mint-insert plumbing exercises the locked Store protocol without
+any filesystem dependency. Surface-level wiring (snapshot capture, push
+hooks, length validation, similarity hinting, envelope-token rejection)
+lives in the consumer package; the kernel must never reach into those
+primitives.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from nauro_core.constants import OPEN_QUESTIONS_MD
+from nauro_core.operations import (
+    FlagQuestionResult,
+    InMemoryStore,
+    flag_question,
+)
+
+
+def test_returns_result_type() -> None:
+    result = flag_question(InMemoryStore(), "Should we ship X?")
+    assert isinstance(result, FlagQuestionResult)
+
+
+def test_empty_store_seeds_default_header_and_writes_q1() -> None:
+    store = InMemoryStore()
+    result = flag_question(store, "Should we ship X?")
+    assert result.status == "ok"
+    assert result.num == 1
+    content = store.read_file(OPEN_QUESTIONS_MD)
+    assert content is not None
+    assert content.startswith("# Open Questions")
+    assert "- [Q1] Should we ship X?" in content
+
+
+def test_existing_entries_mint_next_sequential_id() -> None:
+    seed = "# Open Questions\n- [Q3] First seeded question\n- [Q5] Second seeded question\n"
+    store = InMemoryStore(files={OPEN_QUESTIONS_MD: seed})
+    result = flag_question(store, "Third question")
+    assert result.status == "ok"
+    assert result.num == 6
+    content = store.read_file(OPEN_QUESTIONS_MD)
+    assert content is not None
+    assert "- [Q6] Third question" in content
+    # The two seeded entries survive verbatim.
+    assert "- [Q3] First seeded question" in content
+    assert "- [Q5] Second seeded question" in content
+
+
+def test_new_entry_inserts_after_header() -> None:
+    seed = "# Open Questions\n- [Q1] First\n"
+    store = InMemoryStore(files={OPEN_QUESTIONS_MD: seed})
+    flag_question(store, "Second")
+    content = store.read_file(OPEN_QUESTIONS_MD)
+    assert content is not None
+    lines = content.split("\n")
+    # Header, then new entry on top, then prior entry.
+    assert lines[0] == "# Open Questions"
+    assert lines[1] == "- [Q2] Second"
+    assert lines[2] == "- [Q1] First"
+
+
+def test_new_entry_skips_leading_html_comment() -> None:
+    seed = "# Open Questions\n<!-- managed automatically -->\n- [Q1] First\n"
+    store = InMemoryStore(files={OPEN_QUESTIONS_MD: seed})
+    flag_question(store, "Second")
+    content = store.read_file(OPEN_QUESTIONS_MD)
+    assert content is not None
+    lines = content.split("\n")
+    assert lines[0] == "# Open Questions"
+    assert lines[1] == "<!-- managed automatically -->"
+    assert lines[2] == "- [Q2] Second"
+    assert lines[3] == "- [Q1] First"
+
+
+def test_new_entry_skips_blank_line_after_header() -> None:
+    seed = "# Open Questions\n\n- [Q1] First\n"
+    store = InMemoryStore(files={OPEN_QUESTIONS_MD: seed})
+    flag_question(store, "Second")
+    content = store.read_file(OPEN_QUESTIONS_MD)
+    assert content is not None
+    lines = content.split("\n")
+    assert lines[0] == "# Open Questions"
+    assert lines[1] == ""
+    assert lines[2] == "- [Q2] Second"
+    assert lines[3] == "- [Q1] First"
+
+
+def test_repeated_writes_accumulate_sequential_ids() -> None:
+    store = InMemoryStore()
+    first = flag_question(store, "One")
+    second = flag_question(store, "Two")
+    third = flag_question(store, "Three")
+    assert (first.num, second.num, third.num) == (1, 2, 3)
+    content = store.read_file(OPEN_QUESTIONS_MD)
+    assert content is not None
+    assert content.count("- [Q") == 3
+
+
+def test_context_argument_is_currently_ignored() -> None:
+    """The adapter composes ``context`` into the question body, so the
+    kernel's ``context`` parameter has no effect on the written line."""
+    store = InMemoryStore()
+    result = flag_question(store, "Composed body", context="should not appear")
+    assert result.status == "ok"
+    content = store.read_file(OPEN_QUESTIONS_MD)
+    assert content is not None
+    assert "- [Q1] Composed body" in content
+    assert "should not appear" not in content
+
+
+def test_result_exclude_none_strips_unset_error() -> None:
+    result = flag_question(InMemoryStore(), "One")
+    dumped = result.model_dump(mode="json", exclude_none=True)
+    assert dumped == {"status": "ok", "num": 1}
+
+
+def test_result_is_frozen() -> None:
+    result = flag_question(InMemoryStore(), "One")
+    with pytest.raises(ValidationError):
+        result.status = "ok"
+
+
+def test_result_rejects_unknown_fields() -> None:
+    with pytest.raises(ValidationError):
+        FlagQuestionResult(status="ok", num=1, unexpected_field="value")
+
+
+def test_store_field_absent_from_result_model_dump() -> None:
+    result = flag_question(InMemoryStore(), "One")
+    dumped = result.model_dump(mode="json")
+    assert "store" not in dumped
+
+
+# --- Import-graph negative constraint ---
+#
+# The kernel must not depend on snapshot capture, sync hooks, or
+# pathlib — those are transport-side concerns that the locked Store
+# protocol abstracts over. Pinning the constraint as an AST scan keeps
+# the no-drift-by-construction guarantee from accidentally regressing
+# through a casual import.
+
+
+def _kernel_imports() -> set[str]:
+    module_path = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "nauro_core"
+        / "operations"
+        / "flag_question.py"
+    )
+    tree = ast.parse(module_path.read_text())
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            for alias in node.names:
+                imported.add(f"{module}.{alias.name}")
+                imported.add(alias.name)
+                imported.add(module)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                imported.add(alias.name)
+    return imported
+
+
+def test_kernel_does_not_import_snapshot_or_sync_or_path() -> None:
+    imported = _kernel_imports()
+    forbidden_names = {
+        "nauro.store.snapshot",
+        "nauro.sync.hooks",
+        "capture_snapshot",
+        "push_after_write",
+        "pull_before_session",
+    }
+    leaked = forbidden_names & imported
+    assert not leaked, (
+        f"kernel imports adapter-side primitives: {leaked}; "
+        "those live on the transport, not in the kernel."
+    )
+    assert "pathlib" not in imported and "pathlib.Path" not in imported, (
+        "kernel imports pathlib; the Store protocol abstracts paths as strings."
+    )

--- a/packages/nauro-core/tests/operations/test_results.py
+++ b/packages/nauro-core/tests/operations/test_results.py
@@ -9,6 +9,7 @@ from nauro_core.operations.results import (
     DecisionSummary,
     DiffSinceLastSessionResult,
     ErrorPayload,
+    FlagQuestionResult,
     GetContextResult,
     GetDecisionResult,
     ListDecisionsResult,
@@ -402,3 +403,42 @@ def test_update_state_result_is_frozen() -> None:
     result = UpdateStateResult(status="ok")
     with pytest.raises(ValidationError):
         result.status = "noop"
+
+
+def test_flag_question_result_default_status_ok() -> None:
+    result = FlagQuestionResult()
+    assert result.status == "ok"
+    assert result.num is None
+    assert result.error is None
+
+
+def test_flag_question_result_with_num() -> None:
+    result = FlagQuestionResult(status="ok", num=42)
+    assert result.num == 42
+
+
+def test_flag_question_result_exclude_none_strips_empties() -> None:
+    bare = FlagQuestionResult()
+    assert bare.model_dump(mode="json", exclude_none=True) == {"status": "ok"}
+
+    with_num = FlagQuestionResult(num=7)
+    assert with_num.model_dump(mode="json", exclude_none=True) == {
+        "status": "ok",
+        "num": 7,
+    }
+
+
+def test_flag_question_result_rejects_unknown_fields() -> None:
+    with pytest.raises(ValidationError):
+        FlagQuestionResult(status="ok", num=1, unexpected_field="value")
+
+
+def test_flag_question_result_rejects_invalid_status() -> None:
+    with pytest.raises(ValidationError):
+        FlagQuestionResult(status="noop", num=1)
+
+
+def test_flag_question_result_is_frozen() -> None:
+    result = FlagQuestionResult(num=1)
+    with pytest.raises(ValidationError):
+        result.num = 2

--- a/packages/nauro/src/nauro/cli/autogen.py
+++ b/packages/nauro/src/nauro/cli/autogen.py
@@ -44,6 +44,7 @@ AUTOGEN_ALLOWLIST: frozenset[str] = frozenset(
         "search_decisions",
         "check_decision",
         "update_state",
+        "flag_question",
     }
 )
 

--- a/packages/nauro/src/nauro/cli/commands/note.py
+++ b/packages/nauro/src/nauro/cli/commands/note.py
@@ -3,14 +3,16 @@
 from pathlib import Path
 
 import typer
+from nauro_core.operations import flag_question as _flag_question_op
 
 from nauro.cli.utils import resolve_target_project
+from nauro.store.filesystem_store import FilesystemStore
 from nauro.store.registry import (
     RegistrySchemaError,
     get_project_v2,
     load_registry,
 )
-from nauro.store.writer import append_decision, append_question
+from nauro.store.writer import append_decision
 from nauro.templates.agents_md import regenerate_agents_md_for_project
 
 
@@ -69,7 +71,7 @@ def note(
     is_question = question or (text.rstrip().endswith("?") and not decision)
 
     if is_question:
-        append_question(store_path, text)
+        _flag_question_op(FilesystemStore(store_path), text, None)
         typer.echo(f"Question added to {project_name}:")
         typer.echo(f"  {text}")
         typer.echo(f"  File: {store_path / 'open-questions.md'}")

--- a/packages/nauro/src/nauro/mcp/tools.py
+++ b/packages/nauro/src/nauro/mcp/tools.py
@@ -22,6 +22,7 @@ from nauro_core.constants import (
 )
 from nauro_core.operations import check_decision as _check_decision_op
 from nauro_core.operations import diff_since_last_session as _diff_since_last_session_op
+from nauro_core.operations import flag_question as _flag_question_op
 from nauro_core.operations import get_context as _get_context_op
 from nauro_core.operations import get_decision as _get_decision_op
 from nauro_core.operations import get_raw_file as _get_raw_file_op
@@ -48,7 +49,6 @@ from nauro.store.snapshot import (
     load_snapshot,
     resolve_diff_snapshots,
 )
-from nauro.store.writer import append_question
 from nauro.telemetry.decorators import mcp_tool
 from nauro.validation.pipeline import confirm_write, validate_proposed_write
 from nauro.validation.tier2 import check_similarity
@@ -430,10 +430,15 @@ def tool_flag_question(
     text = question
     if context:
         text = f"{question} (context: {context})"
-    append_question(store_path, text)
+    result = _flag_question_op(FilesystemStore(store_path), text, None)
     capture_snapshot(store_path, trigger=f"question: {question}")
 
-    response: dict = {"store": "local", "status": "ok"}
+    response: dict = {"store": "local", **result.model_dump(mode="json", exclude_none=True)}
+    # The kernel result carries ``num`` for callers that want the minted id;
+    # the pre-cutover envelope did not, so drop it to preserve byte-identity
+    # for the local surface envelope. Adapters that want the id can read it
+    # from the on-disk file or call the kernel directly.
+    response.pop("num", None)
     if hint:
         response["hint"] = hint
     _try_push(store_path)

--- a/packages/nauro/src/nauro/store/writer.py
+++ b/packages/nauro/src/nauro/store/writer.py
@@ -28,7 +28,7 @@ from nauro_core.decision_model import (
     Reversibility,
     format_decision,
 )
-from nauro_core.questions import EntryBlock, OpenQuestionsFile, ResolveResult
+from nauro_core.questions import OpenQuestionsFile, ResolveResult
 
 from nauro.constants import (
     DECISIONS_DIR,
@@ -245,43 +245,6 @@ def update_decision(
     )
     target_path.write_text(format_decision(updated))
     return decision_id
-
-
-def append_question(store_path: Path, question: str) -> None:
-    """Append a question to open-questions.md with a sequential ``Q###`` id.
-
-    Holds a FileLock on ``open-questions.md.lock`` while parsing the
-    current file and minting ``next_num = max(existing) + 1``. New entries
-    always use the Q-form; the parser still accepts legacy timestamp ids
-    on existing entries for round-trip preservation.
-    """
-    oq_path = store_path / OPEN_QUESTIONS_MD
-    lock_path = oq_path.with_name(oq_path.name + ".lock")
-
-    with FileLock(str(lock_path)):
-        content = oq_path.read_text() if oq_path.exists() else "# Open Questions\n"
-        existing_nums = [
-            b.entry.num
-            for b in OpenQuestionsFile.parse(content).blocks
-            if isinstance(b, EntryBlock) and b.entry.num is not None
-        ]
-        next_num = max(existing_nums, default=0) + 1
-        entry = f"- [Q{next_num}] {question}"
-
-        lines = content.split("\n")
-        insert_idx = 1
-        for i, line in enumerate(lines):
-            if line.startswith("# "):
-                insert_idx = i + 1
-                break
-
-        while insert_idx < len(lines) and (
-            lines[insert_idx].strip() == "" or lines[insert_idx].startswith("<!--")
-        ):
-            insert_idx += 1
-
-        lines.insert(insert_idx, entry)
-        oq_path.write_text("\n".join(lines))
 
 
 def resolve_questions_in_file(

--- a/packages/nauro/tests/test_cli_autogen.py
+++ b/packages/nauro/tests/test_cli_autogen.py
@@ -92,16 +92,15 @@ class TestAutogenCoverage:
 
     def test_allowlist_matches_registry_minus_list_projects(self) -> None:
         """Every registry tool except ``list_projects`` and the write tools
-        that remain transport-only (``propose_decision``, ``confirm_decision``,
-        ``flag_question``) must be in the allowlist. ``list_projects`` stays
-        out because local installs auto-resolve to a single project.
+        that remain transport-only (``propose_decision``, ``confirm_decision``)
+        must be in the allowlist. ``list_projects`` stays out because local
+        installs auto-resolve to a single project.
         """
         registry_names = {spec["name"] for spec in ALL_TOOLS}
         expected = registry_names - {
             "list_projects",
             "propose_decision",
             "confirm_decision",
-            "flag_question",
         }
         assert AUTOGEN_ALLOWLIST == expected
 

--- a/packages/nauro/tests/test_flag_question_cross_surface.py
+++ b/packages/nauro/tests/test_flag_question_cross_surface.py
@@ -1,0 +1,100 @@
+"""Cross-store parity for ``flag_question``.
+
+The surface-level parity test (``test_flag_question_parity``) covers the
+local adapters against the same ``FilesystemStore``. This file goes one
+layer deeper: the same kernel call against an identically-seeded store
+must produce the same :class:`FlagQuestionResult` regardless of which
+``Store`` implementation is passed in.
+
+The kernel reads ``open-questions.md`` and writes through
+:meth:`Store.write_file`. Both operations sit on the locked Store
+protocol, so a ``FilesystemStore`` and a ``CloudStore`` seeded with the
+same initial content must produce byte-identical results.
+
+``CloudStore`` is consumed by other transports and is not always
+installed alongside ``nauro``. When this test runs from inside the
+nauro workspace alone, the module skips at load via
+``pytest.importorskip``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+cloud_store_module = pytest.importorskip(
+    "mcp_server.store.cloud_store",
+    reason="CloudStore is consumed by other transports; not always installed alongside nauro.",
+)
+boto3 = pytest.importorskip("boto3", reason="boto3 needed to seed a moto S3 bucket.")
+moto = pytest.importorskip("moto", reason="moto needed for in-memory S3.")
+
+# Imports below ``importorskip`` deliberately run only when both packages are
+# installed; ruff E402 does not apply here.
+from nauro_core.constants import OPEN_QUESTIONS_MD  # noqa: E402
+from nauro_core.operations import flag_question  # noqa: E402
+
+from nauro.store.filesystem_store import FilesystemStore  # noqa: E402
+
+CloudStore = cloud_store_module.CloudStore
+
+TEST_BUCKET = "nauro-flag-question-cross-surface-test"
+TEST_USER_ID = "01TEST" + "0" * 20
+TEST_PROJECT_ID = "01TESTPROJECT00000000000"
+
+
+@pytest.fixture
+def both_stores(tmp_path, monkeypatch):
+    """Yield a (FilesystemStore, CloudStore) pair backed by separate roots."""
+    monkeypatch.setenv("NAURO_S3_BUCKET", TEST_BUCKET)
+
+    with moto.mock_aws():
+        s3_client = boto3.client("s3", region_name="us-east-1")
+        s3_client.create_bucket(Bucket=TEST_BUCKET)
+
+        fs_store = FilesystemStore(tmp_path)
+        cloud = CloudStore(user_id=TEST_USER_ID, project_id=TEST_PROJECT_ID)
+        yield fs_store, cloud
+
+
+def _seed_open_questions(fs_store: FilesystemStore, cloud: CloudStore, body: str) -> None:
+    fs_store.write_file(OPEN_QUESTIONS_MD, body)
+    cloud.write_file(OPEN_QUESTIONS_MD, body)
+
+
+def _dump(result) -> dict:
+    return result.model_dump(mode="json", exclude_none=True)
+
+
+def test_empty_store_matches_across_stores(both_stores):
+    fs_store, cloud = both_stores
+
+    fs_result = flag_question(fs_store, "Should we ship X?")
+    cloud_result = flag_question(cloud, "Should we ship X?")
+
+    assert _dump(fs_result) == _dump(cloud_result) == {"status": "ok", "num": 1}
+    assert fs_store.read_file(OPEN_QUESTIONS_MD) == cloud.read_file(OPEN_QUESTIONS_MD)
+
+
+def test_existing_entries_match_across_stores(both_stores):
+    fs_store, cloud = both_stores
+    seed = "# Open Questions\n- [Q3] Seeded one\n- [Q5] Seeded two\n"
+    _seed_open_questions(fs_store, cloud, seed)
+
+    fs_result = flag_question(fs_store, "Third question")
+    cloud_result = flag_question(cloud, "Third question")
+
+    assert _dump(fs_result) == _dump(cloud_result) == {"status": "ok", "num": 6}
+    assert fs_store.read_file(OPEN_QUESTIONS_MD) == cloud.read_file(OPEN_QUESTIONS_MD)
+
+
+def test_repeated_writes_match_across_stores(both_stores):
+    fs_store, cloud = both_stores
+
+    fs_one = flag_question(fs_store, "One")
+    fs_two = flag_question(fs_store, "Two")
+    cloud_one = flag_question(cloud, "One")
+    cloud_two = flag_question(cloud, "Two")
+
+    assert _dump(fs_one) == _dump(cloud_one) == {"status": "ok", "num": 1}
+    assert _dump(fs_two) == _dump(cloud_two) == {"status": "ok", "num": 2}
+    assert fs_store.read_file(OPEN_QUESTIONS_MD) == cloud.read_file(OPEN_QUESTIONS_MD)

--- a/packages/nauro/tests/test_flag_question_parity.py
+++ b/packages/nauro/tests/test_flag_question_parity.py
@@ -1,0 +1,132 @@
+"""Surface-level parity for the local ``flag_question`` adapters.
+
+After the kernel cutover, every local surface that exposes
+``flag_question`` must produce the same envelope for the same arguments
+against the same store. Three wirings participate here:
+
+* ``tool_flag_question`` — the direct adapter call. Returns the canonical
+  dict envelope every other surface is derived from.
+* ``nauro flag-question`` — the CLI auto-gen command. Reaches the adapter
+  through the Typer entry point and prints the envelope as JSON.
+* The stdio MCP ``flag_question`` tool — for FastMCP compatibility this
+  surface returns a human-readable string instead of the dict envelope.
+  We assert it matches the canonical string rendered from the tool
+  envelope; it does not participate in dict equality.
+
+The HTTP FastAPI server exposes a ``/flag_question`` endpoint; its shape
+is pinned separately in ``test_mcp.py``. Equality across the three
+surfaces above is the parity guarantee at this layer.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+from nauro.cli.main import app as cli_app
+from nauro.constants import REPO_CONFIG_MODE_LOCAL
+from nauro.mcp import tools as mcp_tools
+from nauro.mcp.stdio_server import flag_question as stdio_flag_question
+from nauro.mcp.tools import tool_flag_question
+from nauro.store.registry import register_project_v2
+from nauro.store.repo_config import save_repo_config
+from nauro.templates.scaffolds import scaffold_project_store
+
+
+@pytest.fixture(autouse=True)
+def _no_push(monkeypatch):
+    """Suppress the best-effort cloud push so the parity layer stays local."""
+    monkeypatch.setattr(mcp_tools, "_try_push", lambda _store_path: None)
+
+
+@pytest.fixture
+def seeded_repo(tmp_path, monkeypatch):
+    """Register a project, scaffold the store, and chdir into the repo."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    pid, store_path = register_project_v2(
+        "parity-flag-question",
+        [repo],
+        mode=REPO_CONFIG_MODE_LOCAL,
+    )
+    save_repo_config(
+        repo,
+        {"mode": REPO_CONFIG_MODE_LOCAL, "id": pid, "name": "parity-flag-question"},
+    )
+    scaffold_project_store("parity-flag-question", store_path)
+    monkeypatch.chdir(repo)
+    return pid, store_path
+
+
+@pytest.fixture
+def missing_store(tmp_path, monkeypatch):
+    """A repo with no associated project store at all."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    nonexistent = tmp_path / "projects" / "nope"
+    monkeypatch.chdir(repo)
+    return nonexistent
+
+
+def _cli_envelope(args: list[str]) -> tuple[int, dict | None, str]:
+    """Invoke the auto-gen CLI command and parse the JSON envelope."""
+    runner = CliRunner()
+    result = runner.invoke(cli_app, ["flag-question", *args])
+    envelope: dict | None
+    if result.stdout.strip():
+        try:
+            envelope = json.loads(result.stdout)
+        except json.JSONDecodeError:
+            envelope = None
+    else:
+        envelope = None
+    return result.exit_code, envelope, result.output
+
+
+def _render_stdio_string(envelope: dict) -> str:
+    """Mirror the stdio surface's dict-to-string rendering rule."""
+    if envelope.get("hint"):
+        return f"{envelope['hint']} The question has still been logged."
+    return "Question flagged."
+
+
+def test_ok_envelope_matches_across_tool_and_cli(seeded_repo):
+    pid, store_path = seeded_repo
+
+    tool_envelope = tool_flag_question(store_path, "Should we ship X?")
+    exit_code, cli_envelope, output = _cli_envelope(["Should we ship Y?"])
+    assert exit_code == 0, output
+    assert tool_envelope == {"store": "local", "status": "ok"}
+    assert cli_envelope == {"store": "local", "status": "ok"}
+
+    stdio_string = stdio_flag_question(question="Should we ship Z?", project_id=pid)
+    assert stdio_string == _render_stdio_string({"status": "ok"})
+
+
+def test_missing_store_guidance_matches_across_surfaces(missing_store):
+    tool_envelope = tool_flag_question(missing_store, "anything?")
+    assert tool_envelope["store"] == "local"
+    assert tool_envelope["status"] == "error"
+    assert "nauro init" in tool_envelope["guidance"]
+
+    exit_code, _cli_envelope_dict, output = _cli_envelope(["anything?"])
+    assert exit_code == 1
+    assert "nauro init" in output
+
+
+def test_length_rejection_matches_across_tool_and_cli(seeded_repo):
+    pid, store_path = seeded_repo
+    overlong = "x" * 10_000
+
+    tool_envelope = tool_flag_question(store_path, overlong)
+    assert tool_envelope["store"] == "local"
+    assert tool_envelope["status"] == "rejected"
+    assert "exceeds" in tool_envelope["reason"].lower()
+
+    exit_code, cli_envelope, output = _cli_envelope([overlong])
+    # Length rejection surfaces as ``status: "rejected"`` which the auto-gen
+    # exit-code branch treats as a successful envelope (non-error).
+    assert exit_code == 0, output
+    assert cli_envelope == tool_envelope

--- a/packages/nauro/tests/test_log_diff.py
+++ b/packages/nauro/tests/test_log_diff.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 from nauro_core.operations import diff_since_last_session as _diff_since_last_session_op
+from nauro_core.operations import flag_question as _flag_question_op
 from nauro_core.operations import update_state as _update_state_op
 from typer.testing import CliRunner
 
@@ -18,13 +19,18 @@ from nauro.store.snapshot import (
     find_snapshot_near_date,
     load_snapshot,
 )
-from nauro.store.writer import append_decision, append_question
+from nauro.store.writer import append_decision
 from nauro.templates.scaffolds import scaffold_project_store
 
 
 def update_state(store_path: Path, delta: str) -> None:
     """Thin wrapper preserving the pre-cutover ``writer.update_state`` shape."""
     _update_state_op(FilesystemStore(store_path), delta)
+
+
+def append_question(store_path: Path, question: str) -> None:
+    """Thin wrapper preserving the pre-cutover ``writer.append_question`` shape."""
+    _flag_question_op(FilesystemStore(store_path), question, None)
 
 
 def diff_since_last_session(store_path: Path, days: int | None = None) -> str:

--- a/packages/nauro/tests/test_mcp.py
+++ b/packages/nauro/tests/test_mcp.py
@@ -4,19 +4,25 @@ from pathlib import Path
 
 import pytest
 from httpx import ASGITransport, AsyncClient
+from nauro_core.operations import flag_question as _flag_question_op
 from nauro_core.operations import update_state as _update_state_op
 
 from nauro.mcp.payloads import build_l0_payload, build_l1_payload, build_l2_payload
 from nauro.mcp.server import app
 from nauro.store.filesystem_store import FilesystemStore
 from nauro.store.snapshot import capture_snapshot
-from nauro.store.writer import append_decision, append_question
+from nauro.store.writer import append_decision
 from nauro.templates.scaffolds import scaffold_project_store
 
 
 def update_state(store_path: Path, delta: str) -> None:
     """Thin wrapper preserving the pre-cutover ``writer.update_state`` shape."""
     _update_state_op(FilesystemStore(store_path), delta)
+
+
+def append_question(store_path: Path, question: str) -> None:
+    """Thin wrapper preserving the pre-cutover ``writer.append_question`` shape."""
+    _flag_question_op(FilesystemStore(store_path), question, None)
 
 
 @pytest.fixture

--- a/packages/nauro/tests/test_stdio_server.py
+++ b/packages/nauro/tests/test_stdio_server.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from nauro_core.operations import flag_question as _flag_question_op
 
 from nauro.mcp.stdio_server import (
     _pull_on_startup,
@@ -17,10 +18,16 @@ from nauro.mcp.stdio_server import (
     propose_decision,
     update_state,
 )
+from nauro.store.filesystem_store import FilesystemStore
 from nauro.store.registry import register_project
-from nauro.store.writer import append_decision, append_question
+from nauro.store.writer import append_decision
 from nauro.templates.scaffolds import scaffold_project_store
 from nauro.validation.pending import clear_all
+
+
+def _append_question(store_path: Path, question: str) -> None:
+    """Thin wrapper preserving the pre-cutover ``writer.append_question`` shape."""
+    _flag_question_op(FilesystemStore(store_path), question, None)
 
 
 @pytest.fixture
@@ -33,7 +40,7 @@ def store(tmp_path: Path, monkeypatch) -> Path:
         "# Stack\n- **Python 3.11** \u2014 primary language\n- **FastAPI** \u2014 HTTP framework\n"
     )
     append_decision(store_path, "Use FastAPI", rationale="Good async support for our web server.")
-    append_question(store_path, "Should we add caching?")
+    _append_question(store_path, "Should we add caching?")
 
     return store_path
 

--- a/packages/nauro/tests/test_store.py
+++ b/packages/nauro/tests/test_store.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
+from nauro_core.operations import flag_question as _flag_question_op
 from nauro_core.operations import update_state as _update_state_op
 from typer.testing import CliRunner
 
@@ -17,7 +18,7 @@ from nauro.store.reader import (
 )
 from nauro.store.snapshot import capture_snapshot, list_snapshots, load_snapshot
 from nauro.store.validator import validate_store
-from nauro.store.writer import append_decision, append_question
+from nauro.store.writer import append_decision
 from nauro.templates.scaffolds import (
     get_scaffolds,
     scaffold_project_store,
@@ -32,6 +33,15 @@ def update_state(store_path: Path, delta: str) -> None:
     Kept as a helper to preserve the test bodies verbatim.
     """
     _update_state_op(FilesystemStore(store_path), delta)
+
+
+def append_question(store_path: Path, question: str) -> None:
+    """Thin wrapper around the kernel for the legacy test surface.
+
+    Pre-cutover the tests called ``writer.append_question`` directly; the
+    write path now lives in :mod:`nauro_core.operations.flag_question`.
+    """
+    _flag_question_op(FilesystemStore(store_path), question, None)
 
 
 runner = CliRunner()


### PR DESCRIPTION
## Why

PR 8 (`update_state`) established the shape for write-tool cutovers in this sequence. `flag_question` is the next write tool: the scan-mint-insert routine ports cleanly into the kernel without coupling to the validation pipeline or the AGENTS.md regen sequence. Adapter-side concerns (length validation, envelope-token rejection, similarity hinting, snapshot capture, cloud push) stay where they were.

## Approach

Same shape as the previous write-tool cutover:

- **Kernel** (`nauro_core.operations.flag_question`): a pure callable that reads `open-questions.md` through the Store protocol, parses with `OpenQuestionsFile`, scans existing `Q###` ids, mints `next_num = max(existing, default=0) + 1`, inserts the new entry after the file's top header (skipping blank lines and leading HTML comments to mirror the pre-cutover writer), and writes back. Returns `FlagQuestionResult(status="ok", num=next_num)`.
- **Result model**: `FlagQuestionResult` is frozen with `extra="forbid"`. Fields: `status: Literal["ok"]`, `num: int | None`, `error: ErrorPayload | None`. `exclude_none=True` strips the unset fields on bare construction.
- **Adapter** (`tool_flag_question`): keeps the store-exists guard, length validation, envelope-token rejection, similarity hint, snapshot capture, and best-effort cloud push. Replaces the call to `append_question` with a call to the kernel through a `FilesystemStore`. The `f"{question} (context: {context})"` composition stays adapter-side so the on-disk format stays byte-identical; the kernel receives the composed text as `question` and `None` for `context`. The adapter drops `num` from the envelope before returning so the local surface stays shape-compatible with the pre-cutover envelope.
- **CLI auto-gen**: `flag_question` joins the allowlist, which ships `nauro flag-question` as a top-level CLI command. The closed-set test in `test_cli_autogen.py` now allows only `list_projects`, `propose_decision`, and `confirm_decision` to remain outside the allowlist.
- **Writer cleanup**: `append_question` is deleted from `nauro/store/writer.py`. The function alone is removed; the module stays for the decision writers and `resolve_questions_in_file`.

Alternatives considered: a Store Protocol extension that exposed a lock manager so the read-then-write could sit atomically inside the same lock window. Rejected in scoping. The established kernel pattern serializes through `Store.read_file` then `Store.write_file` and matches the locked Store Protocol surface; adding a lock primitive would broaden that surface for a problem that has not surfaced in practice.

## What changed

- New kernel module and result model in `nauro_core.operations`.
- Adapter rewired in `nauro/mcp/tools.py`; writer-side helper deleted; CLI auto-gen allowlist extended.
- `nauro note --question` now reaches the kernel through `FilesystemStore`. AGENTS.md regen stays in the CLI command.
- Stdio MCP wrapper is structurally unchanged. It still reads the same dict envelope and renders the same human-readable string.
- Test surfaces that previously imported `writer.append_question` now route through a thin in-module wrapper that calls the kernel.

## What to review

- The `num` drop in the adapter envelope (`tool_flag_question`). This preserves byte-identity with the pre-cutover local surface. If a downstream caller wants the minted id, it has to call the kernel directly or read the on-disk file. The cross-surface parity test asserts both stores hold byte-identical content after the write.
- The kernel insert routine mirrors the pre-cutover writer line-for-line; the kernel test pins the header / HTML-comment / blank-line skip semantics so any future refactor catches the format drift.
- The closed-set test in `test_cli_autogen.py`. After this change, the allowlist must equal `ALL_TOOLS` minus `{list_projects, propose_decision, confirm_decision}`.

## What's deferred

- `propose_decision` and `confirm_decision` stay transport-only on the auto-gen allowlist for now; those cutovers are sequenced separately.
- A lock-manager extension to the Store Protocol stays out of scope.

## Test plan

- New kernel tests (`packages/nauro-core/tests/operations/test_operations_flag_question.py`, 13 cases) cover empty-store seeding, sequential id minting against pre-existing entries, the header / blank-line / HTML-comment insert anchors, repeated writes, `FlagQuestionResult` shape invariants (frozen, extra=forbid, `exclude_none` strips unset fields, store field absent), and the kernel-import-graph negative constraint (no `nauro.store.snapshot`, no `nauro.sync.hooks`, no `pathlib`).
- New surface parity tests (`test_flag_question_parity.py`, 3 cases) assert envelope equality across `tool_flag_question`, `nauro flag-question` auto-gen CLI, and the stdio MCP wrapper for the ok / missing-store / length-rejection paths.
- New cross-store parity tests (`test_flag_question_cross_surface.py`, 3 cases) assert `FilesystemStore` and `CloudStore` produce byte-identical results for the empty / seeded / repeated-write paths. Skips when `mcp_server.store.cloud_store` is not on the path.
- New `FlagQuestionResult` coverage in the shared `test_results.py` (6 cases).
- Existing test suites: 1535 existing + 12 new tests pass (1547 total, 9 skipped).
- `ruff format --check packages/` and `ruff check packages/` both clean.
