### PR TITLE
Bump nauro to 0.13.3

### DIFF
--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro"
-version = "0.13.2"
+version = "0.13.3"
 description = "Local CLI + MCP server: set your project's doctrine once, every connected AI agent inherits it."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Why

The opt-in `/nauro-loop` skill is on `main` but unreleased: the latest tag and PyPI release are both `0.13.2`, which predates it. A user who installs nauro today and runs `nauro adopt --with-skills` does not get `nauro-loop`. This cuts the patch release that ships it.

## What changed

`packages/nauro/pyproject.toml` version `0.13.2` → `0.13.3`. Pyproject-only, per the release convention.

## What this release carries (already merged to main)

- The opt-in `/nauro-loop` work-origination skill, so `nauro adopt --with-skills` installs it.
- `check_decision` retrieval-limits wording.
- The open-questions discovery-pointer move into `nauro-core`.
- The refreshed `nauro-core` pin.

## What to review

The version line. Confirm the contents summary matches what's landed since `nauro-v0.13.2`.

## Release ordering

Merge the adopt-prompt docs PR first so it rides this release, then merge this bump. Tagging `nauro-v0.13.3` on `main` afterward triggers the PyPI publish.

## Test plan

Pyproject-only; CI runs the full suite. No code change.
