### PR TITLE
Add bulk read_decisions Store primitive for corpus scans

### DIFF
--- a/packages/nauro-core/src/nauro_core/operations/_in_memory_store.py
+++ b/packages/nauro-core/src/nauro_core/operations/_in_memory_store.py
@@ -60,6 +60,12 @@ class InMemoryStore:
     def read_decision(self, file_stem: str) -> str | None:
         return self._decisions.get(file_stem)
 
+    def read_decisions(self, stems: list[str]) -> dict[str, str | None]:
+        # Dispatch through self.read_decision per stem rather than reading
+        # self._decisions directly: subclasses that instrument read_decision
+        # (e.g. the scan-counting double) must see one call per stem.
+        return {stem: self.read_decision(stem) for stem in stems}
+
 
 def _decision_stem(path: str) -> str | None:
     """Return the decision file stem when ``path`` targets ``decisions/*.md``."""

--- a/packages/nauro-core/src/nauro_core/operations/decision_lookup.py
+++ b/packages/nauro-core/src/nauro_core/operations/decision_lookup.py
@@ -27,13 +27,19 @@ def parse_all_decisions(store: Store) -> list[Decision]:
     not round-trip through the v2 parser is logged at debug and skipped, so
     the scan returns the decisions it could parse rather than raising.
 
-    Listing and ordering follow :meth:`Store.list_decisions` verbatim; no
-    filtering is applied here. Callers that need a status or seed filter
-    apply it after the scan returns.
+    Bodies are fetched in one bulk :meth:`Store.read_decisions` call, but the
+    scan still reasserts :meth:`Store.list_decisions` order: it iterates the
+    stem list (not the returned mapping, which carries no ordering guarantee)
+    so the parsed list follows ``list_decisions`` verbatim. That ordering is
+    load-bearing — BM25 ranking breaks ties by corpus position, so a stable
+    parse order keeps retrieval byte-identical. No filtering is applied here;
+    callers that need a status or seed filter apply it after the scan returns.
     """
     parsed: list[Decision] = []
-    for stem in store.list_decisions():
-        body = store.read_decision(stem)
+    stems = store.list_decisions()
+    bodies = store.read_decisions(stems)
+    for stem in stems:
+        body = bodies.get(stem)
         if body is None:
             continue
         try:

--- a/packages/nauro-core/src/nauro_core/operations/get_context.py
+++ b/packages/nauro-core/src/nauro_core/operations/get_context.py
@@ -7,7 +7,7 @@ transport-specific framing (``store`` field, telemetry emission, onboarding
 sentinels, snapshot-diff trailers); the level dispatch and markdown
 assembly are shared by construction.
 
-Only the five locked Store primitives are used: the snapshot/diff layer
+Only the locked Store primitives are used: the snapshot/diff layer
 and the "Last synced" trailer remain adapter concerns since they sit
 outside the kernel's storage protocol.
 """

--- a/packages/nauro-core/src/nauro_core/operations/store.py
+++ b/packages/nauro-core/src/nauro_core/operations/store.py
@@ -2,10 +2,10 @@
 
 Operations call into a ``Store`` to read and write the project store; each
 transport supplies a concrete implementation (filesystem for local, S3 +
-DynamoDB for cloud). The Protocol stays minimal: only the five primitives
-locked by the operations-kernel restructure. Anything broader (file
-enumeration outside ``decisions/``, pending-state primitives, etc.) is a
-separate decision before the surface grows.
+DynamoDB for cloud). The Protocol stays minimal: the six primitives locked
+by the operations-kernel restructure and the bulk-read addition. Anything
+broader (file enumeration outside ``decisions/``, pending-state primitives,
+etc.) is a separate decision before the surface grows.
 """
 
 from __future__ import annotations
@@ -50,5 +50,17 @@ class Store(Protocol):
 
         ``file_stem`` is a value returned by :meth:`list_decisions` (without
         the ``.md`` suffix). Returns ``None`` if the decision is missing.
+        """
+        ...
+
+    def read_decisions(self, stems: list[str]) -> dict[str, str | None]:
+        """Bulk analogue of :meth:`read_decision`.
+
+        Returns ``{stem: body | None}`` for each stem in ``stems``; a stem
+        whose file is missing maps to ``None``. There is NO ordering
+        guarantee on the returned mapping — callers that need a stable order
+        reassert it against the ``stems`` list they passed. Cloud transports
+        may fan the reads out concurrently, so the mapping's iteration order
+        is not the call order.
         """
         ...

