### PR TITLE
Add advisory UserPromptSubmit hook and --with-hooks install

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/hook.py
+++ b/packages/nauro/src/nauro/cli/commands/hook.py
@@ -1,0 +1,322 @@
+"""nauro hook — client-side advisory hooks for AI coding agents.
+
+Currently implements the Claude Code ``UserPromptSubmit`` hook. On each turn
+Claude Code invokes ``nauro hook user-prompt-submit`` with the hook payload on
+stdin; this command runs the ``check_decision`` kernel against the local store
+and, when a relevant decision clears the relevance floor, emits a compact
+advisory block via ``hookSpecificOutput.additionalContext``.
+
+The hook is advisory by construction: it never blocks a turn, never writes to
+the store, and never exits non-zero. Any failure — malformed stdin, no project
+for the cwd, a missing store, a missing optional embeddings extra — is swallowed
+and the command prints nothing and exits 0. A turn must never be blocked by
+Nauro.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+import typer
+
+from nauro.constants import DEFAULT_NAURO_HOME, NAURO_HOME_ENV
+
+hook_app = typer.Typer(help="Client-side advisory hooks for AI coding agents.")
+
+# ── Tuning constants (initial values; final tuning deferred to the harness) ──
+
+# BM25 relevance floor. A hit must clear this score to be injected. The BM25
+# score scales with corpus size and query length; against a real decision
+# corpus (a few hundred decisions) a strong terse-prompt match scores in the
+# mid-teens, while weak near-neighbours sit in the low single digits. A floor
+# here clears the weak tail and keeps genuine conflicts. This is a sensible
+# initial value; final tuning against field telemetry is deferred.
+RELEVANCE_FLOOR = 8.0
+
+# Maximum decisions injected per turn. Three is enough to surface the cluster
+# around a conflict without flooding the context window.
+MAX_INJECTED = 3
+
+# Per-decision rationale preview length in the injected block. The kernel
+# already caps rationale_preview at 200 chars; trim further for token economy.
+PREVIEW_CHARS = 120
+
+# Per-session dedup state: keep state files small and expire them so the
+# hook-state directory does not grow without bound across long-lived machines.
+SESSION_STATE_TTL_SECONDS = 7 * 24 * 60 * 60  # 7 days
+MAX_SESSION_STATE_FILES = 500
+MAX_DEDUP_ENTRIES_PER_SESSION = 200
+
+# Injection copy. One advisory preamble line and one review instruction; the
+# agent adjudicates the decision body itself.
+_PREAMBLE = "Nauro: prior decisions may bear on this request — advisory only, not a block."
+_INSTRUCTION = "Review these and call get_decision before acting on anything they constrain."
+
+
+@hook_app.command(name="user-prompt-submit")
+def user_prompt_submit() -> None:
+    """Claude Code UserPromptSubmit hook: surface related decisions as context.
+
+    Reads the hook payload JSON from stdin, resolves the project from the
+    payload's ``cwd``, runs ``check_decision`` against the local store, and
+    prints a ``hookSpecificOutput`` envelope with an advisory block when a
+    decision clears the relevance floor and has not already surfaced this
+    session. On any failure prints nothing and exits 0.
+    """
+    try:
+        _run_user_prompt_submit()
+    except Exception:
+        # Fail-open by construction: any failure leaves the turn unblocked.
+        pass
+    raise typer.Exit(code=0)
+
+
+def _run_user_prompt_submit() -> None:
+    payload = json.loads(sys.stdin.read())
+    prompt = payload.get("prompt")
+    if not isinstance(prompt, str) or not prompt.strip():
+        return
+
+    cwd = payload.get("cwd")
+    if not isinstance(cwd, str) or not cwd:
+        return
+    session_id = payload.get("session_id")
+
+    store_path = _resolve_store_path(Path(cwd))
+    if store_path is None or not store_path.exists():
+        return
+
+    related = _check(store_path, prompt)
+    if not related:
+        return
+
+    surviving = _apply_floor(related)
+    if not surviving:
+        return
+
+    already_seen = _load_seen(session_id)
+    fresh = [r for r in surviving if r["number"] not in already_seen]
+    if not fresh:
+        return
+
+    injected = fresh[:MAX_INJECTED]
+    block = _format_block(injected)
+    _record_seen(session_id, [r["number"] for r in injected])
+
+    output = {
+        "hookSpecificOutput": {
+            "hookEventName": "UserPromptSubmit",
+            "additionalContext": block,
+        }
+    }
+    sys.stdout.write(json.dumps(output))
+
+
+def _resolve_store_path(cwd: Path) -> Path | None:
+    """Resolve the project store path from a hook payload's cwd.
+
+    Reuses the per-repo config walk-up and the v2 registry path resolution that
+    ``cli/utils.resolve_target_project`` uses, but operates against the payload's
+    cwd rather than the process cwd and returns None instead of raising — the
+    hook never errors a turn over an unresolvable directory.
+    """
+    from nauro.store.registry import get_store_path_v2, resolve_v2_from_path
+    from nauro.store.repo_config import (
+        RepoConfigSchemaError,
+        find_repo_config,
+        load_repo_config,
+    )
+
+    config_path = find_repo_config(cwd)
+    if config_path is not None:
+        repo_root = config_path.parent.parent
+        try:
+            cfg = load_repo_config(repo_root)
+        except (RepoConfigSchemaError, json.JSONDecodeError, OSError):
+            cfg = None
+        if cfg is not None:
+            return get_store_path_v2(cfg["id"])
+
+    v2_match = resolve_v2_from_path(cwd)
+    if v2_match is not None:
+        pid, _entry = v2_match
+        return get_store_path_v2(pid)
+    return None
+
+
+def _check(store_path: Path, prompt: str) -> list[dict]:
+    """Run the check_decision kernel and return its related-decision hits.
+
+    The embeddings flag is resolved here so the hook shares the MCP and CLI
+    retrieval path, but the MVP install does not set ``NAURO_EMBEDDINGS``, so the
+    hook runs BM25-only by default. The flag wiring is retained for the follow-up
+    that re-admits cosine-gated embedding hits once the kernel exposes the score.
+    Each hit is reduced to the fields the injection block needs.
+    """
+    from nauro_core.operations.check_decision import check_decision
+    from nauro_core.parsing import extract_decision_number
+
+    from nauro.store.config import resolve_embeddings_flag
+    from nauro.store.filesystem_store import FilesystemStore
+
+    result = check_decision(
+        FilesystemStore(store_path),
+        prompt,
+        use_embeddings=resolve_embeddings_flag(),
+    )
+    if result.error is not None:
+        return []
+
+    hits: list[dict] = []
+    for rd in result.related_decisions:
+        number = extract_decision_number(rd.id)
+        if number is None:
+            continue
+        hits.append(
+            {
+                "number": number,
+                "title": rd.title,
+                "score": rd.score,
+                "status": rd.status,
+                "date": rd.date,
+                "preview": rd.rationale_preview,
+            }
+        )
+    return hits
+
+
+def _apply_floor(hits: list[dict]) -> list[dict]:
+    """Filter hits to those worth injecting.
+
+    BM25 hits at or above the relevance floor are kept in order; everything else
+    is dropped. Embedding-only hits (score 0.0) are not admitted: on the
+    validation corpus they recovered no conflict the BM25 floor missed while
+    injecting a nearest-neighbour on every otherwise-silent prompt. The kernel
+    discards the cosine score, so an embedding-only hit cannot be relevance-gated
+    here. Re-admitting them is a follow-up that requires the kernel to expose the
+    embedding score.
+    """
+    return [h for h in hits if h["score"] >= RELEVANCE_FLOOR]
+
+
+def _format_block(hits: list[dict]) -> str:
+    """Render the advisory block: a preamble, one line per hit, an instruction.
+
+    Each hit line is ``D### "title" (status, date) — <preview>`` using the
+    rationale preview already on the hit, so no get_decision call is needed.
+    """
+    lines = [_PREAMBLE]
+    for h in hits:
+        preview = (h["preview"] or "").strip()
+        if len(preview) > PREVIEW_CHARS:
+            preview = preview[: PREVIEW_CHARS - 1].rstrip() + "…"
+        meta = h["status"]
+        if h["date"]:
+            meta = f"{meta}, {h['date']}"
+        line = f'D{h["number"]:03d} "{h["title"]}" ({meta})'
+        if preview:
+            line = f"{line} — {preview}"
+        lines.append(line)
+    lines.append(_INSTRUCTION)
+    return "\n".join(lines)
+
+
+# ── Per-session dedup state ──────────────────────────────────────────────────
+
+
+def _hook_state_dir() -> Path:
+    nauro_home = Path(os.environ.get(NAURO_HOME_ENV, Path.home() / DEFAULT_NAURO_HOME))
+    return nauro_home / "hook-state"
+
+
+def _session_state_file(session_id: str) -> Path | None:
+    """Return the state file path for a session, or None when unusable.
+
+    The session id comes from an external payload, so reject anything that is
+    not a plain identifier rather than letting it shape a filesystem path.
+    """
+    if not isinstance(session_id, str) or not session_id:
+        return None
+    if "/" in session_id or "\\" in session_id or session_id in (".", ".."):
+        return None
+    return _hook_state_dir() / f"{session_id}.json"
+
+
+def _load_seen(session_id: str | None) -> set[int]:
+    """Return the decision numbers already surfaced this session.
+
+    Fail-open: an unreadable or malformed state file means we inject anyway, so
+    a corrupt dedup record never silences a genuine conflict.
+    """
+    if session_id is None:
+        return set()
+    state_file = _session_state_file(session_id)
+    if state_file is None or not state_file.exists():
+        return set()
+    try:
+        data = json.loads(state_file.read_text())
+        seen = data.get("seen", [])
+        return {int(n) for n in seen}
+    except (json.JSONDecodeError, OSError, ValueError, TypeError):
+        return set()
+
+
+def _record_seen(session_id: str | None, numbers: list[int]) -> None:
+    """Persist newly-surfaced decision numbers for this session.
+
+    Best-effort: an unwritable state directory is swallowed, so dedup degrades
+    to per-invocation but the turn still completes.
+    """
+    if session_id is None:
+        return
+    state_file = _session_state_file(session_id)
+    if state_file is None:
+        return
+    try:
+        existing = _load_seen(session_id)
+        merged = sorted(existing | set(numbers))[-MAX_DEDUP_ENTRIES_PER_SESSION:]
+        state_file.parent.mkdir(parents=True, exist_ok=True)
+        _prune_state_dir(state_file.parent)
+        payload = {"seen": merged, "updated_at": time.time()}
+        state_file.write_text(json.dumps(payload))
+    except OSError:
+        return
+
+
+def _prune_state_dir(state_dir: Path) -> None:
+    """Drop expired and surplus session-state files to bound the directory.
+
+    Removes files older than the TTL, then trims to the most-recent cap by
+    mtime. Best-effort: individual unlink failures are ignored.
+    """
+    try:
+        files = [p for p in state_dir.glob("*.json") if p.is_file()]
+    except OSError:
+        return
+    now = time.time()
+    survivors: list[tuple[float, Path]] = []
+    for p in files:
+        try:
+            mtime = p.stat().st_mtime
+        except OSError:
+            continue
+        if now - mtime > SESSION_STATE_TTL_SECONDS:
+            _unlink_quiet(p)
+            continue
+        survivors.append((mtime, p))
+    if len(survivors) <= MAX_SESSION_STATE_FILES:
+        return
+    survivors.sort(key=lambda t: t[0])
+    for _mtime, p in survivors[: len(survivors) - MAX_SESSION_STATE_FILES]:
+        _unlink_quiet(p)
+
+
+def _unlink_quiet(path: Path) -> None:
+    try:
+        path.unlink()
+    except OSError:
+        pass

--- a/packages/nauro/src/nauro/cli/commands/setup.py
+++ b/packages/nauro/src/nauro/cli/commands/setup.py
@@ -215,6 +215,15 @@ def claude_code(
     remove: bool = typer.Option(
         False, "--remove", help="Remove Nauro integration instead of adding it."
     ),
+    with_hooks: bool = typer.Option(
+        False,
+        "--with-hooks",
+        help=(
+            "Wire Nauro's advisory UserPromptSubmit hook into each repo's "
+            "project-scope .claude/settings.json. The hook surfaces related "
+            "decisions as context each turn and never blocks."
+        ),
+    ),
 ) -> None:
     """Configure Claude Code to use Nauro during sessions."""
     project_name, _store_path = resolve_target_project(project)
@@ -236,6 +245,7 @@ def claude_code(
     # via MCP server instructions, so the injected block is no longer needed).
     legacy_results = []
     mcp_results = []
+    hook_results = []
     for repo_str in entry["repo_paths"]:
         repo_path = Path(repo_str)
         if not repo_path.is_dir():
@@ -245,6 +255,11 @@ def claude_code(
         if legacy:
             legacy_results.append(legacy)
         mcp_results.append(_configure_mcp(repo_path, remove=remove))
+        if with_hooks:
+            try:
+                hook_results.append(materialize_hooks_claude_code(repo_path, remove=remove))
+            except Exception as exc:
+                hook_results.append(f"  {repo_path}: hook wiring error — {exc}")
 
     if not remove:
         pruned = _prune_redundant_user_scope_mcp()
@@ -256,6 +271,11 @@ def claude_code(
     typer.echo(f"{action} Nauro for project '{project_name}':\n")
     for line in mcp_results:
         typer.echo(line)
+
+    if hook_results:
+        typer.echo("\nHooks:")
+        for line in hook_results:
+            typer.echo(line)
 
     if legacy_results:
         typer.echo("\nLegacy cleanup:")
@@ -275,6 +295,8 @@ def claude_code(
             "\nNext: start a Claude Code session in one of the repos."
             " The MCP server will start automatically."
         )
+        if with_hooks:
+            typer.echo(f"\n{HOOKS_NOTICE}")
         typer.echo(f"\n{CHECK_HINT_LINE}")
 
 
@@ -660,6 +682,140 @@ def materialize_agents(
     return results
 
 
+# ─── Hook materialization ─────────────────────────────────────────────────────
+
+
+# Claude Code reads hooks from project-scope ``<repo>/.claude/settings.json``.
+# The advisory UserPromptSubmit hook runs ``nauro hook user-prompt-submit`` on
+# each turn; it surfaces related decisions as context and never blocks a turn.
+# The MVP hook is BM25-floor only — it does not set ``NAURO_EMBEDDINGS`` — so the
+# install incurs no embedding model load. The hook still resolves the embeddings
+# flag internally, so the follow-up that re-admits cosine-gated embedding hits
+# can flip the backend on without changing the installed command.
+#
+# The hook is Claude-Code-only: Cursor and Codex have no comparable per-turn
+# client event to bind to.
+
+HOOK_EVENT_NAME = "UserPromptSubmit"
+HOOK_COMMAND = "nauro hook user-prompt-submit"
+HOOK_TIMEOUT_SECONDS = 10
+
+# Substring that identifies a nauro-authored hook entry on the remove path, so a
+# user's own UserPromptSubmit hooks are preserved.
+_HOOK_COMMAND_MARKER = "nauro hook"
+
+
+def _claude_settings_path(repo: Path) -> Path:
+    return repo / ".claude" / "settings.json"
+
+
+def materialize_hooks_claude_code(repo: Path, *, remove: bool) -> str:
+    """Add or remove the Nauro advisory hook in ``<repo>/.claude/settings.json``.
+
+    Add path: idempotently append the hook entry to
+    ``hooks.UserPromptSubmit[].hooks[]`` only when no nauro-authored entry is
+    already present. Remove path: strip only the nauro-authored entry (matched on
+    the command containing ``nauro hook``), preserving any user-authored hooks
+    and the surrounding structure.
+
+    Returns a one-line status string (indented for ``setup_all_surfaces``).
+    """
+    settings_path = _claude_settings_path(repo)
+
+    if settings_path.exists():
+        try:
+            settings = json.loads(settings_path.read_text())
+        except json.JSONDecodeError as exc:
+            return f"  {repo}: could not parse .claude/settings.json — {exc}"
+        if not isinstance(settings, dict):
+            return f"  {repo}: .claude/settings.json is not a JSON object, skipped"
+    else:
+        settings = {}
+
+    if remove:
+        return _remove_hook_entry(settings_path, settings, repo)
+    return _add_hook_entry(settings_path, settings, repo)
+
+
+def _nauro_hook_entry() -> dict:
+    return {
+        "type": "command",
+        "command": HOOK_COMMAND,
+        "timeout": HOOK_TIMEOUT_SECONDS,
+    }
+
+
+def _is_nauro_hook(entry: object) -> bool:
+    return (
+        isinstance(entry, dict)
+        and isinstance(entry.get("command"), str)
+        and _HOOK_COMMAND_MARKER in entry["command"]
+    )
+
+
+def _add_hook_entry(settings_path: Path, settings: dict, repo: Path) -> str:
+    hooks = settings.setdefault("hooks", {})
+    if not isinstance(hooks, dict):
+        return f"  {repo}: hooks key is not a JSON object, skipped"
+    event_matchers = hooks.setdefault(HOOK_EVENT_NAME, [])
+    if not isinstance(event_matchers, list):
+        return f"  {repo}: hooks.{HOOK_EVENT_NAME} is not a JSON array, skipped"
+
+    # Idempotent: if any matcher already carries a nauro hook, do nothing.
+    for matcher in event_matchers:
+        if isinstance(matcher, dict):
+            for entry in matcher.get("hooks", []):
+                if _is_nauro_hook(entry):
+                    return f"  {repo}: nauro hook already present in .claude/settings.json"
+
+    event_matchers.append({"hooks": [_nauro_hook_entry()]})
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    settings_path.write_text(json.dumps(settings, indent=2) + "\n")
+    return f"  {repo}: wrote nauro hook to .claude/settings.json"
+
+
+def _remove_hook_entry(settings_path: Path, settings: dict, repo: Path) -> str:
+    hooks = settings.get("hooks")
+    if not isinstance(hooks, dict):
+        return f"  {repo}: no nauro hook to remove"
+    event_matchers = hooks.get(HOOK_EVENT_NAME)
+    if not isinstance(event_matchers, list):
+        return f"  {repo}: no nauro hook to remove"
+
+    removed = False
+    surviving_matchers = []
+    for matcher in event_matchers:
+        if not isinstance(matcher, dict):
+            surviving_matchers.append(matcher)
+            continue
+        entries = matcher.get("hooks", [])
+        kept = [e for e in entries if not _is_nauro_hook(e)]
+        if len(kept) != len(entries):
+            removed = True
+        if kept:
+            matcher = {**matcher, "hooks": kept}
+            surviving_matchers.append(matcher)
+        elif "hooks" not in matcher:
+            surviving_matchers.append(matcher)
+        # A matcher whose only hooks were nauro-authored is dropped entirely.
+
+    if not removed:
+        return f"  {repo}: no nauro hook to remove"
+
+    if surviving_matchers:
+        hooks[HOOK_EVENT_NAME] = surviving_matchers
+    else:
+        hooks.pop(HOOK_EVENT_NAME, None)
+    if not hooks:
+        settings.pop("hooks", None)
+
+    if settings:
+        settings_path.write_text(json.dumps(settings, indent=2) + "\n")
+    else:
+        settings_path.unlink()
+    return f"  {repo}: removed nauro hook from .claude/settings.json"
+
+
 # ─── nauro setup all ────────────────────────────────────────────────────────
 
 
@@ -671,6 +827,7 @@ def setup_all_surfaces(
     with_subagents: bool = False,
     force_overwrite: bool = False,
     with_skills: bool = False,
+    with_hooks: bool = False,
 ) -> list[str]:
     """Wire MCP and materialize skills across Claude Code, Cursor, Codex.
 
