### PR TITLE
Harden ADR/Memory-Bank import: non-UTF-8 sources and honest counts

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/import_cmd.py
+++ b/packages/nauro/src/nauro/cli/commands/import_cmd.py
@@ -22,6 +22,17 @@ from nauro.store.snapshot import capture_snapshot
 from nauro.store.store_lock import store_write_lock
 
 
+def _read(path: Path) -> str:
+    """Read an import source file, replacing any undecodable bytes.
+
+    ADR and Memory-Bank sources are often legacy docs (cp1252/latin-1), or a
+    directory carries a stray binary file. Strict UTF-8 would abort the whole
+    migration with a traceback on the first bad byte; errors="replace" lets the
+    import proceed and the user see what came through.
+    """
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
 def _import_append_decision(
     store_path: Path,
     title: str,
@@ -70,6 +81,9 @@ def _import_memory_bank(memory_bank: Path, store_path: Path) -> dict[str, int]:
         "files_merged": 0,
         "decisions": 0,
         "progress_items": 0,
+        # Set when decisionLog.md had content but no block matched the expected
+        # heading, so the caller can warn instead of reporting a silent success.
+        "decisionlog_unparsed": 0,
     }
 
     # projectBrief.md → project.md
@@ -77,7 +91,7 @@ def _import_memory_bank(memory_bank: Path, store_path: Path) -> dict[str, int]:
     if brief_path.exists():
         _append_to_store_file(
             store_path / PROJECT_MD,
-            brief_path.read_text(),
+            _read(brief_path),
         )
         counts["files_merged"] += 1
 
@@ -86,27 +100,30 @@ def _import_memory_bank(memory_bank: Path, store_path: Path) -> dict[str, int]:
     if tech_path.exists():
         _append_to_store_file(
             store_path / STACK_MD,
-            tech_path.read_text(),
+            _read(tech_path),
         )
         counts["files_merged"] += 1
 
     # decisionLog.md → decisions/NNN-title.md
     decision_log = memory_bank / "decisionLog.md"
     if decision_log.exists():
-        counts["decisions"] = _parse_and_import_decisions(decision_log.read_text(), store_path)
+        log_text = _read(decision_log)
+        counts["decisions"] = _parse_and_import_decisions(log_text, store_path)
+        if counts["decisions"] == 0 and log_text.strip():
+            counts["decisionlog_unparsed"] = 1
 
     # activeContext.md + progress.md → state_current.md (one composed update_state)
     active_body: str | None = None
     active_path = memory_bank / "activeContext.md"
     if active_path.exists():
-        active_body = _strip_h1_prefix(active_path.read_text())
+        active_body = _strip_h1_prefix(_read(active_path))
         if active_body:
             counts["files_merged"] += 1
 
     progress_items: list[str] = []
     progress_path = memory_bank / "progress.md"
     if progress_path.exists():
-        progress_items = _import_progress(progress_path.read_text())
+        progress_items = _import_progress(_read(progress_path))
     counts["progress_items"] = len(progress_items)
 
     delta = _compose_state_delta(active_body, progress_items)
@@ -166,7 +183,7 @@ def _append_to_store_file(target: Path, content: str) -> None:
         return
 
     if target.exists():
-        existing = target.read_text()
+        existing = _read(target)
         target.write_text(existing.rstrip() + header + stripped + "\n")
     else:
         target.write_text(header.lstrip() + stripped + "\n")
@@ -227,7 +244,7 @@ def _import_adrs(adr_dir: Path, store_path: Path) -> dict[str, Any]:
     adr_files.sort(key=lambda x: x[0])
 
     for _num, adr_path in adr_files:
-        content = adr_path.read_text()
+        content = _read(adr_path)
         title = _extract_adr_title(content)
         if not title:
             counts["skipped"] += 1
