### PR TITLE
Make the advisory hook fire on small stores and off-PATH installs

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/hook.py
+++ b/packages/nauro/src/nauro/cli/commands/hook.py
@@ -16,6 +16,7 @@ Nauro.
 from __future__ import annotations
 
 import json
+import math
 import os
 import sys
 import time
@@ -23,19 +24,28 @@ from pathlib import Path
 
 import typer
 
-from nauro.constants import DEFAULT_NAURO_HOME, NAURO_HOME_ENV
+from nauro.constants import DECISIONS_DIR, DEFAULT_NAURO_HOME, NAURO_HOME_ENV
 
 hook_app = typer.Typer(help="Client-side advisory hooks for AI coding agents.")
 
 # ── Tuning constants (initial values; final tuning deferred to the harness) ──
 
-# BM25 relevance floor. A hit must clear this score to be injected. The BM25
-# score scales with corpus size and query length; against a real decision
-# corpus (a few hundred decisions) a strong terse-prompt match scores in the
-# mid-teens, while weak near-neighbours sit in the low single digits. A floor
-# here clears the weak tail and keeps genuine conflicts. This is a sensible
-# initial value; final tuning against field telemetry is deferred.
+# BM25 relevance floor at the reference corpus size. A hit must clear the
+# effective floor (see _effective_floor) to be injected. The BM25 score scales
+# with corpus size and query length; against a few-hundred-decision corpus a
+# strong terse-prompt match scores in the mid-teens, while weak near-neighbours
+# sit in the low single digits. A floor here clears the weak tail and keeps
+# genuine conflicts. Final tuning against field telemetry is deferred.
 RELEVANCE_FLOOR = 8.0
+
+# Corpus size the absolute RELEVANCE_FLOOR is calibrated for. Because BM25 IDF
+# (and thus the score scale) grows with corpus size, a fixed floor tuned for a
+# large store silences every hit on a small one — e.g. the 7-decision
+# `nauro init --demo` store tops out around 6, so an 8.0 floor would surface
+# nothing, including the marquee websocket→SSE conflict. _effective_floor scales
+# the floor down for smaller corpora; NAURO_HOOK_RELEVANCE_FLOOR overrides both.
+RELEVANCE_FLOOR_REFERENCE_CORPUS = 200
+RELEVANCE_FLOOR_ENV = "NAURO_HOOK_RELEVANCE_FLOOR"
 
 # Maximum decisions injected per turn. Three is enough to surface the cluster
 # around a conflict without flooding the context window.
@@ -94,7 +104,7 @@ def _run_user_prompt_submit() -> None:
     if not related:
         return
 
-    surviving = _apply_floor(related)
+    surviving = _apply_floor(related, _corpus_size(store_path))
     if not surviving:
         return
 
@@ -189,18 +199,49 @@ def _check(store_path: Path, prompt: str) -> list[dict]:
     return hits
 
 
-def _apply_floor(hits: list[dict]) -> list[dict]:
+def _corpus_size(store_path: Path) -> int:
+    """Count decision files in the store, for corpus-size-aware floor scaling."""
+    decisions_dir = store_path / DECISIONS_DIR
+    if not decisions_dir.exists():
+        return 0
+    return sum(1 for _ in decisions_dir.glob("*.md"))
+
+
+def _effective_floor(corpus_size: int) -> float:
+    """Relevance floor adjusted for corpus size.
+
+    An explicit ``NAURO_HOOK_RELEVANCE_FLOOR`` env value always wins. Otherwise
+    the floor scales with ``log10(corpus_size)`` up to the reference corpus, so a
+    small store (including the 7-decision ``--demo``) still surfaces a genuine
+    conflict instead of clearing every hit, while a large store keeps the full
+    floor that trims the weak tail. A single absolute floor cannot fit both
+    because BM25 scores grow with corpus size.
+    """
+    override = os.environ.get(RELEVANCE_FLOOR_ENV)
+    if override is not None:
+        try:
+            return float(override)
+        except ValueError:
+            pass
+    if corpus_size >= RELEVANCE_FLOOR_REFERENCE_CORPUS:
+        return RELEVANCE_FLOOR
+    scale = math.log10(max(corpus_size, 2)) / math.log10(RELEVANCE_FLOOR_REFERENCE_CORPUS)
+    return RELEVANCE_FLOOR * scale
+
+
+def _apply_floor(hits: list[dict], corpus_size: int) -> list[dict]:
     """Filter hits to those worth injecting.
 
-    BM25 hits at or above the relevance floor are kept in order; everything else
-    is dropped. Embedding-only hits (score 0.0) are not admitted: on the
-    validation corpus they recovered no conflict the BM25 floor missed while
-    injecting a nearest-neighbour on every otherwise-silent prompt. The kernel
-    discards the cosine score, so an embedding-only hit cannot be relevance-gated
-    here. Re-admitting them is a follow-up that requires the kernel to expose the
-    embedding score.
+    BM25 hits at or above the corpus-adjusted relevance floor are kept in order;
+    everything else is dropped. Embedding-only hits (score 0.0) are not admitted:
+    on the validation corpus they recovered no conflict the BM25 floor missed
+    while injecting a nearest-neighbour on every otherwise-silent prompt. The
+    kernel discards the cosine score, so an embedding-only hit cannot be
+    relevance-gated here. Re-admitting them is a follow-up that requires the
+    kernel to expose the embedding score.
     """
