### PR TITLE
Add a Rapid Cited Seed step to /nauro-adopt + default-off ADR extractor

### DIFF
--- a/.agents/skills/nauro-adopt/SKILL.md
+++ b/.agents/skills/nauro-adopt/SKILL.md
@@ -11,8 +11,54 @@ The agent helps the user seed Nauro with context from the current repo. Before t
 
 The agent's behaviour depends on whether the surface can read the repo directly.
 
-- **Filesystem-capable surfaces** (Claude Code, Cursor, Codex CLI). The agent runs Steps 1–11 in full. Docs are read for rationale in Step 3; code, config, tests, manifests, and recent git history are inspected for evidence in Step 4; targeted probes in Step 6b turn evidence into rationale by asking the user.
-- **Chat surfaces** (Claude.ai, Perplexity). The agent has no shell. It operates only on content the user pastes into the chat (Step 3b), and only against an already-adopted project (verified in Step 3b). Steps 1, 2, and 4 are filesystem-bound and are skipped on chat surfaces; the Step 6b probes are likewise unavailable, and the agent does not ask the user to paste code in lieu of running shell commands. The skill skips from Step 3b directly to Step 5.
+- **Filesystem-capable surfaces** (Claude Code, Cursor, Codex CLI). The agent runs Step 0 and Steps 1–11 in full. Step 0 is an optional rapid first pass that files only the decisions carrying two verifiable citations; Docs are read for rationale in Step 3; code, config, tests, manifests, and recent git history are inspected for evidence in Step 4; targeted probes in Step 6b turn evidence into rationale by asking the user.
+- **Chat surfaces** (Claude.ai, Perplexity). The agent has no shell. It operates only on content the user pastes into the chat (Step 3b), and only against an already-adopted project (verified in Step 3b). Step 0 is filesystem-only and is skipped on chat surfaces, exactly as Steps 1, 2, and 4 are; the Step 6b probes are likewise unavailable, and the agent does not ask the user to paste code in lieu of running shell commands. The skill skips from Step 3b directly to Step 5.
+
+## Step 0 — Rapid Cited Seed
+
+Filesystem-capable surfaces only; skipped on chat surfaces exactly as Steps 1, 2, and 4 are. Step 0 is a fast first pass that files only the decisions whose rationale and rejected alternative are each a verbatim span the agent can point at by `file:line`. It reads **no new surface** — only the same Step 3 doc set (README; manifests; CONTRIBUTING / ARCHITECTURE / DESIGN / CLAUDE.md / AGENTS.md; the ADR dirs; the Memory-Bank files). Steps 1–11 still run afterward as the deep follow-up; Step 0 never replaces them or lowers their bar. A thin or empty Step 0 is a correct outcome — disciplined refusal, not a missed number.
+
+### Step 0.1 — Draft cited cards
+
+The agent reads the Step 3 doc set and drafts decision **cards**. A card qualifies for the batch **only** when the agent can quote **two** verifiable spans from those docs:
+
+1. a **rationale** span — the documented "why" for the choice, and
+2. a **named rejected-alternative** span — a *distinct* option the source names and sets aside. The grammatical inverse of the choice ("we did not not-do X") is **not** a rejected alternative; the span must name a real second option (e.g. "Memcached", "a monolith", "the embedded adapter"). A deferred or conditional option the source holds open ("this may become valid later", "revisit after v2") is held open, not rejected — it does not satisfy the second span.
+
+Each span is quoted with its `file:line`. There is **no quota**: file as many cards as carry two honest spans — even one, even zero. Never pad to a number, never weaken a span to reach a count.
+
+The agent does not compose rationale. Every character of a card's rationale is either a span quoted from a doc or text the user types. The agent never writes a "why" of its own, never paraphrases prose into a rationale the source did not state, and never infers a rejected alternative the source did not name.
+
+Per card, the agent prepares:
+
+- **Title** (≤60 chars) and a one-line summary (≤140 chars).
+- **Rationale span (read-only)**, shown with its `file:line`. This is source text the agent surfaces; it is not an editable field.
+- **Rejected-alternative span (read-only)**, the named option plus its `file:line`.
+- **An empty "your why" field**, separate from the read-only spans, left blank for the user to fill or edit. The agent never pre-fills this field with the source span or with anything else — a human-supplied or human-edited "why" lives only here, never folded into the read-only span.
+- **Confidence** — `high` only when the source carries a literal ADR `Status: Accepted`; otherwise `medium`. Tone, emphasis, or a confident-sounding paragraph never promote to `high`.
+
+### Step 0.2 — Pre-check each card
+
+Before presenting the batch, the agent calls `check_decision(proposed_approach=<title plus the one-line summary>, project_id=...)` **once per card** and annotates each card with any overlap the pre-pass surfaces (the related decisions and the assessment line). This is the same pre-pass Step 7 step 1 runs; doing it up front lets the user see, on each card, whether it collides with a decision already in the store before the batch is confirmed.
+
+### Step 0.3 — One batch confirm
+
+The agent presents all cards as a single batch and waits for one reply:
+
+> Reply `confirm 1 3` / `skip 2` / `edit 3: <title>` / `confirm all` / `skip all`.
+
+`edit N: <title>` adjusts the title only; rationale stays the cited span. A user "why" goes through the separate empty field, never by editing a read-only span.
+
+### Step 0.4 — File confirmed cards through Step 7's write loop
+
+For each confirmed card, the agent files it through the **unchanged** Step 7 write loop — the screened `propose_decision` path described there. Step 0 never calls a direct-write bypass; it routes every card through the same screened proposal the rest of the skill uses.
+
+- The rationale written for a card carries its provenance as a free-text line inside the rationale body: `Source: <file>:<line>`. This is plain rationale text — not a new field — and it round-trips through the decision format unchanged.
+- The agent **captures the `propose_decision` return status for every card** and does not assume confirm means filed. A card can come back **rejected** even after the user confirmed it — most commonly when its normalized title collides with a card written earlier in the *same* batch (active-title dedup). The agent reports each rejected card by title and reason, and does not silently drop it.
+
+### Step 0.5 — Held-back surface
+
+Cards the agent saw but could **not** back with two honest spans never enter the batch. The agent lists them on a separate **held-back surface**: each candidate, the `file:line` it came from, and one line on why it was withheld (e.g. "rationale span present, no named rejected alternative"; "rejected option is conditional, not set aside"). These route into the existing Step 6b probe loop, where the user supplies the missing "why" and promotes the candidate. A held-back list — even a long one against a short filed list — is the disciplined result, not a shortfall.
 
 ## Step 1 — Detect repo root
 

--- a/.claude/skills/nauro-adopt/SKILL.md
+++ b/.claude/skills/nauro-adopt/SKILL.md
@@ -11,8 +11,54 @@ The agent helps the user seed Nauro with context from the current repo. Before t
 
 The agent's behaviour depends on whether the surface can read the repo directly.
 
