### PR TITLE
Harden CLI credential and store-file permissions

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/auth.py
+++ b/packages/nauro/src/nauro/cli/commands/auth.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import base64
 import contextlib
 import hashlib
+import html
 import json
 import logging
 import os
@@ -268,6 +269,16 @@ def _generate_pkce() -> tuple[str, str]:
     return code_verifier, code_challenge
 
 
+def _callback_page(message: str) -> str:
+    """Render the loopback callback page, escaping the message.
+
+    ``message`` can carry an Auth0-supplied ``error_description`` reflected from
+    the redirect query, so it is HTML-escaped to keep an attacker-influenced
+    error string from injecting markup into the page the browser renders.
+    """
+    return f"<html><body><h2>{html.escape(message)}</h2></body></html>"
+
+
 class _CallbackHandler(BaseHTTPRequestHandler):
     """HTTP handler that captures the OAuth callback code."""
 
@@ -292,8 +303,7 @@ class _CallbackHandler(BaseHTTPRequestHandler):
         self.send_response(200)
         self.send_header("Content-Type", "text/html")
         self.end_headers()
-        html = f"<html><body><h2>{message}</h2></body></html>"
-        self.wfile.write(html.encode())
+        self.wfile.write(_callback_page(message).encode())
 
     def log_message(self, format, *args):
         """Suppress default stderr logging."""

--- a/packages/nauro/src/nauro/store/_atomic.py
+++ b/packages/nauro/src/nauro/store/_atomic.py
@@ -9,26 +9,45 @@ crash-durability is an explicit non-goal here.
 """
 
 import os
+import tempfile
 from pathlib import Path
 
 
 def atomic_write_text(path: Path, text: str, *, mode: int | None = None) -> None:
     """Write ``text`` to ``path`` atomically via a tmp sibling and ``os.replace``.
 
-    Creates the parent directory if needed, writes to a ``.tmp`` sibling,
-    optionally chmods that tmp file, then atomically renames it over ``path``.
-    The chmod is applied to the tmp file before the rename so the target is
-    never momentarily readable at a wider mode.
+    Creates the parent directory if needed, writes to a tmp sibling, then
+    atomically renames it over ``path`` so a reader never observes a partial
+    target.
 
     Args:
         path: Destination file path.
         text: Full file contents to write.
         mode: When set, the permission bits applied to the file (e.g. ``0o600``
             for owner-only). When None, the file keeps the default umask mode.
+
+    When ``mode`` is given the tmp sibling is created owner-only with a random,
+    unguessable name via :func:`tempfile.mkstemp` (which opens with
+    ``O_CREAT|O_EXCL`` at mode ``0o600``). The contents are therefore never
+    momentarily world-readable, and a symlink pre-planted at a predictable
+    ``.tmp`` path cannot redirect or clobber the write — this matters for the
+    auth token, which is written at ``0o600``. The ``mode=None`` path keeps the
+    original default-umask behavior for non-sensitive control-plane JSON.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_suffix(".tmp")
-    tmp.write_text(text)
     if mode is not None:
-        os.chmod(tmp, mode)
-    os.replace(tmp, path)
+        fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.", suffix=".tmp")
+        tmp = Path(tmp_name)
+        try:
+            with os.fdopen(fd, "w") as handle:
+                handle.write(text)
+            if mode != 0o600:
+                os.chmod(tmp, mode)
+            os.replace(tmp, path)
+        except BaseException:
+            tmp.unlink(missing_ok=True)
+            raise
+    else:
+        tmp = path.with_suffix(".tmp")
+        tmp.write_text(text)
+        os.replace(tmp, path)

--- a/packages/nauro/src/nauro/store/config.py
+++ b/packages/nauro/src/nauro/store/config.py
@@ -22,6 +22,7 @@ from nauro.constants import (
     NAURO_TELEMETRY_ENV,
 )
 from nauro.store._atomic import atomic_write_text
+from nauro.store.registry import _ensure_nauro_home
 
 logger = logging.getLogger("nauro.config")
 
