### PR TITLE
Correct adopt skill body drift from kernel behavior

### DIFF
--- a/.agents/skills/nauro-adopt/SKILL.md
+++ b/.agents/skills/nauro-adopt/SKILL.md
@@ -12,7 +12,7 @@ The agent helps the user seed Nauro with context from the current repo. Before t
 The agent's behaviour depends on whether the surface can read the repo directly.
 
 - **Filesystem-capable surfaces** (Claude Code, Cursor, Codex CLI). The agent runs Steps 1–11 in full. Docs are read for rationale in Step 3; code, config, tests, manifests, and recent git history are inspected for evidence in Step 4; targeted probes in Step 6b turn evidence into rationale by asking the user.
-- **Chat surfaces** (Claude.ai, Perplexity). The agent has no shell. It operates only on content the user pastes into the chat (Step 3b), and only against an already-adopted project (verified in Step 2). The code-evidence path (Step 4) and the Step 6b probes are unavailable; the agent does not ask the user to paste code in lieu of running shell commands. The skill skips from Step 3b directly to Step 5.
+- **Chat surfaces** (Claude.ai, Perplexity). The agent has no shell. It operates only on content the user pastes into the chat (Step 3b), and only against an already-adopted project (verified in Step 3b). Steps 1, 2, and 4 are filesystem-bound and are skipped on chat surfaces; the Step 6b probes are likewise unavailable, and the agent does not ask the user to paste code in lieu of running shell commands. The skill skips from Step 3b directly to Step 5.
 
 ## Step 1 — Detect repo root
 
@@ -53,7 +53,11 @@ When filesystem read is unavailable (chat surfaces), the agent first verifies th
 
 > Has this repo been adopted via `nauro adopt` locally? Tell me the project name and id, or paste `<repo>/.nauro/config.json`.
 
-If the user cannot confirm an adopted project, the agent surfaces "Run `nauro adopt` locally first, then return here" and stops. Once the project is confirmed, the agent prompts for source content:
+If the user cannot confirm an adopted project, the agent surfaces "Run `nauro adopt` locally first, then return here" and stops.
+
+A typed project name or id is not taken on faith. The agent calls the `list_projects` tool and matches the user's answer against the projects it returns; on no match, the agent surfaces the listed project names and asks the user to pick one. A project adopted locally but absent from the list is local-only — it needs `nauro link` before chat mode can reach it.
+
+Once the project is confirmed, the agent prompts for source content:
 
 > This skill needs source content. Paste the contents of any of: README, manifest (pyproject.toml/package.json/etc.), ADRs, Memory-Bank files. Send each as a separate message labelled with the filename.
 
@@ -77,7 +81,7 @@ Step 4 ends with a list of observations, not a list of candidate decisions. Prom
 
 ## Step 5 — Call get_context
 
-The agent calls `get_context` (MCP) to surface what the scaffold already wrote — `001-initial-setup.md` and bracketed-prompt placeholders in `project.md` / `stack.md`. The agent uses this to (a) avoid duplicating the scaffold's first decision, (b) confirm the project resolved correctly, and (c) learn what `check_decision` will treat as the existing baseline in Step 7.
+The agent calls `get_context` (MCP) to surface what the scaffold already wrote — `001-initial-setup.md` and bracketed-prompt placeholders in `project.md` / `stack.md`. The agent uses this to (a) avoid duplicating the scaffold's first decision, (b) confirm the project resolved correctly, and (c) know what Step 7's `check_decision` calls will and will not see: `check_decision` filters the scaffold seed from its results by design, so on a fresh store it returns a no-decisions-yet assessment — expected, not a failure — and catching a duplicate of the `001-initial-setup` seed is the agent's job from this step onward. The seed remains visible via `get_context` and `list_decisions`.
 
 ## Step 6 — Triage candidates
 
@@ -95,7 +99,7 @@ Filesystem-capable surfaces only. For each Step 4 observation that points at a r
 
 > I see X in file/path; was Y considered; what pushed you toward X?
 
-Substitute `X` with the observed fact, `file/path` with the source it came from, and `Y` with a credible alternative the agent inferred (or "an alternative" if none is obvious). Probes are batched into one message; the user replies per item:
+Substitute `X` with the observed fact, `file/path` with the source it came from, and `Y` with a credible alternative the agent inferred (or "an alternative" if none is obvious). Probes are batched into one message, capped at eight in the first batch and ordered highest-leverage first — workspace shape, framework picks, and CI / IaC targets before lint and test conventions. When more observations remain, the batch message must end with the line "N more observations remain — say 'more probes' to see them", so nothing is silently dropped. The user replies per item:
 
 > Reply 'rationale N: <why>' to record it as a decision (it flows into the Step 7 write loop), 'inventory N' to drop it to stack inventory (6c), 'question N' to flag it as an open question (Step 9), or 'skip N' to drop it entirely.
 
@@ -111,7 +115,7 @@ Languages, frameworks, package managers, license, lint tooling, and similar fact
 
 For each kept candidate from 6a and each rationale-supplied 6b answer, the agent runs the full propose protocol:
 
