### PR TITLE
feat(mcp): collapse renderer-scoped read tools to single content[] block

### DIFF
--- a/packages/nauro-core/src/nauro_core/renderers.py
+++ b/packages/nauro-core/src/nauro_core/renderers.py
@@ -3,8 +3,8 @@
 Each renderer is a pure function: takes the result dict that the
 ``tools_read`` adapter (or ``list_user_projects``) produced and returns a
 formatted text block intended for chat-UI consumption. The dispatcher
-pairs the rendered text with the unchanged JSON envelope so programmatic
-consumers can still parse the structured payload from ``content[1]``.
+emits the rendered text as the sole ``content[0]`` block of the MCP
+``tools/call`` response.
 
 Renderers must not perform I/O, hit S3/DDB, or import anything that
 would. They must not mutate the input dict.

--- a/packages/nauro/src/nauro/mcp/stdio_server.py
+++ b/packages/nauro/src/nauro/mcp/stdio_server.py
@@ -16,13 +16,11 @@ The shared `nauro_core.mcp_tools.ALL_TOOLS` registry contains 12 tools.
 `list_projects` is remote-only — local installs auto-resolve to the
 single project store, so the discovery tool is not registered here.
 
-Read tools listed in ``nauro_core.renderers.RENDERERS`` return a
-``CallToolResult`` carrying both ``content`` and ``structuredContent``:
-``content`` holds the two-block ``[human, json]`` shape so older clients
-that read ``content[1].text`` keep parsing the same envelope, and
-``structuredContent`` carries the same envelope as a typed dict for
-clients on protocol revision 2025-06-18 and later. FastMCP's session
-layer negotiates 2025-06-18 automatically when the client advertises it.
+Renderer-scoped read tools listed in ``nauro_core.renderers.RENDERERS``
+return a ``CallToolResult`` with a single ``TextContent`` block:
+``content[0]`` carries the renderer output. Other tools — write tools,
+``get_raw_file``, ``diff_since_last_session`` — keep their existing
+single-block shape.
 """
 
 from __future__ import annotations
@@ -78,39 +76,25 @@ NOT_A_NAURO_REPO = (
 
 
 def _wrap_with_renderer(tool_name: str, result: dict) -> CallToolResult:
-    """Compose the read-tool response with both ``content`` and ``structuredContent``.
+    """Wrap a renderer-scoped read-tool result in a single ``TextContent`` block.
 
     Mirrors the remote MCP dispatcher (``mcp_server.mcp_router._build_tool_result``):
-    ``content[0]`` carries the human-formatted summary from
-    ``nauro_core.renderers.RENDERERS[tool_name]``; ``content[1]`` carries
-    the unchanged JSON envelope so older clients pinned to the prior
-    transitional shape stay byte-stable. ``structuredContent`` carries
-    the same envelope as a typed dict for clients on the 2025-06-18
-    protocol revision and later. A renderer raising falls back to
-    JSON-only — a presentation bug must not swallow a response.
+    ``content[0]`` carries the renderer output from
+    ``nauro_core.renderers.RENDERERS[tool_name]``. A renderer raising — or a
+    tool name with no renderer mapped — falls back to a JSON dump of the
+    envelope in ``content[0]`` so a presentation bug never swallows a
+    response.
     """
     json_text = json.dumps(result, indent=2, default=str)
     renderer = _RENDERERS.get(tool_name)
     if renderer is None:
-        return CallToolResult(
-            content=[TextContent(type="text", text=json_text)],
-            structuredContent=result,
-        )
+        return CallToolResult(content=[TextContent(type="text", text=json_text)])
     try:
         rendered = renderer(result)
     except Exception:
         logger.exception("renderer failed for tool=%s; falling back to JSON-only", tool_name)
-        return CallToolResult(
-            content=[TextContent(type="text", text=json_text)],
-            structuredContent=result,
-        )
-    return CallToolResult(
-        content=[
-            TextContent(type="text", text=rendered),
-            TextContent(type="text", text=json_text),
-        ],
-        structuredContent=result,
-    )
+        return CallToolResult(content=[TextContent(type="text", text=json_text)])
+    return CallToolResult(content=[TextContent(type="text", text=rendered)])
 
 
 def _spec_kwargs(name: str) -> dict[str, Any]:

--- a/packages/nauro/tests/test_check_decision_parity.py
+++ b/packages/nauro/tests/test_check_decision_parity.py
@@ -7,6 +7,11 @@ same proposal against the same store. This file pins the envelope
 shape across the three adapter wirings; the cross-store layer-3 test
 (``test_check_decision_cross_surface``) covers local-vs-cloud parity
 once the cloud Store exists.
