### PR TITLE
fix(cli): add email scope to nauro auth login OAuth request

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/auth.py
+++ b/packages/nauro/src/nauro/cli/commands/auth.py
@@ -35,7 +35,7 @@ DEFAULT_AUTH0_DOMAIN = "dev-q1kuoa1a154u26iw.us.auth0.com"
 DEFAULT_AUTH0_CLIENT_ID = "FoVl59QaztJou17Xqr3e2QYOupAr1Ke3"
 DEFAULT_API_URL = "https://mcp.nauro.ai"
 DEFAULT_AUTH0_AUDIENCE = "https://mcp.nauro.ai/mcp"
-AUTH0_SCOPES = "openid profile offline_access read:context write:context"
+AUTH0_SCOPES = "openid profile email offline_access read:context write:context"
 REDIRECT_PORT = 18457
 REDIRECT_URI = f"http://localhost:{REDIRECT_PORT}/callback"
 


### PR DESCRIPTION
## Why

Without the `email` scope, the access token issued by Auth0 to `nauro auth login` has no `email` or `email_verified` claim. The remote MCP server's identity resolution falls through the email-linking branch and creates a fresh orphan `user_id` with no project memberships — even when the same human owns an existing canonical user via a different Auth0 sub. Subsequent tool calls from that token return `"No projects yet"` / `"forbidden"`.

Surfaced 2026-05-26 when trying to drive doctrine work via direct curl against `mcp.nauro.ai/mcp` with the CLI-issued bearer. The token resolved to an orphan user; `list_projects` returned empty.

## What changed

One-line edit to `packages/nauro/src/nauro/cli/commands/auth.py:38` — `AUTH0_SCOPES` adds `email`.

## Scope

Helps **new** users only. Existing orphan `IDENTITY` rows in DynamoDB keep resolving to their orphan `user_id`; reconciling those requires the deferred account-linking work (still tracked in open-questions.md).

## Test plan

- `uv run pytest packages/nauro/tests/ -x -q` — 1025 passed, 11 skipped.
- `uv run ruff check packages/` + `format --check` — clean.
- No tests assert against the literal scope string (verified via `grep -rn AUTH0_SCOPES packages/nauro/`), so no test updates needed.
- Post-merge functional test: a fresh `nauro auth login` flow on a machine with the deployed CLI should produce a token whose JWT payload includes `email` + `email_verified` claims. From that token, `list_projects` against the cloud MCP returns the user's actual project list (matches what claude.ai connector or Claude Code HTTP transport already returns).
