### PR TITLE
fix(agents,skills): resolve filing-ownership contradiction and namespace handoffs

### DIFF
--- a/.agents/skills/nauro-ship-task/SKILL.md
+++ b/.agents/skills/nauro-ship-task/SKILL.md
@@ -47,7 +47,7 @@ A change additionally always gates if any of the following apply:
 
 ### 3. Execute
 
-Invoke the `@nauro-executor` subagent with the approved plan. Include any confirmed decision number from step 1 in the prompt. The executor implements the plan, commits locally, and does not push (per its contract). Any architectural choice the executor makes that the plan did not pre-record gets filed via `propose_decision` at the moment the choice lands in code — not deferred to the end of the chain.
+Invoke the `@nauro-executor` subagent with the approved plan. Include any confirmed decision number from step 1 in the prompt. The executor implements the plan, commits locally, and does not push (per its contract). If the executor hits an architectural choice the plan did not pre-record, it does not file the decision itself — it surfaces the choice and its rationale in its handoff so the parent can gate it with the user (at the push gate, step 7) and route the filing to whoever owns it. A subagent has no user channel mid-run, and `propose_decision` commits on Tier 1 clean, so an executor filing inline would install binding doctrine with no human gate.
 
 ### 4. Local review (no user pause)
 
@@ -84,6 +84,7 @@ On approval, push the branch and open the PR with the drafted description as the
 ## Rules
 
 - Push and `gh pr create` happen only with explicit user approval at GATE 7.
-- `propose_decision` happens only with explicit user approval — the planner / executor / tech-lead draft, the user approves in chat, then the planner files. The kernel commits immediately on Tier 1 clean.
+- `propose_decision` happens only with explicit user approval. Subagents draft or surface decisions; they never file an unapproved one. After the user approves in chat, the originating agent files — the planner for plan-time decisions, `@nauro-tech-lead` for doctrine moves it surfaces in Mode C. The executor never files; it surfaces emergent choices in its handoff (step 3) for the parent to gate. The kernel commits immediately on Tier 1 clean.
+- If a `propose_decision` is pending but the Nauro MCP server is disconnected, that is a hard pause — do not push the PR and file the decision after reconnecting. The code and its decision land together; a push-now-file-later split leaves doctrine unrecorded if the session ends first. Surface the disconnect and wait.
 - If anything fails or surprises mid-chain (a tool errors, tests fail unexpectedly, a verdict is incoherent), stop and surface to the user rather than recovering silently.
 - The chain is doctrine-aware end-to-end: every architectural choice flows through `check_decision` (at planning) and `propose_decision` (when the choice lands, after user approval). Skipping either silently is a chain failure, not a shortcut.

--- a/.claude/skills/nauro-ship-task/SKILL.md
+++ b/.claude/skills/nauro-ship-task/SKILL.md
@@ -47,7 +47,7 @@ A change additionally always gates if any of the following apply:
 
 ### 3. Execute
 
-Invoke the `@nauro-executor` subagent with the approved plan. Include any confirmed decision number from step 1 in the prompt. The executor implements the plan, commits locally, and does not push (per its contract). Any architectural choice the executor makes that the plan did not pre-record gets filed via `propose_decision` at the moment the choice lands in code — not deferred to the end of the chain.
+Invoke the `@nauro-executor` subagent with the approved plan. Include any confirmed decision number from step 1 in the prompt. The executor implements the plan, commits locally, and does not push (per its contract). If the executor hits an architectural choice the plan did not pre-record, it does not file the decision itself — it surfaces the choice and its rationale in its handoff so the parent can gate it with the user (at the push gate, step 7) and route the filing to whoever owns it. A subagent has no user channel mid-run, and `propose_decision` commits on Tier 1 clean, so an executor filing inline would install binding doctrine with no human gate.
 
 ### 4. Local review (no user pause)
 
