### PR TITLE
Add flag-gated embedding union retrieval augmenter (prototype, off by default)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ Nauro is a versioned project context system for AI coding agents. This is a `uv`
 | Package | Path | Python | Purpose |
 |---|---|---|---|
 | `nauro` | `packages/nauro/` | 3.10+ | CLI + local MCP server (stdio). Reads/writes `~/.nauro/projects/` |
-| `nauro-core` | `packages/nauro-core/` | 3.10+ | Shared pure-Python logic: parsing, validation, context assembly, constants. Zero runtime deps. |
+| `nauro-core` | `packages/nauro-core/` | 3.10+ | Shared pure-Python logic: parsing, validation, context assembly, constants. No I/O; compute-only deps. |
 
 Each package has its own `CLAUDE.md`, `pyproject.toml`, and test suite. The remote MCP server (`mcp-server/`) lives in a separate private repository.
 
@@ -114,7 +114,7 @@ uv run ruff format --check packages/
 - Linting: ruff
 - `NAURO_HOME` env var overrides `~/.nauro/` for testing
 - MCP tool implementations in `packages/nauro/src/nauro/mcp/tools.py` are canonical — the stdio transport delegates to them
-- `nauro-core` has zero external runtime dependencies
+- `nauro-core` does no I/O; its runtime dependencies are compute-only (BM25, pydantic, PyYAML). Embeddings ship as an optional extra (`nauro-core[embeddings]`)
 
 ## Project layout
 

--- a/packages/nauro-core/README.md
+++ b/packages/nauro-core/README.md
@@ -18,7 +18,7 @@ pip install nauro-core
 
 ## Design principles
 
-- **Zero runtime dependencies** — pure Python, no I/O, no filesystem, no network
+- **No I/O** — no filesystem, no network; callers inject pre-loaded data. Runtime dependencies are compute-only (BM25, parsing, validation); embeddings are an optional extra (`nauro-core[embeddings]`)
 - **Function injection** — callers pass pre-loaded data (`files: dict[str, str]`, `decisions: list[dict]`); nauro-core never reads files or calls APIs
 - **Import isolation** — enforced via `import-linter`: nauro-core cannot import from `nauro` or `mcp_server`
 

--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = ["pytest", "ruff", "import-linter"]
+embeddings = ["model2vec>=0.3", "numpy>=1.24"]
 
 [project.urls]
 Homepage = "https://github.com/nauro-ai/nauro"

--- a/packages/nauro-core/src/nauro_core/embeddings.py
+++ b/packages/nauro-core/src/nauro_core/embeddings.py
@@ -1,0 +1,122 @@
+"""Optional embedding augmenter for retrieval.
+
+Isolated from ``search.py`` so the BM25 path carries no embedding imports.
+The dependency is an optional extra (``nauro-core[embeddings]``); when it is
+absent the augmenter returns nothing and callers fall back to BM25-only.
+
+Model: ``potion-retrieval-32M`` (Model2Vec static embeddings, numpy-only —
+no torch, no ONNX runtime). Encoding is per-call; no persisted cache lives
+here. Static encode of a few hundred short documents is a sub-second numpy
+matmul, so there is no latency reason to cache at prototype scale.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from nauro_core.decision_model import Decision
+
+logger = logging.getLogger("nauro_core.embeddings")
+
+EMBEDDING_MODEL = "minishlab/potion-retrieval-32M"
+
+# Cache the loaded model across calls within a process. The model load is the
+# one non-trivial cost (~30MB read + numpy array setup); encoding itself is
+# cheap. This is in-process memoization only, not a persisted artifact.
+_model = None
+_load_failed = False
+
+
+def embeddings_available() -> bool:
+    """Return whether the optional embedding dependency can be imported."""
+    try:
+        import model2vec  # noqa: F401
+        import numpy  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def _get_model():
+    """Load and memoize the Model2Vec model, or return None if unavailable.
+
+    A failed load (missing dependency or model fetch failure) is recorded so
+    the import/instantiation is attempted at most once per process; subsequent
+    calls short-circuit to None without re-raising.
+    """
+    global _model, _load_failed
+    if _model is not None:
+        return _model
+    if _load_failed:
+        return None
+    try:
+        from model2vec import StaticModel
+
+        _model = StaticModel.from_pretrained(EMBEDDING_MODEL)
+        return _model
+    except Exception:
+        _load_failed = True
+        logger.warning(
+            "embedding model %s could not be loaded; falling back to BM25-only",
+            EMBEDDING_MODEL,
+            exc_info=True,
+        )
+        return None
+
+
+def embedding_pool(
+    decisions: list[Decision],
+    query: str,
+    top_k: int,
+) -> list[int]:
+    """Return the decision numbers of the top-k embedding matches for ``query``.
+
+    Encodes the ``title + rationale`` of each decision and the query with the
+    static model, ranks by cosine similarity (vectors are L2-normalized so a
+    dot product is cosine), and returns the ``top_k`` decision numbers in
+    descending similarity order.
+
+    Returns an empty list when the dependency is absent, the model fails to
+    load, or there is nothing to rank. Never raises — the caller treats an
+    empty result as "no embedding contribution" and proceeds with BM25 only.
+    """
+    if not decisions or not query or not query.strip() or top_k <= 0:
+        return []
+
+    model = _get_model()
+    if model is None:
+        return []
+
+    import numpy as np
+
+    corpus = [f"{d.title} {d.rationale}" for d in decisions]
+    doc_vectors = model.encode(corpus)
+    query_vector = model.encode([query])[0]
+
+    doc_vectors = _l2_normalize(np.asarray(doc_vectors, dtype=np.float32))
+    query_vector = _l2_normalize_vector(np.asarray(query_vector, dtype=np.float32))
+
+    similarities = doc_vectors @ query_vector
+    k = min(top_k, len(decisions))
+    # argsort ascending; take the last k and reverse for descending order.
+    top_indices = np.argsort(similarities)[-k:][::-1]
+    return [decisions[int(i)].num for i in top_indices]
+
+
+def _l2_normalize(matrix):
+    """L2-normalize each row of ``matrix``; zero rows stay zero."""
+    import numpy as np
+
+    norms = np.linalg.norm(matrix, axis=1, keepdims=True)
+    norms[norms == 0] = 1.0
+    return matrix / norms
+
+
+def _l2_normalize_vector(vector):
+    """L2-normalize a single vector; a zero vector stays zero."""
+    import numpy as np
+
+    norm = np.linalg.norm(vector)
+    if norm == 0:
+        return vector
+    return vector / norm

--- a/packages/nauro-core/src/nauro_core/operations/check_decision.py
+++ b/packages/nauro-core/src/nauro_core/operations/check_decision.py
@@ -25,7 +25,7 @@ from nauro_core.operations.results import (
 )
 from nauro_core.operations.store import Store
 from nauro_core.parsing import extract_decision_number
-from nauro_core.search import bm25_retrieve
+from nauro_core.search import union_retrieve
 from nauro_core.validation import check_content_length
 
 # Scaffold-seed bookkeeping decision is excluded from retrieval; full
@@ -47,6 +47,7 @@ def check_decision(
     store: Store,
     proposed_approach: str,
     context: str | None = None,
+    use_embeddings: bool = False,
 ) -> CheckDecisionResult:
     """Return the conflict-check result for ``proposed_approach``.
 