-- **Filesystem-capable surfaces** (Claude Code, Cursor, Codex CLI). The agent runs Steps 1–11 in full. Docs are read for rationale in Step 3; code, config, tests, manifests, and recent git history are inspected for evidence in Step 4; targeted probes in Step 6b turn evidence into rationale by asking the user.
-- **Chat surfaces** (Claude.ai, Perplexity). The agent has no shell. It operates only on content the user pastes into the chat (Step 3b), and only against an already-adopted project (verified in Step 3b). Steps 1, 2, and 4 are filesystem-bound and are skipped on chat surfaces; the Step 6b probes are likewise unavailable, and the agent does not ask the user to paste code in lieu of running shell commands. The skill skips from Step 3b directly to Step 5.
+- **Filesystem-capable surfaces** (Claude Code, Cursor, Codex CLI). The agent runs Step 0 and Steps 1–11 in full. Step 0 is an optional rapid first pass that files only the decisions carrying two verifiable citations; Docs are read for rationale in Step 3; code, config, tests, manifests, and recent git history are inspected for evidence in Step 4; targeted probes in Step 6b turn evidence into rationale by asking the user.
+- **Chat surfaces** (Claude.ai, Perplexity). The agent has no shell. It operates only on content the user pastes into the chat (Step 3b), and only against an already-adopted project (verified in Step 3b). Step 0 is filesystem-only and is skipped on chat surfaces, exactly as Steps 1, 2, and 4 are; the Step 6b probes are likewise unavailable, and the agent does not ask the user to paste code in lieu of running shell commands. The skill skips from Step 3b directly to Step 5.
+
+## Step 0 — Rapid Cited Seed
+
+Filesystem-capable surfaces only; skipped on chat surfaces exactly as Steps 1, 2, and 4 are. Step 0 is a fast first pass that files only the decisions whose rationale and rejected alternative are each a verbatim span the agent can point at by `file:line`. It reads **no new surface** — only the same Step 3 doc set (README; manifests; CONTRIBUTING / ARCHITECTURE / DESIGN / CLAUDE.md / AGENTS.md; the ADR dirs; the Memory-Bank files). Steps 1–11 still run afterward as the deep follow-up; Step 0 never replaces them or lowers their bar. A thin or empty Step 0 is a correct outcome — disciplined refusal, not a missed number.
+
+### Step 0.1 — Draft cited cards
+
+The agent reads the Step 3 doc set and drafts decision **cards**. A card qualifies for the batch **only** when the agent can quote **two** verifiable spans from those docs:
+
+1. a **rationale** span — the documented "why" for the choice, and
+2. a **named rejected-alternative** span — a *distinct* option the source names and sets aside. The grammatical inverse of the choice ("we did not not-do X") is **not** a rejected alternative; the span must name a real second option (e.g. "Memcached", "a monolith", "the embedded adapter"). A deferred or conditional option the source holds open ("this may become valid later", "revisit after v2") is held open, not rejected — it does not satisfy the second span.
+
+Each span is quoted with its `file:line`. There is **no quota**: file as many cards as carry two honest spans — even one, even zero. Never pad to a number, never weaken a span to reach a count.
+
+The agent does not compose rationale. Every character of a card's rationale is either a span quoted from a doc or text the user types. The agent never writes a "why" of its own, never paraphrases prose into a rationale the source did not state, and never infers a rejected alternative the source did not name.
+
+Per card, the agent prepares:
+
+- **Title** (≤60 chars) and a one-line summary (≤140 chars).
+- **Rationale span (read-only)**, shown with its `file:line`. This is source text the agent surfaces; it is not an editable field.
+- **Rejected-alternative span (read-only)**, the named option plus its `file:line`.
+- **An empty "your why" field**, separate from the read-only spans, left blank for the user to fill or edit. The agent never pre-fills this field with the source span or with anything else — a human-supplied or human-edited "why" lives only here, never folded into the read-only span.
+- **Confidence** — `high` only when the source carries a literal ADR `Status: Accepted`; otherwise `medium`. Tone, emphasis, or a confident-sounding paragraph never promote to `high`.
+
+### Step 0.2 — Pre-check each card
+
+Before presenting the batch, the agent calls `check_decision(proposed_approach=<title plus the one-line summary>, project_id=...)` **once per card** and annotates each card with any overlap the pre-pass surfaces (the related decisions and the assessment line). This is the same pre-pass Step 7 step 1 runs; doing it up front lets the user see, on each card, whether it collides with a decision already in the store before the batch is confirmed.
+
+### Step 0.3 — One batch confirm
+
+The agent presents all cards as a single batch and waits for one reply:
+
+> Reply `confirm 1 3` / `skip 2` / `edit 3: <title>` / `confirm all` / `skip all`.
+
+`edit N: <title>` adjusts the title only; rationale stays the cited span. A user "why" goes through the separate empty field, never by editing a read-only span.
+
+### Step 0.4 — File confirmed cards through Step 7's write loop
+
+For each confirmed card, the agent files it through the **unchanged** Step 7 write loop — the screened `propose_decision` path described there. Step 0 never calls a direct-write bypass; it routes every card through the same screened proposal the rest of the skill uses.
+
+- The rationale written for a card carries its provenance as a free-text line inside the rationale body: `Source: <file>:<line>`. This is plain rationale text — not a new field — and it round-trips through the decision format unchanged.
+- The agent **captures the `propose_decision` return status for every card** and does not assume confirm means filed. A card can come back **rejected** even after the user confirmed it — most commonly when its normalized title collides with a card written earlier in the *same* batch (active-title dedup). The agent reports each rejected card by title and reason, and does not silently drop it.
+
+### Step 0.5 — Held-back surface
+
+Cards the agent saw but could **not** back with two honest spans never enter the batch. The agent lists them on a separate **held-back surface**: each candidate, the `file:line` it came from, and one line on why it was withheld (e.g. "rationale span present, no named rejected alternative"; "rejected option is conditional, not set aside"). These route into the existing Step 6b probe loop, where the user supplies the missing "why" and promotes the candidate. A held-back list — even a long one against a short filed list — is the disciplined result, not a shortfall.
 
 ## Step 1 — Detect repo root
 

--- a/.cursor/rules/nauro-adopt.mdc
+++ b/.cursor/rules/nauro-adopt.mdc
@@ -11,8 +11,54 @@ The agent helps the user seed Nauro with context from the current repo. Before t
 
 The agent's behaviour depends on whether the surface can read the repo directly.
 
-- **Filesystem-capable surfaces** (Claude Code, Cursor, Codex CLI). The agent runs Steps 1–11 in full. Docs are read for rationale in Step 3; code, config, tests, manifests, and recent git history are inspected for evidence in Step 4; targeted probes in Step 6b turn evidence into rationale by asking the user.
-- **Chat surfaces** (Claude.ai, Perplexity). The agent has no shell. It operates only on content the user pastes into the chat (Step 3b), and only against an already-adopted project (verified in Step 3b). Steps 1, 2, and 4 are filesystem-bound and are skipped on chat surfaces; the Step 6b probes are likewise unavailable, and the agent does not ask the user to paste code in lieu of running shell commands. The skill skips from Step 3b directly to Step 5.
+- **Filesystem-capable surfaces** (Claude Code, Cursor, Codex CLI). The agent runs Step 0 and Steps 1–11 in full. Step 0 is an optional rapid first pass that files only the decisions carrying two verifiable citations; Docs are read for rationale in Step 3; code, config, tests, manifests, and recent git history are inspected for evidence in Step 4; targeted probes in Step 6b turn evidence into rationale by asking the user.
+- **Chat surfaces** (Claude.ai, Perplexity). The agent has no shell. It operates only on content the user pastes into the chat (Step 3b), and only against an already-adopted project (verified in Step 3b). Step 0 is filesystem-only and is skipped on chat surfaces, exactly as Steps 1, 2, and 4 are; the Step 6b probes are likewise unavailable, and the agent does not ask the user to paste code in lieu of running shell commands. The skill skips from Step 3b directly to Step 5.
+
+## Step 0 — Rapid Cited Seed
+
+Filesystem-capable surfaces only; skipped on chat surfaces exactly as Steps 1, 2, and 4 are. Step 0 is a fast first pass that files only the decisions whose rationale and rejected alternative are each a verbatim span the agent can point at by `file:line`. It reads **no new surface** — only the same Step 3 doc set (README; manifests; CONTRIBUTING / ARCHITECTURE / DESIGN / CLAUDE.md / AGENTS.md; the ADR dirs; the Memory-Bank files). Steps 1–11 still run afterward as the deep follow-up; Step 0 never replaces them or lowers their bar. A thin or empty Step 0 is a correct outcome — disciplined refusal, not a missed number.
+
+### Step 0.1 — Draft cited cards
+
+The agent reads the Step 3 doc set and drafts decision **cards**. A card qualifies for the batch **only** when the agent can quote **two** verifiable spans from those docs:
+
+1. a **rationale** span — the documented "why" for the choice, and
+2. a **named rejected-alternative** span — a *distinct* option the source names and sets aside. The grammatical inverse of the choice ("we did not not-do X") is **not** a rejected alternative; the span must name a real second option (e.g. "Memcached", "a monolith", "the embedded adapter"). A deferred or conditional option the source holds open ("this may become valid later", "revisit after v2") is held open, not rejected — it does not satisfy the second span.
+
+Each span is quoted with its `file:line`. There is **no quota**: file as many cards as carry two honest spans — even one, even zero. Never pad to a number, never weaken a span to reach a count.
+
+The agent does not compose rationale. Every character of a card's rationale is either a span quoted from a doc or text the user types. The agent never writes a "why" of its own, never paraphrases prose into a rationale the source did not state, and never infers a rejected alternative the source did not name.
+
+Per card, the agent prepares:
+
+- **Title** (≤60 chars) and a one-line summary (≤140 chars).
+- **Rationale span (read-only)**, shown with its `file:line`. This is source text the agent surfaces; it is not an editable field.
+- **Rejected-alternative span (read-only)**, the named option plus its `file:line`.
+- **An empty "your why" field**, separate from the read-only spans, left blank for the user to fill or edit. The agent never pre-fills this field with the source span or with anything else — a human-supplied or human-edited "why" lives only here, never folded into the read-only span.
+- **Confidence** — `high` only when the source carries a literal ADR `Status: Accepted`; otherwise `medium`. Tone, emphasis, or a confident-sounding paragraph never promote to `high`.
+
+### Step 0.2 — Pre-check each card
+
+Before presenting the batch, the agent calls `check_decision(proposed_approach=<title plus the one-line summary>, project_id=...)` **once per card** and annotates each card with any overlap the pre-pass surfaces (the related decisions and the assessment line). This is the same pre-pass Step 7 step 1 runs; doing it up front lets the user see, on each card, whether it collides with a decision already in the store before the batch is confirmed.
+
+### Step 0.3 — One batch confirm
+
+The agent presents all cards as a single batch and waits for one reply:
+
+> Reply `confirm 1 3` / `skip 2` / `edit 3: <title>` / `confirm all` / `skip all`.
+
+`edit N: <title>` adjusts the title only; rationale stays the cited span. A user "why" goes through the separate empty field, never by editing a read-only span.
+
+### Step 0.4 — File confirmed cards through Step 7's write loop
+
+For each confirmed card, the agent files it through the **unchanged** Step 7 write loop — the screened `propose_decision` path described there. Step 0 never calls a direct-write bypass; it routes every card through the same screened proposal the rest of the skill uses.
+
+- The rationale written for a card carries its provenance as a free-text line inside the rationale body: `Source: <file>:<line>`. This is plain rationale text — not a new field — and it round-trips through the decision format unchanged.
+- The agent **captures the `propose_decision` return status for every card** and does not assume confirm means filed. A card can come back **rejected** even after the user confirmed it — most commonly when its normalized title collides with a card written earlier in the *same* batch (active-title dedup). The agent reports each rejected card by title and reason, and does not silently drop it.
+
+### Step 0.5 — Held-back surface
+
+Cards the agent saw but could **not** back with two honest spans never enter the batch. The agent lists them on a separate **held-back surface**: each candidate, the `file:line` it came from, and one line on why it was withheld (e.g. "rationale span present, no named rejected alternative"; "rejected option is conditional, not set aside"). These route into the existing Step 6b probe loop, where the user supplies the missing "why" and promotes the candidate. A held-back list — even a long one against a short filed list — is the disciplined result, not a shortfall.
 
 ## Step 1 — Detect repo root
 

