### PR TITLE
Lead check_decision render with an honest takeaway line

### DIFF
--- a/packages/nauro-core/src/nauro_core/operations/results.py
+++ b/packages/nauro-core/src/nauro_core/operations/results.py
@@ -50,18 +50,20 @@ class ErrorPayload(BaseModel):
 class CheckDecisionResult(BaseModel):
     """Return shape for :func:`nauro_core.operations.check_decision`.
 
-    On the success path ``related_decisions`` contains zero or more
-    :class:`RelatedDecision` hits and ``assessment`` carries the
-    deterministic human-readable summary. On the rejection path
-    ``error`` is populated; ``related_decisions`` stays empty and
-    ``assessment`` stays empty. ``store`` is not part of the model;
+    ``assessment`` is declared first so the takeaway leads the serialized
+    payload (Pydantic ``model_dump`` preserves declaration order), matching
+    the rendered block's takeaway-first order. On the success path it carries
+    the deterministic human-readable summary and ``related_decisions``
+    contains zero or more :class:`RelatedDecision` hits. On the rejection
+    path ``error`` is populated; ``assessment`` stays empty and
+    ``related_decisions`` stays empty. ``store`` is not part of the model;
     transport adapters add it back at serialization time.
     """
 
     model_config = ConfigDict(frozen=True, extra="forbid")
 
-    related_decisions: list[RelatedDecision] = Field(default_factory=list)
     assessment: str = ""
+    related_decisions: list[RelatedDecision] = Field(default_factory=list)
     error: ErrorPayload | None = None
 
 

--- a/packages/nauro-core/src/nauro_core/renderers.py
+++ b/packages/nauro-core/src/nauro_core/renderers.py
@@ -11,9 +11,10 @@ would. They must not mutate the input dict.
 
 Per-tool surface area:
 
-* ``check_decision`` — top hit with rationale preview + lower hits as a
-  short list; the agent-facing call-to-action footer comes from the
-  upstream ``assessment`` field.
+* ``check_decision`` — a single honest lead line (count + call-to-action +
+  lexical-rank caveat), then the hit list: top hit with rationale preview +
+  lower hits as a short list. The agent-facing call-to-action in the lead
+  comes from the upstream ``assessment`` field.
 * ``get_decision`` — light header on top of the markdown body the kernel
   already returns.
 * ``search_decisions`` — query echo, then a ranked short list of hits
@@ -28,7 +29,7 @@ Per-tool surface area:
 
 from __future__ import annotations
 
-from nauro_core.constants import NO_RELATED_DECISIONS
+from nauro_core.constants import LEXICAL_RANK_CAVEAT, NO_RELATED_DECISIONS
 from nauro_core.parsing import _decision_label
 
 # Width target for the rendered text blocks. Picked to fit standard
@@ -108,10 +109,19 @@ def render_check_decision(result: dict) -> str:
 
     lines: list[str] = []
     count = len(related)
-    if count == 1:
-        lines.append("Found 1 related decision:")
-    else:
-        lines.append(f"Found {count} related decisions:")
+    # One honest lead line: the count, the actionable call-to-action, and the
+    # lexical-rank caveat so the ranking is not read as a relevance verdict.
+    # Prefer the upstream assessment's "Call ..." sentence so the get_decision
+    # number and pluralization stay in sync with the kernel; fall back to a
+    # generic prompt.
+    cta = (
+        _extract_call_to_action(assessment)
+        or "Call get_decision on each related decision before proposing."
+    )
+    lead = (
+        f"{count} related {'decision' if count == 1 else 'decisions'}. {cta} {LEXICAL_RANK_CAVEAT}"
+    )
+    lines.append(lead)
     lines.append("")
 
     for idx, hit in enumerate(related):
@@ -132,15 +142,6 @@ def render_check_decision(result: dict) -> str:
                 lines.append(f'    "{preview_line}"')
         lines.append("")
 
