### PR TITLE
Align the ship-task skill copy with how the chain actually runs

### DIFF
--- a/.agents/skills/nauro-ship-task/SKILL.md
+++ b/.agents/skills/nauro-ship-task/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nauro-ship-task
-description: Run the full planner -> executor -> reviewer -> tech-lead -> user-confirm -> push chain for a non-trivial code change against Nauro's bundled @nauro-* subagents. Gates on the user whenever the planner or executor will file a Nauro decision; runs @nauro-tech-lead Mode C between reviewer-APPROVE and the push gate to catch doctrine drift the reviewer missed. Invoke explicitly with /nauro-ship-task <description>. Requires `nauro adopt --with-subagents` to have run.
+description: Run the full planner -> executor -> reviewer -> tech-lead -> user-confirm -> push chain for a non-trivial code change against Nauro's bundled @nauro-* subagents. Gates on the user whenever the planner or tech-lead will file a Nauro decision; the executor never files. Runs @nauro-tech-lead Mode C between reviewer-APPROVE and the push gate to catch doctrine drift the reviewer missed. A prompt that carries a detailed implementation spec or a pasted handoff is still chain input, not license to implement directly. Dispatches the bundled subagents on Claude Code only. Invoke explicitly with /nauro-ship-task <description>. Requires `nauro adopt --with-subagents` to have run.
 ---
 
 # Nauro ship task skill
@@ -11,7 +11,9 @@ Take the user's task description from the prompt that invoked this skill. If the
 
 ## Prerequisites
 
-This skill invokes the bundled `@nauro-*` subagents by name. They install via `nauro adopt --with-subagents` (or `nauro setup all --with-subagents`). If they are missing, the chain cannot run — surface that to the user and stop. The personal-subagent path (`@planner` / `@executor` / `@reviewer` without the `nauro-` prefix) is not a substitute: the bundled subagents call Nauro's MCP tools by design, which is what makes the doctrine gates load-bearing.
+This skill invokes the bundled `@nauro-*` subagents by name. They install via `nauro adopt --with-subagents` (or `nauro setup all --with-subagents`) and dispatch on Claude Code only. If they are missing, or the current surface cannot spawn subagents, the chain cannot run; surface that to the user and stop. Do not reproduce the chain inline in the main session: the gates depend on the subagents' restricted tool access, and an inline imitation runs without those restrictions. The personal-subagent path (`@planner` / `@executor` / `@reviewer` without the `nauro-` prefix) is not a substitute either — the bundled subagents call Nauro's MCP tools by design, which is what makes the doctrine gates load-bearing.
+
+The bundled subagents follow the session's model — chain quality tracks the model the session runs.
 
 ## Execute the chain without waiting for the user to prompt each step
 
@@ -83,6 +85,7 @@ On approval, push the branch and open the PR with the drafted description as the
 
 ## Rules
 
+- A fully specified task still goes through the planner — the spec becomes the planner's input, not a reason to skip the chain and implement directly.
 - Push and `gh pr create` happen only with explicit user approval at GATE 7.
 - `propose_decision` happens only with explicit user approval. Subagents draft or surface decisions; they never file an unapproved one. After the user approves in chat, the originating agent files — the planner for plan-time decisions, `@nauro-tech-lead` for doctrine moves it surfaces in Mode C. The executor never files; it surfaces emergent choices in its handoff (step 3) for the parent to gate. The kernel commits immediately on Tier 1 clean.
 - If a `propose_decision` is pending but the Nauro MCP server is disconnected, that is a hard pause — do not push the PR and file the decision after reconnecting. The code and its decision land together; a push-now-file-later split leaves doctrine unrecorded if the session ends first. Surface the disconnect and wait.

--- a/.claude/skills/nauro-ship-task/SKILL.md
+++ b/.claude/skills/nauro-ship-task/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nauro-ship-task
-description: Run the full planner -> executor -> reviewer -> tech-lead -> user-confirm -> push chain for a non-trivial code change against Nauro's bundled @nauro-* subagents. Gates on the user whenever the planner or executor will file a Nauro decision; runs @nauro-tech-lead Mode C between reviewer-APPROVE and the push gate to catch doctrine drift the reviewer missed. Invoke explicitly with /nauro-ship-task <description>. Requires `nauro adopt --with-subagents` to have run.
+description: Run the full planner -> executor -> reviewer -> tech-lead -> user-confirm -> push chain for a non-trivial code change against Nauro's bundled @nauro-* subagents. Gates on the user whenever the planner or tech-lead will file a Nauro decision; the executor never files. Runs @nauro-tech-lead Mode C between reviewer-APPROVE and the push gate to catch doctrine drift the reviewer missed. A prompt that carries a detailed implementation spec or a pasted handoff is still chain input, not license to implement directly. Dispatches the bundled subagents on Claude Code only. Invoke explicitly with /nauro-ship-task <description>. Requires `nauro adopt --with-subagents` to have run.
 ---
 
 # Nauro ship task skill
