### PR TITLE
Surface same-name cross-repo forks in nauro init; document --add-repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,15 @@ nauro setup claude-code   # or: nauro setup all
 
 `nauro init` writes `.nauro/config.json` into the repo; commit it. For cloud sync from the start, run `nauro auth login` first, then `nauro init --cloud my-project`.
 
+**One project across several repos:** the store lives outside any repo, so multiple repos can share it. Associate another repo with an existing project from inside that repo:
+
+```bash
+cd ../my-other-repo
+nauro init my-project --add-repo .
+```
+
+Re-running plain `nauro init my-project` in a second repo creates a *separate* project that shares no decisions — use `--add-repo` to link them instead.
+
 **Existing repo with docs to seed from:**
 
 ```bash

--- a/packages/nauro/src/nauro/cli/commands/init.py
+++ b/packages/nauro/src/nauro/cli/commands/init.py
@@ -132,6 +132,31 @@ def _refuse_if_repo_already_claimed(rp: Path) -> None:
     raise typer.Exit(code=1)
 
 
+def _warn_if_name_taken(name: str, new_pid: str, pre_existing: list) -> None:
+    """Warn when a fresh init created a second project sharing an existing name.
+
+    v2 allows duplicate names, but two same-named projects are separate stores
+    that share no decisions — rarely what a user re-running ``nauro init`` from
+    another repo intends, and it silently defeats the cross-repo promise. The
+    repo-path collision is already refused by ``_refuse_if_repo_already_claimed``;
+    this surfaces the name collision and points at the association path instead
+    of failing silently. Advisory only — the project is still created.
+    """
+    others = [pid for pid, _entry in pre_existing if pid != new_pid]
+    if not others:
+        return
+    typer.echo(
+        f"  Note: another local project is also named '{name}' (id {others[0]}). "
+        "This is a SEPARATE store; the two repos will not share decisions.",
+        err=True,
+    )
+    typer.echo(
+        f"  To put this repo under the existing project instead, run "
+        f"'nauro projects rm {new_pid}' then 'nauro init {name} --add-repo .'.",
+        err=True,
+    )
+
+
 def _init_demo(name: str, repo_paths: list[Path], force: bool) -> None:
     """Initialize (or reuse) the bundled demo project.
 
@@ -360,6 +385,9 @@ def init(
         return
 
     # ── Local-only ─────────────────────────────────────────────────────────
+    # Captured before minting so a same-name match is necessarily a different
+    # repo (a same-repo claim was already refused above).
+    pre_existing_same_name = find_projects_by_name_v2(name)
     try:
         pid, store_path = register_project_v2(
             name,
@@ -386,5 +414,6 @@ def init(
     typer.echo(f"  Store: {store_path}")
     for rp in repo_paths:
         typer.echo(f"  Repo:  {rp.resolve()}")
+    _warn_if_name_taken(name, pid, pre_existing_same_name)
     typer.echo("  Next: run 'nauro setup claude-code' to connect your agent")
     typer.echo("  Then: run 'nauro sync' to capture the first snapshot")

--- a/packages/nauro/tests/test_init_registry_integrity.py
+++ b/packages/nauro/tests/test_init_registry_integrity.py
@@ -99,3 +99,59 @@ def test_register_project_v2_raises_on_invalid_name(bad_name, tmp_path, monkeypa
         register_project_v2(bad_name, [tmp_path])
     # No entry leaked even on the raising path.
     assert registry.load_registry_v2()["projects"] == {}
+
+
+# ── same-name cross-repo fork: warn, don't silently fork ────────────────────────
+
+
+def test_init_same_name_other_repo_warns_but_creates(tmp_path, monkeypatch):
+    """`init shared` in a second repo still creates a project (v2 allows dup
+    names) but must surface that it is a SEPARATE store and point at --add-repo,
+    instead of silently forking the cross-repo value prop."""
+    repo_a = tmp_path / "a"
+    repo_b = tmp_path / "b"
+    repo_a.mkdir()
+    repo_b.mkdir()
+
+    monkeypatch.chdir(repo_a)
+    first = runner.invoke(app, ["init", "shared"])
+    assert first.exit_code == 0, first.output
+    (pid_a, _entry) = find_projects_by_name_v2("shared")[0]
+
+    monkeypatch.chdir(repo_b)
+    second = runner.invoke(app, ["init", "shared"])
+    assert second.exit_code == 0, second.output
+    assert "SEPARATE store" in second.output
+    assert "--add-repo" in second.output
+    assert pid_a in second.output  # names the pre-existing project
+
+    matches = find_projects_by_name_v2("shared")
+    assert len(matches) == 2
+    assert len({pid for pid, _ in matches}) == 2  # two distinct ids
+
+
+def test_init_unique_name_has_no_collision_warning(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["init", "solo"])
+    assert result.exit_code == 0, result.output
+    assert "SEPARATE store" not in result.output
+
+
+def test_init_add_repo_links_second_repo_to_one_project(tmp_path, monkeypatch):
+    """The documented association path: --add-repo joins a second repo to the
+    same project rather than forking a new one."""
+    repo_a = tmp_path / "a"
+    repo_b = tmp_path / "b"
+    repo_a.mkdir()
+    repo_b.mkdir()
+
+    monkeypatch.chdir(repo_a)
+    assert runner.invoke(app, ["init", "linked"]).exit_code == 0
+
+    monkeypatch.chdir(repo_b)
+    res = runner.invoke(app, ["init", "linked", "--add-repo", "."])
+    assert res.exit_code == 0, res.output
+
+    # Still exactly one project named 'linked' — the second repo joined it.
+    matches = find_projects_by_name_v2("linked")
+    assert len(matches) == 1


### PR DESCRIPTION
## Why

Running `nauro init <name>` from a second repo silently minted a *separate* project with the same name and a fresh id — a different store. The two repos then shared no decisions, so a decision recorded in one was invisible to `check-decision` in the other. That's the exact cross-repo re-litigation Nauro exists to prevent, failing silently on the most natural action. `nauro adopt` already refuses-and-guides on a same-name collision; `init` (the first command in the README) did not. Separately, the only local way to put a second repo under one project — `nauro init <name> --add-repo .` — was documented nowhere, despite "one record shared across every repo" being the headline.

## Approach

Keep v2's duplicate-names-allowed behaviour (so existing flows and tests are unchanged, and no exit code shifts), but make the fork *visible*: in the local fresh-init path, capture same-name projects before minting and, on success, print an advisory naming the other project and pointing at `--add-repo`. Warn-not-refuse was chosen over hard-refusal to avoid changing exit semantics on a launch-eve fix; a stricter refusal could follow. The README "Adopt" section gains a multi-repo recipe.

## What changed

- `cli/commands/init.py`: `_warn_if_name_taken` helper; the local-only branch captures `find_projects_by_name_v2(name)` before the mint and warns after success.
- `README.md`: a "One project across several repos" recipe documenting `nauro init <name> --add-repo .` and the re-init footgun.

## What to review

- The capture is after the same-repo claim refusal and before the mint, so a match is necessarily a *different* repo.
- Scope: only the local fresh-init path — `--demo` (reuses a shared entry), `--add-repo` (associates), and cloud (uses `attach`) are untouched.

## What's deferred

- Flagging duplicate names in `nauro projects` / `nauro status`, case/homoglyph normalization, and a stricter refuse-instead-of-warn variant.

## Test plan

`uv run pytest packages/nauro/tests/test_init_registry_integrity.py` plus the init/registry suites — green, including new tests: second same-name init warns (names the existing id, mentions `--add-repo`, still creates two distinct projects), a unique name produces no warning, and `--add-repo` links a second repo to one project. Full suite green; lint clean. Verified live.