--- a/packages/nauro-core/tests/operations/test_decision_lookup.py
+++ b/packages/nauro-core/tests/operations/test_decision_lookup.py
@@ -10,10 +10,21 @@ path that callers rely on.
 
 from __future__ import annotations
 
+from datetime import date
+
 import pytest
 
+from nauro_core.decision_model import (
+    Decision,
+    DecisionConfidence,
+    DecisionStatus,
+    format_decision,
+)
 from nauro_core.operations import InMemoryStore, find_decision_stem_by_id
-from nauro_core.operations.decision_lookup import find_decision_stem_by_num
+from nauro_core.operations.decision_lookup import (
+    find_decision_stem_by_num,
+    parse_all_decisions,
+)
 
 
 def _seeded_store() -> InMemoryStore:
@@ -60,3 +71,54 @@ def test_find_by_id_unparseable_returns_none() -> None:
 
 def test_find_by_id_parseable_but_absent_returns_none() -> None:
     assert find_decision_stem_by_id(_seeded_store(), "decision-999") is None
+
+
+# ── parse_all_decisions: order is reasserted from list_decisions ──
+
+
+def _decision_body(num: int, title: str) -> str:
+    """Return a well-formed v2 decision body for the given number and title."""
+    return format_decision(
+        Decision(
+            date=date(2026, 1, 1),
+            confidence=DecisionConfidence.medium,
+            status=DecisionStatus.active,
+            num=num,
+            title=title,
+            rationale=f"Rationale for {title}.",
+        )
+    )
+
+
+class _ReversedReadDecisionsStore(InMemoryStore):
+    """Store whose bulk read returns the mapping in reverse-stem order.
+
+    ``read_decisions`` carries no ordering guarantee, so a transport is free
+    to hand the mapping back in any order (a cloud fan-out finishes reads in
+    completion order, not call order). This double exaggerates that by
+    reversing the insertion order; a correct ``parse_all_decisions`` must
+    still iterate ``list_decisions`` and yield decisions in that order, not
+    the mapping's.
+    """
+
+    def read_decisions(self, stems: list[str]) -> dict[str, str | None]:
+        return {stem: self.read_decision(stem) for stem in reversed(stems)}
+
+
+def test_parse_all_decisions_reasserts_list_order_not_mapping_order() -> None:
+    store = _ReversedReadDecisionsStore(
+        decisions={
+            "001-alpha": _decision_body(1, "Alpha"),
+            "002-bravo": _decision_body(2, "Bravo"),
+            "003-charlie": _decision_body(3, "Charlie"),
+        }
+    )
+    # Sanity: the bulk read really does come back in a different order than
+    # list_decisions, so the test exercises the iterate-stems guarantee.
+    assert list(store.read_decisions(store.list_decisions())) == [
+        "003-charlie",
+        "002-bravo",
+        "001-alpha",
+    ]
+    parsed = parse_all_decisions(store)
+    assert [d.num for d in parsed] == [1, 2, 3]

--- a/packages/nauro-core/tests/operations/test_store_protocol.py
+++ b/packages/nauro-core/tests/operations/test_store_protocol.py
@@ -67,6 +67,26 @@ def test_read_decision_returns_none_when_missing() -> None:
     assert store.read_decision("042-nope") is None
 
 
