### PR TITLE
Add opt-in /nauro-loop skill for gated work origination

### DIFF
--- a/.agents/skills/nauro-loop/SKILL.md
+++ b/.agents/skills/nauro-loop/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: nauro-loop
+description: Run a gated iteration of work origination on top of /nauro-ship-task. Invoke under the dynamic /loop command (/loop /nauro-loop). Mines the project's existing Nauro store state read-only (get_context, open-questions RESUME/BRIEF pointers, diff_since_last_session, list_decisions) and originates 1-3 ranked candidate tasks, then surfaces them via AskUserQuestion for the human to pick — a mandatory ratify-gate with no auto-pick path. On the human's pick it dispatches /nauro-ship-task <chosen task> byte-for-byte with all six inner gates intact, then loops back. Originates the candidate set only; the human selects the task, approves the plan, clears every tech-lead pause, and confirms every push. The loop itself never files a decision, never pushes, and never runs gh; it holds no store-write authority. Stops on an empty mine and at a hard per-session ceiling. Installed by `nauro adopt --with-skills`.
+---
+
+# Nauro loop skill
+
+Run a gated iteration of work origination on top of `/nauro-ship-task`. This skill is a thin outer loop invoked under the dynamic `/loop` command (`/loop /nauro-loop`). It mines the project's existing Nauro store state for candidate work, ranks a small set, and surfaces it to the human to pick; on the human's pick it dispatches `/nauro-ship-task <chosen task>` byte-for-byte with all six inner gates intact, then loops back. It originates the candidate set; the human selects, approves, and confirms everything downstream.
+
+The loop adds one net-new agent authority — task origination — and nothing else. Today the human authors the task description handed to `/nauro-ship-task`; the loop now proposes and ranks the candidate "what to build next" set. It enumerates options; it never selects. Everything past enumeration stays with the human: the SELECT ratify-gate, the chain's plan-approval gate, every AMBER/RED tech-lead pause, and every push confirmation.
+
+## What the loop cannot do
+
+These are structural, not stylistic. The loop holds none of these capabilities and must not simulate them.
+
+- The loop never files a decision. It holds no write authority into the store, cannot record doctrine, and carries no path to commit one. It runs in the main-agent context with no tool-lock, so an autonomous filing would install binding doctrine with no human gate; the only filing that ever happens is inside the dispatched chain, after a human clears a chain gate, by the agent the chain assigns.
+- The loop never pushes and never runs `gh`. Push and PR creation live only inside the chain's push-confirmation gate, behind an explicit human "yes".
+- `/loop` is NOT a "keep moving" override of any inner gate. A standing "keep going" or auto-mode directive does not clear the SELECT gate, the plan gate, a tech-lead pause, or the push gate. The loop exists to repeat the gated chain, not to bypass it.
+- Under the loop, the chain's low-stakes auto-proceed path at the plan gate is CLOSED. Inside a bare `/nauro-ship-task` run a plan with no doctrine writes and no high-stakes triggers may auto-proceed to the executor; under `/loop` that path is closed and every plan blocks for explicit human approval at the plan gate. Tightening origination this way is doctrine-positive, not a regression.
+- The loop fails closed on a gate-callback timeout. If a human gate is surfaced and the response channel times out or is unavailable, the loop halts and surfaces the held state; it never treats a timed-out gate as an approval.
+- A held gate takes a lock: while any gate (SELECT or an inner chain gate) is awaiting a human, the loop starts no new ORIENT, composes no new candidates, and dispatches no chain. One gate is open at a time.
+- The loop has a hard per-session ceiling on both completed chains and idle re-orient cycles. When either ceiling is reached, the loop stops and reports; it does not silently continue.
+
+## ORIENT — mine the store, read-only
+
+ORIENT writes nothing. It reuses the Resume R1/R2 mining logic to read the project's current state and assemble candidate work:
+
+- `get_context(level="L1")` for the current sprint, blockers, and recent completions.
+- `get_raw_file(path="open-questions.md")`, read in full, scanning for `RESUME:` and `BRIEF:` pointers — a `RESUME:` pointer names in-flight work to continue; a `BRIEF:` pointer names context another agent left that may seed a task.
+- `diff_since_last_session` to see what changed recently, so the candidate set reflects real movement and not a stale read.
+- `list_decisions` to ground candidates against active doctrine and recent direction.
+
+From that, ORIENT composes 1-3 ranked candidate tasks. Each candidate carries a one-line rationale, the source signal it came from (the `L1` working set, a specific pointer, a recent diff, a decision), and its provenance so the human can trace where it originated.
+
+Re-verify every `RESUME:` anchor before ranking it: check the branch heads, open PR numbers, and any expected-state anchors the pointer names against `origin/main`. A `RESUME:` candidate whose anchors no longer match is demoted to "stale, surface" — it is not ranked as live work; it is reported to the human as a pointer that needs attention. ORIENT never fabricates a candidate: if the mine is empty, it composes nothing and the loop stops (see RE-ORIENT).
+
+## SELECT — GATE — the human picks (mandatory, no auto-pick ever)
+
+SELECT surfaces the ranked candidates and waits for the human to choose. This gate is mandatory and has no auto-pick path — not even when exactly one candidate ranks. Removing the human from selection would begin removing the human from origination, which the loop must never do.
+
+Surface the candidates through `AskUserQuestion`, presenting each candidate with its one-line rationale, its source signal, and its provenance. If ORIENT ran `check_decision` against a candidate, show its output as a raw related-decision list only — never a verdict, score, or recommendation. `check_decision` returns related decisions; it does not judge, and the SELECT surface must not present it as if it did. The human reads the candidates and the related decisions and decides.
+
+The human may pick one candidate, or reject all of them. On rejection the loop surfaces that the mine produced nothing the human wanted and stops; it does not silently re-rank the same set. The human's chosen candidate becomes the verbatim input to `/nauro-ship-task` — the loop passes the task description through as the human ratified it, not a paraphrase.
+
+## CHAIN — dispatch /nauro-ship-task byte-for-byte
+
+On the human's pick, dispatch `/nauro-ship-task <chosen task>` exactly as written, with all six existing gates intact: the RED-supersede pause before the executor, the plan-approval gate, AMBER surfacing, the RED tech-lead pause, the push-confirmation gate, and the doctrine-disconnect hard-pause. Do not reproduce the chain inline in the loop — the gates depend on the chain's structure and the bundled subagents' restricted tool access, and an inline imitation runs without them. The loop's job is to hand the ratified task to the chain and let the chain run; the loop adds no step inside the chain and removes none.
+
+Every filing, every PR, and every push during the chain happens inside the chain after a human clears the relevant chain gate. The loop neither files nor pushes on its own.
+
+## INTEGRATE — record nothing to the store
+
+When the chain returns, INTEGRATE writes nothing to the Nauro store. The chain has already landed whatever it landed (a local commit, an opened PR on the human's push) and filed whatever the human approved inside it. The loop holds no write path, so there is nothing for it to record; it carries the chain's outcome forward only as in-session state for the next ORIENT.
+
+## RE-ORIENT — loop back, or stop
+
+RE-ORIENT runs ORIENT again to mine the now-changed store for the next candidate set. The loop stops, without fabricating work, when either condition holds:
+
+- The mine is empty — ORIENT composes no candidate. The loop reports that there is no further work it can originate and stops. It does not invent a task to keep the loop running.
+- The per-session ceiling is reached — the count of completed chains or idle re-orient cycles hits the hard cap. The loop reports the ceiling and stops.
+
+## Gate H — assistance / stuck
+
+If the dispatched chain self-halts or fails loud — a capped fix loop exhausts, a tech-lead RED with no human override, a tool error, a doctrine-disconnect hard-pause, an incoherent verdict — the loop does not retry blindly and does not move to the next candidate. It surfaces the halted state and the chain's reported reason to the human and waits. Gate H is the loop's stuck-handler: a chain that stops loud is a signal for the human, not a cycle to absorb silently.
+
+## Substrate and scope
+
+The loop runs under the dynamic `/loop` command (`/loop /nauro-loop`), which repeats the skill in the parent session and can pause for the SELECT gate's `AskUserQuestion`. Unattended substrates — cron, scheduled wakeups, or cloud routines — are out of scope: a run on those cannot pause for the human sign-off the SELECT and chain gates require, so the loop is not wired onto them.
+
+## Inherited external review
+
+The dispatched chain offers an optional external second-opinion review at its push gate. That step is off by default and offer-only: the chain offers it per push, the human opts in, and the findings are advisory — never a blocking gate. The loop inherits it for free because it dispatches the chain byte-for-byte, and the loop never auto-accepts it on the human's behalf. If no external-review skill is wired in the environment, the chain does not offer the step.
+
+## Rules
+
+- The loop never files a decision, never pushes, and never runs `gh`. It holds no store-write authority and cannot record doctrine; all of that lives inside the dispatched chain behind a human-cleared gate.
+- SELECT is mandatory with no auto-pick path ever — not even for a single ranked candidate. The human selects every task; the loop only enumerates.
+- `/loop` does not override any gate. Auto-mode and standing "keep moving" directives clear neither the SELECT gate nor any inner chain gate, and under the loop the chain's low-stakes auto-proceed at the plan gate is closed — every plan blocks.
+- ORIENT is read-only and never fabricates a candidate; on an empty mine the loop stops rather than inventing work.
+- A `RESUME:` anchor that no longer matches `origin/main` is demoted to "stale, surface" and reported, never ranked as live work.
+- The loop fails closed on a gate-callback timeout, takes a held-gate lock so only one gate is open at a time, and stops at the hard per-session ceiling on chains and idle cycles.
+- A chain that self-halts or fails loud routes to Gate H — surface and wait; never retry blindly and never skip to the next candidate.
+- `check_decision` output is shown as a raw related-decision list, never as a verdict, score, or recommendation.
+- On any tool error or surprise mid-loop, stop and surface to the human rather than recovering silently.

--- a/.claude/skills/nauro-loop/SKILL.md
+++ b/.claude/skills/nauro-loop/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: nauro-loop
+description: Run a gated iteration of work origination on top of /nauro-ship-task. Invoke under the dynamic /loop command (/loop /nauro-loop). Mines the project's existing Nauro store state read-only (get_context, open-questions RESUME/BRIEF pointers, diff_since_last_session, list_decisions) and originates 1-3 ranked candidate tasks, then surfaces them via AskUserQuestion for the human to pick — a mandatory ratify-gate with no auto-pick path. On the human's pick it dispatches /nauro-ship-task <chosen task> byte-for-byte with all six inner gates intact, then loops back. Originates the candidate set only; the human selects the task, approves the plan, clears every tech-lead pause, and confirms every push. The loop itself never files a decision, never pushes, and never runs gh; it holds no store-write authority. Stops on an empty mine and at a hard per-session ceiling. Installed by `nauro adopt --with-skills`.
+---
+
+# Nauro loop skill
+
+Run a gated iteration of work origination on top of `/nauro-ship-task`. This skill is a thin outer loop invoked under the dynamic `/loop` command (`/loop /nauro-loop`). It mines the project's existing Nauro store state for candidate work, ranks a small set, and surfaces it to the human to pick; on the human's pick it dispatches `/nauro-ship-task <chosen task>` byte-for-byte with all six inner gates intact, then loops back. It originates the candidate set; the human selects, approves, and confirms everything downstream.
+
+The loop adds one net-new agent authority — task origination — and nothing else. Today the human authors the task description handed to `/nauro-ship-task`; the loop now proposes and ranks the candidate "what to build next" set. It enumerates options; it never selects. Everything past enumeration stays with the human: the SELECT ratify-gate, the chain's plan-approval gate, every AMBER/RED tech-lead pause, and every push confirmation.
+
+## What the loop cannot do
+
+These are structural, not stylistic. The loop holds none of these capabilities and must not simulate them.
+
+- The loop never files a decision. It holds no write authority into the store, cannot record doctrine, and carries no path to commit one. It runs in the main-agent context with no tool-lock, so an autonomous filing would install binding doctrine with no human gate; the only filing that ever happens is inside the dispatched chain, after a human clears a chain gate, by the agent the chain assigns.
+- The loop never pushes and never runs `gh`. Push and PR creation live only inside the chain's push-confirmation gate, behind an explicit human "yes".
+- `/loop` is NOT a "keep moving" override of any inner gate. A standing "keep going" or auto-mode directive does not clear the SELECT gate, the plan gate, a tech-lead pause, or the push gate. The loop exists to repeat the gated chain, not to bypass it.
+- Under the loop, the chain's low-stakes auto-proceed path at the plan gate is CLOSED. Inside a bare `/nauro-ship-task` run a plan with no doctrine writes and no high-stakes triggers may auto-proceed to the executor; under `/loop` that path is closed and every plan blocks for explicit human approval at the plan gate. Tightening origination this way is doctrine-positive, not a regression.
+- The loop fails closed on a gate-callback timeout. If a human gate is surfaced and the response channel times out or is unavailable, the loop halts and surfaces the held state; it never treats a timed-out gate as an approval.
+- A held gate takes a lock: while any gate (SELECT or an inner chain gate) is awaiting a human, the loop starts no new ORIENT, composes no new candidates, and dispatches no chain. One gate is open at a time.
+- The loop has a hard per-session ceiling on both completed chains and idle re-orient cycles. When either ceiling is reached, the loop stops and reports; it does not silently continue.
+
+## ORIENT — mine the store, read-only
+
+ORIENT writes nothing. It reuses the Resume R1/R2 mining logic to read the project's current state and assemble candidate work:
+
+- `get_context(level="L1")` for the current sprint, blockers, and recent completions.
+- `get_raw_file(path="open-questions.md")`, read in full, scanning for `RESUME:` and `BRIEF:` pointers — a `RESUME:` pointer names in-flight work to continue; a `BRIEF:` pointer names context another agent left that may seed a task.
+- `diff_since_last_session` to see what changed recently, so the candidate set reflects real movement and not a stale read.
+- `list_decisions` to ground candidates against active doctrine and recent direction.
+
+From that, ORIENT composes 1-3 ranked candidate tasks. Each candidate carries a one-line rationale, the source signal it came from (the `L1` working set, a specific pointer, a recent diff, a decision), and its provenance so the human can trace where it originated.
+
+Re-verify every `RESUME:` anchor before ranking it: check the branch heads, open PR numbers, and any expected-state anchors the pointer names against `origin/main`. A `RESUME:` candidate whose anchors no longer match is demoted to "stale, surface" — it is not ranked as live work; it is reported to the human as a pointer that needs attention. ORIENT never fabricates a candidate: if the mine is empty, it composes nothing and the loop stops (see RE-ORIENT).
+
+## SELECT — GATE — the human picks (mandatory, no auto-pick ever)
+
+SELECT surfaces the ranked candidates and waits for the human to choose. This gate is mandatory and has no auto-pick path — not even when exactly one candidate ranks. Removing the human from selection would begin removing the human from origination, which the loop must never do.
+
+Surface the candidates through `AskUserQuestion`, presenting each candidate with its one-line rationale, its source signal, and its provenance. If ORIENT ran `check_decision` against a candidate, show its output as a raw related-decision list only — never a verdict, score, or recommendation. `check_decision` returns related decisions; it does not judge, and the SELECT surface must not present it as if it did. The human reads the candidates and the related decisions and decides.
+
+The human may pick one candidate, or reject all of them. On rejection the loop surfaces that the mine produced nothing the human wanted and stops; it does not silently re-rank the same set. The human's chosen candidate becomes the verbatim input to `/nauro-ship-task` — the loop passes the task description through as the human ratified it, not a paraphrase.
+
+## CHAIN — dispatch /nauro-ship-task byte-for-byte
+
+On the human's pick, dispatch `/nauro-ship-task <chosen task>` exactly as written, with all six existing gates intact: the RED-supersede pause before the executor, the plan-approval gate, AMBER surfacing, the RED tech-lead pause, the push-confirmation gate, and the doctrine-disconnect hard-pause. Do not reproduce the chain inline in the loop — the gates depend on the chain's structure and the bundled subagents' restricted tool access, and an inline imitation runs without them. The loop's job is to hand the ratified task to the chain and let the chain run; the loop adds no step inside the chain and removes none.
+
+Every filing, every PR, and every push during the chain happens inside the chain after a human clears the relevant chain gate. The loop neither files nor pushes on its own.
+
+## INTEGRATE — record nothing to the store
+
+When the chain returns, INTEGRATE writes nothing to the Nauro store. The chain has already landed whatever it landed (a local commit, an opened PR on the human's push) and filed whatever the human approved inside it. The loop holds no write path, so there is nothing for it to record; it carries the chain's outcome forward only as in-session state for the next ORIENT.
+
+## RE-ORIENT — loop back, or stop
+
+RE-ORIENT runs ORIENT again to mine the now-changed store for the next candidate set. The loop stops, without fabricating work, when either condition holds:
+
+- The mine is empty — ORIENT composes no candidate. The loop reports that there is no further work it can originate and stops. It does not invent a task to keep the loop running.
+- The per-session ceiling is reached — the count of completed chains or idle re-orient cycles hits the hard cap. The loop reports the ceiling and stops.
+
+## Gate H — assistance / stuck
+
+If the dispatched chain self-halts or fails loud — a capped fix loop exhausts, a tech-lead RED with no human override, a tool error, a doctrine-disconnect hard-pause, an incoherent verdict — the loop does not retry blindly and does not move to the next candidate. It surfaces the halted state and the chain's reported reason to the human and waits. Gate H is the loop's stuck-handler: a chain that stops loud is a signal for the human, not a cycle to absorb silently.
+
+## Substrate and scope
+
+The loop runs under the dynamic `/loop` command (`/loop /nauro-loop`), which repeats the skill in the parent session and can pause for the SELECT gate's `AskUserQuestion`. Unattended substrates — cron, scheduled wakeups, or cloud routines — are out of scope: a run on those cannot pause for the human sign-off the SELECT and chain gates require, so the loop is not wired onto them.
+
+## Inherited external review
+
+The dispatched chain offers an optional external second-opinion review at its push gate. That step is off by default and offer-only: the chain offers it per push, the human opts in, and the findings are advisory — never a blocking gate. The loop inherits it for free because it dispatches the chain byte-for-byte, and the loop never auto-accepts it on the human's behalf. If no external-review skill is wired in the environment, the chain does not offer the step.
+
+## Rules
+
+- The loop never files a decision, never pushes, and never runs `gh`. It holds no store-write authority and cannot record doctrine; all of that lives inside the dispatched chain behind a human-cleared gate.
+- SELECT is mandatory with no auto-pick path ever — not even for a single ranked candidate. The human selects every task; the loop only enumerates.
+- `/loop` does not override any gate. Auto-mode and standing "keep moving" directives clear neither the SELECT gate nor any inner chain gate, and under the loop the chain's low-stakes auto-proceed at the plan gate is closed — every plan blocks.
+- ORIENT is read-only and never fabricates a candidate; on an empty mine the loop stops rather than inventing work.
+- A `RESUME:` anchor that no longer matches `origin/main` is demoted to "stale, surface" and reported, never ranked as live work.
+- The loop fails closed on a gate-callback timeout, takes a held-gate lock so only one gate is open at a time, and stops at the hard per-session ceiling on chains and idle cycles.
+- A chain that self-halts or fails loud routes to Gate H — surface and wait; never retry blindly and never skip to the next candidate.
+- `check_decision` output is shown as a raw related-decision list, never as a verdict, score, or recommendation.
+- On any tool error or surprise mid-loop, stop and surface to the human rather than recovering silently.

--- a/.cursor/rules/nauro-loop.mdc
+++ b/.cursor/rules/nauro-loop.mdc
@@ -1,0 +1,84 @@
+---
+description: Run a gated iteration of work origination on top of /nauro-ship-task. Invoke under the dynamic /loop command (/loop /nauro-loop). Mines the project's existing Nauro store state read-only (get_context, open-questions RESUME/BRIEF pointers, diff_since_last_session, list_decisions) and originates 1-3 ranked candidate tasks, then surfaces them via AskUserQuestion for the human to pick — a mandatory ratify-gate with no auto-pick path. On the human's pick it dispatches /nauro-ship-task <chosen task> byte-for-byte with all six inner gates intact, then loops back. Originates the candidate set only; the human selects the task, approves the plan, clears every tech-lead pause, and confirms every push. The loop itself never files a decision, never pushes, and never runs gh; it holds no store-write authority. Stops on an empty mine and at a hard per-session ceiling. Installed by `nauro adopt --with-skills`.
+alwaysApply: false
+---
+
+# Nauro loop skill
+
+Run a gated iteration of work origination on top of `/nauro-ship-task`. This skill is a thin outer loop invoked under the dynamic `/loop` command (`/loop /nauro-loop`). It mines the project's existing Nauro store state for candidate work, ranks a small set, and surfaces it to the human to pick; on the human's pick it dispatches `/nauro-ship-task <chosen task>` byte-for-byte with all six inner gates intact, then loops back. It originates the candidate set; the human selects, approves, and confirms everything downstream.
+
+The loop adds one net-new agent authority — task origination — and nothing else. Today the human authors the task description handed to `/nauro-ship-task`; the loop now proposes and ranks the candidate "what to build next" set. It enumerates options; it never selects. Everything past enumeration stays with the human: the SELECT ratify-gate, the chain's plan-approval gate, every AMBER/RED tech-lead pause, and every push confirmation.
+
+## What the loop cannot do
+
+These are structural, not stylistic. The loop holds none of these capabilities and must not simulate them.
+
+- The loop never files a decision. It holds no write authority into the store, cannot record doctrine, and carries no path to commit one. It runs in the main-agent context with no tool-lock, so an autonomous filing would install binding doctrine with no human gate; the only filing that ever happens is inside the dispatched chain, after a human clears a chain gate, by the agent the chain assigns.
+- The loop never pushes and never runs `gh`. Push and PR creation live only inside the chain's push-confirmation gate, behind an explicit human "yes".
+- `/loop` is NOT a "keep moving" override of any inner gate. A standing "keep going" or auto-mode directive does not clear the SELECT gate, the plan gate, a tech-lead pause, or the push gate. The loop exists to repeat the gated chain, not to bypass it.
+- Under the loop, the chain's low-stakes auto-proceed path at the plan gate is CLOSED. Inside a bare `/nauro-ship-task` run a plan with no doctrine writes and no high-stakes triggers may auto-proceed to the executor; under `/loop` that path is closed and every plan blocks for explicit human approval at the plan gate. Tightening origination this way is doctrine-positive, not a regression.
+- The loop fails closed on a gate-callback timeout. If a human gate is surfaced and the response channel times out or is unavailable, the loop halts and surfaces the held state; it never treats a timed-out gate as an approval.
+- A held gate takes a lock: while any gate (SELECT or an inner chain gate) is awaiting a human, the loop starts no new ORIENT, composes no new candidates, and dispatches no chain. One gate is open at a time.
+- The loop has a hard per-session ceiling on both completed chains and idle re-orient cycles. When either ceiling is reached, the loop stops and reports; it does not silently continue.
+
+## ORIENT — mine the store, read-only
+
+ORIENT writes nothing. It reuses the Resume R1/R2 mining logic to read the project's current state and assemble candidate work:
+
+- `get_context(level="L1")` for the current sprint, blockers, and recent completions.
+- `get_raw_file(path="open-questions.md")`, read in full, scanning for `RESUME:` and `BRIEF:` pointers — a `RESUME:` pointer names in-flight work to continue; a `BRIEF:` pointer names context another agent left that may seed a task.
+- `diff_since_last_session` to see what changed recently, so the candidate set reflects real movement and not a stale read.
+- `list_decisions` to ground candidates against active doctrine and recent direction.
+
+From that, ORIENT composes 1-3 ranked candidate tasks. Each candidate carries a one-line rationale, the source signal it came from (the `L1` working set, a specific pointer, a recent diff, a decision), and its provenance so the human can trace where it originated.
+
+Re-verify every `RESUME:` anchor before ranking it: check the branch heads, open PR numbers, and any expected-state anchors the pointer names against `origin/main`. A `RESUME:` candidate whose anchors no longer match is demoted to "stale, surface" — it is not ranked as live work; it is reported to the human as a pointer that needs attention. ORIENT never fabricates a candidate: if the mine is empty, it composes nothing and the loop stops (see RE-ORIENT).
+
+## SELECT — GATE — the human picks (mandatory, no auto-pick ever)
+
+SELECT surfaces the ranked candidates and waits for the human to choose. This gate is mandatory and has no auto-pick path — not even when exactly one candidate ranks. Removing the human from selection would begin removing the human from origination, which the loop must never do.
+
+Surface the candidates through `AskUserQuestion`, presenting each candidate with its one-line rationale, its source signal, and its provenance. If ORIENT ran `check_decision` against a candidate, show its output as a raw related-decision list only — never a verdict, score, or recommendation. `check_decision` returns related decisions; it does not judge, and the SELECT surface must not present it as if it did. The human reads the candidates and the related decisions and decides.
+
+The human may pick one candidate, or reject all of them. On rejection the loop surfaces that the mine produced nothing the human wanted and stops; it does not silently re-rank the same set. The human's chosen candidate becomes the verbatim input to `/nauro-ship-task` — the loop passes the task description through as the human ratified it, not a paraphrase.
+
+## CHAIN — dispatch /nauro-ship-task byte-for-byte
+
+On the human's pick, dispatch `/nauro-ship-task <chosen task>` exactly as written, with all six existing gates intact: the RED-supersede pause before the executor, the plan-approval gate, AMBER surfacing, the RED tech-lead pause, the push-confirmation gate, and the doctrine-disconnect hard-pause. Do not reproduce the chain inline in the loop — the gates depend on the chain's structure and the bundled subagents' restricted tool access, and an inline imitation runs without them. The loop's job is to hand the ratified task to the chain and let the chain run; the loop adds no step inside the chain and removes none.
+
+Every filing, every PR, and every push during the chain happens inside the chain after a human clears the relevant chain gate. The loop neither files nor pushes on its own.
+
+## INTEGRATE — record nothing to the store
+
+When the chain returns, INTEGRATE writes nothing to the Nauro store. The chain has already landed whatever it landed (a local commit, an opened PR on the human's push) and filed whatever the human approved inside it. The loop holds no write path, so there is nothing for it to record; it carries the chain's outcome forward only as in-session state for the next ORIENT.
+
+## RE-ORIENT — loop back, or stop
+
+RE-ORIENT runs ORIENT again to mine the now-changed store for the next candidate set. The loop stops, without fabricating work, when either condition holds:
+
+- The mine is empty — ORIENT composes no candidate. The loop reports that there is no further work it can originate and stops. It does not invent a task to keep the loop running.
+- The per-session ceiling is reached — the count of completed chains or idle re-orient cycles hits the hard cap. The loop reports the ceiling and stops.
+
+## Gate H — assistance / stuck
+
+If the dispatched chain self-halts or fails loud — a capped fix loop exhausts, a tech-lead RED with no human override, a tool error, a doctrine-disconnect hard-pause, an incoherent verdict — the loop does not retry blindly and does not move to the next candidate. It surfaces the halted state and the chain's reported reason to the human and waits. Gate H is the loop's stuck-handler: a chain that stops loud is a signal for the human, not a cycle to absorb silently.
+
+## Substrate and scope
+
+The loop runs under the dynamic `/loop` command (`/loop /nauro-loop`), which repeats the skill in the parent session and can pause for the SELECT gate's `AskUserQuestion`. Unattended substrates — cron, scheduled wakeups, or cloud routines — are out of scope: a run on those cannot pause for the human sign-off the SELECT and chain gates require, so the loop is not wired onto them.
+
+## Inherited external review
+
+The dispatched chain offers an optional external second-opinion review at its push gate. That step is off by default and offer-only: the chain offers it per push, the human opts in, and the findings are advisory — never a blocking gate. The loop inherits it for free because it dispatches the chain byte-for-byte, and the loop never auto-accepts it on the human's behalf. If no external-review skill is wired in the environment, the chain does not offer the step.
+
+## Rules
+
+- The loop never files a decision, never pushes, and never runs `gh`. It holds no store-write authority and cannot record doctrine; all of that lives inside the dispatched chain behind a human-cleared gate.
+- SELECT is mandatory with no auto-pick path ever — not even for a single ranked candidate. The human selects every task; the loop only enumerates.
+- `/loop` does not override any gate. Auto-mode and standing "keep moving" directives clear neither the SELECT gate nor any inner chain gate, and under the loop the chain's low-stakes auto-proceed at the plan gate is closed — every plan blocks.
+- ORIENT is read-only and never fabricates a candidate; on an empty mine the loop stops rather than inventing work.
+- A `RESUME:` anchor that no longer matches `origin/main` is demoted to "stale, surface" and reported, never ranked as live work.
+- The loop fails closed on a gate-callback timeout, takes a held-gate lock so only one gate is open at a time, and stops at the hard per-session ceiling on chains and idle cycles.
+- A chain that self-halts or fails loud routes to Gate H — surface and wait; never retry blindly and never skip to the next candidate.
+- `check_decision` output is shown as a raw related-decision list, never as a verdict, score, or recommendation.
+- On any tool error or surprise mid-loop, stop and surface to the human rather than recovering silently.

--- a/packages/nauro/src/nauro/cli/commands/adopt.py
+++ b/packages/nauro/src/nauro/cli/commands/adopt.py
@@ -214,7 +214,7 @@ def adopt(
         "--with-skills",
         help=(
             "Install Nauro's bundled opt-in skills "
-            "(/nauro-ship-task, /nauro-context) alongside the "
+            "(/nauro-ship-task, /nauro-context, /nauro-loop) alongside the "
             "always-installed /nauro-adopt skill. Independent of --with-subagents."
         ),
     ),

--- a/packages/nauro/src/nauro/cli/commands/setup.py
+++ b/packages/nauro/src/nauro/cli/commands/setup.py
@@ -450,12 +450,13 @@ def codex(
 # ``OPT_IN_SKILL_NAMES`` is materialized only when the caller passes
 # ``with_skills=True``. ``nauro-ship-task`` references the bundled ``@nauro-*``
 # subagents and is opt-in for that reason, so the ``--with-subagents`` notice
-# stays scoped to it. ``nauro-context`` composes only existing MCP tools (plus
-# the agent's own filesystem write) with no subagent dependency, so it carries
-# no such notice.
+# stays scoped to it. ``nauro-loop`` dispatches ``/nauro-ship-task``
+# byte-for-byte, so it carries the same subagent dependency transitively.
+# ``nauro-context`` composes only existing MCP tools (plus the agent's own
+# filesystem write) with no subagent dependency, so it carries no such notice.
 
 SKILL_NAMES: tuple[str, ...] = ("nauro-adopt",)
-OPT_IN_SKILL_NAMES: tuple[str, ...] = ("nauro-ship-task", "nauro-context")
+OPT_IN_SKILL_NAMES: tuple[str, ...] = ("nauro-ship-task", "nauro-context", "nauro-loop")
 
 
 def _claude_skill_dir() -> Path:
@@ -519,7 +520,8 @@ def materialize_skills_claude_code(
     are preserved because other registered nauro projects still depend on
     them. Defaults to True so direct unit callers and the add path retain
     their previous behavior. ``with_skills`` extends the install/remove set
-    with ``OPT_IN_SKILL_NAMES`` (``nauro-ship-task`` and ``nauro-context``).
+    with ``OPT_IN_SKILL_NAMES`` (``nauro-ship-task``, ``nauro-context``, and
+    ``nauro-loop``).
     """
     from nauro.skills import render_skill
 
@@ -549,7 +551,8 @@ def materialize_skills_codex(
     are preserved because other registered nauro projects still depend on
     them. Defaults to True so direct unit callers and the add path retain
     their previous behavior. ``with_skills`` extends the install/remove set
-    with ``OPT_IN_SKILL_NAMES`` (``nauro-ship-task`` and ``nauro-context``).
+    with ``OPT_IN_SKILL_NAMES`` (``nauro-ship-task``, ``nauro-context``, and
+    ``nauro-loop``).
     """
     from nauro.skills import render_skill
 
@@ -866,12 +869,12 @@ def setup_all_surfaces(
     locally-modified bundled files instead of preserving them.
 
     ``with_skills`` opts into installing the bundled opt-in skills
-    (``nauro-ship-task``, ``nauro-context``). Independent of
+    (``nauro-ship-task``, ``nauro-context``, ``nauro-loop``). Independent of
     ``with_subagents`` so users
     can adopt skills and subagents on separate cadences, though
     ``nauro-ship-task`` references the bundled ``@nauro-*`` subagents in
-    its body — caller surfaces ``with_skills`` without ``with_subagents``
-    should warn the user.
+    its body — and ``nauro-loop`` dispatches that chain — so a caller that
+    surfaces ``with_skills`` without ``with_subagents`` should warn the user.
 
     ``with_hooks`` opts into wiring the advisory ``UserPromptSubmit`` hook into
     each repo's project-scope ``.claude/settings.json`` (Claude-Code-only).
@@ -977,8 +980,8 @@ def setup_all_surfaces(
 
 
 SHIP_TASK_NEEDS_SUBAGENTS_NOTICE = (
-    "nauro-ship-task references the bundled @nauro-* subagents; pass "
-    "`--with-subagents` to install them too."
+    "nauro-ship-task references the bundled @nauro-* subagents (and nauro-loop "
+    "dispatches that chain); pass `--with-subagents` to install them too."
 )
 
 # The bundled subagents allow the cloud tools by the fixed name
@@ -1037,7 +1040,7 @@ def all_(
         "--with-skills",
         help=(
             "Install Nauro's bundled opt-in skills "
-            "(/nauro-ship-task, /nauro-context) alongside the "
+            "(/nauro-ship-task, /nauro-context, /nauro-loop) alongside the "
             "always-installed /nauro-adopt skill. Independent of --with-subagents."
         ),
     ),

--- a/packages/nauro/src/nauro/skills/__init__.py
+++ b/packages/nauro/src/nauro/skills/__init__.py
@@ -22,7 +22,7 @@ from typing import Literal
 from nauro_core.protocol import substitute_protocol_fragments
 
 Surface = Literal["claude_code", "cursor", "codex"]
-SkillName = Literal["nauro-adopt", "nauro-ship-task", "nauro-context"]
+SkillName = Literal["nauro-adopt", "nauro-ship-task", "nauro-context", "nauro-loop"]
 
 SKILL_DESCRIPTIONS: dict[str, str] = {
     "nauro-adopt": (
@@ -67,6 +67,22 @@ SKILL_DESCRIPTIONS: dict[str, str] = {
         "Briefs are append-only and treated as untrusted input the reading "
         "agent adjudicates. Invoke explicitly with /nauro-context. Installed by "
         "`nauro adopt --with-skills`."
+    ),
+    "nauro-loop": (
+        "Run a gated iteration of work origination on top of /nauro-ship-task. "
+        "Invoke under the dynamic /loop command (/loop /nauro-loop). Mines the "
+        "project's existing Nauro store state read-only (get_context, "
+        "open-questions RESUME/BRIEF pointers, diff_since_last_session, "
+        "list_decisions) and originates 1-3 ranked candidate tasks, then "
+        "surfaces them via AskUserQuestion for the human to pick — a mandatory "
+        "ratify-gate with no auto-pick path. On the human's pick it dispatches "
+        "/nauro-ship-task <chosen task> byte-for-byte with all six inner gates "
+        "intact, then loops back. Originates the candidate set only; the human "
+        "selects the task, approves the plan, clears every tech-lead pause, and "
+        "confirms every push. The loop itself never files a decision, never "
+        "pushes, and never runs gh; it holds no store-write authority. Stops on "
+        "an empty mine and at a hard per-session ceiling. Installed by `nauro "
+        "adopt --with-skills`."
     ),
 }
 
@@ -116,6 +132,16 @@ def load_context_body() -> str:
     return substitute_protocol_fragments(_strip_template_header(raw))
 
 
+def load_loop_body() -> str:
+    """Return the canonical ``/nauro-loop`` skill body (no frontmatter).
+
+    The body has no protocol-fragment tokens today, but goes through the same
+    substitution pass so future canonical claims can be added at the source.
+    """
+    raw = resources.files(__package__).joinpath("loop_body.md").read_text(encoding="utf-8")
+    return substitute_protocol_fragments(_strip_template_header(raw))
+
+
 def _load_body(skill_name: str) -> str:
     if skill_name == "nauro-adopt":
         return load_adopt_body()
@@ -123,6 +149,8 @@ def _load_body(skill_name: str) -> str:
         return load_ship_task_body()
     if skill_name == "nauro-context":
         return load_context_body()
+    if skill_name == "nauro-loop":
+        return load_loop_body()
     raise ValueError(f"unknown skill: {skill_name!r}")
 
 
@@ -154,6 +182,7 @@ __all__ = [
     "Surface",
     "load_adopt_body",
     "load_context_body",
+    "load_loop_body",
     "load_ship_task_body",
     "render_skill",
 ]

--- a/packages/nauro/src/nauro/skills/loop_body.md
+++ b/packages/nauro/src/nauro/skills/loop_body.md
@@ -1,0 +1,85 @@
+<!-- Source template. The dogfood files under .claude/, .cursor/, .agents/
+     are the rendered surface. Surface frontmatter is added by render_skill().
+     This body has no protocol-fragment tokens — it composes the existing MCP
+     read tools by name and dispatches the /nauro-ship-task chain byte-for-byte,
+     and makes no canonical protocol claims. -->
+
+# Nauro loop skill
+
+Run a gated iteration of work origination on top of `/nauro-ship-task`. This skill is a thin outer loop invoked under the dynamic `/loop` command (`/loop /nauro-loop`). It mines the project's existing Nauro store state for candidate work, ranks a small set, and surfaces it to the human to pick; on the human's pick it dispatches `/nauro-ship-task <chosen task>` byte-for-byte with all six inner gates intact, then loops back. It originates the candidate set; the human selects, approves, and confirms everything downstream.
+
+The loop adds one net-new agent authority — task origination — and nothing else. Today the human authors the task description handed to `/nauro-ship-task`; the loop now proposes and ranks the candidate "what to build next" set. It enumerates options; it never selects. Everything past enumeration stays with the human: the SELECT ratify-gate, the chain's plan-approval gate, every AMBER/RED tech-lead pause, and every push confirmation.
+
+## What the loop cannot do
+
+These are structural, not stylistic. The loop holds none of these capabilities and must not simulate them.
+
+- The loop never files a decision. It holds no write authority into the store, cannot record doctrine, and carries no path to commit one. It runs in the main-agent context with no tool-lock, so an autonomous filing would install binding doctrine with no human gate; the only filing that ever happens is inside the dispatched chain, after a human clears a chain gate, by the agent the chain assigns.
+- The loop never pushes and never runs `gh`. Push and PR creation live only inside the chain's push-confirmation gate, behind an explicit human "yes".
+- `/loop` is NOT a "keep moving" override of any inner gate. A standing "keep going" or auto-mode directive does not clear the SELECT gate, the plan gate, a tech-lead pause, or the push gate. The loop exists to repeat the gated chain, not to bypass it.
+- Under the loop, the chain's low-stakes auto-proceed path at the plan gate is CLOSED. Inside a bare `/nauro-ship-task` run a plan with no doctrine writes and no high-stakes triggers may auto-proceed to the executor; under `/loop` that path is closed and every plan blocks for explicit human approval at the plan gate. Tightening origination this way is doctrine-positive, not a regression.
+- The loop fails closed on a gate-callback timeout. If a human gate is surfaced and the response channel times out or is unavailable, the loop halts and surfaces the held state; it never treats a timed-out gate as an approval.
+- A held gate takes a lock: while any gate (SELECT or an inner chain gate) is awaiting a human, the loop starts no new ORIENT, composes no new candidates, and dispatches no chain. One gate is open at a time.
+- The loop has a hard per-session ceiling on both completed chains and idle re-orient cycles. When either ceiling is reached, the loop stops and reports; it does not silently continue.
+
+## ORIENT — mine the store, read-only
+
+ORIENT writes nothing. It reuses the Resume R1/R2 mining logic to read the project's current state and assemble candidate work:
+
+- `get_context(level="L1")` for the current sprint, blockers, and recent completions.
+- `get_raw_file(path="open-questions.md")`, read in full, scanning for `RESUME:` and `BRIEF:` pointers — a `RESUME:` pointer names in-flight work to continue; a `BRIEF:` pointer names context another agent left that may seed a task.
+- `diff_since_last_session` to see what changed recently, so the candidate set reflects real movement and not a stale read.
+- `list_decisions` to ground candidates against active doctrine and recent direction.
+
+From that, ORIENT composes 1-3 ranked candidate tasks. Each candidate carries a one-line rationale, the source signal it came from (the `L1` working set, a specific pointer, a recent diff, a decision), and its provenance so the human can trace where it originated.
+
+Re-verify every `RESUME:` anchor before ranking it: check the branch heads, open PR numbers, and any expected-state anchors the pointer names against `origin/main`. A `RESUME:` candidate whose anchors no longer match is demoted to "stale, surface" — it is not ranked as live work; it is reported to the human as a pointer that needs attention. ORIENT never fabricates a candidate: if the mine is empty, it composes nothing and the loop stops (see RE-ORIENT).
+
+## SELECT — GATE — the human picks (mandatory, no auto-pick ever)
+
+SELECT surfaces the ranked candidates and waits for the human to choose. This gate is mandatory and has no auto-pick path — not even when exactly one candidate ranks. Removing the human from selection would begin removing the human from origination, which the loop must never do.
+
+Surface the candidates through `AskUserQuestion`, presenting each candidate with its one-line rationale, its source signal, and its provenance. If ORIENT ran `check_decision` against a candidate, show its output as a raw related-decision list only — never a verdict, score, or recommendation. `check_decision` returns related decisions; it does not judge, and the SELECT surface must not present it as if it did. The human reads the candidates and the related decisions and decides.
+
+The human may pick one candidate, or reject all of them. On rejection the loop surfaces that the mine produced nothing the human wanted and stops; it does not silently re-rank the same set. The human's chosen candidate becomes the verbatim input to `/nauro-ship-task` — the loop passes the task description through as the human ratified it, not a paraphrase.
+
+## CHAIN — dispatch /nauro-ship-task byte-for-byte
+
+On the human's pick, dispatch `/nauro-ship-task <chosen task>` exactly as written, with all six existing gates intact: the RED-supersede pause before the executor, the plan-approval gate, AMBER surfacing, the RED tech-lead pause, the push-confirmation gate, and the doctrine-disconnect hard-pause. Do not reproduce the chain inline in the loop — the gates depend on the chain's structure and the bundled subagents' restricted tool access, and an inline imitation runs without them. The loop's job is to hand the ratified task to the chain and let the chain run; the loop adds no step inside the chain and removes none.
+
+Every filing, every PR, and every push during the chain happens inside the chain after a human clears the relevant chain gate. The loop neither files nor pushes on its own.
+
+## INTEGRATE — record nothing to the store
+
+When the chain returns, INTEGRATE writes nothing to the Nauro store. The chain has already landed whatever it landed (a local commit, an opened PR on the human's push) and filed whatever the human approved inside it. The loop holds no write path, so there is nothing for it to record; it carries the chain's outcome forward only as in-session state for the next ORIENT.
+
+## RE-ORIENT — loop back, or stop
+
+RE-ORIENT runs ORIENT again to mine the now-changed store for the next candidate set. The loop stops, without fabricating work, when either condition holds:
+
+- The mine is empty — ORIENT composes no candidate. The loop reports that there is no further work it can originate and stops. It does not invent a task to keep the loop running.
+- The per-session ceiling is reached — the count of completed chains or idle re-orient cycles hits the hard cap. The loop reports the ceiling and stops.
+
+## Gate H — assistance / stuck
+
+If the dispatched chain self-halts or fails loud — a capped fix loop exhausts, a tech-lead RED with no human override, a tool error, a doctrine-disconnect hard-pause, an incoherent verdict — the loop does not retry blindly and does not move to the next candidate. It surfaces the halted state and the chain's reported reason to the human and waits. Gate H is the loop's stuck-handler: a chain that stops loud is a signal for the human, not a cycle to absorb silently.
+
+## Substrate and scope
+
+The loop runs under the dynamic `/loop` command (`/loop /nauro-loop`), which repeats the skill in the parent session and can pause for the SELECT gate's `AskUserQuestion`. Unattended substrates — cron, scheduled wakeups, or cloud routines — are out of scope: a run on those cannot pause for the human sign-off the SELECT and chain gates require, so the loop is not wired onto them.
+
+## Inherited external review
+
+The dispatched chain offers an optional external second-opinion review at its push gate. That step is off by default and offer-only: the chain offers it per push, the human opts in, and the findings are advisory — never a blocking gate. The loop inherits it for free because it dispatches the chain byte-for-byte, and the loop never auto-accepts it on the human's behalf. If no external-review skill is wired in the environment, the chain does not offer the step.
+
+## Rules
+
+- The loop never files a decision, never pushes, and never runs `gh`. It holds no store-write authority and cannot record doctrine; all of that lives inside the dispatched chain behind a human-cleared gate.
+- SELECT is mandatory with no auto-pick path ever — not even for a single ranked candidate. The human selects every task; the loop only enumerates.
+- `/loop` does not override any gate. Auto-mode and standing "keep moving" directives clear neither the SELECT gate nor any inner chain gate, and under the loop the chain's low-stakes auto-proceed at the plan gate is closed — every plan blocks.
+- ORIENT is read-only and never fabricates a candidate; on an empty mine the loop stops rather than inventing work.
+- A `RESUME:` anchor that no longer matches `origin/main` is demoted to "stale, surface" and reported, never ranked as live work.
+- The loop fails closed on a gate-callback timeout, takes a held-gate lock so only one gate is open at a time, and stops at the hard per-session ceiling on chains and idle cycles.
+- A chain that self-halts or fails loud routes to Gate H — surface and wait; never retry blindly and never skip to the next candidate.
+- `check_decision` output is shown as a raw related-decision list, never as a verdict, score, or recommendation.
+- On any tool error or surprise mid-loop, stop and surface to the human rather than recovering silently.

--- a/packages/nauro/tests/_skill_surfaces.py
+++ b/packages/nauro/tests/_skill_surfaces.py
@@ -17,6 +17,7 @@ from nauro_core import MCP_INSTRUCTIONS_STATIC
 from nauro.skills import (
     load_adopt_body,
     load_context_body,
+    load_loop_body,
     load_ship_task_body,
 )
 
@@ -31,6 +32,7 @@ SKILL_SURFACES: dict[str, Callable[[], str]] = {
     "adopt_body.md": load_adopt_body,
     "ship_task_body.md": load_ship_task_body,
     "context_body.md": load_context_body,
+    "loop_body.md": load_loop_body,
     "MCP_INSTRUCTIONS_STATIC": lambda: MCP_INSTRUCTIONS_STATIC,
     "docs/adopt-prompt.md": load_docs_adopt_prompt,
 }

--- a/packages/nauro/tests/test_adopt.py
+++ b/packages/nauro/tests/test_adopt.py
@@ -450,6 +450,47 @@ def test_adopt_remove_clears_ship_task_when_last_project(tmp_path: Path, monkeyp
     assert not cursor.exists()
 
 
+def _loop_paths(home: Path, repo: Path) -> tuple[Path, Path, Path]:
+    """Return the (claude, codex, cursor) target paths for the bundled
+    /nauro-loop skill in an isolated HOME."""
+    return (
+        home / ".claude" / "skills" / "nauro-loop" / "SKILL.md",
+        home / ".agents" / "skills" / "nauro-loop" / "SKILL.md",
+        repo / ".cursor" / "rules" / "nauro-loop.mdc",
+    )
+
+
+def test_adopt_default_does_not_install_loop_skill(tmp_path: Path, monkeypatch):
+    """Bare ``nauro adopt`` (no ``--with-skills``) leaves nauro-loop uninstalled."""
+    repo = _adopt_env(monkeypatch, tmp_path)
+
+    result = runner.invoke(app, ["adopt", "--name", "alpha"])
+    assert result.exit_code == 0, result.output
+
+    claude, codex, cursor = _loop_paths(tmp_path, repo)
+    assert not claude.exists()
+    assert not codex.exists()
+    assert not cursor.exists()
+
+
+def test_adopt_with_skills_installs_loop_across_surfaces(tmp_path: Path, monkeypatch):
+    """``--with-skills`` materializes nauro-loop byte-equal to render_skill()."""
+    from nauro.skills import render_skill
+
+    repo = _adopt_env(monkeypatch, tmp_path)
+
+    result = runner.invoke(app, ["adopt", "--name", "alpha", "--with-skills"])
+    assert result.exit_code == 0, result.output
+
+    claude, codex, cursor = _loop_paths(tmp_path, repo)
+    assert claude.is_file()
+    assert codex.is_file()
+    assert cursor.is_file()
+    assert claude.read_text(encoding="utf-8") == render_skill("claude_code", "nauro-loop")
+    assert codex.read_text(encoding="utf-8") == render_skill("codex", "nauro-loop")
+    assert cursor.read_text(encoding="utf-8") == render_skill("cursor", "nauro-loop")
+
+
 def test_adopt_print_prompt_conflicts_with_with_skills(tmp_path: Path, monkeypatch):
     """``--print-prompt`` plus ``--with-skills`` is rejected as mutually exclusive."""
     monkeypatch.chdir(tmp_path)

--- a/packages/nauro/tests/test_protocol_drift.py
+++ b/packages/nauro/tests/test_protocol_drift.py
@@ -128,7 +128,7 @@ def test_adopt_body_mentions_operation_anchor(anchor: str) -> None:
     [
         (s, k)
         for s in ("claude_code", "cursor", "codex")
-        for k in ("nauro-adopt", "nauro-ship-task", "nauro-context")
+        for k in ("nauro-adopt", "nauro-ship-task", "nauro-context", "nauro-loop")
     ],
 )
 def test_rendered_skill_has_no_protocol_tokens(surface: str, skill: str) -> None:
@@ -153,7 +153,7 @@ def test_docs_adopt_prompt_has_no_protocol_tokens() -> None:
 # Source templates: only known tokens allowed (catches typos at the source)
 # ─────────────────────────────────────────────────────────────────────────────
 
-SOURCE_TEMPLATE_FILES = ("adopt_body.md", "ship_task_body.md", "context_body.md")
+SOURCE_TEMPLATE_FILES = ("adopt_body.md", "ship_task_body.md", "context_body.md", "loop_body.md")
 
 
 @pytest.mark.parametrize("template_filename", SOURCE_TEMPLATE_FILES)
@@ -186,6 +186,9 @@ DISTRIBUTION_FILES = (
     ".claude/skills/nauro-context/SKILL.md",
     ".cursor/rules/nauro-context.mdc",
     ".agents/skills/nauro-context/SKILL.md",
+    ".claude/skills/nauro-loop/SKILL.md",
+    ".cursor/rules/nauro-loop.mdc",
+    ".agents/skills/nauro-loop/SKILL.md",
     "docs/adopt-prompt.md",
 )
 

--- a/packages/nauro/tests/test_setup_extended.py
+++ b/packages/nauro/tests/test_setup_extended.py
@@ -658,6 +658,9 @@ def test_setup_all_default_does_not_install_ship_task(tmp_path: Path, monkeypatc
     assert not (tmp_path / ".claude" / "skills" / "nauro-context" / "SKILL.md").exists()
     assert not (tmp_path / ".agents" / "skills" / "nauro-context" / "SKILL.md").exists()
     assert not (repo / ".cursor" / "rules" / "nauro-context.mdc").exists()
+    assert not (tmp_path / ".claude" / "skills" / "nauro-loop" / "SKILL.md").exists()
+    assert not (tmp_path / ".agents" / "skills" / "nauro-loop" / "SKILL.md").exists()
+    assert not (repo / ".cursor" / "rules" / "nauro-loop.mdc").exists()
 
 
 def test_setup_all_with_skills_installs_ship_task_everywhere(tmp_path: Path, monkeypatch):
@@ -710,6 +713,36 @@ def test_setup_all_with_skills_installs_context_everywhere(tmp_path: Path, monke
     assert claude.read_text(encoding="utf-8") == render_skill("claude_code", "nauro-context")
     assert codex.read_text(encoding="utf-8") == render_skill("codex", "nauro-context")
     assert cursor.read_text(encoding="utf-8") == render_skill("cursor", "nauro-context")
+
+    remove = runner.invoke(app, ["setup", "all", "--remove", "--with-skills"])
+    assert remove.exit_code == 0, remove.output
+
+    assert not claude.exists()
+    assert not codex.exists()
+    assert not cursor.exists()
+
+
+def test_setup_all_with_skills_installs_loop_everywhere(tmp_path: Path, monkeypatch):
+    """``--with-skills`` materializes nauro-loop to all three surfaces and
+    ``--remove --with-skills`` clears it."""
+    from nauro.skills import render_skill
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    _, store_path = register_project_v2("myproj", [repo])
+    scaffold_project_store("myproj", store_path)
+    monkeypatch.chdir(repo)
+
+    install = runner.invoke(app, ["setup", "all", "--with-skills"])
+    assert install.exit_code == 0, install.output
+
+    claude = tmp_path / ".claude" / "skills" / "nauro-loop" / "SKILL.md"
+    codex = tmp_path / ".agents" / "skills" / "nauro-loop" / "SKILL.md"
+    cursor = repo / ".cursor" / "rules" / "nauro-loop.mdc"
+    assert claude.read_text(encoding="utf-8") == render_skill("claude_code", "nauro-loop")
+    assert codex.read_text(encoding="utf-8") == render_skill("codex", "nauro-loop")
+    assert cursor.read_text(encoding="utf-8") == render_skill("cursor", "nauro-loop")
 
     remove = runner.invoke(app, ["setup", "all", "--remove", "--with-skills"])
     assert remove.exit_code == 0, remove.output

--- a/packages/nauro/tests/test_skills_drift.py
+++ b/packages/nauro/tests/test_skills_drift.py
@@ -17,6 +17,7 @@ from nauro_core.constants import MAX_BRIEF_BYTES, MAX_DELTA_LENGTH
 from nauro.skills import (
     load_adopt_body,
     load_context_body,
+    load_loop_body,
     load_ship_task_body,
     render_skill,
 )
@@ -102,6 +103,74 @@ def test_load_context_body_returns_canonical_bytes():
     # No leaked template syntax.
     assert "<!--" not in body
     assert "{{" not in body
+
+
+def test_load_loop_body_returns_canonical_bytes():
+    body = load_loop_body()
+    # Byte hygiene: exactly one trailing newline (mirrors the context guard).
+    assert body.endswith("\n")
+    assert not body.endswith("\n\n")
+    assert 1000 < len(body) < 25000
+    # Load-bearing section headings so a cleanup edit cannot silently drop the
+    # ORIENT -> SELECT -> CHAIN -> INTEGRATE -> RE-ORIENT procedure.
+    assert "## ORIENT" in body
+    assert "## SELECT" in body
+    assert "## CHAIN" in body
+    assert "## INTEGRATE" in body
+    assert "## RE-ORIENT" in body
+    # SELECT is the net-new human ratify-gate; it surfaces candidates via
+    # AskUserQuestion and never auto-picks — not even a single candidate.
+    assert "AskUserQuestion" in body
+    assert "no auto-pick" in body
+    # The loop holds no decision-FILING authority. The literal write-tool token
+    # must stay absent (mirrors the context guard that the loop runs in the
+    # main-agent context with no tool-lock); the guard is carried by prose that
+    # says the loop never files a decision / holds no write authority.
+    assert "propose_decision" not in body
+    assert "never files a decision" in body
+    assert "no store-write authority" in body or "holds no store-write authority" in body
+    # The chain is dispatched byte-for-byte and never reproduced inline.
+    assert "/nauro-ship-task" in body
+    assert "byte-for-byte" in body
+    # Under the loop the chain's low-stakes auto-proceed at the plan gate closes.
+    assert "auto-proceed" in body
+    assert "closed" in body or "CLOSED" in body
+    # Structural hard rules: fail-closed on gate-callback timeout, a held-gate
+    # lock, and a hard per-session ceiling.
+    assert "fails closed" in body or "fail closed" in body
+    assert "held-gate lock" in body or "held gate" in body
+    assert "per-session ceiling" in body
+    # Gate H is the stuck-handler: a chain that self-halts or fails loud routes
+    # to a surface-and-wait gate, never a blind retry or skip to the next task.
+    assert "Gate H" in body
+    # ORIENT mines via the Resume R1/R2 pointers on the union-merged file.
+    assert "RESUME:" in body
+    assert "BRIEF:" in body
+    # Unattended substrates (cron / scheduled wakeups / routines) are out of
+    # scope — they cannot pause for the SELECT sign-off.
+    assert "cron" in body
+    assert "out of scope" in body
+    # No leaked template syntax.
+    assert "<!--" not in body
+    assert "{{" not in body
+
+
+def test_render_skill_claude_code_loop_frontmatter():
+    rendered = render_skill("claude_code", "nauro-loop")
+    assert rendered.startswith("---\nname: nauro-loop\n")
+    assert "description:" in rendered.split("\n---\n", 1)[0]
+    body = rendered.split("\n---\n", 1)[1].lstrip("\n")
+    assert body == load_loop_body()
+
+
+def test_render_skill_cursor_loop_frontmatter():
+    rendered = render_skill("cursor", "nauro-loop")
+    fm = rendered.split("\n---\n", 1)[0]
+    assert "description:" in fm
+    assert "alwaysApply: false" in fm
+    assert "name:" not in fm
+    body = rendered.split("\n---\n", 1)[1].lstrip("\n")
+    assert body == load_loop_body()
 
 
 def test_context_body_brief_size_gloss_matches_constant():
@@ -217,6 +286,9 @@ DOGFOOD_FILES = [
     (".claude/skills/nauro-context/SKILL.md", "claude_code", "nauro-context"),
     (".cursor/rules/nauro-context.mdc", "cursor", "nauro-context"),
     (".agents/skills/nauro-context/SKILL.md", "codex", "nauro-context"),
+    (".claude/skills/nauro-loop/SKILL.md", "claude_code", "nauro-loop"),
+    (".cursor/rules/nauro-loop.mdc", "cursor", "nauro-loop"),
+    (".agents/skills/nauro-loop/SKILL.md", "codex", "nauro-loop"),
 ]
 
 


### PR DESCRIPTION
## Why

Until now, every task `/nauro-ship-task` ran had to be described by a human. An
agent picking a project back up could read the in-flight state but had no way to
propose what to work on next — the "what should we build next?" step was entirely
manual. `/nauro-loop` closes that gap: the agent originates a ranked set of
candidate tasks from the project's own state, while the human stays the one who
chooses.

## Approach

`/nauro-loop` is a thin outer skill, run under the dynamic `/loop` command. Each
iteration:

- **Orient** — a read-only mine of the project store (working context, open
  questions and their resume/brief pointers, recent changes, recent decisions)
  into 1–3 ranked candidate tasks. It writes nothing.
- **Select** — surface the ranked candidates through `AskUserQuestion` and let
  the human pick. There is no auto-pick path, ever, including when a single
  candidate ranks: the agent proposes the set, the human chooses the task.
- **Chain** — dispatch `/nauro-ship-task <chosen task>` exactly as written, with
  all of its gates intact, and never reproduce the chain inline.
- **Integrate / re-orient** — record nothing, then loop. It stops when the mine
  turns up nothing actionable, or at a hard per-session ceiling; it never
  fabricates work.

The single new capability is task origination; everything downstream of choosing
the task stays with the human — selecting it, approving the plan, clearing
reviews, and confirming every push. That boundary is enforced structurally, not
by good intention: the loop holds no ability to write to the store, push, or run
`gh`, so it cannot file or ship anything on its own. Running under `/loop` is not
a "keep moving" mandate that waves a gate through, and the one place a bare
ship-task run can auto-advance (a low-stakes plan) is closed under the loop, so
every plan stops for the human. The loop also fails closed if a prompt times out,
holds a lock while any gate is open, and surfaces a stuck chain to the human
instead of retrying or skipping it.

Two alternatives were considered and rejected. An auto-pick path for a single
high-confidence candidate was dropped because it starts handing task selection
back to the agent, which is the line this feature exists to hold. For the
optional code review the chain can run before a push, bundling a vendor-specific
review skill was rejected in favor of a documented hook the chain calls only if
one is wired — keeping the dependency opt-in and the bundle vendor-neutral. That
review is off by default, advisory, and never auto-accepted on the human's
behalf.

Cron, scheduled wake-ups, and other unattended runners are deliberately out of
scope: they can't pause for the human sign-off the gates depend on.

## What changed

- **New skill body** (`skills/loop_body.md`) — the orient / select / chain /
  integrate / re-orient procedure, the structural guarantees above, and the
  stuck-handler. Token-free source template.
- **Registry** (`skills/__init__.py`) — `nauro-loop` added to the skill enum and
  loader, with a factual description entry and export.
- **Distribution renders** — the three per-surface skill files (`.claude`,
  `.agents`, `.cursor`) regenerated from the renderer, byte-for-byte equal to its
  output.
- **Install wiring** (`cli/commands/setup.py`, `adopt.py`) — `nauro-loop` added
  to the opt-in skill set behind `--with-skills`, with the install copy updated
  to note that the loop drives the ship-task chain (and therefore wants the
  bundled subagents).
- **Tests** — surface-registry enrollment, per-surface byte-equality, token-free
  checks, the body-invariant assertions, render-frontmatter checks, and install /
  off-by-default / remove round-trips.

## What to review

- `skills/loop_body.md` — the structural-guarantees block is the load-bearing
  part; confirm each guarantee (no store writes / push / gh, no auto-pick, closed
  auto-proceed, fail-closed, held-gate lock, per-session ceiling, stuck-handler)
  reads unambiguously, since the tests anchor on this prose.
- `test_load_loop_body_returns_canonical_bytes` — the string anchors that pin
  those guarantees against future drift.
- The install copy that now names the loop's dependency on the chain.

## What's deferred

Verifying that `/loop` dynamic mode actually pauses for `AskUserQuestion` in the
parent session is a runtime check on the `/loop` substrate, not a code change in
this PR.

## Test plan

Full `nauro` suite green (1499 passed, 10 skipped), including the registry-driven
tool-call-signature and token-free checks that auto-enrolled the new body and
three render surfaces. `nauro-core` suite green (867 passed). `ruff check` and
`ruff format --check` clean.
