### PR TITLE
Render filesystem errors as clean messages, not tracebacks

### DIFF
--- a/packages/nauro/src/nauro/cli/errors.py
+++ b/packages/nauro/src/nauro/cli/errors.py
@@ -1,0 +1,69 @@
+"""Friendly rendering for uncaught filesystem errors.
+
+Commands that write to the store (``note``, ``propose-decision``,
+``update-state``, ``flag-question``, ``sync``) or scaffold it (``init``) can hit
+a read-only store, a read-only ``NAURO_HOME``, a full disk, or a
+permission-denied path. Left unhandled, the ``OSError`` reaches Typer as a raw
+traceback with absolute paths. ``apply_fs_error_handling`` wraps every command
+so such an error renders as a clean one-line message and exits 1.
+
+This is layered OUTSIDE the telemetry instrumentation (applied after it in
+``cli/main.py``), so a command's ``cli.command_invoked`` event is still recorded
+with ``success=False`` before the error is rendered.
+"""
+
+from __future__ import annotations
+
+import functools
+from collections.abc import Callable
+from typing import Any
+
+import typer
+
+
+def _render_and_exit(exc: OSError) -> None:
+    """Print a clean one-line message for *exc* and exit 1 (no traceback)."""
+    detail = exc.strerror or str(exc) or exc.__class__.__name__
+    # For a rename failure (os.replace of a tmp sibling, as atomic_write_text
+    # uses) filename is the temp name and filename2 the real destination —
+    # prefer the destination so the message names the file the user cares about.
+    target = getattr(exc, "filename2", None) or getattr(exc, "filename", None)
+    suffix = f": {target}" if target else ""
+    typer.echo(f"Error: {detail}{suffix}", err=True)
+    raise typer.Exit(code=1)
+
+
+def friendly_fs_errors(func: Callable[..., Any]) -> Callable[..., Any]:
+    """Wrap a command callback to convert an uncaught ``OSError`` into a clean exit.
+
+    Idempotent. Control-flow exceptions (``typer.Exit``/``Abort``/``SystemExit``)
+    pass through untouched; only a genuine filesystem ``OSError`` that no command
+    handled is rendered.
+    """
+    if getattr(func, "_nauro_fs_wrapped", False):
+        return func
+
+    @functools.wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        try:
+            return func(*args, **kwargs)
+        except (typer.Exit, typer.Abort, SystemExit):
+            raise
+        except OSError as exc:
+            _render_and_exit(exc)
+
+    wrapper._nauro_fs_wrapped = True  # type: ignore[attr-defined]
+    return wrapper
+
+
+def apply_fs_error_handling(app: typer.Typer) -> None:
+    """Recursively wrap every command in ``app`` (and its sub-Typers)."""
+    for cmd_info in app.registered_commands:
+        if cmd_info.callback is None:
+            continue
+        cmd_info.callback = friendly_fs_errors(cmd_info.callback)
+    for group_info in app.registered_groups:
+        sub = group_info.typer_instance
+        if sub is None:
+            continue
+        apply_fs_error_handling(sub)

--- a/packages/nauro/src/nauro/cli/main.py
+++ b/packages/nauro/src/nauro/cli/main.py
@@ -8,6 +8,7 @@ config, auth, telemetry.
 import typer
 
 from nauro.cli.autogen import register_autogen_commands
+from nauro.cli.errors import apply_fs_error_handling
 from nauro.telemetry import consent
 from nauro.telemetry.cli_wrapper import instrument_app
 
@@ -93,6 +94,10 @@ def _register_commands() -> None:
 _register_commands()
 register_autogen_commands(app)
 instrument_app(app)
+# Applied after instrument_app so the friendly-error layer sits OUTSIDE the
+# telemetry shim: a failed command is still recorded before its OSError is
+# rendered as a clean message.
+apply_fs_error_handling(app)
 
 if __name__ == "__main__":
     app()

