### PR TITLE
Add cross-store pooling certifier and v2 summary schema

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -52,8 +52,44 @@ consolidation fan, and emits schema-valid JSON. It asserts nothing about
 catch, rank, or score; green CI means the tool runs, not that retrieval
 quality is verified.
 
+## Cross-store pooling
+
+A single store is years from the high-stakes surfacing lower bound; the only
+path to the emit tier is pooling the measurement across independently operated
+stores. `pool_certify.py` does that pooling and certification, stdlib-only:
+
+```bash
+python benchmarks/pool_certify.py --manifest pool.json --pooling-operator me
+python benchmarks/pool_certify.py --manifest pool.json --pooling-operator me \
+    --json-out report.json
+```
+
+Its inputs are the privacy-preserving schema-v2 summaries that
+`retrieval_bench.py --summary-out` emits (counts and bounds only, never store
+text). The manifest lists contributions, each pairing a summary JSON with a
+consent record (operator, attestor, a hash linking the consent to the summary's
+fingerprint, date, scope, revocation terms). Contributions pool only within a
+stratum keyed on firing class, battery hash, bench major version, and g version.
+
+Each stratum lands on one of three verdicts:
+
+- **CERTIFIED** — every pre-registered gate clears (pooled and leave-one-store-out
+  precision lower bounds, coverage, exposure, minimum pooled fires, a breadth
+  floor on stores/operators/attestors, and dual attestation).
+- **HETEROGENEOUS** — the stores disagree (the homogeneity test rejects at the
+  Holm-adjusted alpha); there is no pooled claim and no post-hoc re-stratification
+  to rescue it.
+- **UNATTAINABLE** — stay dark; the bar is not met on this pool.
+
+The pre-registered floors live pinned in code and are never echoed into a report;
+reports carry booleans and measured bounds only.
+
 ## Data posture
 
 The tool and its generic batteries are public. Anything derived from a real
 store (conflict events, paraphrases of decisions, replayed traffic) stays
 private with the store. No store content is ever committed here.
+
+No collection is authorized. `pool_certify.py` never fetches anything: summaries
+are exchanged by hand as attested artifacts under written consent, and pooling
+runs only over what an operator was given directly.

