### PR TITLE
Bump nauro to 0.13.1

### DIFF
--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro"
-version = "0.13.0"
+version = "0.13.1"
 description = "Local CLI + MCP server: set your project's doctrine once, every connected AI agent inherits it."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Why

Patch release carrying the agent allowlist fix (#245): the bundled agents now grant the plugin MCP namespace, so plugin-only installs get functional agents. Unblocks the plugin lockstep bump and the directory submission.

## What changed

pyproject version 0.13.0 to 0.13.1, nothing else, per the tag-triggered release convention.

## Test plan

Version-bump-only PR; CI runs the full suite. The allowlist fix itself was tested and live-verified in #245.