--- a/packages/nauro/tests/test_cli_fs_errors.py
+++ b/packages/nauro/tests/test_cli_fs_errors.py
@@ -1,0 +1,58 @@
+"""Filesystem errors render as a clean message, not a raw traceback.
+
+A read-only store, a read-only NAURO_HOME/CWD, or a full disk used to surface
+as an unhandled PermissionError/OSError traceback (with absolute paths) on the
+write commands and on init. They now exit 1 with a one-line "Error: ..." and no
+traceback.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from nauro.cli.main import app
+from nauro.store.registry import register_project
+from nauro.templates.scaffolds import scaffold_project_store
+
+runner = CliRunner()
+
+# chmod-based read-only dirs don't restrict the directory owner on Windows.
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32", reason="POSIX directory permissions required"
+)
+
+
+def _assert_clean_error(result):
+    assert result.exit_code == 1, result.output
+    assert "Error:" in result.output
+    assert "Traceback" not in result.output
+    assert "PermissionError" not in result.output
+
+
+def test_note_on_read_only_store_reports_clean_error(tmp_path: Path, monkeypatch):
+    register_project("p", [tmp_path])
+    store_path = tmp_path / "projects" / "p"
+    scaffold_project_store("p", store_path)
+    monkeypatch.chdir(tmp_path)
+
+    decisions = store_path / "decisions"
+    decisions.chmod(0o555)  # read-only: the write lock + file can't be created
+    try:
+        result = runner.invoke(app, ["note", "We chose X over Y"])
+        _assert_clean_error(result)
+    finally:
+        decisions.chmod(0o755)  # restore so pytest can clean tmp_path
+
+
+def test_init_in_read_only_cwd_reports_clean_error(tmp_path: Path, monkeypatch):
+    ro = tmp_path / "ro"
+    ro.mkdir()
+    ro.chmod(0o555)  # can't create .nauro/config.json here
+    monkeypatch.chdir(ro)
+    try:
+        result = runner.invoke(app, ["init", "myproj"])
+        _assert_clean_error(result)
+    finally:
+        ro.chmod(0o755)


### PR DESCRIPTION
## Why

The write commands (`note`, `propose-decision`, `update-state`, `flag-question`, `sync`) and `init` had no handling for filesystem write failures, so a read-only store, a read-only `NAURO_HOME`/CWD, or a full disk surfaced as a raw `PermissionError`/`OSError` traceback with absolute paths — an unprofessional first impression on locked-down machines, network mounts, or a misconfigured `~/.nauro/`.

## Approach

Add one small `cli/errors` layer that wraps every command and converts an uncaught `OSError` into a clean `Error: <reason>: <path>` (exit 1). It's a dedicated wrapper rather than folding the logic into the existing telemetry shim (keeping user-facing error UX out of the telemetry module), and it's applied *after* `instrument_app` so it sits outside the telemetry layer — the failed invocation is still recorded before the message is rendered.

## What changed

- `cli/errors.py` (new): `friendly_fs_errors` decorator + `apply_fs_error_handling(app)` recursive walker.
- `cli/main.py`: applies it after `instrument_app`.

## What to review

- Layering/exception flow: `OSError` → telemetry `finally` records `success=False` and re-raises → fs wrapper renders + exits 1 (no double-count). Control-flow exceptions (`typer.Exit`/`Abort`, `SystemExit`) pass through untouched.
- Over-catching: only *unhandled* `OSError`s reach the boundary; commands that catch their own (e.g. init's config-overwrite guard) are unaffected. Converting to a clean exit-1 is strictly better than the prior traceback.
- The message prefers `filename2` (the real destination on a rename failure, since the store writes via tmp+`os.replace`).

## What's deferred

The top-level `app.callback` (first-run consent prompt) isn't wrapped — adjacent to this PR's "write commands + init" scope; a follow-up if read-only `NAURO_HOME` coverage should be total.

## Test plan

New `tests/test_cli_fs_errors.py`: `note` on a read-only store and `init` in a read-only CWD both exit 1 with `Error:` and no traceback/`PermissionError` text; skipped on Windows (POSIX dir perms required; CI runs non-root on ubuntu). Full suite green; lint clean.
