### PR TITLE
Add the graph command to the package readme

### DIFF
--- a/packages/nauro/README.md
+++ b/packages/nauro/README.md
@@ -43,6 +43,8 @@ You'll see a JSON envelope with the related decisions and a deterministic assess
 
 The demo project ruled out WebSocket because persistent connections weren't released during ECS rolling deploys. Without Nauro, a fresh agent has no record of that and would re-propose WebSocket.
 
+`nauro graph` renders the store to one self-contained HTML file and opens it: a node-link map of every decision as the default view, plus drawn supersession lineage, a timeline, and a category browser. The demo store's consolidation, three retired decisions converging on the one that replaced them, draws as a fan. By default the file carries decision titles and metadata only and lands in the store directory rather than your repo; `--include-bodies` embeds full decision bodies.
+
 For real-project setup (`nauro init` / `nauro adopt`), cross-surface access, MCP tool reference, and architecture details, see the [main project README](https://github.com/nauro-ai/nauro#readme). Don't run `nauro setup` from `/tmp/nauro-demo`; that would wire the throwaway demo into your MCP client.
 
 `nauro adopt --with-subagents` additionally installs Nauro's bundled Claude Code workflow subagents (`@nauro-planner`, `@nauro-executor`, `@nauro-reviewer`, `@nauro-tech-lead`) into `~/.claude/agents/`. Off by default to avoid overwriting locally-customized files; pass `--force-overwrite` to replace customized files.


### PR DESCRIPTION
## Why

The readme shipped to the package index carries the quickstart and the conflict-catch walkthrough but never mentions the graph command, so the index page omits the release's headline feature. The page links to the project readme, which covers it, but the index copy should stand on its own.

## What changed

One paragraph after the demo walkthrough: the graph command renders the store to one self-contained HTML file (node-link map default, supersession lineage, timeline, category browser), the demo store's consolidation draws as a fan, the file carries titles and metadata only by default and lands in the store directory, with the bodies flag noted. No other content changes.

## Test plan

Full nauro suite 1446 passed, 10 skipped; ruff clean. The paragraph reaches the package index at the next release; nothing else depends on it.
