### PR TITLE
State the rejection explicitly when a surfaced decision supersedes another

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/hook.py
+++ b/packages/nauro/src/nauro/cli/commands/hook.py
@@ -114,6 +114,7 @@ def _run_user_prompt_submit() -> None:
         return
 
     injected = fresh[:MAX_INJECTED]
+    _enrich_supersedes(store_path, injected)
     block = _format_block(injected)
     _record_seen(session_id, [r["number"] for r in injected])
 
@@ -244,24 +245,124 @@ def _apply_floor(hits: list[dict], corpus_size: int) -> list[dict]:
     return [h for h in hits if h["score"] >= floor]
 
 
+def _enrich_supersedes(store_path: Path, hits: list[dict]) -> None:
+    """Attach resolved structural supersedes refs to injected hits, in place.
+
+    For each hit, resolve whether the surfaced decision structurally supersedes
+    another and, if so, that older decision's number and title, stored under the
+    hit's ``supersedes_ref`` key. Resolution is fail-open per hit (see
+    ``_resolve_supersedes_ref``): a hit that does not resolve is left without the
+    key and renders the shipped line.
+    """
+    from nauro.store.filesystem_store import FilesystemStore
+
+    store = FilesystemStore(store_path)
+    for h in hits:
+        ref = _resolve_supersedes_ref(store, h["number"])
+        if ref is not None:
+            h["supersedes_ref"] = ref
+
+
+def _resolve_supersedes_ref(store, number: int) -> dict | None:
+    """Resolve a surfaced decision's structural supersedes ref, or None.
+
+    Returns ``{"number": old_num, "title": old_title}`` when the decision at
+    ``number`` carries a ``supersedes`` ref that resolves to a readable,
+    parseable decision on disk; otherwise None. Only a structural ref produces a
+    payload: a decision with no ``supersedes`` resolves to None, so no relation
+    wording is ever emitted without one.
+
+    Fail-open per hit: a missing target, an unparseable file, or any OSError
+    degrades to None so the hit renders the shipped line. Never propagates, since
+    propagating would lose the whole advisory block through the caller's
+    outer try/except.
+    """
+    from nauro_core.operations.decision_lookup import (
+        find_decision_stem_by_num,
+        parse_decision_or_none,
+    )
+
+    try:
+        stem = find_decision_stem_by_num(store, number)
+        if stem is None:
+            return None
+        body = store.read_decision(stem)
+        if body is None:
+            return None
+        decision = parse_decision_or_none(body, f"{stem}.md")
+        if decision is None or not decision.supersedes:
+            return None
+        old_number = int(decision.supersedes)
+        old_stem = find_decision_stem_by_num(store, old_number)
+        if old_stem is None:
+            return None
+        old_body = store.read_decision(old_stem)
+        if old_body is None:
+            return None
+        old_decision = parse_decision_or_none(old_body, f"{old_stem}.md")
+        if old_decision is None:
+            return None
+        return {"number": old_number, "title": old_decision.title}
+    except Exception:
+        return None
+
+
+def _hit_meta(h: dict) -> str:
+    """Render a hit's ``status`` or ``status, date`` metadata parenthetical."""
+    meta = h["status"]
+    if h["date"]:
+        meta = f"{meta}, {h['date']}"
+    return meta
+
+
+def _trimmed_preview(h: dict) -> str:
+    """Return the hit's rationale preview trimmed to the ``PREVIEW_CHARS`` cap."""
+    preview = (h["preview"] or "").strip()
+    if len(preview) > PREVIEW_CHARS:
+        preview = preview[: PREVIEW_CHARS - 1].rstrip() + "…"
+    return preview
+
+
+def _shipped_line(h: dict) -> str:
+    """Render the default hit line: id, quoted title, meta, then trimmed preview."""
+    line = f'D{h["number"]:03d} "{h["title"]}" ({_hit_meta(h)})'
+    preview = _trimmed_preview(h)
+    if preview:
+        line = f"{line} — {preview}"
+    return line
+
+
+def _explicit_line(h: dict, ref: dict) -> str:
+    """Render a hit line that states the rejection of the superseded decision.
+
+    Extends the shipped line's relation clause: instead of the bare preview, the
+    line names the superseded decision and states that this decision rejected it
+    in favor of the surfaced one, then appends the same trimmed preview.
+    """
+    old_title = ref["title"]
+    new_title = h["title"]
+    clause = (
+        f'supersedes D{ref["number"]:03d} "{old_title}": '
+        f'this decision rejected "{old_title}" in favor of "{new_title}".'
+    )
+    line = f'D{h["number"]:03d} "{new_title}" ({_hit_meta(h)}) — {clause}'
+    preview = _trimmed_preview(h)
+    if preview:
+        line = f"{line} {preview}"
+    return line
+
+
 def _format_block(hits: list[dict]) -> str:
     """Render the advisory block: a preamble, one line per hit, an instruction.
 
-    Each hit line is ``D### "title" (status, date) — <preview>`` using the
-    rationale preview already on the hit, so no get_decision call is needed.
+    A hit whose enrichment resolved a structural ``supersedes`` ref renders the
+    explicit rejection line; every other hit renders the shipped line, byte for
+    byte as before, so no get_decision call is needed.
     """
     lines = [_PREAMBLE]
     for h in hits:
-        preview = (h["preview"] or "").strip()
-        if len(preview) > PREVIEW_CHARS:
-            preview = preview[: PREVIEW_CHARS - 1].rstrip() + "…"
-        meta = h["status"]
-        if h["date"]:
-            meta = f"{meta}, {h['date']}"
-        line = f'D{h["number"]:03d} "{h["title"]}" ({meta})'
-        if preview:
-            line = f"{line} — {preview}"
-        lines.append(line)
+        ref = h.get("supersedes_ref")
+        lines.append(_explicit_line(h, ref) if ref is not None else _shipped_line(h))
     lines.append(_INSTRUCTION)
     return "\n".join(lines)
 

--- a/packages/nauro/tests/test_hook_command.py
+++ b/packages/nauro/tests/test_hook_command.py
@@ -30,6 +30,8 @@ def _write_decision(
     title: str,
     rationale: str,
     status: str = "active",
+    supersedes: str | None = None,
+    superseded_by: str | None = None,
 ) -> None:
     """Write a valid v2 decision file into the store's decisions directory."""
     decision = Decision(
@@ -39,6 +41,8 @@ def _write_decision(
         num=num,
         title=title,
         rationale=rationale,
+        supersedes=supersedes,
+        superseded_by=superseded_by,
     )
     content = format_decision(decision)
     slug = title.lower().replace(" ", "-")[:40]
@@ -472,3 +476,210 @@ def test_format_block_shape():
     assert hook._PREAMBLE in block
     assert hook._INSTRUCTION in block
     assert 'D007 "adopt postgres" (active, 2026-05-01)' in block
+    # No enrichment payload on the hit: no rejection-relation wording is emitted.
+    assert "supersedes" not in block
+    assert "in favor of" not in block
+
+
+# ── explicit rejection wording for structural supersedes refs ──────────────────
+
+
+def test_supersedes_ref_renders_explicit_rejection(tmp_path: Path):
+    """A surfaced decision that supersedes another states the rejection explicitly."""
+    repo, store_path = _make_project(tmp_path)
+    _write_decision(
+        store_path,
+        num=60,
+        title="use dynamodb as the primary datastore",
+        rationale="dynamodb chosen for the primary datastore key-value access",
+        status="superseded",
+        superseded_by="61",
+    )
+    _write_decision(
+        store_path,
+        num=61,
+        title="adopt postgres as the primary datastore",
+        rationale="postgres chosen over dynamodb for relational integrity and SQL tooling",
+        supersedes="60",
+    )
+    result = _invoke(
+        {
+            "prompt": "should we adopt postgres as the primary datastore for the service",
+            "cwd": str(repo),
+            "session_id": "supersede",
+        }
+    )
+    assert result.exit_code == 0
+    assert result.output != ""
+    ctx = json.loads(result.output)["hookSpecificOutput"]["additionalContext"]
+    assert "D061" in ctx
+    assert 'supersedes D060 "use dynamodb as the primary datastore"' in ctx
+    assert (
+        'rejected "use dynamodb as the primary datastore" '
+        'in favor of "adopt postgres as the primary datastore"' in ctx
+    )
+
+
+def test_supersedes_nonexistent_target_fails_open(tmp_path: Path):
+    """A supersedes ref to a missing decision degrades to today's shipped line."""
+    repo, store_path = _make_project(tmp_path)
+    _write_decision(
+        store_path,
+        num=62,
+        title="adopt redis for the cache tier layer",
+        rationale="redis chosen for the cache tier layer",
+        supersedes="999",
+    )
+    result = _invoke(
+        {
+            "prompt": "should we adopt redis for the cache tier layer",
+            "cwd": str(repo),
+            "session_id": "missing-target",
+        }
+    )
+    assert result.exit_code == 0
+    assert result.output != ""
+    ctx = json.loads(result.output)["hookSpecificOutput"]["additionalContext"]
+    assert "D062" in ctx
+    # Fail-open: the shipped line renders, with no relation wording.
+    assert (
+        'D062 "adopt redis for the cache tier layer" (active, 2026-05-01) — '
+        "redis chosen for the cache tier layer" in ctx
+    )
+    assert "supersedes" not in ctx
+    assert "in favor of" not in ctx
+
+
+def test_supersedes_unparseable_target_fails_open(tmp_path: Path):
+    """A present-but-unparseable supersedes target degrades to the shipped line."""
+    repo, store_path = _make_project(tmp_path)
+    # A file that carries the 063 number prefix but does not parse as v2.
+    (store_path / "decisions" / "063-broken.md").write_text("not a valid decision file at all")
+    _write_decision(
+        store_path,
+        num=64,
+        title="adopt kafka for the event stream bus",
+        rationale="kafka chosen for the event stream bus",
+        supersedes="63",
+    )
+    result = _invoke(
+        {
+            "prompt": "should we adopt kafka for the event stream bus",
+            "cwd": str(repo),
+            "session_id": "unparseable-target",
+        }
+    )
+    assert result.exit_code == 0
+    assert result.output != ""
+    ctx = json.loads(result.output)["hookSpecificOutput"]["additionalContext"]
+    assert "D064" in ctx
+    assert "supersedes" not in ctx
+    assert "in favor of" not in ctx
+
+
+def test_three_injected_refs_block_bounded(tmp_path: Path):
+    """Three surfaced decisions carrying refs stay within the injection cap."""
+    repo, store_path = _make_project(tmp_path)
+    for old_num, new_num in ((65, 75), (66, 76), (67, 77)):
+        _write_decision(
+            store_path,
+            num=old_num,
+            title=f"legacy datastore choice number {old_num}",
+            rationale=f"legacy datastore option {old_num} retired",
+            status="superseded",
+            superseded_by=str(new_num),
+        )
+        _write_decision(
+            store_path,
+            num=new_num,
+            title=f"adopt postgres as the primary datastore variant {new_num}",
+            rationale=(
+                "postgres chosen as the primary datastore for relational integrity, "
+                "SQL tooling, mature operational story, and strong transactional "
+                "guarantees across the whole service surface area"
+            ),
+            supersedes=str(old_num),
+        )
+    result = _invoke(
+        {
+            "prompt": "adopt postgres as the primary datastore for the service",
+            "cwd": str(repo),
+            "session_id": "three-refs",
+        }
+    )
+    assert result.exit_code == 0
+    assert result.output != ""
+    ctx = json.loads(result.output)["hookSpecificOutput"]["additionalContext"]
+    d_lines = [ln for ln in ctx.split("\n") if len(ln) >= 4 and ln[0] == "D" and ln[1:4].isdigit()]
+    # The injection cap holds even when every hit carries a ref.
+    assert 1 <= len(d_lines) <= hook.MAX_INJECTED
+    # Every surfaced decision here supersedes another, so each line states it.
+    for ln in d_lines:
+        assert "in favor of" in ln
+
+
+# ── unit coverage of the rejection-wording renderer ────────────────────────────
+
+
+def test_format_block_line_byte_identical_without_ref():
+    """A hit without an enrichment payload renders exactly today's block."""
+    hit = {
+        "number": 7,
+        "title": "adopt postgres",
+        "score": 5.0,
+        "status": "active",
+        "date": "2026-05-01",
+        "preview": "postgres chosen for relational integrity",
+    }
+    expected = "\n".join(
+        [
+            hook._PREAMBLE,
+            'D007 "adopt postgres" (active, 2026-05-01) — postgres chosen for relational integrity',
+            hook._INSTRUCTION,
+        ]
+    )
+    assert hook._format_block([hit]) == expected
+
+
+def test_format_block_explicit_line_for_enriched_hit():
+    """An enriched hit renders the explicit rejection line verbatim."""
+    hit = {
+        "number": 61,
+        "title": "adopt postgres as the primary datastore",
+        "score": 5.0,
+        "status": "active",
+        "date": "2026-05-01",
+        "preview": "postgres chosen over dynamodb for relational integrity",
+        "supersedes_ref": {"number": 60, "title": "use dynamodb as the primary datastore"},
+    }
+    expected_line = (
+        'D061 "adopt postgres as the primary datastore" (active, 2026-05-01) — '
+        'supersedes D060 "use dynamodb as the primary datastore": this decision '
+        'rejected "use dynamodb as the primary datastore" in favor of '
+        '"adopt postgres as the primary datastore". '
+        "postgres chosen over dynamodb for relational integrity"
+    )
+    expected = "\n".join([hook._PREAMBLE, expected_line, hook._INSTRUCTION])
+    assert hook._format_block([hit]) == expected
+
+
+def test_explicit_line_snippet_respects_preview_cap():
+    """The rationale snippet on an explicit line reuses the shared 120-char cap."""
+    long_preview = "postgres chosen for relational integrity and operational maturity " * 10
+    hit = {
+        "number": 61,
+        "title": "adopt postgres",
+        "score": 5.0,
+        "status": "active",
+        "date": "2026-05-01",
+        "preview": long_preview,
+        "supersedes_ref": {"number": 60, "title": "use dynamodb"},
+    }
+    block = hook._format_block([hit])
+    line = next(ln for ln in block.split("\n") if ln.startswith("D061"))
+    assert 'supersedes D060 "use dynamodb"' in line
+    assert 'rejected "use dynamodb" in favor of "adopt postgres"' in line
+    marker = 'in favor of "adopt postgres".'
+    snippet = line[line.index(marker) + len(marker) :].strip()
+    assert snippet.endswith("…")
+    assert len(snippet) <= hook.PREVIEW_CHARS


### PR DESCRIPTION
## Why

The advisory UserPromptSubmit hook rendered every surfaced decision the same
way, so a decision that had replaced an earlier one read like a standalone
note rather than a replacement. When a surfaced decision structurally
supersedes another in the store, the injected line should say so.

## What changed

When a surfaced decision structurally supersedes another, the hook line now
names the superseded decision and states that it was rejected in favor of the
surfaced one, matching the relationship the store already records. A decision
with no supersedes ref renders exactly as before.

Resolution is store-side and fail-open per hit: a supersedes ref pointing at a
missing or unparseable decision degrades to the existing line, and the whole
block is never lost over one bad ref. The rationale snippet reuses the
existing 120-char preview cap, so the only added text is the relation clause.
Retrieval, relevance floor, per-session dedup, the injection cap, and ranking
are untouched, and the frozen public contract is unchanged.

## Risk / what to review

The load-bearing claims are that the no-ref path renders byte-identical to the
previous line (pinned by a dedicated equality test) and that enrichment is
fail-open per hit, so a bad ref degrades one line but never loses the block.

## Test plan

`.venv/bin/python -m pytest packages/nauro/tests/test_hook_command.py -x -q`
-> 27 passed (7 new: explicit rejection wording, byte-identical no-ref line,
missing target fail-open, unparseable target fail-open, snippet cap, three-ref
injection bound, enriched-hit renderer).

Before applying the source change, the three explicit-wording tests failed and
the byte-identical no-ref test passed, confirming the new assertions exercise
the new behavior and the default line is unchanged.

`.venv/bin/python -m pytest packages/nauro/tests/test_public_contract.py -x -q`
-> passed, snapshot unchanged (no regen).
`.venv/bin/python -m pytest packages/nauro/tests/ -q` -> 1540 passed, 10 skipped.
`ruff check` and `ruff format --check` on the changed files -> clean.