--- a/benchmarks/_stats.py
+++ b/benchmarks/_stats.py
@@ -1,0 +1,384 @@
+"""Pure-stdlib statistical primitives for the retrieval benchmark and the
+cross-store certifier.
+
+No scipy, no numpy: every function takes only integer/float counts, never store
+text, so the whole module is safe to exercise in CI. ``retrieval_bench.py`` and
+``pool_certify.py`` both import from here; keeping the Wilson / Clopper-Pearson /
+homogeneity math in one place means the per-store measurement and the cross-store
+pool cannot drift apart. The per-store primitives (Wilson, Clopper-Pearson, the
+rule of three, exact McNemar, Holm) were factored out of ``retrieval_bench.py``
+unchanged; the homogeneity test and the beta-binomial bound are added for the
+cross-store pool.
+
+Every proportion m/n is reported with an asymmetric lower bound; the gate reads
+the LOWER bound, never the point estimate.
+"""
+
+from __future__ import annotations
+
+import math
+
+# 97.5th percentile of the standard normal (two-sided 95%).
+_Z_95 = 1.959963984540054
+
+
+def wilson_lower(k: int, n: int, z: float = _Z_95) -> float:
+    """Wilson score lower bound for a binomial proportion k/n.
+
+    Closed-form; the asymmetric interval the small-N gate needs. Returns 0.0
+    for n == 0 (no evidence bounds nothing).
+    """
+    if n == 0:
+        return 0.0
+    p = k / n
+    z2 = z * z
+    denom = 1.0 + z2 / n
+    center = p + z2 / (2 * n)
+    margin = z * math.sqrt(p * (1 - p) / n + z2 / (4 * n * n))
+    return max(0.0, (center - margin) / denom)
+
+
+def _betacf(a: float, b: float, x: float) -> float:
+    """Continued-fraction expansion for the incomplete beta (Lentz)."""
+    fpmin = 1e-300
+    qab, qap, qam = a + b, a + 1.0, a - 1.0
+    c = 1.0
+    d = 1.0 - qab * x / qap
+    if abs(d) < fpmin:
+        d = fpmin
+    d = 1.0 / d
+    h = d
+    for m in range(1, 201):
+        m2 = 2 * m
+        aa = m * (b - m) * x / ((qam + m2) * (a + m2))
+        d = 1.0 + aa * d
+        if abs(d) < fpmin:
+            d = fpmin
+        c = 1.0 + aa / c
+        if abs(c) < fpmin:
+            c = fpmin
+        d = 1.0 / d
+        h *= d * c
+        aa = -(a + m) * (qab + m) * x / ((a + m2) * (qap + m2))
+        d = 1.0 + aa * d
+        if abs(d) < fpmin:
+            d = fpmin
+        c = 1.0 + aa / c
+        if abs(c) < fpmin:
+            c = fpmin
+        d = 1.0 / d
+        delta = d * c
+        h *= delta
+        if abs(delta - 1.0) < 3e-16:
+            break
+    return h
+
+
+def _betai(a: float, b: float, x: float) -> float:
+    """Regularized incomplete beta I_x(a, b) via the continued fraction."""
+    if x <= 0.0:
+        return 0.0
+    if x >= 1.0:
+        return 1.0
+    lbeta = math.lgamma(a) + math.lgamma(b) - math.lgamma(a + b)
+    front = math.exp(a * math.log(x) + b * math.log(1.0 - x) - lbeta)
+    if x < (a + 1.0) / (a + b + 2.0):
+        return front * _betacf(a, b, x) / a
+    return 1.0 - front * _betacf(b, a, 1.0 - x) / b
+
+
+def _beta_ppf(p: float, a: float, b: float) -> float:
+    """Inverse of the regularized incomplete beta by bisection.
+
+    Stdlib-only: scipy's ``beta.ppf`` is the conventional route, but the
+    benchmark holds its dependency footprint to compute-only kernel deps, so
+    the Clopper-Pearson bound is built on this bisection over ``_betai``.
+    """
+    lo, hi = 0.0, 1.0
+    for _ in range(200):
+        mid = (lo + hi) / 2.0
+        if _betai(a, b, mid) < p:
+            lo = mid
+        else:
+            hi = mid
+    return (lo + hi) / 2.0
+
+
+def clopper_pearson_lower(k: int, n: int, alpha: float = 0.05) -> float:
+    """Conservative (exact) Clopper-Pearson lower bound for k/n.
+
+    The lower limit is the (alpha/2)-quantile of Beta(k, n-k+1); 0.0 at k == 0
+    (the rule of three then bounds the true rate, not this interval).
+    """
+    if n == 0 or k == 0:
+        return 0.0
+    if k == n:
+        # Closed form avoids a bisection edge at the boundary: (alpha/2)^(1/n).
+        return (alpha / 2.0) ** (1.0 / n)
+    return _beta_ppf(alpha / 2.0, k, n - k + 1)
+
+
+def rule_of_three_upper(n: int) -> float:
+    """Upper bound on a true rate after 0 observed events in n trials (~3/n).
+
+    The honest reading of a clean run: 0/n does not bound the FP rate at 0, only
+    at roughly 3/n at 95% confidence. Returns 1.0 for n == 0.
+    """
+    return 1.0 if n == 0 else min(1.0, 3.0 / n)
+
+
+def mcnemar_exact_p(b: int, c: int) -> float:
+    """Two-sided exact McNemar p-value for discordant pairs (b, c).
+
+    Binomial test on the discordant cells with p = 1/2. Used to report the
+    rejected-name-indexing catch moves (44->46, 46->47) as not statistically
+    distinguishable: at
+    n = 48 the discordant set is 2-4 items, far short of significance.
+    """
+    n = b + c
+    if n == 0:
+        return 1.0
+    k = min(b, c)
+    tail = sum(math.comb(n, i) for i in range(k + 1)) * (0.5**n)
+    return min(1.0, 2.0 * tail)
+
+
+def holm_reject(pvalues: list[float], alpha: float = 0.05) -> list[bool]:
+    """Holm step-down multiplicity correction over the operating points searched.
+
+    Returns a reject/keep mask aligned with the input order. Holm dominates
+    plain Bonferroni at the same family-wise error rate; both are reported so a
+    post-hoc operating-point search cannot manufacture a significant cell.
+    """
+    m = len(pvalues)
+    if m == 0:
+        return []
+    order = sorted(range(m), key=lambda i: pvalues[i])
+    reject = [False] * m
+    for rank, idx in enumerate(order):
+        if pvalues[idx] <= alpha / (m - rank):
+            reject[idx] = True
+        else:
+            break
+    return reject
+
+
+def required_n_fired(target_lb: float, z: float = _Z_95) -> int:
+    """Smallest perfect-run n whose Wilson lower bound reaches ``target_lb``.
+
+    A first-class output: ~120-150 for a 0.975 lower bound; 48/48 caps at
+    ~0.926, so the high-stakes tier is years away on a single store. Capped to
+    avoid an unbounded loop on an unreachable target.
+    """
+    for n in range(1, 100001):
+        if wilson_lower(n, n, z) >= target_lb:
+            return n
+    return -1
+
+
+# ---------------------------------------------------------------------------
+# Cross-store primitives: added for pool_certify.py. Homogeneity across stores
+# and a random-effects sensitivity bound. Same discipline: counts only, no store
+# text, safe in CI.
+# ---------------------------------------------------------------------------
+
+
+def holm_adjusted(pvalues: list[float]) -> list[float]:
+    """Holm step-down adjusted p-values, aligned with the input order.
+
+    The multiplicity-corrected companion to ``holm_reject``: a hypothesis is
+    rejected at level alpha iff its adjusted p-value is <= alpha. Adjusted values
+    are made monotone non-decreasing along the sorted order, so the reject set is
+    nested and the two functions agree on the same family.
+    """
+    m = len(pvalues)
+    if m == 0:
+        return []
+    order = sorted(range(m), key=lambda i: pvalues[i])
+    adjusted = [0.0] * m
+    running = 0.0
+    for rank, idx in enumerate(order):
+        running = max(running, (m - rank) * pvalues[idx])
+        adjusted[idx] = min(1.0, running)
+    return adjusted
+
+
+def _gser(a: float, x: float) -> float:
+    """Series expansion of the regularized lower incomplete gamma P(a, x)."""
+    if x <= 0.0:
+        return 0.0
+    gln = math.lgamma(a)
+    ap = a
+    total = 1.0 / a
+    delta = total
+    for _ in range(1000):
+        ap += 1.0
+        delta *= x / ap
+        total += delta
+        if abs(delta) < abs(total) * 1e-15:
+            break
+    return total * math.exp(-x + a * math.log(x) - gln)
+
+
+def _gcf(a: float, x: float) -> float:
+    """Continued fraction for the regularized upper incomplete gamma Q(a, x)."""
+    fpmin = 1e-300
+    gln = math.lgamma(a)
+    b = x + 1.0 - a
+    c = 1.0 / fpmin
+    d = 1.0 / b
+    h = d
+    for i in range(1, 1000):
+        an = -i * (i - a)
+        b += 2.0
+        d = an * d + b
+        if abs(d) < fpmin:
+            d = fpmin
+        c = b + an / c
+        if abs(c) < fpmin:
+            c = fpmin
+        d = 1.0 / d
+        delta = d * c
+        h *= delta
+        if abs(delta - 1.0) < 1e-15:
+            break
+    return math.exp(-x + a * math.log(x) - gln) * h
+
+
+def chi_square_sf(x: float, df: int) -> float:
+    """Upper-tail (survival) probability of the chi-square distribution.
+
+    Regularized upper incomplete gamma Q(df/2, x/2), computed by series below the
+    turning point and continued fraction above it (Numerical Recipes routing).
+    Stdlib-only replacement for ``scipy.stats.chi2.sf``.
+    """
+    if x <= 0.0:
+        return 1.0
+    a = df / 2.0
+    y = x / 2.0
+    if y < a + 1.0:
+        return 1.0 - _gser(a, y)
+    return _gcf(a, y)
+
+
+def _fisher_freeman_halton(counts: list[tuple[int, int]]) -> float:
+    """Exact homogeneity p-value for a 2xS table by enumeration of the margins.
+
+    ``counts`` is the per-store (successes, trials) list; the table has two rows
+    (success / failure) and one column per store, with all margins fixed. The
+    p-value is the summed hypergeometric probability of every table at least as
+    extreme (probability <= the observed table's, within a floating tolerance) as
+    the observed one. Only reached when a cell's expected count is too small for
+    the chi-square approximation, which bounds the enumeration.
+    """
+    col_sums = [n for _, n in counts]
+    r1 = sum(k for k, _ in counts)
+    total = sum(col_sums)
+    r2 = total - r1
+    const = (
+        math.lgamma(r1 + 1)
+        + math.lgamma(r2 + 1)
+        + sum(math.lgamma(c + 1) for c in col_sums)
+        - math.lgamma(total + 1)
+    )
+
+    def log_prob(top: list[int]) -> float:
+        s = const
+        for a, c in zip(top, col_sums, strict=True):
+            s -= math.lgamma(a + 1) + math.lgamma(c - a + 1)
+        return s
+
+    observed = [k for k, _ in counts]
+    log_threshold = log_prob(observed) + math.log1p(1e-7)
+
+    n_cols = len(col_sums)
+    suffix = [0] * (n_cols + 1)
+    for j in range(n_cols - 1, -1, -1):
+        suffix[j] = suffix[j + 1] + col_sums[j]
+
+    accumulated = 0.0
+
+    def walk(j: int, remaining: int, acc_penalty: float) -> None:
+        nonlocal accumulated
+        if j == n_cols:
+            if remaining == 0:
+                logp = const + acc_penalty
+                if logp <= log_threshold:
+                    accumulated += math.exp(logp)
+            return
+        c = col_sums[j]
+        lo = max(0, remaining - suffix[j + 1])
+        hi = min(c, remaining)
+        for a in range(lo, hi + 1):
+            penalty = -(math.lgamma(a + 1) + math.lgamma(c - a + 1))
+            walk(j + 1, remaining - a, acc_penalty + penalty)
+
+    walk(0, r1, 0.0)
+    return min(1.0, accumulated)
+
+
+def homogeneity_p(counts: list[tuple[int, int]]) -> float:
+    """Homogeneity p-value across per-store 2xS outcome tables.
+
+    ``counts`` is the per-store (successes, trials) list. Tests the null that the
+    success proportion is identical across all stores, i.e. that the pool is one
+    binomial rather than a mix. Uses the Pearson chi-square test of homogeneity
+    when every expected cell count clears the asymptotic threshold, and the exact
+    Fisher-Freeman-Halton test (enumeration over fixed margins) otherwise. Returns
+    1.0 when there is nothing to test (fewer than two informative stores, or a
+    degenerate all-success / all-failure margin).
+    """
+    counts = [(int(k), int(n)) for k, n in counts if n > 0]
+    if len(counts) < 2:
+        return 1.0
+    total = sum(n for _, n in counts)
+    r1 = sum(k for k, _ in counts)
+    r2 = total - r1
+    if r1 == 0 or r2 == 0:
+        return 1.0
+    min_expected = min(min(r1 * n / total, r2 * n / total) for _, n in counts)
+    if min_expected >= 5.0:
+        chi2 = 0.0
+        for k, n in counts:
+            for obs, row_sum in ((k, r1), (n - k, r2)):
+                exp = row_sum * n / total
+                chi2 += (obs - exp) ** 2 / exp
+        return chi_square_sf(chi2, len(counts) - 1)
+    return _fisher_freeman_halton(counts)
+
+
+def _wilson_lower_float(p: float, n: float, z: float = _Z_95) -> float:
+    """Wilson score lower bound at a continuous effective sample size n."""
+    if n <= 0.0:
+        return 0.0
+    z2 = z * z
+    denom = 1.0 + z2 / n
+    center = p + z2 / (2 * n)
+    margin = z * math.sqrt(p * (1 - p) / n + z2 / (4 * n * n))
+    return max(0.0, (center - margin) / denom)
+
+
+def beta_binomial_lower(counts: list[tuple[int, int]], z: float = _Z_95) -> float:
+    """Random-effects (beta-binomial) lower bound on the pooled success rate.
+
+    A sensitivity read that widens the pooled interval for between-store
+    overdispersion, so a pool whose stores disagree is not judged on a
+    fixed-effect interval that assumes they are exchangeable draws from one
+    binomial. Moment-based and stdlib-only: the quasi-binomial Pearson dispersion
+    phi across stores discounts the pooled sample size to an effective n/phi, and
+    the Wilson lower bound is taken at that effective n. Reduces to the plain
+    Wilson lower bound when the stores are homogeneous (phi <= 1). This is a
+    reported sensitivity bound, never a gate; it is not a full posterior.
+    """
+    counts = [(int(k), int(n)) for k, n in counts if n > 0]
+    total = sum(n for _, n in counts)
+    if total == 0:
+        return 0.0
+    k_total = sum(k for k, _ in counts)
+    p = k_total / total
+    if p <= 0.0 or p >= 1.0 or len(counts) < 2:
+        # No usable dispersion signal; fall back to the fixed-effect bound.
+        return _wilson_lower_float(p, float(total), z)
+    chi2 = sum((k - n * p) ** 2 / (n * p * (1.0 - p)) for k, n in counts)
+    phi = max(1.0, chi2 / (len(counts) - 1))
+    return _wilson_lower_float(p, total / phi, z)

