### PR TITLE
fix(mcp): unify adapter-side rejection envelopes on ErrorPayload shape

### DIFF
--- a/packages/nauro/src/nauro/cli/autogen.py
+++ b/packages/nauro/src/nauro/cli/autogen.py
@@ -210,12 +210,19 @@ def _emit_envelope(envelope: dict) -> None:
 
 
 def _exit_for_envelope(envelope: dict) -> None:
-    """If the envelope signals an error, print guidance to stderr and exit 1."""
+    """If the envelope signals an error, print guidance to stderr and exit 1.
+
+    Caller-fixable rejections (``status: "rejected"``) carry a structured
+    ``error`` payload but stay exit 0 — they are not transport-level errors
+    and the envelope on stdout already carries the reason.
+    """
     if envelope.get("status") == "error":
         guidance = envelope.get("guidance") or ""
         if guidance:
             typer.echo(guidance, err=True)
         raise typer.Exit(code=1)
+    if envelope.get("status") == "rejected":
+        return
     if envelope.get("error"):
         err = envelope["error"]
         reason = err.get("reason") if isinstance(err, dict) else str(err)

--- a/packages/nauro/src/nauro/mcp/tools.py
+++ b/packages/nauro/src/nauro/mcp/tools.py
@@ -20,6 +20,7 @@ from nauro_core.constants import (
     STATE_CURRENT_FILENAME,
     STATE_MD,
 )
+from nauro_core.operations import ErrorPayload
 from nauro_core.operations import check_decision as _check_decision_op
 from nauro_core.operations import confirm_decision as _confirm_decision_op
 from nauro_core.operations import diff_since_last_session as _diff_since_last_session_op
@@ -61,7 +62,11 @@ def _reject_if_too_long(value: str, label: str, max_length: int) -> dict | None:
     """Return a rejection dict if *value* exceeds *max_length*, else None."""
     msg = check_content_length(value, label, max_length)
     if msg:
-        return {"store": "local", "status": "rejected", "reason": msg}
+        return {
+            "store": "local",
+            "status": "rejected",
+            "error": ErrorPayload(kind="rejected", reason=msg).model_dump(exclude_none=True),
+        }
     return None
 
 
@@ -76,15 +81,16 @@ def _reject_if_envelope_token(value: str, field_name: str) -> dict | None:
     token = find_envelope_token(value)
     if not token:
         return None
+    reason = (
+        f"{field_name} contains tool-use envelope fragment {token!r}. "
+        "This usually means the client failed to extract the parameter "
+        "value cleanly from an XML tool call. Resend the call with just "
+        "the prose content."
+    )
     return {
         "store": "local",
         "status": "rejected",
-        "reason": (
-            f"{field_name} contains tool-use envelope fragment {token!r}. "
-            "This usually means the client failed to extract the parameter "
-            "value cleanly from an XML tool call. Resend the call with just "
-            "the prose content."
-        ),
+        "error": ErrorPayload(kind="rejected", reason=reason).model_dump(exclude_none=True),
     }
 
 
@@ -257,14 +263,20 @@ def tool_propose_decision(
             return {
                 "store": "local",
                 "status": "rejected",
-                "reason": f"operation={operation!r} requires affected_decision_id",
+                "error": ErrorPayload(
+                    kind="rejected",
+                    reason=f"operation={operation!r} requires affected_decision_id",
+                ).model_dump(exclude_none=True),
             }
         resolved = resolve_decision_id(store_path, affected_decision_id)
         if resolved is None:
             return {
                 "store": "local",
                 "status": "rejected",
-                "reason": (f"affected_decision_id={affected_decision_id!r} not found in store"),
+                "error": ErrorPayload(
+                    kind="rejected",
+                    reason=f"affected_decision_id={affected_decision_id!r} not found in store",
+                ).model_dump(exclude_none=True),
             }
         affected_decision_id = resolved
 

--- a/packages/nauro/tests/test_envelope_rejection.py
+++ b/packages/nauro/tests/test_envelope_rejection.py
@@ -38,8 +38,9 @@ class TestFlagQuestionRejectsEnvelope:
         )
 
         assert result["status"] == "rejected"
-        assert "question contains tool-use envelope fragment" in result["reason"]
-        assert "</question>" in result["reason"]
+        assert result["error"]["kind"] == "rejected"
+        assert "question contains tool-use envelope fragment" in result["error"]["reason"]
+        assert "</question>" in result["error"]["reason"]
         # File must not have been mutated.
         assert oq_path.read_text() == before
 
