### PR TITLE
Generalize the ship-task skill body and fix the PR-creation step

### DIFF
--- a/.agents/skills/nauro-ship-task/SKILL.md
+++ b/.agents/skills/nauro-ship-task/SKILL.md
@@ -21,7 +21,7 @@ Pause only at the two explicit gates marked GATE below.
 
 ## Pre-step — Doctrine triage before the planner spins up
 
-Before invoking `@nauro-planner`, the parent session confirms the planner will run `check_decision` first. The planner's contract already requires this, but the chain enforces it explicitly: if the planner returns a RED verdict (proposal directly contradicts an active decision) and drafts a supersede, the chain pauses before the executor sees anything. The user approves the supersede in chat; only after explicit approval does the planner file via `propose_decision` (which commits immediately) and the executor see the approved plan. This is the doctrine equivalent of GATE 1 firing early — a RED that the user does not resolve never reaches code.
+Before invoking `@nauro-planner`, the parent session confirms the planner will run `check_decision` first. The planner's contract already requires this, but the chain enforces it explicitly: if the planner returns a RED verdict (proposal directly contradicts an active decision) and drafts a supersede, the chain pauses before the executor sees anything. The user approves the supersede in chat; only after explicit approval does the planner file via `propose_decision` (which commits immediately) and the executor see the approved plan. This is the doctrine equivalent of the plan-approval gate (step 2) firing early — a RED that the user does not resolve never reaches code.
 
 ### 1. Plan
 
@@ -31,14 +31,14 @@ If the planner returns RED with a supersede draft, the chain pauses here. Surfac
 
 ### 2. GATE — plan approval (always when `propose_decision` is in play)
 
-The Nauro chain gates the plan whenever the planner indicates it will file a decision via `propose_decision` for any architectural choice, or whenever the plan records a supersede / update draft. This is stricter than the personal `/ship-task` skill: there is no "low-stakes auto-proceed" path when doctrine writes are pending. The user's judgment is the gate on what enters the decision log.
+The Nauro chain gates the plan whenever the planner indicates it will file a decision via `propose_decision` for any architectural choice, or whenever the plan records a supersede / update draft. There is no "low-stakes auto-proceed" path when doctrine writes are pending. The user's judgment is the gate on what enters the decision log.
 
 A change additionally always gates if any of the following apply:
 
 - Touches authentication, credentials, secrets, tokens, signing, or encryption
 - Changes data model, schema, storage format, or existing on-disk / database layout
 - Adds, removes, or renames public surface (CLI commands, public functions, MCP tools, API endpoints, env vars, config keys)
-- Changes the contract between `nauro` and `nauro-core`, or anything `mcp-server` consumes from `nauro-core`
+- Changes a contract between packages that ship or deploy separately, or any surface a deployed consumer depends on
 - Adds, removes, or major-version bumps a dependency
 - Records a Nauro decision with reversibility `hard` or `moderate`
 - Surfaces 2-3 defensible alternatives where the choice is genuinely architectural
