### PR TITLE
Centralize the Auth0 sub sanitizer in nauro-core

### DIFF
--- a/packages/nauro-core/src/nauro_core/__init__.py
+++ b/packages/nauro-core/src/nauro_core/__init__.py
@@ -126,6 +126,9 @@ from nauro_core.decision_model import (
 from nauro_core.decision_model import (
     parse_decision as parse_decision,
 )
+from nauro_core.identity import (
+    sanitize_sub as sanitize_sub,
+)
 from nauro_core.instructions import (
     MAX_INLINE_PROJECTS as MAX_INLINE_PROJECTS,
 )

--- a/packages/nauro-core/src/nauro_core/identity.py
+++ b/packages/nauro-core/src/nauro_core/identity.py
@@ -1,0 +1,31 @@
+"""Identity helpers for deriving per-user storage keys.
+
+Pure, zero-I/O string logic. ``nauro-core`` is compute-only, so this module
+uses only the standard library.
+"""
+
+from __future__ import annotations
+
+import string
+
+_ALLOWED: frozenset[str] = frozenset(string.ascii_letters + string.digits + "_-")
+
+
+def sanitize_sub(sub: str) -> str:
+    """Sanitize an Auth0 ``sub`` claim into a per-user S3 key prefix.
+
+    Contract:
+
+    - Allowed characters are the ASCII class ``A-Z a-z 0-9 _ -``; they pass
+      through unchanged.
+    - Every other character is replaced one-for-one by a single ``-``. Runs are
+      never collapsed: ``"a||b"`` becomes ``"a--b"``, not ``"a-b"``.
+    - The result is truncated to the first 128 characters, applied after
+      substitution.
+
+    This is the single source of truth for deriving the per-user S3 key prefix
+    across every surface that touches the store. The prefix is the storage
+    isolation boundary, so any divergence would route a user's writes and reads
+    to different prefixes. Do not let copies of this logic drift.
+    """
+    return "".join(c if c in _ALLOWED else "-" for c in sub)[:128]

--- a/packages/nauro-core/tests/test_identity.py
+++ b/packages/nauro-core/tests/test_identity.py
@@ -1,0 +1,104 @@
+"""Drift tripwire for ``sanitize_sub``.
+
+These assertions pin the byte-for-byte contract of the per-user S3 key-prefix
+derivation. The prefix is the storage isolation boundary, so any drift here
+would route a user's writes and reads to different prefixes.
+"""
+
+import re
+import string
+
+import pytest
+
+from nauro_core.identity import sanitize_sub
+
+
+def test_allowed_class_round_trips_unchanged():
+    allowed = string.ascii_letters + string.digits + "_-"
+    assert sanitize_sub(allowed) == allowed
+
+
+@pytest.mark.parametrize("sample", ["aZ09", "ABCxyz", "0123456789", "_-_-", "a_b-c"])
+def test_allowed_samples_unchanged(sample):
+    assert sanitize_sub(sample) == sample
+
+
+def test_replacement_is_one_for_one_not_collapsed():
+    assert sanitize_sub("a||b") == "a--b"
+
+
+def test_replacement_uses_single_dash():
+    assert sanitize_sub("user@example.com") == "user-example-com"
+
+
+def test_cap_is_exactly_128_over_limit():
+    assert len(sanitize_sub("x" * 199)) == 128
+
+
+def test_cap_at_boundary():
+    assert len(sanitize_sub("x" * 128)) == 128
+
+
+def test_cap_under_boundary():
+    assert len(sanitize_sub("x" * 127)) == 127
+
+
+def test_real_world_auth0():
+    assert sanitize_sub("auth0|abc123") == "auth0-abc123"
+
+
+def test_real_world_google_oauth2():
+    assert sanitize_sub("google-oauth2|456def") == "google-oauth2-456def"
+
+
+def test_real_world_already_safe_unchanged():
+    assert sanitize_sub("abc-def_123") == "abc-def_123"
+
+
+def test_empty_string():
+    assert sanitize_sub("") == ""
+
+
+def test_adversarial_backslash_path_separator():
+    assert sanitize_sub("auth0\\evil") == "auth0-evil"
+
+
+def test_adversarial_relative_path_traversal():
+    assert sanitize_sub("../../other") == "------other"
+
+
+def test_adversarial_forward_slash():
+    assert sanitize_sub("auth0/evil") == "auth0-evil"
+
+
+def test_adversarial_unicode_each_char_replaced():
+    assert sanitize_sub("café") == "caf-"
+
+
+# Parity tripwire: prove the regex-free rewrite is byte-identical to the
+# original regex over representative and adversarial inputs. The source stays
+# regex-free; only this test references ``re``, to pin parity against the
+# implementation it replaced.
+PARITY_INPUTS = [
+    "",
+    "abc-def_123",
+    "auth0|abc123",
+    "google-oauth2|456def",
+    "user@example.com",
+    "a||b",
+    "auth0\\evil",
+    "../../other",
+    "auth0/evil",
+    "café",
+    "spaces and tabs\there",
+    "emoji \U0001f600 mix",
+    "x" * 199,
+    string.ascii_letters + string.digits + "_-",
+    "MiXeD|cAsE@2026/05::29",
+]
+
+
+@pytest.mark.parametrize("sub", PARITY_INPUTS)
+def test_parity_with_original_regex(sub):
+    expected = re.sub(r"[^a-zA-Z0-9_\-]", "-", sub)[:128]
+    assert sanitize_sub(sub) == expected

--- a/packages/nauro/src/nauro/cli/commands/auth.py
+++ b/packages/nauro/src/nauro/cli/commands/auth.py
@@ -13,7 +13,6 @@ import hashlib
 import json
 import logging
 import os
-import re
 import secrets
 import threading
 import webbrowser
@@ -23,6 +22,7 @@ from urllib.parse import parse_qs, urlencode, urlparse
 
 import httpx
 import typer
+from nauro_core import sanitize_sub
 
 from nauro.store.config import load_config, save_config
 
@@ -181,15 +181,6 @@ def with_token_refresh(call: Callable[[str], httpx.Response]) -> httpx.Response:
     return call(new_token)
 
 
-def _sanitize_sub(sub: str) -> str:
-    """Sanitize an Auth0 ``sub`` claim for use in S3 key paths.
-
-    Must match the server-side logic in ``mcp-server/src/mcp_server/app.py``.
-    """
-    safe = re.sub(r"[^a-zA-Z0-9_\-]", "-", sub)
-    return safe[:128]
-
-
 def _decode_jwt_payload(token: str) -> dict:
     """Base64-decode the JWT payload (no cryptographic verification)."""
     parts = token.split(".")
@@ -346,7 +337,7 @@ def login() -> None:
         typer.echo(f"Failed to decode access token: {exc}", err=True)
         raise typer.Exit(code=1) from exc
 
-    sanitized_sub = _sanitize_sub(sub)
+    sanitized_sub = sanitize_sub(sub)
 
     # Fetch canonical user_id from server
     user_id = None

--- a/packages/nauro/tests/test_auth.py
+++ b/packages/nauro/tests/test_auth.py
@@ -5,13 +5,14 @@ import json
 from unittest.mock import MagicMock, patch
 
 import pytest
+from nauro_core import sanitize_sub
 from typer.testing import CliRunner
 
+from nauro.cli.commands import auth as auth_module
 from nauro.cli.commands.auth import (
     _CallbackHandler,
     _decode_jwt_payload,
     _generate_pkce,
-    _sanitize_sub,
 )
 from nauro.cli.main import app
 from nauro.store.config import load_config, save_config
@@ -27,33 +28,13 @@ def _make_jwt(payload: dict) -> str:
     return f"{header}.{body}.{sig}"
 
 
-# --- _sanitize_sub ---
+# --- sanitize_sub wiring ---
+# Behavior coverage lives in nauro-core's test_identity.py; this only pins that
+# the auth command derives its S3 key prefix from the canonical implementation.
 
 
-class TestSanitizeSub:
-    def test_pipe_replaced(self):
-        assert _sanitize_sub("auth0|abc123") == "auth0-abc123"
-
-    def test_google_oauth2(self):
-        assert _sanitize_sub("google-oauth2|456def") == "google-oauth2-456def"
-
-    def test_already_safe(self):
-        assert _sanitize_sub("abc-def_123") == "abc-def_123"
-
-    def test_truncation_at_128(self):
-        long_sub = "a" * 200
-        assert len(_sanitize_sub(long_sub)) == 128
-
-    def test_special_characters(self):
-        assert _sanitize_sub("user@example.com") == "user-example-com"
-
-    def test_backslash_replaced(self):
-        result = _sanitize_sub("auth0\\evil")
-        assert "\\" not in result
-        assert result == "auth0-evil"
-
-    def test_empty_string(self):
-        assert _sanitize_sub("") == ""
+def test_auth_uses_canonical_sanitize_sub():
+    assert auth_module.sanitize_sub is sanitize_sub
 
 
 # --- _decode_jwt_payload ---


### PR DESCRIPTION
## Why

The Auth0 `sub` sanitizer derives the per-user S3 key prefix — the storage
isolation boundary for a user's store. It was copy-pasted across the public
CLI and the private remote server, kept in sync only by a by-hand "must match"
comment. If the two copies ever diverged, a user's writes and reads would route
to different prefixes silently, with no error surfaced. This project has been
bitten by identity fragmentation before (the same person resolving to different
storage identities), so a duplicated correctness invariant on the isolation
boundary is a standing risk worth removing.

## Approach

Introduce one canonical implementation in nauro-core and have the CLI import it,
rather than maintaining parallel copies. The canonical version is regex-free —
a plain allowed-character-set membership comprehension over the input — which
keeps nauro-core compute-only with no new dependency and matches the codebase
convention of preferring plain string ops over `re`. A parity test pins the
rewrite byte-for-byte against the original regex (`[^a-zA-Z0-9_\-]` → `-`, then
truncate to 128) so the canonical function cannot drift from the behavior it
replaces. The alternative — keeping the copies and adding a cross-repo lint —
was rejected: it would still leave two sources of truth and only detect drift
after it was written.

## What changed

- **nauro-core**: new `identity` module exposing `sanitize_sub`, re-exported
  from the package facade alongside the other public symbols. The docstring
  states the contract (allowed class, one-for-one `-` replacement, 128-char
  cap) and that it is the single source of truth for the per-user key prefix.
- **CLI auth command**: dropped the local sanitizer (and its now-unused `re`
  import) in favor of the nauro-core function at the same call site.
- **Tests**: a new drift tripwire in nauro-core with exact-equality and parity
  assertions; the CLI suite drops its now-redundant behavior matrix and keeps a
  single assertion that the auth command uses the canonical function.

## What to review

- The regex-free rewrite is byte-identical to the original: the allowed class
  is exactly `A-Z a-z 0-9 _ -`, every other character maps to a single `-`
  with no run-collapsing (`a||b` → `a--b`, not `a-b`), and the 128-char cap is
  applied after substitution. The parity test is the strongest guard here.
- The re-export placement and the `import re` removal (confirmed the import had
  no other use in the file).

## What's deferred

- The remote server's copy of this sanitizer (separate private repo) still
  needs to import the canonical function; that swap rides a later batched
  dependency update.
- The kernel id-resolution substitution and a third filesystem-variant copy of
  id-resolution follow in the same later batch.

## Test plan

- nauro-core: 695 passed (34 new in the identity tripwire, 15 of them parity
  cases against the original regex).
- nauro: 1144 passed, 10 skipped.
- `ruff check` and `ruff format --check` clean across `packages/`.
