### PR TITLE
Promote discovery-pointer classification to questions model

### DIFF
--- a/packages/nauro-core/src/nauro_core/context.py
+++ b/packages/nauro-core/src/nauro_core/context.py
@@ -14,7 +14,6 @@ from nauro_core.constants import (
     L0_QUESTIONS_LIMIT,
     L1_DECISIONS_LIMIT,
     L1_DECISIONS_SUMMARY_LIMIT,
-    POINTER_FLAG_PREFIXES,
 )
 from nauro_core.decision_model import Decision, DecisionStatus
 from nauro_core.parsing import (
@@ -34,17 +33,6 @@ _L0_AGE_PROJECTION_DAYS = 30
 def _active_decisions(decisions: list[Decision]) -> list[Decision]:
     """Filter to active decisions only."""
     return [d for d in decisions if d.status is DecisionStatus.active]
-
-
-def _is_discovery_pointer(body: str) -> bool:
-    """Return True when an entry body starts with a discovery-pointer prefix.
-
-    Discovery pointers (BRIEF:/RESUME:/SELECT: entries) are breadcrumbs written
-    by the nauro-context and nauro-loop skills, not questions for human review,
-    and are excluded from the L0 Open Questions projection.
-    """
-    stripped = body.lstrip()
-    return stripped.startswith(POINTER_FLAG_PREFIXES)
 
 
 def _render_l0_open_questions(content: str) -> str:
@@ -76,7 +64,7 @@ def _render_l0_open_questions(content: str) -> str:
             continue
         if block.entry.resolved_by is not None:
             continue
-        if _is_discovery_pointer(block.entry.body):
+        if block.entry.is_discovery_pointer:
             continue
         if rendered >= L0_QUESTIONS_LIMIT:
             break

--- a/packages/nauro-core/src/nauro_core/graph.py
+++ b/packages/nauro-core/src/nauro_core/graph.py
@@ -50,10 +50,11 @@ def build_graph_payload(
             and the dropped number is recorded in ``stats.duplicate_numbers``.
             Only the kept decisions contribute edges and citations, so a dropped
             duplicate never fabricates an edge attributed to the kept node.
-        questions: Parsed open-questions file, or None. Only unresolved entries
-            appear in the payload; each body is capped to its first line or
-            sentence, and each entry carries the in-range decision numbers its
-            full body references.
+        questions: Parsed open-questions file, or None. Only genuinely-open
+            entries appear in the payload (unresolved and not a discovery-pointer
+            breadcrumb); each body is capped to its first line or sentence, and
+            each entry carries the in-range decision numbers its full body
+            references.
         project: Display name for the rendered title. Carried through verbatim.
         include_bodies: When True, each node dict gains a ``"body"`` key holding
             the decision's full body markdown. Default False keeps the artifact
@@ -315,12 +316,15 @@ def _filter_open_questions(
     node_numbers: set[int],
     max_decision_number: int,
 ) -> list[dict]:
-    """Return unresolved open-question entries with capped bodies and references.
+    """Return genuinely-open question entries with capped bodies and references.
 
     Openness is annotation-authoritative via ``OpenQuestionsFile``'s public
-    ``unresolved_entries`` (``resolved_by`` unset), regardless of where the
-    entry sits relative to the ``## Resolved`` divider. Each included body is
-    capped to its first sentence or line for display.
+    ``genuine_open_entries`` (``resolved_by`` unset AND not a discovery-pointer
+    breadcrumb), regardless of where the entry sits relative to the
+    ``## Resolved`` divider. Discovery pointers (``BRIEF:``/``RESUME:``/``SELECT:``
+    body prefix) are breadcrumbs for other agents, not questions for the graph
+    surface, so they are excluded from the count and the listing. Each included
+    body is capped to its first sentence or line for display.
 
     ``references`` holds the decision numbers the entry's FULL body cites (body
     plus every continuation line), not just the capped display body, scanned via
@@ -333,7 +337,7 @@ def _filter_open_questions(
     if questions is None:
         return []
     result: list[dict] = []
-    for entry in questions.unresolved_entries:
+    for entry in questions.genuine_open_entries:
         full_body = "\n".join([entry.body, *entry.continuation])
         cited = scan_decision_references(full_body, max_decision_number)
         references = sorted(n for n in cited if n in node_numbers)

--- a/packages/nauro-core/src/nauro_core/questions.py
+++ b/packages/nauro-core/src/nauro_core/questions.py
@@ -31,6 +31,8 @@ from typing import Annotated, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from nauro_core.constants import POINTER_FLAG_PREFIXES
+
 _TIMESTAMP_FMT = "%Y-%m-%d %H:%M UTC"
 _RESOLVED_HEADER = "## Resolved"
 _DEFAULT_HEADER = "# Open Questions"
@@ -79,6 +81,17 @@ class QuestionEntry(BaseModel):
             return f"Q{self.num}"
         assert self.timestamp is not None  # exactly_one_id validator
         return self.timestamp.strftime(_TIMESTAMP_FMT)
+
+    @property
+    def is_discovery_pointer(self) -> bool:
+        """True when the body is a discovery pointer, not a question for review.
+
+        Discovery pointers (``BRIEF:``/``RESUME:``/``SELECT:`` body prefix) are
+        breadcrumbs written by the nauro-context and nauro-loop skills, not
+        questions awaiting human review. The check is on the left-stripped body
+        against :data:`POINTER_FLAG_PREFIXES`.
+        """
+        return self.body.lstrip().startswith(POINTER_FLAG_PREFIXES)
 
     def render(self) -> list[str]:
         """Return the markdown lines for this entry."""
@@ -363,6 +376,27 @@ class OpenQuestionsFile(BaseModel):
             for b in self.blocks
             if isinstance(b, EntryBlock) and b.entry.resolved_by is None
         ]
