### PR TITLE
Warn before publishing Nauro wiring files

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@ Keep it short and scale it to the change: a small PR needs only a line or two pe
 Write under each heading; the comment prompts are guidance and do not render.
 Add "## Risk / what to review" (non-obvious logic, edge cases, a frozen surface, lower-confidence areas)
 or "## Deferred" (intentionally out of scope; link the follow-up) as their own headings only when they carry weight.
-Link related issues, e.g. "Closes #123". Reference Nauro decisions by number, e.g. D154, where relevant.
+Link related issues, e.g. "Closes #123". Public-facing PR bodies, commits, docs, code comments, schema text, and branch names should paraphrase Nauro rationale instead of raw internal decision or question ids.
 -->
 
 ## Why

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ More at [nauro.ai](https://nauro.ai).
 
 Nauro stores your project's decisions as plain markdown files, each with the alternatives you ruled out and the reasoning behind them. The store can also carry current state and open questions. When an agent proposes an approach, `check_decision` runs deterministic keyword retrieval (BM25) over those files and surfaces the related ones before the agent plans or writes code.
 
+At session start, agents can read a compact L0 standing-context summary: project summary, current state, top open questions, and the last 10 decisions, then pull specific decisions on demand. On Nauro's own 368-decision store, that L0 summary measured about 2,600 Claude tokens; the full store was 539,469 tokens.
+
 No model judges your decisions. The check is advisory and never blocks a change. A decision is recorded only by an explicit write call, and the approval gate lives in the conversation. The store is a folder you own; remove Nauro and the markdown stays.
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ https://github.com/user-attachments/assets/9e6c475b-c584-470b-84c2-12f01b3a425a
 
 *An agent checks the project's prior decisions before it plans, then records the approved decision and makes the change. Captured in Codex.*
 
-**Status:** Stable (1.x). The nauro CLI, the stdio MCP tool contract, and the on-disk store format follow semantic versioning. Cloud sync is versioned and operated separately.
+**Status:** Stable (1.x). The nauro CLI, the stdio MCP tool contract, and the on-disk store format follow semantic versioning. CI covers Python 3.10-3.14, and the public packages currently carry 2,102 tests across 142 files. Cloud sync is versioned and operated separately.
 
 More at [nauro.ai](https://nauro.ai).
 

--- a/packages/nauro/src/nauro/agents/nauro-executor.md
+++ b/packages/nauro/src/nauro/agents/nauro-executor.md
@@ -30,6 +30,7 @@ If implementing the plan forces an architectural choice the plan did not pre-rec
 - **Exact exit codes in tests.** Assert `result.exit_code == N`, not `!= 0` — otherwise a crash before the rejection path passes.
 - **Colocate package-internal tests.** Module invariants live in that package's own test suite. Cross-package wiring tests go in the consumer.
 - **No internal labels in public repos.** Strip internal labeling schemes, dated milestones, and internal filenames from public-facing diffs, commits, and code.
+- **Public surfaces carry rationale.** Public-facing PR bodies, commits, docs, code comments, schema text, and branch names paraphrase rationale instead of raw internal decision or question ids. Internal planning, review, and decision-store surfaces may cite ids.
 
 ## Local completion — do not push
 
@@ -38,8 +39,8 @@ Commit your work to the local branch. **Do not push to remote and do not open a 
 1. **Lint.** Run `ruff format` and `ruff check` (check the project Makefile for the canonical command). Renames especially can silently break format. Lint failures block — fix the root cause, don't bypass.
 2. **Test.** Run the relevant test suite.
 3. **Cross-package dependencies stay in sync.** If the change bumps a dependency pinned across multiple packages or lockfiles, regenerate every affected manifest in the same commit. Use the project's release-helper tooling when one exists.
-4. **Commit.** Default to **one commit per PR**. Subject under 72 chars, imperative voice. Body includes a Why paragraph and a footer referencing the decision the planner recorded, if any. Split into multiple commits only when the plan explicitly justifies it — meaningful, independently-revertible stages (e.g., bug fix + unrelated refactor, or a sequence with a logical hand-off between commits). For bulk cleanup, refactors, or any bounded single-purpose work, one commit is right. The PR body conveys structure; the branch doesn't need to mirror it.
-5. **Draft the PR description.** Follow `.github/PULL_REQUEST_TEMPLATE.md`. The core sections are Why / What changed / Test plan; add "Risk / what to review" and "Deferred" as their own headings only when they carry weight. Narrative for reviewers, not a changelog. Reference any decision the planner recorded.
+4. **Commit.** Default to **one commit per PR**. Subject under 72 chars, imperative voice. Body includes a Why paragraph. If prior doctrine motivated the work, paraphrase that rationale instead of citing raw decision or question ids. Split into multiple commits only when the plan explicitly justifies it, for meaningful and independently revertible stages (e.g., bug fix + unrelated refactor, or a sequence with a logical hand-off between commits). For bulk cleanup, refactors, or any bounded single-purpose work, one commit is right. The PR body conveys structure; the branch doesn't need to mirror it.
+5. **Draft the PR description.** Follow `.github/PULL_REQUEST_TEMPLATE.md`. The core sections are Why / What changed / Test plan; add "Risk / what to review" and "Deferred" as their own headings only when they carry weight. Narrative for reviewers, not a changelog. Paraphrase any planner-recorded rationale that matters to reviewers instead of citing raw ids.
 
 ## What you do NOT do at this stage
 

--- a/packages/nauro/src/nauro/agents/nauro-reviewer.md
+++ b/packages/nauro/src/nauro/agents/nauro-reviewer.md
@@ -69,7 +69,7 @@ These rules apply after the code-review pass. They protect long-lived project co
 #### Hard rules (BLOCK if any fail)
 
 1. **PR body has the required sections.** From `.github/PULL_REQUEST_TEMPLATE.md`: Why, What changed, Test plan. Missing any of the three is always a block. "Risk / what to review" and "Deferred" are conditional headings: block only when a real risk or a real deferral was omitted (reviewer judgment), not merely because the heading is absent.
-2. **Every referenced decision resolves.** Any decision reference in the PR body or commit messages must resolve via `get_decision`. An unresolved reference blocks.
+2. **Public surfaces carry rationale.** Public-facing PR bodies, commits, docs, code comments, schema text, and branch names should paraphrase rationale instead of raw internal decision or question ids. Internal planning, review, and decision-store surfaces may cite ids; verify each internal decision reference with `get_decision`.
 3. **No personal paths.** Grep the diff and PR body for `/Users/<name>/` or similar. Any match blocks.
 4. **No internal labels in public repos.** Internal labeling schemes, dated milestones, and internal filenames in user-facing diffs (docs, READMEs, code comments) block. CI configs and internal tooling are fine.
 5. **No template tokens in distribution artifacts.** User-facing files (docs, GitHub-visible markdown, dogfood content) must not contain raw `<!-- protocol:... -->` or other template syntax.

--- a/packages/nauro/src/nauro/agents/nauro-reviewer.md
+++ b/packages/nauro/src/nauro/agents/nauro-reviewer.md
@@ -14,7 +14,7 @@ You review a diff against the PR template and the project's conventions. You rea
 1. Read the drafted PR description from your prompt.
 2. Read the diff: `git diff origin/main...HEAD` (or against the actual base branch — confirm with `git log --oneline origin/main..HEAD`).
 3. **Code review pass.** Apply the criteria in "What to look for" below. Flag real bugs only — prefer zero findings to weak findings.
-4. **Hard rule check** against the diff and the drafted PR body. For every decision reference, call `get_decision` and confirm it resolves.
+4. **Hard rule check** against the diff and the drafted PR body. Reject raw decision or question ids on public surfaces, then call `get_decision` for each remaining internal decision reference and confirm it resolves.
 5. Skim for soft flags.
 6. Return a structured report.
 

--- a/packages/nauro/src/nauro/cli/commands/adopt.py
+++ b/packages/nauro/src/nauro/cli/commands/adopt.py
@@ -36,6 +36,7 @@ from nauro.cli.commands.setup import (
     _find_nauro_command,
     setup_all_surfaces,
 )
+from nauro.cli.git_hygiene import public_surface_git_warnings
 from nauro.cli.utils import refuse_global_config_collision
 from nauro.constants import REGISTRY_SCHEMA_VERSION_V2, REPO_CONFIG_MODE_LOCAL
 from nauro.skills import load_adopt_body
@@ -52,6 +53,11 @@ from nauro.store.repo_config import RepoConfigSchemaError, load_repo_config, sav
 from nauro.telemetry import capture
 from nauro.telemetry.events import project_created
 from nauro.templates.scaffolds import scaffold_project_store
+
+
+def _echo_repo_config_warnings(repo_root: Path) -> None:
+    for warning in public_surface_git_warnings(repo_root, ".nauro/config.json"):
+        typer.echo(warning, err=True)
 
 
 def _resolve_repo_root(repo_arg: Path | None) -> Path:
@@ -503,6 +509,7 @@ def adopt(
             "name": project_name,
         },
     )
+    _echo_repo_config_warnings(repo_root)
     scaffold_project_store(project_name, store_path)
 
     typer.echo(f"Adopted project '{project_name}' (id: {pid})")

--- a/packages/nauro/src/nauro/cli/commands/attach.py
+++ b/packages/nauro/src/nauro/cli/commands/attach.py
@@ -16,6 +16,7 @@ from pathlib import Path
 import typer
 
 from nauro.cli.commands.auth import DEFAULT_API_URL
+from nauro.cli.git_hygiene import public_surface_git_warnings
 from nauro.cli.utils import refuse_global_config_collision
 from nauro.constants import REPO_CONFIG_MODE_CLOUD
 from nauro.store.registry import (
@@ -84,6 +85,8 @@ def attach(
             "server_url": DEFAULT_API_URL,
         },
     )
+    for warning in public_surface_git_warnings(repo_path, ".nauro/config.json"):
+        typer.echo(warning, err=True)
 
     typer.echo(f"Attached '{name}' to {repo_path.resolve()}")
     typer.echo(f"  Project id: {project_id}")

--- a/packages/nauro/src/nauro/cli/commands/init.py
+++ b/packages/nauro/src/nauro/cli/commands/init.py
@@ -23,6 +23,7 @@ from pathlib import Path
 import typer
 
 from nauro.cli.commands.auth import DEFAULT_API_URL
+from nauro.cli.git_hygiene import public_surface_git_warnings
 from nauro.cli.utils import refuse_global_config_collision
 from nauro.constants import (
     REGISTRY_SCHEMA_VERSION_V2,
@@ -46,6 +47,11 @@ from nauro.sync.cloud_projects import CloudProjectError, create_project
 from nauro.telemetry import capture
 from nauro.telemetry.events import project_created
 from nauro.templates.scaffolds import scaffold_project_store
+
+
+def _echo_repo_config_warnings(repo_path: Path) -> None:
+    for warning in public_surface_git_warnings(repo_path, ".nauro/config.json"):
+        typer.echo(warning, err=True)
 
 
 def _check_config_overwrite(
@@ -208,6 +214,7 @@ def _init_demo(name: str, repo_paths: list[Path], force: bool) -> None:
                 "name": name,
             },
         )
+        _echo_repo_config_warnings(rp)
 
     create_demo_project(store_path)
     cwd_is_git = (Path.cwd() / ".git").is_dir()
@@ -344,6 +351,7 @@ def init(
                         "name": name,
                     },
                 )
