### PR TITLE
fix(cli): reject empty note input; honest wording for local-only sync

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/note.py
+++ b/packages/nauro/src/nauro/cli/commands/note.py
@@ -43,6 +43,10 @@ def note(
     ),
 ) -> None:
     """Record a decision or question in the project store."""
+    if not text.strip():
+        typer.echo("Note text cannot be empty.", err=True)
+        raise typer.Exit(1)
+
     project_name, store_path = resolve_target_project(project)
     fs_store = FilesystemStore(store_path)
 

--- a/packages/nauro/src/nauro/cli/commands/sync.py
+++ b/packages/nauro/src/nauro/cli/commands/sync.py
@@ -74,7 +74,13 @@ def sync(
     pushed = _push_to_cloud(project_key, store_path)
 
     if pushed:
-        typer.echo(f"Synced {project_name} — snapshot v{version:03d}")
+        if is_cloud_project(project_key):
+            typer.echo(f"Synced {project_name} — snapshot v{version:03d}")
+        else:
+            typer.echo(
+                f"Captured snapshot v{version:03d} for {project_name}"
+                " (local-only project; nothing to upload)."
+            )
         for repo_path in updated_repos:
             typer.echo(f"  Updated AGENTS.md: {repo_path}")
     else:

--- a/packages/nauro/tests/test_cli.py
+++ b/packages/nauro/tests/test_cli.py
@@ -71,7 +71,7 @@ def test_sync_command(tmp_path: Path, monkeypatch):
 
     result = runner.invoke(app, ["sync"])
     assert result.exit_code == 0
-    assert "Synced myproj" in result.output
+    assert "local-only project; nothing to upload" in result.output
 
 
 def test_log_command(tmp_path: Path, monkeypatch):
@@ -175,7 +175,7 @@ def test_sync_with_project_flag(tmp_path: Path, monkeypatch):
 
     result = runner.invoke(app, ["sync", "--project", "myproj"])
     assert result.exit_code == 0
-    assert "Synced myproj" in result.output
+    assert "local-only project; nothing to upload" in result.output
 
 
 def test_log_with_project_flag(tmp_path: Path, monkeypatch):

--- a/packages/nauro/tests/test_note.py
+++ b/packages/nauro/tests/test_note.py
@@ -1,4 +1,4 @@
-"""Tests for nauro note auto-regen of AGENTS.md.
+"""Tests for nauro note auto-regen of AGENTS.md and input validation.
 
 `nauro note` writes a decision or question to the store and then regenerates
 AGENTS.md in every associated repo so MCP-disconnected agents see the update
@@ -117,3 +117,45 @@ def test_note_warns_about_missing_repo_paths(tmp_path: Path, monkeypatch):
     # The live repo still got its AGENTS.md refreshed.
     assert (live_repo / "AGENTS.md").exists()
     assert "Move billing to Stripe" in (live_repo / "AGENTS.md").read_text()
+
+
+def test_note_empty_string_rejects(tmp_path: Path, monkeypatch):
+    """Empty text is rejected before any store write."""
+    store = register_project("myproj", [tmp_path])
+    scaffold_project_store("myproj", store)
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["note", ""])
+    assert result.exit_code == 1
+    assert "cannot be empty" in result.output
+    decisions_dir = store / "decisions"
+    decision_files = [f for f in decisions_dir.iterdir() if f.name != "001-initial-setup.md"]
+    assert decision_files == []
+
+
+def test_note_whitespace_only_rejects(tmp_path: Path, monkeypatch):
+    """Whitespace-only text is rejected before any store write."""
+    store = register_project("myproj", [tmp_path])
+    scaffold_project_store("myproj", store)
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["note", "   "])
+    assert result.exit_code == 1
+    assert "cannot be empty" in result.output
+    decisions_dir = store / "decisions"
+    decision_files = [f for f in decisions_dir.iterdir() if f.name != "001-initial-setup.md"]
+    assert decision_files == []
+
+
+def test_note_nonempty_text_succeeds(tmp_path: Path, monkeypatch):
+    """Non-empty text records a decision — the guard does not block valid input."""
+    store = register_project("myproj", [tmp_path])
+    scaffold_project_store("myproj", store)
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["note", "Use Redis for session storage"])
+    assert result.exit_code == 0, result.output
+    decisions_dir = store / "decisions"
+    new_files = [f for f in decisions_dir.iterdir() if f.name != "001-initial-setup.md"]
+    assert len(new_files) == 1
+    assert "use-redis-for-session-storage" in new_files[0].name

--- a/packages/nauro/tests/test_store.py
+++ b/packages/nauro/tests/test_store.py
@@ -727,7 +727,7 @@ def test_sync_cli(tmp_path: Path, monkeypatch):
 
     result = runner.invoke(app, ["sync"])
     assert result.exit_code == 0
