### PR TITLE
Consolidate duplicated test fixture scaffolding into conftest helpers

### DIFF
--- a/packages/nauro/tests/conftest.py
+++ b/packages/nauro/tests/conftest.py
@@ -6,11 +6,16 @@ import json
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 import pytest
+from nauro_core.decision_model import Decision, format_decision
 
+from nauro.constants import REPO_CONFIG_MODE_LOCAL
 from nauro.mcp.tools import tool_get_context
+from nauro.store.registry import register_project_v2
+from nauro.store.repo_config import save_repo_config
+from nauro.templates.scaffolds import scaffold_project_store
 
 # Magic UUID4 used by every telemetry test that seeds a consented config.
 # Centralized so a rotation in one file can't drift away from the rest.
@@ -39,6 +44,63 @@ def read_project_context(store_path: Path, level: int = 0) -> str:
     caring about the surrounding envelope fields.
     """
     return tool_get_context(store_path, level)["content"]
+
+
+class V2Repo(NamedTuple):
+    """Result of the canonical v2 registration body shared by parity fixtures."""
+
+    pid: str
+    store_path: Path
+    repo: Path
+
+
+def register_v2_repo(
+    tmp_path: Path,
+    name: str,
+    *,
+    monkeypatch: pytest.MonkeyPatch | None = None,
+    mode: str = REPO_CONFIG_MODE_LOCAL,
+    seed: str = "scaffold",
+    save_config: bool = True,
+    chdir: bool = True,
+) -> V2Repo:
+    """Run the canonical v2 registration body the local parity fixtures share.
+
+    Creates ``tmp_path/"repo"``, registers a v2 project, optionally writes the
+    per-repo config, seeds the store, and chdirs into the repo. ``seed`` selects
+    the store body: ``"scaffold"`` runs ``scaffold_project_store``, ``"mkdir"``
+    just creates the store directory, and ``"none"`` leaves it to the caller
+    (which then writes its own content, e.g. via ``seed_decisions_into`` or a
+    demo project). ``monkeypatch`` is required only when ``chdir`` is True.
+
+    This body is v2-only by design: v1 ``register_project`` seeders are left
+    untouched and must never be routed through here.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    pid, store_path = register_project_v2(name, [repo], mode=mode)
+    if save_config:
+        save_repo_config(repo, {"mode": mode, "id": pid, "name": name})
+    if seed == "scaffold":
+        scaffold_project_store(name, store_path)
+    elif seed == "mkdir":
+        store_path.mkdir(parents=True, exist_ok=True)
+    if chdir:
+        monkeypatch.chdir(repo)
+    return V2Repo(pid, store_path, repo)
+
+
+def seed_decisions_into(store_path: Path, *decisions: Decision) -> None:
+    """Write decision files into ``store_path/"decisions"`` (creating the dir).
+
+    Filenames follow the ``NNN-slugified-title.md`` rule the context and search
+    parity fixtures both relied on.
+    """
+    decisions_dir = store_path / "decisions"
+    decisions_dir.mkdir(parents=True, exist_ok=True)
+    for d in decisions:
+        slug = d.title.lower().replace(" ", "-")
+        (decisions_dir / f"{d.num:03d}-{slug}.md").write_text(format_decision(d))
 
 
 @contextmanager

--- a/packages/nauro/tests/conftest.py
+++ b/packages/nauro/tests/conftest.py
@@ -11,8 +11,9 @@ from typing import Any, NamedTuple
 import pytest
 from nauro_core.decision_model import Decision, format_decision
 
-from nauro.constants import REPO_CONFIG_MODE_LOCAL
+from nauro.constants import DECISIONS_DIR, REPO_CONFIG_MODE_LOCAL
 from nauro.mcp.tools import tool_get_context
+from nauro.store.config import save_config
 from nauro.store.registry import register_project_v2
 from nauro.store.repo_config import save_repo_config
 from nauro.templates.scaffolds import scaffold_project_store
@@ -103,6 +104,15 @@ def seed_decisions_into(store_path: Path, *decisions: Decision) -> None:
         (decisions_dir / f"{d.num:03d}-{slug}.md").write_text(format_decision(d))
 
 
+def write_decision_file(store: Path, num: int, slug: str, content: str) -> None:
+    """Write raw ``content`` to ``store/decisions/NNN-slug.md`` verbatim.
+
+    Unlike ``seed_decisions_into``, this takes an already-rendered body so tests
+    can seed malformed or hand-crafted decision files.
+    """
+    (store / DECISIONS_DIR / f"{num:03d}-{slug}.md").write_text(content, encoding="utf-8")
+
+
 @contextmanager
 def moto_s3_bucket(monkeypatch, *, bucket: str = CROSS_SURFACE_BUCKET) -> Iterator[Any]:
     """Stand up a moto-mocked S3 bucket and point ``NAURO_S3_BUCKET`` at it.
@@ -144,25 +154,91 @@ class FakeClient:
         self.events.append({"event": event, "distinct_id": distinct_id, "properties": properties})
 
 
-def seed_consented_config(home: Path, *, enabled: bool) -> str:
+def seed_consented_config(
+    home: Path,
+    *,
+    enabled: bool,
+    consent_version: int = 1,
+    consented_at: str = "2026-04-30T00:00:00Z",
+    anonymous_id: str = TEST_ANONYMOUS_ID,
+) -> str:
     """Write a fully consented telemetry config under ``home/config.json``.
 
     Returns the seeded anonymous_id so tests that need to compare against the
