### PR TITLE
feat(flag-question): add resolve action via resolved_by

### DIFF
--- a/packages/nauro-core/src/nauro_core/mcp_tools.py
+++ b/packages/nauro-core/src/nauro_core/mcp_tools.py
@@ -413,17 +413,24 @@ PROPOSE_DECISION: ToolSpec = {
 
 FLAG_QUESTION: ToolSpec = {
     "name": "flag_question",
-    "title": "Flag open question",
+    "title": "Flag or resolve open question",
     "description": (
-        "Flag an unresolved question for human review. Appends to "
-        "open-questions.md in the project store.\n"
+        "Flag an unresolved question for human review, or resolve existing "
+        "questions against a decision. Writes to open-questions.md in the "
+        "project store.\n"
         "\n"
-        "Before writing, checks whether the question is already addressed by "
-        "an existing decision — if so, the response includes a hint pointing "
-        "to that decision (the question is still logged).\n"
+        "To flag: pass `question`. Before writing, checks whether the "
+        "question is already addressed by an existing decision — if so, the "
+        "response includes a hint pointing to that decision (the question is "
+        "still logged).\n"
         "\n"
-        "Use when you encounter an ambiguity a human should weigh in on: "
-        "architectural trade-offs, unclear requirements, or scope boundaries."
+        "To resolve: pass `resolved_by` (a decision id) and the entry ids to "
+        "stamp in `targets`. Each named entry is marked resolved in place; "
+        "nothing is appended.\n"
+        "\n"
+        "Pass exactly one of `question` or `resolved_by`. Use the flag action "
+        "for ambiguities a human should weigh in on; use the resolve action "
+        "once a decision has answered open questions."
     ),
     "annotations": {**_WRITE_ANNOTATIONS, "idempotentHint": False},
     "input_schema": {
@@ -431,7 +438,10 @@ FLAG_QUESTION: ToolSpec = {
         "properties": {
             "question": {
                 "type": "string",
-                "description": "The question to flag.",
+                "description": (
+                    "The question to flag. Pass for the flag action; omit when "
+                    "passing resolved_by."
+                ),
             },
             "context": {
                 "type": "string",
@@ -441,19 +451,29 @@ FLAG_QUESTION: ToolSpec = {
                 "type": "array",
                 "items": {"type": "string"},
                 "description": (
-                    "Optional list of candidate question ids (Q### or legacy "
-                    "timestamp form) this flag may duplicate. When any named id "
-                    "is already resolved by a decision, the server short-circuits "
-                    "without appending and the response names the resolving "
-                    "decision. Pass when call_context (e.g. a Q### surfaced in "
-                    "L0 you suspect this flag re-raises) makes the duplicate "
-                    "plausible. Freshness is bounded by the most recent pull, "
-                    "so a remote resolution may be missed by a stale local copy."
+                    "Question ids (Q### or legacy timestamp form). On the flag "
+                    "action, an optional list of candidates this flag may "
+                    "duplicate: when any named id is already resolved by a "
+                    "decision, the server short-circuits without appending and "
+                    "the response names the resolving decision. On the resolve "
+                    "action (resolved_by set), the entries to stamp as resolved "
+                    "— every id must exist in open-questions.md or the call is "
+                    "rejected. Freshness is bounded by the most recent pull, so "
+                    "a remote resolution may be missed by a stale local copy."
+                ),
+            },
+            "resolved_by": {
+                "type": "string",
+                "description": (
+                    "Decision id (e.g. D123) that resolves the entries named in "
+                    "targets. When set, the call resolves instead of appending; "
+                    "the id must resolve to a decision that exists in the store. "
+                    "Pass exactly one of question or resolved_by."
                 ),
             },
             "project_id": _PROJECT_PARAM,
         },
-        "required": ["question"],
+        "required": [],
     },
 }
 

--- a/packages/nauro-core/src/nauro_core/operations/decision_lookup.py
+++ b/packages/nauro-core/src/nauro_core/operations/decision_lookup.py
@@ -1,0 +1,31 @@
+"""Decision-stem lookup helpers shared across the operations kernel.
+
+Resolving a decision identifier (any of the shapes
+:func:`~nauro_core.parsing.extract_decision_number` accepts) to its
+on-disk file stem only needs the :class:`~nauro_core.operations.store.Store`
+protocol. Both ``propose_decision`` (supersede target resolution) and
+``flag_question`` (resolve-action existence check) need it, so it lives
+here rather than inside either operation module.
+"""
+
+from __future__ import annotations
+
+from nauro_core.operations.store import Store
+from nauro_core.parsing import extract_decision_number
+
+
+def find_decision_stem_by_num(store: Store, num: int) -> str | None:
+    """Return the file stem whose ``NNN-`` prefix matches ``num``, or None."""
+    prefix = f"{num:03d}-"
+    for stem in store.list_decisions():
+        if stem.startswith(prefix):
+            return stem
+    return None
+
+
+def find_decision_stem_by_id(store: Store, decision_id: str) -> str | None:
+    """Resolve any decision-id shape (stem, ``decision-NNN``, ``DNNN``, int) to a stem."""
+    num = extract_decision_number(decision_id)
+    if num is None:
+        return None
+    return find_decision_stem_by_num(store, num)

--- a/packages/nauro-core/src/nauro_core/operations/flag_question.py
+++ b/packages/nauro-core/src/nauro_core/operations/flag_question.py
@@ -1,4 +1,4 @@
-"""``flag_question`` — append an open question with a sequential ``Q###`` id.
+"""``flag_question`` — append an open question, or resolve existing ones.
 
 Cross-transport implementation: CLI, local stdio MCP, and remote HTTP MCP
 all call this function with the same arguments and receive the same
@@ -7,63 +7,101 @@ plumbing through the :class:`~nauro_core.operations.store.Store` protocol;
 length validation, envelope-token rejection, similarity hinting, snapshot
 capture, and cloud-sync push stay on the adapter side.
 
-The insert routine mirrors the pre-cutover writer so the on-disk format
-stays byte-identical: the new entry is placed directly after the file's
-top-level ``# `` header, skipping blank lines and leading HTML comments.
+Two actions share the entry point, discriminated by ``resolved_by``:
 
-When the caller passes ``targets``, the kernel short-circuits the append
-if any named id already carries a ``resolved_by`` reference, returning a
-rejection envelope naming the resolving decision. Freshness is bounded by
-the working copy the Store sees — on the local stdio surface that is the
-last ``_pull_on_startup`` run; on cloud HTTP MCP it is the per-request
-S3 read.
+* **append** (``resolved_by`` is None) — mint a fresh ``Q###`` and insert
+  it directly after the file's top-level ``# `` header, skipping blank
+  lines and leading HTML comments so the on-disk format stays
+  byte-identical to the pre-cutover writer. When the caller passes
+  ``targets``, the append short-circuits if any named id already carries
+  a ``resolved_by`` reference, returning a rejection envelope naming the
+  resolving decision.
+
+* **resolve** (``resolved_by`` is set) — stamp the entries named in
+  ``targets`` as resolved by that decision, flipping each entry's
+  ``resolved_by`` in place. Blocks are never relocated. Re-resolving an
+  already-resolved id is idempotent (returns ok); the append-path
+  already-resolved short-circuit does not apply here.
+
+Freshness is bounded by the working copy the Store sees — on the local
+stdio surface that is the last ``_pull_on_startup`` run; on cloud HTTP
+MCP it is the per-request S3 read.
 """
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
 from nauro_core.constants import OPEN_QUESTIONS_MD
+from nauro_core.operations.decision_lookup import find_decision_stem_by_num
 from nauro_core.operations.results import ErrorPayload, FlagQuestionResult
 from nauro_core.operations.store import Store
+from nauro_core.parsing import extract_decision_number
 from nauro_core.questions import EntryBlock, OpenQuestionsFile
 
 _DEFAULT_FILE_BODY = "# Open Questions\n"
 
+_FRESHNESS_CAVEAT = "This reads the working copy, only as fresh as the most recent pull."
+
 
 def flag_question(
     store: Store,
-    question: str,
+    question: str | None = None,
     context: str | None = None,
     targets: list[str] | None = None,
+    resolved_by: str | None = None,
 ) -> FlagQuestionResult:
-    """Append *question* to ``open-questions.md`` with a fresh ``Q###`` id.
+    """Append *question*, or resolve the entries named in ``targets``.
 
     Args:
         store: Storage adapter. The kernel reads ``open-questions.md`` via
             :meth:`Store.read_file` and writes through
             :meth:`Store.write_file`. The two calls happen back-to-back
             within the same kernel invocation.
-        question: Composed question body. The adapter is responsible for
-            any caller-side composition (e.g. folding ``context`` into the
+        question: Composed question body for the append action. Required
+            when ``resolved_by`` is None; must be omitted when
+            ``resolved_by`` is set. The adapter is responsible for any
+            caller-side composition (e.g. folding ``context`` into the
             same line) before reaching the kernel.
         context: Reserved for future kernel-side composition. Currently
             unused — the adapter folds context into ``question`` and
             passes ``None`` here so the on-disk format stays unchanged.
-        targets: Optional list of candidate ``Q###`` (or legacy timestamp)
-            ids the caller suspects this question may duplicate. When any
-            named id is found in the file with ``resolved_by`` set, the
-            kernel short-circuits and returns a rejection envelope naming
-            the resolving decision. ``None`` and ``[]`` skip the check and
-            always append. Unknown ids are ignored — the only signal is
-            "this id exists and points at a decision."
+        targets: On the append action, optional candidate ``Q###`` (or
+            legacy timestamp) ids the caller suspects this question may
+            duplicate. On the resolve action, the entries to stamp as
+            resolved — every id must exist in the file or the whole call
+            rejects.
+        resolved_by: A decision identifier (``D123``, ``123``,
+            ``decision-123`` …). When set, the call resolves the
+            ``targets`` entries against that decision instead of
+            appending. The number must resolve to a decision that exists
+            in the store.
 
     Returns:
-        :class:`FlagQuestionResult`. On the success path ``status="ok"``
-        and ``num`` carries the minted identifier. On the short-circuit
-        path ``status="rejected"`` and ``error`` names the resolving
-        decision; no write occurs.
+        :class:`FlagQuestionResult`. On the append success path
+        ``status="ok"`` and ``num`` carries the minted identifier. On the
+        resolve success path ``status="ok"`` and ``num`` stays unset. On
+        any rejection ``status="rejected"`` and ``error`` names the
+        specific failure; no write occurs.
     """
     del context  # adapter composes context into question; kernel sees one body.
 
+    has_question = question is not None and question.strip() != ""
+    if resolved_by is not None:
+        if has_question:
+            return _reject(
+                "Pass either question (to append a new flag) or resolved_by "
+                "(to resolve existing entries), not both."
+            )
+        return _resolve(store, targets or [], resolved_by)
+
+    if not has_question:
+        return _reject(
+            "Pass either question (to append a new flag) or resolved_by "
+            "(to resolve existing entries)."
+        )
+
+    assert question is not None  # narrowed by has_question above.
     content = store.read_file(OPEN_QUESTIONS_MD) or _DEFAULT_FILE_BODY
     parsed = OpenQuestionsFile.parse(content)
 
@@ -132,3 +170,68 @@ def _short_circuit_if_resolved(
             error=ErrorPayload(kind="rejected", reason=reason),
         )
     return None
+
+
+def _reject(reason: str) -> FlagQuestionResult:
+    return FlagQuestionResult(
+        status="rejected",
+        error=ErrorPayload(kind="rejected", reason=reason),
+    )
+
+
+def _resolve(
+    store: Store,
+    targets: list[str],
+    resolved_by: str,
+) -> FlagQuestionResult:
+    """Stamp the ``targets`` entries as resolved by ``resolved_by`` in place.
+
+    Every named id must exist in ``open-questions.md`` as a single entry,
+    and ``resolved_by`` must resolve to a decision that exists in the
+    store. Any unparseable identifier, missing decision, unknown target,
+    or ambiguous target rejects the whole call without writing.
+    """
+    num = extract_decision_number(resolved_by)
+    if num is None:
+        return _reject(
+            f"resolved_by {resolved_by!r} is not a decision identifier "
+            "(expected a form like D123, 123, or decision-123)."
+        )
+
+    if find_decision_stem_by_num(store, num) is None:
+        return _reject(
+            f"resolved_by names decision D{num}, which does not exist in the store. "
+            f"{_FRESHNESS_CAVEAT}"
+        )
+
+    if not targets:
+        return _reject("resolved_by requires at least one id in targets to resolve.")
+
+    content = store.read_file(OPEN_QUESTIONS_MD) or _DEFAULT_FILE_BODY
+    parsed = OpenQuestionsFile.parse(content)
+
+    ambiguous = parsed.ambiguous_ids
+    requested_ambiguous = [t for t in targets if t in ambiguous]
+    if requested_ambiguous:
+        return _reject(
+            "targets contains ambiguous id(s) matching more than one entry: "
+            + ", ".join(repr(t) for t in dict.fromkeys(requested_ambiguous))
+            + ". Disambiguate before resolving."
+        )
+
+    entry_ids = {b.entry.id for b in parsed.blocks if isinstance(b, EntryBlock)}
+    missing = [t for t in targets if t not in entry_ids]
+    if missing:
+        return _reject(
+            "targets contains id(s) not present in open-questions.md: "
+            + ", ".join(repr(t) for t in dict.fromkeys(missing))
+            + f". {_FRESHNESS_CAVEAT}"
+        )
+
+    result = parsed.resolve(
+        ids=targets,
+        decision_num=num,
+        date=datetime.now(timezone.utc).date(),
+    )
+    store.write_file(OPEN_QUESTIONS_MD, result.file.format())
+    return FlagQuestionResult(status="ok", num=None)

--- a/packages/nauro-core/src/nauro_core/operations/propose_decision.py
+++ b/packages/nauro-core/src/nauro_core/operations/propose_decision.py
@@ -49,6 +49,10 @@ from nauro_core.decision_model import (
     format_decision,
     parse_decision,
 )
+from nauro_core.operations.decision_lookup import (
+    find_decision_stem_by_id,
+    find_decision_stem_by_num,
+)
 from nauro_core.operations.results import (
     ErrorPayload,
     ProposeDecisionResult,
@@ -436,7 +440,7 @@ def _do_supersede(
 
     # Flip the old decision. Failure here leaves the new decision standing;
     # sync-repair on next pull recovers the half-state.
-    old_stem = _find_decision_stem_by_num(store, old_num)
+    old_stem = find_decision_stem_by_num(store, old_num)
     if old_stem is None:
         return (
             new_decision_id,
@@ -511,7 +515,7 @@ def _do_update(
     affected_decision_id: str,
 ) -> tuple[str | None, str, tuple[str, ...], tuple[str, ...], ErrorPayload | None]:
     """Rationale-only update: bump version, append dated paragraph."""
-    target_stem = _find_decision_stem_by_id(store, affected_decision_id)
+    target_stem = find_decision_stem_by_id(store, affected_decision_id)
     if target_stem is None:
         return (
             None,
@@ -645,22 +649,6 @@ def _next_decision_num(store: Store) -> int:
         if n is not None:
             nums.append(n)
     return max(nums, default=0) + 1
-
-
-def _find_decision_stem_by_num(store: Store, num: int) -> str | None:
-    prefix = f"{num:03d}-"
-    for stem in store.list_decisions():
-        if stem.startswith(prefix):
-            return stem
-    return None
-
-
-def _find_decision_stem_by_id(store: Store, decision_id: str) -> str | None:
-    """Resolve any decision-id shape (stem, ``decision-NNN``, ``DNNN``, int) to a stem."""
-    num = extract_decision_number(decision_id)
-    if num is None:
-        return None
-    return _find_decision_stem_by_num(store, num)
 
 
 def _slugify(title: str) -> str:

--- a/packages/nauro-core/tests/operations/test_operations_flag_question.py
+++ b/packages/nauro-core/tests/operations/test_operations_flag_question.py
@@ -11,6 +11,7 @@ primitives.
 from __future__ import annotations
 
 import ast
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -243,6 +244,166 @@ def test_short_circuit_envelope_mentions_working_copy_freshness() -> None:
     assert result.status == "rejected"
     assert result.error is not None
     assert "pull" in result.error.reason.lower()
+
+
+# --- resolve action (resolved_by) ---
+
+
+def _open_q1_q5_seed() -> str:
+    return "# Open Questions\n\n- [Q1] still open\n- [Q5] also still open\n"
+
+
+def _decisions(*nums: int) -> dict[str, str]:
+    return {f"{n:03d}-some-decision": f"# Decision {n}\n" for n in nums}
+
+
+def test_resolve_stamps_target_in_place_and_returns_ok() -> None:
+    store = InMemoryStore(
+        decisions=_decisions(42),
+        files={OPEN_QUESTIONS_MD: _open_q1_q5_seed()},
+    )
+    result = flag_question(store, targets=["Q5"], resolved_by="D42")
+    assert result.status == "ok"
+    assert result.num is None
+    content = store.read_file(OPEN_QUESTIONS_MD)
+    assert content is not None
+    # Q5 is stamped in place — its line keeps its position (after Q1) and the
+    # entry block is never relocated under ## Resolved.
+    lines = content.split("\n")
+    q5_line = next(line for line in lines if "[Q5]" in line)
+    assert q5_line.startswith("- [Resolved by D42 on ")
+    assert "[Q1] still open" in content
+    assert lines.index(q5_line) > lines.index("- [Q1] still open")
+
+
+def test_resolve_does_not_append_a_question() -> None:
+    store = InMemoryStore(
+        decisions=_decisions(42),
+        files={OPEN_QUESTIONS_MD: _open_q1_q5_seed()},
+    )
+    flag_question(store, targets=["Q5"], resolved_by="D42")
+    content = store.read_file(OPEN_QUESTIONS_MD)
+    assert content is not None
+    # Only the two seeded ids exist; nothing was minted.
+    assert content.count("- [Q") == 1  # Q1 (open); Q5 now carries the Resolved prefix.
+    assert "[Q6]" not in content
+
+
+def test_resolve_already_resolved_id_is_idempotent_ok() -> None:
+    store = InMemoryStore(
+        decisions=_decisions(42),
+        files={OPEN_QUESTIONS_MD: _resolved_q5_seed()},
+    )
+    before = store.read_file(OPEN_QUESTIONS_MD)
+    result = flag_question(store, targets=["Q5"], resolved_by="D42")
+    # The append-path already-resolved short-circuit must NOT fire on the
+    # resolve path; re-resolving the same id is a no-op success.
+    assert result.status == "ok"
+    after = store.read_file(OPEN_QUESTIONS_MD)
+    assert after == before
+
+
+def test_resolve_unparseable_decision_id_rejects() -> None:
+    store = InMemoryStore(files={OPEN_QUESTIONS_MD: _open_q1_q5_seed()})
+    result = flag_question(store, targets=["Q5"], resolved_by="not-a-decision")
+    assert result.status == "rejected"
+    assert result.num is None
+    assert result.error is not None
+    assert "not-a-decision" in result.error.reason
+
+
+def test_resolve_missing_decision_rejects_naming_number() -> None:
+    store = InMemoryStore(files={OPEN_QUESTIONS_MD: _open_q1_q5_seed()})
+    result = flag_question(store, targets=["Q5"], resolved_by="D99")
+    assert result.status == "rejected"
+    assert result.error is not None
+    assert "D99" in result.error.reason
+    # No write occurred — the open question stays open.
+    content = store.read_file(OPEN_QUESTIONS_MD)
+    assert content is not None
+    assert "- [Q5] also still open" in content
+
+
+def test_resolve_unknown_target_rejects_whole_call_naming_id() -> None:
+    store = InMemoryStore(
+        decisions=_decisions(42),
+        files={OPEN_QUESTIONS_MD: _open_q1_q5_seed()},
+    )
+    before = store.read_file(OPEN_QUESTIONS_MD)
+    result = flag_question(store, targets=["Q5", "Q404"], resolved_by="D42")
+    assert result.status == "rejected"
+    assert result.error is not None
+    assert "Q404" in result.error.reason
+    # The whole call is rejected: Q5 must NOT be partially resolved.
+    assert store.read_file(OPEN_QUESTIONS_MD) == before
+
+
+def test_resolve_ambiguous_target_rejects_naming_id() -> None:
+    seed = (
+        "# Open Questions\n"
+        "\n"
+        "- [2026-04-30 10:00 UTC] first collision\n"
+        "- [2026-04-30 10:00 UTC] second collision\n"
+    )
+    store = InMemoryStore(
+        decisions=_decisions(42),
+        files={OPEN_QUESTIONS_MD: seed},
+    )
+    result = flag_question(store, targets=["2026-04-30 10:00 UTC"], resolved_by="D42")
+    assert result.status == "rejected"
+    assert result.error is not None
+    assert "2026-04-30 10:00 UTC" in result.error.reason
+
+
+def test_resolve_with_no_targets_rejects() -> None:
+    store = InMemoryStore(decisions=_decisions(42))
+    result = flag_question(store, targets=[], resolved_by="D42")
+    assert result.status == "rejected"
+    assert result.error is not None
+
+
+def test_resolve_missing_decision_reason_mentions_freshness() -> None:
+    store = InMemoryStore(files={OPEN_QUESTIONS_MD: _open_q1_q5_seed()})
+    result = flag_question(store, targets=["Q5"], resolved_by="D99")
+    assert result.status == "rejected"
+    assert result.error is not None
+    assert "pull" in result.error.reason.lower()
+
+
+def test_resolve_uses_utc_now_date() -> None:
+    store = InMemoryStore(
+        decisions=_decisions(42),
+        files={OPEN_QUESTIONS_MD: _open_q1_q5_seed()},
+    )
+    today = datetime.now(timezone.utc).date().isoformat()
+    flag_question(store, targets=["Q5"], resolved_by="D42")
+    content = store.read_file(OPEN_QUESTIONS_MD)
+    assert content is not None
+    assert f"[Resolved by D42 on {today}]" in content
+
+
+# --- neither / both ---
+
+
+def test_neither_question_nor_resolved_by_rejects() -> None:
+    store = InMemoryStore()
+    result = flag_question(store)
+    assert result.status == "rejected"
+    assert result.error is not None
+    assert "question" in result.error.reason.lower()
+
+
+def test_both_question_and_resolved_by_rejects() -> None:
+    store = InMemoryStore(
+        decisions=_decisions(42),
+        files={OPEN_QUESTIONS_MD: _open_q1_q5_seed()},
+    )
+    before = store.read_file(OPEN_QUESTIONS_MD)
+    result = flag_question(store, question="a flag", targets=["Q5"], resolved_by="D42")
+    assert result.status == "rejected"
+    assert result.error is not None
+    # Neither action ran — no append, no resolve.
+    assert store.read_file(OPEN_QUESTIONS_MD) == before
 
 
 # --- Import-graph negative constraint ---

--- a/packages/nauro/src/nauro/mcp/stdio_server.py
+++ b/packages/nauro/src/nauro/mcp/stdio_server.py
@@ -355,12 +355,17 @@ def propose_decision(
 
 @mcp.tool(**_spec_kwargs("flag_question"))
 def flag_question(
-    question: Annotated[str, Field(description=_param_desc("flag_question", "question"))],
+    question: Annotated[
+        str | None, Field(description=_param_desc("flag_question", "question"))
+    ] = None,
     context: Annotated[
         str | None, Field(description=_param_desc("flag_question", "context"))
     ] = None,
     targets: Annotated[
         list[str] | None, Field(description=_param_desc("flag_question", "targets"))
+    ] = None,
+    resolved_by: Annotated[
+        str | None, Field(description=_param_desc("flag_question", "resolved_by"))
     ] = None,
     project_id: Annotated[
         str | None, Field(description=_param_desc("flag_question", "project_id"))
@@ -373,11 +378,15 @@ def flag_question(
         return WELCOME_NO_PROJECT
     except StoreResolutionError as exc:
         return str(exc)
-    result = tool_flag_question(store_path, question, context, targets=targets)
+    result = tool_flag_question(
+        store_path, question, context, targets=targets, resolved_by=resolved_by
+    )
     if result.get("status") == "rejected":
         error = result.get("error") or {}
         reason = error.get("reason", "Flag rejected.")
         return reason
+    if resolved_by is not None:
+        return "Question(s) resolved."
     if result.get("hint"):
         return f"{result['hint']} The question has still been logged."
     return "Question flagged."

--- a/packages/nauro/src/nauro/mcp/tools.py
+++ b/packages/nauro/src/nauro/mcp/tools.py
@@ -440,50 +440,60 @@ Check for conflicts with existing decisions without writing anything.
 @_stamp_identity
 def tool_flag_question(
     store_path: Path,
-    question: str,
+    question: str | None = None,
     context: str | None = None,
     targets: list[str] | None = None,
+    resolved_by: str | None = None,
 ) -> dict:
-    """Flag an open question for human review. Always writes the question."""
+    """Flag an open question, or resolve existing entries against a decision.
+
+    With ``resolved_by`` set the kernel stamps the ``targets`` entries as
+    resolved; otherwise it appends ``question`` as a new flag. Both are
+    writes — on success the adapter captures a snapshot and pushes; on
+    rejection no write occurred so neither runs.
+    """
     guidance = _check_store_exists(store_path)
     if guidance:
         return {"store": "local", "status": "error", "guidance": guidance}
 
+    if resolved_by is not None:
+        return _flag_question_resolve(store_path, targets, resolved_by)
+
     # Content size limits
     for err in (
-        _reject_if_too_long(question, "Question", MAX_QUESTION_LENGTH),
+        _reject_if_too_long(question or "", "Question", MAX_QUESTION_LENGTH) if question else None,
         _reject_if_too_long(context or "", "Context", MAX_CONTEXT_LENGTH) if context else None,
     ):
         if err:
             return err
 
     # Reject tool-use envelope fragments that leaked from XML-emitting clients.
-    for field_name, value in (("question", question), ("context", context or "")):
+    for field_name, value in (("question", question or ""), ("context", context or "")):
         err = _reject_if_envelope_token(value, field_name)
         if err:
             return err
 
-    pseudo_proposal = {
-        "title": question[:100],
-        "rationale": question + (f" {context}" if context else ""),
-    }
-
     hint = None
-    try:
-        from nauro.store.reader import _list_decisions
+    if question:
+        pseudo_proposal = {
+            "title": question[:100],
+            "rationale": question + (f" {context}" if context else ""),
+        }
+        try:
+            from nauro.store.reader import _list_decisions
 
-        _, similar = check_bm25_similarity(pseudo_proposal, _list_decisions(store_path))
-        if similar and similar[0].get("similarity", 0) > 0.7:
-            top = similar[0]
-            hint = (
-                f"This question appears to be addressed by "
-                f"decision-{top['number']:03d}: {top['title']}."
-            )
-    except Exception:
-        pass
+            _, similar = check_bm25_similarity(pseudo_proposal, _list_decisions(store_path))
+            if similar and similar[0].get("similarity", 0) > 0.7:
+                top = similar[0]
+                hint = (
+                    f"This question appears to be addressed by "
+                    f"decision-{top['number']:03d}: {top['title']}."
+                )
+        except Exception:
+            pass
 
     text = question
-    if context:
+    if question and context:
         text = f"{question} (context: {context})"
     result = _flag_question_op(FilesystemStore(store_path), text, None, targets=targets)
 
@@ -502,6 +512,36 @@ def tool_flag_question(
     capture_snapshot(store_path, trigger=f"question: {question}")
     if hint:
         response["hint"] = hint
+    _try_push(store_path)
+    return response
+
+
+def _flag_question_resolve(
+    store_path: Path,
+    targets: list[str] | None,
+    resolved_by: str,
+) -> dict:
+    """Resolve the ``targets`` entries against ``resolved_by``.
+
+    Skips the BM25 similarity hint — resolving against a known decision is
+    not a duplicate-flag situation. On success this is a write, so capture
+    a snapshot (labelled to distinguish resolve from append) and push; on
+    rejection the kernel performed no write, so neither runs.
+    """
+    result = _flag_question_op(
+        FilesystemStore(store_path),
+        None,
+        None,
+        targets=targets,
+        resolved_by=resolved_by,
+    )
+    response: dict = {"store": "local", **result.model_dump(mode="json", exclude_none=True)}
+    response.pop("num", None)
+
+    if result.status == "rejected":
+        return response
+
+    capture_snapshot(store_path, trigger=f"resolved by {resolved_by}: {targets or []}")
     _try_push(store_path)
     return response
 

--- a/packages/nauro/tests/test_flag_question_cross_surface.py
+++ b/packages/nauro/tests/test_flag_question_cross_surface.py
@@ -98,3 +98,38 @@ def test_repeated_writes_match_across_stores(both_stores):
     assert _dump(fs_one) == _dump(cloud_one) == {"status": "ok", "num": 1}
     assert _dump(fs_two) == _dump(cloud_two) == {"status": "ok", "num": 2}
     assert fs_store.read_file(OPEN_QUESTIONS_MD) == cloud.read_file(OPEN_QUESTIONS_MD)
+
+
+def _seed_resolvable(fs_store: FilesystemStore, cloud: CloudStore) -> None:
+    seed = "# Open Questions\n\n- [Q1] needs a decision\n"
+    _seed_open_questions(fs_store, cloud, seed)
+    decision = "# Decision 42\n"
+    fs_store.write_file("decisions/042-some-decision.md", decision)
+    cloud.write_file("decisions/042-some-decision.md", decision)
+
+
+def test_resolve_matches_across_stores(both_stores):
+    fs_store, cloud = both_stores
+    _seed_resolvable(fs_store, cloud)
+
+    fs_result = flag_question(fs_store, targets=["Q1"], resolved_by="D42")
+    cloud_result = flag_question(cloud, targets=["Q1"], resolved_by="D42")
+
+    assert _dump(fs_result) == _dump(cloud_result) == {"status": "ok"}
+    # The resolve stamps the entry in place identically on both stores.
+    assert fs_store.read_file(OPEN_QUESTIONS_MD) == cloud.read_file(OPEN_QUESTIONS_MD)
+    assert "[Resolved by D42 on " in fs_store.read_file(OPEN_QUESTIONS_MD)
+
+
+def test_resolve_missing_decision_rejects_across_stores(both_stores):
+    fs_store, cloud = both_stores
+    seed = "# Open Questions\n\n- [Q1] needs a decision\n"
+    _seed_open_questions(fs_store, cloud, seed)
+
+    fs_result = flag_question(fs_store, targets=["Q1"], resolved_by="D42")
+    cloud_result = flag_question(cloud, targets=["Q1"], resolved_by="D42")
+
+    assert fs_result.status == cloud_result.status == "rejected"
+    # No write on either store — the question stays open and identical.
+    assert fs_store.read_file(OPEN_QUESTIONS_MD) == cloud.read_file(OPEN_QUESTIONS_MD)
+    assert "[Resolved by" not in fs_store.read_file(OPEN_QUESTIONS_MD)

--- a/packages/nauro/tests/test_flag_question_parity.py
+++ b/packages/nauro/tests/test_flag_question_parity.py
@@ -96,7 +96,7 @@ def test_ok_envelope_matches_across_tool_and_cli(seeded_repo):
     pid, store_path = seeded_repo
 
     tool_envelope = tool_flag_question(store_path, "Should we ship X?")
-    exit_code, cli_envelope, output = _cli_envelope(["Should we ship Y?"])
+    exit_code, cli_envelope, output = _cli_envelope(["--question", "Should we ship Y?"])
     assert exit_code == 0, output
     # Every local surface now carries project identity alongside store.
     assert tool_envelope.pop("project")["id"] == pid
@@ -114,7 +114,7 @@ def test_missing_store_guidance_matches_across_surfaces(missing_store):
     assert tool_envelope["status"] == "error"
     assert "nauro init" in tool_envelope["guidance"]
 
-    exit_code, _cli_envelope_dict, output = _cli_envelope(["anything?"])
+    exit_code, _cli_envelope_dict, output = _cli_envelope(["--question", "anything?"])
     assert exit_code == 1
     assert "nauro init" in output
 
@@ -129,8 +129,73 @@ def test_length_rejection_matches_across_tool_and_cli(seeded_repo):
     assert tool_envelope["error"]["kind"] == "rejected"
     assert "exceeds" in tool_envelope["error"]["reason"].lower()
 
-    exit_code, cli_envelope, output = _cli_envelope([overlong])
+    exit_code, cli_envelope, output = _cli_envelope(["--question", overlong])
     # Length rejection surfaces as ``status: "rejected"`` which the auto-gen
     # exit-code branch treats as a successful envelope (non-error).
+    assert exit_code == 0, output
+    assert cli_envelope == tool_envelope
+
+
+def _seed_resolvable(store_path, q_id: str = "Q1") -> None:
+    """Seed one open question and one decision the resolve action can target."""
+    (store_path / "open-questions.md").write_text(
+        f"# Open Questions\n\n- [{q_id}] needs a decision\n"
+    )
+    decisions = store_path / "decisions"
+    decisions.mkdir(exist_ok=True)
+    (decisions / "042-some-decision.md").write_text("# Decision 42\n")
+
+
+def test_resolve_ok_matches_across_tool_and_cli(seeded_repo):
+    pid, store_path = seeded_repo
+    _seed_resolvable(store_path, "Q1")
+
+    tool_envelope = tool_flag_question(store_path, resolved_by="D42", targets=["Q1"])
+    assert tool_envelope.pop("project")["id"] == pid
+    assert tool_envelope == {"store": "local", "status": "ok"}
+    # The targeted entry is stamped in place; nothing appended.
+    content = (store_path / "open-questions.md").read_text()
+    assert "[Resolved by D42 on " in content
+    assert "[Q2]" not in content
+
+    # Reset and exercise the same resolve through the CLI surface.
+    _seed_resolvable(store_path, "Q1")
+    exit_code, cli_envelope, output = _cli_envelope(["--resolved-by", "D42", "--targets", "Q1"])
+    assert exit_code == 0, output
+    assert cli_envelope.pop("project")["id"] == pid
+    assert cli_envelope == {"store": "local", "status": "ok"}
+
+    # And the stdio surface returns the resolve-specific confirmation string.
+    _seed_resolvable(store_path, "Q1")
+    stdio_string = stdio_flag_question(resolved_by="D42", targets=["Q1"], project_id=pid)
+    assert stdio_string == "Question(s) resolved."
+
+
+def test_resolve_unknown_decision_rejection_matches_across_tool_and_cli(seeded_repo):
+    pid, store_path = seeded_repo
+    _seed_resolvable(store_path, "Q1")
+
+    tool_envelope = tool_flag_question(store_path, resolved_by="D777", targets=["Q1"])
+    assert tool_envelope["store"] == "local"
+    assert tool_envelope["status"] == "rejected"
+    assert "D777" in tool_envelope["error"]["reason"]
+    # No write: the question stays open.
+    assert "[Resolved by" not in (store_path / "open-questions.md").read_text()
+
+    exit_code, cli_envelope, output = _cli_envelope(["--resolved-by", "D777", "--targets", "Q1"])
+    # Caller-fixable rejection stays exit 0 (the auto-gen rejection branch).
+    assert exit_code == 0, output
+    assert cli_envelope == tool_envelope
+
+
+def test_neither_question_nor_resolved_by_rejects_across_tool_and_cli(seeded_repo):
+    pid, store_path = seeded_repo
+
+    tool_envelope = tool_flag_question(store_path)
+    assert tool_envelope["store"] == "local"
+    assert tool_envelope["status"] == "rejected"
+    assert "question" in tool_envelope["error"]["reason"].lower()
+
+    exit_code, cli_envelope, output = _cli_envelope([])
     assert exit_code == 0, output
     assert cli_envelope == tool_envelope


### PR DESCRIPTION
## Why
`flag_question` could only append open questions. Resolving them required a full
decision write through the open-question resolution channel, so an agent that just
wanted to stamp questions as answered by an existing decision had to write or amend
a decision to flip a question's state.

## Approach
Extend the existing `flag_question` entry point with a resolve action gated on a new
optional `resolved_by` field — the same optional-channel pattern the existing `targets`
short-circuit uses, rather than a new tool or op. Branching on `resolved_by` keeps the
append path unchanged while the resolve path reuses the kernel's in-place resolution
(entries are stamped where they sit, never relocated). Adapters only thread the field
through; the resolve logic stays in the kernel so every surface inherits identical
validation. A separate resolve tool/op was rejected — it would duplicate the question
parsing, the decision-existence check, and the result shape for no gain.

## What changed
- Kernel: `flag_question` gains optional `resolved_by`. Set → resolves the entries named
  in `targets` against that decision; unset → existing append path. Resolve validates the
  decision exists, rejects the whole call (naming the id) on any unknown/ambiguous target,
  and is idempotent on already-resolved ids. `question` is now optional with the kernel
  enforcing exactly-one-of `question`/`resolved_by`.
- Shared lookup: the decision-stem lookup both the writer and resolve need moves to a small
  shared operations module, imported by both.
- Tool metadata: `resolved_by` documented, `targets` covers both actions, `question` no
  longer required.
- Adapters: stdio threads `resolved_by` through, labels the resolve snapshot distinctly,
  skips the duplicate-question hint on resolve. The CLI surfaces `--resolved-by`
  automatically through the existing generator (no generator change).

## What to review
- Reject ordering in the resolve path (unparseable → missing decision → empty targets →
  ambiguous → unknown). Ambiguity is checked before existence on purpose.
- CLI surface: dropping `question` from the tool's required list moves it from a positional
  to `--question`, symmetric with `--resolved-by`. The bare-positional human path for
  appending is `nauro note "...?"` (unchanged). Append-path tests updated accordingly.
- The neither/both guard, and that no write occurs on any rejection branch.

## What's deferred
- The cloud adapter + dispatcher pass-through for `resolved_by` ship in a follow-up, gated
  on a nauro-core release. The cross-surface parity tests are in place but skip until the
  cloud adapter is installed alongside this package.
- No version bump, tag, or publish here — the release is a separate step.

## Test plan
- nauro-core: 603 pass (+33 new kernel tests: in-place stamping, no-append, idempotent
  re-resolve, UTC date, unparseable/missing/unknown/ambiguous rejections, neither/both).
- nauro: 1021 pass + 10 skipped (cloud-gated). New three-layer parity tests across adapter,
  CLI, and stdio, plus cross-store resolve parity that activates with the cloud adapter.
- `ruff check` / `format --check` clean.
