### PR TITLE
Pin UTF-8 on content file I/O so non-UTF-8 locales don't crash

### DIFF
--- a/packages/nauro/src/nauro/cli/_json_input.py
+++ b/packages/nauro/src/nauro/cli/_json_input.py
@@ -51,7 +51,7 @@ def parse_json_list_of_dicts(raw: str, flag_name: str) -> list[dict]:
         path = Path(raw[1:])
         if not path.exists() or not path.is_file():
             raise typer.BadParameter(f"{flag_name}: file '{path}' does not exist")
-        text = path.read_text()
+        text = path.read_text(encoding="utf-8")
     else:
         text = raw
 

--- a/packages/nauro/src/nauro/cli/commands/import_cmd.py
+++ b/packages/nauro/src/nauro/cli/commands/import_cmd.py
@@ -184,9 +184,9 @@ def _append_to_store_file(target: Path, content: str) -> None:
 
     if target.exists():
         existing = _read(target)
-        target.write_text(existing.rstrip() + header + stripped + "\n")
+        target.write_text(existing.rstrip() + header + stripped + "\n", encoding="utf-8")
     else:
-        target.write_text(header.lstrip() + stripped + "\n")
+        target.write_text(header.lstrip() + stripped + "\n", encoding="utf-8")
 
 
 def _parse_and_import_decisions(content: str, store_path: Path) -> int:

--- a/packages/nauro/src/nauro/cli/commands/setup.py
+++ b/packages/nauro/src/nauro/cli/commands/setup.py
@@ -19,6 +19,7 @@ import typer
 
 from nauro.cli.utils import _resolve_project_entry, resolve_target_project
 from nauro.constants import CLAUDE_MD, NAURO_BLOCK_END, NAURO_BLOCK_START
