### PR TITLE
Fix over-strip and slug-collapse in rendered output

### DIFF
--- a/packages/nauro-core/src/nauro_core/operations/diff_since_last_session.py
+++ b/packages/nauro-core/src/nauro_core/operations/diff_since_last_session.py
@@ -169,7 +169,7 @@ def _summarize_new_file(filename: str, content: str) -> str:
     if filename.startswith(DECISIONS_DIR + "/"):
         for line in content.split("\n"):
             if line.startswith("# "):
-                return line.lstrip("# ").strip()
+                return line.removeprefix("# ").strip()
         return ""
     return ""
 
@@ -227,7 +227,7 @@ def _diff_state(old: str, new: str) -> list[str]:
     ]
     added = [i for i in new_items if i not in old_items]
     for item in added:
-        changes.append(f"+ Completed: {item.lstrip('- ')}")
+        changes.append(f"+ Completed: {item.removeprefix('- ')}")
 
     return changes
 
@@ -270,9 +270,9 @@ def _diff_questions(old: str, new: str) -> list[str]:
     removed = [q for q in old_qs if q not in new_qs]
 
     for q in added:
-        changes.append(f"+ New question: {q.lstrip('- ')}")
+        changes.append(f"+ New question: {q.removeprefix('- ')}")
     for q in removed:
-        changes.append(f"- Resolved/removed: {q.lstrip('- ')}")
+        changes.append(f"- Resolved/removed: {q.removeprefix('- ')}")
 
     return changes
 

--- a/packages/nauro-core/src/nauro_core/operations/propose_decision.py
+++ b/packages/nauro-core/src/nauro_core/operations/propose_decision.py
@@ -672,7 +672,12 @@ def _slugify(title: str) -> str:
             prev_dash = True
     slug = "".join(out_chars).strip("-")
     if len(slug) > _SLUG_MAX_LENGTH:
-        slug = slug[:_SLUG_MAX_LENGTH].rsplit("-", 1)[0]
+        truncated = slug[:_SLUG_MAX_LENGTH]
+        # Prefer cutting at a word boundary, but only while that keeps at
+        # least half the cap: a title whose only dash sits early would
+        # otherwise collapse to a near-empty slug (and filename).
+        trimmed = truncated.rsplit("-", 1)[0]
+        slug = trimmed if len(trimmed) >= _SLUG_MAX_LENGTH // 2 else truncated
     return slug
 
 

--- a/packages/nauro-core/tests/operations/test_diff_since_last_session.py
+++ b/packages/nauro-core/tests/operations/test_diff_since_last_session.py
@@ -330,3 +330,56 @@ def test_kernel_does_not_import_snapshot_discovery() -> None:
         f"kernel imports snapshot discovery primitives: {forbidden & imported}; "
         "those live in the adapter, not the kernel."
     )
+
+
+# ── Rendered text keeps content-leading markers (removeprefix, not lstrip) ──
+
+
+def test_completed_item_keeps_leading_dashes() -> None:
+    # lstrip("- ") stripped any leading dash/space run, so an item whose
+    # content itself starts with a dash (a CLI flag, a negative number) lost
+    # it: "- --dry-run flag added" rendered as "dry-run flag added".
+    snap_a = _snapshot(
+        1,
+        "2026-05-01T10:00:00+00:00",
+        {"state_current.md": "# Current State\n\n- Set up CI\n"},
+    )
+    snap_b = _snapshot(
+        2,
+        "2026-05-02T10:00:00+00:00",
+        {"state_current.md": "# Current State\n\n- Set up CI\n- --dry-run flag added\n"},
+    )
+    result = diff_since_last_session(InMemoryStore(), snap_a, snap_b)
+    assert result.diff == (
+        "Changes from v001 → v002\n"
+        "  (2026-05-01T10:00:00 → 2026-05-02T10:00:00)\n"
+        "\n"
+        "  ~ state_current.md\n"
+        "    + Completed: --dry-run flag added"
+    )
+
+
+def test_new_decision_title_keeps_leading_hash() -> None:
+    # Same over-strip class on the new-file summary: lstrip("# ") turned a
+    # decision titled "#1 priority hotfix" into "1 priority hotfix".
+    snap_a = _snapshot(
+        1,
+        "2026-05-01T10:00:00+00:00",
+        {"stack.md": "# Stack\n- Python 3.11\n"},
+    )
+    snap_b = _snapshot(
+        2,
+        "2026-05-02T10:00:00+00:00",
+        {
+            "stack.md": "# Stack\n- Python 3.11\n",
+            "decisions/002-hotfix.md": "# #1 priority hotfix\n\nReasoned.\n",
+        },
+    )
+    result = diff_since_last_session(InMemoryStore(), snap_a, snap_b)
+    assert result.diff == (
+        "Changes from v001 → v002\n"
+        "  (2026-05-01T10:00:00 → 2026-05-02T10:00:00)\n"
+        "\n"
+        "  + New file: decisions/002-hotfix.md\n"
+        "    #1 priority hotfix"
+    )

