### PR TITLE
fix(nauro-handoff): teach store-path resolution and round-trip confirmation

### DIFF
--- a/.agents/skills/nauro-handoff/SKILL.md
+++ b/.agents/skills/nauro-handoff/SKILL.md
@@ -19,7 +19,7 @@ The agent calls `get_context(level="L1")` to ground the handoff in the current s
 
 ## Step 2 — Capture: write the handoff file
 
-The agent writes the full handoff body to `<store>/handoffs/<slug>.md` using its own filesystem write. The CLI push enumerates the whole store, so a file under `handoffs/` syncs with no code change. Choose a short kebab-case `<slug>`, for example `auth-refresh-cutover`.
+The agent writes the full handoff body to `<store>/handoffs/<slug>.md` using its own filesystem write. Resolve `<store>` by running `nauro status`, which prints the absolute store path; the store lives at `~/.nauro/projects/<id>/`, outside any repo, so it cannot be guessed from the working directory. The CLI push enumerates the whole store, so a file under `handoffs/` syncs with no code change. Choose a short kebab-case `<slug>`, for example `auth-refresh-cutover`.
 
 The handoff body states what shipped this session, what is still in flight, any branches, stashes, or worktrees left open, the cited pointers a resumer must verify (decision numbers, file paths, PR or branch names), and the next concrete step. Handoffs accumulate append-only under `handoffs/` — never overwrite a prior handoff and never delete one.
 
@@ -43,7 +43,7 @@ Then it asks the user to confirm, and waits for explicit approval. Auto-mode and
 
 ## Step 6 — Capture: sync
 
-On approval, the agent tells the user to run `nauro sync` from the repo, or runs it. This pushes the store so `handoffs/<slug>.md`, `state_current.md`, and `open-questions.md` travel together. This is the only step that leaves the local store.
+On approval, the agent tells the user to run `nauro sync` from the repo, or runs it. This pushes the store so `handoffs/<slug>.md`, `state_current.md`, and `open-questions.md` travel together. This is the only step that leaves the local store. Reading the handoff back with a local `get_raw_file` confirms only that it is on disk, not that it propagated; to confirm it reached the shared store, read it back through the cloud connector after the sync.
 
 ## Step 7 — Resume: read context
 

--- a/.claude/skills/nauro-handoff/SKILL.md
+++ b/.claude/skills/nauro-handoff/SKILL.md
@@ -19,7 +19,7 @@ The agent calls `get_context(level="L1")` to ground the handoff in the current s
 
 ## Step 2 — Capture: write the handoff file
 
-The agent writes the full handoff body to `<store>/handoffs/<slug>.md` using its own filesystem write. The CLI push enumerates the whole store, so a file under `handoffs/` syncs with no code change. Choose a short kebab-case `<slug>`, for example `auth-refresh-cutover`.
+The agent writes the full handoff body to `<store>/handoffs/<slug>.md` using its own filesystem write. Resolve `<store>` by running `nauro status`, which prints the absolute store path; the store lives at `~/.nauro/projects/<id>/`, outside any repo, so it cannot be guessed from the working directory. The CLI push enumerates the whole store, so a file under `handoffs/` syncs with no code change. Choose a short kebab-case `<slug>`, for example `auth-refresh-cutover`.
 
 The handoff body states what shipped this session, what is still in flight, any branches, stashes, or worktrees left open, the cited pointers a resumer must verify (decision numbers, file paths, PR or branch names), and the next concrete step. Handoffs accumulate append-only under `handoffs/` — never overwrite a prior handoff and never delete one.
 
@@ -43,7 +43,7 @@ Then it asks the user to confirm, and waits for explicit approval. Auto-mode and
 
 ## Step 6 — Capture: sync
 
-On approval, the agent tells the user to run `nauro sync` from the repo, or runs it. This pushes the store so `handoffs/<slug>.md`, `state_current.md`, and `open-questions.md` travel together. This is the only step that leaves the local store.
+On approval, the agent tells the user to run `nauro sync` from the repo, or runs it. This pushes the store so `handoffs/<slug>.md`, `state_current.md`, and `open-questions.md` travel together. This is the only step that leaves the local store. Reading the handoff back with a local `get_raw_file` confirms only that it is on disk, not that it propagated; to confirm it reached the shared store, read it back through the cloud connector after the sync.
 
 ## Step 7 — Resume: read context
 

--- a/.cursor/rules/nauro-handoff.mdc
+++ b/.cursor/rules/nauro-handoff.mdc
@@ -19,7 +19,7 @@ The agent calls `get_context(level="L1")` to ground the handoff in the current s
 
 ## Step 2 — Capture: write the handoff file
 
-The agent writes the full handoff body to `<store>/handoffs/<slug>.md` using its own filesystem write. The CLI push enumerates the whole store, so a file under `handoffs/` syncs with no code change. Choose a short kebab-case `<slug>`, for example `auth-refresh-cutover`.
+The agent writes the full handoff body to `<store>/handoffs/<slug>.md` using its own filesystem write. Resolve `<store>` by running `nauro status`, which prints the absolute store path; the store lives at `~/.nauro/projects/<id>/`, outside any repo, so it cannot be guessed from the working directory. The CLI push enumerates the whole store, so a file under `handoffs/` syncs with no code change. Choose a short kebab-case `<slug>`, for example `auth-refresh-cutover`.
 
 The handoff body states what shipped this session, what is still in flight, any branches, stashes, or worktrees left open, the cited pointers a resumer must verify (decision numbers, file paths, PR or branch names), and the next concrete step. Handoffs accumulate append-only under `handoffs/` — never overwrite a prior handoff and never delete one.
 
