### PR TITLE
chore(release): bump nauro to 0.12.0

### DIFF
--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro"
-version = "0.11.1"
+version = "0.12.0"
 description = "Local CLI + MCP server: set your project's doctrine once, every connected AI agent inherits it."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Why

The CLI's published version (0.11.1) has fallen ~27 commits behind `main`. A batch of user-facing features and a large onboarding/correctness hardening pass have merged since the last release and are stranded until the version is bumped and tagged. This cuts the release so they reach PyPI.

## Approach

One-line `version` bump in `packages/nauro/pyproject.toml`, following the established release pattern (each release is a single `chore(release)` bump; the `nauro-v*` tag on the merge commit triggers `publish-nauro.yml`). Minor bump (0.11.x → 0.12.0) rather than patch because the batch adds new user-facing commands and surfaces, not just fixes.

`nauro-core` is intentionally **not** re-released: nothing in its importable source changed since 0.13.4 (only a CI import-contract file and a test), so the existing `>=0.13.0,<0.14` floor is still correct.

## What changed

Version only. The shipped behavior is everything merged since 0.11.1:

- **New surfaces**: `link --cloud` now pushes the local store to the cloud; `projects list`/`rm`; `get_decision` header mode for cheap related-decision triage; the store-native `nauro-handoff` session-handoff skill.
- **Concurrency hardening**: file-locking around decision-number allocation, snapshot capture, and `config.json` read-modify-write; an atomic JSON-write helper for control-plane files.
- **Fail-loud / fail-safe correctness**: safe handling of corrupt control-plane and snapshot inputs; typed config error on corrupt repo config; loud failure on `git merge-file` errors during sync; autogen enum flags now reject bad values with a message.
- **Onboarding accuracy**: `setup`/`adopt` write `AGENTS.md` on every entry point and require git; corrected status/auth guidance; honest local-only sync wording; README/PRIVACY accuracy.
- **Single-sourcing into nauro-core**: decision-id resolution, the Auth0 sub sanitizer, and the envelope-token rejection reason now live in core.

## What to review

The diff itself is one line. The thing to sanity-check is the bump magnitude (minor vs patch) and the claim that `nauro-core` needs no companion release — verifiable via `git diff nauro-core-v0.13.4..HEAD -- packages/nauro-core/src/` (empty).

## What's deferred

Nothing in this PR beyond the version line. The PyPI publish itself happens on the tag push after merge.

## Test plan

CI (the existing suite + ruff) gates this PR. No code changed, so no new tests; the behavior being released was tested in its own PRs as it merged.
