### PR TITLE
Serialize config.json read-modify-write with a file lock

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/auth.py
+++ b/packages/nauro/src/nauro/cli/commands/auth.py
@@ -24,7 +24,7 @@ import httpx
 import typer
 from nauro_core import sanitize_sub
 
-from nauro.store.config import load_config, save_config
+from nauro.store.config import config_transaction, load_config
 
 logger = logging.getLogger("nauro.auth")
 
@@ -151,12 +151,20 @@ def refresh_access_token() -> str:
     if not isinstance(new_access_token, str) or not new_access_token:
         raise AuthRefreshError("Auth0 refresh response did not include an access_token.")
 
-    auth["access_token"] = new_access_token
     rotated_refresh = body.get("refresh_token")
-    if isinstance(rotated_refresh, str) and rotated_refresh:
-        auth["refresh_token"] = rotated_refresh
-    config["auth"] = auth
-    save_config(config)
+
+    # The transaction is entered only after a successful exchange, so a failed
+    # refresh never reaches a save and stored tokens stay intact. The auth
+    # section is reloaded fresh under the lock so a concurrent login isn't
+    # clobbered — only the token fields are updated.
+    with config_transaction() as config:
+        auth = config.get("auth")
+        if not isinstance(auth, dict):
+            auth = {}
+        auth["access_token"] = new_access_token
+        if isinstance(rotated_refresh, str) and rotated_refresh:
+            auth["refresh_token"] = rotated_refresh
+        config["auth"] = auth
 
     return new_access_token
 
@@ -360,15 +368,14 @@ def login() -> None:
         )
 
     # Persist to config
-    config = load_config()
-    config["auth"] = {
-        "sub": sub,
-        "sanitized_sub": sanitized_sub,
-        "user_id": user_id,
-        "access_token": access_token,
-        "refresh_token": refresh_token,
-    }
-    save_config(config)
+    with config_transaction() as config:
+        config["auth"] = {
+            "sub": sub,
+            "sanitized_sub": sanitized_sub,
+            "user_id": user_id,
+            "access_token": access_token,
+            "refresh_token": refresh_token,
+        }
 
     # Telemetry identity merge: auth state is already persisted above —
     # this block only handles the PostHog alias+set. Raw email never leaves
@@ -433,9 +440,12 @@ def logout() -> None:
         typer.echo("Not authenticated — nothing to clear.")
         return
 
-    # Rotate the telemetry anonymous_id at logout (preserves consent).
-    # identify_logout only touches the telemetry section, so call ordering
-    # with del config["auth"] is independent for correctness.
+    # Two sequential standalone transactions, never nested: the config lock is
+    # not re-entrant, so identify_logout (which opens its own rotation
+    # transaction) must run outside the auth-removal transaction. The two writes
+    # touch disjoint keys (telemetry.anonymous_id vs auth), so ordering is
+    # correctness-neutral; rotate first to preserve the documented
+    # "auth cleared after rotation" sequence.
     try:
         from nauro.telemetry import identify_logout as _telemetry_identify_logout
 
@@ -443,6 +453,6 @@ def logout() -> None:
     except Exception:
         logger.debug("telemetry identify_logout failed", exc_info=True)
 
-    del config["auth"]
-    save_config(config)
+    with config_transaction() as config:
+        config.pop("auth", None)
     typer.echo("Logged out. Auth credentials removed from config.")

--- a/packages/nauro/src/nauro/cli/commands/telemetry.py
+++ b/packages/nauro/src/nauro/cli/commands/telemetry.py
@@ -13,7 +13,7 @@ from datetime import datetime, timezone
 import typer
 
 from nauro.constants import NAURO_TELEMETRY_ENV, TELEMETRY_CONSENT_VERSION
