### PR TITLE
Single-source enum-value and state-template literals

### DIFF
--- a/packages/nauro-core/src/nauro_core/operations/check_decision.py
+++ b/packages/nauro-core/src/nauro_core/operations/check_decision.py
@@ -19,7 +19,7 @@ from nauro_core.constants import (
     NO_DECISIONS_TO_CHECK,
     NO_RELATED_DECISIONS,
 )
-from nauro_core.decision_model import Decision
+from nauro_core.decision_model import Decision, DecisionStatus
 from nauro_core.operations.decision_lookup import parse_all_decisions
 from nauro_core.operations.results import (
     CheckDecisionResult,
@@ -111,7 +111,7 @@ def _hit_to_related(hit: dict, by_num: dict[int, Decision]) -> RelatedDecision:
     num = hit["number"]
     decision = by_num.get(num)
     canonical_id = _canonical_decision_id(num)
-    status = decision.status.value if decision else "active"
+    status = decision.status.value if decision else DecisionStatus.active.value
     date = decision.date.isoformat() if decision and decision.date else ""
     # Embedding-sourced hits carry similarity=None (no BM25 score); surface 0.0
     # so the score field stays a float and signals "not a BM25 match".

--- a/packages/nauro-core/src/nauro_core/operations/propose_decision.py
+++ b/packages/nauro-core/src/nauro_core/operations/propose_decision.py
@@ -266,7 +266,9 @@ def _write_decision_direct(store: Store, proposal: dict) -> str:
         date=datetime.now(timezone.utc).date(),
         version=1,
         status=DecisionStatus.active,
-        confidence=DecisionConfidence(proposal.get("confidence") or "medium"),
+        confidence=DecisionConfidence(
+            proposal.get("confidence") or DecisionConfidence.medium.value
+        ),
         decision_type=_optional_enum(proposal.get("decision_type"), DecisionType),
         reversibility=_optional_enum(proposal.get("reversibility"), Reversibility),
         source=_optional_enum(proposal.get("source"), DecisionSource),
@@ -358,7 +360,7 @@ def _to_related_decisions(
     for hit in raw_hits:
         num = hit["number"]
         decision = by_num.get(num)
-        status = decision.status.value if decision else "active"
+        status = decision.status.value if decision else DecisionStatus.active.value
         date = decision.date.isoformat() if decision and decision.date else ""
         out.append(
             RelatedDecision(

--- a/packages/nauro-core/src/nauro_core/state.py
+++ b/packages/nauro-core/src/nauro_core/state.py
@@ -6,6 +6,23 @@ responsible for reading/writing files (local filesystem or S3).
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from typing import Final
+
+# Single-sourced state-file markers. state_current.md is written with the
+# header and the *Last updated* footer; _strip_current_header_footer must
+# recognize the same pair to peel a prior body back off before archiving it.
+# The write template and the strip helper therefore reference one constant each
+# so the recognized markers can never drift from the written ones.
+_CURRENT_STATE_HEADER: Final[str] = "# Current State"
+_LAST_UPDATED_PREFIX: Final[str] = "*Last updated: "
+_LAST_UPDATED_SUFFIX: Final[str] = "*"
+
+# ISO 8601, minute precision: the on-disk timestamp byte format.
+_TIMESTAMP_FORMAT: Final[str] = "%Y-%m-%dT%H:%MZ"
+
+# L2 context assembly joins state_current.md and state_history.md under this
+# heading separator.
+_STATE_HISTORY_SEPARATOR: Final[str] = "\n\n# State History\n\n"
 
 
 @dataclass
@@ -24,7 +41,7 @@ class StateUpdateResult:
 
 def _utc_timestamp() -> str:
     """Return current UTC time as ISO 8601 with minute precision."""
-    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%MZ")
+    return datetime.now(timezone.utc).strftime(_TIMESTAMP_FORMAT)
 
 
 def _strip_current_header_footer(content: str) -> str:
@@ -33,9 +50,9 @@ def _strip_current_header_footer(content: str) -> str:
     stripped: list[str] = []
     for line in lines:
         s = line.strip()
-        if s.startswith("# Current State"):
+        if s.startswith(_CURRENT_STATE_HEADER):
             continue
-        if s.startswith("*Last updated: ") and s.endswith("*"):
+        if s.startswith(_LAST_UPDATED_PREFIX) and s.endswith(_LAST_UPDATED_SUFFIX):
             continue
         stripped.append(line)
     return "\n".join(stripped).strip()
@@ -52,7 +69,10 @@ def prepare_state_update(new_state: str, current_content: str | None) -> StateUp
     """
     timestamp = _utc_timestamp()
 
-    new_current = f"# Current State\n\n{new_state}\n\n*Last updated: {timestamp}*\n"
+    new_current = (
+        f"{_CURRENT_STATE_HEADER}\n\n{new_state}\n\n"
+        f"{_LAST_UPDATED_PREFIX}{timestamp}{_LAST_UPDATED_SUFFIX}\n"
+    )
 
     history_entry: str | None = None
     if current_content is not None:
@@ -93,7 +113,7 @@ def assemble_state_for_context(
         return current_content
 
     if current_content is not None and history_content is not None:
-        return current_content + "\n\n# State History\n\n" + history_content
+        return current_content + _STATE_HISTORY_SEPARATOR + history_content
     if current_content is not None:
         return current_content
     if history_content is not None:

--- a/packages/nauro-core/src/nauro_core/validation.py
+++ b/packages/nauro-core/src/nauro_core/validation.py
@@ -15,6 +15,7 @@ from nauro_core.constants import (
     MIN_RATIONALE_LENGTH,
     VALID_CONFIDENCES,
 )
+from nauro_core.decision_model import DecisionConfidence
 from nauro_core.search import bm25_retrieve
 
 # Tier-2 BM25 defaults shared by local (nauro) and remote (mcp-server) surfaces.
@@ -155,7 +156,7 @@ def screen_structural(
     if not rationale:
         return ("reject", "Rationale is empty.")
 
-    confidence = proposal.get("confidence", "medium")
+    confidence = proposal.get("confidence", DecisionConfidence.medium.value)
     if confidence not in VALID_CONFIDENCES:
         return ("reject", f"Invalid confidence: {confidence}. Must be one of: {VALID_CONFIDENCES}")
 

--- a/packages/nauro-core/tests/operations/test_operations_update_state.py
+++ b/packages/nauro-core/tests/operations/test_operations_update_state.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import ast
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from pydantic import ValidationError
@@ -58,6 +59,17 @@ def test_current_only_non_overlapping_writes_new_body_and_appends_history() -> N
     history = store.read_file(STATE_HISTORY_FILENAME)
     assert history is not None
     assert "Implemented OAuth login flow with PKCE" in history
+
+
+def test_writes_byte_exact_current_and_history() -> None:
+    initial = "# Current State\n\n- Task one\n"
+    store = InMemoryStore(files={STATE_CURRENT_FILENAME: initial})
+    with patch("nauro_core.state._utc_timestamp", return_value="2026-04-08T15:30Z"):
+        update_state(store, "Task two")
+    assert store.read_file(STATE_CURRENT_FILENAME) == (
+        "# Current State\n\nTask two\n\n*Last updated: 2026-04-08T15:30Z*\n"
+    )
+    assert store.read_file(STATE_HISTORY_FILENAME) == "## 2026-04-08T15:30Z\n\n- Task one\n\n---\n"
 
 
 def test_current_only_overlapping_delta_surfaces_warning() -> None:

--- a/packages/nauro-core/tests/test_decision_model.py
+++ b/packages/nauro-core/tests/test_decision_model.py
@@ -850,3 +850,22 @@ class TestSplitFrontmatter:
     def test_unterminated_raises(self) -> None:
         with pytest.raises(ValueError, match="unterminated"):
             _split_frontmatter("---\ndate: 2026-04-01\n", "001-unterminated.md")
+
+
+# ── Enum-value byte pins ──
+
+
+class TestEnumValueBytes:
+    """Lock the serialized bytes of the enum members used as fallback literals.
+
+    Fallback defaults across the operations layer reference these members'
+    ``.value`` instead of bare string literals. The bytes must stay exact so a
+    future member rename fails here loudly instead of silently changing the
+    serialized status/confidence tokens on disk.
+    """
+
+    def test_status_active_value(self) -> None:
+        assert DecisionStatus.active.value == "active"
+
+    def test_confidence_medium_value(self) -> None:
+        assert DecisionConfidence.medium.value == "medium"

--- a/packages/nauro-core/tests/test_state.py
+++ b/packages/nauro-core/tests/test_state.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 from nauro_core.state import (
     StateUpdateResult,
+    _strip_current_header_footer,
     assemble_state_for_context,
     migrate_legacy_state,
     prepare_state_update,
@@ -123,3 +124,37 @@ class TestAssembleStateForContext:
     def test_default_include_history_is_false(self):
         result = assemble_state_for_context("current", "old")
         assert result == "current"
+
+
+class TestByteExactOutput:
+    """Byte-exact locks on the assembled state strings.
+
+    prepare_state_update, _strip_current_header_footer, and
+    assemble_state_for_context feed the on-disk state_current.md /
+    state_history.md bytes. These lock every character, including the trailing
+    newline, so single-sourcing the header/footer/separator markers cannot
+    silently change serialized output.
+    """
+
+    FIXED_TS = "2026-04-08T15:30Z"
+
+    def test_current_content_byte_exact(self):
+        with patch("nauro_core.state._utc_timestamp", return_value=self.FIXED_TS):
+            result = prepare_state_update("Working on v2", None)
+        assert result.current_content == (
+            "# Current State\n\nWorking on v2\n\n*Last updated: 2026-04-08T15:30Z*\n"
+        )
+
+    def test_history_entry_byte_exact(self):
+        old = "# Current State\n\n- Task one\n\n*Last updated: 2026-04-01T10:00Z*\n"
+        with patch("nauro_core.state._utc_timestamp", return_value=self.FIXED_TS):
+            result = prepare_state_update("Task two", old)
+        assert result.history_entry == "## 2026-04-08T15:30Z\n\n- Task one\n\n---\n"
+
+    def test_strip_current_header_footer_byte_exact(self):
+        content = "# Current State\n\n- Body\n\n*Last updated: 2026-04-01T10:00Z*\n"
+        assert _strip_current_header_footer(content) == "- Body"
+
+    def test_assemble_history_separator_byte_exact(self):
+        result = assemble_state_for_context("current body", "history body", include_history=True)
+        assert result == "current body\n\n# State History\n\nhistory body"


### PR DESCRIPTION
## Why

Two nauro-core paths duplicated frozen bytes as bare literals. The operations
and validation layers repeated the "active" / "medium" enum member values as
fallback defaults, and state.py repeated the state-file header, footer,
timestamp, and history-separator markers across the write template and the
strip/assemble helpers. In both cases a rename or edit on one side could
silently diverge from the bytes written to disk.

## What changed

Point the status and confidence fallbacks at the members that own the bytes
(DecisionStatus.active.value, DecisionConfidence.medium.value), and hoist the
duplicated state-file markers into module-private Final constants referenced
from every site. Pure single-sourcing: no constant value or format changes,
store format and the public surface untouched, serialized output byte-identical.

## Test plan

- nauro-core suite green (978 passed)
- public-contract snapshot unchanged (zero diff)
- new enum-value pins and byte-exact locks on the assembled current/history
  strings, the strip round-trip, the history separator, and the on-disk
  state_current.md / state_history.md bytes
- nauro-package consumer state/context tests green
- ruff check and ruff format --check clean