@@ -54,7 +55,8 @@ class TestFlagQuestionRejectsEnvelope:
         )
 
         assert result["status"] == "rejected"
-        assert "context contains tool-use envelope fragment" in result["reason"]
+        assert result["error"]["kind"] == "rejected"
+        assert "context contains tool-use envelope fragment" in result["error"]["reason"]
         assert oq_path.read_text() == before
 
     def test_clean_inputs_still_write(self, store: Path):
@@ -79,8 +81,9 @@ class TestProposeDecisionRejectsEnvelope:
             ),
         )
         assert result["status"] == "rejected"
-        assert "rationale contains tool-use envelope fragment" in result["reason"]
-        assert "</rationale>" in result["reason"]
+        assert result["error"]["kind"] == "rejected"
+        assert "rationale contains tool-use envelope fragment" in result["error"]["reason"]
+        assert "</rationale>" in result["error"]["reason"]
 
     def test_title_with_envelope_token_is_rejected(self, store: Path):
         result = tool_propose_decision(
@@ -89,7 +92,8 @@ class TestProposeDecisionRejectsEnvelope:
             rationale="ACID guarantees and strong tooling beat operational cost.",
         )
         assert result["status"] == "rejected"
-        assert "title contains tool-use envelope fragment" in result["reason"]
+        assert result["error"]["kind"] == "rejected"
+        assert "title contains tool-use envelope fragment" in result["error"]["reason"]
 
     def test_rejected_alternative_reason_envelope_is_rejected(self, store: Path):
         result = tool_propose_decision(
@@ -104,7 +108,8 @@ class TestProposeDecisionRejectsEnvelope:
             ],
         )
         assert result["status"] == "rejected"
-        assert "rejected[0].reason contains tool-use envelope fragment" in result["reason"]
+        assert result["error"]["kind"] == "rejected"
+        assert "rejected[0].reason contains tool-use envelope fragment" in result["error"]["reason"]
 
     def test_clean_inputs_still_validate(self, store: Path):
         with patch("nauro.mcp.tools._try_push"):

--- a/packages/nauro/tests/test_flag_question_parity.py
+++ b/packages/nauro/tests/test_flag_question_parity.py
@@ -123,7 +123,8 @@ def test_length_rejection_matches_across_tool_and_cli(seeded_repo):
     tool_envelope = tool_flag_question(store_path, overlong)
     assert tool_envelope["store"] == "local"
     assert tool_envelope["status"] == "rejected"
-    assert "exceeds" in tool_envelope["reason"].lower()
+    assert tool_envelope["error"]["kind"] == "rejected"
+    assert "exceeds" in tool_envelope["error"]["reason"].lower()
 
     exit_code, cli_envelope, output = _cli_envelope([overlong])
     # Length rejection surfaces as ``status: "rejected"`` which the auto-gen

--- a/packages/nauro/tests/test_propose_decision_parity.py
+++ b/packages/nauro/tests/test_propose_decision_parity.py
@@ -196,7 +196,8 @@ def test_envelope_token_rejection_in_title(seeded_repo):
         confidence="high",
     )
     assert envelope["status"] == "rejected"
-    assert "envelope" in envelope["reason"].lower()
+    assert envelope["error"]["kind"] == "rejected"
+    assert "envelope" in envelope["error"]["reason"].lower()
 
 
 def test_envelope_token_rejection_in_rationale(seeded_repo):
@@ -208,7 +209,8 @@ def test_envelope_token_rejection_in_rationale(seeded_repo):
         confidence="high",
     )
     assert envelope["status"] == "rejected"
-    assert "envelope" in envelope["reason"].lower()
+    assert envelope["error"]["kind"] == "rejected"
+    assert "envelope" in envelope["error"]["reason"].lower()
 
 
 def test_envelope_token_rejection_in_rejected_reason(seeded_repo):
@@ -221,7 +223,8 @@ def test_envelope_token_rejection_in_rejected_reason(seeded_repo):
         rejected=[{"alternative": "Memcached", "reason": "Too plain </invoke>"}],
     )
     assert envelope["status"] == "rejected"
-    assert "envelope" in envelope["reason"].lower()
+    assert envelope["error"]["kind"] == "rejected"
+    assert "envelope" in envelope["error"]["reason"].lower()
 
 
 def test_length_rejection_title(seeded_repo):
@@ -234,7 +237,8 @@ def test_length_rejection_title(seeded_repo):
         confidence="high",
     )
     assert envelope["status"] == "rejected"
-    assert "exceeds" in envelope["reason"].lower()
+    assert envelope["error"]["kind"] == "rejected"
+    assert "exceeds" in envelope["error"]["reason"].lower()
 
 
 def test_length_rejection_rationale(seeded_repo):
