### PR TITLE
Fix MCP no-project guidance, L2 full dump, and import/CLI polish

### DIFF
--- a/packages/nauro-core/src/nauro_core/context.py
+++ b/packages/nauro-core/src/nauro_core/context.py
@@ -214,15 +214,25 @@ def build_l1(files: dict[str, str], decisions: list[Decision]) -> str:
 
 
 def build_l2(files: dict[str, str], decisions: list[Decision]) -> str:
-    """Build L2 payload (full content).
+    """Build L2 payload (the full dump).
 
-    Includes all decision content plus all files provided.
+    Canonical section order mirrors L1: project → state (with history) →
+    stack → questions → all decisions. L2 is a superset of L1: it carries
+    project.md and stack.md verbatim (the loader fetches both for level 2),
+    the appended state history that L1 omits, and every decision including
+    superseded ones rather than L1's recent-active cap. Omitting project and
+    stack here previously made the "full dump" both incomplete and smaller
+    than L1.
 
     Args:
         files: Dict of store-relative keys to file contents.
         decisions: List of parsed decision dicts.
     """
     sections: list[str] = []
+
+    project = files.get("project.md", "")
+    if project.strip():
+        sections.append(project.strip())
 
     raw_state = _resolve_state(files)
     history = files.get("state_history.md")
@@ -233,12 +243,16 @@ def build_l2(files: dict[str, str], decisions: list[Decision]) -> str:
         if assembled and assembled.strip():
             sections.append(assembled.strip())
 
-    if decisions:
-        parts = [d.content.strip() for d in decisions]
-        sections.append("## All Decisions\n\n" + "\n\n---\n\n".join(parts))
+    stack = files.get("stack.md", "")
+    if stack.strip():
+        sections.append(stack.strip())
 
     questions_content = files.get("questions.md", "")
     if questions_content.strip():
         sections.append(questions_content.strip())
+
+    if decisions:
+        parts = [d.content.strip() for d in decisions]
+        sections.append("## All Decisions\n\n" + "\n\n---\n\n".join(parts))
 
     return "\n\n".join(sections)

--- a/packages/nauro-core/src/nauro_core/renderers.py
+++ b/packages/nauro-core/src/nauro_core/renderers.py
@@ -67,6 +67,22 @@ def _error_block(error) -> str:
     return f"Error: {reason}"
 
 
+def _guidance(result: dict) -> str:
+    """Onboarding/empty-state guidance text carried by the envelope, if any.
+
+    Both surfaces attach a ``guidance`` string to empty-payload envelopes: the
+    remote MCP on an empty store, and the local stdio server on the
+    no-project / unresolved-project path (``{"status": "error",
+    "guidance": ...}`` — note that envelope has no ``error`` key, so the
+    error branch above does not fire). Every read renderer surfaces this before
+    its own empty-state default, so a read tool called at session start in a
+    repo that has not run ``nauro init`` returns the actionable welcome text
+    instead of an empty string (``get_context``/``get_decision``) or a
+    misleading "no results" line (``check_decision``/``search_decisions``).
+    """
+    return (result.get("guidance") or "").strip()
+
+
 def render_check_decision(result: dict) -> str:
     """Render the conflict-check result for chat-UI consumption.
 
@@ -82,8 +98,9 @@ def render_check_decision(result: dict) -> str:
     assessment = result.get("assessment", "")
 
     if not related:
-        # NO_DECISIONS_TO_CHECK / "No related decisions found." cases.
-        return assessment.strip() or "No related decisions found."
+        # No-project guidance first, then NO_DECISIONS_TO_CHECK / "No related
+        # decisions found." cases.
+        return _guidance(result) or assessment.strip() or "No related decisions found."
 
     lines: list[str] = []
     count = len(related)
@@ -149,6 +166,10 @@ def render_get_decision(result: dict, mode: str = "full") -> str:
         return _error_block(result["error"])
 
     content = result.get("content", "") or ""
+    if not content:
+        guidance = _guidance(result)
+        if guidance:
+            return guidance
     if mode == "header":
         return content.rstrip()
 
@@ -186,7 +207,7 @@ def render_search_decisions(result: dict) -> str:
     truncated = bool(result.get("truncated"))
 
     if not hits:
-        return f'No matches for "{query}".'
+        return _guidance(result) or f'No matches for "{query}".'
 
     lines: list[str] = []
     header = f'Found {total} match{"" if total == 1 else "es"} for "{query}":'
