### PR TITLE
docs(onboarding): README/PRIVACY accuracy and consent default handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ nauro init my-project
 nauro setup claude-code   # or: nauro setup all
 ```
 
-`nauro init` writes `.nauro/config.json` into the repo; commit it. For cloud sync from the start: `nauro init --cloud my-project`.
+`nauro init` writes `.nauro/config.json` into the repo; commit it. For cloud sync from the start, run `nauro auth login` first, then `nauro init --cloud my-project`.
 
 **Existing repo with docs to seed from:**
 
@@ -66,9 +66,9 @@ Codex users: add `mcp_oauth_callback_port = 8765` to the top of `~/.codex/config
 
 ## MCP tools
 
-11 tools (8 read, 3 write):
+11 tools total (8 read, 3 write). The local stdio server registers 10 (7 read, 3 write); `list_projects` is remote-only.
 
-**Read:** `check_decision`, `get_context`, `list_decisions`, `get_decision`, `search_decisions`, `get_raw_file`, `diff_since_last_session`, `list_projects`.
+**Read:** `check_decision`, `get_context`, `list_decisions`, `get_decision`, `search_decisions`, `get_raw_file`, `diff_since_last_session`, `list_projects` *(remote-only)*.
 
 **Write:** `propose_decision`, `flag_question`, `update_state`.
 

--- a/packages/nauro/PRIVACY.md
+++ b/packages/nauro/PRIVACY.md
@@ -4,7 +4,7 @@ Last updated: 2026-05-10
 
 ## Cloud sync
 
-Project context (decisions, state, open questions — not source code) is stored encrypted in AWS S3 (us-east-1, SSE-S3). Each user's data is isolated under a unique prefix derived from their authentication identity. You can delete all your data at any time with `nauro account delete`.
+Project context (decisions, state, open questions — not source code) is stored encrypted in AWS S3 (us-east-1, SSE-S3). Each user's data is isolated under a unique prefix derived from their authentication identity. There is no self-service deletion command at this time; contact support to request removal of your cloud data.
 
 ## Remote MCP
 
@@ -12,7 +12,7 @@ When connected to Claude AI, Perplexity, ChatGPT, or another MCP client, your pr
 
 ## Telemetry
 
-Nauro collects anonymous product-usage telemetry to understand which commands are used, where users get stuck, and whether the tool is healthy. Telemetry is **default opt-in** via a one-line first-run prompt that points back to this document. (The prompt itself ships in a follow-up release; until then, no events are sent.)
+Nauro collects anonymous product-usage telemetry to understand which commands are used, where users get stuck, and whether the tool is healthy. Telemetry is **default opt-in** via a one-line first-run prompt that points back to this document.
 
 ### Events
 
@@ -42,8 +42,8 @@ project.created       { schema_version }
 
 ### Opting out
 
-- `NAURO_TELEMETRY=0` environment variable — works today, suppresses all telemetry and the first-run prompt.
-- `nauro telemetry disable` — coming in Phase 1, persists the choice in `~/.nauro/config.json`.
+- `NAURO_TELEMETRY=0` environment variable — suppresses all telemetry and the first-run prompt.
+- `nauro telemetry disable` — persists the opt-out in `~/.nauro/config.json`.
 
 ### Vendor
 

--- a/packages/nauro/src/nauro/telemetry/consent.py
+++ b/packages/nauro/src/nauro/telemetry/consent.py
@@ -38,10 +38,7 @@ def _parse_answer(raw: str, default_yes: bool) -> bool:
         return True
     if answer in ("n", "no"):
         return False
-    if answer == "":
-        return default_yes
-    # Unknown input → opposite of default per the behavior matrix.
-    return not default_yes
+    return default_yes
 
 
 def maybe_prompt() -> None:
@@ -72,3 +69,4 @@ def maybe_prompt() -> None:
     raw = input(f"{PROMPT_TEXT} {suffix} ")
     enabled = _parse_answer(raw, default_yes)
     _persist(enabled)
+    print("Telemetry enabled." if enabled else "Telemetry disabled.")

