### PR TITLE
Reject invalid 'nauro note --confidence' cleanly; drop a dead wrapper

### DIFF
--- a/packages/nauro-core/src/nauro_core/operations/propose_decision.py
+++ b/packages/nauro-core/src/nauro_core/operations/propose_decision.py
@@ -191,7 +191,7 @@ def propose_decision(
         else:
             action, reason = "pass", None
     else:
-        parsed = _parse_all_decisions(store)
+        parsed = parse_all_decisions(store)
         action, reason = _screen_structural(store, proposal, parsed, affected_decision_id)
 
     if action == "reject":
@@ -204,7 +204,7 @@ def propose_decision(
 
     # --- Tier 2: BM25 similarity (advisory only — does not gate the write) ---
     if parsed is None:
-        parsed = _parse_all_decisions(store)
+        parsed = parse_all_decisions(store)
     _t2_action, similar_raw = check_bm25_similarity(proposal, parsed)
     similar_models = _to_related_decisions(similar_raw, parsed)
 
@@ -333,16 +333,6 @@ def _update_hash_index(store: Store, title: str, rationale: str, decision_id: st
         "timestamp": datetime.now(timezone.utc).isoformat(),
     }
     _save_hash_index(store, index)
-
-
-def _parse_all_decisions(store: Store) -> list[Decision]:
-    """Read every decision from the store and parse via the v2 model.
-
-    Thin wrapper over the shared guarded scan: files that don't round-trip
-    through the v2 parser are logged at debug and skipped so they can sit on
-    disk during migrations without blocking the validation pipeline.
-    """
-    return parse_all_decisions(store)
 
 
 # ── Tier 2 result reshape ─────────────────────────────────────────────────

--- a/packages/nauro/src/nauro/cli/commands/note.py
+++ b/packages/nauro/src/nauro/cli/commands/note.py
@@ -2,6 +2,7 @@
 
 import typer
 from nauro_core.constants import DECISIONS_DIR, OPEN_QUESTIONS_MD
+from nauro_core.decision_model import DecisionConfidence
 from nauro_core.operations import flag_question as _flag_question_op
 from nauro_core.operations.propose_decision import _write_decision_direct
 
@@ -10,6 +11,23 @@ from nauro.store.decision_lock import decision_write_lock
 from nauro.store.filesystem_store import FilesystemStore
 from nauro.store.store_lock import store_write_lock
 from nauro.templates.agents_md_regen import warn_then_regen
+
+
+def _validate_confidence(value: str) -> str:
+    """Reject an invalid ``--confidence`` at parse time with a clean exit.
+
+    Kept as a string option (not a Typer enum) so the introspected CLI
+    contract stays ``text`` under the frozen public surface; the enum is the
+    source of truth for the accepted set. Without this, an unknown value
+    reaches ``DecisionConfidence(...)`` downstream and surfaces as a raw
+    ``ValueError`` traceback rather than a usage error.
+    """
+    try:
+        DecisionConfidence(value)
+    except ValueError as exc:
+        choices = ", ".join(c.value for c in DecisionConfidence)
+        raise typer.BadParameter(f"{value!r} is not one of {choices}.") from exc
+    return value
 
 
 def note(
@@ -42,6 +60,7 @@ def note(
         "--confidence",
         "-c",
         help="Confidence: high, medium, low.",
+        callback=_validate_confidence,
     ),
 ) -> None:
     """Record a decision or question in the project store."""


### PR DESCRIPTION
Two small fixes surfaced by a codebase-health audit. No public-contract drift — the frozen-surface snapshot test passes unchanged.

## 1. `nauro note --confidence` raw traceback → clean usage error
An unknown `--confidence` value passed straight through the string option and only failed later when `DecisionConfidence(...)` raised `ValueError` — which the filesystem-error wrapper doesn't catch, so it reached the user as a raw Python traceback.

Fix: validate in a callback that raises `typer.BadParameter`, producing a clean exit-2 usage error (`'bogus' is not one of high, medium, low.`). The option stays a **string** (not a Typer enum) deliberately, so the introspected public CLI contract is unchanged; the `DecisionConfidence` enum remains the single source of truth for the accepted set.

## 2. Inline the `_parse_all_decisions` indirection
The private `_parse_all_decisions` wrapper in `propose_decision.py` only returned `parse_all_decisions(store)`, which is already imported in the module. Call it directly at both sites and drop the wrapper.

## Verification
- Invalid `--confidence` → exit 2, no traceback; valid values unchanged; default `medium` unchanged.
- Public-contract / frozen-surface snapshot test: passes (the option's contract `type` stays `text`).
- Full `nauro` + `nauro-core` suites green.