+
+    @property
+    def genuine_open_entries(self) -> list[QuestionEntry]:
+        """Unresolved entries that are not discovery pointers, in file order.
+
+        The genuinely-open questions a human should see: the
+        :attr:`unresolved_entries` set (``resolved_by`` unset,
+        annotation-authoritative) minus the discovery-pointer breadcrumbs
+        (:attr:`QuestionEntry.is_discovery_pointer`).
+        """
+        return [e for e in self.unresolved_entries if not e.is_discovery_pointer]
+
+    @property
+    def discovery_pointers(self) -> list[QuestionEntry]:
+        """Unresolved entries that are discovery pointers, in file order.
+
+        The complement of :attr:`genuine_open_entries` within
+        :attr:`unresolved_entries`: ``BRIEF:``/``RESUME:``/``SELECT:``
+        breadcrumbs that are still open but are not questions for human review.
+        """
+        return [e for e in self.unresolved_entries if e.is_discovery_pointer]
 
     @property
     def known_question_ids(self) -> set[str]:

--- a/packages/nauro-core/tests/test_graph.py
+++ b/packages/nauro-core/tests/test_graph.py
@@ -471,6 +471,32 @@ class TestOpenQuestionsFilter:
         assert payload["open_questions"] == []
 
 
+class TestOpenQuestionsDiscoveryPointerExclusion:
+    """Discovery-pointer entries (BRIEF:/RESUME:/SELECT: body prefix) are
+    breadcrumbs for other agents, not graph-surface open questions: they must be
+    absent from the payload and excluded from the question count."""
+
+    def test_discovery_pointers_absent_and_uncounted(self):
+        content = (
+            "# Open Questions\n"
+            "- [Q1] BRIEF: context/a.md — shared brief\n"
+            "- [Q2] First genuine question?\n"
+            "- [Q3] RESUME: context/b.md — resume brief\n"
+            "- [Q4] Second genuine question?\n"
+            "- [Q5] SELECT: context/c.md — loop checkpoint\n"
+        )
+        questions = OpenQuestionsFile.parse(content)
+        payload = build_graph_payload([], questions=questions)
+        assert [q["id"] for q in payload["open_questions"]] == ["Q2", "Q4"]
+        bodies = " ".join(q["body"] for q in payload["open_questions"])
+        assert "BRIEF:" not in bodies
+        assert "RESUME:" not in bodies
+        assert "SELECT:" not in bodies
+        # The "N open questions" count the renderer shows derives from
+        # len(payload["open_questions"]), so pointers are not counted.
+        assert len(payload["open_questions"]) == 2
+
+
 class TestOpenQuestionReferences:
     def test_multiple_references_from_full_body(self):
         # Two references in the question body resolve to a sorted list. Both

--- a/packages/nauro-core/tests/test_questions.py
+++ b/packages/nauro-core/tests/test_questions.py
@@ -246,6 +246,73 @@ class TestUnresolvedEntries:
         assert file.open_ids == ["Q1"]
 
 
