### PR TITLE
Release: nauro 0.12.5 + nauro-core 0.13.8

### DIFF
--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro-core"
-version = "0.13.7"
+version = "0.13.8"
 description = "Shared pure-Python logic for Nauro: parsing, validation, context assembly, constants."
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro"
-version = "0.12.4"
+version = "0.12.5"
 description = "Local CLI + MCP server: set your project's doctrine once, every connected AI agent inherits it."
 readme = "README.md"
 license = "Apache-2.0"
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "nauro-core>=0.13.7,<0.14",
+    "nauro-core>=0.13.8,<0.14",
     "typer>=0.9",
     "httpx>=0.24",
     "mcp>=1.0",


### PR DESCRIPTION
## Why

Both packages have fallen behind `main`: 18 PRs have merged since the `nauro` 0.12.4 / `nauro-core` 0.13.7 tags, so every fix below — crash hardening, import robustness, onboarding correctness — is stranded in source and absent from PyPI. This release cuts the tags that ship them.

`nauro-core` needs a companion release, not just `nauro`. Its importable source changed in this window: the decision fence-parser and the `decision_type` schema (the canonical type tuple now lives in `decision_model`). Releasing `nauro` against an unchanged `nauro-core` would publish a CLI that imports the old, buggy core. So both versions move together and `nauro`'s dependency floor is raised to pin the new core.

## Approach

Single combined release PR — the established pattern for this monorepo — bumping both packages at once: `nauro` 0.12.4 → 0.12.5, `nauro-core` 0.13.7 → 0.13.8, plus the `nauro-core>=0.13.8,<0.14` floor in `nauro`'s `pyproject.toml`.

Releasing `nauro` alone was considered and rejected: because `nauro-core`'s importable source changed (fence-parse and schema fixes), a `nauro`-only release would resolve against the stale published core and ship the same defects it claims to fix. The floor bump guarantees the two are installed as a matched pair. Both are **patch** bumps — the batch is fixes, hardening, and minor surfacing, with no new command, MCP tool, or public surface; `nauro-core`'s public API is unchanged (`DECISION_TYPES` is preserved as an enum-derived alias).

## What changed

The diff in this PR is only the release plumbing — three lines: the two `version` fields and the `nauro-core` dependency floor. Everything below is the **shipped behavior** already merged since the tags, grouped by concern.

**Correctness and crash hardening.** Closed a cluster of unguarded failure paths that turned recoverable conditions into tracebacks or silent data loss: `propose_decision` crashed on an advertised-but-invalid `decision_type`, and decision parsing silently dropped Rejected Alternatives when nested code fences desynced the tracker (#216); corrupt or truncated snapshots crashed `log`/`sync`/`diff` and could wedge a store (#209); a corrupt `config.json` was overwritten, destroying recoverable auth tokens, now quarantined to a sidecar (#211); non-UTF-8 bytes in store reads (#205) and non-UTF-8 locales on content I/O (#217) crashed the read/write surface, now decoded leniently and pinned to UTF-8 at every write site; filesystem errors render as clean messages instead of tracebacks (#210); `setup` no longer crashes on a non-object MCP config (#212).

**Onboarding and import robustness.** `nauro init` with no name derived the reserved `demo-project` name; it now derives from the directory (#214). Same-name cross-repo forks were minted silently — `init` now surfaces the collision and documents `--add-repo` for the one-project-many-repos recipe (#207). The advisory hook now fires on small stores (corpus-size-aware BM25 floor) and resolves an absolute console-script path so it works off-PATH (#208). ADR/Memory-Bank import tolerates non-UTF-8 sources and reports honest counts instead of a silent zero-import success (#206).

**Surfacing.** Duplicate-name projects are now visible in `nauro projects` and `nauro status` after the fact (#215). Nested credentials are masked in `nauro config` output (#204). The doubled "Current State" heading in L0 / `AGENTS.md` is fixed (#213).

**Single-sourcing into core.** The `decision_type` enum and fence-parse fixes (#216) consolidate the canonical type tuple in `nauro_core.decision_model` and harden the parser against marker desync — the importable changes that necessitate the companion `nauro-core` release.

**Docs and CI.** Install docs lead with `uv tool install` (pipx/pip as fallback) (#201); README positioning updated for agentic engineering, with the package README realigned to match (#203, #218); internal tracking identifiers removed from public source and tests (#218); CI now tests 3.13 + 3.14 and declares the 3.14 classifier (#202).

## What to review

- The three changed lines: both `version` fields and the `nauro-core>=0.13.8,<0.14` floor. Confirm the floor's lower bound equals the `nauro-core` version being cut, so a fresh install can't resolve the stale core.
- That the two versions move in lockstep and the `<0.14` ceiling still admits the new core.
- Nothing else should appear in this diff — any non-version change here is a mistake.

## What's deferred

- Name normalization (case/whitespace/homoglyph) for duplicate-project detection remains a policy decision, out of scope.
- Broader Memory-Bank format parsing and ADR supersede/rejected-alternative extraction stay deferred behind the honest-counts warning.
- Field-tuning the advisory hook's corpus-scaling curve, surfacing the hook in `nauro adopt`, and the per-turn CLI cold-start.
- Broader snapshot integrity (checksums) beyond skip-with-warning.

## Test plan

No new tests in this PR — it is version plumbing only; the shipped behavior arrived with its own coverage, all merged green. Verified the bumped tree the CI way before tagging:

```
uv sync --package nauro-core --all-extras && uv run --package nauro-core pytest packages/nauro-core/tests/   → 761 passed
uv sync --package nauro       --all-extras && uv run --package nauro       pytest packages/nauro/tests/ \
    --ignore=packages/nauro/tests/cross_surface                                                            → 1376 passed
uvx ruff@0.15.8 check packages/ && uvx ruff@0.15.8 format --check packages/                                 → clean
uv run --directory packages/nauro-core --all-extras lint-imports                                            → 2 kept, 0 broken
```

Both wheels build with the correct versions, and the built `nauro` 0.12.5 wheel's metadata pins `nauro-core<0.14,>=0.13.8`. PyPI publish happens on the `nauro-core-v0.13.8` / `nauro-v0.12.5` tag push after merge.
