### PR TITLE
ci: bump checkout v4→v6 and setup-python v5→v6 (Node 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - run: pip install ruff==0.15.8
@@ -22,7 +22,7 @@ jobs:
   import-linter:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v6
       - run: uv python install 3.12
       - run: uv sync --package nauro-core --all-extras --python 3.12
@@ -35,7 +35,7 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v6
       - run: uv python install ${{ matrix.python-version }}
       - run: uv sync --package nauro-core --all-extras --python ${{ matrix.python-version }}
@@ -47,7 +47,7 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v6
       - run: uv python install ${{ matrix.python-version }}
       - run: uv sync --package nauro --all-extras --python ${{ matrix.python-version }}

--- a/.github/workflows/publish-nauro-core.yml
+++ b/.github/workflows/publish-nauro-core.yml
@@ -11,8 +11,8 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - run: pip install build

--- a/.github/workflows/publish-nauro.yml
+++ b/.github/workflows/publish-nauro.yml
@@ -11,8 +11,8 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - run: pip install build


### PR DESCRIPTION
## Summary
Clears the Node.js 20 deprecation warning surfaced on the 0.12.1 publish run. GitHub forces Node 24 for JS actions on **2026-06-16** and removes Node 20 on **2026-09-16**; `actions/checkout@v4` and `actions/setup-python@v5` run on Node 20.

Bumps to the current majors — **checkout v6** (v6.0.3) and **setup-python v6** (v6.2.0), both Node 24 — across all three workflows. `astral-sh/setup-uv@v6` already runs on Node 24 and is left as-is.

### Changes
- `ci.yml`: checkout ×4 → v6, setup-python ×1 → v6
- `publish-nauro.yml`: checkout + setup-python → v6
- `publish-nauro-core.yml`: checkout + setup-python → v6

No behavior change — same actions, newer runtime. Pure version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)