### PR TITLE
Lock local snapshot capture across compute and write to close an overwrite race

### DIFF
--- a/packages/nauro/src/nauro/store/snapshot.py
+++ b/packages/nauro/src/nauro/store/snapshot.py
@@ -13,9 +13,11 @@ and never pruned (preserves the decision chain).
 
 import json
 import logging
+from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+from filelock import FileLock
 from nauro_core.snapshot import serialize_snapshot
 
 from nauro.constants import (
@@ -27,6 +29,22 @@ from nauro.constants import (
 )
 
 logger = logging.getLogger("nauro.snapshot")
+
+
+@contextmanager
+def _snapshot_lock(snapshots_dir: Path):
+    """Exclusive file lock on the snapshots dir for atomic capture.
+
+    Mirrors ``registry._registry_lock``. The version is derived from the
+    existing snapshots, so the lock must span the read-compute-write sequence,
+    not just the write — otherwise two captures compute the same next version
+    and one overwrites the other. The snapshots dir lives under NAURO_HOME, so
+    the lock path inherits that override without re-resolving it here.
+    """
+    lock_path = snapshots_dir / ".lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with FileLock(str(lock_path)):
+        yield
 
 
 def capture_snapshot(store_path: Path, trigger: str = "", trigger_detail: str = "") -> int:
@@ -46,33 +64,39 @@ def capture_snapshot(store_path: Path, trigger: str = "", trigger_detail: str = 
     snapshots_dir = store_path / SNAPSHOTS_DIR
     snapshots_dir.mkdir(parents=True, exist_ok=True)
 
-    # Determine next version
-    existing = list_snapshots(store_path)
-    next_version = (existing[0]["version"] + 1) if existing else 1
+    # Hold the lock across compute-version, write, and prune. Locking only the
+    # write would leave the read-compute race open: two captures would read the
+    # same existing version, derive the same next version, and one would
+    # overwrite the other.
+    with _snapshot_lock(snapshots_dir):
+        # Determine next version
+        existing = list_snapshots(store_path)
+        next_version = (existing[0]["version"] + 1) if existing else 1
 
-    # Read all markdown files
-    files = {}
-    for md in sorted(store_path.glob("*.md")):
-        files[md.name] = md.read_text()
+        # Read all markdown files
+        files = {}
+        for md in sorted(store_path.glob("*.md")):
+            files[md.name] = md.read_text()
 
-    decisions_dir = store_path / DECISIONS_DIR
-    if decisions_dir.exists():
-        for md in sorted(decisions_dir.glob("*.md")):
-            files[f"{DECISIONS_DIR}/{md.name}"] = md.read_text()
+        decisions_dir = store_path / DECISIONS_DIR
+        if decisions_dir.exists():
+            for md in sorted(decisions_dir.glob("*.md")):
+                files[f"{DECISIONS_DIR}/{md.name}"] = md.read_text()
 
-    snapshot = serialize_snapshot(
-        timestamp=datetime.now(timezone.utc).isoformat(),
-        trigger=trigger,
-        trigger_detail=trigger_detail,
-        files=files,
-        version=next_version,
-    )
+        snapshot = serialize_snapshot(
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            trigger=trigger,
+            trigger_detail=trigger_detail,
+            files=files,
+            version=next_version,
+        )
 
-    out_path = snapshots_dir / f"v{next_version:03d}.json"
-    out_path.write_text(json.dumps(snapshot, indent=2) + "\n")
+        out_path = snapshots_dir / f"v{next_version:03d}.json"
+        out_path.write_text(json.dumps(snapshot, indent=2) + "\n")
 
-    # Prune after every capture
-    _prune_snapshots(snapshots_dir)
+        # Prune after every capture. Prune mutates the same dir the version
+        # count reads, so it stays inside the lock.
+        _prune_snapshots(snapshots_dir)
 
     return next_version
 

--- a/packages/nauro/tests/test_snapshot_lock.py
+++ b/packages/nauro/tests/test_snapshot_lock.py
@@ -1,0 +1,92 @@
+"""Serialization guarantees for snapshot capture.
+
+``capture_snapshot`` reads the existing snapshots to compute the next dense
+version, writes ``snapshots/vNNN.json``, then prunes. Without a lock across
+that read-compute-write sequence, two concurrent captures derive the same
+version and one silently overwrites the other — losing snapshot history.
+These tests pin the contract of ``_snapshot_lock``: it holds an exclusive
+file lock spanning compute and write, so concurrent captures land on
+distinct versions. The lock-held assertion is deterministic — no sleep-racing.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import filelock
+import pytest
+
+from nauro.constants import SNAPSHOTS_DIR
+from nauro.store.snapshot import (
+    _snapshot_lock,
+    capture_snapshot,
+    list_snapshots,
+)
+
+
+def _make_store(tmp_path, monkeypatch):
+    """Point NAURO_HOME and HOME into tmp_path and return a scaffolded store dir."""
+    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    store_path = tmp_path / "nauro_home" / "projects" / "proj"
+    store_path.mkdir(parents=True, exist_ok=True)
+    (store_path / "project.md").write_text("# Project\n")
+    return store_path
+
+
+def _lock_path(store_path):
+    return store_path / SNAPSHOTS_DIR / ".lock"
+
+
+def test_concurrent_captures_do_not_overwrite(tmp_path, monkeypatch):
+    """Two concurrent captures against one store land on two distinct versions.
+
+    A barrier maximizes overlap. Without the lock both compute the same next
+    version and write the same file; with it they serialize to {1, 2}.
+    """
+    store_path = _make_store(tmp_path, monkeypatch)
+
+    barrier = threading.Barrier(2)
+
+    def _capture():
+        barrier.wait()
+        capture_snapshot(store_path, trigger="concurrent")
+
+    threads = [threading.Thread(target=_capture) for _ in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    snapshot_files = sorted((store_path / SNAPSHOTS_DIR).glob("v*.json"))
+    assert len(snapshot_files) == 2
+    versions = {meta["version"] for meta in list_snapshots(store_path)}
+    assert versions == {1, 2}
+
+
+def test_lock_is_held_during_body_and_released_after(tmp_path, monkeypatch):
+    """While ``_snapshot_lock`` is held a fresh FileLock times out; after exit it acquires."""
+    store_path = _make_store(tmp_path, monkeypatch)
+    snapshots_dir = store_path / SNAPSHOTS_DIR
+
+    with _snapshot_lock(snapshots_dir):
+        contender = filelock.FileLock(str(_lock_path(store_path)))
+        with pytest.raises(filelock.Timeout):
+            contender.acquire(timeout=0.2)
+
+    # After exit, a fresh instance acquires immediately.
+    after = filelock.FileLock(str(_lock_path(store_path)))
+    after.acquire(timeout=0.2)
+    assert after.is_locked
+    after.release()
+
+
+def test_serial_captures_are_monotonic(tmp_path, monkeypatch):
+    """Three sequential captures produce versions 1, 2, 3 and three files."""
+    store_path = _make_store(tmp_path, monkeypatch)
+
+    versions = [capture_snapshot(store_path, trigger="serial") for _ in range(3)]
+    assert versions == [1, 2, 3]
+
+    snapshot_files = sorted((store_path / SNAPSHOTS_DIR).glob("v*.json"))
+    assert len(snapshot_files) == 3


### PR DESCRIPTION
## Why

`capture_snapshot()` derived the next snapshot version by reading the existing
snapshots (`next_version = existing[0]["version"] + 1`), wrote
`snapshots/vNNN.json`, then pruned — with no lock spanning that sequence. When
two captures run concurrently against one store (multiple MCP/CLI writers, or
overlapping auto-capture triggers), both read the same existing version, derive
the same next version, and write the same file. One silently overwrites the
other, and a slice of snapshot history is lost with no error.

## Approach

Wrap the read-compute-write-prune body of `capture_snapshot` in a
`_snapshot_lock(snapshots_dir)` contextmanager — a fresh `filelock.FileLock`
per call on a `.lock` file under the snapshots dir, following the established
local read-modify-write lock pattern already used for the registry and config
files. The lock deliberately spans both the version computation and the write:
locking only the write would leave the read-compute race open, since the
collision is two callers deriving the same version, not two writes to a
known-distinct path. Prune stays inside the lock because it mutates the same
directory the version count reads.

The local store keeps the sequential `vNNN` key and the dense integer `version`
field. A collision-free key (e.g. a random/sortable id) would sidestep the
shared-counter race without a lock, but it would break the dense-counter
contract that `list`, diff resolution, and load-by-version depend on, and it
diverges from how the local store has always addressed snapshots. Locking
preserves that contract; the random-key route is the right tradeoff for the
remote/cloud path, not the local filesystem one. The snapshots dir already
lives under `NAURO_HOME`, so the lock path inherits that override with no
re-resolution.

## What changed

- `store/snapshot.py`: new `_snapshot_lock` contextmanager; `capture_snapshot`
  now holds it across compute-version, write, and prune. No signature change,
  so all existing capture sites inherit the guard with no caller edits. No new
  dependency — `filelock` already backs the registry and config locks.

## What to review

- The lock spans compute **and** write, not just the write — confirm the
  comment and structure make that invariant obvious, since a future edit that
  narrows the lock to the write alone would reopen the race.
- Lock-file placement: `.lock` under the snapshots dir. The `v*.json` globs in
  `list_snapshots` and `_prune_snapshots` do not match it, so it is inert to
  listing and pruning.
- `test_concurrent_captures_do_not_overwrite` was verified to fail when the
  lock body is neutralized, so it genuinely exercises the race rather than
  passing vacuously.

## What's deferred

Routing the snapshot write through `atomic_write_text` (torn-write hardening on
crash/interrupt mid-write) is orthogonal to this concurrency fix and out of
scope here. The lock serializes writers; it does not make an individual write
atomic against process death.

## Test plan

New colocated `tests/test_snapshot_lock.py` (3 tests): no-overwrite under
concurrency (two barrier-synced threads → exactly two files, versions `{1, 2}`),
lock-held determinism (a fresh `FileLock` times out while the lock is held and
acquires after exit), and serial monotonicity (`1, 2, 3`). All sets
`NAURO_HOME` and `HOME` into `tmp_path` so the real `~/.nauro` is untouched.
1217 existing + 3 new tests pass; `ruff check` and `ruff format --check` clean.