-    assert "Synced myproj" in result.output
+    assert "local-only project; nothing to upload" in result.output
     assert "v001" in result.output
 
 

--- a/packages/nauro/tests/test_sync/test_sync_command.py
+++ b/packages/nauro/tests/test_sync/test_sync_command.py
@@ -51,7 +51,7 @@ class TestSyncPullBeforePush:
         """When S3 is not configured, sync should still work (pull is a no-op)."""
         result = runner.invoke(app, ["sync"])
         assert result.exit_code == 0
-        assert "Synced testproj" in result.output
+        assert "local-only project; nothing to upload" in result.output
         # No "Pulling from remote" because sync is not configured
         assert "Pulling from remote" not in result.output
 
@@ -177,11 +177,11 @@ def _scaffolded_cloud_project(name: str, repo_path: Path):
 
 
 class TestSyncHonesty:
-    """sync() must not print 'Synced' unless an upload actually happened (or
-    none was expected). The three cases below cover the matrix:
+    """sync() must not print 'Synced' unless an actual cloud upload happened.
+    The three cases below cover the matrix:
 
     cloud-mode + disabled creds → warn on stderr, exit 1
-    local-mode + disabled creds → Synced, exit 0
+    local-mode + no creds       → honest local-only message, exit 0
     cloud-mode + enabled creds  → Synced, exit 0
     """
 
@@ -203,7 +203,8 @@ class TestSyncHonesty:
         combined = result.output + (result.stderr or "")
 
         assert result.exit_code == 0, combined
-        assert "Synced testproj" in result.output
+        assert "local-only project; nothing to upload" in result.output
+        assert "Synced testproj" not in result.output
         assert "Warning: this is a cloud-mode project" not in combined
 
     def test_cloud_project_with_token_succeeds(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## Why

Two small but observable correctness bugs in user-facing CLI output:

1. `nauro note ""` and `nauro note "   "` silently wrote a decision file with an empty title to disk and exited 0. The `propose_decision` kernel rejects empty input at Tier 1; `note` bypasses that path via the direct-disk write helper, so the guard was never reached.

2. `nauro sync` on a local-only project printed `"Synced <project> — snapshot v..."` and exited 0. That wording reads as a successful cloud upload, but nothing was uploaded because the project is local-only. Users inspecting sync output to confirm remote consistency were getting a false signal.

## Approach

Both fixes are minimal boundary guards — no new abstractions, no changes to internal data paths.

For `note`: add a strip-and-check at the very top of `note()`, before `resolve_target_project()`. Both the decision and question branches share the same code path, so a single guard covers both. The error goes to stderr and exits 1, mirroring the kernel's own Tier-1 rejection behavior.

For `sync`: in the `if pushed:` success branch, call `is_cloud_project()` (already imported in the module) and branch on the result. Local-only projects get a distinct message that names the snapshot version and states explicitly that nothing was uploaded. Cloud projects with a successful push keep the existing "Synced" wording. The cloud-without-token error path (exit 1) is untouched. The alternative considered for `sync` was making local-only sync exit nonzero, but a local snapshot and AGENTS.md regeneration is a legitimate success — the problem was the misleading wording, not the exit code.

## What changed

- **`note.py`**: a guard at the top of `note()` rejects empty/whitespace input before any store access.
- **`sync.py`**: the `if pushed:` branch now checks `is_cloud_project()` and emits different output depending on whether an upload actually occurred.
- **Tests**: new tests in `test_note.py` cover empty-string rejection, whitespace-only rejection, and the happy-path regression. Existing tests in `test_sync_command.py`, `test_cli.py`, and `test_store.py` that asserted `"Synced ..."` for local-only projects are updated to assert the new honest wording.

## What to review

- `sync.py` success branch: the `is_cloud_project()` call is inside `if pushed:`, which is only reached when `_push_to_cloud()` returns `True`. For a local-only project that always returns `True` (it never contacts the network), so the new wording fires; a real cloud push has `is_cloud_project()` true and still prints "Synced". Confirm that reasoning holds.
- `note.py`: the guard runs before `resolve_target_project()`, so empty input now reports "cannot be empty" rather than a project-not-found error when both conditions hold. This ordering (validate input before side effects) is intentional.

## What's deferred

Nothing. Both fixes are self-contained.

## Test plan

- `uv run ruff format packages/ && uv run ruff check packages/` — 214 files unchanged, all checks passed.
- `uv run pytest packages/nauro/tests/ -x -q` — 1086 passed, 10 skipped.
- New coverage: empty-string rejection (exit 1, no file), whitespace-only rejection (exit 1, no file), non-empty happy path (exit 0, file created), plus updated assertions confirming local-only sync no longer claims "Synced".
