### PR TITLE
Fix claude-code hook teardown and codex remove messaging

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/setup.py
+++ b/packages/nauro/src/nauro/cli/commands/setup.py
@@ -182,6 +182,15 @@ def _resolve_nauro_command() -> str:
     return fallback
 
 
+def _registered_project_keys() -> set[str]:
+    """Return the keys of every project in the registry (v2, v1 fallback)."""
+    try:
+        registry = load_registry_v2()
+    except RegistrySchemaError:
+        registry = load_registry()
+    return set(registry.get("projects", {}).keys())
+
+
 def _user_scope_safe_to_clear(current_project_key: str | None) -> bool:
     """Return True iff no other nauro projects remain in the registry.
 
@@ -191,11 +200,7 @@ def _user_scope_safe_to_clear(current_project_key: str | None) -> bool:
     machine, so a per-project teardown must not strip them while other
     projects still depend on them.
     """
-    try:
-        registry = load_registry_v2()
-    except RegistrySchemaError:
-        registry = load_registry()
-    keys = set(registry.get("projects", {}).keys())
+    keys = _registered_project_keys()
     if current_project_key is not None:
         keys.discard(current_project_key)
     return not keys
@@ -357,7 +362,7 @@ def claude_code(
         if legacy:
             legacy_results.append(legacy)
         mcp_results.append(_configure_mcp(repo_path, remove=remove))
-        if with_hooks:
+        if with_hooks or remove:
             try:
                 hook_results.append(materialize_hooks_claude_code(repo_path, remove=remove))
             except Exception as exc:
@@ -475,8 +480,6 @@ def _configure_codex(
     their previous behavior.
     """
     config_path = config_path or _default_codex_config_path()
-    nauro_cmd = _find_nauro_command()
-    nauro_entry = {"command": nauro_cmd, "args": ["serve", "--stdio"]}
 
     if remove and not clear_user_scope:
         return (
@@ -509,7 +512,7 @@ def _configure_codex(
             return f"Codex: removed nauro from {config_path}"
         return f"Codex: no nauro entry to remove in {config_path}"
 
-    servers["nauro"] = nauro_entry
+    servers["nauro"] = {"command": _find_nauro_command(), "args": ["serve", "--stdio"]}
     config_path.parent.mkdir(parents=True, exist_ok=True)
     config_path.write_bytes(tomli_w.dumps(config).encode("utf-8"))
     return f"Codex: wrote nauro to {config_path}"
@@ -548,11 +551,23 @@ def codex(
         entry = _resolve_project_entry(project_name, store_path.name)
         hook_repos = [Path(repo_path) for repo_path in entry["repo_paths"]]
 
-    # Standalone codex wiring is user-global, so removing it without first
-    # tearing down the other projects would leave them pointed at a missing
-    # MCP entry. Gate on the registry: only the last project's teardown clears.
-    clear_user_scope = _user_scope_safe_to_clear(None) if remove else True
-    typer.echo(_configure_codex(remove=remove, clear_user_scope=clear_user_scope))
+    # Standalone codex wiring is user-global and shared by every registered
+    # project, so this teardown preserves the entry while any project remains
+    # in the registry (it clears only on an empty registry). Clearing on the
+    # last project goes through 'nauro setup all --remove'.
+    registered_count = len(_registered_project_keys()) if remove else 0
+    if registered_count:
+        config_path = _default_codex_config_path()
+        count_phrase = (
+            "1 nauro project" if registered_count == 1 else f"{registered_count} nauro projects"
+        )
+        typer.echo(
+            f"Codex: preserved nauro entry in {config_path} ({count_phrase} registered; "
+            "run 'nauro setup all --remove' on the last project to clear this "
+            "user-global entry)"
+        )
+    else:
+        typer.echo(_configure_codex(remove=remove))
 
     hook_cleanup_unresolved = False
     if remove:

--- a/packages/nauro/tests/test_setup_extended.py
+++ b/packages/nauro/tests/test_setup_extended.py
@@ -176,6 +176,27 @@ def test_setup_codex_no_op_when_remove_and_no_entry(tmp_path: Path):
     assert "no nauro entry to remove" in msg
 
 
+def test_configure_codex_remove_does_not_resolve_command(tmp_path: Path, monkeypatch):
+    """The remove path never resolves the nauro entrypoint. Resolution can
+    probe subprocesses and print install warnings, none of which belong in
+    a teardown that only deletes an entry."""
+    import nauro.cli.commands.setup as setup_mod
+
+    config_path = tmp_path / ".codex" / "config.toml"
+    config_path.parent.mkdir()
+    config_path.write_text('[mcp_servers.nauro]\ncommand = "nauro"\nargs = ["serve", "--stdio"]\n')
+
+    def _fail() -> str:
+        raise AssertionError("command resolution must not run on remove")
+
+    monkeypatch.setattr(setup_mod, "_resolve_nauro_command", _fail)
+    setup_mod._find_nauro_command.cache_clear()
+
+    msg = _configure_codex(remove=True, config_path=config_path)
+
+    assert "removed nauro from" in msg
+
+
 def test_configure_codex_add_surfaces_parse_error(tmp_path: Path):
     """Hand-edited / corrupt `~/.codex/config.toml` surfaces a parse error
     rather than crashing — same contract as the JSON handlers."""
@@ -456,6 +477,42 @@ def test_standalone_codex_remove_preserves_when_projects_remain(tmp_path: Path, 
     with codex_config.open("rb") as f:
         data = tomllib.load(f)
     assert data["mcp_servers"]["nauro"]["args"] == ["serve", "--stdio"]
+
+
+def test_standalone_codex_remove_message_counts_single_project(tmp_path: Path, monkeypatch):
+    """With one project registered, the preserved message states the count and
+    points at ``setup all --remove`` instead of claiming *other* projects."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    register_project_v2("only-project", [repo])
+
+    runner.invoke(app, ["setup", "codex"])
+    result = runner.invoke(app, ["setup", "codex", "--remove"])
+
+    assert result.exit_code == 0, result.output
+    assert "preserved nauro entry" in result.output
+    assert "1 nauro project" in result.output
+    assert "setup all --remove" in result.output
+    assert "other nauro projects" not in result.output
+
+
+def test_standalone_codex_remove_message_counts_two_projects(tmp_path: Path, monkeypatch):
+    """With two projects registered, the preserved message pluralizes the count."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo_a = tmp_path / "repo_a"
+    repo_b = tmp_path / "repo_b"
+    repo_a.mkdir()
+    repo_b.mkdir()
+    register_project_v2("proj-a", [repo_a])
+    register_project_v2("proj-b", [repo_b])
+
+    runner.invoke(app, ["setup", "codex"])
+    result = runner.invoke(app, ["setup", "codex", "--remove"])
+
+    assert result.exit_code == 0, result.output
+    assert "preserved nauro entry" in result.output
+    assert "2 nauro projects" in result.output
 
 
 # ─── nauro check-decision discoverability hint ──────────────────────────────

--- a/packages/nauro/tests/test_setup_hooks.py
+++ b/packages/nauro/tests/test_setup_hooks.py
@@ -510,6 +510,35 @@ def test_setup_claude_code_without_hooks_writes_no_settings(tmp_path: Path, monk
     assert not _settings(repo).is_file()
 
 
+def test_setup_claude_code_remove_cleans_hooks_without_with_hooks(tmp_path: Path, monkeypatch):
+    """`setup claude-code --remove` strips the nauro hook even without
+    --with-hooks, matching `setup codex --remove` and `setup all --remove`,
+    while a plugin-authored hook on the same event survives untouched."""
+    repo, _store = _make_project(tmp_path)
+    monkeypatch.chdir(repo)
+
+    added = runner.invoke(app, ["setup", "claude-code", "--with-hooks"])
+    assert added.exit_code == 0, added.output
+
+    settings_path = _settings(repo)
+    settings = json.loads(settings_path.read_text())
+    plugin_entry = {
+        "type": "command",
+        "command": "${CLAUDE_PLUGIN_ROOT}/scripts/prompt-hook-nauro.sh",
+    }
+    settings["hooks"][HOOK_EVENT_NAME].append({"hooks": [plugin_entry]})
+    settings_path.write_text(json.dumps(settings))
+
+    result = runner.invoke(app, ["setup", "claude-code", "--remove"])
+
+    assert result.exit_code == 0, result.output
+    assert "removed nauro hook" in result.output
+    after = json.loads(settings_path.read_text())
+    assert _nauro_entries(after) == []
+    remaining = [e for m in after["hooks"][HOOK_EVENT_NAME] for e in m["hooks"]]
+    assert remaining == [plugin_entry]
+
+
 def test_setup_codex_with_hooks_wires_project_repos_and_prints_trust_guidance(
     tmp_path: Path, monkeypatch
 ):


### PR DESCRIPTION
## Why

Two teardown defects in `nauro setup`:

1. `setup claude-code --remove` without `--with-hooks` skipped hook teardown
   entirely, leaving the nauro UserPromptSubmit hook orphaned in
   `.claude/settings.json`. The codex command and `setup all --remove` already
   clean hooks on every remove; claude-code was the odd one out.
2. `setup codex --remove` printed "other nauro projects still registered" even
   when exactly one project existed. The standalone command is user-global and
   gates on the whole registry, so with one project the message claimed phantom
   "other" projects and gave no path to actually clear the entry.

## What changed

- claude-code teardown parity: hook removal now runs on `--remove` regardless
  of `--with-hooks`, matching codex and `setup all`. Removal still strips only
  nauro-authored entries (matched on the hook-subcommand marker), so plugin
  wrappers and user hooks on the same event survive untouched.
- The standalone codex command now derives the registered-project count from a
  new single-source helper (`_registered_project_keys`, also used by
  `_user_scope_safe_to_clear`) and prints an accurate preserved message naming
  the count and pointing at `nauro setup all --remove` for last-project
  clearing. The `_configure_codex` preserved branch is unchanged and now serves
  only `setup all`/adopt, where the gate is other-project-aware.
- Command resolution moved out of `_configure_codex`'s remove path: the nauro
  entrypoint is now resolved only at the add-path write site, so a teardown
  never probes subprocesses or emits install warnings for a command it will
  not record.

## Test plan

- New: claude-code remove-without-flag strips the nauro hook while a
  plugin-shaped UserPromptSubmit entry survives (fails on main); preserved
  message asserts singular/plural counts and the `setup all --remove` pointer;
  a unit test patches the resolver seam to raise, proving remove performs zero
  command resolution.
- Full suites green: nauro 1713 passed / 10 skipped, nauro-core 1073 passed;
  ruff check and format clean. Existing teardown-semantics tests (user-global
  preservation, empty-registry clear, multi-project setup-all gating) pass
  unmodified.
