### PR TITLE
Write setup config files atomically

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/setup.py
+++ b/packages/nauro/src/nauro/cli/commands/setup.py
@@ -252,7 +252,7 @@ def _configure_json_mcp(
         if not servers:
             config.pop("mcpServers", None)
         if config:
-            config_path.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+            atomic_write_text(config_path, json.dumps(config, indent=2) + "\n")
         else:
             config_path.unlink()
         return f"  {repo_path}: removed nauro from {label}"
@@ -262,7 +262,7 @@ def _configure_json_mcp(
         return f"  {repo_path}: mcpServers in {label} is not a JSON object, skipped"
     servers["nauro"] = nauro_entry
     config_path.parent.mkdir(parents=True, exist_ok=True)
-    config_path.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+    atomic_write_text(config_path, json.dumps(config, indent=2) + "\n")
     lines = [f"  {repo_path}: wrote nauro to {label}"]
     lines.extend(public_surface_git_warnings(repo_path, config_rel_path))
     return "\n".join(lines)
@@ -326,7 +326,7 @@ def _prune_redundant_user_scope_mcp() -> str | None:
     if not servers:
         config.pop("mcpServers", None)
     try:
-        config_path.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+        atomic_write_text(config_path, json.dumps(config, indent=2) + "\n")
     except OSError:
         return None
     return (
@@ -1068,7 +1068,7 @@ def _add_hook_entry(settings_path: Path, settings: dict, repo: Path) -> str:
 
     event_matchers.append({"hooks": [_nauro_hook_entry()]})
     settings_path.parent.mkdir(parents=True, exist_ok=True)
-    settings_path.write_text(json.dumps(settings, indent=2) + "\n", encoding="utf-8")
+    atomic_write_text(settings_path, json.dumps(settings, indent=2) + "\n")
     lines = [f"  {repo}: wrote nauro hook to .claude/settings.json"]
     lines.extend(public_surface_git_warnings(repo, ".claude/settings.json"))
     return "\n".join(lines)
@@ -1113,7 +1113,7 @@ def _remove_hook_entry(settings_path: Path, settings: dict, repo: Path) -> str:
         settings.pop("hooks", None)
 
     if settings:
-        settings_path.write_text(json.dumps(settings, indent=2) + "\n", encoding="utf-8")
+        atomic_write_text(settings_path, json.dumps(settings, indent=2) + "\n")
     else:
         settings_path.unlink()
     return f"  {repo}: removed nauro hook from .claude/settings.json"
@@ -1188,7 +1188,7 @@ def materialize_hooks_codex(repo: Path, *, remove: bool) -> str:
         if transformed.removed == 0:
             return f"  {repo}: no nauro Codex hooks to remove"
         if transformed.config:
-            hooks_path.write_text(_format_codex_hooks(transformed.config), encoding="utf-8")
+            atomic_write_text(hooks_path, _format_codex_hooks(transformed.config))
         else:
             hooks_path.unlink()
         return f"  {repo}: removed nauro hooks from .codex/hooks.json"
@@ -1197,7 +1197,7 @@ def materialize_hooks_codex(repo: Path, *, remove: bool) -> str:
     if existing_text == rendered:
         return f"  {repo}: nauro hooks already present in .codex/hooks.json"
     hooks_path.parent.mkdir(parents=True, exist_ok=True)
-    hooks_path.write_text(rendered, encoding="utf-8")
+    atomic_write_text(hooks_path, rendered)
     lines = [f"  {repo}: wrote nauro hooks to .codex/hooks.json"]
     lines.extend(public_surface_git_warnings(repo, ".codex/hooks.json"))
     return "\n".join(lines)

--- a/packages/nauro/tests/test_setup_atomic_writes.py
+++ b/packages/nauro/tests/test_setup_atomic_writes.py
@@ -1,0 +1,304 @@
+"""Atomic-write behavior of the external config sinks in ``nauro setup``.
+
+Seven write paths route through ``atomic_write_text``: project-scope
+``.mcp.json`` add/remove, ``.claude/settings.json`` hook add/remove,
+``.codex/hooks.json`` add/remove, and the user-scope ``~/.claude.json`` prune.
+Each sink pins three contracts: the success path stays byte-identical to a
+plain ``write_text`` of the same payload, existing permission bits survive the
+rewrite, and an interrupted write leaves the original bytes intact with no
+temp siblings. The primitive itself is covered in ``test_atomic.py``; these
+tests cover the wiring of each sink through it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from nauro.cli._codex_hooks import (
+    _CODEX_HOOK_EVENTS,
+    _CODEX_HOOK_SUBCOMMAND,
+    _format_codex_hooks,
+    _render_nauro_hook,
+)
+from nauro.cli.commands.setup import (
+    HOOK_EVENT_NAME,
+    HOOK_SUBCOMMAND,
+    HOOK_TIMEOUT_SECONDS,
+    _configure_mcp,
+    _find_nauro_command,
+    _prune_redundant_user_scope_mcp,
+    materialize_hooks_claude_code,
+    materialize_hooks_codex,
+)
+from nauro.store import _atomic
+
+pytestmark = pytest.mark.skipif(
+    os.name == "nt",
+    reason="POSIX-shaped byte expectations; home redirection is env-based",
+)
+
+# Survivor entries: each remove case must rewrite the file (not unlink it),
+# and each add case must merge into existing content.
+_OTHER_MCP_SERVER = {"command": "/usr/local/bin/other", "args": ["serve"]}
+_STALE_NAURO_MCP = {"command": "/x", "args": []}
+_USER_HOOK_MATCHER = {"hooks": [{"type": "command", "command": "my-own-linter --check"}]}
+_CODEX_USER_MATCHER = {"hooks": [{"type": "command", "command": "echo user-hook"}]}
+_NAURO_SETTINGS_MATCHER = {
+    "hooks": [
+        {
+            "type": "command",
+            "command": f"nauro {HOOK_SUBCOMMAND}",
+            "timeout": HOOK_TIMEOUT_SECONDS,
+        }
+    ]
+}
+_NAURO_CODEX_MATCHER = {
+    "hooks": [{"type": "command", "command": f"exec nauro {_CODEX_HOOK_SUBCOMMAND}"}]
+}
+
+
+def _dump(obj: dict) -> str:
+    """The exact serialization every JSON sink writes."""
+    return json.dumps(obj, indent=2) + "\n"
+
+
+def _seed_file(base: Path, rel: str, obj: dict) -> Path:
+    """Seed ``base/rel`` with compact JSON so a rewrite provably reformats."""
+    target = base / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(obj), encoding="utf-8")
+    return target
+
+
+def _nauro_mcp_entry() -> dict:
+    return {"command": _find_nauro_command(), "args": ["serve", "--stdio"]}
+
+
+def _nauro_settings_hook_matcher() -> dict:
+    return {
+        "hooks": [
+            {
+                "type": "command",
+                "command": f"{_find_nauro_command()} {HOOK_SUBCOMMAND}",
+                "timeout": HOOK_TIMEOUT_SECONDS,
+            }
+        ]
+    }
+
+
+def _nauro_codex_matcher() -> dict:
+    return {"hooks": [_render_nauro_hook(_find_nauro_command())]}
+
+
+@dataclass(frozen=True)
+class ConfigWriteDriver:
+    """One external config sink routed through ``atomic_write_text``.
+
+    ``seed`` creates the pre-state under a base directory (the repo parent,
+    doubling as ``$HOME`` for the user-scope prune) and returns the target
+    path; ``run`` executes the mutation; ``expected`` builds the exact
+    post-run file content. ``soft_fails`` marks the prune sink, whose
+    contract is to return ``None`` on any write failure instead of raising.
+    """
+
+    id: str
+    soft_fails: bool
+    seed: Callable[[Path], Path]
+    run: Callable[[Path], object]
+    expected: Callable[[], str]
+
+
+DRIVERS = [
+    ConfigWriteDriver(
+        id="json-mcp-add",
+        soft_fails=False,
+        seed=lambda base: _seed_file(
+            base, "repo/.mcp.json", {"mcpServers": {"other": _OTHER_MCP_SERVER}}
+        ),
+        run=lambda base: _configure_mcp(base / "repo", remove=False),
+        expected=lambda: _dump(
+            {"mcpServers": {"other": _OTHER_MCP_SERVER, "nauro": _nauro_mcp_entry()}}
+        ),
+    ),
+    ConfigWriteDriver(
+        id="json-mcp-remove",
+        soft_fails=False,
+        seed=lambda base: _seed_file(
+            base,
+            "repo/.mcp.json",
+            {"mcpServers": {"nauro": _STALE_NAURO_MCP, "other": _OTHER_MCP_SERVER}},
+        ),
+        run=lambda base: _configure_mcp(base / "repo", remove=True),
+        expected=lambda: _dump({"mcpServers": {"other": _OTHER_MCP_SERVER}}),
+    ),
+    ConfigWriteDriver(
+        id="settings-hook-add",
+        soft_fails=False,
+        seed=lambda base: _seed_file(base, "repo/.claude/settings.json", {"model": "claude-opus"}),
+        run=lambda base: materialize_hooks_claude_code(base / "repo", remove=False),
+        expected=lambda: _dump(
+            {
+                "model": "claude-opus",
+                "hooks": {HOOK_EVENT_NAME: [_nauro_settings_hook_matcher()]},
+            }
+        ),
+    ),
+    ConfigWriteDriver(
+        id="settings-hook-remove",
+        soft_fails=False,
+        seed=lambda base: _seed_file(
+            base,
+            "repo/.claude/settings.json",
+            {
+                "model": "claude-opus",
+                "hooks": {HOOK_EVENT_NAME: [_USER_HOOK_MATCHER, _NAURO_SETTINGS_MATCHER]},
+            },
+        ),
+        run=lambda base: materialize_hooks_claude_code(base / "repo", remove=True),
+        expected=lambda: _dump(
+            {"model": "claude-opus", "hooks": {HOOK_EVENT_NAME: [_USER_HOOK_MATCHER]}}
+        ),
+    ),
+    ConfigWriteDriver(
+        id="codex-hooks-add",
+        soft_fails=False,
+        seed=lambda base: _seed_file(
+            base,
+            "repo/.codex/hooks.json",
+            {"hooks": {_CODEX_HOOK_EVENTS[0]: [_CODEX_USER_MATCHER]}},
+        ),
+        run=lambda base: materialize_hooks_codex(base / "repo", remove=False),
+        expected=lambda: _format_codex_hooks(
+            {
+                "hooks": {
+                    _CODEX_HOOK_EVENTS[0]: [_CODEX_USER_MATCHER, _nauro_codex_matcher()],
+                    _CODEX_HOOK_EVENTS[1]: [_nauro_codex_matcher()],
+                }
+            }
+        ),
+    ),
+    ConfigWriteDriver(
+        id="codex-hooks-remove",
+        soft_fails=False,
+        seed=lambda base: _seed_file(
+            base,
+            "repo/.codex/hooks.json",
+            {
+                "hooks": {
+                    _CODEX_HOOK_EVENTS[0]: [_CODEX_USER_MATCHER, _NAURO_CODEX_MATCHER],
+                    _CODEX_HOOK_EVENTS[1]: [_NAURO_CODEX_MATCHER],
+                }
+            },
+        ),
+        run=lambda base: materialize_hooks_codex(base / "repo", remove=True),
+        expected=lambda: _format_codex_hooks(
+            {"hooks": {_CODEX_HOOK_EVENTS[0]: [_CODEX_USER_MATCHER]}}
+        ),
+    ),
+    ConfigWriteDriver(
+        id="claude-json-prune",
+        soft_fails=True,
+        seed=lambda base: _seed_file(
+            base,
+            ".claude.json",
+            {
+                "mcpServers": {
+                    "nauro": {"type": "http", "url": "https://mcp.nauro.ai"},
+                    "context7": {"command": "ctx", "args": []},
+                },
+                "someOtherKey": 1,
+            },
+        ),
+        run=lambda base: _prune_redundant_user_scope_mcp(),
+        expected=lambda: _dump(
+            {"mcpServers": {"context7": {"command": "ctx", "args": []}}, "someOtherKey": 1}
+        ),
+    ),
+]
+
+
+@pytest.fixture(params=DRIVERS, ids=lambda driver: driver.id)
+def driver(request):
+    return request.param
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path: Path, monkeypatch):
+    """Point the home directory at ``tmp_path`` for every test.
+
+    The prune sink writes ``Path.home() / ".claude.json"``. Both HOME and
+    USERPROFILE are redirected so the developer's real file stays out of
+    reach even if the module-level nt skip is ever lifted (``Path.home()``
+    resolves USERPROFILE on Windows).
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+
+
+def _failing_replace(src, dst):
+    raise OSError("replace failed")
+
+
+def _tmp_siblings(target: Path) -> list[str]:
+    return [p.name for p in target.parent.iterdir() if p.name.endswith(".tmp")]
+
+
+def test_write_lands_exact_bytes(driver, tmp_path: Path):
+    """The atomic path writes exactly what the plain ``write_text`` wrote."""
+    target = driver.seed(tmp_path)
+
+    driver.run(tmp_path)
+
+    assert target.read_bytes() == driver.expected().encode("utf-8")
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits")
+def test_write_preserves_permission_bits(driver, tmp_path: Path):
+    """An existing target's permission bits survive the atomic rewrite."""
+    target = driver.seed(tmp_path)
+    target.chmod(0o640)
+
+    driver.run(tmp_path)
+
+    assert stat.S_IMODE(target.stat().st_mode) == 0o640
+
+
+def test_interrupted_write_leaves_target_and_no_temps(driver, tmp_path: Path, monkeypatch):
+    """A write that fails mid-flight leaves the original bytes and no temps.
+
+    Same seam as ``test_atomic.py``: ``os.replace`` raising stands in for any
+    failure between temp write and rename. The prune sink must additionally
+    keep its soft-fail contract and report ``None`` instead of raising.
+    """
+    target = driver.seed(tmp_path)
+    before = target.read_bytes()
+    monkeypatch.setattr(_atomic.os, "replace", _failing_replace)
+
+    if driver.soft_fails:
+        assert driver.run(tmp_path) is None
+    else:
+        with pytest.raises(OSError, match="replace failed"):
+            driver.run(tmp_path)
+
+    assert target.read_bytes() == before
+    assert _tmp_siblings(target) == []
+
+
+def test_interrupted_fresh_add_leaves_no_partial_target(tmp_path: Path, monkeypatch):
+    """An interrupted first write on a fresh repo leaves no partial file."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.setattr(_atomic.os, "replace", _failing_replace)
+
+    with pytest.raises(OSError, match="replace failed"):
+        _configure_mcp(repo, remove=False)
+
+    assert not (repo / ".mcp.json").exists()
+    assert _tmp_siblings(repo / ".mcp.json") == []


### PR DESCRIPTION
## Why

The setup surface writers for external config files (the shared JSON MCP writer covering `.mcp.json` and `.cursor/mcp.json`, `.claude/settings.json`, `.codex/hooks.json`, and the user-scope `~/.claude.json` prune) still used bare `Path.write_text`, which truncates the target before writing. A crash, full disk, or interrupt mid-write could leave a user's config file empty or partial. The hardened `atomic_write_text` primitive already covers `~/.codex/config.toml` and the control-plane JSON; these were the last five external sinks (seven write calls) outside it.

## What changed

- All seven write calls in `cli/commands/setup.py` now go through `atomic_write_text`: the shared JSON MCP writer's add and remove paths (`.mcp.json` and `.cursor/mcp.json`), the `~/.claude.json` prune (inside its existing soft-fail try/except), the `.claude/settings.json` hook add and remove paths, and the `.codex/hooks.json` add and remove paths.
- Success-path output is byte-identical to the previous writes; no guard, ordering, message, or unlink behavior changed. Internal store writers and the markdown surfaces (legacy CLAUDE.md block, skills, subagents) intentionally stay on plain writes.
- New test module `tests/test_setup_atomic_writes.py` parameterizes seven drivers over the sink contracts: exact success-path bytes, permission-bit preservation, interrupted writes leaving the original bytes (with the prune keeping its return-None soft-fail) and no orphaned temp siblings, plus a fresh-repo interrupted add leaving no partial target. The module is POSIX-scoped (skipped on Windows, matching the suite's existing symlink-test convention) and isolates both `HOME` and `USERPROFILE` so the prune tests can never touch a real user profile.

## Deferred

Structural decomposition of the setup module: deduplicating the shared dump-and-write shape across the JSON sinks and folding the now-redundant parent mkdir calls into the primitive belong to that decomposition, not this migration.

## Test plan

- packages/nauro/tests: 1807 passed, 10 skipped (baseline 1785 + 22 new)
- packages/nauro-core/tests: 1073 passed
- ruff check and ruff format --check: clean
- The 8 interrupted-write/orphan tests fail against the pre-migration code (verified by stashing the source change); the 14 byte-identity and permission tests pass pre-change, pinning byte compatibility with the old writes.
