### PR TITLE
Release versions: nauro 0.12.7, nauro-core 0.13.10

### DIFF
--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro-core"
-version = "0.13.9"
+version = "0.13.10"
 description = "Shared pure-Python logic for Nauro: parsing, validation, context assembly, constants."
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro"
-version = "0.12.6"
+version = "0.12.7"
 description = "Local CLI + MCP server: set your project's doctrine once, every connected AI agent inherits it."
 readme = "README.md"
 license = "Apache-2.0"
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "nauro-core>=0.13.9,<0.14",
+    "nauro-core>=0.13.10,<0.14",
     "typer>=0.9",
     "httpx>=0.24",
     "mcp>=1.0",


### PR DESCRIPTION
## Why

Everything shipped since 0.12.6 is merged but unpublished: the graph command and its four-view renderer, the payload builder and shared parsing helpers in the core package, the label-overlap suppression, and the enriched demo store. The published core package predates the graph kernel, so the CLI release requires a core release alongside it.

## What changed

- nauro-core version 0.13.9 to 0.13.10: the first published version carrying the graph payload builder, the shared reference-scan and sentence-boundary helpers, and the public unresolved-questions and scaffold-seed accessors.
- nauro version 0.12.6 to 0.12.7, with the nauro-core constraint floor raised to 0.13.10 so the published wheel resolves a core that has the modules it imports.

Pyproject-only, per the release convention; publishing is tag-triggered after merge (core tag first, then the CLI tag, so the dependency exists on the index before anything needs it).

## Test plan

Full suites on the bumped tree: 1446 passed (10 skipped) and 852 passed; ruff check clean. Post-merge: push `nauro-core-v0.13.10`, verify it lands on the index, then push `nauro-v0.12.7`, then a clean-environment install smoke test of `nauro graph`.
