### PR TITLE
Consolidate cwd project resolution into a single waterfall helper

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/hook.py
+++ b/packages/nauro/src/nauro/cli/commands/hook.py
@@ -130,33 +130,15 @@ def _run_user_prompt_submit() -> None:
 def _resolve_store_path(cwd: Path) -> Path | None:
     """Resolve the project store path from a hook payload's cwd.
 
-    Reuses the per-repo config walk-up and the v2 registry path resolution that
+    Delegates to the canonical ``resolve_from_cwd`` waterfall that
     ``cli/utils.resolve_target_project`` uses, but operates against the payload's
     cwd rather than the process cwd and returns None instead of raising — the
     hook never errors a turn over an unresolvable directory.
     """
-    from nauro.store.registry import get_store_path_v2, resolve_v2_from_path
-    from nauro.store.repo_config import (
-        RepoConfigSchemaError,
-        find_repo_config,
-        load_repo_config,
-    )
+    from nauro.store.resolution import resolve_from_cwd
 
-    config_path = find_repo_config(cwd)
-    if config_path is not None:
-        repo_root = config_path.parent.parent
-        try:
-            cfg = load_repo_config(repo_root)
-        except (RepoConfigSchemaError, OSError):
-            cfg = None
-        if cfg is not None:
-            return get_store_path_v2(cfg["id"])
-
-    v2_match = resolve_v2_from_path(cwd)
-    if v2_match is not None:
-        pid, _entry = v2_match
-        return get_store_path_v2(pid)
-    return None
+    resolution = resolve_from_cwd(cwd)
+    return resolution.store_path if resolution is not None else None
 
 
 def _check(store_path: Path, prompt: str) -> list[dict]:

--- a/packages/nauro/src/nauro/cli/utils.py
+++ b/packages/nauro/src/nauro/cli/utils.py
@@ -30,16 +30,10 @@ from nauro.store.registry import (
     load_registry,
     load_registry_v2,
     register_project_v2,
-    resolve_project,
-    resolve_v2_from_path,
     suggest_project_for_path,
 )
-from nauro.store.repo_config import (
-    RepoConfigSchemaError,
-    collides_with_global_config,
-    find_repo_config,
-    load_repo_config,
-)
+from nauro.store.repo_config import collides_with_global_config
+from nauro.store.resolution import resolve_from_cwd
 
 
 def probe_nauro_command(cmd: str, *, timeout: float = 1.5) -> bool:
@@ -145,26 +139,6 @@ def _available_project_names() -> list[str]:
     return sorted((v1_names | v2_names) - {""})
 
 
