### PR TITLE
Lock local decision-number allocation across allocate and write

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/import_cmd.py
+++ b/packages/nauro/src/nauro/cli/commands/import_cmd.py
@@ -15,6 +15,7 @@ from nauro_core.operations.propose_decision import _write_decision_direct
 
 from nauro.cli.utils import resolve_target_project
 from nauro.constants import PROJECT_MD, STACK_MD
+from nauro.store.decision_lock import decision_write_lock
 from nauro.store.filesystem_store import FilesystemStore
 from nauro.store.snapshot import capture_snapshot
 
@@ -27,15 +28,19 @@ def _import_append_decision(
     confidence: str = "medium",
 ) -> None:
     """Adapter for the import paths: write a decision via the kernel."""
-    _write_decision_direct(
-        FilesystemStore(store_path),
-        {
-            "title": title,
-            "rationale": rationale,
-            "rejected": rejected,
-            "confidence": confidence,
-        },
-    )
+    # Hold the allocation lock across the number computation and the write so
+    # concurrent local writers cannot mint the same decision number. The
+    # post-loop capture_snapshot stays outside the lock.
+    with decision_write_lock(store_path):
+        _write_decision_direct(
+            FilesystemStore(store_path),
+            {
+                "title": title,
+                "rationale": rationale,
+                "rejected": rejected,
+                "confidence": confidence,
+            },
+        )
 
 
 def _import_memory_bank(memory_bank: Path, store_path: Path) -> dict[str, int]:

--- a/packages/nauro/src/nauro/cli/commands/note.py
+++ b/packages/nauro/src/nauro/cli/commands/note.py
@@ -6,6 +6,7 @@ from nauro_core.operations import flag_question as _flag_question_op
 from nauro_core.operations.propose_decision import _write_decision_direct
 
 from nauro.cli.utils import resolve_target_project
+from nauro.store.decision_lock import decision_write_lock
 from nauro.store.filesystem_store import FilesystemStore
 from nauro.templates.agents_md_regen import warn_then_regen
 
