### PR TITLE
Soften tech-lead drift handling to surface-by-default

### DIFF
--- a/packages/nauro/src/nauro/agents/nauro-tech-lead.md
+++ b/packages/nauro/src/nauro/agents/nauro-tech-lead.md
@@ -37,7 +37,7 @@ The approval channel depends on how you were invoked. **Standalone** (the human 
 1. `gh pr view <num> --json title,body,baseRefName,headRefName,commits` + `gh pr diff <num>` for an open PR. Or `git diff <ref>` + `git log <ref>..HEAD --oneline` locally.
 2. For every architectural choice visible in the diff, `check_decision` against a description of the choice.
 3. For every decision reference in the PR body, `get_decision` and verify the cited claim matches the body.
-4. If the PR drifts from doctrine, the usual move is to require a supersede *first* — don't approve the drift; draft the supersede, present it via `AskUserQuestion` (options: `Approve and file` / `Reject` / `Modify draft`), and only on `Approve and file` call `propose_decision`. Hold the merge until the supersede lands.
+4. If the PR drifts from doctrine, SURFACE the drift first — don't approve it silently, and don't default to filing either. Present the conflict with a drafted supersede via `AskUserQuestion` (options: `Approve and file` / `Reject` / `Modify draft`), and only on `Approve and file` call `propose_decision`. Hold the merge for a landed supersede only when merging would bake the contradiction into the frozen public surface (the CLI commands/flags, the MCP tool schemas, or the store format) or write it into the project store; otherwise the human may merge, with the drift reported under Surfaced for human review.
 5. Return verdict + findings + any drafted supersedes and their `AskUserQuestion` outcomes.
 
 ## What you file vs what you surface
@@ -101,7 +101,7 @@ Summary: <one-line take. If RED, name the single most expensive direction.>
 ```
 
 VERDICT escalation:
-- **RED** — proposed change or observed work directly contradicts an active decision. Standard path: redirect or supersede before proceeding; holds merges in Mode C. *Overridable inline by the human* ("override RED on the cited decision, proceed") — the override is explicit, surfaces in the transcript, and does not require a supersede to be filed.
+- **RED** — proposed change or observed work directly contradicts an active decision. Standard path: redirect or supersede before proceeding. In Mode C, RED holds the merge when merging would bake the contradiction into the frozen public surface or write it into the project store (step 4); for other drift, surface the conflict and let the human rule on merging. *Overridable inline by the human* ("override RED on the cited decision, proceed") — the override is explicit, surfaces in the transcript, and does not require a supersede to be filed.
 - **AMBER** — proceed with the constraints in the assessment.
 - **GREEN** — no doctrine concern; proceed.
 


### PR DESCRIPTION
## Why

The tech-lead subagent's doctrine pass treated any perceived drift as requiring a filed supersede before merge, which biases review rounds toward writing doctrine rather than surfacing judgment calls to the human. A process audit flagged the clause; the maintainer directed a surface-by-default posture.

## What changed

Two sentences in the bundled tech-lead agent contract. On doctrine drift, the agent surfaces the conflict with a drafted supersede for the human's ruling as before, but holds the merge for a landed supersede only when merging would bake the contradiction into the frozen public surface (the CLI commands/flags, the MCP tool schemas, or the store format) or write it into the project store; otherwise the human may merge, with the drift reported for human review. The RED verdict escalation clause is aligned to the same rule so the two sections cannot fork agent behavior. The human approval gate before any filing is unchanged, and the explicit inline override for RED is unchanged.

Deliberate scope note: inside the ship-task chain, a RED verdict still pauses at the chain's human push gate ("do not push past a RED tech-lead verdict without an explicit human override"); that pause is itself the surface-to-human behavior this change wants, so the chain wording is intentionally untouched. This change governs the tech-lead's own default demand for a landed supersede, standalone or in-chain.

## Test plan

Prose-only change to a bundled agent asset; no runtime surface. `uv run ruff check packages/` and `uv run ruff format --check packages/` stay clean; `uv run pytest packages/nauro/tests/ -x -q` unaffected.

## Risk / what to review

The softened clause must not weaken the human gate: filing still requires explicit approval via the question flow; only the merge-hold default changes. Check the RED clause and step 4 read as one consistent rule.
