### PR TITLE
Release: nauro 0.12.3 (security) + nauro-core 0.13.6

### DIFF
--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro-core"
-version = "0.13.5"
+version = "0.13.6"
 description = "Shared pure-Python logic for Nauro: parsing, validation, context assembly, constants."
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro"
-version = "0.12.2"
+version = "0.12.3"
 description = "Local CLI + MCP server: set your project's doctrine once, every connected AI agent inherits it."
 readme = "README.md"
 license = "Apache-2.0"
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "nauro-core>=0.13.0,<0.14",
+    "nauro-core>=0.13.6,<0.14",
     "typer>=0.9",
     "httpx>=0.24",
     "mcp>=1.0",


### PR DESCRIPTION
## Why

The security fixes from #195 (per-repo config `id` path traversal) and #196 (CLI
credential and file-permission hardening) are merged to main but not on PyPI. Until
a version ships, `pip install nauro` still installs the vulnerable 0.12.2. This bump
publishes them.

## Approach

This bumps nauro and nauro-core together rather than nauro alone. `nauro/sync/push.py`
imports `MAX_BRIEF_BYTES` from `nauro_core`. That constant was added after the
`nauro-core-v0.13.5` tag, so it is not in the published nauro-core 0.13.5. The uv
workspace hides this locally because it uses the in-tree nauro-core, but a PyPI
install of nauro alone would resolve nauro-core 0.13.5 and fail with an ImportError
on `nauro sync`.

Changes:

- nauro-core 0.13.5 to 0.13.6, which publishes the missing `MAX_BRIEF_BYTES` (the
  only public nauro-core symbol added since the 0.13.5 tag; the other post-tag
  change was docs).
- nauro 0.12.2 to 0.12.3.
- nauro's nauro-core floor raised from `>=0.13.0` to `>=0.13.6` (still under `<0.14`),
  so a PyPI install cannot resolve a nauro-core without the constant.

Patch bumps: no API or breaking changes; the security fixes are behavior hardening.

## What changed

- `packages/nauro-core/pyproject.toml`: version to 0.13.6.
- `packages/nauro/pyproject.toml`: version to 0.12.3, nauro-core floor to 0.13.6.

pyproject only (`uv.lock` is gitignored).

## What to review

- The floor bump is what guarantees the published nauro 0.12.3 pulls a nauro-core
  that has `MAX_BRIEF_BYTES`.
- Publish order matters (see below): nauro-core must be on PyPI before nauro.

## Test plan

Both wheels build. Verified the built artifact metadata: the nauro-core 0.13.6 wheel
contains `MAX_BRIEF_BYTES`, and the nauro 0.12.3 wheel records `Version: 0.12.3` and
`Requires-Dist: nauro-core>=0.13.6,<0.14`. CI runs lint and the full nauro and
nauro-core suites.

## Release steps (after merge; the tag push is what publishes)

1. Tag `nauro-core-v0.13.6` on the merge commit and push it. Wait for it to appear on PyPI.
2. Tag `nauro-v0.12.3` on the merge commit and push it.

Both publish over OIDC trusted publishing. nauro-core goes first so nauro's
dependency resolves on the first install.
