### PR TITLE
Add nauro graph command and self-contained HTML renderer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ Principal commands (run `nauro --help` for the full surface):
 - `nauro sync` — capture a snapshot, regenerate `AGENTS.md` in all associated repos
 - `nauro log` — list recent snapshots with metadata
 - `nauro status` — capability table for the current project (active surfaces, absolute store path)
+- `nauro graph` — render the decision graph to one self-contained HTML file in the store directory and open it
 - `nauro serve` — start the local MCP server (stdio transport)
 - `nauro import --memory-bank <path>` — migrate a Cline/Roo Code Memory Bank
 - `nauro import --adr <path>` — migrate Architecture Decision Records

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ The demo store holds seven example decisions. One of them ruled out WebSocket in
 
 Output abbreviated to the top match; the live call returns all five related decisions, ranked by score. The same result reaches your agent through the MCP `check_decision` tool, so it sees the prior decision in the flow rather than after the fact.
 
+`nauro graph` renders the decision history to one self-contained HTML file and opens it. The file embeds decision titles and metadata plus open-question summaries, so it lands in the store directory by default rather than the repo; pass `--output` to write it elsewhere.
+
 ## Why not ADRs, grep, or CLAUDE.md?
 
 A decision log in your repo is a good record. The gap is on the read side: a file is read when a person opens it, and a fresh agent session starts with no knowledge that it exists. Nauro closes that gap. The relevant decision reaches your agent automatically, through MCP, at the moment it proposes a change. The store lives outside any single agent's memory, so the same project record is available across tools and sessions instead of being trapped in one prompt file, repo note, or chat history.

--- a/packages/nauro/CLAUDE.md
+++ b/packages/nauro/CLAUDE.md
@@ -43,6 +43,7 @@ Principal commands (run `nauro --help` for the full surface):
 - `nauro sync` — capture a snapshot, regenerate `AGENTS.md` in all associated repos
 - `nauro log` — list recent snapshots with metadata
 - `nauro status` — capability table for the current project (active surfaces, absolute store path)
+- `nauro graph` — render the decision graph to one self-contained HTML file in the store directory and open it
 - `nauro serve` — start the local MCP server (stdio transport)
 - `nauro import --memory-bank <path>` — migrate a Cline/Roo Code Memory Bank
 - `nauro import --adr <path>` — migrate Architecture Decision Records

--- a/packages/nauro/src/nauro/cli/commands/graph.py
+++ b/packages/nauro/src/nauro/cli/commands/graph.py
@@ -1,0 +1,128 @@
+"""nauro graph — render the decision graph to a self-contained HTML file.
+
+Reads the local store, builds the versioned graph payload in nauro-core, and
+writes one read-only HTML document. The output lands in the store directory by
+default because the HTML embeds decision titles and metadata plus open-question
+summaries; a current-directory default would invite committing that store
+extract into a repo. ``--output`` overrides the location, and ``--open``
+(default on) opens the file in a browser.
+"""
+
+from __future__ import annotations
+
+import webbrowser
+from datetime import datetime, timezone
+from pathlib import Path
+
+import typer
+from nauro_core import build_graph_payload, parse_decision
+from nauro_core.constants import OPEN_QUESTIONS_MD
+from nauro_core.decision_model import Decision
+from nauro_core.questions import OpenQuestionsFile
+
+from nauro.cli.utils import resolve_target_project
+from nauro.constants import DECISIONS_DIR
+from nauro.graph import render_html
+from nauro.store._atomic import atomic_write_text
+from nauro.store.reader import read_text_lenient
+
+_OUTPUT_FILENAME = "nauro-graph.html"
+
+
+def _read_decisions_lenient(store_path: Path) -> list[Decision]:
+    """Parse every decision file, skipping unreadable or malformed ones.
+
+    The kernel's ``parse_all_decisions`` skips parse failures but logs them at
+    debug with no per-file user-facing warning, and it reads through the Store
+    protocol rather than tolerating on-disk surprises (a subdirectory named
+    ``*.md``, a dangling symlink, an unreadable file). The graph command needs
+    both a named stderr warning and that I/O tolerance so one bad entry does not
+    deny the user the whole graph, so it keeps its own per-file loop with the
+    read inside the guard.
+    """
+    decisions_dir = store_path / DECISIONS_DIR
+    if not decisions_dir.exists():
+        return []
+
+    decisions: list[Decision] = []
+    for f in sorted(decisions_dir.glob("*.md")):
+        try:
+            content = read_text_lenient(f)
+            decisions.append(parse_decision(content, f.name))
+        except Exception as exc:
+            typer.echo(f"Skipping unreadable decision file {f.name}: {exc}", err=True)
+    return decisions
+
+
+def _read_open_questions(store_path: Path) -> OpenQuestionsFile | None:
+    """Parse the open-questions file when present and readable, else None.
+
+    The read and parse sit inside the guard so a directory shadowing the
+    open-questions path, or an unparseable file, drops the questions section
+    with a warning rather than aborting the whole render.
+    """
+    questions_path = store_path / OPEN_QUESTIONS_MD
+    if not questions_path.exists():
+        return None
+    try:
+        return OpenQuestionsFile.parse(read_text_lenient(questions_path))
+    except Exception as exc:
+        typer.echo(f"Skipping unreadable open-questions file: {exc}", err=True)
+        return None
+
+
+def _resolve_output_path(output: Path | None, store_path: Path) -> Path:
+    """Resolve where the HTML is written.
+
+    With no ``--output`` the file lands at ``<store>/nauro-graph.html``. An
+    explicit ``--output`` that names an existing directory writes the default
+    filename inside it; otherwise the path is taken as the full file path.
+    """
+    if output is None:
+        return store_path / _OUTPUT_FILENAME
+    output = output.expanduser()
+    if output.is_dir():
+        return output / _OUTPUT_FILENAME
+    return output
+
+
+def graph(
+    project: str | None = typer.Option(
+        None,
+        "--project",
+        help="Target project name.",
+    ),
+    output: Path | None = typer.Option(
+        None,
+        "--output",
+        help="Write the HTML here instead of the store directory.",
+    ),
+    open_browser: bool = typer.Option(
+        True,
+        "--open/--no-open",
+        help="Open the generated file in a browser (default on).",
+    ),
+) -> None:
+    """Render the project's decision graph to a self-contained HTML file."""
+    project_name, store_path = resolve_target_project(project)
+
+    decisions = _read_decisions_lenient(store_path)
+    questions = _read_open_questions(store_path)
+    payload = build_graph_payload(decisions, questions, project=project_name)
+
+    generated_at = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    html = render_html(payload, generated_at=generated_at)
+
+    out_path = _resolve_output_path(output, store_path)
+    # newline="\n" keeps the file byte-identical across platforms so its sha is
+    # stable wherever it is generated.
+    atomic_write_text(out_path, html, newline="\n")
+
+    absolute = out_path.resolve()
+    typer.echo(str(absolute))
+
+    if open_browser and not webbrowser.open(absolute.as_uri()):
+        typer.echo(
+            f"Could not open a browser. Open the file directly: {absolute}",
+            err=True,
+        )

--- a/packages/nauro/src/nauro/cli/main.py
+++ b/packages/nauro/src/nauro/cli/main.py
@@ -53,6 +53,7 @@ def _register_commands() -> None:
         attach,
         auth,
         config,
