### PR TITLE
feat(nauro): emit structuredContent for renderer-scoped local stdio reads

### DIFF
--- a/packages/nauro/src/nauro/mcp/stdio_server.py
+++ b/packages/nauro/src/nauro/mcp/stdio_server.py
@@ -17,11 +17,12 @@ The shared `nauro_core.mcp_tools.ALL_TOOLS` registry contains 12 tools.
 single project store, so the discovery tool is not registered here.
 
 Read tools listed in ``nauro_core.renderers.RENDERERS`` return a
-``list[TextContent]`` with two blocks: a human-formatted summary at
-``[0]`` and the JSON envelope at ``[1]``. This mirrors the remote MCP
-dispatcher so chat clients (Claude Code, claude.ai) get the same
-two-block shape regardless of transport. Programmatic consumers — tests,
-CLI, subagents — decode the envelope from ``content[1].text``.
+``CallToolResult`` carrying both ``content`` and ``structuredContent``:
+``content`` holds the two-block ``[human, json]`` shape so older clients
+that read ``content[1].text`` keep parsing the same envelope, and
+``structuredContent`` carries the same envelope as a typed dict for
+clients on protocol revision 2025-06-18 and later. FastMCP's session
+layer negotiates 2025-06-18 automatically when the client advertises it.
 """
 
 from __future__ import annotations
@@ -33,7 +34,7 @@ from pathlib import Path
 from typing import Annotated, Any, Literal
 
 from mcp.server import FastMCP
-from mcp.types import TextContent, ToolAnnotations
+from mcp.types import CallToolResult, TextContent, ToolAnnotations
 from nauro_core.constants import MCP_INSTRUCTIONS
 from nauro_core.mcp_tools import ToolSpec, get_tool_spec
 from nauro_core.renderers import RENDERERS as _RENDERERS
@@ -76,29 +77,40 @@ NOT_A_NAURO_REPO = (
 )
 
 
-def _wrap_with_renderer(tool_name: str, result: dict) -> list[TextContent]:
-    """Compose two text content blocks for a read-tool response.
+def _wrap_with_renderer(tool_name: str, result: dict) -> CallToolResult:
+    """Compose the read-tool response with both ``content`` and ``structuredContent``.
 
-    Mirrors the remote MCP dispatcher (``mcp_server.mcp_router._build_content_blocks``):
+    Mirrors the remote MCP dispatcher (``mcp_server.mcp_router._build_tool_result``):
     ``content[0]`` carries the human-formatted summary from
     ``nauro_core.renderers.RENDERERS[tool_name]``; ``content[1]`` carries
-    the unchanged JSON envelope so programmatic consumers stay byte-stable.
-    A renderer raising falls back to JSON-only — a presentation bug must
-    not swallow a response.
+    the unchanged JSON envelope so older clients pinned to the prior
+    transitional shape stay byte-stable. ``structuredContent`` carries
+    the same envelope as a typed dict for clients on the 2025-06-18
+    protocol revision and later. A renderer raising falls back to
+    JSON-only — a presentation bug must not swallow a response.
     """
     json_text = json.dumps(result, indent=2, default=str)
     renderer = _RENDERERS.get(tool_name)
     if renderer is None:
-        return [TextContent(type="text", text=json_text)]
+        return CallToolResult(
+            content=[TextContent(type="text", text=json_text)],
+            structuredContent=result,
+        )
     try:
         rendered = renderer(result)
     except Exception:
         logger.exception("renderer failed for tool=%s; falling back to JSON-only", tool_name)
-        return [TextContent(type="text", text=json_text)]
-    return [
-        TextContent(type="text", text=rendered),
-        TextContent(type="text", text=json_text),
-    ]
+        return CallToolResult(
+            content=[TextContent(type="text", text=json_text)],
+            structuredContent=result,
+        )
+    return CallToolResult(
+        content=[
+            TextContent(type="text", text=rendered),
+            TextContent(type="text", text=json_text),
+        ],
+        structuredContent=result,
+    )
 
 
 def _spec_kwargs(name: str) -> dict[str, Any]:
@@ -138,7 +150,7 @@ _resolve_store = resolve_store
 _resolve_via_repo_config = resolve_via_repo_config
 
 
-@mcp.tool(structured_output=False, **_spec_kwargs("get_context"))
+@mcp.tool(**_spec_kwargs("get_context"))
 def get_context(
     project_id: Annotated[
         str | None, Field(description=_param_desc("get_context", "project_id"))
@@ -148,7 +160,7 @@ def get_context(
         Literal["L0", "L1", "L2"] | int,
         Field(description=_param_desc("get_context", "level")),
     ] = "L0",
-) -> list[TextContent]:
+) -> CallToolResult:
     try:
         store_path = _resolve_store(project_id, cwd)
     except NoProjectError:
@@ -178,7 +190,7 @@ def get_raw_file(
     return tool_get_raw_file(store_path, path)
 
 
-@mcp.tool(structured_output=False, **_spec_kwargs("list_decisions"))
+@mcp.tool(**_spec_kwargs("list_decisions"))
 def list_decisions(
     project_id: Annotated[
         str | None, Field(description=_param_desc("list_decisions", "project_id"))
@@ -188,7 +200,7 @@ def list_decisions(
     include_superseded: Annotated[
         bool, Field(description=_param_desc("list_decisions", "include_superseded"))
     ] = False,
-) -> list[TextContent]:
+) -> CallToolResult:
     try:
         store_path = _resolve_store(project_id, cwd)
     except NoProjectError:
@@ -200,14 +212,14 @@ def list_decisions(
     return _wrap_with_renderer("list_decisions", result)
 
 
-@mcp.tool(structured_output=False, **_spec_kwargs("get_decision"))
+@mcp.tool(**_spec_kwargs("get_decision"))
 def get_decision(
     number: Annotated[int, Field(description=_param_desc("get_decision", "number"))],
     project_id: Annotated[
         str | None, Field(description=_param_desc("get_decision", "project_id"))
     ] = None,
     cwd: str | None = None,
-) -> list[TextContent]:
+) -> CallToolResult:
     try:
         store_path = _resolve_store(project_id, cwd)
     except NoProjectError:
@@ -239,7 +251,7 @@ def diff_since_last_session(
     return tool_diff_since_last_session(store_path, days)
 
 
-@mcp.tool(structured_output=False, **_spec_kwargs("search_decisions"))
+@mcp.tool(**_spec_kwargs("search_decisions"))
 def search_decisions(
     query: Annotated[str, Field(description=_param_desc("search_decisions", "query"))],
     limit: Annotated[int, Field(description=_param_desc("search_decisions", "limit"))] = 10,
@@ -247,7 +259,7 @@ def search_decisions(
         str | None, Field(description=_param_desc("search_decisions", "project_id"))
     ] = None,
     cwd: str | None = None,
-) -> list[TextContent]:
+) -> CallToolResult:
     try:
         store_path = _resolve_store(project_id, cwd)
     except NoProjectError:
@@ -259,7 +271,7 @@ def search_decisions(
     return _wrap_with_renderer("search_decisions", result)
 
 
-@mcp.tool(structured_output=False, **_spec_kwargs("check_decision"))
+@mcp.tool(**_spec_kwargs("check_decision"))
 def check_decision(
     proposed_approach: Annotated[
         str, Field(description=_param_desc("check_decision", "proposed_approach"))
@@ -271,7 +283,7 @@ def check_decision(
         str | None, Field(description=_param_desc("check_decision", "project_id"))
     ] = None,
     cwd: str | None = None,
-) -> list[TextContent]:
+) -> CallToolResult:
     try:
         store_path = _resolve_store(project_id, cwd)
     except NoProjectError:

--- a/packages/nauro/tests/test_check_decision_parity.py
+++ b/packages/nauro/tests/test_check_decision_parity.py
@@ -50,11 +50,16 @@ def _cli_envelope(store_path: Path) -> dict:
 
 
 def _stdio_envelope(pid: str) -> dict:
-    # stdio check_decision now returns a two-block list[TextContent]; the
-    # JSON envelope is at content[1].text — see stdio_server module
-    # docstring for the contract.
-    blocks = stdio_check_decision(proposed_approach=DEMO_PROMPT, project_id=pid)
-    return json.loads(blocks[1].text)
+    # stdio check_decision returns a CallToolResult carrying both the
+    # two-block content list and a typed structuredContent envelope —
+    # see stdio_server module docstring for the contract. The two
+    # surfaces must mirror each other; this helper validates parity
+    # while returning the canonical envelope dict for the cross-surface
+    # comparison.
+    result = stdio_check_decision(proposed_approach=DEMO_PROMPT, project_id=pid)
+    envelope = json.loads(result.content[1].text)
+    assert result.structuredContent == envelope
+    return envelope
 
 
 def _http_envelope(pid: str) -> dict:
@@ -110,8 +115,9 @@ def test_rejection_envelope_matches_across_surfaces(demo_repo):
     assert cli_raw.exit_code == 1, cli_raw.output
     cli = json.loads(cli_raw.stdout)
 
-    stdio_blocks = stdio_check_decision(proposed_approach=overlong, project_id=pid)
-    stdio = json.loads(stdio_blocks[1].text)
+    stdio_result = stdio_check_decision(proposed_approach=overlong, project_id=pid)
+    stdio = json.loads(stdio_result.content[1].text)
+    assert stdio_result.structuredContent == stdio
 
     client = TestClient(fastapi_app)
     response = client.post(

--- a/packages/nauro/tests/test_get_context_parity.py
+++ b/packages/nauro/tests/test_get_context_parity.py
@@ -105,11 +105,14 @@ def missing_store(tmp_path, monkeypatch):
 
 
 def _stdio_envelope(pid: str, level) -> dict:
-    # stdio get_context now returns a two-block list[TextContent]; the
-    # JSON envelope is at content[1].text — see stdio_server module
-    # docstring for the contract.
-    blocks = stdio_get_context(project_id=pid, level=level)
-    return json.loads(blocks[1].text)
+    # stdio get_context returns a CallToolResult carrying both the
+    # two-block content list and a typed structuredContent envelope —
+    # see stdio_server module docstring for the contract. This helper
+    # validates the two surfaces mirror each other on every call.
+    result = stdio_get_context(project_id=pid, level=level)
+    envelope = json.loads(result.content[1].text)
+    assert result.structuredContent == envelope
+    return envelope
 
 
 def _tool_envelope(store_path: Path, level) -> dict:

--- a/packages/nauro/tests/test_get_decision_parity.py
+++ b/packages/nauro/tests/test_get_decision_parity.py
@@ -48,11 +48,13 @@ def demo_repo(tmp_path, monkeypatch):
 
 
 def _stdio_envelope(pid: str, number: int) -> dict:
-    # stdio get_decision now returns a two-block list[TextContent]; the
-    # JSON envelope is at content[1].text — see stdio_server module
-    # docstring for the contract.
-    blocks = stdio_get_decision(number=number, project_id=pid)
-    return json.loads(blocks[1].text)
+    # stdio get_decision returns a CallToolResult carrying both the
+    # two-block content list and a typed structuredContent envelope —
+    # see stdio_server module docstring for the contract.
+    result = stdio_get_decision(number=number, project_id=pid)
+    envelope = json.loads(result.content[1].text)
+    assert result.structuredContent == envelope
+    return envelope
 
 
 def _tool_envelope(store_path: Path, number: int) -> dict:

--- a/packages/nauro/tests/test_list_decisions_parity.py
+++ b/packages/nauro/tests/test_list_decisions_parity.py
@@ -66,13 +66,15 @@ def empty_repo(tmp_path, monkeypatch):
 
 
 def _stdio_envelope(pid: str, *, limit: int = 20, include_superseded: bool = False) -> dict:
-    # stdio list_decisions now returns a two-block list[TextContent]; the
-    # JSON envelope is at content[1].text — see stdio_server module
-    # docstring for the contract.
-    blocks = stdio_list_decisions(
+    # stdio list_decisions returns a CallToolResult carrying both the
+    # two-block content list and a typed structuredContent envelope —
+    # see stdio_server module docstring for the contract.
+    result = stdio_list_decisions(
         project_id=pid, limit=limit, include_superseded=include_superseded
     )
-    return json.loads(blocks[1].text)
+    envelope = json.loads(result.content[1].text)
+    assert result.structuredContent == envelope
+    return envelope
 
 
 def _tool_envelope(store_path: Path, *, limit: int = 20, include_superseded: bool = False) -> dict:

--- a/packages/nauro/tests/test_search_decisions_parity.py
+++ b/packages/nauro/tests/test_search_decisions_parity.py
@@ -90,11 +90,13 @@ def empty_repo(tmp_path, monkeypatch):
 
 
 def _stdio_envelope(pid: str, query: str, *, limit: int = 10) -> dict:
-    # stdio search_decisions now returns a two-block list[TextContent]; the
-    # JSON envelope is at content[1].text — see stdio_server module
-    # docstring for the contract.
-    blocks = stdio_search_decisions(query=query, limit=limit, project_id=pid)
-    return json.loads(blocks[1].text)
+    # stdio search_decisions returns a CallToolResult carrying both the
+    # two-block content list and a typed structuredContent envelope —
+    # see stdio_server module docstring for the contract.
+    result = stdio_search_decisions(query=query, limit=limit, project_id=pid)
+    envelope = json.loads(result.content[1].text)
+    assert result.structuredContent == envelope
+    return envelope
 
 
 def _tool_envelope(store_path: Path, query: str, *, limit: int = 10) -> dict:

--- a/packages/nauro/tests/test_stdio_renderer_wrap.py
+++ b/packages/nauro/tests/test_stdio_renderer_wrap.py
@@ -1,10 +1,12 @@
 """Block-shape contract for the local stdio MCP read tools.
 
-Read tools listed in ``nauro_core.renderers.RENDERERS`` must return two
-``TextContent`` blocks: a human-formatted summary at ``[0]`` and the
-JSON envelope at ``[1]``. Write tools, ``get_raw_file``,
-``diff_since_last_session``, and pre-resolution error responses stay
-single-block (or stay strings).
+Read tools listed in ``nauro_core.renderers.RENDERERS`` return a
+``CallToolResult`` carrying both ``content`` (two ``TextContent`` blocks:
+a human-formatted summary at ``[0]`` and the JSON envelope at ``[1]``)
+and ``structuredContent`` (the same envelope as a typed dict for clients
+on the 2025-06-18 protocol revision and later). Write tools,
+``get_raw_file``, ``diff_since_last_session``, and pre-resolution error
+responses stay single-block (or stay strings).
 
 Mirrors ``TestContentBlockShape`` from the remote MCP router so both
 transports stay in sync.
@@ -16,7 +18,7 @@ import json
 from pathlib import Path
 
 import pytest
-from mcp.types import TextContent
+from mcp.types import CallToolResult, TextContent
 from nauro_core.operations import flag_question as _flag_question_op
 from nauro_core.operations.propose_decision import _get_pending_store
 
@@ -67,7 +69,9 @@ class TestTwoBlockReadTools:
     """Renderer-scoped read tools return ``[human, json]`` content blocks."""
 
     def test_get_context_returns_two_blocks(self, seeded_store: Path):
-        blocks = get_context(project_id="blockshape", level=0)
+        result = get_context(project_id="blockshape", level=0)
+        assert isinstance(result, CallToolResult)
+        blocks = result.content
         assert len(blocks) == 2
         assert all(isinstance(b, TextContent) and b.type == "text" for b in blocks)
         envelope = json.loads(blocks[1].text)
@@ -79,7 +83,9 @@ class TestTwoBlockReadTools:
         assert "## Current State" in blocks[0].text
 
     def test_list_decisions_returns_two_blocks(self, seeded_store: Path):
-        blocks = list_decisions(project_id="blockshape")
+        result = list_decisions(project_id="blockshape")
+        assert isinstance(result, CallToolResult)
+        blocks = result.content
         assert len(blocks) == 2
         envelope = json.loads(blocks[1].text)
         assert envelope["store"] == "local"
@@ -91,7 +97,9 @@ class TestTwoBlockReadTools:
         # scaffold_project_store seeds D001 (initial-setup); the fixture
         # appends D002 = "Use FastAPI". Ask for D002 so the title
         # assertion is independent of the scaffold's seed text.
-        blocks = get_decision(number=2, project_id="blockshape")
+        result = get_decision(number=2, project_id="blockshape")
+        assert isinstance(result, CallToolResult)
+        blocks = result.content
         assert len(blocks) == 2
         envelope = json.loads(blocks[1].text)
         assert envelope["store"] == "local"
@@ -100,7 +108,9 @@ class TestTwoBlockReadTools:
         assert "Use FastAPI" in blocks[0].text
 
     def test_search_decisions_returns_two_blocks(self, seeded_store: Path):
-        blocks = search_decisions(query="FastAPI", project_id="blockshape")
+        result = search_decisions(query="FastAPI", project_id="blockshape")
+        assert isinstance(result, CallToolResult)
+        blocks = result.content
         assert len(blocks) == 2
         envelope = json.loads(blocks[1].text)
         assert envelope["store"] == "local"
@@ -109,14 +119,51 @@ class TestTwoBlockReadTools:
         assert "FastAPI" in blocks[0].text
 
     def test_check_decision_returns_two_blocks(self, seeded_store: Path):
-        blocks = check_decision(
+        result = check_decision(
             proposed_approach="Use FastAPI with async endpoints for the API server",
             project_id="blockshape",
         )
+        assert isinstance(result, CallToolResult)
+        blocks = result.content
         assert len(blocks) == 2
         envelope = json.loads(blocks[1].text)
         assert envelope["store"] == "local"
         assert "related_decisions" in envelope
+
+
+class TestStructuredContentParity:
+    """Renderer-scoped read tools must emit ``structuredContent`` mirroring
+    the JSON envelope at ``content[1].text``. Clients on the 2025-06-18
+    protocol revision read the structured field; older clients fall back
+    to the JSON-as-text block."""
+
+    def test_get_context_structured_matches_json_envelope(self, seeded_store: Path):
+        result = get_context(project_id="blockshape", level=0)
+        assert isinstance(result.structuredContent, dict)
+        assert result.structuredContent == json.loads(result.content[1].text)
+
+    def test_list_decisions_structured_matches_json_envelope(self, seeded_store: Path):
+        result = list_decisions(project_id="blockshape")
+        assert isinstance(result.structuredContent, dict)
+        assert result.structuredContent == json.loads(result.content[1].text)
+
+    def test_get_decision_structured_matches_json_envelope(self, seeded_store: Path):
+        result = get_decision(number=2, project_id="blockshape")
+        assert isinstance(result.structuredContent, dict)
+        assert result.structuredContent == json.loads(result.content[1].text)
+
+    def test_search_decisions_structured_matches_json_envelope(self, seeded_store: Path):
+        result = search_decisions(query="FastAPI", project_id="blockshape")
+        assert isinstance(result.structuredContent, dict)
+        assert result.structuredContent == json.loads(result.content[1].text)
+
+    def test_check_decision_structured_matches_json_envelope(self, seeded_store: Path):
+        result = check_decision(
+            proposed_approach="Use FastAPI with async endpoints for the API server",
+            project_id="blockshape",
+        )
+        assert isinstance(result.structuredContent, dict)
+        assert result.structuredContent == json.loads(result.content[1].text)
 
 
 class TestSingleBlockReads:
@@ -166,34 +213,42 @@ class TestSingleBlockWrites:
 
 class TestErrorAndFallbackPaths:
     """Renderer-scoped tools that hit a structured error envelope still
-    emit two blocks; renderer failures fall back to JSON-only."""
+    emit two blocks; renderer failures fall back to JSON-only. In both
+    cases ``structuredContent`` still mirrors the JSON envelope."""
 
     def test_overlong_check_decision_keeps_two_blocks(self, seeded_store: Path):
         from nauro_core.constants import MAX_APPROACH_LENGTH
 
         overlong = "x" * (MAX_APPROACH_LENGTH + 1)
-        blocks = check_decision(proposed_approach=overlong, project_id="blockshape")
+        result = check_decision(proposed_approach=overlong, project_id="blockshape")
+        blocks = result.content
         assert len(blocks) == 2
         # Human block leads with the Error: header.
         assert blocks[0].text.startswith("Error:")
         envelope = json.loads(blocks[1].text)
         assert envelope["error"]["kind"] == "rejected"
+        # The structured field mirrors the same envelope verbatim.
+        assert result.structuredContent == envelope
 
     def test_renderer_failure_falls_back_to_json_only(self, seeded_store: Path, monkeypatch):
         """If a renderer raises unexpectedly, the wrapper must not lose
         the response; it falls back to a single JSON block so programmatic
-        consumers still get a parseable envelope."""
+        consumers still get a parseable envelope. ``structuredContent``
+        still carries the same envelope so 2025-06-18 clients keep
+        parsing without depending on the text block."""
         import nauro.mcp.stdio_server as stdio_mod
 
         def explode(_result):
             raise RuntimeError("renderer kaboom")
 
         monkeypatch.setitem(stdio_mod._RENDERERS, "list_decisions", explode)
-        blocks = list_decisions(project_id="blockshape")
+        result = list_decisions(project_id="blockshape")
+        blocks = result.content
         assert len(blocks) == 1
         envelope = json.loads(blocks[0].text)
         assert envelope["store"] == "local"
         assert "decisions" in envelope
+        assert result.structuredContent == envelope
 
     def test_pre_resolution_error_still_two_blocks_on_renderer_scope(self, seeded_store: Path):
         """Store-resolution failures inside a renderer-scoped tool flow
@@ -201,9 +256,11 @@ class TestErrorAndFallbackPaths:
         guidance string and the JSON block carries the error envelope."""
         # Unknown project_id triggers StoreResolutionError; the function
         # still wraps the error dict via the renderer (Error: ... header).
-        blocks = get_context(project_id="does-not-exist")
+        result = get_context(project_id="does-not-exist")
+        blocks = result.content
         assert len(blocks) == 2
         envelope = json.loads(blocks[1].text)
         assert envelope["store"] == "local"
         assert envelope["status"] == "error"
         assert "guidance" in envelope
+        assert result.structuredContent == envelope

--- a/packages/nauro/tests/test_stdio_server.py
+++ b/packages/nauro/tests/test_stdio_server.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-from mcp.types import TextContent
+from mcp.types import CallToolResult
 from nauro_core.operations import flag_question as _flag_question_op
 from nauro_core.operations.propose_decision import _get_pending_store
 
@@ -27,15 +27,19 @@ from nauro.templates.scaffolds import scaffold_project_store
 from tests._writer_compat import append_decision
 
 
-def _envelope(blocks: list[TextContent]) -> dict:
+def _envelope(result: CallToolResult) -> dict:
     """Decode the JSON envelope from a renderer-wrapped read-tool response.
 
-    Read tools listed in ``nauro_core.renderers.RENDERERS`` return two
-    text content blocks: a human-formatted summary at ``[0]`` and the
-    JSON envelope at ``[1]``. Tests that need the structured envelope
-    decode ``[1].text`` directly.
+    Read tools listed in ``nauro_core.renderers.RENDERERS`` return a
+    ``CallToolResult`` carrying two text content blocks (human-formatted
+    summary at ``[0]``, JSON envelope at ``[1]``) and a typed
+    ``structuredContent`` dict mirroring that envelope. Tests that need
+    the structured envelope decode ``content[1].text`` and validate
+    parity with ``structuredContent`` in one shot.
     """
-    return json.loads(blocks[1].text)
+    envelope = json.loads(result.content[1].text)
+    assert result.structuredContent == envelope
+    return envelope
 
 
 def _append_question(store_path: Path, question: str) -> None:


### PR DESCRIPTION
## Why

The local stdio server's five renderer-scoped read tools (`check_decision`, `get_context`, `get_decision`, `list_decisions`, `search_decisions`) emit a two-block content list — a human-formatted summary at `[0]` and the raw JSON envelope at `[1]` — so chat clients (Claude Code, claude.ai) render the summary while programmatic consumers keep parsing the envelope. The JSON block lands in model context as a literal text payload, which is the wrong shape for clients that support the 2025-06-18 protocol revision: they have a typed `structuredContent` field that can be parsed without going through the model's text channel, and Anthropic's reference clients hide it from context entirely.

## Approach

Switch the renderer wrapper to return a `CallToolResult` that carries both:

- `content = [TextContent(rendered), TextContent(json_envelope)]` — unchanged from the prior transitional shape, so older clients pinned to the prior revision keep parsing `content[1].text` byte-stable.
- `structuredContent = <envelope dict>` — the same envelope as a typed field, for clients on 2025-06-18 and later.

The MCP 2025-06-18 spec explicitly says "SHOULD also return the equivalent text content for backwards compatibility" — the two-block content list is that backwards-compat surface. A follow-up cutover will drop `content[1]` once observation logs confirm all consumers handle `structuredContent` properly; that is out of scope here.

Alternative considered: drop `content[1]` immediately and put only the rendered summary in `content`. Rejected — a small number of programmatic consumers (CLI scripts, bundled subagents, pinned clients like Perplexity on the older revision) still read the JSON envelope through the text block. Carrying both fields in this PR removes the migration risk; the drop happens once observation confirms zero text-block consumers remain.

FastMCP's session layer negotiates `protocolVersion: 2025-06-18` automatically when the client advertises support, so no application-level initialize work was needed on the stdio side. The remote Lambda router gets explicit initialize-time logging in its own PR; the stdio server has no equivalent hook surface (FastMCP routes `InitializeRequest` through `ServerSession` internally, not through user-registered handlers).

## What changed

- `packages/nauro/src/nauro/mcp/stdio_server.py`: `_wrap_with_renderer` now returns `CallToolResult` instead of `list[TextContent]`; the five renderer-scoped tools have their return annotations updated and their `structured_output=False` decorator flag removed so FastMCP passes the `CallToolResult` through verbatim.
- `packages/nauro/tests/test_stdio_renderer_wrap.py`: existing block-shape tests assert against `result.content` instead of the bare list; a new `TestStructuredContentParity` class locks `structuredContent == json.loads(content[1].text)` for each renderer-scoped read tool. The renderer-failure-fallback path is updated to confirm `structuredContent` still mirrors the envelope when the renderer raises.
- `packages/nauro/tests/test_stdio_server.py`: `_envelope` helper now takes the full `CallToolResult` and validates the structured-vs-text parity in one shot — every call through this helper exercises both fields.
- `packages/nauro/tests/test_*_parity.py` (five files): cross-surface envelope comparison helpers updated to extract from `CallToolResult.content[1]` and assert `structuredContent` parity along the way.

Pass-through reads (`get_raw_file`, `diff_since_last_session`) and the four write tools keep their existing dict / string return shapes — the renderer scope is read-only.

## What to review

- `_wrap_with_renderer` — the renderer-failure branch returns `structuredContent` even though `content` falls back to JSON-only. Intentional: if rendering of the human block fails, programmatic consumers shouldn't lose access to the structured envelope through the text fallback alone.
- The five `@mcp.tool` decorators: removing `structured_output=False` shifts FastMCP's behavior. With a `CallToolResult` return annotation and no metadata, FastMCP skips output-schema derivation and emits the `CallToolResult` verbatim.
- Parity helpers: each one now does the structured-vs-text equality assertion inline as a precondition before returning the envelope — drift between the two fields would surface as a parity-test failure rather than wait for the dedicated block-shape test.

## What's deferred

- Dropping `content[1]` from the wire shape once observation logs confirm all consumers handle `structuredContent`. Tracked separately.
- Remote `mcp-server` ships the equivalent change in a separate PR (private repo) plus the corresponding `nauro-core` pin bump once this PR cuts a `nauro-core-v0.11.1` release tag.

## Test plan

- `uv run pytest packages/nauro-core/tests/ -x -q` — 599 passed
- `uv run pytest packages/nauro/tests/ -x -q` — 1025 passed, 11 skipped
- `uv run ruff format --check packages/` + `uv run ruff check packages/` — clean
