### PR TITLE
Reframe README positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Nauro
 
-Nauro gives every coding agent project judgment. It keeps your project's product direction, decisions, rationale, open questions, and rejected paths in plain markdown files, then surfaces the relevant ones before an AI agent plans or changes code.
+Nauro gives every connected agent project judgement. It keeps your project's product direction, decisions, rationale, open questions, and rejected paths in plain markdown files, then surfaces the relevant ones before an AI agent plans or changes code.
 
 It works across Claude, Cursor, Codex, Perplexity, and any MCP client. The same decision record travels with the work, not with a single tool or session.
 
@@ -8,7 +8,7 @@ It works across Claude, Cursor, Codex, Perplexity, and any MCP client. The same 
 
 https://github.com/user-attachments/assets/9e6c475b-c584-470b-84c2-12f01b3a425a
 
-*A coding agent checks the project's prior decisions before it plans, then records the approved decision and makes the change. Captured in Codex.*
+*An agent checks the project's prior decisions before it plans, then records the approved decision and makes the change. Captured in Codex.*
 
 **Status:** Stable (1.x). The nauro CLI, the stdio MCP tool contract, and the on-disk store format follow semantic versioning. Cloud sync is versioned and operated separately.
 
@@ -87,7 +87,7 @@ Against tools that extract notes from conversations automatically: Nauro records
 
 ## When Nauro helps, and when it doesn't
 
-Nauro pays off when an agent needs project judgment before acting: architecture choices, rejected approaches, migration plans, operational constraints, and decisions that recur across sessions, tools, repos, machines, or handoffs.
+Nauro pays off when an agent needs project judgement before acting: architecture choices, rejected approaches, migration plans, operational constraints, and decisions that recur across sessions, tools, repos, machines, or handoffs.
 
 If one small repo plus a tight `CLAUDE.md` already keeps your agents oriented, Nauro may be too much.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Nauro
 
-Nauro is a decision system for agentic engineering. It keeps your project's decisions, rationale, and rejected paths in plain markdown files, then surfaces the relevant ones before an AI agent plans or changes code.
+Nauro gives every coding agent project judgment. It keeps your project's product direction, decisions, rationale, open questions, and rejected paths in plain markdown files, then surfaces the relevant ones before an AI agent plans or changes code.
 
