### PR TITLE
Type nauro-core payload dicts with module-private TypedDicts

### DIFF
--- a/packages/nauro-core/src/nauro_core/graph.py
+++ b/packages/nauro-core/src/nauro_core/graph.py
@@ -25,6 +25,8 @@ Plain string operations only; no regex.
 
 from __future__ import annotations
 
+from typing import TypedDict
+
 from nauro_core.decision_model import Decision
 from nauro_core.parsing import _cap_to_first_unit, scan_decision_references
 from nauro_core.questions import OpenQuestionsFile
@@ -35,12 +37,77 @@ from nauro_core.validation import is_scaffold_seed
 GRAPH_PAYLOAD_VERSION = 2
 
 
+# Payload shapes. These annotate the existing dict literals only; every dict is
+# a plain dict at runtime, so the emitted JSON is unchanged. Module-private (not
+# in ``__all__``): the payload is consumed by name-agnostic renderers.
+GraphEdge = TypedDict("GraphEdge", {"from": int, "to": int})
+
+
+class GraphNodeBase(TypedDict):
+    """The always-present keys of a graph node (see ``_node_dict``)."""
+
+    number: int
+    title: str
+    status: str
+    decision_type: str | None
+    confidence: str
+    date: str
+
+
+class GraphNode(GraphNodeBase, total=False):
+    """A graph node; ``body`` is present only when bodies are included."""
+
+    body: str
+
+
+class GraphComponent(TypedDict):
+    """One connected supersession component (see ``_build_components``)."""
+
+    nodes: list[int]
+    edges: list[GraphEdge]
+    branch_points: list[int]
+
+
+class GraphStats(TypedDict):
+    """Summary counts carried under the payload's ``stats`` key."""
+
+    isolated_node_count: int
+    supersession_edge_count: int
+    citation_edge_count: int
+    component_count: int
+    branch_point_count: int
+    duplicate_numbers: list[int]
+
+
+class GraphOpenQuestion(TypedDict):
+    """One genuinely-open question entry in the payload."""
+
+    id: str
+    body: str
+    references: list[int]
+
+
+class GraphPayload(TypedDict):
+    """The full versioned decision-graph payload (see ``build_graph_payload``)."""
+
+    payload_version: int
+    project: str
+    decision_count: int
+    max_decision_number: int
+    nodes: list[GraphNode]
+    supersession_edges: list[GraphEdge]
+    citation_edges: list[GraphEdge]
+    components: list[GraphComponent]
+    open_questions: list[GraphOpenQuestion]
+    stats: GraphStats
+
+
 def build_graph_payload(
     decisions: list[Decision],
     questions: OpenQuestionsFile | None = None,
     project: str = "",
     include_bodies: bool = False,
-) -> dict:
+) -> GraphPayload:
     """Build the decision-graph payload from parsed inputs. Pure; no I/O.
 
     Args:
@@ -147,7 +214,7 @@ def _collect_nodes(decisions: list[Decision]) -> tuple[list[Decision], list[int]
     return kept, duplicate_numbers
 
 
-def _node_dict(d: Decision, include_bodies: bool) -> dict:
+def _node_dict(d: Decision, include_bodies: bool) -> GraphNode:
     """Project a ``Decision`` onto the node schema.
 
     Parallel to ``operations/results.DecisionSummary`` (the list_decisions row
@@ -175,7 +242,7 @@ def _node_dict(d: Decision, include_bodies: bool) -> dict:
 
 def _collect_supersession_edges(
     kept: list[Decision], node_numbers: set[int]
-) -> tuple[list[dict], set[tuple[int, int]]]:
+) -> tuple[list[GraphEdge], set[tuple[int, int]]]:
     """Collect supersession edges as the deduped union of both directions.
 
     Iterates only the kept decisions, so a decision dropped during dedup never
@@ -209,7 +276,7 @@ def _scan_citation_pairs(
     node_numbers: set[int],
     max_decision_number: int,
     supersession_pairs: set[tuple[int, int]],
-) -> list[dict]:
+) -> list[GraphEdge]:
     """Scan kept decisions' bodies for D-references and emit citation edges.
 
     Iterates only the kept decisions, so a dropped duplicate contributes no
@@ -237,8 +304,8 @@ def _scan_citation_pairs(
 
 
 def _build_components(
-    supersession_edges: list[dict],
-) -> tuple[list[dict], set[int], int]:
+    supersession_edges: list[GraphEdge],
+) -> tuple[list[GraphComponent], set[int], int]:
     """Group nodes into connected components with branch points.
 
     Returns ``(components, incident_nodes, branch_point_count)`` so the caller
@@ -315,7 +382,7 @@ def _filter_open_questions(
     questions: OpenQuestionsFile | None,
     node_numbers: set[int],
     max_decision_number: int,
-) -> list[dict]:
+) -> list[GraphOpenQuestion]:
     """Return genuinely-open question entries with capped bodies and references.
 
     Openness is annotation-authoritative via ``OpenQuestionsFile``'s public

