### PR TITLE
Trim MCP tool description prose and relocate supersede-care guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ More at [nauro.ai](https://nauro.ai).
 
 Nauro stores your project's decisions as plain markdown files, each with the alternatives you ruled out and the reasoning behind them. The store can also carry current state and open questions. When an agent proposes an approach, `check_decision` runs deterministic keyword retrieval (BM25) over those files and surfaces the related ones before the agent plans or writes code.
 
-At session start, agents can read a compact L0 standing-context summary: project summary, current state, top open questions, and the last 10 decisions, then pull specific decisions on demand. On Nauro's own 368-decision store, that L0 summary measured about 2,600 Claude tokens; the full store was 539,469 tokens.
+At session start, agents can read a compact L0 standing-context summary: project summary, current state, top open questions, and the last 10 decisions, then pull specific decisions on demand. On Nauro's own 386-decision store, that L0 summary measures about 1,700 tokens against a full store of about 350,000 (o200k_base tokenizer).
 
 No model judges your decisions. The check is advisory and never blocks a change. A decision is recorded only by an explicit write call, and the approval gate lives in the conversation. The store is a folder you own; remove Nauro and the markdown stays.
 

--- a/packages/nauro-core/src/nauro_core/constants.py
+++ b/packages/nauro-core/src/nauro_core/constants.py
@@ -9,7 +9,6 @@ from nauro_core.protocol import (
     CHECK_DECISION_RETURNS,
     GET_DECISION_BEFORE_PROPOSING,
     NO_INVENT_RATIONALE,
-    UPDATE_SUPERSEDE_CARE,
 )
 
 # ── L0/L1/L2 payload limits ──
@@ -161,17 +160,18 @@ MAX_BRIEF_BYTES = 50 * 1024
 # Canonical claims about check_decision/get_decision/propose_decision live in
 # nauro_core.protocol (imported at the top of this module) and are spliced
 # in below; MCP-specific framing prose (precondition / first-principles /
-# push back / vendor swap) stays inline. The PROPOSE_DECISION_OPERATIONS and
-# RESOLVES_OPEN_QUESTIONS fragments are deliberately omitted here — they are
-# bound to the `propose_decision` ToolSpec parameter descriptions instead,
-# where the agent reads them at the moment of use. For the same budget reason
-# the `update_state` "meaningful unit of work" guidance and the `get_context`
-# "do not call list_decisions afterward" nuance are omitted here too — they
-# live on the matching ToolSpec descriptions in mcp_tools.py, which the client
-# delivers intact via tools/list even when initialize.instructions is
-# truncated. Keeping all four out of the static block trims the budget so the
-# per-user project section the remote server prepends survives client-side
-# truncation of the `initialize.instructions` field.
+# push back / vendor swap) stays inline. The PROPOSE_DECISION_OPERATIONS,
+# UPDATE_SUPERSEDE_CARE, and RESOLVES_OPEN_QUESTIONS fragments are
+# deliberately omitted here — they are bound to the `propose_decision`
+# ToolSpec parameter descriptions instead, where the agent reads them at the
+# moment of use. For the same budget reason the `update_state` "meaningful
+# unit of work" guidance and the `get_context` "do not call list_decisions
+# afterward" nuance are omitted here too — they live on the matching ToolSpec
+# descriptions in mcp_tools.py, which the client delivers intact via
+# tools/list even when initialize.instructions is truncated. Keeping all five
+# out of the static block trims the budget so the per-user project section
+# the remote server prepends survives client-side truncation of the
+# `initialize.instructions` field.
 # MCP_INSTRUCTIONS remains as a backward-compatible alias.
 MCP_INSTRUCTIONS_STATIC = (
     "Nauro carries this project's doctrine across every agent session. "
@@ -195,9 +195,8 @@ MCP_INSTRUCTIONS_STATIC = (
     "Call `propose_decision` when you choose between two or more approaches, "
     "replace or remove a dependency, establish a new pattern, or cut scope. "
     "Do it at the moment the decision is made, not at the end of the "
-    "session. Always include what was rejected and why.\n"
-    "\n"
-    f"You own this classification. {UPDATE_SUPERSEDE_CARE}\n"
+    "session. Always include what was rejected and why. You own this "
+    "classification.\n"
     "\n"
     f"{NO_INVENT_RATIONALE} Do NOT propose decisions for obvious bug fixes, "
     "adding tests for existing behavior, or renaming variables.\n"

--- a/packages/nauro-core/src/nauro_core/mcp_tools.py
+++ b/packages/nauro-core/src/nauro_core/mcp_tools.py
@@ -50,10 +50,8 @@ class ToolSpec(TypedDict):
 _PROJECT_PARAM: dict[str, Any] = {
     "type": "string",
     "description": (
-        "Optional. If you have one project, the server resolves it "
-        "automatically. Pass explicitly if you have multiple: the hosted "
-        "server's list_projects tool returns the available IDs, and on the "
-        "local server the `nauro projects` terminal command lists them."
+        "Optional; auto-resolved when you have one project. With multiple, "
+        "list ids via list_projects (hosted) or `nauro projects` (local)."
     ),
 }
 
@@ -245,9 +243,6 @@ SEARCH_DECISIONS: ToolSpec = {
         "than browsing the full list. More token-efficient than list_decisions "
         "for targeted lookups.\n"
         "\n"
-        'Example: search_decisions("authentication") returns all decisions '
-        "related to auth, OAuth, JWT, etc.\n"
-        "\n"
         "Returns decision number, title, date, status, and a relevance "
         "snippet from the matching rationale. Requires a non-empty query."
     ),
@@ -280,8 +275,8 @@ CHECK_DECISION: ToolSpec = {
     "title": "Check decision against existing decisions",
     "description": (
         "Check whether a proposed approach overlaps with existing decisions "
-        "WITHOUT writing anything. Returns related decisions (via Tier 1 + "
-        "Tier 2 BM25 retrieval) and a deterministic assessment string.\n"
+        "WITHOUT writing anything. Returns related decisions via BM25 "
+        "keyword retrieval and a deterministic assessment string.\n"
         "\n"
         f"This tool does NOT judge conflicts. {GET_DECISION_BEFORE_PROPOSING}\n"
         "\n"
@@ -315,13 +310,12 @@ PROPOSE_DECISION: ToolSpec = {
     "name": "propose_decision",
     "title": "Propose a decision",
     "description": (
-        "Record an architectural decision. The kernel commits on Tier 1 "
-        "structural validation pass; the write is single-call.\n"
+        "Record an architectural decision. The write commits in a single "
+        "call once structural validation passes.\n"
         "\n"
-        "Tier 2 BM25 similarity is advisory: any hits return on "
-        "similar_decisions in the response and do not block the write. "
-        "Review similar_decisions before drafting and surface them to the "
-        "user; the human-in-the-loop gate is the chat-session approval "
+        "Similarity hits are advisory: they return on similar_decisions and "
+        "never block the write. Review them before drafting and surface "
+        "them to the user; the human-in-the-loop gate is the chat approval "
         "before this call, not a second tool call after it.\n"
         "\n"
         "Call this when you choose between two or more approaches, replace "
@@ -394,10 +388,9 @@ PROPOSE_DECISION: ToolSpec = {
                 # CLI autogen surface) materialise "medium", which the kernel
                 # then rejects as a disallowed metadata change on update.
                 "description": (
-                    "Author's confidence in the decision. Use 'high' only "
-                    "when a source explicitly accepts or approves the choice; "
-                    "'medium' when it is the best available given known "
-                    "tradeoffs; 'low' when it is a working assumption that "
+                    "Author's confidence: 'high' only when a source "
+                    "explicitly approves; 'medium' when best available given "
+                    "known tradeoffs; 'low' for a working assumption that "
                     "may be revisited."
                 ),
             },
@@ -494,8 +487,7 @@ FLAG_QUESTION: ToolSpec = {
                     "the response names the resolving decision. On the resolve "
                     "action (resolved_by set), the entries to stamp as resolved "
                     "— every id must exist in open-questions.md or the call is "
-                    "rejected. Freshness is bounded by the most recent pull, so "
-                    "a remote resolution may be missed by a stale local copy."
+                    "rejected."
                 ),
             },
             "resolved_by": {

--- a/packages/nauro-core/src/nauro_core/protocol.py
+++ b/packages/nauro-core/src/nauro_core/protocol.py
@@ -58,11 +58,10 @@ NO_INVENT_RATIONALE = (
 
 RESOLVES_OPEN_QUESTIONS = (
     "When a proposal closes one of `get_context`'s open questions, include "
-    "the question's `[Q###]` id in `resolves_questions`. Legacy "
-    "`[YYYY-MM-DD HH:MM UTC]` ids are still accepted for entries that "
-    "predate the Q-form rollout. The named entries move under "
-    "`## Resolved` with a back-reference to the new decision on confirm; "
-    "unknown or ambiguous ids reject at the boundary."
+    "the question's `[Q###]` id (legacy timestamp ids are accepted) in "
+    "`resolves_questions`. Named entries move under `## Resolved` with a "
+    "back-reference to the new decision; unknown or ambiguous ids reject "
+    "at the boundary."
 )
 
 CANONICAL_FRAGMENTS: dict[str, str] = {

--- a/packages/nauro-core/tests/test_constants.py
+++ b/packages/nauro-core/tests/test_constants.py
@@ -41,7 +41,7 @@ from nauro_core.protocol import (
 # matching ToolSpec descriptions, which tools/list delivers intact past the
 # cliff — that durable home is what makes static-tail loss acceptable.
 MCP_INSTRUCTIONS_TRUNCATION_LIMIT = 2023
-MCP_INSTRUCTIONS_STATIC_MAX_CHARS = 1891
+MCP_INSTRUCTIONS_STATIC_MAX_CHARS = 1700
 
 
 class TestLimits:

--- a/packages/nauro-core/tests/test_protocol.py
+++ b/packages/nauro-core/tests/test_protocol.py
@@ -179,17 +179,16 @@ class TestMcpInstructionsComposition:
     """MCP_INSTRUCTIONS_STATIC must contain every fragment used by the MCP
     surface verbatim, and must be fully resolved (no leftover tokens).
 
-    ``PROPOSE_DECISION_OPERATIONS`` and ``RESOLVES_OPEN_QUESTIONS`` are
-    deliberately omitted from the static block — they live on the matching
-    ``propose_decision`` ToolSpec parameter descriptions instead, where the
-    agent reads them at the moment of use. The positive splice asserts
-    below pin those relocations.
+    ``PROPOSE_DECISION_OPERATIONS``, ``UPDATE_SUPERSEDE_CARE``, and
+    ``RESOLVES_OPEN_QUESTIONS`` are deliberately omitted from the static
+    block — they live on the matching ``propose_decision`` ToolSpec
+    parameter descriptions instead, where the agent reads them at the
+    moment of use. The positive splice asserts below pin those relocations.
     """
 
     REQUIRED_FRAGMENTS = (
         CHECK_DECISION_RETURNS,
         GET_DECISION_BEFORE_PROPOSING,
-        UPDATE_SUPERSEDE_CARE,
         NO_INVENT_RATIONALE,
     )
 
@@ -207,6 +206,20 @@ class TestMcpInstructionsComposition:
         spec = get_tool_spec("propose_decision")
         op_desc = spec["input_schema"]["properties"]["operation"]["description"]
         assert PROPOSE_DECISION_OPERATIONS in op_desc
+
+    def test_update_supersede_care_not_in_static(self) -> None:
+        """Relocated to the propose_decision.operation parameter description
+        so the static block stays under the truncation budget; the fragment
+        must not silently reappear in the static block."""
+        assert UPDATE_SUPERSEDE_CARE not in MCP_INSTRUCTIONS_STATIC
+
+    def test_update_supersede_care_in_operation_parameter(self) -> None:
+        """Relocation guard: the fragment must appear verbatim on the
+        ``propose_decision.operation`` parameter description so the agent
+        still reads the default-to-add guidance at the moment of use."""
+        spec = get_tool_spec("propose_decision")
+        op_desc = spec["input_schema"]["properties"]["operation"]["description"]
+        assert UPDATE_SUPERSEDE_CARE in op_desc
 
     def test_resolves_open_questions_in_resolves_questions_parameter(self) -> None:
         """Relocation guard: the fragment must appear verbatim on the

--- a/packages/nauro/src/nauro/mcp/stdio_server.py
+++ b/packages/nauro/src/nauro/mcp/stdio_server.py
@@ -144,10 +144,8 @@ _CWD_PARAM = Annotated[
     str | None,
     Field(
         description=(
-            "Optional. Absolute directory path used to resolve the project "
-            "from the local registry when project_id is not given. Callers "
-            "pass their working directory so resolution matches the repo "
-            "they are operating in."
+            "Optional. The caller's absolute working directory; resolves "
+            "the project from the local registry when project_id is omitted."
         )
     ),
 ]

--- a/packages/nauro/tests/test_cli_autogen.py
+++ b/packages/nauro/tests/test_cli_autogen.py
@@ -275,12 +275,13 @@ class TestAutogenHelp:
             assert sub.help == specs[name]["description"].split("\n\n", 1)[0]
 
     def test_propose_decision_help_omits_later_paragraphs(self) -> None:
-        """'Tier 2' appears only in the description's second paragraph — a
-        marker that later paragraphs never leak into --help output."""
+        """'human-in-the-loop' appears only in the description's second
+        paragraph — a marker that later paragraphs never leak into --help
+        output."""
         result = runner.invoke(app, ["propose-decision", "--help"])
         assert result.exit_code == 0, result.output
         assert "Record an architectural decision" in result.output
-        assert "Tier 2" not in result.output
+        assert "human-in-the-loop" not in result.output
 
 
 # ── Cross-cutting invariants ────────────────────────────────────────────────


### PR DESCRIPTION
## Why

Every session pays for the tools/list payload and the initialize.instructions static block. The tool descriptions leaked internal implementation vocabulary ("Tier 1", "Tier 2", "kernel") that means nothing to a connecting agent, and several parameter descriptions restated the same facts at redundant length. The static block also duplicated the supersede-care guidance, which an agent reads at the moment it picks a propose_decision operation, not at initialize time.

## What changed

- Reworded in behavioral terms (description strings only, no schema structure changes): propose_decision paragraphs 1 and 2, check_decision paragraph 1, the shared project_id parameter, the local-only cwd parameter, and the confidence parameter.
- Deleted prose with no decision weight for agents: the search_decisions example paragraph and the flag_question targets freshness caveat (the maintainer-facing fact stays in the flag_question kernel module docstring).
- Tightened the resolves-questions protocol fragment: legacy timestamp acceptance folded to a parenthetical, stale post-write clause removed.
- Relocated the supersede-care fragment out of MCP_INSTRUCTIONS_STATIC to its point of use on the propose_decision operation parameter, which tools/list delivers intact past the client truncation cliff. The static block drops from 1,811 to 1,658 chars (377 to 344 o200k_base tokens); the ceiling test ratchets from 1,891 to 1,700.
- Tests: the static-composition fragment list drops the relocated fragment and gains a not-in-static pin plus an operation-parameter relocation guard, mirroring the existing operations-fragment pair; the propose-decision --help leak marker re-points from "Tier 2" to "human-in-the-loop", which appears only in the new second paragraph and in no per-property description.
- README: the store-size sentence is re-measured on the current store: 386 decisions, L0 about 1,700 tokens, full store about 350,000 tokens (o200k_base tokenizer, kernel get_context + renderer path, read-only; 1,656 and 346,884 before rounding). The old figures used a different tokenizer on an older 368-decision store.

Measured tools/list payload (FastMCP list_tools, model_dump(by_alias=True, exclude_none=True), tiktoken o200k_base; token counts are serialization-dependent so both serializations are reported):

| Serialization | Before | After |
|---|---|---|
| json.dumps(indent=2) | 6,510 tokens | 6,095 tokens |
| json.dumps(separators=(",", ":")) | 4,757 tokens | 4,342 tokens |

## Test plan

- packages/nauro-core: 1030 passed
- packages/nauro: 1598 passed, 10 skipped
- ruff check and ruff format --check: clean
- test_public_contract.py passes without snapshot regeneration (prose is excluded from the frozen structural contract); test_protocol_drift.py green

## Risk / what to review

- The public-contract snapshot is untouched by design; only description strings changed. Any structural schema diff here would be a defect.
- The retired-wording sweep covers the MCP tool descriptions and the static instructions block. Out of scope and deferred to a follow-up sweep: the bundled subagent bodies, the adopt/ship-task skill bodies (and their installed copies), both CLAUDE.md files, and one runtime assessment string in the propose response still carry the tier vocabulary. Kernel-internal docstrings and tests keep it by design; the tier response field is frozen API shape and stays.