@@ -84,6 +84,7 @@ On approval, push the branch and open the PR with the drafted description as the
 ## Rules
 
 - Push and `gh pr create` happen only with explicit user approval at GATE 7.
-- `propose_decision` happens only with explicit user approval — the planner / executor / tech-lead draft, the user approves in chat, then the planner files. The kernel commits immediately on Tier 1 clean.
+- `propose_decision` happens only with explicit user approval. Subagents draft or surface decisions; they never file an unapproved one. After the user approves in chat, the originating agent files — the planner for plan-time decisions, `@nauro-tech-lead` for doctrine moves it surfaces in Mode C. The executor never files; it surfaces emergent choices in its handoff (step 3) for the parent to gate. The kernel commits immediately on Tier 1 clean.
+- If a `propose_decision` is pending but the Nauro MCP server is disconnected, that is a hard pause — do not push the PR and file the decision after reconnecting. The code and its decision land together; a push-now-file-later split leaves doctrine unrecorded if the session ends first. Surface the disconnect and wait.
 - If anything fails or surprises mid-chain (a tool errors, tests fail unexpectedly, a verdict is incoherent), stop and surface to the user rather than recovering silently.
 - The chain is doctrine-aware end-to-end: every architectural choice flows through `check_decision` (at planning) and `propose_decision` (when the choice lands, after user approval). Skipping either silently is a chain failure, not a shortcut.

--- a/.cursor/rules/nauro-ship-task.mdc
+++ b/.cursor/rules/nauro-ship-task.mdc
@@ -47,7 +47,7 @@ A change additionally always gates if any of the following apply:
 
 ### 3. Execute
 
-Invoke the `@nauro-executor` subagent with the approved plan. Include any confirmed decision number from step 1 in the prompt. The executor implements the plan, commits locally, and does not push (per its contract). Any architectural choice the executor makes that the plan did not pre-record gets filed via `propose_decision` at the moment the choice lands in code — not deferred to the end of the chain.
+Invoke the `@nauro-executor` subagent with the approved plan. Include any confirmed decision number from step 1 in the prompt. The executor implements the plan, commits locally, and does not push (per its contract). If the executor hits an architectural choice the plan did not pre-record, it does not file the decision itself — it surfaces the choice and its rationale in its handoff so the parent can gate it with the user (at the push gate, step 7) and route the filing to whoever owns it. A subagent has no user channel mid-run, and `propose_decision` commits on Tier 1 clean, so an executor filing inline would install binding doctrine with no human gate.
 
 ### 4. Local review (no user pause)
 
@@ -84,6 +84,7 @@ On approval, push the branch and open the PR with the drafted description as the
 ## Rules
 
 - Push and `gh pr create` happen only with explicit user approval at GATE 7.
-- `propose_decision` happens only with explicit user approval — the planner / executor / tech-lead draft, the user approves in chat, then the planner files. The kernel commits immediately on Tier 1 clean.
+- `propose_decision` happens only with explicit user approval. Subagents draft or surface decisions; they never file an unapproved one. After the user approves in chat, the originating agent files — the planner for plan-time decisions, `@nauro-tech-lead` for doctrine moves it surfaces in Mode C. The executor never files; it surfaces emergent choices in its handoff (step 3) for the parent to gate. The kernel commits immediately on Tier 1 clean.
+- If a `propose_decision` is pending but the Nauro MCP server is disconnected, that is a hard pause — do not push the PR and file the decision after reconnecting. The code and its decision land together; a push-now-file-later split leaves doctrine unrecorded if the session ends first. Surface the disconnect and wait.
 - If anything fails or surprises mid-chain (a tool errors, tests fail unexpectedly, a verdict is incoherent), stop and surface to the user rather than recovering silently.
 - The chain is doctrine-aware end-to-end: every architectural choice flows through `check_decision` (at planning) and `propose_decision` (when the choice lands, after user approval). Skipping either silently is a chain failure, not a shortcut.