+        graph,
         hook,
         import_cmd,
         init,
@@ -79,6 +80,7 @@ def _register_commands() -> None:
     app.add_typer(questions.questions_app, name="questions")
     app.add_typer(hook.hook_app, name="hook")
     app.command(name="sync")(sync.sync)
+    app.command(name="graph")(graph.graph)
     app.command(name="log")(log.log)
     app.command(name="import")(import_cmd.import_cmd)
     app.command(name="serve")(serve.serve)

--- a/packages/nauro/src/nauro/graph/__init__.py
+++ b/packages/nauro/src/nauro/graph/__init__.py
@@ -1,0 +1,11 @@
+"""HTML rendering for the decision graph.
+
+``render_html`` turns a graph payload (built by
+``nauro_core.build_graph_payload``) into one self-contained, read-only HTML
+document: inline CSS and JS, no external requests, no third-party assets. The
+payload is embedded as a single JSON block the page reads at load time.
+"""
+
+from nauro.graph.html_render import render_html
+
+__all__ = ["render_html"]

--- a/packages/nauro/src/nauro/graph/html_render.py
+++ b/packages/nauro/src/nauro/graph/html_render.py
@@ -1,0 +1,585 @@
+"""Render a decision-graph payload into one self-contained HTML document.
+
+The output is a single read-only file: inline CSS, inline vanilla JS, no
+external network requests, no third-party assets. The payload is embedded once
+as a ``<script type="application/json">`` block; the page reads it at load time
+to drive the client-side title filter and the citation-layer toggle.
+
+The page draws a lane-and-thread timeline grouped by decision type, per-thread
+lineage cards, and the filtered open-questions list. Supersession relationships
+render textually on each card and lineage row ("supersedes D2, D7" / "superseded
+by D10") with branch points flagged; there are no drawn connectors in this
+version.
+
+This module deliberately consumes only the payload dict, never a store or any
+I/O, so relocating it (for example to a hosted renderer that builds the same
+payload) is mechanical.
+
+Built with f-strings and string templates only; no Jinja2, no regex. All
+authored copy is neutral and diagnostic, uses "decision" as the framing noun,
+and carries no em-dashes.
+"""
+
+from __future__ import annotations
+
+import json
+from html import escape as _html_escape
+
+from nauro_core.decision_model import DECISION_TYPE_VALUES
+
+# Display cap for a node title in the timeline and lineage cards. The full
+# title always survives in the embedded payload and in the title attribute; the
+# cap only governs the visible label so a very long title cannot overflow.
+_TITLE_DISPLAY_CAP = 64
+
+# Lane order for the timeline, derived from the canonical decision-type values
+# so a newly added type gets its own lane automatically rather than falling
+# silently into "other". Decisions with a null or unrecognized type still land
+# in the trailing "other" lane so no decision is dropped from the render.
+_LANE_ORDER = list(DECISION_TYPE_VALUES)
+_OTHER_LANE = "other"
+
+# Lane keys that read better with a custom label than the generic
+# underscore-to-space transform.
+_LANE_LABEL_OVERRIDES = {"api_design": "API design"}
+
+
+def render_html(payload: dict, *, generated_at: str) -> str:
+    """Render the graph payload to a complete HTML document.
+
+    Args:
+        payload: The dict returned by ``build_graph_payload``. Embedded verbatim
+            and also read on the Python side to build the static markup.
+        generated_at: A human-readable generation timestamp for the footer. The
+            payload itself carries no timestamp (the builder is pure), so the
+            caller stamps the time here.
+
+    Returns:
+        One self-contained HTML document as a string.
+    """
+    project = payload.get("project") or "this project"
+    decision_count = payload.get("decision_count", 0)
+    nodes = payload.get("nodes", [])
+
+    embedded = _embed_payload(payload)
+    title_text = _esc(f"Nauro decision graph: {project}")
+    footer = _render_footer(project, decision_count, generated_at)
+
+    if not nodes:
+        # A store can have zero decisions yet still carry flagged open
+        # questions, so the empty branch renders questions too.
+        body = _render_empty_state() + _render_open_questions(payload)
+    else:
+        relations = _supersession_relations(payload)
+        body = (
+            _render_controls()
+            + _render_timeline(payload, relations)
+            + _render_lineage(payload, relations)
+            + _render_open_questions(payload)
+        )
+
+    return _DOCUMENT_TEMPLATE.format(
+        title=title_text,
+        styles=_STYLES,
+        body=body,
+        footer=footer,
+        payload_json=embedded,
+        script=_SCRIPT,
+    )
+
+
+def _embed_payload(payload: dict) -> str:
+    """Serialize the payload for a ``<script type="application/json">`` block.
+
+    The ``.replace`` chain below is the only thing that prevents a string value
+    (a title containing ``</script>``, say) from terminating the script element
+    early: it rewrites ``<``, ``>`` and ``&`` to their JSON unicode escapes,
+    which are valid only inside JSON string literals, which is the only place
+    those characters occur in this document. Do not remove it on the assumption
+    that ``ensure_ascii`` covers the breakout; it does not. ``ensure_ascii`` only
+    forces non-ASCII to ``\\uXXXX`` and leaves ``<`` and ``>`` intact.
+    """
+    raw = json.dumps(payload, ensure_ascii=True, sort_keys=True)
+    return raw.replace("<", "\\u003c").replace(">", "\\u003e").replace("&", "\\u0026")
+
+
+def _esc(text: str) -> str:
+    """Escape text for HTML markup or a double-quoted attribute value.
+
+    ``html.escape`` with ``quote=True`` escapes both quote styles, so this is
+    safe in attribute values regardless of the surrounding quote character.
+    """
+    return _html_escape(text, quote=True)
+
+
+def _truncate_display(title: str) -> str:
+    """Truncate a title at a word boundary with an ellipsis for display.
+
+    The full title is never lost: it stays in the embedded payload and in the
+    ``title`` attribute. This governs only the visible label. The cut falls on
+    the last whitespace at or before the cap so a word is not split; if the
+    first word already exceeds the cap, a hard cut is taken.
+    """
+    if len(title) <= _TITLE_DISPLAY_CAP:
+        return title
+    window = title[:_TITLE_DISPLAY_CAP]
+    cut = window.rfind(" ")
+    if cut <= 0:
+        cut = _TITLE_DISPLAY_CAP
+    return title[:cut].rstrip() + "…"
+
+
+def _lane_of(decision_type) -> str:
+    """Map a node's decision_type onto a timeline lane key."""
+    if decision_type in _LANE_ORDER:
+        return decision_type
+    return _OTHER_LANE
+
+
+def _lane_label(lane: str) -> str:
+    """Human label for a lane key."""
+    return _LANE_LABEL_OVERRIDES.get(lane, lane.replace("_", " "))
+
+
+def _supersession_relations(payload: dict) -> dict[int, dict[str, list[int]]]:
+    """Map each node to the decisions it supersedes and is superseded by.
+
+    An edge ``(from, to)`` means ``from`` supersedes ``to``. For each node this
+    returns ``{"supersedes": [...], "superseded_by": [...]}`` with both lists
+    ascending. Edges come straight from the payload, so the textual relations on
+    the cards reflect exactly the edges the components encode.
+    """
+    relations: dict[int, dict[str, list[int]]] = {}
+    for edge in payload.get("supersession_edges", []):
+        a, b = edge["from"], edge["to"]
+        relations.setdefault(a, {"supersedes": [], "superseded_by": []})
+        relations.setdefault(b, {"supersedes": [], "superseded_by": []})
+        relations[a]["supersedes"].append(b)
+        relations[b]["superseded_by"].append(a)
+    for rel in relations.values():
+        rel["supersedes"].sort()
+        rel["superseded_by"].sort()
+    return relations
+
+
+def _relation_text(relation: dict[str, list[int]] | None) -> str:
+    """Render the supersession relations for a node as escaped HTML, or empty.
+
+    Produces lines like "supersedes D2, D7" and "superseded by D10". Returns an
+    empty string when the node has no supersession relations.
+    """
+    if not relation:
+        return ""
+    parts: list[str] = []
+    if relation["supersedes"]:
+        refs = ", ".join(f"D{n}" for n in relation["supersedes"])
+        parts.append(f'<span class="rel-supersedes">supersedes {refs}</span>')
+    if relation["superseded_by"]:
+        refs = ", ".join(f"D{n}" for n in relation["superseded_by"])
+        parts.append(f'<span class="rel-superseded">superseded by {refs}</span>')
+    if not parts:
+        return ""
+    return f'<span class="node-rel">{"".join(parts)}</span>'
+
+
+def _render_controls() -> str:
+    """Render the filter input and the citation-layer toggle (default off)."""
+    return (
+        '<section class="controls">'
+        '<label class="filter">Filter by title'
+        '<input id="title-filter" type="text" autocomplete="off" '
+        'placeholder="substring" /></label>'
+        '<label class="toggle">'
+        '<input id="citation-toggle" type="checkbox" /> Show citation edges'
+        "</label>"
+        "</section>"
+    )
+
+
+def _render_timeline(payload: dict, relations: dict[int, dict[str, list[int]]]) -> str:
+    """Render the lane-and-thread timeline as positioned HTML nodes.
+
+    Lanes group nodes by decision_type. Within a lane, nodes are ordered by date
+    then number. Each node card states its supersession relations textually so a
+    one-to-many fan is legible from the cards; branch points are flagged.
+    """
+    nodes = payload.get("nodes", [])
+    by_lane: dict[str, list[dict]] = {}
+    for node in nodes:
+        lane = _lane_of(node.get("decision_type"))
+        by_lane.setdefault(lane, []).append(node)
+
+    lane_keys = [k for k in _LANE_ORDER if k in by_lane]
+    if _OTHER_LANE in by_lane:
+        lane_keys.append(_OTHER_LANE)
+
+    branch_points: set[int] = set()
+    for component in payload.get("components", []):
+        for num in component.get("branch_points", []):
+            branch_points.add(num)
+
+    lanes_html: list[str] = []
+    for lane in lane_keys:
+        lane_nodes = sorted(by_lane[lane], key=lambda n: (n.get("date", ""), n.get("number", 0)))
+        cards = "".join(
+            _render_node_card(n, n["number"] in branch_points, relations.get(n["number"]))
+            for n in lane_nodes
+        )
+        lanes_html.append(
+            f'<div class="lane"><h3 class="lane-name">{_esc(_lane_label(lane))}'
+            f'</h3><div class="lane-track">{cards}</div></div>'
+        )
+
+    return (
+        '<section class="timeline"><h2>Timeline</h2>'
+        '<p class="section-note">Lanes group decisions by type. Each card names the '
+        "decisions it supersedes or is superseded by; branch points are flagged. "
+        "Toggle citation edges above to list body references.</p>"
+        f"{''.join(lanes_html)}</section>"
+    )
+
+
+def _render_node_card(
+    node: dict, is_branch_point: bool, relation: dict[str, list[int]] | None
+) -> str:
+    """Render one decision as a timeline node card."""
+    number = node.get("number", 0)
+    full_title = node.get("title", "")
+    display = _truncate_display(full_title)
+    status = node.get("status", "active")
+    date = node.get("date", "")
+    confidence = node.get("confidence", "")
+
+    classes = ["node", f"status-{_esc(status)}"]
+    if is_branch_point:
+        classes.append("branch-point")
+
+    title_attr = _esc(full_title)
+    return (
+        f'<article class="{" ".join(classes)}" data-number="{number}" '
+        f'data-title="{title_attr}" title="{title_attr}">'
+        f'<span class="node-id">D{number}</span>'
+        f'<span class="node-title">{_esc(display)}</span>'
+        f'<span class="node-meta">{_esc(date)} · {_esc(confidence)}</span>'
+        f'<span class="node-status">{_esc(status)}</span>'
+        f"{_relation_text(relation)}"
+        "</article>"
+    )
+
+
+def _render_lineage(payload: dict, relations: dict[int, dict[str, list[int]]]) -> str:
+    """Render one lineage card per supersession component, oldest-first.
+
+    A component lists every decision in its connected supersession thread,
+    ascending by number (which is oldest-first for sequentially numbered
+    decisions), with each entry's title, date, status, and its supersession
+    relations. Branch points are flagged so a fan is legible.
+    """
+    components = payload.get("components", [])
+    if not components:
+        return (
+            '<section class="lineage"><h2>Lineage</h2>'
+            '<p class="section-note">No supersession threads yet. Every decision '
+            "stands on its own.</p></section>"
+        )
+
+    node_by_number = {n["number"]: n for n in payload.get("nodes", [])}
+    cards: list[str] = []
+    for component in components:
+        branch_points = set(component.get("branch_points", []))
+        rows: list[str] = []
+        for num in component.get("nodes", []):
+            node = node_by_number.get(num)
+            if node is None:
+                continue
+            full_title = node.get("title", "")
+            marker = '<span class="branch-flag">branch</span>' if num in branch_points else ""
+            rows.append(
+                '<li class="lineage-row" '
+                f'data-title="{_esc(full_title)}">'
+                f'<span class="node-id">D{num}</span>'
+                f'<span class="lineage-title" title="{_esc(full_title)}">'
+                f"{_esc(_truncate_display(full_title))}</span>"
+                f'<span class="node-meta">{_esc(node.get("date", ""))}</span>'
+                f'<span class="node-status">{_esc(node.get("status", ""))}</span>'
+                f"{_relation_text(relations.get(num))}"
+                f"{marker}</li>"
+            )
+        size = len(component.get("nodes", []))
+        cards.append(
+            f'<article class="lineage-card"><h3>Thread of {size} decisions</h3>'
+            f'<ul class="lineage-list">{"".join(rows)}</ul></article>'
+        )
+
+    return f'<section class="lineage"><h2>Lineage</h2>{"".join(cards)}</section>'
+
+
+def _render_open_questions(payload: dict) -> str:
+    """Render the filtered open-questions list."""
+    questions = payload.get("open_questions", [])
+    if not questions:
+        return (
+            '<section class="questions"><h2>Open questions</h2>'
+            '<p class="section-note">No open questions.</p></section>'
+        )
+
+    items: list[str] = []
+    for q in questions:
+        qid = _esc(q.get("id", ""))
+        body = _esc(q.get("body", ""))
+        items.append(f'<li><span class="q-id">{qid}</span><span class="q-body">{body}</span></li>')
+
+    return (
+        '<section class="questions"><h2>Open questions</h2>'
+        f'<ul class="question-list">{"".join(items)}</ul></section>'
+    )
+
+
+def _render_empty_state() -> str:
+    """Render the intentional empty state for a store with no decisions."""
+    return (
+        '<section class="empty-state">'
+        "<h2>No decisions yet</h2>"
+        "<p>Record the first decision with <code>nauro note</code> or your "
+        "agent's propose-decision tool, then run this command again.</p>"
+        "</section>"
+    )
+
+
+def _render_footer(project: str, decision_count: int, generated_at: str) -> str:
+    """Render the footer naming the project, decision count, and generation time."""
+    plural = "decision" if decision_count == 1 else "decisions"
+    return (
+        f'<footer class="page-footer">{_esc(project)} · '
+        f"{decision_count} {plural} · generated {_esc(generated_at)}</footer>"
+    )
+
+
+_STYLES = """
+:root {
+  --paper: #F5F0E5;
+  --ink: #1a1915;
+  --navy: #0F3A52;
+  --accent: #8a3520;
+  --line: #d8cfbd;
+  --muted: #6b6557;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --paper: #14181b;
+    --ink: #e7e2d6;
+    --navy: #4fb6c4;
+    --accent: #c8745f;
+    --line: #2a3036;
+    --muted: #9a978c;
+  }
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  padding: 0 1.5rem 4rem;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: Georgia, "Times New Roman", serif;
+  line-height: 1.5;
+}
+header.page-header {
+  border-bottom: 2px solid var(--navy);
+  padding: 1.5rem 0 1rem;
+  margin-bottom: 1.5rem;
+}
+header.page-header h1 {
+  margin: 0;
+  font-size: 1.6rem;
+  color: var(--navy);
+  font-weight: 600;
+}
+h2 {
+  color: var(--navy);
+  font-size: 1.2rem;
+  border-bottom: 1px solid var(--line);
+  padding-bottom: 0.3rem;
+}
+h3 { font-size: 1rem; margin: 0.6rem 0 0.4rem; }
+.section-note { color: var(--muted); font-size: 0.85rem; max-width: 60ch; }
+.controls {
+  display: flex;
+  gap: 1.5rem;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-bottom: 1.5rem;
+  font-family: -apple-system, "Segoe UI", sans-serif;
+  font-size: 0.9rem;
+}
+.controls input[type="text"] {
+  margin-left: 0.5rem;
+  padding: 0.3rem 0.5rem;
+  border: 1px solid var(--line);
+  background: var(--paper);
+  color: var(--ink);
+  border-radius: 3px;
+}
+.lane { margin-bottom: 1.2rem; }
+.lane-name {
+  color: var(--accent);
+  margin: 0 0 0.4rem;
+  font-size: 0.95rem;
+}
+.lane-track {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+.node {
+  display: flex;
+  flex-direction: column;
+  min-width: 12rem;
+  max-width: 16rem;
+  padding: 0.5rem 0.6rem;
+  border: 1px solid var(--line);
+  border-left: 3px solid var(--navy);
+  background: var(--paper);
+  font-family: -apple-system, "Segoe UI", sans-serif;
+  font-size: 0.82rem;
+}
+.node.status-superseded { border-left-color: var(--accent); opacity: 0.85; }
+.node.branch-point { border-style: dashed; }
+.node-id { font-weight: 700; color: var(--navy); }
+.node.status-superseded .node-id { color: var(--accent); }
+.node-title { margin: 0.15rem 0; }
+.node-meta { color: var(--muted); font-size: 0.75rem; }
+.node-status { color: var(--muted); font-size: 0.72rem; text-transform: uppercase; }
+.node-rel { margin-top: 0.2rem; font-size: 0.74rem; display: flex; flex-direction: column; }
+.rel-superseded { color: var(--accent); }
+.rel-supersedes { color: var(--muted); }
+.lineage-card {
+  border: 1px solid var(--line);
+  padding: 0.6rem 0.8rem;
+  margin-bottom: 1rem;
+}
+.lineage-list { list-style: none; margin: 0; padding: 0; }
+.lineage-row {
+  display: flex;
+  gap: 0.6rem;
+  align-items: baseline;
+  flex-wrap: wrap;
+  padding: 0.2rem 0;
+  border-bottom: 1px solid var(--line);
+  font-family: -apple-system, "Segoe UI", sans-serif;
+  font-size: 0.82rem;
+}
+.lineage-row .node-rel { flex-direction: row; gap: 0.6rem; }
+.lineage-title { flex: 1; }
+.branch-flag {
+  color: var(--accent);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.question-list { list-style: none; padding: 0; }
+.question-list li {
+  display: flex;
+  gap: 0.6rem;
+  padding: 0.3rem 0;
+  border-bottom: 1px solid var(--line);
+}
+.q-id { font-weight: 700; color: var(--navy); }
+.empty-state { padding: 3rem 0; max-width: 50ch; }
+.empty-state h2 { border: none; }
+code {
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  background: var(--line);
+  padding: 0.05rem 0.3rem;
+  border-radius: 3px;
+  font-size: 0.85em;
+}
+.page-footer {
+  margin-top: 3rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--line);
+  color: var(--muted);
+  font-size: 0.8rem;
+}
+.dimmed { opacity: 0.25; }
+.citation-edges { display: none; color: var(--muted); font-size: 0.8rem; margin-top: 1rem; }
+.citation-edges.visible { display: block; }
+@media (hover: hover) {
+  .node:hover { border-left-width: 5px; }
+}
+@media (prefers-reduced-motion: reduce) {
+  * { transition: none !important; }
+}
+"""
+
+
+_SCRIPT = """
+(function () {
+  var raw = document.getElementById("graph-payload").textContent;
+  var payload = JSON.parse(raw);
+
+  var filterInput = document.getElementById("title-filter");
+  if (filterInput) {
+    filterInput.addEventListener("input", function () {
+      var needle = filterInput.value.trim().toLowerCase();
+      var targets = document.querySelectorAll("[data-title]");
+      for (var i = 0; i < targets.length; i++) {
+        var el = targets[i];
+        var hay = (el.getAttribute("data-title") || "").toLowerCase();
+        if (needle === "" || hay.indexOf(needle) !== -1) {
+          el.classList.remove("dimmed");
+        } else {
+          el.classList.add("dimmed");
+        }
+      }
+    });
+  }
+
+  var toggle = document.getElementById("citation-toggle");
+  var citationBox = document.getElementById("citation-edges");
+  if (toggle && citationBox) {
+    var syncCitations = function () {
+      if (toggle.checked) {
+        citationBox.classList.add("visible");
+      } else {
+        citationBox.classList.remove("visible");
+      }
+    };
+    toggle.addEventListener("change", syncCitations);
+    // Firefox restores a checkbox's prior checked state into a fresh DOM on
+    // reload; sync the layer to the box once at load so the two never desync.
+    syncCitations();
+    var edges = payload.citation_edges || [];
+    if (edges.length === 0) {
+      citationBox.textContent = "No citation edges in this store.";
+    } else {
+      var parts = [];
+      for (var j = 0; j < edges.length; j++) {
+        parts.push("D" + edges[j].from + " cites D" + edges[j].to);
+      }
+      citationBox.textContent = parts.join("  |  ");
+    }
+  }
+})();
+"""
+
+
+_DOCUMENT_TEMPLATE = """<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>{title}</title>
+<style>{styles}</style>
+</head>
+<body>
+<header class="page-header"><h1>{title}</h1></header>
+{body}
+<div id="citation-edges" class="citation-edges"></div>
+{footer}
+<!--graph-payload-start-->
+<script id="graph-payload" type="application/json">{payload_json}</script>
+<!--graph-payload-end-->
+<script>{script}</script>
+</body>
+</html>
+"""

