### PR TITLE
Add nauro doctor store-integrity command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ Principal commands (run `nauro --help` for the full surface):
 - `nauro sync` — capture a snapshot, regenerate `AGENTS.md` in all associated repos
 - `nauro log` — list recent snapshots with metadata
 - `nauro status` — capability table for the current project (active surfaces, absolute store path)
+- `nauro doctor` — report deterministic store-integrity defects (unparseable decision files, dangling or cyclic supersession refs, status contradictions); report-only, always exits 0
 - `nauro graph` — render the decision graph to one self-contained HTML file in the store directory and open it
 - `nauro serve` — start the local MCP server (stdio transport)
 - `nauro import --memory-bank <path>` — migrate a Cline/Roo Code Memory Bank

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Output abbreviated to the top match; the live call returns all five related deci
 
 *A project store rendered by nauro graph: supersession threads converge on the decisions that replaced them, and standalone decisions cluster by category.*
 
+`nauro doctor` checks the store for structural defects: unparseable decision files, supersession refs pointing at a decision that no longer exists or forming a cycle, and status contradictions such as an active decision that also records being superseded. It is deterministic and report-only — it never edits the store and always exits 0 — so it is safe to run any time you want to confirm the record is internally consistent.
+
 ## Why not ADRs, grep, CLAUDE.md, or built-in agent notes?
 
 A decision log in your repo is a good record. The gap is on the read side: a file is read when a person opens it, and a fresh agent session starts with no knowledge that it exists. Nauro closes that gap twice over: the relevant decision reaches your agent through MCP at the moment it proposes a change, and `nauro sync` regenerates a committable `AGENTS.md` summary in every associated repo, so clones and tools without MCP wiring still start from the current record.

