### PR TITLE
Silence posthog logger so telemetry failures never reach stderr

### DIFF
--- a/packages/nauro/src/nauro/telemetry/client.py
+++ b/packages/nauro/src/nauro/telemetry/client.py
@@ -98,16 +98,11 @@ def get_client() -> Any | None:
             enable_exception_autocapture=False,
             before_send=_before_send,
         )
-        # posthog's client catches transport errors internally and re-emits them
-        # via logging.getLogger("posthog").exception(...) at ERROR level — it does
-        # NOT re-raise, so capture()'s try/except can't suppress them. Left alone,
-        # a network failure (offline, or a sandboxed agent with no DNS) dumps a
-        # full traceback to stderr even though the CLI command succeeds. CRITICAL
-        # keeps those failures silent while letting telemetry send normally where
-        # the network is reachable. Two ordering constraints: run it AFTER
-        # Posthog.__init__ (which resets this logger to WARNING), and set it BEFORE
-        # publishing _client so no other thread can observe the client and emit
-        # through the still-WARNING logger before the override lands.
+        # posthog swallows transport errors internally and logs them at ERROR via
+        # the "posthog" logger, so capture()'s try/except never sees them and a
+        # network failure would traceback to stderr. Ordering is load-bearing:
+        # AFTER Posthog() (its __init__ resets this logger to WARNING) and BEFORE
+        # publishing _client (so no thread emits through the still-WARNING logger).
         logging.getLogger("posthog").setLevel(logging.CRITICAL)
         _client = client
     return _client

--- a/packages/nauro/src/nauro/telemetry/client.py
+++ b/packages/nauro/src/nauro/telemetry/client.py
@@ -13,6 +13,7 @@ surface in a short-lived process the user is watching exit.
 
 from __future__ import annotations
 
+import logging
 import os
 import threading
 from typing import Any
@@ -89,7 +90,7 @@ def get_client() -> Any | None:
             return _client
         from posthog import Posthog
 
