### PR TITLE
docs(agents-md): scope the Nauro connector-name rule to Claude Code subagents

### DIFF
--- a/packages/nauro/src/nauro/templates/agents_md.py
+++ b/packages/nauro/src/nauro/templates/agents_md.py
@@ -111,9 +111,11 @@ def generate_agents_md(
         "If a cloud Nauro connector (e.g. `mcp__claude_ai_Nauro__*`) is also mounted, "
         "prefer the local `mcp__nauro__*` tools for this repo — they read the working "
         "copy on this machine.\n\n"
-        "For the cloud connector, name it exactly `Nauro` when adding it: the "
-        "bundled `@nauro-*` subagents allow the `mcp__claude_ai_Nauro__*` tools by "
-        "name, and a differently-named connector leaves those tools unresolved.\n"
+        "Connector naming: if you use the bundled `@nauro-*` Claude Code subagents, "
+        "name the cloud connector exactly `Nauro`, because those subagents reference "
+        "the `mcp__claude_ai_Nauro__*` tools by that name and a different name leaves "
+        "them unresolved. Other tools (Codex, Cursor) can use any connector name, as "
+        "long as it differs from a local stdio `nauro` entry.\n"
     )
 
     # MCP tools and behavioral instructions. Counts are derived from the

--- a/packages/nauro/tests/test_agents_md.py
+++ b/packages/nauro/tests/test_agents_md.py
@@ -63,11 +63,14 @@ def test_routing_block_omits_project_id_line_when_unknown():
     assert "project_id:" not in result
 
 
-def test_routing_block_names_required_cloud_connector_name():
-    """The store-routing block states the cloud connector must be named `Nauro`."""
+def test_routing_block_scopes_cloud_connector_name_to_subagents():
+    """The cloud-connector `Nauro` name is required for the bundled Claude Code
+    subagents; other tools (Codex/Cursor) may use any distinct name."""
     result = generate_agents_md("myproj", "payload")
-    assert "name it exactly `Nauro`" in result
+    assert "exactly `Nauro`" in result
+    assert "`@nauro-*`" in result
     assert "`mcp__claude_ai_Nauro__*`" in result
+    assert "Codex" in result
 
 
 def test_check_decision_categorized_as_read_tool():


### PR DESCRIPTION
## Why

The cloud-connector naming guidance in `AGENTS.md` told every reader to "name it exactly `Nauro`," but that requirement is specific to the bundled `@nauro-*` Claude Code subagents — their tool whitelist references `mcp__claude_ai_Nauro__*` by name, so a differently-named connector leaves those tools unresolved. `AGENTS.md` is the cross-tool file Codex and Cursor read, and the remote-connector docs in #171 tell Codex users to use a name distinct from the local stdio `nauro` entry. So the general "name it `Nauro`" line contradicted the Codex guidance for readers who don't even have those subagents.

## What changed

- **`agents_md.py`** — scope the connector-name rule: `Nauro` is required only when using the bundled `@nauro-*` Claude Code subagents; other tools (Codex, Cursor) can use any name distinct from a local stdio `nauro` entry.
- **`test_agents_md.py`** — update the routing-block test to assert the scoped wording (subagent scope plus the other-tools allowance) instead of the unconditional rule.

## What to review

The scoping claim: the `Nauro` name is load-bearing only for the subagent tool whitelist, not for MCP tool resolution in general. Codex/Cursor resolve their MCP tools regardless of connector name.

## What's deferred

`setup.py`'s `SUBAGENTS_CONNECTOR_NAME_NOTICE` is left unchanged: it only prints with `--with-subagents` (i.e. to the Claude Code subagent audience) and already explains the reason, so it's correctly scoped as-is.

## Test plan

`ruff check` and `ruff format --check` clean on both files; `test_agents_md.py` passes (19 tests).
