### PR TITLE
Correct three README claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Nauro is a decision system for agentic engineering. It keeps your project's decisions, rationale, and rejected paths in plain markdown files, then surfaces the relevant ones before an AI agent plans or changes code.
 
-It works across Claude, Cursor, Codex, ChatGPT, Perplexity, and any MCP client. The result is persistent project judgment that travels with the work, not with a single tool or session.
+It works across Claude, Cursor, Codex, Perplexity, and any MCP client. The result is persistent project judgment that travels with the work, not with a single tool or session.
 
 [![PyPI](https://img.shields.io/pypi/v/nauro.svg)](https://pypi.org/project/nauro/) [![Python](https://img.shields.io/pypi/pyversions/nauro.svg)](https://pypi.org/project/nauro/) [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 
@@ -18,7 +18,7 @@ More at [nauro.ai](https://nauro.ai).
 
 Nauro stores your project's decisions as plain markdown files, each with the alternatives you ruled out and the reasoning behind them. When an agent proposes an approach, `check_decision` runs deterministic keyword retrieval (BM25) over those files and surfaces the related ones before the agent plans or writes code.
 
-No model judges your decisions. The check is advisory and never blocks a change. You approve every decision before it is recorded. The store is a folder you own; remove Nauro and the markdown stays.
+No model judges your decisions. The check is advisory and never blocks a change. A decision is recorded only by an explicit write call, and the approval gate lives in the conversation. The store is a folder you own; remove Nauro and the markdown stays.
 
 ## Install
 
@@ -38,7 +38,7 @@ nauro init --demo
 nauro check-decision "Add a WebSocket endpoint for live task updates"
 ```
 
-The demo store holds seven real decisions. One of them ruled out WebSocket in favor of SSE, and `check-decision` surfaces it as the top match before your agent can re-propose it:
+The demo store holds seven example decisions. One of them ruled out WebSocket in favor of SSE, and `check-decision` surfaces it as the top match before your agent can re-propose it:
 
 ```json
 {
@@ -105,7 +105,7 @@ Add `--with-subagents` on `nauro adopt` or `nauro setup` to install Nauro's bund
 - `@nauro-reviewer` before merging. Audits the diff for real bugs and for missing decision references.
 - `@nauro-tech-lead` to set or correct direction. Reads the decision log, audits PRs against doctrine, files decisions when direction is established.
 
-Chat surfaces (Claude.ai, ChatGPT, Perplexity): run `nauro adopt` from a terminal first, then point the chat agent at [`docs/adopt-prompt.md`](docs/adopt-prompt.md).
+Chat surfaces (Claude.ai, Perplexity): run `nauro adopt` from a terminal first, then point the chat agent at [`docs/adopt-prompt.md`](docs/adopt-prompt.md).
 
 ## Cross-surface sync (optional)
 

--- a/packages/nauro/README.md
+++ b/packages/nauro/README.md
@@ -2,7 +2,7 @@
 
 A decision system for agentic engineering.
 
-Catch the moment an agent re-proposes something you already ruled out. Your project's decisions, including what you chose and what you ruled out, travel with every connected agent. When an agent proposes an approach, Nauro surfaces the past decisions related to it, so the agent sees the prior reasoning before it writes code. The check is advisory: it never blocks, and you approve anything that gets recorded. Works with Claude, Perplexity, ChatGPT, Cursor, and any MCP client.
+Catch the moment an agent re-proposes something you already ruled out. Your project's decisions, including what you chose and what you ruled out, travel with every connected agent. When an agent proposes an approach, Nauro surfaces the past decisions related to it, so the agent sees the prior reasoning before it writes code. The check is advisory: it never blocks, and you approve anything that gets recorded. Works with Claude, Perplexity, Cursor, and any MCP client.
 
 ## Install
 


### PR DESCRIPTION
## Why

Three README claims drifted from what ships. The quickstart called the demo decisions "seven real decisions" when they are written examples. The supported-surfaces lists named ChatGPT, whose connector login does not currently work. And "You approve every decision before it is recorded" reads as an enforced step, when recording is a single write call whose approval happens in conversation.

## What changed

- `README.md`: "seven real decisions" is now "seven example decisions"; ChatGPT removed from the compatibility sentence and the chat-surfaces line; the write-gate sentence now says a decision is recorded only by an explicit write call, with the approval gate living in the conversation.
- `packages/nauro/README.md`: ChatGPT removed from the works-with sentence shown on PyPI.

## What's deferred

`docs/adopt-prompt.md` still names ChatGPT as a chat surface. It is part of the adopt skill contract and is handled separately.

## Test plan

Docs only. The full nauro suite passes on the branch and ruff is clean.
