### PR TITLE
Add get_decision header mode for cheap related-decision triage

### DIFF
--- a/.agents/skills/nauro-adopt/SKILL.md
+++ b/.agents/skills/nauro-adopt/SKILL.md
@@ -112,7 +112,7 @@ Languages, frameworks, package managers, license, lint tooling, and similar fact
 For each kept candidate from 6a and each rationale-supplied 6b answer, the agent runs the full propose protocol:
 
 1. Call `check_decision(proposed_approach=<title or short description>, project_id=...)`. `check_decision` returns related decisions via BM25 retrieval and a deterministic assessment. It does NOT judge conflicts.
-2. When the response lists related decisions, call `get_decision` on each one before proposing — the relevance, supersession status, and full rationale live in those bodies, not in the assessment string. Call signature: `get_decision(number=N, project_id=...)`.
+2. When the response lists related decisions, call `get_decision` on each before proposing — `mode=header` to triage, `mode=full` for those you reason about; the assessment doesn't judge. Call signature: `get_decision(number=N, project_id=...)`.
 3. Classify the operation:
     - **add** (default; new ground, no existing decision covers it).
     - **update** when the candidate augments an existing decision's rationale only. The server consumes only `rationale` on update; `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, and `rejected` are rejected at the boundary — use supersede if any of those must change.

--- a/.claude/skills/nauro-adopt/SKILL.md
+++ b/.claude/skills/nauro-adopt/SKILL.md
@@ -112,7 +112,7 @@ Languages, frameworks, package managers, license, lint tooling, and similar fact
 For each kept candidate from 6a and each rationale-supplied 6b answer, the agent runs the full propose protocol:
 
 1. Call `check_decision(proposed_approach=<title or short description>, project_id=...)`. `check_decision` returns related decisions via BM25 retrieval and a deterministic assessment. It does NOT judge conflicts.
-2. When the response lists related decisions, call `get_decision` on each one before proposing — the relevance, supersession status, and full rationale live in those bodies, not in the assessment string. Call signature: `get_decision(number=N, project_id=...)`.
+2. When the response lists related decisions, call `get_decision` on each before proposing — `mode=header` to triage, `mode=full` for those you reason about; the assessment doesn't judge. Call signature: `get_decision(number=N, project_id=...)`.
 3. Classify the operation:
     - **add** (default; new ground, no existing decision covers it).
     - **update** when the candidate augments an existing decision's rationale only. The server consumes only `rationale` on update; `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, and `rejected` are rejected at the boundary — use supersede if any of those must change.

--- a/.cursor/rules/nauro-adopt.mdc
+++ b/.cursor/rules/nauro-adopt.mdc
@@ -112,7 +112,7 @@ Languages, frameworks, package managers, license, lint tooling, and similar fact
 For each kept candidate from 6a and each rationale-supplied 6b answer, the agent runs the full propose protocol:
 
 1. Call `check_decision(proposed_approach=<title or short description>, project_id=...)`. `check_decision` returns related decisions via BM25 retrieval and a deterministic assessment. It does NOT judge conflicts.
-2. When the response lists related decisions, call `get_decision` on each one before proposing — the relevance, supersession status, and full rationale live in those bodies, not in the assessment string. Call signature: `get_decision(number=N, project_id=...)`.
+2. When the response lists related decisions, call `get_decision` on each before proposing — `mode=header` to triage, `mode=full` for those you reason about; the assessment doesn't judge. Call signature: `get_decision(number=N, project_id=...)`.
 3. Classify the operation:
     - **add** (default; new ground, no existing decision covers it).
     - **update** when the candidate augments an existing decision's rationale only. The server consumes only `rationale` on update; `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, and `rejected` are rejected at the boundary — use supersede if any of those must change.

--- a/docs/adopt-prompt.md
+++ b/docs/adopt-prompt.md
@@ -128,7 +128,7 @@ Languages, frameworks, package managers, license, lint tooling, and similar fact
 For each kept candidate from 6a and each rationale-supplied 6b answer, the agent runs the full propose protocol:
 
 1. Call `check_decision(proposed_approach=<title or short description>, project_id=...)`. `check_decision` returns related decisions via BM25 retrieval and a deterministic assessment. It does NOT judge conflicts.
-2. When the response lists related decisions, call `get_decision` on each one before proposing — the relevance, supersession status, and full rationale live in those bodies, not in the assessment string. Call signature: `get_decision(number=N, project_id=...)`.
+2. When the response lists related decisions, call `get_decision` on each before proposing — `mode=header` to triage, `mode=full` for those you reason about; the assessment doesn't judge. Call signature: `get_decision(number=N, project_id=...)`.
 3. Classify the operation:
     - **add** (default; new ground, no existing decision covers it).
     - **update** when the candidate augments an existing decision's rationale only. The server consumes only `rationale` on update; `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, and `rejected` are rejected at the boundary — use supersede if any of those must change.