@@ -225,8 +246,7 @@ def render_list_decisions(result: dict) -> str:
     truncated = bool(result.get("truncated"))
 
     if not decisions:
-        guidance = (result.get("guidance") or "").strip()
-        return guidance or "No decisions recorded yet."
+        return _guidance(result) or "No decisions recorded yet."
 
     lines: list[str] = []
     lines.append(f"Decisions ({total} total):")
@@ -258,7 +278,7 @@ def render_get_context(result: dict) -> str:
     if "error" in result:
         return _error_block(result["error"])
     body = result.get("context") or result.get("content") or ""
-    return body.rstrip()
+    return body.rstrip() or _guidance(result)
 
 
 def render_list_projects(result: dict) -> str:

--- a/packages/nauro-core/tests/test_context.py
+++ b/packages/nauro-core/tests/test_context.py
@@ -249,6 +249,42 @@ class TestBuildL2:
         result = build_l2(FULL_FILES, [])
         assert "# State" in result
 
+    def test_project_included(self):
+        # The full dump must carry project.md; omitting it previously made L2
+        # both incomplete and smaller than L1.
+        result = build_l2(FULL_FILES, DECISIONS)
+        assert "# MyProject" in result
+        assert "build something great" in result
+
+    def test_stack_included(self):
+        result = build_l2(FULL_FILES, DECISIONS)
+        assert "# Stack" in result
+        assert "Chose over Go for ecosystem" in result
+
+    def test_canonical_ordering(self):
+        result = build_l2(FULL_FILES, DECISIONS)
+        project_pos = result.find("# MyProject")
+        state_pos = result.find("# State")
+        stack_pos = result.find("# Stack")
+        questions_pos = result.find("# Open Questions")
+        decisions_pos = result.find("## All Decisions")
+        assert project_pos < state_pos < stack_pos < questions_pos < decisions_pos
+
+    def test_superset_of_l1(self):
+        # Every project/stack/questions string L1 surfaces must also appear in
+        # the full dump, and L2 must additionally carry superseded decisions.
+        l1 = build_l1(FULL_FILES, DECISIONS)
+        l2 = build_l2(FULL_FILES, DECISIONS)
+        for marker in ("# MyProject", "Chose over Go for ecosystem", "Sixth question?"):
+            assert marker in l1 and marker in l2
+        assert "Old choice" in l2 and "Old choice" not in l1
+
+    def test_missing_project_md(self):
+        files = {k: v for k, v in FULL_FILES.items() if k != "project.md"}
+        result = build_l2(files, DECISIONS)
+        assert "# MyProject" not in result
+        assert "## All Decisions" in result
+
 
 def _legacy_id(target_date) -> str:
     """Render a legacy ``[YYYY-MM-DD HH:MM UTC]`` id for ``target_date``."""

--- a/packages/nauro-core/tests/test_renderers.py
+++ b/packages/nauro-core/tests/test_renderers.py
@@ -547,3 +547,56 @@ class TestRendererPurity:
         snapshot = json.dumps(result, sort_keys=True)
         render_check_decision(result)
         assert json.dumps(result, sort_keys=True) == snapshot
+
+
+class TestNoProjectGuidance:
+    """The local stdio server emits ``{"status": "error", "guidance": ...}``
+    when no project resolves (e.g. a read tool called at session start in a
+    repo that has not run ``nauro init``). That envelope has no ``error`` key
+    and no payload key, so every read renderer must surface the guidance text
+    rather than returning an empty string or a misleading "no results" line.
+    """
+
+    GUIDANCE = (
+        "Welcome to Nauro! No project store found.\n\n"
+        "To get started:\n1. Run: nauro init <project-name>\n"
+    )
+
+    def _envelope(self) -> dict:
+        return {"store": "local", "status": "error", "guidance": self.GUIDANCE}
+
+    def test_get_context_surfaces_guidance(self):
+        # The session-start tool must not return an empty content block.
+        text = render_get_context(self._envelope())
+        assert "Welcome to Nauro" in text
+        assert text != ""
+
+    def test_get_decision_surfaces_guidance(self):
+        text = render_get_decision(self._envelope())
+        assert "Welcome to Nauro" in text
+
+    def test_check_decision_surfaces_guidance_not_false_clear(self):
+        # Must NOT report a false "No related decisions found." — that would
+        # tell the agent the history is clear when no store was read.
+        text = render_check_decision(self._envelope())
+        assert "Welcome to Nauro" in text
+        assert "No related decisions found" not in text
+
+    def test_search_decisions_surfaces_guidance_not_false_empty(self):
+        text = render_search_decisions(self._envelope())
+        assert "Welcome to Nauro" in text
+        assert "No matches" not in text
+
+    def test_list_decisions_still_surfaces_guidance(self):
+        text = render_list_decisions(self._envelope())
+        assert "Welcome to Nauro" in text
+
+    def test_remote_empty_store_guidance_unaffected(self):
+        # The remote empty-store path (decisions empty + guidance, no
+        # status:error) must keep flowing through unchanged.
+        result = {
+            "store": "remote",
+            "decisions": [],
+            "guidance": "No decisions recorded yet for this project.",
+        }
+        assert "No decisions recorded yet" in render_list_decisions(result)

