### PR TITLE
chore(release): bump nauro to 0.12.1

### DIFF
--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro"
-version = "0.12.0"
+version = "0.12.1"
 description = "Local CLI + MCP server: set your project's doctrine once, every connected AI agent inherits it."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
Patch release fixing a broken 0.12.0 on PyPI.

**The bug:** PyPI `nauro` 0.12.0 ships a `FilesystemStore` **missing** the bulk `read_decisions()` primitive (added to the Store protocol in #179 / D273), while its `nauro-core>=0.13.0,<0.14` floor resolves `nauro-core` 0.13.5 — whose `decision_lookup.parse_all_decisions()` calls `store.read_decisions()`. Result: every `get_context` / AGENTS.md-regen path (including `nauro sync`) crashes with `AttributeError: 'FilesystemStore' object has no attribute 'read_decisions'`. The fix was merged to main after the 0.12.0 tag **without a version bump**, so main and the released wheel share a version string but differ in code.

**This PR:** bumps `packages/nauro` `0.12.0 → 0.12.1` (single line). No code change — the fix is already on main.

### Contents since `nauro-v0.12.0`
- #179 — Add bulk `read_decisions` Store primitive for corpus scans *(the fix)*
- #176 — Serialize shared-file store writes with an adapter write lock

### Release steps after merge
1. Tag `nauro-v0.12.1` on the merge commit → `publish-nauro.yml` builds + publishes via trusted publishing.
2. **Yank `0.12.0`** on PyPI (web UI).

Verified: a local build of this branch installs cleanly with `nauro-core` 0.13.5 and `nauro sync` completes end-to-end (pull + push + AGENTS.md regen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)