### PR TITLE
De-duplicate cross-surface test scaffolding into conftest

### DIFF
--- a/packages/nauro/tests/conftest.py
+++ b/packages/nauro/tests/conftest.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
@@ -11,6 +13,41 @@ import pytest
 # Magic UUID4 used by every telemetry test that seeds a consented config.
 # Centralized so a rotation in one file can't drift away from the rest.
 TEST_ANONYMOUS_ID = "11111111-1111-4111-8111-111111111111"
+
+# Fixed identity used by every cross-surface parity test to seed both the
+# FilesystemStore and the CloudStore. Centralized so a change in one file
+# can't drift away from the rest.
+CROSS_SURFACE_USER_ID = "01TEST" + "0" * 20
+CROSS_SURFACE_PROJECT_ID = "01TESTPROJECT00000000000"
+
+# Shared moto bucket for cross-surface tests. Each fixture runs inside its
+# own ``mock_aws()`` context, so the name only needs to be stable, not unique.
+CROSS_SURFACE_BUCKET = "nauro-cross-surface-test"
+
+
+def cloud_prefix(user_id: str, project_id: str) -> str:
+    """Return the S3 key prefix a CloudStore reads/writes under for a project."""
+    return f"users/{user_id}/projects/{project_id}"
+
+
+@contextmanager
+def moto_s3_bucket(monkeypatch, *, bucket: str = CROSS_SURFACE_BUCKET) -> Iterator[Any]:
+    """Stand up a moto-mocked S3 bucket and point ``NAURO_S3_BUCKET`` at it.
+
+    Yields the boto3 ``s3`` client so callers can seed objects before
+    constructing a CloudStore (which reads ``NAURO_S3_BUCKET`` lazily). boto3
+    and moto are imported lazily so this module stays importable in
+    environments where neither package is installed; cross-surface tests gate
+    on their availability via ``pytest.importorskip`` at their own module load.
+    """
+    import boto3
+    import moto
+
+    monkeypatch.setenv("NAURO_S3_BUCKET", bucket)
+    with moto.mock_aws():
+        s3_client = boto3.client("s3", region_name="us-east-1")
+        s3_client.create_bucket(Bucket=bucket)
+        yield s3_client
 
 
 class FakeClient:

--- a/packages/nauro/tests/test_check_decision_cross_surface.py
+++ b/packages/nauro/tests/test_check_decision_cross_surface.py
@@ -25,8 +25,8 @@ cloud_store_module = pytest.importorskip(
     "mcp_server.store.cloud_store",
     reason="CloudStore is provided by the private mcp-server repo.",
 )
-boto3 = pytest.importorskip("boto3", reason="boto3 needed to seed a moto S3 bucket.")
-moto = pytest.importorskip("moto", reason="moto needed for in-memory S3.")
+pytest.importorskip("boto3", reason="boto3 needed to seed a moto S3 bucket.")
+pytest.importorskip("moto", reason="moto needed for in-memory S3.")
 
 # Imports below ``importorskip`` deliberately run only when both packages are
 # installed; ruff E402 does not apply here.
