### PR TITLE
Harden decision_model frontmatter split and drop stale migration prose

### DIFF
--- a/packages/nauro-core/src/nauro_core/decision_model.py
+++ b/packages/nauro-core/src/nauro_core/decision_model.py
@@ -4,15 +4,14 @@ The authoritative shape for a parsed decision. `parse_decision` reads a
 markdown file with YAML frontmatter and returns a validated `Decision`.
 `format_decision` goes the other way.
 
-Strict by design — per the migration plan §9, unknown enum values, missing
-required fields, malformed YAML, non-ISO dates, reasonless rejected
-alternatives on active decisions, and superseded decisions without a
-`superseded_by` ref all raise.
+Strict by design. Unknown enum values, missing required fields, malformed
+YAML, non-ISO dates, reasonless rejected alternatives on active decisions,
+and superseded decisions without a `superseded_by` ref all raise.
 
 Supersession refs (`supersedes`, `superseded_by`) are validated as plain
 integer strings: "70", not "070" or "070-some-slug" or "D70".
 
-Field model (see plan §2):
+Field model:
     Required frontmatter: date, confidence.
     Defaulted frontmatter: version (1), status (active).
     Optional frontmatter: decision_type, reversibility, source, files_affected,
@@ -175,13 +174,13 @@ class Decision(BaseModel):
         return self
 
 
-# ── Frontmatter exclusion set (plan §12.2) ──
+# ── Frontmatter exclusion set ──
 #
 # Fields derived from the filename or body that must NOT appear in the
 # frontmatter dump. Kept as a module-level constant because
 # format_decision applies it; if this ends up being applied in a second
 # place (snapshot v2, a remote payload serializer), split the model into
-# DecisionMetadata + Decision per plan §12.2.
+# DecisionMetadata + Decision.
 _DERIVED_FIELDS: frozenset[str] = frozenset({"num", "title", "rationale", "body", "content"})
 
 # Canonical key order for the frontmatter block. `rejected` is not in this
@@ -210,29 +209,27 @@ _SUBSECTION_SPLIT = re.compile(r"^###\s+(.+?)\s*$", re.MULTILINE)
 _DECISION_ANCHOR = "## Decision"
 _REJECTED_ANCHOR = "## Rejected Alternatives"
 
+# Frontmatter fences and the H1 render template. Module-private, not part of the
+# public API. len(_FM_OPEN_FENCE) == 4 and len(_FM_CLOSE_FENCE) == 5, so slicing
+# by these lengths is byte-identical to the historical literal offsets.
+_FM_OPEN_FENCE = "---\n"
+_FM_CLOSE_FENCE = "\n---\n"
+_H1_FORMAT = "# {num:03d} \u2014 {title}"
+
 
 def parse_decision(text: str, filename: str) -> Decision:
     """Parse a decision markdown file into a validated ``Decision``.
 
     Strict by design: raises ``ValueError`` (and propagates
     ``pydantic.ValidationError``) on any deviation from the canonical
-    v2 format. Migration-time tolerance lives in the Phase 3 script.
+    v2 format.
 
     Raises:
         ValueError: missing/unterminated frontmatter, missing H1, missing
             `## Decision` section, malformed YAML, frontmatter not a mapping.
         pydantic.ValidationError: any field-level validation failure.
     """
-    if not text.startswith("---\n"):
-        raise ValueError(
-            f"{filename}: missing YAML frontmatter (decisions v2 requires a leading `---` fence)"
-        )
-    fm_end = text.find("\n---\n", 4)
-    if fm_end == -1:
-        raise ValueError(f"{filename}: unterminated YAML frontmatter")
-
-    frontmatter_block = text[4:fm_end]
-    body = text[fm_end + 5 :]
+    frontmatter_block, body = _split_frontmatter(text, filename)
 
     try:
         metadata = yaml.safe_load(frontmatter_block)
@@ -259,8 +256,8 @@ def parse_decision(text: str, filename: str) -> Decision:
     if rationale is None:
         raise ValueError(
             f"{filename}: missing `## Decision` section "
-            "(v2 does not accept `## Rationale` — Phase 3 migration renames "
-            "legacy files; the parser itself stays strict)"
+            "(the parser requires a `## Decision` heading and does not accept "
+            "the legacy `## Rationale` heading)"
         )
 
     rejected_list = _parse_rejected_subsections(rejected_body or "")
@@ -276,6 +273,23 @@ def parse_decision(text: str, filename: str) -> Decision:
         body=body,
         content=text,
     )
