### PR TITLE
Add plugin agent emitter and hidden render-plugin command

### DIFF
--- a/packages/nauro/src/nauro/agents/__init__.py
+++ b/packages/nauro/src/nauro/agents/__init__.py
@@ -18,6 +18,7 @@ they raise ``NotImplementedError`` because their subagent equivalents
 from __future__ import annotations
 
 from importlib import resources
+from pathlib import Path
 from typing import Literal
 
 Surface = Literal["claude_code", "cursor", "codex"]
@@ -58,9 +59,32 @@ def render_agent(surface: str, name: str) -> str:
     raise ValueError(f"unknown surface: {surface!r}")
 
 
+def emit_plugin_agents(dest: Path) -> list[Path]:
+    """Render the bundled Claude Code subagents into ``dest/agents/``.
+
+    Writes ``dest/agents/<name>.md`` for every name in ``AGENT_NAMES``,
+    using the same ``render_agent("claude_code", name)`` that the installer
+    materializes into the user's surface directory. This is the single
+    canonical source the cross-repo byte-identity gate verifies against:
+    a separate plugin repo renders from here and byte-compares its committed
+    copies, so there is no second render path or plugin-specific frontmatter.
+
+    Only the ``agents/`` subtree is created. Returns the written paths.
+    """
+    agents_dir = dest / "agents"
+    agents_dir.mkdir(parents=True, exist_ok=True)
+    written: list[Path] = []
+    for name in AGENT_NAMES:
+        target = agents_dir / f"{name}.md"
+        target.write_text(render_agent("claude_code", name), encoding="utf-8")
+        written.append(target)
+    return written
+
+
 __all__ = [
     "AGENT_NAMES",
     "Surface",
+    "emit_plugin_agents",
     "load_agent_body",
     "render_agent",
 ]

--- a/packages/nauro/src/nauro/cli/commands/render_plugin.py
+++ b/packages/nauro/src/nauro/cli/commands/render_plugin.py
@@ -1,0 +1,40 @@
+"""nauro render-plugin — render the bundled subagents into a plugin tree.
+
+Hidden command that materializes the canonical ``nauro-*`` subagent bodies
+into ``<dir>/agents/`` so a separate plugin repo can commit byte-identical
+copies rendered from one source. ``--check`` byte-verifies the committed
+copies against the live render, which is the cross-repo byte-identity gate
+run in the plugin repo's CI.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+from nauro.agents import AGENT_NAMES, emit_plugin_agents, render_agent
+
+
+def render_plugin(
+    dir: Path,
+    check: bool = typer.Option(
+        False,
+        "--check",
+        help="Verify committed agents match the live render; exit 1 on any drift.",
+    ),
+) -> None:
+    """Render or verify the bundled subagents under ``<dir>/agents/``."""
+    if check:
+        for name in AGENT_NAMES:
+            target = dir / "agents" / f"{name}.md"
+            expected = render_agent("claude_code", name)
+            if not target.is_file() or target.read_text(encoding="utf-8") != expected:
+                typer.echo(f"drift: {target}", err=True)
+                typer.echo(f"re-run: nauro render-plugin {dir}", err=True)
+                raise typer.Exit(code=1)
+        typer.echo("OK: rendered agents match the bundled source")
+        return
+
+    for path in emit_plugin_agents(dir):
+        typer.echo(str(path))

--- a/packages/nauro/src/nauro/cli/main.py
+++ b/packages/nauro/src/nauro/cli/main.py
@@ -58,6 +58,7 @@ def _register_commands() -> None:
         log,
         note,
         questions,
+        render_plugin,
         serve,
         setup,
         status,
@@ -76,6 +77,7 @@ def _register_commands() -> None:
     app.command(name="log")(log.log)
     app.command(name="import")(import_cmd.import_cmd)
     app.command(name="serve")(serve.serve)
+    app.command(name="render-plugin", hidden=True)(render_plugin.render_plugin)
     app.add_typer(setup.setup_app, name="setup")
     app.command(name="status")(status.status)
     app.add_typer(config.config_app, name="config")

--- a/packages/nauro/tests/test_agents_drift.py
+++ b/packages/nauro/tests/test_agents_drift.py
@@ -17,8 +17,9 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from typer.testing import CliRunner
 
-from nauro.agents import AGENT_NAMES, load_agent_body, render_agent
+from nauro.agents import AGENT_NAMES, emit_plugin_agents, load_agent_body, render_agent
 
 AGENTS_DIR = Path(__file__).resolve().parents[1] / "src" / "nauro" / "agents"
 
@@ -181,3 +182,71 @@ def test_non_filing_agents_cannot_write_doctrine(name: str) -> None:
 
     for tool in DOCTRINE_WRITE_TOOLS:
         assert tool not in tools_line, f"{name}.md tools allowlist grants store-write tool {tool!r}"
+
+
+# --- plugin emitter + render-plugin command -------------------------------
+#
+# A separate plugin repo commits byte-identical copies of the subagents and
+# verifies them against the live render in its CI (the cross-repo
+# byte-identity gate). ``emit_plugin_agents`` is the single canonical source
+# it renders from; ``nauro render-plugin --check`` is the verification entry
+# point. ``AGENT_NAMES`` / ``render_agent`` are load-bearing public API for
+# that gate and must stay in ``__all__``.
+
+runner = CliRunner()
+
+
+def test_emit_plugin_agents_writes_canonical_bodies(tmp_path: Path) -> None:
+    written = emit_plugin_agents(tmp_path)
+    assert {p.name for p in written} == {f"{name}.md" for name in AGENT_NAMES}
+    for name in AGENT_NAMES:
+        target = tmp_path / "agents" / f"{name}.md"
+        assert target.read_text(encoding="utf-8") == render_agent("claude_code", name)
+
+
+def test_emit_plugin_agents_writes_only_agents_subtree(tmp_path: Path) -> None:
+    emit_plugin_agents(tmp_path)
+    # Only the agents/ subtree is created under dest, nothing else.
+    assert {p.name for p in tmp_path.iterdir()} == {"agents"}
+    agents_dir = tmp_path / "agents"
+    assert {p.stem for p in agents_dir.glob("*.md")} == set(AGENT_NAMES)
+    assert {p.name for p in agents_dir.iterdir()} == {f"{name}.md" for name in AGENT_NAMES}
+
+
+def test_public_api_import_contract() -> None:
+    """``render_agent`` and ``AGENT_NAMES`` are the cross-repo gate's contract."""
+    import nauro.agents as agents_module
+
+    assert "AGENT_NAMES" in agents_module.__all__
+    assert "render_agent" in agents_module.__all__
+    assert agents_module.AGENT_NAMES == AGENT_NAMES
+    assert agents_module.render_agent is render_agent
+
+
+def test_render_plugin_check_passes_on_freshly_emitted_tree(tmp_path: Path) -> None:
+    from nauro.cli.main import app
+
+    emit_plugin_agents(tmp_path)
+    result = runner.invoke(app, ["render-plugin", str(tmp_path), "--check"])
+    assert result.exit_code == 0
+
+
+def test_render_plugin_check_fails_on_drift_and_writes_nothing(tmp_path: Path) -> None:
+    from nauro.cli.main import app
+
+    emit_plugin_agents(tmp_path)
+    mutated = tmp_path / "agents" / f"{AGENT_NAMES[0]}.md"
+    original = mutated.read_text(encoding="utf-8")
+    mutated.write_text(original + "drift\n", encoding="utf-8")
+
+    others = {
+        name: (tmp_path / "agents" / f"{name}.md").read_text(encoding="utf-8")
+        for name in AGENT_NAMES[1:]
+    }
+
+    result = runner.invoke(app, ["render-plugin", str(tmp_path), "--check"])
+    assert result.exit_code == 1
+    # --check writes nothing: the mutated file is left as-is, untouched files unchanged.
+    assert mutated.read_text(encoding="utf-8") == original + "drift\n"
+    for name, content in others.items():
+        assert (tmp_path / "agents" / f"{name}.md").read_text(encoding="utf-8") == content


