### PR TITLE
docs: clarify local-first onboarding; fix Codex remote connector setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ Add `--with-subagents` on `nauro adopt` or `nauro setup` to install Nauro's bund
 
 Chat surfaces (Claude.ai, ChatGPT, Perplexity): run `nauro adopt` from a terminal first, then point the chat agent at [`docs/adopt-prompt.md`](docs/adopt-prompt.md).
 
-## Cross-surface sync
+## Cross-surface sync (optional)
+
+The steps above work fully on your machine with no account. To sync a project to the cloud and reach it from surfaces without a local copy (claude.ai web) or from another machine:
 
 ```bash
 nauro auth login
@@ -62,7 +64,21 @@ nauro sync
 
 Then add `https://mcp.nauro.ai/mcp` as an MCP connector in your tool's settings.
 
-Codex users: add `mcp_oauth_callback_port = 8765` to the top of `~/.codex/config.toml` so the OAuth callback uses a fixed port.
+### Codex (remote connector)
+
+Add it under a name distinct from the local `nauro` stdio server:
+
+```bash
+codex mcp add nauro-cloud --url https://mcp.nauro.ai/mcp
+```
+
+Then pin the OAuth callback port at the top of `~/.codex/config.toml`. Codex's callback uses a fixed, pre-registered port; without it Codex picks a random port and login fails:
+
+```toml
+mcp_oauth_callback_port = 8765
+```
+
+Requires Codex 0.131.0 or newer. Enter the URL exactly as shown, with no trailing slash. If login reports a callback-port error, free port 8765.
 
 ## MCP tools
 

--- a/packages/nauro/src/nauro/cli/commands/auth.py
+++ b/packages/nauro/src/nauro/cli/commands/auth.py
@@ -404,10 +404,12 @@ def login() -> None:
         "    nauro link --cloud    (one-time, per project)\n"
         "    nauro sync\n"
         "\n"
-        "  Add https://mcp.nauro.ai/mcp as an MCP connector in your tool's settings.\n"
+        "  Add https://mcp.nauro.ai/mcp as an MCP connector in your tool's settings\n"
+        "  (enter the URL exactly, with no trailing slash).\n"
         "\n"
-        "  Codex users: add `mcp_oauth_callback_port = 8765` to the top of"
-        " ~/.codex/config.toml"
+        "  Codex: add `mcp_oauth_callback_port = 8765` to the top of ~/.codex/config.toml\n"
+        "  (required for the remote connector; without it, login uses a random port"
+        " and fails)."
     )
 
 


### PR DESCRIPTION
## Why

The "Cross-surface sync" docs and the post-login next-steps under-specified the remote-connector path — especially for Codex — and didn't make clear that everything works locally with no account.

Codex only uses a fixed OAuth callback port when `mcp_oauth_callback_port` is set. The docs framed that line as optional ("so the OAuth callback uses a fixed port"), but it is required: without it Codex binds a random loopback port each run, which can't match a pre-registered callback, so remote login fails every time. A trailing slash on the server URL also changes Codex's derived callback path and causes a mismatch.

## Approach

Keep stdio (local) as the default, friction-free path and present cloud/remote as a clearly-labeled opt-in. This matches how the surfaces are intended to relate: installed clients read the local store directly, and the remote connector serves surfaces that don't have a local copy. Make the remote-connector steps precise enough that a user who follows them verbatim succeeds.

## What changed

- **README** — "Cross-surface sync" → "Cross-surface sync (optional)", with a lead line stating the local path needs no account. New "Codex (remote connector)" subsection: a connector name distinct from the local stdio `nauro` entry (so they don't collide in one session), the exact URL with a no-trailing-slash note, the callback port as a required step, a minimum Codex version, and a one-line busy-port troubleshooting note.
- **auth.py** — the post-login next-steps now note the connector URL must be entered verbatim, and mark the Codex callback-port line as required with the consequence of omitting it.

## What to review

- The minimum Codex version (0.131.0) and the distinct-connector-name guidance — both follow from how recent Codex derives its loopback callback path.
- The trailing-slash sensitivity note: a trailing slash genuinely changes the derived callback identifier.

## What's deferred

- A `nauro setup codex --remote` convenience that writes the remote entry and the callback port in one step.
- A check that watches for upstream Codex changes to the callback derivation.

## Test plan

- Docs plus one CLI echo string; `ruff check` and `ruff format --check` pass on the changed module.
- The remote OAuth flow was verified end-to-end against the live server: successful login and authorization-code → token exchange for the correct audience and scopes.
