### PR TITLE
chore(release): bump nauro to 0.10.1

### DIFF
--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro"
-version = "0.10.0"
+version = "0.10.1"
 description = "Local CLI + MCP server: set your project's doctrine once, every connected AI agent inherits it."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Why

`0.10.0` was published to PyPI at the moment the version was first cut, but several fixes landed on `main` afterward without a further version change. PyPI versions are immutable, so the published `0.10.0` artifact permanently predates those fixes: anyone installing from PyPI gets bundled subagents and skill copy describing the old, pre-fix behavior (including a since-retired MCP tool and a since-corrected filing-ownership rule for emergent decisions). New installs and `--with-subagents` refreshes therefore ship stale guidance, and there is no way to re-cut `0.10.0`.

## Approach

A patch release. Re-publishing `0.10.0` is impossible (immutable), and folding the already-shipped fixes into a larger release would couple an urgent correctness fix to unrelated work. A version-only bump gets the stranded fixes onto PyPI with nothing else in the diff.

## What changed

Bumps `packages/nauro/pyproject.toml` `0.10.0` → `0.10.1`. No code changes. The `nauro-core` dependency (`>=0.13.0,<0.14`) already resolves against the published `nauro-core`, so nothing else moves. The CLI version is single-sourced via `importlib.metadata`, so there is no second version string to update.

## Test plan

- `uv lock` resolves cleanly (`nauro 0.10.0 -> 0.10.1`) — local check only; `uv.lock` is gitignored in this repo and is intentionally not part of the commit.
- `uv run ruff check packages/` — all checks passed.
- `uv run ruff format --check packages/` — 203 files already formatted.

## What's deferred

Merging does not publish. Publishing is tag-triggered: push a `nauro-v0.10.1` tag after merge to run the PyPI publish workflow. Once live, refresh local installs with `pipx install --force nauro==0.10.1` (or upgrade), then `nauro adopt --with-subagents` to pull the corrected bundle.
