### PR TITLE
Extend graph payload with bodies and question references

### DIFF
--- a/packages/nauro-core/src/nauro_core/graph.py
+++ b/packages/nauro-core/src/nauro_core/graph.py
@@ -32,13 +32,14 @@ from nauro_core.validation import is_scaffold_seed
 
 # Graph payload schema version. Bump when the payload schema changes (a new
 # field, a renamed key, a changed value shape).
-GRAPH_PAYLOAD_VERSION = 1
+GRAPH_PAYLOAD_VERSION = 2
 
 
 def build_graph_payload(
     decisions: list[Decision],
     questions: OpenQuestionsFile | None = None,
     project: str = "",
+    include_bodies: bool = False,
 ) -> dict:
     """Build the decision-graph payload from parsed inputs. Pure; no I/O.
 
@@ -51,14 +52,20 @@ def build_graph_payload(
             duplicate never fabricates an edge attributed to the kept node.
         questions: Parsed open-questions file, or None. Only unresolved entries
             appear in the payload; each body is capped to its first line or
-            sentence.
+            sentence, and each entry carries the in-range decision numbers its
+            full body references.
         project: Display name for the rendered title. Carried through verbatim.
+        include_bodies: When True, each node dict gains a ``"body"`` key holding
+            the decision's full body markdown. Default False keeps the artifact
+            titles-and-metadata-only so the rendered file carries no decision
+            prose unless the caller asks for it (sensitivity posture). The key
+            is omitted entirely when False rather than emitted empty.
 
     Returns:
-        A JSON-shaped dict matching the v1 payload schema.
+        A JSON-shaped dict matching the v2 payload schema.
     """
     kept, duplicate_numbers = _collect_nodes(decisions)
-    nodes = [_node_dict(d) for d in kept]
+    nodes = [_node_dict(d, include_bodies) for d in kept]
     node_numbers = {d.num for d in kept}
     max_decision_number = max(node_numbers) if node_numbers else 0
 
@@ -67,7 +74,7 @@ def build_graph_payload(
         kept, node_numbers, max_decision_number, supersession_pairs
     )
     components, incident, branch_point_count = _build_components(supersession_edges)
-    open_questions = _filter_open_questions(questions)
+    open_questions = _filter_open_questions(questions, node_numbers, max_decision_number)
 
     isolated_node_count = len(node_numbers - incident)
 
