### PR TITLE
Harden MCP command resolution and add status liveness probe

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/adopt.py
+++ b/packages/nauro/src/nauro/cli/commands/adopt.py
@@ -95,6 +95,12 @@ def _smoke_test_wired_binary(nauro_cmd: str, timeout: float = 1.5) -> str | None
     Either outcome is "healthy". The failure mode we care about is the binary
     crashing on import — that surfaces as a non-zero exit before the timeout.
 
+    This is intentionally deeper than the shared ``probe_nauro_command``
+    liveness check (``nauro --version``) that the setup resolver and ``nauro
+    status`` use: it exercises the actual ``serve --stdio`` entrypoint the agent
+    spawns, catching import-time crashes a ``--version`` probe would miss. Kept
+    separate for that reason.
+
     Returns a multi-line warning string on detected failure, otherwise None.
     """
     try:

--- a/packages/nauro/src/nauro/cli/commands/setup.py
+++ b/packages/nauro/src/nauro/cli/commands/setup.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 import typer
 
+from nauro.cli import utils as cli_utils
 from nauro.cli.git_hygiene import public_surface_git_warnings
 from nauro.cli.utils import _resolve_project_entry, resolve_target_project
 from nauro.constants import CLAUDE_MD, NAURO_BLOCK_END, NAURO_BLOCK_START
@@ -76,23 +77,105 @@ def _remove_claude_md(repo_path: Path) -> str | None:
         return f"  {repo_path}: removed legacy Nauro block from {CLAUDE_MD}"
 
 
-def _find_nauro_command() -> str:
-    """Resolve an absolute path to the nauro entrypoint for MCP/hook configs.
+def _interpreter_sibling_candidate() -> str | None:
+    """Return the absolute path to a ``nauro`` console script next to the running
+    interpreter, or None when there isn't one.
 
-    Prefer the console script next to the running interpreter — the install the
-    user actually invoked, which a pip-into-venv or pipx/uv-tool layout often
-    keeps off the PATH that Claude Code / Cursor / Codex launch with. Recording
-    an absolute path keeps the spawned stdio server and the per-turn hook
-    independent of the agent's launch environment. Fall back to a PATH lookup,
-    then the bare name.
+    This is the install the user actually invoked, which pipx/uv-tool layouts
+    keep off the PATH that GUI-launched agents see — recording its absolute path
+    is what makes the spawned stdio server and per-turn hook independent of the
+    agent's launch environment.
     """
     bindir = Path(sys.executable).parent
     for name in ("nauro", "nauro.exe"):
         candidate = bindir / name
         if candidate.is_file():
             return str(candidate)
-    path = shutil.which("nauro")
-    return path if path else "nauro"
+    return None
+
+
+_FRAGILE_COMMAND_WARNING = (
+    "WARNING: recording nauro from a project virtualenv ({command}).\n"
+    "  This path breaks if the repo's virtualenv is rebuilt, moved, or "
+    "corrupted, silently killing Nauro's MCP server and hooks. Install nauro "
+    "durably (pipx install nauro, or uv tool install nauro) and re-run "
+    "'nauro setup all'."
+)
+
+_UNRESOLVED_COMMAND_WARNING = (
+    "WARNING: could not validate a working nauro; recorded '{command}'.\n"
+    "  Nauro's MCP server and hooks will not work until nauro is installed on a "
+    "durable PATH (pipx install nauro, or uv tool install nauro), then re-run "
+    "'nauro setup all'."
+)
+
+# Memoized per process so `setup all` validates the entrypoint once rather than
+# once per sink (five subprocess probes collapse to one). Warnings surface on
+# first resolution only; cleared between tests via the cache-clear seam.
+_RESOLVED_NAURO_COMMAND: str | None = None
+
+
+def _find_nauro_command() -> str:
+    """Resolve — and cache for the process — the nauro entrypoint recorded into
+    MCP and hook configs."""
+    global _RESOLVED_NAURO_COMMAND
+    if _RESOLVED_NAURO_COMMAND is None:
+        _RESOLVED_NAURO_COMMAND = _resolve_nauro_command()
+    return _RESOLVED_NAURO_COMMAND
+
+
+def _find_nauro_command_cache_clear() -> None:
+    """Reset the per-process resolution cache (test seam)."""
+    global _RESOLVED_NAURO_COMMAND
+    _RESOLVED_NAURO_COMMAND = None
+
+
+def _resolve_nauro_command() -> str:
+    """Pick the nauro entrypoint to record into MCP/hook configs.
+
+    Prefers a validated, durable install so the recorded command keeps working
+    after a project virtualenv is rebuilt, moved, or corrupted (the observed
+    failure: a ``uv run`` / ``.venv``-invoked setup recorded a fragile
+    repo-venv path that later died). Resolution order:
+
+      1. Interpreter-sibling that both runs and looks durable — the fast path,
+         byte-identical to the historical behavior for pipx/uv-tool/desktop.
+      2. Otherwise a PATH-resolved absolute shim that runs and looks durable —
+         diverts away from a dead or fragile project venv.
+      3. Otherwise the sibling if it merely runs (fragile but working) —
+         recorded with a loud warning naming the project-venv fragility.
+      4. Otherwise the best absolute path we have (else bare ``nauro``), with a
+         loud warning that MCP will not work until nauro is on a durable PATH.
+
+    An absolute path is always preferred over bare ``nauro``; bare ``nauro`` is
+    only the terminal fallback, because GUI-launched agents start with an empty
+    PATH. Durability checks run before the (subprocess) probe so a non-durable
+    candidate short-circuits without spawning.
+    """
+    sibling = _interpreter_sibling_candidate()
+    which = shutil.which("nauro")
+
+    if (
+        sibling is not None
+        and cli_utils._is_durable_install_path(sibling)
+        and cli_utils.probe_nauro_command(sibling)
+    ):
+        return sibling
+
+    if (
+        which is not None
+        and cli_utils._is_durable_install_path(which)
+        and cli_utils.probe_nauro_command(which)
+    ):
+        return which
+
+    if sibling is not None and cli_utils.probe_nauro_command(sibling):
+        typer.echo(_FRAGILE_COMMAND_WARNING.format(command=sibling), err=True)
+        return sibling
+
+    fallback = sibling or which or "nauro"
+    typer.echo(_UNRESOLVED_COMMAND_WARNING.format(command=fallback), err=True)
+    return fallback
 
 
 def _user_scope_safe_to_clear(current_project_key: str | None) -> bool:

--- a/packages/nauro/src/nauro/cli/commands/setup.py
+++ b/packages/nauro/src/nauro/cli/commands/setup.py
@@ -10,6 +10,7 @@ Subcommands:
 
 from __future__ import annotations
 
+import functools
 import json
 import shutil
 import sys
@@ -109,25 +110,18 @@ _UNRESOLVED_COMMAND_WARNING = (
     "'nauro setup all'."
 )
 
-# Memoized per process so `setup all` validates the entrypoint once rather than
-# once per sink (five subprocess probes collapse to one). Warnings surface on
-# first resolution only; cleared between tests via the cache-clear seam.
-_RESOLVED_NAURO_COMMAND: str | None = None
 
-
+@functools.cache
 def _find_nauro_command() -> str:
     """Resolve — and cache for the process — the nauro entrypoint recorded into
-    MCP and hook configs."""
-    global _RESOLVED_NAURO_COMMAND
-    if _RESOLVED_NAURO_COMMAND is None:
-        _RESOLVED_NAURO_COMMAND = _resolve_nauro_command()
-    return _RESOLVED_NAURO_COMMAND
+    MCP and hook configs.
 
-
-def _find_nauro_command_cache_clear() -> None:
-    """Reset the per-process resolution cache (test seam)."""
-    global _RESOLVED_NAURO_COMMAND
-    _RESOLVED_NAURO_COMMAND = None
+    Cached so `setup all` validates the entrypoint once rather than once per
+    sink (five subprocess probes collapse to one). Warnings surface on the
+    cache-miss resolution only; tests reset via
+    ``_find_nauro_command.cache_clear()``.
+    """
+    return _resolve_nauro_command()
 
 
 def _resolve_nauro_command() -> str:

--- a/packages/nauro/src/nauro/cli/commands/status.py
+++ b/packages/nauro/src/nauro/cli/commands/status.py
@@ -57,14 +57,20 @@ def _codex_config_path() -> Path:
     return Path.home() / ".codex" / "config.toml"
 
 
-def _repo_has_mcp_wiring(repo: Path) -> bool:
-    """True when the repo declares a nauro MCP server in .mcp.json or .cursor/mcp.json.
+def _repo_recorded_commands(repo: Path) -> list[str | None]:
+    """Recorded nauro MCP commands in this repo's configs, one entry per wired config.
 
-    Read-only probe: a missing, unreadable, or malformed config counts as
-    not wired — status must never crash on someone else's config file.
+    Single read of ``.mcp.json`` and ``.cursor/mcp.json`` each — presence
+    ("the repo is wired" iff the list is non-empty) and the recorded command
+    both derive from the same parse. A wired config whose nauro entry carries a
+    missing or empty command contributes ``None``: it still counts as wired,
+    but there is nothing to probe. Read-only and soft-failing: a missing,
+    unreadable, or malformed config contributes nothing — status must never
+    crash on someone else's config file.
     """
     import json
 
+    commands: list[str | None] = []
     for rel in (".mcp.json", ".cursor/mcp.json"):
         try:
             config = json.loads((repo / rel).read_text())
@@ -73,15 +79,20 @@ def _repo_has_mcp_wiring(repo: Path) -> bool:
         if not isinstance(config, dict):
             continue
         servers = config.get("mcpServers")
-        if isinstance(servers, dict) and "nauro" in servers:
-            return True
-    return False
+        if not isinstance(servers, dict) or "nauro" not in servers:
+            continue
+        entry = servers["nauro"]
+        cmd = entry.get("command") if isinstance(entry, dict) else None
+        commands.append(cmd if isinstance(cmd, str) and cmd else None)
+    return commands
 
 
-def _codex_global_wired() -> bool:
-    """True when the user-global Codex config declares a nauro MCP server.
+def _codex_recorded_command() -> tuple[bool, str | None]:
+    """Return ``(wired, recorded command)`` for the user-global Codex config.
 
