### PR TITLE
Fix empty query in local stdio search_decisions header

### DIFF
--- a/packages/nauro-core/src/nauro_core/renderers.py
+++ b/packages/nauro-core/src/nauro_core/renderers.py
@@ -196,12 +196,20 @@ def _decision_title_header(body: str) -> str:
     return ""
 
 
-def render_search_decisions(result: dict) -> str:
-    """Render BM25 search results."""
+def render_search_decisions(result: dict, query: str | None = None) -> str:
+    """Render BM25 search results.
+
+    ``query`` is render-time display context for the result header. The
+    kernel envelope intentionally omits the echoed query (a verbatim copy
+    of the caller's argument, pruned at the operations cutover), so the
+    local stdio transport threads it here via renderer kwargs. When given
+    it takes precedence; the remote transport, whose wire envelope still
+    carries ``query``, keeps rendering via the dict fallback.
+    """
     if "error" in result:
         return _error_block(result["error"])
 
-    query = result.get("query", "")
+    query = query if query is not None else result.get("query", "")
     hits = result.get("results") or []
     total = result.get("total_matches", len(hits))
     truncated = bool(result.get("truncated"))

--- a/packages/nauro-core/tests/test_renderers.py
+++ b/packages/nauro-core/tests/test_renderers.py
@@ -331,6 +331,46 @@ class TestRenderSearchDecisions:
         assert text.startswith("Error:")
         assert "non-empty" in text
 
+    def _local_envelope(self):
+        """A local-transport envelope: no echoed ``query`` key (kernel prune)."""
+        return {
+            "store": "local",
+            "results": [
+                {
+                    "number": 7,
+                    "title": "Adopt BM25 ranking",
+                    "date": "2026-05-10",
+                    "status": "active",
+                    "relevance_snippet": "snippet",
+                    "score": 9.0,
+                }
+            ],
+        }
+
+    def test_query_kwarg_renders_header_without_dict_key(self):
+        # The local envelope carries no "query" key; the kwarg must supply it.
+        text = render_search_decisions(self._local_envelope(), query="lexical ranking")
+        assert 'for "lexical ranking"' in text
+
+    def test_missing_query_falls_back_to_empty_header(self):
+        # Without the kwarg and without a dict key, the header degrades to the
+        # empty string (the pre-fix local behavior) rather than raising.
+        text = render_search_decisions(self._local_envelope())
+        assert 'for ""' in text
+
+    def test_query_kwarg_takes_precedence_over_dict_key(self):
+        result = {**self._local_envelope(), "query": "dict-query"}
+        text = render_search_decisions(result, query="kwarg-query")
+        assert 'for "kwarg-query"' in text
+        assert "dict-query" not in text
+
+    def test_dict_query_still_renders_when_no_kwarg(self):
+        # Backward compatibility: the remote calls renderer(result) positionally
+        # and relies on the echoed "query" key in its wire envelope.
+        result = {**self._local_envelope(), "query": "remote-query"}
+        text = render_search_decisions(result)
+        assert 'for "remote-query"' in text
+
 
 class TestRenderListDecisions:
     def test_empty_returns_guidance(self):

