### PR TITLE
fix(setup): refresh stale bundled subagents on install

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/adopt.py
+++ b/packages/nauro/src/nauro/cli/commands/adopt.py
@@ -147,9 +147,10 @@ def adopt(
         False,
         "--force-overwrite",
         help=(
-            "Replace locally-modified ~/.claude/agents/nauro-*.md files when "
-            "--with-subagents is passed. Off by default; without this flag, "
-            "existing files are preserved."
+            "Overwrite ~/.claude/agents/nauro-*.md in place without saving a "
+            ".bak, when --with-subagents is passed. By default, install "
+            "refreshes a differing bundled file and stashes its prior content "
+            "to <name>.md.bak."
         ),
     ),
     with_skills: bool = typer.Option(

--- a/packages/nauro/src/nauro/cli/commands/setup.py
+++ b/packages/nauro/src/nauro/cli/commands/setup.py
@@ -518,10 +518,15 @@ def materialize_skills_cursor_for_repo(
 
 # Subagents are rendered from canonical bodies in nauro.agents and written into
 # the user's surface directories. On Claude Code, that's ``~/.claude/agents/``.
-# Unlike skills, agents are namespaced (``nauro-*``) and opt-in: an existing
-# customized ``nauro-<name>.md`` is preserved unless the caller passes
-# ``force_overwrite=True``. User-authored files without the ``nauro-`` prefix
-# (e.g. a personal ``~/.claude/agents/planner.md``) are never touched.
+# Unlike skills, agents are namespaced (``nauro-*``) and opt-in. The
+# ``nauro-`` namespace is bundle-owned (D177): on install, the current bundle
+# wins, so a published body change (e.g. dropping a removed MCP tool) actually
+# reaches users who installed an earlier version. A pre-existing
+# ``nauro-<name>.md`` that differs from the bundle is refreshed; its prior
+# content is stashed to ``<name>.md.bak`` so the rare hand-customization is
+# recoverable. ``force_overwrite=True`` skips the ``.bak`` and overwrites in
+# place. User-authored files without the ``nauro-`` prefix (e.g. a personal
+# ``~/.claude/agents/planner.md``) are never touched.
 
 
 def materialize_agents(
@@ -540,7 +545,10 @@ def materialize_agents(
     Add path (per agent):
       - file absent → write bundled body.
       - file present and byte-equal → no-op.
-      - file present and differs → preserve unless ``force_overwrite=True``.
+      - file present and differs → refresh from the bundle, stashing the prior
+        content to ``<name>.md.bak`` (the nauro-* namespace is bundle-owned, so
+        a differing file is almost always a stale earlier bundle). Pass
+        ``force_overwrite=True`` to overwrite in place without the ``.bak``.
 
     Remove path (per agent):
       - file absent → skip.
@@ -592,9 +600,10 @@ def materialize_agents(
                 target.write_text(bundled, encoding="utf-8")
                 results.append(f"  overwrote {target}")
             else:
-                results.append(
-                    f"  preserved {target} (locally modified; pass --force-overwrite to replace)"
-                )
+                backup = target.parent / (target.name + ".bak")
+                backup.write_text(current, encoding="utf-8")
+                target.write_text(bundled, encoding="utf-8")
+                results.append(f"  updated {target} (previous saved to {backup.name})")
         else:
             target.parent.mkdir(parents=True, exist_ok=True)
             target.write_text(bundled, encoding="utf-8")
@@ -738,9 +747,10 @@ def all_(
         False,
         "--force-overwrite",
         help=(
-            "Replace locally-modified ~/.claude/agents/nauro-*.md files when "
-            "--with-subagents is passed. Off by default; without this flag, "
-            "existing files are preserved."
+            "Overwrite ~/.claude/agents/nauro-*.md in place without saving a "
+            ".bak, when --with-subagents is passed. By default, install "
+            "refreshes a differing bundled file and stashes its prior content "
+            "to <name>.md.bak."
         ),
     ),
     with_skills: bool = typer.Option(

--- a/packages/nauro/tests/test_adopt.py
+++ b/packages/nauro/tests/test_adopt.py
@@ -196,8 +196,13 @@ def test_adopt_with_subagents_installs_all_four(tmp_path: Path, monkeypatch):
         assert target.read_text(encoding="utf-8") == render_agent("claude_code", name)
 
 
-def test_adopt_with_subagents_preserves_customized_file(tmp_path: Path, monkeypatch):
-    """A locally-modified ``nauro-planner.md`` must be left alone without ``--force-overwrite``."""
+def test_adopt_with_subagents_refreshes_differing_file_with_backup(tmp_path: Path, monkeypatch):
+    """A differing ``nauro-planner.md`` is refreshed from the bundle; prior content goes to .bak.
+
+    The ``nauro-*`` namespace is bundle-owned, so a stale earlier bundle (the
+    common case) is replaced with the current one. The displaced content is
+    recoverable from ``nauro-planner.md.bak`` for the rare hand-edit.
+    """
     _adopt_env(monkeypatch, tmp_path)
     custom = "---\nname: nauro-planner\n---\n\ncustom body\n"
     target = _agent_path(tmp_path, "nauro-planner")
@@ -207,13 +212,15 @@ def test_adopt_with_subagents_preserves_customized_file(tmp_path: Path, monkeypa
     result = runner.invoke(app, ["adopt", "--name", "alpha", "--with-subagents"])
     assert result.exit_code == 0, result.output
 
-    assert target.read_text(encoding="utf-8") == custom
-    assert "preserved" in result.output
-    assert "nauro-planner" in result.output
+    assert target.read_text(encoding="utf-8") == render_agent("claude_code", "nauro-planner")
+    backup = target.parent / (target.name + ".bak")
+    assert backup.read_text(encoding="utf-8") == custom
+    assert "updated" in result.output
+    assert ".bak" in result.output
 
 
-def test_adopt_with_subagents_force_overwrite_replaces_customized_file(tmp_path: Path, monkeypatch):
-    """``--force-overwrite`` replaces a locally-modified bundled agent."""
+def test_adopt_with_subagents_force_overwrite_skips_backup(tmp_path: Path, monkeypatch):
+    """``--force-overwrite`` replaces a differing bundled agent in place, writing no .bak."""
     _adopt_env(monkeypatch, tmp_path)
     custom = "---\nname: nauro-planner\n---\n\ncustom body\n"
     target = _agent_path(tmp_path, "nauro-planner")
@@ -226,6 +233,26 @@ def test_adopt_with_subagents_force_overwrite_replaces_customized_file(tmp_path:
     assert result.exit_code == 0, result.output
 
     assert target.read_text(encoding="utf-8") == render_agent("claude_code", "nauro-planner")
+    assert not (target.parent / (target.name + ".bak")).exists()
+
+
+def test_with_subagents_reinstall_is_idempotent(tmp_path: Path, monkeypatch):
+    """A second install with no bundle change is a no-op — no churned .bak files.
+
+    Driven via ``setup all`` (re-runnable) rather than ``adopt`` (which refuses
+    an already-adopted repo); the materialize-agents code path is shared.
+    """
+    _adopt_env(monkeypatch, tmp_path)
+
+    first = runner.invoke(app, ["adopt", "--name", "alpha", "--with-subagents"])
+    assert first.exit_code == 0, first.output
+
+    result = runner.invoke(app, ["setup", "all", "--with-subagents"])
+    assert result.exit_code == 0, result.output
+
+    target = _agent_path(tmp_path, "nauro-planner")
+    assert "unchanged" in result.output
+    assert not (target.parent / (target.name + ".bak")).exists()
 
 
 def test_adopt_with_subagents_does_not_touch_user_authored_planner_md(tmp_path: Path, monkeypatch):

--- a/packages/nauro/tests/test_agents_drift.py
+++ b/packages/nauro/tests/test_agents_drift.py
@@ -63,6 +63,23 @@ def test_render_agent_claude_code_returns_body(name: str) -> None:
     assert rendered.startswith(f"---\nname: {name}\n")
 
 
+# Retired tool / mechanism names that must never reappear in a rendered agent
+# body. ``confirm_decision`` was removed when propose_decision collapsed to a
+# single-call commit; a stale reference would tell the subagent to call a tool
+# that no longer exists.
+RETIRED_AGENT_PHRASES: tuple[tuple[str, str], ...] = (
+    ("confirm_decision", "confirm_decision was removed; propose_decision is a single-call commit"),
+)
+
+
+@pytest.mark.parametrize("name", list(AGENT_NAMES))
+@pytest.mark.parametrize("phrase,reason", RETIRED_AGENT_PHRASES)
+def test_agent_body_has_no_retired_phrases(name: str, phrase: str, reason: str) -> None:
+    assert phrase not in render_agent("claude_code", name), (
+        f"retired phrase {phrase!r} found in {name}.md: {reason}"
+    )
+
+
 @pytest.mark.parametrize("name", list(AGENT_NAMES))
 def test_render_agent_cursor_raises_not_implemented(name: str) -> None:
     with pytest.raises(NotImplementedError):

--- a/packages/nauro/tests/test_skills_drift.py
+++ b/packages/nauro/tests/test_skills_drift.py
@@ -174,6 +174,10 @@ RETIRED_PHRASES = [
         "Step 5b — Boundary candidates",
         "split into Step 6b (code-evidenced) + Step 6c (stack inventory)",
     ),
+    (
+        "confirm_decision",
+        "confirm_decision was removed; propose_decision is now a single-call commit",
+    ),
 ]
 
 


### PR DESCRIPTION
## Why

A published change to a bundled subagent body never reached users who had installed an earlier version. `materialize_agents` treated any installed `nauro-<name>.md` that byte-differed from the bundle as a user customization and preserved it — a rule written for the rare hand-edit collision. But a legitimate body change makes *every* prior install differ, so the preserve default silently kept the stale version. Concretely: the change that removed the now-deleted `confirm_decision` MCP tool from the subagent bodies never reached an installed `nauro-tech-lead.md` (it still referenced the removed tool four times).

## Approach

Make the `nauro-*` agent namespace bundle-owned on install: the current bundle wins. A differing `nauro-<name>.md` is refreshed from the bundle, with its prior content stashed to `<name>.md.bak` so the rare hand-customization stays recoverable.

Considered and rejected: a hash-history registry that distinguishes a stale prior bundle from a genuine hand-edit and overwrites only known prior renders. Evidence on a real machine showed the only differing file was a byte-exact prior bundle, not a hand-edit (the namespace is designed so customizers use un-prefixed names), so a `.bak` is sufficient insurance at a fraction of the complexity — and the registry would need maintenance on every future body change. Also rejected a one-time migration keyed on the removed tool name: it heals this one removal but not the next silently-stale change.

This reverses the prior preserve-on-collision default; the broader opt-in bundling and namespacing behavior is unchanged.

## What changed

- `cli/commands/setup.py` — the re-install branch in `materialize_agents`: byte-equal is a no-op; a differing file is refreshed with a `.bak`; `--force-overwrite` now means overwrite in place without the `.bak`. Comment + docstring updated.
- `cli/commands/adopt.py` — `--force-overwrite` help text aligned.
- Drift suites (`test_agents_drift.py`, `test_skills_drift.py`) — removed tool names are now banned from every rendered agent body and skill surface, so this class of staleness fails loudly instead of shipping.
- `test_adopt.py` — add-path tests updated to the refresh-with-backup semantics, plus a force-overwrite-skips-backup case and a re-install idempotency case.

## What to review

- The re-install branch in `materialize_agents` — specifically that a `.bak` is only written when content actually differs (no churn on repeated installs).
- That un-prefixed personal files (e.g. `~/.claude/agents/planner.md`) remain untouched — the namespacing guarantee. Test present.

## What's deferred

Skills needed no change — the skill materializer already overwrites unconditionally, so skills self-heal on the next install. The drift guard was still added to the skill surfaces for symmetry.

## Test plan

`uv run pytest packages/nauro/tests/ -q` → 1014 passed, 10 skipped. `ruff check` + `ruff format --check` clean. Verified end-to-end against a copy of a real installed agents directory: the stale `nauro-tech-lead.md` (4 removed-tool references) refreshed to the canonical body (0 references) with its prior content saved to `.bak`; the other three reported `unchanged` with no spurious `.bak`.