-1. Call `check_decision(proposed_approach=<title or short description>, project_id=...)`. `check_decision` returns related decisions via BM25 retrieval and a deterministic assessment. It does NOT judge conflicts.
+1. Call `check_decision(proposed_approach=<for a 6a candidate: the title plus the one-line summary; for a 6b candidate: the observed fact plus the core of the rationale the user supplied>, project_id=...)`. `check_decision` returns related decisions via BM25 retrieval and a deterministic assessment. It does NOT judge conflicts.
 2. When the response lists related decisions, call `get_decision` on each before proposing — `mode=header` to triage, `mode=full` for those you reason about; the assessment doesn't judge. Call signature: `get_decision(number=N, project_id=...)`.
 3. Classify the operation:
     - **add** (default; new ground, no existing decision covers it).
@@ -160,7 +164,7 @@ If Step 6c produced inventory items, append a short trailing section:
 - ...
 ```
 
-If only one of activeContext / progress / inventory is present, the corresponding sections are omitted. If none is present, `update_state` is skipped entirely. **The agent does not call `update_state` per progress item or per inventory entry** — `update_state` archives prior state to history, and the L0 payload ignores history.
+If only one of activeContext / progress / inventory is present, the corresponding sections are omitted. If none is present, `update_state` is skipped entirely. The composed delta must stay under 5,000 characters — `update_state` rejects longer deltas at the boundary. When the activeContext body alone would exceed the cap, condense it to the current focus and the most recent items rather than pasting it whole. Never split the delta across multiple `update_state` calls: each call replaces the state, so a second call clobbers the first. **The agent does not call `update_state` per progress item or per inventory entry** — `update_state` archives prior state to history, and the L0 payload ignores history.
 
 ## Step 9 — Flag open questions
 
@@ -190,4 +194,4 @@ The agent prints one block:
 - Decisions skipped: `M` (titles)
 - State updated: `yes`/`no`
 - Open questions flagged: `K`
-- Next: run `nauro sync` from the repo to capture a snapshot.
+- Next: on filesystem-capable surfaces, the agent tells the user that `nauro sync` captures a snapshot and regenerates `AGENTS.md` in the project's associated repos, and offers to run it, proceeding only on user confirmation. On chat surfaces, the agent instructs the user to run `nauro sync` from the repo.

--- a/.claude/skills/nauro-adopt/SKILL.md
+++ b/.claude/skills/nauro-adopt/SKILL.md
@@ -12,7 +12,7 @@ The agent helps the user seed Nauro with context from the current repo. Before t
 The agent's behaviour depends on whether the surface can read the repo directly.
 
 - **Filesystem-capable surfaces** (Claude Code, Cursor, Codex CLI). The agent runs Steps 1–11 in full. Docs are read for rationale in Step 3; code, config, tests, manifests, and recent git history are inspected for evidence in Step 4; targeted probes in Step 6b turn evidence into rationale by asking the user.
-- **Chat surfaces** (Claude.ai, Perplexity). The agent has no shell. It operates only on content the user pastes into the chat (Step 3b), and only against an already-adopted project (verified in Step 2). The code-evidence path (Step 4) and the Step 6b probes are unavailable; the agent does not ask the user to paste code in lieu of running shell commands. The skill skips from Step 3b directly to Step 5.
+- **Chat surfaces** (Claude.ai, Perplexity). The agent has no shell. It operates only on content the user pastes into the chat (Step 3b), and only against an already-adopted project (verified in Step 3b). Steps 1, 2, and 4 are filesystem-bound and are skipped on chat surfaces; the Step 6b probes are likewise unavailable, and the agent does not ask the user to paste code in lieu of running shell commands. The skill skips from Step 3b directly to Step 5.
 
 ## Step 1 — Detect repo root
 
@@ -53,7 +53,11 @@ When filesystem read is unavailable (chat surfaces), the agent first verifies th
 
 > Has this repo been adopted via `nauro adopt` locally? Tell me the project name and id, or paste `<repo>/.nauro/config.json`.
 
-If the user cannot confirm an adopted project, the agent surfaces "Run `nauro adopt` locally first, then return here" and stops. Once the project is confirmed, the agent prompts for source content:
+If the user cannot confirm an adopted project, the agent surfaces "Run `nauro adopt` locally first, then return here" and stops.
+
+A typed project name or id is not taken on faith. The agent calls the `list_projects` tool and matches the user's answer against the projects it returns; on no match, the agent surfaces the listed project names and asks the user to pick one. A project adopted locally but absent from the list is local-only — it needs `nauro link` before chat mode can reach it.
+
+Once the project is confirmed, the agent prompts for source content:
 
 > This skill needs source content. Paste the contents of any of: README, manifest (pyproject.toml/package.json/etc.), ADRs, Memory-Bank files. Send each as a separate message labelled with the filename.
 
@@ -77,7 +81,7 @@ Step 4 ends with a list of observations, not a list of candidate decisions. Prom
 
 ## Step 5 — Call get_context
 
-The agent calls `get_context` (MCP) to surface what the scaffold already wrote — `001-initial-setup.md` and bracketed-prompt placeholders in `project.md` / `stack.md`. The agent uses this to (a) avoid duplicating the scaffold's first decision, (b) confirm the project resolved correctly, and (c) learn what `check_decision` will treat as the existing baseline in Step 7.
+The agent calls `get_context` (MCP) to surface what the scaffold already wrote — `001-initial-setup.md` and bracketed-prompt placeholders in `project.md` / `stack.md`. The agent uses this to (a) avoid duplicating the scaffold's first decision, (b) confirm the project resolved correctly, and (c) know what Step 7's `check_decision` calls will and will not see: `check_decision` filters the scaffold seed from its results by design, so on a fresh store it returns a no-decisions-yet assessment — expected, not a failure — and catching a duplicate of the `001-initial-setup` seed is the agent's job from this step onward. The seed remains visible via `get_context` and `list_decisions`.
 
 ## Step 6 — Triage candidates
 
@@ -95,7 +99,7 @@ Filesystem-capable surfaces only. For each Step 4 observation that points at a r
 
 > I see X in file/path; was Y considered; what pushed you toward X?
 
-Substitute `X` with the observed fact, `file/path` with the source it came from, and `Y` with a credible alternative the agent inferred (or "an alternative" if none is obvious). Probes are batched into one message; the user replies per item:
+Substitute `X` with the observed fact, `file/path` with the source it came from, and `Y` with a credible alternative the agent inferred (or "an alternative" if none is obvious). Probes are batched into one message, capped at eight in the first batch and ordered highest-leverage first — workspace shape, framework picks, and CI / IaC targets before lint and test conventions. When more observations remain, the batch message must end with the line "N more observations remain — say 'more probes' to see them", so nothing is silently dropped. The user replies per item:
 
 > Reply 'rationale N: <why>' to record it as a decision (it flows into the Step 7 write loop), 'inventory N' to drop it to stack inventory (6c), 'question N' to flag it as an open question (Step 9), or 'skip N' to drop it entirely.
 
@@ -111,7 +115,7 @@ Languages, frameworks, package managers, license, lint tooling, and similar fact
 
 For each kept candidate from 6a and each rationale-supplied 6b answer, the agent runs the full propose protocol:
 
-1. Call `check_decision(proposed_approach=<title or short description>, project_id=...)`. `check_decision` returns related decisions via BM25 retrieval and a deterministic assessment. It does NOT judge conflicts.
+1. Call `check_decision(proposed_approach=<for a 6a candidate: the title plus the one-line summary; for a 6b candidate: the observed fact plus the core of the rationale the user supplied>, project_id=...)`. `check_decision` returns related decisions via BM25 retrieval and a deterministic assessment. It does NOT judge conflicts.
 2. When the response lists related decisions, call `get_decision` on each before proposing — `mode=header` to triage, `mode=full` for those you reason about; the assessment doesn't judge. Call signature: `get_decision(number=N, project_id=...)`.
 3. Classify the operation:
     - **add** (default; new ground, no existing decision covers it).
@@ -160,7 +164,7 @@ If Step 6c produced inventory items, append a short trailing section:
 - ...
 ```
 
