### PR TITLE
Fix decision_type schema drift (crash) and markdown-fence parsing (data loss)

### DIFF
--- a/packages/nauro-core/src/nauro_core/__init__.py
+++ b/packages/nauro-core/src/nauro_core/__init__.py
@@ -13,9 +13,6 @@ from nauro_core.constants import (
     DECISION_HASHES_FILE as DECISION_HASHES_FILE,
 )
 from nauro_core.constants import (
-    DECISION_TYPES as DECISION_TYPES,
-)
-from nauro_core.constants import (
     DECISIONS_DIR as DECISIONS_DIR,
 )
 from nauro_core.constants import (
@@ -110,6 +107,9 @@ from nauro_core.context import (
 )
 from nauro_core.context import (
     build_l2 as build_l2,
+)
+from nauro_core.decision_model import (
+    DECISION_TYPE_VALUES as DECISION_TYPE_VALUES,
 )
 from nauro_core.decision_model import (
     Decision as Decision,
@@ -303,5 +303,9 @@ from nauro_core.validation import (
 from nauro_core.validation import (
     screen_structural as screen_structural,
 )
+
+# Public alias preserving the historical name. The canonical source is the
+# DecisionType enum in decision_model; DECISION_TYPE_VALUES is derived from it.
+DECISION_TYPES = DECISION_TYPE_VALUES
 
 __version__ = version("nauro-core")

--- a/packages/nauro-core/src/nauro_core/constants.py
+++ b/packages/nauro-core/src/nauro_core/constants.py
@@ -71,17 +71,6 @@ STATE_OVERLAP_STOP_WORDS: frozenset[str] = frozenset(
     {"the", "a", "an", "to", "and", "or", "is", "was", "-"}
 )
 
-# ── Decision types ──
-DECISION_TYPES: tuple[str, ...] = (
-    "architecture",
-    "library_choice",
-    "pattern",
-    "refactor",
-    "api_design",
-    "infrastructure",
-    "data_model",
-)
-
 # ── Reversibility levels ──
 REVERSIBILITY_LEVELS: tuple[str, ...] = ("easy", "moderate", "hard")
 

--- a/packages/nauro-core/src/nauro_core/decision_model.py
+++ b/packages/nauro-core/src/nauro_core/decision_model.py
@@ -56,6 +56,15 @@ class DecisionType(str, Enum):
     data_model = "data_model"
 
 
+# Canonical list of advertised decision-type tokens, derived from the
+# DecisionType enum so the schema copies that surface these values (the MCP
+# input schema, the public constants re-export) cannot drift from the
+# validator that actually accepts them. decision_model is the lowest module in
+# the import chain (decision_model -> parsing -> constants -> protocol), so this
+# value is imported outward; constants cannot import it without a cycle.
+DECISION_TYPE_VALUES: tuple[str, ...] = tuple(t.value for t in DecisionType)
+
+
 class Reversibility(str, Enum):
     easy = "easy"
     moderate = "moderate"
@@ -408,6 +417,7 @@ def format_decision(decision: Decision) -> str:
 
 
 __all__ = [
+    "DECISION_TYPE_VALUES",
     "Decision",
     "DecisionConfidence",
     "DecisionSource",

--- a/packages/nauro-core/src/nauro_core/decision_model.py
+++ b/packages/nauro-core/src/nauro_core/decision_model.py
@@ -278,6 +278,21 @@ def parse_decision(text: str, filename: str) -> Decision:
     )
 
 
+def _leading_fence_marker(line: str) -> str | None:
+    """Return the fence marker char if the line opens/closes a code fence.
+
+    A fence line's stripped form starts with a run of at least three of the
+    same marker character (a backtick or a tilde). Returns ``"`"`` or ``"~"``
+    for such a line, else ``None``. An info string after the run (e.g.
+    ``text`` in ```` ```text ````) does not affect the marker.
+    """
+    stripped = line.strip()
+    for marker in ("`", "~"):
+        if stripped.startswith(marker * 3):
+            return marker
+    return None
+
+
 def _split_decision_body(body: str) -> tuple[str | None, str | None]:
     """Split a decision body into ``(rationale, rejected_body)``.
 
@@ -294,8 +309,12 @@ def _split_decision_body(body: str) -> tuple[str | None, str | None]:
       therefore kept in the rationale, and only the genuine trailing block is
       parsed as rejected alternatives.
 
-    Lines inside fenced code blocks (toggled by ``` ``` ``` or ``~~~``) never
-    anchor, and the fence-marker lines themselves are never anchors.
+    Lines inside fenced code blocks never anchor, and the fence-marker lines
+    themselves are never anchors. A fence opened with one marker (``` ``` ```
+    or ``~~~``) closes only on a bare run of the SAME marker, so a run of the
+    opposite marker inside the block (e.g. a ``~~~~~`` separator inside a
+    ```` ```text ```` block) is content, not a close — it cannot desync the
+    tracker and swallow a trailing Rejected Alternatives section.
 
     Returns:
         ``(rationale, rejected_body)`` where ``rationale`` is the stripped text
@@ -305,16 +324,23 @@ def _split_decision_body(body: str) -> tuple[str | None, str | None]:
     """
     lines = body.split("\n")
 
-    in_fence = False
+    fence_char: str | None = None
     decision_idx: int | None = None
     rejected_idx: int | None = None
 
     for i, line in enumerate(lines):
-        stripped = line.strip()
-        if stripped.startswith("```") or stripped.startswith("~~~"):
-            in_fence = not in_fence
+        marker = _leading_fence_marker(line)
+        if marker is not None:
+            if fence_char is None:
+                # An opener may carry an info string (e.g. ```text).
+                fence_char = marker
+            elif marker == fence_char and line.strip() == fence_char * line.strip().count(
+                fence_char
+            ):
+                # A closing fence is a bare run of the same marker, no info string.
+                fence_char = None
             continue
-        if in_fence:
+        if fence_char is not None:
             continue
         trimmed = line.rstrip()
         if decision_idx is None:

--- a/packages/nauro-core/src/nauro_core/mcp_tools.py
+++ b/packages/nauro-core/src/nauro_core/mcp_tools.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 from typing import Any, TypedDict
 
+from nauro_core.decision_model import DECISION_TYPE_VALUES
 from nauro_core.protocol import (
     GET_DECISION_BEFORE_PROPOSING,
     PROPOSE_DECISION_OPERATIONS,
@@ -378,15 +379,7 @@ PROPOSE_DECISION: ToolSpec = {
             },
             "decision_type": {
                 "type": "string",
-                "enum": [
-                    "architecture",
-                    "library_choice",
-                    "pattern",
-                    "refactor",
-                    "api_design",
-                    "infrastructure",
-                    "data_model",
-                ],
+                "enum": list(DECISION_TYPE_VALUES),
                 "description": (
                     "Optional architectural category for the decision. Helps "
                     "downstream filtering and reporting; omit when none "

--- a/packages/nauro-core/tests/operations/test_operations_propose_decision.py
+++ b/packages/nauro-core/tests/operations/test_operations_propose_decision.py
@@ -24,6 +24,7 @@ from pydantic import ValidationError
 
 from nauro_core.constants import OPEN_QUESTIONS_MD
 from nauro_core.decision_model import (
+    DECISION_TYPE_VALUES,
     Decision,
     DecisionConfidence,
     DecisionStatus,
@@ -800,3 +801,21 @@ def test_write_decision_direct_increments_decision_number() -> None:
         },
     )
     assert decision_id.startswith("003-")
+
+
+@pytest.mark.parametrize("decision_type", list(DECISION_TYPE_VALUES))
+def test_every_advertised_decision_type_commits(decision_type: str) -> None:
+    """Every decision_type the schema advertises must reach the validator
+    intact and commit. This is the end-to-end guard that was missing when the
+    advertised list drifted from the DecisionType enum: an advertised value
+    that the enum does not accept raised an uncaught ValueError on the write
+    path. Driving propose_decision over the canonical value set keeps the two
+    in lockstep."""
+    result = propose_decision(
+        InMemoryStore(),
+        title=f"Decision typed as {decision_type}",
+        rationale="A rationale long enough to clear the minimum length threshold.",
+        confidence="medium",
+        decision_type=decision_type,
+    )
+    assert result.status == "confirmed"

--- a/packages/nauro-core/tests/test_constants.py
+++ b/packages/nauro-core/tests/test_constants.py
@@ -1,8 +1,8 @@
 """Tests for nauro_core.constants — sanity checks."""
 
+from nauro_core import DECISION_TYPES
 from nauro_core.constants import (
     DECISION_HASHES_FILE,
-    DECISION_TYPES,
     DECISIONS_DIR,
     L0_DECISIONS_SUMMARY_LIMIT,
     L0_QUESTIONS_LIMIT,
@@ -20,6 +20,7 @@ from nauro_core.constants import (
     STATE_MD,
     VALID_CONFIDENCES,
 )
+from nauro_core.decision_model import DecisionType
 from nauro_core.instructions import build_remote_instructions
 from nauro_core.protocol import (
     GET_DECISION_BEFORE_PROPOSING,
@@ -74,16 +75,12 @@ class TestValidValues:
         assert "medium" in VALID_CONFIDENCES
         assert "low" in VALID_CONFIDENCES
 
-    def test_decision_types_non_empty(self):
-        assert DECISION_TYPES == (
-            "architecture",
-            "library_choice",
-            "pattern",
-            "refactor",
-            "api_design",
-            "infrastructure",
-            "data_model",
-        )
+    def test_decision_types_track_the_enum(self):
+        # DECISION_TYPES is derived from the DecisionType enum, so asserting
+        # against the enum (rather than a hand-copied tuple) keeps the public
+        # constant from drifting away from the values the validator accepts.
+        assert tuple(t.value for t in DecisionType) == DECISION_TYPES
+        assert "library_choice" not in DECISION_TYPES
 
     def test_reversibility_levels_non_empty(self):
         assert REVERSIBILITY_LEVELS == ("easy", "moderate", "hard")

--- a/packages/nauro-core/tests/test_decision_model.py
+++ b/packages/nauro-core/tests/test_decision_model.py
@@ -341,6 +341,38 @@ class TestRationaleBoundary:
         assert [r.name for r in d.rejected] == ["Genuine Option"]
         assert d.rejected[0].reason == "The real reason this was rejected."
 
+    def test_mixed_marker_fence_does_not_desync_rejected_split(self) -> None:
+        """A ```text fence whose body contains a single bare ~~~~~ line must not
+        desync the fence tracker. With a single in_fence boolean the tilde run
+        toggled the tracker a second time, so the parser believed it was still
+        inside a fence when the real `## Rejected Alternatives` heading arrived
+        and silently dropped the whole section. Closing only on the matching
+        marker keeps the trailing rejected block parseable."""
+        text = (
+            "---\n"
+            "date: 2026-04-01\n"
+            "confidence: high\n"
+            "---\n\n"
+            "# 056 — Mixed fence markers\n\n"
+            "## Decision\n\n"
+            "We document the separator convention below.\n\n"
+            "```text\n"
+            "~~~~~\n"
+            "```\n\n"
+            "And then the actual reasoning.\n\n"
+            "## Rejected Alternatives\n\n"
+            "### Genuine Option\n\n"
+            "The real reason this was rejected.\n"
+        )
+        d = parse_decision(text, "056-mixed-fence.md")
+        # The tilde run is fence content, so it stays in the rationale.
+        assert "~~~~~" in d.rationale
+        assert "And then the actual reasoning." in d.rationale
+        # The trailing rejected section survives rather than being swallowed.
+        assert len(d.rejected) == 1
+        assert d.rejected[0].name == "Genuine Option"
+        assert d.rejected[0].reason == "The real reason this was rejected."
+
     def test_no_rejected_section_full_rationale(self) -> None:
         """No rejected section: rejected == [] and the full rationale is kept."""
         text = (

--- a/packages/nauro-core/tests/test_decision_model.py
+++ b/packages/nauro-core/tests/test_decision_model.py
@@ -426,7 +426,9 @@ class TestNegativeValidation:
             parse_decision(text, "001-test.md")
 
     def test_unknown_decision_type_raises(self) -> None:
-        text = self._build(decision_type="library_choice")  # removed from enum
+        # "library_choice" is not a DecisionType member, so the validator must
+        # reject it. The advertised schema copies no longer offer it either.
+        text = self._build(decision_type="library_choice")
         with pytest.raises(ValidationError):
             parse_decision(text, "001-test.md")
 

--- a/packages/nauro/src/nauro/constants.py
+++ b/packages/nauro/src/nauro/constants.py
@@ -9,9 +9,11 @@ CLI-specific constants are defined locally.
 """
 
 # ── Re-exports from nauro-core (shared across nauro + mcp-server) ──
+# DECISION_TYPES comes from the public facade because its canonical source is
+# the DecisionType enum in nauro_core.decision_model, not nauro_core.constants.
+from nauro_core import DECISION_TYPES as DECISION_TYPES
 from nauro_core.constants import CHARS_PER_TOKEN as CHARS_PER_TOKEN
 from nauro_core.constants import DECISION_HASHES_FILE as DECISION_HASHES_FILE
-from nauro_core.constants import DECISION_TYPES as DECISION_TYPES
 from nauro_core.constants import DECISIONS_DIR as DECISIONS_DIR
 from nauro_core.constants import L0_DECISIONS_SUMMARY_LIMIT as L0_DECISIONS_SUMMARY_LIMIT
 from nauro_core.constants import L0_QUESTIONS_LIMIT as L0_QUESTIONS_LIMIT

--- a/packages/nauro/src/nauro/mcp/stdio_server.py
+++ b/packages/nauro/src/nauro/mcp/stdio_server.py
@@ -311,13 +311,15 @@ def propose_decision(
         Field(description=_param_desc("propose_decision", "confidence")),
     ] = None,
     decision_type: Annotated[
+        # A Literal is a static annotation and cannot be built from the runtime
+        # DECISION_TYPE_VALUES tuple, so these are hand-written. The drift-guard
+        # test in test_stdio_server.py asserts this set equals the enum values.
         Literal[
             "architecture",
-            "library_choice",
-            "pattern",
-            "refactor",
             "api_design",
             "infrastructure",
+            "pattern",
+            "refactor",
             "data_model",
         ]
         | None,

--- a/packages/nauro/tests/test_stdio_server.py
+++ b/packages/nauro/tests/test_stdio_server.py
@@ -1,7 +1,7 @@
 """Tests for the Nauro MCP stdio server tools."""
 
 from pathlib import Path
-from typing import get_args, get_type_hints
+from typing import Literal, get_args, get_origin, get_type_hints
 from unittest.mock import patch
 
 import pytest
@@ -421,14 +421,22 @@ class TestToolSpecDescriptionsReachAgent:
         ``DECISION_TYPE_VALUES`` tuple. This guard fails if the two ever drift
         — the exact failure that shipped ``library_choice`` to the schema while
         the validator rejected it."""
-        # decision_type is Annotated[Literal[...] | None, Field(...)]; strip the
-        # Annotated layer to reach the Literal[...] | None union, then the union
-        # to reach the Literal and its None arm.
+
+        # decision_type is Annotated[Literal[...] | None, Field(...)], but
+        # get_type_hints nests Annotated vs Optional in a version-dependent
+        # order, so locate the Literal anywhere in the annotation tree rather
+        # than assuming a fixed shape.
+        def _literal_values(tp):
+            if get_origin(tp) is Literal:
+                return set(get_args(tp))
+            for arg in get_args(tp):
+                found = _literal_values(arg)
+                if found is not None:
+                    return found
+            return None
+
         hints = get_type_hints(propose_decision, include_extras=True)
-        union = get_args(hints["decision_type"])[0]
-        literal, none_type = get_args(union)
-        assert none_type is type(None)
-        assert set(get_args(literal)) == set(DECISION_TYPE_VALUES)
+        assert _literal_values(hints["decision_type"]) == set(DECISION_TYPE_VALUES)
 
     def test_ten_tools_registered(self):
         tools = mcp._tool_manager.list_tools()

--- a/packages/nauro/tests/test_stdio_server.py
+++ b/packages/nauro/tests/test_stdio_server.py
@@ -1,10 +1,12 @@
 """Tests for the Nauro MCP stdio server tools."""
 
 from pathlib import Path
+from typing import get_args, get_type_hints
 from unittest.mock import patch
 
 import pytest
 from mcp.types import CallToolResult
+from nauro_core.decision_model import DECISION_TYPE_VALUES
 from nauro_core.operations import flag_question as _flag_question_op
 
 from nauro.mcp.stdio_server import (
@@ -409,17 +411,24 @@ class TestToolSpecDescriptionsReachAgent:
         params = tools_by_name["propose_decision"].parameters["properties"]
         assert {"high", "medium", "low"} == set(params["confidence"]["anyOf"][0]["enum"])
         decision_type_enum = params["decision_type"]["anyOf"][0]["enum"]
-        for dt in (
-            "architecture",
-            "library_choice",
-            "pattern",
-            "refactor",
-            "api_design",
-            "infrastructure",
-            "data_model",
-        ):
-            assert dt in decision_type_enum
+        assert set(decision_type_enum) == set(DECISION_TYPE_VALUES)
+        assert "library_choice" not in decision_type_enum
         assert {"easy", "moderate", "hard"} == set(params["reversibility"]["anyOf"][0]["enum"])
+
+    def test_decision_type_literal_matches_enum(self):
+        """The stdio decision_type annotation is a hand-written ``Literal``
+        because a Literal cannot be built from the runtime
+        ``DECISION_TYPE_VALUES`` tuple. This guard fails if the two ever drift
+        — the exact failure that shipped ``library_choice`` to the schema while
+        the validator rejected it."""
+        # decision_type is Annotated[Literal[...] | None, Field(...)]; strip the
+        # Annotated layer to reach the Literal[...] | None union, then the union
+        # to reach the Literal and its None arm.
+        hints = get_type_hints(propose_decision, include_extras=True)
+        union = get_args(hints["decision_type"])[0]
+        literal, none_type = get_args(union)
+        assert none_type is type(None)
+        assert set(get_args(literal)) == set(DECISION_TYPE_VALUES)
 
     def test_ten_tools_registered(self):
         tools = mcp._tool_manager.list_tools()


### PR DESCRIPTION
## Why

Two correctness defects on the decision-recording path, both verified end-to-end.

1. **`propose_decision` crashes on an advertised `decision_type`.** The list of valid
   decision types had drifted across four places. The validating `DecisionType` enum
   no longer includes `library_choice`, but three schema copies — the `DECISION_TYPES`
   constants tuple, the MCP tool input-schema enum, and the stdio `Literal` — still
   advertised it as the *first* option. An agent following the published schema and
   picking the leading value hits an uncaught `ValueError` on the write path, while a
   valid type like `architecture` writes cleanly. No test exercised the end-to-end path
   over every advertised type, so the drift shipped green.

2. **Decision parsing silently drops Rejected Alternatives.** `_split_decision_body`
   tracked fenced code with a single boolean toggled by any line starting with ``` or
   `~~~`. A fence opened with one marker that contains a run of the other marker — e.g. a
   `~~~~~` separator pasted inside a ```` ```text ```` block — flips the boolean a second
   time and desyncs the tracker. The parser then believes it is still inside a fence when
   the real `## Rejected Alternatives` heading arrives and discards the whole section with
   no error. A later update/supersede then reformats the decision without the alternatives,
   making the loss permanent.

## Approach

**Enum drift.** Make the `DecisionType` enum the single source. `decision_model` is the
lowest module in the import chain (`decision_model → parsing → constants → protocol`), so
a canonical `DECISION_TYPE_VALUES` tuple lives there and is imported outward; `constants`
cannot derive it without a cycle. The MCP input-schema enum is built from that tuple. The
stdio `Literal` stays hand-written — a `Literal` is a static annotation and cannot be built
from a runtime tuple — but drops `library_choice` to the six valid values, guarded by a test
that fails on future drift. The hardcoded constants tuple is removed and the public
`DECISION_TYPES` name re-exported from the canonical source.

**Fence parser.** Track the opening marker character instead of a boolean. A fence closes
only on a bare run of the same marker (a closing fence carries no info string per CommonMark),
so a run of the opposite marker inside the block is content and cannot desync the tracker.

## What changed

- **nauro-core:** `DECISION_TYPE_VALUES` added to `decision_model`; hardcoded `DECISION_TYPES`
  removed from `constants`; the package facade and the MCP input-schema enum repointed to the
  canonical source. `_split_decision_body` rewritten to key on the fence marker character.
- **nauro:** CLI `constants` repointed to the facade; the stdio `decision_type` `Literal`
  trimmed to the six valid values.

## What to review

- The cycle argument: `decision_model` does not import `constants`, `mcp_tools`, or the package
  `__init__`, so importing `DECISION_TYPE_VALUES` outward is safe.
- The fence close condition — a closer must be a bare same-marker run with no info string.
  Confirm pre-existing fenced-code parses still hold alongside the new mixed-marker regression.

## What's deferred

Nothing. Both defects are fixed in full. (A defensive `try/except` around the enum coercion was
considered and left out — single-sourcing removes the live drift; fail-soft would be a separate
change.)

## Test plan

- New end-to-end regression drives `propose_decision` over every advertised `decision_type` and
  asserts each commits — the guard that was missing when the list drifted.
- New stdio drift-guard asserts the `Literal` args equal the enum values.
- New fence regression: a ```` ```text ```` fence enclosing a bare `~~~~~` line followed by a real
  Rejected Alternatives block now parses the alternative (failed `0 == 1` before the fix).
- nauro-core 763 passed; nauro 1370 passed, 10 skipped; `ruff check` and `ruff format --check` clean.
