### PR TITLE
check_decision: surface retrieval limits as fact, not a confidence verdict (D315)

### DIFF
--- a/packages/nauro-core/src/nauro_core/__init__.py
+++ b/packages/nauro-core/src/nauro_core/__init__.py
@@ -64,6 +64,9 @@ from nauro_core.constants import (
     NO_DECISIONS_TO_CHECK as NO_DECISIONS_TO_CHECK,
 )
 from nauro_core.constants import (
+    NO_RELATED_DECISIONS as NO_RELATED_DECISIONS,
+)
+from nauro_core.constants import (
     OPEN_QUESTIONS_MD as OPEN_QUESTIONS_MD,
 )
 from nauro_core.constants import (

--- a/packages/nauro-core/src/nauro_core/constants.py
+++ b/packages/nauro-core/src/nauro_core/constants.py
@@ -57,6 +57,32 @@ NO_DECISIONS_TO_CHECK = (
     "your recorded decisions."
 )
 
+# ── No-keyword-match assessment (used in check_decision) ──
+# Returned when the store HAS decisions but none match the proposed approach
+# on keywords. Distinct from NO_DECISIONS_TO_CHECK (empty store). Worded so a
+# lexical miss does not read as a clean all-clear: BM25 ranks on keyword
+# overlap, so a related decision phrased differently can score zero and never
+# surface. Stating the retrieval limitation is a fact about the tool, not a
+# judgement of the approach — the agent still reads and judges (D130/D245: no
+# automated scoring verdict). Shared between local (nauro) and remote
+# (mcp-server) so the cross-surface string cannot drift.
+NO_RELATED_DECISIONS = (
+    "No decision matched on keywords. Retrieval is lexical (BM25), so a related "
+    "decision phrased differently may not surface — read this as 'nothing matched', "
+    "not 'nothing exists'. For a significant approach, browse list_decisions or retry "
+    "search_decisions with alternate terms before proposing."
+)
+
+# ── Lexical-rank caveat (used in check_decision assessment) ──
+# Appended whenever check_decision returns hits, so a low (or merely
+# top-of-a-thin-pool) match is not read as an authoritative verdict. Surfaces
+# the retrieval method's nature without grading the match — the BM25 score is a
+# keyword-overlap fact, not a confidence judgement (D130/D245).
+LEXICAL_RANK_CAVEAT = (
+    "Ranked by keyword overlap, not meaning — judge relevance from the decision "
+    "body, not the rank."
+)
+
 # ── State field patterns (used in parsing and diffing) ──
 STATE_DIFF_FIELDS = ("Sprint", "Focus", "Blockers")
 

--- a/packages/nauro-core/src/nauro_core/operations/check_decision.py
+++ b/packages/nauro-core/src/nauro_core/operations/check_decision.py
@@ -13,9 +13,11 @@ from __future__ import annotations
 from bm25s.stopwords import STOPWORDS_EN
 
 from nauro_core.constants import (
+    LEXICAL_RANK_CAVEAT,
     MAX_APPROACH_LENGTH,
     MAX_CONTEXT_LENGTH,
     NO_DECISIONS_TO_CHECK,
+    NO_RELATED_DECISIONS,
 )
 from nauro_core.decision_model import Decision
 from nauro_core.operations.decision_lookup import parse_all_decisions
@@ -89,7 +91,7 @@ def check_decision(
         use_embeddings=use_embeddings,
     )
     if not hits:
-        return CheckDecisionResult(assessment="No related decisions found.")
+        return CheckDecisionResult(assessment=NO_RELATED_DECISIONS)
 
     by_num = {d.num: d for d in decisions}
     related = [_hit_to_related(hit, by_num) for hit in hits]
@@ -121,18 +123,28 @@ def _hit_to_related(hit: dict, by_num: dict[int, Decision]) -> RelatedDecision:
 
 
 def _assessment(related: list[RelatedDecision]) -> str:
-    """Build the deterministic single-line assessment from retrieval facts."""
+    """Build the deterministic single-line assessment from retrieval facts.
+
+    Surfaces retrieval facts — which decision ranked top, its BM25 score (or
+    semantic-match origin), status, date — plus a fixed caveat that the
+    ranking is lexical. It is never a confidence verdict on the match: the
+    agent reads the decision body and judges; the kernel does not grade
+    (D130/D245 — no automated classification or scoring verdict).
+    """
     top = related[0]
     top_num = extract_decision_number(top.id)
     top_label = f"D{top_num:03d}" if top_num is not None else top.id
+    # score == 0.0 marks an embedding-sourced hit carrying no BM25 score (see
+    # _hit_to_related). Don't label it "BM25 0.0" — it didn't match lexically.
+    match_note = f"BM25 {top.score:.1f}" if top.score > 0 else "semantic match"
     top_line = (
         f'Top match: {top_label} "{top.title}"'
-        f" (status {top.status}, decided {top.date}, BM25 {top.score:.1f})."
+        f" (status {top.status}, decided {top.date}, {match_note})."
     )
     if len(related) == 1:
         target = f"get_decision({top_num})" if top_num is not None else "get_decision"
-        return f"{top_line} Call {target} before proposing."
+        return f"{top_line} {LEXICAL_RANK_CAVEAT} Call {target} before proposing."
     return (
-        f"Found {len(related)} related decisions. {top_line}"
+        f"Found {len(related)} related decisions. {top_line} {LEXICAL_RANK_CAVEAT}"
         " Call get_decision on each related decision before proposing."
     )

--- a/packages/nauro-core/src/nauro_core/renderers.py
+++ b/packages/nauro-core/src/nauro_core/renderers.py
@@ -28,6 +28,8 @@ Per-tool surface area:
 
 from __future__ import annotations
 
+from nauro_core.constants import NO_RELATED_DECISIONS
+
 # Width target for the rendered text blocks. Picked to fit standard
 # terminal widths and Markdown chat clients without horizontal scroll.
 _WIDTH = 80
@@ -98,9 +100,10 @@ def render_check_decision(result: dict) -> str:
     assessment = result.get("assessment", "")
 
     if not related:
-        # No-project guidance first, then NO_DECISIONS_TO_CHECK / "No related
-        # decisions found." cases.
-        return _guidance(result) or assessment.strip() or "No related decisions found."
+        # No-project guidance first, then the kernel's NO_DECISIONS_TO_CHECK
+        # (empty store) / NO_RELATED_DECISIONS (no keyword match) assessment.
+        # The literal fallback only fires if the envelope carries neither.
+        return _guidance(result) or assessment.strip() or NO_RELATED_DECISIONS
 
     lines: list[str] = []
     count = len(related)

--- a/packages/nauro-core/tests/operations/test_check_decision.py
+++ b/packages/nauro-core/tests/operations/test_check_decision.py
@@ -11,7 +11,13 @@ from datetime import date
 
 import pytest
 
-from nauro_core.constants import MAX_APPROACH_LENGTH, MAX_CONTEXT_LENGTH, NO_DECISIONS_TO_CHECK
+from nauro_core.constants import (
+    LEXICAL_RANK_CAVEAT,
+    MAX_APPROACH_LENGTH,
+    MAX_CONTEXT_LENGTH,
+    NO_DECISIONS_TO_CHECK,
+    NO_RELATED_DECISIONS,
+)
 from nauro_core.decision_model import (
     Decision,
     DecisionConfidence,
@@ -23,6 +29,8 @@ from nauro_core.operations import (
     InMemoryStore,
     check_decision,
 )
+from nauro_core.operations.check_decision import _assessment
+from nauro_core.operations.results import RelatedDecision
 
 
 def _seed_decision(
@@ -73,8 +81,23 @@ def test_unrelated_proposal_returns_no_related_decisions() -> None:
     )
     result = check_decision(store, "Pineapple production logistics across mid-atlantic ports")
     assert result.related_decisions == []
-    assert result.assessment == "No related decisions found."
+    assert result.assessment == NO_RELATED_DECISIONS
     assert result.error is None
+
+
+def test_no_match_assessment_does_not_read_as_all_clear() -> None:
+    """The no-keyword-match assessment must name the lexical limitation so a
+    paraphrase miss is visibly distinct from 'nothing exists' — and distinct
+    from the empty-store message. Guards the silent-miss fix."""
+    store = _store_with(
+        _seed_decision(1, "Adopt PostgreSQL", "ACID semantics for our transactional workload."),
+    )
+    result = check_decision(store, "Pineapple production logistics across mid-atlantic ports")
+    # A populated store that returns no hits is NOT the empty-store case.
+    assert result.assessment != NO_DECISIONS_TO_CHECK
+    lowered = result.assessment.lower()
+    assert "lexical" in lowered or "keyword" in lowered
+    assert "nothing exists" in lowered
 
 
 def test_related_decision_canonical_id_and_status_enrichment() -> None:
@@ -106,6 +129,7 @@ def test_assessment_single_match_directs_to_get_decision() -> None:
     result = check_decision(store, "Add Redis as a session cache")
     assert result.error is None
     assert "Top match: D007" in result.assessment
+    assert LEXICAL_RANK_CAVEAT in result.assessment
     assert "Call get_decision(7) before proposing." in result.assessment
 
 
@@ -118,6 +142,7 @@ def test_assessment_multi_match_directs_to_each() -> None:
     assert result.error is None
     assert len(result.related_decisions) >= 2
     assert "Found" in result.assessment
+    assert LEXICAL_RANK_CAVEAT in result.assessment
     assert "Call get_decision on each related decision before proposing." in result.assessment
 
 
@@ -302,3 +327,23 @@ def test_long_approach_is_capped_for_retrieval() -> None:
     assert result.error is None
     ids = [hit.id for hit in result.related_decisions]
     assert "decision-005" not in ids
+
+
+def test_assessment_embedding_sourced_top_hit_not_labeled_bm25() -> None:
+    """An embedding-sourced top hit carries score 0.0 (no BM25 score); the
+    assessment must call it a semantic match, never 'BM25 0.0'. Exercises the
+    union path's embedding-only branch at the assessment layer without the
+    optional embeddings dependency."""
+    hit = RelatedDecision(
+        id="decision-042",
+        title="Adopt PostgreSQL",
+        score=0.0,
+        status="active",
+        date="2026-04-16",
+        rationale_preview="ACID semantics for the platform.",
+    )
+    assessment = _assessment([hit])
+    assert "Top match: D042" in assessment
+    assert "semantic match" in assessment
+    assert "BM25 0.0" not in assessment
+    assert LEXICAL_RANK_CAVEAT in assessment

--- a/packages/nauro-core/tests/test_renderers.py
+++ b/packages/nauro-core/tests/test_renderers.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 
+from nauro_core.constants import NO_RELATED_DECISIONS
 from nauro_core.renderers import (
     render_check_decision,
     render_get_context,
@@ -40,10 +41,10 @@ class TestRenderCheckDecision:
         result = {
             "store": "remote",
             "related_decisions": [],
-            "assessment": "No related decisions found.",
+            "assessment": NO_RELATED_DECISIONS,
         }
         text = render_check_decision(result)
-        assert "No related decisions found" in text
+        assert NO_RELATED_DECISIONS in text
 
     def test_single_related_decision(self):
         result = {
@@ -616,11 +617,11 @@ class TestNoProjectGuidance:
         assert "Welcome to Nauro" in text
 
     def test_check_decision_surfaces_guidance_not_false_clear(self):
-        # Must NOT report a false "No related decisions found." — that would
+        # Must NOT fall through to the no-keyword-match assessment — that would
         # tell the agent the history is clear when no store was read.
         text = render_check_decision(self._envelope())
         assert "Welcome to Nauro" in text
-        assert "No related decisions found" not in text
+        assert NO_RELATED_DECISIONS not in text
 
     def test_search_decisions_surfaces_guidance_not_false_empty(self):
         text = render_search_decisions(self._envelope())


### PR DESCRIPTION
## Why
A BM25 retrieval miss in `check_decision` rendered identically to a clean all-clear. When no decision matched, the assessment was just "No related decisions found." — no hint that retrieval is lexical (BM25) and may miss a decision phrased differently than the proposed approach. A user reported the failure mode directly: a silent miss looks like "all clear," so the user feels covered when they aren't.

## Approach
State facts about the retrieval method rather than grade the match — consistent with standing doctrine that retrieval surfaces facts and the agent judges (D245/D130/D243: "no automated classification or scoring verdict"). Concretely:
- No-keyword-match branch states retrieval is lexical and may not surface a differently-phrased decision ("nothing matched" is not "nothing exists").
- Every hit carries a fixed caveat that ranking is keyword overlap, not meaning — so no hit's rank reads as a relevance verdict.
- An embedding-sourced top hit (score 0.0, not on the BM25 scale per D243) is labeled "semantic match" instead of a misleading "BM25 0.0".

Rejected (see **D315**): a weak/strong confidence *verdict* label — an automated scoring verdict (D130/D245/D243) that undercuts the "no model judges your decisions" stance; and an absolute BM25 threshold band — corpus-relative and fragile (D308 rejected score-gating for the same reason), and it would make the change retrieval-affecting.

Wording-only: ranking, candidate pool, and scoring are untouched, so the change is **not** retrieval-affecting under D308 and owes no benchmark run.

## What changed
- `nauro-core/constants.py`: two shared constants — `NO_RELATED_DECISIONS` (no-keyword-match message) and `LEXICAL_RANK_CAVEAT` (per-hit caveat).
- `nauro-core/operations/check_decision.py`: emit `NO_RELATED_DECISIONS` on no hits; `_assessment` appends the caveat and renders score-0.0 hits as "semantic match".
- `nauro-core/renderers.py`: no-hit fallback updated in lockstep to the shared constant.
- `nauro-core/__init__.py`: export `NO_RELATED_DECISIONS`.
- Tests: updated pinned assertions + 3 new tests (no-match-not-all-clear, caveat-on-hits, embedding-sourced-0.0 unit test).

## What to review
- The `top.score > 0` discriminator in `_assessment`: embedding hits floor to exactly 0.0 via `_hit_to_related`; BM25 hits are always > 0 after `round(score, 3)`. Verified by @nauro-reviewer.
- That the new strings state facts, not a verdict — audited against D130/D245/D243/D308 by @nauro-tech-lead (GREEN, no drift).

## What's deferred
The renderer's per-hit `BM25 {score:5.2f}` list line still labels an embedding-sourced (0.0) hit as "BM25 0.00" — a separate display surface, out of scope here. Optional follow-up.

## Test plan
Full nauro-core + nauro suites: **2330 passed, 10 skipped**. `ruff check` clean, `ruff format --check` clean, import-linter 2/2 contracts kept.