### PR TITLE
Release nauro and nauro-core 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ https://github.com/user-attachments/assets/9e6c475b-c584-470b-84c2-12f01b3a425a
 
 *A coding agent checks the project's prior decisions before it plans, then records the approved decision and makes the change. Captured in Codex.*
 
-**Status:** Beta (pre-1.0). The local CLI and stdio MCP server are stable; cloud sync is stabilizing.
+**Status:** Stable (1.0). The nauro CLI, the stdio MCP tool contract, and the on-disk store format follow semantic versioning. Cloud sync is versioned and operated separately.
 
 More at [nauro.ai](https://nauro.ai).
 

--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro-core"
-version = "0.13.12"
+version = "1.0.0"
 description = "Shared pure-Python logic for Nauro: parsing, validation, context assembly, constants."
 readme = "README.md"
 license = "Apache-2.0"
@@ -13,7 +13,7 @@ authors = [
     {name = "Thomas Thomsen"},
 ]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 5 - Production/Stable",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/packages/nauro-core/src/nauro_core/__init__.py
+++ b/packages/nauro-core/src/nauro_core/__init__.py
@@ -327,3 +327,59 @@ from nauro_core.validation import (
 DECISION_TYPES = DECISION_TYPE_VALUES
 
 __version__ = version("nauro-core")
+
+# Curated public import surface promised under semantic versioning. These are the
+# top-level `from nauro_core import X` names that nauro-core's documented API and
+# its real consumers (the Nauro CLI and the remote MCP server) depend on: decision
+# parsing and formatting, context assembly, hashing, the MCP tool contract, plus
+# the size limits and store-format constants the on-disk store and write-path
+# validation rely on. Names not listed remain importable (submodule-equivalent
+# access is unchanged), but are not part of the stability guarantee.
+__all__ = [
+    "__version__",
+    # Decision parsing, formatting, and summaries.
+    "parse_decision",
+    "format_decision",
+    "extract_decision_number",
+    "extract_stack_summary",
+    "decisions_summary_lines",
+    "build_graph_payload",
+    # Context assembly.
+    "build_l0",
+    "build_l1",
+    "build_l2",
+    # Hashing.
+    "compute_hash",
+    # MCP tool contract, remote instructions, and snapshot serialization.
+    "ALL_TOOLS",
+    "build_remote_instructions",
+    "serialize_snapshot",
+    "MCP_INSTRUCTIONS_STATIC",
+    "CHECK_DECISION_RETURNS",
+    "GET_DECISION_BEFORE_PROPOSING",
+    "NO_INVENT_RATIONALE",
+    # Identity.
+    "sanitize_sub",
+    # Valid decision types.
+    "DECISION_TYPES",
+    # Write-path size limits.
+    "MAX_BRIEF_BYTES",
+    "MAX_RATIONALE_LENGTH",
+    "MAX_TITLE_LENGTH",
+    "MAX_CONTEXT_LENGTH",
+    "MAX_APPROACH_LENGTH",
+    "MAX_DELTA_LENGTH",
+    "MAX_QUESTION_LENGTH",
+    "MIN_RATIONALE_LENGTH",
+    # Store-format constants.
+    "SNAPSHOT_SCHEMA_VERSION",
+    "DECISIONS_DIR",
+    "SNAPSHOTS_DIR",
+    "DECISION_HASHES_FILE",
+    "PROJECT_MD",
+    "STACK_MD",
+    "STATE_MD",
+    "OPEN_QUESTIONS_MD",
+    "STATE_CURRENT_FILENAME",
+    "STATE_HISTORY_FILENAME",
+]

--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro"
-version = "0.13.3"
+version = "1.0.0"
 description = "Local CLI + MCP server: set your project's doctrine once, every connected AI agent inherits it."
 readme = "README.md"
 license = "Apache-2.0"
@@ -13,7 +13,7 @@ authors = [
     {name = "Thomas Thomsen"},
 ]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 5 - Production/Stable",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "nauro-core>=0.13.10,<0.14",
+    "nauro-core>=1.0,<2",
     "typer>=0.9",
     "httpx>=0.24",
     "mcp>=1.0",

--- a/server.json
+++ b/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Nauro-AI/nauro",
     "source": "github"
   },
-  "version": "0.13.2",
+  "version": "1.0.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "nauro",
-      "version": "0.13.2",
+      "version": "1.0.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Why

Both packages have shipped as pre-1.0 alphas while the CLI, the stdio MCP tool
contract, and the on-disk store format settled. They are now stable and used in
practice, and the perpetual `0.x` line understates that and leaves consumers
without a stability signal. This promotes nauro and nauro-core to a 1.0.0 line
and states the guarantee explicitly. Crossing 1.0 is a one-way semantic-
versioning door, so the change is deliberately minimal and mechanical.

## Approach

Bump both package versions to 1.0.0, flip their PyPI classifiers from Alpha to
Production/Stable, and align the two non-package version surfaces (root README
status line, server.json).

The load-bearing change is the nauro dependency constraint on nauro-core. It is
widened from the `0.13.x` floor to `>=1.0,<2`. The previously published 0.13.x
core remains on PyPI, so leaving the old constraint would let pip resolve
nauro 1.0.0 against the stale core and orphan the new one. The widened range
pins nauro 1.0.0 to the 1.x core line.

For nauro-core we also make the public import surface explicit rather than
implicit. The package today re-exports a large facade and has no `__all__`, so
every importable name reads as equally guaranteed. We add a curated `__all__`
covering the names other surfaces actually depend on at the top level: the
facade floor, the write-path size limits, and the store-format constants. We
considered exporting the full re-export set, but that would over-promise on
internal helpers; the curated set scopes the 1.0 guarantee to what is genuinely
load-bearing. All existing re-exports stay importable, so the change is
non-breaking; `__all__` only narrows the documented guarantee.

## What changed

- Version + classifier bumps in both `pyproject.toml` files (nauro and nauro-core).
- nauro -> nauro-core dependency constraint widened to the 1.x line.
- Curated `__all__` added to `nauro_core/__init__.py` declaring the promised
  public import surface; existing re-exports unchanged.
- Root README status line rewritten to assert 1.0, the promise scope (CLI, MCP
  tool contract, store format), and that cloud sync is versioned separately.
- server.json top-level and package version bumped to 1.0.0.

## What to review

Two non-obvious points:

1. **The nauro-core dependency widening and the tag order it forces.** The
   constraint is now `nauro-core>=1.0,<2`. Because no 1.x core exists on PyPI
   yet, the nauro-core 1.0.0 tag must publish before the nauro 1.0.0 tag, or a
   fresh `pip install nauro==1.0.0` finds no satisfying core and fails. Publish
   order is non-negotiable: core first, then CLI.

2. **The curated `__all__` set** (28 names). Each was verified to be a real
   top-level re-export and importable from `nauro_core`; the 8-name facade floor
   (every top-level consumer in the workspace) is fully covered. The set:
   `__version__`; facade floor `build_graph_payload`, `parse_decision`,
   `extract_decision_number`, `sanitize_sub`, `DECISION_TYPES`,
   `MCP_INSTRUCTIONS_STATIC`, `CHECK_DECISION_RETURNS`,
   `GET_DECISION_BEFORE_PROPOSING`, `NO_INVENT_RATIONALE`; size limits
   `MAX_BRIEF_BYTES`, `MAX_RATIONALE_LENGTH`, `MAX_TITLE_LENGTH`,
   `MAX_CONTEXT_LENGTH`, `MAX_APPROACH_LENGTH`, `MAX_DELTA_LENGTH`,
   `MAX_QUESTION_LENGTH`, `MIN_RATIONALE_LENGTH`; store-format constants
   `SNAPSHOT_SCHEMA_VERSION`, `DECISIONS_DIR`, `SNAPSHOTS_DIR`,
   `DECISION_HASHES_FILE`, `PROJECT_MD`, `STACK_MD`, `STATE_MD`,
   `OPEN_QUESTIONS_MD`, `STATE_CURRENT_FILENAME`, `STATE_HISTORY_FILENAME`.

## What's deferred

- **Tagging and publishing.** Done manually after merge, in the forced order
  (nauro-core 1.0.0 tag and PyPI publish first, then nauro 1.0.0). Out of scope
  for this PR.
- **The plugin manifest lockstep bump** in the claude-plugins repo. The cross-
  repo version-sync gate requires a matching plugin version for every PyPI
  release; that lands as a separate PR in that repo.
- **mcp-server stays on nauro-core 0.13.12.** It pins core from PyPI and is not
  part of this monorepo release; bumping it is a separate, later change.

## Test plan

All commands mirror CI and pass on the branch:

- `ruff check packages/ benchmarks/` and `ruff format --check packages/ benchmarks/` clean.
- `lint-imports` (from `packages/nauro-core`): 2 contracts kept, 0 broken.
- `pytest packages/nauro-core/tests/`: 869 passed.
- `pytest packages/nauro/tests/` (excluding cross_surface): 1499 passed.

A scripted check confirms every `__all__` name is importable from `nauro_core`
and that the facade floor is fully covered, so the added export list is
non-breaking.