@@ -61,9 +61,9 @@ If the reviewer returns BLOCK, hand the hard-rule failures back to the `@nauro-e
 
 ### 6. Doctrine pass
 
-When the reviewer returns APPROVE or APPROVE WITH NITS, invoke `@nauro-tech-lead` in Mode C on the same local diff. The tech-lead reads decisions, scans the diff for architectural choices, and returns GREEN / AMBER / RED with any drafted supersede / update awaiting user approval.
+When the reviewer returns APPROVE or APPROVE WITH NITS, invoke `@nauro-tech-lead` in Mode C on the same local diff. The invocation explicitly carries the chain context the parent already holds: the task description, the planner's verdict and any decision filed at plan time (or deliberately not filed), and the reviewer's verdict with its nits — the tech-lead does not re-infer chain state from the diff alone. The tech-lead reads decisions, scans the diff for architectural choices, and returns GREEN / AMBER / RED with any drafted supersede / update awaiting user approval.
 
-- **GREEN** — proceed to GATE.
+- **GREEN** — proceed to the push gate (step 7).
 - **AMBER** — surface the constraints to the user alongside the push gate; user decides whether to address before push or document as a follow-up.
 - **RED** — pause. Either redirect the executor (fix the drift, then re-run reviewer + tech-lead) or confirm the drafted supersede first. Do not push past a RED tech-lead verdict without an explicit human override on the cited decision.
 
@@ -81,12 +81,12 @@ If the body would be long, that's fine — paste it anyway. Skipping the verbati
 
 ### 8. Push
 
-On approval, push the branch and open the PR with the drafted description as the body (`gh pr create --body "..."`). Decisions filed during the chain go in the PR's Approach section by paraphrase, not by raw decision number — the public-repo convention is to describe the doctrine move ("the bundled-subagents pattern"), not cite internal D-numbers.
+On approval, push the branch. Write the drafted description to a file and open the PR with `gh pr create --body-file <file>` — passing the body inline breaks on quote characters in the drafted body. If `gh` is unavailable, hand the user the PR-creation URL the push prints (or the compare URL constructed from the remote and branch). Decisions filed during the chain go in the PR's Approach section by paraphrase, not by raw decision number — the public-repo convention is to describe the doctrine move ("the bundled-subagents pattern"), not cite internal D-numbers.
 
 ## Rules
 
 - A fully specified task still goes through the planner — the spec becomes the planner's input, not a reason to skip the chain and implement directly.
-- Push and `gh pr create` happen only with explicit user approval at GATE 7.
+- Push and `gh pr create` happen only with explicit user approval at the push gate (step 7).
 - `propose_decision` happens only with explicit user approval. Subagents draft or surface decisions; they never file an unapproved one. After the user approves in chat, the originating agent files — the planner for plan-time decisions, `@nauro-tech-lead` for doctrine moves it surfaces in Mode C. The executor never files; it surfaces emergent choices in its handoff (step 3) for the parent to gate. The kernel commits immediately on Tier 1 clean.
 - If a `propose_decision` is pending but the Nauro MCP server is disconnected, that is a hard pause — do not push the PR and file the decision after reconnecting. The code and its decision land together; a push-now-file-later split leaves doctrine unrecorded if the session ends first. Surface the disconnect and wait.
 - If anything fails or surprises mid-chain (a tool errors, tests fail unexpectedly, a verdict is incoherent), stop and surface to the user rather than recovering silently.

--- a/.claude/skills/nauro-ship-task/SKILL.md
+++ b/.claude/skills/nauro-ship-task/SKILL.md
@@ -21,7 +21,7 @@ Pause only at the two explicit gates marked GATE below.
 
 ## Pre-step — Doctrine triage before the planner spins up
 
-Before invoking `@nauro-planner`, the parent session confirms the planner will run `check_decision` first. The planner's contract already requires this, but the chain enforces it explicitly: if the planner returns a RED verdict (proposal directly contradicts an active decision) and drafts a supersede, the chain pauses before the executor sees anything. The user approves the supersede in chat; only after explicit approval does the planner file via `propose_decision` (which commits immediately) and the executor see the approved plan. This is the doctrine equivalent of GATE 1 firing early — a RED that the user does not resolve never reaches code.
+Before invoking `@nauro-planner`, the parent session confirms the planner will run `check_decision` first. The planner's contract already requires this, but the chain enforces it explicitly: if the planner returns a RED verdict (proposal directly contradicts an active decision) and drafts a supersede, the chain pauses before the executor sees anything. The user approves the supersede in chat; only after explicit approval does the planner file via `propose_decision` (which commits immediately) and the executor see the approved plan. This is the doctrine equivalent of the plan-approval gate (step 2) firing early — a RED that the user does not resolve never reaches code.
 
 ### 1. Plan
 
@@ -31,14 +31,14 @@ If the planner returns RED with a supersede draft, the chain pauses here. Surfac
 
 ### 2. GATE — plan approval (always when `propose_decision` is in play)
 
-The Nauro chain gates the plan whenever the planner indicates it will file a decision via `propose_decision` for any architectural choice, or whenever the plan records a supersede / update draft. This is stricter than the personal `/ship-task` skill: there is no "low-stakes auto-proceed" path when doctrine writes are pending. The user's judgment is the gate on what enters the decision log.
+The Nauro chain gates the plan whenever the planner indicates it will file a decision via `propose_decision` for any architectural choice, or whenever the plan records a supersede / update draft. There is no "low-stakes auto-proceed" path when doctrine writes are pending. The user's judgment is the gate on what enters the decision log.
 
 A change additionally always gates if any of the following apply:
 
 - Touches authentication, credentials, secrets, tokens, signing, or encryption
 - Changes data model, schema, storage format, or existing on-disk / database layout
 - Adds, removes, or renames public surface (CLI commands, public functions, MCP tools, API endpoints, env vars, config keys)
-- Changes the contract between `nauro` and `nauro-core`, or anything `mcp-server` consumes from `nauro-core`
+- Changes a contract between packages that ship or deploy separately, or any surface a deployed consumer depends on
 - Adds, removes, or major-version bumps a dependency
 - Records a Nauro decision with reversibility `hard` or `moderate`
 - Surfaces 2-3 defensible alternatives where the choice is genuinely architectural
@@ -61,9 +61,9 @@ If the reviewer returns BLOCK, hand the hard-rule failures back to the `@nauro-e
 
 ### 6. Doctrine pass
 