-    persisted value have a single source of truth.
+    persisted value have a single source of truth. The consent fields default
+    to the shared fixture values; callers override them to exercise stale or
+    custom-identity configs.
     """
     (home / "config.json").write_text(
         json.dumps(
             {
                 "telemetry": {
-                    "anonymous_id": TEST_ANONYMOUS_ID,
+                    "anonymous_id": anonymous_id,
                     "enabled": enabled,
-                    "consent_version": 1,
-                    "consented_at": "2026-04-30T00:00:00Z",
+                    "consent_version": consent_version,
+                    "consented_at": consented_at,
                 }
             }
         )
     )
-    return TEST_ANONYMOUS_ID
+    return anonymous_id
+
+
+def seed_auth_config(
+    *,
+    variant: str = "local",
+    access_token: str | None = None,
+    refresh_token: str = "refresh_orig",
+    sub: str = "auth0|test",
+) -> None:
+    """Write an ``auth`` block via ``save_config`` in one of two seeder shapes.
+
+    ``variant="local"`` mirrors ``nauro auth login`` output (keys
+    ``access_token, sub``); ``variant="sync"`` adds a refresh token and orders
+    keys ``sub, access_token, refresh_token`` the way the sync suites seeded it.
+    Writing through ``save_config`` keeps the serialized config byte-identical to
+    the hand-written seeders. ``access_token`` defaults to ``"test-token"`` for
+    the local shape and ``"tok_orig"`` for the sync shape.
+    """
+    if access_token is None:
+        access_token = "test-token" if variant == "local" else "tok_orig"
+    if variant == "local":
+        auth = {"access_token": access_token, "sub": sub}
+    else:
+        auth = {"sub": sub, "access_token": access_token, "refresh_token": refresh_token}
+    save_config({"auth": auth})
+
+
+def make_nauro_home(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    dirname: str = ".nauro",
+    delenv_telemetry: bool = False,
+    chdir_repo: bool = False,
+) -> Path:
+    """Create a temp NAURO_HOME under ``tmp_path`` and point the env var at it.
+
+    ``delenv_telemetry`` clears a stray ``NAURO_TELEMETRY`` override; ``chdir_repo``
+    additionally creates a sibling ``repo`` dir and chdirs into it. Both mirror
+    the per-file extras the telemetry and event suites layered on the shared body.
+    """
+    home = tmp_path / dirname
+    home.mkdir()
+    monkeypatch.setenv("NAURO_HOME", str(home))
+    if delenv_telemetry:
+        monkeypatch.delenv("NAURO_TELEMETRY", raising=False)
+    if chdir_repo:
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        monkeypatch.chdir(repo)
+    return home
+
+
+@pytest.fixture
+def nauro_home(tmp_path, monkeypatch):
+    """Canonical temp NAURO_HOME at ``tmp_path/".nauro"`` for telemetry tests."""
+    return make_nauro_home(tmp_path, monkeypatch)
 
 
 @pytest.fixture

--- a/packages/nauro/tests/test_attach.py
+++ b/packages/nauro/tests/test_attach.py
@@ -15,9 +15,9 @@ from typer.testing import CliRunner
 
 from nauro.cli.main import app
 from nauro.store import registry
-from nauro.store.config import save_config
 from nauro.store.repo_config import load_repo_config
 from nauro.sync import cloud_projects
+from tests.conftest import seed_auth_config
 
 runner = CliRunner()
 
@@ -25,7 +25,7 @@ EXAMPLE_PID = "01KQ6AZGNA0B3QBF67NBXP3S45"
 
 
 def _seed_token(monkeypatch, tmp_path):
-    save_config({"auth": {"access_token": "test-token", "sub": "auth0|test"}})
+    seed_auth_config()
 
 
 def _list_response(projects):

--- a/packages/nauro/tests/test_auth_refresh.py
+++ b/packages/nauro/tests/test_auth_refresh.py
@@ -25,18 +25,11 @@ from nauro.cli.commands.auth import (
     with_token_refresh,
 )
 from nauro.store.config import load_config, save_config
+from tests.conftest import seed_auth_config
 
 
 def _seed_auth(refresh_token: str = "refresh_orig", access_token: str = "access_orig") -> None:
-    save_config(
-        {
-            "auth": {
-                "sub": "auth0|test",
-                "access_token": access_token,
-                "refresh_token": refresh_token,
-            }
-        }
-    )
+    seed_auth_config(variant="sync", access_token=access_token, refresh_token=refresh_token)
 
 
 def _mock_post(status_code: int = 200, payload: dict | None = None, headers: dict | None = None):

--- a/packages/nauro/tests/test_cli_command_invoked.py
+++ b/packages/nauro/tests/test_cli_command_invoked.py
@@ -8,7 +8,7 @@ import pytest
 import typer
 from typer.testing import CliRunner
 
-from tests.conftest import FakeClient, seed_consented_config
+from tests.conftest import FakeClient, make_nauro_home, seed_consented_config
 
 _EXPECTED_KEYS = {"command", "success", "duration_bucket", "nauro_version", "os"}
 _DISALLOWED_KEYS = {"args", "argv", "cwd", "env", "exit_code"}
@@ -16,13 +16,7 @@ _DISALLOWED_KEYS = {"args", "argv", "cwd", "env", "exit_code"}
 
 @pytest.fixture
 def nauro_home(tmp_path, monkeypatch):
-    home = tmp_path / "user_home"
-    home.mkdir()
-    monkeypatch.setenv("NAURO_HOME", str(home))
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    monkeypatch.chdir(repo)
-    return home
+    return make_nauro_home(tmp_path, monkeypatch, dirname="user_home", chdir_repo=True)
 
 
 def _command_events(fake: FakeClient) -> list[dict[str, Any]]:

--- a/packages/nauro/tests/test_cli_doctor.py
+++ b/packages/nauro/tests/test_cli_doctor.py
@@ -14,9 +14,9 @@ from nauro_core.decision_model import Decision, format_decision
 from typer.testing import CliRunner
 
 from nauro.cli.main import app
-from nauro.constants import DECISIONS_DIR
 from nauro.store.registry import register_project
 from nauro.templates.scaffolds import scaffold_project_store
+from tests.conftest import write_decision_file
 
 runner = CliRunner()
 
@@ -26,10 +26,6 @@ def _new_store(tmp_path: Path, name: str = "docproj") -> Path:
     store = register_project(name, [tmp_path])
     scaffold_project_store(name, store)
     return store
-
-
-def _write_decision(store: Path, num: int, slug: str, content: str) -> None:
-    (store / DECISIONS_DIR / f"{num:03d}-{slug}.md").write_text(content, encoding="utf-8")
 
 
 def _decision_md(num: int, *, supersedes: str | None = None) -> str:
@@ -54,8 +50,8 @@ def test_clean_store_exits_zero(tmp_path: Path) -> None:
 
 def test_defective_store_exits_zero_and_renders_defects(tmp_path: Path) -> None:
     store = _new_store(tmp_path)
-    _write_decision(store, 10, "broken", "this file does not parse as a decision")
-    _write_decision(store, 11, "dangling", _decision_md(11, supersedes="999"))
+    write_decision_file(store, 10, "broken", "this file does not parse as a decision")
+    write_decision_file(store, 11, "dangling", _decision_md(11, supersedes="999"))
 
     result = runner.invoke(app, ["doctor", "--project", "docproj"])
 

--- a/packages/nauro/tests/test_cli_graph.py
+++ b/packages/nauro/tests/test_cli_graph.py
@@ -22,6 +22,7 @@ from nauro.cli.main import app
 from nauro.constants import DECISIONS_DIR, OPEN_QUESTIONS_MD
 from nauro.store.registry import register_project
 from nauro.templates.scaffolds import scaffold_project_store
+from tests.conftest import write_decision_file
 
 runner = CliRunner()
 
@@ -81,10 +82,6 @@ def _decision_md(
     return format_decision(decision)
 
 
-def _write_decision(store: Path, num: int, slug: str, content: str) -> None:
-    (store / DECISIONS_DIR / f"{num:03d}-{slug}.md").write_text(content, encoding="utf-8")
-
-
 def _new_store(tmp_path, monkeypatch, name: str = "graphproj") -> Path:
     """Register and scaffold a project, chdir into its repo, return the store."""
     store = register_project(name, [tmp_path])
@@ -96,7 +93,7 @@ def _new_store(tmp_path, monkeypatch, name: str = "graphproj") -> Path:
 def _populated_store(tmp_path, monkeypatch) -> Path:
     """A store with a supersession thread, a citation, and an open question."""
     store = _new_store(tmp_path, monkeypatch)
-    _write_decision(
+    write_decision_file(
         store,
         2,
         "rest-api",
@@ -110,7 +107,7 @@ def _populated_store(tmp_path, monkeypatch) -> Path:
             body="Pairs with the pagination decision D3 for the read surface.",
         ),
     )
-    _write_decision(
+    write_decision_file(
         store,
         3,
         "offset-pagination",
@@ -123,7 +120,7 @@ def _populated_store(tmp_path, monkeypatch) -> Path:
             date="2026-03-17",
         ),
     )
-    _write_decision(
+    write_decision_file(
         store,
         4,
         "graphql-gateway",
@@ -284,7 +281,7 @@ def test_output_is_self_contained(tmp_path, monkeypatch):
     """
     store = _populated_store(tmp_path, monkeypatch)
     # Put a URL in a decision title to prove the scan tolerates inert text.