--- a/benchmarks/pool_certify.py
+++ b/benchmarks/pool_certify.py
@@ -1,0 +1,437 @@
+"""Cross-store pooler / certifier for retrieval-benchmark surfacing summaries.
+
+Out-of-package developer tooling, stdlib-only. It takes the privacy-preserving
+schema-v2 summaries that ``retrieval_bench.py --summary-out`` emits (counts and
+bounds only, never store text), pools them across independently operated stores,
+and reports whether the pooled surfacing claim clears the pre-registered
+feasibility bar. A single store is years from the high-stakes lower bound; the
+only path to the emit tier is pooling across stores, and pooling is only sound
+if the contributions are homogeneous, consented, and broadly sourced. This tool
+mechanizes that check. It never collects: summaries are exchanged by hand as
+attested artifacts under written consent (see benchmarks/README.md).
+
+Inputs (all under the operator's control, none fetched):
+
+  --manifest <json>   A manifest listing contributions. Each contribution pairs
+                      a summary JSON path with a consent-record JSON path:
+                        {"contributions": [
+                           {"summary": "a.json", "consent": "a.consent.json"},
+                           ...]}
+  --pooling-operator  Identity of the operator running the pool (needed for the
+                      dual-attestation gate).
+  --json-out <path>   Write the machine report here; human-readable stdout
+                      otherwise.
+
+A consent record is a JSON object:
+  {"operator": ..., "attestor": ..., "fingerprint_hash": <sha256 hex over the
+   canonical JSON of the summary's fingerprint>, "date": ..., "scope": ...,
+   "revocation_terms": ...}
+
+Stratification key: (firing class, battery_hash, bench major version, g version).
+Contributions only pool within a stratum; a mismatched battery or bench major
+lands in a different stratum, never blended.
+
+Verdicts (per stratum): HETEROGENEOUS (the stores disagree; no pooled claim, and
+no post-hoc re-stratification to rescue it), CERTIFIED (every pre-registered
+gate clears), or UNATTAINABLE (stay dark). The pre-registered floors live in the
+private constants block below and are NEVER echoed into any output -- reports
+carry booleans and measured bounds only, mirroring retrieval_bench.py.
+
+Usage:
+    python benchmarks/pool_certify.py --manifest pool.json --pooling-operator me
+    python benchmarks/pool_certify.py --manifest pool.json --pooling-operator me \
+        --json-out report.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+from _stats import (
+    beta_binomial_lower,
+    clopper_pearson_lower,
+    holm_adjusted,
+    homogeneity_p,
+    wilson_lower,
+)
+
+POOL_CERTIFY_VERSION = "1"
+
+# ---------------------------------------------------------------------------
+# Pre-registered certification constants. PRIVATE and pinned in code: they are
+# the bar the pooled claim must clear, fixed before any pool is assembled, and
+# they are NEVER written into a report. Only the pass/fail booleans and the
+# measured bounds cross into any output -- the same posture retrieval_bench.py
+# holds for its feasibility floors, so a report can be shared without leaking
+# the threshold a future baseline reads against.
+# ---------------------------------------------------------------------------
+
+# Surfacing-precision floor: the developer alert-fatigue floor (pooled + LOSO).
+_PRECISION_LB_FLOOR = 0.90
+# Minimum coverage (fired / candidate-conflicts) lower bound the pool must hold.
+_C_MIN = 0.30
+# Maximum exposure (wrong-flags per artifact reviewed) the trust budget allows.
+_E_MAX = 0.05
+# Family-wise alpha for the homogeneity test (Holm-adjusted across strata).
+_ALPHA = 0.05
+# Minimum pooled n_fired before any pooled precision claim is admissible.
+_MIN_POOLED_FIRED = 30
+# Breadth floor: independent sourcing the pooled claim must rest on.
+_MIN_STORES = 3
+_MIN_OPERATORS = 3
+_MIN_ATTESTORS = 2
+# Pinned bench-major compatibility range: only these majors pool together.
+_BENCH_COMPAT_MAJORS = frozenset({"1"})
+
+# The firing classes a summary reports; each seeds its own stratum.
+_FIRING_CLASSES = ("forward", "reverse_only", "cross_vocabulary")
+
+# Fingerprint keys a v2 summary must carry to be poolable, including the
+# operator-attested certification record.
+_REQUIRED_FINGERPRINT_KEYS = (
+    "bench_version",
+    "battery_hash",
+    "last_attested_date",
+    "last_attested_operator",
+)
+
+
+def _canonical(obj: object) -> str:
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"))
+
+
+def fingerprint_hash(summary: dict) -> str:
+    """SHA-256 over the canonical JSON of the summary's fingerprint.
+
+    The store identity used for breadth counting and the value a consent record
+    hash-links against. Deterministic key ordering so two operators hashing the
+    same fingerprint agree.
+    """
+    return hashlib.sha256(_canonical(summary["fingerprint"]).encode("utf-8")).hexdigest()
+
+
+def _bench_major(bench_version: str) -> str:
+    return str(bench_version).split(".")[0]
+
+
+def _g_version(fingerprint: dict) -> str:
+    """The g-predicate structural version for stratification.
+
+    Read from ``fingerprint.g_version`` when the summary carries one; otherwise
+    derived from the bench major version, since g's structure is versioned in
+    lockstep with the benchmark until it is cut loose on its own tag.
+    """
+    explicit = fingerprint.get("g_version")
+    if explicit:
+        return str(explicit)
+    return _bench_major(fingerprint.get("bench_version", ""))
+
+
+def admit(summary: dict, consent: dict) -> str | None:
+    """Mechanical admissibility check. Returns None if admissible, else a reason.
+
+    All gates are structural and must pass for the contribution to enter a
+    stratum. Every rejection carries a message a human can act on.
+    """
+    if summary.get("summary_schema_version") != "2":
+        got = summary.get("summary_schema_version")
+        return f"summary_schema_version is {got!r}, not '2' (v1 summaries are not certifiable)"
+    fp = summary.get("fingerprint")
+    if not isinstance(fp, dict):
+        return "summary is missing its fingerprint object"
+    for key in _REQUIRED_FINGERPRINT_KEYS:
+        if fp.get(key) in (None, ""):
+            return f"fingerprint is incomplete: {key!r} is missing or empty"
+    top_battery = summary.get("battery_hash")
+    if not top_battery or top_battery != fp.get("battery_hash"):
+        return "battery_hash missing or inconsistent between summary and fingerprint"
+    if _bench_major(fp["bench_version"]) not in _BENCH_COMPAT_MAJORS:
+        return f"bench_version {fp['bench_version']!r} is outside the pinned compatibility range"
+    for key in ("operator", "attestor", "fingerprint_hash"):
+        if not consent.get(key):
+            return f"consent record is missing {key!r}"
+    if consent["fingerprint_hash"] != fingerprint_hash(summary):
+        return "consent record is not hash-linked to the summary fingerprint"
+    art = summary.get("artifact_regime")
+    if not isinstance(art, dict) or "per_class_cell_sizes" not in art or "exposure" not in art:
+        # A structure-only run emits a v2 summary with no artifact regime; it
+        # carries no cells to pool and cannot enter a stratum.
+        return "summary carries no artifact_regime measurement to pool"
+    return None
+
+
+def _stratum_key(firing_class: str, summary: dict) -> tuple[str, str, str, str]:
+    fp = summary["fingerprint"]
+    return (
+        firing_class,
+        fp["battery_hash"],
+        _bench_major(fp["bench_version"]),
+        _g_version(fp),
+    )
+
+
+def _cp_lower_over(members: list[dict]) -> float:
+    k = sum(m["surfacing_hits"] for m in members)
+    n = sum(m["fired"] for m in members)
+    return clopper_pearson_lower(k, n)
+
+
+def _loso_min_cp_lower(members: list[dict]) -> float:
+    """Minimum pooled Clopper-Pearson lower bound over leave-one-store-out pools.
+
+    Distinct stores (by fingerprint hash) are dropped one at a time; the pooled
+    CP lower bound is recomputed on each remainder and the minimum is returned.
+    A pool that only clears the floor because one generous store carries it fails
+    here. Returns 0.0 when fewer than two stores leave nothing to hold out.
+    """
+    by_store: dict[str, list[dict]] = {}
+    for m in members:
+        by_store.setdefault(m["store"], []).append(m)
+    stores = list(by_store)
+    if len(stores) < 2:
+        return 0.0
+    worst = 1.0
+    for dropped in stores:
+        remainder = [m for s in stores if s != dropped for m in by_store[s]]
+        worst = min(worst, _cp_lower_over(remainder))
+    return worst
+
+
+def _build_stratum_report(
+    key: tuple[str, str, str, str],
+    members: list[dict],
+    homogeneity_raw: float,
+    homogeneity_adj: float,
+    pooling_operator: str | None,
+) -> dict:
+    firing_class, battery_hash, bench_major, g_version = key
+
+    pooled_k = sum(m["surfacing_hits"] for m in members)
+    pooled_n = sum(m["fired"] for m in members)
+    coverage_k = sum(m["fired"] for m in members)
+    coverage_n = sum(m["candidate"] for m in members)
+
+    stores = sorted({m["store"] for m in members})
+    operators = sorted({m["operator"] for m in members})
+    attestors = sorted({m["attestor"] for m in members})
+
+    exposure_wrong = sum(m["wrong_fires"] for m in members)
+    exposure_reviewed = sum(m["artifacts_reviewed"] for m in members)
+    exposure_rate = exposure_wrong / exposure_reviewed if exposure_reviewed else None
+
+    cp_lower = clopper_pearson_lower(pooled_k, pooled_n)
+    coverage_cp_lower = clopper_pearson_lower(coverage_k, coverage_n)
+    loso_min = _loso_min_cp_lower(members)
+    bb_lower = beta_binomial_lower([(m["surfacing_hits"], m["fired"]) for m in members])
+
+    homogeneous = homogeneity_adj > _ALPHA
+    dual_attestation = pooling_operator is not None and any(
+        op != pooling_operator for op in operators
+    )
+    checks = {
+        "homogeneous": homogeneous,
+        "cp_lower_ge_floor": cp_lower >= _PRECISION_LB_FLOOR,
+        "coverage_lower_ge_c_min": coverage_cp_lower >= _C_MIN,
+        "exposure_le_e_max": exposure_rate is not None and exposure_rate <= _E_MAX,
+        "pooled_fired_ge_min": pooled_n >= _MIN_POOLED_FIRED,
+        "breadth_stores": len(stores) >= _MIN_STORES,
+        "breadth_operators": len(operators) >= _MIN_OPERATORS,
+        "breadth_attestors": len(attestors) >= _MIN_ATTESTORS,
+        "dual_attestation": dual_attestation,
+        "loso_min_ge_floor": loso_min >= _PRECISION_LB_FLOOR,
+    }
+
+    if not homogeneous:
+        verdict = "HETEROGENEOUS"
+    elif all(checks.values()):
+        verdict = "CERTIFIED"
+    else:
+        verdict = "UNATTAINABLE"
+
+    return {
+        "firing_class": firing_class,
+        "battery_hash": battery_hash,
+        "bench_major": bench_major,
+        "g_version": g_version,
+        "pooled": {"k": pooled_k, "n": pooled_n},
+        "cp_lower": round(cp_lower, 4),
+        "wilson_lower": round(wilson_lower(pooled_k, pooled_n), 4),
+        "coverage": {
+            "k": coverage_k,
+            "n": coverage_n,
+            "cp_lower": round(coverage_cp_lower, 4),
+            "wilson_lower": round(wilson_lower(coverage_k, coverage_n), 4),
+        },
+        "exposure_rate": round(exposure_rate, 4) if exposure_rate is not None else None,
+        "homogeneity_p": round(homogeneity_raw, 6),
+        "homogeneity_p_adjusted": round(homogeneity_adj, 6),
+        "loso_min_cp_lower": round(loso_min, 4),
+        # Reported sensitivity read only; the verdict never reads this.
+        "beta_binomial_lower": round(bb_lower, 4),
+        "n_stores": len(stores),
+        "n_operators": len(operators),
+        "n_attestors": len(attestors),
+        "fingerprint_hashes": stores,
+        "checks": checks,
+        "verdict": verdict,
+    }
+
+
+def build_report(contributions: list[dict], pooling_operator: str | None = None) -> dict:
+    """Pool and certify a list of loaded contributions.
+
+    Each contribution is a dict ``{"summary": <dict>, "consent": <dict>}`` with
+    an optional ``"source"`` label for reporting. Runs admissibility, stratifies
+    the admissible ones, computes each stratum, and applies the Holm correction
+    to the family of homogeneity p-values across strata before the verdicts.
+
+    Structure-only by design: takes already-loaded dicts so callers (and the
+    CI smoke) can pool fabricated counts without any file or store I/O.
+    """
+    rejected: list[dict] = []
+    strata: dict[tuple[str, str, str, str], list[dict]] = {}
+
+    for contribution in contributions:
+        summary = contribution["summary"]
+        consent = contribution["consent"]
+        source = contribution.get("source")
+        reason = admit(summary, consent)
+        if reason is not None:
+            rejected.append({"source": source, "reason": reason})
+            continue
+        store = fingerprint_hash(summary)
+        cells = summary["artifact_regime"]["per_class_cell_sizes"]
+        exposure = summary["artifact_regime"]["exposure"]
+        for firing_class in _FIRING_CLASSES:
+            cell = cells.get(firing_class)
+            if cell is None:
+                continue
+            member = {
+                "store": store,
+                "operator": consent["operator"],
+                "attestor": consent["attestor"],
+                "surfacing_hits": cell["surfacing_hits"],
+                "fired": cell["fired"],
+                "candidate": cell["candidate"],
+                "wrong_fires": exposure["wrong_fires"],
+                "artifacts_reviewed": exposure["artifacts_reviewed"],
+            }
+            strata.setdefault(_stratum_key(firing_class, summary), []).append(member)
+
+    ordered_keys = sorted(strata)
+    raw_p = [
+        homogeneity_p([(m["surfacing_hits"], m["fired"]) for m in strata[key]])
+        for key in ordered_keys
+    ]
+    adj_p = holm_adjusted(raw_p)
+
+    stratum_reports = [
+        _build_stratum_report(key, strata[key], raw, adj, pooling_operator)
+        for key, raw, adj in zip(ordered_keys, raw_p, adj_p, strict=True)
+    ]
+
+    return {
+        "pool_certify_version": POOL_CERTIFY_VERSION,
+        "n_contributions": len(contributions),
+        "n_admissible": len(contributions) - len(rejected),
+        "rejected": rejected,
+        "strata": stratum_reports,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _load_contributions(manifest_path: Path) -> list[dict]:
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    entries = manifest.get("contributions", [])
+    base = manifest_path.parent
+    contributions: list[dict] = []
+    for entry in entries:
+        summary_path = (base / entry["summary"]).expanduser()
+        consent_path = (base / entry["consent"]).expanduser()
+        contributions.append(
+            {
+                "summary": json.loads(summary_path.read_text(encoding="utf-8")),
+                "consent": json.loads(consent_path.read_text(encoding="utf-8")),
+                "source": entry["summary"],
+            }
+        )
+    return contributions
+
+
+def print_report(report: dict) -> None:
+    print(f"pool_certify v{report['pool_certify_version']}")
+    print(
+        f"contributions: {report['n_contributions']} "
+        f"({report['n_admissible']} admissible, {len(report['rejected'])} rejected)"
+    )
+    for row in report["rejected"]:
+        print(f"  rejected {row['source']!r}: {row['reason']}")
+    if not report["strata"]:
+        print("no admissible strata to certify")
+        return
+    for st in report["strata"]:
+        print()
+        print(
+            f"stratum: class={st['firing_class']} battery={st['battery_hash']} "
+            f"bench-major={st['bench_major']} g={st['g_version']}"
+        )
+        print(
+            f"  pooled surfacing {st['pooled']['k']}/{st['pooled']['n']} "
+            f"(CP-LB={st['cp_lower']}, Wilson-LB={st['wilson_lower']})"
+        )
+        print(
+            f"  coverage {st['coverage']['k']}/{st['coverage']['n']} "
+            f"(CP-LB={st['coverage']['cp_lower']}); exposure rate={st['exposure_rate']}"
+        )
+        print(
+            f"  homogeneity p={st['homogeneity_p']} "
+            f"(Holm-adjusted {st['homogeneity_p_adjusted']}); "
+            f"LOSO min CP-LB={st['loso_min_cp_lower']}; "
+            f"beta-binomial LB={st['beta_binomial_lower']} (sensitivity, non-gating)"
+        )
+        print(
+            f"  breadth: {st['n_stores']} stores, {st['n_operators']} operators, "
+            f"{st['n_attestors']} attestors"
+        )
+        failing = [name for name, ok in st["checks"].items() if not ok]
+        print(f"  VERDICT: {st['verdict']}")
+        if st["verdict"] != "CERTIFIED" and failing:
+            print(f"    failing checks: {', '.join(failing)}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument(
+        "--manifest",
+        required=True,
+        type=Path,
+        help="Manifest JSON listing (summary, consent) contribution pairs",
+    )
+    parser.add_argument(
+        "--pooling-operator",
+        help="Identity of the operator running the pool (dual-attestation gate)",
+    )
+    parser.add_argument("--json-out", type=Path, help="Write the machine report JSON here")
+    args = parser.parse_args(argv)
+
+    contributions = _load_contributions(args.manifest.expanduser())
+    report = build_report(contributions, pooling_operator=args.pooling_operator)
+
+    if args.json_out:
+        args.json_out.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+        print(f"wrote {args.json_out}", file=sys.stderr)
+    else:
+        print_report(report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/retrieval_bench.py
+++ b/benchmarks/retrieval_bench.py
@@ -48,18 +48,30 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
-import math
 import sys
 from importlib import metadata
 from pathlib import Path
 
 import bm25s
+from _stats import (
+    clopper_pearson_lower,
+    mcnemar_exact_p,
+    required_n_fired,
+    rule_of_three_upper,
+    wilson_lower,
+)
 from nauro_core.decision_model import Decision, DecisionStatus, parse_decision
 from nauro_core.operations.check_decision import _CHECK_DECISION_STOPWORDS
 from nauro_core.parsing import first_sentence_end
 from nauro_core.search import union_retrieve
 
 BENCH_VERSION = "1"
+# Schema version of the privacy-preserving aggregate summary (build_summary).
+# v2 adds per-class surfacing_hits, the exposure object, and the top-level
+# version tag; pool_certify.py rejects any summary that is not v2. Bumped
+# independently of BENCH_VERSION: the measurement kernel and the exchange
+# envelope version on their own cadences.
+SUMMARY_SCHEMA_VERSION = "2"
 
 # The fixed precision counterweight: generic engineering proposals with no
 # project-private content, committed so contributors can run the precision
@@ -125,171 +137,6 @@ RANK_CUTOFFS = (1, 3, 5, 10)
 def battery_hash() -> str:
     text = "\n".join(NOVEL_BATTERY + OFF_DOMAIN_BATTERY)
     return hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
-
-
-# ---------------------------------------------------------------------------
-# Stage-0 statistics: pure-Python, no scipy. Every proportion m/n is
-# reported with a Wilson and a conservative Clopper-Pearson 95% interval; the
-# gate reads the LOWER bound, never the point estimate. These functions take
-# only counts, never store text, so they are safe to exercise in CI.
-# ---------------------------------------------------------------------------
-
-# 97.5th percentile of the standard normal (two-sided 95%).
-_Z_95 = 1.959963984540054
-
-
-def wilson_lower(k: int, n: int, z: float = _Z_95) -> float:
-    """Wilson score lower bound for a binomial proportion k/n.
-
-    Closed-form; the asymmetric interval the small-N gate needs. Returns 0.0
-    for n == 0 (no evidence bounds nothing).
-    """
-    if n == 0:
-        return 0.0
-    p = k / n
-    z2 = z * z
-    denom = 1.0 + z2 / n
-    center = p + z2 / (2 * n)
-    margin = z * math.sqrt(p * (1 - p) / n + z2 / (4 * n * n))
-    return max(0.0, (center - margin) / denom)
-
-
-def _betacf(a: float, b: float, x: float) -> float:
-    """Continued-fraction expansion for the incomplete beta (Lentz)."""
-    fpmin = 1e-300
-    qab, qap, qam = a + b, a + 1.0, a - 1.0
-    c = 1.0
-    d = 1.0 - qab * x / qap
-    if abs(d) < fpmin:
-        d = fpmin
-    d = 1.0 / d
-    h = d
-    for m in range(1, 201):
-        m2 = 2 * m
-        aa = m * (b - m) * x / ((qam + m2) * (a + m2))
-        d = 1.0 + aa * d
-        if abs(d) < fpmin:
-            d = fpmin
-        c = 1.0 + aa / c
-        if abs(c) < fpmin:
-            c = fpmin
-        d = 1.0 / d
-        h *= d * c
-        aa = -(a + m) * (qab + m) * x / ((a + m2) * (qap + m2))
-        d = 1.0 + aa * d
-        if abs(d) < fpmin:
-            d = fpmin
-        c = 1.0 + aa / c
-        if abs(c) < fpmin:
-            c = fpmin
-        d = 1.0 / d
-        delta = d * c
-        h *= delta
-        if abs(delta - 1.0) < 3e-16:
-            break
-    return h
-
-
-def _betai(a: float, b: float, x: float) -> float:
-    """Regularized incomplete beta I_x(a, b) via the continued fraction."""
-    if x <= 0.0:
-        return 0.0
-    if x >= 1.0:
-        return 1.0
-    lbeta = math.lgamma(a) + math.lgamma(b) - math.lgamma(a + b)
-    front = math.exp(a * math.log(x) + b * math.log(1.0 - x) - lbeta)
-    if x < (a + 1.0) / (a + b + 2.0):
-        return front * _betacf(a, b, x) / a
-    return 1.0 - front * _betacf(b, a, 1.0 - x) / b
-
-
-def _beta_ppf(p: float, a: float, b: float) -> float:
-    """Inverse of the regularized incomplete beta by bisection.
-
-    Stdlib-only: scipy's ``beta.ppf`` is the conventional route, but the
-    benchmark holds its dependency footprint to compute-only kernel deps, so
-    the Clopper-Pearson bound is built on this bisection over ``_betai``.
-    """
-    lo, hi = 0.0, 1.0
-    for _ in range(200):
-        mid = (lo + hi) / 2.0
-        if _betai(a, b, mid) < p:
-            lo = mid
-        else:
-            hi = mid
-    return (lo + hi) / 2.0
-
-
-def clopper_pearson_lower(k: int, n: int, alpha: float = 0.05) -> float:
-    """Conservative (exact) Clopper-Pearson lower bound for k/n.
-
-    The lower limit is the (alpha/2)-quantile of Beta(k, n-k+1); 0.0 at k == 0
-    (the rule of three then bounds the true rate, not this interval).
-    """
-    if n == 0 or k == 0:
-        return 0.0
-    if k == n:
-        # Closed form avoids a bisection edge at the boundary: (alpha/2)^(1/n).
-        return (alpha / 2.0) ** (1.0 / n)
-    return _beta_ppf(alpha / 2.0, k, n - k + 1)
-
-
-def rule_of_three_upper(n: int) -> float:
-    """Upper bound on a true rate after 0 observed events in n trials (~3/n).
-
-    The honest reading of a clean run: 0/n does not bound the FP rate at 0, only
-    at roughly 3/n at 95% confidence. Returns 1.0 for n == 0.
-    """
-    return 1.0 if n == 0 else min(1.0, 3.0 / n)
-
-
-def mcnemar_exact_p(b: int, c: int) -> float:
-    """Two-sided exact McNemar p-value for discordant pairs (b, c).
-
-    Binomial test on the discordant cells with p = 1/2. Used to report the
-    rejected-name-indexing catch moves (44->46, 46->47) as not statistically
-    distinguishable: at
-    n = 48 the discordant set is 2-4 items, far short of significance.
-    """
-    n = b + c
-    if n == 0:
-        return 1.0
-    k = min(b, c)
-    tail = sum(math.comb(n, i) for i in range(k + 1)) * (0.5**n)
-    return min(1.0, 2.0 * tail)
-
-
-def holm_reject(pvalues: list[float], alpha: float = 0.05) -> list[bool]:
-    """Holm step-down multiplicity correction over the operating points searched.
-
-    Returns a reject/keep mask aligned with the input order. Holm dominates
-    plain Bonferroni at the same family-wise error rate; both are reported so a
-    post-hoc operating-point search cannot manufacture a significant cell.
-    """
-    m = len(pvalues)
-    if m == 0:
-        return []
-    order = sorted(range(m), key=lambda i: pvalues[i])
-    reject = [False] * m
-    for rank, idx in enumerate(order):
-        if pvalues[idx] <= alpha / (m - rank):
-            reject[idx] = True
-        else:
-            break
-    return reject
-
-
-def required_n_fired(target_lb: float, z: float = _Z_95) -> int:
-    """Smallest perfect-run n whose Wilson lower bound reaches ``target_lb``.
-
-    A first-class output: ~120-150 for a 0.975 lower bound; 48/48 caps at
-    ~0.926, so the high-stakes tier is years away on a single store. Capped to
-    avoid an unbounded loop on an unreachable target.
-    """
-    for n in range(1, 100001):
-        if wilson_lower(n, n, z) >= target_lb:
-            return n
-    return -1
 
 
 # ---------------------------------------------------------------------------
@@ -1030,16 +877,30 @@ def build_fingerprint(
 
 
 def build_summary(result: dict) -> dict:
-    """Privacy-preserving aggregate SUMMARY: counts and bounds only.
+    """Privacy-preserving aggregate SUMMARY (schema v2): counts and bounds only.
 
-    A second party reproduces the METHOD on their own store from this; it
-    carries NO store text -- no titles, no rationale, no false-fire transcript,
-    no query strings. Only n_fired, m/n counts, interval lower bounds, per-class
-    cell sizes, battery_hash, and the fingerprint cross into it.
+    A second party reproduces the METHOD on their own store from this, and
+    pool_certify.py pools it across stores. It carries NO store text -- no
+    titles, no rationale, no false-fire transcript, no query strings. Only
+    n_fired, m/n counts, interval lower bounds, per-class cell sizes,
+    battery_hash, and the fingerprint cross into it.
+
+    Schema invariant (the exchange contract pool_certify.py depends on): the
+    summary must never contain rejected-alternative tokens or any per-token
+    sketches, hashes, or digests of a store's lexicon; only counts, bounds,
+    versions, and the fingerprint. The top-level key set is closed -- a new
+    field is a schema change, not an incremental add -- so a store-text leak
+    cannot ride in unnoticed.
+
+    v2 over v1: a top-level ``summary_schema_version`` tag; ``surfacing_hits``
+    per class in ``per_class_cell_sizes`` (so precision pools per class, not
+    only per store); and ``exposure`` as an object of raw counts plus rate,
+    replacing the flat ``exposure_rate`` (so exposure pools by summing counts).
     """
     fp = result["fingerprint"]
     art = result.get("artifact_regime")
     summary: dict = {
+        "summary_schema_version": SUMMARY_SCHEMA_VERSION,
         "fingerprint": fp,
         "battery_hash": fp["battery_hash"],
     }
