### PR TITLE
Include project.md in L0 as the stable-scope preamble

### DIFF
--- a/packages/nauro-core/src/nauro_core/constants.py
+++ b/packages/nauro-core/src/nauro_core/constants.py
@@ -110,6 +110,31 @@ POINTER_FLAG_PREFIXES: tuple[str, ...] = ("BRIEF:", "RESUME:", "SELECT:")
 # ── Stack empty marker ──
 STACK_EMPTY_MARKER = "# Stack\n<!-- Tech choices with rationale and rejected alternatives -->"
 
+# ── project.md scaffold body ──
+# The project.md scaffold text after the "# {project_name}" heading line.
+# Single source: nauro's templates/scaffolds.py composes its PROJECT_MD
+# template from this constant, and build_l0 uses it (via
+# parsing.is_scaffold_project_md) to skip unedited scaffold content when
+# rendering the L0 project-scope preamble.
+PROJECT_MD_SCAFFOLD_BODY = """\
+**One-liner:** [What this does in one sentence, e.g. \
+"A CLI tool that syncs project context to AI coding agents."]
+## Goals
+- [Primary goal — what success looks like in concrete terms, \
+e.g. "Reduce agent ramp-up from 5 min to under 30 seconds"]
+- [Secondary goal]
+## Non-goals
+- [Something explicitly out of scope, \
+e.g. "Not a project management tool — no task tracking"]
+## Users
+[Who uses this and how — be specific. \
+"Mobile-first consumers aged 18-35 discovering recipes" \
+is useful. "Users" is not.]
+## Constraints
+- [Hard limits: budget, timeline, regulatory, platform, e.g. "Must ship MVP by June 2026"]
+- [Technical constraints, e.g. "Must run offline — no cloud dependency in v1"]
+"""
+
 # ── Content size limits (H3 — STRIDE) ──
 MAX_TITLE_LENGTH = 300
 MAX_RATIONALE_LENGTH = 10_000

--- a/packages/nauro-core/src/nauro_core/context.py
+++ b/packages/nauro-core/src/nauro_core/context.py
@@ -2,9 +2,8 @@
 
 Accepts pre-loaded file contents (``dict[str, str]``) and parsed decision
 lists (``list[Decision]``) via function injection. Callers control which
-files to include, allowing surface-specific customization (e.g., local L0
-can omit project.md for AGENTS.md compatibility) without nauro-core needing
-to know about I/O.
+files to include, allowing surface-specific customization (e.g., only L2
+loads state_history.md) without nauro-core needing to know about I/O.
 """
 
 from datetime import datetime, timezone
@@ -26,6 +25,8 @@ from nauro_core.parsing import (
     decisions_summary_lines,
     extract_current_state,
     extract_stack_oneliner,
+    is_scaffold_project_md,
+    strip_leading_h1,
 )
 from nauro_core.questions import EntryBlock, OpenQuestionsFile
 from nauro_core.state import assemble_state_for_context
@@ -123,8 +124,13 @@ def _strip_leading_current_header(assembled: str) -> str:
 def build_l0(files: dict[str, str], decisions: list[Decision]) -> str:
     """Build L0 payload (concise summary).
 
-    Section order: project → state → stack summary → open questions (top 5) →
-    recent decisions summary (last 10 active).
+    Section order: project scope preamble → state → stack summary →
+    open questions (top 3) → recent decisions summary (last 10 active).
+
+    project.md leads the payload as a stable-scope preamble, with its leading
+    H1 stripped (the surrounding surface supplies the title heading). An
+    unedited ``nauro init`` scaffold is skipped entirely — placeholder
+    prompts are not project scope.
 
     Args:
         files: Dict of store-relative keys to file contents.
@@ -135,8 +141,10 @@ def build_l0(files: dict[str, str], decisions: list[Decision]) -> str:
     sections: list[str] = []
 
     project = files.get(PROJECT_MD, "")
-    if project.strip():
-        sections.append(project.strip())
+    if project.strip() and not is_scaffold_project_md(project):
+        body = strip_leading_h1(project)
+        if body:
+            sections.append(body)
 
     raw_state = _resolve_state(files)
     if raw_state:

--- a/packages/nauro-core/src/nauro_core/operations/get_context.py
+++ b/packages/nauro-core/src/nauro_core/operations/get_context.py
@@ -40,16 +40,16 @@ _BUILDERS = {
 def _load_context_files(store: Store, level: int) -> dict[str, str]:
     """Load the markdown files the context builders consume.
 
-    L0 deliberately omits ``project.md``: the AGENTS.md surface re-includes
-    that content and rendering it twice would push every L0 caller over its
-    token budget. L1/L2 carry it. Each builder ignores keys it does not
-    use, so the remaining files are loaded unconditionally.
+    ``project.md`` is loaded at every level: L0 carries it as a stable-scope
+    preamble (``build_l0`` skips content still in unedited scaffold form at
+    composition time), and L1/L2 carry it verbatim. Each builder ignores keys
+    it does not use, so files other than the state history are loaded
+    unconditionally.
     """
     files: dict[str, str] = {}
-    if level != 0:
-        project = store.read_file(PROJECT_MD)
-        if project is not None:
-            files[PROJECT_MD] = project
+    project = store.read_file(PROJECT_MD)
+    if project is not None:
+        files[PROJECT_MD] = project
 
     stack = store.read_file(STACK_MD)
     if stack is not None:

--- a/packages/nauro-core/src/nauro_core/parsing.py
+++ b/packages/nauro-core/src/nauro_core/parsing.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import re
 
-from nauro_core.constants import DECISIONS_DIR, STACK_EMPTY_MARKER
+from nauro_core.constants import DECISIONS_DIR, PROJECT_MD_SCAFFOLD_BODY, STACK_EMPTY_MARKER
 
 # Tokens that end in a period without ending the sentence. A terminator
 # closing one of these is treated as part of the abbreviation, not a sentence
@@ -232,6 +232,40 @@ def _stem_from_decision_path(path: str) -> str | None:
     if "/" in tail or not tail.endswith(".md"):
         return None
     return tail[: -len(".md")]
+
+
+def strip_leading_h1(content: str) -> str:
+    """Drop a leading ``# ...`` H1 line plus surrounding blank lines.
+
+    Mirrors ``context._strip_leading_current_header`` but for any H1: leading
+    blank lines are dropped, one H1 line is removed when present, and the
+    remainder is returned stripped. Content without a leading H1 passes
+    through (stripped) unchanged. Shared by ``is_scaffold_project_md`` and the
+    L0 project-scope preamble, which renders project.md under its own section
+    ordering and must not stutter the file's title heading.
+    """
+    # S3-synced bytes on the hosted path decode without the universal-newline
+    # translation local Path.read_text gets; normalizing here fixes both the
+    # scaffold-guard comparison and preamble rendering for CRLF files.
+    content = content.replace("\r\n", "\n")
+    lines = content.strip().split("\n")
+    if lines and lines[0].startswith("# "):
+        lines = lines[1:]
+        while lines and not lines[0].strip():
+            lines.pop(0)
+    return "\n".join(lines).strip()
+
+
+def is_scaffold_project_md(content: str) -> bool:
+    """Whether ``content`` is an unedited ``nauro init`` project.md scaffold.
+
+    The scaffold interpolates only the ``# {project_name}`` heading, so the
+    check strips a leading H1 and compares the remainder against
+    ``PROJECT_MD_SCAFFOLD_BODY`` exactly (trailing whitespace stripped on both
+    sides). Any edit to the body — even one character — means the user has
+    started filling in real scope and the content is no longer scaffold-form.
+    """
+    return strip_leading_h1(content) == PROJECT_MD_SCAFFOLD_BODY.strip()
 
 
 def extract_current_state(state_content: str) -> str:

--- a/packages/nauro-core/tests/operations/test_get_context.py
+++ b/packages/nauro-core/tests/operations/test_get_context.py
@@ -80,11 +80,11 @@ def test_l2_on_empty_store_returns_empty_string() -> None:
     assert result.content == ""
 
 
-def test_l0_omits_project_md() -> None:
-    """L0 deliberately drops project.md — AGENTS.md re-includes it."""
+def test_l0_includes_project_md() -> None:
+    """L0 carries the project.md body as its stable-scope preamble."""
     result = get_context(_seeded_store(), 0)
     assert result.content is not None
-    assert "Goal: build the thing." not in result.content
+    assert "Goal: build the thing." in result.content
     # L0 still renders state, stack, and decisions.
     assert "Current State" in result.content
     assert "Python 3.11" in result.content

--- a/packages/nauro-core/tests/test_context.py
+++ b/packages/nauro-core/tests/test_context.py
@@ -3,6 +3,7 @@
 from datetime import date as _date
 from datetime import datetime, timedelta, timezone
 
+from nauro_core.constants import PROJECT_MD_SCAFFOLD_BODY
 from nauro_core.context import build_l0, build_l1, build_l2
 from nauro_core.decision_model import (
     Decision,
@@ -65,7 +66,9 @@ DECISIONS = [
 class TestBuildL0:
     def test_full_files(self):
         result = build_l0(FULL_FILES, DECISIONS)
-        assert "# MyProject" in result
+        # The project body leads the payload; its H1 is stripped.
+        assert "Goal: build something great." in result
+        assert "# MyProject" not in result
         assert "## Current State" in result
         assert "Shipping v1" in result
         assert "**Stack:** Python 3.11+" in result
@@ -114,7 +117,8 @@ class TestBuildL0:
     def test_empty_decisions(self):
         result = build_l0(FULL_FILES, [])
         assert "## Recent Decisions" not in result
-        assert "# MyProject" in result
+        assert "Goal: build something great." in result
+        assert "# MyProject" not in result
 
     def test_empty_files(self):
         result = build_l0({}, [])
@@ -147,6 +151,64 @@ class TestBuildL0:
         result = build_l0(files, [])
         assert "New format wins" in result
         assert "Shipping v1" not in result
+
+
+class TestBuildL0ProjectPreamble:
+    """L0 leads with the project.md body as a stable-scope preamble.
+
+    The leading H1 is stripped (the consuming surface supplies the title
+    heading), and content still in unedited ``nauro init`` scaffold form is
+    skipped entirely. L1/L2 are untouched: they carry project.md verbatim.
+    """
+
+    SCAFFOLD = "# my-proj\n" + PROJECT_MD_SCAFFOLD_BODY
+
+    def test_project_body_is_first_section(self):
+        result = build_l0(FULL_FILES, DECISIONS)
+        assert result.startswith("Goal: build something great.")
+        assert result.index("Goal: build something great.") < result.index("## Current State")
+
+    def test_scaffold_form_project_md_skipped(self):
+        files = {**FULL_FILES, "project.md": self.SCAFFOLD}
+        result = build_l0(files, DECISIONS)
+        assert "**One-liner:**" not in result
+        assert "my-proj" not in result
+        assert result.startswith("## Current State")
+
+    def test_h1_strip_handles_leading_blank_lines(self):
+        files = {"project.md": "\n\n# MyProject\n\nGoal: something.\n"}
+        result = build_l0(files, [])
+        assert result == "Goal: something."
+
+    def test_crlf_project_md_renders_preamble_without_carriage_returns(self):
+        files = {"project.md": "# MyProject\r\n\r\nGoal: something.\r\n## Goals\r\n- ship it\r\n"}
+        result = build_l0(files, [])
+        assert "\r" not in result
+        assert result.startswith("Goal: something.")
+        assert "## Goals" in result
+
+    def test_no_h1_file_passes_through(self):
+        files = {"project.md": "Goal without heading.\n## Goals\n- ship it\n"}
+        result = build_l0(files, [])
+        assert result.startswith("Goal without heading.")
+        assert "## Goals" in result
+
+    def test_h1_only_project_md_renders_nothing(self):
+        files = {"project.md": "# MyProject\n"}
+        result = build_l0(files, [])
+        assert result == ""
+
+    def test_l1_includes_scaffold_form_project_md_verbatim(self):
+        files = {**FULL_FILES, "project.md": self.SCAFFOLD}
+        result = build_l1(files, DECISIONS)
+        assert "# my-proj" in result
+        assert "**One-liner:**" in result
+
+    def test_l2_includes_scaffold_form_project_md_verbatim(self):
+        files = {**FULL_FILES, "project.md": self.SCAFFOLD}
+        result = build_l2(files, DECISIONS)
+        assert "# my-proj" in result
+        assert "**One-liner:**" in result
 
 
 class TestBuildL1:

--- a/packages/nauro-core/tests/test_parsing.py
+++ b/packages/nauro-core/tests/test_parsing.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from nauro_core.constants import DECISIONS_DIR
+from nauro_core.constants import DECISIONS_DIR, PROJECT_MD_SCAFFOLD_BODY
 from nauro_core.parsing import (
     _canonical_decision_id,
     _cap_to_first_unit,
@@ -15,7 +15,9 @@ from nauro_core.parsing import (
     _stem_from_decision_path,
     extract_decision_number,
     first_sentence_end,
+    is_scaffold_project_md,
     scan_decision_references,
+    strip_leading_h1,
 )
 
 
@@ -55,6 +57,46 @@ class TestExtractDecisionNumber:
 
     def test_decision_without_number_returns_none(self):
         assert extract_decision_number("decision-") is None
+
+
+class TestStripLeadingH1:
+    def test_strips_h1_and_following_blank_lines(self):
+        assert strip_leading_h1("# Title\n\n\nBody line.\n") == "Body line."
+
+    def test_leading_blank_lines_before_h1(self):
+        assert strip_leading_h1("\n\n# Title\n\nBody line.\n") == "Body line."
+
+    def test_no_h1_passes_through_stripped(self):
+        assert strip_leading_h1("Body only.\n\nMore body.\n") == "Body only.\n\nMore body."
+
+    def test_h2_is_not_stripped(self):
+        assert strip_leading_h1("## Section\nBody.") == "## Section\nBody."
+
+    def test_empty_string(self):
+        assert strip_leading_h1("") == ""
+
+
+class TestIsScaffoldProjectMd:
+    def _render(self, project_name: str) -> str:
+        return f"# {project_name}\n" + PROJECT_MD_SCAFFOLD_BODY
+
+    def test_rendered_scaffold_is_scaffold(self):
+        for name in ("x", "my-project", "A Project With Spaces"):
+            assert is_scaffold_project_md(self._render(name)) is True
+
+    def test_crlf_rendered_scaffold_is_scaffold(self):
+        assert is_scaffold_project_md(self._render("x").replace("\n", "\r\n")) is True
+
+    def test_one_character_edit_is_not_scaffold(self):
+        edited = self._render("x").replace("[Secondary goal]", "[Secondary goal!]")
+        assert edited != self._render("x")
+        assert is_scaffold_project_md(edited) is False
+
+    def test_filled_project_md_is_not_scaffold(self):
+        assert is_scaffold_project_md("# proj\n**One-liner:** Ships things.\n") is False
+
+    def test_empty_string_is_not_scaffold(self):
+        assert is_scaffold_project_md("") is False
 
 
 class TestFirstSentenceEnd:

--- a/packages/nauro/src/nauro/constants.py
+++ b/packages/nauro/src/nauro/constants.py
@@ -63,6 +63,11 @@ SKILLS_SECTION_HEADER = "## Skills"
 # ── Validation thresholds (CLI-specific) ──
 STALE_SYNC_DAYS = 7
 L0_TOKEN_LIMIT = 3500
+# project.md leads every L0 payload as the stable-scope preamble, so its size
+# lands on every session start across every surface. 2,000 estimated tokens
+# (8 KB at CHARS_PER_TOKEN = 4) is several times a healthy scope file; beyond
+# that the detail belongs in stack.md or decisions.
+PROJECT_MD_TOKEN_WARN = 2_000
 
 # ── flag_question similar-decision hint ──
 # Compared against a raw BM25 score (not a normalized 0-1 similarity); above

--- a/packages/nauro/src/nauro/mcp/payloads.py
+++ b/packages/nauro/src/nauro/mcp/payloads.py
@@ -25,7 +25,7 @@ def _context_text(store_path: Path, level: int) -> str:
 
 
 def build_l0_payload(store_path: Path) -> str:
-    """Build L0 payload (~2,000-4,000 tokens)."""
+    """Build L0 payload (concise summary)."""
     return _context_text(store_path, 0)
 
 

--- a/packages/nauro/src/nauro/store/validator.py
+++ b/packages/nauro/src/nauro/store/validator.py
@@ -11,6 +11,8 @@ from nauro.constants import (
     CHARS_PER_TOKEN,
     DECISIONS_DIR,
     L0_TOKEN_LIMIT,
+    PROJECT_MD,
+    PROJECT_MD_TOKEN_WARN,
     STALE_SYNC_DAYS,
     STATE_CURRENT_FILENAME,
     STATE_LEGACY_FILENAME,
@@ -28,6 +30,7 @@ def validate_store(store_path: Path) -> list[str]:
     - Unfilled bracket prompts remaining in project.md, state.md, stack.md
     - state.md "Last synced" older than 7 days
     - L0 token count exceeds 3,500
+    - project.md token count exceeds the L0-preamble warning threshold
     - Decision numbering is sequential with no gaps
 
     Args:
@@ -109,6 +112,16 @@ def validate_store(store_path: Path) -> list[str]:
         warnings.append(
             f"L0 token count ~{token_estimate} exceeds {L0_TOKEN_LIMIT:,} — consider trimming"
         )
+
+    # Check project.md size — it leads every L0 payload as the scope preamble.
+    project_path = store_path / PROJECT_MD
+    if project_path.exists():
+        project_estimate = len(read_text_lenient(project_path)) // CHARS_PER_TOKEN
+        if project_estimate > PROJECT_MD_TOKEN_WARN:
+            warnings.append(
+                f"{PROJECT_MD}: ~{project_estimate} estimated tokens exceeds "
+                f"{PROJECT_MD_TOKEN_WARN:,} — move detail to stack.md or decisions"
+            )
 
     # Check decision numbering is sequential with no gaps
     decisions_dir = store_path / DECISIONS_DIR

--- a/packages/nauro/src/nauro/templates/scaffolds.py
+++ b/packages/nauro/src/nauro/templates/scaffolds.py
@@ -15,6 +15,7 @@ in nauro-core.
 from datetime import datetime, timezone
 from pathlib import Path
 
+from nauro_core.constants import PROJECT_MD_SCAFFOLD_BODY
 from nauro_core.decision_model import (
     Decision,
     DecisionConfidence,
@@ -25,25 +26,10 @@ from nauro_core.decision_model import (
 
 from nauro import constants as C  # noqa: N812
 
-PROJECT_MD = """\
-# {project_name}
-**One-liner:** [What this does in one sentence, e.g. \
-"A CLI tool that syncs project context to AI coding agents."]
-## Goals
-- [Primary goal — what success looks like in concrete terms, \
-e.g. "Reduce agent ramp-up from 5 min to under 30 seconds"]
-- [Secondary goal]
-## Non-goals
-- [Something explicitly out of scope, \
-e.g. "Not a project management tool — no task tracking"]
-## Users
-[Who uses this and how — be specific. \
-"Mobile-first consumers aged 18-35 discovering recipes" \
-is useful. "Users" is not.]
-## Constraints
-- [Hard limits: budget, timeline, regulatory, platform, e.g. "Must ship MVP by June 2026"]
-- [Technical constraints, e.g. "Must run offline — no cloud dependency in v1"]
-"""
+# Composed from the shared body constant so this template and the kernel's
+# scaffold-form guard (nauro_core.parsing.is_scaffold_project_md, which lets
+# build_l0 skip unedited scaffolds) can never drift apart.
+PROJECT_MD = "# {project_name}\n" + PROJECT_MD_SCAFFOLD_BODY
 
 STATE_CURRENT_MD = """\
 # Current State

--- a/packages/nauro/tests/test_agents_md.py
+++ b/packages/nauro/tests/test_agents_md.py
@@ -214,6 +214,53 @@ def test_sync_writes_agents_md(tmp_path: Path, monkeypatch):
     assert "# Manual" in content
 
 
+def test_sync_agents_md_carries_project_scope_without_h1_stutter(tmp_path: Path, monkeypatch):
+    """A filled project.md body reaches AGENTS.md under "## Project: {name}".
+
+    The file's own H1 is stripped by the L0 builder, so the payload must not
+    stutter a "# myproj" heading directly under the section header.
+    """
+    from nauro.store.registry import register_project
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    store = register_project("myproj", [repo])
+    scaffold_project_store("myproj", store)
+    (store / "project.md").write_text(
+        "# myproj\n\n**One-liner:** Ships the thing.\n## Goals\n- Ship v1\n"
+    )
+    monkeypatch.chdir(repo)
+
+    result = runner.invoke(app, ["sync"])
+    assert result.exit_code == 0
+
+    content = (repo / "AGENTS.md").read_text()
+    assert "## Project: myproj" in content
+    assert "**One-liner:** Ships the thing." in content
+    assert content.index("## Project: myproj") < content.index("**One-liner:** Ships the thing.")
+    assert "\n# myproj" not in content
+
+
+def test_sync_agents_md_omits_scaffold_project_placeholders(tmp_path: Path, monkeypatch):
+    """A freshly scaffolded store must not leak project.md placeholder prompts."""
+    from nauro.store.registry import register_project
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    store = register_project("myproj", [repo])
+    scaffold_project_store("myproj", store)
+    monkeypatch.chdir(repo)
+
+    result = runner.invoke(app, ["sync"])
+    assert result.exit_code == 0
+
+    content = (repo / "AGENTS.md").read_text()
+    assert "**One-liner:** [What this does" not in content
+    assert "[Primary goal" not in content
+    assert "[Who uses this and how" not in content
+    assert "[Hard limits" not in content
+
+
 def test_sync_multi_repo(tmp_path: Path, monkeypatch):
     from nauro.store.registry import register_project
 

--- a/packages/nauro/tests/test_get_context_parity.py
+++ b/packages/nauro/tests/test_get_context_parity.py
@@ -172,11 +172,14 @@ def test_missing_store_guidance_matches_across_surfaces(missing_store):
 # transport-decoration regression (Last-synced trailer, snapshot diff,
 # NO_CONTEXT_YET sentinel) or a kernel content change.
 #
-# Deviates from that capture in one intended way: the redundant "# Current
+# Deviates from that capture in two intended ways: the redundant "# Current
 # State" sub-header (the file's own header, doubled under L0's "## Current
-# State" section header) is now stripped.
+# State" section header) is now stripped, and the project.md body (leading
+# H1 stripped) now opens the payload as the stable-scope preamble.
 
-_BASELINE_L0 = """## Current State
+_BASELINE_L0 = """Goal: ship Nauro CLI v1 with strong opinions.
+
+## Current State
 **Sprint:** ship beta
 **Blocker:** none
 

--- a/packages/nauro/tests/test_scaffolds.py
+++ b/packages/nauro/tests/test_scaffolds.py
@@ -2,7 +2,14 @@
 
 from pathlib import Path
 
-from nauro.templates.scaffolds import STATE_CURRENT_MD, scaffold_project_store
+from nauro_core.parsing import is_scaffold_project_md
+
+from nauro.templates.scaffolds import (
+    PROJECT_MD,
+    STATE_CURRENT_MD,
+    render_scaffold,
+    scaffold_project_store,
+)
 
 
 def test_state_scaffold_does_not_advertise_cli_update_state():
@@ -25,3 +32,14 @@ def test_scaffold_project_store_writes_clean_state_placeholder(tmp_path: Path):
     state = (tmp_path / "state_current.md").read_text()
     assert "update_state" not in state
     assert "No state recorded yet" in state
+
+
+def test_rendered_project_scaffold_matches_kernel_guard():
+    """The rendered project.md scaffold is recognized by the kernel's guard.
+
+    Cross-package drift pin: the template here and the scaffold-form check in
+    nauro-core (which lets build_l0 skip unedited scaffolds) must compose from
+    the same body constant. If either side drifts, freshly scaffolded stores
+    start leaking placeholder prompts into every L0 payload.
+    """
+    assert is_scaffold_project_md(render_scaffold(PROJECT_MD, project_name="x"))

--- a/packages/nauro/tests/test_store.py
+++ b/packages/nauro/tests/test_store.py
@@ -721,6 +721,46 @@ def test_validate_no_warnings_clean_store(tmp_path: Path):
     assert len(warnings) == 0
 
 
+def _clean_store_with_project_md(tmp_path: Path, project_md: str) -> Path:
+    """Build a warning-free store whose project.md is the given content."""
+    store = tmp_path / "projects" / "sized"
+    store.mkdir(parents=True)
+    (store / "decisions").mkdir()
+    (store / "snapshots").mkdir()
+    (store / "project.md").write_text(project_md)
+    (store / "state.md").write_text("# State\n\n## Current\nShipping v1\n\n## History\n")
+    (store / "stack.md").write_text("# Stack\n- Python 3.11\n")
+    (store / "open-questions.md").write_text("# Open Questions\n")
+    _minimal_v2_decision(store / "decisions" / "001-init.md", num=1, title="Init")
+    return store
+
+
+def test_validate_project_md_over_token_threshold_warns(tmp_path: Path):
+    from nauro.constants import CHARS_PER_TOKEN, PROJECT_MD_TOKEN_WARN
+
+    # One char over the threshold in estimated tokens.
+    oversized = "# Big\n" + "x" * (PROJECT_MD_TOKEN_WARN * CHARS_PER_TOKEN)
+    store = _clean_store_with_project_md(tmp_path, oversized)
+
+    warnings = validate_store(store)
+    size_warnings = [w for w in warnings if "estimated tokens" in w]
+    assert len(size_warnings) == 1
+    assert size_warnings[0].startswith("project.md:")
+    assert f"{PROJECT_MD_TOKEN_WARN:,}" in size_warnings[0]
+    assert "stack.md" in size_warnings[0]
+
+
+def test_validate_project_md_at_token_threshold_is_silent(tmp_path: Path):
+    from nauro.constants import CHARS_PER_TOKEN, PROJECT_MD_TOKEN_WARN
+
+    # Exactly at the threshold: the warning fires only above it.
+    at_threshold = "x" * (PROJECT_MD_TOKEN_WARN * CHARS_PER_TOKEN)
+    store = _clean_store_with_project_md(tmp_path, at_threshold)
+
+    warnings = validate_store(store)
+    assert [w for w in warnings if "estimated tokens" in w] == []
+
+
 def _minimal_v2_decision(path: Path, num: int, title: str) -> None:
     """Write a minimal valid v2 decision file for tests that just need one file."""
     path.write_text(


### PR DESCRIPTION
## Why

The L0 context payload was assembled without project.md, on the recorded premise that the AGENTS.md surface re-includes that content. No surface actually did: AGENTS.md embeds the L0 payload itself, so goals, non-goals, users, and constraints (the store's stable scope) never reached session starts on any surface. On the flagship store that missing scope measures 277 tokens (o200k) against the token budget the omission was meant to protect.

## What changed

- The context loader now reads project.md at every level. `build_l0` renders its body as the first section, with the leading H1 stripped so the payload does not stutter a title under the surface's own heading. The strip helper normalizes CRLF line endings first, so hosted-path reads that bypass the universal-newline translation local reads get behave identically.
- Unedited `nauro init` scaffolds are skipped at composition time: the scaffold body now lives as a single constant in nauro-core, the `nauro init` template composes from it (rendered output verified byte-identical), and a new `is_scaffold_project_md` guard keeps placeholder prompts out of L0. A cross-package test pins the template and the guard to the same source.
- L1/L2 are untouched: verbatim project.md, no guard, no strip.
- Since project.md now lands on every session start, `nauro validate` warns (never errors) when it exceeds 2,000 estimated tokens and points detail at stack.md or decisions.
- Stale docs corrected: the loader comment carrying the false re-inclusion premise, the L0 builder's section order and question count, and the payload builder's token range.

## Test plan

- nauro-core: 1005 passed; nauro: 1583 passed, 10 skipped; ruff check and format clean.
- Public-contract snapshot passes without regeneration (the new constant is deliberately off the frozen facade).
- L0 parity baseline updated to lead with the project preamble; scaffold render hashed before and after the template recomposition (identical).
- New coverage: preamble ordering, scaffold skip, H1 strip edge cases (leading blanks, no H1, H1-only file, CRLF content), L1/L2 verbatim behavior, AGENTS.md scope inclusion without heading stutter, scaffold placeholder exclusion, validator threshold above/at boundary.

## Risk / what to review

- L0 grows by the project.md body: about 31 percent on the flagship store. The validator warning is the guardrail; there is no hard cap by design.
- The scaffold-form check is exact-match after H1 stripping, so any edit to the scaffold body constant is a behavior change for both `nauro init` output and L0 skipping; the drift-pin test makes that loud.
- The remote MCP surface consumes the same kernel and regains project scope at its next dependency bump; no action needed in this repo.
