### PR TITLE
Preserve hand-written AGENTS.md outside sync and skip symlinked targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ The skill reads project documentation for rationale and inspects the repository 
 
 Review `.nauro/config.json` and commit it with the repo. Setup variants and optional tooling are covered in the [quickstart](https://nauro.ai/docs/quickstart) and [agents and skills guide](https://nauro.ai/docs/agents-and-skills).
 
+If the repo already has a hand-written AGENTS.md, adoption and setup leave it in place and warn. Running `nauro sync` is the one action that overwrites it; a `# Manual` section survives the rewrite.
+
 ## How the loop works
 
 1. Nauro orients the agent with project scope, current state, open questions, and relevant prior judgment.

--- a/packages/nauro/src/nauro/cli/commands/attach.py
+++ b/packages/nauro/src/nauro/cli/commands/attach.py
@@ -136,7 +136,6 @@ def attach(
         project_id,
         store_path,
         warn=lambda message: typer.echo(message, err=True),
-        preserve_unmanaged=True,
         fail_soft=True,
     )
 

--- a/packages/nauro/src/nauro/cli/commands/init.py
+++ b/packages/nauro/src/nauro/cli/commands/init.py
@@ -64,7 +64,6 @@ def _regenerate_after_init(project_id: str, store_path: Path) -> None:
         project_id,
         store_path,
         warn=_echo_warning,
-        preserve_unmanaged=True,
         fail_soft=True,
     )
 

--- a/packages/nauro/src/nauro/cli/commands/setup.py
+++ b/packages/nauro/src/nauro/cli/commands/setup.py
@@ -39,10 +39,8 @@ from nauro.store.registry import (
 )
 from nauro.store.resolution import resolve_from_cwd
 from nauro.store.write_safety import find_symlink
-from nauro.templates.agents_md import (
-    regenerate_agents_md_for_project,
-    remove_generated_agents_md,
-)
+from nauro.templates.agents_md import remove_generated_agents_md
+from nauro.templates.agents_md_regen import warn_then_regen
 
 if sys.version_info >= (3, 11):
     import tomllib
