### PR TITLE
Add nauro-handoff skill for store-native session handoffs

### DIFF
--- a/.agents/skills/nauro-handoff/SKILL.md
+++ b/.agents/skills/nauro-handoff/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: nauro-handoff
+description: Captures a session handoff to Nauro's project store so the next agent session resumes cleanly. Writes a handoff body to <store>/handoffs/<slug>.md (picked up by `nauro sync` with no code change) and flags a RESUME pointer question naming that path. Composes existing MCP tools only (get_context, update_state, flag_question, get_raw_file, diff_since_last_session); never calls propose_decision and never dumps the handoff into state_current.md. Invoke explicitly with /nauro-handoff. Installed by `nauro adopt --with-skills`.
+---
+
+# Nauro handoff skill
+
+Capture a resumable session handoff into Nauro's project store, or resume a prior one, composing only the existing Nauro MCP tools. The skill has two modes. Capture, at the end of a session, writes a handoff body to the store and flags a durable resume pointer. Resume, at the start of a session, reconstructs the in-flight state from that pointer and verifies it before continuing. The skill composes `get_context`, `update_state`, `flag_question`, `get_raw_file`, and `diff_since_last_session`, and nothing else. It never files a decision.
+
+## When to capture vs resume
+
+Read the invoking prompt to decide the mode. Capture mode runs at the end of a working session or when the user asks to hand the session off ("hand this off", "wrap up and hand off"). Resume mode runs at the start of a session or when the user asks to pick up prior work ("pick up where we left off", "resume"). If the prompt is ambiguous, ask the user which mode they want and wait for the answer before proceeding.
+
+v1 targets the local-store path: the agent writes the handoff to the local store on disk, then `nauro sync` pushes it. A pure chat surface with no local store cannot write an arbitrary store file, so chat-only capture is out of scope for this version. Pass `project_id` explicitly on every MCP call when more than one project exists, matching the adopt-skill convention.
+
+## Step 1 — Capture: pull working context
+
+The agent calls `get_context(level="L1")` to ground the handoff in the current sprint, blockers, and recent completions. The handoff reflects the project's real state, not the agent's memory of the session.
+
+## Step 2 — Capture: write the handoff file
+
+The agent writes the full handoff body to `<store>/handoffs/<slug>.md` using its own filesystem write. The CLI push enumerates the whole store, so a file under `handoffs/` syncs with no code change. Choose a short kebab-case `<slug>`, for example `auth-refresh-cutover`.
+
+The handoff body states what shipped this session, what is still in flight, any branches, stashes, or worktrees left open, the cited pointers a resumer must verify (decision numbers, file paths, PR or branch names), and the next concrete step. Handoffs accumulate append-only under `handoffs/` — never overwrite a prior handoff and never delete one.
+
+## Step 3 — Capture: state hygiene
+
+The agent calls `update_state(delta=...)` with a short, normal session-end delta describing genuine current state. **`update_state` REPLACES `state_current.md` and is capped at roughly 5000 characters — the delta must be a one-line pointer and summary, and must never contain the handoff body.** The full handoff lives only at `handoffs/<slug>.md`; putting it in the delta would clobber the current-state surface and exceed the cap.
+
+## Step 4 — Capture: flag the resume pointer
+
+The agent calls `flag_question(question="RESUME: handoffs/<slug>.md — <one-line remaining-work summary>")`. This flagged question — not `state_current.md` — is the durable resume pointer. It lives in `open-questions.md`, which is append-only, so it avoids the `update_state` REPLACE-clobber surface. The `RESUME:` marker text is literal so the Resume flow can find it.
+
+## Step 5 — Capture: GATE — confirmation (user)
+
+The agent surfaces, in this order:
+
+1. The handoff file path `handoffs/<slug>.md`.
+2. The literal `RESUME:` marker text just flagged.
+3. The session delta written to state.
+
+Then it asks the user to confirm, and waits for explicit approval. Auto-mode and standing "keep moving" directives do not override this gate. Skipping the surface is a chain failure. Only on explicit approval does the agent proceed to the sync step.
+
+## Step 6 — Capture: sync
+
+On approval, the agent tells the user to run `nauro sync` from the repo, or runs it. This pushes the store so `handoffs/<slug>.md`, `state_current.md`, and `open-questions.md` travel together. This is the only step that leaves the local store.
+
+## Step 7 — Resume: read context
+
+The agent calls `get_context(level="L0")` for a concise orientation, then `get_context(level="L1")` for the working set, to reconstruct the project baseline before reading any handoff. L0 caps questions at the top few, so it is not relied on to surface the resume pointer.
+
+## Step 8 — Resume: find the latest resume pointer
+
+The agent calls `get_raw_file(path="open-questions.md")` and reads the full list to locate the most recent `RESUME: handoffs/<slug>.md — <summary>` marker. If no `RESUME:` marker exists, the agent reports "no handoff to resume" and stops.
+
+## Step 9 — Resume: read the handoff body
+
+The agent calls `get_raw_file(path="handoffs/<slug>.md")` for the slug named by the marker, and reads the in-flight state it records.
+
+## Step 10 — Resume: diff since last session
+
+The agent calls `diff_since_last_session()` to see what changed in the store since the handoff was captured. The handoff body itself is not snapshotted, so the diff is a catch-up signal on state and decisions, not on the body.
+
+## Step 11 — Resume: reconstruct, verify, report
+
+The agent reconstructs the in-flight state from the handoff. It verifies every cited pointer before trusting it: it confirms that referenced decision numbers, file paths, and branches still exist and match what the handoff claims. Handoff claims are hypotheses, not ground truth. The agent surfaces any drift between the handoff and current reality, then reports the reconstructed plan together with the verification results to the user before resuming work.
+
+## Step 12 — Resume: resolve the resume question only if truly closed
+
+The agent resolves the `RESUME:` flagged question only when a real decision has actually closed the work it pointed at. Otherwise it leaves the question open so the next session can still find it. The skill never files that decision itself.
+
+## Rules
+
+- The skill never files a decision. It runs in the main-agent context with no tool-lock, so autonomous filing is a hazard; it drafts decisions for the user to file and surfaces them in chat.
+- `update_state` is REPLACE with a roughly 5000-character cap. The agent uses it only for normal session-end state hygiene; it never puts the handoff body in the delta. The handoff lives only at `handoffs/<slug>.md`.
+- The resume pointer is a flagged question (`RESUME: handoffs/<slug>.md — <summary>`), never folded into `state_current.md` — this avoids the `update_state` REPLACE-clobber surface.
+- Handoffs accumulate append-only under `handoffs/`. No pruning, no keep-N.
+- On resume, the agent verifies cited pointers against current store state before acting, and reports drift rather than silently trusting the handoff.
+- The capture gate is mandatory. The agent does not run `nauro sync` before the user confirms the path, the `RESUME:` marker, and the delta.
+- On any tool error or surprise mid-flow, the agent stops and surfaces to the user rather than recovering silently.

