### PR TITLE
Bump nauro to 1.0.1

### DIFF
--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro"
-version = "1.0.0"
+version = "1.0.1"
 description = "Local CLI + MCP server: set your project's doctrine once, every connected AI agent inherits it."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
**Why**

`nauro` has been at `1.0.0` while seven changes accumulated on `main` (nauro-core moved to 1.0.1 separately). This cuts a patch release so the local CLI + stdio MCP surface ships them — most importantly the day-range diff anchor now showing the **requested** cutoff rather than the resolved baseline timestamp.

**What changes**

- `packages/nauro/pyproject.toml`: `version` `1.0.0` → `1.0.1`.

Release contents (nauro commits since `nauro-v1.0.0`):

- **#269** — anchor the day-range diff on the requested cutoff (`now − N days`), not the baseline timestamp.
- **#267** — fix the dead state-differ branch (`state_current.md`) so current-state changes diff semantically.
- **#265** — treat `SELECT:` pointers as discovery pointers.
- **#263** — add the public-contract snapshot test enforcing the 1.0 freeze.
- **#262** — `loop`: scheduled headless SELECT-checkpoint entry mode.
- **#261** — make `propose_decision(operation="update")` callable.
- **#260** — report the nauro package version in the stdio MCP server.

All additive / fixes — no curated `__all__` removal, no CLI/stdio schema or store-format change — so this is a patch under the 1.0 semver freeze. `__version__` resolves dynamically from package metadata, so no source string change is needed.

`nauro-core` stays at `1.0.1`: its only change since that tag is the `cutoff_date_used` docstring (#269), which is non-behavioral and rides a later nauro-core release. The cutoff fix itself lives in the `nauro` package (`resolve_diff_snapshots`) and works against the already-published nauro-core 1.0.1 kernel.

**After merge**

Push the release tag to trigger the PyPI publish workflow (`publish-nauro.yml`, `on: push: tags: nauro-v*`):

```
git tag nauro-v1.0.1 origin/main && git push origin nauro-v1.0.1
```
