### PR TITLE
test(operations): pin check_decision envelope shape and Result schema

### DIFF
--- a/packages/nauro/tests/snapshots/check_decision_schema.json
+++ b/packages/nauro/tests/snapshots/check_decision_schema.json
@@ -1,0 +1,151 @@
+{
+  "CheckDecisionResult": {
+    "$defs": {
+      "ErrorPayload": {
+        "additionalProperties": false,
+        "description": "Structured error envelope returned on rejection or operation failure.\n\n``kind`` discriminates between caller-fixable rejections (input over\nlength, malformed argument) and operation-side failures. ``guidance``\ncarries an onboarding string when the rejection has a remedial action\nthe caller can take.",
+        "properties": {
+          "guidance": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Guidance"
+          },
+          "kind": {
+            "enum": [
+              "rejected",
+              "error"
+            ],
+            "title": "Kind",
+            "type": "string"
+          },
+          "reason": {
+            "title": "Reason",
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "reason"
+        ],
+        "title": "ErrorPayload",
+        "type": "object"
+      },
+      "RelatedDecision": {
+        "additionalProperties": false,
+        "description": "A decision surfaced by retrieval as related to a proposed approach.\n\nThe canonical retrieval-hit shape: enriched with status/date and a\nrationale preview so any transport can render the same hit without\nre-fetching the underlying decision body.",
+        "properties": {
+          "date": {
+            "title": "Date",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "rationale_preview": {
+            "title": "Rationale Preview",
+            "type": "string"
+          },
+          "score": {
+            "title": "Score",
+            "type": "number"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "score",
+          "status",
+          "date",
+          "rationale_preview"
+        ],
+        "title": "RelatedDecision",
+        "type": "object"
+      }
+    },
+    "additionalProperties": false,
+    "description": "Return shape for :func:`nauro_core.operations.check_decision`.\n\nOn the success path ``related_decisions`` contains zero or more\n:class:`RelatedDecision` hits and ``assessment`` carries the\ndeterministic human-readable summary. On the rejection path\n``error`` is populated; ``related_decisions`` stays empty and\n``assessment`` stays empty. ``store`` is not part of the model;\ntransport adapters add it back at serialization time.",
+    "properties": {
+      "assessment": {
+        "default": "",
+        "title": "Assessment",
+        "type": "string"
+      },
+      "error": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/ErrorPayload"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null
+      },
+      "related_decisions": {
+        "items": {
+          "$ref": "#/$defs/RelatedDecision"
+        },
+        "title": "Related Decisions",
+        "type": "array"
+      }
+    },
+    "title": "CheckDecisionResult",
+    "type": "object"
+  },
+  "RelatedDecision": {
+    "additionalProperties": false,
+    "description": "A decision surfaced by retrieval as related to a proposed approach.\n\nThe canonical retrieval-hit shape: enriched with status/date and a\nrationale preview so any transport can render the same hit without\nre-fetching the underlying decision body.",
+    "properties": {
+      "date": {
+        "title": "Date",
+        "type": "string"
+      },
+      "id": {
+        "title": "Id",
+        "type": "string"
+      },
+      "rationale_preview": {
+        "title": "Rationale Preview",
+        "type": "string"
+      },
+      "score": {
+        "title": "Score",
+        "type": "number"
+      },
+      "status": {
+        "title": "Status",
+        "type": "string"
+      },
+      "title": {
+        "title": "Title",
+        "type": "string"
+      }
+    },
+    "required": [
+      "id",
+      "title",
+      "score",
+      "status",
+      "date",
+      "rationale_preview"
+    ],
+    "title": "RelatedDecision",
+    "type": "object"
+  }
+}

--- a/packages/nauro/tests/test_check_decision_cross_surface.py
+++ b/packages/nauro/tests/test_check_decision_cross_surface.py
@@ -160,3 +160,61 @@ def test_rejection_envelope_matches_across_stores(both_stores):
     )
     assert fs_result.error is not None
     assert fs_result.error.kind == "rejected"