--- a/packages/nauro-core/src/nauro_core/mcp_tools.py
+++ b/packages/nauro-core/src/nauro_core/mcp_tools.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 from typing import Any, TypedDict
 
 from nauro_core.protocol import (
+    GET_DECISION_BEFORE_PROPOSING,
     PROPOSE_DECISION_OPERATIONS,
     RESOLVES_OPEN_QUESTIONS,
     UPDATE_SUPERSEDE_CARE,
@@ -164,8 +165,15 @@ GET_DECISION: ToolSpec = {
     "name": "get_decision",
     "title": "Get decision by number",
     "description": (
-        "Return the full markdown content of a specific decision by its number. "
-        "Includes metadata, rationale, and rejected alternatives."
+        "Return a specific decision by its number.\n"
+        "\n"
+        "mode=header (compact) returns the triage frontmatter (status, "
+        "supersession, date, type, confidence), the title, and a short lede "
+        "from the rationale — enough to decide whether a decision is worth a "
+        "full read. mode=full (default) returns the complete markdown: "
+        "metadata, full rationale, and rejected alternatives. Read header to "
+        "triage a list of related decisions, then full for the ones you "
+        "actually reason about."
     ),
     "annotations": {**_READ_ANNOTATIONS, "idempotentHint": True},
     "input_schema": {
@@ -174,6 +182,15 @@ GET_DECISION: ToolSpec = {
             "number": {
                 "type": "integer",
                 "description": "Decision number (e.g., 23).",
+            },
+            "mode": {
+                "type": "string",
+                "enum": ["header", "full"],
+                "default": "full",
+                "description": (
+                    "header: triage projection (frontmatter + title + lede). "
+                    "full: complete decision body. Default full."
+                ),
             },
             "project_id": _PROJECT_PARAM,
         },
@@ -259,9 +276,7 @@ CHECK_DECISION: ToolSpec = {
         "WITHOUT writing anything. Returns related decisions (via Tier 1 + "
         "Tier 2 BM25 retrieval) and a deterministic assessment string.\n"
         "\n"
-        "This tool does NOT judge conflicts. When the response lists related "
-        "decisions, call get_decision on each before proposing — the relevance, "
-        "supersession status, and full rationale live in those bodies.\n"
+        f"This tool does NOT judge conflicts. {GET_DECISION_BEFORE_PROPOSING}\n"
         "\n"
         "Use this to consult the project's decision history before committing "
         'to an approach — especially when the user asks "should we...", '

--- a/packages/nauro-core/src/nauro_core/operations/get_decision.py
+++ b/packages/nauro-core/src/nauro_core/operations/get_decision.py
@@ -1,21 +1,55 @@
-"""``get_decision`` — return the full body of a decision by number.
+"""``get_decision`` — return the body of a decision by number.
 
 Cross-transport implementation: CLI, local stdio MCP, and remote HTTP MCP
 all call this function with the same arguments and receive the same
 :class:`GetDecisionResult`. Each transport's adapter wraps the call to
 add transport-specific framing (``store`` field, telemetry emission);
 the lookup itself is shared by construction.
+
+``mode`` selects how much of the decision the ``content`` field carries:
+
+* ``"full"`` (default) — the verbatim markdown body, unchanged.
+* ``"header"`` — a compact projection (triage frontmatter fields, the
+  title, and a short lede from the ``## Decision`` section) for cheap
+  triage of the related-decision list a check returns. The projection
+  rides in the existing ``content`` field; the result model shape is the
+  same for both modes.
 """
 
 from __future__ import annotations
 
+from typing import Literal
+
+from nauro_core.decision_model import parse_decision
 from nauro_core.operations.results import ErrorPayload, GetDecisionResult
 from nauro_core.operations.store import Store
 from nauro_core.parsing import extract_decision_number
 
+# Frontmatter fields the header projection carries, in render order. These
+# are the triage signals a reader needs to decide whether a decision is
+# worth a full read: where it sits in the supersession graph, when it was
+# decided, and how it was classified.
+_HEADER_FRONTMATTER_FIELDS: tuple[str, ...] = (
+    "status",
+    "supersedes",
+    "superseded_by",
+    "date",
+    "decision_type",
+    "confidence",
+)
 
-def get_decision(store: Store, number: int) -> GetDecisionResult:
-    """Return the decision body matching ``number``, or a not-found error.
+# Lede budget. The first paragraph of the ``## Decision`` section is the
+# load-bearing sentence(s); cap it so the projection stays compact while
+# still carrying enough rationale to triage on.
+_LEDE_MAX_CHARS = 300
+
+
+def get_decision(
+    store: Store,
+    number: int,
+    mode: Literal["header", "full"] = "full",
+) -> GetDecisionResult:
+    """Return the decision matching ``number``, or a not-found error.
 
     Status filtering (active vs superseded) belongs to ``list_decisions``;
     ``get_decision`` resolves the exact number regardless of status so
@@ -26,18 +60,88 @@ def get_decision(store: Store, number: int) -> GetDecisionResult:
         number: Decision number to resolve. Matched against the leading
             integer of each decision stem via
             :func:`nauro_core.parsing.extract_decision_number`.
+        mode: ``"full"`` returns the verbatim markdown body; ``"header"``
+            returns the compact triage projection.
 
     Returns:
         :class:`GetDecisionResult`. On a hit ``content`` holds the markdown
-        body. On a miss ``error`` is populated with ``kind="error"`` and a
-        reason that names the number.
+        body (``full``) or the projected block (``header``). On a miss
+        ``error`` is populated with ``kind="error"`` and a reason that
+        names the number.
     """
     for stem in store.list_decisions():
         parsed = extract_decision_number(stem)
         if parsed is not None and parsed == number:
             body = store.read_decision(stem)
             if body is not None:
+                if mode == "header":
+                    projected = _project_header(body, f"{stem}.md")
+                    return GetDecisionResult(content=projected)
                 return GetDecisionResult(content=body)
     return GetDecisionResult(
         error=ErrorPayload(kind="error", reason=f"Decision {number} not found"),
     )
+
+
+def _project_header(body: str, filename: str) -> str:
+    """Build the compact header projection for a decision body.
+
+    Layout (blocks joined by a blank line):
+
+        <ordered triage frontmatter lines>
+        # NNN — Title
+        <lede>            (omitted when the first ## Decision paragraph is empty)
+
+    The empty-lede guard keeps supersession stubs and other bodies whose
+    ``## Decision`` section opens with whitespace from emitting a dangling
+    blank lede block.
+    """
+    decision = parse_decision(body, filename)
+
+    frontmatter_lines: list[str] = []
+    for field in _HEADER_FRONTMATTER_FIELDS:
+        value = _frontmatter_value(decision, field)
+        if value:
+            frontmatter_lines.append(f"{field}: {value}")
+
+    blocks: list[str] = ["\n".join(frontmatter_lines)]
+    blocks.append(f"# {decision.num:03d} — {decision.title}")
+
+    lede = _lede(decision.rationale)
+    if lede:
+        blocks.append(lede)
+
+    return "\n\n".join(blocks)
+
+
+def _frontmatter_value(decision, field: str) -> str:
+    """Return the on-disk string for a triage frontmatter field, or ``""``.
+
+    Enum-valued fields (``status``, ``decision_type``, ``confidence``)
+    serialize to their underlying token; ``date`` to ISO format;
+    supersession refs are already plain integer strings.
+    """
+    raw = getattr(decision, field, None)
+    if raw is None:
+        return ""
+    if field == "date":
+        return raw.isoformat()
+    value = getattr(raw, "value", raw)
+    return str(value)
+
+
+def _lede(rationale: str) -> str:
+    """Return the first paragraph of the rationale, truncated to the budget.
+
+    Returns ``""`` when the rationale is empty or opens with whitespace
+    only, so the projection omits the lede block entirely.
+    """
+    stripped = rationale.strip()
+    if not stripped:
+        return ""
+    paragraph = stripped.split("\n\n", 1)[0].strip()
+    if not paragraph:
+        return ""
+    if len(paragraph) <= _LEDE_MAX_CHARS:
+        return paragraph
+    return paragraph[: _LEDE_MAX_CHARS - 1].rstrip() + "…"

--- a/packages/nauro-core/src/nauro_core/protocol.py
+++ b/packages/nauro-core/src/nauro_core/protocol.py
@@ -30,8 +30,8 @@ CHECK_DECISION_RETURNS = (
 
 GET_DECISION_BEFORE_PROPOSING = (
     "When the response lists related decisions, call `get_decision` on each "
-    "one before proposing — the relevance, supersession status, and full "
-    "rationale live in those bodies, not in the assessment string."
+    "before proposing — `mode=header` to triage, `mode=full` for those you "
+    "reason about; the assessment doesn't judge."
 )
 
 PROPOSE_DECISION_OPERATIONS = (

--- a/packages/nauro-core/src/nauro_core/renderers.py
+++ b/packages/nauro-core/src/nauro_core/renderers.py
@@ -136,13 +136,22 @@ def _extract_call_to_action(assessment: str) -> str:
     return assessment[idx:].strip()
 
 
-def render_get_decision(result: dict) -> str:
-    """Render a decision body. The kernel returns markdown; surface it as-is
-    under a one-line header so chat clients can see the title at a glance."""
+def render_get_decision(result: dict, mode: str = "full") -> str:
+    """Render a decision body.
+
+    For ``mode="full"`` the kernel returns the verbatim markdown body;
+    surface it under a one-line header so chat clients see the title at a
+    glance. For ``mode="header"`` the kernel already returns the compact
+    projection (triage frontmatter + title + lede), so emit it as-is — a
+    second title header would duplicate the projection's own title line.
+    """
     if "error" in result:
         return _error_block(result["error"])
 
     content = result.get("content", "") or ""
+    if mode == "header":
+        return content.rstrip()
+
     header = _decision_title_header(content)
     if header:
         return f"{header}\n\n{content}".rstrip()

--- a/packages/nauro-core/tests/operations/test_get_decision.py
+++ b/packages/nauro-core/tests/operations/test_get_decision.py
@@ -13,6 +13,8 @@ from nauro_core.decision_model import (
     Decision,
     DecisionConfidence,
     DecisionStatus,
+    DecisionType,
+    RejectedAlternative,
     format_decision,
 )
 from nauro_core.operations import (
@@ -20,6 +22,7 @@ from nauro_core.operations import (
     InMemoryStore,
     get_decision,
 )
+from nauro_core.operations.get_decision import _LEDE_MAX_CHARS
 
 
 def _seed_decision(
@@ -123,3 +126,178 @@ def test_store_field_absent_from_result_model_dump() -> None:
     result = get_decision(InMemoryStore(), 1)
     dumped = result.model_dump(mode="json")
     assert "store" not in dumped
+
+
+# ── Backward-compat: default mode is byte-identical to the pre-change body ──
+
+
+def test_default_mode_matches_full_and_verbatim_body() -> None:
+    """The default call, ``mode="full"``, and the raw body all coincide.
+
+    This is the byte-identity gate: header mode must not perturb the
+    behaviour callers already depend on.
+    """
+    stem, body = _seed_decision(7, "Adopt Redis", "Use Redis for session cache.")
+    store = _store_with((stem, body))
+
+    default = get_decision(store, 7)
+    full = get_decision(store, 7, mode="full")
+
+    assert default.content == body
+    assert full.content == body
+    assert default.model_dump(mode="json") == full.model_dump(mode="json")
+
+
+def test_result_model_shape_identical_across_modes() -> None:
+    """No discriminator field: both modes serialize to the same key set."""
+    stem, body = _seed_decision(7, "Adopt Redis", "Use Redis for session cache.")
+    store = _store_with((stem, body))
+
+    full_keys = set(get_decision(store, 7, mode="full").model_dump().keys())
+    header_keys = set(get_decision(store, 7, mode="header").model_dump().keys())
+
+    assert full_keys == header_keys == {"content", "error"}
+
+
+# ── Header projection ──
+
+
+def _full_decision(num: int, title: str, rationale: str, **kw) -> tuple[str, str]:
+    """Seed a decision with the optional triage frontmatter fields set."""
+    decision = Decision(
+        date=kw.pop("date", date(2026, 5, 28)),
+        confidence=kw.pop("confidence", DecisionConfidence.medium),
+        status=kw.pop("status", DecisionStatus.active),
+        decision_type=kw.pop("decision_type", DecisionType.api_design),
+        supersedes=kw.pop("supersedes", None),
+        superseded_by=kw.pop("superseded_by", None),
+        rejected=kw.pop("rejected", []),
+        num=num,
+        title=title,
+        rationale=rationale,
+    )
+    slug = title.lower().replace(" ", "-")
+    return f"{num:03d}-{slug}", format_decision(decision)
+
+
+def test_header_carries_triage_fields_title_and_lede() -> None:
+    stem, body = _full_decision(
+        246,
+        "Header projection mode",
+        "Return triage frontmatter, the title, and a short lede.\n\n"
+        "A second paragraph that must not reach the header.",
+        supersedes="190",
+        rejected=[RejectedAlternative(name="Discriminator field", reason="speculative surface")],
+    )
+    store = _store_with((stem, body))
+    header = get_decision(store, 246, mode="header").content
+
+    # Triage frontmatter, in canonical order.
+    assert "status: active" in header
+    assert "supersedes: 190" in header
+    assert "date: 2026-05-28" in header
+    assert "decision_type: api_design" in header
+    assert "confidence: medium" in header
+    # Title line.
+    assert "# 246 — Header projection mode" in header
+    # Lede is the first paragraph only.
+    assert "Return triage frontmatter, the title, and a short lede." in header
+    assert "second paragraph" not in header
+
+
+def test_header_excludes_rejected_alternatives_body() -> None:
+    stem, body = _full_decision(
+        12,
+        "Adopt feature flags",
+        "Gate risky changes behind flags.",
+        rejected=[
+            RejectedAlternative(
+                name="Branch-by-abstraction",
+                reason="heavier refactor than the change warrants",
+            )
+        ],
+    )
+    store = _store_with((stem, body))
+    header = get_decision(store, 12, mode="header").content
+
+    # The full body carries the rejected-alternatives section; the header must not.
+    assert "Branch-by-abstraction" in body
+    assert "Branch-by-abstraction" not in header
+    assert "Rejected Alternatives" not in header
+
+
+def test_header_omits_unset_frontmatter_fields() -> None:
+    """A decision without optional triage fields emits only what it has."""
+    stem, body = _seed_decision(3, "Minimal decision", "A one-paragraph rationale.")
+    store = _store_with((stem, body))
+    header = get_decision(store, 3, mode="header").content
+
+    assert "status: active" in header
+    assert "date:" in header
+    assert "confidence: medium" in header
+    # No supersession edges on a plain active decision.
+    assert "supersedes:" not in header
+    assert "superseded_by:" not in header
+    # _seed_decision does not set a decision_type.
+    assert "decision_type:" not in header
+
+
+def test_header_lede_truncates_at_boundary() -> None:
+    """A long first paragraph is capped to the lede budget with an ellipsis."""
+    long_para = "word " * 200  # ~1000 chars, well past the budget
+    stem, body = _full_decision(99, "Long rationale", long_para.strip())
+    store = _store_with((stem, body))
+    header = get_decision(store, 99, mode="header").content
+
+    lede = header.rsplit("\n\n", 1)[-1]
+    assert lede.endswith("…")
+    assert len(lede) <= _LEDE_MAX_CHARS
+
+
+def test_header_just_under_budget_is_not_truncated() -> None:
+    """A first paragraph exactly at the budget keeps its final character."""
+    para = "x" * _LEDE_MAX_CHARS
+    stem, body = _full_decision(100, "At budget", para)
+    store = _store_with((stem, body))
+    header = get_decision(store, 100, mode="header").content
+
+    lede = header.rsplit("\n\n", 1)[-1]
+    assert lede == para
+    assert "…" not in lede
+
+
+def test_header_empty_decision_body_omits_lede() -> None:
+    """Empty-lede guard: a supersession stub whose ``## Decision`` section
+    opens with whitespace yields frontmatter + title, with no dangling lede."""
+    # A supersession stub: status=superseded, empty rationale.
+    decision = Decision(
+        date=date(2026, 5, 5),
+        confidence=DecisionConfidence.high,
+        status=DecisionStatus.superseded,
+        superseded_by="228",
+        decision_type=DecisionType.architecture,
+        num=122,
+        title="Trust model superseded",
+        rationale="   ",
+    )
+    body = format_decision(decision)
+    store = _store_with(("122-trust-model-superseded", body))
+    header = get_decision(store, 122, mode="header").content
+
+    assert "status: superseded" in header
+    assert "superseded_by: 228" in header
+    assert header.endswith("# 122 — Trust model superseded")
+    # No trailing blank block where a lede would sit.
+    assert not header.endswith("\n")
+    assert "\n\n\n" not in header
+
+
+def test_header_not_found_returns_error() -> None:
+    """Header mode shares the miss path: an absent number errors, no content."""
+    stem, body = _seed_decision(7, "Adopt Redis", "Use Redis for session cache.")
+    store = _store_with((stem, body))
+    result = get_decision(store, 42, mode="header")
+    assert result.content is None
+    assert result.error is not None
+    assert result.error.kind == "error"
+    assert "42" in result.error.reason

--- a/packages/nauro-core/tests/test_constants.py
+++ b/packages/nauro-core/tests/test_constants.py
@@ -19,9 +19,19 @@ from nauro_core.constants import (
     VALID_CONFIDENCES,
 )
 from nauro_core.protocol import (
+    GET_DECISION_BEFORE_PROPOSING,
     PROPOSE_DECISION_OPERATIONS,
     RESOLVES_OPEN_QUESTIONS,
 )
+
+# The static instruction block already sits past the claude.ai
+# initialize.instructions truncation point (~2,023 chars), and the remote
+# server prepends a per-user project section, so the static block must
+# never GROW. This is the pre-change ceiling; the header-first hydration
+# reword holds at or below it. tools/list descriptions arrive intact even
+# when initialize.instructions is truncated, which is where the
+# header/full mode guidance also lives (on the get_decision ToolSpec).
+MCP_INSTRUCTIONS_STATIC_MAX_CHARS = 2135
 
 
 class TestLimits:
@@ -108,3 +118,24 @@ class TestMcpInstructions:
         """Relocated to the propose_decision.resolves_questions parameter
         description, same budget reason as the operations fragment."""
         assert RESOLVES_OPEN_QUESTIONS not in MCP_INSTRUCTIONS_STATIC
+
+    def test_static_block_does_not_exceed_budget_ceiling(self) -> None:
+        """Regression guard: the static block must not grow past its
+        pre-change ceiling. The header-first hydration reword holds at or
+        below it — future edits that would enlarge the block force a
+        conscious bump of the ceiling and a re-check that the remote
+        per-user section still survives truncation."""
+        assert len(MCP_INSTRUCTIONS_STATIC) <= MCP_INSTRUCTIONS_STATIC_MAX_CHARS
+
+    def test_header_first_hydration_fragment_present_and_bounded(self) -> None:
+        """The reworded hydration sentence is spliced into the static block
+        and stays compact. The leading fetch mandate must precede the
+        mode guidance so the sentence cannot read as "skip fetching"."""
+        assert GET_DECISION_BEFORE_PROPOSING in MCP_INSTRUCTIONS_STATIC
+        assert "`mode=header`" in MCP_INSTRUCTIONS_STATIC
+        assert GET_DECISION_BEFORE_PROPOSING.index("before proposing") < (
+            GET_DECISION_BEFORE_PROPOSING.index("`mode=header`")
+        )
+        # The reword must not exceed the original sentence's length, so the
+        # static block holds at or below its pre-change ceiling.
+        assert len(GET_DECISION_BEFORE_PROPOSING) <= 200

--- a/packages/nauro-core/tests/test_protocol.py
+++ b/packages/nauro-core/tests/test_protocol.py
@@ -36,8 +36,16 @@ class TestFragmentAnchors:
 
     def test_get_decision_before_proposing_says_before_proposing(self) -> None:
         assert "`get_decision`" in GET_DECISION_BEFORE_PROPOSING
+        # The fetch mandate stays the leading clause so the fragment cannot
+        # read as "you may skip fetching" — the check-before-propose gate.
         assert "before proposing" in GET_DECISION_BEFORE_PROPOSING
-        assert "supersession status" in GET_DECISION_BEFORE_PROPOSING
+        assert GET_DECISION_BEFORE_PROPOSING.index("on each before proposing") < (
+            GET_DECISION_BEFORE_PROPOSING.index("`mode=header`")
+        )
+        # Header-first selective hydration: triage on header, hydrate the
+        # ones worth reasoning about on full.
+        assert "`mode=header`" in GET_DECISION_BEFORE_PROPOSING
+        assert "`mode=full`" in GET_DECISION_BEFORE_PROPOSING
 
     def test_propose_decision_operations_names_all_three_and_metadata_rule(self) -> None:
         for op in ("add", "update", "supersede"):

--- a/packages/nauro-core/tests/test_renderers.py
+++ b/packages/nauro-core/tests/test_renderers.py
@@ -224,6 +224,46 @@ class TestRenderGetDecision:
         assert text.startswith("Error:")
         assert "Decision 999 not found" in text
 
+    def test_full_mode_default_matches_explicit_full(self):
+        body = (
+            "---\n"
+            "date: 2026-05-10\n"
+            "status: active\n"
+            "---\n"
+            "\n"
+            "# 145 — Adopt 1-hour prompt cache tier for planner\n"
+            "\n"
+            "## Decision\nFoo.\n"
+        )
+        result = {"store": "remote", "content": body}
+        assert render_get_decision(result) == render_get_decision(result, mode="full")
+
+    def test_header_mode_emits_projection_as_sole_block(self):
+        """Header mode surfaces the kernel's compact projection verbatim — no
+        second title header layered on top of the projection's own title."""
+        projection = (
+            "status: active\n"
+            "supersedes: 190\n"
+            "date: 2026-05-28\n"
+            "decision_type: api_design\n"
+            "confidence: medium\n"
+            "\n"
+            "# 246 — Header projection mode\n"
+            "\n"
+            "Triage frontmatter plus a short lede."
+        )
+        result = {"store": "remote", "content": projection}
+        text = render_get_decision(result, mode="header")
+        assert text == projection
+        # The projection's title appears exactly once (no duplicate header).
+        assert text.count("# 246 — Header projection mode") == 1
+
+    def test_header_mode_error_path(self):
+        result = {"store": "remote", "error": "Decision 999 not found"}
+        text = render_get_decision(result, mode="header")
+        assert text.startswith("Error:")
+        assert "Decision 999 not found" in text
+
 
 class TestRenderSearchDecisions:
     def test_empty_results(self):

--- a/packages/nauro/src/nauro/mcp/stdio_server.py
+++ b/packages/nauro/src/nauro/mcp/stdio_server.py
@@ -74,7 +74,9 @@ NOT_A_NAURO_REPO = (
 )
 
 
-def _wrap_with_renderer(tool_name: str, result: dict) -> CallToolResult:
+def _wrap_with_renderer(
+    tool_name: str, result: dict, renderer_kwargs: dict[str, Any] | None = None
+) -> CallToolResult:
     """Wrap a renderer-scoped read-tool result in a single ``TextContent`` block.
 
     Mirrors the remote MCP dispatcher (``mcp_server.mcp_router._build_tool_result``):
@@ -83,13 +85,17 @@ def _wrap_with_renderer(tool_name: str, result: dict) -> CallToolResult:
     tool name with no renderer mapped — falls back to a JSON dump of the
     envelope in ``content[0]`` so a presentation bug never swallows a
     response.
+
+    ``renderer_kwargs`` threads renderer-specific options (e.g.
+    ``get_decision``'s requested ``mode``) without storing them on the
+    result envelope.
     """
     json_text = json.dumps(result, indent=2, default=str)
     renderer = _RENDERERS.get(tool_name)
     if renderer is None:
         return CallToolResult(content=[TextContent(type="text", text=json_text)])
     try:
-        rendered = renderer(result)
+        rendered = renderer(result, **(renderer_kwargs or {}))
     except Exception:
         logger.exception("renderer failed for tool=%s; falling back to JSON-only", tool_name)
         return CallToolResult(content=[TextContent(type="text", text=json_text)])
@@ -198,6 +204,9 @@ def list_decisions(
 @mcp.tool(**_spec_kwargs("get_decision"))
 def get_decision(
     number: Annotated[int, Field(description=_param_desc("get_decision", "number"))],
+    mode: Annotated[
+        Literal["header", "full"], Field(description=_param_desc("get_decision", "mode"))
+    ] = "full",
     project_id: Annotated[
         str | None, Field(description=_param_desc("get_decision", "project_id"))
     ] = None,
@@ -210,8 +219,8 @@ def get_decision(
     except StoreResolutionError as exc:
         result = {"store": "local", "status": "error", "guidance": str(exc)}
     else:
-        result = tool_get_decision(store_path, number)
-    return _wrap_with_renderer("get_decision", result)
+        result = tool_get_decision(store_path, number, mode)
+    return _wrap_with_renderer("get_decision", result, {"mode": mode})
 
 
 @mcp.tool(**_spec_kwargs("diff_since_last_session"))

--- a/packages/nauro/src/nauro/mcp/tools.py
+++ b/packages/nauro/src/nauro/mcp/tools.py
@@ -607,12 +607,12 @@ def tool_list_decisions(
 
 @mcp_tool("get_decision")
 @_stamp_identity
-def tool_get_decision(store_path: Path, number: int) -> dict:
-    """Return full content of a specific decision by number."""
+def tool_get_decision(store_path: Path, number: int, mode: str = "full") -> dict:
+    """Return a specific decision by number (full body, or header projection)."""
     guidance = _check_store_exists(store_path)
     if guidance:
         return {"store": "local", "status": "error", "guidance": guidance}
-    result = _get_decision_op(FilesystemStore(store_path), number)
+    result = _get_decision_op(FilesystemStore(store_path), number, mode)
     return {"store": "local", **result.model_dump(mode="json", exclude_none=True)}
 
 

--- a/packages/nauro/tests/test_cli_autogen.py
+++ b/packages/nauro/tests/test_cli_autogen.py
@@ -202,10 +202,15 @@ class TestGetDecision:
         header = json.loads(runner.invoke(app, ["get-decision", "1", "--mode", "header"]).stdout)
         assert len(header["content"]) < len(full["content"])
 
-    def test_mode_bogus_rejected_with_exit_2(self, demo_repo) -> None:
+    def test_mode_bogus_is_rejected(self, demo_repo) -> None:
         result = runner.invoke(app, ["get-decision", "1", "--mode", "bogus"])
-        # click.Choice rejects an out-of-enum value before the adapter runs.
-        assert result.exit_code == 2
+        # An out-of-enum --mode is rejected before the adapter produces a result.
+        # The exact exit code is typer/click-version-dependent (older versions
+        # raise a usage error -> 2; typer>=0.26 / click>=8.4 reject without the
+        # usage-error code -> 1), so assert the version-stable invariant: the
+        # invocation fails and no result envelope reaches stdout.
+        assert result.exit_code != 0, result.output
+        assert '"store"' not in result.stdout
 
 
 class TestDiffSinceLastSession:

--- a/packages/nauro/tests/test_cli_autogen.py
+++ b/packages/nauro/tests/test_cli_autogen.py
@@ -176,6 +176,37 @@ class TestGetDecision:
         envelope = json.loads(result.stdout)
         assert envelope.get("error")
 
+    def test_mode_flag_advertises_header_and_full_default_full(self) -> None:
+        result = runner.invoke(app, ["get-decision", "--help"])
+        assert result.exit_code == 0, result.output
+        assert "header" in result.output
+        assert "full" in result.output
+        assert "[default: full]" in result.output
+
+    def test_mode_header_happy_path(self, demo_repo) -> None:
+        result = runner.invoke(app, ["get-decision", "1", "--mode", "header"])
+        assert result.exit_code == 0, result.output
+        envelope = json.loads(result.stdout)
+        assert envelope["store"] == "local"
+        assert "content" in envelope
+
+    def test_mode_full_matches_default(self, demo_repo) -> None:
+        default = runner.invoke(app, ["get-decision", "1"])
+        explicit_full = runner.invoke(app, ["get-decision", "1", "--mode", "full"])
+        assert default.exit_code == 0
+        assert explicit_full.exit_code == 0
+        assert default.stdout == explicit_full.stdout
+
+    def test_mode_header_envelope_is_more_compact(self, demo_repo) -> None:
+        full = json.loads(runner.invoke(app, ["get-decision", "1", "--mode", "full"]).stdout)
+        header = json.loads(runner.invoke(app, ["get-decision", "1", "--mode", "header"]).stdout)
+        assert len(header["content"]) < len(full["content"])
+
+    def test_mode_bogus_rejected_with_exit_2(self, demo_repo) -> None:
+        result = runner.invoke(app, ["get-decision", "1", "--mode", "bogus"])
+        # click.Choice rejects an out-of-enum value before the adapter runs.
+        assert result.exit_code == 2
+
 
 class TestDiffSinceLastSession:
     def test_happy_path(self, demo_repo) -> None:

--- a/packages/nauro/tests/test_get_decision_parity.py
+++ b/packages/nauro/tests/test_get_decision_parity.py
@@ -47,22 +47,22 @@ def demo_repo(tmp_path, monkeypatch):
     return pid, store_path
 
 
-def _stdio_rendered(pid: str, number: int) -> str:
+def _stdio_rendered(pid: str, number: int, mode: str = "full") -> str:
     """Return the rendered stdio surface text for the parity comparison.
 
     Renderer-scoped read tools now return a single ``content[0]`` block
     carrying the renderer output. Parity against the direct tool envelope
-    runs through ``RENDERERS["get_decision"]``.
+    runs through ``RENDERERS["get_decision"]`` with the same ``mode``.
     """
-    result = stdio_get_decision(number=number, project_id=pid)
+    result = stdio_get_decision(number=number, project_id=pid, mode=mode)
     assert len(result.content) == 1
     assert result.structuredContent is None
     return result.content[0].text
 
 
-def _tool_envelope(store_path: Path, number: int) -> dict:
+def _tool_envelope(store_path: Path, number: int, mode: str = "full") -> dict:
     """Direct call to the local tool, no transport wrapper."""
-    return tool_get_decision(store_path, number)
+    return tool_get_decision(store_path, number, mode)
 
 
 def test_stdio_and_tool_match_on_success_path(demo_repo):
@@ -90,3 +90,47 @@ def test_not_found_envelope_matches_across_surfaces(demo_repo):
     assert "content" not in tool
     assert tool["error"]["kind"] == "error"
     assert str(MISSING_NUMBER) in tool["error"]["reason"]
+
+
+# ── Backward-compat: default envelope is byte-identical, no extra key ──
+
+
+def test_default_envelope_byte_identical_to_full(demo_repo):
+    """The byte-identity gate: omitting ``mode`` equals ``mode="full"`` and
+    the envelope carries no discriminator key beyond store/content."""
+    _pid, store_path = demo_repo
+    default = _tool_envelope(store_path, EXISTING_NUMBER)
+    full = _tool_envelope(store_path, EXISTING_NUMBER, mode="full")
+    assert default == full
+    # Locked success envelope: store + content only. No "mode" key leaked.
+    assert set(default) == {"store", "content", "project"}
+
+
+# ── Header mode: parity across the stdio + tool surfaces ──
+
+
+def test_stdio_and_tool_match_on_header_mode(demo_repo):
+    pid, store_path = demo_repo
+    tool = _tool_envelope(store_path, EXISTING_NUMBER, mode="header")
+    assert _stdio_rendered(pid, EXISTING_NUMBER, mode="header") == RENDERERS["get_decision"](
+        tool, mode="header"
+    )
+
+
+def test_header_envelope_more_compact_than_full(demo_repo):
+    _pid, store_path = demo_repo
+    full = _tool_envelope(store_path, EXISTING_NUMBER, mode="full")
+    header = _tool_envelope(store_path, EXISTING_NUMBER, mode="header")
+    assert len(header["content"]) < len(full["content"])
+    # Header carries the same envelope key set — no discriminator field.
+    assert set(header) == set(full)
+
+
+def test_header_not_found_matches_full_miss_envelope(demo_repo):
+    pid, store_path = demo_repo
+    header_miss = _tool_envelope(store_path, MISSING_NUMBER, mode="header")
+    full_miss = _tool_envelope(store_path, MISSING_NUMBER, mode="full")
+    assert header_miss == full_miss
+    assert _stdio_rendered(pid, MISSING_NUMBER, mode="header") == RENDERERS["get_decision"](
+        header_miss, mode="header"
+    )


### PR DESCRIPTION
## Why

`get_decision` only ever returned full decision bodies. The check-before-propose loop tells agents to fetch every related decision a check surfaces, so those bodies dominate read-tool token cost — full bodies average ~745 tokens on the live corpus and the check→get fan-out is the common path. Agents pay full-body cost to make a keep-or-skip triage call they could make from the frontmatter and a one-paragraph lede.

## Approach

Add a `mode` parameter (`header` | `full`, default `full`) to `get_decision`. Header returns a compact projection — ordered triage frontmatter (status, supersession edges, date, type, confidence), the title, and a truncated lede from the Decision section.

The projection rides in the existing `content` field. We deliberately did **not** add a field to `GetDecisionResult` or introduce a mode discriminator: the default call stays byte-identical to the prior output, cross-store parity holds by construction, and we avoid speculative result surface. The renderer and adapters branch on the requested mode threaded through at call time, not on a result field. (Rejected: a discriminator field on the result — the renderer and caller already know what they asked for, so it would be dead surface.)

The hydration instruction is reworded to redirect agents to header-first selective fetch (triage on header, hydrate full for the ones they reason about). The fetch mandate stays the leading clause, so the check-before-propose gate is unchanged — only the granularity of how agents read the bodies changes.

## What changed

- **Kernel projection** (`operations/get_decision.py`): the `mode` parameter and the header projection, including an empty-lede guard for supersession stubs whose Decision section opens with whitespace (they project to frontmatter + title only).
- **Render + tool surface**: `render_get_decision` branches on mode; the `get_decision` ToolSpec gains the `mode` enum and a triage-vs-rationale description.
- **Instruction**: the canonical hydration fragment is reworded and spliced into its consuming surfaces. The `check_decision` tool description now splices the same canonical fragment instead of carrying a hand-written paraphrase that had drifted. Rendered distribution artifacts are regenerated from the canonical body.
- **Adapters**: the local tool adapter and the stdio server thread `mode` to the kernel and the renderer; the CLI `--mode` flag surfaces via autogen.

## What to review

- The byte-identity guarantee: `get_decision(store, n)` == `mode="full"` == prior output, and the local envelope gains no key. This is the load-bearing safety property.
- The empty-lede guard and the lede truncation boundary.
- The reworded hydration sentence against the fetch-mandate gate — the leading clause must still read as "fetch, do not skip."
- The instruction-block regression guard. The block already sits past the chat-client truncation point for the `initialize.instructions` field; the guard pins it to its pre-change ceiling so future edits cannot silently enlarge it. The reworded sentence is shorter than the one it replaces, so the block shrinks (2135 → 2119) and holds under the ceiling. The mode guidance also rides on the `get_decision` tool description, which arrives intact even when the instruction field is truncated.

## What's deferred

- The remote MCP server's `mode` passthrough is a follow-up in its own repository. Default-`full` keeps remote behavior unchanged until the mirror lands; the projection lives in the shared kernel, so the remote adapter inherits it on threading `mode`.
- Typed/structured header envelope, batch get_decision, and any embedding-backed retrieval are out of scope.

## Test plan

644 nauro-core + 1082 nauro tests pass (10 cross-store tests skip without the private store package); ruff check + format clean. New coverage: header projection (triage fields, lede, rejected-alts exclusion, truncation boundary, empty-lede guard, miss path), byte-identical default and parity across the stdio + tool surfaces, renderer header/full, the autogen `--mode` flag ({header,full}, default full, bogus → exit 2, header → exit 0, not-found → exit 1), and the instruction-block regression guard. Measured ~85% token reduction (~637 tokens/call) on the live decision corpus.