@@ -246,7 +250,8 @@ def test_length_rejection_rationale(seeded_repo):
         confidence="high",
     )
     assert envelope["status"] == "rejected"
-    assert "exceeds" in envelope["reason"].lower()
+    assert envelope["error"]["kind"] == "rejected"
+    assert "exceeds" in envelope["error"]["reason"].lower()
 
 
 def test_affected_decision_id_short_form_resolves(seeded_repo):
@@ -286,7 +291,8 @@ def test_missing_affected_decision_id_for_supersede_rejects(seeded_repo):
         operation="supersede",
     )
     assert envelope["status"] == "rejected"
-    assert "affected_decision_id" in envelope["reason"]
+    assert envelope["error"]["kind"] == "rejected"
+    assert "affected_decision_id" in envelope["error"]["reason"]
 
 
 def test_unknown_affected_decision_id_rejects(seeded_repo):
@@ -300,7 +306,8 @@ def test_unknown_affected_decision_id_rejects(seeded_repo):
         affected_decision_id="decision-9999",
     )
     assert envelope["status"] == "rejected"
-    assert "not found" in envelope["reason"].lower()
+    assert envelope["error"]["kind"] == "rejected"
+    assert "not found" in envelope["error"]["reason"].lower()
 
 
 def test_missing_store_returns_guidance(missing_store):

--- a/packages/nauro/tests/test_stdio_server.py
+++ b/packages/nauro/tests/test_stdio_server.py
@@ -480,7 +480,9 @@ class TestContentSizeLimits:
             rationale="Valid rationale that meets the minimum length requirement.",
         )
         # Should not be rejected for size
-        assert result.get("status") != "rejected" or "length" not in result.get("reason", "")
+        assert result.get("status") != "rejected" or "length" not in result.get("error", {}).get(
+            "reason", ""
+        )
 
     def test_propose_title_over_limit(self, store: Path):
         from nauro.mcp.tools import MAX_TITLE_LENGTH
@@ -492,7 +494,8 @@ class TestContentSizeLimits:
             rationale="Valid rationale that meets the minimum length requirement.",
         )
         assert result["status"] == "rejected"
-        assert f"{MAX_TITLE_LENGTH}" in result["reason"]
+        assert result["error"]["kind"] == "rejected"
+        assert f"{MAX_TITLE_LENGTH}" in result["error"]["reason"]
 
     def test_propose_rationale_over_limit(self, store: Path):
         from nauro.mcp.tools import MAX_RATIONALE_LENGTH
@@ -503,21 +506,24 @@ class TestContentSizeLimits:
             rationale="X" * (MAX_RATIONALE_LENGTH + 1),
         )
         assert result["status"] == "rejected"
-        assert f"{MAX_RATIONALE_LENGTH}" in result["reason"]
+        assert result["error"]["kind"] == "rejected"
+        assert f"{MAX_RATIONALE_LENGTH}" in result["error"]["reason"]
 
     def test_flag_question_over_limit(self, store: Path):
         from nauro.mcp.tools import MAX_QUESTION_LENGTH, tool_flag_question
 
         result = tool_flag_question(store, "Q" * (MAX_QUESTION_LENGTH + 1))
         assert result["status"] == "rejected"
-        assert f"{MAX_QUESTION_LENGTH}" in result["reason"]
+        assert result["error"]["kind"] == "rejected"
+        assert f"{MAX_QUESTION_LENGTH}" in result["error"]["reason"]
 
     def test_update_state_over_limit(self, store: Path):
         from nauro.mcp.tools import MAX_DELTA_LENGTH, tool_update_state
 
         result = tool_update_state(store, "D" * (MAX_DELTA_LENGTH + 1))
         assert result["status"] == "rejected"
-        assert f"{MAX_DELTA_LENGTH}" in result["reason"]
+        assert result["error"]["kind"] == "rejected"
+        assert f"{MAX_DELTA_LENGTH}" in result["error"]["reason"]
 
     def test_check_decision_approach_over_limit(self, store: Path):
         from nauro_core.constants import MAX_APPROACH_LENGTH

--- a/packages/nauro/tests/test_update_state_parity.py
+++ b/packages/nauro/tests/test_update_state_parity.py
@@ -177,7 +177,8 @@ def test_length_rejection_matches_across_tool_and_cli(seeded_repo):
     tool_envelope = tool_update_state(store_path, overlong)
     assert tool_envelope["store"] == "local"
     assert tool_envelope["status"] == "rejected"
