### PR TITLE
Degrade gracefully on a corrupt per-repo config instead of crashing the resolver

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/hook.py
+++ b/packages/nauro/src/nauro/cli/commands/hook.py
@@ -136,7 +136,7 @@ def _resolve_store_path(cwd: Path) -> Path | None:
         repo_root = config_path.parent.parent
         try:
             cfg = load_repo_config(repo_root)
-        except (RepoConfigSchemaError, json.JSONDecodeError, OSError):
+        except (RepoConfigSchemaError, OSError):
             cfg = None
         if cfg is not None:
             return get_store_path_v2(cfg["id"])

--- a/packages/nauro/src/nauro/cli/utils.py
+++ b/packages/nauro/src/nauro/cli/utils.py
@@ -14,7 +14,6 @@ Resolution priority for any command that needs a project context:
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
 import typer
@@ -66,7 +65,7 @@ def _resolve_from_repo_config() -> tuple[str, Path] | None:
     repo_root = config_path.parent.parent
     try:
         cfg = load_repo_config(repo_root)
-    except (RepoConfigSchemaError, json.JSONDecodeError, OSError):
+    except (RepoConfigSchemaError, OSError):
         return None
     pid = cfg["id"]
     name = cfg.get("name") or pid

--- a/packages/nauro/src/nauro/store/repo_config.py
+++ b/packages/nauro/src/nauro/store/repo_config.py
@@ -95,13 +95,19 @@ def load_repo_config(repo_root: Path) -> dict:
 
     Raises:
         FileNotFoundError: When the config file does not exist.
-        RepoConfigSchemaError: When the file is missing required fields or
-            advertises an unknown schema_version.
-        json.JSONDecodeError: When the file is not valid JSON.
+        RepoConfigSchemaError: When the file is missing required fields,
+            advertises an unknown schema_version, or is corrupt/unparseable
+            JSON. Corrupt JSON is remapped here so a single typed error family
+            covers both schema-mismatch and corruption, letting callers
+            degrade gracefully on either.
     """
     path = repo_config_path(repo_root)
     text = path.read_text()
-    data = json.loads(text)
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        logger.warning("Corrupt repo config at %s: %s", path, exc)
+        raise RepoConfigSchemaError(f"Repo config at {path} is not valid JSON.") from exc
     if not isinstance(data, dict):
         raise RepoConfigSchemaError(f"Repo config at {path} is not a JSON object.")
     _validate(data)

--- a/packages/nauro/src/nauro/store/resolution.py
+++ b/packages/nauro/src/nauro/store/resolution.py
@@ -94,6 +94,9 @@ def resolve_via_repo_config(start: Path | None) -> tuple[str, Path] | None:
     try:
         cfg = load_repo_config(repo_root)
     except RepoConfigSchemaError:
+        # Covers both schema-mismatch and corrupt JSON (the reader remaps a
+        # JSONDecodeError to RepoConfigSchemaError), so either degrades to the
+        # no-project fallback rather than crashing the transport.
         return None
     return cfg["id"], get_store_path_v2(cfg["id"])
 

--- a/packages/nauro/tests/test_repo_config.py
+++ b/packages/nauro/tests/test_repo_config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 
 import pytest
 
@@ -98,6 +99,28 @@ def test_loader_rejects_unknown_schema_version(tmp_path):
     with pytest.raises(RepoConfigSchemaError) as exc:
         load_repo_config(repo)
     assert "schema_version" in str(exc.value)
+
+
+def test_loader_remaps_corrupt_json_to_schema_error(tmp_path, caplog):
+    """Truncated/invalid JSON raises RepoConfigSchemaError, not a bare
+    JSONDecodeError, so callers catching the typed config-error family
+    degrade gracefully. The chained cause preserves the underlying parse
+    error, and a warning breadcrumb names the path so corruption is not
+    silently swallowed.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    cfg_dir = repo / REPO_CONFIG_DIR
+    cfg_dir.mkdir()
+    config_file = cfg_dir / REPO_CONFIG_FILENAME
+    config_file.write_text('{"mode": "local", "id": "01')  # truncated mid-value
+
+    with caplog.at_level(logging.WARNING, logger="nauro.repo_config"):
+        with pytest.raises(RepoConfigSchemaError) as exc:
+            load_repo_config(repo)
+
+    assert isinstance(exc.value.__cause__, json.JSONDecodeError)
+    assert str(config_file) in caplog.text
 
 
 def test_save_rejects_invalid_mode(tmp_path):

