### PR TITLE
docs: front-load README with demo, mechanism, and real check output

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,21 @@
 
 Nauro gives AI agents persistent project context across Claude, Cursor, Codex, ChatGPT, and any MCP client. It captures decisions and rejected options, then checks new proposals against them so agents stop re-suggesting approaches you already ruled out.
 
-**Status:** Beta. 1.0 will be the first production release.
+[![PyPI](https://img.shields.io/pypi/v/nauro.svg)](https://pypi.org/project/nauro/) [![Python](https://img.shields.io/pypi/pyversions/nauro.svg)](https://pypi.org/project/nauro/) [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
+
+https://github.com/user-attachments/assets/9e6c475b-c584-470b-84c2-12f01b3a425a
+
+*A coding agent checks the team's prior decisions before it answers, then records the new one you approved and makes the change. Captured in Codex.*
+
+**Status:** Beta (pre-1.0). The local CLI and stdio MCP server are stable; cloud sync is stabilizing.
 
 More at [nauro.ai](https://nauro.ai).
+
+## How it works
+
+Nauro stores your project's decisions as plain markdown files, each with the alternatives you ruled out and the reasoning behind them. When an agent proposes an approach, `check_decision` runs deterministic keyword retrieval (BM25) over those files and surfaces the related ones to the agent before it writes code.
+
+No model judges your decisions. The check is advisory and never blocks a change. You approve every decision before it is recorded. The store is a folder you own; remove Nauro and the markdown stays.
 
 ## Install
 
@@ -14,9 +26,9 @@ pipx install nauro   # or: pip install nauro
 
 Requires Python 3.10+.
 
-https://github.com/user-attachments/assets/9e6c475b-c584-470b-84c2-12f01b3a425a
-
 ## Quickstart
+
+No account, no MCP wiring, no restart:
 
 ```bash
 mkdir -p /tmp/nauro-demo && cd /tmp/nauro-demo
@@ -24,7 +36,37 @@ nauro init --demo
 nauro check-decision "Add a WebSocket endpoint for live task updates"
 ```
 
-The demo includes a decision that rejected WebSocket for SSE. `nauro check-decision` runs the MCP `check_decision` tool against your local store and surfaces that decision before your agent re-proposes it.
+The demo store holds seven real decisions. One of them ruled out WebSocket in favor of SSE, and `check-decision` surfaces it as the top match before your agent can re-propose it:
+
+```json
+{
+  "store": "local",
+  "related_decisions": [
+    {
+      "id": "decision-004",
+      "title": "SSE over WebSocket for live task updates",
+      "score": 5.015,
+      "status": "active",
+      "date": "2026-03-15",
+      "rationale_preview": "Server-Sent Events (SSE) for pushing live task updates to the frontend. SSE uses standard HTTP, reconnects automatically on disconnect, and works through every proxy and load balancer..."
+    }
+  ],
+  "assessment": "Found 5 related decisions. Top match: D004 \"SSE over WebSocket for live task updates\" (status active, decided 2026-03-15, BM25 5.0). Call get_decision on each related decision before proposing.",
+  "project": { "id": "01K...", "name": "demo-project" }
+}
+```
+
+Output abbreviated to the top match; the live call returns all five related decisions, ranked by score. The same result reaches your agent through the MCP `check_decision` tool, so it sees the prior decision in the flow rather than after the fact.
+
+## Why not ADRs, grep, or CLAUDE.md?
+
+A decision log in your repo is a good record. The gap is on the read side: a file is read when a person opens it, and a fresh agent session starts with no knowledge that it exists. Nauro closes that gap. The relevant decision reaches your agent automatically, through MCP, at the moment it proposes a change. The store lives outside any single repo, so one record is shared across every repo and tool instead of being trapped in one project's history.
+
+## When Nauro helps, and when it doesn't
+
+Nauro pays off when decisions recur across sessions, when more than one agent or developer touches the same project, and when re-litigating a settled choice is costly.
+
+The limits are worth knowing. It surfaces only what has been recorded as a decision. It adds an MCP round-trip to the agent's flow. Retrieval is keyword-based, which is fast, offline, and auditable, and can miss a decision phrased in different words than the proposal; an optional embeddings index is available for closer synonym matching.
 
 ## Adopt Nauro in your project
 


### PR DESCRIPTION
## Why

The repo README is the first surface a developer lands on when they find the project. Today it describes the conflict-catch in prose but never shows it, keeps the demo video below the install block, and never states the underlying mechanism. A skeptical reader who opens the repo to fact-check the headline finds neither the proof nor the honest primitive — and the strongest asset, the demo, is buried mid-page.

## Approach

Reorder to **sell → show → mechanism → install → quickstart → honest limits → reference**, the shape common to the dev-tool READMEs that convert well (uv, ripgrep, aider, Ollama).

Two deliberate choices:
- **Own the mechanism up front** rather than letting copy imply autonomy. The "How it works" block states plainly that retrieval is deterministic BM25, advisory, never blocking, and that a human approves every write. This pre-empts the "grep with a landing page" and "AI laundering rationale into permanent history" teardowns instead of conceding them.
- **Show real output, not a description.** The `check-decision` JSON block is the verbatim result of running the documented quickstart, so a reader who scrolls past the video to verify lands on something true and reproducible.

The video caption names the human-in-the-loop ("the new one you approved") so the write beat is not read as autonomous.

## What changed

README only. No code.

- Demo video moved above `## Install` and captioned.
- New `## How it works` (mechanism honesty).
- Real `check-decision` JSON output added under `## Quickstart`.
- New `## Why not ADRs, grep, or CLAUDE.md?` (positively framed).
- New `## When Nauro helps, and when it doesn't` (honest limits, including the keyword-retrieval vocabulary-mismatch limit and the optional embeddings index).
- PyPI / Python / license badges; sharper Beta status line.
- Everything from `## Adopt` down is unchanged.

## What to review

- The JSON block — confirm it matches current `nauro check-decision` output for the demo store on the release version (it was captured against the installed CLI in an isolated `NAURO_HOME`).
- The caption wording on the video.
- The "when it doesn't" section — it states limits in plain terms and deliberately cites no recall@k number.

## What's deferred

Repo-settings and cross-surface items, tracked separately: publishing a GitHub Release, setting repo topics + homepage link, a custom social-preview image, adding `SECURITY.md`, and the package (PyPI) README house-style cleanups.

## Test plan

- `nauro init --demo` + `nauro check-decision "Add a WebSocket endpoint for live task updates"` run in an isolated `NAURO_HOME`; the JSON in the README is the captured output (`decision-004` top at BM25 5.015).
- Verified the embedded attachment URL resolves (302 → signed CDN) and that GitHub renders it as a `<video>` player (checked the rendered README HTML).
- Diff is README-only (+46/−4); no em-dashes, no personal paths, no internal references.
