### PR TITLE
Fix nauro-loop ORIENT to mine L0 not L1 context

### DIFF
--- a/.agents/skills/nauro-loop/SKILL.md
+++ b/.agents/skills/nauro-loop/SKILL.md
@@ -25,12 +25,12 @@ These are structural, not stylistic. The loop holds none of these capabilities a
 
 ORIENT writes nothing. It reuses the Resume R1/R2 mining logic to read the project's current state and assemble candidate work:
 
-- `get_context(level="L1")` for the current sprint, blockers, and recent completions.
-- `get_raw_file(path="open-questions.md")`, read in full, scanning for `RESUME:` and `BRIEF:` pointers — a `RESUME:` pointer names in-flight work to continue; a `BRIEF:` pointer names context another agent left that may seed a task.
+- `get_context(level="L0")` for the concise project summary — current state, the top open questions, and last-10 active-decision summaries. That is enough to rank candidates against current direction; ORIENT does not need full decision bodies to compose the set, so it takes the cheaper L0 projection rather than the larger working set.
+- `get_raw_file(path="open-questions.md")`, scanned for the `RESUME:` and `BRIEF:` markers — a `RESUME:` marker names in-flight work to continue; a `BRIEF:` marker names context another agent left that may seed a task. This scan stays even though ORIENT already read L0: L0 deliberately excludes the discovery pointers from its open-questions projection, so the markers never appear in the L0 payload and a separate targeted scan of the file is the only way to reach them. Scanning a large file for two literal markers is cheap; reading the whole file into context is what overflowed, so scan for the markers rather than ingesting the file whole.
 - `diff_since_last_session` to see what changed recently, so the candidate set reflects real movement and not a stale read.
 - `list_decisions` to ground candidates against active doctrine and recent direction.
 
-From that, ORIENT composes 1-3 ranked candidate tasks. Each candidate carries a one-line rationale, the source signal it came from (the `L1` working set, a specific pointer, a recent diff, a decision), and its provenance so the human can trace where it originated.
+From that, ORIENT composes 1-3 ranked candidate tasks. Each candidate carries a one-line rationale, the source signal it came from (the `L0` working set, a specific pointer, a recent diff, a decision), and its provenance so the human can trace where it originated.
 
 Re-verify every `RESUME:` anchor before ranking it: check the branch heads, open PR numbers, and any expected-state anchors the pointer names against `origin/main`. A `RESUME:` candidate whose anchors no longer match is demoted to "stale, surface" — it is not ranked as live work; it is reported to the human as a pointer that needs attention. ORIENT never fabricates a candidate: if the mine is empty, it composes nothing and the loop stops (see RE-ORIENT).
 

--- a/.claude/skills/nauro-loop/SKILL.md
+++ b/.claude/skills/nauro-loop/SKILL.md
@@ -25,12 +25,12 @@ These are structural, not stylistic. The loop holds none of these capabilities a
 
 ORIENT writes nothing. It reuses the Resume R1/R2 mining logic to read the project's current state and assemble candidate work:
 
-- `get_context(level="L1")` for the current sprint, blockers, and recent completions.
-- `get_raw_file(path="open-questions.md")`, read in full, scanning for `RESUME:` and `BRIEF:` pointers — a `RESUME:` pointer names in-flight work to continue; a `BRIEF:` pointer names context another agent left that may seed a task.
+- `get_context(level="L0")` for the concise project summary — current state, the top open questions, and last-10 active-decision summaries. That is enough to rank candidates against current direction; ORIENT does not need full decision bodies to compose the set, so it takes the cheaper L0 projection rather than the larger working set.
+- `get_raw_file(path="open-questions.md")`, scanned for the `RESUME:` and `BRIEF:` markers — a `RESUME:` marker names in-flight work to continue; a `BRIEF:` marker names context another agent left that may seed a task. This scan stays even though ORIENT already read L0: L0 deliberately excludes the discovery pointers from its open-questions projection, so the markers never appear in the L0 payload and a separate targeted scan of the file is the only way to reach them. Scanning a large file for two literal markers is cheap; reading the whole file into context is what overflowed, so scan for the markers rather than ingesting the file whole.
 - `diff_since_last_session` to see what changed recently, so the candidate set reflects real movement and not a stale read.
 - `list_decisions` to ground candidates against active doctrine and recent direction.
 
