### PR TITLE
feat(nauro-core): host MCP read-tool renderers; wire local stdio

### DIFF
--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro-core"
-version = "0.11.0"
+version = "0.11.1"
 description = "Shared pure-Python logic for Nauro: parsing, validation, context assembly, constants."
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/nauro-core/src/nauro_core/__init__.py
+++ b/packages/nauro-core/src/nauro_core/__init__.py
@@ -228,6 +228,27 @@ from nauro_core.questions import (
 from nauro_core.questions import (
     UnparsableBlock as UnparsableBlock,
 )
+from nauro_core.renderers import (
+    RENDERERS as RENDERERS,
+)
+from nauro_core.renderers import (
+    render_check_decision as render_check_decision,
+)
+from nauro_core.renderers import (
+    render_get_context as render_get_context,
+)
+from nauro_core.renderers import (
+    render_get_decision as render_get_decision,
+)
+from nauro_core.renderers import (
+    render_list_decisions as render_list_decisions,
+)
+from nauro_core.renderers import (
+    render_list_projects as render_list_projects,
+)
+from nauro_core.renderers import (
+    render_search_decisions as render_search_decisions,
+)
 from nauro_core.search import (
     bm25_retrieve as bm25_retrieve,
 )

--- a/packages/nauro-core/src/nauro_core/renderers.py
+++ b/packages/nauro-core/src/nauro_core/renderers.py
@@ -1,0 +1,297 @@
+"""Human-readable renderers for MCP read-tool responses.
+
+Each renderer is a pure function: takes the result dict that the
+``tools_read`` adapter (or ``list_user_projects``) produced and returns a
+formatted text block intended for chat-UI consumption. The dispatcher
+pairs the rendered text with the unchanged JSON envelope so programmatic
+consumers can still parse the structured payload from ``content[1]``.
+
+Renderers must not perform I/O, hit S3/DDB, or import anything that
+would. They must not mutate the input dict.
+
+Per-tool surface area:
+
+* ``check_decision`` — top hit with rationale preview + lower hits as a
+  short list; the agent-facing call-to-action footer comes from the
+  upstream ``assessment`` field.
+* ``get_decision`` — light header on top of the markdown body the kernel
+  already returns.
+* ``search_decisions`` — query echo, then a ranked short list of hits
+  with snippet for each.
+* ``list_decisions`` — short tabular list of ``(D###, status, title)``
+  rows. Empty-state guidance flows through unchanged.
+* ``get_context`` — passthrough; the kernel-assembled markdown is already
+  human-readable.
+* ``list_projects`` — short tabular list of ``(name, role, project_id)``
+  rows so the agent can disambiguate without re-fetching.
+"""
+
+from __future__ import annotations
+
+# Width target for the rendered text blocks. Picked to fit standard
+# terminal widths and Markdown chat clients without horizontal scroll.
+_WIDTH = 80
+_TITLE_BUDGET = 70  # Truncate titles longer than this in tabular lines.
+
+
+def _id_to_label(decision_id: str) -> str:
+    """Convert ``decision-145`` → ``D145``. Falls back to the raw id."""
+    prefix = "decision-"
+    if decision_id.startswith(prefix):
+        suffix = decision_id[len(prefix) :]
+        if suffix.isdigit():
+            return f"D{int(suffix):03d}"
+    return decision_id
+
+
+def _truncate(text: str, limit: int) -> str:
+    """Truncate ``text`` to ``limit`` chars with an ellipsis marker."""
+    if len(text) <= limit:
+        return text
+    if limit <= 1:
+        return text[:limit]
+    return text[: limit - 1] + "…"
+
+
+def _error_block(error) -> str:
+    """Render an error field as a one-line ``Error: <reason>`` header.
+
+    Most adapters lift ``result.error.reason`` to a top-level string, but
+    ``check_decision`` carries the kernel's full :class:`ErrorPayload`
+    serialization (``{"kind": "...", "reason": "..."}``). Tolerate both.
+    """
+    if isinstance(error, dict):
+        reason = error.get("reason") or error.get("message") or str(error)
+    else:
+        reason = str(error)
+    return f"Error: {reason}"
+
+
+def render_check_decision(result: dict) -> str:
+    """Render the conflict-check result for chat-UI consumption.
+
+    Empty-store and zero-hit assessments flow through unchanged. The
+    rendered list pulls structure from ``related_decisions`` so the
+    top-match marker and rationale preview render even when an upstream
+    assessment-string edit drifts.
+    """
+    if "error" in result:
+        return _error_block(result["error"])
+
+    related = result.get("related_decisions") or []
+    assessment = result.get("assessment", "")
+
+    if not related:
+        # NO_DECISIONS_TO_CHECK / "No related decisions found." cases.
+        return assessment.strip() or "No related decisions found."
+
+    lines: list[str] = []
+    count = len(related)
+    if count == 1:
+        lines.append("Found 1 related decision:")
+    else:
+        lines.append(f"Found {count} related decisions:")
+    lines.append("")
+
+    for idx, hit in enumerate(related):
+        label = _id_to_label(hit.get("id", ""))
+        status = hit.get("status", "")
+        score = hit.get("score", 0.0)
+        title = hit.get("title", "") or "(no title)"
+        is_top = idx == 0
+        score_str = f"BM25 {score:5.2f}" if isinstance(score, (int, float)) else "BM25 ?"
+        marker = "    <- top match" if is_top else ""
+        header = f"  - {label}  [{status}]  {score_str}{marker}"
+        lines.append(header)
+        lines.append(f"    {_truncate(title, _TITLE_BUDGET)}")
+        if is_top:
+            preview = (hit.get("rationale_preview") or "").strip()
+            if preview:
+                preview_line = _truncate(preview.replace("\n", " "), _WIDTH - 6)
+                lines.append(f'    "{preview_line}"')
+        lines.append("")
+
+    # Call-to-action footer. Prefer the upstream assessment's "Call ..."
+    # sentence so the get_decision number and pluralization stay in sync
+    # with what the kernel decided. Fall back to a generic prompt.
+    footer = _extract_call_to_action(assessment)
+    if footer:
+        lines.append(footer)
+    else:
+        lines.append("Call get_decision on each related decision before proposing.")
+
+    return "\n".join(lines).rstrip()
+
+
+def _extract_call_to_action(assessment: str) -> str:
+    """Pull the trailing ``Call get_decision...`` sentence from the assessment.
+
+    The kernel always emits a single ``Call ...`` clause as the last
+    sentence; if the format ever drifts, fall back to an empty string and
+    let the renderer default footer fire.
+    """
+    idx = assessment.find("Call ")
+    if idx == -1:
+        return ""
+    return assessment[idx:].strip()
+
+
+def render_get_decision(result: dict) -> str:
+    """Render a decision body. The kernel returns markdown; surface it as-is
+    under a one-line header so chat clients can see the title at a glance."""
+    if "error" in result:
+        return _error_block(result["error"])
+
+    content = result.get("content", "") or ""
+    header = _decision_title_header(content)
+    if header:
+        return f"{header}\n\n{content}".rstrip()
+    return content.rstrip()
+
+
+def _decision_title_header(body: str) -> str:
+    """Pull the ``# NNN - Title`` line from a decision body.
+
+    Returns an empty string when the body is malformed or missing a
+    decision-style heading.
+    """
+    for line in body.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("# "):
+            return stripped
+        # Stop scanning past the first non-frontmatter, non-blank line that
+        # is not a heading; decisions always lead with the title.
+        if stripped and not stripped.startswith("---") and not stripped.startswith("#"):
+            break
+    return ""
+
+
+def render_search_decisions(result: dict) -> str:
+    """Render BM25 search results."""
+    if "error" in result:
+        return _error_block(result["error"])
+
+    query = result.get("query", "")
+    hits = result.get("results") or []
+    total = result.get("total_matches", len(hits))
+    truncated = bool(result.get("truncated"))
+
+    if not hits:
+        return f'No matches for "{query}".'
+
+    lines: list[str] = []
+    header = f'Found {total} match{"" if total == 1 else "es"} for "{query}":'
+    lines.append(header)
+    lines.append("")
+
+    for hit in hits:
+        number = hit.get("number")
+        label = f"D{number:03d}" if isinstance(number, int) else "D???"
+        status = hit.get("status", "")
+        score = hit.get("score", 0.0)
+        score_str = f"BM25 {score:5.2f}" if isinstance(score, (int, float)) else "BM25 ?"
+        title = hit.get("title", "") or "(no title)"
+        snippet = (hit.get("relevance_snippet") or "").strip()
+
+        lines.append(f"  - {label}  [{status}]  {score_str}")
+        lines.append(f"    {_truncate(title, _TITLE_BUDGET)}")
+        if snippet:
+            snippet_line = _truncate(snippet.replace("\n", " "), _WIDTH - 6)
+            lines.append(f'    "{snippet_line}"')
+        lines.append("")
+
+    if truncated:
+        lines.append(f"Results truncated at {len(hits)} of {total} — raise limit to see more.")
+
+    return "\n".join(lines).rstrip()
+
+
+def render_list_decisions(result: dict) -> str:
+    """Render the project's decision list."""
+    if "error" in result:
+        return _error_block(result["error"])
+
+    decisions = result.get("decisions") or []
+    total = result.get("total", len(decisions))
+    truncated = bool(result.get("truncated"))
+
+    if not decisions:
+        guidance = (result.get("guidance") or "").strip()
+        return guidance or "No decisions recorded yet."
+
+    lines: list[str] = []
+    lines.append(f"Decisions ({total} total):")
+    lines.append("")
+
+    for d in decisions:
+        number = d.get("number")
+        label = f"D{number:03d}" if isinstance(number, int) else "D???"
+        status = d.get("status", "")
+        title = d.get("title", "") or "(no title)"
+        lines.append(f"  - {label}  [{status:<10}]  {_truncate(title, _TITLE_BUDGET)}")
+
+    if truncated:
+        lines.append("")
+        lines.append(f"Showing {len(decisions)} of {total} decisions — raise limit to see more.")
+
+    return "\n".join(lines).rstrip()
+
+
+def render_get_context(result: dict) -> str:
+    """Render context. The kernel already assembles human-readable markdown;
+    pass it through, with structured errors surfaced explicitly.
+
+    The two adapters disagree on the envelope key: the remote MCP server
+    surfaces the assembled markdown under ``context``; the local stdio
+    server uses ``content`` (the kernel ``GetContextResult`` field name).
+    Accept either so a single renderer covers both transports.
+    """
+    if "error" in result:
+        return _error_block(result["error"])
+    body = result.get("context") or result.get("content") or ""
+    return body.rstrip()
+
+
+def render_list_projects(result: dict) -> str:
+    """Render the user's project list as a short tabular block."""
+    projects = result.get("projects") or []
+    if not projects:
+        return (
+            "No projects yet. Run `nauro init <name>` to create one, or "
+            "`nauro attach <project_id>` to connect to an existing one."
+        )
+
+    lines: list[str] = []
+    lines.append(f"Projects ({len(projects)}):")
+    lines.append("")
+    for p in projects:
+        name = p.get("name", "") or "(no name)"
+        role = p.get("role", "")
+        pid = p.get("project_id", "")
+        lines.append(f"  - {name:<32}  {role:<7}  {pid}")
+    return "\n".join(lines).rstrip()
+
+
+# Renderer registry used by the dispatcher. Only read tools whose JSON
+# envelope is unhelpful as primary content appear here; ``get_raw_file``
+# and ``diff_since_last_session`` already return user-rendered bodies and
+# are intentionally absent.
+RENDERERS = {
+    "check_decision": render_check_decision,
+    "get_decision": render_get_decision,
+    "search_decisions": render_search_decisions,
+    "list_decisions": render_list_decisions,
+    "get_context": render_get_context,
+    "list_projects": render_list_projects,
+}
+
+
+__all__ = [
+    "RENDERERS",
+    "render_check_decision",
+    "render_get_context",
+    "render_get_decision",
+    "render_list_decisions",
+    "render_list_projects",
+    "render_search_decisions",
+]

--- a/packages/nauro-core/tests/test_renderers.py
+++ b/packages/nauro-core/tests/test_renderers.py
@@ -1,0 +1,509 @@
+"""Tests for human-readable renderers for MCP read-tool responses.
+
+Each renderer is a pure function: takes the result dict the read-tool
+adapter produces, returns a formatted text block. The JSON envelope
+itself is rendered by the dispatcher; these tests only cover the
+human-formatted block.
+"""
+
+from __future__ import annotations
+
+import json
+
+from nauro_core.renderers import (
+    render_check_decision,
+    render_get_context,
+    render_get_decision,
+    render_list_decisions,
+    render_list_projects,
+    render_search_decisions,
+)
+
+
+class TestRenderCheckDecision:
+    def test_empty_store_passes_through_assessment(self):
+        """When the store has no decisions, the kernel returns its
+        ``NO_DECISIONS_TO_CHECK`` assessment with an empty
+        ``related_decisions`` list; the renderer surfaces that text
+        verbatim."""
+        result = {
+            "store": "remote",
+            "related_decisions": [],
+            "assessment": (
+                "No existing decisions to check against. Propose your decision when ready."
+            ),
+        }
+        text = render_check_decision(result)
+        assert "No existing decisions" in text
+
+    def test_no_related_decisions_passes_through(self):
+        result = {
+            "store": "remote",
+            "related_decisions": [],
+            "assessment": "No related decisions found.",
+        }
+        text = render_check_decision(result)
+        assert "No related decisions found" in text
+
+    def test_single_related_decision(self):
+        result = {
+            "store": "remote",
+            "related_decisions": [
+                {
+                    "id": "decision-145",
+                    "title": "Adopt 1-hour prompt cache tier for planner",
+                    "score": 19.07,
+                    "status": "active",
+                    "date": "2026-05-10",
+                    "rationale_preview": "Planner cache_control set to ttl: 1h.",
+                }
+            ],
+            "assessment": (
+                'Top match: D145 "Adopt 1-hour prompt cache tier for planner" '
+                "(status active, decided 2026-05-10, BM25 19.1). "
+                "Call get_decision(145) before proposing."
+            ),
+        }
+        text = render_check_decision(result)
+        assert "D145" in text
+        assert "top match" in text
+        assert "19.07" in text or "19.1" in text
+        assert "Adopt 1-hour prompt cache tier" in text
+        assert "Planner cache_control" in text
+        # Call-to-action footer must mention get_decision
+        assert "get_decision" in text
+
+    def test_multi_hit_marks_top_and_lists_rest(self):
+        result = {
+            "store": "remote",
+            "related_decisions": [
+                {
+                    "id": "decision-145",
+                    "title": "Adopt 1-hour prompt cache tier for planner",
+                    "score": 19.07,
+                    "status": "active",
+                    "date": "2026-05-10",
+                    "rationale_preview": (
+                        "Pareto sets the planner cache_control to ttl: 1h, "
+                        "paying the documented write surcharge."
+                    ),
+                },
+                {
+                    "id": "decision-058",
+                    "title": (
+                        "Prompt cache strategy: planner always; "
+                        "executor per-session; reviewer never"
+                    ),
+                    "score": 18.05,
+                    "status": "active",
+                    "date": "2026-03-22",
+                    "rationale_preview": "Cache per role.",
+                },
+                {
+                    "id": "decision-102",
+                    "title": "Retire monolithic-agent mode by 2026-Q3",
+                    "score": 5.95,
+                    "status": "active",
+                    "date": "2026-04-01",
+                    "rationale_preview": "Modes go away.",
+                },
+            ],
+            "assessment": (
+                "Found 3 related decisions. "
+                'Top match: D145 "Adopt 1-hour prompt cache tier for planner" '
+                "(status active, decided 2026-05-10, BM25 19.1). "
+                "Call get_decision on each related decision before proposing."
+            ),
+        }
+        text = render_check_decision(result)
+        # Top match marker only on the top hit
+        top_marker_count = text.count("top match")
+        assert top_marker_count == 1
+        # All three decision labels appear
+        assert "D145" in text
+        assert "D058" in text
+        assert "D102" in text
+        # All three titles appear
+        assert "Adopt 1-hour prompt cache tier" in text
+        assert "Prompt cache strategy" in text
+        assert "Retire monolithic-agent mode" in text
+        # Top hit shows rationale preview; lower hits do not
+        assert "Pareto sets the planner" in text
+        assert "Cache per role" not in text
+        assert "Modes go away" not in text
+        # Footer guidance
+        assert "get_decision" in text
+
+    def test_long_title_does_not_blow_up(self):
+        long_title = "x" * 200
+        result = {
+            "store": "remote",
+            "related_decisions": [
+                {
+                    "id": "decision-001",
+                    "title": long_title,
+                    "score": 5.0,
+                    "status": "active",
+                    "date": "2026-05-10",
+                    "rationale_preview": "",
+                }
+            ],
+            "assessment": "...",
+        }
+        text = render_check_decision(result)
+        # Renderer must not crash; the title should appear in some form.
+        assert "D001" in text
+
+    def test_unicode_in_title(self):
+        result = {
+            "store": "remote",
+            "related_decisions": [
+                {
+                    "id": "decision-007",
+                    "title": "Adopt café-style 設計 patterns",
+                    "score": 3.14,
+                    "status": "active",
+                    "date": "2026-05-10",
+                    "rationale_preview": "あいうえお",
+                }
+            ],
+            "assessment": "...",
+        }
+        text = render_check_decision(result)
+        assert "café" in text
+        assert "設計" in text
+
+    def test_missing_optional_fields_does_not_crash(self):
+        result = {
+            "store": "remote",
+            "related_decisions": [
+                {
+                    "id": "decision-001",
+                    "title": "A",
+                    "score": 1.0,
+                    "status": "active",
+                    "date": "",
+                    "rationale_preview": "",
+                }
+            ],
+            "assessment": "...",
+        }
+        text = render_check_decision(result)
+        assert "D001" in text
+
+    def test_error_path_emits_error_header(self):
+        result = {"store": "remote", "error": "Proposed approach exceeds 8000 chars"}
+        text = render_check_decision(result)
+        assert text.startswith("Error:")
+        assert "Proposed approach exceeds" in text
+
+
+class TestRenderGetDecision:
+    def test_content_passthrough_with_header(self):
+        body = (
+            "---\n"
+            "date: 2026-05-10\n"
+            "status: active\n"
+            "---\n"
+            "\n"
+            "# 145 — Adopt 1-hour prompt cache tier for planner\n"
+            "\n"
+            "## Decision\nFoo.\n"
+        )
+        result = {"store": "remote", "content": body}
+        text = render_get_decision(result)
+        # Body must be present
+        assert "Foo." in text
+        # Title is surfaced as a header line for chat clients
+        assert "145" in text
+        assert "Adopt 1-hour prompt cache tier" in text
+
+    def test_error_path(self):
+        result = {"store": "remote", "error": "Decision 999 not found"}
+        text = render_get_decision(result)
+        assert text.startswith("Error:")
+        assert "Decision 999 not found" in text
+
+
+class TestRenderSearchDecisions:
+    def test_empty_results(self):
+        result = {
+            "store": "remote",
+            "results": [],
+            "total_matches": 0,
+            "truncated": False,
+            "query": "nothing matches",
+        }
+        text = render_search_decisions(result)
+        assert "No matches" in text or "no matches" in text
+        assert "nothing matches" in text
+
+    def test_single_hit(self):
+        result = {
+            "store": "remote",
+            "results": [
+                {
+                    "number": 145,
+                    "title": "Adopt 1-hour prompt cache tier for planner",
+                    "date": "2026-05-10",
+                    "status": "active",
+                    "relevance_snippet": "Planner cache_control set to ttl: 1h.",
+                    "score": 19.07,
+                }
+            ],
+            "total_matches": 1,
+            "truncated": False,
+            "query": "prompt cache",
+        }
+        text = render_search_decisions(result)
+        assert "D145" in text
+        assert "Adopt 1-hour prompt cache tier" in text
+        assert "Planner cache_control" in text
+        assert "19.07" in text or "19.1" in text
+        assert "prompt cache" in text
+
+    def test_truncated_flag_surfaces(self):
+        result = {
+            "store": "remote",
+            "results": [
+                {
+                    "number": n,
+                    "title": f"Decision {n}",
+                    "date": "2026-05-10",
+                    "status": "active",
+                    "relevance_snippet": "snippet",
+                    "score": 10.0 - n,
+                }
+                for n in range(1, 6)
+            ],
+            "total_matches": 5,
+            "truncated": True,
+            "query": "something",
+        }
+        text = render_search_decisions(result)
+        for n in range(1, 6):
+            assert f"D00{n}" in text
+        assert "truncated" in text.lower() or "more" in text.lower()
+
+    def test_error_path(self):
+        result = {"store": "remote", "error": "Query must be non-empty"}
+        text = render_search_decisions(result)
+        assert text.startswith("Error:")
+        assert "non-empty" in text
+
+
+class TestRenderListDecisions:
+    def test_empty_returns_guidance(self):
+        result = {
+            "store": "remote",
+            "decisions": [],
+            "total": 0,
+            "truncated": False,
+            "guidance": (
+                "No decisions recorded yet for this project.\n"
+                "\n"
+                "Use propose_decision to record your first..."
+            ),
+        }
+        text = render_list_decisions(result)
+        # Empty-state guidance flows through unchanged.
+        assert "No decisions recorded yet" in text
+
+    def test_lists_decisions(self):
+        result = {
+            "store": "remote",
+            "decisions": [
+                {
+                    "number": 42,
+                    "title": "Use JSON-RPC transport",
+                    "date": "2026-03-14",
+                    "status": "active",
+                    "type": "api_design",
+                    "confidence": "high",
+                },
+                {
+                    "number": 2,
+                    "title": "Chose FastAPI",
+                    "date": "2026-03-12",
+                    "status": "active",
+                    "type": "pattern",
+                    "confidence": "high",
+                },
+            ],
+            "total": 2,
+            "truncated": False,
+        }
+        text = render_list_decisions(result)
+        assert "D042" in text
+        assert "D002" in text
+        assert "Use JSON-RPC transport" in text
+        assert "Chose FastAPI" in text
+
+    def test_truncated_surfaces(self):
+        result = {
+            "store": "remote",
+            "decisions": [
+                {
+                    "number": n,
+                    "title": f"Decision {n}",
+                    "date": "2026-03-14",
+                    "status": "active",
+                    "confidence": "high",
+                }
+                for n in range(50, 30, -1)
+            ],
+            "total": 100,
+            "truncated": True,
+        }
+        text = render_list_decisions(result)
+        assert "truncated" in text.lower() or "more" in text.lower() or "100" in text
+
+    def test_long_title_renders(self):
+        long_title = "Very long decision title " * 10
+        result = {
+            "store": "remote",
+            "decisions": [
+                {
+                    "number": 1,
+                    "title": long_title.strip(),
+                    "date": "2026-03-14",
+                    "status": "active",
+                    "confidence": "high",
+                }
+            ],
+            "total": 1,
+            "truncated": False,
+        }
+        text = render_list_decisions(result)
+        assert "D001" in text
+
+    def test_error_path(self):
+        result = {"store": "remote", "error": "List decisions failed"}
+        text = render_list_decisions(result)
+        assert text.startswith("Error:")
+
+
+class TestRenderGetContext:
+    def test_passthrough_when_present(self):
+        result = {
+            "store": "remote",
+            "context": (
+                "# Current State\n\nWorking on MCP renderer.\n\n## Recent Decisions\n- D215\n"
+            ),
+        }
+        text = render_get_context(result)
+        assert "Current State" in text
+        assert "Recent Decisions" in text
+
+    def test_empty_state_passthrough(self):
+        # Representative empty-state guidance. Both the remote MCP server
+        # (mcp_server.onboarding.NO_CONTEXT_YET) and the local CLI
+        # (nauro.onboarding.NO_CONTEXT_YET) emit text that satisfies the
+        # marker assertions below; the renderer is a passthrough so the
+        # exact upstream wording is not under test here.
+        empty_state = (
+            "This project has no context data yet.\n\n"
+            "Use propose_decision or update_state to record context directly here."
+        )
+        result = {"store": "remote", "context": empty_state}
+        text = render_get_context(result)
+        # Empty-state guidance comes through unchanged.
+        assert "no context" in text.lower() or "propose_decision" in text
+
+    def test_local_envelope_content_key(self):
+        """The local stdio surface keys the assembled markdown under
+        ``content`` (matching the kernel ``GetContextResult.content``
+        field), while the remote MCP server keys it under ``context``.
+        The shared renderer must accept either so both transports can
+        wire the same registry."""
+        result = {
+            "store": "local",
+            "content": "# Current State\n\nLocal envelope path.\n",
+        }
+        text = render_get_context(result)
+        assert "Current State" in text
+        assert "Local envelope path" in text
+
+    def test_error_path(self):
+        result = {"store": "remote", "error": "Invalid level: L9"}
+        text = render_get_context(result)
+        assert text.startswith("Error:")
+        assert "Invalid level" in text
+
+
+class TestRenderListProjects:
+    def test_empty_state(self):
+        result = {"projects": []}
+        text = render_list_projects(result)
+        assert "no projects" in text.lower() or "No projects" in text
+
+    def test_lists_projects(self):
+        result = {
+            "projects": [
+                {
+                    "project_id": "01KQ6AZGNA0B3QBF67NBXP3S45",
+                    "name": "nauro",
+                    "role": "owner",
+                    "created_at": "2026-01-01T00:00:00+00:00",
+                },
+                {
+                    "project_id": "01KREWKMPDW2EVR66F9XXNERGB",
+                    "name": "throwaway-supersede-1778616226",
+                    "role": "member",
+                    "created_at": "2026-04-01T00:00:00+00:00",
+                },
+            ]
+        }
+        text = render_list_projects(result)
+        assert "nauro" in text
+        assert "throwaway-supersede" in text
+        assert "01KQ6AZGNA0B3QBF67NBXP3S45" in text
+        assert "01KREWKMPDW2EVR66F9XXNERGB" in text
+        assert "owner" in text
+        assert "member" in text
+
+
+class TestRendererPurity:
+    """Renderers must be pure functions of the result dict.
+
+    They cannot read S3, hit DDB, or import anything that would. Each call
+    must be deterministic for a given input.
+    """
+
+    def test_same_input_same_output(self):
+        result = {
+            "store": "remote",
+            "related_decisions": [
+                {
+                    "id": "decision-001",
+                    "title": "A decision",
+                    "score": 1.0,
+                    "status": "active",
+                    "date": "2026-05-10",
+                    "rationale_preview": "Rationale.",
+                }
+            ],
+            "assessment": "...",
+        }
+        first = render_check_decision(result)
+        second = render_check_decision(result)
+        assert first == second
+
+    def test_result_dict_not_mutated(self):
+        result = {
+            "store": "remote",
+            "related_decisions": [
+                {
+                    "id": "decision-001",
+                    "title": "A decision",
+                    "score": 1.0,
+                    "status": "active",
+                    "date": "2026-05-10",
+                    "rationale_preview": "Rationale.",
+                }
+            ],
+            "assessment": "...",
+        }
+        snapshot = json.dumps(result, sort_keys=True)
+        render_check_decision(result)
+        assert json.dumps(result, sort_keys=True) == snapshot

--- a/packages/nauro/src/nauro/mcp/stdio_server.py
+++ b/packages/nauro/src/nauro/mcp/stdio_server.py
@@ -15,19 +15,28 @@ MCP tools registered here (11 — 7 read, 4 write):
 The shared `nauro_core.mcp_tools.ALL_TOOLS` registry contains 12 tools.
 `list_projects` is remote-only — local installs auto-resolve to the
 single project store, so the discovery tool is not registered here.
+
+Read tools listed in ``nauro_core.renderers.RENDERERS`` return a
+``list[TextContent]`` with two blocks: a human-formatted summary at
+``[0]`` and the JSON envelope at ``[1]``. This mirrors the remote MCP
+dispatcher so chat clients (Claude Code, claude.ai) get the same
+two-block shape regardless of transport. Programmatic consumers — tests,
+CLI, subagents — decode the envelope from ``content[1].text``.
 """
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 from pathlib import Path
 from typing import Annotated, Any, Literal
 
 from mcp.server import FastMCP
-from mcp.types import ToolAnnotations
+from mcp.types import TextContent, ToolAnnotations
 from nauro_core.constants import MCP_INSTRUCTIONS
 from nauro_core.mcp_tools import ToolSpec, get_tool_spec
+from nauro_core.renderers import RENDERERS as _RENDERERS
 from pydantic import Field
 
 from nauro.mcp.tools import (
@@ -67,6 +76,31 @@ NOT_A_NAURO_REPO = (
 )
 
 
+def _wrap_with_renderer(tool_name: str, result: dict) -> list[TextContent]:
+    """Compose two text content blocks for a read-tool response.
+
+    Mirrors the remote MCP dispatcher (``mcp_server.mcp_router._build_content_blocks``):
+    ``content[0]`` carries the human-formatted summary from
+    ``nauro_core.renderers.RENDERERS[tool_name]``; ``content[1]`` carries
+    the unchanged JSON envelope so programmatic consumers stay byte-stable.
+    A renderer raising falls back to JSON-only — a presentation bug must
+    not swallow a response.
+    """
+    json_text = json.dumps(result, indent=2, default=str)
+    renderer = _RENDERERS.get(tool_name)
+    if renderer is None:
+        return [TextContent(type="text", text=json_text)]
+    try:
+        rendered = renderer(result)
+    except Exception:
+        logger.exception("renderer failed for tool=%s; falling back to JSON-only", tool_name)
+        return [TextContent(type="text", text=json_text)]
+    return [
+        TextContent(type="text", text=rendered),
+        TextContent(type="text", text=json_text),
+    ]
+
+
 def _spec_kwargs(name: str) -> dict[str, Any]:
     """Build FastMCP @tool() decorator kwargs from the shared registry."""
     spec: ToolSpec = get_tool_spec(name)
@@ -104,7 +138,7 @@ _resolve_store = resolve_store
 _resolve_via_repo_config = resolve_via_repo_config
 
 
-@mcp.tool(**_spec_kwargs("get_context"))
+@mcp.tool(structured_output=False, **_spec_kwargs("get_context"))
 def get_context(
     project_id: Annotated[
         str | None, Field(description=_param_desc("get_context", "project_id"))
@@ -114,15 +148,17 @@ def get_context(
         Literal["L0", "L1", "L2"] | int,
         Field(description=_param_desc("get_context", "level")),
     ] = "L0",
-) -> dict:
+) -> list[TextContent]:
     try:
         store_path = _resolve_store(project_id, cwd)
     except NoProjectError:
-        return {"store": "local", "status": "error", "guidance": WELCOME_NO_PROJECT}
+        result = {"store": "local", "status": "error", "guidance": WELCOME_NO_PROJECT}
     except StoreResolutionError as exc:
-        return {"store": "local", "status": "error", "guidance": str(exc)}
-    # tool_get_context accepts both int and string levels.
-    return tool_get_context(store_path, level)
+        result = {"store": "local", "status": "error", "guidance": str(exc)}
+    else:
+        # tool_get_context accepts both int and string levels.
+        result = tool_get_context(store_path, level)
+    return _wrap_with_renderer("get_context", result)
 
 
 @mcp.tool(**_spec_kwargs("get_raw_file"))
@@ -142,7 +178,7 @@ def get_raw_file(
     return tool_get_raw_file(store_path, path)
 
 
-@mcp.tool(**_spec_kwargs("list_decisions"))
+@mcp.tool(structured_output=False, **_spec_kwargs("list_decisions"))
 def list_decisions(
     project_id: Annotated[
         str | None, Field(description=_param_desc("list_decisions", "project_id"))
@@ -152,31 +188,35 @@ def list_decisions(
     include_superseded: Annotated[
         bool, Field(description=_param_desc("list_decisions", "include_superseded"))
     ] = False,
-) -> dict:
+) -> list[TextContent]:
     try:
         store_path = _resolve_store(project_id, cwd)
     except NoProjectError:
-        return {"store": "local", "status": "error", "guidance": WELCOME_NO_PROJECT}
+        result = {"store": "local", "status": "error", "guidance": WELCOME_NO_PROJECT}
     except StoreResolutionError as exc:
-        return {"store": "local", "status": "error", "guidance": str(exc)}
-    return tool_list_decisions(store_path, limit, include_superseded)
+        result = {"store": "local", "status": "error", "guidance": str(exc)}
+    else:
+        result = tool_list_decisions(store_path, limit, include_superseded)
+    return _wrap_with_renderer("list_decisions", result)
 
 
-@mcp.tool(**_spec_kwargs("get_decision"))
+@mcp.tool(structured_output=False, **_spec_kwargs("get_decision"))
 def get_decision(
     number: Annotated[int, Field(description=_param_desc("get_decision", "number"))],
     project_id: Annotated[
         str | None, Field(description=_param_desc("get_decision", "project_id"))
     ] = None,
     cwd: str | None = None,
-) -> dict:
+) -> list[TextContent]:
     try:
         store_path = _resolve_store(project_id, cwd)
     except NoProjectError:
-        return {"store": "local", "status": "error", "guidance": WELCOME_NO_PROJECT}
+        result = {"store": "local", "status": "error", "guidance": WELCOME_NO_PROJECT}
     except StoreResolutionError as exc:
-        return {"store": "local", "status": "error", "guidance": str(exc)}
-    return tool_get_decision(store_path, number)
+        result = {"store": "local", "status": "error", "guidance": str(exc)}
+    else:
+        result = tool_get_decision(store_path, number)
+    return _wrap_with_renderer("get_decision", result)
 
 
 @mcp.tool(**_spec_kwargs("diff_since_last_session"))
@@ -199,7 +239,7 @@ def diff_since_last_session(
     return tool_diff_since_last_session(store_path, days)
 
 
-@mcp.tool(**_spec_kwargs("search_decisions"))
+@mcp.tool(structured_output=False, **_spec_kwargs("search_decisions"))
 def search_decisions(
     query: Annotated[str, Field(description=_param_desc("search_decisions", "query"))],
     limit: Annotated[int, Field(description=_param_desc("search_decisions", "limit"))] = 10,
@@ -207,17 +247,19 @@ def search_decisions(
         str | None, Field(description=_param_desc("search_decisions", "project_id"))
     ] = None,
     cwd: str | None = None,
-) -> dict:
+) -> list[TextContent]:
     try:
         store_path = _resolve_store(project_id, cwd)
     except NoProjectError:
-        return {"store": "local", "status": "error", "guidance": WELCOME_NO_PROJECT}
+        result = {"store": "local", "status": "error", "guidance": WELCOME_NO_PROJECT}
     except StoreResolutionError as exc:
-        return {"store": "local", "status": "error", "guidance": str(exc)}
-    return tool_search_decisions(store_path, query, limit)
+        result = {"store": "local", "status": "error", "guidance": str(exc)}
+    else:
+        result = tool_search_decisions(store_path, query, limit)
+    return _wrap_with_renderer("search_decisions", result)
 
 
-@mcp.tool(**_spec_kwargs("check_decision"))
+@mcp.tool(structured_output=False, **_spec_kwargs("check_decision"))
 def check_decision(
     proposed_approach: Annotated[
         str, Field(description=_param_desc("check_decision", "proposed_approach"))
@@ -229,14 +271,16 @@ def check_decision(
         str | None, Field(description=_param_desc("check_decision", "project_id"))
     ] = None,
     cwd: str | None = None,
-) -> dict:
+) -> list[TextContent]:
     try:
         store_path = _resolve_store(project_id, cwd)
     except NoProjectError:
-        return {"store": "local", "status": "error", "guidance": WELCOME_NO_PROJECT}
+        result = {"store": "local", "status": "error", "guidance": WELCOME_NO_PROJECT}
     except StoreResolutionError as exc:
-        return {"store": "local", "status": "error", "guidance": str(exc)}
-    return tool_check_decision(store_path, proposed_approach, context)
+        result = {"store": "local", "status": "error", "guidance": str(exc)}
+    else:
+        result = tool_check_decision(store_path, proposed_approach, context)
+    return _wrap_with_renderer("check_decision", result)
 
 
 @mcp.tool(**_spec_kwargs("propose_decision"))

--- a/packages/nauro/tests/test_check_decision_parity.py
+++ b/packages/nauro/tests/test_check_decision_parity.py
@@ -50,7 +50,11 @@ def _cli_envelope(store_path: Path) -> dict:
 
 
 def _stdio_envelope(pid: str) -> dict:
-    return stdio_check_decision(proposed_approach=DEMO_PROMPT, project_id=pid)
+    # stdio check_decision now returns a two-block list[TextContent]; the
+    # JSON envelope is at content[1].text — see stdio_server module
+    # docstring for the contract.
+    blocks = stdio_check_decision(proposed_approach=DEMO_PROMPT, project_id=pid)
+    return json.loads(blocks[1].text)
 
 
 def _http_envelope(pid: str) -> dict:
@@ -106,7 +110,8 @@ def test_rejection_envelope_matches_across_surfaces(demo_repo):
     assert cli_raw.exit_code == 1, cli_raw.output
     cli = json.loads(cli_raw.stdout)
 
-    stdio = stdio_check_decision(proposed_approach=overlong, project_id=pid)
+    stdio_blocks = stdio_check_decision(proposed_approach=overlong, project_id=pid)
+    stdio = json.loads(stdio_blocks[1].text)
 
     client = TestClient(fastapi_app)
     response = client.post(

--- a/packages/nauro/tests/test_get_context_parity.py
+++ b/packages/nauro/tests/test_get_context_parity.py
@@ -20,6 +20,7 @@ Two compressions vs. the ``check_decision`` parity test:
 
 from __future__ import annotations
 
+import json
 from datetime import date
 from pathlib import Path
 
@@ -104,7 +105,11 @@ def missing_store(tmp_path, monkeypatch):
 
 
 def _stdio_envelope(pid: str, level) -> dict:
-    return stdio_get_context(project_id=pid, level=level)
+    # stdio get_context now returns a two-block list[TextContent]; the
+    # JSON envelope is at content[1].text — see stdio_server module
+    # docstring for the contract.
+    blocks = stdio_get_context(project_id=pid, level=level)
+    return json.loads(blocks[1].text)
 
 
 def _tool_envelope(store_path: Path, level) -> dict:

--- a/packages/nauro/tests/test_get_decision_parity.py
+++ b/packages/nauro/tests/test_get_decision_parity.py
@@ -19,6 +19,7 @@ Two compressions vs. the ``check_decision`` parity test:
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -47,7 +48,11 @@ def demo_repo(tmp_path, monkeypatch):
 
 
 def _stdio_envelope(pid: str, number: int) -> dict:
-    return stdio_get_decision(number=number, project_id=pid)
+    # stdio get_decision now returns a two-block list[TextContent]; the
+    # JSON envelope is at content[1].text — see stdio_server module
+    # docstring for the contract.
+    blocks = stdio_get_decision(number=number, project_id=pid)
+    return json.loads(blocks[1].text)
 
 
 def _tool_envelope(store_path: Path, number: int) -> dict:

--- a/packages/nauro/tests/test_list_decisions_parity.py
+++ b/packages/nauro/tests/test_list_decisions_parity.py
@@ -19,6 +19,7 @@ Two compressions vs. the ``check_decision`` parity test:
 
 from __future__ import annotations
 
+import json
 from datetime import date
 from pathlib import Path
 
@@ -65,7 +66,13 @@ def empty_repo(tmp_path, monkeypatch):
 
 
 def _stdio_envelope(pid: str, *, limit: int = 20, include_superseded: bool = False) -> dict:
-    return stdio_list_decisions(project_id=pid, limit=limit, include_superseded=include_superseded)
+    # stdio list_decisions now returns a two-block list[TextContent]; the
+    # JSON envelope is at content[1].text — see stdio_server module
+    # docstring for the contract.
+    blocks = stdio_list_decisions(
+        project_id=pid, limit=limit, include_superseded=include_superseded
+    )
+    return json.loads(blocks[1].text)
 
 
 def _tool_envelope(store_path: Path, *, limit: int = 20, include_superseded: bool = False) -> dict:

--- a/packages/nauro/tests/test_search_decisions_parity.py
+++ b/packages/nauro/tests/test_search_decisions_parity.py
@@ -19,6 +19,7 @@ Two compressions vs. the ``check_decision`` parity test:
 
 from __future__ import annotations
 
+import json
 from datetime import date
 from pathlib import Path
 
@@ -89,7 +90,11 @@ def empty_repo(tmp_path, monkeypatch):
 
 
 def _stdio_envelope(pid: str, query: str, *, limit: int = 10) -> dict:
-    return stdio_search_decisions(query=query, limit=limit, project_id=pid)
+    # stdio search_decisions now returns a two-block list[TextContent]; the
+    # JSON envelope is at content[1].text — see stdio_server module
+    # docstring for the contract.
+    blocks = stdio_search_decisions(query=query, limit=limit, project_id=pid)
+    return json.loads(blocks[1].text)
 
 
 def _tool_envelope(store_path: Path, query: str, *, limit: int = 10) -> dict:

--- a/packages/nauro/tests/test_stdio_renderer_wrap.py
+++ b/packages/nauro/tests/test_stdio_renderer_wrap.py
@@ -1,0 +1,209 @@
+"""Block-shape contract for the local stdio MCP read tools.
+
+Read tools listed in ``nauro_core.renderers.RENDERERS`` must return two
+``TextContent`` blocks: a human-formatted summary at ``[0]`` and the
+JSON envelope at ``[1]``. Write tools, ``get_raw_file``,
+``diff_since_last_session``, and pre-resolution error responses stay
+single-block (or stay strings).
+
+Mirrors ``TestContentBlockShape`` from the remote MCP router so both
+transports stay in sync.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from mcp.types import TextContent
+from nauro_core.operations import flag_question as _flag_question_op
+from nauro_core.operations.propose_decision import _get_pending_store
+
+from nauro.mcp.stdio_server import (
+    check_decision,
+    confirm_decision,
+    diff_since_last_session,
+    flag_question,
+    get_context,
+    get_decision,
+    get_raw_file,
+    list_decisions,
+    propose_decision,
+    search_decisions,
+    update_state,
+)
+from nauro.store.filesystem_store import FilesystemStore
+from nauro.store.registry import register_project
+from nauro.templates.scaffolds import scaffold_project_store
+from tests._writer_compat import append_decision
+
+
+@pytest.fixture(autouse=True)
+def _clear_pending():
+    _get_pending_store().clear_all()
+    yield
+    _get_pending_store().clear_all()
+
+
+@pytest.fixture
+def seeded_store(tmp_path: Path, monkeypatch) -> Path:
+    """Pre-scaffolded project store with one decision and one question."""
+    store_path = register_project("blockshape", [tmp_path / "repo"])
+    scaffold_project_store("blockshape", store_path)
+    (store_path / "stack.md").write_text(
+        "# Stack\n- **Python 3.11** — primary language\n- **FastAPI** — HTTP framework\n"
+    )
+    append_decision(
+        store_path,
+        "Use FastAPI",
+        rationale="FastAPI plus Mangum is the Lambda deployment combination.",
+    )
+    _flag_question_op(FilesystemStore(store_path), "Should we add caching?", None)
+    return store_path
+
+
+class TestTwoBlockReadTools:
+    """Renderer-scoped read tools return ``[human, json]`` content blocks."""
+
+    def test_get_context_returns_two_blocks(self, seeded_store: Path):
+        blocks = get_context(project_id="blockshape", level=0)
+        assert len(blocks) == 2
+        assert all(isinstance(b, TextContent) and b.type == "text" for b in blocks)
+        envelope = json.loads(blocks[1].text)
+        assert envelope["store"] == "local"
+        # Local stdio uses `content` (kernel GetContextResult field name);
+        # remote uses `context`. The shared renderer accepts both.
+        assert "content" in envelope
+        # Human block carries the L0 markdown headers verbatim.
+        assert "## Current State" in blocks[0].text
+
+    def test_list_decisions_returns_two_blocks(self, seeded_store: Path):
+        blocks = list_decisions(project_id="blockshape")
+        assert len(blocks) == 2
+        envelope = json.loads(blocks[1].text)
+        assert envelope["store"] == "local"
+        assert "decisions" in envelope
+        # Human block carries the D001 label for the seeded decision.
+        assert "D001" in blocks[0].text
+
+    def test_get_decision_returns_two_blocks(self, seeded_store: Path):
+        # scaffold_project_store seeds D001 (initial-setup); the fixture
+        # appends D002 = "Use FastAPI". Ask for D002 so the title
+        # assertion is independent of the scaffold's seed text.
+        blocks = get_decision(number=2, project_id="blockshape")
+        assert len(blocks) == 2
+        envelope = json.loads(blocks[1].text)
+        assert envelope["store"] == "local"
+        assert "content" in envelope
+        # Title surfaces in the human block.
+        assert "Use FastAPI" in blocks[0].text
+
+    def test_search_decisions_returns_two_blocks(self, seeded_store: Path):
+        blocks = search_decisions(query="FastAPI", project_id="blockshape")
+        assert len(blocks) == 2
+        envelope = json.loads(blocks[1].text)
+        assert envelope["store"] == "local"
+        assert "results" in envelope
+        # Human block echoes the query and surfaces the D### label.
+        assert "FastAPI" in blocks[0].text
+
+    def test_check_decision_returns_two_blocks(self, seeded_store: Path):
+        blocks = check_decision(
+            proposed_approach="Use FastAPI with async endpoints for the API server",
+            project_id="blockshape",
+        )
+        assert len(blocks) == 2
+        envelope = json.loads(blocks[1].text)
+        assert envelope["store"] == "local"
+        assert "related_decisions" in envelope
+
+
+class TestSingleBlockReads:
+    """Pass-through read tools keep the single-value shape — ``get_raw_file``
+    returns a dict (no renderer registered), ``diff_since_last_session`` likewise."""
+
+    def test_get_raw_file_returns_dict(self, seeded_store: Path):
+        result = get_raw_file(path="stack.md", project_id="blockshape")
+        # No renderer scope; the FastMCP layer converts the dict to its own
+        # single content block at the MCP wire boundary. Direct Python
+        # callers see the dict envelope unchanged.
+        assert isinstance(result, dict)
+        assert result["content"].startswith("# Stack")
+
+    def test_diff_since_last_session_returns_dict(self, seeded_store: Path):
+        result = diff_since_last_session(project_id="blockshape")
+        assert isinstance(result, dict)
+
+
+class TestSingleBlockWrites:
+    """Write tools stay single-block; renderer scope is read-only."""
+
+    def test_propose_decision_returns_dict(self, seeded_store: Path):
+        result = propose_decision(
+            project_id="blockshape",
+            title="Adopt Postgres",
+            rationale="ACID compliance trumps document flexibility for this workload.",
+        )
+        assert isinstance(result, dict)
+        assert "status" in result
+
+    def test_confirm_decision_returns_dict(self, seeded_store: Path):
+        # An invalid id surfaces an error envelope, still a dict.
+        result = confirm_decision(confirm_id="nonexistent", project_id="blockshape")
+        assert isinstance(result, dict)
+
+    def test_flag_question_returns_string(self, seeded_store: Path):
+        result = flag_question(question="Need WebSocket?", project_id="blockshape")
+        # flag_question intentionally returns a string for FastMCP
+        # compatibility; the wrapper here is unchanged by the renderer work.
+        assert isinstance(result, str)
+
+    def test_update_state_returns_string(self, seeded_store: Path):
+        result = update_state(delta="Shipped block-shape coverage", project_id="blockshape")
+        assert isinstance(result, str)
+
+
+class TestErrorAndFallbackPaths:
+    """Renderer-scoped tools that hit a structured error envelope still
+    emit two blocks; renderer failures fall back to JSON-only."""
+
+    def test_overlong_check_decision_keeps_two_blocks(self, seeded_store: Path):
+        from nauro_core.constants import MAX_APPROACH_LENGTH
+
+        overlong = "x" * (MAX_APPROACH_LENGTH + 1)
+        blocks = check_decision(proposed_approach=overlong, project_id="blockshape")
+        assert len(blocks) == 2
+        # Human block leads with the Error: header.
+        assert blocks[0].text.startswith("Error:")
+        envelope = json.loads(blocks[1].text)
+        assert envelope["error"]["kind"] == "rejected"
+
+    def test_renderer_failure_falls_back_to_json_only(self, seeded_store: Path, monkeypatch):
+        """If a renderer raises unexpectedly, the wrapper must not lose
+        the response; it falls back to a single JSON block so programmatic
+        consumers still get a parseable envelope."""
+        import nauro.mcp.stdio_server as stdio_mod
+
+        def explode(_result):
+            raise RuntimeError("renderer kaboom")
+
+        monkeypatch.setitem(stdio_mod._RENDERERS, "list_decisions", explode)
+        blocks = list_decisions(project_id="blockshape")
+        assert len(blocks) == 1
+        envelope = json.loads(blocks[0].text)
+        assert envelope["store"] == "local"
+        assert "decisions" in envelope
+
+    def test_pre_resolution_error_still_two_blocks_on_renderer_scope(self, seeded_store: Path):
+        """Store-resolution failures inside a renderer-scoped tool flow
+        through the renderer — the human block carries the kernel's
+        guidance string and the JSON block carries the error envelope."""
+        # Unknown project_id triggers StoreResolutionError; the function
+        # still wraps the error dict via the renderer (Error: ... header).
+        blocks = get_context(project_id="does-not-exist")
+        assert len(blocks) == 2
+        envelope = json.loads(blocks[1].text)
+        assert envelope["store"] == "local"
+        assert envelope["status"] == "error"
+        assert "guidance" in envelope

--- a/packages/nauro/tests/test_stdio_server.py
+++ b/packages/nauro/tests/test_stdio_server.py
@@ -1,9 +1,11 @@
 """Tests for the Nauro MCP stdio server tools."""
 
+import json
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from mcp.types import TextContent
 from nauro_core.operations import flag_question as _flag_question_op
 from nauro_core.operations.propose_decision import _get_pending_store
 
@@ -23,6 +25,17 @@ from nauro.store.filesystem_store import FilesystemStore
 from nauro.store.registry import register_project
 from nauro.templates.scaffolds import scaffold_project_store
 from tests._writer_compat import append_decision
+
+
+def _envelope(blocks: list[TextContent]) -> dict:
+    """Decode the JSON envelope from a renderer-wrapped read-tool response.
+
+    Read tools listed in ``nauro_core.renderers.RENDERERS`` return two
+    text content blocks: a human-formatted summary at ``[0]`` and the
+    JSON envelope at ``[1]``. Tests that need the structured envelope
+    decode ``[1].text`` directly.
+    """
+    return json.loads(blocks[1].text)
 
 
 def _append_question(store_path: Path, question: str) -> None:
@@ -82,16 +95,16 @@ class TestResolveStore:
 
 class TestGetContext:
     def test_l0_returns_current_state(self, store: Path):
-        result = get_context(project_id="testproj", level=0)
+        result = _envelope(get_context(project_id="testproj", level=0))
         assert "## Current State" in result["content"]
 
     def test_l1_returns_full_stack(self, store: Path):
-        result = get_context(project_id="testproj", level=1)
+        result = _envelope(get_context(project_id="testproj", level=1))
         assert "# Stack" in result["content"]
         assert "Python 3.11" in result["content"]
 
     def test_l2_returns_full_content(self, store: Path):
-        result = get_context(project_id="testproj", level=2)
+        result = _envelope(get_context(project_id="testproj", level=2))
         assert "Use FastAPI" in result["content"]
         assert "Should we add caching?" in result["content"]
 
@@ -99,7 +112,7 @@ class TestGetContext:
         # Invalid numeric levels surface as a kernel rejection envelope —
         # `_coerce_level` rejects strings before reaching the kernel, so the
         # ValueError path on string input is exercised separately below.
-        result = get_context(project_id="testproj", level=5)
+        result = _envelope(get_context(project_id="testproj", level=5))
         assert result["store"] == "local"
         assert result["error"]["kind"] == "rejected"
         assert "Invalid level" in result["error"]["reason"]
@@ -294,9 +307,11 @@ class TestConfirmDecision:
 
 class TestCheckDecision:
     def test_check_no_conflicts(self, store: Path):
-        result = check_decision(
-            proposed_approach="Use a completely novel distributed tracing approach",
-            project_id="testproj",
+        result = _envelope(
+            check_decision(
+                proposed_approach="Use a completely novel distributed tracing approach",
+                project_id="testproj",
+            )
         )
         assert "related_decisions" in result
         assert "assessment" in result


### PR DESCRIPTION
## Why

Chat clients (Claude Code, claude.ai) currently render local stdio MCP read-tool responses as a single text block containing the raw JSON envelope. The output reads as a JSON wall, burying the agent-facing call to action (e.g. the top BM25 match on `check_decision`) under syntax noise. The remote MCP server already solved this with text + structured-JSON two-block formatting, but it shipped that renderer inside `mcp_server/`. Duplicating the same six renderer functions in `nauro/` would violate the "no copy-paste across packages" rule and let the two transports drift on field-by-field formatting.

## Approach

Renderers live in nauro-core as pure functions over typed kernel result dicts. Both the remote dispatcher (private repo) and the local stdio server (this repo) import the same registry; the per-transport wrapping into MCP content blocks stays where the transport lives.

Considered and rejected:
- Refactoring stdio to expose a dispatcher seam that mirrors the remote HTTP router. Speculative — the stdio surface has been stable; building infrastructure for one consumer adds churn without payoff.
- Keeping the renderer inside the consumer package and re-importing. Breaks the public-API surface; `nauro` is a CLI install and `nauro_core` is where shared protocol-shape logic lives.
- Switching the stdio tools' return types to `dict | list[TextContent]` so direct callers still see dicts. Loses the type signal that drives FastMCP's content-block conversion.

The FastMCP spike confirmed `structured_output=False` + `list[TextContent]` return is the right wire shape — no auto-generated outputSchema, two content blocks emit through the MCP protocol, direct Python callers (tests) get the `list[TextContent]` back and decode the JSON envelope from `content[1].text` when they need the structured payload.

## What changed

- `nauro-core` now hosts `nauro_core.renderers` with six renderer functions (`check_decision`, `get_decision`, `search_decisions`, `list_decisions`, `get_context`, `list_projects`) plus a `RENDERERS` registry. Zero new third-party deps — module uses only stdlib + `from __future__`. Re-exports added to the package `__init__`. Version bumped 0.11.0 → 0.11.1.
- The local stdio MCP server's five renderer-scoped read tools now return `list[TextContent]` — a human-formatted summary at `[0]` and the JSON envelope at `[1]`. `get_raw_file` and `diff_since_last_session` stay single-value (their bodies are already user-rendered). Write tools and error paths unchanged.
- `render_get_context` accepts both `context` (remote envelope key) and `content` (local kernel envelope field name). The two surfaces disagree on the field name today; a shared registry must cover both without forcing an envelope migration in this PR.
- Five parity tests + the direct-call paths in `test_stdio_server` decode the envelope from `content[1].text`. A new `test_stdio_renderer_wrap.py` adds 14 cases pinning the block-shape contract end-to-end (two-block reads, single-value pass-throughs, write-tool unchanged shape, renderer-failure fallback, error-path envelopes).

## What to review

- `_wrap_with_renderer` in `stdio_server.py`: the renderer-fail-safe path mirrors the remote dispatcher's `_build_content_blocks` — a renderer raising must not swallow the response.
- The `structured_output=False` flag on the five wrapped decorators: keeps the auto-generated `outputSchema` off so the wire shape stays aligned with the dict-returning siblings (`outputSchema=None` across the board for the seven read tools).
- `render_get_context` envelope-key tolerance: see the new nauro-core test case `test_local_envelope_content_key` for the invariant a future envelope cleanup must preserve.
- The five parity tests' `_stdio_envelope` helpers: the JSON-envelope decode from `content[1].text` is the new wire-format parity check, not a workaround.

## What's deferred

- `protocolVersion` bump to `2025-06-18` + structuredContent migration — separate scope, not blocked by this PR.
- Write-tool renderers — same envelope is already a single user-facing block; no benefit until the agent-facing payload changes.
- Local HTTP FastAPI `server.py` renderer wiring — no concrete demand from JSON consumers using that surface.
- Terminal-width detection in the renderer — fixed at 80 today; revisit when a chat client surfaces a width hint.
- Envelope-key unification for `get_context` (`content` vs `context`) — out of scope; the renderer tolerates both for now.

## Test plan

- `uv run pytest packages/nauro-core/tests/ -x -q` → 598 passed
- `uv run pytest packages/nauro/tests/ -x -q` → 1006 passed, 11 skipped
- `uv run ruff format --check packages/` → all formatted
- `uv run ruff check packages/` → all checks passed
- `uv run lint-imports` (nauro-core) → `nauro_core must not import from consumers KEPT`

Includes 27 new renderer tests in nauro-core, 14 new block-shape contract tests in nauro, and 22 updated parity tests covering the five renderer-scoped stdio tools.