--- a/packages/nauro-core/src/nauro_core/instructions.py
+++ b/packages/nauro-core/src/nauro_core/instructions.py
@@ -13,6 +13,18 @@ the caller has access to:
 
 from __future__ import annotations
 
+from typing import TypedDict
+
+
+# Module-private (not in ``__all__``); annotates the existing ``projects`` input
+# shape only, no behavior change.
+class ProjectRef(TypedDict):
+    """A project reference passed to ``build_remote_instructions``."""
+
+    project_id: str
+    name: str
+
+
 MAX_INLINE_PROJECTS = 3
 
 WELCOME_NO_PROJECT = (
@@ -33,7 +45,7 @@ WELCOME_NO_PROJECT = (
 
 def build_remote_instructions(
     static_block: str,
-    projects: list[dict],
+    projects: list[ProjectRef],
 ) -> str:
     """Combine static instructions with a per-user project section.
 

--- a/packages/nauro-core/src/nauro_core/operations/check_decision.py
+++ b/packages/nauro-core/src/nauro_core/operations/check_decision.py
@@ -32,7 +32,7 @@ from nauro_core.parsing import (
     _decision_label,
     extract_decision_number,
 )
-from nauro_core.search import union_retrieve
+from nauro_core.search import Bm25Hit, union_retrieve
 from nauro_core.validation import check_content_length, is_scaffold_seed
 
 # Extended stopword list for ``check_decision`` retrieval. Mirrors the
@@ -106,7 +106,7 @@ def check_decision(
     )
 
 
-def _hit_to_related(hit: dict, by_num: dict[int, Decision]) -> RelatedDecision:
+def _hit_to_related(hit: Bm25Hit, by_num: dict[int, Decision]) -> RelatedDecision:
     """Lift a ``bm25_retrieve`` hit into the canonical retrieval-hit shape."""
     num = hit["number"]
     decision = by_num.get(num)

--- a/packages/nauro-core/src/nauro_core/operations/propose_decision.py
+++ b/packages/nauro-core/src/nauro_core/operations/propose_decision.py
@@ -67,6 +67,7 @@ from nauro_core.parsing import (
     extract_decision_number,
 )
 from nauro_core.questions import EntryBlock, OpenQuestionsFile
+from nauro_core.search import Bm25Hit
 from nauro_core.validation import (
     check_bm25_similarity,
     compute_hash,
@@ -346,7 +347,7 @@ def _update_hash_index(store: Store, title: str, rationale: str, decision_id: st
 
 
 def _to_related_decisions(
-    raw_hits: list[dict],
+    raw_hits: list[Bm25Hit],
     parsed_decisions: list[Decision],
 ) -> list[RelatedDecision]:
     """Lift the ``bm25_retrieve`` dict shape into :class:`RelatedDecision`.

--- a/packages/nauro-core/src/nauro_core/search.py
+++ b/packages/nauro-core/src/nauro_core/search.py
@@ -15,6 +15,8 @@ declined path's identity).
 
 from __future__ import annotations
 
+from typing import TypedDict
+
 import bm25s
 import Stemmer
 
@@ -22,6 +24,29 @@ from nauro_core.decision_model import Decision, DecisionStatus
 from nauro_core.parsing import _first_sentence_snippet, extract_relevance_snippet
 
 _stemmer = Stemmer.Stemmer("english")
+
+
+# Two distinct result shapes, deliberately not unified. Module-private (not in
+# ``__all__``). These annotate the existing dict literals only; each dict is a
+# plain dict at runtime, so the returned rows are unchanged.
+class Bm25SearchRow(TypedDict):
+    """One row of the ``bm25_search`` ranked result."""
+
+    number: int
+    title: str
+    date: str | None
+    status: str
+    relevance_snippet: str
+    score: float
+
+
+class Bm25Hit(TypedDict):
+    """One hit from ``bm25_retrieve`` / ``union_retrieve``."""
+
+    number: int
+    title: str
+    similarity: float | None
+    rationale_preview: str
 
 
 def _index_text(d: Decision) -> str:
@@ -40,7 +65,7 @@ def bm25_search(
     decisions: list[Decision],
     query: str,
     limit: int = 10,
-) -> list[dict]:
+) -> list[Bm25SearchRow]:
     """Rank decisions by BM25 relevance to query.
 
     Returns list of result dicts sorted by BM25 score descending.
@@ -97,7 +122,7 @@ def bm25_retrieve(
     query_text: str,
     top_k: int = 5,
     stopwords: str | list[str] = "en",
-) -> list[dict]:
+) -> list[Bm25Hit]:
     """Retrieve top-k related active decisions for conflict checking.
 
     Returns list of dicts sorted by BM25 score descending.
@@ -152,7 +177,7 @@ def union_retrieve(
     top_k: int = 5,
     stopwords: str | list[str] = "en",
     use_embeddings: bool = False,
-) -> list[dict]:
+) -> list[Bm25Hit]:
     """Retrieve a BM25 ∪ embedding candidate pool of related active decisions.
 
     With ``use_embeddings`` False this is exactly :func:`bm25_retrieve` — same

--- a/packages/nauro-core/src/nauro_core/snapshot.py
+++ b/packages/nauro-core/src/nauro_core/snapshot.py
@@ -13,11 +13,35 @@ and makes the output a pure function of its inputs.
 
 from __future__ import annotations
 
+from typing import TypedDict
+
 from nauro_core.constants import (
     CHARS_PER_TOKEN,
     LEGACY_SCHEMA_VERSION,
     SNAPSHOT_SCHEMA_VERSION,
 )
+
+
+# Snapshot shape. These annotate the existing dict literals only; the dict is a
+# plain dict at runtime and the key order is unchanged, so the on-disk byte
+# order is preserved. Module-private (not in ``__all__``). ``version`` is a
+# conditional key, so it lives on a ``total=False`` subclass (3.10 target: mixed
+# totality, not ``NotRequired``).
+class SnapshotBase(TypedDict):
+    """The always-present keys of a serialized snapshot."""
+
+    schema_version: int
+    timestamp: str
+    trigger: str
+    trigger_detail: str
+    token_count: int
+    files: dict[str, str]
+
+
+class Snapshot(SnapshotBase, total=False):
+    """A snapshot; ``version`` is present only when the caller versions it."""
+
+    version: int
 
 
 def serialize_snapshot(
@@ -27,7 +51,7 @@ def serialize_snapshot(
     files: dict[str, str],
     trigger_detail: str = "",
     version: int | None = None,
-) -> dict:
+) -> Snapshot:
     """Build a canonical snapshot dict from its parts.
 
     Args:
@@ -70,7 +94,7 @@ def serialize_snapshot(
     return snapshot
 
 
-def normalize_snapshot(raw: dict) -> dict:
+def normalize_snapshot(raw: dict) -> Snapshot:
     """Fill in defaults for fields a legacy snapshot may omit.
 
     Legacy snapshots predate ``schema_version`` and may lack

--- a/packages/nauro-core/src/nauro_core/validation.py
+++ b/packages/nauro-core/src/nauro_core/validation.py
@@ -16,7 +16,7 @@ from nauro_core.constants import (
     VALID_CONFIDENCES,
 )
 from nauro_core.decision_model import DecisionConfidence
-from nauro_core.search import bm25_retrieve
+from nauro_core.search import Bm25Hit, bm25_retrieve
 
 # Tier-2 BM25 defaults shared by local (nauro) and remote (mcp-server) surfaces.
 # Both call check_bm25_similarity below so the same proposal produces the same
@@ -70,7 +70,7 @@ def check_bm25_similarity(
     existing_decisions: list,
     top_k: int = TIER2_TOP_K,
     stopwords: list[str] | None = None,
-) -> tuple[str, list[dict]]:
+) -> tuple[str, list[Bm25Hit]]:
     """Tier-2 BM25 similarity check. Shared by local and remote surfaces.
 
     Filters the scaffold-seed decision (bookkeeping, not a user choice) and


### PR DESCRIPTION
## Why

The graph, search, snapshot, and instructions payloads in nauro-core were
returned as bare dict. Their shapes lived only in docstrings, so nothing
statically checked the keys callers read or the keys builders emit. This is the
final PR of the machine-pass cleanup: give those payloads named shapes without
changing a single byte of output.

## What changed

Annotation-only. Defines module-private TypedDicts matching the exact current
dict shapes and annotates the relevant signatures, returns, and params:

- graph.py: GraphEdge, GraphNode (a total base plus an optional body key),
  GraphComponent, GraphStats, GraphOpenQuestion, GraphPayload.
- search.py: Bm25SearchRow (the bm25_search row) and Bm25Hit (the
  bm25_retrieve / union_retrieve hit), kept as two distinct shapes.
- snapshot.py: SnapshotBase plus Snapshot (optional version key).
- instructions.py: ProjectRef.
- Consumers import Bm25Hit from nauro_core.search: check_decision,
  propose_decision, and check_bm25_similarity in validation.

No dict literal and no return body is touched. A TypedDict is a plain dict at
runtime, so every payload is byte-identical by construction. Every new type is
module-private (not added to any __all__), so the frozen 1.0 surface is
unchanged. Conditional keys use mixed-totality inheritance (a total base plus a
total=False subclass) for the 3.10 target, not NotRequired.

Per the standing decision governing this machine-pass cleanup, no Nauro
decision is filed for this PR.

## Deferred

The renderers.py render_* envelopes stay untyped: they are deliberately
cross-transport-loose and deferred.

## Test plan

- nauro-core suite (graph-payload golden, snapshot serializer golden,
  search/check/propose/validation): green.
- nauro consumer suite: green.
- Frozen public-contract snapshot: passes with no regeneration.
- ruff check + format check on nauro-core: clean.
- import-linter: both contracts kept.
- One-time local mypy sanity pass: no TypedDict vs reality mismatch.
