### PR TITLE
fix(mcp): trim instructions static block under client truncation limit

### DIFF
--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro-core"
-version = "0.13.2"
+version = "0.13.3"
 description = "Shared pure-Python logic for Nauro: parsing, validation, context assembly, constants."
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/nauro-core/src/nauro_core/constants.py
+++ b/packages/nauro-core/src/nauro_core/constants.py
@@ -98,10 +98,14 @@ MAX_APPROACH_LENGTH = 5_000
 # push back / vendor swap) stays inline. The PROPOSE_DECISION_OPERATIONS and
 # RESOLVES_OPEN_QUESTIONS fragments are deliberately omitted here — they are
 # bound to the `propose_decision` ToolSpec parameter descriptions instead,
-# where the agent reads them at the moment of use, and keeping them out of
-# the static block trims the budget so the per-user project section the
-# remote server prepends survives client-side truncation of the
-# `initialize.instructions` field.
+# where the agent reads them at the moment of use. For the same budget reason
+# the `update_state` "meaningful unit of work" guidance and the `get_context`
+# "do not call list_decisions afterward" nuance are omitted here too — they
+# live on the matching ToolSpec descriptions in mcp_tools.py, which the client
+# delivers intact via tools/list even when initialize.instructions is
+# truncated. Keeping all four out of the static block trims the budget so the
+# per-user project section the remote server prepends survives client-side
+# truncation of the `initialize.instructions` field.
 # MCP_INSTRUCTIONS remains as a backward-compatible alias.
 MCP_INSTRUCTIONS_STATIC = (
     "Nauro carries this project's doctrine across every agent session. "
@@ -135,15 +139,7 @@ MCP_INSTRUCTIONS_STATIC = (
     "## When to get context\n"
     "\n"
     "Call `get_context` at the start of a session or when you need to "
-    "understand the project's current state, goals, and constraints. "
-    "L0 includes the last 10 decisions — do not call `list_decisions` "
-    "after `get_context` unless you need older or superseded decisions.\n"
-    "\n"
-    "## When to update state\n"
-    "\n"
-    "Call `update_state` when you complete a meaningful unit of work — "
-    "a feature, a refactor, a bug fix — so the next session starts with "
-    "current context."
+    "understand the project's current state, goals, and constraints."
 )
 
 MCP_INSTRUCTIONS = MCP_INSTRUCTIONS_STATIC

--- a/packages/nauro-core/tests/test_constants.py
+++ b/packages/nauro-core/tests/test_constants.py
@@ -8,6 +8,7 @@ from nauro_core.constants import (
     L0_QUESTIONS_LIMIT,
     L1_DECISIONS_LIMIT,
     L1_DECISIONS_SUMMARY_LIMIT,
+    MCP_INSTRUCTIONS,
     MCP_INSTRUCTIONS_STATIC,
     MIN_RATIONALE_LENGTH,
     OPEN_QUESTIONS_MD,
@@ -18,20 +19,24 @@ from nauro_core.constants import (
     STATE_MD,
     VALID_CONFIDENCES,
 )
+from nauro_core.instructions import build_remote_instructions
 from nauro_core.protocol import (
     GET_DECISION_BEFORE_PROPOSING,
     PROPOSE_DECISION_OPERATIONS,
     RESOLVES_OPEN_QUESTIONS,
 )
 
-# The static instruction block already sits past the claude.ai
-# initialize.instructions truncation point (~2,023 chars), and the remote
-# server prepends a per-user project section, so the static block must
-# never GROW. This is the pre-change ceiling; the header-first hydration
-# reword holds at or below it. tools/list descriptions arrive intact even
-# when initialize.instructions is truncated, which is where the
-# header/full mode guidance also lives (on the get_decision ToolSpec).
-MCP_INSTRUCTIONS_STATIC_MAX_CHARS = 2135
+# The static instruction block must stay under the claude.ai
+# initialize.instructions truncation point (~2,023 chars) with room for the
+# per-user project section the remote server prepends. Trimming the trailing
+# update-state and get-context-followup guidance — now carried on the
+# matching ToolSpec descriptions, which tools/list delivers intact — brought
+# the block back under the cliff. This is the post-trim ceiling: modest
+# headroom above the current length so future growth past the cliff forces a
+# conscious bump and a re-check that the composed remote payload still keeps
+# every section header under the truncation point.
+MCP_INSTRUCTIONS_TRUNCATION_LIMIT = 2023
+MCP_INSTRUCTIONS_STATIC_MAX_CHARS = 1891
 
 
 class TestLimits:
@@ -121,11 +126,38 @@ class TestMcpInstructions:
 
     def test_static_block_does_not_exceed_budget_ceiling(self) -> None:
         """Regression guard: the static block must not grow past its
-        pre-change ceiling. The header-first hydration reword holds at or
-        below it — future edits that would enlarge the block force a
+        post-trim ceiling. Future edits that would enlarge the block force a
         conscious bump of the ceiling and a re-check that the remote
         per-user section still survives truncation."""
         assert len(MCP_INSTRUCTIONS_STATIC) <= MCP_INSTRUCTIONS_STATIC_MAX_CHARS
+
+    def test_budget_ceiling_under_truncation_limit(self) -> None:
+        """The ceiling itself must stay under the claude.ai cliff so the
+        static block always leaves headroom for the prepended per-user
+        project section. A bump that pushed the ceiling past the cliff would
+        re-introduce the truncation that drops trailing sections."""
+        assert MCP_INSTRUCTIONS_STATIC_MAX_CHARS < MCP_INSTRUCTIONS_TRUNCATION_LIMIT
+
+    def test_update_state_section_not_in_static(self) -> None:
+        """The 'When to update state' section was trimmed from the static
+        block; its canonical home is the update_state ToolSpec description,
+        which tools/list delivers intact past the truncation point."""
+        assert "## When to update state" not in MCP_INSTRUCTIONS_STATIC
+
+    def test_list_decisions_followup_nuance_not_in_static(self) -> None:
+        """The 'do not call list_decisions after get_context' nuance was the
+        truncation-risk tail of the get-context section; it now lives on the
+        get_context ToolSpec description instead of the static block."""
+        assert "list_decisions" not in MCP_INSTRUCTIONS_STATIC
+
+    def test_local_and_remote_share_static_tail(self) -> None:
+        """The local stdio server delivers MCP_INSTRUCTIONS verbatim; the
+        remote server composes MCP_INSTRUCTIONS_STATIC into a per-user
+        payload. Both draw from the same static tail, so the two surfaces
+        cannot silently drift. The alias pins that single source."""
+        assert MCP_INSTRUCTIONS == MCP_INSTRUCTIONS_STATIC
+        remote = build_remote_instructions(MCP_INSTRUCTIONS_STATIC, [])
+        assert remote.endswith(MCP_INSTRUCTIONS)
 
     def test_header_first_hydration_fragment_present_and_bounded(self) -> None:
         """The reworded hydration sentence is spliced into the static block

--- a/packages/nauro-core/tests/test_mcp_tools.py
+++ b/packages/nauro-core/tests/test_mcp_tools.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from nauro_core.constants import MCP_INSTRUCTIONS_STATIC
 from nauro_core.instructions import (
     MAX_INLINE_PROJECTS,
     WELCOME_NO_PROJECT,
@@ -269,3 +270,61 @@ class TestBuildRemoteInstructions:
         projects = [{"project_id": "01ID00000000000000000000A1", "name": "x"}]
         result = build_remote_instructions(STATIC, projects)
         assert STATIC in result
+
+
+# The claude.ai client truncates the MCP initialize.instructions field at
+# roughly this many characters; tools/list descriptions arrive intact even
+# when it is truncated, which is why per-tool guidance is the durable home.
+INSTRUCTIONS_TRUNCATION_LIMIT = 2023
+
+# Representative multi-project inputs that stress the prepended per-user
+# section the way real callers do (long names, full ULIDs).
+THREE_PROJECTS = [
+    {"project_id": "01KQ6AZGNA0B3QBF67NBXP3S45", "name": "nauro"},
+    {"project_id": "01KREWKMPDW2EVR66F9XXNERGB", "name": "throwaway-supersede-1778616226"},
+    {"project_id": "01KRVJWEPXJHTC7ZZNHVAR0PV5", "name": "valid-empty-1779042236"},
+]
+ONE_PROJECT = [{"project_id": "01KQ6AZGNA0B3QBF67NBXP3S45", "name": "nauro"}]
+
+SECTION_HEADERS = (
+    "## When to check decisions",
+    "## When to propose decisions",
+    "## When to get context",
+)
+
+
+class TestInstructionsSurviveTruncation:
+    """The real static block, composed with a per-user project section, must
+    keep every section header before the client-side truncation point so no
+    load-bearing guidance silently falls off the chat surface."""
+
+    @pytest.mark.parametrize("projects", [ONE_PROJECT, THREE_PROJECTS])
+    def test_every_section_header_before_truncation(self, projects):
+        result = build_remote_instructions(MCP_INSTRUCTIONS_STATIC, projects)
+        for header in SECTION_HEADERS:
+            offset = result.find(header)
+            assert offset != -1, f"{header} missing from composed instructions"
+            assert offset < INSTRUCTIONS_TRUNCATION_LIMIT, (
+                f"{header} falls at offset {offset}, past the "
+                f"{INSTRUCTIONS_TRUNCATION_LIMIT}-char truncation point"
+            )
+
+
+class TestTrimmedGuidanceCanonicalHome:
+    """Guidance trimmed from the static block must remain reachable on the
+    matching ToolSpec descriptions, which tools/list delivers intact."""
+
+    def test_update_state_description_carries_completion_guidance(self):
+        """The 'When to update state' static section was trimmed; the
+        update_state ToolSpec description is its canonical home."""
+        desc = get_tool_spec("update_state")["description"]
+        assert "meaningful unit of work" in desc
+        assert "next session starts with current context" in desc
+
+    def test_get_context_description_carries_list_decisions_nuance(self):
+        """The 'do not call list_decisions after get_context' nuance was the
+        truncation-risk tail of the static get-context section; the
+        get_context ToolSpec description is its canonical home."""
+        desc = get_tool_spec("get_context")["description"]
+        assert "list_decisions" in desc
+        assert "after get_context" in desc


### PR DESCRIPTION
## Why

The MCP `initialize.instructions` field is truncated by the claude.ai client at roughly 2,023 characters. `MCP_INSTRUCTIONS_STATIC` had grown to 2,119 characters on its own, and the remote server prepends a per-user project section on top of it via `build_remote_instructions()`. That pushed the trailing `## When to update state` section and the tail of `## When to get context` past the cutoff, so chat-surface users never saw that guidance. The local stdio server delivers the same constant, so the budget is a shared constraint.

## Approach

Trim both trailing fragments from the static block rather than restructure delivery. The canonical home for each already lives on a ToolSpec `description`, which `tools/list` delivers intact even when `initialize.instructions` is truncated: the "meaningful unit of work / next session starts with current context" guidance on `update_state`, and the "do not call `list_decisions` after `get_context`" nuance on `get_context`. Both sit well under the established per-description headroom, so no edit to those descriptions was needed — only tests pinning them as the canonical home. This mirrors the prior relocation of the `propose_decision` operation fragments off the static block.

An alternative — moving the static block after the per-user section so the prepend can't push it past the cliff — was not taken: the per-user project IDs are the load-bearing payload and must come first, which is exactly why the static tail is the part that gets cut.

## What changed

- `nauro-core/constants.py`: removed the `## When to update state` section and the `list_decisions`-followup clause from `## When to get context`; the block drops from 2,119 to 1,811 chars. Updated the adjacent comment to record where the trimmed guidance now lives.
- `nauro-core` version bumped to `0.13.3` so the fix is publish-ready.
- Tests: ratcheted the regression ceiling from 2,135 to 1,891 with a new guard that the ceiling itself stays under the truncation limit; added removal guards, a composed-payload guard that every remaining section header lands before the cutoff for 1- and 3-project users, canonical-home assertions on the two ToolSpec descriptions, and a local/remote consistency check that both surfaces draw from the same static tail.

## What to review

- The two trimmed fragments are genuinely redundant with the ToolSpec descriptions — confirm no load-bearing nuance was lost rather than relocated.
- The composed-offset guard uses representative multi-project inputs (long names + full ULIDs) to stress the prepend; the 3-project case is the heaviest, with the last header at offset 1,920.
- The new ceiling (1,891) is the trimmed length + 80 — modest headroom that forces a conscious bump if the block grows back toward the cliff.

## What's deferred

This PR fixes the local stdio server immediately (it consumes the constant directly). Reaching the claude.ai chat surface requires a separate cross-repo rollout: publish `nauro-core` 0.13.3 to PyPI (tag-triggered), then a separate PR in the private mcp-server repo to bump its `nauro-core` pin and regenerate `src/requirements.txt`, followed by a Lambda redeploy. That sequencing is intentionally out of scope here.

## Test plan

- `uv run ruff format --check packages/` and `uv run ruff check packages/` — both clean.
- `uv run pytest packages/nauro-core/tests/ -x -q` — 652 passed.
- `uv run pytest packages/nauro/tests/ -x -q` — 1137 passed, 10 skipped.
- All existing static-block content guards pass unchanged; the local stdio suite asserts nothing about the removed text.
