### PR TITLE
chore: gitignore local IDE MCP config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ AGENTS.md
 .claude/*
 !.claude/skills/
 **/.claude/settings.local.json
+.cursor/
+.mcp.json


### PR DESCRIPTION
## Why

\`.cursor/mcp.json\` and \`.mcp.json\` were sitting as untracked-but-not-ignored at the repo root. Both embed an absolute path to the developer's home (e.g. \`/Users/<name>/.local/bin/nauro\`) and are per-machine IDE wiring rather than shared config. Leaving them visible in \`git status\` makes accidental \`git add .\` commits easy to slip through — and that would violate the no-personal-paths-in-git posture.

## What changed

Two lines appended to \`.gitignore\`:
- \`.cursor/\` (whole directory — Cursor occasionally writes other per-user state there too)
- \`.mcp.json\` (Claude Code's MCP server registration at repo root)

## Test plan

- \`git status --short\` after the change: empty. Both untracked files now suppressed.