### PR TITLE
Tolerate non-UTF-8 bytes in store reads

### DIFF
--- a/packages/nauro/src/nauro/mcp/tools.py
+++ b/packages/nauro/src/nauro/mcp/tools.py
@@ -60,6 +60,7 @@ from nauro.onboarding import (
 from nauro.store.config import resolve_embeddings_flag
 from nauro.store.decision_lock import decision_write_lock
 from nauro.store.filesystem_store import FilesystemStore
+from nauro.store.reader import read_text_lenient
 from nauro.store.snapshot import (
     capture_snapshot,
     list_snapshots,
@@ -200,11 +201,11 @@ def _last_synced_trailer(store_path: Path) -> str:
     state = ""
     current = store_path / STATE_CURRENT_FILENAME
     if current.exists():
-        state = current.read_text()
+        state = read_text_lenient(current)
     else:
         legacy = store_path / STATE_MD
         if legacy.exists():
-            state = legacy.read_text()
+            state = read_text_lenient(legacy)
     marker = "**Last synced:**"
     line = next((line for line in state.splitlines() if marker in line), None)
     if line is None:

--- a/packages/nauro/src/nauro/store/filesystem_store.py
+++ b/packages/nauro/src/nauro/store/filesystem_store.py
@@ -12,6 +12,8 @@ from pathlib import Path
 from filelock import FileLock
 from nauro_core.constants import DECISIONS_DIR
 
+from nauro.store.reader import read_text_lenient
+
 
 class FilesystemStore:
     """Concrete ``Store`` rooted at a single project's on-disk directory.
@@ -46,7 +48,7 @@ class FilesystemStore:
             return None
         if not target.exists() or not target.is_file():
             return None
-        return target.read_text()
+        return read_text_lenient(target)
 
     # Per-write FileLock only — no cross-file lock to serialize decision
     # numbering across concurrent writers. Collisions (two writers minting
@@ -80,7 +82,7 @@ class FilesystemStore:
         target = self._store_path / DECISIONS_DIR / f"{file_stem}.md"
         if not target.exists():
             return None
-        return target.read_text()
+        return read_text_lenient(target)
 
     # Serial loop, no thread pool: local disk reads are fast and a pool would
     # contend with the per-write FileLock. Byte-identical to scanning the

--- a/packages/nauro/src/nauro/store/reader.py
+++ b/packages/nauro/src/nauro/store/reader.py
@@ -11,10 +11,22 @@ from nauro_core.decision_model import Decision, DecisionStatus
 from nauro.constants import DECISIONS_DIR
 
 
+def read_text_lenient(path: Path) -> str:
+    """Read a store file as UTF-8, replacing any undecodable bytes.
+
+    Store markdown is freeform and hand/agent-editable, so a file saved in a
+    legacy encoding — a smart quote pasted from a non-UTF-8 editor, an imported
+    doc in cp1252 — must not crash a read. Decoding with ``errors="replace"``
+    keeps the whole read surface (get_context, sync, search) working on a
+    mostly-valid file instead of aborting the command on a single bad byte.
+    """
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
 def _read_file(path: Path) -> str:
     """Read a file, return empty string if missing."""
     if path.exists():
-        return path.read_text()
+        return read_text_lenient(path)
     return ""
 
 
@@ -26,7 +38,7 @@ def _list_decisions(store_path: Path) -> list[Decision]:
 
     results: list[Decision] = []
     for f in sorted(decisions_dir.glob("*.md")):
-        content = f.read_text()
+        content = read_text_lenient(f)
         results.append(parse_decision(content, f.name))
     return results
 

--- a/packages/nauro/src/nauro/store/snapshot.py
+++ b/packages/nauro/src/nauro/store/snapshot.py
@@ -27,6 +27,7 @@ from nauro.constants import (
     PRUNE_WEEKLY_DAYS,
     SNAPSHOTS_DIR,
 )
+from nauro.store.reader import read_text_lenient
 
 logger = logging.getLogger("nauro.snapshot")
 
@@ -76,12 +77,12 @@ def capture_snapshot(store_path: Path, trigger: str = "", trigger_detail: str = 
         # Read all markdown files
         files = {}
         for md in sorted(store_path.glob("*.md")):
-            files[md.name] = md.read_text()
+            files[md.name] = read_text_lenient(md)
 
         decisions_dir = store_path / DECISIONS_DIR
         if decisions_dir.exists():
             for md in sorted(decisions_dir.glob("*.md")):
-                files[f"{DECISIONS_DIR}/{md.name}"] = md.read_text()
+                files[f"{DECISIONS_DIR}/{md.name}"] = read_text_lenient(md)
 
         snapshot = serialize_snapshot(
             timestamp=datetime.now(timezone.utc).isoformat(),

--- a/packages/nauro/src/nauro/store/validator.py
+++ b/packages/nauro/src/nauro/store/validator.py
@@ -16,6 +16,7 @@ from nauro.constants import (
     STATE_LEGACY_FILENAME,
     VALIDATED_STORE_FILES,
 )
+from nauro.store.reader import read_text_lenient
 
 logger = logging.getLogger("nauro.store.validator")
 
@@ -42,7 +43,7 @@ def validate_store(store_path: Path) -> list[str]:
         filepath = store_path / filename
         if not filepath.exists():
             continue
-        content = filepath.read_text()
+        content = read_text_lenient(filepath)
         # Filter out markdown links [text](url) and timestamps [2026-01-01 ...]
         unfilled = []
         for m in re.finditer(r"\[([^\]]+)\]", content):
@@ -71,7 +72,7 @@ def validate_store(store_path: Path) -> list[str]:
     if not state_path.exists():
         state_path = store_path / STATE_LEGACY_FILENAME
     if state_path.exists():
-        content = state_path.read_text()
+        content = read_text_lenient(state_path)
         synced_str: str | None = None
         for line in content.splitlines():
             stripped = line.strip()

--- a/packages/nauro/tests/test_read_encoding.py
+++ b/packages/nauro/tests/test_read_encoding.py
@@ -1,0 +1,80 @@
+"""Store reads must tolerate non-UTF-8 bytes.
+
+Store markdown is freeform and hand/agent-editable, so a file saved in a legacy
+encoding (a smart quote from a non-UTF-8 editor, an imported cp1252 doc) used to
+crash the whole read surface with an unhandled UnicodeDecodeError. Reads now
+decode with errors="replace"; these tests pin that the headline read commands,
+snapshot capture, and the Store protocol all survive a stray byte.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from nauro import constants
+from nauro.demo import create_demo_project
+from nauro.mcp.tools import tool_get_context, tool_get_raw_file
+from nauro.store.filesystem_store import FilesystemStore
+from nauro.store.reader import _list_decisions, read_text_lenient
+from nauro.store.snapshot import capture_snapshot
+
+# A lone 0xe9 is "é" in latin-1/cp1252 but an invalid UTF-8 start byte.
+_BAD_BYTE = b"\xe9"
+_REPLACEMENT = "�"
+
+
+@pytest.fixture()
+def poisoned_store(tmp_path: Path) -> Path:
+    """A valid demo store with one non-UTF-8 byte in state and in a decision."""
+    store_path = tmp_path / "projects" / "demo-project"
+    create_demo_project(store_path)
+
+    state = store_path / constants.STATE_CURRENT_FILENAME
+    state.write_bytes(b"# Current State\n\nStatus: caf" + _BAD_BYTE + b" shipped\n")
+
+    decision = sorted((store_path / constants.DECISIONS_DIR).glob("*.md"))[0]
+    decision.write_bytes(decision.read_bytes() + b"\nlegacy note: na" + _BAD_BYTE + b"ve\n")
+    return store_path
+
+
+def test_read_text_lenient_replaces_bad_byte(poisoned_store):
+    state = poisoned_store / constants.STATE_CURRENT_FILENAME
+    text = read_text_lenient(state)
+    assert _REPLACEMENT in text
+    assert "Status: caf" in text
+
+
+@pytest.mark.parametrize("level", [0, 1, 2])
+def test_get_context_survives_non_utf8(poisoned_store, level):
+    # The headline read command must not raise on a poisoned store.
+    result = tool_get_context(poisoned_store, level)
+    assert isinstance(result["content"], str)
+    assert result["content"]
+
+
+def test_list_decisions_survives_non_utf8(poisoned_store):
+    decisions = _list_decisions(poisoned_store)
+    assert len(decisions) == 7  # all still parse, none crash the read
+
+
+def test_get_raw_file_survives_non_utf8(poisoned_store):
+    # get-raw-file is one of the headline read commands; it must not crash.
+    result = tool_get_raw_file(poisoned_store, constants.STATE_CURRENT_FILENAME)
+    assert result.get("error") is None
+    # ensure_ascii=False keeps the literal U+FFFD so the substring check is valid.
+    assert _REPLACEMENT in json.dumps(result, ensure_ascii=False)
+
+
+def test_filesystem_store_reads_survive_non_utf8(poisoned_store):
+    store = FilesystemStore(poisoned_store)
+    state = store.read_file(constants.STATE_CURRENT_FILENAME)
+    assert state is not None and _REPLACEMENT in state
+    for stem in store.list_decisions():
+        assert store.read_decision(stem) is not None
+
+
+def test_snapshot_capture_survives_non_utf8(poisoned_store):
+    # sync regenerates AGENTS.md off a snapshot; capture reads every md file.
+    version = capture_snapshot(poisoned_store, trigger="test")
+    assert version >= 1


### PR DESCRIPTION
## Why

Every store read used `Path.read_text()` in strict UTF-8 mode. Store markdown is documented as freeform and hand/agent-editable, so a single non-UTF-8 byte — a smart quote pasted from a legacy editor, an imported cp1252 doc — crashed the entire read surface with an unhandled `UnicodeDecodeError` traceback: `get-context` (the headline read), `sync`, `list`/`search-decisions`, `get-raw-file`, and `validate`. Once a byte landed in a store file, those commands stayed broken.

## Approach

Add one `read_text_lenient` helper (`errors="replace"`) and route the freeform-markdown reads through it. `errors="replace"` (degrade a bad byte to U+FFFD, keep working) was chosen over raising a clean per-file error, because the value prop is that `get-context` keeps working on a mostly-valid store rather than aborting on one byte. This mirrors the existing `sync/pull.py` decode pattern. JSON files (config, registry, snapshot `v*.json`, repo config) are deliberately left strict — silently replacing bytes there would mask real corruption.

## What changed

- `store/reader.py`: new `read_text_lenient`; the two content reads use it.
- `store/filesystem_store.py`: `read_file` / `read_decision` use it (covers `get-context` project/stack/open-questions + decisions, `get-raw-file`, `search`).
- `store/snapshot.py`: the two markdown-content reads in `capture_snapshot`.
- `store/validator.py`: the two store-file reads.
- `mcp/tools.py`: the `get-context` state trailer read.

## What to review

- No new import cycle: `reader` imports only `nauro_core` + `nauro.constants`; the other modules import `reader` one-directionally.
- Confirm only freeform markdown reads changed — every JSON read stays strict.

## What's deferred

- Repo-side files read during sync (`AGENTS.md`, `CLAUDE.md`) remain strict — out of scope here (not store content).

## Test plan

New `tests/test_read_encoding.py` (8 tests) injects an invalid UTF-8 byte into state and a decision file and asserts no crash + replacement char across `get_context` L0/L1/L2, `get_raw_file`, `list_decisions` (still parses all 7), the `FilesystemStore` reads, and snapshot capture. Full nauro suite green; lint clean.
