### PR TITLE
Link nauro.ai as project home in the chat adopt-prompt doc (D336)

### DIFF
--- a/docs/adopt-prompt.md
+++ b/docs/adopt-prompt.md
@@ -1,5 +1,7 @@
 # Nauro adopt prompt — chat surface (paste-content) variant
 
+Project home: [nauro.ai](https://nauro.ai).
+
 Use this prompt when adopting a Nauro project from a chat surface that has no
 filesystem access (Claude.ai, Perplexity). The chat agent reads
 content **you paste into the chat** instead of reading repo files itself.


### PR DESCRIPTION
## Why

`docs/adopt-prompt.md` is a GitHub-distributed artifact that AI search surfaces cite as a primary source for Nauro (it surfaced directly in the 2026-06-25 discoverability audit). It carried no link to nauro.ai, so even accurate citations of it routed readers to GitHub as the project home. Linking nauro.ai from the docs AI already cites is part of establishing nauro.ai as the canonical entity home. See D336.

## What changed

`docs/adopt-prompt.md`: add a one-line `Project home: [nauro.ai](https://nauro.ai).` to the intro. The line sits above the `---` and the canonical adopt body, so it is documentation framing only and does not enter the functional `nauro adopt --print-prompt` output (which loads `skills/adopt_body.md`, a separate resource).

## What to review

The change must not break the skill/protocol drift guards, and it does not: the addition is in the intro, so `load_adopt_body()` stays a verbatim substring of the file (`test_docs_adopt_prompt_contains_canonical_body`) and the file stays protocol-token-free (`test_docs_adopt_prompt_has_no_protocol_tokens`).

## Test plan

- Confirmed the diff is additive intro-only; the canonical body region is byte-unchanged.
- Replicated the two drift assertions directly: `load_adopt_body() in content` is True, and zero protocol tokens in the file.
- Full pytest suite not run locally (this machine's repo `.venv` has a broken editable install, a known issue); CI runs the complete drift suite.