-If only one of activeContext / progress / inventory is present, the corresponding sections are omitted. If none is present, `update_state` is skipped entirely. **The agent does not call `update_state` per progress item or per inventory entry** — `update_state` archives prior state to history, and the L0 payload ignores history.
+If only one of activeContext / progress / inventory is present, the corresponding sections are omitted. If none is present, `update_state` is skipped entirely. The composed delta must stay under 5,000 characters — `update_state` rejects longer deltas at the boundary. When the activeContext body alone would exceed the cap, condense it to the current focus and the most recent items rather than pasting it whole. Never split the delta across multiple `update_state` calls: each call replaces the state, so a second call clobbers the first. **The agent does not call `update_state` per progress item or per inventory entry** — `update_state` archives prior state to history, and the L0 payload ignores history.
 
 ## Step 9 — Flag open questions
 
@@ -190,4 +194,4 @@ The agent prints one block:
 - Decisions skipped: `M` (titles)
 - State updated: `yes`/`no`
 - Open questions flagged: `K`
-- Next: run `nauro sync` from the repo to capture a snapshot.
+- Next: on filesystem-capable surfaces, the agent tells the user that `nauro sync` captures a snapshot and regenerates `AGENTS.md` in the project's associated repos, and offers to run it, proceeding only on user confirmation. On chat surfaces, the agent instructs the user to run `nauro sync` from the repo.

--- a/.cursor/rules/nauro-adopt.mdc
+++ b/.cursor/rules/nauro-adopt.mdc
@@ -12,7 +12,7 @@ The agent helps the user seed Nauro with context from the current repo. Before t
 The agent's behaviour depends on whether the surface can read the repo directly.
 
 - **Filesystem-capable surfaces** (Claude Code, Cursor, Codex CLI). The agent runs Steps 1–11 in full. Docs are read for rationale in Step 3; code, config, tests, manifests, and recent git history are inspected for evidence in Step 4; targeted probes in Step 6b turn evidence into rationale by asking the user.
-- **Chat surfaces** (Claude.ai, Perplexity). The agent has no shell. It operates only on content the user pastes into the chat (Step 3b), and only against an already-adopted project (verified in Step 2). The code-evidence path (Step 4) and the Step 6b probes are unavailable; the agent does not ask the user to paste code in lieu of running shell commands. The skill skips from Step 3b directly to Step 5.
+- **Chat surfaces** (Claude.ai, Perplexity). The agent has no shell. It operates only on content the user pastes into the chat (Step 3b), and only against an already-adopted project (verified in Step 3b). Steps 1, 2, and 4 are filesystem-bound and are skipped on chat surfaces; the Step 6b probes are likewise unavailable, and the agent does not ask the user to paste code in lieu of running shell commands. The skill skips from Step 3b directly to Step 5.
 
 ## Step 1 — Detect repo root
 