@@ -39,12 +39,15 @@ from nauro_core.decision_model import (  # noqa: E402
 from nauro_core.operations import check_decision  # noqa: E402
 
 from nauro.store.filesystem_store import FilesystemStore  # noqa: E402
+from tests.conftest import (  # noqa: E402
+    CROSS_SURFACE_BUCKET,
+    CROSS_SURFACE_PROJECT_ID,
+    CROSS_SURFACE_USER_ID,
+    cloud_prefix,
+    moto_s3_bucket,
+)
 
 CloudStore = cloud_store_module.CloudStore
-
-TEST_BUCKET = "nauro-cross-surface-test"
-TEST_USER_ID = "01TEST" + "0" * 20
-TEST_PROJECT_ID = "01TESTPROJECT00000000000"
 
 PROPOSED_APPROACH = "Migrate primary storage to PostgreSQL"
 
@@ -91,14 +94,14 @@ def _seed_filesystem_store(root: Path) -> FilesystemStore:
 
 
 def _seed_cloud_store(s3_client) -> CloudStore:
-    prefix = f"users/{TEST_USER_ID}/projects/{TEST_PROJECT_ID}"
+    prefix = cloud_prefix(CROSS_SURFACE_USER_ID, CROSS_SURFACE_PROJECT_ID)
     for stem, body in SEED_DECISIONS.items():
         s3_client.put_object(
-            Bucket=TEST_BUCKET,
+            Bucket=CROSS_SURFACE_BUCKET,
             Key=f"{prefix}/decisions/{stem}.md",
             Body=body.encode(),
         )
-    return CloudStore(user_id=TEST_USER_ID, project_id=TEST_PROJECT_ID)
+    return CloudStore(user_id=CROSS_SURFACE_USER_ID, project_id=CROSS_SURFACE_PROJECT_ID)
 
 
 @pytest.fixture
@@ -106,15 +109,9 @@ def both_stores(tmp_path, monkeypatch):
     """Yield a (FilesystemStore, CloudStore) pair seeded with identical decisions.
 
     The cloud half lives inside a moto-mocked S3 + an env-pointed bucket so
-    the test never touches AWS. ``NAURO_S3_BUCKET`` is monkey-patched onto
-    the environment because :class:`CloudStore` reads it lazily.
+    the test never touches AWS.
     """
-    monkeypatch.setenv("NAURO_S3_BUCKET", TEST_BUCKET)
-
-    with moto.mock_aws():
-        s3_client = boto3.client("s3", region_name="us-east-1")
-        s3_client.create_bucket(Bucket=TEST_BUCKET)
-
+    with moto_s3_bucket(monkeypatch) as s3_client:
         fs_store = _seed_filesystem_store(tmp_path)
         cloud = _seed_cloud_store(s3_client)
         yield fs_store, cloud

--- a/packages/nauro/tests/test_diff_since_last_session_cross_surface.py
+++ b/packages/nauro/tests/test_diff_since_last_session_cross_surface.py
@@ -27,22 +27,23 @@ import pytest
 
 cloud_store_module = pytest.importorskip(
     "mcp_server.store.cloud_store",
-    reason="CloudStore is consumed by other transports; not always installed alongside nauro.",
+    reason="CloudStore is provided by the private mcp-server repo.",
 )
-boto3 = pytest.importorskip("boto3", reason="boto3 needed to seed a moto S3 bucket.")
-moto = pytest.importorskip("moto", reason="moto needed for in-memory S3.")
+pytest.importorskip("boto3", reason="boto3 needed to seed a moto S3 bucket.")
+pytest.importorskip("moto", reason="moto needed for in-memory S3.")
 
 # Imports below ``importorskip`` deliberately run only when both packages are
 # installed; ruff E402 does not apply here.
 from nauro_core.operations import diff_since_last_session  # noqa: E402
 
 from nauro.store.filesystem_store import FilesystemStore  # noqa: E402
+from tests.conftest import (  # noqa: E402
+    CROSS_SURFACE_PROJECT_ID,
+    CROSS_SURFACE_USER_ID,
+    moto_s3_bucket,
+)
 
 CloudStore = cloud_store_module.CloudStore
-
-TEST_BUCKET = "nauro-diff-cross-surface-test"
-TEST_USER_ID = "01TEST" + "0" * 20
-TEST_PROJECT_ID = "01TESTPROJECT00000000000"
 
 
 BASELINE_SNAPSHOT: dict = {
@@ -70,14 +71,9 @@ LATEST_SNAPSHOT: dict = {
 @pytest.fixture
 def both_stores(tmp_path, monkeypatch):
     """Yield a (FilesystemStore, CloudStore) pair — kernel ignores both."""
-    monkeypatch.setenv("NAURO_S3_BUCKET", TEST_BUCKET)
-
-    with moto.mock_aws():
-        s3_client = boto3.client("s3", region_name="us-east-1")
-        s3_client.create_bucket(Bucket=TEST_BUCKET)
-
+    with moto_s3_bucket(monkeypatch):
         fs_store = FilesystemStore(tmp_path)
-        cloud = CloudStore(user_id=TEST_USER_ID, project_id=TEST_PROJECT_ID)
+        cloud = CloudStore(user_id=CROSS_SURFACE_USER_ID, project_id=CROSS_SURFACE_PROJECT_ID)
         yield fs_store, cloud
 
 

--- a/packages/nauro/tests/test_flag_question_cross_surface.py
+++ b/packages/nauro/tests/test_flag_question_cross_surface.py
@@ -23,10 +23,10 @@ import pytest
 
 cloud_store_module = pytest.importorskip(
     "mcp_server.store.cloud_store",
-    reason="CloudStore is consumed by other transports; not always installed alongside nauro.",
+    reason="CloudStore is provided by the private mcp-server repo.",
 )
-boto3 = pytest.importorskip("boto3", reason="boto3 needed to seed a moto S3 bucket.")
-moto = pytest.importorskip("moto", reason="moto needed for in-memory S3.")
+pytest.importorskip("boto3", reason="boto3 needed to seed a moto S3 bucket.")
+pytest.importorskip("moto", reason="moto needed for in-memory S3.")
 
 # Imports below ``importorskip`` deliberately run only when both packages are
 # installed; ruff E402 does not apply here.
@@ -34,25 +34,21 @@ from nauro_core.constants import OPEN_QUESTIONS_MD  # noqa: E402
 from nauro_core.operations import flag_question  # noqa: E402
 
 from nauro.store.filesystem_store import FilesystemStore  # noqa: E402
+from tests.conftest import (  # noqa: E402
+    CROSS_SURFACE_PROJECT_ID,
+    CROSS_SURFACE_USER_ID,
+    moto_s3_bucket,
+)
 
 CloudStore = cloud_store_module.CloudStore
-
-TEST_BUCKET = "nauro-flag-question-cross-surface-test"
-TEST_USER_ID = "01TEST" + "0" * 20
-TEST_PROJECT_ID = "01TESTPROJECT00000000000"
 
 
 @pytest.fixture
 def both_stores(tmp_path, monkeypatch):
     """Yield a (FilesystemStore, CloudStore) pair backed by separate roots."""
-    monkeypatch.setenv("NAURO_S3_BUCKET", TEST_BUCKET)
-
-    with moto.mock_aws():
-        s3_client = boto3.client("s3", region_name="us-east-1")
-        s3_client.create_bucket(Bucket=TEST_BUCKET)
-
+    with moto_s3_bucket(monkeypatch):
         fs_store = FilesystemStore(tmp_path)
-        cloud = CloudStore(user_id=TEST_USER_ID, project_id=TEST_PROJECT_ID)
+        cloud = CloudStore(user_id=CROSS_SURFACE_USER_ID, project_id=CROSS_SURFACE_PROJECT_ID)
         yield fs_store, cloud
 
 

--- a/packages/nauro/tests/test_get_context_cross_surface.py
+++ b/packages/nauro/tests/test_get_context_cross_surface.py
@@ -24,10 +24,10 @@ import pytest
 
 cloud_store_module = pytest.importorskip(
     "mcp_server.store.cloud_store",
-    reason="CloudStore is consumed by other transports; not always installed alongside nauro.",
+    reason="CloudStore is provided by the private mcp-server repo.",
 )
-boto3 = pytest.importorskip("boto3", reason="boto3 needed to seed a moto S3 bucket.")
-moto = pytest.importorskip("moto", reason="moto needed for in-memory S3.")
+pytest.importorskip("boto3", reason="boto3 needed to seed a moto S3 bucket.")
+pytest.importorskip("moto", reason="moto needed for in-memory S3.")
 
 # Imports below ``importorskip`` deliberately run only when both packages are
 # installed; ruff E402 does not apply here.
@@ -40,12 +40,15 @@ from nauro_core.decision_model import (  # noqa: E402
 from nauro_core.operations import get_context  # noqa: E402
 
 from nauro.store.filesystem_store import FilesystemStore  # noqa: E402
+from tests.conftest import (  # noqa: E402
+    CROSS_SURFACE_BUCKET,
+    CROSS_SURFACE_PROJECT_ID,
+    CROSS_SURFACE_USER_ID,
+    cloud_prefix,
+    moto_s3_bucket,
+)
 
 CloudStore = cloud_store_module.CloudStore
-
-TEST_BUCKET = "nauro-cross-surface-test"
-TEST_USER_ID = "01TEST" + "0" * 20
-TEST_PROJECT_ID = "01TESTPROJECT00000000000"
 
 # Fixed seed: project + state + stack + questions + two active decisions.
 # Mirrored byte-for-byte across both stores so any envelope drift is a
@@ -93,27 +96,26 @@ def _seed_filesystem_store(root: Path) -> FilesystemStore:
 
 
 def _seed_cloud_store(s3_client) -> CloudStore:
-    prefix = f"users/{TEST_USER_ID}/projects/{TEST_PROJECT_ID}"
+    prefix = cloud_prefix(CROSS_SURFACE_USER_ID, CROSS_SURFACE_PROJECT_ID)
     for name, body in SEED_FILES.items():
-        s3_client.put_object(Bucket=TEST_BUCKET, Key=f"{prefix}/{name}", Body=body.encode())
+        s3_client.put_object(
+            Bucket=CROSS_SURFACE_BUCKET,
+            Key=f"{prefix}/{name}",
+            Body=body.encode(),
+        )
     for stem, body in SEED_DECISIONS.items():
         s3_client.put_object(
-            Bucket=TEST_BUCKET,
+            Bucket=CROSS_SURFACE_BUCKET,
             Key=f"{prefix}/decisions/{stem}.md",
             Body=body.encode(),
         )
-    return CloudStore(user_id=TEST_USER_ID, project_id=TEST_PROJECT_ID)
+    return CloudStore(user_id=CROSS_SURFACE_USER_ID, project_id=CROSS_SURFACE_PROJECT_ID)
 
 
 @pytest.fixture
 def both_stores(tmp_path, monkeypatch):
     """Yield a (FilesystemStore, CloudStore) pair seeded with identical content."""
-    monkeypatch.setenv("NAURO_S3_BUCKET", TEST_BUCKET)
-
-    with moto.mock_aws():
-        s3_client = boto3.client("s3", region_name="us-east-1")
-        s3_client.create_bucket(Bucket=TEST_BUCKET)
-
+    with moto_s3_bucket(monkeypatch) as s3_client:
         fs_store = _seed_filesystem_store(tmp_path)
         cloud = _seed_cloud_store(s3_client)
         yield fs_store, cloud

--- a/packages/nauro/tests/test_get_decision_cross_surface.py
+++ b/packages/nauro/tests/test_get_decision_cross_surface.py
@@ -26,8 +26,8 @@ cloud_store_module = pytest.importorskip(
     "mcp_server.store.cloud_store",
     reason="CloudStore is provided by the private mcp-server repo.",
 )
-boto3 = pytest.importorskip("boto3", reason="boto3 needed to seed a moto S3 bucket.")
-moto = pytest.importorskip("moto", reason="moto needed for in-memory S3.")
+pytest.importorskip("boto3", reason="boto3 needed to seed a moto S3 bucket.")
+pytest.importorskip("moto", reason="moto needed for in-memory S3.")
 
 # Imports below ``importorskip`` deliberately run only when both packages are
 # installed; ruff E402 does not apply here.
@@ -40,12 +40,15 @@ from nauro_core.decision_model import (  # noqa: E402
 from nauro_core.operations import get_decision  # noqa: E402
 
 from nauro.store.filesystem_store import FilesystemStore  # noqa: E402
+from tests.conftest import (  # noqa: E402
+    CROSS_SURFACE_BUCKET,
+    CROSS_SURFACE_PROJECT_ID,
+    CROSS_SURFACE_USER_ID,
+    cloud_prefix,
+    moto_s3_bucket,
+)
 
 CloudStore = cloud_store_module.CloudStore
-
-TEST_BUCKET = "nauro-cross-surface-test"
-TEST_USER_ID = "01TEST" + "0" * 20
-TEST_PROJECT_ID = "01TESTPROJECT00000000000"
 
 EXISTING_NUMBER = 1
 MISSING_NUMBER = 999
@@ -79,14 +82,14 @@ def _seed_filesystem_store(root: Path) -> FilesystemStore:
 
 
 def _seed_cloud_store(s3_client) -> CloudStore:
-    prefix = f"users/{TEST_USER_ID}/projects/{TEST_PROJECT_ID}"
+    prefix = cloud_prefix(CROSS_SURFACE_USER_ID, CROSS_SURFACE_PROJECT_ID)
     for stem, body in SEED_DECISIONS.items():
         s3_client.put_object(
-            Bucket=TEST_BUCKET,
+            Bucket=CROSS_SURFACE_BUCKET,
             Key=f"{prefix}/decisions/{stem}.md",
             Body=body.encode(),
         )
-    return CloudStore(user_id=TEST_USER_ID, project_id=TEST_PROJECT_ID)
+    return CloudStore(user_id=CROSS_SURFACE_USER_ID, project_id=CROSS_SURFACE_PROJECT_ID)
 
 
 @pytest.fixture
@@ -94,15 +97,9 @@ def both_stores(tmp_path, monkeypatch):
     """Yield a (FilesystemStore, CloudStore) pair seeded with identical decisions.
 
     The cloud half lives inside a moto-mocked S3 + an env-pointed bucket so
-    the test never touches AWS. ``NAURO_S3_BUCKET`` is monkey-patched onto
-    the environment because :class:`CloudStore` reads it lazily.
+    the test never touches AWS.
     """
-    monkeypatch.setenv("NAURO_S3_BUCKET", TEST_BUCKET)
-
-    with moto.mock_aws():
-        s3_client = boto3.client("s3", region_name="us-east-1")
-        s3_client.create_bucket(Bucket=TEST_BUCKET)
-
+    with moto_s3_bucket(monkeypatch) as s3_client:
         fs_store = _seed_filesystem_store(tmp_path)
         cloud = _seed_cloud_store(s3_client)
         yield fs_store, cloud

--- a/packages/nauro/tests/test_get_raw_file_cross_surface.py
+++ b/packages/nauro/tests/test_get_raw_file_cross_surface.py
@@ -24,22 +24,25 @@ import pytest
 
 cloud_store_module = pytest.importorskip(
     "mcp_server.store.cloud_store",
-    reason="CloudStore is consumed by other transports; not always installed alongside nauro.",
+    reason="CloudStore is provided by the private mcp-server repo.",
 )
-boto3 = pytest.importorskip("boto3", reason="boto3 needed to seed a moto S3 bucket.")
-moto = pytest.importorskip("moto", reason="moto needed for in-memory S3.")
+pytest.importorskip("boto3", reason="boto3 needed to seed a moto S3 bucket.")
+pytest.importorskip("moto", reason="moto needed for in-memory S3.")
 
 # Imports below ``importorskip`` deliberately run only when both packages are
 # installed; ruff E402 does not apply here.
 from nauro_core.operations import get_raw_file  # noqa: E402
 
 from nauro.store.filesystem_store import FilesystemStore  # noqa: E402
+from tests.conftest import (  # noqa: E402
+    CROSS_SURFACE_BUCKET,
+    CROSS_SURFACE_PROJECT_ID,
+    CROSS_SURFACE_USER_ID,
+    cloud_prefix,
+    moto_s3_bucket,
+)
 
 CloudStore = cloud_store_module.CloudStore
-
-TEST_BUCKET = "nauro-cross-surface-test"
-TEST_USER_ID = "01TEST" + "0" * 20
-TEST_PROJECT_ID = "01TESTPROJECT00000000000"
 
 EXISTING_PATH = "project.md"
 MISSING_PATH = "does-not-exist.md"
@@ -62,14 +65,14 @@ def _seed_filesystem_store(root: Path) -> FilesystemStore:
 
 
 def _seed_cloud_store(s3_client) -> CloudStore:
-    prefix = f"users/{TEST_USER_ID}/projects/{TEST_PROJECT_ID}"
+    prefix = cloud_prefix(CROSS_SURFACE_USER_ID, CROSS_SURFACE_PROJECT_ID)
     for path, body in SEED_FILES.items():
         s3_client.put_object(
-            Bucket=TEST_BUCKET,
+            Bucket=CROSS_SURFACE_BUCKET,
             Key=f"{prefix}/{path}",
             Body=body.encode(),
         )
-    return CloudStore(user_id=TEST_USER_ID, project_id=TEST_PROJECT_ID)
+    return CloudStore(user_id=CROSS_SURFACE_USER_ID, project_id=CROSS_SURFACE_PROJECT_ID)
 
 
 @pytest.fixture
@@ -77,15 +80,9 @@ def both_stores(tmp_path, monkeypatch):
     """Yield a (FilesystemStore, CloudStore) pair seeded with identical files.
 
     The cloud half lives inside a moto-mocked S3 + an env-pointed bucket so
-    the test never touches AWS. ``NAURO_S3_BUCKET`` is monkey-patched onto
-    the environment because :class:`CloudStore` reads it lazily.
+    the test never touches AWS.
     """
-    monkeypatch.setenv("NAURO_S3_BUCKET", TEST_BUCKET)
-
-    with moto.mock_aws():
-        s3_client = boto3.client("s3", region_name="us-east-1")
-        s3_client.create_bucket(Bucket=TEST_BUCKET)
-
+    with moto_s3_bucket(monkeypatch) as s3_client:
         fs_store = _seed_filesystem_store(tmp_path)
         cloud = _seed_cloud_store(s3_client)
         yield fs_store, cloud

--- a/packages/nauro/tests/test_list_decisions_cross_surface.py
+++ b/packages/nauro/tests/test_list_decisions_cross_surface.py
@@ -24,10 +24,10 @@ import pytest
 
 cloud_store_module = pytest.importorskip(
     "mcp_server.store.cloud_store",
-    reason="CloudStore is consumed by other transports; not always installed alongside nauro.",
+    reason="CloudStore is provided by the private mcp-server repo.",
 )
-boto3 = pytest.importorskip("boto3", reason="boto3 needed to seed a moto S3 bucket.")
-moto = pytest.importorskip("moto", reason="moto needed for in-memory S3.")
+pytest.importorskip("boto3", reason="boto3 needed to seed a moto S3 bucket.")
+pytest.importorskip("moto", reason="moto needed for in-memory S3.")
 
 # Imports below ``importorskip`` deliberately run only when both packages are
 # installed; ruff E402 does not apply here.
@@ -40,12 +40,15 @@ from nauro_core.decision_model import (  # noqa: E402
 from nauro_core.operations import list_decisions  # noqa: E402
 
 from nauro.store.filesystem_store import FilesystemStore  # noqa: E402
+from tests.conftest import (  # noqa: E402
+    CROSS_SURFACE_BUCKET,
+    CROSS_SURFACE_PROJECT_ID,
+    CROSS_SURFACE_USER_ID,
+    cloud_prefix,
+    moto_s3_bucket,
+)
 
 CloudStore = cloud_store_module.CloudStore
-
-TEST_BUCKET = "nauro-cross-surface-test"
-TEST_USER_ID = "01TEST" + "0" * 20
-TEST_PROJECT_ID = "01TESTPROJECT00000000000"
 
 # Fixed seed: one active and one superseded decision so the
 # include_superseded toggle has something to filter. The exact strings
@@ -87,14 +90,14 @@ def _seed_filesystem_store(root: Path) -> FilesystemStore:
 
 
 def _seed_cloud_store(s3_client) -> CloudStore:
-    prefix = f"users/{TEST_USER_ID}/projects/{TEST_PROJECT_ID}"
+    prefix = cloud_prefix(CROSS_SURFACE_USER_ID, CROSS_SURFACE_PROJECT_ID)
     for stem, body in SEED_DECISIONS.items():
         s3_client.put_object(
-            Bucket=TEST_BUCKET,
+            Bucket=CROSS_SURFACE_BUCKET,
             Key=f"{prefix}/decisions/{stem}.md",
             Body=body.encode(),
         )
-    return CloudStore(user_id=TEST_USER_ID, project_id=TEST_PROJECT_ID)
+    return CloudStore(user_id=CROSS_SURFACE_USER_ID, project_id=CROSS_SURFACE_PROJECT_ID)
 
 
 @pytest.fixture
@@ -102,15 +105,9 @@ def both_stores(tmp_path, monkeypatch):
     """Yield a (FilesystemStore, CloudStore) pair seeded with identical decisions.
 
     The cloud half lives inside a moto-mocked S3 + an env-pointed bucket so
-    the test never touches AWS. ``NAURO_S3_BUCKET`` is monkey-patched onto
-    the environment because :class:`CloudStore` reads it lazily.
+    the test never touches AWS.
     """
-    monkeypatch.setenv("NAURO_S3_BUCKET", TEST_BUCKET)
-
-    with moto.mock_aws():
-        s3_client = boto3.client("s3", region_name="us-east-1")
-        s3_client.create_bucket(Bucket=TEST_BUCKET)
-
+    with moto_s3_bucket(monkeypatch) as s3_client:
         fs_store = _seed_filesystem_store(tmp_path)
         cloud = _seed_cloud_store(s3_client)
         yield fs_store, cloud

--- a/packages/nauro/tests/test_propose_decision_cross_surface.py
+++ b/packages/nauro/tests/test_propose_decision_cross_surface.py
@@ -26,10 +26,10 @@ import pytest
 
 cloud_store_module = pytest.importorskip(
     "mcp_server.store.cloud_store",
-    reason="CloudStore is consumed by other transports; not always installed alongside nauro.",
+    reason="CloudStore is provided by the private mcp-server repo.",
 )
-boto3 = pytest.importorskip("boto3", reason="boto3 needed to seed a moto S3 bucket.")
-moto = pytest.importorskip("moto", reason="moto needed for in-memory S3.")
+pytest.importorskip("boto3", reason="boto3 needed to seed a moto S3 bucket.")
+pytest.importorskip("moto", reason="moto needed for in-memory S3.")
 
 # Imports below ``importorskip`` deliberately run only when both packages are
 # installed; ruff E402 does not apply here.
@@ -41,25 +41,21 @@ from nauro_core.operations.propose_decision import (  # noqa: E402
 )
 
 from nauro.store.filesystem_store import FilesystemStore  # noqa: E402
+from tests.conftest import (  # noqa: E402
+    CROSS_SURFACE_PROJECT_ID,
+    CROSS_SURFACE_USER_ID,
+    moto_s3_bucket,
+)
 
 CloudStore = cloud_store_module.CloudStore
-
-TEST_BUCKET = "nauro-propose-decision-cross-surface-test"
-TEST_USER_ID = "01TEST" + "0" * 20
-TEST_PROJECT_ID = "01TESTPROJECT00000000000"
 
 
 @pytest.fixture
 def both_stores(tmp_path, monkeypatch):
     """Yield a (FilesystemStore, CloudStore) pair backed by separate roots."""
-    monkeypatch.setenv("NAURO_S3_BUCKET", TEST_BUCKET)
-
-    with moto.mock_aws():
-        s3_client = boto3.client("s3", region_name="us-east-1")
-        s3_client.create_bucket(Bucket=TEST_BUCKET)
-
+    with moto_s3_bucket(monkeypatch):
         fs_store = FilesystemStore(tmp_path)
-        cloud = CloudStore(user_id=TEST_USER_ID, project_id=TEST_PROJECT_ID)
+        cloud = CloudStore(user_id=CROSS_SURFACE_USER_ID, project_id=CROSS_SURFACE_PROJECT_ID)
         yield fs_store, cloud
 
 

--- a/packages/nauro/tests/test_search_decisions_cross_surface.py
+++ b/packages/nauro/tests/test_search_decisions_cross_surface.py
@@ -24,10 +24,10 @@ import pytest
 
 cloud_store_module = pytest.importorskip(
     "mcp_server.store.cloud_store",
-    reason="CloudStore is consumed by other transports; not always installed alongside nauro.",
+    reason="CloudStore is provided by the private mcp-server repo.",
 )
-boto3 = pytest.importorskip("boto3", reason="boto3 needed to seed a moto S3 bucket.")
-moto = pytest.importorskip("moto", reason="moto needed for in-memory S3.")
+pytest.importorskip("boto3", reason="boto3 needed to seed a moto S3 bucket.")
+pytest.importorskip("moto", reason="moto needed for in-memory S3.")
 
 # Imports below ``importorskip`` deliberately run only when both packages are
 # installed; ruff E402 does not apply here.
@@ -40,12 +40,15 @@ from nauro_core.decision_model import (  # noqa: E402
 from nauro_core.operations import search_decisions  # noqa: E402
 
 from nauro.store.filesystem_store import FilesystemStore  # noqa: E402
+from tests.conftest import (  # noqa: E402
+    CROSS_SURFACE_BUCKET,
+    CROSS_SURFACE_PROJECT_ID,
+    CROSS_SURFACE_USER_ID,
+    cloud_prefix,
+    moto_s3_bucket,
+)
 
 CloudStore = cloud_store_module.CloudStore
-
-TEST_BUCKET = "nauro-cross-surface-test"
-TEST_USER_ID = "01TEST" + "0" * 20
-TEST_PROJECT_ID = "01TESTPROJECT00000000000"
 
 # Fixed seed: two active decisions whose titles + rationale make BM25
 # scoring deterministic. The same strings are mirrored into both stores
@@ -84,14 +87,14 @@ def _seed_filesystem_store(root: Path) -> FilesystemStore:
 
 
 def _seed_cloud_store(s3_client) -> CloudStore:
-    prefix = f"users/{TEST_USER_ID}/projects/{TEST_PROJECT_ID}"
+    prefix = cloud_prefix(CROSS_SURFACE_USER_ID, CROSS_SURFACE_PROJECT_ID)
     for stem, body in SEED_DECISIONS.items():
         s3_client.put_object(
-            Bucket=TEST_BUCKET,
+            Bucket=CROSS_SURFACE_BUCKET,
             Key=f"{prefix}/decisions/{stem}.md",
             Body=body.encode(),
         )
-    return CloudStore(user_id=TEST_USER_ID, project_id=TEST_PROJECT_ID)
+    return CloudStore(user_id=CROSS_SURFACE_USER_ID, project_id=CROSS_SURFACE_PROJECT_ID)
 
 
 @pytest.fixture
@@ -99,15 +102,9 @@ def both_stores(tmp_path, monkeypatch):
     """Yield a (FilesystemStore, CloudStore) pair seeded with identical decisions.
 
     The cloud half lives inside a moto-mocked S3 + an env-pointed bucket so
-    the test never touches AWS. ``NAURO_S3_BUCKET`` is monkey-patched onto
-    the environment because :class:`CloudStore` reads it lazily.
+    the test never touches AWS.
     """
-    monkeypatch.setenv("NAURO_S3_BUCKET", TEST_BUCKET)
-
-    with moto.mock_aws():
-        s3_client = boto3.client("s3", region_name="us-east-1")
-        s3_client.create_bucket(Bucket=TEST_BUCKET)
-
+    with moto_s3_bucket(monkeypatch) as s3_client:
         fs_store = _seed_filesystem_store(tmp_path)
         cloud = _seed_cloud_store(s3_client)
         yield fs_store, cloud

--- a/packages/nauro/tests/test_update_state_cross_surface.py
+++ b/packages/nauro/tests/test_update_state_cross_surface.py
@@ -24,10 +24,10 @@ import pytest
 
 cloud_store_module = pytest.importorskip(
     "mcp_server.store.cloud_store",
-    reason="CloudStore is consumed by other transports; not always installed alongside nauro.",
+    reason="CloudStore is provided by the private mcp-server repo.",
 )
-boto3 = pytest.importorskip("boto3", reason="boto3 needed to seed a moto S3 bucket.")
-moto = pytest.importorskip("moto", reason="moto needed for in-memory S3.")
+pytest.importorskip("boto3", reason="boto3 needed to seed a moto S3 bucket.")
+pytest.importorskip("moto", reason="moto needed for in-memory S3.")
 
 # Imports below ``importorskip`` deliberately run only when both packages are
 # installed; ruff E402 does not apply here.
@@ -39,25 +39,21 @@ from nauro_core.constants import (  # noqa: E402
 from nauro_core.operations import update_state  # noqa: E402
 
 from nauro.store.filesystem_store import FilesystemStore  # noqa: E402
+from tests.conftest import (  # noqa: E402
+    CROSS_SURFACE_PROJECT_ID,
+    CROSS_SURFACE_USER_ID,
+    moto_s3_bucket,
+)
 
 CloudStore = cloud_store_module.CloudStore
-
-TEST_BUCKET = "nauro-update-state-cross-surface-test"
-TEST_USER_ID = "01TEST" + "0" * 20
-TEST_PROJECT_ID = "01TESTPROJECT00000000000"
 
 
 @pytest.fixture
 def both_stores(tmp_path, monkeypatch):
     """Yield a (FilesystemStore, CloudStore) pair backed by separate roots."""
-    monkeypatch.setenv("NAURO_S3_BUCKET", TEST_BUCKET)
-
-    with moto.mock_aws():
-        s3_client = boto3.client("s3", region_name="us-east-1")
-        s3_client.create_bucket(Bucket=TEST_BUCKET)
-
+    with moto_s3_bucket(monkeypatch):
         fs_store = FilesystemStore(tmp_path)
-        cloud = CloudStore(user_id=TEST_USER_ID, project_id=TEST_PROJECT_ID)
+        cloud = CloudStore(user_id=CROSS_SURFACE_USER_ID, project_id=CROSS_SURFACE_PROJECT_ID)
         yield fs_store, cloud
 
 


### PR DESCRIPTION
## Why

The 10 `test_*_cross_surface.py` parity test files each duplicated the same
cross-surface scaffolding: the identity constants (`TEST_USER_ID`,
`TEST_PROJECT_ID`), the S3 cloud key-prefix (`users/{user}/projects/{project}`,
in the 6 read-path files), and the moto bootstrap (`mock_aws()` +
`create_bucket` + `setenv("NAURO_S3_BUCKET")`) inside every `both_stores`
fixture. The duplication had already started to rot: the CloudStore
`importorskip` reason string had drifted 8-vs-2 across the files ("consumed by
other transports..." vs "provided by the private mcp-server repo"). That is
exactly the silent divergence centralizing shared test scaffolding prevents.

## Approach

Hoist the genuinely-identical parts into the package `conftest.py`:

- `CROSS_SURFACE_USER_ID` / `CROSS_SURFACE_PROJECT_ID` constants, mirroring the
  existing `TEST_ANONYMOUS_ID` precedent (centralized so a change in one file
  can't drift).
- A `cloud_prefix(user_id, project_id)` helper for the S3 key prefix.
- A `moto_s3_bucket(...)` context manager that owns the moto bootstrap and
  yields the boto3 client; boto3/moto are imported lazily inside it so the
  conftest stays importable in environments where neither is installed.

Each operation keeps its own per-file seed data — the seed content
legitimately differs per operation (decisions vs files vs snapshots vs
open-questions), so consolidating it would couple unrelated tests. A fully
parametrized single fixture was rejected as over-consolidation that hurts
readability for no behavior gain.

The `importorskip` call stays module-level in every file so collection-skip
granularity is unchanged; only its reason string is unified onto the more
precise "provided by the private mcp-server repo" wording.

## What changed

- `conftest.py` gains the shared cross-surface seam (constants, prefix helper,
  bucket constant, moto context manager).
- The 6 read-path files drop their local identity constants + inline prefix and
  call the shared helper; their `_seed_cloud_store` now uses `cloud_prefix` and
  the shared bucket.
- The 4 write-path files (whose empty-store fixtures were byte-identical modulo
  bucket name) collapse onto the shared context manager.
- All 10 `importorskip` reason strings unified.

## What to review

- No test was dropped or weakened: same assertions, same per-file seed data,
  same test count.
- The skip count is identical before and after (10 skipped, unchanged) — a
  hoist that broke collection would have silently skipped tests instead.
- The `importorskip` calls stayed module-level (not moved into conftest), so
  per-file collection-skip granularity is preserved.

## What's deferred

The `*_parity.py` files use a different fixture recipe (only 4 of 10 share a
fixture) and are left for a separate follow-up.

## Test plan

- `uv run pytest packages/nauro/tests/ -q` -> 1162 passed, 10 skipped (count
  unchanged vs baseline).
- `uv run pytest packages/nauro/tests/ -k cross_surface -rs -q` -> 25 passed,
  10 skipped, 1137 deselected, identical to the pre-change baseline.
- `uv run ruff check packages/` and `uv run ruff format --check packages/`
  both clean.