@@ -43,7 +44,7 @@ def _config_lock():
     must never open a ``config_transaction`` inside another, or it deadlocks.
     """
     lock_path = _config_file().with_suffix(".lock")
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    _ensure_nauro_home()  # lock_path.parent is the home dir; create it owner-only
     with FileLock(str(lock_path)):
         yield
 

--- a/packages/nauro/src/nauro/store/registry.py
+++ b/packages/nauro/src/nauro/store/registry.py
@@ -53,7 +53,7 @@ class RegistrySchemaError(Exception):
 def _registry_lock():
     """Exclusive file lock on registry.json for atomic read-modify-write."""
     lock_path = _registry_file().with_suffix(".lock")
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    _ensure_nauro_home()  # lock_path.parent is the home dir; create it owner-only
     with FileLock(lock_path):
         yield
 
@@ -68,6 +68,28 @@ def _registry_file() -> Path:
 
 def _projects_dir() -> Path:
     return _nauro_home() / PROJECTS_DIR
+
+
+def _ensure_nauro_home() -> Path:
+    """Create the Nauro home dir (``~/.nauro`` or ``$NAURO_HOME``) owner-only.
+
+    The home holds the auth token (``config.json``) and the full project store,
+    so it must not be group/other-accessible. New installs are created at
+    ``0o700``; a home created at the umask default by an older build is tightened
+    in place. Deeper paths are created under the returned home with
+    ``parents=True`` after this call, so the home never transits a wider mode.
+    """
+    home = _nauro_home()
+    home.mkdir(mode=0o700, parents=True, exist_ok=True)
+    try:
+        if (home.stat().st_mode & 0o077) != 0:
+            home.chmod(0o700)
+    except OSError as exc:
+        # Best-effort tightening of a pre-existing wide dir; a real failure
+        # surfaces at the FileLock that follows. Log for diagnosis on locked-down
+        # hosts rather than masking it entirely.
+        logger.debug("Could not tighten %s to 0o700: %s", home, exc)
+    return home
 
 
 def load_registry() -> dict:

--- a/packages/nauro/tests/test_atomic.py
+++ b/packages/nauro/tests/test_atomic.py
@@ -48,3 +48,27 @@ def test_target_untouched_when_replace_fails(tmp_path, monkeypatch):
     with pytest.raises(OSError, match="replace failed"):
         atomic_write_text(p, "new\n")
     assert not p.exists()
+
+
+def test_sensitive_write_ignores_predictable_tmp_symlink(tmp_path):
+    """A symlink pre-planted at the old predictable ``<name>.tmp`` path must not
+    redirect a mode-restricted write. The symlink target stays untouched and the
+    real file is written owner-only via an unguessable temp name."""
+    target = tmp_path / "config.json"
+    outside = tmp_path / "outside.txt"
+    outside.write_text("original")
+    target.with_suffix(".tmp").symlink_to(outside)
+
+    atomic_write_text(target, "secret\n", mode=0o600)
+
+    assert outside.read_text() == "original"  # not clobbered through the symlink
+    assert target.read_text() == "secret\n"
+    assert oct(target.stat().st_mode & 0o777) == "0o600"
+
+
+def test_sensitive_write_leaves_no_tmp_behind(tmp_path):
+    """A successful mode-restricted write leaves only the target — the random
+    temp sibling is renamed over it, not left in the directory."""
+    target = tmp_path / "config.json"
+    atomic_write_text(target, "x\n", mode=0o600)
+    assert [p.name for p in tmp_path.iterdir()] == ["config.json"]

--- a/packages/nauro/tests/test_auth.py
+++ b/packages/nauro/tests/test_auth.py
@@ -99,6 +99,16 @@ def _simulate_callback_error(error: str = "access_denied"):
     _CallbackHandler.error = error
 
 
+def test_callback_page_escapes_reflected_message():
+    """The loopback callback page escapes its message so an Auth0-supplied
+    error_description reflected from the redirect cannot inject markup."""
+    from nauro.cli.commands.auth import _callback_page
+
+    page = _callback_page("<script>alert(1)</script>")
+    assert "<script>" not in page
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in page
+
+
 class TestAuthLogin:
     def test_login_success(self, tmp_path, monkeypatch):
         monkeypatch.setenv("NAURO_API_URL", "https://test.api.example.com")

--- a/packages/nauro/tests/test_registry.py
+++ b/packages/nauro/tests/test_registry.py
@@ -399,3 +399,27 @@ def test_get_store_path_v2_allows_contained_non_canonical_id(tmp_path, monkeypat
     full ULID alphabet — keeping it from breaking non-escaping callers."""
     pid = "01TESTPROJECT00000000000"
     assert registry.get_store_path_v2(pid) == registry._projects_dir() / pid
