### PR TITLE
Harden atomic_write_text against planted temps and permission loss

### DIFF
--- a/packages/nauro/src/nauro/store/_atomic.py
+++ b/packages/nauro/src/nauro/store/_atomic.py
@@ -82,9 +82,11 @@ def atomic_write_text(
         try:
             final_mode = stat.S_IMODE(path.stat().st_mode)
             creation_mode = 0o600
-        except OSError:
-            # New non-sensitive file: the umask-applied creation mode is
-            # already the final mode, no chmod needed.
+        except FileNotFoundError:
+            # No existing file: the umask-applied creation mode is already the
+            # final mode, no chmod needed. Any other stat error (permissions,
+            # not-a-directory) propagates rather than silently dropping an
+            # existing target's bits.
             final_mode = None
             creation_mode = 0o666
     fd, tmp = _open_random_tmp(path, creation_mode)

--- a/packages/nauro/src/nauro/store/_atomic.py
+++ b/packages/nauro/src/nauro/store/_atomic.py
@@ -9,8 +9,32 @@ every existing call site, and crash-durability is an explicit non-goal here.
 """
 
 import os
-import tempfile
+import secrets
+import stat
 from pathlib import Path
+
+_TMP_OPEN_FLAGS = (
+    os.O_CREAT | os.O_EXCL | os.O_WRONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_BINARY", 0)
+)
+
+
+def _open_random_tmp(path: Path, creation_mode: int) -> tuple[int, Path]:
+    """Open a randomly named ``O_CREAT|O_EXCL`` tmp sibling of ``path``.
+
+    Same shape as :func:`tempfile.mkstemp` (unguessable name, exclusive
+    creation that never follows a pre-planted symlink, umask applied to the
+    creation mode) but with the creation mode as a parameter, so a
+    non-sensitive new file can be born at the default umask mode instead of
+    ``0o600`` without touching the process-wide umask — ``os.umask`` is
+    process-global, and a read-restore dance around it races against every
+    other thread creating files.
+    """
+    while True:
+        tmp = path.parent / f".{path.name}.{secrets.token_hex(8)}.tmp"
+        try:
+            return os.open(tmp, _TMP_OPEN_FLAGS, creation_mode), tmp
+        except FileExistsError:  # pragma: no cover - 64-bit-random collision
+            continue
 
 
 def atomic_write_text(
@@ -26,35 +50,50 @@ def atomic_write_text(
         path: Destination file path.
         text: Full file contents to write.
         mode: When set, the permission bits applied to the file (e.g. ``0o600``
-            for owner-only). When None, the file keeps the default umask mode.
+            for owner-only). When None, an existing file keeps its current
+            permission bits and a new file gets the default umask mode, the
+            same bits a plain ``write_text`` would produce.
         newline: Passed through to the underlying text write. ``"\\n"`` pins LF
             line endings on every platform, so a file written on Windows is
             byte-identical to one written on POSIX (the default would translate
             ``\\n`` to ``\\r\\n`` on Windows). When None, the platform default
             applies, matching the original control-plane behavior.
 
-    When ``mode`` is given the tmp sibling is created owner-only with a random,
-    unguessable name via :func:`tempfile.mkstemp` (which opens with
-    ``O_CREAT|O_EXCL`` at mode ``0o600``). The contents are therefore never
-    momentarily world-readable, and a symlink pre-planted at a predictable
-    ``.tmp`` path cannot redirect or clobber the write — this matters for the
-    auth token, which is written at ``0o600``. The ``mode=None`` path keeps the
-    original default-umask behavior for non-sensitive control-plane JSON.
+    Every write goes through a tmp sibling with a random, unguessable name
+    opened ``O_CREAT|O_EXCL``, so a symlink pre-planted at a predictable tmp
+    path can neither redirect nor clobber the write, and the tmp file is
+    removed on any failure. When ``mode`` is given, or when an existing
+    target's bits are being preserved, the tmp is created owner-only so the
+    contents are never momentarily more readable than the final file — this
+    matters for the auth token, which is written at ``0o600``. A brand-new
+    modeless file is instead created at the default umask mode directly (the
+    kernel applies the umask at creation), matching plain ``write_text`` for
+    non-sensitive control-plane JSON without any process-global umask
+    manipulation. Guarantees are atomic-replace only: concurrent writers each
+    land a complete file (last replace wins, intermediate read-modify-write
+    updates can still be lost), and crash durability remains out of scope.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
+    final_mode: int | None
     if mode is not None:
-        fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.", suffix=".tmp")
-        tmp = Path(tmp_name)
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8", newline=newline) as handle:
-                handle.write(text)
-            if mode != 0o600:
-                os.chmod(tmp, mode)
-            os.replace(tmp, path)
-        except BaseException:
-            tmp.unlink(missing_ok=True)
-            raise
+        final_mode = mode
+        creation_mode = 0o600
     else:
-        tmp = path.with_suffix(".tmp")
-        tmp.write_text(text, encoding="utf-8", newline=newline)
+        try:
+            final_mode = stat.S_IMODE(path.stat().st_mode)
+            creation_mode = 0o600
+        except OSError:
+            # New non-sensitive file: the umask-applied creation mode is
+            # already the final mode, no chmod needed.
+            final_mode = None
+            creation_mode = 0o666
+    fd, tmp = _open_random_tmp(path, creation_mode)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline=newline) as handle:
+            handle.write(text)
+        if final_mode is not None and final_mode != 0o600:
+            os.chmod(tmp, final_mode)
         os.replace(tmp, path)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise

--- a/packages/nauro/tests/test_atomic.py
+++ b/packages/nauro/tests/test_atomic.py
@@ -1,6 +1,7 @@
 """Tests for the atomic text-write primitive in ``nauro.store._atomic``."""
 
 import threading
+from pathlib import Path
 
 import pytest
 
@@ -37,6 +38,27 @@ def test_mode_none_does_not_force_0o600(tmp_path):
     p = tmp_path / "open.json"
     atomic_write_text(p, "{}\n")
     assert (p.stat().st_mode & 0o777) == (control.stat().st_mode & 0o777)
+
+
+def test_modeless_stat_error_other_than_missing_propagates(tmp_path, monkeypatch):
+    """A stat failure that is not "file missing" must propagate, not be read as
+    a new file: silently treating it as new would drop an existing target's
+    permission bits."""
+    p = tmp_path / "out.json"
+    p.write_text("old\n")
+    p.chmod(0o640)
+    real_stat = Path.stat
+
+    def fake_stat(self, *args, **kwargs):
+        if self == p:
+            raise PermissionError("stat blocked")
+        return real_stat(self, *args, **kwargs)
+
+    monkeypatch.setattr(_atomic.Path, "stat", fake_stat)
+    with pytest.raises(PermissionError):
+        atomic_write_text(p, "new\n")
+    assert p.read_text() == "old\n"  # target untouched
+    assert list(tmp_path.iterdir()) == [p]  # no tmp sibling left behind
 
 
 def test_creates_missing_parent_dirs(tmp_path):

--- a/packages/nauro/tests/test_atomic.py
+++ b/packages/nauro/tests/test_atomic.py
@@ -1,5 +1,7 @@
 """Tests for the atomic text-write primitive in ``nauro.store._atomic``."""
 
+import threading
+
 import pytest
 
 from nauro.store import _atomic
@@ -27,9 +29,14 @@ def test_mode_0o600_applied(tmp_path):
 
 
 def test_mode_none_does_not_force_0o600(tmp_path):
+    """A new modeless file matches plain ``write_text`` permissions exactly,
+    so the owner-only tmp creation mode never leaks onto non-sensitive files
+    (under the default umask that means bits other than ``0o600``)."""
+    control = tmp_path / "control.json"
+    control.write_text("{}\n")
     p = tmp_path / "open.json"
     atomic_write_text(p, "{}\n")
-    assert p.stat().st_mode & 0o777 != 0o600
+    assert (p.stat().st_mode & 0o777) == (control.stat().st_mode & 0o777)
 
 
 def test_creates_missing_parent_dirs(tmp_path):
@@ -55,6 +62,66 @@ def test_target_untouched_when_replace_fails(tmp_path, monkeypatch):
     with pytest.raises(OSError, match="replace failed"):
         atomic_write_text(p, "new\n")
     assert not p.exists()
+    assert list(tmp_path.iterdir()) == []  # failed write leaves no tmp sibling
+
+
+def test_modeless_write_ignores_predictable_tmp_symlink(tmp_path):
+    """A symlink pre-planted at the old predictable ``<name>.tmp`` path must not
+    redirect a modeless write either. The symlink and its target stay untouched
+    and the real file is written via an unguessable temp name."""
+    target = tmp_path / "config.json"
+    outside = tmp_path / "outside.txt"
+    outside.write_text("original")
+    trap = target.with_suffix(".tmp")
+    trap.symlink_to(outside)
+
+    atomic_write_text(target, "payload\n")
+
+    assert outside.read_text() == "original"  # not clobbered through the symlink
+    assert target.read_text() == "payload\n"
+    assert trap.is_symlink()  # the planted link itself is never touched
+
+
+def test_mode_none_preserves_existing_permissions(tmp_path):
+    p = tmp_path / "out.json"
+    p.write_text("old\n")
+    p.chmod(0o640)
+    atomic_write_text(p, "new\n")
+    assert p.read_text() == "new\n"
+    assert oct(p.stat().st_mode & 0o777) == "0o640"
+
+
+def test_explicit_mode_wins_over_existing_permissions(tmp_path):
+    p = tmp_path / "out.json"
+    p.write_text("old\n")
+    p.chmod(0o644)
+    atomic_write_text(p, "new\n", mode=0o600)
+    assert oct(p.stat().st_mode & 0o777) == "0o600"
+
+
+def test_concurrent_writers_land_one_complete_payload(tmp_path):
+    """Interleaved writers never corrupt the target: the final content is one
+    writer's complete payload and no temp siblings survive."""
+    p = tmp_path / "out.json"
+    payloads = [f"payload-{i}\n" * 200 for i in range(8)]
+    errors: list[BaseException] = []
+
+    def write(payload: str) -> None:
+        try:
+            for _ in range(20):
+                atomic_write_text(p, payload)
+        except BaseException as exc:  # pragma: no cover - failure diagnostics
+            errors.append(exc)
+
+    threads = [threading.Thread(target=write, args=(payload,)) for payload in payloads]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert not errors
+    assert p.read_text() in payloads
+    assert [f.name for f in tmp_path.iterdir()] == ["out.json"]
 
 
 def test_sensitive_write_ignores_predictable_tmp_symlink(tmp_path):


### PR DESCRIPTION
## Why

The atomic write helper's modeless branch wrote through a predictable `<name>.tmp` sibling with `write_text`, which follows a symlink pre-planted at that path, so a write into a repo-influenced location (such as the per-repo `.nauro/config.json` that adopt writes) could be redirected outside its target. The same branch left the temp file behind on failure and reset an existing file's permission bits on replace. This hardening is the base other setup write-safety fixes build on.

## What changed

- All writes (not just mode-restricted ones) go through a randomly named `O_CREAT|O_EXCL` temp sibling, which cannot be redirected by a planted symlink, and the temp is removed on any failure.
- Permission handling is now explicit: a given `mode` wins; a modeless write preserves an existing target's permission bits; a brand-new modeless file is created at the default umask mode by the kernel, matching plain `write_text`. No process-global umask manipulation is involved.
- The auth-token call site (`mode=0o600`) behaves identically; no callers changed.

## Risk / what to review

The mode/creation-mode branch logic in `atomic_write_text` and the parity assertion in `test_mode_none_does_not_force_0o600` (verified under both the ambient umask and `umask 077`).

## Test plan

Five new regression tests: modeless planted-temp-symlink refusal, failure cleanup leaves no temp, existing-permission preservation, explicit-mode override, and 8-thread concurrent writers landing one complete payload. Full suites green: nauro 1708 passed / 10 skipped, nauro-core 1073 passed; ruff check and format clean.