-    return [h for h in hits if h["score"] >= RELEVANCE_FLOOR]
+    floor = _effective_floor(corpus_size)
+    return [h for h in hits if h["score"] >= floor]
 
 
 def _format_block(hits: list[dict]) -> str:

--- a/packages/nauro/src/nauro/cli/commands/setup.py
+++ b/packages/nauro/src/nauro/cli/commands/setup.py
@@ -72,7 +72,20 @@ def _remove_claude_md(repo_path: Path) -> str | None:
 
 
 def _find_nauro_command() -> str:
-    """Find the full path to the nauro binary for the MCP config."""
+    """Resolve an absolute path to the nauro entrypoint for MCP/hook configs.
+
+    Prefer the console script next to the running interpreter — the install the
+    user actually invoked, which a pip-into-venv or pipx/uv-tool layout often
+    keeps off the PATH that Claude Code / Cursor / Codex launch with. Recording
+    an absolute path keeps the spawned stdio server and the per-turn hook
+    independent of the agent's launch environment. Fall back to a PATH lookup,
+    then the bare name.
+    """
+    bindir = Path(sys.executable).parent
+    for name in ("nauro", "nauro.exe"):
+        candidate = bindir / name
+        if candidate.is_file():
+            return str(candidate)
     path = shutil.which("nauro")
     return path if path else "nauro"
 
