### PR TITLE
feat: close the open-questions loop in L0 and flag_question

### DIFF
--- a/packages/nauro-core/src/nauro_core/context.py
+++ b/packages/nauro-core/src/nauro_core/context.py
@@ -7,6 +7,8 @@ can omit project.md for AGENTS.md compatibility) without nauro-core needing
 to know about I/O.
 """
 
+from datetime import datetime, timezone
+
 from nauro_core.constants import (
     L0_DECISIONS_SUMMARY_LIMIT,
     L0_QUESTIONS_LIMIT,
@@ -18,14 +20,59 @@ from nauro_core.parsing import (
     decisions_summary_lines,
     extract_current_state,
     extract_stack_oneliner,
-    parse_questions,
 )
+from nauro_core.questions import EntryBlock, OpenQuestionsFile
 from nauro_core.state import assemble_state_for_context
+
+# Open questions older than this nudge the reader to close or defer.
+# Q-form entries without a minted-at timestamp silently skip the projection
+# until ``flag_question`` starts stamping them.
+_L0_AGE_PROJECTION_DAYS = 30
 
 
 def _active_decisions(decisions: list[Decision]) -> list[Decision]:
     """Filter to active decisions only."""
     return [d for d in decisions if d.status is DecisionStatus.active]
+
+
+def _render_l0_open_questions(content: str) -> str:
+    """Render the first ``L0_QUESTIONS_LIMIT`` open ``EntryBlock``s for L0.
+
+    Walks the parsed block list rather than ``parse_questions`` so the
+    entry's ``timestamp`` survives for the age projection. Entries
+    physically under ``## Resolved`` are skipped via the divider index.
+    A ``(open NN days — consider closing or deferring)`` line is prepended
+    when ``entry.timestamp`` is set and the entry is older than
+    :data:`_L0_AGE_PROJECTION_DAYS`. Q-form entries without a timestamp
+    render without the projection.
+    """
+    if not content.strip():
+        return ""
+
+    parsed = OpenQuestionsFile.parse(content)
+    divider = parsed.resolved_divider_idx
+    today = datetime.now(timezone.utc).date()
+
+    lines: list[str] = []
+    rendered = 0
+    for idx, block in enumerate(parsed.blocks):
+        if divider is not None and idx >= divider:
+            break
+        if not isinstance(block, EntryBlock):
+            continue
+        if block.entry.resolved_by is not None:
+            continue
+        if rendered >= L0_QUESTIONS_LIMIT:
+            break
+        entry = block.entry
+        if entry.timestamp is not None:
+            age_days = (today - entry.timestamp.date()).days
+            if age_days > _L0_AGE_PROJECTION_DAYS:
+                lines.append(f"(open {age_days} days — consider closing or deferring)")
+        lines.extend(entry.render())
+        rendered += 1
+
+    return "\n".join(lines)
 
 
 def _resolve_state(files: dict[str, str]) -> str | None:
@@ -84,10 +131,9 @@ def build_l0(files: dict[str, str], decisions: list[Decision]) -> str:
         sections.append("**Stack:** " + oneliner)
 
     questions_content = files.get("questions.md", "")
-    questions = parse_questions(questions_content)
-    if questions:
-        top = questions[:L0_QUESTIONS_LIMIT]
-        sections.append("## Open Questions\n" + "\n".join(top))
+    rendered_questions = _render_l0_open_questions(questions_content)
+    if rendered_questions:
+        sections.append("## Open Questions\n" + rendered_questions)
 
     active = _active_decisions(decisions)
     if active:

--- a/packages/nauro-core/src/nauro_core/context.py
+++ b/packages/nauro-core/src/nauro_core/context.py
@@ -41,7 +41,7 @@ def _render_l0_open_questions(content: str) -> str:
     Walks the parsed block list rather than ``parse_questions`` so the
     entry's ``timestamp`` survives for the age projection. Entries
     physically under ``## Resolved`` are skipped via the divider index.
-    A ``(open NN days — consider closing or deferring)`` line is prepended
+    A ``(open NN days; consider closing or deferring)`` line is prepended
     when ``entry.timestamp`` is set and the entry is older than
     :data:`_L0_AGE_PROJECTION_DAYS`. Q-form entries without a timestamp
     render without the projection.
@@ -68,7 +68,7 @@ def _render_l0_open_questions(content: str) -> str:
         if entry.timestamp is not None:
             age_days = (today - entry.timestamp.date()).days
             if age_days > _L0_AGE_PROJECTION_DAYS:
-                lines.append(f"(open {age_days} days — consider closing or deferring)")
+                lines.append(f"(open {age_days} days; consider closing or deferring)")
         lines.extend(entry.render())
         rendered += 1
 

--- a/packages/nauro-core/src/nauro_core/mcp_tools.py
+++ b/packages/nauro-core/src/nauro_core/mcp_tools.py
@@ -428,7 +428,15 @@ CONFIRM_DECISION: ToolSpec = {
         "Only needed when propose_decision returns status=pending_confirmation. "
         "The confirm_id expires after 10 minutes — if it has expired, call "
         "propose_decision again to get a fresh id. Calling confirm_decision "
-        "twice with the same id is safe; only the first call writes."
+        "twice with the same id is safe; only the first call writes.\n"
+        "\n"
+        "On the cloud HTTP MCP, treat each propose→confirm as a single "
+        "uninterrupted pair: call confirm_decision before issuing another "
+        "propose_decision (or any other write). Pending state lives in "
+        "process memory on the serving instance; interleaving writes can "
+        "land the confirm on a different instance and surface as an "
+        '"Invalid or expired confirm_id" error well inside the 10-minute '
+        "TTL. The local stdio MCP has no equivalent constraint."
     ),
     "annotations": {**_WRITE_ANNOTATIONS, "idempotentHint": True},
     "input_schema": {
@@ -469,6 +477,20 @@ FLAG_QUESTION: ToolSpec = {
             "context": {
                 "type": "string",
                 "description": "Optional context about why this question matters.",
+            },
+            "targets": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Optional list of candidate question ids (Q### or legacy "
+                    "timestamp form) this flag may duplicate. When any named id "
+                    "is already resolved by a decision, the server short-circuits "
+                    "without appending and the response names the resolving "
+                    "decision. Pass when call_context (e.g. a Q### surfaced in "
+                    "L0 you suspect this flag re-raises) makes the duplicate "
+                    "plausible. Freshness is bounded by the most recent pull, "
+                    "so a remote resolution may be missed by a stale local copy."
+                ),
             },
             "project_id": _PROJECT_PARAM,
         },

--- a/packages/nauro-core/src/nauro_core/operations/flag_question.py
+++ b/packages/nauro-core/src/nauro_core/operations/flag_question.py
@@ -10,12 +10,19 @@ capture, and cloud-sync push stay on the adapter side.
 The insert routine mirrors the pre-cutover writer so the on-disk format
 stays byte-identical: the new entry is placed directly after the file's
 top-level ``# `` header, skipping blank lines and leading HTML comments.
+
+When the caller passes ``targets``, the kernel short-circuits the append
+if any named id already carries a ``resolved_by`` reference, returning a
+rejection envelope naming the resolving decision. Freshness is bounded by
+the working copy the Store sees — on the local stdio surface that is the
+last ``_pull_on_startup`` run; on cloud HTTP MCP it is the per-request
+S3 read.
 """
 
 from __future__ import annotations
 
 from nauro_core.constants import OPEN_QUESTIONS_MD
