### PR TITLE
Release nauro 1.1.0 (Step 0 Rapid Cited Seed)

### DIFF
--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro"
-version = "1.0.1"
+version = "1.1.0"
 description = "Local CLI + MCP server: set your project's doctrine once, every connected AI agent inherits it."
 readme = "README.md"
 license = "Apache-2.0"

--- a/server.json
+++ b/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Nauro-AI/nauro",
     "source": "github"
   },
-  "version": "1.0.1",
+  "version": "1.1.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "nauro",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## nauro 1.1.0

Minor, additive release. Ships **Step 0 — Rapid Cited Seed** in the `/nauro-adopt` skill (#278): a freshly-adopted repo now reaches a fast, honest first `check_decision` hit from documentation that already states a rationale and a named rejected alternative — each filed only behind two file:line-cited spans and a human batch-confirm, nothing composed. Includes a default-off, alternatives-aware ADR extractor (`### `-subsection aware) that the seed step can cite.

### Why a minor (not a patch / not a major)
New user-facing functionality → semver-minor. It is **freeze-safe under D318**: no new CLI command/flag, no stdio MCP tool, no store-format field, no `nauro-core` public-API change. The default `nauro import --adr` path is byte-for-byte unchanged.

### Version changes
- `packages/nauro/pyproject.toml`: `1.0.1` → `1.1.0`.
- `server.json`: **both** `.version` and `.packages[0].version` → `1.1.0` (the `publish-registry` gate hard-fails unless both match the tag).
- `nauro-core` stays `1.0.1` — its shipped wheel is unchanged (only a test was edited), and `nauro` depends on `nauro-core>=1.0,<2`, so no nauro-core release is needed (independent tags per D318).

### Release steps after merge
1. Tag `nauro-v1.1.0` on the merge commit and push it → triggers `publish-nauro.yml` (PyPI publish + MCP-registry publish via DNS auth).
2. Cross-repo (D241): bump `plugin.json` to `1.1.0` in the **claude-plugins** repo, or the version-sync gate fails.
