### PR TITLE
chore(release): bump nauro to 0.10.0 and nauro-core to 0.12.0

### DIFF
--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro-core"
-version = "0.11.2"
+version = "0.12.0"
 description = "Shared pure-Python logic for Nauro: parsing, validation, context assembly, constants."
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro"
-version = "0.9.0"
+version = "0.10.0"
 description = "Local CLI + MCP server: set your project's doctrine once, every connected AI agent inherits it."
 readme = "README.md"
 license = "Apache-2.0"
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "nauro-core>=0.11.0,<0.12",
+    "nauro-core>=0.12.0,<0.13",
     "typer>=0.9",
     "fastapi>=0.100",
     "uvicorn>=0.23",


### PR DESCRIPTION
## Release contents

### nauro 0.9.0 → 0.10.0

- `feat(mcp)` `flag_question` adapter accepts and passes optional `targets: list[str]` through to the kernel; the FastMCP stdio signature exposes the new parameter so claude.ai web and other clients can opt in (#121).
- `feat(mcp)` adapter short-circuits snapshot capture and push on the rejected path when `targets` matches an already-resolved question (#121).
- `chore` widens the `nauro-core` constraint to `>=0.12.0,<0.13` to track the kernel release this depends on.

### nauro-core 0.11.2 → 0.12.0

- `feat(operations)` `flag_question` gains an optional `targets: list[str]` parameter; on non-empty, the kernel parses the working copy and short-circuits with a structured rejection naming the resolving decision when any named id has `resolved_by` set. Honors the annotation-as-source-of-truth contract regardless of physical block position (#121).
- `feat(operations)` `FlagQuestionResult` widens `status` from `Literal["ok"]` to `Literal["ok", "rejected"]` and gains `error: ErrorPayload | None`, mirroring the propose-side rejection envelope shape so adapters can lift the structured error verbatim (#121).
- `feat(context)` `build_l0` switches to a block-list walk for open questions; renders `(open NN days; consider closing or deferring)` above legacy-timestamp entries older than 30 days. Q-form entries without a minted-at timestamp render without projection — that gap closes when `flag_question` starts stamping minted-at (out of scope here) (#121).
- `docs(mcp_tools)` `CONFIRM_DECISION` ToolSpec description gains a sentence on the propose→confirm uninterrupted-pair rule on cloud HTTP MCP; pending state is in-process per serving instance, so interleaving writes can land a confirm on a different instance and surface as "Invalid or expired confirm_id" inside the documented 10-minute TTL (#121).

## Constraint check

`nauro`'s prior `nauro-core>=0.11.0,<0.12` constraint does NOT accept `0.12.0`. This release widens it to `>=0.12.0,<0.13` so the workspace and PyPI installs both resolve to the new kernel.

## Release process

After merge, push two tags on the merge commit:
- `nauro-v0.10.0` — triggers `publish-nauro.yml` → PyPI `nauro`
- `nauro-core-v0.12.0` — triggers `publish-nauro-core.yml` → PyPI `nauro-core`

Both publishes are OIDC-gated via the `pypi-nauro` / `pypi-nauro-core` GitHub Environments.

## Test plan

- `uv run pytest packages/ -x -q` — 1644 passed, 11 skipped.
- `uv run ruff check packages/` + `format --check` — clean.
- Post-publish: `pipx upgrade nauro` from a clean shell; verify `nauro --version` reports `0.10.0`.
- Post-publish: mcp-server PR #58 (`feat/flag-question-targets-passthrough`) gets unblocked; `make bump-nauro-core REV=0.12.0` in mcp-server regenerates `src/requirements.txt` and the `verify-requirements` CI gate allows merge.
