### PR TITLE
Bump nauro to 0.13.2

### DIFF
--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro"
-version = "0.13.1"
+version = "0.13.2"
 description = "Local CLI + MCP server: set your project's doctrine once, every connected AI agent inherits it."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Why

Patch release with two payloads: the MCP registry ownership marker in the package README (required on PyPI before the registry publish of ai.nauro/nauro can verify ownership) and the local-server guidance copy fixes from the Cowork testing round (adopt-first onboarding, transport-neutral project_id wording, cwd parameter description).

## What changed

pyproject version 0.13.1 to 0.13.2, nothing else, per the tag-triggered release convention.

## Test plan

Version-bump-only PR; CI runs the full suite. Both payloads were tested in their own PRs.