-    Same parse approach as setup.py; any read or parse failure counts as
+    Single read of ``~/.codex/config.toml``, same parse approach as setup.py.
+    ``(True, None)`` means a nauro entry exists but records no usable command —
+    wired for presence, nothing to probe. Any read or parse failure counts as
     not wired.
     """
     import sys
@@ -95,92 +106,23 @@ def _codex_global_wired() -> bool:
         with _codex_config_path().open("rb") as f:
             config = tomllib.load(f)
     except Exception:
-        return False
+        return (False, None)
     servers = config.get("mcp_servers")
-    return isinstance(servers, dict) and "nauro" in servers
-
-
-def _recorded_repo_commands(repo: Path) -> list[str]:
-    """Return the nauro MCP command strings recorded in a repo's configs.
-
-    Reads ``.mcp.json`` and ``.cursor/mcp.json`` and extracts
-    ``mcpServers.nauro.command`` from each. Read-only and soft-failing: a
-    missing, unreadable, malformed, or command-less config contributes nothing.
-    """
-    import json
-
-    commands: list[str] = []
-    for rel in (".mcp.json", ".cursor/mcp.json"):
-        try:
-            config = json.loads((repo / rel).read_text())
-        except Exception:
-            continue
-        if not isinstance(config, dict):
-            continue
-        servers = config.get("mcpServers")
-        if not isinstance(servers, dict):
-            continue
-        entry = servers.get("nauro")
-        if isinstance(entry, dict):
-            cmd = entry.get("command")
-            if isinstance(cmd, str) and cmd:
-                commands.append(cmd)
-    return commands
-
-
-def _recorded_codex_command() -> str | None:
-    """Return the nauro command recorded in the user-global Codex config, if any.
-
-    Same parse approach as ``_codex_global_wired``; any read or parse failure
-    yields None.
-    """
-    import sys
-
-    if sys.version_info >= (3, 11):
-        import tomllib
-    else:
-        import tomli as tomllib
-
-    try:
-        with _codex_config_path().open("rb") as f:
-            config = tomllib.load(f)
-    except Exception:
-        return None
-    servers = config.get("mcp_servers")
-    if not isinstance(servers, dict):
-        return None
-    entry = servers.get("nauro")
-    if isinstance(entry, dict):
-        cmd = entry.get("command")
-        if isinstance(cmd, str) and cmd:
-            return cmd
-    return None
-
-
-def _safe_probe(cmd: str) -> bool:
-    """Liveness probe wrapper that never raises (status soft-fail contract)."""
-    try:
-        return cli_utils.probe_nauro_command(cmd)
-    except Exception:
-        return False
+    if not isinstance(servers, dict) or "nauro" not in servers:
+        return (False, None)
+    entry = servers["nauro"]
+    cmd = entry.get("command") if isinstance(entry, dict) else None
+    return (True, cmd if isinstance(cmd, str) and cmd else None)
 
 
 def _probe_distinct_commands(commands: set[str]) -> dict[str, bool]:
     """Probe each distinct recorded command once for liveness.
 
-    Sequential for a single command — the common case, where N repos share one
-    recorded path. A small bounded thread pool only when several distinct
-    commands exist, so their probes overlap instead of summing their timeouts.
+    Sequential: N repos usually share one recorded path, so the common case is
+    a single short probe. ``probe_nauro_command`` soft-fails by contract, so a
+    dead command costs at most its timeout, never an exception.
     """
-    distinct = list(commands)
-    if not distinct:
-        return {}
-    if len(distinct) == 1:
-        return {distinct[0]: _safe_probe(distinct[0])}
-    from concurrent.futures import ThreadPoolExecutor
-
-    with ThreadPoolExecutor(max_workers=min(4, len(distinct))) as pool:
-        return dict(zip(distinct, pool.map(_safe_probe, distinct)))
+    return {cmd: cli_utils.probe_nauro_command(cmd) for cmd in commands}
 
 
 def _repo_has_generated_agents_md(repo: Path) -> bool:
@@ -270,14 +212,17 @@ def status(
     except Exception:
         repo_paths = []
 
+    # Each wiring config is read once: presence and the recorded command come
+    # from the same parse.
     try:
-        mcp_wired = sum(1 for repo in repo_paths if _repo_has_mcp_wiring(repo))
+        repo_commands = [_repo_recorded_commands(repo) for repo in repo_paths]
     except Exception:
-        mcp_wired = 0
+        repo_commands = []
+    mcp_wired = sum(1 for cmds in repo_commands if cmds)
     try:
-        codex_global = _codex_global_wired()
+        codex_global, codex_command = _codex_recorded_command()
     except Exception:
-        codex_global = False
+        codex_global, codex_command = False, None
 
     if mcp_wired or codex_global:
         details = []
@@ -293,12 +238,9 @@ def status(
         healthy = True
         if not no_probe:
             try:
-                commands: set[str] = set()
-                for repo in repo_paths:
-                    commands.update(_recorded_repo_commands(repo))
-                codex_cmd = _recorded_codex_command()
-                if codex_cmd:
-                    commands.add(codex_cmd)
+                commands = {cmd for cmds in repo_commands for cmd in cmds if cmd}
+                if codex_command:
+                    commands.add(codex_command)
                 if commands:
                     healthy = all(_probe_distinct_commands(commands).values())
             except Exception:

--- a/packages/nauro/src/nauro/cli/commands/status.py
+++ b/packages/nauro/src/nauro/cli/commands/status.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import typer
 
+from nauro.cli import utils as cli_utils
 from nauro.cli.utils import resolve_target_project
 
 
@@ -99,6 +100,89 @@ def _codex_global_wired() -> bool:
     return isinstance(servers, dict) and "nauro" in servers
 
 
+def _recorded_repo_commands(repo: Path) -> list[str]:
+    """Return the nauro MCP command strings recorded in a repo's configs.
+
+    Reads ``.mcp.json`` and ``.cursor/mcp.json`` and extracts
+    ``mcpServers.nauro.command`` from each. Read-only and soft-failing: a
+    missing, unreadable, malformed, or command-less config contributes nothing.
+    """
+    import json
+
+    commands: list[str] = []
+    for rel in (".mcp.json", ".cursor/mcp.json"):
+        try:
+            config = json.loads((repo / rel).read_text())
+        except Exception:
+            continue
+        if not isinstance(config, dict):
+            continue
+        servers = config.get("mcpServers")
+        if not isinstance(servers, dict):
+            continue
+        entry = servers.get("nauro")
+        if isinstance(entry, dict):
+            cmd = entry.get("command")
+            if isinstance(cmd, str) and cmd:
+                commands.append(cmd)
+    return commands
+
+
+def _recorded_codex_command() -> str | None:
+    """Return the nauro command recorded in the user-global Codex config, if any.
+
+    Same parse approach as ``_codex_global_wired``; any read or parse failure
+    yields None.
+    """
+    import sys
+
+    if sys.version_info >= (3, 11):
+        import tomllib
+    else:
+        import tomli as tomllib
+
+    try:
+        with _codex_config_path().open("rb") as f:
+            config = tomllib.load(f)
+    except Exception:
+        return None
+    servers = config.get("mcp_servers")
+    if not isinstance(servers, dict):
+        return None
+    entry = servers.get("nauro")
+    if isinstance(entry, dict):
+        cmd = entry.get("command")
+        if isinstance(cmd, str) and cmd:
+            return cmd
+    return None
+
+
+def _safe_probe(cmd: str) -> bool:
+    """Liveness probe wrapper that never raises (status soft-fail contract)."""
+    try:
+        return cli_utils.probe_nauro_command(cmd)
+    except Exception:
+        return False
+
+
+def _probe_distinct_commands(commands: set[str]) -> dict[str, bool]:
+    """Probe each distinct recorded command once for liveness.
+
+    Sequential for a single command — the common case, where N repos share one
+    recorded path. A small bounded thread pool only when several distinct
+    commands exist, so their probes overlap instead of summing their timeouts.
+    """
+    distinct = list(commands)
+    if not distinct:
+        return {}
+    if len(distinct) == 1:
+        return {distinct[0]: _safe_probe(distinct[0])}
+    from concurrent.futures import ThreadPoolExecutor
+
+    with ThreadPoolExecutor(max_workers=min(4, len(distinct))) as pool:
+        return dict(zip(distinct, pool.map(_safe_probe, distinct)))
+
+
 def _repo_has_generated_agents_md(repo: Path) -> bool:
     """True when the repo's AGENTS.md carries the Nauro generation footer.
 