-From that, ORIENT composes 1-3 ranked candidate tasks. Each candidate carries a one-line rationale, the source signal it came from (the `L1` working set, a specific pointer, a recent diff, a decision), and its provenance so the human can trace where it originated.
+From that, ORIENT composes 1-3 ranked candidate tasks. Each candidate carries a one-line rationale, the source signal it came from (the `L0` working set, a specific pointer, a recent diff, a decision), and its provenance so the human can trace where it originated.
 
 Re-verify every `RESUME:` anchor before ranking it: check the branch heads, open PR numbers, and any expected-state anchors the pointer names against `origin/main`. A `RESUME:` candidate whose anchors no longer match is demoted to "stale, surface" — it is not ranked as live work; it is reported to the human as a pointer that needs attention. ORIENT never fabricates a candidate: if the mine is empty, it composes nothing and the loop stops (see RE-ORIENT).
 

--- a/.cursor/rules/nauro-loop.mdc
+++ b/.cursor/rules/nauro-loop.mdc
@@ -25,12 +25,12 @@ These are structural, not stylistic. The loop holds none of these capabilities a
 
 ORIENT writes nothing. It reuses the Resume R1/R2 mining logic to read the project's current state and assemble candidate work:
 
-- `get_context(level="L1")` for the current sprint, blockers, and recent completions.
-- `get_raw_file(path="open-questions.md")`, read in full, scanning for `RESUME:` and `BRIEF:` pointers — a `RESUME:` pointer names in-flight work to continue; a `BRIEF:` pointer names context another agent left that may seed a task.
+- `get_context(level="L0")` for the concise project summary — current state, the top open questions, and last-10 active-decision summaries. That is enough to rank candidates against current direction; ORIENT does not need full decision bodies to compose the set, so it takes the cheaper L0 projection rather than the larger working set.
+- `get_raw_file(path="open-questions.md")`, scanned for the `RESUME:` and `BRIEF:` markers — a `RESUME:` marker names in-flight work to continue; a `BRIEF:` marker names context another agent left that may seed a task. This scan stays even though ORIENT already read L0: L0 deliberately excludes the discovery pointers from its open-questions projection, so the markers never appear in the L0 payload and a separate targeted scan of the file is the only way to reach them. Scanning a large file for two literal markers is cheap; reading the whole file into context is what overflowed, so scan for the markers rather than ingesting the file whole.
 - `diff_since_last_session` to see what changed recently, so the candidate set reflects real movement and not a stale read.
 - `list_decisions` to ground candidates against active doctrine and recent direction.
 
-From that, ORIENT composes 1-3 ranked candidate tasks. Each candidate carries a one-line rationale, the source signal it came from (the `L1` working set, a specific pointer, a recent diff, a decision), and its provenance so the human can trace where it originated.
+From that, ORIENT composes 1-3 ranked candidate tasks. Each candidate carries a one-line rationale, the source signal it came from (the `L0` working set, a specific pointer, a recent diff, a decision), and its provenance so the human can trace where it originated.
 
 Re-verify every `RESUME:` anchor before ranking it: check the branch heads, open PR numbers, and any expected-state anchors the pointer names against `origin/main`. A `RESUME:` candidate whose anchors no longer match is demoted to "stale, surface" — it is not ranked as live work; it is reported to the human as a pointer that needs attention. ORIENT never fabricates a candidate: if the mine is empty, it composes nothing and the loop stops (see RE-ORIENT).
 

--- a/packages/nauro/src/nauro/skills/loop_body.md
+++ b/packages/nauro/src/nauro/skills/loop_body.md
@@ -26,12 +26,12 @@ These are structural, not stylistic. The loop holds none of these capabilities a
 
 ORIENT writes nothing. It reuses the Resume R1/R2 mining logic to read the project's current state and assemble candidate work:
 
-- `get_context(level="L1")` for the current sprint, blockers, and recent completions.
-- `get_raw_file(path="open-questions.md")`, read in full, scanning for `RESUME:` and `BRIEF:` pointers — a `RESUME:` pointer names in-flight work to continue; a `BRIEF:` pointer names context another agent left that may seed a task.
+- `get_context(level="L0")` for the concise project summary — current state, the top open questions, and last-10 active-decision summaries. That is enough to rank candidates against current direction; ORIENT does not need full decision bodies to compose the set, so it takes the cheaper L0 projection rather than the larger working set.
+- `get_raw_file(path="open-questions.md")`, scanned for the `RESUME:` and `BRIEF:` markers — a `RESUME:` marker names in-flight work to continue; a `BRIEF:` marker names context another agent left that may seed a task. This scan stays even though ORIENT already read L0: L0 deliberately excludes the discovery pointers from its open-questions projection, so the markers never appear in the L0 payload and a separate targeted scan of the file is the only way to reach them. Scanning a large file for two literal markers is cheap; reading the whole file into context is what overflowed, so scan for the markers rather than ingesting the file whole.
 - `diff_since_last_session` to see what changed recently, so the candidate set reflects real movement and not a stale read.
 - `list_decisions` to ground candidates against active doctrine and recent direction.
 