@@ -43,7 +43,7 @@ Then it asks the user to confirm, and waits for explicit approval. Auto-mode and
 
 ## Step 6 — Capture: sync
 
-On approval, the agent tells the user to run `nauro sync` from the repo, or runs it. This pushes the store so `handoffs/<slug>.md`, `state_current.md`, and `open-questions.md` travel together. This is the only step that leaves the local store.
+On approval, the agent tells the user to run `nauro sync` from the repo, or runs it. This pushes the store so `handoffs/<slug>.md`, `state_current.md`, and `open-questions.md` travel together. This is the only step that leaves the local store. Reading the handoff back with a local `get_raw_file` confirms only that it is on disk, not that it propagated; to confirm it reached the shared store, read it back through the cloud connector after the sync.
 
 ## Step 7 — Resume: read context
 

--- a/packages/nauro/src/nauro/skills/handoff_body.md
+++ b/packages/nauro/src/nauro/skills/handoff_body.md
@@ -20,7 +20,7 @@ The agent calls `get_context(level="L1")` to ground the handoff in the current s
 
 ## Step 2 — Capture: write the handoff file
 
-The agent writes the full handoff body to `<store>/handoffs/<slug>.md` using its own filesystem write. The CLI push enumerates the whole store, so a file under `handoffs/` syncs with no code change. Choose a short kebab-case `<slug>`, for example `auth-refresh-cutover`.
+The agent writes the full handoff body to `<store>/handoffs/<slug>.md` using its own filesystem write. Resolve `<store>` by running `nauro status`, which prints the absolute store path; the store lives at `~/.nauro/projects/<id>/`, outside any repo, so it cannot be guessed from the working directory. The CLI push enumerates the whole store, so a file under `handoffs/` syncs with no code change. Choose a short kebab-case `<slug>`, for example `auth-refresh-cutover`.
 
 The handoff body states what shipped this session, what is still in flight, any branches, stashes, or worktrees left open, the cited pointers a resumer must verify (decision numbers, file paths, PR or branch names), and the next concrete step. Handoffs accumulate append-only under `handoffs/` — never overwrite a prior handoff and never delete one.
 
@@ -44,7 +44,7 @@ Then it asks the user to confirm, and waits for explicit approval. Auto-mode and
 
 ## Step 6 — Capture: sync
 
-On approval, the agent tells the user to run `nauro sync` from the repo, or runs it. This pushes the store so `handoffs/<slug>.md`, `state_current.md`, and `open-questions.md` travel together. This is the only step that leaves the local store.
+On approval, the agent tells the user to run `nauro sync` from the repo, or runs it. This pushes the store so `handoffs/<slug>.md`, `state_current.md`, and `open-questions.md` travel together. This is the only step that leaves the local store. Reading the handoff back with a local `get_raw_file` confirms only that it is on disk, not that it propagated; to confirm it reached the shared store, read it back through the cloud connector after the sync.
 
 ## Step 7 — Resume: read context
 

--- a/packages/nauro/tests/test_skills_drift.py
+++ b/packages/nauro/tests/test_skills_drift.py
@@ -82,6 +82,9 @@ def test_load_handoff_body_returns_canonical_bytes():
     # pointer is a flagged question -- not folded into state (avoids the
     # update_state REPLACE-clobber surface).
     assert "handoffs/" in body
+    # Parity with nauro-context: the skill must teach the agent how to resolve
+    # the store path it writes into (the store lives outside any repo).
+    assert "nauro status" in body
     # The skill runs in the main-agent context with no tool-lock, so it must
     # only DRAFT decisions for the user to file -- it never autonomously
     # commits doctrine. This assertion is the load-bearing guard for that.


### PR DESCRIPTION
## Why

`nauro-context`'s dogfooding surfaced two skill-usability gaps that `nauro-handoff` shares (both skills write a file directly into the store): it never tells the agent how to resolve `<store>` — which lives at `~/.nauro/projects/<id>/`, outside any repo, so it can't be guessed from the cwd — and it doesn't warn that a local `get_raw_file` confirms on-disk, not propagation.

## What changed

`handoff_body.md` gains the same two lines the context skill got in the dogfooding-corrections PR: resolve `<store>` via `nauro status` (Step 2), and the round-trip caution (Step 6). Regenerated the three handoff surfaces; a drift guard pins the store-path guidance so it can't silently drop.

The lock-claim correction from that PR was context-only — `nauro-handoff` never made the "lock-protected" claim, so nothing else carries over.

## Test plan

- `uv run pytest packages/nauro-core/tests packages/nauro/tests -q` → 2008 passed, 10 skipped.
- `ruff check` + `ruff format --check` clean. Drift/signature suites green against the regenerated surfaces.