+
+
+def _envelope(store_label: str, result) -> dict:
+    """Mirror the adapter envelope construction used by tool wrappers."""
+    return {"store": store_label, **result.model_dump(mode="json", exclude_none=True)}
+
+
+def test_envelope_byte_identical_modulo_store_field(both_stores):
+    """Envelopes are byte-identical once the store discriminator is substituted.
+
+    Pins the wire-shape guarantee: once the ``"store"`` field is normalised,
+    the JSON-serialised envelope from FilesystemStore is byte-equal to the
+    one from CloudStore. Any field-ordering, default-elision, or coercion
+    drift between the two surfaces shows up here, even when the underlying
+    ``CheckDecisionResult`` model dumps still compare equal as dicts.
+    """
+    fs_store, cloud = both_stores
+
+    fs_result = check_decision(fs_store, PROPOSED_APPROACH)
+    cloud_result = check_decision(cloud, PROPOSED_APPROACH)
+
+    # Happy path: similar_decisions is non-empty because D001 matches.
+    assert fs_result.related_decisions, "fixture should surface decision-001"
+
+    local_envelope = _envelope("local", fs_result)
+    remote_envelope = _envelope("remote", cloud_result)
+    remote_envelope["store"] = "local"
+
+    import json as _json
+
+    local_bytes = _json.dumps(local_envelope, sort_keys=True).encode()
+    remote_bytes = _json.dumps(remote_envelope, sort_keys=True).encode()
+    assert local_bytes == remote_bytes
+
+
+def test_envelope_byte_identical_empty_result_branch(both_stores):
+    """Empty-result envelopes also stay byte-identical across surfaces."""
+    fs_store, cloud = both_stores
+
+    # An approach with no overlap with the seeded decisions; retrieval
+    # returns no hits from either store.
+    no_match_approach = "Adopt a fictional widget library for sprocket rendering"
+
+    fs_result = check_decision(fs_store, no_match_approach)
+    cloud_result = check_decision(cloud, no_match_approach)
+
+    assert fs_result.related_decisions == []
+    assert cloud_result.related_decisions == []
+
+    local_envelope = _envelope("local", fs_result)
+    remote_envelope = _envelope("remote", cloud_result)
+    remote_envelope["store"] = "local"
+
+    import json as _json
+
+    local_bytes = _json.dumps(local_envelope, sort_keys=True).encode()
+    remote_bytes = _json.dumps(remote_envelope, sort_keys=True).encode()
+    assert local_bytes == remote_bytes

