### PR TITLE
Mask nested credentials in nauro config output

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/config.py
+++ b/packages/nauro/src/nauro/cli/commands/config.py
@@ -18,10 +18,31 @@ from nauro.store.config import (
 config_app = typer.Typer(help="Inspect and remove Nauro configuration.")
 
 
-def _mask(key: str, value: str) -> str:
-    """Mask sensitive values (keys/tokens) for display."""
-    if "key" in key.lower() and len(value) > 8:
-        return value[:4] + "..." + value[-4:]
+# Substrings that mark a config key (at any nesting depth) as sensitive. The
+# `auth` block nests credentials under `access_token` / `refresh_token`, so
+# matching must look inside dict values, not just top-level string keys.
+_SENSITIVE_KEY_MARKERS = ("key", "token", "secret", "password", "credential")
+
+
+def _is_sensitive_key(key: str) -> bool:
+    lowered = key.lower()
+    return any(marker in lowered for marker in _SENSITIVE_KEY_MARKERS)
+
+
+def _mask(key: str, value: object) -> object:
+    """Mask sensitive values (keys/tokens) for display.
+
+    Recurses into dicts so nested credentials — notably the bearer and refresh
+    tokens under the ``auth`` block — are never printed in full. A sensitive
+    string is shown as ``abcd...wxyz``; a short sensitive string is fully
+    redacted; non-sensitive values pass through unchanged.
+    """
+    if isinstance(value, dict):
+        return {k: _mask(k, v) for k, v in value.items()}
+    if isinstance(value, str) and _is_sensitive_key(key):
+        if len(value) > 8:
+            return value[:4] + "..." + value[-4:]
+        return "***"
     return value
 
 
@@ -45,8 +66,7 @@ def config_list() -> None:
         typer.echo("No configuration set.")
         return
     for key, value in sorted(data.items()):
-        display = _mask(key, value) if isinstance(value, str) else value
-        typer.echo(f"{key}: {display}")
+        typer.echo(f"{key}: {_mask(key, value)}")
 
 
 @config_app.command(name="unset")

--- a/packages/nauro/tests/test_config.py
+++ b/packages/nauro/tests/test_config.py
@@ -98,6 +98,36 @@ def test_config_list_empty_cli(tmp_path, monkeypatch):
     assert "No configuration set" in result.output
 
 
+# Credentials live in a nested ``auth`` dict; the display must redact the bearer
+# and refresh tokens (which `_mask`'s string-only path used to skip entirely)
+# while leaving the non-secret identity fields visible, as `auth status` does.
+_FAKE_AUTH = {
+    "sub": "auth0|FAKE123",
+    "access_token": "AT_SECRET_eyJleUFAKEBEARER",
+    "refresh_token": "RT_SECRET_v1FAKEREFRESH",
+}
+
+
+def test_config_get_auth_masks_nested_tokens(tmp_path, monkeypatch):
+    save_config({"auth": dict(_FAKE_AUTH)})
+    result = runner.invoke(app, ["config", "get", "auth"])
+    assert result.exit_code == 0
+    assert "AT_SECRET_eyJleUFAKEBEARER" not in result.output
+    assert "RT_SECRET_v1FAKEREFRESH" not in result.output
+    # Non-secret identity field stays visible.
+    assert "auth0|FAKE123" in result.output
+
+
+def test_config_list_masks_auth_block(tmp_path, monkeypatch):
+    save_config({"auth": dict(_FAKE_AUTH), "model": "haiku"})
+    result = runner.invoke(app, ["config", "list"])
+    assert result.exit_code == 0
+    assert "AT_SECRET_eyJleUFAKEBEARER" not in result.output
+    assert "RT_SECRET_v1FAKEREFRESH" not in result.output
+    # Non-sensitive values are untouched.
+    assert "model: haiku" in result.output
+
+
 def test_config_unset_cli(tmp_path, monkeypatch):
     set_config("secret_key", "sk-test")
     result = runner.invoke(app, ["config", "unset", "secret_key"])


### PR DESCRIPTION
## Why

`nauro config get auth` and `nauro config list` printed the Auth0 `access_token` and `refresh_token` in cleartext. The masking helper only redacted top-level *string* values whose key contained `"key"`; credentials live in a nested `auth` dict, so the whole block bypassed masking. This is the exact command CLAUDE.md points users to for inspecting auth, and `config list` is a natural "paste this into a bug report / screen-share" reflex — so a user could leak live bearer + refresh tokens into terminal scrollback without realizing it.

## Approach

Make masking recurse into dict values and broaden the sensitive-key match beyond `key` to also cover `token`/`secret`/`password`/`credential`. The alternative — special-casing the `auth` block — was rejected because it wouldn't catch future nested secrets; a general recursive mask is the durable fix. Non-secret identity fields (`sub`, `user_id`, `sanitized_sub`) stay visible, matching what `nauro auth status` already shows.

## What changed

- `cli/commands/config.py`: `_mask` now recurses into dicts and redacts any sensitive-keyed string as `abcd...wxyz` (short ones fully to `***`); both `config get` and `config list` route every value through it.

## What to review

- The recursion handles non-str/non-dict values (ints, bools, `None`) by passing them through unchanged. Lists are not recursed — no list-valued secret exists in the config today, noted as a future hardening only.
- `config get auth.access_token` (dotted) still returns `(not set)` — config lookup is top-level only, unchanged.

## What's deferred

- Recursing into list values (no current config stores secrets in a list).

## Test plan

`uv run pytest packages/nauro/tests/test_config.py` — 17 pass, including 2 new tests asserting both tokens are absent from `config get auth` / `config list` output while `sub` remains visible. Lint clean. Verified live: tokens now render as `AT_S...ALUE`.