-    _write_decision(
+    write_decision_file(
         store,
         5,
         "link-in-title",
@@ -347,7 +344,7 @@ def test_default_view_is_graph_with_color_schemes(tmp_path, monkeypatch):
 def test_api_design_lane_label(tmp_path, monkeypatch):
     """The api_design lane renders as 'API design', not 'Api Design'."""
     store = _new_store(tmp_path, monkeypatch)
-    _write_decision(store, 2, "rest", _decision_md(2, "Use REST", decision_type="api_design"))
+    write_decision_file(store, 2, "rest", _decision_md(2, "Use REST", decision_type="api_design"))
 
     result = runner.invoke(app, ["graph"])
     assert result.exit_code == 0
@@ -431,7 +428,9 @@ def test_browser_open_failure_prints_hint(tmp_path, monkeypatch):
 def test_malformed_decision_is_skipped_with_warning(tmp_path, monkeypatch):
     store = _populated_store(tmp_path, monkeypatch)
     # A file that the strict parser rejects (missing required frontmatter).
-    _write_decision(store, 9, "broken", "---\nnot: valid frontmatter for a decision\n---\n\nbody\n")
+    write_decision_file(
+        store, 9, "broken", "---\nnot: valid frontmatter for a decision\n---\n\nbody\n"
+    )
 
     result = runner.invoke(app, ["graph"])
     assert result.exit_code == 0
@@ -501,7 +500,7 @@ def test_long_title_wraps_in_full_in_browse_view(tmp_path, monkeypatch):
     """
     store = _new_store(tmp_path, monkeypatch)
     long_title = "Adopt the layered ingestion pipeline " + "x" * 400
-    _write_decision(store, 2, "long-title", _decision_md(2, long_title))
+    write_decision_file(store, 2, "long-title", _decision_md(2, long_title))
 
     result = runner.invoke(app, ["graph"])
     assert result.exit_code == 0
@@ -530,7 +529,7 @@ def test_script_breakout_in_title_question_and_body_is_escaped(tmp_path, monkeyp
     store = _new_store(tmp_path, monkeypatch)
     hostile_title = 'Title </script><script>alert("x")</script> & <b>bold</b> "quote\''
     hostile_body = 'Body </script><script>alert("b")</script> & <i>i</i> "q\' angle <z>'
-    _write_decision(store, 2, "hostile", _decision_md(2, hostile_title, body=hostile_body))
+    write_decision_file(store, 2, "hostile", _decision_md(2, hostile_title, body=hostile_body))
     (store / OPEN_QUESTIONS_MD).write_text(
         '# Open Questions\n\n- [Q1] Body </script><img src=x onerror="y"> & "quote\'.\n',
         encoding="utf-8",
@@ -567,14 +566,14 @@ def _fan_in_store(tmp_path, monkeypatch, retired: int = 4) -> Path:
     """
     store = _new_store(tmp_path, monkeypatch)
     targets = list(range(2, 2 + retired))
-    _write_decision(
+    write_decision_file(
         store,
         10,
         "consolidate",
         _decision_md(10, "Consolidate the cluster", supersedes=str(targets[0]), date="2026-04-10"),
     )
     for i, num in enumerate(targets):
-        _write_decision(
+        write_decision_file(
             store,
             num,
             f"retired-{num}",
@@ -668,7 +667,7 @@ def test_question_references_link_both_directions(tmp_path, monkeypatch):
     badge linking back to the questions section.
     """
     store = _new_store(tmp_path, monkeypatch)
-    _write_decision(store, 2, "rest", _decision_md(2, "Use REST", date="2026-03-15"))
+    write_decision_file(store, 2, "rest", _decision_md(2, "Use REST", date="2026-03-15"))
     (store / OPEN_QUESTIONS_MD).write_text(
         "# Open Questions\n\n- [Q1] Does the REST surface in D2 need versioning.\n",
         encoding="utf-8",
@@ -699,9 +698,9 @@ def test_timeline_marks_positioned_by_date_not_index(tmp_path, monkeypatch):
     gutter and the latest at the right edge of the plot.
     """
     store = _new_store(tmp_path, monkeypatch)
-    _write_decision(store, 2, "early", _decision_md(2, "Early one", date="2026-03-01"))
-    _write_decision(store, 3, "early-two", _decision_md(3, "Early two", date="2026-03-02"))
-    _write_decision(store, 4, "late", _decision_md(4, "Late one", date="2026-06-01"))
+    write_decision_file(store, 2, "early", _decision_md(2, "Early one", date="2026-03-01"))
+    write_decision_file(store, 3, "early-two", _decision_md(3, "Early two", date="2026-03-02"))
+    write_decision_file(store, 4, "late", _decision_md(4, "Late one", date="2026-06-01"))
 
     result = runner.invoke(app, ["graph"])
     assert result.exit_code == 0
@@ -739,7 +738,7 @@ def test_bodies_default_on_and_no_include_bodies_redacts(tmp_path, monkeypatch):
     """
     store = _new_store(tmp_path, monkeypatch)
     body = "The full rationale text that should appear by default."
-    _write_decision(store, 2, "with-body", _decision_md(2, "A decision", body=body))
+    write_decision_file(store, 2, "with-body", _decision_md(2, "A decision", body=body))
 
     # Default: body embedded and shown as structured detail.
     result = runner.invoke(app, ["graph", "--no-open"])
@@ -772,7 +771,7 @@ def test_graph_has_one_node_element_per_payload_node(tmp_path, monkeypatch):
     """Every payload node renders exactly one Graph circle, keyed by number."""
     store = _populated_store(tmp_path, monkeypatch)
     # Add an isolated decision so the disc path is exercised alongside threads.
-    _write_decision(store, 7, "isolated", _decision_md(7, "Standalone", date="2026-03-20"))
+    write_decision_file(store, 7, "isolated", _decision_md(7, "Standalone", date="2026-03-20"))
 
     result = runner.invoke(app, ["graph"])
     assert result.exit_code == 0
@@ -847,7 +846,7 @@ def test_no_relation_chip_dead_ends(tmp_path, monkeypatch):
     store = _populated_store(tmp_path, monkeypatch)
     # D5 cites D2 and D3 in its body but has no supersession edge: an isolated
     # citation source whose chips must still resolve.
-    _write_decision(
+    write_decision_file(
         store,
         5,
         "isolated-citer",
@@ -884,14 +883,14 @@ def test_timeline_same_day_same_lane_marks_stack(tmp_path, monkeypatch):
     """Three decisions on the same date in the same lane get three distinct y."""
     store = _new_store(tmp_path, monkeypatch)
     for num in (2, 3, 4):
-        _write_decision(
+        write_decision_file(
             store,
             num,
             f"sameday-{num}",
             _decision_md(num, f"Same day {num}", decision_type="architecture", date="2026-04-10"),
         )
     # A second date so there is a real span and the lane is not degenerate.
-    _write_decision(store, 5, "later", _decision_md(5, "Later", date="2026-05-10"))
+    write_decision_file(store, 5, "later", _decision_md(5, "Later", date="2026-05-10"))
 
     result = runner.invoke(app, ["graph"])
     assert result.exit_code == 0
@@ -919,9 +918,9 @@ def test_timeline_uses_exact_calendar_dates(tmp_path, monkeypatch):
     so lane stacking does not perturb the x positions under test.
     """
     store = _new_store(tmp_path, monkeypatch)
-    _write_decision(store, 2, "feb28", _decision_md(2, "Feb 28", date="2024-02-28"))
-    _write_decision(store, 3, "feb29", _decision_md(3, "Leap day", date="2024-02-29"))
-    _write_decision(store, 4, "mar01", _decision_md(4, "Mar 1", date="2024-03-01"))
+    write_decision_file(store, 2, "feb28", _decision_md(2, "Feb 28", date="2024-02-28"))
+    write_decision_file(store, 3, "feb29", _decision_md(3, "Leap day", date="2024-02-29"))
+    write_decision_file(store, 4, "mar01", _decision_md(4, "Mar 1", date="2024-03-01"))
 
     result = runner.invoke(app, ["graph"])
     assert result.exit_code == 0
@@ -1015,7 +1014,7 @@ def test_question_refs_route_through_jump_to_node(tmp_path, monkeypatch):
     handler routes through the same Graph-first helper the relation chips use.
     """
     store = _new_store(tmp_path, monkeypatch)
-    _write_decision(store, 2, "rest", _decision_md(2, "Use REST", date="2026-03-15"))
+    write_decision_file(store, 2, "rest", _decision_md(2, "Use REST", date="2026-03-15"))
     (store / OPEN_QUESTIONS_MD).write_text(
         "# Open Questions\n\n- [Q1] Does the REST surface in D2 need versioning.\n",
         encoding="utf-8",
@@ -1073,21 +1072,21 @@ def test_story_strip_renders_deterministic_metrics(tmp_path, monkeypatch):
     # D4 already retires D2 and D3 (consolidation defined at the 2+ threshold).
     # Add an active decision cited in another body so the anchor is defined, and
     # a question that references a decision so the hotspot is defined.
-    _write_decision(
+    write_decision_file(
         store,
         7,
         "anchor",
         _decision_md(7, "Anchored choice", date="2026-03-21"),
     )
-    _write_decision(
+    write_decision_file(
         store,
         8,
         "citer",
         _decision_md(8, "Cites the anchor", date="2026-03-22", body="Builds on D7."),
     )
     # Two decisions on one date so the recent-activity cluster is defined (2+).
-    _write_decision(store, 9, "busy-a", _decision_md(9, "Busy day A", date="2026-03-25"))
-    _write_decision(store, 10, "busy-b", _decision_md(10, "Busy day B", date="2026-03-25"))
+    write_decision_file(store, 9, "busy-a", _decision_md(9, "Busy day A", date="2026-03-25"))
+    write_decision_file(store, 10, "busy-b", _decision_md(10, "Busy day B", date="2026-03-25"))
     (store / OPEN_QUESTIONS_MD).write_text(
         "# Open Questions\n\n- [Q1] Should the gateway in D4 expose subscriptions.\n",
         encoding="utf-8",
@@ -1135,7 +1134,7 @@ def test_story_strip_omits_undefined_metrics(tmp_path, monkeypatch):
     nothing rather than empty buttons.
     """
     store = _new_store(tmp_path, monkeypatch)
-    _write_decision(store, 2, "lonely", _decision_md(2, "A single decision", date="2026-03-15"))
+    write_decision_file(store, 2, "lonely", _decision_md(2, "A single decision", date="2026-03-15"))
 
     result = runner.invoke(app, ["graph"])
     assert result.exit_code == 0
@@ -1152,7 +1151,7 @@ def test_timeline_single_day_shows_one_tick(tmp_path, monkeypatch):
     """
     store = _new_store(tmp_path, monkeypatch)
     for num in (2, 3):
-        _write_decision(
+        write_decision_file(
             store,
             num,
             f"sameday-{num}",
@@ -1208,8 +1207,8 @@ def test_insight_labels_pinned_to_insight_nodes_only(tmp_path, monkeypatch):
     store = _populated_store(tmp_path, monkeypatch)
     # Add an anchor (cited active decision) and a question hotspot so multiple
     # insight targets exist alongside the consolidation D4.
-    _write_decision(store, 7, "anchor", _decision_md(7, "Anchor", date="2026-03-21"))
-    _write_decision(
+    write_decision_file(store, 7, "anchor", _decision_md(7, "Anchor", date="2026-03-21"))
+    write_decision_file(
         store, 8, "citer", _decision_md(8, "Cites anchor", date="2026-03-22", body="On D7.")
     )
 
@@ -1574,8 +1573,8 @@ def test_story_chip_selection_state_and_aria(tmp_path, monkeypatch):
     """
     store = _populated_store(tmp_path, monkeypatch)
     # Two decisions on one date so the date (busiest-day) chip is defined.
-    _write_decision(store, 9, "busy-a", _decision_md(9, "Busy day A", date="2026-03-25"))
-    _write_decision(store, 10, "busy-b", _decision_md(10, "Busy day B", date="2026-03-25"))
+    write_decision_file(store, 9, "busy-a", _decision_md(9, "Busy day A", date="2026-03-25"))
+    write_decision_file(store, 10, "busy-b", _decision_md(10, "Busy day B", date="2026-03-25"))
 
     result = runner.invoke(app, ["graph"])
     assert result.exit_code == 0
@@ -1607,7 +1606,7 @@ def test_category_labels_still_rendered(tmp_path, monkeypatch):
     store = _new_store(tmp_path, monkeypatch)
     # Several isolated decisions in one category form a labelled disc.
     for num in range(2, 7):
-        _write_decision(
+        write_decision_file(
             store,
             num,
             f"iso-{num}",

--- a/packages/nauro/tests/test_cloud_projects.py
+++ b/packages/nauro/tests/test_cloud_projects.py
@@ -15,11 +15,12 @@ from nauro.sync.cloud_projects import (
     create_project,
     list_projects,
 )
+from tests.conftest import seed_auth_config
 
 
 def _seed_token(monkeypatch, tmp_path, token: str = "test-token") -> None:
     """Write a config.json with an OAuth access token, mirroring `nauro auth login`."""
-    save_config({"auth": {"access_token": token, "sub": "auth0|test"}})
+    seed_auth_config(access_token=token)
 
 
 def _stub_request(handler):

--- a/packages/nauro/tests/test_consent_prompt.py
+++ b/packages/nauro/tests/test_consent_prompt.py
@@ -5,15 +5,7 @@ from __future__ import annotations
 import json
 from datetime import datetime
 
-import pytest
-
-
-@pytest.fixture
-def nauro_home(tmp_path, monkeypatch):
-    home = tmp_path / ".nauro"
-    home.mkdir()
-    monkeypatch.setenv("NAURO_HOME", str(home))
-    return home
+from tests.conftest import seed_consented_config
 
 
 def _set_tty(monkeypatch, value: bool) -> None:
@@ -33,18 +25,7 @@ def _read_telemetry(home) -> dict:
 
 
 def _seed(home, *, enabled, consent_version) -> None:
-    (home / "config.json").write_text(
-        json.dumps(
-            {
-                "telemetry": {
-                    "anonymous_id": "11111111-1111-4111-8111-111111111111",
-                    "enabled": enabled,
-                    "consent_version": consent_version,
-                    "consented_at": "2026-04-30T00:00:00Z",
-                }
-            }
-        )
-    )
+    seed_consented_config(home, enabled=enabled, consent_version=consent_version)
 
 
 def test_non_tty_does_not_fire_prompt(nauro_home, monkeypatch):

--- a/packages/nauro/tests/test_diff_since_last_session_parity.py
+++ b/packages/nauro/tests/test_diff_since_last_session_parity.py
@@ -32,6 +32,7 @@ from nauro.store.repo_config import save_repo_config
 from nauro.store.snapshot import capture_snapshot, load_snapshot
 from nauro.templates.scaffolds import scaffold_project_store
 from tests._writer_compat import append_decision
+from tests.conftest import register_v2_repo
 
 
 def _backdate_snapshot(store_path: Path, version: int, days_ago: int) -> None:
@@ -44,16 +45,11 @@ def _backdate_snapshot(store_path: Path, version: int, days_ago: int) -> None:
 @pytest.fixture
 def seeded_repo(tmp_path, monkeypatch):
     """Register a project, scaffold the store, capture two snapshots."""
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    pid, store_path = register_project_v2("parity-diff", [repo], mode=REPO_CONFIG_MODE_LOCAL)
-    save_repo_config(repo, {"mode": REPO_CONFIG_MODE_LOCAL, "id": pid, "name": "parity-diff"})
-    scaffold_project_store("parity-diff", store_path)
-    capture_snapshot(store_path, trigger="initial")
-    append_decision(store_path, "Adopt Postgres", rationale="ACID semantics matter.")
-    capture_snapshot(store_path, trigger="with-decision")
-    monkeypatch.chdir(repo)
-    return pid, store_path
+    result = register_v2_repo(tmp_path, "parity-diff", monkeypatch=monkeypatch)
+    capture_snapshot(result.store_path, trigger="initial")
+    append_decision(result.store_path, "Adopt Postgres", rationale="ACID semantics matter.")
+    capture_snapshot(result.store_path, trigger="with-decision")
+    return result.pid, result.store_path
 
 
 @pytest.fixture

--- a/packages/nauro/tests/test_flag_question_parity.py
+++ b/packages/nauro/tests/test_flag_question_parity.py
@@ -26,13 +26,10 @@ import pytest
 from typer.testing import CliRunner
 
 from nauro.cli.main import app as cli_app
-from nauro.constants import REPO_CONFIG_MODE_LOCAL
 from nauro.mcp import tools as mcp_tools
 from nauro.mcp.stdio_server import flag_question as stdio_flag_question
 from nauro.mcp.tools import tool_flag_question
-from nauro.store.registry import register_project_v2
-from nauro.store.repo_config import save_repo_config
-from nauro.templates.scaffolds import scaffold_project_store
+from tests.conftest import register_v2_repo
 
 
 @pytest.fixture(autouse=True)
@@ -44,20 +41,8 @@ def _no_push(monkeypatch):
 @pytest.fixture
 def seeded_repo(tmp_path, monkeypatch):
     """Register a project, scaffold the store, and chdir into the repo."""
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    pid, store_path = register_project_v2(
-        "parity-flag-question",
-        [repo],
-        mode=REPO_CONFIG_MODE_LOCAL,
-    )
-    save_repo_config(
-        repo,
-        {"mode": REPO_CONFIG_MODE_LOCAL, "id": pid, "name": "parity-flag-question"},
-    )
-    scaffold_project_store("parity-flag-question", store_path)
-    monkeypatch.chdir(repo)
-    return pid, store_path
+    result = register_v2_repo(tmp_path, "parity-flag-question", monkeypatch=monkeypatch)
+    return result.pid, result.store_path
 
 
 @pytest.fixture

--- a/packages/nauro/tests/test_get_context_parity.py
+++ b/packages/nauro/tests/test_get_context_parity.py
@@ -37,29 +37,19 @@ from nauro.mcp.stdio_server import get_context as stdio_get_context
 from nauro.mcp.tools import tool_get_context
 from nauro.store.registry import register_project_v2
 from nauro.store.repo_config import save_repo_config
-
-
-def _seed(store_path: Path, *decisions: Decision) -> None:
-    decisions_dir = store_path / "decisions"
-    decisions_dir.mkdir(parents=True, exist_ok=True)
-    for d in decisions:
-        slug = d.title.lower().replace(" ", "-")
-        (decisions_dir / f"{d.num:03d}-{slug}.md").write_text(format_decision(d))
+from tests.conftest import register_v2_repo, seed_decisions_into
 
 
 @pytest.fixture
 def seeded_repo(tmp_path, monkeypatch):
     """Seed a project with two decisions plus the canonical store files."""
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    pid, store_path = register_project_v2("parity-context", [repo], mode=REPO_CONFIG_MODE_LOCAL)
-    save_repo_config(repo, {"mode": REPO_CONFIG_MODE_LOCAL, "id": pid, "name": "parity-context"})
-    store_path.mkdir(parents=True, exist_ok=True)
+    result = register_v2_repo(tmp_path, "parity-context", monkeypatch=monkeypatch, seed="mkdir")
+    store_path = result.store_path
     (store_path / "project.md").write_text("# Project\n\nGoal: ship the thing.\n")
     (store_path / "state_current.md").write_text("# Current State\n\n- Shipped Postgres adoption\n")
     (store_path / "stack.md").write_text("# Stack\n- **Python 3.11** — primary language\n")
     (store_path / "open-questions.md").write_text("# Open Questions\n- [Q1] Should we add Redis?\n")
-    _seed(
+    seed_decisions_into(
         store_path,
         Decision(
             date=date(2026, 1, 1),
@@ -78,8 +68,7 @@ def seeded_repo(tmp_path, monkeypatch):
             rationale="FastAPI plus Mangum is the Lambda deployment combination.",
         ),
     )
-    monkeypatch.chdir(repo)
-    return pid, store_path
+    return result.pid, store_path
 
 
 @pytest.fixture

--- a/packages/nauro/tests/test_get_decision_parity.py
+++ b/packages/nauro/tests/test_get_decision_parity.py
@@ -24,12 +24,10 @@ from pathlib import Path
 import pytest
 from nauro_core.renderers import RENDERERS
 
-from nauro.constants import REPO_CONFIG_MODE_LOCAL
 from nauro.demo import create_demo_project
 from nauro.mcp.stdio_server import get_decision as stdio_get_decision
 from nauro.mcp.tools import tool_get_decision
-from nauro.store.registry import register_project_v2
-from nauro.store.repo_config import save_repo_config
+from tests.conftest import register_v2_repo
 
 EXISTING_NUMBER = 4
 MISSING_NUMBER = 999
@@ -38,13 +36,9 @@ MISSING_NUMBER = 999
 @pytest.fixture
 def demo_repo(tmp_path, monkeypatch):
     """Seed a demo project + chdir into the repo so cwd resolution wins."""
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    pid, store_path = register_project_v2("parity-project", [repo], mode=REPO_CONFIG_MODE_LOCAL)
-    save_repo_config(repo, {"mode": REPO_CONFIG_MODE_LOCAL, "id": pid, "name": "parity-project"})
-    create_demo_project(store_path)
-    monkeypatch.chdir(repo)
-    return pid, store_path
+    result = register_v2_repo(tmp_path, "parity-project", monkeypatch=monkeypatch, seed="none")
+    create_demo_project(result.store_path)
+    return result.pid, result.store_path
 
 
 def _stdio_rendered(pid: str, number: int, mode: str = "full") -> str:

--- a/packages/nauro/tests/test_hook_command.py
+++ b/packages/nauro/tests/test_hook_command.py
@@ -18,7 +18,7 @@ from typer.testing import CliRunner
 from nauro.cli.commands import hook
 from nauro.cli.main import app
 from nauro.store.registry import register_project, register_project_v2
-from nauro.templates.scaffolds import scaffold_project_store
+from tests.conftest import register_v2_repo
 
 runner = CliRunner()
 
@@ -90,18 +90,15 @@ _DISTRACTOR_TOPICS = [
 
 def _make_project(tmp_path: Path) -> tuple[Path, Path]:
     """Register a project rooted at a fresh repo dir; return (repo, store_path)."""
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    _pid, store_path = register_project_v2("hookproj", [repo])
-    scaffold_project_store("hookproj", store_path)
+    result = register_v2_repo(tmp_path, "hookproj", save_config=False, chdir=False)
     for i, topic in enumerate(_DISTRACTOR_TOPICS, start=100):
         _write_decision(
-            store_path,
+            result.store_path,
             num=i,
             title=f"approach for the {topic} subsystem",
             rationale=f"the {topic} subsystem uses a dedicated module with isolated state",
         )
-    return repo, store_path
+    return result.repo, result.store_path
 
 
 def _invoke(payload: dict):

--- a/packages/nauro/tests/test_identity_lifecycle.py
+++ b/packages/nauro/tests/test_identity_lifecycle.py
@@ -27,7 +27,7 @@ from typing import Any
 
 import pytest
 
-from tests.conftest import TEST_ANONYMOUS_ID
+from tests.conftest import TEST_ANONYMOUS_ID, make_nauro_home, seed_consented_config
 
 _UUID4_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$")
 
@@ -52,11 +52,7 @@ class FakeClient:
 
 @pytest.fixture
 def nauro_home(tmp_path, monkeypatch):
-    home = tmp_path / ".nauro"
-    home.mkdir()
-    monkeypatch.setenv("NAURO_HOME", str(home))
-    monkeypatch.delenv("NAURO_TELEMETRY", raising=False)
-    return home
+    return make_nauro_home(tmp_path, monkeypatch, delenv_telemetry=True)
 
 
 @pytest.fixture(autouse=True)
@@ -80,19 +76,7 @@ def fake_posthog(monkeypatch):
 
 def _seed_telemetry_config(home, *, enabled: bool, anonymous_id: str | None = None) -> str:
     aid = anonymous_id or TEST_ANONYMOUS_ID
-    (home / "config.json").write_text(
-        json.dumps(
-            {
-                "telemetry": {
-                    "anonymous_id": aid,
-                    "enabled": enabled,
-                    "consent_version": 1,
-                    "consented_at": "2026-04-30T00:00:00Z",
-                }
-            }
-        )
-    )
-    return aid
+    return seed_consented_config(home, enabled=enabled, anonymous_id=aid)
 
 
 # ── 1. Login order (telemetry enabled): alias FIRST, then set ───────────────

--- a/packages/nauro/tests/test_init_cloud.py
+++ b/packages/nauro/tests/test_init_cloud.py
@@ -23,15 +23,14 @@ from nauro.store import registry
 from nauro.store.repo_config import load_repo_config
 from nauro.sync import cloud_projects
 from tests._ansi import strip_ansi
+from tests.conftest import seed_auth_config
 
 runner = CliRunner()
 
 
 def _seed_token(monkeypatch, tmp_path):
     """Make cloud_projects believe the user is authenticated."""
-    from nauro.store.config import save_config
-
-    save_config({"auth": {"access_token": "test-token", "sub": "auth0|test"}})
+    seed_auth_config()
 
 
 # ── local mode ────────────────────────────────────────────────────────────────

--- a/packages/nauro/tests/test_link_cloud.py
+++ b/packages/nauro/tests/test_link_cloud.py
@@ -25,9 +25,9 @@ from typer.testing import CliRunner
 
 from nauro.cli.main import app
 from nauro.store import registry
-from nauro.store.config import save_config
 from nauro.store.repo_config import load_repo_config, save_repo_config
 from nauro.sync import cloud_projects, remote
+from tests.conftest import seed_auth_config
 
 runner = CliRunner()
 
@@ -36,11 +36,7 @@ CLOUD_PID = "01KQ6AZGNA0B3QBF67NBXP3S45"
 
 def _seed_token(monkeypatch, tmp_path):
     monkeypatch.setenv("HOME", str(tmp_path))
-    save_config(
-        {
-            "auth": {"access_token": "test-token", "sub": "auth0|test"},
-        }
-    )
+    seed_auth_config()
 
 
 def _create_response(name: str = "linkproj", project_id: str = CLOUD_PID):

--- a/packages/nauro/tests/test_list_decisions_parity.py
+++ b/packages/nauro/tests/test_list_decisions_parity.py
@@ -38,31 +38,22 @@ from nauro.mcp.tools import tool_list_decisions
 from nauro.onboarding import WELCOME_NO_PROJECT
 from nauro.store.registry import register_project_v2
 from nauro.store.repo_config import save_repo_config
+from tests.conftest import register_v2_repo
 
 
 @pytest.fixture
 def demo_repo(tmp_path, monkeypatch):
     """Seed a demo project + chdir into the repo so cwd resolution wins."""
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    pid, store_path = register_project_v2("parity-project", [repo], mode=REPO_CONFIG_MODE_LOCAL)
-    save_repo_config(repo, {"mode": REPO_CONFIG_MODE_LOCAL, "id": pid, "name": "parity-project"})
-    create_demo_project(store_path)
-    monkeypatch.chdir(repo)
-    return pid, store_path
+    result = register_v2_repo(tmp_path, "parity-project", monkeypatch=monkeypatch, seed="none")
+    create_demo_project(result.store_path)
+    return result.pid, result.store_path
 
 
 @pytest.fixture
 def empty_repo(tmp_path, monkeypatch):
     """Register a project with an empty store (no decisions) and chdir in."""
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    pid, store_path = register_project_v2("empty-project", [repo], mode=REPO_CONFIG_MODE_LOCAL)
-    save_repo_config(repo, {"mode": REPO_CONFIG_MODE_LOCAL, "id": pid, "name": "empty-project"})
-    # Create the store path but no decisions/ subdir.
-    store_path.mkdir(parents=True, exist_ok=True)
-    monkeypatch.chdir(repo)
-    return pid, store_path
+    result = register_v2_repo(tmp_path, "empty-project", monkeypatch=monkeypatch, seed="mkdir")
+    return result.pid, result.store_path
 
 
 def _stdio_rendered(pid: str, *, limit: int = 20, include_superseded: bool = False) -> str:

--- a/packages/nauro/tests/test_mcp_tool_called.py
+++ b/packages/nauro/tests/test_mcp_tool_called.py
@@ -19,7 +19,7 @@ from typing import Any
 
 import pytest
 
-from tests.conftest import seed_consented_config
+from tests.conftest import make_nauro_home, seed_consented_config
 
 _ALLOWED_KEYS = frozenset({"tool_name", "transport", "success", "duration_bucket"})
 _DURATION_PATTERN = re.compile(r"^(<10ms|10-100ms|100ms-1s|1-10s|>10s)$")
@@ -27,11 +27,7 @@ _DURATION_PATTERN = re.compile(r"^(<10ms|10-100ms|100ms-1s|1-10s|>10s)$")
 
 @pytest.fixture
 def nauro_home(tmp_path, monkeypatch):
-    home = tmp_path / ".nauro"
-    home.mkdir()
-    monkeypatch.setenv("NAURO_HOME", str(home))
-    monkeypatch.delenv("NAURO_TELEMETRY", raising=False)
-    return home
+    return make_nauro_home(tmp_path, monkeypatch, delenv_telemetry=True)
 
 
 @pytest.fixture

--- a/packages/nauro/tests/test_project_created_event.py
+++ b/packages/nauro/tests/test_project_created_event.py
@@ -7,18 +7,12 @@ from typing import Any
 import pytest
 from typer.testing import CliRunner
 
-from tests.conftest import FakeClient, seed_consented_config
+from tests.conftest import FakeClient, make_nauro_home, seed_consented_config
 
 
 @pytest.fixture
 def nauro_home(tmp_path, monkeypatch):
-    home = tmp_path / "user_home"
-    home.mkdir()
-    monkeypatch.setenv("NAURO_HOME", str(home))
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    monkeypatch.chdir(repo)
-    return home
+    return make_nauro_home(tmp_path, monkeypatch, dirname="user_home", chdir_repo=True)
 
 
 def _events_named(fake: FakeClient, name: str) -> list[dict[str, Any]]:

--- a/packages/nauro/tests/test_propose_decision_parity.py
+++ b/packages/nauro/tests/test_propose_decision_parity.py
@@ -30,15 +30,12 @@ from pathlib import Path
 
 import pytest
 
-from nauro.constants import REPO_CONFIG_MODE_LOCAL
 from nauro.mcp import tools as mcp_tools
 from nauro.mcp.stdio_server import propose_decision as stdio_propose_decision
 from nauro.mcp.tools import tool_propose_decision
-from nauro.store.registry import register_project_v2
-from nauro.store.repo_config import save_repo_config
 from nauro.templates.agents_md_regen import warn_then_regen
-from nauro.templates.scaffolds import scaffold_project_store
 from tests._writer_compat import append_decision
+from tests.conftest import register_v2_repo
 
 
 @pytest.fixture(autouse=True)
@@ -62,20 +59,8 @@ def _no_snapshot(monkeypatch):
 @pytest.fixture
 def seeded_repo(tmp_path, monkeypatch):
     """Register a project, scaffold the store, and chdir into the repo."""
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    pid, store_path = register_project_v2(
-        "parity-propose",
-        [repo],
-        mode=REPO_CONFIG_MODE_LOCAL,
-    )
-    save_repo_config(
-        repo,
-        {"mode": REPO_CONFIG_MODE_LOCAL, "id": pid, "name": "parity-propose"},
-    )
-    scaffold_project_store("parity-propose", store_path)
-    monkeypatch.chdir(repo)
-    return pid, store_path
+    result = register_v2_repo(tmp_path, "parity-propose", monkeypatch=monkeypatch)
+    return result.pid, result.store_path
 
 
 @pytest.fixture

--- a/packages/nauro/tests/test_search_decisions_parity.py
+++ b/packages/nauro/tests/test_search_decisions_parity.py
@@ -27,7 +27,6 @@ from nauro_core.decision_model import (
     Decision,
     DecisionConfidence,
     DecisionStatus,
-    format_decision,
 )
 from nauro_core.renderers import RENDERERS
 
@@ -36,26 +35,16 @@ from nauro.mcp.stdio_server import search_decisions as stdio_search_decisions
 from nauro.mcp.tools import tool_search_decisions
 from nauro.store.registry import register_project_v2
 from nauro.store.repo_config import save_repo_config
-
-
-def _seed(store_path: Path, *decisions: Decision) -> None:
-    decisions_dir = store_path / "decisions"
-    decisions_dir.mkdir(parents=True, exist_ok=True)
-    for d in decisions:
-        slug = d.title.lower().replace(" ", "-")
-        (decisions_dir / f"{d.num:03d}-{slug}.md").write_text(format_decision(d))
+from tests.conftest import register_v2_repo, seed_decisions_into
 
 
 @pytest.fixture
 def seeded_repo(tmp_path, monkeypatch):
     """Seed a project with two decisions whose titles + rationale make
     BM25 searches deterministic for the parity assertions below."""
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    pid, store_path = register_project_v2("parity-search", [repo], mode=REPO_CONFIG_MODE_LOCAL)
-    save_repo_config(repo, {"mode": REPO_CONFIG_MODE_LOCAL, "id": pid, "name": "parity-search"})
-    _seed(
-        store_path,
+    result = register_v2_repo(tmp_path, "parity-search", monkeypatch=monkeypatch, seed="none")
+    seed_decisions_into(
+        result.store_path,
         Decision(
             date=date(2026, 1, 1),
             confidence=DecisionConfidence.high,
@@ -73,8 +62,7 @@ def seeded_repo(tmp_path, monkeypatch):
             rationale="FastAPI plus Mangum is the Lambda deployment combination.",
         ),
     )
-    monkeypatch.chdir(repo)
-    return pid, store_path
+    return result.pid, result.store_path
 
 
 @pytest.fixture

--- a/packages/nauro/tests/test_setup_hooks.py
+++ b/packages/nauro/tests/test_setup_hooks.py
@@ -21,8 +21,7 @@ from nauro.cli.commands.setup import (
     setup_all_surfaces,
 )
 from nauro.cli.main import app
-from nauro.store.registry import register_project_v2
-from nauro.templates.scaffolds import scaffold_project_store
+from tests.conftest import register_v2_repo
 
 runner = CliRunner()
 
@@ -41,11 +40,8 @@ def _nauro_entries(settings: dict) -> list[dict]:
 
 
 def _make_project(tmp_path: Path) -> tuple[Path, Path]:
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    _pid, store_path = register_project_v2("hookproj", [repo])
-    scaffold_project_store("hookproj", store_path)
-    return repo, store_path
+    result = register_v2_repo(tmp_path, "hookproj", save_config=False, chdir=False)
+    return result.repo, result.store_path
 
 
 # ── direct helper: add path ────────────────────────────────────────────────────

--- a/packages/nauro/tests/test_sync/test_hooks.py
+++ b/packages/nauro/tests/test_sync/test_hooks.py
@@ -32,6 +32,7 @@ from nauro.sync.state import (
     save_state,
 )
 from nauro.templates.scaffolds import scaffold_project_store
+from tests.conftest import seed_auth_config
 from tests.test_sync.conftest import CLOUD_PID, _scaffolded_cloud_project
 
 
@@ -44,15 +45,7 @@ def _ok(status: int, payload: dict) -> httpx.Response:
 
 
 def _seed_token() -> None:
-    save_config(
-        {
-            "auth": {
-                "sub": "auth0|test",
-                "access_token": "tok_orig",
-                "refresh_token": "refresh_orig",
-            }
-        }
-    )
+    seed_auth_config(variant="sync")
 
 
 # --- gating: silent no-op semantics ---

--- a/packages/nauro/tests/test_sync/test_pull.py
+++ b/packages/nauro/tests/test_sync/test_pull.py
@@ -17,7 +17,6 @@ from unittest.mock import patch
 import httpx
 import pytest
 
-from nauro.store.config import save_config
 from nauro.store.registry import register_project
 from nauro.sync.merge import UnionMergeError
 from nauro.sync.pull import _renumber_decision_if_collision, run_pull
@@ -29,6 +28,7 @@ from nauro.sync.state import (
     save_state,
 )
 from nauro.templates.scaffolds import scaffold_project_store
+from tests.conftest import seed_auth_config
 from tests.test_sync.conftest import CLOUD_PID, _scaffolded_cloud_project
 
 
@@ -41,15 +41,7 @@ def _ok(status: int, payload: dict) -> httpx.Response:
 
 
 def _seed_token() -> None:
-    save_config(
-        {
-            "auth": {
-                "sub": "auth0|test",
-                "access_token": "tok_orig",
-                "refresh_token": "refresh_orig",
-            }
-        }
-    )
+    seed_auth_config(variant="sync")
 
 
 def _manifest(files, next_cursor=None) -> httpx.Response:

--- a/packages/nauro/tests/test_sync/test_sync_command.py
+++ b/packages/nauro/tests/test_sync/test_sync_command.py
@@ -9,6 +9,7 @@ from typer.testing import CliRunner
 from nauro.cli.main import app
 from nauro.store.registry import register_project
 from nauro.templates.scaffolds import scaffold_project_store
+from tests.conftest import seed_auth_config
 from tests.test_sync.conftest import _scaffolded_cloud_project
 
 runner = CliRunner()
@@ -270,18 +271,8 @@ class TestSyncPullSurfacesAndMerges:
     def _seed_cloud_auth(name: str, tmp_path: Path):
         import json as _json
 
-        from nauro.store.config import save_config
-
         store = _scaffolded_cloud_project(name, tmp_path)
-        save_config(
-            {
-                "auth": {
-                    "sub": "auth0|test",
-                    "access_token": "tok_orig",
-                    "refresh_token": "refresh_orig",
-                }
-            }
-        )
+        seed_auth_config(variant="sync")
         return store, _json
 
     @staticmethod

--- a/packages/nauro/tests/test_sync/test_sync_presign.py
+++ b/packages/nauro/tests/test_sync/test_sync_presign.py
@@ -30,6 +30,7 @@ from nauro.sync.state import (
     load_state,
     save_state,
 )
+from tests.conftest import seed_auth_config
 from tests.test_sync.conftest import CLOUD_PID, _scaffolded_cloud_project
 
 
@@ -42,15 +43,7 @@ def _ok(status: int, payload: dict) -> httpx.Response:
 
 
 def _seed_token(access_token: str = "tok_orig", refresh_token: str = "refresh_orig") -> None:
-    save_config(
-        {
-            "auth": {
-                "sub": "auth0|test",
-                "access_token": access_token,
-                "refresh_token": refresh_token,
-            }
-        }
-    )
+    seed_auth_config(variant="sync", access_token=access_token, refresh_token=refresh_token)
 
 
 # --- mode detection ---

--- a/packages/nauro/tests/test_sync_completed_event.py
+++ b/packages/nauro/tests/test_sync_completed_event.py
@@ -16,7 +16,7 @@ from typer.testing import CliRunner
 
 from nauro.store.registry import register_project
 from nauro.templates.scaffolds import scaffold_project_store
-from tests.conftest import FakeClient, seed_consented_config
+from tests.conftest import FakeClient, make_nauro_home, seed_consented_config
 
 _SYNC_COMPLETED_KEYS = frozenset({"snapshot_count", "duration_bucket", "bytes_bucket"})
 _DURATION_PATTERN = re.compile(r"^(<10ms|10-100ms|100ms-1s|1-10s|>10s)$")
@@ -27,11 +27,7 @@ runner = CliRunner()
 
 @pytest.fixture
 def nauro_home(tmp_path, monkeypatch):
-    home = tmp_path / "user_home"
-    home.mkdir()
-    monkeypatch.setenv("NAURO_HOME", str(home))
-    monkeypatch.delenv("NAURO_TELEMETRY", raising=False)
-    return home
+    return make_nauro_home(tmp_path, monkeypatch, dirname="user_home", delenv_telemetry=True)
 
 
 @pytest.fixture

--- a/packages/nauro/tests/test_telemetry_config.py
+++ b/packages/nauro/tests/test_telemetry_config.py
@@ -3,16 +3,7 @@
 import json
 import uuid
 
-import pytest
-
-
-@pytest.fixture
-def nauro_home(tmp_path, monkeypatch):
-    """Set up a temporary NAURO_HOME."""
-    home = tmp_path / ".nauro"
-    home.mkdir()
-    monkeypatch.setenv("NAURO_HOME", str(home))
-    return home
+from tests.conftest import TEST_ANONYMOUS_ID
 
 
 def test_first_call_generates_anonymous_id(nauro_home):
@@ -47,7 +38,7 @@ def test_env_override_forces_disabled(nauro_home, monkeypatch):
         json.dumps(
             {
                 "telemetry": {
-                    "anonymous_id": "11111111-1111-4111-8111-111111111111",
+                    "anonymous_id": TEST_ANONYMOUS_ID,
                     "enabled": True,
                     "consent_version": 1,
                     "consented_at": "2026-04-30T00:00:00Z",
@@ -66,7 +57,7 @@ def test_env_override_forces_disabled(nauro_home, monkeypatch):
 def test_env_override_does_not_mutate_file(nauro_home, monkeypatch):
     initial = {
         "telemetry": {
-            "anonymous_id": "11111111-1111-4111-8111-111111111111",
+            "anonymous_id": TEST_ANONYMOUS_ID,
             "enabled": True,
             "consent_version": 1,
             "consented_at": "2026-04-30T00:00:00Z",

--- a/packages/nauro/tests/test_telemetry_module.py
+++ b/packages/nauro/tests/test_telemetry_module.py
@@ -13,14 +13,6 @@ import pytest
 from tests.conftest import seed_consented_config
 
 
-@pytest.fixture
-def nauro_home(tmp_path, monkeypatch):
-    home = tmp_path / ".nauro"
-    home.mkdir()
-    monkeypatch.setenv("NAURO_HOME", str(home))
-    return home
-
-
 @pytest.fixture(autouse=True)
 def _reset_client_singleton():
     """Each test gets a fresh client singleton — protects against leak across tests."""

--- a/packages/nauro/tests/test_telemetry_subcommand.py
+++ b/packages/nauro/tests/test_telemetry_subcommand.py
@@ -9,32 +9,23 @@ import uuid
 import pytest
 from typer.testing import CliRunner
 
+from tests.conftest import TEST_ANONYMOUS_ID, make_nauro_home, seed_consented_config
+
 _UUID4_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$")
 
 
 @pytest.fixture
 def nauro_home(tmp_path, monkeypatch):
-    home = tmp_path / "user_home"
-    home.mkdir()
-    monkeypatch.setenv("NAURO_HOME", str(home))
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    monkeypatch.chdir(repo)
-    return home
+    return make_nauro_home(tmp_path, monkeypatch, dirname="user_home", chdir_repo=True)
 
 
 def _seed_config(home, *, enabled, consent_version, consented_at, anonymous_id) -> None:
-    (home / "config.json").write_text(
-        json.dumps(
-            {
-                "telemetry": {
-                    "anonymous_id": anonymous_id,
-                    "enabled": enabled,
-                    "consent_version": consent_version,
-                    "consented_at": consented_at,
-                }
-            }
-        )
+    seed_consented_config(
+        home,
+        enabled=enabled,
+        consent_version=consent_version,
+        consented_at=consented_at,
+        anonymous_id=anonymous_id,
     )
 
 
@@ -60,7 +51,7 @@ def test_disable_persists_and_blocks_emit(nauro_home, telemetry_key):
         enabled=True,
         consent_version=1,
         consented_at="2026-04-30T00:00:00Z",
-        anonymous_id="11111111-1111-4111-8111-111111111111",
+        anonymous_id=TEST_ANONYMOUS_ID,
     )
 
     from nauro.cli.main import app
@@ -86,7 +77,7 @@ def test_enable_persists_and_allows_emit(nauro_home, telemetry_key, monkeypatch)
         enabled=False,
         consent_version=1,
         consented_at="2026-04-30T00:00:00Z",
-        anonymous_id="11111111-1111-4111-8111-111111111111",
+        anonymous_id=TEST_ANONYMOUS_ID,
     )
 
     from nauro.cli.main import app
@@ -156,7 +147,7 @@ def test_rotate_anonymous_id_helper_unit(nauro_home):
         enabled=True,
         consent_version=1,
         consented_at="2026-04-30T00:00:00Z",
-        anonymous_id="11111111-1111-4111-8111-111111111111",
+        anonymous_id=TEST_ANONYMOUS_ID,
     )
 
     from nauro.telemetry import _rotate_anonymous_id

--- a/packages/nauro/tests/test_update_state_parity.py
+++ b/packages/nauro/tests/test_update_state_parity.py
@@ -33,6 +33,7 @@ from nauro.mcp.tools import tool_update_state
 from nauro.store.registry import register_project_v2
 from nauro.store.repo_config import save_repo_config
 from nauro.templates.scaffolds import scaffold_project_store
+from tests.conftest import register_v2_repo
 
 
 @pytest.fixture(autouse=True)
@@ -44,20 +45,8 @@ def _no_push(monkeypatch):
 @pytest.fixture
 def seeded_repo(tmp_path, monkeypatch):
     """Register a project, scaffold the store, and chdir into the repo."""
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    pid, store_path = register_project_v2(
-        "parity-update-state",
-        [repo],
-        mode=REPO_CONFIG_MODE_LOCAL,
-    )
-    save_repo_config(
-        repo,
-        {"mode": REPO_CONFIG_MODE_LOCAL, "id": pid, "name": "parity-update-state"},
-    )
-    scaffold_project_store("parity-update-state", store_path)
-    monkeypatch.chdir(repo)
-    return pid, store_path
+    result = register_v2_repo(tmp_path, "parity-update-state", monkeypatch=monkeypatch)
+    return result.pid, result.store_path
 
 
 @pytest.fixture

--- a/packages/nauro/tests/test_write_command_autogen.py
+++ b/packages/nauro/tests/test_write_command_autogen.py
@@ -26,13 +26,10 @@ from nauro_core.constants import MAX_RATIONALE_LENGTH
 from typer.testing import CliRunner
 
 from nauro.cli.main import app
-from nauro.constants import REPO_CONFIG_MODE_LOCAL
 from nauro.mcp import tools as mcp_tools
-from nauro.store.registry import register_project_v2
-from nauro.store.repo_config import save_repo_config
-from nauro.templates.scaffolds import scaffold_project_store
 from tests._ansi import strip_ansi
 from tests._writer_compat import append_decision
+from tests.conftest import register_v2_repo
 
 runner = CliRunner()
 
@@ -58,20 +55,8 @@ def _no_snapshot(monkeypatch):
 @pytest.fixture
 def seeded_repo(tmp_path: Path, monkeypatch) -> tuple[str, Path, Path]:
     """Register a project, scaffold the store, and chdir into the repo."""
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    pid, store_path = register_project_v2(
-        "cli-write",
-        [repo],
-        mode=REPO_CONFIG_MODE_LOCAL,
-    )
-    save_repo_config(
-        repo,
-        {"mode": REPO_CONFIG_MODE_LOCAL, "id": pid, "name": "cli-write"},
-    )
-    scaffold_project_store("cli-write", store_path)
-    monkeypatch.chdir(repo)
-    return pid, store_path, repo
+    result = register_v2_repo(tmp_path, "cli-write", monkeypatch=monkeypatch)
+    return result.pid, result.store_path, result.repo
 
 
 # ── Happy paths ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Why

The nauro test suite carried the same setup boilerplate copied across many
files. The v2 project-registration body (create repo, register, save repo
config, seed store, chdir) appeared in seven parity fixtures and several
helpers, and small seeders for auth config, temp NAURO_HOME, consented
telemetry config, and raw decision files were duplicated with slight per-file
drift. That drift is silent: a magic anonymous-id was hard-coded in three
telemetry files and each auth seeder re-spelled the same JSON by hand. Lifting
the shared bodies into the tests conftest gives one place to change them.

## What changed

Two commits, staged for review:

1. Store-scaffold factory. Adds register_v2_repo and seed_decisions_into to the
   nauro tests conftest and routes the already-v2 fixtures through them: the
   seven seeded_repo parity fixtures, the demo_repo and empty_repo fixtures in
   the get_decision and list_decisions suites, and the two _make_project helpers
   in the hook and setup-hooks suites. Each fixture keeps its exact name, return
   arity, project name, seeded content, and registry mode.

2. Small seed helpers. Adds seed_auth_config (covering both the local auth-login
   shape and the sync shape with a refresh token), make_nauro_home plus a
   canonical nauro_home fixture, a generalized seed_consented_config, and
   write_decision_file. Routes the matching per-file seeders through them and
   replaces the three hard-coded telemetry anonymous-id literals with the shared
   TEST_ANONYMOUS_ID constant.

The shared helpers are v2-only. Every v1 register_project seeder is left byte
for byte untouched: the doctor and graph _new_store scaffolds, the sync-status
scaffold, the hook suite's v1-only arm, and every other v1 site. No test's
registry shape changes, and the change is tests-only with no production code
touched.

## Test plan

- nauro-core: 1073 passed.
- nauro: 1636 passed, 10 skipped (cross-surface skips unchanged).
- The collected node-id set for both suites is byte-identical before and after,
  confirming no test was added, removed, or renamed.
- ruff check and ruff format --check clean.
- test_public_contract green.

## Risk / what to review

The mandate was byte-identical behavior. Two things to sanity-check.
seed_auth_config preserves per-shape JSON key order (the local shape writes
access_token then sub; the sync shape writes sub, access_token, refresh_token)
because it writes through save_config exactly as the originals did. The migrated
fixtures now chdir before their post-registration seeding, which is inert since
all seeding targets the absolute store path rather than the working directory.

## Deferred

The cloud-store scaffold helper (the sync suite's _scaffolded_cloud_project) and
the sync-status _scaffold were left in place. The former is already a single
shared helper with no duplication to remove and uses a divergent shape (cloud
mode, no repo config, no chdir, tmp_path used directly as the repo); the latter
registers via the v1 path, which is out of scope for the v2-only factory.