+from nauro.store.reader import read_text_lenient
 from nauro.store.registry import (
     RegistrySchemaError,
     load_registry,
@@ -55,7 +56,7 @@ def _remove_claude_md(repo_path: Path) -> str | None:
     if not claude_md.exists():
         return None
 
-    content = claude_md.read_text()
+    content = read_text_lenient(claude_md)
     if CLAUDE_MD_START not in content:
         return None
 
@@ -67,7 +68,7 @@ def _remove_claude_md(repo_path: Path) -> str | None:
         claude_md.unlink()
         return f"  {repo_path}: removed legacy Nauro block (deleted empty {CLAUDE_MD})"
     else:
-        claude_md.write_text(remaining + "\n")
+        claude_md.write_text(remaining + "\n", encoding="utf-8")
         return f"  {repo_path}: removed legacy Nauro block from {CLAUDE_MD}"
 
 

--- a/packages/nauro/src/nauro/demo/__init__.py
+++ b/packages/nauro/src/nauro/demo/__init__.py
@@ -304,17 +304,19 @@ def create_demo_project(store_path: Path) -> None:
     snapshots_dir = store_path / constants.SNAPSHOTS_DIR
     snapshots_dir.mkdir(exist_ok=True)
 
-    (store_path / constants.PROJECT_MD).write_text(PROJECT_MD)
-    (store_path / constants.STATE_CURRENT_FILENAME).write_text(DEMO_STATE_CURRENT_MD)
-    (store_path / constants.STACK_MD).write_text(STACK_MD)
-    (store_path / constants.OPEN_QUESTIONS_MD).write_text(OPEN_QUESTIONS_MD)
+    (store_path / constants.PROJECT_MD).write_text(PROJECT_MD, encoding="utf-8")
+    (store_path / constants.STATE_CURRENT_FILENAME).write_text(
+        DEMO_STATE_CURRENT_MD, encoding="utf-8"
+    )
+    (store_path / constants.STACK_MD).write_text(STACK_MD, encoding="utf-8")
+    (store_path / constants.OPEN_QUESTIONS_MD).write_text(OPEN_QUESTIONS_MD, encoding="utf-8")
 
     # Emit decisions via format_decision so they match the writer's output shape.
     decision_files: dict[str, str] = {}
     for d in DEMO_DECISIONS:
         filename = _decision_filename(d, _DEMO_SLUGS[d.num])
         body = format_decision(d)
-        (decisions_dir / filename).write_text(body)
+        (decisions_dir / filename).write_text(body, encoding="utf-8")
         decision_files[f"{constants.DECISIONS_DIR}/{filename}"] = body
 
     files = {
@@ -335,4 +337,6 @@ def create_demo_project(store_path: Path) -> None:
         "files": files,
     }
 
-    (snapshots_dir / "v001.json").write_text(json.dumps(snapshot, indent=2) + "\n")
+    (snapshots_dir / "v001.json").write_text(
+        json.dumps(snapshot, indent=2) + "\n", encoding="utf-8"
+    )

--- a/packages/nauro/src/nauro/store/_atomic.py
+++ b/packages/nauro/src/nauro/store/_atomic.py
@@ -39,7 +39,7 @@ def atomic_write_text(path: Path, text: str, *, mode: int | None = None) -> None
         fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.", suffix=".tmp")
         tmp = Path(tmp_name)
         try:
-            with os.fdopen(fd, "w") as handle:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
                 handle.write(text)
             if mode != 0o600:
                 os.chmod(tmp, mode)
@@ -49,5 +49,5 @@ def atomic_write_text(path: Path, text: str, *, mode: int | None = None) -> None
             raise
     else:
         tmp = path.with_suffix(".tmp")
-        tmp.write_text(text)
+        tmp.write_text(text, encoding="utf-8")
         os.replace(tmp, path)

--- a/packages/nauro/src/nauro/store/filesystem_store.py
+++ b/packages/nauro/src/nauro/store/filesystem_store.py
@@ -61,7 +61,7 @@ class FilesystemStore:
         target.parent.mkdir(parents=True, exist_ok=True)
         lock = target.with_name(target.name + ".lock")
         with FileLock(str(lock)):
-            target.write_text(content)
+            target.write_text(content, encoding="utf-8")
 
     def delete_file(self, path: str) -> None:
         try:

--- a/packages/nauro/src/nauro/templates/agents_md.py
+++ b/packages/nauro/src/nauro/templates/agents_md.py
@@ -12,6 +12,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from nauro.constants import AGENTS_MD, MANUAL_SECTION_HEADER, SKILLS_SECTION_HEADER
+from nauro.store.reader import read_text_lenient
 
 # Prefix shared by every auto-generated attribution footer. Match by prefix
 # (not by full canonical URL) so a stale footer from an earlier tagline cycle
@@ -224,7 +225,7 @@ def regenerate_agents_md_for_project(project_key: str, store_path: Path) -> list
             skills_section=preserved.skills,
             section_order=preserved.order or None,
         )
-        agents_md_path.write_text(content)
+        agents_md_path.write_text(content, encoding="utf-8")
         updated.append(repo_path)
 
     return updated
@@ -244,7 +245,7 @@ def parse_preserved_sections(agents_md_path: Path) -> PreservedSections:
     if not agents_md_path.exists():
         return PreservedSections()
 
-    content = agents_md_path.read_text()
+    content = read_text_lenient(agents_md_path)
     skills_idx = _find_header(content, SKILLS_SECTION_HEADER)
     manual_idx = _find_header(content, MANUAL_SECTION_HEADER)
 

--- a/packages/nauro/src/nauro/templates/scaffolds.py
+++ b/packages/nauro/src/nauro/templates/scaffolds.py
@@ -139,14 +139,20 @@ def scaffold_project_store(project_name: str, store_path: Path) -> None:
 
     created_at = datetime.now(timezone.utc).strftime("%Y-%m-%d")
 