+                _echo_repo_config_warnings(rp)
                 added.append(rp.resolve())
             typer.echo(f"Updated project '{name}'")
             typer.echo(f"  Store: {store_path}")
@@ -404,6 +412,7 @@ def init(
                     "server_url": DEFAULT_API_URL,
                 },
             )
+            _echo_repo_config_warnings(rp)
         scaffold_project_store(name, store_path)
         typer.echo(f"Initialized cloud project '{name}'")
         typer.echo(f"  Project id: {pid}")
@@ -437,6 +446,7 @@ def init(
                 "name": name,
             },
         )
+        _echo_repo_config_warnings(rp)
 
     scaffold_project_store(name, store_path)
     typer.echo(f"Initialized project '{name}'")

--- a/packages/nauro/src/nauro/cli/commands/link.py
+++ b/packages/nauro/src/nauro/cli/commands/link.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import typer
 
 from nauro.cli.commands.auth import DEFAULT_API_URL, load_access_token
+from nauro.cli.git_hygiene import public_surface_git_warnings
 from nauro.constants import (
     REPO_CONFIG_MODE_CLOUD,
     REPO_CONFIG_MODE_LOCAL,
@@ -119,6 +120,8 @@ def link(
             "server_url": DEFAULT_API_URL,
         },
     )
