### PR TITLE
Preserve full decision rationale with subsections

### DIFF
--- a/packages/nauro-core/src/nauro_core/decision_model.py
+++ b/packages/nauro-core/src/nauro_core/decision_model.py
@@ -196,8 +196,10 @@ _FRONTMATTER_ORDER: tuple[str, ...] = (
 
 
 _H1_PATTERN = re.compile(r"^#\s+(\d+)\s+\u2014\s+(.+)$", re.MULTILINE)
-_SECTION_START = re.compile(r"^##\s+", re.MULTILINE)
 _SUBSECTION_SPLIT = re.compile(r"^###\s+(.+?)\s*$", re.MULTILINE)
+
+_DECISION_ANCHOR = "## Decision"
+_REJECTED_ANCHOR = "## Rejected Alternatives"
 
 
 def parse_decision(text: str, filename: str) -> Decision:
@@ -244,7 +246,7 @@ def parse_decision(text: str, filename: str) -> Decision:
     title = h1.group(2).strip()
     file_num = extract_decision_number(filename) or 0
 
-    rationale = _extract_section_body(body, "Decision")
+    rationale, rejected_body = _split_decision_body(body)
     if rationale is None:
         raise ValueError(
             f"{filename}: missing `## Decision` section "
@@ -252,7 +254,6 @@ def parse_decision(text: str, filename: str) -> Decision:
             "legacy files; the parser itself stays strict)"
         )
 
-    rejected_body = _extract_section_body(body, "Rejected Alternatives")
     rejected_list = _parse_rejected_subsections(rejected_body or "")
 
     # Body-rendered field goes in via the normal constructor path so the
@@ -268,20 +269,62 @@ def parse_decision(text: str, filename: str) -> Decision:
     )
 
 
-def _extract_section_body(body: str, heading: str) -> str | None:
-    """Return the stripped body of a ``## {heading}`` section, or None.
+def _split_decision_body(body: str) -> tuple[str | None, str | None]:
+    """Split a decision body into ``(rationale, rejected_body)``.
 
