### PR TITLE
Fit server.json description to the MCP registry cap and guard it in CI

### DIFF
--- a/scripts/check_server_json_version.py
+++ b/scripts/check_server_json_version.py
@@ -10,12 +10,18 @@ PR time: it fails if ``server.json``'s top-level ``version`` or its first
 package's ``version`` drifts from the ``nauro`` package version in
 ``packages/nauro/pyproject.toml``.
 
+It also enforces the MCP registry's ``description`` length cap (100
+characters) — the registry rejects longer descriptions with a 422 at the
+same post-tag moment (this happened on the 1.3.0 release, after a copy
+rewrite grew the description to 140 characters).
+
 Usage::
 
     python scripts/check_server_json_version.py
     python scripts/check_server_json_version.py server.json packages/nauro/pyproject.toml
 
-Exits 0 when in lockstep, 1 on a version mismatch, 2 on a usage/IO error.
+Exits 0 when in lockstep, 1 on a version mismatch or an over-long
+description, 2 on a usage/IO error.
 """
 
 from __future__ import annotations
@@ -23,6 +29,9 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
+
+# The MCP registry rejects a server description longer than this (HTTP 422).
+MAX_DESCRIPTION_CHARS = 100
 
 
 def project_version(pyproject_text: str) -> str:
@@ -90,7 +99,20 @@ def main(argv: list[str]) -> int:
         )
         return 1
 
-    print(f"server.json is version-locked to the nauro package ({pkg_version}).")
+    description = server.get("description") or ""
+    if len(description) > MAX_DESCRIPTION_CHARS:
+        print(
+            f"server.json .description is {len(description)} characters; the MCP "
+            f"registry caps it at {MAX_DESCRIPTION_CHARS} and rejects the publish "
+            "with a 422 after the tag is cut. Shorten it before releasing."
+        )
+        return 1
+
+    print(
+        f"server.json is version-locked to the nauro package ({pkg_version}) "
+        f"and its description fits the registry cap "
+        f"({len(description)}/{MAX_DESCRIPTION_CHARS} chars)."
+    )
     return 0
 
 

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "ai.nauro/nauro",
   "title": "Nauro",
-  "description": "Human-ratified project judgment for AI coding agents, surfaced before work in every session.",
+  "description": "Human-ratified project judgment for AI coding agents; approved corrections carry forward.",
   "websiteUrl": "https://nauro.ai",
   "repository": {
     "url": "https://github.com/Nauro-AI/nauro",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "ai.nauro/nauro",
   "title": "Nauro",
-  "description": "Human-ratified project judgment for AI coding agents. Surfaces relevant prior judgment before work and carries approved corrections forward.",
+  "description": "Human-ratified project judgment for AI coding agents, surfaced before work in every session.",
   "websiteUrl": "https://nauro.ai",
   "repository": {
     "url": "https://github.com/Nauro-AI/nauro",


### PR DESCRIPTION
## Why

The 1.3.0 release published cleanly to PyPI, but the MCP-registry publish job failed post-tag with a 422: the registry caps a server description at 100 characters, and the recent public-copy rewrite grew `server.json`'s description to 140. The PR-time guard checks only the version fields, so the length regression was invisible until after the tag was cut — the exact loud-but-late failure the guard script exists to prevent for versions.

## What changed

- `server.json` description shortened to 92 characters, keeping the human-ratified project-judgment framing: "Human-ratified project judgment for AI coding agents, surfaced before work in every session."
- `scripts/check_server_json_version.py` now also enforces the registry's 100-character description cap at PR time, with a message naming the post-tag failure it prevents. Docstring updated to record the 1.3.0 incident alongside the 1.0.1 version-drift one.

The registry entry catches up automatically at the next release tag; no re-publish is needed now.

## Test plan

- `python3 scripts/check_server_json_version.py` — passes on the fixed file (92/100 chars reported).
- Negative check: the same script against a copy of server.json with a 140-character description exits 1 with the cap message.
- `uv run ruff check scripts/check_server_json_version.py` — clean.
