### PR TITLE
Fix dead state-diff branch and surface resolved day-range anchor in diff_since_last_session

### DIFF
--- a/packages/nauro-core/src/nauro_core/operations/diff_since_last_session.py
+++ b/packages/nauro-core/src/nauro_core/operations/diff_since_last_session.py
@@ -20,6 +20,7 @@ from nauro_core.constants import (
     DECISIONS_DIR,
     OPEN_QUESTIONS_MD,
     STACK_MD,
+    STATE_CURRENT_FILENAME,
     STATE_DIFF_FIELDS,
     STATE_MD,
 )
@@ -35,6 +36,14 @@ NO_SNAPSHOTS_AVAILABLE = "No snapshots available."
 NOT_ENOUGH_SNAPSHOTS = "Not enough snapshots to compute a diff (need at least 2)."
 ONE_SNAPSHOT_COVERS_RANGE = (
     "Only one snapshot covers the requested time range — no diff available."
+)
+# Day-range anchor line. A format template (interpolates two runtime values)
+# rather than a plain sentinel, but kept here beside the sibling sentinels so
+# the wording stays single-sourced: the hosted adapter (mcp-server) imports
+# this to render the same line, byte-for-byte, on the remote surface.
+ANCHOR_LINE_TEMPLATE = (
+    "Anchor: requested ≤ {cutoff}; resolved to baseline {baseline} "
+    "(most-recent snapshot at-or-before cutoff; oldest-snapshot fallback)"
 )
 
 
