### PR TITLE
chore(release): bump nauro to 0.11.1

### DIFF
--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro"
-version = "0.11.0"
+version = "0.11.1"
 description = "Local CLI + MCP server: set your project's doctrine once, every connected AI agent inherits it."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Why

Cut `nauro` 0.11.1 to publish the work merged since 0.11.0. The release is needed now so the Claude Code plugin's cross-repo byte-identity CI has a published wheel that includes `nauro render-plugin` to pin against — PyPI 0.11.0 predates it.

## What's included (since 0.11.0)

- Advisory `UserPromptSubmit` hook + `--with-hooks` install (#140)
- Plugin agent emitter + hidden `render-plugin` command (#139)
- Embedding retrieval augmenter — prototype, off by default (#138)
- Executor restricted to a tool allowlist excluding the store-write tools (#137)

## What changed

`packages/nauro/pyproject.toml` version `0.11.0` → `0.11.1` (pyproject-only; `uv.lock` is gitignored). No `nauro-core` bump — its `>=0.13.0,<0.14` constraint already allows the published 0.13.2.

## Test plan

No code change beyond the version string. CI (lint + the nauro-core / nauro test matrices) runs on this PR. Publish is tag-triggered (`nauro-v0.11.1`) after merge.