### PR DESCRIPTION
## Why

A separate plugin repo needs to ship byte-identical copies of the four bundled
`nauro-*` subagents and verify them against the published CLI in its own CI.
Without a canonical render entry point in this repo, the plugin repo would fork
the subagent bodies into a second source, and the two copies would silently
drift over time.

## Approach

Render the bundled subagents from one canonical source, and let the plugin repo
run a cross-repo byte-identity gate against it. `emit_plugin_agents` reuses the
exact `render_agent("claude_code", name)` the installer already calls — no
second render path and no plugin-specific frontmatter, so the bytes the plugin
commits are the bytes the CLI ships. Rejected alternative: a separate
plugin-shaped render path, which would reintroduce the drift this is meant to
prevent.

The CLI surface is a hidden command rather than a public one: it is tooling for
the plugin repo's build/CI, not a user-facing workflow, so it is registered with
`hidden=True` and stays out of `nauro --help`.

## What changed

- Agents package gains `emit_plugin_agents(dest)`, which writes
  `dest/agents/<name>.md` for every bundled agent and returns the written paths.
  It is exported alongside `render_agent`/`AGENT_NAMES`, which remain the
  load-bearing public contract the plugin gate imports.
- New hidden `nauro render-plugin <dir>` command: no flag emits the `agents/`
  subtree; `--check` byte-compares each committed copy against the live render
  and exits 1 on the first drift or missing file (writing nothing), printing the
  offending path plus a re-run hint to stderr.
- The drift test suite is extended with emitter, coverage-parity, public-API
  import-contract, and CLI `--check` (pass/fail) cases.

## What to review

- The `--check` path in `render_plugin.py`: it must write nothing on failure and
  exit with code 1 on the first mismatch. A test asserts the mutated and
  untouched files are both left as-is.
- That `emit_plugin_agents` only creates the `agents/` subtree under `dest` and
  nothing else (covered by a parity test).
- Plain string/path ops only — no regex, no Jinja2.

## What's deferred

Everything on the plugin-repo side: `plugin.json`, `.mcp.json`,
`marketplace.json`, skills, and the CI workflow that calls `render-plugin
--check`. Those are separate follow-ups and intentionally out of scope here. No
`pyproject` version bump in this PR.

## Test plan

`uv run ruff format --check packages/` and `uv run ruff check packages/` pass.
`uv run pytest packages/nauro/tests/ -x -q` → 1046 passed, 10 skipped (35 in the
extended drift suite). Manually verified: `render-plugin` is hidden from `nauro
--help`; a no-flag run writes the four agent files; `--check` exits 0 on a clean
tree and exits 1 with the drift path on a mutated one.
