### PR TITLE
feat(mcp): stamp project identity on every local tool response

### DIFF
--- a/packages/nauro/src/nauro/mcp/tools.py
+++ b/packages/nauro/src/nauro/mcp/tools.py
@@ -8,8 +8,11 @@ strings for FastMCP compatibility).
 
 from __future__ import annotations
 
+import functools
 import logging
+from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 
 from nauro_core.constants import (
     MAX_CONTEXT_LENGTH,
@@ -55,6 +58,55 @@ from nauro.telemetry.decorators import mcp_tool
 from nauro.templates.agents_md_regen import warn_then_regen
 
 logger = logging.getLogger("nauro.mcp.tools")
+
+
+def _project_identity(store_path: Path) -> dict:
+    """Best-effort project identity (name + id) for the response envelope.
+
+    The store directory name is the v2 project id (ULID) or, for a legacy v1
+    store, the project name itself. Resolve the human-readable name from the
+    registry when the store is v2; fall back to the directory name otherwise.
+    Never raises — identity is advisory, and a lookup failure must not break a
+    tool response.
+    """
+    key = store_path.name
+    try:
+        from nauro.store.registry import RegistrySchemaError, get_project_v2
+
+        try:
+            entry = get_project_v2(key)
+        except RegistrySchemaError:
+            entry = None
+        if entry is not None:
+            return {"id": key, "name": entry.get("name") or key}
+    except Exception:
+        logger.debug("project identity resolution failed for %s", key, exc_info=True)
+    return {"id": None, "name": key}
+
+
+def _stamp_identity(func: Callable[..., Any]) -> Callable[..., Any]:
+    """Add ``project`` identity to a tool's ``store='local'`` response envelope.
+
+    Stacks under ``@mcp_tool`` so every return path — success, rejection, and
+    store-missing error — carries the resolved project name + id alongside the
+    ``store`` field (D061's store indicator, extended to project identity).
+    Local surface only; the remote mcp-server envelope is unchanged.
+    """
+
+    @functools.wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        result = func(*args, **kwargs)
+        store_path = args[0] if args else kwargs.get("store_path")
+        if (
+            isinstance(result, dict)
+            and isinstance(store_path, Path)
+            and result.get("store") == "local"
+            and "project" not in result
+        ):
+            result["project"] = _project_identity(store_path)
+        return result
+
+    return wrapper
 
 
 def _reject_if_too_long(value: str, label: str, max_length: int) -> dict | None:
@@ -183,6 +235,7 @@ def _snapshot_diff_section(store_path: Path) -> str:
 
 
 @mcp_tool("get_context")
+@_stamp_identity
 def tool_get_context(store_path: Path, level: int | str = "L0") -> dict:
     """Return project context at the requested detail level."""
     guidance = _check_store_exists(store_path)
@@ -218,6 +271,7 @@ def tool_get_context(store_path: Path, level: int | str = "L0") -> dict:
 
 
 @mcp_tool("propose_decision")
+@_stamp_identity
 def tool_propose_decision(
     store_path: Path,
     title: str = "",
@@ -355,6 +409,7 @@ Args:
 
 
 @mcp_tool("check_decision")
+@_stamp_identity
 def tool_check_decision(
     store_path: Path,
     proposed_approach: str,
@@ -383,6 +438,7 @@ Check for conflicts with existing decisions without writing anything.
 
 
 @mcp_tool("flag_question")
+@_stamp_identity
 def tool_flag_question(
     store_path: Path,
     question: str,
@@ -452,6 +508,7 @@ def tool_flag_question(
 
 
 @mcp_tool("get_raw_file")
+@_stamp_identity
 def tool_get_raw_file(store_path: Path, path: str) -> dict:
     """Return raw content of any file in the project store."""
     guidance = _check_store_exists(store_path)
@@ -489,6 +546,7 @@ def tool_get_raw_file(store_path: Path, path: str) -> dict:
 
 
 @mcp_tool("list_decisions")
+@_stamp_identity
 def tool_list_decisions(
     store_path: Path,
     limit: int = 20,
@@ -503,6 +561,7 @@ def tool_list_decisions(
 
 
 @mcp_tool("get_decision")
+@_stamp_identity
 def tool_get_decision(store_path: Path, number: int) -> dict:
     """Return full content of a specific decision by number."""
     guidance = _check_store_exists(store_path)
@@ -513,6 +572,7 @@ def tool_get_decision(store_path: Path, number: int) -> dict:
 
 
 @mcp_tool("diff_since_last_session")
+@_stamp_identity
 def tool_diff_since_last_session(
     store_path: Path,
     days: int | None = None,
@@ -541,6 +601,7 @@ def tool_diff_since_last_session(
 
 
 @mcp_tool("search_decisions")
+@_stamp_identity
 def tool_search_decisions(
     store_path: Path,
     query: str,
@@ -555,6 +616,7 @@ def tool_search_decisions(
 
 
 @mcp_tool("update_state")
+@_stamp_identity
 def tool_update_state(store_path: Path, delta: str) -> dict:
     """Update current project state. Returns a warning on keyword overlap."""
     guidance = _check_store_exists(store_path)

--- a/packages/nauro/tests/test_flag_question_parity.py
+++ b/packages/nauro/tests/test_flag_question_parity.py
@@ -98,6 +98,9 @@ def test_ok_envelope_matches_across_tool_and_cli(seeded_repo):
     tool_envelope = tool_flag_question(store_path, "Should we ship X?")
     exit_code, cli_envelope, output = _cli_envelope(["Should we ship Y?"])
     assert exit_code == 0, output
+    # Every local surface now carries project identity alongside store.
+    assert tool_envelope.pop("project")["id"] == pid
+    assert cli_envelope.pop("project")["id"] == pid
     assert tool_envelope == {"store": "local", "status": "ok"}
     assert cli_envelope == {"store": "local", "status": "ok"}
 

--- a/packages/nauro/tests/test_list_decisions_parity.py
+++ b/packages/nauro/tests/test_list_decisions_parity.py
@@ -89,6 +89,7 @@ def test_empty_store_envelope_matches_across_surfaces(empty_repo):
     pid, store_path = empty_repo
     tool = _tool_envelope(store_path)
     assert _stdio_rendered(pid) == RENDERERS["list_decisions"](tool)
+    assert tool.pop("project")["id"] == pid
     assert tool == {"store": "local", "decisions": []}
 
 
@@ -179,4 +180,7 @@ def test_store_missing_guidance_branch_on_tool(tmp_path):
     missing_store = tmp_path / "no-such-store"
     assert not missing_store.exists()
     envelope = _tool_envelope(missing_store)
+    # Identity is best-effort: an unregistered/missing store falls back to the
+    # directory name with no id.
+    assert envelope.pop("project") == {"id": None, "name": "no-such-store"}
     assert envelope == {"store": "local", "status": "error", "guidance": WELCOME_NO_PROJECT}

--- a/packages/nauro/tests/test_search_decisions_parity.py
+++ b/packages/nauro/tests/test_search_decisions_parity.py
@@ -129,6 +129,7 @@ def test_empty_store_envelope_matches_across_surfaces(empty_repo):
     pid, store_path = empty_repo
     tool = _tool_envelope(store_path, "anything")
     assert _stdio_rendered(pid, "anything") == RENDERERS["search_decisions"](tool)
+    assert tool.pop("project")["id"] == pid
     assert tool == {"store": "local", "results": []}
 
 

--- a/packages/nauro/tests/test_tools_store_field.py
+++ b/packages/nauro/tests/test_tools_store_field.py
@@ -48,3 +48,23 @@ class TestStoreFieldPresent:
         store = _setup_store(tmp_path, monkeypatch)
         result = tool_update_state(store, delta="Completed initial setup")
         assert result["store"] == "local"
+
+
+class TestProjectIdentityPresent:
+    """Every local response carries project identity alongside the store field.
+
+    Extends the store indicator (store='local') to name the resolved project so
+    a call routed to the wrong store is self-evident in the response.
+    """
+
+    def test_check_decision_includes_project_identity(self, tmp_path, monkeypatch):
+        store = _setup_store(tmp_path, monkeypatch)
+        result = tool_check_decision(store, proposed_approach="Use a REST API")
+        # v1 store: the directory name is the project name, no separate id.
+        assert result["project"] == {"id": None, "name": "testproj"}
+
+    def test_error_envelope_also_carries_project(self, tmp_path, monkeypatch):
+        missing = tmp_path / "absent-store"
+        result = tool_check_decision(missing, proposed_approach="anything")
+        assert result["status"] == "error"  # store-missing branch
+        assert result["project"] == {"id": None, "name": "absent-store"}

--- a/packages/nauro/tests/test_update_state_parity.py
+++ b/packages/nauro/tests/test_update_state_parity.py
@@ -126,6 +126,9 @@ def test_ok_envelope_matches_across_tool_and_cli(seeded_repo):
     # to keep the envelope shape the same (no warning) and exercise the rotation.
     exit_code, cli_envelope, output = _cli_envelope(["Shipped the CLI surface"])
     assert exit_code == 0, output
+    # Every local surface now carries project identity alongside store.
+    assert tool_envelope.pop("project")["id"] == pid
+    assert cli_envelope.pop("project")["id"] == pid
     assert tool_envelope == {"store": "local", "status": "ok"}
     assert cli_envelope == {"store": "local", "status": "ok"}
 


### PR DESCRIPTION
## Why

The store indicator (`store: "local" | "remote"`) lets a consumer tell which *kind* of store answered, but not *which project*. When two Nauro MCP servers are mounted (e.g. a local stdio server plus a user-scope HTTP entry or a claude.ai web connector) and a call lands on the wrong store, the response is a bare empty result — "no related decisions" — with no signal that it queried the wrong project. The agent (and the human reading the transcript) can't tell a genuine empty store from a misroute.

## Approach

Extend the store indicator to also carry project identity (`project: {id, name}`) on every local tool response, so a misroute is self-evident in the response itself.

Implemented as a small `_stamp_identity` decorator stacked under `@mcp_tool`, rather than editing each return site. This covers every return path — success, rejection, and store-missing error — uniformly, and keeps the existing payload construction byte-for-byte (the key is added post-return). Identity resolution is best-effort and never raises: a v2 store resolves its name from the registry; a registry miss or a legacy v1 store falls back to the store directory name with a `null` id.

Scoped to the **local** surface. The three local surfaces (CLI, stdio MCP, FastAPI) all route through the `tool_*` adapters, so cross-surface parity holds by construction. The remote mcp-server envelope (separate repo) is deliberately left unchanged, keeping the deferred cross-store response-shape unification out of scope — when that work happens, project identity carries to remote with the key-set guard it calls for.

## What changed

- `mcp/tools.py` — `_project_identity` resolver + `_stamp_identity` decorator, applied to all ten `tool_*` adapters.
- Parity suites (`flag_question`, `list_decisions`, `search_decisions`, `update_state`) — the exact-dict assertions now pop and verify `project` (the cross-surface `==` and renderer-parity assertions pass unchanged, since all surfaces stamp identically).
- `test_tools_store_field.py` — new cases pinning the exact `project` dict for the registry-name path and the missing-store fallback.

## What to review

- The decorator stacking order under `@mcp_tool` and the `args[0] if args else kwargs.get("store_path")` extraction — confirm identity attaches to every envelope and never raises.
- That the remote envelope is genuinely untouched (the change is confined to the local `tools.py`).

## What's deferred

Carrying project identity to the remote mcp-server envelope — folded into the eventual cross-store response-shape unification, not done here.

## Test plan

`uv run pytest packages/nauro/tests/ -q` → 1016 passed, 10 skipped. `ruff check` + `ruff format --check` clean. Parity suites assert identity threads identically across CLI/stdio/FastAPI; new unit cases pin the exact `project` dict for both the registry-name and missing-store paths.