+
+The stdio MCP surface now returns a single rendered ``content[0]``
+text block; the parity assertion against the other surfaces is the
+identity ``stdio.content[0].text == RENDERERS["check_decision"](envelope)``
+where ``envelope`` is the kernel result that drives every other surface.
 """
 
 from __future__ import annotations
@@ -16,6 +21,7 @@ from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
+from nauro_core.renderers import RENDERERS
 from typer.testing import CliRunner
 
 from nauro.cli.main import app as cli_app
@@ -49,17 +55,18 @@ def _cli_envelope(store_path: Path) -> dict:
     return json.loads(result.stdout)
 
 
-def _stdio_envelope(pid: str) -> dict:
-    # stdio check_decision returns a CallToolResult carrying both the
-    # two-block content list and a typed structuredContent envelope —
-    # see stdio_server module docstring for the contract. The two
-    # surfaces must mirror each other; this helper validates parity
-    # while returning the canonical envelope dict for the cross-surface
-    # comparison.
-    result = stdio_check_decision(proposed_approach=DEMO_PROMPT, project_id=pid)
-    envelope = json.loads(result.content[1].text)
-    assert result.structuredContent == envelope
-    return envelope
+def _stdio_rendered(pid: str, proposed_approach: str = DEMO_PROMPT) -> str:
+    """Return the rendered stdio surface text for the parity comparison.
+
+    Renderer-scoped read tools now return a single ``content[0]`` block
+    carrying the renderer output. The stdio surface participates in
+    parity by emitting the same renderer output the other surfaces would
+    produce for their (identical) kernel envelope.
+    """
+    result = stdio_check_decision(proposed_approach=proposed_approach, project_id=pid)
+    assert len(result.content) == 1
+    assert result.structuredContent is None
+    return result.content[0].text
 
 
 def _http_envelope(pid: str) -> dict:
@@ -83,15 +90,17 @@ def _tool_envelope(store_path: Path) -> dict:
 def test_cli_stdio_http_match_on_success_path(demo_repo):
     pid, store_path = demo_repo
     cli = _cli_envelope(store_path)
-    stdio = _stdio_envelope(pid)
     http = _http_envelope(pid)
     tool = _tool_envelope(store_path)
-    assert cli == stdio == http == tool
+    assert cli == http == tool
+    # stdio collapses to the rendered surface; parity is that the rendered
+    # text is what the shared renderer would produce for the same envelope.
+    assert _stdio_rendered(pid) == RENDERERS["check_decision"](tool)
 
 
 def test_success_envelope_contains_d141_canonical_fields(demo_repo):
-    pid, _ = demo_repo
-    envelope = _stdio_envelope(pid)
+    pid, store_path = demo_repo
+    envelope = _tool_envelope(store_path)
     assert envelope["store"] == "local"
     assert "related_decisions" in envelope
     assert "assessment" in envelope
@@ -115,10 +124,6 @@ def test_rejection_envelope_matches_across_surfaces(demo_repo):
     assert cli_raw.exit_code == 1, cli_raw.output
     cli = json.loads(cli_raw.stdout)
 
-    stdio_result = stdio_check_decision(proposed_approach=overlong, project_id=pid)
-    stdio = json.loads(stdio_result.content[1].text)
-    assert stdio_result.structuredContent == stdio
-
     client = TestClient(fastapi_app)
     response = client.post(
         "/check_decision",
@@ -129,7 +134,12 @@ def test_rejection_envelope_matches_across_surfaces(demo_repo):
 
     tool = tool_check_decision(store_path, overlong)
 
-    assert cli == stdio == http == tool
+    assert cli == http == tool
+    # stdio surfaces the kernel rejection through the renderer's error block;
+    # parity is that the rendered text matches what the renderer would emit
+    # for the same envelope every other surface returned.
+    stdio_rendered = _stdio_rendered(pid, overlong)
+    assert stdio_rendered == RENDERERS["check_decision"](tool)
     # Locked rejection envelope shape (closes D141 for this operation).
     assert cli["store"] == "local"
     assert cli["related_decisions"] == []

--- a/packages/nauro/tests/test_get_context_parity.py
+++ b/packages/nauro/tests/test_get_context_parity.py
@@ -20,7 +20,6 @@ Two compressions vs. the ``check_decision`` parity test:
 
 from __future__ import annotations
 
-import json
 from datetime import date
 from pathlib import Path
 
@@ -31,6 +30,7 @@ from nauro_core.decision_model import (
     DecisionStatus,
     format_decision,
 )
+from nauro_core.renderers import RENDERERS
 
 from nauro.constants import REPO_CONFIG_MODE_LOCAL
 from nauro.mcp.stdio_server import get_context as stdio_get_context
@@ -104,15 +104,17 @@ def missing_store(tmp_path, monkeypatch):
     return nonexistent
 
 
-def _stdio_envelope(pid: str, level) -> dict:
-    # stdio get_context returns a CallToolResult carrying both the
-    # two-block content list and a typed structuredContent envelope —
-    # see stdio_server module docstring for the contract. This helper
-    # validates the two surfaces mirror each other on every call.
+def _stdio_rendered(pid: str, level) -> str:
+    """Return the rendered stdio surface text for the parity comparison.
+
+    Renderer-scoped read tools now return a single ``content[0]`` block
+    carrying the renderer output. Parity against the direct tool envelope
+    runs through ``RENDERERS["get_context"]``.
+    """
     result = stdio_get_context(project_id=pid, level=level)
-    envelope = json.loads(result.content[1].text)
-    assert result.structuredContent == envelope
-    return envelope
+    assert len(result.content) == 1
+    assert result.structuredContent is None
+    return result.content[0].text
 
 
 def _tool_envelope(store_path: Path, level) -> dict:
@@ -122,35 +124,32 @@ def _tool_envelope(store_path: Path, level) -> dict:
 @pytest.mark.parametrize("level", ["L0", "L1", "L2"])
 def test_hit_envelope_matches_across_surfaces(seeded_repo, level):
     pid, store_path = seeded_repo
-    stdio = _stdio_envelope(pid, level)
     tool = _tool_envelope(store_path, level)
-    assert stdio == tool
-    assert stdio["store"] == "local"
-    assert isinstance(stdio["content"], str)
-    assert "Use Auth0" in stdio["content"]
+    assert _stdio_rendered(pid, level) == RENDERERS["get_context"](tool)
+    assert tool["store"] == "local"
+    assert isinstance(tool["content"], str)
+    assert "Use Auth0" in tool["content"]
 
 
 def test_empty_store_envelope_matches_across_surfaces(empty_repo):
     pid, store_path = empty_repo
-    stdio = _stdio_envelope(pid, "L0")
     tool = _tool_envelope(store_path, "L0")
-    assert stdio == tool
+    assert _stdio_rendered(pid, "L0") == RENDERERS["get_context"](tool)
     # Empty stores surface the NO_CONTEXT_YET trailer via the content body;
     # the envelope itself stays the dict shape.
-    assert stdio["store"] == "local"
-    assert "no context data yet" in stdio["content"] or "propose_decision" in stdio["content"]
+    assert tool["store"] == "local"
+    assert "no context data yet" in tool["content"] or "propose_decision" in tool["content"]
 
 
 def test_invalid_level_rejection_matches_across_surfaces(seeded_repo):
     pid, store_path = seeded_repo
     # Use a numeric level outside {0,1,2} so _coerce_level passes it through
     # and the kernel surfaces the rejection.
-    stdio = _stdio_envelope(pid, 7)
     tool = _tool_envelope(store_path, 7)
-    assert stdio == tool
-    assert stdio["store"] == "local"
-    assert stdio["error"]["kind"] == "rejected"
-    assert "Invalid level" in stdio["error"]["reason"]
+    assert _stdio_rendered(pid, 7) == RENDERERS["get_context"](tool)
+    assert tool["store"] == "local"
+    assert tool["error"]["kind"] == "rejected"
+    assert "Invalid level" in tool["error"]["reason"]
 
 
 def test_missing_store_guidance_matches_across_surfaces(missing_store):

--- a/packages/nauro/tests/test_get_decision_parity.py
+++ b/packages/nauro/tests/test_get_decision_parity.py
@@ -19,10 +19,10 @@ Two compressions vs. the ``check_decision`` parity test:
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
 import pytest
+from nauro_core.renderers import RENDERERS
 
 from nauro.constants import REPO_CONFIG_MODE_LOCAL
 from nauro.demo import create_demo_project
@@ -47,14 +47,17 @@ def demo_repo(tmp_path, monkeypatch):
     return pid, store_path
 
 
-def _stdio_envelope(pid: str, number: int) -> dict:
-    # stdio get_decision returns a CallToolResult carrying both the
-    # two-block content list and a typed structuredContent envelope —
-    # see stdio_server module docstring for the contract.
+def _stdio_rendered(pid: str, number: int) -> str:
+    """Return the rendered stdio surface text for the parity comparison.
+
+    Renderer-scoped read tools now return a single ``content[0]`` block
+    carrying the renderer output. Parity against the direct tool envelope
+    runs through ``RENDERERS["get_decision"]``.
+    """
     result = stdio_get_decision(number=number, project_id=pid)
-    envelope = json.loads(result.content[1].text)
-    assert result.structuredContent == envelope
-    return envelope
+    assert len(result.content) == 1
+    assert result.structuredContent is None
+    return result.content[0].text
 
 
 def _tool_envelope(store_path: Path, number: int) -> dict:
@@ -64,14 +67,13 @@ def _tool_envelope(store_path: Path, number: int) -> dict:
 
 def test_stdio_and_tool_match_on_success_path(demo_repo):
     pid, store_path = demo_repo
-    stdio = _stdio_envelope(pid, EXISTING_NUMBER)
     tool = _tool_envelope(store_path, EXISTING_NUMBER)
-    assert stdio == tool
+    assert _stdio_rendered(pid, EXISTING_NUMBER) == RENDERERS["get_decision"](tool)
 
 
 def test_success_envelope_carries_content(demo_repo):
-    pid, _ = demo_repo
-    envelope = _stdio_envelope(pid, EXISTING_NUMBER)
+    _pid, store_path = demo_repo
+    envelope = _tool_envelope(store_path, EXISTING_NUMBER)
     assert envelope["store"] == "local"
     assert "content" in envelope
     assert envelope["content"]
@@ -81,11 +83,10 @@ def test_success_envelope_carries_content(demo_repo):
 
 def test_not_found_envelope_matches_across_surfaces(demo_repo):
     pid, store_path = demo_repo
-    stdio = _stdio_envelope(pid, MISSING_NUMBER)
     tool = _tool_envelope(store_path, MISSING_NUMBER)
-    assert stdio == tool
+    assert _stdio_rendered(pid, MISSING_NUMBER) == RENDERERS["get_decision"](tool)
     # Locked rejection envelope shape.
-    assert stdio["store"] == "local"
-    assert "content" not in stdio
-    assert stdio["error"]["kind"] == "error"
-    assert str(MISSING_NUMBER) in stdio["error"]["reason"]
+    assert tool["store"] == "local"
+    assert "content" not in tool
+    assert tool["error"]["kind"] == "error"
+    assert str(MISSING_NUMBER) in tool["error"]["reason"]

--- a/packages/nauro/tests/test_list_decisions_parity.py
+++ b/packages/nauro/tests/test_list_decisions_parity.py
@@ -19,7 +19,6 @@ Two compressions vs. the ``check_decision`` parity test:
 
 from __future__ import annotations
 
-import json
 from datetime import date
 from pathlib import Path
 
@@ -30,6 +29,7 @@ from nauro_core.decision_model import (
     DecisionStatus,
     format_decision,
 )
+from nauro_core.renderers import RENDERERS
 
 from nauro.constants import REPO_CONFIG_MODE_LOCAL
 from nauro.demo import create_demo_project
@@ -65,16 +65,19 @@ def empty_repo(tmp_path, monkeypatch):
     return pid, store_path
 
 
-def _stdio_envelope(pid: str, *, limit: int = 20, include_superseded: bool = False) -> dict:
-    # stdio list_decisions returns a CallToolResult carrying both the
-    # two-block content list and a typed structuredContent envelope —
-    # see stdio_server module docstring for the contract.
+def _stdio_rendered(pid: str, *, limit: int = 20, include_superseded: bool = False) -> str:
+    """Return the rendered stdio surface text for the parity comparison.
+
+    Renderer-scoped read tools now return a single ``content[0]`` block
+    carrying the renderer output. Parity against the direct tool envelope
+    runs through ``RENDERERS["list_decisions"]``.
+    """
     result = stdio_list_decisions(
         project_id=pid, limit=limit, include_superseded=include_superseded
     )
-    envelope = json.loads(result.content[1].text)
-    assert result.structuredContent == envelope
-    return envelope
+    assert len(result.content) == 1
+    assert result.structuredContent is None
+    return result.content[0].text
 
 
 def _tool_envelope(store_path: Path, *, limit: int = 20, include_superseded: bool = False) -> dict:
@@ -84,24 +87,22 @@ def _tool_envelope(store_path: Path, *, limit: int = 20, include_superseded: boo
 
 def test_empty_store_envelope_matches_across_surfaces(empty_repo):
     pid, store_path = empty_repo
-    stdio = _stdio_envelope(pid)
     tool = _tool_envelope(store_path)
-    assert stdio == tool
-    assert stdio == {"store": "local", "decisions": []}
+    assert _stdio_rendered(pid) == RENDERERS["list_decisions"](tool)
+    assert tool == {"store": "local", "decisions": []}
 
 
 def test_populated_store_envelope_matches_across_surfaces(demo_repo):
     pid, store_path = demo_repo
-    stdio = _stdio_envelope(pid)
     tool = _tool_envelope(store_path)
-    assert stdio == tool
+    assert _stdio_rendered(pid) == RENDERERS["list_decisions"](tool)
     # Locked envelope shape: store + decisions list, no error / status keys.
-    assert stdio["store"] == "local"
-    assert isinstance(stdio["decisions"], list)
-    assert stdio["decisions"], "demo project seeds 7 active decisions"
+    assert tool["store"] == "local"
+    assert isinstance(tool["decisions"], list)
+    assert tool["decisions"], "demo project seeds 7 active decisions"
     # All demo decisions are active and seeded with date + decision_type,
     # so every row carries the full set of optional keys.
-    for row in stdio["decisions"]:
+    for row in tool["decisions"]:
         for key in ("number", "title", "date", "status", "type", "confidence"):
             assert key in row, f"missing field {key!r} in row {row!r}"
         assert row["status"] == "active"
@@ -109,17 +110,17 @@ def test_populated_store_envelope_matches_across_surfaces(demo_repo):
 
 def test_include_superseded_toggle_matches_across_surfaces(demo_repo):
     pid, store_path = demo_repo
-    stdio_default = _stdio_envelope(pid, include_superseded=False)
     tool_default = _tool_envelope(store_path, include_superseded=False)
-    assert stdio_default == tool_default
+    assert _stdio_rendered(pid, include_superseded=False) == RENDERERS["list_decisions"](
+        tool_default
+    )
 
-    stdio_with = _stdio_envelope(pid, include_superseded=True)
     tool_with = _tool_envelope(store_path, include_superseded=True)
-    assert stdio_with == tool_with
+    assert _stdio_rendered(pid, include_superseded=True) == RENDERERS["list_decisions"](tool_with)
 
     # Demo project has only active decisions, so both toggles return the
-    # same set; the parity assertion is the load-bearing one.
-    assert stdio_default == stdio_with
+    # same envelope; the parity assertion is the load-bearing one.
+    assert tool_default == tool_with
 
 
 def test_exclude_none_strips_unset_type_across_surfaces(tmp_path, monkeypatch):
@@ -151,11 +152,10 @@ def test_exclude_none_strips_unset_type_across_surfaces(tmp_path, monkeypatch):
     (decisions_dir / "001-decision-without-a-type.md").write_text(body)
     monkeypatch.chdir(repo)
 
-    stdio = _stdio_envelope(pid)
     tool = _tool_envelope(store_path)
-    assert stdio == tool
-    assert len(stdio["decisions"]) == 1
-    row = stdio["decisions"][0]
+    assert _stdio_rendered(pid) == RENDERERS["list_decisions"](tool)
+    assert len(tool["decisions"]) == 1
+    row = tool["decisions"][0]
     assert "type" not in row
     assert row == {
         "number": 1,

--- a/packages/nauro/tests/test_search_decisions_parity.py
+++ b/packages/nauro/tests/test_search_decisions_parity.py
@@ -19,7 +19,6 @@ Two compressions vs. the ``check_decision`` parity test:
 
 from __future__ import annotations
 
-import json
 from datetime import date
 from pathlib import Path
 
@@ -30,6 +29,7 @@ from nauro_core.decision_model import (
     DecisionStatus,
     format_decision,
 )
+from nauro_core.renderers import RENDERERS
 
 from nauro.constants import REPO_CONFIG_MODE_LOCAL
 from nauro.mcp.stdio_server import search_decisions as stdio_search_decisions
@@ -89,14 +89,18 @@ def empty_repo(tmp_path, monkeypatch):
     return pid, store_path
 
 
-def _stdio_envelope(pid: str, query: str, *, limit: int = 10) -> dict:
-    # stdio search_decisions returns a CallToolResult carrying both the
-    # two-block content list and a typed structuredContent envelope —
-    # see stdio_server module docstring for the contract.
+def _stdio_rendered(pid: str, query: str, *, limit: int = 10) -> str:
+    """Return the rendered stdio surface text for the parity comparison.
+
+    Renderer-scoped read tools now return a single ``content[0]`` block
+    carrying the renderer output. The stdio surface participates in
+    parity by emitting the same renderer output the direct tool envelope
+    drives through ``RENDERERS["search_decisions"]``.
+    """
     result = stdio_search_decisions(query=query, limit=limit, project_id=pid)
-    envelope = json.loads(result.content[1].text)
-    assert result.structuredContent == envelope
-    return envelope
+    assert len(result.content) == 1
+    assert result.structuredContent is None
+    return result.content[0].text
 
 
 def _tool_envelope(store_path: Path, query: str, *, limit: int = 10) -> dict:
@@ -106,44 +110,40 @@ def _tool_envelope(store_path: Path, query: str, *, limit: int = 10) -> dict:
 
 def test_hit_envelope_matches_across_surfaces(seeded_repo):
     pid, store_path = seeded_repo
-    stdio = _stdio_envelope(pid, "Auth0")
     tool = _tool_envelope(store_path, "Auth0")
-    assert stdio == tool
-    assert stdio["store"] == "local"
-    assert "results" in stdio
-    assert stdio["results"], "Auth0 query must surface at least one hit"
-    hit = stdio["results"][0]
+    assert _stdio_rendered(pid, "Auth0") == RENDERERS["search_decisions"](tool)
+    assert tool["store"] == "local"
+    assert "results" in tool
+    assert tool["results"], "Auth0 query must surface at least one hit"
+    hit = tool["results"][0]
     # Locked row shape: number, title, status, score are always present;
     # date + relevance_snippet present when populated.
     for key in ("number", "title", "status", "score"):
         assert key in hit, f"missing field {key!r} in row {hit!r}"
     # The dropped envelope keys must not surface.
-    assert "total_matches" not in stdio
-    assert "query" not in stdio
+    assert "total_matches" not in tool
+    assert "query" not in tool
 
 
 def test_empty_store_envelope_matches_across_surfaces(empty_repo):
     pid, store_path = empty_repo
-    stdio = _stdio_envelope(pid, "anything")
     tool = _tool_envelope(store_path, "anything")
-    assert stdio == tool
-    assert stdio == {"store": "local", "results": []}
+    assert _stdio_rendered(pid, "anything") == RENDERERS["search_decisions"](tool)
+    assert tool == {"store": "local", "results": []}
 
 
 def test_empty_query_rejection_matches_across_surfaces(seeded_repo):
     pid, store_path = seeded_repo
-    stdio = _stdio_envelope(pid, "")
     tool = _tool_envelope(store_path, "")
-    assert stdio == tool
-    assert stdio["store"] == "local"
-    assert stdio["results"] == []
-    assert stdio["error"]["kind"] == "rejected"
-    assert "non-empty" in stdio["error"]["reason"]
+    assert _stdio_rendered(pid, "") == RENDERERS["search_decisions"](tool)
+    assert tool["store"] == "local"
+    assert tool["results"] == []
+    assert tool["error"]["kind"] == "rejected"
+    assert "non-empty" in tool["error"]["reason"]
 
 
 def test_limit_truncates_across_surfaces(seeded_repo):
     pid, store_path = seeded_repo
-    stdio = _stdio_envelope(pid, "Auth0 FastAPI", limit=1)
     tool = _tool_envelope(store_path, "Auth0 FastAPI", limit=1)
-    assert stdio == tool
-    assert len(stdio["results"]) <= 1
+    assert _stdio_rendered(pid, "Auth0 FastAPI", limit=1) == RENDERERS["search_decisions"](tool)
+    assert len(tool["results"]) <= 1

--- a/packages/nauro/tests/test_stdio_renderer_wrap.py
+++ b/packages/nauro/tests/test_stdio_renderer_wrap.py
@@ -1,10 +1,8 @@
 """Block-shape contract for the local stdio MCP read tools.
 
