### PR TITLE
fix(init): protect registry integrity and add projects list/rm

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/init.py
+++ b/packages/nauro/src/nauro/cli/commands/init.py
@@ -33,6 +33,7 @@ from nauro.store.registry import (
     find_projects_by_name_v2,
     get_store_path_v2,
     register_project_v2,
+    resolve_v2_from_path,
 )
 from nauro.store.repo_config import (
     RepoConfigSchemaError,
@@ -103,6 +104,104 @@ def _check_config_overwrite(
     raise typer.Exit(code=1)
 
 
+def _refuse_if_repo_already_claimed(rp: Path) -> None:
+    """Refuse to mint a new project for a repo an existing project already claims.
+
+    A repo path resolves to at most one project. If ``rp`` already walks up to
+    a registered project, minting a second id here would shadow that
+    association and leave a duplicate registry entry the user never intended.
+    Aborts via :class:`typer.Exit` naming the safe recovery paths.
+    """
+    resolved = resolve_v2_from_path(rp)
+    if resolved is None:
+        return
+    existing_id, entry = resolved
+    existing_name = entry.get("name", "<unnamed>")
+    typer.echo(
+        f"Repo {rp.resolve()} is already part of project "
+        f"{existing_name!r} (id: {existing_id}).\n"
+        "Refusing to register a second project for the same repo.\n"
+        "\n"
+        "Options:\n"
+        f"  - Add this repo to the existing project: "
+        f"nauro init {existing_name!r} --add-repo {rp.resolve()}\n"
+        f"  - Remove the existing registry entry: nauro projects rm {existing_id}\n"
+        "  - Promote a local project to cloud: nauro link",
+        err=True,
+    )
+    raise typer.Exit(code=1)
+
+
+def _init_demo(name: str, repo_paths: list[Path], force: bool) -> None:
+    """Initialize (or reuse) the bundled demo project.
+
+    Demo init has its own idempotency contract that the generic new-project
+    flow does not: a single shared demo entry is reused rather than
+    duplicated, and the cwd-config overwrite message is demo-specific.
+    """
+    from nauro.demo import create_demo_project
+
+    # Demo-specific overwrite guard: when the cwd already carries a config and
+    # --force is absent, surface a reset-oriented message instead of the
+    # generic --add-repo recovery line. Only the cwd (first/only path) gets the
+    # demo-config; --demo does not take --add-repo, so repo_paths is [cwd].
+    for rp in repo_paths:
+        config_file = repo_config_path(rp)
+        if config_file.is_file() and not force:
+            typer.echo(
+                f"Demo already initialized here ({rp.resolve()}).\n"
+                "Re-run with --force to reset it.",
+                err=True,
+            )
+            raise typer.Exit(code=1)
+
+    # Reuse an existing demo entry rather than minting a duplicate.
+    existing = find_projects_by_name_v2(name)
+    if existing:
+        pid, _entry = existing[0]
+        store_path = get_store_path_v2(pid)
+        typer.echo(f"Demo project already exists ({pid}); reusing it.")
+    else:
+        # No pre-existing demo entry: refuse if any target repo is already
+        # claimed by a *different* project before minting a new id.
+        for rp in repo_paths:
+            _refuse_if_repo_already_claimed(rp)
+        pid, store_path = register_project_v2(
+            name,
+            repo_paths,
+            mode=REPO_CONFIG_MODE_LOCAL,
+        )
+        capture("project.created", project_created(REGISTRY_SCHEMA_VERSION_V2))
+
+    for rp in repo_paths:
+        save_repo_config(
+            rp,
+            {
+                "mode": REPO_CONFIG_MODE_LOCAL,
+                "id": pid,
+                "name": name,
+            },
+        )
+
+    create_demo_project(store_path)
+    cwd_is_git = (Path.cwd() / ".git").is_dir()
+
+    typer.echo(f"Initialized demo project '{name}'")
+    typer.echo(f"  Project id: {pid}")
+    typer.echo(f"  Store: {store_path}")
+    for rp in repo_paths:
+        typer.echo(f"  Repo:  {rp.resolve()}")
+    typer.echo("  Includes: 7 decisions, project state, open questions, and a snapshot")
+    typer.echo(f"  Wrote .nauro/config.json into {Path.cwd()}")
+    if cwd_is_git:
+        typer.echo(
+            "  Warning: this directory is a git repo; the demo config will steer "
+            "its resolution to the demo doctrine.",
+            err=True,
+        )
+    typer.echo("  Next: run 'nauro check-decision \"<approach>\"' to try a conflict check")
+
+
 _Opt_add_repo_paths = typer.Option(
     None,
     "--add-repo",
@@ -127,9 +226,9 @@ def init(
         False,
         "--force",
         help=(
-            "Overwrite an existing .nauro/config.json in the target repo. "
-            "Without this flag init refuses to replace a config pointing at "
-            "a different project."
+            "Overwrite the .nauro/config.json in the current directory only. "
+            "Without this flag init refuses to replace a config pointing at a "
+            "different project. This does not replace the project itself."
         ),
     ),
 ) -> None:
@@ -197,6 +296,14 @@ def init(
                 typer.echo(f"  Added repo: {rp}")
             return
 
+    # ── --demo ───────────────────────────────────────────────────────────────
+    # Handled before the generic new-project flow because demo has its own
+    # idempotency rules: a single shared 'demo-project' entry is reused rather
+    # than duplicated, and the cwd-config overwrite message is demo-specific.
+    if demo:
+        _init_demo(name, repo_paths, force)
+        return
+
     # ── New project: cloud or local ────────────────────────────────────────
     # Pre-check every target repo before allocating a new id. For a fresh
     # init we have no pid to compare against; any existing config is treated
@@ -207,6 +314,12 @@ def init(
     # existing project association.
     for rp in repo_paths:
         _check_config_overwrite(rp, None, name, force)
+
+    # Refuse to mint a second entry for a repo a project already claims. A
+    # repo's identity is single-valued; minting a new id would shadow the
+    # existing association and leave a duplicate the user never intended.
+    for rp in repo_paths:
+        _refuse_if_repo_already_claimed(rp)
 
     if cloud:
         try:
@@ -242,7 +355,8 @@ def init(
         typer.echo(f"  Store: {store_path}")
         for rp in repo_paths:
             typer.echo(f"  Repo:  {rp.resolve()}")
-        typer.echo("  Next: run 'nauro sync' to capture the first snapshot")
+        typer.echo("  Next: run 'nauro setup claude-code' to connect your agent")
+        typer.echo("  Then: run 'nauro sync' to capture the first snapshot")
         return
 
     # ── Local-only ─────────────────────────────────────────────────────────
@@ -266,19 +380,11 @@ def init(
             },
         )
 
-    if demo:
-        from nauro.demo import create_demo_project
-
-        create_demo_project(store_path)
-        typer.echo(f"Initialized demo project '{name}'")
-        typer.echo(f"  Project id: {pid}")
-        typer.echo(f"  Store: {store_path}")
-        typer.echo("  Includes: 7 decisions, project state, open questions, and a snapshot")
-    else:
-        scaffold_project_store(name, store_path)
-        typer.echo(f"Initialized project '{name}'")
-        typer.echo(f"  Project id: {pid}")
-        typer.echo(f"  Store: {store_path}")
-        for rp in repo_paths:
-            typer.echo(f"  Repo:  {rp.resolve()}")
-        typer.echo("  Next: run 'nauro sync' to capture the first snapshot")
+    scaffold_project_store(name, store_path)
+    typer.echo(f"Initialized project '{name}'")
+    typer.echo(f"  Project id: {pid}")
+    typer.echo(f"  Store: {store_path}")
+    for rp in repo_paths:
+        typer.echo(f"  Repo:  {rp.resolve()}")
+    typer.echo("  Next: run 'nauro setup claude-code' to connect your agent")
+    typer.echo("  Then: run 'nauro sync' to capture the first snapshot")

--- a/packages/nauro/src/nauro/cli/commands/projects.py
+++ b/packages/nauro/src/nauro/cli/commands/projects.py
@@ -1,0 +1,81 @@
+"""nauro projects — inspect and recover registry entries.
+
+``nauro projects`` (or ``nauro projects list``) prints every v2 registry
+entry: project_id, name, mode, and associated repo paths.
+
+``nauro projects rm <project_id>`` removes a single registry entry. It does
+NOT delete the on-disk store directory — decision history under
+``~/.nauro/projects/<id>/`` survives so a mistaken removal is recoverable.
+This is the documented recovery path when ``nauro init`` refuses to mint a
+second entry for a repo that is already claimed.
+"""
+
+from __future__ import annotations
+
+import typer
+
+from nauro.store.registry import (
+    get_store_path_v2,
+    load_registry_v2,
+    remove_project_v2,
+)
+
+projects_app = typer.Typer(help="Inspect and recover Nauro project registry entries.")
+
+
+def _print_project_list() -> None:
+    registry = load_registry_v2()
+    entries = registry["projects"]
+    if not entries:
+        typer.echo("No projects registered.")
+        return
+    for pid, entry in entries.items():
+        name = entry.get("name", "<unnamed>")
+        mode = entry.get("mode", "<unknown>")
+        repo_paths = entry.get("repo_paths", [])
+        typer.echo(f"{pid}")
+        typer.echo(f"  Name: {name}")
+        typer.echo(f"  Mode: {mode}")
+        if repo_paths:
+            for rp in repo_paths:
+                typer.echo(f"  Repo: {rp}")
+        else:
+            typer.echo("  Repo: (none)")
+
+
+@projects_app.callback(invoke_without_command=True)
+def projects_main(ctx: typer.Context) -> None:
+    """List registered projects when no subcommand is given."""
+    if ctx.invoked_subcommand is None:
+        _print_project_list()
+
+
+@projects_app.command(name="list")
+def list_projects() -> None:
+    """List every registered project: id, name, mode, and repo paths."""
+    _print_project_list()
+
+
+@projects_app.command(name="rm")
+def remove_project(
+    project_id: str = typer.Argument(..., help="Project id (ULID) to remove."),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        help="Skip the confirmation prompt.",
+    ),
+) -> None:
+    """Remove a project's registry entry, leaving its on-disk store intact."""
+    store_path = get_store_path_v2(project_id)
+    if not yes:
+        typer.confirm(
+            f"Remove registry entry for {project_id}? "
+            f"The store at {store_path} will be left intact.",
+            abort=True,
+        )
+    removed = remove_project_v2(project_id)
+    if not removed:
+        typer.echo(f"No project registered with id {project_id!r}.", err=True)
+        raise typer.Exit(code=1)
+    typer.echo(f"Removed registry entry for {project_id}.")
+    typer.echo(f"  Store left intact: {store_path}")

--- a/packages/nauro/src/nauro/cli/main.py
+++ b/packages/nauro/src/nauro/cli/main.py
@@ -58,6 +58,7 @@ def _register_commands() -> None:
         link,
         log,
         note,
+        projects,
         questions,
         render_plugin,
         serve,
@@ -73,6 +74,7 @@ def _register_commands() -> None:
     app.command(name="attach")(attach.attach)
     app.command(name="link")(link.link)
     app.command(name="note")(note.note)
+    app.add_typer(projects.projects_app, name="projects")
     app.add_typer(questions.questions_app, name="questions")
     app.add_typer(hook.hook_app, name="hook")
     app.command(name="sync")(sync.sync)

--- a/packages/nauro/src/nauro/store/registry.py
+++ b/packages/nauro/src/nauro/store/registry.py
@@ -329,6 +329,38 @@ def remove_repo(project_name: str, repo_path_str: str) -> bool:
 
 _VALID_MODES_V2 = (REPO_CONFIG_MODE_LOCAL, REPO_CONFIG_MODE_CLOUD)
 
+_MAX_PROJECT_NAME_LEN = 100
+
+
+def _validate_project_name(name: str) -> str:
+    """Validate a v2 project name and return its stripped form.
+
+    Rejects names that would corrupt the registry or escape the store
+    directory layout. The store path is derived from the project_id (a
+    ULID), not the name, but the name is persisted to ``registry.json`` and
+    surfaced in repo configs and AGENTS.md, so it must stay printable and
+    free of path-traversal substrings.
+
+    Raises:
+        ValueError: If the stripped name is empty, longer than 100 chars,
+            contains a path separator (``/`` or ``\\``) or the ``..``
+            substring, or contains a non-printable character.
+    """
+    name = name.strip()
+    if not name:
+        raise ValueError("Project name cannot be empty.")
+    if len(name) > _MAX_PROJECT_NAME_LEN:
+        raise ValueError(
+            f"Project name is too long ({len(name)} chars); keep it under {_MAX_PROJECT_NAME_LEN}."
+        )
+    if "/" in name or "\\" in name or ".." in name:
+        raise ValueError(f"Invalid project name {name!r}: must not contain '/', '\\', or '..'.")
+    if any(not ch.isprintable() for ch in name):
+        raise ValueError(
+            f"Invalid project name {name!r}: must not contain non-printable characters."
+        )
+    return name
+
 
 def get_store_path_v2(project_id: str) -> Path:
     """Return the id-keyed store directory for a v2 project."""
@@ -421,9 +453,10 @@ def register_project_v2(
         Tuple of (project_id, store_path).
 
     Raises:
-        ValueError: If mode/server_url combination is invalid, or if the
-            project_id is already present in the registry.
+        ValueError: If the name is invalid, the mode/server_url combination
+            is invalid, or the project_id is already present in the registry.
     """
+    name = _validate_project_name(name)
     if mode not in _VALID_MODES_V2:
         raise ValueError(f"Invalid mode {mode!r}; expected one of {_VALID_MODES_V2}.")
     if mode == REPO_CONFIG_MODE_CLOUD and not server_url:
@@ -465,6 +498,26 @@ def add_repo_v2(project_id: str, repo_path: Path) -> None:
         if resolved not in paths:
             paths.append(resolved)
         save_registry_v2(registry)
+
+
+def remove_project_v2(project_id: str) -> bool:
+    """Remove a v2 project's registry entry. Leaves the on-disk store intact.
+
+    The store directory under ``~/.nauro/projects/<id>/`` is deliberately
+    preserved so a mistaken removal does not destroy decision history; the
+    caller is responsible for surfacing where that data still lives.
+
+    Returns:
+        True if an entry with ``project_id`` existed and was removed, False
+        if no such entry was present.
+    """
+    with _registry_lock():
+        registry = load_registry_v2()
+        if project_id not in registry["projects"]:
+            return False
+        registry["projects"].pop(project_id)
+        save_registry_v2(registry)
+    return True
 
 
 def rename_project_id_v2(

--- a/packages/nauro/tests/test_init_demo_and_next_steps.py
+++ b/packages/nauro/tests/test_init_demo_and_next_steps.py
@@ -1,0 +1,103 @@
+"""Tests for `nauro init --demo` behavior and the post-init next-step guidance.
+
+* --demo prints the Repo: line, a cwd-config note, and a git-repo warning
+  when the cwd is a git repo (and not otherwise).
+* --demo reuses a single shared demo entry instead of duplicating it.
+* The plain-init next-step points at `nauro setup`; --demo points at
+  `nauro check-decision`.
+* A repeat --demo in the same dir surfaces a reset-oriented message and not
+  the generic --add-repo recovery line.
+
+CWD and NAURO_HOME are isolated to tmp_path by autouse conftest fixtures.
+"""
+
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from nauro.cli.main import app
+from nauro.store import registry
+
+runner = CliRunner()
+
+
+# ── demo inside a real repo ─────────────────────────────────────────────────────
+
+
+def test_demo_in_git_repo_warns(tmp_path, monkeypatch):
+    """Inside a git repo, --demo names the repo, the cwd config, and warns."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".git").mkdir()
+
+    result = runner.invoke(app, ["init", "--demo"])
+    assert result.exit_code == 0, result.output
+    assert "Repo:" in result.output
+    assert str(tmp_path.resolve()) in result.output
+    assert ".nauro/config.json" in result.output
+    assert "git repo" in result.output
+
+
+def test_demo_in_non_git_dir_does_not_warn(tmp_path, monkeypatch):
+    """Outside a git repo, the steering warning does not fire."""
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["init", "--demo"])
+    assert result.exit_code == 0, result.output
+    assert "git repo" not in result.output
+
+
+# ── demo entry reuse ─────────────────────────────────────────────────────────────
+
+
+def test_demo_reused_across_dirs(tmp_path, monkeypatch):
+    """Two --demo runs in fresh dirs leave exactly one demo entry."""
+    dir_a = tmp_path / "a"
+    dir_a.mkdir()
+    dir_b = tmp_path / "b"
+    dir_b.mkdir()
+
+    monkeypatch.chdir(dir_a)
+    first = runner.invoke(app, ["init", "--demo"])
+    assert first.exit_code == 0, first.output
+
+    monkeypatch.chdir(dir_b)
+    second = runner.invoke(app, ["init", "--demo"])
+    assert second.exit_code == 0, second.output
+    assert "reusing it" in second.output
+
+    assert len(registry.find_projects_by_name_v2("demo-project")) == 1
+
+
+# ── next-step guidance ───────────────────────────────────────────────────────────
+
+
+def test_plain_init_next_step_points_at_setup(tmp_path, monkeypatch):
+    """Plain init guides the user to `nauro setup` next."""
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["init", "plainproj"])
+    assert result.exit_code == 0, result.output
+    assert "setup" in result.output
+
+
+def test_demo_next_step_points_at_check_decision(tmp_path, monkeypatch):
+    """--demo guides the user to try `nauro check-decision`."""
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["init", "--demo"])
+    assert result.exit_code == 0, result.output
+    assert "check-decision" in result.output
+
+
+# ── repeat-demo reset message ────────────────────────────────────────────────────
+
+
+def test_repeat_demo_same_dir_offers_reset_not_add_repo(tmp_path, monkeypatch):
+    """A second --demo in the same dir says to reset, never --add-repo."""
+    monkeypatch.chdir(tmp_path)
+    first = runner.invoke(app, ["init", "--demo"])
+    assert first.exit_code == 0, first.output
+
+    second = runner.invoke(app, ["init", "--demo"])
+    assert second.exit_code == 1, second.output
+    assert "Demo already initialized" in second.output
+    assert "--force to reset" in second.output
+    assert "--add-repo" not in second.output

--- a/packages/nauro/tests/test_init_registry_integrity.py
+++ b/packages/nauro/tests/test_init_registry_integrity.py
@@ -1,0 +1,101 @@
+"""Registry data-integrity tests for `nauro init`.
+
+* init refuses to mint a second registry entry for a repo an existing
+  project already claims (the duplicate-entry footgun), even under --force.
+* register_project_v2 validates the project name before any registry write,
+  so garbage names never leak a half-written entry.
+
+CWD and NAURO_HOME are both isolated to tmp_path by autouse conftest
+fixtures; tests that need a specific cwd override on the same monkeypatch.
+"""
+
+from __future__ import annotations
+
+import pytest
+from typer.testing import CliRunner
+
+from nauro.cli.main import app
+from nauro.store import registry
+from nauro.store.registry import find_projects_by_name_v2, register_project_v2
+
+runner = CliRunner()
+
+
+# ── duplicate-claim refusal ────────────────────────────────────────────────────
+
+
+def test_init_force_refuses_already_claimed_repo(tmp_path, monkeypatch):
+    """`init projF` → note → `init projF --force` must not mint a second entry.
+
+    --force bypasses the cwd-config overwrite guard, but the repo is still
+    claimed by the first projF; re-initializing would shadow that association
+    with a duplicate registry entry. The refusal is independent of --force and
+    exits 1. The earlier decision must survive in the original store.
+    """
+    monkeypatch.chdir(tmp_path)
+
+    first = runner.invoke(app, ["init", "projF"])
+    assert first.exit_code == 0, first.output
+
+    matches = find_projects_by_name_v2("projF")
+    assert len(matches) == 1
+    pid, _entry = matches[0]
+
+    note_res = runner.invoke(app, ["note", "Chose X for Y reasons"])
+    assert note_res.exit_code == 0, note_res.output
+    decisions_dir = tmp_path / "projects" / pid / "decisions"
+    seeded = sorted(decisions_dir.glob("*.md"))
+    assert seeded, "the note should have written a decision file"
+
+    forced = runner.invoke(app, ["init", "projF", "--force"])
+    assert forced.exit_code == 1, forced.output
+
+    # Still exactly one projF entry; the decision survived untouched.
+    assert len(find_projects_by_name_v2("projF")) == 1
+    assert sorted((tmp_path / "projects" / pid / "decisions").glob("*.md")) == seeded
+
+
+# ── project-name validation ────────────────────────────────────────────────────
+
+# Names the locked validation rules reject: empty / whitespace-only,
+# over-length, path separators, the '..' traversal substring, or a
+# non-printable character. A single-leading-dot name (".hidden") is NOT in
+# this set — the store path is ULID-keyed, so a leading dot is not a
+# traversal risk and the locked rule does not enumerate it. ".dotdot.." below
+# stands in for the dot-prefixed traversal case the rules do catch.
+_INVALID_NAMES = [
+    "",
+    "   ",
+    "x" * 300,
+    "../escape",
+    "foo/bar",
+    ".dotdot..",
+    "ctrl\x07char",
+]
+
+
+@pytest.mark.parametrize("bad_name", _INVALID_NAMES)
+def test_init_rejects_invalid_name_without_leaking_entry(bad_name, tmp_path, monkeypatch):
+    """Invalid names exit 1 and leave no registry entry behind."""
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["init", bad_name])
+    assert result.exit_code == 1, result.output
+    assert find_projects_by_name_v2(bad_name) == []
+    assert find_projects_by_name_v2(bad_name.strip()) == []
+
+
+def test_init_accepts_valid_name(tmp_path, monkeypatch):
+    """A valid name still registers and exits 0."""
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["init", "valid-name_1"])
+    assert result.exit_code == 0, result.output
+    assert len(find_projects_by_name_v2("valid-name_1")) == 1
+
+
+@pytest.mark.parametrize("bad_name", _INVALID_NAMES)
+def test_register_project_v2_raises_on_invalid_name(bad_name, tmp_path, monkeypatch):
+    """register_project_v2 raises ValueError before touching the registry."""
+    with pytest.raises(ValueError):
+        register_project_v2(bad_name, [tmp_path])
+    # No entry leaked even on the raising path.
+    assert registry.load_registry_v2()["projects"] == {}

