### PR TITLE
docs: list nauro-loop in the chat adopt-prompt opt-in skill set

### DIFF
--- a/docs/adopt-prompt.md
+++ b/docs/adopt-prompt.md
@@ -11,8 +11,9 @@ nauro adopt --name <your-project-name>
 ```
 
 That registers the project, wires MCP across surfaces, and installs the
-`nauro-adopt` skill. (The session skill `nauro-context` and the workflow skill
-`nauro-ship-task` are opt-in via `nauro adopt --with-skills`.) Once that has
+`nauro-adopt` skill. (The session skill `nauro-context`, the workflow skill
+`nauro-ship-task`, and the loop skill `nauro-loop` are opt-in via
+`nauro adopt --with-skills`.) Once that has
 run, you can use the prompt below from any connected chat surface to seed the
 project's store with context.
 


### PR DESCRIPTION
## Why

The chat-paste adopt prompt (`docs/adopt-prompt.md`) enumerates what `nauro adopt --with-skills` installs, but listed only `nauro-context` and `nauro-ship-task`. `nauro-loop` is the third member of `OPT_IN_SKILL_NAMES` and is installed by the same flag, so a user running `--with-skills` received it yet the doc implied only two skills landed.

## What changed

The intro parenthetical now names all three opt-in skills: `nauro-context`, `nauro-ship-task`, and `nauro-loop`.

## What to review

Just the wording. The edit lives in the hand-authored intro paragraph, above the canonical adopt body that the drift tests pin.

## What's deferred

Nothing.

## Test plan

`test_protocol_drift.py` + `test_skills_drift.py` pass (199). The canonical-body drift anchor is untouched (the intro sits above it); no protocol tokens were introduced.
