### PR TITLE
Release nauro 1.2.1 and nauro-core 1.0.3

### DIFF
--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro-core"
-version = "1.0.2"
+version = "1.0.3"
 description = "Shared pure-Python logic for Nauro: parsing, validation, context assembly, constants."
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro"
-version = "1.2.0"
+version = "1.2.1"
 description = "Local CLI + MCP server: set your project's doctrine once, every connected AI agent inherits it."
 readme = "README.md"
 license = "Apache-2.0"
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "nauro-core>=1.0.2,<2",
+    "nauro-core>=1.0.3,<2",
     "typer>=0.9",
     "httpx>=0.24",
     "mcp>=1.0",

--- a/server.json
+++ b/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Nauro-AI/nauro",
     "source": "github"
   },
-  "version": "1.2.0",
+  "version": "1.2.1",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "nauro",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -423,7 +423,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1051,7 +1051,7 @@ wheels = [
 
 [[package]]
 name = "nauro"
-version = "1.2.0"
+version = "1.2.1"
 source = { editable = "packages/nauro" }
 dependencies = [
     { name = "filelock" },
@@ -1095,7 +1095,7 @@ provides-extras = ["dev", "embeddings"]
 
 [[package]]
 name = "nauro-core"
-version = "1.0.2"
+version = "1.0.3"
 source = { editable = "packages/nauro-core" }
 dependencies = [
     { name = "bm25s" },


### PR DESCRIPTION
## Release

- **nauro-core**: 1.0.2 -> 1.0.3
- **nauro**: 1.2.0 -> 1.2.1 (dependency floor bumped to `nauro-core>=1.0.3,<2`)
- **server.json**: 1.2.0 -> 1.2.1 (lockstep with the nauro package)
- **uv.lock**: re-locked for the version bumps (`uv sync --locked` now requires it)

## What ships

**nauro-core 1.0.3**
- check_decision's rendered output leads with an honest takeaway line (count, the get_decision call-to-action, and the lexical-rank caveat); the caveat reaches the rendered surface for the first time.
- Over-strip and slug-collapse render fix.
- A guaranteed block slot for the top superseding decision.
- diff-since-last-session refinements.

**nauro 1.2.1**
- Single-flight the Auth0 token refresh.
- Reskin `nauro init --demo` to a local-first budgeting app.
- Skip the decision-hash index lock artifact in sync.
- Hook and config refinements.

No breaking changes; the frozen 1.0 contract surface is unchanged.

## Checks

- `scripts/check_server_json_version.py` -> version-locked to 1.2.1
- `scripts/check_single_sourced.py` -> clean
- `uv sync --locked` passes for both nauro and nauro-core

## Release steps after merge

1. Tag the merge commit: `nauro-core-v1.0.3` and `nauro-v1.2.1` (each tag triggers its PyPI publish workflow; the `nauro-v*` tag also publishes `server.json` to the MCP registry).
2. Create the two GitHub Releases with notes.