@@ -367,9 +384,18 @@ def _import_progress(content: str) -> list[str]:
 
 
 _Opt_memory_bank = typer.Option(
-    None, "--memory-bank", help="Path to a Cline/Roo Code Memory Bank (.context/ directory)."
+    None,
+    "--memory-bank",
+    help=(
+        "Path to a Cline/Roo Code Memory Bank (.context/ directory). "
+        "decisionLog.md entries must use '## Decision: <title>' headings to import."
+    ),
 )
-_Opt_adr = typer.Option(None, "--adr", help="Path to an Architecture Decision Records directory.")
+_Opt_adr = typer.Option(
+    None,
+    "--adr",
+    help="Path to an Architecture Decision Records directory (files named '<NNN>-title.md').",
+)
 
 
 def import_cmd(
@@ -412,6 +438,13 @@ def import_cmd(
         typer.echo(f"  {counts['files_merged']} file(s) merged")
         typer.echo(f"  {counts['decisions']} decision(s) imported")
         typer.echo(f"  {counts['progress_items']} progress item(s) imported")
+        if counts.get("decisionlog_unparsed"):
+            typer.echo(
+                "  Warning: decisionLog.md had content but no entries matched the "
+                "expected '## Decision: <title>' heading — 0 decisions imported. "
+                "Re-check the heading format (see 'nauro import --help').",
+                err=True,
+            )
         typer.echo("  Next: run 'nauro sync' to update AGENTS.md in associated repos")
 
     if adr is not None:
@@ -429,4 +462,10 @@ def import_cmd(
         typer.echo(f"  {adr_counts['skipped']} ADR(s) skipped")
         for reason in adr_counts.get("_skipped_reasons", []):
             typer.echo(f"    - {reason}")
+        if adr_counts["imported"] == 0 and adr_counts["skipped"] == 0:
+            typer.echo(
+                "  Warning: no ADRs imported. Files must be named '<NNN>-title.md' "
+                "(e.g. 0001-use-postgres.md); other .md files are ignored.",
+                err=True,
+            )
         typer.echo("  Next: run 'nauro sync' to update AGENTS.md in associated repos")

--- a/packages/nauro/tests/test_import.py
+++ b/packages/nauro/tests/test_import.py
@@ -601,3 +601,76 @@ def test_import_adr_cli_integration(tmp_path: Path, monkeypatch, madr_directory:
     snaps = list_snapshots(store)
     assert len(snaps) >= 1
     assert snaps[0]["trigger"] == "import: adr"
+
+
+# --- Hardening: non-UTF-8 sources and honest zero-import warnings ---
+
+
+def test_import_adr_non_utf8_does_not_crash(store: Path, tmp_path: Path):
+    """A legacy-encoded byte in an ADR file must not abort the migration."""
+    adr_dir = tmp_path / "legacy_adrs"
+    adr_dir.mkdir()
+    # Valid ADR structure with a lone 0xe9 ("é" in latin-1) in the body.
+    (adr_dir / "0001-legacy.md").write_bytes(
+        b"# Use a legacy thing\n\n## Context\n\nThe caf" + b"\xe9" + b" service is slow.\n"
+    )
+
+    counts = _import_adrs(adr_dir, store)
+    assert counts["imported"] == 1  # no UnicodeDecodeError; the ADR imports
+
+
+def test_import_memory_bank_unparsed_decisionlog_warns(tmp_path: Path, monkeypatch):
+    """A non-empty decisionLog in Cline's native (non '## Decision:') format
+    imports zero decisions but must say so, not report a silent success."""
+    register_project("myproj", [tmp_path])
+    store = tmp_path / "projects" / "myproj"
+    scaffold_project_store("myproj", store)
+    monkeypatch.chdir(tmp_path)
+
+    mb = tmp_path / ".context_native"
+    mb.mkdir()
+    (mb / "projectBrief.md").write_text("# Brief\n\nA project.\n")
+    (mb / "decisionLog.md").write_text(
+        "# Decision Log\n\n"
+        "[2024-05-01 10:30:00] - Chose REST over GraphQL\n"
+        "[2024-05-02 09:00:00] - Adopted Postgres\n"
+    )
+
+    result = runner.invoke(app, ["import", "--memory-bank", str(mb)])
+    assert result.exit_code == 0
+    assert "0 decision(s) imported" in result.output
+    assert "Warning" in result.output
+    assert "## Decision:" in result.output  # names the expected format
+
+
+def test_import_memory_bank_proper_heading_no_warning(
+    tmp_path: Path, monkeypatch, full_memory_bank: Path
+):
+    """A decisionLog that uses the expected heading imports without the warning."""
+    register_project("myproj", [tmp_path])
+    store = tmp_path / "projects" / "myproj"
+    scaffold_project_store("myproj", store)
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["import", "--memory-bank", str(full_memory_bank)])
+    assert result.exit_code == 0
+    assert "2 decision(s) imported" in result.output
+    assert "Warning" not in result.output
+
+
+def test_import_adr_no_matching_files_warns(tmp_path: Path, monkeypatch):
+    """An ADR dir with only non-'<NNN>-title.md' files imports nothing and says why."""
+    register_project("myproj", [tmp_path])
+    store = tmp_path / "projects" / "myproj"
+    scaffold_project_store("myproj", store)
+    monkeypatch.chdir(tmp_path)
+
+    adr_dir = tmp_path / "loose_adrs"
+    adr_dir.mkdir()
+    (adr_dir / "decision-records.md").write_text("# Notes\n\nSome unstructured notes.\n")
+
+    result = runner.invoke(app, ["import", "--adr", str(adr_dir)])
+    assert result.exit_code == 0
+    assert "0 ADR(s) imported" in result.output
+    assert "Warning" in result.output
+    assert "<NNN>-title.md" in result.output


### PR DESCRIPTION
## Why

Two migration-trust gaps on the documented import on-ramps:

1. `nauro import --adr` crashed with a `UnicodeDecodeError` traceback on the first non-UTF-8 source file. A real ADR directory commonly holds a legacy cp1252/latin-1 doc, so pointing import at an existing folder could abort with a traceback and migrate nothing.
2. `nauro import --memory-bank` reported a silent success — `0 decision(s) imported`, exit 0, no warning — when `decisionLog.md` held content that didn't match the required `## Decision: <title>` heading (e.g. Cline/Roo's native timestamped format). Users believed their decisions migrated when none did.

## Approach

For the crash: route every import source read through a small `_read` helper (`errors="replace"`) so one bad file degrades instead of aborting. For the silent zero-import: detect "log had content but nothing parsed" and warn, naming the expected heading. The minimal honesty fix (warn + document) was chosen over rewriting the parser to accept more formats — broader format support is a larger change with its own regression surface, deferred. ADR import gets the same treatment: warn when no `<NNN>-title.md` files were found. The required formats are now in `--memory-bank` / `--adr` help.

## What changed

- `cli/commands/import_cmd.py`: `_read` lenient helper used for all source reads; `_import_memory_bank` flags an unparsed-but-non-empty `decisionLog.md`; the command warns (stderr, exit still 0) for that case and for a zero-match ADR import; help text documents both formats.

## What to review

- The unparsed warning only fires when `decisionLog.md` was non-empty AND zero decisions parsed — it can't fire when decisions were imported.
- The ADR `imported == 0 and skipped == 0` condition distinguishes "no matching filenames" from "files present but skipped for no title".

## What's deferred

- Parsing additional Memory-Bank decisionLog formats (timestamped entries, varied headings) and splitting multiple decisions that currently merge under one matched heading. ADR supersede-status mapping and richer rejected-alternative extraction.

## Test plan

`uv run pytest packages/nauro/tests/test_import.py` — 29 pass, including new tests for: a non-UTF-8 ADR file (imports cleanly, no crash), the unparsed-decisionLog warning (exit 0 + names the format), the proper-heading no-warning case, and the no-matching-ADR warning. Full suite green; lint clean. Verified live: `import --adr` on a leading-bad-byte file now skips it cleanly instead of tracebacking.
