### PR TITLE
Skip corrupt snapshots instead of crashing log/sync/diff

### DIFF
--- a/packages/nauro/src/nauro/store/snapshot.py
+++ b/packages/nauro/src/nauro/store/snapshot.py
@@ -27,7 +27,14 @@ from nauro.constants import (
     PRUNE_WEEKLY_DAYS,
     SNAPSHOTS_DIR,
 )
+from nauro.store._atomic import atomic_write_text
 from nauro.store.reader import read_text_lenient
+
+# Exceptions that mean a snapshot file on disk is unreadable or malformed: a
+# truncated/garbage JSON body, a missing required key, or an OS read error. The
+# read paths skip such a file with a warning rather than letting it crash the
+# command (log/sync/diff) on a single bad snapshot.
+_CORRUPT_SNAPSHOT_ERRORS = (OSError, json.JSONDecodeError, KeyError, TypeError)
 
 logger = logging.getLogger("nauro.snapshot")
 
@@ -93,7 +100,7 @@ def capture_snapshot(store_path: Path, trigger: str = "", trigger_detail: str = 
         )
 
         out_path = snapshots_dir / f"v{next_version:03d}.json"
-        out_path.write_text(json.dumps(snapshot, indent=2) + "\n")
+        atomic_write_text(out_path, json.dumps(snapshot, indent=2) + "\n")
 
         # Prune after every capture. Prune mutates the same dir the version
         # count reads, so it stays inside the lock.
@@ -129,11 +136,15 @@ def _prune_snapshots(snapshots_dir: Path) -> None:
     # the valid snapshots.
     snapshots = []
     for f in snapshot_files:
-        data = json.loads(f.read_text())
         try:
+            data = json.loads(f.read_text())
             timestamp = datetime.fromisoformat(data["timestamp"])
