### PR TITLE
Shorten remote welcome so 0-project instructions survive truncation

### DIFF
--- a/packages/nauro-core/src/nauro_core/instructions.py
+++ b/packages/nauro-core/src/nauro_core/instructions.py
@@ -27,19 +27,17 @@ class ProjectRef(TypedDict):
 
 MAX_INLINE_PROJECTS = 3
 
+# Compressed hard: the 0-project composition must fit entirely under the
+# claude.ai initialize.instructions truncation point (2,023 chars). That
+# point minus the static block (1,811 chars today) and the two joining
+# newlines leaves ~210 chars for the per-user section at the current
+# static size — less if the static block grows toward its 1,891-char
+# ceiling — so this copy targets ≤195 to keep headroom.
 WELCOME_NO_PROJECT = (
-    "Welcome to Nauro. You have no projects yet.\n"
-    "\n"
-    "Next steps:\n"
-    "1. Run `nauro auth login` (required before any cloud operation).\n"
-    "2. Create a project:\n"
-    "   - `nauro init <name>` for a local-only project (no network).\n"
-    "   - `nauro init --cloud <name>` to create a server-minted cloud project.\n"
-    "3. Or, if a teammate already created a cloud project, run "
-    "`nauro attach <project_id>` to connect this machine to it.\n"
-    "\n"
-    "Once a project exists, tools auto-resolve to it — you do not need to "
-    "pass a project_id."
+    "`nauro auth login` before cloud ops. "
+    "`nauro init <name>` (local), `nauro init --cloud <name>`, or "
+    "`nauro attach <project_id>` (teammate's cloud project). "
+    "Tools then auto-resolve (no project_id)."
 )
 
 

--- a/packages/nauro-core/tests/test_constants.py
+++ b/packages/nauro-core/tests/test_constants.py
@@ -29,15 +29,17 @@ from nauro_core.protocol import (
     RESOLVES_OPEN_QUESTIONS,
 )
 
-# The static instruction block must stay under the claude.ai
-# initialize.instructions truncation point (~2,023 chars) with room for the
-# per-user project section the remote server prepends. Trimming the trailing
-# update-state and get-context-followup guidance — now carried on the
-# matching ToolSpec descriptions, which tools/list delivers intact — brought
-# the block back under the cliff. This is the post-trim ceiling: modest
-# headroom above the current length so future growth past the cliff forces a
-# conscious bump and a re-check that the composed remote payload still keeps
-# every section header under the truncation point.
+# The static block's ceiling exists to leave headroom under the claude.ai
+# initialize.instructions truncation point (~2,023 chars) for the per-user
+# project section the remote server prepends. The composed payload holds a
+# tiered contract, enforced by TestInstructionsSurviveTruncation in
+# test_mcp_tools.py: 0- and 1-project compositions survive in full;
+# realistic inline multi-project compositions keep every section header and
+# the whole per-user section before the cliff (static tail-body truncation
+# accepted); pathological max-name inline compositions guarantee only the
+# per-user section. Guidance relocated out of the static block lives on the
+# matching ToolSpec descriptions, which tools/list delivers intact past the
+# cliff — that durable home is what makes static-tail loss acceptable.
 MCP_INSTRUCTIONS_TRUNCATION_LIMIT = 2023
 MCP_INSTRUCTIONS_STATIC_MAX_CHARS = 1891
 

--- a/packages/nauro-core/tests/test_mcp_tools.py
+++ b/packages/nauro-core/tests/test_mcp_tools.py
@@ -286,6 +286,15 @@ THREE_PROJECTS = [
 ]
 ONE_PROJECT = [{"project_id": "01KQ6AZGNA0B3QBF67NBXP3S45", "name": "nauro"}]
 
