### PR TITLE
Dedup the setup project-entry lookup into one helper

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/setup.py
+++ b/packages/nauro/src/nauro/cli/commands/setup.py
@@ -17,12 +17,10 @@ from pathlib import Path
 
 import typer
 
-from nauro.cli.utils import resolve_target_project
+from nauro.cli.utils import _resolve_project_entry, resolve_target_project
 from nauro.constants import CLAUDE_MD, NAURO_BLOCK_END, NAURO_BLOCK_START
 from nauro.store.registry import (
     RegistrySchemaError,
-    get_project,
-    get_project_v2,
     load_registry,
     load_registry_v2,
 )
@@ -227,19 +225,7 @@ def claude_code(
 ) -> None:
     """Configure Claude Code to use Nauro during sessions."""
     project_name, _store_path = resolve_target_project(project)
-    project_key = _store_path.name
-
-    # Try v2 first (id-keyed), then fall back to v1 (name-keyed legacy)
-    try:
-        entry = get_project_v2(project_key)
-    except RegistrySchemaError:
-        entry = None
-    if entry is None:
-        entry = get_project(project_name)
-
-    if entry is None or not entry.get("repo_paths"):
-        typer.echo(f"Project '{project_name}' has no associated repos.", err=True)
-        raise typer.Exit(code=1)
+    entry = _resolve_project_entry(project_name, _store_path.name)
 
     # Clean up legacy CLAUDE.md blocks (behavioral guidance now delivered
     # via MCP server instructions, so the injected block is no longer needed).