-def _resolve_from_repo_config() -> tuple[str, Path] | None:
-    """Resolve via ``.nauro/config.json`` walk-up from cwd.
-
-    Returns (display_name, store_path) or None when no repo config is found.
-    A repo-config that names a project_id missing from the v2 registry is
-    still honored — the store path uses the id from the config.
-    """
-    config_path = find_repo_config()
-    if config_path is None:
-        return None
-    repo_root = config_path.parent.parent
-    try:
-        cfg = load_repo_config(repo_root)
-    except (RepoConfigSchemaError, OSError):
-        return None
-    pid = cfg["id"]
-    name = cfg.get("name") or pid
-    return name, get_store_path_v2(pid)
-
-
 def resolve_target_project(project_flag: str | None) -> tuple[str, Path]:
     """Resolve the target project from --project flag or cwd.
 
@@ -211,24 +185,13 @@ def resolve_target_project(project_flag: str | None) -> tuple[str, Path]:
             typer.echo("No projects registered. Run 'nauro init' first.", err=True)
         raise typer.Exit(code=1)
 
-    # 2 — repo config walk-up
-    via_repo = _resolve_from_repo_config()
-    if via_repo is not None:
-        return via_repo
-
-    # 2b — v2 registry by cwd repo_paths (no repo config, but registered)
+    # 2 — cwd waterfall: repo config walk-up → v2 registry by path → v1 legacy
     cwd = Path.cwd()
-    v2_match = resolve_v2_from_path(cwd)
-    if v2_match is not None:
-        pid, entry = v2_match
-        return entry.get("name", pid), get_store_path_v2(pid)
+    resolution = resolve_from_cwd(cwd)
+    if resolution is not None:
+        return resolution.display_name, resolution.store_path
 
-    # 3 — v1 fallback (legacy)
-    project_name = resolve_project(cwd)
-    if project_name:
-        return project_name, get_store_path(project_name)
-
-    # 4 — error
+    # 3 — error
     available = _available_project_names()
     typer.echo("No project found for current directory.", err=True)
 

--- a/packages/nauro/src/nauro/mcp/stdio_server.py
+++ b/packages/nauro/src/nauro/mcp/stdio_server.py
@@ -52,17 +52,11 @@ from nauro.mcp.tools import (
     tool_update_state,
 )
 from nauro.onboarding import WELCOME_NO_PROJECT
-from nauro.store.registry import (
-    get_store_path,
-    get_store_path_v2,
-    resolve_project,
-    resolve_v2_from_path,
-)
 from nauro.store.resolution import (
     NoProjectError,
     StoreResolutionError,
+    resolve_from_cwd,
     resolve_store,
-    resolve_via_repo_config,
 )
 
 logger = logging.getLogger("nauro.stdio")
@@ -132,10 +126,28 @@ def _param_desc(tool_name: str, param: str) -> str:
     return props[param]["description"]
 
 
-# Back-compat re-exports — tests import these symbols from this module.
+# Back-compat re-export — tests import this symbol from this module.
 # The resolution logic itself lives in nauro.store.resolution.
 _resolve_store = resolve_store
-_resolve_via_repo_config = resolve_via_repo_config
+
+
+def _resolve_or_error(project_id, cwd) -> tuple[Path | None, dict | None]:
+    """Resolve a store path, or translate a resolution failure to an error dict.
+
+    Every tool wrapper shares this preamble: on success it returns
+    ``(store_path, None)``; on failure it returns ``(None, error_dict)`` where
+    the dict carries the transport-appropriate guidance — the welcome screen for
+    the genuine no-project case, the specific diagnostic otherwise. Each wrapper
+    routes the dict to its own output shape (renderer envelope, dict, or the
+    guidance string).
+    """
+    try:
+        return _resolve_store(project_id, cwd), None
+    except NoProjectError:
+        return None, {"store": "local", "status": "error", "guidance": WELCOME_NO_PROJECT}
+    except StoreResolutionError as exc:
+        return None, {"store": "local", "status": "error", "guidance": str(exc)}
+
 
 # ``cwd`` exists only on the local transport (the hosted server has no
 # filesystem to resolve against), so its description lives here rather than
@@ -162,15 +174,9 @@ def get_context(
         Field(description=_param_desc("get_context", "level")),
     ] = "L0",
 ) -> CallToolResult:
-    try:
-        store_path = _resolve_store(project_id, cwd)
-    except NoProjectError:
-        result = {"store": "local", "status": "error", "guidance": WELCOME_NO_PROJECT}
-    except StoreResolutionError as exc:
-        result = {"store": "local", "status": "error", "guidance": str(exc)}
-    else:
-        # tool_get_context accepts both int and string levels.
-        result = tool_get_context(store_path, level)
+    store_path, err = _resolve_or_error(project_id, cwd)
+    # tool_get_context accepts both int and string levels.
+    result = err if err is not None else tool_get_context(store_path, level)
     return _wrap_with_renderer("get_context", result)
 
 
@@ -182,12 +188,9 @@ def get_raw_file(
     ] = None,
     cwd: _CWD_PARAM = None,
 ) -> dict:
-    try:
-        store_path = _resolve_store(project_id, cwd)
-    except NoProjectError:
-        return {"store": "local", "status": "error", "guidance": WELCOME_NO_PROJECT}
-    except StoreResolutionError as exc:
-        return {"store": "local", "status": "error", "guidance": str(exc)}
+    store_path, err = _resolve_or_error(project_id, cwd)
+    if err is not None:
+        return err
     return tool_get_raw_file(store_path, path)
 
 
@@ -202,14 +205,8 @@ def list_decisions(
         bool, Field(description=_param_desc("list_decisions", "include_superseded"))
     ] = False,
 ) -> CallToolResult:
-    try:
-        store_path = _resolve_store(project_id, cwd)
-    except NoProjectError:
-        result = {"store": "local", "status": "error", "guidance": WELCOME_NO_PROJECT}
-    except StoreResolutionError as exc:
-        result = {"store": "local", "status": "error", "guidance": str(exc)}
-    else:
-        result = tool_list_decisions(store_path, limit, include_superseded)
+    store_path, err = _resolve_or_error(project_id, cwd)
+    result = err if err is not None else tool_list_decisions(store_path, limit, include_superseded)
     return _wrap_with_renderer("list_decisions", result)
 
 
@@ -224,14 +221,8 @@ def get_decision(
     ] = None,
     cwd: _CWD_PARAM = None,
 ) -> CallToolResult:
-    try:
-        store_path = _resolve_store(project_id, cwd)
-    except NoProjectError:
-        result = {"store": "local", "status": "error", "guidance": WELCOME_NO_PROJECT}
-    except StoreResolutionError as exc:
-        result = {"store": "local", "status": "error", "guidance": str(exc)}
-    else:
-        result = tool_get_decision(store_path, number, mode)
+    store_path, err = _resolve_or_error(project_id, cwd)
+    result = err if err is not None else tool_get_decision(store_path, number, mode)
     return _wrap_with_renderer("get_decision", result, {"mode": mode})
 
 
@@ -246,12 +237,9 @@ def diff_since_last_session(
         int | None, Field(description=_param_desc("diff_since_last_session", "days"))
     ] = None,
 ) -> dict:
-    try:
-        store_path = _resolve_store(project_id, cwd)
-    except NoProjectError:
-        return {"store": "local", "status": "error", "guidance": WELCOME_NO_PROJECT}
-    except StoreResolutionError as exc:
-        return {"store": "local", "status": "error", "guidance": str(exc)}
+    store_path, err = _resolve_or_error(project_id, cwd)
+    if err is not None:
+        return err
     return tool_diff_since_last_session(store_path, days)
 
 
@@ -267,14 +255,12 @@ def search_decisions(
     ] = None,
     cwd: _CWD_PARAM = None,
 ) -> CallToolResult:
-    try:
-        store_path = _resolve_store(project_id, cwd)
-    except NoProjectError:
-        result = {"store": "local", "status": "error", "guidance": WELCOME_NO_PROJECT}
-    except StoreResolutionError as exc:
-        result = {"store": "local", "status": "error", "guidance": str(exc)}
-    else:
-        result = tool_search_decisions(store_path, query, limit, include_superseded)
+    store_path, err = _resolve_or_error(project_id, cwd)
+    result = (
+        err
+        if err is not None
+        else tool_search_decisions(store_path, query, limit, include_superseded)
+    )
     # The kernel envelope omits the echoed query (pruned at the operations
     # cutover); thread it to the renderer so the local header shows the term,
     # matching the remote transport, which still carries query in its envelope.
@@ -294,14 +280,8 @@ def check_decision(
     ] = None,
     cwd: _CWD_PARAM = None,
 ) -> CallToolResult:
-    try:
-        store_path = _resolve_store(project_id, cwd)
-    except NoProjectError:
-        result = {"store": "local", "status": "error", "guidance": WELCOME_NO_PROJECT}
-    except StoreResolutionError as exc:
-        result = {"store": "local", "status": "error", "guidance": str(exc)}
-    else:
-        result = tool_check_decision(store_path, proposed_approach, context)
+    store_path, err = _resolve_or_error(project_id, cwd)
+    result = err if err is not None else tool_check_decision(store_path, proposed_approach, context)
     return _wrap_with_renderer("check_decision", result)
 
 
@@ -358,12 +338,9 @@ def propose_decision(
     ] = None,
     cwd: _CWD_PARAM = None,
 ) -> dict:
-    try:
-        store_path = _resolve_store(project_id, cwd)
-    except NoProjectError:
-        return {"store": "local", "status": "error", "guidance": WELCOME_NO_PROJECT}
-    except StoreResolutionError as exc:
-        return {"store": "local", "status": "error", "guidance": str(exc)}
+    store_path, err = _resolve_or_error(project_id, cwd)
+    if err is not None:
+        return err
     return tool_propose_decision(
         store_path,
         title=title,
@@ -398,12 +375,9 @@ def flag_question(
     ] = None,
     cwd: _CWD_PARAM = None,
 ) -> str:
-    try:
-        store_path = _resolve_store(project_id, cwd)
-    except NoProjectError:
-        return WELCOME_NO_PROJECT
-    except StoreResolutionError as exc:
-        return str(exc)
+    store_path, err = _resolve_or_error(project_id, cwd)
+    if err is not None:
+        return err["guidance"]
     result = tool_flag_question(
         store_path, question, context, targets=targets, resolved_by=resolved_by
     )
@@ -426,12 +400,9 @@ def update_state(
     ] = None,
     cwd: _CWD_PARAM = None,
 ) -> str:
-    try:
-        store_path = _resolve_store(project_id, cwd)
-    except NoProjectError:
-        return WELCOME_NO_PROJECT
-    except StoreResolutionError as exc:
-        return str(exc)
+    store_path, err = _resolve_or_error(project_id, cwd)
+    if err is not None:
+        return err["guidance"]
     result = tool_update_state(store_path, delta)
     if result.get("warning"):
         return f"State updated. {result['warning']}"
@@ -447,26 +418,11 @@ def _pull_on_startup() -> None:
     and the server starts with local state.
     """
     try:
-        cwd = Path(os.getcwd())
-        project_key: str | None = None
-        store_path: Path | None = None
-
-        via_config = _resolve_via_repo_config(cwd)
-        if via_config is not None:
-            project_key, store_path = via_config
-        else:
-            v2_match = resolve_v2_from_path(cwd)
-            if v2_match is not None:
-                pid, _entry = v2_match
-                project_key, store_path = pid, get_store_path_v2(pid)
-            else:
-                legacy_name = resolve_project(cwd)
-                if legacy_name:
-                    project_key, store_path = legacy_name, get_store_path(legacy_name)
-
-        if not project_key or store_path is None:
+        resolution = resolve_from_cwd(Path(os.getcwd()))
+        if resolution is None:
             logger.debug("session-start pull: no project found in cwd, skipping")
             return
+        project_key, store_path = resolution.project_id, resolution.store_path
         if not store_path.exists():
             logger.debug("session-start pull: store not found for %s, skipping", project_key)
             return

--- a/packages/nauro/src/nauro/store/resolution.py
+++ b/packages/nauro/src/nauro/store/resolution.py
@@ -22,6 +22,7 @@ for the other failure modes.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import NamedTuple
 
 from nauro.store.registry import (
     find_projects_by_name_v2,
@@ -81,11 +82,29 @@ class MultipleProjectsError(StoreResolutionError):
     """
 
 
-def resolve_via_repo_config(start: Path | None) -> tuple[str, Path] | None:
-    """Walk up from ``start`` looking for ``.nauro/config.json``.
+class RepoResolution(NamedTuple):
+    """A cwd resolved to a project store.
 
-    Returns ``(project_id, store_path)`` or ``None`` when no config is found.
-    Mirrors how git locates ``.git`` from anywhere inside a working tree.
+    ``project_id`` is the store key: a ULID for v2 projects (from the repo
+    config or the v2 registry) or the legacy name for v1 projects. It is the
+    key the sync layer pulls under. ``display_name`` is the human-facing name
+    for CLI output. ``store_path`` is not existence-checked — each caller
+    decides how to treat a resolved-but-missing store.
+    """
+
+    store_path: Path
+    project_id: str
+    display_name: str
+
+
+def _resolve_repo_config_from_cwd(start: Path | None) -> tuple[dict, Path] | None:
+    """Walk up from ``start`` for ``.nauro/config.json`` and load it.
+
+    Returns ``(config, store_path)`` or ``None`` when no config is found or the
+    config is unreadable. Both ``RepoConfigSchemaError`` (schema mismatch, or a
+    corrupt-JSON error the reader remaps to it) and ``OSError`` (an unreadable
+    file) degrade to ``None`` so a resolution failure surfaces the no-project
+    fallback rather than crashing the transport.
     """
     config_path = find_repo_config(start=start)
     if config_path is None:
@@ -93,12 +112,55 @@ def resolve_via_repo_config(start: Path | None) -> tuple[str, Path] | None:
     repo_root = config_path.parent.parent
     try:
         cfg = load_repo_config(repo_root)
-    except RepoConfigSchemaError:
-        # Covers both schema-mismatch and corrupt JSON (the reader remaps a
-        # JSONDecodeError to RepoConfigSchemaError), so either degrades to the
-        # no-project fallback rather than crashing the transport.
+    except (RepoConfigSchemaError, OSError):
         return None
-    return cfg["id"], get_store_path_v2(cfg["id"])
+    return cfg, get_store_path_v2(cfg["id"])
+
+
+def resolve_via_repo_config(start: Path | None) -> tuple[str, Path] | None:
+    """Walk up from ``start`` looking for ``.nauro/config.json``.
+
+    Returns ``(project_id, store_path)`` or ``None`` when no config is found.
+    Mirrors how git locates ``.git`` from anywhere inside a working tree.
+    """
+    resolved = _resolve_repo_config_from_cwd(start)
+    if resolved is None:
+        return None
+    cfg, store_path = resolved
+    return cfg["id"], store_path
+
+
+def resolve_from_cwd(cwd: str | Path | None) -> RepoResolution | None:
+    """Resolve a cwd to a project store via the canonical waterfall.
+
+    Applies the three cwd-based tiers in order and returns the first match:
+
+      1. ``.nauro/config.json`` walk-up (id-keyed v2 store).
+      2. v2 registry matched by repo path.
+      3. v1 ``resolve_project`` (legacy, name-keyed).
+
+    Returns a :class:`RepoResolution`, or ``None`` when no tier matches. Does
+    NOT check that ``store_path`` exists — each caller decides how to treat a
+    resolved-but-missing store.
+    """
+    start = Path(cwd) if cwd else Path.cwd()
+
+    resolved = _resolve_repo_config_from_cwd(start)
+    if resolved is not None:
+        cfg, store_path = resolved
+        pid = cfg["id"]
+        return RepoResolution(store_path, pid, cfg.get("name") or pid)
+
+    v2_match = resolve_v2_from_path(start)
+    if v2_match is not None:
+        pid, entry = v2_match
+        return RepoResolution(get_store_path_v2(pid), pid, entry.get("name", pid))
+
+    name = resolve_project(start)
+    if name:
+        return RepoResolution(get_store_path(name), name, name)
+
+    return None
 
 
 def resolve_store(project_id: str | None, cwd: str | Path | None) -> Path:
@@ -190,8 +252,10 @@ __all__ = [
     "NoProjectError",
     "ProjectIdMismatchError",
     "ProjectNotFoundError",
+    "RepoResolution",
     "StoreMissingError",
     "StoreResolutionError",
+    "resolve_from_cwd",
     "resolve_store",
     "resolve_via_repo_config",
 ]

--- a/packages/nauro/tests/test_hook_command.py
+++ b/packages/nauro/tests/test_hook_command.py
@@ -17,7 +17,7 @@ from typer.testing import CliRunner
 
 from nauro.cli.commands import hook
 from nauro.cli.main import app
-from nauro.store.registry import register_project_v2
+from nauro.store.registry import register_project, register_project_v2
 from nauro.templates.scaffolds import scaffold_project_store
 
 runner = CliRunner()
@@ -162,6 +162,21 @@ def test_missing_store_exits_zero_empty(tmp_path: Path):
     result = _invoke({"prompt": "rework the auth layer", "cwd": str(repo), "session_id": "s1"})
     assert result.exit_code == 0
     assert result.output == ""
+
+
+def test_v1_registry_project_resolves_for_hook(tmp_path: Path):
+    """A project registered only in the v1 (name-keyed) registry resolves.
+
+    The hook's resolver delegates to the canonical ``resolve_from_cwd``
+    waterfall, whose third tier is the v1 legacy registry. Previously the hook
+    stopped after the repo-config and v2-by-path tiers, so a v1-only project
+    got no advisory context; now it resolves like every other surface.
+    """
+    repo = tmp_path / "v1repo"
+    repo.mkdir()
+    store_path = register_project("v1only", [repo])
+
+    assert hook._resolve_store_path(repo) == store_path
 
 
 def test_oversize_prompt_exits_zero_empty(tmp_path: Path):

--- a/packages/nauro/tests/test_resolution_v2.py
+++ b/packages/nauro/tests/test_resolution_v2.py
@@ -277,6 +277,115 @@ def test_get_context_does_not_crash_transport_on_corrupt_config(tmp_path, monkey
     assert len(result.content) == 1
 
 
+# ── resolve_from_cwd: the canonical cwd waterfall shared by every surface ─────
+
+
+def test_resolve_from_cwd_repo_config_tier(tmp_path, monkeypatch):
+    """Tier 1: a ``.nauro/config.json`` walk-up resolves to the id-keyed store."""
+    from nauro.store.resolution import resolve_from_cwd
+
+    cloud_pid, repo_root = _post_migration_state(tmp_path, monkeypatch)
+
+    resolution = resolve_from_cwd(repo_root)
+
+    assert resolution is not None
+    assert resolution.store_path == tmp_path / "projects" / cloud_pid
+    assert resolution.project_id == cloud_pid
+    assert resolution.display_name == "nauro"
+
+
+def test_resolve_from_cwd_v2_registry_by_path_tier(tmp_path, monkeypatch):
+    """Tier 2: no repo config, but the cwd is a registered v2 repo path."""
+    from nauro.store.resolution import resolve_from_cwd
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    pid, store = registry.register_project_v2("byname", [repo])
+
+    resolution = resolve_from_cwd(repo)
+
+    assert resolution is not None
+    assert resolution.store_path == store
+    assert resolution.project_id == pid
+    assert resolution.display_name == "byname"
+
+
+def test_resolve_from_cwd_v1_legacy_tier(tmp_path, monkeypatch):
+    """Tier 3: neither a repo config nor a v2 path match; the v1 registry wins."""
+    from nauro.store.resolution import resolve_from_cwd
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    store = registry.register_project("legacy", [repo])
+
+    resolution = resolve_from_cwd(repo)
+
+    assert resolution is not None
+    assert resolution.store_path == store
+    assert resolution.project_id == "legacy"
+    assert resolution.display_name == "legacy"
+
+
+def test_resolve_from_cwd_repo_config_precedes_v2_registry(tmp_path, monkeypatch):
+    """Tier 1 wins over tier 2: the repo config id is honored even when the same
+    cwd is also a registered v2 repo path pointing at a different project."""
+    from nauro.store.resolution import resolve_from_cwd
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    # The cwd is registered by path under one project id ...
+    pid_by_path, _store = registry.register_project_v2("bypath", [repo])
+    # ... but its repo config names a different, config-only project id.
+    pid_config, _store2 = registry.register_project_v2("byconfig", [tmp_path / "elsewhere"])
+    save_repo_config(repo, {"mode": "local", "id": pid_config, "name": "byconfig"})
+
+    resolution = resolve_from_cwd(repo)
+
+    assert resolution is not None
+    assert resolution.project_id == pid_config
+    assert resolution.store_path == tmp_path / "projects" / pid_config
+    assert pid_config != pid_by_path
+
+
+def test_resolve_from_cwd_none_when_nothing_matches(tmp_path, monkeypatch):
+    """No repo config, no v2 path, no v1 match: the waterfall returns None."""
+    from nauro.store.resolution import resolve_from_cwd
+
+    isolated = tmp_path / "isolated"
+    isolated.mkdir()
+
+    assert resolve_from_cwd(isolated) is None
+
+
+def test_stdio_resolve_welcome_on_oserror_reading_repo_config(tmp_path, monkeypatch):
+    """Fork 1a: a raw OSError while reading the repo config degrades to the
+    welcome/no-project outcome rather than propagating out of the transport.
+
+    Before the shared tier-1 helper caught OSError alongside
+    RepoConfigSchemaError, an unreadable ``.nauro/config.json`` let the OSError
+    escape ``_resolve_store`` and crash the tool call. Now it reaches the same
+    NoProjectError the genuine no-project case surfaces as the welcome screen.
+    """
+    from nauro.store import resolution
+    from nauro.store.resolution import NoProjectError
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    save_repo_config(
+        repo_root,
+        {"mode": "local", "id": "01KQ6AZGNA0B3QBF67NBXP3S45", "name": "proj"},
+    )
+
+    def _raise_oserror(_repo_root):
+        raise OSError("simulated unreadable repo config")
+
+    monkeypatch.setattr(resolution, "load_repo_config", _raise_oserror)
+    monkeypatch.chdir(repo_root)
+
+    with pytest.raises(NoProjectError, match="No Nauro project found"):
+        _resolve_store(None, None)
+
+
 # ── integration: two projects coexist post-migration ─────────────────────────
 
 


### PR DESCRIPTION
## Why

Four surfaces each carried their own copy of the "resolve a project store from a
working directory" waterfall: the CLI's `resolve_target_project`, the hook's
`_resolve_store_path`, the stdio server's startup pull, and the stdio typed
resolver's tier-1 step. The copies had drifted on which fallback tiers they
applied and on how they degraded when a repo config could not be read, and the
ten stdio tool wrappers each repeated the same six-line resolve-or-error
preamble. That duplication is where a resolution regression hides.

## What changed

- `store/resolution.py` gains a single home for the walk. `resolve_from_cwd`
  runs the three cwd tiers in order (`.nauro/config.json` walk-up, v2 registry
  by repo path, then the v1 legacy resolve) and returns a small
  `RepoResolution` (`store_path`, `project_id`, `display_name`) with no
  existence check, so each caller keeps deciding how to treat a
  resolved-but-missing store. The tier-1 config load is factored into a shared
  private helper that both `resolve_via_repo_config` and `resolve_from_cwd`
  delegate to, so the config name is available without a second read.
- The three call sites (`cli/utils.resolve_target_project`,
  `hook._resolve_store_path`, stdio `_pull_on_startup`) now delegate to it.
  For `resolve_target_project` and `_pull_on_startup` the set of resolvable
  directories, return shapes, error text, and exit behavior are unchanged. The
  hook's resolver keeps its silent-None contract but now resolves one more
  class of directory; see the risk section.
- The stdio server routes its ten resolution preambles through one
  `_resolve_or_error` adapter that translates a resolution failure into the
  transport's error shape. Each tool wrapper keeps its own registered
  signature, docstring, and output shape (renderer envelope, dict, or guidance
  string); only the shared preamble moved. The now-unused
  `_resolve_via_repo_config` back-compat alias is removed.

## Risk / what to review

Two deliberate behavior changes, both pinned by new tests:

- The shared tier-1 step now catches `OSError` alongside the schema error when
  reading a repo config, so an unreadable `.nauro/config.json` degrades to the
  welcome/no-project screen instead of letting the error escape and crash the
  stdio tool call. This aligns the stdio typed resolver with the degradation
  the CLI and hook already applied.
- Hook resolution now runs the full three-tier waterfall and gains the
  v1-legacy registry tier it previously omitted. A project resolvable only via
  the v1 (name-keyed) registry now receives advisory hook context where it
  previously got none. The hook remains advisory-only and fail-open.

The 10 tool-parity suites and the public-contract snapshot both stay green with
zero diff, confirming the wire surfaces are unchanged.

## Test plan

- Full `packages/nauro/tests/` suite: 1634 passed, 10 skipped.
- `packages/nauro-core/tests/`: 1073 passed (package untouched; run for
  completeness).
- All 10 `test_*_parity.py` suites green.
- `test_public_contract.py` green with zero diff to `public_contract_v1.json`.
- New tests: unit coverage for each `resolve_from_cwd` tier, tier precedence,
  and the no-match case; a pin for the welcome-screen-on-OSError outcome in
  the stdio typed resolver; a pin for the hook resolving a v1-only-registry
  project.
- `ruff check` and `ruff format --check` clean on `packages/` and
  `benchmarks/`.
