### PR TITLE
Centralize decision id and filename formatting in parsing helpers

### DIFF
--- a/packages/nauro-core/src/nauro_core/operations/_in_memory_store.py
+++ b/packages/nauro-core/src/nauro_core/operations/_in_memory_store.py
@@ -7,9 +7,7 @@ introspecting the broader file table.
 
 from __future__ import annotations
 
-from nauro_core.constants import DECISIONS_DIR
-
-_DECISIONS_PREFIX = f"{DECISIONS_DIR}/"
+from nauro_core.parsing import _stem_from_decision_path
 
 
 class InMemoryStore:
@@ -69,9 +67,4 @@ class InMemoryStore:
 
 def _decision_stem(path: str) -> str | None:
     """Return the decision file stem when ``path`` targets ``decisions/*.md``."""
-    if not path.startswith(_DECISIONS_PREFIX):
-        return None
-    tail = path[len(_DECISIONS_PREFIX) :]
-    if "/" in tail or not tail.endswith(".md"):
-        return None
-    return tail[: -len(".md")]
+    return _stem_from_decision_path(path)

--- a/packages/nauro-core/src/nauro_core/operations/check_decision.py
+++ b/packages/nauro-core/src/nauro_core/operations/check_decision.py
@@ -27,7 +27,11 @@ from nauro_core.operations.results import (
     RelatedDecision,
 )
 from nauro_core.operations.store import Store
-from nauro_core.parsing import extract_decision_number
+from nauro_core.parsing import (
+    _canonical_decision_id,
+    _decision_label,
+    extract_decision_number,
+)
 from nauro_core.search import union_retrieve
 from nauro_core.validation import check_content_length, is_scaffold_seed
 
@@ -106,7 +110,7 @@ def _hit_to_related(hit: dict, by_num: dict[int, Decision]) -> RelatedDecision:
     """Lift a ``bm25_retrieve`` hit into the canonical retrieval-hit shape."""
     num = hit["number"]
     decision = by_num.get(num)
-    canonical_id = f"decision-{num:03d}"
+    canonical_id = _canonical_decision_id(num)
     status = decision.status.value if decision else "active"
     date = decision.date.isoformat() if decision and decision.date else ""
     # Embedding-sourced hits carry similarity=None (no BM25 score); surface 0.0
