### PR TITLE
Report the nauro package version in the stdio MCP server

### DIFF
--- a/packages/nauro/src/nauro/mcp/stdio_server.py
+++ b/packages/nauro/src/nauro/mcp/stdio_server.py
@@ -38,6 +38,7 @@ from nauro_core.mcp_tools import ToolSpec, get_tool_spec
 from nauro_core.renderers import RENDERERS as _RENDERERS
 from pydantic import Field
 
+from nauro import __version__
 from nauro.mcp.tools import (
     tool_check_decision,
     tool_diff_since_last_session,
@@ -66,6 +67,10 @@ from nauro.store.resolution import (
 
 logger = logging.getLogger("nauro.stdio")
 mcp = FastMCP("nauro", instructions=MCP_INSTRUCTIONS, log_level="WARNING")
+# FastMCP does not forward a version to the underlying low-level server, which
+# otherwise reports the mcp framework version in the initialize response. Set
+# the nauro package version so connecting clients see the release in use.
+mcp._mcp_server.version = __version__
 
 
 NOT_A_NAURO_REPO = (

--- a/packages/nauro/tests/test_stdio_server.py
+++ b/packages/nauro/tests/test_stdio_server.py
@@ -338,6 +338,19 @@ class TestToolRegistration:
         assert "diff_since_last_session" in tool_names
 
 
+class TestServerInfo:
+    def test_server_reports_nauro_version(self):
+        """initialize advertises the nauro package version, not the mcp
+        framework version. FastMCP does not forward a version to the underlying
+        low-level server, so stdio_server sets it explicitly; this guards the
+        wiring against regressing to the framework default."""
+        from nauro import __version__
+
+        assert mcp._mcp_server.version == __version__
+        opts = mcp._mcp_server.create_initialization_options()
+        assert opts.server_version == __version__
+
+
 class TestToolSpecDescriptionsReachAgent:
     """Per-property descriptions in nauro_core.mcp_tools must reach agents
     via FastMCP's tools/list inputSchema, not just the parent tool


### PR DESCRIPTION
## Why

The stdio MCP server's `initialize` response reported the `mcp` framework version (e.g. `1.28.0`) as `serverInfo.version` instead of nauro's package version, so a connecting client saw a version that did not match the installed nauro. Surfaced while functionally testing the 1.0.0 release.

## What changed

`stdio_server` sets `mcp._mcp_server.version = __version__` after constructing `FastMCP`. The SDK's `FastMCP` does not forward a version to the underlying low-level `Server`, which otherwise falls back to `pkg_version("mcp")`. A guard test asserts `initialize` advertises the nauro package version.

## What to review

The fix reaches into `mcp._mcp_server` because `FastMCP.__init__` exposes no `version` parameter in the pinned SDK; the low-level `Server` does accept one, and `create_initialization_options()` uses `self.version` when set. If a future SDK adds a first-class `version` kwarg, prefer that.

## What's deferred

The hosted MCP server (separate repo) constructs its app differently and is not touched here. This change reaches users on the next release tag.

## Test plan

Full nauro suite passes (1500, including the new `TestServerInfo` guard). Functional check: a fresh `initialize` against `nauro serve` reports the nauro package version.