--- a/packages/nauro/tests/test_check_decision_schema.py
+++ b/packages/nauro/tests/test_check_decision_schema.py
@@ -1,0 +1,45 @@
+"""Schema snapshot guard for ``check_decision`` Result models.
+
+The JSON Schema produced by :class:`CheckDecisionResult` and
+:class:`RelatedDecision` is the wire contract every transport adapter
+relies on. Any unintentional drift in field names, defaults, or required
+markers would silently change how downstream consumers (CLI, local MCP,
+remote MCP) render hits. This test pins the schema against a checked-in
+snapshot so additive or breaking changes show up as a reviewable diff.
+
+To regenerate the snapshot after an intentional schema change:
+
+    uv run python -c "from nauro_core.operations.results import \\
+        CheckDecisionResult, RelatedDecision; import json; \\
+        print(json.dumps({'CheckDecisionResult': CheckDecisionResult.model_json_schema(), \\
+        'RelatedDecision': RelatedDecision.model_json_schema()}, \\
+        indent=2, sort_keys=True))" \\
+        > packages/nauro/tests/snapshots/check_decision_schema.json
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from nauro_core.operations.results import CheckDecisionResult, RelatedDecision
+
+SNAPSHOT_PATH = Path(__file__).parent / "snapshots" / "check_decision_schema.json"
+
+
+def test_check_decision_result_schema_matches_snapshot():
+    current = json.dumps(
+        {
+            "CheckDecisionResult": CheckDecisionResult.model_json_schema(),
+            "RelatedDecision": RelatedDecision.model_json_schema(),
+        },
+        indent=2,
+        sort_keys=True,
+    )
+    snapshot = SNAPSHOT_PATH.read_text().rstrip("\n")
+    assert current == snapshot, (
+        "CheckDecisionResult/RelatedDecision JSON schema has drifted from the "
+        "checked-in snapshot. If the change is intentional, regenerate the "
+        "snapshot using the command in this file's module docstring and review "
+        "the diff carefully."
+    )


### PR DESCRIPTION
## Why

The `check_decision` kernel now powers two transport surfaces (local FilesystemStore via the stdio adapter, remote CloudStore via the Lambda adapter). The existing parity test compares Pydantic `model_dump()` dicts. That catches semantic drift but misses byte-level wire-shape drift (field ordering, default elision, coercion edge cases) and won't catch a silent schema change in `CheckDecisionResult` or `RelatedDecision` that downstream renderers depend on.

## Approach

Add two test-only guards rather than introducing runtime validation in the kernel or adapters. Runtime validation at internal boundaries would duplicate Pydantic's existing guarantees; tests that fail loudly on a reviewable diff are cheaper.

Two layers:

1. A JSON-schema snapshot for `CheckDecisionResult` + `RelatedDecision`, pinned against a checked-in deterministic file. Intentional schema changes regenerate the snapshot; unintentional ones fail in CI with a diff a reviewer can read.
2. Envelope-byte-identical assertions across both stores. The adapters wrap the result as `{"store": "local" | "remote", **dump}` and serialize to JSON; the new tests build the same envelope and assert `json.dumps(..., sort_keys=True)` byte-equality after normalising the store discriminator.

Alternative considered: adding runtime envelope validation in the adapters themselves. Rejected on scope grounds. Adapters trust the kernel by design, and the wire contract is more naturally enforced at test time.

## What changed

- `packages/nauro/tests/test_check_decision_schema.py` — new file. Loads both Pydantic models' JSON schemas and compares to the snapshot. Module docstring carries the regen command.
- `packages/nauro/tests/snapshots/check_decision_schema.json` — new snapshot file. Sorted keys, 2-space indent for minimal future diffs.
- `packages/nauro/tests/test_check_decision_cross_surface.py` — two new tests covering the happy-path (related decisions present) and empty-result branches. Both build the actual adapter envelope shape, swap the store field, and assert JSON-byte-equality.

No source files changed.

## What to review

- The regen command in the schema test docstring. Verified locally to produce byte-identical output to the committed snapshot.
- The empty-result branch test uses a fixed approach string (`"Adopt a fictional widget library for sprocket rendering"`) chosen to have zero overlap with the seeded decisions. If retrieval gets more permissive in the future, this assumption is worth re-examining; the test asserts `related_decisions == []` before the envelope compare so the failure mode is loud.

## What's deferred

- The pre-existing `Decision(...)` fixture in `test_check_decision_cross_surface.py` omits the now-required `date` field. It fails at collection time only when `mcp_server` is importable; public-monorepo CI skips the file before that path runs. Fix belongs in a separate test-hygiene PR.
- Generalizing the schema snapshot to the other operation Result models. Recommended only if silent field drift actually surfaces in practice.

## Test plan

- `uv run pytest packages/nauro/tests/test_check_decision_schema.py` — 1 passed.
- `uv run pytest packages/nauro/tests/test_check_decision_cross_surface.py` — skipped (CloudStore absent in this workspace; runs in CI where it's installed).
- `uv run pytest packages/nauro-core/tests/ packages/nauro/tests/` — 1553 passed, 11 skipped.
- `uv run ruff format --check packages/` — 202 files already formatted.
- `uv run ruff check packages/` — all checks passed.