@@ -133,7 +137,7 @@ def _assessment(related: list[RelatedDecision]) -> str:
     """
     top = related[0]
     top_num = extract_decision_number(top.id)
-    top_label = f"D{top_num:03d}" if top_num is not None else top.id
+    top_label = _decision_label(top_num) if top_num is not None else top.id
     # score == 0.0 marks an embedding-sourced hit carrying no BM25 score (see
     # _hit_to_related). Don't label it "BM25 0.0" — it didn't match lexically.
     match_note = f"BM25 {top.score:.1f}" if top.score > 0 else "semantic match"

--- a/packages/nauro-core/src/nauro_core/operations/decision_lookup.py
+++ b/packages/nauro-core/src/nauro_core/operations/decision_lookup.py
@@ -14,7 +14,11 @@ import logging
 
 from nauro_core.decision_model import Decision, parse_decision
 from nauro_core.operations.store import Store
-from nauro_core.parsing import extract_decision_number
+from nauro_core.parsing import (
+    _decision_filename,
+    _decision_number_prefix,
+    extract_decision_number,
+)
 
 logger = logging.getLogger("nauro_core.operations.decision_lookup")
 
@@ -43,7 +47,7 @@ def parse_all_decisions(store: Store) -> list[Decision]:
         if body is None:
             continue
         try:
-            parsed.append(parse_decision(body, f"{stem}.md"))
+            parsed.append(parse_decision(body, _decision_filename(stem)))
         except Exception:
             logger.debug("Skipping unparseable decision file: %s.md", stem)
             continue
@@ -66,7 +70,7 @@ def parse_decision_or_none(body: str, filename: str) -> Decision | None:
 
 def find_decision_stem_by_num(store: Store, num: int) -> str | None:
     """Return the file stem whose ``NNN-`` prefix matches ``num``, or None."""
-    prefix = f"{num:03d}-"
+    prefix = _decision_number_prefix(num)
     for stem in store.list_decisions():
         if stem.startswith(prefix):
             return stem

--- a/packages/nauro-core/src/nauro_core/operations/get_decision.py
+++ b/packages/nauro-core/src/nauro_core/operations/get_decision.py
@@ -24,7 +24,7 @@ from nauro_core.decision_model import Decision
 from nauro_core.operations.decision_lookup import parse_decision_or_none
 from nauro_core.operations.results import ErrorPayload, GetDecisionResult
 from nauro_core.operations.store import Store
-from nauro_core.parsing import extract_decision_number
+from nauro_core.parsing import _decision_filename, extract_decision_number
 
 # Frontmatter fields the header projection carries, in render order. These
 # are the triage signals a reader needs to decide whether a decision is
@@ -76,7 +76,7 @@ def get_decision(
             body = store.read_decision(stem)
             if body is not None:
                 if mode == "header":
-                    decision = parse_decision_or_none(body, f"{stem}.md")
+                    decision = parse_decision_or_none(body, _decision_filename(stem))
                     if decision is None:
                         return GetDecisionResult(
                             error=ErrorPayload(

--- a/packages/nauro-core/src/nauro_core/operations/propose_decision.py
+++ b/packages/nauro-core/src/nauro_core/operations/propose_decision.py
@@ -34,7 +34,6 @@ from typing import Literal
 
 from nauro_core.constants import (
     DECISION_HASHES_FILE,
-    DECISIONS_DIR,
     MIN_RATIONALE_LENGTH,
     OPEN_QUESTIONS_MD,
 )
@@ -60,7 +59,13 @@ from nauro_core.operations.results import (
     RelatedDecision,
 )
 from nauro_core.operations.store import Store
-from nauro_core.parsing import extract_decision_number
+from nauro_core.parsing import (
+    _canonical_decision_id,
+    _decision_filename,
+    _decision_number_prefix,
+    _decision_path,
+    extract_decision_number,
+)
 from nauro_core.questions import EntryBlock, OpenQuestionsFile
 from nauro_core.validation import (
     check_bm25_similarity,
@@ -254,7 +259,7 @@ def _write_decision_direct(store: Store, proposal: dict) -> str:
     next_num = _next_decision_num(store)
     title = proposal.get("title", "Untitled")
     slug = _slugify(title)
-    filename = f"{next_num:03d}-{slug}"
+    filename = f"{_decision_number_prefix(next_num)}{slug}"
     rationale = proposal.get("rationale") or title
 
     decision = Decision(
@@ -271,7 +276,7 @@ def _write_decision_direct(store: Store, proposal: dict) -> str:
         title=title,
         rationale=rationale,
     )
-    store.write_file(f"{DECISIONS_DIR}/{filename}.md", format_decision(decision))
+    store.write_file(_decision_path(filename), format_decision(decision))
 
     _update_hash_index(store, title, rationale, filename)
     return filename
@@ -357,7 +362,7 @@ def _to_related_decisions(
         date = decision.date.isoformat() if decision and decision.date else ""
         out.append(
             RelatedDecision(
-                id=f"decision-{num:03d}",
+                id=_canonical_decision_id(num),
                 title=hit.get("title", ""),
                 score=hit.get("similarity", 0.0),
                 status=status,
@@ -431,10 +436,10 @@ def _do_supersede(
                 ),
             ),
         )
-    new_decision = parse_decision(new_body, f"{new_decision_id}.md")
+    new_decision = parse_decision(new_body, _decision_filename(new_decision_id))
     new_decision_rewritten = new_decision.model_copy(update={"supersedes": str(old_num)})
     store.write_file(
-        f"{DECISIONS_DIR}/{new_decision_id}.md",
+        _decision_path(new_decision_id),
         format_decision(new_decision_rewritten),
     )
     new_num = new_decision.num
@@ -472,7 +477,7 @@ def _do_supersede(
             ),
         )
     try:
-        old_decision = parse_decision(old_body, f"{old_stem}.md")
+        old_decision = parse_decision(old_body, _decision_filename(old_stem))
         old_rewritten = old_decision.model_copy(
             update={
                 "status": DecisionStatus.superseded,
@@ -480,7 +485,7 @@ def _do_supersede(
             }
         )
         store.write_file(
-            f"{DECISIONS_DIR}/{old_stem}.md",
+            _decision_path(old_stem),
             format_decision(old_rewritten),
         )
     except Exception as exc:
@@ -540,7 +545,7 @@ def _do_update(
                 reason=f"update target {target_stem} could not be read.",
             ),
         )
-    target = parse_decision(body, f"{target_stem}.md")
+    target = parse_decision(body, _decision_filename(target_stem))
     date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     additional = (proposal.get("rationale") or "").strip()
     appended_rationale = (
@@ -553,7 +558,7 @@ def _do_update(
             "rationale": appended_rationale,
         }
     )
-    store.write_file(f"{DECISIONS_DIR}/{target_stem}.md", format_decision(updated))
+    store.write_file(_decision_path(target_stem), format_decision(updated))
 
     resolved, resolve_error = _apply_question_resolves(store, proposal, target_stem)
     if resolve_error is not None:

--- a/packages/nauro-core/src/nauro_core/parsing.py
+++ b/packages/nauro-core/src/nauro_core/parsing.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import re
 
-from nauro_core.constants import STACK_EMPTY_MARKER
+from nauro_core.constants import DECISIONS_DIR, STACK_EMPTY_MARKER
 
 # Tokens that end in a period without ending the sentence. A terminator
 # closing one of these is treated as part of the abbreviation, not a sentence
@@ -155,6 +155,49 @@ def _scan_prefix(text: str, low: str, prefix: str, found: set[int], max_number: 
         # i is always at least start + plen >= start + 1, so resuming the scan
         # at i never re-examines the just-handled prefix.
         start = low.find(prefix, i)
+
+
+# Decision id / filename formatting. These are the write-side counterparts to
+# extract_decision_number: they render a decision number or file stem into the
+# canonical id, label, filename-prefix, filename, and store-path forms used
+# across the operations kernel. Module-private (not exported in a public API)
+# so callers converge on one spelling of each form.
+
+
+def _canonical_decision_id(num: int) -> str:
+    """Render ``num`` as the canonical ``decision-NNN`` retrieval id."""
+    return f"decision-{num:03d}"
+
+
+def _decision_label(num: int) -> str:
+    """Render ``num`` as the short ``DNNN`` display label."""
+    return f"D{num:03d}"
+
+
+def _decision_number_prefix(num: int) -> str:
+    """Render ``num`` as the ``NNN-`` file-stem prefix."""
+    return f"{num:03d}-"
+
+
+def _decision_filename(stem: str) -> str:
+    """Render a decision file stem as its ``<stem>.md`` filename."""
+    return f"{stem}.md"
+
+
+def _decision_path(stem: str) -> str:
+    """Render a decision file stem as its store-relative ``decisions/<stem>.md`` path."""
+    return f"{DECISIONS_DIR}/{stem}.md"
+
+
+def _stem_from_decision_path(path: str) -> str | None:
+    """Return the decision file stem when ``path`` targets ``decisions/*.md``."""
+    prefix = f"{DECISIONS_DIR}/"
+    if not path.startswith(prefix):
+        return None
+    tail = path[len(prefix) :]
+    if "/" in tail or not tail.endswith(".md"):
+        return None
+    return tail[: -len(".md")]
 
 
 def extract_current_state(state_content: str) -> str:

--- a/packages/nauro-core/src/nauro_core/renderers.py
+++ b/packages/nauro-core/src/nauro_core/renderers.py
@@ -29,6 +29,7 @@ Per-tool surface area:
 from __future__ import annotations
 
 from nauro_core.constants import NO_RELATED_DECISIONS
+from nauro_core.parsing import _decision_label
 
 # Width target for the rendered text blocks. Picked to fit standard
 # terminal widths and Markdown chat clients without horizontal scroll.
@@ -42,7 +43,7 @@ def _id_to_label(decision_id: str) -> str:
     if decision_id.startswith(prefix):
         suffix = decision_id[len(prefix) :]
         if suffix.isdigit():
-            return f"D{int(suffix):03d}"
+            return _decision_label(int(suffix))
     return decision_id
 
 
@@ -227,7 +228,7 @@ def render_search_decisions(result: dict, query: str | None = None) -> str:
 
     for hit in hits:
         number = hit.get("number")
-        label = f"D{number:03d}" if isinstance(number, int) else "D???"
+        label = _decision_label(number) if isinstance(number, int) else "D???"
         status = hit.get("status", "")
         score = hit.get("score", 0.0)
         score_str = f"BM25 {score:5.2f}" if isinstance(score, (int, float)) else "BM25 ?"
@@ -265,7 +266,7 @@ def render_list_decisions(result: dict) -> str:
 
     for d in decisions:
         number = d.get("number")
-        label = f"D{number:03d}" if isinstance(number, int) else "D???"
+        label = _decision_label(number) if isinstance(number, int) else "D???"
         status = d.get("status", "")
         title = d.get("title", "") or "(no title)"
         lines.append(f"  - {label}  [{status:<10}]  {_truncate(title, _TITLE_BUDGET)}")

--- a/packages/nauro-core/tests/test_parsing.py
+++ b/packages/nauro-core/tests/test_parsing.py
@@ -1,6 +1,15 @@
 """Tests for nauro_core.parsing."""
 
+import pytest
+
+from nauro_core.constants import DECISIONS_DIR
 from nauro_core.parsing import (
+    _canonical_decision_id,
+    _decision_filename,
+    _decision_label,
+    _decision_number_prefix,
+    _decision_path,
+    _stem_from_decision_path,
     extract_decision_number,
     first_sentence_end,
     scan_decision_references,
@@ -134,3 +143,87 @@ class TestScanDecisionReferences:
 
     def test_multiple_references(self):
         assert scan_decision_references("D1 and D2 and decision-3", 100) == {1, 2, 3}
+
+
+# ── Decision id / filename formatters ──
+#
+# Byte-identity guard for the module-private formatters extracted from the
+# operations kernel. Each assertion pins the helper output against the exact
+# inline expression it replaced at its former call site, so a future edit to a
+# helper that drifts from that spelling fails here rather than silently at a
+# call site.
+
+_FORMATTER_NUMBERS = [0, 1, 5, 42, 100, 999]
+
+
+class TestDecisionNumberFormatters:
+    @pytest.mark.parametrize("num", _FORMATTER_NUMBERS)
+    def test_canonical_decision_id_matches_inline(self, num: int) -> None:
+        assert _canonical_decision_id(num) == f"decision-{num:03d}"
+
+    @pytest.mark.parametrize("num", _FORMATTER_NUMBERS)
+    def test_decision_label_matches_inline(self, num: int) -> None:
+        assert _decision_label(num) == f"D{num:03d}"
+
+    @pytest.mark.parametrize("num", _FORMATTER_NUMBERS)
+    def test_decision_number_prefix_matches_inline(self, num: int) -> None:
+        assert _decision_number_prefix(num) == f"{num:03d}-"
+
+
+class TestDecisionFilenameFormatters:
+    @pytest.mark.parametrize(
+        "stem",
+        ["001-foo", "042-use-postgres", "999-z", ""],
+    )
+    def test_decision_filename_matches_inline(self, stem: str) -> None:
+        assert _decision_filename(stem) == f"{stem}.md"
+
+    @pytest.mark.parametrize(
+        "stem",
+        ["001-foo", "042-use-postgres", "999-z", ""],
+    )
+    def test_decision_path_matches_inline(self, stem: str) -> None:
+        assert _decision_path(stem) == f"{DECISIONS_DIR}/{stem}.md"
+
+
+def _old_decision_stem(path: str) -> str | None:
+    """Reference copy of the former ``_in_memory_store._decision_stem`` logic."""
+    prefix = f"{DECISIONS_DIR}/"
+    if not path.startswith(prefix):
+        return None
+    tail = path[len(prefix) :]
+    if "/" in tail or not tail.endswith(".md"):
+        return None
+    return tail[: -len(".md")]
+
+
+class TestStemFromDecisionPath:
+    @pytest.mark.parametrize(
+        "path",
+        [
+            f"{DECISIONS_DIR}/001-foo.md",
+            f"{DECISIONS_DIR}/042-use-postgres.md",
+            f"{DECISIONS_DIR}/.md",
+            f"{DECISIONS_DIR}/001-foo",
+            f"{DECISIONS_DIR}/sub/001-foo.md",
+            f"{DECISIONS_DIR}/001-foo.txt",
+            "001-foo.md",
+            "state_current.md",
+            "",
+        ],
+    )
+    def test_matches_old_logic(self, path: str) -> None:
+        assert _stem_from_decision_path(path) == _old_decision_stem(path)
+
+    def test_prefixed_with_md_returns_stem(self) -> None:
+        path = f"{DECISIONS_DIR}/042-use-postgres.md"
+        assert _stem_from_decision_path(path) == "042-use-postgres"
+
+    def test_without_prefix_returns_none(self) -> None:
+        assert _stem_from_decision_path("042-use-postgres.md") is None
+
+    def test_prefixed_without_md_returns_none(self) -> None:
+        assert _stem_from_decision_path(f"{DECISIONS_DIR}/042-use-postgres") is None
+
+    def test_nested_path_returns_none(self) -> None:
+        assert _stem_from_decision_path(f"{DECISIONS_DIR}/sub/042.md") is None


### PR DESCRIPTION
## Why

The canonical decision id, DNNN label, NNN- stem prefix, filename, and
store-path forms were spelled inline across the operations kernel, the
renderers, and the in-memory store, with no single place to pin them. A drift
in any one spelling would pull retrieval ids, display labels, or on-disk paths
apart silently.

## What changed

Added module-private formatters to nauro_core.parsing (canonical id, label,
number prefix, filename, store path, and stem-from-path). The id, label,
number-prefix, filename, and store-path forms across check_decision,
decision_lookup, get_decision, propose_decision, _in_memory_store, and
renderers now route through these helpers. Output is byte-identical at every
site. The renderers _id_to_label and "D???" guards keep their own stricter
checks and are not routed through extract_decision_number, so behavior on
non-canonical or non-int ids is unchanged. Added parallel-equivalence tests
that pin each helper against the exact inline expression it replaced, over a
range of numbers and path shapes.

## Test plan

- nauro-core suite: 939 passed (+39 new formatter tests)
- Public contract snapshot: passes with zero diff (helpers are private, the
  curated public API is untouched)
- Full nauro package suite: 1533 passed, 10 skipped
- ruff check and ruff format --check clean on nauro-core

## Deferred

- PR 2b will co-locate the decision snippet helpers.
