### PR TITLE
Rework propose_decision Tier-1: single corpus scan + active-status title dedup

### DIFF
--- a/packages/nauro-core/src/nauro_core/operations/propose_decision.py
+++ b/packages/nauro-core/src/nauro_core/operations/propose_decision.py
@@ -174,6 +174,10 @@ def propose_decision(
             )
 
     # --- Tier 1: structural screening ---
+    # ``parsed`` is the single corpus scan shared between Tier 1 recent-title
+    # dedup and Tier 2 BM25. It stays None on the update early-reject path so a
+    # short-rationale update rejects without scanning the corpus at all.
+    parsed: list[Decision] | None = None
     if operation == "update":
         rationale_stripped = (proposal.get("rationale") or "").strip()
         if not rationale_stripped:
@@ -187,7 +191,8 @@ def propose_decision(
         else:
             action, reason = "pass", None
     else:
-        action, reason = _screen_structural(store, proposal)
+        parsed = _parse_all_decisions(store)
+        action, reason = _screen_structural(store, proposal, parsed)
 
     if action == "reject":
         return ProposeDecisionResult(
@@ -198,9 +203,10 @@ def propose_decision(
         )
 
     # --- Tier 2: BM25 similarity (advisory only — does not gate the write) ---
-    parsed_decisions = _parse_all_decisions(store)
-    _t2_action, similar_raw = check_bm25_similarity(proposal, parsed_decisions)
-    similar_models = _to_related_decisions(similar_raw, parsed_decisions)
+    if parsed is None:
+        parsed = _parse_all_decisions(store)
+    _t2_action, similar_raw = check_bm25_similarity(proposal, parsed)
+    similar_models = _to_related_decisions(similar_raw, parsed)
 
     # --- Commit ---
     decision_id, actual_operation, touched, resolved_ids, error = _execute_operation(
@@ -274,11 +280,18 @@ def _write_decision_direct(store: Store, proposal: dict) -> str:
 # ── Tier 1 helpers ────────────────────────────────────────────────────────
 
 
-def _screen_structural(store: Store, proposal: dict) -> tuple[str, str | None]:
-    """Run Tier 1 structural screening with hashes + recent-title dedup."""
+def _screen_structural(
+    store: Store, proposal: dict, parsed: list[Decision]
+) -> tuple[str, str | None]:
+    """Run Tier 1 structural screening with hashes + recent-title dedup.
+
+    ``parsed`` is the shared corpus scan reused for Tier 2 BM25, so this no
+    longer re-reads the store for the 24h recent-title window.
+    """
     hash_index = _load_hash_index(store)
     existing_hashes = set(hash_index.keys())
-    recent = _load_recent_decisions(store)
+    cutoff = (datetime.now(timezone.utc) - timedelta(hours=24)).date()
+    recent = [d for d in parsed if d.date >= cutoff]
     return screen_structural(proposal, existing_hashes, recent)
 
 
@@ -307,13 +320,6 @@ def _update_hash_index(store: Store, title: str, rationale: str, decision_id: st
         "timestamp": datetime.now(timezone.utc).isoformat(),
     }
     _save_hash_index(store, index)
-
-
-def _load_recent_decisions(store: Store) -> list[Decision]:
-    """Return decisions written in the last 24h for title dedup."""
-    cutoff = (datetime.now(timezone.utc) - timedelta(hours=24)).date()
-    parsed = _parse_all_decisions(store)
-    return [d for d in parsed if d.date >= cutoff]
 
 
 def _parse_all_decisions(store: Store) -> list[Decision]:

--- a/packages/nauro-core/src/nauro_core/operations/propose_decision.py
+++ b/packages/nauro-core/src/nauro_core/operations/propose_decision.py
@@ -5,7 +5,7 @@ all call this function with the same arguments and receive the same
 :class:`ProposeDecisionResult`. The kernel owns:
 
 * Tier 1 structural screening (rejects empty fields, short rationale,
-  exact-hash duplicates, recent-title duplicates).
+  exact-hash duplicates, and titles that match a decision still in force).
 * ``operation="update"`` disallowed-fields rejection.
 * ``resolves_questions`` boundary validation (unknown ids, ambiguous
   ids).
@@ -29,7 +29,7 @@ push stay on the adapter side per the locked Store Protocol boundary.
 from __future__ import annotations
 
 import json
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from typing import Literal
 
 from nauro_core.constants import (
@@ -174,7 +174,7 @@ def propose_decision(
             )
 
     # --- Tier 1: structural screening ---
-    # ``parsed`` is the single corpus scan shared between Tier 1 recent-title
+    # ``parsed`` is the single corpus scan shared between Tier 1 active-title
     # dedup and Tier 2 BM25. It stays None on the update early-reject path so a
     # short-rationale update rejects without scanning the corpus at all.
     parsed: list[Decision] | None = None
@@ -192,7 +192,7 @@ def propose_decision(
             action, reason = "pass", None
     else:
         parsed = _parse_all_decisions(store)
-        action, reason = _screen_structural(store, proposal, parsed)
+        action, reason = _screen_structural(store, proposal, parsed, affected_decision_id)
 
     if action == "reject":
         return ProposeDecisionResult(
@@ -281,18 +281,31 @@ def _write_decision_direct(store: Store, proposal: dict) -> str:
 
 
 def _screen_structural(
-    store: Store, proposal: dict, parsed: list[Decision]
+    store: Store,
+    proposal: dict,
+    parsed: list[Decision],
+    affected_decision_id: str | None,
 ) -> tuple[str, str | None]:
-    """Run Tier 1 structural screening with hashes + recent-title dedup.
+    """Run Tier 1 structural screening with hashes + active-title dedup.
 
-    ``parsed`` is the shared corpus scan reused for Tier 2 BM25, so this no
-    longer re-reads the store for the 24h recent-title window.
+    Title dedup keys on active status, not recency: an add or supersede whose
+    normalized title matches any active decision is rejected regardless of the
+    matched decision's age. ``parsed`` is the shared corpus scan reused for
+    Tier 2 BM25, so this does not re-read the store.
+
+    The supersede target is excluded from the dedup set. Screening runs before
+    the supersede flip, so the target is still active at this point; without
+    the exclusion a same-title supersede of an established decision would
+    self-reject. A supersede whose new title collides with a *different* active
+    decision still rejects.
     """
     hash_index = _load_hash_index(store)
     existing_hashes = set(hash_index.keys())
-    cutoff = (datetime.now(timezone.utc) - timedelta(hours=24)).date()
-    recent = [d for d in parsed if d.date >= cutoff]
-    return screen_structural(proposal, existing_hashes, recent)
+    affected_num = extract_decision_number(affected_decision_id) if affected_decision_id else None
+    dedup_decisions = [
+        d for d in parsed if d.status is DecisionStatus.active and d.num != affected_num
+    ]
+    return screen_structural(proposal, existing_hashes, dedup_decisions)
 
 
 def _load_hash_index(store: Store) -> dict:

--- a/packages/nauro-core/src/nauro_core/validation.py
+++ b/packages/nauro-core/src/nauro_core/validation.py
@@ -120,18 +120,23 @@ def _normalize_title(title: str) -> str:
 def screen_structural(
     proposal: dict,
     existing_hashes: set[str],
-    recent_decisions: list[dict],
+    active_decisions: list[dict],
 ) -> tuple[str, str | None]:
     """Run structural screening on a proposal. No I/O.
 
     Checks: schema validation (title, rationale, confidence), minimum rationale
     length, hash dedup against existing_hashes, and title dedup against
-    recent_decisions (same title within 24h — caller filters by recency).
+    active_decisions (same title as a decision still in force).
+
+    This function is operation-agnostic: it dedups the proposal title against
+    whatever list the caller hands it. The caller decides which decisions are
+    eligible (active decisions, with any supersede target excluded).
 
     Args:
         proposal: Dict with title, rationale, confidence keys.
         existing_hashes: Set of content hashes from the hash index.
-        recent_decisions: Decisions from the last 24 hours (caller filters).
+        active_decisions: Decisions to dedup the title against (caller filters
+            to active decisions, excluding any supersede target).
 
     Returns:
         (action, reason) where action is "pass" or "reject".
@@ -159,12 +164,12 @@ def screen_structural(
     if content_hash in existing_hashes:
         return ("reject", "Exact duplicate of existing decision (hash match).")
 
-    # Title dedup against recent decisions (caller provides 24h window).
-    # Recent-decision entries may be either Decision objects or lightweight
+    # Title dedup against active decisions (caller filters to active, minus any
+    # supersede target). Entries may be either Decision objects or lightweight
     # dicts (the mcp-server tier-1 path loads just title+num from S3 without
     # full parsing). Handle both shapes.
     title_normalized = _normalize_title(title)
-    for d in recent_decisions:
+    for d in active_decisions:
         if hasattr(d, "title"):
             existing_title = d.title
             existing_num = d.num
@@ -174,7 +179,9 @@ def screen_structural(
         if _normalize_title(existing_title) == title_normalized:
             return (
                 "reject",
-                f"Decision with same title written recently: D{existing_num}",
+                f"An active decision already has this title: D{existing_num}. "
+                'Use operation="supersede" to replace it, or operation="update" '
+                "to append rationale — not a second add.",
             )
 
     return ("pass", None)

--- a/packages/nauro-core/tests/operations/test_operations_propose_decision.py
+++ b/packages/nauro-core/tests/operations/test_operations_propose_decision.py
@@ -366,6 +366,136 @@ def test_supersede_no_similarity_still_executes_write() -> None:
     assert "status: superseded" in old_body
 
 
+# ── active-title dedup (Tier 1) ──────────────────────────────────────────
+
+
+def test_add_title_matching_old_active_decision_rejects() -> None:
+    """An add whose title matches an active decision rejects regardless of the
+    matched decision's age. Under the prior 24h window this add would have
+    wrongly passed because the existing decision fell outside the window."""
+    store = _store_with(
+        _seed_decision(
+            1,
+            "Adopt PostgreSQL primary database",
+            "Mature ecosystem with strong JSON support and excellent tooling.",
+            decision_date=date(2024, 1, 1),
+        ),
+    )
+    result = propose_decision(
+        store,
+        title="Adopt PostgreSQL primary database",
+        rationale="Re-proposing the same choice with fresh rationale text that is long enough.",
+        confidence="medium",
+    )
+    assert result.status == "rejected"
+    assert result.tier == 1
+    assert result.operation == "reject"
+    assert "active decision already has this title" in result.assessment.lower()
+    assert "D1" in result.assessment
+
+
+def test_add_title_matching_superseded_decision_passes() -> None:
+    """Title dedup keys on active status, so an add whose title matches a
+    superseded decision is not blocked."""
+    store = _store_with(
+        _seed_decision(
+            1,
+            "Adopt PostgreSQL primary database",
+            "Mature ecosystem with strong JSON support and excellent tooling.",
+            status=DecisionStatus.superseded,
+            decision_date=date(2024, 1, 1),
+        ),
+    )
+    result = propose_decision(
+        store,
+        title="Adopt PostgreSQL primary database",
+        rationale="The superseded decision no longer applies; re-establishing the choice now.",
+        confidence="medium",
+    )
+    assert result.status == "confirmed"
+    assert result.operation == "add"
+    assert result.decision_id is not None
+
+
+def test_supersede_same_title_as_target_confirms() -> None:
+    """A supersede whose new title equals the target's own title must not
+    self-reject: screening runs before the flip, so the still-active target is
+    excluded from the dedup set."""
+    store = _store_with(
+        _seed_decision(
+            1,
+            "Adopt PostgreSQL primary database",
+            "Mature ecosystem with strong JSON support and excellent tooling.",
+            decision_date=date(2024, 1, 1),
+        ),
+    )
+    result = propose_decision(
+        store,
+        title="Adopt PostgreSQL primary database",
+        rationale="Keeping the title but recording a materially revised rationale for the choice.",
+        confidence="medium",
+        operation="supersede",
+        affected_decision_id="decision-001",
+    )
+    assert result.status == "confirmed"
+    assert result.operation == "supersede"
+    assert result.decision_id is not None
+
+
+def test_supersede_title_collides_with_different_active_decision_rejects() -> None:
+    """A supersede whose new title collides with a *different* active decision
+    still rejects — only the supersede target is excluded from the dedup set."""
+    store = _store_with(
+        _seed_decision(
+            1,
+            "Adopt PostgreSQL primary database",
+            "Mature ecosystem with strong JSON support and excellent tooling.",
+        ),
+        _seed_decision(
+            2,
+            "Adopt Redis for hot caching",
+            "In-memory cache keeps hot read paths off the primary database.",
+        ),
+    )
+    result = propose_decision(
+        store,
+        title="Adopt Redis for hot caching",
+        rationale="Superseding decision 1 but reusing a title already held by active decision 2.",
+        confidence="medium",
+        operation="supersede",
+        affected_decision_id="decision-001",
+    )
+    assert result.status == "rejected"
+    assert result.tier == 1
+    assert result.operation == "reject"
+    assert "active decision already has this title" in result.assessment.lower()
+    assert "D2" in result.assessment
+
+
+def test_add_matching_active_scaffold_seed_rejects() -> None:
+    """The scaffold seed is an active decision, so an add titled exactly as the
+    seed rejects on the active-title axis. Tier 2 seed filtering is unrelated:
+    Tier 1 rejects before Tier 2 runs."""
+    store = _store_with(
+        _seed_decision(
+            1,
+            "Initial project setup",
+            "Scaffold-seeded bookkeeping decision recording store initialization.",
+        ),
+    )
+    result = propose_decision(
+        store,
+        title="Initial project setup",
+        rationale="A second add reusing the scaffold seed title that should be turned away.",
+        confidence="medium",
+    )
+    assert result.status == "rejected"
+    assert result.tier == 1
+    assert result.operation == "reject"
+    assert "active decision already has this title" in result.assessment.lower()
+    assert "D1" in result.assessment
+
+
 # ── update ──────────────────────────────────────────────────────────────
 
 

--- a/packages/nauro-core/tests/operations/test_operations_propose_decision.py
+++ b/packages/nauro-core/tests/operations/test_operations_propose_decision.py
@@ -212,6 +212,92 @@ class TestAdvisorySimilarDecisions:
         assert result.similar_decisions == []
 
 
+# ── corpus-scan deduplication ───────────────────────────────────────────
+
+
+class _ScanCountingStore(InMemoryStore):
+    """In-memory store that counts full-corpus scans.
+
+    ``parse_all_decisions`` is the expensive scan being deduplicated: it
+    lists every decision stem and then ``read_decision``\\ s each one to parse
+    it. We count corpus scans by counting ``read_decision`` calls and dividing
+    by the seeded corpus size, because ``list_decisions`` alone conflates a
+    corpus parse with the cheap stem-only listing in ``_next_decision_num``
+    on the write path. ``corpus_scans`` therefore isolates the Tier 1 / Tier 2
+    parse work the change collapses from two scans to one.
+    """
+
+    def __init__(
+        self,
+        decisions: dict[str, str] | None = None,
+        files: dict[str, str] | None = None,
+    ) -> None:
+        super().__init__(decisions=decisions, files=files)
+        self.read_decision_calls = 0
+
+    def read_decision(self, file_stem: str) -> str | None:
+        self.read_decision_calls += 1
+        return super().read_decision(file_stem)
+
+    def corpus_scans(self, corpus_size: int) -> int:
+        """Number of full-corpus parses, derived from per-stem reads."""
+        if corpus_size == 0:
+            return 0
+        scanned, remainder = divmod(self.read_decision_calls, corpus_size)
+        assert remainder == 0, (
+            f"read_decision called {self.read_decision_calls} times for a "
+            f"corpus of {corpus_size}; not a whole number of full scans."
+        )
+        return scanned
+
+
+def test_add_accept_scans_corpus_once() -> None:
+    """A non-update ``add`` accept parses the corpus exactly once: Tier 1 and
+    Tier 2 share the single parsed list rather than re-reading and re-parsing
+    the store. Before the change this path parsed the corpus twice."""
+    store = _ScanCountingStore(
+        decisions=dict(
+            (
+                _seed_decision(1, "Adopt PostgreSQL", "ACID transactional semantics."),
+                _seed_decision(2, "Adopt Redis", "In-memory cache for hot read paths."),
+            )
+        )
+    )
+    result = propose_decision(
+        store,
+        title="Add dark mode toggle to settings page",
+        rationale="Users have requested a dark theme for reduced eye strain.",
+        confidence="medium",
+    )
+    assert store.corpus_scans(corpus_size=2) == 1
+    # The accept path is unchanged: same status, tier, decision id, and
+    # advisory shape as the existing auto-confirm expectations.
+    assert result.status == "confirmed"
+    assert result.tier == 2
+    assert result.operation == "add"
+    assert result.decision_id is not None
+    assert result.similar_decisions == []
+
+
+def test_update_short_rationale_rejects_without_scanning() -> None:
+    """An ``operation="update"`` with a too-short rationale rejects at Tier 1
+    before any corpus scan. Guards the lazy-compute: ``parsed`` must not be
+    hoisted to the top, which would regress this path to a needless scan."""
+    store = _ScanCountingStore(
+        decisions=dict((_seed_decision(1, "Adopt PostgreSQL", "ACID transactional semantics."),))
+    )
+    result = propose_decision(
+        store,
+        title="",
+        rationale="too short",
+        operation="update",
+        affected_decision_id="decision-001",
+    )
+    assert store.corpus_scans(corpus_size=1) == 0
+    assert result.status == "rejected"
+    assert result.tier == 1
+
+
 # ── supersede ───────────────────────────────────────────────────────────
 
 

--- a/packages/nauro-core/tests/test_validation.py
+++ b/packages/nauro-core/tests/test_validation.py
@@ -215,17 +215,18 @@ class TestScreenStructural:
         assert action == "reject"
         assert "hash match" in reason.lower()
 
-    def test_title_dedup_recent(self):
+    def test_title_dedup_active(self):
         proposal = self._proposal()
-        recent = [{"title": "Use FastAPI for MCP server", "num": 42}]
-        action, reason = screen_structural(proposal, set(), recent)
+        active = [{"title": "Use FastAPI for MCP server", "num": 42}]
+        action, reason = screen_structural(proposal, set(), active)
         assert action == "reject"
-        assert "same title" in reason.lower()
+        assert "active decision already has this title" in reason.lower()
+        assert "D42" in reason
 
     def test_title_dedup_case_insensitive(self):
         proposal = self._proposal()
-        recent = [{"title": "use fastapi for mcp server", "num": 42}]
-        action, _reason = screen_structural(proposal, set(), recent)
+        active = [{"title": "use fastapi for mcp server", "num": 42}]
+        action, _reason = screen_structural(proposal, set(), active)
         assert action == "reject"
 
     def test_default_confidence_accepted(self):


### PR DESCRIPTION
## Why

`propose_decision`'s Tier 1 path had two problems, both in how it reads the decision corpus:

1. **It scanned the whole corpus twice.** On every non-update operation it parsed every decision once for the Tier 1 recent-title dedup and again for Tier 2 BM25 similarity — two identical full scans. Production telemetry over the last 30 days puts this write path at ~8s p50 warm with a p99 near 28s, brushing the 30s timeout; the duplicate scan is pure waste on the operation most exposed to it.
2. **The title dedup used the wrong axis.** It rejected an add/supersede whose normalized title matched a decision *written in the last 24 hours*. That window is day-granular (`(now - 24h).date()`, an effective 0–48h depending on the time of day a decision was filed), keys off an agent-suppliable frontmatter `date:` field (a backdated decision evades it), and recency was never the real intent: the check exists to stop a second copy of a decision *already in force*, and a decision's age has nothing to do with that.

## Approach

Two coordinated changes to the Tier 1 path.

**Single corpus scan.** Parse the corpus once and thread the single list through both tiers. The parse is lazy: the `operation="update"` early-reject path (empty or too-short rationale) never needs the corpus, so it rejects without paying for a scan. The non-update branch parses before Tier 1; Tier 2 reuses the same list via a `None` guard.

**Active-status dedup.** Reject an add/supersede whose normalized title matches any *active* decision, regardless of age, and drop the date window entirely. The pure validator (`screen_structural`) stays operation-agnostic — it dedups against whatever list it is handed; the filtering moves to the kernel caller (`_screen_structural`), which builds the set as active decisions *excluding the supersede target*. That exclusion is the load-bearing point: screening runs before the supersede flip, so the target is still active at screen time, and without excluding it a same-title supersede of an established decision would self-reject. A supersede whose new title collides with a *different* active decision still rejects, which is the invariant the new axis buys.

Alternatives considered and rejected:
- **Memoize the scan, or hoist it to the top of the function.** Adds caching state, or reintroduces a needless scan on the update early-reject path; lazy threading is simpler and avoids both.
- **Fix the 24h window to a real rolling 24–48h.** Makes the boundary precise but keeps the wrong axis and the agent-suppliable-date evasion.
- **Skip title dedup entirely on supersede.** Simpler, but loses the cross-decision collision catch (a supersede whose new title duplicates a different active decision).

## What changed

- `nauro-core/operations/propose_decision.py`: one lazy `parsed` corpus scan shared across Tier 1 and Tier 2. `_screen_structural` takes the parsed list plus `affected_decision_id`, resolves it to a number, and dedups against active decisions minus that target. The 24h cutoff, the `timedelta` import, and the `_load_recent_decisions` helper are gone. `update` is unchanged (it skips structural screening and cannot change title).
- `nauro-core/validation.py`: `screen_structural`'s third parameter renamed `recent_decisions` → `active_decisions`; the rejection message names the matched active decision and points the agent at `supersede`/`update` instead of a second `add`. The function stays pure and operation-agnostic; the dict-tolerance branch is unchanged.
- Tests: a scan-count regression guard (exactly one corpus parse on a non-update accept; zero on the update early-reject); the two `screen_structural` title-dedup unit tests reconciled to the active axis and the new message; five new kernel-level tests for the status behavior.

## What to review

- **The supersede target exclusion** in `_screen_structural` — the correctness pivot. `test_supersede_same_title_as_target_confirms` guards the self-rejection regression; `test_supersede_title_collides_with_different_active_decision_rejects` guards that the exclusion does not over-reach.
- **The lazy `parsed` boundary** — the update branch must leave it unset so the early-reject stays scan-free; Tier 2 recomputes it via the `None` guard.
- **The scaffold seed is no longer date-shielded.** It is a permanent active decision, so a re-add of its exact title now rejects at Tier 1 (intended twin-catch). Tier 2's separate seed filtering is untouched — Tier 1 rejects before Tier 2 runs.

## What's deferred

- The remote (S3-backed) surface picks up both changes only after a later nauro-core version bump. This is a nauro-core-only change with no cross-package dependency to regenerate, so no requirements manifest is touched here.
- The dominant per-call cost — one sequential S3 GET per decision in the shared scan, also hit by `search_decisions` and `get_context` — is untouched. Cutting it (batched/parallel reads) is a separate, larger effort.
- The stale dict-path tolerance branch in `screen_structural` is left as-is.

## Test plan

- `uv run pytest packages/nauro-core/tests/ -x -q` → 743 passed.
- `uv run pytest packages/nauro/tests/ -x -q` → 1225 passed, 10 skipped (consumer + cross-surface propose-decision parity unchanged).
- `uv run ruff check packages/` and `uv run ruff format --check packages/` → clean.
