### PR TITLE
Test 3.13 + 3.14 in CI; declare the 3.14 classifier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v6
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v6

--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
     "bm25s>=0.2",

--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
     "nauro-core>=0.13.7,<0.14",


### PR DESCRIPTION
## Why

The classifiers advertised Python 3.13, but CI only tested 3.10–3.12 — and 3.14 (the current stable, and what `uv tool install nauro` now provisions for new users by default) was neither declared nor tested. Launch traffic therefore lands on interpreters no CI job exercises: 3.13 was an unverified claim, 3.14 an undeclared one. A future dependency bump could silently break either and CI would never notice.

## Approach

Close the gap rather than narrow the claim: add the `Python :: 3.14` classifier (3.13 was already listed) and extend both test matrices to `["3.10", "3.11", "3.12", "3.13", "3.14"]`, so every advertised version is actually tested. The `>=3.10` floor is unchanged and no upper cap is added — nothing requires capping, and a cap would hard-break the 3.14 users uv provisions by default. pydantic is left to resolve its own matched core pair (no pin).

## What changed

- `.github/workflows/ci.yml` — the `test-nauro-core` and `test-nauro` matrices now include 3.13 and 3.14.
- `packages/nauro/pyproject.toml`, `packages/nauro-core/pyproject.toml` — add the `Python :: 3.14` classifier.

## What to review

That CI can provision 3.13/3.14 via `uv python install` (python-build-standalone ships both) and that the compiled deps have wheels there — PyStemmer, pydantic-core, numpy, and PyYAML all ship cp313 + cp314 manylinux wheels, so the runner never falls back to a source build.

## What's deferred

A macOS and a Windows CI runner. The code is portable (no POSIX-only calls; paths via pathlib), but only Linux is exercised today. Out of scope here.

## Test plan

Ran both suites locally under 3.13 and 3.14, mirroring the CI invocation (`uv sync --all-extras` then pytest, `cross_surface` excluded for nauro as CI does):

- Python 3.13 — nauro-core **753 passed**, nauro **1327 passed**
- Python 3.14 — nauro-core **753 passed**, nauro **1327 passed**