@@ -696,6 +853,11 @@ def setup_all_surfaces(
     ``nauro-ship-task`` references the bundled ``@nauro-*`` subagents in
     its body — caller surfaces ``with_skills`` without ``with_subagents``
     should warn the user.
+
+    ``with_hooks`` opts into wiring the advisory ``UserPromptSubmit`` hook into
+    each repo's project-scope ``.claude/settings.json`` (Claude-Code-only).
+    Off by default. A hook-wiring failure is caught and reported as a status
+    line so it never aborts the rest of setup.
     """
     clear_user_scope = _user_scope_safe_to_clear(current_project_key) if remove else True
 
@@ -741,6 +903,15 @@ def setup_all_surfaces(
         except Exception as exc:
             lines.append(f"Claude Code agents: error — {exc}")
 
+    if with_hooks:
+        for repo in project_repos:
+            if not repo.is_dir():
+                continue
+            try:
+                lines.append(materialize_hooks_claude_code(repo, remove=remove))
+            except Exception as exc:
+                lines.append(f"Claude Code hook ({repo}): error — {exc}")
+
     # Cursor (MCP per-repo + skills per-repo)
     for repo in project_repos:
         if not repo.is_dir():
@@ -778,6 +949,12 @@ def setup_all_surfaces(
 SHIP_TASK_NEEDS_SUBAGENTS_NOTICE = (
     "nauro-ship-task references the bundled @nauro-* subagents; pass "
     "`--with-subagents` to install them too."
+)
+
+HOOKS_NOTICE = (
+    "The advisory hook surfaces related decisions as context on each turn "
+    "(BM25 retrieval) and never blocks. Start a new Claude Code session in a "
+    "wired repo for it to take effect."
 )
 
 
@@ -818,6 +995,15 @@ def all_(
             "of --with-subagents."
         ),
     ),
+    with_hooks: bool = typer.Option(
+        False,
+        "--with-hooks",
+        help=(
+            "Wire Nauro's advisory UserPromptSubmit hook into each repo's "
+            "project-scope .claude/settings.json (Claude Code only). The hook "
+            "surfaces related decisions as context each turn and never blocks."
+        ),
+    ),
 ) -> None:
     """Configure Claude Code, Cursor, and Codex CLI in one call."""
     project_name, _store_path = resolve_target_project(project)
@@ -844,11 +1030,15 @@ def all_(
         with_subagents=with_subagents,
         force_overwrite=force_overwrite,
         with_skills=with_skills,
+        with_hooks=with_hooks,
     ):
         typer.echo(line)
 
     if not remove and with_skills and not with_subagents:
         typer.echo(f"\n{SHIP_TASK_NEEDS_SUBAGENTS_NOTICE}")
+
+    if not remove and with_hooks:
+        typer.echo(f"\n{HOOKS_NOTICE}")
 
     if not remove:
         typer.echo(f"\n{CHECK_HINT_LINE}")

--- a/packages/nauro/src/nauro/cli/main.py
+++ b/packages/nauro/src/nauro/cli/main.py
@@ -52,6 +52,7 @@ def _register_commands() -> None:
         attach,
         auth,
         config,
+        hook,
         import_cmd,
         init,
         link,
@@ -73,6 +74,7 @@ def _register_commands() -> None:
     app.command(name="link")(link.link)
     app.command(name="note")(note.note)
     app.add_typer(questions.questions_app, name="questions")
+    app.add_typer(hook.hook_app, name="hook")
     app.command(name="sync")(sync.sync)
     app.command(name="log")(log.log)
     app.command(name="import")(import_cmd.import_cmd)

--- a/packages/nauro/tests/test_hook_command.py
+++ b/packages/nauro/tests/test_hook_command.py
@@ -1,0 +1,422 @@
+"""Tests for ``nauro hook user-prompt-submit`` — the advisory Claude Code hook.
+
+The hook is advisory by construction: it must never block a turn, so every
+failure path is asserted to exit 0 with empty stdout. Project resolution,
+relevance-floor suppression, and per-session dedup are exercised against an
+isolated ``NAURO_HOME`` store seeded with real-shaped decision files.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+from pathlib import Path
+
+from nauro_core.decision_model import Decision, format_decision
+from typer.testing import CliRunner
+
+from nauro.cli.commands import hook
+from nauro.cli.main import app
+from nauro.store.registry import register_project_v2
+from nauro.templates.scaffolds import scaffold_project_store
+
+runner = CliRunner()
+
+
+def _write_decision(
+    store_path: Path,
+    *,
+    num: int,
+    title: str,
+    rationale: str,
+    status: str = "active",
+) -> None:
+    """Write a valid v2 decision file into the store's decisions directory."""
+    decision = Decision(
+        date=dt.date(2026, 5, 1),
+        confidence="medium",
+        status=status,
+        num=num,
+        title=title,
+        rationale=rationale,
+    )
+    content = format_decision(decision)
+    slug = title.lower().replace(" ", "-")[:40]
+    (store_path / "decisions" / f"{num:03d}-{slug}.md").write_text(content)
+
+
+# BM25 IDF — and therefore the relevance-floor score — scales with corpus
+# size. A tiny store scores a strong match well below the production floor, an
+# artifact of corpus size rather than relevance. Seed a corpus of unrelated
+# distractor decisions so scoring approximates a real store and a genuine match
+# clears RELEVANCE_FLOOR the way it does in the field.
+_DISTRACTOR_TOPICS = [
+    "billing",
+    "authentication",
+    "logging",
+    "caching",
+    "deployment",
+    "metrics",
+    "search",
+    "synchronization",
+    "configuration",
+    "schema",
+    "telemetry",
+    "registry",
+    "snapshot",
+    "migration",
+    "templating",
+    "cursor",
+    "codex",
+    "embedding",
+    "retrieval",
+    "parser",
+    "validator",
+    "session",
+    "questions",
+    "import",
+    "export",
+    "backup",
+    "throttle",
+    "webhook",
+    "queue",
+    "indexing",
+]
+
+
+def _make_project(tmp_path: Path) -> tuple[Path, Path]:
+    """Register a project rooted at a fresh repo dir; return (repo, store_path)."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _pid, store_path = register_project_v2("hookproj", [repo])
+    scaffold_project_store("hookproj", store_path)
+    for i, topic in enumerate(_DISTRACTOR_TOPICS, start=100):
+        _write_decision(
+            store_path,
+            num=i,
+            title=f"approach for the {topic} subsystem",
+            rationale=f"the {topic} subsystem uses a dedicated module with isolated state",
+        )
+    return repo, store_path
+
+
+def _invoke(payload: dict):
+    return runner.invoke(
+        app,
+        ["hook", "user-prompt-submit"],
+        input=json.dumps(payload),
+    )
+
+
+# ── stdin parsing ─────────────────────────────────────────────────────────────
+
+
+def test_malformed_json_exits_zero_empty(tmp_path: Path):
+    """Malformed stdin JSON fails open: exit 0, no stdout."""
+    result = runner.invoke(app, ["hook", "user-prompt-submit"], input="{not json")
+    assert result.exit_code == 0
+    assert result.output == ""
+
+
+def test_missing_prompt_exits_zero_empty(tmp_path: Path):
+    """A payload without a prompt key fails open: exit 0, no stdout."""
+    repo, _store = _make_project(tmp_path)
+    result = _invoke({"cwd": str(repo), "session_id": "s1"})
+    assert result.exit_code == 0
+    assert result.output == ""
+
+
+def test_empty_prompt_exits_zero_empty(tmp_path: Path):
+    """A blank prompt fails open: exit 0, no stdout."""
+    repo, _store = _make_project(tmp_path)
+    result = _invoke({"prompt": "   ", "cwd": str(repo), "session_id": "s1"})
+    assert result.exit_code == 0
+    assert result.output == ""
+
+
+# ── fail-open on resolution / store problems ───────────────────────────────────
+
+
+def test_no_project_for_cwd_exits_zero_empty(tmp_path: Path):
+    """An unregistered cwd resolves to no project: exit 0, no stdout."""
+    unregistered = tmp_path / "elsewhere"
+    unregistered.mkdir()
+    result = _invoke(
+        {"prompt": "switch the database to postgres", "cwd": str(unregistered), "session_id": "s1"}
+    )
+    assert result.exit_code == 0
+    assert result.output == ""
+
+
+def test_missing_store_exits_zero_empty(tmp_path: Path):
+    """A registered repo whose store dir was removed fails open: exit 0, empty."""
+    repo, store_path = _make_project(tmp_path)
+    # Remove the store directory the registry points at.
+    for child in sorted(store_path.rglob("*"), reverse=True):
+        child.unlink() if child.is_file() else child.rmdir()
+    store_path.rmdir()
+    result = _invoke({"prompt": "rework the auth layer", "cwd": str(repo), "session_id": "s1"})
+    assert result.exit_code == 0
+    assert result.output == ""
+
+
+def test_oversize_prompt_exits_zero_empty(tmp_path: Path):
+    """An over-length prompt trips the kernel's rejection path: exit 0, empty."""
+    repo, store_path = _make_project(tmp_path)
+    _write_decision(
+        store_path,
+        num=10,
+        title="adopt postgres for the primary datastore",
+        rationale="postgres chosen for relational integrity and operational maturity",
+    )
+    # MAX_APPROACH_LENGTH is in the low thousands; 50k chars trips rejection.
+    result = _invoke({"prompt": "x" * 50_000, "cwd": str(repo), "session_id": "s1"})
+    assert result.exit_code == 0
+    assert result.output == ""
+
+
+# ── the success envelope ───────────────────────────────────────────────────────
+
+
+def test_valid_hook_output_envelope(tmp_path: Path):
+    """A relevant prompt yields a valid hookSpecificOutput envelope."""
+    repo, store_path = _make_project(tmp_path)
+    _write_decision(
+        store_path,
+        num=12,
+        title="adopt postgres as the primary datastore",
+        rationale="postgres chosen over dynamodb for relational integrity and SQL tooling",
+    )
+    result = _invoke(
+        {
+            "prompt": "should we adopt postgres as the primary datastore for the service",
+            "cwd": str(repo),
+            "session_id": "envelope",
+        }
+    )
+    assert result.exit_code == 0
+    assert result.output != ""
+    payload = json.loads(result.output)
+    out = payload["hookSpecificOutput"]
+    assert out["hookEventName"] == "UserPromptSubmit"
+    assert "D012" in out["additionalContext"]
+    assert "postgres" in out["additionalContext"]
+    # Advisory framing + the review instruction are both present.
+    assert "advisory" in out["additionalContext"].lower()
+    assert "get_decision" in out["additionalContext"]
+
+
+# ── relevance-floor suppression ────────────────────────────────────────────────
+
+
+def test_no_hits_above_floor_suppressed(tmp_path: Path):
+    """A prompt with no decision above the BM25 floor injects nothing."""
+    repo, store_path = _make_project(tmp_path)
+    _write_decision(
+        store_path,
+        num=20,
+        title="adopt postgres as the primary datastore",
+        rationale="postgres chosen for relational integrity",
+    )
+    # A prompt sharing no vocabulary with any decision.
+    result = _invoke(
+        {
+            "prompt": "draw a purple butterfly on the canvas widget",
+            "cwd": str(repo),
+            "session_id": "floor",
+        }
+    )
+    assert result.exit_code == 0
+    assert result.output == ""
+
+
+# ── per-session dedup ──────────────────────────────────────────────────────────
+
+
+def test_per_session_dedup_does_not_resurface(tmp_path: Path):
+    """Within one session, a decision surfaced once is not surfaced again."""
+    repo, store_path = _make_project(tmp_path)
+    _write_decision(
+        store_path,
+        num=30,
+        title="adopt postgres as the primary datastore",
+        rationale="postgres chosen over dynamodb for relational integrity and SQL tooling",
+    )
+    payload = {
+        "prompt": "should we adopt postgres as the primary datastore",
+        "cwd": str(repo),
+        "session_id": "dedup-session",
+    }
+    first = _invoke(payload)
+    assert first.exit_code == 0
+    assert "D030" in first.output
+
+    second = _invoke(payload)
+    assert second.exit_code == 0
+    # Already surfaced this session — not re-injected.
+    assert second.output == ""
+
+
+def test_distinct_session_resurfaces(tmp_path: Path):
+    """A different session id surfaces the same decision again."""
+    repo, store_path = _make_project(tmp_path)
+    _write_decision(
+        store_path,
+        num=31,
+        title="adopt postgres as the primary datastore",
+        rationale="postgres chosen over dynamodb for relational integrity and SQL tooling",
+    )
+    base = {
+        "prompt": "should we adopt postgres as the primary datastore",
+        "cwd": str(repo),
+    }
+    first = _invoke({**base, "session_id": "session-a"})
+    assert "D031" in first.output
+    second = _invoke({**base, "session_id": "session-b"})
+    assert "D031" in second.output
+
+
+# ── embeddings flag on the invocation path ─────────────────────────────────────
+
+
+def _patch_capturing_check(monkeypatch, captured: dict) -> None:
+    """Patch the kernel's check_decision to capture the use_embeddings argument.
+
+    The operations package re-exports ``check_decision`` at package level, which
+    shadows the submodule of the same name; reach the real module via sys.modules
+    so the patch lands on the binding ``hook._check`` imports.
+    """
+    import sys
+
+    def fake_check(store, approach, use_embeddings=False):
+        captured["use_embeddings"] = use_embeddings
+
+        class _Empty:
+            error = None
+            related_decisions: list = []
+
+        return _Empty()
+
+    check_mod = sys.modules["nauro_core.operations.check_decision"]
+    monkeypatch.setattr(check_mod, "check_decision", fake_check)
+
+
+def test_mvp_runs_bm25_only(tmp_path: Path, monkeypatch):
+    """With no NAURO_EMBEDDINGS in the environment, the hook runs BM25-only.
+
+    The MVP install does not set the flag, so the resolved value passed to the
+    kernel is False — embeddings are not engaged by default.
+    """
+    repo, store_path = _make_project(tmp_path)
+    _write_decision(
+        store_path,
+        num=40,
+        title="adopt postgres as the primary datastore",
+        rationale="postgres chosen for relational integrity",
+    )
+    monkeypatch.delenv("NAURO_EMBEDDINGS", raising=False)
+    captured: dict = {}
+    _patch_capturing_check(monkeypatch, captured)
+
+    result = _invoke({"prompt": "adopt postgres", "cwd": str(repo), "session_id": "flag"})
+    assert result.exit_code == 0
+    assert captured["use_embeddings"] is False
+
+
+def test_embeddings_flag_wiring_retained(tmp_path: Path, monkeypatch):
+    """The flag wiring is retained: setting NAURO_EMBEDDINGS engages it.
+
+    The MVP install leaves the flag unset, but the hook still resolves it, so the
+    cosine-gated follow-up can flip the backend on without code changes here.
+    """
+    repo, store_path = _make_project(tmp_path)
+    _write_decision(
+        store_path,
+        num=41,
+        title="adopt postgres as the primary datastore",
+        rationale="postgres chosen for relational integrity",
+    )
+    monkeypatch.setenv("NAURO_EMBEDDINGS", "1")
+    captured: dict = {}
+    _patch_capturing_check(monkeypatch, captured)
+
+    result = _invoke({"prompt": "adopt postgres", "cwd": str(repo), "session_id": "flag2"})
+    assert result.exit_code == 0
+    assert captured["use_embeddings"] is True
+
+
+# ── dedup state is fail-open ───────────────────────────────────────────────────
+
+
+def test_corrupt_dedup_state_injects_anyway(tmp_path: Path):
+    """An unreadable session state file does not silence a genuine conflict."""
+    repo, store_path = _make_project(tmp_path)
+    _write_decision(
+        store_path,
+        num=50,
+        title="adopt postgres as the primary datastore",
+        rationale="postgres chosen over dynamodb for relational integrity and SQL tooling",
+    )
+    state_dir = tmp_path / "hook-state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / "corrupt.json").write_text("{not valid json")
+
+    result = _invoke(
+        {
+            "prompt": "should we adopt postgres as the primary datastore",
+            "cwd": str(repo),
+            "session_id": "corrupt",
+        }
+    )
+    assert result.exit_code == 0
+    assert "D050" in result.output
+
+
+# ── direct unit coverage of the floor + block helpers ──────────────────────────
+
+
+def test_apply_floor_drops_embedding_only_hits():
+    """Embedding-only hits (score 0.0) are not admitted in the BM25-only MVP."""
+    hits = [
+        {"number": 1, "title": "a", "score": 0.0, "status": "active", "date": "", "preview": ""},
+        {"number": 2, "title": "b", "score": 0.0, "status": "active", "date": "", "preview": ""},
+    ]
+    assert hook._apply_floor(hits) == []
+
+
+def test_apply_floor_keeps_only_bm25_above_floor():
+    """Only BM25 hits at or above the floor survive; an embedding-only hit drops."""
+    above = hook.RELEVANCE_FLOOR + 1.0
+    hits = [
+        {"number": 1, "title": "a", "score": above, "status": "active", "date": "", "preview": ""},
+        {"number": 2, "title": "b", "score": 0.0, "status": "active", "date": "", "preview": ""},
+    ]
+    surviving = hook._apply_floor(hits)
+    assert [h["number"] for h in surviving] == [1]
+
+
+def test_apply_floor_drops_bm25_below_floor():
+    """A BM25 hit below the floor is dropped; no embedding-only hit present."""
+    below = hook.RELEVANCE_FLOOR - 0.1
+    hits = [
+        {"number": 1, "title": "a", "score": below, "status": "active", "date": "", "preview": ""},
+    ]
+    assert hook._apply_floor(hits) == []
+
+
+def test_format_block_shape():
+    """The block carries the preamble, the D### line, and the instruction."""
+    hits = [
+        {
+            "number": 7,
+            "title": "adopt postgres",
+            "score": 5.0,
+            "status": "active",
+            "date": "2026-05-01",
+            "preview": "postgres chosen for relational integrity",
+        }
+    ]
+    block = hook._format_block(hits)
+    assert hook._PREAMBLE in block
+    assert hook._INSTRUCTION in block
+    assert 'D007 "adopt postgres" (active, 2026-05-01)' in block

--- a/packages/nauro/tests/test_setup_hooks.py
+++ b/packages/nauro/tests/test_setup_hooks.py
@@ -1,0 +1,201 @@
+"""Tests for ``--with-hooks`` — wiring the advisory hook into .claude/settings.json.
+
+The hook is wired into project-scope ``<repo>/.claude/settings.json`` under
+``hooks.UserPromptSubmit``. Adds are idempotent; removes strip only the
+nauro-authored entry and preserve user hooks. The wiring is Claude-Code-only and
+never aborts the rest of setup.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from nauro.cli.commands.setup import (
+    HOOK_COMMAND,
+    HOOK_EVENT_NAME,
+    HOOK_TIMEOUT_SECONDS,
+    materialize_hooks_claude_code,
+    setup_all_surfaces,
+)
+from nauro.cli.main import app
+from nauro.store.registry import register_project_v2
+from nauro.templates.scaffolds import scaffold_project_store
+
+runner = CliRunner()
+
+
+def _settings(repo: Path) -> Path:
+    return repo / ".claude" / "settings.json"
+
+
+def _nauro_entries(settings: dict) -> list[dict]:
+    out = []
+    for matcher in settings.get("hooks", {}).get(HOOK_EVENT_NAME, []):
+        for entry in matcher.get("hooks", []):
+            if isinstance(entry, dict) and "nauro hook" in entry.get("command", ""):
+                out.append(entry)
+    return out
+
+
+def _make_project(tmp_path: Path) -> tuple[Path, Path]:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _pid, store_path = register_project_v2("hookproj", [repo])
+    scaffold_project_store("hookproj", store_path)
+    return repo, store_path
+
+
+# ── direct helper: add path ────────────────────────────────────────────────────
+
+
+def test_materialize_writes_correct_structure(tmp_path: Path):
+    """The add path writes the canonical UserPromptSubmit hook entry."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    line = materialize_hooks_claude_code(repo, remove=False)
+    assert "wrote nauro hook" in line
+
+    settings = json.loads(_settings(repo).read_text())
+    entries = _nauro_entries(settings)
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["type"] == "command"
+    assert entry["command"] == HOOK_COMMAND
+    assert entry["timeout"] == HOOK_TIMEOUT_SECONDS
+    # The MVP install is BM25-only: it must not set the embeddings flag.
+    assert "NAURO_EMBEDDINGS" not in entry["command"]
+    assert entry["command"] == "nauro hook user-prompt-submit"
+
+
+def test_materialize_is_idempotent(tmp_path: Path):
+    """A re-run does not duplicate the nauro hook entry."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    materialize_hooks_claude_code(repo, remove=False)
+    line = materialize_hooks_claude_code(repo, remove=False)
+    assert "already present" in line
+
+    settings = json.loads(_settings(repo).read_text())
+    assert len(_nauro_entries(settings)) == 1
+
+
+# ── direct helper: remove path ─────────────────────────────────────────────────
+
+
+def test_remove_strips_only_nauro_entry(tmp_path: Path):
+    """Remove deletes the nauro hook but preserves user-authored hooks."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    settings_path = _settings(repo)
+    settings_path.parent.mkdir(parents=True)
+    # A user hook on the same event, plus other settings, must survive.
+    user_settings = {
+        "hooks": {
+            HOOK_EVENT_NAME: [
+                {"hooks": [{"type": "command", "command": "my-own-linter --check"}]},
+            ]
+        },
+        "model": "claude-opus",
+    }
+    settings_path.write_text(json.dumps(user_settings))
+
+    materialize_hooks_claude_code(repo, remove=False)
+    # Both the user hook and the nauro hook are now present.
+    after_add = json.loads(settings_path.read_text())
+    assert len(_nauro_entries(after_add)) == 1
+
+    line = materialize_hooks_claude_code(repo, remove=True)
+    assert "removed nauro hook" in line
+
+    after_remove = json.loads(settings_path.read_text())
+    assert _nauro_entries(after_remove) == []
+    # User hook and unrelated settings preserved.
+    commands = [e["command"] for m in after_remove["hooks"][HOOK_EVENT_NAME] for e in m["hooks"]]
+    assert "my-own-linter --check" in commands
+    assert after_remove["model"] == "claude-opus"
+
+
+def test_remove_when_absent_is_noop(tmp_path: Path):
+    """Removing with no nauro hook present reports nothing to remove."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    line = materialize_hooks_claude_code(repo, remove=True)
+    assert "no nauro hook to remove" in line
+
+
+def test_remove_deletes_empty_settings_file(tmp_path: Path):
+    """When the nauro hook was the only content, the file is unlinked on remove."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    materialize_hooks_claude_code(repo, remove=False)
+    assert _settings(repo).is_file()
+    materialize_hooks_claude_code(repo, remove=True)
+    assert not _settings(repo).is_file()
+
+
+# ── CLI integration via `setup claude-code --with-hooks` ───────────────────────
+
+
+def test_setup_claude_code_with_hooks(tmp_path: Path, monkeypatch):
+    """`setup claude-code --with-hooks` wires the hook for the project's repo."""
+    repo, _store = _make_project(tmp_path)
+    monkeypatch.chdir(repo)
+
+    result = runner.invoke(app, ["setup", "claude-code", "--with-hooks"])
+    assert result.exit_code == 0, result.output
+
+    settings = json.loads(_settings(repo).read_text())
+    assert len(_nauro_entries(settings)) == 1
+
+
+def test_setup_claude_code_without_hooks_writes_no_settings(tmp_path: Path, monkeypatch):
+    """Without --with-hooks, no .claude/settings.json hook is written."""
+    repo, _store = _make_project(tmp_path)
+    monkeypatch.chdir(repo)
+
+    result = runner.invoke(app, ["setup", "claude-code"])
+    assert result.exit_code == 0, result.output
+    assert not _settings(repo).is_file()
+
+
+# ── setup all integration ──────────────────────────────────────────────────────
+
+
+def test_setup_all_with_hooks_claude_code_only(tmp_path: Path):
+    """setup_all_surfaces with hooks wires Claude Code only — no Cursor/Codex hook."""
+    repo, _store = _make_project(tmp_path)
+    lines = setup_all_surfaces([repo], with_hooks=True)
+    assert any("nauro hook" in line for line in lines)
+
+    settings = json.loads(_settings(repo).read_text())
+    assert len(_nauro_entries(settings)) == 1
+    # No hook file is written under Cursor's surface.
+    assert not (repo / ".cursor" / "settings.json").exists()
+
+
+def test_setup_all_hook_failure_does_not_abort(tmp_path: Path, monkeypatch):
+    """A hook-wiring failure is caught and reported, not propagated."""
+    repo, _store = _make_project(tmp_path)
+
+    import nauro.cli.commands.setup as setup_mod
+
+    def boom(repo, *, remove):
+        raise RuntimeError("simulated wiring failure")
+
+    monkeypatch.setattr(setup_mod, "materialize_hooks_claude_code", boom)
+
+    # Must not raise; the rest of setup still produces its lines.
+    lines = setup_all_surfaces([repo], with_hooks=True)
+    assert any("hook" in line and "error" in line for line in lines)
+    # MCP wiring still happened despite the hook failure.
+    assert (repo / ".mcp.json").is_file()
+
+
+def test_setup_all_without_hooks_writes_nothing(tmp_path: Path):
+    """Default setup_all_surfaces does not touch .claude/settings.json."""
+    repo, _store = _make_project(tmp_path)
+    setup_all_surfaces([repo])
+    assert not _settings(repo).is_file()


### PR DESCRIPTION
## Why
Bundled subagents inherit the doctrine-check gate, but non-bundled and bare Claude Code sessions only do so if they voluntarily call `check_decision` — many never do. Prior decisions then silently fail to surface at the moment an agent is about to act on them. This adds a client-side advisory hook that closes that gap without re-introducing a blocking gate (which would re-create the kernel gate that was deliberately retired and inherit a poor-precision signal).

## Approach
A Claude Code `UserPromptSubmit` hook. On each turn Claude Code invokes `nauro hook user-prompt-submit` with the hook payload on stdin; the command runs the `check_decision` kernel directly against the local store and emits the top related decisions whose BM25 score clears a relevance floor via `hookSpecificOutput.additionalContext`.

A dedicated `nauro hook` command — rather than shelling out to the autogen `check-decision` and re-parsing its pretty-printed envelope — keeps the hook contract (stdin parse, fail-open, output envelope) in one tested place. The hook reuses the existing `rationale_preview` already on each retrieval hit, so no `get_decision` call is needed. Install is opt-in via `nauro setup --with-hooks`, mirroring `--with-subagents`.

The MVP is BM25-floor only. An end-to-end harness against the real decision corpus showed the embedding-only admission (surfacing the nearest embedding neighbour when no BM25 hit cleared the floor) recovered no conflict the BM25 floor already caught, while injecting a decision on every otherwise-silent prompt — so it is dropped. Keeping it BM25-only yields a strong conflict-catch rate at zero noise on unrelated input.

## What changed
- **New `nauro hook user-prompt-submit`** (`cli/commands/hook.py`): resolves the project from the payload `cwd`, runs the kernel, applies a BM25 relevance floor and per-session dedup, prints the advisory block. Fail-open by construction — any failure prints nothing and exits 0. The embeddings flag is still resolved internally so the deferred cosine-gated admission can flip it on without changing the installed command.
- **`nauro setup --with-hooks`** (`cli/commands/setup.py`): wires the hook into project-scope `<repo>/.claude/settings.json`, idempotent add, remove strips only the nauro-authored entry and preserves user hooks. Threaded through `setup all` and `setup claude-code`; a hook-wiring failure is caught and reported, never aborting the rest of setup. Claude-Code-only. The installed command is BM25-only (no embeddings env var), so install incurs no embedding model load.

## What to review
- The fail-open envelope in `hook.py` — every error path must exit 0 with empty stdout. Tests assert exact exit code 0 + empty output on malformed stdin, no project for cwd, missing store, and oversize prompt.
- The BM25 relevance floor in `_apply_floor`. The floor is corpus-size-sensitive; the chosen value is a sensible initial constant with final tuning deferred. Embedding-only hits (score 0.0) are now dropped.
- `materialize_hooks_claude_code` add/remove/idempotency, especially that `--remove` preserves a user's own `UserPromptSubmit` hooks.

## What's deferred
- **Cosine-gated union admission (immediate follow-up):** re-admit embedding hits, relevance-gated by the cosine score. This requires a small nauro-core change — `embedding_pool` currently returns only ranked decision numbers and discards the cosine score, so an embedding-only hit cannot be relevance-gated today. With the score exposed, embedding hits can be admitted above a similarity threshold without the per-prompt noise that got the unguarded version dropped here.
- Final relevance-floor / dedup tuning against field telemetry.
- A diff-as-query edit-time hook variant (higher signal, needs throttling).
- A blocking variant (out of scope; would need its own doctrine review).
- Cursor / Codex equivalents (no comparable per-turn client event).

## Test plan
1073 nauro tests pass (10 skipped) + 630 nauro-core tests pass; new tests across `test_hook_command.py` and `test_setup_hooks.py` cover fail-open exits, the BM25 floor, embedding-only-hit drop, per-session dedup, BM25-only-by-default invocation, the retained flag wiring, and the setup add/remove/idempotency. `ruff check` and `ruff format --check` clean. A customer-grounded end-to-end harness replays the real supersession/body-reference cases through the actual hook command (BM25-only, matching the install): 75% supersession conflict-catch-rate, and 0.00 injected-decisions-per-turn on a probe of genuinely-unrelated prompts (10/10 silent).
