### PR TITLE
Fail safe on corrupt control-plane and snapshot inputs

### DIFF
--- a/packages/nauro/src/nauro/store/config.py
+++ b/packages/nauro/src/nauro/store/config.py
@@ -68,10 +68,14 @@ def load_config() -> dict:
     cf = _config_file()
     if cf.exists():
         try:
-            return json.loads(cf.read_text())  # type: ignore[no-any-return]
+            data = json.loads(cf.read_text())
         except json.JSONDecodeError:
             logger.warning("config.json is corrupt — returning empty config")
             return {}
+        if not isinstance(data, dict):
+            logger.warning("config.json is corrupt — returning empty config")
+            return {}
+        return data  # type: ignore[no-any-return]
     return {}
 
 

--- a/packages/nauro/src/nauro/store/registry.py
+++ b/packages/nauro/src/nauro/store/registry.py
@@ -83,7 +83,11 @@ def load_registry() -> dict:
         except json.JSONDecodeError:
             logger.warning("registry.json is corrupt — starting with empty registry")
             return {"projects": {}, "schema_version": REGISTRY_SCHEMA_VERSION_V1}
+        if not isinstance(data, dict):
+            logger.warning("registry.json is corrupt — starting with empty registry")
+            return {"projects": {}, "schema_version": REGISTRY_SCHEMA_VERSION_V1}
         data.setdefault("schema_version", REGISTRY_SCHEMA_VERSION_V1)
+        data.setdefault("projects", {})
         return data  # type: ignore[no-any-return]
     return {"projects": {}, "schema_version": REGISTRY_SCHEMA_VERSION_V1}
 
@@ -134,6 +138,9 @@ def load_registry_v2() -> dict:
     except json.JSONDecodeError:
         logger.warning("registry.json is corrupt — starting with empty v2 registry")
         return {"projects": {}, "schema_version": REGISTRY_SCHEMA_VERSION_V2}
+    if not isinstance(data, dict):
+        logger.warning("registry.json is corrupt — starting with empty v2 registry")
+        return {"projects": {}, "schema_version": REGISTRY_SCHEMA_VERSION_V2}
 
     version = data.get("schema_version", REGISTRY_SCHEMA_VERSION_V1)
     if version == REGISTRY_SCHEMA_VERSION_V1:
@@ -146,6 +153,7 @@ def load_registry_v2() -> dict:
             f"Unknown registry schema_version={version!r} at {rf}. "
             f"Upgrade nauro to a version that supports this schema."
         )
+    data.setdefault("projects", {})
     return data  # type: ignore[no-any-return]
 
 