-from nauro_core.operations.results import FlagQuestionResult
+from nauro_core.operations.results import ErrorPayload, FlagQuestionResult
 from nauro_core.operations.store import Store
 from nauro_core.questions import EntryBlock, OpenQuestionsFile
 
@@ -26,6 +33,7 @@ def flag_question(
     store: Store,
     question: str,
     context: str | None = None,
+    targets: list[str] | None = None,
 ) -> FlagQuestionResult:
     """Append *question* to ``open-questions.md`` with a fresh ``Q###`` id.
 
@@ -40,18 +48,32 @@ def flag_question(
         context: Reserved for future kernel-side composition. Currently
             unused — the adapter folds context into ``question`` and
             passes ``None`` here so the on-disk format stays unchanged.
+        targets: Optional list of candidate ``Q###`` (or legacy timestamp)
+            ids the caller suspects this question may duplicate. When any
+            named id is found in the file with ``resolved_by`` set, the
+            kernel short-circuits and returns a rejection envelope naming
+            the resolving decision. ``None`` and ``[]`` skip the check and
+            always append. Unknown ids are ignored — the only signal is
+            "this id exists and points at a decision."
 
     Returns:
-        :class:`FlagQuestionResult` with ``status="ok"`` and ``num`` set
-        to the newly-minted entry's sequential identifier.
+        :class:`FlagQuestionResult`. On the success path ``status="ok"``
+        and ``num`` carries the minted identifier. On the short-circuit
+        path ``status="rejected"`` and ``error`` names the resolving
+        decision; no write occurs.
     """
     del context  # adapter composes context into question; kernel sees one body.
 
     content = store.read_file(OPEN_QUESTIONS_MD) or _DEFAULT_FILE_BODY
+    parsed = OpenQuestionsFile.parse(content)
+
+    if targets:
+        rejection = _short_circuit_if_resolved(parsed, targets)
+        if rejection is not None:
+            return rejection
+
     existing_nums = [
-        b.entry.num
-        for b in OpenQuestionsFile.parse(content).blocks
-        if isinstance(b, EntryBlock) and b.entry.num is not None
+        b.entry.num for b in parsed.blocks if isinstance(b, EntryBlock) and b.entry.num is not None
     ]
     next_num = max(existing_nums, default=0) + 1
     entry = f"- [Q{next_num}] {question}"