+def test_read_decisions_round_trip_present_and_missing() -> None:
+    store = InMemoryStore(
+        decisions={
+            "001-first": "body-1",
+            "002-second": "body-2",
+        }
+    )
+    bodies = store.read_decisions(["001-first", "002-second", "999-missing"])
+    assert bodies == {
+        "001-first": "body-1",
+        "002-second": "body-2",
+        "999-missing": None,
+    }
+
+
+def test_read_decisions_empty_stems_returns_empty_mapping() -> None:
+    store = InMemoryStore(decisions={"001-first": "body-1"})
+    assert store.read_decisions([]) == {}
+
+
 def test_decisions_and_files_are_independent_namespaces() -> None:
     """Writing under a file path must not surface a decision stem, and vice versa."""
     store = InMemoryStore(decisions={"001-only-a-decision": "body"})

--- a/packages/nauro/src/nauro/store/filesystem_store.py
+++ b/packages/nauro/src/nauro/store/filesystem_store.py
@@ -64,3 +64,9 @@ class FilesystemStore:
         if not target.exists():
             return None
         return target.read_text()
+
+    # Serial loop, no thread pool: local disk reads are fast and a pool would
+    # contend with the per-write FileLock. Byte-identical to scanning the
+    # stems one at a time. Cloud transports override this to fan out.
+    def read_decisions(self, stems: list[str]) -> dict[str, str | None]:
+        return {stem: self.read_decision(stem) for stem in stems}

--- a/packages/nauro/tests/test_store.py
+++ b/packages/nauro/tests/test_store.py
@@ -622,6 +622,49 @@ def test_reader_roundtrip_new_format(store: Path):
     assert "### Polling" in d.content
 
 
+# --- FilesystemStore bulk read tests ---
+
+
+def test_read_decisions_matches_serial_read(store: Path):
+    """The bulk read returns, per stem, exactly what serial read_decision does."""
+    append_decision(store, "Use Postgres")
+    append_decision(store, "Use Redis")
+    fs = FilesystemStore(store)
+    stems = fs.list_decisions()
+    bodies = fs.read_decisions(stems)
+    assert [bodies[s] for s in stems] == [fs.read_decision(s) for s in stems]
+
+
+def test_read_decisions_missing_stem_maps_to_none(store: Path):
+    """A stem with no backing file maps to None, matching read_decision."""
+    fs = FilesystemStore(store)
+    bodies = fs.read_decisions(["999-vanished"])
+    assert bodies == {"999-vanished": None}
+    assert fs.read_decision("999-vanished") is None
+
+
+def test_parse_all_decisions_bulk_equals_serial(store: Path):
+    """parse_all_decisions over FilesystemStore yields the same decisions in the
+    same order as reading and parsing each stem serially in list order."""
+    from nauro_core.decision_model import parse_decision
+    from nauro_core.operations.decision_lookup import parse_all_decisions
+
+    append_decision(store, "Use Postgres")
+    append_decision(store, "Use Redis")
+    fs = FilesystemStore(store)
+
+    serial = []
+    for stem in fs.list_decisions():
+        body = fs.read_decision(stem)
+        if body is None:
+            continue
+        serial.append(parse_decision(body, f"{stem}.md"))
+
+    bulk = parse_all_decisions(fs)
+    assert [d.num for d in bulk] == [d.num for d in serial]
+    assert [d.title for d in bulk] == [d.title for d in serial]
+
+
 # --- Question parser tests ---
 
 


### PR DESCRIPTION
## Why

Every retrieval and write-path operation that needs the decision corpus
(`get_context`, `list_decisions`, `search_decisions`, `check_decision`,
`propose_decision`) parses it through one chokepoint: `parse_all_decisions`.
That helper lists the decision stems and then issues one read per stem. On
the local filesystem this is cheap, but the same loop runs against the cloud
transport as one network GET per decision, serialized. On a real store that
measured at roughly 7–8s median and a ~30s tail just to assemble context —
the corpus scan dominated the latency.