-When the reviewer returns APPROVE or APPROVE WITH NITS, invoke `@nauro-tech-lead` in Mode C on the same local diff. The tech-lead reads decisions, scans the diff for architectural choices, and returns GREEN / AMBER / RED with any drafted supersede / update awaiting user approval.
+When the reviewer returns APPROVE or APPROVE WITH NITS, invoke `@nauro-tech-lead` in Mode C on the same local diff. The invocation explicitly carries the chain context the parent already holds: the task description, the planner's verdict and any decision filed at plan time (or deliberately not filed), and the reviewer's verdict with its nits — the tech-lead does not re-infer chain state from the diff alone. The tech-lead reads decisions, scans the diff for architectural choices, and returns GREEN / AMBER / RED with any drafted supersede / update awaiting user approval.
 
-- **GREEN** — proceed to GATE.
+- **GREEN** — proceed to the push gate (step 7).
 - **AMBER** — surface the constraints to the user alongside the push gate; user decides whether to address before push or document as a follow-up.
 - **RED** — pause. Either redirect the executor (fix the drift, then re-run reviewer + tech-lead) or confirm the drafted supersede first. Do not push past a RED tech-lead verdict without an explicit human override on the cited decision.
 
@@ -81,12 +81,12 @@ If the body would be long, that's fine — paste it anyway. Skipping the verbati
 
 ### 8. Push
 
-On approval, push the branch and open the PR with the drafted description as the body (`gh pr create --body "..."`). Decisions filed during the chain go in the PR's Approach section by paraphrase, not by raw decision number — the public-repo convention is to describe the doctrine move ("the bundled-subagents pattern"), not cite internal D-numbers.
+On approval, push the branch. Write the drafted description to a file and open the PR with `gh pr create --body-file <file>` — passing the body inline breaks on quote characters in the drafted body. If `gh` is unavailable, hand the user the PR-creation URL the push prints (or the compare URL constructed from the remote and branch). Decisions filed during the chain go in the PR's Approach section by paraphrase, not by raw decision number — the public-repo convention is to describe the doctrine move ("the bundled-subagents pattern"), not cite internal D-numbers.
 
 ## Rules
 
 - A fully specified task still goes through the planner — the spec becomes the planner's input, not a reason to skip the chain and implement directly.
-- Push and `gh pr create` happen only with explicit user approval at GATE 7.
+- Push and `gh pr create` happen only with explicit user approval at the push gate (step 7).
 - `propose_decision` happens only with explicit user approval. Subagents draft or surface decisions; they never file an unapproved one. After the user approves in chat, the originating agent files — the planner for plan-time decisions, `@nauro-tech-lead` for doctrine moves it surfaces in Mode C. The executor never files; it surfaces emergent choices in its handoff (step 3) for the parent to gate. The kernel commits immediately on Tier 1 clean.
 - If a `propose_decision` is pending but the Nauro MCP server is disconnected, that is a hard pause — do not push the PR and file the decision after reconnecting. The code and its decision land together; a push-now-file-later split leaves doctrine unrecorded if the session ends first. Surface the disconnect and wait.
 - If anything fails or surprises mid-chain (a tool errors, tests fail unexpectedly, a verdict is incoherent), stop and surface to the user rather than recovering silently.

