### PR TITLE
Align human-ratified approval contracts

### DIFF
--- a/.agents/skills/nauro-adopt/SKILL.md
+++ b/.agents/skills/nauro-adopt/SKILL.md
@@ -37,21 +37,21 @@ Per card, the agent prepares:
 - **An empty "your why" field**, separate from the read-only spans, left blank for the user to fill or edit. The agent never pre-fills this field with the source span or with anything else — a human-supplied or human-edited "why" lives only here, never folded into the read-only span.
 - **Confidence** — `high` only when the source carries a literal ADR `Status: Accepted`; otherwise `medium`. Tone, emphasis, or a confident-sounding paragraph never promote to `high`.
 
-### Step 0.2 — Pre-check each card
+### Step 0.2: Pre-check and classify each card
 
-Before presenting the batch, the agent calls `check_decision(proposed_approach=<title plus the one-line summary>, project_id=...)` **once per card** and annotates each card with any overlap the pre-pass surfaces (the related decisions and the assessment line). This is the same pre-pass Step 7 step 1 runs; doing it up front lets the user see, on each card, whether it collides with a decision already in the store before the batch is confirmed.
+Before presenting the batch, the agent runs Step 7 steps 1–3 for each card: call `check_decision(proposed_approach=<title plus the one-line summary>, project_id=...)` **once per card**, read every related decision, classify the operation, and prepare the complete operation-specific proposal. Annotate each card with the related decisions and assessment from the pre-pass. Doing this up front lets the batch show the exact proposed write and any overlap before confirmation.
 
 ### Step 0.3 — One batch confirm
 
-The agent presents all cards as a single batch and waits for one reply:
+The agent presents all complete classified proposals as a single batch and waits for one reply. Each card includes its operation, affected decision id when applicable, title, rationale, rejected alternatives, confidence, related decisions, and assessment:
 
 > Reply `confirm 1 3` / `skip 2` / `edit 3: <title>` / `confirm all` / `skip all`.
 
-`edit N: <title>` adjusts the title only; rationale stays the cited span. A user "why" goes through the separate empty field, never by editing a read-only span.
+`confirm` is explicit approval for the complete proposal shown on that card. `edit N: <title>` adjusts the title only; rationale stays the cited span. A user "why" goes through the separate empty field, never by editing a read-only span. An edit changes the proposal, so the agent reruns Step 0.2 and presents the revised card for fresh approval.
 
 ### Step 0.4 — File confirmed cards through Step 7's write loop
 
-For each confirmed card, the agent files it through the **unchanged** Step 7 write loop — the screened `propose_decision` path described there. Step 0 never calls a direct-write bypass; it routes every card through the same screened proposal the rest of the skill uses.
+For each confirmed card, the agent routes it through the **unchanged** Step 7 write loop, the screened `propose_decision` path described there. Step 0 never calls a direct-write bypass. If the Step 7 recheck changes the operation, payload, related decisions, or assessment from what the user confirmed, the agent presents the revised complete proposal and waits for fresh approval before filing.
 
 - The rationale written for a card carries its provenance as a free-text line inside the rationale body: `Source: <file>:<line>`. This is plain rationale text — not a new field — and it round-trips through the decision format unchanged.
 - The agent **captures the `propose_decision` return status for every card** and does not assume confirm means filed. A card can come back **rejected** even after the user confirmed it — most commonly when its normalized title collides with a card written earlier in the *same* batch (active-title dedup). The agent reports each rejected card by title and reason, and does not silently drop it.
@@ -168,7 +168,8 @@ For each kept candidate from 6a and each rationale-supplied 6b answer, the agent
     - **update** when the candidate augments an existing decision's rationale only. The server consumes only `rationale` on update; `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, and `rejected` are rejected at the boundary — use supersede if any of those must change.
     - **supersede** when the title or other metadata must change, or the candidate replaces or contradicts an existing decision. Pass the full new body and set `affected_decision_id`.
     - **skip** when the candidate is a duplicate (e.g. matches `001-initial-setup` or a candidate already seeded earlier in this same adopt run).
-4. Call `propose_decision` using the call signature for the chosen operation — these are operation-specific by design so an agent copying the template cannot accidentally send a field the server will reject:
+4. Present the complete classified proposal to the user: operation, affected decision id when applicable, title, rationale, rejected alternatives, confidence, and the related decisions and assessment from Step 7 step 1. Earlier `keep` replies select candidates; they do not approve a later `propose_decision` call. A Step 0 `confirm` counts only when the proposal and surfaced overlaps remain unchanged. Otherwise, wait for explicit approval of the exact current proposal and overlaps. On reject, skip it. On modification, revise, rerun `check_decision`, and present the complete proposal again; any changed proposal needs fresh approval.
+5. Only after approval, call `propose_decision` using the call signature for the chosen operation. These are operation-specific by design so an agent copying the template cannot accidentally send a field the server will reject:
     - For **add** (new decisions):
       ```
       propose_decision(project_id=..., title=..., rationale=..., operation="add", rejected=..., confidence=...)
@@ -183,7 +184,7 @@ For each kept candidate from 6a and each rationale-supplied 6b answer, the agent
       ```
 
    `rationale` is drawn from explicit Step 3 source text (6a) or the user's probe answer (6b). `confidence` defaults to `medium`; use `high` only when a source explicitly says "accepted" or "approved". Include rejected alternatives only when the source names them or the user supplies them in the probe answer.
-5. After `propose_decision`, the kernel commits immediately on Tier 1 clean. If `similar_decisions` is non-empty, surface those hits to the user before drafting the next candidate; the human approval gate is the chat-session moment before this call, not a second tool call after it.
+6. After `propose_decision`, the kernel commits immediately on Tier 1 clean. If `similar_decisions` is non-empty, surface those hits to the user before drafting the next candidate; the human approval gate is the chat-session moment before this call, not a second tool call after it.
 
 One `propose_decision` per candidate. No batching across candidates without surfacing each `similar_decisions` response first.
 

--- a/.agents/skills/nauro-ship-task/SKILL.md
+++ b/.agents/skills/nauro-ship-task/SKILL.md
@@ -21,17 +21,19 @@ Pause only at the two explicit gates marked GATE below.
 
 ## Pre-step — Doctrine triage before the planner spins up
 
-Before invoking `@nauro-planner`, the parent session confirms the planner will run `check_decision` first. The planner's contract already requires this, but the chain enforces it explicitly: if the planner returns a RED verdict (proposal directly contradicts an active decision) and drafts a supersede, the chain pauses before the executor sees anything. The user approves the supersede in chat; only after explicit approval does the planner file via `propose_decision` (which commits immediately) and the executor see the approved plan. This is the doctrine equivalent of the plan-approval gate (step 2) firing early — a RED that the user does not resolve never reaches code.
+Before invoking `@nauro-planner`, the parent session confirms the planner will run `check_decision` first. The planner's contract already requires this, but the chain enforces it explicitly: if the planner returns a RED verdict (proposal directly contradicts an active decision) and drafts a supersede, the chain pauses before the executor sees anything. The user approves the supersede in chat; only after explicit approval does the parent re-invoke the planner with that approval so the planner can file via `propose_decision` (which commits immediately). The parent never files a subagent's draft itself. A RED that the user does not resolve never reaches code.
 
 ### 1. Plan
 