@@ -401,13 +399,17 @@ def claude_code(
     if not remove:
         # Regenerate AGENTS.md so context is fresh from the start. The store
         # dir name is the v2 id (or v1 name) used by the registry-aware lookup.
-        updated_repos = regenerate_agents_md_for_project(_store_path.name, _store_path)
+        # warn_then_regen surfaces missing-repo, symlink-refusal, and
+        # git-hygiene warnings through the warn callback.
+        updated_repos = warn_then_regen(
+            _store_path.name,
+            _store_path,
+            warn=lambda msg: typer.echo(msg, err=True),
+        )
         if updated_repos:
             typer.echo("\nAGENTS.md:")
             for repo_path in updated_repos:
                 typer.echo(f"  {repo_path}: regenerated AGENTS.md")
-                for warning in public_surface_git_warnings(repo_path, "AGENTS.md"):
-                    typer.echo(warning, err=True)
 
         typer.echo(
             "\nNext: start a Claude Code session in one of the repos."
@@ -1262,13 +1264,13 @@ def setup_all_surfaces(
 
     # Regenerate AGENTS.md once so context is fresh from the start on every
     # entry point that wires surfaces. Guarded on the add path and on having a
-    # store to read from.
+    # store to read from. warn_then_regen routes missing-repo, symlink-refusal,
+    # and git-hygiene warnings into the status lines.
     if not remove and current_project_key is not None and store_path is not None:
         try:
-            updated = regenerate_agents_md_for_project(current_project_key, store_path)
+            updated = warn_then_regen(current_project_key, store_path, warn=lines.append)
             for repo_path in updated:
                 lines.append(f"  {repo_path}: regenerated AGENTS.md")
-                lines.extend(public_surface_git_warnings(repo_path, "AGENTS.md"))
         except Exception as exc:
             lines.append(f"AGENTS.md regeneration: error - {exc}")
 

--- a/packages/nauro/src/nauro/cli/commands/sync.py
+++ b/packages/nauro/src/nauro/cli/commands/sync.py
@@ -37,6 +37,11 @@ def sync(
 ) -> None:
     """Capture a snapshot and regenerate AGENTS.md in each associated repo.
 
+    This is the one command that overwrites an existing AGENTS.md even when
+    Nauro did not generate it; a # Manual section survives the rewrite. Every
+    other command (setup, adopt, init, attach, note, propose_decision)
+    preserves a non-Nauro AGENTS.md and warns instead.
+
     With cloud sync configured, pulls from the server first (git-style
     pull-then-push), then pushes the updated store back. Project state in
     state_current.md is not touched — use the MCP 'update_state' tool to
@@ -62,6 +67,7 @@ def sync(
         project_key,
         store_path,
         warn=lambda msg: typer.echo(msg, err=True),
+        overwrite_unmanaged=True,
     )
 
     pushed = _push_to_cloud(project_key, store_path)

--- a/packages/nauro/src/nauro/templates/agents_md.py
+++ b/packages/nauro/src/nauro/templates/agents_md.py
@@ -15,6 +15,7 @@ from nauro_core.constants import MCP_INSTRUCTIONS_STATIC
 
 from nauro.constants import AGENTS_MD, MANUAL_SECTION_HEADER, SKILLS_SECTION_HEADER
 from nauro.store.reader import read_text_lenient
+from nauro.store.write_safety import find_symlink
 
 # Prefix shared by every auto-generated attribution footer. Match by prefix
 # (not by full canonical URL) so a stale footer from an earlier tagline cycle
@@ -196,7 +197,7 @@ def regenerate_agents_md_for_project(
     project_key: str,
     store_path: Path,
     *,
-    preserve_unmanaged: bool = False,
+    overwrite_unmanaged: bool = False,
 ) -> list[Path]:
     """Regenerate AGENTS.md in all repos associated with a project.
 
@@ -204,7 +205,9 @@ def regenerate_agents_md_for_project(
         project_key: Either a v2 project_id (ULID) or a v1 project name.
             v2 takes priority — the v1 name lookup is the legacy fallback.
         store_path: Path to the project store directory.
-        preserve_unmanaged: Skip existing files that Nauro did not generate.
+        overwrite_unmanaged: Replace an existing AGENTS.md even when Nauro
+            did not generate it. Off by default: only ``nauro sync`` passes
+            True, every other caller preserves hand-written files.
 
     Returns:
         List of repo paths where AGENTS.md was updated.
@@ -235,8 +238,12 @@ def regenerate_agents_md_for_project(
         repo_path = Path(repo_str)
         if not repo_path.is_dir():
             continue
+        # Never write through a pre-planted symlink, regardless of
+        # overwrite_unmanaged; warn_then_regen surfaces the refusal.
+        if find_symlink(repo_path, AGENTS_MD) is not None:
+            continue
         agents_md_path = repo_path / AGENTS_MD
-        if preserve_unmanaged and not agents_md_is_safe_to_replace(agents_md_path):
+        if not overwrite_unmanaged and not agents_md_is_safe_to_replace(agents_md_path):
             continue
         preserved = parse_preserved_sections(agents_md_path)
         content = generate_agents_md(
@@ -271,6 +278,9 @@ def remove_generated_agents_md(repo_path: Path) -> str | None:
     Returns a one-line status string (indented for ``setup_all_surfaces``) when
     it acted, else ``None``.
     """
+    refusal = find_symlink(repo_path, AGENTS_MD)
+    if refusal is not None:
+        return f"  {repo_path}: {refusal.message}"
     agents_md_path = repo_path / AGENTS_MD
     if not agents_md_path.exists():
         return None

--- a/packages/nauro/src/nauro/templates/agents_md_regen.py
+++ b/packages/nauro/src/nauro/templates/agents_md_regen.py
@@ -12,7 +12,9 @@ from collections.abc import Callable
 from pathlib import Path
 
 from nauro.cli.git_hygiene import public_surface_git_warnings
+from nauro.constants import AGENTS_MD
 from nauro.store.registry import get_repo_paths
+from nauro.store.write_safety import find_symlink
 from nauro.templates.agents_md import (
     agents_md_is_safe_to_replace,
     regenerate_agents_md_for_project,
@@ -24,19 +26,20 @@ def warn_then_regen(
     store_path: Path,
     *,
     warn: Callable[[str], None] | None = None,
-    preserve_unmanaged: bool = False,
+    overwrite_unmanaged: bool = False,
     fail_soft: bool = False,
 ) -> list[Path]:
-    """Warn on missing repo paths, then regenerate ``AGENTS.md`` everywhere.
+    """Warn on skipped repo paths, then regenerate ``AGENTS.md`` everywhere.
 
     Args:
         project_key: Either a v2 project_id (ULID) or a v1 project name.
         store_path: Path to the project store directory.
-        warn: Optional callback for missing-repo and git-hygiene warnings.
-            When ``None``, missing repo paths are silently skipped and
-            git-hygiene checks do not run.
-        preserve_unmanaged: Leave an existing ``AGENTS.md`` untouched unless
-            it carries Nauro's generation marker.
+        warn: Optional callback for skip and git-hygiene warnings. When
+            ``None``, skipped repo paths are silent and git-hygiene checks
+            do not run.
+        overwrite_unmanaged: Replace an existing ``AGENTS.md`` even when
+            Nauro did not generate it. Off by default: only ``nauro sync``
+            passes True, every other caller preserves hand-written files.
         fail_soft: Report filesystem errors through ``warn`` and return rather
             than raising after project registration has succeeded.
 
@@ -46,27 +49,35 @@ def warn_then_regen(
         existing CLI surfaces can continue echoing the per-repo line.
     """
     repo_paths = [Path(repo_str) for repo_str in get_repo_paths(project_key)]
-    for repo_path in repo_paths:
-        if not repo_path.is_dir() and warn is not None:
-            warn(
-                f"  Warning: repo path does not exist, skipping AGENTS.md: {repo_path}\n"
-                f"  Fix: remove from registry or update path in ~/.nauro/registry.json"
-            )
-
     try:
-        if preserve_unmanaged:
+        # Warn channel only: the regeneration itself re-applies every skip
+        # below, so nothing outside a real checkout is ever written through.
+        # One loop, first matching skip wins, so no repo path double-warns.
+        # The ownership probe reads the existing file, so it stays inside the
+        # try: a read-side permission error is covered by the same fail_soft
+        # contract as a failed write.
+        if warn is not None:
             for repo_path in repo_paths:
-                agents_md_path = repo_path / "AGENTS.md"
-                if not agents_md_is_safe_to_replace(agents_md_path):
-                    if warn is not None:
-                        warn(
-                            "  Warning: existing AGENTS.md is not Nauro-generated; "
-                            f"left unchanged: {agents_md_path}"
-                        )
+                if not repo_path.is_dir():
+                    warn(
+                        f"  Warning: repo path does not exist, skipping AGENTS.md: {repo_path}\n"
+                        f"  Fix: remove from registry or update path in ~/.nauro/registry.json"
+                    )
+                    continue
+                refusal = find_symlink(repo_path, AGENTS_MD)
+                if refusal is not None:
+                    warn(f"  Warning: {refusal.message}")
+                    continue
+                agents_md_path = repo_path / AGENTS_MD
+                if not overwrite_unmanaged and not agents_md_is_safe_to_replace(agents_md_path):
+                    warn(
+                        "  Warning: existing AGENTS.md is not Nauro-generated; "
+                        f"left unchanged: {agents_md_path}"
+                    )
         updated = regenerate_agents_md_for_project(
             project_key,
             store_path,
-            preserve_unmanaged=preserve_unmanaged,
+            overwrite_unmanaged=overwrite_unmanaged,
         )
     except OSError as exc:
         if not fail_soft:

--- a/packages/nauro/tests/test_agents_md.py
+++ b/packages/nauro/tests/test_agents_md.py
@@ -1,7 +1,9 @@
 """Tests for AGENTS.md generation and sync integration."""
 
+import os
 from pathlib import Path
 
+import pytest
 from nauro_core.constants import MCP_INSTRUCTIONS_STATIC
 from nauro_core.protocol import _APPROVAL_BEFORE_PROPOSE
 from typer.testing import CliRunner
@@ -282,3 +284,47 @@ def test_sync_preserves_manual_section(tmp_path: Path, monkeypatch):
     content = (repo / "AGENTS.md").read_text()
     assert "Keep this note." in content
     assert "Old content" not in content  # auto section was regenerated
+
+
+# --- Symlink refusal ---
+
+
+@pytest.mark.skipif(os.name == "nt", reason="symlink creation requires extra Windows privileges")
+def test_warn_then_regen_warns_and_skips_symlinked_agents_md(tmp_path: Path):
+    """A symlinked AGENTS.md is warned about and never written through."""
+    from nauro.templates.agents_md_regen import warn_then_regen
+    from tests.conftest import register_v2_repo
+
+    v2 = register_v2_repo(tmp_path, "linkproj", chdir=False)
+    outside = tmp_path / "outside-agents.md"
+    outside.write_text("untouchable")
+    (v2.repo / "AGENTS.md").symlink_to(outside)
+
+    warnings: list[str] = []
+    updated = warn_then_regen(v2.pid, v2.store_path, warn=warnings.append)
+
+    assert updated == []
+    assert any("refused to modify" in w for w in warnings)
+    assert outside.read_text() == "untouchable"
+    assert (v2.repo / "AGENTS.md").is_symlink()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="symlink creation requires extra Windows privileges")
+def test_remove_generated_agents_md_refuses_symlink(tmp_path: Path):
+    """Teardown neither unlinks nor rewrites a symlinked AGENTS.md."""
+    from nauro.templates.agents_md import FOOTER_MARKER, remove_generated_agents_md
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    outside = tmp_path / "outside-agents.md"
+    # Looks Nauro-generated, so it would be unlinked were it not behind a link.
+    outside.write_text(f"# AGENTS.md\n\n---\n{FOOTER_MARKER}https://nauro.ai)*\n")
+    before = outside.read_bytes()
+    (repo / "AGENTS.md").symlink_to(outside)
+
+    line = remove_generated_agents_md(repo)
+
+    assert line is not None
+    assert "refused to modify" in line
+    assert (repo / "AGENTS.md").is_symlink()
+    assert outside.read_bytes() == before

--- a/packages/nauro/tests/test_agents_md_ownership.py
+++ b/packages/nauro/tests/test_agents_md_ownership.py
@@ -1,0 +1,82 @@
+"""AGENTS.md ownership: only ``nauro sync`` overwrites hand-written files.
+
+``regenerate_agents_md_for_project`` preserves an existing AGENTS.md that
+Nauro did not generate unless the caller passes ``overwrite_unmanaged=True``,
+which only ``nauro sync`` does. Every other write path (setup, adopt, init,
+attach, note, propose_decision) leaves a hand-written file byte-identical
+and warns. A symlinked AGENTS.md is never written through, even on the
+overwrite path.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from nauro.cli.main import app
+from nauro.store.registry import register_project_v2
+from nauro.templates.agents_md import regenerate_agents_md_for_project
+from nauro.templates.scaffolds import scaffold_project_store
+from tests.conftest import register_v2_repo
+
+runner = CliRunner()
+
+SENTINEL = b"# Hand-written agent rules\n\nKeep these instructions.\n"
+
+
+def test_regenerate_default_preserves_unmanaged_agents_md(tmp_path: Path):
+    """Without an explicit overwrite grant, a marker-less file is untouched."""
+    v2 = register_v2_repo(tmp_path, "preserveproj", chdir=False)
+    (v2.repo / "AGENTS.md").write_bytes(SENTINEL)
+
+    updated = regenerate_agents_md_for_project(v2.pid, v2.store_path)
+
+    assert updated == []
+    assert (v2.repo / "AGENTS.md").read_bytes() == SENTINEL
+
+
+def test_regenerate_overwrite_unmanaged_replaces(tmp_path: Path):
+    """The sync-only overwrite grant replaces a marker-less file."""
+    v2 = register_v2_repo(tmp_path, "overwriteproj", chdir=False)
+    (v2.repo / "AGENTS.md").write_bytes(SENTINEL)
+
+    updated = regenerate_agents_md_for_project(v2.pid, v2.store_path, overwrite_unmanaged=True)
+
+    assert updated == [v2.repo]
+    content = (v2.repo / "AGENTS.md").read_text()
+    assert "Keep these instructions." not in content
+    assert "## Project: overwriteproj" in content
+
+
+@pytest.mark.skipif(os.name == "nt", reason="symlink creation requires extra Windows privileges")
+def test_regenerate_refuses_symlink_even_with_overwrite(tmp_path: Path):
+    """A symlinked AGENTS.md is skipped even under overwrite_unmanaged=True."""
+    v2 = register_v2_repo(tmp_path, "linkproj", chdir=False)
+    outside = tmp_path / "outside-agents.md"
+    outside.write_text("untouchable")
+    (v2.repo / "AGENTS.md").symlink_to(outside)
+
+    updated = regenerate_agents_md_for_project(v2.pid, v2.store_path, overwrite_unmanaged=True)
+
+    assert updated == []
+    assert (v2.repo / "AGENTS.md").is_symlink()
+    assert outside.read_text() == "untouchable"
+
+
+def test_setup_all_preserves_hand_written_agents_md(tmp_path: Path, monkeypatch):
+    """``setup all`` leaves a hand-written AGENTS.md byte-identical and warns."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    _, store_path = register_project_v2("myproj", [repo])
+    scaffold_project_store("myproj", store_path)
+    monkeypatch.chdir(repo)
+    (repo / "AGENTS.md").write_bytes(SENTINEL)
+
+    result = runner.invoke(app, ["setup", "all"])
+    assert result.exit_code == 0, result.output
+
+    assert (repo / "AGENTS.md").read_bytes() == SENTINEL
+    assert "existing AGENTS.md is not Nauro-generated" in result.output
+    assert "regenerated AGENTS.md" not in result.output

--- a/packages/nauro/tests/test_init_cloud.py
+++ b/packages/nauro/tests/test_init_cloud.py
@@ -107,7 +107,7 @@ def test_init_does_not_write_through_agents_md_symlink(tmp_path, monkeypatch):
     assert result.exit_code == 0, result.output
     assert (tmp_path / "AGENTS.md").is_symlink()
     assert target.read_bytes() == before
-    assert "existing AGENTS.md is not Nauro-generated" in result.output
+    assert "refused to modify" in result.output
 
 
 def test_init_agents_write_failure_is_nonfatal_after_registration(tmp_path, monkeypatch):
@@ -128,6 +128,34 @@ def test_init_agents_write_failure_is_nonfatal_after_registration(tmp_path, monk
     assert f"Project id: {matches[0][0]}" in result.output
     assert "project registration succeeded" in result.output
     assert "Traceback" not in result.output
+
+
+@pytest.mark.skipif(os.name == "nt", reason="chmod 000 does not block reads on Windows")
+def test_init_agents_read_failure_is_nonfatal_after_registration(tmp_path, monkeypatch):
+    """An unreadable AGENTS.md must not crash init after registration.
+
+    The ownership probe reads the existing file to decide whether it is
+    Nauro-generated; a permission error on that read is covered by the same
+    fail-soft contract as a failed write.
+    """
+    if os.geteuid() == 0:
+        pytest.skip("root ignores file permission bits")
+    monkeypatch.chdir(tmp_path)
+    agents_md = tmp_path / "AGENTS.md"
+    agents_md.write_bytes(b"# Hand-written rules\n")
+    agents_md.chmod(0)
+
+    try:
+        result = runner.invoke(app, ["init", "localproj"])
+    finally:
+        agents_md.chmod(0o644)
+
+    assert result.exit_code == 0, result.output
+    matches = registry.find_projects_by_name_v2("localproj")
+    assert len(matches) == 1
+    assert "project registration succeeded" in result.output
+    assert "Traceback" not in result.output
+    assert agents_md.read_bytes() == b"# Hand-written rules\n"
 
 
 # ── cloud mode ────────────────────────────────────────────────────────────────
@@ -203,6 +231,41 @@ def test_init_cloud_preserves_hand_authored_agents_md(tmp_path, monkeypatch):
     assert result.exit_code == 0, result.output
     assert (tmp_path / "AGENTS.md").read_bytes() == sentinel
     assert "existing AGENTS.md is not Nauro-generated" in result.output
+
+
+@pytest.mark.skipif(os.name == "nt", reason="symlink creation requires extra Windows privileges")
+def test_init_cloud_refuses_config_symlink_before_remote_create(tmp_path, monkeypatch):
+    """A planted .nauro/config.json symlink aborts before any remote call.
+
+    The refusal must precede project creation on the server: otherwise a
+    refused init leaves an orphaned cloud project behind. Pins exit 1, the
+    refusal message, zero create_project calls, and no registry entry.
+    """
+    _seed_token(monkeypatch, tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("NAURO_API_URL", "https://example.test")
+
+    outside = tmp_path / "outside-config.json"
+    outside.write_text("{}")
+    (tmp_path / ".nauro").mkdir()
+    (tmp_path / ".nauro" / "config.json").symlink_to(outside)
+
+    create_calls: list[str] = []
+
+    def _record_create(name):
+        create_calls.append(name)
+        raise AssertionError("create_project must not run after a symlink refusal")
+
+    monkeypatch.setattr("nauro.cli.commands.init.create_project", _record_create)
+
+    result = runner.invoke(app, ["init", "--cloud", "cloudproj"])
+
+    assert result.exit_code == 1
+    assert "refused to modify" in result.output
+    assert create_calls == []
+    assert registry.find_projects_by_name_v2("cloudproj") == []
+    assert (tmp_path / ".nauro" / "config.json").is_symlink()
+    assert outside.read_text() == "{}"
 
 
 def test_init_cloud_renders_server_error(tmp_path, monkeypatch):

--- a/packages/nauro/tests/test_note.py
+++ b/packages/nauro/tests/test_note.py
@@ -11,6 +11,7 @@ from typer.testing import CliRunner
 
 from nauro.cli.main import app
 from nauro.store.registry import register_project
+from nauro.templates.agents_md import generate_agents_md
 from nauro.templates.scaffolds import scaffold_project_store
 
 runner = CliRunner()
@@ -77,18 +78,41 @@ def test_note_decision_refreshes_all_associated_repos(tmp_path: Path, monkeypatc
         assert "Pick GraphQL over REST" in agents_md.read_text()
 
 
-def test_note_preserves_manual_section_across_regen(tmp_path: Path, monkeypatch):
-    """A `# Manual` section already in AGENTS.md survives the auto-regen."""
+def test_note_preserves_unmanaged_agents_md(tmp_path: Path, monkeypatch):
+    """An AGENTS.md without Nauro's markers stays byte-identical across note."""
     repo = tmp_path / "repo"
     repo.mkdir()
     store = register_project("myproj", [repo])
     scaffold_project_store("myproj", store)
     monkeypatch.chdir(repo)
 
-    # Seed AGENTS.md with a manual block, then trigger a regen via note.
-    (repo / "AGENTS.md").write_text(
-        "# AGENTS.md\n\n# Manual\n\nHand-written guidance the user wrote.\n"
+    # Marker-less seed: Nauro did not generate this file, so note must not
+    # rewrite it. Only `nauro sync` overwrites an unmanaged AGENTS.md.
+    sentinel = b"# AGENTS.md\n\n# Manual\n\nHand-written guidance the user wrote.\n"
+    (repo / "AGENTS.md").write_bytes(sentinel)
+
+    result = runner.invoke(app, ["note", "Adopt strict TypeScript"])
+    assert result.exit_code == 0, result.output
+
+    assert (repo / "AGENTS.md").read_bytes() == sentinel
+    assert "existing AGENTS.md is not Nauro-generated" in result.output
+    assert "left unchanged" in result.output
+
+
+def test_note_refreshes_nauro_generated_agents_md(tmp_path: Path, monkeypatch):
+    """A Nauro-generated AGENTS.md is still refreshed; `# Manual` survives."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    store = register_project("myproj", [repo])
+    scaffold_project_store("myproj", store)
+    monkeypatch.chdir(repo)
+
+    seeded = generate_agents_md(
+        "myproj",
+        "seed payload",
+        manual_section="Hand-written guidance the user wrote.",
     )
+    (repo / "AGENTS.md").write_text(seeded, encoding="utf-8")
 
     result = runner.invoke(app, ["note", "Adopt strict TypeScript"])
     assert result.exit_code == 0, result.output
@@ -96,6 +120,8 @@ def test_note_preserves_manual_section_across_regen(tmp_path: Path, monkeypatch)
     content = (repo / "AGENTS.md").read_text()
     assert "Adopt strict TypeScript" in content
     assert "Hand-written guidance the user wrote." in content
+    assert "seed payload" not in content
+    assert "Updated AGENTS.md" in result.output
 
 
 def test_note_warns_about_missing_repo_paths(tmp_path: Path, monkeypatch):

--- a/packages/nauro/tests/test_propose_decision_parity.py
+++ b/packages/nauro/tests/test_propose_decision_parity.py
@@ -390,7 +390,10 @@ def test_confirmed_regen_surfaces_tracked_agents_warning(seeded_repo, monkeypatc
     _pid, store_path = seeded_repo
     repo = Path.cwd()
     subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
-    (repo / "AGENTS.md").write_text("stale\n", encoding="utf-8")
+    # Seed a Nauro-generated AGENTS.md: only managed files are rewritten on
+    # the confirmed path, and only rewritten repos get git-hygiene checks.
+    warn_then_regen(store_path.name, store_path)
+    assert (repo / "AGENTS.md").is_file()
     subprocess.run(["git", "add", "AGENTS.md"], cwd=repo, check=True)
     monkeypatch.setattr(mcp_tools, "warn_then_regen", warn_then_regen)
 
@@ -403,3 +406,23 @@ def test_confirmed_regen_surfaces_tracked_agents_warning(seeded_repo, monkeypatc
 
     assert envelope["status"] == "confirmed"
     assert "AGENTS.md is tracked by git" in envelope["assessment"]
+
+
+def test_confirmed_regen_preserves_unmanaged_agents_md(seeded_repo, monkeypatch):
+    """A hand-written AGENTS.md survives a confirmed write; the envelope warns."""
+    _pid, store_path = seeded_repo
+    repo = Path.cwd()
+    sentinel = b"# Hand-written agent rules\n\nKeep these instructions.\n"
+    (repo / "AGENTS.md").write_bytes(sentinel)
+    monkeypatch.setattr(mcp_tools, "warn_then_regen", warn_then_regen)
+
+    envelope = tool_propose_decision(
+        store_path,
+        title="Record a decision without touching agent rules",
+        rationale="Hand-written AGENTS.md files must survive decision writes.",
+        confidence="high",
+    )
+
+    assert envelope["status"] == "confirmed"
+    assert (repo / "AGENTS.md").read_bytes() == sentinel
+    assert "existing AGENTS.md is not Nauro-generated" in envelope["assessment"]

--- a/packages/nauro/tests/test_read_encoding.py
+++ b/packages/nauro/tests/test_read_encoding.py
@@ -111,6 +111,8 @@ def test_parse_preserved_sections_survives_non_utf8_manual(tmp_path: Path):
 def test_regenerate_survives_poisoned_existing_agents_md(tmp_path: Path):
     # Full sync path: a poisoned # Manual section in an existing AGENTS.md must
     # not crash regeneration, and the manual text must survive the round-trip.
+    # The seed carries no generation markers, so the sync-only overwrite grant
+    # is required to exercise the rewrite.
     repo = tmp_path / "repo"
     repo.mkdir()
     store = register_project("myproj", [repo])
@@ -119,7 +121,7 @@ def test_regenerate_survives_poisoned_existing_agents_md(tmp_path: Path):
     agents_md = repo / "AGENTS.md"
     agents_md.write_bytes(b"# AGENTS.md\n\nOld auto content\n\n# Manual\n\nKeep caf\xe9 note\n")
 
-    updated = regenerate_agents_md_for_project("myproj", store)
+    updated = regenerate_agents_md_for_project("myproj", store, overwrite_unmanaged=True)
 
     assert repo in updated
     regenerated = read_text_lenient(agents_md)

--- a/packages/nauro/tests/test_setup_extended.py
+++ b/packages/nauro/tests/test_setup_extended.py
@@ -985,13 +985,13 @@ def test_setup_all_regenerates_agents_md_exactly_once(tmp_path: Path, monkeypatc
     monkeypatch.chdir(repo)
 
     calls: list[tuple] = []
-    real = setup_mod.regenerate_agents_md_for_project
+    real = setup_mod.warn_then_regen
 
-    def _counting(project_key, store):
+    def _counting(project_key, store, **kwargs):
         calls.append((project_key, store))
-        return real(project_key, store)
+        return real(project_key, store, **kwargs)
 
-    monkeypatch.setattr(setup_mod, "regenerate_agents_md_for_project", _counting)
+    monkeypatch.setattr(setup_mod, "warn_then_regen", _counting)
 
     result = runner.invoke(app, ["setup", "all"])
     assert result.exit_code == 0, result.output
@@ -1012,8 +1012,8 @@ def test_setup_all_remove_does_not_write_agents_md(tmp_path: Path, monkeypatch):
     calls: list[tuple] = []
     monkeypatch.setattr(
         setup_mod,
-        "regenerate_agents_md_for_project",
-        lambda *a: calls.append(a) or [],
+        "warn_then_regen",
+        lambda *a, **k: calls.append(a) or [],
     )
 
     runner.invoke(app, ["setup", "all"])


### PR DESCRIPTION
## Why

Most write paths that refresh AGENTS.md (setup, adopt, note, questions migrate, propose_decision) could overwrite a hand-written AGENTS.md the user never asked Nauro to manage; init and attach already preserved via an opt-in that now becomes the default for everyone. A pre-planted symlink at AGENTS.md could also redirect a write outside the checkout on the paths that rewrote unconditionally. Sync is the only surface where an unconditional rewrite is the user's stated intent.

## What changed

- Ownership default flip: `regenerate_agents_md_for_project` and `warn_then_regen` now preserve any AGENTS.md that does not carry Nauro's generation markers. The old `preserve_unmanaged` opt-in is replaced by an `overwrite_unmanaged` opt-out that only `nauro sync` passes; init and attach drop the now-redundant kwarg, and note, questions, setup, and the MCP `propose_decision` adapter flip to preserving via the default.
- One warning loop: `warn_then_regen` folds missing-repo, symlink-refusal, and not-Nauro-generated warnings into a single per-repo pass, so each skipped path warns exactly once through the caller's channel (CLI stderr, setup status lines, or the propose_decision envelope), and a read failure on the ownership probe stays inside the fail-soft contract instead of raising after registration.
- Symlink safety: the regen loop skips a symlinked AGENTS.md before any other check, including under the sync overwrite grant, and `remove_generated_agents_md` refuses a symlinked target on teardown instead of unlinking or rewriting through it.
- `setup claude-code` and `setup all` route regen through `warn_then_regen`, moving their inline git-hygiene loops into the helper so all surfaces share one warning shape.
- Docs: the sync help text and the README now state that sync is the one command that overwrites a non-Nauro AGENTS.md, and that a `# Manual` section survives the rewrite.
- Ride-along: a test pins that `nauro init --cloud` refuses a planted `.nauro/config.json` symlink before creating the remote project, so a refused init cannot leave an orphaned cloud project behind.

## Deferred

No overwrite escape hatch was added to setup, init, or note; after the preserve warning, adopting the managed file is a deliberate `nauro sync`. If a per-command force flag turns out to be wanted, it is a follow-up.

## Test plan

- Full suites: `packages/nauro/tests/` 1758 passed / 10 skipped, `packages/nauro-core/tests/` 1073 passed; `ruff check` and `ruff format --check` clean.
- New ownership tests: helper default preserves a marker-less AGENTS.md byte-identical; `overwrite_unmanaged=True` replaces it; a symlinked AGENTS.md is refused even under the overwrite grant; `setup all`, `nauro note`, and `propose_decision` each preserve a hand-written file and surface the warning on their own channel; a Nauro-generated file is still refreshed by note with its `# Manual` section intact; a read-permission failure on an existing AGENTS.md stays non-fatal after registration on the fail-soft init path.
- The existing sync manual-section test is unmodified and still passes, pinning the sync overwrite path.
- 13 of the new or adjusted tests were confirmed failing against the unmodified source tree before the change.