+
+
+def _split_frontmatter(text: str, filename: str) -> tuple[str, str]:
+    """Split a decision file into ``(frontmatter_block, body)`` on the fences.
+
+    The frontmatter is the text between the leading open fence and the first
+    following close fence. Raises ``ValueError`` when the open fence is absent
+    or the close fence is never found.
+    """
+    if not text.startswith(_FM_OPEN_FENCE):
+        raise ValueError(
+            f"{filename}: missing YAML frontmatter (decisions v2 requires a leading `---` fence)"
+        )
+    fm_end = text.find(_FM_CLOSE_FENCE, len(_FM_OPEN_FENCE))
+    if fm_end == -1:
+        raise ValueError(f"{filename}: unterminated YAML frontmatter")
+    return text[len(_FM_OPEN_FENCE) : fm_end], text[fm_end + len(_FM_CLOSE_FENCE) :]
 
 
 def _leading_fence_marker(line: str) -> str | None:
@@ -427,7 +441,7 @@ def format_decision(decision: Decision) -> str:
 
     sections: list[str] = [
         f"---\n{yaml_block}---",
-        f"# {decision.num:03d} \u2014 {decision.title}",
+        _H1_FORMAT.format(num=decision.num, title=decision.title),
         f"## Decision\n\n{decision.rationale.strip()}",
     ]
 

--- a/packages/nauro-core/tests/test_decision_model.py
+++ b/packages/nauro-core/tests/test_decision_model.py
@@ -8,9 +8,9 @@ Coverage:
     - Negative: every validation rule raises.
     - Positive: optional fields accept None / empty cleanly.
 
