### PR TITLE
Move POINTER_FLAG_PREFIXES to nauro-core, exclude discovery pointers from L0, and remove dead code

### DIFF
--- a/packages/nauro-core/README.md
+++ b/packages/nauro-core/README.md
@@ -12,7 +12,7 @@ pip install nauro-core
 
 - **`decision_model`** — the Pydantic `Decision` model plus compiled regexes and `parse_decision`/`format_decision` for the Nauro markdown protocol (decision titles, metadata fields, section headers)
 - **`constants`** — limits, thresholds, valid values, file paths shared across all Nauro surfaces
-- **`parsing`** — pure markdown→data helpers: `parse_questions`, `extract_stack_summary`, `decisions_summary_lines` (decision parsing lives in `decision_model.parse_decision`, which returns a validated `Decision`)
+- **`parsing`** — pure markdown→data helpers: `extract_stack_summary`, `decisions_summary_lines` (decision parsing lives in `decision_model.parse_decision`, which returns a validated `Decision`)
 - **`context`** — `build_l0`/`build_l1`/`build_l2` context assembly from pre-loaded files and parsed decisions
 - **`validation`** — structural screening, hash dedup, BM25 similarity for decision conflict detection
 

--- a/packages/nauro-core/src/nauro_core/__init__.py
+++ b/packages/nauro-core/src/nauro_core/__init__.py
@@ -67,6 +67,9 @@ from nauro_core.constants import (
     OPEN_QUESTIONS_MD as OPEN_QUESTIONS_MD,
 )
 from nauro_core.constants import (
+    POINTER_FLAG_PREFIXES as POINTER_FLAG_PREFIXES,
+)
+from nauro_core.constants import (
     PROJECT_MD as PROJECT_MD,
 )
 from nauro_core.constants import (
@@ -185,9 +188,6 @@ from nauro_core.parsing import (
 )
 from nauro_core.parsing import (
     first_sentence_end as first_sentence_end,
-)
-from nauro_core.parsing import (
-    parse_questions as parse_questions,
 )
 from nauro_core.parsing import (
     scan_decision_references as scan_decision_references,

--- a/packages/nauro-core/src/nauro_core/constants.py
+++ b/packages/nauro-core/src/nauro_core/constants.py
@@ -74,6 +74,12 @@ STATE_OVERLAP_STOP_WORDS: frozenset[str] = frozenset(
 # ── Reversibility levels ──
 REVERSIBILITY_LEVELS: tuple[str, ...] = ("easy", "moderate", "hard")
 
+# ── Discovery-pointer flag markers ──
+# Entries in open-questions.md whose body starts with one of these prefixes
+# are discovery breadcrumbs (BRIEF for shared context briefs, RESUME for
+# agent resume briefs), not questions for human review.
+POINTER_FLAG_PREFIXES: tuple[str, ...] = ("BRIEF:", "RESUME:")
+
 # ── Stack empty marker ──
 STACK_EMPTY_MARKER = "# Stack\n<!-- Tech choices with rationale and rejected alternatives -->"
 

--- a/packages/nauro-core/src/nauro_core/context.py
+++ b/packages/nauro-core/src/nauro_core/context.py
@@ -14,6 +14,7 @@ from nauro_core.constants import (
     L0_QUESTIONS_LIMIT,
     L1_DECISIONS_LIMIT,
     L1_DECISIONS_SUMMARY_LIMIT,
+    POINTER_FLAG_PREFIXES,
 )
 from nauro_core.decision_model import Decision, DecisionStatus
 from nauro_core.parsing import (
@@ -35,12 +36,25 @@ def _active_decisions(decisions: list[Decision]) -> list[Decision]:
     return [d for d in decisions if d.status is DecisionStatus.active]
 
 
+def _is_discovery_pointer(body: str) -> bool:
+    """Return True when an entry body starts with a discovery-pointer prefix.
+
+    Discovery pointers (BRIEF:/RESUME: entries) are breadcrumbs written by
+    the nauro-context skill, not questions for human review, and are excluded
+    from the L0 Open Questions projection.
+    """
+    stripped = body.lstrip()
+    return stripped.startswith(POINTER_FLAG_PREFIXES)
+
+
 def _render_l0_open_questions(content: str) -> str:
     """Render the first ``L0_QUESTIONS_LIMIT`` open ``EntryBlock``s for L0.
 
-    Walks the parsed block list rather than ``parse_questions`` so the
-    entry's ``timestamp`` survives for the age projection. Entries
+    Walks the parsed block list so the entry's ``timestamp`` survives for
+    the age projection. Entries
     physically under ``## Resolved`` are skipped via the divider index.
+    Discovery-pointer entries (body starts with ``BRIEF:`` or ``RESUME:``)
+    are excluded entirely and do not consume a slot in the limit.
     A ``(open NN days; consider closing or deferring)`` line is prepended
     when ``entry.timestamp`` is set and the entry is older than
     :data:`_L0_AGE_PROJECTION_DAYS`. Q-form entries without a timestamp
@@ -61,6 +75,8 @@ def _render_l0_open_questions(content: str) -> str:
         if not isinstance(block, EntryBlock):
             continue
         if block.entry.resolved_by is not None:
+            continue
+        if _is_discovery_pointer(block.entry.body):
             continue
         if rendered >= L0_QUESTIONS_LIMIT:
             break

--- a/packages/nauro-core/src/nauro_core/parsing.py
+++ b/packages/nauro-core/src/nauro_core/parsing.py
@@ -208,26 +208,6 @@ def extract_stack_summary(stack_content: str) -> str:
     return "\n".join(lines)
 
 
-def parse_questions(content: str) -> list[str]:
-    """Extract question lines from open-questions.md."""
-    questions: list[str] = []
-    in_resolved = False
-    for line in content.split("\n"):
-        stripped = line.strip()
-        if stripped.startswith("## "):
-            in_resolved = "resolved" in stripped.lower()
-            continue
-        if in_resolved:
-            continue
-        if line.startswith("- ["):
-            questions.append(line)
-        elif line.startswith("### "):
-            questions.append("- " + line.lstrip("# "))
-        elif line.startswith("- ") and not line.startswith("  "):
-            questions.append(line)
-    return questions
-
-
 def decisions_summary_lines(decisions: list, limit: int = 10) -> list[str]:
     """Build compact summary lines for decisions: ``D{num} — Title (date)``."""
     lines = []

--- a/packages/nauro-core/src/nauro_core/questions.py
+++ b/packages/nauro-core/src/nauro_core/questions.py
@@ -11,9 +11,8 @@ entries written before the Q-form rollout keep round-tripping without
 rewrite. The discriminator is which of ``num`` / ``timestamp`` is set on
 :class:`QuestionEntry`. Resolution sets ``resolved_by`` on the matching
 :class:`EntryBlock`; ``format`` then re-emits it with the ``[Resolved by
-Dnn on YYYY-MM-DD]`` prefix. ``parse_questions`` (in
-:mod:`nauro_core.parsing`) already filters the ``## Resolved`` subsection
-out of L0 reads.
+Dnn on YYYY-MM-DD]`` prefix. The ``## Resolved`` subsection is excluded
+from L0 reads via the divider index on the parsed model.
 
 The internal shape is a flat ``blocks`` list. Each markdown line maps to
 exactly one block (``HeaderBlock``, ``ProseBlock``, ``EntryBlock``,

--- a/packages/nauro-core/src/nauro_core/validation.py
+++ b/packages/nauro-core/src/nauro_core/validation.py
@@ -64,11 +64,6 @@ def is_scaffold_seed(decision) -> bool:
     return decision.get("num") == 1 and decision.get("title") == _SCAFFOLD_SEED_TITLE
 
 
-# Historical private name kept as an alias for callers that imported it before
-# the public predicate existed.
-_is_scaffold_seed = is_scaffold_seed
-
-
 def check_bm25_similarity(
     proposal: dict,
     existing_decisions: list,
@@ -94,7 +89,7 @@ def check_bm25_similarity(
         and related uses the ``bm25_retrieve`` shape:
         ``{"number", "title", "similarity", "rationale_preview"}``.
     """
-    candidates = [d for d in existing_decisions if not _is_scaffold_seed(d)]
+    candidates = [d for d in existing_decisions if not is_scaffold_seed(d)]
     if not candidates:
         return ("auto_confirm", [])
 

--- a/packages/nauro-core/tests/test_constants.py
+++ b/packages/nauro-core/tests/test_constants.py
@@ -13,6 +13,7 @@ from nauro_core.constants import (
     MCP_INSTRUCTIONS_STATIC,
     MIN_RATIONALE_LENGTH,
     OPEN_QUESTIONS_MD,
+    POINTER_FLAG_PREFIXES,
     PROJECT_MD,
     REVERSIBILITY_LEVELS,
     SNAPSHOTS_DIR,
@@ -84,6 +85,14 @@ class TestValidValues:
 
     def test_reversibility_levels_non_empty(self):
         assert REVERSIBILITY_LEVELS == ("easy", "moderate", "hard")
+
+
+class TestPointerFlagPrefixes:
+    def test_exact_value(self):
+        assert POINTER_FLAG_PREFIXES == ("BRIEF:", "RESUME:")
+
+    def test_is_tuple(self):
+        assert isinstance(POINTER_FLAG_PREFIXES, tuple)
 
 
 class TestFilenames:

--- a/packages/nauro-core/tests/test_context.py
+++ b/packages/nauro-core/tests/test_context.py
@@ -415,3 +415,80 @@ class TestBuildL0OpenQuestionsAgeProjection:
         old_idx = result.index("Old one?")
         between = result[old_idx + len("Old one?") : recent_idx]
         assert self._PROJECTION_PREFIX not in between
+
+
+class TestBuildL0DiscoveryPointerExclusion:
+    """Discovery-pointer entries (BRIEF:/RESUME: body prefix) are excluded
+    from the L0 Open Questions section and do not consume a limit slot.
+    """
+
+    def _files(self, content: str) -> dict[str, str]:
+        return {"questions.md": content}
+
+    def test_brief_pointer_excluded(self):
+        content = (
+            "# Open Questions\n"
+            "\n"
+            "- [Q1] BRIEF: context/topic-20260601-ab12.md — shared brief\n"
+            "- [Q2] Genuine open question?\n"
+        )
+        result = build_l0(self._files(content), [])
+        assert "Genuine open question?" in result
+        assert "BRIEF:" not in result
+
+    def test_resume_pointer_excluded(self):
+        content = (
+            "# Open Questions\n"
+            "\n"
+            "- [Q1] RESUME: context/auth-cutover-20260601-cd34.md — resume brief\n"
+            "- [Q2] Another genuine question?\n"
+        )
+        result = build_l0(self._files(content), [])
+        assert "Another genuine question?" in result
+        assert "RESUME:" not in result
+
+    def test_pointer_does_not_consume_limit_slot(self):
+        # With limit = 3, three genuine questions plus two pointers should all
+        # three genuine questions appear (pointers do not count toward the cap).
+        content = (
+            "# Open Questions\n"
+            "\n"
+            "- [Q1] BRIEF: context/a.md — pointer one\n"
+            "- [Q2] First genuine question?\n"
+            "- [Q3] Second genuine question?\n"
+            "- [Q4] RESUME: context/b.md — pointer two\n"
+            "- [Q5] Third genuine question?\n"
+            "- [Q6] Fourth genuine question — should be cut by limit?\n"
+        )
+        result = build_l0(self._files(content), [])
+        assert "First genuine question?" in result
+        assert "Second genuine question?" in result
+        assert "Third genuine question?" in result
+        assert "Fourth genuine question" not in result
+        assert "BRIEF:" not in result
+        assert "RESUME:" not in result
+
+    def test_pointer_free_file_unaffected(self):
+        content = (
+            "# Open Questions\n"
+            "\n"
+            "- [Q1] How does auth work?\n"
+            "- [Q2] What about caching?\n"
+            "- [Q3] Redis or Memcached?\n"
+        )
+        result = build_l0(self._files(content), [])
+        assert "How does auth work?" in result
+        assert "What about caching?" in result
+        assert "Redis or Memcached?" in result
+        assert "## Open Questions" in result
+
+    def test_all_pointers_yields_empty_open_questions(self):
+        # When every open entry is a pointer, the section is suppressed entirely.
+        content = (
+            "# Open Questions\n"
+            "\n"
+            "- [Q1] BRIEF: context/x.md — brief one\n"
+            "- [Q2] RESUME: context/y.md — resume one\n"
+        )
+        result = build_l0(self._files(content), [])
+        assert "## Open Questions" not in result

--- a/packages/nauro/src/nauro/constants.py
+++ b/packages/nauro/src/nauro/constants.py
@@ -21,6 +21,7 @@ from nauro_core.constants import L1_DECISIONS_LIMIT as L1_DECISIONS_LIMIT
 from nauro_core.constants import L1_DECISIONS_SUMMARY_LIMIT as L1_DECISIONS_SUMMARY_LIMIT
 from nauro_core.constants import MIN_RATIONALE_LENGTH as MIN_RATIONALE_LENGTH
 from nauro_core.constants import OPEN_QUESTIONS_MD as OPEN_QUESTIONS_MD
+from nauro_core.constants import POINTER_FLAG_PREFIXES as POINTER_FLAG_PREFIXES
 from nauro_core.constants import PROJECT_MD as PROJECT_MD
 from nauro_core.constants import REVERSIBILITY_LEVELS as REVERSIBILITY_LEVELS
 from nauro_core.constants import SNAPSHOT_SCHEMA_VERSION as SNAPSHOT_SCHEMA_VERSION
@@ -77,15 +78,6 @@ L0_TOKEN_LIMIT = 3500
 # this the flag is annotated with a hint pointing at the matching decision.
 FLAG_QUESTION_HINT_MIN_SCORE = 0.7
 FLAG_QUESTION_HINT_TITLE_LENGTH = 100
-
-# ── Discovery-pointer flag markers ──
-# The nauro-context skill flags a stored file's path as a question (it lands on
-# the union-merged open-questions.md): BRIEF for a shared brief, RESUME for a
-# self-directed resume brief from its resume mode. Such a flag is a discovery
-# pointer, not a question for human review, so the similar-decision hint above
-# is skipped for it — otherwise a pointer draws a spurious
-# "addressed by decision-NNN" annotation.
-POINTER_FLAG_PREFIXES: tuple[str, ...] = ("BRIEF:", "RESUME:")
 
 # ── Writer limits ──
 SLUG_MAX_LENGTH = 60

--- a/packages/nauro/tests/conftest.py
+++ b/packages/nauro/tests/conftest.py
@@ -10,6 +10,8 @@ from typing import Any
 
 import pytest
 
+from nauro.mcp.tools import tool_get_context
+
 # Magic UUID4 used by every telemetry test that seeds a consented config.
 # Centralized so a rotation in one file can't drift away from the rest.
 TEST_ANONYMOUS_ID = "11111111-1111-4111-8111-111111111111"
@@ -28,6 +30,15 @@ CROSS_SURFACE_BUCKET = "nauro-cross-surface-test"
 def cloud_prefix(user_id: str, project_id: str) -> str:
     """Return the S3 key prefix a CloudStore reads/writes under for a project."""
     return f"users/{user_id}/projects/{project_id}"
+
+
+def read_project_context(store_path: Path, level: int = 0) -> str:
+    """Extract the ``content`` string from the ``tool_get_context`` envelope.
+
+    Shared by tests that assert on the rendered context string without
+    caring about the surrounding envelope fields.
+    """
+    return tool_get_context(store_path, level)["content"]
 
 
 @contextmanager

--- a/packages/nauro/tests/test_check_command.py
+++ b/packages/nauro/tests/test_check_command.py
@@ -47,24 +47,6 @@ def demo_repo(tmp_path, monkeypatch):
     return "demo-project", pid, store_path, repo
 
 
-@pytest.fixture
-def no_decisions_repo(tmp_path, monkeypatch):
-    """Register a v2 project whose store has no decisions/ directory at all.
-
-    Hits the empty-store branch in ``check_decision`` — distinct from a
-    scaffolded store (which seeds 001-initial-setup.md and therefore has
-    decisions).
-    """
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    pid, store_path = register_project_v2("bare-project", [repo], mode=REPO_CONFIG_MODE_LOCAL)
-    save_repo_config(repo, {"mode": REPO_CONFIG_MODE_LOCAL, "id": pid, "name": "bare-project"})
-    # register_project_v2 already created the store dir; deliberately skip
-    # scaffold_project_store so decisions/ never gets populated.
-    monkeypatch.chdir(repo)
-    return "bare-project", pid, store_path, repo
-
-
 # --- happy path: demo prompt retrieves the SSE-over-WebSocket decision ------
 
 

--- a/packages/nauro/tests/test_demo.py
+++ b/packages/nauro/tests/test_demo.py
@@ -7,14 +7,9 @@ import pytest
 
 from nauro import constants
 from nauro.demo import create_demo_project
-from nauro.mcp.tools import tool_get_context
 from nauro.store.reader import _list_decisions
 from nauro.store.snapshot import list_snapshots
-
-
-def read_project_context(store_path: Path, level: int = 0) -> str:
-    """Local test helper — keeps the existing assertions using str content."""
-    return tool_get_context(store_path, level)["content"]
+from tests.conftest import read_project_context
 
 
 @pytest.fixture()

--- a/packages/nauro/tests/test_log_diff.py
+++ b/packages/nauro/tests/test_log_diff.py
@@ -12,7 +12,7 @@ from typer.testing import CliRunner
 
 from nauro.cli.main import app
 from nauro.constants import SNAPSHOTS_DIR
-from nauro.mcp.tools import tool_diff_since_last_session, tool_get_context
+from nauro.mcp.tools import tool_diff_since_last_session
 from nauro.store.filesystem_store import FilesystemStore
 from nauro.store.snapshot import (
     capture_snapshot,
@@ -21,6 +21,7 @@ from nauro.store.snapshot import (
 )
 from nauro.templates.scaffolds import scaffold_project_store
 from tests._writer_compat import append_decision
+from tests.conftest import read_project_context
 
 
 def update_state(store_path: Path, delta: str) -> None:
@@ -59,17 +60,6 @@ def diff_snapshots(store_path: Path, version_a: int, version_b: int) -> str:
 
 
 runner = CliRunner()
-
-
-def read_project_context(store_path: Path, level: int = 0) -> str:
-    """Local test helper — keeps the existing assertions using str content.
-
-    The MCP boundary now returns a dict envelope; this shim extracts the
-    ``content`` field so the tests below can keep their pre-cutover shape
-    while exercising the same dispatch through ``tool_get_context``.
-    """
-    result = tool_get_context(store_path, level)
-    return result["content"]
 
 
 @pytest.fixture

--- a/packages/nauro/tests/test_store.py
+++ b/packages/nauro/tests/test_store.py
@@ -11,7 +11,6 @@ from typer.testing import CliRunner
 
 from nauro.cli.main import app
 from nauro.constants import SNAPSHOTS_DIR
-from nauro.mcp.tools import tool_get_context
 from nauro.store.filesystem_store import FilesystemStore
 from nauro.store.reader import _list_decisions
 from nauro.store.snapshot import capture_snapshot, list_snapshots, load_snapshot
@@ -21,6 +20,7 @@ from nauro.templates.scaffolds import (
     scaffold_project_store,
 )
 from tests._writer_compat import append_decision
+from tests.conftest import read_project_context
 
 
 def update_state(store_path: Path, delta: str) -> None:
@@ -43,11 +43,6 @@ def append_question(store_path: Path, question: str) -> None:
 
 
 runner = CliRunner()
-
-
-def read_project_context(store_path: Path, level: int = 0) -> str:
-    """Local test helper — keeps the existing assertions using str content."""
-    return tool_get_context(store_path, level)["content"]
 
 
 @pytest.fixture

--- a/packages/nauro/tests/test_sync/conftest.py
+++ b/packages/nauro/tests/test_sync/conftest.py
@@ -1,0 +1,32 @@
+"""Shared helpers for the test_sync test suite."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from nauro.constants import REPO_CONFIG_MODE_CLOUD
+from nauro.store.registry import register_project_v2
+from nauro.templates.scaffolds import scaffold_project_store
+
+CLOUD_PID = "01KQ6AZGNA0B3QBF67NBXP3S45"
+
+
+def _scaffolded_cloud_project(name: str, repo_path: Path, project_id: str | None = None) -> Path:
+    """Register a cloud-mode v2 project, scaffold its store, and return the store path.
+
+    When ``project_id`` is omitted a ULID is minted automatically. Tests that
+    pass a project id to a hook (``pull_before_session`` / ``push_after_write``)
+    or presign call must supply ``project_id`` explicitly here so the registry
+    lookup that gates those paths (``is_cloud_project``) resolves the same id —
+    otherwise the hook early-returns at the project-not-found gate and the test
+    silently exercises a shallower path.
+    """
+    _pid, store = register_project_v2(
+        name,
+        [repo_path],
+        mode=REPO_CONFIG_MODE_CLOUD,
+        server_url="https://example.test",
+        project_id=project_id,
+    )
+    scaffold_project_store(name, store)
+    return store

--- a/packages/nauro/tests/test_sync/test_hooks.py
+++ b/packages/nauro/tests/test_sync/test_hooks.py
@@ -18,7 +18,6 @@ from unittest.mock import MagicMock, patch
 import httpx
 import pytest
 
-from nauro.constants import REPO_CONFIG_MODE_CLOUD
 from nauro.store.config import save_config
 from nauro.store.registry import register_project, register_project_v2
 from nauro.sync.hooks import (
@@ -33,8 +32,7 @@ from nauro.sync.state import (
     save_state,
 )
 from nauro.templates.scaffolds import scaffold_project_store
-
-CLOUD_PID = "01KQ6AZGNA0B3QBF67NBXP3S45"
+from tests.test_sync.conftest import CLOUD_PID, _scaffolded_cloud_project
 
 
 def _ok(status: int, payload: dict) -> httpx.Response:
@@ -57,18 +55,6 @@ def _seed_token() -> None:
     )
 
 
-def _scaffolded_cloud_project(name: str, repo_path: Path, project_id: str = CLOUD_PID) -> Path:
-    _pid, store = register_project_v2(
-        name,
-        [repo_path],
-        mode=REPO_CONFIG_MODE_CLOUD,
-        server_url="https://example.test",
-        project_id=project_id,
-    )
-    scaffold_project_store(name, store)
-    return store
-
-
 # --- gating: silent no-op semantics ---
 
 
@@ -78,7 +64,7 @@ class TestSilentNoOpGating:
     would be hostile; v1/local projects have no presign target."""
 
     def test_pull_silent_when_not_authenticated(self, tmp_path):
-        store = _scaffolded_cloud_project("noauth", tmp_path)
+        store = _scaffolded_cloud_project("noauth", tmp_path, project_id=CLOUD_PID)
         # no _seed_token() — load_access_token() returns None
 
         with patch("nauro.sync.remote.httpx.get") as mock_get:
@@ -88,7 +74,7 @@ class TestSilentNoOpGating:
         mock_get.assert_not_called()
 
     def test_push_silent_when_not_authenticated(self, tmp_path):
-        store = _scaffolded_cloud_project("noauth", tmp_path)
+        store = _scaffolded_cloud_project("noauth", tmp_path, project_id=CLOUD_PID)
         # no _seed_token()
 
         with patch("nauro.sync.remote.httpx.post") as mock_post:
@@ -166,7 +152,7 @@ class TestSilentNoOpGating:
 class TestPullBeforeSessionPresign:
     @pytest.fixture()
     def cloud_store(self, tmp_path):
-        store = _scaffolded_cloud_project("pullproj", tmp_path)
+        store = _scaffolded_cloud_project("pullproj", tmp_path, project_id=CLOUD_PID)
         _seed_token()
         return store
 
@@ -301,7 +287,7 @@ class TestPullBeforeSessionPresign:
 class TestPushAfterWritePresign:
     @pytest.fixture()
     def cloud_store(self, tmp_path):
-        store = _scaffolded_cloud_project("pushproj", tmp_path)
+        store = _scaffolded_cloud_project("pushproj", tmp_path, project_id=CLOUD_PID)
         _seed_token()
         return store
 
@@ -419,7 +405,7 @@ class TestPullBeforeSessionNeverRaises:
 
     @pytest.fixture()
     def cloud_store(self, tmp_path):
-        store = _scaffolded_cloud_project("silentpull", tmp_path)
+        store = _scaffolded_cloud_project("silentpull", tmp_path, project_id=CLOUD_PID)
         _seed_token()
         return store
 

--- a/packages/nauro/tests/test_sync/test_pull.py
+++ b/packages/nauro/tests/test_sync/test_pull.py
@@ -12,15 +12,13 @@ cases the hook previously owned.
 from __future__ import annotations
 
 import json
-from pathlib import Path
 from unittest.mock import patch
 
 import httpx
 import pytest
 
-from nauro.constants import REPO_CONFIG_MODE_CLOUD
 from nauro.store.config import save_config
-from nauro.store.registry import register_project, register_project_v2
+from nauro.store.registry import register_project
 from nauro.sync.merge import UnionMergeError
 from nauro.sync.pull import _renumber_decision_if_collision, run_pull
 from nauro.sync.state import (
@@ -31,8 +29,7 @@ from nauro.sync.state import (
     save_state,
 )
 from nauro.templates.scaffolds import scaffold_project_store
-
-CLOUD_PID = "01KQ6AZGNA0B3QBF67NBXP3S45"
+from tests.test_sync.conftest import CLOUD_PID, _scaffolded_cloud_project
 
 
 def _ok(status: int, payload: dict) -> httpx.Response:
@@ -53,18 +50,6 @@ def _seed_token() -> None:
             }
         }
     )
-
-
-def _scaffolded_cloud_project(name: str, repo_path: Path, project_id: str = CLOUD_PID) -> Path:
-    _pid, store = register_project_v2(
-        name,
-        [repo_path],
-        mode=REPO_CONFIG_MODE_CLOUD,
-        server_url="https://example.test",
-        project_id=project_id,
-    )
-    scaffold_project_store(name, store)
-    return store
 
 
 def _manifest(files, next_cursor=None) -> httpx.Response:

--- a/packages/nauro/tests/test_sync/test_sync_command.py
+++ b/packages/nauro/tests/test_sync/test_sync_command.py
@@ -9,6 +9,7 @@ from typer.testing import CliRunner
 from nauro.cli.main import app
 from nauro.store.registry import register_project
 from nauro.templates.scaffolds import scaffold_project_store
+from tests.test_sync.conftest import _scaffolded_cloud_project
 
 runner = CliRunner()
 
@@ -158,22 +159,6 @@ class TestSyncPreservesState:
         assert "Sprint 6: new sprint." in current
         assert "Sprint 5: shipping feature X." in history
         assert "Snapshot v" not in history
-
-
-def _scaffolded_cloud_project(name: str, repo_path: Path):
-    """Register a cloud-mode v2 project and scaffold its store. Returns the store path."""
-    from nauro.constants import REPO_CONFIG_MODE_CLOUD
-    from nauro.store.registry import register_project_v2
-    from nauro.templates.scaffolds import scaffold_project_store
-
-    _pid, store = register_project_v2(
-        name,
-        [repo_path],
-        mode=REPO_CONFIG_MODE_CLOUD,
-        server_url="https://example.test",
-    )
-    scaffold_project_store(name, store)
-    return store
 
 
 class TestSyncHonesty:

--- a/packages/nauro/tests/test_sync/test_sync_presign.py
+++ b/packages/nauro/tests/test_sync/test_sync_presign.py
@@ -22,9 +22,7 @@ import httpx
 import pytest
 from nauro_core.constants import MAX_BRIEF_BYTES
 
-from nauro.constants import REPO_CONFIG_MODE_CLOUD
 from nauro.store.config import save_config
-from nauro.store.registry import register_project_v2
 from nauro.sync.state import (
     FileState,
     SyncState,
@@ -32,21 +30,7 @@ from nauro.sync.state import (
     load_state,
     save_state,
 )
-from nauro.templates.scaffolds import scaffold_project_store
-
-CLOUD_PID = "01KQ6AZGNA0B3QBF67NBXP3S45"
-
-
-def _scaffolded_cloud_project(name: str, repo_path: Path, project_id: str = CLOUD_PID) -> Path:
-    _pid, store = register_project_v2(
-        name,
-        [repo_path],
-        mode=REPO_CONFIG_MODE_CLOUD,
-        server_url="https://example.test",
-        project_id=project_id,
-    )
-    scaffold_project_store(name, store)
-    return store
+from tests.test_sync.conftest import CLOUD_PID, _scaffolded_cloud_project
 
 
 def _ok(status: int, payload: dict) -> httpx.Response:

--- a/packages/nauro/tests/test_write_integration/conftest.py
+++ b/packages/nauro/tests/test_write_integration/conftest.py
@@ -1,6 +1,0 @@
-"""Shared fixtures for the write-integration test subdirectory.
-
-The kernel commits propose_decision on Tier 1 clean — there is no
-pending-state machine to reset between tests. This module is kept so the
-subdirectory has a discoverable conftest if shared fixtures land later.
-"""


### PR DESCRIPTION
## Why

Two related cleanups in the open-questions / pointer-handling area, plus the dead and duplicated code that surfaced alongside them.

`POINTER_FLAG_PREFIXES` ("BRIEF:", "RESUME:") lived in the `nauro` CLI package, so nauro-core could not reference it. That blocked the L0 context assembler from filtering discovery-pointer entries out of "Open Questions" and forced a module-local duplicate in the separate mcp-server repo. Discovery pointers are breadcrumbs written by the nauro-context skill, not questions for human review, so surfacing them in the L0 top-N fills the slot budget with noise.

Separately, a sweep for dead and duplicated code found a public export with no callers, an unused alias, dead test scaffolding, and helpers copy-pasted across several test files.

## Approach

Move `POINTER_FLAG_PREFIXES` to `nauro_core.constants` (the canonical cross-package home), re-export it from the nauro-core facade, and re-export it from `nauro.constants` so existing callers are unchanged. In `_render_l0_open_questions`, skip pointer-bodied entries before the slot-count gate, so they neither appear in nor consume a slot of the list. Exclusion only; a separate pointer section is left for evaluation.

For the cleanup, each item was verified to have zero references across the whole workspace before removal. Duplicated test helpers were consolidated into the nearest shared conftest, matching the established pattern. The shared `_scaffolded_cloud_project` takes an optional `project_id`; callers that pass the id to a hook or presign call (which gate on a registry lookup) supply it explicitly, so those tests keep exercising their intended path rather than an early project-not-found return.

## What changed

- **Pointer constant + L0 split** — `POINTER_FLAG_PREFIXES` moved to nauro-core and re-exported; `_render_l0_open_questions` excludes discovery pointers; docstring updated.
- **Dead code removed** — the unused public export `parse_questions` (superseded by `OpenQuestionsFile.parse`) plus its re-export, README entry, and two stale docstring mentions; the `_is_scaffold_seed` alias; a docstring-only stub conftest; an unused test fixture.
- **Test dedup** — `read_project_context` consolidated from three files into the package conftest; `_scaffolded_cloud_project` consolidated from four files into the test_sync conftest.

## What to review

- The L0 skip sits before the slot-count check, so a pointer never consumes a slot or halts iteration; entry bodies genuinely start with the prefix, so the exclusion is not a no-op.
- The `_scaffolded_cloud_project` default change to an optional `project_id`: the explicit-id call sites are the ones whose hooks gate on `is_cloud_project`. Coverage was confirmed by mutation (removing the catch envelope makes the never-raise test fail).
- `parse_questions` removal drops a public nauro-core export, taken now while the install base is small.

## What's deferred

- mcp-server duplicate removal rides the next nauro-core version bump (it cannot import the new constant until nauro-core is released and the pin is bumped).
- Surfacing discovery pointers in a separate projection section is left for evaluation.

## Test plan

- 867 nauro-core tests pass (7 new); 1461 nauro tests pass, 10 skipped (unchanged count).
- `ruff check packages/` and `ruff format --check packages/` clean.
