### PR TITLE
chore(release): bump nauro-core to 0.13.4

### DIFF
--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro-core"
-version = "0.13.3"
+version = "0.13.4"
 description = "Shared pure-Python logic for Nauro: parsing, validation, context assembly, constants."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
Pyproject-only version bump. Publishes the canonical snapshot serializer (`serialize_snapshot` / `normalize_snapshot` / `snapshot_schema_version`) and the decision-stem resolver export added in #161, so the remote MCP server can adopt them in its batched dependency bump.

No code change. Merging this and pushing the matching release tag triggers the PyPI publish.