### PR TITLE
Make propose_decision operation="update" callable

### DIFF
--- a/packages/nauro-core/src/nauro_core/mcp_tools.py
+++ b/packages/nauro-core/src/nauro_core/mcp_tools.py
@@ -330,6 +330,7 @@ PROPOSE_DECISION: ToolSpec = {
         "properties": {
             "title": {
                 "type": "string",
+                "default": "",
                 "description": "Short title for the decision.",
             },
             "rationale": {
@@ -369,7 +370,12 @@ PROPOSE_DECISION: ToolSpec = {
             "confidence": {
                 "type": "string",
                 "enum": ["high", "medium", "low"],
-                "default": "medium",
+                # No schema default: the adapter applies "medium" for add/
+                # supersede when confidence is unset, and relies on an unset
+                # (None) value to recognise "caller did not send confidence" on
+                # update. A schema default makes every derived transport (the
+                # CLI autogen surface) materialise "medium", which the kernel
+                # then rejects as a disallowed metadata change on update.
                 "description": (
                     "Author's confidence in the decision. Use 'high' only "
                     "when a source explicitly accepts or approves the choice; "
@@ -416,7 +422,11 @@ PROPOSE_DECISION: ToolSpec = {
             },
             "project_id": _PROJECT_PARAM,
         },
-        "required": ["title", "rationale"],
+        # title is optional: operation="update" appends rationale only and the
+        # kernel rejects a non-empty title on update, so a required title made
+        # update uncallable through any schema-respecting transport. On add/
+        # supersede the kernel still rejects an empty title structurally.
+        "required": ["rationale"],
     },
 }
 

--- a/packages/nauro-core/tests/operations/test_operations_propose_decision.py
+++ b/packages/nauro-core/tests/operations/test_operations_propose_decision.py
@@ -527,6 +527,39 @@ def test_update_appends_rationale_paragraph() -> None:
     assert "version: 2" in body
 
 
+def test_update_rationale_only_omitting_title_preserves_target_title() -> None:
+    """A rationale-only update that omits ``title`` confirms and leaves the
+    target's title untouched.
+
+    This is the kernel half of the deadlock fix: a schema-respecting client now
+    omits ``title`` entirely (rather than being forced to send a non-empty value
+    the kernel would reject). ``title=None`` must pass the disallowed-fields
+    check and the rewrite must preserve the original title verbatim.
+    """
+    original_title = "Adopt PostgreSQL"
+    store = _store_with(
+        _seed_decision(
+            1,
+            original_title,
+            "Mature ecosystem with strong JSON support and excellent tooling.",
+        ),
+    )
+    result = propose_decision(
+        store,
+        title=None,
+        rationale="Add a managed-extensions clause after the first month in production.",
+        operation="update",
+        affected_decision_id="decision-001",
+    )
+    assert result.status == "confirmed"
+    assert result.operation == "update"
+    body = store.read_decision("001-adopt-postgresql")
+    assert body is not None
+    # The title lives in the decision heading; the update must leave it intact.
+    assert f"— {original_title}" in body
+    assert "managed-extensions clause" in body
+
+
 def test_update_disallowed_field_rejected_loudly() -> None:
     """``operation="update"`` cannot change metadata; rejection at Tier 0."""
     store = _store_with(

--- a/packages/nauro/CLAUDE.md
+++ b/packages/nauro/CLAUDE.md
@@ -50,7 +50,7 @@ Principal commands (run `nauro --help` for the full surface):
 
 Command groups: `setup <claude-code|cursor|codex|all>`, `auth <login|status|logout>`, `config <get|list|unset>`, `telemetry <status|enable|disable|reset>`, `validate`, `projects`, `questions`, `hook`.
 
-The 10 read/write MCP tools are also mirrored as CLI commands, auto-generated from the tool allowlist in `cli/autogen.py` (underscored tool names become hyphenated commands). For example: `nauro check-decision`, `nauro diff-since-last-session [--days N]`, and `nauro propose-decision <title> <rationale> [--operation add|update|supersede] [--rejected JSON] [--files-affected PATH ...]` (single-call commit on Tier 1 clean; Tier 2 BM25 hits surface as advisory `similar_decisions` on the same response).
+The 10 read/write MCP tools are also mirrored as CLI commands, auto-generated from the tool allowlist in `cli/autogen.py` (underscored tool names become hyphenated commands). For example: `nauro check-decision`, `nauro diff-since-last-session [--days N]`, and `nauro propose-decision <rationale> [--title TITLE] [--operation add|update|supersede] [--rejected JSON] [--files-affected PATH ...]` (single-call commit on Tier 1 clean; Tier 2 BM25 hits surface as advisory `similar_decisions` on the same response). `--title` is optional: `operation="update"` appends rationale only, so a rationale-only update omits it.
 
 `list[str]` flags (`--files-affected`, `--resolves-questions`) repeat: `--files-affected a.py --files-affected b.py`. `list[dict]` flags (`--rejected`) take a single JSON value: inline (`'[{...}]'`), `@file.json`, or `-` to read from stdin.
 

--- a/packages/nauro/src/nauro/mcp/stdio_server.py
+++ b/packages/nauro/src/nauro/mcp/stdio_server.py
@@ -315,8 +315,8 @@ def check_decision(
 
 @mcp.tool(**_spec_kwargs("propose_decision"))
 def propose_decision(
-    title: Annotated[str, Field(description=_param_desc("propose_decision", "title"))],
     rationale: Annotated[str, Field(description=_param_desc("propose_decision", "rationale"))],
+    title: Annotated[str, Field(description=_param_desc("propose_decision", "title"))] = "",
     operation: Annotated[
         Literal["add", "update", "supersede"],
         Field(description=_param_desc("propose_decision", "operation")),

--- a/packages/nauro/tests/test_skill_tool_signatures.py
+++ b/packages/nauro/tests/test_skill_tool_signatures.py
@@ -244,16 +244,15 @@ def _kwarg_value(kwargs: dict[str, str], key: str) -> str:
 
 
 def _required_for_call(spec: ToolSpec, kwargs: dict[str, str]) -> set[str]:
-    """Effective required-param set, applying the update-operation exception.
+    """Effective required-param set for a tool call.
 
-    ``propose_decision(operation="update")`` only accepts ``rationale`` +
-    ``affected_decision_id`` at the server boundary, so ``title`` is
-    relaxed from the schema's static required list.
+    ``propose_decision`` marks only ``rationale`` required: ``title`` is
+    optional because ``operation="update"`` appends rationale only and the
+    kernel rejects a non-empty title on update. A required title would make
+    update uncallable through any schema-respecting transport. The set is read
+    straight from the schema; no per-operation adjustment is needed.
     """
-    required = set(spec["input_schema"].get("required", []))
-    if spec["name"] == "propose_decision" and _kwarg_value(kwargs, "operation") == "update":
-        required.discard("title")
-    return required
+    return set(spec["input_schema"].get("required", []))
 
 
 def _call_looks_complete(positional: list[str], kwargs: dict[str, str]) -> bool:
@@ -290,12 +289,14 @@ def test_parser_emits_unbalanced_calls_with_none_args():
     assert call.offset == len("propose_decision")
 
 
-def test_required_for_call_relaxes_title_for_update_propose():
+def test_required_for_call_title_optional_rationale_required():
+    """propose_decision requires only ``rationale``; ``title`` is optional for
+    every operation so rationale-only update is callable through the schema."""
     spec = _TOOL_BY_NAME["propose_decision"]
-    assert "title" in _required_for_call(spec, kwargs={})
-    relaxed = _required_for_call(spec, kwargs={"operation": '"update"'})
-    assert "title" not in relaxed
-    assert "rationale" in relaxed
+    for kwargs in ({}, {"operation": '"add"'}, {"operation": '"update"'}):
+        required = _required_for_call(spec, kwargs=kwargs)
+        assert "rationale" in required
+        assert "title" not in required
 
 
 def test_tool_prefixes_derived_from_all_tools():

--- a/packages/nauro/tests/test_write_command_autogen.py
+++ b/packages/nauro/tests/test_write_command_autogen.py
@@ -83,8 +83,9 @@ class TestProposeDecisionHappyPaths:
             app,
             [
                 "propose-decision",
-                "Adopt Redis for hot caching",
                 "In-memory cache for the hot read paths across the API tier.",
+                "--title",
+                "Adopt Redis for hot caching",
             ],
         )
         assert result.exit_code == 0, result.output
@@ -109,8 +110,9 @@ class TestProposeDecisionHappyPaths:
             app,
             [
                 "propose-decision",
-                "Switch to managed PostgreSQL provider",
                 "Reduces operational burden; self-hosting rationale no longer applies.",
+                "--title",
+                "Switch to managed PostgreSQL provider",
                 "--operation",
                 "supersede",
                 "--affected-decision-id",
@@ -123,17 +125,61 @@ class TestProposeDecisionHappyPaths:
         assert envelope["status"] == "confirmed"
         assert envelope["operation"] == "supersede"
 
+    def test_update_rationale_only_no_title_confirms_and_preserves_title(self, seeded_repo) -> None:
+        """A rationale-only ``--operation update`` with no ``--title`` confirms
+        end-to-end and leaves the target decision's title untouched.
+
+        This is the path the old schema deadlocked: ``title`` was a required
+        positional, so a schema-respecting CLI client could never omit it, yet
+        the kernel rejects a non-empty title on update. With ``title`` optional
+        the positional is gone and the update is callable. Title preservation is
+        asserted on the rewritten decision file, not just the envelope.
+        """
+        _pid, store_path, _repo = seeded_repo
+        original_title = "Adopt PostgreSQL primary database"
+        append_decision(
+            store_path,
+            original_title,
+            rationale="Mature ecosystem with strong JSON support and excellent tooling.",
+        )
+        decisions = sorted(f.stem for f in (store_path / "decisions").glob("*.md"))
+        postgres_stem = next(s for s in decisions if "postgres" in s)
+        short_form = postgres_stem.split("-", 1)[0]
+
+        result = runner.invoke(
+            app,
+            [
+                "propose-decision",
+                "Add a managed-extensions clause after the first month in production.",
+                "--operation",
+                "update",
+                "--affected-decision-id",
+                short_form,
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        envelope = json.loads(result.stdout)
+        assert envelope["status"] == "confirmed"
+        assert envelope["operation"] == "update"
+
+        # The target's title survives the rationale append; the rationale grows.
+        body = (store_path / "decisions" / f"{postgres_stem}.md").read_text()
+        assert f"— {original_title}" in body
+        assert "managed-extensions clause" in body
+        assert "version: 2" in body
+
 
 # ── Rejection paths ─────────────────────────────────────────────────────────
 
 
 class TestProposeDecisionRejections:
     def test_update_without_affected_id_rejected(self, seeded_repo) -> None:
+        # A real rationale-only update omits --title; the adapter rejects the
+        # missing affected_decision_id before the kernel is reached.
         result = runner.invoke(
             app,
             [
                 "propose-decision",
-                "Tweak PostgreSQL rationale",
                 "Add operational notes after the first month of production use.",
                 "--operation",
                 "update",
@@ -151,7 +197,6 @@ class TestProposeDecisionRejections:
             app,
             [
                 "propose-decision",
-                "Tweak something that does not exist",
                 "Add operational notes after the first month of production use.",
                 "--operation",
                 "update",
@@ -171,8 +216,9 @@ class TestProposeDecisionRejections:
             app,
             [
                 "propose-decision",
-                "Adopt Redis for hot caching",
                 oversized,
+                "--title",
+                "Adopt Redis for hot caching",
             ],
         )
         assert result.exit_code == 0, result.output
@@ -191,8 +237,9 @@ class TestProposeDecisionRejections:
             app,
             [
                 "propose-decision",
-                "Adopt Redis for hot caching",
                 "In-memory cache for the hot read paths across the API tier.",
+                "--title",
+                "Adopt Redis for hot caching",
             ],
         )
         assert result.exit_code == 1
@@ -209,8 +256,9 @@ class TestFlagShapes:
             app,
             [
                 "propose-decision",
-                "Adopt Redis for hot caching",
                 "In-memory cache for the hot read paths across the API tier.",
+                "--title",
+                "Adopt Redis for hot caching",
                 "--files-affected",
                 "a.py",
                 "--files-affected",
@@ -232,8 +280,9 @@ class TestFlagShapes:
             app,
             [
                 "propose-decision",
-                "Adopt Redis for hot caching",
                 "In-memory cache for the hot read paths across the API tier.",
+                "--title",
+                "Adopt Redis for hot caching",
                 "--rejected",
                 '[{"alternative": "Memcached", "reason": "Less feature-rich"}]',
             ],
@@ -249,8 +298,9 @@ class TestFlagShapes:
             app,
             [
                 "propose-decision",
-                "Adopt Redis for hot caching",
                 "In-memory cache for the hot read paths across the API tier.",
+                "--title",
+                "Adopt Redis for hot caching",
                 "--rejected",
                 f"@{payload}",
             ],
@@ -264,8 +314,9 @@ class TestFlagShapes:
             app,
             [
                 "propose-decision",
-                "Adopt Redis for hot caching",
                 "In-memory cache for the hot read paths across the API tier.",
+                "--title",
+                "Adopt Redis for hot caching",
                 "--rejected",
                 "-",
             ],
@@ -280,8 +331,9 @@ class TestFlagShapes:
             app,
             [
                 "propose-decision",
-                "Adopt Redis for hot caching",
                 "In-memory cache for the hot read paths across the API tier.",
+                "--title",
+                "Adopt Redis for hot caching",
                 "--rejected",
                 "not json",
             ],
@@ -296,8 +348,9 @@ class TestFlagShapes:
             app,
             [
                 "propose-decision",
-                "Adopt Redis for hot caching",
                 "In-memory cache for the hot read paths across the API tier.",
+                "--title",
+                "Adopt Redis for hot caching",
                 "--rejected",
                 '{"not": "a list"}',
             ],
@@ -315,8 +368,9 @@ class TestFlagShapes:
             app,
             [
                 "propose-decision",
-                "Adopt Redis for hot caching",
                 "In-memory cache for the hot read paths across the API tier.",
+                "--title",
+                "Adopt Redis for hot caching",
                 "--operation",
                 "bogus",
             ],


### PR DESCRIPTION
## Why

`propose_decision operation="update"` was uncallable through any schema-respecting client. The tool's input schema marked `title` required, so every transport forced callers to send a non-empty title — but the kernel rejects a non-empty title on update (update appends rationale only; metadata changes must go through supersede). No caller could satisfy both constraints, so rationale-only update — the cheap, append-only operation the tool was designed around — could not be invoked at all.

## Approach

The deadlock is single-sourced, so the fix is single-sourced: relax the tool's input schema so `title` is no longer required. That loosens the contract on every derived transport (CLI, local stdio, hosted) from one edit. The kernel is left untouched — its disallowed-fields check already fires only on a *non-empty* title, and the update path preserves the target decision's existing title — so a non-empty title on update is still rejected and nothing is silently dropped.

Implementing this surfaced a second, same-shaped deadlock the title fix alone did not clear: the `confidence` property carried a schema-level default of `"medium"`, which the CLI command generator materializes into every invocation. On update the kernel then rejected that materialized `"medium"` as a disallowed metadata change. The schema default was redundant — the request adapter is the real default source, applying `"medium"` for add/supersede when confidence is unset and relying on an unset value to recognize "caller did not send confidence" on update. Removing the schema default restores that contract on the CLI surface (it was already honored on the hosted transport) and completes the prior single-source consolidation that earlier installments missed; `confidence` now behaves like the other optional enum metadata fields, which carry no schema default.

Both changes loosen the contract rather than tighten it, so they are backward-compatible / semver-minor on the MCP tool surface: callers that always sent a title or a confidence are unaffected.

## What changes

- The tool's required-field set drops `title` (now `["rationale"]`).
- The `confidence` property no longer declares a schema default; the adapter remains the source of the `"medium"` default for add/supersede.
- **User-visible:** the CLI `propose-decision` command moves `title` from a required positional to a `--title` option, and `rationale` becomes the sole required positional: `nauro propose-decision <rationale> [--title TITLE] [--operation ...]`. No back-compat positional shim is included, by deliberate choice — the 1.0 install base is days old, so we migrate while it's free rather than carry a second input shape.
- The local stdio `title` parameter defaults to `""` (not `None`) so the adapter's length/envelope validation never sees `None` on an omitted title.
- Docs: the CLI signature reference is updated to the new shape.

## What's deferred

- The hosted MCP server stays pinned to its current core version and is untouched in this PR; its dispatch already tolerates an omitted title, and it picks up the relaxed schema on a later, separately-gated dependency bump.

## Test plan

- New regression: a confirmed rationale-only update with no title, exercised end-to-end through **both** the kernel and the CLI contract (not bypassing the schema), asserting the result is `confirmed` and the target decision's title is preserved on disk. This is the path that was previously uncallable.
- Migrated the add-path CLI tests from the `title rationale` positional form to the `--title` form, preserving every assertion.
- Updated the tool-signature required-set test to the new truth (title optional for every operation; rationale required).
- Full suites green: nauro-core 870 passed; nauro 1501 passed, 10 skipped. Lint clean (`ruff check`, `ruff format --check`).
