### PR TITLE
Single-source decision-id resolution on the kernel function

### DIFF
--- a/packages/nauro-core/tests/operations/test_decision_lookup.py
+++ b/packages/nauro-core/tests/operations/test_decision_lookup.py
@@ -1,0 +1,62 @@
+"""Kernel-level tests for ``operations.decision_lookup``.
+
+Each test seeds an :class:`~nauro_core.operations.InMemoryStore` with decision
+file stems so stem resolution exercises the Store protocol without any
+filesystem dependency. The id shapes mirror those pinned for
+:func:`~nauro_core.parsing.extract_decision_number` in
+``tests/test_parsing.py``, but here they exercise the full resolve-to-stem
+path that callers rely on.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nauro_core.operations import InMemoryStore, find_decision_stem_by_id
+from nauro_core.operations.decision_lookup import find_decision_stem_by_num
+
+
+def _seeded_store() -> InMemoryStore:
+    return InMemoryStore(
+        decisions={
+            "001-foo": "body",
+            "042-use-postgres": "body",
+        }
+    )
+
+
+def test_find_by_num_matches_prefix() -> None:
+    assert find_decision_stem_by_num(_seeded_store(), 42) == "042-use-postgres"
+
+
+def test_find_by_num_missing_number_returns_none() -> None:
+    assert find_decision_stem_by_num(_seeded_store(), 999) is None
+
+
+def test_find_by_num_empty_store_returns_none() -> None:
+    assert find_decision_stem_by_num(InMemoryStore(), 42) is None
+
+
+@pytest.mark.parametrize(
+    "decision_id",
+    [
+        "042-use-postgres",
+        "042-use-postgres.md",
+        "decision-42",
+        "decision-042",
+        "D42",
+        "D042",
+        "42",
+        "042",
+    ],
+)
+def test_find_by_id_resolves_every_shape_to_stem(decision_id: str) -> None:
+    assert find_decision_stem_by_id(_seeded_store(), decision_id) == "042-use-postgres"
+
+
+def test_find_by_id_unparseable_returns_none() -> None:
+    assert find_decision_stem_by_id(_seeded_store(), "not-a-decision") is None
+
+
+def test_find_by_id_parseable_but_absent_returns_none() -> None:
+    assert find_decision_stem_by_id(_seeded_store(), "decision-999") is None

--- a/packages/nauro/src/nauro/mcp/tools.py
+++ b/packages/nauro/src/nauro/mcp/tools.py
@@ -22,7 +22,7 @@ from nauro_core.constants import (
     STATE_CURRENT_FILENAME,
     STATE_MD,
 )
-from nauro_core.operations import ErrorPayload
+from nauro_core.operations import ErrorPayload, find_decision_stem_by_id
 from nauro_core.operations import check_decision as _check_decision_op
 from nauro_core.operations import diff_since_last_session as _diff_since_last_session_op
 from nauro_core.operations import flag_question as _flag_question_op
@@ -57,7 +57,6 @@ from nauro.onboarding import (
 )
 from nauro.store.config import resolve_embeddings_flag
 from nauro.store.filesystem_store import FilesystemStore
-from nauro.store.reader import resolve_decision_id
 from nauro.store.snapshot import (
     capture_snapshot,
     list_snapshots,
@@ -324,7 +323,7 @@ def tool_propose_decision(
                     reason=f"operation={operation!r} requires affected_decision_id",
                 ).model_dump(exclude_none=True),
             }
-        resolved = resolve_decision_id(store_path, affected_decision_id)
+        resolved = find_decision_stem_by_id(FilesystemStore(store_path), affected_decision_id)
         if resolved is None:
             return {
                 "store": "local",

--- a/packages/nauro/src/nauro/store/reader.py
+++ b/packages/nauro/src/nauro/store/reader.py
@@ -31,25 +31,6 @@ def _list_decisions(store_path: Path) -> list[Decision]:
     return results
 
 
-def resolve_decision_id(project_path: Path, identifier: str) -> str | None:
-    """Resolve any decision id shape to the canonical file stem.
-
-    Accepts whatever ``extract_decision_number`` accepts (file stem, synthetic
-    ``decision-NNN``, ``DNNN``, or bare integer). Returns the on-disk file
-    stem (e.g. ``"042-use-postgres"``); returns None if the identifier can't
-    be parsed or no matching decision file exists.
-    """
-    num = extract_decision_number(identifier)
-    if num is None:
-        return None
-    decisions_dir = project_path / DECISIONS_DIR
-    if not decisions_dir.exists():
-        return None
-    for f in decisions_dir.glob(f"{num:03d}-*.md"):
-        return f.stem
-    return None
-
-
 def list_active_decisions(store_path: Path) -> list[Decision]:
     """Return only decisions with status=active."""
     return [d for d in _list_decisions(store_path) if d.status is DecisionStatus.active]

--- a/packages/nauro/tests/test_propose_decision_parity.py
+++ b/packages/nauro/tests/test_propose_decision_parity.py
@@ -247,7 +247,7 @@ def test_length_rejection_rationale(seeded_repo):
 
 def test_affected_decision_id_short_form_resolves(seeded_repo):
     """The adapter resolves a short ``"NNN"`` reference to the full stem