--- a/packages/nauro/tests/test_projects_cmd.py
+++ b/packages/nauro/tests/test_projects_cmd.py
@@ -1,0 +1,74 @@
+"""Tests for the `nauro projects` command (list + rm).
+
+`nauro projects` lists every registry entry. `nauro projects rm <id>` removes
+a single entry behind a confirmation prompt (skipped with --yes) and leaves
+the on-disk store directory intact — the documented recovery path when init
+refuses to reuse an already-claimed repo.
+
+CWD and NAURO_HOME are isolated to tmp_path by autouse conftest fixtures.
+"""
+
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from nauro.cli.main import app
+from nauro.store import registry
+from nauro.store.registry import get_store_path_v2, register_project_v2
+
+runner = CliRunner()
+
+
+def _seed_two_projects(tmp_path):
+    """Register two local projects with distinct repo dirs; return their ids."""
+    repo_a = tmp_path / "repo_a"
+    repo_a.mkdir()
+    repo_b = tmp_path / "repo_b"
+    repo_b.mkdir()
+    pid_a, _ = register_project_v2("proj-a", [repo_a])
+    pid_b, _ = register_project_v2("proj-b", [repo_b])
+    return pid_a, pid_b
+
+
+def test_projects_lists_all_entries(tmp_path, monkeypatch):
+    """`nauro projects` prints every id and name; exit 0."""
+    pid_a, pid_b = _seed_two_projects(tmp_path)
+    result = runner.invoke(app, ["projects"])
+    assert result.exit_code == 0, result.output
+    assert pid_a in result.output
+    assert pid_b in result.output
+    assert "proj-a" in result.output
+    assert "proj-b" in result.output
+
+
+def test_projects_rm_removes_entry_leaves_store(tmp_path, monkeypatch):
+    """`rm <id> --yes` drops the entry, leaves the store, prints its path."""
+    pid_a, pid_b = _seed_two_projects(tmp_path)
+    store_path = get_store_path_v2(pid_a)
+    assert store_path.is_dir()
+
+    result = runner.invoke(app, ["projects", "rm", pid_a, "--yes"])
+    assert result.exit_code == 0, result.output
+    assert str(store_path) in result.output
+
+    # Entry gone, store intact, other project untouched.
+    assert registry.get_project_v2(pid_a) is None
+    assert store_path.is_dir()
+    assert registry.get_project_v2(pid_b) is not None
+
+
+def test_projects_rm_missing_id_exits_1(tmp_path, monkeypatch):
+    """`rm <missing-id>` exits 1 with a clear message."""
+    _seed_two_projects(tmp_path)
+    result = runner.invoke(app, ["projects", "rm", "01KMISSING00000000000000000", "--yes"])
+    assert result.exit_code == 1, result.output
+    assert "No project registered" in result.output
+
+
+def test_projects_rm_declined_confirm_keeps_entry(tmp_path, monkeypatch):
+    """Declining the confirmation prompt leaves the entry in place."""
+    pid_a, _pid_b = _seed_two_projects(tmp_path)
+    result = runner.invoke(app, ["projects", "rm", pid_a], input="n\n")
+    # typer.confirm(abort=True) raises Abort → exit 1 on decline.
+    assert result.exit_code == 1, result.output
+    assert registry.get_project_v2(pid_a) is not None

