### PR TITLE
Document the code bar in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,17 @@ uv run ruff check packages/
 uv run ruff format --check packages/
 ```
 
+## Code bar
+
+Nauro holds a high code bar. These apply to every change and are enforced in review:
+
+- Parse untrusted or semi-structured input (hook configs, registry JSON, MCP payloads, tool configs) into validated models at the boundary — Pydantic is already a nauro-core dependency. Downstream logic operates on typed objects, never raw dicts.
+- `isinstance`/`.get()` chains, regex extraction of structure, and nested conditional loops are tripwires: model the data instead. Python is the wrong place for heavy looping over loosely-shaped data.
+- Functions have limited scope: one job, named for it. Reach for classes and inheritance when the domain calls for them, not by default.
+- Modules organize code accurately: shared pure logic lives in its own module (see `store/resolution.py`, `cli/_codex_hooks.py`), never as private helpers imported across command modules.
+- Errors are typed; no sentinel strings for control flow.
+- A multi-round fix cycle owes a design-coherent end state before merge: the result must read as designed, not patched.
+
 ## Conventions
 
 - No Jinja2 — f-strings and string templates only


### PR DESCRIPTION
## Why

The Codex bootstrap PR (#341) needed a structural refactor after review even though every review finding was closed and CI was green: point fixes accumulated into patchwork. The bar that refactor applied (validated models at boundaries, limited-scope functions, shared pure logic in its own module) existed only as founder judgment, so agents and reviewers had nothing to write or cite against.

## What changed

Adds a "Code bar" section to CLAUDE.md stating the standard: parse untrusted or semi-structured input into validated models (Pydantic) at the boundary instead of dict-walking; treat isinstance/.get() chains, regex structure-extraction, and nested conditional loops as tripwires; keep functions narrow; use OOP when the domain calls for it; keep shared pure logic in accurately-named modules rather than cross-command private imports; typed errors over sentinel strings; fix cycles owe a design-coherent end state before merge.

## Test plan

Docs-only change; no runtime surface. Verified the section renders correctly and the referenced modules (store/resolution.py, cli/_codex_hooks.py) exist on main.