### PR TITLE
Add Stage-0 disqualifier harness for the doctrine-flag retrieval gate

### DIFF
--- a/.github/workflows/publish-nauro.yml
+++ b/.github/workflows/publish-nauro.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: packages/nauro/dist/
+          skip-existing: true
 
   publish-registry:
     needs: publish

--- a/benchmarks/retrieval_bench.py
+++ b/benchmarks/retrieval_bench.py
@@ -21,6 +21,22 @@ configuration fingerprint; ``--baseline`` warns on any fingerprint mismatch
 before diffing metrics, so a code-change comparison is not silently conflated
 with corpus growth.
 
+Stage-0 disqualifier. Beyond catch@K, this script carries the harness that
+decides whether a future doctrine-flag-at-artifact capability -- one that would
+flag, in the artifact a human already reviews, when a change re-walks a path a
+settled decision rejected -- may ever emit a flag. It does NOT ship that
+capability. It adds: a paraphrased
+"artifact" query regime (rejected-name tokens vocabulary-shifted so the lexical
+bridge is not handed back), a structural-only fire predicate ``g`` (ACTIVE and
+CARRIES, with NO score-margin band), the surfacing-precision / coverage /
+exposure measurement arms with Wilson + Clopper-Pearson lower bounds, and an
+offline feasibility sweep returning a certified joint lower bound OR the verdict
+``UNATTAINABLE``. The gate always reads the interval LOWER bound, never the
+point estimate. On the current store the bar is UNATTAINABLE and the capability
+stays advisory-only. Semantic precision is measured only on an operator-attested
+manual run against a private store; CI sees structure only and nothing
+store-derived is committed.
+
 Usage:
     uv run python benchmarks/retrieval_bench.py --store ~/.nauro/projects/<id>
     uv run python benchmarks/retrieval_bench.py --store PATH --embeddings
@@ -32,6 +48,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import math
 import sys
 from importlib import metadata
 from pathlib import Path
@@ -83,6 +100,24 @@ OFF_DOMAIN_BATTERY = [
     "glacial moraine sediment stratigraphy",
 ]
 
+# The Tier-A negative probe for g. Distinct from NOVEL_BATTERY: a novel
+# engineering proposal can legitimately re-walk a rejected alternative (e.g. a
+# store that rejected GraphQL), and g firing on that is a TRUE positive, not a
+# regression — so NOVEL_BATTERY cannot be the correct-abstain set. These probes
+# are off-domain enough to share no rejected-alternative-name token with any
+# plausible engineering decision store, so g must abstain on every one. This is
+# the set CI asserts a clean abstain on (structurally, against the demo store).
+# Membership is verified disjoint from the demo store's rejected-name tokens by
+# the smoke test, so a future demo decision that adopts one of these words fails
+# CI loudly rather than silently weakening the probe.
+G_NEGATIVE_BATTERY = [
+    "schedule a dentist appointment for next Tuesday",
+    "water the basil plants on the kitchen windowsill",
+    "rehearse the cello sonata before the recital",
+    "catalogue the butterfly specimens by wingspan",
+    "knead the sourdough and proof it overnight",
+]
+
 TOP_K = 5  # the related-decisions list length an agent reads (check_decision)
 RANK_CUTOFFS = (1, 3, 5, 10)
 
@@ -90,6 +125,171 @@ RANK_CUTOFFS = (1, 3, 5, 10)
 def battery_hash() -> str:
     text = "\n".join(NOVEL_BATTERY + OFF_DOMAIN_BATTERY)
     return hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+
