### PR TITLE
Suppress overlapping hub labels in the graph view

### DIFF
--- a/packages/nauro/src/nauro/graph/html_render.py
+++ b/packages/nauro/src/nauro/graph/html_render.py
@@ -106,6 +106,11 @@ _GRAPH_LABEL_CLEARANCE = 26.0  # extra cluster radius reserved for labels
 _GRAPH_CLUSTER_PADDING = 40.0  # gap enforced between packed clusters
 _GRAPH_SPIRAL_STEP = 26.0  # radial step walked along the packing spiral
 _GRAPH_HUB_LABEL_LIMIT = 18  # hubs labelled at the default zoom
+# Conservative character-count text-box heuristic for the label overlap pass.
+# No DOM measurement is available at render time, so a label's box is estimated
+# from its character count, the same approach the insight pill already uses.
+_GRAPH_LABEL_CHAR_W = 7.0  # estimated width per character, in SVG user units
+_GRAPH_LABEL_LINE_H = 14.0  # estimated single-line text-box height
 
 
 def render_html(payload: dict, *, generated_at: str) -> str:
@@ -820,9 +825,12 @@ def _render_graph_view(
     Decisions are nodes (radius by degree, hue by category, filled when active /
     hollow ring when superseded, opacity by confidence). Supersession edges are
     always drawn and stronger; consolidation fan-ins are heaviest. Citation
-    edges are a faint always-on web. Only hubs are labelled at the default zoom;
-    every node carries its label in a data attribute for hover and search. The
-    SVG viewBox is fit to content so the initial view frames the whole map.
+    edges are a faint always-on web. Only hubs are labelled at the default zoom,
+    and a hub whose label box would collide with a higher-priority label is
+    suppressed so no two visible labels overlap; every node still carries its
+    label in a data attribute for hover and search, so a suppressed hub loses
+    nothing permanently. The SVG viewBox is fit to content so the initial view
+    frames the whole map.
     """
     nodes = payload.get("nodes", [])
     node_by_number = {n["number"]: n for n in nodes}
@@ -973,6 +981,92 @@ def _graph_hub_numbers(
     return hubs
 
 
+def _hub_label_text(num: int, title: str) -> str:
+    """The visible text of a hub label: ``D<n> <title>`` with the title capped.
+
+    Single source of truth for the label string so the suppression pass sizes
+    the box from exactly the text that is emitted.
+    """
+    label = title if len(title) <= 32 else title[:31].rstrip() + "…"
+    return f"D{num} {label}"
+
+
+def _hub_label_box(
+    num: int, title: str, x: float, y: float, r: float
+) -> tuple[float, float, float, float]:
+    """Estimate a hub label's text box as ``(x0, y0, x1, y1)``.
+
+    The label is anchored at the middle of ``x`` on a baseline at ``y - r - 6``
+    (the emit geometry below). Width is the character count times the per-glyph
+    estimate; the box rises one line height above the baseline. Conservative by
+    construction: the heuristic overshoots real glyph widths, so a box that does
+    not intersect here cannot collide on screen.
+    """
+    text = _hub_label_text(num, title)
+    width = len(text) * _GRAPH_LABEL_CHAR_W
+    baseline = y - r - 6
+    return (x - width / 2, baseline - _GRAPH_LABEL_LINE_H, x + width / 2, baseline)
+
+
+def _insight_label_text(num: int, meta: dict) -> str:
+    """The visible text of an insight pill: the ``short`` headline or ``D<n>``.
+
+    Single source of truth shared by the pill renderer and the suppression
+    pass so both size the box from the same string.
+    """
+    if meta["primary"] and meta.get("short"):
+        return meta["short"]
+    return f"D{num}"
+
+
+def _insight_label_box(
+    num: int, meta: dict, x: float, y: float, r: float
+) -> tuple[float, float, float, float]:
+    """Estimate an insight pill's box as ``(x0, y0, x1, y1)``.
+
+    Mirrors the pill geometry in ``_render_insight_labels`` exactly so the
+    suppression pass blocks against the same rectangle that renders.
+    """
+    pill_w = len(_insight_label_text(num, meta)) * _GRAPH_LABEL_CHAR_W + 12
+    pill_h = 18.0
+    px = x - pill_w / 2
+    py = y - r - 8 - pill_h
+    return (px, py, px + pill_w, py + pill_h)
+
+
+def _boxes_intersect(
+    a: tuple[float, float, float, float], b: tuple[float, float, float, float]
+) -> bool:
+    """True when two axis-aligned boxes overlap (edge contact does not count)."""
+    ax0, ay0, ax1, ay1 = a
+    bx0, by0, bx1, by1 = b
+    return not (ax1 <= bx0 or bx1 <= ax0 or ay1 <= by0 or by1 <= ay0)
+
+
+def _suppressed_hub_labels(
+    hub_labels: list[tuple[int, tuple[float, float, float, float]]],
+    insight_boxes: list[tuple[float, float, float, float]],
+    degree: dict[int, int],
+) -> set[int]:
+    """Return the hub numbers whose labels collide with a higher-priority box.
+
+    Priority order: insight labels first (never suppressed, but their boxes
+    block), then hub labels by degree descending, ties by decision number
+    ascending. The walk keeps every accepted box and suppresses any hub whose
+    box intersects one already accepted. Pure and deterministic: the same
+    payload yields the same suppression set.
+    """
+    accepted: list[tuple[float, float, float, float]] = list(insight_boxes)
+    suppressed: set[int] = set()
+    ordered = sorted(hub_labels, key=lambda item: (-degree.get(item[0], 0), item[0]))
+    for num, box in ordered:
+        if any(_boxes_intersect(box, kept) for kept in accepted):
+            suppressed.add(num)
+            continue
+        accepted.append(box)
+    return suppressed
+
+
 def _graph_nodes_and_labels(
     payload: dict,
     positions: dict[int, tuple[float, float]],
@@ -1003,6 +1097,32 @@ def _graph_nodes_and_labels(
             continue
         insight_target.setdefault(ins["target"], {"primary": i == 0, "short": ins.get("short")})
 
+    # Deterministic overlap suppression. Insight pills are pinned (never
+    # suppressed) but their boxes block lower-priority hub labels; remaining hub
+    # labels are accepted by descending degree and any whose box intersects an
+    # already-accepted box is dropped. Hover labels are untouched, so a suppressed
+    # hub still labels on hover and loses nothing permanently.
+    insight_boxes = [
+        _insight_label_box(num, meta, positions[num][0], positions[num][1], radii[num])
+        for num, meta in insight_target.items()
+        if num in positions
+    ]
+    hub_label_candidates = [
+        (
+            num,
+            _hub_label_box(
+                num,
+                node_by_number.get(num, {}).get("title", ""),
+                positions[num][0],
+                positions[num][1],
+                radii[num],
+            ),
+        )
+        for num in hubs
+        if num in positions and num not in insight_target
+    ]
+    suppressed_hubs = _suppressed_hub_labels(hub_label_candidates, insight_boxes, degree)
+
     node_svg: list[str] = []
     label_svg: list[str] = []
     for node in payload.get("nodes", []):
@@ -1032,14 +1152,15 @@ def _graph_nodes_and_labels(
         )
         # A node that carries a pinned insight pill must not also carry the regular
         # hub label: the pill is strictly more informative and two labels on one
-        # node overlap and read as noise. Suppress the hub label for insight nodes.
-        if num in hubs and num not in insight_target:
-            label = title if len(title) <= 32 else title[:31].rstrip() + "…"
+        # node overlap and read as noise. A hub label whose box collides with an
+        # accepted higher-priority box is suppressed by the overlap pass above.
+        # Both cases still label on hover, so nothing is lost permanently.
+        if num in hubs and num not in insight_target and num not in suppressed_hubs:
             ly = y - r - 6
             label_svg.append(
                 f'<text class="gnode-label" x="{x:.1f}" y="{ly:.1f}" '
                 f'text-anchor="middle" data-label-for="{num}">'
-                f"D{num} {_esc(label)}</text>"
+                f"{_esc(_hub_label_text(num, title))}</text>"
             )
 
     # Cluster labels for the sunflower discs sit under each disc.
@@ -1084,9 +1205,8 @@ def _render_insight_labels(
         x, y = positions[num]
         r = radii[num]
         primary = meta["primary"]
-        text = meta["short"] if primary and meta.get("short") else f"D{num}"
-        char_w = 7.0
-        pill_w = len(text) * char_w + 12
+        text = _insight_label_text(num, meta)
+        pill_w = len(text) * _GRAPH_LABEL_CHAR_W + 12
         pill_h = 18.0
         px = x - pill_w / 2
         py = y - r - 8 - pill_h

--- a/packages/nauro/tests/test_cli_graph.py
+++ b/packages/nauro/tests/test_cli_graph.py
@@ -1361,6 +1361,206 @@ def test_hub_label_suppressed_for_insight_labeled_nodes(tmp_path, monkeypatch):
         assert 'class="gnode-label" x=' not in graph or f'data-label-for="{num}"' not in graph
 
 
+# ── Hub-label overlap suppression ──
+#
+# These build the graph payload directly (so node degree and category are under
+# the test's control) and exercise the renderer's deterministic suppression pass
+# at the function level, the same way the packing-priority test does. A long
+# title widens a label's estimated box, and a dense same-category disc places
+# two nodes close enough that their wide boxes intersect, which is the live
+# overlap the pass exists to resolve.
+
+_LONG_LABEL_TITLE = "Adopt the layered hexagonal service architecture platform wide spanning title"
+
+
+def _disc_node(num: int, title: str, *, status: str = "active") -> dict:
+    """A single isolated-decision node for a directly-built graph payload."""
+    return {
+        "number": num,
+        "title": title,
+        "status": status,
+        "decision_type": "architecture",
+        "confidence": "high",
+        "date": "2026-03-15",
+    }
+
+
+def _emitted_label_nums(payload: dict) -> tuple[list[int], list[int]]:
+    """Render the node/label layer and return (hub-label nums, insight nums).
+
+    Runs the same layout and node/label render the Graph view uses, then reads
+    back which nodes carry a ``gnode-label`` text element and which carry a
+    pinned insight pill, so a test can assert exactly which hub labels survived
+    the suppression pass.
+    """
+    from nauro.graph.html_render import (
+        _compute_insights,
+        _graph_nodes_and_labels,
+        _question_reference_map,
+        _supersession_relations,
+        build_graph_layout,
+    )
+
+    relations = _supersession_relations(payload)
+    question_refs = _question_reference_map(payload)
+    layout = build_graph_layout(payload)
+    node_by_number = {n["number"]: n for n in payload["nodes"]}
+    insights = _compute_insights(payload, relations, question_refs)
+    _, label_layer = _graph_nodes_and_labels(
+        payload,
+        layout["positions"],
+        layout["radii"],
+        layout["degree"],
+        relations,
+        question_refs,
+        node_by_number,
+        layout["clusters"],
+        insights,
+    )
+
+    def _nums(attr: str) -> list[int]:
+        found: list[int] = []
+        pos = 0
+        marker = f'{attr}="'
+        while True:
+            i = label_layer.find(marker, pos)
+            if i == -1:
+                break
+            start = i + len(marker)
+            found.append(int(label_layer[start : label_layer.index('"', start)]))
+            pos = start
+        return sorted(set(found))
+
+    return _nums("data-label-for"), _nums("data-insight-for")
+
+
+def test_colliding_same_disc_hub_labels_keep_only_the_higher_degree():
+    """Two adjacent same-disc hubs whose label boxes collide emit one hub label.
+
+    Eight isolated architecture decisions form one dense sunflower disc. D2 and
+    D6 land adjacent and both carry a long title, so their estimated label boxes
+    intersect. D2 has the higher degree (it cites two decisions; D6 cites one),
+    so the suppression pass keeps D2 and drops D6. The citation targets are
+    superseded, so no anchor insight fires and the case is a clean hub-vs-hub
+    collision.
+    """
+    nodes = [
+        _disc_node(
+            num,
+            _LONG_LABEL_TITLE if num in (2, 6) else f"S{num}",
+            status="superseded" if num in (7, 8, 9) else "active",
+        )
+        for num in range(2, 10)
+    ]
+    payload = {
+        "nodes": nodes,
+        "supersession_edges": [],
+        # D2 cites two decisions (degree 2), D6 cites one (degree 1); the targets
+        # are superseded so the most-cited-active anchor metric stays undefined.
+        "citation_edges": [
+            {"from": 2, "to": 7},
+            {"from": 2, "to": 8},
+            {"from": 6, "to": 9},
+        ],
+        "components": [],
+        "open_questions": [],
+    }
+
+    hub_labels, insight_labels = _emitted_label_nums(payload)
+    assert insight_labels == []  # the fixture defines no insight target
+    # The higher-degree node of the colliding pair keeps its label; the lower one
+    # is suppressed. Every other node, uncolliding, keeps its label.
+    assert 2 in hub_labels
+    assert 6 not in hub_labels
+    assert hub_labels == [2, 3, 4, 5, 7, 8, 9]
+
+
+def test_insight_label_blocks_colliding_hub_but_is_never_suppressed():
+    """An insight pill survives and suppresses a hub whose box collides with it.
+
+    D2 is the most-cited active decision, so it carries the anchor insight pill,
+    and it sits adjacent to D6, a long-titled hub. D6's estimated label box
+    intersects D2's pill box. The insight pill is exempt from suppression but its
+    box still blocks, so D2 keeps its pill and D6's hub label is dropped.
+    """
+    nodes = [
+        _disc_node(
+            num,
+            _LONG_LABEL_TITLE if num in (2, 6) else f"S{num}",
+            status="superseded" if num in (3, 4, 5) else "active",
+        )
+        for num in range(2, 10)
+    ]
+    payload = {
+        "nodes": nodes,
+        "supersession_edges": [],
+        # D2 is cited three times by active short nodes, so it is the anchor.
+        "citation_edges": [
+            {"from": 3, "to": 2},
+            {"from": 4, "to": 2},
+            {"from": 5, "to": 2},
+        ],
+        "components": [],
+        "open_questions": [],
+    }
+
+    hub_labels, insight_labels = _emitted_label_nums(payload)
+    # D2 carries the (exempt) insight pill and never a hub label.
+    assert insight_labels == [2]
+    assert 2 not in hub_labels
+    # D6, the hub colliding with D2's pill, is suppressed; the rest keep labels.
+    assert 6 not in hub_labels
+    assert hub_labels == [3, 4, 5, 7, 8, 9]
+
+
+def test_suppression_pass_is_deterministic():
+    """The same payload yields the same emitted label set on every render."""
+    nodes = [
+        _disc_node(
+            num,
+            _LONG_LABEL_TITLE if num in (2, 6) else f"S{num}",
+            status="superseded" if num in (7, 8, 9) else "active",
+        )
+        for num in range(2, 10)
+    ]
+    payload = {
+        "nodes": nodes,
+        "supersession_edges": [],
+        "citation_edges": [
+            {"from": 2, "to": 7},
+            {"from": 2, "to": 8},
+            {"from": 6, "to": 9},
+        ],
+        "components": [],
+        "open_questions": [],
+    }
+
+    first = _emitted_label_nums(payload)
+    second = _emitted_label_nums(payload)
+    assert first == second
+
+
+def test_sparse_disc_keeps_every_hub_label():
+    """A sparse disc collides nowhere, so the pass suppresses nothing.
+
+    Four short-titled isolated decisions spread far enough apart that no two
+    estimated label boxes intersect, so every hub keeps its label and the pass
+    is a no-op. This pins the absence of over-suppression.
+    """
+    nodes = [_disc_node(num, f"Short title {num}") for num in (2, 3, 4, 5)]
+    payload = {
+        "nodes": nodes,
+        "supersession_edges": [],
+        "citation_edges": [],
+        "components": [],
+        "open_questions": [],
+    }
+
+    hub_labels, insight_labels = _emitted_label_nums(payload)
+    assert insight_labels == []
+    assert hub_labels == [2, 3, 4, 5]
+
+
 def test_story_chip_selection_state_and_aria(tmp_path, monkeypatch):
     """Chips ship unpressed and mirror selection into aria-pressed, date included.
 


### PR DESCRIPTION
## Why

In dense category discs the graph view renders overlapping hub labels. The view
labels the top hubs by degree at fixed offsets with no collision handling, so
two high-degree neighbours in the same disc both earn a label and their text
boxes overlap. A 72-decision store renders three overlapping hub-label pairs
inside its two densest discs.

## Approach

Extend the existing top-N hub selection with a deterministic suppression pass
that runs after selection, rather than changing how hubs are chosen or moving
labels to new offsets (which would fight the deterministic layout and could
push labels off other nodes). Each candidate label's box is estimated from its
character count, the same conservative heuristic the insight pill already uses,
since no DOM measurement is available at render time. Candidates are ordered
insight labels first (pinned story-strip pills, exempt from suppression, but
their boxes still block), then hub labels by degree descending with ties broken
by decision number ascending. Walking the ordered list, any hub label whose box
intersects an already-accepted box is dropped. The pass is pure, so the same
payload yields the same suppression set.

## What changed

- A new render-time suppression pass in the graph node/label renderer: box
  estimation helpers, an axis-aligned intersection test, and the ordered walk
  that returns the suppressed hub set.
- The hub-label and insight-pill text strings each gained a single-source-of-
  truth helper so the box estimate is sized from exactly the text that is
  emitted, and the insight pill now shares the extracted char-width constant.
- The label-emit guard skips suppressed hubs in addition to insight-target
  nodes; the graph-view docstring's hub-label sentence reflects the new
  behaviour.

## What to review

- The box geometry helpers must match the emit geometry exactly. The hub box is
  anchored at the same baseline the text element uses, and the insight box
  mirrors the pill rectangle, so the pass blocks against what actually renders.
- The priority ordering and the insight exemption in the suppression walk:
  insight boxes seed the accepted set and never enter the suppressed set, but
  they do block lower-priority hub labels.
- The estimate is intentionally conservative (it overshoots real glyph widths),
  so it can suppress a label whose glyphs would have just cleared. This trades a
  rare extra suppression for a guarantee of no visible overlap; the suppressed
  hub still labels on hover.

## What's deferred

Nothing functional. Hover labels are untouched, so every node still labels on
hover and a suppressed hub loses nothing permanently.

## Test plan

Four new renderer tests cover the colliding-pair winner, the insight-exemption
case, determinism, and a sparse no-over-suppression fixture, built directly from
graph payloads so node degree and positions are under test control. Existing
hub-label, insight-label, and layout-determinism pins are unchanged.

Verified empirically against the real 72-decision store: the three known
overlapping pairs each now show one label, with zero overlaps measured against
the rendered SVG, and a sparse store keeps all its labels.

1442 nauro tests pass (4 new), 852 nauro-core tests pass; ruff check and format
clean.
