### PR TITLE
feat(link): push store to cloud during link --cloud

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/link.py
+++ b/packages/nauro/src/nauro/cli/commands/link.py
@@ -30,6 +30,7 @@ from nauro.store.repo_config import (
     save_repo_config,
 )
 from nauro.sync.cloud_projects import CloudProjectError, create_project
+from nauro.sync.push import push_changed_files
 
 
 def link(
@@ -123,3 +124,24 @@ def link(
     typer.echo(f"  Old id: {local_id}")
     typer.echo(f"  New id: {cloud_id}")
     typer.echo(f"  Store:  {new_store}")
+
+    # The re-key above is the irreversible promotion step and has already
+    # persisted. Pushing the store is best-effort: a transient presign/S3
+    # failure must not roll back the promotion, so we warn and exit 0 and
+    # let the user retry the upload with 'nauro sync'.
+    import httpx
+
+    from nauro.cli.commands.auth import AuthRefreshError
+    from nauro.sync.remote import PresignError
+
+    try:
+        pushed = push_changed_files(cloud_id, new_store)
+    except (AuthRefreshError, PresignError, httpx.HTTPError) as exc:
+        typer.echo(
+            f"  Warning: linked, but the initial cloud push failed ({exc}).\n"
+            "  Run 'nauro sync' to upload the project store.",
+            err=True,
+        )
+        return
+
+    typer.echo(f"  Pushed {pushed} file(s) to cloud")

--- a/packages/nauro/src/nauro/cli/commands/sync.py
+++ b/packages/nauro/src/nauro/cli/commands/sync.py
@@ -15,9 +15,14 @@ from nauro.store.registry import (
 )
 from nauro.store.snapshot import capture_snapshot
 from nauro.store.validator import print_warnings, validate_store
+from nauro.sync.push import push_store_to_cloud
 from nauro.templates.agents_md import regenerate_agents_md_for_project
 
 logger = logging.getLogger("nauro.sync")
+
+# Names retained for callers/tests that import the push helper from this
+# command module; the implementation now lives in ``nauro.sync.push``.
+_push_to_cloud = push_store_to_cloud
 
 
 def _registry_repo_paths(project_key: str) -> list[str]:
@@ -235,98 +240,6 @@ def _pull_via_presign(project_id: str, store_path: Path) -> int:
         typer.echo("  No remote changes")
 
     return merged
-
-
-def _push_to_cloud(project_id: str, store_path: Path) -> bool:
-    """Push store changes after a local sync.
-
-    Cloud-mode projects with a token → presign push. Cloud-mode without
-    a token → warn and return False (caller surfaces exit 1). Anything
-    else (v1, v2-local) → True since nothing was expected to upload.
-    """
-    if not is_cloud_project(project_id):
-        return True
-    if not load_access_token():
-        typer.echo(
-            "  Warning: this is a cloud-mode project but you're not authenticated.\n"
-            "  Your local snapshot is captured, but nothing was uploaded.\n"
-            "  Run 'nauro auth login' to configure credentials.",
-            err=True,
-        )
-        return False
-    return _push_via_presign(project_id, store_path)
-
-
-def _push_via_presign(project_id: str, store_path: Path) -> bool:
-    """POST /sync/presign for changed files → S3 PUTs."""
-    from nauro.cli.commands.auth import AuthRefreshError
-    from nauro.sync.merge import should_skip
-    from nauro.sync.remote import (
-        PresignError,
-        put_via_presigned_url,
-        request_presigned_urls,
-    )
-    from nauro.sync.state import compute_sha256, load_state, save_state, update_file_state
-
-    state = load_state(store_path)
-
-    changed: list[tuple[str, str, Path]] = []
-    for local_file in store_path.rglob("*"):
-        if not local_file.is_file():
-            continue
-        try:
-            rel = str(local_file.relative_to(store_path))
-        except ValueError:
-            continue
-        if should_skip(rel) or rel.startswith(".conflict-backup") or rel.startswith("__pycache__"):
-            continue
-
-        local_sha = compute_sha256(local_file)
-        fs = state.files.get(rel)
-        if fs is None or fs.local_sha256 != local_sha:
-            changed.append((rel, local_sha, local_file))
-
-    if not changed:
-        save_state(store_path, state)
-        return True
-
-    operations = [{"verb": "PUT", "path": rel} for rel, _sha, _path in changed]
-    try:
-        urls = request_presigned_urls(project_id, operations)
-    except AuthRefreshError as exc:
-        typer.echo(f"  {exc}", err=True)
-        return False
-    except PresignError as exc:
-        logger.exception("Failed to request presigned PUT URLs")
-        typer.echo(f"  Warning: presign request failed ({exc})", err=True)
-        return False
-
-    if len(urls) < len(operations):
-        logger.warning("Presign returned %d URLs for %d ops", len(urls), len(operations))
-
-    url_by_path = {
-        entry["path"]: entry["url"]
-        for entry in urls
-        if isinstance(entry, dict) and entry.get("verb") == "PUT"
-    }
-
-    pushed = 0
-    for rel, local_sha, local_file in changed:
-        url = url_by_path.get(rel)
-        if not url:
-            continue
-        try:
-            new_etag = put_via_presigned_url(url, local_file)
-            if new_etag:
-                update_file_state(state, rel, local_sha, new_etag)
-                pushed += 1
-        except PresignError:
-            logger.exception("Failed to push %s", rel)
-
-    save_state(store_path, state)
-    if pushed:
-        typer.echo(f"  Pushed {pushed} file(s) to S3")
-    return True
 
 
 def _show_status(project_flag: str | None) -> None:

--- a/packages/nauro/src/nauro/sync/push.py
+++ b/packages/nauro/src/nauro/sync/push.py
@@ -1,0 +1,136 @@
+"""Store → cloud push over the presign transport.
+
+Shared by ``nauro sync`` (push half of pull-then-push) and ``nauro link
+--cloud`` (the first push after promoting a local project). Both callers
+scan the store for files whose local sha differs from sync-state, mint
+presigned PUT URLs, and upload directly to S3.
+
+The push is token-gated and offline-tolerant: a project that is not
+cloud-mode, or a cloud-mode project without a token, never reaches the
+network here.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import typer
+
+from nauro.cli.commands.auth import load_access_token
+from nauro.store.registry import is_cloud_project
+
+logger = logging.getLogger("nauro.sync")
+
+
+def push_store_to_cloud(project_id: str, store_path: Path) -> bool:
+    """Push store changes after a local sync.
+
+    Cloud-mode projects with a token → presign push. Cloud-mode without
+    a token → warn and return False (caller surfaces exit 1). Anything
+    else (v1, v2-local) → True since nothing was expected to upload.
+
+    A presign/auth-refresh failure during the push is reported and maps
+    to False; per-file PUT failures are logged and skipped.
+    """
+    from nauro.cli.commands.auth import AuthRefreshError
+    from nauro.sync.remote import PresignError
+
+    if not is_cloud_project(project_id):
+        return True
+    if not load_access_token():
+        typer.echo(
+            "  Warning: this is a cloud-mode project but you're not authenticated.\n"
+            "  Your local snapshot is captured, but nothing was uploaded.\n"
+            "  Run 'nauro auth login' to configure credentials.",
+            err=True,
+        )
+        return False
+
+    try:
+        pushed = push_changed_files(project_id, store_path)
+    except AuthRefreshError as exc:
+        typer.echo(f"  {exc}", err=True)
+        return False
+    except PresignError as exc:
+        logger.exception("Failed to request presigned PUT URLs")
+        typer.echo(f"  Warning: presign request failed ({exc})", err=True)
+        return False
+
+    if pushed:
+        typer.echo(f"  Pushed {pushed} file(s) to S3")
+    return True
+
+
+def push_changed_files(project_id: str, store_path: Path) -> int:
+    """Upload every store file whose local sha differs from sync-state.
+
+    POSTs ``/sync/presign`` for the changed paths, then PUTs each one to
+    its presigned URL, recording the returned ETag in sync-state. Returns
+    the number of files successfully pushed.
+
+    Raises :class:`~nauro.cli.commands.auth.AuthRefreshError` or
+    :class:`~nauro.sync.remote.PresignError` if minting the presigned
+    URLs fails; per-file PUT failures are logged and skipped so a partial
+    upload still records the files that did land.
+    """
+    from nauro.sync.merge import should_skip
+    from nauro.sync.remote import (
+        PresignError,
+        put_via_presigned_url,
+        request_presigned_urls,
+    )
+    from nauro.sync.state import compute_sha256, load_state, save_state, update_file_state
+
+    state = load_state(store_path)
+
+    changed: list[tuple[str, str, Path]] = []
+    for local_file in store_path.rglob("*"):
+        if not local_file.is_file():
+            continue
+        try:
+            rel = str(local_file.relative_to(store_path))
+        except ValueError:
+            continue
+        if should_skip(rel) or rel.startswith(".conflict-backup") or rel.startswith("__pycache__"):
+            continue
+
+        local_sha = compute_sha256(local_file)
+        fs = state.files.get(rel)
+        if fs is None or fs.local_sha256 != local_sha:
+            changed.append((rel, local_sha, local_file))
+
+    if not changed:
+        save_state(store_path, state)
+        return 0
+
+    operations = [{"verb": "PUT", "path": rel} for rel, _sha, _path in changed]
+    urls = request_presigned_urls(project_id, operations)
+
+    if len(urls) < len(operations):
+        logger.warning("Presign returned %d URLs for %d ops", len(urls), len(operations))
+
+    url_by_path = {
+        entry["path"]: entry["url"]
+        for entry in urls
+        if isinstance(entry, dict) and entry.get("verb") == "PUT"
+    }
+
+    pushed = 0
+    for rel, local_sha, local_file in changed:
+        url = url_by_path.get(rel)
+        if not url:
+            continue
+        try:
+            new_etag = put_via_presigned_url(url, local_file)
+            if new_etag:
+                update_file_state(state, rel, local_sha, new_etag)
+                pushed += 1
+        except PresignError:
+            logger.exception("Failed to push %s", rel)
+
+    save_state(store_path, state)
+    return pushed
+
+
+__all__ = ["push_changed_files", "push_store_to_cloud"]

--- a/packages/nauro/tests/test_link_cloud.py
+++ b/packages/nauro/tests/test_link_cloud.py
@@ -1,16 +1,22 @@
 """Tests for `nauro link --cloud`.
 
-Three paths to cover:
+``link --cloud`` mints a cloud project, re-keys the local store to it, then
+performs the first cloud push in the same invocation so promotion is one
+command rather than link-then-sync.
 
-1. Happy path: local-mode repo gets re-keyed to a server-minted ULID.
-   The store directory is renamed and the registry entry is moved.
-2. Already-cloud repo: nothing to link → clear error, no-op.
-3. No-config repo: not a nauro repo → clear error.
+Paths covered:
+
+1. Happy path: local-mode repo is re-keyed to a server-minted ULID and the
+   store is pushed to the cloud within the single invocation.
+2. Push-failure resilience: a transient presign/upload error warns and exits
+   0 with the re-key intact — the irreversible promotion is never rolled back.
+3. Already-cloud repo: nothing to link → clear error, no-op.
+4. No-config repo: not a nauro repo → clear error.
 """
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import httpx
 from typer.testing import CliRunner
@@ -19,7 +25,7 @@ from nauro.cli.main import app
 from nauro.store import registry
 from nauro.store.config import save_config
 from nauro.store.repo_config import load_repo_config, save_repo_config
-from nauro.sync import cloud_projects
+from nauro.sync import cloud_projects, remote
 
 runner = CliRunner()
 
@@ -27,6 +33,7 @@ CLOUD_PID = "01KQ6AZGNA0B3QBF67NBXP3S45"
 
 
 def _seed_token(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
     save_config(
         {
             "auth": {"access_token": "test-token", "sub": "auth0|test"},
@@ -50,13 +57,39 @@ def _create_response(name: str = "linkproj", project_id: str = CLOUD_PID):
     return handler
 
 
-def test_link_cloud_promotes_local_project(tmp_path, monkeypatch):
-    """The store dir is moved to the cloud id and the registry entry re-keyed."""
+def _presign_post(url, **kwargs):
+    """Mint a presigned PUT URL per requested operation."""
+    operations = kwargs["json"]["operations"]
+    return httpx.Response(
+        200,
+        json={
+            "urls": [
+                {
+                    "verb": op["verb"],
+                    "path": op["path"],
+                    "url": f"https://s3.example/PUT/{op['path']}",
+                    "expires_at": "2026-05-29T13:00:00Z",
+                }
+                for op in operations
+            ]
+        },
+        request=httpx.Request("POST", url),
+    )
+
+
+def _ok_put():
+    put_response = MagicMock(spec=httpx.Response)
+    put_response.status_code = 200
+    put_response.headers = {"ETag": '"e_pushed"'}
+    return put_response
+
+
+def test_link_cloud_promotes_and_pushes_in_one_command(tmp_path, monkeypatch):
+    """The store is re-keyed to the cloud id AND pushed within one invocation."""
     _seed_token(monkeypatch, tmp_path)
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("NAURO_API_URL", "https://example.test")
 
-    # Stand up a local project from scratch
     init_result = runner.invoke(app, ["init", "linkproj"])
     assert init_result.exit_code == 0, init_result.output
 
@@ -68,11 +101,19 @@ def test_link_cloud_promotes_local_project(tmp_path, monkeypatch):
 
     # Mark the store with a sentinel so we can prove the rename moved its contents
     sentinel = local_store / "decisions" / "999-sentinel.md"
-    sentinel.write_text("# 999 — sentinel\n")
+    sentinel.write_text("# 999 sentinel\n")
 
-    with patch.object(cloud_projects.httpx, "request", side_effect=_create_response()):
+    with (
+        patch.object(cloud_projects.httpx, "request", side_effect=_create_response()),
+        patch.object(remote.httpx, "post", side_effect=_presign_post),
+        patch.object(remote.httpx, "put", return_value=_ok_put()) as mock_put,
+    ):
         result = runner.invoke(app, ["link", "--cloud"])
     assert result.exit_code == 0, result.output
+
+    # The push ran inside this single invocation: store files were PUT to S3.
+    assert mock_put.call_count > 0
+    assert "Pushed" in result.output
 
     new_store = tmp_path / "projects" / CLOUD_PID
     assert new_store.is_dir()
@@ -85,6 +126,41 @@ def test_link_cloud_promotes_local_project(tmp_path, monkeypatch):
     assert new_entry is not None
     assert new_entry["mode"] == "cloud"
     assert str(tmp_path.resolve()) in new_entry["repo_paths"]
+
+    cfg = load_repo_config(tmp_path)
+    assert cfg["mode"] == "cloud"
+    assert cfg["id"] == CLOUD_PID
+
+
+def test_link_cloud_push_failure_keeps_rekey(tmp_path, monkeypatch):
+    """A transient push failure warns + exits 0; the promotion persists."""
+    _seed_token(monkeypatch, tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("NAURO_API_URL", "https://example.test")
+
+    init_result = runner.invoke(app, ["init", "linkproj"])
+    assert init_result.exit_code == 0, init_result.output
+
+    matches = registry.find_projects_by_name_v2("linkproj")
+    local_id, _entry = matches[0]
+
+    transient = remote.PresignError("POST /sync/presign failed (503): unavailable")
+
+    with (
+        patch.object(cloud_projects.httpx, "request", side_effect=_create_response()),
+        patch.object(remote, "request_presigned_urls", side_effect=transient),
+    ):
+        result = runner.invoke(app, ["link", "--cloud"])
+
+    # Push failed, but promotion is irreversible — exit 0, warn naming sync.
+    assert result.exit_code == 0, result.output
+    assert "nauro sync" in result.output
+
+    # The re-key persisted despite the failed push.
+    assert registry.get_project_v2(local_id) is None
+    new_entry = registry.get_project_v2(CLOUD_PID)
+    assert new_entry is not None
+    assert new_entry["mode"] == "cloud"
 
     cfg = load_repo_config(tmp_path)
     assert cfg["mode"] == "cloud"
@@ -115,22 +191,20 @@ def test_link_cloud_on_already_cloud_repo_errors(tmp_path, monkeypatch):
 
 
 def test_link_cloud_succeeds_with_only_auth_token(tmp_path, monkeypatch):
-    """After softening the Tier 1 1.3 guard, an Auth0 token alone is enough —
-    static IAM creds are no longer required to link.
-    """
-    save_config(
-        {
-            "auth": {"access_token": "test-token", "sub": "auth0|test"},
-        }
-    )
+    """An Auth0 token alone is enough to link — static IAM creds are not required."""
+    _seed_token(monkeypatch, tmp_path)
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("NAURO_API_URL", "https://example.test")
 
     init_result = runner.invoke(app, ["init", "auth-only-link"])
     assert init_result.exit_code == 0, init_result.output
 
-    with patch.object(
-        cloud_projects.httpx, "request", side_effect=_create_response("auth-only-link")
+    with (
+        patch.object(
+            cloud_projects.httpx, "request", side_effect=_create_response("auth-only-link")
+        ),
+        patch.object(remote.httpx, "post", side_effect=_presign_post),
+        patch.object(remote.httpx, "put", return_value=_ok_put()),
     ):
         result = runner.invoke(app, ["link", "--cloud"])
 


### PR DESCRIPTION
## Why

Promoting a local-only project to the cloud took two commands. `nauro link --cloud` minted a cloud project id and re-keyed the registry/store to it, but uploaded nothing — the user then had to run `nauro sync` to actually push the store. The promotion was incomplete until that second step, which is easy to forget and leaves a cloud project with no data behind it. Every other cloud write already pushes at the meaningful moment; `link` was the lone exception.

## Approach

Push the store inside `link --cloud`, immediately after the re-key succeeds, reusing the presign upload path `nauro sync` already uses. Rather than have `link.py` import from the `sync` command module (one CLI command depending on another), the reusable push logic moves into a new `nauro/sync/push.py` alongside `remote.py`/`cloud_projects.py`. Both commands call it; `sync.py` re-exports the prior `_push_to_cloud` name so existing callers and tests are unaffected.

The re-key is the irreversible promotion step, so the push is best-effort. On a transient presign/upload failure, `link --cloud` warns the user to run `nauro sync` and exits 0 with the re-key intact — promotion never half-fails on the local side. The alternative (rolling back the re-key on push failure) was rejected: it would re-introduce a window where a server-side project exists with no local mapping, and the registry change is the value-bearing part of promotion.

## What changed

- New `nauro/sync/push.py`: `push_changed_files` (scan → presign → PUT core, returns count, raises on presign/auth failure) and `push_store_to_cloud` (sync's token-gated wrapper, unchanged semantics).
- `nauro/cli/commands/sync.py`: push helpers moved out; `_push_to_cloud` retained as a module-level alias to the extracted wrapper so the existing call seam and tests keep working.
- `nauro/cli/commands/link.py`: after the re-key + repo-config write, push the store; report "Pushed N file(s) to cloud" on success, or warn + exit 0 on failure.

## What to review

- Failure classification in `link.py`: it catches `PresignError`, `AuthRefreshError`, and `httpx.HTTPError`. The last matters because transport failures (S3 unreachable) surface as raw `httpx.HTTPError`, not `PresignError` — without it a network blip would crash `link --cloud` instead of warning. Non-200 responses (incl. 403) already become `PresignError`, so this doesn't change how actionable HTTP errors are handled.
- The `_push_to_cloud` re-export shim in `sync.py`, and that `sync()` still calls it via the module attribute (so existing monkeypatch-based sync tests hold).
- That sync's observable behavior (messages, `bool` return, partial-PUT swallowing) is preserved by the extraction.

## What's deferred

No retry/backoff on a failed first push — the user is directed to `nauro sync`, which already owns the retry surface. No change to sync's transport-error handling. The broader cross-surface promotion chain (`auth login` → connector-add in each tool's settings UI) stays multi-step: the connector-add is not scriptable, so an orchestrating command can't deliver true one-command promotion.

## Test plan

`packages/nauro/tests/test_link_cloud.py`: the two happy-path link tests now mock the presign + PUT so they exercise the real one-command push (asserting PUTs issued and "Pushed" reported); a new test asserts a transient push failure exits 0, warns naming `nauro sync`, and leaves the registry re-keyed to the cloud id. Tests isolate both HOME and NAURO_HOME and assert exact exit codes.

- `uv run ruff format --check packages/` and `uv run ruff check packages/` — clean.
- `uv run pytest packages/nauro/tests/ -x -q` — 1138 passed, 10 skipped.
- `uv run pytest packages/nauro-core/tests/ -x -q` — 652 passed.