The serial loop is baked into the read contract: `parse_all_decisions` calls
`read_decision` one stem at a time, so there is no seam where the cloud
transport could batch or parallelize the reads without rewriting the kernel.
This change adds that seam.

## Approach

The storage protocol grows one primitive: a bulk `read_decisions(stems)` that
returns `{stem: body | None}`. `parse_all_decisions` now fetches all bodies in
a single call and parses them. The new method carries no ordering guarantee on
its returned mapping — a cloud transport is free to fan the reads out
concurrently and assemble the mapping in completion order — so the scan
reasserts order itself by iterating the `stems` list rather than the mapping.
That ordering is load-bearing: BM25 ranking breaks ties by corpus position, so
a stable parse order keeps retrieval byte-identical to the old serial loop.

The filesystem implementation loops serially with no thread pool. Local disk
reads are fast and a pool would contend with the per-write file lock, so this
PR is performance-neutral locally; it only opens the door for the cloud
transport to parallelize later.

The primitive is required, not an optional capability — a transport that ships
a stale store implementation without it fails loud at the protocol boundary
rather than silently falling back to the slow path.

Rejected alternatives:
- A duck-typed optional capability (`getattr(store, "read_decisions", None)`),
  which would let a stale transport silently keep the per-GET behavior.
- A transport-level prefetch cache, which adds cache-invalidation surface
  without changing the contract the kernel depends on.
- A per-invocation parse/BM25 cache, which targets repeated scans within one
  call rather than the single-scan latency this addresses.

This follows the recorded decision to grow the store protocol from five to six
primitives with a bulk read.

## What changed

- **Store protocol** (`nauro-core`): added `read_decisions`; updated the module
  docstring to reflect six primitives.
- **Corpus scan** (`nauro-core/decision_lookup`): `parse_all_decisions` reads in
  bulk and reasserts `list_decisions` order; skip-on-missing and
  skip-on-unparseable semantics are unchanged.
- **Filesystem transport** (`nauro`): serial-loop implementation, byte-identical
  to the prior behavior.
- **Test double** (`nauro-core/InMemoryStore`): serial-loop implementation that
  dispatches through `read_decision` per stem; all kernel Store doubles inherit
  it.

## What to review

- The iterate-stems ordering invariant in `parse_all_decisions`. Iterating the
  returned mapping instead of the `stems` list would silently reorder the corpus
  and shift BM25 tie-breaks. A new order-preservation test pins this with a
  store double whose bulk read returns the mapping in reversed order.
- `InMemoryStore.read_decisions` deliberately calls `self.read_decision` per
  stem rather than reading the backing dict directly. The scan-counting test
  double subclasses `InMemoryStore` and counts corpus scans by instrumenting
  `read_decision`; bypassing it would silently break the "scan corpus once"
  invariant. The comment on the method records why.

## What's deferred

- The actual remote win: the cloud transport gaining a thread-pool fan-out
  implementation of `read_decisions` plus the dependency bump that ships it.
  This PR is the contract only.
- A per-invocation parse/BM25 cache to deduplicate repeated scans within a
  single operation.
- Pulling the L0 context-assembly path off the full corpus scan.

## Test plan

- `nauro-core`: 746 existing pass; added order-preservation (bulk read returns
  reversed mapping, decisions still emerge in `list_decisions` order) plus
  `read_decisions` round-trip coverage (present stems → bodies, missing → None,
  empty stems → empty mapping). The malformed-file read-path guard and the
  scan-corpus-once invariant stay green.
- `nauro`: 1228 pass / 10 skipped; added a FilesystemStore
  batched-equals-serial invariant (bulk read matches serial per stem, missing
  stem → None, and `parse_all_decisions` over the filesystem store yields the
  same decisions in the same order as the serial loop).
- `ruff check` and `ruff format --check` clean across `packages/`.
