### PR TITLE
Lead public copy with context and expand the loop to the full project record

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 # Nauro
 
-Nauro gives every connected agent project judgement. It helps you capture and approve the intent, decisions, tradeoffs, open questions, and rejected paths that define a project, then brings the relevant judgement into an agent's work.
+**Give your agents the context code leaves out.**
 
-It works across Claude, Cursor, Codex, Perplexity, and any MCP client. The same human-ratified project judgement travels with the work, rather than belonging to a single tool or session.
+Nauro keeps current state, open questions, and human-approved project judgment in one record, ready for every agent you connect.
+
+Nauro keeps a living project record. It combines project scope, current state, and open questions with human-approved project judgment: intent, goals, decisions, rationale, tradeoffs, and rejected paths. Project judgment is the human-ratified part of the record; context is the relevant slice of the record an agent receives for the work in front of it.
+
+Before connected agents plan or change work, Nauro surfaces the relevant parts of that record. Afterward, they explain how the context shaped the result and report what changed. New or revised judgment becomes project truth only after you approve it.
+
+It works across Claude, Cursor, Codex, Perplexity, and any MCP client. The same project record travels with the work, rather than belonging to a single tool or session.
 
 [![PyPI](https://img.shields.io/pypi/v/nauro.svg)](https://pypi.org/project/nauro/) [![Python](https://img.shields.io/pypi/pyversions/nauro.svg)](https://pypi.org/project/nauro/) [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 
@@ -16,14 +22,14 @@ More at [nauro.ai](https://nauro.ai).
 
 ## How the loop works
 
-1. You and an agent capture or elicit the project judgement relevant to the work.
-2. The agent drafts any addition, update, or supersession, and you explicitly approve what becomes project truth.
-3. Relevant judgement reaches an agent before it plans or changes work.
-4. The agent explains how that judgement affected its recommendation or implementation.
-5. You accept, correct, except, reopen, or supersede the result in conversation.
-6. Approved corrections become part of what later agents inherit.
+1. Nauro orients the agent with project scope, current state, open questions, and relevant prior judgment.
+2. You and the agent clarify missing intent, constraints, or tradeoffs.
+3. If the work needs new or revised judgment, the agent drafts it and waits for your explicit approval.
+4. The agent plans, recommends, or implements with that context in view.
+5. The agent explains how the context shaped the result, and you accept, correct, except, reopen, or supersede it in conversation.
+6. The agent reports meaningful completed progress as current state, so later connected agents inherit the updated state and approved judgment.
 
-Nauro supports this loop with a plain markdown store, compact context, and deterministic retrieval. Decisions include the alternatives you ruled out and the reasoning behind them; the store can also carry current state and open questions. When an agent proposes an approach, `check_decision` runs keyword retrieval (BM25) over those files and surfaces related records before the agent plans or writes code.
+Nauro supports this loop with a plain markdown store, compact context, and deterministic retrieval. Decisions include the alternatives you ruled out and the reasoning behind them; the record also carries current state and open questions. When an agent proposes an approach, `check_decision` runs keyword retrieval (BM25) over those files and surfaces related records before the agent plans or writes code.
 
 At session start, agents can read L0 for a concise orientation, use L1 for a bounded working set, or request L2 for a full dump. On mature stores, L2 can reach hundreds of thousands of tokens, so agents should start with L0 and pull exact decisions as needed.
 
@@ -94,13 +100,13 @@ A committed decision log plus a reliable pointer in `AGENTS.md` or `CLAUDE.md` c
 
 Against a coding tool's built-in memory (Claude Code memory, Cursor memories): those are scoped to one tool and one user. Nauro's record belongs to the project. The same store answers in Claude, Cursor, Codex, and any MCP client, across every repo you associate with it.
 
-Against tools that extract notes from conversations automatically: Nauro records human-ratified judgement. An entry is a reviewed choice with its rationale and the alternatives you rejected. An agent drafts the change, you explicitly approve it, and `propose_decision` commits it in one call. Entries are retrieved by deterministic keyword search you can audit and superseded rather than silently rewritten. They remain plain markdown in a folder you own.
+Against tools that extract notes from conversations automatically: Nauro records human-ratified judgment. An entry is a reviewed choice with its rationale and the alternatives you rejected. An agent drafts the change, you explicitly approve it, and `propose_decision` commits it in one call. Entries are retrieved by deterministic keyword search you can audit and superseded rather than silently rewritten. They remain plain markdown in a folder you own.
 
 ## When Nauro helps, and when it doesn't
 
-Nauro is designed for long-lived projects where agents need project judgement before acting: architecture choices, rejected approaches, migration plans, operational constraints, and decisions that recur across sessions, tools, repos, machines, or handoffs.
+Nauro is designed for long-lived projects where agents need project judgment before acting: architecture choices, rejected approaches, migration plans, operational constraints, and decisions that recur across sessions, tools, repos, machines, or handoffs.
 
-If one small repo plus a tight `CLAUDE.md` already keeps your agents oriented, Nauro may be too much.
+If a small repo plus a reliable AGENTS.md or CLAUDE.md keeps agents oriented, Nauro may be more than you need.
 
 The limits are worth knowing. It surfaces only what has been recorded as a decision. It adds an MCP round-trip to the agent's flow. Retrieval is keyword-based, which is fast, offline, and auditable, and can miss a decision phrased in different words than the proposal; an optional embeddings index is available for closer synonym matching.
 

--- a/packages/nauro/README.md
+++ b/packages/nauro/README.md
@@ -1,19 +1,21 @@
 # Nauro
 
-Project judgement for every connected agent.
+Give your agents the context code leaves out.
 
-Nauro carries human-ratified project judgement across agents, sessions, and tools. It helps you capture and approve the intent, decisions, rationale, open questions, and rejected paths that define a project, then brings the relevant judgement into an agent's work. Works with Claude, Perplexity, Cursor, Codex, and any MCP client.
+Nauro keeps current state, open questions, and human-approved project judgment in one record, ready for every agent you connect.
+
+Nauro keeps a living project record. It combines project scope, current state, and open questions with human-approved project judgment: intent, goals, decisions, rationale, tradeoffs, and rejected paths. Project judgment is the human-ratified part of the record; context is the relevant slice of the record an agent receives for the work in front of it. Works with Claude, Perplexity, Cursor, Codex, and any MCP client.
 
 ## How the loop works
 
-1. You and an agent capture or elicit the judgement relevant to the work.
-2. The agent drafts any addition, update, or supersession, and you explicitly approve what becomes project truth.
-3. Relevant judgement reaches an agent before it plans or changes work.
-4. The agent explains how the judgement affected its recommendation or implementation.
-5. You accept, correct, except, reopen, or supersede the result in conversation.
-6. Approved corrections become part of what later agents inherit.
+1. Nauro orients the agent with project scope, current state, open questions, and relevant prior judgment.
+2. You and the agent clarify missing intent, constraints, or tradeoffs.
+3. If the work needs new or revised judgment, the agent drafts it and waits for your explicit approval.
+4. The agent plans, recommends, or implements with that context in view.
+5. The agent explains how the context shaped the result, and you accept, correct, except, reopen, or supersede it in conversation.
+6. The agent reports meaningful completed progress as current state, so later connected agents inherit the updated state and approved judgment.
 
-The markdown store, context summaries, BM25 retrieval, advisory checks, and optional sync support this loop. They do not replace your judgement or silently change project truth.
+The markdown store, context summaries, BM25 retrieval, advisory checks, and optional sync support this loop. They do not replace your judgment or silently change project truth.
 
 ## Install
 
@@ -54,7 +56,7 @@ You'll see a JSON envelope with the related decisions and a deterministic assess
 
 The demo project ruled out storing money as floating-point dollars because binary floating point cannot represent a value like 0.10 exactly, so totals accumulate rounding error and a balance that should read 0.00 shows -0.01. This protective example isolates Nauro's retrieval mechanism: it brings a recorded constraint into the proposal flow before an agent can re-propose the rejected field.
 
-A committed ADR plus a reliable `AGENTS.md` or `CLAUDE.md` pointer can provide enough continuity in a small repo. Nauro is designed for project judgement that must persist across longer histories, sessions, tools, repos, machines, or repeated handoffs.
+If a small repo plus a reliable AGENTS.md or CLAUDE.md keeps agents oriented, Nauro may be more than you need. Nauro is designed for context that must persist across longer histories, sessions, tools, repos, machines, or repeated handoffs.
 
 `nauro graph` renders the store to one self-contained HTML file and opens it: a node-link map of every decision as the default view, plus drawn supersession lineage, a timeline, and a category browser. The demo store's consolidation, three retired decisions converging on the one that replaced them, draws as a fan. By default the file carries the full decision store, including each decision's body rendered as structured detail in the side panel, and lands in the store directory rather than your repo; `--no-include-bodies` produces a redacted titles-and-metadata artifact for wider sharing.
 
@@ -66,7 +68,7 @@ For real-project setup (`nauro init` / `nauro adopt`), cross-surface access, MCP
 
 ## Why Nauro?
 
-Nauro supports a human-ratified project-judgement loop. It captures what you decided and what you ruled out, with the reasoning, then brings related judgement into agent work. Keyword search over the decision store is one mechanism for putting prior reasoning in front of an agent at proposal time.
+Nauro supports a human-ratified project-judgment loop. It captures what you decided and what you ruled out, with the reasoning, then brings related judgment into agent work. Keyword search over the decision store is one mechanism for putting prior reasoning in front of an agent at proposal time.
 
 No model judges your decisions. The check uses deterministic keyword retrieval (BM25), is advisory, and never blocks a change. Agents draft additions, updates, and supersessions; you explicitly approve each one before `propose_decision` commits it in one call.
 

--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "nauro"
 version = "1.3.0"
-description = "Human-ratified project judgement for every connected AI agent."
+description = "Human-approved project judgment and current state for connected AI agents, surfaced before work."
 readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.10"

--- a/packages/nauro/src/nauro/cli/main.py
+++ b/packages/nauro/src/nauro/cli/main.py
@@ -24,7 +24,8 @@ def _version_callback(value: bool) -> None:
 app = typer.Typer(
     name="nauro",
     help=(
-        "Human-ratified project judgment for every connected AI agent."
+        "Human-approved project judgment and current state for connected AI agents, "
+        "surfaced before work."
         "\n\nRun 'nauro telemetry --help' to manage anonymous usage telemetry."
     ),
     no_args_is_help=True,
@@ -42,7 +43,9 @@ def main(
         help="Show version and exit.",
     ),
 ) -> None:
-    """Human-ratified project judgment for every connected AI agent."""
+    """Human-approved project judgment and current state for connected AI agents,
+    surfaced before work.
+    """
     consent.maybe_prompt()
 
 

--- a/packages/nauro/tests/test_cli.py
+++ b/packages/nauro/tests/test_cli.py
@@ -8,6 +8,7 @@ from nauro.cli.main import app
 from nauro.store.registry import get_project, register_project
 from nauro.store.snapshot import capture_snapshot
 from nauro.templates.scaffolds import scaffold_project_store
+from tests._ansi import strip_ansi
 
 runner = CliRunner()
 
@@ -17,7 +18,11 @@ def test_app_shows_help():
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0
     assert "nauro" in result.output.lower()
-    assert "Human-ratified project judgment" in result.output
+    normalized = " ".join(strip_ansi(result.output).split())
+    assert (
+        "Human-approved project judgment and current state for connected AI agents, "
+        "surfaced before work." in normalized
+    )
     assert "doctrine once" not in result.output
 
 

--- a/packages/nauro/tests/test_distribution_copy.py
+++ b/packages/nauro/tests/test_distribution_copy.py
@@ -13,6 +13,32 @@ except ModuleNotFoundError:
 
 ROOT = Path(__file__).resolve().parents[3]
 
+HEADLINE = "Give your agents the context code leaves out."
+
+SUPPORT_LINE = (
+    "Nauro keeps current state, open questions, and human-approved project judgment "
+    "in one record, ready for every agent you connect."
+)
+
+FIT_BOUNDARY = (
+    "If a small repo plus a reliable AGENTS.md or CLAUDE.md keeps agents oriented, "
+    "Nauro may be more than you need."
+)
+
+COMPACT_DESCRIPTION = (
+    "Human-approved project judgment and current state for connected AI agents, "
+    "surfaced before work."
+)
+
+README_PATHS = ("README.md", "packages/nauro/README.md")
+
+PUBLIC_COPY_PATHS = (
+    *README_PATHS,
+    "packages/nauro/pyproject.toml",
+    "server.json",
+    "packages/nauro/src/nauro/cli/main.py",
+)
+
 
 def test_readme_uses_stable_context_and_setup_claims() -> None:
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
@@ -25,12 +51,30 @@ def test_readme_uses_stable_context_and_setup_claims() -> None:
     assert "o200k_base" not in readme
 
 
-def test_package_and_registry_descriptions_name_human_authority() -> None:
+def test_readmes_carry_headline_support_line_and_fit_boundary() -> None:
+    for relative in README_PATHS:
+        text = (ROOT / relative).read_text(encoding="utf-8")
+        assert HEADLINE in text, relative
+        assert SUPPORT_LINE in text, relative
+        assert FIT_BOUNDARY in text, relative
+
+
+def test_compact_description_identical_across_distribution_surfaces() -> None:
     pyproject = tomllib.loads((ROOT / "packages/nauro/pyproject.toml").read_text(encoding="utf-8"))
     server = json.loads((ROOT / "server.json").read_text(encoding="utf-8"))
-    assert "Human-ratified project judgement" in pyproject["project"]["description"]
-    assert "Human-ratified project judgment" in server["description"]
-    assert "approved corrections" in server["description"]
+    assert pyproject["project"]["description"] == COMPACT_DESCRIPTION
+    assert server["description"] == COMPACT_DESCRIPTION
+
+    from nauro.cli.main import app
+
+    assert app.info.help is not None
+    assert app.info.help.startswith(COMPACT_DESCRIPTION)
+
+
+def test_public_copy_uses_us_judgment_spelling() -> None:
+    for relative in PUBLIC_COPY_PATHS:
+        text = (ROOT / relative).read_text(encoding="utf-8")
+        assert "judgement" not in text.lower(), relative
 
 
 def test_contributor_catalogs_describe_retrieval_without_judgment() -> None:

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "ai.nauro/nauro",
   "title": "Nauro",
-  "description": "Human-ratified project judgment for AI coding agents; approved corrections carry forward.",
+  "description": "Human-approved project judgment and current state for connected AI agents, surfaced before work.",
   "websiteUrl": "https://nauro.ai",
   "repository": {
     "url": "https://github.com/Nauro-AI/nauro",


### PR DESCRIPTION
## Why

The category-first headline read as precise but opaque to readers meeting Nauro cold. "Context" communicates the benefit faster, while the supporting copy immediately defines it through current state, open questions, and human-approved project judgment. The old loop description covered only decisions, which made Nauro sound like a decision ledger rather than a living project record. Distribution surfaces also carried three slightly different one-liners and a mix of judgment spellings.

## What changed

- Both READMEs lead with "Give your agents the context code leaves out." and the shared support line, then explain the model: the project record holds scope, current state, open questions, and human-approved project judgment; project judgment is the human-ratified part; context is the relevant slice an agent receives for the work.
- "How the loop works" in both READMEs is now the six-step full-record loop: orient, clarify, draft judgment for explicit approval, work with context in view, explain and accept/correct/except/reopen/supersede, report meaningful progress as current state.
- The package description, MCP registry description, and top-level CLI help now share one identical compact line, within the registry's 100-character cap.
- The fit boundary is now the same sentence in both READMEs; affected public prose standardizes on the US "judgment" spelling.
- Copy guards pin the headline, support line, fit boundary, and the identical compact line across all three distribution surfaces, and reject the UK spelling in public copy.

Advisory-check mechanics, explicit-read context tiers, vendor neutrality, human approval authority, local-first storage wording, and install instructions are unchanged. No functional prompts, skills, subagents, MCP tool contracts, or store behavior are touched.

## Test plan

- `python scripts/check_server_json_version.py`: pass, description 96/100 chars
- `uv run pytest packages/nauro/tests/ -x -q`: 1629 passed, 10 skipped
- `uv run pytest packages/nauro-core/tests/ -x -q`: 1073 passed
- `uv run ruff check packages/` and `uv run ruff format --check packages/`: clean

