### PR TITLE
Harden CLI command bodies against raw tracebacks from bad input/state

### DIFF
--- a/packages/nauro-core/src/nauro_core/operations/search_decisions.py
+++ b/packages/nauro-core/src/nauro_core/operations/search_decisions.py
@@ -62,6 +62,14 @@ def search_decisions(
             ),
         )
 
+    if limit < 1:
+        return SearchDecisionsResult(
+            error=ErrorPayload(
+                kind="rejected",
+                reason="search_decisions requires a positive limit.",
+            ),
+        )
+
     decisions = parse_all_decisions(store)
 
     if not include_superseded:

--- a/packages/nauro-core/src/nauro_core/search.py
+++ b/packages/nauro-core/src/nauro_core/search.py
@@ -57,7 +57,11 @@ def bm25_search(
     retriever = bm25s.BM25()
     retriever.index(corpus_tokens, show_progress=False)
 
-    k = min(limit, len(decisions))
+    # Clamp k into [0, N]: bm25s/numpy argpartition raises ValueError on a
+    # negative k, which a negative limit would otherwise pass straight through.
+    k = max(0, min(limit, len(decisions)))
+    if k == 0:
+        return []
     query_tokens = bm25s.tokenize([query], stopwords="en", stemmer=_stemmer, show_progress=False)
     results, scores = retriever.retrieve(query_tokens, k=k, show_progress=False)
 

--- a/packages/nauro-core/tests/operations/test_search_decisions.py
+++ b/packages/nauro-core/tests/operations/test_search_decisions.py
@@ -79,6 +79,14 @@ def test_whitespace_query_returns_rejection_error() -> None:
     assert result.error.kind == "rejected"
 
 
+def test_non_positive_limit_returns_rejection_error() -> None:
+    result = search_decisions(InMemoryStore(), "anything", limit=-1)
+    assert result.results == []
+    assert result.error is not None
+    assert result.error.kind == "rejected"
+    assert "limit" in result.error.reason
+
+
 def test_title_match_returns_hit_with_positive_score() -> None:
     stem, body = _seed_decision(
         1,

--- a/packages/nauro-core/tests/test_search.py
+++ b/packages/nauro-core/tests/test_search.py
@@ -75,6 +75,11 @@ class TestBm25Search:
         assert len(results) >= 1
         assert results[0]["title"] == "Use Auth0 for authentication"
 
+    def test_negative_limit_returns_empty_not_value_error(self):
+        """A negative limit must not reach numpy argpartition (k<0 raises ValueError)."""
+        assert bm25_search(DECISIONS, "authentication", limit=-1) == []
+        assert bm25_search(DECISIONS, "authentication", limit=0) == []
+
     def test_stemming_matches_vocabulary_variants(self):
         """'deploying' should match 'deployment' via stemming."""
         results = bm25_search(DECISIONS, "deploying Lambda")

--- a/packages/nauro/src/nauro/cli/_json_input.py
+++ b/packages/nauro/src/nauro/cli/_json_input.py
@@ -51,7 +51,10 @@ def parse_json_list_of_dicts(raw: str, flag_name: str) -> list[dict]:
         path = Path(raw[1:])
         if not path.exists() or not path.is_file():
             raise typer.BadParameter(f"{flag_name}: file '{path}' does not exist")
-        text = path.read_text(encoding="utf-8")
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError as exc:
+            raise typer.BadParameter(f"{flag_name}: file '{path}' is not valid UTF-8") from exc
     else:
         text = raw
 

--- a/packages/nauro/src/nauro/cli/commands/adopt.py
+++ b/packages/nauro/src/nauro/cli/commands/adopt.py
@@ -38,7 +38,11 @@ from nauro.cli.commands.setup import (
 from nauro.cli.utils import refuse_global_config_collision
 from nauro.constants import REGISTRY_SCHEMA_VERSION_V2, REPO_CONFIG_MODE_LOCAL
 from nauro.skills import load_adopt_body
-from nauro.store.registry import find_projects_by_name_v2, register_project_v2
+from nauro.store.registry import (
+    RegistrySchemaError,
+    find_projects_by_name_v2,
+    register_project_v2,
+)
 from nauro.store.repo_config import save_repo_config
 from nauro.telemetry import capture
 from nauro.telemetry.events import project_created
@@ -302,7 +306,10 @@ def adopt(
             [repo_root],
             mode=REPO_CONFIG_MODE_LOCAL,
         )
-    except ValueError as exc:
+    except (ValueError, RegistrySchemaError) as exc:
+        # RegistrySchemaError carries the one-time v1->v2 migration guidance;
+        # surface it cleanly instead of as a raw traceback (the collision
+        # pre-check swallows it and returns empty, so it only fires here).
         typer.echo(f"Error: {exc}", err=True)
         raise typer.Exit(code=1) from None
 

--- a/packages/nauro/src/nauro/cli/commands/auth.py
+++ b/packages/nauro/src/nauro/cli/commands/auth.py
@@ -491,6 +491,8 @@ def status() -> None:
     """Show current authentication state."""
     config = load_config()
     auth = config.get("auth")
+    if not isinstance(auth, dict):
+        auth = {}
 
     if not auth or not auth.get("access_token"):
         typer.echo("Not authenticated. Run 'nauro auth login' to sign in.")

--- a/packages/nauro/src/nauro/cli/commands/projects.py
+++ b/packages/nauro/src/nauro/cli/commands/projects.py
@@ -85,7 +85,14 @@ def remove_project(
     ),
 ) -> None:
     """Remove a project's registry entry, leaving its on-disk store intact."""
-    store_path = get_store_path_v2(project_id)
+    try:
+        store_path = get_store_path_v2(project_id)
+    except ValueError as exc:
+        # A project_id that escapes the projects root (e.g. ``..`` or an
+        # absolute path) trips the containment guard; reject it cleanly
+        # rather than surfacing a raw traceback.
+        typer.echo(f"Invalid project id {project_id!r}: {exc}", err=True)
+        raise typer.Exit(code=1) from None
     if not yes:
         typer.confirm(
             f"Remove registry entry for {project_id}? "

--- a/packages/nauro/src/nauro/mcp/tools.py
+++ b/packages/nauro/src/nauro/mcp/tools.py
@@ -590,9 +590,11 @@ def tool_get_raw_file(store_path: Path, path: str) -> dict:
 
     # Adapter-side traversal check. Distinct from the kernel-side
     # file-not-found case so callers get a clear "Invalid path" signal
-    # before any Store I/O.
-    resolved = (store_path / path).resolve()
+    # before any Store I/O. ``.resolve()`` is inside the guard because it
+    # itself raises ValueError on a path with an embedded NUL — same clean
+    # "Invalid path" rejection, not a raw traceback.
     try:
+        resolved = (store_path / path).resolve()
         resolved.relative_to(store_path.resolve())
     except ValueError:
         return {

--- a/packages/nauro/src/nauro/store/registry.py
+++ b/packages/nauro/src/nauro/store/registry.py
@@ -228,7 +228,7 @@ def resolve_project(path: Path) -> str | None:
     registry = load_registry()
     path = path.resolve()
     for name, entry in registry["projects"].items():
-        for repo in entry["repo_paths"]:
+        for repo in entry.get("repo_paths", []):
             repo_resolved = Path(repo).resolve()
             if path == repo_resolved or repo_resolved in path.parents:
                 return name  # type: ignore[no-any-return]

--- a/packages/nauro/src/nauro/store/snapshot.py
+++ b/packages/nauro/src/nauro/store/snapshot.py
@@ -350,7 +350,12 @@ def resolve_diff_snapshots(
     if days is not None:
         if not snapshots:
             return None, None, None
-        target = datetime.now(timezone.utc) - timedelta(days=days)
+        now = datetime.now(timezone.utc)
+        # Clamp an out-of-range lookback before it overflows the subtraction:
+        # a --days reaching past the earliest representable date just means
+        # "everything", so anchor at the oldest in-range instant instead.
+        max_days = (now - datetime.min.replace(tzinfo=timezone.utc)).days
+        target = now - timedelta(days=min(days, max_days))
         baseline_meta = find_snapshot_near_date(store_path, target)
         if baseline_meta is None:
             return None, None, None

--- a/packages/nauro/src/nauro/store/snapshot.py
+++ b/packages/nauro/src/nauro/store/snapshot.py
@@ -351,11 +351,15 @@ def resolve_diff_snapshots(
         if not snapshots:
             return None, None, None
         now = datetime.now(timezone.utc)
-        # Clamp an out-of-range lookback before it overflows the subtraction:
-        # a --days reaching past the earliest representable date just means
-        # "everything", so anchor at the oldest in-range instant instead.
+        # Clamp the lookback to the representable date range on both sides
+        # before the subtraction. A huge positive --days reaches past the
+        # earliest representable date and just means "everything" (anchor at
+        # the oldest in-range instant); a huge negative --days would push the
+        # target past datetime.max and overflow. In-range negatives still
+        # resolve to the most-recent snapshot.
         max_days = (now - datetime.min.replace(tzinfo=timezone.utc)).days
-        target = now - timedelta(days=min(days, max_days))
+        min_days = -((datetime.max.replace(tzinfo=timezone.utc) - now).days)
+        target = now - timedelta(days=max(min(days, max_days), min_days))
         baseline_meta = find_snapshot_near_date(store_path, target)
         if baseline_meta is None:
             return None, None, None

--- a/packages/nauro/tests/test_get_raw_file_parity.py
+++ b/packages/nauro/tests/test_get_raw_file_parity.py
@@ -104,3 +104,18 @@ def test_traversal_envelope_matches_across_surfaces(demo_repo):
     assert "available_files" not in stdio
     assert stdio["error"]["kind"] == "error"
     assert stdio["error"]["reason"] == f"Invalid path: {TRAVERSAL_PATH}"
+
+
+def test_nul_path_returns_rejection_not_raw_traceback(demo_repo):
+    pid, store_path = demo_repo
+    # An embedded NUL makes Path.resolve() raise ValueError before the
+    # traversal check; the adapter must convert it to the same "Invalid path"
+    # rejection envelope as traversal, not let a raw ValueError escape.
+    nul_path = "foo\x00bar"
+    tool = _tool_envelope(store_path, nul_path)
+    assert tool["store"] == "local"
+    assert "content" not in tool
+    assert tool["error"]["kind"] == "error"
+    assert tool["error"]["reason"] == f"Invalid path: {nul_path}"
+    # Same clean envelope across surfaces.
+    assert _stdio_envelope(pid, nul_path) == tool

--- a/packages/nauro/tests/test_log_diff.py
+++ b/packages/nauro/tests/test_log_diff.py
@@ -487,6 +487,17 @@ class TestDiffSinceLastSessionTimeBased:
         assert "v002" in result
         assert "v003" in result
 
+    def test_days_huge_negative_does_not_overflow(self, timed_store: Path):
+        """A huge negative days clamps instead of overflowing datetime arithmetic.
+
+        ``now - timedelta(days=-1e8)`` would push the target past datetime.max;
+        the two-sided clamp keeps the subtraction in range. The future cutoff
+        resolves to the most-recent snapshot, so the call returns cleanly
+        rather than raising OverflowError.
+        """
+        result = diff_since_last_session(timed_store, days=-100000000)
+        assert isinstance(result, str) and result
+
     def test_no_snapshots_graceful(self, store: Path):
         """days=7 with no snapshots returns graceful message."""
         result = diff_since_last_session(store, days=7)


### PR DESCRIPTION
Nine fixes from a CLI-command audit. Each turned a non-`OSError` raised in a command body — or on the auto-generated command path — into a raw Python traceback, because the CLI filesystem-error wrapper catches only `OSError`, so anything else (`ValueError`, `KeyError`, `OverflowError`, `UnicodeDecodeError`, `AttributeError`) escaped unrendered. None changes the introspected CLI surface, so the frozen public-contract snapshot is byte-identical and all nine ship as patches.

## Raw-traceback guards (bad CLI input)
- **`nauro adopt` on a legacy `schema_version: 1` registry** — `RegistrySchemaError` escaped the `except ValueError`, burying the migration message. Widened the clause (exit 1).
- **`nauro propose-decision --rejected @<non-utf8-file>`** — the `@file` read sat outside the helper's try/except, raising `UnicodeDecodeError`. Wrapped it → `BadParameter` (exit 2).
- **`nauro diff-since-last-session --days <huge>`** — overflowed the `datetime` subtraction. Clamped the lookback **on both sides** (huge positive = "everything"; huge negative would push past `datetime.max`). In-range negatives still resolve to the most-recent snapshot.
- **`nauro projects rm <escaping-id>`** (`..`, `/etc/passwd`) — tripped the path-containment `ValueError`. Caught it → clean exit 1.

## Numeric & path guards (auto-generated command path)
- **`nauro search-decisions --limit <0>`** — a negative limit flowed into bm25s/numpy `argpartition` (`ValueError: kth out of bounds`). The kernel now returns a structured `rejected` envelope for `limit < 1` (mirroring its empty-query path), and `bm25_search` clamps `k` into `[0, N]` as defense.
- **`nauro get-raw-file <path-with-embedded-NUL>`** — `(store_path / path).resolve()` raised `ValueError: embedded null character` *before* the traversal try/except. Moved `.resolve()` inside the guard so a NUL path returns the same `Invalid path` rejection envelope as a traversal attempt (clean on both CLI and stdio).

## Defensive reads (malformed on-disk state)
- **`store/registry.py` `resolve_project()`** — subscripted `entry["repo_paths"]`, raising `KeyError` on a legacy/partial registry entry. Use `.get("repo_paths", [])`, matching the sibling resolvers.
- **`nauro auth status`** — called `.get()` on the `auth` config section without a type check, raising `AttributeError` on a corrupted `config.json`. Added the `isinstance(auth, dict)` guard the other readers already have.

## Verification
- Each reproduced as fixed: clean exit/envelope + no traceback; normal paths unchanged (`--days 7`, valid `--limit`, traversal still rejected).
- No public-contract drift (no option/flag/default/type touched).
- Regression tests added for the numeric guards (leaf clamp, kernel rejection envelope, no-overflow) and the NUL path (cross-surface rejection envelope).
- Full `nauro` + `nauro-core` suites green (2388 passed); `ruff` clean.