+
+
+# --- nauro home directory permissions ---
+
+
+def test_ensure_nauro_home_creates_owner_only(tmp_path, monkeypatch):
+    """A fresh Nauro home is created at 0o700 so the token and store are not
+    readable by other accounts on a shared host."""
+    home = tmp_path / "fresh_home"
+    monkeypatch.setenv("NAURO_HOME", str(home))
+    created = registry._ensure_nauro_home()
+    assert created == home
+    assert oct(home.stat().st_mode & 0o777) == "0o700"
+
+
+def test_ensure_nauro_home_tightens_existing_wide_dir(tmp_path, monkeypatch):
+    """A home left group/other-accessible by an older build is tightened to
+    owner-only in place."""
+    home = tmp_path / "wide_home"
+    home.mkdir()
+    home.chmod(0o755)
+    monkeypatch.setenv("NAURO_HOME", str(home))
+    registry._ensure_nauro_home()
+    assert (home.stat().st_mode & 0o077) == 0


### PR DESCRIPTION
## Why

A pre-launch pass over the CLI's local credential and store-file handling found a few
low-severity hardening gaps that are cheap to close before the install base grows.
None is remotely exploitable; all matter mainly on a shared multi-user host or as
defense in depth.

## Approach

Three independent, self-contained hardenings:

1. **Owner-only home directory.** `~/.nauro/` (which holds the auth token and the
   whole project store) was created at the umask default (typically `0o755`), so
   other accounts on a shared host could traverse it. A new
   `registry._ensure_nauro_home()` creates it `0o700` and tightens an existing wider
   dir in place. It is called from both lock chokepoints (`_registry_lock`,
   `_config_lock`) where the home is first created, so the home never transits a
   wider mode. `config.py` imports the helper from `registry` rather than duplicating
   the home-dir logic (no new cycle, since `registry` does not import `config`).

2. **No predictable temp for sensitive writes.** `atomic_write_text` wrote to a
   predictable `<name>.tmp` sibling and chmod'd it to `0o600` only after the write.
   That left a brief `0o644` window, and a symlink pre-planted at that path could
   redirect or clobber the write. For mode-restricted writes (the token is written at
   `0o600`) it now uses `tempfile.mkstemp` (random name, `O_EXCL`, `0o600` from
   creation). The `mode=None` path is intentionally unchanged.

3. **Escaped OAuth callback page.** The loopback callback reflected an Auth0
   `error_description` into HTML unescaped. It now renders through a small
   `_callback_page()` helper that `html.escape()`s the message. Loopback-only and
   single-request, but free to close.

## What changed

- `store/registry.py`: `_ensure_nauro_home()`, used in `_registry_lock`.
- `store/config.py`: uses `_ensure_nauro_home()` in `_config_lock`.
- `store/_atomic.py`: `mkstemp`-based temp for mode-restricted writes.
- `cli/commands/auth.py`: `_callback_page()` helper; escaped callback HTML.

## What to review

- `_atomic.py`: the mode-restricted branch's final-mode logic (`mkstemp` is already
  `0o600`, so chmod is skipped for `0o600` and applied for any other mode) and the
  failure path (`os.fdopen` closes the fd before the `except` removes the temp). The
  `mode=None` path is byte-identical to before.
- `_ensure_nauro_home`: the substitution is exact because `lock_path.parent` is the
  home dir at both call sites.

## What's deferred

- Other `~/.nauro` creators (`snapshot.py`, the store lock, `FilesystemStore`
  parents-mkdir, the v2 store-dir mkdirs) still create with the default umask. They
  are safe today because project creation always runs through `_registry_lock` first,
  so the home is already `0o700` and later `exist_ok=True` mkdirs do not re-widen it.
  Routing every home-rooted creator through the helper is a tidy-up left for a
  follow-up, flagged so a future entry point does not silently create the home wide.
- GitHub Actions SHA-pinning and Dependabot/pip-audit are a separate supply-chain
  change, not bundled here.

## Test plan

New regression tests:

- `test_atomic.py`: a symlink pre-planted at the predictable `<name>.tmp` path is not
  followed for a `0o600` write (target written owner-only, symlink target untouched);
  success leaves no temp behind.
- `test_registry.py`: `_ensure_nauro_home` creates a fresh home at `0o700` and
  tightens an existing `0o755` home.
- `test_auth.py`: `_callback_page` escapes a reflected `<script>` payload.

Existing `0o600`-token tests (`test_auth.py`, `test_config_lock.py`,
`test_telemetry_config.py`) and the full atomic-primitive suite stay green. Full
suites: `nauro-core` 747 passed, `nauro` 1326 passed / 10 skipped. `ruff check` and
`ruff format --check` clean.