@@ -139,16 +146,20 @@ def _collect_nodes(decisions: list[Decision]) -> tuple[list[Decision], list[int]
     return kept, duplicate_numbers
 
 
-def _node_dict(d: Decision) -> dict:
+def _node_dict(d: Decision, include_bodies: bool) -> dict:
     """Project a ``Decision`` onto the node schema.
 
     Parallel to ``operations/results.DecisionSummary`` (the list_decisions row
     projection); the two differ only in the type key name (``decision_type``
     here, ``type`` there) and the date being required here. Kept separate so a
     renderer change does not perturb the tool envelope.
+
+    When ``include_bodies`` is True the full body markdown is carried under a
+    ``"body"`` key; when False the key is omitted entirely (no empty string), so
+    the default artifact stays titles-and-metadata-only.
     """
     decision_type = d.decision_type.value if d.decision_type is not None else None
-    return {
+    node = {
         "number": d.num,
         "title": d.title,
         "status": d.status.value,
@@ -156,6 +167,9 @@ def _node_dict(d: Decision) -> dict:
         "confidence": d.confidence.value,
         "date": d.date.isoformat(),
     }
+    if include_bodies:
+        node["body"] = d.body
+    return node
 
 
 def _collect_supersession_edges(
@@ -296,20 +310,41 @@ def _build_components(
     return components, set(component_of), branch_point_count
 
 
-def _filter_open_questions(questions: OpenQuestionsFile | None) -> list[dict]:
-    """Return unresolved open-question entries with bodies capped to one unit.
+def _filter_open_questions(
+    questions: OpenQuestionsFile | None,
+    node_numbers: set[int],
+    max_decision_number: int,
+) -> list[dict]:
+    """Return unresolved open-question entries with capped bodies and references.
 
     Openness is annotation-authoritative via ``OpenQuestionsFile``'s public
     ``unresolved_entries`` (``resolved_by`` unset), regardless of where the
     entry sits relative to the ``## Resolved`` divider. Each included body is
-    capped to its first sentence or line.
+    capped to its first sentence or line for display.
+
+    ``references`` holds the decision numbers the entry's FULL body cites (body
+    plus every continuation line), not just the capped display body, scanned via
+    the shared ``scan_decision_references`` grammar and bounded to live nodes.
+    A reference to a number with no node (out of range, or no decision file)
+    is dropped. The list is sorted ascending. The renderer derives the reverse
+    direction (which decision a question points at) from this field, so the
+    payload carries only the question-to-decision direction.
     """
     if questions is None:
         return []
-    return [
-        {"id": entry.id, "body": _cap_to_first_unit(entry.body)}
-        for entry in questions.unresolved_entries
-    ]
+    result: list[dict] = []
+    for entry in questions.unresolved_entries:
+        full_body = "\n".join([entry.body, *entry.continuation])
+        cited = scan_decision_references(full_body, max_decision_number)
+        references = sorted(n for n in cited if n in node_numbers)
+        result.append(
+            {
+                "id": entry.id,
+                "body": _cap_to_first_unit(entry.body),
+                "references": references,
+            }
+        )
+    return result
 
 
 def _cap_to_first_unit(body: str) -> str:

--- a/packages/nauro-core/tests/test_graph.py
+++ b/packages/nauro-core/tests/test_graph.py
@@ -158,6 +158,17 @@ class TestNodes:
         payload = build_graph_payload([make_decision(3, decision_type=None)])
         assert payload["nodes"][0]["decision_type"] is None
 
+    def test_include_bodies_false_omits_body_key(self):
+        # Default keeps the artifact titles-and-metadata-only: no "body" key at
+        # all, not an empty string.
+        payload = build_graph_payload([make_decision(5, body="The full rationale prose.")])
+        assert "body" not in payload["nodes"][0]
+
+    def test_include_bodies_true_carries_verbatim_body(self):
+        body = "The full rationale prose.\n\nWith a second paragraph and detail."
+        payload = build_graph_payload([make_decision(5, body=body)], include_bodies=True)
+        assert payload["nodes"][0]["body"] == body
+
     def test_nodes_sorted_ascending(self):
         payload = build_graph_payload([make_decision(7), make_decision(2), make_decision(5)])
         assert [n["number"] for n in payload["nodes"]] == [2, 5, 7]
@@ -460,6 +471,47 @@ class TestOpenQuestionsFilter:
         assert payload["open_questions"] == []
 
 
+class TestOpenQuestionReferences:
+    def test_multiple_references_from_full_body(self):
+        # Two references in the question body resolve to a sorted list. Both
+        # decisions exist as nodes.
+        content = "# Open Questions\n- [Q1] Does D7 conflict with the D70 retirement?\n"
+        questions = OpenQuestionsFile.parse(content)
+        payload = build_graph_payload([make_decision(7), make_decision(70)], questions=questions)
+        assert payload["open_questions"][0]["references"] == [7, 70]
+
+    def test_reference_to_unknown_number_excluded(self):
+        # D999 is referenced but no such node exists; it is dropped, leaving the
+        # one live reference.
+        content = "# Open Questions\n- [Q1] Compare D7 against the abandoned D999 sketch.\n"
+        questions = OpenQuestionsFile.parse(content)
+        payload = build_graph_payload([make_decision(7)], questions=questions)
+        assert payload["open_questions"][0]["references"] == [7]
+
+    def test_references_scan_full_body_not_capped_display(self):
+        # The capped display body is the first sentence only; a reference living
+        # in a later sentence or a continuation line is still extracted because
+        # the scan reads the full body, not the cap.
+        content = (
+            "# Open Questions\n"
+            "- [Q1] First sentence with no reference. Later sentence cites D7.\n"
+            "  Continuation line cites D70.\n"
+        )
+        questions = OpenQuestionsFile.parse(content)
+        payload = build_graph_payload([make_decision(7), make_decision(70)], questions=questions)
+        q = payload["open_questions"][0]
+        # The display body is capped to the first sentence (no reference visible)
+        # yet both references are still carried.
+        assert q["body"] == "First sentence with no reference."
+        assert q["references"] == [7, 70]
+
+    def test_no_references_yields_empty_list(self):
+        content = "# Open Questions\n- [Q1] A question with no decision reference at all.\n"
+        questions = OpenQuestionsFile.parse(content)
+        payload = build_graph_payload([make_decision(7)], questions=questions)
+        assert payload["open_questions"][0]["references"] == []
+
+
 # ── Cycle guard ──
 
 
@@ -552,12 +604,14 @@ class TestStats:
 
 
 class TestPayloadVersionAndEmpty:
-    def test_payload_version_is_one(self):
+    def test_payload_version_is_two(self):
         payload = build_graph_payload([make_decision(2)])
-        assert payload["payload_version"] == 1
-        assert GRAPH_PAYLOAD_VERSION == 1
+        assert payload["payload_version"] == 2
+        assert GRAPH_PAYLOAD_VERSION == 2
 
     def test_no_findings_key(self):
+        # The no-findings pin stays true in v2: the payload carries graph data,
+        # never an analysis "findings" block.
         payload = build_graph_payload([make_decision(2)])
         assert "findings" not in payload
 
@@ -571,7 +625,7 @@ class TestPayloadVersionAndEmpty:
 
     def test_empty_input_well_formed(self):
         payload = build_graph_payload([])
-        assert payload["payload_version"] == 1
+        assert payload["payload_version"] == 2
         assert payload["nodes"] == []
         assert payload["supersession_edges"] == []
         assert payload["citation_edges"] == []


### PR DESCRIPTION
## Why

The graph payload carried decision titles and metadata only, and open-question entries surfaced no link to the decisions they reference. A renderer that draws lineage and links questions to decisions needs two things the payload did not provide: optional decision bodies for detail-on-demand, and the decision numbers each question cites so the link direction is derivable without client-side parsing.

## Approach

Extend the existing versioned payload rather than add a parallel shape. `build_graph_payload` gains `include_bodies` (default off) so the artifact stays titles-and-metadata-only unless the caller opts in, preserving the sensitivity posture that put the file in the store directory. Question references are extracted server-side from the full question body using the shared reference grammar already in nauro-core, so there is one home for that parsing and the renderer needs no fallback. The reverse direction (decision to questions) stays derivable in the renderer, so the payload carries only the forward direction. Version bumped to 2.

## What changed

- `build_graph_payload` adds `include_bodies`; when set, each node carries its full body markdown under a `body` key, omitted entirely when off (no empty strings).
- Open-question entries gain `references`: in-range decision numbers from the full body (body plus continuation lines, not the capped display body), bounded to live nodes, sorted ascending.
- `GRAPH_PAYLOAD_VERSION` is now 2.

## What to review

The reference scan reads the full body including continuation lines, which on the real store yields references the capped display body misses (a question whose first sentence has no reference but a later line does). Confirm the unknown-number and out-of-range exclusions still drop dead references.

## What's deferred

Nothing in this branch; the renderer that consumes these fields ships in the stacked branch.

## Test plan

Existing builder invariants stay green; the v1 version pins are updated to 2 explicitly and the no-findings pin is kept true in v2. New tests: multi-reference extraction, unknown-number exclusion, full-body-not-capped scan, and include_bodies omit/carry. nauro-core suite: 852 passed.