@@ -11,7 +11,9 @@ Take the user's task description from the prompt that invoked this skill. If the
 
 ## Prerequisites
 
-This skill invokes the bundled `@nauro-*` subagents by name. They install via `nauro adopt --with-subagents` (or `nauro setup all --with-subagents`). If they are missing, the chain cannot run — surface that to the user and stop. The personal-subagent path (`@planner` / `@executor` / `@reviewer` without the `nauro-` prefix) is not a substitute: the bundled subagents call Nauro's MCP tools by design, which is what makes the doctrine gates load-bearing.
+This skill invokes the bundled `@nauro-*` subagents by name. They install via `nauro adopt --with-subagents` (or `nauro setup all --with-subagents`) and dispatch on Claude Code only. If they are missing, or the current surface cannot spawn subagents, the chain cannot run; surface that to the user and stop. Do not reproduce the chain inline in the main session: the gates depend on the subagents' restricted tool access, and an inline imitation runs without those restrictions. The personal-subagent path (`@planner` / `@executor` / `@reviewer` without the `nauro-` prefix) is not a substitute either — the bundled subagents call Nauro's MCP tools by design, which is what makes the doctrine gates load-bearing.
+
+The bundled subagents follow the session's model — chain quality tracks the model the session runs.
 
 ## Execute the chain without waiting for the user to prompt each step
 
@@ -83,6 +85,7 @@ On approval, push the branch and open the PR with the drafted description as the
 
 ## Rules
 
+- A fully specified task still goes through the planner — the spec becomes the planner's input, not a reason to skip the chain and implement directly.
 - Push and `gh pr create` happen only with explicit user approval at GATE 7.
 - `propose_decision` happens only with explicit user approval. Subagents draft or surface decisions; they never file an unapproved one. After the user approves in chat, the originating agent files — the planner for plan-time decisions, `@nauro-tech-lead` for doctrine moves it surfaces in Mode C. The executor never files; it surfaces emergent choices in its handoff (step 3) for the parent to gate. The kernel commits immediately on Tier 1 clean.
 - If a `propose_decision` is pending but the Nauro MCP server is disconnected, that is a hard pause — do not push the PR and file the decision after reconnecting. The code and its decision land together; a push-now-file-later split leaves doctrine unrecorded if the session ends first. Surface the disconnect and wait.

--- a/.cursor/rules/nauro-ship-task.mdc
+++ b/.cursor/rules/nauro-ship-task.mdc
@@ -1,5 +1,5 @@
 ---
-description: Run the full planner -> executor -> reviewer -> tech-lead -> user-confirm -> push chain for a non-trivial code change against Nauro's bundled @nauro-* subagents. Gates on the user whenever the planner or executor will file a Nauro decision; runs @nauro-tech-lead Mode C between reviewer-APPROVE and the push gate to catch doctrine drift the reviewer missed. Invoke explicitly with /nauro-ship-task <description>. Requires `nauro adopt --with-subagents` to have run.
+description: Run the full planner -> executor -> reviewer -> tech-lead -> user-confirm -> push chain for a non-trivial code change against Nauro's bundled @nauro-* subagents. Gates on the user whenever the planner or tech-lead will file a Nauro decision; the executor never files. Runs @nauro-tech-lead Mode C between reviewer-APPROVE and the push gate to catch doctrine drift the reviewer missed. A prompt that carries a detailed implementation spec or a pasted handoff is still chain input, not license to implement directly. Dispatches the bundled subagents on Claude Code only. Invoke explicitly with /nauro-ship-task <description>. Requires `nauro adopt --with-subagents` to have run.
 alwaysApply: false
 ---
 
@@ -11,7 +11,9 @@ Take the user's task description from the prompt that invoked this skill. If the
 
 ## Prerequisites
 
-This skill invokes the bundled `@nauro-*` subagents by name. They install via `nauro adopt --with-subagents` (or `nauro setup all --with-subagents`). If they are missing, the chain cannot run — surface that to the user and stop. The personal-subagent path (`@planner` / `@executor` / `@reviewer` without the `nauro-` prefix) is not a substitute: the bundled subagents call Nauro's MCP tools by design, which is what makes the doctrine gates load-bearing.
+This skill invokes the bundled `@nauro-*` subagents by name. They install via `nauro adopt --with-subagents` (or `nauro setup all --with-subagents`) and dispatch on Claude Code only. If they are missing, or the current surface cannot spawn subagents, the chain cannot run; surface that to the user and stop. Do not reproduce the chain inline in the main session: the gates depend on the subagents' restricted tool access, and an inline imitation runs without those restrictions. The personal-subagent path (`@planner` / `@executor` / `@reviewer` without the `nauro-` prefix) is not a substitute either — the bundled subagents call Nauro's MCP tools by design, which is what makes the doctrine gates load-bearing.
+
+The bundled subagents follow the session's model — chain quality tracks the model the session runs.
 
 ## Execute the chain without waiting for the user to prompt each step
 