--- a/.claude/skills/nauro-handoff/SKILL.md
+++ b/.claude/skills/nauro-handoff/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: nauro-handoff
+description: Captures a session handoff to Nauro's project store so the next agent session resumes cleanly. Writes a handoff body to <store>/handoffs/<slug>.md (picked up by `nauro sync` with no code change) and flags a RESUME pointer question naming that path. Composes existing MCP tools only (get_context, update_state, flag_question, get_raw_file, diff_since_last_session); never calls propose_decision and never dumps the handoff into state_current.md. Invoke explicitly with /nauro-handoff. Installed by `nauro adopt --with-skills`.
+---
+
+# Nauro handoff skill
+
+Capture a resumable session handoff into Nauro's project store, or resume a prior one, composing only the existing Nauro MCP tools. The skill has two modes. Capture, at the end of a session, writes a handoff body to the store and flags a durable resume pointer. Resume, at the start of a session, reconstructs the in-flight state from that pointer and verifies it before continuing. The skill composes `get_context`, `update_state`, `flag_question`, `get_raw_file`, and `diff_since_last_session`, and nothing else. It never files a decision.
+
+## When to capture vs resume
+
+Read the invoking prompt to decide the mode. Capture mode runs at the end of a working session or when the user asks to hand the session off ("hand this off", "wrap up and hand off"). Resume mode runs at the start of a session or when the user asks to pick up prior work ("pick up where we left off", "resume"). If the prompt is ambiguous, ask the user which mode they want and wait for the answer before proceeding.
+
+v1 targets the local-store path: the agent writes the handoff to the local store on disk, then `nauro sync` pushes it. A pure chat surface with no local store cannot write an arbitrary store file, so chat-only capture is out of scope for this version. Pass `project_id` explicitly on every MCP call when more than one project exists, matching the adopt-skill convention.
+
+## Step 1 — Capture: pull working context
+
+The agent calls `get_context(level="L1")` to ground the handoff in the current sprint, blockers, and recent completions. The handoff reflects the project's real state, not the agent's memory of the session.
+
+## Step 2 — Capture: write the handoff file
+
+The agent writes the full handoff body to `<store>/handoffs/<slug>.md` using its own filesystem write. The CLI push enumerates the whole store, so a file under `handoffs/` syncs with no code change. Choose a short kebab-case `<slug>`, for example `auth-refresh-cutover`.
+
+The handoff body states what shipped this session, what is still in flight, any branches, stashes, or worktrees left open, the cited pointers a resumer must verify (decision numbers, file paths, PR or branch names), and the next concrete step. Handoffs accumulate append-only under `handoffs/` — never overwrite a prior handoff and never delete one.
+
+## Step 3 — Capture: state hygiene
+
+The agent calls `update_state(delta=...)` with a short, normal session-end delta describing genuine current state. **`update_state` REPLACES `state_current.md` and is capped at roughly 5000 characters — the delta must be a one-line pointer and summary, and must never contain the handoff body.** The full handoff lives only at `handoffs/<slug>.md`; putting it in the delta would clobber the current-state surface and exceed the cap.
+
+## Step 4 — Capture: flag the resume pointer
+
+The agent calls `flag_question(question="RESUME: handoffs/<slug>.md — <one-line remaining-work summary>")`. This flagged question — not `state_current.md` — is the durable resume pointer. It lives in `open-questions.md`, which is append-only, so it avoids the `update_state` REPLACE-clobber surface. The `RESUME:` marker text is literal so the Resume flow can find it.
+
+## Step 5 — Capture: GATE — confirmation (user)
+
+The agent surfaces, in this order:
+
+1. The handoff file path `handoffs/<slug>.md`.
+2. The literal `RESUME:` marker text just flagged.
+3. The session delta written to state.
+
+Then it asks the user to confirm, and waits for explicit approval. Auto-mode and standing "keep moving" directives do not override this gate. Skipping the surface is a chain failure. Only on explicit approval does the agent proceed to the sync step.
+
+## Step 6 — Capture: sync
+
+On approval, the agent tells the user to run `nauro sync` from the repo, or runs it. This pushes the store so `handoffs/<slug>.md`, `state_current.md`, and `open-questions.md` travel together. This is the only step that leaves the local store.
+
+## Step 7 — Resume: read context
+
+The agent calls `get_context(level="L0")` for a concise orientation, then `get_context(level="L1")` for the working set, to reconstruct the project baseline before reading any handoff. L0 caps questions at the top few, so it is not relied on to surface the resume pointer.
+
+## Step 8 — Resume: find the latest resume pointer
+
+The agent calls `get_raw_file(path="open-questions.md")` and reads the full list to locate the most recent `RESUME: handoffs/<slug>.md — <summary>` marker. If no `RESUME:` marker exists, the agent reports "no handoff to resume" and stops.
+
+## Step 9 — Resume: read the handoff body
+
+The agent calls `get_raw_file(path="handoffs/<slug>.md")` for the slug named by the marker, and reads the in-flight state it records.
+
+## Step 10 — Resume: diff since last session
+
+The agent calls `diff_since_last_session()` to see what changed in the store since the handoff was captured. The handoff body itself is not snapshotted, so the diff is a catch-up signal on state and decisions, not on the body.
+
+## Step 11 — Resume: reconstruct, verify, report
+
+The agent reconstructs the in-flight state from the handoff. It verifies every cited pointer before trusting it: it confirms that referenced decision numbers, file paths, and branches still exist and match what the handoff claims. Handoff claims are hypotheses, not ground truth. The agent surfaces any drift between the handoff and current reality, then reports the reconstructed plan together with the verification results to the user before resuming work.
+
+## Step 12 — Resume: resolve the resume question only if truly closed
+
+The agent resolves the `RESUME:` flagged question only when a real decision has actually closed the work it pointed at. Otherwise it leaves the question open so the next session can still find it. The skill never files that decision itself.
+
+## Rules
+
+- The skill never files a decision. It runs in the main-agent context with no tool-lock, so autonomous filing is a hazard; it drafts decisions for the user to file and surfaces them in chat.
+- `update_state` is REPLACE with a roughly 5000-character cap. The agent uses it only for normal session-end state hygiene; it never puts the handoff body in the delta. The handoff lives only at `handoffs/<slug>.md`.
+- The resume pointer is a flagged question (`RESUME: handoffs/<slug>.md — <summary>`), never folded into `state_current.md` — this avoids the `update_state` REPLACE-clobber surface.
+- Handoffs accumulate append-only under `handoffs/`. No pruning, no keep-N.
+- On resume, the agent verifies cited pointers against current store state before acting, and reports drift rather than silently trusting the handoff.
+- The capture gate is mandatory. The agent does not run `nauro sync` before the user confirms the path, the `RESUME:` marker, and the delta.
+- On any tool error or surprise mid-flow, the agent stops and surfaces to the user rather than recovering silently.