+class TestDiscoveryPointerClassification:
+    def test_brief_prefix_is_pointer(self):
+        e = QuestionEntry(num=1, body="BRIEF: context/x.md — shared brief")
+        assert e.is_discovery_pointer is True
+
+    def test_resume_prefix_is_pointer(self):
+        e = QuestionEntry(num=1, body="RESUME: context/y.md — resume brief")
+        assert e.is_discovery_pointer is True
+
+    def test_select_prefix_is_pointer(self):
+        e = QuestionEntry(num=1, body="SELECT: context/z.md — loop checkpoint")
+        assert e.is_discovery_pointer is True
+
+    def test_leading_whitespace_still_pointer(self):
+        e = QuestionEntry(num=1, body="   BRIEF: context/x.md")
+        assert e.is_discovery_pointer is True
+
+    def test_genuine_question_is_not_pointer(self):
+        e = QuestionEntry(num=1, body="Should we cache the index?")
+        assert e.is_discovery_pointer is False
+
+    def test_prefix_not_at_start_is_not_pointer(self):
+        # The marker must lead the body; a mention mid-sentence is a real question.
+        e = QuestionEntry(num=1, body="Where should the BRIEF: marker live?")
+        assert e.is_discovery_pointer is False
+
+
+class TestDiscoveryPointerPartition:
+    """``genuine_open_entries`` / ``discovery_pointers`` partition the
+    ``unresolved_entries`` set on the discovery-pointer flag, annotation-first."""
+
+    def _file(self) -> OpenQuestionsFile:
+        content = (
+            "# Open Questions\n"
+            "- [Q1] BRIEF: context/a.md — shared brief\n"
+            "- [Q2] First genuine question?\n"
+            "- [Resolved by D5 on 2026-04-02] [Q3] RESUME: context/b.md — settled pointer\n"
+            "- [Q4] SELECT: context/c.md — loop checkpoint\n"
+            "- [Resolved by D6 on 2026-04-03] [Q5] Already-settled question?\n"
+            "- [Q6] Second genuine question?\n"
+        )
+        return OpenQuestionsFile.parse(content)
+
+    def test_genuine_open_excludes_pointers_and_resolved(self):
+        file = self._file()
+        assert [e.id for e in file.genuine_open_entries] == ["Q2", "Q6"]
+
+    def test_discovery_pointers_are_unresolved_pointers_only(self):
+        # Q3 is a RESUME pointer but resolved-annotated, so it lands in neither
+        # half — the partition mirrors unresolved_entries on the "unresolved" axis.
+        file = self._file()
+        assert [e.id for e in file.discovery_pointers] == ["Q1", "Q4"]
+
+    def test_partition_covers_unresolved_exactly(self):
+        file = self._file()
+        partitioned = {e.id for e in file.genuine_open_entries} | {
+            e.id for e in file.discovery_pointers
+        }
+        assert partitioned == {e.id for e in file.unresolved_entries}
+
+    def test_pointer_free_file_genuine_equals_unresolved(self):
+        content = "# Open Questions\n- [Q1] One?\n- [Q2] Two?\n"
+        file = OpenQuestionsFile.parse(content)
+        assert [e.id for e in file.genuine_open_entries] == ["Q1", "Q2"]
+        assert file.discovery_pointers == []
+
+
 class TestResolve:
     def _file(self) -> OpenQuestionsFile:
         return OpenQuestionsFile.parse(


### PR DESCRIPTION
## Why

Discovery pointers are open-questions entries written by the context-sharing
and loop skills with a `BRIEF:`/`RESUME:`/`SELECT:` body prefix. They are
breadcrumbs for other agents, not questions awaiting human review. The L0
summary already excluded them via a renderer-local filter, but the
decision-graph surface still counted and listed them as open questions, because
the classification lived only in the L0 renderer. The same entry was treated two
ways on two surfaces.

## Approach

Promote the classification to a first-class, tested concept on the questions
model, then route both surfaces through it:

- `QuestionEntry.is_discovery_pointer`: True when the left-stripped body starts
  with any discovery-pointer prefix (the shared `POINTER_FLAG_PREFIXES`
  constant).
- `OpenQuestionsFile.genuine_open_entries` (unresolved and not a pointer) and
  `OpenQuestionsFile.discovery_pointers` (unresolved and a pointer): both mirror
  the annotation-authoritative "unresolved" half of `unresolved_entries`.

Projection-only. A prior decision established the resolution annotation as the
source of truth, so entries are projected and filtered, never mutated or
relocated.

## What changed

- `questions.py`: new `is_discovery_pointer` property plus the two partition
  helpers.
- `context.py`: the L0 renderer consumes `entry.is_discovery_pointer`; the local
  `_is_discovery_pointer` helper and its unused import are removed. L0 behavior
  is unchanged: the positional `## Resolved` divider break and
  `L0_QUESTIONS_LIMIT` slot accounting are preserved.
- `graph.py`: `_filter_open_questions` iterates `genuine_open_entries`, so
  pointers no longer appear in the graph payload. The HTML "N open questions"
  count derives from payload length, so it self-corrects with no change to that
  file.
- Tests: model-partition tests, plus a graph test asserting pointers are absent
  from the payload and the count.

## What to review

- L0 output is byte-identical. The refactor swaps only the source of the pointer
  check (renderer-local function to model property), not the openness source.
  The L0 loop still keys on physical `## Resolved` divider position, and slot
  accounting is untouched (pointers still consume no slot).
- The partition is exact. `genuine_open_entries` and `discovery_pointers`
  partition `unresolved_entries` with no overlap and no gap; a resolved-annotated
  pointer falls in neither half. Covered by
  `test_discovery_pointers_are_unresolved_pointers_only` and
  `test_partition_covers_unresolved_exactly`.

## What's deferred

A follow-up to add a `retire`/consumed vocabulary for pointers is out of scope.
This PR changes how pointers are projected, not how they are retired.

## Test plan

- `pytest packages/nauro-core/tests/ -x -q`: 892 passed
- `pytest packages/nauro/tests/ -x -q`: 1521 passed, 10 skipped
- `pytest packages/nauro/tests/test_public_contract.py`: passes with no snapshot
  regeneration. The 1.0 public-contract freeze is unaffected; no frozen symbol,
  tool schema, CLI flag, or store-format constant changes.
- `ruff check packages/` and `ruff format --check packages/`: clean
