### PR TITLE
Validate repo-config id as a ULID and contain store paths

### DIFF
--- a/packages/nauro/src/nauro/store/filesystem_store.py
+++ b/packages/nauro/src/nauro/store/filesystem_store.py
@@ -26,10 +26,22 @@ class FilesystemStore:
     def __init__(self, store_path: Path) -> None:
         self._store_path = store_path
 
-    def read_file(self, path: str) -> str | None:
+    def _resolve_within(self, path: str) -> Path:
+        """Resolve ``path`` against the store root, refusing any escape.
+
+        Returns the resolved target when it stays inside ``store_path``; raises
+        ``ValueError`` when ``path`` carries ``..`` segments or an absolute path
+        that would land outside the project store. Shared by every file op so
+        the containment invariant is enforced uniformly rather than only on
+        reads.
+        """
         target = (self._store_path / path).resolve()
+        target.relative_to(self._store_path.resolve())  # raises ValueError on escape
+        return target
+
+    def read_file(self, path: str) -> str | None:
         try:
-            target.relative_to(self._store_path.resolve())
+            target = self._resolve_within(path)
         except ValueError:
             return None
         if not target.exists() or not target.is_file():
@@ -41,14 +53,19 @@ class FilesystemStore:
     # the same num because they raced between list/write) are caught and
     # repaired on the next sync-pull.
     def write_file(self, path: str, content: str) -> None:
-        target = self._store_path / path
+        # Fail loud on an out-of-store path: silently dropping or redirecting a
+        # write would corrupt the store, so a traversal path is an error.
+        target = self._resolve_within(path)
         target.parent.mkdir(parents=True, exist_ok=True)
         lock = target.with_name(target.name + ".lock")
         with FileLock(str(lock)):
             target.write_text(content)
 
     def delete_file(self, path: str) -> None:
-        target = self._store_path / path
+        try:
+            target = self._resolve_within(path)
+        except ValueError:
+            return
         if not target.exists():
             return
         target.unlink()

--- a/packages/nauro/src/nauro/store/registry.py
+++ b/packages/nauro/src/nauro/store/registry.py
@@ -365,8 +365,26 @@ def _validate_project_name(name: str) -> str:
 
 
 def get_store_path_v2(project_id: str) -> Path:
-    """Return the id-keyed store directory for a v2 project."""
-    return _projects_dir() / project_id
+    """Return the id-keyed store directory for a v2 project.
+
+    Defense-in-depth: ``project_id`` becomes a path component under the
+    projects directory, so a value containing ``..`` or an absolute path could
+    relocate the store outside ``~/.nauro/projects/``. The primary guard is
+    ULID validation at the config trust boundary (``repo_config._validate``);
+    this containment check ensures no caller — present or future, including
+    ``nauro attach <project_id>`` taking the id straight from argv — can escape
+    the projects root. It rejects only escapes, not the full ULID alphabet, so
+    contained non-canonical ids (e.g. test fixtures) are left alone.
+    """
+    projects_root = _projects_dir()
+    store_path = projects_root / project_id
+    try:
+        store_path.resolve().relative_to(projects_root.resolve())
+    except ValueError as exc:
+        raise ValueError(
+            f"Refusing project_id {project_id!r}: resolves outside the project store."
+        ) from exc
+    return store_path
 
 
 def _load_registry_v2_or_empty() -> dict:

--- a/packages/nauro/src/nauro/store/repo_config.py
+++ b/packages/nauro/src/nauro/store/repo_config.py
@@ -34,6 +34,20 @@ logger = logging.getLogger("nauro.repo_config")
 
 _VALID_MODES = (REPO_CONFIG_MODE_LOCAL, REPO_CONFIG_MODE_CLOUD)
 _CROCKFORD = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+_ULID_LEN = 26
+
+
+def _is_valid_ulid(value: str) -> bool:
+    """True when ``value`` is a 26-char Crockford-base32 ULID.
+
+    Mirrors the alphabet and length produced by :func:`generate_ulid` and by
+    the server when it mints cloud project ids. This is a trust-boundary check:
+    the ``id`` from an untrusted ``.nauro/config.json`` becomes a path component
+    under ``~/.nauro/projects/``, so a value carrying ``..``, path separators,
+    or an absolute path could relocate the store root. Constraining ``id`` to
+    the ULID alphabet rejects all of those before they reach the filesystem.
+    """
+    return len(value) == _ULID_LEN and all(ch in _CROCKFORD for ch in value)
 
 
 class RepoConfigSchemaError(Exception):