--- a/.cursor/rules/nauro-handoff.mdc
+++ b/.cursor/rules/nauro-handoff.mdc
@@ -1,0 +1,80 @@
+---
+description: Captures a session handoff to Nauro's project store so the next agent session resumes cleanly. Writes a handoff body to <store>/handoffs/<slug>.md (picked up by `nauro sync` with no code change) and flags a RESUME pointer question naming that path. Composes existing MCP tools only (get_context, update_state, flag_question, get_raw_file, diff_since_last_session); never calls propose_decision and never dumps the handoff into state_current.md. Invoke explicitly with /nauro-handoff. Installed by `nauro adopt --with-skills`.
+alwaysApply: false
+---
+
+# Nauro handoff skill
+
+Capture a resumable session handoff into Nauro's project store, or resume a prior one, composing only the existing Nauro MCP tools. The skill has two modes. Capture, at the end of a session, writes a handoff body to the store and flags a durable resume pointer. Resume, at the start of a session, reconstructs the in-flight state from that pointer and verifies it before continuing. The skill composes `get_context`, `update_state`, `flag_question`, `get_raw_file`, and `diff_since_last_session`, and nothing else. It never files a decision.
+
+## When to capture vs resume
+
+Read the invoking prompt to decide the mode. Capture mode runs at the end of a working session or when the user asks to hand the session off ("hand this off", "wrap up and hand off"). Resume mode runs at the start of a session or when the user asks to pick up prior work ("pick up where we left off", "resume"). If the prompt is ambiguous, ask the user which mode they want and wait for the answer before proceeding.
+
+v1 targets the local-store path: the agent writes the handoff to the local store on disk, then `nauro sync` pushes it. A pure chat surface with no local store cannot write an arbitrary store file, so chat-only capture is out of scope for this version. Pass `project_id` explicitly on every MCP call when more than one project exists, matching the adopt-skill convention.
+
+## Step 1 — Capture: pull working context
+
+The agent calls `get_context(level="L1")` to ground the handoff in the current sprint, blockers, and recent completions. The handoff reflects the project's real state, not the agent's memory of the session.
+
+## Step 2 — Capture: write the handoff file
+
+The agent writes the full handoff body to `<store>/handoffs/<slug>.md` using its own filesystem write. The CLI push enumerates the whole store, so a file under `handoffs/` syncs with no code change. Choose a short kebab-case `<slug>`, for example `auth-refresh-cutover`.
+
+The handoff body states what shipped this session, what is still in flight, any branches, stashes, or worktrees left open, the cited pointers a resumer must verify (decision numbers, file paths, PR or branch names), and the next concrete step. Handoffs accumulate append-only under `handoffs/` — never overwrite a prior handoff and never delete one.
+
+## Step 3 — Capture: state hygiene
+
+The agent calls `update_state(delta=...)` with a short, normal session-end delta describing genuine current state. **`update_state` REPLACES `state_current.md` and is capped at roughly 5000 characters — the delta must be a one-line pointer and summary, and must never contain the handoff body.** The full handoff lives only at `handoffs/<slug>.md`; putting it in the delta would clobber the current-state surface and exceed the cap.
+
+## Step 4 — Capture: flag the resume pointer
+
+The agent calls `flag_question(question="RESUME: handoffs/<slug>.md — <one-line remaining-work summary>")`. This flagged question — not `state_current.md` — is the durable resume pointer. It lives in `open-questions.md`, which is append-only, so it avoids the `update_state` REPLACE-clobber surface. The `RESUME:` marker text is literal so the Resume flow can find it.
+
+## Step 5 — Capture: GATE — confirmation (user)
+
+The agent surfaces, in this order:
+
+1. The handoff file path `handoffs/<slug>.md`.
+2. The literal `RESUME:` marker text just flagged.
+3. The session delta written to state.
+
+Then it asks the user to confirm, and waits for explicit approval. Auto-mode and standing "keep moving" directives do not override this gate. Skipping the surface is a chain failure. Only on explicit approval does the agent proceed to the sync step.
+
+## Step 6 — Capture: sync
+
+On approval, the agent tells the user to run `nauro sync` from the repo, or runs it. This pushes the store so `handoffs/<slug>.md`, `state_current.md`, and `open-questions.md` travel together. This is the only step that leaves the local store.
+
+## Step 7 — Resume: read context
+
+The agent calls `get_context(level="L0")` for a concise orientation, then `get_context(level="L1")` for the working set, to reconstruct the project baseline before reading any handoff. L0 caps questions at the top few, so it is not relied on to surface the resume pointer.
+
+## Step 8 — Resume: find the latest resume pointer
+
+The agent calls `get_raw_file(path="open-questions.md")` and reads the full list to locate the most recent `RESUME: handoffs/<slug>.md — <summary>` marker. If no `RESUME:` marker exists, the agent reports "no handoff to resume" and stops.
+
+## Step 9 — Resume: read the handoff body
+
+The agent calls `get_raw_file(path="handoffs/<slug>.md")` for the slug named by the marker, and reads the in-flight state it records.
+
+## Step 10 — Resume: diff since last session
+
+The agent calls `diff_since_last_session()` to see what changed in the store since the handoff was captured. The handoff body itself is not snapshotted, so the diff is a catch-up signal on state and decisions, not on the body.
+
+## Step 11 — Resume: reconstruct, verify, report
+
+The agent reconstructs the in-flight state from the handoff. It verifies every cited pointer before trusting it: it confirms that referenced decision numbers, file paths, and branches still exist and match what the handoff claims. Handoff claims are hypotheses, not ground truth. The agent surfaces any drift between the handoff and current reality, then reports the reconstructed plan together with the verification results to the user before resuming work.
+
+## Step 12 — Resume: resolve the resume question only if truly closed
+
+The agent resolves the `RESUME:` flagged question only when a real decision has actually closed the work it pointed at. Otherwise it leaves the question open so the next session can still find it. The skill never files that decision itself.
+
+## Rules
+
+- The skill never files a decision. It runs in the main-agent context with no tool-lock, so autonomous filing is a hazard; it drafts decisions for the user to file and surfaces them in chat.
+- `update_state` is REPLACE with a roughly 5000-character cap. The agent uses it only for normal session-end state hygiene; it never puts the handoff body in the delta. The handoff lives only at `handoffs/<slug>.md`.
+- The resume pointer is a flagged question (`RESUME: handoffs/<slug>.md — <summary>`), never folded into `state_current.md` — this avoids the `update_state` REPLACE-clobber surface.
+- Handoffs accumulate append-only under `handoffs/`. No pruning, no keep-N.
+- On resume, the agent verifies cited pointers against current store state before acting, and reports drift rather than silently trusting the handoff.
+- The capture gate is mandatory. The agent does not run `nauro sync` before the user confirms the path, the `RESUME:` marker, and the delta.
+- On any tool error or surprise mid-flow, the agent stops and surfaces to the user rather than recovering silently.