--- a/.cursor/rules/nauro-ship-task.mdc
+++ b/.cursor/rules/nauro-ship-task.mdc
@@ -21,7 +21,7 @@ Pause only at the two explicit gates marked GATE below.
 
 ## Pre-step — Doctrine triage before the planner spins up
 
-Before invoking `@nauro-planner`, the parent session confirms the planner will run `check_decision` first. The planner's contract already requires this, but the chain enforces it explicitly: if the planner returns a RED verdict (proposal directly contradicts an active decision) and drafts a supersede, the chain pauses before the executor sees anything. The user approves the supersede in chat; only after explicit approval does the planner file via `propose_decision` (which commits immediately) and the executor see the approved plan. This is the doctrine equivalent of GATE 1 firing early — a RED that the user does not resolve never reaches code.
+Before invoking `@nauro-planner`, the parent session confirms the planner will run `check_decision` first. The planner's contract already requires this, but the chain enforces it explicitly: if the planner returns a RED verdict (proposal directly contradicts an active decision) and drafts a supersede, the chain pauses before the executor sees anything. The user approves the supersede in chat; only after explicit approval does the planner file via `propose_decision` (which commits immediately) and the executor see the approved plan. This is the doctrine equivalent of the plan-approval gate (step 2) firing early — a RED that the user does not resolve never reaches code.
 
 ### 1. Plan
 
@@ -31,14 +31,14 @@ If the planner returns RED with a supersede draft, the chain pauses here. Surfac
 
 ### 2. GATE — plan approval (always when `propose_decision` is in play)
 
-The Nauro chain gates the plan whenever the planner indicates it will file a decision via `propose_decision` for any architectural choice, or whenever the plan records a supersede / update draft. This is stricter than the personal `/ship-task` skill: there is no "low-stakes auto-proceed" path when doctrine writes are pending. The user's judgment is the gate on what enters the decision log.
+The Nauro chain gates the plan whenever the planner indicates it will file a decision via `propose_decision` for any architectural choice, or whenever the plan records a supersede / update draft. There is no "low-stakes auto-proceed" path when doctrine writes are pending. The user's judgment is the gate on what enters the decision log.
 
 A change additionally always gates if any of the following apply:
 
 - Touches authentication, credentials, secrets, tokens, signing, or encryption
 - Changes data model, schema, storage format, or existing on-disk / database layout
 - Adds, removes, or renames public surface (CLI commands, public functions, MCP tools, API endpoints, env vars, config keys)
-- Changes the contract between `nauro` and `nauro-core`, or anything `mcp-server` consumes from `nauro-core`
+- Changes a contract between packages that ship or deploy separately, or any surface a deployed consumer depends on
 - Adds, removes, or major-version bumps a dependency
 - Records a Nauro decision with reversibility `hard` or `moderate`
 - Surfaces 2-3 defensible alternatives where the choice is genuinely architectural
