### PR TITLE
Skip the decision-hash index lock artifact in sync

### DIFF
--- a/packages/nauro/src/nauro/sync/merge.py
+++ b/packages/nauro/src/nauro/sync/merge.py
@@ -41,12 +41,13 @@ NEVER_SYNC = (".sync-state.json", DEFAULT_GRAPH_FILENAME)
 # Lock-file artifacts are local concurrency plumbing, not store content.
 # filelock keeps Unix lock files after release as of 3.29.5 (deleting them
 # raced concurrent acquirers), so store writes leave these behind: the
-# per-target ``<name>.md.lock`` from write_file, the read-modify-write
-# ``<name>.rmwlock``, and the bare ``.lock`` directory sentinels. Syncing them
-# would fan the droppings out to every collaborator's store. The suffixes are
-# deliberately narrow (``.md.lock``, not ``.lock``) so a legitimate store file
-# such as ``context/poetry.lock`` still syncs.
-LOCK_ARTIFACT_SUFFIXES = (".md.lock", RMW_LOCK_SUFFIX)
+# per-target ``<name>.lock`` from write_file (its targets are ``*.md`` files
+# plus the ``.decision-hashes.json`` index, hence both suffixes below), the
+# read-modify-write ``<name>.rmwlock``, and the bare ``.lock`` directory
+# sentinels. Syncing them would fan the droppings out to every collaborator's
+# store. The suffixes are deliberately narrow (``.md.lock``, not ``.lock``) so
+# a legitimate store file such as ``context/poetry.lock`` still syncs.
+LOCK_ARTIFACT_SUFFIXES = (".md.lock", ".json.lock", RMW_LOCK_SUFFIX)
 
 
 def should_skip(relative_path: str) -> bool:

--- a/packages/nauro/tests/test_sync/test_merge.py
+++ b/packages/nauro/tests/test_sync/test_merge.py
@@ -46,6 +46,8 @@ class TestShouldSkip:
         assert should_skip("decisions/002-use-redis.md.lock") is True
         assert should_skip("open-questions.md.rmwlock") is True
         assert should_skip("snapshots/.lock") is True
+        # write_file's one non-markdown target, the decision-hash index.
+        assert should_skip(".decision-hashes.json.lock") is True
 
     def test_non_artifact_lock_names_still_sync(self):
         # Only the store's own artifact shapes are skipped; user content that


### PR DESCRIPTION
## Why

The lock-artifact sync filter added for filelock 3.29.5 matched only
`.md.lock`, but `write_file` also targets `.decision-hashes.json`, so its
leftover `.decision-hashes.json.lock` dropping still synced. Surfaced by a
post-merge review pass.

## What changed

- `.json.lock` joins `LOCK_ARTIFACT_SUFFIXES`; the comment now names
  write_file's exact target set (`*.md` plus the decision-hash index).

## Test plan

- New `should_skip(".decision-hashes.json.lock")` regression case; full
  nauro suite green (1558), ruff clean.