@@ -79,6 +93,12 @@ def _validate(data: dict) -> None:
 
     if not isinstance(data.get("id"), str) or not data["id"]:
         raise RepoConfigSchemaError("Repo config is missing required field 'id'.")
+    if not _is_valid_ulid(data["id"]):
+        raise RepoConfigSchemaError(
+            f"Repo config 'id' {data['id']!r} is not a valid ULID "
+            f"({_ULID_LEN} Crockford-base32 chars). The id names a directory under "
+            "the project store; a malformed value is refused so it cannot escape it."
+        )
     if not isinstance(data.get("name"), str) or not data["name"]:
         raise RepoConfigSchemaError("Repo config is missing required field 'name'.")
 

--- a/packages/nauro/tests/test_registry.py
+++ b/packages/nauro/tests/test_registry.py
@@ -370,3 +370,32 @@ def test_load_registry_v2_non_dict_returns_empty(tmp_path, monkeypatch):
     (tmp_path / "registry.json").write_text("[]")
     data = registry.load_registry_v2()
     assert data == {"projects": {}, "schema_version": 2}
+
+
+# --- get_store_path_v2 containment (defense-in-depth) ---
+
+
+def test_get_store_path_v2_accepts_valid_ulid(tmp_path, monkeypatch):
+    """A canonical ULID maps to the id-keyed directory under the projects dir."""
+    pid = "01KQ6AZGNA0B3QBF67NBXP3S45"
+    assert registry.get_store_path_v2(pid) == registry._projects_dir() / pid
+
+
+@pytest.mark.parametrize("evil", ["../../../../etc", "../escape", "/etc"])
+def test_get_store_path_v2_rejects_escape(tmp_path, monkeypatch, evil):
+    """A project_id that resolves outside the projects dir is refused.
+
+    ULID validation at the config boundary is the primary guard; this is the
+    second layer that protects callers taking an id straight from argv (e.g.
+    ``nauro attach <project_id>``) from escaping ~/.nauro/projects/.
+    """
+    with pytest.raises(ValueError, match="outside the project store"):
+        registry.get_store_path_v2(evil)
+
+
+def test_get_store_path_v2_allows_contained_non_canonical_id(tmp_path, monkeypatch):
+    """Containment-only: a contained id that is not a canonical ULID (legacy /
+    test-fixture ids) is still returned. This guard rejects escapes, not the
+    full ULID alphabet — keeping it from breaking non-escaping callers."""
+    pid = "01TESTPROJECT00000000000"
+    assert registry.get_store_path_v2(pid) == registry._projects_dir() / pid

--- a/packages/nauro/tests/test_repo_config.py
+++ b/packages/nauro/tests/test_repo_config.py
@@ -146,6 +146,68 @@ def test_save_rejects_cloud_without_server_url(tmp_path):
         )
 
 
