### PR TITLE
Release: nauro 0.12.6 + nauro-core 0.13.9

### DIFF
--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro-core"
-version = "0.13.8"
+version = "0.13.9"
 description = "Shared pure-Python logic for Nauro: parsing, validation, context assembly, constants."
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro"
-version = "0.12.5"
+version = "0.12.6"
 description = "Local CLI + MCP server: set your project's doctrine once, every connected AI agent inherits it."
 readme = "README.md"
 license = "Apache-2.0"
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "nauro-core>=0.13.8,<0.14",
+    "nauro-core>=0.13.9,<0.14",
     "typer>=0.9",
     "httpx>=0.24",
     "mcp>=1.0",


### PR DESCRIPTION
## Why

PR #221 landed five behavioral fixes after the 0.12.5/0.13.8 release tag without bumping versions, so they are stranded off PyPI. With the Show HN launch imminent, the MCP no-project guidance fix matters most: an agent calling a read tool in a repo that has not run `nauro init` currently gets nothing actionable, or a false "history is clear" signal, which is exactly the first-run path a new installer hits.

## What changed

Version bump only.

- `nauro` 0.12.5 -> 0.12.6
- `nauro-core` 0.13.8 -> 0.13.9
- CLI `nauro-core` floor -> 0.13.9, so a fresh install pulls the renderer and context fixes that live in core

## What ships (already merged via #221)

- MCP read renderers (`get_context`, `get_decision`, `check_decision`, `search_decisions`) surface the no-project guidance envelope instead of an empty or falsely-clear result on uninitialized repos
- L2 full dump now includes `project.md` and `stack.md`
- import no longer mis-parses an empty decision heading as a title
- duplicate-name disambiguation hint prints the full ULID
- README demo score corrected to match real output

## What to review

The `nauro-core` floor bump (`>=0.13.9`) is the line that matters: without it a fresh install could resolve the old core and miss the renderer fix.

## Test plan

ruff format + check clean locally. The per-fix regression tests shipped with #221 and are already on main. PyPI publish is tag-triggered after merge (`nauro-v0.12.6`, `nauro-core-v0.13.9`).
