### PR TITLE
Align the demo open question and package readme with the enriched store

### DIFF
--- a/packages/nauro/README.md
+++ b/packages/nauro/README.md
@@ -30,14 +30,14 @@ You'll see a JSON envelope with the related decisions and a deterministic assess
   "related_decisions": [
     {
       "id": "decision-004",
-      "title": "SSE over WebSocket for live task updates",
-      "score": 5.015,
+      "title": "SSE over WebSocket for live updates",
+      "score": 6.117,
       "status": "active",
       "date": "2026-03-15",
       "rationale_preview": "Server-Sent Events (SSE) for pushing live task updates..."
     }
   ],
-  "assessment": "Found 5 related decisions. Top match: D004 \"SSE over WebSocket for live task updates\"..."
+  "assessment": "Found 5 related decisions. Top match: D004 \"SSE over WebSocket for live updates\"..."
 }
 ```
 

--- a/packages/nauro/src/nauro/demo/__init__.py
+++ b/packages/nauro/src/nauro/demo/__init__.py
@@ -408,7 +408,7 @@ with refresh tokens and RBAC.
 
 OPEN_QUESTIONS_MD = """\
 # Open Questions
-- [Q1] Should we add rate limiting at the API gateway or application layer?
+- [Q1] Should gateway rate limit quotas differ per client tier, or stay uniform?
 - [Q2] Redis vs in-memory caching for session storage?
 """
 

--- a/packages/nauro/tests/test_demo.py
+++ b/packages/nauro/tests/test_demo.py
@@ -80,7 +80,7 @@ class TestDemoProjectStructure:
 
     def test_open_questions_has_content(self, demo_store):
         content = (demo_store / constants.OPEN_QUESTIONS_MD).read_text()
-        assert "rate limiting" in content
+        assert "rate limit quotas" in content
         assert "Redis" in content
 
     def test_project_md_has_content(self, demo_store):


### PR DESCRIPTION
## Why

Two small consistency defects landed with the demo-store enrichment, caught in external review after the merge. The seeded open question asked whether rate limiting should live at the gateway or the application layer, while the same demo now seeds an active decision settling exactly that; the demo was teaching that a settled decision has an unresolved question, which is the failure the product exists to catch. Separately, the package readme shipped to the package index still carried the pre-enrichment captured quickstart output, which is no longer reproducible.

## What changed

- The seeded question now asks the follow-up that presupposes the gateway decision: "Should gateway rate limit quotas differ per client tier, or stay uniform?" A cross-check confirms no seeded open question contradicts any seeded active decision.
- The package readme's captured excerpt was re-run against the enriched demo store in an isolated home directory and updated to the verified output (top match title, score 6.117, assessment line, five results), never hand-edited.
- One test assertion updated to pin the new question phrasing.

## Test plan

Full nauro suite 1446 passed, 10 skipped; nauro-core 852 passed; ruff check and format clean. The capture was reproduced in isolation so the real store was never touched.
