### PR TITLE
Add a public-contract snapshot test enforcing the 1.0 freeze

### DIFF
--- a/packages/nauro/tests/snapshots/public_contract_v1.json
+++ b/packages/nauro/tests/snapshots/public_contract_v1.json
@@ -23,7 +23,7 @@
               "--force-overwrite"
             ],
             "is_flag": true,
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "force_overwrite",
             "required": false,
             "type": "boolean"
@@ -32,7 +32,7 @@
             "flags": [
               "--name"
             ],
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "name",
             "required": false,
             "type": "text"
@@ -43,7 +43,7 @@
               "--no-setup-and-skills"
             ],
             "is_flag": true,
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "no_setup_and_skills",
             "required": false,
             "type": "boolean"
@@ -54,7 +54,7 @@
               "--print-prompt"
             ],
             "is_flag": true,
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "print_prompt",
             "required": false,
             "type": "boolean"
@@ -63,7 +63,7 @@
             "flags": [
               "--repo"
             ],
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "repo",
             "required": false,
             "type": "path"
@@ -74,7 +74,7 @@
               "--with-skills"
             ],
             "is_flag": true,
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "with_skills",
             "required": false,
             "type": "boolean"
@@ -85,7 +85,7 @@
               "--with-subagents"
             ],
             "is_flag": true,
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "with_subagents",
             "required": false,
             "type": "boolean"
@@ -97,7 +97,7 @@
         "name": "attach",
         "params": [
           {
-            "kind": "TyperArgument",
+            "kind": "argument",
             "name": "project_id",
             "required": true,
             "type": "text"
@@ -106,7 +106,7 @@
             "flags": [
               "--repo"
             ],
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "repo_path",
             "required": false,
             "type": "path"
@@ -143,7 +143,7 @@
             "flags": [
               "--context"
             ],
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "context",
             "required": false,
             "type": "text"
@@ -155,7 +155,7 @@
               "--no-json"
             ],
             "is_flag": true,
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "json_output",
             "required": false,
             "type": "boolean"
@@ -164,13 +164,13 @@
             "flags": [
               "--project"
             ],
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "project",
             "required": false,
             "type": "text"
           },
           {
-            "kind": "TyperArgument",
+            "kind": "argument",
             "name": "proposed_approach",
             "required": true,
             "type": "text"
@@ -184,7 +184,7 @@
             "name": "get",
             "params": [
               {
-                "kind": "TyperArgument",
+                "kind": "argument",
                 "name": "key",
                 "required": true,
                 "type": "text"
@@ -201,7 +201,7 @@
             "name": "unset",
             "params": [
               {
-                "kind": "TyperArgument",
+                "kind": "argument",
                 "name": "key",
                 "required": true,
                 "type": "text"
@@ -221,7 +221,7 @@
             "flags": [
               "--days"
             ],
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "days",
             "required": false,
             "type": "integer"
@@ -233,7 +233,7 @@
               "--no-json"
             ],
             "is_flag": true,
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "json_output",
             "required": false,
             "type": "boolean"
@@ -242,7 +242,7 @@
             "flags": [
               "--project"
             ],
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "project",
             "required": false,
             "type": "text"
@@ -257,7 +257,7 @@
             "flags": [
               "--context"
             ],
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "context",
             "required": false,
             "type": "text"
@@ -269,7 +269,7 @@
               "--no-json"
             ],
             "is_flag": true,
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "json_output",
             "required": false,
             "type": "boolean"
@@ -278,7 +278,7 @@
             "flags": [
               "--project"
             ],
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "project",
             "required": false,
             "type": "text"
@@ -287,7 +287,7 @@
             "flags": [
               "--question"
             ],
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "question",
             "required": false,
             "type": "text"
@@ -296,7 +296,7 @@
             "flags": [
               "--resolved-by"
             ],
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "resolved_by",
             "required": false,
             "type": "text"
@@ -305,7 +305,7 @@
             "flags": [
               "--targets"
             ],
-            "kind": "TyperOption",
+            "kind": "option",
             "multiple": true,
             "name": "targets",
             "required": false,
@@ -324,7 +324,7 @@
               "--no-json"
             ],
             "is_flag": true,
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "json_output",
             "required": false,
             "type": "boolean"
@@ -339,7 +339,7 @@
             "flags": [
               "--level"
             ],
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "level",
             "required": false,
             "type": "choice"
@@ -348,7 +348,7 @@
             "flags": [
               "--project"
             ],
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "project",
             "required": false,
             "type": "text"
@@ -366,7 +366,7 @@
               "--no-json"
             ],
             "is_flag": true,
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "json_output",
             "required": false,
             "type": "boolean"
@@ -380,13 +380,13 @@
             "flags": [
               "--mode"
             ],
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "mode",
             "required": false,
             "type": "choice"
           },
           {
-            "kind": "TyperArgument",
+            "kind": "argument",
             "name": "number",
             "required": true,
             "type": "integer"
@@ -395,7 +395,7 @@
             "flags": [
               "--project"
             ],
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "project",
             "required": false,
             "type": "text"
@@ -413,13 +413,13 @@
               "--no-json"
             ],
             "is_flag": true,
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "json_output",
             "required": false,
             "type": "boolean"
           },
           {
-            "kind": "TyperArgument",
+            "kind": "argument",
             "name": "path",
             "required": true,
             "type": "text"
@@ -428,7 +428,7 @@
             "flags": [
               "--project"
             ],
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "project",
             "required": false,
             "type": "text"
@@ -446,7 +446,7 @@
               "--no-include-bodies"
             ],
             "is_flag": true,
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "include_bodies",
             "required": false,
             "type": "boolean"
@@ -458,7 +458,7 @@
               "--open"
             ],
             "is_flag": true,
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "open_browser",
             "required": false,
             "type": "boolean"
@@ -467,7 +467,7 @@
             "flags": [
               "--output"
             ],
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "output",
             "required": false,
             "type": "path"
@@ -476,7 +476,7 @@
             "flags": [
               "--project"
             ],
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "project",
             "required": false,
             "type": "text"
@@ -503,7 +503,7 @@
             "flags": [
               "--adr"
             ],
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "adr",
             "required": false,
             "type": "path"
@@ -512,7 +512,7 @@
             "flags": [
               "--memory-bank"
             ],
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "memory_bank",
             "required": false,
             "type": "path"
@@ -521,7 +521,7 @@
             "flags": [
               "--project"
             ],
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "project",
             "required": false,
             "type": "text"
@@ -536,7 +536,7 @@
             "flags": [
               "--add-repo"
             ],
-            "kind": "TyperOption",
+            "kind": "option",
             "multiple": true,
             "name": "add_repo_paths",
             "required": false,
@@ -548,7 +548,7 @@
               "--cloud"
             ],
             "is_flag": true,
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "cloud",
             "required": false,
             "type": "boolean"
@@ -559,7 +559,7 @@
               "--demo"
             ],
             "is_flag": true,
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "demo",
             "required": false,
             "type": "boolean"
@@ -570,13 +570,13 @@
               "--force"
             ],
             "is_flag": true,
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "force",
             "required": false,
             "type": "boolean"
           },
           {
-            "kind": "TyperArgument",
+            "kind": "argument",
             "name": "name",
             "required": false,
             "type": "text"
@@ -593,7 +593,7 @@
               "--cloud"
             ],
             "is_flag": true,
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "cloud",
             "required": false,
             "type": "boolean"
@@ -611,7 +611,7 @@
               "--no-include-superseded"
             ],
             "is_flag": true,
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "include_superseded",
             "required": false,
             "type": "boolean"
@@ -623,7 +623,7 @@
               "--no-json"
             ],
             "is_flag": true,
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "json_output",
             "required": false,
             "type": "boolean"
@@ -633,7 +633,7 @@
             "flags": [
               "--limit"
             ],
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "limit",
             "required": false,
             "type": "integer"
@@ -642,7 +642,7 @@
             "flags": [
               "--project"
             ],
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "project",
             "required": false,
             "type": "text"
@@ -659,7 +659,7 @@
               "--all"
             ],
             "is_flag": true,
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "all_decisions",
             "required": false,
             "type": "boolean"
@@ -670,7 +670,7 @@
               "--decisions"
             ],
             "is_flag": true,
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "decisions",
             "required": false,
             "type": "boolean"
@@ -681,7 +681,7 @@
               "--full"
             ],
             "is_flag": true,
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "full",
             "required": false,
             "type": "boolean"
@@ -692,7 +692,7 @@
               "--limit",
               "-n"
             ],
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "limit",
             "required": false,
             "type": "integer"
@@ -701,7 +701,7 @@
             "flags": [
               "--project"
             ],
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "project",
             "required": false,
             "type": "text"
@@ -718,7 +718,7 @@
               "--confidence",
               "-c"
             ],
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "confidence",
             "required": false,
             "type": "text"
@@ -730,7 +730,7 @@
               "-d"
             ],
             "is_flag": true,
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "decision",
             "required": false,
             "type": "boolean"
@@ -739,7 +739,7 @@
             "flags": [
               "--project"
             ],
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "project",
             "required": false,
             "type": "text"
@@ -751,7 +751,7 @@
               "-q"
             ],
             "is_flag": true,
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "question",
             "required": false,
             "type": "boolean"