-Read tools listed in ``nauro_core.renderers.RENDERERS`` return a
-``CallToolResult`` carrying both ``content`` (two ``TextContent`` blocks:
-a human-formatted summary at ``[0]`` and the JSON envelope at ``[1]``)
-and ``structuredContent`` (the same envelope as a typed dict for clients
-on the 2025-06-18 protocol revision and later). Write tools,
+Renderer-scoped read tools listed in ``nauro_core.renderers.RENDERERS``
+return a ``CallToolResult`` with a single ``TextContent`` block:
+``content[0]`` carries the renderer output. Write tools,
 ``get_raw_file``, ``diff_since_last_session``, and pre-resolution error
 responses stay single-block (or stay strings).
 
@@ -65,105 +63,83 @@ def seeded_store(tmp_path: Path, monkeypatch) -> Path:
     return store_path
 
 
-class TestTwoBlockReadTools:
-    """Renderer-scoped read tools return ``[human, json]`` content blocks."""
+class TestSingleBlockReadTools:
+    """Renderer-scoped read tools return a single rendered ``content[0]`` block."""
 
-    def test_get_context_returns_two_blocks(self, seeded_store: Path):
+    def test_get_context_returns_single_block(self, seeded_store: Path):
         result = get_context(project_id="blockshape", level=0)
         assert isinstance(result, CallToolResult)
         blocks = result.content
