### PR TITLE
Anchor day-range diff on the requested cutoff, not the baseline timestamp

### DIFF
--- a/packages/nauro-core/src/nauro_core/operations/diff_since_last_session.py
+++ b/packages/nauro-core/src/nauro_core/operations/diff_since_last_session.py
@@ -65,8 +65,10 @@ def diff_since_last_session(
         latest_snapshot: Later snapshot dict, same shape. ``None`` signals
             no snapshots at all.
         cutoff_date_used: When the adapter resolved the baseline via a
-            time-based lookup, the baseline snapshot's timestamp is
-            threaded through here so callers can render it.
+            time-based lookup, the requested cutoff (``now - N days``) is
+            threaded through here so callers can render it. This is the
+            cutoff the caller asked for, not the (possibly older) baseline
+            snapshot's timestamp the lookup resolved to.
 
     Returns:
         :class:`DiffSinceLastSessionResult`. ``diff`` carries the

--- a/packages/nauro/src/nauro/store/snapshot.py
+++ b/packages/nauro/src/nauro/store/snapshot.py
@@ -341,7 +341,9 @@ def resolve_diff_snapshots(
     * ``days=N`` + baseline == latest → the matched pair; kernel renders
       ``Only one snapshot covers the requested range…``.
     * ``days=N`` otherwise → resolved baseline/latest pair plus the
-      baseline timestamp as ``cutoff_date_used``.
+      REQUESTED cutoff (``now - N days``) as ``cutoff_date_used``. The
+      anchor reflects what the caller asked for, not the older baseline
+      the lookup happened to resolve to.
     """
     snapshots = list_snapshots(store_path)
 
@@ -356,7 +358,7 @@ def resolve_diff_snapshots(
         baseline_version = baseline_meta["version"]
         baseline_snapshot = load_snapshot(store_path, baseline_version)
         latest_snapshot = load_snapshot(store_path, latest_version)
-        return baseline_snapshot, latest_snapshot, baseline_meta["timestamp"]
+        return baseline_snapshot, latest_snapshot, target.isoformat()
 
     if not snapshots:
         return None, None, None

--- a/packages/nauro/tests/test_diff_since_last_session_parity.py
+++ b/packages/nauro/tests/test_diff_since_last_session_parity.py
@@ -58,7 +58,14 @@ def seeded_repo(tmp_path, monkeypatch):
 
 @pytest.fixture
 def time_indexed_repo(tmp_path, monkeypatch):
-    """A repo with snapshots at known time offsets, suitable for days-based diffs."""
+    """A repo with snapshots at known time offsets, suitable for days-based diffs.
+
+    v001 is backdated to 14 days ago — comfortably older than the
+    ``now - 7d`` cutoff the days-based tests request — so it resolves as
+    the baseline while the requested cutoff and the baseline's own
+    timestamp stay visibly DISTINCT (7 days apart). v002 is captured at
+    ``now`` and serves as latest.
+    """
     repo = tmp_path / "repo"
     repo.mkdir()
     pid, store_path = register_project_v2("parity-diff-time", [repo], mode=REPO_CONFIG_MODE_LOCAL)
@@ -115,6 +122,24 @@ def _tool_envelope(store_path: Path, days: int | None = None) -> dict:
     return tool_diff_since_last_session(store_path, days)
 
 
+def _clock_invariant(envelope: dict) -> dict:
+    """Strip clock-derived parts so two independent calls compare equal.
+
+    The days-based ``cutoff_date_used`` is the REQUESTED cutoff
+    (``now - N days``), recomputed from ``datetime.now()`` on every call,
+    and that same value is interpolated into the rendered ``Anchor:`` line.
+    Two independent surface calls therefore differ by microseconds in the
+    cutoff field and the anchor line, so parity is asserted on everything
+    else; the cutoff's own consistency is checked separately.
+    """
+    out = {k: v for k, v in envelope.items() if k != "cutoff_date_used"}
+    if isinstance(out.get("diff"), str):
+        out["diff"] = "\n".join(
+            line for line in out["diff"].split("\n") if not line.startswith("Anchor:")
+        )
+    return out
+
+
 def test_session_scoped_envelope_matches_across_surfaces(seeded_repo):
     pid, store_path = seeded_repo
     stdio = _stdio_envelope(pid)
@@ -131,25 +156,42 @@ def test_time_based_envelope_matches_across_surfaces(time_indexed_repo):
     pid, store_path = time_indexed_repo
     stdio = _stdio_envelope(pid, days=7)
     tool = _tool_envelope(store_path, days=7)
-    assert stdio == tool
+    # The cutoff is now() - N days, recomputed per call, so the two
+    # independent surfaces agree on everything but that clock-derived value.
+    assert _clock_invariant(stdio) == _clock_invariant(tool)
     assert stdio["store"] == "local"
     assert "v001" in stdio["diff"]
     assert "v002" in stdio["diff"]
-    # Days-based path threads the baseline timestamp through as cutoff_date_used.
+    # Days-based path threads the REQUESTED cutoff (now - N days) through as
+    # cutoff_date_used — not the (older) resolved baseline timestamp.
     assert stdio["cutoff_date_used"]
 
 
 def test_days_based_surfaces_anchor_line(time_indexed_repo):
     # The local adapter threads cutoff_date_used into the kernel, so the
-    # days-based path surfaces the resolved-anchor header on both the
+    # days-based path surfaces the requested-cutoff anchor header on both the
     # auto-generated CLI and the stdio MCP surface with no adapter change.
     pid, store_path = time_indexed_repo
     stdio = _stdio_envelope(pid, days=7)
     tool = _tool_envelope(store_path, days=7)
-    assert stdio == tool
+    assert _clock_invariant(stdio) == _clock_invariant(tool)
     assert "Anchor: requested ≤ " in stdio["diff"]
     assert "most-recent snapshot at-or-before cutoff" in stdio["diff"]
     assert stdio["cutoff_date_used"] in stdio["diff"]
+
+    # The anchor's "requested ≤" value is the REQUESTED cutoff (now - 7d),
+    # parsing within a few seconds of it — not the resolved baseline.
+    cutoff = datetime.fromisoformat(stdio["cutoff_date_used"])
+    expected_cutoff = datetime.now(timezone.utc) - timedelta(days=7)
+    assert abs((cutoff - expected_cutoff).total_seconds()) < 60
+
+    # The cutoff must be DISTINCT from the resolved baseline timestamp: the
+    # fixture backdates the baseline (v001) to 14 days ago, so the requested
+    # cutoff (7 days ago) and the "resolved to baseline <ts>" value differ.
+    baseline_ts = load_snapshot(store_path, 1)["timestamp"]
+    assert stdio["cutoff_date_used"] != baseline_ts
+    assert f"resolved to baseline {baseline_ts[:19]}" in stdio["diff"]
+    assert f"requested ≤ {stdio['cutoff_date_used']}" in stdio["diff"]
 
 
 def test_session_scoped_diff_omits_anchor_line(seeded_repo):
@@ -186,7 +228,9 @@ def test_days_based_one_snapshot_covers_range_matches_across_surfaces(single_sna
     pid, store_path = single_snapshot_repo
     stdio = _stdio_envelope(pid, days=7)
     tool = _tool_envelope(store_path, days=7)
-    assert stdio == tool
+    # The sentinel diff carries no anchor line, but the envelope still
+    # surfaces the (clock-derived) requested cutoff, so compare modulo it.
+    assert _clock_invariant(stdio) == _clock_invariant(tool)
     assert stdio["store"] == "local"
     assert stdio["diff"] == "Only one snapshot covers the requested time range — no diff available."
 


### PR DESCRIPTION
**Why**

The day-range diff anchor line ("Anchor: requested ≤ {cutoff}; resolved to baseline {baseline}") rendered the resolved baseline snapshot's timestamp as the cutoff. The baseline is whatever snapshot the nearest-at-or-before lookup landed on, which can be far older than the window the caller requested, so the "requested ≤" label promised the user's cutoff but showed the baseline's age.

**Approach**

Option A: the kernel is unchanged — it already renders `cutoff=cutoff_date_used` and the resolved baseline timestamp on the same line. Only the adapter changes what it threads in: `resolve_diff_snapshots` now returns the REQUESTED cutoff (`now - N days`, the already-computed `target`) as `cutoff_date_used`. The matching hosted-MCP adapter change ships in mcp-server so both surfaces render identically.

**What changes**

- `packages/nauro/src/nauro/store/snapshot.py`: `resolve_diff_snapshots` returns `target.isoformat()` instead of `baseline_meta["timestamp"]`; docstring updated.
- `packages/nauro-core/src/nauro_core/operations/diff_since_last_session.py`: docstring only — `cutoff_date_used` is the requested cutoff. No code change to `_render_diff` / `ANCHOR_LINE_TEMPLATE`.
- `packages/nauro/tests/test_diff_since_last_session_parity.py`: anchor assertions verify the `requested ≤` value equals the requested cutoff (within seconds of `now - N days`) and is distinct from `resolved to baseline <ts>`; the `time_indexed_repo` fixture documents its 14-day backdated baseline.

**What to review**

- The cutoff is derived from `now()` per call, so two independent surface calls are no longer byte-identical on the days path. The parity tests compare envelopes modulo the clock-derived cutoff/anchor line (`_clock_invariant`) and check the cutoff's consistency separately. The session path (no cutoff) is unaffected and still asserts strict equality.

**What's deferred**

The 1.0.2 nauro-core/nauro release bump follows as a separate PR, matching the project's release pattern.

**Test plan**

- `.venv/bin/python -m pytest packages/nauro-core/tests/ packages/nauro/tests/ -q`: 2381 passed, 10 skipped.
- ruff check + format --check on `packages/`: clean.
