### PR TITLE
Treat SELECT: pointers as discovery pointers in POINTER_FLAG_PREFIXES

### DIFF
--- a/packages/nauro-core/src/nauro_core/constants.py
+++ b/packages/nauro-core/src/nauro_core/constants.py
@@ -103,8 +103,9 @@ REVERSIBILITY_LEVELS: tuple[str, ...] = ("easy", "moderate", "hard")
 # ── Discovery-pointer flag markers ──
 # Entries in open-questions.md whose body starts with one of these prefixes
 # are discovery breadcrumbs (BRIEF for shared context briefs, RESUME for
-# agent resume briefs), not questions for human review.
-POINTER_FLAG_PREFIXES: tuple[str, ...] = ("BRIEF:", "RESUME:")
+# agent resume briefs, SELECT for /nauro-loop candidate-set checkpoints per
+# D322), not questions for human review.
+POINTER_FLAG_PREFIXES: tuple[str, ...] = ("BRIEF:", "RESUME:", "SELECT:")
 
 # ── Stack empty marker ──
 STACK_EMPTY_MARKER = "# Stack\n<!-- Tech choices with rationale and rejected alternatives -->"

--- a/packages/nauro-core/src/nauro_core/context.py
+++ b/packages/nauro-core/src/nauro_core/context.py
@@ -39,9 +39,9 @@ def _active_decisions(decisions: list[Decision]) -> list[Decision]:
 def _is_discovery_pointer(body: str) -> bool:
     """Return True when an entry body starts with a discovery-pointer prefix.
 
-    Discovery pointers (BRIEF:/RESUME: entries) are breadcrumbs written by
-    the nauro-context skill, not questions for human review, and are excluded
-    from the L0 Open Questions projection.
+    Discovery pointers (BRIEF:/RESUME:/SELECT: entries) are breadcrumbs written
+    by the nauro-context and nauro-loop skills, not questions for human review,
+    and are excluded from the L0 Open Questions projection.
     """
     stripped = body.lstrip()
     return stripped.startswith(POINTER_FLAG_PREFIXES)
@@ -53,8 +53,8 @@ def _render_l0_open_questions(content: str) -> str:
     Walks the parsed block list so the entry's ``timestamp`` survives for
     the age projection. Entries
     physically under ``## Resolved`` are skipped via the divider index.
-    Discovery-pointer entries (body starts with ``BRIEF:`` or ``RESUME:``)
-    are excluded entirely and do not consume a slot in the limit.
+    Discovery-pointer entries (body starts with ``BRIEF:``, ``RESUME:`` or
+    ``SELECT:``) are excluded entirely and do not consume a slot in the limit.
     A ``(open NN days; consider closing or deferring)`` line is prepended
     when ``entry.timestamp`` is set and the entry is older than
     :data:`_L0_AGE_PROJECTION_DAYS`. Q-form entries without a timestamp

--- a/packages/nauro-core/tests/test_constants.py
+++ b/packages/nauro-core/tests/test_constants.py
@@ -89,7 +89,7 @@ class TestValidValues:
 
 class TestPointerFlagPrefixes:
     def test_exact_value(self):
-        assert POINTER_FLAG_PREFIXES == ("BRIEF:", "RESUME:")
+        assert POINTER_FLAG_PREFIXES == ("BRIEF:", "RESUME:", "SELECT:")
 
     def test_is_tuple(self):
         assert isinstance(POINTER_FLAG_PREFIXES, tuple)

--- a/packages/nauro-core/tests/test_context.py
+++ b/packages/nauro-core/tests/test_context.py
@@ -418,8 +418,8 @@ class TestBuildL0OpenQuestionsAgeProjection:
 
 
 class TestBuildL0DiscoveryPointerExclusion:
-    """Discovery-pointer entries (BRIEF:/RESUME: body prefix) are excluded
-    from the L0 Open Questions section and do not consume a limit slot.
+    """Discovery-pointer entries (BRIEF:/RESUME:/SELECT: body prefix) are
+    excluded from the L0 Open Questions section and do not consume a limit slot.
     """
 
     def _files(self, content: str) -> dict[str, str]:
@@ -446,6 +446,19 @@ class TestBuildL0DiscoveryPointerExclusion:
         result = build_l0(self._files(content), [])
         assert "Another genuine question?" in result
         assert "RESUME:" not in result
+
+    def test_select_pointer_excluded(self):
+        # SELECT: checkpoints (nauro-loop candidate sets, D322) are discovery
+        # pointers too and must not surface as L0 open questions.
+        content = (
+            "# Open Questions\n"
+            "\n"
+            "- [Q1] SELECT: context/origin-select-20260619-ef56.md — loop checkpoint\n"
+            "- [Q2] Yet another genuine question?\n"
+        )
+        result = build_l0(self._files(content), [])
+        assert "Yet another genuine question?" in result
+        assert "SELECT:" not in result
 
     def test_pointer_does_not_consume_limit_slot(self):
         # With limit = 3, three genuine questions plus two pointers should all

--- a/packages/nauro/src/nauro/mcp/tools.py
+++ b/packages/nauro/src/nauro/mcp/tools.py
@@ -495,9 +495,10 @@ def tool_flag_question(
             return err
 
     hint = None
-    # Skip the similar-decision hint for discovery pointers (BRIEF:/RESUME:):
-    # they are file pointers, not questions for review, so a "addressed by
-    # decision-NNN" annotation on them is pure noise. The flag still logs.
+    # Skip the similar-decision hint for discovery pointers
+    # (BRIEF:/RESUME:/SELECT:): they are file pointers, not questions for
+    # review, so a "addressed by decision-NNN" annotation on them is pure
+    # noise. The flag still logs.
     if question and not question.lstrip().startswith(POINTER_FLAG_PREFIXES):
         pseudo_proposal = {
             "title": question[:FLAG_QUESTION_HINT_TITLE_LENGTH],

--- a/packages/nauro/tests/test_flag_question_hint.py
+++ b/packages/nauro/tests/test_flag_question_hint.py
@@ -65,7 +65,7 @@ def test_hint_absent_below_threshold(store):
 
 
 def test_pointer_flag_prefixes_constant():
-    assert POINTER_FLAG_PREFIXES == ("BRIEF:", "RESUME:")
+    assert POINTER_FLAG_PREFIXES == ("BRIEF:", "RESUME:", "SELECT:")
 
 
 @pytest.mark.parametrize(
@@ -73,13 +73,14 @@ def test_pointer_flag_prefixes_constant():
     [
         "BRIEF: context/origin-topic-20260605-ab12.md — a shared brief",
         "RESUME: context/auth-cutover-20260605-cd34.md — wip resume brief",
+        "SELECT: context/origin-select-20260619-ef56.md — a loop checkpoint",
         "  BRIEF: context/x.md — leading whitespace still skips the hint",
     ],
 )
 def test_hint_skipped_for_discovery_pointers(store, pointer):
-    """BRIEF:/RESUME: discovery pointers are file pointers, not questions for
-    review, so the similar-decision hint is skipped even when BM25 scores above
-    threshold. The flag itself still logs."""
+    """BRIEF:/RESUME:/SELECT: discovery pointers are file pointers, not
+    questions for review, so the similar-decision hint is skipped even when
+    BM25 scores above threshold. The flag itself still logs."""
     above = FLAG_QUESTION_HINT_MIN_SCORE + 0.1
     with (
         patch("nauro.mcp.tools.check_bm25_similarity", return_value=_stub_similar(above)),


### PR DESCRIPTION
### Why
D322 introduced `SELECT:` durable-checkpoint pointers (written by the nauro-loop skill via `flag_question`), but `POINTER_FLAG_PREFIXES` was left as `("BRIEF:", "RESUME:")`. As a result `SELECT:` pointers leaked into the L0 Open Questions projection as noise and triggered the `flag_question` similar-decision hint — the exact symptom tracked by open question Q61. Q64 is a live `SELECT:` pointer that surfaced in L0 because of this gap.

### Approach
Add `"SELECT:"` to the single shared nauro-core constant `POINTER_FLAG_PREFIXES`. Both consumption sites — the L0 open-questions exclusion in `nauro_core/context.py` and the `flag_question` hint suppression in `nauro/mcp/tools.py` — drive off that one constant, so the single change fixes both. This completes D322's already-decided intent (SELECT: is documented there as a discovery pointer scanned on open-questions.md), so it is treated as a bug fix — no new decision filed.

### What changed
- `packages/nauro-core/src/nauro_core/constants.py`: add `"SELECT:"` to `POINTER_FLAG_PREFIXES`; update the comment.
- `packages/nauro-core/src/nauro_core/context.py`: docstring updates at the `_is_discovery_pointer` / `_render_l0_open_questions` sites.
- `packages/nauro/src/nauro/mcp/tools.py`: comment update at the hint-suppression site.
- Tests: updated the two pinned-value assertions; added an L0 `SELECT:` exclusion test and a `SELECT:` parametrized hint-skip case.

### What to review
Whether `SELECT:` truly belongs alongside `BRIEF:`/`RESUME:` (see D322), and whether both consumption sites are covered by the single constant.

### What's deferred
Retirement/GC of consumed `SELECT:` pointers stays under the existing Q61 stale-pointer gap (D322 explicitly scopes it there). The separate mcp-server repo's module-local duplicate (Q55) is out of scope.

### Test plan
- `uv run pytest packages/nauro-core/tests/ packages/nauro/tests/ -q`
- `uv run ruff check packages/`

All related tests pass. The 2 pre-existing failures in `test_cli_fs_errors.py` are environmental (tests run as root, which bypasses the `chmod 0o555` read-only-dir assertion) and unrelated to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GWe9czzrKcEhnwz6tuUxtb)_