### PR TITLE
Release nauro 1.3.0 and nauro-core 1.1.0

### DIFF
--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro-core"
-version = "1.0.3"
+version = "1.1.0"
 description = "Shared pure-Python logic for Nauro: parsing, validation, context assembly, constants."
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro"
-version = "1.2.1"
+version = "1.3.0"
 description = "Human-ratified project judgement for every connected AI agent."
 readme = "README.md"
 license = "Apache-2.0"
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "nauro-core>=1.0.3,<2",
+    "nauro-core>=1.1.0,<2",
     "typer>=0.9",
     "httpx>=0.24",
     "mcp>=1.0",

--- a/server.json
+++ b/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Nauro-AI/nauro",
     "source": "github"
   },
-  "version": "1.2.1",
+  "version": "1.3.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "nauro",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -1051,7 +1051,7 @@ wheels = [
 
 [[package]]
 name = "nauro"
-version = "1.2.1"
+version = "1.3.0"
 source = { editable = "packages/nauro" }
 dependencies = [
     { name = "filelock" },
@@ -1095,7 +1095,7 @@ provides-extras = ["dev", "embeddings"]
 
 [[package]]
 name = "nauro-core"
-version = "1.0.3"
+version = "1.1.0"
 source = { editable = "packages/nauro-core" }
 dependencies = [
     { name = "bm25s" },


### PR DESCRIPTION
## Why

Release the work merged since nauro 1.2.1 / nauro-core 1.0.3 (20 PRs). Both packages move minor: new additive user-facing surface in each.

## What ships

**nauro 1.2.1 -> 1.3.0**
- New `nauro doctor` command: deterministic, report-only store-integrity check (unparseable decision files, dangling supersession refs, cycles, status contradictions)
- Hardened MCP command resolution: recorded commands are validated durable absolute paths; `nauro status` gains a liveness probe
- Publish-safety warnings when generated wiring files are tracked in git
- CLI help and status output aligned with actual behavior; telemetry logger failures no longer reach stderr

**nauro-core 1.0.3 -> 1.1.0**
- New `nauro_core.doctor` module (pure integrity checks over the Store protocol) and a capturing decision-scan primitive
- Open-questions file self-heals on resolve: stamped entries relocate below the Resolved divider on both write paths
- L0 context payload leads with the project scope preamble; L1 becomes a bounded working set with an omission trailer
- propose_decision rejects nameless rejected-alternative items instead of minting an "Unknown" heading; tool description prose trimmed

**Dependency floor:** nauro now requires `nauro-core>=1.1.0,<2`. This bump is required, not routine: current nauro source imports nauro-core surface that does not exist in published 1.0.3.

`server.json` moves to 1.3.0 in lockstep with the nauro package.

## Checks

- `scripts/check_server_json_version.py` — pass (server.json version-locked to 1.3.0)
- `scripts/check_single_sourced.py packages/nauro/src` — pass
- `uv lock --check` — pass; `uv sync --locked` for both packages with all extras — pass

## After merge

Tag the squash-merge commit `nauro-core-v1.1.0` and `nauro-v1.3.0`; each tag triggers its trusted-publish workflow (PyPI, and the MCP registry for the nauro tag). GitHub Releases follow.
