### PR TITLE
Share the envelope-token rejection reason via nauro-core

### DIFF
--- a/packages/nauro-core/src/nauro_core/validation.py
+++ b/packages/nauro-core/src/nauro_core/validation.py
@@ -209,3 +209,22 @@ def find_envelope_token(text: str) -> str | None:
         if token in text:
             return token
     return None
+
+
+def envelope_token_message(value: str, field_name: str) -> str | None:
+    """Return the rejection reason if *value* carries an envelope fragment, else None.
+
+    Wraps ``find_envelope_token``: on a hit, returns the full reason string
+    naming the offending *field_name* and the detected token; on no hit,
+    returns None. Both MCP transports share this builder so the message agents
+    see does not drift by transport. Pure — no I/O.
+    """
+    token = find_envelope_token(value)
+    if not token:
+        return None
+    return (
+        f"{field_name} contains tool-use envelope fragment {token!r}. "
+        "This usually means the client failed to extract the parameter "
+        "value cleanly from an XML tool call. Resend the call with just "
+        "the prose content."
+    )

--- a/packages/nauro-core/tests/test_validation.py
+++ b/packages/nauro-core/tests/test_validation.py
@@ -2,6 +2,8 @@
 
 from datetime import date
 
+import pytest
+
 from nauro_core.decision_model import (
     Decision,
     DecisionConfidence,
@@ -10,6 +12,7 @@ from nauro_core.decision_model import (
 from nauro_core.validation import (
     check_bm25_similarity,
     compute_hash,
+    envelope_token_message,
     find_envelope_token,
     screen_structural,
 )
@@ -284,3 +287,50 @@ class TestFindEnvelopeToken:
         # rephrase (e.g. "the parameter named 'rationale'") to disambiguate.
         text = "How should we describe the <parameter name='rationale'> field in docs?"
         assert find_envelope_token(text) == "<parameter name="
+
+
+class TestEnvelopeTokenMessage:
+    # Canonical home for the rejection-reason contract. Both MCP transports
+    # build their rejection envelope from this string, so the full wording is
+    # pinned here with exact-equality assertions; the transports only assert
+    # wiring (their per-transport envelope), not the message text.
+    def _expected(self, field_name: str, token: str) -> str:
+        return (
+            f"{field_name} contains tool-use envelope fragment {token!r}. "
+            "This usually means the client failed to extract the parameter "
+            "value cleanly from an XML tool call. Resend the call with just "
+            "the prose content."
+        )
+
+    def test_clean_input_returns_none(self):
+        text = "Should we adopt OpenTelemetry for tracing across the gateway?"
+        assert envelope_token_message(text, "question") is None
+
+    def test_empty_input_returns_none(self):
+        assert envelope_token_message("", "title") is None
+
+    @pytest.mark.parametrize(
+        "value, token",
+        [
+            ("How should we model tenants?</question>", "</question>"),
+            ("Picked Postgres for ACID.</rationale>", "</rationale>"),
+            ("Some context about the choice.</context>", "</context>"),
+            ("value here</parameter>", "</parameter>"),
+            ("trailing junk</invoke>", "</invoke>"),
+            ('leaked <parameter name="context">rest', "<parameter name="),
+            ('wrapper <invoke name="propose_decision">', "<invoke name="),
+        ],
+    )
+    def test_each_token_produces_exact_reason(self, value, token):
+        message = envelope_token_message(value, "rationale")
+        assert message == self._expected("rationale", token)
+
+    def test_field_name_is_interpolated_verbatim(self):
+        message = envelope_token_message("Use Postgres</invoke>", "rejected[0].reason")
+        assert message == self._expected("rejected[0].reason", "</invoke>")
+
+    def test_token_is_repr_quoted_in_message(self):
+        # The {token!r} repr formatting must place the token in quotes so the
+        # offending fragment is unambiguous in the surfaced message.
+        message = envelope_token_message("How should we model tenants?</question>", "question")
+        assert "'</question>'" in message

--- a/packages/nauro/src/nauro/mcp/tools.py
+++ b/packages/nauro/src/nauro/mcp/tools.py
@@ -39,7 +39,11 @@ from nauro_core.protocol import (
     PROPOSE_DECISION_OPERATIONS,
     UPDATE_SUPERSEDE_CARE,
 )
-from nauro_core.validation import check_bm25_similarity, check_content_length, find_envelope_token
+from nauro_core.validation import (
+    check_bm25_similarity,
+    check_content_length,
+    envelope_token_message,
+)
 
 from nauro.onboarding import (
     NO_CONTEXT_YET,
@@ -127,17 +131,11 @@ def _reject_if_envelope_token(value: str, field_name: str) -> dict | None:
     Some non-Anthropic agent surfaces emit tool calls as XML and their MCP
     bridges occasionally fail to extract <parameter> values cleanly, so the
     envelope tail leaks into the string field. Reject before any I/O — see
-    nauro_core.validation.find_envelope_token.
+    nauro_core.validation.envelope_token_message.
     """
-    token = find_envelope_token(value)
-    if not token:
+    reason = envelope_token_message(value, field_name)
+    if not reason:
         return None
-    reason = (
-        f"{field_name} contains tool-use envelope fragment {token!r}. "
-        "This usually means the client failed to extract the parameter "
-        "value cleanly from an XML tool call. Resend the call with just "
-        "the prose content."
-    )
     return {
         "store": "local",
         "status": "rejected",


### PR DESCRIPTION
## Why

The envelope-token rejection reason string — the message agents see when a tool-use XML fragment leaks into a string field — was duplicated across the two MCP transports. Editing one copy would silently drift the message by transport, so an agent would see different wording depending on which transport handled its call. The underlying token detection (`find_envelope_token`) and the length-rejection message (`check_content_length`) are already shared in nauro-core; this closes the last duplicated piece.

## Approach

Extract one pure reason builder, `envelope_token_message(value, field_name)`, into nauro-core, placed beside `find_envelope_token`, which it wraps. It returns the full rejection reason on a hit and `None` otherwise. Each transport keeps its own, intentionally-different rejection envelope (the local CLI builds `store="local"` with no assessment; the remote builds `store="remote"` with an assessment) — only the reason text is shared, consistent with the established rule that these helpers stay transport-generic and nauro-core stays compute-only. The alternative of also sharing the envelope was rejected: the envelopes differ by design and must stay per-transport.

## What changed

- nauro-core `validation.py`: added the pure `envelope_token_message` builder beside the detector it wraps.
- nauro CLI `mcp/tools.py`: `_reject_if_envelope_token` now delegates to the shared builder and keeps building its own local-store envelope; the inline reason f-string is removed and the direct `find_envelope_token` import is narrowed (it had no other use in this file).
- Tests: the full rejection-message contract now lives in nauro-core's `test_validation.py` (exact-string matrix across every token); the CLI test suite continues to assert only its transport wiring.

## What to review

- The extracted message is byte-identical to the prior inline string — same field-name placement, same token repr formatting, same wording and punctuation. The diff of `tools.py` shows the inline block lifted verbatim.
- The CLI rejection envelope is unchanged; only the reason source moved.

## What's deferred

- The remote MCP transport repointing its own rejection helper to the shared builder rides a later batched nauro-core dependency update; its `store="remote"` + assessment envelope stays as-is. Not touched here.
- The propose-decision confidence default and the assessment-field divergence are intentionally out of scope.

## Test plan

- nauro-core: 706 passed (adds the `envelope_token_message` exact-message matrix).
- nauro: 1144 passed, 10 skipped (existing envelope-rejection wiring tests pass unchanged against the delegated builder).
- `ruff check packages/` and `ruff format --check packages/` clean.