-from nauro.store.config import get_telemetry_config, load_config, save_config
+from nauro.store.config import config_transaction, get_telemetry_config, load_config
 from nauro.telemetry import _rotate_anonymous_id
 
 telemetry_app = typer.Typer(
@@ -54,13 +54,12 @@ def status() -> None:
 
 
 def _persist_enabled(enabled: bool) -> None:
-    data = load_config()
-    section = data.get("telemetry") or {}
-    section["enabled"] = enabled
-    section["consent_version"] = TELEMETRY_CONSENT_VERSION
-    section["consented_at"] = datetime.now(timezone.utc).isoformat()
-    data["telemetry"] = section
-    save_config(data)
+    with config_transaction() as data:
+        section = data.get("telemetry") or {}
+        section["enabled"] = enabled
+        section["consent_version"] = TELEMETRY_CONSENT_VERSION
+        section["consented_at"] = datetime.now(timezone.utc).isoformat()
+        data["telemetry"] = section
 
 
 @telemetry_app.command()

--- a/packages/nauro/src/nauro/store/config.py
+++ b/packages/nauro/src/nauro/store/config.py
@@ -8,8 +8,11 @@ import json
 import logging
 import os
 import uuid
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
+
+from filelock import FileLock
 
 from nauro.constants import (
     CONFIG_FILENAME,
@@ -30,6 +33,34 @@ _EMBEDDINGS_CONFIG_KEY = "search.embeddings"
 def _config_file() -> Path:
     nauro_home = Path(os.environ.get(NAURO_HOME_ENV, Path.home() / DEFAULT_NAURO_HOME))
     return nauro_home / CONFIG_FILENAME
+
+
+@contextmanager
+def _config_lock():
+    """Exclusive file lock on config.json for atomic read-modify-write.
+
+    Mirrors ``registry._registry_lock``. The lock is NOT re-entrant — callers
+    must never open a ``config_transaction`` inside another, or it deadlocks.
+    """
+    lock_path = _config_file().with_suffix(".lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with FileLock(str(lock_path)):
+        yield
+
+
+@contextmanager
+def config_transaction():
+    """Lock, reload fresh, yield the working dict, then persist on clean exit.
+
+    Binding the lock to a reload-and-save means a holder can never operate on a
+    stale snapshot. A body that raises skips ``save_config`` entirely, leaving
+    the file untouched. The lock is not re-entrant: a body must not open a
+    second ``config_transaction`` (sequence the writes instead).
+    """
+    with _config_lock():
+        data = load_config()
+        yield data
+        save_config(data)
 
 
 def load_config() -> dict:
@@ -57,18 +88,23 @@ def get_config(key: str) -> str | None:
 
 def set_config(key: str, value: str) -> None:
     """Set a single config value."""
-    data = load_config()
-    data[key] = value
-    save_config(data)
+    with config_transaction() as data:
+        data[key] = value
 
 
 def unset_config(key: str) -> bool:
-    """Remove a config key. Returns True if the key existed."""
-    data = load_config()
-    if key not in data:
-        return False
-    del data[key]
-    save_config(data)
+    """Remove a config key. Returns True if the key existed.
+
+    Uses the lock primitive directly rather than ``config_transaction`` so the
+    missing-key path can return without rewriting the file, mirroring
+    ``registry.remove_repo``.
+    """
+    with _config_lock():
+        data = load_config()
+        if key not in data:
+            return False
+        del data[key]
+        save_config(data)
     return True
 
 
@@ -119,13 +155,21 @@ def get_telemetry_config() -> TelemetryConfig:
     if not anonymous_id:
         # anonymous_id is generated and persisted before consent so the
         # consent record can attach to a stable identity that already exists.
+        # The write goes through config_transaction so the persisted dict is
+        # reloaded fresh under the lock rather than the snapshot read above.
         anonymous_id = str(uuid.uuid4())
-        section["anonymous_id"] = anonymous_id
-        section.setdefault("enabled", None)
-        section.setdefault("consent_version", None)
-        section.setdefault("consented_at", None)
-        data[_TELEMETRY_KEY] = section
-        save_config(data)
+        with config_transaction() as fresh:
+            fresh_section = fresh.get(_TELEMETRY_KEY) or {}
+            if fresh_section.get("anonymous_id"):
+                # A concurrent caller already minted one; adopt it.
+                anonymous_id = fresh_section["anonymous_id"]
+            else:
+                fresh_section["anonymous_id"] = anonymous_id
+                fresh_section.setdefault("enabled", None)
+                fresh_section.setdefault("consent_version", None)
+                fresh_section.setdefault("consented_at", None)
+                fresh[_TELEMETRY_KEY] = fresh_section
+            section = fresh_section
 
     enabled = section.get("enabled")
     if os.environ.get(NAURO_TELEMETRY_ENV) == "0":

--- a/packages/nauro/src/nauro/telemetry/__init__.py
+++ b/packages/nauro/src/nauro/telemetry/__init__.py
@@ -13,7 +13,7 @@ import uuid
 from typing import Any
 
 from nauro.constants import NAURO_TELEMETRY_ENV
-from nauro.store.config import get_telemetry_config, load_config, save_config
+from nauro.store.config import config_transaction, get_telemetry_config, load_config
 from nauro.telemetry.client import _resolve_project_key, get_client
 
 logger = logging.getLogger("nauro.telemetry")
@@ -78,11 +78,10 @@ def _rotate_anonymous_id() -> str:
     new id via _get_distinct_id() without any SDK reset.
     """
     new_id = str(uuid.uuid4())
-    data = load_config()
-    section = data.get("telemetry") or {}
-    section["anonymous_id"] = new_id
-    data["telemetry"] = section
-    save_config(data)
+    with config_transaction() as data:
+        section = data.get("telemetry") or {}
+        section["anonymous_id"] = new_id
+        data["telemetry"] = section
     return new_id
 
 

--- a/packages/nauro/src/nauro/telemetry/consent.py
+++ b/packages/nauro/src/nauro/telemetry/consent.py
@@ -13,7 +13,7 @@ import sys
 from datetime import datetime, timezone
 
 from nauro.constants import NAURO_TELEMETRY_ENV, TELEMETRY_CONSENT_VERSION
-from nauro.store.config import get_telemetry_config, load_config, save_config
+from nauro.store.config import config_transaction, get_telemetry_config
 
 PRIVACY_URL = "https://github.com/Nauro-AI/nauro/blob/main/packages/nauro/PRIVACY.md"
 PROMPT_TEXT = f"Help improve Nauro? Anonymous usage data only. See {PRIVACY_URL}"
@@ -23,13 +23,12 @@ REPROMPT_PREFACE = (
 
 
 def _persist(enabled: bool) -> None:
-    data = load_config()
-    section = data.get("telemetry") or {}
-    section["enabled"] = enabled
-    section["consent_version"] = TELEMETRY_CONSENT_VERSION
-    section["consented_at"] = datetime.now(timezone.utc).isoformat()
-    data["telemetry"] = section
-    save_config(data)
+    with config_transaction() as data:
+        section = data.get("telemetry") or {}
+        section["enabled"] = enabled
+        section["consent_version"] = TELEMETRY_CONSENT_VERSION
+        section["consented_at"] = datetime.now(timezone.utc).isoformat()
+        data["telemetry"] = section
 
 
 def _parse_answer(raw: str, default_yes: bool) -> bool:

--- a/packages/nauro/tests/test_config_lock.py
+++ b/packages/nauro/tests/test_config_lock.py
@@ -1,0 +1,128 @@
+"""Serialization guarantees for config.json read-modify-write.
+
+config.json holds the auth token and the telemetry identity. Concurrent
+token refresh racing a manual auth/logout, or the single-threaded
+logout -> telemetry-rotation path, could previously lose a write. These
+tests pin the contract of ``config_transaction``: it holds an exclusive
+file lock, reloads fresh inside the lock, and persists only on clean exit.
+All assertions are deterministic — no sleep-racing.
+"""
+
+from __future__ import annotations
+
+import pytest
+from filelock import FileLock, Timeout
+
+from nauro.store.config import (
+    _config_file,
+    config_transaction,
+    load_config,
+    save_config,
+)
+
+
+def _lock_path():
+    return _config_file().with_suffix(".lock")
+
+
+def test_lock_is_held_during_body_and_released_after(tmp_path):
+    """The config lock is present and held inside the body, released on exit."""
+    seen_locked = False
+    with config_transaction():
+        # A fresh FileLock instance cannot acquire while the body holds the lock.
+        contender = FileLock(str(_lock_path()))
+        try:
+            contender.acquire(timeout=0.2)
+        except Timeout:
+            seen_locked = True
+        else:
+            contender.release()
+    assert seen_locked, "lock was not held during the transaction body"
+
+    # After exit, a fresh instance acquires immediately.
+    after = FileLock(str(_lock_path()))
+    after.acquire(timeout=0.2)
+    assert after.is_locked
+    after.release()
+
+
+def test_sequential_transactions_each_reload_fresh(tmp_path):
+    """Two transactions mutating different keys both survive — no stale overwrite."""
+    with config_transaction() as data:
+        data["auth"] = {"access_token": "tok"}
+
+    with config_transaction() as data:
+        section = data.get("telemetry") or {}
+        section["enabled"] = True
+        data["telemetry"] = section
+
+    final = load_config()
+    assert final["auth"] == {"access_token": "tok"}
+    assert final["telemetry"]["enabled"] is True
+
+
+def test_logout_sequence_preserves_rotation_and_removes_auth(tmp_path):
+    """Regression pin for the logout clobber.
+
+    logout runs two sequential standalone transactions: rotate
+    ``telemetry.anonymous_id`` first, then remove ``auth``. Because each reloads
+    fresh inside the lock, the auth-removal transaction does not re-persist a
+    pre-rotation snapshot — the rotated id survives and auth is gone.
+    """
+    save_config(
+        {
+            "auth": {"access_token": "tok"},
+            "telemetry": {"anonymous_id": "old-id", "enabled": True},
+        }
+    )
+
+    # Transaction 1: rotate the anonymous_id.
+    with config_transaction() as data:
+        section = data.get("telemetry") or {}
+        section["anonymous_id"] = "new-id"
+        data["telemetry"] = section
+
+    # Transaction 2: remove auth (reloads fresh, so it sees the rotated id).
+    with config_transaction() as data:
+        data.pop("auth", None)
+
+    final = load_config()
+    assert "auth" not in final, "auth survived the removal transaction"
+    assert final["telemetry"]["anonymous_id"] == "new-id", "rotated id was clobbered"
+    assert final["telemetry"]["enabled"] is True
+
+
+def test_second_acquirer_blocks_until_release(tmp_path):
+    """A separate lock instance times out while a transaction holds the lock."""
+    with config_transaction():
+        contender = FileLock(str(_lock_path()))
+        with pytest.raises(Timeout):
+            contender.acquire(timeout=0.2)
+
+    # Once the transaction has exited, the same contender acquires.
+    contender = FileLock(str(_lock_path()))
+    contender.acquire(timeout=0.2)
+    assert contender.is_locked
+    contender.release()
+
+
+def test_transaction_preserves_owner_only_permissions(tmp_path):
+    """A transaction write keeps config.json at 0o600."""
+    with config_transaction() as data:
+        data["auth"] = {"access_token": "tok"}
+
+    config_path = _config_file()
+    assert oct(config_path.stat().st_mode & 0o777) == "0o600"
+
+
+def test_failed_body_leaves_disk_unchanged(tmp_path):
+    """A body that raises skips the save — the file is byte-identical."""
+    save_config({"auth": {"access_token": "tok"}})
+    before = _config_file().read_bytes()
+
+    with pytest.raises(RuntimeError):
+        with config_transaction() as data:
+            data["auth"] = {"access_token": "mutated"}
+            raise RuntimeError("boom")
+
+    assert _config_file().read_bytes() == before


### PR DESCRIPTION
## Why

`config.json` holds the auth token and the telemetry identity, but its read-modify-write was unguarded — while `registry.json` already serialized its RMW behind a file lock. Two concrete failures fall out of that gap:

- A background token refresh racing a manual `auth login`/`logout` can lose a freshly rotated token, forcing the user to re-authenticate.
- A single-threaded `logout` clobbered the just-rotated telemetry `anonymous_id`: `logout` loaded config, `identify_logout()` did its own write to rotate the id, then `logout` saved its stale pre-rotation snapshot back over it.

## Approach

Add `config_transaction()` — an exclusive file lock bound to a reload-and-save, so a holder can never persist a stale snapshot. The lock binds reload + save together, so it can't be held without reloading and saving. This mirrors the existing `registry._registry_lock`: a fresh `FileLock` per call, reload fresh inside the lock, save only on clean exit (a raised body leaves the file untouched). Reads stay unlocked, matching the registry.

The lock is deliberately not re-entrant. The only path that wrote config twice in one logical operation was `logout` (remove auth + rotate the telemetry id), so `logout` now runs two sequential standalone transactions on disjoint keys (`telemetry.anonymous_id` vs `auth`) rather than nesting — rotate first to preserve the documented "auth cleared after rotation" order. Because each transaction reloads fresh, the auth-removal write sees the rotated id and does not clobber it.

Rejected: a per-mutator lock (sprawl, easy to forget at a new call site) and a bare lock the caller acquires manually (forgettable, doesn't enforce reload-fresh). Also rejected a re-entrant/cached-lock design — it would defend a multi-thread-same-process config write that does not occur (the only background thread is the OAuth callback server, which writes no config; telemetry is synchronous), while adding a lock-cache and thread-local stack as latent complexity.

## What changed

- **`store/config.py`** — new `config_transaction()` + `_config_lock()` mirroring the registry lock; routed `set_config`, `unset_config`, and `get_telemetry_config`'s first-run persist through the lock. Read-only paths (`load_config`, `get_config`, `resolve_embeddings_flag`) stay unlocked.
- **`cli/commands/auth.py`** — `refresh_access_token`, `login`, and `logout` persist via `config_transaction()`. `logout` rotates the telemetry id and removes `auth` as two sequential transactions. The refresh transaction is entered only after a successful exchange, so a failed refresh leaves tokens intact.
- **`telemetry/__init__.py`, `telemetry/consent.py`, `cli/commands/telemetry.py`** — the `_rotate_anonymous_id`, `_persist`, and `_persist_enabled` writes go through the transaction. Each is a standalone leaf writer; none nests inside another transaction.

## What to review

- That no `config_transaction()` body opens another (the lock is not re-entrant; a nest would deadlock). The logout de-nesting is the one spot this mattered — confirm rotation and auth-removal run as two separate transactions.
- The `logout` clobber fix — `test_logout_sequence_preserves_rotation_and_removes_auth` pins that the final on-disk state has `auth` removed AND the rotated `anonymous_id` preserved.
- That reads remain unlocked (matching the registry).

## What's deferred

- Per-repo `.nauro/config.json` RMW (holds no credentials, low contention).
- `fsync`/crash-durability of the config write (separate concern from concurrent-write serialization).

## Test plan

New `test_config_lock.py` (6 tests): lock-held-during-body, sequential-no-lost-update, logout-sequence-preserves-rotation, second-acquirer-blocks (deterministic `filelock.Timeout`), `0o600` preserved, failed-body-leaves-disk-unchanged. Full `packages/nauro/tests/` 1156 passed / 10 skipped (no deadlock); `packages/nauro-core/tests/` 706 passed; ruff check + format clean.