--- a/packages/nauro/tests/test_registry.py
+++ b/packages/nauro/tests/test_registry.py
@@ -242,17 +242,21 @@ def test_init_cli_refuses_overwrite_without_force(tmp_path, monkeypatch):
     assert cfg["name"] == "first"
 
 
-def test_init_cli_force_overwrites(tmp_path, monkeypatch):
-    """--force replaces an existing .nauro/config.json with the new
-    project's handle; the registry shows both."""
+def test_init_cli_force_does_not_duplicate_claimed_repo(tmp_path, monkeypatch):
+    """--force overwrites only the cwd config — it does not mint a second
+    registry entry for a repo an existing project already claims.
+
+    --force bypasses the config-overwrite guard, but the repo remains claimed
+    by 'first'; minting a 'second' entry for the same repo would shadow that
+    association. init refuses (exit 1) and 'second' never enters the registry.
+    """
     monkeypatch.chdir(tmp_path)
-    runner.invoke(app, ["init", "first"])
+    first = runner.invoke(app, ["init", "first"])
+    assert first.exit_code == 0, first.output
     result = runner.invoke(app, ["init", "second", "--force"])
-    assert result.exit_code == 0
-    cfg = load_repo_config(tmp_path)
-    assert cfg["name"] == "second"
+    assert result.exit_code == 1, result.output
     assert len(registry.find_projects_by_name_v2("first")) == 1
