### PR TITLE
Fix CLI hygiene cluster: project-listing precedence, dead status handler, magic numbers, repo_paths dedup

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/status.py
+++ b/packages/nauro/src/nauro/cli/commands/status.py
@@ -60,9 +60,9 @@ def status(
     """Show which Nauro capabilities are active or inactive."""
     try:
         project_name, store_path = resolve_target_project(project)
-    except SystemExit as exc:
+    except typer.Exit as exc:
         typer.echo("No project found. Run 'nauro init <name>' to get started.", err=True)
-        raise typer.Exit(1) from exc
+        raise typer.Exit(exc.exit_code) from exc
 
     typer.echo(f"Project: {project_name}\n")
 

--- a/packages/nauro/src/nauro/cli/commands/sync.py
+++ b/packages/nauro/src/nauro/cli/commands/sync.py
@@ -8,10 +8,8 @@ import typer
 from nauro.cli.commands.auth import load_access_token
 from nauro.cli.utils import resolve_target_project
 from nauro.store.registry import (
-    RegistrySchemaError,
-    get_project_v2,
+    get_repo_paths,
     is_cloud_project,
-    load_registry,
 )
 from nauro.store.snapshot import capture_snapshot
 from nauro.store.validator import print_warnings, validate_store
@@ -23,18 +21,6 @@ logger = logging.getLogger("nauro.sync")
 # Names retained for callers/tests that import the push helper from this
 # command module; the implementation now lives in ``nauro.sync.push``.
 _push_to_cloud = push_store_to_cloud
-
-
-def _registry_repo_paths(project_key: str) -> list[str]:
-    """Return repo paths for ``project_key`` from v2 (preferred) or v1 registry."""
-    try:
-        v2_entry = get_project_v2(project_key)
-    except RegistrySchemaError:
-        v2_entry = None
-    if v2_entry is not None:
-        return list(v2_entry.get("repo_paths", []))
-    registry = load_registry()
-    return list(registry["projects"].get(project_key, {}).get("repo_paths", []))
 
 
 def sync(
@@ -66,7 +52,7 @@ def sync(
 
     version = capture_snapshot(store_path, trigger=trigger)
 
-    for repo_str in _registry_repo_paths(project_key):
+    for repo_str in get_repo_paths(project_key):
         if not Path(repo_str).is_dir():
             typer.echo(
                 f"  Warning: repo path does not exist, skipping AGENTS.md: {repo_str}\n"

--- a/packages/nauro/src/nauro/cli/utils.py
+++ b/packages/nauro/src/nauro/cli/utils.py
@@ -52,6 +52,19 @@ def _v2_registry_or_empty() -> dict:
         return {"projects": {}}
 
 
+def _available_project_names() -> list[str]:
+    """Return the sorted union of v1 and v2 project names, blanks removed.
+
+    The empty-string is subtracted from the *combined* set so a v2 entry
+    missing its ``name`` field cannot leak a blank token into the
+    "Available projects:" listing.
+    """
+    registry = load_registry()
+    v2_names = {e.get("name", "") for e in _v2_registry_or_empty()["projects"].values()}
+    v1_names = set(registry["projects"].keys())
+    return sorted((v1_names | v2_names) - {""})
+
+
 def _resolve_from_repo_config() -> tuple[str, Path] | None:
     """Resolve via ``.nauro/config.json`` walk-up from cwd.
 
@@ -107,10 +120,7 @@ def resolve_target_project(project_flag: str | None) -> tuple[str, Path]:
         if entry is not None:
             return project_flag, get_store_path(project_flag)
 
-        registry = load_registry()
-        v2_names = sorted({e.get("name", "") for e in _v2_registry_or_empty()["projects"].values()})
-        v1_names = sorted(registry["projects"].keys())
-        available = sorted(set(v1_names) | set(v2_names) - {""})
+        available = _available_project_names()
         typer.echo(f"Unknown project '{project_flag}'.", err=True)
         if available:
             typer.echo(f"Available projects: {', '.join(available)}", err=True)
@@ -136,10 +146,7 @@ def resolve_target_project(project_flag: str | None) -> tuple[str, Path]:
         return project_name, get_store_path(project_name)
 
     # 4 — error
-    registry = load_registry()
-    v2_names = sorted({e.get("name", "") for e in _v2_registry_or_empty()["projects"].values()})
-    v1_names = sorted(registry["projects"].keys())
-    available = sorted(set(v1_names) | set(v2_names) - {""})
+    available = _available_project_names()
     typer.echo("No project found for current directory.", err=True)
 
     suggestion = suggest_project_for_path(cwd)

--- a/packages/nauro/src/nauro/constants.py
+++ b/packages/nauro/src/nauro/constants.py
@@ -68,6 +68,12 @@ SKILLS_SECTION_HEADER = "## Skills"
 STALE_SYNC_DAYS = 7
 L0_TOKEN_LIMIT = 3500
 
+# ── flag_question similar-decision hint ──
+# Compared against a raw BM25 score (not a normalized 0-1 similarity); above
+# this the flag is annotated with a hint pointing at the matching decision.
+FLAG_QUESTION_HINT_MIN_SCORE = 0.7
+FLAG_QUESTION_HINT_TITLE_LENGTH = 100
+
 # ── Token heuristic ──
 CHARS_PER_TOKEN = 4  # rough chars-per-token for GPT/Claude family models
 

--- a/packages/nauro/src/nauro/mcp/tools.py
+++ b/packages/nauro/src/nauro/mcp/tools.py
@@ -45,6 +45,10 @@ from nauro_core.validation import (
     envelope_token_message,
 )
 
+from nauro.constants import (
+    FLAG_QUESTION_HINT_MIN_SCORE,
+    FLAG_QUESTION_HINT_TITLE_LENGTH,
+)
 from nauro.onboarding import (
     NO_CONTEXT_YET,
     WELCOME_NO_PROJECT,
@@ -480,14 +484,14 @@ def tool_flag_question(
     hint = None
     if question:
         pseudo_proposal = {
-            "title": question[:100],
+            "title": question[:FLAG_QUESTION_HINT_TITLE_LENGTH],
             "rationale": question + (f" {context}" if context else ""),
         }
         try:
             from nauro.store.reader import _list_decisions
 
             _, similar = check_bm25_similarity(pseudo_proposal, _list_decisions(store_path))
-            if similar and similar[0].get("similarity", 0) > 0.7:
+            if similar and similar[0].get("similarity", 0) > FLAG_QUESTION_HINT_MIN_SCORE:
                 top = similar[0]
                 hint = (
                     f"This question appears to be addressed by "

--- a/packages/nauro/src/nauro/store/registry.py
+++ b/packages/nauro/src/nauro/store/registry.py
@@ -417,6 +417,23 @@ def find_projects_by_name_v2(name: str) -> list[tuple[str, dict]]:
     return out
 
 
+def get_repo_paths(project_key: str) -> list[str]:
+    """Return repo paths for ``project_key`` from v2 (preferred) or v1 registry.
+
+    ``project_key`` is a v2 project_id (ULID) or a v1 project name; v2 takes
+    priority with v1 as the legacy fallback. Returns an empty list when the
+    key is unknown in both schemas.
+    """
+    try:
+        v2_entry = get_project_v2(project_key)
+    except RegistrySchemaError:
+        v2_entry = None
+    if v2_entry is not None:
+        return list(v2_entry.get("repo_paths", []))
+    registry = load_registry()
+    return list(registry["projects"].get(project_key, {}).get("repo_paths", []))
+
+
 def resolve_v2_from_path(path: Path) -> tuple[str, dict] | None:
     """Walk up ``path`` and return (project_id, entry) for the matching v2 project.
 

--- a/packages/nauro/src/nauro/templates/agents_md.py
+++ b/packages/nauro/src/nauro/templates/agents_md.py
@@ -190,10 +190,9 @@ def regenerate_agents_md_for_project(project_key: str, store_path: Path) -> list
     from nauro.store.registry import (
         RegistrySchemaError,
         get_project_v2,
-        load_registry,
+        get_repo_paths,
     )
 
-    repo_paths: list[str] = []
     display_name = project_key
     project_id: str | None = None
 
@@ -202,14 +201,10 @@ def regenerate_agents_md_for_project(project_key: str, store_path: Path) -> list
     except RegistrySchemaError:
         v2_entry = None
     if v2_entry is not None:
-        repo_paths = list(v2_entry.get("repo_paths", []))
         display_name = v2_entry.get("name", project_key)
         project_id = project_key  # v2 registry is id-keyed
-    else:
-        registry = load_registry()
-        entry = registry["projects"].get(project_key, {})
-        repo_paths = list(entry.get("repo_paths", []))
 
+    repo_paths = get_repo_paths(project_key)
     l0_payload = build_l0_payload(store_path)
     updated = []
 

--- a/packages/nauro/src/nauro/templates/agents_md_regen.py
+++ b/packages/nauro/src/nauro/templates/agents_md_regen.py
@@ -12,11 +12,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from pathlib import Path
 
-from nauro.store.registry import (
-    RegistrySchemaError,
-    get_project_v2,
-    load_registry,
-)
+from nauro.store.registry import get_repo_paths
 from nauro.templates.agents_md import regenerate_agents_md_for_project
 
 
@@ -40,22 +36,10 @@ def warn_then_regen(
         regenerated. Mirrors :func:`regenerate_agents_md_for_project` so
         existing CLI surfaces can continue echoing the per-repo line.
     """
-    for repo_str in _registry_repo_paths(project_key):
+    for repo_str in get_repo_paths(project_key):
         if not Path(repo_str).is_dir() and warn is not None:
             warn(
                 f"  Warning: repo path does not exist, skipping AGENTS.md: {repo_str}\n"
                 f"  Fix: remove from registry or update path in ~/.nauro/registry.json"
             )
     return regenerate_agents_md_for_project(project_key, store_path)
-
-
-def _registry_repo_paths(project_key: str) -> list[str]:
-    """Return repo paths for ``project_key`` from v2 (preferred) or v1 registry."""
-    try:
-        v2_entry = get_project_v2(project_key)
-    except RegistrySchemaError:
-        v2_entry = None
-    if v2_entry is not None:
-        return list(v2_entry.get("repo_paths", []))
-    registry = load_registry()
-    return list(registry["projects"].get(project_key, {}).get("repo_paths", []))

--- a/packages/nauro/tests/test_cli_status.py
+++ b/packages/nauro/tests/test_cli_status.py
@@ -32,3 +32,19 @@ def test_status_sync_inactive(tmp_path, monkeypatch):
     result = runner.invoke(app, ["status"])
     assert result.exit_code == 0
     assert "Sync          inactive" in result.output
+
+
+def test_status_no_project_shows_friendly_message(tmp_path, monkeypatch):
+    """No resolvable project surfaces the status-specific guidance with exit 1.
+
+    ``resolve_target_project`` raises ``typer.Exit``, which is not a
+    ``SystemExit`` subclass — the friendly message only reaches the user when
+    the handler catches the right exception type.
+    """
+    isolated = tmp_path / "isolated"
+    isolated.mkdir()
+    monkeypatch.chdir(isolated)
+
+    result = runner.invoke(app, ["status"])
+    assert result.exit_code == 1
+    assert "No project found. Run 'nauro init <name>' to get started." in result.output

--- a/packages/nauro/tests/test_flag_question_hint.py
+++ b/packages/nauro/tests/test_flag_question_hint.py
@@ -1,0 +1,63 @@
+"""Tests for the flag_question similar-decision hint threshold.
+
+The hint fires when the top BM25 match scores above
+``FLAG_QUESTION_HINT_MIN_SCORE`` (a raw BM25 score, not a normalized 0-1
+similarity). These tests pin the threshold behavior and the named constants
+that replaced the previously-inlined literals.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from nauro.constants import (
+    FLAG_QUESTION_HINT_MIN_SCORE,
+    FLAG_QUESTION_HINT_TITLE_LENGTH,
+)
+from nauro.mcp.tools import tool_flag_question
+from nauro.templates.scaffolds import scaffold_project_store
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> Path:
+    store_path = tmp_path / "projects" / "testproj"
+    scaffold_project_store("testproj", store_path)
+    return store_path
+
+
+def test_hint_constants_exist():
+    assert FLAG_QUESTION_HINT_MIN_SCORE == 0.7
+    assert FLAG_QUESTION_HINT_TITLE_LENGTH == 100
+
+
+def _stub_similar(score: float) -> tuple[str, list[dict]]:
+    return (
+        "needs_review",
+        [{"number": 7, "title": "Existing decision", "similarity": score}],
+    )
+
+
+def test_hint_fires_above_threshold(store):
+    """A top score above the threshold annotates the flag with a hint."""
+    above = FLAG_QUESTION_HINT_MIN_SCORE + 0.1
+    with (
+        patch("nauro.mcp.tools.check_bm25_similarity", return_value=_stub_similar(above)),
+        patch("nauro.mcp.tools._try_push"),
+    ):
+        result = tool_flag_question(store, question="Should we cache hot reads?")
+
+    assert "hint" in result
+    assert "decision-007" in result["hint"]
+
+
+def test_hint_absent_below_threshold(store):
+    """A top score at or below the threshold leaves the flag without a hint."""
+    below = FLAG_QUESTION_HINT_MIN_SCORE - 0.1
+    with (
+        patch("nauro.mcp.tools.check_bm25_similarity", return_value=_stub_similar(below)),
+        patch("nauro.mcp.tools._try_push"),
+    ):
+        result = tool_flag_question(store, question="Should we cache hot reads?")
+
+    assert "hint" not in result

--- a/packages/nauro/tests/test_resolution_v2.py
+++ b/packages/nauro/tests/test_resolution_v2.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import json
 
 import pytest
+import typer
 from typer.testing import CliRunner
 
 from nauro.cli.main import app
@@ -257,3 +258,73 @@ def test_two_projects_each_resolve_to_own_store(tmp_path, monkeypatch):
     cfg = load_repo_config(cloud_repo)
     assert cfg["mode"] == "cloud"
     assert cfg["id"] == cloud_pid
+
+
+# ── available-project listing excludes blank tokens ──────────────────────────
+#
+# The listing unions v1 names (registry ``projects`` keys) with v2 names
+# (``name`` field of each v2 entry). A blank token can enter from either side:
+# a v2 entry missing ``name`` resolves to "", and a malformed v1 entry can have
+# a "" key. The old ``set(v1) | set(v2) - {""}`` grouping only stripped the
+# blank from the v2 operand (``-`` binds tighter than ``|``), so a blank on the
+# v1 side leaked into "Available projects:". These tests drive a blank in on
+# the v1 side so they fail against the old grouping and pass against the fix.
+
+
+def _write_registry(tmp_path, schema_version: int, projects: dict) -> None:
+    """Write registry.json with the given schema version and ``projects`` map."""
+    (tmp_path / REGISTRY_FILENAME).write_text(
+        json.dumps({"schema_version": schema_version, "projects": projects}) + "\n"
+    )
+
+
+def test_available_project_names_excludes_blank_from_combined_set(tmp_path, monkeypatch):
+    """A blank entry on the v1 side must not leak into the available list.
+
+    Pins the operator-precedence fix: the blank is subtracted from the
+    *combined* v1 ∪ v2 set, not just the v2 operand.
+    """
+    from nauro.cli.utils import _available_project_names
+
+    _write_registry(
+        tmp_path,
+        1,
+        {
+            "alpha": {"repo_paths": []},
+            "": {"repo_paths": []},  # malformed blank-named v1 entry
+        },
+    )
+    monkeypatch.chdir(tmp_path)
+
+    names = _available_project_names()
+    assert "" not in names
+    assert names == ["alpha"]
+
+
+def test_unknown_project_listing_has_no_blank_token(tmp_path, monkeypatch, capsys):
+    """The ``--project`` error path lists only real names, never a blank.
+
+    A blank-named entry previously leaked an empty token into
+    "Available projects:" because ``-`` bound tighter than ``|``.
+    """
+    _write_registry(
+        tmp_path,
+        1,
+        {
+            "alpha": {"repo_paths": []},
+            "": {"repo_paths": []},  # malformed blank-named v1 entry
+        },
+    )
+    isolated = tmp_path / "isolated"
+    isolated.mkdir()
+    monkeypatch.chdir(isolated)
+
+    with pytest.raises(typer.Exit) as excinfo:
+        resolve_target_project("does-not-exist")
+    assert excinfo.value.exit_code == 1
+
+    err = capsys.readouterr().err
+    listing_line = next(line for line in err.splitlines() if line.startswith("Available projects:"))
+    parsed = [name.strip() for name in listing_line[len("Available projects:") :].split(",")]
+    assert parsed == ["alpha"]
+    assert "" not in parsed


### PR DESCRIPTION
## Why

An audit surfaced a cluster of local CLI hygiene issues — two live defects and two maintainability nits — in the project-resolution, `status`, MCP, and AGENTS.md-regen paths.

The first defect is an operator-precedence bug in the "Available projects:" listing. `sorted(set(v1) | set(v2) - {""})` parses as `set(v1) | (set(v2) - {""})` because `-` binds tighter than `|`, so the blank is only stripped from the v2 operand. A blank token on the v1 side (e.g. a malformed blank-named registry entry) leaks straight into the error output.

The second defect is a dead exception handler in `status`. It caught `SystemExit`, but `resolve_target_project` raises `typer.Exit`, which is not a `SystemExit` subclass — so the friendly "No project found. Run 'nauro init <name>'..." message was unreachable and users saw only the generic resolution error.

The nits: the `flag_question` hint threshold (a raw BM25 score) and its title slice were inline magic numbers, and the v2-then-v1 `repo_paths` lookup was copy-pasted in three places.

## Approach

Fix the precedence bug once, in a shared `_available_project_names()` helper that subtracts the blank from the parenthesized combined set, and call it from both error paths. Make the friendly `status` message reachable by catching `typer.Exit` (and re-raising while preserving the exit code) instead of the wrong exception type. Hoist the BM25 hint literals to named constants in `constants.py`, alongside the existing CLI thresholds. Collapse the three `repo_paths` copies into one `get_repo_paths` helper.

For the helper's home, `store/registry.py` is the natural fit: it already houses every v2/v1 registry read helper, and all three call sites (`cli/commands/sync.py`, `templates/agents_md.py`, `templates/agents_md_regen.py`) can import it without an import cycle. Placing it in `templates/` or `cli/` would have risked one.

## What changed

- `cli/utils.py` — new `_available_project_names()`; both error paths route through it.
- `cli/commands/status.py` — handler catches `typer.Exit`, re-raises preserving the code.
- `constants.py` — adds `FLAG_QUESTION_HINT_MIN_SCORE` and `FLAG_QUESTION_HINT_TITLE_LENGTH`.
- `mcp/tools.py` — `flag_question` uses the two new constants.
- `store/registry.py` — new `get_repo_paths()` helper.
- `cli/commands/sync.py`, `templates/agents_md.py`, `templates/agents_md_regen.py` — two duplicate `_registry_repo_paths` copies deleted, all three callers use `get_repo_paths`.

## What to review

- The precedence fix and its regression test. The test drives a blank in on the v1 side of the union, which is the side the old grouping failed to strip; it fails against the old code and passes against the fix.
- The home chosen for `get_repo_paths` — confirm no import cycle. `registry.py` imports only `nauro.constants` and `nauro.store.repo_config`, so the three consumers import it cleanly.
- `templates/agents_md.py` still derives `display_name`/`project_id` from its own `get_project_v2` call (those are not part of the deduplicated shape) and uses `get_repo_paths` only for the path list — output-identical.

## What's deferred

Deliberately excluded to keep this a hygiene PR rather than a refactor:
- The `setup.py` v2-then-v1 entry+guard cluster (three sites): it has a different return shape (full entry plus an exit guard), so collapsing it means a new helper and editing three command bodies — a refactor.
- Other audit theme items: god-function splits, private-name reach-across, inline-import cleanup, broad-except narrowing, and OAuth/JWT idiom tidy-ups.

## Test plan

1150 existing + 5 new tests pass (`uv run pytest packages/nauro/tests/`), 10 skipped. New tests: two pinning the precedence fix (a direct unit test of `_available_project_names()` and an end-to-end check that the listing carries no blank token), one pinning the now-reachable `status` message with an exact exit code of 1, and two pinning the `flag_question` hint firing above the threshold and staying absent below it. `ruff check` and `ruff format --check` are clean across `packages/`.
