### PR TITLE
Add README maturity and context facts

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ More at [nauro.ai](https://nauro.ai).
 
 Nauro stores your project's decisions as plain markdown files, each with the alternatives you ruled out and the reasoning behind them. The store can also carry current state and open questions. When an agent proposes an approach, `check_decision` runs deterministic keyword retrieval (BM25) over those files and surfaces the related ones before the agent plans or writes code.
 
+At session start, agents can read a compact L0 standing-context summary: project summary, current state, top open questions, and the last 10 decisions, then pull specific decisions on demand. On Nauro's own 368-decision store, that L0 summary measured about 2,600 Claude tokens; the full store was 539,469 tokens.
+
 No model judges your decisions. The check is advisory and never blocks a change. A decision is recorded only by an explicit write call, and the approval gate lives in the conversation. The store is a folder you own; remove Nauro and the markdown stays.
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ https://github.com/user-attachments/assets/9e6c475b-c584-470b-84c2-12f01b3a425a
 
 *An agent checks the project's prior decisions before it plans, then records the approved decision and makes the change. Captured in Codex.*
 
-**Status:** Stable (1.x). The nauro CLI, the stdio MCP tool contract, and the on-disk store format follow semantic versioning. Cloud sync is versioned and operated separately.
+**Status:** Stable (1.x). The nauro CLI, the stdio MCP tool contract, and the on-disk store format follow semantic versioning. CI covers Python 3.10-3.14, and the public packages currently carry 2,102 tests across 142 files. Cloud sync is versioned and operated separately.
 
 More at [nauro.ai](https://nauro.ai).
 


### PR DESCRIPTION
## Why

The README should carry a small set of verifiable product facts now that the positioning copy has been refreshed.

## What changed

Adds CI coverage and public test-count facts to the Stable 1.x status paragraph.

Adds a measured example of the compact L0 standing-context summary versus the full store, framed as summary plus on-demand decision retrieval.

## Test plan

- git diff --check -- README.md
- Verified the public test count and Python matrix from source
- Site docs counterpart validated separately in Nauro-AI/site #98