### PR TITLE
Run the nauro-core import-isolation contract in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,16 @@ jobs:
       - run: ruff check packages/
       - run: ruff format --check packages/
 
+  import-linter:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+      - run: uv python install 3.12
+      - run: uv sync --package nauro-core --all-extras --python 3.12
+      - run: uv run --package nauro-core lint-imports
+        working-directory: packages/nauro-core
+
   test-nauro-core:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
## Why

The `.importlinter` contract that pins nauro-core's zero-consumer-import boundary — it must not import the CLI or the MCP server — shipped with the package and `import-linter` is already a dev dependency, but the contract was never executed in CI. A regression that made the shared package import a consumer could merge silently, quietly breaking the standalone-dependency guarantee.

## What changed

A dedicated `import-linter` CI job that installs nauro-core with its dev extra and runs `lint-imports` against the contract. The contract passes today (1 kept, 0 broken), so this wires it in as an enforced guard rather than fixing a live violation.

## What to review

The job mirrors the existing `test-nauro-core` setup (same uv sync), running from `packages/nauro-core` so `lint-imports` finds the `.importlinter` config. Verified locally against the current tree.