### PR TITLE
Restrict bundled executor to a tool allowlist excluding store writes

### DIFF
--- a/packages/nauro/src/nauro/agents/nauro-executor.md
+++ b/packages/nauro/src/nauro/agents/nauro-executor.md
@@ -1,6 +1,7 @@
 ---
 name: nauro-executor
 description: Use to implement an approved plan. Has full edit/write/test access. Runs lint and tests before declaring done. Always opens PRs (never pushes to main). Pauses before pushing for confirmation. Use after a plan from the planner has been agreed.
+tools: Read, Write, Edit, Grep, Glob, Bash, NotebookEdit, WebSearch, WebFetch, TodoWrite, mcp__claude_ai_Nauro__check_decision, mcp__claude_ai_Nauro__get_decision, mcp__claude_ai_Nauro__search_decisions, mcp__claude_ai_Nauro__list_decisions, mcp__nauro__check_decision, mcp__nauro__get_decision, mcp__nauro__search_decisions, mcp__nauro__list_decisions
 model: opus
 ---
 

--- a/packages/nauro/tests/test_agents_drift.py
+++ b/packages/nauro/tests/test_agents_drift.py
@@ -124,8 +124,9 @@ def test_all_agent_files_have_required_frontmatter(name: str) -> None:
 
     ``name`` must equal the filename minus ``.md``. ``description`` and
     ``model`` are required on every file. ``tools`` is required on agents
-    that restrict tool access; ``nauro-executor`` intentionally omits the
-    key to inherit all available tools.
+    that restrict tool access; the non-filing agents (``nauro-executor``
+    and ``nauro-reviewer``) carry a ``tools`` allowlist that excludes the
+    store-write tools.
     """
     body = load_agent_body(name)
     assert body.startswith("---\n"), f"{name}.md is missing opening frontmatter fence"
@@ -148,3 +149,35 @@ def test_all_agent_files_have_required_frontmatter(name: str) -> None:
                 f"frontmatter name does not match filename for {name}.md"
             )
             break
+
+
+# Store-write tools that must never appear in the tools allowlist of an agent
+# that is not authorized to file doctrine.
+DOCTRINE_WRITE_TOOLS: tuple[str, ...] = (
+    "propose_decision",
+    "flag_question",
+    "update_state",
+)
+
+
+@pytest.mark.parametrize("name", ["nauro-executor", "nauro-reviewer"])
+def test_non_filing_agents_cannot_write_doctrine(name: str) -> None:
+    """Executor and reviewer carry a ``tools`` allowlist with no store-write tools.
+
+    The allowlist is the structural guarantee that these agents cannot file
+    doctrine; the prose in their bodies is defense-in-depth. Planner and
+    tech-lead legitimately carry the write tools, so they are out of scope.
+    """
+    body = load_agent_body(name)
+    end = body.find("\n---\n", 4)
+    assert end > 0, f"{name}.md frontmatter is not terminated"
+    frontmatter = body[4:end]
+
+    tools_line = next(
+        (line for line in frontmatter.splitlines() if line.startswith("tools:")),
+        None,
+    )
+    assert tools_line is not None, f"{name}.md frontmatter is missing a tools allowlist"
+
+    for tool in DOCTRINE_WRITE_TOOLS:
+        assert tool not in tools_line, f"{name}.md tools allowlist grants store-write tool {tool!r}"


### PR DESCRIPTION
## Why

The bundled `nauro-executor` agent shipped without a `tools:` key in its
frontmatter. Claude Code interprets a missing `tools:` key as "inherit all
available tools", so the executor implicitly had access to the Nauro
store-write tools — `propose_decision`, `flag_question`, `update_state`.
That contradicts the surface-and-route rule for non-filing agents: the
executor is meant to surface emergent decisions in its handoff and let the
parent session route the filing, never to write doctrine itself. The
guarantee existed only as prose in the agent body, and the drift test even
documented the missing `tools:` key as intentional — directly at odds with
the no-write contract.

## Approach

Bring the executor's tool access in line with the surface-and-route rule by
making the no-write guarantee structural rather than prose-only. Add an
explicit `tools:` allowlist to the executor frontmatter that grants the
file/test/shell tools it needs plus the read-only Nauro tools, and excludes
every store-write tool. The allowlist mirrors the dual-prefix MCP style
already used by the reviewer and planner (`mcp__claude_ai_Nauro__*` and
`mcp__nauro__*` for both surfaces). The defense-in-depth prose in the body
("Surfacing emergent decisions — do not file them") stays untouched.

Alternative considered: a `settings.json` denylist note in the body. Rejected
to keep the diff tight — the frontmatter allowlist is the enforcement point,
and a denylist note adds prose without adding a guarantee.

## What changed

- `nauro-executor.md` frontmatter gains a `tools:` allowlist (read/edit/shell
  + read-only Nauro tools on both MCP prefixes). `name:` stays the first
  frontmatter line and `model: opus` is unchanged.
- `test_agents_drift.py`: the frontmatter-keys test docstring no longer claims
  the executor intentionally omits `tools:`; it now describes the non-filing
  agents (executor, reviewer) carrying an allowlist that excludes store-write
  tools. A new parametrized test asserts the executor and reviewer `tools:`
  lines exist and grant none of `propose_decision`, `flag_question`,
  `update_state`.

## What to review

- The exact `tools:` list on the executor — confirm it covers what the
  executor needs to do its job (Read/Write/Edit/Grep/Glob/Bash/NotebookEdit/
  WebSearch/WebFetch/TodoWrite + the four read-only Nauro tools on both
  prefixes) and drops nothing it relies on.
- The new test is scoped by explicit agent name to executor and reviewer.
  Planner and tech-lead legitimately carry the write tools, so they are
  deliberately out of the parametrization.

## What's deferred

Nothing in scope here. No production code changed — `render_agent` returns the
`.md` verbatim and the materializer iterates agents generically, so the new
frontmatter flows through unchanged.

## Test plan

- `uv run ruff format packages/` and `uv run ruff check packages/` — clean.
- `uv run pytest packages/nauro/tests/test_agents_drift.py -x -q` — 30 passed
  (28 prior + 2 new params).
- `uv run pytest packages/nauro/tests/test_setup_extended.py packages/nauro/tests/test_setup.py -x -q` — 57 passed (install round-trip vs `render_agent`).
- `uv run pytest packages/nauro/tests/ -x -q` — 1029 passed, 10 skipped.
