### PR TITLE
Fix get_raw_file miss hint ordering and tool contract wording

### DIFF
--- a/packages/nauro-core/src/nauro_core/mcp_tools.py
+++ b/packages/nauro-core/src/nauro_core/mcp_tools.py
@@ -331,7 +331,14 @@ PROPOSE_DECISION: ToolSpec = {
             "title": {
                 "type": "string",
                 "default": "",
-                "description": "Short title for the decision.",
+                "description": (
+                    "Short title for the decision. Required non-empty for "
+                    "operation=add and operation=supersede: an empty title is "
+                    "structurally rejected. Omit (or leave empty) for "
+                    "operation=update, which appends rationale only and "
+                    "rejects a non-empty title; the target decision keeps its "
+                    "existing title."
+                ),
             },
             "rationale": {
                 "type": "string",
@@ -501,9 +508,9 @@ UPDATE_STATE: ToolSpec = {
     "title": "Update project state",
     "description": (
         "Update the project's current state with a progress delta and trigger "
-        "a snapshot. Before writing, checks for potential contradictions with "
-        "recent state entries and returns a warning if found (the update is "
-        "still applied).\n"
+        "a snapshot. Before writing, checks whether the delta appears to "
+        "repeat work already recorded in recent state entries and returns a "
+        "warning if found (the update is still applied).\n"
         "\n"
         "Use when you complete a meaningful unit of work — a feature, a "
         "refactor, a bug fix — so the next session starts with current context."

--- a/packages/nauro/src/nauro/mcp/tools.py
+++ b/packages/nauro/src/nauro/mcp/tools.py
@@ -20,7 +20,11 @@ from nauro_core.constants import (
     MAX_RATIONALE_LENGTH,
     MAX_TITLE_LENGTH,
     OPEN_QUESTIONS_MD,
+    PROJECT_MD,
+    SNAPSHOTS_DIR,
+    STACK_MD,
     STATE_CURRENT_FILENAME,
+    STATE_HISTORY_FILENAME,
     STATE_MD,
 )
 from nauro_core.operations import ErrorPayload, find_decision_stem_by_id
@@ -408,7 +412,9 @@ tool_propose_decision.__doc__ = f"""\
 Propose a new decision through the validation pipeline.
 
 Args:
-    title: Short title for the decision.
+    title: Short title for the decision. Required non-empty for add and
+        supersede; omit for update, which appends rationale only and
+        rejects a non-empty title.
     rationale: Why this decision is being made.
     operation: How this proposal relates to existing decisions.
 
@@ -481,7 +487,7 @@ def tool_flag_question(
         return {"store": "local", "status": "error", "guidance": guidance}
 
     if resolved_by is not None:
-        return _flag_question_resolve(store_path, targets, resolved_by)
+        return _flag_question_resolve(store_path, question, targets, resolved_by)
 
     # Content size limits
     for err in (
@@ -551,15 +557,18 @@ def tool_flag_question(
 
 def _flag_question_resolve(
     store_path: Path,
+    question: str | None,
     targets: list[str] | None,
     resolved_by: str,
 ) -> dict:
     """Resolve the ``targets`` entries against ``resolved_by``.
 
     Skips the BM25 similarity hint — resolving against a known decision is
-    not a duplicate-flag situation. On success this is a write, so capture
-    a snapshot (labelled to distinguish resolve from append) and push; on
-    rejection the kernel performed no write, so neither runs.
+    not a duplicate-flag situation. ``question`` is forwarded so the kernel's
+    pass-exactly-one rejection fires when the caller sent both. On success
+    this is a write, so capture a snapshot (labelled to distinguish resolve
+    from append) and push; on rejection the kernel performed no write, so
+    neither runs.
     """
     # The resolve action reads open-questions.md, stamps the targets, and
     # writes the file back — same read-modify-write race as the append path,
@@ -567,7 +576,7 @@ def _flag_question_resolve(
     with store_write_lock(store_path, OPEN_QUESTIONS_MD):
         result = _flag_question_op(
             FilesystemStore(store_path),
-            None,
+            question,
             None,
             targets=targets,
             resolved_by=resolved_by,
@@ -581,6 +590,53 @@ def _flag_question_resolve(
     capture_snapshot(store_path, trigger=f"resolved by {resolved_by}: {targets or []}")
     _try_push(store_path)
     return response
+
+
+# Composed adapter-locally rather than exported from nauro-core: the fixed
+# ordering is a hint-presentation concern of this surface, not a new public
+# store-format constant.
+_CANONICAL_ROOT_FILES: tuple[str, ...] = (
+    PROJECT_MD,
+    STATE_CURRENT_FILENAME,
+    STATE_HISTORY_FILENAME,
+    STACK_MD,
+    OPEN_QUESTIONS_MD,
+)
+
+
+def _available_files_hint(store_path: Path, cap: int = 20) -> list[str]:
+    """Ordered ``available_files`` entries for the ``get_raw_file`` miss envelope.
+
+    Canonical root files lead in a fixed order (when present), then remaining
+    root-level markdown files ascending by name, then one anchor per visible
+    subdirectory ascending by directory name: its lexicographically-last
+    markdown path (for a flat, zero-padded ``decisions/`` layout, the newest
+    decision) plus a ``<dir>/ (N files)`` roll-up when the directory holds
+    more than one file.
+    ``snapshots/`` and dot-directories are excluded. The cap applies after
+    ordering so root files are never crowded out by a large directory.
+    """
+    root_files: set[str] = set()
+    subdir_files: dict[str, list[str]] = {}
+    for f in store_path.rglob("*.md"):
+        rel = f.relative_to(store_path)
+        if any(part.startswith(".") for part in rel.parts):
+            continue
+        if rel.parts[0] == SNAPSHOTS_DIR:
+            continue
+        if len(rel.parts) == 1:
+            root_files.add(rel.name)
+        else:
+            subdir_files.setdefault(rel.parts[0], []).append(str(rel))
+
+    entries: list[str] = [name for name in _CANONICAL_ROOT_FILES if name in root_files]
+    entries.extend(sorted(root_files - set(_CANONICAL_ROOT_FILES)))
+    for dirname in sorted(subdir_files):
+        files = sorted(subdir_files[dirname])
+        entries.append(files[-1])
+        if len(files) > 1:
+            entries.append(f"{dirname}/ ({len(files)} files)")
+    return entries[:cap]
 
 
 @mcp_tool("get_raw_file")
@@ -613,12 +669,7 @@ def tool_get_raw_file(store_path: Path, path: str) -> dict:
     # Store protocol's locked surface. Cap at 20 entries so the miss
     # envelope stays bounded for stores with many markdown files.
     if result.error is not None:
-        available = []
-        for f in sorted(store_path.rglob("*.md")):
-            rel = f.relative_to(store_path)
-            if not str(rel).startswith("snapshots/"):
-                available.append(str(rel))
-        envelope["available_files"] = available[:20]
+        envelope["available_files"] = _available_files_hint(store_path)
 
     return envelope
 

--- a/packages/nauro/tests/test_flag_question_parity.py
+++ b/packages/nauro/tests/test_flag_question_parity.py
@@ -188,6 +188,34 @@ def test_resolve_unknown_decision_rejection_matches_across_tool_and_cli(seeded_r
     assert cli_envelope == tool_envelope
 
 
+def test_both_question_and_resolved_by_rejects_across_tool_and_stdio(seeded_repo):
+    pid, store_path = seeded_repo
+    _seed_resolvable(store_path, "Q1")
+    before = (store_path / "open-questions.md").read_text()
+    snapshots_dir = store_path / "snapshots"
+    snapshots_before = sorted(snapshots_dir.glob("*")) if snapshots_dir.exists() else []
+
+    tool_envelope = tool_flag_question(
+        store_path, question="Also new?", targets=["Q1"], resolved_by="D42"
+    )
+    assert tool_envelope["store"] == "local"
+    assert tool_envelope["status"] == "rejected"
+    assert "not both" in tool_envelope["error"]["reason"]
+
+    # The stdio surface renders the same kernel rejection reason.
+    stdio_string = stdio_flag_question(
+        question="Also new?", targets=["Q1"], resolved_by="D42", project_id=pid
+    )
+    assert stdio_string == tool_envelope["error"]["reason"]
+
+    # No write occurred: the file is untouched, the entry is not stamped, and
+    # no snapshot was captured.
+    assert (store_path / "open-questions.md").read_text() == before
+    assert "[Resolved by" not in before
+    snapshots_after = sorted(snapshots_dir.glob("*")) if snapshots_dir.exists() else []
+    assert snapshots_after == snapshots_before
+
+
 def test_neither_question_nor_resolved_by_rejects_across_tool_and_cli(seeded_repo):
     pid, store_path = seeded_repo
 

--- a/packages/nauro/tests/test_get_raw_file_miss_hint.py
+++ b/packages/nauro/tests/test_get_raw_file_miss_hint.py
@@ -1,0 +1,149 @@
+"""Ordering contract for the ``get_raw_file`` miss-path ``available_files`` hint.
+
+The envelope shape on a miss (``error`` + ``available_files`` siblings) is
+pinned in ``test_get_raw_file_parity``; this file pins the *content* contract
+of the hint list:
+
+1. Canonical root files lead, in a fixed order, only when present on disk.
+2. Other root-level markdown files follow, ascending by name.
+3. Each visible subdirectory contributes its lexicographically-last markdown
+   path (a concrete path ``get_raw_file`` can fetch; for a flat, zero-padded
+   ``decisions/`` layout, the newest decision) plus a ``<dir>/ (N files)``
+   roll-up when it holds more than one file, directories ascending by name.
+4. ``snapshots/`` and dot-directories are excluded.
+5. The 20-entry cap applies after ordering, so root files are never crowded
+   out by a large ``decisions/`` directory.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nauro.mcp.tools import tool_get_raw_file
+
+MISSING_PATH = "does-not-exist.md"
+
+CANONICAL_ROOTS = (
+    "project.md",
+    "state_current.md",
+    "state_history.md",
+    "stack.md",
+    "open-questions.md",
+)
+
+
+@pytest.fixture
+def crowded_store(tmp_path) -> Path:
+    """A store with all five canonical roots, a dot-directory, a context/
+    directory, a markdown file inside snapshots/, and more decisions than
+    the 20-entry cap."""
+    store = tmp_path / "store"
+    store.mkdir()
+    for name in CANONICAL_ROOTS:
+        (store / name).write_text(f"# {name}\n")
+
+    backup = store / ".conflict-backup"
+    backup.mkdir()
+    (backup / "state_current.md").write_text("backup\n")
+
+    context = store / "context"
+    context.mkdir()
+    (context / "alpha.md").write_text("alpha\n")
+    (context / "omega.md").write_text("omega\n")
+
+    snapshots = store / "snapshots"
+    snapshots.mkdir()
+    (snapshots / "stray.md").write_text("stray\n")
+
+    decisions = store / "decisions"
+    decisions.mkdir()
+    for num in range(1, 22):
+        (decisions / f"{num:03d}-decision-{num}.md").write_text(f"# Decision {num}\n")
+    return store
+
+
+def _available_files(store: Path) -> list[str]:
+    envelope = tool_get_raw_file(store, MISSING_PATH)
+    assert envelope["error"]["reason"] == f"File not found: {MISSING_PATH}"
+    return envelope["available_files"]
+
+
+def test_full_hint_ordering(crowded_store):
+    assert _available_files(crowded_store) == [
+        *CANONICAL_ROOTS,
+        "context/omega.md",
+        "context/ (2 files)",
+        "decisions/021-decision-21.md",
+        "decisions/ (21 files)",
+    ]
+
+
+def test_canonical_roots_lead_in_fixed_order(crowded_store):
+    available = _available_files(crowded_store)
+    # Fixed order, not lexicographic (which would put open-questions.md first).
+    assert tuple(available[: len(CANONICAL_ROOTS)]) == CANONICAL_ROOTS
+
+
+def test_missing_canonical_root_is_skipped(crowded_store):
+    (crowded_store / "stack.md").unlink()
+    available = _available_files(crowded_store)
+    assert "stack.md" not in available
+    assert available[:4] == [
+        "project.md",
+        "state_current.md",
+        "state_history.md",
+        "open-questions.md",
+    ]
+
+
+def test_other_root_files_follow_roots_ascending(crowded_store):
+    (crowded_store / "brief.md").write_text("brief\n")
+    (crowded_store / "archive.md").write_text("archive\n")
+    available = _available_files(crowded_store)
+    n = len(CANONICAL_ROOTS)
+    assert available[n : n + 2] == ["archive.md", "brief.md"]
+
+
+def test_dot_directories_and_snapshots_excluded(crowded_store):
+    available = _available_files(crowded_store)
+    assert not any(entry.startswith(".") for entry in available)
+    assert not any("conflict-backup" in entry for entry in available)
+    assert not any(entry.startswith("snapshots/") for entry in available)
+
+
+def test_single_file_subdirectory_gets_no_rollup(crowded_store):
+    notes = crowded_store / "notes"
+    notes.mkdir()
+    (notes / "only.md").write_text("only\n")
+    available = _available_files(crowded_store)
+    assert "notes/only.md" in available
+    assert not any(entry.startswith("notes/ (") for entry in available)
+
+
+def test_cap_honored_with_many_decisions(crowded_store):
+    # 21 decisions collapse to anchor + roll-up, so the whole listing fits.
+    available = _available_files(crowded_store)
+    assert len(available) <= 20
+    assert "decisions/021-decision-21.md" in available
+    assert "decisions/ (21 files)" in available
+
+
+def test_cap_applies_after_ordering_so_roots_survive(crowded_store):
+    for num in range(1, 19):
+        (crowded_store / f"note-{num:02d}.md").write_text("note\n")
+    available = _available_files(crowded_store)
+    assert len(available) == 20
+    # Canonical roots still lead; the cap truncates from the tail (here the
+    # trailing note files and all subdirectory entries).
+    assert tuple(available[: len(CANONICAL_ROOTS)]) == CANONICAL_ROOTS
+
+
+def test_every_path_entry_is_fetchable(crowded_store):
+    for entry in _available_files(crowded_store):
+        if entry.endswith(" files)"):
+            continue
+        envelope = tool_get_raw_file(crowded_store, entry)
+        assert "error" not in envelope, f"hint entry {entry!r} is not fetchable"
+        assert envelope["content"]


### PR DESCRIPTION
## Why

Three places where the tool surface told agents something the code did not do:

1. The `get_raw_file` miss hint listed every store markdown file in plain lexicographic order and cut at 20 entries. A store with more than 20 decisions crowded the canonical root files out of the hint entirely, and internal dot-directories such as the conflict-backup directory leaked into it.
2. `flag_question` silently dropped a `question` passed alongside `resolved_by`: the adapter hardcoded `question=None` on the resolve path, so the kernel's pass-exactly-one rejection could never fire and the caller got a resolve they may not have intended.
3. Two ToolSpec descriptions drifted from behavior: `propose_decision.title` read as unconditionally optional prose, and `update_state` claimed to detect "contradictions" when the check is a repeat-work keyword overlap.

## What changed

- **Miss-hint ordering contract** (`packages/nauro/src/nauro/mcp/tools.py`): new `_available_files_hint` helper. Canonical root files lead in a fixed order (project, state_current, state_history, stack, open-questions) when present, then other root-level markdown ascending by name, then per subdirectory (ascending) one concrete fetchable anchor (its lexicographically-last markdown path; for the flat, zero-padded `decisions/` layout that is the newest decision) plus a `<dir>/ (N files)` roll-up when N > 1. `snapshots/` and any dot-directory are excluded. The 20-entry cap applies after ordering, so roots can never be crowded out. Envelope field name and cap value unchanged.
- **flag_question both-passed** (same file): the resolve routing now forwards `question` into the kernel call, so passing both `question` and `resolved_by` returns the kernel's "not both" rejection through the existing rejected short-circuit: no write, no snapshot, no push. Lock structure unchanged.
- **Wording only** (`packages/nauro-core/src/nauro_core/mcp_tools.py`): `title` description now states the real contract (required non-empty for add/supersede, must be omitted or empty for update, which appends rationale only); `update_state` first paragraph describes the repeat-work warning instead of "contradictions". Schema structure (`default`, `required`) untouched, so the frozen public-contract snapshot did not change. The stale mirror line in `tool_propose_decision`'s docstring was updated to match.

## Test plan

- New `test_get_raw_file_miss_hint.py` (9 tests, written first): fixed root order, missing-root skip, other-root ordering, dot-dir and snapshots exclusion, single-file dirs get no roll-up, newest-decision anchor plus roll-up shape, cap honored with 21 decisions, cap-after-ordering keeps roots, every path-shaped entry is fetchable via `get_raw_file`.
- New both-passed parity test: tool adapter envelope and stdio string both carry the kernel's "not both" reason; `open-questions.md` byte-unchanged; no snapshot captured.
- Full suites: nauro 1578 passed / 10 skipped; nauro-core 987 passed. `ruff check` and `ruff format --check` clean. `test_public_contract.py` green without snapshot regeneration; the two anchored `update_state` guidance fragments still present.

## Risk / what to review

- The miss hint is agent-facing output on the local surface only; the shape (error + `available_files` siblings) is unchanged, but any downstream consumer assuming every entry is a real path would now see roll-up strings such as `decisions/ (21 files)`. The parity test pins that path entries remain fetchable.
- The flag_question change turns a previously silent drop into an explicit rejection. Callers who were (incorrectly) passing both fields will now see the rejection instead of a resolve.
