### PR TITLE
chore(release): bump nauro-core to 0.13.5

### DIFF
--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro-core"
-version = "0.13.4"
+version = "0.13.5"
 description = "Shared pure-Python logic for Nauro: parsing, validation, context assembly, constants."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
Release `nauro-core` 0.13.5 to PyPI (the `nauro-core-v0.13.5` tag triggers publish after merge).

Carries the changes merged since 0.13.4:
- propose_decision Tier-1 title dedup now keys on active status instead of a recency window; the corpus is scanned once per write.
- The Store protocol gained a sixth primitive, the bulk `read_decisions`, so the cloud transport can parallelize the decision scan.

Pyproject-only version bump; no code change. The hosted MCP server picks these up via a follow-up `nauro-core` bump.