### PR TITLE
Serialize shared-file store writes with an adapter write lock

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/import_cmd.py
+++ b/packages/nauro/src/nauro/cli/commands/import_cmd.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any
 
 import typer
+from nauro_core.constants import STATE_CURRENT_FILENAME
 from nauro_core.operations import update_state as _update_state_op
 from nauro_core.operations.propose_decision import _write_decision_direct
 
@@ -18,6 +19,7 @@ from nauro.constants import PROJECT_MD, STACK_MD
 from nauro.store.decision_lock import decision_write_lock
 from nauro.store.filesystem_store import FilesystemStore
 from nauro.store.snapshot import capture_snapshot
+from nauro.store.store_lock import store_write_lock
 
 
 def _import_append_decision(
@@ -109,7 +111,11 @@ def _import_memory_bank(memory_bank: Path, store_path: Path) -> dict[str, int]:
 
     delta = _compose_state_delta(active_body, progress_items)
     if delta is not None:
-        _update_state_op(FilesystemStore(store_path), delta)
+        # update_state rewrites state_current.md and read-appends
+        # state_history.md; hold one lock across the whole kernel call so a
+        # concurrent local writer cannot drop an update on either file.
+        with store_write_lock(store_path, STATE_CURRENT_FILENAME):
+            _update_state_op(FilesystemStore(store_path), delta)
 
     return counts
 

--- a/packages/nauro/src/nauro/cli/commands/note.py
+++ b/packages/nauro/src/nauro/cli/commands/note.py
@@ -1,13 +1,14 @@
 """nauro note — Add a decision or question to the project store."""
 
 import typer
-from nauro_core.constants import DECISIONS_DIR
+from nauro_core.constants import DECISIONS_DIR, OPEN_QUESTIONS_MD
 from nauro_core.operations import flag_question as _flag_question_op
 from nauro_core.operations.propose_decision import _write_decision_direct
 
 from nauro.cli.utils import resolve_target_project
 from nauro.store.decision_lock import decision_write_lock
 from nauro.store.filesystem_store import FilesystemStore
+from nauro.store.store_lock import store_write_lock
 from nauro.templates.agents_md_regen import warn_then_regen
 
 
@@ -54,7 +55,12 @@ def note(
     is_question = question or (text.rstrip().endswith("?") and not decision)
 
     if is_question:
-        _flag_question_op(fs_store, text, None)
+        # Hold the lock across the read-mint-insert-write append so concurrent
+        # local writers cannot read the same open-questions.md pre-image and
+        # clobber one another's entry. Mirrors the decision branch below, which
+        # already wraps decision_write_lock. AGENTS.md regen stays outside.
+        with store_write_lock(store_path, OPEN_QUESTIONS_MD):
+            _flag_question_op(fs_store, text, None)
         typer.echo(f"Question added to {project_name}:")
         typer.echo(f"  {text}")
         typer.echo(f"  File: {store_path / 'open-questions.md'}")

--- a/packages/nauro/src/nauro/mcp/tools.py
+++ b/packages/nauro/src/nauro/mcp/tools.py
@@ -19,6 +19,7 @@ from nauro_core.constants import (
     MAX_QUESTION_LENGTH,
     MAX_RATIONALE_LENGTH,
     MAX_TITLE_LENGTH,
+    OPEN_QUESTIONS_MD,
     STATE_CURRENT_FILENAME,
     STATE_MD,
 )
@@ -64,6 +65,7 @@ from nauro.store.snapshot import (
     load_snapshot,
     resolve_diff_snapshots,
 )
+from nauro.store.store_lock import store_write_lock
 from nauro.telemetry.decorators import mcp_tool
 from nauro.templates.agents_md_regen import warn_then_regen
 
@@ -512,7 +514,12 @@ def tool_flag_question(
     text = question
     if question and context:
         text = f"{question} (context: {context})"
-    result = _flag_question_op(FilesystemStore(store_path), text, None, targets=targets)
+    # Hold the lock across the whole append (read open-questions.md, mint the
+    # next id, insert, write back) so concurrent local writers cannot read the
+    # same pre-image and clobber one another's entry. Snapshot and push below
+    # stay outside the lock.
+    with store_write_lock(store_path, OPEN_QUESTIONS_MD):
+        result = _flag_question_op(FilesystemStore(store_path), text, None, targets=targets)
 
     response: dict = {"store": "local", **result.model_dump(mode="json", exclude_none=True)}
     # The kernel result carries ``num`` for callers that want the minted id;
@@ -545,13 +552,17 @@ def _flag_question_resolve(
     a snapshot (labelled to distinguish resolve from append) and push; on
     rejection the kernel performed no write, so neither runs.
     """
-    result = _flag_question_op(
-        FilesystemStore(store_path),
-        None,
-        None,
-        targets=targets,
-        resolved_by=resolved_by,
-    )
+    # The resolve action reads open-questions.md, stamps the targets, and
+    # writes the file back — same read-modify-write race as the append path,
+    # so it takes the same lock. Snapshot and push stay outside.
+    with store_write_lock(store_path, OPEN_QUESTIONS_MD):
+        result = _flag_question_op(
+            FilesystemStore(store_path),
+            None,
+            None,
+            targets=targets,
+            resolved_by=resolved_by,
+        )
     response: dict = {"store": "local", **result.model_dump(mode="json", exclude_none=True)}
     response.pop("num", None)
 
@@ -710,7 +721,12 @@ def tool_update_state(store_path: Path, delta: str) -> dict:
     if err:
         return err
 
-    result = _update_state_op(FilesystemStore(store_path), delta)
+    # update_state is a multi-file read-modify-write: it rewrites
+    # state_current.md and read-appends state_history.md. Hold one lock across
+    # the whole kernel call so concurrent writers cannot interleave and drop an
+    # update on either file. Snapshot and push below stay outside the lock.
+    with store_write_lock(store_path, STATE_CURRENT_FILENAME):
+        result = _update_state_op(FilesystemStore(store_path), delta)
     envelope: dict = {"store": "local", **result.model_dump(mode="json", exclude_none=True)}
 
     # Adapter-side side effects only run on the success path. ``noop``

--- a/packages/nauro/src/nauro/store/decision_lock.py
+++ b/packages/nauro/src/nauro/store/decision_lock.py
@@ -19,9 +19,8 @@ inherits any NAURO_HOME override without re-resolving it.
 from contextlib import contextmanager
 from pathlib import Path
 
-from filelock import FileLock
-
 from nauro.constants import DECISIONS_DIR
+from nauro.store.store_lock import store_write_lock
 
 
 @contextmanager
@@ -32,9 +31,10 @@ def decision_write_lock(store_path: Path):
     suffix, so it is excluded from the ``*.md`` decision enumeration in
     ``list_decisions``. The lock path differs from ``write_file``'s
     per-file ``<file>.lock``, so the two never deadlock.
+
+    Delegates to the general :func:`store_write_lock` for the
+    directory-scoped decisions resource; the observable lock path stays
+    ``decisions/.lock``.
     """
-    decisions_dir = store_path / DECISIONS_DIR
-    lock_path = decisions_dir / ".lock"
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
-    with FileLock(str(lock_path)):
+    with store_write_lock(store_path, DECISIONS_DIR, is_directory=True):
         yield

--- a/packages/nauro/src/nauro/store/store_lock.py
+++ b/packages/nauro/src/nauro/store/store_lock.py
@@ -1,0 +1,83 @@
+"""Adapter-layer write lock for whole-store read-modify-write sequences.
+
+Several kernel operations read a shared store file, mutate it in memory, and
+write it back (``flag_question`` appends an entry to ``open-questions.md``;
+``update_state`` rewrites ``state_current.md`` and appends to
+``state_history.md``). The per-target :class:`~filelock.FileLock` in
+``FilesystemStore.write_file`` only excludes writers aiming at the *same*
+filename, so two concurrent local writers each read the same pre-image, append
+distinct entries, and the second write overwrites the first — one entry is
+silently lost.
+
+``store_write_lock`` closes that race by serializing the whole
+read-modify-write kernel call on a single lock derived from ``store_path`` (so
+it inherits any ``NAURO_HOME`` override without re-resolving it). The kernels
+stay lock-agnostic; the lock is held by the adapter around the kernel call.
+
+The lock path must never collide with the ``<name>.lock`` that ``write_file``
+takes for the same target, because ``flock`` is not reentrant across file
+descriptors: the outer read-modify-write lock nesting the kernel's inner
+``write_file`` on the same path would self-deadlock. Two resource shapes keep
+the two distinct:
+
+* **Directory-scoped resources** (``decisions/``, ``snapshots/``) take the
+  bare ``<dir>/.lock`` sentinel inside the directory. ``write_file`` never
+  targets that bare name, so the two never alias.
+* **Root-level files** (``open-questions.md``, ``state_current.md``,
+  ``state_history.md``) have no owning subdirectory, so the sentinel is a
+  sibling ``<name>`` with the :data:`RMW_LOCK_SUFFIX` suffix —
+  ``open-questions.md.rmwlock`` — distinct from ``write_file``'s
+  ``open-questions.md.lock``.
+"""
+
+from contextlib import contextmanager
+from pathlib import Path
+
+from filelock import FileLock
+
+# Sentinel suffix for root-level file locks. Deliberately distinct from the
+# ``.lock`` suffix ``write_file`` appends, so the adapter read-modify-write
+# lock and the kernel's per-target write lock never alias the same path.
+RMW_LOCK_SUFFIX = ".rmwlock"
+
+# Sentinel filename for directory-scoped resources, placed inside the
+# directory. Carries no ``.md`` suffix, so it is excluded from the ``*.md``
+# enumeration that lists decisions and snapshots.
+DIR_LOCK_NAME = ".lock"
+
+
+def rmw_lock_path(store_path: Path, resource: str, *, is_directory: bool = False) -> Path:
+    """Return the lock-file path for a read-modify-write on *resource*.
+
+    Args:
+        store_path: The project store root. The lock path is derived from it,
+            so any ``NAURO_HOME`` override already baked into ``store_path`` is
+            inherited without re-resolving it here.
+        resource: Store-relative path of the resource being mutated — a
+            root-level filename (``open-questions.md``) or a directory name
+            (``decisions``).
+        is_directory: When ``True``, *resource* names a directory and the lock
+            is the bare ``<dir>/.lock`` sentinel inside it. When ``False``
+            (the default), *resource* names a root-level file and the lock is a
+            sibling with the :data:`RMW_LOCK_SUFFIX` suffix.
+    """
+    target = store_path / resource
+    if is_directory:
+        return target / DIR_LOCK_NAME
+    return target.with_name(target.name + RMW_LOCK_SUFFIX)
+
+
+@contextmanager
+def store_write_lock(store_path: Path, resource: str, *, is_directory: bool = False):
+    """Serialize a whole read-modify-write kernel call on *resource*.
+
+    The lock spans only the kernel call that reads and rewrites the resource.
+    Best-effort side effects such as snapshot capture and cloud push must stay
+    outside the lock — the snapshot machinery self-serializes under its own
+    lock, and holding this lock across a network push would needlessly block
+    other local writers.
+    """
+    lock_path = rmw_lock_path(store_path, resource, is_directory=is_directory)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with FileLock(str(lock_path)):
+        yield

--- a/packages/nauro/tests/test_store_write_lock.py
+++ b/packages/nauro/tests/test_store_write_lock.py
@@ -1,0 +1,185 @@
+"""Lost-update guarantees for shared-file read-modify-write store writes.
+
+``flag_question`` and ``update_state`` read a shared store file, mutate it in
+memory, and write it back. The per-target lock in ``write_file`` only excludes
+writers aiming at the same filename, so two concurrent local writers each read
+the same pre-image and the second write silently clobbers the first — one entry
+is lost. ``store_write_lock`` closes that race by serializing the whole
+read-modify-write kernel call.
+
+These tests pin the contract: concurrent appends both persist, concurrent state
+updates do not drop one another, the lock-file path is distinct from
+``write_file``'s per-target lock (so the adapter lock nesting the kernel's write
+cannot self-deadlock), and the refactored decision lock keeps its observable
+path byte-identical.
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+import filelock
+import pytest
+from nauro_core.constants import (
+    DECISIONS_DIR,
+    OPEN_QUESTIONS_MD,
+    STATE_CURRENT_FILENAME,
+)
+from nauro_core.operations import flag_question as _flag_question_op
+from nauro_core.operations import update_state as _update_state_op
+from typer.testing import CliRunner
+
+from nauro.cli.main import app
+from nauro.store.decision_lock import decision_write_lock
+from nauro.store.filesystem_store import FilesystemStore
+from nauro.store.registry import register_project
+from nauro.store.store_lock import RMW_LOCK_SUFFIX, rmw_lock_path, store_write_lock
+from nauro.templates.scaffolds import scaffold_project_store
+
+runner = CliRunner()
+
+
+def _make_store(tmp_path, monkeypatch) -> Path:
+    """Point NAURO_HOME/HOME into tmp_path and return a scaffolded store dir."""
+    monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    store = register_project("proj", [tmp_path / "repo"])
+    scaffold_project_store("proj", store)
+    return store
+
+
+def _question_entries(store_path: Path) -> list[str]:
+    """Return the on-disk question entry lines (``- [Q###] ...``)."""
+    content = (store_path / OPEN_QUESTIONS_MD).read_text()
+    return [line for line in content.split("\n") if line.startswith("- [Q")]
+
+
+def _flag_locked(store_path: Path, question: str) -> None:
+    with store_write_lock(store_path, OPEN_QUESTIONS_MD):
+        _flag_question_op(FilesystemStore(store_path), question, None)
+
+
+def _update_locked(store_path: Path, delta: str) -> None:
+    with store_write_lock(store_path, STATE_CURRENT_FILENAME):
+        _update_state_op(FilesystemStore(store_path), delta)
+
+
+def test_concurrent_appends_both_persist(tmp_path, monkeypatch):
+    """Two concurrent locked appends both land; exactly two entries on disk.
+
+    A barrier maximizes overlap. Without the lock both read the same
+    open-questions.md pre-image and the second write clobbers the first,
+    leaving one entry; with it they serialize and both survive.
+    """
+    store_path = _make_store(tmp_path, monkeypatch)
+
+    barrier = threading.Barrier(2)
+
+    def _flag(question: str) -> None:
+        barrier.wait()
+        _flag_locked(store_path, question)
+
+    threads = [
+        threading.Thread(target=_flag, args=("First question?",)),
+        threading.Thread(target=_flag, args=("Second question?",)),
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    entries = _question_entries(store_path)
+    assert len(entries) == 2
+    joined = "\n".join(entries)
+    assert "First question?" in joined
+    assert "Second question?" in joined
+
+
+def test_concurrent_state_updates_serialize(tmp_path, monkeypatch):
+    """Two concurrent locked update_state writers do not lose an update.
+
+    Each delta archives the prior body into state_history.md. Serialized, the
+    two updates chain: the second update's history carries the first delta, so
+    neither is dropped. Without the lock both read the same pre-image and one
+    history append is lost.
+    """
+    store_path = _make_store(tmp_path, monkeypatch)
+    (store_path / STATE_CURRENT_FILENAME).write_text("# Current State\n\n- Seed entry\n")
+
+    barrier = threading.Barrier(2)
+
+    def _update(delta: str) -> None:
+        barrier.wait()
+        _update_locked(store_path, delta)
+
+    threads = [
+        threading.Thread(target=_update, args=("Completed alpha milestone",)),
+        threading.Thread(target=_update, args=("Completed beta milestone",)),
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    current = (store_path / STATE_CURRENT_FILENAME).read_text()
+    history = (store_path / "state_history.md").read_text()
+    # The latest update wins state_current.md; the other survives in history.
+    # Serialized, every prior body is archived, so both deltas are present
+    # across the two files with none silently dropped.
+    combined = current + history
+    assert "alpha milestone" in combined
+    assert "beta milestone" in combined
+
+
+def test_lock_path_distinct_from_write_file_lock(tmp_path):
+    """The RMW lock for a root file is not ``write_file``'s ``<name>.lock``.
+
+    ``write_file`` locks ``open-questions.md.lock``; the adapter
+    read-modify-write lock must differ, or the outer lock nesting the kernel's
+    inner write on the same path self-deadlocks (flock is not reentrant across
+    file descriptors).
+    """
+    store_path = tmp_path / "store"
+    write_file_lock = store_path / (OPEN_QUESTIONS_MD + ".lock")
+    rmw_lock = rmw_lock_path(store_path, OPEN_QUESTIONS_MD)
+
+    assert rmw_lock != write_file_lock
+    assert rmw_lock == store_path / (OPEN_QUESTIONS_MD + RMW_LOCK_SUFFIX)
+
+
+def test_decision_lock_path_byte_identical_after_refactor(tmp_path, monkeypatch):
+    """``decision_write_lock`` still locks exactly ``decisions/.lock``.
+
+    The refactor delegates to ``store_write_lock`` but the observable lock
+    path must not move — a contender on the literal ``decisions/.lock`` still
+    times out while the lock is held.
+    """
+    store_path = _make_store(tmp_path, monkeypatch)
+    expected = store_path / DECISIONS_DIR / ".lock"
+
+    with decision_write_lock(store_path):
+        contender = filelock.FileLock(str(expected))
+        with pytest.raises(filelock.Timeout):
+            contender.acquire(timeout=0.2)
+
+    after = filelock.FileLock(str(expected))
+    after.acquire(timeout=0.2)
+    assert after.is_locked
+    after.release()
+
+
+def test_note_question_branch_exits_zero_and_persists(tmp_path, monkeypatch):
+    """``nauro note`` question branch exits 0 and the entry lands on disk."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    store = register_project("myproj", [repo])
+    scaffold_project_store("myproj", store)
+    monkeypatch.chdir(repo)
+
+    result = runner.invoke(app, ["note", "Should we shard the store?"])
+    assert result.exit_code == 0, result.output
+
+    entries = _question_entries(store)
+    assert len(entries) == 1
+    assert "Should we shard the store?" in entries[0]


### PR DESCRIPTION
## Why

`flag_question` and `update_state` perform an unlocked full-file read-modify-write on shared local store files. The kernel reads `open-questions.md` (or `state_current.md` + `state_history.md`), mutates the content in memory, and writes it back. The only lock in the write path is `FilesystemStore.write_file`'s per-target `<name>.lock`, which excludes writers aiming at the *same filename* — it does not span the read. So two concurrent local writers each read the same pre-image, append distinct entries, and the second write overwrites the first. One writer's entry is silently lost.

This is the same class of race the decision-number allocation lock already guards against, but on the append/state surfaces it had no equivalent.

## Approach

Add a reusable adapter-layer contextmanager, `store_write_lock`, that serializes the whole read-modify-write kernel call on a single lock derived from `store_path` (so it inherits any `NAURO_HOME` override without re-resolving). The lock lives at the adapter layer; the kernels stay lock-agnostic and untouched.

The load-bearing correctness property is that the read-modify-write lock path must never alias `write_file`'s per-target `<name>.lock` — `flock` is not reentrant across file descriptors, so the outer lock nesting the kernel's inner `write_file` on the same path would self-deadlock. Two resource shapes keep the paths distinct:

- Directory-scoped resources (`decisions/`, `snapshots/`) keep their bare `<dir>/.lock` sentinel, which `write_file` never targets.
- Root-level files (`open-questions.md`, `state_current.md`, `state_history.md`) have no owning subdirectory, so the sentinel is a sibling with a `.rmwlock` suffix — `open-questions.md.rmwlock`, distinct from `write_file`'s `open-questions.md.lock`.

`decision_write_lock` now delegates to the new helper (directory-scoped) while keeping its observable lock path byte-identical at `decisions/.lock`.

Rejected alternative: a narrow per-call-site point lock (e.g. inline `FileLock` at each adapter call, as `decision_write_lock` originally was). The race repeats across `flag_question` append, `flag_question` resolve, and `update_state` on two call surfaces each, and `update_state` spans two files — five wrap sites with the same path-aliasing invariant to get right. A single shared helper pins the invariant in one place with one test, rather than re-deriving the sentinel rule at each site. A `Store.with_lock` protocol method was also rejected: the locked Store surface stays locked, and the lock belongs to the adapter, not the kernel.

## What changed

- New `store/store_lock.py`: the `store_write_lock` contextmanager plus a `rmw_lock_path` helper and the `RMW_LOCK_SUFFIX` / `DIR_LOCK_NAME` sentinels.
- `store/decision_lock.py`: `decision_write_lock` delegates to the helper; observable path unchanged.
- Adapter call sites wrapped (kernels unchanged): `mcp/tools.py` `flag_question` append + resolve and `update_state`; `cli/commands/note.py` question branch (previously took no lock — now mirrors the decision branch); `cli/commands/import_cmd.py` `update_state`. Snapshot capture and best-effort cloud push stay outside the lock at every site.

## What to review

- The lock-path invariant in `store_lock.py` — the `.rmwlock` sentinel for root files versus `write_file`'s `.lock`. `test_lock_path_distinct_from_write_file_lock` pins it.
- The `update_state` wrap is a multi-file read-modify-write: the kernel rewrites `state_current.md` and read-appends `state_history.md`. The lock spans the whole kernel call (keyed on `state_current.md`), not a single file, so a concurrent writer cannot interleave and drop an update on either file.
- That snapshot/push stay outside the lock at all three `mcp/tools.py` sites (snapshot self-serializes under its own lock; holding this lock across a network push would needlessly block other writers).

## What's deferred

The cloud/S3 write path (`s3.write_file`) has a separate lost-update gap — no compare-and-swap on the remote object. That is out of scope here and tracked as an open question.

## Test plan

New `tests/test_store_write_lock.py` (5 tests): two-thread barrier concurrency for appends (both persist) and state updates (no lost update); the lock-path distinctness invariant; decision-lock path byte-identity after the refactor; and the `nauro note` question branch exiting `0` with the entry landing. The two concurrency tests were confirmed to FAIL when the lock is neutered to a no-op, proving they catch the regression.

1225 existing + 5 new nauro tests pass (10 skipped); 736 nauro-core tests pass unchanged (kernel parity unaffected). `ruff check` and `ruff format --check` clean across `packages/`.