-From that, ORIENT composes 1-3 ranked candidate tasks. Each candidate carries a one-line rationale, the source signal it came from (the `L1` working set, a specific pointer, a recent diff, a decision), and its provenance so the human can trace where it originated.
+From that, ORIENT composes 1-3 ranked candidate tasks. Each candidate carries a one-line rationale, the source signal it came from (the `L0` working set, a specific pointer, a recent diff, a decision), and its provenance so the human can trace where it originated.
 
 Re-verify every `RESUME:` anchor before ranking it: check the branch heads, open PR numbers, and any expected-state anchors the pointer names against `origin/main`. A `RESUME:` candidate whose anchors no longer match is demoted to "stale, surface" — it is not ranked as live work; it is reported to the human as a pointer that needs attention. ORIENT never fabricates a candidate: if the mine is empty, it composes nothing and the loop stops (see RE-ORIENT).
 


### PR DESCRIPTION
## Why

The `/nauro-loop` skill's ORIENT step mined the project store with
`get_context(level="L1")`. L1 is the working set: it pulls full decision bodies
plus the larger project/state/stack/questions payload into context on every loop
iteration. ORIENT only ranks 1-3 candidate tasks against current direction; it
does not need full decision bodies to do that. The result was an oversized read
on each ORIENT and RE-ORIENT cycle, and on stores with a large
`open-questions.md` the accompanying full-file ingest pushed context past where
it needed to be.

## Approach

Two coordinated reads, each scoped to what ORIENT actually consumes:

1. Switch the context mine to `get_context(level="L0")`. L0 is the concise
   projection — current state, the top open questions, and last-10
   active-decision summaries — which is exactly enough to rank candidates
   against current direction. Full decision bodies are not needed at ranking
   time, so ORIENT takes the cheaper projection.

2. Reframe the `open-questions.md` read from a full-file ingest to a targeted
   scan for the `RESUME:`/`BRIEF:` markers. This read has to stay even though
   ORIENT now reads L0: the L0 open-questions projection deliberately omits
   discovery pointers, so the markers never appear in the L0 payload, and a
   separate targeted scan of the file is the only way to reach them. Scanning a
   large file for two literal markers is cheap; ingesting the file whole is what
   inflated context.

An alternative — folding the marker read into L0 so ORIENT issues one call —
was rejected because L0 intentionally excludes those pointers from its
open-questions section. There is no L0 path to the markers, so a separate
scan is structurally required, not redundant.

## What changed

- `packages/nauro/src/nauro/skills/loop_body.md`: the ORIENT section's context
  mine, the open-questions read framing, and the candidate source-signal label
  (now "the L0 working set", matching the mine).
- The three rendered dogfood surfaces (`.claude`, `.agents`, `.cursor`)
  regenerated from the source body via the renderer so they stay byte-equal.

No behavioral logic changed — this is a skill-body correction. Every
load-bearing loop invariant is preserved untouched: mandatory human SELECT gate
with no auto-pick, the loop's no-store-write / no-push / no-`gh` posture, the
closed low-stakes auto-proceed under the loop, fail-closed on gate timeout, the
held-gate lock, the per-session ceiling, Gate H, and byte-for-byte chain
dispatch.

## What to review

- The added prose in the open-questions bullet explaining why the marker scan
  survives the switch to L0. That reasoning is the crux: if the L0 projection
  ever started including discovery pointers, the separate scan could fold in,
  but today it cannot. Confirm the rationale reads correctly.
- That the source-signal label and the mine now agree (both say L0).
- The three rendered files match the source body byte-for-byte (the drift test
  enforces this).

## What's deferred

- The same overflow pattern exists in the resume-brief mining of a sibling
  skill, which reads the working set where the concise summary would do. That
  correction is a separate change and is not included here.
- The loop's design write-up still describes the old L1 mine; updating it is
  deferred behind a separate tooling fix.

## Test plan

- `test_skills_drift.py`: 120 passed. The drift anchors (`## ORIENT`, `RESUME:`,
  `BRIEF:`, and the load-bearing invariant strings) are all preserved; no anchor
  referenced the old L1 mine, so no test edits were needed.
- Full `packages/nauro/` suite: 1499 passed, 10 skipped.
- `ruff check packages/` and `ruff format --check packages/`: clean.