-It works across Claude, Cursor, Codex, Perplexity, and any MCP client. The result is persistent project judgment that travels with the work, not with a single tool or session.
+It works across Claude, Cursor, Codex, Perplexity, and any MCP client. The same decision record travels with the work, not with a single tool or session.
 
 [![PyPI](https://img.shields.io/pypi/v/nauro.svg)](https://pypi.org/project/nauro/) [![Python](https://img.shields.io/pypi/pyversions/nauro.svg)](https://pypi.org/project/nauro/) [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 
@@ -16,7 +16,7 @@ More at [nauro.ai](https://nauro.ai).
 
 ## How it works
 
-Nauro stores your project's decisions as plain markdown files, each with the alternatives you ruled out and the reasoning behind them. When an agent proposes an approach, `check_decision` runs deterministic keyword retrieval (BM25) over those files and surfaces the related ones before the agent plans or writes code.
+Nauro stores your project's decisions as plain markdown files, each with the alternatives you ruled out and the reasoning behind them. The store can also carry current state and open questions. When an agent proposes an approach, `check_decision` runs deterministic keyword retrieval (BM25) over those files and surfaces the related ones before the agent plans or writes code.
 
 No model judges your decisions. The check is advisory and never blocks a change. A decision is recorded only by an explicit write call, and the approval gate lives in the conversation. The store is a folder you own; remove Nauro and the markdown stays.
 
@@ -77,17 +77,19 @@ Output abbreviated to the top match; the live call returns all five related deci
 
 *A project store rendered by nauro graph: supersession threads converge on the decisions that replaced them, and standalone decisions cluster by category.*
 
-## Why not ADRs, grep, CLAUDE.md, or a memory product?
+## Why not ADRs, grep, CLAUDE.md, or built-in agent notes?
 
 A decision log in your repo is a good record. The gap is on the read side: a file is read when a person opens it, and a fresh agent session starts with no knowledge that it exists. Nauro closes that gap twice over: the relevant decision reaches your agent through MCP at the moment it proposes a change, and `nauro sync` regenerates a committable `AGENTS.md` summary in every associated repo, so clones and tools without MCP wiring still start from the current record.
 
 Against a coding tool's built-in memory (Claude Code memory, Cursor memories): those are scoped to one tool and one user. Nauro's record belongs to the project. The same store answers in Claude, Cursor, Codex, and any MCP client, across every repo you associate with it.
 
-Against agent-memory products: most extract and store memories from conversations automatically. Nauro records decisions instead: an entry is a reviewed choice with its rationale and the alternatives you rejected, written only on an explicit call after approval in the conversation, retrieved by deterministic keyword search you can audit, and superseded rather than silently rewritten. It is plain markdown in a folder you own; remove Nauro and the record stays readable.
+Against tools that extract notes from conversations automatically: Nauro records decisions instead. An entry is a reviewed choice with its rationale and the alternatives you rejected, written only on an explicit call after approval in the conversation, retrieved by deterministic keyword search you can audit, and superseded rather than silently rewritten. It is plain markdown in a folder you own; remove Nauro and the record stays readable.
 
 ## When Nauro helps, and when it doesn't
 
-Nauro pays off when an agent needs project judgment before acting: architecture choices, rejected approaches, migration plans, operational constraints, and decisions that recur across sessions or tools.
+Nauro pays off when an agent needs project judgment before acting: architecture choices, rejected approaches, migration plans, operational constraints, and decisions that recur across sessions, tools, repos, machines, or handoffs.
+
+If one small repo plus a tight `CLAUDE.md` already keeps your agents oriented, Nauro may be too much.
 
 The limits are worth knowing. It surfaces only what has been recorded as a decision. It adds an MCP round-trip to the agent's flow. Retrieval is keyword-based, which is fast, offline, and auditable, and can miss a decision phrased in different words than the proposal; an optional embeddings index is available for closer synonym matching.
 

--- a/packages/nauro/README.md
+++ b/packages/nauro/README.md
@@ -1,8 +1,8 @@
 # Nauro
 
-A decision system for agentic engineering.
+Project judgment for every coding agent.
 
-Catch the moment an agent re-proposes something you already ruled out. Your project's decisions, including what you chose and what you ruled out, travel with every connected agent. When an agent proposes an approach, Nauro surfaces the past decisions related to it, so the agent sees the prior reasoning before it writes code. The check is advisory: it never blocks, and you approve anything that gets recorded. Works with Claude, Perplexity, Cursor, and any MCP client.
+Your project's product direction, decisions, rationale, open questions, and rejected paths travel with every connected agent. When an agent proposes an approach, Nauro surfaces the related decisions, so the agent sees the prior reasoning before it writes code. The check is advisory: it never blocks, and you approve anything that gets recorded. Works with Claude, Perplexity, Cursor, Codex, and any MCP client.
 
 ## Install
 
@@ -14,7 +14,7 @@ No `uv`? Install it with `curl -LsSf https://astral.sh/uv/install.sh | sh` (macO
 
 ## Quickstart
 
-Catch a conflict in about 30 seconds. No account, MCP wiring, or restart required:
+See a prior decision in about 30 seconds. No account, MCP wiring, or restart required:
 
 ```bash
 mkdir -p /tmp/nauro-demo && cd /tmp/nauro-demo
@@ -55,7 +55,7 @@ Nauro is decisional, not observational. It captures what you decided and what yo
 
 No model judges your decisions. The check uses deterministic keyword retrieval (BM25), is advisory, and never blocks a change. You approve every decision before it is recorded.
 
-`check_decision` returns the related prior decisions (the `related_decisions` list shown above) so the agent can weigh them before proposing; Nauro ranks by keyword relevance and does not judge whether they conflict. When you record a choice with `propose_decision`, near-matches surface as advisory `similar_decisions` on the same call, and a clean proposal commits in one call. What you decide in one tool, every connected agent inherits; for example, a decision recorded in Claude Code is available later in Perplexity. The store is plain markdown in a folder you own. Run it fully locally with no account; cloud sync is opt-in.
+`check_decision` returns the related prior decisions (the `related_decisions` list shown above) so the agent can weigh them before proposing; Nauro ranks by keyword relevance and does not judge the proposal. When you record a choice with `propose_decision`, near-matches surface as advisory `similar_decisions` on the same call, and a clean proposal commits in one call. What you decide in one tool, every connected agent inherits; for example, a decision recorded in Claude Code is available later in Perplexity. The store is plain markdown in a folder you own. Run it fully locally with no account; cloud sync is opt-in.
 
 ## Pricing
 

--- a/packages/nauro/README.md
+++ b/packages/nauro/README.md
@@ -1,6 +1,6 @@
 # Nauro
 
-Project judgment for every coding agent.
+Project judgement for every connected agent.
 
 Your project's product direction, decisions, rationale, open questions, and rejected paths travel with every connected agent. When an agent proposes an approach, Nauro surfaces the related decisions, so the agent sees the prior reasoning before it writes code. The check is advisory: it never blocks, and you approve anything that gets recorded. Works with Claude, Perplexity, Cursor, Codex, and any MCP client.
 

--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "nauro"
 version = "1.2.1"
-description = "Local CLI + MCP server: project judgment for every connected coding agent."
+description = "Local CLI + MCP server: project judgement for every connected agent."
 readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.10"

--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "nauro"
 version = "1.2.1"
-description = "Local CLI + MCP server: set your project's doctrine once, every connected AI agent inherits it."
+description = "Local CLI + MCP server: project judgment for every connected coding agent."
 readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Why

GitHub, PyPI, and package readers still saw Nauro as a decision system or conflict checker. The public frame is now project judgement for connected agents, with decisions as the concrete stored unit.

## What changed

- Updated the root README lead, how-it-works copy, comparison section, and fit guidance.
- Updated the package README lead, quickstart framing, and check_decision wording.
- Updated the package description to match the project-judgment frame.
- Kept product behavior, CLI behavior, MCP behavior, dependencies, public API, and video surfaces unchanged.

## Test plan

- `ruff format .`
- `ruff check .`
- `packages/nauro-core` tests: 984 passed.
- `packages/nauro` tests: 1558 passed, 10 skipped.
- `git diff --check`
