### PR TITLE
Consolidate duplicated test seed helpers into conftests

### DIFF
--- a/packages/nauro-core/tests/conftest.py
+++ b/packages/nauro-core/tests/conftest.py
@@ -1,0 +1,76 @@
+"""Shared pytest helpers for the nauro-core test suite.
+
+Hosts the decision-seeding helpers that the operations-kernel tests and the
+search/embeddings tests previously duplicated per module. Plain functions
+rather than fixtures: the tests call them at module scope to build shared
+``DECISIONS`` lists and inline stores, mirroring how the nauro package exposes
+``seed_consented_config`` and friends from its own ``tests/conftest.py``.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+from nauro_core.decision_model import (
+    Decision,
+    DecisionConfidence,
+    DecisionStatus,
+    DecisionType,
+    format_decision,
+)
+from nauro_core.operations import InMemoryStore
+
+
+def _seed_decision(
+    num: int,
+    title: str,
+    rationale: str = "Test rationale.",
+    *,
+    status: DecisionStatus = DecisionStatus.active,
+    confidence: DecisionConfidence = DecisionConfidence.medium,
+    decision_type: DecisionType | None = None,
+    decision_date: date | None = None,
+    stem: str | None = None,
+) -> tuple[str, str]:
+    """Return ``(file_stem, formatted_markdown)`` for a minimal v2 decision.
+
+    The parameter set is the union of the per-module ``_seed_decision`` copies
+    the operations-kernel tests carried. Every argument defaults so an existing
+    call site keeps its meaning: ``decision_date`` falls back to 2026-01-01, an
+    unset ``decision_type`` renders identically to omitting it, and ``stem``
+    defaults to the ``NNN-slug`` form.
+    """
+    superseded_by = "999" if status is DecisionStatus.superseded else None
+    decision = Decision(
+        date=decision_date or date(2026, 1, 1),
+        confidence=confidence,
+        status=status,
+        superseded_by=superseded_by,
+        decision_type=decision_type,
+        num=num,
+        title=title,
+        rationale=rationale,
+    )
+    if stem is None:
+        slug = title.lower().replace(" ", "-")
+        stem = f"{num:03d}-{slug}"
+    return stem, format_decision(decision)
+
+
+def _store_with(*decisions: tuple[str, str], **files: str) -> InMemoryStore:
+    """Build an ``InMemoryStore`` from ``(stem, body)`` pairs and extra files."""
+    return InMemoryStore(decisions=dict(decisions), files=dict(files))
+
+
+def make_decision(num: int, title: str, rationale: str, status: str = "active") -> Decision:
+    """Construct an in-memory ``Decision`` for the BM25 search-path tests."""
+    status_enum = DecisionStatus(status)
+    return Decision(
+        date=date(2026, 4, 7),
+        confidence=DecisionConfidence.medium,
+        status=status_enum,
+        superseded_by="999" if status_enum is DecisionStatus.superseded else None,
+        num=num,
+        title=title,
+        rationale=rationale,
+    )

--- a/packages/nauro-core/tests/operations/test_check_decision.py
+++ b/packages/nauro-core/tests/operations/test_check_decision.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from datetime import date
 
 import pytest
+from conftest import _seed_decision, _store_with
 
 from nauro_core.constants import (
     LEXICAL_RANK_CAVEAT,
@@ -18,12 +19,7 @@ from nauro_core.constants import (
     NO_DECISIONS_TO_CHECK,
     NO_RELATED_DECISIONS,
 )
-from nauro_core.decision_model import (
-    Decision,
-    DecisionConfidence,
-    DecisionStatus,
-    format_decision,
-)
+from nauro_core.decision_model import DecisionStatus
 from nauro_core.operations import (
     CheckDecisionResult,
     InMemoryStore,
@@ -31,34 +27,6 @@ from nauro_core.operations import (
 )
 from nauro_core.operations.check_decision import _assessment
 from nauro_core.operations.results import RelatedDecision
-
-
-def _seed_decision(
-    num: int,
-    title: str,
-    rationale: str,
-    *,
-    status: DecisionStatus = DecisionStatus.active,
-    decision_date: date | None = None,
-) -> tuple[str, str]:
-    """Return (file_stem, formatted_markdown) for a minimal v2 decision."""
-    superseded_by = "999" if status is DecisionStatus.superseded else None
-    decision = Decision(
-        date=decision_date or date(2026, 1, 1),
-        confidence=DecisionConfidence.medium,
-        status=status,
-        superseded_by=superseded_by,
-        num=num,
-        title=title,
-        rationale=rationale,
-    )
-    slug = title.lower().replace(" ", "-")
-    stem = f"{num:03d}-{slug}"
-    return stem, format_decision(decision)
-
-
-def _store_with(*decisions: tuple[str, str]) -> InMemoryStore:
-    return InMemoryStore(decisions=dict(decisions))
 
 
 def test_returns_result_type() -> None:

--- a/packages/nauro-core/tests/operations/test_get_decision.py
+++ b/packages/nauro-core/tests/operations/test_get_decision.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 from datetime import date
 
+from conftest import _seed_decision, _store_with
+
 from nauro_core.decision_model import (
     Decision,
     DecisionConfidence,
@@ -23,35 +25,6 @@ from nauro_core.operations import (
     get_decision,
 )
 from nauro_core.operations.get_decision import _LEDE_MAX_CHARS
-
-
-def _seed_decision(
-    num: int,
-    title: str,
-    rationale: str,
-    *,
-    status: DecisionStatus = DecisionStatus.active,
-    stem: str | None = None,
-) -> tuple[str, str]:
-    """Return (file_stem, formatted_markdown) for a minimal v2 decision."""
-    superseded_by = "999" if status is DecisionStatus.superseded else None
-    decision = Decision(
-        date=date(2026, 1, 1),
-        confidence=DecisionConfidence.medium,
-        status=status,
-        superseded_by=superseded_by,
-        num=num,
-        title=title,
-        rationale=rationale,
-    )
-    if stem is None:
-        slug = title.lower().replace(" ", "-")
-        stem = f"{num:03d}-{slug}"
-    return stem, format_decision(decision)
-
-
-def _store_with(*decisions: tuple[str, str]) -> InMemoryStore:
-    return InMemoryStore(decisions=dict(decisions))
 
 
 def test_returns_result_type() -> None:

--- a/packages/nauro-core/tests/operations/test_list_decisions.py
+++ b/packages/nauro-core/tests/operations/test_list_decisions.py
@@ -7,14 +7,12 @@ each transport's own suite.
 
 from __future__ import annotations
 
-from datetime import date
+from conftest import _seed_decision, _store_with
 
 from nauro_core.decision_model import (
-    Decision,
     DecisionConfidence,
     DecisionStatus,
     DecisionType,
-    format_decision,
 )
 from nauro_core.operations import (
     DecisionSummary,
@@ -22,39 +20,6 @@ from nauro_core.operations import (
     ListDecisionsResult,
     list_decisions,
 )
-
-
-def _seed_decision(
-    num: int,
-    title: str,
-    rationale: str = "Test rationale.",
-    *,
-    status: DecisionStatus = DecisionStatus.active,
-    confidence: DecisionConfidence = DecisionConfidence.medium,
-    decision_type: DecisionType | None = None,
-    decision_date: date | None = date(2026, 1, 1),
-    stem: str | None = None,
-) -> tuple[str, str]:
-    """Return (file_stem, formatted_markdown) for a minimal v2 decision."""
-    superseded_by = "999" if status is DecisionStatus.superseded else None
-    decision = Decision(
-        date=decision_date,
-        confidence=confidence,
-        status=status,
-        superseded_by=superseded_by,
-        decision_type=decision_type,
-        num=num,
-        title=title,
-        rationale=rationale,
-    )
-    if stem is None:
-        slug = title.lower().replace(" ", "-")
-        stem = f"{num:03d}-{slug}"
-    return stem, format_decision(decision)
-
-
-def _store_with(*decisions: tuple[str, str]) -> InMemoryStore:
-    return InMemoryStore(decisions=dict(decisions))
 
 
 def test_returns_result_type() -> None:

--- a/packages/nauro-core/tests/operations/test_operations_propose_decision.py
+++ b/packages/nauro-core/tests/operations/test_operations_propose_decision.py
@@ -20,50 +20,19 @@ from datetime import date
 from pathlib import Path
 
 import pytest
+from conftest import _seed_decision, _store_with
 from pydantic import ValidationError
 
 from nauro_core.constants import OPEN_QUESTIONS_MD
 from nauro_core.decision_model import (
     DECISION_TYPE_VALUES,
-    Decision,
-    DecisionConfidence,
     DecisionStatus,
-    format_decision,
 )
 from nauro_core.operations import (
     InMemoryStore,
     ProposeDecisionResult,
     propose_decision,
 )
-
-
-def _seed_decision(
-    num: int,
-    title: str,
-    rationale: str,
-    *,
-    status: DecisionStatus = DecisionStatus.active,
-    decision_date: date | None = None,
-) -> tuple[str, str]:
-    """Return ``(file_stem, formatted_markdown)`` for a parseable v2 decision."""
-    superseded_by = "999" if status is DecisionStatus.superseded else None
-    decision = Decision(
-        date=decision_date or date(2026, 1, 1),
-        confidence=DecisionConfidence.medium,
-        status=status,
-        superseded_by=superseded_by,
-        num=num,
-        title=title,
-        rationale=rationale,
-    )
-    slug = title.lower().replace(" ", "-")
-    stem = f"{num:03d}-{slug}"
-    return stem, format_decision(decision)
-
-
-def _store_with(*decisions: tuple[str, str], **files: str) -> InMemoryStore:
-    return InMemoryStore(decisions=dict(decisions), files=dict(files))
-
 
 # ── Result type / shape ─────────────────────────────────────────────────
 

--- a/packages/nauro-core/tests/operations/test_search_decisions.py
+++ b/packages/nauro-core/tests/operations/test_search_decisions.py
@@ -7,50 +7,14 @@ in each transport's own suite.
 
 from __future__ import annotations
 
-from datetime import date
+from conftest import _seed_decision, _store_with
 
-from nauro_core.decision_model import (
-    Decision,
-    DecisionConfidence,
-    DecisionStatus,
-    format_decision,
-)
+from nauro_core.decision_model import DecisionStatus
 from nauro_core.operations import (
     InMemoryStore,
     SearchDecisionsResult,
     search_decisions,
 )
-
-
-def _seed_decision(
-    num: int,
-    title: str,
-    rationale: str = "Test rationale.",
-    *,
-    status: DecisionStatus = DecisionStatus.active,
-    confidence: DecisionConfidence = DecisionConfidence.medium,
-    decision_date: date | None = date(2026, 1, 1),
-    stem: str | None = None,
-) -> tuple[str, str]:
-    """Return (file_stem, formatted_markdown) for a minimal v2 decision."""
-    superseded_by = "999" if status is DecisionStatus.superseded else None
-    decision = Decision(
-        date=decision_date,
-        confidence=confidence,
-        status=status,
-        superseded_by=superseded_by,
-        num=num,
-        title=title,
-        rationale=rationale,
-    )
-    if stem is None:
-        slug = title.lower().replace(" ", "-")
-        stem = f"{num:03d}-{slug}"
-    return stem, format_decision(decision)
-
-
-def _store_with(*decisions: tuple[str, str]) -> InMemoryStore:
-    return InMemoryStore(decisions=dict(decisions))
 
 
 def test_returns_result_type() -> None:

--- a/packages/nauro-core/tests/test_embeddings_union.py
+++ b/packages/nauro-core/tests/test_embeddings_union.py
@@ -13,46 +13,30 @@ against a deterministic encoder.
 
 from __future__ import annotations
 
-from datetime import date
-
 import numpy as np
 import pytest
+from conftest import make_decision
 
 import nauro_core.embeddings as embeddings_mod
-from nauro_core.decision_model import Decision, DecisionConfidence, DecisionStatus
 from nauro_core.search import bm25_retrieve, union_retrieve
 
-
-def _make_decision(num: int, title: str, rationale: str, status: str = "active") -> Decision:
-    status_enum = DecisionStatus(status)
-    return Decision(
-        date=date(2026, 4, 7),
-        confidence=DecisionConfidence.medium,
-        status=status_enum,
-        superseded_by="999" if status_enum is DecisionStatus.superseded else None,
-        num=num,
-        title=title,
-        rationale=rationale,
-    )
-
-
 DECISIONS = [
-    _make_decision(
+    make_decision(
         1,
         "Use Auth0 for authentication",
         "Auth0 provides OAuth 2.1 support and handles JWT validation.",
     ),
-    _make_decision(
+    make_decision(
         2,
         "Chose Memcached for session state",
         "Memcached is simpler than Redis for session caching.",
     ),
-    _make_decision(
+    make_decision(
         3,
         "Use FastAPI for MCP server",
         "FastAPI provides async support and automatic OpenAPI docs.",
     ),
-    _make_decision(
+    make_decision(
         4,
         "Identity tokens carry no email scope",
         "Login tokens omit the email claim, so users land without a profile.",

--- a/packages/nauro-core/tests/test_search.py
+++ b/packages/nauro-core/tests/test_search.py
@@ -2,6 +2,8 @@
 
 from datetime import date
 
+from conftest import make_decision
+
 from nauro_core.decision_model import (
     Decision,
     DecisionConfidence,
@@ -10,39 +12,25 @@ from nauro_core.decision_model import (
 )
 from nauro_core.search import bm25_retrieve, bm25_search
 
-
-def _make_decision(num: int, title: str, rationale: str, status: str = "active") -> Decision:
-    status_enum = DecisionStatus(status)
-    return Decision(
-        date=date(2026, 4, 7),
-        confidence=DecisionConfidence.medium,
-        status=status_enum,
-        superseded_by="999" if status_enum is DecisionStatus.superseded else None,
-        num=num,
-        title=title,
-        rationale=rationale,
-    )
-
-
 DECISIONS = [
-    _make_decision(
+    make_decision(
         1,
         "Use Auth0 for authentication",
         "Auth0 provides OAuth 2.1 support and handles JWT validation.",
     ),
-    _make_decision(
+    make_decision(
         2,
         "Chose Memcached for session state",
         "Memcached is simpler than Redis for session caching. "
         "Lower operational overhead and sufficient for our read-heavy workload.",
     ),
-    _make_decision(
+    make_decision(
         3,
         "Use FastAPI for MCP server",
         "FastAPI provides async support and automatic OpenAPI docs. "
         "Works well with Mangum for Lambda deployment.",
     ),
-    _make_decision(
+    make_decision(
         4,
         "Defer multi-repo sync to v2",
         "Current scope is single-repo. Multi-repo sync adds complexity "

--- a/packages/nauro/tests/cross_surface/conftest.py
+++ b/packages/nauro/tests/cross_surface/conftest.py
@@ -1,0 +1,83 @@
+"""Shared helpers for the cross-surface parity tests.
+
+Each ``test_*_cross_surface.py`` module seeds a ``FilesystemStore`` and a
+``mcp_server.store.cloud_store.CloudStore`` with identical content, then asserts
+the operations kernel returns byte-identical envelopes across both surfaces. The
+seeding helpers and the envelope-dump shim were duplicated per module; they live
+here now, parameterized by each module's ``SEED_DECISIONS`` / ``SEED_FILES`` maps.
+
+``CloudStore`` ships in the private mcp-server repo and is absent from the public
+monorepo CI, where every cross-surface module skips at load via
+``pytest.importorskip``. This conftest is imported unconditionally by pytest, so
+it must stay importable without ``mcp_server`` / ``boto3`` / ``moto``: the
+CloudStore import is deferred into ``seed_cloud_store`` and runs only once a test
+that cleared its own importorskip gate calls it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from nauro.store.filesystem_store import FilesystemStore
+from tests.conftest import (
+    CROSS_SURFACE_BUCKET,
+    CROSS_SURFACE_PROJECT_ID,
+    CROSS_SURFACE_USER_ID,
+    cloud_prefix,
+)
+
+
+def seed_filesystem_store(
+    root: Path,
+    decisions: dict[str, str] | None = None,
+    files: dict[str, str] | None = None,
+) -> FilesystemStore:
+    """Seed a ``FilesystemStore`` rooted at ``root`` with the given content.
+
+    Plain ``files`` land at the store root; ``decisions`` land under
+    ``decisions/<stem>.md``. Either mapping may be omitted.
+    """
+    root.mkdir(parents=True, exist_ok=True)
+    for name, body in (files or {}).items():
+        target = root / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(body)
+    if decisions:
+        decisions_dir = root / "decisions"
+        decisions_dir.mkdir(parents=True, exist_ok=True)
+        for stem, body in decisions.items():
+            (decisions_dir / f"{stem}.md").write_text(body)
+    return FilesystemStore(root)
+
+
+def seed_cloud_store(
+    s3_client,
+    decisions: dict[str, str] | None = None,
+    files: dict[str, str] | None = None,
+):
+    """Seed a moto-backed ``CloudStore`` with the given content.
+
+    ``CloudStore`` is imported lazily so this module stays importable when the
+    private mcp-server package is absent.
+    """
+    from mcp_server.store.cloud_store import CloudStore
+
+    prefix = cloud_prefix(CROSS_SURFACE_USER_ID, CROSS_SURFACE_PROJECT_ID)
+    for name, body in (files or {}).items():
+        s3_client.put_object(
+            Bucket=CROSS_SURFACE_BUCKET,
+            Key=f"{prefix}/{name}",
+            Body=body.encode(),
+        )
+    for stem, body in (decisions or {}).items():
+        s3_client.put_object(
+            Bucket=CROSS_SURFACE_BUCKET,
+            Key=f"{prefix}/decisions/{stem}.md",
+            Body=body.encode(),
+        )
+    return CloudStore(user_id=CROSS_SURFACE_USER_ID, project_id=CROSS_SURFACE_PROJECT_ID)
+
+
+def _dump(result) -> dict:
+    """Return the JSON-mode model dump with ``None`` fields dropped."""
+    return result.model_dump(mode="json", exclude_none=True)