@@ -58,14 +59,18 @@ def note(
         typer.echo(f"  {text}")
         typer.echo(f"  File: {store_path / 'open-questions.md'}")
     else:
-        decision_id = _write_decision_direct(
-            fs_store,
-            {
-                "title": text,
-                "rationale": rationale,
-                "confidence": confidence,
-            },
-        )
+        # Hold the allocation lock across the number computation and the write
+        # so concurrent local writers cannot mint the same decision number.
+        # AGENTS.md regen below stays outside the lock.
+        with decision_write_lock(store_path):
+            decision_id = _write_decision_direct(
+                fs_store,
+                {
+                    "title": text,
+                    "rationale": rationale,
+                    "confidence": confidence,
+                },
+            )
         filepath = store_path / DECISIONS_DIR / f"{decision_id}.md"
         typer.echo(f"Decision recorded in {project_name}:")
         typer.echo(f"  {filepath}")

--- a/packages/nauro/src/nauro/mcp/tools.py
+++ b/packages/nauro/src/nauro/mcp/tools.py
@@ -56,6 +56,7 @@ from nauro.onboarding import (
     WELCOME_NO_PROJECT,
 )
 from nauro.store.config import resolve_embeddings_flag
+from nauro.store.decision_lock import decision_write_lock
 from nauro.store.filesystem_store import FilesystemStore
 from nauro.store.snapshot import (
     capture_snapshot,
@@ -346,20 +347,27 @@ def tool_propose_decision(
     else:
         proposal_confidence = confidence
 
-    result = _propose_decision_op(
-        FilesystemStore(store_path),
-        title=title,
-        rationale=rationale,
-        operation=operation,
-        affected_decision_id=affected_decision_id,
-        rejected=rejected,
-        confidence=proposal_confidence,
-        decision_type=decision_type,
-        reversibility=reversibility,
-        files_affected=files_affected,
-        resolves_questions=resolves_questions,
-        source="mcp",
-    )
+    # Hold the allocation lock across the kernel call. add and supersede both
+    # mint a fresh max+1 number, so the lock must span the number computation
+    # and the write to keep concurrent local writers from colliding; update
+    # appends to a known file and is a no-contention pass through the lock. The
+    # snapshot/AGENTS.md regen below stay outside so the lock never nests with
+    # _snapshot_lock.
+    with decision_write_lock(store_path):
+        result = _propose_decision_op(
+            FilesystemStore(store_path),
+            title=title,
+            rationale=rationale,
+            operation=operation,
+            affected_decision_id=affected_decision_id,
+            rejected=rejected,
+            confidence=proposal_confidence,
+            decision_type=decision_type,
+            reversibility=reversibility,
+            files_affected=files_affected,
+            resolves_questions=resolves_questions,
+            source="mcp",
+        )
 
     dumped = result.model_dump(mode="json", exclude_none=True)
     # touched_decisions is consumed by the adapter to drive AGENTS.md regen;

--- a/packages/nauro/src/nauro/store/decision_lock.py
+++ b/packages/nauro/src/nauro/store/decision_lock.py
@@ -1,0 +1,40 @@
+"""Lock for local decision-number allocation.
+
+Decision files are named ``decisions/NNN-slug.md`` where ``NNN`` is
+``max(existing num) + 1``. The kernel computes that number from the store and
+then writes the file, but the per-target-file lock in ``write_file`` only
+mutually excludes writers aiming at the *same* filename. Two concurrent local
+writers compute the same next number, slugify distinct titles, and both land —
+yielding two decisions sharing a number.
+
+``decision_write_lock`` closes that race by serializing the whole
+allocate-then-write sequence on a single lock under the decisions dir. The
+remote path renumbers colliding decisions on pull, but that pull-time repair
+never runs for local-only projects (both pull paths gate on a cloud project),
+so prevention has to live here at the adapter layer. Mirrors
+``snapshot._snapshot_lock``: the lock path is derived from ``store_path`` so it
+inherits any NAURO_HOME override without re-resolving it.
+"""
+
+from contextlib import contextmanager
+from pathlib import Path
+
+from filelock import FileLock
+
+from nauro.constants import DECISIONS_DIR
+
+
+@contextmanager
+def decision_write_lock(store_path: Path):
+    """Exclusive file lock spanning decision-number allocation and the write.
+
+    The lock file is ``<store_path>/decisions/.lock``. It carries no ``.md``
+    suffix, so it is excluded from the ``*.md`` decision enumeration in
+    ``list_decisions``. The lock path differs from ``write_file``'s
+    per-file ``<file>.lock``, so the two never deadlock.
+    """
+    decisions_dir = store_path / DECISIONS_DIR
+    lock_path = decisions_dir / ".lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with FileLock(str(lock_path)):
+        yield

--- a/packages/nauro/tests/test_decision_write_lock.py
+++ b/packages/nauro/tests/test_decision_write_lock.py
@@ -1,0 +1,112 @@
+"""Allocation guarantees for local decision writes.
+
+``_write_decision_direct`` computes the next decision number as
+``max(existing num) + 1`` and then writes ``decisions/NNN-slug.md``. The
+per-target-file lock in ``write_file`` only excludes writers aiming at the
+same filename, so two concurrent local writers with distinct titles compute
+the same number and both land — yielding two decisions sharing a number.
+``decision_write_lock`` closes that race by serializing the whole
+allocate-then-write sequence. These tests pin its contract: concurrent writes
+land on distinct numbers, and the lock-held assertion is deterministic — no
+sleep-racing.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import filelock
+import pytest
+from nauro_core.constants import DECISIONS_DIR
+from nauro_core.operations.propose_decision import _write_decision_direct
+
+from nauro.store.decision_lock import decision_write_lock
+from nauro.store.filesystem_store import FilesystemStore
+
+
+def _make_store(tmp_path, monkeypatch):
+    """Point NAURO_HOME and HOME into tmp_path and return a scaffolded store dir."""
+    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    store_path = tmp_path / "nauro_home" / "projects" / "proj"
+    (store_path / DECISIONS_DIR).mkdir(parents=True, exist_ok=True)
+    (store_path / "project.md").write_text("# Project\n")
+    return store_path
+
+
+def _lock_path(store_path):
+    return store_path / DECISIONS_DIR / ".lock"
+
+
+def _decision_numbers(store_path):
+    """Parse the NNN prefix off each decision file on disk."""
+    nums = set()
+    for md in (store_path / DECISIONS_DIR).glob("*.md"):
+        prefix = md.name.split("-", 1)[0]
+        nums.add(int(prefix))
+    return nums
+
+
+def _write_locked(store_path, title):
+    with decision_write_lock(store_path):
+        _write_decision_direct(
+            FilesystemStore(store_path),
+            {"title": title, "rationale": f"Rationale for {title}.", "confidence": "medium"},
+        )
+
+
+def test_concurrent_writes_get_distinct_numbers(tmp_path, monkeypatch):
+    """Two concurrent writes against one store land on two distinct numbers.
+
+    A barrier maximizes overlap. Without the lock both compute the same next
+    number and write distinct slugs that both land; with it they serialize to
+    {1, 2}.
+    """
+    store_path = _make_store(tmp_path, monkeypatch)
+
+    barrier = threading.Barrier(2)
+
+    def _write(title):
+        barrier.wait()
+        _write_locked(store_path, title)
+
+    threads = [
+        threading.Thread(target=_write, args=("First decision",)),
+        threading.Thread(target=_write, args=("Second decision",)),
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    decision_files = sorted((store_path / DECISIONS_DIR).glob("*.md"))
+    assert len(decision_files) == 2
+    assert _decision_numbers(store_path) == {1, 2}
+
+
+def test_lock_is_held_during_body_and_released_after(tmp_path, monkeypatch):
+    """While ``decision_write_lock`` is held a fresh FileLock times out; after exit it acquires."""
+    store_path = _make_store(tmp_path, monkeypatch)
+
+    with decision_write_lock(store_path):
+        contender = filelock.FileLock(str(_lock_path(store_path)))
+        with pytest.raises(filelock.Timeout):
+            contender.acquire(timeout=0.2)
+
+    # After exit, a fresh instance acquires immediately.
+    after = filelock.FileLock(str(_lock_path(store_path)))
+    after.acquire(timeout=0.2)
+    assert after.is_locked
+    after.release()
+
+
+def test_serial_writes_are_monotonic(tmp_path, monkeypatch):
+    """Three sequential writes produce numbers 1, 2, 3 and three files."""
+    store_path = _make_store(tmp_path, monkeypatch)
+
+    for title in ("One", "Two", "Three"):
+        _write_locked(store_path, title)
+
+    decision_files = sorted((store_path / DECISIONS_DIR).glob("*.md"))
+    assert len(decision_files) == 3
+    assert _decision_numbers(store_path) == {1, 2, 3}


### PR DESCRIPTION
## Why

Two concurrent local writers can mint the same decision number. `_write_decision_direct` computes the next number as `max(existing num) + 1` over the store, then writes `decisions/NNN-slug.md` — with no lock spanning that read-compute-write. The per-target-file lock inside `write_file` only mutually excludes writers aiming at the *same* filename, so two writers that compute the same number but slugify distinct titles both land, leaving two decisions sharing a number.

This race was previously considered acceptable because the remote path renumbers colliding decisions on pull. But that pull-time repair never fires for local-only projects: both pull paths gate on the project being a cloud project. For a local store the duplicate is permanent, so the allocation has to be serialized at write time.

## Approach

Re-lock the local decision-allocation window: hold an exclusive lock across the whole allocate-then-write sequence so concurrent writers serialize onto distinct numbers. The lock spans both the number computation and the write — locking only `write_file` would leave the read-compute race open.

The lock lives in the **nauro adapter layer**, not in nauro-core. nauro-core stays I/O-free, owns no filesystem access, and the `Store` protocol is unchanged (no new method). Rather than thread lock-awareness into the kernel, each local entry point wraps the kernel call in one shared `decision_write_lock` context manager. This is coarse — on `supersede` and `update` the lock covers more than the bare allocation — but `supersede` also mints a fresh `max+1` number so it genuinely needs the lock, and `update` appends to a known file and is a harmless no-contention pass-through. The simplicity of wrapping the single kernel call was preferred over kernel surgery.

The new helper mirrors the existing `snapshot._snapshot_lock` exactly: a fresh `FileLock` per call on `<store_path>/decisions/.lock`, `mkdir` before locking, and a `store_path`-relative lock path so the `NAURO_HOME` override is inherited without re-resolving it. The `.lock` filename has no `.md` suffix, so it stays out of the `*.md` decision enumeration. It is a distinct path from `write_file`'s per-file `<file>.lock`, so the two never deadlock.

The cloud path is untouched: the remote server has its own on-pull renumber and is out of scope here. This is a local-only fix and adds no new dependency (`filelock` was already in use).

## What changed

- **New `store/decision_lock.py`** — `decision_write_lock(store_path)` context manager.
- **Three local entry points** now route their allocate→write through that one helper: `nauro note`, the `propose_decision` MCP tool (which the autogen `nauro propose-decision` CLI also dispatches through, so both are covered by the single wrap), and the `nauro import` decision-append path.
- The lock region is kept tight: AGENTS.md regeneration (`warn_then_regen`) and snapshot capture (`capture_snapshot`) stay **outside** the lock at every site, so `decision_write_lock` never nests with `_snapshot_lock`.

## What to review

- **Lock scope at each call site.** Confirm only the kernel allocate→write call is inside the lock and that `warn_then_regen` / `capture_snapshot` are outside.
- **The autogen routing claim.** `nauro propose-decision` is generated from the `propose_decision` tool and dispatches to `tool_propose_decision`, so wrapping the tool covers the CLI too — verify there is no second, separate allocation path that bypasses the lock.
- **No re-entrancy / deadlock.** The decision lock path (`decisions/.lock`) is distinct from `write_file`'s per-file lock path, and the snapshot lock is never taken inside it.

## What's deferred

A local dedupe/renumber repair command (lifting the remote on-pull renumber to run locally) is intentionally out of scope: there are zero duplicates on disk today and this fix makes new local ones unreachable, so a repair tool is speculative until a duplicate is actually observed.

## Test plan

New colocated `packages/nauro/tests/test_decision_write_lock.py` (3 tests), modeled on `test_snapshot_lock.py`:
1. **Concurrency** — two barrier-synced threads write distinct decisions against one store; asserts exactly two files exist carrying the exact number set `{1, 2}`. Verified to fail when the lock is neutralized (both writers mint `1`, one overwrites the other, leaving `{1}` on disk).
2. **Lock-held** — while `decision_write_lock` is held, a fresh `FileLock` on the same path times out; it acquires after exit. Deterministic, no sleep-race.
3. **Serial monotonicity** — three sequential writes produce `{1, 2, 3}` and three files.

Full suites green: 1220 passed / 10 skipped (nauro), 736 passed (nauro-core, unchanged — confirms the kernel stays I/O-free). `ruff check` and `ruff format --check` clean.
