### PR TITLE
fix(setup): resolve cross-server store routing for the local working copy

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/setup.py
+++ b/packages/nauro/src/nauro/cli/commands/setup.py
@@ -163,6 +163,50 @@ def _configure_mcp(repo_path: Path, *, remove: bool = False) -> str:
     )
 
 
+def _prune_redundant_user_scope_mcp() -> str | None:
+    """Remove a redundant user-scope HTTP ``nauro`` entry from ``~/.claude.json``.
+
+    On a machine with a local working copy, the stdio server is the canonical
+    Claude Code transport: ``nauro serve --stdio`` resolves the store from the
+    repo's ``.nauro/config.json`` and pulls remote changes on startup. An HTTP
+    ``nauro`` entry in user-scope ``~/.claude.json`` collides with the
+    project-scope stdio entry under the same name, so a session can resolve to
+    the wrong store. When the project stdio entry is written, drop the
+    redundant user-scope HTTP one.
+
+    Only the HTTP-transport entry is pruned — a user-scope ``nauro`` defined as
+    a stdio command is the user's own choice and is left alone. Soft-fails
+    (never raises) so a malformed or absent file cannot break wiring. Returns a
+    status line when something was removed, otherwise ``None``.
+    """
+    config_path = Path.home() / ".claude.json"
+    if not config_path.exists():
+        return None
+    try:
+        config = json.loads(config_path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return None
+    servers = config.get("mcpServers")
+    if not isinstance(servers, dict):
+        return None
+    entry = servers.get("nauro")
+    if not isinstance(entry, dict):
+        return None
+    if entry.get("type") != "http" and "url" not in entry:
+        return None
+    del servers["nauro"]
+    if not servers:
+        config.pop("mcpServers", None)
+    try:
+        config_path.write_text(json.dumps(config, indent=2) + "\n")
+    except OSError:
+        return None
+    return (
+        "  removed redundant user-scope HTTP nauro entry from ~/.claude.json "
+        "(project-scope stdio is canonical)"
+    )
+
+
 @setup_app.command(name="claude-code")
 def claude_code(
     project: str | None = typer.Option(
@@ -201,6 +245,11 @@ def claude_code(
         if legacy:
             legacy_results.append(legacy)
         mcp_results.append(_configure_mcp(repo_path, remove=remove))
+
+    if not remove:
+        pruned = _prune_redundant_user_scope_mcp()
+        if pruned:
+            mcp_results.append(pruned)
 
     # Print summary
     action = "Removed" if remove else "Configured"
@@ -661,6 +710,13 @@ def setup_all_surfaces(
             lines.append(_configure_mcp(repo, remove=remove))
         except Exception as exc:
             lines.append(f"Claude Code MCP ({repo}): error — {exc}")
+    if not remove:
+        try:
+            pruned = _prune_redundant_user_scope_mcp()
+            if pruned:
+                lines.append(pruned)
+        except Exception as exc:  # never let cleanup break wiring
+            lines.append(f"Claude Code MCP (user-scope cleanup): error — {exc}")
     try:
         lines.extend(
             materialize_skills_claude_code(

--- a/packages/nauro/src/nauro/templates/agents_md.py
+++ b/packages/nauro/src/nauro/templates/agents_md.py
@@ -62,6 +62,7 @@ def generate_agents_md(
     l0_payload: str,
     manual_section: str | None = None,
     *,
+    project_id: str | None = None,
     skills_section: str | None = None,
     section_order: list[str] | None = None,
 ) -> str:
@@ -71,6 +72,8 @@ def generate_agents_md(
         project_name: Name of the Nauro project.
         l0_payload: L0 context payload from build_l0_payload.
         manual_section: Preserved manual section content, or None.
+        project_id: v2 project id (ULID). When set, the store-routing block
+            tells agents which id to pass; omitted for legacy v1 projects.
         skills_section: Preserved ``## Skills`` content, or None to omit.
         section_order: Order in which to emit preserved sections — list of
             ``"skills"`` and/or ``"manual"``. Defaults to source-appearance
@@ -90,6 +93,25 @@ def generate_agents_md(
 
     # L0 payload
     parts.append(f"## Project: {project_name}\n\n{l0_payload}\n")
+
+    # Store-routing block. This file lives in the working copy, so any agent
+    # reading it is on a machine with the local store — where the stdio server
+    # is the canonical transport (it resolves the store from this repo and
+    # pulls remote changes on startup). Steer agents to the local tools so a
+    # separately-mounted cloud connector under the same name does not capture
+    # calls to the wrong store.
+    project_id_line = (
+        f"Pass `project_id: {project_id}` on calls that accept it. " if project_id else ""
+    )
+    parts.append(
+        "## Nauro store for this repo\n\n"
+        "This repo's Nauro store is served locally. Use the `mcp__nauro__*` tools "
+        "(the local stdio server). "
+        f"{project_id_line}"
+        "If a cloud Nauro connector (e.g. `mcp__claude_ai_Nauro__*`) is also mounted, "
+        "prefer the local `mcp__nauro__*` tools for this repo — they read the working "
+        "copy on this machine.\n"
+    )
 
     # MCP tools and behavioral instructions. Counts are derived from the
     # row catalogs above so they can never drift from the rendered lists.
@@ -170,6 +192,7 @@ def regenerate_agents_md_for_project(project_key: str, store_path: Path) -> list
 
     repo_paths: list[str] = []
     display_name = project_key
+    project_id: str | None = None
 
     try:
         v2_entry = get_project_v2(project_key)
@@ -178,6 +201,7 @@ def regenerate_agents_md_for_project(project_key: str, store_path: Path) -> list
     if v2_entry is not None:
         repo_paths = list(v2_entry.get("repo_paths", []))
         display_name = v2_entry.get("name", project_key)
+        project_id = project_key  # v2 registry is id-keyed
     else:
         registry = load_registry()
         entry = registry["projects"].get(project_key, {})
@@ -196,6 +220,7 @@ def regenerate_agents_md_for_project(project_key: str, store_path: Path) -> list
             display_name,
             l0_payload,
             manual_section=preserved.manual,
+            project_id=project_id,
             skills_section=preserved.skills,
             section_order=preserved.order or None,
         )

--- a/packages/nauro/tests/test_agents_md.py
+++ b/packages/nauro/tests/test_agents_md.py
@@ -45,6 +45,24 @@ def test_generate_includes_behavioral_instructions():
     assert "Update state" in result
 
 
+def test_routing_block_steers_to_local_stdio_with_project_id():
+    """The store-routing block names the local tools and the id to pass."""
+    result = generate_agents_md("myproj", "payload", project_id="01ABCXYZ")
+    assert "## Nauro store for this repo" in result
+    assert "`mcp__nauro__*`" in result
+    assert "project_id: 01ABCXYZ" in result
+    # Names the cloud connector only to steer away from it for this repo.
+    assert "mcp__claude_ai_Nauro__*" in result
+
+
+def test_routing_block_omits_project_id_line_when_unknown():
+    """Legacy v1 projects have no id — the block still steers to local, no id line."""
+    result = generate_agents_md("myproj", "payload")
+    assert "## Nauro store for this repo" in result
+    assert "`mcp__nauro__*`" in result
+    assert "project_id:" not in result
+
+
 def test_check_decision_categorized_as_read_tool():
     """check_decision is a read-only tool — it must not appear under Write tools.
 

--- a/packages/nauro/tests/test_setup_extended.py
+++ b/packages/nauro/tests/test_setup_extended.py
@@ -12,6 +12,7 @@ from nauro.cli.commands.setup import (
     CHECK_HINT_LINE,
     _configure_codex,
     _configure_cursor_for_repo,
+    _prune_redundant_user_scope_mcp,
 )
 from nauro.cli.main import app
 from nauro.store.registry import register_project_v2
@@ -556,6 +557,82 @@ def test_setup_all_help_lists_with_subagents():
     assert "--with-subagents" in output
     assert "--force-overwrite" in output
     assert "--with-skills" in output
+
+
+# ─── user-scope HTTP nauro collision cleanup ────────────────────────────────
+
+
+def _write_user_claude_json(home: Path, servers: dict) -> Path:
+    path = home / ".claude.json"
+    path.write_text(json.dumps({"mcpServers": servers, "someOtherKey": 1}) + "\n")
+    return path
+
+
+def test_prune_removes_http_nauro_entry(tmp_path: Path, monkeypatch):
+    """An HTTP ``nauro`` entry in user-scope ~/.claude.json is pruned; siblings stay."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    path = _write_user_claude_json(
+        tmp_path,
+        {
+            "nauro": {"type": "http", "url": "https://mcp.nauro.ai"},
+            "context7": {"command": "ctx", "args": []},
+        },
+    )
+
+    msg = _prune_redundant_user_scope_mcp()
+    assert msg is not None and "~/.claude.json" in msg
+
+    config = json.loads(path.read_text())
+    assert "nauro" not in config["mcpServers"]
+    assert "context7" in config["mcpServers"]  # untouched
+    assert config["someOtherKey"] == 1  # unrelated state preserved
+
+
+def test_prune_leaves_stdio_nauro_entry(tmp_path: Path, monkeypatch):
+    """A user-scope ``nauro`` defined as a stdio command is the user's own choice — keep it."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    path = _write_user_claude_json(
+        tmp_path, {"nauro": {"command": "nauro", "args": ["serve", "--stdio"]}}
+    )
+
+    assert _prune_redundant_user_scope_mcp() is None
+    config = json.loads(path.read_text())
+    assert "nauro" in config["mcpServers"]
+
+
+def test_prune_noops_without_file_or_entry(tmp_path: Path, monkeypatch):
+    """No ~/.claude.json, or no nauro entry, is a clean no-op (returns None)."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert _prune_redundant_user_scope_mcp() is None  # no file
+
+    _write_user_claude_json(tmp_path, {"context7": {"command": "ctx"}})
+    assert _prune_redundant_user_scope_mcp() is None  # no nauro entry
+
+
+def test_prune_soft_fails_on_malformed_json(tmp_path: Path, monkeypatch):
+    """A malformed ~/.claude.json must not raise — wiring cannot be broken by cleanup."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / ".claude.json").write_text("{not valid json")
+    assert _prune_redundant_user_scope_mcp() is None
+
+
+def test_setup_all_prunes_redundant_http_entry(tmp_path: Path, monkeypatch):
+    """``setup all`` removes the colliding user-scope HTTP nauro entry on the add path."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    _, store_path = register_project_v2("myproj", [repo])
+    scaffold_project_store("myproj", store_path)
+    monkeypatch.chdir(repo)
+    claude_json = _write_user_claude_json(
+        tmp_path, {"nauro": {"type": "http", "url": "https://mcp.nauro.ai"}}
+    )
+
+    result = runner.invoke(app, ["setup", "all"])
+    assert result.exit_code == 0, result.output
+    assert "removed redundant user-scope HTTP nauro entry" in result.output
+    config = json.loads(claude_json.read_text())
+    assert "nauro" not in config.get("mcpServers", {})
 
 
 # ─── nauro setup all --with-skills ──────────────────────────────────────────


### PR DESCRIPTION
## Why

A repo with a local working copy has the local stdio server as its canonical Nauro store: `nauro serve --stdio` resolves the store from the repo's `.nauro/config.json` and pulls remote changes on startup. But when a second Nauro MCP server is mounted under the same name — specifically a user-scope **HTTP** `nauro` entry in `~/.claude.json` alongside the project-scope **stdio** entry — a session can resolve to the wrong store and the agent gets "no related decisions" for doctrine that exists locally. Confirmed live on a dev machine (the user-scope entry was `{type: http, url: …}` colliding with the project-scope stdio entry).

Local store resolution is already deterministic from cwd; the problem is *which server the agent talks to* when two are mounted, not how a given server resolves.

## Approach

Two complementary layers, following the four-surface model (the local FilesystemStore is the working copy; stdio and the CLI are clients on it; the cloud HTTP MCP is the remote for install-less surfaces):

1. **Config layer** — when the Claude Code add path writes the project-scope stdio entry, prune a redundant user-scope HTTP `nauro` entry from `~/.claude.json`. On a machine with the working copy, stdio is canonical, so the HTTP entry under the same name is a collision, not a second transport.
2. **Distribution layer** — AGENTS.md (regenerated per repo) carries a store-routing block: use the local `mcp__nauro__*` tools, pass this repo's `project_id`, and prefer them over a separately-mounted cloud connector. Any agent that can read AGENTS.md is on a machine with the working copy, so steering to local stdio is always correct there.

The config fix can't reach a cloud connector Nauro doesn't manage (a claude.ai web connector mounted under a different name); the AGENTS.md guidance is the lever for that case.

## What changed

- `cli/commands/setup.py` — `_prune_redundant_user_scope_mcp` helper, called on the add path of both `setup all` and the standalone `setup claude-code`. Removes only the HTTP-transport `nauro` entry (a user-defined stdio entry is left alone), soft-fails on a malformed or absent file so cleanup can never break wiring, and preserves unrelated config state.
- `templates/agents_md.py` — `generate_agents_md` gains an optional `project_id` and emits the routing block after the project header; `regenerate_agents_md_for_project` threads the v2 id.

## What to review

- The `~/.claude.json` edit — confirm it only deletes a `type: http` / `url`-bearing `nauro` entry, never raises, and leaves siblings and unrelated top-level keys intact. It rewrites the file via JSON round-trip; Claude Code re-reads/normalizes its own state on next run.

## What's deferred

- Stamping resolved project identity (name + id) into the MCP response envelope so a misroute is self-evident — follow-up PR, scoped to the local surface to respect the deferred cross-store response-shape unification.
- The claude.ai web connector itself: not Nauro-controllable from the CLI, so it's handled by the AGENTS.md guidance rather than config cleanup.

## Test plan

`uv run pytest packages/nauro/tests/ -q` → 1021 passed, 10 skipped. `ruff check` + `ruff format --check` clean. The prune helper was verified against a copy of a real `~/.claude.json` (siblings and unrelated keys preserved); removal, stdio-keep, no-op (absent file / no entry), and malformed-file paths are unit-tested, plus an end-to-end `setup all` prune test; the routing block is asserted with and without a `project_id`.