--- a/packages/nauro/tests/cross_surface/test_check_decision_cross_surface.py
+++ b/packages/nauro/tests/cross_surface/test_check_decision_cross_surface.py
@@ -18,8 +18,6 @@ locally to catch local-vs-cloud envelope drift before merge.
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
 
 cloud_store_module = pytest.importorskip(
@@ -39,13 +37,10 @@ from nauro_core.decision_model import (  # noqa: E402
 )
 from nauro_core.operations import check_decision  # noqa: E402
 
-from nauro.store.filesystem_store import FilesystemStore  # noqa: E402
-from tests.conftest import (  # noqa: E402
-    CROSS_SURFACE_BUCKET,
-    CROSS_SURFACE_PROJECT_ID,
-    CROSS_SURFACE_USER_ID,
-    cloud_prefix,
-    moto_s3_bucket,
+from tests.conftest import moto_s3_bucket  # noqa: E402
+from tests.cross_surface.conftest import (  # noqa: E402
+    seed_cloud_store,
+    seed_filesystem_store,
 )
 
 CloudStore = cloud_store_module.CloudStore
@@ -86,25 +81,6 @@ SEED_DECISIONS: dict[str, str] = {
 }
 
 
-def _seed_filesystem_store(root: Path) -> FilesystemStore:
-    decisions_dir = root / "decisions"
-    decisions_dir.mkdir(parents=True, exist_ok=True)
-    for stem, body in SEED_DECISIONS.items():
-        (decisions_dir / f"{stem}.md").write_text(body)
-    return FilesystemStore(root)
-
-
-def _seed_cloud_store(s3_client) -> CloudStore:
-    prefix = cloud_prefix(CROSS_SURFACE_USER_ID, CROSS_SURFACE_PROJECT_ID)
-    for stem, body in SEED_DECISIONS.items():
-        s3_client.put_object(
-            Bucket=CROSS_SURFACE_BUCKET,
-            Key=f"{prefix}/decisions/{stem}.md",
-            Body=body.encode(),
-        )
-    return CloudStore(user_id=CROSS_SURFACE_USER_ID, project_id=CROSS_SURFACE_PROJECT_ID)
-
-
 @pytest.fixture
 def both_stores(tmp_path, monkeypatch):
     """Yield a (FilesystemStore, CloudStore) pair seeded with identical decisions.
@@ -113,8 +89,8 @@ def both_stores(tmp_path, monkeypatch):
     the test never touches AWS.
     """
     with moto_s3_bucket(monkeypatch) as s3_client:
-        fs_store = _seed_filesystem_store(tmp_path)
-        cloud = _seed_cloud_store(s3_client)
+        fs_store = seed_filesystem_store(tmp_path, SEED_DECISIONS)
+        cloud = seed_cloud_store(s3_client, SEED_DECISIONS)
         yield fs_store, cloud
 
 

--- a/packages/nauro/tests/cross_surface/test_flag_question_cross_surface.py
+++ b/packages/nauro/tests/cross_surface/test_flag_question_cross_surface.py
@@ -39,6 +39,7 @@ from tests.conftest import (  # noqa: E402
     CROSS_SURFACE_USER_ID,
     moto_s3_bucket,
 )
+from tests.cross_surface.conftest import _dump  # noqa: E402
 
 CloudStore = cloud_store_module.CloudStore
 
@@ -55,10 +56,6 @@ def both_stores(tmp_path, monkeypatch):
 def _seed_open_questions(fs_store: FilesystemStore, cloud: CloudStore, body: str) -> None:
     fs_store.write_file(OPEN_QUESTIONS_MD, body)
     cloud.write_file(OPEN_QUESTIONS_MD, body)
-
-
-def _dump(result) -> dict:
-    return result.model_dump(mode="json", exclude_none=True)
 
 
 def test_empty_store_matches_across_stores(both_stores):

--- a/packages/nauro/tests/cross_surface/test_get_context_cross_surface.py
+++ b/packages/nauro/tests/cross_surface/test_get_context_cross_surface.py
@@ -18,8 +18,6 @@ local-vs-cloud envelope drift before merge.
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
 
 cloud_store_module = pytest.importorskip(
@@ -39,13 +37,10 @@ from nauro_core.decision_model import (  # noqa: E402
 )
 from nauro_core.operations import get_context  # noqa: E402
 
-from nauro.store.filesystem_store import FilesystemStore  # noqa: E402
-from tests.conftest import (  # noqa: E402
-    CROSS_SURFACE_BUCKET,
-    CROSS_SURFACE_PROJECT_ID,
-    CROSS_SURFACE_USER_ID,
-    cloud_prefix,
-    moto_s3_bucket,
+from tests.conftest import moto_s3_bucket  # noqa: E402
+from tests.cross_surface.conftest import (  # noqa: E402
+    seed_cloud_store,
+    seed_filesystem_store,
 )
 
 CloudStore = cloud_store_module.CloudStore
@@ -84,40 +79,12 @@ SEED_DECISIONS: dict[str, str] = {
 }
 
 
-def _seed_filesystem_store(root: Path) -> FilesystemStore:
-    root.mkdir(parents=True, exist_ok=True)
-    for name, body in SEED_FILES.items():
-        (root / name).write_text(body)
-    decisions_dir = root / "decisions"
-    decisions_dir.mkdir(parents=True, exist_ok=True)
-    for stem, body in SEED_DECISIONS.items():
-        (decisions_dir / f"{stem}.md").write_text(body)
-    return FilesystemStore(root)
-
-
-def _seed_cloud_store(s3_client) -> CloudStore:
-    prefix = cloud_prefix(CROSS_SURFACE_USER_ID, CROSS_SURFACE_PROJECT_ID)
-    for name, body in SEED_FILES.items():
-        s3_client.put_object(
-            Bucket=CROSS_SURFACE_BUCKET,
-            Key=f"{prefix}/{name}",
-            Body=body.encode(),
-        )
-    for stem, body in SEED_DECISIONS.items():
-        s3_client.put_object(
-            Bucket=CROSS_SURFACE_BUCKET,
-            Key=f"{prefix}/decisions/{stem}.md",
-            Body=body.encode(),
-        )
-    return CloudStore(user_id=CROSS_SURFACE_USER_ID, project_id=CROSS_SURFACE_PROJECT_ID)
-
-
 @pytest.fixture
 def both_stores(tmp_path, monkeypatch):
     """Yield a (FilesystemStore, CloudStore) pair seeded with identical content."""
     with moto_s3_bucket(monkeypatch) as s3_client:
-        fs_store = _seed_filesystem_store(tmp_path)
-        cloud = _seed_cloud_store(s3_client)
+        fs_store = seed_filesystem_store(tmp_path, SEED_DECISIONS, SEED_FILES)
+        cloud = seed_cloud_store(s3_client, SEED_DECISIONS, SEED_FILES)
         yield fs_store, cloud
 
 

--- a/packages/nauro/tests/cross_surface/test_get_decision_cross_surface.py
+++ b/packages/nauro/tests/cross_surface/test_get_decision_cross_surface.py
@@ -18,8 +18,6 @@ locally to catch local-vs-cloud envelope drift before merge.
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
 
 cloud_store_module = pytest.importorskip(
@@ -39,13 +37,10 @@ from nauro_core.decision_model import (  # noqa: E402
 )
 from nauro_core.operations import get_decision  # noqa: E402
 
-from nauro.store.filesystem_store import FilesystemStore  # noqa: E402
-from tests.conftest import (  # noqa: E402
-    CROSS_SURFACE_BUCKET,
-    CROSS_SURFACE_PROJECT_ID,
-    CROSS_SURFACE_USER_ID,
-    cloud_prefix,
-    moto_s3_bucket,
+from tests.conftest import moto_s3_bucket  # noqa: E402
+from tests.cross_surface.conftest import (  # noqa: E402
+    seed_cloud_store,
+    seed_filesystem_store,
 )
 
 CloudStore = cloud_store_module.CloudStore
@@ -73,25 +68,6 @@ SEED_DECISIONS: dict[str, str] = {
 }
 
 
-def _seed_filesystem_store(root: Path) -> FilesystemStore:
-    decisions_dir = root / "decisions"
-    decisions_dir.mkdir(parents=True, exist_ok=True)
-    for stem, body in SEED_DECISIONS.items():
-        (decisions_dir / f"{stem}.md").write_text(body)
-    return FilesystemStore(root)
-
-
-def _seed_cloud_store(s3_client) -> CloudStore:
-    prefix = cloud_prefix(CROSS_SURFACE_USER_ID, CROSS_SURFACE_PROJECT_ID)
-    for stem, body in SEED_DECISIONS.items():
-        s3_client.put_object(
-            Bucket=CROSS_SURFACE_BUCKET,
-            Key=f"{prefix}/decisions/{stem}.md",
-            Body=body.encode(),
-        )
-    return CloudStore(user_id=CROSS_SURFACE_USER_ID, project_id=CROSS_SURFACE_PROJECT_ID)
-
-
 @pytest.fixture
 def both_stores(tmp_path, monkeypatch):
     """Yield a (FilesystemStore, CloudStore) pair seeded with identical decisions.
@@ -100,8 +76,8 @@ def both_stores(tmp_path, monkeypatch):
     the test never touches AWS.
     """
     with moto_s3_bucket(monkeypatch) as s3_client:
-        fs_store = _seed_filesystem_store(tmp_path)
-        cloud = _seed_cloud_store(s3_client)
+        fs_store = seed_filesystem_store(tmp_path, SEED_DECISIONS)
+        cloud = seed_cloud_store(s3_client, SEED_DECISIONS)
         yield fs_store, cloud
 
 

--- a/packages/nauro/tests/cross_surface/test_get_raw_file_cross_surface.py
+++ b/packages/nauro/tests/cross_surface/test_get_raw_file_cross_surface.py
@@ -18,8 +18,6 @@ it locally to catch local-vs-cloud envelope drift before merge.
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
 
 cloud_store_module = pytest.importorskip(
@@ -33,13 +31,10 @@ pytest.importorskip("moto", reason="moto needed for in-memory S3.")
 # installed; ruff E402 does not apply here.
 from nauro_core.operations import get_raw_file  # noqa: E402
 
-from nauro.store.filesystem_store import FilesystemStore  # noqa: E402
-from tests.conftest import (  # noqa: E402
-    CROSS_SURFACE_BUCKET,
-    CROSS_SURFACE_PROJECT_ID,
-    CROSS_SURFACE_USER_ID,
-    cloud_prefix,
-    moto_s3_bucket,
+from tests.conftest import moto_s3_bucket  # noqa: E402
+from tests.cross_surface.conftest import (  # noqa: E402
+    seed_cloud_store,
+    seed_filesystem_store,
 )
 
 CloudStore = cloud_store_module.CloudStore
@@ -55,26 +50,6 @@ SEED_FILES: dict[str, str] = {
 }
 
 
-def _seed_filesystem_store(root: Path) -> FilesystemStore:
-    root.mkdir(parents=True, exist_ok=True)
-    for path, body in SEED_FILES.items():
-        target = root / path
-        target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_text(body)
-    return FilesystemStore(root)
-
-
-def _seed_cloud_store(s3_client) -> CloudStore:
-    prefix = cloud_prefix(CROSS_SURFACE_USER_ID, CROSS_SURFACE_PROJECT_ID)
-    for path, body in SEED_FILES.items():
-        s3_client.put_object(
-            Bucket=CROSS_SURFACE_BUCKET,
-            Key=f"{prefix}/{path}",
-            Body=body.encode(),
-        )
-    return CloudStore(user_id=CROSS_SURFACE_USER_ID, project_id=CROSS_SURFACE_PROJECT_ID)
-
-
 @pytest.fixture
 def both_stores(tmp_path, monkeypatch):
     """Yield a (FilesystemStore, CloudStore) pair seeded with identical files.
@@ -83,8 +58,8 @@ def both_stores(tmp_path, monkeypatch):
     the test never touches AWS.
     """
     with moto_s3_bucket(monkeypatch) as s3_client:
-        fs_store = _seed_filesystem_store(tmp_path)
-        cloud = _seed_cloud_store(s3_client)
+        fs_store = seed_filesystem_store(tmp_path, files=SEED_FILES)
+        cloud = seed_cloud_store(s3_client, files=SEED_FILES)
         yield fs_store, cloud
 
 

--- a/packages/nauro/tests/cross_surface/test_list_decisions_cross_surface.py
+++ b/packages/nauro/tests/cross_surface/test_list_decisions_cross_surface.py
@@ -18,8 +18,6 @@ it locally to catch local-vs-cloud envelope drift before merge.
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
 
 cloud_store_module = pytest.importorskip(
@@ -39,13 +37,10 @@ from nauro_core.decision_model import (  # noqa: E402
 )
 from nauro_core.operations import list_decisions  # noqa: E402
 
-from nauro.store.filesystem_store import FilesystemStore  # noqa: E402
-from tests.conftest import (  # noqa: E402
-    CROSS_SURFACE_BUCKET,
-    CROSS_SURFACE_PROJECT_ID,
-    CROSS_SURFACE_USER_ID,
-    cloud_prefix,
-    moto_s3_bucket,
+from tests.conftest import moto_s3_bucket  # noqa: E402
+from tests.cross_surface.conftest import (  # noqa: E402
+    seed_cloud_store,
+    seed_filesystem_store,
 )
 
 CloudStore = cloud_store_module.CloudStore
@@ -81,25 +76,6 @@ SEED_DECISIONS: dict[str, str] = {
 }
 
 
-def _seed_filesystem_store(root: Path) -> FilesystemStore:
-    decisions_dir = root / "decisions"
-    decisions_dir.mkdir(parents=True, exist_ok=True)
-    for stem, body in SEED_DECISIONS.items():
-        (decisions_dir / f"{stem}.md").write_text(body)
-    return FilesystemStore(root)
-
-
-def _seed_cloud_store(s3_client) -> CloudStore:
-    prefix = cloud_prefix(CROSS_SURFACE_USER_ID, CROSS_SURFACE_PROJECT_ID)
-    for stem, body in SEED_DECISIONS.items():
-        s3_client.put_object(
-            Bucket=CROSS_SURFACE_BUCKET,
-            Key=f"{prefix}/decisions/{stem}.md",
-            Body=body.encode(),
-        )
-    return CloudStore(user_id=CROSS_SURFACE_USER_ID, project_id=CROSS_SURFACE_PROJECT_ID)
-
-
 @pytest.fixture
 def both_stores(tmp_path, monkeypatch):
     """Yield a (FilesystemStore, CloudStore) pair seeded with identical decisions.
@@ -108,8 +84,8 @@ def both_stores(tmp_path, monkeypatch):
     the test never touches AWS.
     """
     with moto_s3_bucket(monkeypatch) as s3_client:
-        fs_store = _seed_filesystem_store(tmp_path)
-        cloud = _seed_cloud_store(s3_client)
+        fs_store = seed_filesystem_store(tmp_path, SEED_DECISIONS)
+        cloud = seed_cloud_store(s3_client, SEED_DECISIONS)
         yield fs_store, cloud
 
 

--- a/packages/nauro/tests/cross_surface/test_propose_decision_cross_surface.py
+++ b/packages/nauro/tests/cross_surface/test_propose_decision_cross_surface.py
@@ -46,6 +46,7 @@ from tests.conftest import (  # noqa: E402
     CROSS_SURFACE_USER_ID,
     moto_s3_bucket,
 )
+from tests.cross_surface.conftest import _dump  # noqa: E402
 
 CloudStore = cloud_store_module.CloudStore
 
@@ -71,10 +72,6 @@ def _seed_postgres(store) -> str:
             "confidence": "high",
         },
     )
-
-
-def _dump(result) -> dict:
-    return result.model_dump(mode="json", exclude_none=True)
 
 
 def test_add_confirmed_decision_file_byte_identical(both_stores):

--- a/packages/nauro/tests/cross_surface/test_search_decisions_cross_surface.py
+++ b/packages/nauro/tests/cross_surface/test_search_decisions_cross_surface.py
@@ -18,8 +18,6 @@ it locally to catch local-vs-cloud envelope drift before merge.
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
 
 cloud_store_module = pytest.importorskip(
@@ -39,13 +37,10 @@ from nauro_core.decision_model import (  # noqa: E402
 )
 from nauro_core.operations import search_decisions  # noqa: E402
 
-from nauro.store.filesystem_store import FilesystemStore  # noqa: E402
-from tests.conftest import (  # noqa: E402
-    CROSS_SURFACE_BUCKET,
-    CROSS_SURFACE_PROJECT_ID,
-    CROSS_SURFACE_USER_ID,
-    cloud_prefix,
-    moto_s3_bucket,
+from tests.conftest import moto_s3_bucket  # noqa: E402
+from tests.cross_surface.conftest import (  # noqa: E402
+    seed_cloud_store,
+    seed_filesystem_store,
 )
 
 CloudStore = cloud_store_module.CloudStore
@@ -78,25 +73,6 @@ SEED_DECISIONS: dict[str, str] = {
 }
 
 
-def _seed_filesystem_store(root: Path) -> FilesystemStore:
-    decisions_dir = root / "decisions"
-    decisions_dir.mkdir(parents=True, exist_ok=True)
-    for stem, body in SEED_DECISIONS.items():
-        (decisions_dir / f"{stem}.md").write_text(body)
-    return FilesystemStore(root)
-
-
-def _seed_cloud_store(s3_client) -> CloudStore:
-    prefix = cloud_prefix(CROSS_SURFACE_USER_ID, CROSS_SURFACE_PROJECT_ID)
-    for stem, body in SEED_DECISIONS.items():
-        s3_client.put_object(
-            Bucket=CROSS_SURFACE_BUCKET,
-            Key=f"{prefix}/decisions/{stem}.md",
-            Body=body.encode(),
-        )
-    return CloudStore(user_id=CROSS_SURFACE_USER_ID, project_id=CROSS_SURFACE_PROJECT_ID)
-
-
 @pytest.fixture
 def both_stores(tmp_path, monkeypatch):
     """Yield a (FilesystemStore, CloudStore) pair seeded with identical decisions.
@@ -105,8 +81,8 @@ def both_stores(tmp_path, monkeypatch):
     the test never touches AWS.
     """
     with moto_s3_bucket(monkeypatch) as s3_client:
-        fs_store = _seed_filesystem_store(tmp_path)
-        cloud = _seed_cloud_store(s3_client)
+        fs_store = seed_filesystem_store(tmp_path, SEED_DECISIONS)
+        cloud = seed_cloud_store(s3_client, SEED_DECISIONS)
         yield fs_store, cloud
 
 

--- a/packages/nauro/tests/cross_surface/test_update_state_cross_surface.py
+++ b/packages/nauro/tests/cross_surface/test_update_state_cross_surface.py
@@ -44,6 +44,7 @@ from tests.conftest import (  # noqa: E402
     CROSS_SURFACE_USER_ID,
     moto_s3_bucket,
 )
+from tests.cross_surface.conftest import _dump  # noqa: E402
 
 CloudStore = cloud_store_module.CloudStore
 
@@ -65,10 +66,6 @@ def _seed_current(fs_store: FilesystemStore, cloud: CloudStore, body: str) -> No
 def _seed_legacy(fs_store: FilesystemStore, cloud: CloudStore, body: str) -> None:
     fs_store.write_file(STATE_LEGACY_FILENAME, body)
     cloud.write_file(STATE_LEGACY_FILENAME, body)
-
-
-def _dump(result) -> dict:
-    return result.model_dump(mode="json", exclude_none=True)
 
 
 def test_noop_branch_matches_across_stores(both_stores):


### PR DESCRIPTION
## Why

Several test suites carried copy-pasted seeding helpers. The nauro-core
operations-kernel tests each defined a near-identical `_seed_decision` /
`_store_with` pair; the BM25 search and embeddings tests duplicated a
`_make_decision` builder byte for byte; and the cross-surface parity tests
repeated `_seed_filesystem_store` / `_seed_cloud_store` and a `_dump` shim
across modules. Each copy is a place drift can creep in.

## What changed

The duplicated helpers move into conftests as supersets whose defaults
preserve every call site's produced store shape and seeded content, so no
test's observable behavior changes.

nauro-core: a new `tests/conftest.py` hosts the union `_seed_decision`,
`_store_with`, and `make_decision`. The five operations tests plus
`test_search` and `test_embeddings_union` now import them.

nauro: a new `tests/cross_surface/conftest.py` holds parameterized
`seed_filesystem_store` / `seed_cloud_store` (taking the per-module decision
and file maps) and the shared `_dump`. The six seeded modules and the three
`_dump` users import from it. CloudStore is imported lazily inside
`seed_cloud_store` so the conftest loads even when the private mcp_server
package is absent, and every cross-surface module keeps its own importorskip
gate. `cross_surface/__init__.py` makes the conftest importable as
`tests.cross_surface.conftest`.

The deliberately divergent seeders are left in place: the full-store fixtures
in `test_get_context` and `test_decision_lookup`, and the decision builders
in `test_context` and `test_graph`, each produce materially different content
and do not fold into a shared superset.

## Test plan

- nauro-core: 1073 collected, all pass.
- nauro: 1634 passed, 10 skipped (cross-surface, mcp_server absent). The
  public-contract freeze gate (test_public_contract_matches_snapshot) and the
  bench smoke test (test_bench_smoke_on_demo_store) both pass.
- `pytest packages/nauro/tests/cross_surface/` with mcp_server absent: 10
  skipped, 0 errors.
- Combined collection unchanged at 2707 (no conftest module collision).
- `ruff check packages/` and `ruff format --check packages/` clean.