@@ -1061,9 +922,19 @@ def build_summary(result: dict) -> dict:
             "wilson_lb": art["coverage"]["wilson_lb"],
             "cp_lb": art["coverage"]["cp_lb"],
         },
-        "exposure_rate": art["exposure"]["rate"],
+        "exposure": {
+            "wrong_fires": art["exposure"]["wrong_fires"],
+            "artifacts_reviewed": art["exposure"]["artifacts_reviewed"],
+            "rate": art["exposure"]["rate"],
+        },
         "per_class_cell_sizes": {
-            klass: {"candidate": cell["candidate"], "fired": cell["fired"]}
+            klass: {
+                "candidate": cell["candidate"],
+                "fired": cell["fired"],
+                # The value already exists in run_artifact_regime's per-class
+                # diagnostics as the numerator of the class surfacing interval.
+                "surfacing_hits": cell["surfacing_precision"]["k"],
+            }
             for klass, cell in art["per_class"].items()
         },
         "required_n_fired": art["required_n_fired"],

--- a/packages/nauro/tests/test_pool_certify_smoke.py
+++ b/packages/nauro/tests/test_pool_certify_smoke.py
@@ -1,0 +1,287 @@
+"""Structural smoke for benchmarks/pool_certify.py and the new _stats primitives.
+
+Scope is deliberately structure-only, on SYNTHETIC fabricated counts. No fixture
+is store-derived and nothing here asserts a precision/catch/score number: the
+verdict logic and the admissibility gates are mechanical, so this pins their
+structure (schema, the three-value verdict set, breadth and homogeneity routing,
+the admissibility rejections) without gating retrieval quality.
+
+The counts are hand-built to exercise each path: a certifiable homogeneous
+large-n three-store pool, a breadth-short two-store pool, a wildly heterogeneous
+pool, a consent-hash mismatch, and a v1 summary. The _stats checks are
+monotonicity / range properties, not tuned values.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+BENCH_DIR = Path(__file__).resolve().parents[3] / "benchmarks"
+# pool_certify.py imports its sibling _stats module; a direct script run resolves
+# that via sys.path[0]. Under pytest the loader needs benchmarks/ on sys.path.
+if str(BENCH_DIR) not in sys.path:
+    sys.path.insert(0, str(BENCH_DIR))
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, BENCH_DIR / f"{name}.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# Synthetic fixture builders (fabricated counts only, never store-derived).
+# ---------------------------------------------------------------------------
+
+
+def _summary(
+    store_seed: str,
+    cells: dict[str, tuple[int, int, int]],
+    *,
+    exposure: dict | None = None,
+    schema: str = "2",
+    battery: str = "batt-1",
+    bench_version: str = "1",
+    attested_date: str = "2026-07-01",
+    attested_operator: str = "att-op",
+) -> dict:
+    """A fabricated schema-v2 summary. ``cells`` maps class -> (hits, fired, candidate)."""
+    fingerprint = {
+        "bench_version": bench_version,
+        "battery_hash": battery,
+        "last_attested_date": attested_date,
+        "last_attested_operator": attested_operator,
+        # Distinguishes store identity so distinct seeds hash to distinct stores.
+        "store_seed": store_seed,
+    }
+    if exposure is None:
+        exposure = {"wrong_fires": 0, "artifacts_reviewed": 200, "rate": 0.0}
+    per_class = {
+        klass: {"candidate": candidate, "fired": fired, "surfacing_hits": hits}
+        for klass, (hits, fired, candidate) in cells.items()
+    }
+    return {
+        "summary_schema_version": schema,
+        "fingerprint": fingerprint,
+        "battery_hash": battery,
+        "artifact_regime": {
+            "per_class_cell_sizes": per_class,
+            "exposure": exposure,
+        },
+    }
+
+
+def _consent(pc, summary: dict, operator: str, attestor: str, *, valid_hash: bool = True) -> dict:
+    fp_hash = pc.fingerprint_hash(summary) if valid_hash else "0" * 64
+    return {
+        "operator": operator,
+        "attestor": attestor,
+        "fingerprint_hash": fp_hash,
+        "date": "2026-07-01",
+        "scope": "surfacing precision pooling",
+        "revocation_terms": "revocable on written notice",
+    }
+
+
+def _contribution(
+    pc,
+    store_seed: str,
+    operator: str,
+    attestor: str,
+    cells: dict[str, tuple[int, int, int]],
+    *,
+    valid_hash: bool = True,
+    **summary_kwargs,
+) -> dict:
+    summary = _summary(store_seed, cells, **summary_kwargs)
+    consent = _consent(pc, summary, operator, attestor, valid_hash=valid_hash)
+    return {"summary": summary, "consent": consent, "source": store_seed}
+
+
+def _certifiable_pool(pc) -> list[dict]:
+    """Three homogeneous high-precision large-n stores that clear every gate."""
+    cells = {"forward": (49, 50, 60)}  # hits, fired, candidate -> precision 49/50
+    exposure = {"wrong_fires": 1, "artifacts_reviewed": 200, "rate": 0.005}
+    return [
+        _contribution(pc, "s1", "op-a", "att-x", cells, exposure=exposure),
+        _contribution(pc, "s2", "op-b", "att-y", cells, exposure=exposure),
+        _contribution(pc, "s3", "op-c", "att-x", cells, exposure=exposure),
+    ]
+
+
+_STRATUM_KEYS = {
+    "firing_class",
+    "battery_hash",
+    "bench_major",
+    "g_version",
+    "pooled",
+    "cp_lower",
+    "wilson_lower",
+    "coverage",
+    "exposure_rate",
+    "homogeneity_p",
+    "homogeneity_p_adjusted",
+    "loso_min_cp_lower",
+    "beta_binomial_lower",
+    "n_stores",
+    "n_operators",
+    "n_attestors",
+    "fingerprint_hashes",
+    "checks",
+    "verdict",
+}
+_VERDICTS = {"CERTIFIED", "HETEROGENEOUS", "UNATTAINABLE"}
+
+
+# ---------------------------------------------------------------------------
+# Report structure and verdict routing.
+# ---------------------------------------------------------------------------
+
+
+def test_report_is_schema_valid_and_verdicts_bounded() -> None:
+    pc = _load("pool_certify")
+    report = pc.build_report(_certifiable_pool(pc), pooling_operator="op-pooler")
+
+    assert set(report) == {
+        "pool_certify_version",
+        "n_contributions",
+        "n_admissible",
+        "rejected",
+        "strata",
+    }
+    assert report["n_contributions"] == 3
+    assert report["n_admissible"] == 3
+    assert report["rejected"] == []
+    assert report["strata"], "expected at least one stratum"
+    for st in report["strata"]:
+        assert set(st) == _STRATUM_KEYS
+        assert st["verdict"] in _VERDICTS
+        assert isinstance(st["checks"], dict)
+        assert all(isinstance(v, bool) for v in st["checks"].values())
+
+
+def test_homogeneous_large_n_three_store_pool_certifies() -> None:
+    pc = _load("pool_certify")
+    report = pc.build_report(_certifiable_pool(pc), pooling_operator="op-pooler")
+    forward = next(st for st in report["strata"] if st["firing_class"] == "forward")
+    assert forward["verdict"] == "CERTIFIED", forward["checks"]
+    assert forward["n_stores"] == 3
+    assert forward["n_operators"] == 3
+    assert forward["n_attestors"] == 2
+
+
+def test_two_store_pool_fails_breadth_floor() -> None:
+    pc = _load("pool_certify")
+    report = pc.build_report(_certifiable_pool(pc)[:2], pooling_operator="op-pooler")
+    forward = next(st for st in report["strata"] if st["firing_class"] == "forward")
+    assert forward["verdict"] != "CERTIFIED"
+    assert forward["verdict"] == "UNATTAINABLE"
+    assert forward["checks"]["breadth_stores"] is False
+
+
+def test_heterogeneous_pool_is_flagged() -> None:
+    pc = _load("pool_certify")
+    exposure = {"wrong_fires": 1, "artifacts_reviewed": 200, "rate": 0.005}
+    contribs = [
+        _contribution(pc, "s1", "op-a", "att-x", {"forward": (50, 50, 60)}, exposure=exposure),
+        _contribution(pc, "s2", "op-b", "att-y", {"forward": (25, 50, 60)}, exposure=exposure),
+        _contribution(pc, "s3", "op-c", "att-x", {"forward": (5, 50, 60)}, exposure=exposure),
+    ]
+    report = pc.build_report(contribs, pooling_operator="op-pooler")
+    forward = next(st for st in report["strata"] if st["firing_class"] == "forward")
+    assert forward["verdict"] == "HETEROGENEOUS"
+    assert forward["checks"]["homogeneous"] is False
+
+
+def test_consent_hash_mismatch_is_rejected() -> None:
+    pc = _load("pool_certify")
+    contribs = [
+        _contribution(pc, "s1", "op-a", "att-x", {"forward": (49, 50, 60)}, valid_hash=False),
+    ]
+    report = pc.build_report(contribs, pooling_operator="op-pooler")
+    assert report["n_admissible"] == 0
+    assert report["strata"] == []
+    assert len(report["rejected"]) == 1
+    assert "hash-linked" in report["rejected"][0]["reason"]
+
+
+def test_v1_summary_is_rejected() -> None:
+    pc = _load("pool_certify")
+    contribs = [
+        _contribution(pc, "s1", "op-a", "att-x", {"forward": (49, 50, 60)}, schema="1"),
+    ]
+    report = pc.build_report(contribs, pooling_operator="op-pooler")
+    assert report["n_admissible"] == 0
+    assert report["strata"] == []
+    assert len(report["rejected"]) == 1
+    assert "v1" in report["rejected"][0]["reason"]
+
+
+def test_bench_version_out_of_range_is_rejected() -> None:
+    pc = _load("pool_certify")
+    contribs = [
+        _contribution(pc, "s1", "op-a", "att-x", {"forward": (49, 50, 60)}, bench_version="99"),
+    ]
+    report = pc.build_report(contribs, pooling_operator="op-pooler")
+    assert report["n_admissible"] == 0
+    assert "compatibility range" in report["rejected"][0]["reason"]
+
+
+def test_beta_binomial_never_gates_verdict() -> None:
+    """The certifier reports the beta-binomial bound but never reads it in checks."""
+    pc = _load("pool_certify")
+    report = pc.build_report(_certifiable_pool(pc), pooling_operator="op-pooler")
+    forward = next(st for st in report["strata"] if st["firing_class"] == "forward")
+    assert "beta_binomial_lower" in forward
+    assert "beta_binomial" not in forward["checks"]
+
+
+# ---------------------------------------------------------------------------
+# _stats primitive properties (monotonicity / range, not tuned values).
+# ---------------------------------------------------------------------------
+
+
+def test_homogeneity_p_range_and_ordering() -> None:
+    st = _load("_stats")
+    homogeneous = [(49, 50), (49, 50), (48, 50)]
+    heterogeneous = [(50, 50), (25, 50), (5, 50)]
+    p_hom = st.homogeneity_p(homogeneous)
+    p_het = st.homogeneity_p(heterogeneous)
+    for p in (p_hom, p_het):
+        assert 0.0 <= p <= 1.0
+    assert p_het < p_hom
+    # Nothing to test with fewer than two informative stores.
+    assert st.homogeneity_p([(5, 10)]) == 1.0
+    assert st.homogeneity_p([]) == 1.0
+
+
+def test_homogeneity_exact_path_small_counts() -> None:
+    st = _load("_stats")
+    p_hom = st.homogeneity_p([(3, 3), (3, 3), (2, 3)])
+    p_het = st.homogeneity_p([(3, 3), (0, 3), (3, 3)])
+    assert 0.0 <= p_het <= p_hom <= 1.0
+    assert p_het < p_hom
+
+
+def test_beta_binomial_lower_below_pooled_point_estimate() -> None:
+    st = _load("_stats")
+    for counts in ([(49, 50), (48, 50), (49, 50)], [(50, 50), (25, 50), (5, 50)]):
+        k = sum(a for a, _ in counts)
+        n = sum(b for _, b in counts)
+        point = k / n
+        bb = st.beta_binomial_lower(counts)
+        assert 0.0 <= bb <= point
+        # Overdispersion only widens the interval: never above the fixed-effect bound.
+        assert bb <= st.wilson_lower(k, n) + 1e-12
+
+
+def test_holm_adjusted_is_monotone_and_bounded() -> None:
+    st = _load("_stats")
+    adjusted = st.holm_adjusted([0.001, 0.02, 0.5])
+    assert all(0.0 <= p <= 1.0 for p in adjusted)
+    # Aligned with input order; the smallest raw p carries the family multiplier.
+    assert adjusted[0] >= 0.001
+    assert st.holm_adjusted([]) == []

--- a/packages/nauro/tests/test_retrieval_bench_smoke.py
+++ b/packages/nauro/tests/test_retrieval_bench_smoke.py
@@ -31,6 +31,12 @@ from nauro.demo import DEMO_DECISIONS, create_demo_project
 
 SCRIPT = Path(__file__).resolve().parents[3] / "benchmarks" / "retrieval_bench.py"
 
+# retrieval_bench.py imports its sibling _stats module; a direct script run
+# resolves that via sys.path[0]. Under pytest the loader below must put the
+# benchmarks/ directory on sys.path for the sibling import to resolve.
+if str(SCRIPT.parent) not in sys.path:
+    sys.path.insert(0, str(SCRIPT.parent))
+
 
 def _load_bench_module():
     """Import the out-of-package benchmark script as a module for direct calls.
