### PR TITLE
auth: retry Auth0 token POSTs on HTTP 429 (graceful rate-limit handling)

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/auth.py
+++ b/packages/nauro/src/nauro/cli/commands/auth.py
@@ -15,6 +15,7 @@ import logging
 import os
 import secrets
 import threading
+import time
 import webbrowser
 from collections.abc import Callable, Mapping
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -46,6 +47,57 @@ class PartialAuthConfigError(Exception):
 
 class AuthRefreshError(Exception):
     """Raised when an Auth0 refresh-token exchange fails."""
+
+
+RATE_LIMITED_MESSAGE = (
+    "Auth0 is rate-limiting logins right now. Wait a few seconds and re-run 'nauro auth login'."
+)
+
+# Honor Retry-After up to this many seconds. A hostile or buggy header could
+# otherwise stall the CLI indefinitely; the ceiling keeps a retry bounded.
+_RETRY_AFTER_CEILING_SECONDS = 10.0
+# Fixed backoff per attempt when Retry-After is absent or unparseable.
+_DEFAULT_BACKOFF_SECONDS = (1.0, 2.0)
+
+
+def _retry_after_seconds(response: httpx.Response, attempt: int) -> float:
+    """Pick a backoff duration for a 429 retry.
+
+    Reads the integer-seconds form of the ``Retry-After`` header using plain
+    string operations and clamps it to a small ceiling. The HTTP-date form is
+    ignored. When the header is absent or unparseable, falls back to a short
+    per-attempt default.
+    """
+    value = response.headers.get("Retry-After")
+    if isinstance(value, str):
+        seconds = value.strip()
+        # ``str.isdigit`` accepts non-ASCII digit characters (e.g. superscript
+        # "²") that ``int`` then rejects, so gate on ASCII first.
+        if seconds.isascii() and seconds.isdigit():
+            return min(float(int(seconds)), _RETRY_AFTER_CEILING_SECONDS)
+    index = min(attempt - 1, len(_DEFAULT_BACKOFF_SECONDS) - 1)
+    return _DEFAULT_BACKOFF_SECONDS[index]
+
+
+def _post_with_429_retry(
+    make_request: Callable[[], httpx.Response], *, max_attempts: int = 3
+) -> httpx.Response:
+    """Run ``make_request`` and retry with backoff on HTTP 429.
+
+    ``make_request`` is a zero-arg callable returning an ``httpx.Response``;
+    each caller closes over its own URL, body, and timeout. Any non-429
+    response is returned immediately. On a 429 with attempts remaining, sleep
+    for the backoff interval and retry. A 429 on the final attempt is returned
+    as-is so the caller can render its own guidance — this helper never raises
+    and never emits user-facing messaging.
+    """
+    response = make_request()
+    for attempt in range(1, max_attempts):
+        if response.status_code != 429:
+            return response
+        time.sleep(_retry_after_seconds(response, attempt))
+        response = make_request()
+    return response
 
 
 def _resolve_auth_config(
@@ -123,17 +175,22 @@ def refresh_access_token() -> str:
         raise AuthRefreshError(str(exc)) from exc
 
     try:
-        response = httpx.post(
-            f"https://{domain}/oauth/token",
-            json={
-                "grant_type": "refresh_token",
-                "client_id": client_id,
-                "refresh_token": refresh_token,
-            },
-            timeout=15.0,
+        response = _post_with_429_retry(
+            lambda: httpx.post(
+                f"https://{domain}/oauth/token",
+                json={
+                    "grant_type": "refresh_token",
+                    "client_id": client_id,
+                    "refresh_token": refresh_token,
+                },
+                timeout=15.0,
+            )
         )
     except httpx.HTTPError as exc:
         raise AuthRefreshError(f"Network error contacting Auth0: {exc}") from exc
+
+    if response.status_code == 429:
+        raise AuthRefreshError(RATE_LIMITED_MESSAGE)
 
     if response.status_code != 200:
         try:
@@ -312,16 +369,22 @@ def login() -> None:
 
     # Exchange code for tokens
     try:
-        token_resp = httpx.post(
-            f"https://{domain}/oauth/token",
-            json={
-                "grant_type": "authorization_code",
-                "client_id": client_id,
-                "code": auth_code,
-                "redirect_uri": REDIRECT_URI,
-                "code_verifier": code_verifier,
-            },
+        token_resp = _post_with_429_retry(
+            lambda: httpx.post(
+                f"https://{domain}/oauth/token",
+                json={
+                    "grant_type": "authorization_code",
+                    "client_id": client_id,
+                    "code": auth_code,
+                    "redirect_uri": REDIRECT_URI,
+                    "code_verifier": code_verifier,
+                },
+                timeout=15.0,
+            )
         )
+        if token_resp.status_code == 429:
+            typer.echo(RATE_LIMITED_MESSAGE, err=True)
+            raise typer.Exit(code=1)
         token_resp.raise_for_status()
     except httpx.HTTPError as exc:
         typer.echo(f"Token exchange failed: {exc}", err=True)

--- a/packages/nauro/tests/test_auth.py
+++ b/packages/nauro/tests/test_auth.py
@@ -4,6 +4,7 @@ import base64
 import json
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 from nauro_core import sanitize_sub
 from typer.testing import CliRunner
@@ -245,8 +246,6 @@ class TestAuthLogin:
         def fake_server_close(self):
             pass
 
-        import httpx
-
         with (
             patch("nauro.cli.commands.auth.httpx.post", side_effect=fake_post),
             patch("nauro.cli.commands.auth.webbrowser.open"),
@@ -270,6 +269,153 @@ class TestAuthLogin:
 
         assert result.exit_code == 1
         assert "Token exchange failed" in result.output
+
+    def test_login_429_then_success(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("NAURO_API_URL", "https://test.api.example.com")
+
+        fake_token = _make_jwt({"sub": "auth0|user123"})
+
+        rate_limited = MagicMock()
+        rate_limited.status_code = 429
+        rate_limited.headers = {}
+
+        ok = MagicMock()
+        ok.status_code = 200
+        ok.headers = {}
+        ok.json.return_value = {
+            "access_token": fake_token,
+            "refresh_token": "refresh_xyz",
+            "token_type": "Bearer",
+        }
+        ok.raise_for_status = MagicMock()
+
+        post = MagicMock(side_effect=[rate_limited, ok])
+
+        def fake_server_init(self, addr, handler_class):
+            pass
+
+        def fake_handle_request(self):
+            _simulate_callback_success()
+
+        def fake_server_close(self):
+            pass
+
+        with (
+            patch("nauro.cli.commands.auth.httpx.post", post),
+            patch("nauro.cli.commands.auth.time.sleep"),
+            patch("nauro.cli.commands.auth.webbrowser.open"),
+            patch.object(
+                __import__("http.server", fromlist=["HTTPServer"]).HTTPServer,
+                "__init__",
+                fake_server_init,
+            ),
+            patch.object(
+                __import__("http.server", fromlist=["HTTPServer"]).HTTPServer,
+                "handle_request",
+                fake_handle_request,
+            ),
+            patch.object(
+                __import__("http.server", fromlist=["HTTPServer"]).HTTPServer,
+                "server_close",
+                fake_server_close,
+            ),
+        ):
+            result = runner.invoke(app, ["auth", "login"])
+
+        assert result.exit_code == 0
+        assert post.call_count == 2
+        config = load_config()
+        assert config["auth"]["sub"] == "auth0|user123"
+        assert config["auth"]["access_token"] == fake_token
+
+    def test_login_429_exhausted(self, tmp_path, monkeypatch):
+        rate_limited = MagicMock()
+        rate_limited.status_code = 429
+        rate_limited.headers = {}
+        post = MagicMock(return_value=rate_limited)
+
+        def fake_server_init(self, addr, handler_class):
+            pass
+
+        def fake_handle_request(self):
+            _simulate_callback_success()
+
+        def fake_server_close(self):
+            pass
+
+        with (
+            patch("nauro.cli.commands.auth.httpx.post", post),
+            patch("nauro.cli.commands.auth.time.sleep"),
+            patch("nauro.cli.commands.auth.webbrowser.open"),
+            patch.object(
+                __import__("http.server", fromlist=["HTTPServer"]).HTTPServer,
+                "__init__",
+                fake_server_init,
+            ),
+            patch.object(
+                __import__("http.server", fromlist=["HTTPServer"]).HTTPServer,
+                "handle_request",
+                fake_handle_request,
+            ),
+            patch.object(
+                __import__("http.server", fromlist=["HTTPServer"]).HTTPServer,
+                "server_close",
+                fake_server_close,
+            ),
+        ):
+            result = runner.invoke(app, ["auth", "login"])
+
+        assert result.exit_code == 1
+        assert "rate-limiting" in result.output
+        assert post.call_count == 3
+
+    def test_login_non_429_failure_does_not_retry(self, tmp_path, monkeypatch):
+        bad = MagicMock()
+        bad.status_code = 400
+        bad.headers = {}
+        bad.raise_for_status = MagicMock(
+            side_effect=httpx.HTTPStatusError(
+                "400 Bad Request",
+                request=MagicMock(),
+                response=MagicMock(status_code=400),
+            )
+        )
+        post = MagicMock(return_value=bad)
+
+        def fake_server_init(self, addr, handler_class):
+            pass
+
+        def fake_handle_request(self):
+            _simulate_callback_success()
+
+        def fake_server_close(self):
+            pass
+
+        with (
+            patch("nauro.cli.commands.auth.httpx.post", post),
+            patch("nauro.cli.commands.auth.time.sleep") as sleep,
+            patch("nauro.cli.commands.auth.webbrowser.open"),
+            patch.object(
+                __import__("http.server", fromlist=["HTTPServer"]).HTTPServer,
+                "__init__",
+                fake_server_init,
+            ),
+            patch.object(
+                __import__("http.server", fromlist=["HTTPServer"]).HTTPServer,
+                "handle_request",
+                fake_handle_request,
+            ),
+            patch.object(
+                __import__("http.server", fromlist=["HTTPServer"]).HTTPServer,
+                "server_close",
+                fake_server_close,
+            ),
+        ):
+            result = runner.invoke(app, ["auth", "login"])
+
+        assert result.exit_code == 1
+        assert post.call_count == 1
+        sleep.assert_not_called()
 
 
 # --- auth status ---

--- a/packages/nauro/tests/test_auth_refresh.py
+++ b/packages/nauro/tests/test_auth_refresh.py
@@ -37,11 +37,14 @@ def _seed_auth(refresh_token: str = "refresh_orig", access_token: str = "access_
     )
 
 
-def _mock_post(status_code: int = 200, payload: dict | None = None):
+def _mock_post(status_code: int = 200, payload: dict | None = None, headers: dict | None = None):
     response = MagicMock(spec=httpx.Response)
     response.status_code = status_code
     response.json.return_value = payload or {}
     response.text = str(payload or "")
+    # spec=httpx.Response does not expose ``headers`` as a mock attribute, so
+    # the 429 backoff path needs a real mapping to read Retry-After from.
+    response.headers = headers or {}
     return response
 
 
@@ -130,6 +133,100 @@ class TestRefreshAccessToken:
 
         with pytest.raises(AuthRefreshError, match="No refresh token"):
             refresh_access_token()
+
+
+# --- refresh_access_token 429 backoff ---
+
+
+class TestRefreshRateLimitBackoff:
+    def test_429_then_200_retries_and_succeeds(self):
+        _seed_auth(refresh_token="refresh_orig", access_token="access_orig")
+
+        rate_limited = _mock_post(429, {"error": "too_many_requests"})
+        ok = _mock_post(200, {"access_token": "access_new"})
+        post = MagicMock(side_effect=[rate_limited, ok])
+
+        with (
+            patch("nauro.cli.commands.auth.httpx.post", post),
+            patch("nauro.cli.commands.auth.time.sleep") as sleep,
+        ):
+            new_token = refresh_access_token()
+
+        assert new_token == "access_new"
+        assert load_config()["auth"]["access_token"] == "access_new"
+        assert post.call_count == 2
+        assert sleep.call_count == 1
+
+    def test_429_exhausted_raises_and_preserves_tokens(self):
+        _seed_auth(refresh_token="refresh_orig", access_token="access_orig")
+
+        rate_limited = _mock_post(429, {"error": "too_many_requests"})
+        post = MagicMock(return_value=rate_limited)
+
+        with (
+            patch("nauro.cli.commands.auth.httpx.post", post),
+            patch("nauro.cli.commands.auth.time.sleep"),
+            pytest.raises(AuthRefreshError, match="rate-limiting"),
+        ):
+            refresh_access_token()
+
+        assert post.call_count == 3
+        auth = load_config()["auth"]
+        assert auth["access_token"] == "access_orig"
+        assert auth["refresh_token"] == "refresh_orig"
+
+    def test_non_429_failure_does_not_retry_or_sleep(self):
+        _seed_auth(refresh_token="refresh_orig", access_token="access_orig")
+
+        bad = _mock_post(
+            400,
+            {"error": "invalid_grant", "error_description": "refresh token expired"},
+        )
+        post = MagicMock(return_value=bad)
+
+        with (
+            patch("nauro.cli.commands.auth.httpx.post", post),
+            patch("nauro.cli.commands.auth.time.sleep") as sleep,
+            pytest.raises(AuthRefreshError),
+        ):
+            refresh_access_token()
+
+        assert post.call_count == 1
+        sleep.assert_not_called()
+
+    def test_retry_after_header_honored(self):
+        _seed_auth(refresh_token="refresh_orig", access_token="access_orig")
+
+        rate_limited = _mock_post(429, {"error": "too_many_requests"}, headers={"Retry-After": "2"})
+        ok = _mock_post(200, {"access_token": "access_new"})
+        post = MagicMock(side_effect=[rate_limited, ok])
+
+        with (
+            patch("nauro.cli.commands.auth.httpx.post", post),
+            patch("nauro.cli.commands.auth.time.sleep") as sleep,
+        ):
+            refresh_access_token()
+
+        sleep.assert_called_once_with(2.0)
+
+    def test_retry_after_unicode_digit_falls_back_without_raising(self):
+        # "²" is a Unicode digit that str.isdigit accepts but int rejects;
+        # the header parse must fall back to the default backoff, not crash.
+        _seed_auth(refresh_token="refresh_orig", access_token="access_orig")
+
+        rate_limited = _mock_post(429, {"error": "too_many_requests"}, headers={"Retry-After": "²"})
+        ok = _mock_post(200, {"access_token": "access_new"})
+        post = MagicMock(side_effect=[rate_limited, ok])
+
+        with (
+            patch("nauro.cli.commands.auth.httpx.post", post),
+            patch("nauro.cli.commands.auth.time.sleep") as sleep,
+        ):
+            new_token = refresh_access_token()
+
+        assert new_token == "access_new"
+        assert post.call_count == 2
+        sleep.assert_called_once_with(1.0)
 
 
 # --- with_token_refresh ---


### PR DESCRIPTION
## Why

Auth0 returns HTTP 429 when logins are being rate-limited. Both Auth0 token
POSTs in the CLI handled that poorly: the `login` token-exchange surfaced a 429
as a generic "Token exchange failed" error, and `refresh_access_token` surfaced
it as an opaque "Refresh failed (429)" message. Neither retried, so a transient
rate-limit burst forced the user to start the whole flow over with no guidance
on what to do.

## Approach

A single bounded retry helper, `_post_with_429_retry`, that both call sites route
their POST through. It takes a zero-arg callable so each caller keeps ownership of
its own URL, body, and timeout, and it never emits user-facing messaging — it
returns the final 429 response and lets each site render its own guidance. This
keeps the messaging policy (raise `AuthRefreshError` in the refresh path vs.
print-and-exit in the interactive `login` path) at the call sites where it
belongs.

Backoff honors the integer-seconds form of `Retry-After`, parsed with plain
string operations (per the repo's no-regex convention), and ignores the HTTP-date
form. The honored value is clamped to a 10-second ceiling so a hostile or buggy
header cannot stall the CLI; when the header is absent or unparseable it falls
back to a short fixed per-attempt default. Sleep goes through the module-level
`time.sleep` so tests can patch it to a no-op.

A general-purpose retry library was not pulled in: this is two call sites with one
status code and a bounded attempt count, so a dependency would be more surface
than the problem warrants.

## What changed

- `cli/commands/auth.py`: new `_post_with_429_retry` helper plus a `Retry-After`
  parsing helper and the shared rate-limit message constant; `refresh_access_token`
  and the `login` token-exchange now route their POST through the helper and handle
  the exhausted-429 case. The `login` token-exchange also gains an explicit 15s
  timeout, which it was previously missing.
- Tests: 429 coverage added in both colocated suites.

## What to review

- The exhausted-429 contract differs by call site on purpose: the refresh path
  raises `AuthRefreshError`, the interactive `login` path prints and exits 1.
- The `Retry-After` ceiling clamp and the absent/unparseable fallback — the helper
  honors only the integer-seconds form and ignores HTTP-date deliberately.
- That non-429 behavior, exit codes, and exception types are unchanged; the helper
  only changes what happens on 429.
- Test fixture note: `MagicMock(spec=httpx.Response)` does not expose `.headers`,
  so the shared `_mock_post` helper now sets a real headers mapping for the backoff
  path to read.

## What's deferred

- No retry on non-429 errors (network errors, other 5xx) — out of scope; current
  behavior is preserved exactly.
- No jitter or shared retry policy across other HTTP call sites; if more endpoints
  need this, a small shared utility can be extracted later.

## Test plan

Targeted suites pass: `uv run --package nauro pytest packages/nauro/tests/test_auth.py packages/nauro/tests/test_auth_refresh.py -x -q` -> 50 passed. Full nauro suite as a regression guard: 1301+ passed. `ruff check packages/` and `ruff format --check packages/` clean. New tests cover: refresh 429-then-200; refresh 429 exhausted; refresh non-429; Retry-After honored; Retry-After Unicode-digit falls back without raising; login 429-then-200; login 429 exhausted; login non-429.