-    # Call-to-action footer. Prefer the upstream assessment's "Call ..."
-    # sentence so the get_decision number and pluralization stay in sync
-    # with what the kernel decided. Fall back to a generic prompt.
-    footer = _extract_call_to_action(assessment)
-    if footer:
-        lines.append(footer)
-    else:
-        lines.append("Call get_decision on each related decision before proposing.")
-
     return "\n".join(lines).rstrip()
 
 
@@ -149,7 +150,7 @@ def _extract_call_to_action(assessment: str) -> str:
 
     The kernel always emits a single ``Call ...`` clause as the last
     sentence; if the format ever drifts, fall back to an empty string and
-    let the renderer default footer fire.
+    let the renderer's default call-to-action fire in the lead line.
     """
     idx = assessment.find("Call ")
     if idx == -1:

--- a/packages/nauro-core/tests/test_renderers.py
+++ b/packages/nauro-core/tests/test_renderers.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import json
 
-from nauro_core.constants import NO_RELATED_DECISIONS
+from nauro_core.constants import LEXICAL_RANK_CAVEAT, NO_RELATED_DECISIONS
 from nauro_core.renderers import (
     render_check_decision,
     render_get_context,
@@ -71,7 +71,7 @@ class TestRenderCheckDecision:
         assert "19.07" in text or "19.1" in text
         assert "Adopt 1-hour prompt cache tier" in text
         assert "Planner cache_control" in text
-        # Call-to-action footer must mention get_decision
+        # Lead-line call-to-action must mention get_decision
         assert "get_decision" in text
 
     def test_multi_hit_marks_top_and_lists_rest(self):
@@ -117,9 +117,9 @@ class TestRenderCheckDecision:
             ),
         }
         text = render_check_decision(result)
-        # Top match marker only on the top hit
-        top_marker_count = text.count("top match")
-        assert top_marker_count == 1
+        # The "<- top match" row marker appears on exactly one hit row; the
+        # lead line no longer carries a "top match" phrase.
+        assert text.count("<- top match") == 1
         # All three decision labels appear
         assert "D145" in text
         assert "D058" in text
@@ -132,8 +132,47 @@ class TestRenderCheckDecision:
         assert "Pareto sets the planner" in text
         assert "Cache per role" not in text
         assert "Modes go away" not in text
-        # Footer guidance
+        # Lead-line call-to-action mentions get_decision
         assert "get_decision" in text
+
+    def test_takeaway_leads_before_list(self):
+        """The honest takeaway (count + call-to-action + lexical caveat)
+        leads the block, above the first hit row, and the lexical-rank
+        caveat now reaches the rendered surface."""
+        result = {
+            "store": "remote",
+            "related_decisions": [
+                {
+                    "id": "decision-145",
+                    "title": "Adopt 1-hour prompt cache tier for planner",
+                    "score": 19.07,
+                    "status": "active",
+                    "date": "2026-05-10",
+                    "rationale_preview": "Planner cache_control set to ttl: 1h.",
+                },
+                {
+                    "id": "decision-058",
+                    "title": "Prompt cache strategy per role",
+                    "score": 18.05,
+                    "status": "active",
+                    "date": "2026-03-22",
+                    "rationale_preview": "Cache per role.",
+                },
+            ],
+            "assessment": (
+                "Found 2 related decisions. "
+                'Top match: D145 "Adopt 1-hour prompt cache tier for planner" '
+                "(status active, decided 2026-05-10, BM25 19.1). "
+                "Call get_decision on each related decision before proposing."
+            ),
+        }
+        text = render_check_decision(result)
+        # The call-to-action lead appears before the first hit row.
+        assert text.index("Call get_decision") < text.index("- D145")
+        # The count also leads, above the list.
+        assert text.index("2 related decisions") < text.index("- D145")
+        # The lexical-rank caveat now reaches the rendered surface.
+        assert LEXICAL_RANK_CAVEAT in text
 
     def test_long_title_does_not_blow_up(self):
         long_title = "x" * 200

--- a/packages/nauro/tests/snapshots/check_decision_schema.json
+++ b/packages/nauro/tests/snapshots/check_decision_schema.json
@@ -79,7 +79,7 @@
       }
     },
     "additionalProperties": false,
-    "description": "Return shape for :func:`nauro_core.operations.check_decision`.\n\nOn the success path ``related_decisions`` contains zero or more\n:class:`RelatedDecision` hits and ``assessment`` carries the\ndeterministic human-readable summary. On the rejection path\n``error`` is populated; ``related_decisions`` stays empty and\n``assessment`` stays empty. ``store`` is not part of the model;\ntransport adapters add it back at serialization time.",
+    "description": "Return shape for :func:`nauro_core.operations.check_decision`.\n\n``assessment`` is declared first so the takeaway leads the serialized\npayload (Pydantic ``model_dump`` preserves declaration order), matching\nthe rendered block's takeaway-first order. On the success path it carries\nthe deterministic human-readable summary and ``related_decisions``\ncontains zero or more :class:`RelatedDecision` hits. On the rejection\npath ``error`` is populated; ``assessment`` stays empty and\n``related_decisions`` stays empty. ``store`` is not part of the model;\ntransport adapters add it back at serialization time.",
     "properties": {
       "assessment": {
         "default": "",

--- a/packages/nauro/tests/test_stdio_server.py
+++ b/packages/nauro/tests/test_stdio_server.py
@@ -246,8 +246,8 @@ class TestCheckDecision:
                 project_id="testproj",
             )
         )
-        # Renderer surfaces either the "Found N related decisions" header
-        # plus a call-to-action footer, or the empty-state guidance.
+        # Renderer surfaces either the honest lead line (count + call-to-action
+        # + lexical caveat) above the hit list, or the empty-state guidance.
         assert "related decision" in rendered.lower() or "no related decisions" in rendered.lower()
 
 


### PR DESCRIPTION
## Why

The rendered check_decision block is the sole content a modern MCP client
shows, yet it buried its actionable call-to-action under every hit and never
surfaced the lexical-rank caveat at all. Agents saw BM25 scores and a "top
match" marker with no signal that the ranking is keyword overlap, not a
relevance or conflict judgment. That is an over-trust gap on the surface the
agent actually reads.

## What changed

- The check_decision renderer now leads with one honest takeaway line: the
  related-decision count, the get_decision call-to-action (reused from the
  kernel assessment so the number and pluralization stay in sync, with the
  existing generic fallback), and the full lexical-rank caveat. The per-hit
  list follows unchanged, and the old trailing footer is gone. The caveat
  reaches the rendered surface for the first time; the top-match signal stays
  in the list, where the row marker, highest score, and rationale preview
  already read unambiguously.
- CheckDecisionResult declares `assessment` before `related_decisions` so
  raw-JSON surfaces also lead with the takeaway. The reorder is schema-neutral
  under sort_keys.
- Renderer and result docstrings, plus the affected test comments, were
  refreshed from "footer" to "lead" wording.

## Test plan

- `pytest packages/nauro-core/tests/test_renderers.py packages/nauro-core/tests/operations/test_check_decision.py` -> 58 passed
- `pytest packages/nauro/tests/test_check_decision_schema.py packages/nauro/tests/test_check_decision_parity.py packages/nauro/tests/test_stdio_server.py packages/nauro/tests/test_stdio_renderer_wrap.py packages/nauro/tests/test_public_contract.py` -> 89 passed
- Full suites: nauro-core 984 passed; nauro 1558 passed, 10 skipped
- `ruff check packages/` and `ruff format --check packages/` clean

## Risk / what to review

The schema snapshot (`check_decision_schema.json`) changed by one line, only
the `description` field, because Pydantic embeds the CheckDecisionResult
docstring as the schema description and that docstring was updated for the
takeaway-first order. Field names, defaults, and required markers are
unchanged. Worth a glance to confirm the wire contract is otherwise identical.

## Deferred

The per-hit `BM25 0.00` label for embedding-sourced hits and applying a
similar lead to sibling renderers stay out of scope.