@@ -171,3 +177,68 @@ def test_g_abstains_on_negative_probe() -> None:
     decisions = {d.num: d for d in DEMO_DECISIONS}
     slice_result = bench.run_abstain_slice(decisions)
     assert slice_result["correct_abstain"], slice_result["fires"]
+
+
+def _build_demo_result(bench, store: Path) -> dict:
+    """Reconstruct main()'s result dict for the demo store at the function boundary."""
+    decisions, unparseable = bench.load_decisions(store)
+    events, skipped_order = bench.extract_events(decisions)
+    catching, skipped_temporal = bench.run_conflict_catching(decisions, events, False)
+    artifact_regime = bench.run_artifact_regime(decisions, events)
+    return {
+        "fingerprint": bench.build_fingerprint(
+            decisions, events, skipped_order, skipped_temporal, unparseable, False
+        ),
+        "conflict_catching": catching,
+        "batteries": bench.run_batteries(decisions),
+        "artifact_regime": artifact_regime,
+        "abstain_slice": bench.run_abstain_slice(decisions),
+        "feasibility": bench.feasibility_sweep(artifact_regime),
+    }
+
+
+def test_summary_schema_v2(tmp_path: Path) -> None:
+    """build_summary emits schema v2 and never widens the closed top-level key set.
+
+    Structure-only: version tag, per-class surfacing_hits, exposure raw counts,
+    and a hard allowlist on the top-level keys so a store-text or lexicon field
+    cannot leak into the exchanged summary. No precision/catch number is asserted.
+    """
+    bench = _load_bench_module()
+    store = tmp_path / "demo-store"
+    create_demo_project(store)
+    summary = bench.build_summary(_build_demo_result(bench, store))
+
+    assert summary["summary_schema_version"] == "2"
+    assert summary["summary_schema_version"] == bench.SUMMARY_SCHEMA_VERSION
+
+    # The top-level key set is closed: a new field is a schema change, so a
+    # store-text/lexicon field cannot ride in unnoticed.
+    assert set(summary) == {
+        "summary_schema_version",
+        "fingerprint",
+        "battery_hash",
+        "artifact_regime",
+    }
+
+    art = summary["artifact_regime"]
+    assert set(art) == {
+        "n_candidate_conflicts",
+        "n_fired",
+        "min_n_fired_met",
+        "surfacing_precision",
+        "coverage",
+        "exposure",
+        "per_class_cell_sizes",
+        "required_n_fired",
+        "feasibility_verdict",
+    }
+
+    # Exposure is an object of raw counts plus rate (poolable by summation).
+    assert set(art["exposure"]) == {"wrong_fires", "artifacts_reviewed", "rate"}
+
+    # Every per-class cell carries surfacing_hits alongside the cell sizes.
+    assert set(art["per_class_cell_sizes"]) == {"forward", "reverse_only", "cross_vocabulary"}
+    for cell in art["per_class_cell_sizes"].values():
+        assert set(cell) == {"candidate", "fired", "surfacing_hits"}
+        assert cell["surfacing_hits"] <= cell["fired"]


