### PR TITLE
Key context builders on OPEN_QUESTIONS_MD constant

### DIFF
--- a/packages/nauro-core/src/nauro_core/context.py
+++ b/packages/nauro-core/src/nauro_core/context.py
@@ -14,6 +14,7 @@ from nauro_core.constants import (
     L0_QUESTIONS_LIMIT,
     L1_DECISIONS_LIMIT,
     L1_DECISIONS_SUMMARY_LIMIT,
+    OPEN_QUESTIONS_MD,
     PROJECT_MD,
     STACK_MD,
     STATE_CURRENT_FILENAME,
@@ -128,7 +129,7 @@ def build_l0(files: dict[str, str], decisions: list[Decision]) -> str:
     Args:
         files: Dict of store-relative keys to file contents.
             Recognized keys: "project.md", "state_current.md" (preferred;
-            legacy "state.md"), "stack.md", "questions.md".
+            legacy "state.md"), "stack.md", "open-questions.md".
         decisions: List of parsed decision dicts (from parse_decision).
     """
     sections: list[str] = []
@@ -159,7 +160,7 @@ def build_l0(files: dict[str, str], decisions: list[Decision]) -> str:
     if oneliner:
         sections.append("**Stack:** " + oneliner)
 
-    questions_content = files.get("questions.md", "")
+    questions_content = files.get(OPEN_QUESTIONS_MD, "")
     rendered_questions = _render_l0_open_questions(questions_content)
     if rendered_questions:
         sections.append("## Open Questions\n" + rendered_questions)
@@ -203,7 +204,7 @@ def build_l1(files: dict[str, str], decisions: list[Decision]) -> str:
     if stack.strip():
         sections.append(stack.strip())
 
-    questions_content = files.get("questions.md", "")
+    questions_content = files.get(OPEN_QUESTIONS_MD, "")
     if questions_content.strip():
         sections.append(questions_content.strip())
 
@@ -257,7 +258,7 @@ def build_l2(files: dict[str, str], decisions: list[Decision]) -> str:
     if stack.strip():
         sections.append(stack.strip())
 
-    questions_content = files.get("questions.md", "")
+    questions_content = files.get(OPEN_QUESTIONS_MD, "")
     if questions_content.strip():
         sections.append(questions_content.strip())
 

--- a/packages/nauro-core/src/nauro_core/operations/get_context.py
+++ b/packages/nauro-core/src/nauro_core/operations/get_context.py
@@ -27,12 +27,6 @@ from nauro_core.operations.decision_lookup import parse_all_decisions
 from nauro_core.operations.results import ErrorPayload, GetContextResult
 from nauro_core.operations.store import Store
 
-# build_l0/l1/l2 read questions content from the ``questions.md`` key
-# (a builder-internal convention that predates the ``open-questions.md``
-# on-disk filename). The kernel rebinds the loaded content under that
-# key so the builders find it.
-_QUESTIONS_BUILDER_KEY = "questions.md"
-
 # Builder dispatch keyed by level. Keeping this as a module-level dict
 # rather than an if/elif keeps the level-set check (``level in _BUILDERS``)
 # the single source of truth for valid levels.
@@ -63,7 +57,7 @@ def _load_context_files(store: Store, level: int) -> dict[str, str]:
 
     questions = store.read_file(OPEN_QUESTIONS_MD)
     if questions is not None:
-        files[_QUESTIONS_BUILDER_KEY] = questions
+        files[OPEN_QUESTIONS_MD] = questions
 
     # Prefer state_current.md; fall back to state.md for pre-upgrade stores.
     # Truthy check (not ``is not None``) so a migration that left an empty

--- a/packages/nauro-core/tests/operations/test_get_context.py
+++ b/packages/nauro-core/tests/operations/test_get_context.py
@@ -106,6 +106,24 @@ def test_l2_includes_state_history() -> None:
     assert "Adopt Postgres" in result.content
 
 
+def test_open_questions_body_reaches_every_level() -> None:
+    """The seeded ``open-questions.md`` body must survive the store to builder
+    hop at all three levels.
+
+    ``get_context`` loads ``open-questions.md`` and the builders read it back
+    under the same key. If either side drifts, the Open Questions section goes
+    silently empty while every other assertion here still passes. Pinning the
+    question body at L0/L1/L2 fails loudly on a half-done key change.
+    """
+    store = _seeded_store()
+    for level in (0, 1, 2):
+        result = get_context(store, level)
+        assert result.content is not None, f"level {level} returned None content"
+        assert "Do we cache?" in result.content, (
+            f"level {level} dropped the open-questions body: {result.content!r}"
+        )
+
+
 def test_legacy_state_md_falls_back_when_state_current_missing() -> None:
     """Pre-upgrade stores with only state.md still surface state content."""
     store = InMemoryStore(

--- a/packages/nauro-core/tests/test_context.py
+++ b/packages/nauro-core/tests/test_context.py
@@ -43,7 +43,7 @@ FULL_FILES = {
         "## Infrastructure\n"
         "- **AWS Lambda** \u2014 serverless\n"
     ),
-    "questions.md": (
+    "open-questions.md": (
         "# Open Questions\n"
         "- [Q1] How does auth work?\n"
         "- [Q2] What about caching?\n"
@@ -307,7 +307,7 @@ class TestBuildL0OpenQuestionsAgeProjection:
     _PROJECTION_PREFIX = "(open"
 
     def _files(self, content: str) -> dict[str, str]:
-        return {"questions.md": content}
+        return {"open-questions.md": content}
 
     def _today(self):
         return datetime.now(timezone.utc).date()
@@ -423,7 +423,7 @@ class TestBuildL0DiscoveryPointerExclusion:
     """
 
     def _files(self, content: str) -> dict[str, str]:
-        return {"questions.md": content}
+        return {"open-questions.md": content}
 
     def test_brief_pointer_excluded(self):
         content = (


### PR DESCRIPTION
## Why

The L0/L1/L2 context builders read open-questions content from a legacy
internal "questions.md" key, and get_context rebound the loaded
open-questions.md content under that alias so the builders would find it.
That left a filename literal matching no on-disk file and forced the caller
to carry a remap. PR 3b of the machine-pass cleanup removes the alias.

## What changed

- Key the builders on the canonical OPEN_QUESTIONS_MD constant (build_l0,
  build_l1, build_l2) instead of the "questions.md" literal; import the
  constant into context.py.
- Drop the _QUESTIONS_BUILDER_KEY remap and its comment in get_context; the
  caller now writes the loaded content under OPEN_QUESTIONS_MD directly.
- Move the direct-builder fixtures in test_context.py to the same key.
- Add a kernel guard pinning the open-questions body through get_context at
  L0/L1/L2.

The on-disk filename open-questions.md is unchanged; only the internal dict
key the builder reads changes, matched on both sides. The rendered L0/L1/L2
payload is byte-identical.

## Test plan

- nauro-core: 971 passed
- nauro: 1533 passed, 10 skipped
- test_public_contract.py: zero snapshot diff
- ruff check + ruff format --check on nauro-core: clean

## Risk / what to review

This is the one behavior-coupling item in the cleanup. The read (context.py,
three sites) and the write (get_context.py) must move together or the Open
Questions section empties silently. Review the OPEN_QUESTIONS_MD key on both
sides, and the questions-content assertions: the existing nauro-package L0
byte-for-byte baseline (test_get_context_parity.py, its _BASELINE_L0 carries
the Open Questions section) plus the new kernel L0/L1/L2 body guard in
test_get_context.py both fail if the two sides diverge.
