### PR TITLE
fix(adopt): add subagents/skills to an already-adopted repo instead of aborting

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/adopt.py
+++ b/packages/nauro/src/nauro/cli/commands/adopt.py
@@ -111,6 +111,35 @@ def _check_collision(name: str, repo_root: Path) -> str | None:
     return None
 
 
+def _install_into_adopted_repo(
+    repo_root: Path,
+    *,
+    with_subagents: bool,
+    with_skills: bool,
+    force_overwrite: bool,
+) -> None:
+    """Install bundled subagents/skills onto an already-adopted repo.
+
+    Mirrors the materialize step of a fresh adoption (``setup_all_surfaces``)
+    without re-registering the project or rewriting ``.nauro/config.json`` —
+    the repo is already adopted, so registration is intact and untouched.
+    Lets ``nauro adopt --with-subagents`` (or ``--with-skills``) add the
+    bundled artifacts to an existing adoption instead of aborting.
+    """
+    typer.echo("Repo already adopted. Installing requested artifacts across surfaces:\n")
+    for line in setup_all_surfaces(
+        [repo_root],
+        remove=False,
+        with_subagents=with_subagents,
+        force_overwrite=force_overwrite,
+        with_skills=with_skills,
+    ):
+        typer.echo(line)
+    if with_skills and not with_subagents:
+        typer.echo(f"\n{SHIP_TASK_NEEDS_SUBAGENTS_NOTICE}")
+    typer.echo("\nNext: restart your agent so it picks up the newly installed files.")
+
+
 _Opt_repo = typer.Option(None, "--repo", help="Repo root (default: current working directory).")
 
 
@@ -191,10 +220,25 @@ def adopt(
     # ── already-adopted guard ──────────────────────────────────────────────
     config_path = repo_root / ".nauro" / "config.json"
     if config_path.exists():
+        # Already adopted. If the caller asked to install bundled subagents or
+        # skills, route to the materialize step for the existing adoption rather
+        # than dead-ending — those flags are otherwise unreachable on `adopt`
+        # once a repo is adopted, and `adopt` is the command users reach for
+        # first. Registration and config.json are left untouched, so D128's
+        # "every adoption writes config.json" invariant is unaffected.
+        if with_subagents or with_skills or force_overwrite:
+            _install_into_adopted_repo(
+                repo_root,
+                with_subagents=with_subagents,
+                with_skills=with_skills,
+                force_overwrite=force_overwrite,
+            )
+            return
         typer.echo(
-            f"This repo is already adopted (config at {config_path}). To "
-            f"start a fresh project from this repo, remove '.nauro/config.json' "
-            f"and re-run.",
+            f"This repo is already adopted (config at {config_path}). To add "
+            f"Nauro's bundled subagents or skills, re-run with --with-subagents "
+            f"and/or --with-skills. To start a fresh project from this repo, "
+            f"remove '.nauro/config.json' and re-run.",
             err=True,
         )
         raise typer.Exit(code=1)

--- a/packages/nauro/tests/test_adopt.py
+++ b/packages/nauro/tests/test_adopt.py
@@ -63,6 +63,41 @@ def test_adopt_aborts_when_repo_already_adopted(tmp_path: Path, monkeypatch):
     result = runner.invoke(app, ["adopt", "--name", "alpha"])
     assert result.exit_code == 1
     assert "already adopted" in result.output.lower()
+    # The abort points at the flags that add artifacts, not only the
+    # destructive "remove config.json" path.
+    assert "--with-subagents" in result.output
+
+
+def test_adopt_already_adopted_with_subagents_installs_instead_of_aborting(
+    tmp_path: Path, monkeypatch
+):
+    """`adopt --with-subagents` on an already-adopted repo installs the bundled
+    subagents rather than dead-ending on the already-adopted guard."""
+    from nauro.agents import AGENT_NAMES
+
+    _adopt_env(monkeypatch, tmp_path)
+    first = runner.invoke(app, ["adopt", "--name", "alpha"])
+    assert first.exit_code == 0, first.output
+    # Fresh adopt without the flag installs no subagents.
+    for n in AGENT_NAMES:
+        assert not _agent_path(tmp_path, n).exists()
+
+    result = runner.invoke(app, ["adopt", "--with-subagents"])
+    assert result.exit_code == 0, result.output
+    assert "already adopted" not in result.output.lower() or "Installing" in result.output
+    for n in AGENT_NAMES:
+        assert _agent_path(tmp_path, n).is_file(), f"missing {n} after re-adopt --with-subagents"
+
+
+def test_adopt_already_adopted_with_skills_installs_and_notices(tmp_path: Path, monkeypatch):
+    """`adopt --with-skills` on an already-adopted repo installs the opt-in skill
+    and emits the needs-subagents notice."""
+    _adopt_env(monkeypatch, tmp_path)
+    assert runner.invoke(app, ["adopt", "--name", "alpha"]).exit_code == 0
+
+    result = runner.invoke(app, ["adopt", "--with-skills"])
+    assert result.exit_code == 0, result.output
+    assert (tmp_path / ".claude" / "skills" / "nauro-ship-task" / "SKILL.md").is_file()
 
 
 def test_adopt_aborts_on_same_name_collision(tmp_path: Path, monkeypatch):


### PR DESCRIPTION
## Why

`nauro adopt --with-subagents` (and `--with-skills`) dead-ended on an already-adopted repo. The already-adopted guard raised `Exit(1)` *before* the materialize step ran, so those flags were unreachable once a repo was adopted — and the abort pointed at a destructive fix ("remove `.nauro/config.json` and re-run") rather than the path that works.

This was the core of a long onboarding stall observed in a real session: `adopt --with-subagents` aborts → bare `nauro setup` doesn't carry the flag → only `nauro setup all --with-subagents` works, discovered by trial and error (~35+ minutes). `adopt` is the command users (and the install instructions) reach for first, so everyone with an existing adoption hit the wall.

## Approach

When the repo is already adopted **and** the caller passed `--with-subagents` / `--with-skills` / `--force-overwrite`, route to the materialize step (`setup_all_surfaces`) for the existing adoption and return success, instead of aborting. Registration and `.nauro/config.json` are left untouched — the "every adoption writes config.json" invariant the already-adopted guard relies on (D128) is unaffected, because this path neither re-registers nor rewrites config.

When no such flag is passed, still abort (re-adopting from scratch is a deliberate, destructive action) — but the message now names the flags that add artifacts, not only the `remove config.json` reset.

Routing through `setup_all_surfaces` also means the already-adopted path inherits the same MCP re-wiring and the redundant-HTTP-entry cleanup the fresh path gets.

## What changed

- `cli/commands/adopt.py` — the already-adopted branch routes to a new `_install_into_adopted_repo` helper when install flags are present; the no-flags abort message is rewritten to surface the flags.

## What to review

- The routing branch does not re-register or rewrite `config.json` — confirm the already-adopted-guard invariant stays intact.

## What's deferred

Adding `--with-subagents` to bare `nauro setup` — unnecessary now that the natural command (`adopt`) works on an already-adopted repo. (The flag remains on `adopt` and `setup all`.)

## Test plan

`uv run pytest packages/nauro/tests/ -q` → 1027 passed, 10 skipped (+3 new). `ruff check` + `ruff format --check` clean. Verified against the real CLI: re-running `adopt --with-subagents` on an already-adopted repo installs the four bundled subagents (`nauro-planner/executor/reviewer/tech-lead`).
