### PR TITLE
Fail loud on git merge-file failure in sync union merge

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/sync.py
+++ b/packages/nauro/src/nauro/cli/commands/sync.py
@@ -119,7 +119,12 @@ def _pull_via_presign(project_id: str, store_path: Path) -> int:
     from datetime import datetime, timezone
 
     from nauro.cli.commands.auth import AuthRefreshError
-    from nauro.sync.merge import detect_conflict, resolve_conflict, should_skip
+    from nauro.sync.merge import (
+        UnionMergeError,
+        detect_conflict,
+        resolve_conflict,
+        should_skip,
+    )
     from nauro.sync.remote import (
         PresignError,
         fetch_manifest,
@@ -230,6 +235,11 @@ def _pull_via_presign(project_id: str, store_path: Path) -> int:
             merged += 1
         except PresignError:
             logger.exception("Error resolving conflict for %s", rel)
+        except UnionMergeError as exc:
+            # Explicit sync must not report success on a failed merge. Surface
+            # the error and skip the file, leaving it untouched on disk.
+            logger.exception("Union merge failed for %s", rel)
+            typer.echo(f"  Error: merge failed for {rel} ({exc}) — left unchanged", err=True)
 
     state.last_full_sync = datetime.now(timezone.utc).isoformat()
     save_state(store_path, state)

--- a/packages/nauro/src/nauro/sync/hooks.py
+++ b/packages/nauro/src/nauro/sync/hooks.py
@@ -110,7 +110,12 @@ def pull_before_session(project_id: str, store_path: Path) -> int:
         return 0
 
     try:
-        from nauro.sync.merge import detect_conflict, resolve_conflict, should_skip
+        from nauro.sync.merge import (
+            UnionMergeError,
+            detect_conflict,
+            resolve_conflict,
+            should_skip,
+        )
         from nauro.sync.remote import (
             PresignError,
             fetch_manifest,
@@ -227,7 +232,15 @@ def pull_before_session(project_id: str, store_path: Path) -> int:
             update_file_state(state, actual_rel, local_sha, remote_etag)
         else:
             local_file = store_path / rel
-            merged_content = resolve_conflict(store_path, local_file, remote_content, rel, state)
+            try:
+                merged_content = resolve_conflict(
+                    store_path, local_file, remote_content, rel, state
+                )
+            except UnionMergeError:
+                # Leave the local file untouched rather than overwrite it with
+                # possibly-corrupt bytes. Session startup must never crash.
+                logger.exception("sync pull: union merge failed for %s", rel)
+                continue
             local_file.write_bytes(merged_content)
             local_sha = compute_sha256(local_file)
             update_file_state(state, rel, local_sha, remote_etag)

--- a/packages/nauro/src/nauro/sync/merge.py
+++ b/packages/nauro/src/nauro/sync/merge.py
@@ -15,6 +15,15 @@ from nauro.sync.state import SyncState
 
 logger = logging.getLogger("nauro.sync")
 
+
+class UnionMergeError(Exception):
+    """Raised when ``git merge-file --union`` exits with a nonzero status.
+
+    Signals that the merged content cannot be trusted. Callers decide
+    whether to surface the failure or skip the file untouched.
+    """
+
+
 # Files where append-only union merge is appropriate
 APPEND_ONLY_PATTERNS = ("decisions/", "open-questions.md", "state_history.md")
 
@@ -102,7 +111,15 @@ def _union_merge(
 ) -> bytes:
     """Use git merge-file --union for append-only files.
 
-    Uses the last-synced version as the common base.
+    The common base is always empty (we do not persist the last-synced
+    content), so ``--union`` degenerates to an append-only union: every
+    line unique to either side is retained, with no conflict markers.
+
+    A nonzero exit from git signals a genuine failure (IO/stat error, or
+    a signal kill) rather than a resolved conflict — union resolution
+    returns 0 in that case. On a nonzero status the merged file cannot be
+    trusted, so this raises ``UnionMergeError`` instead of returning
+    possibly-corrupt content.
     """
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp = Path(tmpdir)
@@ -112,22 +129,19 @@ def _union_merge(
 
         local_tmp.write_bytes(local_content)
         remote_tmp.write_bytes(remote_content)
-
-        # Use empty base if we don't have one — union merge handles this fine
-        fs = state.files.get(relative_path)
-        if fs and fs.local_sha256:
-            # We don't store the base content, so use empty as base
-            # This makes union merge act like a concatenation of unique lines
-            base_tmp.write_bytes(b"")
-        else:
-            base_tmp.write_bytes(b"")
+        base_tmp.write_bytes(b"")
 
         result = subprocess.run(
             ["git", "merge-file", "--union", str(local_tmp), str(base_tmp), str(remote_tmp)],
             capture_output=True,
         )
 
-        # git merge-file returns 0 on clean merge, >0 on conflicts (but --union resolves them)
+        if result.returncode != 0:
+            raise UnionMergeError(
+                f"git merge-file --union failed for {relative_path} "
+                f"(exit code {result.returncode}): {result.stderr.decode(errors='replace')}"
+            )
+
         merged = local_tmp.read_bytes()
         logger.info("Union merge completed for %s (exit code %d)", relative_path, result.returncode)
         return merged

--- a/packages/nauro/tests/test_sync/test_hooks.py
+++ b/packages/nauro/tests/test_sync/test_hooks.py
@@ -244,6 +244,57 @@ class TestPullBeforeSessionPresign:
 
         assert result == 0
 
+    def test_pull_swallows_union_merge_error_and_leaves_file_untouched(
+        self, cloud_store, monkeypatch
+    ):
+        """SessionStart auto-pull must not crash on a failed union merge.
+
+        The failing file is skipped (left on disk as-is), the rest of the
+        pull continues, and the call returns normally.
+        """
+        from nauro.sync.merge import UnionMergeError
+
+        rel = "decisions/050-conflicted.md"
+        local_file = cloud_store / rel
+        local_file.parent.mkdir(parents=True, exist_ok=True)
+        local_file.write_bytes(b"# 050\nlocal body\n")
+        original = local_file.read_bytes()
+
+        # Diverged from last-synced state on both sides → conflict, not pull.
+        state = SyncState()
+        state.files[rel] = FileState(
+            local_sha256="old_sha",
+            remote_etag='"old_etag"',
+            last_sync="2026-05-16T00:00:00Z",
+        )
+        save_state(cloud_store, state)
+
+        manifest = self._manifest(
+            [{"path": rel, "etag": '"new_etag"', "size": 1, "last_modified": "x"}],
+        )
+        presign = self._presign([{"verb": "GET", "path": rel}])
+
+        def fake_get(url, **kwargs):
+            if "/sync/manifest" in url:
+                return manifest
+            return httpx.Response(200, content=b"# 050\nremote body\n")
+
+        def boom(*args, **kwargs):
+            raise UnionMergeError("simulated git failure")
+
+        monkeypatch.setattr("nauro.sync.merge._union_merge", boom)
+
+        with (
+            patch("nauro.sync.remote.httpx.get", side_effect=fake_get),
+            patch("nauro.sync.remote.httpx.post", return_value=presign),
+        ):
+            # Must not raise.
+            result = pull_before_session(CLOUD_PID, cloud_store)
+
+        assert result == 0
+        # The local file was left untouched rather than overwritten.
+        assert local_file.read_bytes() == original
+
 
 # --- push happy path ---
 

--- a/packages/nauro/tests/test_sync/test_merge.py
+++ b/packages/nauro/tests/test_sync/test_merge.py
@@ -1,12 +1,15 @@
 """Tests for nauro.sync.merge."""
 
 import shutil
+import subprocess
 
 import pytest
 
 from nauro.sync.merge import (
+    UnionMergeError,
     _is_append_only,
     _set_union_markdown,
+    _union_merge,
     detect_conflict,
     resolve_conflict,
     should_skip,
@@ -151,6 +154,71 @@ class TestResolveConflict:
 
         result_str = result.decode()
         assert "Question 1" in result_str
+
+
+class TestUnionMergeFailLoud:
+    """``_union_merge`` raises on a genuine git failure, not on benign stderr."""
+
+    def test_nonzero_exit_raises(self, monkeypatch):
+        """A nonzero git exit (command-not-found territory) raises UnionMergeError."""
+
+        def fake_run(*args, **kwargs):
+            return subprocess.CompletedProcess(args=args[0], returncode=127, stdout=b"", stderr=b"")
+
+        monkeypatch.setattr("nauro.sync.merge.subprocess.run", fake_run)
+
+        with pytest.raises(UnionMergeError):
+            _union_merge(b"local\n", b"remote\n", "decisions/001-foo.md", SyncState())
+
+    def test_io_error_exit_raises_with_stderr(self, monkeypatch):
+        """A 255 IO/stat error raises, and the decoded stderr is in the message."""
+
+        def fake_run(*args, **kwargs):
+            return subprocess.CompletedProcess(
+                args=args[0], returncode=255, stdout=b"", stderr=b"error: cannot stat 'local'"
+            )
+
+        monkeypatch.setattr("nauro.sync.merge.subprocess.run", fake_run)
+
+        with pytest.raises(UnionMergeError) as excinfo:
+            _union_merge(b"local\n", b"remote\n", "decisions/001-foo.md", SyncState())
+
+        message = str(excinfo.value)
+        assert "255" in message
+        assert "error: cannot stat 'local'" in message
+
+    def test_rc_zero_with_stderr_does_not_raise(self, monkeypatch):
+        """git emits benign ``warning:`` lines with rc=0 — those must not raise.
+
+        The predicate is returncode-only; the merged bytes are still returned.
+        """
+
+        def fake_run(*args, **kwargs):
+            # args[0] is the git argv: [..., local_tmp, base_tmp, remote_tmp].
+            # The function reads back the local temp file, so leave it untouched.
+            return subprocess.CompletedProcess(
+                args=args[0], returncode=0, stdout=b"", stderr=b"warning: something benign"
+            )
+
+        monkeypatch.setattr("nauro.sync.merge.subprocess.run", fake_run)
+
+        result = _union_merge(
+            b"local body\n", b"remote body\n", "decisions/001-foo.md", SyncState()
+        )
+        # No raise; the local temp content is returned untouched.
+        assert result == b"local body\n"
+
+    @pytest.mark.skipif(not shutil.which("git"), reason="git not available")
+    def test_benign_union_merges_unique_lines(self):
+        """Real git merge-file --union retains lines unique to each side."""
+        local = b"# Decision 001\n- local-only line\n"
+        remote = b"# Decision 001\n- remote-only line\n"
+
+        result = _union_merge(local, remote, "decisions/001-foo.md", SyncState())
+        result_str = result.decode()
+
+        assert "- local-only line" in result_str
+        assert "- remote-only line" in result_str
 
 
 class TestSetUnionMarkdown:

--- a/packages/nauro/tests/test_sync/test_sync_presign.py
+++ b/packages/nauro/tests/test_sync/test_sync_presign.py
@@ -335,6 +335,65 @@ class TestPullViaPresign:
         backups = list((cloud_store / ".conflict-backup").iterdir())
         assert any("stack.md" in b.name for b in backups)
 
+    def test_union_merge_failure_surfaces_and_leaves_file_untouched(
+        self, cloud_store, monkeypatch, capsys
+    ):
+        """Explicit ``nauro sync`` must not report success on a failed merge.
+
+        The failure is echoed to stderr, the file is left untouched, and it is
+        not counted toward the merged total.
+        """
+        from nauro.sync.merge import UnionMergeError
+
+        rel = "decisions/051-conflicted.md"
+        local_file = cloud_store / rel
+        local_file.parent.mkdir(parents=True, exist_ok=True)
+        local_file.write_bytes(b"# 051\nlocal body\n")
+        original = local_file.read_bytes()
+
+        state = SyncState()
+        state.files[rel] = FileState(
+            local_sha256="old_sha",
+            remote_etag='"old_etag"',
+            last_sync="2026-05-16T00:00:00Z",
+        )
+        save_state(cloud_store, state)
+
+        manifest = self._manifest_response(
+            [{"path": rel, "etag": '"new_etag"', "size": 1, "last_modified": "x"}],
+            next_cursor=None,
+        )
+        presign = self._presign_response([{"verb": "GET", "path": rel}])
+
+        def fake_get(url, **kwargs):
+            if "/sync/manifest" in url:
+                return manifest
+            return httpx.Response(200, content=b"# 051\nremote body\n")
+
+        def boom(*args, **kwargs):
+            raise UnionMergeError("simulated git failure")
+
+        monkeypatch.setattr("nauro.sync.merge._union_merge", boom)
+
+        from nauro.sync import remote
+
+        with (
+            patch.object(remote.httpx, "get", side_effect=fake_get),
+            patch.object(remote.httpx, "post", return_value=presign),
+        ):
+            from nauro.cli.commands.sync import _pull_from_cloud
+
+            merged = _pull_from_cloud(cloud_store.name, cloud_store)
+
+        # Failed file is not counted as merged.
+        assert merged == 0
+        # A clear error line was surfaced to stderr.
+        err = capsys.readouterr().err
+        assert rel in err
+        assert "merge failed" in err
+        # The local file was left untouched.
+        assert local_file.read_bytes() == original
+
     def test_manifest_401_refresh_then_retry_succeeds(self, cloud_store):
         manifest_ok = self._manifest_response(
             [{"path": "decisions/001.md", "etag": '"e1"', "size": 1, "last_modified": "x"}],


### PR DESCRIPTION
## Why

The append-only union merge in `nauro sync` swallowed git's exit code. After
running `git merge-file --union`, `_union_merge` read the local temp file and
returned it unconditionally, ignoring `result.returncode`. On a genuine git
failure — an IO/stat error, or the process killed by a signal — it returned
possibly-corrupt content as a successful merge. That content was then written
straight over the local decision/question/history file, silently corrupting
append-only content with no error surfaced anywhere.

## Approach

Make the merge fail loud via a dedicated `UnionMergeError`, and let each caller
handle it per its own contract — fail-loud on the explicit command, fail-safe on
the background hook.

The raise predicate is **returncode-only**. Two facts drive this:

- Union resolution returns exit 0 even when it auto-resolves overlapping
  hunks, so a nonzero code only ever means a genuine failure (verified against
  git 2.50.1: 0 on clean/auto-resolved, 255 on IO/stat error, negative on signal).
- git emits benign `warning:` lines on stderr with rc=0, so also gating on
  nonempty stderr would raise false positives on healthy merges.

The two callers diverge deliberately:

- The explicit `nauro sync` command must never report success on a failed merge,
  so it surfaces the error to stderr and skips the file.
- The session-start auto-pull is contractually never-crash (it runs on every
  session entry), so it logs and continues to the next file.

In both cases the file on disk is left untouched rather than overwritten with
suspect bytes — the asymmetry is in how the failure is reported, not in whether
data is protected.

## What changed

- `sync/merge.py`: added `UnionMergeError`; `_union_merge` now raises it when
  `git merge-file --union` exits nonzero. Collapsed a dead if/else (both
  branches wrote an empty base) into one empty-base write, and rewrote the
  docstring to describe the actual behavior — the base is always empty, so
  `--union` degenerates to an append-only union of unique lines.
- `sync/hooks.py`: the session-start conflict loop catches `UnionMergeError`,
  logs it, and continues — preserving the never-crash guarantee.
- `cli/commands/sync.py`: the explicit-command conflict loop catches
  `UnionMergeError`, echoes a clear error line to stderr, and skips the file
  (not counted toward the merged total), matching the surrounding
  PresignError-handling idiom.

## What to review

- The `returncode != 0` predicate in `_union_merge` and the rationale above —
  specifically that gating on stderr would be wrong here.
- The two caller handlers and their divergence: the explicit command surfaces
  the error; the background hook stays silent-but-safe.

## What's deferred

Nothing. The `_union_merge` signature is unchanged (`state` is now unused inside
the body but stays part of the call contract that `resolve_conflict` and the
tests use); the union-merge strategy itself is untouched.

## Test plan

`uv run pytest packages/nauro/tests/test_sync/` → 96 passed. Full package suite
`uv run pytest packages/nauro/tests/` → 1144 passed, 10 skipped, no regressions.
Lint clean (`ruff check` + `ruff format --check`).

New tests:
- Nonzero exit (127, and 255 with stderr) raises `UnionMergeError`, with the
  returncode and decoded stderr in the message.
- rc=0 with nonempty stderr does **not** raise and still returns merged bytes
  (locks the returncode-only predicate).
- Real `git merge-file --union` on two decision-file inputs returns bytes
  carrying the lines unique to each side.
- Session-start auto-pull does not propagate `UnionMergeError` and leaves the
  local file unchanged on disk.
- Explicit `nauro sync` surfaces the failure to stderr, does not count the file
  as merged (`merged == 0`), and leaves the local file unchanged.
