### PR TITLE
Preserve user Codex config formatting and refuse symlinked user files

### DIFF
--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "filelock>=3.20.3",
     "posthog>=7.0,<8.0",
     "tomli>=2.0; python_version<'3.11'",
-    "tomli-w>=1.0",
+    "tomlkit>=0.13.2",
 ]
 
 [project.optional-dependencies]

--- a/packages/nauro/src/nauro/cli/commands/setup.py
+++ b/packages/nauro/src/nauro/cli/commands/setup.py
@@ -14,9 +14,13 @@ import functools
 import json
 import shutil
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
+import tomlkit
 import typer
+from tomlkit.exceptions import ParseError as TOMLParseError
+from tomlkit.items import InlineTable
 
 from nauro.cli import utils as cli_utils
 from nauro.cli._codex_hooks import (
@@ -30,6 +34,7 @@ from nauro.cli._codex_hooks import (
 from nauro.cli.git_hygiene import public_surface_git_warnings
 from nauro.cli.utils import _resolve_project_entry, resolve_target_project
 from nauro.constants import CLAUDE_MD, NAURO_BLOCK_END, NAURO_BLOCK_START
+from nauro.store._atomic import atomic_write_text
 from nauro.store.reader import read_text_lenient
 from nauro.store.registry import (
     RegistrySchemaError,
@@ -38,16 +43,9 @@ from nauro.store.registry import (
     load_registry_v2,
 )
 from nauro.store.resolution import resolve_from_cwd
-from nauro.store.write_safety import find_symlink
+from nauro.store.write_safety import find_file_symlink, find_symlink
 from nauro.templates.agents_md import remove_generated_agents_md
 from nauro.templates.agents_md_regen import warn_then_regen
-
-if sys.version_info >= (3, 11):
-    import tomllib
-else:
-    import tomli as tomllib
-
-import tomli_w
 
 setup_app = typer.Typer(help="Configure tool integrations.")
 
@@ -307,6 +305,9 @@ def _prune_redundant_user_scope_mcp() -> str | None:
     config_path = Path.home() / ".claude.json"
     if not config_path.exists():
         return None
+    refusal = find_file_symlink(config_path)
+    if refusal is not None:
+        return f"  skipped user-scope prune: {refusal.message}"
     try:
         config = json.loads(config_path.read_text(encoding="utf-8"))
     except UnicodeDecodeError:
@@ -478,6 +479,36 @@ def _default_codex_config_path() -> Path:
     return Path.home() / ".codex" / "config.toml"
 
 
+@dataclass(frozen=True)
+class _CodexNauroEntry:
+    """Typed view of the ``[mcp_servers.nauro]`` keys Nauro owns.
+
+    Only ``command`` and ``args`` belong to Nauro; any other keys the user
+    added to the entry (timeouts, env, ...) are never touched. A field is
+    None when the underlying key is missing or off-shape, so each owned key
+    is compared and rewritten independently: a key whose value already
+    matches stays untouched, preserving its formatting and comments.
+    """
+
+    command: str | None
+    args: list[str] | None
+
+
+def _parse_codex_nauro_entry(entry: object) -> _CodexNauroEntry:
+    """Parse an existing ``mcp_servers.nauro`` value into the typed view."""
+    if not isinstance(entry, dict):
+        return _CodexNauroEntry(command=None, args=None)
+    command = entry.get("command")
+    args = entry.get("args")
+    parsed_args: list[str] | None = None
+    if isinstance(args, list) and all(isinstance(item, str) for item in args):
+        parsed_args = [str(item) for item in args]
+    return _CodexNauroEntry(
+        command=str(command) if isinstance(command, str) else None,
+        args=parsed_args,
+    )
+
+
 def _configure_codex(
     *,
     remove: bool,
@@ -485,6 +516,13 @@ def _configure_codex(
     clear_user_scope: bool = True,
 ) -> str:
     """Add or remove the Nauro MCP entry in ``~/.codex/config.toml``.
+
+    The file is hand-maintained user config, so edits go through tomlkit:
+    comments, formatting, and user-added keys inside the nauro entry survive,
+    and only the ``command``/``args`` keys Nauro owns are rewritten. A
+    config.toml that is itself a symlink is refused (a dotfile manager may
+    own the real file); a symlinked parent directory works. Writes are
+    atomic, preserve permission bits, and are skipped when nothing changes.
 
     ``clear_user_scope`` gates the remove path: when False, the codex MCP
     entry is preserved because other registered nauro projects still depend
@@ -498,36 +536,81 @@ def _configure_codex(
             f"Codex: preserved nauro entry in {config_path} (other nauro projects still registered)"
         )
 
-    if config_path.exists():
-        try:
-            with config_path.open("rb") as f:
-                config = tomllib.load(f)
-        except tomllib.TOMLDecodeError as exc:
-            return f"Codex: could not parse {config_path} - {exc}"
-    else:
-        config = {}
+    refusal = find_file_symlink(config_path)
+    if refusal is not None:
+        return f"Codex: {refusal.message}"
 
-    servers = config.setdefault("mcp_servers", {})
+    original: bytes | None
+    if config_path.exists():
+        original = config_path.read_bytes()
+        try:
+            document = tomlkit.parse(original.decode("utf-8"))
+        except UnicodeDecodeError:
+            return f"Codex: could not parse {config_path} - not valid UTF-8"
+        except TOMLParseError as exc:
+            return f"Codex: could not parse {config_path} - {exc}"
+    elif remove:
+        return f"Codex: no nauro entry to remove in {config_path}"
+    else:
+        original = None
+        document = tomlkit.document()
+
+    servers = document.get("mcp_servers")
     # A hand-edited config.toml could define mcp_servers as a non-table (e.g. a
     # string); mutating it would raise. Skip with a clear message, not a crash.
-    if not isinstance(servers, dict):
+    if servers is not None and not isinstance(servers, dict):
         if remove:
             return f"Codex: no nauro entry to remove in {config_path}"
         return f"Codex: mcp_servers in {config_path} is not a table, skipped"
 
     if remove:
-        if "nauro" in servers:
-            del servers["nauro"]
-            if not servers:
-                config.pop("mcp_servers", None)
-            config_path.write_bytes(tomli_w.dumps(config).encode("utf-8"))
-            return f"Codex: removed nauro from {config_path}"
-        return f"Codex: no nauro entry to remove in {config_path}"
+        if servers is None or "nauro" not in servers:
+            return f"Codex: no nauro entry to remove in {config_path}"
+        # The emptied parent table is deliberately left in place: popping it
+        # would rewrite user formatting beyond the entry being removed.
+        del servers["nauro"]
+        status = f"Codex: removed nauro from {config_path}"
+    else:
+        desired = _CodexNauroEntry(command=_find_nauro_command(), args=["serve", "--stdio"])
+        if servers is None:
+            servers = tomlkit.table(is_super_table=False)
+            document["mcp_servers"] = servers
+        entry = servers.get("nauro")
+        current = _parse_codex_nauro_entry(entry)
+        if current == desired:
+            return f"Codex: nauro already configured in {config_path}"
+        if isinstance(entry, dict):
+            # Per-key update: a key whose value already matches keeps its
+            # formatting and comments (e.g. a multiline args array).
+            if current.command != desired.command:
+                entry["command"] = desired.command
+            if current.args != desired.args:
+                entry["args"] = desired.args
+        elif isinstance(servers, InlineTable):
+            # A block table nested inside an inline parent renders invalid
+            # TOML; match the user's inline style instead.
+            inline = tomlkit.inline_table()
+            inline["command"] = desired.command
+            inline["args"] = desired.args
+            servers["nauro"] = inline
+        else:
+            table = tomlkit.table()
+            table["command"] = desired.command
+            table["args"] = desired.args
+            servers["nauro"] = table
+            # Appended without a leading blank line: a reparse attributes the
+            # separator to the preceding entry, which would strand a stray
+            # blank line once a later remove deletes the block.
+            table.trivia.indent = ""
+        status = f"Codex: wrote nauro to {config_path}"
 
-    servers["nauro"] = {"command": _find_nauro_command(), "args": ["serve", "--stdio"]}
-    config_path.parent.mkdir(parents=True, exist_ok=True)
-    config_path.write_bytes(tomli_w.dumps(config).encode("utf-8"))
-    return f"Codex: wrote nauro to {config_path}"
+    rendered = tomlkit.dumps(document)
+    if original is not None and rendered.encode("utf-8") == original:
+        return status
+    # newline="\n" is load-bearing: tomlkit output carries the file's original
+    # line endings as literal characters, so translation would corrupt CRLF.
+    atomic_write_text(config_path, rendered, newline="\n")
+    return status
 
 
 def _nearest_codex_hooks_repo(start: Path) -> Path | None:
@@ -655,6 +738,9 @@ def _claude_agent_dir() -> Path:
 
 
 def _materialize_skill_file(target: Path, content: str) -> str:
+    refusal = find_file_symlink(target)
+    if refusal is not None:
+        return f"  {refusal.message}"
     target.parent.mkdir(parents=True, exist_ok=True)
     target.write_text(content, encoding="utf-8")
     return f"  wrote {target}"
@@ -667,6 +753,9 @@ def _remove_skill_file(target: Path, *, stop_above: Path) -> str:
     (``~/.claude/skills/``, ``<repo>/.cursor/rules/``, etc.) or — worse —
     keep going if those happen to be empty after MCP config also got removed.
     """
+    refusal = find_file_symlink(target)
+    if refusal is not None:
+        return f"  {refusal.message}"
     if not target.is_file():
         return f"  no skill at {target}"
     target.unlink()
@@ -846,6 +935,10 @@ def materialize_agents(
     results: list[str] = []
     for name in AGENT_NAMES:
         target = base / f"{name}.md"
+        refusal = find_file_symlink(target)
+        if refusal is not None:
+            results.append(f"  {refusal.message}")
+            continue
         bundled = render_agent("claude_code", name)
         if remove:
             if not target.is_file():
@@ -868,6 +961,10 @@ def materialize_agents(
                 results.append(f"  overwrote {target}")
             else:
                 backup = target.parent / (target.name + ".bak")
+                backup_refusal = find_file_symlink(backup)
+                if backup_refusal is not None:
+                    results.append(f"  {backup_refusal.message}")
+                    continue
                 backup.write_text(current, encoding="utf-8")
                 target.write_text(bundled, encoding="utf-8")
                 results.append(f"  updated {target} (previous saved to {backup.name})")

--- a/packages/nauro/src/nauro/store/write_safety.py
+++ b/packages/nauro/src/nauro/store/write_safety.py
@@ -1,14 +1,24 @@
-"""Symlink refusal for repo-scoped writes.
+"""Symlink refusal for repo-scoped and user-global writes.
 
-A cloned repository is untrusted content: a symlink pre-planted at a path
-Nauro mutates (a write, a read-before-mutate, an unlink, a directory prune)
-redirects the operation outside the repo. The rule is that repo-scoped
+Repo scope: a cloned repository is untrusted content, so a symlink pre-planted
+at a path Nauro mutates (a write, a read-before-mutate, an unlink, a
+directory prune) redirects the operation outside the repo. Repo-scoped
 mutations never traverse a symlink, covering directory components (``.nauro``,
-``.cursor``, ``.claude``, ``.codex`` as symlinks) and the final file. On
-detection the writer refuses and warns, naming the path; it never writes
-through the link and never replaces the link. The repo root itself is trusted
-(the user's own choice); everything below it is checkout content. The
-guarantee covers pre-planted symlinks, not TOCTOU races.
+``.cursor``, ``.claude``, ``.codex`` as symlinks) and the final file
+(:func:`find_symlink`). The repo root itself is trusted (the user's own
+choice); everything below it is checkout content.
+
+User scope: files under the user's home directory (``~/.codex/config.toml``,
+``~/.claude.json``, skill and agent files) are the user's own content, but
+replacing a symlinked file would sever it from the real file a dotfile
+manager owns. User-global mutations refuse only when the final path component
+is itself a symlink (:func:`find_file_symlink`); symlinked parent directories
+are expected and allowed; dotfile managers routinely symlink whole config
+directories.
+
+On detection the writer refuses and warns, naming the path; it never writes
+through the link and never replaces the link. The guarantee covers
+pre-planted symlinks, not TOCTOU races.
 """
 
 from __future__ import annotations
@@ -39,6 +49,34 @@ class SymlinkRefusal:
             f"refused to modify {self.target}: {self.link} is a symlink; "
             "Nauro does not write through symlinks in a repo checkout"
         )
+
+
+@dataclass(frozen=True)
+class UserSymlinkRefusal:
+    """A refused user-global mutation: ``target`` itself is a symlink."""
+
+    target: Path
+
+    @property
+    def message(self) -> str:
+        return (
+            f"refused to modify {self.target}: it is a symlink; "
+            "Nauro does not replace symlinked user files "
+            "(a dotfile manager may own the real file)"
+        )
+
+
+def find_file_symlink(path: Path) -> UserSymlinkRefusal | None:
+    """Return a refusal when ``path`` itself is a symlink, else None.
+
+    Exactly one lstat-based check on the final component; parent directories
+    are deliberately not walked, so a symlinked ``~/.codex`` or ``~/.claude``
+    keeps working. ``Path.is_symlink`` never follows the link, so a dangling
+    symlink is still refused. A missing path is safe.
+    """
+    if path.is_symlink():
+        return UserSymlinkRefusal(target=path)
+    return None
 
 
 def find_symlink(repo_root: Path, relative: str) -> SymlinkRefusal | None:

--- a/packages/nauro/tests/test_setup_user_write_safety.py
+++ b/packages/nauro/tests/test_setup_user_write_safety.py
@@ -1,0 +1,436 @@
+"""Tests for user-global write safety in ``nauro setup``.
+
+Two guarantees for files under the user's home directory:
+
+1. ``~/.codex/config.toml`` is hand-maintained user config: edits preserve
+   comments, formatting, and user-added keys (tomlkit), only mutate the
+   ``command``/``args`` keys Nauro owns, skip the write entirely when nothing
+   would change, and go through the atomic writer (permission bits survive).
+2. A user-global final target that is itself a symlink is refused (a dotfile
+   manager may own the real file), while symlinked parent directories keep
+   working (dotfile managers routinely symlink whole config directories).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+import tomlkit
+
+from nauro.cli.commands.setup import (
+    _configure_codex,
+    _find_nauro_command,
+    _materialize_skill_file,
+    _prune_redundant_user_scope_mcp,
+    _remove_skill_file,
+    materialize_agents,
+)
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
+
+symlinks_required = pytest.mark.skipif(
+    os.name == "nt", reason="symlink creation requires extra Windows privileges"
+)
+
+# A commented, oddly formatted config with a pre-existing [mcp_servers] header
+# and a sibling entry. Every byte outside the nauro entry must survive edits.
+COMMENTED_SEED = (
+    "# Codex configuration\n"
+    'model = "gpt-5"        # pinned\n'
+    "\n"
+    "# my servers\n"
+    "[mcp_servers]\n"
+    "\n"
+    "[mcp_servers.other]\n"
+    'command = "other-cmd"   # keep\n'
+    'args = [ "a",   "b" ]\n'
+)
+
+MTIME_SENTINEL = 1_000_000_000
+
+
+def _seed_config(tmp_path: Path, content: str) -> Path:
+    config_path = tmp_path / ".codex" / "config.toml"
+    config_path.parent.mkdir()
+    config_path.write_text(content, encoding="utf-8")
+    return config_path
+
+
+# ─── formatting preservation (tomlkit) ───────────────────────────────────────
+
+
+def test_codex_add_preserves_commented_config_outside_nauro_entry(tmp_path: Path):
+    config_path = _seed_config(tmp_path, COMMENTED_SEED)
+
+    msg = _configure_codex(remove=False, config_path=config_path)
+
+    assert "wrote nauro" in msg
+    text = config_path.read_text(encoding="utf-8")
+    # Everything before the appended entry is byte-identical to the seed.
+    assert text.startswith(COMMENTED_SEED)
+    assert "[mcp_servers.nauro]" in text[len(COMMENTED_SEED) :]
+    data = tomllib.loads(text)
+    assert data["mcp_servers"]["other"]["args"] == ["a", "b"]
+    assert data["mcp_servers"]["nauro"]["args"] == ["serve", "--stdio"]
+
+
+def test_codex_add_then_remove_is_byte_identical_with_existing_table(tmp_path: Path):
+    config_path = _seed_config(tmp_path, COMMENTED_SEED)
+
+    _configure_codex(remove=False, config_path=config_path)
+    msg = _configure_codex(remove=True, config_path=config_path)
+
+    assert "removed nauro" in msg
+    assert config_path.read_bytes() == COMMENTED_SEED.encode("utf-8")
+
+
+def test_codex_add_then_remove_on_tableless_file_leaves_empty_header(tmp_path: Path):
+    original = '# hello\nmodel = "gpt-5"\n'
+    config_path = _seed_config(tmp_path, original)
+
+    _configure_codex(remove=False, config_path=config_path)
+    _configure_codex(remove=True, config_path=config_path)
+
+    # The parent table was created by the add and is deliberately not popped
+    # on remove; all pre-existing content is byte-identical.
+    assert config_path.read_text(encoding="utf-8") == original + "\n[mcp_servers]\n"
+
+
+def test_codex_second_identical_add_skips_render_and_write(tmp_path: Path):
+    config_path = tmp_path / ".codex" / "config.toml"
+    _configure_codex(remove=False, config_path=config_path)
+    before = config_path.read_bytes()
+    os.utime(config_path, (MTIME_SENTINEL, MTIME_SENTINEL))
+
+    msg = _configure_codex(remove=False, config_path=config_path)
+
+    assert msg == f"Codex: nauro already configured in {config_path}"
+    assert config_path.read_bytes() == before
+    assert config_path.stat().st_mtime == MTIME_SENTINEL
+
+
+def test_codex_remove_without_entry_leaves_commented_file_untouched(tmp_path: Path):
+    config_path = _seed_config(tmp_path, COMMENTED_SEED)
+    os.utime(config_path, (MTIME_SENTINEL, MTIME_SENTINEL))
+
+    msg = _configure_codex(remove=True, config_path=config_path)
+
+    assert "no nauro entry to remove" in msg
+    assert config_path.read_bytes() == COMMENTED_SEED.encode("utf-8")
+    assert config_path.stat().st_mtime == MTIME_SENTINEL
+
+
+def test_codex_add_refuses_invalid_utf8_without_writing(tmp_path: Path):
+    raw = b'\xff\xfemodel = "x"\n'
+    config_path = tmp_path / ".codex" / "config.toml"
+    config_path.parent.mkdir()
+    config_path.write_bytes(raw)
+
+    msg = _configure_codex(remove=False, config_path=config_path)
+
+    assert msg == f"Codex: could not parse {config_path} - not valid UTF-8"
+    assert config_path.read_bytes() == raw
+
+
+def test_codex_remove_refuses_invalid_utf8_without_writing(tmp_path: Path):
+    raw = b'\xff\xfemodel = "x"\n'
+    config_path = tmp_path / ".codex" / "config.toml"
+    config_path.parent.mkdir()
+    config_path.write_bytes(raw)
+
+    msg = _configure_codex(remove=True, config_path=config_path)
+
+    assert msg == f"Codex: could not parse {config_path} - not valid UTF-8"
+    assert config_path.read_bytes() == raw
+
+
+def test_codex_new_entry_renders_as_standard_table_not_inline(tmp_path: Path):
+    config_path = tmp_path / ".codex" / "config.toml"
+
+    msg = _configure_codex(remove=False, config_path=config_path)
+
+    assert "wrote nauro" in msg
+    text = config_path.read_text(encoding="utf-8")
+    assert "[mcp_servers.nauro]" in text
+    assert "nauro = {" not in text
+    data = tomllib.loads(text)
+    assert data["mcp_servers"]["nauro"]["args"] == ["serve", "--stdio"]
+
+
+def test_codex_command_drift_rewrite_preserves_user_keys_and_comments(tmp_path: Path):
+    """Targeted key update: a drifted command is rewritten in place, and the
+    user's own keys and comments inside the nauro entry survive."""
+    seed = (
+        "[mcp_servers.nauro]\n"
+        "# tuned for my machine\n"
+        'command = "/old/dead/venv/bin/nauro"\n'
+        'args = ["serve", "--stdio"]\n'
+        "startup_timeout_ms = 20000\n"
+    )
+    config_path = _seed_config(tmp_path, seed)
+
+    msg = _configure_codex(remove=False, config_path=config_path)
+
+    assert "wrote nauro" in msg
+    text = config_path.read_text(encoding="utf-8")
+    assert "# tuned for my machine" in text
+    entry = tomllib.loads(text)["mcp_servers"]["nauro"]
+    assert entry["startup_timeout_ms"] == 20000
+    assert entry["command"] == _find_nauro_command()
+    assert entry["command"] != "/old/dead/venv/bin/nauro"
+    assert entry["args"] == ["serve", "--stdio"]
+
+
+def test_codex_command_only_drift_leaves_matching_args_bytes_untouched(tmp_path: Path):
+    """Per-key update: when only the command drifted, an args array whose
+    value already matches is not rewritten, so its multiline layout and
+    inline comment survive byte-for-byte."""
+    args_block = 'args = [\n  "serve", # transport pinned\n  "--stdio",\n]\n'
+    seed = "[mcp_servers.nauro]\n" + 'command = "/old/dead/venv/bin/nauro"\n' + args_block
+    config_path = _seed_config(tmp_path, seed)
+
+    msg = _configure_codex(remove=False, config_path=config_path)
+
+    assert "wrote nauro" in msg
+    text = config_path.read_text(encoding="utf-8")
+    assert args_block in text
+    entry = tomlkit.parse(text)["mcp_servers"]["nauro"]
+    assert entry["command"] == _find_nauro_command()
+    assert list(entry["args"]) == ["serve", "--stdio"]
+
+
+# ─── inline-table mcp_servers parents ────────────────────────────────────────
+
+
+# An inline `mcp_servers = { ... }` is valid hand-written TOML. Nesting a
+# block table inside it renders invalid TOML, so entry creation must match
+# the user's inline style. Every test reparses the written file with tomlkit
+# to prove the config was not corrupted.
+
+
+def test_codex_add_into_empty_inline_mcp_servers(tmp_path: Path):
+    config_path = _seed_config(tmp_path, "mcp_servers = {}\n")
+
+    msg = _configure_codex(remove=False, config_path=config_path)
+
+    assert "wrote nauro" in msg
+    text = config_path.read_text(encoding="utf-8")
+    reparsed = tomlkit.parse(text)
+    assert reparsed["mcp_servers"]["nauro"]["command"] == _find_nauro_command()
+    assert list(reparsed["mcp_servers"]["nauro"]["args"]) == ["serve", "--stdio"]
+    # The parent kept its inline style: no [mcp_servers] block header appeared.
+    assert text.startswith("mcp_servers = {")
+    assert "[mcp_servers" not in text
+
+
+def test_codex_add_into_inline_mcp_servers_preserves_sibling(tmp_path: Path):
+    seed = 'mcp_servers = { other = { command = "c", args = [] } }\n'
+    config_path = _seed_config(tmp_path, seed)
+
+    msg = _configure_codex(remove=False, config_path=config_path)
+
+    assert "wrote nauro" in msg
+    text = config_path.read_text(encoding="utf-8")
+    assert '{ command = "c", args = [] }' in text
+    reparsed = tomlkit.parse(text)
+    assert reparsed["mcp_servers"]["other"]["command"] == "c"
+    assert list(reparsed["mcp_servers"]["other"]["args"]) == []
+    assert reparsed["mcp_servers"]["nauro"]["command"] == _find_nauro_command()
+    assert list(reparsed["mcp_servers"]["nauro"]["args"]) == ["serve", "--stdio"]
+
+
+def test_codex_add_replaces_non_table_nauro_inside_inline_parent(tmp_path: Path):
+    config_path = _seed_config(tmp_path, 'mcp_servers = { nauro = "weird" }\n')
+
+    msg = _configure_codex(remove=False, config_path=config_path)
+
+    assert "wrote nauro" in msg
+    text = config_path.read_text(encoding="utf-8")
+    reparsed = tomlkit.parse(text)
+    assert reparsed["mcp_servers"]["nauro"]["command"] == _find_nauro_command()
+    assert list(reparsed["mcp_servers"]["nauro"]["args"]) == ["serve", "--stdio"]
+    assert "[mcp_servers" not in text
+
+
+def test_codex_add_then_remove_on_inline_mcp_servers_round_trips(tmp_path: Path):
+    seed = "mcp_servers = {}\n"
+    config_path = _seed_config(tmp_path, seed)
+
+    _configure_codex(remove=False, config_path=config_path)
+    msg = _configure_codex(remove=True, config_path=config_path)
+
+    assert "removed nauro" in msg
+    text = config_path.read_text(encoding="utf-8")
+    reparsed = tomlkit.parse(text)
+    assert "nauro" not in reparsed["mcp_servers"]
+    # The inline parent survives the round trip byte-for-byte.
+    assert text == seed
+
+
+# ─── symlink refusal on user-global final targets ────────────────────────────
+
+
+@symlinks_required
+def test_codex_add_refuses_symlinked_config(tmp_path: Path):
+    real = tmp_path / "real-config.toml"
+    seed = '[mcp_servers.other]\ncommand = "c"\nargs = []\n'
+    real.write_text(seed, encoding="utf-8")
+    link = tmp_path / ".codex" / "config.toml"
+    link.parent.mkdir()
+    link.symlink_to(real)
+
+    msg = _configure_codex(remove=False, config_path=link)
+
+    assert msg.startswith(f"Codex: refused to modify {link}")
+    assert "symlink" in msg
+    assert link.is_symlink()
+    assert real.read_text(encoding="utf-8") == seed
+
+
+@symlinks_required
+def test_codex_remove_refuses_symlinked_config(tmp_path: Path):
+    real = tmp_path / "real-config.toml"
+    seed = '[mcp_servers.nauro]\ncommand = "nauro"\nargs = ["serve", "--stdio"]\n'
+    real.write_text(seed, encoding="utf-8")
+    link = tmp_path / ".codex" / "config.toml"
+    link.parent.mkdir()
+    link.symlink_to(real)
+
+    msg = _configure_codex(remove=True, config_path=link)
+
+    assert msg.startswith(f"Codex: refused to modify {link}")
+    assert link.is_symlink()
+    assert real.read_text(encoding="utf-8") == seed
+
+
+@symlinks_required
+def test_codex_writes_through_symlinked_parent_dir(tmp_path: Path):
+    """A symlinked ~/.codex directory is the dotfile-manager layout and must
+    keep working: the write lands through the resolved directory."""
+    real_dir = tmp_path / "dotfiles" / "codex"
+    real_dir.mkdir(parents=True)
+    codex_dir = tmp_path / ".codex"
+    codex_dir.symlink_to(real_dir, target_is_directory=True)
+    config_path = codex_dir / "config.toml"
+
+    msg = _configure_codex(remove=False, config_path=config_path)
+
+    assert "wrote nauro" in msg
+    assert codex_dir.is_symlink()
+    with (real_dir / "config.toml").open("rb") as f:
+        data = tomllib.load(f)
+    assert data["mcp_servers"]["nauro"]["args"] == ["serve", "--stdio"]
+
+
+@symlinks_required
+def test_prune_skips_symlinked_claude_json(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    real = tmp_path / "dotfiles-claude.json"
+    raw = json.dumps({"mcpServers": {"nauro": {"type": "http", "url": "https://mcp.nauro.ai"}}})
+    real.write_text(raw, encoding="utf-8")
+    (tmp_path / ".claude.json").symlink_to(real)
+
+    msg = _prune_redundant_user_scope_mcp()
+
+    assert msg is not None
+    assert msg.startswith("  skipped user-scope prune: refused to modify")
+    assert (tmp_path / ".claude.json").is_symlink()
+    assert real.read_text(encoding="utf-8") == raw
+
+
+@symlinks_required
+def test_skill_add_refuses_symlinked_target(tmp_path: Path):
+    real = tmp_path / "real-skill.md"
+    real.write_text("original", encoding="utf-8")
+    target = tmp_path / "skills" / "nauro-adopt" / "SKILL.md"
+    target.parent.mkdir(parents=True)
+    target.symlink_to(real)
+
+    line = _materialize_skill_file(target, "new body")
+
+    assert "refused to modify" in line
+    assert target.is_symlink()
+    assert real.read_text(encoding="utf-8") == "original"
+
+
+@symlinks_required
+def test_skill_remove_refuses_symlinked_target(tmp_path: Path):
+    real = tmp_path / "real-skill.md"
+    real.write_text("original", encoding="utf-8")
+    base = tmp_path / "skills"
+    target = base / "nauro-adopt" / "SKILL.md"
+    target.parent.mkdir(parents=True)
+    target.symlink_to(real)
+
+    line = _remove_skill_file(target, stop_above=base)
+
+    assert "refused to modify" in line
+    assert target.is_symlink()
+    assert real.read_text(encoding="utf-8") == "original"
+
+
+@symlinks_required
+def test_skill_writes_through_symlinked_parent_dir(tmp_path: Path):
+    real_dir = tmp_path / "dotfiles" / "skills"
+    real_dir.mkdir(parents=True)
+    base = tmp_path / "skills"
+    base.symlink_to(real_dir, target_is_directory=True)
+    target = base / "nauro-adopt" / "SKILL.md"
+
+    line = _materialize_skill_file(target, "body")
+
+    assert line == f"  wrote {target}"
+    assert base.is_symlink()
+    assert (real_dir / "nauro-adopt" / "SKILL.md").read_text(encoding="utf-8") == "body"
+
+
+@symlinks_required
+def test_agent_materialization_refuses_symlinked_target(tmp_path: Path, monkeypatch):
+    from nauro.agents import AGENT_NAMES
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    base = tmp_path / ".claude" / "agents"
+    base.mkdir(parents=True)
+    real = tmp_path / "real-agent.md"
+    real.write_text("mine", encoding="utf-8")
+    linked = base / f"{AGENT_NAMES[0]}.md"
+    linked.symlink_to(real)
+
+    add_lines = materialize_agents("claude_code", remove=False)
+
+    add_refusals = [line for line in add_lines if "refused to modify" in line]
+    assert len(add_refusals) == 1
+    assert str(linked) in add_refusals[0]
+    assert linked.is_symlink()
+    assert real.read_text(encoding="utf-8") == "mine"
+    for name in AGENT_NAMES[1:]:
+        assert (base / f"{name}.md").is_file()
+
+    remove_lines = materialize_agents("claude_code", remove=True)
+
+    remove_refusals = [line for line in remove_lines if "refused to modify" in line]
+    assert len(remove_refusals) == 1
+    assert linked.is_symlink()
+    assert real.read_text(encoding="utf-8") == "mine"
+
+
+# ─── permission preservation through the atomic write ───────────────────────
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits")
+def test_codex_write_preserves_permission_bits(tmp_path: Path):
+    seed = '[mcp_servers.nauro]\ncommand = "/stale/nauro"\nargs = ["serve", "--stdio"]\n'
+    config_path = _seed_config(tmp_path, seed)
+    config_path.chmod(0o640)
+
+    msg = _configure_codex(remove=False, config_path=config_path)
+
+    assert "wrote nauro" in msg
+    assert oct(config_path.stat().st_mode & 0o777) == "0o640"

--- a/packages/nauro/tests/test_write_safety.py
+++ b/packages/nauro/tests/test_write_safety.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import pytest
 
-from nauro.store.write_safety import SymlinkRefusal, find_symlink
+from nauro.store.write_safety import SymlinkRefusal, find_file_symlink, find_symlink
 
 pytestmark = pytest.mark.skipif(
     os.name == "nt", reason="symlink creation requires extra Windows privileges"
@@ -120,3 +120,47 @@ def test_message_when_a_component_is_the_link(tmp_path: Path):
         f"refused to modify {target}: {link} is a symlink; "
         "Nauro does not write through symlinks in a repo checkout"
     )
+
+
+# ─── find_file_symlink (user-global final-target rule) ──────────────────────
+
+
+def test_file_symlink_regular_file_is_safe(tmp_path: Path):
+    target = tmp_path / "config.toml"
+    target.write_text("x")
+
+    assert find_file_symlink(target) is None
+
+
+def test_file_symlink_final_target_is_refused(tmp_path: Path):
+    real = tmp_path / "real.toml"
+    real.write_text("x")
+    link = tmp_path / "config.toml"
+    link.symlink_to(real)
+
+    refusal = find_file_symlink(link)
+
+    assert refusal is not None
+    assert refusal.target == link
+    assert refusal.message == (
+        f"refused to modify {link}: it is a symlink; "
+        "Nauro does not replace symlinked user files "
+        "(a dotfile manager may own the real file)"
+    )
+
+
+def test_file_symlink_missing_path_is_safe(tmp_path: Path):
+    assert find_file_symlink(tmp_path / "absent.toml") is None
+
+
+def test_file_symlink_symlinked_parent_is_safe(tmp_path: Path):
+    """Only the final component is checked: a dotfile-managed parent directory
+    (a symlinked ~/.codex, ~/.claude, ...) stays writable."""
+    real_dir = tmp_path / "real"
+    real_dir.mkdir()
+    link_dir = tmp_path / ".codex"
+    link_dir.symlink_to(real_dir, target_is_directory=True)
+    target = link_dir / "config.toml"
+    target.write_text("x")
+
+    assert find_file_symlink(target) is None

--- a/uv.lock
+++ b/uv.lock
@@ -1060,7 +1060,7 @@ dependencies = [
     { name = "nauro-core" },
     { name = "posthog" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "tomli-w" },
+    { name = "tomlkit" },
     { name = "typer" },
 ]
 
@@ -1088,7 +1088,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0" },
-    { name = "tomli-w", specifier = ">=1.0" },
+    { name = "tomlkit", specifier = ">=0.13.2" },
     { name = "typer", specifier = ">=0.9" },
 ]
 provides-extras = ["dev", "embeddings"]
@@ -2235,12 +2235,12 @@ wheels = [
 ]
 
 [[package]]
-name = "tomli-w"
-version = "1.2.0"
+name = "tomlkit"
+version = "0.15.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/db/03eaf4331631ef6b27d6e3c9b68c54dc6f0d63d87201fed600cc409307fd/tomlkit-0.15.0.tar.gz", hash = "sha256:7d1a9ecba3086638211b13814ea79c90dd54dd11993564376f3aa92271f5c7a3", size = 161875, upload-time = "2026-05-10T07:38:22.245Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/43/8bd850ee71a191bf072e31302c73a66be413fecdd98fdcd111ecbcce13ca/tomlkit-0.15.0-py3-none-any.whl", hash = "sha256:4dbc8f0fc024412b57ced8757ac7461305126a648ff8c2c807fcb8e133a78738", size = 41328, upload-time = "2026-05-10T07:38:23.517Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

`~/.codex/config.toml` is the user's hand-maintained Codex config, but `nauro setup codex` round-tripped it through a plain TOML serializer: every add or remove destroyed comments, formatting, and any keys the user had added to the nauro entry (timeouts, env), and the file was rewritten non-atomically even when nothing changed. Separately, none of the user-global write sites (codex config, the `~/.claude.json` prune, skill files, agent files) refused a symlinked final target, so a setup run could silently replace a file owned by a dotfile manager with a plain copy, severing it from the user's real config.

## What changed

- Codex TOML handling now goes through tomlkit (replacing tomli-w): edits are style-preserving, and when a `[mcp_servers.nauro]` entry already exists, only the `command` and `args` keys Nauro owns are rewritten in place through a small typed view of the entry, each key only when its own value differs, so user-added keys, intra-entry comments, and an already-correct multiline args array all survive. When the user wrote `mcp_servers` as an inline table, the nauro entry is created inline to match.
- Semantic no-ops return before rendering: an add whose command and args already match reports "already configured" without touching the file (bytes and mtime), and a remove with no entry keeps its existing early return. A rendered result byte-identical to the original also skips the write.
- Real writes go through `atomic_write_text` with the newline pinned so tomlkit's literal line endings pass through untranslated; existing permission bits survive the replace. The emptied `mcp_servers` parent table is left in place on remove instead of popped.
- New `find_file_symlink` in `store/write_safety.py`: user-global mutations refuse when the final path component is itself a symlink, with a message naming the dotfile-manager rationale. Wired into `_configure_codex`, `_prune_redundant_user_scope_mcp`, `_materialize_skill_file`, `_remove_skill_file`, and `materialize_agents` (including the `.bak` sibling). Parent directories are deliberately not walked: a symlinked `~/.codex` or `~/.claude` is the dotfile-manager layout and keeps working, pinned by tests.

## Risk / what to review

Three subtle tomlkit behaviors are load-bearing. New block entries are appended flush, with the auto-inserted leading blank line cleared, because a reparse attributes that separator to the preceding entry and a later remove would strand it, breaking the byte-identical round trip. A freshly created `[mcp_servers]` parent is pinned `is_super_table=False`, since tomlkit's render heuristic otherwise hides the header of a table whose only child is a sub-table. And when `mcp_servers` is an inline table, the nauro entry is created as an inline table too: nesting a block table inside an inline parent renders invalid TOML that would corrupt the user's config.

## Deferred

- Atomic migration of the five remaining external config writers (`.mcp.json`, `.cursor/mcp.json`, `.claude/settings.json`, `.codex/hooks.json`, and the `~/.claude.json` prune) to the same write path. Skill and agent files are excluded from atomicity by design.
- Structural decomposition of `setup.py` into per-surface modules.

## Test plan

- 27 new tests: byte-for-byte preservation of a commented config outside the nauro entry; add-then-remove round trips (byte-identical with a pre-existing table, empty `[mcp_servers]` header on a table-less file); no-op add and remove leave bytes and mtime untouched; invalid UTF-8 refused without writing on both paths; standard (not inline) table rendering; user keys and comments inside the entry surviving a command rewrite; a command-only drift leaving a matching multiline args array byte-identical; inline-table `mcp_servers` shapes (empty, with sibling, off-shape nauro value, add-then-remove) all producing reparse-valid output; symlink refusal on the codex config, claude.json prune, skills, and agents, with symlinked parent dirs still writable; permission bits preserved through a real rewrite; and `find_file_symlink` unit tests.
- Full suites green: packages/nauro 1785 passed / 10 skipped, packages/nauro-core 1073 passed (untouched). `ruff check` and `ruff format --check` clean.
- Behavior tests verified failing on the pre-change source; the handful that pass pre-change pin behavior that must not regress (parent-dir writes, standard table rendering, no-entry remove, permission bits).
