### PR TITLE
Add MCP registry listing metadata

### DIFF
--- a/packages/nauro/README.md
+++ b/packages/nauro/README.md
@@ -66,3 +66,5 @@ Free: unlimited local usage, unlimited projects, 5,000 remote MCP calls/month. S
 Apache 2.0 license. Part of the [nauro-ai/nauro](https://github.com/nauro-ai/nauro) monorepo.
 
 Named for Peter Naur, whose 1985 paper *Programming as Theory Building* argued the real program is the theory in the programmer's mind, not the code. Every fresh agent session is the equivalent of losing that programmer.
+
+<!-- mcp-name: ai.nauro/nauro -->

--- a/server.json
+++ b/server.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "ai.nauro/nauro",
+  "title": "Nauro",
+  "description": "Decision system for AI coding agents. Surfaces what your project decided, and why, before changes.",
+  "websiteUrl": "https://nauro.ai",
+  "repository": {
+    "url": "https://github.com/Nauro-AI/nauro",
+    "source": "github"
+  },
+  "version": "0.13.2",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "nauro",
+      "version": "0.13.2",
+      "runtimeHint": "uvx",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "serve"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Why

PulseMCP and other MCP directories ingest from the official MCP registry rather than accepting direct submissions, so listing Nauro there is the one publish that feeds the aggregator ecosystem. The registry verifies PyPI package ownership by finding an mcp-name marker in the published package README, which means the marker must ship in a release before the registry publish can succeed.

## What changed

- packages/nauro/README.md gains a hidden-comment marker naming the server ai.nauro/nauro (the domain-verified namespace for nauro.ai). PyPI preserves HTML comments in the rendered description, so the marker is invisible to readers.
- server.json at the repo root carries the registry metadata: PyPI package nauro, stdio transport, uvx runtime hint with the single serve argument (serve defaults to stdio; the --stdio flag is backward-compat only).

## What to review

The registry name ai.nauro/nauro is load-bearing in two places that must match exactly: the README marker and the server.json name field. Ownership verification fails on any mismatch.

## Test plan

server.json validates against the published 2025-12-11 registry schema. Full nauro package suite passes (1461 passed). The README change is a trailing hidden comment; rendering is unaffected.
