### PR TITLE
docs: add SECURITY.md with private vulnerability reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+## Supported versions
+
+Nauro is pre-1.0. Security fixes land on the latest published release of `nauro` and `nauro-core` on PyPI. Please upgrade to the latest version before reporting.
+
+## Reporting a vulnerability
+
+Please report security issues privately. Do not open a public issue for a suspected vulnerability.
+
+- Preferred: use GitHub's private vulnerability reporting — open the **Security** tab of this repository and click **Report a vulnerability**.
+- Or email **thomas@nauro.ai** with the details and, if possible, a proof of concept.
+
+We aim to acknowledge a report within 3 business days and to keep you updated as we investigate. Once a fix is available we will coordinate disclosure and credit you if you would like.
+
+## Scope
+
+The `nauro` CLI and `nauro-core` library in this repository are open source (Apache 2.0), so their behavior can be reviewed here. The hosted sync service (`mcp.nauro.ai`) is operated separately and is not part of this repository. Reports about either are welcome through the channels above.
+
+Issues we especially care about: leakage or mishandling of credentials and tokens, unauthorized access to a project's stored decisions, path traversal or arbitrary file read/write through the CLI or MCP server, and injection through stored decision content.


### PR DESCRIPTION
## Why

The repository had no security policy, so a researcher who found an issue had no private channel and would either open a public issue or post it elsewhere. Nauro brokers auth tokens and talks to a hosted sync service, so responsible disclosure needs a clear path.

## Approach

Add a minimal `SECURITY.md` and rely on GitHub's built-in private vulnerability reporting (now enabled on the repo) as the preferred channel, with an email fallback. The policy scopes what is in this repository (the Apache-2.0 CLI and `nauro-core`) versus the separately operated hosted service, so reporters know what they are looking at.

## What changed

- New `SECURITY.md` at the repo root: supported-versions note (pre-1.0, latest release), a private reporting path (GitHub Security tab → Report a vulnerability, or email), an acknowledgement-timeframe commitment, and a scope section listing the issue classes we most care about.

## What to review

- The acknowledgement window (3 business days) — adjust if you want a different commitment.
- The contact email (`thomas@nauro.ai`) — swap for a dedicated security alias if one exists.

## What's deferred

None. Repo-settings counterparts (topics, homepage link, branch-on-merge cleanup) were applied directly; the GitHub Release publish and stale-branch prune are handled separately.

## Test plan

Documentation only. Rendered the Markdown locally; GitHub will surface `SECURITY.md` in the Security tab and the "Report a vulnerability" flow once merged.