-    via ``resolve_decision_id`` before calling the kernel."""
+    via the kernel ``find_decision_stem_by_id`` before calling the kernel."""
     _pid, store_path = seeded_repo
     append_decision(
         store_path,

--- a/packages/nauro/tests/test_store.py
+++ b/packages/nauro/tests/test_store.py
@@ -13,10 +13,7 @@ from nauro.cli.main import app
 from nauro.constants import SNAPSHOTS_DIR
 from nauro.mcp.tools import tool_get_context
 from nauro.store.filesystem_store import FilesystemStore
-from nauro.store.reader import (
-    _list_decisions,
-    resolve_decision_id,
-)
+from nauro.store.reader import _list_decisions
 from nauro.store.snapshot import capture_snapshot, list_snapshots, load_snapshot
 from nauro.store.validator import validate_store
 from nauro.templates.scaffolds import (
@@ -783,35 +780,3 @@ def test_sync_no_project(tmp_path: Path, monkeypatch):
     result = runner.invoke(app, ["sync"])
     assert result.exit_code == 1
     assert "No project found" in result.output
-
-
-class TestResolveDecisionId:
-    def test_resolves_file_stem(self, store):
-        append_decision(store, "Use Postgres", rationale="A solid pick for OLTP workloads.")
-        result = resolve_decision_id(store, "002-use-postgres")
-        assert result is not None
-        assert result.startswith("002-")
-
-    def test_resolves_synthetic_id(self, store):
-        append_decision(store, "Use Postgres", rationale="A solid pick for OLTP workloads.")
-        result = resolve_decision_id(store, "decision-002")
-        assert result is not None
-        assert result.startswith("002-")
-
-    def test_resolves_d_prefixed(self, store):
-        append_decision(store, "Use Postgres", rationale="A solid pick for OLTP workloads.")
-        result = resolve_decision_id(store, "D002")
-        assert result is not None
-        assert result.startswith("002-")
-
-    def test_resolves_bare_integer(self, store):
-        append_decision(store, "Use Postgres", rationale="A solid pick for OLTP workloads.")
-        result = resolve_decision_id(store, "2")
-        assert result is not None
-        assert result.startswith("002-")
-
-    def test_returns_none_for_unknown_number(self, store):
-        assert resolve_decision_id(store, "decision-999") is None
-
-    def test_returns_none_for_garbage(self, store):
-        assert resolve_decision_id(store, "not-a-decision") is None


### PR DESCRIPTION
## Why

`nauro/store/reader.py` held a third local copy of decision-id-to-stem resolution
(`resolve_decision_id`). The canonical implementation already lives in nauro-core as
`find_decision_stem_by_id`, and the remote MCP server adopted it in a prior change, deleting its
own copy. This is the symmetric cutover on the CLI side: remove the duplicate so the logic has a
single home.

## Approach

Swap the one caller (`tool_propose_decision`'s update/supersede branch) to the kernel function and
delete the local copy. Equivalence holds: both extract the number via `extract_decision_number`,
then return the first stem matching the `NNN-` prefix; decision numbers are unique, so "first match"
is deterministic. `FilesystemStore.list_decisions()` returns sorted stems (and `[]` on a missing
decisions dir), so the kernel path is behavior-equivalent and more deterministic than the old `glob`.

Rejected alternative: keep a thin path-based wrapper in `reader.py` that forwards to the kernel. That
preserves a redundant indirection layer for no benefit — the caller can construct a `FilesystemStore`
directly (its `__init__` only stores the path), so the clean delete is correct.

## What changed

- **nauro CLI:** deleted `resolve_decision_id` from `store/reader.py`; `mcp/tools.py` now calls
  `find_decision_stem_by_id` against a `FilesystemStore`. The not-found rejection envelope is
  byte-unchanged.
- **nauro-core:** added kernel-side coverage for `find_decision_stem_by_id` /
  `find_decision_stem_by_num`, which previously had none — the only tests of stem-lookup +
  None-on-miss lived in the CLI copy. `InMemoryStore`-backed, no filesystem.
- **nauro tests:** removed the relocated CLI-copy test cluster; updated a docstring in the parity
  test to reference the kernel function.

## What to review

- The call-site swap in `tool_propose_decision` — confirm the `None` → rejection path and its reason
  string are unchanged.
- The glob→sorted-iteration equivalence in the resolver swap (unique decision numbers make "first
  match" deterministic either way).
- The new kernel tests pin every id shape against the resolve-to-stem path; they mirror the shapes
  already pinned for `extract_decision_number` but now exercise the full lookup, asserting exact stems.

## What's deferred

Nothing. `find_decision_stem_by_num` remains module-private to `decision_lookup` (not re-exported from
`operations.__init__`); no need to widen the public surface for this change.

## Test plan

- nauro-core: 723 → 736 (13 new lookup tests).
- nauro: 1177 → 1171 (6 relocated copy tests removed; the adapter parity test that exercises
  resolution end-to-end stays and passes).
- `ruff check` + `ruff format --check` clean; import-linter 2 kept, 0 broken.