-        _client = Posthog(
+        client = Posthog(
             project_api_key=key,
             host=POSTHOG_HOST,
             sync_mode=True,
@@ -97,4 +98,16 @@ def get_client() -> Any | None:
             enable_exception_autocapture=False,
             before_send=_before_send,
         )
+        # posthog's client catches transport errors internally and re-emits them
+        # via logging.getLogger("posthog").exception(...) at ERROR level — it does
+        # NOT re-raise, so capture()'s try/except can't suppress them. Left alone,
+        # a network failure (offline, or a sandboxed agent with no DNS) dumps a
+        # full traceback to stderr even though the CLI command succeeds. CRITICAL
+        # keeps those failures silent while letting telemetry send normally where
+        # the network is reachable. Two ordering constraints: run it AFTER
+        # Posthog.__init__ (which resets this logger to WARNING), and set it BEFORE
+        # publishing _client so no other thread can observe the client and emit
+        # through the still-WARNING logger before the override lands.
+        logging.getLogger("posthog").setLevel(logging.CRITICAL)
+        _client = client
     return _client

--- a/packages/nauro/tests/test_telemetry_module.py
+++ b/packages/nauro/tests/test_telemetry_module.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+import logging
 import socket
 import sys
 from unittest.mock import patch
@@ -229,6 +230,41 @@ def test_get_client_none_with_placeholder_baked_key(nauro_home, monkeypatch):
     monkeypatch.setattr(client_mod, "_BAKED_PROJECT_KEY", "phc_REPLACE_WITH_PROD_KEY")
 
     assert client_mod.get_client() is None
+
+
+def test_get_client_silences_posthog_logger(nauro_home, monkeypatch):
+    """get_client() pins the "posthog" logger to CRITICAL after construction.
+
+    posthog catches transport errors internally and logs them at ERROR via the
+    "posthog" logger without re-raising, so capture()'s try/except can't stop a
+    full traceback from reaching stderr when the network is unreachable (offline,
+    or a sandboxed agent). The override must land AFTER Posthog(), which itself
+    resets the logger to WARNING — so a fake constructor that mimics that reset
+    guards the ordering as well as the final level.
+    """
+    import nauro.telemetry.client as client_mod
+
+    monkeypatch.delenv("NAURO_POSTHOG_KEY", raising=False)
+    monkeypatch.setattr(client_mod, "_BAKED_PROJECT_KEY", _REALISTIC_BAKED_KEY)
+
+    posthog_logger = logging.getLogger("posthog")
+    original_level = posthog_logger.level
+    posthog_logger.setLevel(logging.NOTSET)
+
+    def _fake_posthog(**kwargs):
+        # Mimic Posthog.__init__ pinning its logger to WARNING; the override in
+        # get_client() must run after this to win.
+        posthog_logger.setLevel(logging.WARNING)
+        return object()
+
+    monkeypatch.setattr("posthog.Posthog", _fake_posthog)
+
+    try:
+        client_mod.get_client()
+        assert posthog_logger.level == logging.CRITICAL
+    finally:
+        # Restore the process-global logger level so this test doesn't leak state.
+        posthog_logger.setLevel(original_level)
 
 
 def test_should_emit_false_under_shipped_placeholder(nauro_home, monkeypatch):

--- a/packages/nauro/tests/test_telemetry_module.py
+++ b/packages/nauro/tests/test_telemetry_module.py
@@ -235,12 +235,10 @@ def test_get_client_none_with_placeholder_baked_key(nauro_home, monkeypatch):
 def test_get_client_silences_posthog_logger(nauro_home, monkeypatch):
     """get_client() pins the "posthog" logger to CRITICAL after construction.
 
-    posthog catches transport errors internally and logs them at ERROR via the
-    "posthog" logger without re-raising, so capture()'s try/except can't stop a
-    full traceback from reaching stderr when the network is unreachable (offline,
-    or a sandboxed agent). The override must land AFTER Posthog(), which itself
-    resets the logger to WARNING — so a fake constructor that mimics that reset
-    guards the ordering as well as the final level.
+    posthog logs swallowed transport errors at ERROR via this logger, so only
+    the level override keeps tracebacks off stderr. The fake constructor mimics
+    Posthog.__init__ resetting the logger to WARNING, so the assert also guards
+    the after-construction ordering.
     """
     import nauro.telemetry.client as client_mod
 
@@ -252,9 +250,7 @@ def test_get_client_silences_posthog_logger(nauro_home, monkeypatch):
     posthog_logger.setLevel(logging.NOTSET)
 
     def _fake_posthog(**kwargs):
-        # Mimic Posthog.__init__ pinning its logger to WARNING; the override in
-        # get_client() must run after this to win.
-        posthog_logger.setLevel(logging.WARNING)
+        posthog_logger.setLevel(logging.WARNING)  # mimic Posthog.__init__'s reset
         return object()
 
     monkeypatch.setattr("posthog.Posthog", _fake_posthog)
@@ -263,7 +259,28 @@ def test_get_client_silences_posthog_logger(nauro_home, monkeypatch):
         client_mod.get_client()
         assert posthog_logger.level == logging.CRITICAL
     finally:
-        # Restore the process-global logger level so this test doesn't leak state.
+        posthog_logger.setLevel(original_level)
+
+
+def test_get_client_pins_real_posthog_logger(nauro_home, monkeypatch):
+    """Same guard as above, against the real Posthog constructor.
+
+    The fake in the ordering test mirrors today's Posthog.__init__; this one
+    fails if a future posthog release changes how it configures the "posthog"
+    logger. Safe without network: sync_mode=True means no consumer threads and
+    __init__ performs no I/O.
+    """
+    import nauro.telemetry.client as client_mod
+
+    monkeypatch.delenv("NAURO_POSTHOG_KEY", raising=False)
+    monkeypatch.setattr(client_mod, "_BAKED_PROJECT_KEY", _REALISTIC_BAKED_KEY)
+
+    posthog_logger = logging.getLogger("posthog")
+    original_level = posthog_logger.level
+    try:
+        assert client_mod.get_client() is not None
+        assert posthog_logger.level == logging.CRITICAL
+    finally:
         posthog_logger.setLevel(original_level)
 
 


### PR DESCRIPTION
## Why

When telemetry is opted-in and the PostHog host is unreachable — offline, behind a firewall/proxy, during a PostHog outage, or inside a sandboxed agent with no DNS — every `nauro` command printed a full multi-frame traceback to stderr, even though the command itself succeeded. For a tool consumed by AI coding agents this is more than cosmetic: an agent parsing the output can read the traceback as a command failure and act on it.

## What changed

`get_client()` now pins the `posthog` logger to CRITICAL. The posthog SDK catches transport errors internally and re-emits them via `logging.getLogger("posthog").exception(...)` at ERROR without re-raising, so `capture()`'s existing `try/except` never sees them and they fall through to Python's last-resort handler. Silencing the SDK logger closes the one remaining gap in the "telemetry is best-effort and never disrupts the CLI" contract. Telemetry still sends normally where the network is reachable.

Ordering is load-bearing and documented in-code: the override runs after `Posthog()` (which resets the logger to WARNING) and before the client singleton is published (so no other thread can observe the client and emit through the still-WARNING logger).

## Test plan

- `test_get_client_silences_posthog_logger` guards both the final level and the ordering — a fake constructor mimics posthog's WARNING reset, so moving the override before construction flips the result to WARNING and fails the test.
- `test_get_client_pins_real_posthog_logger` runs the same guard against the real `Posthog` constructor, so a future posthog release changing how it configures its logger fails the suite rather than silently reopening the stderr leak. Safe without network: `sync_mode=True` means no consumer threads and `__init__` performs no I/O.
- Full nauro suite: 1600 passed, 10 skipped. `ruff check` and `ruff format --check` clean on the changed files.