### PR TITLE
Fix autogen enum flags to reject bad values with exit 2 + message

### DIFF
--- a/packages/nauro/src/nauro/cli/autogen.py
+++ b/packages/nauro/src/nauro/cli/autogen.py
@@ -19,12 +19,12 @@ exit 2 without ever invoking the adapter.
 
 from __future__ import annotations
 
+import enum
 import inspect
 import json
 from collections.abc import Callable
 from typing import Any
 
-import click
 import typer
 from nauro_core.mcp_tools import ALL_TOOLS, ToolSpec
 
@@ -162,6 +162,33 @@ def _required_param(name: str, prop: dict[str, Any]) -> tuple[Any, Any]:
     )
 
 
+# Generated enum types are cached per (property, values) so repeated walks
+# of ALL_TOOLS reuse one type rather than minting fresh ones. Identity churn
+# is otherwise harmless here (commands build once at import) but the cache is
+# cheap insurance.
+_ENUM_CACHE: dict[tuple[str, tuple[str, ...]], type[enum.Enum]] = {}
+
+
+def _enum_for_property(name: str, enum_values: list[str]) -> type[enum.Enum]:
+    """Build a ``str``-mixed Enum whose members carry the wire strings.
+
+    Used as the Typer annotation for an enum-valued property so Typer maps it
+    to a native Choice. A bad value then exits 2 with a choices-naming message
+    across typer/click versions, where ``click.Choice`` exits 1 without one
+    under typer>=0.26 / click>=8.4. Each member's ``.value`` is its wire
+    string, so the valid value reaches the adapter byte-identically once the
+    dispatch converts the member back to its ``.value``.
+    """
+    key = (name, tuple(enum_values))
+    cached = _ENUM_CACHE.get(key)
+    if cached is not None:
+        return cached
+    class_name = name.replace("_", " ").title().replace(" ", "") + "Choice"
+    generated = enum.Enum(class_name, {value: value for value in enum_values}, type=str)
+    _ENUM_CACHE[key] = generated
+    return generated
+
+
 def _optional_param(name: str, prop: dict[str, Any]) -> tuple[Any, Any]:
     """Return (annotation, default) for an optional schema property."""
     prop_type = prop.get("type")
@@ -171,13 +198,14 @@ def _optional_param(name: str, prop: dict[str, Any]) -> tuple[Any, Any]:
     enum_values = prop.get("enum")
 
     if prop_type == "string" and enum_values:
+        enum_type = _enum_for_property(name, list(enum_values))
+        default_member = enum_type(default_value) if default_value is not None else None
         return (
-            str,
+            enum_type,
             typer.Option(
-                default_value,
+                default_member,
                 _option_flag(name),
                 help=desc,
-                click_type=click.Choice(list(enum_values)),
             ),
         )
     if prop_type == "string":
@@ -286,6 +314,14 @@ def _make_command(spec: ToolSpec) -> Callable[..., None]:
         )
     ]
 
+    # Enum-valued properties arrive as Enum members from Typer. The adapters
+    # and kernel expect the plain wire string (str()/f-string formatting and
+    # ``DecisionConfidence(value)`` paths would otherwise see a member), so
+    # convert each set member back to its ``.value`` before dispatch.
+    enum_arg_names: list[str] = [
+        name for name in schema_arg_names if props.get(name, {}).get("enum")
+    ]
+
     def command(**kwargs: Any) -> None:
         project = kwargs.pop("project", None)
         # --json is a parity no-op; JSON is the only output mode.
@@ -300,6 +336,11 @@ def _make_command(spec: ToolSpec) -> Callable[..., None]:
             if raw is None:
                 continue
             kwargs[name] = parse_json_list_of_dicts(raw, _option_flag(name))
+
+        for name in enum_arg_names:
+            value = kwargs.get(name)
+            if isinstance(value, enum.Enum):
+                kwargs[name] = value.value
 
         adapter_kwargs = {name: kwargs[name] for name in schema_arg_names if name in kwargs}
         envelope = adapter(store_path, **adapter_kwargs)

--- a/packages/nauro/tests/test_cli_autogen.py
+++ b/packages/nauro/tests/test_cli_autogen.py
@@ -204,12 +204,10 @@ class TestGetDecision:
 
     def test_mode_bogus_is_rejected(self, demo_repo) -> None:
         result = runner.invoke(app, ["get-decision", "1", "--mode", "bogus"])