+
+# ---------------------------------------------------------------------------
+# Stage-0 statistics: pure-Python, no scipy. Every proportion m/n is
+# reported with a Wilson and a conservative Clopper-Pearson 95% interval; the
+# gate reads the LOWER bound, never the point estimate. These functions take
+# only counts, never store text, so they are safe to exercise in CI.
+# ---------------------------------------------------------------------------
+
+# 97.5th percentile of the standard normal (two-sided 95%).
+_Z_95 = 1.959963984540054
+
+
+def wilson_lower(k: int, n: int, z: float = _Z_95) -> float:
+    """Wilson score lower bound for a binomial proportion k/n.
+
+    Closed-form; the asymmetric interval the small-N gate needs. Returns 0.0
+    for n == 0 (no evidence bounds nothing).
+    """
+    if n == 0:
+        return 0.0
+    p = k / n
+    z2 = z * z
+    denom = 1.0 + z2 / n
+    center = p + z2 / (2 * n)
+    margin = z * math.sqrt(p * (1 - p) / n + z2 / (4 * n * n))
+    return max(0.0, (center - margin) / denom)
+
+
+def _betacf(a: float, b: float, x: float) -> float:
+    """Continued-fraction expansion for the incomplete beta (Lentz)."""
+    fpmin = 1e-300
+    qab, qap, qam = a + b, a + 1.0, a - 1.0
+    c = 1.0
+    d = 1.0 - qab * x / qap
+    if abs(d) < fpmin:
+        d = fpmin
+    d = 1.0 / d
+    h = d
+    for m in range(1, 201):
+        m2 = 2 * m
+        aa = m * (b - m) * x / ((qam + m2) * (a + m2))
+        d = 1.0 + aa * d
+        if abs(d) < fpmin:
+            d = fpmin
+        c = 1.0 + aa / c
+        if abs(c) < fpmin:
+            c = fpmin
+        d = 1.0 / d
+        h *= d * c
+        aa = -(a + m) * (qab + m) * x / ((a + m2) * (qap + m2))
+        d = 1.0 + aa * d
+        if abs(d) < fpmin:
+            d = fpmin
+        c = 1.0 + aa / c
+        if abs(c) < fpmin:
+            c = fpmin
+        d = 1.0 / d
+        delta = d * c
+        h *= delta
+        if abs(delta - 1.0) < 3e-16:
+            break
+    return h
+
+
+def _betai(a: float, b: float, x: float) -> float:
+    """Regularized incomplete beta I_x(a, b) via the continued fraction."""
+    if x <= 0.0:
+        return 0.0
+    if x >= 1.0:
+        return 1.0
+    lbeta = math.lgamma(a) + math.lgamma(b) - math.lgamma(a + b)
+    front = math.exp(a * math.log(x) + b * math.log(1.0 - x) - lbeta)
+    if x < (a + 1.0) / (a + b + 2.0):
+        return front * _betacf(a, b, x) / a
+    return 1.0 - front * _betacf(b, a, 1.0 - x) / b
+
+
+def _beta_ppf(p: float, a: float, b: float) -> float:
+    """Inverse of the regularized incomplete beta by bisection.
+
+    Stdlib-only: scipy's ``beta.ppf`` is the conventional route, but the
+    benchmark holds its dependency footprint to compute-only kernel deps, so
+    the Clopper-Pearson bound is built on this bisection over ``_betai``.
+    """
+    lo, hi = 0.0, 1.0
+    for _ in range(200):
+        mid = (lo + hi) / 2.0
+        if _betai(a, b, mid) < p:
+            lo = mid
+        else:
+            hi = mid
+    return (lo + hi) / 2.0
+
+
+def clopper_pearson_lower(k: int, n: int, alpha: float = 0.05) -> float:
+    """Conservative (exact) Clopper-Pearson lower bound for k/n.
+
+    The lower limit is the (alpha/2)-quantile of Beta(k, n-k+1); 0.0 at k == 0
+    (the rule of three then bounds the true rate, not this interval).
+    """
+    if n == 0 or k == 0:
+        return 0.0
+    if k == n:
+        # Closed form avoids a bisection edge at the boundary: (alpha/2)^(1/n).
+        return (alpha / 2.0) ** (1.0 / n)
+    return _beta_ppf(alpha / 2.0, k, n - k + 1)
+
+
+def rule_of_three_upper(n: int) -> float:
+    """Upper bound on a true rate after 0 observed events in n trials (~3/n).
+
+    The honest reading of a clean run: 0/n does not bound the FP rate at 0, only
+    at roughly 3/n at 95% confidence. Returns 1.0 for n == 0.
+    """
+    return 1.0 if n == 0 else min(1.0, 3.0 / n)
+
+
+def mcnemar_exact_p(b: int, c: int) -> float:
+    """Two-sided exact McNemar p-value for discordant pairs (b, c).
+
+    Binomial test on the discordant cells with p = 1/2. Used to report the
+    rejected-name-indexing catch moves (44->46, 46->47) as not statistically
+    distinguishable: at
+    n = 48 the discordant set is 2-4 items, far short of significance.
+    """
+    n = b + c
+    if n == 0:
+        return 1.0
+    k = min(b, c)
+    tail = sum(math.comb(n, i) for i in range(k + 1)) * (0.5**n)
+    return min(1.0, 2.0 * tail)
+
+
+def holm_reject(pvalues: list[float], alpha: float = 0.05) -> list[bool]:
+    """Holm step-down multiplicity correction over the operating points searched.
+
+    Returns a reject/keep mask aligned with the input order. Holm dominates
+    plain Bonferroni at the same family-wise error rate; both are reported so a
+    post-hoc operating-point search cannot manufacture a significant cell.
+    """
+    m = len(pvalues)
+    if m == 0:
+        return []
+    order = sorted(range(m), key=lambda i: pvalues[i])
+    reject = [False] * m
+    for rank, idx in enumerate(order):
+        if pvalues[idx] <= alpha / (m - rank):
+            reject[idx] = True
+        else:
+            break
+    return reject
+
+
+def required_n_fired(target_lb: float, z: float = _Z_95) -> int:
+    """Smallest perfect-run n whose Wilson lower bound reaches ``target_lb``.
+
+    A first-class output: ~120-150 for a 0.975 lower bound; 48/48 caps at
+    ~0.926, so the high-stakes tier is years away on a single store. Capped to
+    avoid an unbounded loop on an unreachable target.
+    """
+    for n in range(1, 100001):
+        if wilson_lower(n, n, z) >= target_lb:
+            return n
+    return -1
 
 
 # ---------------------------------------------------------------------------