--- a/packages/nauro/src/nauro/store/_atomic.py
+++ b/packages/nauro/src/nauro/store/_atomic.py
@@ -1,11 +1,11 @@
-"""Atomic text-write primitive for control-plane JSON files.
+"""Atomic text-write primitive for store files.
 
 The single tmp-write-then-``os.replace`` primitive used by the control-plane
-JSON writers (``registry.json``, ``config.json``, per-repo ``config.json``).
-Durability scope is atomic-replace only: the rename is atomic on a single
-filesystem, so a reader never observes a partially written target. There is
-deliberately no ``fsync`` — that matches every existing call site, and
-crash-durability is an explicit non-goal here.
+JSON writers (``registry.json``, ``config.json``, per-repo ``config.json``) and
+by the graph command for its rendered HTML. Durability scope is atomic-replace
+only: the rename is atomic on a single filesystem, so a reader never observes a
+partially written target. There is deliberately no ``fsync`` — that matches
+every existing call site, and crash-durability is an explicit non-goal here.
 """
 
 import os
@@ -13,7 +13,9 @@ import tempfile
 from pathlib import Path
 
 
-def atomic_write_text(path: Path, text: str, *, mode: int | None = None) -> None:
+def atomic_write_text(
+    path: Path, text: str, *, mode: int | None = None, newline: str | None = None
+) -> None:
     """Write ``text`` to ``path`` atomically via a tmp sibling and ``os.replace``.
 
     Creates the parent directory if needed, writes to a tmp sibling, then