--- a/packages/nauro/tests/test_consent_prompt.py
+++ b/packages/nauro/tests/test_consent_prompt.py
@@ -217,3 +217,66 @@ def test_already_consented_at_current_version_does_not_re_prompt(nauro_home, mon
     assert section["enabled"] is True
     assert section["consent_version"] == 1
     assert section["consented_at"] == "2026-04-30T00:00:00Z"
+
+
+def test_unrecognized_input_applies_stated_default_yes(nauro_home, monkeypatch, capsys):
+    """An unrecognized keystroke must apply the stated default, not its opposite."""
+    monkeypatch.delenv("NAURO_TELEMETRY", raising=False)
+    _set_tty(monkeypatch, True)
+    _set_input(monkeypatch, "??")  # not y/n/yes/no/empty
+
+    from nauro.telemetry.consent import maybe_prompt
+
+    maybe_prompt()
+
+    section = _read_telemetry(nauro_home)
+    assert section["enabled"] is True  # default_yes=True on first run
+    assert section["consent_version"] == 1
+    out = capsys.readouterr().out
+    assert "Telemetry enabled." in out
+
+
+def test_unrecognized_input_applies_stated_default_no(nauro_home, monkeypatch, capsys):
+    """When the default is no (previous opt-out), unrecognized input must preserve it."""
+    monkeypatch.delenv("NAURO_TELEMETRY", raising=False)
+    _seed(nauro_home, enabled=False, consent_version=1)
+    _set_tty(monkeypatch, True)
+    _set_input(monkeypatch, "??")
+
+    import nauro.telemetry.consent as consent_mod
+
+    monkeypatch.setattr(consent_mod, "TELEMETRY_CONSENT_VERSION", 2)
+
+    consent_mod.maybe_prompt()
+
+    section = _read_telemetry(nauro_home)
+    assert section["enabled"] is False  # default_yes=False (previous opt-out)
+    assert section["consent_version"] == 2
+    out = capsys.readouterr().out
+    assert "Telemetry disabled." in out
+
+
+def test_explicit_yes_echoes_enabled(nauro_home, monkeypatch, capsys):
+    monkeypatch.delenv("NAURO_TELEMETRY", raising=False)
+    _set_tty(monkeypatch, True)
+    _set_input(monkeypatch, "y")
+
+    from nauro.telemetry.consent import maybe_prompt
+
+    maybe_prompt()
+
+    out = capsys.readouterr().out
+    assert "Telemetry enabled." in out
+
+
+def test_explicit_no_echoes_disabled(nauro_home, monkeypatch, capsys):
+    monkeypatch.delenv("NAURO_TELEMETRY", raising=False)
+    _set_tty(monkeypatch, True)
+    _set_input(monkeypatch, "n")
+
+    from nauro.telemetry.consent import maybe_prompt
+
+    maybe_prompt()
+
+    out = capsys.readouterr().out
+    assert "Telemetry disabled." in out


### PR DESCRIPTION
## Why

Four accuracy bugs in onboarding docs and the first-run consent flow were making the public-facing experience misleading or subtly broken:

1. The README's New-project section showed `nauro init --cloud my-project` without noting that `nauro auth login` is a prerequisite. A fresh-machine user following only that section would hit an auth error on `POST /projects`.
2. The README's MCP tools section listed `list_projects` among the read tools with no indication it is unavailable on the local stdio server, and the tool count was accurate only for the full remote set — not the local server most users interact with first.
3. `PRIVACY.md` referenced `nauro account delete` (a command that does not exist) and described already-shipped features in future tense.
4. In `consent.py`, `_parse_answer` returned the opposite of the stated default for any unrecognised keystroke, silently recording the wrong choice, and never echoed the outcome.

## Approach

All four are minimal targeted fixes — no refactor, no new abstractions. Fix 1 adds an inline prerequisite note where `--cloud` is introduced rather than reordering the whole section. Fix 2 clarifies local vs. remote counts and adds an inline `(remote-only)` annotation. Fix 3 removes the phantom command, states plainly that no self-service deletion exists yet (it does not invent one), and corrects tense. Fix 4 collapses the unrecognised-input branch to return the stated default and prints the chosen outcome after persisting.

## What changed

- **README.md:** `--cloud` prerequisite note; MCP tools section count and `list_projects` annotation.
- **packages/nauro/PRIVACY.md:** phantom `nauro account delete` replaced with an honest statement; stale future-tense corrected.
- **packages/nauro/src/nauro/telemetry/consent.py:** `_parse_answer` unrecognised input now falls through to the stated default; the prompt echoes the chosen outcome.
- **Tests:** new consent tests covering unrecognised input (both default-yes and default-no) and the echo for explicit yes/no.

## What to review

- `_parse_answer`: empty → default, unrecognised → default, explicit y/yes → True, explicit n/no → False (explicit answers are not flipped). The echo prints the value actually persisted.
- PRIVACY data-deletion wording is intentionally non-committal — no deletion mechanism exists in the code today.

## What's deferred

Telemetry consent is collected and persisted, but events cannot currently transmit because no analytics key ships in the distribution. That is a separate product decision and is not addressed here. Surfacing a real self-service account-deletion command is likewise out of scope.

## Test plan

- New consent tests: unrecognised input applies the stated default (opt-in and opt-out paths); explicit `y` echoes "Telemetry enabled."; explicit `n` echoes "Telemetry disabled."
- `uv run pytest packages/nauro/tests/ -x -q` — 1087 passed, 10 skipped (1083 existing + 4 new).
- `ruff format` / `ruff check`: 214 files unchanged, all checks passed.