--- a/packages/nauro-core/src/nauro_core/doctor.py
+++ b/packages/nauro-core/src/nauro_core/doctor.py
@@ -1,0 +1,289 @@
+"""Deterministic store-integrity diagnosis for ``nauro doctor``.
+
+``diagnose_store`` reads a project store through the :class:`Store` protocol
+and reports four kinds of structural defect in the decision set:
+
+    1. Unparseable decision files.
+    2. Dangling supersession refs — a ``supersedes``/``superseded_by`` value
+       pointing at a decision number with no file on disk.
+    3. Supersession cycles — a directed cycle over the union of both ref
+       directions, self-loops included.
+    4. Status contradictions — an active decision carrying ``superseded_by``,
+       or a forward/back conflict where ``X.supersedes=Y`` while ``Y`` records
+       ``superseded_by=Z`` naming a third, present decision.
+
+Every check is zero-false-positive by construction and the output is fully
+sorted, so two diagnoses over the same store are identical. The module stands
+apart from ``graph.py``: that builder's edge collection keeps only live
+endpoints and drops self-edges, which are exactly the anomalies this reports.
+
+Pure: no I/O beyond the Store reads, no clock, no randomness. It is imported
+submodule-only and is deliberately not part of ``nauro_core.__all__``.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from nauro_core.decision_model import Decision, DecisionStatus
+from nauro_core.operations.decision_lookup import scan_decisions
+from nauro_core.operations.store import Store
+from nauro_core.parsing import extract_decision_number
+
+RefField = Literal["supersedes", "superseded_by"]
+
+
+class UnparseableDecision(BaseModel):
+    """A decision file that does not round-trip through the v2 parser."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    stem: str
+    error: str
+
+
+class DanglingRef(BaseModel):
+    """A supersession ref pointing at a decision number with no file on disk."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    source: int
+    field: RefField
+    target: int
+
+
+class SupersessionCycle(BaseModel):
+    """A directed cycle in the supersession graph.
+
+    ``members`` is the sorted node set of the cycle: a single number for a
+    self-loop, two or more for a longer cycle.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    members: tuple[int, ...]
+
+
+class StatusContradiction(BaseModel):
+    """A decision whose status and supersession fields disagree.
+
+    Two shapes, discriminated by ``kind``:
+
+    - ``active_with_superseded_by``: ``decision`` is active yet carries
+      ``superseded_by=other``.
+    - ``forward_back_conflict``: ``decision`` records ``supersedes=other``,
+      but ``other`` records ``superseded_by=conflicting_with`` naming a third,
+      present decision rather than ``decision``. ``conflicting_with`` is unset
+      for the first shape.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    kind: Literal["active_with_superseded_by", "forward_back_conflict"]
+    decision: int
+    other: int
+    conflicting_with: int | None = None
+
+
+class StoreDiagnosis(BaseModel):
+    """The full result of :func:`diagnose_store`. Every list is sorted."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    unparseable: list[UnparseableDecision] = Field(default_factory=list)
+    dangling_refs: list[DanglingRef] = Field(default_factory=list)
+    cycles: list[SupersessionCycle] = Field(default_factory=list)
+    contradictions: list[StatusContradiction] = Field(default_factory=list)
+
+    @property
+    def is_clean(self) -> bool:
+        """True when no defect of any category was found."""
+        return not (self.unparseable or self.dangling_refs or self.cycles or self.contradictions)
+
+
+def diagnose_store(store: Store) -> StoreDiagnosis:
+    """Diagnose store-integrity defects. Pure; reads only through ``store``."""
+    parsed, failures = scan_decisions(store)
+
+    # Existence is on-disk stems, not parsed nums: a present-but-unparseable
+    # file still counts as existing, so a ref to it is reported once (as
+    # unparseable) and never double-reported as dangling.
+    existing_numbers = {
+        num
+        for stem in store.list_decisions()
+        if (num := extract_decision_number(stem)) is not None
+    }
+    by_num = _index_by_num(parsed)
+
+    unparseable = sorted(
+        (UnparseableDecision(stem=f.stem, error=f.error) for f in failures),
+        key=lambda row: row.stem,
+    )
+    dangling_refs = _dangling_refs(parsed, existing_numbers)
+    cycles = _cycles(parsed)
+    contradictions = _contradictions(parsed, by_num, existing_numbers)
+
+    return StoreDiagnosis(
+        unparseable=unparseable,
+        dangling_refs=dangling_refs,
+        cycles=cycles,
+        contradictions=contradictions,
+    )
+
+
+def _index_by_num(parsed: list[Decision]) -> dict[int, Decision]:
+    """Map each decision number to its parsed decision, first stem wins.
+
+    Duplicate numbers are a separate anomaly this command does not report; the
+    first occurrence in scan order is kept so target lookups are deterministic.
+    """
+    by_num: dict[int, Decision] = {}
+    for d in parsed:
+        by_num.setdefault(d.num, d)
+    return by_num
+
+
+def _dangling_refs(parsed: list[Decision], existing_numbers: set[int]) -> list[DanglingRef]:
+    """Refs whose target number has no file on disk. Sorted."""
+    rows: list[DanglingRef] = []
+    for d in parsed:
+        for field in ("supersedes", "superseded_by"):
+            raw = getattr(d, field)
+            if raw is None:
+                continue
+            target = int(raw)
+            if target not in existing_numbers:
+                rows.append(DanglingRef(source=d.num, field=field, target=target))
+    return sorted(rows, key=lambda r: (r.source, r.field, r.target))
+
+
+def _cycles(parsed: list[Decision]) -> list[SupersessionCycle]:
+    """Detect directed cycles over the union of both ref directions.
+
+    ``supersedes: Y`` on decision N yields the edge ``N -> Y``;
+    ``superseded_by: X`` on decision N yields ``X -> N`` (X is newer, so X
+    supersedes N). A reciprocal pair collapses to one directed edge and is not
+    a cycle. Detection is by strongly connected component: an SCC of two or
+    more nodes always contains a directed cycle, and a single node with a
+    self-edge is a length-one cycle, so no acyclic chain can be flagged.
+    """
+    adjacency: dict[int, set[int]] = {}
+    for d in parsed:
+        if d.supersedes is not None:
+            adjacency.setdefault(d.num, set()).add(int(d.supersedes))
+        if d.superseded_by is not None:
+            adjacency.setdefault(int(d.superseded_by), set()).add(d.num)
+
+    cycles: list[tuple[int, ...]] = []
+    for scc in _strongly_connected_components(adjacency):
+        if len(scc) > 1:
+            cycles.append(tuple(sorted(scc)))
+        else:
+            (node,) = scc
+            if node in adjacency.get(node, ()):
+                cycles.append((node,))
+    return [SupersessionCycle(members=members) for members in sorted(cycles)]
+
+
+def _strongly_connected_components(adjacency: dict[int, set[int]]) -> list[list[int]]:
+    """Tarjan's SCC, iterative to avoid recursion limits on long chains.
+
+    Neighbors are visited in sorted order so traversal is deterministic; SCC
+    membership is order-independent regardless, but a stable walk keeps the
+    output reproducible.
+    """
+    index_of: dict[int, int] = {}
+    low: dict[int, int] = {}
+    on_stack: set[int] = set()
+    scc_stack: list[int] = []
+    result: list[list[int]] = []
+    counter = 0
+
+    for root in sorted(adjacency):
+        if root in index_of:
+            continue
+        # Each frame: [node, sorted neighbors, next-neighbor index].
+        work: list[list] = [[root, sorted(adjacency.get(root, ())), 0]]
+        index_of[root] = low[root] = counter
+        counter += 1
+        scc_stack.append(root)
+        on_stack.add(root)
+        while work:
+            node, neighbors, i = work[-1]
+            if i < len(neighbors):
+                work[-1][2] += 1
+                nbr = neighbors[i]
+                if nbr not in index_of:
+                    index_of[nbr] = low[nbr] = counter
+                    counter += 1
+                    scc_stack.append(nbr)
+                    on_stack.add(nbr)
+                    work.append([nbr, sorted(adjacency.get(nbr, ())), 0])
+                elif nbr in on_stack:
+                    low[node] = min(low[node], index_of[nbr])
+            else:
+                if low[node] == index_of[node]:
+                    component: list[int] = []
+                    while True:
+                        member = scc_stack.pop()
+                        on_stack.discard(member)
+                        component.append(member)
+                        if member == node:
+                            break
+                    result.append(component)
+                work.pop()
+                if work:
+                    parent = work[-1][0]
+                    low[parent] = min(low[parent], low[node])
+    return result
+
+
+def _contradictions(
+    parsed: list[Decision],
+    by_num: dict[int, Decision],
+    existing_numbers: set[int],
+) -> list[StatusContradiction]:
+    """Status/supersession contradictions. Sorted.
+
+    Two shapes:
+
+    (i) An active decision carrying a ``superseded_by`` value.
+
+    (ii) A forward/back conflict anchored on the forward edge only: ``X``
+    records ``supersedes=Y`` while ``Y`` records ``superseded_by=Z`` with ``Z``
+    present on disk and ``Z != X``. Anchoring on the forward edge is the
+    load-bearing guard for the one-to-many retirement convention (one forward
+    root, other members back-only ``superseded_by``): a back-only member has no
+    forward edge, so it is never examined and never flagged. Requiring ``Z``
+    present keeps a dangling ``superseded_by`` reported once (as dangling)
+    rather than also here.
+    """
+    rows: list[StatusContradiction] = []
+    for d in parsed:
+        if d.status is DecisionStatus.active and d.superseded_by is not None:
+            rows.append(
+                StatusContradiction(
+                    kind="active_with_superseded_by",
+                    decision=d.num,
+                    other=int(d.superseded_by),
+                )
+            )
+        if d.supersedes is not None:
+            target = by_num.get(int(d.supersedes))
+            if target is not None and target.superseded_by is not None:
+                claimed = int(target.superseded_by)
+                if claimed in existing_numbers and claimed != d.num:
+                    rows.append(
+                        StatusContradiction(
+                            kind="forward_back_conflict",
+                            decision=d.num,
+                            other=target.num,
+                            conflicting_with=claimed,
+                        )
+                    )
+    return sorted(
+        rows,
+        key=lambda r: (r.kind, r.decision, r.other, r.conflicting_with or 0),
+    )