-        assert len(blocks) == 2
-        assert all(isinstance(b, TextContent) and b.type == "text" for b in blocks)
-        envelope = json.loads(blocks[1].text)
-        assert envelope["store"] == "local"
-        # Local stdio uses `content` (kernel GetContextResult field name);
-        # remote uses `context`. The shared renderer accepts both.
-        assert "content" in envelope
-        # Human block carries the L0 markdown headers verbatim.
+        assert len(blocks) == 1
+        assert isinstance(blocks[0], TextContent) and blocks[0].type == "text"
+        # Rendered block carries the L0 markdown headers verbatim.
         assert "## Current State" in blocks[0].text
 
-    def test_list_decisions_returns_two_blocks(self, seeded_store: Path):
+    def test_list_decisions_returns_single_block(self, seeded_store: Path):
         result = list_decisions(project_id="blockshape")
         assert isinstance(result, CallToolResult)
         blocks = result.content
-        assert len(blocks) == 2
-        envelope = json.loads(blocks[1].text)
-        assert envelope["store"] == "local"
-        assert "decisions" in envelope
-        # Human block carries the D001 label for the seeded decision.
+        assert len(blocks) == 1
+        # Rendered block carries the D001 label for the seeded decision.
         assert "D001" in blocks[0].text
 
-    def test_get_decision_returns_two_blocks(self, seeded_store: Path):
+    def test_get_decision_returns_single_block(self, seeded_store: Path):
         # scaffold_project_store seeds D001 (initial-setup); the fixture
         # appends D002 = "Use FastAPI". Ask for D002 so the title
         # assertion is independent of the scaffold's seed text.
         result = get_decision(number=2, project_id="blockshape")
         assert isinstance(result, CallToolResult)
         blocks = result.content
