### PR TITLE
feat(search): filter decision status in the kernel; add include_superseded

### DIFF
--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro-core"
-version = "0.13.0"
+version = "0.13.1"
 description = "Shared pure-Python logic for Nauro: parsing, validation, context assembly, constants."
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/nauro-core/src/nauro_core/mcp_tools.py
+++ b/packages/nauro-core/src/nauro_core/mcp_tools.py
@@ -214,8 +214,8 @@ SEARCH_DECISIONS: ToolSpec = {
     "title": "Search decisions",
     "description": (
         "Search across all project decisions using BM25 relevance ranking "
-        "against titles and rationale. Includes both active and superseded "
-        "decisions.\n"
+        "against titles and rationale. Returns active decisions by default; "
+        "pass include_superseded=true to include superseded ones.\n"
         "\n"
         "Use when you need to find decisions about a specific topic rather "
         "than browsing the full list. More token-efficient than list_decisions "
@@ -239,6 +239,11 @@ SEARCH_DECISIONS: ToolSpec = {
                 "type": "integer",
                 "default": 10,
                 "description": "Maximum results to return.",
+            },
+            "include_superseded": {
+                "type": "boolean",
+                "default": False,
+                "description": "Include superseded decisions in the result.",
             },
             "project_id": _PROJECT_PARAM,
         },

--- a/packages/nauro-core/src/nauro_core/operations/search_decisions.py
+++ b/packages/nauro-core/src/nauro_core/operations/search_decisions.py
@@ -4,15 +4,16 @@ All transports call this with the same arguments; each one wraps the
 call to add transport-specific framing (``store`` field, telemetry
 emission). The listing, BM25 ranking, and projection live here.
 
-Superseded decisions stay in the result set: an agent searching the
-project history may legitimately want to surface the prior rationale
-behind a current decision. Status filtering belongs to
-``list_decisions``.
+Status filtering happens here: by default only active decisions are
+ranked. Pass ``include_superseded=True`` to also surface superseded
+decisions (e.g. reviewing the prior rationale behind a current one).
+Filtering before ranking keeps ``limit`` honored against the active set
+rather than letting superseded hits crowd out active ones.
 """
 
 from __future__ import annotations
 
-from nauro_core.decision_model import parse_decision
+from nauro_core.decision_model import DecisionStatus, parse_decision
 from nauro_core.operations.results import (
     ErrorPayload,
     SearchDecisionsResult,
@@ -26,6 +27,7 @@ def search_decisions(
     store: Store,
     query: str,
     limit: int = 10,
+    include_superseded: bool = False,
 ) -> SearchDecisionsResult:
     """Return BM25-ranked decisions for ``query``.
 
@@ -33,12 +35,15 @@ def search_decisions(
         store: Storage adapter providing ``list_decisions`` / ``read_decision``.
         query: Search text. Empty or whitespace-only is rejected.
         limit: Maximum number of hits to return.
+        include_superseded: When False (default), only active decisions are
+            ranked. When True, superseded decisions are ranked as well.
 
     Returns:
         :class:`SearchDecisionsResult` with ``results`` populated on the
         success path (sorted by BM25 score descending, truncated to
-        ``limit``). On an empty/whitespace query, ``error`` is populated
-        with ``kind="rejected"`` and ``results`` stays empty.
+        ``limit`` against the filtered set). On an empty/whitespace query,
+        ``error`` is populated with ``kind="rejected"`` and ``results``
+        stays empty.
     """
     if not query or not query.strip():
         return SearchDecisionsResult(
@@ -57,6 +62,9 @@ def search_decisions(
         if body is None:
             continue
         decisions.append(parse_decision(body, f"{stem}.md"))
+
+    if not include_superseded:
+        decisions = [d for d in decisions if d.status is DecisionStatus.active]
 
     ranked = bm25_search(decisions, query, limit=limit)
     hits = [

--- a/packages/nauro-core/tests/operations/test_search_decisions.py
+++ b/packages/nauro-core/tests/operations/test_search_decisions.py
@@ -123,12 +123,9 @@ def test_stemming_matches_morphological_variants() -> None:
     assert "Auth0" in result.results[0].title
 
 
-def test_superseded_decisions_appear_in_results() -> None:
-    """Status is not a filter on search; superseded rationale stays inspectable.
-
-    Pins the no-status-filter contract for ``search_decisions`` so an agent
-    looking at past doctrine can still surface a superseded decision by
-    keyword. Status filtering belongs to ``list_decisions``.
+def test_superseded_excluded_by_default() -> None:
+    """search_decisions filters status in the kernel: superseded decisions are
+    excluded by default so they cannot crowd active hits out of ``limit``.
     """
     active = _seed_decision(
         1,
@@ -142,9 +139,54 @@ def test_superseded_decisions_appear_in_results() -> None:
         status=DecisionStatus.superseded,
     )
     store = _store_with(active, superseded)
-    result = search_decisions(store, "Auth0")
+    result = search_decisions(store, "authentication")
+    statuses = {hit.status for hit in result.results}
+    assert "superseded" not in statuses
+    assert "active" in statuses
+
+
+def test_include_superseded_true_retains_superseded() -> None:
+    """Passing ``include_superseded=True`` surfaces superseded decisions."""
+    active = _seed_decision(
+        1,
+        "Use Cognito for authentication",
+        "Cognito ties tightly to AWS-native IAM.",
+    )
+    superseded = _seed_decision(
+        2,
+        "Use Auth0 for authentication",
+        "Auth0 was the prior managed identity provider.",
+        status=DecisionStatus.superseded,
+    )
+    store = _store_with(active, superseded)
+    result = search_decisions(store, "Auth0", include_superseded=True)
     statuses = {hit.status for hit in result.results}
     assert "superseded" in statuses
+
+
+def test_filter_runs_before_truncation() -> None:
+    """Status filtering runs before the ``limit`` truncation, so an active-only
+    query returns active hits even when superseded decisions would otherwise
+    outrank them in the BM25 top-N.
+    """
+    superseded = [
+        _seed_decision(
+            i,
+            f"Superseded match {i}",
+            "match phrase superseded here.",
+            status=DecisionStatus.superseded,
+        )
+        for i in range(1, 4)
+    ]
+    active = [
+        _seed_decision(i, f"Active match {i}", "match phrase active here.") for i in range(4, 7)
+    ]
+    store = _store_with(*superseded, *active)
+    result = search_decisions(store, "match phrase", limit=3)
+    statuses = {hit.status for hit in result.results}
+    assert result.results, "active decisions matching the query should be returned"
+    assert "superseded" not in statuses
+    assert len(result.results) <= 3
 
 
 def test_results_sorted_descending_by_score() -> None:

--- a/packages/nauro/src/nauro/mcp/stdio_server.py
+++ b/packages/nauro/src/nauro/mcp/stdio_server.py
@@ -238,6 +238,9 @@ def diff_since_last_session(
 def search_decisions(
     query: Annotated[str, Field(description=_param_desc("search_decisions", "query"))],
     limit: Annotated[int, Field(description=_param_desc("search_decisions", "limit"))] = 10,
+    include_superseded: Annotated[
+        bool, Field(description=_param_desc("search_decisions", "include_superseded"))
+    ] = False,
     project_id: Annotated[
         str | None, Field(description=_param_desc("search_decisions", "project_id"))
     ] = None,
@@ -250,7 +253,7 @@ def search_decisions(
     except StoreResolutionError as exc:
         result = {"store": "local", "status": "error", "guidance": str(exc)}
     else:
-        result = tool_search_decisions(store_path, query, limit)
+        result = tool_search_decisions(store_path, query, limit, include_superseded)
     return _wrap_with_renderer("search_decisions", result)
 
 

--- a/packages/nauro/src/nauro/mcp/tools.py
+++ b/packages/nauro/src/nauro/mcp/tools.py
@@ -605,12 +605,15 @@ def tool_search_decisions(
     store_path: Path,
     query: str,
     limit: int = 10,
+    include_superseded: bool = False,
 ) -> dict:
     """Search decisions by keyword. Returns matching decisions with snippets."""
     guidance = _check_store_exists(store_path)
     if guidance:
         return {"store": "local", "status": "error", "guidance": guidance}
-    result = _search_decisions_op(FilesystemStore(store_path), query, limit)
+    result = _search_decisions_op(
+        FilesystemStore(store_path), query, limit, include_superseded=include_superseded
+    )
     return {"store": "local", **result.model_dump(mode="json", exclude_none=True)}
 
 


### PR DESCRIPTION
> PR 1 of 2. The companion mcp-server PR (drop the adapter's post-hoc strip) is gated on `nauro-core` 0.13.1 publishing.

## Why

`search_decisions` ranked active and superseded decisions together and truncated to `limit`. On the remote surface, a post-hoc superseded strip then ran *after* truncation — so an active-only query could return fewer than `limit` active hits while reporting no truncation, silently under-returning matches when superseded decisions outranked active ones in the BM25 top-N.

## Approach

Move the status filter into the nauro-core kernel so it runs **before** ranking and truncation, honoring `limit` against the active set. Add `include_superseded` (default `false`) to opt back into superseded results, declared in the `SEARCH_DECISIONS` schema (mirroring `list_decisions`) so it propagates to every surface uniformly. This reverses the kernel's prior "superseded stays in search results" docstring contract — a deliberate, recorded decision. Keeping the filter in the remote adapter was considered and rejected: it duplicates the logic across adapters and diverges from the kernel-as-single-source-of-truth contract.

## What changed

- **nauro-core**: `search_decisions` filters to active-only before `bm25_search`; `SEARCH_DECISIONS` schema declares `include_superseded`; module + function docstrings reversed; version `0.13.0` → `0.13.1`.
- **nauro**: `tool_search_decisions` and the stdio `search_decisions` tool thread `include_superseded` through to the kernel. The autogen CLI gains `--include-superseded/--no-include-superseded` for free from the schema property.

## What to review

- The filter-before-rank ordering in `search_decisions.py` — it runs on the decision list before `bm25_search`, so `limit` and the BM25 retrieval cap operate on the active set.
- The schema→autogen path: autogen calls `adapter(store_path, **adapter_kwargs)` from the schema, so `tool_search_decisions` must accept `include_superseded` (it does) — otherwise a TypeError.

## What's deferred

- No `truncated`/"more results exist" signal is added; the op has none today and a real one would require over-fetching beyond `limit`.
- The mcp-server adapter's now-redundant post-hoc superseded strip is removed in the companion PR, gated on `nauro-core` 0.13.1 reaching PyPI.

## Behavior change

Local `nauro search-decisions` and the local stdio search tool now return **active-only by default** — parity with the remote tool, which already defaulted to active-only. Pass `--include-superseded` (CLI) or the `include_superseded` param to include superseded decisions.

## Test plan

- Kernel tests: rewrote the superseded-in-search test to active-only-by-default; added `include_superseded=True` opt-in and filter-before-truncation coverage.
- Search cross-surface + parity suites green.
- Full suites: nauro-core 591 passed; nauro 1018 passed, 10 skipped.
- `ruff check` + `ruff format --check` clean.