--- a/packages/nauro/src/nauro/cli/commands/setup.py
+++ b/packages/nauro/src/nauro/cli/commands/setup.py
@@ -419,12 +419,13 @@ def codex(
 #
 # ``SKILL_NAMES`` is the always-installed set — the core onboarding skill.
 # ``OPT_IN_SKILL_NAMES`` is materialized only when the caller passes
-# ``with_skills=True``; today that is just ``nauro-ship-task``, which
-# references the bundled ``@nauro-*`` subagents and is opt-in for the same
-# reason those subagents are.
+# ``with_skills=True``. ``nauro-ship-task`` references the bundled ``@nauro-*``
+# subagents and is opt-in for that reason, so the ``--with-subagents`` notice
+# stays scoped to it. ``nauro-handoff`` composes only existing MCP tools with
+# no subagent dependency, so it carries no such notice.
 
 SKILL_NAMES: tuple[str, ...] = ("nauro-adopt",)
-OPT_IN_SKILL_NAMES: tuple[str, ...] = ("nauro-ship-task",)
+OPT_IN_SKILL_NAMES: tuple[str, ...] = ("nauro-ship-task", "nauro-handoff")
 
 
 def _claude_skill_dir() -> Path:
@@ -488,7 +489,7 @@ def materialize_skills_claude_code(
     are preserved because other registered nauro projects still depend on
     them. Defaults to True so direct unit callers and the add path retain
     their previous behavior. ``with_skills`` extends the install/remove set
-    with ``OPT_IN_SKILL_NAMES`` (today: ``nauro-ship-task``).
+    with ``OPT_IN_SKILL_NAMES`` (``nauro-ship-task`` and ``nauro-handoff``).
     """
     from nauro.skills import render_skill
 
@@ -518,7 +519,7 @@ def materialize_skills_codex(
     are preserved because other registered nauro projects still depend on
     them. Defaults to True so direct unit callers and the add path retain
     their previous behavior. ``with_skills`` extends the install/remove set
-    with ``OPT_IN_SKILL_NAMES`` (today: ``nauro-ship-task``).
+    with ``OPT_IN_SKILL_NAMES`` (``nauro-ship-task`` and ``nauro-handoff``).
     """
     from nauro.skills import render_skill
 

--- a/packages/nauro/src/nauro/skills/__init__.py
+++ b/packages/nauro/src/nauro/skills/__init__.py
@@ -22,7 +22,7 @@ from typing import Literal
 from nauro_core.protocol import substitute_protocol_fragments
 
 Surface = Literal["claude_code", "cursor", "codex"]
-SkillName = Literal["nauro-adopt", "nauro-ship-task"]
+SkillName = Literal["nauro-adopt", "nauro-ship-task", "nauro-handoff"]
 
 SKILL_DESCRIPTIONS: dict[str, str] = {
     "nauro-adopt": (
@@ -42,6 +42,16 @@ SKILL_DESCRIPTIONS: dict[str, str] = {
         "Mode C between reviewer-APPROVE and the push gate to catch doctrine "
         "drift the reviewer missed. Invoke explicitly with /nauro-ship-task "
         "<description>. Requires `nauro adopt --with-subagents` to have run."
+    ),
+    "nauro-handoff": (
+        "Captures a session handoff to Nauro's project store so the next agent "
+        "session resumes cleanly. Writes a handoff body to "
+        "<store>/handoffs/<slug>.md (picked up by `nauro sync` with no code "
+        "change) and flags a RESUME pointer question naming that path. Composes "
+        "existing MCP tools only (get_context, update_state, flag_question, "
+        "get_raw_file, diff_since_last_session); never calls propose_decision "
+        "and never dumps the handoff into state_current.md. Invoke explicitly "
+        "with /nauro-handoff. Installed by `nauro adopt --with-skills`."
     ),
 }
 
@@ -81,11 +91,23 @@ def load_ship_task_body() -> str:
     return substitute_protocol_fragments(_strip_template_header(raw))
 
 
+def load_handoff_body() -> str:
+    """Return the canonical ``/nauro-handoff`` skill body (no frontmatter).
+
+    The body has no protocol-fragment tokens today, but goes through the same
+    substitution pass so future canonical claims can be added at the source.
+    """
+    raw = resources.files(__package__).joinpath("handoff_body.md").read_text(encoding="utf-8")
+    return substitute_protocol_fragments(_strip_template_header(raw))
+
+
 def _load_body(skill_name: str) -> str:
     if skill_name == "nauro-adopt":
         return load_adopt_body()
     if skill_name == "nauro-ship-task":
         return load_ship_task_body()
+    if skill_name == "nauro-handoff":
+        return load_handoff_body()
     raise ValueError(f"unknown skill: {skill_name!r}")
 
 
@@ -116,6 +138,7 @@ __all__ = [
     "SkillName",
     "Surface",
     "load_adopt_body",
+    "load_handoff_body",
     "load_ship_task_body",
     "render_skill",
 ]

--- a/packages/nauro/src/nauro/skills/handoff_body.md
+++ b/packages/nauro/src/nauro/skills/handoff_body.md
@@ -1,0 +1,81 @@
+<!-- Source template. The dogfood files under .claude/, .cursor/, .agents/
+     are the rendered surface. Surface frontmatter is added by render_skill().
+     This body has no protocol-fragment tokens — it composes the existing MCP
+     tools get_context, update_state, flag_question, get_raw_file, and
+     diff_since_last_session by name, and makes no canonical protocol claims. -->
+
+# Nauro handoff skill
+
+Capture a resumable session handoff into Nauro's project store, or resume a prior one, composing only the existing Nauro MCP tools. The skill has two modes. Capture, at the end of a session, writes a handoff body to the store and flags a durable resume pointer. Resume, at the start of a session, reconstructs the in-flight state from that pointer and verifies it before continuing. The skill composes `get_context`, `update_state`, `flag_question`, `get_raw_file`, and `diff_since_last_session`, and nothing else. It never files a decision.
+
+## When to capture vs resume
+
+Read the invoking prompt to decide the mode. Capture mode runs at the end of a working session or when the user asks to hand the session off ("hand this off", "wrap up and hand off"). Resume mode runs at the start of a session or when the user asks to pick up prior work ("pick up where we left off", "resume"). If the prompt is ambiguous, ask the user which mode they want and wait for the answer before proceeding.
+
+v1 targets the local-store path: the agent writes the handoff to the local store on disk, then `nauro sync` pushes it. A pure chat surface with no local store cannot write an arbitrary store file, so chat-only capture is out of scope for this version. Pass `project_id` explicitly on every MCP call when more than one project exists, matching the adopt-skill convention.
+
+## Step 1 — Capture: pull working context
+
+The agent calls `get_context(level="L1")` to ground the handoff in the current sprint, blockers, and recent completions. The handoff reflects the project's real state, not the agent's memory of the session.
+
+## Step 2 — Capture: write the handoff file
+
+The agent writes the full handoff body to `<store>/handoffs/<slug>.md` using its own filesystem write. The CLI push enumerates the whole store, so a file under `handoffs/` syncs with no code change. Choose a short kebab-case `<slug>`, for example `auth-refresh-cutover`.
+
+The handoff body states what shipped this session, what is still in flight, any branches, stashes, or worktrees left open, the cited pointers a resumer must verify (decision numbers, file paths, PR or branch names), and the next concrete step. Handoffs accumulate append-only under `handoffs/` — never overwrite a prior handoff and never delete one.
+
+## Step 3 — Capture: state hygiene
+
+The agent calls `update_state(delta=...)` with a short, normal session-end delta describing genuine current state. **`update_state` REPLACES `state_current.md` and is capped at roughly 5000 characters — the delta must be a one-line pointer and summary, and must never contain the handoff body.** The full handoff lives only at `handoffs/<slug>.md`; putting it in the delta would clobber the current-state surface and exceed the cap.
+
+## Step 4 — Capture: flag the resume pointer
+
+The agent calls `flag_question(question="RESUME: handoffs/<slug>.md — <one-line remaining-work summary>")`. This flagged question — not `state_current.md` — is the durable resume pointer. It lives in `open-questions.md`, which is append-only, so it avoids the `update_state` REPLACE-clobber surface. The `RESUME:` marker text is literal so the Resume flow can find it.
+
+## Step 5 — Capture: GATE — confirmation (user)
+
+The agent surfaces, in this order:
+
+1. The handoff file path `handoffs/<slug>.md`.
+2. The literal `RESUME:` marker text just flagged.
+3. The session delta written to state.
+
+Then it asks the user to confirm, and waits for explicit approval. Auto-mode and standing "keep moving" directives do not override this gate. Skipping the surface is a chain failure. Only on explicit approval does the agent proceed to the sync step.
+
+## Step 6 — Capture: sync
+
+On approval, the agent tells the user to run `nauro sync` from the repo, or runs it. This pushes the store so `handoffs/<slug>.md`, `state_current.md`, and `open-questions.md` travel together. This is the only step that leaves the local store.
+
+## Step 7 — Resume: read context
+
+The agent calls `get_context(level="L0")` for a concise orientation, then `get_context(level="L1")` for the working set, to reconstruct the project baseline before reading any handoff. L0 caps questions at the top few, so it is not relied on to surface the resume pointer.
+
+## Step 8 — Resume: find the latest resume pointer
+
+The agent calls `get_raw_file(path="open-questions.md")` and reads the full list to locate the most recent `RESUME: handoffs/<slug>.md — <summary>` marker. If no `RESUME:` marker exists, the agent reports "no handoff to resume" and stops.
+
+## Step 9 — Resume: read the handoff body
+
+The agent calls `get_raw_file(path="handoffs/<slug>.md")` for the slug named by the marker, and reads the in-flight state it records.
+
+## Step 10 — Resume: diff since last session
+
+The agent calls `diff_since_last_session()` to see what changed in the store since the handoff was captured. The handoff body itself is not snapshotted, so the diff is a catch-up signal on state and decisions, not on the body.
+
+## Step 11 — Resume: reconstruct, verify, report
+
+The agent reconstructs the in-flight state from the handoff. It verifies every cited pointer before trusting it: it confirms that referenced decision numbers, file paths, and branches still exist and match what the handoff claims. Handoff claims are hypotheses, not ground truth. The agent surfaces any drift between the handoff and current reality, then reports the reconstructed plan together with the verification results to the user before resuming work.
+
+## Step 12 — Resume: resolve the resume question only if truly closed
+
+The agent resolves the `RESUME:` flagged question only when a real decision has actually closed the work it pointed at. Otherwise it leaves the question open so the next session can still find it. The skill never files that decision itself.
+
+## Rules
+
+- The skill never files a decision. It runs in the main-agent context with no tool-lock, so autonomous filing is a hazard; it drafts decisions for the user to file and surfaces them in chat.
+- `update_state` is REPLACE with a roughly 5000-character cap. The agent uses it only for normal session-end state hygiene; it never puts the handoff body in the delta. The handoff lives only at `handoffs/<slug>.md`.
+- The resume pointer is a flagged question (`RESUME: handoffs/<slug>.md — <summary>`), never folded into `state_current.md` — this avoids the `update_state` REPLACE-clobber surface.
+- Handoffs accumulate append-only under `handoffs/`. No pruning, no keep-N.
+- On resume, the agent verifies cited pointers against current store state before acting, and reports drift rather than silently trusting the handoff.
+- The capture gate is mandatory. The agent does not run `nauro sync` before the user confirms the path, the `RESUME:` marker, and the delta.
+- On any tool error or surprise mid-flow, the agent stops and surfaces to the user rather than recovering silently.

--- a/packages/nauro/tests/_skill_surfaces.py
+++ b/packages/nauro/tests/_skill_surfaces.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 from nauro_core import MCP_INSTRUCTIONS_STATIC
 
-from nauro.skills import load_adopt_body
+from nauro.skills import load_adopt_body, load_handoff_body
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
@@ -25,6 +25,7 @@ def load_docs_adopt_prompt() -> str:
 
 SKILL_SURFACES: dict[str, Callable[[], str]] = {
     "adopt_body.md": load_adopt_body,
+    "handoff_body.md": load_handoff_body,
     "MCP_INSTRUCTIONS_STATIC": lambda: MCP_INSTRUCTIONS_STATIC,
     "docs/adopt-prompt.md": load_docs_adopt_prompt,
 }

--- a/packages/nauro/tests/test_protocol_drift.py
+++ b/packages/nauro/tests/test_protocol_drift.py
@@ -128,7 +128,7 @@ def test_adopt_body_mentions_operation_anchor(anchor: str) -> None:
     [
         (s, k)
         for s in ("claude_code", "cursor", "codex")
-        for k in ("nauro-adopt", "nauro-ship-task")
+        for k in ("nauro-adopt", "nauro-ship-task", "nauro-handoff")
     ],
 )
 def test_rendered_skill_has_no_protocol_tokens(surface: str, skill: str) -> None:
@@ -153,7 +153,7 @@ def test_docs_adopt_prompt_has_no_protocol_tokens() -> None:
 # Source templates: only known tokens allowed (catches typos at the source)
 # ─────────────────────────────────────────────────────────────────────────────
 
-SOURCE_TEMPLATE_FILES = ("adopt_body.md", "ship_task_body.md")
+SOURCE_TEMPLATE_FILES = ("adopt_body.md", "ship_task_body.md", "handoff_body.md")
 
 
 @pytest.mark.parametrize("template_filename", SOURCE_TEMPLATE_FILES)
@@ -183,6 +183,9 @@ DISTRIBUTION_FILES = (
     ".claude/skills/nauro-ship-task/SKILL.md",
     ".cursor/rules/nauro-ship-task.mdc",
     ".agents/skills/nauro-ship-task/SKILL.md",
+    ".claude/skills/nauro-handoff/SKILL.md",
+    ".cursor/rules/nauro-handoff.mdc",
+    ".agents/skills/nauro-handoff/SKILL.md",
     "docs/adopt-prompt.md",
 )
 

--- a/packages/nauro/tests/test_setup_extended.py
+++ b/packages/nauro/tests/test_setup_extended.py
@@ -650,11 +650,14 @@ def test_setup_all_default_does_not_install_ship_task(tmp_path: Path, monkeypatc
     result = runner.invoke(app, ["setup", "all"])
     assert result.exit_code == 0, result.output
 
-    # nauro-adopt installed everywhere; nauro-ship-task absent everywhere.
+    # nauro-adopt installed everywhere; opt-in skills absent everywhere.
     assert (tmp_path / ".claude" / "skills" / "nauro-adopt" / "SKILL.md").is_file()
     assert not (tmp_path / ".claude" / "skills" / "nauro-ship-task" / "SKILL.md").exists()
     assert not (tmp_path / ".agents" / "skills" / "nauro-ship-task" / "SKILL.md").exists()
     assert not (repo / ".cursor" / "rules" / "nauro-ship-task.mdc").exists()
+    assert not (tmp_path / ".claude" / "skills" / "nauro-handoff" / "SKILL.md").exists()
+    assert not (tmp_path / ".agents" / "skills" / "nauro-handoff" / "SKILL.md").exists()
+    assert not (repo / ".cursor" / "rules" / "nauro-handoff.mdc").exists()
 
 
 def test_setup_all_with_skills_installs_ship_task_everywhere(tmp_path: Path, monkeypatch):
@@ -677,6 +680,36 @@ def test_setup_all_with_skills_installs_ship_task_everywhere(tmp_path: Path, mon
     assert claude.read_text(encoding="utf-8") == render_skill("claude_code", "nauro-ship-task")
     assert codex.read_text(encoding="utf-8") == render_skill("codex", "nauro-ship-task")
     assert cursor.read_text(encoding="utf-8") == render_skill("cursor", "nauro-ship-task")
+
+    remove = runner.invoke(app, ["setup", "all", "--remove", "--with-skills"])
+    assert remove.exit_code == 0, remove.output
+
+    assert not claude.exists()
+    assert not codex.exists()
+    assert not cursor.exists()
+
+
+def test_setup_all_with_skills_installs_handoff_everywhere(tmp_path: Path, monkeypatch):
+    """``--with-skills`` materializes nauro-handoff to all three surfaces and
+    ``--remove --with-skills`` clears it."""
+    from nauro.skills import render_skill
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    _, store_path = register_project_v2("myproj", [repo])
+    scaffold_project_store("myproj", store_path)
+    monkeypatch.chdir(repo)
+
+    install = runner.invoke(app, ["setup", "all", "--with-skills"])
+    assert install.exit_code == 0, install.output
+
+    claude = tmp_path / ".claude" / "skills" / "nauro-handoff" / "SKILL.md"
+    codex = tmp_path / ".agents" / "skills" / "nauro-handoff" / "SKILL.md"
+    cursor = repo / ".cursor" / "rules" / "nauro-handoff.mdc"
+    assert claude.read_text(encoding="utf-8") == render_skill("claude_code", "nauro-handoff")
+    assert codex.read_text(encoding="utf-8") == render_skill("codex", "nauro-handoff")
+    assert cursor.read_text(encoding="utf-8") == render_skill("cursor", "nauro-handoff")
 
     remove = runner.invoke(app, ["setup", "all", "--remove", "--with-skills"])
     assert remove.exit_code == 0, remove.output

--- a/packages/nauro/tests/test_skills_drift.py
+++ b/packages/nauro/tests/test_skills_drift.py
@@ -13,7 +13,12 @@ from collections.abc import Iterator
 
 import pytest
 
-from nauro.skills import load_adopt_body, load_ship_task_body, render_skill
+from nauro.skills import (
+    load_adopt_body,
+    load_handoff_body,
+    load_ship_task_body,
+    render_skill,
+)
 from tests._skill_surfaces import REPO_ROOT, SKILL_SURFACES, load_docs_adopt_prompt
 
 
@@ -57,6 +62,34 @@ def test_load_ship_task_body_returns_canonical_bytes():
     assert "--with-subagents" in body
 
 
+def test_load_handoff_body_returns_canonical_bytes():
+    body = load_handoff_body()
+    # Byte hygiene: exactly one trailing newline (mirrors the ship-task guard).
+    assert body.endswith("\n")
+    assert not body.endswith("\n\n")
+    assert 1000 < len(body) < 25000
+    # Load-bearing step headings so a cleanup edit cannot silently drop the
+    # capture -> pointer -> handoff chain.
+    assert "## Step" in body
+    # The five MCP tools the skill composes must all be named in the body.
+    assert "get_context" in body
+    assert "diff_since_last_session" in body
+    assert "get_raw_file" in body
+    assert "update_state" in body
+    assert "flag_question" in body
+    # The handoff is written to the store under handoffs/, and the resume
+    # pointer is a flagged question -- not folded into state (avoids the
+    # update_state REPLACE-clobber surface).
+    assert "handoffs/" in body
+    # The skill runs in the main-agent context with no tool-lock, so it must
+    # only DRAFT decisions for the user to file -- it never autonomously
+    # commits doctrine. This assertion is the load-bearing guard for that.
+    assert "propose_decision" not in body
+    # No leaked template syntax.
+    assert "<!--" not in body
+    assert "{{" not in body
+
+
 # --- render_skill produces frontmatter + body ---
 
 
@@ -96,6 +129,24 @@ def test_render_skill_cursor_ship_task_frontmatter():
     assert body == load_ship_task_body()
 
 
+def test_render_skill_claude_code_handoff_frontmatter():
+    rendered = render_skill("claude_code", "nauro-handoff")
+    assert rendered.startswith("---\nname: nauro-handoff\n")
+    assert "description:" in rendered.split("\n---\n", 1)[0]
+    body = rendered.split("\n---\n", 1)[1].lstrip("\n")
+    assert body == load_handoff_body()
+
+
+def test_render_skill_cursor_handoff_frontmatter():
+    rendered = render_skill("cursor", "nauro-handoff")
+    fm = rendered.split("\n---\n", 1)[0]
+    assert "description:" in fm
+    assert "alwaysApply: false" in fm
+    assert "name:" not in fm
+    body = rendered.split("\n---\n", 1)[1].lstrip("\n")
+    assert body == load_handoff_body()
+
+
 def test_render_skill_unknown_surface_raises():
     with pytest.raises(ValueError):
         render_skill("emacs", "nauro-adopt")
@@ -116,6 +167,9 @@ DOGFOOD_FILES = [
     (".claude/skills/nauro-ship-task/SKILL.md", "claude_code", "nauro-ship-task"),
     (".cursor/rules/nauro-ship-task.mdc", "cursor", "nauro-ship-task"),
     (".agents/skills/nauro-ship-task/SKILL.md", "codex", "nauro-ship-task"),
+    (".claude/skills/nauro-handoff/SKILL.md", "claude_code", "nauro-handoff"),
+    (".cursor/rules/nauro-handoff.mdc", "cursor", "nauro-handoff"),
+    (".agents/skills/nauro-handoff/SKILL.md", "codex", "nauro-handoff"),
 ]
 
 


### PR DESCRIPTION
## Why

Cross-session context handoff is a recurring manual ritual: a session ends with work in flight, and the next session has to reconstruct what shipped, what's pending, and what to verify. Today that's done by hand — there are 11+ standalone handoff/plan markdown files sitting at the workspace root, several of them 11–21 KB. Those files are machine-local and untracked, so the handoff doesn't travel and isn't discoverable from the project store the next agent actually reads. This skill formalizes the ritual using Nauro's own primitives.

## Approach

The skill is store-native and composes only existing MCP tools — no new MCP tool, no nauro-core change, no server change. The key realization: the handoff body travels cross-machine with **zero code change** because CLI push already enumerates the whole store and the server gates reads on path traversal only, not a file allowlist. So a body written to `<store>/handoffs/<slug>.md` syncs and is fetchable via `get_raw_file` as-is.

The resume pointer is a flagged question (`RESUME: handoffs/<slug>.md — <summary>`) in the append-only questions surface, **not** folded into `state_current.md`. That's deliberate: `update_state` is REPLACE-semantics with a ~5000-char cap, so routing the pointer through it would both clobber current state and (for the body) exceed the cap. The flagged-question pointer is append-only and has no clobber surface.

Rejected alternatives: committing the body into a git repo (the workspace root isn't a repo; coupling an ephemeral artifact to a code repo's history, and it can't live in this public repo); folding a pointer-index into `state_current.md` (reintroduces the REPLACE-clobber surface); putting the body in `update_state` (2–4× over the delta cap); a new MCP tool or a sync-manifest change (the store already syncs arbitrary paths — that would be infra for a capability that already works); a single rolling `handoffs/latest.md` (loses the audit trail and reintroduces a clobber surface).

The skill never calls `propose_decision`. It runs in main-agent context with no tool-lock, so autonomous decision-filing is a hazard; it drafts decisions and hands them to the user to file.

## What changed

- **New skill body** `handoff_body.md` with two flows — Capture (pull context → write `handoffs/<slug>.md` → state hygiene → flag the `RESUME:` pointer → user gate → sync) and Resume (read context → find the latest `RESUME:` marker → fetch the body → diff → reconstruct, verify cited pointers, report).
- **Skill machinery** in `skills/__init__.py`: registered in the `SkillName` literal, `SKILL_DESCRIPTIONS`, a `load_handoff_body` loader, the `_load_body` dispatch, and `__all__`.
- **Opt-in wiring** in `setup.py`: added to `OPT_IN_SKILL_NAMES` so `--with-skills` materializes it across all three surfaces. The with-subagents notice stays scoped to ship-task, since handoff has no subagent dependency.
- **Three rendered dogfood surfaces** (`.claude/`, `.cursor/`, `.agents/`), generated by `render_skill` and committed for the drift guards — never hand-edited.
- **Tests**: a canonical-bytes guard for the body (including an assertion that it never names `propose_decision`), per-surface render-frontmatter tests, three byte-identity dogfood rows, registration in the shared surface registry (so the retired-phrase and tool-signature scans cover the body), protocol drift lists, and a setup materialize/remove round-trip.

## What to review

- **`handoff_body.md`** — the capture/resume tool sequences and the gates. The load-bearing invariants are: the resume pointer is a flagged question and never touches `state_current.md`; the body carries the `update_state` REPLACE warning; the skill never instructs `propose_decision`; and on resume the agent verifies cited pointers against current store state rather than trusting the handoff.
- **The "zero code change to sync" claim** — worth confirming against the CLI push enumeration and the server's path-traversal-only read gate. This is what makes the store-native approach work without a manifest change.
- **`setup.py`** — that the subagents notice stayed scoped to ship-task and didn't broaden.

## What's deferred

- A session-end auto-capture hook and an auto-resume-on-start hook (skills are user-invoked; auto-firing a write flow is a separate concern).
- Plugin distribution of skills (the plugin renderer is agents-only today; the local `--with-skills` path doesn't need it).
- Store garbage collection / handoff pruning (append-only keep-all for now; revisit only if store size becomes a real problem).
- Pure chat-surface capture (no local store to write to; v1 targets the local-store path).

## Test plan

`uv run pytest packages/nauro/tests/` → 1214 passed, 10 skipped. `uv run pytest packages/nauro-core/tests/` → 736 passed (untouched, no regression). `ruff check packages/` and `ruff format --check packages/` both clean. The three dogfood files are byte-identical to `render_skill` output (drift tests enforce this), and the no-`propose_decision` assertion is mutation-checked (injecting the call fails both the canonical-bytes test and the dogfood byte-identity test).