@@ -55,6 +56,10 @@ def check_decision(
         proposed_approach: Free-form description of the approach to check.
         context: Optional additional context concatenated into the retrieval
             query. Subject to ``MAX_CONTEXT_LENGTH``.
+        use_embeddings: When True, augment the BM25 candidate pool with the
+            optional embedding retriever (union). Resolved by the adapter from
+            env/config; the kernel stays I/O-free. Fail-open: if the optional
+            dependency is absent the result is BM25-only.
 
     Returns:
         :class:`CheckDecisionResult`. On the rejection path ``error`` is
@@ -81,7 +86,13 @@ def check_decision(
     approach_head = proposed_approach[:100]
     body_text = proposed_approach + (f" {context}" if context else "")
     query_text = f"{approach_head}. {body_text[:200]}"
-    hits = bm25_retrieve(decisions, query_text, top_k=5, stopwords=_CHECK_DECISION_STOPWORDS)
+    hits = union_retrieve(
+        decisions,
+        query_text,
+        top_k=5,
+        stopwords=_CHECK_DECISION_STOPWORDS,
+        use_embeddings=use_embeddings,
+    )
     if not hits:
         return CheckDecisionResult(assessment="No related decisions found.")
 
@@ -112,10 +123,13 @@ def _hit_to_related(hit: dict, by_num: dict[int, Decision]) -> RelatedDecision:
     canonical_id = f"decision-{num:03d}"
     status = decision.status.value if decision else "active"
     date = decision.date.isoformat() if decision and decision.date else ""
+    # Embedding-sourced hits carry similarity=None (no BM25 score); surface 0.0
+    # so the score field stays a float and signals "not a BM25 match".
+    similarity = hit.get("similarity")
     return RelatedDecision(
         id=canonical_id,
         title=hit.get("title", ""),
-        score=hit.get("similarity", 0.0),
+        score=similarity if similarity is not None else 0.0,
         status=status,
         date=date,
         rationale_preview=hit.get("rationale_preview", ""),

--- a/packages/nauro-core/src/nauro_core/operations/search_decisions.py
+++ b/packages/nauro-core/src/nauro_core/operations/search_decisions.py
@@ -13,7 +13,7 @@ rather than letting superseded hits crowd out active ones.
 
 from __future__ import annotations
 
-from nauro_core.decision_model import DecisionStatus, parse_decision
+from nauro_core.decision_model import Decision, DecisionStatus, parse_decision
 from nauro_core.operations.results import (
     ErrorPayload,
     SearchDecisionsResult,
@@ -28,6 +28,7 @@ def search_decisions(
     query: str,
     limit: int = 10,
     include_superseded: bool = False,
+    use_embeddings: bool = False,
 ) -> SearchDecisionsResult:
     """Return BM25-ranked decisions for ``query``.
 
@@ -37,6 +38,10 @@ def search_decisions(
         limit: Maximum number of hits to return.
         include_superseded: When False (default), only active decisions are
             ranked. When True, superseded decisions are ranked as well.
+        use_embeddings: When True, augment the BM25 result with the optional
+            embedding retriever (union). Resolved by the adapter from
+            env/config; the kernel stays I/O-free. Fail-open: if the optional
+            dependency is absent the result is BM25-only.
 
     Returns:
         :class:`SearchDecisionsResult` with ``results`` populated on the
@@ -79,4 +84,52 @@ def search_decisions(
         )
         for row in ranked
     ]
+
+    if use_embeddings:
+        hits = _append_embedding_hits(decisions, query, limit, hits)
+
     return SearchDecisionsResult(results=hits)
+
+
+def _append_embedding_hits(
+    decisions: list[Decision],
+    query: str,
+    limit: int,
+    bm25_hits: list[SearchHit],
+) -> list[SearchHit]:
+    """Append embedding top-k decisions BM25 did not surface (union pool).
+
+    BM25 hits keep their order and shape; embedding-only hits are appended
+    with ``score=0.0`` (no BM25 score) so the row stays serializable. The
+    augmenter is fail-open: an absent dependency yields an empty pool and the
+    BM25 hits pass through unchanged. The combined list is truncated to
+    ``limit`` so the candidate pool stays bounded.
+    """
+    from nauro_core.embeddings import embedding_pool
+
+    pool = embedding_pool(decisions, query, top_k=limit)
+    if not pool:
+        return bm25_hits
+
+    seen = {hit.number for hit in bm25_hits}
+    by_num = {d.num: d for d in decisions}
+    augmented = list(bm25_hits)
+    for num in pool:
+        if num in seen:
+            continue
+        d = by_num.get(num)
+        if d is None:
+            continue
+        seen.add(num)
+        augmented.append(
+            SearchHit(
+                number=d.num,
+                title=d.title,
+                date=d.date.isoformat() if d.date else None,
+                status=str(d.status.value),
+                relevance_snippet=None,
+                score=0.0,
+            )
+        )
+
+    return augmented[:limit]

--- a/packages/nauro-core/src/nauro_core/operations/search_decisions.py
+++ b/packages/nauro-core/src/nauro_core/operations/search_decisions.py
@@ -99,7 +99,8 @@ def search_decisions(
 # cap and is sliced off — the augmenter would contribute nothing exactly when
 # it should. Reserving a few slots guarantees the embedding pool widens the
 # result (the augmenter's whole point) while the total stays bounded by
-# ``limit``. BM25 keeps the majority because it remains the primary signal.
+# ``limit``. The reserve is clamped to ``limit - 1`` so BM25 always retains at
+# least one slot (and the majority at typical limits) as the primary signal.
 _EMBEDDING_RESERVED_SLOTS = 3
 
 
@@ -132,7 +133,11 @@ def _append_embedding_hits(
     by_num = {d.num: d for d in decisions}
 
     embedding_hits: list[SearchHit] = []
-    reserve = min(_EMBEDDING_RESERVED_SLOTS, limit)
+    # Clamp to ``limit - 1`` so BM25 keeps at least one slot whenever it has
+    # hits. At ``limit == 1`` the reserve is 0 and the result is pure BM25 —
+    # a single-result query returns the strongest lexical match, not an
+    # embedding-only hit.
+    reserve = min(_EMBEDDING_RESERVED_SLOTS, max(0, limit - 1))
     for num in pool:
         if len(embedding_hits) >= reserve:
             break

--- a/packages/nauro-core/src/nauro_core/operations/search_decisions.py
+++ b/packages/nauro-core/src/nauro_core/operations/search_decisions.py
@@ -91,19 +91,36 @@ def search_decisions(
     return SearchDecisionsResult(results=hits)
 
 
+# Slots reserved inside ``limit`` for embedding-only hits in search_decisions.
+# search_decisions is a search tool: callers expect at most ``limit`` results,
+# so the union cannot simply exceed the budget the way union_retrieve's
+# fixed-top_k candidate pool does. Without a reservation, a healthy corpus
+# fills ``limit`` with BM25 hits and every embedding-only hit lands past the
+# cap and is sliced off — the augmenter would contribute nothing exactly when
+# it should. Reserving a few slots guarantees the embedding pool widens the
+# result (the augmenter's whole point) while the total stays bounded by
+# ``limit``. BM25 keeps the majority because it remains the primary signal.
+_EMBEDDING_RESERVED_SLOTS = 3
+
+
 def _append_embedding_hits(
     decisions: list[Decision],
     query: str,
     limit: int,
     bm25_hits: list[SearchHit],
 ) -> list[SearchHit]:
-    """Append embedding top-k decisions BM25 did not surface (union pool).
+    """Blend embedding-only hits into the BM25 result, bounded by ``limit``.
 
-    BM25 hits keep their order and shape; embedding-only hits are appended
-    with ``score=0.0`` (no BM25 score) so the row stays serializable. The
-    augmenter is fail-open: an absent dependency yields an empty pool and the
-    BM25 hits pass through unchanged. The combined list is truncated to
-    ``limit`` so the candidate pool stays bounded.
+    BM25 hits keep their order and shape; embedding-only decisions BM25 did not
+    surface are appended with ``score=0.0`` (no BM25 score) so the row stays
+    serializable. The augmenter is fail-open: an absent dependency yields an
+    empty pool and the BM25 hits pass through unchanged.
+
+    ``limit`` is honored as a hard cap. Up to ``_EMBEDDING_RESERVED_SLOTS`` of
+    those slots are reserved for embedding-only hits, so they survive even when
+    BM25 already returned a full ``limit`` set; the BM25 list is trimmed only as
+    far as needed to make room and never below the slots embeddings actually
+    fill. When BM25 underfills ``limit`` no trimming happens.
     """
     from nauro_core.embeddings import embedding_pool
 
@@ -113,15 +130,19 @@ def _append_embedding_hits(
 
     seen = {hit.number for hit in bm25_hits}
     by_num = {d.num: d for d in decisions}
-    augmented = list(bm25_hits)
+
+    embedding_hits: list[SearchHit] = []
+    reserve = min(_EMBEDDING_RESERVED_SLOTS, limit)
     for num in pool:
+        if len(embedding_hits) >= reserve:
+            break
         if num in seen:
             continue
         d = by_num.get(num)
         if d is None:
             continue
         seen.add(num)
-        augmented.append(
+        embedding_hits.append(
             SearchHit(
                 number=d.num,
                 title=d.title,
@@ -132,4 +153,9 @@ def _append_embedding_hits(
             )
         )
 
-    return augmented[:limit]
+    if not embedding_hits:
+        return bm25_hits
+
+    # Trim BM25 only enough to fit the embedding hits within ``limit``.
+    bm25_budget = limit - len(embedding_hits)
+    return bm25_hits[:bm25_budget] + embedding_hits

--- a/packages/nauro-core/src/nauro_core/search.py
+++ b/packages/nauro-core/src/nauro_core/search.py
@@ -124,3 +124,63 @@ def bm25_retrieve(
         )
 
     return related
+
+
+def union_retrieve(
+    decisions: list[Decision],
+    query_text: str,
+    top_k: int = 5,
+    stopwords: str | list[str] = "en",
+    use_embeddings: bool = False,
+) -> list[dict]:
+    """Retrieve a BM25 ∪ embedding candidate pool of related active decisions.
+
+    With ``use_embeddings`` False this is exactly :func:`bm25_retrieve` — same
+    arguments, same result list, byte-identical to the BM25-only path.
+
+    With ``use_embeddings`` True the BM25 top-k results are returned first, in
+    their existing order and shape, and any decision in the embedding top-k
+    that BM25 did not already surface is appended as an embedding-sourced hit.
+    Embedding-sourced hits carry ``similarity: None`` (the static-embedding
+    cosine is not on the BM25 score scale, so it is not reported as a BM25
+    score) and the same ``number`` / ``title`` / ``rationale_preview`` shape.
+
+    The augmenter is fail-open: when the optional embedding dependency is
+    absent or the model fails to load, the embedding pool is empty and the
+    result is the BM25-only list. Importing the augmenter here keeps the
+    optional dependency out of the module-level import graph.
+    """
+    bm25_hits = bm25_retrieve(decisions, query_text, top_k=top_k, stopwords=stopwords)
+    if not use_embeddings:
+        return bm25_hits
+
+    from nauro_core.embeddings import embedding_pool
+
+    active = [d for d in decisions if d.status is DecisionStatus.active]
+    if not active or not query_text or not query_text.strip():
+        return bm25_hits
+
+    pool = embedding_pool(active, query_text, top_k=top_k)
+    if not pool:
+        return bm25_hits
+
+    seen = {hit["number"] for hit in bm25_hits}
+    by_num = {d.num: d for d in active}
+    augmented = list(bm25_hits)
+    for num in pool:
+        if num in seen:
+            continue
+        d = by_num.get(num)
+        if d is None:
+            continue
+        seen.add(num)
+        augmented.append(
+            {
+                "number": d.num,
+                "title": d.title,
+                "similarity": None,
+                "rationale_preview": d.rationale[:200] if d.rationale else "",
+            }
+        )
+
+    return augmented

--- a/packages/nauro-core/tests/operations/test_embeddings_flag.py
+++ b/packages/nauro-core/tests/operations/test_embeddings_flag.py
@@ -217,6 +217,51 @@ class TestSearchDecisionsFlag:
         assert 99 in on_nums
         assert len(on_nums) <= limit
 
+    def test_bm25_top_hit_survives_at_limit_one(self, monkeypatch):
+        """``limit == 1`` -> reserve is 0, so the result is BM25's top hit.
+
+        The reserve must never crowd out BM25's primary signal at small limits.
+        Without the ``limit - 1`` clamp the single slot is handed to an
+        embedding-only hit, replacing the strongest lexical match instead of
+        augmenting it.
+        """
+        # Decision 1 lexically matches the query; decision 99 matches only via
+        # the embedding stub and shares no lexical surface with the query.
+        decisions = {}
+        stem, body = _seed(
+            1,
+            "Caching strategy for the layer",
+            "Caching strategy for the caching layer.",
+        )
+        decisions[stem] = body
+        stem, body = _seed(
+            99,
+            "Identity tokens omit email scope",
+            "Login tokens lack the email claim so profiles never link.",
+        )
+        decisions[stem] = body
+        store = InMemoryStore(decisions=decisions)
+
+        off = search_decisions(store, "caching strategy", limit=1, use_embeddings=False)
+        # Precondition: BM25 alone returns decision 1 as the single hit.
+        assert [h.number for h in off.results] == [1]
+
+        stub = _StubModel(
+            vectors={
+                "Identity tokens omit email scope": [1.0, 0.0],
+                "caching strategy": [1.0, 0.0],
+            },
+            default=[0.0, 1.0],
+        )
+        monkeypatch.setattr(embeddings_mod, "_get_model", lambda: stub)
+        on = search_decisions(store, "caching strategy", limit=1, use_embeddings=True)
+        on_nums = [h.number for h in on.results]
+
+        # BM25's primary hit is retained; the embedding-only hit cannot crowd
+        # it out at limit=1 (this assertion fails against the unclamped reserve).
+        assert on_nums == [1]
+        assert 99 not in on_nums
+
 
 def extract_num(decision_id: str) -> int:
     return int(decision_id.rsplit("-", 1)[1])

--- a/packages/nauro-core/tests/operations/test_embeddings_flag.py
+++ b/packages/nauro-core/tests/operations/test_embeddings_flag.py
@@ -169,6 +169,54 @@ class TestSearchDecisionsFlag:
         assert on_nums[: len(off_nums)] == off_nums
         assert 3 in on_nums and 3 not in off_nums
 
+    def test_embedding_hit_survives_when_bm25_fills_limit(self, monkeypatch):
+        """BM25 fills ``limit`` -> the embedding-only hit must still appear.
+
+        Without a reserved slot the embedding-only hit lands past ``limit`` and
+        is sliced off, so the augmenter would contribute nothing exactly when
+        BM25 already saturates the budget — the common case on a healthy corpus.
+        """
+        limit = 5
+        # ``limit`` decisions that all share the query's lexical surface, so BM25
+        # fills the budget on its own. Plus one related decision sharing no
+        # surface with the query, which only the embedding pool can surface.
+        decisions = {}
+        for i in range(1, limit + 1):
+            stem, body = _seed(
+                i,
+                f"Caching strategy variant {i}",
+                f"Caching strategy variant {i} for the caching layer.",
+            )
+            decisions[stem] = body
+        stem, body = _seed(
+            99,
+            "Identity tokens omit email scope",
+            "Login tokens lack the email claim so profiles never link.",
+        )
+        decisions[stem] = body
+        store = InMemoryStore(decisions=decisions)
+
+        off = search_decisions(store, "caching strategy", limit=limit, use_embeddings=False)
+        off_nums = [h.number for h in off.results]
+        # Precondition: BM25 alone saturates the budget and never surfaces 99.
+        assert len(off_nums) == limit
+        assert 99 not in off_nums
+
+        stub = _StubModel(
+            vectors={
+                "Identity tokens omit email scope": [1.0, 0.0],
+                "caching strategy": [1.0, 0.0],
+            },
+            default=[0.0, 1.0],
+        )
+        monkeypatch.setattr(embeddings_mod, "_get_model", lambda: stub)
+        on = search_decisions(store, "caching strategy", limit=limit, use_embeddings=True)
+        on_nums = [h.number for h in on.results]
+
+        # The embedding-only hit survives; the result stays within ``limit``.
+        assert 99 in on_nums
+        assert len(on_nums) <= limit
+
 
 def extract_num(decision_id: str) -> int:
     return int(decision_id.rsplit("-", 1)[1])

--- a/packages/nauro-core/tests/operations/test_embeddings_flag.py
+++ b/packages/nauro-core/tests/operations/test_embeddings_flag.py
@@ -1,0 +1,174 @@
+"""Kernel-level ``use_embeddings`` flag behavior for check/search operations.
+
+The kernel stays I/O-free: the flag arrives as a bool argument. These tests
+assert the three flag states at the operation boundary against an
+``InMemoryStore``, stubbing the optional Model2Vec model rather than installing
+the extra. Surface-level env/config resolution is tested in the nauro package.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import numpy as np
+import pytest
+
+import nauro_core.embeddings as embeddings_mod
+from nauro_core.decision_model import (
+    Decision,
+    DecisionConfidence,
+    DecisionStatus,
+    format_decision,
+)
+from nauro_core.operations import (
+    InMemoryStore,
+    check_decision,
+    search_decisions,
+)
+
+
+def _seed(num: int, title: str, rationale: str) -> tuple[str, str]:
+    decision = Decision(
+        date=date(2026, 1, 1),
+        confidence=DecisionConfidence.medium,
+        status=DecisionStatus.active,
+        num=num,
+        title=title,
+        rationale=rationale,
+    )
+    slug = title.lower().replace(" ", "-")
+    return f"{num:03d}-{slug}", format_decision(decision)
+
+
+def _store() -> InMemoryStore:
+    return InMemoryStore(
+        decisions=dict(
+            [
+                _seed(1, "Adopt Memcached for session cache", "Memcached for read sessions."),
+                _seed(2, "Use FastAPI for the server", "FastAPI async support and OpenAPI docs."),
+                _seed(
+                    3,
+                    "Identity tokens omit email scope",
+                    "Login tokens lack the email claim so profiles never link.",
+                ),
+            ]
+        )
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_model_cache():
+    embeddings_mod._model = None
+    embeddings_mod._load_failed = False
+    yield
+    embeddings_mod._model = None
+    embeddings_mod._load_failed = False
+
+
+class _StubModel:
+    def __init__(self, vectors: dict[str, list[float]], default: list[float]):
+        self._vectors = vectors
+        self._default = default
+
+    def encode(self, texts):
+        out = []
+        for text in texts:
+            vec = self._default
+            for needle, v in self._vectors.items():
+                if needle in text:
+                    vec = v
+                    break
+            out.append(vec)
+        return np.asarray(out, dtype=np.float32)
+
+
+class TestCheckDecisionFlag:
+    def test_flag_off_is_default(self):
+        store = _store()
+        default = check_decision(store, "Add a Memcached session cache")
+        explicit_off = check_decision(store, "Add a Memcached session cache", use_embeddings=False)
+        assert default.model_dump() == explicit_off.model_dump()
+
+    def test_flag_on_dep_absent_is_bm25_only(self, monkeypatch, caplog):
+        import builtins
+
+        real_import = builtins.__import__
+
+        def _fail(name, *args, **kwargs):
+            if name == "model2vec":
+                raise ImportError("absent")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _fail)
+        store = _store()
+        off = check_decision(store, "Add a Memcached session cache", use_embeddings=False)
+        with caplog.at_level("WARNING", logger="nauro_core.embeddings"):
+            on = check_decision(store, "Add a Memcached session cache", use_embeddings=True)
+        assert on.model_dump() == off.model_dump()
+        assert len([r for r in caplog.records if r.levelname == "WARNING"]) == 1
+
+    def test_flag_on_dep_present_superset(self, monkeypatch):
+        store = _store()
+        off = check_decision(store, "Add a Memcached session cache", use_embeddings=False)
+        off_nums = [extract_num(d.id) for d in off.related_decisions]
+
+        stub = _StubModel(
+            vectors={
+                "Identity tokens omit email scope": [1.0, 0.0],
+                "Add a Memcached session cache": [1.0, 0.0],
+            },
+            default=[0.0, 1.0],
+        )
+        monkeypatch.setattr(embeddings_mod, "_get_model", lambda: stub)
+        on = check_decision(store, "Add a Memcached session cache", use_embeddings=True)
+        on_nums = [extract_num(d.id) for d in on.related_decisions]
+
+        assert on_nums[: len(off_nums)] == off_nums
+        assert 3 in on_nums and 3 not in off_nums
+
+
+class TestSearchDecisionsFlag:
+    def test_flag_off_is_default(self):
+        store = _store()
+        default = search_decisions(store, "Memcached session")
+        explicit_off = search_decisions(store, "Memcached session", use_embeddings=False)
+        assert default.model_dump() == explicit_off.model_dump()
+
+    def test_flag_on_dep_absent_is_bm25_only(self, monkeypatch):
+        import builtins
+
+        real_import = builtins.__import__
+
+        def _fail(name, *args, **kwargs):
+            if name == "model2vec":
+                raise ImportError("absent")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _fail)
+        store = _store()
+        off = search_decisions(store, "Memcached session", use_embeddings=False)
+        on = search_decisions(store, "Memcached session", use_embeddings=True)
+        assert on.model_dump() == off.model_dump()
+
+    def test_flag_on_dep_present_superset(self, monkeypatch):
+        store = _store()
+        off = search_decisions(store, "Memcached session", use_embeddings=False)
+        off_nums = [h.number for h in off.results]
+
+        stub = _StubModel(
+            vectors={
+                "Identity tokens omit email scope": [1.0, 0.0],
+                "Memcached session": [1.0, 0.0],
+            },
+            default=[0.0, 1.0],
+        )
+        monkeypatch.setattr(embeddings_mod, "_get_model", lambda: stub)
+        on = search_decisions(store, "Memcached session", use_embeddings=True)
+        on_nums = [h.number for h in on.results]
+
+        assert on_nums[: len(off_nums)] == off_nums
+        assert 3 in on_nums and 3 not in off_nums
+
+
+def extract_num(decision_id: str) -> int:
+    return int(decision_id.rsplit("-", 1)[1])

--- a/packages/nauro-core/tests/test_embeddings_union.py
+++ b/packages/nauro-core/tests/test_embeddings_union.py
@@ -1,0 +1,236 @@
+"""Embedding-augmented union retrieval — module invariants.
+
+Covers the three flag states the prototype must satisfy:
+
+1. Flag OFF -> results are byte-identical to BM25-only.
+2. Flag ON + optional dependency absent -> BM25-only, with a single warning.
+3. Flag ON + dependency present -> union pool is a superset of the BM25 hits.
+
+State #3 stubs the Model2Vec model rather than installing the optional extra,
+so the test exercises the real ``union_retrieve`` / ``embedding_pool`` plumbing
+against a deterministic encoder.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import numpy as np
+import pytest
+
+import nauro_core.embeddings as embeddings_mod
+from nauro_core.decision_model import Decision, DecisionConfidence, DecisionStatus
+from nauro_core.search import bm25_retrieve, union_retrieve
+
+
+def _make_decision(num: int, title: str, rationale: str, status: str = "active") -> Decision:
+    status_enum = DecisionStatus(status)
+    return Decision(
+        date=date(2026, 4, 7),
+        confidence=DecisionConfidence.medium,
+        status=status_enum,
+        superseded_by="999" if status_enum is DecisionStatus.superseded else None,
+        num=num,
+        title=title,
+        rationale=rationale,
+    )
+
+
+DECISIONS = [
+    _make_decision(
+        1,
+        "Use Auth0 for authentication",
+        "Auth0 provides OAuth 2.1 support and handles JWT validation.",
+    ),
+    _make_decision(
+        2,
+        "Chose Memcached for session state",
+        "Memcached is simpler than Redis for session caching.",
+    ),
+    _make_decision(
+        3,
+        "Use FastAPI for MCP server",
+        "FastAPI provides async support and automatic OpenAPI docs.",
+    ),
+    _make_decision(
+        4,
+        "Identity tokens carry no email scope",
+        "Login tokens omit the email claim, so users land without a profile.",
+    ),
+]
+
+
+@pytest.fixture(autouse=True)
+def _reset_model_cache():
+    """Clear the in-process model cache so each test sees a clean load state."""
+    embeddings_mod._model = None
+    embeddings_mod._load_failed = False
+    yield
+    embeddings_mod._model = None
+    embeddings_mod._load_failed = False
+
+
+class _StubModel:
+    """Deterministic stand-in for a Model2Vec ``StaticModel``.
+
+    ``encode`` returns a fixed unit vector per text keyed off a substring, so a
+    chosen query lands closest to a target decision the BM25 path would miss.
+    """
+
+    def __init__(self, vectors: dict[str, list[float]], default: list[float]):
+        self._vectors = vectors
+        self._default = default
+
+    def encode(self, texts):
+        out = []
+        for text in texts:
+            vec = self._default
+            for needle, v in self._vectors.items():
+                if needle in text:
+                    vec = v
+                    break
+            out.append(vec)
+        return np.asarray(out, dtype=np.float32)
+
+
+class TestFlagOff:
+    def test_union_matches_bm25_when_flag_off(self):
+        """Flag OFF -> union_retrieve is the BM25-only list, unchanged."""
+        query = "authentication OAuth provider"
+        bm25 = bm25_retrieve(DECISIONS, query)
+        union = union_retrieve(DECISIONS, query, use_embeddings=False)
+        assert union == bm25
+
+    def test_flag_off_does_not_import_optional_dep(self, monkeypatch):
+        """Flag OFF must not even attempt to load the embedding model."""
+        called = False
+
+        def _boom():
+            nonlocal called
+            called = True
+            return None
+
+        monkeypatch.setattr(embeddings_mod, "_get_model", _boom)
+        union_retrieve(DECISIONS, "session caching", use_embeddings=False)
+        assert called is False
+
+
+class TestFlagOnDependencyAbsent:
+    def test_union_falls_back_to_bm25_and_logs_once(self, monkeypatch, caplog):
+        """Flag ON + dep absent -> BM25-only result, exactly one warning."""
+        # Force the import path to fail as if the optional extra is uninstalled.
+        import builtins
+
+        real_import = builtins.__import__
+
+        def _fail_model2vec(name, *args, **kwargs):
+            if name == "model2vec":
+                raise ImportError("No module named 'model2vec'")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _fail_model2vec)
+
+        query = "authentication OAuth provider"
+        bm25 = bm25_retrieve(DECISIONS, query)
+        with caplog.at_level("WARNING", logger="nauro_core.embeddings"):
+            first = union_retrieve(DECISIONS, query, use_embeddings=True)
+            second = union_retrieve(DECISIONS, query, use_embeddings=True)
+
+        assert first == bm25
+        assert second == bm25
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert len(warnings) == 1
+
+
+class TestFlagOnDependencyPresent:
+    def test_union_is_superset_of_bm25_hits(self, monkeypatch):
+        """Flag ON + dep present -> every BM25 hit survives, embedding hits append."""
+        query = "session caching"
+        bm25 = bm25_retrieve(DECISIONS, query)
+        bm25_nums = [h["number"] for h in bm25]
+
+        # Make the query land closest to decision 4 (identity/email), which
+        # shares no lexical surface with "session caching" -> BM25 misses it.
+        stub = _StubModel(
+            vectors={
+                "Identity tokens carry no email scope": [1.0, 0.0],
+                "session caching": [1.0, 0.0],
+            },
+            default=[0.0, 1.0],
+        )
+        monkeypatch.setattr(embeddings_mod, "_get_model", lambda: stub)
+
+        union = union_retrieve(DECISIONS, query, use_embeddings=True)
+        union_nums = [h["number"] for h in union]
+
+        # Superset: every BM25 hit appears in the union, in the same order.
+        assert union_nums[: len(bm25_nums)] == bm25_nums
+        for hit in bm25:
+            assert hit in union
+        # The embedding-only target was appended.
+        assert 4 in union_nums
+        assert 4 not in bm25_nums
+
+    def test_embedding_only_hits_carry_null_similarity(self, monkeypatch):
+        """Appended embedding hits report similarity None (no BM25 score)."""
+        query = "session caching"
+        stub = _StubModel(
+            vectors={
+                "Identity tokens carry no email scope": [1.0, 0.0],
+                "session caching": [1.0, 0.0],
+            },
+            default=[0.0, 1.0],
+        )
+        monkeypatch.setattr(embeddings_mod, "_get_model", lambda: stub)
+
+        union = union_retrieve(DECISIONS, query, use_embeddings=True)
+        appended = [h for h in union if h["number"] == 4]
+        assert len(appended) == 1
+        assert appended[0]["similarity"] is None
+        assert appended[0]["title"] == "Identity tokens carry no email scope"
+
+    def test_union_does_not_duplicate_shared_hits(self, monkeypatch):
+        """A decision in both BM25 and embedding pools appears once."""
+        query = "session caching"
+        bm25 = bm25_retrieve(DECISIONS, query)
+        bm25_top = bm25[0]["number"]
+
+        # Point the embedding model at the same decision BM25 already ranked top.
+        target_title = next(d.title for d in DECISIONS if d.num == bm25_top)
+        stub = _StubModel(
+            vectors={target_title: [1.0, 0.0], "session caching": [1.0, 0.0]},
+            default=[0.0, 1.0],
+        )
+        monkeypatch.setattr(embeddings_mod, "_get_model", lambda: stub)
+
+        union = union_retrieve(DECISIONS, query, use_embeddings=True)
+        union_nums = [h["number"] for h in union]
+        assert union_nums.count(bm25_top) == 1
+
+
+class TestEmbeddingPool:
+    def test_returns_empty_when_model_unavailable(self, monkeypatch):
+        monkeypatch.setattr(embeddings_mod, "_get_model", lambda: None)
+        assert embeddings_mod.embedding_pool(DECISIONS, "anything", top_k=5) == []
+
+    def test_returns_empty_for_blank_query(self, monkeypatch):
+        stub = _StubModel(vectors={}, default=[1.0, 0.0])
+        monkeypatch.setattr(embeddings_mod, "_get_model", lambda: stub)
+        assert embeddings_mod.embedding_pool(DECISIONS, "   ", top_k=5) == []
+
+    def test_ranks_by_cosine_descending(self, monkeypatch):
+        stub = _StubModel(
+            vectors={
+                "Use Auth0 for authentication": [1.0, 0.0],
+                "Use FastAPI for MCP server": [0.0, 1.0],
+            },
+            default=[0.0, 1.0],
+        )
+        monkeypatch.setattr(embeddings_mod, "_get_model", lambda: stub)
+        # Query aligned with the Auth0 vector -> decision 1 ranks first.
+        pool = embeddings_mod.embedding_pool(
+            [d for d in DECISIONS if d.num in (1, 3)],
+            "Use Auth0 for authentication",
+            top_k=2,
+        )
+        assert pool[0] == 1

--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -38,6 +38,7 @@ dev = [
     "ruff>=0.1",
     "mypy>=1.0",
 ]
+embeddings = ["nauro-core[embeddings]"]
 
 [project.urls]
 Homepage = "https://github.com/nauro-ai/nauro"

--- a/packages/nauro/src/nauro/constants.py
+++ b/packages/nauro/src/nauro/constants.py
@@ -32,6 +32,7 @@ from nauro_core.constants import VALID_CONFIDENCES as VALID_CONFIDENCES
 # ── Environment variables (CLI-specific) ──
 NAURO_HOME_ENV = "NAURO_HOME"
 NAURO_TELEMETRY_ENV = "NAURO_TELEMETRY"
+NAURO_EMBEDDINGS_ENV = "NAURO_EMBEDDINGS"
 
 # ── Paths (CLI-specific) ──
 DEFAULT_NAURO_HOME = ".nauro"

--- a/packages/nauro/src/nauro/mcp/tools.py
+++ b/packages/nauro/src/nauro/mcp/tools.py
@@ -45,6 +45,7 @@ from nauro.onboarding import (
     NO_CONTEXT_YET,
     WELCOME_NO_PROJECT,
 )
+from nauro.store.config import resolve_embeddings_flag
 from nauro.store.filesystem_store import FilesystemStore
 from nauro.store.reader import resolve_decision_id
 from nauro.store.snapshot import (
@@ -419,7 +420,12 @@ def tool_check_decision(
     if guidance:
         return {"store": "local", "status": "error", "guidance": guidance}
 
-    result = _check_decision_op(FilesystemStore(store_path), proposed_approach, context)
+    result = _check_decision_op(
+        FilesystemStore(store_path),
+        proposed_approach,
+        context,
+        use_embeddings=resolve_embeddings_flag(),
+    )
     return {"store": "local", **result.model_dump(mode="json", exclude_none=True)}
 
 
@@ -652,7 +658,11 @@ def tool_search_decisions(
     if guidance:
         return {"store": "local", "status": "error", "guidance": guidance}
     result = _search_decisions_op(
-        FilesystemStore(store_path), query, limit, include_superseded=include_superseded
+        FilesystemStore(store_path),
+        query,
+        limit,
+        include_superseded=include_superseded,
+        use_embeddings=resolve_embeddings_flag(),
     )
     return {"store": "local", **result.model_dump(mode="json", exclude_none=True)}
 

--- a/packages/nauro/src/nauro/store/config.py
+++ b/packages/nauro/src/nauro/store/config.py
@@ -14,11 +14,16 @@ from pathlib import Path
 from nauro.constants import (
     CONFIG_FILENAME,
     DEFAULT_NAURO_HOME,
+    NAURO_EMBEDDINGS_ENV,
     NAURO_HOME_ENV,
     NAURO_TELEMETRY_ENV,
 )
 
 logger = logging.getLogger("nauro.config")
+
+# Config key for the optional embedding retrieval augmenter. The env var
+# NAURO_EMBEDDINGS overrides it, mirroring the NAURO_HOME precedence.
+_EMBEDDINGS_CONFIG_KEY = "search.embeddings"
 
 
 def _config_file() -> Path:
@@ -68,6 +73,30 @@ def unset_config(key: str) -> bool:
     del data[key]
     save_config(data)
     return True
+
+
+def resolve_embeddings_flag() -> bool:
+    """Resolve whether embedding-augmented retrieval is enabled.
+
+    Precedence (mirrors NAURO_HOME): the ``NAURO_EMBEDDINGS`` env var wins when
+    set; otherwise the ``search.embeddings`` config key is consulted; otherwise
+    the default is OFF. Env and config both accept the same truthy tokens
+    (``"1"``, ``"true"``, ``"yes"``, ``"on"``, case-insensitive) and a native
+    bool from config.
+    """
+    env_value = os.environ.get(NAURO_EMBEDDINGS_ENV)
+    if env_value is not None:
+        return _is_truthy(env_value)
+    return _is_truthy(get_config(_EMBEDDINGS_CONFIG_KEY))
+
+
+def _is_truthy(value: object) -> bool:
+    """Interpret a config/env value as a boolean flag."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in ("1", "true", "yes", "on")
+    return False
 
 
 _TELEMETRY_KEY = "telemetry"

--- a/packages/nauro/tests/test_embeddings_flag_resolution.py
+++ b/packages/nauro/tests/test_embeddings_flag_resolution.py
@@ -1,0 +1,126 @@
+"""Adapter-side embedding-flag resolution and pass-through (consumer wiring).
+
+The kernel takes ``use_embeddings`` as a bool; the adapters own resolving it
+from the environment and config. Precedence mirrors NAURO_HOME: the
+``NAURO_EMBEDDINGS`` env var wins over the ``search.embeddings`` config key,
+and the default is OFF.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nauro.mcp import tools as mcp_tools
+from nauro.store.config import resolve_embeddings_flag, set_config
+
+
+@pytest.fixture(autouse=True)
+def _clear_embeddings_env(monkeypatch):
+    """Ensure no stray NAURO_EMBEDDINGS leaks from the dev shell."""
+    monkeypatch.delenv("NAURO_EMBEDDINGS", raising=False)
+
+
+class TestResolveEmbeddingsFlag:
+    def test_default_off(self):
+        assert resolve_embeddings_flag() is False
+
+    def test_env_on(self, monkeypatch):
+        monkeypatch.setenv("NAURO_EMBEDDINGS", "1")
+        assert resolve_embeddings_flag() is True
+
+    def test_env_truthy_tokens(self, monkeypatch):
+        for token in ("1", "true", "TRUE", "yes", "On"):
+            monkeypatch.setenv("NAURO_EMBEDDINGS", token)
+            assert resolve_embeddings_flag() is True
+
+    def test_env_off_tokens(self, monkeypatch):
+        for token in ("0", "false", "no", "off", ""):
+            monkeypatch.setenv("NAURO_EMBEDDINGS", token)
+            assert resolve_embeddings_flag() is False
+
+    def test_config_on_when_env_unset(self):
+        set_config("search.embeddings", "true")
+        assert resolve_embeddings_flag() is True
+
+    def test_config_bool_value(self):
+        set_config("search.embeddings", True)
+        assert resolve_embeddings_flag() is True
+
+    def test_env_overrides_config_off(self, monkeypatch):
+        """Env wins: config ON but env OFF resolves OFF."""
+        set_config("search.embeddings", "true")
+        monkeypatch.setenv("NAURO_EMBEDDINGS", "0")
+        assert resolve_embeddings_flag() is False
+
+    def test_env_overrides_config_on(self, monkeypatch):
+        """Env wins: config OFF (unset) but env ON resolves ON."""
+        monkeypatch.setenv("NAURO_EMBEDDINGS", "1")
+        assert resolve_embeddings_flag() is True
+
+
+def _scaffold_store(root: Path) -> Path:
+    store = root / "proj"
+    (store / "decisions").mkdir(parents=True)
+    return store
+
+
+class TestAdapterPassThrough:
+    def test_check_decision_passes_resolved_flag(self, tmp_path, monkeypatch):
+        store_path = _scaffold_store(tmp_path)
+        captured = {}
+
+        def _fake_op(store, proposed_approach, context, use_embeddings=False):
+            captured["use_embeddings"] = use_embeddings
+            from nauro_core.operations import CheckDecisionResult
+
+            return CheckDecisionResult(assessment="ok")
+
+        monkeypatch.setattr(mcp_tools, "_check_decision_op", _fake_op)
+        monkeypatch.setenv("NAURO_EMBEDDINGS", "1")
+        mcp_tools.tool_check_decision(store_path, "Use Redis for caching")
+        assert captured["use_embeddings"] is True
+
+    def test_check_decision_default_off(self, tmp_path, monkeypatch):
+        store_path = _scaffold_store(tmp_path)
+        captured = {}
+
+        def _fake_op(store, proposed_approach, context, use_embeddings=False):
+            captured["use_embeddings"] = use_embeddings
+            from nauro_core.operations import CheckDecisionResult
+
+            return CheckDecisionResult(assessment="ok")
+
+        monkeypatch.setattr(mcp_tools, "_check_decision_op", _fake_op)
+        mcp_tools.tool_check_decision(store_path, "Use Redis for caching")
+        assert captured["use_embeddings"] is False
+
+    def test_search_decisions_passes_resolved_flag(self, tmp_path, monkeypatch):
+        store_path = _scaffold_store(tmp_path)
+        captured = {}
+
+        def _fake_op(store, query, limit, include_superseded=False, use_embeddings=False):
+            captured["use_embeddings"] = use_embeddings
+            from nauro_core.operations import SearchDecisionsResult
+
+            return SearchDecisionsResult(results=[])
+
+        monkeypatch.setattr(mcp_tools, "_search_decisions_op", _fake_op)
+        monkeypatch.setenv("NAURO_EMBEDDINGS", "1")
+        mcp_tools.tool_search_decisions(store_path, "redis")
+        assert captured["use_embeddings"] is True
+
+    def test_search_decisions_default_off(self, tmp_path, monkeypatch):
+        store_path = _scaffold_store(tmp_path)
+        captured = {}
+
+        def _fake_op(store, query, limit, include_superseded=False, use_embeddings=False):
+            captured["use_embeddings"] = use_embeddings
+            from nauro_core.operations import SearchDecisionsResult
+
+            return SearchDecisionsResult(results=[])
+
+        monkeypatch.setattr(mcp_tools, "_search_decisions_op", _fake_op)
+        mcp_tools.tool_search_decisions(store_path, "redis")
+        assert captured["use_embeddings"] is False


### PR DESCRIPTION
## Why

`check_decision` and `search_decisions` retrieve over BM25 keyword matching only. BM25 misses related decisions that share little lexical surface with the query, and that gap bites hardest exactly where it matters: when an agent runs a short, terse `check_decision` before acting, BM25 can fail to surface a decision the proposed approach would contradict.

Validation against the project's real supersession history (cases where a new decision replaced an active one — genuine conflicts) makes this concrete. With a term-rich query BM25 already surfaces the conflicting decision ~95% of the time, but with a terse proposed-approach (the common case) it misses 12–17% of those conflicts. A BM25 ∪ embedding candidate pool recovers exactly those misses, reaching 100% conflict-catching in the realistic terse case.

## Approach

Union candidate-pool augmentation: additive to BM25, flag-gated, off by default, fail-open. BM25 stays the primary retriever and its hits keep their exact shape and order; embedding hits widen the pool to reach low-lexical-overlap matches. The flag-off path is byte-identical to today.

Model: `potion-retrieval-32M` (Model2Vec static embeddings, numpy-only — no torch, no ONNX). `pipx install nauro` is unchanged; `pipx install 'nauro[embeddings]'` opts in (~30MB). Rejected: sentence-transformers/torch (multi-GB, pipx-hostile). A torch-free ONNX model is a documented fallback if the static model proves insufficient; the conflict-catching validation showed the static model reaches 100% on realistic queries, so it is not needed here.

Per-call encode; no persisted cache in this build (static encode of a few hundred short docs is sub-second). Caching is a deferred follow-up behind a measured latency trigger.

This advances the prior embeddings-deferral decision on measured evidence, while carrying its scope-tag deferral forward unchanged.

## What changed

- **nauro-core retrieval:** new `embeddings.py` isolates the optional dependency behind a lazy, fail-open guarded import; `search.py` gains `union_retrieve` (the module stays BM25-pure, the augmenter is imported locally). Kernel ops take a `use_embeddings` bool and stay I/O-free.
- **Flag plumbing:** `NAURO_EMBEDDINGS` env (wins) plus `search.embeddings` config key, mirroring `NAURO_HOME` precedence; default OFF; resolved in the MCP/CLI adapters. Flag on with the dependency absent logs once and falls back to BM25-only.
- **Packaging:** `nauro-core[embeddings]` optional extra; `nauro[embeddings]` pass-through. No version bumps (prototype).
- **Docs:** corrected the stale "zero runtime dependencies" claim (inaccurate since BM25 landed).

## What to review

- `union_retrieve` shape preservation: BM25 hits stay first, in order, with the same dict keys; embedding-only hits carry `similarity: None`. The flag-off path returning the BM25 list unchanged is the load-bearing parity guarantee.
- `search_decisions` reserve logic: embedding-only hits get up to 3 reserved slots within `limit`, clamped to `limit - 1` so BM25 always keeps at least one slot — a `limit=1` query returns the strongest lexical match, not an embedding-only hit.
- Fail-open: flag on with the dependency absent must log exactly once and never raise.
- Adapter resolution precedence (env over config, default off).

## What's deferred

Persisted embedding cache + invalidation; flipping the flag default on (a separate decision, gated on real conflict-catching in dogfooding); any ranking/RRF change (union touches the candidate pool only); scope-tag filtering (remains rejected); the ONNX fallback model; remote-MCP cache warming.

## Test plan

- nauro-core: 630 passed (17 new — flag-off byte-identical parity, on+absent BM25-only + single log, on+present union ⊇ BM25, full-budget survival, and the `limit=1` boundary).
- nauro: 1041 passed, 10 skipped (12 new — env/config precedence + adapter pass-through). Existing BM25 and parity suites green unchanged.
- ruff check + format: clean. Import-linter contract kept.
- Conflict-catching validation (offline, against real supersession events, shipped `union_retrieve` + `potion-retrieval-32M`): on terse proposed-approach queries, BM25@5 catches 21/24 and the union catches 24/24, recovering the 3 low-overlap conflicts BM25 misses. Retrieval recall@10 on low-overlap related pairs lifts 0.234 → 0.416 with no overall regression.
