### PR TITLE
Match h3 headings in ADR import section extraction

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/import_cmd.py
+++ b/packages/nauro/src/nauro/cli/commands/import_cmd.py
@@ -239,8 +239,11 @@ def _import_adrs(
             ``## Options Considered`` section, each carrying its verbatim body
             as the reason. No ``## Consequences`` scraping and no placeholder
             reason: an ADR that names no alternatives imports with no rejected
-            list. Defaults to False, which preserves the legacy
-            ``_extract_adr_rejected`` path byte-for-byte.
+            list. Defaults to False, which selects the legacy
+            ``_extract_adr_rejected`` path (unchanged in shape). Section
+            extraction is heading-level-aware per ``_extract_section``, so h3
+            ``### Rejected``/``### Consequences`` sections now reach the legacy
+            path where they were previously dropped.
 
     Returns:
         Dict with counts: imported, skipped.
@@ -491,24 +494,37 @@ def _extract_adr_confidence(content: str) -> str:
 
 
 def _extract_section(content: str, heading: str) -> str | None:
-    """Extract the body text of a ## heading section.
+    """Extract the body text of an h2 or h3 heading section, stripped.
 
-    Returns the text between the given ## heading and the next ## heading
-    (or end of file), stripped. Returns None if the section is not found
-    or is empty.
+    An h2 heading is preferred over h3: the heading is matched at level 2 first
+    (``## <heading>``) and level 3 (``### <heading>``) is tried only when no h2
+    of that name exists anywhere in the content, so an h2 section extracts
+    identically to the h2-only rule even when a same-named ``###`` sits earlier
+    in the content. The body runs up to the next heading at the matched level or
+    shallower: for an h2 match the boundary is the next h2, so nested ``###``
+    subsections stay in the body; for an h3 match the boundary is the next h2 or
+    h3. h1 is never a boundary and never a section heading (the level floor is
+    2); h4 and deeper never match as a heading and stay inside the body. Setext
+    headings are not supported. Returns None if the section is not found or is
+    empty.
     """
-    pattern = rf"^##\s+{re.escape(heading)}\s*$"
-    m = re.search(pattern, content, re.MULTILINE | re.IGNORECASE)
-    if not m:
-        return None
+    for level in (2, 3):
+        hashes = "#" * level
+        pattern = rf"^{hashes}\s+{re.escape(heading)}\s*$"
+        m = re.search(pattern, content, re.MULTILINE | re.IGNORECASE)
+        if not m:
+            continue
 
-    start = m.end()
-    # Find next ## heading or end of content
-    next_heading = re.search(r"^##\s+", content[start:], re.MULTILINE)
-    body = content[start : start + next_heading.start()] if next_heading else content[start:]
+        start = m.end()
+        # Boundary is the next heading at the matched level or shallower.
+        boundary = re.compile(rf"^#{{2,{level}}}\s+", re.MULTILINE)
+        next_heading = boundary.search(content[start:])
+        body = content[start : start + next_heading.start()] if next_heading else content[start:]
 
-    body = body.strip()
-    return body if body else None
+        body = body.strip()
+        return body if body else None
+
+    return None
 
 
 def _extract_list_items(text: str) -> list[str]:

--- a/packages/nauro/tests/test_import.py
+++ b/packages/nauro/tests/test_import.py
@@ -7,6 +7,7 @@ from typer.testing import CliRunner
 
 from nauro.cli.commands.import_cmd import (
     _extract_adr_alternatives_strict,
+    _extract_section,
     _import_adrs,
     _import_memory_bank,
     _import_progress,
@@ -583,6 +584,88 @@ def test_import_nygard_format(store: Path, nygard_directory: Path):
 
     # Nygard consequences with "rejected" keyword should be extracted
     assert "monolith" in micro_content
+
+
+@pytest.fixture
+def h3_adr_directory(tmp_path: Path) -> Path:
+    """Directory with an h3-heading ADR: h1 title, sections under ### headings."""
+    adr_dir = tmp_path / "h3_adrs"
+    adr_dir.mkdir()
+
+    (adr_dir / "001-use-structured-logging.md").write_text(
+        "# Use structured logging\n\n"
+        "### Status\n\n"
+        "Accepted\n\n"
+        "### Context\n\n"
+        "Plain-text logs are hard to query in aggregation tools.\n\n"
+        "### Decision\n\n"
+        "Emit logs as JSON with a stable field schema.\n\n"
+        "### Consequences\n\n"
+        "- Logs are machine-parseable\n"
+        "- Local reading needs a pretty-printer\n"
+    )
+    return adr_dir
+
+
+def test_import_h3_heading_adr(store: Path, h3_adr_directory: Path):
+    """h3-heading ADRs (h1 title + ### sections) capture rationale and status.
+
+    Before the fix ### sections were not matched, so these imported title-only
+    with rationale None and default (medium) confidence.
+    """
+    counts = _import_adrs(h3_adr_directory, store)
+
+    assert counts["imported"] == 1
+    assert counts["skipped"] == 0
+
+    decisions = sorted((store / "decisions").glob("*.md"))
+    assert len(decisions) == 2  # 001 scaffold + 1 imported
+
+    content = decisions[1].read_text()
+    assert "Use structured logging" in content
+    # Rationale captures both the ### Context and ### Decision bodies.
+    assert "Plain-text logs are hard to query in aggregation tools." in content
+    assert "Emit logs as JSON with a stable field schema." in content
+    # ### Status "Accepted" maps to high confidence.
+    assert "confidence: high" in content
+
+
+def test_extract_section_mixed_h2_context_h3_decision():
+    """A mixed-level ADR extracts an h3 subsection heading as its own section.
+
+    The h3 heading is independently extractable (was None before the fix),
+    while an h3 nested under an h2 stays inside the h2 body (unchanged
+    boundary at level 2).
+    """
+    content = (
+        "# Mixed heading levels\n\n"
+        "## Context\n\n"
+        "The context section text.\n\n"
+        "### Decision\n\n"
+        "The decision section text.\n"
+    )
+    assert _extract_section(content, "Decision") == "The decision section text."
+
+    context = _extract_section(content, "Context")
+    assert context is not None
+    assert context.startswith("The context section text.")
+    assert "### Decision" in context
+
+
+def test_extract_section_prefers_h2_over_earlier_h3():
+    """When a heading name exists at both h3 and h2, the h2 body wins even if
+    the h3 appears first, so h2 extraction is byte-identical to the h2-only rule.
+    """
+    content = (
+        "# Title\n\n"
+        "## Decision\n\n"
+        "Use the daemon.\n\n"
+        "### Context\n\n"
+        "A nested detail that must not shadow the top-level section.\n\n"
+        "## Context\n\n"
+        "The real top-level context body.\n"
+    )
+    assert _extract_section(content, "Context") == "The real top-level context body."
 
 
 def test_import_skips_non_adr_markdown(store: Path, tmp_path: Path):


### PR DESCRIPTION
## Why

`nauro import --adr` read each ADR section body by matching only h2 headings
(`## Context`, `## Decision`, `## Status`). ADRs that put the title on an h1 and
their sections under h3 (`# Title` then `### Status/Context/Decision`) matched
nothing below the title, so they imported title-only: rationale None and
confidence falling back to the default medium. `### Rejected` and `### Status`
were likewise missed.

## What changed

`_extract_section` is now heading-level-aware, with h2 preferred over h3. It
matches the target heading at level 2 first and falls back to level 3 only when
no h2 of that name exists anywhere in the content, then bounds the section body
at the next heading of that level or shallower:

- An h2 match keeps the old boundary (next h2), so h2 extraction is
  byte-identical to before regardless of where a same-named `###` sits, and
  nested `###` subsections stay in the body.
- An h3 match bounds at the next h2 or h3, so h3 sections extract their own
  bodies.
- h1 is never a boundary or a section heading, and h4 or deeper never match as a
  heading and stay inside the body.

Only `_extract_section` changed. The opt-in strict alternatives extractor is
untouched. The import command's output content is not part of the frozen public
contract surface, so the contract snapshot is unchanged and its guard test still
passes with no regeneration.

Not included: no backfill or validate-time warning for stores that already
imported ADRs title-only. The remedy there is re-running the import after
upgrading.

## Test plan

- Added an h3-heading ADR fixture and three tests (h3 rationale + confidence, a
  mixed h2/h3 ADR, and an h2-preferred-over-earlier-h3 regression). Ran each new
  test against the unfixed code first and confirmed it FAILS (h3 ADR imported
  title-only with medium confidence; `_extract_section` returned None for an h3
  heading; and an earlier same-named h3 shadowed a later h2), then applied the
  fix and confirmed they PASS.
- `pytest packages/nauro/tests/test_import.py` -> 40 passed.
- `pytest packages/nauro/tests/test_public_contract.py` -> 1 passed, snapshot
  unchanged.
- Full `packages/nauro/tests/` -> 1536 passed, 10 skipped.
- `ruff check` and `ruff format --check` clean on both files.