@@ -676,12 +689,17 @@ def materialize_agents(
 # client event to bind to.
 
 HOOK_EVENT_NAME = "UserPromptSubmit"
-HOOK_COMMAND = "nauro hook user-prompt-submit"
+# The subcommand the hook entry runs; the full command is built at install time
+# by prefixing the resolved absolute nauro path (see _nauro_hook_entry), so the
+# hook fires even when nauro is not on the agent's launch PATH.
+HOOK_SUBCOMMAND = "hook user-prompt-submit"
 HOOK_TIMEOUT_SECONDS = 10
 
 # Substring that identifies a nauro-authored hook entry on the remove path, so a
-# user's own UserPromptSubmit hooks are preserved.
-_HOOK_COMMAND_MARKER = "nauro hook"
+# user's own UserPromptSubmit hooks are preserved. Matches the subcommand rather
+# than "nauro " so it holds regardless of how the entrypoint resolves — a bare
+# "nauro", an absolute POSIX path, or a Windows "nauro.exe".
+_HOOK_COMMAND_MARKER = HOOK_SUBCOMMAND
 
 
 def _claude_settings_path(repo: Path) -> Path:
@@ -719,7 +737,7 @@ def materialize_hooks_claude_code(repo: Path, *, remove: bool) -> str:
 def _nauro_hook_entry() -> dict:
     return {
         "type": "command",
-        "command": HOOK_COMMAND,
+        "command": f"{_find_nauro_command()} {HOOK_SUBCOMMAND}",
         "timeout": HOOK_TIMEOUT_SECONDS,
     }
 

--- a/packages/nauro/tests/test_hook_command.py
+++ b/packages/nauro/tests/test_hook_command.py
@@ -257,6 +257,53 @@ def test_per_session_dedup_does_not_resurface(tmp_path: Path):
     assert second.output == ""
 
 
+# ── corpus-size-aware relevance floor ───────────────────────────────────────────
+
+
+def test_effective_floor_scales_down_for_small_corpus():
+    """A small corpus gets a reachable floor; at/above the reference it is full."""
+    assert hook._effective_floor(hook.RELEVANCE_FLOOR_REFERENCE_CORPUS) == hook.RELEVANCE_FLOOR
+    assert hook._effective_floor(1000) == hook.RELEVANCE_FLOOR
+    demo_floor = hook._effective_floor(7)
+    assert 0 < demo_floor < hook.RELEVANCE_FLOOR
+
+
+def test_effective_floor_env_override(monkeypatch):
+    monkeypatch.setenv(hook.RELEVANCE_FLOOR_ENV, "1.5")
+    assert hook._effective_floor(7) == 1.5
+    assert hook._effective_floor(1000) == 1.5
+    # A non-numeric override is ignored, falling back to corpus scaling.
+    monkeypatch.setenv(hook.RELEVANCE_FLOOR_ENV, "not-a-number")
+    assert hook._effective_floor(1000) == hook.RELEVANCE_FLOOR
+
+
+def test_demo_store_surfaces_conflict_without_corpus_padding(tmp_path: Path):
+    """The 7-decision demo store must surface its marquee websocket→SSE conflict.
+
+    Regression for the fixed 8.0 floor that no demo decision could reach (D004
+    scores ~5), making --with-hooks look broken on the obvious demo path. No
+    distractor padding here — the corpus-aware floor must do the work.
+    """
+    from nauro.demo import create_demo_project
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _pid, store_path = register_project_v2("demoproj", [repo])
+    create_demo_project(store_path)
+
+    result = _invoke(
+        {
+            "prompt": "add a websocket endpoint for live task updates",
+            "cwd": str(repo),
+            "session_id": "demo",
+        }
+    )
+    assert result.exit_code == 0
+    assert result.output != ""
+    out = json.loads(result.output)["hookSpecificOutput"]
+    assert "D004" in out["additionalContext"]
+
+
 def test_distinct_session_resurfaces(tmp_path: Path):
     """A different session id surfaces the same decision again."""
     repo, store_path = _make_project(tmp_path)
@@ -375,13 +422,18 @@ def test_corrupt_dedup_state_injects_anyway(tmp_path: Path):
 # ── direct unit coverage of the floor + block helpers ──────────────────────────
 
 
+# These pin behaviour at the full floor, so they pass a reference-sized corpus
+# (effective floor == RELEVANCE_FLOOR); corpus-size scaling is covered separately.
+_REF_CORPUS = hook.RELEVANCE_FLOOR_REFERENCE_CORPUS
+
+
 def test_apply_floor_drops_embedding_only_hits():
     """Embedding-only hits (score 0.0) are not admitted in the BM25-only MVP."""
     hits = [
         {"number": 1, "title": "a", "score": 0.0, "status": "active", "date": "", "preview": ""},
         {"number": 2, "title": "b", "score": 0.0, "status": "active", "date": "", "preview": ""},
     ]
-    assert hook._apply_floor(hits) == []
+    assert hook._apply_floor(hits, _REF_CORPUS) == []
 
 
 def test_apply_floor_keeps_only_bm25_above_floor():
@@ -391,7 +443,7 @@ def test_apply_floor_keeps_only_bm25_above_floor():
         {"number": 1, "title": "a", "score": above, "status": "active", "date": "", "preview": ""},
         {"number": 2, "title": "b", "score": 0.0, "status": "active", "date": "", "preview": ""},
     ]
-    surviving = hook._apply_floor(hits)
+    surviving = hook._apply_floor(hits, _REF_CORPUS)
     assert [h["number"] for h in surviving] == [1]
 
 
@@ -401,7 +453,7 @@ def test_apply_floor_drops_bm25_below_floor():
     hits = [
         {"number": 1, "title": "a", "score": below, "status": "active", "date": "", "preview": ""},
     ]
-    assert hook._apply_floor(hits) == []
+    assert hook._apply_floor(hits, _REF_CORPUS) == []
 
 
 def test_format_block_shape():