@@ -25,6 +27,11 @@ def atomic_write_text(path: Path, text: str, *, mode: int | None = None) -> None
         text: Full file contents to write.
         mode: When set, the permission bits applied to the file (e.g. ``0o600``
             for owner-only). When None, the file keeps the default umask mode.
+        newline: Passed through to the underlying text write. ``"\\n"`` pins LF
+            line endings on every platform, so a file written on Windows is
+            byte-identical to one written on POSIX (the default would translate
+            ``\\n`` to ``\\r\\n`` on Windows). When None, the platform default
+            applies, matching the original control-plane behavior.
 
     When ``mode`` is given the tmp sibling is created owner-only with a random,
     unguessable name via :func:`tempfile.mkstemp` (which opens with
@@ -39,7 +46,7 @@ def atomic_write_text(path: Path, text: str, *, mode: int | None = None) -> None
         fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.", suffix=".tmp")
         tmp = Path(tmp_name)
         try:
-            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            with os.fdopen(fd, "w", encoding="utf-8", newline=newline) as handle:
                 handle.write(text)
             if mode != 0o600:
                 os.chmod(tmp, mode)
@@ -49,5 +56,5 @@ def atomic_write_text(path: Path, text: str, *, mode: int | None = None) -> None
             raise
     else:
         tmp = path.with_suffix(".tmp")
-        tmp.write_text(text, encoding="utf-8")
+        tmp.write_text(text, encoding="utf-8", newline=newline)
         os.replace(tmp, path)

--- a/packages/nauro/src/nauro/sync/merge.py
+++ b/packages/nauro/src/nauro/sync/merge.py
@@ -29,8 +29,12 @@ class UnionMergeError(Exception):
 # conflicts resolve by last-write-wins with a recoverable backup instead.
 APPEND_ONLY_PATTERNS = ("open-questions.md", "state_history.md")
 
-# Files that are never synced
-NEVER_SYNC = (".sync-state.json",)
+# Files that are never synced. The graph command's default output lands in the
+# store directory; its generation timestamp changes every run, so its sha never
+# settles and syncing it would re-push the artifact on every run and fan it out
+# to every collaborator. A custom --output path is the user's explicit choice
+# and is not guarded here; only the default filename is.
+NEVER_SYNC = (".sync-state.json", "nauro-graph.html")
 
 
 def should_skip(relative_path: str) -> bool:

--- a/packages/nauro/tests/test_atomic.py
+++ b/packages/nauro/tests/test_atomic.py
@@ -38,6 +38,13 @@ def test_creates_missing_parent_dirs(tmp_path):
     assert p.read_text() == "data\n"
 
 
+def test_newline_lf_keeps_lf_bytes(tmp_path):
+    """``newline="\\n"`` writes LF verbatim so the file is platform-stable."""
+    p = tmp_path / "out.html"
+    atomic_write_text(p, "a\nb\n", newline="\n")
+    assert p.read_bytes() == b"a\nb\n"
+
+
 def test_target_untouched_when_replace_fails(tmp_path, monkeypatch):
     p = tmp_path / "out.json"
 

--- a/packages/nauro/tests/test_cli_graph.py
+++ b/packages/nauro/tests/test_cli_graph.py
@@ -1,0 +1,467 @@
+"""Tests for the ``nauro graph`` command and its HTML output.
+
+Every invocation patches ``webbrowser.open`` so the suite never opens a real
+browser; the autouse fixture below records the call so a test can assert it was
+or was not invoked, and with which URI.
+
+These tests own the command and renderer behavior only. Builder invariants
+(sentence caps, citation-pair grammar, scaffold-seed exclusion) are pinned in
+the nauro-core suite and are not re-asserted here.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from nauro.cli.main import app
+from nauro.constants import DECISIONS_DIR, OPEN_QUESTIONS_MD
+from nauro.store.registry import register_project
+from nauro.templates.scaffolds import scaffold_project_store
+
+runner = CliRunner()
+
+# The H1 separator the decision parser requires between number and title.
+_H1_SEP = "—"
+
+
+@pytest.fixture(autouse=True)
+def _no_browser(monkeypatch):
+    """Replace ``webbrowser.open`` with a recorder so no test opens a browser.
+
+    Returns the call-list so a test can assert the file URI it was handed, or
+    that it was never called under ``--no-open``. The default return is True
+    (a browser opened); a test that needs the headless path overrides it.
+    """
+    calls: list[str] = []
+
+    def _record(uri, *args, **kwargs):
+        calls.append(uri)
+        return True
+
+    monkeypatch.setattr("nauro.cli.commands.graph.webbrowser.open", _record)
+    return calls
+
+
+def _decision_md(
+    num: int,
+    title: str,
+    *,
+    decision_type: str = "architecture",
+    status: str = "active",
+    confidence: str = "high",
+    date: str = "2026-03-15",
+    supersedes: str | None = None,
+    superseded_by: str | None = None,
+    body: str = "Rationale body for the decision.",
+) -> str:
+    """Return canonical decision markdown the parser accepts."""
+    sup = "null" if supersedes is None else f"'{supersedes}'"
+    sup_by = "null" if superseded_by is None else f"'{superseded_by}'"
+    return (
+        "---\n"
+        f"date: {date}\n"
+        "version: 1\n"
+        f"status: {status}\n"
+        f"confidence: {confidence}\n"
+        f"decision_type: {decision_type}\n"
+        "reversibility: moderate\n"
+        "source: manual\n"
+        "files_affected: []\n"
+        f"supersedes: {sup}\n"
+        f"superseded_by: {sup_by}\n"
+        "---\n\n"
+        f"# {num:03d} {_H1_SEP} {title}\n\n"
+        "## Decision\n\n"
+        f"{body}\n"
+    )
+
+
+def _write_decision(store: Path, num: int, slug: str, content: str) -> None:
+    (store / DECISIONS_DIR / f"{num:03d}-{slug}.md").write_text(content, encoding="utf-8")
+
+
+def _new_store(tmp_path, monkeypatch, name: str = "graphproj") -> Path:
+    """Register and scaffold a project, chdir into its repo, return the store."""
+    store = register_project(name, [tmp_path])
+    scaffold_project_store(name, store)
+    monkeypatch.chdir(tmp_path)
+    return store
+
+
+def _populated_store(tmp_path, monkeypatch) -> Path:
+    """A store with a supersession thread, a citation, and an open question."""
+    store = _new_store(tmp_path, monkeypatch)
+    _write_decision(
+        store,
+        2,
+        "rest-api",
+        _decision_md(
+            2,
+            "Use REST for the public API",
+            decision_type="api_design",
+            status="superseded",
+            superseded_by="4",
+            date="2026-03-16",
+            body="Pairs with the pagination decision D3 for the read surface.",
+        ),
+    )
+    _write_decision(
+        store,
+        3,
+        "offset-pagination",
+        _decision_md(
+            3,
+            "Paginate with offset and limit",
+            decision_type="api_design",
+            status="superseded",
+            superseded_by="4",
+            date="2026-03-17",
+        ),
+    )
+    _write_decision(
+        store,
+        4,
+        "graphql-gateway",
+        _decision_md(
+            4,
+            "Replace the REST surface with a GraphQL gateway",
+            decision_type="architecture",
+            supersedes="2",
+            date="2026-03-18",
+            body="Supersedes the REST surface. See D2 for the earlier reasoning.",
+        ),
+    )
+    (store / OPEN_QUESTIONS_MD).write_text(
+        "# Open Questions\n\n- [Q1] Should the gateway expose subscriptions.\n",
+        encoding="utf-8",
+    )
+    return store
+
+
+def _read_embedded_payload(html: str) -> dict:
+    """Extract and parse the embedded JSON payload from the rendered HTML.
+
+    Anchors on the explicit ``graph-payload`` sentinel comments rather than the
+    first ``</script>`` after the marker, so the helper does not depend on the
+    very escaping it would otherwise be used to verify.
+    """
+    start = html.index("<!--graph-payload-start-->") + len("<!--graph-payload-start-->")
+    end = html.index("<!--graph-payload-end-->")
+    block = html[start:end]
+    open_tag_end = block.index(">") + 1
+    close_tag = block.index("</script>")
+    return json.loads(block[open_tag_end:close_tag])
+
+
+def test_happy_path_writes_to_store_dir(tmp_path, monkeypatch, _no_browser):
+    store = _populated_store(tmp_path, monkeypatch)
+
+    result = runner.invoke(app, ["graph"])
+    assert result.exit_code == 0
+
+    out_path = store / "nauro-graph.html"
+    assert out_path.exists()
+    # The absolute path is printed to stdout.
+    assert str(out_path.resolve()) in result.output
+
+    html = out_path.read_text(encoding="utf-8")
+    payload = _read_embedded_payload(html)
+    numbers = {n["number"] for n in payload["nodes"]}
+    assert numbers == {2, 3, 4}
+    # The supersession thread lands in one component.
+    assert payload["components"]
+    component_nodes = set(payload["components"][0]["nodes"])
+    assert {2, 3, 4} <= component_nodes
+    # Content, not key-presence: the rendered markup carries the node titles.
+    assert "Replace the REST surface with a GraphQL gateway" in html
+    assert "Thread of 3 decisions" in html
+    # The open question renders.
+    assert "Should the gateway expose subscriptions." in html
+
+
+def test_supersession_relations_render_textually(tmp_path, monkeypatch, _no_browser):
+    """Each card states the decisions it supersedes or is superseded by."""
+    store = _populated_store(tmp_path, monkeypatch)
+
+    result = runner.invoke(app, ["graph"])
+    assert result.exit_code == 0
+    html = (store / "nauro-graph.html").read_text(encoding="utf-8")
+
+    # D4 retires D2 and D3 (a fan), so its card lists both targets.
+    assert "supersedes D2, D3" in html
+    # D2 and D3 each state they were superseded by D4.
+    assert "superseded by D4" in html
+
+
+def test_output_override_writes_there(tmp_path, monkeypatch, _no_browser):
+    _populated_store(tmp_path, monkeypatch)
+    target = tmp_path / "elsewhere" / "decision-graph.html"
+
+    result = runner.invoke(app, ["graph", "--output", str(target)])
+    assert result.exit_code == 0
+    assert target.exists()
+    assert str(target.resolve()) in result.output
+    # Default location must not also be written when overridden.
+    store_default = next((tmp_path).glob("**/nauro-graph.html"), None)
+    assert store_default is None
+
+
+def test_output_into_existing_directory(tmp_path, monkeypatch, _no_browser):
+    """--output naming a directory writes the default filename inside it."""
+    _populated_store(tmp_path, monkeypatch)
+    target_dir = tmp_path / "reports"
+    target_dir.mkdir()
+
+    result = runner.invoke(app, ["graph", "--output", str(target_dir)])
+    assert result.exit_code == 0
+    written = target_dir / "nauro-graph.html"
+    assert written.exists()
+    assert str(written.resolve()) in result.output
+
+
+def test_output_uses_lf_newlines(tmp_path, monkeypatch, _no_browser):
+    """The HTML is written with LF endings so its sha is platform-stable."""
+    store = _populated_store(tmp_path, monkeypatch)
+
+    result = runner.invoke(app, ["graph"])
+    assert result.exit_code == 0
+    raw = (store / "nauro-graph.html").read_bytes()
+    assert b"\r\n" not in raw
+
+
+def test_output_is_self_contained(tmp_path, monkeypatch, _no_browser):
+    """No resource sink (src/href/url()/@import) outside the embedded payload.
+
+    A blanket ``http(s)://`` substring scan would false-fail on an inert URL
+    sitting in a decision title; the meaningful invariant is that the document
+    loads no external resource, so the scan targets actual resource sinks in the
+    markup outside the JSON block.
+    """
+    store = _populated_store(tmp_path, monkeypatch)
+    # Put a URL in a decision title to prove the scan tolerates inert text.
+    _write_decision(
+        store,
+        5,
+        "link-in-title",
+        _decision_md(5, "Mirror docs at https://example.com/docs", date="2026-03-19"),
+    )
+
+    result = runner.invoke(app, ["graph"])
+    assert result.exit_code == 0
+    html = (store / "nauro-graph.html").read_text(encoding="utf-8")
+
+    # Strip the embedded JSON block; a URL inside a title is inert data there.
+    start = html.index("<!--graph-payload-start-->")
+    end = html.index("<!--graph-payload-end-->")
+    markup = html[:start] + html[end:]
+    for sink in ("src=", "href=", "url(", "@import"):
+        assert sink not in markup
+    # No distribution-template token leaks anywhere.
+    assert "<!-- protocol:" not in html
+    # No unrendered f-string field markers from the document template.
+    for marker in ("{title}", "{body}", "{styles}", "{footer}", "{payload_json}", "{script}"):
+        assert marker not in html
+
+
+def test_citation_toggle_defaults_off_and_color_scheme_present(tmp_path, monkeypatch, _no_browser):
+    """The citation checkbox ships unchecked and both color schemes are styled."""
+    store = _populated_store(tmp_path, monkeypatch)
+
+    result = runner.invoke(app, ["graph"])
+    assert result.exit_code == 0
+    html = (store / "nauro-graph.html").read_text(encoding="utf-8")
+
+    # The toggle ships unchecked: the rendered input carries no checked attr.
+    assert '<input id="citation-toggle" type="checkbox" />' in html
+    # Light is the base palette; dark is provided via prefers-color-scheme.
+    assert "prefers-color-scheme: dark" in html
+
+
+def test_api_design_lane_label(tmp_path, monkeypatch, _no_browser):
+    """The api_design lane renders as 'API design', not 'Api Design'."""
+    store = _new_store(tmp_path, monkeypatch)
+    _write_decision(store, 2, "rest", _decision_md(2, "Use REST", decision_type="api_design"))
+
+    result = runner.invoke(app, ["graph"])
+    assert result.exit_code == 0
+    html = (store / "nauro-graph.html").read_text(encoding="utf-8")
+    assert "API design" in html
+
+
+def test_unknown_project_exits_1(tmp_path, monkeypatch, _no_browser):
+    isolated = tmp_path / "isolated"
+    isolated.mkdir()
+    monkeypatch.chdir(isolated)
+
+    result = runner.invoke(app, ["graph", "--project", "does-not-exist"])
+    assert result.exit_code == 1
+
+
+def test_scaffold_only_store_renders_empty_state(tmp_path, monkeypatch, _no_browser):
+    """A fresh store holds only the scaffold seed, which is excluded; empty UI."""
+    store = _new_store(tmp_path, monkeypatch)
+
+    result = runner.invoke(app, ["graph"])
+    assert result.exit_code == 0
+    html = (store / "nauro-graph.html").read_text(encoding="utf-8")
+    assert "No decisions yet" in html
+    payload = _read_embedded_payload(html)
+    assert payload["nodes"] == []
+
+
+def test_empty_store_renders_empty_state(tmp_path, monkeypatch, _no_browser):
+    """A store with an empty decisions directory renders the empty state."""
+    store = _new_store(tmp_path, monkeypatch)
+    # Remove the scaffold seed so the decisions directory is genuinely empty.
+    for f in (store / DECISIONS_DIR).glob("*.md"):
+        f.unlink()
+
+    result = runner.invoke(app, ["graph"])
+    assert result.exit_code == 0
+    html = (store / "nauro-graph.html").read_text(encoding="utf-8")
+    assert "No decisions yet" in html
+
+
+def test_empty_state_still_shows_open_questions(tmp_path, monkeypatch, _no_browser):
+    """Zero decisions plus a flagged question still renders the question."""
+    store = _new_store(tmp_path, monkeypatch)
+    for f in (store / DECISIONS_DIR).glob("*.md"):
+        f.unlink()
+    (store / OPEN_QUESTIONS_MD).write_text(
+        "# Open Questions\n\n- [Q7] Which auth provider do we standardize on.\n",
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["graph"])
+    assert result.exit_code == 0
+    html = (store / "nauro-graph.html").read_text(encoding="utf-8")
+    assert "No decisions yet" in html
+    assert "Which auth provider do we standardize on." in html
+
+
+def test_open_by_default_calls_browser_with_output_path(tmp_path, monkeypatch, _no_browser):
+    store = _populated_store(tmp_path, monkeypatch)
+
+    result = runner.invoke(app, ["graph"])
+    assert result.exit_code == 0
+    out_path = store / "nauro-graph.html"
+    assert len(_no_browser) == 1
+    assert _no_browser[0] == out_path.resolve().as_uri()
+
+
+def test_no_open_does_not_call_browser(tmp_path, monkeypatch, _no_browser):
+    _populated_store(tmp_path, monkeypatch)
+
+    result = runner.invoke(app, ["graph", "--no-open"])
+    assert result.exit_code == 0
+    assert _no_browser == []
+
+
+def test_browser_open_failure_prints_hint(tmp_path, monkeypatch, _no_browser):
+    """On a headless host where webbrowser.open returns False, hint the path."""
+    store = _populated_store(tmp_path, monkeypatch)
+    monkeypatch.setattr("nauro.cli.commands.graph.webbrowser.open", lambda *a, **k: False)
+
+    result = runner.invoke(app, ["graph"])
+    assert result.exit_code == 0
+    out_path = (store / "nauro-graph.html").resolve()
+    assert "Could not open a browser" in result.output
+    assert str(out_path) in result.output
+
+
+def test_malformed_decision_is_skipped_with_warning(tmp_path, monkeypatch, _no_browser):
+    store = _populated_store(tmp_path, monkeypatch)
+    # A file that the strict parser rejects (missing required frontmatter).
+    _write_decision(store, 9, "broken", "---\nnot: valid frontmatter for a decision\n---\n\nbody\n")
+
+    result = runner.invoke(app, ["graph"])
+    assert result.exit_code == 0
+    assert "Skipping unreadable decision file" in result.output
+    assert "009-broken.md" in result.output
+
+    html = (store / "nauro-graph.html").read_text(encoding="utf-8")
+    payload = _read_embedded_payload(html)
+    numbers = {n["number"] for n in payload["nodes"]}
+    # The good decisions still render; the broken file is absent.
+    assert {2, 3, 4} <= numbers
+    assert 9 not in numbers
+
+
+def test_unreadable_decision_file_does_not_abort(tmp_path, monkeypatch, _no_browser):
+    """A subdirectory matching ``*.md`` is skipped, not fatal; the graph renders.
+
+    ``glob("*.md")`` matches directories too, and reading one raises ``IsADir``;
+    the read sits inside the per-file guard, so the command exits 0 with the good
+    decisions rendered and a warning naming the bad entry.
+    """
+    store = _populated_store(tmp_path, monkeypatch)
+    (store / DECISIONS_DIR / "099-a-directory.md").mkdir()
+
+    result = runner.invoke(app, ["graph"])
+    assert result.exit_code == 0
+    assert "Skipping unreadable decision file" in result.output
+    assert "099-a-directory.md" in result.output
+
+    html = (store / "nauro-graph.html").read_text(encoding="utf-8")
+    payload = _read_embedded_payload(html)
+    numbers = {n["number"] for n in payload["nodes"]}
+    assert {2, 3, 4} <= numbers
+
+
+def test_long_title_full_in_payload_truncated_in_display(tmp_path, monkeypatch, _no_browser):
+    store = _new_store(tmp_path, monkeypatch)
+    long_title = "Adopt the layered ingestion pipeline " + "x" * 400
+    _write_decision(store, 2, "long-title", _decision_md(2, long_title))
+
+    result = runner.invoke(app, ["graph"])
+    assert result.exit_code == 0
+    html = (store / "nauro-graph.html").read_text(encoding="utf-8")
+
+    payload = _read_embedded_payload(html)
+    node = next(n for n in payload["nodes"] if n["number"] == 2)
+    # Full title survives in the embedded payload.
+    assert node["title"] == long_title
+
+    # The visible label is truncated with an ellipsis; the 400-x run is not in
+    # the rendered node-title span.
+    title_span_open = '<span class="node-title">'
+    span_start = html.index(title_span_open) + len(title_span_open)
+    span_end = html.index("</span>", span_start)
+    visible = html[span_start:span_end]
+    assert "…" in visible
+    assert "x" * 400 not in visible
+
+
+def test_script_breakout_in_title_and_question_is_escaped(tmp_path, monkeypatch, _no_browser):
+    """A decision title and an open question carrying a script-closing tag plus
+    quotes and angle brackets must not break out of the embedded JSON or the
+    markup, and the payload must still parse. This is the load-critical pin.
+    """
+    store = _new_store(tmp_path, monkeypatch)
+    hostile = 'Title </script><script>alert("x")</script> & <b>bold</b> "quote\''
+    _write_decision(store, 2, "hostile", _decision_md(2, hostile))
+    (store / OPEN_QUESTIONS_MD).write_text(
+        '# Open Questions\n\n- [Q1] Body </script><img src=x onerror="y"> & "quote\'.\n',
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["graph"])
+    assert result.exit_code == 0
+    html = (store / "nauro-graph.html").read_text(encoding="utf-8")
+
+    # Exactly two real script elements close: the JSON block and the behavior
+    # script. A breakout would add a third.
+    assert html.count("</script>") == 2
+    # The injected raw tags never reach the document as live markup.
+    assert '<script>alert("x")</script>' not in html
+    assert '<img src=x onerror="y">' not in html
+
+    # The payload still parses and round-trips the hostile strings verbatim.
+    payload = _read_embedded_payload(html)
+    node = next(n for n in payload["nodes"] if n["number"] == 2)
+    assert node["title"] == hostile
+    assert payload["open_questions"][0]["body"].startswith("Body </script>")

--- a/packages/nauro/tests/test_sync/test_merge.py
+++ b/packages/nauro/tests/test_sync/test_merge.py
@@ -28,6 +28,17 @@ class TestShouldSkip:
     def test_decision_file(self):
         assert should_skip("decisions/001-foo.md") is False
 
+    def test_default_graph_output_is_skipped(self):
+        # The graph command's default output carries a generation timestamp that
+        # changes every run, so its sha never settles; syncing it would re-push
+        # the artifact endlessly and fan it out to every collaborator.
+        assert should_skip("nauro-graph.html") is True
+
+    def test_graph_output_under_subdir_is_not_skipped(self):
+        # Only the default store-root filename is guarded; a path the user chose
+        # via --output is their explicit choice and may sync.
+        assert should_skip("reports/nauro-graph.html") is False
+
 
 class TestIsAppendOnly:
     def test_decision_file(self):


### PR DESCRIPTION
## Why

The decision history is hard to read as a flat list once supersession threads
and one-to-many retirements accumulate. There is no way to see, at a glance,
which decisions retired which, where a thread branches, or how decisions cluster
by type over time. A pure payload builder already lands the structure; this
change gives a human a way to look at it.

## Approach

A hand-written `nauro graph` command reads the local store, builds the versioned
graph payload, and renders it into one self-contained read-only HTML document:
inline CSS, inline vanilla JS, no external network requests, no third-party
assets, no build step. The payload is embedded once as a JSON block the page
reads at load time.

The command is hand-written rather than part of the auto-generated tool surface
on purpose: it writes a file and opens a browser, side effects an MCP tool
result cannot model. The renderer is a separate module that consumes only the
payload dict, so a future hosted view can reuse the same payload shape without
a kernel change.

A lane-and-thread timeline was chosen over a force-directed node graph: most
decisions are isolated under supersession, so a force layout renders as a field
of unconnected dots. Lanes encode decision type and position encodes date.
Supersession relationships render as text on each card and lineage row
(supersedes, superseded by) derived from the component edges, with branch
points flagged; drawn connectors are future work and are not part of this
change. A third-party charting library was rejected to keep the file
self-contained and offline-openable.

## What changed

- A new graph package under the CLI holds the renderer: the HTML/CSS/JS
  template, payload embedding with script-breakout-safe escaping, textual
  supersession relations, word-boundary title truncation, theming via
  `prefers-color-scheme`, and an empty state that still lists open questions.
- A new `graph` command resolves the project, reads decisions leniently (a
  malformed or unreadable file is skipped with a warning instead of aborting),
  reads open questions, builds the payload, writes the HTML atomically with LF
  newlines, and opens it (with a printed hint when no browser is available).
- The default artifact name is excluded from sync so the generated file never
  rides the store's sync surface; a custom output path remains the user's
  choice.
- The command is registered as a flat command; the auto-generated tool surface
  is untouched.
- Docs: a principal-commands line in each CLAUDE.md and a command-surface line
  in the README noting the file embeds decision titles and metadata plus
  open-question summaries.

## What to review

- The payload embedding escape: the explicit replace chain on `<`, `>`, `&`
  is the guard that prevents a title containing a script-closing tag from
  breaking out of the embedded JSON block; an adversarial regression test
  pins it with hostile titles and question bodies, and the test helper
  extracts the payload via explicit sentinel comments rather than scanning
  for the first script close.
- Output defaults to the store directory, not the current directory. The HTML
  embeds decision titles and metadata plus open-question summaries, so a cwd
  default would invite committing that store extract into a repo; `--output`
  overrides, and pointing it at an existing directory writes the default
  filename inside it.
- The sync exclusion for the default artifact name: without it the generated
  file would enter the store sync loop and re-upload on every regeneration.
- The lenient per-file decision read: file reads sit inside the per-file
  guard, so an unreadable entry warns and the rest still renders; a comment
  explains why the kernel's store-protocol scan does not fit here.

## What's deferred

- A screenshot from a demo store can land in a follow-up doc change.
- Drawn thread connectors; relations are textual in this version.
- Citation edges render as a text layer behind a default-off toggle; a richer
  visual overlay is out of scope here.
- No pagination or virtualization for very large stores; the citation layer is
  default-off, so the heavy edge set is not built into the visible page until
  toggled.
- Small renderer cleanups (duplicate title attributes, eager citation text
  build, a dead style pair) are queued as a follow-up.

## Test plan

18 command and HTML tests plus sync and atomic-write pins, all under tmp_path
with HOME/NAURO_HOME isolation and `webbrowser.open` patched in every
invocation: happy path writing to the store directory with the absolute path
on stdout, `--output` override including the existing-directory case,
self-containment via a resource-sink scan that tolerates URLs in titles,
unknown project exits 1, scaffold-only and empty stores render the empty state
including open questions, open-by-default with a stderr hint when the browser
declines and `--no-open` suppressing, malformed and unreadable files skipped
with warnings at exit 0, long titles full in the payload and truncated in
display, the adversarial escaping regression, textual supersession relations,
citation toggle default off, color-scheme support, the API design lane label,
LF-byte output, and the default artifact name excluded from sync. Full suite:
1409 passed, 10 skipped; core suite green at 846.

Stacked on the graph payload-builder change and should merge after it.
