### PR TITLE
Parse decision corpus once per propose_decision write

### DIFF
--- a/packages/nauro-core/src/nauro_core/operations/propose_decision.py
+++ b/packages/nauro-core/src/nauro_core/operations/propose_decision.py
@@ -174,6 +174,10 @@ def propose_decision(
             )
 
     # --- Tier 1: structural screening ---
+    # ``parsed`` is the single corpus scan shared between Tier 1 recent-title
+    # dedup and Tier 2 BM25. It stays None on the update early-reject path so a
+    # short-rationale update rejects without scanning the corpus at all.
+    parsed: list[Decision] | None = None
     if operation == "update":
         rationale_stripped = (proposal.get("rationale") or "").strip()
         if not rationale_stripped:
@@ -187,7 +191,8 @@ def propose_decision(
         else:
             action, reason = "pass", None
     else:
-        action, reason = _screen_structural(store, proposal)
+        parsed = _parse_all_decisions(store)
+        action, reason = _screen_structural(store, proposal, parsed)
 
     if action == "reject":
         return ProposeDecisionResult(
@@ -198,9 +203,10 @@ def propose_decision(
         )
 
     # --- Tier 2: BM25 similarity (advisory only — does not gate the write) ---
-    parsed_decisions = _parse_all_decisions(store)
-    _t2_action, similar_raw = check_bm25_similarity(proposal, parsed_decisions)
-    similar_models = _to_related_decisions(similar_raw, parsed_decisions)
+    if parsed is None:
+        parsed = _parse_all_decisions(store)
+    _t2_action, similar_raw = check_bm25_similarity(proposal, parsed)
+    similar_models = _to_related_decisions(similar_raw, parsed)
 
     # --- Commit ---
     decision_id, actual_operation, touched, resolved_ids, error = _execute_operation(
@@ -274,11 +280,18 @@ def _write_decision_direct(store: Store, proposal: dict) -> str:
 # ── Tier 1 helpers ────────────────────────────────────────────────────────
 
 
-def _screen_structural(store: Store, proposal: dict) -> tuple[str, str | None]:
-    """Run Tier 1 structural screening with hashes + recent-title dedup."""
+def _screen_structural(
+    store: Store, proposal: dict, parsed: list[Decision]
+) -> tuple[str, str | None]:
+    """Run Tier 1 structural screening with hashes + recent-title dedup.
+
+    ``parsed`` is the shared corpus scan reused for Tier 2 BM25, so this no
+    longer re-reads the store for the 24h recent-title window.
+    """
     hash_index = _load_hash_index(store)
     existing_hashes = set(hash_index.keys())
-    recent = _load_recent_decisions(store)
+    cutoff = (datetime.now(timezone.utc) - timedelta(hours=24)).date()
+    recent = [d for d in parsed if d.date >= cutoff]
     return screen_structural(proposal, existing_hashes, recent)
 
 
@@ -307,13 +320,6 @@ def _update_hash_index(store: Store, title: str, rationale: str, decision_id: st
         "timestamp": datetime.now(timezone.utc).isoformat(),
     }
     _save_hash_index(store, index)
-
-
-def _load_recent_decisions(store: Store) -> list[Decision]:
-    """Return decisions written in the last 24h for title dedup."""
-    cutoff = (datetime.now(timezone.utc) - timedelta(hours=24)).date()
-    parsed = _parse_all_decisions(store)
-    return [d for d in parsed if d.date >= cutoff]
 
 
 def _parse_all_decisions(store: Store) -> list[Decision]:

--- a/packages/nauro-core/tests/operations/test_operations_propose_decision.py
+++ b/packages/nauro-core/tests/operations/test_operations_propose_decision.py
@@ -212,6 +212,92 @@ class TestAdvisorySimilarDecisions:
         assert result.similar_decisions == []
 
 
+# ── corpus-scan deduplication ───────────────────────────────────────────
+
+
+class _ScanCountingStore(InMemoryStore):
+    """In-memory store that counts full-corpus scans.
+
+    ``parse_all_decisions`` is the expensive scan being deduplicated: it
+    lists every decision stem and then ``read_decision``\\ s each one to parse
+    it. We count corpus scans by counting ``read_decision`` calls and dividing
+    by the seeded corpus size, because ``list_decisions`` alone conflates a
+    corpus parse with the cheap stem-only listing in ``_next_decision_num``
+    on the write path. ``corpus_scans`` therefore isolates the Tier 1 / Tier 2
+    parse work the change collapses from two scans to one.
+    """
+
+    def __init__(
+        self,
+        decisions: dict[str, str] | None = None,
+        files: dict[str, str] | None = None,
+    ) -> None:
+        super().__init__(decisions=decisions, files=files)
+        self.read_decision_calls = 0
+
+    def read_decision(self, file_stem: str) -> str | None:
+        self.read_decision_calls += 1
+        return super().read_decision(file_stem)
+
+    def corpus_scans(self, corpus_size: int) -> int:
+        """Number of full-corpus parses, derived from per-stem reads."""
+        if corpus_size == 0:
+            return 0
+        scanned, remainder = divmod(self.read_decision_calls, corpus_size)
+        assert remainder == 0, (
+            f"read_decision called {self.read_decision_calls} times for a "
+            f"corpus of {corpus_size}; not a whole number of full scans."
+        )
+        return scanned
+
+
+def test_add_accept_scans_corpus_once() -> None:
+    """A non-update ``add`` accept parses the corpus exactly once: Tier 1 and
+    Tier 2 share the single parsed list rather than re-reading and re-parsing
+    the store. Before the change this path parsed the corpus twice."""
+    store = _ScanCountingStore(
+        decisions=dict(
+            (
+                _seed_decision(1, "Adopt PostgreSQL", "ACID transactional semantics."),
+                _seed_decision(2, "Adopt Redis", "In-memory cache for hot read paths."),
+            )
+        )
+    )
+    result = propose_decision(
+        store,
+        title="Add dark mode toggle to settings page",
+        rationale="Users have requested a dark theme for reduced eye strain.",
+        confidence="medium",
+    )
+    assert store.corpus_scans(corpus_size=2) == 1
+    # The accept path is unchanged: same status, tier, decision id, and
+    # advisory shape as the existing auto-confirm expectations.
+    assert result.status == "confirmed"
+    assert result.tier == 2
+    assert result.operation == "add"
+    assert result.decision_id is not None
+    assert result.similar_decisions == []
+
+
+def test_update_short_rationale_rejects_without_scanning() -> None:
+    """An ``operation="update"`` with a too-short rationale rejects at Tier 1
+    before any corpus scan. Guards the lazy-compute: ``parsed`` must not be
+    hoisted to the top, which would regress this path to a needless scan."""
+    store = _ScanCountingStore(
+        decisions=dict((_seed_decision(1, "Adopt PostgreSQL", "ACID transactional semantics."),))
+    )
+    result = propose_decision(
+        store,
+        title="",
+        rationale="too short",
+        operation="update",
+        affected_decision_id="decision-001",
+    )
+    assert store.corpus_scans(corpus_size=1) == 0
+    assert result.status == "rejected"
+    assert result.tier == 1
+
+
 # ── supersede ───────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Why

Production latency telemetry over the last 30 days puts the decision write
path at roughly 8s p50 warm and a p99 near 28s, brushing the 30s Lambda
timeout. On every non-update `propose_decision`, the kernel scans the entire
decision corpus twice: once in Tier 1 structural screening (the 24h
recent-title dedup parses every decision) and again in Tier 2 BM25
similarity. Both scans read and parse the same files and return identical
lists, so the second is pure duplicated work on the operation most exposed
to the timeout.

## Approach

Parse the corpus once and thread the single parsed list through both tiers.
`_screen_structural` now takes the already-parsed decisions and applies the
24h cutoff filter inline instead of re-reading the store; Tier 2 reuses the
same list.

The parse is computed lazily, not hoisted to the top of the function. The
`operation="update"` early-reject path (empty or too-short rationale) never
needs the corpus, so it must reject without paying for a scan — hoisting
would regress that path from zero scans to one. The non-update branch
computes the parse before Tier 1 and Tier 2 reuses it via a `None` check.

Alternatives considered and rejected:
- `lru_cache` / memoization on the parse helper — adds caching state and
  invalidation concerns to a pure function for a within-call dedup that a
  shared local already solves.
- Hoisting the parse to the top of the function — simpler control flow, but
  it reintroduces a needless corpus scan on the update early-reject path,
  which the lazy approach specifically avoids.

## What changed

All changes are in `nauro-core`'s `propose_decision` operation:
- `_screen_structural` takes the parsed corpus and filters the 24h
  recent-title window from it rather than calling its own store read.
- The main flow computes the parse once on the non-update branch and reuses
  it for Tier 2; the update branch leaves it unset so the early-reject path
  stays scan-free.
- Removed the now-unused `_load_recent_decisions` helper; its 24h filter
  moved inline into `_screen_structural`.

Behavior is byte-identical on every path: same Tier 1 reject reasons, same
Tier 2 advisory `similar_decisions`, same commit and return shape. Only the
corpus-scan count changes — a non-update accept drops from two scans to one;
non-update reject, update rationale-reject (zero), and update accept are
unchanged.

## What to review

- The lazy `parsed` handling across the Tier 1 / Tier 2 boundary: the
  update branch must leave `parsed` unset and the Tier 2 `if parsed is None`
  guard must recompute it for paths that skip Tier 1's non-update branch.
- The inlined 24h filter preserves the original `d.date >= cutoff`
  comparison exactly, including the absence of a `None` date guard, so dedup
  behavior is unchanged.
- The new scan-counting test counts full-corpus parses via `read_decision`
  rather than `list_decisions`. This is deliberate: the write path's
  `_next_decision_num` also calls `list_decisions` (a cheap stem-only
  listing, not a corpus parse), so counting `list_decisions` would conflate
  the two. Counting per-stem reads isolates the Tier 1 / Tier 2 parse work
  the change collapses.

## What's deferred

- The remote-path latency win does not land until a later `nauro-core` bump
  flows into the remote server. This is a `nauro-core`-only change with no
  cross-package dependency to regenerate here.
- This removes one source of pressure on the write-path timeout but does not
  claim to fix the "request can return a service-unavailable error yet still
  commit" behavior; that remains its own concern.

## Test plan

`nauro-core`: 738 passed (736 existing + 2 new). The new tests assert a
non-update accept parses the corpus exactly once and that an
`operation="update"` with a too-short rationale rejects with zero corpus
parses (guarding the lazy-compute against regression).

`nauro` consumer parity: 1225 passed, 10 skipped, unchanged. The named
parity and cross-surface propose-decision suites pass without modification.

Lint: `ruff check packages/` and `ruff format --check packages/` both clean.