-    (store_path / C.PROJECT_MD).write_text(render_scaffold(PROJECT_MD, project_name=project_name))
-    (store_path / C.STATE_CURRENT_FILENAME).write_text(render_scaffold(STATE_CURRENT_MD))
-    (store_path / C.STACK_MD).write_text(render_scaffold(STACK_MD))
-    (store_path / C.OPEN_QUESTIONS_MD).write_text(render_scaffold(OPEN_QUESTIONS_MD))
+    (store_path / C.PROJECT_MD).write_text(
+        render_scaffold(PROJECT_MD, project_name=project_name), encoding="utf-8"
+    )
+    (store_path / C.STATE_CURRENT_FILENAME).write_text(
+        render_scaffold(STATE_CURRENT_MD), encoding="utf-8"
+    )
+    (store_path / C.STACK_MD).write_text(render_scaffold(STACK_MD), encoding="utf-8")
+    (store_path / C.OPEN_QUESTIONS_MD).write_text(
+        render_scaffold(OPEN_QUESTIONS_MD), encoding="utf-8"
+    )
 
     # Scaffold the first decision as a teaching example (v2 format via nauro-core).
     (store_path / C.DECISIONS_DIR / "001-initial-setup.md").write_text(
-        _build_first_decision(created_at)
+        _build_first_decision(created_at), encoding="utf-8"
     )
 
 

--- a/packages/nauro/tests/test_cli_json_input.py
+++ b/packages/nauro/tests/test_cli_json_input.py
@@ -33,6 +33,18 @@ def test_at_sigil_reads_file(tmp_path: Path) -> None:
     assert parsed == [{"alternative": "X", "reason": "Y"}]
 
 
