### PR TITLE
Index rejected-alternative names in the BM25 retrieval corpus

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,13 @@ The demo store holds thirteen example decisions. One of them ruled out WebSocket
     {
       "id": "decision-004",
       "title": "SSE over WebSocket for live updates",
-      "score": 6.117,
+      "score": 6.635,
       "status": "active",
       "date": "2026-03-15",
       "rationale_preview": "Server-Sent Events (SSE) for pushing live task updates to the frontend. SSE uses standard HTTP, reconnects automatically on disconnect, and works through every proxy and load balancer..."
     }
   ],
-  "assessment": "Found 5 related decisions. Top match: D004 \"SSE over WebSocket for live updates\" (status active, decided 2026-03-15, BM25 6.1). Call get_decision on each related decision before proposing.",
+  "assessment": "Found 5 related decisions. Top match: D004 \"SSE over WebSocket for live updates\" (status active, decided 2026-03-15, BM25 6.6). Call get_decision on each related decision before proposing.",
   "project": { "id": "01K...", "name": "demo-project" }
 }
 ```

--- a/packages/nauro-core/src/nauro_core/search.py
+++ b/packages/nauro-core/src/nauro_core/search.py
@@ -1,7 +1,16 @@
 """BM25 search over decisions.
 
 Builds an in-memory BM25 index per call using bm25s + PyStemmer.
-Index text: title + rationale for each decision.
+Index text per decision: title + rationale + rejected-alternative names.
+
+Rejected names are indexed because they carry the vocabulary of paths the
+project declined — the bridge for two conflict classes the title+rationale
+text cannot reach: a cross-vocabulary supersession whose only shared token
+lives in a rejected alternative's name, and a proposal that revisits an
+explicitly-rejected path. Rejected reasons stay out of the index: they tie
+on conflict catch but dilute ranking and inflate scores on verbose
+unrelated queries (reason prose rewards verbosity; names carry the
+declined path's identity).
 """
 
 from __future__ import annotations
@@ -13,6 +22,18 @@ from nauro_core.decision_model import Decision, DecisionStatus
 from nauro_core.parsing import extract_relevance_snippet, first_sentence_end
 
 _stemmer = Stemmer.Stemmer("english")
+
+
+def _index_text(d: Decision) -> str:
+    """The BM25 corpus document for one decision.
+
+    Title + rationale + rejected-alternative names (names only — see the
+    module docstring for why reasons are excluded). Shared by
+    :func:`bm25_search` and :func:`bm25_retrieve` so the two retrieval
+    paths rank over the same corpus by construction.
+    """
+    names = " ".join(r.name for r in d.rejected)
+    return f"{d.title} {d.rationale} {names}" if names else f"{d.title} {d.rationale}"
 
 
 def bm25_search(
@@ -28,7 +49,7 @@ def bm25_search(
     if not decisions or not query or not query.strip():
         return []
 
-    corpus = [f"{d.title} {d.rationale}" for d in decisions]
+    corpus = [_index_text(d) for d in decisions]
     # show_progress=False — bm25s defaults to True; the tqdm output is invisible
     # in MCP server stderr but pollutes the `nauro check-decision` CLI surface.
     corpus_tokens = bm25s.tokenize(corpus, stopwords="en", stemmer=_stemmer, show_progress=False)
@@ -93,7 +114,7 @@ def bm25_retrieve(
     if not active or not query_text or not query_text.strip():
         return []
 
-    corpus = [f"{d.title} {d.rationale}" for d in active]
+    corpus = [_index_text(d) for d in active]
     corpus_tokens = bm25s.tokenize(
         corpus, stopwords=stopwords, stemmer=_stemmer, show_progress=False
     )

--- a/packages/nauro-core/tests/test_search.py
+++ b/packages/nauro-core/tests/test_search.py
@@ -6,6 +6,7 @@ from nauro_core.decision_model import (
     Decision,
     DecisionConfidence,
     DecisionStatus,
+    RejectedAlternative,
 )
 from nauro_core.search import bm25_retrieve, bm25_search
 
@@ -47,6 +48,23 @@ DECISIONS = [
         "Current scope is single-repo. Multi-repo sync adds complexity "
         "that is not justified at launch.",
         status="superseded",
+    ),
+    Decision(
+        date=date(2026, 4, 7),
+        confidence=DecisionConfidence.medium,
+        status=DecisionStatus.active,
+        num=5,
+        title="Stay on Python for the CLI",
+        rationale="The ecosystem fit and developer velocity outweigh "
+        "distribution friction at current scale.",
+        rejected=[
+            RejectedAlternative(
+                name="Rewrite the CLI in Golang for a static binary",
+                reason="A full rewrite costs weeks for marginal distribution "
+                "gains; PyInstaller packaging covers single-file installs if "
+                "they become a requirement.",
+            )
+        ],
     ),
 ]
 
@@ -96,6 +114,18 @@ class TestBm25Search:
         assert len(results) >= 1
         assert results[0]["relevance_snippet"]
 
+    def test_rejected_name_vocabulary_is_indexed(self):
+        """A query matching only a rejected alternative's name surfaces the
+        decision — the revisits-a-rejected-path conflict class."""
+        results = bm25_search(DECISIONS, "Golang static binary")
+        assert any(r["number"] == 5 for r in results)
+
+    def test_rejected_reason_vocabulary_is_not_indexed(self):
+        """Reasons stay out of the index: a token appearing only in a
+        rejected alternative's reason must not match."""
+        results = bm25_search(DECISIONS, "PyInstaller packaging")
+        assert not any(r["number"] == 5 for r in results)
+
 
 class TestBm25Retrieve:
     def test_returns_related(self):
@@ -123,6 +153,16 @@ class TestBm25Retrieve:
     def test_top_k(self):
         related = bm25_retrieve(DECISIONS, "server session authentication", top_k=1)
         assert len(related) <= 1
+
+    def test_rejected_name_vocabulary_is_indexed(self):
+        """check_decision's retrieval path indexes rejected names too, so a
+        proposal that revisits a rejected path surfaces the deciding record."""
+        related = bm25_retrieve(DECISIONS, "compile a static Golang binary")
+        assert any(r["number"] == 5 for r in related)
+
+    def test_rejected_reason_vocabulary_is_not_indexed(self):
+        related = bm25_retrieve(DECISIONS, "PyInstaller packaging")
+        assert not any(r["number"] == 5 for r in related)
 
 
 class TestBm25SilencesProgressBars:

--- a/packages/nauro/README.md
+++ b/packages/nauro/README.md
@@ -31,7 +31,7 @@ You'll see a JSON envelope with the related decisions and a deterministic assess
     {
       "id": "decision-004",
       "title": "SSE over WebSocket for live updates",
-      "score": 6.117,
+      "score": 6.635,
       "status": "active",
       "date": "2026-03-15",
       "rationale_preview": "Server-Sent Events (SSE) for pushing live task updates..."


### PR DESCRIPTION
## Why

The BM25 retrieval corpus behind `search_decisions` and `check_decision` indexes `title + rationale` only. The Rejected Alternatives section, present in most decisions, is parsed into a structured block and never reaches the index. That text carries the vocabulary of paths the project declined, and its absence leaves two conflict classes unreachable: a cross-vocabulary supersession whose only bridging token lives in a rejected alternative's name, and a proposal that revisits an explicitly-rejected path. Measured on the live store across 48 real supersession events, the exclusion costs 2 catches at top-5, including one the opt-in embedding union also misses.

## Approach

Add rejected-alternative names to the corpus document, via a shared helper so both retrieval paths rank over the same corpus by construction. Names only, and the scope is measured rather than a hedge: indexing reasons as well ties on conflict catch but dilutes ranking (MRR 0.747 vs 0.783) and inflates scores on verbose unrelated queries (novel-proposal score ceiling 11.8 to 16.0), because reason prose rewards verbosity while names carry the declined path's identity. Names alone leave a 17-query novel-proposal control battery statistically unchanged (top-1 median 7.72 vs 7.85 baseline).

Alternatives measured and declined: indexing reasons as well (above), title-weighting variants (tie exactly on catch, no win nearby), and reaching for the embedding union instead (recovers only rank-6/7 near-misses and misses the cross-vocabulary case this change recovers).

## What changed

- `nauro-core/search.py`: corpus document becomes `title + rationale + rejected names` through a new `_index_text()` helper used by both `bm25_search` and `bm25_retrieve`; module docstring records the names-only scope and its reasoning.
- Tests: four new cases pinning both sides of the scope, rejected-name vocabulary is retrievable through both retrieval paths, and reason-only vocabulary is not.
- Readmes: the quickstart's captured demo output is regenerated empirically against the new index (same top match, same five results, score 6.117 to 6.635 because the demo decisions carry rejected alternatives).

## What to review

- The names-only boundary in `_index_text()`: reasons are deliberately excluded, and `test_rejected_reason_vocabulary_is_not_indexed` pins that in both paths. If a future change widens the corpus, that test should force the discussion.
- The regenerated readme capture was produced by running the real demo flow against this branch in an isolated `NAURO_HOME`, not by hand-editing numbers.
- `propose_decision`'s advisory similar-decisions pass rides the same kernel, so it inherits the new corpus automatically; no separate change needed there.

## What's deferred

- The embedding-pool corpus stays `title + rationale`: the union flag is off in production and its measured baselines were taken on that text; widening it is a separate measured change if the flag ever defaults on.
- Field weighting of the rejected text: swept, no signal demanding it.

## Test plan

- `pytest packages/nauro-core/tests/`: 860 passed (4 new). `pytest packages/nauro/tests/`: 1446 passed, 10 skipped.
- `ruff check` and `ruff format --check`: clean.
- Offline evaluation against the live store through the real kernel: conflict catch@5 44/48 to 46/48 across all query-length regimes with zero regressions, MRR 0.783; novel-proposal control battery unchanged (median 7.72 vs 7.85, max 11.86 vs 11.80).
- Manual: demo quickstart reproduces the captured readme output exactly on this branch.
