### PR TITLE
Extract a shared atomic JSON-write helper for the registry and config files

### DIFF
--- a/packages/nauro/src/nauro/store/_atomic.py
+++ b/packages/nauro/src/nauro/store/_atomic.py
@@ -1,0 +1,34 @@
+"""Atomic text-write primitive for control-plane JSON files.
+
+The single tmp-write-then-``os.replace`` primitive used by the control-plane
+JSON writers (``registry.json``, ``config.json``, per-repo ``config.json``).
+Durability scope is atomic-replace only: the rename is atomic on a single
+filesystem, so a reader never observes a partially written target. There is
+deliberately no ``fsync`` — that matches every existing call site, and
+crash-durability is an explicit non-goal here.
+"""
+
+import os
+from pathlib import Path
+
+
+def atomic_write_text(path: Path, text: str, *, mode: int | None = None) -> None:
+    """Write ``text`` to ``path`` atomically via a tmp sibling and ``os.replace``.
+
+    Creates the parent directory if needed, writes to a ``.tmp`` sibling,
+    optionally chmods that tmp file, then atomically renames it over ``path``.
+    The chmod is applied to the tmp file before the rename so the target is
+    never momentarily readable at a wider mode.
+
+    Args:
+        path: Destination file path.
+        text: Full file contents to write.
+        mode: When set, the permission bits applied to the file (e.g. ``0o600``
+            for owner-only). When None, the file keeps the default umask mode.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(text)
+    if mode is not None:
+        os.chmod(tmp, mode)
+    os.replace(tmp, path)

--- a/packages/nauro/src/nauro/store/config.py
+++ b/packages/nauro/src/nauro/store/config.py
@@ -18,6 +18,7 @@ from nauro.constants import (
     NAURO_HOME_ENV,
     NAURO_TELEMETRY_ENV,
 )
+from nauro.store._atomic import atomic_write_text
 
 logger = logging.getLogger("nauro.config")
 
@@ -46,11 +47,7 @@ def load_config() -> dict:
 def save_config(data: dict) -> None:
     """Write config.json atomically (write-to-tmp + rename). Restricts to owner-only (0o600)."""
     cf = _config_file()
-    cf.parent.mkdir(parents=True, exist_ok=True)
-    tmp = cf.with_suffix(".tmp")
-    tmp.write_text(json.dumps(data, indent=2) + "\n")
-    os.chmod(tmp, 0o600)
-    os.replace(tmp, cf)
+    atomic_write_text(cf, json.dumps(data, indent=2) + "\n", mode=0o600)
 
 
 def get_config(key: str) -> str | None:

--- a/packages/nauro/src/nauro/store/registry.py
+++ b/packages/nauro/src/nauro/store/registry.py
@@ -40,6 +40,7 @@ from nauro.constants import (
     REPO_CONFIG_MODE_LOCAL,
     SCHEMA_VERSION,
 )
+from nauro.store._atomic import atomic_write_text
 from nauro.store.repo_config import generate_ulid
 
 logger = logging.getLogger("nauro.registry")
@@ -96,10 +97,7 @@ def save_registry(data: dict) -> None:
     """
     data.setdefault("schema_version", SCHEMA_VERSION)
     rf = _registry_file()
-    rf.parent.mkdir(parents=True, exist_ok=True)
-    tmp = rf.with_suffix(".tmp")
-    tmp.write_text(json.dumps(data, indent=2) + "\n")
-    os.replace(tmp, rf)
+    atomic_write_text(rf, json.dumps(data, indent=2) + "\n")
 
 
 # ── v2 registry (id-keyed) ───────────────────────────────────────────────────
@@ -166,10 +164,7 @@ def save_registry_v2(data: dict) -> None:
             f"{data['schema_version']!r}; expected {REGISTRY_SCHEMA_VERSION_V2}."
         )
     rf = _registry_file()
-    rf.parent.mkdir(parents=True, exist_ok=True)
-    tmp = rf.with_suffix(".tmp")
-    tmp.write_text(json.dumps(data, indent=2) + "\n")
-    os.replace(tmp, rf)
+    atomic_write_text(rf, json.dumps(data, indent=2) + "\n")
 
 
 def get_store_path(name: str) -> Path:

--- a/packages/nauro/src/nauro/store/repo_config.py
+++ b/packages/nauro/src/nauro/store/repo_config.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import secrets
 import time
 from pathlib import Path
@@ -29,6 +28,7 @@ from nauro.constants import (
     REPO_CONFIG_MODE_LOCAL,
     REPO_CONFIG_SCHEMA_VERSION,
 )
+from nauro.store._atomic import atomic_write_text
 
 logger = logging.getLogger("nauro.repo_config")
 
@@ -124,10 +124,7 @@ def save_repo_config(repo_root: Path, data: dict) -> Path:
     _validate(data)
 
     path = repo_config_path(repo_root)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_suffix(".tmp")
-    tmp.write_text(json.dumps(data, indent=2) + "\n")
-    os.replace(tmp, path)
+    atomic_write_text(path, json.dumps(data, indent=2) + "\n")
     return path
 
 