--- a/packages/nauro/src/nauro/mcp/stdio_server.py
+++ b/packages/nauro/src/nauro/mcp/stdio_server.py
@@ -263,7 +263,10 @@ def search_decisions(
         result = {"store": "local", "status": "error", "guidance": str(exc)}
     else:
         result = tool_search_decisions(store_path, query, limit, include_superseded)
-    return _wrap_with_renderer("search_decisions", result)
+    # The kernel envelope omits the echoed query (pruned at the operations
+    # cutover); thread it to the renderer so the local header shows the term,
+    # matching the remote transport, which still carries query in its envelope.
+    return _wrap_with_renderer("search_decisions", result, {"query": query})
 
 
 @mcp.tool(**_spec_kwargs("check_decision"))

--- a/packages/nauro/tests/test_search_decisions_parity.py
+++ b/packages/nauro/tests/test_search_decisions_parity.py
@@ -103,6 +103,16 @@ def _stdio_rendered(pid: str, query: str, *, limit: int = 10) -> str:
     return result.content[0].text
 
 
+def _rendered(tool: dict, query: str) -> str:
+    """Reference render for the parity comparison.
+
+    The stdio surface threads the caller's ``query`` into the renderer (the
+    envelope intentionally omits the echoed key), so the reference render
+    must receive the same ``query`` to stay an apples-to-apples comparison.
+    """
+    return RENDERERS["search_decisions"](tool, query=query)
+
+
 def _tool_envelope(store_path: Path, query: str, *, limit: int = 10) -> dict:
     """Direct call to the local tool, no transport wrapper."""
     return tool_search_decisions(store_path, query, limit)
@@ -111,7 +121,7 @@ def _tool_envelope(store_path: Path, query: str, *, limit: int = 10) -> dict:
 def test_hit_envelope_matches_across_surfaces(seeded_repo):
     pid, store_path = seeded_repo
     tool = _tool_envelope(store_path, "Auth0")
-    assert _stdio_rendered(pid, "Auth0") == RENDERERS["search_decisions"](tool)
+    assert _stdio_rendered(pid, "Auth0") == _rendered(tool, "Auth0")
     assert tool["store"] == "local"
     assert "results" in tool
     assert tool["results"], "Auth0 query must surface at least one hit"
@@ -128,7 +138,7 @@ def test_hit_envelope_matches_across_surfaces(seeded_repo):
 def test_empty_store_envelope_matches_across_surfaces(empty_repo):
     pid, store_path = empty_repo
     tool = _tool_envelope(store_path, "anything")
-    assert _stdio_rendered(pid, "anything") == RENDERERS["search_decisions"](tool)
+    assert _stdio_rendered(pid, "anything") == _rendered(tool, "anything")
     assert tool.pop("project")["id"] == pid
     assert tool == {"store": "local", "results": []}
 
@@ -146,5 +156,5 @@ def test_empty_query_rejection_matches_across_surfaces(seeded_repo):
 def test_limit_truncates_across_surfaces(seeded_repo):
     pid, store_path = seeded_repo
     tool = _tool_envelope(store_path, "Auth0 FastAPI", limit=1)
-    assert _stdio_rendered(pid, "Auth0 FastAPI", limit=1) == RENDERERS["search_decisions"](tool)
+    assert _stdio_rendered(pid, "Auth0 FastAPI", limit=1) == _rendered(tool, "Auth0 FastAPI")
     assert len(tool["results"]) <= 1

--- a/packages/nauro/tests/test_stdio_renderer_wrap.py
+++ b/packages/nauro/tests/test_stdio_renderer_wrap.py
@@ -90,8 +90,13 @@ class TestSingleBlockReadTools:
         assert isinstance(result, CallToolResult)
         blocks = result.content
         assert len(blocks) == 1
-        # Rendered block echoes the query and surfaces the D### label.
-        assert "FastAPI" in blocks[0].text
+        # The header echoes the caller's query. Asserting the exact header
+        # substring (not just "FastAPI" anywhere) guards the kernel-envelope
+        # prune of the echoed query: the term also appears in the matched
+        # decision's title, so a bare membership check passes even when the
+        # header renders the empty string. ``for "FastAPI"`` only appears when
+        # the query is threaded through to the renderer.
+        assert 'for "FastAPI"' in blocks[0].text
 
     def test_check_decision_returns_single_block(self, seeded_store: Path):
         result = check_decision(


### PR DESCRIPTION
## Why

On the local stdio MCP surface, `search_decisions` rendered its header as `Found N matches for ""` with the query missing. The renderer pulls the query from the result dict, but the kernel result envelope intentionally omits the echoed query (it was pruned along with the other redundant echoed/derivable keys at the operations-kernel cutover). The remote transport re-injects `query` into its wire envelope, so the remote surface renders the header correctly; the local stdio adapter does not, so the local header degrades to an empty string. Functionally minor, but it makes the local surface look broken and drops the one piece of context that tells the reader what was searched.

## Approach

Thread the query to the renderer as render-time display context through the existing `renderer_kwargs` channel (the same mechanism `get_decision` already uses to pass `mode`), rather than re-adding `query` to the envelope. This keeps the envelope prune intact and leaves the remote path untouched.

`render_search_decisions` gains an optional `query` parameter that takes precedence over the dict key; when it is absent the renderer falls back to the dict key, so the remote's positional `renderer(result)` call keeps working unchanged. The alternative of re-adding `query`/`total_matches` to the kernel `SearchDecisionsResult` model was rejected: that would undo the deliberate envelope prune and reintroduce a key that is a verbatim echo of the caller's argument.

## What changed

- `nauro-core/renderers.py`: `render_search_decisions` accepts an optional `query`, preferring it over `result["query"]`.
- `nauro/mcp/stdio_server.py`: the local `search_decisions` tool threads its `query` argument into the renderer kwargs.
- Tests: strengthened the stdio block test to assert the exact header substring, added renderer unit tests for kwarg precedence / dict fallback / empty-when-absent, and updated the local parity reference render to thread the same query.

## What to review

- The precedence logic in `renderers.py`: `query if query is not None else result.get("query", "")`. An empty-string kwarg is honored as-is; the error path returns before the query is used, so the empty-query rejection render is unaffected.
- The parity test change: the envelope assertions (`"query" not in tool`, `"total_matches" not in tool`) are unchanged, confirming the fix adds nothing to the envelope. Only the reference render now receives the same query the stdio surface threads.
- The prior stdio test passed despite the bug because the query term ("FastAPI") also appears in the matched decision's title. The new assertion checks `for "FastAPI"`, which only the header produces.

## What's deferred

- The remote transport still carries `query`, `total_matches`, and `truncated` in its wire envelope (a transport-owned wire-shape choice); not changed here.
- The local surface still does not render the "Results truncated" notice, since `truncated`/`total_matches` are derivable counts the local envelope omits. Out of scope for this header fix.

## Test plan

- `pytest packages/nauro-core/tests/`: 856 passed. `pytest packages/nauro/tests/`: 1446 passed, 10 skipped.
- `ruff check packages/` and `ruff format --check packages/`: clean.
- Manual: local stdio `search_decisions(query="embedding model retrieval")` now renders `Found 3 matches for "embedding model retrieval":` against the live store.
