### PR TITLE
feat(cli): auto-gen propose-decision + confirm-decision

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,16 @@ Codex users: add `mcp_oauth_callback_port = 8765` to the top of `~/.codex/config
 
 **Write:** `propose_decision` / `confirm_decision`, `flag_question`, `update_state`.
 
-`nauro check-decision "<approach>"` runs `check_decision` from the shell.
+`nauro check-decision "<approach>"` runs `check_decision` from the shell. The write tools surface the same way:
+
+```bash
+nauro propose-decision "Adopt Redis" "In-memory cache for hot read paths" \
+    --files-affected src/cache.py --files-affected src/api.py \
+    --rejected '[{"alternative": "Memcached", "reason": "Less feature-rich"}]'
+nauro confirm-decision <confirm_id>   # only needed on Tier 2 match
+```
+
+Repeat `--files-affected` for each entry. `--rejected` accepts inline JSON, `@file.json`, or `-` to read from stdin.
 
 ## Packages
 

--- a/packages/nauro/CLAUDE.md
+++ b/packages/nauro/CLAUDE.md
@@ -38,9 +38,13 @@ All files are freeform markdown. No database. No JSON for content — JSON only 
 - `nauro sync` — capture a snapshot, regenerate `AGENTS.md` in all associated repos
 - `nauro log` — list recent snapshots with metadata
 - `nauro diff-since-last-session [--days N]` — semantic diff against the previous snapshot (or N days back when supplied)
+- `nauro propose-decision <title> <rationale> [--operation add|update|supersede] [--rejected JSON] [--files-affected PATH ...]` — propose a decision; auto-confirms on Tier 2 clean, otherwise returns a `confirm_id`
+- `nauro confirm-decision <confirm_id>` — confirm a previously proposed decision
 - `nauro serve` — start the MCP server on localhost:7432
 - `nauro import --memory-bank <path>` — migrate a Cline/Roo Code Memory Bank
 - `nauro import --adr <path>` — migrate Architecture Decision Records
+
+`list[str]` flags (`--files-affected`, `--resolves-questions`) repeat: `--files-affected a.py --files-affected b.py`. `list[dict]` flags (`--rejected`) take a single JSON value: inline (`'[{...}]'`), `@file.json`, or `-` to read from stdin.
 
 ## MCP tools (12 total in `nauro_core.mcp_tools` — 8 read, 4 write)
 

--- a/packages/nauro/src/nauro/cli/_json_input.py
+++ b/packages/nauro/src/nauro/cli/_json_input.py
@@ -1,0 +1,70 @@
+"""Internal CLI helper for parsing ``list[dict]`` arguments.
+
+The auto-gen framework uses this to translate a single Typer flag into
+the structured value the matching MCP adapter expects. Three input
+sources are supported behind one flag:
+
+- literal JSON on the command line:
+  ``--rejected '[{"alternative": "X", "reason": "Y"}]'``
+- ``@path`` sigil reading a JSON file:
+  ``--rejected @rejected.json``
+- ``-`` sigil reading stdin:
+  ``echo '[...]' | nauro propose-decision ... --rejected -``
+
+All parse failures raise ``typer.BadParameter``. Typer renders that to
+stderr with exit code 2; the adapter is never invoked. This keeps the
+semantic split clean: kernel-side rejections flow through the JSON
+envelope on stdout at exit 0, CLI argument-parse failures stay on
+stderr at exit 2.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import typer
+
+
+def parse_json_list_of_dicts(raw: str, flag_name: str) -> list[dict]:
+    """Parse a CLI argument that accepts inline JSON, ``@file``, or stdin.
+
+    Args:
+        raw: The literal value passed to the flag.
+        flag_name: The long-form flag name (e.g. ``"--rejected"``) used
+            verbatim in the error message so the user sees which flag
+            failed.
+
+    Returns:
+        The parsed JSON value, guaranteed to be a ``list[dict]``.
+
+    Raises:
+        typer.BadParameter: When the value cannot be read, is not valid
+            JSON, or is not a list of objects.
+    """
+    if raw == "-":
+        text = sys.stdin.read()
+        if not text:
+            raise typer.BadParameter(f"{flag_name}: stdin closed without input")
+    elif raw.startswith("@"):
+        path = Path(raw[1:])
+        if not path.exists() or not path.is_file():
+            raise typer.BadParameter(f"{flag_name}: file '{path}' does not exist")
+        text = path.read_text()
+    else:
+        text = raw
+
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise typer.BadParameter(f"{flag_name}: invalid JSON ({exc.msg})") from exc
+
+    if not isinstance(parsed, list):
+        raise typer.BadParameter(
+            f"{flag_name}: expected JSON array of objects, got {type(parsed).__name__}"
+        )
+    for idx, item in enumerate(parsed):
+        if not isinstance(item, dict):
+            raise typer.BadParameter(f"{flag_name}: element [{idx}] is not an object")
+    return parsed

--- a/packages/nauro/src/nauro/cli/autogen.py
+++ b/packages/nauro/src/nauro/cli/autogen.py
@@ -1,16 +1,20 @@
 """Auto-generate Typer CLI commands from the ToolSpec registry.
 
 Walks ``nauro_core.mcp_tools.ALL_TOOLS`` and, for each tool name in the
-read allowlist, registers a Typer command that calls the matching
+allowlist, registers a Typer command that calls the matching
 ``tool_<name>`` adapter in ``nauro.mcp.tools`` and prints the resulting
-envelope as JSON. Auto-generation keeps the CLI surface in lockstep with
-the MCP surface for read-only tools.
+envelope as JSON. Auto-generation keeps the CLI surface in lockstep
+with the MCP surface.
 
 The allowlist is explicit (not derived from the ``readOnlyHint``
-annotation) so that future read-tool additions to the registry surface
-through this generator only when the maintainer opts them in, and so
-write tools added to the registry later can never reach the CLI through
-this path by accident.
+annotation) so future additions to the registry — read or write —
+surface through this generator only when the maintainer opts them in.
+
+``list[str]`` properties map to repeated Typer flags (Typer aggregates
+them natively). ``list[dict]`` properties map to a single JSON-valued
+flag parsed at dispatch time by ``cli._json_input``; that helper raises
+``typer.BadParameter`` on malformed input so Typer renders to stderr at
+exit 2 without ever invoking the adapter.
 """
 
 from __future__ import annotations
@@ -24,6 +28,7 @@ import click
 import typer
 from nauro_core.mcp_tools import ALL_TOOLS, ToolSpec
 
+from nauro.cli._json_input import parse_json_list_of_dicts
 from nauro.cli.utils import resolve_target_project
 from nauro.mcp import tools as mcp_tools
 from nauro.telemetry.transport import set_transport
@@ -45,6 +50,8 @@ AUTOGEN_ALLOWLIST: frozenset[str] = frozenset(
         "check_decision",
         "update_state",
         "flag_question",
+        "propose_decision",
+        "confirm_decision",
     }
 )
 
@@ -187,6 +194,29 @@ def _optional_param(name: str, prop: dict[str, Any]) -> tuple[Any, Any]:
                 help=desc,
             ),
         )
+    if prop_type == "array":
+        items_type = (prop.get("items") or {}).get("type")
+        if items_type == "string":
+            return (
+                list[str],
+                typer.Option(
+                    None,
+                    _option_flag(name),
+                    help=f"{desc} Repeat the flag for each value.",
+                ),
+            )
+        if items_type == "object":
+            return (
+                str | None,
+                typer.Option(
+                    None,
+                    _option_flag(name),
+                    help=(
+                        f"{desc} Pass JSON: literal '[{{...}}]', '@file.json', or '-' for stdin."
+                    ),
+                    metavar="JSON",
+                ),
+            )
     raise ValueError(
         f"Unsupported optional property type {prop_type!r} for {name!r}. "
         "Extend the type-coercion table in cli/autogen.py."
@@ -244,6 +274,19 @@ def _make_command(spec: ToolSpec) -> Callable[..., None]:
         p.name for p in params if p.name not in {"project", "json_output"}
     ]
 
+    # Properties declared as ``array of object`` arrive as raw strings from
+    # Typer and must be JSON-parsed before reaching the adapter. Precompute
+    # the names once at command-construction time.
+    props: dict[str, Any] = spec["input_schema"].get("properties", {}) or {}
+    json_array_names: list[str] = [
+        name
+        for name in schema_arg_names
+        if (
+            props.get(name, {}).get("type") == "array"
+            and (props.get(name, {}).get("items") or {}).get("type") == "object"
+        )
+    ]
+
     def command(**kwargs: Any) -> None:
         project = kwargs.pop("project", None)
         # --json is a parity no-op; JSON is the only output mode.
@@ -252,6 +295,12 @@ def _make_command(spec: ToolSpec) -> Callable[..., None]:
         _project_name, store_path = resolve_target_project(project)
 
         set_transport("cli")
+
+        for name in json_array_names:
+            raw = kwargs.get(name)
+            if raw is None:
+                continue
+            kwargs[name] = parse_json_list_of_dicts(raw, _option_flag(name))
 
         adapter_kwargs = {name: kwargs[name] for name in schema_arg_names if name in kwargs}
         envelope = adapter(store_path, **adapter_kwargs)

--- a/packages/nauro/tests/_ansi.py
+++ b/packages/nauro/tests/_ansi.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 
 def strip_ansi(text: str) -> str:
-    """Strip ANSI CSI escape sequences without regex (per ``feedback_no_regex``)."""
+    """Strip ANSI CSI escape sequences using plain string ops (no regex)."""
     out: list[str] = []
     i = 0
     n = len(text)

--- a/packages/nauro/tests/_ansi.py
+++ b/packages/nauro/tests/_ansi.py
@@ -1,0 +1,29 @@
+"""Shared ANSI-stripping helper for CLI output assertions.
+
+Typer renders --help and BadParameter messages through Rich, which wraps
+flag tokens in bold/colour escapes when the runner detects a colour-capable
+terminal (CI runners with ``FORCE_COLOR=1``, GH Actions, etc.). The escapes
+split substrings like ``--rejected`` into ``-\\x1b[0m\\x1b[1m-rejected``,
+breaking literal ``"--rejected" in output`` checks. ``NO_COLOR`` only
+suppresses colour, not bold/dim — stripping here is the only
+environment-independent fix.
+"""
+
+from __future__ import annotations
+
+
+def strip_ansi(text: str) -> str:
+    """Strip ANSI CSI escape sequences without regex (per ``feedback_no_regex``)."""
+    out: list[str] = []
+    i = 0
+    n = len(text)
+    while i < n:
+        if text[i] == "\x1b" and i + 1 < n and text[i + 1] == "[":
+            i += 2
+            while i < n and text[i] != "m":
+                i += 1
+            i += 1
+        else:
+            out.append(text[i])
+            i += 1
+    return "".join(out)

--- a/packages/nauro/tests/test_cli_autogen.py
+++ b/packages/nauro/tests/test_cli_autogen.py
@@ -91,17 +91,12 @@ class TestAutogenCoverage:
                 )
 
     def test_allowlist_matches_registry_minus_list_projects(self) -> None:
-        """Every registry tool except ``list_projects`` and the write tools
-        that remain transport-only (``propose_decision``, ``confirm_decision``)
-        must be in the allowlist. ``list_projects`` stays out because local
-        installs auto-resolve to a single project.
+        """Every registry tool except ``list_projects`` must be in the
+        allowlist. ``list_projects`` stays out because local installs
+        auto-resolve to a single project.
         """
         registry_names = {spec["name"] for spec in ALL_TOOLS}
-        expected = registry_names - {
-            "list_projects",
-            "propose_decision",
-            "confirm_decision",
-        }
+        expected = registry_names - {"list_projects"}
         assert AUTOGEN_ALLOWLIST == expected
 
 

--- a/packages/nauro/tests/test_cli_json_input.py
+++ b/packages/nauro/tests/test_cli_json_input.py
@@ -1,0 +1,103 @@
+"""Tests for the ``_json_input`` CLI helper.
+
+The helper parses CLI arguments shaped as ``list[dict]`` from three input
+sources: literal JSON on the command line, ``@path`` to a file, and ``-``
+for stdin. It raises ``typer.BadParameter`` with the flag name on every
+malformed input so Typer renders the error to stderr at exit 2 without
+ever invoking the underlying adapter.
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import pytest
+import typer
+
+from nauro.cli._json_input import parse_json_list_of_dicts
+
+
+def test_literal_json_list_of_dicts() -> None:
+    parsed = parse_json_list_of_dicts(
+        '[{"alternative": "X", "reason": "Y"}]',
+        "--rejected",
+    )
+    assert parsed == [{"alternative": "X", "reason": "Y"}]
+
+
+def test_at_sigil_reads_file(tmp_path: Path) -> None:
+    payload = tmp_path / "rejected.json"
+    payload.write_text('[{"alternative": "X", "reason": "Y"}]')
+    parsed = parse_json_list_of_dicts(f"@{payload}", "--rejected")
+    assert parsed == [{"alternative": "X", "reason": "Y"}]
+
+
+def test_stdin_sigil_reads_stdin(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "sys.stdin",
+        io.StringIO('[{"alternative": "X", "reason": "Y"}]'),
+    )
+    parsed = parse_json_list_of_dicts("-", "--rejected")
+    assert parsed == [{"alternative": "X", "reason": "Y"}]
+
+
+def test_stdin_sigil_empty_input_rejects(monkeypatch) -> None:
+    monkeypatch.setattr("sys.stdin", io.StringIO(""))
+    with pytest.raises(typer.BadParameter) as excinfo:
+        parse_json_list_of_dicts("-", "--rejected")
+    assert "--rejected" in str(excinfo.value)
+    assert "stdin closed without input" in str(excinfo.value)
+
+
+def test_at_sigil_missing_file_rejects(tmp_path: Path) -> None:
+    missing = tmp_path / "does-not-exist.json"
+    with pytest.raises(typer.BadParameter) as excinfo:
+        parse_json_list_of_dicts(f"@{missing}", "--rejected")
+    msg = str(excinfo.value)
+    assert "--rejected" in msg
+    assert "does not exist" in msg
+    assert str(missing) in msg
+
+
+def test_malformed_json_rejects() -> None:
+    with pytest.raises(typer.BadParameter) as excinfo:
+        parse_json_list_of_dicts("not json", "--rejected")
+    msg = str(excinfo.value)
+    assert "--rejected" in msg
+    assert "invalid JSON" in msg
+
+
+def test_json_object_instead_of_list_rejects() -> None:
+    with pytest.raises(typer.BadParameter) as excinfo:
+        parse_json_list_of_dicts('{"not": "a list"}', "--rejected")
+    msg = str(excinfo.value)
+    assert "--rejected" in msg
+    assert "expected JSON array of objects" in msg
+
+
+def test_list_with_non_dict_element_rejects() -> None:
+    with pytest.raises(typer.BadParameter) as excinfo:
+        parse_json_list_of_dicts('[{"a": 1}, "scalar"]', "--rejected")
+    msg = str(excinfo.value)
+    assert "--rejected" in msg
+    assert "element [1] is not an object" in msg
+
+
+def test_list_of_dicts_with_unusual_but_valid_keys() -> None:
+    parsed = parse_json_list_of_dicts(
+        '[{"a": 1, "nested": {"k": [1, 2]}, "": "empty-key"}]',
+        "--rejected",
+    )
+    assert parsed == [{"a": 1, "nested": {"k": [1, 2]}, "": "empty-key"}]
+
+
+def test_at_sigil_pointing_at_directory_rejects(tmp_path: Path) -> None:
+    sub = tmp_path / "subdir"
+    sub.mkdir()
+    with pytest.raises(typer.BadParameter) as excinfo:
+        parse_json_list_of_dicts(f"@{sub}", "--rejected")
+    msg = str(excinfo.value)
+    assert "--rejected" in msg
+    assert "does not exist" in msg
+    assert str(sub) in msg

--- a/packages/nauro/tests/test_init_cloud.py
+++ b/packages/nauro/tests/test_init_cloud.py
@@ -22,6 +22,7 @@ from nauro.cli.main import app
 from nauro.store import registry
 from nauro.store.repo_config import load_repo_config
 from nauro.sync import cloud_projects
+from tests._ansi import strip_ansi
 
 runner = CliRunner()
 
@@ -122,31 +123,6 @@ def test_init_cloud_renders_server_error(tmp_path, monkeypatch):
 # ── --demo + --cloud rejection ───────────────────────────────────────────────
 
 
-def _strip_ansi(text: str) -> str:
-    """Strip ANSI CSI escape sequences (``\\x1b[…m``) without regex.
-
-    Typer renders BadParameter through Rich, which injects style escapes
-    around every flag token when the runner detects a colour-capable
-    terminal (CI runners with FORCE_COLOR=1, GH Actions, etc.). The escapes
-    split substrings like ``--demo`` into ``-\\x1b[0m-demo``, so a literal
-    ``"--demo" in output`` check fails on those runners. Stripping here
-    keeps the substring check colour-environment-independent.
-    """
-    out: list[str] = []
-    i = 0
-    n = len(text)
-    while i < n:
-        if text[i] == "\x1b" and i + 1 < n and text[i + 1] == "[":
-            i += 2
-            while i < n and text[i] != "m":
-                i += 1
-            i += 1
-        else:
-            out.append(text[i])
-            i += 1
-    return "".join(out)
-
-
 def test_init_demo_plus_cloud_rejects_at_entry(tmp_path, monkeypatch):
     """`nauro init --demo --cloud` must reject before any state is written.
 
@@ -172,7 +148,7 @@ def test_init_demo_plus_cloud_rejects_at_entry(tmp_path, monkeypatch):
         f"output={result.output!r}; exception={result.exception!r}"
     )
     raw_output = (result.output or "") + (str(result.exception) if result.exception else "")
-    combined_output = _strip_ansi(raw_output)
+    combined_output = strip_ansi(raw_output)
     assert "--demo" in combined_output and "--cloud" in combined_output, (
         f"expected both flag names in stripped output; got: {combined_output!r}"
     )

--- a/packages/nauro/tests/test_propose_decision_parity.py
+++ b/packages/nauro/tests/test_propose_decision_parity.py
@@ -11,10 +11,8 @@ against the same store. The participating wirings here:
   only write tool whose stdio surface preserves the dict (the others —
   ``flag_question`` / ``update_state`` — string-render for FastMCP).
 
-The ``propose_decision`` CLI auto-gen path is intentionally skipped: it
-is not on the auto-generated allowlist (the four read-only tools are
-listed in ``cli.commands.tools``), and there is no separate Typer
-command for ``propose_decision`` either. The HTTP MCP server exposes
+The CLI auto-gen surface for ``propose_decision`` is pinned separately
+in ``test_write_command_autogen.py``. The HTTP MCP server exposes
 ``/propose_decision`` but the FastAPI surface is pinned separately in
 ``test_mcp.py``.
 

--- a/packages/nauro/tests/test_setup_extended.py
+++ b/packages/nauro/tests/test_setup_extended.py
@@ -16,6 +16,7 @@ from nauro.cli.commands.setup import (
 from nauro.cli.main import app
 from nauro.store.registry import register_project_v2
 from nauro.templates.scaffolds import scaffold_project_store
+from tests._ansi import strip_ansi
 
 if sys.version_info >= (3, 11):
     import tomllib
@@ -23,31 +24,6 @@ else:
     import tomli as tomllib
 
 runner = CliRunner()
-
-
-def _strip_ansi(text: str) -> str:
-    """Strip ANSI CSI escape sequences so substring checks survive Rich styling.
-
-    Typer renders --help through Rich, which wraps each flag token in bold
-    escapes when the runner detects a colour-capable terminal (CI with
-    FORCE_COLOR=1 etc.). The escapes split ``--with-subagents`` into
-    ``-\\x1b[0m\\x1b[1m-with\\x1b[0m\\x1b[1m-subagents``, breaking literal
-    ``"--with-subagents" in output`` checks. NO_COLOR only suppresses colour,
-    not bold/dim — stripping here is the only environment-independent fix.
-    """
-    out: list[str] = []
-    i = 0
-    n = len(text)
-    while i < n:
-        if text[i] == "\x1b" and i + 1 < n and text[i + 1] == "[":
-            i += 2
-            while i < n and text[i] != "m":
-                i += 1
-            i += 1
-        else:
-            out.append(text[i])
-            i += 1
-    return "".join(out)
 
 
 # ─── nauro setup cursor ─────────────────────────────────────────────────────
@@ -576,7 +552,7 @@ def test_setup_all_help_lists_with_subagents():
     """``setup all --help`` advertises the new flag for discovery."""
     result = runner.invoke(app, ["setup", "all", "--help"])
     assert result.exit_code == 0
-    output = _strip_ansi(result.output)
+    output = strip_ansi(result.output)
     assert "--with-subagents" in output
     assert "--force-overwrite" in output
     assert "--with-skills" in output

--- a/packages/nauro/tests/test_write_command_autogen.py
+++ b/packages/nauro/tests/test_write_command_autogen.py
@@ -263,8 +263,8 @@ class TestConfirmDecisionRejections:
     def test_unknown_confirm_id_rejection_envelope(self, seeded_repo) -> None:
         result = runner.invoke(app, ["confirm-decision", "no-such-id"])
         # Unknown confirm_ids land status="rejected" with a structured
-        # ErrorPayload; per D202 the wrapper exits 0 — the envelope on
-        # stdout carries the reason and the user can fix the call.
+        # ErrorPayload; the wrapper exits 0 — the envelope on stdout
+        # carries the reason and the user can fix the call.
         assert result.exit_code == 0, result.output
         envelope = json.loads(result.stdout)
         assert envelope["status"] == "rejected"

--- a/packages/nauro/tests/test_write_command_autogen.py
+++ b/packages/nauro/tests/test_write_command_autogen.py
@@ -1,0 +1,379 @@
+"""End-to-end tests for the auto-generated ``propose-decision`` and
+``confirm-decision`` CLI commands.
+
+Three concerns are pinned here:
+
+* Happy paths through the write tools land the same envelope the adapter
+  returns (auto-confirmed adds, supersedes with ``--operation supersede
+  --affected-decision-id``, pending-confirmation followed by
+  ``confirm-decision``).
+* Rejection paths surface kernel ``status="rejected"`` envelopes on
+  stdout at exit 0 (caller-fixable) and ``status="error"`` guidance on
+  stderr at exit 1 (transport-level).
+* CLI argument-parse failures (``--rejected`` malformed / wrong shape)
+  raise ``typer.BadParameter`` and exit 2 with stderr text, never
+  invoking the adapter. The ``list[str]`` (``--files-affected``)
+  repeated-flag form and ``list[dict]`` (``--rejected``) literal /
+  ``@file`` / ``-`` (stdin) sigil forms are exercised here so the
+  framework convention is pinned at the CLI surface.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from nauro_core.constants import MAX_RATIONALE_LENGTH
+from nauro_core.operations.propose_decision import _get_pending_store
+from typer.testing import CliRunner
+
+from nauro.cli.main import app
+from nauro.constants import REPO_CONFIG_MODE_LOCAL
+from nauro.mcp import tools as mcp_tools
+from nauro.store.registry import register_project_v2
+from nauro.store.repo_config import save_repo_config
+from nauro.templates.scaffolds import scaffold_project_store
+from tests._writer_compat import append_decision
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _reset_pending_store() -> None:
+    """Each test starts with a clean kernel pending store."""
+    _get_pending_store().clear_all()
+    yield
+    _get_pending_store().clear_all()
+
+
+@pytest.fixture(autouse=True)
+def _no_push(monkeypatch):
+    """Suppress the best-effort cloud push so the CLI layer stays local."""
+    monkeypatch.setattr(mcp_tools, "_try_push", lambda _store_path: None)
+
+
+@pytest.fixture(autouse=True)
+def _no_regen(monkeypatch):
+    """Suppress AGENTS.md regen so the CLI layer stays local."""
+    monkeypatch.setattr(mcp_tools, "warn_then_regen", lambda *args, **kwargs: [])
+
+
+@pytest.fixture(autouse=True)
+def _no_snapshot(monkeypatch):
+    """Suppress snapshot capture so the CLI layer doesn't touch snapshots/."""
+    monkeypatch.setattr(mcp_tools, "capture_snapshot", lambda *args, **kwargs: None)
+
+
+@pytest.fixture
+def seeded_repo(tmp_path: Path, monkeypatch) -> tuple[str, Path, Path]:
+    """Register a project, scaffold the store, and chdir into the repo."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    pid, store_path = register_project_v2(
+        "cli-write",
+        [repo],
+        mode=REPO_CONFIG_MODE_LOCAL,
+    )
+    save_repo_config(
+        repo,
+        {"mode": REPO_CONFIG_MODE_LOCAL, "id": pid, "name": "cli-write"},
+    )
+    scaffold_project_store("cli-write", store_path)
+    monkeypatch.chdir(repo)
+    return pid, store_path, repo
+
+
+# ── Happy paths ─────────────────────────────────────────────────────────────
+
+
+class TestProposeDecisionHappyPaths:
+    def test_clean_add_lands_confirmed(self, seeded_repo) -> None:
+        result = runner.invoke(
+            app,
+            [
+                "propose-decision",
+                "Adopt Redis for hot caching",
+                "In-memory cache for the hot read paths across the API tier.",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        envelope = json.loads(result.stdout)
+        assert envelope["store"] == "local"
+        assert envelope["status"] == "confirmed"
+        assert envelope["operation"] == "add"
+        assert "decision_id" in envelope
+
+    def test_skip_validation_flag(self, seeded_repo) -> None:
+        result = runner.invoke(
+            app,
+            [
+                "propose-decision",
+                "Adopt Redis for hot caching",
+                "In-memory cache for the hot read paths across the API tier.",
+                "--skip-validation",
+            ],
+        )
+        # skip_validation bypasses Tier 2, so the auto-confirm short-circuit
+        # never runs; Tier 1 hands off via confirm_id.
+        assert result.exit_code == 0, result.output
+        envelope = json.loads(result.stdout)
+        assert envelope["status"] == "pending_confirmation"
+        assert envelope["tier"] == 1
+        assert envelope.get("confirm_id")
+
+    def test_supersede_with_affected_decision_id(self, seeded_repo) -> None:
+        _pid, store_path, _repo = seeded_repo
+        append_decision(
+            store_path,
+            "Adopt PostgreSQL primary database",
+            rationale="Mature ecosystem with strong JSON support and excellent tooling.",
+        )
+        decisions = sorted(f.stem for f in (store_path / "decisions").glob("*.md"))
+        postgres_stem = next(s for s in decisions if "postgres" in s)
+        short_form = postgres_stem.split("-", 1)[0]
+
+        result = runner.invoke(
+            app,
+            [
+                "propose-decision",
+                "Switch to managed PostgreSQL provider",
+                "Reduces operational burden; self-hosting rationale no longer applies.",
+                "--operation",
+                "supersede",
+                "--affected-decision-id",
+                short_form,
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        envelope = json.loads(result.stdout)
+        # Either confirmed (Tier 2 clean) or pending_confirmation (Tier 2 hit);
+        # both are acceptable — the point is the affected_decision_id resolved.
+        assert envelope["status"] in ("confirmed", "pending_confirmation")
+        assert envelope["operation"] == "supersede"
+
+
+class TestConfirmDecisionHappyPath:
+    def test_confirm_after_pending(self, seeded_repo) -> None:
+        _pid, store_path, _repo = seeded_repo
+        # Seed a similar decision so Tier 2 routes the next add to pending.
+        append_decision(
+            store_path,
+            "Adopt PostgreSQL primary database",
+            rationale="Mature ecosystem with strong JSON support and excellent tooling.",
+        )
+        propose = runner.invoke(
+            app,
+            [
+                "propose-decision",
+                "Use PostgreSQL for the data layer",
+                "Better JSON handling than alternatives for our application data.",
+            ],
+        )
+        assert propose.exit_code == 0, propose.output
+        propose_env = json.loads(propose.stdout)
+        assert propose_env["status"] == "pending_confirmation"
+        confirm_id = propose_env["confirm_id"]
+
+        confirm = runner.invoke(app, ["confirm-decision", confirm_id])
+        assert confirm.exit_code == 0, confirm.output
+        confirm_env = json.loads(confirm.stdout)
+        assert confirm_env["store"] == "local"
+        assert confirm_env["status"] == "confirmed"
+        assert "decision_id" in confirm_env
+
+
+# ── Rejection paths ─────────────────────────────────────────────────────────
+
+
+class TestProposeDecisionRejections:
+    def test_update_without_affected_id_rejected(self, seeded_repo) -> None:
+        result = runner.invoke(
+            app,
+            [
+                "propose-decision",
+                "Tweak PostgreSQL rationale",
+                "Add operational notes after the first month of production use.",
+                "--operation",
+                "update",
+            ],
+        )
+        # Caller-fixable rejection: envelope on stdout, exit 0.
+        assert result.exit_code == 0, result.output
+        envelope = json.loads(result.stdout)
+        assert envelope["status"] == "rejected"
+        assert envelope["error"]["kind"] == "rejected"
+        assert "affected_decision_id" in envelope["error"]["reason"]
+
+    def test_update_with_unknown_affected_id_rejected(self, seeded_repo) -> None:
+        result = runner.invoke(
+            app,
+            [
+                "propose-decision",
+                "Tweak something that does not exist",
+                "Add operational notes after the first month of production use.",
+                "--operation",
+                "update",
+                "--affected-decision-id",
+                "9999",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        envelope = json.loads(result.stdout)
+        assert envelope["status"] == "rejected"
+        assert envelope["error"]["kind"] == "rejected"
+        assert "not found" in envelope["error"]["reason"].lower()
+
+    def test_overlong_rationale_rejected(self, seeded_repo) -> None:
+        oversized = "x" * (MAX_RATIONALE_LENGTH + 1)
+        result = runner.invoke(
+            app,
+            [
+                "propose-decision",
+                "Adopt Redis for hot caching",
+                oversized,
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        envelope = json.loads(result.stdout)
+        assert envelope["status"] == "rejected"
+        assert envelope["error"]["kind"] == "rejected"
+        assert "exceeds" in envelope["error"]["reason"].lower()
+
+    def test_propose_missing_store_exits_one_with_guidance(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        # No project registered, no repo config — the resolver fails before
+        # the adapter is reached.
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(
+            app,
+            [
+                "propose-decision",
+                "Adopt Redis for hot caching",
+                "In-memory cache for the hot read paths across the API tier.",
+            ],
+        )
+        assert result.exit_code == 1
+        assert "No project found" in result.output
+
+
+class TestConfirmDecisionRejections:
+    def test_unknown_confirm_id_rejection_envelope(self, seeded_repo) -> None:
+        result = runner.invoke(app, ["confirm-decision", "no-such-id"])
+        # Unknown confirm_ids land status="rejected" with a structured
+        # ErrorPayload; per D202 the wrapper exits 0 — the envelope on
+        # stdout carries the reason and the user can fix the call.
+        assert result.exit_code == 0, result.output
+        envelope = json.loads(result.stdout)
+        assert envelope["status"] == "rejected"
+        assert envelope["error"]["kind"] == "rejected"
+        assert "confirm_id" in envelope["error"]["reason"].lower()
+
+
+# ── Flag-shape coverage ─────────────────────────────────────────────────────
+
+
+class TestFlagShapes:
+    def test_files_affected_repeats(self, seeded_repo) -> None:
+        _pid, store_path, _repo = seeded_repo
+        result = runner.invoke(
+            app,
+            [
+                "propose-decision",
+                "Adopt Redis for hot caching",
+                "In-memory cache for the hot read paths across the API tier.",
+                "--files-affected",
+                "a.py",
+                "--files-affected",
+                "b.py",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        envelope = json.loads(result.stdout)
+        assert envelope["status"] == "confirmed"
+        # The repeated flag landed as ["a.py", "b.py"] in the written
+        # decision file's frontmatter.
+        decision_file = next((store_path / "decisions").glob("*adopt-redis*.md"))
+        body = decision_file.read_text()
+        assert "- a.py" in body
+        assert "- b.py" in body
+
+    def test_rejected_literal_json(self, seeded_repo) -> None:
+        result = runner.invoke(
+            app,
+            [
+                "propose-decision",
+                "Adopt Redis for hot caching",
+                "In-memory cache for the hot read paths across the API tier.",
+                "--rejected",
+                '[{"alternative": "Memcached", "reason": "Less feature-rich"}]',
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        envelope = json.loads(result.stdout)
+        assert envelope["status"] == "confirmed"
+
+    def test_rejected_at_file_sigil(self, seeded_repo, tmp_path: Path) -> None:
+        payload = tmp_path / "rejected.json"
+        payload.write_text('[{"alternative": "Memcached", "reason": "Less feature-rich"}]')
+        result = runner.invoke(
+            app,
+            [
+                "propose-decision",
+                "Adopt Redis for hot caching",
+                "In-memory cache for the hot read paths across the API tier.",
+                "--rejected",
+                f"@{payload}",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        envelope = json.loads(result.stdout)
+        assert envelope["status"] == "confirmed"
+
+    def test_rejected_stdin_sigil(self, seeded_repo) -> None:
+        result = runner.invoke(
+            app,
+            [
+                "propose-decision",
+                "Adopt Redis for hot caching",
+                "In-memory cache for the hot read paths across the API tier.",
+                "--rejected",
+                "-",
+            ],
+            input='[{"alternative": "Memcached", "reason": "Less feature-rich"}]',
+        )
+        assert result.exit_code == 0, result.output
+        envelope = json.loads(result.stdout)
+        assert envelope["status"] == "confirmed"
+
+    def test_rejected_malformed_json_exits_two(self, seeded_repo) -> None:
+        result = runner.invoke(
+            app,
+            [
+                "propose-decision",
+                "Adopt Redis for hot caching",
+                "In-memory cache for the hot read paths across the API tier.",
+                "--rejected",
+                "not json",
+            ],
+        )
+        # typer.BadParameter renders to stderr at exit 2.
+        assert result.exit_code == 2
+        assert "--rejected" in result.output
+        assert "invalid JSON" in result.output
+
+    def test_rejected_wrong_shape_exits_two(self, seeded_repo) -> None:
+        result = runner.invoke(
+            app,
+            [
+                "propose-decision",
+                "Adopt Redis for hot caching",
+                "In-memory cache for the hot read paths across the API tier.",
+                "--rejected",
+                '{"not": "a list"}',
+            ],
+        )
+        assert result.exit_code == 2
+        assert "--rejected" in result.output
+        assert "expected JSON array of objects" in result.output

--- a/packages/nauro/tests/test_write_command_autogen.py
+++ b/packages/nauro/tests/test_write_command_autogen.py
@@ -34,6 +34,7 @@ from nauro.mcp import tools as mcp_tools
 from nauro.store.registry import register_project_v2
 from nauro.store.repo_config import save_repo_config
 from nauro.templates.scaffolds import scaffold_project_store
+from tests._ansi import strip_ansi
 from tests._writer_compat import append_decision
 
 runner = CliRunner()
@@ -360,7 +361,7 @@ class TestFlagShapes:
         )
         # typer.BadParameter renders to stderr at exit 2.
         assert result.exit_code == 2
-        assert "--rejected" in result.output
+        assert "--rejected" in strip_ansi(result.output)
         assert "invalid JSON" in result.output
 
     def test_rejected_wrong_shape_exits_two(self, seeded_repo) -> None:
@@ -375,5 +376,5 @@ class TestFlagShapes:
             ],
         )
         assert result.exit_code == 2
-        assert "--rejected" in result.output
+        assert "--rejected" in strip_ansi(result.output)
         assert "expected JSON array of objects" in result.output


### PR DESCRIPTION
## Why

The auto-gen framework in `cli/autogen.py` covers seven read tools plus two of the four write tools — `update_state` and `flag_question` landed in the allowlist when their kernel adapters cut over (#104, #105). The remaining two write tools, `propose_decision` and `confirm_decision`, had their kernel adapters cut over (#107, #108) but their CLI commands were held back because the framework didn't yet know how to render `list[dict]` arguments (specifically `propose_decision.rejected: list[dict]`) or `list[str]` arguments (`files_affected`, `resolves_questions`).

Without this PR, CLI-only users have no way to write decisions — they have to attach an MCP-aware agent for any write operation, which is exactly the surface-switching cost the uniform auto-gen surface was built to defend against.

## Approach

Auto-gen, not hand-write. The framework's uniformity is the load-bearing posture; introducing hand-written `nauro propose-decision` or interactive twin commands would impose the doctrine cost the auto-gen surface was built to avoid. The work decomposes into three pieces.

1. Allowlist `propose_decision` and `confirm_decision` in `cli/autogen.py`. Both have matching `tool_<name>` adapters in `mcp/tools.py`, so no kernel or adapter changes are needed.
2. Extend the type table to handle two JSON-Schema array shapes (the only registry shapes currently outside the table):
   - `items.type == "string"` → repeated Typer flag (`list[str]`). Typer aggregates `--files-affected a.py --files-affected b.py` natively.
   - `items.type == "object"` → single JSON-valued flag (`list[dict]`) with `metavar="JSON"`, parsed at dispatch time by a new helper that accepts inline JSON, `@file.json`, or `-` (reads from stdin).
3. Parse failures raise `typer.BadParameter` → Typer renders to stderr at exit 2, adapter never runs. This preserves the existing semantic split: kernel-side rejections are JSON envelopes on stdout at exit 0; CLI argument-parse failures stay on stderr at exit 2.

Alternatives considered and rejected: hand-write a `nauro check` interactive twin to pair with `nauro check-decision`, or introduce a one-off `nauro propose-decision` outside the auto-gen path. Both impose the cost of multiple commands per tool and per-tool special-casing in the framework without a friction report to justify it.

The `operation` / `affected_decision_id` coupling is **not** validated at the CLI layer — the kernel adapter at `mcp/tools.py:261-281` already returns a structured rejection envelope, and the user sees the same `{store, status: "rejected", error}` shape they would see through the MCP transport. Duplicating the check at the CLI would create two rejection sites that can drift.

## What changed

- `cli/_json_input.py` (new) — `parse_json_list_of_dicts(raw, flag_name)`. Three input sources behind one flag; `typer.BadParameter` on every failure (missing file, malformed JSON, wrong shape).
- `cli/autogen.py` (+63 / −8) — `propose_decision` + `confirm_decision` added to `AUTOGEN_ALLOWLIST`; `_optional_param` gains an `array` branch covering `string` and `object` item types; `_make_command` precomputes `json_array_names` from the spec and transforms `kwargs` in-place before calling the adapter; module docstring refreshed (the old text said "read allowlist" and was misleading after this cutover).
- `tests/_ansi.py` (new) — shared `strip_ansi` helper extracted from byte-equivalent copies in `test_setup_extended.py` and `test_init_cloud.py`. Needed for assertion stability across colour-capable CI runners.
- `tests/test_cli_json_input.py` (new) — 10 unit cases for the helper covering all three sigils and every error path.
- `tests/test_write_command_autogen.py` (new) — 15 cases: happy paths through `propose-decision` (clean add, `--skip-validation`, supersede with `--affected-decision-id`); pending-then-confirm via `confirm-decision`; rejection paths (missing `--affected-decision-id`, unknown id, overlong rationale, unknown `confirm_id`, missing store); flag-shape coverage (`--files-affected` repeats; `--rejected` literal / `@file` / `-` / malformed / wrong shape).
- `tests/test_cli_autogen.py` — closure-invariant tightened: allowlist must equal registry minus `list_projects` (no write-tool carve-outs).
- `tests/test_propose_decision_parity.py` / `test_setup_extended.py` / `test_init_cloud.py` — stale comment fix; local `_strip_ansi` removed in favour of the shared helper.
- `README.md` / `packages/nauro/CLAUDE.md` — short usage snippets for the new commands and the JSON-flag convention.

## What to review

- The `_optional_param` array branch in `cli/autogen.py` — the one place where the type table grows. Confirm the `items.type` lookup is safe against missing `items` keys (`(prop.get("items") or {}).get("type")`).
- The dispatch transform in `_make_command` — precomputed `json_array_names` list, in-place `kwargs[name]` rewrite before the adapter is called. Confirm the order of operations (project resolution → transport set → JSON parse → adapter call) is right.
- The semantic split — `BadParameter` (exit 2, stderr, no adapter) vs rejection envelope (exit 0, stdout JSON, kernel-rejected). The unknown-`confirm_id` test asserts the latter, which is the load-bearing invariant for write tools surfacing rejection envelopes through the auto-gen path.
- The `--skip-validation` test asserts the **pending** shape, not auto-confirm. Rationale: `skip_validation=true` bypasses the Tier 2 similarity check entirely, so the kernel's "auto-confirm on Tier 2 clean" short-circuit never runs; the kernel hands off via `confirm_id` and the user runs `nauro confirm-decision <id>` separately. The two branches are different kernel paths.

## What's deferred

- Hand-written interactive `nauro check` — revisit only if a real user reports friction with the two-step `check-decision` → `propose-decision` flow.
- `$EDITOR` ladder for `--rationale` — shell heredocs and `$(cat file.md)` cover the long-rationale case for now.

## Test plan

- 25 new tests across `test_cli_json_input.py` (10) and `test_write_command_autogen.py` (15).
- Full `packages/nauro/tests/` suite: 1006 passed, 11 skipped.
- Full `packages/nauro-core/tests/` suite: 572 passed.
- `ruff format packages/` clean; `ruff check packages/` clean.
- `mypy packages/nauro/src/nauro/cli/autogen.py packages/nauro/src/nauro/cli/_json_input.py` clean.
- CI green across `lint`, `test-nauro` (3.10/3.11/3.12), `test-nauro-core` (3.10/3.11/3.12).
- Smoke-tested both commands end-to-end against a real local store: `nauro propose-decision <title> <rationale> --files-affected a.py --files-affected b.py --rejected '[{...}]'` writes a correctly-shaped decision file with the YAML list and rejected-alternative entries populated.
