### PR TITLE
Bump server.json to 1.0.1; make nauro PyPI publish idempotent (skip-existing)

### DIFF
--- a/.github/workflows/publish-nauro.yml
+++ b/.github/workflows/publish-nauro.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: packages/nauro/dist/
+          skip-existing: true
 
   publish-registry:
     needs: publish

--- a/server.json
+++ b/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Nauro-AI/nauro",
     "source": "github"
   },
-  "version": "1.0.0",
+  "version": "1.0.1",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "nauro",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
**Why**

The `nauro-v1.0.1` tag published `nauro 1.0.1` to PyPI successfully, but the `publish-registry` job failed at "Verify server.json version matches the release tag": `server.json` was still at `1.0.0` (both `.version` and `.packages[0].version`) because the 1.0.1 release bump (#270) updated `packages/nauro/pyproject.toml` but not `server.json`. So the PyPI release is live but the MCP registry was left advertising 1.0.0.

`server.json` is hand-bumped in the release PR (it was last updated in the 1.0.0 release, #259); nothing currently enforces it tracking the package version.

**What changes**

- `server.json`: `version` and `packages[0].version` `1.0.0` → `1.0.1`, matching the published package and the `nauro-v1.0.1` tag.
- `.github/workflows/publish-nauro.yml`: add `skip-existing: true` to the PyPI publish step. The two jobs are coupled (`publish-registry` `needs: publish`); without this, re-firing the tag to recover the registry publish would hard-fail on the already-uploaded 1.0.1 and block the registry job. `skip-existing` makes the publish step idempotent so release re-runs/recovery are safe.

**After merge**

Move the `nauro-v1.0.1` tag to this commit and re-push to re-fire the workflow; `publish` skips the existing PyPI upload and `publish-registry` then publishes `server.json` 1.0.1 to the MCP registry:

```
git tag -f nauro-v1.0.1 origin/main && git push --force origin nauro-v1.0.1
```

**Follow-up (not in this PR)**

Add a PR-time guard so `server.json` version can't drift from `packages/nauro/pyproject.toml` again (e.g. extend `scripts/check_single_sourced.py` or add a CI check), since the publish-time verify only catches it after the tag is cut.