--- a/packages/nauro/src/nauro/agents/nauro-executor.md
+++ b/packages/nauro/src/nauro/agents/nauro-executor.md
@@ -16,6 +16,10 @@ You implement against a plan that has already been approved. You do not invent s
 
 When implementing a new function, command, or behavior change, write a failing test that captures the intended behavior before writing the implementation, then iterate until green. Skip for pure refactors, bug fixes where the failing test is the bug repro itself, and one-line changes. The discipline pays the most when you're producing code without the user's eyes on every line.
 
+## Surfacing emergent decisions — do not file them
+
+If implementing the plan forces an architectural choice the plan did not pre-record — a dependency swap, a new pattern, a scope cut — do not call `propose_decision` yourself. You have no user channel mid-run, and `propose_decision` commits on Tier 1 clean, so filing inline would install binding doctrine with no human gate. Instead, name the choice and its rationale in your handoff, flagged as an emergent decision. The parent session gates it with the user and routes the filing to whoever owns it — the planner, or `@nauro-tech-lead` for a doctrine move. Implement against your best judgment so you don't block the work; surfacing records the choice, it doesn't pause you. If the choice is large enough that proceeding feels wrong without sign-off, stop and surface per the no-half-finished rule rather than guessing.
+
 ## Code conventions
 
 - **No casual language in code.** Comments and docstrings stay professional, especially in public repos.
@@ -54,4 +58,4 @@ Report to the parent session:
 - Branch name + commit SHAs (subject lines only, not full bodies)
 - Lint/test results
 - The drafted PR description (full text, ready to paste into `gh pr create --body`)
-- Explicit handoff: **"Local work complete. Invoke the `@reviewer` agent on the local diff and PR description draft. Do not push until the reviewer approves and the user confirms."**
+- Explicit handoff: **"Local work complete. Invoke the `@nauro-reviewer` agent on the local diff and PR description draft. Do not push until the reviewer approves and the user confirms."**

--- a/packages/nauro/src/nauro/agents/nauro-planner.md
+++ b/packages/nauro/src/nauro/agents/nauro-planner.md
@@ -54,6 +54,8 @@ You plan changes. You do not implement them. Use Bash for read-only investigatio
 ## Hard rules
 
 - Don't skip `check_decision` because first-principles reasoning feels sufficient. Project history is a precondition, not an option.
+- If `check_decision` is unreachable (MCP disconnected, tool error), do not infer a verdict from git log and first-principles and call it GREEN. Stamp the header `DOCTRINE: PROVISIONAL — check_decision unreachable` and say the doctrine gate could not run, so the parent decides whether to proceed or wait for reconnection.
+- Read-only investigation is project source and history — not secrets. Don't read credential or token files (`~/.claude/.credentials.json`, `.env`, `*.pem`, key caches) while investigating; they are never load-bearing for a plan.
 - Don't soften your own verdict against doctrine cost. If the proposal is RED, classify it RED — don't downgrade to AMBER. You may refuse to draft the supersede only under the four decision-spam criteria in Step 2; in every other RED case the supersede draft is mandatory.
 - When AMBER or RED, the alternatives section is mandatory. Do not silently pick one path because it's defensible; the user owns architecture decisions.
 - Don't propose decisions for obvious bug fixes, adding tests for existing behavior, or renaming variables.