@@ -53,7 +53,11 @@ When filesystem read is unavailable (chat surfaces), the agent first verifies th
 
 > Has this repo been adopted via `nauro adopt` locally? Tell me the project name and id, or paste `<repo>/.nauro/config.json`.
 
-If the user cannot confirm an adopted project, the agent surfaces "Run `nauro adopt` locally first, then return here" and stops. Once the project is confirmed, the agent prompts for source content:
+If the user cannot confirm an adopted project, the agent surfaces "Run `nauro adopt` locally first, then return here" and stops.
+
+A typed project name or id is not taken on faith. The agent calls the `list_projects` tool and matches the user's answer against the projects it returns; on no match, the agent surfaces the listed project names and asks the user to pick one. A project adopted locally but absent from the list is local-only — it needs `nauro link` before chat mode can reach it.
+
+Once the project is confirmed, the agent prompts for source content:
 
 > This skill needs source content. Paste the contents of any of: README, manifest (pyproject.toml/package.json/etc.), ADRs, Memory-Bank files. Send each as a separate message labelled with the filename.
 
@@ -77,7 +81,7 @@ Step 4 ends with a list of observations, not a list of candidate decisions. Prom
 
 ## Step 5 — Call get_context
 
-The agent calls `get_context` (MCP) to surface what the scaffold already wrote — `001-initial-setup.md` and bracketed-prompt placeholders in `project.md` / `stack.md`. The agent uses this to (a) avoid duplicating the scaffold's first decision, (b) confirm the project resolved correctly, and (c) learn what `check_decision` will treat as the existing baseline in Step 7.
+The agent calls `get_context` (MCP) to surface what the scaffold already wrote — `001-initial-setup.md` and bracketed-prompt placeholders in `project.md` / `stack.md`. The agent uses this to (a) avoid duplicating the scaffold's first decision, (b) confirm the project resolved correctly, and (c) know what Step 7's `check_decision` calls will and will not see: `check_decision` filters the scaffold seed from its results by design, so on a fresh store it returns a no-decisions-yet assessment — expected, not a failure — and catching a duplicate of the `001-initial-setup` seed is the agent's job from this step onward. The seed remains visible via `get_context` and `list_decisions`.
 
 ## Step 6 — Triage candidates
 
@@ -95,7 +99,7 @@ Filesystem-capable surfaces only. For each Step 4 observation that points at a r
 
 > I see X in file/path; was Y considered; what pushed you toward X?
 
-Substitute `X` with the observed fact, `file/path` with the source it came from, and `Y` with a credible alternative the agent inferred (or "an alternative" if none is obvious). Probes are batched into one message; the user replies per item:
+Substitute `X` with the observed fact, `file/path` with the source it came from, and `Y` with a credible alternative the agent inferred (or "an alternative" if none is obvious). Probes are batched into one message, capped at eight in the first batch and ordered highest-leverage first — workspace shape, framework picks, and CI / IaC targets before lint and test conventions. When more observations remain, the batch message must end with the line "N more observations remain — say 'more probes' to see them", so nothing is silently dropped. The user replies per item:
 
 > Reply 'rationale N: <why>' to record it as a decision (it flows into the Step 7 write loop), 'inventory N' to drop it to stack inventory (6c), 'question N' to flag it as an open question (Step 9), or 'skip N' to drop it entirely.
 
@@ -111,7 +115,7 @@ Languages, frameworks, package managers, license, lint tooling, and similar fact
 
 For each kept candidate from 6a and each rationale-supplied 6b answer, the agent runs the full propose protocol:
 
-1. Call `check_decision(proposed_approach=<title or short description>, project_id=...)`. `check_decision` returns related decisions via BM25 retrieval and a deterministic assessment. It does NOT judge conflicts.
+1. Call `check_decision(proposed_approach=<for a 6a candidate: the title plus the one-line summary; for a 6b candidate: the observed fact plus the core of the rationale the user supplied>, project_id=...)`. `check_decision` returns related decisions via BM25 retrieval and a deterministic assessment. It does NOT judge conflicts.
 2. When the response lists related decisions, call `get_decision` on each before proposing — `mode=header` to triage, `mode=full` for those you reason about; the assessment doesn't judge. Call signature: `get_decision(number=N, project_id=...)`.
 3. Classify the operation:
     - **add** (default; new ground, no existing decision covers it).