### PR DESCRIPTION
## Why

The retrieval benchmark's per-store surfacing lower bound is years from the
high-stakes tier on any single store. Per the pre-registered pooling protocol,
cross-store pooling is the only path to the emit tier — but pooling is only
sound when the contributions are homogeneous, consented, and broadly sourced.
This adds the tooling that mechanizes that check, and the versioned summary
envelope it pools over. It is developer tooling only: nothing ships in a wheel,
nothing is a quality gate, and no store content is ever committed.

## What changed

- **`benchmarks/_stats.py` (new).** The per-store statistics (Wilson,
  Clopper-Pearson, rule of three, exact McNemar, Holm, required-n) are factored
  out of `retrieval_bench.py` unchanged into one stdlib-math module, so the
  per-store measurement and the cross-store pool share one source of truth. It
  adds the cross-store primitives: an exact homogeneity test across per-store
  2xS outcome tables (Pearson chi-square where the expected counts permit,
  Fisher-Freeman-Halton enumeration over the fixed margins otherwise), a
  moment-based beta-binomial random-effects lower bound, and Holm-adjusted
  p-values.
- **`benchmarks/retrieval_bench.py`.** Imports the moved primitives from the
  sibling module and rewrites the privacy-preserving summary to schema v2: a
  top-level `summary_schema_version`, per-class `surfacing_hits`, and an
  `exposure` object of raw counts, so a summary pools per firing class and by
  summation. The summary's top-level key set is closed — counts, bounds,
  versions, and the fingerprint only, never store text.