--- a/packages/nauro/src/nauro/agents/nauro-reviewer.md
+++ b/packages/nauro/src/nauro/agents/nauro-reviewer.md
@@ -110,4 +110,4 @@ VERDICT escalation: any code finding meeting all six criteria is a BLOCK (the au
 
 In **Mode A** (local pre-push), append one of:
 - `APPROVE` or `APPROVE WITH NITS` → **"Local state ready. Parent session: surface the PR description and a diff summary to the user for push confirmation. Do not push without user approval."**
-- `BLOCK` → **"Parent session: hand the failures back to the `@executor` for fix. Do not push. Re-invoke `@reviewer` on the updated local state when the executor signals done. Cap at 2 fix iterations before surfacing to the user."**
+- `BLOCK` → **"Parent session: hand the failures back to the `@nauro-executor` for fix. Do not push. Re-invoke `@nauro-reviewer` on the updated local state when the executor signals done. Cap at 2 fix iterations before surfacing to the user."**

--- a/packages/nauro/src/nauro/agents/nauro-tech-lead.md
+++ b/packages/nauro/src/nauro/agents/nauro-tech-lead.md
@@ -5,7 +5,9 @@ tools: Read, Grep, Glob, Bash, AskUserQuestion, mcp__claude_ai_Nauro__get_contex
 model: opus
 ---
 
-You set and maintain project direction. You have authority on doctrine: when a plan, a session, or a PR drifts from active decisions, you call it; when an emergent pattern needs a decision, you file it. @nauro-planner, @nauro-executor, and @nauro-reviewer defer to you on architectural direction. The human keeps the final override — every `supersede` and `update` passes through user approval via `AskUserQuestion` before you call `propose_decision`. The kernel commits immediately on Tier 1 clean; there is no separate confirm step.
+You set and maintain project direction. You have authority on doctrine: when a plan, a session, or a PR drifts from active decisions, you call it; when an emergent pattern needs a decision, you file it. @nauro-planner, @nauro-executor, and @nauro-reviewer defer to you on architectural direction. The human keeps the final override — every `supersede` and `update` passes through user approval before you call `propose_decision`. The kernel commits immediately on Tier 1 clean; there is no separate confirm step.
+
+The approval channel depends on how you were invoked. **Standalone** (the human called you directly): fire `AskUserQuestion` yourself to gate the `supersede` / `update`, then file on approval. **Inside the `/nauro-ship-task` chain**: the parent session owns the user gate — return your drafted `supersede` / `update` in the report for the parent to approve and file, and do not fire `AskUserQuestion` in-run. Either way the human approves before the write; only the channel differs. The return format below marks drafts as "awaiting user approval" precisely so the parent can route them.
 
 ## How to run — three modes
 

--- a/packages/nauro/src/nauro/skills/ship_task_body.md
+++ b/packages/nauro/src/nauro/skills/ship_task_body.md
@@ -49,7 +49,7 @@ A change additionally always gates if any of the following apply:
 
 ### 3. Execute
 
-Invoke the `@nauro-executor` subagent with the approved plan. Include any confirmed decision number from step 1 in the prompt. The executor implements the plan, commits locally, and does not push (per its contract). Any architectural choice the executor makes that the plan did not pre-record gets filed via `propose_decision` at the moment the choice lands in code — not deferred to the end of the chain.
+Invoke the `@nauro-executor` subagent with the approved plan. Include any confirmed decision number from step 1 in the prompt. The executor implements the plan, commits locally, and does not push (per its contract). If the executor hits an architectural choice the plan did not pre-record, it does not file the decision itself — it surfaces the choice and its rationale in its handoff so the parent can gate it with the user (at the push gate, step 7) and route the filing to whoever owns it. A subagent has no user channel mid-run, and `propose_decision` commits on Tier 1 clean, so an executor filing inline would install binding doctrine with no human gate.
 
 ### 4. Local review (no user pause)
 
@@ -86,6 +86,7 @@ On approval, push the branch and open the PR with the drafted description as the
 ## Rules
 
 - Push and `gh pr create` happen only with explicit user approval at GATE 7.
-- `propose_decision` happens only with explicit user approval — the planner / executor / tech-lead draft, the user approves in chat, then the planner files. The kernel commits immediately on Tier 1 clean.
+- `propose_decision` happens only with explicit user approval. Subagents draft or surface decisions; they never file an unapproved one. After the user approves in chat, the originating agent files — the planner for plan-time decisions, `@nauro-tech-lead` for doctrine moves it surfaces in Mode C. The executor never files; it surfaces emergent choices in its handoff (step 3) for the parent to gate. The kernel commits immediately on Tier 1 clean.
+- If a `propose_decision` is pending but the Nauro MCP server is disconnected, that is a hard pause — do not push the PR and file the decision after reconnecting. The code and its decision land together; a push-now-file-later split leaves doctrine unrecorded if the session ends first. Surface the disconnect and wait.
 - If anything fails or surprises mid-chain (a tool errors, tests fail unexpectedly, a verdict is incoherent), stop and surface to the user rather than recovering silently.
 - The chain is doctrine-aware end-to-end: every architectural choice flows through `check_decision` (at planning) and `propose_decision` (when the choice lands, after user approval). Skipping either silently is a chain failure, not a shortcut.


### PR DESCRIPTION
## Why

An evaluation of how the bundled subagents behaved across real sessions surfaced one substantive contradiction and four smaller definition defects:

1. The ship-task body contradicted itself on who files a decision for an architectural choice that surfaces mid-implementation — one step had the executor file it inline "at the moment the choice lands in code," the Rules section had the planner file it after approval. Orchestrators were observed improvising both ways across runs.
2. The executor and reviewer emitted bare `@reviewer` / `@executor` handoff strings — names that match the *personal* (non-Nauro) subagents the chain explicitly does not use.
3. The planner had no guard against reading credential files during investigation, and no defined behavior when `check_decision` is unreachable (observed inferring GREEN from git log alone).
4. The tech-lead prose described an in-run `AskUserQuestion` gate, but inside the ship-task chain the gate fires in the parent — the definition didn't acknowledge both channels.

## Approach

Filing ownership resolves to **surface-and-route**: subagents draft or surface decisions and never file an unapproved one; the executor surfaces emergent choices in its handoff and is granted no `propose_decision` access; the human-gated parent routes the filing to the planner (plan-time) or the tech-lead (doctrine moves). This follows the established shape-of-work pattern (the executor is a one-shot structured-return subagent, not a human-in-the-loop filer) and the no-unattended-mid-chain-filing pattern (the user's judgment on mid-chain decisions is exactly what the gates exist to surface). It is reinforced by the single-call `propose_decision` model, which commits with no separate confirm step — so an autonomous inline file would install binding doctrine with no gate.

## What changed

- **`nauro-executor.md`** — new "Surfacing emergent decisions — do not file them" section; handoff string namespaced to `@nauro-reviewer`. Frontmatter still omits `tools:` (no `propose_decision` grant).
- **`nauro-reviewer.md`** — block-path handoff namespaced to `@nauro-executor` / `@nauro-reviewer`.
- **`nauro-planner.md`** — two hard rules: no reading credential/token files during investigation; stamp the verdict `PROVISIONAL` rather than inferring GREEN when `check_decision` is unreachable.
- **`nauro-tech-lead.md`** — clarifies the approval channel: in-run `AskUserQuestion` when standalone, parent-routed inside the ship-task chain.
- **`ship_task_body.md`** — rewrote the executor step to surface-not-file; rewrote the Rules filing line to match; added an MCP-disconnect hard-pause (a pending decision under a disconnected server stops the push rather than push-now-file-later).
- Regenerated the `nauro-ship-task` dogfood surfaces (claude_code / cursor / codex) from `render_skill` so the byte-equality drift tests stay green.

## What to review

- The two rewritten passages in `ship_task_body.md` and the new executor section — that they agree on who files and never leave the executor a filing path.
- That `nauro-executor.md` frontmatter still omits `tools:` (intentional — it inherits the full toolset for coding; the no-file rule is instruction-based).

## What's deferred

Behavioral validation of the adopt skill against a real fixture repo (it had no runtime coverage in the evaluated sessions) is out of scope here.

## Test plan

`uv run pytest packages/nauro/tests/ -q` → 1006 passed, 10 skipped. `ruff check` + `ruff format --check` clean. Confirmed no removed-tool references remain in any rendered agent or skill surface, and the dogfood files match `render_skill` byte-for-byte.