-        assert len(blocks) == 2
-        envelope = json.loads(blocks[1].text)
-        assert envelope["store"] == "local"
-        assert "content" in envelope
-        # Title surfaces in the human block.
+        assert len(blocks) == 1
+        # Title surfaces in the rendered block.
         assert "Use FastAPI" in blocks[0].text
 
-    def test_search_decisions_returns_two_blocks(self, seeded_store: Path):
+    def test_search_decisions_returns_single_block(self, seeded_store: Path):
         result = search_decisions(query="FastAPI", project_id="blockshape")
         assert isinstance(result, CallToolResult)
         blocks = result.content
-        assert len(blocks) == 2
-        envelope = json.loads(blocks[1].text)
-        assert envelope["store"] == "local"
-        assert "results" in envelope
-        # Human block echoes the query and surfaces the D### label.
+        assert len(blocks) == 1
+        # Rendered block echoes the query and surfaces the D### label.
         assert "FastAPI" in blocks[0].text
 
-    def test_check_decision_returns_two_blocks(self, seeded_store: Path):
+    def test_check_decision_returns_single_block(self, seeded_store: Path):
         result = check_decision(
             proposed_approach="Use FastAPI with async endpoints for the API server",
             project_id="blockshape",
         )
         assert isinstance(result, CallToolResult)
         blocks = result.content
