### PR TITLE
Forbid network and cloud-IO imports in nauro-core

### DIFF
--- a/packages/nauro-core/.importlinter
+++ b/packages/nauro-core/.importlinter
@@ -11,3 +11,18 @@ source_modules =
 forbidden_modules =
     nauro
     mcp_server
+
+[importlinter:contract:no-io-deps]
+name = nauro_core must not import network or cloud-IO libraries
+type = forbidden
+source_modules =
+    nauro_core
+forbidden_modules =
+    boto3
+    botocore
+    requests
+    httpx
+    aiohttp
+    socket
+    smtplib
+    ftplib


### PR DESCRIPTION
## Why

nauro-core's compute-only / no-I/O guarantee — it must do parsing, validation, and context assembly with zero filesystem, S3, or network access so both the CLI and the Lambda surface can embed it freely — was enforced only by convention. The import-linter job that just went live runs only the consumer-isolation contract; the I/O-purity half of the same guarantee had no mechanical check.

## What changed

A second `forbidden` contract in `packages/nauro-core/.importlinter`: nauro-core must not import boto3/botocore, an HTTP client (requests/httpx/aiohttp), or raw socket/smtplib/ftplib. It runs in the same already-live import-linter CI job — no workflow change.

## What to review

- Verified locally against the current tree (2 kept, 0 broken) and confirmed **non-vacuous** — pointing the contract at a module core actually imports (pydantic) flips it to BROKEN.
- Scope nuance: import-linter can't express submodule targets like `urllib.request` when external packages are included, and forbidding top-level `urllib`/`http` would also block the pure `urllib.parse` / `HTTPStatus`. Those are intentionally omitted; the realistic violation — a cloud SDK or HTTP client landing in core — is covered. Filesystem-write purity (`open(...,'w')`) isn't an import, so it's out of scope here (would need a separate AST/grep rule).