-Fixtures are synthesized inline because no file in the current store is in v2
-format yet — Phase 3 migration will produce v2 output. Each fixture is
-documented with a reference to the real decision it is modeled on.
+Fixtures are synthesized inline rather than read from the store, so the suite
+does not depend on store contents. Each fixture is documented with a reference
+to the real decision it is modeled on.
 """
 
 from __future__ import annotations
@@ -28,6 +28,7 @@ from nauro_core.decision_model import (
     DecisionType,
     RejectedAlternative,
     Reversibility,
+    _split_frontmatter,
     format_decision,
     parse_decision,
 )
@@ -389,6 +390,47 @@ class TestRationaleBoundary:
         d = parse_decision(text, "055-no-rejected.md")
         assert "## Context" in d.rationale
         assert "Second paragraph with a subsection heading." in d.rationale
+        assert d.rejected == []
+
+    def test_fenced_decision_heading_alone_raises(self) -> None:
+        """A `## Decision` that appears only inside a fenced code block must not
+        anchor. With no real section, the missing-section error is raised."""
+        text = (
+            "---\n"
+            "date: 2026-04-01\n"
+            "confidence: high\n"
+            "---\n\n"
+            "# 057 — Fenced decision only\n\n"
+            "Here is a sample document, not the real section:\n\n"
+            "```markdown\n"
+            "## Decision\n\n"
+            "Sample body inside the fence.\n"
+            "```\n\n"
+            "Prose but no real Decision heading.\n"
+        )
+        with pytest.raises(ValueError, match="missing `## Decision`"):
+            parse_decision(text, "057-fenced-decision-only.md")
+
+    def test_fenced_fake_decision_before_real_anchors_on_real(self) -> None:
+        """A fenced fake `## Decision` before the real one must not anchor; the
+        real, non-fenced heading is the anchor and the body parses cleanly."""
+        text = (
+            "---\n"
+            "date: 2026-04-01\n"
+            "confidence: high\n"
+            "---\n\n"
+            "# 058 — Fenced fake before real\n\n"
+            "```markdown\n"
+            "## Decision\n\n"
+            "This is a documentation sample, not the real section.\n"
+            "```\n\n"
+            "## Decision\n\n"
+            "The real chosen path lives here.\n"
+        )
+        d = parse_decision(text, "058-fenced-fake-before-real.md")
+        # The fenced sample precedes the anchor, so the rationale is exactly the
+        # real body below the genuine heading.
+        assert d.rationale == "The real chosen path lives here."
         assert d.rejected == []
 
 
@@ -762,3 +804,49 @@ class TestSourceCitationRoundTrip:
         once = format_decision(decision)
         twice = format_decision(parse_decision(once, "002-store-path.md"))
         assert once == twice
+
+
+# ── Frontmatter split helper ──
+
+
+class TestSplitFrontmatter:
+    """Direct unit tests for ``_split_frontmatter``.
+
+    The split must stay byte-identical to the historical inline slice, which
+    used the literal offsets 4 (length of the open fence) and 5 (length of the
+    close fence).
+    """
+
+    def test_valid_input_byte_exact_against_literal_slice(self) -> None:
+        text = (
+            "---\n"
+            "date: 2026-04-01\n"
+            "confidence: high\n"
+            "---\n\n"
+            "# 001 — Title\n\n"
+            "## Decision\n\nChose A.\n"
+        )
+        # Reproduce the pre-refactor inline slice exactly.
+        fm_end = text.find("\n---\n", 4)
+        expected_block = text[4:fm_end]
+        expected_body = text[fm_end + 5 :]
+
+        block, body = _split_frontmatter(text, "001-title.md")
+        assert block == expected_block
+        assert body == expected_body
+
+    def test_empty_frontmatter_yields_empty_block(self) -> None:
+        # An open fence immediately followed by the close fence: the block and
+        # the body are both empty. ("---\n\n---\n" is the smallest input whose
+        # close fence has the leading newline the fence requires.)
+        block, body = _split_frontmatter("---\n\n---\n", "001-empty.md")
+        assert block == ""
+        assert body == ""
+
+    def test_missing_open_fence_raises(self) -> None:
+        with pytest.raises(ValueError, match="missing YAML frontmatter"):
+            _split_frontmatter("no fence here\n", "001-no-fence.md")
+
+    def test_unterminated_raises(self) -> None:
+        with pytest.raises(ValueError, match="unterminated"):
+            _split_frontmatter("---\ndate: 2026-04-01\n", "001-unterminated.md")


### PR DESCRIPTION
## Why

The frontmatter-fence offsets and the decision H1 template lived as duplicated
magic literals inside parse_decision and format_decision, and several docstrings
and comments still referenced a migration plan and a Phase 3 script that no
longer describe how the parser behaves. This is a mechanical cleanup pass: name
the frontmatter split so it is testable in isolation, and remove the stale prose,
without changing a single serialized byte.

## Approach

Extract the inline frontmatter-fence slice into a named helper,
_split_frontmatter, and route the fence literals and the H1 render through
module-private constants (_FM_OPEN_FENCE, _FM_CLOSE_FENCE, _H1_FORMAT). The split
is byte-identical by construction: len("---\n") is 4 and len("\n---\n") is 5, so
slicing by the constant lengths reproduces the previous literal offsets exactly.
The new constants are underscore-prefixed and are not added to __all__, so the
frozen public surface is unchanged.

The strict parser contract is preserved verbatim. The missing-section error keeps
its "missing `## Decision` section" prefix; only the trailing parenthetical is
rewritten to accurate present-tense prose. The enums, the advertised decision-type
tuple, the frontmatter key order, and the on-disk format are untouched.

## What changes

- New module-private constants for the two frontmatter fences and the H1 template.
- New _split_frontmatter(text, filename) helper; parse_decision calls it in place
  of the inline slice.
- format_decision renders the H1 via the shared template.
- Docstring and comment cleanup: drop references to a migration plan and a Phase 3
  script that no longer match the parser, rewritten in present tense.
- Tests: direct unit coverage for _split_frontmatter (valid split checked
  byte-exact against the literal-offset result, empty block, missing open fence,
  unterminated), plus two tests proving a fenced `## Decision` never anchors (as
  the sole occurrence it raises the missing-section error; before a real heading
  it anchors on the real one).

## What to review

- Fence-length arithmetic in _split_frontmatter. len("---\n") is 4 and
  len("\n---\n") is 5, so the constant-driven slices
  (text[len(_FM_OPEN_FENCE):fm_end] and text[fm_end + len(_FM_CLOSE_FENCE):])
  reproduce the previous literal offsets (text[4:fm_end] and text[fm_end + 5:])
  exactly. The byte-exact unit test pins this against the pre-refactor slice.
- H1 render spec. _H1_FORMAT keeps the :03d zero-pad and the em-dash separator,
  so format_decision output is byte-identical. Spot-check that decision number 7
  renders as `# 007 — Title`.
- Frozen surface. Confirm __all__, the five enums (DecisionStatus,
  DecisionConfidence, DecisionType, Reversibility, DecisionSource),
  DECISION_TYPE_VALUES, and _FRONTMATTER_ORDER are unchanged, so the 1.0 public
  and store contract is untouched. The public_contract snapshot stays zero-diff.

## Test plan

- packages/nauro-core/tests/test_decision_model.py: 58 passed.
- packages/nauro-core/tests/: 900 passed.
- packages/nauro/tests/test_public_contract.py: passed with zero snapshot diff
  (the 1.0 frozen public surface is unchanged).
- ruff check packages/ and ruff format --check packages/: clean.
- Callers of parse_decision/format_decision across the nauro package
  (store, cross-surface, parity, sync-merge, graph, hook): 178 passed, 10 skipped.

## Deferred

None.
