### PR TITLE
Reject nameless rejected-alternative items at Tier 1

### DIFF
--- a/packages/nauro-core/src/nauro_core/mcp_tools.py
+++ b/packages/nauro-core/src/nauro_core/mcp_tools.py
@@ -377,7 +377,12 @@ PROPOSE_DECISION: ToolSpec = {
                         "reason": {"type": "string"},
                     },
                 },
-                "description": "Alternatives considered and rejected, each with reason.",
+                "description": (
+                    "Alternatives considered and rejected. Each item must "
+                    "carry a non-empty 'alternative' key (legacy alias: "
+                    "'name') plus a 'reason'; items without one are rejected "
+                    "at the boundary."
+                ),
             },
             "confidence": {
                 "type": "string",

--- a/packages/nauro-core/src/nauro_core/operations/propose_decision.py
+++ b/packages/nauro-core/src/nauro_core/operations/propose_decision.py
@@ -71,6 +71,7 @@ from nauro_core.search import Bm25Hit
 from nauro_core.validation import (
     check_bm25_similarity,
     compute_hash,
+    rejected_item_label,
     screen_structural,
 )
 
@@ -721,9 +722,17 @@ def _coerce_rejected(rejected) -> list[RejectedAlternative]:
         if isinstance(item, RejectedAlternative):
             out.append(item)
         elif isinstance(item, dict):
-            name = item.get("alternative") or item.get("name") or "Unknown"
+            # Tier 1 already rejects nameless items on the validated path;
+            # raising here is fail-loud insurance for bypass callers rather
+            # than silently defaulting the heading.
+            name = rejected_item_label(item)
+            if name is None:
+                raise ValueError(
+                    "rejected item has no label: expected a non-empty "
+                    f"'alternative' (or 'name') key; got keys {list(item.keys())}."
+                )
             reason = item.get("reason")
-            out.append(RejectedAlternative(name=str(name), reason=reason or None))
+            out.append(RejectedAlternative(name=name, reason=reason or None))
         elif isinstance(item, str):
             out.append(RejectedAlternative(name=item, reason=None))
     return out

--- a/packages/nauro-core/src/nauro_core/validation.py
+++ b/packages/nauro-core/src/nauro_core/validation.py
@@ -124,6 +124,25 @@ def _normalize_title(title: str) -> str:
     return " ".join(title.lower().split())
 
 
+def rejected_item_label(item: dict) -> str | None:
+    """Extract the label from a dict-form rejected-alternative item.
+
+    The label is the first value under ``alternative`` then the legacy
+    ``name`` alias that is non-empty after stripping; an empty
+    ``alternative`` falls through to ``name``. Returns the stripped label,
+    or None when neither key carries one. Shared by the Tier 1 screen and
+    the write-path coercer so both agree on what counts as labeled.
+    """
+    for key in ("alternative", "name"):
+        value = item.get(key)
+        if value is None:
+            continue
+        label = str(value).strip()
+        if label:
+            return label
+    return None
+
+
 def screen_structural(
     proposal: dict,
     existing_hashes: set[str],
@@ -132,8 +151,9 @@ def screen_structural(
     """Run structural screening on a proposal. No I/O.
 
     Checks: schema validation (title, rationale, confidence), minimum rationale
-    length, hash dedup against existing_hashes, and title dedup against
-    active_decisions (same title as a decision still in force).
+    length, rejected-alternative labels (each dict item must carry a non-empty
+    'alternative' or 'name'), hash dedup against existing_hashes, and title
+    dedup against active_decisions (same title as a decision still in force).
 
     This function is operation-agnostic: it dedups the proposal title against
     whatever list the caller hands it. The caller decides which decisions are
@@ -165,6 +185,17 @@ def screen_structural(
             "reject",
             f"Rationale too short ({len(rationale)} chars). Minimum {MIN_RATIONALE_LENGTH}.",
         )
+
+    # Dict-form rejected items must carry a label; a nameless item used to
+    # silently default its heading to "Unknown" on the write path. The
+    # message echoes key names only — never the item's values.
+    for idx, item in enumerate(proposal.get("rejected") or ()):
+        if isinstance(item, dict) and rejected_item_label(item) is None:
+            return (
+                "reject",
+                f"rejected[{idx}] has no label: expected a non-empty "
+                f"'alternative' (or 'name') key; got keys {list(item.keys())}.",
+            )
 
     # Hash dedup
     content_hash = compute_hash(title, rationale)

--- a/packages/nauro-core/tests/operations/test_operations_propose_decision.py
+++ b/packages/nauro-core/tests/operations/test_operations_propose_decision.py
@@ -605,6 +605,69 @@ def test_add_short_rationale_rejected_at_tier_1() -> None:
     assert result.tier == 1
 
 
+def test_add_rejected_item_without_label_rejected_at_tier_1() -> None:
+    """A dict-form rejected item with no 'alternative'/'name' label rejects
+    at Tier 1 instead of silently defaulting the heading, and nothing is
+    written to the store."""
+    store = InMemoryStore()
+    result = propose_decision(
+        store,
+        title="Adopt Redis for hot caching",
+        rationale="In-memory cache for the hot read paths across the API tier.",
+        confidence="medium",
+        rejected=[{"title": "Memcached", "reason": "No native persistence."}],
+    )
+    assert result.status == "rejected"
+    assert result.tier == 1
+    assert result.operation == "reject"
+    assert "rejected[0] has no label" in result.assessment
+    assert "'alternative'" in result.assessment
+    assert store.list_decisions() == []
+
+
+def test_add_valid_rejected_writes_labeled_headings() -> None:
+    store = InMemoryStore()
+    result = propose_decision(
+        store,
+        title="Adopt Redis for hot caching",
+        rationale="In-memory cache for the hot read paths across the API tier.",
+        confidence="medium",
+        rejected=[{"alternative": "Memcached", "reason": "No native persistence."}],
+    )
+    assert result.status == "confirmed"
+    body = store.read_decision(result.decision_id)
+    assert body is not None
+    assert "## Rejected Alternatives" in body
+    assert "### Memcached" in body
+
+
+def test_supersede_rejected_item_without_label_rejects_before_write() -> None:
+    store = _store_with(
+        _seed_decision(
+            1,
+            "Adopt PostgreSQL primary database",
+            "Mature ecosystem with strong JSON support and excellent tooling.",
+        ),
+    )
+    result = propose_decision(
+        store,
+        title="Switch to managed PostgreSQL provider",
+        rationale="Reduces operational burden; the self-hosting rationale no longer applies.",
+        confidence="medium",
+        operation="supersede",
+        affected_decision_id="decision-001",
+        rejected=[{"reason": "No label on this one."}],
+    )
+    assert result.status == "rejected"
+    assert result.tier == 1
+    assert "rejected[0] has no label" in result.assessment
+    # No new decision written; the supersede target is untouched.
+    assert store.list_decisions() == ["001-adopt-postgresql-primary-database"]
+    old_body = store.read_decision("001-adopt-postgresql-primary-database")
+    assert old_body is not None
+    assert "status: active" in old_body
+
+
 # ── resolves_questions ──────────────────────────────────────────────────
 
 

--- a/packages/nauro-core/tests/test_validation.py
+++ b/packages/nauro-core/tests/test_validation.py
@@ -8,6 +8,7 @@ from nauro_core.decision_model import (
     Decision,
     DecisionConfidence,
     DecisionStatus,
+    RejectedAlternative,
 )
 from nauro_core.validation import (
     check_bm25_similarity,
@@ -244,6 +245,87 @@ class TestScreenStructural:
         action, reason = screen_structural(self._proposal(rationale=None), set(), [])
         assert action == "reject"
         assert "Rationale is empty" in reason
+
+
+class TestScreenStructuralRejectedLabels:
+    def _proposal(self, **overrides):
+        base = {
+            "title": "Use FastAPI for MCP server",
+            "rationale": "FastAPI provides async support and type safety for the server.",
+            "confidence": "high",
+        }
+        base.update(overrides)
+        return base
+
+    def test_item_without_label_key_rejects_and_echoes_keys(self):
+        proposal = self._proposal(rejected=[{"title": "Flask", "reason": "Sync-only workers."}])
+        action, reason = screen_structural(proposal, set(), [])
+        assert action == "reject"
+        assert "rejected[0] has no label" in reason
+        assert "'alternative'" in reason
+        assert "'name'" in reason
+        assert "['title', 'reason']" in reason
+        # Key names only — never the offending item's values.
+        assert "Flask" not in reason
+        assert "Sync-only" not in reason
+
+    def test_empty_alternative_without_name_rejects(self):
+        proposal = self._proposal(rejected=[{"alternative": "", "reason": "Too slow."}])
+        action, reason = screen_structural(proposal, set(), [])
+        assert action == "reject"
+        assert "rejected[0] has no label" in reason
+
+    def test_whitespace_only_label_rejects(self):
+        proposal = self._proposal(rejected=[{"alternative": "   ", "name": "\t"}])
+        action, reason = screen_structural(proposal, set(), [])
+        assert action == "reject"
+        assert "rejected[0] has no label" in reason
+
+    def test_later_item_named_by_index(self):
+        proposal = self._proposal(
+            rejected=[
+                {"alternative": "Flask", "reason": "Sync-only workers."},
+                {"reason": "No label here."},
+            ]
+        )
+        action, reason = screen_structural(proposal, set(), [])
+        assert action == "reject"
+        assert "rejected[1] has no label" in reason
+
+    def test_empty_alternative_with_name_passes(self):
+        # The or-chain fallthrough: an empty 'alternative' resolves to 'name'.
+        proposal = self._proposal(rejected=[{"alternative": "", "name": "Flask"}])
+        action, reason = screen_structural(proposal, set(), [])
+        assert action == "pass"
+        assert reason is None
+
+    def test_labeled_items_pass(self):
+        proposal = self._proposal(
+            rejected=[{"alternative": "Flask", "reason": "Sync-only workers."}]
+        )
+        action, reason = screen_structural(proposal, set(), [])
+        assert action == "pass"
+        assert reason is None
+
+    def test_string_items_pass(self):
+        proposal = self._proposal(rejected=["Flask", "Django"])
+        action, reason = screen_structural(proposal, set(), [])
+        assert action == "pass"
+        assert reason is None
+
+    def test_rejected_alternative_instances_pass(self):
+        proposal = self._proposal(
+            rejected=[RejectedAlternative(name="Flask", reason="Sync-only workers.")]
+        )
+        action, reason = screen_structural(proposal, set(), [])
+        assert action == "pass"
+        assert reason is None
+
+    def test_none_rejected_passes(self):
+        proposal = self._proposal(rejected=None)
+        action, reason = screen_structural(proposal, set(), [])
+        assert action == "pass"
+        assert reason is None
 
 
 class TestFindEnvelopeToken:

--- a/packages/nauro/src/nauro/mcp/tools.py
+++ b/packages/nauro/src/nauro/mcp/tools.py
@@ -424,7 +424,9 @@ Args:
 
     affected_decision_id: Required when ``operation`` is ``update`` or
         ``supersede``. The id (e.g. "decision-042") being modified.
-    rejected: List of {{alternative, reason}} dicts.
+    rejected: List of {{alternative, reason}} dicts. Each item must carry a
+        non-empty 'alternative' key (legacy alias: 'name'); items without
+        one are rejected at the boundary.
     confidence: "high" | "medium" | "low".
     decision_type: Optional category string.
     reversibility: Optional "easy" | "moderate" | "hard".

--- a/packages/nauro/tests/test_propose_decision_parity.py
+++ b/packages/nauro/tests/test_propose_decision_parity.py
@@ -151,6 +151,26 @@ def test_rejected_envelope_tier_1(seeded_repo):
     assert "touched_decisions" not in envelope
 
 
+def test_nameless_rejected_item_rejected_at_tier_1(seeded_repo):
+    """A dict-form rejected item with no 'alternative'/'name' label surfaces
+    the kernel Tier 1 rejection through the adapter envelope."""
+    _pid, store_path = seeded_repo
+    envelope = tool_propose_decision(
+        store_path,
+        title="Adopt Redis for hot caching",
+        rationale="In-memory cache for the hot read paths across the API tier.",
+        confidence="high",
+        rejected=[{"title": "Memcached", "reason": "No native persistence."}],
+    )
+    assert envelope["store"] == "local"
+    assert envelope["status"] == "rejected"
+    assert envelope["tier"] == 1
+    assert "rejected[0] has no label" in envelope["assessment"]
+    assert "'alternative'" in envelope["assessment"]
+    assert "decision_id" not in envelope
+    assert "touched_decisions" not in envelope
+
+
 def test_stdio_returns_dict_envelope_matching_adapter(seeded_repo):
     """The stdio MCP ``propose_decision`` returns the same dict envelope
     as the direct adapter call. This is the load-bearing dict-return

--- a/packages/nauro/tests/test_write_command_autogen.py
+++ b/packages/nauro/tests/test_write_command_autogen.py
@@ -227,6 +227,26 @@ class TestProposeDecisionRejections:
         assert envelope["error"]["kind"] == "rejected"
         assert "exceeds" in envelope["error"]["reason"].lower()
 
+    def test_nameless_rejected_item_rejected(self, seeded_repo) -> None:
+        # Well-formed JSON, wrong keys: parse succeeds, the kernel rejects
+        # at Tier 1. Caller-fixable — envelope on stdout, exit 0.
+        result = runner.invoke(
+            app,
+            [
+                "propose-decision",
+                "In-memory cache for the hot read paths across the API tier.",
+                "--title",
+                "Adopt Redis for hot caching",
+                "--rejected",
+                '[{"title": "Memcached", "reason": "No native persistence."}]',
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        envelope = json.loads(result.stdout)
+        assert envelope["status"] == "rejected"
+        assert envelope["tier"] == 1
+        assert "rejected[0] has no label" in envelope["assessment"]
+
     def test_propose_missing_store_exits_one_with_guidance(
         self, tmp_path: Path, monkeypatch
     ) -> None:


### PR DESCRIPTION
## Why

`propose_decision` accepted dict-form rejected-alternative items with no usable label — e.g. `{"title": "Memcached", "reason": ...}` — and silently wrote the heading as "Unknown", losing the alternative's name in the permanent decision record with no signal to the caller.

## What changed

- The Tier 1 structural screen now rejects any dict-form `rejected` item whose `alternative` key (legacy alias: `name`) carries no non-empty label after stripping. The rejection names the item index and the accepted keys, echoing the offending item's key names only — never its values.
- A shared `rejected_item_label` helper backs both the screen and the write-path coercer; the coercer's "Unknown" default is replaced with a `ValueError` (unreachable via the validated path; fail-loud insurance for callers that bypass validation).
- The or-chain fallthrough is preserved: an empty `alternative` with a non-empty `name` still passes and resolves to `name`. String items and `RejectedAlternative` instances pass unchanged.
- The `rejected` parameter descriptions (tool-spec prose and adapter docstring) now state the accepted item shape.

## Risk / what to review

- `screen_structural` is shared with the remote MCP server through nauro-core, so the remote surface picks up the same rejection when it next bumps nauro-core — same message, same tier.
- The description edits are prose-only: `test_public_contract.py` passes against the untouched frozen snapshot.

## Test plan

- New screen unit tests: nameless dict item rejects with keys echoed (values never leaked); empty/whitespace-only labels reject; `alternative=""` with `name="X"` passes; string items and model instances pass.
- New kernel end-to-end tests: nameless item on add rejects at tier 1 with nothing written; valid `rejected` still writes labeled `###` headings; supersede with a nameless item rejects before any write and leaves the target active.
- New adapter parity test (tier-1 envelope) and CLI test (`--rejected '[{"title": ...}]'` exits 0 with the rejection envelope on stdout).
- Full suites: nauro-core 1029 passed; nauro 1585 passed / 10 skipped; ruff check + format clean.

## Deferred

- nauro-core version bump: releases in this repo ship as dedicated lockstep commits (both `pyproject.toml`s, `server.json`, `uv.lock`, and the cross-package pin together, guarded by `scripts/check_server_json_version.py`), so the bump belongs to the next release PR rather than this change.
