### PR TITLE
Make first-run telemetry consent opt-in (default-decline)

### DIFF
--- a/packages/nauro/PRIVACY.md
+++ b/packages/nauro/PRIVACY.md
@@ -1,6 +1,6 @@
 # Nauro Privacy & Data Paths
 
-Last updated: 2026-06-05
+Last updated: 2026-06-28
 
 ## Cloud sync
 
@@ -12,7 +12,7 @@ When connected to Claude AI, Perplexity, or another MCP client, your project con
 
 ## Telemetry
 
-Nauro collects anonymous product-usage telemetry to understand which commands are used, where users get stuck, and whether the tool is healthy. Telemetry is **default opt-in** via a one-line first-run prompt that points back to this document.
+Nauro collects anonymous product-usage telemetry to understand which commands are used, where users get stuck, and whether the tool is healthy. Telemetry is **opt-in and off by default**: a one-line first-run prompt (which defaults to *no*) points back to this document, and nothing is sent unless you explicitly turn it on.
 
 ### Events
 

--- a/packages/nauro/src/nauro/telemetry/client.py
+++ b/packages/nauro/src/nauro/telemetry/client.py
@@ -24,9 +24,10 @@ POSTHOG_HOST = "https://us.i.posthog.com"
 # This is an intentionally-public, WRITE-ONLY ingestion key (PostHog phc_ keys
 # can only submit events, never read them) — see PRIVACY.md for the full
 # data-collection contract. The NAURO_POSTHOG_KEY env var still overrides it.
-# Emission stays gated by consent (_should_emit): default-opt-in, set only on
-# an interactive first run, so CI and non-TTY installs never emit regardless of
-# this key. The "phc_REPLACE" guard in _resolve_project_key() is a safety net:
+# Emission stays gated by consent (_should_emit): off by default, enabled only
+# on an explicit interactive first-run opt-in, so CI and non-TTY installs never
+# emit regardless of this key. The "phc_REPLACE" guard in _resolve_project_key()
+# is a safety net:
 # if this value is ever reset to a placeholder, telemetry disables cleanly.
 _BAKED_PROJECT_KEY = "phc_oGL7Q29uiGrocGujHP5TvJzmPfJLKoej7BKsQRL5S35J"
 

--- a/packages/nauro/src/nauro/telemetry/consent.py
+++ b/packages/nauro/src/nauro/telemetry/consent.py
@@ -59,7 +59,10 @@ def maybe_prompt() -> None:
 
     is_first_run = cfg.consent_version is None
     if is_first_run:
-        default_yes = True
+        # Opt-in: a bare Enter or any unrecognized keystroke leaves telemetry
+        # off; only an explicit y/yes enables it. A re-prompt (version bump)
+        # still pre-selects the user's previous answer as the default below.
+        default_yes = False
     else:
         default_yes = cfg.enabled is True
         print(REPROMPT_PREFACE)

--- a/packages/nauro/tests/test_consent_prompt.py
+++ b/packages/nauro/tests/test_consent_prompt.py
@@ -135,7 +135,8 @@ def test_tty_user_enters_n(nauro_home, monkeypatch):
     assert section["consent_version"] == 1
 
 
-def test_first_run_empty_input_defaults_to_yes(nauro_home, monkeypatch):
+def test_first_run_empty_input_defaults_to_no(nauro_home, monkeypatch):
+    """Opt-in: a bare Enter on first run leaves telemetry disabled."""
     monkeypatch.delenv("NAURO_TELEMETRY", raising=False)
     _set_tty(monkeypatch, True)
     _set_input(monkeypatch, "")
@@ -145,7 +146,7 @@ def test_first_run_empty_input_defaults_to_yes(nauro_home, monkeypatch):
     maybe_prompt()
 
     section = _read_telemetry(nauro_home)
-    assert section["enabled"] is True
+    assert section["enabled"] is False
     assert section["consent_version"] == 1
 
 
