### PR TITLE
Bump nauro-core to 1.0.1

### DIFF
--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro-core"
-version = "1.0.0"
+version = "1.0.1"
 description = "Shared pure-Python logic for Nauro: parsing, validation, context assembly, constants."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
**Why**

Cut a `nauro-core` patch release to publish three additive changes that have merged to `main` since `nauro-core-v1.0.0` but are not yet on PyPI:

- **#267** — fix the dead state-differ branch (`state_current.md`) and surface the resolved day-range anchor in `diff_since_last_session` (adds `ANCHOR_LINE_TEMPLATE`).
- **#265** — treat `SELECT:` pointers as discovery pointers.
- **#261** — make `propose_decision(operation="update")` callable.

This release also unblocks the hosted anchor-line follow-up (mcp-server), which imports `ANCHOR_LINE_TEMPLATE` from the published `nauro-core` for byte-parity and bumps its pin off `<0.14`.

**What changes**

- `packages/nauro-core/pyproject.toml`: `version` `1.0.0` → `1.0.1`.

All three released changes are additive / non-breaking — no curated `__all__` removal, no signature or store-format change — so this is a patch under the 1.0 semver freeze, not a minor or major bump. `__version__` resolves dynamically from package metadata, so no source string change is needed. `nauro`'s pin (`nauro-core>=1.0,<2`) already admits `1.0.1`.

**After merge**

Push the release tag to trigger the PyPI publish workflow (`publish-nauro-core.yml`, `on: push: tags: nauro-core-v*`):

```
git tag nauro-core-v1.0.1 && git push origin nauro-core-v1.0.1
```
