### PR TITLE
Remove internal tracking IDs from public source/tests; align package README positioning

### DIFF
--- a/packages/nauro-core/tests/operations/test_check_decision.py
+++ b/packages/nauro-core/tests/operations/test_check_decision.py
@@ -78,7 +78,7 @@ def test_unrelated_proposal_returns_no_related_decisions() -> None:
 
 
 def test_related_decision_canonical_id_and_status_enrichment() -> None:
-    """Hits expose D141 canonical fields populated from the parsed decision."""
+    """Hits expose canonical id, status, and date fields from the parsed decision."""
     store = _store_with(
         _seed_decision(
             42,

--- a/packages/nauro/README.md
+++ b/packages/nauro/README.md
@@ -1,8 +1,8 @@
 # Nauro
 
-The decision system for teams and agents.
+A decision system for agentic engineering.
 
-Catch the moment an agent re-proposes something your team already ruled out. Your team's decisions, including what you chose and what you ruled out, travel with every connected agent. When an agent proposes an approach, Nauro surfaces the past decisions related to it, so the agent sees the prior reasoning before it writes code. The check is advisory: it never blocks, and you approve anything that gets recorded. Works with Claude, Perplexity, ChatGPT, Cursor, and any MCP client.
+Catch the moment an agent re-proposes something you already ruled out. Your project's decisions, including what you chose and what you ruled out, travel with every connected agent. When an agent proposes an approach, Nauro surfaces the past decisions related to it, so the agent sees the prior reasoning before it writes code. The check is advisory: it never blocks, and you approve anything that gets recorded. Works with Claude, Perplexity, ChatGPT, Cursor, and any MCP client.
 
 ## Install
 

--- a/packages/nauro/src/nauro/cli/commands/adopt.py
+++ b/packages/nauro/src/nauro/cli/commands/adopt.py
@@ -261,8 +261,8 @@ def adopt(
         # skills, route to the materialize step for the existing adoption rather
         # than dead-ending — those flags are otherwise unreachable on `adopt`
         # once a repo is adopted, and `adopt` is the command users reach for
-        # first. Registration and config.json are left untouched, so D128's
-        # "every adoption writes config.json" invariant is unaffected.
+        # first. Registration and config.json are left untouched, so the
+        # invariant that every adoption writes config.json is unaffected.
         if with_subagents or with_skills or force_overwrite:
             _install_into_adopted_repo(
                 repo_root,

--- a/packages/nauro/src/nauro/cli/commands/setup.py
+++ b/packages/nauro/src/nauro/cli/commands/setup.py
@@ -597,7 +597,7 @@ def materialize_skills_cursor_for_repo(
 # Subagents are rendered from canonical bodies in nauro.agents and written into
 # the user's surface directories. On Claude Code, that's ``~/.claude/agents/``.
 # Unlike skills, agents are namespaced (``nauro-*``) and opt-in. The
-# ``nauro-`` namespace is bundle-owned (D177): on install, the current bundle
+# ``nauro-`` namespace is bundle-owned: on install, the current bundle
 # wins, so a published body change (e.g. dropping a removed MCP tool) actually
 # reaches users who installed an earlier version. A pre-existing
 # ``nauro-<name>.md`` that differs from the bundle is refreshed; its prior

--- a/packages/nauro/src/nauro/mcp/tools.py
+++ b/packages/nauro/src/nauro/mcp/tools.py
@@ -103,7 +103,7 @@ def _stamp_identity(func: Callable[..., Any]) -> Callable[..., Any]:
 
     Stacks under ``@mcp_tool`` so every return path — success, rejection, and
     store-missing error — carries the resolved project name + id alongside the
-    ``store`` field (D061's store indicator, extended to project identity).
+    ``store`` field (the local-store indicator, extended to also carry project identity).
     Local surface only; the remote mcp-server envelope is unchanged.
     """
 

--- a/packages/nauro/tests/cross_surface/test_check_decision_cross_surface.py
+++ b/packages/nauro/tests/cross_surface/test_check_decision_cross_surface.py
@@ -5,7 +5,8 @@ three local adapters against the same ``FilesystemStore``. This file goes
 one layer deeper: the same kernel call against ``FilesystemStore`` and
 ``mcp_server.store.cloud_store.CloudStore`` must produce the same
 :class:`CheckDecisionResult` for the same fixed inputs. That is the
-no-drift-by-construction guarantee D170 + D174 commit to.
+no-drift-by-construction guarantee: both surfaces run the same operations
+kernel, so identical inputs must yield identical results.
 
 CloudStore lives in the private mcp-server repo and ships in the paired
 cross-repo cutover PR. When this test runs from inside the nauro

--- a/packages/nauro/tests/test_check_decision_parity.py
+++ b/packages/nauro/tests/test_check_decision_parity.py
@@ -85,7 +85,7 @@ def test_cli_stdio_tool_match_on_success_path(demo_repo):
     assert _stdio_rendered(pid) == RENDERERS["check_decision"](tool)
 
 
-def test_success_envelope_contains_d141_canonical_fields(demo_repo):
+def test_success_envelope_contains_canonical_fields(demo_repo):
     pid, store_path = demo_repo
     envelope = _tool_envelope(store_path)
     assert envelope["store"] == "local"
@@ -119,7 +119,7 @@ def test_rejection_envelope_matches_across_surfaces(demo_repo):
     # the same envelope every other surface returned.
     stdio_rendered = _stdio_rendered(pid, overlong)
     assert stdio_rendered == RENDERERS["check_decision"](tool)
-    # Locked rejection envelope shape (closes D141 for this operation).
+    # Locked rejection envelope shape for this operation.
     assert cli["store"] == "local"
     assert cli["related_decisions"] == []
     assert cli["assessment"] == ""


### PR DESCRIPTION
## Why

Two public-facing cleanups ahead of launch.

1. Three source comments — in `mcp/tools.py`, `cli/commands/adopt.py`, `cli/commands/setup.py` —
   plus three public test docstrings/comments cited internal decision identifiers that mean nothing
   to outside readers and expose internal process. Each already states its rationale inline, so the
   tag is pure noise.
2. The PyPI-facing package README still led with a "teams and agents" framing, while the root README
   had already been repositioned to solo agentic engineering. A reader hitting PyPI and GitHub
   back-to-back saw two different one-liners for the same product.

## Approach

Drop each internal-identifier parenthetical and keep the surrounding sentence intact. For the README,
mirror the root README's existing voice rather than invent new copy, so the package README is a
faithful subset of the canonical positioning. Comments, test docstrings, and markdown only — no
behavior change.

## What changed

- Removed internal-identifier citations from three source comments and three public test
  docstrings/comments, preserving the inline rationale in each.
- Realigned the package README: the headline tagline and the lead paragraph move from "your team's
  decisions" to "your project's decisions" / solo framing.

## What to review

The README lead paragraph is the only judgement call — confirm the rewritten lines read as a clean
subset of the root README's positioning. The comment and docstring edits are mechanical.

## What's deferred

Out of scope by design: the redundant "Why Nauro?" prose lower in the package README, and the
legitimate decision-id *format examples* (the demo-envelope `decision-004` and the nauro-core
docstring syntax samples) — those are illustrative strings, not internal references.

## Test plan

No behavior touched. nauro 1368 passed (10 skipped); nauro-core 754 passed; `ruff check` and
`ruff format --check` clean. Verified `grep -rnE '\bD[0-9]{2,4}\b' packages/nauro/src/` returns
nothing, no `D###` residue remains in the public test tree, and `grep -niE 'team' packages/nauro/README.md`
is empty.