+    for warning in public_surface_git_warnings(repo_root, ".nauro/config.json"):
+        typer.echo(warning, err=True)
 
     typer.echo(f"Linked '{name}' to cloud project")
     typer.echo(f"  Old id: {local_id}")

--- a/packages/nauro/src/nauro/cli/commands/setup.py
+++ b/packages/nauro/src/nauro/cli/commands/setup.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 import typer
 
+from nauro.cli.git_hygiene import public_surface_git_warnings
 from nauro.cli.utils import _resolve_project_entry, resolve_target_project
 from nauro.constants import CLAUDE_MD, NAURO_BLOCK_END, NAURO_BLOCK_START
 from nauro.store.reader import read_text_lenient
@@ -167,7 +168,9 @@ def _configure_json_mcp(
     servers["nauro"] = nauro_entry
     config_path.parent.mkdir(parents=True, exist_ok=True)
     config_path.write_text(json.dumps(config, indent=2) + "\n")
-    return f"  {repo_path}: wrote nauro to {label}"
+    lines = [f"  {repo_path}: wrote nauro to {label}"]
+    lines.extend(public_surface_git_warnings(repo_path, config_rel_path))
+    return "\n".join(lines)
 
 
 def _configure_mcp(repo_path: Path, *, remove: bool = False) -> str:
@@ -302,6 +305,8 @@ def claude_code(
             typer.echo("\nAGENTS.md:")
             for repo_path in updated_repos:
                 typer.echo(f"  {repo_path}: regenerated AGENTS.md")
+                for warning in public_surface_git_warnings(repo_path, "AGENTS.md"):
+                    typer.echo(warning, err=True)
 
         typer.echo(
             "\nNext: start a Claude Code session in one of the repos."
@@ -788,7 +793,9 @@ def _add_hook_entry(settings_path: Path, settings: dict, repo: Path) -> str:
     event_matchers.append({"hooks": [_nauro_hook_entry()]})
     settings_path.parent.mkdir(parents=True, exist_ok=True)
     settings_path.write_text(json.dumps(settings, indent=2) + "\n")
-    return f"  {repo}: wrote nauro hook to .claude/settings.json"
+    lines = [f"  {repo}: wrote nauro hook to .claude/settings.json"]
+    lines.extend(public_surface_git_warnings(repo, ".claude/settings.json"))
+    return "\n".join(lines)
 
 
 def _remove_hook_entry(settings_path: Path, settings: dict, repo: Path) -> str:
@@ -987,6 +994,7 @@ def setup_all_surfaces(
             updated = regenerate_agents_md_for_project(current_project_key, store_path)
             for repo_path in updated:
                 lines.append(f"  {repo_path}: regenerated AGENTS.md")
+                lines.extend(public_surface_git_warnings(repo_path, "AGENTS.md"))
         except Exception as exc:
             lines.append(f"AGENTS.md regeneration: error — {exc}")
 

--- a/packages/nauro/src/nauro/cli/git_hygiene.py
+++ b/packages/nauro/src/nauro/cli/git_hygiene.py
@@ -1,0 +1,99 @@
+"""Advisory git hygiene warnings for Nauro-generated public surfaces."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+KNOWN_PUBLIC_SURFACE_PATHS = frozenset(
+    {
+        "AGENTS.md",
+        ".mcp.json",
+        ".cursor/mcp.json",
+        ".claude/settings.json",
+        ".nauro/config.json",
+    }
+)
+
+
+def public_surface_git_warnings(repo_root: Path, rel_path: str) -> list[str]:
+    """Return advisory warnings for a known path Nauro just wrote."""
+    if rel_path not in KNOWN_PUBLIC_SURFACE_PATHS:
+        return []
+
+    target = repo_root / rel_path
+    if not target.exists():
+        return []
+
+    git_root = _git_root(repo_root)
+    if git_root is None:
+        return []
+
+    try:
+        git_rel = target.resolve().relative_to(git_root).as_posix()
+    except ValueError:
+        return []
+
+    if _is_tracked(git_root, git_rel):
+        return [_tracked_warning(rel_path)]
+    if _is_ignored(git_root, git_rel):
+        return []
+    return [_untracked_warning(rel_path)]
+
+
+def _git_root(path: Path) -> Path | None:
+    proc = _run_git(path, "rev-parse", "--show-toplevel")
+    if proc is None or proc.returncode != 0:
+        return None
+    root = proc.stdout.strip()
+    return Path(root).resolve() if root else None
+
+
+def _is_tracked(git_root: Path, git_rel: str) -> bool:
+    proc = _run_git(git_root, "ls-files", "--error-unmatch", "--", git_rel)
+    return proc is not None and proc.returncode == 0
+
+
+def _is_ignored(git_root: Path, git_rel: str) -> bool:
+    proc = _run_git(git_root, "check-ignore", "-q", "--", git_rel)
+    return proc is not None and proc.returncode == 0
+
+
+def _run_git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str] | None:
+    try:
+        return subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except (FileNotFoundError, OSError):
+        return None
+
+
+def _tracked_warning(rel_path: str) -> str:
+    if rel_path == ".nauro/config.json":
+        detail = "it is repo-local Nauro project config"
+    elif rel_path == "AGENTS.md":
+        detail = "it may expose generated Nauro context"
+    else:
+        detail = "it may expose local Nauro wiring"
+    return (
+        f"  Warning: {rel_path} is tracked by git. "
+        f"Review before publishing a public-bound repo; {detail}."
+    )
+
+
+def _untracked_warning(rel_path: str) -> str:
+    if rel_path == ".nauro/config.json":
+        detail = "It is repo-local Nauro project config"
+    elif rel_path == "AGENTS.md":
+        detail = "It contains generated Nauro context"
+    else:
+        detail = "It contains local Nauro wiring"
+    return (
+        f"  Note: {rel_path} is untracked and not git-ignored. "
+        "It is easy to add by accident; review or ignore it before publishing "
+        f"a public-bound repo. {detail}."
+    )

--- a/packages/nauro/src/nauro/mcp/tools.py
+++ b/packages/nauro/src/nauro/mcp/tools.py
@@ -391,7 +391,10 @@ def tool_propose_decision(
     if result.status == "confirmed":
         capture_snapshot(store_path, trigger=f"decision: {result.decision_id}")
         if touched:
-            warn_then_regen(store_path.name, store_path)
+            regen_warnings: list[str] = []
+            warn_then_regen(store_path.name, store_path, warn=regen_warnings.append)
+            if regen_warnings:
+                response["assessment"] = "\n\n".join([response["assessment"], *regen_warnings])
         _try_push(store_path)
 
     return response

--- a/packages/nauro/src/nauro/templates/agents_md.py
+++ b/packages/nauro/src/nauro/templates/agents_md.py
@@ -141,6 +141,9 @@ def generate_agents_md(
         "scope boundaries.\n\n"
         "**Update state** when you complete a meaningful unit of work — a feature,\n"
         "a refactor, a bug fix — so the next session starts with current context.\n"
+        "\n"
+        "**Keep public-facing artifacts public.** Paraphrase Nauro rationale instead of\n"
+        "citing raw decision or question ids. Internal planning and review may cite ids.\n"
     )
 
     # Preserved sections in source-appearance order.

--- a/packages/nauro/src/nauro/templates/agents_md_regen.py
+++ b/packages/nauro/src/nauro/templates/agents_md_regen.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from pathlib import Path
 
+from nauro.cli.git_hygiene import public_surface_git_warnings
 from nauro.store.registry import get_repo_paths
 from nauro.templates.agents_md import regenerate_agents_md_for_project
 
@@ -42,4 +43,9 @@ def warn_then_regen(
                 f"  Warning: repo path does not exist, skipping AGENTS.md: {repo_str}\n"
                 f"  Fix: remove from registry or update path in ~/.nauro/registry.json"
             )
-    return regenerate_agents_md_for_project(project_key, store_path)
+    updated = regenerate_agents_md_for_project(project_key, store_path)
+    if warn is not None:
+        for repo_path in updated:
+            for message in public_surface_git_warnings(repo_path, "AGENTS.md"):
+                warn(message)
+    return updated

--- a/packages/nauro/src/nauro/templates/agents_md_regen.py
+++ b/packages/nauro/src/nauro/templates/agents_md_regen.py
@@ -28,9 +28,9 @@ def warn_then_regen(
     Args:
         project_key: Either a v2 project_id (ULID) or a v1 project name.
         store_path: Path to the project store directory.
-        warn: Optional callback for the per-repo "repo path does not exist"
-            warning. When ``None`` (the MCP adapter case) missing repo
-            paths are silently skipped.
+        warn: Optional callback for missing-repo and git-hygiene warnings.
+            When ``None``, missing repo paths are silently skipped and
+            git-hygiene checks do not run.
 
     Returns:
         The list of repo paths whose ``AGENTS.md`` was successfully

--- a/packages/nauro/tests/test_adopt.py
+++ b/packages/nauro/tests/test_adopt.py
@@ -217,6 +217,15 @@ def test_adopt_no_setup_and_skills_skips_wiring(tmp_path: Path, monkeypatch):
     assert not (Path(tmp_path) / ".agents" / "skills" / "nauro-adopt" / "SKILL.md").exists()
 
 
+def test_adopt_warns_for_unignored_repo_config(tmp_path: Path, monkeypatch):
+    _adopt_env(monkeypatch, tmp_path)
+
+    result = runner.invoke(app, ["adopt", "--name", "alpha", "--no-setup-and-skills"])
+    assert result.exit_code == 0, result.output
+    assert ".nauro/config.json is untracked and not git-ignored" in result.output
+    assert "repo-local Nauro project config" in result.output
+
+
 def test_adopt_materializes_skills_across_surfaces(tmp_path: Path, monkeypatch):
     repo = _adopt_env(monkeypatch, tmp_path)
 

--- a/packages/nauro/tests/test_agents_drift.py
+++ b/packages/nauro/tests/test_agents_drift.py
@@ -22,6 +22,7 @@ from typer.testing import CliRunner
 from nauro.agents import AGENT_NAMES, emit_plugin_agents, load_agent_body, render_agent
 
 AGENTS_DIR = Path(__file__).resolve().parents[1] / "src" / "nauro" / "agents"
+REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
 AGENT_ANCHORS: dict[str, tuple[str, ...]] = {
@@ -117,6 +118,16 @@ def test_agent_names_matches_files_on_disk() -> None:
     on_disk = sorted(p.stem for p in AGENTS_DIR.glob("*.md"))
     registered = sorted(AGENT_NAMES)
     assert on_disk == registered
+
+
+def test_public_surface_pointer_rule_stays_in_agent_and_pr_guidance() -> None:
+    phrase = "Public-facing PR bodies, commits, docs, code comments, schema text, and branch names"
+    for name in ("nauro-executor", "nauro-reviewer"):
+        assert phrase in load_agent_body(name)
+
+    template = (REPO_ROOT / ".github" / "PULL_REQUEST_TEMPLATE.md").read_text(encoding="utf-8")
+    assert phrase in template
+    assert "Reference Nauro decisions by number" not in template
 
 
 @pytest.mark.parametrize("name", list(AGENT_NAMES))

--- a/packages/nauro/tests/test_agents_drift.py
+++ b/packages/nauro/tests/test_agents_drift.py
@@ -125,6 +125,19 @@ def test_public_surface_pointer_rule_stays_in_agent_and_pr_guidance() -> None:
     for name in ("nauro-executor", "nauro-reviewer"):
         assert phrase in load_agent_body(name)
 
+    reviewer = load_agent_body("nauro-reviewer")
+    reviewer_instruction = (
+        "4. **Hard rule check** against the diff and the drafted PR body. Reject raw decision "
+        "or question ids on public surfaces, then call `get_decision` for each remaining "
+        "internal decision reference and confirm it resolves."
+    )
+    stale_instruction = (
+        "4. **Hard rule check** against the diff and the drafted PR body. For every decision "
+        "reference, call `get_decision` and confirm it resolves."
+    )
+    assert reviewer.count(reviewer_instruction) == 1
+    assert stale_instruction not in reviewer
+
     template = (REPO_ROOT / ".github" / "PULL_REQUEST_TEMPLATE.md").read_text(encoding="utf-8")
     assert phrase in template
     assert "Reference Nauro decisions by number" not in template

--- a/packages/nauro/tests/test_agents_md.py
+++ b/packages/nauro/tests/test_agents_md.py
@@ -39,10 +39,15 @@ def test_generate_includes_all_sections():
 
 def test_generate_includes_behavioral_instructions():
     result = generate_agents_md("myproj", "payload")
+    public_artifacts_rule = (
+        "**Keep public-facing artifacts public.** Paraphrase Nauro rationale instead of\n"
+        "citing raw decision or question ids. Internal planning and review may cite ids."
+    )
     assert "When to use these tools" in result
     assert "Propose a decision" in result
     assert "Flag a question" in result
     assert "Update state" in result
+    assert result.count(public_artifacts_rule) == 1
 
 
 def test_routing_block_steers_to_local_stdio_with_project_id():

--- a/packages/nauro/tests/test_init_registry_integrity.py
+++ b/packages/nauro/tests/test_init_registry_integrity.py
@@ -11,6 +11,8 @@ fixtures; tests that need a specific cwd override on the same monkeypatch.
 
 from __future__ import annotations
 
+import subprocess
+
 import pytest
 from typer.testing import CliRunner
 
@@ -19,6 +21,10 @@ from nauro.store import registry
 from nauro.store.registry import find_projects_by_name_v2, register_project_v2
 
 runner = CliRunner()
+
+
+def _git_init(repo) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
 
 
 # ── duplicate-claim refusal ────────────────────────────────────────────────────
@@ -182,3 +188,23 @@ def test_init_demo_without_name_still_uses_demo_project(tmp_path, monkeypatch):
     result = runner.invoke(app, ["init", "--demo"])
     assert result.exit_code == 0, result.output
     assert len(find_projects_by_name_v2("demo-project")) == 1
+
+
+def test_init_warns_for_unignored_repo_config_in_git_repo(tmp_path, monkeypatch):
+    _git_init(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["init", "gitproj"])
+    assert result.exit_code == 0, result.output
+    assert ".nauro/config.json is untracked and not git-ignored" in result.output
+    assert "repo-local Nauro project config" in result.output
+
+
+def test_init_suppresses_repo_config_warning_when_ignored(tmp_path, monkeypatch):
+    _git_init(tmp_path)
+    (tmp_path / ".gitignore").write_text(".nauro/config.json\n")
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["init", "gitproj"])
+    assert result.exit_code == 0, result.output
+    assert ".nauro/config.json is untracked and not git-ignored" not in result.output

--- a/packages/nauro/tests/test_link_cloud.py
+++ b/packages/nauro/tests/test_link_cloud.py
@@ -16,9 +16,11 @@ Paths covered:
 
 from __future__ import annotations
 
+import subprocess
 from unittest.mock import MagicMock, patch
 
 import httpx
+import pytest
 from typer.testing import CliRunner
 
 from nauro.cli.main import app
@@ -212,6 +214,38 @@ def test_link_cloud_succeeds_with_only_auth_token(tmp_path, monkeypatch):
     new_entry = registry.get_project_v2(CLOUD_PID)
     assert new_entry is not None
     assert new_entry["mode"] == "cloud"
+
+
+@pytest.mark.parametrize(
+    ("track_config", "expected"),
+    [
+        (False, ".nauro/config.json is untracked and not git-ignored"),
+        (True, ".nauro/config.json is tracked by git"),
+    ],
+)
+def test_link_cloud_warns_for_repo_config_git_hygiene(
+    tmp_path, monkeypatch, track_config, expected
+):
+    _seed_token(monkeypatch, tmp_path)
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("NAURO_API_URL", "https://example.test")
+
+    init_result = runner.invoke(app, ["init", "linkproj"])
+    assert init_result.exit_code == 0, init_result.output
+    if track_config:
+        subprocess.run(["git", "add", ".nauro/config.json"], cwd=tmp_path, check=True)
+
+    with (
+        patch.object(cloud_projects.httpx, "request", side_effect=_create_response()),
+        patch.object(remote.httpx, "post", side_effect=_presign_post),
+        patch.object(remote.httpx, "put", return_value=_ok_put()),
+    ):
+        result = runner.invoke(app, ["link", "--cloud"])
+
+    assert result.exit_code == 0, result.output
+    assert expected in result.output
+    assert "repo-local Nauro project config" in result.output
 
 
 def test_link_cloud_with_no_repo_config_errors(tmp_path, monkeypatch):

--- a/packages/nauro/tests/test_propose_decision_parity.py
+++ b/packages/nauro/tests/test_propose_decision_parity.py
@@ -25,6 +25,9 @@ side-effects (snapshot, AGENTS.md regen, push) fire only on
 
 from __future__ import annotations
 
+import subprocess
+from pathlib import Path
+
 import pytest
 
 from nauro.constants import REPO_CONFIG_MODE_LOCAL
@@ -33,6 +36,7 @@ from nauro.mcp.stdio_server import propose_decision as stdio_propose_decision
 from nauro.mcp.tools import tool_propose_decision
 from nauro.store.registry import register_project_v2
 from nauro.store.repo_config import save_repo_config
+from nauro.templates.agents_md_regen import warn_then_regen
 from nauro.templates.scaffolds import scaffold_project_store
 from tests._writer_compat import append_decision
 
@@ -375,3 +379,22 @@ def test_regen_runs_only_on_confirmed(seeded_repo, monkeypatch):
     )
     assert second["status"] == "confirmed", second
     assert len(regen_called) == 1
+
+
+def test_confirmed_regen_surfaces_tracked_agents_warning(seeded_repo, monkeypatch):
+    _pid, store_path = seeded_repo
+    repo = Path.cwd()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    (repo / "AGENTS.md").write_text("stale\n", encoding="utf-8")
+    subprocess.run(["git", "add", "AGENTS.md"], cwd=repo, check=True)
+    monkeypatch.setattr(mcp_tools, "warn_then_regen", warn_then_regen)
+
+    envelope = tool_propose_decision(
+        store_path,
+        title="Refresh generated agent context",
+        rationale="Keep connected agents current after recording project decisions.",
+        confidence="high",
+    )
+
+    assert envelope["status"] == "confirmed"
+    assert "AGENTS.md is tracked by git" in envelope["assessment"]

--- a/packages/nauro/tests/test_setup_extended.py
+++ b/packages/nauro/tests/test_setup_extended.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import sys
 from pathlib import Path
 
@@ -25,6 +26,10 @@ else:
     import tomli as tomllib
 
 runner = CliRunner()
+
+
+def _git_init(repo: Path) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
 
 
 # ─── nauro setup cursor ─────────────────────────────────────────────────────
@@ -212,6 +217,55 @@ def test_setup_claude_code_subcommand_unchanged(tmp_path: Path, monkeypatch):
     result = runner.invoke(app, ["setup", "claude-code"])
     assert result.exit_code == 0, result.output
     assert "Configured Nauro" in result.output
+
+
+def test_setup_claude_code_warns_for_untracked_unignored_known_paths(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    _git_init(repo)
+    _, store_path = register_project_v2("myproj", [repo])
+    scaffold_project_store("myproj", store_path)
+    monkeypatch.chdir(repo)
+
+    result = runner.invoke(app, ["setup", "claude-code"])
+    assert result.exit_code == 0, result.output
+    assert ".mcp.json is untracked and not git-ignored" in result.output
+    assert "AGENTS.md is untracked and not git-ignored" in result.output
+    assert "easy to add by accident" in result.output
+
+
+def test_setup_claude_code_warns_for_tracked_known_path(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    _git_init(repo)
+    (repo / ".mcp.json").write_text("{}\n")
+    subprocess.run(["git", "add", ".mcp.json"], cwd=repo, check=True)
+    _, store_path = register_project_v2("myproj", [repo])
+    scaffold_project_store("myproj", store_path)
+    monkeypatch.chdir(repo)
+
+    result = runner.invoke(app, ["setup", "claude-code"])
+    assert result.exit_code == 0, result.output
+    assert ".mcp.json is tracked by git" in result.output
+    assert "local Nauro wiring" in result.output
+
+
+def test_setup_claude_code_suppresses_warning_for_ignored_known_paths(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    _git_init(repo)
+    (repo / ".gitignore").write_text(".mcp.json\nAGENTS.md\n")
+    _, store_path = register_project_v2("myproj", [repo])
+    scaffold_project_store("myproj", store_path)
+    monkeypatch.chdir(repo)
+
+    result = runner.invoke(app, ["setup", "claude-code"])
+    assert result.exit_code == 0, result.output
+    assert "untracked and not git-ignored" not in result.output
+    assert "is tracked by git" not in result.output
 
 
 def test_setup_top_level_help_lists_new_subcommands():


### PR DESCRIPTION
## Why

Public repositories need a write-time prompt when generated Nauro context, repo-local project config, or local tool wiring is tracked by git or easy to add by accident. The CLI should make that review explicit without blocking private setup flows or forbidding `.nauro/config.json`.

Connected agents need a consistent rule that public artifacts carry rationale instead of internal pointers. README readers also need accurate signals about project maturity and the measured size of the default context payload so they can judge readiness and context cost from public documentation.

## What changed

- Added a shared git hygiene helper for known Nauro-generated context and wiring paths.
- Emitted advisory warnings after init, adopt, attach, `link --cloud`, setup, and AGENTS refresh paths write those files.
- Surfaced the same `AGENTS.md` advisory through the existing local MCP assessment when a confirmed decision refreshes generated context.
- Kept ignored files, non-git directories, untouched files, and arbitrary user files silent.
- Updated bundled agent and PR guidance so public-facing prose paraphrases rationale instead of citing raw internal pointers.
- Added the same boundary to generated `AGENTS.md` guidance for every connected agent, and made reviewer checks reject public pointers before resolving internal references.
- Added README maturity and measured L0 context-size facts.

## Test plan

- `uv run ruff format .`
- `uv run ruff check .`
- Focused MCP, stdio, AGENTS, note, setup, and regeneration suites: 214 passed.
- `uv run pytest packages/nauro/tests`: 1,568 passed, 10 skipped.
- `git diff --check origin/main...HEAD`

## Deferred

- Publication-time scanning of public artifacts.
- Per-repo audience state for classifying public surfaces.