--- a/packages/nauro/tests/test_resolution_v2.py
+++ b/packages/nauro/tests/test_resolution_v2.py
@@ -20,12 +20,36 @@ from typer.testing import CliRunner
 
 from nauro.cli.main import app
 from nauro.cli.utils import resolve_target_project
-from nauro.constants import REGISTRY_FILENAME, REGISTRY_SCHEMA_VERSION_V2
+from nauro.constants import (
+    REGISTRY_FILENAME,
+    REGISTRY_SCHEMA_VERSION_V2,
+    REPO_CONFIG_DIR,
+    REPO_CONFIG_FILENAME,
+)
 from nauro.mcp.stdio_server import _resolve_store
 from nauro.store import registry
 from nauro.store.repo_config import load_repo_config, save_repo_config
 
 runner = CliRunner()
+
+# Two distinct corrupt-config shapes that must reach the same graceful outcome:
+# (a) unparseable JSON, which the reader now remaps to RepoConfigSchemaError, and
+# (b) parseable JSON whose schema is wrong, which already raised that error.
+_CORRUPT_CONFIGS = {
+    "invalid_json": '{"mode": "local", "id": "01',  # truncated mid-value
+    "wrong_schema": json.dumps({"mode": "local", "id": "x", "schema_version": 99}),
+}
+
+
+def _write_repo_config_text(repo_root, text: str) -> None:
+    """Write raw config text under ``<repo_root>/.nauro/config.json``.
+
+    Bypasses ``save_repo_config`` so the on-disk bytes can be corrupt — the
+    writer validates before write and would refuse these shapes.
+    """
+    cfg_dir = repo_root / REPO_CONFIG_DIR
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    (cfg_dir / REPO_CONFIG_FILENAME).write_text(text)
 
 
 def _post_migration_state(tmp_path, monkeypatch):
@@ -134,6 +158,71 @@ def test_stdio_resolve_explicit_id_matching_config(tmp_path, monkeypatch):
     monkeypatch.chdir(repo_root)
     store = _resolve_store(cloud_pid, str(repo_root))
     assert store == tmp_path / "projects" / cloud_pid
+
+
+# ── corrupt repo config degrades gracefully (no transport crash) ─────────────
+
+
+@pytest.mark.parametrize("corrupt_kind", sorted(_CORRUPT_CONFIGS))
+def test_resolve_via_repo_config_returns_none_on_corrupt_config(
+    tmp_path, monkeypatch, corrupt_kind
+):
+    """Both corrupt shapes resolve to None rather than raising.
+
+    Resolution runs on the MCP transport path, so a raised JSONDecodeError
+    would crash the transport. A wrong-schema config already degraded; this
+    pins that a truncated/unparseable config reaches the same fallback.
+    """
+    from nauro.store.resolution import resolve_via_repo_config
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    _write_repo_config_text(repo_root, _CORRUPT_CONFIGS[corrupt_kind])
+    monkeypatch.chdir(repo_root)
+
+    assert resolve_via_repo_config(repo_root) is None
+
+
+@pytest.mark.parametrize("corrupt_kind", sorted(_CORRUPT_CONFIGS))
+def test_stdio_resolve_corrupt_config_raises_no_project(tmp_path, monkeypatch, corrupt_kind):
+    """A corrupt config falls through to the welcome anchor, not a crash.
+
+    Both corrupt shapes reach the identical NoProjectError outcome — the
+    genuine no-project case the transport surfaces as the welcome screen.
+    """
+    from nauro.store.resolution import NoProjectError
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    _write_repo_config_text(repo_root, _CORRUPT_CONFIGS[corrupt_kind])
+    monkeypatch.chdir(repo_root)
+
+    with pytest.raises(NoProjectError, match="No Nauro project found"):
+        _resolve_store(None, None)
+
+
+def test_get_context_does_not_crash_transport_on_corrupt_config(tmp_path, monkeypatch):
+    """End-to-end: the get_context MCP wrapper returns rather than raising when
+    the repo config is corrupt.
+
+    The original bug was a transport crash — a corrupt config let a parse error
+    escape the resolver and propagate out of the tool. This pins the wrapper's
+    try/except that converts the resolution failure into a returned
+    CallToolResult, coverage the two parametrized tests above do not reach
+    because they stop at _resolve_store raising.
+    """
+    from mcp.types import CallToolResult
+
+    from nauro.mcp.stdio_server import get_context
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    _write_repo_config_text(repo_root, _CORRUPT_CONFIGS["invalid_json"])
+    monkeypatch.chdir(repo_root)
+
+    result = get_context(project_id=None, cwd=None)
+    assert isinstance(result, CallToolResult)
+    assert len(result.content) == 1
 
 
 # ── integration: two projects coexist post-migration ─────────────────────────


