### PR TITLE
Add canonical snapshot serializer to nauro-core; decouple diff header from version

### DIFF
--- a/packages/nauro-core/src/nauro_core/__init__.py
+++ b/packages/nauro-core/src/nauro_core/__init__.py
@@ -7,6 +7,9 @@ from importlib.metadata import version
 
 from nauro_core import operations as operations
 from nauro_core.constants import (
+    CHARS_PER_TOKEN as CHARS_PER_TOKEN,
+)
+from nauro_core.constants import (
     DECISION_HASHES_FILE as DECISION_HASHES_FILE,
 )
 from nauro_core.constants import (
@@ -26,6 +29,9 @@ from nauro_core.constants import (
 )
 from nauro_core.constants import (
     L1_DECISIONS_SUMMARY_LIMIT as L1_DECISIONS_SUMMARY_LIMIT,
+)
+from nauro_core.constants import (
+    LEGACY_SCHEMA_VERSION as LEGACY_SCHEMA_VERSION,
 )
 from nauro_core.constants import (
     MAX_APPROACH_LENGTH as MAX_APPROACH_LENGTH,
@@ -65,6 +71,9 @@ from nauro_core.constants import (
 )
 from nauro_core.constants import (
     REVERSIBILITY_LEVELS as REVERSIBILITY_LEVELS,
+)
+from nauro_core.constants import (
+    SNAPSHOT_SCHEMA_VERSION as SNAPSHOT_SCHEMA_VERSION,
 )
 from nauro_core.constants import (
     SNAPSHOTS_DIR as SNAPSHOTS_DIR,
@@ -251,6 +260,15 @@ from nauro_core.search import (
 )
 from nauro_core.search import (
     bm25_search as bm25_search,
+)
+from nauro_core.snapshot import (
+    normalize_snapshot as normalize_snapshot,
+)
+from nauro_core.snapshot import (
+    serialize_snapshot as serialize_snapshot,
+)
+from nauro_core.snapshot import (
+    snapshot_schema_version as snapshot_schema_version,
 )
 from nauro_core.state import (
     StateUpdateResult as StateUpdateResult,

--- a/packages/nauro-core/src/nauro_core/constants.py
+++ b/packages/nauro-core/src/nauro_core/constants.py
@@ -25,6 +25,15 @@ MIN_RATIONALE_LENGTH = 20
 # ── Decision hash dedup ──
 DECISION_HASHES_FILE = ".decision-hashes.json"
 
+# ── Snapshot schema versioning ──
+# Stamped onto every snapshot the serializer writes. Snapshots written
+# before the field existed read back as LEGACY_SCHEMA_VERSION.
+SNAPSHOT_SCHEMA_VERSION = 1
+LEGACY_SCHEMA_VERSION = 0
+
+# ── Token heuristic ──
+CHARS_PER_TOKEN = 4  # rough chars-per-token for GPT/Claude family models
+
 # ── Store filenames ──
 PROJECT_MD = "project.md"
 STATE_MD = "state.md"

--- a/packages/nauro-core/src/nauro_core/operations/__init__.py
+++ b/packages/nauro-core/src/nauro_core/operations/__init__.py
@@ -8,6 +8,9 @@ emit no telemetry; transports own event emission.
 
 from nauro_core.operations._in_memory_store import InMemoryStore as InMemoryStore
 from nauro_core.operations.check_decision import check_decision as check_decision
+from nauro_core.operations.decision_lookup import (
+    find_decision_stem_by_id as find_decision_stem_by_id,
+)
 from nauro_core.operations.diff_since_last_session import (
     diff_since_last_session as diff_since_last_session,
 )
@@ -58,6 +61,7 @@ __all__ = [
     "UpdateStateResult",
     "check_decision",
     "diff_since_last_session",
+    "find_decision_stem_by_id",
     "flag_question",
     "get_context",
     "get_decision",

--- a/packages/nauro-core/src/nauro_core/operations/diff_since_last_session.py
+++ b/packages/nauro-core/src/nauro_core/operations/diff_since_last_session.py
@@ -61,12 +61,13 @@ def diff_since_last_session(
 
     Returns:
         :class:`DiffSinceLastSessionResult`. ``diff`` carries the
-        rendered diff body. For the empty/insufficient cases the
-        adapter renders the canonical sentinel strings exposed by this
-        module and short-circuits before calling in; the kernel itself
-        only handles the "diff two dicts" path plus the
-        ``baseline == latest`` no-op. ``error`` stays unset — the
-        sentinel paths are normal success-path results, not errors.
+        rendered diff body. For the empty/insufficient and
+        one-snapshot-covers-range cases the adapter renders the canonical
+        sentinel strings exposed by this module and short-circuits before
+        calling in; the kernel itself only handles the
+        ``(None, *)``/``(*, None)`` sentinels and the "diff two dicts"
+        path. ``error`` stays unset — the sentinel paths are normal
+        success-path results, not errors.
     """
     # ``store`` is part of the locked kernel signature (see PRs 1-6); the
     # diff body operates on the supplied snapshot dicts only.
@@ -83,12 +84,6 @@ def diff_since_last_session(
         )
         return DiffSinceLastSessionResult(diff=diff, cutoff_date_used=cutoff_date_used)
 
-    if baseline_snapshot.get("version") == latest_snapshot.get("version"):
-        return DiffSinceLastSessionResult(
-            diff=ONE_SNAPSHOT_COVERS_RANGE,
-            cutoff_date_used=cutoff_date_used,
-        )
-
     return DiffSinceLastSessionResult(
         diff=_render_diff(baseline_snapshot, latest_snapshot),
         cutoff_date_used=cutoff_date_used,
@@ -99,19 +94,22 @@ def _render_diff(snap_a: dict, snap_b: dict) -> str:
     """Render the semantic diff body between two snapshot dicts."""
     # Version numbers come from the snapshot dict itself, not a caller-supplied
     # integer like the pre-cutover ``diff_snapshots(store_path, version_a,
-    # version_b)``. Hand-constructed test snapshots must carry their own
-    # ``version`` field.
-    version_a = snap_a.get("version", 0)
-    version_b = snap_b.get("version", 0)
+    # version_b)``. Snapshots that carry no integer ``version`` (e.g. the
+    # versionless remote shape) fall back to a single timestamp-only header.
+    version_a = snap_a.get("version")
+    version_b = snap_b.get("version")
+    ts_a = snap_a.get("timestamp", "?")[:19]
+    ts_b = snap_b.get("timestamp", "?")[:19]
     files_a = snap_a.get("files", {})
     files_b = snap_b.get("files", {})
     all_keys = sorted(set(files_a) | set(files_b))
 
     sections = []
-    sections.append(f"Changes from v{version_a:03d} → v{version_b:03d}")
-    sections.append(
-        f"  ({snap_a.get('timestamp', '?')[:19]} → {snap_b.get('timestamp', '?')[:19]})"
-    )
+    if isinstance(version_a, int) and isinstance(version_b, int):
+        sections.append(f"Changes from v{version_a:03d} → v{version_b:03d}")
+        sections.append(f"  ({ts_a} → {ts_b})")
+    else:
+        sections.append(f"Changes from {ts_a} → {ts_b}")
     sections.append("")
 
     has_changes = False

--- a/packages/nauro-core/src/nauro_core/snapshot.py
+++ b/packages/nauro-core/src/nauro_core/snapshot.py
@@ -1,0 +1,106 @@
+"""Canonical snapshot serialization — pure compute, no I/O, no clock.
+
+Both the local CLI capture path and the remote capture path build their
+snapshot dicts here so the two on-disk formats cannot drift. The caller
+supplies the timestamp (already an ISO string) and the file contents; the
+serializer stamps the schema version, derives the token count, and emits
+the keys in the canonical order.
+
+The module is deliberately side-effect free: no filesystem access, no
+``datetime.now`` call, no regex. That keeps it usable from any transport
+and makes the output a pure function of its inputs.
+"""
+
+from __future__ import annotations
+
+from nauro_core.constants import (
+    CHARS_PER_TOKEN,
+    LEGACY_SCHEMA_VERSION,
+    SNAPSHOT_SCHEMA_VERSION,
+)
+
+
+def serialize_snapshot(
+    *,
+    timestamp: str,
+    trigger: str,
+    files: dict[str, str],
+    trigger_detail: str = "",
+    version: int | None = None,
+) -> dict:
+    """Build a canonical snapshot dict from its parts.
+
+    Args:
+        timestamp: ISO-8601 timestamp string. The caller owns the clock;
+            the serializer never calls ``datetime.now``.
+        trigger: Short description of what triggered the snapshot.
+        files: Mapping of store-relative filename to file content.
+        trigger_detail: Optional extra detail about the trigger.
+        version: Dense snapshot version. Local supplies its integer here;
+            callers that do not version snapshots omit it, and the
+            ``version`` key is then left out of the emitted dict entirely.
+
+    Returns:
+        A snapshot dict whose keys appear in the canonical order
+        ``schema_version, version, timestamp, trigger, trigger_detail,
+        token_count, files``. ``version`` is present only when supplied.
+
+    Raises:
+        ValueError: If ``files`` is not a dict, ``timestamp`` is empty or
+            not a string, or ``trigger`` is not a string. The timestamp
+            *format* is not validated — surfaces already produce ISO.
+    """
+    if not isinstance(files, dict):
+        raise ValueError("files must be a dict of filename to content.")
+    if not isinstance(timestamp, str) or not timestamp:
+        raise ValueError("timestamp must be a non-empty string.")
+    if not isinstance(trigger, str):
+        raise ValueError("trigger must be a string.")
+
+    token_count = sum(len(v) for v in files.values()) // CHARS_PER_TOKEN
+
+    snapshot: dict = {"schema_version": SNAPSHOT_SCHEMA_VERSION}
+    if version is not None:
+        snapshot["version"] = version
+    snapshot["timestamp"] = timestamp
+    snapshot["trigger"] = trigger
+    snapshot["trigger_detail"] = trigger_detail
+    snapshot["token_count"] = token_count
+    snapshot["files"] = files
+    return snapshot
+
+
+def normalize_snapshot(raw: dict) -> dict:
+    """Fill in defaults for fields a legacy snapshot may omit.
+
+    Legacy snapshots predate ``schema_version`` and may lack
+    ``trigger_detail`` / ``token_count``. This read-path helper returns a
+    dict with those fields defaulted so consumers that distinguish on
+    ``schema_version`` / ``version`` can read old and new snapshots
+    uniformly. ``version`` round-trips only when present — it is never
+    required.
+
+    Args:
+        raw: A snapshot dict as read back from storage.
+
+    Returns:
+        A new dict with ``schema_version`` defaulted to
+        ``LEGACY_SCHEMA_VERSION`` when absent, ``trigger`` / ``trigger_detail``
+        to ``""``, ``token_count`` to ``0``, and ``files`` to ``{}``.
+    """
+    normalized: dict = {
+        "schema_version": raw.get("schema_version", LEGACY_SCHEMA_VERSION),
+    }
+    if "version" in raw:
+        normalized["version"] = raw["version"]
+    normalized["timestamp"] = raw.get("timestamp", "")
+    normalized["trigger"] = raw.get("trigger", "")
+    normalized["trigger_detail"] = raw.get("trigger_detail", "")
+    normalized["token_count"] = raw.get("token_count", 0)
+    normalized["files"] = raw.get("files", {})
+    return normalized
+
+
+def snapshot_schema_version(raw: dict) -> int:
+    """Return a snapshot's schema version, defaulting legacy reads to 0."""
+    return raw.get("schema_version", LEGACY_SCHEMA_VERSION)

--- a/packages/nauro-core/tests/operations/test_diff_since_last_session.py
+++ b/packages/nauro-core/tests/operations/test_diff_since_last_session.py
@@ -71,12 +71,42 @@ def test_baseline_none_latest_set_renders_not_enough_snapshots() -> None:
     assert result.cutoff_date_used is None
 
 
-def test_baseline_eq_latest_renders_one_snapshot_covers_range() -> None:
+def test_baseline_eq_latest_renders_real_diff_with_no_changes() -> None:
+    # The kernel no longer collapses on equal versions — the
+    # one-snapshot-covers-range sentinel is the adapter's responsibility.
+    # Passing the same dict twice renders a real (empty) diff body.
     snap = _baseline()
     result = diff_since_last_session(InMemoryStore(), snap, snap)
     assert result.error is None
     assert result.diff is not None
-    assert "Only one snapshot covers the requested time range" in result.diff
+    assert "Only one snapshot covers the requested time range" not in result.diff
+    assert "No changes detected." in result.diff
+
+
+def test_int_versions_render_two_line_version_header() -> None:
+    result = diff_since_last_session(InMemoryStore(), _baseline(), _latest())
+    assert result.diff is not None
+    header = result.diff.split("\n", 1)[0]
+    assert header == "Changes from v001 → v002"
+
+
+def test_missing_versions_render_single_line_timestamp_header() -> None:
+    snap_a = {
+        "timestamp": "2026-05-01T10:00:00+00:00",
+        "files": {"stack.md": "# Stack\n- Python 3.11\n"},
+    }
+    snap_b = {
+        "timestamp": "2026-05-02T10:00:00+00:00",
+        "files": {"stack.md": "# Stack\n- Python 3.11\n- PostgreSQL\n"},
+    }
+    result = diff_since_last_session(InMemoryStore(), snap_a, snap_b)
+    assert result.diff is not None
+    lines = result.diff.split("\n")
+    assert lines[0] == "Changes from 2026-05-01T10:00:00 → 2026-05-02T10:00:00"
+    assert "v0" not in lines[0]
+    # The redundant second timestamp line is dropped; line 1 is the blank
+    # separator the body always carries, not a parenthesised timestamp row.
+    assert lines[1] == ""
 
 
 def test_both_populated_renders_real_diff() -> None:

--- a/packages/nauro-core/tests/test_snapshot_serializer.py
+++ b/packages/nauro-core/tests/test_snapshot_serializer.py
@@ -1,0 +1,122 @@
+"""Tests for the canonical snapshot serializer.
+
+The serializer is pure compute: no I/O, no clock, no regex. These tests
+pin the on-disk dict shape (key order, schema stamping, token derivation)
+and the legacy read-path normalization both surfaces rely on.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nauro_core.snapshot import (
+    normalize_snapshot,
+    serialize_snapshot,
+    snapshot_schema_version,
+)
+
+# 12 + 8 = 20 characters across the two files; 20 // 4 == 5.
+_FILES = {"state_current.md": "# State\nabcd", "stack.md": "# Stack\n"}
+_TIMESTAMP = "2026-05-29T12:00:00+00:00"
+
+
+def test_serialize_stamps_schema_and_derives_token_count() -> None:
+    snap = serialize_snapshot(timestamp=_TIMESTAMP, trigger="sync", files=_FILES)
+    assert snap["schema_version"] == 1
+    assert snap["trigger"] == "sync"
+    assert snap["trigger_detail"] == ""
+    assert snap["token_count"] == 5
+    assert snap["files"] == _FILES
+
+
+def test_serialize_omits_version_when_not_supplied() -> None:
+    snap = serialize_snapshot(timestamp=_TIMESTAMP, trigger="sync", files=_FILES)
+    assert "version" not in snap
+
+
+def test_serialize_includes_version_when_supplied() -> None:
+    snap = serialize_snapshot(timestamp=_TIMESTAMP, trigger="sync", files=_FILES, version=7)
+    assert snap["version"] == 7
+
+
+def test_serialize_local_key_order_is_canonical() -> None:
+    snap = serialize_snapshot(
+        timestamp=_TIMESTAMP,
+        trigger="sync",
+        trigger_detail="detail",
+        files=_FILES,
+        version=7,
+    )
+    assert list(snap.keys()) == [
+        "schema_version",
+        "version",
+        "timestamp",
+        "trigger",
+        "trigger_detail",
+        "token_count",
+        "files",
+    ]
+
+
+def test_serialize_versionless_key_order_omits_version() -> None:
+    snap = serialize_snapshot(timestamp=_TIMESTAMP, trigger="sync", files=_FILES)
+    assert list(snap.keys()) == [
+        "schema_version",
+        "timestamp",
+        "trigger",
+        "trigger_detail",
+        "token_count",
+        "files",
+    ]
+
+
+def test_serialize_rejects_non_dict_files() -> None:
+    with pytest.raises(ValueError):
+        serialize_snapshot(timestamp=_TIMESTAMP, trigger="sync", files=["not", "a", "dict"])
+
+
+def test_serialize_rejects_empty_timestamp() -> None:
+    with pytest.raises(ValueError):
+        serialize_snapshot(timestamp="", trigger="sync", files=_FILES)
+
+
+def test_serialize_rejects_non_str_timestamp() -> None:
+    with pytest.raises(ValueError):
+        serialize_snapshot(timestamp=1234567890, trigger="sync", files=_FILES)
+
+
+def test_serialize_is_clock_free_and_deterministic() -> None:
+    first = serialize_snapshot(timestamp=_TIMESTAMP, trigger="sync", files=_FILES, version=3)
+    second = serialize_snapshot(timestamp=_TIMESTAMP, trigger="sync", files=_FILES, version=3)
+    assert first == second
+
+
+def test_normalize_defaults_absent_schema_version_to_legacy() -> None:
+    normalized = normalize_snapshot({"timestamp": _TIMESTAMP, "files": {}})
+    assert normalized["schema_version"] == 0
+    assert normalized["trigger_detail"] == ""
+    assert normalized["token_count"] == 0
+    assert normalized["files"] == {}
+
+
+def test_normalize_preserves_present_schema_version() -> None:
+    normalized = normalize_snapshot({"schema_version": 1, "timestamp": _TIMESTAMP, "files": {}})
+    assert normalized["schema_version"] == 1
+
+
+def test_normalize_round_trips_version_when_present() -> None:
+    normalized = normalize_snapshot({"version": 9, "timestamp": _TIMESTAMP, "files": {}})
+    assert normalized["version"] == 9
+
+
+def test_normalize_omits_version_when_absent() -> None:
+    normalized = normalize_snapshot({"timestamp": _TIMESTAMP, "files": {}})
+    assert "version" not in normalized
+
+
+def test_snapshot_schema_version_defaults_absent_to_legacy() -> None:
+    assert snapshot_schema_version({"timestamp": _TIMESTAMP}) == 0
+
+
+def test_snapshot_schema_version_reads_present_value() -> None:
+    assert snapshot_schema_version({"schema_version": 1}) == 1

--- a/packages/nauro/src/nauro/constants.py
+++ b/packages/nauro/src/nauro/constants.py
@@ -9,6 +9,7 @@ CLI-specific constants are defined locally.
 """
 
 # ── Re-exports from nauro-core (shared across nauro + mcp-server) ──
+from nauro_core.constants import CHARS_PER_TOKEN as CHARS_PER_TOKEN
 from nauro_core.constants import DECISION_HASHES_FILE as DECISION_HASHES_FILE
 from nauro_core.constants import DECISION_TYPES as DECISION_TYPES
 from nauro_core.constants import DECISIONS_DIR as DECISIONS_DIR
@@ -20,6 +21,7 @@ from nauro_core.constants import MIN_RATIONALE_LENGTH as MIN_RATIONALE_LENGTH
 from nauro_core.constants import OPEN_QUESTIONS_MD as OPEN_QUESTIONS_MD
 from nauro_core.constants import PROJECT_MD as PROJECT_MD
 from nauro_core.constants import REVERSIBILITY_LEVELS as REVERSIBILITY_LEVELS
+from nauro_core.constants import SNAPSHOT_SCHEMA_VERSION as SNAPSHOT_SCHEMA_VERSION
 from nauro_core.constants import SNAPSHOTS_DIR as SNAPSHOTS_DIR
 from nauro_core.constants import STACK_EMPTY_MARKER as STACK_EMPTY_MARKER
 from nauro_core.constants import STACK_MD as STACK_MD
@@ -74,9 +76,6 @@ L0_TOKEN_LIMIT = 3500
 FLAG_QUESTION_HINT_MIN_SCORE = 0.7
 FLAG_QUESTION_HINT_TITLE_LENGTH = 100
 
-# ── Token heuristic ──
-CHARS_PER_TOKEN = 4  # rough chars-per-token for GPT/Claude family models
-
 # ── Writer limits ──
 SLUG_MAX_LENGTH = 60
 
@@ -84,9 +83,6 @@ SLUG_MAX_LENGTH = 60
 PRUNE_KEEP_ALL_DAYS = 7
 PRUNE_DAILY_DAYS = 30
 PRUNE_WEEKLY_DAYS = 180
-
-# ── Schema versioning ──
-SCHEMA_VERSION = 1
 
 # ── Telemetry ──
 TELEMETRY_CONSENT_VERSION = 1

--- a/packages/nauro/src/nauro/mcp/tools.py
+++ b/packages/nauro/src/nauro/mcp/tools.py
@@ -33,6 +33,8 @@ from nauro_core.operations import list_decisions as _list_decisions_op
 from nauro_core.operations import propose_decision as _propose_decision_op
 from nauro_core.operations import search_decisions as _search_decisions_op
 from nauro_core.operations import update_state as _update_state_op
+from nauro_core.operations.diff_since_last_session import ONE_SNAPSHOT_COVERS_RANGE
+from nauro_core.operations.results import DiffSinceLastSessionResult
 from nauro_core.protocol import (
     CHECK_DECISION_RETURNS,
     GET_DECISION_BEFORE_PROPOSING,
@@ -630,6 +632,24 @@ def tool_diff_since_last_session(
         return {"store": "local", "status": "error", "guidance": guidance}
 
     baseline, latest, cutoff = resolve_diff_snapshots(store_path, days)
+
+    # Days-based one-snapshot-covers-range case: resolve_diff_snapshots
+    # returns the same snapshot as baseline and latest. The kernel no
+    # longer collapses on equal versions, so the adapter renders the
+    # canonical sentinel itself, preserving any resolved cutoff timestamp.
+    if (
+        baseline is not None
+        and latest is not None
+        and isinstance(baseline.get("version"), int)
+        and baseline.get("version") == latest.get("version")
+    ):
+        result = DiffSinceLastSessionResult(
+            diff=ONE_SNAPSHOT_COVERS_RANGE,
+            cutoff_date_used=cutoff,
+        )
+        envelope = result.model_dump(mode="json", exclude_none=True)
+        return {"store": "local", **envelope}
+
     result = _diff_since_last_session_op(
         FilesystemStore(store_path),
         baseline,

--- a/packages/nauro/src/nauro/store/registry.py
+++ b/packages/nauro/src/nauro/store/registry.py
@@ -38,7 +38,6 @@ from nauro.constants import (
     REGISTRY_SCHEMA_VERSION_V2,
     REPO_CONFIG_MODE_CLOUD,
     REPO_CONFIG_MODE_LOCAL,
-    SCHEMA_VERSION,
 )
 from nauro.store._atomic import atomic_write_text
 from nauro.store.repo_config import generate_ulid
@@ -83,10 +82,10 @@ def load_registry() -> dict:
             data = json.loads(rf.read_text())
         except json.JSONDecodeError:
             logger.warning("registry.json is corrupt — starting with empty registry")
-            return {"projects": {}, "schema_version": SCHEMA_VERSION}
-        data.setdefault("schema_version", 1)
+            return {"projects": {}, "schema_version": REGISTRY_SCHEMA_VERSION_V1}
+        data.setdefault("schema_version", REGISTRY_SCHEMA_VERSION_V1)
         return data  # type: ignore[no-any-return]
-    return {"projects": {}, "schema_version": SCHEMA_VERSION}
+    return {"projects": {}, "schema_version": REGISTRY_SCHEMA_VERSION_V1}
 
 
 def save_registry(data: dict) -> None:
@@ -95,7 +94,7 @@ def save_registry(data: dict) -> None:
     Args:
         data: Full registry dict to persist.
     """
-    data.setdefault("schema_version", SCHEMA_VERSION)
+    data.setdefault("schema_version", REGISTRY_SCHEMA_VERSION_V1)
     rf = _registry_file()
     atomic_write_text(rf, json.dumps(data, indent=2) + "\n")
 

--- a/packages/nauro/src/nauro/store/snapshot.py
+++ b/packages/nauro/src/nauro/store/snapshot.py
@@ -15,13 +15,13 @@ import json
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+from nauro_core.snapshot import serialize_snapshot
+
 from nauro.constants import (
-    CHARS_PER_TOKEN,
     DECISIONS_DIR,
     PRUNE_DAILY_DAYS,
     PRUNE_KEEP_ALL_DAYS,
     PRUNE_WEEKLY_DAYS,
-    SCHEMA_VERSION,
     SNAPSHOTS_DIR,
 )
 
@@ -57,18 +57,13 @@ def capture_snapshot(store_path: Path, trigger: str = "", trigger_detail: str = 
         for md in sorted(decisions_dir.glob("*.md")):
             files[f"{DECISIONS_DIR}/{md.name}"] = md.read_text()
 
-    # Count total characters as a rough token proxy
-    token_count = sum(len(v) for v in files.values()) // CHARS_PER_TOKEN
-
-    snapshot = {
-        "schema_version": SCHEMA_VERSION,
-        "version": next_version,
-        "timestamp": datetime.now(timezone.utc).isoformat(),
-        "trigger": trigger,
-        "trigger_detail": trigger_detail,
-        "token_count": token_count,
-        "files": files,
-    }
+    snapshot = serialize_snapshot(
+        timestamp=datetime.now(timezone.utc).isoformat(),
+        trigger=trigger,
+        trigger_detail=trigger_detail,
+        files=files,
+        version=next_version,
+    )
 
     out_path = snapshots_dir / f"v{next_version:03d}.json"
     out_path.write_text(json.dumps(snapshot, indent=2) + "\n")

--- a/packages/nauro/tests/test_diff_since_last_session_parity.py
+++ b/packages/nauro/tests/test_diff_since_last_session_parity.py
@@ -73,6 +73,19 @@ def time_indexed_repo(tmp_path, monkeypatch):
 
 
 @pytest.fixture
+def single_snapshot_repo(tmp_path, monkeypatch):
+    """A registered project whose store holds exactly one snapshot."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    pid, store_path = register_project_v2("parity-diff-one", [repo], mode=REPO_CONFIG_MODE_LOCAL)
+    save_repo_config(repo, {"mode": REPO_CONFIG_MODE_LOCAL, "id": pid, "name": "parity-diff-one"})
+    scaffold_project_store("parity-diff-one", store_path)
+    capture_snapshot(store_path, trigger="initial")
+    monkeypatch.chdir(repo)
+    return pid, store_path
+
+
+@pytest.fixture
 def empty_repo(tmp_path, monkeypatch):
     """A registered project whose store has no snapshots yet."""
     repo = tmp_path / "repo"
@@ -142,6 +155,19 @@ def test_empty_store_days_based_envelope_matches(empty_repo):
     assert stdio == tool
     assert stdio["store"] == "local"
     assert "No snapshots" in stdio["diff"]
+
+
+def test_days_based_one_snapshot_covers_range_matches_across_surfaces(single_snapshot_repo):
+    # With one snapshot, the days-based lookup resolves it as both
+    # baseline and latest. The adapter short-circuits to the canonical
+    # one-snapshot-covers-range sentinel (byte-identical to pre-cutover
+    # output) on both the auto-generated CLI path and the stdio MCP path.
+    pid, store_path = single_snapshot_repo
+    stdio = _stdio_envelope(pid, days=7)
+    tool = _tool_envelope(store_path, days=7)
+    assert stdio == tool
+    assert stdio["store"] == "local"
+    assert stdio["diff"] == "Only one snapshot covers the requested time range — no diff available."
 
 
 def test_missing_store_guidance_matches_across_surfaces(missing_store):

--- a/packages/nauro/tests/test_store.py
+++ b/packages/nauro/tests/test_store.py
@@ -10,6 +10,7 @@ from nauro_core.operations import update_state as _update_state_op
 from typer.testing import CliRunner
 
 from nauro.cli.main import app
+from nauro.constants import SNAPSHOTS_DIR
 from nauro.mcp.tools import tool_get_context
 from nauro.store.filesystem_store import FilesystemStore
 from nauro.store.reader import (
@@ -330,6 +331,36 @@ def test_snapshot_has_new_fields(store: Path):
     assert snap["trigger_detail"] == "detail here"
     assert "token_count" in snap
     assert isinstance(snap["token_count"], int)
+
+
+def test_snapshot_capture_round_trips_canonical_fields(store: Path):
+    # A local capture carries the full canonical field set: the snapshot
+    # schema version, the trigger detail, a derived token count, and a
+    # dense integer version.
+    version = capture_snapshot(store, trigger="sync", trigger_detail="auto")
+    snap = load_snapshot(store, version)
+    assert snap["schema_version"] == 1
+    assert snap["trigger_detail"] == "auto"
+    assert isinstance(snap["token_count"], int)
+    assert snap["version"] == version
+    assert isinstance(snap["version"], int)
+
+
+def test_snapshot_on_disk_key_order_matches_local_shape(store: Path):
+    # The on-disk JSON key set and order must match the pre-serializer
+    # local shape so existing local snapshots stay byte-compatible; this
+    # is why the snapshot schema stays at 1 rather than bumping to 2.
+    version = capture_snapshot(store, trigger="sync", trigger_detail="auto")
+    raw = json.loads((store / SNAPSHOTS_DIR / f"v{version:03d}.json").read_text())
+    assert list(raw.keys()) == [
+        "schema_version",
+        "version",
+        "timestamp",
+        "trigger",
+        "trigger_detail",
+        "token_count",
+        "files",
+    ]
 
 
 def test_snapshot_auto_increment(store: Path):


### PR DESCRIPTION
## Why

The local and remote snapshot capture paths each built their snapshot dicts by hand, with no
shared serializer, so the two on-disk formats had already drifted — the remote shape omits
`schema_version`, `trigger_detail`, and `token_count`. Separately, the diff kernel collapsed any
two snapshots with equal versions into a one-snapshot-covers-range sentinel and printed a
version-only header, which prevents a versionless snapshot shape from rendering a real diff at
all. This makes the snapshot serializer canonical in nauro-core and changes the kernel's no-op
semantics so a versionless caller is a first-class citizen.

## Approach

The serializer lives in nauro-core as a pure, clock-free, I/O-free module (not under
`operations/`, since it is a serializer rather than a Store-backed operation). The caller passes
the timestamp, so the module never touches the clock; this keeps its output a pure function of its
inputs and testable without freezing time.

The kernel stops collapsing on equal versions. That sentinel becomes the adapter's responsibility,
which is where the days-based one-snapshot-covers-range case is actually detected. The diff header
is decoupled from version: two integer versions render the existing two-line version header;
otherwise a single timestamp-only header. Local output stays byte-identical because local always
supplies an integer version.

Alternatives considered and rejected:

- **Unify the field set only, leave the kernel keying its no-op on version.** A half-step: it would
  declare version non-canonical yet leave the kernel's one structural branch keyed on it, forcing
  the remote read adapter to keep synthesizing a version it no longer stores. It never reaches the
  state where that synthetic-version workaround can be removed.
- **Give the remote a dense monotonic version via a control-plane atomic counter.** Crosses the
  content-storage / control-plane-storage boundary, adds a failure path to a best-effort capture,
  and over-solves — the consumer needs distinct identity, not dense integers.
- **Bump the snapshot schema to 2 to mark the new serializer.** The local on-disk field set and key
  order are unchanged, so old local snapshots stay byte-compatible and a bump would be noise. The
  schema stays at 1; a legacy default of 0 covers reads of pre-field-set snapshots.

## What changed

- **Canonical serializer** (`nauro_core.snapshot`): `serialize_snapshot` / `normalize_snapshot` /
  `snapshot_schema_version`. The serializer derives the token count, stamps the schema version, and
  emits keys in the canonical local order, emitting `version` only when supplied.
- **Shared constants**: snapshot schema versions and `CHARS_PER_TOKEN` moved to nauro-core and
  re-exported.
- **Diff kernel**: removed the equal-version no-op; header decoupled from version presence.
- **Local capture + adapter**: capture consumes the shared serializer; the local diff adapter
  short-circuits the days-based one-snapshot case while preserving the resolved cutoff timestamp.
- **Constant collision**: the snapshot schema and the registry-file schema both used
  `SCHEMA_VERSION`; the registry now uses its own `REGISTRY_SCHEMA_VERSION_V1` and snapshot
  importers use `SNAPSHOT_SCHEMA_VERSION`.
- **Export**: `find_decision_stem_by_id` is now exported from the operations package for a
  downstream consumer.

## What to review

- The adapter short-circuit in `tool_diff_since_last_session`: it rebuilds the exact result object
  the kernel used to return, so the envelope (including `cutoff_date_used`) stays byte-identical.
  Parity is pinned across the auto-generated CLI and stdio MCP surfaces.
- Local snapshot byte-parity is the load-bearing property: `serialize_snapshot` must reproduce the
  prior on-disk dict exactly (key set, order, `token_count` arithmetic). A test pins the on-disk
  key order; confirm it covers the versioned local path.
- The header branch in `_render_diff` uses an integer-version check for header shape; local always
  supplies an int, so its output is unchanged. The version-omission branch is the new path.
- The registry collision fix — confirm the registry-file schema kept its own constant and did not
  get repointed at the snapshot schema.

## What's deferred

- The nauro-core version bump and PyPI publish are a separate release step after this merges (this
  PR is code-only).
- The versionless remote-capture consumption — serializer adoption, deletion of the remote read
  adapter's version override, and the remote adapter short-circuit — lands in the downstream
  mcp-server change and batches into the later nauro-core bump. This PR only makes nauro-core ready
  for it.

## Test plan

- nauro-core: 706 → 723 tests. New serializer suite pins schema stamping, token derivation, key
  order, version omission, validation, and legacy normalization. Kernel tests rewritten for
  no-collapse semantics and the two header branches.
- nauro: 1174 → 1177 tests (10 skipped unchanged). Added days-based one-snapshot-covers-range
  parity coverage across both local surfaces, plus on-disk key-order and canonical-field round-trip
  guards for local capture.
- `ruff check` + `ruff format --check` clean across packages.