@@ -118,6 +202,11 @@ def status(
         None,
         "--project",
         help="Target project name.",
+    ),
+    no_probe: bool = typer.Option(
+        False,
+        "--no-probe",
+        help="Skip the MCP liveness probe; report wiring presence only.",
     ),
 ) -> None:
     """Show which Nauro capabilities are active or inactive."""
@@ -196,7 +285,34 @@ def status(
             details.append(f"wired in {mcp_wired}/{len(repo_paths)} repos")
         if codex_global:
             details.append("Codex global")
-        typer.echo(f"  MCP           active ({'; '.join(details)})")
+        detail_str = "; ".join(details)
+
+        # Liveness: wiring can point at a nauro that no longer runs (a rebuilt or
+        # corrupted project venv). Probe the distinct recorded commands so a
+        # wired-but-dead install renders BROKEN instead of a false-green active.
+        healthy = True
+        if not no_probe:
+            try:
+                commands: set[str] = set()
+                for repo in repo_paths:
+                    commands.update(_recorded_repo_commands(repo))
+                codex_cmd = _recorded_codex_command()
+                if codex_cmd:
+                    commands.add(codex_cmd)
+                if commands:
+                    healthy = all(_probe_distinct_commands(commands).values())
+            except Exception:
+                # A probe error must never crash status or flip a live wiring to
+                # BROKEN; fall back to presence-only reporting.
+                healthy = True
+
+        if healthy:
+            typer.echo(f"  MCP           active ({detail_str})")
+        else:
+            typer.echo(
+                f"  MCP           BROKEN — {detail_str} but the recorded command "
+                "won't run; re-run 'nauro setup all'"
+            )
     else:
         typer.echo("  MCP           inactive — run 'nauro setup all'")
 

--- a/packages/nauro/src/nauro/cli/utils.py
+++ b/packages/nauro/src/nauro/cli/utils.py
@@ -14,6 +14,7 @@ Resolution priority for any command that needs a project context:
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
 import typer
@@ -39,6 +40,56 @@ from nauro.store.repo_config import (
     find_repo_config,
     load_repo_config,
 )
+
+
+def probe_nauro_command(cmd: str, *, timeout: float = 1.5) -> bool:
+    """Return True iff ``[cmd, "--version"]`` launches and exits 0.
+
+    The single subprocess seam for validating a recorded MCP/hook command: the
+    setup resolver calls it before recording a command, and ``nauro status``
+    calls it to probe wired commands for liveness. A launch failure (missing
+    binary or permission error), a hang past ``timeout``, or a non-zero exit
+    all count as "won't run". Soft-fails — never raises — so callers can treat
+    the boolean as authoritative. Centralized here so tests mock exactly one
+    function and no test ever spawns a real binary.
+    """
+    try:
+        proc = subprocess.run(
+            [cmd, "--version"],
+            timeout=timeout,
+            capture_output=True,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return proc.returncode == 0
+
+
+_DURABLE_PATH_MARKERS: tuple[tuple[str, str], ...] = (("pipx", "venvs"), ("uv", "tools"))
+_FRAGILE_VENV_DIRS = frozenset({".venv", "venv", "env"})
+
+
+def _is_durable_install_path(path: str) -> bool:
+    """Heuristic: does ``path`` look like a durable, tool-managed install?
+
+    Separator-agnostic via ``Path.parts`` so Windows ``Scripts\\nauro.exe``
+    layouts read the same as POSIX ``bin/nauro``. pipx (``.../pipx/venvs/...``)
+    and uv-tool (``.../uv/tools/...``) installs live outside any single repo and
+    survive that repo's virtualenv being rebuilt or corrupted, so they count as
+    durable. A path whose grandparent directory is a bare ``.venv``/``venv``/
+    ``env`` is a project-local virtualenv that dies with the checkout, so it
+    counts as fragile. Any other shape (system, Homebrew, conda) is treated as
+    durable. This is only a resolver tiebreaker — a fragile path that still runs
+    is recorded with a warning, never dropped.
+    """
+    parts = [p.lower() for p in Path(path).parts]
+    for first, second in _DURABLE_PATH_MARKERS:
+        for i in range(len(parts) - 1):
+            if parts[i] == first and parts[i + 1] == second:
+                return True
+    if len(parts) >= 3 and parts[-3] in _FRAGILE_VENV_DIRS:
+        return False
+    return True
 
 
 def refuse_global_config_collision(repo_root: Path) -> None:
@@ -229,6 +280,7 @@ def _resolve_project_entry(project_name: str, project_key: str) -> dict:
 # Re-exported for callers that need to write or extend v2 entries directly
 __all__ = [
     "add_repo_v2",
+    "probe_nauro_command",
     "refuse_global_config_collision",
     "register_project_v2",
     "resolve_target_project",

--- a/packages/nauro/tests/conftest.py
+++ b/packages/nauro/tests/conftest.py
@@ -144,7 +144,7 @@ def _neutralize_nauro_command_probe(monkeypatch):
     the historical fast path (record the interpreter-sibling, no warning) and get
     a valid absolute command without a subprocess. Tests that exercise
     dead/fragile wiring override these on their own monkeypatch instance (later
-    setattr wins). The module-level resolver cache is cleared so each test
+    setattr wins). The functools cache on the resolver is cleared so each test
     resolves fresh and any warnings emit deterministically.
 
     Probe/durability unit tests capture the real functions at import time (before
@@ -155,9 +155,9 @@ def _neutralize_nauro_command_probe(monkeypatch):
 
     monkeypatch.setattr(cli_utils, "probe_nauro_command", lambda cmd, **kwargs: True)
     monkeypatch.setattr(cli_utils, "_is_durable_install_path", lambda path: True)
-    setup_mod._find_nauro_command_cache_clear()
+    setup_mod._find_nauro_command.cache_clear()
     yield
-    setup_mod._find_nauro_command_cache_clear()
+    setup_mod._find_nauro_command.cache_clear()
 
 
 @pytest.fixture(autouse=True)

--- a/packages/nauro/tests/conftest.py
+++ b/packages/nauro/tests/conftest.py
@@ -135,6 +135,32 @@ def _isolate_cwd(tmp_path, monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _neutralize_nauro_command_probe(monkeypatch):
+    """Never spawn a real nauro binary, and reset the resolver cache per test.
+
+    ``_find_nauro_command`` (setup) and ``nauro status`` liveness both go through
+    ``nauro.cli.utils.probe_nauro_command`` — the single subprocess seam. Default
+    it to "runs fine" and mark every path durable so surface-wiring tests take
+    the historical fast path (record the interpreter-sibling, no warning) and get
+    a valid absolute command without a subprocess. Tests that exercise
+    dead/fragile wiring override these on their own monkeypatch instance (later
+    setattr wins). The module-level resolver cache is cleared so each test
+    resolves fresh and any warnings emit deterministically.
+
+    Probe/durability unit tests capture the real functions at import time (before
+    this fixture patches) and call them directly, so they are unaffected.
+    """
+    from nauro.cli import utils as cli_utils
+    from nauro.cli.commands import setup as setup_mod
+
+    monkeypatch.setattr(cli_utils, "probe_nauro_command", lambda cmd, **kwargs: True)
+    monkeypatch.setattr(cli_utils, "_is_durable_install_path", lambda path: True)
+    setup_mod._find_nauro_command_cache_clear()
+    yield
+    setup_mod._find_nauro_command_cache_clear()
+
+
+@pytest.fixture(autouse=True)
 def _isolate_nauro_home(tmp_path, monkeypatch):
     """Point NAURO_HOME at tmp_path so tests never see the dev's real store.
 

--- a/packages/nauro/tests/snapshots/public_contract_v1.json
+++ b/packages/nauro/tests/snapshots/public_contract_v1.json
@@ -1274,6 +1274,17 @@
         "name": "status",
         "params": [
           {
+            "default": false,
+            "flags": [
+              "--no-probe"
+            ],
+            "is_flag": true,
+            "kind": "option",
+            "name": "no_probe",
+            "required": false,
+            "type": "boolean"
+          },
+          {
             "flags": [
               "--project"
             ],

--- a/packages/nauro/tests/test_cli_status.py
+++ b/packages/nauro/tests/test_cli_status.py
@@ -5,6 +5,7 @@ import json
 from typer.testing import CliRunner
 
 import nauro.cli.commands.status as status_mod
+from nauro.cli import utils as cli_utils
 from nauro.cli.main import app
 from nauro.store.registry import register_project
 from nauro.templates.agents_md import FOOTER_MARKER
@@ -139,6 +140,57 @@ def test_status_sync_inactive(tmp_path, monkeypatch):
     result = runner.invoke(app, ["status"])
     assert result.exit_code == 0
     assert "Sync          inactive" in result.output
+
+
+# ── MCP liveness probe ──────────────────────────────────────────────────────
+
+
+def test_status_mcp_broken_when_recorded_command_dead(tmp_path, monkeypatch):
+    """Wired but the recorded command fails the liveness probe → BROKEN, exit 0."""
+    _setup_project(tmp_path, monkeypatch)
+    _wire_repo_mcp(tmp_path)
+    monkeypatch.setattr(cli_utils, "probe_nauro_command", lambda cmd, **kwargs: False)
+
+    result = runner.invoke(app, ["status"])
+    assert result.exit_code == 0
+    assert "MCP           BROKEN" in result.output
+    assert "won't run" in result.output
+    assert "re-run 'nauro setup all'" in result.output
+
+
+def test_status_no_probe_skips_liveness(tmp_path, monkeypatch):
+    """`--no-probe` reports presence only and never calls the probe."""
+    _setup_project(tmp_path, monkeypatch)
+    _wire_repo_mcp(tmp_path)
+    calls: list[str] = []
+    monkeypatch.setattr(
+        cli_utils, "probe_nauro_command", lambda cmd, **kwargs: calls.append(cmd) or True
+    )
+
+    result = runner.invoke(app, ["status", "--no-probe"])
+    assert result.exit_code == 0
+    assert calls == []
+    assert "MCP           active (wired in 1/1 repos)" in result.output
+
+
+def test_status_dedupes_shared_command_to_one_probe(tmp_path, monkeypatch):
+    """N repos sharing one recorded command probe that command exactly once."""
+    repo1 = tmp_path / "repo1"
+    repo2 = tmp_path / "repo2"
+    repo1.mkdir()
+    repo2.mkdir()
+    _setup_project(tmp_path, monkeypatch, repos=[repo1, repo2])
+    _wire_repo_mcp(repo1)
+    _wire_repo_mcp(repo2)
+    calls: list[str] = []
+    monkeypatch.setattr(
+        cli_utils, "probe_nauro_command", lambda cmd, **kwargs: calls.append(cmd) or True
+    )
+
+    result = runner.invoke(app, ["status"])
+    assert result.exit_code == 0
+    assert calls == ["nauro"]  # deduped to a single probe
+    assert "MCP           active (wired in 2/2 repos)" in result.output
 
 
 def test_status_no_project_shows_friendly_message(tmp_path, monkeypatch):

--- a/packages/nauro/tests/test_command_resolution.py
+++ b/packages/nauro/tests/test_command_resolution.py
@@ -1,0 +1,263 @@
+"""Tests for MCP/hook command resolution and validation.
+
+Covers three units introduced to stop Nauro recording a fragile or dead nauro
+path into its MCP and hook configs:
+
+  - ``probe_nauro_command`` — the single subprocess seam (``nauro --version``).
+  - ``_is_durable_install_path`` — the pipx/uv-tool vs project-venv heuristic.
+  - ``_resolve_nauro_command`` — the resolver that prefers a validated durable
+    install, diverts away from a dead/fragile venv, and warns loudly when only a
+    fragile or unresolvable command exists.
+
+The autouse conftest fixture stubs the probe and durability helpers so no other
+test spawns a real binary. These tests capture the real implementations at import
+(before that fixture patches) so they exercise the genuine logic; resolver tests
+override the seam functions on their own monkeypatch instance.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from nauro.cli import utils as cli_utils
+from nauro.cli.commands import setup as setup_mod
+
+# Real implementations captured before the autouse fixture patches them.
+_REAL_PROBE = cli_utils.probe_nauro_command
+_REAL_DURABLE = cli_utils._is_durable_install_path
+
+
+# ── probe_nauro_command ────────────────────────────────────────────────────────
+
+
+class _FakeProc:
+    def __init__(self, returncode: int) -> None:
+        self.returncode = returncode
+
+
+def test_probe_true_on_exit_zero(monkeypatch):
+    monkeypatch.setattr(cli_utils.subprocess, "run", lambda *a, **k: _FakeProc(0))
+    assert _REAL_PROBE("nauro") is True
+
+
+def test_probe_false_on_nonzero_exit(monkeypatch):
+    monkeypatch.setattr(cli_utils.subprocess, "run", lambda *a, **k: _FakeProc(1))
+    assert _REAL_PROBE("nauro") is False
+
+
+def test_probe_false_on_missing_binary(monkeypatch):
+    def boom(*a, **k):
+        raise FileNotFoundError("nauro")
+
+    monkeypatch.setattr(cli_utils.subprocess, "run", boom)
+    assert _REAL_PROBE("/gone/nauro") is False
+
+
+def test_probe_false_on_timeout(monkeypatch):
+    def boom(*a, **k):
+        raise subprocess.TimeoutExpired(cmd="nauro", timeout=1.5)
+
+    monkeypatch.setattr(cli_utils.subprocess, "run", boom)
+    assert _REAL_PROBE("nauro") is False
+
+
+def test_probe_invokes_version_subcommand(monkeypatch):
+    seen: dict = {}
+
+    def capture(cmd, **kwargs):
+        seen["cmd"] = cmd
+        return _FakeProc(0)
+
+    monkeypatch.setattr(cli_utils.subprocess, "run", capture)
+    _REAL_PROBE("/opt/nauro")
+    assert seen["cmd"] == ["/opt/nauro", "--version"]
+
+
+# ── _is_durable_install_path ───────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        # pipx / uv-tool layouts are durable.
+        ("/home/u/.local/pipx/venvs/nauro/bin/nauro", True),
+        ("/home/u/.local/share/uv/tools/nauro/bin/nauro", True),
+        # Project-local virtualenvs are fragile (grandparent is the venv dir).
+        ("/repo/.venv/bin/nauro", False),
+        ("/repo/venv/bin/nauro", False),
+        ("/repo/env/bin/nauro", False),
+        # System / Homebrew / conda: unknown shape defaults to durable.
+        ("/usr/local/bin/nauro", True),
+        ("/opt/homebrew/bin/nauro", True),
+        ("/home/u/miniconda3/envs/proj/bin/nauro", True),
+        # Windows Scripts layout (forward slashes so Path.parts splits on POSIX
+        # test hosts): the .venv grandparent still marks it fragile, pipx durable.
+        ("/c/Users/me/project/.venv/Scripts/nauro.exe", False),
+        ("/c/Users/me/pipx/venvs/nauro/Scripts/nauro.exe", True),
+    ],
+)
+def test_is_durable_install_path(path, expected):
+    assert _REAL_DURABLE(path) is expected
+
+
+# ── _resolve_nauro_command ─────────────────────────────────────────────────────
+
+
+def _wire_resolver(monkeypatch, *, sibling, which, probe, durable):
+    """Point the resolver at controlled candidates and seam functions."""
+    monkeypatch.setattr(setup_mod, "_interpreter_sibling_candidate", lambda: sibling)
+    monkeypatch.setattr(setup_mod.shutil, "which", lambda name: which)
+    monkeypatch.setattr(cli_utils, "probe_nauro_command", probe)
+    monkeypatch.setattr(cli_utils, "_is_durable_install_path", durable)
+
+
+def test_resolver_records_durable_sibling_without_warning(monkeypatch, capsys):
+    """Fast path: a sibling that runs and looks durable is recorded, no warning.
+
+    This is the pipx/uv-tool/desktop flow — must stay byte-identical to before.
+    """
+    sibling = "/opt/pipx/venvs/nauro/bin/nauro"
+    _wire_resolver(
+        monkeypatch,
+        sibling=sibling,
+        which="/usr/local/bin/nauro",
+        probe=lambda cmd, **k: True,
+        durable=lambda p: True,
+    )
+    assert setup_mod._resolve_nauro_command() == sibling
+    assert capsys.readouterr().err == ""
+
+
+def test_resolver_diverts_to_which_when_sibling_dead(monkeypatch, capsys):
+    """A dead fragile project-venv sibling diverts to a healthy durable PATH shim."""
+    sibling = "/repo/.venv/bin/nauro"
+    which = "/opt/pipx/venvs/nauro/bin/nauro"
+    _wire_resolver(
+        monkeypatch,
+        sibling=sibling,
+        which=which,
+        probe=lambda cmd, **k: cmd == which,  # sibling crashes on import
+        durable=lambda p: p == which,  # sibling is fragile, which is durable
+    )
+    assert setup_mod._resolve_nauro_command() == which
+    # Silent divert — no warning when a durable replacement is found.
+    assert capsys.readouterr().err == ""
+
+
+def test_resolver_records_fragile_sibling_with_warning(monkeypatch, capsys):
+    """Only a fragile-but-working sibling exists → record it, but warn loudly."""
+    sibling = "/repo/.venv/bin/nauro"
+    _wire_resolver(
+        monkeypatch,
+        sibling=sibling,
+        which=None,  # nothing durable on PATH
+        probe=lambda cmd, **k: True,  # sibling runs
+        durable=lambda p: False,  # ...but is fragile
+    )
+    assert setup_mod._resolve_nauro_command() == sibling
+    err = capsys.readouterr().err
+    assert "WARNING" in err
+    assert "virtualenv" in err
+    assert sibling in err
+
+
+def test_resolver_falls_back_with_loud_warning_when_nothing_runs(monkeypatch, capsys):
+    """Nothing validates → keep the best absolute path and warn MCP won't work."""
+    sibling = "/repo/.venv/bin/nauro"
+    _wire_resolver(
+        monkeypatch,
+        sibling=sibling,
+        which=None,
+        probe=lambda cmd, **k: False,  # nothing runs
+        durable=lambda p: False,
+    )
+    assert setup_mod._resolve_nauro_command() == sibling
+    err = capsys.readouterr().err
+    assert "WARNING" in err
+    assert "will not work" in err
+
+
+def test_resolver_bare_nauro_only_as_last_resort(monkeypatch, capsys):
+    """Bare ``nauro`` is recorded only when no absolute path exists at all."""
+    _wire_resolver(
+        monkeypatch,
+        sibling=None,
+        which=None,
+        probe=lambda cmd, **k: False,
+        durable=lambda p: False,
+    )
+    assert setup_mod._resolve_nauro_command() == "nauro"
+    assert "WARNING" in capsys.readouterr().err
+
+
+def test_resolver_never_prefers_bare_over_absolute(monkeypatch, capsys):
+    """Guarantee: an available absolute path always beats bare ``nauro``."""
+    sibling = "/repo/.venv/bin/nauro"
+    _wire_resolver(
+        monkeypatch,
+        sibling=sibling,
+        which="/usr/local/bin/nauro",
+        probe=lambda cmd, **k: False,  # neither validates
+        durable=lambda p: False,
+    )
+    result = setup_mod._resolve_nauro_command()
+    assert result != "nauro"
+    assert result == sibling  # best absolute path retained
+    capsys.readouterr()
+
+
+# ── memoization ────────────────────────────────────────────────────────────────
+
+
+def test_find_nauro_command_memoizes_resolution(monkeypatch):
+    """The cached entrypoint resolves once; a second call spawns no new probe."""
+    calls: list[str] = []
+
+    def counting_probe(cmd, **kwargs):
+        calls.append(cmd)
+        return True
+
+    monkeypatch.setattr(
+        setup_mod, "_interpreter_sibling_candidate", lambda: "/opt/pipx/venvs/nauro/bin/nauro"
+    )
+    monkeypatch.setattr(setup_mod.shutil, "which", lambda name: None)
+    monkeypatch.setattr(cli_utils, "probe_nauro_command", counting_probe)
+    monkeypatch.setattr(cli_utils, "_is_durable_install_path", lambda p: True)
+    setup_mod._find_nauro_command_cache_clear()
+
+    first = setup_mod._find_nauro_command()
+    after_first = len(calls)
+    second = setup_mod._find_nauro_command()
+
+    assert first == second == "/opt/pipx/venvs/nauro/bin/nauro"
+    assert len(calls) == after_first  # no re-probe on the cached call
+
+
+def test_setup_all_resolves_command_once(tmp_path, monkeypatch):
+    """`setup all` validates the entrypoint once across all five sinks."""
+    from nauro.cli.commands.setup import setup_all_surfaces
+
+    repo1 = tmp_path / "repo1"
+    repo2 = tmp_path / "repo2"
+    repo1.mkdir()
+    repo2.mkdir()
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        setup_mod, "_interpreter_sibling_candidate", lambda: "/opt/pipx/venvs/nauro/bin/nauro"
+    )
+    monkeypatch.setattr(setup_mod.shutil, "which", lambda name: None)
+    monkeypatch.setattr(
+        cli_utils, "probe_nauro_command", lambda cmd, **k: calls.append(cmd) or True
+    )
+    monkeypatch.setattr(cli_utils, "_is_durable_install_path", lambda p: True)
+    setup_mod._find_nauro_command_cache_clear()
+
+    setup_all_surfaces([repo1, repo2], remove=False)
+
+    # Two repos × two JSON surfaces + codex would be five _find_nauro_command
+    # calls; memoization collapses them to a single probe.
+    assert len(calls) == 1

--- a/packages/nauro/tests/test_command_resolution.py
+++ b/packages/nauro/tests/test_command_resolution.py
@@ -225,7 +225,7 @@ def test_find_nauro_command_memoizes_resolution(monkeypatch):
     monkeypatch.setattr(setup_mod.shutil, "which", lambda name: None)
     monkeypatch.setattr(cli_utils, "probe_nauro_command", counting_probe)
     monkeypatch.setattr(cli_utils, "_is_durable_install_path", lambda p: True)
-    setup_mod._find_nauro_command_cache_clear()
+    setup_mod._find_nauro_command.cache_clear()
 
     first = setup_mod._find_nauro_command()
     after_first = len(calls)
@@ -254,7 +254,7 @@ def test_setup_all_resolves_command_once(tmp_path, monkeypatch):
         cli_utils, "probe_nauro_command", lambda cmd, **k: calls.append(cmd) or True
     )
     monkeypatch.setattr(cli_utils, "_is_durable_install_path", lambda p: True)