@@ -160,7 +164,7 @@ If Step 6c produced inventory items, append a short trailing section:
 - ...
 ```
 
-If only one of activeContext / progress / inventory is present, the corresponding sections are omitted. If none is present, `update_state` is skipped entirely. **The agent does not call `update_state` per progress item or per inventory entry** — `update_state` archives prior state to history, and the L0 payload ignores history.
+If only one of activeContext / progress / inventory is present, the corresponding sections are omitted. If none is present, `update_state` is skipped entirely. The composed delta must stay under 5,000 characters — `update_state` rejects longer deltas at the boundary. When the activeContext body alone would exceed the cap, condense it to the current focus and the most recent items rather than pasting it whole. Never split the delta across multiple `update_state` calls: each call replaces the state, so a second call clobbers the first. **The agent does not call `update_state` per progress item or per inventory entry** — `update_state` archives prior state to history, and the L0 payload ignores history.
 
 ## Step 9 — Flag open questions
 
@@ -190,4 +194,4 @@ The agent prints one block:
 - Decisions skipped: `M` (titles)
 - State updated: `yes`/`no`
 - Open questions flagged: `K`
-- Next: run `nauro sync` from the repo to capture a snapshot.
+- Next: on filesystem-capable surfaces, the agent tells the user that `nauro sync` captures a snapshot and regenerates `AGENTS.md` in the project's associated repos, and offers to run it, proceeding only on user confirmation. On chat surfaces, the agent instructs the user to run `nauro sync` from the repo.

--- a/docs/adopt-prompt.md
+++ b/docs/adopt-prompt.md
@@ -30,7 +30,7 @@ The agent helps the user seed Nauro with context from the current repo. Before t
 The agent's behaviour depends on whether the surface can read the repo directly.
 
 - **Filesystem-capable surfaces** (Claude Code, Cursor, Codex CLI). The agent runs Steps 1–11 in full. Docs are read for rationale in Step 3; code, config, tests, manifests, and recent git history are inspected for evidence in Step 4; targeted probes in Step 6b turn evidence into rationale by asking the user.
-- **Chat surfaces** (Claude.ai, Perplexity). The agent has no shell. It operates only on content the user pastes into the chat (Step 3b), and only against an already-adopted project (verified in Step 2). The code-evidence path (Step 4) and the Step 6b probes are unavailable; the agent does not ask the user to paste code in lieu of running shell commands. The skill skips from Step 3b directly to Step 5.
+- **Chat surfaces** (Claude.ai, Perplexity). The agent has no shell. It operates only on content the user pastes into the chat (Step 3b), and only against an already-adopted project (verified in Step 3b). Steps 1, 2, and 4 are filesystem-bound and are skipped on chat surfaces; the Step 6b probes are likewise unavailable, and the agent does not ask the user to paste code in lieu of running shell commands. The skill skips from Step 3b directly to Step 5.
 
 ## Step 1 — Detect repo root
 
@@ -71,7 +71,11 @@ When filesystem read is unavailable (chat surfaces), the agent first verifies th
 
 > Has this repo been adopted via `nauro adopt` locally? Tell me the project name and id, or paste `<repo>/.nauro/config.json`.
 
-If the user cannot confirm an adopted project, the agent surfaces "Run `nauro adopt` locally first, then return here" and stops. Once the project is confirmed, the agent prompts for source content:
+If the user cannot confirm an adopted project, the agent surfaces "Run `nauro adopt` locally first, then return here" and stops.
+
+A typed project name or id is not taken on faith. The agent calls the `list_projects` tool and matches the user's answer against the projects it returns; on no match, the agent surfaces the listed project names and asks the user to pick one. A project adopted locally but absent from the list is local-only — it needs `nauro link` before chat mode can reach it.
+
+Once the project is confirmed, the agent prompts for source content:
 
 > This skill needs source content. Paste the contents of any of: README, manifest (pyproject.toml/package.json/etc.), ADRs, Memory-Bank files. Send each as a separate message labelled with the filename.
 
@@ -95,7 +99,7 @@ Step 4 ends with a list of observations, not a list of candidate decisions. Prom
 
 ## Step 5 — Call get_context
 
-The agent calls `get_context` (MCP) to surface what the scaffold already wrote — `001-initial-setup.md` and bracketed-prompt placeholders in `project.md` / `stack.md`. The agent uses this to (a) avoid duplicating the scaffold's first decision, (b) confirm the project resolved correctly, and (c) learn what `check_decision` will treat as the existing baseline in Step 7.
+The agent calls `get_context` (MCP) to surface what the scaffold already wrote — `001-initial-setup.md` and bracketed-prompt placeholders in `project.md` / `stack.md`. The agent uses this to (a) avoid duplicating the scaffold's first decision, (b) confirm the project resolved correctly, and (c) know what Step 7's `check_decision` calls will and will not see: `check_decision` filters the scaffold seed from its results by design, so on a fresh store it returns a no-decisions-yet assessment — expected, not a failure — and catching a duplicate of the `001-initial-setup` seed is the agent's job from this step onward. The seed remains visible via `get_context` and `list_decisions`.
 
 ## Step 6 — Triage candidates
 
@@ -113,7 +117,7 @@ Filesystem-capable surfaces only. For each Step 4 observation that points at a r
 
 > I see X in file/path; was Y considered; what pushed you toward X?
 
-Substitute `X` with the observed fact, `file/path` with the source it came from, and `Y` with a credible alternative the agent inferred (or "an alternative" if none is obvious). Probes are batched into one message; the user replies per item:
+Substitute `X` with the observed fact, `file/path` with the source it came from, and `Y` with a credible alternative the agent inferred (or "an alternative" if none is obvious). Probes are batched into one message, capped at eight in the first batch and ordered highest-leverage first — workspace shape, framework picks, and CI / IaC targets before lint and test conventions. When more observations remain, the batch message must end with the line "N more observations remain — say 'more probes' to see them", so nothing is silently dropped. The user replies per item:
 
 > Reply 'rationale N: <why>' to record it as a decision (it flows into the Step 7 write loop), 'inventory N' to drop it to stack inventory (6c), 'question N' to flag it as an open question (Step 9), or 'skip N' to drop it entirely.
 
@@ -129,7 +133,7 @@ Languages, frameworks, package managers, license, lint tooling, and similar fact
 
 For each kept candidate from 6a and each rationale-supplied 6b answer, the agent runs the full propose protocol:
 
-1. Call `check_decision(proposed_approach=<title or short description>, project_id=...)`. `check_decision` returns related decisions via BM25 retrieval and a deterministic assessment. It does NOT judge conflicts.
+1. Call `check_decision(proposed_approach=<for a 6a candidate: the title plus the one-line summary; for a 6b candidate: the observed fact plus the core of the rationale the user supplied>, project_id=...)`. `check_decision` returns related decisions via BM25 retrieval and a deterministic assessment. It does NOT judge conflicts.
 2. When the response lists related decisions, call `get_decision` on each before proposing — `mode=header` to triage, `mode=full` for those you reason about; the assessment doesn't judge. Call signature: `get_decision(number=N, project_id=...)`.
 3. Classify the operation:
     - **add** (default; new ground, no existing decision covers it).
@@ -178,7 +182,7 @@ If Step 6c produced inventory items, append a short trailing section:
 - ...
 ```
 
