### PR TITLE
chore(release): bump nauro to 0.9.0 and nauro-core to 0.11.2

### DIFF
--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro-core"
-version = "0.11.1"
+version = "0.11.2"
 description = "Shared pure-Python logic for Nauro: parsing, validation, context assembly, constants."
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro"
-version = "0.8.0"
+version = "0.9.0"
 description = "Local CLI + MCP server: set your project's doctrine once, every connected AI agent inherits it."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Release contents

### nauro 0.8.0 → 0.9.0

- `feat(cli)` auto-generated `propose-decision` and `confirm-decision` commands (#114)
- `feat` emit `structuredContent` for renderer-scoped read tools (#116, #117)
- `fix(cli)` add `email` scope to `nauro auth login` OAuth request (#119) — unblocks new users from the orphan-user identity-resolution trap
- `chore` gitignore local IDE MCP config (#113), remove CONTRIBUTING.md and CODE_OF_CONDUCT.md (#118)

### nauro-core 0.11.1 → 0.11.2

- `feat(renderers)` collapse renderer-scoped read tools to a single `content[]` block; drop the `content[1]` JSON envelope and `structuredContent` typed dict (#117). Renderer registry and per-tool renderers unchanged.

## Constraint check

`nauro`'s `nauro-core>=0.11.0,<0.12` constraint already accepts `0.11.2`. No dependency-constraint change required.

## Release process

After merge, push two tags on the merge commit:
- `nauro-v0.9.0` — triggers `publish-nauro.yml` → PyPI `nauro`
- `nauro-core-v0.11.2` — triggers `publish-nauro-core.yml` → PyPI `nauro-core`

Both publishes are OIDC-gated via the `pypi-nauro` / `pypi-nauro-core` GitHub Environments.

## Test plan

- `uv run pytest packages/ -x -q` — 1624 passed.
- `uv run ruff check packages/` + `format --check` — clean.
- Post-publish: `pipx upgrade nauro` from a clean shell; verify `nauro --version` reports `0.9.0`; run `nauro auth login` and confirm JWT payload now includes `email` + `email_verified` claims.