-        assert len(blocks) == 2
-        envelope = json.loads(blocks[1].text)
-        assert envelope["store"] == "local"
-        assert "related_decisions" in envelope
+        assert len(blocks) == 1
+        # Renderer emits a "top match" / BM25 line when at least one hit lands.
+        assert "top match" in blocks[0].text or "BM25" in blocks[0].text
 
 
-class TestStructuredContentParity:
-    """Renderer-scoped read tools must emit ``structuredContent`` mirroring
-    the JSON envelope at ``content[1].text``. Clients on the 2025-06-18
-    protocol revision read the structured field; older clients fall back
-    to the JSON-as-text block."""
+class TestNoStructuredContent:
+    """Renderer-scoped read tools must not emit ``structuredContent`` —
+    the wire shape is a single text block carrying the renderer output."""
 
-    def test_get_context_structured_matches_json_envelope(self, seeded_store: Path):
+    def test_get_context_has_no_structured_content(self, seeded_store: Path):
         result = get_context(project_id="blockshape", level=0)
-        assert isinstance(result.structuredContent, dict)
-        assert result.structuredContent == json.loads(result.content[1].text)
+        assert result.structuredContent is None
 
-    def test_list_decisions_structured_matches_json_envelope(self, seeded_store: Path):
+    def test_list_decisions_has_no_structured_content(self, seeded_store: Path):
         result = list_decisions(project_id="blockshape")
-        assert isinstance(result.structuredContent, dict)
-        assert result.structuredContent == json.loads(result.content[1].text)
+        assert result.structuredContent is None
 
-    def test_get_decision_structured_matches_json_envelope(self, seeded_store: Path):
+    def test_get_decision_has_no_structured_content(self, seeded_store: Path):
         result = get_decision(number=2, project_id="blockshape")
-        assert isinstance(result.structuredContent, dict)
-        assert result.structuredContent == json.loads(result.content[1].text)
+        assert result.structuredContent is None
 
-    def test_search_decisions_structured_matches_json_envelope(self, seeded_store: Path):
+    def test_search_decisions_has_no_structured_content(self, seeded_store: Path):
         result = search_decisions(query="FastAPI", project_id="blockshape")
-        assert isinstance(result.structuredContent, dict)
-        assert result.structuredContent == json.loads(result.content[1].text)
+        assert result.structuredContent is None
 
-    def test_check_decision_structured_matches_json_envelope(self, seeded_store: Path):
+    def test_check_decision_has_no_structured_content(self, seeded_store: Path):
         result = check_decision(
             proposed_approach="Use FastAPI with async endpoints for the API server",
             project_id="blockshape",
         )
-        assert isinstance(result.structuredContent, dict)
-        assert result.structuredContent == json.loads(result.content[1].text)
+        assert result.structuredContent is None
 
 
 class TestSingleBlockReads:
@@ -212,30 +188,24 @@ class TestSingleBlockWrites:
 
 
 class TestErrorAndFallbackPaths:
-    """Renderer-scoped tools that hit a structured error envelope still
-    emit two blocks; renderer failures fall back to JSON-only. In both
-    cases ``structuredContent`` still mirrors the JSON envelope."""
+    """Renderer-scoped tools keep the single-block shape on structured
+    error envelopes and renderer failures alike."""
 
-    def test_overlong_check_decision_keeps_two_blocks(self, seeded_store: Path):
+    def test_overlong_check_decision_keeps_single_block(self, seeded_store: Path):
         from nauro_core.constants import MAX_APPROACH_LENGTH
 
         overlong = "x" * (MAX_APPROACH_LENGTH + 1)
         result = check_decision(proposed_approach=overlong, project_id="blockshape")
         blocks = result.content
-        assert len(blocks) == 2
-        # Human block leads with the Error: header.
+        assert len(blocks) == 1
+        # Rendered block leads with the Error: header.
         assert blocks[0].text.startswith("Error:")
