### PR TITLE
Centralize snippet, body-cap, and bullet primitives in parsing

### DIFF
--- a/packages/nauro-core/src/nauro_core/graph.py
+++ b/packages/nauro-core/src/nauro_core/graph.py
@@ -26,7 +26,7 @@ Plain string operations only; no regex.
 from __future__ import annotations
 
 from nauro_core.decision_model import Decision
-from nauro_core.parsing import first_sentence_end, scan_decision_references
+from nauro_core.parsing import _cap_to_first_unit, scan_decision_references
 from nauro_core.questions import OpenQuestionsFile
 from nauro_core.validation import is_scaffold_seed
 
@@ -349,20 +349,3 @@ def _filter_open_questions(
             }
         )
     return result
-
-
-def _cap_to_first_unit(body: str) -> str:
-    """Cap a body to its first sentence or first line, whichever ends sooner.
-
-    The first line ends at the first newline; the first sentence ends per the
-    shared ``parsing.first_sentence_end`` grammar (terminator plus boundary,
-    abbreviations skipped). The shorter boundary wins, so a multi-sentence
-    single line truncates to the first sentence and a multi-line body to its
-    first line.
-    """
-    text = body.strip()
-    line_end = text.find("\n")
-    if line_end == -1:
-        line_end = len(text)
-    cut = min(line_end, first_sentence_end(text))
-    return text[:cut].rstrip()

--- a/packages/nauro-core/src/nauro_core/operations/diff_since_last_session.py
+++ b/packages/nauro-core/src/nauro_core/operations/diff_since_last_session.py
@@ -26,6 +26,7 @@ from nauro_core.constants import (
 )
 from nauro_core.operations.results import DiffSinceLastSessionResult
 from nauro_core.operations.store import Store
+from nauro_core.parsing import _is_top_level_bullet
 
 # Success-path sentinels rendered when the adapter cannot supply a usable
 # (baseline, latest) pair. Exposed as module constants so adapters can
@@ -236,11 +237,7 @@ def _diff_stack(old: str, new: str) -> list[str]:
     changes: list[str] = []
 
     def extract_bullets(content: str) -> list[str]:
-        return [
-            line.strip()
-            for line in content.split("\n")
-            if line.strip().startswith("- ") and not line.startswith("  ")
-        ]
+        return [line.strip() for line in content.split("\n") if _is_top_level_bullet(line)]
 
     old_bullets = extract_bullets(old)
     new_bullets = extract_bullets(new)

--- a/packages/nauro-core/src/nauro_core/parsing.py
+++ b/packages/nauro-core/src/nauro_core/parsing.py
@@ -65,6 +65,40 @@ def _ends_with_abbreviation(text: str, period_idx: int) -> bool:
     return len(token) == 1 and token.isalpha()
 
 
