### PR TITLE
Resolve decision-file sync conflicts by last-write-wins

### DIFF
--- a/packages/nauro/src/nauro/sync/merge.py
+++ b/packages/nauro/src/nauro/sync/merge.py
@@ -24,8 +24,10 @@ class UnionMergeError(Exception):
     """
 
 
-# Files where append-only union merge is appropriate
-APPEND_ONLY_PATTERNS = ("decisions/", "open-questions.md", "state_history.md")
+# Append-only logs where a set-union merge is safe. Decisions are not
+# append-only. An interleaving union merge would corrupt them, so decision
+# conflicts resolve by last-write-wins with a recoverable backup instead.
+APPEND_ONLY_PATTERNS = ("open-questions.md", "state_history.md")
 
 # Files that are never synced
 NEVER_SYNC = (".sync-state.json",)

--- a/packages/nauro/tests/test_sync/test_hooks.py
+++ b/packages/nauro/tests/test_sync/test_hooks.py
@@ -281,7 +281,7 @@ class TestPullBeforeSessionPresign:
         def boom(*args, **kwargs):
             raise UnionMergeError("simulated git failure")
 
-        monkeypatch.setattr("nauro.sync.merge._union_merge", boom)
+        monkeypatch.setattr("nauro.sync.pull.resolve_conflict", boom)
 
         with (
             patch("nauro.sync.remote.httpx.get", side_effect=fake_get),

--- a/packages/nauro/tests/test_sync/test_merge.py
+++ b/packages/nauro/tests/test_sync/test_merge.py
@@ -4,6 +4,7 @@ import shutil
 import subprocess
 
 import pytest
+from nauro_core.decision_model import parse_decision
 
 from nauro.sync.merge import (
     UnionMergeError,
@@ -30,7 +31,7 @@ class TestShouldSkip:
 
 class TestIsAppendOnly:
     def test_decision_file(self):
-        assert _is_append_only("decisions/001-foo.md") is True
+        assert _is_append_only("decisions/001-foo.md") is False
 
     def test_open_questions(self):
         assert _is_append_only("open-questions.md") is True
@@ -119,9 +120,13 @@ class TestResolveConflict:
 
         assert result == b'{"local": true}'
 
-    @pytest.mark.skipif(not shutil.which("git"), reason="git not available")
-    def test_union_merge_for_decisions(self, tmp_path):
-        """Decision files use git merge-file --union."""
+    def test_lww_for_decisions(self, tmp_path):
+        """Decision files use last-write-wins with backup of the losing version.
+
+        A decision file is immutable per number; interleaving two divergent
+        versions line-by-line would corrupt the file. So a content conflict
+        keeps the local copy whole and backs up the remote loser instead.
+        """
         project_path = tmp_path / "project"
         project_path.mkdir()
         (project_path / "decisions").mkdir()
@@ -134,9 +139,77 @@ class TestResolveConflict:
             project_path, local_file, remote_content, "decisions/001-foo.md", state
         )
 
-        # Union merge should include content from both sides
-        result_str = result.decode()
-        assert "Decision 001" in result_str
+        # Local copy is kept whole, never interleaved with remote.
+        assert result == b"# Decision 001\nLocal addition\n"
+        backup_dir = project_path / ".conflict-backup"
+        assert backup_dir.exists()
+        backups = list(backup_dir.iterdir())
+        assert len(backups) == 1
+        assert backups[0].read_bytes() == remote_content
+
+    def test_update_vs_supersede_conflict_survivor_parses(self, tmp_path):
+        """An update-vs-supersede conflict on the same number stays parseable.
+
+        Both sides are in-place rewrites of decision 042: local marks it
+        superseded, remote bumps its version with new rationale. A union merge
+        would interleave the two frontmatter blocks and bodies into a single
+        file that no longer parses. Last-write-wins keeps the local rewrite
+        whole and backs the remote loser up, so the survivor is one decision
+        that ``parse_decision`` accepts.
+        """
+        local_text = (
+            "---\n"
+            "date: 2026-06-01\n"
+            "confidence: high\n"
+            "version: 2\n"
+            "status: superseded\n"
+            'superseded_by: "99"\n'
+            "---\n"
+            "\n"
+            "# 042 — Cache layer choice\n"
+            "\n"
+            "## Decision\n"
+            "\n"
+            "Superseded by the persisted-index approach.\n"
+        )
+        remote_text = (
+            "---\n"
+            "date: 2026-06-01\n"
+            "confidence: medium\n"
+            "version: 2\n"
+            "status: active\n"
+            "---\n"
+            "\n"
+            "# 042 — Cache layer choice\n"
+            "\n"
+            "## Decision\n"
+            "\n"
+            "Revised in place to use a write-through cache.\n"
+        )
+
+        project_path = tmp_path / "project"
+        project_path.mkdir()
+        (project_path / "decisions").mkdir()
+        local_file = project_path / "decisions" / "042-cache-layer.md"
+        local_file.write_text(local_text)
+        remote_content = remote_text.encode("utf-8")
+
+        state = SyncState()
+        result = resolve_conflict(
+            project_path, local_file, remote_content, "decisions/042-cache-layer.md", state
+        )
+
+        # The survivor is the local rewrite, whole and parseable as ONE decision.
+        assert result == local_text.encode("utf-8")
+        survivor = parse_decision(result.decode("utf-8"), "042-cache-layer.md")
+        assert survivor.num == 42
+        assert survivor.status.value == "superseded"
+        assert survivor.superseded_by == "99"
+
+        # The remote loser was backed up rather than interleaved into the file.
+        backups = list((project_path / ".conflict-backup").iterdir())
+        assert len(backups) == 1
+        assert backups[0].read_bytes() == remote_content
 
     @pytest.mark.skipif(not shutil.which("git"), reason="git not available")
     def test_union_merge_for_open_questions(self, tmp_path):
@@ -323,9 +396,7 @@ class TestSetUnionMarkdown:
             assert twice_lines.count(token) == 1, f"{token!r} repeats in {twice!r}"
 
     def test_decisions_do_not_route_to_set_union(self, tmp_path, monkeypatch):
-        """Decision conflicts stay on _union_merge, not _set_union_markdown."""
-        if not shutil.which("git"):
-            pytest.skip("git not available")
+        """Decision conflicts resolve by last-write-wins, not _set_union_markdown."""
         project_path = tmp_path / "project"
         project_path.mkdir()
         (project_path / "decisions").mkdir()
@@ -345,6 +416,10 @@ class TestSetUnionMarkdown:
         resolve_conflict(project_path, local_file, remote_content, "decisions/001-foo.md", state)
 
         assert calls == []
+        # Last-write-wins backs the remote loser up rather than interleaving it.
+        backups = list((project_path / ".conflict-backup").iterdir())
+        assert len(backups) == 1
+        assert backups[0].read_bytes() == remote_content
 
     def test_open_questions_routes_to_set_union(self, tmp_path, monkeypatch):
         """open-questions.md conflicts go through _set_union_markdown."""

--- a/packages/nauro/tests/test_sync/test_pull.py
+++ b/packages/nauro/tests/test_sync/test_pull.py
@@ -282,7 +282,7 @@ class TestRunPullUnionMergeRouting:
         def boom(*args, **kwargs):
             raise UnionMergeError("simulated git failure")
 
-        monkeypatch.setattr("nauro.sync.merge._union_merge", boom)
+        monkeypatch.setattr("nauro.sync.pull.resolve_conflict", boom)
 
         with (
             patch("nauro.sync.remote.httpx.get", side_effect=fake_get),
@@ -304,7 +304,7 @@ class TestRunPullUnionMergeRouting:
         def boom(*args, **kwargs):
             raise UnionMergeError("simulated git failure")
 
-        monkeypatch.setattr("nauro.sync.merge._union_merge", boom)
+        monkeypatch.setattr("nauro.sync.pull.resolve_conflict", boom)
 
         with (
             patch("nauro.sync.remote.httpx.get", side_effect=fake_get),

--- a/packages/nauro/tests/test_sync/test_sync_command.py
+++ b/packages/nauro/tests/test_sync/test_sync_command.py
@@ -409,7 +409,7 @@ class TestSyncPullSurfacesAndMerges:
         def boom(*args, **kwargs):
             raise UnionMergeError("simulated git failure")
 
-        monkeypatch.setattr("nauro.sync.merge._union_merge", boom)
+        monkeypatch.setattr("nauro.sync.pull.resolve_conflict", boom)
 
         with (
             patch("nauro.sync.remote.httpx.get", side_effect=fake_get),

--- a/packages/nauro/tests/test_sync/test_sync_presign.py
+++ b/packages/nauro/tests/test_sync/test_sync_presign.py
@@ -375,7 +375,7 @@ class TestPullViaPresign:
         def boom(*args, **kwargs):
             raise UnionMergeError("simulated git failure")
 
-        monkeypatch.setattr("nauro.sync.merge._union_merge", boom)
+        monkeypatch.setattr("nauro.sync.pull.resolve_conflict", boom)
 
         from nauro.sync import remote
 


### PR DESCRIPTION
## Why

Sync resolved decision-file conflicts (local and remote both changed since
last sync) with a `git merge-file --union` line-union. Decision files are
immutable per number, so a divergent rewrite on each side, for example one
side marking the decision superseded while the other revises it in place,
gets interleaved into a single file with two frontmatter blocks and two
bodies. That output no longer parses as one decision and silently corrupts
the store.

## Approach

Decision-file content conflicts now resolve by last-write-wins with a
recoverable backup: keep the local copy whole, write the remote loser to
`.conflict-backup/` for manual recovery. Concretely, `decisions/` is removed
from the append-only union patterns so a decision conflict falls through
`resolve_conflict` to the existing last-write-wins branch instead of being
union-merged.

Union merge stays the right tool for genuinely append-only logs, so
`open-questions.md` and `state_history.md` are untouched. They are
intercepted by the set-union path before the append-only branch and keep
their section-aware merge.

Alternative considered and rejected: a smarter decision-aware merge that
picks the higher version or the superseding side. That bakes conflict-policy
into the sync layer and still has to choose a loser. Last-write-wins with a
durable backup is simpler, predictable, and recoverable.

## What changed

- `sync/merge.py`: `APPEND_ONLY_PATTERNS` drops `decisions/`; the constant's
  comment now states decisions are not append-only and explains why they take
  the last-write-wins path.
- Merge tests: the decision-conflict case now asserts the last-write-wins plus
  backup outcome; a new regression covers an update-vs-supersede conflict on
  the same number and asserts the survivor still parses as a single decision.
- Sync/pull integration tests that verify fail-loud merge handling now inject
  the failure at `resolve_conflict` (the boundary `pull.py` calls) rather than
  the internal union helper.

## What to review

- This is forward-only. Decision files already corrupted by a prior union
  merge are not auto-repaired. Recovery is manual, from `.conflict-backup/`
  or the cloud copy.
- The union helpers (`_union_merge`, `UnionMergeError`, `_is_append_only`,
  `_git_available`) are intentionally left in place. They are still live:
  `pull.py` imports `UnionMergeError` and `resolve_conflict`, and `_union_merge`
  remains reachable through `resolve_conflict`'s append-only branch (now only
  for `open-questions.md` and `state_history.md`, which are intercepted by the
  set-union path earlier). The path is unreachable for decisions, but removing
  it is a separate dead-code pass kept out of this PR.
- The integration-test monkeypatch was repointed from `_union_merge` to
  `resolve_conflict` because decision conflicts no longer reach `_union_merge`.
  `resolve_conflict` is the boundary `pull.py` actually invokes, so the
  reporter reraise/swallow contract is still exercised end to end.

## What's deferred

- A dead-code pass to remove the union-merge helpers once nothing else routes
  through them.
- No retroactive repair of already-corrupted decision files.

## Test plan

- `packages/nauro/tests/test_sync/`: 111 passed (was 110; +1 regression for
  the update-vs-supersede case).
- Full `packages/nauro/tests/`: 1327 passed, 10 skipped.
- `packages/nauro-core/tests/`: 747 passed.
- `ruff check` and `ruff format --check` clean across `packages/`.
