### PR TITLE
fix(nauro-context): dogfooding corrections — skill accuracy + pointer-flag noise

### DIFF
--- a/.agents/skills/nauro-context/SKILL.md
+++ b/.agents/skills/nauro-context/SKILL.md
@@ -17,7 +17,7 @@ v1 targets the local-store path: the agent writes the brief to the local store o
 
 ## Step 1 — Author: write the brief file
 
-The agent writes the brief body to `<store>/context/<slug>.md` using its own filesystem write. The CLI push enumerates the whole store, so a file under `context/` syncs with no code change.
+The agent writes the brief body to `<store>/context/<slug>.md` using its own filesystem write. Resolve `<store>` by running `nauro status`, which prints the absolute store path; the store lives at `~/.nauro/projects/<id>/`, outside any repo, so it cannot be guessed from the working directory. The CLI push enumerates the whole store, so a file under `context/` syncs with no code change.
 
 The slug is `<origin>-<topic>-<YYYYMMDD>-<short-uid>`, for example `codex-auth-migration-20260605-h7k2`. `<origin>` is your surface or agent tag, `<topic>` is a short kebab-case subject, `<YYYYMMDD>` is today's date, and `<short-uid>` is a few random or session-derived characters. The short-uid is load-bearing: two agents on separate machines reconcile only at the shared store, so entropy in the slug — not a lock — is what keeps their briefs from colliding. Briefs accumulate append-only under `context/` — never overwrite or delete an existing brief. If the chosen slug already exists, add a disambiguator rather than replacing it.
 