@@ -761,13 +761,13 @@
               "--rationale",
               "-r"
             ],
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "rationale",
             "required": false,
             "type": "text"
           },
           {
-            "kind": "TyperArgument",
+            "kind": "argument",
             "name": "text",
             "required": true,
             "type": "text"
@@ -786,7 +786,7 @@
             "name": "rm",
             "params": [
               {
-                "kind": "TyperArgument",
+                "kind": "argument",
                 "name": "project_id",
                 "required": true,
                 "type": "text"
@@ -797,7 +797,7 @@
                   "--yes"
                 ],
                 "is_flag": true,
-                "kind": "TyperOption",
+                "kind": "option",
                 "name": "yes",
                 "required": false,
                 "type": "boolean"
@@ -817,7 +817,7 @@
             "flags": [
               "--affected-decision-id"
             ],
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "affected_decision_id",
             "required": false,
             "type": "text"
@@ -831,7 +831,7 @@
             "flags": [
               "--confidence"
             ],
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "confidence",
             "required": false,
             "type": "choice"
@@ -848,7 +848,7 @@
             "flags": [
               "--decision-type"
             ],
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "decision_type",
             "required": false,
             "type": "choice"
@@ -857,7 +857,7 @@
             "flags": [
               "--files-affected"
             ],
-            "kind": "TyperOption",
+            "kind": "option",
             "multiple": true,
             "name": "files_affected",
             "required": false,
@@ -870,7 +870,7 @@
               "--no-json"
             ],
             "is_flag": true,
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "json_output",
             "required": false,
             "type": "boolean"
@@ -885,7 +885,7 @@
             "flags": [
               "--operation"
             ],
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "operation",
             "required": false,
             "type": "choice"
@@ -894,13 +894,13 @@
             "flags": [
               "--project"
             ],
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "project",
             "required": false,
             "type": "text"
           },
           {
-            "kind": "TyperArgument",
+            "kind": "argument",
             "name": "rationale",
             "required": true,
             "type": "text"
@@ -909,7 +909,7 @@
             "flags": [
               "--rejected"
             ],
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "rejected",
             "required": false,
             "type": "text"
@@ -918,7 +918,7 @@
             "flags": [
               "--resolves-questions"
             ],
-            "kind": "TyperOption",
+            "kind": "option",
             "multiple": true,
             "name": "resolves_questions",
             "required": false,
@@ -933,7 +933,7 @@
             "flags": [
               "--reversibility"
             ],
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "reversibility",
             "required": false,
             "type": "choice"
@@ -943,7 +943,7 @@
             "flags": [
               "--title"
             ],
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "title",
             "required": false,
             "type": "text"
@@ -962,7 +962,7 @@
                   "--dry-run"
                 ],
                 "is_flag": true,
-                "kind": "TyperOption",
+                "kind": "option",
                 "name": "dry_run",
                 "required": false,
                 "type": "boolean"
@@ -971,7 +971,7 @@
                 "flags": [
                   "--project"
                 ],
-                "kind": "TyperOption",
+                "kind": "option",
                 "name": "project",
                 "required": false,
                 "type": "text"
@@ -994,13 +994,13 @@
               "--check"
             ],
             "is_flag": true,
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "check",
             "required": false,
             "type": "boolean"
           },
           {
-            "kind": "TyperArgument",
+            "kind": "argument",
             "name": "dir",
             "required": true,
             "type": "path"
@@ -1018,7 +1018,7 @@
               "--no-include-superseded"
             ],
             "is_flag": true,
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "include_superseded",
             "required": false,
             "type": "boolean"
@@ -1030,7 +1030,7 @@
               "--no-json"
             ],
             "is_flag": true,
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "json_output",
             "required": false,
             "type": "boolean"
@@ -1040,7 +1040,7 @@
             "flags": [
               "--limit"
             ],
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "limit",
             "required": false,
             "type": "integer"
@@ -1049,13 +1049,13 @@
             "flags": [
               "--project"
             ],
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "project",
             "required": false,
             "type": "text"
           },
           {
-            "kind": "TyperArgument",
+            "kind": "argument",
             "name": "query",
             "required": true,
             "type": "text"
@@ -1072,7 +1072,7 @@
               "--stdio"
             ],
             "is_flag": true,
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "stdio",
             "required": false,
             "type": "boolean"
@@ -1091,7 +1091,7 @@
                   "--force-overwrite"
                 ],
                 "is_flag": true,
-                "kind": "TyperOption",
+                "kind": "option",
                 "name": "force_overwrite",
                 "required": false,
                 "type": "boolean"
@@ -1100,7 +1100,7 @@
                 "flags": [
                   "--project"
                 ],
-                "kind": "TyperOption",
+                "kind": "option",
                 "name": "project",
                 "required": false,
                 "type": "text"
@@ -1111,7 +1111,7 @@
                   "--remove"
                 ],
                 "is_flag": true,
-                "kind": "TyperOption",
+                "kind": "option",
                 "name": "remove",
                 "required": false,
                 "type": "boolean"
@@ -1122,7 +1122,7 @@
                   "--with-hooks"
                 ],
                 "is_flag": true,
-                "kind": "TyperOption",
+                "kind": "option",
                 "name": "with_hooks",
                 "required": false,
                 "type": "boolean"
@@ -1133,7 +1133,7 @@
                   "--with-skills"
                 ],
                 "is_flag": true,
-                "kind": "TyperOption",
+                "kind": "option",
                 "name": "with_skills",
                 "required": false,
                 "type": "boolean"
@@ -1144,7 +1144,7 @@
                   "--with-subagents"
                 ],
                 "is_flag": true,
-                "kind": "TyperOption",
+                "kind": "option",
                 "name": "with_subagents",
                 "required": false,
                 "type": "boolean"
@@ -1159,7 +1159,7 @@
                 "flags": [
                   "--project"
                 ],
-                "kind": "TyperOption",
+                "kind": "option",
                 "name": "project",
                 "required": false,
                 "type": "text"
@@ -1170,7 +1170,7 @@
                   "--remove"
                 ],
                 "is_flag": true,
-                "kind": "TyperOption",
+                "kind": "option",
                 "name": "remove",
                 "required": false,
                 "type": "boolean"
@@ -1181,7 +1181,7 @@
                   "--with-hooks"
                 ],
                 "is_flag": true,
-                "kind": "TyperOption",
+                "kind": "option",
                 "name": "with_hooks",
                 "required": false,
                 "type": "boolean"
@@ -1198,7 +1198,7 @@
                   "--remove"
                 ],
                 "is_flag": true,
-                "kind": "TyperOption",
+                "kind": "option",
                 "name": "remove",
                 "required": false,
                 "type": "boolean"
@@ -1213,7 +1213,7 @@
                 "flags": [
                   "--project"
                 ],
-                "kind": "TyperOption",
+                "kind": "option",
                 "name": "project",
                 "required": false,
                 "type": "text"
@@ -1224,7 +1224,7 @@
                   "--remove"
                 ],
                 "is_flag": true,
-                "kind": "TyperOption",
+                "kind": "option",
                 "name": "remove",
                 "required": false,
                 "type": "boolean"
@@ -1244,7 +1244,7 @@
             "flags": [
               "--project"
             ],
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "project",
             "required": false,
             "type": "text"
@@ -1261,7 +1261,7 @@
               "--message",
               "-m"
             ],
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "message",
             "required": false,
             "type": "text"
@@ -1270,7 +1270,7 @@
             "flags": [
               "--project"
             ],
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "project",
             "required": false,
             "type": "text"
@@ -1281,7 +1281,7 @@
               "--status"
             ],
             "is_flag": true,
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "status",
             "required": false,
             "type": "boolean"
@@ -1320,7 +1320,7 @@
         "name": "update-state",
         "params": [
           {
-            "kind": "TyperArgument",
+            "kind": "argument",
             "name": "delta",
             "required": true,
             "type": "text"
@@ -1332,7 +1332,7 @@
               "--no-json"
             ],
             "is_flag": true,
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "json_output",
             "required": false,
             "type": "boolean"
@@ -1341,7 +1341,7 @@
             "flags": [
               "--project"
             ],
-            "kind": "TyperOption",
+            "kind": "option",
             "name": "project",
             "required": false,
             "type": "text"
@@ -1358,7 +1358,7 @@
                 "flags": [
                   "--project"
                 ],
-                "kind": "TyperOption",
+                "kind": "option",
                 "name": "project",
                 "required": false,
                 "type": "text"
@@ -1380,7 +1380,7 @@
           "-V"
         ],
         "is_flag": true,
-        "kind": "TyperOption",
+        "kind": "option",
         "name": "version",
         "required": false,
         "type": "boolean"

