### PR TITLE
Add a security policy (SECURITY.md)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+# Security Policy
+
+## Reporting
+
+Report vulnerabilities privately — not in a public issue:
+
+- [GitHub's private reporting form](https://github.com/Nauro-AI/nauro/security/advisories/new) (preferred)
+- email thomas@nauro.ai
+
+You'll get an acknowledgment within a week. Nauro is maintained by one
+person; confirmed issues in token handling or the hosted service are
+treated as drop-everything work.
+
+## Scope
+
+The `nauro` and `nauro-core` PyPI packages, this repository, and the
+hosted service (`mcp.nauro.ai` and the sync API). Nauro stores OAuth
+tokens in `~/.nauro/config.json` — anything exposing those tokens, or
+letting one user's cloud store be read or written by another, is high
+severity.
+
+**Out of scope:** `check_decision` being advisory rather than blocking
+(by design); your own store's content influencing your agent (it's
+your trusted input — cross-tenant injection via the hosted service is
+in scope); DoS against the hosted endpoint; scanner reports without a
+proof of concept.
+
+## Disclosure
+
+Fixes land on the latest 1.x release. Please allow reasonable time to
+ship a fix before publishing details. Good-faith research under this
+policy will never result in legal action; reporters are credited
+unless they prefer otherwise.


### PR DESCRIPTION
## Why

The repo had no vulnerability disclosure channel. Nauro stores OAuth tokens in `~/.nauro/config.json` and operates a hosted endpoint, exactly the profile where a researcher looks for a security policy and, finding none, either opens a public issue with the details in it or walks away. GitHub's private vulnerability reporting is already enabled on the repo; this file makes it discoverable and sets expectations.

## What changed

Added `SECURITY.md` at the repo root: private reporting channels (GitHub advisory form preferred, email fallback), scope covering the PyPI packages and the hosted service with token exposure and cross-tenant access called out as high severity, out-of-scope items for the two most likely non-issues (the advisory-by-design check, own-store content steering your own agent), and a coordinated-disclosure / safe-harbor statement.

## Test plan

Docs-only; no code paths affected. Verified the advisory-form URL resolves and that GitHub picks up root-level `SECURITY.md` for the repo's Security tab.