- **`benchmarks/pool_certify.py` (new).** A stdlib-only cross-store
  pooler/certifier over attested v2 summaries. Mechanical admissibility gates
  (schema v2, complete fingerprint, battery consistency, pinned bench-major
  range, consent hash-linked to the fingerprint), stratification by firing
  class / battery hash / bench major / g version, and a per-stratum verdict of
  CERTIFIED, HETEROGENEOUS, or UNATTAINABLE. Pre-registered floors are pinned
  private in code and never echoed; reports carry booleans and measured bounds
  only. The tool never collects — summaries are exchanged by hand as attested
  artifacts under written consent.
- **`benchmarks/README.md`.** A short "Cross-store pooling" section: inputs,
  the three verdicts, and the no-collection posture.

## Test plan

Structure-only smoke tests on synthetic fabricated counts (never store-derived);
no precision/catch/score number is asserted, matching the existing CI posture.

- `test_retrieval_bench_smoke.py`: adds `test_summary_schema_v2` — the v2 tag,
  per-class `surfacing_hits`, exposure raw counts, and a hard allowlist on the
  top-level keys so a store-text/lexicon field cannot leak. Existing subprocess
  and generator-invariant smokes still pass.
- `test_pool_certify_smoke.py` (new): report schema and the three-value verdict
  set; a homogeneous high-precision large-n 3-store pool certifies; a 2-store
  pool fails the breadth floor; a heterogeneous pool is flagged HETEROGENEOUS;
  consent-hash mismatch and v1 summaries are rejected at admissibility; and
  monotonicity/range properties of the new `_stats` primitives.
- Full suites green: `packages/nauro/tests/` and `packages/nauro-core/tests/`.
- `ruff check` and `ruff format --check` clean on `packages/` and `benchmarks/`.

## Risk / what to review

- `_stats.py` moved functions are byte-identical to the originals (docstrings
  kept); the smoke suite exercises them through the unchanged code paths.
- The exact homogeneity enumeration is only reached for small expected counts,
  which bounds it; large-n strata route to chi-square.
