### PR TITLE
Surface duplicate-name projects in projects and status

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/projects.py
+++ b/packages/nauro/src/nauro/cli/commands/projects.py
@@ -12,6 +12,8 @@ second entry for a repo that is already claimed.
 
 from __future__ import annotations
 
+from collections import Counter
+
 import typer
 
 from nauro.store.registry import (
@@ -41,6 +43,23 @@ def _print_project_list() -> None:
                 typer.echo(f"  Repo: {rp}")
         else:
             typer.echo("  Repo: (none)")
+
+    # Flag duplicate names: v2 allows them, but two same-named projects are
+    # separate stores that share no decisions — usually an accidental fork from
+    # re-running `nauro init <name>` in a second repo. Surface it so it is
+    # discoverable here, not just at creation time.
+    name_counts = Counter(e.get("name", "<unnamed>") for e in entries.values())
+    dupes = sorted(n for n, c in name_counts.items() if c > 1)
+    if dupes:
+        typer.echo("")
+        typer.echo(
+            "Warning: multiple projects share a name: "
+            + ", ".join(f"'{n}'" for n in dupes)
+            + ". These are separate stores. To put repos under one project, use "
+            "`nauro init <name> --add-repo <path>` and drop the extra with "
+            "`nauro projects rm <id>`.",
+            err=True,
+        )
 
 
 @projects_app.callback(invoke_without_command=True)

--- a/packages/nauro/src/nauro/cli/commands/status.py
+++ b/packages/nauro/src/nauro/cli/commands/status.py
@@ -71,6 +71,24 @@ def status(
     # handoffs/<slug>.md or context/<slug>.md.
     typer.echo(f"Store:   {store_path}\n")
 
+    # Warn when another local project shares this name — a separate store that
+    # shares no decisions, usually an accidental fork. Broadly guarded so this
+    # status nicety can never break the command; a v1 registry yields [] from
+    # the helper, so the check simply no-ops there.
+    current_id = store_path.name
+    try:
+        from nauro.store.registry import find_projects_by_name_v2
+
+        shared = [pid for pid, _ in find_projects_by_name_v2(project_name) if pid != current_id]
+    except Exception:
+        shared = []
+    if shared:
+        typer.echo(
+            f"  Warning: {len(shared)} other local project(s) share the name "
+            f"'{project_name}'. They are separate stores — run `nauro projects` to inspect.\n",
+            err=True,
+        )
+
     # Sync — gated on auth token + v2 cloud-mode (matches hooks.py semantics).
     # ``store_path.name`` is the project_id for v2; v1 entries pass their name
     # here and silent-no-op inside is_cloud_project.

--- a/packages/nauro/tests/test_projects_cmd.py
+++ b/packages/nauro/tests/test_projects_cmd.py
@@ -72,3 +72,42 @@ def test_projects_rm_declined_confirm_keeps_entry(tmp_path, monkeypatch):
     # typer.confirm(abort=True) raises Abort → exit 1 on decline.
     assert result.exit_code == 1, result.output
     assert registry.get_project_v2(pid_a) is not None
+
+
+# ── duplicate-name discoverability ──────────────────────────────────────────────
+
+
+def test_projects_flags_duplicate_names(tmp_path, monkeypatch):
+    """`nauro projects` warns when two entries share a name (separate stores)."""
+    register_project_v2("dup", [tmp_path / "a"])
+    register_project_v2("dup", [tmp_path / "b"])
+    result = runner.invoke(app, ["projects"])
+    assert result.exit_code == 0, result.output
+    assert "share a name" in result.output
+    assert "'dup'" in result.output
+
+
+def test_projects_no_duplicate_warning_for_unique_names(tmp_path, monkeypatch):
+    register_project_v2("alpha", [tmp_path / "a"])
+    register_project_v2("beta", [tmp_path / "b"])
+    result = runner.invoke(app, ["projects"])
+    assert result.exit_code == 0, result.output
+    assert "share a name" not in result.output
+
+
+def test_status_warns_when_name_shared(tmp_path, monkeypatch):
+    """`nauro status` flags another local project sharing the resolved name."""
+    repo_a = tmp_path / "ra"
+    repo_b = tmp_path / "rb"
+    repo_a.mkdir()
+    repo_b.mkdir()
+
+    monkeypatch.chdir(repo_a)
+    assert runner.invoke(app, ["init", "shared"]).exit_code == 0
+    monkeypatch.chdir(repo_b)
+    assert runner.invoke(app, ["init", "shared"]).exit_code == 0
+
+    monkeypatch.chdir(repo_a)
+    result = runner.invoke(app, ["status"])
+    assert result.exit_code == 0, result.output
+    assert "share the name" in result.output and "shared" in result.output


### PR DESCRIPTION
## Why

A same-name fork (two projects sharing a name but holding separate stores) was undiscoverable after creation: `nauro projects` listed both with no hint they collide, and `nauro status` presented a forked project as healthy with no sign another store shared its name. (`nauro init` already warns at creation time; this closes the after-the-fact discovery gap.)

## Approach

Surface duplicates where a user would look: `nauro projects` warns, naming the duplicated names and the recovery path; `nauro status` warns when another local project shares the resolved name. The status check is broadly guarded so the nicety can never break the command (a v1 registry simply yields no matches).

## What changed

- `cli/commands/projects.py`: a `Counter`-based duplicate-name warning after the listing.
- `cli/commands/status.py`: a guarded warning when another local project shares the current name.

## What to review

- `projects`: the warning prints only when a name actually repeats; the empty-registry early return is before it.
- `status`: `current_id = store_path.name` excludes self correctly for v2 ids; the broad `except` means v1/cloud/unresolved just no-op (no false positive, no crash).

## What's deferred

Case/whitespace/homoglyph name normalization (a policy decision) is out of scope.

## Test plan

`tests/test_projects_cmd.py` gains: `projects` warns on duplicate names, stays quiet for unique names, and `status` warns when two real `nauro init <same>` runs share a name. Full suite green; lint clean.
