### PR TITLE
Publish server.json to the MCP registry on release

### DIFF
--- a/.github/workflows/publish-nauro.yml
+++ b/.github/workflows/publish-nauro.yml
@@ -20,3 +20,36 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: packages/nauro/dist/
+
+  publish-registry:
+    needs: publish
+    runs-on: ubuntu-latest
+    environment: mcp-registry
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+      - name: Verify server.json version matches the release tag
+        run: |
+          tag_version="${GITHUB_REF_NAME#nauro-v}"
+          server_version="$(jq -r '.version' server.json)"
+          package_version="$(jq -r '.packages[0].version' server.json)"
+          if [ "$server_version" != "$tag_version" ]; then
+            echo "server.json version ($server_version) does not match release tag ($tag_version)" >&2
+            exit 1
+          fi
+          if [ "$package_version" != "$tag_version" ]; then
+            echo "server.json packages[0].version ($package_version) does not match release tag ($tag_version)" >&2
+            exit 1
+          fi
+          echo "server.json version $server_version matches release tag $tag_version"
+      - name: Download mcp-publisher
+        run: |
+          curl -fsSL https://github.com/modelcontextprotocol/registry/releases/download/v1.7.9/mcp-publisher_linux_amd64.tar.gz -o mcp-publisher.tar.gz
+          tar -xzf mcp-publisher.tar.gz mcp-publisher
+          chmod +x mcp-publisher
+      - name: Authenticate to the MCP registry via DNS
+        env:
+          MCP_PRIVATE_KEY: ${{ secrets.MCP_PRIVATE_KEY }}
+        run: ./mcp-publisher login dns --domain nauro.ai --private-key "$MCP_PRIVATE_KEY"
+      - name: Publish server.json to the MCP registry
+        run: ./mcp-publisher publish


### PR DESCRIPTION
## Why

The MCP registry listing at registry.modelcontextprotocol.io drifted from the
PyPI release: it served version 0.13.2 while both PyPI and `server.json` had
already advanced to 1.0.0. The cause is that pushing `server.json` to the
registry was a manual follow-up to the registry-metadata PR, and that step was
never re-run after the 1.0.0 release. Nothing in CI guaranteed the registry
stayed in lockstep with the package, so the listing could silently go stale.

## Approach

Add a second job to the release workflow that publishes `server.json`
automatically once the PyPI upload succeeds, so the registry entry can no
longer drift from the published package.

- The new `publish-registry` job declares `needs: publish` and therefore runs
  only after the PyPI upload completes. This ordering is required because the
  registry validates the submission by fetching the PyPI package and checking
  its `mcp-name` marker — the version must already exist on PyPI.
- Authentication uses `mcp-publisher login dns`. DNS auth is the only
  non-interactive path for the reverse-DNS-verified `ai.nauro` namespace;
  GitHub-OIDC login would resolve to an `io.github.*` namespace instead and
  could not publish under `ai.nauro`. The job therefore does not request
  `id-token: write` permissions.
- The signing key lives in a dedicated `mcp-registry` GitHub environment
  (`MCP_PRIVATE_KEY`), kept separate from the PyPI OIDC environment for least
  privilege and a cleaner failure signal.
- A version-match guard reads `server.json` with `jq` (preinstalled on
  ubuntu-latest) and fails the job if either `.version` or `.packages[0].version`
  disagrees with the tag-derived version (`${GITHUB_REF_NAME#nauro-v}`). A
  forgotten bump in the release commit becomes a loud CI failure instead of a
  silently mismatched registry entry.
- The `mcp-publisher` binary is pinned to v1.7.9 and downloaded from a pinned
  release URL (not `releases/latest`), so the workflow meant to prevent drift
  does not itself reintroduce it.

## What changes

- `.github/workflows/publish-nauro.yml`: adds the `publish-registry` job
  (checkout → version-match guard → download pinned mcp-publisher → DNS login →
  publish). No other files are touched; `server.json` and the README marker are
  already correct.

## What's deferred / follow-up

- **One-time 1.0.0 registry publish.** This automation only fires on the next
  `nauro-v*` tag. The current gap (registry on 0.13.2, package on 1.0.0) still
  needs a one-time manual `mcp-publisher publish` of the existing 1.0.0
  `server.json` to close it; that is out of scope for this PR.
- **One-time human provisioning, required before the job can succeed.** Someone
  must: (1) generate an Ed25519 key pair; (2) publish the public half as a DNS
  TXT record on nauro.ai in the form `v=MCPv1; k=ed25519; p=<pubkey>`; and
  (3) store the hex-encoded private key as the `MCP_PRIVATE_KEY` secret in a new
  `mcp-registry` GitHub environment. Until this is in place the new job will
  fail at the DNS login step.
- **SHA-pinning of GitHub Actions.** This job keeps the existing tag-pin house
  style (`actions/checkout@v6`). Migrating actions to SHA pins is a separate,
  already-tracked hardening pass and is intentionally not done here.

## Test plan

- YAML validated (parses cleanly; `publish-registry` has `needs: publish`,
  `environment: mcp-registry`, no `id-token` permissions, and all five named
  steps). actionlint was not available in the local environment.
- `ruff check packages/` passes — unaffected, confirming no lint regression.
- The mcp-publisher v1.7.9 asset name (`mcp-publisher_linux_amd64.tar.gz`) and
  the `login dns` flag surface (`--domain`, `--private-key`) were verified
  against the pinned v1.7.9 release assets and source.
- End-to-end behavior (DNS login + publish) can only be exercised once the
  human provisioning above is complete and a release tag is pushed.
