### PR TITLE
Release nauro 1.2.0 and nauro-core 1.0.2

### DIFF
--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro-core"
-version = "1.0.1"
+version = "1.0.2"
 description = "Shared pure-Python logic for Nauro: parsing, validation, context assembly, constants."
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro"
-version = "1.1.0"
+version = "1.2.0"
 description = "Local CLI + MCP server: set your project's doctrine once, every connected AI agent inherits it."
 readme = "README.md"
 license = "Apache-2.0"
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "nauro-core>=1.0,<2",
+    "nauro-core>=1.0.2,<2",
     "typer>=0.9",
     "httpx>=0.24",
     "mcp>=1.0",

--- a/server.json
+++ b/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Nauro-AI/nauro",
     "source": "github"
   },
-  "version": "1.1.0",
+  "version": "1.2.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "nauro",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Why

Main is 22 commits ahead of the last release (nauro-v1.1.0) and holds
user-facing fixes that only matter once installable: the h3 ADR import fix
(silent rationale loss; the remedy for affected stores is re-importing after
upgrading), the first-run telemetry consent flip to default-decline, and
`nauro adopt --remove`.

## What changed

- nauro 1.1.0 -> 1.2.0 (minor: additive CLI surface plus behavior fixes, no
  frozen-surface break).
- nauro-core 1.0.1 -> 1.0.2 (patch: internal refactors and questions-model
  changes; the curated public `__all__` is unchanged since 1.0.1).
- nauro's dependency floor raised to `nauro-core>=1.0.2,<2` so upgrades pull
  the pair together instead of leaving a stale core installed.
- server.json version fields locked to 1.2.0 for the MCP registry publish.

After merge: tag `nauro-core-v1.0.2` first, then `nauro-v1.2.0` (the nauro tag
also publishes to the MCP registry).

## Test plan

- `scripts/check_server_json_version.py` -> version-locked at 1.2.0.
- `pytest packages/nauro/tests/test_public_contract.py` -> passed, snapshot
  unchanged.
- CI runs the full matrix on this PR.