--- a/packages/nauro/src/nauro/store/snapshot.py
+++ b/packages/nauro/src/nauro/store/snapshot.py
@@ -12,6 +12,7 @@ and never pruned (preserves the decision chain).
 """
 
 import json
+import logging
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -24,6 +25,8 @@ from nauro.constants import (
     PRUNE_WEEKLY_DAYS,
     SNAPSHOTS_DIR,
 )
+
+logger = logging.getLogger("nauro.snapshot")
 
 
 def capture_snapshot(store_path: Path, trigger: str = "", trigger_detail: str = "") -> int:
@@ -95,18 +98,29 @@ def _prune_snapshots(snapshots_dir: Path) -> None:
     if len(snapshot_files) <= 1:
         return
 
-    # Load all snapshots with their metadata
+    # Load all snapshots with their metadata. The timestamp is a
+    # user-editable field, so a single snapshot with an unparseable value is
+    # skipped (left on disk untouched) rather than allowed to break pruning of
+    # the valid snapshots.
     snapshots = []
     for f in snapshot_files:
         data = json.loads(f.read_text())
+        try:
+            timestamp = datetime.fromisoformat(data["timestamp"])
+        except (ValueError, TypeError, KeyError):
+            logger.debug("Skipping snapshot with unparseable timestamp: %s", f)
+            continue
         snapshots.append(
             {
                 "path": f,
                 "data": data,
-                "timestamp": datetime.fromisoformat(data["timestamp"]),
+                "timestamp": timestamp,
                 "decision_count": _count_decisions(data),
             }
         )
+
+    if not snapshots:
+        return
 
     # Sort by version (chronological)
     snapshots.sort(key=lambda s: s["data"]["version"])
@@ -190,7 +204,11 @@ def find_snapshot_near_date(store_path: Path, target: datetime) -> dict | None:
     all_snaps = []
     for f in snapshots_dir.glob("v*.json"):
         data = json.loads(f.read_text())
-        ts = datetime.fromisoformat(data["timestamp"])
+        try:
+            ts = datetime.fromisoformat(data["timestamp"])
+        except (ValueError, TypeError, KeyError):
+            logger.debug("Skipping snapshot with unparseable timestamp: %s", f)
+            continue
         all_snaps.append(
             {
                 "version": data["version"],

--- a/packages/nauro/tests/test_config.py
+++ b/packages/nauro/tests/test_config.py
@@ -58,6 +58,13 @@ def test_set_preserves_other_keys(tmp_path, monkeypatch):
     assert get_config("model") == "haiku"
 
 
+def test_load_config_non_dict_returns_empty(tmp_path, monkeypatch):
+    """A config.json that parses to a non-dict (valid JSON, wrong shape)
+    returns an empty config rather than crashing downstream callers."""
+    (tmp_path / "config.json").write_text("[]")
+    assert load_config() == {}
+
+
 # --- CLI ---
 
 

--- a/packages/nauro/tests/test_log_diff.py
+++ b/packages/nauro/tests/test_log_diff.py
@@ -501,3 +501,80 @@ class TestDiffSinceLastSessionTimeBased:
         """days=7 with no snapshots returns graceful message."""
         result = diff_since_last_session(store, days=7)
         assert "No snapshots" in result
+
+
+# --- Corrupt-timestamp tolerance ---
+
+
+def _corrupt_timestamp(store_path: Path, version: int, value: str = "not-a-date") -> None:
+    """Rewrite a snapshot's timestamp to an unparseable value on disk."""
+    snap_path = store_path / SNAPSHOTS_DIR / f"v{version:03d}.json"
+    data = load_snapshot(store_path, version)
+    data["timestamp"] = value
+    snap_path.write_text(json.dumps(data, indent=2) + "\n")
+
+
+def _snapshot_file(store_path: Path, version: int) -> Path:
+    return store_path / SNAPSHOTS_DIR / f"v{version:03d}.json"
+
+
+class TestCorruptSnapshotTimestamp:
+    def test_capture_snapshot_prunes_around_bad_timestamp(self, store: Path):
+        """A snapshot with an unparseable timestamp does not break pruning of
+        the valid ones, and the bad snapshot file is left on disk untouched."""
+        capture_snapshot(store, trigger="first")
+        _backdate_snapshot(store, 1, days_ago=400)
+        append_decision(store, "Use Postgres", rationale="Reliable RDBMS.")
+        capture_snapshot(store, trigger="second")
+        _backdate_snapshot(store, 2, days_ago=200)
+
+        # Corrupt v002's timestamp before the next capture triggers a prune.
+        _corrupt_timestamp(store, 2)
+
+        # A third capture prunes; the prune loop must skip v002 and still
+        # process v001/v003 without raising.
+        capture_snapshot(store, trigger="third")
+
+        # The corrupted snapshot is neither deleted nor pruned.
+        assert _snapshot_file(store, 2).exists()
+        # The latest snapshot is always kept.
+        assert _snapshot_file(store, 3).exists()
+
+    def test_find_snapshot_near_date_ignores_bad_timestamp(self, timed_store: Path):
+        """find_snapshot_near_date resolves among the valid snapshots and
+        ignores one whose timestamp cannot be parsed."""
+        # timed_store: v001 14d ago, v002 7d ago, v003 now.
+        _corrupt_timestamp(timed_store, 2)
+
+        # Target 7 days ago: v002 would have matched exactly, but it is now
+        # unparseable, so the nearest valid snapshot at/before the target is
+        # v001 (14 days ago).
+        target = datetime.now(timezone.utc) - timedelta(days=7)
+        result = find_snapshot_near_date(timed_store, target)
+        assert result is not None
+        assert result["version"] == 1
+
+    def test_find_snapshot_near_date_all_bad_returns_none(self, timed_store: Path):
+        """When every snapshot has an unparseable timestamp, the scan resolves
+        to no candidates and returns None."""
+        for version in (1, 2, 3):
+            _corrupt_timestamp(timed_store, version)
+
+        result = find_snapshot_near_date(timed_store, datetime.now(timezone.utc))
+        assert result is None
+
+    def test_capture_snapshot_all_bad_does_not_crash(self, store: Path):
+        """capture_snapshot prunes after writing; with only bad-timestamp
+        prior snapshots the prune must no-op rather than raise."""
+        capture_snapshot(store, trigger="first")
+        capture_snapshot(store, trigger="second")
+        _corrupt_timestamp(store, 1)
+        _corrupt_timestamp(store, 2)
+
+        # The new capture writes v003 then prunes; every prior snapshot has a
+        # bad timestamp, so the prune skips them all and returns without error.
+        version = capture_snapshot(store, trigger="third")
+        assert version == 3
+        assert _snapshot_file(store, 1).exists()
+        assert _snapshot_file(store, 2).exists()
+        assert _snapshot_file(store, 3).exists()

