### PR TITLE
docs: align operation references with code (CLI, MCP, config, skills)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Nauro is a versioned project context system for AI coding agents. This is a `uv`
 | `nauro` | `packages/nauro/` | 3.10+ | CLI + local MCP server (stdio). Reads/writes `~/.nauro/projects/` |
 | `nauro-core` | `packages/nauro-core/` | 3.10+ | Shared pure-Python logic: parsing, validation, context assembly, constants. No I/O; compute-only deps. |
 
-Each package has its own `CLAUDE.md`, `pyproject.toml`, and test suite. The remote MCP server (`mcp-server/`) lives in a separate private repository.
+Each package has its own `pyproject.toml` and test suite; `packages/nauro/` also carries a package-level `CLAUDE.md` (nauro-core does not). The remote MCP server (`mcp-server/`) lives in a separate private repository.
 
 ## The one architectural fact that matters
 
@@ -46,8 +46,8 @@ All files are freeform markdown. No database. No JSON for content — JSON only 
 
 ## Config and credentials
 
-User config lives at `~/.nauro/config.json` (written by `nauro auth login` and other feature-specific commands; inspect with `nauro config get/list/unset`):
-- `auth.access_token`, `auth.refresh_token`, `auth.sub` → Auth0 bearer for the presign sync endpoints
+User config lives at `~/.nauro/config.json` (written by `nauro auth login` and other feature-specific commands; inspect with `nauro config get/list/unset`, which resolve top-level keys only):
+- `auth` object — credentials from `nauro auth login`, nested under one top-level `auth` key (so inspect with `nauro config get auth`, not a dotted path): `access_token` is the Auth0 bearer sent to the presign sync endpoints; `refresh_token` mints a fresh access token when the bearer expires; `sub` is the raw JWT subject id (identity; the block also persists `sanitized_sub` and `user_id`)
 - Auth0 domain, client ID, API URL, and audience ship as defaults in `cli/commands/auth.py`; env vars (`NAURO_AUTH0_*`, `NAURO_API_URL`) or config keys override (domain + client_id must be set as a pair)
 - `NAURO_HOME` env var overrides `~/.nauro/` for testing
 