--- a/packages/nauro-core/tests/operations/test_operations_propose_decision.py
+++ b/packages/nauro-core/tests/operations/test_operations_propose_decision.py
@@ -852,3 +852,43 @@ def test_every_advertised_decision_type_commits(decision_type: str) -> None:
         decision_type=decision_type,
     )
     assert result.status == "confirmed"
+
+
+# ── Slug truncation goldens ─────────────────────────────────────────────
+
+
+def test_slug_early_dash_no_longer_collapses_slug() -> None:
+    # The word-boundary backoff after truncation had no floor: a title whose
+    # only dash sits early collapsed to a near-empty slug ("001-aaaa"). The
+    # backoff now applies only while it keeps at least half the cap;
+    # otherwise the hard character cut stands.
+    result = propose_decision(
+        InMemoryStore(),
+        title=f"Aaaa {'b' * 80}",
+        rationale="A rationale long enough to clear the minimum length threshold.",
+        confidence="medium",
+    )
+    assert result.status == "confirmed"
+    assert result.decision_id == "001-aaaa-" + "b" * 55
+
+
+def test_slug_multiword_title_still_trims_at_word_boundary() -> None:
+    result = propose_decision(
+        InMemoryStore(),
+        title="word " * 20,
+        rationale="A rationale long enough to clear the minimum length threshold.",
+        confidence="medium",
+    )
+    assert result.status == "confirmed"
+    assert result.decision_id == "001-" + "word-" * 11 + "word"
+
+
+def test_slug_single_giant_word_hard_cuts_at_cap() -> None:
+    result = propose_decision(
+        InMemoryStore(),
+        title="x" * 80,
+        rationale="A rationale long enough to clear the minimum length threshold.",
+        confidence="medium",
+    )
+    assert result.status == "confirmed"
+    assert result.decision_id == "001-" + "x" * 60


### PR DESCRIPTION
## Why

Two latent output bugs deferred from the earlier byte-identical cleanup sweep
because they change emitted bytes. Rendering bullets and new-decision titles
through `lstrip("- ")` / `lstrip("# ")` strips any leading run of those
characters from the content itself, not just the marker: a completed item
"--dry-run flag added" rendered as "dry-run flag added", and a decision titled
"#1 priority hotfix" rendered as "1 priority hotfix". Separately, the decision
slug's word-boundary backoff after truncation had no floor, so a title whose
only dash sits early collapsed to a near-empty slug and filename.

## What changed

- `diff_since_last_session` renders through `removeprefix` at all four marker
  sites (state completions, question added/removed lines, new-decision title
  summary), so exactly the marker is stripped and content-leading dashes or
  hashes survive.
- `_slugify` keeps the word-boundary trim after truncation only while it
  retains at least half the 60-character cap; otherwise the hard character cut
  stands. Normal titles are unaffected.

## Test plan

- Five new regression tests pin exact outputs: byte-equal `result.diff`
  goldens for the dash and hash cases, and exact decision-id goldens for the
  early-dash, multi-word, and single-giant-word slug cases.
- Full `pytest` green: 983 (nauro-core) and 1558 (nauro); `ruff check` and
  `ruff format --check` clean.
