### PR TITLE
Add PR template and align subagents to three core sections

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+<!--
+PR descriptions are for reviewers, not changelogs: lead with why, let the diff carry the what.
+Keep it short. Write under each heading; the comment prompts are guidance and do not render.
+Add "## Risk / what to review" (non-obvious logic, edge cases, a frozen surface, lower-confidence areas)
+or "## Deferred" (intentionally out of scope; link the follow-up) as their own headings only when they carry weight.
+Link related issues, e.g. "Closes #123". Reference Nauro decisions by number, e.g. D154, where relevant.
+-->
+
+## Why
+
+<!-- The problem or motivation: what was wrong, missing, or worth changing. -->
+
+## What changed
+
+<!-- A high-level summary, grouped by concern. The diff carries the line-by-line. -->
+
+## Test plan
+
+<!-- What you ran and the result, or note why testing does not apply. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,7 @@
 <!--
 PR descriptions are for reviewers, not changelogs: lead with why, let the diff carry the what.
-Keep it short. Write under each heading; the comment prompts are guidance and do not render.
+Keep it short and scale it to the change: a small PR needs only a line or two per heading.
+Write under each heading; the comment prompts are guidance and do not render.
 Add "## Risk / what to review" (non-obvious logic, edge cases, a frozen surface, lower-confidence areas)
 or "## Deferred" (intentionally out of scope; link the follow-up) as their own headings only when they carry weight.
 Link related issues, e.g. "Closes #123". Reference Nauro decisions by number, e.g. D154, where relevant.

--- a/packages/nauro/src/nauro/agents/nauro-executor.md
+++ b/packages/nauro/src/nauro/agents/nauro-executor.md
@@ -39,7 +39,7 @@ Commit your work to the local branch. **Do not push to remote and do not open a 
 2. **Test.** Run the relevant test suite.
 3. **Cross-package dependencies stay in sync.** If the change bumps a dependency pinned across multiple packages or lockfiles, regenerate every affected manifest in the same commit. Use the project's release-helper tooling when one exists.
 4. **Commit.** Default to **one commit per PR**. Subject under 72 chars, imperative voice. Body includes a Why paragraph and a footer referencing the decision the planner recorded, if any. Split into multiple commits only when the plan explicitly justifies it — meaningful, independently-revertible stages (e.g., bug fix + unrelated refactor, or a sequence with a logical hand-off between commits). For bulk cleanup, refactors, or any bounded single-purpose work, one commit is right. The PR body conveys structure; the branch doesn't need to mirror it.
-5. **Draft the PR description.** Follow the project's PR template: Why / Approach / What changed / What to review / Deferred / Test plan. Narrative for reviewers, not a changelog. Reference any decision the planner recorded.
+5. **Draft the PR description.** Follow `.github/PULL_REQUEST_TEMPLATE.md`. The core sections are Why / What changed / Test plan; add "Risk / what to review" and "Deferred" as their own headings only when they carry weight. Narrative for reviewers, not a changelog. Reference any decision the planner recorded.
 
 ## What you do NOT do at this stage
 

--- a/packages/nauro/src/nauro/agents/nauro-reviewer.md
+++ b/packages/nauro/src/nauro/agents/nauro-reviewer.md
@@ -68,7 +68,7 @@ These rules apply after the code-review pass. They protect long-lived project co
 
 #### Hard rules (BLOCK if any fail)
 
-1. **PR body has the required sections.** From `.github/PULL_REQUEST_TEMPLATE.md`: Why, Approach, What changed, What to review, What's deferred, Test plan. Missing Why / Approach / Test plan is always a block. Missing What to review / Deferred is a block unless the PR is genuinely trivial (typo, doc-only, lockfile bump) — say so explicitly when waiving.
+1. **PR body has the required sections.** From `.github/PULL_REQUEST_TEMPLATE.md`: Why, What changed, Test plan. Missing any of the three is always a block. "Risk / what to review" and "Deferred" are conditional headings: block only when a real risk or a real deferral was omitted (reviewer judgment), not merely because the heading is absent.
 2. **Every referenced decision resolves.** Any decision reference in the PR body or commit messages must resolve via `get_decision`. An unresolved reference blocks.
 3. **No personal paths.** Grep the diff and PR body for `/Users/<name>/` or similar. Any match blocks.
 4. **No internal labels in public repos.** Internal labeling schemes, dated milestones, and internal filenames in user-facing diffs (docs, READMEs, code comments) block. CI configs and internal tooling are fine.


### PR DESCRIPTION
## Why

Two bundled subagents told contributors to follow a `.github/PULL_REQUEST_TEMPLATE.md`
that did not exist, and prescribed a six-section shape that overlapped and forced
empty sections on small PRs.

## What changed

- New `.github/PULL_REQUEST_TEMPLATE.md` (codex-reviewed): three core sections
  (Why / What changed / Test plan), with Risk / what to review and Deferred added
  only when they carry weight.
- `nauro-executor.md` and `nauro-reviewer.md` aligned to it. The reviewer now blocks
  only on the three core sections; Risk / Deferred block only when a real risk or
  deferral was omitted, not on a missing heading.

## Test plan

test_agents_drift + test_public_contract + test_skills_drift: 161 passed; ruff clean.

## Deferred

claude-plugins mirror re-render (`nauro render-plugin`), site template sync, and a
stale-"Approach"-phrasing cleanup in `ship_task_body.md` / `nauro-reviewer.md`.