### PR DESCRIPTION
## Why

A corrupt or truncated per-repo `.nauro/config.json` crashed the project resolver. Because resolution runs on the MCP transport path, that crash took down the transport — not just the one command. A schema-mismatch config already degraded gracefully (the resolver caught the typed config error and fell back to the welcome screen); corrupt JSON did not, because `json.loads` raised a bare `JSONDecodeError` that nothing on the resolver path caught. The config file is committed and clone-editable, so corrupt input (a bad merge, a truncated checkout, a hand-edit) is a realistic failure mode rather than a theoretical one.

## Approach

Remap corrupt JSON to the existing typed config-error family at the reader. `load_repo_config` now catches `json.JSONDecodeError` and re-raises it as `RepoConfigSchemaError`, chaining the original via `from exc`, and logs a warning naming the config path so corruption is observable rather than silently swallowed.

This was preferred over adding a second `except json.JSONDecodeError` branch at each call site: that approach scatters the same defensive catch across every consumer and lets the two failure modes (schema-mismatch vs. corruption) drift apart. Remapping at the single reader means the resolver's one existing catch covers both, and the redundant per-caller catches collapse. A warning breadcrumb is added because the graceful fallback is otherwise indistinguishable from "no config present" — corruption should leave a trace.

This follows the established typed-error / graceful-fallback pattern for repo-config reads: surface one typed error family for malformed config and let resolution degrade to the welcome anchor.

## What changed

- **Reader (`store/repo_config.py`):** `load_repo_config` wraps the parse, remaps `JSONDecodeError` to `RepoConfigSchemaError` with a chained cause, and emits a warning naming the path. Docstring `Raises:` updated to drop `JSONDecodeError` and note corrupt JSON now raises `RepoConfigSchemaError`.
- **Resolver (`store/resolution.py`):** no behavior change beyond the new fallback it inherits for free; a comment records that the existing catch now covers both schema-mismatch and corruption.
- **CLI call sites (`cli/utils.py`, `cli/commands/hook.py`):** dropped the now-redundant `json.JSONDecodeError` from their defensive catches; kept `RepoConfigSchemaError` and `OSError` (the reader does not remap `OSError`). Removed the now-unused `import json` from `cli/utils.py`.

## What to review

- The reader remap and chained cause in `load_repo_config` — confirm corrupt input raises the typed error with `__cause__` set to the underlying `JSONDecodeError`.
- That `resolution.py` behavior is unchanged except that corrupt JSON now falls back to the welcome anchor instead of crashing.
- That dropping `json.JSONDecodeError` from the two CLI catches is safe — i.e. the reader fully remaps it, and `OSError` (a distinct failure the reader does not remap) is still caught.

## What's deferred

- A distinct agent-facing "your config is corrupt" message. Corrupt configs currently land on the same welcome screen as the genuine no-project case; a more specific diagnostic is a separate change.
- Corrupt-input handling for `~/.nauro/registry.json` and `~/.nauro/config.json`. Both are already independently guarded; this change is scoped to the per-repo config reader.

## Test plan

`uv run pytest packages/nauro/tests/`: 1150 passed, 10 skipped, no regressions. New tests:
- `test_repo_config.py`: corrupt/truncated config raises `RepoConfigSchemaError` (not a bare `JSONDecodeError`), the chained `__cause__` is a `JSONDecodeError`, and the warning breadcrumb fires naming the path.
- `test_resolution_v2.py`: parametrized over two corrupt shapes (truncated JSON, valid-JSON-wrong-schema) — `resolve_via_repo_config` returns `None` and `_resolve_store(None, None)` raises `NoProjectError` for both, reaching the same outcome. Plus an end-to-end pin that the `get_context` MCP wrapper returns (rather than raising) on a corrupt config — the transport-crash contract the bug actually broke.