-If only one of activeContext / progress / inventory is present, the corresponding sections are omitted. If none is present, `update_state` is skipped entirely. **The agent does not call `update_state` per progress item or per inventory entry** — `update_state` archives prior state to history, and the L0 payload ignores history.
+If only one of activeContext / progress / inventory is present, the corresponding sections are omitted. If none is present, `update_state` is skipped entirely. The composed delta must stay under 5,000 characters — `update_state` rejects longer deltas at the boundary. When the activeContext body alone would exceed the cap, condense it to the current focus and the most recent items rather than pasting it whole. Never split the delta across multiple `update_state` calls: each call replaces the state, so a second call clobbers the first. **The agent does not call `update_state` per progress item or per inventory entry** — `update_state` archives prior state to history, and the L0 payload ignores history.
 
 ## Step 9 — Flag open questions
 
@@ -208,4 +212,4 @@ The agent prints one block:
 - Decisions skipped: `M` (titles)
 - State updated: `yes`/`no`
 - Open questions flagged: `K`
-- Next: run `nauro sync` from the repo to capture a snapshot.
+- Next: on filesystem-capable surfaces, the agent tells the user that `nauro sync` captures a snapshot and regenerates `AGENTS.md` in the project's associated repos, and offers to run it, proceeding only on user confirmation. On chat surfaces, the agent instructs the user to run `nauro sync` from the repo.

--- a/packages/nauro/src/nauro/skills/adopt_body.md
+++ b/packages/nauro/src/nauro/skills/adopt_body.md
@@ -13,7 +13,7 @@ The agent helps the user seed Nauro with context from the current repo. Before t
 The agent's behaviour depends on whether the surface can read the repo directly.
 
 - **Filesystem-capable surfaces** (Claude Code, Cursor, Codex CLI). The agent runs Steps 1–11 in full. Docs are read for rationale in Step 3; code, config, tests, manifests, and recent git history are inspected for evidence in Step 4; targeted probes in Step 6b turn evidence into rationale by asking the user.
-- **Chat surfaces** (Claude.ai, Perplexity). The agent has no shell. It operates only on content the user pastes into the chat (Step 3b), and only against an already-adopted project (verified in Step 2). The code-evidence path (Step 4) and the Step 6b probes are unavailable; the agent does not ask the user to paste code in lieu of running shell commands. The skill skips from Step 3b directly to Step 5.
+- **Chat surfaces** (Claude.ai, Perplexity). The agent has no shell. It operates only on content the user pastes into the chat (Step 3b), and only against an already-adopted project (verified in Step 3b). Steps 1, 2, and 4 are filesystem-bound and are skipped on chat surfaces; the Step 6b probes are likewise unavailable, and the agent does not ask the user to paste code in lieu of running shell commands. The skill skips from Step 3b directly to Step 5.
 
 ## Step 1 — Detect repo root
 
@@ -54,7 +54,11 @@ When filesystem read is unavailable (chat surfaces), the agent first verifies th
 
 > Has this repo been adopted via `nauro adopt` locally? Tell me the project name and id, or paste `<repo>/.nauro/config.json`.
 
-If the user cannot confirm an adopted project, the agent surfaces "Run `nauro adopt` locally first, then return here" and stops. Once the project is confirmed, the agent prompts for source content:
+If the user cannot confirm an adopted project, the agent surfaces "Run `nauro adopt` locally first, then return here" and stops.
+
+A typed project name or id is not taken on faith. The agent calls the `list_projects` tool and matches the user's answer against the projects it returns; on no match, the agent surfaces the listed project names and asks the user to pick one. A project adopted locally but absent from the list is local-only — it needs `nauro link` before chat mode can reach it.
+
+Once the project is confirmed, the agent prompts for source content:
 
 > This skill needs source content. Paste the contents of any of: README, manifest (pyproject.toml/package.json/etc.), ADRs, Memory-Bank files. Send each as a separate message labelled with the filename.
 
