### PR TITLE
Harden repo-scoped config writes: symlink refusal and UTF-8 pinning

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/adopt.py
+++ b/packages/nauro/src/nauro/cli/commands/adopt.py
@@ -31,13 +31,15 @@ from pathlib import Path
 import typer
 
 from nauro.cli.commands.setup import (
+    OPT_IN_SKILL_NAMES,
     SHIP_TASK_NEEDS_SUBAGENTS_NOTICE,
+    SKILL_NAMES,
     SUBAGENTS_CONNECTOR_NAME_NOTICE,
     _find_nauro_command,
     setup_all_surfaces,
 )
 from nauro.cli.git_hygiene import public_surface_git_warnings
-from nauro.cli.utils import refuse_global_config_collision
+from nauro.cli.utils import refuse_global_config_collision, refuse_repo_config_symlink
 from nauro.constants import REGISTRY_SCHEMA_VERSION_V2, REPO_CONFIG_MODE_LOCAL
 from nauro.skills import load_adopt_body
 from nauro.store.registry import (
@@ -50,6 +52,7 @@ from nauro.store.registry import (
     remove_repo_v2,
 )
 from nauro.store.repo_config import RepoConfigSchemaError, load_repo_config, save_repo_config
+from nauro.store.write_safety import SymlinkRefusal, find_symlink
 from nauro.telemetry import capture
 from nauro.telemetry.events import project_created
 from nauro.templates.scaffolds import scaffold_project_store
@@ -188,6 +191,26 @@ def _install_into_adopted_repo(
     typer.echo("\nNext: restart your agent so it picks up the newly installed files.")
 
 
+def _unadopt_symlink_refusals(repo_root: Path) -> list[SymlinkRefusal]:
+    """Preflight every repo-scoped teardown target for symlink components.
+
+    Un-adopt rewrites, unlinks, or prunes these paths. A symlink pre-planted
+    in the checkout would redirect the removal outside the repo, so the whole
+    teardown is refused before anything is mutated or deregistered.
+    """
+    targets = [
+        ".nauro/config.json",
+        ".mcp.json",
+        ".cursor/mcp.json",
+        ".claude/settings.json",
+        ".codex/hooks.json",
+        "AGENTS.md",
+        "CLAUDE.md",
+        *(f".cursor/rules/{name}.mdc" for name in SKILL_NAMES + OPT_IN_SKILL_NAMES),
+    ]
+    return [refusal for rel in targets if (refusal := find_symlink(repo_root, rel)) is not None]
+
+
 def _remove_adoption(repo_root: Path, *, purge_store: bool, assume_yes: bool) -> None:
     """Inverse of adoption for one repo.
 
@@ -238,6 +261,21 @@ def _remove_adoption(repo_root: Path, *, purge_store: bool, assume_yes: bool) ->
             "Error: --purge-store refused: this project has other associated "
             f"repos ({len(other_repos)}) that still use the store. Un-adopt "
             "those first, or drop this repo without --purge-store.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    # ── symlink preflight ────────────────────────────────────────────────
+    # Refused before the confirmation prompt: nothing may be removed or
+    # deregistered when any teardown target traverses a pre-planted symlink.
+    refusals = _unadopt_symlink_refusals(repo_root)
+    if refusals:
+        for refusal in refusals:
+            typer.echo(f"Error: {refusal.message}", err=True)
+        typer.echo(
+            "Un-adopt aborted before any removal, so the wiring and registry "
+            "entry are intact. Replace the offending symlinks with real files "
+            "and re-run.",
             err=True,
         )
         raise typer.Exit(code=1)
@@ -492,6 +530,10 @@ def adopt(
     if collision is not None:
         typer.echo(collision, err=True)
         raise typer.Exit(code=1)
+
+    # Refused before registration so a pre-planted symlink at the config
+    # path leaves no registry entry behind.
+    refuse_repo_config_symlink(repo_root)
 
     # ── mint project + write per-repo config + scaffold store ──────────────
     try:

--- a/packages/nauro/src/nauro/cli/commands/adopt.py
+++ b/packages/nauro/src/nauro/cli/commands/adopt.py
@@ -230,6 +230,22 @@ def _remove_adoption(repo_root: Path, *, purge_store: bool, assume_yes: bool) ->
         )
         raise typer.Exit(code=1)
 
+    # ── symlink preflight ────────────────────────────────────────────────
+    # Refused before the config read and the confirmation prompt: the config
+    # must not be read through a planted link, and nothing may be removed or
+    # deregistered when any teardown target traverses a pre-planted symlink.
+    refusals = _unadopt_symlink_refusals(repo_root)
+    if refusals:
+        for refusal in refusals:
+            typer.echo(f"Error: {refusal.message}", err=True)
+        typer.echo(
+            "Un-adopt aborted before any removal, so the wiring and registry "
+            "entry are intact. Replace the offending symlinks with real files "
+            "and re-run.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
     pid: str | None = None
     name: str | None = None
     try:
@@ -261,21 +277,6 @@ def _remove_adoption(repo_root: Path, *, purge_store: bool, assume_yes: bool) ->
             "Error: --purge-store refused: this project has other associated "
             f"repos ({len(other_repos)}) that still use the store. Un-adopt "
             "those first, or drop this repo without --purge-store.",
-            err=True,
-        )
-        raise typer.Exit(code=1)
-
-    # ── symlink preflight ────────────────────────────────────────────────
-    # Refused before the confirmation prompt: nothing may be removed or
-    # deregistered when any teardown target traverses a pre-planted symlink.
-    refusals = _unadopt_symlink_refusals(repo_root)
-    if refusals:
-        for refusal in refusals:
-            typer.echo(f"Error: {refusal.message}", err=True)
-        typer.echo(
-            "Un-adopt aborted before any removal, so the wiring and registry "
-            "entry are intact. Replace the offending symlinks with real files "
-            "and re-run.",
             err=True,
         )
         raise typer.Exit(code=1)
@@ -497,6 +498,11 @@ def adopt(
         )
         raise typer.Exit(code=1)
 
+    # Refused before the already-adopted routing and before registration, so
+    # a planted link can neither impersonate an adoption nor leave a registry
+    # entry behind.
+    refuse_repo_config_symlink(repo_root)
+
     # ── already-adopted guard ──────────────────────────────────────────────
     config_path = repo_root / ".nauro" / "config.json"
     if config_path.exists():
@@ -530,10 +536,6 @@ def adopt(
     if collision is not None:
         typer.echo(collision, err=True)
         raise typer.Exit(code=1)
-
-    # Refused before registration so a pre-planted symlink at the config
-    # path leaves no registry entry behind.
-    refuse_repo_config_symlink(repo_root)
 
     # ── mint project + write per-repo config + scaffold store ──────────────
     try:

--- a/packages/nauro/src/nauro/cli/commands/attach.py
+++ b/packages/nauro/src/nauro/cli/commands/attach.py
@@ -17,7 +17,7 @@ import typer
 
 from nauro.cli.commands.auth import DEFAULT_API_URL
 from nauro.cli.git_hygiene import public_surface_git_warnings
-from nauro.cli.utils import refuse_global_config_collision
+from nauro.cli.utils import refuse_global_config_collision, refuse_repo_config_symlink
 from nauro.constants import REPO_CONFIG_MODE_CLOUD
 from nauro.store.registry import (
     add_repo_v2,
@@ -85,6 +85,7 @@ def attach(
     # config, not a repo config slot.
     refuse_global_config_collision(repo_path)
     _refuse_attach_collision(repo_path, project_id)
+    refuse_repo_config_symlink(repo_path)
     try:
         projects = list_projects()
     except CloudProjectError as exc:

--- a/packages/nauro/src/nauro/cli/commands/attach.py
+++ b/packages/nauro/src/nauro/cli/commands/attach.py
@@ -82,10 +82,12 @@ def attach(
     repo_path = repo_path if repo_path is not None else Path.cwd()
     # Refused before the membership call so the failure is local and
     # immediate; the home directory's .nauro/config.json is the global
-    # config, not a repo config slot.
+    # config, not a repo config slot. The symlink refusal precedes the
+    # collision check because the collision check reads the repo config,
+    # and a planted link must never be read through.
     refuse_global_config_collision(repo_path)
-    _refuse_attach_collision(repo_path, project_id)
     refuse_repo_config_symlink(repo_path)
+    _refuse_attach_collision(repo_path, project_id)
     try:
         projects = list_projects()
     except CloudProjectError as exc:

--- a/packages/nauro/src/nauro/cli/commands/init.py
+++ b/packages/nauro/src/nauro/cli/commands/init.py
@@ -24,7 +24,7 @@ import typer
 
 from nauro.cli.commands.auth import DEFAULT_API_URL
 from nauro.cli.git_hygiene import public_surface_git_warnings
-from nauro.cli.utils import refuse_global_config_collision
+from nauro.cli.utils import refuse_global_config_collision, refuse_repo_config_symlink
 from nauro.constants import (
     REGISTRY_SCHEMA_VERSION_V2,
     REPO_CONFIG_MODE_CLOUD,
@@ -199,6 +199,7 @@ def _init_demo(name: str, repo_paths: list[Path], force: bool) -> None:
     # generic --add-repo recovery line. Only the cwd (first/only path) gets the
     # demo-config; --demo does not take --add-repo, so repo_paths is [cwd].
     for rp in repo_paths:
+        refuse_repo_config_symlink(rp)
         config_file = repo_config_path(rp)
         if config_file.is_file() and not force:
             typer.echo(
@@ -365,6 +366,7 @@ def init(
             store_path = get_store_path_v2(pid)
             # Pre-check every target repo before any state changes.
             for rp in repo_paths:
+                refuse_repo_config_symlink(rp)
                 _check_config_overwrite(rp, pid, name, force)
                 _refuse_if_repo_already_claimed(rp, allowed_project_id=pid)
             added = []
@@ -407,6 +409,7 @@ def init(
     # a cwd already linked to a different projA would lose the user's
     # existing project association.
     for rp in repo_paths:
+        refuse_repo_config_symlink(rp)
         _check_config_overwrite(rp, None, name, force)
 
     # Refuse to mint a second entry for a repo a project already claims. A

--- a/packages/nauro/src/nauro/cli/commands/link.py
+++ b/packages/nauro/src/nauro/cli/commands/link.py
@@ -16,6 +16,7 @@ import typer
 
 from nauro.cli.commands.auth import DEFAULT_API_URL, load_access_token
 from nauro.cli.git_hygiene import public_surface_git_warnings
+from nauro.cli.utils import refuse_repo_config_symlink
 from nauro.constants import (
     REPO_CONFIG_MODE_CLOUD,
     REPO_CONFIG_MODE_LOCAL,
@@ -59,6 +60,10 @@ def link(
         raise typer.Exit(code=1)
 
     repo_root = config_path.parent.parent
+    # A cloned repo is untrusted content: refused before the config read so
+    # planted content can neither pick the project to promote nor reach the
+    # remote create/rename steps.
+    refuse_repo_config_symlink(repo_root)
     try:
         cfg = load_repo_config(repo_root)
     except RepoConfigSchemaError as exc:

--- a/packages/nauro/src/nauro/cli/commands/setup.py
+++ b/packages/nauro/src/nauro/cli/commands/setup.py
@@ -38,6 +38,7 @@ from nauro.store.registry import (
     load_registry_v2,
 )
 from nauro.store.resolution import resolve_from_cwd
+from nauro.store.write_safety import find_symlink
 from nauro.templates.agents_md import (
     regenerate_agents_md_for_project,
     remove_generated_agents_md,
@@ -68,6 +69,9 @@ def _remove_claude_md(repo_path: Path) -> str | None:
 
     Returns a status string if a block was removed, or None if no block found.
     """
+    refusal = find_symlink(repo_path, CLAUDE_MD)
+    if refusal is not None:
+        return f"  {repo_path}: {refusal.message}"
     claude_md = repo_path / CLAUDE_MD
     if not claude_md.exists():
         return None
@@ -223,6 +227,9 @@ def _configure_json_mcp(
 
     Returns a one-line status string (indented for ``setup_all_surfaces``).
     """
+    refusal = find_symlink(repo_path, config_rel_path)
+    if refusal is not None:
+        return f"  {repo_path}: {refusal.message}"
     config_path = repo_path / config_rel_path
     nauro_cmd = _find_nauro_command()
     nauro_entry = {"command": nauro_cmd, "args": ["serve", "--stdio"]}
@@ -756,6 +763,10 @@ def materialize_skills_cursor_for_repo(
     base = repo / ".cursor" / "rules"
     results: list[str] = []
     for name in _resolved_skill_names(with_skills):
+        refusal = find_symlink(repo, f".cursor/rules/{name}.mdc")
+        if refusal is not None:
+            results.append(f"  {repo}: {refusal.message}")
+            continue
         target = base / f"{name}.mdc"
         if remove:
             results.append(_remove_skill_file(target, stop_above=base))
@@ -902,6 +913,9 @@ def materialize_hooks_claude_code(repo: Path, *, remove: bool) -> str:
 
     Returns a one-line status string (indented for ``setup_all_surfaces``).
     """
+    refusal = find_symlink(repo, ".claude/settings.json")
+    if refusal is not None:
+        return f"  {repo}: {refusal.message}"
     settings_path = _claude_settings_path(repo)
 
     if settings_path.exists():
@@ -1038,6 +1052,9 @@ def _find_nauro_codex_hook_command() -> str | None:
 
 def materialize_hooks_codex(repo: Path, *, remove: bool) -> str:
     """Add or remove project-scoped Codex lifecycle hooks for ``repo``."""
+    refusal = find_symlink(repo, ".codex/hooks.json")
+    if refusal is not None:
+        return f"  {repo}: {refusal.message}"
     hooks_path = _codex_hooks_path(repo)
     existing_text: str | None = None
     if hooks_path.exists():

--- a/packages/nauro/src/nauro/cli/commands/setup.py
+++ b/packages/nauro/src/nauro/cli/commands/setup.py
@@ -236,8 +236,8 @@ def _configure_json_mcp(
 
     if config_path.exists():
         try:
-            config = json.loads(config_path.read_text())
-        except json.JSONDecodeError as exc:
+            config = json.loads(config_path.read_text(encoding="utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
             return f"  {repo_path}: could not parse {label} - {exc}"
     else:
         config = {}
@@ -256,7 +256,7 @@ def _configure_json_mcp(
         if not servers:
             config.pop("mcpServers", None)
         if config:
-            config_path.write_text(json.dumps(config, indent=2) + "\n")
+            config_path.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
         else:
             config_path.unlink()
         return f"  {repo_path}: removed nauro from {label}"
@@ -266,7 +266,7 @@ def _configure_json_mcp(
         return f"  {repo_path}: mcpServers in {label} is not a JSON object, skipped"
     servers["nauro"] = nauro_entry
     config_path.parent.mkdir(parents=True, exist_ok=True)
-    config_path.write_text(json.dumps(config, indent=2) + "\n")
+    config_path.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
     lines = [f"  {repo_path}: wrote nauro to {label}"]
     lines.extend(public_surface_git_warnings(repo_path, config_rel_path))
     return "\n".join(lines)
@@ -303,13 +303,16 @@ def _prune_redundant_user_scope_mcp() -> str | None:
     Only the HTTP-transport entry is pruned — a user-scope ``nauro`` defined as
     a stdio command is the user's own choice and is left alone. Soft-fails
     (never raises) so a malformed or absent file cannot break wiring. Returns a
-    status line when something was removed, otherwise ``None``.
+    status line when something was removed or when the file is not valid
+    UTF-8, otherwise ``None``.
     """
     config_path = Path.home() / ".claude.json"
     if not config_path.exists():
         return None
     try:
-        config = json.loads(config_path.read_text())
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+    except UnicodeDecodeError:
+        return "  skipped user-scope prune: ~/.claude.json is not valid UTF-8"
     except (json.JSONDecodeError, OSError):
         return None
     servers = config.get("mcpServers")
@@ -324,7 +327,7 @@ def _prune_redundant_user_scope_mcp() -> str | None:
     if not servers:
         config.pop("mcpServers", None)
     try:
-        config_path.write_text(json.dumps(config, indent=2) + "\n")
+        config_path.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
     except OSError:
         return None
     return (
@@ -920,8 +923,8 @@ def materialize_hooks_claude_code(repo: Path, *, remove: bool) -> str:
 
     if settings_path.exists():
         try:
-            settings = json.loads(settings_path.read_text())
-        except json.JSONDecodeError as exc:
+            settings = json.loads(settings_path.read_text(encoding="utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
             return f"  {repo}: could not parse .claude/settings.json - {exc}"
         if not isinstance(settings, dict):
             return f"  {repo}: .claude/settings.json is not a JSON object, skipped"
@@ -966,7 +969,7 @@ def _add_hook_entry(settings_path: Path, settings: dict, repo: Path) -> str:
 
     event_matchers.append({"hooks": [_nauro_hook_entry()]})
     settings_path.parent.mkdir(parents=True, exist_ok=True)
-    settings_path.write_text(json.dumps(settings, indent=2) + "\n")
+    settings_path.write_text(json.dumps(settings, indent=2) + "\n", encoding="utf-8")
     lines = [f"  {repo}: wrote nauro hook to .claude/settings.json"]
     lines.extend(public_surface_git_warnings(repo, ".claude/settings.json"))
     return "\n".join(lines)
@@ -1011,7 +1014,7 @@ def _remove_hook_entry(settings_path: Path, settings: dict, repo: Path) -> str:
         settings.pop("hooks", None)
 
     if settings:
-        settings_path.write_text(json.dumps(settings, indent=2) + "\n")
+        settings_path.write_text(json.dumps(settings, indent=2) + "\n", encoding="utf-8")
     else:
         settings_path.unlink()
     return f"  {repo}: removed nauro hook from .claude/settings.json"

--- a/packages/nauro/src/nauro/cli/utils.py
+++ b/packages/nauro/src/nauro/cli/utils.py
@@ -34,6 +34,7 @@ from nauro.store.registry import (
 )
 from nauro.store.repo_config import collides_with_global_config
 from nauro.store.resolution import resolve_from_cwd
+from nauro.store.write_safety import find_symlink
 
 
 def probe_nauro_command(
@@ -115,6 +116,25 @@ def refuse_global_config_collision(repo_root: Path) -> None:
         "  mkdir my-project && cd my-project",
         err=True,
     )
+    raise typer.Exit(code=1)
+
+
+def refuse_repo_config_symlink(repo_root: Path) -> None:
+    """Abort when ``repo_root``'s ``.nauro/config.json`` path traverses a symlink.
+
+    A cloned repo is untrusted content: a pre-planted symlink at ``.nauro`` or
+    ``.nauro/config.json`` would redirect the registration write outside the
+    checkout. Commands that register a repo call this before any registry,
+    cloud, or store mutation so a refusal leaves no partial state.
+    ``save_repo_config`` enforces the same rule as the last line of defense.
+
+    Raises:
+        typer.Exit: code 1 when a symlink component is found.
+    """
+    refusal = find_symlink(repo_root, ".nauro/config.json")
+    if refusal is None:
+        return
+    typer.echo(f"Error: {refusal.message}", err=True)
     raise typer.Exit(code=1)
 
 
@@ -250,6 +270,7 @@ __all__ = [
     "add_repo_v2",
     "probe_nauro_command",
     "refuse_global_config_collision",
+    "refuse_repo_config_symlink",
     "register_project_v2",
     "resolve_target_project",
 ]

--- a/packages/nauro/src/nauro/store/repo_config.py
+++ b/packages/nauro/src/nauro/store/repo_config.py
@@ -151,12 +151,16 @@ def load_repo_config(repo_root: Path) -> dict:
         FileNotFoundError: When the config file does not exist.
         RepoConfigSchemaError: When the file is missing required fields,
             advertises an unknown schema_version, or is corrupt/unparseable
-            JSON. Corrupt JSON is remapped here so a single typed error family
-            covers both schema-mismatch and corruption, letting callers
-            degrade gracefully on either.
+            JSON or not valid UTF-8. Corruption is remapped here so a single
+            typed error family covers both schema-mismatch and corruption,
+            letting callers degrade gracefully on either.
     """
     path = repo_config_path(repo_root)
-    text = path.read_text()
+    try:
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        logger.warning("Corrupt repo config at %s: %s", path, exc)
+        raise RepoConfigSchemaError(f"Repo config at {path} is not valid UTF-8.") from exc
     try:
         data = json.loads(text)
     except json.JSONDecodeError as exc:

--- a/packages/nauro/src/nauro/store/repo_config.py
+++ b/packages/nauro/src/nauro/store/repo_config.py
@@ -176,24 +176,25 @@ def save_repo_config(repo_root: Path, data: dict) -> Path:
     """Write the repo config atomically. Returns the path written.
 
     The data dict is validated before write; an invalid shape raises
-    RepoConfigSchemaError without touching disk. A ``repo_root`` whose config
-    path collides with the global config raises RepoConfigLocationError —
-    the last line of defense for every writer; CLI commands additionally
-    refuse such paths up front with friendlier guidance. A config path that
-    traverses a symlink inside the checkout (a symlinked ``.nauro`` directory
-    or ``config.json``) raises RepoConfigSymlinkError under the same
-    last-line-of-defense contract: a pre-planted link in a cloned repo would
-    redirect the write outside the checkout.
+    RepoConfigSchemaError without touching disk. A config path that traverses
+    a symlink inside the checkout (a symlinked ``.nauro`` directory or
+    ``config.json``) raises RepoConfigSymlinkError, and is checked first: a
+    pre-planted link in a cloned repo would redirect the write outside the
+    checkout, and it must be diagnosed as a planted link rather than by
+    whatever the link resolves to. A ``repo_root`` whose config path collides
+    with the global config raises RepoConfigLocationError. Both are the last
+    line of defense for every writer; CLI commands additionally refuse such
+    paths up front with friendlier guidance.
     """
+    refusal = find_symlink(repo_root, f"{REPO_CONFIG_DIR}/{REPO_CONFIG_FILENAME}")
+    if refusal is not None:
+        raise RepoConfigSymlinkError(refusal.message)
     if collides_with_global_config(repo_root):
         raise RepoConfigLocationError(
             f"Refusing to write a repo config at {repo_config_path(repo_root)}: "
             "that path is Nauro's global config file, which holds auth and "
             "telemetry settings. Run from a project directory instead."
         )
-    refusal = find_symlink(repo_root, f"{REPO_CONFIG_DIR}/{REPO_CONFIG_FILENAME}")
-    if refusal is not None:
-        raise RepoConfigSymlinkError(refusal.message)
     data.setdefault("schema_version", REPO_CONFIG_SCHEMA_VERSION)
     _validate(data)
 

--- a/packages/nauro/src/nauro/store/repo_config.py
+++ b/packages/nauro/src/nauro/store/repo_config.py
@@ -33,6 +33,7 @@ from nauro.constants import (
     REPO_CONFIG_SCHEMA_VERSION,
 )
 from nauro.store._atomic import atomic_write_text
+from nauro.store.write_safety import find_symlink
 
 logger = logging.getLogger("nauro.repo_config")
 
@@ -60,6 +61,10 @@ class RepoConfigSchemaError(Exception):
 
 class RepoConfigLocationError(Exception):
     """Raised when a repo config write targets Nauro's own global config file."""
+
+
+class RepoConfigSymlinkError(Exception):
+    """Raised when a repo config write would traverse a symlink in the checkout."""
 
 
 def _global_config_file() -> Path:
@@ -170,7 +175,11 @@ def save_repo_config(repo_root: Path, data: dict) -> Path:
     RepoConfigSchemaError without touching disk. A ``repo_root`` whose config
     path collides with the global config raises RepoConfigLocationError —
     the last line of defense for every writer; CLI commands additionally
-    refuse such paths up front with friendlier guidance.
+    refuse such paths up front with friendlier guidance. A config path that
+    traverses a symlink inside the checkout (a symlinked ``.nauro`` directory
+    or ``config.json``) raises RepoConfigSymlinkError under the same
+    last-line-of-defense contract: a pre-planted link in a cloned repo would
+    redirect the write outside the checkout.
     """
     if collides_with_global_config(repo_root):
         raise RepoConfigLocationError(
@@ -178,6 +187,9 @@ def save_repo_config(repo_root: Path, data: dict) -> Path:
             "that path is Nauro's global config file, which holds auth and "
             "telemetry settings. Run from a project directory instead."
         )
+    refusal = find_symlink(repo_root, f"{REPO_CONFIG_DIR}/{REPO_CONFIG_FILENAME}")
+    if refusal is not None:
+        raise RepoConfigSymlinkError(refusal.message)
     data.setdefault("schema_version", REPO_CONFIG_SCHEMA_VERSION)
     _validate(data)
 

--- a/packages/nauro/src/nauro/store/resolution.py
+++ b/packages/nauro/src/nauro/store/resolution.py
@@ -19,6 +19,7 @@ and surface specific diagnostics for the other failure modes.
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import NamedTuple
 
@@ -34,6 +35,9 @@ from nauro.store.repo_config import (
     find_repo_config,
     load_repo_config,
 )
+from nauro.store.write_safety import find_symlink
+
+logger = logging.getLogger("nauro.resolution")
 
 
 class StoreResolutionError(ValueError):
@@ -102,12 +106,20 @@ def _resolve_repo_config_from_cwd(start: Path | None) -> tuple[dict, Path] | Non
     config is unreadable. Both ``RepoConfigSchemaError`` (schema mismatch, or a
     corrupt-JSON error the reader remaps to it) and ``OSError`` (an unreadable
     file) degrade to ``None`` so a resolution failure surfaces the no-project
-    fallback rather than crashing the transport.
+    fallback rather than crashing the transport. A config path that traverses
+    a symlink (a symlinked ``.nauro`` directory or ``config.json``) degrades
+    to ``None`` the same way: a cloned repo is untrusted content, and a
+    pre-planted link must not let attacker-chosen content select which
+    project a command operates on.
     """
     config_path = find_repo_config(start=start)
     if config_path is None:
         return None
     repo_root = config_path.parent.parent
+    refusal = find_symlink(repo_root, ".nauro/config.json")
+    if refusal is not None:
+        logger.warning("Declining repo config at %s: %s", config_path, refusal.message)
+        return None
     try:
         cfg = load_repo_config(repo_root)
     except (RepoConfigSchemaError, OSError):

--- a/packages/nauro/src/nauro/store/write_safety.py
+++ b/packages/nauro/src/nauro/store/write_safety.py
@@ -1,0 +1,58 @@
+"""Symlink refusal for repo-scoped writes.
+
+A cloned repository is untrusted content: a symlink pre-planted at a path
+Nauro mutates (a write, a read-before-mutate, an unlink, a directory prune)
+redirects the operation outside the repo. The rule is that repo-scoped
+mutations never traverse a symlink, covering directory components (``.nauro``,
+``.cursor``, ``.claude``, ``.codex`` as symlinks) and the final file. On
+detection the writer refuses and warns, naming the path; it never writes
+through the link and never replaces the link. The repo root itself is trusted
+(the user's own choice); everything below it is checkout content. The
+guarantee covers pre-planted symlinks, not TOCTOU races.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class SymlinkRefusal:
+    """A refused repo-scoped mutation.
+
+    ``target`` is the path the caller wanted to mutate; ``link`` is the
+    offending symlink component (may equal ``target``).
+    """
+
+    target: Path
+    link: Path
+
+    @property
+    def message(self) -> str:
+        if self.link == self.target:
+            return (
+                f"refused to modify {self.target}: it is a symlink; "
+                "Nauro does not write through symlinks in a repo checkout"
+            )
+        return (
+            f"refused to modify {self.target}: {self.link} is a symlink; "
+            "Nauro does not write through symlinks in a repo checkout"
+        )
+
+
+def find_symlink(repo_root: Path, relative: str) -> SymlinkRefusal | None:
+    """Return a refusal for the first symlink component of ``repo_root / relative``.
+
+    Walks each component from the first one below ``repo_root`` down to and
+    including the final path, using the lstat-based ``Path.is_symlink()``,
+    which never follows links. A missing component is safe: there is nothing
+    to traverse. The untrusted suffix is never resolved.
+    """
+    target = repo_root / relative
+    current = repo_root
+    for part in Path(relative).parts:
+        current = current / part
+        if current.is_symlink():
+            return SymlinkRefusal(target=target, link=current)
+    return None

--- a/packages/nauro/tests/test_adopt.py
+++ b/packages/nauro/tests/test_adopt.py
@@ -116,6 +116,55 @@ def test_adopt_refuses_symlinked_repo_config_before_registering(tmp_path: Path, 
     assert not (tmp_path / "attacker-target.json").exists()
 
 
+def _planted_adoption(tmp_path: Path, monkeypatch) -> Path:
+    """An un-adopted git repo whose config.json is a symlink to another
+    repo's valid adoption config."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    victim = tmp_path / "victim"
+    victim.mkdir()
+    _git_init(victim)
+    monkeypatch.chdir(victim)
+    assert runner.invoke(app, ["adopt", "--name", "alpha"]).exit_code == 0
+
+    attack = tmp_path / "attack"
+    (attack / ".nauro").mkdir(parents=True)
+    _git_init(attack)
+    (attack / ".nauro" / "config.json").symlink_to(victim / ".nauro" / "config.json")
+    monkeypatch.chdir(attack)
+    return attack
+
+
+@pytest.mark.skipif(os.name == "nt", reason="symlink creation requires extra Windows privileges")
+def test_adopt_with_skills_refuses_planted_config_link(tmp_path: Path, monkeypatch):
+    """A link to another repo's valid config must not route into the
+    already-adopted branch: the planted link is refused and no skill files
+    are materialized."""
+    attack = _planted_adoption(tmp_path, monkeypatch)
+
+    result = runner.invoke(app, ["adopt", "--with-skills"])
+
+    assert result.exit_code == 1
+    assert "refused to modify" in result.output
+    assert "already adopted" not in result.output.lower()
+    assert not (tmp_path / ".claude" / "skills" / "nauro-ship-task" / "SKILL.md").exists()
+    assert not (attack / ".cursor").exists()
+    assert (attack / ".nauro" / "config.json").is_symlink()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="symlink creation requires extra Windows privileges")
+def test_adopt_plain_refuses_planted_config_link(tmp_path: Path, monkeypatch):
+    """Plain adopt on the same planted link gets the symlink refusal, not the
+    already-adopted hint that a real prior adoption would earn."""
+    attack = _planted_adoption(tmp_path, monkeypatch)
+
+    result = runner.invoke(app, ["adopt"])
+
+    assert result.exit_code == 1
+    assert "refused to modify" in result.output
+    assert "already adopted" not in result.output.lower()
+    assert (attack / ".nauro" / "config.json").is_symlink()
+
+
 def test_adopt_aborts_when_repo_already_adopted(tmp_path: Path, monkeypatch):
     _adopt_env(monkeypatch, tmp_path)
     runner.invoke(app, ["adopt", "--name", "alpha"])

--- a/packages/nauro/tests/test_adopt.py
+++ b/packages/nauro/tests/test_adopt.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 from pathlib import Path
 
+import pytest
 from typer.testing import CliRunner
 
 from nauro.agents import AGENT_NAMES, render_agent
@@ -92,6 +94,26 @@ def test_adopt_from_home_is_refused(tmp_path: Path, monkeypatch):
     assert data["auth"] == {"access_token": "keep-me"}
     assert "mode" not in data
     assert find_projects_by_name_v2("alpha") == []
+
+
+@pytest.mark.skipif(os.name == "nt", reason="symlink creation requires extra Windows privileges")
+def test_adopt_refuses_symlinked_repo_config_before_registering(tmp_path: Path, monkeypatch):
+    """A pre-planted symlink at .nauro/config.json aborts adoption cleanly.
+
+    The refusal fires before ``register_project_v2``, so the registry gains
+    no entry that would then need manual cleanup.
+    """
+    repo = _adopt_env(monkeypatch, tmp_path)
+    (repo / ".nauro").mkdir()
+    (repo / ".nauro" / "config.json").symlink_to(tmp_path / "attacker-target.json")
+
+    result = runner.invoke(app, ["adopt", "--name", "alpha"])
+
+    assert result.exit_code == 1
+    assert "refused to modify" in result.output
+    assert find_projects_by_name_v2("alpha") == []
+    assert (repo / ".nauro" / "config.json").is_symlink()
+    assert not (tmp_path / "attacker-target.json").exists()
 
 
 def test_adopt_aborts_when_repo_already_adopted(tmp_path: Path, monkeypatch):

--- a/packages/nauro/tests/test_adopt_remove.py
+++ b/packages/nauro/tests/test_adopt_remove.py
@@ -205,6 +205,28 @@ def test_remove_aborts_when_teardown_target_is_symlinked(tmp_path, monkeypatch):
     assert (repo / "AGENTS.md").read_bytes() == agents_before
 
 
+@pytest.mark.skipif(os.name == "nt", reason="symlink creation requires extra Windows privileges")
+def test_remove_symlinked_config_refused_before_read(tmp_path, monkeypatch):
+    """The preflight fires before the config is read: a planted link to
+    invalid JSON aborts with the refusal, and the unreadable-config warning
+    never appears because the load never ran."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo = tmp_path / "repo"
+    (repo / ".nauro").mkdir(parents=True)
+    bogus = tmp_path / "bogus.json"
+    bogus.write_text("{not json")
+    (repo / ".nauro" / "config.json").symlink_to(bogus)
+    monkeypatch.chdir(repo)
+
+    result = runner.invoke(app, ["adopt", "--remove", "--yes"])
+
+    assert result.exit_code == 1
+    assert "refused to modify" in result.output
+    assert "unreadable" not in result.output
+    assert (repo / ".nauro" / "config.json").is_symlink()
+    assert bogus.read_text() == "{not json"
+
+
 def test_remove_rejects_add_path_flags(tmp_path, monkeypatch):
     repo = _adopt_env(monkeypatch, tmp_path)
     runner.invoke(app, ["adopt", "--name", "alpha"])

--- a/packages/nauro/tests/test_adopt_remove.py
+++ b/packages/nauro/tests/test_adopt_remove.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 from pathlib import Path
 
+import pytest
 from typer.testing import CliRunner
 
 from nauro.cli.main import app
@@ -175,6 +177,32 @@ def test_remove_multi_repo_drops_only_this_repo_and_keeps_shared_scope(tmp_path,
     # Shared user-scope (Codex entry) preserved because repo_b still depends on it.
     assert codex_cfg.is_file()
     assert "nauro" in codex_cfg.read_text()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="symlink creation requires extra Windows privileges")
+def test_remove_aborts_when_teardown_target_is_symlinked(tmp_path, monkeypatch):
+    """A symlink planted at any teardown target aborts un-adopt before removal.
+
+    Nothing is removed and nothing is deregistered: the wiring, the per-repo
+    config, and the registry entry all survive intact.
+    """
+    repo = _adopt_env(monkeypatch, tmp_path)
+    assert runner.invoke(app, ["adopt", "--name", "alpha"]).exit_code == 0
+    # Swap the wired .mcp.json for a symlink, as a hostile checkout would plant.
+    outside = tmp_path / "outside.json"
+    (repo / ".mcp.json").rename(outside)
+    (repo / ".mcp.json").symlink_to(outside)
+    agents_before = (repo / "AGENTS.md").read_bytes()
+
+    result = runner.invoke(app, ["adopt", "--remove", "--yes"])
+
+    assert result.exit_code == 1
+    assert "refused to modify" in result.output
+    assert "aborted before any removal" in result.output
+    assert (repo / ".nauro" / "config.json").is_file()
+    assert find_projects_by_name_v2("alpha") != []
+    assert (repo / ".mcp.json").is_symlink()
+    assert (repo / "AGENTS.md").read_bytes() == agents_before
 
 
 def test_remove_rejects_add_path_flags(tmp_path, monkeypatch):

--- a/packages/nauro/tests/test_attach.py
+++ b/packages/nauro/tests/test_attach.py
@@ -17,7 +17,7 @@ from typer.testing import CliRunner
 
 from nauro.cli.main import app
 from nauro.store import registry
-from nauro.store.repo_config import load_repo_config
+from nauro.store.repo_config import load_repo_config, save_repo_config
 from nauro.sync import cloud_projects
 from tests.conftest import seed_auth_config
 
@@ -183,6 +183,29 @@ def test_attach_refuses_symlinked_repo_config_before_any_network_call(tmp_path, 
     assert "refused to modify" in result.output
     assert registry.get_project_v2(EXAMPLE_PID) is None
     assert not (tmp_path / "attacker.json").exists()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="symlink creation requires extra Windows privileges")
+def test_attach_symlink_refusal_precedes_collision_check(tmp_path, monkeypatch):
+    """The symlink refusal fires before the collision check, which reads the
+    repo config: a link to another project's valid config is reported as a
+    planted link, never read through and attributed to that project."""
+    other = tmp_path / "other"
+    other.mkdir()
+    other_pid, _store = registry.register_project_v2("other", [other])
+    save_repo_config(other, {"mode": "local", "id": other_pid, "name": "other"})
+
+    repo = tmp_path / "repo"
+    (repo / ".nauro").mkdir(parents=True)
+    (repo / ".nauro" / "config.json").symlink_to(other / ".nauro" / "config.json")
+    monkeypatch.chdir(repo)
+
+    result = runner.invoke(app, ["attach", EXAMPLE_PID])
+
+    assert result.exit_code == 1
+    assert "refused to modify" in result.output
+    assert "already part of project" not in result.output
+    assert "Refusing to overwrite" not in result.output
 
 
 def test_attach_non_member_writes_nothing(tmp_path, monkeypatch):

--- a/packages/nauro/tests/test_attach.py
+++ b/packages/nauro/tests/test_attach.py
@@ -8,9 +8,11 @@ side effects to keep the failure mode safe.
 from __future__ import annotations
 
 import json
+import os
 from unittest.mock import patch
 
 import httpx
+import pytest
 from typer.testing import CliRunner
 
 from nauro.cli.main import app
@@ -165,6 +167,22 @@ def test_attach_from_home_is_refused_before_any_network_call(tmp_path, monkeypat
     assert data["auth"] == {"access_token": "keep-me"}
     assert "mode" not in data
     assert registry.get_project_v2(EXAMPLE_PID) is None
+
+
+@pytest.mark.skipif(os.name == "nt", reason="symlink creation requires extra Windows privileges")
+def test_attach_refuses_symlinked_repo_config_before_any_network_call(tmp_path, monkeypatch):
+    """A pre-planted symlink at .nauro/config.json is refused before the
+    membership lookup, so no token and no mocked transport are needed."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".nauro").mkdir()
+    (tmp_path / ".nauro" / "config.json").symlink_to(tmp_path / "attacker.json")
+
+    result = runner.invoke(app, ["attach", EXAMPLE_PID])
+
+    assert result.exit_code == 1
+    assert "refused to modify" in result.output
+    assert registry.get_project_v2(EXAMPLE_PID) is None
+    assert not (tmp_path / "attacker.json").exists()
 
 
 def test_attach_non_member_writes_nothing(tmp_path, monkeypatch):

--- a/packages/nauro/tests/test_init_registry_integrity.py
+++ b/packages/nauro/tests/test_init_registry_integrity.py
@@ -11,6 +11,7 @@ fixtures; tests that need a specific cwd override on the same monkeypatch.
 
 from __future__ import annotations
 
+import os
 import subprocess
 
 import pytest
@@ -261,3 +262,64 @@ def test_init_suppresses_repo_config_warning_when_ignored(tmp_path, monkeypatch)
     assert result.exit_code == 0, result.output
     assert ".nauro/config.json is untracked and not git-ignored" not in result.output
     assert "AGENTS.md is untracked and not git-ignored" not in result.output
+
+
+# ── symlinked .nauro/config.json refusal ──────────────────────────────────────
+
+
+_symlink_supported = pytest.mark.skipif(
+    os.name == "nt", reason="symlink creation requires extra Windows privileges"
+)
+
+
+@_symlink_supported
+def test_init_refuses_symlinked_repo_config_before_registering(tmp_path, monkeypatch):
+    """A pre-planted symlink at the config path aborts init before any registry write."""
+    project_dir = tmp_path / "proj"
+    (project_dir / ".nauro").mkdir(parents=True)
+    (project_dir / ".nauro" / "config.json").symlink_to(tmp_path / "attacker.json")
+    monkeypatch.chdir(project_dir)
+
+    result = runner.invoke(app, ["init", "someproj"])
+
+    assert result.exit_code == 1
+    assert "refused to modify" in result.output
+    assert find_projects_by_name_v2("someproj") == []
+    assert not (tmp_path / "attacker.json").exists()
+
+
+@_symlink_supported
+def test_init_add_repo_refuses_symlinked_repo_config(tmp_path, monkeypatch):
+    """--add-repo refuses a symlinked config path before extending the entry."""
+    first = tmp_path / "first"
+    first.mkdir()
+    monkeypatch.chdir(first)
+    assert runner.invoke(app, ["init", "projS"]).exit_code == 0
+
+    second = tmp_path / "second"
+    (second / ".nauro").mkdir(parents=True)
+    (second / ".nauro" / "config.json").symlink_to(tmp_path / "attacker.json")
+
+    result = runner.invoke(app, ["init", "projS", "--add-repo", str(second)])
+
+    assert result.exit_code == 1
+    assert "refused to modify" in result.output
+    _pid, entry = find_projects_by_name_v2("projS")[0]
+    assert str(second.resolve()) not in entry["repo_paths"]
+    assert not (tmp_path / "attacker.json").exists()
+
+
+@_symlink_supported
+def test_init_demo_refuses_symlinked_repo_config(tmp_path, monkeypatch):
+    """--demo refuses a symlinked config path before registering the demo project."""
+    project_dir = tmp_path / "demo-dir"
+    (project_dir / ".nauro").mkdir(parents=True)
+    (project_dir / ".nauro" / "config.json").symlink_to(tmp_path / "attacker.json")
+    monkeypatch.chdir(project_dir)
+
+    result = runner.invoke(app, ["init", "--demo"])
+
+    assert result.exit_code == 1
+    assert "refused to modify" in result.output
+    assert find_projects_by_name_v2("demo-project") == []
+    assert not (tmp_path / "attacker.json").exists()

--- a/packages/nauro/tests/test_link_cloud.py
+++ b/packages/nauro/tests/test_link_cloud.py
@@ -12,10 +12,12 @@ Paths covered:
    0 with the re-key intact — the irreversible promotion is never rolled back.
 3. Already-cloud repo: nothing to link → clear error, no-op.
 4. No-config repo: not a nauro repo → clear error.
+5. Planted config symlink: refused before the config read; no remote call.
 """
 
 from __future__ import annotations
 
+import os
 import subprocess
 from unittest.mock import MagicMock, patch
 
@@ -23,6 +25,7 @@ import httpx
 import pytest
 from typer.testing import CliRunner
 
+from nauro.cli.commands import link as link_module
 from nauro.cli.main import app
 from nauro.store import registry
 from nauro.store.repo_config import load_repo_config, save_repo_config
@@ -242,6 +245,39 @@ def test_link_cloud_warns_for_repo_config_git_hygiene(
     assert result.exit_code == 0, result.output
     assert expected in result.output
     assert "repo-local Nauro project config" in result.output
+
+
+@pytest.mark.skipif(os.name == "nt", reason="symlink creation requires extra Windows privileges")
+def test_link_cloud_refuses_symlinked_repo_config(tmp_path, monkeypatch):
+    """A planted config symlink is refused before the config read, so
+    attacker-chosen content can neither pick the project to promote nor
+    reach the remote create/rename steps."""
+    _seed_token(monkeypatch, tmp_path)
+    monkeypatch.setenv("NAURO_API_URL", "https://example.test")
+
+    victim = tmp_path / "victim"
+    victim.mkdir()
+    monkeypatch.chdir(victim)
+    init_result = runner.invoke(app, ["init", "linkproj"])
+    assert init_result.exit_code == 0, init_result.output
+
+    attack = tmp_path / "attack"
+    (attack / ".nauro").mkdir(parents=True)
+    (attack / ".nauro" / "config.json").symlink_to(victim / ".nauro" / "config.json")
+    monkeypatch.chdir(attack)
+
+    registry_before = (tmp_path / "registry.json").read_bytes()
+
+    with patch.object(
+        link_module, "create_project", side_effect=AssertionError("must not be called")
+    ) as mock_create:
+        result = runner.invoke(app, ["link", "--cloud"])
+
+    assert result.exit_code == 1
+    assert "refused to modify" in result.output
+    assert mock_create.call_count == 0
+    assert (tmp_path / "registry.json").read_bytes() == registry_before
+    assert (attack / ".nauro" / "config.json").is_symlink()
 
 
 def test_link_cloud_with_no_repo_config_errors(tmp_path, monkeypatch):

--- a/packages/nauro/tests/test_repo_config.py
+++ b/packages/nauro/tests/test_repo_config.py
@@ -344,6 +344,33 @@ def test_save_refuses_symlinked_nauro_dir(tmp_path):
     assert (repo / REPO_CONFIG_DIR).is_symlink()
 
 
+@pytest.mark.skipif(os.name == "nt", reason="symlink creation requires extra Windows privileges")
+def test_save_symlink_to_global_config_raises_symlink_error(tmp_path, monkeypatch):
+    """A planted link that resolves to the global config is diagnosed as a
+    symlink, not as the location collision: the collision error's guidance
+    (run from a project directory) is wrong for an attack artifact, and the
+    classification must not resolve through the link."""
+    home = tmp_path / "home"
+    nauro_home = home / ".nauro"
+    nauro_home.mkdir(parents=True)
+    monkeypatch.setenv("NAURO_HOME", str(nauro_home))
+    global_config = nauro_home / "config.json"
+    sentinel = '{"auth": {"access_token": "keep-me"}}\n'
+    global_config.write_text(sentinel)
+
+    repo = tmp_path / "repo"
+    (repo / REPO_CONFIG_DIR).mkdir(parents=True)
+    (repo / REPO_CONFIG_DIR / REPO_CONFIG_FILENAME).symlink_to(global_config)
+
+    with pytest.raises(RepoConfigSymlinkError):
+        save_repo_config(
+            repo,
+            {"mode": "local", "id": generate_ulid(), "name": "demo-project"},
+        )
+
+    assert global_config.read_text() == sentinel
+
+
 def test_collision_respects_nauro_home_override(tmp_path):
     """A ``<dir>/.nauro`` that is not the configured home is a valid repo root.
 

--- a/packages/nauro/tests/test_repo_config.py
+++ b/packages/nauro/tests/test_repo_config.py
@@ -127,6 +127,27 @@ def test_loader_remaps_corrupt_json_to_schema_error(tmp_path, caplog):
     assert str(config_file) in caplog.text
 
 
+def test_loader_remaps_invalid_utf8_to_schema_error(tmp_path, caplog):
+    """A non-UTF-8 config raises RepoConfigSchemaError, not a bare
+    UnicodeDecodeError, preserving the single typed error family the loader
+    docstring promises. The warning breadcrumb names the path.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    cfg_dir = repo / REPO_CONFIG_DIR
+    cfg_dir.mkdir()
+    config_file = cfg_dir / REPO_CONFIG_FILENAME
+    config_file.write_bytes(b'\xff\xfe{"mode": "local"}')
+
+    with caplog.at_level(logging.WARNING, logger="nauro.repo_config"):
+        with pytest.raises(RepoConfigSchemaError) as exc:
+            load_repo_config(repo)
+
+    assert "not valid UTF-8" in str(exc.value)
+    assert isinstance(exc.value.__cause__, UnicodeDecodeError)
+    assert str(config_file) in caplog.text
+
+
 def test_save_rejects_invalid_mode(tmp_path):
     """Writing an unknown mode is refused before disk is touched."""
     repo = tmp_path / "repo"

--- a/packages/nauro/tests/test_repo_config.py
+++ b/packages/nauro/tests/test_repo_config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 
 import pytest
 
@@ -15,6 +16,7 @@ from nauro.constants import (
 from nauro.store.repo_config import (
     RepoConfigLocationError,
     RepoConfigSchemaError,
+    RepoConfigSymlinkError,
     collides_with_global_config,
     find_repo_config,
     generate_ulid,
@@ -300,6 +302,25 @@ def test_save_refuses_global_config_path(tmp_path, monkeypatch):
         )
 
     assert global_config.read_text() == sentinel
+
+
+@pytest.mark.skipif(os.name == "nt", reason="symlink creation requires extra Windows privileges")
+def test_save_refuses_symlinked_nauro_dir(tmp_path):
+    """A symlinked ``.nauro`` directory in the checkout is never written through."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    (repo / REPO_CONFIG_DIR).symlink_to(elsewhere)
+
+    with pytest.raises(RepoConfigSymlinkError):
+        save_repo_config(
+            repo,
+            {"mode": "local", "id": generate_ulid(), "name": "demo-project"},
+        )
+
+    assert list(elsewhere.iterdir()) == []
+    assert (repo / REPO_CONFIG_DIR).is_symlink()
 
 
 def test_collision_respects_nauro_home_override(tmp_path):

--- a/packages/nauro/tests/test_resolution_v2.py
+++ b/packages/nauro/tests/test_resolution_v2.py
@@ -14,6 +14,7 @@ each cwd resolves to its own store.
 from __future__ import annotations
 
 import json
+import os
 
 import pytest
 import typer
@@ -345,6 +346,46 @@ def test_resolve_from_cwd_repo_config_precedes_v2_registry(tmp_path, monkeypatch
     assert resolution.project_id == pid_config
     assert resolution.store_path == tmp_path / "projects" / pid_config
     assert pid_config != pid_by_path
+
+
+@pytest.mark.skipif(os.name == "nt", reason="symlink creation requires extra Windows privileges")
+def test_resolve_from_cwd_declines_symlinked_repo_config(tmp_path, monkeypatch):
+    """Tier 1 declines when config.json is a symlink, even one that points at
+    a fully valid config: a cloned repo is untrusted content, and a planted
+    link must not let attacker-chosen content select which project a command
+    operates on."""
+    from nauro.store.resolution import resolve_from_cwd
+
+    victim = tmp_path / "victim"
+    victim.mkdir()
+    pid, _store = registry.register_project_v2("victim", [victim])
+    save_repo_config(victim, {"mode": "local", "id": pid, "name": "victim"})
+
+    attack = tmp_path / "attack"
+    (attack / REPO_CONFIG_DIR).mkdir(parents=True)
+    (attack / REPO_CONFIG_DIR / REPO_CONFIG_FILENAME).symlink_to(
+        victim / REPO_CONFIG_DIR / REPO_CONFIG_FILENAME
+    )
+
+    assert resolve_from_cwd(attack) is None
+
+
+@pytest.mark.skipif(os.name == "nt", reason="symlink creation requires extra Windows privileges")
+def test_resolve_from_cwd_declines_symlinked_nauro_dir(tmp_path, monkeypatch):
+    """A symlinked ``.nauro`` directory declines tier-1 resolution the same way
+    as a symlinked config file: the walk covers directory components too."""
+    from nauro.store.resolution import resolve_from_cwd
+
+    victim = tmp_path / "victim"
+    victim.mkdir()
+    pid, _store = registry.register_project_v2("victim", [victim])
+    save_repo_config(victim, {"mode": "local", "id": pid, "name": "victim"})
+
+    attack = tmp_path / "attack"
+    attack.mkdir()
+    (attack / REPO_CONFIG_DIR).symlink_to(victim / REPO_CONFIG_DIR)
+
+    assert resolve_from_cwd(attack) is None
 
 
 def test_resolve_from_cwd_none_when_nothing_matches(tmp_path, monkeypatch):

--- a/packages/nauro/tests/test_setup.py
+++ b/packages/nauro/tests/test_setup.py
@@ -14,7 +14,8 @@ from nauro.cli.commands.setup import (
     _configure_mcp,
 )
 from nauro.cli.main import app
-from nauro.store.registry import register_project
+from nauro.store.registry import register_project, register_project_v2
+from nauro.store.repo_config import save_repo_config
 from nauro.templates.scaffolds import scaffold_project_store
 
 runner = CliRunner()
@@ -347,6 +348,29 @@ class TestSymlinkRefusal:
         assert "refused to modify" in result.output
         assert (repos[0] / "CLAUDE.md").is_symlink()
         assert outside.read_text() == content
+
+    def test_setup_all_declines_symlinked_repo_config(self, tmp_path: Path, monkeypatch):
+        """A planted config symlink must not select the project whose surfaces
+        get wired: cwd resolution declines the link, and setup falls through
+        to the no-project error without writing anything."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        victim = tmp_path / "victim"
+        victim.mkdir()
+        pid, _store = register_project_v2("victim", [victim])
+        save_repo_config(victim, {"mode": "local", "id": pid, "name": "victim"})
+
+        attack = tmp_path / "attack"
+        (attack / ".nauro").mkdir(parents=True)
+        (attack / ".nauro" / "config.json").symlink_to(victim / ".nauro" / "config.json")
+        monkeypatch.chdir(attack)
+
+        result = runner.invoke(app, ["setup", "all"])
+
+        assert result.exit_code == 1
+        assert "No project found" in result.output
+        assert not (attack / ".mcp.json").exists()
+        assert not (attack / ".cursor").exists()
+        assert not (attack / "AGENTS.md").exists()
 
 
 class TestMalformedConfigGuards:

--- a/packages/nauro/tests/test_setup.py
+++ b/packages/nauro/tests/test_setup.py
@@ -1,8 +1,10 @@
 """Tests for nauro setup claude-code command."""
 
 import json
+import os
 from pathlib import Path
 
+import pytest
 from typer.testing import CliRunner
 
 from nauro.cli.commands.setup import (
@@ -280,6 +282,40 @@ class TestProjectResolution:
         # No CLAUDE.md created
         assert not (repo1 / "CLAUDE.md").exists()
         assert not (repo2 / "CLAUDE.md").exists()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="symlink creation requires extra Windows privileges")
+class TestSymlinkRefusal:
+    """Repo-scoped setup writers refuse pre-planted symlinks in the checkout."""
+
+    def test_setup_claude_code_refuses_symlinked_mcp_json(self, tmp_path: Path, monkeypatch):
+        repos = _setup_project(tmp_path, monkeypatch)
+        outside = tmp_path / "outside.json"
+        outside.write_text("{}")
+        (repos[0] / ".mcp.json").symlink_to(outside)
+
+        result = runner.invoke(app, ["setup", "claude-code", "--project", "testproj"])
+
+        assert result.exit_code == 0
+        assert "refused to modify" in result.output
+        assert "it is a symlink" in result.output
+        # Never written through, never replaced.
+        assert (repos[0] / ".mcp.json").is_symlink()
+        assert outside.read_text() == "{}"
+
+    def test_legacy_cleanup_refuses_symlinked_claude_md(self, tmp_path: Path, monkeypatch):
+        repos = _setup_project(tmp_path, monkeypatch)
+        content = f"{CLAUDE_MD_START}\nold block\n{CLAUDE_MD_END}\n"
+        outside = tmp_path / "outside.md"
+        outside.write_text(content)
+        (repos[0] / "CLAUDE.md").symlink_to(outside)
+
+        result = runner.invoke(app, ["setup", "claude-code", "--project", "testproj"])
+
+        assert result.exit_code == 0
+        assert "refused to modify" in result.output
+        assert (repos[0] / "CLAUDE.md").is_symlink()
+        assert outside.read_text() == content
 
 
 class TestMalformedConfigGuards:

--- a/packages/nauro/tests/test_setup.py
+++ b/packages/nauro/tests/test_setup.py
@@ -92,6 +92,37 @@ class TestMCPConfigDirectWrite:
         assert "could not parse .mcp.json" in result
         assert (repo / ".mcp.json").read_text() == "{not json"
 
+    def test_add_surfaces_invalid_utf8_without_clobbering(self, tmp_path: Path):
+        """A non-UTF-8 `.mcp.json` surfaces the parse-error status instead of
+        raising, and the existing bytes are left untouched."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        raw = b'\xff\xfe{"mcpServers": {}}'
+        (repo / ".mcp.json").write_bytes(raw)
+
+        result = _configure_mcp(repo, remove=False)
+
+        assert "could not parse .mcp.json" in result
+        assert (repo / ".mcp.json").read_bytes() == raw
+
+    def test_add_round_trips_non_ascii_content_as_utf8(self, tmp_path: Path):
+        """Existing non-ASCII server config survives the add as UTF-8 bytes,
+        independent of the platform's locale encoding."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        seeded = json.dumps(
+            {"mcpServers": {"other": {"command": "café", "args": []}}},
+            ensure_ascii=False,
+        )
+        (repo / ".mcp.json").write_bytes(seeded.encode("utf-8"))
+
+        result = _configure_mcp(repo, remove=False)
+
+        assert "wrote nauro to .mcp.json" in result
+        data = json.loads((repo / ".mcp.json").read_bytes().decode("utf-8"))
+        assert data["mcpServers"]["other"]["command"] == "café"
+        assert "nauro" in data["mcpServers"]
+
     def test_remove_deletes_nauro_entry_and_unlinks_empty_file(self, tmp_path: Path):
         """Remove the nauro entry; if mcpServers becomes empty, drop the file."""
         repo = tmp_path / "repo"

--- a/packages/nauro/tests/test_setup_extended.py
+++ b/packages/nauro/tests/test_setup_extended.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
 
+import pytest
 from typer.testing import CliRunner
 
 from nauro.cli.commands.setup import (
@@ -14,6 +16,7 @@ from nauro.cli.commands.setup import (
     _configure_codex,
     _configure_cursor_for_repo,
     _prune_redundant_user_scope_mcp,
+    materialize_skills_cursor_for_repo,
 )
 from nauro.cli.main import app
 from nauro.store.registry import register_project_v2
@@ -125,6 +128,25 @@ def test_configure_cursor_remove_surfaces_parse_error(tmp_path: Path):
     msg = _configure_cursor_for_repo(repo, remove=True)
 
     assert "could not parse .cursor/mcp.json" in msg
+
+
+@pytest.mark.skipif(os.name == "nt", reason="symlink creation requires extra Windows privileges")
+def test_cursor_surfaces_refuse_symlinked_cursor_dir(tmp_path: Path):
+    """A symlinked `.cursor` directory blocks both the MCP and rules writes."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    (repo / ".cursor").symlink_to(elsewhere)
+
+    mcp_line = _configure_cursor_for_repo(repo, remove=False)
+    skill_lines = materialize_skills_cursor_for_repo(repo, remove=False, with_skills=True)
+
+    assert "refused to modify" in mcp_line
+    assert skill_lines and all("refused to modify" in line for line in skill_lines)
+    # Nothing written through the link; the link itself untouched.
+    assert list(elsewhere.iterdir()) == []
+    assert (repo / ".cursor").is_symlink()
 
 
 # ─── nauro setup codex ──────────────────────────────────────────────────────

--- a/packages/nauro/tests/test_setup_extended.py
+++ b/packages/nauro/tests/test_setup_extended.py
@@ -749,6 +749,21 @@ def test_prune_soft_fails_on_malformed_json(tmp_path: Path, monkeypatch):
     assert _prune_redundant_user_scope_mcp() is None
 
 
+def test_prune_reports_invalid_utf8_claude_json(tmp_path: Path, monkeypatch):
+    """A non-UTF-8 ~/.claude.json must not raise; the skip names the file so
+    the user knows the prune did not run."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    raw = b'\xff\xfe{"mcpServers": {}}'
+    (tmp_path / ".claude.json").write_bytes(raw)
+
+    msg = _prune_redundant_user_scope_mcp()
+
+    assert msg is not None
+    assert "~/.claude.json" in msg
+    assert "UTF-8" in msg
+    assert (tmp_path / ".claude.json").read_bytes() == raw
+
+
 def test_setup_all_prunes_redundant_http_entry(tmp_path: Path, monkeypatch):
     """``setup all`` removes the colliding user-scope HTTP nauro entry on the add path."""
     monkeypatch.setenv("HOME", str(tmp_path))

--- a/packages/nauro/tests/test_setup_hooks.py
+++ b/packages/nauro/tests/test_setup_hooks.py
@@ -170,6 +170,41 @@ def test_claude_hook_round_trip_preserves_empty_user_matcher(tmp_path: Path):
     assert settings == {"hooks": {HOOK_EVENT_NAME: [user_matcher]}}
 
 
+@pytest.mark.skipif(os.name == "nt", reason="symlink creation requires extra Windows privileges")
+def test_claude_hook_add_and_remove_refuse_symlinked_settings(tmp_path: Path):
+    """Both hook paths refuse a symlinked .claude/settings.json untouched."""
+    repo = tmp_path / "repo"
+    (repo / ".claude").mkdir(parents=True)
+    outside = tmp_path / "outside-settings.json"
+    outside.write_text("{}")
+    (repo / ".claude" / "settings.json").symlink_to(outside)
+
+    add_line = materialize_hooks_claude_code(repo, remove=False)
+    remove_line = materialize_hooks_claude_code(repo, remove=True)
+
+    assert "refused to modify" in add_line
+    assert "refused to modify" in remove_line
+    assert outside.read_text() == "{}"
+    assert (repo / ".claude" / "settings.json").is_symlink()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="symlink creation requires extra Windows privileges")
+def test_codex_hooks_refuse_symlinked_hooks_json(tmp_path: Path):
+    repo = tmp_path / "repo"
+    (repo / ".codex").mkdir(parents=True)
+    outside = tmp_path / "outside-hooks.json"
+    outside.write_text("{}")
+    (repo / ".codex" / "hooks.json").symlink_to(outside)
+
+    add_line = materialize_hooks_codex(repo, remove=False)
+    remove_line = materialize_hooks_codex(repo, remove=True)
+
+    assert "refused to modify" in add_line
+    assert "refused to modify" in remove_line
+    assert outside.read_text() == "{}"
+    assert (repo / ".codex" / "hooks.json").is_symlink()
+
+
 def test_claude_hook_remove_preserves_matcher_metadata(tmp_path: Path):
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/packages/nauro/tests/test_setup_hooks.py
+++ b/packages/nauro/tests/test_setup_hooks.py
@@ -98,6 +98,22 @@ def test_materialize_is_idempotent(tmp_path: Path):
     assert len(_nauro_entries(settings)) == 1
 
 
+def test_materialize_surfaces_invalid_utf8_settings(tmp_path: Path):
+    """A non-UTF-8 settings file surfaces the parse-error status instead of
+    raising, and the existing bytes are left untouched."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    raw = b'\xff\xfe{"hooks": {}}'
+    settings_path = _settings(repo)
+    settings_path.parent.mkdir(parents=True)
+    settings_path.write_bytes(raw)
+
+    line = materialize_hooks_claude_code(repo, remove=False)
+
+    assert "could not parse .claude/settings.json" in line
+    assert settings_path.read_bytes() == raw
+
+
 # ── direct helper: remove path ─────────────────────────────────────────────────
 
 

--- a/packages/nauro/tests/test_write_safety.py
+++ b/packages/nauro/tests/test_write_safety.py
@@ -1,0 +1,122 @@
+"""Tests for the pure symlink-refusal module (``nauro.store.write_safety``).
+
+Repo-scoped mutations never traverse a symlink, whether the link is the final
+file or a directory component on the way to it. Missing paths and regular
+files are safe.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from nauro.store.write_safety import SymlinkRefusal, find_symlink
+
+pytestmark = pytest.mark.skipif(
+    os.name == "nt", reason="symlink creation requires extra Windows privileges"
+)
+
+
+def test_final_file_symlink_is_refused(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    outside = tmp_path / "outside.json"
+    outside.write_text("{}")
+    (repo / ".mcp.json").symlink_to(outside)
+
+    refusal = find_symlink(repo, ".mcp.json")
+
+    assert refusal is not None
+    assert refusal.target == repo / ".mcp.json"
+    assert refusal.link == repo / ".mcp.json"
+
+
+def test_directory_component_symlink_is_refused(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    outside = tmp_path / "elsewhere"
+    outside.mkdir()
+    (repo / ".cursor").symlink_to(outside)
+
+    refusal = find_symlink(repo, ".cursor/mcp.json")
+
+    assert refusal is not None
+    assert refusal.target == repo / ".cursor" / "mcp.json"
+    assert refusal.link == repo / ".cursor"
+
+
+def test_nested_component_symlink_is_refused(tmp_path: Path):
+    repo = tmp_path / "repo"
+    (repo / ".cursor").mkdir(parents=True)
+    outside = tmp_path / "elsewhere"
+    outside.mkdir()
+    (repo / ".cursor" / "rules").symlink_to(outside)
+
+    refusal = find_symlink(repo, ".cursor/rules/nauro-adopt.mdc")
+
+    assert refusal is not None
+    assert refusal.link == repo / ".cursor" / "rules"
+
+
+def test_first_symlink_component_wins(tmp_path: Path):
+    """When several components are links, the refusal names the first one."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    outside = tmp_path / "elsewhere"
+    (outside / "rules").mkdir(parents=True)
+    (repo / ".cursor").symlink_to(outside)
+
+    refusal = find_symlink(repo, ".cursor/rules/nauro-adopt.mdc")
+
+    assert refusal is not None
+    assert refusal.link == repo / ".cursor"
+
+
+def test_missing_path_is_safe(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    assert find_symlink(repo, ".nauro/config.json") is None
+
+
+def test_regular_files_are_safe(tmp_path: Path):
+    repo = tmp_path / "repo"
+    (repo / ".nauro").mkdir(parents=True)
+    (repo / ".nauro" / "config.json").write_text("{}")
+
+    assert find_symlink(repo, ".nauro/config.json") is None
+
+
+def test_dangling_final_symlink_is_refused(tmp_path: Path):
+    """A link to a nonexistent target is still a link and is still refused."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "AGENTS.md").symlink_to(tmp_path / "does-not-exist")
+
+    refusal = find_symlink(repo, "AGENTS.md")
+
+    assert refusal is not None
+    assert refusal.link == repo / "AGENTS.md"
+
+
+def test_message_when_target_is_the_link(tmp_path: Path):
+    target = tmp_path / "repo" / "AGENTS.md"
+    refusal = SymlinkRefusal(target=target, link=target)
+
+    assert refusal.message == (
+        f"refused to modify {target}: it is a symlink; "
+        "Nauro does not write through symlinks in a repo checkout"
+    )
+
+
+def test_message_when_a_component_is_the_link(tmp_path: Path):
+    target = tmp_path / "repo" / ".cursor" / "mcp.json"
+    link = tmp_path / "repo" / ".cursor"
+    refusal = SymlinkRefusal(target=target, link=link)
+
+    assert refusal.message == (
+        f"refused to modify {target}: {link} is a symlink; "
+        "Nauro does not write through symlinks in a repo checkout"
+    )


### PR DESCRIPTION
## Why

A cloned repository is untrusted content. A symlink pre-planted at a path Nauro mutates inside a repo (.mcp.json, .cursor/, .claude/settings.json, .codex/hooks.json, .nauro/config.json, legacy CLAUDE.md cleanup) would redirect the write, read-before-mutate, unlink, or directory prune outside the checkout. Separately, several JSON config reads and writes relied on the platform locale encoding, so a non-UTF-8 locale could mis-decode or mis-encode managed configs, and a non-UTF-8 file produced a raw traceback out of paths that promise status strings or typed errors.

## What changed

- New pure module `nauro.store.write_safety` owns the symlink component walk (directory components and the final file) and the refusal message. Writers never traverse, write through, or replace a detected link.
- Setup surface writers refuse a symlinked target with a per-artifact status line and keep processing independent artifacts, matching the existing continue-across-errors posture.
- Registration and promotion paths (`adopt`; `init` new-project, `--add-repo`, and `--demo`; `attach`; `link --cloud`) check the repo config path up front, before reading the config and before any registry, cloud, or store mutation, and abort with exit code 1. `adopt --remove` preflights every teardown target before the confirmation prompt and before its own config read, leaving wiring and registry intact.
- Cwd project resolution declines a repo config whose path traverses a symlink (a symlinked `.nauro` directory or `config.json`), logging a warning and falling through to no-project handling, so a planted link cannot select which project's surfaces a setup command mutates.
- `save_repo_config` raises a typed `RepoConfigSymlinkError` as the last line of defense, under the same contract as the existing global-config collision guard, and checks the symlink ahead of the global-config collision so the error names the actual problem.
- UTF-8 is now pinned on the remaining locale-dependent JSON I/O: the project MCP config writer, the Claude Code hooks settings read/write, the user-scope ~/.claude.json prune, and `load_repo_config`. Decode failures join the existing "could not parse" status family where one exists; the prune reports a skip line naming the file instead of silently returning; the repo config loader remaps to `RepoConfigSchemaError`, keeping its single typed error family.

## Deferred

- The AGENTS.md regeneration and removal paths get the same symlink handling in an immediate follow-up PR.
- User-global config files (the Codex TOML) are a separate follow-up.
- Migrating the setup JSON config writers to the hardened atomic write primitive is a named follow-up that lands before any structural refactor of the setup module.

## Test plan

- New unit tests: refusal on symlinked files and symlinked parent directories for each setup surface writer; registration aborts before any state mutation; the `adopt --remove` preflight; the typed `save_repo_config` error; non-UTF-8 input on each newly pinned read path; a non-ASCII round-trip through the project MCP config writer. Ordering tests pin that refusals fire before config reads, collision checks, already-adopted routing, and any remote call. Symlink tests are skipped on Windows.
- Full suites green: packages/nauro 1748 passed / 10 skipped; packages/nauro-core 1073 passed. ruff check and format clean.
