### PR TITLE
Add pure decision-graph payload builder to nauro-core

### DIFF
--- a/packages/nauro-core/src/nauro_core/__init__.py
+++ b/packages/nauro-core/src/nauro_core/__init__.py
@@ -138,6 +138,12 @@ from nauro_core.decision_model import (
 from nauro_core.decision_model import (
     parse_decision as parse_decision,
 )
+from nauro_core.graph import (
+    GRAPH_PAYLOAD_VERSION as GRAPH_PAYLOAD_VERSION,
+)
+from nauro_core.graph import (
+    build_graph_payload as build_graph_payload,
+)
 from nauro_core.identity import (
     sanitize_sub as sanitize_sub,
 )
@@ -178,7 +184,13 @@ from nauro_core.parsing import (
     extract_stack_summary as extract_stack_summary,
 )
 from nauro_core.parsing import (
+    first_sentence_end as first_sentence_end,
+)
+from nauro_core.parsing import (
     parse_questions as parse_questions,
+)
+from nauro_core.parsing import (
+    scan_decision_references as scan_decision_references,
 )
 from nauro_core.protocol import (
     CANONICAL_FRAGMENTS as CANONICAL_FRAGMENTS,
@@ -299,6 +311,9 @@ from nauro_core.validation import (
 )
 from nauro_core.validation import (
     compute_hash as compute_hash,
+)
+from nauro_core.validation import (
+    is_scaffold_seed as is_scaffold_seed,
 )
 from nauro_core.validation import (
     screen_structural as screen_structural,

--- a/packages/nauro-core/src/nauro_core/graph.py
+++ b/packages/nauro-core/src/nauro_core/graph.py
@@ -1,0 +1,329 @@
+"""Pure builder for the decision-graph payload.
+
+``build_graph_payload`` takes already-parsed ``Decision`` objects and an
+optional parsed ``OpenQuestionsFile`` and returns one versioned JSON-shaped
+dict: nodes, supersession edges, citation edges, connected supersession
+components with explicit branch points, filtered open questions, and summary
+stats. Every renderer (the CLI HTML writer today, a hosted view later)
+consumes this one shape.
+
+The builder is pure: no I/O, no clock read, no randomness. Ordering is fully
+deterministic so two builds over the same input produce byte-identical JSON.
+
+Edge semantics. Supersession edges are the union of both frontmatter
+directions. The recorded store convention is a scalar ``supersedes`` carrying
+one forward edge per retirement and back-only ``superseded_by`` refs for the
+rest of a one-to-many retirement, with refs in the canonical plain-integer
+form enforced at the model boundary. The union reconstructs every retirement
+relationship as a directed edge ``(from, to)`` where ``from`` supersedes
+``to``. Citation edges come from string-scanning decision bodies for
+D-references (the shared ``parsing.scan_decision_references`` grammar) and are
+a separate, lower-signal layer.
+
+Plain string operations only; no regex.
+"""
+
+from __future__ import annotations
+
+from nauro_core.decision_model import Decision
+from nauro_core.parsing import first_sentence_end, scan_decision_references
+from nauro_core.questions import OpenQuestionsFile
+from nauro_core.validation import is_scaffold_seed
+
+# Graph payload schema version. Bump when the payload schema changes (a new
+# field, a renamed key, a changed value shape).
+GRAPH_PAYLOAD_VERSION = 1
+
+
+def build_graph_payload(
+    decisions: list[Decision],
+    questions: OpenQuestionsFile | None = None,
+    project: str = "",
+) -> dict:
+    """Build the decision-graph payload from parsed inputs. Pure; no I/O.
+
+    Args:
+        decisions: Parsed ``Decision`` objects. The scaffold seed (num 1 with
+            the scaffold title) is excluded. When two files resolve to the same
+            number one is kept (see ``_collect_nodes`` for the ordering rule)
+            and the dropped number is recorded in ``stats.duplicate_numbers``.
+            Only the kept decisions contribute edges and citations, so a dropped
+            duplicate never fabricates an edge attributed to the kept node.
+        questions: Parsed open-questions file, or None. Only unresolved entries
+            appear in the payload; each body is capped to its first line or
+            sentence.
+        project: Display name for the rendered title. Carried through verbatim.
+
+    Returns:
+        A JSON-shaped dict matching the v1 payload schema.
+    """
+    kept, duplicate_numbers = _collect_nodes(decisions)
+    nodes = [_node_dict(d) for d in kept]
+    node_numbers = {d.num for d in kept}
+    max_decision_number = max(node_numbers) if node_numbers else 0
+
+    supersession_edges, supersession_pairs = _collect_supersession_edges(kept, node_numbers)
+    citation_edges = _scan_citation_pairs(
+        kept, node_numbers, max_decision_number, supersession_pairs
+    )
+    components, incident, branch_point_count = _build_components(supersession_edges)
+    open_questions = _filter_open_questions(questions)
+
+    isolated_node_count = len(node_numbers - incident)
+
+    return {
+        "payload_version": GRAPH_PAYLOAD_VERSION,
+        "project": project,
+        "decision_count": len(nodes),
+        "max_decision_number": max_decision_number,
+        "nodes": nodes,
+        "supersession_edges": supersession_edges,
+        "citation_edges": citation_edges,
+        "components": components,
+        "open_questions": open_questions,
+        "stats": {
+            "isolated_node_count": isolated_node_count,
+            "supersession_edge_count": len(supersession_edges),
+            "citation_edge_count": len(citation_edges),
+            "component_count": len(components),
+            "branch_point_count": branch_point_count,
+            "duplicate_numbers": duplicate_numbers,
+        },
+    }
+
+
+def _collect_nodes(decisions: list[Decision]) -> tuple[list[Decision], list[int]]:
+    """Return ``(kept_decisions, duplicate_numbers)`` after scaffold and dedup.
+
+    The scaffold seed is dropped via the shared ``is_scaffold_seed`` predicate.
+    Decisions are then ordered by a total deterministic key so duplicate-number
+    resolution does not depend on input order: the first decision for each
+    number is kept, every later file resolving to that number is recorded in
+    ``duplicate_numbers``.
+
+    The dedup key is ``(num, title, date, status, confidence, body)``. This is
+    a total order over the parsed fields, so two files sharing a number (even
+    with identical titles) resolve identically regardless of input order. It
+    does NOT match the store layer's duplicate resolution: ``get_decision``
+    resolves a number to the first matching on-disk file stem
+    (``operations/decision_lookup.find_decision_stem_by_num``), and the parsed
+    ``Decision`` model does not retain its source stem, so the graph cannot
+    reproduce stem order. For a store with duplicate numbers the graph and
+    ``get_decision`` can therefore disagree on which file is "D5". Duplicate
+    numbers are a local-only anomaly the payload surfaces in
+    ``stats.duplicate_numbers`` rather than hides.
+    """
+    ordered = sorted(
+        (d for d in decisions if not is_scaffold_seed(d)),
+        key=lambda d: (
+            d.num,
+            d.title,
+            d.date.isoformat(),
+            d.status.value,
+            d.confidence.value,
+            d.body,
+        ),
+    )
+    kept: list[Decision] = []
+    seen: set[int] = set()
+    duplicate_numbers: list[int] = []
+    for d in ordered:
+        if d.num in seen:
+            if d.num not in duplicate_numbers:
+                duplicate_numbers.append(d.num)
+            continue
+        seen.add(d.num)
+        kept.append(d)
+    # ``ordered`` is already ascending by ``num`` (the leading key), so ``kept``
+    # is ascending by number and ``duplicate_numbers`` ascends as encountered.
+    return kept, duplicate_numbers
+
+
+def _node_dict(d: Decision) -> dict:
+    """Project a ``Decision`` onto the node schema.
+
+    Parallel to ``operations/results.DecisionSummary`` (the list_decisions row
+    projection); the two differ only in the type key name (``decision_type``
+    here, ``type`` there) and the date being required here. Kept separate so a
+    renderer change does not perturb the tool envelope.
+    """
+    decision_type = d.decision_type.value if d.decision_type is not None else None
+    return {
+        "number": d.num,
+        "title": d.title,
+        "status": d.status.value,
+        "decision_type": decision_type,
+        "confidence": d.confidence.value,
+        "date": d.date.isoformat(),
+    }
+
+
+def _collect_supersession_edges(
+    kept: list[Decision], node_numbers: set[int]
+) -> tuple[list[dict], set[tuple[int, int]]]:
+    """Collect supersession edges as the deduped union of both directions.
+
+    Iterates only the kept decisions, so a decision dropped during dedup never
+    contributes an edge attributed to the node that survived under its number.
+
+    ``supersedes: X`` on decision N yields the forward edge ``(N, X)``;
+    ``superseded_by: X`` on decision N yields ``(X, N)`` (X is newer, so X
+    supersedes N). Both refs are canonical plain-integer strings per the model
+    boundary. An edge is kept only when both endpoints are live nodes and the
+    two endpoints differ.
+
+    Returns ``(edges, pairs)`` where ``pairs`` is the set the caller reuses to
+    exclude already-superseded relationships from the citation layer.
+    """
+    pairs: set[tuple[int, int]] = set()
+    for d in kept:
+        if d.supersedes is not None:
+            target = int(d.supersedes)
+            if target in node_numbers and target != d.num:
+                pairs.add((d.num, target))
+        if d.superseded_by is not None:
+            newer = int(d.superseded_by)
+            if newer in node_numbers and newer != d.num:
+                pairs.add((newer, d.num))
+    edges = [{"from": a, "to": b} for a, b in sorted(pairs)]
+    return edges, pairs
+
+
+def _scan_citation_pairs(
+    kept: list[Decision],
+    node_numbers: set[int],
+    max_decision_number: int,
+    supersession_pairs: set[tuple[int, int]],
+) -> list[dict]:
+    """Scan kept decisions' bodies for D-references and emit citation edges.
+
+    Iterates only the kept decisions, so a dropped duplicate contributes no
+    citation attributed to the surviving node. Reference parsing is delegated
+    to the shared ``parsing.scan_decision_references`` grammar (forms ``D70`` /
+    ``D070`` / ``decision-70``, case-insensitive, alphanumeric-left-boundary
+    guarded, bounded to ``1..max_decision_number``).
+
+    A pair is excluded when it points at a non-node, is a self-reference, or is
+    already a supersession relationship. The supersession exclusion is on the
+    unordered pair: ``A`` citing ``B`` is dropped whenever ``A`` supersedes
+    ``B`` OR ``B`` supersedes ``A``, so a back-reference body citation never
+    mirrors the supersession edge in the opposite direction.
+    """
+    pairs: set[tuple[int, int]] = set()
+    for d in kept:
+        cited = scan_decision_references(d.body, max_decision_number)
+        for target in cited:
+            if target == d.num or target not in node_numbers:
+                continue
+            if (d.num, target) in supersession_pairs or (target, d.num) in supersession_pairs:
+                continue
+            pairs.add((d.num, target))
+    return [{"from": a, "to": b} for a, b in sorted(pairs)]
+
+
+def _build_components(
+    supersession_edges: list[dict],
+) -> tuple[list[dict], set[int], int]:
+    """Group nodes into connected components with branch points.
+
+    Returns ``(components, incident_nodes, branch_point_count)`` so the caller
+    derives the isolated-node count from the adjacency built here rather than
+    re-walking the edge list.
+
+    Connectivity is undirected over the supersession edges, so a one-to-many
+    fan (one retiring decision linked to many retired ones) lands in a single
+    component. Only nodes touched by at least one edge form components; fully
+    isolated nodes are omitted (they carry no thread). A branch point is any
+    node incident to more than one edge in the same direction (fan-in on the
+    ``to`` side or fan-out on the ``from`` side). Components sort by node count
+    descending then by smallest member; within a component, nodes sort
+    ascending and edges sort by ``(from, to)``.
+    """
+    adjacency: dict[int, set[int]] = {}
+    out_degree: dict[int, int] = {}
+    in_degree: dict[int, int] = {}
+    for e in supersession_edges:
+        a, b = e["from"], e["to"]
+        adjacency.setdefault(a, set()).add(b)
+        adjacency.setdefault(b, set()).add(a)
+        out_degree[a] = out_degree.get(a, 0) + 1
+        in_degree[b] = in_degree.get(b, 0) + 1
+
+    # Assign each node to a component id in one traversal, then bucket the edges
+    # by component in one pass so edge collection is O(E), not O(components * E).
+    component_of: dict[int, int] = {}
+    members_by_component: list[set[int]] = []
+    # Iterate incident nodes in ascending order so traversal order, and thus
+    # the smallest-member tiebreak, is deterministic. The cycle guard is the
+    # ``component_of`` map: a back-reference revisits an already-assigned node
+    # and the frontier loop terminates rather than recurring forever.
+    for seed in sorted(adjacency):
+        if seed in component_of:
+            continue
+        cid = len(members_by_component)
+        members: set[int] = set()
+        frontier = [seed]
+        while frontier:
+            node = frontier.pop()
+            if node in component_of:
+                continue
+            component_of[node] = cid
+            members.add(node)
+            for neighbor in adjacency[node]:
+                if neighbor not in component_of:
+                    frontier.append(neighbor)
+        members_by_component.append(members)
+
+    edges_by_component: list[list[tuple[int, int]]] = [[] for _ in members_by_component]
+    for e in supersession_edges:
+        edges_by_component[component_of[e["from"]]].append((e["from"], e["to"]))
+
+    components: list[dict] = []
+    for members, member_edges in zip(members_by_component, edges_by_component, strict=True):
+        branch_points = sorted(
+            node for node in members if out_degree.get(node, 0) > 1 or in_degree.get(node, 0) > 1
+        )
+        components.append(
+            {
+                "nodes": sorted(members),
+                "edges": [{"from": a, "to": b} for a, b in sorted(member_edges)],
+                "branch_points": branch_points,
+            }
+        )
+
+    components.sort(key=lambda c: (-len(c["nodes"]), c["nodes"][0]))
+    branch_point_count = sum(len(c["branch_points"]) for c in components)
+    return components, set(component_of), branch_point_count
+
+
+def _filter_open_questions(questions: OpenQuestionsFile | None) -> list[dict]:
+    """Return unresolved open-question entries with bodies capped to one unit.
+
+    Openness is annotation-authoritative via ``OpenQuestionsFile``'s public
+    ``unresolved_entries`` (``resolved_by`` unset), regardless of where the
+    entry sits relative to the ``## Resolved`` divider. Each included body is
+    capped to its first sentence or line.
+    """
+    if questions is None:
+        return []
+    return [
+        {"id": entry.id, "body": _cap_to_first_unit(entry.body)}
+        for entry in questions.unresolved_entries
+    ]
+
+
+def _cap_to_first_unit(body: str) -> str:
+    """Cap a body to its first sentence or first line, whichever ends sooner.
+
+    The first line ends at the first newline; the first sentence ends per the
+    shared ``parsing.first_sentence_end`` grammar (terminator plus boundary,
+    abbreviations skipped). The shorter boundary wins, so a multi-sentence
+    single line truncates to the first sentence and a multi-line body to its
+    first line.
+    """
+    text = body.strip()
+    line_end = text.find("\n")
+    if line_end == -1:
+        line_end = len(text)
+    cut = min(line_end, first_sentence_end(text))
+    return text[:cut].rstrip()

--- a/packages/nauro-core/src/nauro_core/operations/check_decision.py
+++ b/packages/nauro-core/src/nauro_core/operations/check_decision.py
@@ -27,13 +27,7 @@ from nauro_core.operations.results import (
 from nauro_core.operations.store import Store
 from nauro_core.parsing import extract_decision_number
 from nauro_core.search import union_retrieve
-from nauro_core.validation import check_content_length
-
-# Scaffold-seed bookkeeping decision is excluded from retrieval; full
-# rationale lives in ``nauro_core/validation.py:40-51``. The convention
-# match (num == 1 and exact title) is the same one tier-2 validation uses,
-# so both surfaces agree on what counts as the seed.
-_SCAFFOLD_SEED_TITLE = "Initial project setup"
+from nauro_core.validation import check_content_length, is_scaffold_seed
 
 # Extended stopword list for ``check_decision`` retrieval. Mirrors the
 # tier-2 ``TIER2_STOPWORDS`` curation (``nauro_core/validation.py:20-38``):
@@ -75,7 +69,7 @@ def check_decision(
             return CheckDecisionResult(error=ErrorPayload(kind="rejected", reason=rejection))
 
     decisions = parse_all_decisions(store)
-    decisions = [d for d in decisions if not (d.num == 1 and d.title == _SCAFFOLD_SEED_TITLE)]
+    decisions = [d for d in decisions if not is_scaffold_seed(d)]
     if not decisions:
         return CheckDecisionResult(assessment=NO_DECISIONS_TO_CHECK)
 

--- a/packages/nauro-core/src/nauro_core/parsing.py
+++ b/packages/nauro-core/src/nauro_core/parsing.py
@@ -11,6 +11,59 @@ import re
 
 from nauro_core.constants import STACK_EMPTY_MARKER
 
+# Tokens that end in a period without ending the sentence. A terminator
+# closing one of these is treated as part of the abbreviation, not a sentence
+# boundary, so "Should we e.g. cache?" is not clipped to "Should we e.g.".
+# Lowercased and stripped of the trailing period for the comparison.
+_SENTENCE_ABBREVIATIONS: frozenset[str] = frozenset({"e.g", "i.e", "vs", "etc", "cf"})
+
+_SENTENCE_TERMINATORS = ".!?"
+
+
+def first_sentence_end(text: str) -> int:
+    """Index just past the end of the first sentence in ``text``.
+
+    A sentence ends at a ``.``, ``!`` or ``?`` that is followed by whitespace
+    or the end of the string. A terminator immediately followed by a non-space
+    (a decimal point, a mid-word ellipsis) is not a boundary, and a terminating
+    period that closes a known abbreviation (``e.g.``, ``vs.``, ``etc.``) or a
+    single letter is skipped so the sentence runs past it. Returns ``len(text)``
+    when no boundary is found. Plain string ops; no regex.
+
+    Shared by the graph payload builder (first-sentence body cap) and BM25
+    snippet generation so the two surfaces split sentences identically.
+    """
+    n = len(text)
+    for i, ch in enumerate(text):
+        if ch not in _SENTENCE_TERMINATORS:
+            continue
+        if i + 1 < n and not text[i + 1].isspace():
+            continue
+        if ch == "." and _ends_with_abbreviation(text, i):
+            continue
+        return i + 1
+    return n
+
+
+def _ends_with_abbreviation(text: str, period_idx: int) -> bool:
+    """Whether the period at ``period_idx`` closes an abbreviation or initial.
+
+    Reads the token ending at the period (the run of non-space characters
+    immediately before it, with any embedded periods kept so ``e.g`` is one
+    token) and reports a match against the known-abbreviation set or a
+    single-letter initial.
+    """
+    start = period_idx
+    while start > 0 and not text[start - 1].isspace():
+        start -= 1
+    token = text[start:period_idx].lower()
+    if not token:
+        return False
+    if token in _SENTENCE_ABBREVIATIONS:
+        return True
+    # A single trailing letter ("A." in an initial) with no other letters.
+    return len(token) == 1 and token.isalpha()
+
 
 def extract_decision_number(identifier: str) -> int | None:
     """Extract the decision number from a decision identifier.
@@ -36,6 +89,72 @@ def extract_decision_number(identifier: str) -> int | None:
         else:
             break
     return int(leading) if leading else None
+
+
+_ASCII_DIGITS = "0123456789"
+
+# Body reference prefixes, lowercased. ``extract_decision_number`` accepts the
+# same forms for a single identifier; this scanner finds every occurrence in a
+# free-text body. The ``d`` form is matched case-insensitively to agree with
+# that function, and the alphanumeric left-boundary guard keeps it from firing
+# inside a longer token.
+_REFERENCE_PREFIXES: tuple[str, ...] = ("decision-", "d")
+
+
+def scan_decision_references(text: str, max_number: int) -> set[int]:
+    """Return every in-range decision number referenced in ``text``.
+
+    Recognized forms, case-insensitive: ``D70`` / ``d70``, zero-padded
+    ``D070``, and ``decision-70`` / ``Decision-70``. A reference must be
+    preceded by a non-alphanumeric character (or the start of the text) so a
+    digit or letter run does not fabricate a match (a UUID's ``...d4`` or an
+    identifier's ``...D70`` is rejected). The digit run is read to its boundary
+    so a short reference never matches inside a longer number (``D118`` parses
+    as 118, never 1 then 18), and only ASCII digits are consumed so a trailing
+    Unicode digit cannot reach ``int`` and raise. Numbers outside
+    ``1..max_number`` are dropped. Plain string ops; no regex.
+
+    This is the single home for the body-reference grammar. The graph payload
+    builder is the current consumer; ``extract_decision_number`` stays the
+    single-identifier analogue.
+    """
+    low = text.lower()
+    found: set[int] = set()
+    for prefix in _REFERENCE_PREFIXES:
+        _scan_prefix(text, low, prefix, found, max_number)
+    return found
+
+
+def _scan_prefix(text: str, low: str, prefix: str, found: set[int], max_number: int) -> None:
+    """Accumulate every ``<prefix><digits>`` occurrence into ``found``.
+
+    ``low`` is ``text`` lowercased once so the prefix match is case-insensitive
+    without rescanning; offsets line up because lowercasing is length-preserving
+    for the ASCII letters in the prefixes. The original ``text`` supplies the
+    digit run.
+    """
+    plen = len(prefix)
+    n = len(text)
+    start = low.find(prefix)
+    while start != -1:
+        # Left boundary: the char before the prefix must not be alphanumeric,
+        # else this is the tail of a longer token (an identifier ending in "d",
+        # a UUID digit run, a longer number). The digit run after the prefix is
+        # then read whole, which is also the prefix-collision guard.
+        if start > 0 and text[start - 1].isalnum():
+            start = low.find(prefix, start + 1)
+            continue
+        i = start + plen
+        digit_start = i
+        while i < n and text[i] in _ASCII_DIGITS:
+            i += 1
+        if i > digit_start:
+            value = int(text[digit_start:i])
+            if 1 <= value <= max_number:
+                found.add(value)
+        # i is always at least start + plen >= start + 1, so resuming the scan
+        # at i never re-examines the just-handled prefix.
+        start = low.find(prefix, i)
 
 
 def extract_current_state(state_content: str) -> str:

--- a/packages/nauro-core/src/nauro_core/questions.py
+++ b/packages/nauro-core/src/nauro_core/questions.py
@@ -349,6 +349,23 @@ class OpenQuestionsFile(BaseModel):
         return result
 
     @property
+    def unresolved_entries(self) -> list[QuestionEntry]:
+        """Entries whose resolution annotation is unset, in file order.
+
+        Annotation-authoritative, not positional: an entry is unresolved iff
+        its ``resolved_by`` is None, regardless of whether it sits before or
+        after the ``## Resolved`` divider. This is the definition a reader of
+        genuinely-still-open questions wants. It differs from :attr:`open_ids`,
+        which partitions strictly on divider position and is kept for the
+        round-trip and resolve machinery that depends on physical layout.
+        """
+        return [
+            b.entry
+            for b in self.blocks
+            if isinstance(b, EntryBlock) and b.entry.resolved_by is None
+        ]
+
+    @property
     def known_question_ids(self) -> set[str]:
         """All ids the file knows about: entry ids plus triple-hash embedded ids."""
         known: set[str] = set()

--- a/packages/nauro-core/src/nauro_core/search.py
+++ b/packages/nauro-core/src/nauro_core/search.py
@@ -6,13 +6,11 @@ Index text: title + rationale for each decision.
 
 from __future__ import annotations
 
-import re
-
 import bm25s
 import Stemmer
 
 from nauro_core.decision_model import Decision, DecisionStatus
-from nauro_core.parsing import extract_relevance_snippet
+from nauro_core.parsing import extract_relevance_snippet, first_sentence_end
 
 _stemmer = Stemmer.Stemmer("english")
 
@@ -53,7 +51,10 @@ def bm25_search(
         d = decisions[idx]
         snippet = extract_relevance_snippet(d.rationale, query_words)
         if not snippet and d.rationale:
-            first_sentence = re.split(r"[.!?]\s", d.rationale, maxsplit=1)[0]
+            # First sentence via the shared splitter, with the trailing
+            # terminator dropped to match the prior snippet shape.
+            end = first_sentence_end(d.rationale)
+            first_sentence = d.rationale[:end].rstrip(".!?")
             snippet = first_sentence[:100].strip()
             if len(first_sentence) > 100:
                 snippet += "..."

--- a/packages/nauro-core/src/nauro_core/validation.py
+++ b/packages/nauro-core/src/nauro_core/validation.py
@@ -51,11 +51,22 @@ TIER2_STOPWORDS = [*list(STOPWORDS_EN), "use"]
 _SCAFFOLD_SEED_TITLE = "Initial project setup"
 
 
-def _is_scaffold_seed(decision) -> bool:
-    """Detect the scaffold-seeded first decision (``Decision`` or legacy dict)."""
+def is_scaffold_seed(decision) -> bool:
+    """Detect the scaffold-seeded first decision (``Decision`` or legacy dict).
+
+    The convention match (``num == 1`` and the exact scaffold title) is the
+    single source every surface shares: tier-2 validation, ``check_decision``
+    retrieval, and the graph payload builder all call this predicate so they
+    agree on what counts as the seed.
+    """
     if hasattr(decision, "num"):
         return decision.num == 1 and decision.title == _SCAFFOLD_SEED_TITLE
     return decision.get("num") == 1 and decision.get("title") == _SCAFFOLD_SEED_TITLE
+
+
+# Historical private name kept as an alias for callers that imported it before
+# the public predicate existed.
+_is_scaffold_seed = is_scaffold_seed
 
 
 def check_bm25_similarity(

--- a/packages/nauro-core/tests/test_graph.py
+++ b/packages/nauro-core/tests/test_graph.py
@@ -1,0 +1,587 @@
+"""Tests for nauro_core.graph — the pure decision-graph payload builder.
+
+Builder invariants only; no I/O. Decision fixtures are constructed in memory
+and open-question fixtures are parsed from markdown strings, so these never
+read the live store.
+"""
+
+import json
+from datetime import date
+
+from nauro_core.decision_model import (
+    Decision,
+    DecisionConfidence,
+    DecisionStatus,
+    DecisionType,
+)
+from nauro_core.graph import GRAPH_PAYLOAD_VERSION, build_graph_payload
+from nauro_core.questions import OpenQuestionsFile
+
+
+def make_decision(
+    num,
+    title=None,
+    status="active",
+    supersedes=None,
+    superseded_by=None,
+    decision_type=None,
+    confidence="medium",
+    body="",
+    day=1,
+):
+    """Construct an in-memory Decision for graph fixtures.
+
+    A superseded status carries a superseded_by ref by default so the model's
+    superseded-requires-ref validator is satisfied without the caller spelling
+    it out on every node.
+    """
+    status_enum = DecisionStatus(status)
+    if status_enum is DecisionStatus.superseded and superseded_by is None:
+        superseded_by = "9999"
+    return Decision(
+        date=date(2026, 4, day),
+        confidence=DecisionConfidence(confidence),
+        status=status_enum,
+        decision_type=DecisionType(decision_type) if decision_type is not None else None,
+        supersedes=supersedes,
+        superseded_by=superseded_by,
+        num=num,
+        title=title if title is not None else f"Decision {num}",
+        rationale="A rationale long enough to be plausible decision text.",
+        body=body,
+    )
+
+
+# ── Shared fixtures (module-level functions, not test-class instances) ──
+
+
+def fan_in_13():
+    """A 13-way fan-in: node 100 retires a cluster via one forward edge to 7
+    plus 12 back-only superseded_by refs (8..19). Exercises forward-plus-back
+    union inside one fan."""
+    retiring = make_decision(100, title="Consolidate the cluster", supersedes="7")
+    forward_target = make_decision(7, status="superseded", superseded_by="100")
+    back_only = [make_decision(n, status="superseded", superseded_by="100") for n in range(8, 20)]
+    return [retiring, forward_target, *back_only]
+
+
+def mixed_fan():
+    """A fan centered on 40 (forward supersedes 26, back-only refs 27/28) plus a
+    linear tail 40 -> 50 -> 60 where 60 itself branches by also superseding 55.
+    One connected component containing a fan and a branching tail."""
+    return [
+        make_decision(40, supersedes="26"),
+        make_decision(26, status="superseded", superseded_by="40"),
+        make_decision(27, status="superseded", superseded_by="40"),
+        make_decision(28, status="superseded", superseded_by="40"),
+        make_decision(50, supersedes="40", status="superseded", superseded_by="60"),
+        make_decision(60, supersedes="50"),
+        make_decision(55, status="superseded", superseded_by="60"),
+    ]
+
+
+def assert_edges_partition_components(payload):
+    """Every supersession edge appears in exactly one component, and the union
+    of component edges equals the payload's edge list."""
+    component_edges = [(e["from"], e["to"]) for c in payload["components"] for e in c["edges"]]
+    all_edges = [(e["from"], e["to"]) for e in payload["supersession_edges"]]
+    assert sorted(component_edges) == sorted(all_edges)
+    assert len(component_edges) == len(set(component_edges))
+
+
+# ── Scaffold seed ──
+
+
+class TestScaffoldSeed:
+    def test_scaffold_seed_excluded(self):
+        decisions = [
+            make_decision(1, title="Initial project setup"),
+            make_decision(2, title="Use Postgres"),
+        ]
+        payload = build_graph_payload(decisions)
+        assert [n["number"] for n in payload["nodes"]] == [2]
+        assert payload["decision_count"] == 1
+
+    def test_real_d1_with_different_title_retained(self):
+        decisions = [
+            make_decision(1, title="Adopt event sourcing"),
+            make_decision(2, title="Use Postgres"),
+        ]
+        payload = build_graph_payload(decisions)
+        assert [n["number"] for n in payload["nodes"]] == [1, 2]
+
+    def test_scaffold_seed_contributes_no_edges_or_citations(self):
+        # A real D1 supersedes 2 and cites D2 in its body; the scaffold seed,
+        # present alongside under the same number, must contribute nothing.
+        decisions = [
+            make_decision(1, title="Initial project setup", body="see D2"),
+            make_decision(1, title="Adopt event sourcing", supersedes="2", body="replaces D2"),
+            make_decision(2, status="superseded", superseded_by="1"),
+        ]
+        payload = build_graph_payload(decisions)
+        # The seed is dropped before dedup, so the kept D1 is the real one and
+        # is NOT recorded as a duplicate of the seed.
+        assert [n["number"] for n in payload["nodes"]] == [1, 2]
+        kept_one = next(n for n in payload["nodes"] if n["number"] == 1)
+        assert kept_one["title"] == "Adopt event sourcing"
+        assert payload["supersession_edges"] == [{"from": 1, "to": 2}]
+        # The body citation D2 coincides with the supersession pair, so excluded.
+        assert payload["citation_edges"] == []
+        assert payload["stats"]["duplicate_numbers"] == []
+
+
+# ── Node shape ──
+
+
+class TestNodes:
+    def test_node_fields(self):
+        d = make_decision(
+            5,
+            title="Pick a queue",
+            status="superseded",
+            decision_type="infrastructure",
+            confidence="high",
+            day=9,
+        )
+        payload = build_graph_payload([d], project="demo")
+        assert payload["nodes"][0] == {
+            "number": 5,
+            "title": "Pick a queue",
+            "status": "superseded",
+            "decision_type": "infrastructure",
+            "confidence": "high",
+            "date": "2026-04-09",
+        }
+        assert payload["project"] == "demo"
+
+    def test_null_decision_type(self):
+        payload = build_graph_payload([make_decision(3, decision_type=None)])
+        assert payload["nodes"][0]["decision_type"] is None
+
+    def test_nodes_sorted_ascending(self):
+        payload = build_graph_payload([make_decision(7), make_decision(2), make_decision(5)])
+        assert [n["number"] for n in payload["nodes"]] == [2, 5, 7]
+
+    def test_max_decision_number(self):
+        payload = build_graph_payload([make_decision(2), make_decision(9), make_decision(4)])
+        assert payload["max_decision_number"] == 9
+
+
+# ── Input not mutated ──
+
+
+class TestInputNotMutated:
+    def test_input_list_and_decisions_unchanged(self):
+        decisions = mixed_fan()
+        before_len = len(decisions)
+        before_ids = [id(d) for d in decisions]
+        before_repr = [d.model_dump() for d in decisions]
+        build_graph_payload(decisions)
+        assert len(decisions) == before_len
+        assert [id(d) for d in decisions] == before_ids
+        assert [d.model_dump() for d in decisions] == before_repr
+
+
+# ── Supersession edges: union of both directions ──
+
+
+class TestSupersessionEdgeUnion:
+    def test_forward_and_back_dedup_to_one(self):
+        decisions = [
+            make_decision(2, supersedes="1"),
+            make_decision(1, status="superseded", superseded_by="2"),
+        ]
+        payload = build_graph_payload(decisions)
+        # Forward (supersedes) and back (superseded_by) describe the same edge;
+        # the union dedups it to exactly one.
+        assert payload["supersession_edges"] == [{"from": 2, "to": 1}]
+
+    def test_back_only_superseded_by_emits_edge(self):
+        # B has no `supersedes: A`; only A carries `superseded_by: B`.
+        decisions = [
+            make_decision(1, status="superseded", superseded_by="2"),
+            make_decision(2),
+        ]
+        payload = build_graph_payload(decisions)
+        assert payload["supersession_edges"] == [{"from": 2, "to": 1}]
+
+    def test_edge_to_missing_node_dropped(self):
+        # supersedes points at a decision not present (e.g. the scaffold seed).
+        decisions = [make_decision(2, supersedes="1", title="Real")]
+        payload = build_graph_payload(decisions)
+        assert payload["supersession_edges"] == []
+
+
+# ── Components: branching topologies ──
+
+
+class TestComponentsFanIn:
+    def test_single_component(self):
+        payload = build_graph_payload(fan_in_13())
+        assert payload["stats"]["component_count"] == 1
+        assert payload["components"][0]["nodes"] == [7, *range(8, 20), 100]
+
+    def test_all_13_edges_present_once(self):
+        payload = build_graph_payload(fan_in_13())
+        comp = payload["components"][0]
+        expected = [{"from": 100, "to": t} for t in [7, *range(8, 20)]]
+        assert comp["edges"] == expected
+        assert len(comp["edges"]) == 13
+        assert payload["stats"]["supersession_edge_count"] == 13
+
+    def test_fan_in_node_is_branch_point(self):
+        payload = build_graph_payload(fan_in_13())
+        assert payload["components"][0]["branch_points"] == [100]
+        assert payload["stats"]["branch_point_count"] == 1
+
+    def test_edges_partition(self):
+        assert_edges_partition_components(build_graph_payload(fan_in_13()))
+
+
+class TestComponentsMixedFanBranchingTail:
+    def test_one_component(self):
+        payload = build_graph_payload(mixed_fan())
+        assert payload["stats"]["component_count"] == 1
+        assert payload["components"][0]["nodes"] == [26, 27, 28, 40, 50, 55, 60]
+
+    def test_edges_sorted_and_complete(self):
+        payload = build_graph_payload(mixed_fan())
+        assert payload["components"][0]["edges"] == [
+            {"from": 40, "to": 26},
+            {"from": 40, "to": 27},
+            {"from": 40, "to": 28},
+            {"from": 50, "to": 40},
+            {"from": 60, "to": 50},
+            {"from": 60, "to": 55},
+        ]
+
+    def test_branch_points_explicit(self):
+        payload = build_graph_payload(mixed_fan())
+        # 40 fans out to 26/27/28; 60 fans out to 50/55. The linear node 50 is
+        # not a branch point.
+        assert payload["components"][0]["branch_points"] == [40, 60]
+
+    def test_edges_partition(self):
+        assert_edges_partition_components(build_graph_payload(mixed_fan()))
+
+
+class TestComponentOrdering:
+    def test_sorted_by_size_then_smallest_number(self):
+        decisions = [
+            make_decision(6, supersedes="5"),
+            make_decision(5, status="superseded", superseded_by="6"),
+            make_decision(11, supersedes="10"),
+            make_decision(12, supersedes="11"),
+            make_decision(10, status="superseded", superseded_by="11"),
+        ]
+        payload = build_graph_payload(decisions)
+        assert [len(c["nodes"]) for c in payload["components"]] == [3, 2]
+        assert payload["components"][0]["nodes"] == [10, 11, 12]
+        assert payload["components"][1]["nodes"] == [5, 6]
+
+    def test_equal_size_tiebreak_on_smallest_member(self):
+        decisions = [
+            make_decision(6, supersedes="5"),
+            make_decision(5, status="superseded", superseded_by="6"),
+            make_decision(3, supersedes="2"),
+            make_decision(2, status="superseded", superseded_by="3"),
+        ]
+        payload = build_graph_payload(decisions)
+        assert [c["nodes"][0] for c in payload["components"]] == [2, 5]
+
+
+# ── Determinism ──
+
+
+class TestDeterminism:
+    def test_build_twice_byte_identical(self):
+        decisions = mixed_fan()
+        first = json.dumps(build_graph_payload(decisions))
+        second = json.dumps(build_graph_payload(decisions))
+        assert first == second
+
+    def test_input_order_does_not_change_output(self):
+        decisions = fan_in_13()
+        forward = build_graph_payload(decisions)
+        reversed_in = build_graph_payload(list(reversed(decisions)))
+        assert forward == reversed_in
+
+
+# ── Citation scan grammar ──
+
+
+class TestCitationScan:
+    def test_plain_d_form(self):
+        decisions = [
+            make_decision(10, body="As noted in D7 we keep the queue."),
+            make_decision(7),
+        ]
+        payload = build_graph_payload(decisions)
+        assert payload["citation_edges"] == [{"from": 10, "to": 7}]
+
+    def test_zero_padded_form(self):
+        decisions = [
+            make_decision(10, body="See D007 for the rationale."),
+            make_decision(7),
+        ]
+        payload = build_graph_payload(decisions)
+        assert payload["citation_edges"] == [{"from": 10, "to": 7}]
+
+    def test_decision_hyphen_form(self):
+        decisions = [
+            make_decision(10, body="Superseded per decision-7 last quarter."),
+            make_decision(7),
+        ]
+        payload = build_graph_payload(decisions)
+        assert payload["citation_edges"] == [{"from": 10, "to": 7}]
+
+    def test_prefix_collision_only_d1_inside_d118(self):
+        # The body's ONLY "D1" occurrence is inside "D118". A broken substring
+        # scanner that matched the prefix would fabricate a 200->1 edge; reading
+        # the full digit run yields 118 only.
+        decisions = [
+            make_decision(200, body="Compare against D118 before deciding."),
+            make_decision(1, title="Real first decision"),
+            make_decision(118),
+        ]
+        payload = build_graph_payload(decisions)
+        assert payload["citation_edges"] == [{"from": 200, "to": 118}]
+
+    def test_letter_preceded_token_not_a_citation(self):
+        # A "keyID70" token must not yield a citation to D70.
+        decisions = [
+            make_decision(200, body="The keyID70 identifier is unrelated."),
+            make_decision(70),
+        ]
+        payload = build_graph_payload(decisions)
+        assert payload["citation_edges"] == []
+
+    def test_uuid_substring_not_a_citation(self):
+        # A UUID4 body must not fabricate a citation (the live phantom-edge case
+        # where "...d4..." yielded a D4 edge).
+        decisions = [
+            make_decision(200, body="ref 7c9e6679-7425-40de-944b-e07fc1f90ae7 only"),
+            make_decision(4),
+        ]
+        payload = build_graph_payload(decisions)
+        assert payload["citation_edges"] == []
+
+    def test_unicode_digit_does_not_crash(self):
+        # A superscript footnote after the number must not reach int() and raise.
+        decisions = [
+            make_decision(200, body="See D118¹ in the footnote."),
+            make_decision(118),
+        ]
+        payload = build_graph_payload(decisions)
+        assert payload["citation_edges"] == [{"from": 200, "to": 118}]
+
+    def test_self_reference_excluded(self):
+        decisions = [make_decision(7, body="This is D7 talking about itself.")]
+        payload = build_graph_payload(decisions)
+        assert payload["citation_edges"] == []
+
+    def test_out_of_range_above_max_excluded(self):
+        decisions = [
+            make_decision(10, body="A forward pointer to D999 that does not exist."),
+            make_decision(7),
+        ]
+        payload = build_graph_payload(decisions)
+        assert payload["citation_edges"] == []
+
+    def test_citation_to_missing_node_excluded(self):
+        # 8 is in range (< max 10) but no node 8 exists.
+        decisions = [
+            make_decision(10, body="See D8 for context."),
+            make_decision(7),
+        ]
+        payload = build_graph_payload(decisions)
+        assert payload["citation_edges"] == []
+
+    def test_supersession_pair_excluded_same_direction(self):
+        # 10 supersedes 7 AND cites D7; the forward pair is already a
+        # supersession edge, so it is not also a citation edge.
+        decisions = [
+            make_decision(10, supersedes="7", body="Replaces D7 entirely."),
+            make_decision(7, status="superseded", superseded_by="10"),
+        ]
+        payload = build_graph_payload(decisions)
+        assert payload["supersession_edges"] == [{"from": 10, "to": 7}]
+        assert payload["citation_edges"] == []
+
+    def test_supersession_pair_excluded_unordered(self):
+        # 70 supersedes 69 (edge 70->69). 69's body cites D70, which would be a
+        # citation 69->70 mirroring the supersession in the opposite direction.
+        # The exclusion is on the unordered pair, so no citation edge is emitted.
+        decisions = [
+            make_decision(70, supersedes="69"),
+            make_decision(
+                69,
+                status="superseded",
+                superseded_by="70",
+                body="Replaced by D70, see there.",
+            ),
+        ]
+        payload = build_graph_payload(decisions)
+        assert payload["supersession_edges"] == [{"from": 70, "to": 69}]
+        assert payload["citation_edges"] == []
+
+
+# ── Open-questions filter ──
+
+
+class TestOpenQuestionsFilter:
+    def test_unresolved_only_resolved_interleaved_excluded(self):
+        content = (
+            "# Open Questions\n"
+            "- [Q1] First open question?\n"
+            "- [Resolved by D5 on 2026-04-02] [Q2] Already settled question?\n"
+            "- [Q3] Third open question?\n"
+        )
+        questions = OpenQuestionsFile.parse(content)
+        payload = build_graph_payload([], questions=questions)
+        assert [q["id"] for q in payload["open_questions"]] == ["Q1", "Q3"]
+
+    def test_body_capped_to_first_sentence(self):
+        content = (
+            "# Open Questions\n- [Q1] First sentence here. Second sentence should be dropped.\n"
+        )
+        questions = OpenQuestionsFile.parse(content)
+        payload = build_graph_payload([], questions=questions)
+        assert payload["open_questions"][0]["body"] == "First sentence here."
+
+    def test_body_abbreviation_not_clipped(self):
+        content = "# Open Questions\n- [Q1] Should we e.g. cache the index here?\n"
+        questions = OpenQuestionsFile.parse(content)
+        payload = build_graph_payload([], questions=questions)
+        assert payload["open_questions"][0]["body"] == "Should we e.g. cache the index here?"
+
+    def test_no_questions_yields_empty(self):
+        payload = build_graph_payload([], questions=None)
+        assert payload["open_questions"] == []
+
+
+# ── Cycle guard ──
+
+
+class TestCycleGuard:
+    def test_back_reference_does_not_infinite_loop(self):
+        # A and B each reference the other; the union produces both directed
+        # edges. Traversal must terminate and the edges land in one component.
+        decisions = [
+            make_decision(1, supersedes="2", superseded_by="2", status="superseded"),
+            make_decision(2, supersedes="1", superseded_by="1", status="superseded"),
+        ]
+        payload = build_graph_payload(decisions)
+        assert payload["stats"]["component_count"] == 1
+        comp = payload["components"][0]
+        assert comp["nodes"] == [1, 2]
+        assert comp["edges"] == [{"from": 1, "to": 2}, {"from": 2, "to": 1}]
+        assert_edges_partition_components(payload)
+
+
+# ── Duplicate decision numbers ──
+
+
+class TestDuplicateNumbers:
+    def test_first_kept_duplicate_recorded(self):
+        # Two files resolve to number 5; the deterministic key keeps "Alpha".
+        decisions = [
+            make_decision(5, title="Beta version"),
+            make_decision(5, title="Alpha version"),
+            make_decision(6, title="Other"),
+        ]
+        payload = build_graph_payload(decisions)
+        assert [n["number"] for n in payload["nodes"]] == [5, 6]
+        kept = next(n for n in payload["nodes"] if n["number"] == 5)
+        assert kept["title"] == "Alpha version"
+        assert payload["stats"]["duplicate_numbers"] == [5]
+        assert payload["decision_count"] == 2
+
+    def test_identical_title_duplicate_input_order_invariant(self):
+        # Same number, same title; the duplicates differ only on date. The total
+        # ordering key keeps resolution input-order independent.
+        a = make_decision(5, title="Same", day=1)
+        b = make_decision(5, title="Same", day=9)
+        payload_ab = build_graph_payload([a, b])
+        payload_ba = build_graph_payload([b, a])
+        assert payload_ab == payload_ba
+        # The earlier date sorts first and is kept.
+        assert payload_ab["nodes"][0]["date"] == "2026-04-01"
+        assert payload_ab["stats"]["duplicate_numbers"] == [5]
+
+    def test_dropped_duplicate_contributes_no_edge_or_citation(self):
+        # The dropped file for number 5 carries supersedes + a body reference;
+        # neither must appear, because only the kept decision contributes.
+        kept = make_decision(5, title="Alpha", day=1)
+        dropped = make_decision(5, title="Beta", day=9, supersedes="6", body="see D6")
+        target = make_decision(6, status="superseded", superseded_by="5")
+        payload = build_graph_payload([kept, dropped, target])
+        assert payload["stats"]["duplicate_numbers"] == [5]
+        # Node 6's superseded_by still points at 5, so that back-only edge is
+        # legitimate and present. The dropped file's supersedes adds nothing new.
+        assert payload["supersession_edges"] == [{"from": 5, "to": 6}]
+        # The dropped file's body "see D6" must not fabricate a citation; the
+        # surviving 5->6 relationship is a supersession pair, so excluded anyway.
+        assert payload["citation_edges"] == []
+        kept_node = next(n for n in payload["nodes"] if n["number"] == 5)
+        assert kept_node["title"] == "Alpha"
+
+
+# ── Stats ──
+
+
+class TestStats:
+    def test_isolated_node_count(self):
+        decisions = [
+            make_decision(2, supersedes="1"),
+            make_decision(1, status="superseded", superseded_by="2"),
+            make_decision(9, title="Standalone"),
+        ]
+        payload = build_graph_payload(decisions)
+        assert payload["stats"]["isolated_node_count"] == 1
+
+    def test_stats_counts_consistent(self):
+        payload = build_graph_payload(mixed_fan())
+        stats = payload["stats"]
+        assert stats["supersession_edge_count"] == len(payload["supersession_edges"])
+        assert stats["citation_edge_count"] == len(payload["citation_edges"])
+        assert stats["component_count"] == len(payload["components"])
+
+
+# ── Payload version and empty input ──
+
+
+class TestPayloadVersionAndEmpty:
+    def test_payload_version_is_one(self):
+        payload = build_graph_payload([make_decision(2)])
+        assert payload["payload_version"] == 1
+        assert GRAPH_PAYLOAD_VERSION == 1
+
+    def test_no_findings_key(self):
+        payload = build_graph_payload([make_decision(2)])
+        assert "findings" not in payload
+
+    def test_plan_schema_fields_present(self):
+        # decision_count, max_decision_number, and branch_point_count are part
+        # of the approved schema and must stay in the payload.
+        payload = build_graph_payload(fan_in_13())
+        assert "decision_count" in payload
+        assert "max_decision_number" in payload
+        assert "branch_point_count" in payload["stats"]
+
+    def test_empty_input_well_formed(self):
+        payload = build_graph_payload([])
+        assert payload["payload_version"] == 1
+        assert payload["nodes"] == []
+        assert payload["supersession_edges"] == []
+        assert payload["citation_edges"] == []
+        assert payload["components"] == []
+        assert payload["open_questions"] == []
+        assert payload["decision_count"] == 0
+        assert payload["max_decision_number"] == 0
+        assert payload["stats"]["duplicate_numbers"] == []
+
+    def test_scaffold_only_yields_empty_nodes(self):
+        payload = build_graph_payload([make_decision(1, title="Initial project setup")])
+        assert payload["nodes"] == []
+        assert payload["decision_count"] == 0

--- a/packages/nauro-core/tests/test_parsing.py
+++ b/packages/nauro-core/tests/test_parsing.py
@@ -1,6 +1,10 @@
 """Tests for nauro_core.parsing."""
 
-from nauro_core.parsing import extract_decision_number
+from nauro_core.parsing import (
+    extract_decision_number,
+    first_sentence_end,
+    scan_decision_references,
+)
 
 
 class TestExtractDecisionNumber:
@@ -39,3 +43,94 @@ class TestExtractDecisionNumber:
 
     def test_decision_without_number_returns_none(self):
         assert extract_decision_number("decision-") is None
+
+
+class TestFirstSentenceEnd:
+    def test_simple_sentence(self):
+        text = "First sentence here. Second one."
+        assert text[: first_sentence_end(text)] == "First sentence here."
+
+    def test_no_terminator_returns_full_length(self):
+        text = "No terminator at all"
+        assert first_sentence_end(text) == len(text)
+
+    def test_terminator_at_end_of_text(self):
+        text = "Just one sentence."
+        assert first_sentence_end(text) == len(text)
+
+    def test_decimal_point_not_a_boundary(self):
+        text = "The ratio is 3.14 in this case. Next."
+        assert text[: first_sentence_end(text)] == "The ratio is 3.14 in this case."
+
+    def test_eg_abbreviation_not_a_boundary(self):
+        text = "Should we e.g. cache the index?"
+        assert text[: first_sentence_end(text)] == "Should we e.g. cache the index?"
+
+    def test_ie_abbreviation_not_a_boundary(self):
+        text = "Use one store, i.e. the local one. Done."
+        assert text[: first_sentence_end(text)] == "Use one store, i.e. the local one."
+
+    def test_vs_abbreviation_not_a_boundary(self):
+        text = "Local vs. remote first. Then decide."
+        assert text[: first_sentence_end(text)] == "Local vs. remote first."
+
+    def test_single_letter_initial_not_a_boundary(self):
+        text = "Authored by T. Thomsen here. Next sentence."
+        assert text[: first_sentence_end(text)] == "Authored by T. Thomsen here."
+
+    def test_question_and_exclamation_terminate(self):
+        assert "Why?"[: first_sentence_end("Why? Because.")] == "Why?"
+        assert "Stop!"[: first_sentence_end("Stop! Now.")] == "Stop!"
+
+
+class TestScanDecisionReferences:
+    def test_plain_d_form(self):
+        assert scan_decision_references("As in D7 we agreed.", 100) == {7}
+
+    def test_zero_padded_form(self):
+        assert scan_decision_references("See D007 again.", 100) == {7}
+
+    def test_decision_hyphen_lowercase(self):
+        assert scan_decision_references("Per decision-7 last week.", 100) == {7}
+
+    def test_decision_hyphen_capital_d(self):
+        # extract_decision_number accepts "Decision-70"; the scanner agrees.
+        assert scan_decision_references("Per Decision-70 last week.", 100) == {70}
+
+    def test_lowercase_d_form(self):
+        assert scan_decision_references("see d70 there", 100) == {70}
+
+    def test_prefix_collision_full_run_read(self):
+        # The only "D1" in the body is the prefix of "D118"; reading the whole
+        # digit run yields 118, never a spurious 1.
+        assert scan_decision_references("only D118 here", 200) == {118}
+
+    def test_letter_preceded_token_rejected(self):
+        # "keyID70" must not yield D70; the char before "D" is a letter.
+        assert scan_decision_references("keyID70 is an identifier", 100) == set()
+
+    def test_uuid_digit_run_rejected(self):
+        # A UUID4 substring "...d4..." must not yield D4; the char before is a
+        # hex digit. This is one of the live phantom-edge cases.
+        assert scan_decision_references("uuid 7c9e6679-7425-40de-944b-e07fc1f90ae7", 100) == set()
+
+    def test_ulid_substring_rejected(self):
+        # A ULID like "01ARZ3NDEKTSV4RRFFQ69G5FAV" embeds "d..." runs preceded by
+        # alphanumerics; none should surface as a reference.
+        assert scan_decision_references("id 01ARZ3NDEKTSV4RRFFQ69G5FAV6", 100) == set()
+
+    def test_digit_preceded_token_rejected(self):
+        # "12D70" — the "D70" is preceded by a digit, so it is the tail of a
+        # longer token and must not match.
+        assert scan_decision_references("12D70 stuck together", 100) == set()
+
+    def test_out_of_range_dropped(self):
+        assert scan_decision_references("D999 and D0 are out of range", 100) == set()
+
+    def test_unicode_digit_does_not_crash(self):
+        # A superscript footnote digit after the number must not reach int();
+        # only ASCII digits are consumed, so "D118¹" parses as 118.
+        assert scan_decision_references("see D118¹ footnote", 200) == {118}
+
+    def test_multiple_references(self):
+        assert scan_decision_references("D1 and D2 and decision-3", 100) == {1, 2, 3}

--- a/packages/nauro-core/tests/test_questions.py
+++ b/packages/nauro-core/tests/test_questions.py
@@ -216,6 +216,36 @@ class TestRoundTripFidelity:
         assert "UnparsableBlock" in kinds
 
 
+class TestUnresolvedEntries:
+    def test_resolved_annotation_excluded_even_in_active_section(self):
+        # A resolved-annotated entry sits interleaved before the divider; it is
+        # excluded by annotation, unlike open_ids which keys on position.
+        content = (
+            "# Open Questions\n"
+            "- [Q1] First open question?\n"
+            "- [Resolved by D5 on 2026-04-02] [Q2] Already settled?\n"
+            "- [Q3] Third open question?\n"
+        )
+        file = OpenQuestionsFile.parse(content)
+        assert [e.id for e in file.unresolved_entries] == ["Q1", "Q3"]
+        # open_ids stays positional: with no divider it reports all three.
+        assert file.open_ids == ["Q1", "Q2", "Q3"]
+
+    def test_unannotated_entry_under_resolved_divider_is_unresolved(self):
+        # The inverse of the open_ids Bug #4 case: an entry physically under
+        # ## Resolved but lacking a resolution annotation is still unresolved by
+        # annotation. open_ids treats it as resolved by position.
+        content = (
+            "# Open Questions\n"
+            "- [Q1] Still open?\n"
+            "## Resolved\n"
+            "- [Q2] Open-form but under the divider?\n"
+        )
+        file = OpenQuestionsFile.parse(content)
+        assert [e.id for e in file.unresolved_entries] == ["Q1", "Q2"]
+        assert file.open_ids == ["Q1"]
+
+
 class TestResolve:
     def _file(self) -> OpenQuestionsFile:
         return OpenQuestionsFile.parse(


### PR DESCRIPTION
## Why

The decision-graph view needs a single payload shape that every renderer can
consume. Computing nodes, supersession edges, citation edges, and connected
components once keeps the rendering command, and any later hosted view, as thin
renderers over the same data instead of each reimplementing the topology logic.
This change lands that builder on its own so it is independently testable with
no command surface attached.

## Approach

A pure function in the shared core package takes already-parsed decision objects
and an optional parsed open-questions file and returns one versioned
JSON-shaped payload. Payload-first was chosen over baking the computation into
the command: the same payload feeds the file renderer now and leaves a hosted
renderer open at no cost, since the core already does no I/O.

Supersession edges are the union of both frontmatter directions. The store's
retirement convention records a scalar forward reference plus back-only reverse
references for the rest of a one-to-many retirement, so taking the union
reconstructs every relationship as a directed edge. Connectivity is treated as
undirected, so a fan of retirements lands in one component with its fan node
marked as a branch point (a node incident to more than one edge in the same
direction). Components are connected components, not longest paths, because the
real topology includes wide fan-ins and tails that themselves branch, which a
path model cannot represent without dropping edges.

The citation layer is a separate, lower-signal scan over decision bodies. The
reference grammar and the sentence splitter live in the shared parsing module
as single helpers consumed by both this builder and the existing search
snippets, so every consumer reads references and sentence boundaries the same
way. The scan is plain string operations: it reads the full digit run after a
reference prefix, rejects any alphanumeric character immediately before the
prefix so identifiers and longer numbers never produce phantom references,
bounds matches to known decision numbers, and drops self-references and any
pair that mirrors a supersession edge in either direction.

Rejected here: folding the computation into the command (couples every future
renderer to the command), and a path-based thread model (drops edges on the
fan-in and branching-tail shapes the store actually contains).

## What changed

- New builder module in the core package: the public builder plus internal
  helpers for node collection, supersession-edge union, citation scanning,
  component construction with branch points, and the open-questions filter.
- Shared parsing helpers: a case-insensitive decision-reference scanner and an
  abbreviation-aware sentence-boundary helper, consumed by the builder and by
  the existing search snippet path.
- The open-questions model gains a public accessor for unresolved entries
  keyed on the resolution annotation; the positional accessor is unchanged.
- The scaffold-seed predicate is now public in the validation module; the
  conflict-check operation consumes it instead of carrying its own copy.
- The core package facade re-exports the builder and the payload-version
  constant.
- A test module pinning the builder invariants, plus new parsing and
  open-questions tests for the shared helpers.

The side-effecting command that writes and opens the rendered file is a
follow-up change and is not in this diff.

## What to review

- Containment of dropped decisions: node collection returns the kept decision
  objects, and the edge and citation collectors iterate exactly those, so a
  duplicate-numbered file or an excluded bookkeeping seed contributes no
  edges, citations, or component membership.
- The citation boundary guards: any alphanumeric predecessor rejects the
  match, digit runs are ASCII-only so Unicode digits cannot crash the parse,
  and supersession pairs are excluded unordered (a body citing its superseder
  does not produce a mirror citation).
- Deterministic duplicate handling: ties resolve by a total field tuple
  because parsed decisions retain no source filename; the docstring documents
  where this can diverge from the store layer's first-file rule.
- Component construction on the two topology fixtures: a wide fan-in with one
  forward reference plus back-only refs, and a mixed fan whose component also
  carries a branching tail. The pins assert every edge lands in exactly one
  component, branch points are listed explicitly, and no edge is dropped.

## What's deferred

- The command and HTML renderer that consume this payload.
- A findings field. It joins the payload under the next version bump when the
  diagnostics feature lands; the version constant is in place to carry that.
- No release or tag work; this rides a later tag.

## Test plan

74 new tests across the core package (builder, shared parsing helpers, and
open-questions accessor), full core suite green at 846. The consumer package
suite passes against the changed kernel (1387 passed, 10 skipped). Lint and
format checks are clean. Coverage includes the edge union (both directions,
deduped, back-only), dropped-duplicate and scaffold-seed containment, the
fan-in and branching-tail component fixtures, deterministic ordering including
same-title duplicates under input reordering, input non-mutation, the full
citation grammar with alphanumeric boundary guards and Unicode-digit safety,
unordered supersession-pair exclusion, the abbreviation-aware sentence cap,
the annotation-keyed open-questions filter, the cycle guard, the version
constant with no findings key, and a well-formed empty payload.