--- a/packages/nauro/tests/test_atomic.py
+++ b/packages/nauro/tests/test_atomic.py
@@ -1,0 +1,50 @@
+"""Tests for the atomic text-write primitive in ``nauro.store._atomic``."""
+
+import pytest
+
+from nauro.store import _atomic
+from nauro.store._atomic import atomic_write_text
+
+
+def test_round_trip_exact_bytes(tmp_path):
+    p = tmp_path / "out.json"
+    atomic_write_text(p, "abc\n")
+    assert p.read_text() == "abc\n"
+
+
+def test_replace_overwrites_existing_and_removes_tmp(tmp_path):
+    p = tmp_path / "out.json"
+    p.write_text("old\n")
+    atomic_write_text(p, "new\n")
+    assert p.read_text() == "new\n"
+    assert not p.with_suffix(".tmp").exists()
+
+
+def test_mode_0o600_applied(tmp_path):
+    p = tmp_path / "secret.json"
+    atomic_write_text(p, "{}\n", mode=0o600)
+    assert oct(p.stat().st_mode & 0o777) == "0o600"
+
+
+def test_mode_none_does_not_force_0o600(tmp_path):
+    p = tmp_path / "open.json"
+    atomic_write_text(p, "{}\n")
+    assert p.stat().st_mode & 0o777 != 0o600
+
+
+def test_creates_missing_parent_dirs(tmp_path):
+    p = tmp_path / "nested" / "deeper" / "out.json"
+    atomic_write_text(p, "data\n")
+    assert p.read_text() == "data\n"
+
+
+def test_target_untouched_when_replace_fails(tmp_path, monkeypatch):
+    p = tmp_path / "out.json"
+
+    def boom(src, dst):
+        raise OSError("replace failed")
+
+    monkeypatch.setattr(_atomic.os, "replace", boom)
+    with pytest.raises(OSError, match="replace failed"):
+        atomic_write_text(p, "new\n")
+    assert not p.exists()


### PR DESCRIPTION
## Why

The atomic-write idiom — write to a `.tmp` sibling, then `os.replace` over the
target — was duplicated across four control-plane JSON writers: `save_registry`,
`save_registry_v2`, `save_config`, and `save_repo_config`. A future durability
or permission change would have had to be made in four places. Worse,
`config.json`'s owner-only `0o600` chmod (which protects the stored API key /
auth token) sat in only one of the four copies, reading like an accidental
divergence rather than a deliberate security choice.

## Approach

Extract a single primitive, `atomic_write_text(path, text, *, mode=None)`, into
`store/_atomic.py`. The call sites keep their own `json.dumps(...)` so the
on-disk byte output stays visibly owned at each writer and is provably
unchanged. `config.py` now passes `mode=0o600` explicitly, turning the
permission divergence into an intentional, documented argument instead of
copy-paste drift; the other three writers pass no mode and keep default
permissions.

Rejected alternatives:
- An `atomic_write_json` variant that owned serialization too — it would bury
  the `indent=2` + trailing-newline contract inside the helper and make the
  per-file byte output harder to audit.
- Folding this into `filesystem_store.py` — that module writes store *content*
  under a different `FileLock` discipline; these are control-plane metadata
  files with no shared locking, so the abstractions don't belong together.

Durability scope is deliberately unchanged: atomic same-filesystem replace, no
`fsync`. That matches every prior call site.

## What changed

- New `store/_atomic.py` with `atomic_write_text` (parent-dir creation, tmp
  write, optional chmod-before-replace, atomic rename).
- `registry.py`, `config.py`, `repo_config.py` call the helper instead of
  inlining the idiom. `repo_config.py` keeps its pre-write `_validate(data)`
  call; `config.py` keeps `mode=0o600`.
- `import os` removed from `repo_config.py` (newly unused); retained where
  `os.environ` is still read.

## What to review

- That `config.json` still lands at `0o600` and the other three files are
  byte-identical to before (same `indent=2`, same trailing newline, no
  `sort_keys`).
- The chmod-before-replace ordering in the helper — the tmp file is restricted
  before it becomes the target, so the destination is never briefly world/group
  readable.
- The no-`fsync` durability scope is preserved, not silently introduced.

## What's deferred

- `fsync` / crash-durability — out of scope; explicit non-goal here.
- Whether `registry.json` / repo-config should also be `0o600` — a security
  question to weigh separately, not bundled into a behavior-preserving refactor.

## Test plan

New `tests/test_atomic.py` (6 tests): exact-byte round-trip, replace semantics
with tmp-sibling cleanup, `mode=0o600` applied, `mode=None` does not force
`0o600`, nested-parent creation, and target-untouched-on-replace-failure
(monkeypatched `os.replace`). Full nauro suite: 1156 passed, 10 skipped. The
two `0o600` permission pins (config-permission test in `test_auth.py`,
`test_telemetry_config.py`) pass unchanged. `ruff check` and
`ruff format --check` clean.
