### PR TITLE
Stop doubling the Current State heading in L0 / AGENTS.md

### DIFF
--- a/packages/nauro-core/src/nauro_core/context.py
+++ b/packages/nauro-core/src/nauro_core/context.py
@@ -93,6 +93,23 @@ def _resolve_state(files: dict[str, str]) -> str | None:
     return None
 
 
+def _strip_leading_current_header(assembled: str) -> str:
+    """Drop a leading ``# Current State`` header line from assembled state.
+
+    state_current.md carries its own ``# Current State`` header. L0 wraps the
+    state under its own ``## Current State`` section header, so without this the
+    payload (and the generated AGENTS.md) shows a stuttered ``## Current State``
+    immediately followed by ``# Current State``. Only the header line is removed;
+    the body and any footer are preserved.
+    """
+    lines = assembled.strip().split("\n")
+    if lines and lines[0].strip() == "# Current State":
+        lines = lines[1:]
+        while lines and not lines[0].strip():
+            lines.pop(0)
+    return "\n".join(lines).strip()
+
+
 def build_l0(files: dict[str, str], decisions: list[Decision]) -> str:
     """Build L0 payload (concise summary).
 
@@ -123,7 +140,9 @@ def build_l0(files: dict[str, str], decisions: list[Decision]) -> str:
             include_history=False,
         )
         if assembled and assembled.strip():
-            sections.append("## Current State\n" + assembled.strip())
+            body = _strip_leading_current_header(assembled)
+            if body:
+                sections.append("## Current State\n" + body)
 
     stack = files.get("stack.md", "")
     oneliner = extract_stack_oneliner(stack)

--- a/packages/nauro-core/tests/test_context.py
+++ b/packages/nauro-core/tests/test_context.py
@@ -78,6 +78,16 @@ class TestBuildL0:
         assert "Shipping v1" in result
         assert "Set up project scaffolding" not in result  # history excluded
 
+    def test_current_state_header_not_doubled(self):
+        # state_current.md carries its own "# Current State" header; L0 wraps it
+        # under a "## Current State" section header. The two must not stutter.
+        files = {"state_current.md": "# Current State\n\n- Shipped the thing\n"}
+        result = build_l0(files, [])
+        assert "## Current State" in result
+        assert "# Current State\n# Current State" not in result
+        assert "## Current State\n# Current State" not in result
+        assert "- Shipped the thing" in result
+
     def test_decisions_summary_present(self):
         result = build_l0(FULL_FILES, DECISIONS)
         assert "D3 \u2014 Auth0 for OAuth" in result

--- a/packages/nauro/tests/test_get_context_parity.py
+++ b/packages/nauro/tests/test_get_context_parity.py
@@ -171,10 +171,12 @@ def test_missing_store_guidance_matches_across_surfaces(missing_store):
 # reproduce it character-for-character; any drift indicates either a
 # transport-decoration regression (Last-synced trailer, snapshot diff,
 # NO_CONTEXT_YET sentinel) or a kernel content change.
+#
+# Deviates from that capture in one intended way: the redundant "# Current
+# State" sub-header (the file's own header, doubled under L0's "## Current
+# State" section header) is now stripped.
 
 _BASELINE_L0 = """## Current State
-# Current State
-
 **Sprint:** ship beta
 **Blocker:** none
 


### PR DESCRIPTION
## Why

`state_current.md` carries its own `# Current State` header, and `build_l0` wrapped it under an additional `## Current State` section header — so the L0 payload and **every generated AGENTS.md** showed a stuttered `## Current State` immediately followed by `# Current State`. It's the first templating artifact a reader sees in the repo, and reads as a bug.

## Approach

Strip a leading `# Current State` header line from the assembled state before adding the L0 section header (body and any footer preserved), matching the no-blank-after-header style of the other L0 sections (Open Questions, Recent Decisions). Exact-line match, so it won't touch a `# Current State Machine`-style heading or a mid-body occurrence.

## What changed

- `nauro_core/context.py`: `_strip_leading_current_header` helper; `build_l0` uses it and only appends the section when a non-empty body remains.

## What to review

- Scope is L0-only — L1/L2 append assembled state without the `## Current State` wrapper and are untouched; the legacy `state.md` path (via `extract_current_state`) never carries the header so it's a no-op there.
- The byte-for-byte L0 parity fixture (`_BASELINE_L0`) is updated to the de-duplicated output; the comment notes the one intended deviation from the captured baseline.

## What's deferred

Nothing in scope.

## Test plan

`nauro-core` `tests/test_context.py` gains a regression test using a `state_current.md` input (the existing fixture uses legacy `state.md` and wouldn't exhibit the stutter). The L0 parity fixture is updated. Verified live: a generated AGENTS.md now shows a single `## Current State`. nauro-core + nauro suites green; lint clean.