-    assert len(registry.find_projects_by_name_v2("second")) == 1
+    assert registry.find_projects_by_name_v2("second") == []
 
 
 def test_init_cli_add_repo_idempotent_on_same_id(tmp_path, monkeypatch):


### PR DESCRIPTION
## Why

`nauro init` could silently corrupt the project registry, and there was no way to recover:

- A garbage project name (empty, path-traversal, control chars) was written to the registry *before* any validation, leaving a half-formed orphan entry.
- Re-running `nauro init <name>` from a directory a project already claimed minted a *second* registry entry for the same repo. The two entries then resolved differently (repo-config walk → the new store, path walk → the old one), silently detaching the original project's decisions — and the recovery the tool itself suggested (`--force`) made it worse, since `--force` only ever bypassed the cwd-config overwrite guard, not the registry.
- The only way to fix a duplicate or orphaned entry was hand-editing `~/.nauro/registry.json`.
- `nauro init --demo` duplicated the sample project on every run, wrote its config into the cwd with no warning (hijacking a real repo's resolution if run there), and pointed users at the wrong next step.

## Approach

Validation lives at the single v2 write chokepoint (`register_project_v2`), so every caller is protected and invalid input raises before any disk write — `init` already maps `ValueError` to exit 1. Name validation uses plain string ops, per the codebase's no-regex convention.

For the duplicate-repo case, the refusal is deliberately **independent of `--force`**: `--force` was always scoped to overwriting the cwd `.nauro/config.json`, never to replacing a project, so letting it mint a duplicate entry was the actual bug. Two alternatives were rejected: teaching `--force` to de-register the old entry and mint a new one (a silent data-loss path on a flag documented as "overwrite config"), and reusing the existing project id in place (ambiguous when the supplied name differs from the existing entry). Refusing with named recovery paths is the narrowest fix that closes the split-brain.

Recovery is a new read/remove command pair rather than auto-deletion: `nauro projects rm` removes only the registry entry and leaves the on-disk store, so a mistaken removal never destroys decision history.

## What changed

- **registry.py** — project-name validation (plain string ops) at the v2 registration chokepoint; a `remove_project_v2` helper that pops one entry under the registry lock and leaves the store dir.
- **init.py** — refuses to register a new project for a repo an existing project already claims, naming the safe recovery paths (`--add-repo`, `projects rm`, `link`); `--force` reworded to config-overwrite only. `--demo` reuses a single shared demo entry, prints the repo/cwd-config lines, warns when run inside a git repo, and gives a reset-oriented message on repeat. Post-init guidance points at `nauro setup` first, then `sync`; `--demo` points at a conflict check.
- **projects.py (new) + main.py** — `nauro projects` (list) and `nauro projects rm <id>` (confirmation-gated, `--yes` to skip, store left intact), wired into the CLI.

## What to review

- The duplicate-claim refusal fires only on the fresh-creation path — re-init via `--add-repo` for the same project, and first-time init of an unclaimed repo, are unaffected (`resolve_v2_from_path` id-comparison).
- `_init_demo` ordering: a second `--demo` in a *new* dir reuses the entry; a second `--demo` in the *same* dir hits the reset message.
- Project-name validation deliberately allows a single leading dot (e.g. `.hidden`) — the ULID-keyed store means the name never forms a path, so there's no traversal risk; `..`, separators, and non-printables are rejected.

## What's deferred

`projects rm` does not delete the on-disk store directory (by design — decisions stay recoverable); a `--purge` flag could be added later if needed. Demo reuse writes the new dir's per-repo config but does not append it to the entry's `repo_paths` — per-repo config is the resolution source of truth, so this is sufficient.

## Test plan

Colocated CliRunner tests isolating both `HOME` and `NAURO_HOME`, asserting exact exit codes: name validation (parametrized invalid + valid + a direct `ValueError` unit test), the duplicate-claim refusal with decision-survival, demo reuse/messaging/git-warning, next-step guidance, and `projects` list/rm (including missing-id and declined-confirm). One existing test that encoded the old force-duplicates-entry behavior was updated to the new refusal contract.

- `uv run ruff format --check packages/ && uv run ruff check packages/` — clean.
- `uv run pytest packages/nauro/tests/ -x -q` — 1123 passed, 10 skipped.
- `uv run pytest packages/nauro-core/tests/ -x -q` — 644 passed.
