### PR TITLE
Align stale PR-template phrasing to three core sections

### DIFF
--- a/.agents/skills/nauro-ship-task/SKILL.md
+++ b/.agents/skills/nauro-ship-task/SKILL.md
@@ -25,7 +25,7 @@ Before invoking `@nauro-planner`, the parent session confirms the planner will r
 
 ### 1. Plan
 
-Invoke the `@nauro-planner` subagent with the task description. The planner runs `check_decision` against the proposed approach, classifies as GREEN / AMBER / RED, reads related decision bodies via `get_decision`, investigates the code, and returns a plan in the PR-template shape (Why / Approach / What changes / What's deferred / Test plan), plus the verdict line and any decision number it drafted.
+Invoke the `@nauro-planner` subagent with the task description. The planner runs `check_decision` against the proposed approach, classifies as GREEN / AMBER / RED, reads related decision bodies via `get_decision`, investigates the code, and returns a plan in the plan shape (Why / Approach / What changes / What's deferred / Test plan), plus the verdict line and any decision number it drafted.
 
 If the planner returns RED with a supersede draft, the chain pauses here. Surface the draft to the user. Only on explicit user approval (or an explicit "override RED on the cited decision, proceed") does the chain continue to the executor.
 
@@ -81,7 +81,7 @@ If the body would be long, that's fine — paste it anyway. Skipping the verbati
 
 ### 8. Push
 
-On approval, push the branch. Write the drafted description to a file and open the PR with `gh pr create --body-file <file>` — passing the body inline breaks on quote characters in the drafted body. If `gh` is unavailable, hand the user the PR-creation URL the push prints (or the compare URL constructed from the remote and branch). Decisions filed during the chain go in the PR's Approach section by paraphrase, not by raw decision number — the public-repo convention is to describe the doctrine move ("the bundled-subagents pattern"), not cite internal D-numbers.
+On approval, push the branch. Write the drafted description to a file and open the PR with `gh pr create --body-file <file>` — passing the body inline breaks on quote characters in the drafted body. If `gh` is unavailable, hand the user the PR-creation URL the push prints (or the compare URL constructed from the remote and branch). Decisions filed during the chain go in the PR body by paraphrase (Why or What changed), not by raw decision number — the public-repo convention is to describe the doctrine move ("the bundled-subagents pattern"), not cite internal D-numbers.
 
 ## Rules
 

--- a/.claude/skills/nauro-ship-task/SKILL.md
+++ b/.claude/skills/nauro-ship-task/SKILL.md
@@ -25,7 +25,7 @@ Before invoking `@nauro-planner`, the parent session confirms the planner will r
 
 ### 1. Plan
 
-Invoke the `@nauro-planner` subagent with the task description. The planner runs `check_decision` against the proposed approach, classifies as GREEN / AMBER / RED, reads related decision bodies via `get_decision`, investigates the code, and returns a plan in the PR-template shape (Why / Approach / What changes / What's deferred / Test plan), plus the verdict line and any decision number it drafted.
+Invoke the `@nauro-planner` subagent with the task description. The planner runs `check_decision` against the proposed approach, classifies as GREEN / AMBER / RED, reads related decision bodies via `get_decision`, investigates the code, and returns a plan in the plan shape (Why / Approach / What changes / What's deferred / Test plan), plus the verdict line and any decision number it drafted.
 
 If the planner returns RED with a supersede draft, the chain pauses here. Surface the draft to the user. Only on explicit user approval (or an explicit "override RED on the cited decision, proceed") does the chain continue to the executor.
 
@@ -81,7 +81,7 @@ If the body would be long, that's fine — paste it anyway. Skipping the verbati
 
 ### 8. Push
 
-On approval, push the branch. Write the drafted description to a file and open the PR with `gh pr create --body-file <file>` — passing the body inline breaks on quote characters in the drafted body. If `gh` is unavailable, hand the user the PR-creation URL the push prints (or the compare URL constructed from the remote and branch). Decisions filed during the chain go in the PR's Approach section by paraphrase, not by raw decision number — the public-repo convention is to describe the doctrine move ("the bundled-subagents pattern"), not cite internal D-numbers.
+On approval, push the branch. Write the drafted description to a file and open the PR with `gh pr create --body-file <file>` — passing the body inline breaks on quote characters in the drafted body. If `gh` is unavailable, hand the user the PR-creation URL the push prints (or the compare URL constructed from the remote and branch). Decisions filed during the chain go in the PR body by paraphrase (Why or What changed), not by raw decision number — the public-repo convention is to describe the doctrine move ("the bundled-subagents pattern"), not cite internal D-numbers.
 
 ## Rules
 

--- a/.cursor/rules/nauro-ship-task.mdc
+++ b/.cursor/rules/nauro-ship-task.mdc
@@ -25,7 +25,7 @@ Before invoking `@nauro-planner`, the parent session confirms the planner will r
 
 ### 1. Plan
 
-Invoke the `@nauro-planner` subagent with the task description. The planner runs `check_decision` against the proposed approach, classifies as GREEN / AMBER / RED, reads related decision bodies via `get_decision`, investigates the code, and returns a plan in the PR-template shape (Why / Approach / What changes / What's deferred / Test plan), plus the verdict line and any decision number it drafted.
+Invoke the `@nauro-planner` subagent with the task description. The planner runs `check_decision` against the proposed approach, classifies as GREEN / AMBER / RED, reads related decision bodies via `get_decision`, investigates the code, and returns a plan in the plan shape (Why / Approach / What changes / What's deferred / Test plan), plus the verdict line and any decision number it drafted.
 
 If the planner returns RED with a supersede draft, the chain pauses here. Surface the draft to the user. Only on explicit user approval (or an explicit "override RED on the cited decision, proceed") does the chain continue to the executor.
 
@@ -81,7 +81,7 @@ If the body would be long, that's fine — paste it anyway. Skipping the verbati
 
 ### 8. Push
 
-On approval, push the branch. Write the drafted description to a file and open the PR with `gh pr create --body-file <file>` — passing the body inline breaks on quote characters in the drafted body. If `gh` is unavailable, hand the user the PR-creation URL the push prints (or the compare URL constructed from the remote and branch). Decisions filed during the chain go in the PR's Approach section by paraphrase, not by raw decision number — the public-repo convention is to describe the doctrine move ("the bundled-subagents pattern"), not cite internal D-numbers.
+On approval, push the branch. Write the drafted description to a file and open the PR with `gh pr create --body-file <file>` — passing the body inline breaks on quote characters in the drafted body. If `gh` is unavailable, hand the user the PR-creation URL the push prints (or the compare URL constructed from the remote and branch). Decisions filed during the chain go in the PR body by paraphrase (Why or What changed), not by raw decision number — the public-repo convention is to describe the doctrine move ("the bundled-subagents pattern"), not cite internal D-numbers.
 
 ## Rules
 

--- a/packages/nauro/src/nauro/agents/nauro-planner.md
+++ b/packages/nauro/src/nauro/agents/nauro-planner.md
@@ -39,7 +39,7 @@ You plan changes. You do not implement them. Use Bash for read-only investigatio
 
 3. **Investigate the current code.** Use Read/Grep/Glob to verify the change is necessary and your mental model matches what's in the repo. Scale to the verdict: GREEN reads a few files; AMBER reads broadly across affected modules; RED reads the full surface of every decision that would be touched.
 
-4. **Write the plan in the PR-template shape.**
+4. **Write the plan in this shape.**
     - **DOCTRINE: GREEN | AMBER | RED** — verdict + the decision references that informed it (omit only if GREEN with zero hits)
     - **Why** — the problem or motivation
     - **Approach** — the choice, and what was considered or rejected. **When the verdict is AMBER or RED, 2–3 alternatives with concrete tradeoffs are mandatory; the user picks before commit.** When GREEN, alternatives are at your discretion — present them only when the approach itself is non-obvious.

--- a/packages/nauro/src/nauro/agents/nauro-reviewer.md
+++ b/packages/nauro/src/nauro/agents/nauro-reviewer.md
@@ -82,7 +82,7 @@ These rules apply after the code-review pass. They protect long-lived project co
 - **Example-as-claim.** A single tool pairing (e.g., "Claude Code → Perplexity") presented as the general behavior. Suggest generalizing or framing as illustrative.
 - **Explicit negation.** Anti-frames like "Not a memory tool." Suggest the positive assertion in opposition ("Decisional, not observational").
 - **Casual language in code comments**, especially in public repos.
-- **Scope creep.** Changes that exceed the Why and Approach. Flag for the author to either expand the description or trim the diff.
+- **Scope creep.** Changes that exceed the change's stated why and approach. Flag for the author to either expand the description or trim the diff.
 - **Speculative infrastructure.** Discovery endpoints, schema layers, or indirection without a concrete incident or scale pressure.
 
 ## Return format

--- a/packages/nauro/src/nauro/skills/ship_task_body.md
+++ b/packages/nauro/src/nauro/skills/ship_task_body.md
@@ -27,7 +27,7 @@ Before invoking `@nauro-planner`, the parent session confirms the planner will r
 
 ### 1. Plan
 
-Invoke the `@nauro-planner` subagent with the task description. The planner runs `check_decision` against the proposed approach, classifies as GREEN / AMBER / RED, reads related decision bodies via `get_decision`, investigates the code, and returns a plan in the PR-template shape (Why / Approach / What changes / What's deferred / Test plan), plus the verdict line and any decision number it drafted.
+Invoke the `@nauro-planner` subagent with the task description. The planner runs `check_decision` against the proposed approach, classifies as GREEN / AMBER / RED, reads related decision bodies via `get_decision`, investigates the code, and returns a plan in the plan shape (Why / Approach / What changes / What's deferred / Test plan), plus the verdict line and any decision number it drafted.
 
 If the planner returns RED with a supersede draft, the chain pauses here. Surface the draft to the user. Only on explicit user approval (or an explicit "override RED on the cited decision, proceed") does the chain continue to the executor.
 
@@ -83,7 +83,7 @@ If the body would be long, that's fine — paste it anyway. Skipping the verbati
 
 ### 8. Push
 
-On approval, push the branch. Write the drafted description to a file and open the PR with `gh pr create --body-file <file>` — passing the body inline breaks on quote characters in the drafted body. If `gh` is unavailable, hand the user the PR-creation URL the push prints (or the compare URL constructed from the remote and branch). Decisions filed during the chain go in the PR's Approach section by paraphrase, not by raw decision number — the public-repo convention is to describe the doctrine move ("the bundled-subagents pattern"), not cite internal D-numbers.
+On approval, push the branch. Write the drafted description to a file and open the PR with `gh pr create --body-file <file>` — passing the body inline breaks on quote characters in the drafted body. If `gh` is unavailable, hand the user the PR-creation URL the push prints (or the compare URL constructed from the remote and branch). Decisions filed during the chain go in the PR body by paraphrase (Why or What changed), not by raw decision number — the public-repo convention is to describe the doctrine move ("the bundled-subagents pattern"), not cite internal D-numbers.
 
 ## Rules
 


### PR DESCRIPTION
## Why

Follow-up to the PR-template tightening: a few bundled subagent and skill files still
named the old six-section "PR-template shape" or routed filed decisions to the removed
"Approach" section.

## What changed

- `ship_task_body.md` and `nauro-planner.md`: relabel the plan shape (it keeps Approach
  by design, the plan is where alternatives live) so it no longer claims to mirror the PR
  template; route filed-decision paraphrases to the PR body (Why or What changed) instead
  of an Approach section.
- `nauro-reviewer.md`: the scope-creep flag now reads "the change's stated why and
  approach" rather than implying a required Approach heading.
- Regenerated the three ship-task dogfood copies (.claude / .agents / .cursor).

## Test plan

test_skills_drift + test_agents_drift + test_public_contract: 161 passed; ruff clean.

## Deferred

The claude-plugins mirror re-render (`nauro render-plugin`) is still pending from the
prior PR and now also covers these agent edits.