--- a/packages/nauro/tests/snapshots/public_contract_v1.json
+++ b/packages/nauro/tests/snapshots/public_contract_v1.json
@@ -1,0 +1,1800 @@
+{
+  "cli_autogen_commands": [
+    "check_decision",
+    "diff_since_last_session",
+    "flag_question",
+    "get_context",
+    "get_decision",
+    "get_raw_file",
+    "list_decisions",
+    "propose_decision",
+    "search_decisions",
+    "update_state"
+  ],
+  "cli_command_tree": {
+    "commands": [
+      {
+        "kind": "command",
+        "name": "adopt",
+        "params": [
+          {
+            "default": false,
+            "flags": [
+              "--force-overwrite"
+            ],
+            "is_flag": true,
+            "kind": "TyperOption",
+            "name": "force_overwrite",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "flags": [
+              "--name"
+            ],
+            "kind": "TyperOption",
+            "name": "name",
+            "required": false,
+            "type": "text"
+          },
+          {
+            "default": false,
+            "flags": [
+              "--no-setup-and-skills"
+            ],
+            "is_flag": true,
+            "kind": "TyperOption",
+            "name": "no_setup_and_skills",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "default": false,
+            "flags": [
+              "--print-prompt"
+            ],
+            "is_flag": true,
+            "kind": "TyperOption",
+            "name": "print_prompt",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "flags": [
+              "--repo"
+            ],
+            "kind": "TyperOption",
+            "name": "repo",
+            "required": false,
+            "type": "path"
+          },
+          {
+            "default": false,
+            "flags": [
+              "--with-skills"
+            ],
+            "is_flag": true,
+            "kind": "TyperOption",
+            "name": "with_skills",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "default": false,
+            "flags": [
+              "--with-subagents"
+            ],
+            "is_flag": true,
+            "kind": "TyperOption",
+            "name": "with_subagents",
+            "required": false,
+            "type": "boolean"
+          }
+        ]
+      },
+      {
+        "kind": "command",
+        "name": "attach",
+        "params": [
+          {
+            "kind": "TyperArgument",
+            "name": "project_id",
+            "required": true,
+            "type": "text"
+          },
+          {
+            "flags": [
+              "--repo"
+            ],
+            "kind": "TyperOption",
+            "name": "repo_path",
+            "required": false,
+            "type": "path"
+          }
+        ]
+      },
+      {
+        "commands": [
+          {
+            "kind": "command",
+            "name": "login",
+            "params": []
+          },
+          {
+            "kind": "command",
+            "name": "logout",
+            "params": []
+          },
+          {
+            "kind": "command",
+            "name": "status",
+            "params": []
+          }
+        ],
+        "kind": "group",
+        "name": "auth",
+        "params": []
+      },
+      {
+        "kind": "command",
+        "name": "check-decision",
+        "params": [
+          {
+            "flags": [
+              "--context"
+            ],
+            "kind": "TyperOption",
+            "name": "context",
+            "required": false,
+            "type": "text"
+          },
+          {
+            "default": true,
+            "flags": [
+              "--json",
+              "--no-json"
+            ],
+            "is_flag": true,
+            "kind": "TyperOption",
+            "name": "json_output",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "flags": [
+              "--project"
+            ],
+            "kind": "TyperOption",
+            "name": "project",
+            "required": false,
+            "type": "text"
+          },
+          {
+            "kind": "TyperArgument",
+            "name": "proposed_approach",
+            "required": true,
+            "type": "text"
+          }
+        ]
+      },
+      {
+        "commands": [
+          {
+            "kind": "command",
+            "name": "get",
+            "params": [
+              {
+                "kind": "TyperArgument",
+                "name": "key",
+                "required": true,
+                "type": "text"
+              }
+            ]
+          },
+          {
+            "kind": "command",
+            "name": "list",
+            "params": []
+          },
+          {
+            "kind": "command",
+            "name": "unset",
+            "params": [
+              {
+                "kind": "TyperArgument",
+                "name": "key",
+                "required": true,
+                "type": "text"
+              }
+            ]
+          }
+        ],
+        "kind": "group",
+        "name": "config",
+        "params": []
+      },
+      {
+        "kind": "command",
+        "name": "diff-since-last-session",
+        "params": [
+          {
+            "flags": [
+              "--days"
+            ],
+            "kind": "TyperOption",
+            "name": "days",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "default": true,
+            "flags": [
+              "--json",
+              "--no-json"
+            ],
+            "is_flag": true,
+            "kind": "TyperOption",
+            "name": "json_output",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "flags": [
+              "--project"
+            ],
+            "kind": "TyperOption",
+            "name": "project",
+            "required": false,
+            "type": "text"
+          }
+        ]
+      },
+      {
+        "kind": "command",
+        "name": "flag-question",
+        "params": [
+          {
+            "flags": [
+              "--context"
+            ],
+            "kind": "TyperOption",
+            "name": "context",
+            "required": false,
+            "type": "text"
+          },
+          {
+            "default": true,
+            "flags": [
+              "--json",
+              "--no-json"
+            ],
+            "is_flag": true,
+            "kind": "TyperOption",
+            "name": "json_output",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "flags": [
+              "--project"
+            ],
+            "kind": "TyperOption",
+            "name": "project",
+            "required": false,
+            "type": "text"
+          },
+          {
+            "flags": [
+              "--question"
+            ],
+            "kind": "TyperOption",
+            "name": "question",
+            "required": false,
+            "type": "text"
+          },
+          {
+            "flags": [
+              "--resolved-by"
+            ],
+            "kind": "TyperOption",
+            "name": "resolved_by",
+            "required": false,
+            "type": "text"
+          },
+          {
+            "flags": [
+              "--targets"
+            ],
+            "kind": "TyperOption",
+            "multiple": true,
+            "name": "targets",
+            "required": false,
+            "type": "text"
+          }
+        ]
+      },
+      {
+        "kind": "command",
+        "name": "get-context",
+        "params": [
+          {
+            "default": true,
+            "flags": [
+              "--json",
+              "--no-json"
+            ],
+            "is_flag": true,
+            "kind": "TyperOption",
+            "name": "json_output",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "choices": [
+              "L0",
+              "L1",
+              "L2"
+            ],
+            "default": "L0",
+            "flags": [
+              "--level"
+            ],
+            "kind": "TyperOption",
+            "name": "level",
+            "required": false,
+            "type": "choice"
+          },
+          {
+            "flags": [
+              "--project"
+            ],
+            "kind": "TyperOption",
+            "name": "project",
+            "required": false,
+            "type": "text"
+          }
+        ]
+      },
+      {
+        "kind": "command",
+        "name": "get-decision",
+        "params": [
+          {
+            "default": true,
+            "flags": [
+              "--json",
+              "--no-json"
+            ],
+            "is_flag": true,
+            "kind": "TyperOption",
+            "name": "json_output",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "choices": [
+              "full",
+              "header"
+            ],
+            "default": "full",
+            "flags": [
+              "--mode"
+            ],
+            "kind": "TyperOption",
+            "name": "mode",
+            "required": false,
+            "type": "choice"
+          },
+          {
+            "kind": "TyperArgument",
+            "name": "number",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "flags": [
+              "--project"
+            ],
+            "kind": "TyperOption",
+            "name": "project",
+            "required": false,
+            "type": "text"
+          }
+        ]
+      },
+      {
+        "kind": "command",
+        "name": "get-raw-file",
+        "params": [
+          {
+            "default": true,
+            "flags": [
+              "--json",
+              "--no-json"
+            ],
+            "is_flag": true,
+            "kind": "TyperOption",
+            "name": "json_output",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "kind": "TyperArgument",
+            "name": "path",
+            "required": true,
+            "type": "text"
+          },
+          {
+            "flags": [
+              "--project"
+            ],
+            "kind": "TyperOption",
+            "name": "project",
+            "required": false,
+            "type": "text"
+          }
+        ]
+      },
+      {
+        "kind": "command",
+        "name": "graph",
+        "params": [
+          {
+            "default": false,
+            "flags": [
+              "--include-bodies",
+              "--no-include-bodies"
+            ],
+            "is_flag": true,
+            "kind": "TyperOption",
+            "name": "include_bodies",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "default": true,
+            "flags": [
+              "--no-open",
+              "--open"
+            ],
+            "is_flag": true,
+            "kind": "TyperOption",
+            "name": "open_browser",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "flags": [
+              "--output"
+            ],
+            "kind": "TyperOption",
+            "name": "output",
+            "required": false,
+            "type": "path"
+          },
+          {
+            "flags": [
+              "--project"
+            ],
+            "kind": "TyperOption",
+            "name": "project",
+            "required": false,
+            "type": "text"
+          }
+        ]
+      },
+      {
+        "commands": [
+          {
+            "kind": "command",
+            "name": "user-prompt-submit",
+            "params": []
+          }
+        ],
+        "kind": "group",
+        "name": "hook",
+        "params": []
+      },
+      {
+        "kind": "command",
+        "name": "import",
+        "params": [
+          {
+            "flags": [
+              "--adr"
+            ],
+            "kind": "TyperOption",
+            "name": "adr",
+            "required": false,
+            "type": "path"
+          },
+          {
+            "flags": [
+              "--memory-bank"
+            ],
+            "kind": "TyperOption",
+            "name": "memory_bank",
+            "required": false,
+            "type": "path"
+          },
+          {
+            "flags": [
+              "--project"
+            ],
+            "kind": "TyperOption",
+            "name": "project",
+            "required": false,
+            "type": "text"
+          }
+        ]
+      },
+      {
+        "kind": "command",
+        "name": "init",
+        "params": [
+          {
+            "flags": [
+              "--add-repo"
+            ],
+            "kind": "TyperOption",
+            "multiple": true,
+            "name": "add_repo_paths",
+            "required": false,
+            "type": "path"
+          },
+          {
+            "default": false,
+            "flags": [
+              "--cloud"
+            ],
+            "is_flag": true,
+            "kind": "TyperOption",
+            "name": "cloud",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "default": false,
+            "flags": [
+              "--demo"
+            ],
+            "is_flag": true,
+            "kind": "TyperOption",
+            "name": "demo",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "default": false,
+            "flags": [
+              "--force"
+            ],
+            "is_flag": true,
+            "kind": "TyperOption",
+            "name": "force",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "kind": "TyperArgument",
+            "name": "name",
+            "required": false,
+            "type": "text"
+          }
+        ]
+      },
+      {
+        "kind": "command",
+        "name": "link",
+        "params": [
+          {
+            "default": false,
+            "flags": [
+              "--cloud"
+            ],
+            "is_flag": true,
+            "kind": "TyperOption",
+            "name": "cloud",
+            "required": false,
+            "type": "boolean"
+          }
+        ]
+      },
+      {
+        "kind": "command",
+        "name": "list-decisions",
+        "params": [
+          {
+            "default": false,
+            "flags": [
+              "--include-superseded",
+              "--no-include-superseded"
+            ],
+            "is_flag": true,
+            "kind": "TyperOption",
+            "name": "include_superseded",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "default": true,
+            "flags": [
+              "--json",
+              "--no-json"
+            ],
+            "is_flag": true,
+            "kind": "TyperOption",
+            "name": "json_output",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "default": 20,
+            "flags": [
+              "--limit"
+            ],
+            "kind": "TyperOption",
+            "name": "limit",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "flags": [
+              "--project"
+            ],
+            "kind": "TyperOption",
+            "name": "project",
+            "required": false,
+            "type": "text"
+          }
+        ]
+      },
+      {
+        "kind": "command",
+        "name": "log",
+        "params": [
+          {
+            "default": false,
+            "flags": [
+              "--all"
+            ],
+            "is_flag": true,
+            "kind": "TyperOption",
+            "name": "all_decisions",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "default": false,
+            "flags": [
+              "--decisions"
+            ],
+            "is_flag": true,
+            "kind": "TyperOption",
+            "name": "decisions",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "default": false,
+            "flags": [
+              "--full"
+            ],
+            "is_flag": true,
+            "kind": "TyperOption",
+            "name": "full",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "default": 10,
+            "flags": [
+              "--limit",
+              "-n"
+            ],
+            "kind": "TyperOption",
+            "name": "limit",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "flags": [
+              "--project"
+            ],
+            "kind": "TyperOption",
+            "name": "project",
+            "required": false,
+            "type": "text"
+          }
+        ]
+      },
+      {
+        "kind": "command",
+        "name": "note",
+        "params": [
+          {
+            "default": "medium",
+            "flags": [
+              "--confidence",
+              "-c"
+            ],
+            "kind": "TyperOption",
+            "name": "confidence",
+            "required": false,
+            "type": "text"
+          },
+          {
+            "default": false,
+            "flags": [
+              "--decision",
+              "-d"
+            ],
+            "is_flag": true,
+            "kind": "TyperOption",
+            "name": "decision",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "flags": [
+              "--project"
+            ],
+            "kind": "TyperOption",
+            "name": "project",
+            "required": false,
+            "type": "text"
+          },
+          {
+            "default": false,
+            "flags": [
+              "--question",
+              "-q"
+            ],
+            "is_flag": true,
+            "kind": "TyperOption",
+            "name": "question",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "flags": [
+              "--rationale",
+              "-r"
+            ],
+            "kind": "TyperOption",
+            "name": "rationale",
+            "required": false,
+            "type": "text"
+          },
+          {
+            "kind": "TyperArgument",
+            "name": "text",
+            "required": true,
+            "type": "text"
+          }
+        ]
+      },
+      {
+        "commands": [
+          {
+            "kind": "command",
+            "name": "list",
+            "params": []
+          },
+          {
+            "kind": "command",
+            "name": "rm",
+            "params": [
+              {
+                "kind": "TyperArgument",
+                "name": "project_id",
+                "required": true,
+                "type": "text"
+              },
+              {
+                "default": false,
+                "flags": [
+                  "--yes"
+                ],
+                "is_flag": true,
+                "kind": "TyperOption",
+                "name": "yes",
+                "required": false,
+                "type": "boolean"
+              }
+            ]
+          }
+        ],
+        "kind": "group",
+        "name": "projects",
+        "params": []
+      },
+      {
+        "kind": "command",
+        "name": "propose-decision",
+        "params": [
+          {
+            "flags": [
+              "--affected-decision-id"
+            ],
+            "kind": "TyperOption",
+            "name": "affected_decision_id",
+            "required": false,
+            "type": "text"
+          },
+          {
+            "choices": [
+              "high",
+              "low",
+              "medium"
+            ],
+            "flags": [
+              "--confidence"
+            ],
+            "kind": "TyperOption",
+            "name": "confidence",
+            "required": false,
+            "type": "choice"
+          },
+          {
+            "choices": [
+              "api_design",
+              "architecture",
+              "data_model",
+              "infrastructure",
+              "pattern",
+              "refactor"
+            ],
+            "flags": [
+              "--decision-type"
+            ],
+            "kind": "TyperOption",
+            "name": "decision_type",
+            "required": false,
+            "type": "choice"
+          },
+          {
+            "flags": [
+              "--files-affected"
+            ],
+            "kind": "TyperOption",
+            "multiple": true,
+            "name": "files_affected",
+            "required": false,
+            "type": "text"
+          },
+          {
+            "default": true,
+            "flags": [
+              "--json",
+              "--no-json"
+            ],
+            "is_flag": true,
+            "kind": "TyperOption",
+            "name": "json_output",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "choices": [
+              "add",
+              "supersede",
+              "update"
+            ],
+            "default": "add",
+            "flags": [
+              "--operation"
+            ],
+            "kind": "TyperOption",
+            "name": "operation",
+            "required": false,
+            "type": "choice"
+          },
+          {
+            "flags": [
+              "--project"
+            ],
+            "kind": "TyperOption",
+            "name": "project",
+            "required": false,
+            "type": "text"
+          },
+          {
+            "kind": "TyperArgument",
+            "name": "rationale",
+            "required": true,
+            "type": "text"
+          },
+          {
+            "flags": [
+              "--rejected"
+            ],
+            "kind": "TyperOption",
+            "name": "rejected",
+            "required": false,
+            "type": "text"
+          },
+          {
+            "flags": [
+              "--resolves-questions"
+            ],
+            "kind": "TyperOption",
+            "multiple": true,
+            "name": "resolves_questions",
+            "required": false,
+            "type": "text"
+          },
+          {
+            "choices": [
+              "easy",
+              "hard",
+              "moderate"
+            ],
+            "flags": [
+              "--reversibility"
+            ],
+            "kind": "TyperOption",
+            "name": "reversibility",
+            "required": false,
+            "type": "choice"
+          },
+          {
+            "default": "",
+            "flags": [
+              "--title"
+            ],
+            "kind": "TyperOption",
+            "name": "title",
+            "required": false,
+            "type": "text"
+          }
+        ]
+      },
+      {
+        "commands": [
+          {
+            "kind": "command",
+            "name": "migrate",
+            "params": [
+              {
+                "default": false,
+                "flags": [
+                  "--dry-run"
+                ],
+                "is_flag": true,
+                "kind": "TyperOption",
+                "name": "dry_run",
+                "required": false,
+                "type": "boolean"
+              },
+              {
+                "flags": [
+                  "--project"
+                ],
+                "kind": "TyperOption",
+                "name": "project",
+                "required": false,
+                "type": "text"
+              }
+            ]
+          }
+        ],
+        "kind": "group",
+        "name": "questions",
+        "params": []
+      },
+      {
+        "hidden": true,
+        "kind": "command",
+        "name": "render-plugin",
+        "params": [
+          {
+            "default": false,
+            "flags": [
+              "--check"
+            ],
+            "is_flag": true,
+            "kind": "TyperOption",
+            "name": "check",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "kind": "TyperArgument",
+            "name": "dir",
+            "required": true,
+            "type": "path"
+          }
+        ]
+      },
+      {
+        "kind": "command",
+        "name": "search-decisions",
+        "params": [
+          {
+            "default": false,
+            "flags": [
+              "--include-superseded",
+              "--no-include-superseded"
+            ],
+            "is_flag": true,
+            "kind": "TyperOption",
+            "name": "include_superseded",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "default": true,
+            "flags": [
+              "--json",
+              "--no-json"
+            ],
+            "is_flag": true,
+            "kind": "TyperOption",
+            "name": "json_output",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "default": 10,
+            "flags": [
+              "--limit"
+            ],
+            "kind": "TyperOption",
+            "name": "limit",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "flags": [
+              "--project"
+            ],
+            "kind": "TyperOption",
+            "name": "project",
+            "required": false,
+            "type": "text"
+          },
+          {
+            "kind": "TyperArgument",
+            "name": "query",
+            "required": true,
+            "type": "text"
+          }
+        ]
+      },
+      {
+        "kind": "command",
+        "name": "serve",
+        "params": [
+          {
+            "default": true,
+            "flags": [
+              "--stdio"
+            ],
+            "is_flag": true,
+            "kind": "TyperOption",
+            "name": "stdio",
+            "required": false,
+            "type": "boolean"
+          }
+        ]
+      },
+      {
+        "commands": [
+          {
+            "kind": "command",
+            "name": "all",
+            "params": [
+              {
+                "default": false,
+                "flags": [
+                  "--force-overwrite"
+                ],
+                "is_flag": true,
+                "kind": "TyperOption",
+                "name": "force_overwrite",
+                "required": false,
+                "type": "boolean"
+              },
+              {
+                "flags": [
+                  "--project"
+                ],
+                "kind": "TyperOption",
+                "name": "project",
+                "required": false,
+                "type": "text"
+              },
+              {
+                "default": false,
+                "flags": [
+                  "--remove"
+                ],
+                "is_flag": true,
+                "kind": "TyperOption",
+                "name": "remove",
+                "required": false,
+                "type": "boolean"
+              },
+              {
+                "default": false,
+                "flags": [
+                  "--with-hooks"
+                ],
+                "is_flag": true,
+                "kind": "TyperOption",
+                "name": "with_hooks",
+                "required": false,
+                "type": "boolean"
+              },
+              {
+                "default": false,
+                "flags": [
+                  "--with-skills"
+                ],
+                "is_flag": true,
+                "kind": "TyperOption",
+                "name": "with_skills",
+                "required": false,
+                "type": "boolean"
+              },
+              {
+                "default": false,
+                "flags": [
+                  "--with-subagents"
+                ],
+                "is_flag": true,
+                "kind": "TyperOption",
+                "name": "with_subagents",
+                "required": false,
+                "type": "boolean"
+              }
+            ]
+          },
+          {
+            "kind": "command",
+            "name": "claude-code",
+            "params": [
+              {
+                "flags": [
+                  "--project"
+                ],
+                "kind": "TyperOption",
+                "name": "project",
+                "required": false,
+                "type": "text"
+              },
+              {
+                "default": false,
+                "flags": [
+                  "--remove"
+                ],
+                "is_flag": true,
+                "kind": "TyperOption",
+                "name": "remove",
+                "required": false,
+                "type": "boolean"
+              },
+              {
+                "default": false,
+                "flags": [
+                  "--with-hooks"
+                ],
+                "is_flag": true,
+                "kind": "TyperOption",
+                "name": "with_hooks",
+                "required": false,
+                "type": "boolean"
+              }
+            ]
+          },
+          {
+            "kind": "command",
+            "name": "codex",
+            "params": [
+              {
+                "default": false,
+                "flags": [
+                  "--remove"
+                ],
+                "is_flag": true,
+                "kind": "TyperOption",
+                "name": "remove",
+                "required": false,
+                "type": "boolean"
+              }
+            ]
+          },
+          {
+            "kind": "command",
+            "name": "cursor",
+            "params": [
+              {
+                "flags": [
+                  "--project"
+                ],
+                "kind": "TyperOption",
+                "name": "project",
+                "required": false,
+                "type": "text"
+              },
+              {
+                "default": false,
+                "flags": [
+                  "--remove"
+                ],
+                "is_flag": true,
+                "kind": "TyperOption",
+                "name": "remove",
+                "required": false,
+                "type": "boolean"
+              }
+            ]
+          }
+        ],
+        "kind": "group",
+        "name": "setup",
+        "params": []
+      },
+      {
+        "kind": "command",
+        "name": "status",
+        "params": [
+          {
+            "flags": [
+              "--project"
+            ],
+            "kind": "TyperOption",
+            "name": "project",
+            "required": false,
+            "type": "text"
+          }
+        ]
+      },
+      {
+        "kind": "command",
+        "name": "sync",
+        "params": [
+          {
+            "default": "",
+            "flags": [
+              "--message",
+              "-m"
+            ],
+            "kind": "TyperOption",
+            "name": "message",
+            "required": false,
+            "type": "text"
+          },
+          {
+            "flags": [
+              "--project"
+            ],
+            "kind": "TyperOption",
+            "name": "project",
+            "required": false,
+            "type": "text"
+          },
+          {
+            "default": false,
+            "flags": [
+              "--status"
+            ],
+            "is_flag": true,
+            "kind": "TyperOption",
+            "name": "status",
+            "required": false,
+            "type": "boolean"
+          }
+        ]
+      },
+      {
+        "commands": [
+          {
+            "kind": "command",
+            "name": "disable",
+            "params": []
+          },
+          {
+            "kind": "command",
+            "name": "enable",
+            "params": []
+          },
+          {
+            "kind": "command",
+            "name": "reset",
+            "params": []
+          },
+          {
+            "kind": "command",
+            "name": "status",
+            "params": []
+          }
+        ],
+        "kind": "group",
+        "name": "telemetry",
+        "params": []
+      },
+      {
+        "kind": "command",
+        "name": "update-state",
+        "params": [
+          {
+            "kind": "TyperArgument",
+            "name": "delta",
+            "required": true,
+            "type": "text"
+          },
+          {
+            "default": true,
+            "flags": [
+              "--json",
+              "--no-json"
+            ],
+            "is_flag": true,
+            "kind": "TyperOption",
+            "name": "json_output",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "flags": [
+              "--project"
+            ],
+            "kind": "TyperOption",
+            "name": "project",
+            "required": false,
+            "type": "text"
+          }
+        ]
+      },
+      {
+        "commands": [
+          {
+            "kind": "command",
+            "name": "status",
+            "params": [
+              {
+                "flags": [
+                  "--project"
+                ],
+                "kind": "TyperOption",
+                "name": "project",
+                "required": false,
+                "type": "text"
+              }
+            ]
+          }
+        ],
+        "kind": "group",
+        "name": "validate",
+        "params": []
+      }
+    ],
+    "kind": "group",
+    "name": "nauro",
+    "params": [
+      {
+        "flags": [
+          "--version",
+          "-V"
+        ],
+        "is_flag": true,
+        "kind": "TyperOption",
+        "name": "version",
+        "required": false,
+        "type": "boolean"
+      }
+    ]
+  },
+  "contract_version": 1,
+  "nauro_core_public_api": [
+    "ALL_TOOLS",
+    "CHECK_DECISION_RETURNS",
+    "DECISIONS_DIR",
+    "DECISION_HASHES_FILE",
+    "DECISION_TYPES",
+    "GET_DECISION_BEFORE_PROPOSING",
+    "MAX_APPROACH_LENGTH",
+    "MAX_BRIEF_BYTES",
+    "MAX_CONTEXT_LENGTH",
+    "MAX_DELTA_LENGTH",
+    "MAX_QUESTION_LENGTH",
+    "MAX_RATIONALE_LENGTH",
+    "MAX_TITLE_LENGTH",
+    "MCP_INSTRUCTIONS_STATIC",
+    "MIN_RATIONALE_LENGTH",
+    "NO_INVENT_RATIONALE",
+    "OPEN_QUESTIONS_MD",
+    "PROJECT_MD",
+    "SNAPSHOTS_DIR",
+    "SNAPSHOT_SCHEMA_VERSION",
+    "STACK_MD",
+    "STATE_CURRENT_FILENAME",
+    "STATE_HISTORY_FILENAME",
+    "STATE_MD",
+    "__version__",
+    "build_graph_payload",
+    "build_l0",
+    "build_l1",
+    "build_l2",
+    "build_remote_instructions",
+    "compute_hash",
+    "decisions_summary_lines",
+    "extract_decision_number",
+    "extract_stack_summary",
+    "format_decision",
+    "parse_decision",
+    "sanitize_sub",
+    "serialize_snapshot"
+  ],
+  "public_constant_values": {
+    "DECISIONS_DIR": "decisions",
+    "DECISION_HASHES_FILE": ".decision-hashes.json",
+    "DECISION_TYPES": [
+      "api_design",
+      "architecture",
+      "data_model",
+      "infrastructure",
+      "pattern",
+      "refactor"
+    ],
+    "MAX_APPROACH_LENGTH": 5000,
+    "MAX_BRIEF_BYTES": 51200,
+    "MAX_CONTEXT_LENGTH": 5000,
+    "MAX_DELTA_LENGTH": 5000,
+    "MAX_QUESTION_LENGTH": 2000,
+    "MAX_RATIONALE_LENGTH": 10000,
+    "MAX_TITLE_LENGTH": 300,
+    "MIN_RATIONALE_LENGTH": 20,
+    "OPEN_QUESTIONS_MD": "open-questions.md",
+    "PROJECT_MD": "project.md",
+    "SNAPSHOTS_DIR": "snapshots",
+    "SNAPSHOT_SCHEMA_VERSION": 1,
+    "STACK_MD": "stack.md",
+    "STATE_CURRENT_FILENAME": "state_current.md",
+    "STATE_HISTORY_FILENAME": "state_history.md",
+    "STATE_MD": "state.md"
+  },
+  "stdio_tool_specs": [
+    {
+      "annotations": {
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": true
+      },
+      "input_schema": {
+        "properties": {
+          "context": {
+            "type": "string"
+          },
+          "project_id": {
+            "type": "string"
+          },
+          "proposed_approach": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "proposed_approach"
+        ],
+        "type": "object"
+      },
+      "name": "check_decision"
+    },
+    {
+      "annotations": {
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": true
+      },
+      "input_schema": {
+        "properties": {
+          "days": {
+            "type": "integer"
+          },
+          "project_id": {
+            "type": "string"
+          }
+        },
+        "required": [],
+        "type": "object"
+      },
+      "name": "diff_since_last_session"
+    },
+    {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
+      "input_schema": {
+        "properties": {
+          "context": {
+            "type": "string"
+          },
+          "project_id": {
+            "type": "string"
+          },
+          "question": {
+            "type": "string"
+          },
+          "resolved_by": {
+            "type": "string"
+          },
+          "targets": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [],
+        "type": "object"
+      },
+      "name": "flag_question"
+    },
+    {
+      "annotations": {
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": true
+      },
+      "input_schema": {
+        "properties": {
+          "level": {
+            "default": "L0",
+            "enum": [
+              "L0",
+              "L1",
+              "L2"
+            ],
+            "type": "string"
+          },
+          "project_id": {
+            "type": "string"
+          }
+        },
+        "required": [],
+        "type": "object"
+      },
+      "name": "get_context"
+    },
+    {
+      "annotations": {
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": true
+      },
+      "input_schema": {
+        "properties": {
+          "mode": {
+            "default": "full",
+            "enum": [
+              "full",
+              "header"
+            ],
+            "type": "string"
+          },
+          "number": {
+            "type": "integer"
+          },
+          "project_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "number"
+        ],
+        "type": "object"
+      },
+      "name": "get_decision"
+    },
+    {
+      "annotations": {
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": true
+      },
+      "input_schema": {
+        "properties": {
+          "path": {
+            "type": "string"
+          },
+          "project_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "type": "object"
+      },
+      "name": "get_raw_file"
+    },
+    {
+      "annotations": {
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": true
+      },
+      "input_schema": {
+        "properties": {
+          "include_superseded": {
+            "default": false,
+            "type": "boolean"
+          },
+          "limit": {
+            "default": 20,
+            "type": "integer"
+          },
+          "project_id": {
+            "type": "string"
+          }
+        },
+        "required": [],
+        "type": "object"
+      },
+      "name": "list_decisions"
+    },
+    {
+      "annotations": {
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": true
+      },
+      "input_schema": {
+        "properties": {},
+        "required": [],
+        "type": "object"
+      },
+      "name": "list_projects"
+    },
+    {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
+      "input_schema": {
+        "properties": {
+          "affected_decision_id": {
+            "type": "string"
+          },
+          "confidence": {
+            "enum": [
+              "high",
+              "low",
+              "medium"
+            ],
+            "type": "string"
+          },
+          "decision_type": {
+            "enum": [
+              "api_design",
+              "architecture",
+              "data_model",
+              "infrastructure",
+              "pattern",
+              "refactor"
+            ],
+            "type": "string"
+          },
+          "files_affected": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "operation": {
+            "default": "add",
+            "enum": [
+              "add",
+              "supersede",
+              "update"
+            ],
+            "type": "string"
+          },
+          "project_id": {
+            "type": "string"
+          },
+          "rationale": {
+            "type": "string"
+          },
+          "rejected": {
+            "items": {
+              "properties": {
+                "alternative": {
+                  "type": "string"
+                },
+                "reason": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "resolves_questions": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "reversibility": {
+            "enum": [
+              "easy",
+              "hard",
+              "moderate"
+            ],
+            "type": "string"
+          },
+          "title": {
+            "default": "",
+            "type": "string"
+          }
+        },
+        "required": [
+          "rationale"
+        ],
+        "type": "object"
+      },
+      "name": "propose_decision"
+    },
+    {
+      "annotations": {
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": true
+      },
+      "input_schema": {
+        "properties": {
+          "include_superseded": {
+            "default": false,
+            "type": "boolean"
+          },
+          "limit": {
+            "default": 10,
+            "type": "integer"
+          },
+          "project_id": {
+            "type": "string"
+          },
+          "query": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "type": "object"
+      },
+      "name": "search_decisions"
+    },
+    {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
+      "input_schema": {
+        "properties": {
+          "delta": {
+            "type": "string"
+          },
+          "project_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "delta"
+        ],
+        "type": "object"
+      },
+      "name": "update_state"
+    }
+  ]
+}

--- a/packages/nauro/tests/test_public_contract.py
+++ b/packages/nauro/tests/test_public_contract.py
@@ -199,7 +199,24 @@ def _build_cli_tree() -> dict[str, Any]:
     from nauro.cli.main import app
 
     command = typer.main.get_command(app)
-    return _walk_cli(command, "nauro", click.Context(command, info_name="nauro"))
+    ctx = click.Context(command, info_name="nauro")
+    tree = _walk_cli(command, "nauro", ctx)
+    if not tree.get("commands"):
+        # An empty top-level CLI tree is always a defect (the app registers
+        # ~30 commands at import). Fail loudly with the state that explains why,
+        # rather than silently freezing an empty surface.
+        lc = command.list_commands(ctx) if hasattr(command, "list_commands") else None
+        raise RuntimeError(
+            "CLI command tree resolved empty.\n"
+            f"  type={type(command).__name__} is_group={isinstance(command, click.Group)}\n"
+            f"  mro={[c.__name__ for c in type(command).__mro__]}\n"
+            f"  registered_commands={len(app.registered_commands)} "
+            f"registered_groups={len(app.registered_groups)}\n"
+            f"  list_commands={lc!r}\n"
+            f"  commands_attr={list(getattr(command, 'commands', {}) or {})!r}\n"
+            f"  click={click.__version__} typer={typer.__version__} py={sys.version.split()[0]}"
+        )
+    return tree
 
 
 # Capture the CLI tree from a FRESH interpreter, not in-process. The tree is

--- a/packages/nauro/tests/test_public_contract.py
+++ b/packages/nauro/tests/test_public_contract.py
@@ -151,20 +151,27 @@ def _tool_specs() -> list[dict[str, Any]]:
 
 
 def _param_node(param: click.Parameter) -> dict[str, Any]:
+    # Classify by Click's stable ``param_type_name`` ("option" / "argument")
+    # and read option-only attributes by capability, not isinstance. Across
+    # Typer/Click versions the concrete classes (TyperOption/TyperArgument) do
+    # not reliably subclass click.Option/click.Argument, so an isinstance gate
+    # silently drops fields like ``flags`` on newer versions.
+    kind = getattr(param, "param_type_name", type(param).__name__)
     node: dict[str, Any] = {
         "name": param.name,
-        "kind": type(param).__name__,
+        "kind": kind,
         "type": getattr(param.type, "name", type(param.type).__name__),
         "required": bool(param.required),
     }
-    if isinstance(param, click.Option):
+    if kind == "option":
         node["flags"] = sorted([*param.opts, *param.secondary_opts])
-        if param.is_flag:
+        if getattr(param, "is_flag", False):
             node["is_flag"] = True
-        if param.multiple:
+        if getattr(param, "multiple", False):
             node["multiple"] = True
-    if isinstance(param.type, click.Choice):
-        node["choices"] = sorted(param.type.choices)
+    choices = getattr(param.type, "choices", None)
+    if choices is not None:
+        node["choices"] = sorted(map(str, choices))
     # Record only JSON-literal defaults; None/callables/sentinels are omitted
     # (a stable omission rather than a volatile repr).
     if isinstance(param.default, (str, int, float, bool)):
@@ -172,16 +179,25 @@ def _param_node(param: click.Parameter) -> dict[str, Any]:
     return node
 
 
+def _is_group(command: click.Command) -> bool:
+    # Detect group-ness by capability, not isinstance. Across Typer/Click
+    # versions TyperGroup's bases vary — in Typer >=0.26 / Click >=8.2 it
+    # subclasses click.Command, not click.Group — but a group always exposes
+    # list_commands/get_command. An isinstance(click.Group) gate silently
+    # drops every subcommand on those versions.
+    return hasattr(command, "list_commands") and hasattr(command, "get_command")
+
+
 def _walk_cli(command: click.Command, name: str, ctx: click.Context) -> dict[str, Any]:
     node: dict[str, Any] = {
         "name": name,
-        "kind": "group" if isinstance(command, click.Group) else "command",
+        "kind": "group" if _is_group(command) else "command",
     }
     if getattr(command, "hidden", False):
         node["hidden"] = True
     params = [_param_node(p) for p in command.params if p.name not in _FRAMEWORK_PARAMS]
     node["params"] = sorted(params, key=lambda p: p["name"])
-    if isinstance(command, click.Group):
+    if _is_group(command):
         children = []
         for sub_name in sorted(command.list_commands(ctx)):
             sub = command.get_command(ctx, sub_name)

--- a/packages/nauro/tests/test_public_contract.py
+++ b/packages/nauro/tests/test_public_contract.py
@@ -73,7 +73,6 @@ import typer
 from nauro_core.mcp_tools import ALL_TOOLS
 
 from nauro.cli.autogen import AUTOGEN_ALLOWLIST
-from nauro.cli.main import app
 
 CONTRACT_VERSION = 1
 SNAPSHOT_PATH = Path(__file__).parent / "snapshots" / f"public_contract_v{CONTRACT_VERSION}.json"
@@ -193,7 +192,19 @@ def _walk_cli(command: click.Command, name: str, ctx: click.Context) -> dict[str
 
 
 def _cli_tree() -> dict[str, Any]:
-    command = typer.main.get_command(app)
+    # Read the tree from a freshly-reloaded app, not the process-global
+    # singleton. Other tests in the suite import and exercise
+    # ``nauro.cli.main.app`` (CliRunner invocations, registration assertions);
+    # reloading re-runs ``_register_commands`` so this snapshot reflects the
+    # real registered surface regardless of suite ordering or any prior
+    # in-place mutation of the shared app. The real CLI always starts from a
+    # fresh process, so this matches production, not a test artifact.
+    import importlib
+
+    from nauro.cli import main as cli_main
+
+    cli_main = importlib.reload(cli_main)
+    command = typer.main.get_command(cli_main.app)
     return _walk_cli(command, "nauro", click.Context(command, info_name="nauro"))
 
 

--- a/packages/nauro/tests/test_public_contract.py
+++ b/packages/nauro/tests/test_public_contract.py
@@ -1,0 +1,248 @@
+"""Frozen-contract snapshot for the 1.0 public surface (D318).
+
+D318 took ``nauro`` and ``nauro-core`` to 1.0.0 and froze the *local product
+surface*: the stdio MCP tool contract (names + schemas), the CLI command tree
+(commands + flags), the on-disk store-format constants, and ``nauro-core``'s
+curated public import API. After 1.0, breaking any of these requires a major
+bump.
+
+This test is the *mechanical* enforcement of that doctrinal promise. It
+serializes the live contract and asserts it equals a checked-in snapshot. The
+crucial property is that the expectation is **checked in, not derived from live
+code** — unlike the sibling drift tests (``test_skill_tool_signatures`` derives
+``_TOOL_NAMES`` from the live registry; ``cli.autogen`` verifies its allowlist
+against live ``ALL_TOOLS``), which move *with* the code and so cannot, by
+construction, catch a contract change. A pinned snapshot is the one test that
+can disagree with the code, which is exactly what a freeze needs.
+
+The test never decides major-vs-minor. It makes a contract change **loud**: an
+intentional change is a deliberate snapshot regen, and the resulting diff (e.g.
+``+ "required": ["proposed_approach", "scope"]``) is the trigger to ask "is this
+a 2.0?" — a question for review (the @nauro-reviewer pass) against D318, not for
+this assertion.
+
+What is frozen here:
+  - ``stdio_tool_specs``     — every ``ALL_TOOLS`` spec: name, annotations, and
+                               the *structural* input schema (param names, types,
+                               required, enums, defaults).
+  - ``cli_command_tree``     — the Typer/Click command + subcommand tree with
+                               each option's flags, type, required, choices.
+  - ``cli_autogen_commands`` — the explicit set of tools mirrored as CLI
+                               commands (``AUTOGEN_ALLOWLIST``).
+  - ``nauro_core_public_api``— ``nauro_core.__all__``, the curated import surface
+                               D318 promised (vs. the ~107 incidental exports).
+  - ``public_constant_values``— the *values* of the store-format filenames,
+                               schema version, size limits, and decision types
+                               (renaming ``project.md`` breaks every store).
+
+Deliberately OUT of scope (documented, not silent — coverage is the value):
+  - Prose. Tool ``title``/``description`` and per-property descriptions are
+    stripped: they are documentation, not a breaking contract, and including
+    them trains regen-without-reading. Wording drift is owned by
+    ``test_protocol_drift``.
+  - Tool *output* models. ``check_decision``'s result schema is already pinned
+    by ``test_check_decision_schema``; generalizing output models to the other
+    tools is the natural next extension of that test, not this one.
+  - The on-disk store *body* format beyond the constants above (the strict v2
+    parser in ``nauro_core.decision_model`` owns it) and the stdio-vs-remote
+    registration split (``list_projects`` is remote-only by design).
+
+Regenerate after an intentional, reviewed contract change (note: ``.venv`` per
+the project's test-env convention — ``uv run`` clobbers the shared venv), from
+the ``nauro`` workspace root:
+
+    NAURO_UPDATE_CONTRACT=1 .venv/bin/python -m pytest \\
+        packages/nauro/tests/test_public_contract.py
+
+then review the diff to ``snapshots/public_contract_v1.json`` carefully — a
+``v2`` file is what a 2.0 looks like.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import click
+import nauro_core
+import pytest
+import typer
+from nauro_core.mcp_tools import ALL_TOOLS
+
+from nauro.cli.autogen import AUTOGEN_ALLOWLIST
+from nauro.cli.main import app
+
+CONTRACT_VERSION = 1
+SNAPSHOT_PATH = Path(__file__).parent / "snapshots" / f"public_contract_v{CONTRACT_VERSION}.json"
+_UPDATE_ENV = "NAURO_UPDATE_CONTRACT"
+
+# Schema annotation keys carrying prose, dropped so wording edits do not trip a
+# structural freeze. NOT to be confused with property *names* (see _strip_prose).
+_PROSE_KEYS = frozenset({"description", "title"})
+# Schema keywords that are semantically sets — sorted for run-to-run determinism
+# regardless of source ordering (reordering an enum is not a breaking change;
+# adding or removing a value is, and still trips).
+_SORTED_SCHEMA_KEYS = frozenset({"required", "enum"})
+
+# Framework-injected CLI params excluded so the snapshot tracks *our* surface,
+# not Typer/Click internals that shift on a dependency bump.
+_FRAMEWORK_PARAMS = frozenset({"help", "install_completion", "show_completion"})
+
+# nauro-core public names whose *value* (not just presence in __all__) is part
+# of the contract: store-format filenames, schema version, write-path limits,
+# and the decision-type vocabulary.
+_CONTRACT_CONSTANTS: tuple[str, ...] = (
+    "MAX_BRIEF_BYTES",
+    "MAX_RATIONALE_LENGTH",
+    "MAX_TITLE_LENGTH",
+    "MAX_CONTEXT_LENGTH",
+    "MAX_APPROACH_LENGTH",
+    "MAX_DELTA_LENGTH",
+    "MAX_QUESTION_LENGTH",
+    "MIN_RATIONALE_LENGTH",
+    "SNAPSHOT_SCHEMA_VERSION",
+    "DECISIONS_DIR",
+    "SNAPSHOTS_DIR",
+    "DECISION_HASHES_FILE",
+    "PROJECT_MD",
+    "STACK_MD",
+    "STATE_MD",
+    "OPEN_QUESTIONS_MD",
+    "STATE_CURRENT_FILENAME",
+    "STATE_HISTORY_FILENAME",
+    "DECISION_TYPES",
+)
+
+
+def _strip_prose(node: Any) -> Any:
+    """Return ``node`` with schema prose removed, structure preserved.
+
+    Drops ``description``/``title`` annotation keys at every schema level, but
+    recurses into ``properties`` *values* while keeping their keys — so a
+    property literally named ``description`` survives as a property; only a
+    schema-level ``description`` annotation is removed. ``required``/``enum``
+    lists are sorted for determinism. The input is never mutated.
+    """
+    if isinstance(node, dict):
+        out: dict[str, Any] = {}
+        for key, value in node.items():
+            if key in _PROSE_KEYS:
+                continue
+            if key == "properties" and isinstance(value, dict):
+                out[key] = {name: _strip_prose(sub) for name, sub in value.items()}
+            elif key in _SORTED_SCHEMA_KEYS and isinstance(value, list):
+                out[key] = sorted(value, key=repr)
+            else:
+                out[key] = _strip_prose(value)
+        return out
+    if isinstance(node, list):
+        return [_strip_prose(value) for value in node]
+    return node
+
+
+def _tool_specs() -> list[dict[str, Any]]:
+    """Structural snapshot of every tool spec, sorted by name."""
+    specs = [_strip_prose(dict(spec)) for spec in ALL_TOOLS]
+    return sorted(specs, key=lambda spec: spec["name"])
+
+
+def _param_node(param: click.Parameter) -> dict[str, Any]:
+    node: dict[str, Any] = {
+        "name": param.name,
+        "kind": type(param).__name__,
+        "type": getattr(param.type, "name", type(param.type).__name__),
+        "required": bool(param.required),
+    }
+    if isinstance(param, click.Option):
+        node["flags"] = sorted([*param.opts, *param.secondary_opts])
+        if param.is_flag:
+            node["is_flag"] = True
+        if param.multiple:
+            node["multiple"] = True
+    if isinstance(param.type, click.Choice):
+        node["choices"] = sorted(param.type.choices)
+    # Record only JSON-literal defaults; None/callables/sentinels are omitted
+    # (a stable omission rather than a volatile repr).
+    if isinstance(param.default, (str, int, float, bool)):
+        node["default"] = param.default
+    return node
+
+
+def _walk_cli(command: click.Command, name: str, ctx: click.Context) -> dict[str, Any]:
+    node: dict[str, Any] = {
+        "name": name,
+        "kind": "group" if isinstance(command, click.Group) else "command",
+    }
+    if getattr(command, "hidden", False):
+        node["hidden"] = True
+    params = [_param_node(p) for p in command.params if p.name not in _FRAMEWORK_PARAMS]
+    node["params"] = sorted(params, key=lambda p: p["name"])
+    if isinstance(command, click.Group):
+        children = []
+        for sub_name in sorted(command.list_commands(ctx)):
+            sub = command.get_command(ctx, sub_name)
+            if sub is None:
+                continue
+            child_ctx = click.Context(sub, parent=ctx, info_name=sub_name)
+            children.append(_walk_cli(sub, sub_name, child_ctx))
+        node["commands"] = children
+    return node
+
+
+def _cli_tree() -> dict[str, Any]:
+    command = typer.main.get_command(app)
+    return _walk_cli(command, "nauro", click.Context(command, info_name="nauro"))
+
+
+def _constant_values() -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for name in _CONTRACT_CONSTANTS:
+        value = getattr(nauro_core, name)
+        if isinstance(value, (str, int, bool)):
+            out[name] = value
+        elif isinstance(value, (set, frozenset, tuple, list)):
+            out[name] = sorted(value, key=repr)
+        else:  # pragma: no cover - defensive; no such constant today
+            out[name] = repr(value)
+    return out
+
+
+def build_contract() -> dict[str, Any]:
+    """Assemble the full public-contract snapshot from live sources."""
+    return {
+        "contract_version": CONTRACT_VERSION,
+        "stdio_tool_specs": _tool_specs(),
+        "cli_command_tree": _cli_tree(),
+        "cli_autogen_commands": sorted(AUTOGEN_ALLOWLIST),
+        "nauro_core_public_api": sorted(nauro_core.__all__),
+        "public_constant_values": _constant_values(),
+    }
+
+
+def _dumps(contract: dict[str, Any]) -> str:
+    return json.dumps(contract, indent=2, sort_keys=True)
+
+
+def test_public_contract_matches_snapshot() -> None:
+    current = _dumps(build_contract())
+
+    if os.environ.get(_UPDATE_ENV) == "1":
+        SNAPSHOT_PATH.parent.mkdir(parents=True, exist_ok=True)
+        SNAPSHOT_PATH.write_text(current + "\n", encoding="utf-8")
+        pytest.skip(f"{SNAPSHOT_PATH.name} regenerated from the live contract")
+
+    assert SNAPSHOT_PATH.exists(), (
+        f"{SNAPSHOT_PATH} is missing. Generate it once with "
+        f"{_UPDATE_ENV}=1 .venv/bin/python -m pytest {Path(__file__).name}"
+    )
+    expected = SNAPSHOT_PATH.read_text(encoding="utf-8").rstrip("\n")
+    assert current == expected, (
+        "The 1.0 public contract has drifted from the checked-in snapshot "
+        f"({SNAPSHOT_PATH.name}). This is a frozen surface under D318: a change "
+        "here is a major-version (2.0) concern unless it is purely additive and "
+        "you have confirmed so. If the change is intentional and reviewed, "
+        f"regenerate with `{_UPDATE_ENV}=1 .venv/bin/python -m pytest "
+        f"{Path(__file__).name}` and review the diff carefully."
+    )

--- a/packages/nauro/tests/test_public_contract.py
+++ b/packages/nauro/tests/test_public_contract.py
@@ -60,6 +60,7 @@ then review the diff to ``snapshots/public_contract_v1.json`` carefully — a
 
 from __future__ import annotations
 
+import difflib
 import json
 import os
 from pathlib import Path
@@ -238,11 +239,25 @@ def test_public_contract_matches_snapshot() -> None:
         f"{_UPDATE_ENV}=1 .venv/bin/python -m pytest {Path(__file__).name}"
     )
     expected = SNAPSHOT_PATH.read_text(encoding="utf-8").rstrip("\n")
-    assert current == expected, (
-        "The 1.0 public contract has drifted from the checked-in snapshot "
-        f"({SNAPSHOT_PATH.name}). This is a frozen surface under D318: a change "
-        "here is a major-version (2.0) concern unless it is purely additive and "
-        "you have confirmed so. If the change is intentional and reviewed, "
-        f"regenerate with `{_UPDATE_ENV}=1 .venv/bin/python -m pytest "
-        f"{Path(__file__).name}` and review the diff carefully."
-    )
+    if current != expected:
+        diff = "\n".join(
+            difflib.unified_diff(
+                expected.splitlines(),
+                current.splitlines(),
+                fromfile="snapshot (expected)",
+                tofile="live contract (current)",
+                lineterm="",
+                n=2,
+            )
+        )
+        if len(diff) > 8000:
+            diff = diff[:8000] + "\n... (diff truncated)"
+        raise AssertionError(
+            "The 1.0 public contract has drifted from the checked-in snapshot "
+            f"({SNAPSHOT_PATH.name}). This is a frozen surface under D318: a change "
+            "here is a major-version (2.0) concern unless it is purely additive and "
+            "you have confirmed so. If the change is intentional and reviewed, "
+            f"regenerate with `{_UPDATE_ENV}=1 .venv/bin/python -m pytest "
+            f"{Path(__file__).name}` and review the diff carefully.\n\n"
+            f"{diff}"
+        )

--- a/packages/nauro/tests/test_public_contract.py
+++ b/packages/nauro/tests/test_public_contract.py
@@ -63,6 +63,8 @@ from __future__ import annotations
 import difflib
 import json
 import os
+import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -191,21 +193,42 @@ def _walk_cli(command: click.Command, name: str, ctx: click.Context) -> dict[str
     return node
 
 
-def _cli_tree() -> dict[str, Any]:
-    # Read the tree from a freshly-reloaded app, not the process-global
-    # singleton. Other tests in the suite import and exercise
-    # ``nauro.cli.main.app`` (CliRunner invocations, registration assertions);
-    # reloading re-runs ``_register_commands`` so this snapshot reflects the
-    # real registered surface regardless of suite ordering or any prior
-    # in-place mutation of the shared app. The real CLI always starts from a
-    # fresh process, so this matches production, not a test artifact.
-    import importlib
+def _build_cli_tree() -> dict[str, Any]:
+    """Walk the CLI command tree in-process. Runs inside the fresh subprocess
+    spawned by :func:`_cli_tree`, where the app is pristine."""
+    from nauro.cli.main import app
 
-    from nauro.cli import main as cli_main
-
-    cli_main = importlib.reload(cli_main)
-    command = typer.main.get_command(cli_main.app)
+    command = typer.main.get_command(app)
     return _walk_cli(command, "nauro", click.Context(command, info_name="nauro"))
+
+
+# Capture the CLI tree from a FRESH interpreter, not in-process. The tree is
+# read off the process-global ``nauro.cli.main.app`` singleton, which other
+# tests in the suite import and exercise (CliRunner invocations, registration
+# assertions). An in-process read is therefore sensitive to suite ordering and
+# prior mutation of that shared object — observed as the registered commands
+# being absent under CI's ordering, collapsing the tree to an empty list. A
+# subprocess is hermetic and matches how the real CLI runs (a fresh process),
+# so the frozen surface is the surface a user actually gets. (Same fresh-process
+# pattern as test_retrieval_bench_smoke.)
+_CLI_TREE_DUMP = (
+    "import json, sys; sys.path.insert(0, sys.argv[1]); "
+    "import test_public_contract as _t; print(json.dumps(_t._build_cli_tree()))"
+)
+
+
+def _cli_tree() -> dict[str, Any]:
+    proc = subprocess.run(
+        [sys.executable, "-c", _CLI_TREE_DUMP, str(Path(__file__).parent)],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            "Failed to capture the CLI command tree in a subprocess:\n" + proc.stderr
+        )
+    return json.loads(proc.stdout)
 
 
 def _constant_values() -> dict[str, Any]:


### PR DESCRIPTION
## Summary

Adds a snapshot test that freezes the **1.0 public contract** (per **D318**) and fails on any drift, making a contract change a deliberate, reviewable act rather than a quiet diff.

D318 froze the local product surface at 1.0; breaking it now requires a major bump. The existing drift tests can't enforce that — they derive their expectations from live code (`test_skill_tool_signatures` builds `_TOOL_NAMES` from the live registry; `cli.autogen` checks its allowlist against live `ALL_TOOLS`), so they move *with* the code and stay green through a rename. A checked-in snapshot is the one test that can disagree with the code, which is exactly what a freeze needs.

## What it freezes

- **stdio tool specs** — all 11 `ALL_TOOLS` entries: name, annotations, and the *structural* input schema (param names, types, required, enums, defaults). Prose stripped.
- **CLI command tree** — the Typer/Click commands, subgroups, and each option's flags / type / required / choices.
- **`nauro_core.__all__`** — the curated public import surface D318 promised (vs. the ~107 incidental exports).
- **public constant values** — store-format filenames, schema version, write-path size limits, and the decision-type vocabulary (renaming `project.md` trips it).

## Deliberately out of scope (documented in the module docstring)

- Prose (tool / param descriptions) — owned by `test_protocol_drift`; including it would train regen-without-reading.
- Tool *output* models — `check_decision`'s is already pinned by `test_check_decision_schema`; generalizing to the other tools is the natural extension of that test.
- The on-disk store *body* format beyond the constants (the strict v2 parser owns it) and the stdio-vs-remote registration split.

## On drift

The test never decides major-vs-minor — it makes the change loud. An intentional, reviewed change is a deliberate regen:

```
NAURO_UPDATE_CONTRACT=1 .venv/bin/python -m pytest packages/nauro/tests/test_public_contract.py
```

…and the resulting diff to `snapshots/public_contract_v1.json` is the trigger to ask "is this a 2.0?" A `public_contract_v2.json` is what a 2.0 looks like.

## Test plan

- `pytest packages/nauro/tests/test_public_contract.py` — passes.
- Perturbed a constant in the snapshot → test fails with the D318 drift message; restored → passes. Drift detection is real, not vacuous.
- `ruff check` + `ruff format --check` — clean.
- Full `packages/nauro/tests/` suite — 1502 passed, 10 skipped.

## Decision reference

Enforces **D318** (nauro / nauro-core 1.0 lockstep semver freeze). No new decision proposed: this adds a test for existing behavior, which Nauro's own guidance exempts from `propose_decision`.