@@ -219,8 +220,9 @@ def test_already_consented_at_current_version_does_not_re_prompt(nauro_home, mon
     assert section["consented_at"] == "2026-04-30T00:00:00Z"
 
 
-def test_unrecognized_input_applies_stated_default_yes(nauro_home, monkeypatch, capsys):
-    """An unrecognized keystroke must apply the stated default, not its opposite."""
+def test_first_run_unrecognized_input_defaults_to_no(nauro_home, monkeypatch, capsys):
+    """Opt-in: an unrecognized keystroke on first run leaves telemetry disabled,
+    rather than being read as consent."""
     monkeypatch.delenv("NAURO_TELEMETRY", raising=False)
     _set_tty(monkeypatch, True)
     _set_input(monkeypatch, "??")  # not y/n/yes/no/empty
@@ -230,8 +232,29 @@ def test_unrecognized_input_applies_stated_default_yes(nauro_home, monkeypatch, 
     maybe_prompt()
 
     section = _read_telemetry(nauro_home)
-    assert section["enabled"] is True  # default_yes=True on first run
+    assert section["enabled"] is False  # default_yes=False on first run
     assert section["consent_version"] == 1
+    out = capsys.readouterr().out
+    assert "Telemetry disabled." in out
+
+
+def test_reprompt_unrecognized_input_preserves_previous_yes(nauro_home, monkeypatch, capsys):
+    """A version-bump re-prompt still applies the stated default (the user's prior
+    answer): unrecognized input for a previously-opted-in user stays enabled."""
+    monkeypatch.delenv("NAURO_TELEMETRY", raising=False)
+    _seed(nauro_home, enabled=True, consent_version=1)
+    _set_tty(monkeypatch, True)
+    _set_input(monkeypatch, "??")
+
+    import nauro.telemetry.consent as consent_mod
+
+    monkeypatch.setattr(consent_mod, "TELEMETRY_CONSENT_VERSION", 2)
+
+    consent_mod.maybe_prompt()
+
+    section = _read_telemetry(nauro_home)
+    assert section["enabled"] is True  # default_yes=True (previous opt-in)
+    assert section["consent_version"] == 2
     out = capsys.readouterr().out
     assert "Telemetry enabled." in out
 


### PR DESCRIPTION
## Why

An adversarial red-team of the repo and site from the AI-skeptical-developer viewpoint flagged the first-run telemetry default as one of the highest-bounce, cheapest-to-fix trust defects. The prompt defaulted to accept (`[Y/n]`): a bare Enter or any unrecognized keystroke was recorded as consent. For a tool that leads with "local-first", treating a reflexive keystroke as agreement to send usage data is the wrong default and reads as a dark pattern at the exact moment a skeptic evaluates the project.

## Approach

Flip the first-run default to decline (`[y/N]`) so telemetry is genuinely opt-in: silence means no. This reverses the consent-default stance of D117 ("default opt-in") and D282, which chose default-on to protect pre-PMF funnel/retention data. That cost is near-zero right now (adoption is ~0, so the protected dataset barely exists yet), while the trust cost is paid up front against every evaluating developer. Rejected alternatives: keeping Enter-enables (opt-out with a friendlier label, which just re-creates the finding) and forced-choice / no-default (a true opt-in, but adds first-run friction; recorded as the lever to revisit if participation proves too thin). See D340.

## What changed

- `consent.py`: the first-run default flips to decline. A bare Enter or unrecognized input leaves telemetry off; only an explicit `y`/`yes` enables it. The version-bump re-prompt path still inherits the user's prior answer.
- `PRIVACY.md` and a stale baked-key comment in `client.py`: corrected to say opt-in, off by default.
- Tests: the two first-run assertions are flipped (empty and unrecognized input now leave telemetry disabled), plus a new re-prompt case locking that an unrecognized keystroke still applies the user's prior opt-in.

Telemetry is otherwise unchanged: still anonymous, allowlisted, content-free, and disableable via `NAURO_TELEMETRY=0` or `nauro telemetry disable`.

## What to review

The re-prompt branch in `consent.py`: confirm a version bump still defaults to the user's previous choice (so existing opted-in users are not silently dropped), and that `TELEMETRY_CONSENT_VERSION` staying at 1 means no existing user is re-prompted by this change.

## What's deferred

The forced-choice (no-default) variant. The matching site copy lives in `Nauro-AI/site` and ships as a separate PR.

## Test plan

15 consent tests and 70 telemetry-related tests pass via pytest; ruff clean; the frozen 1.0 public-contract snapshot test passes unchanged. An independent Codex review returned APPROVED (one nit fixed: the stale `client.py` comment).

Refs: Nauro D340 (supersedes the consent-default stance of D117 and D282).