--- a/packages/nauro/tests/test_setup_hooks.py
+++ b/packages/nauro/tests/test_setup_hooks.py
@@ -14,8 +14,8 @@ from pathlib import Path
 from typer.testing import CliRunner
 
 from nauro.cli.commands.setup import (
-    HOOK_COMMAND,
     HOOK_EVENT_NAME,
+    HOOK_SUBCOMMAND,
     HOOK_TIMEOUT_SECONDS,
     materialize_hooks_claude_code,
     setup_all_surfaces,
@@ -35,7 +35,7 @@ def _nauro_entries(settings: dict) -> list[dict]:
     out = []
     for matcher in settings.get("hooks", {}).get(HOOK_EVENT_NAME, []):
         for entry in matcher.get("hooks", []):
-            if isinstance(entry, dict) and "nauro hook" in entry.get("command", ""):
+            if isinstance(entry, dict) and HOOK_SUBCOMMAND in entry.get("command", ""):
                 out.append(entry)
     return out
 
@@ -63,11 +63,14 @@ def test_materialize_writes_correct_structure(tmp_path: Path):
     assert len(entries) == 1
     entry = entries[0]
     assert entry["type"] == "command"
-    assert entry["command"] == HOOK_COMMAND
+    # Command is the resolved nauro path + the hook subcommand, so it fires even
+    # when nauro is off the agent's launch PATH. It still carries the "nauro hook"
+    # marker the remove path matches on.
+    assert entry["command"].endswith(HOOK_SUBCOMMAND)
+    assert "nauro hook" in entry["command"]
     assert entry["timeout"] == HOOK_TIMEOUT_SECONDS
     # The MVP install is BM25-only: it must not set the embeddings flag.
     assert "NAURO_EMBEDDINGS" not in entry["command"]
-    assert entry["command"] == "nauro hook user-prompt-submit"
 
 
 def test_materialize_is_idempotent(tmp_path: Path):
@@ -199,3 +202,19 @@ def test_setup_all_without_hooks_writes_nothing(tmp_path: Path):
     repo, _store = _make_project(tmp_path)
     setup_all_surfaces([repo])
     assert not _settings(repo).is_file()
+
+
+def test_is_nauro_hook_matches_regardless_of_entrypoint_name():
+    """The remove/idempotency marker must recognise the nauro hook however the
+    entrypoint resolved — bare name, absolute POSIX path, or Windows .exe —
+    otherwise --remove orphans the entry and re-running setup duplicates it."""
+    from nauro.cli.commands.setup import _is_nauro_hook
+
+    for cmd in (
+        "nauro hook user-prompt-submit",
+        "/opt/venv/bin/nauro hook user-prompt-submit",
+        r"C:\Users\me\Scripts\nauro.exe hook user-prompt-submit",
+    ):
+        assert _is_nauro_hook({"type": "command", "command": cmd}), cmd
+    # A user's own UserPromptSubmit hook is left alone.
+    assert not _is_nauro_hook({"type": "command", "command": "my-linter --check"})


### PR DESCRIPTION
## Why

`--with-hooks` (the Claude Code per-turn advisory hook) was unreliable at first contact in three ways:

1. The BM25 relevance floor was a fixed `8.0`, calibrated for a few-hundred-decision corpus. BM25 scores scale with corpus size, so on the 7-decision `nauro init --demo` store every decision fell below the floor — including the marquee websocket→SSE conflict (score ~5). Demoing the hook on the demo store (the obvious path) surfaced nothing and looked broken.
2. `setup` recorded the MCP server and the hook as the bare string `nauro …`. When nauro lives in a venv or a pipx/uv-tool shim that isn't on the PATH Claude Code / Cursor / Codex launch with, the server never starts and the hook fails every turn — silently no tools.
3. (Found in review) routing the hook command through the path resolver could yield `nauro.exe hook …` on Windows, which the removal/idempotency marker `"nauro hook"` wouldn't match — orphaning the entry on `--remove` and duplicating it on re-run.

## Approach

Make the floor corpus-size-aware: scale by `log10(corpus)` up to a reference corpus, with an explicit `NAURO_HOOK_RELEVANCE_FLOOR` env override. This keeps the weak-tail trimming on large stores while letting a genuine conflict surface on a small one — preferred over simply lowering the constant (which would get noisy at scale) or hard-coding a demo special-case. For the launch environment: resolve the absolute console-script path next to the running interpreter, so the spawned server/hook is independent of the agent's PATH. For the marker: match on the subcommand (`hook user-prompt-submit`) so it holds for a bare name, an absolute POSIX path, or a Windows `.exe`.

## What changed

- `cli/commands/hook.py`: `_effective_floor(corpus_size)` (+ env override) and `_corpus_size`; `_apply_floor` takes the corpus size.
- `cli/commands/setup.py`: `_find_nauro_command` prefers the interpreter-adjacent console script; the hook command is built from it (`HOOK_COMMAND` → `HOOK_SUBCOMMAND`); the nauro-hook marker matches the subcommand.

## What to review

- `_effective_floor` math: `log10(max(corpus,2))` avoids the zero case; the scaled floor is never *higher* than the old `8.0`, so no suppression regresses (the existing distractor-padded tests still drop the zero-vocabulary prompt).
- The hook still fails open (never raises, exit 0) — the floor change is inside the guarded path.

## What's deferred

- Field-telemetry tuning of the reference corpus / scaling curve; surfacing the hook in `nauro adopt` (currently `setup --with-hooks` only); the ~190ms per-turn CLI cold-start.

## Test plan

`uv run pytest packages/nauro/tests/test_hook_command.py packages/nauro/tests/test_setup_hooks.py` and the setup/adopt suites — green, including new tests: `_effective_floor` scaling + env override, the demo store surfacing D004 **without** distractor padding, the updated `_apply_floor(hits, corpus)` signature, and a marker regression test matching bare / POSIX-absolute / Windows-`.exe` commands. Full suite green; lint clean. Verified live: `.mcp.json` and `.claude/settings.json` carry absolute commands and the hook surfaces the conflict on the demo store.
