### PR TITLE
Bump nauro-core to 0.13.12

### DIFF
--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro-core"
-version = "0.13.11"
+version = "0.13.12"
 description = "Shared pure-Python logic for Nauro: parsing, validation, context assembly, constants."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Why

Release `nauro-core` 0.13.12 to publish the changes merged since 0.13.11. The headline items: removal of the dead public export `parse_questions` (superseded by `OpenQuestionsFile.parse`), exclusion of `BRIEF:`/`RESUME:` discovery pointers from the L0 Open Questions projection, and the new `POINTER_FLAG_PREFIXES` constant. Publishing unblocks the remote mcp-server from sharing that constant instead of carrying a module-local duplicate.

## Approach

Pyproject-only version bump (0.13.11 → 0.13.12). Merging and pushing the `nauro-core-v0.13.12` tag triggers the PyPI publish workflow.

## Note

The `parse_questions` removal is technically a breaking export removal. Shipping it as a patch under the pre-1.0 line keeps consumers inside the existing `<0.14` range rather than forcing a pin widen.

## Test plan

No code change in this PR; CI runs the nauro-core suite against the bumped package.