@@ -60,14 +60,23 @@ User config lives at `~/.nauro/config.json` (written by `nauro auth login` and o
 
 ## CLI commands
 
+Principal commands (run `nauro --help` for the full surface):
+
 - `nauro init <name>` — register a new project in `~/.nauro/`, scaffold the store, associate repo paths
+- `nauro adopt` — adopt an existing repo: register it, wire MCP across surfaces, install the `/nauro-adopt` skill (`--with-skills` / `--with-subagents` add the opt-in skills and bundled subagents)
+- `nauro attach <project_id>` — associate the current repo with an existing cloud project
+- `nauro link` — promote a local-only project to cloud
 - `nauro note <text>` — append a decision (default) or question (if text ends with `?` or `--question` flag)
 - `nauro sync` — capture a snapshot, regenerate `AGENTS.md` in all associated repos
 - `nauro log` — list recent snapshots with metadata
-- `nauro diff-since-last-session [--days N]` — semantic diff against the previous snapshot (or N days back when supplied)
+- `nauro status` — capability table for the current project (active surfaces, absolute store path)
 - `nauro serve` — start the local MCP server (stdio transport)
 - `nauro import --memory-bank <path>` — migrate a Cline/Roo Code Memory Bank
 - `nauro import --adr <path>` — migrate Architecture Decision Records
+
+Command groups: `nauro setup <claude-code|cursor|codex|all>`, `nauro auth <login|status|logout>`, `nauro config <get|list|unset>`, `nauro telemetry <status|enable|disable|reset>`, `nauro validate`, `nauro projects`, `nauro questions`, `nauro hook`.
+
+The 10 read/write MCP tools are also mirrored as CLI commands — `nauro check-decision`, `nauro propose-decision`, `nauro get-context`, `nauro diff-since-last-session [--days N]`, … — auto-generated from the tool allowlist in `cli/autogen.py` (underscored tool names become hyphenated commands).
 
 ## MCP tools (11 total in `nauro_core.mcp_tools` — 8 read, 3 write)
 
@@ -148,7 +157,7 @@ packages/nauro-core/
     __init__.py            # public API
     constants.py           # shared constants
     context.py             # context assembly
-    format.py              # formatting utilities
+    decision_model.py      # Decision model + parse/format + protocol regexes
     parsing.py             # markdown/decision parsing
     validation.py          # structural validation
   tests/

--- a/docs/adopt-prompt.md
+++ b/docs/adopt-prompt.md
@@ -11,8 +11,10 @@ nauro adopt --name <your-project-name>
 ```
 
 That registers the project, wires MCP across surfaces, and installs the
-session + adopt skills. Once that has run, you can use the prompt below from
-any connected chat surface to seed the project's store with context.
+`nauro-adopt` skill. (The session skills — `nauro-handoff` and `nauro-context`
+— plus `nauro-ship-task` are opt-in via `nauro adopt --with-skills`.) Once that
+has run, you can use the prompt below from any connected chat surface to seed
+the project's store with context.
 
 If you have `nauro` installed locally, `nauro adopt --print-prompt` outputs
 this same body to stdout (without the intro paragraph above).

--- a/packages/nauro-core/README.md
+++ b/packages/nauro-core/README.md
@@ -10,11 +10,11 @@ pip install nauro-core
 
 ## What's inside
 
-- **`format`** — compiled regexes and parse/format functions for the Nauro markdown protocol (decision titles, metadata fields, section headers)
+- **`decision_model`** — the Pydantic `Decision` model plus compiled regexes and `parse_decision`/`format_decision` for the Nauro markdown protocol (decision titles, metadata fields, section headers)
 - **`constants`** — limits, thresholds, valid values, file paths shared across all Nauro surfaces
-- **`parsing`** — pure `str → dict` functions: `parse_decision`, `parse_questions`, `extract_stack_summary`, `decisions_summary_lines`
+- **`parsing`** — pure markdown→data helpers: `parse_questions`, `extract_stack_summary`, `decisions_summary_lines` (decision parsing lives in `decision_model.parse_decision`, which returns a validated `Decision`)
 - **`context`** — `build_l0`/`build_l1`/`build_l2` context assembly from pre-loaded files and parsed decisions
-- **`validation`** — structural screening, hash dedup, Jaccard similarity for decision conflict detection
+- **`validation`** — structural screening, hash dedup, BM25 similarity for decision conflict detection
 
 ## Design principles
 

--- a/packages/nauro/CLAUDE.md
+++ b/packages/nauro/CLAUDE.md
@@ -33,15 +33,23 @@ All files are freeform markdown. No database. No JSON for content — JSON only 
 
 ## CLI commands
 
+Principal commands (run `nauro --help` for the full surface):
+
 - `nauro init <name>` — register a new project in `~/.nauro/`, scaffold the store, associate repo paths
+- `nauro adopt` — adopt an existing repo: register it, wire MCP across surfaces, install the `/nauro-adopt` skill (`--with-skills` adds the opt-in skills; `--with-subagents` adds the bundled subagents)
+- `nauro attach <project_id>` — associate the current repo with an existing cloud project
+- `nauro link` — promote a local-only project to cloud
 - `nauro note <text>` — append a decision (default) or question (if text ends with `?` or `--question` flag)
 - `nauro sync` — capture a snapshot, regenerate `AGENTS.md` in all associated repos
 - `nauro log` — list recent snapshots with metadata
-- `nauro diff-since-last-session [--days N]` — semantic diff against the previous snapshot (or N days back when supplied)
-- `nauro propose-decision <title> <rationale> [--operation add|update|supersede] [--rejected JSON] [--files-affected PATH ...]` — record a decision (single-call commit on Tier 1 clean; Tier 2 BM25 hits surface as advisory `similar_decisions` on the same response)
+- `nauro status` — capability table for the current project (active surfaces, absolute store path)
 - `nauro serve` — start the local MCP server (stdio transport)
 - `nauro import --memory-bank <path>` — migrate a Cline/Roo Code Memory Bank
 - `nauro import --adr <path>` — migrate Architecture Decision Records
+
+Command groups: `setup <claude-code|cursor|codex|all>`, `auth <login|status|logout>`, `config <get|list|unset>`, `telemetry <status|enable|disable|reset>`, `validate`, `projects`, `questions`, `hook`.
+
+The 10 read/write MCP tools are also mirrored as CLI commands, auto-generated from the tool allowlist in `cli/autogen.py` (underscored tool names become hyphenated commands). For example: `nauro check-decision`, `nauro diff-since-last-session [--days N]`, and `nauro propose-decision <title> <rationale> [--operation add|update|supersede] [--rejected JSON] [--files-affected PATH ...]` (single-call commit on Tier 1 clean; Tier 2 BM25 hits surface as advisory `similar_decisions` on the same response).
 
 `list[str]` flags (`--files-affected`, `--resolves-questions`) repeat: `--files-affected a.py --files-affected b.py`. `list[dict]` flags (`--rejected`) take a single JSON value: inline (`'[{...}]'`), `@file.json`, or `-` to read from stdin.
 

--- a/packages/nauro/src/nauro/cli/commands/adopt.py
+++ b/packages/nauro/src/nauro/cli/commands/adopt.py
@@ -212,9 +212,9 @@ def adopt(
         False,
         "--with-skills",
         help=(
-            "Install Nauro's bundled opt-in skills (today: /nauro-ship-task) "
-            "alongside the always-installed /nauro-adopt skill. Independent "
-            "of --with-subagents."
+            "Install Nauro's bundled opt-in skills "
+            "(/nauro-ship-task, /nauro-handoff, /nauro-context) alongside the "
+            "always-installed /nauro-adopt skill. Independent of --with-subagents."
         ),
     ),
 ) -> None:

--- a/packages/nauro/src/nauro/cli/commands/setup.py
+++ b/packages/nauro/src/nauro/cli/commands/setup.py
@@ -833,8 +833,9 @@ def setup_all_surfaces(
     ``with_subagents`` is True and ``remove`` is False — it replaces
     locally-modified bundled files instead of preserving them.
 
-    ``with_skills`` opts into installing the bundled opt-in skills (today
-    just ``nauro-ship-task``). Independent of ``with_subagents`` so users
+    ``with_skills`` opts into installing the bundled opt-in skills
+    (``nauro-ship-task``, ``nauro-handoff``, ``nauro-context``). Independent of
+    ``with_subagents`` so users
     can adopt skills and subagents on separate cadences, though
     ``nauro-ship-task`` references the bundled ``@nauro-*`` subagents in
     its body — caller surfaces ``with_skills`` without ``with_subagents``
@@ -1003,9 +1004,9 @@ def all_(
         False,
         "--with-skills",
         help=(
-            "Install Nauro's bundled opt-in skills (today: /nauro-ship-task) "
-            "alongside the always-installed /nauro-adopt skill. Independent "
-            "of --with-subagents."
+            "Install Nauro's bundled opt-in skills "
+            "(/nauro-ship-task, /nauro-handoff, /nauro-context) alongside the "
+            "always-installed /nauro-adopt skill. Independent of --with-subagents."
         ),
     ),
     with_hooks: bool = typer.Option(


### PR DESCRIPTION
## Why

A pass over the codebase's "operations" (CLI commands, MCP tools, config keys, env vars, bundled skills) against every documentation surface turned up accumulated drift. Nothing was high-severity and the core architecture narrative held up, but several references had gone stale or were factually wrong — most notably the `nauro-core` README describing a module and an algorithm that don't exist. These are the docs an in-repo agent (or a new contributor) consults first, so wrong entries actively mislead.

## Approach

Treat code as ground truth and fix the docs to match — every discrepancy here was a documentation error, not a code bug, so no logic changed. For the two CLI-command catalogs that had fallen well behind the registered surface, the choice was "exhaustively list every command" vs. "curate + point at `nauro --help`". Chose the latter (relabel as a principal-commands subset, add the genuinely missing user-facing commands, and explain that the MCP-mirror commands are auto-generated) so the lists stay useful without re-drifting every time a command is added.

## What changed

- **`nauro-core` README** — three factual corrections: the `format` module → `decision_model` (where the regexes and `parse_decision`/`format_decision` actually live); "Jaccard similarity" → "BM25 similarity" (the validator delegates to `bm25_retrieve`); and `parse_decision` re-attributed out of the `parsing` bullet with its real return type.
- **Root + package `CLAUDE.md`** — refreshed the "CLI commands" sections (added `adopt`, `attach`, `link`, `status`, and the `setup`/`auth`/`config`/`telemetry`/`validate`/`projects`/`questions`/`hook` groups; noted the autogen MCP-mirror commands); removed the nonexistent `format.py` from the layout block; softened the "each package has its own `CLAUDE.md`" claim; and split the conflated `auth.*` gloss while clarifying `config get` resolves top-level keys only.
- **`docs/adopt-prompt.md`** — bare `nauro adopt` installs only the adopt skill; session skills are opt-in via `--with-skills`.
- **`adopt.py` / `setup.py`** — the `--with-skills` help string and docstring named only `nauro-ship-task`; now enumerate all three opt-in skills (`OPT_IN_SKILL_NAMES`).

## What to review

- The two `CLAUDE.md` CLI sections — confirm the curated command list and the autogen note read well and that the two files now agree.
- The `auth.*` rewrite in the root `CLAUDE.md` config section — it now distinguishes `access_token` (bearer) / `refresh_token` (refresh) / `sub` (identity) and explains the nesting; check the wording matches your mental model.

## What's deferred

Nothing functional. The CLI catalogs are deliberately a curated subset rather than an exhaustive mirror of `nauro --help`; if you'd prefer a generated, always-complete list, that's a separate follow-up.

## Test plan

No code paths changed, but ran the full suites and lint to be safe: `nauro-core` 747 passed; `nauro` 1294 passed, 10 skipped; `ruff check` + `ruff format --check` clean. Also rendered `nauro adopt --help` and `nauro setup all --help` to confirm the edited help text wraps correctly and lists all three opt-in skills.