-    setup_mod._find_nauro_command_cache_clear()
+    setup_mod._find_nauro_command.cache_clear()
 
     setup_all_surfaces([repo1, repo2], remove=False)
 


### PR DESCRIPTION
## Why

Nauro's MCP/hook wiring recorded the `nauro` console script next to the running
interpreter with no check that it actually runs, and preferred it even when it
was a project-virtualenv path. Run through a repo's own venv (`uv run nauro
adopt`, `.venv/bin/nauro setup ...`), that fragile path landed in every sink —
`.mcp.json`, `.cursor/mcp.json`, `~/.codex/config.toml`, and the `--with-hooks`
command. When the venv was later rebuilt, moved, or corrupted, the recorded
command died and the MCP server and per-turn hooks silently stopped working
(observed: an iCloud-corrupted venv producing `ModuleNotFoundError`). Meanwhile
`nauro status` only checked config-key presence, so a wired-but-dead install
still rendered green.

## What changed

**Resolver (`cli/commands/setup.py`, `cli/utils.py`)**
- New `probe_nauro_command` in `cli/utils.py` validates a candidate with `nauro
  --version` (short timeout, soft-fail) — the single subprocess seam.
- New `_is_durable_install_path` heuristic: pipx (`.../pipx/venvs/...`) and
  uv-tool (`.../uv/tools/...`) layouts are durable; a project-venv grandparent
  (`.venv`/`venv`/`env`) is fragile; anything else defaults to durable.
- `_find_nauro_command` now resolves in order: durable+validated
  interpreter-sibling → durable+validated PATH shim → fragile-but-working
  sibling (recorded with a loud warning) → best absolute path or bare `nauro`
  (recorded with a loud warning that MCP won't work until nauro is on a durable
  PATH). The recorded command stays absolute; bare `nauro` remains only the
  terminal fallback, since GUI-launched clients start with an empty PATH.
- Resolution is memoized per process, so `setup all` validates once, not five
  times; warnings still surface on first resolution.

**Status liveness (`cli/commands/status.py`)**
- After presence detection, `status` extracts the recorded command from each
  wired config, dedupes across repos, and probes each distinct command once
  (bounded parallelism only when more than one). A wired-but-dead install now
  renders a distinct `MCP  BROKEN — … won't run; re-run 'nauro setup all'` row.