--- a/docs/adopt-prompt.md
+++ b/docs/adopt-prompt.md
@@ -30,8 +30,54 @@ The agent helps the user seed Nauro with context from the current repo. Before t
 
 The agent's behaviour depends on whether the surface can read the repo directly.
 
-- **Filesystem-capable surfaces** (Claude Code, Cursor, Codex CLI). The agent runs Steps 1–11 in full. Docs are read for rationale in Step 3; code, config, tests, manifests, and recent git history are inspected for evidence in Step 4; targeted probes in Step 6b turn evidence into rationale by asking the user.
-- **Chat surfaces** (Claude.ai, Perplexity). The agent has no shell. It operates only on content the user pastes into the chat (Step 3b), and only against an already-adopted project (verified in Step 3b). Steps 1, 2, and 4 are filesystem-bound and are skipped on chat surfaces; the Step 6b probes are likewise unavailable, and the agent does not ask the user to paste code in lieu of running shell commands. The skill skips from Step 3b directly to Step 5.
+- **Filesystem-capable surfaces** (Claude Code, Cursor, Codex CLI). The agent runs Step 0 and Steps 1–11 in full. Step 0 is an optional rapid first pass that files only the decisions carrying two verifiable citations; Docs are read for rationale in Step 3; code, config, tests, manifests, and recent git history are inspected for evidence in Step 4; targeted probes in Step 6b turn evidence into rationale by asking the user.
+- **Chat surfaces** (Claude.ai, Perplexity). The agent has no shell. It operates only on content the user pastes into the chat (Step 3b), and only against an already-adopted project (verified in Step 3b). Step 0 is filesystem-only and is skipped on chat surfaces, exactly as Steps 1, 2, and 4 are; the Step 6b probes are likewise unavailable, and the agent does not ask the user to paste code in lieu of running shell commands. The skill skips from Step 3b directly to Step 5.
+
+## Step 0 — Rapid Cited Seed
+
+Filesystem-capable surfaces only; skipped on chat surfaces exactly as Steps 1, 2, and 4 are. Step 0 is a fast first pass that files only the decisions whose rationale and rejected alternative are each a verbatim span the agent can point at by `file:line`. It reads **no new surface** — only the same Step 3 doc set (README; manifests; CONTRIBUTING / ARCHITECTURE / DESIGN / CLAUDE.md / AGENTS.md; the ADR dirs; the Memory-Bank files). Steps 1–11 still run afterward as the deep follow-up; Step 0 never replaces them or lowers their bar. A thin or empty Step 0 is a correct outcome — disciplined refusal, not a missed number.
+
+### Step 0.1 — Draft cited cards
+
+The agent reads the Step 3 doc set and drafts decision **cards**. A card qualifies for the batch **only** when the agent can quote **two** verifiable spans from those docs:
+
+1. a **rationale** span — the documented "why" for the choice, and
+2. a **named rejected-alternative** span — a *distinct* option the source names and sets aside. The grammatical inverse of the choice ("we did not not-do X") is **not** a rejected alternative; the span must name a real second option (e.g. "Memcached", "a monolith", "the embedded adapter"). A deferred or conditional option the source holds open ("this may become valid later", "revisit after v2") is held open, not rejected — it does not satisfy the second span.
+
+Each span is quoted with its `file:line`. There is **no quota**: file as many cards as carry two honest spans — even one, even zero. Never pad to a number, never weaken a span to reach a count.
+
+The agent does not compose rationale. Every character of a card's rationale is either a span quoted from a doc or text the user types. The agent never writes a "why" of its own, never paraphrases prose into a rationale the source did not state, and never infers a rejected alternative the source did not name.
+
+Per card, the agent prepares:
+
+- **Title** (≤60 chars) and a one-line summary (≤140 chars).
+- **Rationale span (read-only)**, shown with its `file:line`. This is source text the agent surfaces; it is not an editable field.
+- **Rejected-alternative span (read-only)**, the named option plus its `file:line`.
+- **An empty "your why" field**, separate from the read-only spans, left blank for the user to fill or edit. The agent never pre-fills this field with the source span or with anything else — a human-supplied or human-edited "why" lives only here, never folded into the read-only span.
+- **Confidence** — `high` only when the source carries a literal ADR `Status: Accepted`; otherwise `medium`. Tone, emphasis, or a confident-sounding paragraph never promote to `high`.
+
+### Step 0.2 — Pre-check each card
+
+Before presenting the batch, the agent calls `check_decision(proposed_approach=<title plus the one-line summary>, project_id=...)` **once per card** and annotates each card with any overlap the pre-pass surfaces (the related decisions and the assessment line). This is the same pre-pass Step 7 step 1 runs; doing it up front lets the user see, on each card, whether it collides with a decision already in the store before the batch is confirmed.
+
+### Step 0.3 — One batch confirm
+
+The agent presents all cards as a single batch and waits for one reply:
+
+> Reply `confirm 1 3` / `skip 2` / `edit 3: <title>` / `confirm all` / `skip all`.
+
+`edit N: <title>` adjusts the title only; rationale stays the cited span. A user "why" goes through the separate empty field, never by editing a read-only span.
+
+### Step 0.4 — File confirmed cards through Step 7's write loop
+
+For each confirmed card, the agent files it through the **unchanged** Step 7 write loop — the screened `propose_decision` path described there. Step 0 never calls a direct-write bypass; it routes every card through the same screened proposal the rest of the skill uses.
+
+- The rationale written for a card carries its provenance as a free-text line inside the rationale body: `Source: <file>:<line>`. This is plain rationale text — not a new field — and it round-trips through the decision format unchanged.
+- The agent **captures the `propose_decision` return status for every card** and does not assume confirm means filed. A card can come back **rejected** even after the user confirmed it — most commonly when its normalized title collides with a card written earlier in the *same* batch (active-title dedup). The agent reports each rejected card by title and reason, and does not silently drop it.
+
+### Step 0.5 — Held-back surface
+
+Cards the agent saw but could **not** back with two honest spans never enter the batch. The agent lists them on a separate **held-back surface**: each candidate, the `file:line` it came from, and one line on why it was withheld (e.g. "rationale span present, no named rejected alternative"; "rejected option is conditional, not set aside"). These route into the existing Step 6b probe loop, where the user supplies the missing "why" and promotes the candidate. A held-back list — even a long one against a short filed list — is the disciplined result, not a shortfall.
 
 ## Step 1 — Detect repo root
 