@@ -78,7 +82,7 @@ Step 4 ends with a list of observations, not a list of candidate decisions. Prom
 
 ## Step 5 — Call get_context
 
-The agent calls `get_context` (MCP) to surface what the scaffold already wrote — `001-initial-setup.md` and bracketed-prompt placeholders in `project.md` / `stack.md`. The agent uses this to (a) avoid duplicating the scaffold's first decision, (b) confirm the project resolved correctly, and (c) learn what `check_decision` will treat as the existing baseline in Step 7.
+The agent calls `get_context` (MCP) to surface what the scaffold already wrote — `001-initial-setup.md` and bracketed-prompt placeholders in `project.md` / `stack.md`. The agent uses this to (a) avoid duplicating the scaffold's first decision, (b) confirm the project resolved correctly, and (c) know what Step 7's `check_decision` calls will and will not see: `check_decision` filters the scaffold seed from its results by design, so on a fresh store it returns a no-decisions-yet assessment — expected, not a failure — and catching a duplicate of the `001-initial-setup` seed is the agent's job from this step onward. The seed remains visible via `get_context` and `list_decisions`.
 
 ## Step 6 — Triage candidates
 
@@ -96,7 +100,7 @@ Filesystem-capable surfaces only. For each Step 4 observation that points at a r
 
 > I see X in file/path; was Y considered; what pushed you toward X?
 
-Substitute `X` with the observed fact, `file/path` with the source it came from, and `Y` with a credible alternative the agent inferred (or "an alternative" if none is obvious). Probes are batched into one message; the user replies per item:
+Substitute `X` with the observed fact, `file/path` with the source it came from, and `Y` with a credible alternative the agent inferred (or "an alternative" if none is obvious). Probes are batched into one message, capped at eight in the first batch and ordered highest-leverage first — workspace shape, framework picks, and CI / IaC targets before lint and test conventions. When more observations remain, the batch message must end with the line "N more observations remain — say 'more probes' to see them", so nothing is silently dropped. The user replies per item:
 
 > Reply 'rationale N: <why>' to record it as a decision (it flows into the Step 7 write loop), 'inventory N' to drop it to stack inventory (6c), 'question N' to flag it as an open question (Step 9), or 'skip N' to drop it entirely.
 
@@ -112,7 +116,7 @@ Languages, frameworks, package managers, license, lint tooling, and similar fact
 
 For each kept candidate from 6a and each rationale-supplied 6b answer, the agent runs the full propose protocol:
 
-1. Call `check_decision(proposed_approach=<title or short description>, project_id=...)`. <!-- protocol:CHECK_DECISION_RETURNS -->
+1. Call `check_decision(proposed_approach=<for a 6a candidate: the title plus the one-line summary; for a 6b candidate: the observed fact plus the core of the rationale the user supplied>, project_id=...)`. <!-- protocol:CHECK_DECISION_RETURNS -->
 2. <!-- protocol:GET_DECISION_BEFORE_PROPOSING --> Call signature: `get_decision(number=N, project_id=...)`.
 3. Classify the operation:
     - **add** (default; new ground, no existing decision covers it).
