### PR TITLE
chore(release): bump nauro-core to 0.13.2 and nauro to 0.11.0

### DIFF
--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro-core"
-version = "0.13.1"
+version = "0.13.2"
 description = "Shared pure-Python logic for Nauro: parsing, validation, context assembly, constants."
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro"
-version = "0.10.1"
+version = "0.11.0"
 description = "Local CLI + MCP server: set your project's doctrine once, every connected AI agent inherits it."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Why
Release the work merged since the last tags. nauro-core 0.13.1 and nauro 0.10.1 are the
current published versions, but `main` has unreleased commits on top — so nothing reaches
PyPI (and the connector/pipx) until the versions bump. PyPI rejects re-uploading an
existing version, so the bump is mandatory.

## What ships
- **nauro-core 0.13.2** — the `flag_question` resolve action and the open-questions id
  migration helper. Backward-compatible additions (a new optional param and a new method),
  so a patch bump; stays inside the mcp-server `>=0.13.0,<0.14` pin.
- **nauro 0.11.0** — the above, plus the `nauro questions migrate` command, the
  `--resolved-by` CLI surface, the search status filter, and the local HTTP-transport
  retirement (stdio only). Minor bump for the feature/surface changes.

## Notes
- pyproject-only; `uv.lock` is gitignored and the runtime version derives from
  `importlib.metadata`.
- On merge, push tags `nauro-core-v0.13.2` and `nauro-v0.11.0` to trigger the tag-driven
  PyPI publish.
- No code change; CI validates the build on a fresh install.