--- a/packages/nauro-core/tests/test_decision_model.py
+++ b/packages/nauro-core/tests/test_decision_model.py
@@ -701,3 +701,64 @@ class TestSupersessionRefValidator:
                 status=DecisionStatus.superseded,
                 superseded_by="070",
             )
+
+
+class TestSourceCitationRoundTrip:
+    """A free-text ``Source: file:line`` citation inside the rationale.
+
+    The Rapid Cited Seed records the provenance of a documented decision as a
+    plain ``Source: <file>:<line>`` line in the rationale body. That line must
+    survive ``format_decision`` -> ``parse_decision`` byte-for-byte and must
+    never be mistaken for the ``## Rejected Alternatives`` anchor (the
+    rationale/rejected split keys on a whole-line ``## Rejected Alternatives``
+    heading, not on the word "Rejected" appearing in prose).
+    """
+
+    def test_citation_line_survives_round_trip(self) -> None:
+        rationale = (
+            "Chose a store-owned daemon as the single shared store writer.\n\n"
+            "Source: docs/adr/0003-shared-store-daemon.md:26"
+        )
+        decision = _minimal_decision(rationale=rationale)
+
+        formatted = format_decision(decision)
+        reparsed = parse_decision(formatted, "002-shared-store-daemon.md")
+
+        assert reparsed.rationale == rationale
+        assert "Source: docs/adr/0003-shared-store-daemon.md:26" in reparsed.rationale
+        # No rejected alternatives were declared, so the citation prose did not
+        # spuriously open a Rejected Alternatives section.
+        assert reparsed.rejected == []
+
+    def test_citation_does_not_break_rejected_anchor(self) -> None:
+        """A citation line sitting just above a real Rejected Alternatives
+        block must stay in the rationale; the anchor split is unaffected."""
+        rationale = (
+            "Daemon owns the shared store.\n\nSource: docs/adr/0003-shared-store-daemon.md:26"
+        )
+        decision = _minimal_decision(
+            rationale=rationale,
+            rejected=[
+                RejectedAlternative(
+                    name="Keep CLI-Only Embedded Access",
+                    reason="No central place for request ordering or admission control.",
+                ),
+            ],
+        )
+
+        formatted = format_decision(decision)
+        reparsed = parse_decision(formatted, "002-shared-store-daemon.md")
+
+        # The citation rides with the rationale, not the rejected section.
+        assert reparsed.rationale == rationale
+        assert "Source: docs/adr" in reparsed.rationale
+        assert [r.name for r in reparsed.rejected] == ["Keep CLI-Only Embedded Access"]
+        assert "Source:" not in (reparsed.rejected[0].reason or "")
+
+    def test_citation_with_literal_colon_line_byte_identical(self) -> None:
+        """Reformat is idempotent with the citation present (byte-identical)."""
+        rationale = "Pinned the store path outside the repo.\n\nSource: CLAUDE.md:12"
+        decision = _minimal_decision(num=2, rationale=rationale)
+        once = format_decision(decision)
+        twice = format_decision(parse_decision(once, "002-store-path.md"))
+        assert once == twice

--- a/packages/nauro/src/nauro/cli/commands/import_cmd.py
+++ b/packages/nauro/src/nauro/cli/commands/import_cmd.py
@@ -218,7 +218,12 @@ def _parse_and_import_decisions(content: str, store_path: Path) -> int:
     return count
 
 