@@ -83,6 +85,7 @@ On approval, push the branch and open the PR with the drafted description as the
 
 ## Rules
 
+- A fully specified task still goes through the planner — the spec becomes the planner's input, not a reason to skip the chain and implement directly.
 - Push and `gh pr create` happen only with explicit user approval at GATE 7.
 - `propose_decision` happens only with explicit user approval. Subagents draft or surface decisions; they never file an unapproved one. After the user approves in chat, the originating agent files — the planner for plan-time decisions, `@nauro-tech-lead` for doctrine moves it surfaces in Mode C. The executor never files; it surfaces emergent choices in its handoff (step 3) for the parent to gate. The kernel commits immediately on Tier 1 clean.
 - If a `propose_decision` is pending but the Nauro MCP server is disconnected, that is a hard pause — do not push the PR and file the decision after reconnecting. The code and its decision land together; a push-now-file-later split leaves doctrine unrecorded if the session ends first. Surface the disconnect and wait.

--- a/packages/nauro/src/nauro/skills/__init__.py
+++ b/packages/nauro/src/nauro/skills/__init__.py
@@ -38,10 +38,14 @@ SKILL_DESCRIPTIONS: dict[str, str] = {
         "Run the full planner -> executor -> reviewer -> tech-lead -> "
         "user-confirm -> push chain for a non-trivial code change against "
         "Nauro's bundled @nauro-* subagents. Gates on the user whenever the "
-        "planner or executor will file a Nauro decision; runs @nauro-tech-lead "
-        "Mode C between reviewer-APPROVE and the push gate to catch doctrine "
-        "drift the reviewer missed. Invoke explicitly with /nauro-ship-task "
-        "<description>. Requires `nauro adopt --with-subagents` to have run."
+        "planner or tech-lead will file a Nauro decision; the executor never "
+        "files. Runs @nauro-tech-lead Mode C between reviewer-APPROVE and the "
+        "push gate to catch doctrine drift the reviewer missed. A prompt that "
+        "carries a detailed implementation spec or a pasted handoff is still "
+        "chain input, not license to implement directly. Dispatches the "
+        "bundled subagents on Claude Code only. Invoke explicitly with "
+        "/nauro-ship-task <description>. Requires `nauro adopt "
+        "--with-subagents` to have run."
     ),
     "nauro-handoff": (
         "Captures a session handoff to Nauro's project store so the next agent "

--- a/packages/nauro/src/nauro/skills/ship_task_body.md
+++ b/packages/nauro/src/nauro/skills/ship_task_body.md
@@ -13,7 +13,9 @@ Take the user's task description from the prompt that invoked this skill. If the
 
 ## Prerequisites
 
-This skill invokes the bundled `@nauro-*` subagents by name. They install via `nauro adopt --with-subagents` (or `nauro setup all --with-subagents`). If they are missing, the chain cannot run — surface that to the user and stop. The personal-subagent path (`@planner` / `@executor` / `@reviewer` without the `nauro-` prefix) is not a substitute: the bundled subagents call Nauro's MCP tools by design, which is what makes the doctrine gates load-bearing.
+This skill invokes the bundled `@nauro-*` subagents by name. They install via `nauro adopt --with-subagents` (or `nauro setup all --with-subagents`) and dispatch on Claude Code only. If they are missing, or the current surface cannot spawn subagents, the chain cannot run; surface that to the user and stop. Do not reproduce the chain inline in the main session: the gates depend on the subagents' restricted tool access, and an inline imitation runs without those restrictions. The personal-subagent path (`@planner` / `@executor` / `@reviewer` without the `nauro-` prefix) is not a substitute either — the bundled subagents call Nauro's MCP tools by design, which is what makes the doctrine gates load-bearing.
+
+The bundled subagents follow the session's model — chain quality tracks the model the session runs.
 
 ## Execute the chain without waiting for the user to prompt each step
 
@@ -85,6 +87,7 @@ On approval, push the branch and open the PR with the drafted description as the
 
 ## Rules
 
+- A fully specified task still goes through the planner — the spec becomes the planner's input, not a reason to skip the chain and implement directly.
 - Push and `gh pr create` happen only with explicit user approval at GATE 7.
 - `propose_decision` happens only with explicit user approval. Subagents draft or surface decisions; they never file an unapproved one. After the user approves in chat, the originating agent files — the planner for plan-time decisions, `@nauro-tech-lead` for doctrine moves it surfaces in Mode C. The executor never files; it surfaces emergent choices in its handoff (step 3) for the parent to gate. The kernel commits immediately on Tier 1 clean.
 - If a `propose_decision` is pending but the Nauro MCP server is disconnected, that is a hard pause — do not push the PR and file the decision after reconnecting. The code and its decision land together; a push-now-file-later split leaves doctrine unrecorded if the session ends first. Surface the disconnect and wait.

--- a/packages/nauro/tests/_skill_surfaces.py
+++ b/packages/nauro/tests/_skill_surfaces.py
@@ -14,7 +14,12 @@ from pathlib import Path
 
 from nauro_core import MCP_INSTRUCTIONS_STATIC
 
-from nauro.skills import load_adopt_body, load_context_body, load_handoff_body
+from nauro.skills import (
+    load_adopt_body,
+    load_context_body,
+    load_handoff_body,
+    load_ship_task_body,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
@@ -25,6 +30,7 @@ def load_docs_adopt_prompt() -> str:
 
 SKILL_SURFACES: dict[str, Callable[[], str]] = {
     "adopt_body.md": load_adopt_body,
+    "ship_task_body.md": load_ship_task_body,
     "handoff_body.md": load_handoff_body,
     "context_body.md": load_context_body,
     "MCP_INSTRUCTIONS_STATIC": lambda: MCP_INSTRUCTIONS_STATIC,


### PR DESCRIPTION
## Why

The `nauro-ship-task` skill copy had drifted from how the chain actually runs, on four points:

1. **Executor-filing misstatement.** The frontmatter description and the Rules body implied the executor could file a Nauro decision. It never does. A subagent has no user channel mid-run, so the executor surfaces emergent choices in its handoff for the parent to gate, and only the planner (plan-time) or tech-lead (Mode C doctrine) file.
2. **False install-remedy.** Prerequisites told the reader that if the chain cannot run, the fix is installing the subagents. That is wrong on any surface that cannot spawn subagents at all: the bundled subagents dispatch on Claude Code only, and no install makes them run elsewhere.
3. **No spec-trigger cue.** A documented bypass is treating a fully specified task or pasted handoff as license to implement inline. The copy gave no cue that such a prompt is still planner input, not a reason to skip the chain.
4. **No model disclosure.** Nothing told the reader that the bundled subagents follow the session's model, so chain quality tracks whatever model the session runs.

## Approach

Edit the single source of truth (the description string in `skills/__init__.py` and the `ship_task_body.md` template) and regenerate the three rendered surface files (`.claude` / `.cursor` / `.agents`) from source in the same commit. The alternative of hand-editing the rendered files is structurally excluded: the byte-equality drift tests assert each dogfood file equals `render_skill(...)`, so a hand-edit that skips the source would fail CI.

Separately, the ship-task body is added to the scanned-surface registry (`_skill_surfaces.py`). That registry drives both the retired-phrase guard and the tool-signature scan, so registering the body extends those guards to the heaviest skill body; previously only the adopt, handoff, and context bodies were covered.

## What changed

- **Skill description** (`skills/__init__.py`): rewritten to say the executor never files, that a detailed spec or pasted handoff is still chain input, and that dispatch is Claude Code only.
- **Skill body** (`ship_task_body.md`): Prerequisites paragraph rewritten (Claude-Code-only dispatch, surface-cannot-spawn case, no-inline-imitation); a model-disclosure line appended; a new first Rules bullet added on routing a fully specified task through the planner.
- **Rendered surfaces**: the three `nauro-ship-task` dogfood files regenerated from source.
- **Test registry** (`_skill_surfaces.py`): `ship_task_body.md` registered and imported.

## What to review

- The description string renders as an unquoted YAML scalar in surface frontmatter. Confirm there is no colon-space sequence that would re-parse it as a nested mapping (verified locally; the frontmatter parses to a flat `{name, description}` dict).
- The body edits preserve every anchor the drift test asserts (`Mode C`, `--with-subagents`, the four subagent names, `propose_decision`).

## What's deferred

- **Per-surface install behavior.** Skills currently materialize uniformly on all surfaces; the copy now states the runtime truth (Claude-Code-only dispatch) but the install path is unchanged. Differentiating materialization per surface is out of scope.
- **Anything in the plugins repo.** This change is confined to the CLI's bundled skill sources and rendered dogfood files.

## Test plan

- `test_skills_drift.py` + `test_skill_tool_signatures.py`: 148 passed, including the newly registered `ship_task_body.md` surface across the parametrized retired-phrase and tool-signature guards, plus the byte-equality checks on the regenerated dogfood files.
- Full `packages/nauro/tests/`: 1466 passed, 10 skipped.
- `packages/nauro-core/tests/`: 860 passed (cross-package safety check).
- `ruff check packages/` clean; `ruff format --check packages/` reports 251 files already formatted.
