### PR TITLE
Remove dead code in the nauro package

### DIFF
--- a/packages/nauro/src/nauro/constants.py
+++ b/packages/nauro/src/nauro/constants.py
@@ -52,15 +52,6 @@ PROJECTS_DIR = "projects"
 # so listing both is safe.
 VALIDATED_STORE_FILES = (PROJECT_MD, STATE_CURRENT_FILENAME, STATE_LEGACY_FILENAME, STACK_MD)
 
-# Files counted toward L0 token estimate
-TOKEN_ESTIMATE_FILES = (
-    PROJECT_MD,
-    STATE_CURRENT_FILENAME,
-    STATE_LEGACY_FILENAME,
-    STACK_MD,
-    OPEN_QUESTIONS_MD,
-)
-
 # ── AGENTS.md ──
 AGENTS_MD = "AGENTS.md"
 CLAUDE_MD = "CLAUDE.md"
@@ -78,9 +69,6 @@ L0_TOKEN_LIMIT = 3500
 # this the flag is annotated with a hint pointing at the matching decision.
 FLAG_QUESTION_HINT_MIN_SCORE = 0.7
 FLAG_QUESTION_HINT_TITLE_LENGTH = 100
-
-# ── Writer limits ──
-SLUG_MAX_LENGTH = 60
 
 # ── Snapshot pruning intervals (days) ──
 PRUNE_KEEP_ALL_DAYS = 7

--- a/packages/nauro/src/nauro/mcp/stdio_server.py
+++ b/packages/nauro/src/nauro/mcp/stdio_server.py
@@ -73,12 +73,6 @@ mcp = FastMCP("nauro", instructions=MCP_INSTRUCTIONS, log_level="WARNING")
 mcp._mcp_server.version = __version__
 
 
-NOT_A_NAURO_REPO = (
-    "Not a nauro repo: no .nauro/config.json found. "
-    "Run 'nauro init <name>' in this repo, or pass project_id explicitly."
-)
-
-
 def _wrap_with_renderer(
     tool_name: str, result: dict, renderer_kwargs: dict[str, Any] | None = None
 ) -> CallToolResult:

--- a/packages/nauro/src/nauro/onboarding.py
+++ b/packages/nauro/src/nauro/onboarding.py
@@ -26,21 +26,6 @@ WELCOME_NO_PROJECT = (
     "Your decisions will then be available here and across all connected AI tools."
 )
 
-NO_DECISIONS_YET = (
-    "This project has no decisions yet.\n"
-    "\n"
-    "To add your first decision:\n"
-    '- Run: nauro note "Your decision here"\n'
-    "- Or use propose_decision right here in this conversation"
-)
-
-NO_SNAPSHOTS_YET = (
-    "No snapshots available yet.\n"
-    "\n"
-    "Snapshots are created automatically when decisions are written "
-    "or state is updated. Use propose_decision or update_state to get started."
-)
-
 NO_CONTEXT_YET = (
     "This project has no context data yet.\n"
     "\n"

--- a/packages/nauro/src/nauro/store/reader.py
+++ b/packages/nauro/src/nauro/store/reader.py
@@ -23,13 +23,6 @@ def read_text_lenient(path: Path) -> str:
     return path.read_text(encoding="utf-8", errors="replace")
 
 
-def _read_file(path: Path) -> str:
-    """Read a file, return empty string if missing."""
-    if path.exists():
-        return read_text_lenient(path)
-    return ""
-
-
 def _list_decisions(store_path: Path) -> list[Decision]:
     """Parse all decision files, return ``Decision`` objects sorted by number."""
     decisions_dir = store_path / DECISIONS_DIR

--- a/packages/nauro/src/nauro/telemetry/__init__.py
+++ b/packages/nauro/src/nauro/telemetry/__init__.py
@@ -49,10 +49,6 @@ def _get_distinct_id() -> str:
     return get_telemetry_config().anonymous_id
 
 
-def is_enabled() -> bool:
-    return _should_emit()
-
-
 def capture(event_name: str, properties: dict[str, Any] | None = None) -> None:
     """Send an event if telemetry is enabled. Silent on failure — must never crash the CLI."""
     if not _should_emit():

--- a/packages/nauro/src/nauro/templates/agents_md.py
+++ b/packages/nauro/src/nauro/templates/agents_md.py
@@ -147,7 +147,7 @@ def generate_agents_md(
     order = (
         section_order
         if section_order is not None
-        else _default_section_order(skills_section is not None, manual_section is not None)
+        else _default_section_order(skills_section is not None)
     )
     for section in order:
         if section == "skills" and skills_section is not None:
@@ -168,7 +168,7 @@ def generate_agents_md(
     return "\n".join(parts)
 
 
-def _default_section_order(has_skills: bool, has_manual: bool) -> list[str]:
+def _default_section_order(has_skills: bool) -> list[str]:
     """When no explicit order is provided, emit skills before manual."""
     out: list[str] = []
     if has_skills:


### PR DESCRIPTION
### Why
A vulture sweep + a fan-out verification workflow + manual grep confirmation identified eight symbols in the `nauro` package with zero references across src, tests, and markdown. Removing them reduces drift hazard (notably a duplicated constant) and noise.

### Approach
Delete only symbols proven unused. Each was verified against the whole repo (src + tests + markdown), against nauro-core's curated public `__all__`, and against framework-implicit usage (Typer, pydantic, Protocol, enums, dynamic dispatch). Nothing removed is part of nauro-core's public surface, the CLI flag surface, or the stdio MCP tool contract, so D318's 1.0 semver promise is unaffected. No behavior change.

### What changed
- `constants.py`: removed `SLUG_MAX_LENGTH` (unused duplicate shadowing nauro-core's live `_SLUG_MAX_LENGTH=60`) and `TOKEN_ESTIMATE_FILES`.
- `mcp/stdio_server.py`: removed `NOT_A_NAURO_REPO` (real guidance comes from `_check_store_exists`, 11 call sites).
- `store/reader.py`: removed `_read_file` (live reads use `read_text_lenient`).
- `telemetry/__init__.py`: removed `is_enabled` (callers use `_should_emit` directly).
- `templates/agents_md.py`: removed the unread `has_manual` parameter of `_default_section_order` (signature + the single call site).
- `onboarding.py`: removed the unwired `NO_DECISIONS_YET` and `NO_SNAPSHOTS_YET` strings.

### What to review
That each removed symbol is genuinely unreferenced (incl. dynamic/string/framework usage), and that the `has_manual` parameter removal doesn't change `_default_section_order` behavior.

### What's deferred
The empty-store UX that `NO_DECISIONS_YET`/`NO_SNAPSHOTS_YET` hinted at is not being wired up here; deletion was chosen over wire-up. A future dedup of nauro-core's near-namesake `_SLUG_MAX_LENGTH` is noted but out of scope.

### Test plan
- `uv run pytest packages/nauro-core/tests/ packages/nauro/tests/ -q` — 2415 passed
- `uv run ruff check packages/` — all checks passed

The only failures are 2 pre-existing environmental cases in `test_cli_fs_errors.py` (the suite runs as root, which bypasses the `chmod 0o555` read-only-dir assertion); they are present on `main` and unrelated to this diff.