### PR TITLE
Release: nauro 0.12.4 + nauro-core 0.13.7

### DIFF
--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro-core"
-version = "0.13.6"
+version = "0.13.7"
 description = "Shared pure-Python logic for Nauro: parsing, validation, context assembly, constants."
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro"
-version = "0.12.3"
+version = "0.12.4"
 description = "Local CLI + MCP server: set your project's doctrine once, every connected AI agent inherits it."
 readme = "README.md"
 license = "Apache-2.0"
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "nauro-core>=0.13.6,<0.14",
+    "nauro-core>=0.13.7,<0.14",
     "typer>=0.9",
     "httpx>=0.24",
     "mcp>=1.0",


### PR DESCRIPTION
## Why

Two data-correctness fixes merged after the 0.12.3 / 0.13.6 release but are not yet
on PyPI, so `pipx install nauro` still ships the versions with the bugs:

- Decision files were silently corrupted when a sync conflict hit a `decisions/` file
  (the conflict was union-merged into one file with interleaved bodies and duplicate
  frontmatter, reported as a successful merge). Fixed in the nauro package.
- Decision rationale containing `##` / `###` subsections was truncated to its lead
  paragraph, degrading search, conflict-detection, and the embeddings index, and the
  loss became permanent on the next update or supersede. Fixed in nauro-core.

Both land on the decision artifact itself, the surface the product leads with, so they
should reach launch-day installers.

## What changed

- `packages/nauro/pyproject.toml`: version 0.12.3 -> 0.12.4.
- `packages/nauro-core/pyproject.toml`: version 0.13.6 -> 0.13.7.
- `packages/nauro/pyproject.toml`: lift the `nauro-core` floor from `>=0.13.6` to
  `>=0.13.7` so an installed CLI cannot resolve a core that lacks the rationale fix.

Patch bumps: both changes are bug fixes, no API change.

## Release steps (after merge)

PyPI publish is tag-triggered. Push `nauro-core-v0.13.7` first, then `nauro-v0.12.4`,
so the core is on the index before the CLI resolves its `>=0.13.7` floor. Then cut the
matching GitHub Releases.

## Test plan

- `ruff check` and `ruff format --check` clean across `packages/`.
- pyproject-only change; `uv.lock` is gitignored in this repo, so no lockfile delta.
- The underlying fixes ship with their own tests (already merged and green on main).