- Note that `status` is therefore no longer purely passive: it spawns the
  recorded command with a fixed `--version` argument (`shell=False`, soft-fail,
  short timeout). `--no-probe` restores fully inert, presence-only behavior.
- Status stays read-only, soft-fails every probe, and always exits 0. The
  healthy-path wording is unchanged.

**adopt.py** — the deeper `serve --stdio` post-wiring smoke test is unchanged;
a comment records why it stays separate from the shared `--version` probe.

## Test plan

- `uv run pytest packages/nauro/tests/ packages/nauro-core/tests/` → 2679 passed,
  10 skipped.
- `ruff check packages/` and `ruff format --check packages/` → clean.
- New `test_command_resolution.py` covers the probe, the durability heuristic
  (incl. Windows `Scripts` shape), the four resolver tiers, the
  never-bare-over-absolute guarantee, and memoization (probe called once across
  `setup all`).
- New status tests cover wired-but-dead → BROKEN (exit 0), `--no-probe` → zero
  probe calls, and dedupe → one probe for N repos sharing a command.
- An autouse test fixture stubs the probe so no test spawns a real binary;
  existing setup/adopt/status assertions still pass.

## Risk / what to review

- The public CLI contract snapshot (`public_contract_v1.json`) is regenerated for
  the new `--no-probe` option. This is purely additive (a new optional flag) —
  please confirm it's treated as a minor/additive change, not a major-version
  concern.