-        envelope = json.loads(blocks[1].text)
-        assert envelope["error"]["kind"] == "rejected"
-        # The structured field mirrors the same envelope verbatim.
-        assert result.structuredContent == envelope
+        assert result.structuredContent is None
 
     def test_renderer_failure_falls_back_to_json_only(self, seeded_store: Path, monkeypatch):
         """If a renderer raises unexpectedly, the wrapper must not lose
         the response; it falls back to a single JSON block so programmatic
-        consumers still get a parseable envelope. ``structuredContent``
-        still carries the same envelope so 2025-06-18 clients keep
-        parsing without depending on the text block."""
+        consumers still get a parseable envelope."""
         import nauro.mcp.stdio_server as stdio_mod
 
         def explode(_result):
@@ -248,19 +218,17 @@ class TestErrorAndFallbackPaths:
         envelope = json.loads(blocks[0].text)
         assert envelope["store"] == "local"
         assert "decisions" in envelope
-        assert result.structuredContent == envelope
+        assert result.structuredContent is None
 
-    def test_pre_resolution_error_still_two_blocks_on_renderer_scope(self, seeded_store: Path):
+    def test_pre_resolution_error_still_single_block_on_renderer_scope(
+        self, seeded_store: Path
+    ):
         """Store-resolution failures inside a renderer-scoped tool flow
-        through the renderer — the human block carries the kernel's
-        guidance string and the JSON block carries the error envelope."""
+        through the renderer wrapper and surface as a single-block shape
+        with no ``structuredContent``."""
         # Unknown project_id triggers StoreResolutionError; the function
-        # still wraps the error dict via the renderer (Error: ... header).
+        # still wraps the error dict via the renderer.
         result = get_context(project_id="does-not-exist")
         blocks = result.content
-        assert len(blocks) == 2
-        envelope = json.loads(blocks[1].text)
-        assert envelope["store"] == "local"
-        assert envelope["status"] == "error"
-        assert "guidance" in envelope
-        assert result.structuredContent == envelope
+        assert len(blocks) == 1
+        assert result.structuredContent is None

--- a/packages/nauro/tests/test_stdio_renderer_wrap.py
+++ b/packages/nauro/tests/test_stdio_renderer_wrap.py
@@ -220,9 +220,7 @@ class TestErrorAndFallbackPaths:
         assert "decisions" in envelope
         assert result.structuredContent is None
 
-    def test_pre_resolution_error_still_single_block_on_renderer_scope(
-        self, seeded_store: Path
-    ):
+    def test_pre_resolution_error_still_single_block_on_renderer_scope(self, seeded_store: Path):
         """Store-resolution failures inside a renderer-scoped tool flow
         through the renderer wrapper and surface as a single-block shape
         with no ``structuredContent``."""

--- a/packages/nauro/tests/test_stdio_server.py
+++ b/packages/nauro/tests/test_stdio_server.py
@@ -1,6 +1,5 @@
 """Tests for the Nauro MCP stdio server tools."""
 
-import json
 from pathlib import Path
 from unittest.mock import patch
 
@@ -27,19 +26,16 @@ from nauro.templates.scaffolds import scaffold_project_store
 from tests._writer_compat import append_decision
 
 
-def _envelope(result: CallToolResult) -> dict:
-    """Decode the JSON envelope from a renderer-wrapped read-tool response.
+def _rendered(result: CallToolResult) -> str:
+    """Return the renderer output from a renderer-wrapped read-tool response.
 