+def test_at_sigil_reads_utf8_file_regardless_of_locale(tmp_path: Path) -> None:
+    # JSON is UTF-8 by spec, and rejected-alternative text flows into a decision
+    # file on disk; a non-ASCII char (em-dash) must decode the same way no matter
+    # what the platform's default encoding is, so the read pins UTF-8.
+    payload = tmp_path / "rejected.json"
+    payload.write_bytes(
+        b'[{"alternative": "Redis", "reason": "single-AZ \xe2\x80\x94 no failover"}]'
+    )
+    parsed = parse_json_list_of_dicts(f"@{payload}", "--rejected")
+    assert parsed == [{"alternative": "Redis", "reason": "single-AZ — no failover"}]
+
+
 def test_stdin_sigil_reads_stdin(monkeypatch) -> None:
     monkeypatch.setattr(
         "sys.stdin",

--- a/packages/nauro/tests/test_read_encoding.py
+++ b/packages/nauro/tests/test_read_encoding.py
@@ -13,15 +13,27 @@ from pathlib import Path
 import pytest
 
 from nauro import constants
+from nauro.cli.commands.import_cmd import _append_to_store_file
 from nauro.demo import create_demo_project
 from nauro.mcp.tools import tool_get_context, tool_get_raw_file
 from nauro.store.filesystem_store import FilesystemStore
 from nauro.store.reader import _list_decisions, read_text_lenient
+from nauro.store.registry import register_project
 from nauro.store.snapshot import capture_snapshot
+from nauro.templates.agents_md import (
+    parse_preserved_sections,
+    regenerate_agents_md_for_project,
+)
+from nauro.templates.scaffolds import scaffold_project_store
 
 # A lone 0xe9 is "é" in latin-1/cp1252 but an invalid UTF-8 start byte.
 _BAD_BYTE = b"\xe9"
 _REPLACEMENT = "�"
+# Load-bearing non-ASCII the templates actually emit: em-dash (U+2014) is in
+# the scaffold decision body and the AGENTS.md header; the arrow (U+2192) shows
+# up in store markdown.
+_EM_DASH = "—"
+_ARROW = "→"
 
 
 @pytest.fixture()
@@ -78,3 +90,96 @@ def test_snapshot_capture_survives_non_utf8(poisoned_store):
     # sync regenerates AGENTS.md off a snapshot; capture reads every md file.
     version = capture_snapshot(poisoned_store, trigger="test")
     assert version >= 1
+
+
+# --- AGENTS.md Manual section: parse must tolerate a raw non-UTF-8 byte ---
+
+
+def test_parse_preserved_sections_survives_non_utf8_manual(tmp_path: Path):
+    # The # Manual section is user-editable, so a legacy byte pasted in must not
+    # crash the parse that sync runs on every regeneration.
+    agents_md = tmp_path / "AGENTS.md"
+    agents_md.write_bytes(b"# AGENTS\n\n# Manual\n\nNote: caf\xe9 shipped\n")
+
+    preserved = parse_preserved_sections(agents_md)
+
+    assert preserved.manual is not None
+    assert "Note: caf" in preserved.manual
+    assert "shipped" in preserved.manual
+
+
+def test_regenerate_survives_poisoned_existing_agents_md(tmp_path: Path):
+    # Full sync path: a poisoned # Manual section in an existing AGENTS.md must
+    # not crash regeneration, and the manual text must survive the round-trip.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    store = register_project("myproj", [repo])
+    scaffold_project_store("myproj", store)
+
+    agents_md = repo / "AGENTS.md"
+    agents_md.write_bytes(b"# AGENTS.md\n\nOld auto content\n\n# Manual\n\nKeep caf\xe9 note\n")
+
+    updated = regenerate_agents_md_for_project("myproj", store)
+
+    assert repo in updated
+    regenerated = read_text_lenient(agents_md)
+    assert "Keep caf" in regenerated
+    assert "note" in regenerated
+    assert "Old auto content" not in regenerated
+
+
+# --- Content writes emit UTF-8 regardless of locale (raw-bytes assertions) ---
+
+
+def test_scaffold_writes_utf8_bytes(tmp_path: Path):
+    store = tmp_path / "projects" / "myproj"
+    scaffold_project_store("myproj", store)
+
+    decision = sorted((store / constants.DECISIONS_DIR).glob("*.md"))[0]
+    raw = decision.read_bytes()
+    # The scaffold decision template carries the load-bearing em-dash.
+    assert _EM_DASH.encode("utf-8") in raw
+    assert raw == decision.read_text(encoding="utf-8").encode("utf-8")
+
+
+def test_agents_md_write_emits_utf8_bytes(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    store = register_project("myproj", [repo])
+    scaffold_project_store("myproj", store)
+
+    regenerate_agents_md_for_project("myproj", store)
+
+    agents_md = repo / "AGENTS.md"
+    raw = agents_md.read_bytes()
+    # The generated AGENTS.md header carries the load-bearing em-dash.
+    assert _EM_DASH.encode("utf-8") in raw
+    assert raw == agents_md.read_text(encoding="utf-8").encode("utf-8")
+
+
+def test_import_append_writes_utf8_bytes(tmp_path: Path):
+    # New-file branch and append branch both carry non-ASCII through to disk.
+    target = tmp_path / "stack.md"
+    _append_to_store_file(target, f"Chose Postgres {_ARROW} Redis cache layer")
+    raw_new = target.read_bytes()
+    assert _ARROW.encode("utf-8") in raw_new
+
+    _append_to_store_file(target, f"Added {_EM_DASH} background worker")
+    raw_appended = target.read_bytes()
+    assert _EM_DASH.encode("utf-8") in raw_appended
+    assert raw_appended == target.read_text(encoding="utf-8").encode("utf-8")
+
+
+def test_filesystem_store_write_emits_utf8_bytes(tmp_path: Path):
+    store_path = tmp_path / "projects" / "myproj"
+    store_path.mkdir(parents=True)
+    store = FilesystemStore(store_path)
+
+    content = f"# State\n\nMigrated auth {_ARROW} OAuth, dropped sessions {_EM_DASH} legacy\n"
+    store.write_file(constants.STATE_CURRENT_FILENAME, content)
+
+    target = store_path / constants.STATE_CURRENT_FILENAME
+    raw = target.read_bytes()
+    assert _ARROW.encode("utf-8") in raw
+    assert _EM_DASH.encode("utf-8") in raw
+    assert raw == content.encode("utf-8")


### PR DESCRIPTION
## Why

Content file writes used bare `Path.write_text(...)` and two content reads used bare
`read_text()`, so they relied on the platform default encoding (`locale.getpreferredencoding`).
Template content carries em-dashes (U+2014) and a U+2192 arrow, so on any non-UTF-8 locale —
Windows CJK code pages, POSIX `C`/latin-1 — the writes raise `UnicodeEncodeError` and the reads
raise `UnicodeDecodeError`, crashing `nauro init`, `nauro sync`, `nauro note`, `nauro import`,
and the MCP write tools. The `AGENTS.md` `# Manual`-section read is a confirmed `nauro sync`
crash when a user pastes a non-UTF-8 byte into that editable region. The store read surface
already standardized on UTF-8 via `read_text_lenient`; the writers and these reads had drifted
off it.

## Approach

Pin `encoding="utf-8"` at each content write site, so correctness is local to the call and does
not depend on how the CLI was launched (rather than relying on a process-global like `PYTHONUTF8`).
For the two reads that touch user-editable content — the `AGENTS.md` Manual section and the legacy
`CLAUDE.md` strip block — route through the existing `read_text_lenient` helper instead of a strict
UTF-8 read: a strict decode would still crash on a stray legacy byte, whereas the lenient helper
keeps the command working on a mostly-valid file.

The control-plane JSON writers (registry, config, repo config, snapshots) all funnel through one
`atomic_write_text` primitive, so pinning both of its branches covers every JSON writer at once.
JSON is ASCII today via `ensure_ascii=True`, so that part is a no-op for current data — it removes
the latent locale dependency without touching the JSON round-trip reads, which close as soon as
the writers are pinned.

## What changed

- Content writes pinned to UTF-8: store scaffolds, the demo project, `AGENTS.md` regeneration, the
  import-append path, the `FilesystemStore` protocol write (which backs `propose_decision` /
  `update_state` / `flag_question` and all decision/state writes), and the setup `CLAUDE.md`
  strip-block write.
- Two user-editable content reads routed through `read_text_lenient`: the `AGENTS.md` Manual parse
  (the verified `sync` crash) and the setup `CLAUDE.md` read.
- The user-supplied `--rejected @file.json` read pinned to UTF-8 (JSON is UTF-8 by spec, and that
  text flows into a decision file).
- Both branches of the `atomic_write_text` primitive pinned to UTF-8.

## What to review

- The `AGENTS.md` Manual read is the one real behavior change — confirm the lenient helper (not a
  strict UTF-8 read) is right for user-editable content.
- The JSON control-plane reads left unpinned — confirm the ASCII-via-`ensure_ascii` round-trip
  reasoning holds.

## What's deferred

Nothing reachable. The JSON writers are pinned at the shared primitive; the remaining bare JSON
reads are intentionally left as round-trip-safe.

## Test plan

Extended the non-UTF-8 read test module with 8 tests: the `AGENTS.md` Manual parse and a full
regeneration survive a raw non-UTF-8 byte (manual text preserved), plus raw-bytes assertions that
the scaffold, `AGENTS.md`, import-append, and `FilesystemStore` writes emit UTF-8 regardless of
locale, and a UTF-8 `--rejected @file.json` round-trip. Verified under an actual `LC_ALL=C` ASCII
locale that the old bare write crashes on U+2192 while the pinned write succeeds. nauro 1374 passed
(10 skipped); nauro-core 754 passed; `ruff check` and `ruff format --check` clean.
