### PR TITLE
feat(questions): add nauro questions migrate for legacy id cutover

### DIFF
--- a/packages/nauro-core/src/nauro_core/questions.py
+++ b/packages/nauro-core/src/nauro_core/questions.py
@@ -172,6 +172,39 @@ Block = Annotated[
 
 
 @dataclass(frozen=True)
+class MigrationRename:
+    """One legacy entry's rename, recorded by :meth:`OpenQuestionsFile.migrate`.
+
+    Attributes:
+        old_id: The legacy ``YYYY-MM-DD HH:MM UTC`` id the entry carried.
+        new_id: The minted ``Q###`` id that replaces it.
+        logged: The ``(logged YYYY-MM-DD HH:MM UTC)`` text appended to the
+            body so the human timestamp survives the id rewrite.
+    """
+
+    old_id: str
+    new_id: str
+    logged: str
+
+
+@dataclass(frozen=True)
+class MigrationResult:
+    """Outcome of :meth:`OpenQuestionsFile.migrate`.
+
+    Attributes:
+        file: A new :class:`OpenQuestionsFile` with legacy entries minted
+            into Q-form. Non-legacy blocks are the same objects as the
+            input, so a file with no legacy entries returns an unchanged
+            ``blocks`` list (idempotent).
+        renames: One :class:`MigrationRename` per legacy entry migrated, in
+            block order. Empty when nothing was migrated.
+    """
+
+    file: OpenQuestionsFile
+    renames: tuple[MigrationRename, ...]
+
+
+@dataclass(frozen=True)
 class ResolveResult:
     """Outcome of :meth:`OpenQuestionsFile.resolve`.
 
@@ -403,6 +436,61 @@ class OpenQuestionsFile(BaseModel):
             file=self.model_copy(update={"blocks": new_blocks}),
             moved_ids=moved,
             unknown_ids=unknown,
+        )
+
+    def migrate(self) -> MigrationResult:
+        """Mint a ``Q###`` id for every legacy ``[timestamp]`` entry.
+
+        A legacy entry is an :class:`EntryBlock` whose ``QuestionEntry`` has
+        ``timestamp`` set and ``num`` unset. Each such entry is reassigned
+        the next sequential id — ``max(num across the whole file) + 1``,
+        continuing past any existing Q ids — with ``timestamp`` cleared and
+        the original timestamp appended to the body as
+        ``(logged YYYY-MM-DD HH:MM UTC)``.
+
+        A resolved legacy entry keeps its ``resolved_by`` prefix; only the
+        ``[<timestamp>]`` id segment becomes ``[Q###]`` because
+        :meth:`QuestionEntry.render` builds the head from model fields.
+        Entries are never reordered — an entry physically under
+        ``## Resolved`` stays there with its id rewritten.
+
+        Only touched legacy entries are ``model_copy``'d; every other block
+        is reused by reference, so a file that is already all-Q-form returns
+        an unchanged ``blocks`` list and empty ``renames`` (idempotent).
+        """
+        next_num = (
+            max(
+                (
+                    b.entry.num
+                    for b in self.blocks
+                    if isinstance(b, EntryBlock) and b.entry.num is not None
+                ),
+                default=0,
+            )
+            + 1
+        )
+
+        renames: list[MigrationRename] = []
+        new_blocks: list[Block] = []
+        for b in self.blocks:
+            if isinstance(b, EntryBlock) and b.entry.timestamp is not None and b.entry.num is None:
+                old_id = b.entry.id
+                logged = f"(logged {b.entry.timestamp.strftime(_TIMESTAMP_FMT)})"
+                new_body = f"{b.entry.body} {logged}" if b.entry.body else logged
+                new_entry = b.entry.model_copy(
+                    update={"num": next_num, "timestamp": None, "body": new_body}
+                )
+                new_blocks.append(EntryBlock(entry=new_entry))
+                renames.append(
+                    MigrationRename(old_id=old_id, new_id=f"Q{next_num}", logged=logged)
+                )
+                next_num += 1
+            else:
+                new_blocks.append(b)
+
+        return MigrationResult(
+            file=self.model_copy(update={"blocks": new_blocks}),
+            renames=tuple(renames),
         )
 
 

--- a/packages/nauro-core/tests/test_questions.py
+++ b/packages/nauro-core/tests/test_questions.py
@@ -8,6 +8,7 @@ from pydantic import ValidationError
 from nauro_core.questions import (
     EntryBlock,
     HeaderBlock,
+    MigrationRename,
     OpenQuestionsFile,
     ProseBlock,
     QuestionEntry,
@@ -629,3 +630,199 @@ class TestResolveRejectsAmbiguous:
         assert result.ambiguous_ids == ("2026-05-12 20:18 UTC",)
         assert result.moved_ids == ()
         assert result.file.format() == before
+
+
+class TestMigrate:
+    """Legacy ``[timestamp]`` -> sequential ``Q###`` migration."""
+
+    def test_mints_sequential_ids_and_appends_logged_timestamp(self):
+        content = (
+            "# Open Questions\n"
+            "\n"
+            "- [2026-05-12 20:18 UTC] first legacy q\n"
+            "- [2026-05-11 15:29 UTC] second legacy q\n"
+        )
+        result = OpenQuestionsFile.parse(content).migrate()
+        assert result.file.format() == (
+            "# Open Questions\n"
+            "\n"
+            "- [Q1] first legacy q (logged 2026-05-12 20:18 UTC)\n"
+            "- [Q2] second legacy q (logged 2026-05-11 15:29 UTC)\n"
+        )
+        assert result.renames == (
+            MigrationRename(
+                old_id="2026-05-12 20:18 UTC",
+                new_id="Q1",
+                logged="(logged 2026-05-12 20:18 UTC)",
+            ),
+            MigrationRename(
+                old_id="2026-05-11 15:29 UTC",
+                new_id="Q2",
+                logged="(logged 2026-05-11 15:29 UTC)",
+            ),
+        )
+
+    def test_continues_past_existing_q_ids(self):
+        """The next id is max(num) + 1 across the whole file, not 1."""
+        content = (
+            "# Open Questions\n"
+            "\n"
+            "- [Q5] already migrated\n"
+            "- [2026-05-12 20:18 UTC] legacy after a high Q\n"
+        )
+        result = OpenQuestionsFile.parse(content).migrate()
+        assert result.renames == (
+            MigrationRename(
+                old_id="2026-05-12 20:18 UTC",
+                new_id="Q6",
+                logged="(logged 2026-05-12 20:18 UTC)",
+            ),
+        )
+        assert "- [Q5] already migrated\n" in result.file.format()
+        assert "- [Q6] legacy after a high Q (logged 2026-05-12 20:18 UTC)\n" in (
+            result.file.format()
+        )
+
+    def test_resolved_legacy_entry_keeps_prefix_rewrites_id(self):
+        """A resolved legacy entry keeps its [Resolved by ...] prefix; only
+        the id segment becomes [Q###]."""
+        content = (
+            "# Open Questions\n"
+            "\n"
+            "- [2026-05-12 20:18 UTC] still open\n"
+            "\n"
+            "## Resolved\n"
+            "\n"
+            "- [Resolved by D100 on 2026-05-01] [2026-04-30 10:00 UTC] q-old\n"
+        )
+        result = OpenQuestionsFile.parse(content).migrate()
+        out = result.file.format()
+        assert "- [Q1] still open (logged 2026-05-12 20:18 UTC)" in out
+        assert "- [Resolved by D100 on 2026-05-01] [Q2] q-old (logged 2026-04-30 10:00 UTC)" in out
+
+    def test_resolved_entry_stays_under_resolved_divider(self):
+        """No relocation: the resolved entry keeps its position after the
+        ## Resolved divider with its id rewritten."""
+        content = (
+            "# Open Questions\n"
+            "\n"
+            "- [2026-05-12 20:18 UTC] open\n"
+            "\n"
+            "## Resolved\n"
+            "\n"
+            "- [Resolved by D100 on 2026-05-01] [2026-04-30 10:00 UTC] q-old\n"
+        )
+        result = OpenQuestionsFile.parse(content).migrate()
+        assert result.file.open_ids == ["Q1"]
+        assert result.file.resolved_ids == ["Q2"]
+
+    def test_idempotent_on_all_q_form(self):
+        content = (
+            "# Open Questions\n"
+            "\n"
+            "- [Q1] one\n"
+            "- [Q2] two\n"
+            "\n"
+            "## Resolved\n"
+            "\n"
+            "- [Resolved by D100 on 2026-05-01] [Q3] three\n"
+        )
+        result = OpenQuestionsFile.parse(content).migrate()
+        assert result.renames == ()
+        assert result.file.format() == content
+
+    def test_non_legacy_blocks_are_byte_identical(self):
+        """Prose, ### blocks, headers, the divider, unparsable lines, and
+        already-Q entries round-trip verbatim through migrate."""
+        content = (
+            "# Open Questions\n"
+            "\n"
+            "Free-form intro a human wrote.\n"
+            "\n"
+            "### [2026-05-10 09:00 UTC] Topic: deployment\n"
+            "Topic narrative kept verbatim.\n"
+            "\n"
+            "- [Q4] already migrated\n"
+            "- [not-a-timestamp] garbage but please keep\n"
+            "- [2026-05-12 20:18 UTC] the one legacy entry\n"
+        )
+        result = OpenQuestionsFile.parse(content).migrate()
+        out = result.file.format()
+        # Only the single legacy entry changed.
+        assert "- [Q5] the one legacy entry (logged 2026-05-12 20:18 UTC)" in out
+        # Everything else is verbatim.
+        for verbatim in (
+            "Free-form intro a human wrote.",
+            "### [2026-05-10 09:00 UTC] Topic: deployment",
+            "Topic narrative kept verbatim.",
+            "- [Q4] already migrated",
+            "- [not-a-timestamp] garbage but please keep",
+        ):
+            assert verbatim in out
+
+    def test_migrated_output_reparses_stably(self):
+        """Re-parsing migrated output and re-formatting is a fixed point."""
+        content = (
+            "# Open Questions\n"
+            "\n"
+            "- [2026-05-12 20:18 UTC] q1\n"
+            "  Context: a continuation line\n"
+            "\n"
+            "## Resolved\n"
+            "\n"
+            "- [Resolved by D100 on 2026-05-01] [2026-04-30 10:00 UTC] q-old\n"
+        )
+        once = OpenQuestionsFile.parse(content).migrate().file.format()
+        twice = OpenQuestionsFile.parse(once).format()
+        assert once == twice
+        # And a second migrate over the migrated output is a no-op.
+        second = OpenQuestionsFile.parse(once).migrate()
+        assert second.renames == ()
+        assert second.file.format() == once
+
+    def test_continuation_lines_survive(self):
+        content = (
+            "# Open Questions\n"
+            "\n"
+            "- [2026-05-12 20:18 UTC] q1\n"
+            "  Context: extra detail\n"
+            "  Another line\n"
+        )
+        result = OpenQuestionsFile.parse(content).migrate()
+        assert result.file.format() == (
+            "# Open Questions\n"
+            "\n"
+            "- [Q1] q1 (logged 2026-05-12 20:18 UTC)\n"
+            "  Context: extra detail\n"
+            "  Another line\n"
+        )
+
+    def test_empty_file_is_noop(self):
+        result = OpenQuestionsFile.parse("").migrate()
+        assert result.renames == ()
+        assert result.file.format() == "# Open Questions"
+
+    def test_same_minute_collision_gets_distinct_ids(self):
+        """Two legacy entries sharing one timestamp id — the collision this
+        migration exists to fix — mint two distinct Q ids and stop being
+        ambiguous."""
+        content = (
+            "# Open Questions\n"
+            "\n"
+            "- [2026-05-12 20:18 UTC] first colliding question\n"
+            "- [2026-05-12 20:18 UTC] second colliding question\n"
+        )
+        parsed = OpenQuestionsFile.parse(content)
+        assert parsed.ambiguous_ids == {"2026-05-12 20:18 UTC": 2}
+
+        result = parsed.migrate()
+        new_ids = [r.new_id for r in result.renames]
+        assert new_ids == ["Q1", "Q2"]
+        assert len(set(new_ids)) == 2
+        # Both records carry the shared legacy id.
+        assert [r.old_id for r in result.renames] == [
+            "2026-05-12 20:18 UTC",
+            "2026-05-12 20:18 UTC",
+        ]
+        # The collision is gone after migration.
+        assert result.file.ambiguous_ids == {}

--- a/packages/nauro/src/nauro/cli/commands/questions.py
+++ b/packages/nauro/src/nauro/cli/commands/questions.py
@@ -1,0 +1,69 @@
+"""nauro questions — maintenance commands for open-questions.md.
+
+``migrate`` mints a sequential ``Q###`` id for every legacy
+``[YYYY-MM-DD HH:MM UTC]`` entry left over from before the Q-form writer
+rollout. It is a one-shot local maintenance command — the parse/format
+model and the migration logic live in
+:mod:`nauro_core.questions`; this surface only locates the store, drives
+the kernel helper, and prints a summary.
+"""
+
+import typer
+from nauro_core.constants import OPEN_QUESTIONS_MD
+from nauro_core.questions import OpenQuestionsFile
+
+from nauro.cli.utils import resolve_target_project
+from nauro.store.filesystem_store import FilesystemStore
+from nauro.templates.agents_md_regen import warn_then_regen
+
+questions_app = typer.Typer(help="Maintenance commands for open-questions.md.")
+
+_DEFAULT_FILE_BODY = "# Open Questions\n"
+
+
+@questions_app.command(name="migrate")
+def migrate(
+    project: str | None = typer.Option(
+        None,
+        "--project",
+        help="Target project name. Overrides cwd resolution.",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Print the legacy to Q### rename map and write nothing.",
+    ),
+) -> None:
+    """Mint sequential ``Q###`` ids for legacy timestamp question entries."""
+    project_name, store_path = resolve_target_project(project)
+    fs_store = FilesystemStore(store_path)
+
+    content = fs_store.read_file(OPEN_QUESTIONS_MD) or _DEFAULT_FILE_BODY
+    result = OpenQuestionsFile.parse(content).migrate()
+
+    if not result.renames:
+        typer.echo(f"No legacy question entries to migrate in {project_name}.")
+        return
+
+    if dry_run:
+        typer.echo(f"Would migrate {len(result.renames)} entry(ies) in {project_name}:")
+        for rename in result.renames:
+            typer.echo(f"  [{rename.old_id}] -> [{rename.new_id}]  +{rename.logged}")
+        typer.echo("Dry run: no changes written.")
+        return
+
+    fs_store.write_file(OPEN_QUESTIONS_MD, result.file.format())
+    typer.echo(f"Migrated {len(result.renames)} entry(ies) in {project_name}:")
+    for rename in result.renames:
+        typer.echo(f"  [{rename.old_id}] -> [{rename.new_id}]  +{rename.logged}")
+    typer.echo(f"  File: {store_path / OPEN_QUESTIONS_MD}")
+
+    # Refresh AGENTS.md so MCP-disconnected agents see the new ids without a
+    # separate `nauro sync`. Mirrors `nauro note`.
+    updated_repos = warn_then_regen(
+        store_path.name,
+        store_path,
+        warn=lambda msg: typer.echo(msg, err=True),
+    )
+    for repo_path in updated_repos:
+        typer.echo(f"  Updated AGENTS.md: {repo_path}")

--- a/packages/nauro/src/nauro/cli/main.py
+++ b/packages/nauro/src/nauro/cli/main.py
@@ -57,6 +57,7 @@ def _register_commands() -> None:
         link,
         log,
         note,
+        questions,
         serve,
         setup,
         status,
@@ -70,6 +71,7 @@ def _register_commands() -> None:
     app.command(name="attach")(attach.attach)
     app.command(name="link")(link.link)
     app.command(name="note")(note.note)
+    app.add_typer(questions.questions_app, name="questions")
     app.command(name="sync")(sync.sync)
     app.command(name="log")(log.log)
     app.command(name="import")(import_cmd.import_cmd)

--- a/packages/nauro/tests/test_questions_migrate.py
+++ b/packages/nauro/tests/test_questions_migrate.py
@@ -1,0 +1,133 @@
+"""Tests for `nauro questions migrate`.
+
+The command mints sequential `Q###` ids for legacy `[timestamp]` entries in
+open-questions.md. The migration logic itself lives in
+`nauro_core.questions`; these tests pin the CLI surface — store resolution,
+the dry-run/apply split, the summary output, and AGENTS.md refresh — against
+an isolated store.
+"""
+
+from pathlib import Path
+
+from nauro_core.constants import OPEN_QUESTIONS_MD
+from typer.testing import CliRunner
+
+from nauro.cli.main import app
+from nauro.store.registry import register_project
+from nauro.templates.scaffolds import scaffold_project_store
+
+runner = CliRunner()
+
+_LEGACY_FILE = (
+    "# Open Questions\n"
+    "\n"
+    "- [2026-05-12 20:18 UTC] first legacy q\n"
+    "- [2026-05-11 15:29 UTC] second legacy q\n"
+)
+
+
+def _setup_project(tmp_path: Path, monkeypatch, questions: str) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    store = register_project("myproj", [repo])
+    scaffold_project_store("myproj", store)
+    (store / OPEN_QUESTIONS_MD).write_text(questions)
+    monkeypatch.chdir(repo)
+    return store
+
+
+def test_migrate_rewrites_legacy_ids_to_q_form(tmp_path: Path, monkeypatch):
+    store = _setup_project(tmp_path, monkeypatch, _LEGACY_FILE)
+
+    result = runner.invoke(app, ["questions", "migrate"])
+    assert result.exit_code == 0, result.output
+
+    assert (store / OPEN_QUESTIONS_MD).read_text() == (
+        "# Open Questions\n"
+        "\n"
+        "- [Q1] first legacy q (logged 2026-05-12 20:18 UTC)\n"
+        "- [Q2] second legacy q (logged 2026-05-11 15:29 UTC)\n"
+    )
+    assert "Migrated 2 entry(ies) in myproj" in result.output
+    assert "[2026-05-12 20:18 UTC] -> [Q1]" in result.output
+    assert "[2026-05-11 15:29 UTC] -> [Q2]" in result.output
+
+
+def test_migrate_dry_run_writes_nothing(tmp_path: Path, monkeypatch):
+    store = _setup_project(tmp_path, monkeypatch, _LEGACY_FILE)
+
+    result = runner.invoke(app, ["questions", "migrate", "--dry-run"])
+    assert result.exit_code == 0, result.output
+
+    # File is untouched.
+    assert (store / OPEN_QUESTIONS_MD).read_text() == _LEGACY_FILE
+    assert "Would migrate 2 entry(ies) in myproj" in result.output
+    assert "[2026-05-12 20:18 UTC] -> [Q1]" in result.output
+    assert "+(logged 2026-05-12 20:18 UTC)" in result.output
+    assert "Dry run: no changes written." in result.output
+
+
+def test_migrate_noop_when_all_q_form(tmp_path: Path, monkeypatch):
+    already_migrated = "# Open Questions\n\n- [Q1] one\n- [Q2] two\n"
+    store = _setup_project(tmp_path, monkeypatch, already_migrated)
+
+    result = runner.invoke(app, ["questions", "migrate"])
+    assert result.exit_code == 0, result.output
+
+    assert (store / OPEN_QUESTIONS_MD).read_text() == already_migrated
+    assert "No legacy question entries to migrate in myproj." in result.output
+
+
+def test_migrate_refreshes_agents_md(tmp_path: Path, monkeypatch):
+    """Open questions surface in AGENTS.md, so the migrated ids must too."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    store = register_project("myproj", [repo])
+    scaffold_project_store("myproj", store)
+    (store / OPEN_QUESTIONS_MD).write_text(
+        "# Open Questions\n\n- [2026-05-12 20:18 UTC] surfaced question\n"
+    )
+    monkeypatch.chdir(repo)
+
+    result = runner.invoke(app, ["questions", "migrate"])
+    assert result.exit_code == 0, result.output
+
+    agents_md = repo / "AGENTS.md"
+    assert agents_md.exists()
+    content = agents_md.read_text()
+    assert "[Q1]" in content
+    assert "Updated AGENTS.md" in result.output
+    assert str(repo) in result.output
+
+
+def test_migrate_continues_past_existing_q_ids(tmp_path: Path, monkeypatch):
+    mixed = (
+        "# Open Questions\n"
+        "\n"
+        "- [Q5] already migrated\n"
+        "- [2026-05-12 20:18 UTC] legacy after a high Q\n"
+    )
+    store = _setup_project(tmp_path, monkeypatch, mixed)
+
+    result = runner.invoke(app, ["questions", "migrate"])
+    assert result.exit_code == 0, result.output
+
+    assert (store / OPEN_QUESTIONS_MD).read_text() == (
+        "# Open Questions\n"
+        "\n"
+        "- [Q5] already migrated\n"
+        "- [Q6] legacy after a high Q (logged 2026-05-12 20:18 UTC)\n"
+    )
+    assert "[2026-05-12 20:18 UTC] -> [Q6]" in result.output
+
+
+def test_migrate_unknown_project_rejected(tmp_path: Path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    store = register_project("myproj", [repo])
+    scaffold_project_store("myproj", store)
+    monkeypatch.chdir(repo)
+
+    result = runner.invoke(app, ["questions", "migrate", "--project", "nope"])
+    assert result.exit_code == 1
+    assert "Unknown project 'nope'." in result.output


### PR DESCRIPTION
## Why
Open-questions entries written before the sequential question-id scheme still carry
their `[YYYY-MM-DD HH:MM UTC]` id. There was no maintenance path to mint stable `Q###`
ids for them, so a backlog mixes two id grammars and older entries can't be referenced
by the canonical id the writer now mints. Worse, entries logged in the same minute share
an id and can't be addressed at all.

## Approach
The migration logic lives in the kernel (`nauro_core.questions`), not the CLI, so it's
testable without a store and reuses the existing parse/format block model. A new
`OpenQuestionsFile.migrate()` returns a `MigrationResult` (rewritten file + per-entry
rename record) that drives both dry-run output and the apply path from one call. For
each legacy entry it mints `max(num across the file) + 1`, clears the timestamp, and
folds the original into the body as `(logged ...)` so the human timestamp survives.
Same-minute duplicates each get a distinct id, which is what makes previously-ambiguous
entries addressable. Resolved legacy entries keep their resolved-by prefix and only have
the id segment rewritten; the renderer already builds that combined head from model
fields, so no formatter change was needed. The command is hand-written alongside
`nauro import` / `nauro note` — the pure schema-to-command rule governs MCP-tool-generated
commands; this is a one-shot local maintenance command, not an MCP tool.

## What changed
- Kernel: `migrate()` + `MigrationResult`/`MigrationRename`. Only touched legacy entries
  are copied; every other block is reused by reference.
- CLI: a `questions` group with `migrate`; `--dry-run` prints the rename map and writes
  nothing; the apply path writes via the store and refreshes AGENTS.md. Registered in main.

## What to review
- The resolved-legacy rewrite (relies on the renderer emitting prefix + id from fields).
- The byte-identity round-trip: non-legacy blocks (prose, `###` topics, headers, the
  resolved divider, unparsable lines, already-Q entries) round-trip verbatim, and a second
  migrate over migrated output is a no-op. Both pinned by tests.
- The same-minute-collision case: two entries sharing one timestamp id mint two distinct
  ids and the ambiguity clears. Pinned by a dedicated test.
- Entries are never relocated — a resolved legacy entry under `## Resolved` stays there
  with only its id rewritten.

## What's deferred
- The cross-machine collision sync hook (single-operator scale has no multi-machine Q###
  collision yet).
- The actual backlog migration against the real store is the operator's call, run
  separately. This PR builds and tests the command on fixtures only.
- No mcp-server changes; no version bump / tag / publish.

## Test plan
1640 passed, 10 skipped (10 new kernel tests in `TestMigrate`, 6 new CLI tests); `ruff
check` and `format --check` clean. All store-touching tests under `NAURO_HOME`/`tmp_path`
isolation; `migrate` was never run against a real store.