@@ -85,12 +94,12 @@ def diff_since_last_session(
         return DiffSinceLastSessionResult(diff=diff, cutoff_date_used=cutoff_date_used)
 
     return DiffSinceLastSessionResult(
-        diff=_render_diff(baseline_snapshot, latest_snapshot),
+        diff=_render_diff(baseline_snapshot, latest_snapshot, cutoff_date_used),
         cutoff_date_used=cutoff_date_used,
     )
 
 
-def _render_diff(snap_a: dict, snap_b: dict) -> str:
+def _render_diff(snap_a: dict, snap_b: dict, cutoff_date_used: str | None = None) -> str:
     """Render the semantic diff body between two snapshot dicts."""
     # Version numbers come from the snapshot dict itself, not a caller-supplied
     # integer like the pre-cutover ``diff_snapshots(store_path, version_a,
@@ -110,6 +119,13 @@ def _render_diff(snap_a: dict, snap_b: dict) -> str:
         sections.append(f"  ({ts_a} → {ts_b})")
     else:
         sections.append(f"Changes from {ts_a} → {ts_b}")
+    # Day-range path only: surface the requested cutoff against the resolved
+    # baseline so the (silent, age-degrading) anchor fuzz is visible. Keyed off
+    # cutoff_date_used and the baseline TIMESTAMP only — never an integer
+    # version, which versionless remote snapshots do not carry. Absent for the
+    # no-arg session diff, keeping that output byte-identical.
+    if cutoff_date_used is not None:
+        sections.append(ANCHOR_LINE_TEMPLATE.format(cutoff=cutoff_date_used, baseline=ts_a))
     sections.append("")
 
     has_changes = False
@@ -159,7 +175,10 @@ def _semantic_file_diff(filename: str, old: str, new: str) -> list[str]:
     """Produce semantic change descriptions for a modified file."""
     changes: list[str] = []
 
-    if filename == STATE_MD:
+    if filename in (STATE_CURRENT_FILENAME, STATE_MD):
+        # Live snapshots store current state under state_current.md; old
+        # snapshots predating the rename used state.md, kept as a legacy
+        # alias so they still diff semantically.
         changes.extend(_diff_state(old, new))
     elif filename == STACK_MD:
         changes.extend(_diff_stack(old, new))

--- a/packages/nauro-core/tests/operations/test_diff_since_last_session.py
+++ b/packages/nauro-core/tests/operations/test_diff_since_last_session.py
@@ -121,6 +121,101 @@ def test_both_populated_renders_real_diff() -> None:
     assert "decisions/001-adopt-postgres.md" in result.diff
 
 
+def test_state_current_sprint_transition_renders_semantically() -> None:
+    # state_current.md is the real key live snapshots use. The Sprint
+    # alpha → beta transition must route through _diff_state and render as a
+    # semantic field delta, not degrade to a generic line-count. Asserting on
+    # the rendered transition catches the dead state-diff branch.
+    result = diff_since_last_session(InMemoryStore(), _baseline(), _latest())
+    assert result.diff is not None
+    assert "Sprint: 'alpha' → 'beta'" in result.diff
+    # The generic line-count fallback must NOT fire for the state file.
+    assert "Content changed" not in result.diff
+
+
+def test_legacy_state_md_key_still_diffs_semantically() -> None:
+    # Snapshots predating the state_current.md rename keyed state under
+    # state.md. The legacy alias must still route through _diff_state so old
+    # snapshots diff semantically rather than collapsing to a line-count.
+    snap_a = _snapshot(
+        1,
+        "2026-05-01T10:00:00+00:00",
+        {"state.md": "# Current State\n\n**Sprint:** alpha\n"},
+    )
+    snap_b = _snapshot(
+        2,
+        "2026-05-02T10:00:00+00:00",
+        {"state.md": "# Current State\n\n**Sprint:** beta\n"},
+    )
+    result = diff_since_last_session(InMemoryStore(), snap_a, snap_b)
+    assert result.diff is not None
+    assert "Sprint: 'alpha' → 'beta'" in result.diff
+    assert "Content changed" not in result.diff
+
+
+def test_anchor_line_present_when_cutoff_supplied() -> None:
+    cutoff = "2026-04-24T10:00:00+00:00"
+    result = diff_since_last_session(
+        InMemoryStore(), _baseline(), _latest(), cutoff_date_used=cutoff
+    )
+    assert result.diff is not None
+    lines = result.diff.split("\n")
+    anchor = next((line for line in lines if line.startswith("Anchor:")), None)
+    assert anchor is not None
+    # The requested cutoff and the resolved baseline timestamp both surface,
+    # along with the selection rule.
+    assert f"requested ≤ {cutoff}" in anchor
+    assert "resolved to baseline 2026-05-01T10:00:00" in anchor
+    assert "most-recent snapshot at-or-before cutoff" in anchor
+    assert "oldest-snapshot fallback" in anchor
+
+
+def test_no_arg_diff_is_byte_identical_without_anchor_line() -> None:
+    # When cutoff_date_used is None (the no-arg session diff), output must be
+    # byte-identical to the pre-anchor rendering: no Anchor line at all.
+    with_cutoff = diff_since_last_session(
+        InMemoryStore(),
+        _baseline(),
+        _latest(),
+        cutoff_date_used="2026-04-24T10:00:00+00:00",
+    )
+    without_cutoff = diff_since_last_session(InMemoryStore(), _baseline(), _latest())
+    assert without_cutoff.diff is not None
+    assert "Anchor:" not in without_cutoff.diff
+    # The only structural difference vs. the cutoff variant is the inserted
+    # Anchor line; dropping it recovers the no-arg body exactly.
+    assert with_cutoff.diff is not None
+    stripped = "\n".join(
+        line for line in with_cutoff.diff.split("\n") if not line.startswith("Anchor:")
+    )
+    assert stripped == without_cutoff.diff
+
+
+def test_anchor_line_renders_on_versionless_snapshots() -> None:
+    # Remote/cloud snapshots carry no integer version. The anchor must render
+    # off the baseline timestamp alone — never raise, never print a bogus
+    # version — and coexist with the single-line timestamp header.
+    snap_a = {
+        "timestamp": "2026-05-01T10:00:00+00:00",
+        "files": {"stack.md": "# Stack\n- Python 3.11\n"},
+    }
+    snap_b = {
+        "timestamp": "2026-05-02T10:00:00+00:00",
+        "files": {"stack.md": "# Stack\n- Python 3.11\n- PostgreSQL\n"},
+    }
+    cutoff = "2026-04-24T10:00:00+00:00"
+    result = diff_since_last_session(InMemoryStore(), snap_a, snap_b, cutoff_date_used=cutoff)
+    assert result.diff is not None
+    lines = result.diff.split("\n")
+    assert lines[0] == "Changes from 2026-05-01T10:00:00 → 2026-05-02T10:00:00"
+    anchor = next((line for line in lines if line.startswith("Anchor:")), None)
+    assert anchor is not None
+    assert f"requested ≤ {cutoff}" in anchor
+    assert "resolved to baseline 2026-05-01T10:00:00" in anchor
+    # No version token leaks into the anchor on the versionless shape.
+    assert "v0" not in anchor
+
+
 def test_cutoff_date_used_threaded_only_when_supplied() -> None:
     result_with = diff_since_last_session(
         InMemoryStore(),

--- a/packages/nauro/src/nauro/store/snapshot.py
+++ b/packages/nauro/src/nauro/store/snapshot.py
@@ -223,8 +223,9 @@ def _prune_snapshots(snapshots_dir: Path) -> None:
 def find_snapshot_near_date(store_path: Path, target: datetime) -> dict | None:
     """Find the most recent snapshot that is at or before the target datetime.
 
-    Scans all snapshots and returns the one closest to (but not after) the
-    target. If no snapshot is old enough, returns the oldest available.
+    Scans all snapshots and returns the most recent snapshot at or before the
+    target, with an oldest-snapshot fallback when no snapshot predates the
+    target.
 
     Args:
         store_path: Path to the project store directory.

--- a/packages/nauro/tests/test_diff_since_last_session_parity.py
+++ b/packages/nauro/tests/test_diff_since_last_session_parity.py
@@ -139,6 +139,27 @@ def test_time_based_envelope_matches_across_surfaces(time_indexed_repo):
     assert stdio["cutoff_date_used"]
 
 
+def test_days_based_surfaces_anchor_line(time_indexed_repo):
+    # The local adapter threads cutoff_date_used into the kernel, so the
+    # days-based path surfaces the resolved-anchor header on both the
+    # auto-generated CLI and the stdio MCP surface with no adapter change.
+    pid, store_path = time_indexed_repo
+    stdio = _stdio_envelope(pid, days=7)
+    tool = _tool_envelope(store_path, days=7)
+    assert stdio == tool
+    assert "Anchor: requested ≤ " in stdio["diff"]
+    assert "most-recent snapshot at-or-before cutoff" in stdio["diff"]
+    assert stdio["cutoff_date_used"] in stdio["diff"]
+
+
+def test_session_scoped_diff_omits_anchor_line(seeded_repo):
+    # The no-arg session diff carries no cutoff, so the anchor header must be
+    # absent — keeping that output byte-identical to pre-anchor behaviour.
+    pid, _store_path = seeded_repo
+    stdio = _stdio_envelope(pid)
+    assert "Anchor:" not in stdio["diff"]
+
+
 def test_empty_store_session_scoped_envelope_matches(empty_repo):
     pid, store_path = empty_repo
     stdio = _stdio_envelope(pid)


### PR DESCRIPTION
**Why**

The `diff_since_last_session` day-range (`days=N`) path had two silent correctness gaps. (1) Its semantic state-differ keyed on `STATE_MD` (`"state.md"`), but live snapshots store current state under `state_current.md`, so on real stores the state branch never fired — Sprint / Focus / Blockers changes degraded to a generic line-count, gutting the highest-value surface of the only axis where this diff earns its keep over `list_decisions`. (2) The resolved baseline anchor was invisible: callers saw a diff but not which baseline `days=N` resolved against, and that fuzz widens with snapshot pruning.

**Approach**

Adopt the established fan-out / anchor-surfacing direction: the canonical rendered string lives in the kernel as the single source of truth, not per-adapter. Key the state-differ on `STATE_CURRENT_FILENAME` (primary) with `STATE_MD` retained as a legacy alias so pre-rename snapshots still diff semantically. Emit the anchor line from the kernel `_render_diff`, keyed off `cutoff_date_used` and the baseline timestamp only — never an integer version, since remote/cloud snapshots are versionless — and only when `cutoff_date_used` is set, so the no-arg session diff stays byte-identical.

**What changes**

- `_semantic_file_diff` matches `filename in (STATE_CURRENT_FILENAME, STATE_MD)`; imports `STATE_CURRENT_FILENAME`. `STATE_MD`'s value is unchanged.
- `_render_diff` takes `cutoff_date_used` and emits one `Anchor: requested ≤ …; resolved to baseline …` line on the day-range path. The existing `vNNN → vNNN` header is untouched. The local adapter already threads `cutoff_date_used` in, so this surfaces on `nauro diff --days N` (CLI + stdio) with no adapter change.
- The anchor wording is single-sourced as the module constant `ANCHOR_LINE_TEMPLATE`, co-located with the sibling diff sentinels so the remote adapter can import and render the same line byte-for-byte rather than copying the literal.
- `find_snapshot_near_date` docstring corrected from "closest to" to "most recent at or before the target, with oldest-snapshot fallback" to match the code.

**What to review**

- The anchor line is gated strictly on `cutoff_date_used is not None`, so the no-arg session diff is byte-identical — the parity / cross-surface / log-diff tests are the guard for that.
- The anchor renders off the baseline timestamp only and never reads or prints an integer version, so it is correct for versionless (remote) snapshots.
- The new state-diff test asserts the `Sprint: alpha → beta` semantic transition (the assertion the prior suite omitted, which is what masked the dead branch).

**What's deferred**

PR2 (mcp-server repo) follows after this publishes: the hosted fan-out (parallelize the serial `days=N` snapshot scan across the existing worker pool, drop the redundant baseline re-GET) and the hosted `cutoff_date_used` wiring so the anchor line also surfaces on the remote HTTP MCP surface. PR2 imports `ANCHOR_LINE_TEMPLATE` from this change to guarantee byte-for-byte parity.

**Test plan**

- `pytest packages/nauro-core/tests/ packages/nauro/tests/` — 2379 pass. (Two pre-existing subprocess tests fail only under a locally broken editable install — identical on `main`, unrelated to this diff.)
- `ruff check packages/` and `ruff format --check packages/` clean.
- Parity / cross-surface / log-diff / version-header byte-parity and the `STATE_MD == "state.md"` constants test all green — proof the no-arg output is unchanged. No tool name, MCP schema, CLI command/flag, or store-format change; `days` semantics and baseline selection are unchanged.
