### PR TITLE
Guard decision read scans against a malformed file

### DIFF
--- a/packages/nauro-core/src/nauro_core/operations/check_decision.py
+++ b/packages/nauro-core/src/nauro_core/operations/check_decision.py
@@ -17,7 +17,8 @@ from nauro_core.constants import (
     MAX_CONTEXT_LENGTH,
     NO_DECISIONS_TO_CHECK,
 )
-from nauro_core.decision_model import Decision, parse_decision
+from nauro_core.decision_model import Decision
+from nauro_core.operations.decision_lookup import parse_all_decisions
 from nauro_core.operations.results import (
     CheckDecisionResult,
     ErrorPayload,
@@ -73,7 +74,7 @@ def check_decision(
         if rejection:
             return CheckDecisionResult(error=ErrorPayload(kind="rejected", reason=rejection))
 
-    decisions = _parse_all_decisions(store)
+    decisions = parse_all_decisions(store)
     decisions = [d for d in decisions if not (d.num == 1 and d.title == _SCAFFOLD_SEED_TITLE)]
     if not decisions:
         return CheckDecisionResult(assessment=NO_DECISIONS_TO_CHECK)
@@ -103,17 +104,6 @@ def check_decision(
         related_decisions=related,
         assessment=_assessment(related),
     )
-
-
-def _parse_all_decisions(store: Store) -> list[Decision]:
-    """Read every decision from ``store`` and parse it via the v2 model."""
-    parsed: list[Decision] = []
-    for stem in store.list_decisions():
-        body = store.read_decision(stem)
-        if body is None:
-            continue
-        parsed.append(parse_decision(body, f"{stem}.md"))
-    return parsed
 
 
 def _hit_to_related(hit: dict, by_num: dict[int, Decision]) -> RelatedDecision:

--- a/packages/nauro-core/src/nauro_core/operations/decision_lookup.py
+++ b/packages/nauro-core/src/nauro_core/operations/decision_lookup.py
@@ -10,8 +10,52 @@ here rather than inside either operation module.
 
 from __future__ import annotations
 
+import logging
+
+from nauro_core.decision_model import Decision, parse_decision
 from nauro_core.operations.store import Store
 from nauro_core.parsing import extract_decision_number
+
+logger = logging.getLogger("nauro_core.operations.decision_lookup")
+
+
+def parse_all_decisions(store: Store) -> list[Decision]:
+    """Read and parse every decision in the store, skipping unparseable files.
+
+    A single malformed file on disk (a half-written body, a pre-v2 file left
+    during a migration) must not take down the read path. Each file that does
+    not round-trip through the v2 parser is logged at debug and skipped, so
+    the scan returns the decisions it could parse rather than raising.
+
+    Listing and ordering follow :meth:`Store.list_decisions` verbatim; no
+    filtering is applied here. Callers that need a status or seed filter
+    apply it after the scan returns.
+    """
+    parsed: list[Decision] = []
+    for stem in store.list_decisions():
+        body = store.read_decision(stem)
+        if body is None:
+            continue
+        try:
+            parsed.append(parse_decision(body, f"{stem}.md"))
+        except Exception:
+            logger.debug("Skipping unparseable decision file: %s.md", stem)
+            continue
+    return parsed
+
+
+def parse_decision_or_none(body: str, filename: str) -> Decision | None:
+    """Parse a single decision body, returning ``None`` if it does not parse.
+
+    The single-file analogue of :func:`parse_all_decisions`: a targeted
+    lookup of a known file that fails to parse is logged at debug and
+    surfaces as ``None`` so the caller can decide how to report it.
+    """
+    try:
+        return parse_decision(body, filename)
+    except Exception:
+        logger.debug("Could not parse decision file: %s", filename)
+        return None
 
 
 def find_decision_stem_by_num(store: Store, num: int) -> str | None:

--- a/packages/nauro-core/src/nauro_core/operations/get_context.py
+++ b/packages/nauro-core/src/nauro_core/operations/get_context.py
@@ -23,7 +23,7 @@ from nauro_core.constants import (
     STATE_MD,
 )
 from nauro_core.context import build_l0, build_l1, build_l2
-from nauro_core.decision_model import Decision, parse_decision
+from nauro_core.operations.decision_lookup import parse_all_decisions
 from nauro_core.operations.results import ErrorPayload, GetContextResult
 from nauro_core.operations.store import Store
 
@@ -41,16 +41,6 @@ _BUILDERS = {
     1: build_l1,
     2: build_l2,
 }
-
-
-def _load_decisions(store: Store) -> list[Decision]:
-    decisions: list[Decision] = []
-    for stem in store.list_decisions():
-        body = store.read_decision(stem)
-        if body is None:
-            continue
-        decisions.append(parse_decision(body, f"{stem}.md"))
-    return decisions
 
 
 def _load_context_files(store: Store, level: int) -> dict[str, str]:
@@ -115,5 +105,5 @@ def get_context(store: Store, level: int) -> GetContextResult:
         )
 
     files = _load_context_files(store, level)
-    decisions = _load_decisions(store)
+    decisions = parse_all_decisions(store)
     return GetContextResult(content=builder(files, decisions))

--- a/packages/nauro-core/src/nauro_core/operations/get_decision.py
+++ b/packages/nauro-core/src/nauro_core/operations/get_decision.py
@@ -20,7 +20,8 @@ from __future__ import annotations
 
 from typing import Literal
 
-from nauro_core.decision_model import parse_decision
+from nauro_core.decision_model import Decision
+from nauro_core.operations.decision_lookup import parse_decision_or_none
 from nauro_core.operations.results import ErrorPayload, GetDecisionResult
 from nauro_core.operations.store import Store
 from nauro_core.parsing import extract_decision_number
@@ -75,16 +76,23 @@ def get_decision(
             body = store.read_decision(stem)
             if body is not None:
                 if mode == "header":
-                    projected = _project_header(body, f"{stem}.md")
-                    return GetDecisionResult(content=projected)
+                    decision = parse_decision_or_none(body, f"{stem}.md")
+                    if decision is None:
+                        return GetDecisionResult(
+                            error=ErrorPayload(
+                                kind="error",
+                                reason=f"Decision {number} could not be parsed",
+                            ),
+                        )
+                    return GetDecisionResult(content=_project_header(decision))
                 return GetDecisionResult(content=body)
     return GetDecisionResult(
         error=ErrorPayload(kind="error", reason=f"Decision {number} not found"),
     )
 
 
-def _project_header(body: str, filename: str) -> str:
-    """Build the compact header projection for a decision body.
+def _project_header(decision: Decision) -> str:
+    """Build the compact header projection for a parsed decision.
 
     Layout (blocks joined by a blank line):
 
@@ -96,8 +104,6 @@ def _project_header(body: str, filename: str) -> str:
     ``## Decision`` section opens with whitespace from emitting a dangling
     blank lede block.
     """
-    decision = parse_decision(body, filename)
-
     frontmatter_lines: list[str] = []
     for field in _HEADER_FRONTMATTER_FIELDS:
         value = _frontmatter_value(decision, field)

--- a/packages/nauro-core/src/nauro_core/operations/list_decisions.py
+++ b/packages/nauro-core/src/nauro_core/operations/list_decisions.py
@@ -15,7 +15,8 @@ rationale stays inspectable.
 
 from __future__ import annotations
 
-from nauro_core.decision_model import DecisionStatus, parse_decision
+from nauro_core.decision_model import DecisionStatus
+from nauro_core.operations.decision_lookup import parse_all_decisions
 from nauro_core.operations.results import DecisionSummary, ListDecisionsResult
 from nauro_core.operations.store import Store
 
@@ -37,12 +38,7 @@ def list_decisions(
         :class:`ListDecisionsResult` with ``decisions`` populated. Rows
         are sorted by decision number descending and sliced to ``limit``.
     """
-    decisions = []
-    for stem in store.list_decisions():
-        body = store.read_decision(stem)
-        if body is None:
-            continue
-        decisions.append(parse_decision(body, f"{stem}.md"))
+    decisions = parse_all_decisions(store)
 
     if not include_superseded:
         decisions = [d for d in decisions if d.status is DecisionStatus.active]

--- a/packages/nauro-core/src/nauro_core/operations/propose_decision.py
+++ b/packages/nauro-core/src/nauro_core/operations/propose_decision.py
@@ -52,6 +52,7 @@ from nauro_core.decision_model import (
 from nauro_core.operations.decision_lookup import (
     find_decision_stem_by_id,
     find_decision_stem_by_num,
+    parse_all_decisions,
 )
 from nauro_core.operations.results import (
     ErrorPayload,
@@ -318,20 +319,11 @@ def _load_recent_decisions(store: Store) -> list[Decision]:
 def _parse_all_decisions(store: Store) -> list[Decision]:
     """Read every decision from the store and parse via the v2 model.
 
-    Files that don't round-trip through the v2 parser are skipped — they
-    can sit on disk during migrations without blocking the validation
-    pipeline.
+    Thin wrapper over the shared guarded scan: files that don't round-trip
+    through the v2 parser are logged at debug and skipped so they can sit on
+    disk during migrations without blocking the validation pipeline.
     """
-    parsed: list[Decision] = []
-    for stem in store.list_decisions():
-        body = store.read_decision(stem)
-        if body is None:
-            continue
-        try:
-            parsed.append(parse_decision(body, f"{stem}.md"))
-        except Exception:
-            continue
-    return parsed
+    return parse_all_decisions(store)
 
 
 # ── Tier 2 result reshape ─────────────────────────────────────────────────

--- a/packages/nauro-core/src/nauro_core/operations/search_decisions.py
+++ b/packages/nauro-core/src/nauro_core/operations/search_decisions.py
@@ -13,7 +13,8 @@ rather than letting superseded hits crowd out active ones.
 
 from __future__ import annotations
 
-from nauro_core.decision_model import Decision, DecisionStatus, parse_decision
+from nauro_core.decision_model import Decision, DecisionStatus
+from nauro_core.operations.decision_lookup import parse_all_decisions
 from nauro_core.operations.results import (
     ErrorPayload,
     SearchDecisionsResult,
@@ -61,12 +62,7 @@ def search_decisions(
             ),
         )
 
-    decisions = []
-    for stem in store.list_decisions():
-        body = store.read_decision(stem)
-        if body is None:
-            continue
-        decisions.append(parse_decision(body, f"{stem}.md"))
+    decisions = parse_all_decisions(store)
 
     if not include_superseded:
         decisions = [d for d in decisions if d.status is DecisionStatus.active]

--- a/packages/nauro-core/tests/operations/test_read_path_parse_guard.py
+++ b/packages/nauro-core/tests/operations/test_read_path_parse_guard.py
@@ -1,0 +1,212 @@
+"""A single malformed decision file must not take down the read path.
+
+The decision parser is strict by design (``decision_model.parse_decision``
+raises on any deviation from the canonical v2 format). Tolerance for a stray
+unparseable file on disk — a half-written body, a pre-v2 file left during a
+migration — lives at the scan layer: the five scans skip-and-continue while
+the targeted ``get_decision`` returns a typed error rather than crashing.
+
+These tests seed an :class:`InMemoryStore` with one well-formed decision and
+one malformed file (missing the leading ``---`` frontmatter fence, which
+raises ``ValueError``) and assert every read path returns the good decision
+without raising. The ``check_decision`` seed-filter asymmetry is exercised
+here too: ``check_decision`` drops the scaffold seed, ``search_decisions``
+does not.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+from nauro_core.decision_model import (
+    Decision,
+    DecisionConfidence,
+    DecisionStatus,
+    format_decision,
+)
+from nauro_core.operations import (
+    CheckDecisionResult,
+    GetContextResult,
+    GetDecisionResult,
+    InMemoryStore,
+    ListDecisionsResult,
+    SearchDecisionsResult,
+    check_decision,
+    get_context,
+    get_decision,
+    list_decisions,
+    search_decisions,
+)
+from nauro_core.operations.decision_lookup import parse_all_decisions
+
+# A body with no leading ``---`` fence; ``parse_decision`` raises ValueError on
+# it ("missing YAML frontmatter"). Stem is a well-formed ``NNN-slug`` so the
+# scans reach the read/parse step rather than skipping it for another reason.
+_MALFORMED_STEM = "042-corrupt-decision"
+_MALFORMED_BODY = "# 042 — Corrupt decision\n\nNo frontmatter fence here.\n"
+
+# Number a caller can target with get_decision; matches _MALFORMED_STEM.
+_MALFORMED_NUM = 42
+
+
+def _good_decision(
+    num: int = 7,
+    title: str = "Adopt Redis cache",
+    rationale: str = "Use Redis for the session cache layer.",
+) -> tuple[str, str]:
+    """Return (file_stem, formatted markdown) for a parseable v2 decision."""
+    decision = Decision(
+        date=date(2026, 1, 1),
+        confidence=DecisionConfidence.medium,
+        status=DecisionStatus.active,
+        num=num,
+        title=title,
+        rationale=rationale,
+    )
+    slug = title.lower().replace(" ", "-")
+    return f"{num:03d}-{slug}", format_decision(decision)
+
+
+def _scaffold_seed() -> tuple[str, str]:
+    """Return the scaffold-seed bookkeeping decision (num==1, fixed title)."""
+    decision = Decision(
+        date=date(2026, 1, 1),
+        confidence=DecisionConfidence.medium,
+        status=DecisionStatus.active,
+        num=1,
+        title="Initial project setup",
+        rationale="Scaffold the project store.",
+    )
+    return "001-initial-project-setup", format_decision(decision)
+
+
+def _store_with_good_and_malformed() -> tuple[InMemoryStore, str, str]:
+    """Seed a store with one good decision and one malformed file.
+
+    Returns the store plus the good decision's stem and body for assertions.
+    """
+    good_stem, good_body = _good_decision()
+    store = InMemoryStore(
+        decisions={
+            good_stem: good_body,
+            _MALFORMED_STEM: _MALFORMED_BODY,
+        }
+    )
+    return store, good_stem, good_body
+
+
+# ── parse_all_decisions: the shared guarded scan ──
+
+
+def test_parse_all_decisions_skips_malformed_returns_only_good() -> None:
+    store, _, _ = _store_with_good_and_malformed()
+    parsed = parse_all_decisions(store)
+    assert [d.num for d in parsed] == [7]
+    assert parsed[0].title == "Adopt Redis cache"
+
+
+# ── list_decisions ──
+
+
+def test_list_decisions_returns_only_good_does_not_raise() -> None:
+    store, _, _ = _store_with_good_and_malformed()
+    result = list_decisions(store)
+    assert isinstance(result, ListDecisionsResult)
+    assert [row.number for row in result.decisions] == [7]
+    assert result.decisions[0].title == "Adopt Redis cache"
+
+
+# ── search_decisions ──
+
+
+def test_search_decisions_matches_good_does_not_raise() -> None:
+    store, _, _ = _store_with_good_and_malformed()
+    result = search_decisions(store, "Redis cache")
+    assert isinstance(result, SearchDecisionsResult)
+    assert result.error is None
+    assert 7 in {hit.number for hit in result.results}
+
+
+# ── check_decision ──
+
+
+def test_check_decision_returns_good_does_not_raise() -> None:
+    store, _, _ = _store_with_good_and_malformed()
+    result = check_decision(store, "Adopt Redis cache")
+    assert isinstance(result, CheckDecisionResult)
+    assert result.error is None
+    assert 7 in {extract for extract in _related_numbers(result)}
+
+
+def test_check_decision_filters_scaffold_seed_search_does_not() -> None:
+    """Locks the by-design asymmetry: ``check_decision`` drops the scaffold
+    seed (num==1 / "Initial project setup"); ``search_decisions`` does not."""
+    seed_stem, seed_body = _scaffold_seed()
+    store = InMemoryStore(decisions={seed_stem: seed_body})
+
+    # check_decision drops the seed: with only the seed present it reports the
+    # empty-store assessment rather than surfacing the seed as a related hit.
+    checked = check_decision(store, "Initial project setup scaffold")
+    assert _related_numbers(checked) == []
+
+    # search_decisions retains the seed: a query matching it returns it.
+    searched = search_decisions(store, "Initial project setup")
+    assert 1 in {hit.number for hit in searched.results}
+
+
+def _related_numbers(result: CheckDecisionResult) -> list[int]:
+    """Extract the decision numbers from a check result's related list."""
+    numbers: list[int] = []
+    for related in result.related_decisions:
+        # id is the canonical ``decision-NNN`` form.
+        numbers.append(int(related.id.rsplit("-", 1)[-1]))
+    return numbers
+
+
+# ── get_context ──
+
+
+def test_get_context_assembles_at_every_level_with_good_decision() -> None:
+    store, _, _ = _store_with_good_and_malformed()
+    for level in (0, 1, 2):
+        result = get_context(store, level)
+        assert isinstance(result, GetContextResult)
+        assert result.error is None
+        assert result.content is not None
+        assert "Adopt Redis cache" in result.content
+
+
+# ── get_decision ──
+
+
+def test_get_decision_good_header_and_full() -> None:
+    store, _, good_body = _store_with_good_and_malformed()
+
+    header = get_decision(store, 7, mode="header")
+    assert header.error is None
+    assert header.content is not None
+    assert "# 007 — Adopt Redis cache" in header.content
+
+    full = get_decision(store, 7, mode="full")
+    assert full.error is None
+    assert full.content == good_body
+
+
+def test_get_decision_malformed_target_header_returns_typed_error() -> None:
+    """A corrupt target in header mode returns a Result with a typed error —
+    not an exception, and not a silent skip."""
+    store, _, _ = _store_with_good_and_malformed()
+    result = get_decision(store, _MALFORMED_NUM, mode="header")
+    assert isinstance(result, GetDecisionResult)
+    assert result.content is None
+    assert result.error is not None
+    assert result.error.kind == "error"
+    assert str(_MALFORMED_NUM) in result.error.reason
+
+
+def test_get_decision_malformed_target_full_returns_verbatim_body() -> None:
+    """Full mode never parses, so a corrupt target still returns its body."""
+    store, _, _ = _store_with_good_and_malformed()
+    result = get_decision(store, _MALFORMED_NUM, mode="full")
+    assert result.error is None
+    assert result.content == _MALFORMED_BODY


### PR DESCRIPTION
## Why

A single unparseable decision file on disk took down the entire read path. `check_decision`, `search_decisions`, `list_decisions`, and `get_context` each parsed every decision eagerly and let `parse_decision`'s `ValueError` propagate, so one half-written body or a pre-v2 file left behind during a migration crashed all four reads. The write path already tolerated this (it wrapped its scan in a `try/except` skip), so the two paths disagreed on what a malformed file means — silent on write, fatal on read.

## Approach

One shared guarded scan helper, `parse_all_decisions`, lives in `decision_lookup.py`. It skips-and-continues on a parse failure and logs the skipped stem at debug, then returns the decisions it could parse. All five scans route through it, so the read path now tolerates a stray bad file exactly as the write path already did — and the write path's previously-silent skip is now debug-logged through the same helper.

The parser stays strict by design; tolerance lives at the scan layer, not in the parser. The asymmetry between bulk scans and a targeted lookup is deliberate: a bulk scan skips a bad file because the caller asked for "all the decisions I can parse," but a caller naming a specific number deserves to know that file is corrupt rather than getting a silent miss. So `get_decision` in header mode returns a typed error (`kind="error"`, reusing the existing not-found error shape — no new taxonomy) when its target won't parse. `full` mode never parses, so it still returns the verbatim body for a corrupt target — useful for inspecting exactly what's wrong.

Considered and rejected: making the parser lenient (would erode the strict v2 contract every other surface relies on), and a per-call try/except duplicated at each scan (the copy-paste the shared helper exists to avoid).

## What changed

- `decision_lookup.py`: new `parse_all_decisions` (guarded bulk scan, skip-and-continue, debug-logged) and `parse_decision_or_none` (single guarded parse), plus a module logger.
- The five scans — `list_decisions`, `search_decisions`, `check_decision`, `get_context`, `propose_decision` — drop their local scan loops and call the shared helper. `propose_decision` keeps its private name as a thin delegating wrapper (two call sites, zero behavior change).
- `get_decision` header mode returns a typed parse-error on a corrupt target; `_project_header` now takes the already-parsed decision instead of re-parsing.

## What to review

- The shared helper in `decision_lookup.py` — confirm the listing/ordering matches the prior scans (it follows `Store.list_decisions` verbatim, no filtering).
- `get_decision`'s typed-error branch — that it reuses the existing error shape and that `full` mode is untouched.
- That `check_decision`'s scaffold-seed filter is still applied *after* the scan (it must not move into the helper), and that `search_decisions` still does *not* filter that seed. A test locks this asymmetry.

## What's deferred

Nothing in scope. The parser remains strict; no migration/repair tooling for corrupt files is added here — a bad file is skipped or reported, not rewritten.

## Test plan

New colocated test file seeds a store with one well-formed decision and one malformed file (missing the leading `---` fence, which raises `ValueError`) and asserts each read path returns the good decision without raising, plus a direct unit test of the helper and the `get_decision` typed-error / verbatim-full behavior. 661 nauro-core tests pass (652 prior + 9 new); 1144 consumer tests pass with no regressions. `ruff check` and `ruff format --check` clean.
