### PR TITLE
Lead install docs with `uv tool install`, pipx/pip as fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ No model judges your decisions. The check is advisory and never blocks a change.
 ## Install
 
 ```bash
-pipx install nauro   # or: pip install nauro
+uv tool install nauro     # uv fetches its own Python — nothing else needed
 ```
 
-Requires Python 3.10+.
+No `uv`? Install it with `curl -LsSf https://astral.sh/uv/install.sh | sh` (macOS/Linux) or the [PowerShell line](https://docs.astral.sh/uv/getting-started/installation/) on Windows. Already on Python 3.10+? `pipx install nauro` (or `pip install nauro`) works too.
 
 ## Quickstart
 
@@ -144,9 +144,9 @@ Repeat `--files-affected` for each entry. `--rejected` accepts inline JSON, `@fi
 
 ## Packages
 
-| Package | Path | PyPI |
+| Package | Path | Install |
 |---|---|---|
-| `nauro` | `packages/nauro/` | `pip install nauro` |
+| `nauro` | `packages/nauro/` | `uv tool install nauro` |
 | `nauro-core` | `packages/nauro-core/` | `pip install nauro-core` |
 
 `nauro-core` is the parsing, validation, and context assembly shared between the CLI and the hosted MCP server. Minimal dependencies; usable by third-party tools that read or write the Nauro decision format.

--- a/packages/nauro/README.md
+++ b/packages/nauro/README.md
@@ -7,10 +7,10 @@ Catch the moment an agent re-proposes something your team already ruled out. You
 ## Install
 
 ```bash
-pipx install nauro   # or: pip install nauro
+uv tool install nauro     # uv fetches its own Python — nothing else needed
 ```
 
-Requires Python 3.10+.
+No `uv`? Install it with `curl -LsSf https://astral.sh/uv/install.sh | sh` (macOS/Linux) or the [PowerShell line](https://docs.astral.sh/uv/getting-started/installation/) on Windows. Already on Python 3.10+? `pipx install nauro` (or `pip install nauro`) works too.
 
 ## Quickstart
 


### PR DESCRIPTION
## Why

The README and PyPI page lead with `pipx install nauro` and "Requires Python 3.10+". For the polyglot audience a Show HN draws, many readers have no suitable Python on PATH: a fresh macOS ships system Python 3.9 (Xcode CLT), so `pip install nauro` is rejected by `requires-python`; a fresh Windows ships none; and pipx itself needs 3.10+. The very first command in the README hard-fails for exactly the people we most want to reach.

## Approach

Lead with `uv tool install nauro`. uv auto-provisions its own managed CPython, so the Python-version constraint disappears from the user's view — on a machine with zero Python on PATH, uv downloads a CPython and runs `nauro` in seconds. pipx/pip drop to an "already have Python 3.10+" fallback, plus the uv bootstrap one-liner for readers without uv.

Alternatives weighed: keeping pipx primary and only mentioning uv (doesn't fix the first-command failure for the no-Python segment, since pipx also needs 3.10+); lowering the `requires-python` floor to 3.9 (a multi-failure-class refactor for an upstream-EOL target — uv provisioning gets the reach without touching the floor). The `>=3.10` floor is unchanged, and `nauro-core` (a library, not a CLI tool) stays `pip install nauro-core`.

## What changed

- `README.md` — install block now leads with `uv tool install nauro` + the bootstrap line; the Packages table's install column for the `nauro` CLI uses uv (`nauro-core` stays pip).
- `packages/nauro/README.md` (the PyPI page) — same install block.

## What to review

The exact install copy — the fallback phrasing and the bootstrap one-liner. Docs-only; no code paths touched.

## What's deferred

The 3.14 classifier + CI-matrix expansion (3.13/3.14) is a separate change. A standalone binary / Homebrew formula stays deferred.

## Test plan

Docs-only. `ruff check packages/` and `ruff format --check packages/` pass (no Python source touched).