--- a/packages/nauro-core/src/nauro_core/operations/decision_lookup.py
+++ b/packages/nauro-core/src/nauro_core/operations/decision_lookup.py
@@ -11,6 +11,7 @@ here rather than inside either operation module.
 from __future__ import annotations
 
 import logging
+from typing import NamedTuple
 
 from nauro_core.decision_model import Decision, parse_decision
 from nauro_core.operations.store import Store
@@ -23,13 +24,28 @@ from nauro_core.parsing import (
 logger = logging.getLogger("nauro_core.operations.decision_lookup")
 
 
-def parse_all_decisions(store: Store) -> list[Decision]:
-    """Read and parse every decision in the store, skipping unparseable files.
+class ParseFailure(NamedTuple):
+    """A decision file that did not round-trip through the v2 parser.
 
-    A single malformed file on disk (a half-written body, a pre-v2 file left
-    during a migration) must not take down the read path. Each file that does
-    not round-trip through the v2 parser is logged at debug and skipped, so
-    the scan returns the decisions it could parse rather than raising.
+    ``stem`` is the on-disk file stem; ``error`` is the parser's message. The
+    guarded scan captures these rather than dropping them so a caller that
+    reports on store integrity (``doctor``) can name the offending file.
+    """
+
+    stem: str
+    error: str
+
+
+def scan_decisions(store: Store) -> tuple[list[Decision], list[ParseFailure]]:
+    """Read every decision, capturing the parsed set and the parse failures.
+
+    The single guarded scan: one place reads every stem, parses each body, and
+    routes the outcome to one of two lists. A malformed file on disk (a
+    half-written body, a pre-v2 file left during a migration) must not take
+    down the read path, so a file that does not round-trip through the v2
+    parser is logged at debug and recorded as a :class:`ParseFailure` rather
+    than raising. :func:`parse_all_decisions` consumes only the parsed list;
+    ``doctor`` consumes both.
 
     Bodies are fetched in one bulk :meth:`Store.read_decisions` call, but the
     scan still reasserts :meth:`Store.list_decisions` order: it iterates the
@@ -40,6 +56,7 @@ def parse_all_decisions(store: Store) -> list[Decision]:
     callers that need a status or seed filter apply it after the scan returns.
     """
     parsed: list[Decision] = []
+    failures: list[ParseFailure] = []
     stems = store.list_decisions()
     bodies = store.read_decisions(stems)
     for stem in stems:
@@ -48,9 +65,21 @@ def parse_all_decisions(store: Store) -> list[Decision]:
             continue
         try:
             parsed.append(parse_decision(body, _decision_filename(stem)))
-        except Exception:
+        except Exception as exc:
             logger.debug("Skipping unparseable decision file: %s.md", stem)
-            continue
+            failures.append(ParseFailure(stem=stem, error=str(exc)))
+    return parsed, failures
+
+
+def parse_all_decisions(store: Store) -> list[Decision]:
+    """Read and parse every decision in the store, skipping unparseable files.
+
+    Thin wrapper over :func:`scan_decisions` that discards the parse failures.
+    The retrieval hot path only needs the decisions it could parse, so this
+    keeps the historical return shape while the capturing scan lives in one
+    place.
+    """
+    parsed, _ = scan_decisions(store)
     return parsed
 
 

--- a/packages/nauro-core/tests/operations/test_decision_lookup.py
+++ b/packages/nauro-core/tests/operations/test_decision_lookup.py
@@ -22,8 +22,10 @@ from nauro_core.decision_model import (
 )
 from nauro_core.operations import InMemoryStore, find_decision_stem_by_id
 from nauro_core.operations.decision_lookup import (
+    ParseFailure,
     find_decision_stem_by_num,
     parse_all_decisions,
+    scan_decisions,
 )
 
 
@@ -122,3 +124,41 @@ def test_parse_all_decisions_reasserts_list_order_not_mapping_order() -> None:
     ]
     parsed = parse_all_decisions(store)
     assert [d.num for d in parsed] == [1, 2, 3]
+
+
+# ── scan_decisions: the capturing primitive behind parse_all_decisions ──
+
+
+def test_scan_decisions_returns_parsed_and_failures() -> None:
+    store = InMemoryStore(
+        decisions={
+            "001-alpha": _decision_body(1, "Alpha"),
+            "002-broken": "not a decision file",
+            "003-charlie": _decision_body(3, "Charlie"),
+        }
+    )
+    parsed, failures = scan_decisions(store)
+    assert [d.num for d in parsed] == [1, 3]
+    assert len(failures) == 1
+    failure = failures[0]
+    assert isinstance(failure, ParseFailure)
+    assert failure.stem == "002-broken"
+    assert failure.error
+
+
+def test_parse_all_decisions_matches_scan_parsed_half() -> None:
+    store = InMemoryStore(
+        decisions={
+            "001-alpha": _decision_body(1, "Alpha"),
+            "002-broken": "not a decision file",
+        }
+    )
+    parsed, _ = scan_decisions(store)
+    assert [d.num for d in parse_all_decisions(store)] == [d.num for d in parsed]
+
+
+def test_scan_decisions_clean_store_has_no_failures() -> None:
+    store = InMemoryStore(decisions={"001-alpha": _decision_body(1, "Alpha")})
+    parsed, failures = scan_decisions(store)
+    assert [d.num for d in parsed] == [1]
+    assert failures == []

--- a/packages/nauro-core/tests/test_doctor.py
+++ b/packages/nauro-core/tests/test_doctor.py
@@ -1,0 +1,219 @@
+"""Tests for ``nauro_core.doctor`` deterministic store-integrity diagnosis.
+
+Each test seeds an :class:`~nauro_core.operations.InMemoryStore` with decision
+bodies built through ``format_decision`` so the fixtures cannot drift from the
+on-disk v2 format. The load-bearing case is the one-to-many retirement
+convention, which must never be flagged as a contradiction.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+from nauro_core.decision_model import (
+    Decision,
+    DecisionConfidence,
+    DecisionStatus,
+    format_decision,
+)
+from nauro_core.doctor import diagnose_store
+from nauro_core.operations import InMemoryStore
+
+
+def _stem(num: int, slug: str = "decision") -> str:
+    return f"{num:03d}-{slug}"
+
+
+def _body(
+    num: int,
+    *,
+    status: DecisionStatus = DecisionStatus.active,
+    supersedes: str | None = None,
+    superseded_by: str | None = None,
+) -> str:
+    """Return canonical v2 markdown for a decision via the shared serializer."""
+    return format_decision(
+        Decision(
+            date=date(2026, 1, 1),
+            confidence=DecisionConfidence.medium,
+            status=status,
+            supersedes=supersedes,
+            superseded_by=superseded_by,
+            num=num,
+            title=f"Decision {num}",
+            rationale=f"Rationale for decision {num}.",
+        )
+    )
+
+
+# ── Unparseable files ──
+
+
+def test_unparseable_file_reported_with_stem_and_error() -> None:
+    store = InMemoryStore(decisions={_stem(1): "this is not a decision file"})
+    diagnosis = diagnose_store(store)
+    assert len(diagnosis.unparseable) == 1
+    row = diagnosis.unparseable[0]
+    assert row.stem == _stem(1)
+    assert row.error
+    assert diagnosis.is_clean is False
+
+
+# ── Dangling refs ──
+
+
+def test_dangling_supersedes_reported() -> None:
+    store = InMemoryStore(decisions={_stem(10): _body(10, supersedes="999")})
+    diagnosis = diagnose_store(store)
+    assert len(diagnosis.dangling_refs) == 1
+    ref = diagnosis.dangling_refs[0]
+    assert (ref.source, ref.field, ref.target) == (10, "supersedes", 999)
+
+
+def test_dangling_superseded_by_reported() -> None:
+    store = InMemoryStore(
+        decisions={
+            _stem(10): _body(10, status=DecisionStatus.superseded, superseded_by="999"),
+        }
+    )
+    diagnosis = diagnose_store(store)
+    assert len(diagnosis.dangling_refs) == 1
+    ref = diagnosis.dangling_refs[0]
+    assert (ref.source, ref.field, ref.target) == (10, "superseded_by", 999)
+
+
+def test_ref_to_unparseable_but_present_file_is_not_dangling() -> None:
+    # D10 supersedes D11; D11's file is present but does not parse. Existence
+    # is on-disk stems, so the ref resolves and is not dangling; D11 is only
+    # reported once, as unparseable.
+    store = InMemoryStore(
+        decisions={
+            _stem(10): _body(10, supersedes="11"),
+            _stem(11, "broken"): "garbage that does not parse",
+        }
+    )
+    diagnosis = diagnose_store(store)
+    assert diagnosis.dangling_refs == []
+    assert [row.stem for row in diagnosis.unparseable] == [_stem(11, "broken")]
+
+
+# ── Cycles ──
+
+
+def test_two_cycle_reported() -> None:
+    store = InMemoryStore(
+        decisions={
+            _stem(5): _body(5, supersedes="6"),
+            _stem(6): _body(6, supersedes="5"),
+        }
+    )
+    diagnosis = diagnose_store(store)
+    assert [c.members for c in diagnosis.cycles] == [(5, 6)]
+
+
+def test_self_loop_reported() -> None:
+    store = InMemoryStore(decisions={_stem(5): _body(5, supersedes="5")})
+    diagnosis = diagnose_store(store)
+    assert [c.members for c in diagnosis.cycles] == [(5,)]
+
+
+def test_reciprocal_pair_is_not_a_cycle() -> None:
+    # A normal supersession recorded on both endpoints collapses to one edge.
+    store = InMemoryStore(
+        decisions={
+            _stem(5): _body(5, status=DecisionStatus.superseded, superseded_by="6"),
+            _stem(6): _body(6, supersedes="5"),
+        }
+    )
+    diagnosis = diagnose_store(store)
+    assert diagnosis.cycles == []
+
+
+# ── Status contradictions ──
+
+
+def test_active_with_superseded_by_reported() -> None:
+    store = InMemoryStore(
+        decisions={
+            _stem(7): _body(7, status=DecisionStatus.active, superseded_by="8"),
+            _stem(8): _body(8),
+        }
+    )
+    diagnosis = diagnose_store(store)
+    assert len(diagnosis.contradictions) == 1
+    row = diagnosis.contradictions[0]
+    assert row.kind == "active_with_superseded_by"
+    assert (row.decision, row.other) == (7, 8)
+
+
+def test_forward_back_conflict_reported() -> None:
+    # D9 supersedes D10, but D10 records superseded_by=D11 (present, != 9).
+    store = InMemoryStore(
+        decisions={
+            _stem(9): _body(9, supersedes="10"),
+            _stem(10): _body(10, status=DecisionStatus.superseded, superseded_by="11"),
+            _stem(11): _body(11),
+        }
+    )
+    diagnosis = diagnose_store(store)
+    conflicts = [c for c in diagnosis.contradictions if c.kind == "forward_back_conflict"]
+    assert len(conflicts) == 1
+    row = conflicts[0]
+    assert (row.decision, row.other, row.conflicting_with) == (9, 10, 11)
+
+
+def test_one_to_many_convention_not_flagged() -> None:
+    # D4 retires D2, D3, D5. Convention: one forward edge (D4 supersedes D2, the
+    # reciprocal root) plus back-only superseded_by on every retired member.
+    # No forward edge points at D3 or D5, so none is flagged.
+    store = InMemoryStore(
+        decisions={
+            _stem(4): _body(4, supersedes="2"),
+            _stem(2): _body(2, status=DecisionStatus.superseded, superseded_by="4"),
+            _stem(3): _body(3, status=DecisionStatus.superseded, superseded_by="4"),
+            _stem(5): _body(5, status=DecisionStatus.superseded, superseded_by="4"),
+        }
+    )
+    diagnosis = diagnose_store(store)
+    assert diagnosis.contradictions == []
+    assert diagnosis.cycles == []
+    assert diagnosis.dangling_refs == []
+    assert diagnosis.is_clean is True
+
+
+# ── Clean store + ordering ──
+
+
+def test_clean_store_yields_empty_diagnosis() -> None:
+    store = InMemoryStore(
+        decisions={
+            _stem(1): _body(1),
+            _stem(2): _body(2, status=DecisionStatus.superseded, superseded_by="3"),
+            _stem(3): _body(3, supersedes="2"),
+        }
+    )
+    diagnosis = diagnose_store(store)
+    assert diagnosis.is_clean is True
+    assert diagnosis.unparseable == []
+    assert diagnosis.dangling_refs == []
+    assert diagnosis.cycles == []
+    assert diagnosis.contradictions == []
+
+
+def test_deterministic_ordering() -> None:
+    # Multiple unparseable files and multiple dangling refs come back sorted
+    # regardless of the store's stem order.
+    store = InMemoryStore(
+        decisions={
+            _stem(30, "zeta"): "nope",
+            _stem(10, "alpha"): "nope",
+            _stem(20): _body(20, supersedes="900"),
+            _stem(5): _body(5, supersedes="800"),
+        }
+    )
+    diagnosis = diagnose_store(store)
+    assert [row.stem for row in diagnosis.unparseable] == [
+        _stem(10, "alpha"),
+        _stem(30, "zeta"),
+    ]
+    assert [(r.source, r.target) for r in diagnosis.dangling_refs] == [(5, 800), (20, 900)]

--- a/packages/nauro/CLAUDE.md
+++ b/packages/nauro/CLAUDE.md
@@ -43,6 +43,7 @@ Principal commands (run `nauro --help` for the full surface):
 - `nauro sync` — capture a snapshot, regenerate `AGENTS.md` in all associated repos
 - `nauro log` — list recent snapshots with metadata
 - `nauro status` — capability table for the current project (active surfaces, absolute store path)
+- `nauro doctor` — report deterministic store-integrity defects (unparseable decision files, dangling or cyclic supersession refs, status contradictions); report-only, always exits 0
 - `nauro graph` — render the decision graph to one self-contained HTML file in the store directory and open it
 - `nauro serve` — start the local MCP server (stdio transport)
 - `nauro import --memory-bank <path>` — migrate a Cline/Roo Code Memory Bank

--- a/packages/nauro/README.md
+++ b/packages/nauro/README.md
@@ -45,6 +45,8 @@ The demo project ruled out storing money as floating-point dollars because binar
 
 `nauro graph` renders the store to one self-contained HTML file and opens it: a node-link map of every decision as the default view, plus drawn supersession lineage, a timeline, and a category browser. The demo store's consolidation, three retired decisions converging on the one that replaced them, draws as a fan. By default the file carries the full decision store, including each decision's body rendered as structured detail in the side panel, and lands in the store directory rather than your repo; `--no-include-bodies` produces a redacted titles-and-metadata artifact for wider sharing.
 
+`nauro doctor` checks the store for structural defects: unparseable decision files, dangling or cyclic supersession refs, and status contradictions. It is deterministic and report-only — it never edits the store and always exits 0.
+
 For real-project setup (`nauro init` / `nauro adopt`), cross-surface access, MCP tool reference, and architecture details, see the [main project README](https://github.com/nauro-ai/nauro#readme). Don't run `nauro setup` from `/tmp/nauro-demo`; that would wire the throwaway demo into your MCP client.
 
 `nauro adopt --with-subagents` additionally installs Nauro's bundled Claude Code workflow subagents (`@nauro-planner`, `@nauro-executor`, `@nauro-reviewer`, `@nauro-tech-lead`) into `~/.claude/agents/`. Off by default to avoid overwriting locally-customized files; pass `--force-overwrite` to replace customized files.

--- a/packages/nauro/src/nauro/cli/commands/doctor.py
+++ b/packages/nauro/src/nauro/cli/commands/doctor.py
@@ -1,0 +1,94 @@
+"""nauro doctor — report deterministic store-integrity defects.
+
+Reads the local store and reports structural defects in the decision set:
+unparseable decision files, dangling or cyclic supersession refs, and status
+contradictions. Report-only — it never edits the store — and it exits 0
+whether or not it finds defects, because a defect is information for the user,
+not a failed command.
+"""
+
+from __future__ import annotations
+
+import typer
+from nauro_core.doctor import StoreDiagnosis, diagnose_store
+
+from nauro.cli.utils import resolve_target_project
+from nauro.store.filesystem_store import FilesystemStore
+
+
+def _label(number: int) -> str:
+    return f"D{number}"
+
+
+def _render_report(diagnosis: StoreDiagnosis) -> list[str]:
+    """Render a diagnosis as human-readable report lines."""
+    if diagnosis.is_clean:
+        return ["No integrity defects found."]
+
+    lines: list[str] = []
+
+    if diagnosis.unparseable:
+        lines.append(f"Unparseable decision files ({len(diagnosis.unparseable)}):")
+        for row in diagnosis.unparseable:
+            lines.append(f"  {row.stem}: {row.error}")
+        lines.append("")
+
+    if diagnosis.dangling_refs:
+        lines.append(f"Dangling supersession refs ({len(diagnosis.dangling_refs)}):")
+        for ref in diagnosis.dangling_refs:
+            lines.append(
+                f"  {_label(ref.source)}.{ref.field} -> {_label(ref.target)} "
+                "(no such decision on disk)"
+            )
+        lines.append("")
+
+    if diagnosis.cycles:
+        lines.append(f"Supersession cycles ({len(diagnosis.cycles)}):")
+        for cycle in diagnosis.cycles:
+            if len(cycle.members) == 1:
+                lines.append(f"  {_label(cycle.members[0])} (self-reference)")
+            else:
+                lines.append("  " + " -> ".join(_label(n) for n in cycle.members))
+        lines.append("")
+
+    if diagnosis.contradictions:
+        lines.append(f"Status contradictions ({len(diagnosis.contradictions)}):")
+        for row in diagnosis.contradictions:
+            if row.kind == "active_with_superseded_by":
+                lines.append(
+                    f"  {_label(row.decision)} is active but records "
+                    f"superseded_by={_label(row.other)}"
+                )
+            else:
+                lines.append(
+                    f"  {_label(row.decision)} supersedes {_label(row.other)}, but "
+                    f"{_label(row.other)} records "
+                    f"superseded_by={_label(row.conflicting_with)}"
+                )
+        lines.append("")
+
+    total = (
+        len(diagnosis.unparseable)
+        + len(diagnosis.dangling_refs)
+        + len(diagnosis.cycles)
+        + len(diagnosis.contradictions)
+    )
+    lines.append(f"Found {total} defect(s).")
+    return lines
+
+
+def doctor(
+    project: str | None = typer.Option(
+        None,
+        "--project",
+        help="Target project name.",
+    ),
+) -> None:
+    """Report deterministic integrity defects in the project's decision store."""
+    project_name, store_path = resolve_target_project(project)
+
+    diagnosis = diagnose_store(FilesystemStore(store_path))
+
+    typer.echo(f"Project: {project_name}\n")
+    for line in _render_report(diagnosis):
+        typer.echo(line)

--- a/packages/nauro/src/nauro/cli/main.py
+++ b/packages/nauro/src/nauro/cli/main.py
@@ -53,6 +53,7 @@ def _register_commands() -> None:
         attach,
         auth,
         config,
+        doctor,
         graph,
         hook,
         import_cmd,
@@ -87,6 +88,7 @@ def _register_commands() -> None:
     app.command(name="render-plugin", hidden=True)(render_plugin.render_plugin)
     app.add_typer(setup.setup_app, name="setup")
     app.command(name="status")(status.status)
+    app.command(name="doctor")(doctor.doctor)
     app.add_typer(config.config_app, name="config")
     app.add_typer(validate.validate_app, name="validate")
     app.add_typer(auth.auth_app, name="auth")

--- a/packages/nauro/tests/snapshots/public_contract_v1.json
+++ b/packages/nauro/tests/snapshots/public_contract_v1.json
@@ -284,6 +284,21 @@
       },
       {
         "kind": "command",
+        "name": "doctor",
+        "params": [
+          {
+            "flags": [
+              "--project"
+            ],
+            "kind": "option",
+            "name": "project",
+            "required": false,
+            "type": "text"
+          }
+        ]
+      },
+      {
+        "kind": "command",
         "name": "flag-question",
         "params": [
           {

--- a/packages/nauro/tests/test_cli_doctor.py
+++ b/packages/nauro/tests/test_cli_doctor.py
@@ -1,0 +1,79 @@
+"""Tests for the ``nauro doctor`` command.
+
+Command-and-adapter behavior only: exit code posture, project resolution, and
+the rendered report shape. The diagnosis logic itself (which defects fire, the
+one-to-many guard, ordering) is pinned in the nauro-core suite and is not
+re-asserted here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from nauro_core.decision_model import Decision, format_decision
+from typer.testing import CliRunner
+
+from nauro.cli.main import app
+from nauro.constants import DECISIONS_DIR
+from nauro.store.registry import register_project
+from nauro.templates.scaffolds import scaffold_project_store
+
+runner = CliRunner()
+
+
+def _new_store(tmp_path: Path, name: str = "docproj") -> Path:
+    """Register and scaffold a project, returning its store path."""
+    store = register_project(name, [tmp_path])
+    scaffold_project_store(name, store)
+    return store
+
+
+def _write_decision(store: Path, num: int, slug: str, content: str) -> None:
+    (store / DECISIONS_DIR / f"{num:03d}-{slug}.md").write_text(content, encoding="utf-8")
+
+
+def _decision_md(num: int, *, supersedes: str | None = None) -> str:
+    return format_decision(
+        Decision(
+            date="2026-03-15",
+            confidence="high",
+            num=num,
+            title=f"Decision {num}",
+            rationale=f"Rationale for decision {num}.",
+            supersedes=supersedes,
+        )
+    )
+
+
+def test_clean_store_exits_zero(tmp_path: Path) -> None:
+    _new_store(tmp_path)
+    result = runner.invoke(app, ["doctor", "--project", "docproj"])
+    assert result.exit_code == 0
+    assert "No integrity defects found." in result.stdout
+
+
+def test_defective_store_exits_zero_and_renders_defects(tmp_path: Path) -> None:
+    store = _new_store(tmp_path)
+    _write_decision(store, 10, "broken", "this file does not parse as a decision")
+    _write_decision(store, 11, "dangling", _decision_md(11, supersedes="999"))
+
+    result = runner.invoke(app, ["doctor", "--project", "docproj"])
+
+    assert result.exit_code == 0
+    assert "Unparseable decision files" in result.stdout
+    assert "010-broken" in result.stdout
+    assert "Dangling supersession refs" in result.stdout
+    assert "D11" in result.stdout
+    assert "D999" in result.stdout
+
+
+def test_project_resolution_and_report_header(tmp_path: Path) -> None:
+    _new_store(tmp_path, name="another")
+    result = runner.invoke(app, ["doctor", "--project", "another"])
+    assert result.exit_code == 0
+    assert "Project: another" in result.stdout
+
+
+def test_unknown_project_exits_nonzero(tmp_path: Path) -> None:
+    result = runner.invoke(app, ["doctor", "--project", "nope"])
+    assert result.exit_code == 1


### PR DESCRIPTION
## Why

A project's decision store can drift into structural defects that no surface reports today: a decision file that no longer parses, a supersession ref pointing at a decision that was never written or has been removed, a reference cycle, or a status that contradicts its own supersession fields (an active decision that also records being superseded). The graph view deliberately drops edges whose other endpoint is missing and drops self-edges, so exactly these anomalies stay invisible. `nauro doctor` gives the store owner a deterministic, report-only integrity check.

## What changed

- New `nauro doctor` command. Resolves the target project (`--project` or cwd), reads the store, and prints a human-readable report of four defect categories: unparseable decision files, dangling supersession refs, supersession cycles, and status contradictions. Report-only — it never edits the store — and always exits 0, so a defective store is information, not a failed command.
- The integrity checks live in a new pure `nauro_core.doctor` module reading through the Store protocol. It stands apart from the graph payload builder, whose edge collection keeps only live endpoints and drops self-edges — the very cases doctor exists to catch. Every check is deterministic and its output fully sorted.
- Two design guards keep the checks free of false positives: existence is derived from on-disk file stems (not parsed numbers), so a corrupt target is reported once as unparseable and never also as dangling; and the forward/back conflict check is anchored on the forward edge only, so the established one-to-many retirement convention (one forward root plus back-only refs on the retired members) is never flagged.
- The guarded decision scan is refactored into one capturing primitive (`scan_decisions`) in the operations kernel; `parse_all_decisions` now delegates to it, keeping the retrieval path byte-identical while giving doctor access to the parse failures.

## Test plan

- `uv run pytest packages/nauro-core/tests/` — 1067 passed.
- `uv run pytest packages/nauro/tests/` — 1644 passed, 10 skipped.
- `uv run ruff check packages/` and `uv run ruff format --check packages/` — clean.
- New unit coverage: each defect category fires; a ref to a present-but-unparseable file is not dangling; reciprocal pairs and the one-to-many convention are not flagged; clean stores yield an empty diagnosis; output ordering is deterministic. CLI coverage: exit 0 on clean and defective stores, `--project` resolution, unknown project exits non-zero.

## Risk / what to review

- Touches the frozen 1.0 public CLI contract. The snapshot regen is additive-only: exactly one new `doctor` command node with a single `--project` option. Confirmed by running the contract test without regen first (it failed, showing only the additive diff). `diagnose_store` is imported submodule-only and is deliberately kept out of the `nauro-core` public import surface.
- The `parse_all_decisions` refactor is meant to be behavior-preserving for all existing callers; the retrieval hot path should be byte-identical.