@@ -72,3 +94,39 @@ def flag_question(
     store.write_file(OPEN_QUESTIONS_MD, "\n".join(lines))
 
     return FlagQuestionResult(status="ok", num=next_num)
+
+
+def _short_circuit_if_resolved(
+    parsed: OpenQuestionsFile,
+    targets: list[str],
+) -> FlagQuestionResult | None:
+    """Return a rejection result if any ``targets`` id is already resolved.
+
+    Reads the working copy only — freshness is bounded by whatever pull
+    cadence the Store's transport runs (none, on cloud HTTP; ``_pull_on_startup``
+    on local stdio). The check is therefore best-effort by construction:
+    a stale local copy that lacks a fresh remote resolution will fall
+    through to the normal append path.
+    """
+    entries_by_id: dict[str, EntryBlock] = {}
+    for block in parsed.blocks:
+        if isinstance(block, EntryBlock):
+            entries_by_id.setdefault(block.entry.id, block)
+
+    for target in targets:
+        block = entries_by_id.get(target)
+        if block is None or block.entry.resolved_by is None:
+            continue
+        ref = block.entry.resolved_by
+        reason = (
+            f"{target} is already resolved by D{ref.decision_num} on "
+            f"{ref.date.isoformat()}. The flag was not appended. "
+            "Working-copy freshness is bounded by the most recent pull; "
+            "if a newer flag is intended despite the existing resolution, "
+            "resend without targets."
+        )
+        return FlagQuestionResult(
+            status="rejected",
+            error=ErrorPayload(kind="rejected", reason=reason),
+        )
+    return None

--- a/packages/nauro-core/src/nauro_core/operations/flag_question.py
+++ b/packages/nauro-core/src/nauro_core/operations/flag_question.py
@@ -113,6 +113,8 @@ def _short_circuit_if_resolved(
         if isinstance(block, EntryBlock):
             entries_by_id.setdefault(block.entry.id, block)
 
+    # Iterate ``targets`` in caller order; the first resolved hit wins the
+    # rejection envelope. Priority belongs to the caller, not file position.
     for target in targets:
         block = entries_by_id.get(target)
         if block is None or block.entry.resolved_by is None:

--- a/packages/nauro-core/src/nauro_core/operations/results.py
+++ b/packages/nauro-core/src/nauro_core/operations/results.py
@@ -212,16 +212,19 @@ class FlagQuestionResult(BaseModel):
     """Return shape for :func:`nauro_core.operations.flag_question`.
 
     ``status="ok"`` signals the kernel appended a new ``Q###`` entry to
-    ``open-questions.md``. ``num`` carries the minted identifier. The
-    error path stays unset on the kernel side; length validation,
-    envelope-token rejection, and similarity hinting live on the adapter
-    and surface through a separate envelope shape. ``store`` is not part
-    of the model; transport adapters add it back at serialization time.
+    ``open-questions.md``; ``num`` carries the minted identifier.
+    ``status="rejected"`` signals the caller passed ``targets`` naming
+    an already-resolved id, so the append was short-circuited; ``error``
+    names the resolving decision and ``num`` stays unset. Length
+    validation, envelope-token rejection, and similarity hinting still
+    live on the adapter and surface through a separate envelope shape.
+    ``store`` is not part of the model; transport adapters add it back
+    at serialization time.
     """
 
     model_config = ConfigDict(frozen=True, extra="forbid")
 
-    status: Literal["ok"] = "ok"
+    status: Literal["ok", "rejected"] = "ok"
     num: int | None = None
     error: ErrorPayload | None = None
 

--- a/packages/nauro-core/tests/operations/test_operations_flag_question.py
+++ b/packages/nauro-core/tests/operations/test_operations_flag_question.py
@@ -139,6 +139,112 @@ def test_store_field_absent_from_result_model_dump() -> None:
     assert "store" not in dumped
 
 
+# --- targets short-circuit ---
+
+
+def _resolved_q5_seed() -> str:
+    return (
+        "# Open Questions\n"
+        "\n"
+        "- [Q1] still open\n"
+        "- [Resolved by D42 on 2026-05-20] [Q5] already resolved by D42\n"
+        "\n"
+        "## Resolved\n"
+    )
+
+
+def test_targets_pointing_at_resolved_entry_short_circuits() -> None:
+    store = InMemoryStore(files={OPEN_QUESTIONS_MD: _resolved_q5_seed()})
+    before = store.read_file(OPEN_QUESTIONS_MD)
+    result = flag_question(store, "duplicate of Q5", targets=["Q5"])
+    assert result.status == "rejected"
+    assert result.num is None
+    assert result.error is not None
+    assert result.error.kind == "rejected"
+    assert "D42" in result.error.reason
+    # No write happened on the rejection path.
+    assert store.read_file(OPEN_QUESTIONS_MD) == before
+
+
+def test_targets_pointing_at_open_entry_appends_normally() -> None:
+    seed = "# Open Questions\n\n- [Q1] still open\n- [Q5] also still open\n"
+    store = InMemoryStore(files={OPEN_QUESTIONS_MD: seed})
+    result = flag_question(store, "follow-up to Q5", targets=["Q5"])
+    assert result.status == "ok"
+    assert result.num == 6
+    content = store.read_file(OPEN_QUESTIONS_MD)
+    assert content is not None
+    assert "- [Q6] follow-up to Q5" in content
+
+
+def test_targets_with_unknown_id_falls_through_and_appends() -> None:
+    seed = "# Open Questions\n\n- [Q1] only known id\n"
+    store = InMemoryStore(files={OPEN_QUESTIONS_MD: seed})
+    result = flag_question(store, "new flag", targets=["Q99"])
+    assert result.status == "ok"
+    assert result.num == 2
+
+
+def test_targets_none_skips_short_circuit_check() -> None:
+    """``targets=None`` is the back-compat path; existing callers see no
+    change. A resolved id in the file is ignored when targets isn't passed."""
+    store = InMemoryStore(files={OPEN_QUESTIONS_MD: _resolved_q5_seed()})
+    result = flag_question(store, "unrelated flag")
+    assert result.status == "ok"
+    # Q5 stays the highest existing num; mint Q6.
+    assert result.num == 6
+
+
+def test_targets_empty_list_skips_short_circuit_check() -> None:
+    store = InMemoryStore(files={OPEN_QUESTIONS_MD: _resolved_q5_seed()})
+    result = flag_question(store, "unrelated flag", targets=[])
+    assert result.status == "ok"
+    assert result.num == 6
+
+
+def test_targets_with_multiple_ids_first_resolved_wins() -> None:
+    """When more than one id matches, the kernel rejects on the first
+    already-resolved hit and names that decision in the envelope."""
+    seed = (
+        "# Open Questions\n"
+        "\n"
+        "- [Resolved by D42 on 2026-05-20] [Q5] resolved by D42\n"
+        "- [Resolved by D77 on 2026-05-21] [Q7] resolved by D77\n"
+    )
+    store = InMemoryStore(files={OPEN_QUESTIONS_MD: seed})
+    result = flag_question(store, "dup", targets=["Q5", "Q7"])
+    assert result.status == "rejected"
+    assert result.error is not None
+    # The envelope names the first matched id's resolving decision.
+    assert "Q5" in result.error.reason
+    assert "D42" in result.error.reason
+
+
+def test_targets_with_legacy_timestamp_id_short_circuits() -> None:
+    """Short-circuit treats legacy timestamp ids the same as Q### ids."""
+    seed = (
+        "# Open Questions\n"
+        "\n"
+        "- [Resolved by D99 on 2026-05-10] "
+        "[2026-04-30 10:00 UTC] legacy resolved\n"
+    )
+    store = InMemoryStore(files={OPEN_QUESTIONS_MD: seed})
+    result = flag_question(store, "dup", targets=["2026-04-30 10:00 UTC"])
+    assert result.status == "rejected"
+    assert result.error is not None
+    assert "D99" in result.error.reason
+
+
+def test_short_circuit_envelope_mentions_working_copy_freshness() -> None:
+    """The rejection envelope must call out the working-copy freshness
+    bound so callers know stale local state may miss a remote resolution."""
+    store = InMemoryStore(files={OPEN_QUESTIONS_MD: _resolved_q5_seed()})
+    result = flag_question(store, "dup", targets=["Q5"])
+    assert result.status == "rejected"
+    assert result.error is not None
+    assert "pull" in result.error.reason.lower()
+
+
 # --- Import-graph negative constraint ---
 #
 # The kernel must not depend on snapshot capture, sync hooks, or

--- a/packages/nauro-core/tests/test_context.py
+++ b/packages/nauro-core/tests/test_context.py
@@ -1,6 +1,7 @@
 """Tests for nauro_core.context — L0/L1/L2 context assembly."""
 
 from datetime import date as _date
+from datetime import datetime, timedelta, timezone
 
 from nauro_core.context import build_l0, build_l1, build_l2
 from nauro_core.decision_model import (
@@ -44,12 +45,12 @@ FULL_FILES = {
     ),
     "questions.md": (
         "# Open Questions\n"
-        "- [2026-01-01 UTC] How does auth work?\n"
-        "- [2026-01-02 UTC] What about caching?\n"
-        "- [2026-01-03 UTC] Redis or Memcached?\n"
-        "- [2026-01-04 UTC] Deploy strategy?\n"
-        "- [2026-01-05 UTC] Monitoring setup?\n"
-        "- [2026-01-06 UTC] Sixth question?\n"
+        "- [Q1] How does auth work?\n"
+        "- [Q2] What about caching?\n"
+        "- [Q3] Redis or Memcached?\n"
+        "- [Q4] Deploy strategy?\n"
+        "- [Q5] Monitoring setup?\n"
+        "- [Q6] Sixth question?\n"
     ),
 }
 
@@ -237,3 +238,134 @@ class TestBuildL2:
     def test_state_md_fallback_l2(self):
         result = build_l2(FULL_FILES, [])
         assert "# State" in result
+
+
+def _legacy_id(target_date) -> str:
+    """Render a legacy ``[YYYY-MM-DD HH:MM UTC]`` id for ``target_date``."""
+    return target_date.strftime("%Y-%m-%d") + " 12:00 UTC"
+
+
+class TestBuildL0OpenQuestionsAgeProjection:
+    """L0 prepends an age hint above open questions older than 30 days.
+
+    Walks ``OpenQuestionsFile.parse(...).blocks`` so the entry's
+    ``timestamp`` is available for the age computation. Q-form entries
+    without a minted-at timestamp render without the projection.
+
+    Tests pin the threshold by sourcing ``today`` from the same
+    ``datetime.now(timezone.utc).date()`` the builder uses, so the
+    boundary assertions stay deterministic regardless of wall-clock
+    timezone offsets.
+    """
+
+    _PROJECTION_PREFIX = "(open"
+
+    def _files(self, content: str) -> dict[str, str]:
+        return {"questions.md": content}
+
+    def _today(self):
+        return datetime.now(timezone.utc).date()
+
+    def test_legacy_entry_31_days_old_renders_projection(self):
+        target = self._today() - timedelta(days=31)
+        content = f"# Open Questions\n\n- [{_legacy_id(target)}] Old question?\n"
+        result = build_l0(self._files(content), [])
+        assert "## Open Questions" in result
+        assert "(open 31 days — consider closing or deferring)" in result
+        assert "Old question?" in result
+
+    def test_legacy_entry_29_days_old_skips_projection(self):
+        target = self._today() - timedelta(days=29)
+        content = f"# Open Questions\n\n- [{_legacy_id(target)}] Fresh question?\n"
+        result = build_l0(self._files(content), [])
+        assert "## Open Questions" in result
+        assert "Fresh question?" in result
+        assert self._PROJECTION_PREFIX not in result
+
+    def test_legacy_entry_30_days_old_skips_projection(self):
+        # 30-day boundary: projection fires only on > 30 days (strictly older).
+        # Exactly-30 stays clean so the threshold is not noisily reached on
+        # the first day a question crosses month-old territory.
+        target = self._today() - timedelta(days=30)
+        content = f"# Open Questions\n\n- [{_legacy_id(target)}] Right on the line?\n"
+        result = build_l0(self._files(content), [])
+        assert "Right on the line?" in result
+        assert self._PROJECTION_PREFIX not in result
+
+    def test_q_form_entry_renders_without_projection(self):
+        # Q-form entries do not carry a minted-at timestamp today, so the
+        # projection skips them regardless of age. The gap closes when
+        # flag_question stamps minted-at on Q-form entries (out of scope).
+        content = "# Open Questions\n\n- [Q5] Q-form has no timestamp.\n"
+        result = build_l0(self._files(content), [])
+        assert "Q-form has no timestamp." in result
+        assert self._PROJECTION_PREFIX not in result
+
+    def test_only_first_three_open_entries_render(self):
+        # Honours L0_QUESTIONS_LIMIT (3). The fourth open entry is dropped
+        # even when older than 30 days; the projection doesn't expand the cap.
+        today = self._today()
+        content = (
+            "# Open Questions\n"
+            "\n"
+            f"- [{_legacy_id(today - timedelta(days=40))}] first?\n"
+            f"- [{_legacy_id(today - timedelta(days=35))}] second?\n"
+            f"- [{_legacy_id(today - timedelta(days=33))}] third?\n"
+            f"- [{_legacy_id(today - timedelta(days=60))}] fourth?\n"
+        )
+        result = build_l0(self._files(content), [])
+        assert "first?" in result
+        assert "second?" in result
+        assert "third?" in result
+        assert "fourth?" not in result
+
+    def test_resolved_entries_skipped_in_l0(self):
+        # Entries physically under ## Resolved (position-based partition)
+        # are not L0 surface. They must not render even when fresh.
+        today = self._today()
+        old_id = _legacy_id(today - timedelta(days=60))
+        content = (
+            "# Open Questions\n"
+            "\n"
+            f"- [{_legacy_id(today - timedelta(days=2))}] still open?\n"
+            "\n"
+            "## Resolved\n"
+            "\n"
+            f"- [Resolved by D42 on 2026-05-01] [{old_id}] resolved old?\n"
+        )
+        result = build_l0(self._files(content), [])
+        assert "still open?" in result
+        assert "resolved old?" not in result
+
+    def test_empty_questions_file_renders_nothing(self):
+        result = build_l0(self._files(""), [])
+        assert "## Open Questions" not in result
+
+    def test_projection_appears_above_its_entry(self):
+        # Pin layout: the projection line precedes the entry it nudges,
+        # not below it, so the hint is read before the question body.
+        target = self._today() - timedelta(days=45)
+        content = f"# Open Questions\n\n- [{_legacy_id(target)}] Stale question?\n"
+        result = build_l0(self._files(content), [])
+        proj_idx = result.index("(open 45 days")
+        entry_idx = result.index("Stale question?")
+        assert proj_idx < entry_idx
+
+    def test_mixed_ages_only_old_get_projection(self):
+        today = self._today()
+        content = (
+            "# Open Questions\n"
+            "\n"
+            f"- [{_legacy_id(today - timedelta(days=45))}] Old one?\n"
+            f"- [{_legacy_id(today - timedelta(days=5))}] Recent one?\n"
+        )
+        result = build_l0(self._files(content), [])
+        # Old one carries a projection; recent one does not.
+        assert "(open 45 days" in result
+        assert "Old one?" in result
+        assert "Recent one?" in result
+        # No projection lurks between the old entry and the recent one.
+        recent_idx = result.index("Recent one?")
+        old_idx = result.index("Old one?")
+        between = result[old_idx + len("Old one?") : recent_idx]
+        assert self._PROJECTION_PREFIX not in between

--- a/packages/nauro-core/tests/test_context.py
+++ b/packages/nauro-core/tests/test_context.py
@@ -271,7 +271,7 @@ class TestBuildL0OpenQuestionsAgeProjection:
         content = f"# Open Questions\n\n- [{_legacy_id(target)}] Old question?\n"
         result = build_l0(self._files(content), [])
         assert "## Open Questions" in result
-        assert "(open 31 days — consider closing or deferring)" in result
+        assert "(open 31 days; consider closing or deferring)" in result
         assert "Old question?" in result
 
     def test_legacy_entry_29_days_old_skips_projection(self):

--- a/packages/nauro-core/tests/test_questions.py
+++ b/packages/nauro-core/tests/test_questions.py
@@ -364,6 +364,38 @@ class TestResolve:
         assert result.unknown_ids == ("2026-05-12 20:18 UTC",)
         assert result.file.format() == content
 
+    def test_resolve_mutates_in_place_block_index_preserved(self):
+        """Pin the in-place mutation contract: a resolved entry keeps its
+        position in ``blocks``. ``resolve`` flips ``resolved_by`` on the
+        matching EntryBlock without relocating it under ``## Resolved``.
+        """
+        content = (
+            "# Open Questions\n"
+            "\n"
+            "- [2026-05-12 20:18 UTC] first open\n"
+            "- [2026-05-11 15:29 UTC] second open\n"
+            "- [2026-05-10 09:00 UTC] third open\n"
+        )
+        file = OpenQuestionsFile.parse(content)
+        entry_ids_before = [b.entry.id for b in file.blocks if isinstance(b, EntryBlock)]
+        result = file.resolve(["2026-05-11 15:29 UTC"], 139, date(2026, 5, 14))
+        entry_ids_after = [b.entry.id for b in result.file.blocks if isinstance(b, EntryBlock)]
+        # Block index of every entry stays where it was.
+        assert entry_ids_before == entry_ids_after
+        # The middle entry now carries a resolved_by ref; siblings stay open.
+        flags = [
+            b.entry.resolved_by is not None
+            for b in result.file.blocks
+            if isinstance(b, EntryBlock)
+        ]
+        assert flags == [False, True, False]
+        # The resolved entry's rendered line stays inside the open section
+        # of the file (before the appended divider), reflecting in-place mutation.
+        rendered = result.file.format()
+        resolved_idx = rendered.index("[Resolved by D139 on 2026-05-14]")
+        divider_idx = rendered.index("## Resolved")
+        assert resolved_idx < divider_idx
+
 
 class TestEntryRender:
     def test_open_form(self):

--- a/packages/nauro/src/nauro/mcp/stdio_server.py
+++ b/packages/nauro/src/nauro/mcp/stdio_server.py
@@ -379,6 +379,9 @@ def flag_question(
     context: Annotated[
         str | None, Field(description=_param_desc("flag_question", "context"))
     ] = None,
+    targets: Annotated[
+        list[str] | None, Field(description=_param_desc("flag_question", "targets"))
+    ] = None,
     project_id: Annotated[
         str | None, Field(description=_param_desc("flag_question", "project_id"))
     ] = None,
@@ -390,7 +393,11 @@ def flag_question(
         return WELCOME_NO_PROJECT
     except StoreResolutionError as exc:
         return str(exc)
-    result = tool_flag_question(store_path, question, context)
+    result = tool_flag_question(store_path, question, context, targets=targets)
+    if result.get("status") == "rejected":
+        error = result.get("error") or {}
+        reason = error.get("reason", "Flag rejected.")
+        return reason
     if result.get("hint"):
         return f"{result['hint']} The question has still been logged."
     return "Question flagged."

--- a/packages/nauro/src/nauro/mcp/tools.py
+++ b/packages/nauro/src/nauro/mcp/tools.py
@@ -419,6 +419,7 @@ def tool_flag_question(
     store_path: Path,
     question: str,
     context: str | None = None,
+    targets: list[str] | None = None,
 ) -> dict:
     """Flag an open question for human review. Always writes the question."""
     guidance = _check_store_exists(store_path)
@@ -461,8 +462,7 @@ def tool_flag_question(
     text = question
     if context:
         text = f"{question} (context: {context})"
-    result = _flag_question_op(FilesystemStore(store_path), text, None)
-    capture_snapshot(store_path, trigger=f"question: {question}")
+    result = _flag_question_op(FilesystemStore(store_path), text, None, targets=targets)
 
     response: dict = {"store": "local", **result.model_dump(mode="json", exclude_none=True)}
     # The kernel result carries ``num`` for callers that want the minted id;
@@ -470,6 +470,13 @@ def tool_flag_question(
     # for the local surface envelope. Adapters that want the id can read it
     # from the on-disk file or call the kernel directly.
     response.pop("num", None)
+
+    if result.status == "rejected":
+        # Kernel short-circuit fired; no write happened — skip snapshot and push
+        # so the on-disk store stays untouched and observers see a clean reject.
+        return response
+
+    capture_snapshot(store_path, trigger=f"question: {question}")
     if hint:
         response["hint"] = hint
     _try_push(store_path)

--- a/packages/nauro/tests/test_stdio_server.py
+++ b/packages/nauro/tests/test_stdio_server.py
@@ -336,6 +336,49 @@ class TestFlagQuestion:
         assert "Need auth?" in oq
         assert "For the admin API" in oq
 
+    def test_targets_short_circuits_against_resolved_entry(self, store: Path):
+        """Adapter wires ``targets`` through to the kernel. A flag aimed
+        at an already-resolved id rejects without writing and the
+        returned string carries the resolving decision number."""
+        resolved_seed = (
+            "# Open Questions\n"
+            "\n"
+            "- [Resolved by D42 on 2026-05-20] [Q5] resolved earlier\n"
+            "\n"
+            "## Resolved\n"
+        )
+        (store / "open-questions.md").write_text(resolved_seed)
+        before = (store / "open-questions.md").read_text()
+
+        result = flag_question(
+            project_id="testproj",
+            question="Duplicate of Q5?",
+            targets=["Q5"],
+        )
+
+        # Rejection envelope surfaces as the assertion string for FastMCP.
+        assert "D42" in result
+        assert "Q5" in result
+        # The on-disk file is not mutated on the short-circuit path.
+        assert (store / "open-questions.md").read_text() == before
+
+    def test_targets_with_open_entry_appends_normally(self, store: Path):
+        """When the targeted id is open (not yet resolved), the adapter
+        falls through to the normal append path."""
+        open_seed = "# Open Questions\n\n- [Q5] still open\n"
+        (store / "open-questions.md").write_text(open_seed)
+
+        result = flag_question(
+            project_id="testproj",
+            question="Follow-up to Q5?",
+            targets=["Q5"],
+        )
+
+        # Normal append path returns the success string ("flagged" or hint).
+        assert "flagged" in result.lower() or "addressed" in result.lower()
+        oq = (store / "open-questions.md").read_text()
+        assert "Follow-up to Q5?" in oq
+
 
 class TestUpdateState:
     def test_updates_state(self, store: Path):


### PR DESCRIPTION
## Why

Two pain points surfaced during a multi-decision doctrine session against the cloud Lambda:

1. Agents reflag already-resolved questions because `flag_question` has no way to ask "is this Q### already closed?" before appending. Stale duplicates accumulate in the open-questions file.
2. Open questions older than 30 days sit in the L0 context payload with no nudge toward closure or deferral. The backlog drifts because the agent's audit surface doesn't surface the staleness signal.

Both are inside the existing open-questions workflow — closing them does not require new tools or a new question lifecycle, just the right metadata surfaced in the right place.

A third pain point — the cloud HTTP MCP's `confirm_id` invalidation behavior during batch propose+confirm sequences — needed documentation but not code, since the in-process pending-state architecture is intentional given current scale.

## Approach

Three changes that compose:

1. **L0 question rendering walks the parsed block list** instead of the flat string projection. Legacy-timestamp entries get an `(open NN days; consider closing or deferring)` hint above the entry when age exceeds 30 days. Q-form entries without a minted-at timestamp render without the projection — that gap closes in a separate change when `flag_question` starts stamping minted-at on creation. The block walk also honors the in-place open/resolved partition so entries physically under `## Resolved` correctly stay out of L0.

2. **`flag_question` gains an optional `targets: list[str]` parameter.** When non-empty, the kernel scans the working copy and short-circuits with a structured rejection naming the resolving decision when any named id is already resolved. `FlagQuestionResult` widens to `status: Literal["ok", "rejected"]` with an `ErrorPayload | None` `error` field on the rejection branch — mirrors the propose-side result shape rather than introducing a new envelope variant. The short-circuit reads working-copy state only, so freshness is bounded by the per-surface pull cadence; the rejection envelope says so verbatim.

3. **`CONFIRM_DECISION` ToolSpec description gains a paragraph** on the propose→confirm uninterrupted-pair rule for the cloud HTTP MCP. Pending state is in-process on the serving instance, so interleaving writes can land the confirm on a different instance and surface as an "Invalid or expired confirm_id" error well inside the 10-minute TTL. The local stdio MCP is single-process and unaffected. No kernel change — the underlying lifecycle is intentional under the current architecture.

Alternatives considered for the `flag_question` short-circuit mechanism: heuristic body-scanning for embedded `Q###` references was rejected as brittle; adding a separate pre-check tool was rejected against the "no new write-tool surface" stance and the auto-gen framework's "no per-tool bespoke surface" principle. The kernel-hosted check with an additive optional param on the existing tool was the minimum-viable shape.

For the L0 projection, alternatives included keeping the flat string projection and zip-by-id from a parallel parse (more duplication, no cleaner story) and a per-project configurable threshold (rejected as speculative — 30 days is the working assumption until dogfooding shows otherwise).

## What changed

**Kernel (`packages/nauro-core/`):**
- `src/nauro_core/context.py` — `build_l0` switches to a block-list walk for open questions; new `_render_l0_open_questions` helper.
- `src/nauro_core/operations/flag_question.py` — adds `targets` param + `_short_circuit_if_resolved` helper.
- `src/nauro_core/operations/results.py` — `FlagQuestionResult` widens `status`, adds `error` field.
- `src/nauro_core/mcp_tools.py` — `FLAG_QUESTION` ToolSpec advertises `targets`; `CONFIRM_DECISION` ToolSpec adds the pair-rule paragraph.

**Adapter (`packages/nauro/`):**
- `src/nauro/mcp/tools.py` — `tool_flag_question` accepts and passes `targets` through; skips snapshot capture and push on the rejected path.
- `src/nauro/mcp/stdio_server.py` — FastMCP signature declares `targets`.

**Tests:**
- `packages/nauro-core/tests/test_context.py` — L0 age projection across the 29/30/31 boundary plus empty-file and all-resolved cases.
- `packages/nauro-core/tests/test_questions.py` — pins the in-place mutation contract for `OpenQuestionsFile.resolve` against future drift.
- `packages/nauro-core/tests/operations/test_operations_flag_question.py` — kernel-side short-circuit envelope shape, multi-id `targets`, working-copy freshness note in rejection text.
- `packages/nauro/tests/test_stdio_server.py` — adapter-side short-circuit envelope, including a seed that places the resolved annotation on an entry physically in the open section, exercising the annotation-as-source-of-truth contract for the short-circuit.

## What to review

- The 30-day age boundary uses strict `>` so the day a question crosses the threshold stays clean; tests pin 29/30/31. Time-of-day flake risk near UTC midnight: none — both sides reduce to `.date()` before subtraction. Worth a sanity glance.
- The `flag_question` short-circuit checks `entry.resolved_by` regardless of which side of `## Resolved` the block physically sits on. This anticipates the broader "annotation prefix is the source of truth; physical position is incidental" framing that the supersede of the original `resolves_questions` decision will land in a follow-up PR. The short-circuit test seeds an annotated resolved entry in the open section to pin that contract.
- Working-copy freshness composition: the short-circuit reads the local file, so it's only as fresh as the most recent pull. The rejection envelope's reason text names this constraint verbatim so callers don't conclude an open question is closed when their working copy is stale.
- Multi-target priority: `_short_circuit_if_resolved` iterates `targets` in the order the caller passed them, so the first already-resolved id in caller order wins the rejection envelope. A comment in the helper pins that intent against future refactors.
- The `CONFIRM_DECISION` ToolSpec description gain is documentation only, not a kernel change. The underlying behavior (per-instance in-process pending state on cloud) is intentional under current architecture, not a bug to fix.

## What's deferred

- A first-class `nauro pull` command to close the working-copy-freshness gap structurally. Composes with this PR; not a blocker.
- `flag_question` stamping minted-at timestamps on Q-form entries so the L0 age projection works on them too.
- Supersede of the original `resolves_questions` decision to align its body text with shipped behavior. Lands as a separate one-call PR after this PR merges, so the supersede describes shipped behavior rather than a forward-promise.
- A persisted-pending-state cutover that would allow batched propose+confirm sequences on cloud. Reframes the in-process posture; intentionally deferred until concrete demand surfaces.

## Test plan

- `uv run pytest packages/nauro-core/tests/ -x -q` — 617 tests pass (11 skipped) including the new in-place mutation, L0 projection, and short-circuit kernel cases.
- `uv run pytest packages/nauro/tests/ -x -q` — 1027 tests pass including the new adapter-side short-circuit envelope cases.
- `uv run ruff format --check packages/ && uv run ruff check packages/` — formatting and lints clean.

The mcp-server side of the `flag_question` `targets` wiring ships as a paired PR that does not bump the nauro-core pin in this cycle. Sequencing: this PR merges → nauro-core release cuts → the mcp-server PR rebases on a follow-up that runs `make bump-nauro-core REV=<rev>` to refresh `src/requirements.txt`. The `verify-requirements` CI gate enforces the merge order.
