### PR TITLE
Unify the sync pull-core and fix the nauro sync decision-overwrite bug

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/sync.py
+++ b/packages/nauro/src/nauro/cli/commands/sync.py
@@ -7,14 +7,11 @@ import typer
 
 from nauro.cli.commands.auth import load_access_token
 from nauro.cli.utils import resolve_target_project
-from nauro.store.registry import (
-    get_repo_paths,
-    is_cloud_project,
-)
+from nauro.store.registry import is_cloud_project
 from nauro.store.snapshot import capture_snapshot
 from nauro.store.validator import print_warnings, validate_store
 from nauro.sync.push import push_store_to_cloud
-from nauro.templates.agents_md import regenerate_agents_md_for_project
+from nauro.templates.agents_md_regen import warn_then_regen
 
 logger = logging.getLogger("nauro.sync")
 
@@ -52,15 +49,11 @@ def sync(
 
     version = capture_snapshot(store_path, trigger=trigger)
 
-    for repo_str in get_repo_paths(project_key):
-        if not Path(repo_str).is_dir():
-            typer.echo(
-                f"  Warning: repo path does not exist, skipping AGENTS.md: {repo_str}\n"
-                f"  Fix: remove from registry or update path in ~/.nauro/registry.json",
-                err=True,
-            )
-
-    updated_repos = regenerate_agents_md_for_project(project_key, store_path)
+    updated_repos = warn_then_regen(
+        project_key,
+        store_path,
+        warn=lambda msg: typer.echo(msg, err=True),
+    )
 
     pushed = _push_to_cloud(project_key, store_path)
 
@@ -100,142 +93,39 @@ def _pull_from_cloud(project_id: str, store_path: Path) -> int:
     return _pull_via_presign(project_id, store_path)
 
 
-def _pull_via_presign(project_id: str, store_path: Path) -> int:
-    """GET /sync/manifest → POST /sync/presign → S3 GETs."""
-    from datetime import datetime, timezone
+class _EchoReporter:
+    """Pull reporter for ``nauro sync``.
 
-    from nauro.cli.commands.auth import AuthRefreshError
-    from nauro.sync.merge import (
-        UnionMergeError,
-        detect_conflict,
-        resolve_conflict,
-        should_skip,
-    )
-    from nauro.sync.remote import (
-        PresignError,
-        fetch_manifest,
-        fetch_via_presigned_url,
-        get_via_presigned_url,
-        request_presigned_urls,
-    )
-    from nauro.sync.state import (
-        compute_sha256,
-        file_changed_locally,
-        file_changed_remotely,
-        load_state,
-        save_state,
-        update_file_state,
-    )
+    Echoes progress to the terminal (warnings on stderr) and re-raises on a
+    union-merge failure so an explicit sync fails loud rather than reporting a
+    partial success.
+    """
+
+    def info(self, msg: str) -> None:
+        typer.echo(f"  {msg}")
+
+    def warn(self, msg: str) -> None:
+        typer.echo(f"  {msg}", err=True)
+
+    def on_merge_failure(self, relative_path: str, exc: Exception) -> bool:
+        logger.exception("Union merge failed for %s", relative_path)
+        typer.echo(
+            f"  Error: merge failed for {relative_path} ({exc}) — left unchanged",
+            err=True,
+        )
+        return True
+
+
+def _pull_via_presign(project_id: str, store_path: Path) -> int:
+    """GET /sync/manifest → POST /sync/presign → S3 GETs.
+
+    Delegates to the shared pull core with an echo reporter; a union-merge
+    failure propagates so ``nauro sync`` exits nonzero.
+    """
+    from nauro.sync.pull import run_pull
 
     typer.echo("Pulling from remote...")
-
-    try:
-        manifest = fetch_manifest(project_id)
-    except AuthRefreshError as exc:
-        typer.echo(f"  {exc}", err=True)
-        return 0
-    except PresignError as exc:
-        logger.exception("Failed to fetch manifest")
-        typer.echo(f"  Warning: could not reach remote ({exc})", err=True)
-        return 0
-
-    state = load_state(store_path)
-
-    pulls: list[tuple[str, str]] = []
-    conflicts: list[tuple[str, str]] = []
-    for entry in manifest:
-        rel = entry.get("path", "") if isinstance(entry, dict) else ""
-        if not rel or should_skip(rel):
-            continue
-        # Server validates per-op on presign, but the manifest itself is
-        # currently trusted — drop suspicious entries before they hit disk.
-        if ".." in Path(rel).parts or rel.startswith("/"):
-            logger.warning("Skipping manifest entry with suspicious path: %r", rel)
-            continue
-        remote_etag = entry.get("etag", "")
-        if not file_changed_remotely(remote_etag, rel, state):
-            continue
-
-        local_file = store_path / rel
-        local_changed = file_changed_locally(store_path, rel, state)
-
-        if not local_changed:
-            pulls.append((rel, remote_etag))
-            continue
-
-        local_sha = compute_sha256(local_file) if local_file.exists() else ""
-        if detect_conflict(rel, state, local_sha, remote_etag):
-            conflicts.append((rel, remote_etag))
-
-    if not pulls and not conflicts:
-        state.last_full_sync = datetime.now(timezone.utc).isoformat()
-        save_state(store_path, state)
-        typer.echo("  No remote changes")
-        return 0
-
-    operations = [{"verb": "GET", "path": rel} for rel, _etag in pulls + conflicts]
-    try:
-        urls = request_presigned_urls(project_id, operations)
-    except AuthRefreshError as exc:
-        typer.echo(f"  {exc}", err=True)
-        return 0
-    except PresignError as exc:
-        logger.exception("Failed to request presigned URLs")
-        typer.echo(f"  Warning: presign request failed ({exc})", err=True)
-        return 0
-
-    if len(urls) < len(operations):
-        logger.warning("Presign returned %d URLs for %d ops", len(urls), len(operations))
-
-    url_by_path = {
-        entry["path"]: entry["url"]
-        for entry in urls
-        if isinstance(entry, dict) and entry.get("verb") == "GET"
-    }
-    merged = 0
-
-    for rel, remote_etag in pulls:
-        url = url_by_path.get(rel)
-        if not url:
-            continue
-        local_file = store_path / rel
-        try:
-            get_via_presigned_url(url, local_file)
-            local_sha = compute_sha256(local_file)
-            update_file_state(state, rel, local_sha, remote_etag)
-            merged += 1
-        except PresignError:
-            logger.exception("Error pulling %s", rel)
-
-    for rel, remote_etag in conflicts:
-        url = url_by_path.get(rel)
-        if not url:
-            continue
-        local_file = store_path / rel
-        try:
-            remote_content = fetch_via_presigned_url(url)
-            merged_content = resolve_conflict(store_path, local_file, remote_content, rel, state)
-            local_file.write_bytes(merged_content)
-            local_sha = compute_sha256(local_file)
-            update_file_state(state, rel, local_sha, remote_etag)
-            merged += 1
-        except PresignError:
-            logger.exception("Error resolving conflict for %s", rel)
-        except UnionMergeError as exc:
-            # Explicit sync must not report success on a failed merge. Surface
-            # the error and skip the file, leaving it untouched on disk.
-            logger.exception("Union merge failed for %s", rel)
-            typer.echo(f"  Error: merge failed for {rel} ({exc}) — left unchanged", err=True)
-
-    state.last_full_sync = datetime.now(timezone.utc).isoformat()
-    save_state(store_path, state)
-
-    if merged:
-        typer.echo(f"  Merged {merged} file(s) from remote")
-    else:
-        typer.echo("  No remote changes")
-
-    return merged
+    return run_pull(project_id, store_path, _EchoReporter())
 
 
 def _show_status(project_flag: str | None) -> None:

--- a/packages/nauro/src/nauro/sync/hooks.py
+++ b/packages/nauro/src/nauro/sync/hooks.py
@@ -14,86 +14,43 @@ silent-no-op when either is missing. The two no-op cases are:
   and v2 local-mode is not remote-backed. The presign endpoints can
   address neither.
 
+The pull and push transport lives in ``nauro.sync.pull`` and
+``nauro.sync.push`` and is shared with the ``nauro sync`` CLI command.
+These hooks supply a logging :class:`~nauro.sync.pull.Reporter` that
+never re-raises, so the shared core stays silent and crash-free here
+while the CLI surfaces failures.
+
 Token refresh on 401 is handled inside ``request_presigned_urls`` and
 ``fetch_manifest`` via ``with_token_refresh``. ``AuthRefreshError``
 escapes here as a swallowed log line.
 """
 
 import logging
-import re
-from datetime import datetime, timezone
 from pathlib import Path
 
-from nauro_core import extract_decision_number
-
-from nauro.cli.commands.auth import AuthRefreshError, load_access_token
+from nauro.cli.commands.auth import load_access_token
 from nauro.store.registry import is_cloud_project
 
 logger = logging.getLogger("nauro.sync")
 
 
-def _renumber_decision_if_collision(
-    store_path: Path,
-    rel: str,
-    content: bytes,
-) -> tuple[str, bytes]:
-    """If a pulled decision file's number collides with an existing local file, renumber it.
+class _LoggingReporter:
+    """Pull reporter for the SessionStart hook.
 
-    Returns (possibly_renamed_rel, possibly_updated_content).
+    Routes progress to ``logger`` at the appropriate level and swallows
+    union-merge failures (returns False) so auto-pull never crashes a
+    session start.
     """
-    if not rel.startswith("decisions/"):
-        return rel, content
 
-    filename = rel.split("/", 1)[1]
-    incoming_num = extract_decision_number(filename)
-    if incoming_num is None:
-        return rel, content
-    decisions_dir = store_path / "decisions"
-    if not decisions_dir.exists():
-        return rel, content
+    def info(self, msg: str) -> None:
+        logger.info("sync pull: %s", msg)
 
-    if (decisions_dir / filename).exists():
-        return rel, content
+    def warn(self, msg: str) -> None:
+        logger.warning("sync pull: %s", msg)
 
-    collision = False
-    for f in decisions_dir.glob("*.md"):
-        n = extract_decision_number(f.name)
-        if n is not None and n == incoming_num:
-            collision = True
-            break
-
-    if not collision:
-        return rel, content
-
-    existing_nums = set()
-    for f in decisions_dir.glob("*.md"):
-        n = extract_decision_number(f.name)
-        if n is not None:
-            existing_nums.add(n)
-
-    next_num = max(existing_nums) + 1 if existing_nums else 1
-
-    slug = re.sub(r"^\d+-", "", filename)
-    new_filename = f"{next_num:03d}-{slug}"
-    new_rel = f"decisions/{new_filename}"
-
-    text = content.decode("utf-8", errors="replace")
-    text = re.sub(
-        rf"^# {incoming_num:03d}( [—-])",
-        f"# {next_num:03d}\\1",
-        text,
-        count=1,
-        flags=re.MULTILINE,
-    )
-    content = text.encode("utf-8")
-
-    logger.info(
-        "Renumbered pulled decision %s → %s to avoid collision with local decision %03d",
-        filename,
-        new_filename,
-        incoming_num,
-    )
-    return new_rel, content
+    def on_merge_failure(self, relative_path: str, exc: Exception) -> bool:
+        logger.exception("sync pull: union merge failed for %s", relative_path)
+        return False
 
 
 def pull_before_session(project_id: str, store_path: Path) -> int:
@@ -110,149 +67,17 @@ def pull_before_session(project_id: str, store_path: Path) -> int:
         return 0
 
     try:
-        from nauro.sync.merge import (
-            UnionMergeError,
-            detect_conflict,
-            resolve_conflict,
-            should_skip,
-        )
-        from nauro.sync.remote import (
-            PresignError,
-            fetch_manifest,
-            fetch_via_presigned_url,
-            request_presigned_urls,
-        )
-        from nauro.sync.state import (
-            compute_sha256,
-            file_changed_locally,
-            file_changed_remotely,
-            load_state,
-            save_state,
-            update_file_state,
-        )
+        from nauro.sync.pull import run_pull
     except ImportError:
         return 0
 
     try:
-        manifest = fetch_manifest(project_id)
-    except AuthRefreshError as exc:
-        logger.warning("sync pull: %s", exc)
+        return run_pull(project_id, store_path, _LoggingReporter())
+    except Exception:
+        # The logging reporter never re-raises union-merge failures, but a
+        # genuinely unexpected error must not escape session startup either.
+        logger.exception("sync pull: unexpected failure for %s", project_id)
         return 0
-    except PresignError as exc:
-        logger.warning("sync pull: manifest fetch failed: %s", exc)
-        return 0
-
-    state = load_state(store_path)
-
-    pulls: list[tuple[str, str]] = []
-    conflicts: list[tuple[str, str]] = []
-    for entry in manifest:
-        rel = entry.get("path", "") if isinstance(entry, dict) else ""
-        if not rel or should_skip(rel):
-            continue
-        # Server validates per-op on presign, but the manifest itself is
-        # currently trusted — drop suspicious entries before they hit disk.
-        if ".." in Path(rel).parts or rel.startswith("/"):
-            logger.warning("sync pull: skipping suspicious manifest entry %r", rel)
-            continue
-        remote_etag = entry.get("etag", "")
-        if not file_changed_remotely(remote_etag, rel, state):
-            continue
-
-        local_file = store_path / rel
-        local_changed = file_changed_locally(store_path, rel, state)
-        if not local_changed:
-            pulls.append((rel, remote_etag))
-            continue
-
-        local_sha = compute_sha256(local_file) if local_file.exists() else ""
-        if detect_conflict(rel, state, local_sha, remote_etag):
-            conflicts.append((rel, remote_etag))
-
-    if not pulls and not conflicts:
-        state.last_full_sync = datetime.now(timezone.utc).isoformat()
-        save_state(store_path, state)
-        return 0
-
-    operations = [{"verb": "GET", "path": rel} for rel, _etag in pulls + conflicts]
-    try:
-        urls = request_presigned_urls(project_id, operations)
-    except AuthRefreshError as exc:
-        logger.warning("sync pull: %s", exc)
-        return 0
-    except PresignError as exc:
-        logger.warning("sync pull: presign request failed: %s", exc)
-        return 0
-
-    url_by_path = {
-        entry["path"]: entry["url"]
-        for entry in urls
-        if isinstance(entry, dict) and entry.get("verb") == "GET"
-    }
-
-    merged = 0
-
-    for rel, remote_etag in pulls:
-        url = url_by_path.get(rel)
-        if not url:
-            continue
-        try:
-            remote_content = fetch_via_presigned_url(url)
-        except PresignError:
-            logger.exception("sync pull: error pulling %s", rel)
-            continue
-        actual_rel, remote_content = _renumber_decision_if_collision(
-            store_path, rel, remote_content
-        )
-        actual_file = store_path / actual_rel
-        actual_file.parent.mkdir(parents=True, exist_ok=True)
-        actual_file.write_bytes(remote_content)
-        local_sha = compute_sha256(actual_file)
-        update_file_state(state, actual_rel, local_sha, remote_etag)
-        merged += 1
-
-    for rel, remote_etag in conflicts:
-        url = url_by_path.get(rel)
-        if not url:
-            continue
-        try:
-            remote_content = fetch_via_presigned_url(url)
-        except PresignError:
-            logger.exception("sync pull: error resolving conflict for %s", rel)
-            continue
-        actual_rel, remote_content = _renumber_decision_if_collision(
-            store_path, rel, remote_content
-        )
-        if actual_rel != rel:
-            # Decision-number collision, not a content conflict — write as a new file.
-            actual_file = store_path / actual_rel
-            actual_file.parent.mkdir(parents=True, exist_ok=True)
-            actual_file.write_bytes(remote_content)
-            local_sha = compute_sha256(actual_file)
-            update_file_state(state, actual_rel, local_sha, remote_etag)
-        else:
-            local_file = store_path / rel
-            try:
-                merged_content = resolve_conflict(
-                    store_path, local_file, remote_content, rel, state
-                )
-            except UnionMergeError:
-                # Leave the local file untouched rather than overwrite it with
-                # possibly-corrupt bytes. Session startup must never crash.
-                logger.exception("sync pull: union merge failed for %s", rel)
-                continue
-            local_file.write_bytes(merged_content)
-            local_sha = compute_sha256(local_file)
-            update_file_state(state, rel, local_sha, remote_etag)
-        merged += 1
-
-    state.last_full_sync = datetime.now(timezone.utc).isoformat()
-    save_state(store_path, state)
-
-    if merged:
-        logger.info("sync pull: merged %d file(s) for %s", merged, project_id)
-
-    return merged
 
 
 def push_after_write(project_id: str, store_path: Path) -> int:
@@ -269,76 +94,20 @@ def push_after_write(project_id: str, store_path: Path) -> int:
         return 0
 
     try:
-        from nauro.sync.merge import should_skip
-        from nauro.sync.remote import (
-            PresignError,
-            put_via_presigned_url,
-            request_presigned_urls,
-        )
-        from nauro.sync.state import (
-            compute_sha256,
-            file_changed_locally,
-            load_state,
-            save_state,
-            update_file_state,
-        )
+        from nauro.cli.commands.auth import AuthRefreshError
+        from nauro.sync.push import push_changed_files
+        from nauro.sync.remote import PresignError
     except ImportError:
         return 0
 
-    state = load_state(store_path)
-
-    changed: list[tuple[str, str, Path]] = []
-    for local_file in store_path.rglob("*"):
-        if not local_file.is_file():
-            continue
-        try:
-            rel = str(local_file.relative_to(store_path))
-        except ValueError:
-            continue
-        if should_skip(rel) or rel.startswith(".conflict-backup") or rel.startswith("__pycache__"):
-            continue
-        if not file_changed_locally(store_path, rel, state):
-            continue
-        local_sha = compute_sha256(local_file)
-        changed.append((rel, local_sha, local_file))
-
-    if not changed:
-        save_state(store_path, state)
-        return 0
-
-    operations = [{"verb": "PUT", "path": rel} for rel, _sha, _path in changed]
     try:
-        urls = request_presigned_urls(project_id, operations)
+        return push_changed_files(project_id, store_path)
     except AuthRefreshError as exc:
         logger.warning("sync push: %s", exc)
         return 0
     except PresignError as exc:
         logger.warning("sync push: presign request failed: %s", exc)
         return 0
-
-    url_by_path = {
-        entry["path"]: entry["url"]
-        for entry in urls
-        if isinstance(entry, dict) and entry.get("verb") == "PUT"
-    }
-
-    pushed = 0
-    for rel, local_sha, local_file in changed:
-        url = url_by_path.get(rel)
-        if not url:
-            continue
-        try:
-            new_etag = put_via_presigned_url(url, local_file)
-        except PresignError:
-            logger.exception("sync push: failed to push %s", rel)
-            continue
-        if new_etag:
-            update_file_state(state, rel, local_sha, new_etag)
-            pushed += 1
-
-    save_state(store_path, state)
-
-    if pushed:
-        logger.info("sync push: pushed %d file(s) for %s", pushed, project_id)
-
-    return pushed
+    except Exception:
+        logger.exception("sync push: unexpected failure for %s", project_id)
+        return 0

--- a/packages/nauro/src/nauro/sync/pull.py
+++ b/packages/nauro/src/nauro/sync/pull.py
@@ -1,0 +1,302 @@
+"""Store ← cloud pull-and-merge over the presign transport.
+
+Shared by ``nauro sync`` (the pull half of pull-then-push) and the
+SessionStart hook (``pull_before_session``). Both callers fetch the
+server manifest, diff it against sync-state, mint presigned GET URLs, and
+transfer changed files directly from S3 — then renumber colliding
+decisions and merge conflicting append-only files.
+
+The two callers differ only in how they surface progress and how they
+react to a union-merge failure: the CLI echoes to the terminal and must
+fail loud on a bad merge; the hook logs quietly and must never raise.
+That asymmetry is injected through the :class:`Reporter` protocol rather
+than branched inside the pull core, so the two paths cannot drift again.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Protocol
+
+from nauro_core import extract_decision_number
+
+from nauro.cli.commands.auth import AuthRefreshError
+from nauro.sync.merge import (
+    UnionMergeError,
+    detect_conflict,
+    resolve_conflict,
+    should_skip,
+)
+from nauro.sync.remote import (
+    PresignError,
+    fetch_manifest,
+    fetch_via_presigned_url,
+    request_presigned_urls,
+)
+from nauro.sync.state import (
+    compute_sha256,
+    file_changed_locally,
+    file_changed_remotely,
+    load_state,
+    save_state,
+    update_file_state,
+)
+
+
+class Reporter(Protocol):
+    """Surface for pull progress and merge-failure policy.
+
+    The CLI implementation echoes to the terminal and re-raises on a union
+    merge failure (``nauro sync`` must exit nonzero). The hook implementation
+    logs quietly and swallows the failure (session startup must never crash).
+    """
+
+    def info(self, msg: str) -> None:
+        """Report routine progress (file written, nothing to pull)."""
+
+    def warn(self, msg: str) -> None:
+        """Report a recoverable anomaly (presign URL shortfall, bad manifest)."""
+
+    def on_merge_failure(self, relative_path: str, exc: Exception) -> bool:
+        """Handle a union-merge failure for ``relative_path``.
+
+        Return True to re-raise (surface the failure to the caller) or False
+        to swallow it and leave the local file untouched.
+        """
+
+
+def _renumber_decision_if_collision(
+    store_path: Path,
+    rel: str,
+    content: bytes,
+) -> tuple[str, bytes]:
+    """If a pulled decision file's number collides with an existing local file, renumber it.
+
+    Returns ``(possibly_renamed_rel, possibly_updated_content)``. Non-decision
+    files, files with no parseable number, an exact-filename match, or no
+    collision all pass through unchanged.
+    """
+    if not rel.startswith("decisions/"):
+        return rel, content
+
+    filename = rel.split("/", 1)[1]
+    incoming_num = extract_decision_number(filename)
+    if incoming_num is None:
+        return rel, content
+    decisions_dir = store_path / "decisions"
+    if not decisions_dir.exists():
+        return rel, content
+
+    if (decisions_dir / filename).exists():
+        return rel, content
+
+    collision = False
+    for f in decisions_dir.glob("*.md"):
+        n = extract_decision_number(f.name)
+        if n is not None and n == incoming_num:
+            collision = True
+            break
+
+    if not collision:
+        return rel, content
+
+    existing_nums = set()
+    for f in decisions_dir.glob("*.md"):
+        n = extract_decision_number(f.name)
+        if n is not None:
+            existing_nums.add(n)
+
+    next_num = max(existing_nums) + 1 if existing_nums else 1
+
+    slug = _strip_number_prefix(filename)
+    new_filename = f"{next_num:03d}-{slug}"
+    new_rel = f"decisions/{new_filename}"
+
+    text = content.decode("utf-8", errors="replace")
+    text = _rewrite_decision_heading(text, incoming_num, next_num)
+    content = text.encode("utf-8")
+
+    return new_rel, content
+
+
+def _strip_number_prefix(filename: str) -> str:
+    """Drop a leading ``NNN-`` decision-number prefix from a filename.
+
+    Mirrors ``re.sub(r"^\\d+-", "", filename)``: the leading digit run plus the
+    single hyphen that immediately follows it are removed. A digit run with no
+    trailing hyphen is left intact.
+    """
+    idx = 0
+    while idx < len(filename) and filename[idx].isdigit():
+        idx += 1
+    if idx > 0 and idx < len(filename) and filename[idx] == "-":
+        return filename[idx + 1 :]
+    return filename
+
+
+def _rewrite_decision_heading(text: str, incoming_num: int, next_num: int) -> str:
+    """Rewrite the first ``# NNN —`` / ``# NNN -`` decision H1 to the new number.
+
+    Mirrors ``re.sub(rf"^# {incoming_num:03d}( [—-])", ..., count=1,
+    flags=re.MULTILINE)``: only the first line whose start matches ``# NNN``
+    followed by a space and an em-dash or hyphen is rewritten; the separator and
+    the rest of the line are preserved byte-for-byte.
+    """
+    old_prefix = f"# {incoming_num:03d}"
+    new_prefix = f"# {next_num:03d}"
+    lines = text.splitlines(keepends=True)
+    for i, line in enumerate(lines):
+        if line.startswith(f"{old_prefix} —") or line.startswith(f"{old_prefix} -"):
+            lines[i] = new_prefix + line[len(old_prefix) :]
+            break
+    return "".join(lines)
+
+
+def run_pull(
+    project_id: str,
+    store_path: Path,
+    reporter: Reporter,
+) -> int:
+    """Pull remote changes for ``project_id`` into ``store_path``.
+
+    Walks the server manifest, fetches every changed file in memory (so a
+    colliding decision can be renumbered before it touches disk), then writes
+    clean pulls and resolves conflicting append-only files. Returns the number
+    of files merged.
+
+    Caller-facing failures (manifest/presign auth-refresh or transport errors)
+    are reported through ``reporter`` and map to a 0 return. A union-merge
+    failure is routed to ``reporter.on_merge_failure`` — re-raised when it
+    returns True (the CLI), swallowed when it returns False (the hook).
+    """
+    try:
+        manifest = fetch_manifest(project_id)
+    except AuthRefreshError as exc:
+        reporter.warn(str(exc))
+        return 0
+    except PresignError as exc:
+        reporter.warn(f"manifest fetch failed: {exc}")
+        return 0
+
+    state = load_state(store_path)
+
+    pulls: list[tuple[str, str]] = []
+    conflicts: list[tuple[str, str]] = []
+    for entry in manifest:
+        rel = entry.get("path", "") if isinstance(entry, dict) else ""
+        if not rel or should_skip(rel):
+            continue
+        # Server validates per-op on presign, but the manifest itself is
+        # currently trusted — drop suspicious entries before they hit disk.
+        if ".." in Path(rel).parts or rel.startswith("/"):
+            reporter.warn(f"skipping suspicious manifest entry {rel!r}")
+            continue
+        remote_etag = entry.get("etag", "")
+        if not file_changed_remotely(remote_etag, rel, state):
+            continue
+
+        local_file = store_path / rel
+        local_changed = file_changed_locally(store_path, rel, state)
+        if not local_changed:
+            pulls.append((rel, remote_etag))
+            continue
+
+        local_sha = compute_sha256(local_file) if local_file.exists() else ""
+        if detect_conflict(rel, state, local_sha, remote_etag):
+            conflicts.append((rel, remote_etag))
+
+    if not pulls and not conflicts:
+        state.last_full_sync = datetime.now(timezone.utc).isoformat()
+        save_state(store_path, state)
+        reporter.info("No remote changes")
+        return 0
+
+    operations = [{"verb": "GET", "path": rel} for rel, _etag in pulls + conflicts]
+    try:
+        urls = request_presigned_urls(project_id, operations)
+    except AuthRefreshError as exc:
+        reporter.warn(str(exc))
+        return 0
+    except PresignError as exc:
+        reporter.warn(f"presign request failed: {exc}")
+        return 0
+
+    if len(urls) < len(operations):
+        reporter.warn(f"presign returned {len(urls)} URLs for {len(operations)} ops")
+
+    url_by_path = {
+        entry["path"]: entry["url"]
+        for entry in urls
+        if isinstance(entry, dict) and entry.get("verb") == "GET"
+    }
+
+    merged = 0
+
+    for rel, remote_etag in pulls:
+        url = url_by_path.get(rel)
+        if not url:
+            continue
+        try:
+            remote_content = fetch_via_presigned_url(url)
+        except PresignError as exc:
+            reporter.warn(f"error pulling {rel}: {exc}")
+            continue
+        actual_rel, remote_content = _renumber_decision_if_collision(
+            store_path, rel, remote_content
+        )
+        actual_file = store_path / actual_rel
+        actual_file.parent.mkdir(parents=True, exist_ok=True)
+        actual_file.write_bytes(remote_content)
+        local_sha = compute_sha256(actual_file)
+        update_file_state(state, actual_rel, local_sha, remote_etag)
+        merged += 1
+
+    for rel, remote_etag in conflicts:
+        url = url_by_path.get(rel)
+        if not url:
+            continue
+        try:
+            remote_content = fetch_via_presigned_url(url)
+        except PresignError as exc:
+            reporter.warn(f"error resolving conflict for {rel}: {exc}")
+            continue
+        actual_rel, remote_content = _renumber_decision_if_collision(
+            store_path, rel, remote_content
+        )
+        if actual_rel != rel:
+            # Decision-number collision, not a content conflict — write as a new file.
+            actual_file = store_path / actual_rel
+            actual_file.parent.mkdir(parents=True, exist_ok=True)
+            actual_file.write_bytes(remote_content)
+            local_sha = compute_sha256(actual_file)
+            update_file_state(state, actual_rel, local_sha, remote_etag)
+            merged += 1
+            continue
+
+        local_file = store_path / rel
+        try:
+            merged_content = resolve_conflict(store_path, local_file, remote_content, rel, state)
+        except UnionMergeError as exc:
+            # Leave the local file untouched rather than overwrite it with
+            # possibly-corrupt bytes. The reporter decides whether to surface.
+            if reporter.on_merge_failure(rel, exc):
+                raise
+            continue
+        local_file.write_bytes(merged_content)
+        local_sha = compute_sha256(local_file)
+        update_file_state(state, rel, local_sha, remote_etag)
+        merged += 1
+
+    state.last_full_sync = datetime.now(timezone.utc).isoformat()
+    save_state(store_path, state)
+
+    if merged:
+        reporter.info(f"Merged {merged} file(s) from remote")
+    else:
+        reporter.info("No remote changes")
+
+    return merged
+
+
+__all__ = ["Reporter", "run_pull"]

--- a/packages/nauro/tests/test_sync/test_hooks.py
+++ b/packages/nauro/tests/test_sync/test_hooks.py
@@ -22,7 +22,6 @@ from nauro.constants import REPO_CONFIG_MODE_CLOUD
 from nauro.store.config import save_config
 from nauro.store.registry import register_project, register_project_v2
 from nauro.sync.hooks import (
-    _renumber_decision_if_collision,
     pull_before_session,
     push_after_write,
 )
@@ -396,78 +395,38 @@ class TestPushAfterWritePresign:
 
         assert result == 0
 
+    def test_push_after_write_delegates_to_push_changed_files(self, cloud_store):
+        """The hook is a thin wrapper over the shared push module — it must
+        route the same changed-file set through ``push_changed_files`` exactly
+        once (retiring the old inline copy and its double-hash)."""
+        self._seed_synced_state(cloud_store)
+        (cloud_store / "stack.md").write_text("changed\n")
 
-# --- decision collision renumbering (unchanged from pre-port) ---
+        with patch("nauro.sync.push.push_changed_files", return_value=2) as mock_push:
+            result = push_after_write(CLOUD_PID, cloud_store)
+
+        assert result == 2
+        assert mock_push.call_count == 1
+        assert mock_push.call_args.args == (CLOUD_PID, cloud_store)
 
 
-class TestRenumberDecisionIfCollision:
+# --- hook never-raise envelope ---
+
+
+class TestPullBeforeSessionNeverRaises:
+    """``pull_before_session`` must never propagate an exception and must stay
+    silent on stdout even when the shared core's dependencies blow up."""
+
     @pytest.fixture()
-    def project_store(self, tmp_path):
-        store = register_project("renumproj", [tmp_path])
-        scaffold_project_store("renumproj", store)
+    def cloud_store(self, tmp_path):
+        store = _scaffolded_cloud_project("silentpull", tmp_path)
+        _seed_token()
         return store
 
-    def test_no_collision_passes_through(self, project_store):
-        decisions_dir = project_store / "decisions"
-        decisions_dir.mkdir(exist_ok=True)
-        (decisions_dir / "001-existing.md").write_text("# 001 — Existing")
+    def test_returns_zero_and_silent_when_run_pull_raises(self, cloud_store, capsys):
+        with patch("nauro.sync.pull.run_pull", side_effect=RuntimeError("unexpected boom")):
+            result = pull_before_session(CLOUD_PID, cloud_store)
 
-        content = b"# 002 \xe2\x80\x94 New decision\n\nSome content"
-        rel, out = _renumber_decision_if_collision(project_store, "decisions/002-new.md", content)
-
-        assert rel == "decisions/002-new.md"
-        assert out == content
-
-    def test_collision_renumbers(self, project_store):
-        decisions_dir = project_store / "decisions"
-        decisions_dir.mkdir(exist_ok=True)
-        (decisions_dir / "003-local-decision.md").write_text("# 003 — Local decision")
-
-        content = b"# 003 \xe2\x80\x94 Remote decision\n\nRemote content"
-        rel, out = _renumber_decision_if_collision(
-            project_store,
-            "decisions/003-remote-decision.md",
-            content,
-        )
-
-        assert rel == "decisions/004-remote-decision.md"
-        assert b"# 004 " in out
-        assert b"Remote content" in out
-
-    def test_collision_skips_multiple_taken_numbers(self, project_store):
-        decisions_dir = project_store / "decisions"
-        decisions_dir.mkdir(exist_ok=True)
-        (decisions_dir / "005-a.md").write_text("# 005 — A")
-        (decisions_dir / "006-b.md").write_text("# 006 — B")
-
-        content = b"# 005 \xe2\x80\x94 Incoming\n\nContent"
-        rel, out = _renumber_decision_if_collision(
-            project_store,
-            "decisions/005-incoming.md",
-            content,
-        )
-
-        assert rel == "decisions/007-incoming.md"
-        assert b"# 007 " in out
-
-    def test_exact_filename_match_is_not_collision(self, project_store):
-        decisions_dir = project_store / "decisions"
-        decisions_dir.mkdir(exist_ok=True)
-        (decisions_dir / "003-same-slug.md").write_text("# 003 — Same slug")
-
-        content = b"# 003 \xe2\x80\x94 Same slug\n\nUpdated content"
-        rel, out = _renumber_decision_if_collision(
-            project_store,
-            "decisions/003-same-slug.md",
-            content,
-        )
-
-        assert rel == "decisions/003-same-slug.md"
-        assert out == content
-
-    def test_non_decision_files_pass_through(self, project_store):
-        content = b"some content"
-        rel, out = _renumber_decision_if_collision(project_store, "state.md", content)
-
-        assert rel == "state.md"
-        assert out == content
+        assert result == 0
+        captured = capsys.readouterr()
+        assert captured.out == ""

--- a/packages/nauro/tests/test_sync/test_pull.py
+++ b/packages/nauro/tests/test_sync/test_pull.py
@@ -1,0 +1,410 @@
+"""Tests for the shared pull core (``nauro.sync.pull``).
+
+``run_pull`` is the single pull-and-merge implementation behind both
+``nauro sync`` and the SessionStart hook. The two callers differ only in
+their :class:`~nauro.sync.pull.Reporter`: the CLI echoes and re-raises on
+a union-merge failure, the hook logs and swallows. These tests drive the
+core directly with both reporter flavors plus a recording stub, and pin
+the renumber-on-collision helper byte-for-byte against the canonical
+cases the hook previously owned.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from nauro.constants import REPO_CONFIG_MODE_CLOUD
+from nauro.store.config import save_config
+from nauro.store.registry import register_project, register_project_v2
+from nauro.sync.merge import UnionMergeError
+from nauro.sync.pull import _renumber_decision_if_collision, run_pull
+from nauro.sync.state import (
+    FileState,
+    SyncState,
+    compute_sha256,
+    load_state,
+    save_state,
+)
+from nauro.templates.scaffolds import scaffold_project_store
+
+CLOUD_PID = "01KQ6AZGNA0B3QBF67NBXP3S45"
+
+
+def _ok(status: int, payload: dict) -> httpx.Response:
+    return httpx.Response(
+        status,
+        content=json.dumps(payload).encode("utf-8"),
+        headers={"content-type": "application/json"},
+    )
+
+
+def _seed_token() -> None:
+    save_config(
+        {
+            "auth": {
+                "sub": "auth0|test",
+                "access_token": "tok_orig",
+                "refresh_token": "refresh_orig",
+            }
+        }
+    )
+
+
+def _scaffolded_cloud_project(name: str, repo_path: Path, project_id: str = CLOUD_PID) -> Path:
+    _pid, store = register_project_v2(
+        name,
+        [repo_path],
+        mode=REPO_CONFIG_MODE_CLOUD,
+        server_url="https://example.test",
+        project_id=project_id,
+    )
+    scaffold_project_store(name, store)
+    return store
+
+
+def _manifest(files, next_cursor=None) -> httpx.Response:
+    return _ok(200, {"files": files, "next_cursor": next_cursor})
+
+
+def _presign(ops) -> httpx.Response:
+    return _ok(
+        200,
+        {
+            "urls": [
+                {
+                    "verb": op["verb"],
+                    "path": op["path"],
+                    "url": f"https://s3.example/{op['verb']}/{op['path']}",
+                    "expires_at": "2026-05-16T13:00:00Z",
+                }
+                for op in ops
+            ]
+        },
+    )
+
+
+class _RecordingReporter:
+    """Records messages; ``on_merge_failure`` returns the configured policy."""
+
+    def __init__(self, *, reraise: bool) -> None:
+        self.reraise = reraise
+        self.infos: list[str] = []
+        self.warns: list[str] = []
+        self.merge_failures: list[tuple[str, Exception]] = []
+
+    def info(self, msg: str) -> None:
+        self.infos.append(msg)
+
+    def warn(self, msg: str) -> None:
+        self.warns.append(msg)
+
+    def on_merge_failure(self, relative_path: str, exc: Exception) -> bool:
+        self.merge_failures.append((relative_path, exc))
+        return self.reraise
+
+
+# --- run_pull happy path (both reporter policies behave identically here) ---
+
+
+class TestRunPullCleanPull:
+    @pytest.fixture()
+    def cloud_store(self, tmp_path):
+        store = _scaffolded_cloud_project("pullcore", tmp_path)
+        _seed_token()
+        return store
+
+    @pytest.mark.parametrize("reraise", [True, False])
+    def test_clean_pull_writes_file_and_updates_state(self, cloud_store, reraise):
+        rel = "decisions/099-remote.md"
+        manifest = _manifest([{"path": rel, "etag": '"new"', "size": 1, "last_modified": "x"}])
+        presign = _presign([{"verb": "GET", "path": rel}])
+
+        def fake_get(url, **kwargs):
+            if "/sync/manifest" in url:
+                return manifest
+            return httpx.Response(200, content=b"# 099\nfresh remote body\n")
+
+        reporter = _RecordingReporter(reraise=reraise)
+        with (
+            patch("nauro.sync.remote.httpx.get", side_effect=fake_get),
+            patch("nauro.sync.remote.httpx.post", return_value=presign),
+        ):
+            merged = run_pull(CLOUD_PID, cloud_store, reporter)
+
+        assert merged == 1
+        assert (cloud_store / rel).read_bytes() == b"# 099\nfresh remote body\n"
+        state = load_state(cloud_store)
+        assert state.files[rel].remote_etag == '"new"'
+        assert reporter.infos == ["Merged 1 file(s) from remote"]
+        assert reporter.warns == []
+
+    @pytest.mark.parametrize("reraise", [True, False])
+    def test_append_only_conflict_invokes_resolve_and_writes_merge(self, cloud_store, reraise):
+        # state_history.md is append-only with section-aware set-union merge.
+        rel = "state_history.md"
+        local = cloud_store / rel
+        local.write_text("## History\n\nlocal entry\n")
+        local_sha = compute_sha256(local)
+
+        state = SyncState()
+        state.files[rel] = FileState(
+            local_sha256="old_sha",
+            remote_etag='"old_etag"',
+            last_sync="2026-05-16T00:00:00Z",
+        )
+        save_state(cloud_store, state)
+
+        manifest = _manifest([{"path": rel, "etag": '"new_etag"', "size": 1, "last_modified": "x"}])
+        presign = _presign([{"verb": "GET", "path": rel}])
+
+        def fake_get(url, **kwargs):
+            if "/sync/manifest" in url:
+                return manifest
+            return httpx.Response(200, content=b"## History\n\nremote entry\n")
+
+        reporter = _RecordingReporter(reraise=reraise)
+        with (
+            patch("nauro.sync.remote.httpx.get", side_effect=fake_get),
+            patch("nauro.sync.remote.httpx.post", return_value=presign),
+        ):
+            merged = run_pull(CLOUD_PID, cloud_store, reporter)
+
+        assert merged == 1
+        merged_bytes = local.read_bytes()
+        # Union of both sides — neither entry was dropped.
+        assert b"local entry" in merged_bytes
+        assert b"remote entry" in merged_bytes
+        assert compute_sha256(local) != local_sha
+        assert reporter.merge_failures == []
+
+
+# --- the bug-fix pin: decision-number collision renumbers, never overwrites ---
+
+
+class TestRunPullDecisionCollision:
+    @pytest.fixture()
+    def cloud_store(self, tmp_path):
+        store = _scaffolded_cloud_project("collisioncore", tmp_path)
+        _seed_token()
+        return store
+
+    def test_colliding_decision_written_as_next_sequential_file_echo_reporter(self, cloud_store):
+        """The CLI (echo) reporter is the reconciled path that previously
+        overwrote. A pulled decision whose number collides with a local one is
+        written as the NEXT sequential file with its H1 body number rewritten;
+        the local file is left untouched."""
+        from nauro.cli.commands.sync import _EchoReporter
+
+        decisions_dir = cloud_store / "decisions"
+        decisions_dir.mkdir(exist_ok=True)
+        local_file = decisions_dir / "003-local-decision.md"
+        local_file.write_bytes(b"# 003 \xe2\x80\x94 Local decision\n\nLocal body\n")
+        local_original = local_file.read_bytes()
+
+        rel = "decisions/003-remote-decision.md"
+        manifest = _manifest([{"path": rel, "etag": '"new"', "size": 1, "last_modified": "x"}])
+        presign = _presign([{"verb": "GET", "path": rel}])
+
+        remote_body = b"# 003 \xe2\x80\x94 Remote decision\n\nRemote body\n"
+
+        def fake_get(url, **kwargs):
+            if "/sync/manifest" in url:
+                return manifest
+            return httpx.Response(200, content=remote_body)
+
+        with (
+            patch("nauro.sync.remote.httpx.get", side_effect=fake_get),
+            patch("nauro.sync.remote.httpx.post", return_value=presign),
+        ):
+            merged = run_pull(CLOUD_PID, cloud_store, _EchoReporter())
+
+        assert merged == 1
+        # Local decision untouched — this is the data-loss bug the fix closes.
+        assert local_file.read_bytes() == local_original
+        # Remote landed as the next sequential file with the H1 number rewritten.
+        new_file = decisions_dir / "004-remote-decision.md"
+        assert new_file.exists()
+        new_bytes = new_file.read_bytes()
+        assert new_bytes == b"# 004 \xe2\x80\x94 Remote decision\n\nRemote body\n"
+        # State keys the renumbered path, not the colliding incoming one.
+        state = load_state(cloud_store)
+        assert "decisions/004-remote-decision.md" in state.files
+        assert rel not in state.files
+
+
+# --- union-merge routing: one test per reporter policy ---
+
+
+class TestRunPullUnionMergeRouting:
+    @pytest.fixture()
+    def cloud_store(self, tmp_path):
+        store = _scaffolded_cloud_project("mergecore", tmp_path)
+        _seed_token()
+        return store
+
+    def _setup_conflict(self, cloud_store):
+        rel = "decisions/050-conflicted.md"
+        local_file = cloud_store / rel
+        local_file.parent.mkdir(parents=True, exist_ok=True)
+        local_file.write_bytes(b"# 050\nlocal body\n")
+
+        state = SyncState()
+        state.files[rel] = FileState(
+            local_sha256="old_sha",
+            remote_etag='"old_etag"',
+            last_sync="2026-05-16T00:00:00Z",
+        )
+        save_state(cloud_store, state)
+
+        manifest = _manifest([{"path": rel, "etag": '"new_etag"', "size": 1, "last_modified": "x"}])
+        presign = _presign([{"verb": "GET", "path": rel}])
+
+        def fake_get(url, **kwargs):
+            if "/sync/manifest" in url:
+                return manifest
+            return httpx.Response(200, content=b"# 050\nremote body\n")
+
+        return rel, local_file, fake_get, presign
+
+    def test_echo_reporter_reraises_on_union_merge_failure(self, cloud_store, monkeypatch):
+        """The echo reporter returns True from on_merge_failure → run_pull
+        re-raises so nauro sync fails loud. The local file is left untouched."""
+        from nauro.cli.commands.sync import _EchoReporter
+
+        rel, local_file, fake_get, presign = self._setup_conflict(cloud_store)
+        original = local_file.read_bytes()
+
+        def boom(*args, **kwargs):
+            raise UnionMergeError("simulated git failure")
+
+        monkeypatch.setattr("nauro.sync.merge._union_merge", boom)
+
+        with (
+            patch("nauro.sync.remote.httpx.get", side_effect=fake_get),
+            patch("nauro.sync.remote.httpx.post", return_value=presign),
+            pytest.raises(UnionMergeError),
+        ):
+            run_pull(CLOUD_PID, cloud_store, _EchoReporter())
+
+        assert local_file.read_bytes() == original
+
+    def test_logging_reporter_swallows_union_merge_failure(self, cloud_store, monkeypatch):
+        """The logging reporter returns False → run_pull swallows the failure,
+        returns without raising, and leaves the file byte-identical."""
+        from nauro.sync.hooks import _LoggingReporter
+
+        rel, local_file, fake_get, presign = self._setup_conflict(cloud_store)
+        original = local_file.read_bytes()
+
+        def boom(*args, **kwargs):
+            raise UnionMergeError("simulated git failure")
+
+        monkeypatch.setattr("nauro.sync.merge._union_merge", boom)
+
+        with (
+            patch("nauro.sync.remote.httpx.get", side_effect=fake_get),
+            patch("nauro.sync.remote.httpx.post", return_value=presign),
+        ):
+            merged = run_pull(CLOUD_PID, cloud_store, _LoggingReporter())
+
+        # The failed file was skipped, not counted, and never raised.
+        assert merged == 0
+        assert local_file.read_bytes() == original
+
+
+# --- renumber helper: byte-identical to the canonical pre-port cases ---
+
+
+class TestRenumberDecisionIfCollision:
+    @pytest.fixture()
+    def project_store(self, tmp_path):
+        store = register_project("renumproj", [tmp_path])
+        scaffold_project_store("renumproj", store)
+        return store
+
+    def test_no_collision_passes_through(self, project_store):
+        decisions_dir = project_store / "decisions"
+        decisions_dir.mkdir(exist_ok=True)
+        (decisions_dir / "001-existing.md").write_text("# 001 — Existing")
+
+        content = b"# 002 \xe2\x80\x94 New decision\n\nSome content"
+        rel, out = _renumber_decision_if_collision(project_store, "decisions/002-new.md", content)
+
+        assert rel == "decisions/002-new.md"
+        assert out == content
+
+    def test_collision_renumbers(self, project_store):
+        decisions_dir = project_store / "decisions"
+        decisions_dir.mkdir(exist_ok=True)
+        (decisions_dir / "003-local-decision.md").write_text("# 003 — Local decision")
+
+        content = b"# 003 \xe2\x80\x94 Remote decision\n\nRemote content"
+        rel, out = _renumber_decision_if_collision(
+            project_store,
+            "decisions/003-remote-decision.md",
+            content,
+        )
+
+        assert rel == "decisions/004-remote-decision.md"
+        # Byte-identical to the old regex rewrite: only the number changed.
+        assert out == b"# 004 \xe2\x80\x94 Remote decision\n\nRemote content"
+
+    def test_collision_skips_multiple_taken_numbers(self, project_store):
+        decisions_dir = project_store / "decisions"
+        decisions_dir.mkdir(exist_ok=True)
+        (decisions_dir / "005-a.md").write_text("# 005 — A")
+        (decisions_dir / "006-b.md").write_text("# 006 — B")
+
+        content = b"# 005 \xe2\x80\x94 Incoming\n\nContent"
+        rel, out = _renumber_decision_if_collision(
+            project_store,
+            "decisions/005-incoming.md",
+            content,
+        )
+
+        assert rel == "decisions/007-incoming.md"
+        assert out == b"# 007 \xe2\x80\x94 Incoming\n\nContent"
+
+    def test_collision_renumbers_hyphen_separator_heading(self, project_store):
+        """The old regex group ``( [—-])`` also matched a plain ASCII hyphen
+        separator; the string-ops rewrite must too."""
+        decisions_dir = project_store / "decisions"
+        decisions_dir.mkdir(exist_ok=True)
+        (decisions_dir / "008-local.md").write_text("# 008 - Local")
+
+        content = b"# 008 - Remote decision\n\nRemote content"
+        rel, out = _renumber_decision_if_collision(
+            project_store,
+            "decisions/008-remote.md",
+            content,
+        )
+
+        assert rel == "decisions/009-remote.md"
+        assert out == b"# 009 - Remote decision\n\nRemote content"
+
+    def test_exact_filename_match_is_not_collision(self, project_store):
+        decisions_dir = project_store / "decisions"
+        decisions_dir.mkdir(exist_ok=True)
+        (decisions_dir / "003-same-slug.md").write_text("# 003 — Same slug")
+
+        content = b"# 003 \xe2\x80\x94 Same slug\n\nUpdated content"
+        rel, out = _renumber_decision_if_collision(
+            project_store,
+            "decisions/003-same-slug.md",
+            content,
+        )
+
+        assert rel == "decisions/003-same-slug.md"
+        assert out == content
+
+    def test_non_decision_files_pass_through(self, project_store):
+        content = b"some content"
+        rel, out = _renumber_decision_if_collision(project_store, "state.md", content)
+
+        assert rel == "state.md"
+        assert out == content

--- a/packages/nauro/tests/test_sync/test_sync_command.py
+++ b/packages/nauro/tests/test_sync/test_sync_command.py
@@ -271,6 +271,156 @@ class TestSyncHonesty:
         assert "Warning: this is a cloud-mode project" not in combined
 
 
+class TestSyncPullSurfacesAndMerges:
+    """End-to-end ``nauro sync`` pull behaviour through the shared core.
+
+    A clean pull echoes a "Merged N file(s)" line; a union-merge failure
+    surfaces and exits nonzero rather than reporting a partial success.
+    """
+
+    @staticmethod
+    def _seed_cloud_auth(name: str, tmp_path: Path):
+        import json as _json
+
+        from nauro.store.config import save_config
+
+        store = _scaffolded_cloud_project(name, tmp_path)
+        save_config(
+            {
+                "auth": {
+                    "sub": "auth0|test",
+                    "access_token": "tok_orig",
+                    "refresh_token": "refresh_orig",
+                }
+            }
+        )
+        return store, _json
+
+    @staticmethod
+    def _http_ok(payload, _json):
+        import httpx
+
+        return httpx.Response(
+            200,
+            content=_json.dumps(payload).encode("utf-8"),
+            headers={"content-type": "application/json"},
+        )
+
+    def test_clean_pull_echoes_merged_count(self, tmp_path, monkeypatch):
+        from unittest.mock import MagicMock
+
+        import httpx
+
+        store, _json = self._seed_cloud_auth("mergedcount", tmp_path)
+        rel = "decisions/099-remote.md"
+
+        def fake_get(url, **kwargs):
+            if "/sync/manifest" in url:
+                return self._http_ok(
+                    {
+                        "files": [{"path": rel, "etag": '"new"', "size": 1, "last_modified": "x"}],
+                        "next_cursor": None,
+                    },
+                    _json,
+                )
+            return httpx.Response(200, content=b"# 099\nfresh remote body\n")
+
+        def fake_post(url, **kwargs):
+            ops = kwargs.get("json", {}).get("operations", [])
+            return self._http_ok(
+                {
+                    "urls": [
+                        {
+                            "verb": op["verb"],
+                            "path": op["path"],
+                            "url": f"https://s3.example/{op['verb']}/{op['path']}",
+                            "expires_at": "2026-05-16T13:00:00Z",
+                        }
+                        for op in ops
+                    ]
+                },
+                _json,
+            )
+
+        put_response = MagicMock(spec=httpx.Response)
+        put_response.status_code = 200
+        put_response.headers = {"ETag": '"e_pushed"'}
+
+        with (
+            patch("nauro.sync.remote.httpx.get", side_effect=fake_get),
+            patch("nauro.sync.remote.httpx.post", side_effect=fake_post),
+            patch("nauro.sync.remote.httpx.put", return_value=put_response),
+        ):
+            result = runner.invoke(app, ["sync", "--project", "mergedcount"])
+
+        assert result.exit_code == 0, result.output + (result.stderr or "")
+        assert "Merged 1 file(s) from remote" in result.output
+
+    def test_union_merge_failure_exits_one(self, tmp_path, monkeypatch):
+        import httpx
+
+        from nauro.sync.merge import UnionMergeError
+        from nauro.sync.state import FileState, SyncState, save_state
+
+        store, _json = self._seed_cloud_auth("mergefail", tmp_path)
+        rel = "decisions/051-conflicted.md"
+        local_file = store / rel
+        local_file.parent.mkdir(parents=True, exist_ok=True)
+        local_file.write_bytes(b"# 051\nlocal body\n")
+
+        state = SyncState()
+        state.files[rel] = FileState(
+            local_sha256="old_sha",
+            remote_etag='"old_etag"',
+            last_sync="2026-05-16T00:00:00Z",
+        )
+        save_state(store, state)
+
+        def fake_get(url, **kwargs):
+            if "/sync/manifest" in url:
+                return self._http_ok(
+                    {
+                        "files": [
+                            {"path": rel, "etag": '"new_etag"', "size": 1, "last_modified": "x"}
+                        ],
+                        "next_cursor": None,
+                    },
+                    _json,
+                )
+            return httpx.Response(200, content=b"# 051\nremote body\n")
+
+        def fake_post(url, **kwargs):
+            ops = kwargs.get("json", {}).get("operations", [])
+            return self._http_ok(
+                {
+                    "urls": [
+                        {
+                            "verb": op["verb"],
+                            "path": op["path"],
+                            "url": f"https://s3.example/{op['verb']}/{op['path']}",
+                            "expires_at": "2026-05-16T13:00:00Z",
+                        }
+                        for op in ops
+                    ]
+                },
+                _json,
+            )
+
+        def boom(*args, **kwargs):
+            raise UnionMergeError("simulated git failure")
+
+        monkeypatch.setattr("nauro.sync.merge._union_merge", boom)
+
+        with (
+            patch("nauro.sync.remote.httpx.get", side_effect=fake_get),
+            patch("nauro.sync.remote.httpx.post", side_effect=fake_post),
+        ):
+            result = runner.invoke(app, ["sync", "--project", "mergefail"])
+
+        assert result.exit_code == 1
+        assert isinstance(result.exception, UnionMergeError)
+
+
 class TestLinkCloudRefusesWithoutAuth:
     """`nauro link --cloud` must refuse when the install has no Auth0 token —
     presigned URLs are minted server-side from the bearer, so without one we

--- a/packages/nauro/tests/test_sync/test_sync_presign.py
+++ b/packages/nauro/tests/test_sync/test_sync_presign.py
@@ -338,10 +338,11 @@ class TestPullViaPresign:
     def test_union_merge_failure_surfaces_and_leaves_file_untouched(
         self, cloud_store, monkeypatch, capsys
     ):
-        """Explicit ``nauro sync`` must not report success on a failed merge.
+        """Explicit ``nauro sync`` must fail loud on a failed merge.
 
-        The failure is echoed to stderr, the file is left untouched, and it is
-        not counted toward the merged total.
+        The echo reporter re-raises the ``UnionMergeError`` so the pull does
+        not report a partial success; the failure is echoed to stderr and the
+        file is left untouched on disk.
         """
         from nauro.sync.merge import UnionMergeError
 
@@ -380,14 +381,13 @@ class TestPullViaPresign:
         with (
             patch.object(remote.httpx, "get", side_effect=fake_get),
             patch.object(remote.httpx, "post", return_value=presign),
+            pytest.raises(UnionMergeError),
         ):
             from nauro.cli.commands.sync import _pull_from_cloud
 
-            merged = _pull_from_cloud(cloud_store.name, cloud_store)
+            _pull_from_cloud(cloud_store.name, cloud_store)
 
-        # Failed file is not counted as merged.
-        assert merged == 0
-        # A clear error line was surfaced to stderr.
+        # A clear error line was surfaced to stderr before the re-raise.
         err = capsys.readouterr().err
         assert rel in err
         assert "merge failed" in err


### PR DESCRIPTION
## Why

`nauro sync` could silently overwrite a local decision. The CLI pull path wrote a remote decision file straight to disk with no number-collision check, so a remote `decisions/003-*.md` whose number matched an existing local 003 clobbered the local file — a data-loss path. The SessionStart hook already handled this correctly, renumbering a colliding incoming decision to the next sequential file. The two pull-and-triage implementations had diverged: the canonical renumber behavior lived only in the hook. A third inline copy of the push path in the hook also double-hashed every file (it called `file_changed_locally`, which hashes, then `compute_sha256` again).

## Approach

Extract one `sync/pull.py` core, mirroring the existing `sync/push.py`, parameterized by a `Reporter` protocol (`info` / `warn` / `on_merge_failure`). The two legitimate asymmetries between the callers are injected through the reporter rather than branched inside the core, so the paths cannot drift again:

- CLI echoes to the terminal; the hook logs quietly.
- On a union-merge failure the CLI must fail loud (an explicit sync cannot report a partial success), while the hook must never raise (session startup cannot crash). `on_merge_failure` returns True to re-raise, False to swallow.

The CLI now renumbers on collision and uses an in-memory-then-write transfer (fetch bytes, renumber, then write) — the prior write-straight-to-disk path is what made the overwrite possible. The hook's push routes through the shared `push.push_changed_files`, retiring the inline copy and its double-hash. The renumber helper moved into `pull.py`; its `re.sub` calls are replaced with plain string ops (`extract_decision_number` for the leading-digit walk, `splitlines()` + `startswith` for the H1 rewrite), byte-identical to the prior output.

`merge.py` is unchanged — `UnionMergeError`, `resolve_conflict`, `should_skip`, and `detect_conflict` are consumed as-is.

## What changed

- **New `sync/pull.py`** — the shared `run_pull(project_id, store_path, reporter)` core plus the renumber helper.
- **`sync/hooks.py`** — `pull_before_session` is now a thin wrapper supplying a logging reporter inside the never-raise envelope; `push_after_write` wraps `push.push_changed_files`.
- **`cli/commands/sync.py`** — `_pull_via_presign` is now a thin wrapper supplying an echo reporter that fails loud; the inline missing-repo warn loop was replaced with the shared `warn_then_regen` helper.

## What to review

- The renumber reconciliation in the CLI path: `nauro sync` now renumbers a colliding pulled decision to the next sequential file instead of overwriting the local one. This is the data-loss fix and the main observable behavior change.
- The union-merge routing through `on_merge_failure`: the CLI now re-raises (exits nonzero) on a failed merge where it previously echoed an error and returned a partial count. The pre-existing presign test for this case was updated accordingly. On-disk preservation is unchanged (failed file left byte-identical); the abort-on-first-failure contract matches git-pull semantics.
- The regex → string-ops swap in `_renumber_decision_if_collision` and `_rewrite_decision_heading` / `_strip_number_prefix`. Output is pinned byte-identical against the canonical em-dash and hyphen heading cases.

## What's deferred

- `remote.get_via_presigned_url` is no longer called by production code after the CLI moved to the in-memory transfer; it remains defined and exported and can be retired in a follow-up.
- Continue-and-report-all (surface every union-merge failure in one run, rather than aborting on the first) is a possible fast-follow if serial union-merge failures show up in practice.
- Broader sync/snapshot serializer consolidation and other cleanup themes are out of scope here.

## Test plan

- `packages/nauro/tests/test_sync/`: 108 pass (new `test_pull.py` covers both reporter flavors, the collision bug-fix pin against the echo reporter, union-merge routing per flavor, and the byte-identical renumber cases; `test_sync_command.py` adds CLI e2e for the merged-count echo and the `exit_code == 1` merge-failure path; `test_hooks.py` covers push delegation and the never-raise envelope).
- Full `packages/nauro/tests/`: 1174 pass, 10 pre-existing skips, no regressions.
- `packages/nauro-core/tests/`: 706 pass.
- `ruff check` and `ruff format --check` clean across `packages/`.