-    Scans for `## heading` followed by newline; returns everything up to the
-    next `##` heading (or end of body).
+    The rationale may contain arbitrary ``##``/``###`` subsections, ``---``
+    rules, and fenced code blocks. Only two top-level headings are treated as
+    section boundaries, and only when they appear as non-fenced whole lines:
+
+    - The Decision anchor is the FIRST non-fenced line whose stripped form is
+      exactly ``## Decision``. If none exists, the rationale is ``None`` and the
+      caller raises the missing-section error (contract unchanged).
+    - The Rejected anchor is the LAST non-fenced whole-line ``## Rejected
+      Alternatives`` occurring after the Decision anchor. A literal heading line
+      inside the rationale (e.g. an example, or one preceding the real block) is
+      therefore kept in the rationale, and only the genuine trailing block is
+      parsed as rejected alternatives.
+
+    Lines inside fenced code blocks (toggled by ``` ``` ``` or ``~~~``) never
+    anchor, and the fence-marker lines themselves are never anchors.
+
+    Returns:
+        ``(rationale, rejected_body)`` where ``rationale`` is the stripped text
+        between the Decision anchor and the Rejected anchor (or end of body),
+        and ``rejected_body`` is the stripped text after the Rejected anchor, or
+        ``None`` when there is no Rejected anchor.
     """
-    pattern = re.compile(rf"^##\s+{re.escape(heading)}\s*$", re.MULTILINE)
-    m = pattern.search(body)
-    if not m:
-        return None
-    start = m.end()
-    next_section = _SECTION_START.search(body[start:])
-    section = body[start : start + next_section.start()] if next_section else body[start:]
-    return section.strip()
+    lines = body.split("\n")
+
+    in_fence = False
+    decision_idx: int | None = None
+    rejected_idx: int | None = None
+
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped.startswith("```") or stripped.startswith("~~~"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        trimmed = line.rstrip()
+        if decision_idx is None:
+            if trimmed == _DECISION_ANCHOR:
+                decision_idx = i
+            continue
+        if trimmed == _REJECTED_ANCHOR:
+            rejected_idx = i
+
+    if decision_idx is None:
+        return None, None
+
+    if rejected_idx is None:
+        rationale = "\n".join(lines[decision_idx + 1 :]).strip()
+        return rationale, None
+
+    rationale = "\n".join(lines[decision_idx + 1 : rejected_idx]).strip()
+    rejected_body = "\n".join(lines[rejected_idx + 1 :]).strip()
+    return rationale, rejected_body
 
 
 def _parse_rejected_subsections(section_text: str) -> list[RejectedAlternative]:

--- a/packages/nauro-core/tests/test_decision_model.py
+++ b/packages/nauro-core/tests/test_decision_model.py
@@ -203,6 +203,163 @@ class TestRejectedAlternativeRoundTrip:
         assert [r.reason for r in reparsed.rejected] == [r.reason for r in decision.rejected]
 
 
+# ── Rationale boundary: subsections, fences, whole-line anchoring ──
+
+
+class TestRationaleBoundary:
+    """The rationale may contain arbitrary `##`/`###`/`---` and fenced code.
+
+    The parser anchors only on non-fenced whole-line `## Decision` and the
+    last non-fenced whole-line `## Rejected Alternatives`.
+    """
+
+    def test_rationale_with_subsections_preserved(self) -> None:
+        """A rationale with `## Tradeoffs`, `### Detail`, `---`, and trailing
+        prose is preserved in full, and reformat is byte-identical idempotent."""
+        text = (
+            "---\n"
+            "date: 2026-04-01\n"
+            "confidence: high\n"
+            "---\n\n"
+            "# 050 — Decision with rich rationale\n\n"
+            "## Decision\n\n"
+            "Lead paragraph describing the chosen path.\n\n"
+            "## Tradeoffs\n\n"
+            "We accept slower cold starts for simpler code.\n\n"
+            "### Detail\n\n"
+            "The fan-out adds bounded latency.\n\n"
+            "---\n\n"
+            "Trailing prose after a horizontal rule.\n"
+        )
+        d = parse_decision(text, "050-rich-rationale.md")
+        assert "## Tradeoffs" in d.rationale
+        assert "### Detail" in d.rationale
+        assert "---" in d.rationale
+        assert "Trailing prose after a horizontal rule." in d.rationale
+        # Not truncated to the lead paragraph.
+        assert d.rationale != "Lead paragraph describing the chosen path."
+        assert d.rejected == []
+
+        once = format_decision(d)
+        twice = format_decision(parse_decision(once, "050-rich-rationale.md"))
+        assert once == twice
+
+    def test_literal_rejected_heading_in_rationale_not_fabricated(self) -> None:
+        """A literal `## Rejected Alternatives` + `### Fake` mid-rationale must
+        stay in the rationale; only the REAL trailing section is parsed."""
+        text = (
+            "---\n"
+            "date: 2026-04-01\n"
+            "confidence: high\n"
+            "---\n\n"
+            "# 051 — Worst case literal heading\n\n"
+            "## Decision\n\n"
+            "We discuss a hypothetical below.\n\n"
+            "## Rejected Alternatives\n\n"
+            "### Fake\n\n"
+            "This is prose inside the rationale, not a real rejection.\n\n"
+            "## Rejected Alternatives\n\n"
+            "### Real Option\n\n"
+            "The genuinely-rejected alternative, with its reason.\n"
+        )
+        d = parse_decision(text, "051-worst-case.md")
+        # The literal earlier heading and its fake subsection stay in rationale.
+        assert "## Rejected Alternatives" in d.rationale
+        assert "### Fake" in d.rationale
+        assert "This is prose inside the rationale, not a real rejection." in d.rationale
+        # Only the real option is parsed; no fabricated "Fake" record.
+        assert [r.name for r in d.rejected] == ["Real Option"]
+
+    def test_midline_heading_mention_does_not_truncate(self) -> None:
+        """A mid-line mention of the heading words must not anchor."""
+        text = (
+            "---\n"
+            "date: 2026-04-01\n"
+            "confidence: high\n"
+            "---\n\n"
+            "# 052 — Mid-line mention\n\n"
+            "## Decision\n\n"
+            "We reference the ## Decision marker inline and also a phrase like "
+            "the ## Rejected Alternatives heading mid-sentence.\n\n"
+            "More rationale follows the inline mentions.\n"
+        )
+        d = parse_decision(text, "052-midline.md")
+        assert "More rationale follows the inline mentions." in d.rationale
+        assert "## Rejected Alternatives heading mid-sentence" in d.rationale
+        assert d.rejected == []
+
+    def test_fenced_rejected_heading_not_anchor(self) -> None:
+        """A fenced code block containing a `## Rejected Alternatives` line with
+        NO real rejected section: the fenced heading is not an anchor, the full
+        rationale (including the fence) is preserved, rejected == []."""
+        text = (
+            "---\n"
+            "date: 2026-04-01\n"
+            "confidence: high\n"
+            "---\n\n"
+            "# 053 — Fenced heading only\n\n"
+            "## Decision\n\n"
+            "We show a sample document below.\n\n"
+            "```markdown\n"
+            "## Rejected Alternatives\n\n"
+            "### Not Real\n"
+            "```\n\n"
+            "Closing rationale after the fence.\n"
+        )
+        d = parse_decision(text, "053-fenced-only.md")
+        assert "```markdown" in d.rationale
+        assert "## Rejected Alternatives" in d.rationale
+        assert "### Not Real" in d.rationale
+        assert "Closing rationale after the fence." in d.rationale
+        assert d.rejected == []
+
+    def test_fenced_heading_plus_real_section(self) -> None:
+        """A fenced `## Rejected Alternatives` inside the rationale AND a real
+        rejected section after the fence: the real section is the anchor."""
+        text = (
+            "---\n"
+            "date: 2026-04-01\n"
+            "confidence: high\n"
+            "---\n\n"
+            "# 054 — Fence plus real section\n\n"
+            "## Decision\n\n"
+            "Here is an illustrative document:\n\n"
+            "```\n"
+            "## Rejected Alternatives\n"
+            "### Illustrative Only\n"
+            "```\n\n"
+            "And here is the actual reasoning.\n\n"
+            "## Rejected Alternatives\n\n"
+            "### Genuine Option\n\n"
+            "The real reason this was rejected.\n"
+        )
+        d = parse_decision(text, "054-fence-plus-real.md")
+        # Fenced heading stays in the rationale.
+        assert "### Illustrative Only" in d.rationale
+        assert "And here is the actual reasoning." in d.rationale
+        # Only the real, post-fence section is parsed.
+        assert [r.name for r in d.rejected] == ["Genuine Option"]
+        assert d.rejected[0].reason == "The real reason this was rejected."
+
+    def test_no_rejected_section_full_rationale(self) -> None:
+        """No rejected section: rejected == [] and the full rationale is kept."""
+        text = (
+            "---\n"
+            "date: 2026-04-01\n"
+            "confidence: high\n"
+            "---\n\n"
+            "# 055 — No rejected\n\n"
+            "## Decision\n\n"
+            "First paragraph.\n\n"
+            "## Context\n\n"
+            "Second paragraph with a subsection heading.\n"
+        )
+        d = parse_decision(text, "055-no-rejected.md")
+        assert "## Context" in d.rationale
+        assert "Second paragraph with a subsection heading." in d.rationale
+        assert d.rejected == []
+
+
 # ── Positive: optional fields accept None / empty ──
 
 


### PR DESCRIPTION
## Why

The decision parser silently truncated the rationale. `_extract_section_body`
returned a section body only up to the next `## ` of any kind, but agents write
`## Tradeoffs`, `## Context`, and `### Detail` subsections inside the rationale.
The result was that the parsed rationale was cut down to its lead paragraph.

The truncation propagated three ways:
1. Read-path indexers (`search.py`, `embeddings.py`) and `check_decision` only
   ever saw the truncated lead.
2. A later update or supersede reformatted the truncated rationale back to the
   store, making the loss permanent.
3. Because the match took the first occurrence, a literal `## Rejected
   Alternatives` line written inside a rationale was parsed as a fabricated
   rejected-alternative record, while the real rejected block below it was
   dropped.

## Approach

The doctrine move: a decision rationale may contain arbitrary `##`/`###`
subsections, `---` rules, and fenced code blocks. The parser anchors only on
non-fenced whole-line `## Decision` and the last non-fenced whole-line `##
Rejected Alternatives`.

Implementation is a fence-aware line scan instead of a multiline regex:
- Track fenced-code state; a line whose stripped form starts with a code fence
  marker toggles it. Inside a fence, no line can anchor, and the fence-marker
  lines themselves never anchor.
- The Decision anchor is the first non-fenced line equal to `## Decision`
  (whole-line). Missing it raises the same error as before (contract unchanged).
- The Rejected anchor is the last non-fenced whole-line `## Rejected
  Alternatives` after the Decision anchor, so a literal earlier heading stays in
  the rationale and only the genuine trailing block is parsed.

Considered keeping two separate extract calls but the two slices now share one
scan, so they collapse into a single `_split_decision_body` helper called once
from `parse_decision`. Plain string operations throughout (`split` + whole-line
compare + fence toggle); the now-dead section-start regex is removed.

## What changed

- `decision_model.py`: replaced the regex section extractor with
  `_split_decision_body`, returning `(rationale, rejected_body)` from one pass;
  removed the dead section-start regex; added whole-line anchor constants.
  `parse_decision`'s public contract is unchanged.
- Tests: added boundary coverage for subsections, the literal-heading worst
  case, mid-line mentions, and the two fence cases.

## What to review

- The fence toggle and whole-line equality logic in `_split_decision_body`, and
  the "last Rejected anchor wins" choice that disambiguates a literal heading in
  the rationale from the real block.
- This is forward-only. Decisions already truncated by a prior update or
  supersede have lost the original rationale from the store; there is no source
  to back-fill from, so they are not auto-repaired. Only decisions parsed from
  intact source benefit.

## What's deferred

Nothing in scope was cut. No backfill of already-truncated decisions is
possible and none is attempted.

## Test plan

- nauro-core decision_model suite: 48 passed (42 prior + 6 new boundary cases).
- nauro-core full suite: 753 passed.
- nauro full suite (cross-surface parity, since decision_model is the shared
  kernel both packages consume): 1326 passed, 10 skipped.
- ruff check + format check: clean.
