### PR TITLE
Harden two CLI reads against malformed on-disk state

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/auth.py
+++ b/packages/nauro/src/nauro/cli/commands/auth.py
@@ -491,6 +491,8 @@ def status() -> None:
     """Show current authentication state."""
     config = load_config()
     auth = config.get("auth")
+    if not isinstance(auth, dict):
+        auth = {}
 
     if not auth or not auth.get("access_token"):
         typer.echo("Not authenticated. Run 'nauro auth login' to sign in.")

--- a/packages/nauro/src/nauro/store/registry.py
+++ b/packages/nauro/src/nauro/store/registry.py
@@ -228,7 +228,7 @@ def resolve_project(path: Path) -> str | None:
     registry = load_registry()
     path = path.resolve()
     for name, entry in registry["projects"].items():
-        for repo in entry["repo_paths"]:
+        for repo in entry.get("repo_paths", []):
             repo_resolved = Path(repo).resolve()
             if path == repo_resolved or repo_resolved in path.parents:
                 return name  # type: ignore[no-any-return]


### PR DESCRIPTION
Two defensive-read fixes surfaced by a CLI-command audit. Both previously surfaced as raw Python tracebacks because the shared filesystem-error wrapper catches only `OSError`, so a non-`OSError` from a command body escapes unrendered.

## Changes

**`store/registry.py` — `resolve_project()` reads `repo_paths` defensively**
The v1 resolution path subscripted `entry["repo_paths"]`, raising `KeyError` on a legacy or partially-written registry entry that lacks the key. Its sibling resolvers (`find_stale_paths`, the v2 path) already use `.get("repo_paths", [])`. Match them: a malformed entry is now skipped, not fatal.

**`cli/commands/auth.py` — `nauro auth status` guards the `auth` section type**
`status` called `auth.get(...)` on the `auth` config section without confirming it is a dict, raising `AttributeError` on a corrupted `config.json` (e.g. `{"auth": "corrupted"}`). Every other reader in the file already guards with `isinstance(auth, dict)`. Add the same guard; a non-dict section now reports `Not authenticated` (exit 1).

## Verification
- Repro'd both: corrupted non-dict `auth` → clean `Not authenticated` (exit 1, no traceback); v1 entry missing `repo_paths` → `resolve_project` returns `None`, no `KeyError`.
- No public-contract drift (internal reads only; no option/flag/default touched).
- Full `nauro` + `nauro-core` suites green; `ruff` clean.