### PR TITLE
Preserve a corrupt config.json instead of destroying recoverable tokens

### DIFF
--- a/packages/nauro/src/nauro/store/config.py
+++ b/packages/nauro/src/nauro/store/config.py
@@ -10,6 +10,7 @@ import os
 import uuid
 from contextlib import contextmanager
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 
 from filelock import FileLock
@@ -64,17 +65,51 @@ def config_transaction():
         save_config(data)
 
 
+def _quarantine_corrupt_config(cf: Path) -> None:
+    """Preserve a corrupt config.json before a caller overwrites it.
+
+    load_config returns {} on a corrupt file and config_transaction then
+    persists that empty dict — which would destroy any hand-recoverable content
+    (e.g. the auth tokens) in the broken file. Rename it to a timestamped
+    sidecar first so the data survives, and tell the user where it went.
+    Best-effort: a read-only dir or a concurrent rename is swallowed.
+    """
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%f")
+    sidecar = cf.with_name(f"{cf.name}.corrupt-{ts}")
+    try:
+        cf.rename(sidecar)
+        logger.warning(
+            "config.json was unreadable; preserved a copy at %s and started a "
+            "fresh config. If you were logged in, re-run `nauro auth login`.",
+            sidecar,
+        )
+    except OSError:
+        # Could not move the broken file aside (e.g. a read-only dir). It stays
+        # on disk and a later save may overwrite it, so flag that the tokens may
+        # still be at risk rather than implying a clean recovery.
+        logger.warning(
+            "config.json is corrupt and could not be preserved (check directory "
+            "permissions) — returning empty config; back it up manually if it held "
+            "credentials"
+        )
+
+
 def load_config() -> dict:
-    """Read config.json, return empty dict if it doesn't exist or is corrupt."""
+    """Read config.json, return empty dict if it doesn't exist or is corrupt.
+
+    A corrupt or wrong-shape file is moved aside to a ``.corrupt-<ts>`` sidecar
+    before returning {} so a subsequent save cannot silently destroy any
+    recoverable content.
+    """
     cf = _config_file()
     if cf.exists():
         try:
             data = json.loads(cf.read_text())
         except json.JSONDecodeError:
-            logger.warning("config.json is corrupt — returning empty config")
+            _quarantine_corrupt_config(cf)
             return {}
         if not isinstance(data, dict):
-            logger.warning("config.json is corrupt — returning empty config")
+            _quarantine_corrupt_config(cf)
             return {}
         return data  # type: ignore[no-any-return]
     return {}

--- a/packages/nauro/tests/test_config.py
+++ b/packages/nauro/tests/test_config.py
@@ -1,5 +1,7 @@
 """Tests for nauro config."""
 
+import logging
+
 from typer.testing import CliRunner
 
 from nauro.cli.main import app
@@ -63,6 +65,33 @@ def test_load_config_non_dict_returns_empty(tmp_path, monkeypatch):
     returns an empty config rather than crashing downstream callers."""
     (tmp_path / "config.json").write_text("[]")
     assert load_config() == {}
+
+
+def test_corrupt_config_is_quarantined_not_destroyed(tmp_path, monkeypatch, caplog):
+    """A corrupt config.json is moved to a sidecar so recoverable tokens survive."""
+    cf = tmp_path / "config.json"
+    # Truncated JSON that still contains the (recoverable) auth tokens.
+    cf.write_text('{"auth": {"access_token": "AT_RECOVERABLE", "refresh_token": "RT_RECOV"')
+
+    with caplog.at_level(logging.WARNING):
+        assert load_config() == {}
+
+    sidecars = list(tmp_path.glob("config.json.corrupt-*"))
+    assert len(sidecars) == 1
+    preserved = sidecars[0].read_text()
+    assert "AT_RECOVERABLE" in preserved and "RT_RECOV" in preserved
+    assert "preserved a copy" in caplog.text
+
+
+def test_transaction_after_corruption_writes_fresh_config(tmp_path, monkeypatch):
+    """After quarantine, the next load+save writes a clean config; the corrupt
+    copy is preserved rather than overwritten with an empty file."""
+    (tmp_path / "config.json").write_text("{ not valid json")
+
+    set_config("model", "haiku")  # load+save path that previously destroyed tokens
+
+    assert load_config() == {"model": "haiku"}
+    assert list(tmp_path.glob("config.json.corrupt-*"))
 
 
 # --- CLI ---


### PR DESCRIPTION
## Why

`load_config()` returned `{}` on a corrupt or wrong-shape `config.json`, and `config_transaction` then re-saved that empty dict. So any routine command that touches config (telemetry enable/disable, anonymous_id minting) silently overwrote a partially-corrupt file — **destroying hand-recoverable auth tokens** with only a logger warning and no backup.

## Approach

Quarantine before overwrite: on a corrupt/non-dict file, rename it to a timestamped `config.json.corrupt-<ts>` sidecar before returning `{}`, so the next save writes a fresh file while the broken one (with its tokens) survives for manual recovery. Best-effort — a read-only dir or a concurrent rename degrades to the prior behaviour, now with a warning that says the file couldn't be preserved.

## What changed

- `store/config.py`: `_quarantine_corrupt_config` helper; `load_config` calls it on both the `JSONDecodeError` and non-dict branches and warns naming the sidecar + the re-login step.

## What to review

- Ordering: quarantine runs inside `load_config`, which `config_transaction` calls before `save_config` — so the rename always precedes any overwrite.
- The sidecar path is disjoint from the `config.lock` lock path, so the rename can't disturb a held lock.
- Racing renames / read-only dir are swallowed (`OSError`), degrading gracefully.

## What's deferred

Nothing in scope.

## Test plan

`tests/test_config.py` gains: a corrupt file with fake recoverable tokens is moved to a sidecar (tokens present there) with a warning; and a subsequent `set_config` writes a clean config without re-destroying the sidecar. Existing non-dict test still holds. Full config/telemetry suites green; lint clean.