+# ── id validation (path-traversal trust boundary) ─────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "bad_id",
+    [
+        "../../../../etc",  # relative traversal
+        "../" * 8 + "etc/passwd",  # deep traversal
+        "/etc/passwd",  # absolute path
+        "a/b",  # nested separator
+        "01KQ6AZGNA0B3QBF67NBXP3S4",  # 25 chars — too short
+        "01KQ6AZGNA0B3QBF67NBXP3S455",  # 27 chars — too long
+        "01KQ6AZGNA0B3QBF67NBXP3S4I",  # 'I' is not in the Crockford alphabet
+        "01kq6azgna0b3qbf67nbxp3s45",  # lowercase — not the minted form
+    ],
+)
+def test_validate_rejects_non_ulid_id(tmp_path, bad_id):
+    """A repo config whose ``id`` is not a canonical ULID is refused.
+
+    The ``id`` becomes a directory component under ``~/.nauro/projects/``, so
+    rejecting traversal/absolute/garbage values at the loader boundary is what
+    stops a cloned repo from relocating the store onto arbitrary filesystem
+    paths (and thereby reading/writing files outside it).
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    cfg_dir = repo / REPO_CONFIG_DIR
+    cfg_dir.mkdir()
+    (cfg_dir / REPO_CONFIG_FILENAME).write_text(
+        json.dumps(
+            {
+                "mode": "local",
+                "id": bad_id,
+                "name": "x",
+                "schema_version": REPO_CONFIG_SCHEMA_VERSION,
+            }
+        )
+    )
+    with pytest.raises(RepoConfigSchemaError) as exc:
+        load_repo_config(repo)
+    assert "ULID" in str(exc.value)
+
+
+def test_save_rejects_non_ulid_id(tmp_path):
+    """The writer refuses a malformed id before any bytes touch disk."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    with pytest.raises(RepoConfigSchemaError):
+        save_repo_config(repo, {"mode": "local", "id": "../../etc", "name": "x"})
+    assert not repo_config_path(repo).exists()
+
+
+def test_validate_accepts_minted_and_server_ulids(tmp_path):
+    """Both a CLI-minted ULID and a representative server-minted ULID validate,
+    so the guard does not regress legitimate local or cloud configs."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    for ulid in (generate_ulid(), "01KQ6AZGNA0B3QBF67NBXP3S45"):
+        save_repo_config(repo, {"mode": "local", "id": ulid, "name": "x"})
+        assert load_repo_config(repo)["id"] == ulid
+
+
 # ── find_repo_config walk-up ──────────────────────────────────────────────────
 
 

--- a/packages/nauro/tests/test_resolution_v2.py
+++ b/packages/nauro/tests/test_resolution_v2.py
@@ -26,6 +26,7 @@ from nauro.constants import (
     REGISTRY_SCHEMA_VERSION_V2,
     REPO_CONFIG_DIR,
     REPO_CONFIG_FILENAME,
+    REPO_CONFIG_SCHEMA_VERSION,
 )
 from nauro.mcp.stdio_server import _resolve_store
 from nauro.store import registry
@@ -179,6 +180,37 @@ def test_resolve_via_repo_config_returns_none_on_corrupt_config(
     repo_root = tmp_path / "repo"
     repo_root.mkdir()
     _write_repo_config_text(repo_root, _CORRUPT_CONFIGS[corrupt_kind])
+    monkeypatch.chdir(repo_root)
+
+    assert resolve_via_repo_config(repo_root) is None
+
+
+def test_resolve_via_repo_config_returns_none_on_traversal_id(tmp_path, monkeypatch):
+    """End-to-end closure of the trust-boundary bug: a cloned repo whose
+    ``.nauro/config.json`` carries a path-traversal ``id`` resolves to
+    no-project rather than relocating the store outside ~/.nauro/projects/.
+
+    Without the ULID guard the malformed (but otherwise schema-valid) id would
+    flow through ``get_store_path_v2`` into a store path under an attacker-chosen
+    directory, letting get_raw_file / propose_decision reach arbitrary local
+    files when an agent merely opens the repo. The resolver must instead degrade
+    to the no-project fallback.
+    """
+    from nauro.store.resolution import resolve_via_repo_config
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    _write_repo_config_text(
+        repo_root,
+        json.dumps(
+            {
+                "mode": "local",
+                "id": "../../../../../../etc",
+                "name": "evil",
+                "schema_version": REPO_CONFIG_SCHEMA_VERSION,
+            }
+        ),
+    )
     monkeypatch.chdir(repo_root)
 
     assert resolve_via_repo_config(repo_root) is None

--- a/packages/nauro/tests/test_store.py
+++ b/packages/nauro/tests/test_store.py
@@ -823,3 +823,38 @@ def test_sync_no_project(tmp_path: Path, monkeypatch):
     result = runner.invoke(app, ["sync"])
     assert result.exit_code == 1
     assert "No project found" in result.output
+
+
+# --- FilesystemStore path containment ---
+
+
+def test_filesystem_store_write_file_rejects_traversal(tmp_path):
+    """write_file fails loud on a traversal path rather than writing outside the
+    store. Silently dropping or redirecting a write would corrupt the store, so
+    an out-of-store path is an error, not a no-op."""
+    store_root = tmp_path / "store"
+    outside = tmp_path / "outside.md"
+    with pytest.raises(ValueError):
+        FilesystemStore(store_root).write_file("../outside.md", "pwned")
+    assert not outside.exists()
+
+
+def test_filesystem_store_delete_file_ignores_traversal(tmp_path):
+    """delete_file never reaches outside the store; a traversal path is a no-op
+    that leaves the sibling file intact."""
+    store_root = tmp_path / "store"
+    store_root.mkdir()
+    victim = tmp_path / "victim.md"
+    victim.write_text("keep me")
+    FilesystemStore(store_root).delete_file("../victim.md")
+    assert victim.read_text() == "keep me"
+
+
+def test_filesystem_store_read_file_returns_none_on_traversal(tmp_path):
+    """read_file treats an out-of-store path as absent rather than disclosing a
+    file outside the project store."""
+    store_root = tmp_path / "store"
+    store_root.mkdir()
+    secret = tmp_path / "secret.md"
+    secret.write_text("top secret")
+    assert FilesystemStore(store_root).read_file("../secret.md") is None


### PR DESCRIPTION
## Why

A per-repo `.nauro/config.json` is untrusted input. It ships inside any repo a user
clones, and Nauro reads it during project resolution whenever a CLI command or the
stdio MCP server runs inside that repo. Its `id` field was used verbatim as a
directory component under `~/.nauro/projects/`, with the only check being "is a
non-empty string" (`repo_config._validate`).

A crafted `id` (a relative `../../…` or an absolute path) resolved the store root to
a location outside the projects directory, so the store's read and write file
operations no longer stayed within the intended per-project directory. Adjacent code
already sanitized the v1 project *name* (`validate_project_name` rejects `/`, `\`,
`..`), but that guard was never applied to the untrusted v2 `id`.

## Approach

Validate at the trust boundary, with a second check behind it:

1. **Primary guard.** Constrain `id` to a canonical ULID where it enters the system.
   `id` is always a 26-char Crockford-base32 ULID, whether CLI-minted
   (`generate_ulid`) or server-minted, so nothing legitimate is non-canonical. A
   strict allowlist (length plus alphabet) rejects every traversal, separator, and
   absolute form, since none of those characters are in the alphabet.
2. **Defense in depth.** `get_store_path_v2` adds a `resolve()` plus `relative_to()`
   containment assertion, so any other caller that takes an id from argv (for example
   `nauro attach <project_id>`) also cannot escape the projects root. This check
   rejects only escapes, not the alphabet, so contained non-canonical ids still work.
3. **Store boundary.** `FilesystemStore.write_file` and `delete_file` previously
   lacked the containment check `read_file` already had. The check is now factored
   into a shared `_resolve_within`. Writes raise on an out-of-store path (silently
   redirecting a write would corrupt the store); reads and deletes treat it as absent.

Alternative considered: validating only in `get_store_path_v2`. Rejected, because
failing at the config loader makes a malicious repo degrade to "no project" (the
resolver already maps `RepoConfigSchemaError` to that fallback) instead of raising
deeper in the stack, and it keeps the trust boundary where the untrusted bytes are
first parsed.

## What changed

- `store/repo_config.py`: `_is_valid_ulid` helper; `_validate` now rejects a non-ULID
  `id` with a clear error.
- `store/registry.py`: `get_store_path_v2` gains a containment assertion.
- `store/filesystem_store.py`: shared `_resolve_within`; `write_file` raises and
  `delete_file` no-ops on an out-of-store path.

## What to review

- The ULID allowlist in `repo_config._is_valid_ulid`. Confirm the alphabet matches
  `generate_ulid` and real server-minted ids (it does; both are uppercase Crockford,
  no I/L/O/U).
- The behavior split in `FilesystemStore`: `write_file` raises while `read_file` and
  `delete_file` swallow. The rationale is in the comments: a dropped or redirected
  write is worse than a loud failure, and legitimate callers never pass `..`.
- `get_store_path_v2` is containment-only by design (rejects escapes, not the full
  alphabet), so it does not break contained non-canonical ids used elsewhere.

## What's deferred

None. The fix closes the trust boundary and brings the `FilesystemStore` write and
delete paths in line with the existing read guard in the same change.

## Test plan

New regression tests, each pinned to fail if the fix is reverted:

- `test_repo_config.py`: `_validate`/`load`/`save` reject a matrix of bad ids
  (relative and deep traversal, absolute, nested separator, off-by-one length in both
  directions, out-of-alphabet `I`, lowercase); accept both a minted and a
  representative server ULID.
- `test_registry.py`: `get_store_path_v2` accepts a valid ULID, rejects `..` and
  absolute escapes, and still allows a contained non-canonical id.
- `test_store.py`: `FilesystemStore` write raises, delete no-ops, read returns None
  on a traversal path (sibling file left intact).
- `test_resolution_v2.py`: end-to-end, a malicious repo config with a traversal `id`
  resolves to no-project.

Full suites green: `nauro-core` 747 passed, `nauro` 1321 passed / 10 skipped.
`ruff check` and `ruff format --check` clean on all touched files.