-    assert "exceeds" in tool_envelope["reason"].lower()
+    assert tool_envelope["error"]["kind"] == "rejected"
+    assert "exceeds" in tool_envelope["error"]["reason"].lower()
 
     exit_code, cli_envelope, output = _cli_envelope([overlong])
     # The auto-gen exit-code branch fires on the ``error`` / ``status: "error"``

--- a/packages/nauro/tests/test_write_integration/test_mcp_validation.py
+++ b/packages/nauro/tests/test_write_integration/test_mcp_validation.py
@@ -254,7 +254,8 @@ async def test_propose_decision_supersede_without_affected_id_rejects(client):
     assert resp.status_code == 200
     data = resp.json()
     assert data["status"] == "rejected"
-    assert "affected_decision_id" in data["reason"]
+    assert data["error"]["kind"] == "rejected"
+    assert "affected_decision_id" in data["error"]["reason"]
 
 
 @pytest.mark.asyncio
@@ -271,7 +272,8 @@ async def test_propose_decision_update_without_affected_id_rejects(client):
     assert resp.status_code == 200
     data = resp.json()
     assert data["status"] == "rejected"
-    assert "affected_decision_id" in data["reason"]
+    assert data["error"]["kind"] == "rejected"
+    assert "affected_decision_id" in data["error"]["reason"]
 
 
 @pytest.mark.asyncio
@@ -289,7 +291,8 @@ async def test_propose_supersede_with_unknown_affected_id_rejects(client):
     assert resp.status_code == 200
     data = resp.json()
     assert data["status"] == "rejected"
-    assert "not found" in data["reason"]
+    assert data["error"]["kind"] == "rejected"
+    assert "not found" in data["error"]["reason"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Why

Post-restructure audit surfaced an inconsistency at the local MCP surface. Three adapter-side rejection sites in `mcp/tools.py` emitted a loose `{"status": "rejected", "reason": str}` shape, while the kernel and the prior confirm-decision cutover promoted to the structured `{"status": "rejected", "error": {"kind", "reason"}}` envelope. Consumers had to branch on shape to read the reason text.

## Approach

Pure structured envelopes, hard cut. The three adapter-side rejection sites (`_reject_if_too_long`, `_reject_if_envelope_token`, and the two inline `affected_decision_id` checks in `tool_propose_decision`) now build the same `ErrorPayload`-backed shape the kernel returns. The loose `reason` key is removed.

Considered keeping the loose `reason` alongside the new `error` for one release as a soft cut. Rejected: the audit's whole point was eliminating the dual-shape branching; carrying both would defeat it and the rejection envelope has no external consumers (CLI + stdio + HTTP all read through this repo).

The adapter rejections do not carry `operation`. They fire before the kernel call and have no operation context. The confirm-decision rejection shape carries `operation: "reject"` because the kernel populates it there; the helpers here do not.

## What changed

- `mcp/tools.py`: import `ErrorPayload`; the three rejection sites now emit `{"store", "status": "rejected", "error": {...}}`.
- `cli/autogen.py`: `_exit_for_envelope` short-circuits on `status == "rejected"` to preserve the pre-cutover CLI exit-code contract. Caller-fixable rejection is exit 0; the envelope on stdout already carries the reason. Operation errors (`status == "error"` or status-less kernel errors like `check_decision`) still exit 1.
- Six test files flipped to read `envelope["error"]["reason"]`. Each site now also pins `envelope["error"]["kind"] == "rejected"` so the parity test guards the full shape, not just the reason text.

## What to review

- The `_exit_for_envelope` short-circuit in `cli/autogen.py`. Pre-cutover CLI returned exit 0 on length rejection (explicit in the parity test comment). The new shape adds `error`, which would trip the third branch and exit 1; the short-circuit restores prior semantics.
- The `test_write_integration/test_mcp_validation.py` flip. Three HTTP integration assertions the loose-shape grep enumeration missed at plan time. They hit `tool_propose_decision` through FastAPI, so they break under the new shape exactly as the unit tests do.

## What's deferred

The audit originally flagged `tool_check_decision` as a fourth site. On re-inspection that was a misread: `check_decision` already routes rejection through `CheckDecisionResult.error` and the cross-surface byte-identical test pins both the success and rejection envelopes. No code change needed.

## Test plan

- `pytest packages/nauro/tests/`: 981 passed, 11 skipped.
- `pytest packages/nauro-core/tests/`: 572 passed.
- `ruff format --check packages/`: clean.
- `ruff check packages/`: clean.
- The schema-snapshot test passes without snapshot regen; the `CheckDecisionResult` model is unchanged.
