### PR TITLE
feat(status): surface the store path in `nauro status`

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/status.py
+++ b/packages/nauro/src/nauro/cli/commands/status.py
@@ -64,7 +64,12 @@ def status(
         typer.echo("No project found. Run 'nauro init <name>' to get started.", err=True)
         raise typer.Exit(exc.exit_code) from exc
 
-    typer.echo(f"Project: {project_name}\n")
+    typer.echo(f"Project: {project_name}")
+    # Surface the absolute store path. The store lives at ~/.nauro/projects/<id>/,
+    # outside any repo, and no other command prints it — an agent following the
+    # nauro-handoff / nauro-context skills needs it to resolve where to write
+    # handoffs/<slug>.md or context/<slug>.md.
+    typer.echo(f"Store:   {store_path}\n")
 
     # Sync — gated on auth token + v2 cloud-mode (matches hooks.py semantics).
     # ``store_path.name`` is the project_id for v2; v1 entries pass their name

--- a/packages/nauro/tests/test_cli_status.py
+++ b/packages/nauro/tests/test_cli_status.py
@@ -26,6 +26,22 @@ def test_status_shows_active_capabilities(tmp_path, monkeypatch):
     assert "Decisions:" in result.output
 
 
+def test_status_shows_store_path(tmp_path, monkeypatch):
+    """`nauro status` surfaces the absolute store path.
+
+    The store lives at ~/.nauro/projects/<id>/ — outside any repo — and no other
+    command prints it. An agent following the nauro-handoff / nauro-context
+    skills needs it to resolve where to write handoffs/<slug>.md or
+    context/<slug>.md.
+    """
+    store = _setup_project(tmp_path, monkeypatch)
+
+    result = runner.invoke(app, ["status"])
+    assert result.exit_code == 0
+    assert "Store:" in result.output
+    assert str(store) in result.output
+
+
 def test_status_sync_inactive(tmp_path, monkeypatch):
     _setup_project(tmp_path, monkeypatch)
 


### PR DESCRIPTION
## Why

The project store lives at `~/.nauro/projects/<id>/`, outside any repo, and no command surfaced where it is. Agents following the `nauro-handoff` and `nauro-context` skills write files directly into the store (`handoffs/<slug>.md`, `context/<slug>.md`) and have to resolve that path by hand — a gap surfaced while dogfooding `nauro-context`. Humans hit the same "where is my store?" question.

## What changed

`nauro status` now prints a `Store:` line with the resolved absolute store path, directly under `Project:`. One new test pins it.

```
Project: nauro
Store:   /Users/you/.nauro/projects/01KQ6AZGNA0B3QBF67NBXP3S45

  Sync          active (event-driven, presign)
  ...
```

## Test plan

- `uv run pytest packages/nauro/tests -q` → 1257 passed, 10 skipped.
- `uv run ruff check packages/` and `uv run ruff format --check packages/` — clean.
