### PR TITLE
Local MCP server copy: adopt-first onboarding, transport-neutral project_id guidance, cwd description

### DIFF
--- a/packages/nauro-core/src/nauro_core/mcp_tools.py
+++ b/packages/nauro-core/src/nauro_core/mcp_tools.py
@@ -51,8 +51,9 @@ _PROJECT_PARAM: dict[str, Any] = {
     "type": "string",
     "description": (
         "Optional. If you have one project, the server resolves it "
-        "automatically. Pass explicitly if you have multiple — call "
-        "list_projects to discover the IDs available to the current user."
+        "automatically. Pass explicitly if you have multiple: the hosted "
+        "server's list_projects tool returns the available IDs, and on the "
+        "local server the `nauro projects` terminal command lists them."
     ),
 }
 

--- a/packages/nauro/src/nauro/mcp/stdio_server.py
+++ b/packages/nauro/src/nauro/mcp/stdio_server.py
@@ -138,13 +138,28 @@ def _param_desc(tool_name: str, param: str) -> str:
 _resolve_store = resolve_store
 _resolve_via_repo_config = resolve_via_repo_config
 
+# ``cwd`` exists only on the local transport (the hosted server has no
+# filesystem to resolve against), so its description lives here rather than
+# in the shared ToolSpec registry, which would surface it on remote schemas.
+_CWD_PARAM = Annotated[
+    str | None,
+    Field(
+        description=(
+            "Optional. Absolute directory path used to resolve the project "
+            "from the local registry when project_id is not given. Callers "
+            "pass their working directory so resolution matches the repo "
+            "they are operating in."
+        )
+    ),
+]
+
 
 @mcp.tool(**_spec_kwargs("get_context"))
 def get_context(
     project_id: Annotated[
         str | None, Field(description=_param_desc("get_context", "project_id"))
     ] = None,
-    cwd: str | None = None,
+    cwd: _CWD_PARAM = None,
     level: Annotated[
         Literal["L0", "L1", "L2"] | int,
         Field(description=_param_desc("get_context", "level")),
@@ -168,7 +183,7 @@ def get_raw_file(
     project_id: Annotated[
         str | None, Field(description=_param_desc("get_raw_file", "project_id"))
     ] = None,
-    cwd: str | None = None,
+    cwd: _CWD_PARAM = None,
 ) -> dict:
     try:
         store_path = _resolve_store(project_id, cwd)
@@ -184,7 +199,7 @@ def list_decisions(
     project_id: Annotated[
         str | None, Field(description=_param_desc("list_decisions", "project_id"))
     ] = None,
-    cwd: str | None = None,
+    cwd: _CWD_PARAM = None,
     limit: Annotated[int, Field(description=_param_desc("list_decisions", "limit"))] = 20,
     include_superseded: Annotated[
         bool, Field(description=_param_desc("list_decisions", "include_superseded"))
@@ -210,7 +225,7 @@ def get_decision(
     project_id: Annotated[
         str | None, Field(description=_param_desc("get_decision", "project_id"))
     ] = None,
-    cwd: str | None = None,
+    cwd: _CWD_PARAM = None,
 ) -> CallToolResult:
     try:
         store_path = _resolve_store(project_id, cwd)
@@ -229,7 +244,7 @@ def diff_since_last_session(
         str | None,
         Field(description=_param_desc("diff_since_last_session", "project_id")),
     ] = None,
-    cwd: str | None = None,
+    cwd: _CWD_PARAM = None,
     days: Annotated[
         int | None, Field(description=_param_desc("diff_since_last_session", "days"))
     ] = None,
@@ -253,7 +268,7 @@ def search_decisions(
     project_id: Annotated[
         str | None, Field(description=_param_desc("search_decisions", "project_id"))
     ] = None,
-    cwd: str | None = None,
+    cwd: _CWD_PARAM = None,
 ) -> CallToolResult:
     try:
         store_path = _resolve_store(project_id, cwd)
@@ -280,7 +295,7 @@ def check_decision(
     project_id: Annotated[
         str | None, Field(description=_param_desc("check_decision", "project_id"))
     ] = None,
-    cwd: str | None = None,
+    cwd: _CWD_PARAM = None,
 ) -> CallToolResult:
     try:
         store_path = _resolve_store(project_id, cwd)
@@ -344,7 +359,7 @@ def propose_decision(
         str | None,
         Field(description=_param_desc("propose_decision", "project_id")),
     ] = None,
-    cwd: str | None = None,
+    cwd: _CWD_PARAM = None,
 ) -> dict:
     try:
         store_path = _resolve_store(project_id, cwd)
@@ -384,7 +399,7 @@ def flag_question(
     project_id: Annotated[
         str | None, Field(description=_param_desc("flag_question", "project_id"))
     ] = None,
-    cwd: str | None = None,
+    cwd: _CWD_PARAM = None,
 ) -> str:
     try:
         store_path = _resolve_store(project_id, cwd)
@@ -412,7 +427,7 @@ def update_state(
     project_id: Annotated[
         str | None, Field(description=_param_desc("update_state", "project_id"))
     ] = None,
-    cwd: str | None = None,
+    cwd: _CWD_PARAM = None,
 ) -> str:
     try:
         store_path = _resolve_store(project_id, cwd)

--- a/packages/nauro/src/nauro/onboarding.py
+++ b/packages/nauro/src/nauro/onboarding.py
@@ -15,8 +15,12 @@ from nauro_core.constants import NO_DECISIONS_TO_CHECK as NO_DECISIONS_TO_CHECK
 WELCOME_NO_PROJECT = (
     "Welcome to Nauro! No project store found.\n"
     "\n"
+    "Nauro is local-first: this server reads the store at ~/.nauro on this\n"
+    "machine, resolved from the current working directory.\n"
+    "\n"
     "To get started:\n"
-    "1. Run: nauro init <project-name>\n"
+    "1. From an existing repo, run: nauro adopt\n"
+    "   (for a project without a repo: nauro init <project-name>)\n"
     '2. Log a decision: nauro note "Chose Postgres over MongoDB"\n'
     "\n"
     "Your decisions will then be available here and across all connected AI tools."


### PR DESCRIPTION
## Why

Cross-surface testing of the Claude Code plugin (Cowork session, 2026-06-12) surfaced three guidance gaps in the local MCP server, all copy-level but each one lands on a new user's first run:

1. The no-store welcome message led with `nauro init`, but for anyone sitting in an existing repo the right first step is `nauro adopt`. It also never stated the local-first resolution model, so users coming from the hosted connector could not tell why the plugin saw no project.
2. The shared `project_id` parameter description told callers to use `list_projects`, which only the hosted server registers; on the local server that is a dead reference to a tool the user cannot call.
3. The local-only `cwd` parameter carried no description at all, leaving the resolution mechanism it drives undocumented in the schema.

## Approach

All three are wording fixes in the existing structures, no behavior changes. The `project_id` text stays a single shared constant in nauro-core, reworded to be accurate on both transports rather than forked per surface. The `cwd` description lives in the stdio module as a module-level `Annotated` alias, with a comment explaining why it cannot move into the shared ToolSpec registry: the parameter exists only on the local transport, and registry placement would surface it on remote schemas.

## What changed

- `onboarding.py`: the welcome message states the local-first model and leads with `nauro adopt`, keeping `nauro init` as the no-repo alternative.
- `nauro_core/mcp_tools.py`: transport-neutral `project_id` guidance (hosted: `list_projects` tool; local: `nauro projects` command).
- `stdio_server.py`: `_CWD_PARAM` alias applied to all ten tool signatures.

## What to review

The reworded `project_id` description is shared by both servers; confirm the hosted phrasing still reads correctly in the connector context.

## What's deferred

Two related findings from the same testing round are tracked separately: error-envelope parity between the local and hosted servers (filed as an open question), and whether the local server should register `list_projects` now that multi-project local registries are common.

## Test plan

Both package suites pass (2321 passed, 10 skipped); ruff check and format clean. Live-verified by instantiating the FastMCP server and inspecting the rendered schemas: the `cwd` description is present, `project_id` references the `nauro projects` command, and the welcome constant carries the adopt-first text.