-        except (ValueError, TypeError, KeyError):
-            logger.debug("Skipping snapshot with unparseable timestamp: %s", f)
+            _ = data["version"]  # required for the sort below; skip if absent
+        except (ValueError, *_CORRUPT_SNAPSHOT_ERRORS):
+            # Skip an unreadable/unparseable snapshot (incl. a missing timestamp
+            # or version) rather than crashing prune — which runs inside capture,
+            # so a corrupt sibling would otherwise break sync.
+            logger.warning("Skipping unreadable snapshot during prune: %s", f)
             continue
         snapshots.append(
             {
@@ -228,19 +239,18 @@ def find_snapshot_near_date(store_path: Path, target: datetime) -> dict | None:
 
     all_snaps = []
     for f in snapshots_dir.glob("v*.json"):
-        data = json.loads(f.read_text())
         try:
+            data = json.loads(f.read_text())
             ts = datetime.fromisoformat(data["timestamp"])
-        except (ValueError, TypeError, KeyError):
-            logger.debug("Skipping snapshot with unparseable timestamp: %s", f)
-            continue
-        all_snaps.append(
-            {
+            entry = {
                 "version": data["version"],
                 "timestamp": data["timestamp"],
                 "datetime": ts,
             }
-        )
+        except (ValueError, *_CORRUPT_SNAPSHOT_ERRORS):
+            logger.warning("Skipping unreadable snapshot: %s", f)
+            continue
+        all_snaps.append(entry)
 
     if not all_snaps:
         return None
@@ -270,16 +280,21 @@ def list_snapshots(store_path: Path) -> list[dict]:
 
     result = []
     for f in sorted(snapshots_dir.glob("v*.json"), reverse=True):
-        data = json.loads(f.read_text())
-        result.append(
-            {
+        try:
+            data = json.loads(f.read_text())
+            entry = {
                 "version": data["version"],
                 "timestamp": data["timestamp"],
                 "trigger": data.get("trigger", ""),
                 "trigger_detail": data.get("trigger_detail", ""),
                 "token_count": data.get("token_count", 0),
             }
-        )
+        except _CORRUPT_SNAPSHOT_ERRORS:
+            # Skip a corrupt/truncated snapshot (e.g. an interrupted write)
+            # rather than crashing log/sync/diff; capture overwrites the slot.
+            logger.warning("Skipping unreadable snapshot: %s", f)
+            continue
+        result.append(entry)
     return result
 
 

--- a/packages/nauro/tests/test_snapshot_corruption.py
+++ b/packages/nauro/tests/test_snapshot_corruption.py
@@ -1,0 +1,110 @@
+"""A corrupt snapshot file must not brick log / sync / diff.
+
+Snapshot JSON is written to disk and can be left truncated by an interrupted
+write (Ctrl-C, sleep, disk full) or hand-edited. The read paths used to call
+json.loads unguarded, so one bad file crashed `nauro log`, `nauro sync` (capture
+reads the existing snapshots to compute the next version), and diff. They now
+skip an unreadable snapshot with a warning; capture stays atomic.
+"""
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from nauro.cli.main import app
+from nauro.store.registry import register_project
+from nauro.store.snapshot import (
+    capture_snapshot,
+    find_snapshot_near_date,
+    list_snapshots,
+)
+from nauro.templates.scaffolds import scaffold_project_store
+
+runner = CliRunner()
+
+
+def _store_with_two_snapshots(tmp_path: Path) -> Path:
+    store_path = tmp_path / "projects" / "p"
+    scaffold_project_store("p", store_path)
+    capture_snapshot(store_path, trigger="first")
+    capture_snapshot(store_path, trigger="second")
+    return store_path
+
+
+def _snap(store_path: Path, version: int) -> Path:
+    return store_path / "snapshots" / f"v{version:03d}.json"
+
+
+def test_list_snapshots_skips_corrupt(tmp_path: Path):
+    store_path = _store_with_two_snapshots(tmp_path)
+    # Truncated JSON body.
+    _snap(store_path, 3).write_text('{"version": 3, "timestamp": "2026-01-01T0')
+    # Valid JSON but missing the required version key.
+    _snap(store_path, 4).write_text('{"timestamp": "2026-01-01T00:00:00+00:00"}')
+
+    snaps = list_snapshots(store_path)
+    versions = {s["version"] for s in snaps}
+    assert versions == {1, 2}  # the two corrupt files are skipped, no crash
+
+
+def test_find_snapshot_near_date_skips_corrupt(tmp_path: Path):
+    store_path = _store_with_two_snapshots(tmp_path)
+    _snap(store_path, 3).write_text("not json at all")
+    from datetime import datetime, timezone
+
+    # Must not raise on the corrupt v003.
+    result = find_snapshot_near_date(store_path, datetime.now(timezone.utc))
+    assert result is not None and result["version"] in {1, 2}
+
+
+def test_capture_survives_corrupt_snapshot(tmp_path: Path):
+    store_path = _store_with_two_snapshots(tmp_path)
+    _snap(store_path, 3).write_text('{"version": 3, "timestamp": "trunc')
+
+    # sync's capture reads existing snapshots to compute the next version; a
+    # corrupt v003 must not block it. The corrupt slot is overwritten.
+    version = capture_snapshot(store_path, trigger="after-corruption")
+    assert version == 3
+    assert not list(store_path.glob("snapshots/*.tmp"))  # atomic write left no temp
+    # The slot is now valid and the read surface recovers.
+    assert {s["version"] for s in list_snapshots(store_path)} == {1, 2, 3}
+
+
+def test_capture_survives_corrupt_older_snapshot_during_prune(tmp_path: Path):
+    store_path = _store_with_two_snapshots(tmp_path)
+    # Corrupt an OLDER snapshot, then capture a NEW one. Capture's prune step
+    # reads every v*.json, so a corrupt sibling must not crash it.
+    _snap(store_path, 1).write_text("{ not valid json")
+
+    version = capture_snapshot(store_path, trigger="newer")
+    assert version == 3
+    assert not list(store_path.glob("snapshots/*.tmp"))
+
+
+def test_bad_timestamp_snapshot_skipped_by_date_search_and_prune(tmp_path: Path):
+    store_path = _store_with_two_snapshots(tmp_path)
+    # Valid JSON with a version but an unparseable timestamp: the timestamp-
+    # parsing paths (find_snapshot_near_date, prune) must skip it, not raise.
+    _snap(store_path, 3).write_text('{"version": 3, "timestamp": "not-a-date"}')
+    from datetime import datetime, timezone
+
+    result = find_snapshot_near_date(store_path, datetime.now(timezone.utc))
+    assert result is not None and result["version"] in {1, 2}
+
+    # capture runs prune, which parses every timestamp — must not raise.
+    version = capture_snapshot(store_path, trigger="after-bad-ts")
+    assert version >= 3
+    assert not list(store_path.glob("snapshots/*.tmp"))
+
+
+def test_nauro_log_does_not_crash_on_corrupt_snapshot(tmp_path: Path, monkeypatch):
+    register_project("p", [tmp_path])
+    store_path = tmp_path / "projects" / "p"
+    scaffold_project_store("p", store_path)
+    capture_snapshot(store_path, trigger="ok")
+    _snap(store_path, 2).write_text("{ broken")
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["log"])
+    assert result.exit_code == 0, result.output
+    assert "Traceback" not in result.output


### PR DESCRIPTION
## Why

A snapshot left truncated by an interrupted write (Ctrl-C, laptop sleep, full disk) or a hand-edited/garbage `v*.json` crashed **every** snapshot read with an unguarded `json.loads`/`KeyError`: `nauro log`, `nauro diff-since-last-session`, and `nauro sync` (capture reads existing snapshots to compute the next version, so a corrupt file meant the store could no longer snapshot or regenerate AGENTS.md — a stuck store).

## Approach

Skip an unreadable snapshot with a warning rather than letting it crash the command — the same degradation the code already applied to an unparseable *timestamp*. The fix generalizes that to the whole snapshot read (bad JSON, missing keys, OS error) across all the read paths, and makes capture's write atomic so an interruption can't leave a partial file in the first place.

## What changed

- `store/snapshot.py`: a shared `_CORRUPT_SNAPSHOT_ERRORS` tuple; `list_snapshots`, `find_snapshot_near_date`, and `_prune_snapshots` (which runs inside capture) now skip-with-warning on a corrupt file. `capture_snapshot` writes via the atomic tmp+rename helper.

## What to review

- `load_snapshot` is intentionally left unguarded: every caller derives its version from the now-guarded scanners, so a corrupt file's version can't reach it. Confirm that invariant holds.
- The `.tmp` sibling from the atomic write can't be matched by the `v*.json` glob.
- Next-version computation when the highest-numbered snapshot is the corrupt one (it gets overwritten; no gap).

## What's deferred

Nothing in scope. (Broader snapshot integrity — checksums, etc. — out of scope.)

## Test plan

New `tests/test_snapshot_corruption.py` (6 tests): truncated JSON, missing-key, and bad-timestamp snapshots are skipped by `list_snapshots`/`find_snapshot_near_date`; capture survives a corrupt newer **and** older (prune-path) snapshot with no leftover `.tmp`; and `nauro log` exits 0 with no traceback. Full nauro suite green; lint + single-sourced clean.