-    Read tools listed in ``nauro_core.renderers.RENDERERS`` return a
-    ``CallToolResult`` carrying two text content blocks (human-formatted
-    summary at ``[0]``, JSON envelope at ``[1]``) and a typed
-    ``structuredContent`` dict mirroring that envelope. Tests that need
-    the structured envelope decode ``content[1].text`` and validate
-    parity with ``structuredContent`` in one shot.
+    Renderer-scoped read tools listed in ``nauro_core.renderers.RENDERERS``
+    return a ``CallToolResult`` carrying a single ``TextContent`` block at
+    ``content[0]`` whose text is the renderer output. Tests that need to
+    assert on the rendered surface use this helper to skip the boilerplate.
     """
-    envelope = json.loads(result.content[1].text)
-    assert result.structuredContent == envelope
-    return envelope
+    assert len(result.content) == 1
+    return result.content[0].text
 
 
 def _append_question(store_path: Path, question: str) -> None:
@@ -99,27 +95,27 @@ class TestResolveStore:
 
 class TestGetContext:
     def test_l0_returns_current_state(self, store: Path):
-        result = _envelope(get_context(project_id="testproj", level=0))
-        assert "## Current State" in result["content"]
+        rendered = _rendered(get_context(project_id="testproj", level=0))
+        assert "## Current State" in rendered
 
     def test_l1_returns_full_stack(self, store: Path):
-        result = _envelope(get_context(project_id="testproj", level=1))
-        assert "# Stack" in result["content"]
-        assert "Python 3.11" in result["content"]
+        rendered = _rendered(get_context(project_id="testproj", level=1))
+        assert "# Stack" in rendered
+        assert "Python 3.11" in rendered
 
     def test_l2_returns_full_content(self, store: Path):
-        result = _envelope(get_context(project_id="testproj", level=2))
-        assert "Use FastAPI" in result["content"]
-        assert "Should we add caching?" in result["content"]
+        rendered = _rendered(get_context(project_id="testproj", level=2))
+        assert "Use FastAPI" in rendered
+        assert "Should we add caching?" in rendered
 
     def test_invalid_level_rejection(self, store: Path):
         # Invalid numeric levels surface as a kernel rejection envelope —
+        # the renderer surfaces the rejection reason in its Error: block.
         # `_coerce_level` rejects strings before reaching the kernel, so the
         # ValueError path on string input is exercised separately below.
-        result = _envelope(get_context(project_id="testproj", level=5))
-        assert result["store"] == "local"
-        assert result["error"]["kind"] == "rejected"
-        assert "Invalid level" in result["error"]["reason"]
+        rendered = _rendered(get_context(project_id="testproj", level=5))
+        assert rendered.startswith("Error:")
+        assert "Invalid level" in rendered
 
     def test_invalid_string_level_raises(self, store: Path):
         with pytest.raises(ValueError, match="Invalid level"):
@@ -311,14 +307,15 @@ class TestConfirmDecision:
 
 class TestCheckDecision:
     def test_check_no_conflicts(self, store: Path):
-        result = _envelope(
+        rendered = _rendered(
             check_decision(
                 proposed_approach="Use a completely novel distributed tracing approach",
                 project_id="testproj",
             )
         )
-        assert "related_decisions" in result
-        assert "assessment" in result
+        # Renderer surfaces either the "Found N related decisions" header
+        # plus a call-to-action footer, or the empty-state guidance.
+        assert "related decision" in rendered.lower() or "no related decisions" in rendered.lower()
 
 
 class TestFlagQuestion:


### PR DESCRIPTION
## Why

Renderer-scoped read tools across both MCP transports emitted three
parallel representations: a rendered `content[0]` block, a JSON envelope
at `content[1]`, and a typed `structuredContent` dict. The intent was
that clients on protocol revision 2025-06-18+ would read
`structuredContent` and could hide it from model context; older clients
would fall back to `content[1].text`. The premise turned out to be
inverted on every dominant client today.

Direct stdio probe against `nauro serve --stdio` confirmed Claude Code
drops `content[]` entirely from both UI and model context whenever
`structuredContent` is present, leaving the rendered summary out of the
user-visible surface. Cross-client research (May 2026) showed the same
bug in VS Code Copilot Chat MCP and OpenAI Codex; Cursor staff publicly
recommend "return data directly in the text response rather than relying
on structuredContent." The MCP SEP-1624 in-progress clarification
explicitly reinforces that returning only `content` is valid, and the
2025-06-18 spec's own first `tools/call` example is a single TextContent
block with no structuredContent.

Workspace grep confirmed `content[1]` was never load-bearing outside
test code — no CLI, agent, subagent, or pareto orchestrator parsed it.
The "older clients pinned to the prior transitional shape" framing in
the docstrings was a hedge for non-existent consumers.

## Approach

Collapse renderer-scoped read tools to a single `content[0]` text block
carrying the renderer output. Keep protocol negotiation at 2025-06-18
and the initialize-time client-info logger — both remain correct and
give us the observation surface to re-evaluate later. Renderer-failure
fallback stays single-block with a JSON dump of the result so a
presentation bug never swallows a response.

Alternatives considered and rejected: keep `structuredContent` and drop
only `content[1]` (Claude Code still drops content[]); keep `content[1]`
and drop only `structuredContent` (reintroduces the ~2,500-char JSON
wall per call with no non-test consumer); conditional wire shape per
negotiated protocolVersion (two surfaces to test, picks the broken path
for the highest version); wait for upstream client fixes (inverts the
'migrate while free' principle).

This mirrors the spec's 2025-06-18 example and the universal
lowest-common-denominator across MCP clients today. `structuredContent`
re-adds under a fresh decision when upstream client shadowing bugs are
fixed and a concrete consumer needs typed envelopes back.

Decisions: D218 (supersedes D217), D219 (supersedes D216)

## What changed

- `packages/nauro/src/nauro/mcp/stdio_server.py::_wrap_with_renderer` —
  returns `CallToolResult(content=[TextContent(text=rendered)])` on the
  success path. Renderer-missing and renderer-failure paths return a
  single JSON content[0] block. Module docstring rewritten.
- `packages/nauro-core/src/nauro_core/renderers.py` — module docstring
  updated to describe the single-block dispatch contract; no renderer
  behavior change.
- Migrated tests: `test_stdio_renderer_wrap.py`, `test_stdio_server.py`,
  and five parity tests (`test_check_decision_parity.py`,
  `test_search_decisions_parity.py`, `test_get_decision_parity.py`,
  `test_list_decisions_parity.py`, `test_get_context_parity.py`).
  Parity tests now assert
  `stdio.content[0].text == RENDERERS[tool_name](tool_envelope)` so
  both surfaces still must agree on the rendered text the renderer
  derives from the shared kernel envelope.

## What to review

- `_wrap_with_renderer` — three paths (success, renderer-missing,
  renderer-failure) must all be single-block with no
  `structuredContent` kwarg.
- Parity re-anchor: the new equality runs through the shared renderer
  module, so a regression in any renderer surfaces here as a parity
  failure. The `test_pre_resolution_error_still_single_block_on_renderer_scope`
  case now only asserts shape (single block + no structuredContent);
  the renderer's handling of the store-error envelope shape is a
  pre-existing characteristic not exercised by the kernel.

## What's deferred

- Re-adding `structuredContent` (and possibly `content[1]`) is gated
  behind two preconditions recorded in the decision body: Anthropic /
  Microsoft / OpenAI ship fixes for the structuredContent-shadowing
  bugs, AND a concrete non-test consumer in the org needs typed
  envelopes back. Neither holds today.
- The local FastAPI `/check_decision` and `/context` endpoints are a
  different surface and were not touched.

## Test plan

- Migrated test files (111 tests): all pass after re-anchoring on the
  renderer-applied envelope.
- Full nauro suite: 1624 passed, 11 skipped.
- Manual stdio probe (`nauro serve --stdio` → `tools/call
  check_decision`): wire response has `len(result.content) == 1` and no
  `structuredContent` field; rendered text matches the expected
  "Found N related decisions" block from
  `RENDERERS["check_decision"]`.
- `ruff format` + `ruff check` clean on all changed files.
