### PR TITLE
Guard setup against a non-object MCP config instead of crashing

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/setup.py
+++ b/packages/nauro/src/nauro/cli/commands/setup.py
@@ -138,9 +138,15 @@ def _configure_json_mcp(
     else:
         config = {}
 
+    # A hand-mangled config can have a non-object top level (e.g. a JSON array)
+    # or an mcpServers that isn't an object; mutating it would raise. Skip with a
+    # clear message instead of a traceback, mirroring the hook path's guard.
+    if not isinstance(config, dict):
+        return f"  {repo_path}: {label} is not a JSON object, skipped"
+
     if remove:
         servers = config.get("mcpServers", {})
-        if "nauro" not in servers:
+        if not isinstance(servers, dict) or "nauro" not in servers:
             return f"  {repo_path}: no nauro entry to remove"
         del servers["nauro"]
         if not servers:
@@ -151,7 +157,10 @@ def _configure_json_mcp(
             config_path.unlink()
         return f"  {repo_path}: removed nauro from {label}"
 
-    config.setdefault("mcpServers", {})["nauro"] = nauro_entry
+    servers = config.setdefault("mcpServers", {})
+    if not isinstance(servers, dict):
+        return f"  {repo_path}: mcpServers in {label} is not a JSON object, skipped"
+    servers["nauro"] = nauro_entry
     config_path.parent.mkdir(parents=True, exist_ok=True)
     config_path.write_text(json.dumps(config, indent=2) + "\n")
     return f"  {repo_path}: wrote nauro to {label}"
@@ -389,6 +398,12 @@ def _configure_codex(
         config = {}
 
     servers = config.setdefault("mcp_servers", {})
+    # A hand-edited config.toml could define mcp_servers as a non-table (e.g. a
+    # string); mutating it would raise. Skip with a clear message, not a crash.
+    if not isinstance(servers, dict):
+        if remove:
+            return f"Codex: no nauro entry to remove in {config_path}"
+        return f"Codex: mcp_servers in {config_path} is not a table, skipped"
 
     if remove:
         if "nauro" in servers:

--- a/packages/nauro/tests/test_setup.py
+++ b/packages/nauro/tests/test_setup.py
@@ -5,7 +5,12 @@ from pathlib import Path
 
 from typer.testing import CliRunner
 
-from nauro.cli.commands.setup import CLAUDE_MD_END, CLAUDE_MD_START, _configure_mcp
+from nauro.cli.commands.setup import (
+    CLAUDE_MD_END,
+    CLAUDE_MD_START,
+    _configure_codex,
+    _configure_mcp,
+)
 from nauro.cli.main import app
 from nauro.store.registry import register_project
 from nauro.templates.scaffolds import scaffold_project_store
@@ -275,3 +280,42 @@ class TestProjectResolution:
         # No CLAUDE.md created
         assert not (repo1 / "CLAUDE.md").exists()
         assert not (repo2 / "CLAUDE.md").exists()
+
+
+class TestMalformedConfigGuards:
+    """A pre-existing, off-shape MCP config must skip cleanly, not crash."""
+
+    def test_json_top_level_array_is_skipped(self, tmp_path: Path):
+        (tmp_path / ".mcp.json").write_text("[]")
+        line = _configure_mcp(tmp_path, remove=False)
+        assert "not a JSON object" in line
+        # Left untouched, not crashed or clobbered.
+        assert (tmp_path / ".mcp.json").read_text().strip() == "[]"
+
+    def test_mcpservers_non_object_is_skipped(self, tmp_path: Path):
+        original = '{"mcpServers": "oops"}'
+        (tmp_path / ".mcp.json").write_text(original)
+        line = _configure_mcp(tmp_path, remove=False)
+        assert "mcpServers" in line and "not a JSON object" in line
+        # The off-shape add path must not clobber the file.
+        assert (tmp_path / ".mcp.json").read_text() == original
+
+    def test_mcpservers_non_object_remove_is_noop(self, tmp_path: Path):
+        (tmp_path / ".mcp.json").write_text('{"mcpServers": "oops"}')
+        line = _configure_mcp(tmp_path, remove=True)
+        assert "no nauro entry to remove" in line
+
+    def test_codex_non_table_mcp_servers_is_skipped(self, tmp_path: Path):
+        cfg = tmp_path / "config.toml"
+        cfg.write_text('mcp_servers = "oops"\n')
+        line = _configure_codex(remove=False, config_path=cfg)
+        assert "not a table" in line
+        # Original content preserved.
+        assert 'mcp_servers = "oops"' in cfg.read_text()
+
+    def test_codex_non_table_mcp_servers_remove_is_noop(self, tmp_path: Path):
+        cfg = tmp_path / "config.toml"
+        cfg.write_text('mcp_servers = "oops"\n')
+        line = _configure_codex(remove=True, config_path=cfg)
+        assert "no nauro entry to remove" in line
+        assert 'mcp_servers = "oops"' in cfg.read_text()


### PR DESCRIPTION
## Why

`nauro setup claude-code/cursor/codex` mutated `mcpServers`/`mcp_servers` without checking the container's shape. A pre-existing config with `mcpServers` as a string/list — or a `.mcp.json` whose top level is a JSON array — raised a raw `TypeError`/`AttributeError` traceback on the first `setup`/`adopt` run. The hook path already guarded with `isinstance`; the MCP paths did not.

## Approach

Mirror the hook path's guard: check the top level is an object and that `mcpServers`/`mcp_servers` is a table/object before mutating, on both the add and remove paths. On an off-shape config, return a clear `… is not a JSON object/table, skipped` line and leave the file untouched.

## What changed

- `cli/commands/setup.py`: `_configure_json_mcp` guards the top-level dict and the `mcpServers` dict (add + remove); `_configure_codex` guards the `mcp_servers` table (add + remove).

## What to review

- Each skip path returns *before* any write, so an off-shape file is never clobbered.
- `tomllib.load` always yields a dict, so codex needs only the `mcp_servers` guard.
- Messages match the existing JSONDecodeError / hook-guard convention.

## What's deferred

`setup codex` still rewrites `~/.codex/config.toml` through a parse→re-emit that drops comments — a separate, cosmetic (no data-loss) issue tracked for a follow-up (wants `tomlkit` or a textual-append rewrite).

## Test plan

`tests/test_setup.py` gains a `TestMalformedConfigGuards` class: JSON top-level array, `mcpServers` non-object (add + remove, with no-clobber assertion), and codex `mcp_servers` non-table (add + remove) all skip cleanly and preserve the file. Full setup/adopt suites green; lint clean.