@@ -61,9 +61,9 @@ If the reviewer returns BLOCK, hand the hard-rule failures back to the `@nauro-e
 
 ### 6. Doctrine pass
 
-When the reviewer returns APPROVE or APPROVE WITH NITS, invoke `@nauro-tech-lead` in Mode C on the same local diff. The tech-lead reads decisions, scans the diff for architectural choices, and returns GREEN / AMBER / RED with any drafted supersede / update awaiting user approval.
+When the reviewer returns APPROVE or APPROVE WITH NITS, invoke `@nauro-tech-lead` in Mode C on the same local diff. The invocation explicitly carries the chain context the parent already holds: the task description, the planner's verdict and any decision filed at plan time (or deliberately not filed), and the reviewer's verdict with its nits — the tech-lead does not re-infer chain state from the diff alone. The tech-lead reads decisions, scans the diff for architectural choices, and returns GREEN / AMBER / RED with any drafted supersede / update awaiting user approval.
 
-- **GREEN** — proceed to GATE.
+- **GREEN** — proceed to the push gate (step 7).
 - **AMBER** — surface the constraints to the user alongside the push gate; user decides whether to address before push or document as a follow-up.
 - **RED** — pause. Either redirect the executor (fix the drift, then re-run reviewer + tech-lead) or confirm the drafted supersede first. Do not push past a RED tech-lead verdict without an explicit human override on the cited decision.
 
@@ -81,12 +81,12 @@ If the body would be long, that's fine — paste it anyway. Skipping the verbati
 
 ### 8. Push
 
-On approval, push the branch and open the PR with the drafted description as the body (`gh pr create --body "..."`). Decisions filed during the chain go in the PR's Approach section by paraphrase, not by raw decision number — the public-repo convention is to describe the doctrine move ("the bundled-subagents pattern"), not cite internal D-numbers.
+On approval, push the branch. Write the drafted description to a file and open the PR with `gh pr create --body-file <file>` — passing the body inline breaks on quote characters in the drafted body. If `gh` is unavailable, hand the user the PR-creation URL the push prints (or the compare URL constructed from the remote and branch). Decisions filed during the chain go in the PR's Approach section by paraphrase, not by raw decision number — the public-repo convention is to describe the doctrine move ("the bundled-subagents pattern"), not cite internal D-numbers.
 
 ## Rules
 
 - A fully specified task still goes through the planner — the spec becomes the planner's input, not a reason to skip the chain and implement directly.
-- Push and `gh pr create` happen only with explicit user approval at GATE 7.
+- Push and `gh pr create` happen only with explicit user approval at the push gate (step 7).
 - `propose_decision` happens only with explicit user approval. Subagents draft or surface decisions; they never file an unapproved one. After the user approves in chat, the originating agent files — the planner for plan-time decisions, `@nauro-tech-lead` for doctrine moves it surfaces in Mode C. The executor never files; it surfaces emergent choices in its handoff (step 3) for the parent to gate. The kernel commits immediately on Tier 1 clean.
 - If a `propose_decision` is pending but the Nauro MCP server is disconnected, that is a hard pause — do not push the PR and file the decision after reconnecting. The code and its decision land together; a push-now-file-later split leaves doctrine unrecorded if the session ends first. Surface the disconnect and wait.
 - If anything fails or surprises mid-chain (a tool errors, tests fail unexpectedly, a verdict is incoherent), stop and surface to the user rather than recovering silently.

--- a/packages/nauro/src/nauro/skills/ship_task_body.md
+++ b/packages/nauro/src/nauro/skills/ship_task_body.md
@@ -23,7 +23,7 @@ Pause only at the two explicit gates marked GATE below.
 
 ## Pre-step — Doctrine triage before the planner spins up
 
-Before invoking `@nauro-planner`, the parent session confirms the planner will run `check_decision` first. The planner's contract already requires this, but the chain enforces it explicitly: if the planner returns a RED verdict (proposal directly contradicts an active decision) and drafts a supersede, the chain pauses before the executor sees anything. The user approves the supersede in chat; only after explicit approval does the planner file via `propose_decision` (which commits immediately) and the executor see the approved plan. This is the doctrine equivalent of GATE 1 firing early — a RED that the user does not resolve never reaches code.
+Before invoking `@nauro-planner`, the parent session confirms the planner will run `check_decision` first. The planner's contract already requires this, but the chain enforces it explicitly: if the planner returns a RED verdict (proposal directly contradicts an active decision) and drafts a supersede, the chain pauses before the executor sees anything. The user approves the supersede in chat; only after explicit approval does the planner file via `propose_decision` (which commits immediately) and the executor see the approved plan. This is the doctrine equivalent of the plan-approval gate (step 2) firing early — a RED that the user does not resolve never reaches code.
 
 ### 1. Plan
 
@@ -33,14 +33,14 @@ If the planner returns RED with a supersede draft, the chain pauses here. Surfac
 
 ### 2. GATE — plan approval (always when `propose_decision` is in play)
 
-The Nauro chain gates the plan whenever the planner indicates it will file a decision via `propose_decision` for any architectural choice, or whenever the plan records a supersede / update draft. This is stricter than the personal `/ship-task` skill: there is no "low-stakes auto-proceed" path when doctrine writes are pending. The user's judgment is the gate on what enters the decision log.
+The Nauro chain gates the plan whenever the planner indicates it will file a decision via `propose_decision` for any architectural choice, or whenever the plan records a supersede / update draft. There is no "low-stakes auto-proceed" path when doctrine writes are pending. The user's judgment is the gate on what enters the decision log.
 
 A change additionally always gates if any of the following apply:
 
 - Touches authentication, credentials, secrets, tokens, signing, or encryption
 - Changes data model, schema, storage format, or existing on-disk / database layout
 - Adds, removes, or renames public surface (CLI commands, public functions, MCP tools, API endpoints, env vars, config keys)
-- Changes the contract between `nauro` and `nauro-core`, or anything `mcp-server` consumes from `nauro-core`
+- Changes a contract between packages that ship or deploy separately, or any surface a deployed consumer depends on
 - Adds, removes, or major-version bumps a dependency
 - Records a Nauro decision with reversibility `hard` or `moderate`
 - Surfaces 2-3 defensible alternatives where the choice is genuinely architectural
@@ -63,9 +63,9 @@ If the reviewer returns BLOCK, hand the hard-rule failures back to the `@nauro-e
 
 ### 6. Doctrine pass
 
