### PR TITLE
Bump nauro-core to 0.13.11 and nauro to 0.13.0

### DIFF
--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro-core"
-version = "0.13.10"
+version = "0.13.11"
 description = "Shared pure-Python logic for Nauro: parsing, validation, context assembly, constants."
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro"
-version = "0.12.7"
+version = "0.13.0"
 description = "Local CLI + MCP server: set your project's doctrine once, every connected AI agent inherits it."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
Version bumps for the next release pair.

- nauro-core 0.13.11: rejected-alternative names indexed into the BM25 retrieval corpus; empty-query fix in the local stdio search_decisions header. Stays inside the mcp-server pin band.
- nauro 0.13.0: session resume converged into the nauro-context skill (the separate handoff skill is removed, hence the minor bump), bundled subagents inherit the session model, ship-task skill copy aligned with the chain's real behavior, graph paragraph added to the package readme, retrieval benchmark harness.

Pyproject-only per the release convention; publish is tag-triggered after merge (core tag first, then nauro).