@@ -283,9 +269,9 @@ def claude_code(
             typer.echo(line)
 
     if not remove:
-        # Regenerate AGENTS.md so context is fresh from the start.
-        # project_key is the v2 id (or v1 name) used by the registry-aware lookup.
-        updated_repos = regenerate_agents_md_for_project(project_key, _store_path)
+        # Regenerate AGENTS.md so context is fresh from the start. The store
+        # dir name is the v2 id (or v1 name) used by the registry-aware lookup.
+        updated_repos = regenerate_agents_md_for_project(_store_path.name, _store_path)
         if updated_repos:
             typer.echo("\nAGENTS.md:")
             for repo_path in updated_repos:
@@ -330,18 +316,7 @@ def cursor(
 ) -> None:
     """Configure Cursor to use Nauro for this project's repos."""
     project_name, _store_path = resolve_target_project(project)
-    project_key = _store_path.name
-
-    try:
-        entry = get_project_v2(project_key)
-    except RegistrySchemaError:
-        entry = None
-    if entry is None:
-        entry = get_project(project_name)
-
-    if entry is None or not entry.get("repo_paths"):
-        typer.echo(f"Project '{project_name}' has no associated repos.", err=True)
-        raise typer.Exit(code=1)
+    entry = _resolve_project_entry(project_name, _store_path.name)
 
     action = "Removed" if remove else "Configured"
     typer.echo(f"{action} Nauro (Cursor) for project '{project_name}':\n")
@@ -1041,18 +1016,7 @@ def all_(
 ) -> None:
     """Configure Claude Code, Cursor, and Codex CLI in one call."""
     project_name, _store_path = resolve_target_project(project)
-    project_key = _store_path.name
-
-    try:
-        entry = get_project_v2(project_key)
-    except RegistrySchemaError:
-        entry = None
-    if entry is None:
-        entry = get_project(project_name)
-
-    if entry is None or not entry.get("repo_paths"):
-        typer.echo(f"Project '{project_name}' has no associated repos.", err=True)
-        raise typer.Exit(code=1)
+    entry = _resolve_project_entry(project_name, _store_path.name)
 
     project_repos = [Path(rp) for rp in entry["repo_paths"]]
     action = "Removed" if remove else "Configured"
@@ -1060,7 +1024,7 @@ def all_(
     for line in setup_all_surfaces(
         project_repos,
         remove=remove,
-        current_project_key=project_key,
+        current_project_key=_store_path.name,
         store_path=_store_path,
         with_subagents=with_subagents,
         force_overwrite=force_overwrite,

--- a/packages/nauro/src/nauro/cli/utils.py
+++ b/packages/nauro/src/nauro/cli/utils.py
@@ -23,6 +23,7 @@ from nauro.store.registry import (
     add_repo_v2,
     find_projects_by_name_v2,
     get_project,
+    get_project_v2,
     get_store_path,
     get_store_path_v2,
     load_registry,
@@ -165,6 +166,33 @@ def resolve_target_project(project_flag: str | None) -> tuple[str, Path]:
     else:
         typer.echo("Run 'nauro init' first.", err=True)
     raise typer.Exit(code=1)
+
+
+def _resolve_project_entry(project_name: str, project_key: str) -> dict:
+    """Resolve a registry entry that has at least one associated repo path.
+
+    Args:
+        project_name: Display name (used for the v1 lookup and error message).
+        project_key: v2 project_id (store directory name) for the v2 lookup.
+
+    Returns:
+        The resolved registry entry dict, guaranteed to carry ``repo_paths``.
+
+    Raises:
+        typer.Exit: code 1 when no entry resolves or the entry has no repos.
+    """
+    # Try v2 first (id-keyed), then fall back to v1 (name-keyed legacy)
+    try:
+        entry = get_project_v2(project_key)
+    except RegistrySchemaError:
+        entry = None
+    if entry is None:
+        entry = get_project(project_name)
+
+    if entry is None or not entry.get("repo_paths"):
+        typer.echo(f"Project '{project_name}' has no associated repos.", err=True)
+        raise typer.Exit(code=1)
+    return entry
 
 
 # Re-exported for callers that need to write or extend v2 entries directly

--- a/packages/nauro/tests/test_resolution_v2.py
+++ b/packages/nauro/tests/test_resolution_v2.py
@@ -328,3 +328,49 @@ def test_unknown_project_listing_has_no_blank_token(tmp_path, monkeypatch, capsy
     parsed = [name.strip() for name in listing_line[len("Available projects:") :].split(",")]
     assert parsed == ["alpha"]
     assert "" not in parsed
+
+
+# ── _resolve_project_entry: v2-first, v1-fallback, repo_paths guard ──────────
+
+
+def test_resolve_project_entry_v2_first(tmp_path, monkeypatch):
+    """A v2 entry is resolved by its id-keyed project_key."""
+    from nauro.cli.utils import _resolve_project_entry
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    pid, _store = registry.register_project_v2("alpha", [repo])
+
+    entry = _resolve_project_entry("alpha", pid)
+
+    assert entry == registry.get_project_v2(pid)
+    assert entry["repo_paths"] == [str(repo.resolve())]
+
+
+def test_resolve_project_entry_v1_fallback(tmp_path, monkeypatch):
+    """A v1 (name-keyed legacy) entry is resolved when no v2 entry matches."""
+    from nauro.cli.utils import _resolve_project_entry
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    registry.register_project("beta", [repo])
+
+    # The v2 lookup misses (no id-keyed entry); the name-keyed v1 entry wins.
+    entry = _resolve_project_entry("beta", "01MISSINGV2KEY0000000000")
+
+    assert entry == registry.get_project("beta")
+    assert entry["repo_paths"] == [str(repo.resolve())]
+
+
+def test_resolve_project_entry_no_repos_exits(tmp_path, monkeypatch, capsys):
+    """An entry with no repo_paths exits 1 with the exact message on stderr."""
+    from nauro.cli.utils import _resolve_project_entry
+
+    _write_registry(tmp_path, 1, {"gamma": {"repo_paths": []}})
+
+    with pytest.raises(typer.Exit) as excinfo:
+        _resolve_project_entry("gamma", "gamma")
+    assert excinfo.value.exit_code == 1
+
+    err = capsys.readouterr().err
+    assert "Project 'gamma' has no associated repos." in err


### PR DESCRIPTION
## Why

The three `nauro setup` subcommands — `claude-code`, `cursor`, and `all` — each carried a
byte-identical block that resolves a project's registry entry (v2 id-keyed first, v1 name-keyed legacy
fallback), guards that it has `repo_paths`, and otherwise exits 1 with "Project '<name>' has no
associated repos." Three verbatim copies drift independently, and the empty-repos guard was only ever
exercised indirectly through each command's own test, never directly.

## Approach

Extract the block into a single `_resolve_project_entry(project_name, project_key)` helper in
`cli/utils.py`, beside the sibling `resolve_target_project`. utils.py already imported `typer`,
`RegistrySchemaError`, and `get_project`, so hosting the helper adds only the one `get_project_v2`
import and cannot introduce a cycle (`registry.py` imports nothing from `cli`). The alternative —
keeping the helper module-local in `setup.py` — was rejected because the natural home is alongside the
other project-resolution helper.

## What changed

- New `_resolve_project_entry` helper in `cli/utils.py`, preserving the existing explanatory comment,
  error message, `err=True`, and exit code 1.
- All three setup subcommands route their lookup through the helper; each keeps its preceding
  `resolve_target_project` call.
- `claude-code` and `all` referenced the old `project_key` local downstream (AGENTS.md regen and the
  surface-orchestration call); those now read `_store_path.name` directly, which is the same value
  (`project_key` was defined as `_store_path.name` and never reassigned).
- Removed the now-unused `get_project`/`get_project_v2` imports from `setup.py`; added `get_project_v2`
  to utils.py's existing registry import group.

## What to review

- The two downstream `_store_path.name` substitutions in `claude-code` and `all` — value-identical to
  the removed `project_key` local.
- That the helper's behavior (message text, stderr routing, exit code 1) is unchanged from the inlined
  blocks.

## What's deferred

The larger `setup.py` findings (the `setup_all_surfaces`/`materialize_agents` god-functions, the
duplicated `_available_project_names` paths) are out of scope for this change.

## Test plan

Full nauro suite green: 1171 → 1174 passed, 10 skipped (3 new helper tests in `test_resolution_v2.py`
covering v2-first resolution, v1 fallback, and the no-repos exit-1 guard with exact-message and
exact-exit-code assertions). ruff check + format clean. import-linter 2 kept / 0 broken; single-sourced
guard exit 0.
