### PR TITLE
Refuse repo roots whose .nauro/config.json is the global config

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/adopt.py
+++ b/packages/nauro/src/nauro/cli/commands/adopt.py
@@ -35,6 +35,7 @@ from nauro.cli.commands.setup import (
     _find_nauro_command,
     setup_all_surfaces,
 )
+from nauro.cli.utils import refuse_global_config_collision
 from nauro.constants import REGISTRY_SCHEMA_VERSION_V2, REPO_CONFIG_MODE_LOCAL
 from nauro.skills import load_adopt_body
 from nauro.store.registry import find_projects_by_name_v2, register_project_v2
@@ -242,6 +243,12 @@ def adopt(
     if not repo_root.is_dir():
         typer.echo(f"Error: {repo_root} is not a directory.", err=True)
         raise typer.Exit(code=1)
+
+    # Refused before the git and already-adopted checks: from the home
+    # directory the global config would otherwise read as an existing
+    # adoption, and the recovery hint there ("remove .nauro/config.json")
+    # would point at the user's auth and telemetry settings.
+    refuse_global_config_collision(repo_root)
 
     # ── git precondition ───────────────────────────────────────────────────
     # Refuse before any registration or config write so the /nauro-adopt

--- a/packages/nauro/src/nauro/cli/commands/attach.py
+++ b/packages/nauro/src/nauro/cli/commands/attach.py
@@ -16,6 +16,7 @@ from pathlib import Path
 import typer
 
 from nauro.cli.commands.auth import DEFAULT_API_URL
+from nauro.cli.utils import refuse_global_config_collision
 from nauro.constants import REPO_CONFIG_MODE_CLOUD
 from nauro.store.registry import (
     add_repo_v2,
@@ -38,6 +39,10 @@ def attach(
 ) -> None:
     """Attach the current repo to an existing cloud project."""
     repo_path = repo_path if repo_path is not None else Path.cwd()
+    # Refused before the membership call so the failure is local and
+    # immediate; the home directory's .nauro/config.json is the global
+    # config, not a repo config slot.
+    refuse_global_config_collision(repo_path)
     try:
         projects = list_projects()
     except CloudProjectError as exc:

--- a/packages/nauro/src/nauro/cli/commands/init.py
+++ b/packages/nauro/src/nauro/cli/commands/init.py
@@ -23,6 +23,7 @@ from pathlib import Path
 import typer
 
 from nauro.cli.commands.auth import DEFAULT_API_URL
+from nauro.cli.utils import refuse_global_config_collision
 from nauro.constants import (
     REGISTRY_SCHEMA_VERSION_V2,
     REPO_CONFIG_MODE_CLOUD,
@@ -292,6 +293,16 @@ def init(
             raise typer.Exit(code=1)
 
     repo_paths = add_repo_paths if add_repo_paths else [Path.cwd()]
+
+    # The home directory is never a valid repo root: its .nauro/config.json
+    # is the global config (auth tokens, telemetry consent). Refused for every
+    # target path before any registry or store mutation, and deliberately
+    # before the --force-aware overwrite checks below, which must not be able
+    # to bypass it. Previously `nauro init --demo` from $HOME hit the generic
+    # config-exists branch, whose "Re-run with --force" hint replaced the
+    # global config.
+    for rp in repo_paths:
+        refuse_global_config_collision(rp)
 
     # ── --add-repo against an existing project ──────────────────────────────
     if add_repo_paths:

--- a/packages/nauro/src/nauro/cli/utils.py
+++ b/packages/nauro/src/nauro/cli/utils.py
@@ -35,9 +35,37 @@ from nauro.store.registry import (
 )
 from nauro.store.repo_config import (
     RepoConfigSchemaError,
+    collides_with_global_config,
     find_repo_config,
     load_repo_config,
 )
+
+
+def refuse_global_config_collision(repo_root: Path) -> None:
+    """Abort when ``repo_root``'s ``.nauro/config.json`` is the global config.
+
+    With the default home layout that is exactly the home directory:
+    ``~/.nauro/config.json`` holds auth tokens and telemetry consent, and a
+    repo config written there replaces them. Commands that take a repo root
+    call this before any registry or store mutation. The refusal is
+    deliberately independent of ``--force`` — there is no situation where
+    overwriting the global config with a project pointer is what the user
+    wanted.
+
+    Raises:
+        typer.Exit: code 1 when ``repo_root`` collides with the global config.
+    """
+    if not collides_with_global_config(repo_root):
+        return
+    typer.echo(
+        f"Cannot use {repo_root.resolve()} as a project directory: its "
+        ".nauro/config.json is Nauro's own global config file, which holds "
+        "auth and telemetry settings.\n"
+        "Run this command from a project directory instead, e.g.:\n"
+        "  mkdir my-project && cd my-project",
+        err=True,
+    )
+    raise typer.Exit(code=1)
 
 
 def _v2_registry_or_empty() -> dict:
@@ -201,6 +229,7 @@ def _resolve_project_entry(project_name: str, project_key: str) -> dict:
 # Re-exported for callers that need to write or extend v2 entries directly
 __all__ = [
     "add_repo_v2",
+    "refuse_global_config_collision",
     "register_project_v2",
     "resolve_target_project",
 ]

--- a/packages/nauro/src/nauro/store/repo_config.py
+++ b/packages/nauro/src/nauro/store/repo_config.py
@@ -17,11 +17,15 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import secrets
 import time
 from pathlib import Path
 
 from nauro.constants import (
+    CONFIG_FILENAME,
+    DEFAULT_NAURO_HOME,
+    NAURO_HOME_ENV,
     REPO_CONFIG_DIR,
     REPO_CONFIG_FILENAME,
     REPO_CONFIG_MODE_CLOUD,
@@ -52,6 +56,31 @@ def _is_valid_ulid(value: str) -> bool:
 
 class RepoConfigSchemaError(Exception):
     """Raised when a ``.nauro/config.json`` has an unknown schema_version or shape."""
+
+
+class RepoConfigLocationError(Exception):
+    """Raised when a repo config write targets Nauro's own global config file."""
+
+
+def _global_config_file() -> Path:
+    """Path of the global config. Mirrors ``registry._nauro_home()``.
+
+    Not imported from registry because registry imports this module;
+    the resolution must stay in lockstep with it.
+    """
+    home = Path(os.environ.get(NAURO_HOME_ENV, Path.home() / DEFAULT_NAURO_HOME))
+    return home / CONFIG_FILENAME
+
+
+def collides_with_global_config(repo_root: Path) -> bool:
+    """True when ``repo_root``'s config path is Nauro's global config file.
+
+    With the default home layout, ``repo_config_path(Path.home())`` resolves to
+    ``~/.nauro/config.json`` — the same file that holds auth tokens and
+    telemetry consent for the whole machine. Writing a repo config there would
+    replace those settings, so writers must refuse the path.
+    """
+    return repo_config_path(repo_root).resolve() == _global_config_file().resolve()
 
 
 def generate_ulid() -> str:
@@ -138,8 +167,17 @@ def save_repo_config(repo_root: Path, data: dict) -> Path:
     """Write the repo config atomically. Returns the path written.
 
     The data dict is validated before write; an invalid shape raises
-    RepoConfigSchemaError without touching disk.
+    RepoConfigSchemaError without touching disk. A ``repo_root`` whose config
+    path collides with the global config raises RepoConfigLocationError —
+    the last line of defense for every writer; CLI commands additionally
+    refuse such paths up front with friendlier guidance.
     """
+    if collides_with_global_config(repo_root):
+        raise RepoConfigLocationError(
+            f"Refusing to write a repo config at {repo_config_path(repo_root)}: "
+            "that path is Nauro's global config file, which holds auth and "
+            "telemetry settings. Run from a project directory instead."
+        )
     data.setdefault("schema_version", REPO_CONFIG_SCHEMA_VERSION)
     _validate(data)
 

--- a/packages/nauro/tests/test_adopt.py
+++ b/packages/nauro/tests/test_adopt.py
@@ -63,6 +63,37 @@ def test_adopt_uses_repo_basename_when_name_omitted(tmp_path: Path, monkeypatch)
     assert data["name"] == "myrepo"
 
 
+def test_adopt_from_home_is_refused(tmp_path: Path, monkeypatch):
+    """A repo root whose .nauro/config.json is the global config is refused.
+
+    The guard outranks the git and already-adopted checks: even as a git
+    repo, the home directory must not read as an adoption, because the
+    recovery hint there ("remove .nauro/config.json") would point at the
+    file holding auth tokens and telemetry consent.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    home = tmp_path / "home"
+    nauro_home = home / ".nauro"
+    nauro_home.mkdir(parents=True)
+    monkeypatch.setenv("NAURO_HOME", str(nauro_home))
+    sentinel = '{"auth": {"access_token": "keep-me"}}\n'
+    (nauro_home / "config.json").write_text(sentinel)
+    _git_init(home)
+    monkeypatch.chdir(home)
+
+    result = runner.invoke(app, ["adopt", "--name", "alpha"])
+
+    assert result.exit_code == 1
+    assert "global config" in result.output
+    assert "already adopted" not in result.output.lower()
+    # Telemetry bookkeeping may merge into the file on any CLI run; the auth
+    # block must survive and no repo-config keys may appear.
+    data = json.loads((nauro_home / "config.json").read_text())
+    assert data["auth"] == {"access_token": "keep-me"}
+    assert "mode" not in data
+    assert find_projects_by_name_v2("alpha") == []
+
+
 def test_adopt_aborts_when_repo_already_adopted(tmp_path: Path, monkeypatch):
     _adopt_env(monkeypatch, tmp_path)
     runner.invoke(app, ["adopt", "--name", "alpha"])

--- a/packages/nauro/tests/test_attach.py
+++ b/packages/nauro/tests/test_attach.py
@@ -7,6 +7,7 @@ side effects to keep the failure mode safe.
 
 from __future__ import annotations
 
+import json
 from unittest.mock import patch
 
 import httpx
@@ -68,6 +69,33 @@ def test_attach_happy_path(tmp_path, monkeypatch):
 
     store_path = tmp_path / "projects" / EXAMPLE_PID
     assert store_path.is_dir()
+
+
+def test_attach_from_home_is_refused_before_any_network_call(tmp_path, monkeypatch):
+    """A repo path whose .nauro/config.json is the global config is refused.
+
+    The guard fires before the membership lookup, so no token and no mocked
+    transport are needed: an unpatched httpx call here would be a test
+    failure in itself.
+    """
+    home = tmp_path / "home"
+    nauro_home = home / ".nauro"
+    nauro_home.mkdir(parents=True)
+    monkeypatch.setenv("NAURO_HOME", str(nauro_home))
+    sentinel = '{"auth": {"access_token": "keep-me"}}\n'
+    (nauro_home / "config.json").write_text(sentinel)
+    monkeypatch.chdir(home)
+
+    result = runner.invoke(app, ["attach", EXAMPLE_PID])
+
+    assert result.exit_code == 1
+    assert "global config" in result.output
+    # Telemetry bookkeeping may merge into the file on any CLI run; the auth
+    # block must survive and no repo-config keys may appear.
+    data = json.loads((nauro_home / "config.json").read_text())
+    assert data["auth"] == {"access_token": "keep-me"}
+    assert "mode" not in data
+    assert registry.get_project_v2(EXAMPLE_PID) is None
 
 
 def test_attach_non_member_writes_nothing(tmp_path, monkeypatch):

--- a/packages/nauro/tests/test_init_home_collision.py
+++ b/packages/nauro/tests/test_init_home_collision.py
@@ -1,0 +1,115 @@
+"""`nauro init` refuses repo roots whose ``.nauro/config.json`` is the global config.
+
+With the default home layout that is the home directory itself:
+``repo_config_path($HOME)`` and the global config are the same file, and that
+file holds auth tokens and telemetry consent. Before this guard, ``nauro init
+--demo`` run from $HOME exited with a misleading "Re-run with --force" hint,
+and obeying it replaced the global config with a demo project pointer. The
+refusal fires before any registry or store mutation and is force-proof.
+
+CWD and NAURO_HOME are isolated by autouse conftest fixtures; each test
+re-points NAURO_HOME at a ``<home>/.nauro`` layout to replicate production.
+"""
+
+from __future__ import annotations
+
+import json
+
+from typer.testing import CliRunner
+
+from nauro.cli.main import app
+from nauro.store import registry
+
+runner = CliRunner()
+
+SENTINEL = json.dumps({"auth": {"access_token": "keep-me"}}, indent=2) + "\n"
+
+
+def _home_layout(tmp_path, monkeypatch):
+    """Replicate the production default: global config at ``<home>/.nauro/config.json``."""
+    home = tmp_path / "home"
+    nauro_home = home / ".nauro"
+    nauro_home.mkdir(parents=True)
+    monkeypatch.setenv("NAURO_HOME", str(nauro_home))
+    global_config = nauro_home / "config.json"
+    global_config.write_text(SENTINEL)
+    monkeypatch.chdir(home)
+    return home, global_config
+
+
+def _assert_global_config_intact(global_config):
+    """The global config kept its auth block and did not become a repo config.
+
+    Telemetry consent bookkeeping (``anonymous_id``) is merged into the global
+    config by the app callback on any CLI run; that merge is fine. What must
+    not happen is the repo-config replacement: auth gone, ``mode``/``id`` keys
+    present.
+    """
+    data = json.loads(global_config.read_text())
+    assert data["auth"] == {"access_token": "keep-me"}
+    assert "mode" not in data
+    assert "id" not in data
+
+
+def test_init_demo_from_home_is_refused(tmp_path, monkeypatch):
+    """--demo from the home directory aborts without touching any state."""
+    _home, global_config = _home_layout(tmp_path, monkeypatch)
+
+    result = runner.invoke(app, ["init", "--demo"])
+
+    assert result.exit_code == 1
+    assert "global config" in result.output
+    assert "Re-run with --force" not in result.output
+    _assert_global_config_intact(global_config)
+    assert registry.find_projects_by_name_v2("demo-project") == []
+
+
+def test_init_demo_force_from_home_is_still_refused(tmp_path, monkeypatch):
+    """--force must not bypass the guard; bypassing destroyed auth and consent."""
+    _home, global_config = _home_layout(tmp_path, monkeypatch)
+
+    result = runner.invoke(app, ["init", "--demo", "--force"])
+
+    assert result.exit_code == 1
+    _assert_global_config_intact(global_config)
+    assert registry.find_projects_by_name_v2("demo-project") == []
+
+
+def test_plain_init_from_home_is_refused(tmp_path, monkeypatch):
+    """Non-demo init from the home directory is refused the same way."""
+    _home, global_config = _home_layout(tmp_path, monkeypatch)
+
+    result = runner.invoke(app, ["init", "someproject"])
+
+    assert result.exit_code == 1
+    assert "global config" in result.output
+    _assert_global_config_intact(global_config)
+    assert registry.find_projects_by_name_v2("someproject") == []
+
+
+def test_init_add_repo_pointing_at_home_is_refused(tmp_path, monkeypatch):
+    """--add-repo <home> is refused even when the cwd is elsewhere."""
+    home, global_config = _home_layout(tmp_path, monkeypatch)
+    elsewhere = tmp_path / "work"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+
+    result = runner.invoke(app, ["init", "someproject", "--add-repo", str(home)])
+
+    assert result.exit_code == 1
+    assert "global config" in result.output
+    _assert_global_config_intact(global_config)
+    assert registry.find_projects_by_name_v2("someproject") == []
+
+
+def test_init_demo_in_ordinary_dir_still_works(tmp_path, monkeypatch):
+    """The guard does not catch normal directories under the same home."""
+    home, _global_config = _home_layout(tmp_path, monkeypatch)
+    project_dir = home / "nauro-demo"
+    project_dir.mkdir()
+    monkeypatch.chdir(project_dir)
+
+    result = runner.invoke(app, ["init", "--demo"])
+
+    assert result.exit_code == 0, result.output
+    assert (project_dir / ".nauro" / "config.json").is_file()

--- a/packages/nauro/tests/test_repo_config.py
+++ b/packages/nauro/tests/test_repo_config.py
@@ -13,7 +13,9 @@ from nauro.constants import (
     REPO_CONFIG_SCHEMA_VERSION,
 )
 from nauro.store.repo_config import (
+    RepoConfigLocationError,
     RepoConfigSchemaError,
+    collides_with_global_config,
     find_repo_config,
     generate_ulid,
     load_repo_config,
@@ -269,3 +271,50 @@ def test_find_repo_config_defaults_to_cwd(tmp_path, monkeypatch):
     monkeypatch.chdir(repo)
     found = find_repo_config()
     assert found == config_path
+
+
+# ── global-config collision guard ─────────────────────────────────────────────
+
+
+def test_save_refuses_global_config_path(tmp_path, monkeypatch):
+    """A repo root whose config path is the global config is refused.
+
+    Replicates the production default layout, where the global config lives
+    at ``<home>/.nauro/config.json``: a repo config for ``<home>`` resolves to
+    the same file, and writing it would replace auth tokens and telemetry
+    consent.
+    """
+    home = tmp_path / "home"
+    nauro_home = home / ".nauro"
+    nauro_home.mkdir(parents=True)
+    monkeypatch.setenv("NAURO_HOME", str(nauro_home))
+    global_config = nauro_home / "config.json"
+    sentinel = '{"auth": {"access_token": "keep-me"}}\n'
+    global_config.write_text(sentinel)
+
+    assert collides_with_global_config(home)
+    with pytest.raises(RepoConfigLocationError):
+        save_repo_config(
+            home,
+            {"mode": "local", "id": generate_ulid(), "name": "demo-project"},
+        )
+
+    assert global_config.read_text() == sentinel
+
+
+def test_collision_respects_nauro_home_override(tmp_path):
+    """A ``<dir>/.nauro`` that is not the configured home is a valid repo root.
+
+    The conftest points NAURO_HOME at ``tmp_path``, so ``home-lookalike`` is
+    an ordinary directory here; only the actual global config path collides.
+    """
+    repo = tmp_path / "home-lookalike"
+    repo.mkdir()
+
+    assert not collides_with_global_config(repo)
+    written = save_repo_config(
+        repo,
+        {"mode": "local", "id": generate_ulid(), "name": "demo-project"},
+    )
+    assert written == repo_config_path(repo)
+    assert written.is_file()


### PR DESCRIPTION
## Why

With the default home layout, `repo_config_path($HOME)` and the global config resolve to the same file: `~/.nauro/config.json`, which holds auth tokens and telemetry consent. Running `nauro init --demo` from the home directory therefore misread the global config as a repo config and exited with "Demo already initialized here. Re-run with --force to reset it." Obeying that hint replaced the global config with a demo project pointer, destroying the auth and consent state. `adopt` and `attach` write repo configs through the same path and carried the same exposure; `adopt` additionally treated such a directory as an already-adopted repo, and its recovery hint ("remove .nauro/config.json") pointed at the global config.

## Approach

Two layers. `save_repo_config` raises a typed `RepoConfigLocationError` whenever the target path resolves to the global config, covering every writer, current and future. On top of that, `init`, `adopt`, and `attach` refuse such repo roots up front with guidance pointing at a project directory, before any registry or store mutation, and independent of `--force`.

Alternatives considered: guarding only the demo path (rejected: adopt and attach share the writer and the same collision), and guarding only inside `save_repo_config` (rejected: the typed error would surface mid-command as a traceback after partial registry writes; the up-front refusal keeps state untouched and the message actionable). The collision check compares against the resolved `NAURO_HOME` location rather than hardcoding the home directory, so an overridden home keeps `<home>/.nauro` directories valid as ordinary repo roots.

## What changed

- `store/repo_config.py`: a `collides_with_global_config()` predicate plus the `RepoConfigLocationError` guard in `save_repo_config`. The global-config path is resolved locally because `registry` imports this module, so importing its resolver back would be circular.
- `cli/utils.py`: shared `refuse_global_config_collision()` that prints the guidance and exits 1.
- `cli/commands/init.py`, `adopt.py`, `attach.py`: the refusal runs before any state change. In `init` it covers `--demo`, plain init, `--cloud`, and every `--add-repo` target; in `adopt` it runs before the git and already-adopted checks; in `attach` before the cloud membership call.
- Tests: new `test_init_home_collision.py` (five CLI-level cases including the `--force` bypass attempt), guard cases in `test_adopt.py` and `test_attach.py`, and unit coverage of the predicate and writer guard in `test_repo_config.py`.

## What to review

- Path comparison semantics: both sides use `Path.resolve()`; confirm that holds for symlinked-home setups worth caring about.
- Guard placement in `adopt` relative to the git and already-adopted checks.
- The "config intact" test invariant: telemetry bookkeeping merges an `anonymous_id` key into the global config on any CLI run, so the tests assert the auth block survives and no repo-config keys appear, rather than byte equality.

## What's deferred

- The read side is unchanged: the repo-config walk-up can still reach `<home>/.nauro/config.json` and discards it on schema error. Only writes are guarded here.
- `link` relies on the writer guard alone; it only rewrites configs it previously loaded as valid repo configs, which the global config can never be.
- A release bump so installs pick the fix up; this PR does not change versions.

## Test plan

- 11 new tests covering init (demo, demo with --force, plain, --add-repo, fresh-subdir control), adopt, attach, and the store-layer predicate and writer guard.
- Full suites: packages/nauro 1387 passed, 10 skipped; packages/nauro-core 772 passed.
- `ruff check` and `ruff format --check` clean.
- Manual reproduction against the patched CLI from a temp home: refusal with exit 1, `--force` also refused, auth block intact, demo succeeds from a fresh subdirectory.