--- a/packages/nauro/README.md
+++ b/packages/nauro/README.md
@@ -31,7 +31,7 @@ You'll see a JSON envelope with the related decisions and a deterministic assess
     {
       "id": "decision-004",
       "title": "SSE over WebSocket for live task updates",
-      "score": 5.0,
+      "score": 5.015,
       "status": "active",
       "date": "2026-03-15",
       "rationale_preview": "Server-Sent Events (SSE) for pushing live task updates..."

--- a/packages/nauro/src/nauro/cli/commands/import_cmd.py
+++ b/packages/nauro/src/nauro/cli/commands/import_cmd.py
@@ -197,8 +197,13 @@ def _parse_and_import_decisions(content: str, store_path: Path) -> int:
     Returns:
         Number of decisions imported.
     """
-    # Split on ## Decision: headers
-    pattern = r"^## Decision:\s*(.+)$"
+    # Split on ## Decision: headers. The title must begin with a non-whitespace
+    # char (\S): this stops an empty heading ("## Decision:" with no title, with
+    # or without trailing spaces) from either swallowing the newline to promote
+    # the next body line to the title or capturing a lone space as a 1-char
+    # title. Such a malformed heading is simply not treated as a decision
+    # boundary.
+    pattern = r"^## Decision:[ \t]*(\S.*)$"
     blocks = re.split(pattern, content, flags=re.MULTILINE)
 
     # blocks[0] is preamble (before first ## Decision:), then alternating title/body

--- a/packages/nauro/src/nauro/cli/utils.py
+++ b/packages/nauro/src/nauro/cli/utils.py
@@ -102,8 +102,11 @@ def resolve_target_project(project_flag: str | None) -> tuple[str, Path]:
         # 1a — v2 by name (canonical)
         matches = find_projects_by_name_v2(project_flag)
         if len(matches) > 1:
+            # Show the full ULID, not a prefix: ULIDs minted seconds apart share
+            # a long time-based prefix, so a short slice can render identically
+            # for every match and is not accepted as a --project value anyway.
             ids = ", ".join(
-                f"{name} ({pid[:8]})"
+                f"{name} ({pid})"
                 for pid, _entry in matches[:5]
                 for name in [_entry.get("name", "?")]
             )

--- a/packages/nauro/tests/test_import.py
+++ b/packages/nauro/tests/test_import.py
@@ -267,6 +267,41 @@ def test_import_progress_with_empty_items(store: Path, tmp_path: Path):
     assert counts["progress_items"] == 1
 
 
+def test_import_empty_decision_heading_not_promoted_to_title(store: Path, tmp_path: Path):
+    """A malformed empty '## Decision:' heading must not consume the following
+    body line as its title or fabricate a phantom decision; only the real,
+    titled decision is imported and the count stays honest."""
+    ctx = tmp_path / ".context_empty_heading"
+    ctx.mkdir()
+    (ctx / "projectBrief.md").write_text("# Brief\n\nSomething.\n")
+    (ctx / "decisionLog.md").write_text(
+        "# Decision Log\n\n"
+        "## Decision: Use Redis cache\n"
+        "Fast in-memory store.\n\n"
+        "## Decision: \n"
+        "This line must not become a decision title.\n"
+    )
+
+    counts = _import_memory_bank(ctx, store)
+
+    assert counts["decisions"] == 1
+    decisions = sorted((store / "decisions").glob("*.md"))
+    assert len(decisions) == 2  # scaffold 001 + the one real import
+
+    # Collect every decision's title line ("# NNN — ..."); decision files lead
+    # with YAML frontmatter, so the title is not the first line.
+    title_lines = [
+        ln
+        for d in decisions
+        for ln in d.read_text().splitlines()
+        if ln.startswith("# ") and ln[2:3].isdigit()
+    ]
+    # The real decision keeps its title; the orphaned body line is never
+    # promoted to any decision's title (it stays in the prior decision's body).
+    assert any("Use Redis cache" in ln for ln in title_lines)
+    assert not any("must not become a decision title" in ln for ln in title_lines)
+
+
 # --- v2 split-state composition (single update_state call) ---
 
 

--- a/packages/nauro/tests/test_resolution_v2.py
+++ b/packages/nauro/tests/test_resolution_v2.py
@@ -126,6 +126,25 @@ def test_explicit_project_flag_overrides_repo_config(tmp_path, monkeypatch):
     assert store == tmp_path / "projects" / other_pid
 
 
+def test_duplicate_name_disambiguation_shows_full_ulid(tmp_path, monkeypatch, capsys):
+    """Two projects sharing a name must disambiguate by FULL ULID. ULIDs minted
+    seconds apart share a long prefix, so a short slice can render identically
+    for both matches and is not accepted as a ``--project`` value anyway."""
+    pid_a, _ = registry.register_project_v2("dup", [tmp_path / "a"], mode="local")
+    pid_b, _ = registry.register_project_v2("dup", [tmp_path / "b"], mode="local")
+    assert pid_a != pid_b
+
+    with pytest.raises(typer.Exit) as exc:
+        resolve_target_project("dup")
+    assert exc.value.exit_code == 1
+
+    err = capsys.readouterr().err
+    assert "Multiple projects named 'dup'" in err
+    # Both full ULIDs (the only values the resolver accepts) appear verbatim.
+    assert pid_a in err
+    assert pid_b in err
+
+
 # ── stdio _resolve_store mirrors the same precedence ─────────────────────────
 
 


### PR DESCRIPTION
## Why

A regression sweep found the codebase otherwise solid, but five real defects sit on core read/onboarding surfaces. The two MCP ones matter most: an agent calling a read tool at session start in a repo that has not run `nauro init` got an empty `get_context`, and `check_decision` falsely reported "No related decisions found." when no project store was read at all.

## Approach

The stdio server already emits a `{status: "error", guidance: …}` envelope on the no-project path, but only `render_list_decisions` honored the `guidance` key. Rather than special-case each renderer or change `isError` semantics (bigger blast radius), route all read renderers through one shared `_guidance` fallback — the established `list_decisions` pattern. For L2, mirror L1's canonical section order so the "full dump" is a true superset. The import and dup-name fixes are surgical; the README change is cosmetic alignment.

## What changed

- **`nauro_core/renderers.py`** — shared `_guidance` fallback so `get_context`, `get_decision`, `check_decision`, and `search_decisions` surface the no-project welcome text instead of an empty string or a misleading "no results" line.
- **`nauro_core/context.py`** — `build_l2` now includes `project.md` and `stack.md` (the loader already fetched both for level 2; the builder dropped them), so L2 is no longer smaller and less complete than L1.
- **`cli/commands/import_cmd.py`** — the `## Decision:` title regex now requires a non-whitespace first char, so an empty heading is not treated as a decision boundary.
- **`cli/utils.py`** — duplicate-name disambiguation prints the full ULID (a short prefix could render identically for both matches and is not a valid `--project` value).
- **`packages/nauro/README.md`** — demo score aligned to real output (`5.0` → `5.015`).
- Regression tests added across four test modules.

## What to review

- The renderer change is load-bearing: confirm the guidance fallback can't mask a genuine empty result on the happy path — it only fires when the payload is empty **and** a `guidance` key is present.
- The L2 reorder: confirm no consumer depended on the previous state → decisions → questions ordering.

## What's deferred

- The local `search_decisions` envelope deliberately omits `query`/`total_matches` (pinned by a parity test), so the empty-query echo and truncation hint are a separate, intentional contract — not touched here.
- The remote MCP `decision_type` enum advertises a stale extra value; that lives in the separate mcp-server repo. Worth confirming it serves `nauro-core` 0.13.8.

## Test plan

- `ruff check` + `ruff format --check` + single-source guard + import-linter: clean.
- `nauro-core`: 772 passed (+11). `nauro`: 1378 passed (+2). `cross_surface`: skips by design.
- End-to-end JSON-RPC driver against `nauro serve` in an empty `NAURO_HOME` confirms the no-project read tools now return the welcome guidance; live CLI confirms L2 carries Stack + Goals.