-        # An out-of-enum --mode is rejected before the adapter produces a result.
-        # The exact exit code is typer/click-version-dependent (older versions
-        # raise a usage error -> 2; typer>=0.26 / click>=8.4 reject without the
-        # usage-error code -> 1), so assert the version-stable invariant: the
-        # invocation fails and no result envelope reaches stdout.
-        assert result.exit_code != 0, result.output
+        # An out-of-enum --mode is a usage error: exit 2 with the valid choices
+        # named in the message, before the adapter produces a result.
+        assert result.exit_code == 2, result.output
+        assert "header" in result.output
         assert '"store"' not in result.stdout
 
 

--- a/packages/nauro/tests/test_write_command_autogen.py
+++ b/packages/nauro/tests/test_write_command_autogen.py
@@ -305,3 +305,22 @@ class TestFlagShapes:
         assert result.exit_code == 2
         assert "--rejected" in strip_ansi(result.output)
         assert "expected JSON array of objects" in result.output
+
+    def test_operation_bogus_exits_two_with_choices(self, seeded_repo) -> None:
+        # An out-of-enum --operation is a usage error: exit 2 with the valid
+        # choices named, before the adapter produces an envelope. Pairs with
+        # the read-tool --mode case so the enum regression can't silently
+        # return on either the read or the write autogen path.
+        result = runner.invoke(
+            app,
+            [
+                "propose-decision",
+                "Adopt Redis for hot caching",
+                "In-memory cache for the hot read paths across the API tier.",
+                "--operation",
+                "bogus",
+            ],
+        )
+        assert result.exit_code == 2, result.output
+        assert "supersede" in strip_ansi(result.output)
+        assert '"store"' not in result.stdout


### PR DESCRIPTION
## Why
The autogen enum branch annotated every generated enum flag as `str` with a `click.Choice`. Under typer>=0.26 / click>=8.4 (what CI resolves; the local pin is older), a bad enum value is rejected but exits **1 with no output** instead of the usage-error **exit 2 + a message naming the valid choices**. This regressed the whole generated CLI surface: `--level`, `--mode`, `--operation`, `--confidence`, `--decision-type`, `--reversibility`. A user typing `--mode bogs` got a bare nonzero exit and no hint.

## Approach
Generate a `str`-mixed `enum.Enum` per enum-valued ToolSpec property and use it as the Typer parameter annotation. Typer maps an Enum to a native Choice, which yields exit 2 + a choices-naming message across typer/click versions and renders a clean `[default: <value>]` in `--help`. Typer passes an Enum *member* into the callback, so the dispatch converts members back to `.value` before invoking the adapter — the wire string reaches the kernel byte-identically.

Rejected: pinning typer/click in pyproject (freezes a dep to dodge a UX bug; the regression returns on any bump) and a custom callback re-raise that keeps `click.Choice` (more code re-deriving what an Enum gives for free; the callback body never runs on a rejection, so there is no hook).

## What changed
- `cli/autogen.py`: new `_enum_for_property` helper (str-mixed Enum, cached per property+values); the `_optional_param` enum branch now returns the generated Enum annotation with a member-or-`None` default; `_make_command` converts Enum-member kwargs to `.value` at dispatch. Dropped the unused `click` import.
- Tests: tightened the read-tool bad-enum case to assert exit 2 + a named choice; added the write-tool counterpart (`--operation bogus`) so the regression can't silently return on either branch.

The `.value` conversion is load-bearing, not cosmetic: the kernel constructs enums from and string-formats the raw value, so a leaked member would corrupt the written decision.

## What to review
- The member→`.value` conversion in `_make_command` is the correctness hinge — confirm an unset optional flag (`None`) passes through untouched and a set flag reaches the adapter as the wire string.
- The two no-default flags (`decision_type`, `reversibility`) use a bare Enum annotation with `typer.Option(None, ...)`; confirm this stays optional rather than being forced required.
- Default rendering in `--help` (`[default: full]`, not `Class.member`) — verified empirically under both version sets rather than reasoned about.

## What's deferred
Non-identifier-safe enum value sanitization (no live enum needs it), the required-enum path (none exist), and the stdio `Literal` mapping (a separate surface, untouched).

## Test plan
Both autogen test files run under two version sets — the local pin and the CI-resolved typer 0.26.3 / click 8.4.1 — and the exit-2 assertions pass under both (39 tests each). Valid-value byte-identity holds (default output equals explicit valid value). Full suites: nauro 1083 passed / 10 skipped, nauro-core 644 passed. Lint clean (ruff check + format).