--- a/packages/nauro/tests/test_registry.py
+++ b/packages/nauro/tests/test_registry.py
@@ -352,3 +352,21 @@ def test_remove_repo_not_found(tmp_path, monkeypatch):
     repo.mkdir()
     registry.register_project("proj", [repo])
     assert registry.remove_repo("proj", "/nonexistent") is False
+
+
+# --- Corrupt-shape tolerance ---
+
+
+def test_load_registry_non_dict_returns_empty(tmp_path, monkeypatch):
+    """A registry.json that parses to a non-dict (valid JSON, wrong shape)
+    falls back to the empty-registry default rather than crashing downstream."""
+    (tmp_path / "registry.json").write_text("[]")
+    data = registry.load_registry()
+    assert data == {"projects": {}, "schema_version": 1}
+
+
+def test_load_registry_v2_non_dict_returns_empty(tmp_path, monkeypatch):
+    """The v2 loader applies the same non-dict guard as the v1 loader."""
+    (tmp_path / "registry.json").write_text("[]")
+    data = registry.load_registry_v2()
+    assert data == {"projects": {}, "schema_version": 2}


### PR DESCRIPTION
## Why

`registry.json`, `config.json`, and snapshot timestamps are all user-editable on disk. The
malformed-JSON branches of `load_registry`, `load_registry_v2`, and `load_config` already fail safe
(corrupt → empty default, warning-logged), but a file that parses to a valid non-dict (`[]`, `42`,
`"x"`) slipped through and crashed downstream with an opaque `AttributeError`/`KeyError`. Snapshot
timestamps were unguarded entirely: a single non-ISO timestamp — a user-editable field — raised
`ValueError` inside the prune and find-near-date scan loops, breaking pruning, diff resolution, and
therefore every snapshot capture (capture prunes on each run).

## Approach

Extend the existing fail-safe handling to the remaining un-guarded points, following the established
asymmetric-failure contract the codebase already models (the typed corrupt-JSON branches and the
repo-config loader): scan and guard-rail paths skip the bad item, continue, and log at debug;
tolerance lives at the scan layer, not in parsers. This is deliberately not a schema-validation
framework, and it adds no skipped-item counts to any return shape.

## What changed

- **Snapshots** (`store/snapshot.py`): both `datetime.fromisoformat` scan sites — the prune load
  loop and the find-near-date scan loop — skip a snapshot whose timestamp can't be parsed,
  debug-logged. A skipped snapshot is left on disk untouched (neither pruned nor counted as a
  keeper). When every snapshot is unparseable, prune no-ops and find-near-date returns `None`. Added
  the module logger this file previously lacked.
- **Registry** (`store/registry.py`): `load_registry` and `load_registry_v2` fall back to the
  empty-registry default when the parsed JSON is not a dict, mirroring the malformed-JSON branch, and
  guarantee a dict `projects` key on the returned shape so downstream `registry["projects"]` can't
  KeyError.
- **Config** (`store/config.py`): `load_config` returns `{}` when the parsed JSON is not a dict,
  matching its `JSONDecodeError` branch.

## What to review

- The early `return` added to `_prune_snapshots` for the all-bad-timestamps case — the
  keeper/pruning logic below assumes a non-empty list (`snapshots[-1]`). It is placed after the load
  loop, before any indexing, and leaves all files on disk.
- The skip-not-delete property: the `try/except` wraps only the timestamp parse, and the delete loop
  iterates only the filtered (valid) snapshots, so a corrupt snapshot is never unlinked.

## What's deferred

Nothing. This is a contained extension of existing fail-safe handling, not a broader validation
effort.

## Test plan

7 new colocated tests (snapshot corruption in `test_log_diff.py`; registry v1 and v2 non-dict in
`test_registry.py`; config non-dict in `test_config.py`), all asserting exact outcomes including that
the corrupt snapshot file is NOT deleted. Full suite: nauro 1171 → 1178 passed, 10 skipped; nauro-core
736 passed. Lint clean. Structural guards: import-linter 2 kept / 0 broken; no-reintroduction guard
exit 0.
