### PR TITLE
Align CLI help and status output with actual behavior

### DIFF
--- a/packages/nauro/src/nauro/cli/autogen.py
+++ b/packages/nauro/src/nauro/cli/autogen.py
@@ -139,7 +139,7 @@ def _schema_to_typer_params(spec: ToolSpec) -> list[inspect.Parameter]:
             default=typer.Option(
                 True,
                 "--json/--no-json",
-                help="Emit JSON output (default; no-op identity for parity).",
+                help="Compatibility no-op; JSON is the only output format.",
             ),
             annotation=bool,
         )
@@ -349,7 +349,9 @@ def _make_command(spec: ToolSpec) -> Callable[..., None]:
 
     command.__signature__ = inspect.Signature(parameters=params)  # type: ignore[attr-defined]
     command.__name__ = f"autogen_{tool_name}"
-    command.__doc__ = spec["description"]
+    # First paragraph only: the full tool description is MCP-client prose
+    # (multi-paragraph agent guidance) and would dominate --help output.
+    command.__doc__ = spec["description"].split("\n\n", 1)[0]
     return command
 
 
@@ -372,4 +374,4 @@ def register_autogen_commands(app: typer.Typer) -> None:
             continue
         command_name = _command_name(spec["name"])
         callback = _make_command(spec)
-        app.command(name=command_name, help=spec["description"])(callback)
+        app.command(name=command_name, help=spec["description"].split("\n\n", 1)[0])(callback)

--- a/packages/nauro/src/nauro/cli/commands/adopt.py
+++ b/packages/nauro/src/nauro/cli/commands/adopt.py
@@ -380,7 +380,9 @@ def adopt(
         help="Skip the --remove confirmation prompt (for scripting).",
     ),
 ) -> None:
-    """Adopt an existing repo into Nauro: register, wire MCP, install skills."""
+    """Adopt an existing repo into Nauro: register, wire MCP, install skills;
+    --remove inverts adoption (--purge-store also deletes the store).
+    """
     if print_prompt:
         if (
             name is not None

--- a/packages/nauro/src/nauro/cli/commands/import_cmd.py
+++ b/packages/nauro/src/nauro/cli/commands/import_cmd.py
@@ -578,7 +578,11 @@ def import_cmd(
         help="Target project name. Overrides cwd resolution.",
     ),
 ) -> None:
-    """Import context from an external source into the project store."""
+    """Import context from an external source into the project store.
+
+    Each import captures a snapshot; AGENTS.md in the associated repos is
+    not refreshed here — run 'nauro sync' afterwards.
+    """
     if memory_bank is None and adr is None:
         typer.echo(
             "Error: specify --memory-bank <path> or --adr <path>. See nauro import --help",

--- a/packages/nauro/src/nauro/cli/commands/init.py
+++ b/packages/nauro/src/nauro/cli/commands/init.py
@@ -259,7 +259,10 @@ def init(
     cloud: bool = typer.Option(
         False,
         "--cloud",
-        help="Create a cloud-scoped project on the remote MCP server.",
+        help=(
+            "Create a cloud-scoped project on the remote MCP server. "
+            "Requires prior 'nauro auth login'."
+        ),
     ),
     force: bool = typer.Option(
         False,
@@ -275,7 +278,7 @@ def init(
 
     If a project with the given name already exists locally and --add-repo
     is provided, the repos are appended to the existing local-mode entry.
-    Cloud-mode entries cannot be extended this way — use ``nauro attach``.
+    Cloud-mode entries cannot be extended this way — use 'nauro attach'.
     """
     # --demo seeds pre-written decisions directly to disk; the --cloud path
     # goes through propose_decision, which has no batch-seed bypass. Reject

--- a/packages/nauro/src/nauro/cli/commands/log.py
+++ b/packages/nauro/src/nauro/cli/commands/log.py
@@ -19,7 +19,7 @@ def log(
     all_decisions: bool = typer.Option(
         False,
         "--all",
-        help="Show all decisions including superseded ones.",
+        help="Show all decisions including superseded ones (only with --decisions).",
     ),
     decisions: bool = typer.Option(
         False,
@@ -32,7 +32,10 @@ def log(
         help="Target project name. Overrides cwd resolution.",
     ),
 ) -> None:
-    """List recent snapshots with version, timestamp, trigger, and change summary."""
+    """List recent snapshots with version, timestamp, and trigger.
+
+    --decisions lists the decision history instead; --all includes superseded.
+    """
     _project_name, store_path = resolve_target_project(project)
 
     if decisions:

--- a/packages/nauro/src/nauro/cli/commands/note.py
+++ b/packages/nauro/src/nauro/cli/commands/note.py
@@ -41,32 +41,47 @@ def note(
         False,
         "--question",
         "-q",
-        help="Force treating as a question.",
+        help="Force treating as a question. Takes precedence over --decision.",
     ),
     decision: bool = typer.Option(
         False,
         "--decision",
         "-d",
-        help="Force treating as a decision (default).",
+        help=(
+            "Force treating as a decision (default). Only disables the "
+            "trailing-'?' question autodetect; --question wins when both "
+            "are passed."
+        ),
     ),
     rationale: str | None = typer.Option(
         None,
         "--rationale",
         "-r",
-        help="Why this decision was made.",
+        help="Why this decision was made (decisions only; ignored for questions).",
     ),
     confidence: str = typer.Option(
         "medium",
         "--confidence",
         "-c",
-        help="Confidence: high, medium, low.",
+        help="Confidence: high, medium, low (decisions only; ignored for questions).",
         callback=_validate_confidence,
     ),
 ) -> None:
-    """Record a decision or question in the project store."""
+    """Record a decision or question in the project store.
+
+    Decisions are written to decisions/NNN-title.md; questions are appended
+    to open-questions.md. Every note also regenerates AGENTS.md in all
+    associated repos.
+    """
     if not text.strip():
         typer.echo("Note text cannot be empty.", err=True)
         raise typer.Exit(1)
+
+    if question and decision:
+        typer.echo(
+            "Warning: --question and --decision were both passed; --question wins.",
+            err=True,
+        )
 
     project_name, store_path = resolve_target_project(project)
     fs_store = FilesystemStore(store_path)
@@ -74,6 +89,14 @@ def note(
     is_question = question or (text.rstrip().endswith("?") and not decision)
 
     if is_question:
+        # Explicit `-c medium` is indistinguishable from the default, so it
+        # cannot trigger the warning; that trade-off is accepted.
+        if rationale is not None or confidence != "medium":
+            typer.echo(
+                "Warning: --rationale/--confidence apply to decisions only; "
+                "ignored for this question.",
+                err=True,
+            )
         # Hold the lock across the read-mint-insert-write append so concurrent
         # local writers cannot read the same open-questions.md pre-image and
         # clobber one another's entry. Mirrors the decision branch below, which

--- a/packages/nauro/src/nauro/cli/commands/questions.py
+++ b/packages/nauro/src/nauro/cli/commands/questions.py
@@ -34,7 +34,7 @@ def migrate(
         help="Print the legacy to Q### rename map and write nothing.",
     ),
 ) -> None:
-    """Mint sequential ``Q###`` ids for legacy timestamp question entries."""
+    """Mint sequential 'Q###' ids for legacy timestamp question entries."""
     project_name, store_path = resolve_target_project(project)
     fs_store = FilesystemStore(store_path)
 

--- a/packages/nauro/src/nauro/cli/commands/serve.py
+++ b/packages/nauro/src/nauro/cli/commands/serve.py
@@ -21,8 +21,8 @@ def serve(
 ) -> None:
     """Start the Nauro MCP server over stdio.
 
-    ``--stdio`` is accepted for backward compatibility with installed client
-    configurations that spawn ``nauro serve --stdio``; stdio is now the only
+    '--stdio' is accepted for backward compatibility with installed client
+    configurations that spawn 'nauro serve --stdio'; stdio is now the only
     transport, so the flag is a no-op.
     """
     from nauro.mcp.stdio_server import run_stdio

--- a/packages/nauro/src/nauro/cli/commands/setup.py
+++ b/packages/nauro/src/nauro/cli/commands/setup.py
@@ -435,7 +435,7 @@ def codex(
         False, "--remove", help="Remove Nauro integration instead of adding it."
     ),
 ) -> None:
-    """Configure Codex CLI to use Nauro (writes ``~/.codex/config.toml``)."""
+    """Configure Codex CLI to use Nauro (writes '~/.codex/config.toml')."""
     # Standalone codex wiring is user-global, so removing it without first
     # tearing down the other projects would leave them pointed at a missing
     # MCP entry. Gate on the registry: only the last project's teardown clears.

--- a/packages/nauro/src/nauro/cli/commands/status.py
+++ b/packages/nauro/src/nauro/cli/commands/status.py
@@ -1,6 +1,7 @@
 """nauro status — Show capability table for the current project."""
 
 from datetime import datetime, timezone
+from pathlib import Path
 
 import typer
 
@@ -48,6 +49,68 @@ def _count_remote_decisions(project_id: str) -> int | None:
         and entry.get("path", "").startswith("decisions/")
         and entry.get("path", "").endswith(".md")
     )
+
+
+def _codex_config_path() -> Path:
+    """User-global Codex config path (same location setup.py writes)."""
+    return Path.home() / ".codex" / "config.toml"
+
+
+def _repo_has_mcp_wiring(repo: Path) -> bool:
+    """True when the repo declares a nauro MCP server in .mcp.json or .cursor/mcp.json.
+
+    Read-only probe: a missing, unreadable, or malformed config counts as
+    not wired — status must never crash on someone else's config file.
+    """
+    import json
+
+    for rel in (".mcp.json", ".cursor/mcp.json"):
+        try:
+            config = json.loads((repo / rel).read_text())
+        except Exception:
+            continue
+        if not isinstance(config, dict):
+            continue
+        servers = config.get("mcpServers")
+        if isinstance(servers, dict) and "nauro" in servers:
+            return True
+    return False
+
+
+def _codex_global_wired() -> bool:
+    """True when the user-global Codex config declares a nauro MCP server.
+
+    Same parse approach as setup.py; any read or parse failure counts as
+    not wired.
+    """
+    import sys
+
+    if sys.version_info >= (3, 11):
+        import tomllib
+    else:
+        import tomli as tomllib
+
+    try:
+        with _codex_config_path().open("rb") as f:
+            config = tomllib.load(f)
+    except Exception:
+        return False
+    servers = config.get("mcp_servers")
+    return isinstance(servers, dict) and "nauro" in servers
+
+
+def _repo_has_generated_agents_md(repo: Path) -> bool:
+    """True when the repo's AGENTS.md carries the Nauro generation footer.
+
+    A file without the footer is hand-written (or stale beyond recognition)
+    and counts as not generated. Unreadable files count as not generated.
+    """
+    from nauro.templates.agents_md import FOOTER_MARKER
+
+    try:
+        return FOOTER_MARKER in (repo / "AGENTS.md").read_text()
+    except Exception:
+        return False
 
 
 def status(
@@ -103,16 +166,49 @@ def status(
     elif not is_cloud:
         typer.echo(
             "  Sync          inactive — local-only project."
-            " Enable with `nauro auth login`, then `nauro link --cloud`."
+            " Enable with 'nauro auth login', then 'nauro link --cloud'."
         )
     else:
-        typer.echo("  Sync          inactive — run `nauro auth login` to enable")
+        typer.echo("  Sync          inactive — run 'nauro auth login' to enable")
 
-    # MCP
-    typer.echo("  MCP           active")
+    # MCP + AGENTS.md — computed from on-disk wiring, never assumed. Every
+    # probe is guarded (same rationale as the shared-name check above): a
+    # corrupt config or unreadable file counts as not wired, never a crash.
+    try:
+        from nauro.store.registry import get_repo_paths
 
-    # AGENTS.md
-    typer.echo("  AGENTS.md     active")
+        repo_paths = [Path(p) for p in get_repo_paths(project_id)]
+    except Exception:
+        repo_paths = []
+
+    try:
+        mcp_wired = sum(1 for repo in repo_paths if _repo_has_mcp_wiring(repo))
+    except Exception:
+        mcp_wired = 0
+    try:
+        codex_global = _codex_global_wired()
+    except Exception:
+        codex_global = False
+
+    if mcp_wired or codex_global:
+        details = []
+        if repo_paths:
+            details.append(f"wired in {mcp_wired}/{len(repo_paths)} repos")
+        if codex_global:
+            details.append("Codex global")
+        typer.echo(f"  MCP           active ({'; '.join(details)})")
+    else:
+        typer.echo("  MCP           inactive — run 'nauro setup all'")
+
+    try:
+        agents_generated = sum(1 for repo in repo_paths if _repo_has_generated_agents_md(repo))
+    except Exception:
+        agents_generated = 0
+
+    if agents_generated:
+        typer.echo(f"  AGENTS.md     active ({agents_generated}/{len(repo_paths)} repos)")
+    else:
+        typer.echo("  AGENTS.md     inactive — run 'nauro sync'")
 
     # Decision counts and sync divergence
     from nauro.store.reader import _list_decisions

--- a/packages/nauro/src/nauro/cli/commands/sync.py
+++ b/packages/nauro/src/nauro/cli/commands/sync.py
@@ -39,8 +39,9 @@ def sync(
 
     With cloud sync configured, pulls from the server first (git-style
     pull-then-push), then pushes the updated store back. Project state in
-    state_current.md is not touched — use the MCP ``update_state`` tool to
-    record what changed.
+    state_current.md is not touched — use the MCP 'update_state' tool to
+    record what changed. After a successful sync, structural store
+    validation runs and any warnings are printed at the end.
     """
     if status:
         _show_status(project)
@@ -77,7 +78,8 @@ def sync(
             typer.echo(f"  Updated AGENTS.md: {repo_path}")
     else:
         typer.echo(
-            f"Snapshot v{version:03d} captured locally; not uploaded.",
+            f"Error: cloud push failed for {project_name}; snapshot v{version:03d} "
+            "was captured locally and will be pushed on the next successful sync.",
             err=True,
         )
         raise typer.Exit(code=1)

--- a/packages/nauro/src/nauro/templates/agents_md.py
+++ b/packages/nauro/src/nauro/templates/agents_md.py
@@ -126,7 +126,9 @@ def generate_agents_md(
     total_count = read_count + write_count
     parts.append(
         f"## Nauro MCP Tools\n\n"
-        f"If your tool supports MCP, these {total_count} tools are available:\n\n"
+        f"If your tool supports MCP, these {total_count} tools are available; "
+        f"without MCP, the same tools work as `nauro <tool-name>` shell commands "
+        f"(e.g. `nauro check-decision`).\n\n"
         f"**Read tools ({read_count}):**\n"
         f"{_render_tool_rows(READ_TOOL_ROWS)}\n\n"
         f"**Write tools ({write_count}):**\n"

--- a/packages/nauro/tests/test_agents_md.py
+++ b/packages/nauro/tests/test_agents_md.py
@@ -104,6 +104,15 @@ def test_tool_counts_derived_from_row_catalogs():
     assert f"**Write tools ({write_count}):**" in result
 
 
+def test_tools_lead_line_covers_no_mcp_agents():
+    """The tools section tells MCP-less agents about the CLI mirror."""
+    result = generate_agents_md("myproj", "payload")
+    assert (
+        "without MCP, the same tools work as `nauro <tool-name>` shell commands "
+        "(e.g. `nauro check-decision`)."
+    ) in result
+
+
 def test_generate_with_manual_section():
     result = generate_agents_md("proj", "payload", manual_section="Use conventional commits.\n")
     assert "# Manual" in result

--- a/packages/nauro/tests/test_cli_autogen.py
+++ b/packages/nauro/tests/test_cli_autogen.py
@@ -253,6 +253,36 @@ class TestCheckDecision:
         assert "No project found" in result.output
 
 
+# ── Help surface ────────────────────────────────────────────────────────────
+
+
+class TestAutogenHelp:
+    def test_command_help_is_exactly_the_first_description_paragraph(self) -> None:
+        """Registered help must equal the tool description's first paragraph.
+
+        The rest of the description is MCP-client prose (multi-paragraph
+        agent guidance) and stays off the --help surface.
+        """
+        import click
+        import typer as typer_mod
+
+        command = typer_mod.main.get_command(app)
+        ctx = click.Context(command, info_name="nauro")
+        specs = {spec["name"]: spec for spec in ALL_TOOLS}
+        for name in AUTOGEN_ALLOWLIST:
+            sub = command.get_command(ctx, name.replace("_", "-"))
+            assert sub is not None
+            assert sub.help == specs[name]["description"].split("\n\n", 1)[0]
+
+    def test_propose_decision_help_omits_later_paragraphs(self) -> None:
+        """'Tier 2' appears only in the description's second paragraph — a
+        marker that later paragraphs never leak into --help output."""
+        result = runner.invoke(app, ["propose-decision", "--help"])
+        assert result.exit_code == 0, result.output
+        assert "Record an architectural decision" in result.output
+        assert "Tier 2" not in result.output
+
+
 # ── Cross-cutting invariants ────────────────────────────────────────────────
 
 

--- a/packages/nauro/tests/test_cli_status.py
+++ b/packages/nauro/tests/test_cli_status.py
@@ -1,29 +1,121 @@
 """Tests for nauro status command."""
 
+import json
+
 from typer.testing import CliRunner
 
+import nauro.cli.commands.status as status_mod
 from nauro.cli.main import app
 from nauro.store.registry import register_project
+from nauro.templates.agents_md import FOOTER_MARKER
 from nauro.templates.scaffolds import scaffold_project_store
 
 runner = CliRunner()
 
 
-def _setup_project(tmp_path, monkeypatch):
-    store = register_project("testproj", [tmp_path])
+def _setup_project(tmp_path, monkeypatch, repos=None):
+    """Register a project with the given repos (default: tmp_path itself).
+
+    Also points the Codex-global probe at a path under tmp_path so a wired
+    ~/.codex/config.toml on the developer's machine cannot leak into the
+    detection assertions.
+    """
+    repos = repos if repos is not None else [tmp_path]
+    store = register_project("testproj", repos)
     scaffold_project_store("testproj", store)
-    monkeypatch.chdir(tmp_path)
+    monkeypatch.chdir(repos[0])
+    monkeypatch.setattr(
+        status_mod, "_codex_config_path", lambda: tmp_path / "codex-home" / "config.toml"
+    )
     return store
 
 
-def test_status_shows_active_capabilities(tmp_path, monkeypatch):
+def _wire_repo_mcp(repo):
+    (repo / ".mcp.json").write_text(json.dumps({"mcpServers": {"nauro": {"command": "nauro"}}}))
+
+
+def test_status_mcp_and_agents_inactive_when_nothing_wired(tmp_path, monkeypatch):
+    """No MCP config anywhere and no generated AGENTS.md → both rows inactive."""
     _setup_project(tmp_path, monkeypatch)
 
     result = runner.invoke(app, ["status"])
     assert result.exit_code == 0
-    assert "MCP           active" in result.output
-    assert "AGENTS.md     active" in result.output
+    assert "MCP           inactive — run 'nauro setup all'" in result.output
+    assert "AGENTS.md     inactive — run 'nauro sync'" in result.output
     assert "Decisions:" in result.output
+
+
+def test_status_mcp_partial_repo_wiring(tmp_path, monkeypatch):
+    """One of two associated repos wired via .mcp.json → active (1/2)."""
+    repo1 = tmp_path / "repo1"
+    repo2 = tmp_path / "repo2"
+    repo1.mkdir()
+    repo2.mkdir()
+    _setup_project(tmp_path, monkeypatch, repos=[repo1, repo2])
+    _wire_repo_mcp(repo1)
+
+    result = runner.invoke(app, ["status"])
+    assert result.exit_code == 0
+    assert "MCP           active (wired in 1/2 repos)" in result.output
+
+
+def test_status_mcp_cursor_wiring_counts(tmp_path, monkeypatch):
+    """A nauro entry in .cursor/mcp.json counts as repo wiring."""
+    _setup_project(tmp_path, monkeypatch)
+    cursor_dir = tmp_path / ".cursor"
+    cursor_dir.mkdir()
+    (cursor_dir / "mcp.json").write_text(
+        json.dumps({"mcpServers": {"nauro": {"command": "nauro"}}})
+    )
+
+    result = runner.invoke(app, ["status"])
+    assert result.exit_code == 0
+    assert "MCP           active (wired in 1/1 repos)" in result.output
+
+
+def test_status_mcp_codex_global_only(tmp_path, monkeypatch):
+    """No repo wiring but a nauro entry in the Codex global config → active."""
+    _setup_project(tmp_path, monkeypatch)
+    codex_config = tmp_path / "codex-home" / "config.toml"
+    codex_config.parent.mkdir(parents=True)
+    codex_config.write_text('[mcp_servers.nauro]\ncommand = "nauro"\nargs = ["serve", "--stdio"]\n')
+
+    result = runner.invoke(app, ["status"])
+    assert result.exit_code == 0
+    assert "MCP           active (wired in 0/1 repos; Codex global)" in result.output
+
+
+def test_status_agents_md_active_with_footer(tmp_path, monkeypatch):
+    """An AGENTS.md carrying the generation footer counts as generated."""
+    _setup_project(tmp_path, monkeypatch)
+    (tmp_path / "AGENTS.md").write_text(f"# AGENTS.md\n\npayload\n\n{FOOTER_MARKER}https://x)\n")
+
+    result = runner.invoke(app, ["status"])
+    assert result.exit_code == 0
+    assert "AGENTS.md     active (1/1 repos)" in result.output
+
+
+def test_status_agents_md_without_footer_counts_not_generated(tmp_path, monkeypatch):
+    """A hand-written AGENTS.md (no Nauro footer) does not count as generated."""
+    _setup_project(tmp_path, monkeypatch)
+    (tmp_path / "AGENTS.md").write_text("# AGENTS.md\n\nHand-written project notes.\n")
+
+    result = runner.invoke(app, ["status"])
+    assert result.exit_code == 0
+    assert "AGENTS.md     inactive — run 'nauro sync'" in result.output
+
+
+def test_status_corrupt_mcp_config_soft_fails(tmp_path, monkeypatch):
+    """Unparseable wiring configs count as unwired; status never crashes."""
+    _setup_project(tmp_path, monkeypatch)
+    (tmp_path / ".mcp.json").write_text("{not valid json")
+    codex_config = tmp_path / "codex-home" / "config.toml"
+    codex_config.parent.mkdir(parents=True)
+    codex_config.write_text("mcp_servers = not-toml [")
+
+    result = runner.invoke(app, ["status"])
+    assert result.exit_code == 0
+    assert "MCP           inactive — run 'nauro setup all'" in result.output
 
 
 def test_status_shows_store_path(tmp_path, monkeypatch):

--- a/packages/nauro/tests/test_note.py
+++ b/packages/nauro/tests/test_note.py
@@ -119,6 +119,56 @@ def test_note_warns_about_missing_repo_paths(tmp_path: Path, monkeypatch):
     assert "Move billing to Stripe" in (live_repo / "AGENTS.md").read_text()
 
 
+def test_note_question_with_rationale_warns(tmp_path: Path, monkeypatch):
+    """--rationale on the question path is ignored, and the user is told so."""
+    store = register_project("myproj", [tmp_path])
+    scaffold_project_store("myproj", store)
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(
+        app, ["note", "Should we shard the database?", "--rationale", "scaling pressure"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "Warning: --rationale/--confidence apply to decisions only" in result.output
+    # Still recorded as a question, not a decision.
+    assert "Question added" in result.output
+
+
+def test_note_question_with_confidence_warns(tmp_path: Path, monkeypatch):
+    """A non-default --confidence on the question path triggers the warning."""
+    store = register_project("myproj", [tmp_path])
+    scaffold_project_store("myproj", store)
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["note", "--question", "Which queue to use", "-c", "high"])
+    assert result.exit_code == 0, result.output
+    assert "Warning: --rationale/--confidence apply to decisions only" in result.output
+
+
+def test_note_both_question_and_decision_warns(tmp_path: Path, monkeypatch):
+    """--question and --decision together warn that --question wins."""
+    store = register_project("myproj", [tmp_path])
+    scaffold_project_store("myproj", store)
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["note", "Pick a message broker", "--question", "--decision"])
+    assert result.exit_code == 0, result.output
+    assert "Warning: --question and --decision were both passed; --question wins" in result.output
+    assert "Question added" in result.output
+
+
+def test_note_plain_decision_no_warning(tmp_path: Path, monkeypatch):
+    """The decision path with --rationale emits no flag-usage warning."""
+    store = register_project("myproj", [tmp_path])
+    scaffold_project_store("myproj", store)
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["note", "Use Postgres", "--rationale", "battle-tested"])
+    assert result.exit_code == 0, result.output
+    assert "Warning: --rationale/--confidence apply to decisions only" not in result.output
+    assert "Warning: --question and --decision" not in result.output
+
+
 def test_note_empty_string_rejects(tmp_path: Path, monkeypatch):
     """Empty text is rejected before any store write."""
     store = register_project("myproj", [tmp_path])

--- a/packages/nauro/tests/test_sync/test_sync_command.py
+++ b/packages/nauro/tests/test_sync/test_sync_command.py
@@ -179,6 +179,9 @@ class TestSyncHonesty:
         assert result.exit_code == 1, combined
         assert "Warning: this is a cloud-mode project" in combined
         assert "not authenticated" in combined
+        # The final line leads with the failure, not the local capture.
+        assert "Error: cloud push failed for cloudproj" in combined
+        assert "will be pushed on the next successful sync" in combined
         assert "Synced cloudproj" not in result.output
 
     def test_local_project_without_auth_succeeds(self, project_store):


### PR DESCRIPTION
## Why

`nauro status` reported MCP and AGENTS.md as active unconditionally: both rows were hardcoded strings, so the capability table could not tell a wired repo from an unwired one. Several help surfaces had also drifted from real behavior: `nauro log --help` promised a change-summary column that is never rendered, `nauro note` silently ignored decision-only flags on the question path and never said where notes land, auto-generated tool commands dumped the full multi-paragraph MCP tool description into `--help`, and a handful of help strings leaked literal reST double-backticks into terminal output.

## What changed

- **status:** the MCP row is computed from on-disk wiring (`mcpServers.nauro` in `.mcp.json` or `.cursor/mcp.json` per associated repo, plus `mcp_servers.nauro` in the user-global Codex config); the AGENTS.md row counts repos whose AGENTS.md carries the Nauro generation footer. Every probe is read-only and guarded: unreadable or corrupt configs count as unwired and status keeps exit 0. Sample rows:

  ```
    MCP           active (wired in 1/2 repos; Codex global)
    AGENTS.md     active (2/2 repos)
  ```
  and when nothing is wired:
  ```
    MCP           inactive — run 'nauro setup all'
    AGENTS.md     inactive — run 'nauro sync'
  ```

- **note:** the docstring names the destination files (`decisions/NNN-title.md` for decisions, `open-questions.md` for questions) and the AGENTS.md regeneration in all associated repos. New stderr warnings when `--rationale`/`--confidence` hit the question path, and when `--question` and `--decision` are combined (`--question` wins). Flag help documents both. Exit codes unchanged. Known limit: an explicit `-c medium` is indistinguishable from the default and does not warn.
- **sync:** the cloud-push failure message now leads with the failure ("Error: cloud push failed for <project>; snapshot vNNN was captured locally and will be pushed on the next successful sync."), still exit 1. The docstring documents the post-sync validation-warnings tail.
- **log:** the docstring matches the rendered columns (version, timestamp, trigger) and documents `--decisions` / `--all`; the `--all` help notes it only applies with `--decisions`.
- **autogen:** command help is the first paragraph of the tool description only, applied to both the callback docstring and the registered help. `--json/--no-json` help now reads "Compatibility no-op; JSON is the only output format." Flags, types, choices, and defaults are untouched.
- **AGENTS.md template:** the tools lead line now covers agents without MCP support (the same tools work as `nauro <tool-name>` shell commands).
- **Small drift:** adopt's one-line help mentions `--remove` / `--purge-store`; `init --cloud` help notes it requires prior `nauro auth login`; the import docstring notes the snapshot capture and the follow-up `nauro sync`; double-backtick sweep across sync/init/serve/questions/setup user-visible strings, including the pre-existing Sync status row for one consistent quote style.

Measured with CliRunner at COLUMNS=80: `nauro propose-decision --help` shrank from 14,905 to 14,014 chars; `nauro --help` is unchanged except the intended adopt and log listing entries.

## Test plan

- New status detection tests: nothing wired (inactive rows), partial wiring (1/2), `.cursor/mcp.json` wiring, Codex-global-only, AGENTS.md without the generation footer (counts as not generated), corrupt JSON and TOML configs (soft-fail, exit 0).
- New note tests: warning on question + `--rationale`, question + non-default `--confidence`, `--question --decision` together; no warning on the plain decision path.
- Autogen: registered help equals the description's first paragraph for all 10 mirrored commands; a marker test confirms later paragraphs (e.g. the Tier 2 advisory text) never reach `--help`.
- Template sentence pinned in test_agents_md; the new sync failure message pinned in test_sync_command.
- Full suites: nauro-core 1029 passed; nauro 1598 passed, 10 skipped. `ruff check` and `ruff format --check` clean.

## Risk / what to review

- The CLI command tree is a frozen surface: this change is help prose, computed output, and two warn-only behaviors. The public-contract snapshot test passes without regeneration; no command, flag, type, choice, or default changed.
- The status probes read files owned by other tools (`.mcp.json`, `.cursor/mcp.json`, `~/.codex/config.toml`). Each probe is individually guarded so a malformed file counts as unwired rather than crashing; that guard layering is the main thing worth eyeballing.