+# Pathological but server-legal inputs: 100 characters is the server-side
+# project-name cap (no nauro-core constant exists for it), paired with full
+# 26-char ULIDs.
+MAX_NAME_PROJECTS = [
+    {"project_id": "01KQ6AZGNA0B3QBF67NBXP3S45", "name": "a" * 100},
+    {"project_id": "01KREWKMPDW2EVR66F9XXNERGB", "name": "b" * 100},
+    {"project_id": "01KRVJWEPXJHTC7ZZNHVAR0PV5", "name": "c" * 100},
+]
+
 SECTION_HEADERS = (
     "## When to check decisions",
     "## When to propose decisions",
@@ -294,13 +303,34 @@ SECTION_HEADERS = (
 
 
 class TestInstructionsSurviveTruncation:
-    """The real static block, composed with a per-user project section, must
-    keep every section header before the client-side truncation point so no
-    load-bearing guidance silently falls off the chat surface."""
+    """Tiered contract for what survives the claude.ai client's truncation
+    of the composed ``initialize.instructions`` payload.
 
-    @pytest.mark.parametrize("projects", [ONE_PROJECT, THREE_PROJECTS])
-    def test_every_section_header_before_truncation(self, projects):
+    The per-user section is the load-bearing payload: it carries the
+    project_id a multi-project caller must pass, and no other surface
+    delivers it. Static-block guidance has a durable home on the matching
+    ToolSpec descriptions, which tools/list delivers intact, so losing the
+    static tail is recoverable — losing the per-user section is not.
+
+    - Tier 1 (full survival): 0- and 1-project compositions fit entirely
+      under the cliff.
+    - Tier 2 (header + per-user survival): a realistic inline multi-project
+      composition keeps every static section header and the whole per-user
+      section before the cliff; static tail-body truncation is accepted.
+    - Tier 3 (per-user survival): a pathological max-name composition
+      guarantees only the per-user section; static headers may truncate.
+    """
+
+    @pytest.mark.parametrize("projects", [[], ONE_PROJECT], ids=["zero", "one"])
+    def test_tier1_full_composition_survives(self, projects):
         result = build_remote_instructions(MCP_INSTRUCTIONS_STATIC, projects)
+        assert len(result) <= INSTRUCTIONS_TRUNCATION_LIMIT, (
+            f"composed instructions are {len(result)} chars, past the "
+            f"{INSTRUCTIONS_TRUNCATION_LIMIT}-char truncation point"
+        )
+
+    def test_tier2_every_section_header_before_truncation(self):
+        result = build_remote_instructions(MCP_INSTRUCTIONS_STATIC, THREE_PROJECTS)
         for header in SECTION_HEADERS:
             offset = result.find(header)
             assert offset != -1, f"{header} missing from composed instructions"
@@ -308,6 +338,28 @@ class TestInstructionsSurviveTruncation:
                 f"{header} falls at offset {offset}, past the "
                 f"{INSTRUCTIONS_TRUNCATION_LIMIT}-char truncation point"
             )
+
+    def test_tier2_per_user_section_before_truncation(self):
+        """The entire per-user section (project list plus the explicit
+        project_id directive) must end before the cliff — the static block
+        may lose tail body here, but never the per-user payload."""
+        result = build_remote_instructions(MCP_INSTRUCTIONS_STATIC, THREE_PROJECTS)
+        static_offset = result.index(MCP_INSTRUCTIONS_STATIC)
+        assert static_offset < INSTRUCTIONS_TRUNCATION_LIMIT, (
+            f"static block starts at offset {static_offset}, past the "
+            f"{INSTRUCTIONS_TRUNCATION_LIMIT}-char truncation point"
+        )
+
+    def test_tier3_per_user_section_before_truncation_max_names(self):
+        """Accepted limit: with server-cap-length names, static section
+        headers may fall past the cliff — only the per-user section (project
+        list plus the explicit-project_id directive) is guaranteed."""
+        result = build_remote_instructions(MCP_INSTRUCTIONS_STATIC, MAX_NAME_PROJECTS)
+        static_offset = result.index(MCP_INSTRUCTIONS_STATIC)
+        assert static_offset < INSTRUCTIONS_TRUNCATION_LIMIT, (
+            f"static block starts at offset {static_offset}, past the "
+            f"{INSTRUCTIONS_TRUNCATION_LIMIT}-char truncation point"
+        )
 
 
 class TestTrimmedGuidanceCanonicalHome:


### PR DESCRIPTION
## Why

The claude.ai client truncates the MCP `initialize.instructions` field at roughly 2,023 characters. The zero-project welcome (486 chars) composed with the static instruction block (1,811 chars) ran to 2,299 chars, so brand-new users, who have the least recovery context, silently lost the tail of the static guidance before they had any project at all. Users with an existing project can recover trimmed guidance from other surfaces; first-run users cannot.

## What changed

- Compressed `WELCOME_NO_PROJECT` from 486 to 194 characters, bringing the 0-project composition to 2,007 chars, fully under the truncation point, while keeping all four onboarding elements: auth before cloud ops, local vs cloud init, attach by project_id, and tool auto-resolve. The comment above the copy derives the 195-char budget from the truncation point, the current static block size, and the two joining newlines.
- Restated the truncation tests as a three-tier survival contract:
  - Tier 1: 0- and 1-project compositions survive in full under the truncation point.
  - Tier 2: realistic inline multi-project compositions keep every static section header and the entire per-user section before the cliff.
  - Tier 3: pathological max-length-name compositions guarantee only the per-user section; static headers may fall past the cliff.
- Rewrote the stale comment above the static-block ceiling in `test_constants.py` to match the tiered contract.

No runtime truncation of project names is introduced; the contract is test-only.

## Test plan

- New Tier 1 zero-project assertion confirmed failing against the old welcome (2,299 > 2,023) and passing after the rewrite (2,007).
- `pytest packages/nauro-core/tests/`: 987 passed.
- `ruff check packages/` and `ruff format --check packages/`: clean.

## Risk / what to review

The compressed welcome is terse by design; check that the four onboarding elements still read unambiguously to a first-run agent. Multi-project compositions (2,072 chars for the realistic fixture) intentionally exceed the cliff; the contract accepts static-tail loss there because `tools/list` descriptions carry the trimmed guidance.
