### PR TITLE
chore(release): bump nauro-core to 0.11.0 and nauro to 0.8.0

### DIFF
--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro-core"
-version = "0.10.0"
+version = "0.11.0"
 description = "Shared pure-Python logic for Nauro: parsing, validation, context assembly, constants."
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro"
-version = "0.7.0"
+version = "0.8.0"
 description = "Local CLI + MCP server: set your project's doctrine once, every connected AI agent inherits it."
 readme = "README.md"
 license = "Apache-2.0"
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "nauro-core>=0.10.0,<0.11",
+    "nauro-core>=0.11.0,<0.12",
     "typer>=0.9",
     "fastapi>=0.100",
     "uvicorn>=0.23",


### PR DESCRIPTION
## Why

Cut a versioned release of both workspace packages so the `mcp-server` companion repo can pin `nauro-core` to a PyPI version instead of the current git SHA, and so downstream `pipx install nauro` users get the post-restructure shape.

## What changed

- `packages/nauro-core/pyproject.toml`: version `0.10.0` → `0.11.0`.
- `packages/nauro/pyproject.toml`: version `0.7.0` → `0.8.0`; dep specifier `nauro-core>=0.10.0,<0.11` → `nauro-core>=0.11.0,<0.12`.

No source code changes. No test changes. `uv.lock` regenerated locally (gitignored).

## What's in the release

**nauro-core 0.11.0** — operations-kernel restructure:

- New `nauro_core.operations` public surface: 10 kernel callables (`check_decision`, `get_decision`, `get_raw_file`, `list_decisions`, `search_decisions`, `get_context`, `diff_since_last_session`, `update_state`, `flag_question`, `propose_decision`, `confirm_decision`).
- Single Result class per operation (frozen, `extra="forbid"`).
- `Store` protocol (five file-I/O methods); `_write_decision_direct` shared helper across the kernel and CLI bypass paths.
- `RelatedDecision` and `ErrorPayload` re-exported through `nauro_core.operations`.
- `CheckDecisionResult` schema snapshot test pins the wire shape.

**nauro 0.8.0** — consumes the new kernel:

- All four MCP write tools (`update_state`, `flag_question`, `propose_decision`, `confirm_decision`) route through `nauro_core.operations` via thin adapters.
- Adapter-side rejection envelopes unified on the structured `{status: "rejected", error: {kind, reason}}` shape (replaces loose `{status, reason}`).
- Auto-generated CLI commands for all read tools plus `update-state` and `flag-question` (`propose-decision` and `confirm-decision` stay off the allowlist).
- Three-layer parity test mix (kernel + per-package surface + cross-surface) across all 10 cut-over operations.

## Test plan

- `uv run pytest packages/nauro-core/tests/ packages/nauro/tests/`: 1553 passed, 11 skipped.
- `uv run ruff format --check packages/` + `uv run ruff check packages/`: clean.

## Post-merge tag plan

1. Tag `nauro-core-v0.11.0` on the merge commit; wait for `publish-nauro-core.yml` to publish to PyPI.
2. Tag `nauro-v0.8.0`; wait for `publish-nauro.yml` to publish.
3. After PyPI confirms both, the `mcp-server` repo can run `make bump-nauro-core REV=0.11.0` to slide off the transitional git pin.
