### PR TITLE
Derive nauro init name from the directory instead of 'demo-project'

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/init.py
+++ b/packages/nauro/src/nauro/cli/commands/init.py
@@ -235,7 +235,10 @@ _Opt_add_repo_paths = typer.Option(
 
 
 def init(
-    name: str = typer.Argument(default="demo-project", help="Project name."),
+    name: str | None = typer.Argument(
+        default=None,
+        help="Project name. Defaults to the directory name (or 'demo-project' with --demo).",
+    ),
     add_repo_paths: list[Path] | None = _Opt_add_repo_paths,
     demo: bool = typer.Option(
         False,
@@ -274,6 +277,19 @@ def init(
             "or `nauro init <name> --cloud` for an empty cloud project.",
             param_hint="--demo / --cloud",
         )
+
+    # Resolve an omitted name. --demo keeps its fixed sample name; otherwise
+    # derive from the current directory (like `git init`/`npm init`) instead of
+    # silently creating a real, empty project literally named 'demo-project'.
+    if name is None:
+        name = "demo-project" if demo else Path.cwd().name
+        if not name:
+            typer.echo(
+                "Error: could not derive a project name from the current directory. "
+                "Pass one explicitly: nauro init <name>",
+                err=True,
+            )
+            raise typer.Exit(code=1)
 
     repo_paths = add_repo_paths if add_repo_paths else [Path.cwd()]
 

--- a/packages/nauro/tests/test_init_registry_integrity.py
+++ b/packages/nauro/tests/test_init_registry_integrity.py
@@ -155,3 +155,30 @@ def test_init_add_repo_links_second_repo_to_one_project(tmp_path, monkeypatch):
     # Still exactly one project named 'linked' — the second repo joined it.
     matches = find_projects_by_name_v2("linked")
     assert len(matches) == 1
+
+
+# ── omitted-name default ────────────────────────────────────────────────────────
+
+
+def test_init_without_name_derives_from_directory(tmp_path, monkeypatch):
+    """A bare `nauro init` names the project after the directory, not the
+    surprising literal 'demo-project'."""
+    repo = tmp_path / "my-cool-repo"
+    repo.mkdir()
+    monkeypatch.chdir(repo)
+
+    result = runner.invoke(app, ["init"])
+    assert result.exit_code == 0, result.output
+    assert len(find_projects_by_name_v2("my-cool-repo")) == 1
+    assert find_projects_by_name_v2("demo-project") == []
+
+
+def test_init_demo_without_name_still_uses_demo_project(tmp_path, monkeypatch):
+    """`nauro init --demo` (no name) keeps the fixed sample name."""
+    repo = tmp_path / "anything"
+    repo.mkdir()
+    monkeypatch.chdir(repo)
+
+    result = runner.invoke(app, ["init", "--demo"])
+    assert result.exit_code == 0, result.output
+    assert len(find_projects_by_name_v2("demo-project")) == 1


### PR DESCRIPTION
## Why

A bare `nauro init` (no name, no `--demo`) registered a real, empty project literally named `demo-project` — the name reserved for the sample store — because the name argument defaulted to that string. A user who fat-fingers the command got a confusingly-named project and could later collide with `nauro init --demo`.

## Approach

Default the name argument to `None` and resolve it in the body: `--demo` keeps the fixed `demo-project` sample name, while a plain init derives the name from the current directory (the `git init` / `npm init` convention), erroring with usage guidance only when no name can be derived.

## What changed

- `cli/commands/init.py`: `name` argument is now `str | None` defaulting to `None`; the body resolves `demo-project` for `--demo` or `Path.cwd().name` otherwise.

## What to review

- `nauro init --demo` (no name) still resolves to `demo-project`, preserving the demo reuse/idempotency path.
- An invalid derived basename (e.g. empty at filesystem root) errors cleanly via the empty-name guard or the caught `ValueError`, not a traceback. (Spaces in a dir name are accepted by the existing validator — unchanged behaviour.)
- The resolution runs before all branches (`--add-repo`, `--cloud`, local) that read `name`.

## What's deferred

Nothing in scope.

## Test plan

`tests/test_init_registry_integrity.py` gains: bare `init` derives the directory name (and does **not** create `demo-project`), and `init --demo` still creates `demo-project`. Full init suites green; lint clean. Verified live.