-When the reviewer returns APPROVE or APPROVE WITH NITS, invoke `@nauro-tech-lead` in Mode C on the same local diff. The tech-lead reads decisions, scans the diff for architectural choices, and returns GREEN / AMBER / RED with any drafted supersede / update awaiting user approval.
+When the reviewer returns APPROVE or APPROVE WITH NITS, invoke `@nauro-tech-lead` in Mode C on the same local diff. The invocation explicitly carries the chain context the parent already holds: the task description, the planner's verdict and any decision filed at plan time (or deliberately not filed), and the reviewer's verdict with its nits — the tech-lead does not re-infer chain state from the diff alone. The tech-lead reads decisions, scans the diff for architectural choices, and returns GREEN / AMBER / RED with any drafted supersede / update awaiting user approval.
 
-- **GREEN** — proceed to GATE.
+- **GREEN** — proceed to the push gate (step 7).
 - **AMBER** — surface the constraints to the user alongside the push gate; user decides whether to address before push or document as a follow-up.
 - **RED** — pause. Either redirect the executor (fix the drift, then re-run reviewer + tech-lead) or confirm the drafted supersede first. Do not push past a RED tech-lead verdict without an explicit human override on the cited decision.
 
@@ -83,12 +83,12 @@ If the body would be long, that's fine — paste it anyway. Skipping the verbati
 
 ### 8. Push
 
-On approval, push the branch and open the PR with the drafted description as the body (`gh pr create --body "..."`). Decisions filed during the chain go in the PR's Approach section by paraphrase, not by raw decision number — the public-repo convention is to describe the doctrine move ("the bundled-subagents pattern"), not cite internal D-numbers.
+On approval, push the branch. Write the drafted description to a file and open the PR with `gh pr create --body-file <file>` — passing the body inline breaks on quote characters in the drafted body. If `gh` is unavailable, hand the user the PR-creation URL the push prints (or the compare URL constructed from the remote and branch). Decisions filed during the chain go in the PR's Approach section by paraphrase, not by raw decision number — the public-repo convention is to describe the doctrine move ("the bundled-subagents pattern"), not cite internal D-numbers.
 
 ## Rules
 
 - A fully specified task still goes through the planner — the spec becomes the planner's input, not a reason to skip the chain and implement directly.
-- Push and `gh pr create` happen only with explicit user approval at GATE 7.
+- Push and `gh pr create` happen only with explicit user approval at the push gate (step 7).
 - `propose_decision` happens only with explicit user approval. Subagents draft or surface decisions; they never file an unapproved one. After the user approves in chat, the originating agent files — the planner for plan-time decisions, `@nauro-tech-lead` for doctrine moves it surfaces in Mode C. The executor never files; it surfaces emergent choices in its handoff (step 3) for the parent to gate. The kernel commits immediately on Tier 1 clean.
 - If a `propose_decision` is pending but the Nauro MCP server is disconnected, that is a hard pause — do not push the PR and file the decision after reconnecting. The code and its decision land together; a push-now-file-later split leaves doctrine unrecorded if the session ends first. Surface the disconnect and wait.
 - If anything fails or surprises mid-chain (a tool errors, tests fail unexpectedly, a verdict is incoherent), stop and surface to the user rather than recovering silently.

--- a/packages/nauro/tests/test_skills_drift.py
+++ b/packages/nauro/tests/test_skills_drift.py
@@ -54,13 +54,16 @@ def test_load_ship_task_body_returns_canonical_bytes():
     assert "@nauro-executor" in body
     assert "@nauro-reviewer" in body
     assert "@nauro-tech-lead" in body