-def _import_adrs(adr_dir: Path, store_path: Path) -> dict[str, Any]:
+def _import_adrs(
+    adr_dir: Path,
+    store_path: Path,
+    *,
+    strict_alternatives: bool = False,
+) -> dict[str, Any]:
     """Import Architecture Decision Records from a directory into the store.
 
     Scans for markdown files matching ADR naming patterns (NNN-title.md or
@@ -228,6 +233,14 @@ def _import_adrs(adr_dir: Path, store_path: Path) -> dict[str, Any]:
     Args:
         adr_dir: Path to directory containing ADR markdown files.
         store_path: Path to the target project store.
+        strict_alternatives: When True, rejected alternatives come from
+            ``_extract_adr_alternatives_strict`` — only ``### <title>``
+            subsections under an explicit ``## Alternatives Considered`` /
+            ``## Options Considered`` section, each carrying its verbatim body
+            as the reason. No ``## Consequences`` scraping and no placeholder
+            reason: an ADR that names no alternatives imports with no rejected
+            list. Defaults to False, which preserves the legacy
+            ``_extract_adr_rejected`` path byte-for-byte.
 
     Returns:
         Dict with counts: imported, skipped.
@@ -257,22 +270,12 @@ def _import_adrs(adr_dir: Path, store_path: Path) -> dict[str, Any]:
             continue
 
         rationale = _extract_adr_rationale(content)
-        rejected = _extract_adr_rejected(content)
         confidence = _extract_adr_confidence(content)
 
-        # ADR source format has no structured reason-per-alternative; attach a
-        # placeholder so the v2 validator (which requires a reason on every
-        # rejected alternative of an active decision) accepts the import. The
-        # placeholder makes the data gap explicit rather than fabricating prose.
-        structured_rejected: list[dict] | None = None
-        if rejected:
-            structured_rejected = [
-                {
-                    "alternative": alt,
-                    "reason": "Rejected reason not available in source ADR.",
-                }
-                for alt in rejected
-            ]
+        if strict_alternatives:
+            structured_rejected = _extract_adr_alternatives_strict(content)
+        else:
+            structured_rejected = _legacy_structured_rejected(content)
 
         _import_append_decision(
             store_path,
@@ -285,6 +288,26 @@ def _import_adrs(adr_dir: Path, store_path: Path) -> dict[str, Any]:
 
     counts["_skipped_reasons"] = skipped_reasons
     return counts
+
+
+def _legacy_structured_rejected(content: str) -> list[dict] | None:
+    """Legacy default rejected-alternative shape for ``nauro import --adr``.
+
+    ADR source format has no structured reason-per-alternative; attach a
+    placeholder so the v2 validator (which requires a reason on every rejected
+    alternative of an active decision) accepts the import. The placeholder makes
+    the data gap explicit rather than fabricating prose.
+    """
+    rejected = _extract_adr_rejected(content)
+    if not rejected:
+        return None
+    return [
+        {
+            "alternative": alt,
+            "reason": "Rejected reason not available in source ADR.",
+        }
+        for alt in rejected
+    ]
 
 
 def _extract_adr_title(content: str) -> str | None:
@@ -328,6 +351,133 @@ def _extract_adr_rejected(content: str) -> list[str] | None:
             return rejected
 
     return None
+
+
+# A subsection title under "## Alternatives Considered" that opens with one of
+# these deferred/conditional phrasings names an option the source explicitly
+# left open, not a rejected one. A "may become valid later" alternative is not a
+# named rejected-alternative span, so the strict extractor drops it rather than
+# recording it as rejected with no honest rejection rationale.
+# Forward-looking, held-open dispositions only. Phrase-anchored on purpose: a
+# bare "revisit"/"reconsider" would also match past-tense rejection narration
+# ("we revisited X and rejected it"), dropping a genuine rejection as held-open.
+_DEFERRED_OPTION_MARKERS: tuple[str, ...] = (
+    "may become",
+    "might become",
+    "may later",
+    "maybe later",
+    "could become",
+    "to be decided",
+    "tbd",
+    "deferred",
+    "defer until",
+    "revisit later",
+    "revisit after",
+    "revisit when",
+    "revisit once",
+    "reconsider later",
+    "reconsider once",
+    "postpone",
+)
+
+
+def _extract_adr_alternatives_strict(content: str) -> list[dict] | None:
+    """Extract NAMED rejected alternatives from an explicit alternatives section.
+
+    Strict, alternatives-aware companion to ``_extract_adr_rejected`` — opt-in
+    and never on the default ``nauro import --adr`` path. It reads only a
+    ``## Alternatives Considered`` or ``## Options Considered`` section, splits
+    it into ``### <title>`` subsections, and returns one entry per subsection
+    whose body verbatim is the rejection reason::
+
+        {"alternative": <title>, "reason": <verbatim body>, "offset": <int>}
+
+    ``offset`` is the character index of the ``### `` heading line in
+    ``content``, so a caller can derive a file:line citation for the span.
+
+    Deliberately narrow, by design:
+
+    - No ``## Consequences`` scraping — that fallback infers rejection from
+      prose, which fabricates a "why" the source never stated.
+    - When the source names no alternatives section, returns ``None`` (the
+      caller omits ``rejected`` entirely — no placeholder reason).
+    - A subsection whose body opens with a deferred/conditional marker (e.g.
+      "This may become valid later") is an option held open, not a named
+      rejection, and is skipped.
+
+    Returns ``None`` when there is no alternatives section or it yields no
+    honest named rejection; otherwise a non-empty list.
+    """
+    section = _find_alternatives_section(content)
+    if section is None:
+        return None
+    section_text, section_start = section
+
+    entries: list[dict] = []
+    for title, body, rel_offset in _iter_subsections(section_text):
+        if _is_deferred_option(body):
+            continue
+        if not body:
+            continue
+        entries.append(
+            {
+                "alternative": title,
+                "reason": body,
+                "offset": section_start + rel_offset,
+            }
+        )
+    return entries or None
+
+
+def _find_alternatives_section(content: str) -> tuple[str, int] | None:
+    """Return ``(section_body, body_start_offset)`` for the alternatives section.
+
+    Matches ``## Alternatives Considered`` or ``## Options Considered`` (case
+    insensitive). ``body_start_offset`` is the character index in ``content``
+    where the section body begins (just after the heading line). Returns
+    ``None`` when neither heading is present.
+    """
+    pattern = re.compile(
+        r"^##\s+(?:Alternatives|Options)\s+Considered\s*$",
+        re.MULTILINE | re.IGNORECASE,
+    )
+    m = pattern.search(content)
+    if not m:
+        return None
+    start = m.end()
+    next_heading = re.search(r"^##\s+", content[start:], re.MULTILINE)
+    body = content[start : start + next_heading.start()] if next_heading else content[start:]
+    return body, start
+
+
+def _iter_subsections(section_text: str):
+    """Yield ``(title, verbatim_body, offset)`` per ``### <title>`` subsection.
+
+    ``offset`` is the index of the ``###`` heading line within ``section_text``;
+    ``verbatim_body`` is the stripped text between this heading and the next
+    ``###`` (or end of section). The body is returned exactly as written — no
+    rewording, no summarization — so the reason is a quoted span, never composed.
+    """
+    heading = re.compile(r"^###\s+(.+?)\s*$", re.MULTILINE)
+    matches = list(heading.finditer(section_text))
+    for i, m in enumerate(matches):
+        title = m.group(1).strip()
+        body_start = m.end()
+        body_end = matches[i + 1].start() if i + 1 < len(matches) else len(section_text)
+        body = section_text[body_start:body_end].strip()
+        yield title, body, m.start()
+
+
+def _is_deferred_option(body: str) -> bool:
+    """True when a subsection body opens with a deferred/conditional marker.
+
+    Guards against recording an option the source held open ("may become valid
+    later") as a rejected alternative. Only the opening of the body is checked —
+    a marker buried mid-paragraph does not flip an otherwise-rejected option.
+    """
+    lowered = body.lstrip().lower()
+    opening = lowered[:200]
+    return any(marker in opening for marker in _DEFERRED_OPTION_MARKERS)
 
 
 def _extract_adr_confidence(content: str) -> str:

--- a/packages/nauro/src/nauro/skills/adopt_body.md
+++ b/packages/nauro/src/nauro/skills/adopt_body.md
@@ -12,8 +12,54 @@ The agent helps the user seed Nauro with context from the current repo. Before t
 
 The agent's behaviour depends on whether the surface can read the repo directly.
 
-- **Filesystem-capable surfaces** (Claude Code, Cursor, Codex CLI). The agent runs Steps 1–11 in full. Docs are read for rationale in Step 3; code, config, tests, manifests, and recent git history are inspected for evidence in Step 4; targeted probes in Step 6b turn evidence into rationale by asking the user.
-- **Chat surfaces** (Claude.ai, Perplexity). The agent has no shell. It operates only on content the user pastes into the chat (Step 3b), and only against an already-adopted project (verified in Step 3b). Steps 1, 2, and 4 are filesystem-bound and are skipped on chat surfaces; the Step 6b probes are likewise unavailable, and the agent does not ask the user to paste code in lieu of running shell commands. The skill skips from Step 3b directly to Step 5.
+- **Filesystem-capable surfaces** (Claude Code, Cursor, Codex CLI). The agent runs Step 0 and Steps 1–11 in full. Step 0 is an optional rapid first pass that files only the decisions carrying two verifiable citations; Docs are read for rationale in Step 3; code, config, tests, manifests, and recent git history are inspected for evidence in Step 4; targeted probes in Step 6b turn evidence into rationale by asking the user.
+- **Chat surfaces** (Claude.ai, Perplexity). The agent has no shell. It operates only on content the user pastes into the chat (Step 3b), and only against an already-adopted project (verified in Step 3b). Step 0 is filesystem-only and is skipped on chat surfaces, exactly as Steps 1, 2, and 4 are; the Step 6b probes are likewise unavailable, and the agent does not ask the user to paste code in lieu of running shell commands. The skill skips from Step 3b directly to Step 5.
+
+## Step 0 — Rapid Cited Seed
+
+Filesystem-capable surfaces only; skipped on chat surfaces exactly as Steps 1, 2, and 4 are. Step 0 is a fast first pass that files only the decisions whose rationale and rejected alternative are each a verbatim span the agent can point at by `file:line`. It reads **no new surface** — only the same Step 3 doc set (README; manifests; CONTRIBUTING / ARCHITECTURE / DESIGN / CLAUDE.md / AGENTS.md; the ADR dirs; the Memory-Bank files). Steps 1–11 still run afterward as the deep follow-up; Step 0 never replaces them or lowers their bar. A thin or empty Step 0 is a correct outcome — disciplined refusal, not a missed number.
+
+### Step 0.1 — Draft cited cards
+
+The agent reads the Step 3 doc set and drafts decision **cards**. A card qualifies for the batch **only** when the agent can quote **two** verifiable spans from those docs:
+
+1. a **rationale** span — the documented "why" for the choice, and
+2. a **named rejected-alternative** span — a *distinct* option the source names and sets aside. The grammatical inverse of the choice ("we did not not-do X") is **not** a rejected alternative; the span must name a real second option (e.g. "Memcached", "a monolith", "the embedded adapter"). A deferred or conditional option the source holds open ("this may become valid later", "revisit after v2") is held open, not rejected — it does not satisfy the second span.
+
+Each span is quoted with its `file:line`. There is **no quota**: file as many cards as carry two honest spans — even one, even zero. Never pad to a number, never weaken a span to reach a count.
+
+The agent does not compose rationale. Every character of a card's rationale is either a span quoted from a doc or text the user types. The agent never writes a "why" of its own, never paraphrases prose into a rationale the source did not state, and never infers a rejected alternative the source did not name.
+
+Per card, the agent prepares:
+
+- **Title** (≤60 chars) and a one-line summary (≤140 chars).
+- **Rationale span (read-only)**, shown with its `file:line`. This is source text the agent surfaces; it is not an editable field.
+- **Rejected-alternative span (read-only)**, the named option plus its `file:line`.
+- **An empty "your why" field**, separate from the read-only spans, left blank for the user to fill or edit. The agent never pre-fills this field with the source span or with anything else — a human-supplied or human-edited "why" lives only here, never folded into the read-only span.
+- **Confidence** — `high` only when the source carries a literal ADR `Status: Accepted`; otherwise `medium`. Tone, emphasis, or a confident-sounding paragraph never promote to `high`.
+
+### Step 0.2 — Pre-check each card
+
+Before presenting the batch, the agent calls `check_decision(proposed_approach=<title plus the one-line summary>, project_id=...)` **once per card** and annotates each card with any overlap the pre-pass surfaces (the related decisions and the assessment line). This is the same pre-pass Step 7 step 1 runs; doing it up front lets the user see, on each card, whether it collides with a decision already in the store before the batch is confirmed.
+
+### Step 0.3 — One batch confirm
+
+The agent presents all cards as a single batch and waits for one reply:
+
+> Reply `confirm 1 3` / `skip 2` / `edit 3: <title>` / `confirm all` / `skip all`.
+
+`edit N: <title>` adjusts the title only; rationale stays the cited span. A user "why" goes through the separate empty field, never by editing a read-only span.
+
+### Step 0.4 — File confirmed cards through Step 7's write loop
+
+For each confirmed card, the agent files it through the **unchanged** Step 7 write loop — the screened `propose_decision` path described there. Step 0 never calls a direct-write bypass; it routes every card through the same screened proposal the rest of the skill uses.
+
+- The rationale written for a card carries its provenance as a free-text line inside the rationale body: `Source: <file>:<line>`. This is plain rationale text — not a new field — and it round-trips through the decision format unchanged.
+- The agent **captures the `propose_decision` return status for every card** and does not assume confirm means filed. A card can come back **rejected** even after the user confirmed it — most commonly when its normalized title collides with a card written earlier in the *same* batch (active-title dedup). The agent reports each rejected card by title and reason, and does not silently drop it.
+
+### Step 0.5 — Held-back surface
+
+Cards the agent saw but could **not** back with two honest spans never enter the batch. The agent lists them on a separate **held-back surface**: each candidate, the `file:line` it came from, and one line on why it was withheld (e.g. "rationale span present, no named rejected alternative"; "rejected option is conditional, not set aside"). These route into the existing Step 6b probe loop, where the user supplies the missing "why" and promotes the candidate. A held-back list — even a long one against a short filed list — is the disciplined result, not a shortfall.
 
 ## Step 1 — Detect repo root
 

--- a/packages/nauro/tests/fixtures/adr/0003-shared-store-daemon.md
+++ b/packages/nauro/tests/fixtures/adr/0003-shared-store-daemon.md
@@ -1,0 +1,68 @@
+# ADR 0003: Use a store-owned daemon for shared store access
+
+## Status
+
+Accepted
+
+## Context
+
+Several agents write to one embedded key-value store. With more than one process
+opening a handle to the same embedded data directory, the service has multiple
+OS processes competing to own the same local store, and no clear multi-process
+coordination boundary.
+
+The service also owns concerns above raw storage:
+
+- schema validation and domain namespaces
+- redaction before persistence
+- idempotent agent writes
+- request admission, backpressure, and operational health
+
+A generic database pool in front of embedded handles would not solve the real
+problem. It would multiply store owners instead of defining one owner.
+
+## Decision
+
+Introduce a single store-owned local daemon as the primary shared writer and
+query service for multi-agent workflows.
+
+The daemon opens exactly one embedded store handle for a configured data
+directory and acquires an OS-level exclusive lease for that directory before
+serving requests. The CLI and other clients send requests to the daemon instead
+of independently opening the same store.
+
+Do not build a pool of embedded handles against the same data directory.
+
+## Alternatives Considered
+
+### Keep CLI-Only Embedded Access
+
+This is the simplest short-term shape, but it is unsafe as the default
+multi-agent architecture. It relies on every caller behaving well and gives no
+central place for request ordering, idempotency, or admission control.
+
+### Add a Local File Lock Around CLI Writes
+
+This is a useful emergency guard and should still be added for the embedded
+fallback. It prevents the worst concurrent writers, but it does not create a
+good shared read/write service. Agents would still repeatedly start processes,
+rebuild local state, and miss daemon-level observability.
+
+### Use the Embedded Engine's Daemon Directly
+
+This may become a valid storage transport if the embedded engine's own daemon
+exposes the needed primitives. The service still needs its own workflow layer
+for schemas, redaction, provenance, and session semantics, so direct access
+should be an adapter target, not the default surface.
+
+## Consequences
+
+Positive:
+
+- Multi-agent writes have one serialization and recovery boundary.
+- The CLI stays ergonomic while becoming a thin client for shared use.
+
+Negative:
+
+- The service now has a local daemon lifecycle to manage.
+- The daemon protocol becomes a compatibility surface and needs tests.

--- a/packages/nauro/tests/test_adopt_step0_seed_integration.py
+++ b/packages/nauro/tests/test_adopt_step0_seed_integration.py
@@ -1,0 +1,127 @@
+"""Integration: a Step-0 Rapid-Cited-Seed card reaches check_decision retrieval.
+
+Step 0 of the adopt skill files a documented decision through the same screened
+``propose_decision`` path the rest of the skill uses, with the source citation
+persisted as a free-text ``Source: file:line`` line in the rationale. This test
+exercises that seam end to end: file a ``num >= 2`` decision through the local
+``tool_propose_decision`` adapter (so it clears the scaffold-seed filter), then
+confirm the proactive ``check_decision`` retrieval hook actually fires against
+the seeded store on the 1.0.1 instruction floor — it is not aspirational prose.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from nauro_core import MCP_INSTRUCTIONS_STATIC
+
+from nauro.cli.commands.import_cmd import _extract_adr_alternatives_strict
+from nauro.constants import REPO_CONFIG_MODE_LOCAL
+from nauro.mcp.tools import tool_check_decision, tool_propose_decision
+from nauro.store.registry import register_project_v2
+from nauro.templates.scaffolds import scaffold_project_store
+
+# The Step-0 contract is "no model-composed why": every span a card carries is
+# either quoted verbatim from a source doc or typed by the human. This test
+# proves that end to end by deriving the seed's rejected reason from the strict
+# ADR extractor (the verbatim subsection body, not a paraphrase) and using a
+# rationale span quoted verbatim from the fixture's ## Decision section.
+FIXTURE_ADR = Path(__file__).parent / "fixtures" / "adr" / "0003-shared-store-daemon.md"
+
+# Verbatim span from the fixture's ## Decision section (asserted present below).
+_RATIONALE_SPAN = (
+    "Introduce a single store-owned local daemon as the primary shared writer and\n"
+    "query service for multi-agent workflows."
+)
+
+
+def _extracted_keep_cli_reason() -> str:
+    """The verbatim 'Keep CLI-Only Embedded Access' rejection reason, taken
+    straight from the strict extractor's output on the fixture ADR — so the seed
+    is the extractor's quoted span, never composed for the test."""
+    entries = _extract_adr_alternatives_strict(FIXTURE_ADR.read_text(encoding="utf-8"))
+    assert entries, "fixture must yield strict alternatives"
+    entry = next(e for e in entries if e["alternative"] == "Keep CLI-Only Embedded Access")
+    return entry["reason"]
+
+
+@pytest.fixture
+def seeded_store(tmp_path: Path) -> Path:
+    """A scaffolded store with one Step-0-shaped cited card filed (num >= 2).
+
+    The card is built the way Step 0.4 builds it: a rationale span quoted
+    verbatim from the source ADR plus a free-text Source: citation, and a named
+    rejected alternative whose reason is the strict extractor's verbatim
+    subsection body — nothing composed.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _pid, store_path = register_project_v2("step0-project", [repo], mode=REPO_CONFIG_MODE_LOCAL)
+    scaffold_project_store("step0-project", store_path)
+
+    result = tool_propose_decision(
+        store_path,
+        title="Use a store-owned daemon for shared store access",
+        rationale=(_RATIONALE_SPAN + "\n\nSource: docs/adr/0003-shared-store-daemon.md:26"),
+        operation="add",
+        rejected=[
+            {
+                "alternative": "Keep CLI-Only Embedded Access",
+                "reason": _extracted_keep_cli_reason(),
+            }
+        ],
+        confidence="high",
+    )
+    # The card came back filed (not rejected) and at num >= 2 (002, since the
+    # scaffold seed holds 001).
+    assert result["status"] == "confirmed", result
+    assert result["decision_id"].startswith("002-"), result["decision_id"]
+    return store_path
+
+
+def test_seeded_card_yields_non_empty_check_decision(seeded_store: Path):
+    """A num>=2 seeded decision surfaces on check_decision retrieval."""
+    envelope = tool_check_decision(
+        seeded_store, "Add a daemon to own shared store access for agents"
+    )
+
+    # The scaffold seed (001) is filtered from check_decision, so a non-empty
+    # result proves the num>=2 card — not the seed — was retrieved.
+    assert envelope["store"] == "local"
+    assert envelope.get("error") is None
+    assert envelope["related_decisions"], envelope
+    assert envelope["assessment"], envelope
+
+    titles = [hit["title"] for hit in envelope["related_decisions"]]
+    assert any("daemon" in t.lower() for t in titles), titles
+    # The deterministic assessment names a top match (the proactive hook's payload).
+    assert "Top match" in envelope["assessment"], envelope["assessment"]
+
+
+def test_citation_line_survives_into_seeded_decision(seeded_store: Path):
+    """The Source: citation and the extractor's verbatim rejection both persist
+    into the written decision — no paraphrase, no placeholder."""
+    decisions = sorted((seeded_store / "decisions").glob("*.md"))
+    card = next(d for d in decisions if d.name.startswith("002-"))
+    body = card.read_text(encoding="utf-8")
+    assert "Source: docs/adr/0003-shared-store-daemon.md:26" in body
+    # The rationale span is a verbatim quote from the fixture, not composed for the test.
+    assert _RATIONALE_SPAN in FIXTURE_ADR.read_text(encoding="utf-8")
+    # The named rejected alternative carries the extractor's VERBATIM reason end
+    # to end — not a paraphrase and not a placeholder.
+    assert "Keep CLI-Only Embedded Access" in body
+    assert _extracted_keep_cli_reason() in body
+    assert "Rejected reason not available in source ADR." not in body
+
+
+def test_proactive_check_decision_hook_present_on_floor():
+    """The 1.0.1 instruction floor carries the proactive check_decision hook.
+
+    Step 0's per-card pre-pass leans on the same proactive instruction that
+    tells an agent to call check_decision before responding to a change request.
+    Pin that the hook text ships, so the end-to-end retrieval above is wired to
+    a real instruction and not just an in-test convenience.
+    """
+    assert "check_decision" in MCP_INSTRUCTIONS_STATIC
+    assert "Before responding to any technical change request" in MCP_INSTRUCTIONS_STATIC

--- a/packages/nauro/tests/test_import.py
+++ b/packages/nauro/tests/test_import.py
@@ -6,6 +6,7 @@ import pytest
 from typer.testing import CliRunner
 
 from nauro.cli.commands.import_cmd import (
+    _extract_adr_alternatives_strict,
     _import_adrs,
     _import_memory_bank,
     _import_progress,
@@ -17,6 +18,8 @@ from nauro.store.snapshot import list_snapshots
 from nauro.templates.scaffolds import scaffold_project_store
 
 runner = CliRunner()
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
 
 
 @pytest.fixture
@@ -709,3 +712,154 @@ def test_import_adr_no_matching_files_warns(tmp_path: Path, monkeypatch):
     assert "0 ADR(s) imported" in result.output
     assert "Warning" in result.output
     assert "<NNN>-title.md" in result.output
+
+
+# ===========================================================================
+# Strict, alternatives-aware ADR extractor (opt-in; default-False path)
+# ===========================================================================
+
+
+def test_strict_extractor_named_rejections_verbatim_drops_conditional():
+    """The `### `-aware extractor on a MADR `## Alternatives Considered` section.
+
+    The 0003 ADR fixture names three `### ` options. Two are genuine
+    rejections; the third ("Use the Embedded Engine's Daemon Directly") opens
+    with a conditional "This may become a valid storage transport ..." and is an
+    option held open, not a named rejection. The strict extractor returns the
+    two rejections with their bodies verbatim, drops the conditional, and never
+    scrapes `## Consequences`.
+    """
+    content = (FIXTURES / "adr" / "0003-shared-store-daemon.md").read_text()
+
+    result = _extract_adr_alternatives_strict(content)
+    assert result is not None
+    alternatives = [entry["alternative"] for entry in result]
+
+    # Two named rejections; the conditional "may become" option is excluded.
+    assert alternatives == [
+        "Keep CLI-Only Embedded Access",
+        "Add a Local File Lock Around CLI Writes",
+    ]
+    assert "Use the Embedded Engine's Daemon Directly" not in alternatives
+
+    # Reason text is the verbatim subsection body — quoted, never composed.
+    first = result[0]
+    assert first["reason"].startswith("This is the simplest short-term shape")
+    assert "central place for request ordering" in first["reason"]
+    second = result[1]
+    assert second["reason"].startswith("This is a useful emergency guard")
+
+    # The offset points at the `### ` heading line so a caller can cite file:line.
+    assert content[first["offset"] :].startswith("### Keep CLI-Only Embedded Access")
+
+    # No `## Consequences` scraping: nothing from the Consequences list leaks in.
+    reasons = " ".join(entry["reason"] for entry in result)
+    assert "one serialization and recovery boundary" not in reasons
+
+
+def test_strict_extractor_no_alternatives_section_yields_none():
+    """An ADR with no `## Alternatives`/`## Options Considered` section yields
+    None — no fabricated rejection, no `## Consequences` fallback."""
+    content = (
+        "# Use PostgreSQL\n\n"
+        "## Context\n\nWe need ACID.\n\n"
+        "## Decision\n\nUse PostgreSQL.\n\n"
+        "## Consequences\n\n"
+        "- Bad, because it rules out SQLite as an alternative\n"
+    )
+    assert _extract_adr_alternatives_strict(content) is None
+
+
+def test_strict_extractor_options_considered_heading_supported():
+    """`## Options Considered` is recognized alongside `## Alternatives Considered`."""
+    content = (
+        "# Choose a queue\n\n"
+        "## Decision\n\nUse SQS.\n\n"
+        "## Options Considered\n\n"
+        "### RabbitMQ\n\n"
+        "Heavier ops burden for our load.\n\n"
+        "### Kafka\n\n"
+        "Overkill for low-volume events.\n"
+    )
+    result = _extract_adr_alternatives_strict(content)
+    assert result is not None
+    assert [e["alternative"] for e in result] == ["RabbitMQ", "Kafka"]
+    assert result[0]["reason"] == "Heavier ops burden for our load."
+    assert result[1]["reason"] == "Overkill for low-volume events."
+
+
+def test_strict_extractor_excludes_held_open_revisit_after_marker():
+    """A held-open option phrased "Revisit after v2 ..." is excluded, not recorded
+    as a rejection — matching the adopt skill's advertised "revisit after v2"
+    held-open example. Guards the deferred-marker set against fabricating a
+    rejection from a deferral the source left open."""
+    content = (
+        "# Choose a transport\n\n"
+        "## Decision\n\nUse SSE now.\n\n"
+        "## Alternatives Considered\n\n"
+        "### WebSockets\n\n"
+        "Needs sticky sessions our proxies do not support.\n\n"
+        "### A gRPC streaming layer\n\n"
+        "Revisit after v2 ships; the streaming primitives are not in place yet.\n"
+    )
+    result = _extract_adr_alternatives_strict(content)
+    assert result is not None
+    alternatives = [e["alternative"] for e in result]
+    # The genuine rejection is kept; the "revisit after v2" option is held open.
+    assert alternatives == ["WebSockets"]
+    assert "A gRPC streaming layer" not in alternatives
+
+
+def test_strict_extractor_keeps_rejection_that_narrates_revisiting():
+    """A genuine rejection whose body recounts that the option was revisited and
+    reconsidered before being ruled out is KEPT. The deferred markers match
+    forward-looking held-open phrasings ("revisit after"), not past-tense
+    rejection narration ("we revisited X and rejected it")."""
+    content = (
+        "# Choose a store\n\n"
+        "## Decision\n\nUse the daemon.\n\n"
+        "## Alternatives Considered\n\n"
+        "### A shared connection pool\n\n"
+        "We revisited and reconsidered a pool of embedded handles, then rejected "
+        "it: it multiplies store owners instead of defining one.\n"
+    )
+    result = _extract_adr_alternatives_strict(content)
+    assert result is not None
+    assert [e["alternative"] for e in result] == ["A shared connection pool"]
+
+
+def test_strict_extractor_import_omits_rejected_when_none_named(store: Path, tmp_path: Path):
+    """On the strict path, an ADR with no alternatives section imports a
+    decision with no rejected list — no placeholder reason."""
+    adr_dir = tmp_path / "strict_adrs"
+    adr_dir.mkdir()
+    (adr_dir / "0001-no-alternatives.md").write_text(
+        "# Use a thing\n\n## Context\n\nC.\n\n## Decision\n\nDo it.\n\n"
+        "## Consequences\n\n- Good, it is simple\n"
+    )
+
+    counts = _import_adrs(adr_dir, store, strict_alternatives=True)
+    assert counts["imported"] == 1
+
+    decisions = sorted((store / "decisions").glob("*.md"))
+    imported = decisions[1].read_text()
+    # No fabricated placeholder reason leaks onto the strict path.
+    assert "Rejected reason not available in source ADR." not in imported
+    assert "## Rejected Alternatives" not in imported
+
+
+def test_strict_extractor_import_records_named_rejections(store: Path):
+    """The strict path imports the fixture's two named rejections with
+    their verbatim reasons and skips the conditional option."""
+    adr_dir = FIXTURES / "adr"
+
+    counts = _import_adrs(adr_dir, store, strict_alternatives=True)
+    assert counts["imported"] == 1
+
+    decisions = sorted((store / "decisions").glob("*.md"))
+    imported = decisions[1].read_text()
+    assert "## Rejected Alternatives" in imported
+    assert "### Keep CLI-Only Embedded Access" in imported
+    assert "### Add a Local File Lock Around CLI Writes" in imported
+    assert "### Use the Embedded Engine's Daemon Directly" not in imported
+    assert "This is the simplest short-term shape" in imported

--- a/packages/nauro/tests/test_skills_drift.py
+++ b/packages/nauro/tests/test_skills_drift.py
@@ -27,8 +27,11 @@ from tests._skill_surfaces import REPO_ROOT, SKILL_SURFACES, load_docs_adopt_pro
 def test_load_adopt_body_returns_canonical_bytes():
     body = load_adopt_body()
     assert body.endswith("\n")
-    assert 1000 < len(body) < 25000
+    # Upper bound is a corruption/runaway sentinel, not a doctrine cap; raised
+    # to 30000 when Step 0 (Rapid Cited Seed) was added ahead of Step 1.
+    assert 1000 < len(body) < 30000
     # Anchor on key step markers — catches accidental empty / corrupted body.
+    assert "Step 0 — Rapid Cited Seed" in body
     assert "Step 1 — Detect repo root" in body
     assert "## Surface modes" in body
     assert "Step 4 — Read code evidence" in body
@@ -230,6 +233,67 @@ def test_adopt_body_delta_size_gloss_matches_constant():
         f"adopt_body.md delta-cap gloss is out of sync with MAX_DELTA_LENGTH "
         f"({MAX_DELTA_LENGTH} characters); expected the prose to read {gloss!r}."
     )
+
+
+def test_adopt_body_step0_mandates_two_citations_batch_confirm_and_precheck():
+    """Step 0 (Rapid Cited Seed) load-bearing contract.
+
+    Mirrors the prompt-content drift checks elsewhere in this module: anchor the
+    invariants that make Step 0 safe so a cleanup edit cannot quietly soften
+    them. Step 0 must (1) require two cited spans — a rationale span AND a named
+    rejected-alternative span — per card, (2) run ``check_decision`` once per
+    card before the batch, (3) gate every write behind one human batch confirm,
+    (4) route writes through the unchanged screened ``propose_decision`` path
+    (never a direct-write bypass), (5) capture each ``propose_decision`` status
+    rather than assume confirm == filed, (6) persist the citation as a free-text
+    ``Source: file:line`` line, and (7) hold back un-cited candidates.
+    """
+    body = load_adopt_body()
+
+    # The section exists and precedes Step 1 (rapid pass before the deep run).
+    assert "## Step 0 — Rapid Cited Seed" in body
+    assert body.index("## Step 0 — Rapid Cited Seed") < body.index("## Step 1 — Detect repo root")
+
+    # Two cited spans per card: a rationale span AND a named rejected alternative.
+    assert "rationale** span" in body
+    assert "named rejected-alternative" in body
+    assert "`file:line`" in body
+    # The grammatical-inverse trap is named so a card cannot pass on a fake
+    # second option.
+    assert "grammatical inverse" in body
+
+    # check_decision runs once per card before the batch is presented.
+    assert "`check_decision(" in body
+    assert "once per card" in body
+
+    # One human batch confirm is the write gate.
+    assert "confirm 1 3" in body
+    assert "confirm all" in body
+    assert "skip all" in body
+
+    # Writes route through the unchanged Step 7 screened propose_decision path,
+    # never a direct-write bypass.
+    assert "Step 7 write loop" in body
+    assert "propose_decision" in body
+    assert "direct-write bypass" in body
+
+    # Capture status; confirm does not imply filed (D272 active-title dedup can
+    # reject a card colliding with one written earlier in the same batch).
+    assert "captures the `propose_decision` return status" in body
+    assert "does not assume confirm means filed" in body
+
+    # Provenance persists as a free-text Source: file:line line in the rationale.
+    assert "Source: <file>:<line>" in body
+
+    # Un-cited candidates surface on a held-back list routed to Step 6b.
+    assert "held-back surface" in body
+    assert "Step 6b" in body
+
+    # NO_INVENT_RATIONALE: the agent never composes a why.
+    assert "does not compose rationale" in body
+
+    # confidence=high only on a literal ADR Status: Accepted.
+    assert "Status: Accepted" in body
 
 
 # --- render_skill produces frontmatter + body ---


### PR DESCRIPTION
**Why**

`nauro adopt` seeds a store from docs, but the only route to rationale is the Step 6b probe loop — every documented decision waits on a per-observation question to the user, even when the doc already states both the "why" and a named rejected alternative. That is slow for ADR-style repos whose decisions are already cited. We want a fast first pass that files exactly those self-citing decisions, and nothing it cannot prove, without ever composing rationale.

**Approach**

Add a Step 0 *before* the existing deep run rather than a new command or a rationale-extracting code path — the doctrine move is to make the rapid seed a disciplined, citation-gated step inside the skill the agent already runs, plus a default-off ADR helper, so no autonomous rationale and no new 1.0 surface area. Step 0 reads only the existing Step 3 doc set, drafts cards that qualify solely on two file:line-cited spans (a rationale span and a named rejected-alternative span — not the grammatical inverse, not a deferred option), runs `check_decision` per card before one human batch confirm, and files confirmed cards through the unchanged screened `propose_decision` path with the citation persisted as a free-text `Source: file:line` line. Cards lacking two honest spans route to a held-back surface feeding Step 6b. The deep Steps 1–11 are untouched and still run as the follow-up.

**What changed**

- `adopt_body.md`: new `## Step 0 — Rapid Cited Seed` (0.1 draft cited cards → 0.2 per-card `check_decision` → 0.3 one batch confirm → 0.4 file via Step 7, capture status, persist `Source:` line → 0.5 held-back surface); Surface modes names Step 0 as filesystem-only.
- `import_cmd.py`: new default-False, alternatives-aware ADR extractor (named `### ` rejections with verbatim reasons + offsets; omits when none named; no Consequences fallback; guards deferred/conditional options). The default `nauro import --adr` path is byte-for-byte unchanged.
- Dogfood render surfaces (`.claude`, `.cursor`, `.agents`, `docs/adopt-prompt.md`) regenerated from `render_skill()`.
- Tests: citation round-trip, strict-extractor units against an `### `-aware ADR fixture, a Step-0 prompt-content test, and a seeded-store integration test that the proactive `check_decision` retrieval fires on the 1.0.1 floor.

**What to review**

- `adopt_body.md` Step 0 prose: that no instruction lets the agent compose a "why", that confirm ≠ filed is explicit, and that the two-span / named-alternative bar is unambiguous.
- `import_cmd.py`: that the default path is genuinely unchanged and the strict path omits (not placeholders) rejected when the source names none.
- The size-sentinel bump (25000→30000) in `test_skills_drift.py`.

**What's deferred**

- No CLI flag to invoke the strict extractor from `nauro import` (the helper is opt-in at the function boundary only — wiring a `--strict` flag would add 1.0 surface area).
- Step 0 remains filesystem-only; no chat-surface analogue.

**Test plan**

- `.venv/bin/python -m pytest packages/nauro-core/tests/ -x -q` → 881 passed
- `.venv/bin/python -m pytest packages/nauro/tests/ -x -q` → 1519 passed, 10 skipped
- `ruff check packages/` and `ruff format --check packages/` → clean
- Frozen-path guard: the 7 existing `--adr` import tests pass unchanged.
