### PR TITLE
CI: guard server.json version against the nauro package version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       - run: ruff check packages/ benchmarks/
       - run: ruff format --check packages/ benchmarks/
       - run: python scripts/check_single_sourced.py packages/nauro/src
+      - run: python scripts/check_server_json_version.py
 
   import-linter:
     runs-on: ubuntu-latest

--- a/scripts/check_server_json_version.py
+++ b/scripts/check_server_json_version.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Guard that ``server.json`` stays version-locked to the ``nauro`` package.
+
+The MCP registry publish job (``publish-nauro.yml``) verifies ``server.json``'s
+version against the release tag — but only AFTER the tag is cut. So a release
+that bumps ``packages/nauro/pyproject.toml`` without bumping ``server.json``
+publishes to PyPI cleanly and then fails the ``publish-registry`` job
+post-tag (this happened on the 1.0.1 release). This check moves the guard to
+PR time: it fails if ``server.json``'s top-level ``version`` or its first
+package's ``version`` drifts from the ``nauro`` package version in
+``packages/nauro/pyproject.toml``.
+
+Usage::
+
+    python scripts/check_server_json_version.py
+    python scripts/check_server_json_version.py server.json packages/nauro/pyproject.toml
+
+Exits 0 when in lockstep, 1 on a version mismatch, 2 on a usage/IO error.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+def project_version(pyproject_text: str) -> str:
+    """Return ``[project].version`` from pyproject text.
+
+    Stdlib-only line parser (no ``tomllib``) so the guard runs on the whole
+    ``requires-python >= 3.10`` range, including 3.10 where ``tomllib`` is
+    absent. Reads the ``version`` key only within the ``[project]`` table, so a
+    ``version`` under another table (e.g. ``[build-system]``) is not matched.
+    """
+    in_project = False
+    for line in pyproject_text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("[") and stripped.endswith("]"):
+            in_project = stripped == "[project]"
+            continue
+        if in_project and stripped.startswith("version") and "=" in stripped:
+            return stripped.partition("=")[2].strip().strip("\"'")
+    raise KeyError("no [project].version found in pyproject.toml")
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) > 3:
+        print(
+            "usage: check_server_json_version.py [server.json] [pyproject.toml]",
+            file=sys.stderr,
+        )
+        return 2
+    server_json = Path(argv[1]) if len(argv) > 1 else Path("server.json")
+    pyproject = Path(argv[2]) if len(argv) > 2 else Path("packages/nauro/pyproject.toml")
+
+    for p in (server_json, pyproject):
+        if not p.exists():
+            print(f"error: path does not exist: {p}", file=sys.stderr)
+            return 2
+
+    try:
+        pkg_version = project_version(pyproject.read_text())
+        server = json.loads(server_json.read_text())
+    except (KeyError, ValueError, OSError) as exc:
+        print(f"error: could not read versions: {exc}", file=sys.stderr)
+        return 2
+
+    server_version = server.get("version")
+    packages = server.get("packages") or [{}]
+    package_version = packages[0].get("version")
+
+    mismatches: list[str] = []
+    if server_version != pkg_version:
+        mismatches.append(f"server.json .version = {server_version!r}")
+    if package_version != pkg_version:
+        mismatches.append(f"server.json .packages[0].version = {package_version!r}")
+
+    if mismatches:
+        print(
+            "server.json is out of lockstep with the nauro package "
+            f"(packages/nauro/pyproject.toml version = {pkg_version!r}):"
+        )
+        for m in mismatches:
+            print(f"  {m}")
+        print(
+            "\nBump server.json's `version` and `packages[0].version` to match "
+            "before releasing — the publish-time registry check only catches "
+            "this after the tag is cut."
+        )
+        return 1
+
+    print(f"server.json is version-locked to the nauro package ({pkg_version}).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
**Why**

The 1.0.1 release bumped `packages/nauro/pyproject.toml` but not `server.json`, so the `nauro-v1.0.1` tag published to PyPI cleanly and then failed the `publish-registry` job (server.json was still 1.0.0). The only existing guard — the jq version-match check in `publish-nauro.yml` — runs **after** the tag is cut, so it can't prevent the bad tag, only report it post-hoc. This adds a **PR-time** guard so the drift is caught on the PR that introduces it.

**What changes**

- `scripts/check_server_json_version.py` (new): fails if `server.json`'s `.version` or `.packages[0].version` doesn't match the `nauro` package version in `packages/nauro/pyproject.toml`. Stdlib-only (no `tomllib`) so it runs across the whole `requires-python >= 3.10` range, including 3.10; the version is read only from the `[project]` table. Exit codes mirror `check_single_sourced.py` (0 clean / 1 mismatch / 2 IO/usage).
- `.github/workflows/ci.yml`: run it in the existing `lint` job, right after `check_single_sourced.py`.

**Test plan**

Verified locally: passes on the current in-sync state (both 1.1.0); fails (exit 1) on a `.version` mismatch, on a `.packages[0].version`-only mismatch, and exits 2 on a missing file. The `[project]`-table parse ignores a `version` key under any other table. ruff check + format clean.