@@ -161,7 +165,7 @@ If Step 6c produced inventory items, append a short trailing section:
 - ...
 ```
 
-If only one of activeContext / progress / inventory is present, the corresponding sections are omitted. If none is present, `update_state` is skipped entirely. **The agent does not call `update_state` per progress item or per inventory entry** — `update_state` archives prior state to history, and the L0 payload ignores history.
+If only one of activeContext / progress / inventory is present, the corresponding sections are omitted. If none is present, `update_state` is skipped entirely. The composed delta must stay under 5,000 characters — `update_state` rejects longer deltas at the boundary. When the activeContext body alone would exceed the cap, condense it to the current focus and the most recent items rather than pasting it whole. Never split the delta across multiple `update_state` calls: each call replaces the state, so a second call clobbers the first. **The agent does not call `update_state` per progress item or per inventory entry** — `update_state` archives prior state to history, and the L0 payload ignores history.
 
 ## Step 9 — Flag open questions
 
@@ -191,4 +195,4 @@ The agent prints one block:
 - Decisions skipped: `M` (titles)
 - State updated: `yes`/`no`
 - Open questions flagged: `K`
-- Next: run `nauro sync` from the repo to capture a snapshot.
+- Next: on filesystem-capable surfaces, the agent tells the user that `nauro sync` captures a snapshot and regenerates `AGENTS.md` in the project's associated repos, and offers to run it, proceeding only on user confirmation. On chat surfaces, the agent instructs the user to run `nauro sync` from the repo.

--- a/packages/nauro/tests/test_skills_drift.py
+++ b/packages/nauro/tests/test_skills_drift.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from collections.abc import Iterator
 
 import pytest
-from nauro_core.constants import MAX_BRIEF_BYTES
+from nauro_core.constants import MAX_BRIEF_BYTES, MAX_DELTA_LENGTH
 
 from nauro.skills import (
     load_adopt_body,
@@ -114,6 +114,23 @@ def test_context_body_brief_size_gloss_matches_constant():
     assert gloss in body, (
         f"context_body.md size gloss is out of sync with MAX_BRIEF_BYTES "
         f"({MAX_BRIEF_BYTES} bytes); expected the prose to read {gloss!r}."
+    )
+
+
+def test_adopt_body_delta_size_gloss_matches_constant():
+    """The body glosses ``MAX_DELTA_LENGTH`` in prose as a human-readable count.
+
+    The constant is the enforced cap on ``update_state`` deltas; the prose
+    gloss is what an agent reads at the Step 8 write. If the constant changes,
+    the prose must change with it, or the skill teaches a cap the code does
+    not enforce. Pin the gloss to the constant so the two cannot drift apart
+    silently.
+    """
+    body = load_adopt_body()
+    gloss = f"{MAX_DELTA_LENGTH:,} characters"
+    assert gloss in body, (
+        f"adopt_body.md delta-cap gloss is out of sync with MAX_DELTA_LENGTH "
+        f"({MAX_DELTA_LENGTH} characters); expected the prose to read {gloss!r}."
     )
 
 


### PR DESCRIPTION
## Why

The adopt skill is the always-installed first-contact surface: every `nauro adopt` run installs it, and a fresh user's first session executes it end to end. The body had drifted from kernel behavior in ways that land exactly on that first run:

- The Step 8 state write never mentioned the delta cap, so a doc-heavy repo composed a delta that `update_state` rejected at the final write step with no explanation in the skill. Worse, the natural recovery (splitting the delta across two calls) silently clobbers state, because each call replaces it.
- Step 5 taught a wrong fresh-store baseline: it told the agent `check_decision` would treat the scaffold seed as the existing baseline, when the kernel filters the seed from `check_decision` results by design. On a fresh store the agent saw a "no decisions" assessment it had been told not to expect.
- The chat path took a typed project name/id on faith, with no verification against the projects the user can actually reach.
- Step 6b put no ceiling on the probe batch, so an evidence-rich repo produced a wall of probes in one message.
- The surface-modes section pointed chat surfaces at Step 2 for project verification, a filesystem-bound step a chat surface cannot run.

## Approach

Wording-level accuracy fixes to the canonical source template, each anchored to verified kernel behavior, plus one new drift test so the most failure-prone claim (the delta cap) cannot silently rot. Alternatives considered and rejected:

- A protocol-fragment token for the delta-cap integer: rejected as speculative infrastructure for a single integer gloss. The drift test pins the prose to the constant with no new machinery.
- Per-candidate `search_decisions` dedup in the Step 7 write loop: rejected because it adds a retrieval round-trip per candidate to a loop that is already the slow path, for overlap `check_decision` already surfaces.
- Restructuring the body (splitting or reordering steps): rejected for zero usage evidence that the step structure confuses agents. Only the claims were wrong.

## What changed

- Source template (`adopt_body.md`), seven edits: chat-surface cross-reference corrected to Step 3b, with an explicit list of which steps are filesystem-bound; Step 3b verifies a typed project name/id against `list_projects` and routes local-only projects to `nauro link`; Step 5 documents that `check_decision` filters the scaffold seed by design (a fresh store returns a no-decisions-yet assessment, and the seed stays visible via `get_context` / `list_decisions`); Step 6b caps the first probe batch at eight, ordered highest-leverage first, with a mandatory remaining-count line; Step 7's `check_decision` placeholder now covers both candidate sources; Step 8 documents the 5,000-character delta cap, a condense-don't-paste rule, and the never-split rule (each `update_state` call replaces the state); Step 11's closing bullet matches the established context-skill voice (offer to run `nauro sync`, proceed only on confirmation; instruction-only text on chat surfaces).
- Drift suite: one new anchor test pinning the body's "5,000 characters" gloss to `MAX_DELTA_LENGTH`, modeled on the existing brief-size gloss test.
- Renders regenerated in the same commit: the three dogfood skill files and `docs/adopt-prompt.md` (intro preserved, canonical body re-appended), keeping the byte-equality drift tests green.

## What to review

- Step 5's rewritten clause (c): check it against the seed filtering in the kernel's check-decision operation (the seed is filtered before retrieval; `get_context` and `list_decisions` still show it).
- The Step 7 placeholder text sits inside a parsed tool-call signature, so it deliberately avoids commas, apostrophes, and equals signs. Confirm the wording is acceptable under that constraint.
- Step 8's never-split rule states that each `update_state` call replaces the state. This is the documented kernel semantic (prior state archives to history; the L0 payload ignores history).

## What's deferred

- The ship-task and context body edits from the same audit ride their own PRs.
- A per-surface installer skip (not shipping filesystem-bound steps to chat surfaces at all) is deferred pending a recorded decision.
- The fix reaches users at the next release tag, not at merge: installed skill files materialize from the packaged body at adopt time.

## Test plan

- New drift test written first and confirmed failing before the body edit, green after.
- Full `packages/nauro` suite: 1,442 passed, 10 skipped, including the byte-equality tests that pin all four regenerated artifacts to the renderer output, the structural tool-signature tests that parse the edited Step 7 call, the cross-step reference integrity test over the edited prose, and the protocol-token tests covering the preserved token.
- `ruff check` and `ruff format --check` clean.
- `packages/nauro-core` untouched.