+def _first_sentence_snippet(text: str, length: int = 100) -> str:
+    """First sentence of ``text``, trimmed to ``length`` with a trailing ellipsis.
+
+    Splits at the first sentence boundary via the co-located ``first_sentence_end``,
+    drops the trailing terminator, trims to ``length`` characters, and appends
+    ``...`` when the first sentence runs longer than ``length``. This is the BM25
+    search snippet fallback used when no query word matches the rationale, so its
+    output shape is user-visible on the search surface.
+    """
+    end = first_sentence_end(text)
+    first_sentence = text[:end].rstrip(".!?")
+    snippet = first_sentence[:length].strip()
+    if len(first_sentence) > length:
+        snippet += "..."
+    return snippet
+
+
+def _cap_to_first_unit(body: str) -> str:
+    """Cap a body to its first sentence or first line, whichever ends sooner.
+
+    The first line ends at the first newline; the first sentence ends per the
+    co-located ``first_sentence_end`` grammar (terminator plus boundary,
+    abbreviations skipped). The shorter boundary wins, so a multi-sentence
+    single line truncates to the first sentence and a multi-line body to its
+    first line. Feeds the graph payload's open-question display bodies.
+    """
+    text = body.strip()
+    line_end = text.find("\n")
+    if line_end == -1:
+        line_end = len(text)
+    cut = min(line_end, first_sentence_end(text))
+    return text[:cut].rstrip()
+
+
 def extract_decision_number(identifier: str) -> int | None:
     """Extract the decision number from a decision identifier.
 
@@ -221,6 +255,17 @@ def extract_current_state(state_content: str) -> str:
     return "\n".join(current_lines).strip()
 
 
+def _is_top_level_bullet(line: str) -> bool:
+    """Whether ``line`` is a top-level ``- `` bullet, not an indented child.
+
+    The stripped line opens with ``- `` and the raw line carries no leading
+    indent, so a nested bullet under a parent item does not count. Shared by the
+    stack extractors here and the snapshot stack diff so the three sites agree on
+    what a top-level bullet is.
+    """
+    return line.strip().startswith("- ") and not line.startswith("  ")
+
+
 def extract_stack_oneliner(stack_content: str) -> str:
     """Extract a one-line stack summary listing only technology names."""
     if not stack_content.strip() or stack_content.strip() == STACK_EMPTY_MARKER:
@@ -229,7 +274,7 @@ def extract_stack_oneliner(stack_content: str) -> str:
     names: list[str] = []
     for line in stack_content.split("\n"):
         stripped = line.strip()
-        if stripped.startswith("- ") and not line.startswith("  "):
+        if _is_top_level_bullet(line):
             m = re.match(r"-\s+\*\*(.+?)\*\*", stripped)
             if m:
                 names.append(m.group(1))
@@ -246,7 +291,7 @@ def extract_stack_summary(stack_content: str) -> str:
         stripped = line.strip()
         if stripped.startswith("# ") or stripped.startswith("<!--"):
             continue
-        if (stripped.startswith("- ") and not line.startswith("  ")) or stripped.startswith("## "):
+        if _is_top_level_bullet(line) or stripped.startswith("## "):
             lines.append(stripped)
     return "\n".join(lines)
 

--- a/packages/nauro-core/src/nauro_core/search.py
+++ b/packages/nauro-core/src/nauro_core/search.py
@@ -19,7 +19,7 @@ import bm25s
 import Stemmer
 
 from nauro_core.decision_model import Decision, DecisionStatus
-from nauro_core.parsing import extract_relevance_snippet, first_sentence_end
+from nauro_core.parsing import _first_sentence_snippet, extract_relevance_snippet
 
 _stemmer = Stemmer.Stemmer("english")
 
@@ -76,13 +76,7 @@ def bm25_search(
         d = decisions[idx]
         snippet = extract_relevance_snippet(d.rationale, query_words)
         if not snippet and d.rationale:
-            # First sentence via the shared splitter, with the trailing
-            # terminator dropped to match the prior snippet shape.
-            end = first_sentence_end(d.rationale)
-            first_sentence = d.rationale[:end].rstrip(".!?")
-            snippet = first_sentence[:100].strip()
-            if len(first_sentence) > 100:
-                snippet += "..."
+            snippet = _first_sentence_snippet(d.rationale)
 
         ranked.append(
             {

--- a/packages/nauro-core/tests/test_parsing.py
+++ b/packages/nauro-core/tests/test_parsing.py
@@ -5,10 +5,13 @@ import pytest
 from nauro_core.constants import DECISIONS_DIR
 from nauro_core.parsing import (
     _canonical_decision_id,
+    _cap_to_first_unit,
     _decision_filename,
     _decision_label,
     _decision_number_prefix,
     _decision_path,
+    _first_sentence_snippet,
+    _is_top_level_bullet,
     _stem_from_decision_path,
     extract_decision_number,
     first_sentence_end,
@@ -227,3 +230,200 @@ class TestStemFromDecisionPath:
 
     def test_nested_path_returns_none(self) -> None:
         assert _stem_from_decision_path(f"{DECISIONS_DIR}/sub/042.md") is None
+
+
+# ── Snippet / body-cap / bullet primitives ──
+#
+# Golden characterization guard for the module-private primitives lifted out of
+# search.py and graph.py. Each case pins the CURRENT byte-for-byte output the
+# inline block produced at its former call site: these strings feed user-visible
+# BM25 search snippets and the graph open-question payload, so a future edit that
+# shifts the ellipsis style, the strip ordering, or the boundary rule must fail
+# here rather than silently change either surface. Expected strings are recorded
+# literals, not re-derived from the input.
+
+# A first sentence of exactly 100 characters (no terminator) stays whole; one
+# character longer trips the 100-char cap and gains the three-dot ellipsis. The
+# 101-char input is the 100-char one plus a trailing character, and its output
+# is the 100-char prefix (which equals the 100-char input) plus "...".
+_SNIPPET_100_INPUT = (
+    "The single readable search snippet line holds exactly one hundred "
+    "characters before any ellipsis xxz"
+)
+_SNIPPET_101_INPUT = _SNIPPET_100_INPUT + "z"
+
+_FIRST_SENTENCE_SNIPPET_CASES = [
+    (
+        "real_rationale_multi_sentence",
+        "Memcached is simpler than Redis for session caching. Lower overhead suffices.",
+        "Memcached is simpler than Redis for session caching",
+    ),
+    (
+        "multi_sentence_single_line",
+        "First sentence here. Second one.",
+        "First sentence here",
+    ),
+    (
+        "eg_abbreviation_not_clipped",
+        "Should we e.g. cache the index?",
+        "Should we e.g. cache the index",
+    ),
+    (
+        "ie_abbreviation_not_clipped",
+        "Use one store, i.e. the local one. Done.",
+        "Use one store, i.e. the local one",
+    ),
+    (
+        "empty",
+        "",
+        "",
+    ),
+    (
+        "whitespace_only",
+        "   ",
+        "",
+    ),
+    (
+        "exactly_100_chars_no_ellipsis",
+        _SNIPPET_100_INPUT,
+        _SNIPPET_100_INPUT,
+    ),
+    (
+        "over_100_chars_gets_ellipsis",
+        _SNIPPET_101_INPUT,
+        _SNIPPET_100_INPUT + "...",
+    ),
+]
+
+
+class TestFirstSentenceSnippet:
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [(text, expected) for _, text, expected in _FIRST_SENTENCE_SNIPPET_CASES],
+        ids=[label for label, _, _ in _FIRST_SENTENCE_SNIPPET_CASES],
+    )
+    def test_matches_golden(self, text: str, expected: str) -> None:
+        assert _first_sentence_snippet(text) == expected
+
+    def test_exactly_100_input_is_100_chars_and_keeps_no_ellipsis(self) -> None:
+        assert len(_SNIPPET_100_INPUT) == 100
+        assert not _first_sentence_snippet(_SNIPPET_100_INPUT).endswith("...")
+
+    def test_over_100_input_is_101_chars_and_appends_three_dots(self) -> None:
+        assert len(_SNIPPET_101_INPUT) == 101
+        out = _first_sentence_snippet(_SNIPPET_101_INPUT)
+        assert out.endswith("...")
+        assert out[:-3] == _SNIPPET_101_INPUT[:100]
+
+    def test_length_argument_caps_and_ellipsizes(self) -> None:
+        # The cap and ellipsis track the length argument, not a hardcoded 100.
+        assert _first_sentence_snippet("abcdefghij", length=5) == "abcde..."
+
+
+_CAP_TO_FIRST_UNIT_CASES = [
+    (
+        "multi_line_first_line_terminated",
+        "First line of the note.\nSecond line with more detail.",
+        "First line of the note.",
+    ),
+    (
+        "multi_sentence_single_line",
+        "First sentence here. Second sentence should be dropped.",
+        "First sentence here.",
+    ),
+    (
+        "eg_abbreviation_single_line",
+        "Should we e.g. cache the index here?",
+        "Should we e.g. cache the index here?",
+    ),
+    (
+        "multi_line_first_line_unterminated",
+        "Just the first line\nSecond line here.",
+        "Just the first line",
+    ),
+    (
+        "empty",
+        "",
+        "",
+    ),
+    (
+        "whitespace_only",
+        "   \n  ",
+        "",
+    ),
+    (
+        "real_open_question",
+        "Should we support team sync in v1 or defer to v2?",
+        "Should we support team sync in v1 or defer to v2?",
+    ),
+    (
+        "real_multi_paragraph_body",
+        "Explicit decision tracking prevents context loss.\n\nMore detail follows.",
+        "Explicit decision tracking prevents context loss.",
+    ),
+]
+
+
+class TestCapToFirstUnit:
+    @pytest.mark.parametrize(
+        ("body", "expected"),
+        [(body, expected) for _, body, expected in _CAP_TO_FIRST_UNIT_CASES],
+        ids=[label for label, _, _ in _CAP_TO_FIRST_UNIT_CASES],
+    )
+    def test_matches_golden(self, body: str, expected: str) -> None:
+        assert _cap_to_first_unit(body) == expected
+
+
+_IS_TOP_LEVEL_BULLET_CASES = [
+    ("top_level", "- Shipped the graph payload builder", True),
+    ("top_level_bold", "- **Python + Typer** chosen for CLI", True),
+    ("two_space_indent", "  - nested item", False),
+    ("four_space_indent", "    - deeper nested", False),
+    ("one_space_indent_still_top_level", " - single space still top level", True),
+    ("tab_indent_still_top_level", "\t- tab indented", True),
+    ("heading_h2", "## Infrastructure", False),
+    ("heading_h1", "# Stack", False),
+    ("empty", "", False),
+    ("dash_without_space", "-nospace", False),
+]
+
+
+class TestIsTopLevelBullet:
+    @pytest.mark.parametrize(
+        ("line", "expected"),
+        [(line, expected) for _, line, expected in _IS_TOP_LEVEL_BULLET_CASES],
+        ids=[label for label, _, _ in _IS_TOP_LEVEL_BULLET_CASES],
+    )
+    def test_matches_golden(self, line: str, expected: bool) -> None:
+        assert _is_top_level_bullet(line) is expected
+
+    def test_stack_sample_selects_only_top_level_bullets(self) -> None:
+        # Over a realistic stack.md sample, only the unindented "- " lines count;
+        # nested caveats and headings are excluded.
+        stack_sample = (
+            "# Stack\n"
+            "## Language & Framework\n"
+            "- **Python + Typer** chosen for fast CLI prototyping\n"
+            "  - sub-note about Typer version pinning\n"
+            "## Infrastructure\n"
+            "- **SQLite** for local-first storage\n"
+            "    - deeper nested caveat\n"
+        )
+        selected = [line for line in stack_sample.split("\n") if _is_top_level_bullet(line)]
+        assert selected == [
+            "- **Python + Typer** chosen for fast CLI prototyping",
+            "- **SQLite** for local-first storage",
+        ]
+
+    def test_questions_sample_selects_only_top_level_bullets(self) -> None:
+        questions_sample = (
+            "# Open Questions\n"
+            "- [Q1] Should we support team sync in v1 or defer to v2?\n"
+            "  - follow-up detail line\n"
+            "- [Q2] Do we need embeddings for retrieval?\n"
+        )
+        selected = [line for line in questions_sample.split("\n") if _is_top_level_bullet(line)]
+        assert selected == [
+            "- [Q1] Should we support team sync in v1 or defer to v2?",
+            "- [Q2] Do we need embeddings for retrieval?",
+        ]


### PR DESCRIPTION
## Why

The first-sentence snippet block (search.py), the graph body-cap helper
(graph.py), and the top-level bullet predicate (open-coded in three places)
were duplicated logic living outside parsing.py, the single home for
non-decision markdown parsing. This is the byte-identical continuation of the
machine-pass cleanup: converge each on one spelling without changing any
output.

## What changed

- Added three module-private helpers to `parsing.py`, each derived verbatim
  from its former call site:
  - `_first_sentence_snippet(text, length=100)` — the BM25 snippet fallback
    (first sentence, terminator dropped, trimmed to length, three-dot ellipsis
    when longer).
  - `_cap_to_first_unit(body)` — the graph open-question display-body cap
    (first line or first sentence, whichever ends sooner), moved out of
    graph.py.
  - `_is_top_level_bullet(line)` — the unindented `- ` bullet predicate.
- `search.py` now calls `_first_sentence_snippet`; `graph.py` imports
  `_cap_to_first_unit`; the snapshot stack diff and the two stack extractors
  call `_is_top_level_bullet`.
- Divergent bullet predicates (the unstripped-line check in `update_state`,
  and the stripped-only / `- [` checks in the state and questions diffs) are
  intentionally left as-is. Only the exact top-level-bullet form was folded.
- Helpers stay module-private and are not added to the frozen public surface.

## Test plan

- Added golden characterization tests in `test_parsing.py` that pin the
  current byte-for-byte output of all three helpers over a fixture corpus
  (real decision-body, state, stack, and open-questions samples) plus edge
  cases: multi-sentence single line, `e.g.`/`i.e.` abbreviations, exactly-100
  vs over-100 (ellipsis) cut, multi-line bodies, empty/whitespace, and
  indented bullets that must not count as top-level.
- Existing regressions stay green unmodified: `test_graph.py` body-cap tests,
  `test_search.py` snippet test, and the diff/parsing/stack suites.
- `nauro-core` suite: 970 passed. Public-contract snapshot: zero diff.
- ruff check + format clean; import-linter contracts kept.

## Deferred

- The single-consumer state-field extractor (`_extract_state_field`).
- The two BM25 `rationale` head slices in `search.py` (`[:200]` / `[:100]`)
  are their own pass.
- The bespoke lede / call-to-action / decision-title sites
  (`get_decision._lede`, the renderer extractors) stay bespoke.
