### PR TITLE
chore(skills): strengthen GATE 7 to require verbatim PR body

### DIFF
--- a/.agents/skills/nauro-ship-task/SKILL.md
+++ b/.agents/skills/nauro-ship-task/SKILL.md
@@ -69,16 +69,13 @@ The reviewer's bug-finding pass and the tech-lead's doctrine pass are deliberate
 
 ### 7. GATE — push confirmation (user)
 
-When the reviewer returns APPROVE / APPROVE WITH NITS and the tech-lead returns GREEN (or AMBER with surfaced constraints), surface:
+When the reviewer returns APPROVE / APPROVE WITH NITS and the tech-lead returns GREEN (or AMBER with surfaced constraints), surface — in this order — before asking for the push:
 
-- The drafted PR description (full text)
-- A one-paragraph diff summary
-- The reviewer's verdict and any nits
-- The tech-lead's verdict and any AMBER constraints
-- Any Nauro decisions filed during the chain (numbers + one-line rationale)
-- "Push and open PR?"
+1. **A general summary of what's about to ship.** One short paragraph naming the branch, the commit hash, the file count + line delta, and the test result. Reviewer's verdict and any nits. Tech-lead's verdict and any AMBER constraints. Any Nauro decisions filed during the chain (numbers + one-line rationale each).
+2. **The drafted PR description (full body, verbatim).** Paste the executor's PR body inside a fenced block exactly as it will land on GitHub — do not abbreviate, do not paraphrase, do not link to "the executor's output above". The user reads this body to decide whether to push; if it's not in front of them, the gate isn't really firing.
+3. **Then ask: "Push and open PR?"** Wait for explicit approval. No push without an explicit "yes" / "go" / "push" reply.
 
-Wait for explicit approval.
+If the body would be long, that's fine — paste it anyway. Skipping the verbatim body is a chain failure.
 
 ### 8. Push
 

--- a/.claude/skills/nauro-ship-task/SKILL.md
+++ b/.claude/skills/nauro-ship-task/SKILL.md
@@ -69,16 +69,13 @@ The reviewer's bug-finding pass and the tech-lead's doctrine pass are deliberate
 
 ### 7. GATE — push confirmation (user)
 
-When the reviewer returns APPROVE / APPROVE WITH NITS and the tech-lead returns GREEN (or AMBER with surfaced constraints), surface:
+When the reviewer returns APPROVE / APPROVE WITH NITS and the tech-lead returns GREEN (or AMBER with surfaced constraints), surface — in this order — before asking for the push:
 
-- The drafted PR description (full text)
-- A one-paragraph diff summary
-- The reviewer's verdict and any nits
-- The tech-lead's verdict and any AMBER constraints
-- Any Nauro decisions filed during the chain (numbers + one-line rationale)
-- "Push and open PR?"
+1. **A general summary of what's about to ship.** One short paragraph naming the branch, the commit hash, the file count + line delta, and the test result. Reviewer's verdict and any nits. Tech-lead's verdict and any AMBER constraints. Any Nauro decisions filed during the chain (numbers + one-line rationale each).
+2. **The drafted PR description (full body, verbatim).** Paste the executor's PR body inside a fenced block exactly as it will land on GitHub — do not abbreviate, do not paraphrase, do not link to "the executor's output above". The user reads this body to decide whether to push; if it's not in front of them, the gate isn't really firing.
+3. **Then ask: "Push and open PR?"** Wait for explicit approval. No push without an explicit "yes" / "go" / "push" reply.
 
-Wait for explicit approval.
+If the body would be long, that's fine — paste it anyway. Skipping the verbatim body is a chain failure.
 
 ### 8. Push
 

--- a/.cursor/rules/nauro-ship-task.mdc
+++ b/.cursor/rules/nauro-ship-task.mdc
@@ -69,16 +69,13 @@ The reviewer's bug-finding pass and the tech-lead's doctrine pass are deliberate
 
 ### 7. GATE — push confirmation (user)
 
-When the reviewer returns APPROVE / APPROVE WITH NITS and the tech-lead returns GREEN (or AMBER with surfaced constraints), surface:
+When the reviewer returns APPROVE / APPROVE WITH NITS and the tech-lead returns GREEN (or AMBER with surfaced constraints), surface — in this order — before asking for the push:
 