-Invoke the `@nauro-planner` subagent with the task description. The planner runs `check_decision` against the proposed approach, classifies as GREEN / AMBER / RED, reads related decision bodies via `get_decision`, investigates the code, and returns a plan in the plan shape (Why / Approach / What changes / What's deferred / Test plan), plus the verdict line and any decision number it drafted.
+Invoke the `@nauro-planner` subagent with the task description. The planner runs `check_decision` against the proposed approach, classifies as GREEN / AMBER / RED, reads related decision bodies via `get_decision`, investigates the code, and returns a plan in the plan shape (Why / Approach / What changes / What's deferred / Test plan), plus the verdict line and any complete decision draft awaiting approval.
 
-If the planner returns RED with a supersede draft, the chain pauses here. Surface the draft to the user. Only on explicit user approval (or an explicit "override RED on the cited decision, proceed") does the chain continue to the executor.
+If the planner returns RED with a supersede draft, the chain pauses here. Surface the complete draft to the user. Only on explicit user approval does the parent re-invoke the planner with that approval to file the exact draft. An explicit "override RED on the cited decision, proceed" may continue without filing, but it is not approval to call `propose_decision`.
 
 ### 2. GATE — plan approval (always when `propose_decision` is in play)
 
-The Nauro chain gates the plan whenever the planner indicates it will file a decision via `propose_decision` for any architectural choice, or whenever the plan records a supersede / update draft. There is no "low-stakes auto-proceed" path when doctrine writes are pending. The user's judgment is the gate on what enters the decision log.
+The Nauro chain gates the plan whenever the planner indicates it will file a decision via `propose_decision` for any architectural choice, or whenever the plan records an `add`, `update`, or `supersede` draft. There is no "low-stakes auto-proceed" path when doctrine writes are pending. The user's judgment is the gate on what enters the decision log.
+
+This gate covers all three operations: `add`, `update`, and `supersede`. Surface the complete proposal draft, including its operation and affected decision when applicable. After explicit approval of that exact draft, re-invoke the planner with that approval so it can file. Rejecting or modifying the draft returns it to the planner; any changed draft requires fresh approval. The parent never files a subagent's draft itself.
 
 A change additionally always gates if any of the following apply:
 
@@ -61,7 +63,9 @@ If the reviewer returns BLOCK, hand the hard-rule failures back to the `@nauro-e
 
 ### 6. Doctrine pass
 
-When the reviewer returns APPROVE or APPROVE WITH NITS, invoke `@nauro-tech-lead` in Mode C on the same local diff. The invocation explicitly carries the chain context the parent already holds: the task description, the planner's verdict and any decision filed at plan time (or deliberately not filed), and the reviewer's verdict with its nits — the tech-lead does not re-infer chain state from the diff alone. The tech-lead reads decisions, scans the diff for architectural choices, and returns GREEN / AMBER / RED with any drafted supersede / update awaiting user approval.
+When the reviewer returns APPROVE or APPROVE WITH NITS, invoke `@nauro-tech-lead` in Mode C on the same local diff. The invocation explicitly carries the chain context the parent already holds: the task description, the planner's verdict and any decision filed at plan time (or deliberately not filed), and the reviewer's verdict with its nits. The tech-lead does not re-infer chain state from the diff alone. It reads decisions, scans the diff for architectural choices, and returns GREEN / AMBER / RED with any complete `add`, `update`, or `supersede` draft awaiting user approval.
+
+Any decision draft pauses the chain before step 7. Surface the complete draft to the user. After explicit approval of that exact draft, re-invoke the tech-lead with that approval so it can file. Rejecting or modifying the draft returns it to the tech-lead; any changed draft requires fresh approval. The parent never files a subagent's draft itself.
 
 - **GREEN** — proceed to the push gate (step 7).
 - **AMBER** — surface the constraints to the user alongside the push gate; user decides whether to address before push or document as a follow-up.

--- a/.claude/skills/nauro-adopt/SKILL.md
+++ b/.claude/skills/nauro-adopt/SKILL.md
@@ -37,21 +37,21 @@ Per card, the agent prepares:
 - **An empty "your why" field**, separate from the read-only spans, left blank for the user to fill or edit. The agent never pre-fills this field with the source span or with anything else — a human-supplied or human-edited "why" lives only here, never folded into the read-only span.
 - **Confidence** — `high` only when the source carries a literal ADR `Status: Accepted`; otherwise `medium`. Tone, emphasis, or a confident-sounding paragraph never promote to `high`.
 
-### Step 0.2 — Pre-check each card
+### Step 0.2: Pre-check and classify each card
 
-Before presenting the batch, the agent calls `check_decision(proposed_approach=<title plus the one-line summary>, project_id=...)` **once per card** and annotates each card with any overlap the pre-pass surfaces (the related decisions and the assessment line). This is the same pre-pass Step 7 step 1 runs; doing it up front lets the user see, on each card, whether it collides with a decision already in the store before the batch is confirmed.
+Before presenting the batch, the agent runs Step 7 steps 1–3 for each card: call `check_decision(proposed_approach=<title plus the one-line summary>, project_id=...)` **once per card**, read every related decision, classify the operation, and prepare the complete operation-specific proposal. Annotate each card with the related decisions and assessment from the pre-pass. Doing this up front lets the batch show the exact proposed write and any overlap before confirmation.
 
 ### Step 0.3 — One batch confirm
 
-The agent presents all cards as a single batch and waits for one reply:
+The agent presents all complete classified proposals as a single batch and waits for one reply. Each card includes its operation, affected decision id when applicable, title, rationale, rejected alternatives, confidence, related decisions, and assessment:
 
 > Reply `confirm 1 3` / `skip 2` / `edit 3: <title>` / `confirm all` / `skip all`.
 
-`edit N: <title>` adjusts the title only; rationale stays the cited span. A user "why" goes through the separate empty field, never by editing a read-only span.
+`confirm` is explicit approval for the complete proposal shown on that card. `edit N: <title>` adjusts the title only; rationale stays the cited span. A user "why" goes through the separate empty field, never by editing a read-only span. An edit changes the proposal, so the agent reruns Step 0.2 and presents the revised card for fresh approval.
 
 ### Step 0.4 — File confirmed cards through Step 7's write loop
 
-For each confirmed card, the agent files it through the **unchanged** Step 7 write loop — the screened `propose_decision` path described there. Step 0 never calls a direct-write bypass; it routes every card through the same screened proposal the rest of the skill uses.
+For each confirmed card, the agent routes it through the **unchanged** Step 7 write loop, the screened `propose_decision` path described there. Step 0 never calls a direct-write bypass. If the Step 7 recheck changes the operation, payload, related decisions, or assessment from what the user confirmed, the agent presents the revised complete proposal and waits for fresh approval before filing.
 
 - The rationale written for a card carries its provenance as a free-text line inside the rationale body: `Source: <file>:<line>`. This is plain rationale text — not a new field — and it round-trips through the decision format unchanged.
 - The agent **captures the `propose_decision` return status for every card** and does not assume confirm means filed. A card can come back **rejected** even after the user confirmed it — most commonly when its normalized title collides with a card written earlier in the *same* batch (active-title dedup). The agent reports each rejected card by title and reason, and does not silently drop it.
@@ -168,7 +168,8 @@ For each kept candidate from 6a and each rationale-supplied 6b answer, the agent
     - **update** when the candidate augments an existing decision's rationale only. The server consumes only `rationale` on update; `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, and `rejected` are rejected at the boundary — use supersede if any of those must change.
     - **supersede** when the title or other metadata must change, or the candidate replaces or contradicts an existing decision. Pass the full new body and set `affected_decision_id`.
     - **skip** when the candidate is a duplicate (e.g. matches `001-initial-setup` or a candidate already seeded earlier in this same adopt run).
-4. Call `propose_decision` using the call signature for the chosen operation — these are operation-specific by design so an agent copying the template cannot accidentally send a field the server will reject:
+4. Present the complete classified proposal to the user: operation, affected decision id when applicable, title, rationale, rejected alternatives, confidence, and the related decisions and assessment from Step 7 step 1. Earlier `keep` replies select candidates; they do not approve a later `propose_decision` call. A Step 0 `confirm` counts only when the proposal and surfaced overlaps remain unchanged. Otherwise, wait for explicit approval of the exact current proposal and overlaps. On reject, skip it. On modification, revise, rerun `check_decision`, and present the complete proposal again; any changed proposal needs fresh approval.
+5. Only after approval, call `propose_decision` using the call signature for the chosen operation. These are operation-specific by design so an agent copying the template cannot accidentally send a field the server will reject:
     - For **add** (new decisions):
       ```
       propose_decision(project_id=..., title=..., rationale=..., operation="add", rejected=..., confidence=...)
@@ -183,7 +184,7 @@ For each kept candidate from 6a and each rationale-supplied 6b answer, the agent
       ```
 
    `rationale` is drawn from explicit Step 3 source text (6a) or the user's probe answer (6b). `confidence` defaults to `medium`; use `high` only when a source explicitly says "accepted" or "approved". Include rejected alternatives only when the source names them or the user supplies them in the probe answer.
-5. After `propose_decision`, the kernel commits immediately on Tier 1 clean. If `similar_decisions` is non-empty, surface those hits to the user before drafting the next candidate; the human approval gate is the chat-session moment before this call, not a second tool call after it.
+6. After `propose_decision`, the kernel commits immediately on Tier 1 clean. If `similar_decisions` is non-empty, surface those hits to the user before drafting the next candidate; the human approval gate is the chat-session moment before this call, not a second tool call after it.
 
 One `propose_decision` per candidate. No batching across candidates without surfacing each `similar_decisions` response first.
 

--- a/.claude/skills/nauro-ship-task/SKILL.md
+++ b/.claude/skills/nauro-ship-task/SKILL.md
@@ -21,17 +21,19 @@ Pause only at the two explicit gates marked GATE below.
 
 ## Pre-step — Doctrine triage before the planner spins up
 
-Before invoking `@nauro-planner`, the parent session confirms the planner will run `check_decision` first. The planner's contract already requires this, but the chain enforces it explicitly: if the planner returns a RED verdict (proposal directly contradicts an active decision) and drafts a supersede, the chain pauses before the executor sees anything. The user approves the supersede in chat; only after explicit approval does the planner file via `propose_decision` (which commits immediately) and the executor see the approved plan. This is the doctrine equivalent of the plan-approval gate (step 2) firing early — a RED that the user does not resolve never reaches code.
+Before invoking `@nauro-planner`, the parent session confirms the planner will run `check_decision` first. The planner's contract already requires this, but the chain enforces it explicitly: if the planner returns a RED verdict (proposal directly contradicts an active decision) and drafts a supersede, the chain pauses before the executor sees anything. The user approves the supersede in chat; only after explicit approval does the parent re-invoke the planner with that approval so the planner can file via `propose_decision` (which commits immediately). The parent never files a subagent's draft itself. A RED that the user does not resolve never reaches code.
 
 ### 1. Plan
 
-Invoke the `@nauro-planner` subagent with the task description. The planner runs `check_decision` against the proposed approach, classifies as GREEN / AMBER / RED, reads related decision bodies via `get_decision`, investigates the code, and returns a plan in the plan shape (Why / Approach / What changes / What's deferred / Test plan), plus the verdict line and any decision number it drafted.
+Invoke the `@nauro-planner` subagent with the task description. The planner runs `check_decision` against the proposed approach, classifies as GREEN / AMBER / RED, reads related decision bodies via `get_decision`, investigates the code, and returns a plan in the plan shape (Why / Approach / What changes / What's deferred / Test plan), plus the verdict line and any complete decision draft awaiting approval.
 
-If the planner returns RED with a supersede draft, the chain pauses here. Surface the draft to the user. Only on explicit user approval (or an explicit "override RED on the cited decision, proceed") does the chain continue to the executor.
+If the planner returns RED with a supersede draft, the chain pauses here. Surface the complete draft to the user. Only on explicit user approval does the parent re-invoke the planner with that approval to file the exact draft. An explicit "override RED on the cited decision, proceed" may continue without filing, but it is not approval to call `propose_decision`.
 
 ### 2. GATE — plan approval (always when `propose_decision` is in play)
 
-The Nauro chain gates the plan whenever the planner indicates it will file a decision via `propose_decision` for any architectural choice, or whenever the plan records a supersede / update draft. There is no "low-stakes auto-proceed" path when doctrine writes are pending. The user's judgment is the gate on what enters the decision log.
+The Nauro chain gates the plan whenever the planner indicates it will file a decision via `propose_decision` for any architectural choice, or whenever the plan records an `add`, `update`, or `supersede` draft. There is no "low-stakes auto-proceed" path when doctrine writes are pending. The user's judgment is the gate on what enters the decision log.
+
+This gate covers all three operations: `add`, `update`, and `supersede`. Surface the complete proposal draft, including its operation and affected decision when applicable. After explicit approval of that exact draft, re-invoke the planner with that approval so it can file. Rejecting or modifying the draft returns it to the planner; any changed draft requires fresh approval. The parent never files a subagent's draft itself.
 
 A change additionally always gates if any of the following apply:
 
@@ -61,7 +63,9 @@ If the reviewer returns BLOCK, hand the hard-rule failures back to the `@nauro-e
 
 ### 6. Doctrine pass
 
-When the reviewer returns APPROVE or APPROVE WITH NITS, invoke `@nauro-tech-lead` in Mode C on the same local diff. The invocation explicitly carries the chain context the parent already holds: the task description, the planner's verdict and any decision filed at plan time (or deliberately not filed), and the reviewer's verdict with its nits — the tech-lead does not re-infer chain state from the diff alone. The tech-lead reads decisions, scans the diff for architectural choices, and returns GREEN / AMBER / RED with any drafted supersede / update awaiting user approval.
+When the reviewer returns APPROVE or APPROVE WITH NITS, invoke `@nauro-tech-lead` in Mode C on the same local diff. The invocation explicitly carries the chain context the parent already holds: the task description, the planner's verdict and any decision filed at plan time (or deliberately not filed), and the reviewer's verdict with its nits. The tech-lead does not re-infer chain state from the diff alone. It reads decisions, scans the diff for architectural choices, and returns GREEN / AMBER / RED with any complete `add`, `update`, or `supersede` draft awaiting user approval.
+
+Any decision draft pauses the chain before step 7. Surface the complete draft to the user. After explicit approval of that exact draft, re-invoke the tech-lead with that approval so it can file. Rejecting or modifying the draft returns it to the tech-lead; any changed draft requires fresh approval. The parent never files a subagent's draft itself.
 
 - **GREEN** — proceed to the push gate (step 7).
 - **AMBER** — surface the constraints to the user alongside the push gate; user decides whether to address before push or document as a follow-up.

--- a/.cursor/rules/nauro-adopt.mdc
+++ b/.cursor/rules/nauro-adopt.mdc
@@ -37,21 +37,21 @@ Per card, the agent prepares:
 - **An empty "your why" field**, separate from the read-only spans, left blank for the user to fill or edit. The agent never pre-fills this field with the source span or with anything else — a human-supplied or human-edited "why" lives only here, never folded into the read-only span.
 - **Confidence** — `high` only when the source carries a literal ADR `Status: Accepted`; otherwise `medium`. Tone, emphasis, or a confident-sounding paragraph never promote to `high`.
 
-### Step 0.2 — Pre-check each card
+### Step 0.2: Pre-check and classify each card
 
-Before presenting the batch, the agent calls `check_decision(proposed_approach=<title plus the one-line summary>, project_id=...)` **once per card** and annotates each card with any overlap the pre-pass surfaces (the related decisions and the assessment line). This is the same pre-pass Step 7 step 1 runs; doing it up front lets the user see, on each card, whether it collides with a decision already in the store before the batch is confirmed.
+Before presenting the batch, the agent runs Step 7 steps 1–3 for each card: call `check_decision(proposed_approach=<title plus the one-line summary>, project_id=...)` **once per card**, read every related decision, classify the operation, and prepare the complete operation-specific proposal. Annotate each card with the related decisions and assessment from the pre-pass. Doing this up front lets the batch show the exact proposed write and any overlap before confirmation.
 
 ### Step 0.3 — One batch confirm
 
-The agent presents all cards as a single batch and waits for one reply:
+The agent presents all complete classified proposals as a single batch and waits for one reply. Each card includes its operation, affected decision id when applicable, title, rationale, rejected alternatives, confidence, related decisions, and assessment:
 
 > Reply `confirm 1 3` / `skip 2` / `edit 3: <title>` / `confirm all` / `skip all`.
 
-`edit N: <title>` adjusts the title only; rationale stays the cited span. A user "why" goes through the separate empty field, never by editing a read-only span.
+`confirm` is explicit approval for the complete proposal shown on that card. `edit N: <title>` adjusts the title only; rationale stays the cited span. A user "why" goes through the separate empty field, never by editing a read-only span. An edit changes the proposal, so the agent reruns Step 0.2 and presents the revised card for fresh approval.
 
 ### Step 0.4 — File confirmed cards through Step 7's write loop
 
-For each confirmed card, the agent files it through the **unchanged** Step 7 write loop — the screened `propose_decision` path described there. Step 0 never calls a direct-write bypass; it routes every card through the same screened proposal the rest of the skill uses.
+For each confirmed card, the agent routes it through the **unchanged** Step 7 write loop, the screened `propose_decision` path described there. Step 0 never calls a direct-write bypass. If the Step 7 recheck changes the operation, payload, related decisions, or assessment from what the user confirmed, the agent presents the revised complete proposal and waits for fresh approval before filing.
 
 - The rationale written for a card carries its provenance as a free-text line inside the rationale body: `Source: <file>:<line>`. This is plain rationale text — not a new field — and it round-trips through the decision format unchanged.
 - The agent **captures the `propose_decision` return status for every card** and does not assume confirm means filed. A card can come back **rejected** even after the user confirmed it — most commonly when its normalized title collides with a card written earlier in the *same* batch (active-title dedup). The agent reports each rejected card by title and reason, and does not silently drop it.
@@ -168,7 +168,8 @@ For each kept candidate from 6a and each rationale-supplied 6b answer, the agent
     - **update** when the candidate augments an existing decision's rationale only. The server consumes only `rationale` on update; `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, and `rejected` are rejected at the boundary — use supersede if any of those must change.
     - **supersede** when the title or other metadata must change, or the candidate replaces or contradicts an existing decision. Pass the full new body and set `affected_decision_id`.
     - **skip** when the candidate is a duplicate (e.g. matches `001-initial-setup` or a candidate already seeded earlier in this same adopt run).
-4. Call `propose_decision` using the call signature for the chosen operation — these are operation-specific by design so an agent copying the template cannot accidentally send a field the server will reject:
+4. Present the complete classified proposal to the user: operation, affected decision id when applicable, title, rationale, rejected alternatives, confidence, and the related decisions and assessment from Step 7 step 1. Earlier `keep` replies select candidates; they do not approve a later `propose_decision` call. A Step 0 `confirm` counts only when the proposal and surfaced overlaps remain unchanged. Otherwise, wait for explicit approval of the exact current proposal and overlaps. On reject, skip it. On modification, revise, rerun `check_decision`, and present the complete proposal again; any changed proposal needs fresh approval.
+5. Only after approval, call `propose_decision` using the call signature for the chosen operation. These are operation-specific by design so an agent copying the template cannot accidentally send a field the server will reject:
     - For **add** (new decisions):
       ```
       propose_decision(project_id=..., title=..., rationale=..., operation="add", rejected=..., confidence=...)
@@ -183,7 +184,7 @@ For each kept candidate from 6a and each rationale-supplied 6b answer, the agent
       ```
 
    `rationale` is drawn from explicit Step 3 source text (6a) or the user's probe answer (6b). `confidence` defaults to `medium`; use `high` only when a source explicitly says "accepted" or "approved". Include rejected alternatives only when the source names them or the user supplies them in the probe answer.
-5. After `propose_decision`, the kernel commits immediately on Tier 1 clean. If `similar_decisions` is non-empty, surface those hits to the user before drafting the next candidate; the human approval gate is the chat-session moment before this call, not a second tool call after it.
+6. After `propose_decision`, the kernel commits immediately on Tier 1 clean. If `similar_decisions` is non-empty, surface those hits to the user before drafting the next candidate; the human approval gate is the chat-session moment before this call, not a second tool call after it.
 
 One `propose_decision` per candidate. No batching across candidates without surfacing each `similar_decisions` response first.
 

--- a/.cursor/rules/nauro-ship-task.mdc
+++ b/.cursor/rules/nauro-ship-task.mdc
@@ -21,17 +21,19 @@ Pause only at the two explicit gates marked GATE below.
 
 ## Pre-step — Doctrine triage before the planner spins up
 
-Before invoking `@nauro-planner`, the parent session confirms the planner will run `check_decision` first. The planner's contract already requires this, but the chain enforces it explicitly: if the planner returns a RED verdict (proposal directly contradicts an active decision) and drafts a supersede, the chain pauses before the executor sees anything. The user approves the supersede in chat; only after explicit approval does the planner file via `propose_decision` (which commits immediately) and the executor see the approved plan. This is the doctrine equivalent of the plan-approval gate (step 2) firing early — a RED that the user does not resolve never reaches code.
+Before invoking `@nauro-planner`, the parent session confirms the planner will run `check_decision` first. The planner's contract already requires this, but the chain enforces it explicitly: if the planner returns a RED verdict (proposal directly contradicts an active decision) and drafts a supersede, the chain pauses before the executor sees anything. The user approves the supersede in chat; only after explicit approval does the parent re-invoke the planner with that approval so the planner can file via `propose_decision` (which commits immediately). The parent never files a subagent's draft itself. A RED that the user does not resolve never reaches code.
 
 ### 1. Plan
 
-Invoke the `@nauro-planner` subagent with the task description. The planner runs `check_decision` against the proposed approach, classifies as GREEN / AMBER / RED, reads related decision bodies via `get_decision`, investigates the code, and returns a plan in the plan shape (Why / Approach / What changes / What's deferred / Test plan), plus the verdict line and any decision number it drafted.
+Invoke the `@nauro-planner` subagent with the task description. The planner runs `check_decision` against the proposed approach, classifies as GREEN / AMBER / RED, reads related decision bodies via `get_decision`, investigates the code, and returns a plan in the plan shape (Why / Approach / What changes / What's deferred / Test plan), plus the verdict line and any complete decision draft awaiting approval.
 
-If the planner returns RED with a supersede draft, the chain pauses here. Surface the draft to the user. Only on explicit user approval (or an explicit "override RED on the cited decision, proceed") does the chain continue to the executor.
+If the planner returns RED with a supersede draft, the chain pauses here. Surface the complete draft to the user. Only on explicit user approval does the parent re-invoke the planner with that approval to file the exact draft. An explicit "override RED on the cited decision, proceed" may continue without filing, but it is not approval to call `propose_decision`.
 
 ### 2. GATE — plan approval (always when `propose_decision` is in play)
 
-The Nauro chain gates the plan whenever the planner indicates it will file a decision via `propose_decision` for any architectural choice, or whenever the plan records a supersede / update draft. There is no "low-stakes auto-proceed" path when doctrine writes are pending. The user's judgment is the gate on what enters the decision log.
+The Nauro chain gates the plan whenever the planner indicates it will file a decision via `propose_decision` for any architectural choice, or whenever the plan records an `add`, `update`, or `supersede` draft. There is no "low-stakes auto-proceed" path when doctrine writes are pending. The user's judgment is the gate on what enters the decision log.
+
+This gate covers all three operations: `add`, `update`, and `supersede`. Surface the complete proposal draft, including its operation and affected decision when applicable. After explicit approval of that exact draft, re-invoke the planner with that approval so it can file. Rejecting or modifying the draft returns it to the planner; any changed draft requires fresh approval. The parent never files a subagent's draft itself.
 
 A change additionally always gates if any of the following apply:
 
@@ -61,7 +63,9 @@ If the reviewer returns BLOCK, hand the hard-rule failures back to the `@nauro-e
 
 ### 6. Doctrine pass
 
-When the reviewer returns APPROVE or APPROVE WITH NITS, invoke `@nauro-tech-lead` in Mode C on the same local diff. The invocation explicitly carries the chain context the parent already holds: the task description, the planner's verdict and any decision filed at plan time (or deliberately not filed), and the reviewer's verdict with its nits — the tech-lead does not re-infer chain state from the diff alone. The tech-lead reads decisions, scans the diff for architectural choices, and returns GREEN / AMBER / RED with any drafted supersede / update awaiting user approval.
+When the reviewer returns APPROVE or APPROVE WITH NITS, invoke `@nauro-tech-lead` in Mode C on the same local diff. The invocation explicitly carries the chain context the parent already holds: the task description, the planner's verdict and any decision filed at plan time (or deliberately not filed), and the reviewer's verdict with its nits. The tech-lead does not re-infer chain state from the diff alone. It reads decisions, scans the diff for architectural choices, and returns GREEN / AMBER / RED with any complete `add`, `update`, or `supersede` draft awaiting user approval.
+
+Any decision draft pauses the chain before step 7. Surface the complete draft to the user. After explicit approval of that exact draft, re-invoke the tech-lead with that approval so it can file. Rejecting or modifying the draft returns it to the tech-lead; any changed draft requires fresh approval. The parent never files a subagent's draft itself.
 
 - **GREEN** — proceed to the push gate (step 7).
 - **AMBER** — surface the constraints to the user alongside the push gate; user decides whether to address before push or document as a follow-up.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Nauro
 
-Nauro gives every connected agent project judgement. It keeps your project's product direction, decisions, rationale, open questions, and rejected paths in plain markdown files, then surfaces the relevant ones before an AI agent plans or changes code.
+Nauro gives every connected agent project judgement. It helps you capture and approve the intent, decisions, tradeoffs, open questions, and rejected paths that define a project, then brings the relevant judgement into an agent's work.
 
-It works across Claude, Cursor, Codex, Perplexity, and any MCP client. The same decision record travels with the work, not with a single tool or session.
+It works across Claude, Cursor, Codex, Perplexity, and any MCP client. The same human-ratified project judgement travels with the work, rather than belonging to a single tool or session.
 
 [![PyPI](https://img.shields.io/pypi/v/nauro.svg)](https://pypi.org/project/nauro/) [![Python](https://img.shields.io/pypi/pyversions/nauro.svg)](https://pypi.org/project/nauro/) [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 
@@ -14,13 +14,20 @@ https://github.com/user-attachments/assets/9e6c475b-c584-470b-84c2-12f01b3a425a
 
 More at [nauro.ai](https://nauro.ai).
 
-## How it works
+## How the loop works
 
-Nauro stores your project's decisions as plain markdown files, each with the alternatives you ruled out and the reasoning behind them. The store can also carry current state and open questions. When an agent proposes an approach, `check_decision` runs deterministic keyword retrieval (BM25) over those files and surfaces the related ones before the agent plans or writes code.
+1. You and an agent capture or elicit the project judgement relevant to the work.
+2. The agent drafts any addition, update, or supersession, and you explicitly approve what becomes project truth.
+3. Relevant judgement reaches an agent before it plans or changes work.
+4. The agent explains how that judgement affected its recommendation or implementation.
+5. You accept, correct, except, reopen, or supersede the result in conversation.
+6. Approved corrections become part of what later agents inherit.
+
+Nauro supports this loop with a plain markdown store, compact context, and deterministic retrieval. Decisions include the alternatives you ruled out and the reasoning behind them; the store can also carry current state and open questions. When an agent proposes an approach, `check_decision` runs keyword retrieval (BM25) over those files and surfaces related records before the agent plans or writes code.
 
 At session start, agents can read a compact L0 standing-context summary: project summary, current state, top open questions, and the last 10 decisions, then pull specific decisions on demand. On Nauro's own 386-decision store, that L0 summary measures about 1,700 tokens against a full store of about 350,000 (o200k_base tokenizer).
 
-No model judges your decisions. The check is advisory and never blocks a change. A decision is recorded only by an explicit write call, and the approval gate lives in the conversation. The store is a folder you own; remove Nauro and the markdown stays.
+No model judges your decisions. The check is advisory and never blocks a change. Agents draft decision additions, updates, and supersessions; you explicitly approve each one in the conversation before `propose_decision` commits it in one call. The store is a folder you own; remove Nauro and the markdown stays.
 
 ## Install
 
@@ -81,15 +88,15 @@ Output abbreviated to the top match; the live call returns all five related deci
 
 ## Why not ADRs, grep, CLAUDE.md, or built-in agent notes?
 
-A decision log in your repo is a good record. The gap is on the read side: a file is read when a person opens it, and a fresh agent session starts with no knowledge that it exists. Nauro closes that gap twice over: the relevant decision reaches your agent through MCP at the moment it proposes a change, and `nauro sync` regenerates a committable `AGENTS.md` summary in every associated repo, so clones and tools without MCP wiring still start from the current record.
+A committed decision log plus a reliable pointer in `AGENTS.md` or `CLAUDE.md` can be enough, especially in a small repo. Nauro is designed for longer histories that must stay available across sessions, tools, repos, machines, or repeated handoffs. It can surface related decisions through MCP when an agent proposes a change, while `nauro sync` regenerates a committable `AGENTS.md` summary for clones and tools without MCP wiring.
 
 Against a coding tool's built-in memory (Claude Code memory, Cursor memories): those are scoped to one tool and one user. Nauro's record belongs to the project. The same store answers in Claude, Cursor, Codex, and any MCP client, across every repo you associate with it.
 
-Against tools that extract notes from conversations automatically: Nauro records decisions instead. An entry is a reviewed choice with its rationale and the alternatives you rejected, written only on an explicit call after approval in the conversation, retrieved by deterministic keyword search you can audit, and superseded rather than silently rewritten. It is plain markdown in a folder you own; remove Nauro and the record stays readable.
+Against tools that extract notes from conversations automatically: Nauro records human-ratified judgement. An entry is a reviewed choice with its rationale and the alternatives you rejected. An agent drafts the change, you explicitly approve it, and `propose_decision` commits it in one call. Entries are retrieved by deterministic keyword search you can audit and superseded rather than silently rewritten. They remain plain markdown in a folder you own.
 
 ## When Nauro helps, and when it doesn't
 
-Nauro pays off when an agent needs project judgement before acting: architecture choices, rejected approaches, migration plans, operational constraints, and decisions that recur across sessions, tools, repos, machines, or handoffs.
+Nauro is designed for long-lived projects where agents need project judgement before acting: architecture choices, rejected approaches, migration plans, operational constraints, and decisions that recur across sessions, tools, repos, machines, or handoffs.
 
 If one small repo plus a tight `CLAUDE.md` already keeps your agents oriented, Nauro may be too much.
 
@@ -131,9 +138,9 @@ Re-running plain `nauro init my-project` in a second repo creates a *separate* p
 **Optional: bundled subagents.** Add `--with-subagents` on `nauro adopt` or `nauro setup` to install Nauro's bundled Claude Code subagents into `~/.claude/agents/`. They are off by default; installed, a typical chain looks like:
 
 - `@nauro-planner` before non-trivial work. Drafts a plan and classifies doctrine risk (GREEN/AMBER/RED) against your decision log.
-- `@nauro-executor` after a plan is agreed. Implements it, runs tests, opens a PR.
+- `@nauro-executor` after a plan is agreed. Implements it, runs tests, commits locally, and drafts the PR body. It does not push or open a PR.
 - `@nauro-reviewer` before merging. Audits the diff for real bugs and for missing decision references.
-- `@nauro-tech-lead` to set or correct direction. Reads the decision log, audits PRs against doctrine, files decisions when direction is established.
+- `@nauro-tech-lead` to set or correct direction. Reads the decision log, audits PRs against doctrine, and drafts any needed doctrine change for your approval.
 
 ## Cross-surface sync (optional)
 

--- a/docs/adopt-prompt.md
+++ b/docs/adopt-prompt.md
@@ -56,21 +56,21 @@ Per card, the agent prepares:
 - **An empty "your why" field**, separate from the read-only spans, left blank for the user to fill or edit. The agent never pre-fills this field with the source span or with anything else — a human-supplied or human-edited "why" lives only here, never folded into the read-only span.
 - **Confidence** — `high` only when the source carries a literal ADR `Status: Accepted`; otherwise `medium`. Tone, emphasis, or a confident-sounding paragraph never promote to `high`.
 
-### Step 0.2 — Pre-check each card
+### Step 0.2: Pre-check and classify each card
 
-Before presenting the batch, the agent calls `check_decision(proposed_approach=<title plus the one-line summary>, project_id=...)` **once per card** and annotates each card with any overlap the pre-pass surfaces (the related decisions and the assessment line). This is the same pre-pass Step 7 step 1 runs; doing it up front lets the user see, on each card, whether it collides with a decision already in the store before the batch is confirmed.
+Before presenting the batch, the agent runs Step 7 steps 1–3 for each card: call `check_decision(proposed_approach=<title plus the one-line summary>, project_id=...)` **once per card**, read every related decision, classify the operation, and prepare the complete operation-specific proposal. Annotate each card with the related decisions and assessment from the pre-pass. Doing this up front lets the batch show the exact proposed write and any overlap before confirmation.
 
 ### Step 0.3 — One batch confirm
 
-The agent presents all cards as a single batch and waits for one reply:
+The agent presents all complete classified proposals as a single batch and waits for one reply. Each card includes its operation, affected decision id when applicable, title, rationale, rejected alternatives, confidence, related decisions, and assessment:
 
 > Reply `confirm 1 3` / `skip 2` / `edit 3: <title>` / `confirm all` / `skip all`.
 
-`edit N: <title>` adjusts the title only; rationale stays the cited span. A user "why" goes through the separate empty field, never by editing a read-only span.
+`confirm` is explicit approval for the complete proposal shown on that card. `edit N: <title>` adjusts the title only; rationale stays the cited span. A user "why" goes through the separate empty field, never by editing a read-only span. An edit changes the proposal, so the agent reruns Step 0.2 and presents the revised card for fresh approval.
 
 ### Step 0.4 — File confirmed cards through Step 7's write loop
 
-For each confirmed card, the agent files it through the **unchanged** Step 7 write loop — the screened `propose_decision` path described there. Step 0 never calls a direct-write bypass; it routes every card through the same screened proposal the rest of the skill uses.
+For each confirmed card, the agent routes it through the **unchanged** Step 7 write loop, the screened `propose_decision` path described there. Step 0 never calls a direct-write bypass. If the Step 7 recheck changes the operation, payload, related decisions, or assessment from what the user confirmed, the agent presents the revised complete proposal and waits for fresh approval before filing.
 
 - The rationale written for a card carries its provenance as a free-text line inside the rationale body: `Source: <file>:<line>`. This is plain rationale text — not a new field — and it round-trips through the decision format unchanged.
 - The agent **captures the `propose_decision` return status for every card** and does not assume confirm means filed. A card can come back **rejected** even after the user confirmed it — most commonly when its normalized title collides with a card written earlier in the *same* batch (active-title dedup). The agent reports each rejected card by title and reason, and does not silently drop it.
@@ -187,7 +187,8 @@ For each kept candidate from 6a and each rationale-supplied 6b answer, the agent
     - **update** when the candidate augments an existing decision's rationale only. The server consumes only `rationale` on update; `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, and `rejected` are rejected at the boundary — use supersede if any of those must change.
     - **supersede** when the title or other metadata must change, or the candidate replaces or contradicts an existing decision. Pass the full new body and set `affected_decision_id`.
     - **skip** when the candidate is a duplicate (e.g. matches `001-initial-setup` or a candidate already seeded earlier in this same adopt run).
-4. Call `propose_decision` using the call signature for the chosen operation — these are operation-specific by design so an agent copying the template cannot accidentally send a field the server will reject:
+4. Present the complete classified proposal to the user: operation, affected decision id when applicable, title, rationale, rejected alternatives, confidence, and the related decisions and assessment from Step 7 step 1. Earlier `keep` replies select candidates; they do not approve a later `propose_decision` call. A Step 0 `confirm` counts only when the proposal and surfaced overlaps remain unchanged. Otherwise, wait for explicit approval of the exact current proposal and overlaps. On reject, skip it. On modification, revise, rerun `check_decision`, and present the complete proposal again; any changed proposal needs fresh approval.
+5. Only after approval, call `propose_decision` using the call signature for the chosen operation. These are operation-specific by design so an agent copying the template cannot accidentally send a field the server will reject:
     - For **add** (new decisions):
       ```
       propose_decision(project_id=..., title=..., rationale=..., operation="add", rejected=..., confidence=...)
@@ -202,7 +203,7 @@ For each kept candidate from 6a and each rationale-supplied 6b answer, the agent
       ```
 
    `rationale` is drawn from explicit Step 3 source text (6a) or the user's probe answer (6b). `confidence` defaults to `medium`; use `high` only when a source explicitly says "accepted" or "approved". Include rejected alternatives only when the source names them or the user supplies them in the probe answer.
-5. After `propose_decision`, the kernel commits immediately on Tier 1 clean. If `similar_decisions` is non-empty, surface those hits to the user before drafting the next candidate; the human approval gate is the chat-session moment before this call, not a second tool call after it.
+6. After `propose_decision`, the kernel commits immediately on Tier 1 clean. If `similar_decisions` is non-empty, surface those hits to the user before drafting the next candidate; the human approval gate is the chat-session moment before this call, not a second tool call after it.
 
 One `propose_decision` per candidate. No batching across candidates without surfacing each `similar_decisions` response first.
 

--- a/packages/nauro/README.md
+++ b/packages/nauro/README.md
@@ -2,7 +2,18 @@
 
 Project judgement for every connected agent.
 
-Your project's product direction, decisions, rationale, open questions, and rejected paths travel with every connected agent. When an agent proposes an approach, Nauro surfaces the related decisions, so the agent sees the prior reasoning before it writes code. The check is advisory: it never blocks, and you approve anything that gets recorded. Works with Claude, Perplexity, Cursor, Codex, and any MCP client.
+Nauro carries human-ratified project judgement across agents, sessions, and tools. It helps you capture and approve the intent, decisions, rationale, open questions, and rejected paths that define a project, then brings the relevant judgement into an agent's work. Works with Claude, Perplexity, Cursor, Codex, and any MCP client.
+
+## How the loop works
+
+1. You and an agent capture or elicit the judgement relevant to the work.
+2. The agent drafts any addition, update, or supersession, and you explicitly approve what becomes project truth.
+3. Relevant judgement reaches an agent before it plans or changes work.
+4. The agent explains how the judgement affected its recommendation or implementation.
+5. You accept, correct, except, reopen, or supersede the result in conversation.
+6. Approved corrections become part of what later agents inherit.
+
+The markdown store, context summaries, BM25 retrieval, advisory checks, and optional sync support this loop. They do not replace your judgement or silently change project truth.
 
 ## Install
 
@@ -41,7 +52,9 @@ You'll see a JSON envelope with the related decisions and a deterministic assess
 }
 ```
 
-The demo project ruled out storing money as floating-point dollars because binary floating point cannot represent a value like 0.10 exactly, so totals accumulate rounding error and a balance that should read 0.00 shows -0.01. Without Nauro, a fresh agent has no record of that and could re-propose a floating-point amount field.
+The demo project ruled out storing money as floating-point dollars because binary floating point cannot represent a value like 0.10 exactly, so totals accumulate rounding error and a balance that should read 0.00 shows -0.01. This protective example isolates Nauro's retrieval mechanism: it brings a recorded constraint into the proposal flow before an agent can re-propose the rejected field.
+
+A committed ADR plus a reliable `AGENTS.md` or `CLAUDE.md` pointer can provide enough continuity in a small repo. Nauro is designed for project judgement that must persist across longer histories, sessions, tools, repos, machines, or repeated handoffs.
 
 `nauro graph` renders the store to one self-contained HTML file and opens it: a node-link map of every decision as the default view, plus drawn supersession lineage, a timeline, and a category browser. The demo store's consolidation, three retired decisions converging on the one that replaced them, draws as a fan. By default the file carries the full decision store, including each decision's body rendered as structured detail in the side panel, and lands in the store directory rather than your repo; `--no-include-bodies` produces a redacted titles-and-metadata artifact for wider sharing.
 
@@ -51,15 +64,15 @@ For real-project setup (`nauro init` / `nauro adopt`), cross-surface access, MCP
 
 ## Why Nauro?
 
-Nauro is decisional, not observational. It captures what you decided and what you ruled out, with the reasoning. When an agent proposes a change, a keyword search over those decisions surfaces the relevant ones, so the prior reasoning is in front of the agent at proposal time.
+Nauro supports a human-ratified project-judgement loop. It captures what you decided and what you ruled out, with the reasoning, then brings related judgement into agent work. Keyword search over the decision store is one mechanism for putting prior reasoning in front of an agent at proposal time.
 
-No model judges your decisions. The check uses deterministic keyword retrieval (BM25), is advisory, and never blocks a change. You approve every decision before it is recorded.
+No model judges your decisions. The check uses deterministic keyword retrieval (BM25), is advisory, and never blocks a change. Agents draft additions, updates, and supersessions; you explicitly approve each one before `propose_decision` commits it in one call.
 
-`check_decision` returns the related prior decisions (the `related_decisions` list shown above) so the agent can weigh them before proposing; Nauro ranks by keyword relevance and does not judge the proposal. When you record a choice with `propose_decision`, near-matches surface as advisory `similar_decisions` on the same call, and a clean proposal commits in one call. What you decide in one tool, every connected agent inherits; for example, a decision recorded in Claude Code is available later in Perplexity. The store is plain markdown in a folder you own. Run it fully locally with no account; cloud sync is opt-in.
+`check_decision` returns the related prior decisions (the `related_decisions` list shown above) so the agent can weigh them before proposing; Nauro ranks by keyword relevance and does not judge the proposal. On the approved `propose_decision` call, near-matches surface as advisory `similar_decisions`, and a clean proposal commits in one call. What you approve in one tool, every connected agent inherits; for example, a decision recorded in Claude Code is available later in Perplexity. The store is plain markdown in a folder you own. Run it fully locally with no account; cloud sync is opt-in.
 
-## Pricing
+## Hosted allowance
 
-Free: unlimited local usage, unlimited projects, 5,000 remote MCP calls/month. See [nauro.ai/pricing](https://nauro.ai/pricing) for hosted tiers.
+Nauro includes unlimited local usage, unlimited projects, and 5,000 remote MCP calls per month. For higher hosted limits, contact [thomas@nauro.ai](mailto:thomas@nauro.ai). See [nauro.ai/pricing](https://nauro.ai/pricing) for current details.
 
 ---
 

--- a/packages/nauro/src/nauro/agents/nauro-planner.md
+++ b/packages/nauro/src/nauro/agents/nauro-planner.md
@@ -1,11 +1,13 @@
 ---
 name: nauro-planner
-description: Use to plan a non-trivial change before any code is written. Classifies doctrine risk (GREEN/AMBER/RED) via Nauro, writes a structured plan, drafts supersedes when proposals contradict active doctrine, and records new decisions before handoff. Use proactively when the user asks "should we...", "what if we...", or "how should we approach X". Returns a plan; does not edit files.
+description: Use to plan a non-trivial change before any code is written. Classifies doctrine risk (GREEN/AMBER/RED) via Nauro, writes a structured plan, and drafts decision additions, updates, or supersedes for explicit user approval before any write. Use proactively when the user asks "should we...", "what if we...", or "how should we approach X". Returns a plan; does not edit files.
 tools: Read, Grep, Glob, WebSearch, WebFetch, Bash, mcp__claude_ai_Nauro__check_decision, mcp__claude_ai_Nauro__propose_decision, mcp__claude_ai_Nauro__get_decision, mcp__claude_ai_Nauro__search_decisions, mcp__claude_ai_Nauro__list_decisions, mcp__claude_ai_Nauro__list_projects, mcp__nauro__check_decision, mcp__nauro__propose_decision, mcp__nauro__get_decision, mcp__nauro__search_decisions, mcp__nauro__list_decisions, mcp__nauro__list_projects, mcp__plugin_nauro_nauro__check_decision, mcp__plugin_nauro_nauro__propose_decision, mcp__plugin_nauro_nauro__get_decision, mcp__plugin_nauro_nauro__search_decisions, mcp__plugin_nauro_nauro__list_decisions, mcp__plugin_nauro_nauro__list_projects
 model: inherit
 ---
 
 You plan changes. You do not implement them. Use Bash for read-only investigation only (git log, grep, ls, gh view) — never for writes.
+
+Every decision proposal uses the same approval rule for all three operations: `add`, `update`, and `supersede`. A planner subagent without a user channel never files directly. It returns the complete draft to the parent, which presents it to the user and re-invokes the planner with the user's explicit approval before any `propose_decision` call. On a standalone invocation, show the complete draft and return without filing; only a later invocation that carries the user's explicit approval may file that exact draft. The kernel commits immediately on Tier 1 clean, so there is no later confirmation step.
 
 ## Required steps before returning
 
@@ -35,7 +37,7 @@ You plan changes. You do not implement them. Use Bash for read-only investigatio
 
         When all four hold, output at the top of the plan: `REFUSE TO DRAFT — the related decision settles this within N days at high confidence; this proposal restates a rejected alternative with no new evidence.` Then surface (a) the load-bearing facts from the related decision, (b) the criteria-for-revisit that would change the answer, and (c) any alternative direction worth investigating if the underlying worry is real. The user can override the refusal by asking for the supersede draft anyway.
 
-    Either way, do not file via `propose_decision` until the user agrees with the direction. Drafting is for human review; filing comes after.
+    Either way, do not file via `propose_decision` in the planning run. Drafting is for human review; filing comes only on a later invocation that carries explicit user approval for the exact draft.
 
 3. **Investigate the current code.** Use Read/Grep/Glob to verify the change is necessary and your mental model matches what's in the repo. Scale to the verdict: GREEN reads a few files; AMBER reads broadly across affected modules; RED reads the full surface of every decision that would be touched.
 
@@ -47,9 +49,9 @@ You plan changes. You do not implement them. Use Bash for read-only investigatio
     - **What's deferred** — anything intentionally out of scope
     - **Test plan** — what proves it works
 
-5. **Record the decision if non-trivial.** Call `propose_decision` when the plan chooses between approaches, replaces a dependency, establishes a pattern, or cuts scope. Always include what was rejected and why. Pick `operation`: `add` (new ground), `update` (augment existing — provide `affected_decision_id`), or `supersede` (replace existing — provide `affected_decision_id`). Prefer `add` when uncertain. A RED verdict that produced an agreed supersede direction lands here — file the draft from Step 2.
+5. **Draft a decision if non-trivial, then gate the write.** When the plan chooses between approaches, replaces a dependency, establishes a pattern, or cuts scope, prepare the complete `propose_decision` payload and include what was rejected and why. Pick `operation`: `add` for new ground, `update` to augment existing rationale (provide `affected_decision_id`), or `supersede` to replace an existing decision (provide `affected_decision_id`). Prefer `add` when uncertain. Return the draft with the related decisions and assessment from `check_decision`, marked as awaiting explicit user approval. If a later invocation carries explicit approval for that exact draft and those surfaced overlaps, call `propose_decision` once and report the result. A changed draft requires fresh approval.
 
-6. **Return.** Give the plan, the verdict, and the decision number (if any). State which Bash commands the executor will need (lint, tests, build).
+6. **Return.** Give the plan, the verdict, and either the complete draft awaiting approval or the decision number from an explicitly approved write. State which Bash commands the executor will need (lint, tests, build).
 
 ## Hard rules
 

--- a/packages/nauro/src/nauro/agents/nauro-tech-lead.md
+++ b/packages/nauro/src/nauro/agents/nauro-tech-lead.md
@@ -1,13 +1,13 @@
 ---
 name: nauro-tech-lead
-description: Use to set or maintain project direction. The tech-lead reads the Nauro decision log, recent session transcripts (by ID), and PR diffs; judges architectural choices against active doctrine; and can file decisions (add / update / supersede) when direction is established. Has write authority on Nauro — but every supersede / update is gated by user approval in chat via `AskUserQuestion` before the agent fires `propose_decision`, so the human keeps the final gate by design. Outranks @nauro-planner and @nauro-reviewer on architectural direction. Invoke before a planner spins up on substantive work, after a substantive session to file decisions made implicitly, or when a PR feels like it's drifting from doctrine.
+description: Use to set or maintain project direction. The tech-lead reads the Nauro decision log, recent session transcripts (by ID), and PR diffs; judges architectural choices against active doctrine; and can file decisions (add / update / supersede) when direction is established. Has write authority on Nauro, but every add, update, and supersede is gated by explicit user approval before the agent fires `propose_decision`. Outranks @nauro-planner and @nauro-reviewer on architectural direction. Invoke before a planner spins up on substantive work, after a substantive session to file decisions made implicitly, or when a PR feels like it's drifting from doctrine.
 tools: Read, Grep, Glob, Bash, AskUserQuestion, mcp__claude_ai_Nauro__get_context, mcp__claude_ai_Nauro__get_decision, mcp__claude_ai_Nauro__search_decisions, mcp__claude_ai_Nauro__list_decisions, mcp__claude_ai_Nauro__list_projects, mcp__claude_ai_Nauro__check_decision, mcp__claude_ai_Nauro__propose_decision, mcp__claude_ai_Nauro__flag_question, mcp__claude_ai_Nauro__update_state, mcp__nauro__get_context, mcp__nauro__get_decision, mcp__nauro__search_decisions, mcp__nauro__list_decisions, mcp__nauro__list_projects, mcp__nauro__check_decision, mcp__nauro__propose_decision, mcp__nauro__flag_question, mcp__nauro__update_state, mcp__plugin_nauro_nauro__get_context, mcp__plugin_nauro_nauro__get_decision, mcp__plugin_nauro_nauro__search_decisions, mcp__plugin_nauro_nauro__list_decisions, mcp__plugin_nauro_nauro__list_projects, mcp__plugin_nauro_nauro__check_decision, mcp__plugin_nauro_nauro__propose_decision, mcp__plugin_nauro_nauro__flag_question, mcp__plugin_nauro_nauro__update_state
 model: inherit
 ---
 
-You set and maintain project direction. You have authority on doctrine: when a plan, a session, or a PR drifts from active decisions, you call it; when an emergent pattern needs a decision, you file it. @nauro-planner, @nauro-executor, and @nauro-reviewer defer to you on architectural direction. The human keeps the final override — every `supersede` and `update` passes through user approval before you call `propose_decision`. The kernel commits immediately on Tier 1 clean; there is no separate confirm step.
+You set and maintain project direction. You have authority on doctrine: when a plan, a session, or a PR drifts from active decisions, you call it; when an emergent pattern needs a decision, you draft it and file only after approval. @nauro-planner, @nauro-executor, and @nauro-reviewer defer to you on architectural direction. The human keeps the final override: every `add`, `update`, and `supersede` passes through explicit user approval before you call `propose_decision`. The kernel commits immediately on Tier 1 clean; there is no separate confirm step.
 
-The approval channel depends on how you were invoked. **Standalone** (the human called you directly): fire `AskUserQuestion` yourself to gate the `supersede` / `update`, then file on approval. **Inside the `/nauro-ship-task` chain**: the parent session owns the user gate — return your drafted `supersede` / `update` in the report for the parent to approve and file, and do not fire `AskUserQuestion` in-run. Either way the human approves before the write; only the channel differs. The return format below marks drafts as "awaiting user approval" precisely so the parent can route them.
+The approval channel depends on how you were invoked. The complete draft includes its operation, full payload, and the related decisions and assessment from `check_decision`. **Standalone** (the human called you directly): present that draft through `AskUserQuestion` with options `Approve and file` / `Reject` / `Modify draft`, then file only on `Approve and file`. **Inside the `/nauro-ship-task` chain**: the parent session owns the user gate, so return the complete draft to the parent and do not file in-run or fire `AskUserQuestion`. After the parent gets explicit user approval, it re-invokes you with that approval so you can file the exact draft. The parent never files your draft itself. This channel rule covers every `add`, `update`, and `supersede`.
 
 ## How to run — three modes
 
@@ -17,7 +17,7 @@ The approval channel depends on how you were invoked. **Standalone** (the human 
 2. `get_decision` on every related result. Do not act on the assessment string alone; the body has the rationale and supersession state.
 3. Cross-reference adjacent surface area via `search_decisions` if the change touches a known contested area.
 4. Return verdict: GREEN (no doctrine concern, proceed), AMBER (proceed with the listed constraints), RED (contradicts active doctrine — redirect or supersede first).
-5. If the right move is to supersede an existing decision, draft the supersede body, present it via `AskUserQuestion` (options: `Approve and file` / `Reject` / `Modify draft`), and only on `Approve and file` call `propose_decision(operation="supersede", ...)`. The kernel commits immediately on Tier 1 clean.
+5. If the direction establishes new doctrine or changes existing doctrine, draft the complete `add`, `update`, or `supersede` payload and route it through the approval channel above. Call `propose_decision` only after explicit approval of that exact draft. The kernel commits immediately on Tier 1 clean.
 
 **Mode B: Session audit and file (post-session).** Caller provides a Claude Code session ID. Transcript lives at:
 
@@ -27,25 +27,25 @@ The approval channel depends on how you were invoked. **Standalone** (the human 
 
 1. Inspect transcript structure with `Read` (limit ~50 lines).
 2. Filter with `jq -c` or `grep` against the raw JSONL — never load the whole file into context.
-3. For each "we decided X" moment without a `propose_decision` follow-up in the transcript, judge whether it was a real architectural decision (between approaches, replacing a dependency, establishing a pattern, cutting scope). If yes, file via `propose_decision`. If borderline, surface for human review.
-4. For each substantive architectural change in the transcript without a `check_decision` precedent, retroactively run `check_decision` now. If contradiction, surface.
+3. For each "we decided X" moment without a `propose_decision` follow-up in the transcript, judge whether it was a real architectural decision (between approaches, replacing a dependency, establishing a pattern, cutting scope). If borderline, surface for human review.
+4. For each real architectural decision identified in step 3, ensure the decision was checked against doctrine and every related decision body was read. If the transcript has no `check_decision` precedent for that choice, run it retroactively. For an existing or retroactive check, call `get_decision` on every related result unless the transcript shows that body was already read. If contradiction, surface. Then draft the complete proposal and route it through the approval channel above. Mode B never files an `add` directly from the transcript.
 5. If the session produced meaningful progress that `state_current.md` does not reflect, call `update_state` with a concise delta. Treat this conservatively — `update_state` is replace-semantics: it wipes the prior state to history.
-6. Return: decisions filed (with numbers), drafts presented via `AskUserQuestion` and their outcomes (`Approve and file` → filed; `Reject` → dropped; `Modify draft` → revised then re-presented), drift findings, items surfaced for human review.
+6. Return: decisions filed after explicit approval (with numbers), drafts routed through the applicable approval channel and their outcomes, drift findings, items surfaced for human review.
 
 **Mode C: PR / diff doctrine audit.** Caller passes a PR number or a git ref. Default ref: `git diff origin/main...HEAD`.
 
 1. `gh pr view <num> --json title,body,baseRefName,headRefName,commits` + `gh pr diff <num>` for an open PR. Or `git diff <ref>` + `git log <ref>..HEAD --oneline` locally.
 2. For every architectural choice visible in the diff, `check_decision` against a description of the choice.
 3. For every decision reference in the PR body, `get_decision` and verify the cited claim matches the body.
-4. If the PR drifts from doctrine, SURFACE the drift first — don't approve it silently, and don't default to filing either. Present the conflict with a drafted supersede via `AskUserQuestion` (options: `Approve and file` / `Reject` / `Modify draft`), and only on `Approve and file` call `propose_decision`. Hold the merge for a landed supersede only when merging would bake the contradiction into the frozen public surface (the CLI commands/flags, the MCP tool schemas, or the store format) or write it into the project store; otherwise the human may merge, with the drift reported under Surfaced for human review.
-5. Return verdict + findings + any drafted supersedes and their `AskUserQuestion` outcomes.
+4. If the PR drifts from doctrine, SURFACE the drift first. Don't approve it silently, and don't default to filing either. Draft the needed addition, update, or supersede and route it through the approval channel above. Hold the merge for a landed supersede only when merging would bake the contradiction into the frozen public surface (the CLI commands/flags, the MCP tool schemas, or the store format) or write it into the project store; otherwise the human may merge, with the drift reported under Surfaced for human review.
+5. Return verdict + findings + any complete decision drafts and their approval status.
 
 ## What you file vs what you surface
 
 You FILE via `propose_decision` (kernel commits on Tier 1 clean; Tier 2 hits surface advisory `similar_decisions` on the same response):
-- **`add`** — genuinely new ground. Commits immediately on Tier 1 clean; surface any `similar_decisions` to the human.
-- **`update`** — rationale-only append on an existing decision. The server consumes only `rationale` on update; `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, and `rejected` are rejected at the boundary — use supersede for any of those. Commits on user approval via `AskUserQuestion` (chat-session gate before propose).
-- **`supersede`** — replace an existing decision the new direction contradicts or wholly subsumes. Commits on user approval via `AskUserQuestion`.
+- **`add`**: genuinely new ground. Requires explicit user approval through the applicable channel, then commits immediately on Tier 1 clean; surface any `similar_decisions` to the human.
+- **`update`**: rationale-only append on an existing decision. The server consumes only `rationale` on update; `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, and `rejected` are rejected at the boundary. Use supersede for any of those. Requires explicit user approval through the applicable channel.
+- **`supersede`**: replace an existing decision the new direction contradicts or wholly subsumes. Requires explicit user approval through the applicable channel.
 
 You FLAG via `flag_question` when something needs human judgment but isn't a decision yet — open architectural tensions, unresolved tradeoffs.
 
@@ -75,8 +75,9 @@ Direction: <one-paragraph assessment of the architectural direction proposed or 
 
 Decisions filed this run:
 - <decision> "title" (committed on Tier 1 clean) — <one-line rationale>
-- awaiting user approval via AskUserQuestion — drafted supersede of <decision> "title" — <one-line rationale; human must approve before agent files>
-- awaiting user approval via AskUserQuestion — drafted update of <decision> "title" — <one-line rationale; human must approve before agent files>
+- awaiting user approval via AskUserQuestion or parent gate: drafted add "title", <one-line rationale; human must approve before agent files>
+- awaiting user approval via AskUserQuestion or parent gate: drafted supersede of <decision> "title", <one-line rationale; human must approve before agent files>
+- awaiting user approval via AskUserQuestion or parent gate: drafted update of <decision> "title", <one-line rationale; human must approve before agent files>
 (omit block if none)
 
 Questions flagged:
@@ -108,7 +109,7 @@ VERDICT escalation:
 ## Hard rules
 
 - **Read decision bodies.** Never propose, judge, or cite from a search snippet alone. `get_decision` first.
-- **Never file without user approval.** You draft, present the supersede via `AskUserQuestion` (options: `Approve and file` / `Reject` / `Modify draft`); only on `Approve and file` do you call `propose_decision`. The kernel commits immediately on Tier 1 clean; there is no separate confirm step.
+- **Never file without user approval.** For every `add`, `update`, or `supersede`, draft the complete proposal and route it through the applicable approval channel. Only after explicit approval of that exact draft do you call `propose_decision`. If a modification changes the draft, rerun `check_decision` and surface the current overlaps before presenting it again. The kernel commits immediately on Tier 1 clean; there is no separate confirm step.
 - **Don't propose for trivia.** Bug fixes, renames, single-file refactors, adding tests for existing behavior — these don't need decisions. Only file when the choice is architectural: between two defensible approaches, replacing a dependency, establishing a pattern, cutting scope.
 - **Conservatism on supersede.** Supersede is hard to reverse. File a supersede only when the existing decision is materially wrong or the new direction subsumes it. If the existing decision is merely outdated in tone, surface for human — don't supersede.
 - **Update semantics.** `update` appends rationale to an existing decision; it cannot change `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, or `rejected`. For any of those, use `supersede`.

--- a/packages/nauro/src/nauro/skills/adopt_body.md
+++ b/packages/nauro/src/nauro/skills/adopt_body.md
@@ -38,21 +38,21 @@ Per card, the agent prepares:
 - **An empty "your why" field**, separate from the read-only spans, left blank for the user to fill or edit. The agent never pre-fills this field with the source span or with anything else — a human-supplied or human-edited "why" lives only here, never folded into the read-only span.
 - **Confidence** — `high` only when the source carries a literal ADR `Status: Accepted`; otherwise `medium`. Tone, emphasis, or a confident-sounding paragraph never promote to `high`.
 
-### Step 0.2 — Pre-check each card
+### Step 0.2: Pre-check and classify each card
 
-Before presenting the batch, the agent calls `check_decision(proposed_approach=<title plus the one-line summary>, project_id=...)` **once per card** and annotates each card with any overlap the pre-pass surfaces (the related decisions and the assessment line). This is the same pre-pass Step 7 step 1 runs; doing it up front lets the user see, on each card, whether it collides with a decision already in the store before the batch is confirmed.
+Before presenting the batch, the agent runs Step 7 steps 1–3 for each card: call `check_decision(proposed_approach=<title plus the one-line summary>, project_id=...)` **once per card**, read every related decision, classify the operation, and prepare the complete operation-specific proposal. Annotate each card with the related decisions and assessment from the pre-pass. Doing this up front lets the batch show the exact proposed write and any overlap before confirmation.
 
 ### Step 0.3 — One batch confirm
 
-The agent presents all cards as a single batch and waits for one reply:
+The agent presents all complete classified proposals as a single batch and waits for one reply. Each card includes its operation, affected decision id when applicable, title, rationale, rejected alternatives, confidence, related decisions, and assessment:
 
 > Reply `confirm 1 3` / `skip 2` / `edit 3: <title>` / `confirm all` / `skip all`.
 
-`edit N: <title>` adjusts the title only; rationale stays the cited span. A user "why" goes through the separate empty field, never by editing a read-only span.
+`confirm` is explicit approval for the complete proposal shown on that card. `edit N: <title>` adjusts the title only; rationale stays the cited span. A user "why" goes through the separate empty field, never by editing a read-only span. An edit changes the proposal, so the agent reruns Step 0.2 and presents the revised card for fresh approval.
 
 ### Step 0.4 — File confirmed cards through Step 7's write loop
 
-For each confirmed card, the agent files it through the **unchanged** Step 7 write loop — the screened `propose_decision` path described there. Step 0 never calls a direct-write bypass; it routes every card through the same screened proposal the rest of the skill uses.
+For each confirmed card, the agent routes it through the **unchanged** Step 7 write loop, the screened `propose_decision` path described there. Step 0 never calls a direct-write bypass. If the Step 7 recheck changes the operation, payload, related decisions, or assessment from what the user confirmed, the agent presents the revised complete proposal and waits for fresh approval before filing.
 
 - The rationale written for a card carries its provenance as a free-text line inside the rationale body: `Source: <file>:<line>`. This is plain rationale text — not a new field — and it round-trips through the decision format unchanged.
 - The agent **captures the `propose_decision` return status for every card** and does not assume confirm means filed. A card can come back **rejected** even after the user confirmed it — most commonly when its normalized title collides with a card written earlier in the *same* batch (active-title dedup). The agent reports each rejected card by title and reason, and does not silently drop it.
@@ -169,7 +169,8 @@ For each kept candidate from 6a and each rationale-supplied 6b answer, the agent
     - **update** when the candidate augments an existing decision's rationale only. The server consumes only `rationale` on update; `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, and `rejected` are rejected at the boundary — use supersede if any of those must change.
     - **supersede** when the title or other metadata must change, or the candidate replaces or contradicts an existing decision. Pass the full new body and set `affected_decision_id`.
     - **skip** when the candidate is a duplicate (e.g. matches `001-initial-setup` or a candidate already seeded earlier in this same adopt run).
-4. Call `propose_decision` using the call signature for the chosen operation — these are operation-specific by design so an agent copying the template cannot accidentally send a field the server will reject:
+4. Present the complete classified proposal to the user: operation, affected decision id when applicable, title, rationale, rejected alternatives, confidence, and the related decisions and assessment from Step 7 step 1. Earlier `keep` replies select candidates; they do not approve a later `propose_decision` call. A Step 0 `confirm` counts only when the proposal and surfaced overlaps remain unchanged. Otherwise, wait for explicit approval of the exact current proposal and overlaps. On reject, skip it. On modification, revise, rerun `check_decision`, and present the complete proposal again; any changed proposal needs fresh approval.
+5. Only after approval, call `propose_decision` using the call signature for the chosen operation. These are operation-specific by design so an agent copying the template cannot accidentally send a field the server will reject:
     - For **add** (new decisions):
       ```
       propose_decision(project_id=..., title=..., rationale=..., operation="add", rejected=..., confidence=...)
@@ -184,7 +185,7 @@ For each kept candidate from 6a and each rationale-supplied 6b answer, the agent
       ```
 
    `rationale` is drawn from explicit Step 3 source text (6a) or the user's probe answer (6b). `confidence` defaults to `medium`; use `high` only when a source explicitly says "accepted" or "approved". Include rejected alternatives only when the source names them or the user supplies them in the probe answer.
-5. After `propose_decision`, the kernel commits immediately on Tier 1 clean. If `similar_decisions` is non-empty, surface those hits to the user before drafting the next candidate; the human approval gate is the chat-session moment before this call, not a second tool call after it.
+6. After `propose_decision`, the kernel commits immediately on Tier 1 clean. If `similar_decisions` is non-empty, surface those hits to the user before drafting the next candidate; the human approval gate is the chat-session moment before this call, not a second tool call after it.
 
 One `propose_decision` per candidate. No batching across candidates without surfacing each `similar_decisions` response first.
 

--- a/packages/nauro/src/nauro/skills/ship_task_body.md
+++ b/packages/nauro/src/nauro/skills/ship_task_body.md
@@ -23,17 +23,19 @@ Pause only at the two explicit gates marked GATE below.
 
 ## Pre-step — Doctrine triage before the planner spins up
 
-Before invoking `@nauro-planner`, the parent session confirms the planner will run `check_decision` first. The planner's contract already requires this, but the chain enforces it explicitly: if the planner returns a RED verdict (proposal directly contradicts an active decision) and drafts a supersede, the chain pauses before the executor sees anything. The user approves the supersede in chat; only after explicit approval does the planner file via `propose_decision` (which commits immediately) and the executor see the approved plan. This is the doctrine equivalent of the plan-approval gate (step 2) firing early — a RED that the user does not resolve never reaches code.
+Before invoking `@nauro-planner`, the parent session confirms the planner will run `check_decision` first. The planner's contract already requires this, but the chain enforces it explicitly: if the planner returns a RED verdict (proposal directly contradicts an active decision) and drafts a supersede, the chain pauses before the executor sees anything. The user approves the supersede in chat; only after explicit approval does the parent re-invoke the planner with that approval so the planner can file via `propose_decision` (which commits immediately). The parent never files a subagent's draft itself. A RED that the user does not resolve never reaches code.
 
 ### 1. Plan
 
-Invoke the `@nauro-planner` subagent with the task description. The planner runs `check_decision` against the proposed approach, classifies as GREEN / AMBER / RED, reads related decision bodies via `get_decision`, investigates the code, and returns a plan in the plan shape (Why / Approach / What changes / What's deferred / Test plan), plus the verdict line and any decision number it drafted.
+Invoke the `@nauro-planner` subagent with the task description. The planner runs `check_decision` against the proposed approach, classifies as GREEN / AMBER / RED, reads related decision bodies via `get_decision`, investigates the code, and returns a plan in the plan shape (Why / Approach / What changes / What's deferred / Test plan), plus the verdict line and any complete decision draft awaiting approval.
 
-If the planner returns RED with a supersede draft, the chain pauses here. Surface the draft to the user. Only on explicit user approval (or an explicit "override RED on the cited decision, proceed") does the chain continue to the executor.
+If the planner returns RED with a supersede draft, the chain pauses here. Surface the complete draft to the user. Only on explicit user approval does the parent re-invoke the planner with that approval to file the exact draft. An explicit "override RED on the cited decision, proceed" may continue without filing, but it is not approval to call `propose_decision`.
 
 ### 2. GATE — plan approval (always when `propose_decision` is in play)
 
-The Nauro chain gates the plan whenever the planner indicates it will file a decision via `propose_decision` for any architectural choice, or whenever the plan records a supersede / update draft. There is no "low-stakes auto-proceed" path when doctrine writes are pending. The user's judgment is the gate on what enters the decision log.
+The Nauro chain gates the plan whenever the planner indicates it will file a decision via `propose_decision` for any architectural choice, or whenever the plan records an `add`, `update`, or `supersede` draft. There is no "low-stakes auto-proceed" path when doctrine writes are pending. The user's judgment is the gate on what enters the decision log.
+
+This gate covers all three operations: `add`, `update`, and `supersede`. Surface the complete proposal draft, including its operation and affected decision when applicable. After explicit approval of that exact draft, re-invoke the planner with that approval so it can file. Rejecting or modifying the draft returns it to the planner; any changed draft requires fresh approval. The parent never files a subagent's draft itself.
 
 A change additionally always gates if any of the following apply:
 
@@ -63,7 +65,9 @@ If the reviewer returns BLOCK, hand the hard-rule failures back to the `@nauro-e
 
 ### 6. Doctrine pass
 
-When the reviewer returns APPROVE or APPROVE WITH NITS, invoke `@nauro-tech-lead` in Mode C on the same local diff. The invocation explicitly carries the chain context the parent already holds: the task description, the planner's verdict and any decision filed at plan time (or deliberately not filed), and the reviewer's verdict with its nits — the tech-lead does not re-infer chain state from the diff alone. The tech-lead reads decisions, scans the diff for architectural choices, and returns GREEN / AMBER / RED with any drafted supersede / update awaiting user approval.
+When the reviewer returns APPROVE or APPROVE WITH NITS, invoke `@nauro-tech-lead` in Mode C on the same local diff. The invocation explicitly carries the chain context the parent already holds: the task description, the planner's verdict and any decision filed at plan time (or deliberately not filed), and the reviewer's verdict with its nits. The tech-lead does not re-infer chain state from the diff alone. It reads decisions, scans the diff for architectural choices, and returns GREEN / AMBER / RED with any complete `add`, `update`, or `supersede` draft awaiting user approval.
+
+Any decision draft pauses the chain before step 7. Surface the complete draft to the user. After explicit approval of that exact draft, re-invoke the tech-lead with that approval so it can file. Rejecting or modifying the draft returns it to the tech-lead; any changed draft requires fresh approval. The parent never files a subagent's draft itself.
 
 - **GREEN** — proceed to the push gate (step 7).
 - **AMBER** — surface the constraints to the user alongside the push gate; user decides whether to address before push or document as a follow-up.

--- a/packages/nauro/tests/test_agents_drift.py
+++ b/packages/nauro/tests/test_agents_drift.py
@@ -242,6 +242,41 @@ def test_non_filing_agents_cannot_write_doctrine(name: str) -> None:
         assert tool not in tools_line, f"{name}.md tools allowlist grants store-write tool {tool!r}"
 
 
+def test_planner_gates_every_decision_operation_on_explicit_user_approval() -> None:
+    body = load_agent_body("nauro-planner")
+
+    assert "all three operations: `add`, `update`, and `supersede`" in body
+    assert "A planner subagent without a user channel never files directly." in body
+    assert "re-invokes the planner with the user's explicit approval" in body
+    assert "On a standalone invocation, show the complete draft and return without filing" in body
+    assert "related decisions and assessment from `check_decision`" in body
+
+
+def test_tech_lead_gates_every_decision_operation_on_explicit_user_approval() -> None:
+    body = load_agent_body("nauro-tech-lead")
+
+    assert "every `add`, `update`, and `supersede`" in body
+    assert "Standalone" in body
+    assert "AskUserQuestion" in body
+    assert "Inside the `/nauro-ship-task` chain" in body
+    assert "return the complete draft to the parent and do not file in-run" in body
+    assert "Mode B never files an `add` directly from the transcript." in body
+    assert "related decisions and assessment from `check_decision`" in body
+    assert "For each real architectural decision identified in step 3" in body
+    assert "If the transcript has no `check_decision` precedent" in body
+    assert "For an existing or retroactive check, call `get_decision`" in body
+
+
+def test_tech_lead_mode_c_preserves_surface_first_merge_posture() -> None:
+    body = load_agent_body("nauro-tech-lead")
+
+    assert "SURFACE the drift first" in body
+    assert "Hold the merge for a landed supersede only when" in body
+    assert "frozen public surface" in body
+    assert "or write it into the project store" in body
+    assert "otherwise the human may merge" in body
+
+
 # --- plugin emitter + render-plugin command -------------------------------
 #
 # A separate plugin repo commits byte-identical copies of the subagents and

--- a/packages/nauro/tests/test_skills_drift.py
+++ b/packages/nauro/tests/test_skills_drift.py
@@ -266,7 +266,8 @@ def test_adopt_body_step0_mandates_two_citations_batch_confirm_and_precheck():
     assert "`check_decision(" in body
     assert "once per card" in body
 
-    # One human batch confirm is the write gate.
+    # One human batch confirm approves the complete proposals after operation
+    # classification and overlap surfacing.
     assert "confirm 1 3" in body
     assert "confirm all" in body
     assert "skip all" in body
@@ -294,6 +295,29 @@ def test_adopt_body_step0_mandates_two_citations_batch_confirm_and_precheck():
 
     # confidence=high only on a literal ADR Status: Accepted.
     assert "Status: Accepted" in body
+
+
+def test_adopt_body_gates_each_classified_proposal_before_write():
+    body = load_adopt_body()
+
+    assert "Present the complete classified proposal to the user" in body
+    assert "Earlier `keep` replies select candidates" in body
+    assert (
+        "A Step 0 `confirm` counts only when the proposal and surfaced overlaps remain unchanged"
+        in body
+    )
+    assert "wait for explicit approval of the exact current proposal" in body
+    assert "related decisions and assessment from Step 7 step 1" in body
+    assert "rerun `check_decision`" in body
+
+
+def test_ship_task_routes_all_decision_drafts_through_parent_approval():
+    body = load_ship_task_body()
+
+    assert "all three operations: `add`, `update`, and `supersede`" in body
+    assert "re-invoke the planner with that approval" in body
+    assert "re-invoke the tech-lead with that approval" in body
+    assert "The parent never files a subagent's draft itself." in body
 
 
 # --- render_skill produces frontmatter + body ---


### PR DESCRIPTION
## Why

Nauro's documentation and bundled workflow contracts did not consistently describe humans as the authority over project judgment. Several decision-writing paths could also be read as allowing agents to file additions, updates, or supersessions before explicit approval. The post-session audit contract had a further gap: a real unfiled architectural decision could be skipped if the session had already run an advisory check.

## What changed

- Explain the human-ratified project-judgment loop in both READMEs.
- Require explicit user approval for every planner, tech-lead, adoption, and shipping workflow decision write, while keeping the executor from filing doctrine.
- Make the tech-lead audit every real unfiled architectural decision, run the advisory check only when absent, and read related decision bodies before drafting.
- Regenerate the checked-in skill surfaces and add drift tests for approval, audit, and rendering contracts.

## Risk / what to review

- Verify that standalone invocations own their approval prompt, while chained invocations return the exact draft to the parent-owned approval gate.
- Confirm rapid-seed candidates receive explicit batch confirmation before any writes.
- Check that the Mode B recovery path handles every real unfiled decision, whether or not an advisory check already ran, reads related decision bodies, and never files directly from the transcript.

## Test plan

- `PYTHONPATH=packages/nauro/src:packages/nauro-core/src .venv/bin/pytest packages/nauro/tests/test_agents_drift.py packages/nauro/tests/test_skills_drift.py -q` (166 passed)
- `.venv/bin/ruff format --check packages/nauro/tests/test_agents_drift.py`
- `.venv/bin/ruff check packages/nauro/tests/test_agents_drift.py`
- `git diff HEAD^ HEAD --check`