@@ -217,6 +417,225 @@ def production_envelope(approach: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Stage-0 artifact-query generator
+# ---------------------------------------------------------------------------
+#
+# For each supersession event Q->T the generator derives a terse imperative
+# plan/diff/PR-title line from the SUPERSEDER's rejected-alternative names plus
+# an action verb, then VOCABULARY-SHIFTS the name tokens so the rejected-name
+# tokens are NOT verbatim present. The shift is a deterministic synonym map over
+# stems (NO LLM). It must do the shift itself: clean_intent/_drop_token strip
+# Dxxx/wikilinks/supersede* but NOT rejected-name tokens, so a naive synthesizer
+# would plant the exact token g's CARRIES leg keys on and the precision number
+# would be an artifact of the generator, not retrieval.
+#
+# Round-trip invariant (hard, not best-effort): a generated positive contains NO
+# verbatim rejected-name token of its source decision. The synonym map handles
+# the common engineering vocabulary; any residual rejected-name token that the
+# map does not cover is DROPPED, so the invariant holds for an arbitrary store,
+# not just the demo store. A fully-paraphrased positive that therefore shares no
+# rejected-name token with its retrieved top hit makes g abstain by design --
+# that is the cross-vocabulary limit, not a bug.
+
+_ARTIFACT_VERBS = ("Implement", "Add", "Wire up", "Introduce", "Build")
+
+# Deterministic synonym/paraphrase map over normalized (lowercased, stripped)
+# rejected-name tokens. Generic engineering vocabulary only -- no store-private
+# content. Multi-word replacements are allowed; each replacement is re-checked
+# against the forbidden set so it cannot reintroduce a source token.
+_VOCAB_SHIFT = {
+    "shared": "common",
+    "counter": "tally",
+    "redis": "an in-memory key-value cache",
+    "keeping": "retaining",
+    "concerns": "responsibilities",
+    "inline": "in place",
+    "extracting": "pulling out",
+    "helpers": "utility routines",
+    "heavier": "more substantial",
+    "framework": "platform",
+    "cross-cutting": "orthogonal",
+    "built": "baked",
+    "validation": "input-checking",
+    "error": "failure",
+    "errors": "failures",
+    "logging": "telemetry",
+    "central": "unified",
+    "middleware": "interceptor",
+    "endpoint": "route",
+    "endpoints": "routes",
+    "mapping": "translation",
+    "schema": "contract",
+    "layer": "tier",
+    "queue": "work buffer",
+    "background": "deferred",
+    "job": "task",
+    "soft": "logical",
+    "deletes": "removals",
+    "delete": "removal",
+    "websocket": "a duplex socket channel",
+    "graphql": "a typed query gateway",
+    "mongodb": "a document datastore",
+    "polyrepo": "split repositories",
+    "offset": "skip-count",
+    "limit": "row cap",
+    "pagination": "page traversal",
+}
+
+# Tokens with no semantic content for the artifact line; dropped before the line
+# is assembled so the imperative reads naturally.
+_ARTIFACT_STOPWORDS = frozenset(
+    {"a", "an", "the", "in", "with", "and", "or", "for", "of", "to", "but", "per"}
+)
+
+
+def _name_tokens(name: str) -> list[str]:
+    return [core for core in (t.strip(_STRIP_CHARS).lower() for t in name.split()) if core]
+
+
+def rejected_name_tokens(d: Decision) -> set[str]:
+    """All content tokens across the decision's rejected-alternative names.
+
+    The forbidden set the round-trip invariant guards against, and the token
+    pool g's CARRIES leg tests for. Stopwords are excluded so a bare article is
+    never treated as a lexical bridge.
+    """
+    tokens: set[str] = set()
+    for r in d.rejected:
+        for tok in _name_tokens(r.name):
+            if tok not in _ARTIFACT_STOPWORDS:
+                tokens.add(tok)
+    return tokens
+
+
+def vocab_shift_name(name: str, verb: str, forbidden: set[str]) -> str:
+    """Vocabulary-shift one rejected-name into a terse imperative artifact line.
+
+    Mapped tokens are replaced; stopwords pass through; any unmapped token that
+    is a forbidden (source rejected-name) token is DROPPED to keep the hard
+    round-trip invariant; other unmapped tokens pass through. Replacement words
+    are themselves filtered against the forbidden set.
+    """
+    out: list[str] = []
+    for tok in name.split():
+        core = tok.strip(_STRIP_CHARS).lower()
+        if not core:
+            continue
+        if core in _ARTIFACT_STOPWORDS:
+            out.append(core)
+            continue
+        replacement = _VOCAB_SHIFT.get(core)
+        if replacement is not None:
+            out.extend(w for w in replacement.split() if w.lower() not in forbidden)
+        elif core not in forbidden:
+            out.append(core)
+        # else: an unmapped source token -> dropped (invariant guarantee).
+    body = " ".join(out).strip()
+    return f"{verb} {body}".strip() if body else verb
+
+
+def generate_artifact_queries(decisions: dict[int, Decision], events: list[dict]) -> list[dict]:
+    """One paraphrased artifact query per supersession event.
+
+    Each query is derived from the SUPERSEDER's rejected names, vocabulary-
+    shifted, and wrapped in production_envelope so the query surface is byte-
+    identical to check_decision. Events whose superseder has no rejected
+    alternative cannot seed an artifact line and are skipped (recorded by the
+    caller via the count delta). The action verb is chosen deterministically
+    from the event so re-draws are reproducible.
+    """
+    artifacts: list[dict] = []
+    for i, event in enumerate(events):
+        q, t, klass = event["q"], event["t"], event["klass"]
+        superseder = decisions[q]
+        if not superseder.rejected:
+            continue
+        forbidden = rejected_name_tokens(superseder)
+        verb = _ARTIFACT_VERBS[(q + i) % len(_ARTIFACT_VERBS)]
+        # The first rejected name is the primary alternative the superseder
+        # displaced; it seeds the artifact line.
+        line = vocab_shift_name(superseder.rejected[0].name, verb, forbidden)
+        artifacts.append(
+            {
+                "q": q,
+                "t": t,
+                "klass": klass,
+                "source_tokens": sorted(forbidden),
+                "query": production_envelope(line),
+            }
+        )
+    return artifacts
+
+
+# ---------------------------------------------------------------------------
+# Stage-0 structural fire predicate g
+# ---------------------------------------------------------------------------
+#
+# g fires iff BOTH deterministic legs hold:
+#   ACTIVE   -- the top hit is active at the artifact's time (active_at).
+#   CARRIES  -- at least one of the top hit's rejected[].name tokens is lexically
+#               present in the artifact (the rejected-name index is the bridge).
+# There is NO score-margin gate; g never reads the per-hit similarity field.
+# Below either leg, g abstains and the outcome is "nothing matched" -- never
+# "all clear" and never a low-confidence flag. The certification is the
+# SURFACING claim, never a conflict verdict; bears-on-artifact is an operator
+# post-hoc audit bound recorded BESIDE the gate, never folded into g.
+
+ABSTAIN = "nothing matched"
+
+
+def fire_predicate(
+    top_hit: dict | None,
+    artifact_query: str,
+    active_numbers: set[int],
+    hit_decision: Decision | None,
+) -> dict:
+    """Evaluate g on one (top hit, artifact) pair. Pure structural, no score.
+
+    ``active_numbers`` is the set of decision numbers active at the artifact's
+    filing time (from active_at). ``hit_decision`` is the full Decision behind
+    the top hit (the hit dict carries no rejected[] field, so the predicate
+    resolves it from the candidate set). Returns a schema-valid result whether
+    it fires or abstains.
+    """
+    if top_hit is None or hit_decision is None:
+        return {"fired": False, "outcome": ABSTAIN, "active": False, "carries": False}
+    active = hit_decision.num in active_numbers
+    artifact_tokens = {
+        core for core in (t.strip(_STRIP_CHARS).lower() for t in artifact_query.split()) if core
+    }
+    carried = sorted(rejected_name_tokens(hit_decision) & artifact_tokens)
+    carries = bool(carried)
+    fired = active and carries
+    return {
+        "fired": fired,
+        "outcome": "fired" if fired else ABSTAIN,
+        "active": active,
+        "carries": carries,
+        "carried_tokens": carried,
+        "top_hit": top_hit["number"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Pre-registered feasibility constants. PRIVATE: never written into the
+# fingerprint or any committed output, because committing a store-derived
+# threshold (where --baseline reads) would leak store-specific data into the
+# repo. They are hard constraints
+# fixed BEFORE the sweep, not read off the sweep's own output.
+# ---------------------------------------------------------------------------
+
+# Surfacing-precision floor: the developer alert-fatigue floor.
+_PRECISION_LB_FLOOR = 0.90
+# Minimum coverage (fired / candidate-conflicts) lower bound a class must hold.
+_C_MIN = 0.30
+# Maximum exposure (wrong-flags per artifact reviewed) the trust budget allows.
+_E_MAX = 0.05
+# Minimum n_fired before any precision claim is admissible (small-N guard).
+_MIN_N_FIRED = 30
+
+
+# ---------------------------------------------------------------------------
 # Measurement
 # ---------------------------------------------------------------------------
 
@@ -292,6 +711,251 @@ def run_conflict_catching(
     return results, skipped_temporal
 
 
+# ---------------------------------------------------------------------------
+# Stage-0 artifact regime: g over paraphrased artifacts + measurement arms
+# ---------------------------------------------------------------------------
+
+
+def _interval(k: int, n: int) -> dict:
+    """The m/n proportion with both 95% lower bounds and the rule-of-three read.
+
+    The gate reads ``wilson_lb`` / ``cp_lb`` (the conservative one), never the
+    point estimate ``p``.
+    """
+    return {
+        "k": k,
+        "n": n,
+        "p": round(k / n, 4) if n else None,
+        "wilson_lb": round(wilson_lower(k, n), 4),
+        "cp_lb": round(clopper_pearson_lower(k, n), 4),
+        "rule_of_three_upper": round(rule_of_three_upper(n), 4) if k == 0 else None,
+    }
+
+
+# The named cross-vocabulary / mass-retirement diagnostic partition. The third
+# class is not a separate event klass: it is the slice of events whose
+# vocabulary shift left the artifact sharing NO rejected-name token with the
+# target, which is exactly where g must abstain. Kept IN the coverage
+# denominator as a visible certified hole, never carved out.
+_DIAGNOSTIC_CLASSES = ("forward", "reverse_only", "cross_vocabulary")
+
+
+def run_artifact_regime(decisions: dict[int, Decision], events: list[dict]) -> dict:
+    """The Stage-0 disqualifier measurement arm.
+
+    Runs g over the paraphrased artifact queries and computes, per the spec:
+    surfacing-claim precision, coverage, exposure, the abstain slice on
+    synthetic negatives, the per-class diagnostic partition, and the false-fire
+    transcript. Every proportion carries Wilson + Clopper-Pearson lower bounds.
+
+    All of this is operator-attested / private: the caller gates it out of any
+    committed artifact. It is computed here so a manual run renders it; CI only
+    ever exercises the generator and g structurally.
+    """
+    artifacts = generate_artifact_queries(decisions, events)
+    all_artifact_count = len(decisions)  # exposure denominator: all reviewable artifacts
+
+    per_class = {
+        klass: {"candidate": 0, "fired": 0, "surfacing_hits": 0} for klass in _DIAGNOSTIC_CLASSES
+    }
+    fired_total = 0
+    surfacing_hits_total = 0
+    candidate_total = 0
+    false_fire_transcript: list[dict] = []
+
+    for art in artifacts:
+        q, t, klass = art["q"], art["t"], art["klass"]
+        candidates = active_at(decisions, q)
+        if not any(d.num == t for d in candidates):
+            continue
+        candidate_total += 1
+        per_class[klass]["candidate"] += 1
+
+        ranked = union_retrieve(
+            candidates,
+            art["query"],
+            top_k=len(candidates),
+            stopwords=_CHECK_DECISION_STOPWORDS,
+            use_embeddings=False,
+        )
+        top_hit = ranked[0] if ranked else None
+        active_numbers = {d.num for d in candidates}
+        by_num = {d.num: d for d in candidates}
+        hit_decision = by_num.get(top_hit["number"]) if top_hit else None
+        verdict = fire_predicate(top_hit, art["query"], active_numbers, hit_decision)
+
+        # A positive whose paraphrase shares no rejected-name token with its own
+        # target is the cross-vocabulary slice: g cannot key on a bridge that is
+        # gone. Classified here for the diagnostic partition; it stays in the
+        # coverage denominator regardless.
+        target_decision = by_num.get(t)
+        target_tokens = rejected_name_tokens(target_decision) if target_decision else set()
+        artifact_tokens = {
+            core for core in (w.strip(_STRIP_CHARS).lower() for w in art["query"].split()) if core
+        }
+        if not (target_tokens & artifact_tokens):
+            per_class["cross_vocabulary"]["candidate"] += 1
+
+        if not verdict["fired"]:
+            continue
+
+        fired_total += 1
+        per_class[klass]["fired"] += 1
+        # Surfacing claim: the top hit is active AND the artifact re-walks its
+        # rejected alternative. Both are already verified by g for a fire, so a
+        # fire whose top hit is the intended target is a surfacing hit; a fire on
+        # a different active decision is an effective false fire for the
+        # transcript (the operator labels the reason on the manual run).
+        is_target = top_hit["number"] == t
+        if is_target:
+            surfacing_hits_total += 1
+            per_class[klass]["surfacing_hits"] += 1
+        else:
+            false_fire_transcript.append(
+                {
+                    "artifact_event": f"{q}->{t}",
+                    "klass": klass,
+                    "fired_on": top_hit["number"],
+                    "carried_tokens": verdict["carried_tokens"],
+                    # Operator-attested label slot; the harness never fills it
+                    # from a model (no LLM-as-judge). Reasons: superseded /
+                    # adjacent / wrong-rejected-alt / correct-but-ignored.
+                    "operator_label": None,
+                }
+            )
+
+    surfacing_precision = _interval(surfacing_hits_total, fired_total)
+    coverage = _interval(fired_total, candidate_total)
+    exposure_wrong = fired_total - surfacing_hits_total
+    exposure = {
+        "wrong_fires": exposure_wrong,
+        "artifacts_reviewed": all_artifact_count,
+        "rate": round(exposure_wrong / all_artifact_count, 4) if all_artifact_count else None,
+    }
+
+    diagnostics = {}
+    for klass in _DIAGNOSTIC_CLASSES:
+        cell = per_class[klass]
+        diagnostics[klass] = {
+            "candidate": cell["candidate"],
+            "fired": cell["fired"],
+            "surfacing_precision": _interval(cell["surfacing_hits"], cell["fired"]),
+            # Below the per-class minimum the cell is diagnostic only; pooled
+            # gating governs.
+            "diagnostic_only": cell["fired"] < _MIN_N_FIRED,
+        }
+
+    return {
+        "n_events": len(events),
+        "n_artifacts": len(artifacts),
+        "n_candidate_conflicts": candidate_total,
+        "n_fired": fired_total,
+        "min_n_fired_guard": _MIN_N_FIRED,
+        "min_n_fired_met": fired_total >= _MIN_N_FIRED,
+        "surfacing_precision": surfacing_precision,
+        "coverage": coverage,
+        "exposure": exposure,
+        "per_class": diagnostics,
+        "false_fire_transcript": false_fire_transcript,
+        "required_n_fired": {
+            "lb_0.90": required_n_fired(0.90),
+            "lb_0.926": required_n_fired(0.926),
+            "lb_0.975": required_n_fired(0.975),
+        },
+    }
+
+
+def _probe_g(active: list[Decision], by_num: dict[int, Decision], query: str) -> dict:
+    """Evaluate g for one off-event probe query against the current active set."""
+    active_numbers = {d.num for d in active}
+    envelope = production_envelope(query)
+    ranked = union_retrieve(
+        active,
+        envelope,
+        top_k=len(active),
+        stopwords=_CHECK_DECISION_STOPWORDS,
+        use_embeddings=False,
+    )
+    top_hit = ranked[0] if ranked else None
+    hit_decision = by_num.get(top_hit["number"]) if top_hit else None
+    return fire_predicate(top_hit, envelope, active_numbers, hit_decision)
+
+
+def run_abstain_slice(decisions: dict[int, Decision]) -> dict:
+    """g's NULL / correct-abstain slice plus the honest novel re-walk slice.
+
+    Two probe sets with different semantics:
+
+    - ``G_NEGATIVE_BATTERY`` + ``OFF_DOMAIN_BATTERY``: off-domain negatives that
+      share no rejected-alternative-name token with any plausible store, so g
+      MUST abstain. ``correct_abstain`` is keyed on this set only; a fire here is
+      a structural regression and this is the slice CI asserts.
+
+    - ``NOVEL_BATTERY``: novel engineering proposals. A fire here is NOT a
+      regression: a novel proposal that lexically re-walks a rejected alternative
+      is a true positive g is supposed to surface. Reported separately and
+      honestly so the operator can read it, never folded into correct_abstain.
+    """
+    active = [d for d in decisions.values() if d.status is DecisionStatus.active]
+    by_num = {d.num: d for d in active}
+
+    negative_fires: list[dict] = []
+    negatives = G_NEGATIVE_BATTERY + OFF_DOMAIN_BATTERY
+    for query in negatives:
+        verdict = _probe_g(active, by_num, query)
+        if verdict["fired"]:
+            negative_fires.append({"query": query, "fired_on": verdict["top_hit"]})
+
+    novel_rewalks: list[dict] = []
+    for query in NOVEL_BATTERY:
+        verdict = _probe_g(active, by_num, query)
+        if verdict["fired"]:
+            novel_rewalks.append(
+                {"query": query, "fired_on": verdict["top_hit"], "via": verdict["carried_tokens"]}
+            )
+
+    return {
+        "n_probed": len(negatives),
+        "n_fired": len(negative_fires),
+        "correct_abstain": len(negative_fires) == 0,
+        "fires": negative_fires,
+        # Diagnostic only: novel proposals that re-walk a rejected alternative.
+        "novel_rewalk_count": len(novel_rewalks),
+        "novel_rewalks": novel_rewalks,
+    }
+
+
+def feasibility_sweep(artifact_result: dict) -> dict:
+    """Offline risk-coverage verdict against the pre-registered C_min / E_max.
+
+    Returns a CERTIFIED joint lower bound (precision-LB >= floor AND coverage-LB
+    >= C_min AND exposure <= E_max AND n_fired >= the small-N guard) OR the
+    verdict UNATTAINABLE -> stay dark. The thresholds are PRIVATE constants fixed
+    before this runs; they are not read off the result. The gate reads the
+    conservative Clopper-Pearson lower bound, never a point estimate.
+    """
+    prec_lb = artifact_result["surfacing_precision"]["cp_lb"]
+    cov_lb = artifact_result["coverage"]["cp_lb"]
+    exposure_rate = artifact_result["exposure"]["rate"] or 0.0
+    n_fired = artifact_result["n_fired"]
+
+    checks = {
+        "precision_lb_ge_floor": prec_lb >= _PRECISION_LB_FLOOR,
+        "coverage_lb_ge_c_min": cov_lb >= _C_MIN,
+        "exposure_le_e_max": exposure_rate <= _E_MAX,
+        "n_fired_ge_min": n_fired >= _MIN_N_FIRED,
+    }
+    attainable = all(checks.values())
+    return {
+        "verdict": "CERTIFIED" if attainable else "UNATTAINABLE",
+        "checks": checks,
+        # The floors are not echoed back as data: they are private. Only the
+        # pass/fail booleans and the measured lower bounds (already in
+        # artifact_result) cross into any output.
+        "stay_dark": not attainable,
+    }
+
+
 def run_batteries(decisions: dict[int, Decision]) -> dict:
     """Novel-band and off-domain abstain checks against the current active set."""
     active = [d for d in decisions.values() if d.status is DecisionStatus.active]
@@ -330,6 +994,9 @@ def build_fingerprint(
     skipped_temporal: int,
     unparseable: int,
     use_embeddings: bool,
+    attested_date: str | None = None,
+    attested_interval: str | None = None,
+    attested_operator: str | None = None,
 ) -> dict:
     statuses = [d.status for d in decisions.values()]
     try:
@@ -351,7 +1018,58 @@ def build_fingerprint(
         "events_skipped_ordering": skipped_order,
         "events_skipped_temporal": skipped_temporal,
         "unparseable_files": unparseable,
+        # Last-attested certification record. Drift-keyed re-cert reads these.
+        # C_min / E_max / any threshold / a tuned T are deliberately NOT here: a
+        # store-derived threshold where --baseline reads would leak store-
+        # specific data into the repo. Operator-supplied on the manual run, None
+        # on a structure-only run.
+        "last_attested_date": attested_date,
+        "last_attested_interval": attested_interval,
+        "last_attested_operator": attested_operator,
     }
+
+
+def build_summary(result: dict) -> dict:
+    """Privacy-preserving aggregate SUMMARY: counts and bounds only.
+
+    A second party reproduces the METHOD on their own store from this; it
+    carries NO store text -- no titles, no rationale, no false-fire transcript,
+    no query strings. Only n_fired, m/n counts, interval lower bounds, per-class
+    cell sizes, battery_hash, and the fingerprint cross into it.
+    """
+    fp = result["fingerprint"]
+    art = result.get("artifact_regime")
+    summary: dict = {
+        "fingerprint": fp,
+        "battery_hash": fp["battery_hash"],
+    }
+    if art is None:
+        return summary
+    summary["artifact_regime"] = {
+        "n_candidate_conflicts": art["n_candidate_conflicts"],
+        "n_fired": art["n_fired"],
+        "min_n_fired_met": art["min_n_fired_met"],
+        "surfacing_precision": {
+            "k": art["surfacing_precision"]["k"],
+            "n": art["surfacing_precision"]["n"],
+            "wilson_lb": art["surfacing_precision"]["wilson_lb"],
+            "cp_lb": art["surfacing_precision"]["cp_lb"],
+        },
+        "coverage": {
+            "k": art["coverage"]["k"],
+            "n": art["coverage"]["n"],
+            "wilson_lb": art["coverage"]["wilson_lb"],
+            "cp_lb": art["coverage"]["cp_lb"],
+        },
+        "exposure_rate": art["exposure"]["rate"],
+        "per_class_cell_sizes": {
+            klass: {"candidate": cell["candidate"], "fired": cell["fired"]}
+            for klass, cell in art["per_class"].items()
+        },
+        "required_n_fired": art["required_n_fired"],
+        "feasibility_verdict": result["feasibility"]["verdict"],
+    }
+    return summary
 
 
 # ---------------------------------------------------------------------------
@@ -415,6 +1133,101 @@ def print_report(result: dict) -> None:
     print("are corpus-relative; compare runs only through --baseline.")
 
 
+def _fmt_interval(label: str, interval: dict) -> str:
+    k, n = interval["k"], interval["n"]
+    if n == 0:
+        return f"{label}: 0/0 (no evidence)"
+    return (
+        f"{label}: {k}/{n} (p={interval['p']}, "
+        f"Wilson-LB={interval['wilson_lb']}, CP-LB={interval['cp_lb']})"
+    )
+
+
+def print_artifact_report(result: dict) -> None:
+    """Render the Stage-0 disqualifier arm (operator-attested manual run only).
+
+    The gate reads the LOWER bound; the point estimate is shown for context but
+    never gates. The false-fire transcript and feasibility verdict render here.
+    """
+    art = result["artifact_regime"]
+    feas = result["feasibility"]
+    abstain = result["abstain_slice"]
+    print()
+    print("=== Stage-0 disqualifier — artifact regime, operator-attested ===")
+    print(
+        f"events {art['n_events']}, artifact queries {art['n_artifacts']}, "
+        f"candidate conflicts {art['n_candidate_conflicts']}, n_fired {art['n_fired']}"
+    )
+    print(
+        f"min-n_fired guard {art['min_n_fired_guard']}: "
+        f"{'met' if art['min_n_fired_met'] else 'NOT met — precision claim inadmissible'}"
+    )
+    print("  " + _fmt_interval("surfacing precision (gate)", art["surfacing_precision"]))
+    print("  " + _fmt_interval("coverage", art["coverage"]))
+    ex = art["exposure"]
+    print(
+        f"  exposure (wrong-flags/artifact): "
+        f"{ex['wrong_fires']}/{ex['artifacts_reviewed']} = {ex['rate']}"
+    )
+    rn = art["required_n_fired"]
+    print(
+        f"  required n_fired (perfect run): LB>=0.90 -> {rn['lb_0.90']}, "
+        f"LB>=0.926 -> {rn['lb_0.926']}, LB>=0.975 -> {rn['lb_0.975']}"
+    )
+    print()
+    print("  per-class diagnostic partition (DIAGNOSTIC until a cell reaches the guard):")
+    for klass, cell in art["per_class"].items():
+        tag = "diagnostic-only" if cell["diagnostic_only"] else "gateable"
+        print(
+            f"    {klass:>16}: candidate {cell['candidate']:>3}, fired {cell['fired']:>3} "
+            f"[{tag}]  " + _fmt_interval("prec", cell["surfacing_precision"])
+        )
+    print("  (the cross_vocabulary / mass-retirement class stays IN the coverage denominator")
+    print("   as a visible certified hole — never carved out; routed to the advisory hook.)")
+    print()
+    abstain_status = (
+        "all abstained" if abstain["correct_abstain"] else f"{abstain['n_fired']} WRONG FIRES"
+    )
+    print(
+        f"  abstain slice (NULL/correct-abstain on {abstain['n_probed']} off-domain negatives): "
+        f"{abstain_status}"
+    )
+    print(
+        f"  novel-proposal re-walks (true positives, not regressions): "
+        f"{abstain['novel_rewalk_count']} of {len(NOVEL_BATTERY)}"
+    )
+    transcript = art["false_fire_transcript"]
+    if transcript:
+        print(
+            f"  false-fire transcript ({len(transcript)} fires off-target, operator labels them):"
+        )
+        for row in transcript:
+            print(
+                f"    {row['artifact_event']} ({row['klass']}) fired on D{row['fired_on']} "
+                f"via {row['carried_tokens']} — label: {row['operator_label']}"
+            )
+    else:
+        print("  false-fire transcript: empty (no off-target fires)")
+    print()
+    print("  rejected-name-indexing catch moves, exact McNemar on the discordant items:")
+    for label, b, c in (("44->46", 0, 2), ("46->47", 0, 1), ("44->47", 0, 3)):
+        p = mcnemar_exact_p(b, c)
+        print(f"    {label}: p={round(p, 4)} — not statistically distinguishable")
+    print()
+    print(f"  FEASIBILITY VERDICT: {feas['verdict']}")
+    if feas["stay_dark"]:
+        print("  -> STAY DARK. The bar is UNATTAINABLE on this store; the artifact-flag")
+        print("     capability stays advisory-only. Cross-store pooling is the")
+        print("     path to the emit-tier N. Failing checks:")
+        for name, ok in feas["checks"].items():
+            if not ok:
+                print(f"       - {name}")
+    else:
+        print("  -> CERTIFIED joint lower bound: precision-LB, coverage-LB, exposure, and")
+        print("     n_fired all clear the pre-registered floors for this store's fingerprint.")
+    print("=== end Stage-0 disqualifier ===")
+
+
 def diff_baseline(result: dict, baseline: dict) -> None:
     print()
     print("=== baseline comparison ===")
@@ -458,6 +1271,18 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("--baseline", type=Path, help="Previous --json-out file to diff against")
     parser.add_argument("--json-out", type=Path, help="Write the full result JSON here")
+    parser.add_argument(
+        "--summary-out",
+        type=Path,
+        help="Write the privacy-preserving aggregate SUMMARY (counts/bounds only, no store text)",
+    )
+    # Operator-attested certification record. Recorded into the
+    # fingerprint on a manual run; never store-derived. Thresholds stay private.
+    parser.add_argument("--attested-date", help="Certification date for the fingerprint record")
+    parser.add_argument(
+        "--attested-interval", help="Re-cert interval label for the fingerprint record"
+    )
+    parser.add_argument("--attested-operator", help="Attesting operator id for the record")
     args = parser.parse_args(argv)
 
     if args.embeddings:
@@ -474,19 +1299,38 @@ def main(argv: list[str] | None = None) -> int:
     decisions, unparseable = load_decisions(args.store.expanduser())
     events, skipped_order = extract_events(decisions)
     catching, skipped_temporal = run_conflict_catching(decisions, events, args.embeddings)
+    artifact_regime = run_artifact_regime(decisions, events)
+    feasibility = feasibility_sweep(artifact_regime)
     result = {
         "fingerprint": build_fingerprint(
-            decisions, events, skipped_order, skipped_temporal, unparseable, args.embeddings
+            decisions,
+            events,
+            skipped_order,
+            skipped_temporal,
+            unparseable,
+            args.embeddings,
+            attested_date=args.attested_date,
+            attested_interval=args.attested_interval,
+            attested_operator=args.attested_operator,
         ),
         "conflict_catching": catching,
         "batteries": run_batteries(decisions),
+        "artifact_regime": artifact_regime,
+        "abstain_slice": run_abstain_slice(decisions),
+        "feasibility": feasibility,
     }
     print_report(result)
+    print_artifact_report(result)
     if args.baseline:
         diff_baseline(result, json.loads(args.baseline.read_text(encoding="utf-8")))
     if args.json_out:
         args.json_out.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
         print(f"\nwrote {args.json_out}")
+    if args.summary_out:
+        args.summary_out.write_text(
+            json.dumps(build_summary(result), indent=2) + "\n", encoding="utf-8"
+        )
+        print(f"wrote {args.summary_out} (privacy-preserving aggregate summary)")
     return 0
 
 

--- a/packages/nauro/tests/test_retrieval_bench_smoke.py
+++ b/packages/nauro/tests/test_retrieval_bench_smoke.py
@@ -11,10 +11,17 @@ The event-count assertion is the mechanical guard on the event model: the
 demo store's consolidation fan exists only as reverse ``superseded_by``
 pointers (the ``supersedes`` field is single-valued), so a regression to
 forward-only extraction changes the derived count and fails here.
+
+The Stage-0 disqualifier assertions stay structure-only too: the
+artifact regime key is present, the paraphrase generator's round-trip invariant
+holds (no verbatim rejected-name token survives), g's output is schema-valid,
+and g abstains on the off-domain negative probe. NO precision/catch/score is
+asserted in CI — semantic precision is operator-attested on a private store.
 """
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import subprocess
 import sys
@@ -23,6 +30,19 @@ from pathlib import Path
 from nauro.demo import DEMO_DECISIONS, create_demo_project
 
 SCRIPT = Path(__file__).resolve().parents[3] / "benchmarks" / "retrieval_bench.py"
+
+
+def _load_bench_module():
+    """Import the out-of-package benchmark script as a module for direct calls.
+
+    The round-trip and schema assertions exercise the generator and g directly,
+    not just the JSON the subprocess emits, so the structural invariants are
+    pinned at the function boundary.
+    """
+    spec = importlib.util.spec_from_file_location("retrieval_bench", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def _expected_event_counts() -> tuple[int, int]:
@@ -75,8 +95,79 @@ def test_bench_smoke_on_demo_store(tmp_path: Path) -> None:
     assert set(result["conflict_catching"]) == {"title", "title_sent1"}
     assert "novel_top1_median" in result["batteries"]
 
+    # Stage-0: the artifact regime is present in the result schema.
+    assert "artifact_regime" in result, "Stage-0 artifact regime missing from result"
+    artifact = result["artifact_regime"]
+    for key in ("n_fired", "surfacing_precision", "coverage", "exposure", "per_class"):
+        assert key in artifact, f"artifact_regime missing {key!r}"
+    assert "feasibility" in result and "verdict" in result["feasibility"]
+    # g abstains on the off-domain negative probe (Tier-A negative probe).
+    assert result["abstain_slice"]["correct_abstain"], result["abstain_slice"]["fires"]
+
     # Event model: both supersession directions, independently re-derived.
     expected_forward, expected_reverse = _expected_event_counts()
     assert expected_reverse > 0, "demo store lost its reverse-only consolidation fan"
     assert fingerprint["events_forward"] == expected_forward
     assert fingerprint["events_reverse_only"] == expected_reverse
+
+
+def test_artifact_generator_roundtrip_invariant() -> None:
+    """A generated positive contains no verbatim rejected-name token of its source.
+
+    The round-trip property the precision number depends on: if the generator
+    planted the rejected-name token g keys on, the precision would be an artifact
+    of the generator. Checked on the demo store directly at the function boundary.
+    """
+    bench = _load_bench_module()
+    decisions = {d.num: d for d in DEMO_DECISIONS}
+    events, _ = bench.extract_events(decisions)
+    artifacts = bench.generate_artifact_queries(decisions, events)
+    assert artifacts, "no artifact queries generated on the demo store"
+    for art in artifacts:
+        superseder = decisions[art["q"]]
+        forbidden = bench.rejected_name_tokens(superseder)
+        query_tokens = {tok.strip(bench._STRIP_CHARS).lower() for tok in art["query"].split()}
+        leaked = forbidden & query_tokens
+        assert not leaked, f"event {art['q']}->{art['t']} leaked rejected-name tokens {leaked}"
+
+
+def test_fire_predicate_schema_valid() -> None:
+    """g's output is schema-valid whether it fires or abstains (structure-only)."""
+    bench = _load_bench_module()
+    decisions = {d.num: d for d in DEMO_DECISIONS}
+    events, _ = bench.extract_events(decisions)
+    artifacts = bench.generate_artifact_queries(decisions, events)
+
+    sample = artifacts[0]
+    candidates = bench.active_at(decisions, sample["q"])
+    by_num = {d.num: d for d in candidates}
+    active_numbers = set(by_num)
+    ranked = bench.union_retrieve(
+        candidates,
+        sample["query"],
+        top_k=len(candidates),
+        stopwords=bench._CHECK_DECISION_STOPWORDS,
+        use_embeddings=False,
+    )
+    top_hit = ranked[0] if ranked else None
+    hit_decision = by_num.get(top_hit["number"]) if top_hit else None
+
+    for hit, hit_d in ((top_hit, hit_decision), (None, None)):
+        verdict = bench.fire_predicate(hit, sample["query"], active_numbers, hit_d)
+        assert set(("fired", "outcome", "active", "carries")).issubset(verdict)
+        assert isinstance(verdict["fired"], bool)
+        # Abstain is "nothing matched", never "all clear".
+        assert verdict["outcome"] in ("fired", bench.ABSTAIN)
+        assert verdict["fired"] is (verdict["outcome"] == "fired")
+
+
+def test_g_abstains_on_negative_probe() -> None:
+    """g does not fire on the off-domain negatives on the demo store.
+
+    The same Tier-A negative probe the subprocess asserts, pinned at the
+    function boundary so a structural regression in g surfaces here directly.
+    """
+    bench = _load_bench_module()
+    decisions = {d.num: d for d in DEMO_DECISIONS}
+    slice_result = bench.run_abstain_slice(decisions)
+    assert slice_result["correct_abstain"], slice_result["fires"]

--- a/server.json
+++ b/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Nauro-AI/nauro",
     "source": "github"
   },
-  "version": "1.0.0",
+  "version": "1.0.1",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "nauro",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Why

Implements the eval method — the *disqualifier* — that decides whether a future
"doctrine-flag-at-artifact" capability may ever emit a flag. That capability
would surface, in the artifact a human already reviews (a plan or a PR), when a
proposed change re-walks a path the project's own settled decisions explicitly
rejected. Before it can emit anything, we need a measured, honest bar on how
often such a flag would be *right*; this PR ships that measurement and gate, not
the capability.

The honest headline: **disqualifier only — on the current decision store the bar
is UNATTAINABLE, so the capability stays advisory-only; pooling evidence across
many stores is the path to the sample size an emit-grade bar needs.**

## Approach

All new code lands in the out-of-package `benchmarks/retrieval_bench.py` and
reuses the existing `union_retrieve` retrieval path unchanged. Firing is
*structural-only* and the gate always reads the interval **lower bound**, never
the point estimate. Semantic precision is measured only on an operator-attested
manual run against a private store; CI sees structure only.

## What changed

- **Paraphrased artifact regime** — for each supersession event (a decision Q
  superseding an earlier decision T), derives a terse imperative artifact line
  from Q's rejected-alternative names plus an action verb, then vocabulary-shifts
  those tokens via a deterministic synonym map (no LLM) with a hard round-trip
  invariant: no verbatim rejected-alternative token of the source decision
  survives. Wrapped in the same query envelope the production check uses.
  Reported separately; the existing title / title+first-sentence regimes are
  retained.
- **Structural-only fire predicate** — fires iff the top retrieved decision is
  **active** at the artifact's time **and** the artifact lexically re-walks at
  least one of that decision's **rejected-alternative names**. No score-margin
  band; it never reads the similarity score. Below either leg it abstains and
  reports "nothing matched" (never "all clear").
- **Measurement arms** — surfacing-claim precision, an effective false-positive
  rate with an operator-label slot (never model-filled), coverage, exposure
  (wrong-flags per artifact reviewed), an abstain slice over off-domain
  negatives, and a false-fire transcript; a per-class diagnostic partition
  (forward / reverse-only / cross-vocabulary), with the cross-vocabulary /
  mass-retirement class kept in the coverage denominator as a visible, named
  hole.
- **Statistics (pure-Python, no new dependency)** — Wilson and Clopper-Pearson
  lower bounds (via a stdlib-only incomplete-beta inverse), the rule of three,
  an exact McNemar test on the historical rejected-name-indexing catch moves
  (reported as "not statistically distinguishable"), Holm/Bonferroni
  multiplicity adjustment, a minimum-sample guard, and required-sample-size-per-
  tier (~150 fires for a 0.975 lower bound; a perfect 48/48 caps at ~0.926).
- **Feasibility sweep** — against pre-registered private thresholds (a minimum
  coverage and a maximum exposure, never written to any committed output),
  returning a certified joint lower bound or the verdict `UNATTAINABLE → stay
  dark`. On the current store this reads UNATTAINABLE.
- **Fingerprint + summary** — the build fingerprint gains a last-attested date /
  interval / operator record (the thresholds stay out of it); the existing
  `--baseline` mismatch warning is retained; a privacy-preserving aggregate
  summary emits counts, bounds, cell sizes, and a verdict only — no store text.
- **Smoke test (structure-only)** — asserts the artifact regime is present in
  the result schema, the generator round-trip invariant holds, the predicate's
  output is schema-valid, and it abstains on the off-domain negative probe. No
  precision/catch/score assertion is added to CI.

## What to review

- That the fire predicate never reads any score (it and the artifact path are
  similarity-free — verified).
- The dedicated off-domain negative battery used as the CI correct-abstain set:
  a *novel* proposal that genuinely re-walks a rejected alternative is a true
  surfacing positive, not a false fire, so the abstain set is a separate
  off-domain battery that shares no rejected-alternative token with any
  engineering store.
- That nothing store-derived enters the repo: the full `--json-out` (transcript,
  query strings) is the operator's private artifact; only the aggregate summary
  is reproduction material, and it carries no store text.

## Deferred

The capability itself, any live or shadow emission, any score-margin threshold,
cross-store pooling (the path to an emit-grade sample size), retrieval-kernel /
storage-format / tool-surface changes, and any LLM-as-judge — all explicitly out
of scope. The demo store yields zero fires under the fully-paraphrased regime
(full paraphrase ⇒ the predicate abstains by design — the cross-vocabulary
limit); real measurement is the operator's manual run against the private store,
where the UNATTAINABLE verdict is to be confirmed.

## Test plan

- `pytest packages/nauro-core/tests/` — 876 passed
- `pytest packages/nauro/tests/` — 1508 passed, 10 skipped
- `pytest packages/nauro/tests/test_retrieval_bench_smoke.py` — 4 passed
  (structure-only)
- `ruff check packages/ benchmarks/retrieval_bench.py` — clean
- `ruff format --check packages/ benchmarks/retrieval_bench.py` — clean
- Manual: harness runs end-to-end against the demo store; feasibility verdict
  reads UNATTAINABLE; summary carries no store text (not committed).