-- The drafted PR description (full text)
-- A one-paragraph diff summary
-- The reviewer's verdict and any nits
-- The tech-lead's verdict and any AMBER constraints
-- Any Nauro decisions filed during the chain (numbers + one-line rationale)
-- "Push and open PR?"
+1. **A general summary of what's about to ship.** One short paragraph naming the branch, the commit hash, the file count + line delta, and the test result. Reviewer's verdict and any nits. Tech-lead's verdict and any AMBER constraints. Any Nauro decisions filed during the chain (numbers + one-line rationale each).
+2. **The drafted PR description (full body, verbatim).** Paste the executor's PR body inside a fenced block exactly as it will land on GitHub — do not abbreviate, do not paraphrase, do not link to "the executor's output above". The user reads this body to decide whether to push; if it's not in front of them, the gate isn't really firing.
+3. **Then ask: "Push and open PR?"** Wait for explicit approval. No push without an explicit "yes" / "go" / "push" reply.
 
-Wait for explicit approval.
+If the body would be long, that's fine — paste it anyway. Skipping the verbatim body is a chain failure.
 
 ### 8. Push
 

--- a/packages/nauro/src/nauro/skills/ship_task_body.md
+++ b/packages/nauro/src/nauro/skills/ship_task_body.md
@@ -71,16 +71,13 @@ The reviewer's bug-finding pass and the tech-lead's doctrine pass are deliberate
 
 ### 7. GATE — push confirmation (user)
 
-When the reviewer returns APPROVE / APPROVE WITH NITS and the tech-lead returns GREEN (or AMBER with surfaced constraints), surface:
+When the reviewer returns APPROVE / APPROVE WITH NITS and the tech-lead returns GREEN (or AMBER with surfaced constraints), surface — in this order — before asking for the push:
 
-- The drafted PR description (full text)
-- A one-paragraph diff summary
-- The reviewer's verdict and any nits
-- The tech-lead's verdict and any AMBER constraints
-- Any Nauro decisions filed during the chain (numbers + one-line rationale)
-- "Push and open PR?"
+1. **A general summary of what's about to ship.** One short paragraph naming the branch, the commit hash, the file count + line delta, and the test result. Reviewer's verdict and any nits. Tech-lead's verdict and any AMBER constraints. Any Nauro decisions filed during the chain (numbers + one-line rationale each).
+2. **The drafted PR description (full body, verbatim).** Paste the executor's PR body inside a fenced block exactly as it will land on GitHub — do not abbreviate, do not paraphrase, do not link to "the executor's output above". The user reads this body to decide whether to push; if it's not in front of them, the gate isn't really firing.
+3. **Then ask: "Push and open PR?"** Wait for explicit approval. No push without an explicit "yes" / "go" / "push" reply.
 
-Wait for explicit approval.
+If the body would be long, that's fine — paste it anyway. Skipping the verbatim body is a chain failure.
 
 ### 8. Push
 


### PR DESCRIPTION
## Why

The original GATE 7 was a 6-bullet list, asking the orchestrator to "surface" a set of items. In practice this admitted shortcuts: the executor's PR body was sometimes referenced by link ("see above") rather than pasted verbatim, leaving the user to scroll up to find what they were approving. The point of GATE 7 is that the user reads the body and decides whether to push. If the body isn't in front of them at that moment, the gate isn't really firing.

## What changed

GATE 7 in `ship_task_body.md` now reads as an ordered three-step protocol:

1. A general summary (branch, commit, file count, line delta, test result, reviewer + tech-lead verdicts, decisions filed).
2. The drafted PR description, full body, verbatim, inside a fenced block. No abbreviation, no paraphrase, no linking back.
3. The push question, with the rule that no push happens without an explicit "yes" / "go" / "push" reply.

A trailing line spells out that skipping the verbatim body is a chain failure, not a stylistic preference.

The three rendered dogfood SKILL files (`.claude`, `.cursor`, `.agents`) are regenerated to match.

## Test plan

- `packages/nauro/tests/test_skills_drift.py` and `packages/nauro/tests/test_protocol_drift.py` pass — re-rendered dogfood files match `render_skill(...)` byte-for-byte.
- Full nauro + nauro-core suite: 1547 passed, 9 skipped.
- `ruff format --check packages/` + `ruff check packages/`: clean.
