### PR TITLE
fix(cli): `nauro validate status` crashes on any non-empty store

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/validate.py
+++ b/packages/nauro/src/nauro/cli/commands/validate.py
@@ -16,12 +16,14 @@ def status(
     ),
 ) -> None:
     """Show validation search status."""
+    from nauro_core.decision_model import DecisionStatus
+
     from nauro.cli.utils import resolve_target_project
     from nauro.store.reader import _list_decisions
 
     project_name, store_path = resolve_target_project(project)
     decisions = _list_decisions(store_path)
-    active = [d for d in decisions if d.get("status", "active") == "active"]
+    active = [d for d in decisions if d.status is DecisionStatus.active]
 
     typer.echo(f"Project: {project_name}")
     typer.echo(f"Total decisions: {len(decisions)}")

--- a/packages/nauro/tests/test_cli_validate.py
+++ b/packages/nauro/tests/test_cli_validate.py
@@ -1,0 +1,50 @@
+"""Tests for nauro validate command."""
+
+from typer.testing import CliRunner
+
+from nauro.cli.main import app
+from nauro.store.registry import register_project
+from nauro.templates.scaffolds import scaffold_project_store
+
+runner = CliRunner()
+
+
+def _setup_project(tmp_path, monkeypatch):
+    store = register_project("testproj", [tmp_path])
+    scaffold_project_store("testproj", store)
+    monkeypatch.chdir(tmp_path)
+    return store
+
+
+def test_validate_status_on_non_empty_store(tmp_path, monkeypatch):
+    """`validate status` must not crash when the store holds decisions.
+
+    The scaffold seeds 001-initial-setup.md, so the store is non-empty.
+    Regression: status used dict access (``d.get(...)``) on the Pydantic
+    ``Decision`` objects returned by ``_list_decisions``, raising
+    AttributeError on any non-empty store (empty stores passed by accident).
+    """
+    _setup_project(tmp_path, monkeypatch)
+
+    result = runner.invoke(app, ["validate", "status"])
+
+    assert result.exit_code == 0
+    assert "Project: testproj" in result.output
+    assert "Total decisions: 1" in result.output
+    assert "Active decisions: 1" in result.output
+
+
+def test_validate_status_empty_store(tmp_path, monkeypatch):
+    """An empty decisions set reports zero counts without error."""
+    store = register_project("emptyproj", [tmp_path])
+    scaffold_project_store("emptyproj", store)
+    # Remove the seed decision so the store has no decisions.
+    for decision in (store / "decisions").glob("*.md"):
+        decision.unlink()
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["validate", "status"])
+
+    assert result.exit_code == 0
+    assert "Total decisions: 0" in result.output
+    assert "Active decisions: 0" in result.output


### PR DESCRIPTION
## Why

`nauro validate status` crashed with `AttributeError: 'Decision' object has no attribute 'get'` on any project store containing at least one decision. `store/reader.py:_list_decisions` returns Pydantic `Decision` objects, but the active-count filter used dict access (`d.get("status", "active")`). An empty store passed by accident (the comprehension never calls `.get()`), which is why the bug shipped untested.

## Approach

Switch to the `d.status is DecisionStatus.active` idiom already established in `reader.py:list_active_decisions`, filtering the decision list already loaded for the total count — no second parse. Reusing `list_active_decisions()` directly was considered but it re-reads and re-parses the store; inline filtering reuses the list already in hand.

## What changed

- `cli/commands/validate.py` — one-line fix to the active-decision filter, plus the `DecisionStatus` import.
- `tests/test_cli_validate.py` (new, colocated in the `nauro` package) — covers the non-empty store path (the regression) and the empty store path.

## What to review

The empty-store test's `unlink()` of the scaffold-seeded `001-initial-setup.md` is load-bearing — without it the store is non-empty and the zero-count assertions would not exercise the empty path.

## What's deferred

Nothing.

## Test plan

- Reproduced the crash on baseline (`exit_code 1`, `AttributeError`) before the fix.
- New tests pass; both assert exact `exit_code == 0`.
- Full `nauro` package suite green: 1029 passed, 10 skipped.
- `ruff check` and `ruff format --check` clean on both changed files.
