### PR TITLE
Scrub internal task/phase identifiers from telemetry test docstrings

### DIFF
--- a/packages/nauro/tests/test_cli_command_invoked.py
+++ b/packages/nauro/tests/test_cli_command_invoked.py
@@ -1,4 +1,4 @@
-"""Tests for cli.command_invoked telemetry instrumentation (T1.4)."""
+"""Tests for cli.command_invoked telemetry instrumentation."""
 
 from __future__ import annotations
 

--- a/packages/nauro/tests/test_identity_lifecycle.py
+++ b/packages/nauro/tests/test_identity_lifecycle.py
@@ -204,14 +204,14 @@ def test_logout_rotates_anonymous_id_and_preserves_consent(nauro_home):
     assert cfg["telemetry"]["consented_at"] == "2026-04-30T00:00:00Z"
 
 
-# ── 5. No posthog.reset() — C1 correction ───────────────────────────────────
+# ── 5. No posthog.reset() ────────────────────────────────────────────────────
 
 
 def test_posthog_python_sdk_has_no_reset_attr():
     """Sanity guard against a future regression that re-adds posthog.reset().
 
-    C1 correction (Phase 1c review): posthog.reset() is a JS-SDK API. The
-    Python SDK 7.x has no such method. Calling it would raise AttributeError.
+    posthog.reset() is a JS-SDK API. The Python SDK 7.x has no such method;
+    calling it would raise AttributeError.
     Identity reset is application-side rotation only.
     """
     import posthog

--- a/packages/nauro/tests/test_mcp_tool_called.py
+++ b/packages/nauro/tests/test_mcp_tool_called.py
@@ -1,4 +1,4 @@
-"""Phase 1c T1.5 — mcp.tool_called decorator tests.
+"""Tests for the mcp.tool_called telemetry decorator.
 
 Covers:
 1. All 10 canonical MCP tools emit one mcp.tool_called event per call with the

--- a/packages/nauro/tests/test_project_created_event.py
+++ b/packages/nauro/tests/test_project_created_event.py
@@ -1,4 +1,4 @@
-"""Tests for project.created funnel-anchor event (T1.6)."""
+"""Tests for project.created funnel-anchor event."""
 
 from __future__ import annotations
 

--- a/packages/nauro/tests/test_telemetry_module.py
+++ b/packages/nauro/tests/test_telemetry_module.py
@@ -249,5 +249,5 @@ def test_should_emit_false_under_shipped_placeholder(nauro_home, monkeypatch):
     assert _should_emit() is False
 
 
-# Phase 1c — identify_login / identify_logout are implemented now.
+# identify_login / identify_logout are implemented now.
 # Comprehensive coverage lives in tests/test_identity_lifecycle.py.

--- a/packages/nauro/tests/test_telemetry_subcommand.py
+++ b/packages/nauro/tests/test_telemetry_subcommand.py
@@ -1,4 +1,4 @@
-"""Tests for nauro telemetry subcommand (T1.9)."""
+"""Tests for nauro telemetry subcommand."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Why

A prior pass removed internal tracking identifiers from public source and tests, but it targeted one ID format and missed another: several telemetry test files still carry internal task/phase labels (`T1.4`/`T1.5`/`T1.6`/`T1.9`, `Phase 1c`, `C1 correction`) in their docstrings, comments, and section headers. These are opaque to anyone outside the team and have no place in a public repo. No secret value, but the cleanup should be complete.

## Approach

Docstring/comment-only edits — replace the internal labels with plain descriptive text, preserving the actual explanatory content (what each test covers, why `posthog.reset()` is guarded against, etc.). No test logic, names, or assertions change.

## What changed

- `test_mcp_tool_called.py`, `test_cli_command_invoked.py`, `test_telemetry_subcommand.py`, `test_project_created_event.py`: dropped `T1.x` / `Phase 1c` from the module docstrings.
- `test_identity_lifecycle.py`, `test_telemetry_module.py`: generalized two `Phase 1c` / `C1 correction` comments.

## What to review

Nothing behavioral — confirm the diff is wording-only and the remaining text still reads clearly. A repo-wide grep for `T1.[0-9]` / `Phase 1[a-c]` / `C1 correction` under `packages/` now returns nothing.

## Test plan

The six affected test files pass (`pytest … -q` → 57 passed). Ruff check + format clean on the touched files.