-    # Nauro-strict gate language must remain — the chain always gates on
-    # propose_decision firing, not the personal /ship-task low-stakes path.
+    # Nauro-strict gate language must remain — the chain always gates when
+    # doctrine writes are pending; there is no low-stakes auto-proceed path.
     assert "propose_decision" in body
     # Tech-lead Mode C pass sits between reviewer-APPROVE and the push gate.
     assert "Mode C" in body
     # Required prerequisite reference to the bundled subagents flag.
     assert "--with-subagents" in body
+    # PR creation goes through a body file — an inline body argument breaks
+    # on quote characters in the drafted description.
+    assert "--body-file" in body
 
 
 def test_load_context_body_returns_canonical_bytes():
@@ -275,6 +278,14 @@ RETIRED_PHRASES = [
     (
         "confirm_decision",
         "confirm_decision was removed; propose_decision is now a single-call commit",
+    ),
+    (
+        'gh pr create --body "',
+        "inline PR bodies break on quote characters; the chain writes the body to a file",
+    ),
+    (
+        "`mcp-server` consumes from `nauro-core`",
+        "the always-gate triggers were generalized; the body must not name this project's repos",
     ),
 ]
 


### PR DESCRIPTION
## Why

The ship-task skill body ships to end users' machines, and three parts of it were wrong or dead text outside this repo. The PR-creation step instructed an inline `gh pr create --body "..."`, which breaks on quote characters in the drafted body; the shipped instruction contradicted a lesson already learned in dogfood. The doctrine pass invoked the tech-lead on the diff alone, forcing it to re-infer chain state (task description, planner verdict, reviewer verdict) that the parent session already holds. And the always-gate list named this project's own internal repos as a trigger condition, which is dead text in every other project.

## Approach

Generalize in the single shared body: one body serves both the dogfood files at the repo root and the rendered surfaces end users install, so the fix lands everywhere at once. Two alternatives were rejected. Per-audience renders would break the dogfood byte-identity invariant the drift tests enforce and double the maintenance surface. A config-parameterized trigger list is speculative infrastructure with no second consumer. Gate labels move from sequence numbers to descriptive names with step references ("the plan-approval gate (step 2)", "the push gate (step 7)") because sequence numbers re-rot every time a step is inserted; the two GATE headings keep their markers.

## What changed

Four edit groups in the canonical body:

- The push step writes the drafted description to a file and opens the PR with `gh pr create --body-file <file>`, with a fallback when `gh` is unavailable: hand the user the PR-creation URL the push prints (or the compare URL built from the remote and branch).
- The Mode C tech-lead invocation explicitly carries the chain context: the task description, the planner's verdict and any decision filed at plan time (or deliberately not filed), and the reviewer's verdict with its nits. The tech-lead does not re-infer chain state from the diff alone.
- The internal-repo gate trigger is restated as abstract conditions: a contract between packages that ship or deploy separately, or any surface a deployed consumer depends on.
- The comparison to a personal skill is dropped while keeping the no-auto-proceed semantics, and the two numbered gate references move to descriptive names with step references.

Test side: two new retired-phrase drift anchors (the inline-body instruction and the internal-repo trigger wording), a positive `--body-file` anchor in the canonical-bytes test, and a comment reword. The three dogfood renders (.claude, .cursor, .agents) are regenerated via `render_skill` in the same commit; frontmatter is untouched.

## What to review

The generalized gate trigger ("packages that ship or deploy separately, or any surface a deployed consumer depends on") is the one place where abstraction could under-trigger relative to the old concrete list; check that it still covers the cases the old line named. On the test side, both retired phrases were verified unique to the edited lines across all scanned surfaces before being added; the inline-body anchor keeps its trailing quote character so it cannot collide with the new `--body-file` instruction.

## What's deferred

The downstream plugin re-render rides the next plugin publish. Per-surface skill materialization awaits its own decision. Adopt and context body edits ride other PRs.

## Test plan

The three new anchors were added before the body edits and failed exactly as expected, each failing only against the ship-task body (confirming phrase uniqueness on the other scanned surfaces). After the body edits and re-render: 1456 passed, 10 skipped across the nauro package suite; `ruff check` and `ruff format --check` clean. The byte-identity tests pin all three regenerated renders to `render_skill` output.