@@ -25,11 +25,11 @@ The brief opens with YAML frontmatter. Required: `author` (your surface or agent
 
 ## Step 2 — Author: flag the discovery pointer
 
-The agent calls `flag_question(question="BRIEF: context/<slug>.md — <one-line summary>")`. This flagged question is how other agents discover the brief. It lives in `open-questions.md`, which is set-union-merged and lock-protected on sync, so pointers from concurrent authors all survive. A shared index file is deliberately not used: it would not be union-merged, so concurrent appends would be lost under last-writer-wins. The `BRIEF:` marker text is literal so the Find flow can locate it.
+The agent calls `flag_question(question="BRIEF: context/<slug>.md — <one-line summary>")`. This flagged question is how other agents discover the brief. It lives in `open-questions.md`, which is set-union-merged on sync, so pointers from concurrent authors all survive. A shared index file is deliberately not used: it would not be union-merged, so concurrent appends would be lost under last-writer-wins. The `BRIEF:` marker text is literal so the Find flow can locate it.
 
 ## Step 3 — Author: sync
 
-The agent tells the user to run `nauro sync` from the repo, or runs it. This pushes the store so `context/<slug>.md` and the `open-questions.md` pointer travel together. A brief over `MAX_BRIEF_BYTES` is skipped from the push with a loud warning and kept on disk; if that happens, trim the brief under the cap and sync again rather than assuming it was shared.
+The agent tells the user to run `nauro sync` from the repo, or runs it. This pushes the store so `context/<slug>.md` and the `open-questions.md` pointer travel together. A brief over `MAX_BRIEF_BYTES` is skipped from the push with a loud warning and kept on disk; if that happens, trim the brief under the cap and sync again rather than assuming it was shared. Reading the brief back with a local `get_raw_file` confirms only that it is on disk, not that it propagated; to confirm it reached the shared store, read it back through the cloud connector after the sync.
 
 ## Step 4 — Find: orient, then scan the pointers
 

--- a/.claude/skills/nauro-context/SKILL.md
+++ b/.claude/skills/nauro-context/SKILL.md
@@ -17,7 +17,7 @@ v1 targets the local-store path: the agent writes the brief to the local store o
 
 ## Step 1 — Author: write the brief file
 
-The agent writes the brief body to `<store>/context/<slug>.md` using its own filesystem write. The CLI push enumerates the whole store, so a file under `context/` syncs with no code change.
+The agent writes the brief body to `<store>/context/<slug>.md` using its own filesystem write. Resolve `<store>` by running `nauro status`, which prints the absolute store path; the store lives at `~/.nauro/projects/<id>/`, outside any repo, so it cannot be guessed from the working directory. The CLI push enumerates the whole store, so a file under `context/` syncs with no code change.
 
 The slug is `<origin>-<topic>-<YYYYMMDD>-<short-uid>`, for example `codex-auth-migration-20260605-h7k2`. `<origin>` is your surface or agent tag, `<topic>` is a short kebab-case subject, `<YYYYMMDD>` is today's date, and `<short-uid>` is a few random or session-derived characters. The short-uid is load-bearing: two agents on separate machines reconcile only at the shared store, so entropy in the slug — not a lock — is what keeps their briefs from colliding. Briefs accumulate append-only under `context/` — never overwrite or delete an existing brief. If the chosen slug already exists, add a disambiguator rather than replacing it.
 
@@ -25,11 +25,11 @@ The brief opens with YAML frontmatter. Required: `author` (your surface or agent
 
 ## Step 2 — Author: flag the discovery pointer
 
-The agent calls `flag_question(question="BRIEF: context/<slug>.md — <one-line summary>")`. This flagged question is how other agents discover the brief. It lives in `open-questions.md`, which is set-union-merged and lock-protected on sync, so pointers from concurrent authors all survive. A shared index file is deliberately not used: it would not be union-merged, so concurrent appends would be lost under last-writer-wins. The `BRIEF:` marker text is literal so the Find flow can locate it.
+The agent calls `flag_question(question="BRIEF: context/<slug>.md — <one-line summary>")`. This flagged question is how other agents discover the brief. It lives in `open-questions.md`, which is set-union-merged on sync, so pointers from concurrent authors all survive. A shared index file is deliberately not used: it would not be union-merged, so concurrent appends would be lost under last-writer-wins. The `BRIEF:` marker text is literal so the Find flow can locate it.
 
 ## Step 3 — Author: sync
 
-The agent tells the user to run `nauro sync` from the repo, or runs it. This pushes the store so `context/<slug>.md` and the `open-questions.md` pointer travel together. A brief over `MAX_BRIEF_BYTES` is skipped from the push with a loud warning and kept on disk; if that happens, trim the brief under the cap and sync again rather than assuming it was shared.
+The agent tells the user to run `nauro sync` from the repo, or runs it. This pushes the store so `context/<slug>.md` and the `open-questions.md` pointer travel together. A brief over `MAX_BRIEF_BYTES` is skipped from the push with a loud warning and kept on disk; if that happens, trim the brief under the cap and sync again rather than assuming it was shared. Reading the brief back with a local `get_raw_file` confirms only that it is on disk, not that it propagated; to confirm it reached the shared store, read it back through the cloud connector after the sync.
 
 ## Step 4 — Find: orient, then scan the pointers
 

--- a/.cursor/rules/nauro-context.mdc
+++ b/.cursor/rules/nauro-context.mdc
@@ -17,7 +17,7 @@ v1 targets the local-store path: the agent writes the brief to the local store o
 
 ## Step 1 — Author: write the brief file
 
-The agent writes the brief body to `<store>/context/<slug>.md` using its own filesystem write. The CLI push enumerates the whole store, so a file under `context/` syncs with no code change.
+The agent writes the brief body to `<store>/context/<slug>.md` using its own filesystem write. Resolve `<store>` by running `nauro status`, which prints the absolute store path; the store lives at `~/.nauro/projects/<id>/`, outside any repo, so it cannot be guessed from the working directory. The CLI push enumerates the whole store, so a file under `context/` syncs with no code change.
 
 The slug is `<origin>-<topic>-<YYYYMMDD>-<short-uid>`, for example `codex-auth-migration-20260605-h7k2`. `<origin>` is your surface or agent tag, `<topic>` is a short kebab-case subject, `<YYYYMMDD>` is today's date, and `<short-uid>` is a few random or session-derived characters. The short-uid is load-bearing: two agents on separate machines reconcile only at the shared store, so entropy in the slug — not a lock — is what keeps their briefs from colliding. Briefs accumulate append-only under `context/` — never overwrite or delete an existing brief. If the chosen slug already exists, add a disambiguator rather than replacing it.
 
@@ -25,11 +25,11 @@ The brief opens with YAML frontmatter. Required: `author` (your surface or agent
 
 ## Step 2 — Author: flag the discovery pointer
 
-The agent calls `flag_question(question="BRIEF: context/<slug>.md — <one-line summary>")`. This flagged question is how other agents discover the brief. It lives in `open-questions.md`, which is set-union-merged and lock-protected on sync, so pointers from concurrent authors all survive. A shared index file is deliberately not used: it would not be union-merged, so concurrent appends would be lost under last-writer-wins. The `BRIEF:` marker text is literal so the Find flow can locate it.
+The agent calls `flag_question(question="BRIEF: context/<slug>.md — <one-line summary>")`. This flagged question is how other agents discover the brief. It lives in `open-questions.md`, which is set-union-merged on sync, so pointers from concurrent authors all survive. A shared index file is deliberately not used: it would not be union-merged, so concurrent appends would be lost under last-writer-wins. The `BRIEF:` marker text is literal so the Find flow can locate it.
 
 ## Step 3 — Author: sync
 
-The agent tells the user to run `nauro sync` from the repo, or runs it. This pushes the store so `context/<slug>.md` and the `open-questions.md` pointer travel together. A brief over `MAX_BRIEF_BYTES` is skipped from the push with a loud warning and kept on disk; if that happens, trim the brief under the cap and sync again rather than assuming it was shared.
+The agent tells the user to run `nauro sync` from the repo, or runs it. This pushes the store so `context/<slug>.md` and the `open-questions.md` pointer travel together. A brief over `MAX_BRIEF_BYTES` is skipped from the push with a loud warning and kept on disk; if that happens, trim the brief under the cap and sync again rather than assuming it was shared. Reading the brief back with a local `get_raw_file` confirms only that it is on disk, not that it propagated; to confirm it reached the shared store, read it back through the cloud connector after the sync.
 
 ## Step 4 — Find: orient, then scan the pointers
 

--- a/packages/nauro/src/nauro/constants.py
+++ b/packages/nauro/src/nauro/constants.py
@@ -76,6 +76,14 @@ L0_TOKEN_LIMIT = 3500
 FLAG_QUESTION_HINT_MIN_SCORE = 0.7
 FLAG_QUESTION_HINT_TITLE_LENGTH = 100
 
+# ── Discovery-pointer flag markers ──
+# The nauro-handoff (RESUME) and nauro-context (BRIEF) skills flag a stored
+# file's path as a question (it lands on the union-merged open-questions.md).
+# Such a flag is a discovery pointer, not a question for human review, so the
+# similar-decision hint above is skipped for it — otherwise a pointer draws a
+# spurious "addressed by decision-NNN" annotation.
+POINTER_FLAG_PREFIXES: tuple[str, ...] = ("BRIEF:", "RESUME:")
+
 # ── Writer limits ──
 SLUG_MAX_LENGTH = 60
 

--- a/packages/nauro/src/nauro/mcp/tools.py
+++ b/packages/nauro/src/nauro/mcp/tools.py
@@ -51,6 +51,7 @@ from nauro_core.validation import (
 from nauro.constants import (
     FLAG_QUESTION_HINT_MIN_SCORE,
     FLAG_QUESTION_HINT_TITLE_LENGTH,
+    POINTER_FLAG_PREFIXES,
 )
 from nauro.onboarding import (
     NO_CONTEXT_YET,
@@ -493,7 +494,10 @@ def tool_flag_question(
             return err
 
     hint = None
-    if question:
+    # Skip the similar-decision hint for discovery pointers (BRIEF:/RESUME:):
+    # they are file pointers, not questions for review, so a "addressed by
+    # decision-NNN" annotation on them is pure noise. The flag still logs.
+    if question and not question.lstrip().startswith(POINTER_FLAG_PREFIXES):
         pseudo_proposal = {
             "title": question[:FLAG_QUESTION_HINT_TITLE_LENGTH],
             "rationale": question + (f" {context}" if context else ""),

--- a/packages/nauro/src/nauro/skills/context_body.md
+++ b/packages/nauro/src/nauro/skills/context_body.md
@@ -18,7 +18,7 @@ v1 targets the local-store path: the agent writes the brief to the local store o
 
 ## Step 1 — Author: write the brief file
 
-The agent writes the brief body to `<store>/context/<slug>.md` using its own filesystem write. The CLI push enumerates the whole store, so a file under `context/` syncs with no code change.
+The agent writes the brief body to `<store>/context/<slug>.md` using its own filesystem write. Resolve `<store>` by running `nauro status`, which prints the absolute store path; the store lives at `~/.nauro/projects/<id>/`, outside any repo, so it cannot be guessed from the working directory. The CLI push enumerates the whole store, so a file under `context/` syncs with no code change.
 
 The slug is `<origin>-<topic>-<YYYYMMDD>-<short-uid>`, for example `codex-auth-migration-20260605-h7k2`. `<origin>` is your surface or agent tag, `<topic>` is a short kebab-case subject, `<YYYYMMDD>` is today's date, and `<short-uid>` is a few random or session-derived characters. The short-uid is load-bearing: two agents on separate machines reconcile only at the shared store, so entropy in the slug — not a lock — is what keeps their briefs from colliding. Briefs accumulate append-only under `context/` — never overwrite or delete an existing brief. If the chosen slug already exists, add a disambiguator rather than replacing it.
 
@@ -26,11 +26,11 @@ The brief opens with YAML frontmatter. Required: `author` (your surface or agent
 
 ## Step 2 — Author: flag the discovery pointer
 
-The agent calls `flag_question(question="BRIEF: context/<slug>.md — <one-line summary>")`. This flagged question is how other agents discover the brief. It lives in `open-questions.md`, which is set-union-merged and lock-protected on sync, so pointers from concurrent authors all survive. A shared index file is deliberately not used: it would not be union-merged, so concurrent appends would be lost under last-writer-wins. The `BRIEF:` marker text is literal so the Find flow can locate it.
+The agent calls `flag_question(question="BRIEF: context/<slug>.md — <one-line summary>")`. This flagged question is how other agents discover the brief. It lives in `open-questions.md`, which is set-union-merged on sync, so pointers from concurrent authors all survive. A shared index file is deliberately not used: it would not be union-merged, so concurrent appends would be lost under last-writer-wins. The `BRIEF:` marker text is literal so the Find flow can locate it.
 
 ## Step 3 — Author: sync
 
-The agent tells the user to run `nauro sync` from the repo, or runs it. This pushes the store so `context/<slug>.md` and the `open-questions.md` pointer travel together. A brief over `MAX_BRIEF_BYTES` is skipped from the push with a loud warning and kept on disk; if that happens, trim the brief under the cap and sync again rather than assuming it was shared.
+The agent tells the user to run `nauro sync` from the repo, or runs it. This pushes the store so `context/<slug>.md` and the `open-questions.md` pointer travel together. A brief over `MAX_BRIEF_BYTES` is skipped from the push with a loud warning and kept on disk; if that happens, trim the brief under the cap and sync again rather than assuming it was shared. Reading the brief back with a local `get_raw_file` confirms only that it is on disk, not that it propagated; to confirm it reached the shared store, read it back through the cloud connector after the sync.
 
 ## Step 4 — Find: orient, then scan the pointers
 

--- a/packages/nauro/tests/test_flag_question_hint.py
+++ b/packages/nauro/tests/test_flag_question_hint.py
@@ -14,6 +14,7 @@ import pytest
 from nauro.constants import (
     FLAG_QUESTION_HINT_MIN_SCORE,
     FLAG_QUESTION_HINT_TITLE_LENGTH,
+    POINTER_FLAG_PREFIXES,
 )
 from nauro.mcp.tools import tool_flag_question
 from nauro.templates.scaffolds import scaffold_project_store
@@ -61,3 +62,30 @@ def test_hint_absent_below_threshold(store):
         result = tool_flag_question(store, question="Should we cache hot reads?")
 
     assert "hint" not in result
+
+
+def test_pointer_flag_prefixes_constant():
+    assert POINTER_FLAG_PREFIXES == ("BRIEF:", "RESUME:")
+
+
+@pytest.mark.parametrize(
+    "pointer",
+    [
+        "BRIEF: context/origin-topic-20260605-ab12.md — a shared brief",
+        "RESUME: handoffs/auth-cutover.md — wip handoff",
+        "  BRIEF: context/x.md — leading whitespace still skips the hint",
+    ],
+)
+def test_hint_skipped_for_discovery_pointers(store, pointer):
+    """BRIEF:/RESUME: discovery pointers are file pointers, not questions for
+    review, so the similar-decision hint is skipped even when BM25 scores above
+    threshold. The flag itself still logs."""
+    above = FLAG_QUESTION_HINT_MIN_SCORE + 0.1
+    with (
+        patch("nauro.mcp.tools.check_bm25_similarity", return_value=_stub_similar(above)),
+        patch("nauro.mcp.tools._try_push"),
+    ):
+        result = tool_flag_question(store, question=pointer)
+
+    assert "hint" not in result
+    assert result["status"] == "ok"  # the pointer still logged; only the hint is skipped

--- a/packages/nauro/tests/test_skills_drift.py
+++ b/packages/nauro/tests/test_skills_drift.py
@@ -108,6 +108,13 @@ def test_load_context_body_returns_canonical_bytes():
     # on the union-merged open-questions.md, never a shared index file.
     assert "context/" in body
     assert "BRIEF:" in body
+    # Regression (dogfood-verified): the discovery surface survives concurrent
+    # authors because open-questions.md is set-union-merged on sync — NOT because
+    # of a lock (the store lock guards only same-machine local appends). The
+    # corrected skill must not reintroduce the wrong "lock-protected" claim, and
+    # must teach the agent how to resolve the store path it writes into.
+    assert "lock-protected" not in body
+    assert "nauro status" in body
     # Like nauro-handoff, the skill runs in the main-agent context with no
     # tool-lock, so it must only DRAFT decisions for the user to file -- it
     # never autonomously commits doctrine. Load-bearing guard for that.


### PR DESCRIPTION
## Why

Dogfooding `nauro-context` in a second session (on the same machine, as a cold agent) surfaced a factual error in shipped code plus three smaller rough edges. The important one: `context_body.md` told agents `open-questions.md` is "lock-protected on sync" — verified false against the code. The store lock guards only same-machine local appends; the sync write-back is unlocked. Concurrent-author survival comes from **set-union-merge alone**. An agent could otherwise lean on a guarantee that isn't there.

## What changed

- **`context_body.md`** — correct the concurrency claim (set-union-merged on sync, no lock); add store-path resolution (`nauro status` prints the absolute path, since the store lives outside any repo); warn that a local `get_raw_file` proves on-disk, not propagation. Drift guards now fail if the wrong claim returns or the store-path guidance is dropped.
- **`flag_question`** — skip the "addressed by decision-NNN" similar-decision hint for `BRIEF:`/`RESUME:` discovery pointers. They are file pointers, not questions for review, so the hint was pure noise. Adds a `POINTER_FLAG_PREFIXES` constant, a local guard, and tests. Verified local-only — the remote server doesn't replicate this computation.
- Regenerated the three `nauro-context` skill surfaces from the corrected body.

## What to review

- The corrected concurrency sentence in `context_body.md` Step 2 — the load-bearing fix. The same wrong phrasing also exists in the governing decision's rationale; a separate decision update corrects that.
- The `flag_question` guard placement: it skips only the hint computation; the flag still logs normally.

## Test plan

- `uv run pytest packages/nauro-core/tests packages/nauro/tests -q` → **2008 passed, 10 skipped**.
- `ruff check` + `ruff format --check` — clean.
- New: parametrized pointer-flag-skips-hint tests; drift regression guards pinning the corrected claim and store-path guidance.
