### PR TITLE
Characterize setup surface behavior ahead of restructuring

### DIFF
--- a/packages/nauro/tests/conftest.py
+++ b/packages/nauro/tests/conftest.py
@@ -38,6 +38,37 @@ def cloud_prefix(user_id: str, project_id: str) -> str:
     return f"users/{user_id}/projects/{project_id}"
 
 
+def normalize_transcript(text: str, replacements: dict[str, str]) -> str:
+    """Replace each volatile substring in ``text`` with its placeholder.
+
+    Pure helper for transcript pins: callers pass a mapping of volatile
+    values (temp dirs, resolved command paths) to stable placeholders such
+    as ``{TMP}`` or ``{NAURO_CMD}``. Replacements are applied in mapping
+    order, so callers with nested volatile values list the longer needle
+    first.
+    """
+    for needle, placeholder in replacements.items():
+        text = text.replace(needle, placeholder)
+    return text
+
+
+def snapshot_tree(root: Path) -> list[str]:
+    """Sorted relative POSIX paths of all files under ``root``.
+
+    ``.git`` subtrees are excluded so inventory assertions stay independent
+    of the git version's on-disk layout.
+    """
+    paths = []
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(root)
+        if ".git" in rel.parts:
+            continue
+        paths.append(rel.as_posix())
+    return sorted(paths)
+
+
 def read_project_context(store_path: Path, level: int = 0) -> str:
     """Extract the ``content`` string from the ``tool_get_context`` envelope.
 

--- a/packages/nauro/tests/test_onboarding_inventories.py
+++ b/packages/nauro/tests/test_onboarding_inventories.py
@@ -1,0 +1,335 @@
+"""Filesystem inventory pins for the onboarding commands.
+
+Pins the full set of files each onboarding flow (``adopt``, ``init``,
+``attach``) leaves behind across the repo and the fake home directory, ahead
+of the internal restructuring of the setup module. Inventories are asserted
+with set equality over ``snapshot_tree`` plus ordered section-marker checks
+on the output; full transcripts are not pinned here because ``adopt``
+requires a real git repo, whose hygiene notes vary with the environment.
+
+The telemetry bookkeeping files (``config.json`` + ``config.lock`` under
+NAURO_HOME) appear because the first CLI run persists an anonymous id; the
+autouse fixture clears ``NAURO_TELEMETRY`` so that default behavior is what
+gets pinned regardless of the developer's shell.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import httpx
+import pytest
+from typer.testing import CliRunner
+
+from nauro.cli.main import app
+from nauro.store.registry import register_project_v2
+from nauro.sync import cloud_projects
+from tests.conftest import seed_auth_config, snapshot_tree
+
+runner = CliRunner()
+
+EXAMPLE_PID = "01KQ6AZGNA0B3QBF67NBXP3S45"
+
+# Written by every flow below: the telemetry anonymous-id bookkeeping and the
+# registry plus its filelock sibling, all under NAURO_HOME (tmp_path here).
+BOOKKEEPING = {"config.json", "config.lock", "registry.json", "registry.lock"}
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path: Path, monkeypatch):
+    """Home + telemetry-env isolation so inventories are environment-independent."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.delenv("NAURO_TELEMETRY", raising=False)
+
+
+def _git_init(repo: Path) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+
+
+def _make_git_repo(tmp_path: Path, monkeypatch) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git_init(repo)
+    monkeypatch.chdir(repo)
+    return repo
+
+
+def _repo_pid(repo: Path) -> str:
+    return json.loads((repo / ".nauro" / "config.json").read_text(encoding="utf-8"))["id"]
+
+
+def _store_files(pid: str) -> set[str]:
+    """The scaffolded store files for a project id, relative to NAURO_HOME."""
+    return {
+        f"projects/{pid}/decisions/001-initial-setup.md",
+        f"projects/{pid}/open-questions.md",
+        f"projects/{pid}/project.md",
+        f"projects/{pid}/stack.md",
+        f"projects/{pid}/state_current.md",
+    }
+
+
+def _assert_markers_in_order(text: str, markers: list[str]) -> None:
+    pos = 0
+    for marker in markers:
+        idx = text.find(marker, pos)
+        assert idx != -1, f"marker missing or out of order: {marker!r}\n---\n{text}"
+        pos = idx + len(marker)
+
+
+def test_adopt_default_inventory(tmp_path: Path, monkeypatch):
+    repo = _make_git_repo(tmp_path, monkeypatch)
+
+    result = runner.invoke(app, ["adopt", "--name", "proj"])
+
+    assert result.exit_code == 0
+    pid = _repo_pid(repo)
+    assert snapshot_tree(tmp_path) == sorted(
+        BOOKKEEPING
+        | _store_files(pid)
+        | {
+            ".agents/skills/nauro-adopt/SKILL.md",
+            ".claude/skills/nauro-adopt/SKILL.md",
+            ".codex/config.toml",
+            "repo/.cursor/mcp.json",
+            "repo/.cursor/rules/nauro-adopt.mdc",
+            "repo/.mcp.json",
+            "repo/.nauro/config.json",
+            "repo/AGENTS.md",
+        }
+    )
+    _assert_markers_in_order(
+        result.stdout,
+        [
+            "Adopted project 'proj' (id: ",
+            "Wiring MCP and installing skills across surfaces:",
+            "wrote nauro to .mcp.json",
+            "wrote nauro to .cursor/mcp.json",
+            "Codex: wrote nauro to ",
+            "regenerated AGENTS.md",
+            "Next: restart your agent and invoke /nauro-adopt",
+        ],
+    )
+
+
+def test_adopt_with_skills_and_subagents_inventory(tmp_path: Path, monkeypatch):
+    repo = _make_git_repo(tmp_path, monkeypatch)
+
+    result = runner.invoke(app, ["adopt", "--name", "proj", "--with-skills", "--with-subagents"])
+
+    assert result.exit_code == 0
+    pid = _repo_pid(repo)
+    assert snapshot_tree(tmp_path) == sorted(
+        BOOKKEEPING
+        | _store_files(pid)
+        | {
+            ".agents/skills/nauro-adopt/SKILL.md",
+            ".agents/skills/nauro-context/SKILL.md",
+            ".agents/skills/nauro-loop/SKILL.md",
+            ".agents/skills/nauro-ship-task/SKILL.md",
+            ".claude/agents/nauro-executor.md",
+            ".claude/agents/nauro-planner.md",
+            ".claude/agents/nauro-reviewer.md",
+            ".claude/agents/nauro-tech-lead.md",
+            ".claude/skills/nauro-adopt/SKILL.md",
+            ".claude/skills/nauro-context/SKILL.md",
+            ".claude/skills/nauro-loop/SKILL.md",
+            ".claude/skills/nauro-ship-task/SKILL.md",
+            ".codex/config.toml",
+            "repo/.cursor/mcp.json",
+            "repo/.cursor/rules/nauro-adopt.mdc",
+            "repo/.cursor/rules/nauro-context.mdc",
+            "repo/.cursor/rules/nauro-loop.mdc",
+            "repo/.cursor/rules/nauro-ship-task.mdc",
+            "repo/.mcp.json",
+            "repo/.nauro/config.json",
+            "repo/AGENTS.md",
+        }
+    )
+    _assert_markers_in_order(
+        result.stdout,
+        [
+            "Adopted project 'proj' (id: ",
+            "Wiring MCP and installing skills across surfaces:",
+            "wrote nauro to .mcp.json",
+            "installed ",
+            "Cloud users: name the remote MCP connector exactly `Nauro`",
+            "Next: restart your agent and invoke /nauro-adopt",
+        ],
+    )
+
+
+def test_adopt_no_setup_and_skills_inventory(tmp_path: Path, monkeypatch):
+    repo = _make_git_repo(tmp_path, monkeypatch)
+
+    result = runner.invoke(app, ["adopt", "--name", "proj", "--no-setup-and-skills"])
+
+    assert result.exit_code == 0
+    pid = _repo_pid(repo)
+    # Registration + store only: no surface wiring and no AGENTS.md.
+    assert snapshot_tree(tmp_path) == sorted(
+        BOOKKEEPING | _store_files(pid) | {"repo/.nauro/config.json"}
+    )
+    _assert_markers_in_order(
+        result.stdout,
+        [
+            "Adopted project 'proj' (id: ",
+            "Next: restart your agent and invoke /nauro-adopt",
+        ],
+    )
+    assert "Wiring MCP and installing skills across surfaces:" not in result.stdout
+
+
+def test_adopt_remove_round_trip_inventory(tmp_path: Path, monkeypatch):
+    """Un-adopt inverts adoption up to the pinned residue.
+
+    The residue: the store (left intact by design), the registry and
+    telemetry bookkeeping, and ``~/.codex/config.toml``, whose nauro entry
+    is removed while the emptied file survives teardown.
+    """
+    repo = _make_git_repo(tmp_path, monkeypatch)
+    pre = snapshot_tree(tmp_path)
+
+    adopt = runner.invoke(app, ["adopt", "--name", "proj"])
+    assert adopt.exit_code == 0
+    pid = _repo_pid(repo)
+
+    result = runner.invoke(app, ["adopt", "--remove", "--yes"])
+
+    assert result.exit_code == 0
+    assert snapshot_tree(tmp_path) == sorted(
+        set(pre) | BOOKKEEPING | _store_files(pid) | {".codex/config.toml"}
+    )
+    _assert_markers_in_order(
+        result.stdout,
+        [
+            "Removing Nauro integration across surfaces:",
+            "removed nauro from .mcp.json",
+            "removed nauro from .cursor/mcp.json",
+            "Codex: removed nauro from ",
+            "removed generated AGENTS.md",
+            f"removed project registry entry {pid}",
+            "store left intact: ",
+            "Done. Restart your agent so it drops the Nauro MCP server.",
+        ],
+    )
+
+
+def test_init_with_repo_association_inventory(tmp_path: Path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    result = runner.invoke(app, ["init", "myproj", "--add-repo", str(repo)])
+
+    assert result.exit_code == 0
+    pid = _repo_pid(repo)
+    # init registers and scaffolds but wires no surfaces; AGENTS.md is the
+    # only repo artifact beyond the per-repo config.
+    assert snapshot_tree(tmp_path) == sorted(
+        BOOKKEEPING | _store_files(pid) | {"repo/.nauro/config.json", "repo/AGENTS.md"}
+    )
+    _assert_markers_in_order(
+        result.stdout,
+        [
+            "Initialized project 'myproj'",
+            "  Project id: ",
+            "  Store: ",
+            "  Repo:  ",
+            "Next: run 'nauro setup claude-code' to connect your agent",
+        ],
+    )
+
+
+def test_attach_happy_path_inventory(tmp_path: Path, monkeypatch):
+    """Cloud attach writes repo config + AGENTS.md; the store stays empty.
+
+    Unlike init/adopt, attach does not scaffold the store: the directory is
+    created empty (files arrive via sync), so nothing under ``projects/``
+    shows up in the inventory.
+    """
+    seed_auth_config()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.chdir(repo)
+    monkeypatch.setenv("NAURO_API_URL", "https://example.test")
+
+    def handler(method, url, **kwargs):
+        return httpx.Response(
+            200,
+            json=[
+                {
+                    "project_id": EXAMPLE_PID,
+                    "name": "team-proj",
+                    "role": "viewer",
+                    "created_at": "2026-04-27T00:00:00Z",
+                }
+            ],
+            request=httpx.Request(method, url),
+        )
+
+    with patch.object(cloud_projects.httpx, "request", side_effect=handler):
+        result = runner.invoke(app, ["attach", EXAMPLE_PID])
+
+    assert result.exit_code == 0
+    assert snapshot_tree(tmp_path) == sorted(
+        BOOKKEEPING | {"repo/.nauro/config.json", "repo/AGENTS.md"}
+    )
+    _assert_markers_in_order(
+        result.stdout,
+        [
+            "Attached 'team-proj' to ",
+            f"  Project id: {EXAMPLE_PID}",
+            "  Store: ",
+        ],
+    )
+
+
+def test_adopt_remove_last_repo_keeps_user_scope_for_other_project(tmp_path: Path, monkeypatch):
+    """Removing a project's last repo preserves user-scope artifacts while a
+    second project remains registered.
+
+    The gate is registry-wide, not project-scoped: the other project never
+    wired any surface, yet its bare registry entry is enough to preserve the
+    shared skills and the codex entry.
+    """
+    repo = _make_git_repo(tmp_path, monkeypatch)
+    adopt = runner.invoke(app, ["adopt", "--name", "proj"])
+    assert adopt.exit_code == 0
+    pid = _repo_pid(repo)
+
+    other = tmp_path / "other"
+    other.mkdir()
+    register_project_v2("other", [other])
+
+    result = runner.invoke(app, ["adopt", "--remove", "--yes"])
+
+    assert result.exit_code == 0
+    assert snapshot_tree(tmp_path) == sorted(
+        BOOKKEEPING
+        | _store_files(pid)
+        | {
+            ".agents/skills/nauro-adopt/SKILL.md",
+            ".claude/skills/nauro-adopt/SKILL.md",
+            ".codex/config.toml",
+        }
+    )
+    # The preserved codex file still carries the nauro entry, not an
+    # emptied table.
+    assert "[mcp_servers.nauro]" in (tmp_path / ".codex" / "config.toml").read_text(
+        encoding="utf-8"
+    )
+    _assert_markers_in_order(
+        result.stdout,
+        [
+            "Removing Nauro integration across surfaces:",
+            "preserved ~/.claude/skills/nauro-* (other nauro projects still registered)",
+            "preserved ~/.claude/agents/nauro-* (other nauro projects still registered)",
+            "Codex: preserved nauro entry in ",
+            "preserved ~/.agents/skills/nauro-* (other nauro projects still registered)",
+            f"removed project registry entry {pid}",
+        ],
+    )

--- a/packages/nauro/tests/test_setup_characterization.py
+++ b/packages/nauro/tests/test_setup_characterization.py
@@ -1,0 +1,990 @@
+"""Characterization pins for the ``nauro setup`` command surface.
+
+Pins the observable behavior of ``setup claude-code``, ``setup cursor``,
+``setup codex``, and ``setup all`` ahead of the internal restructuring of
+the setup module, so move-only changes can be verified behavior-neutral.
+Transcripts are pinned as they stand today, including asymmetries (e.g.
+``.mcp.json`` re-reports "wrote" on a no-op re-run while codex and hooks
+report no-op statuses); a failure here after a refactor means observable
+behavior changed, not that this file is wrong.
+
+Rules for this module:
+
+- Every test drives the CLI through ``CliRunner`` on ``nauro.cli.main.app``.
+- Expected strings are inline literals; nothing is imported from
+  ``nauro.cli.commands.setup`` so a refactor cannot rewrite the expectations
+  it is being checked against.
+- Projects are registered via ``register_project_v2`` without ``git init``
+  so git-hygiene notes stay out of the transcripts.
+- stdout and stderr are asserted separately, plus the exact exit code.
+- Volatile values are masked via ``normalize_transcript``: the pytest tmp
+  dir as ``{TMP}`` and the resolved nauro entrypoint as ``{NAURO_CMD}``.
+
+Seam note: the resolver-warning tests override the conftest probe seam
+(``cli_utils.probe_nauro_command`` / ``cli_utils._is_durable_install_path``)
+patched by the autouse ``_neutralize_nauro_command_probe`` fixture. They ride
+that fixture's existing retarget obligation: if the seam moves, retarget
+these overrides together with the fixture.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from nauro.cli.main import app
+from nauro.store.registry import register_project_v2
+from nauro.store.repo_config import save_repo_config
+from nauro.templates.scaffolds import scaffold_project_store
+from tests.conftest import normalize_transcript, snapshot_tree
+
+pytestmark = pytest.mark.skipif(
+    os.name == "nt",
+    reason="POSIX-shaped transcripts, env-based home redirection, symlink fixtures",
+)
+
+runner = CliRunner()
+
+
+# ─── shared notice lines (inline literals, one place per repeated line) ──────
+
+TRY_IT_LINE = 'Try it now from this shell: nauro check-decision "<approach>"\n'
+
+CLAUDE_NEXT_LINE = (
+    "Next: start a Claude Code session in one of the repos."
+    " The MCP server will start automatically.\n"
+)
+
+CURSOR_NEXT_LINE = (
+    "Next: open this repo in Cursor and start a chat \u2014 Nauro MCP will connect.\n"
+)
+
+CODEX_NEXT_LINE = "Next: run a Codex session \u2014 it reads ~/.codex/config.toml on start.\n"
+
+ALL_RESTART_LINE = (
+    "Next: start a fresh agent session (Claude Code/Cursor) \u2014 MCP config is read at"
+    " session start.\n"
+)
+
+HOOKS_NOTICE_LINE = (
+    "The advisory hook surfaces related decisions as context on each turn (BM25 retrieval)"
+    " and never blocks. Start a new Claude Code session in a wired repo for it to take"
+    " effect.\n"
+)
+
+CODEX_HOOKS_NOTICE_LINE = (
+    "Codex skips new or changed hooks until you review and trust them. Start Codex in a"
+    " wired repo, then open `/hooks` to review the project hooks.\n"
+)
+
+CONNECTOR_NOTICE_LINE = (
+    "Cloud users: name the remote MCP connector exactly `Nauro` so the bundled @nauro-*"
+    " subagents' `mcp__claude_ai_Nauro__*` tools resolve.\n"
+)
+
+SKILLS_NEEDS_SUBAGENTS_LINE = (
+    "nauro-ship-task references the bundled @nauro-* subagents (and nauro-loop dispatches"
+    " that chain); pass `--with-subagents` to install them too.\n"
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path: Path, monkeypatch):
+    """Point the home directory at ``tmp_path`` for every test.
+
+    User-scope sinks (``~/.claude/skills``, ``~/.agents/skills``,
+    ``~/.codex/config.toml``, ``~/.claude.json``, ``~/.claude/agents``) must
+    land inside the test tree. Both HOME and USERPROFILE are redirected,
+    mirroring test_setup_atomic_writes.py.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+
+
+def _register_project(tmp_path: Path, monkeypatch, name="proj", repos=("repo",)):
+    """Register a v2 project without ``git init`` and chdir into its first repo.
+
+    No git repo means ``public_surface_git_warnings`` stays silent, keeping
+    the pinned transcripts free of environment-dependent hygiene notes.
+    """
+    paths = []
+    for rel in repos:
+        p = tmp_path / rel
+        p.mkdir()
+        paths.append(p)
+    pid, store = register_project_v2(name, paths)
+    scaffold_project_store(name, store)
+    for p in paths:
+        save_repo_config(p, {"mode": "local", "id": pid, "name": name})
+    monkeypatch.chdir(paths[0])
+    return pid, store, paths
+
+
+def _norm(text: str, tmp_path: Path) -> str:
+    return normalize_transcript(text, {str(tmp_path): "{TMP}"})
+
+
+def _all_add_plain_expected() -> str:
+    """The ``setup all`` add transcript for a single-repo project, no flags."""
+    return (
+        "Configured Nauro for project 'proj' across all surfaces:\n"
+        "\n"
+        "  {TMP}/repo: wrote nauro to .mcp.json\n"
+        "  wrote {TMP}/.claude/skills/nauro-adopt/SKILL.md\n"
+        "  {TMP}/repo: wrote nauro to .cursor/mcp.json\n"
+        "  wrote {TMP}/repo/.cursor/rules/nauro-adopt.mdc\n"
+        "Codex: wrote nauro to {TMP}/.codex/config.toml\n"
+        "  wrote {TMP}/.agents/skills/nauro-adopt/SKILL.md\n"
+        "  {TMP}/repo: regenerated AGENTS.md\n"
+        "\n" + ALL_RESTART_LINE + "\n" + TRY_IT_LINE
+    )
+
+
+# ─── transcript pins ─────────────────────────────────────────────────────────
+
+
+class TestClaudeCodeTranscripts:
+    def test_add(self, tmp_path: Path, monkeypatch):
+        _register_project(tmp_path, monkeypatch)
+
+        result = runner.invoke(app, ["setup", "claude-code"])
+
+        assert result.exit_code == 0
+        assert _norm(result.stdout, tmp_path) == (
+            "Configured Nauro for project 'proj':\n"
+            "\n"
+            "  {TMP}/repo: wrote nauro to .mcp.json\n"
+            "\n"
+            "AGENTS.md:\n"
+            "  {TMP}/repo: regenerated AGENTS.md\n"
+            "\n" + CLAUDE_NEXT_LINE + "\n" + TRY_IT_LINE
+        )
+        assert result.stderr == ""
+
+    def test_add_with_hooks(self, tmp_path: Path, monkeypatch):
+        _register_project(tmp_path, monkeypatch)
+
+        result = runner.invoke(app, ["setup", "claude-code", "--with-hooks"])
+
+        assert result.exit_code == 0
+        assert _norm(result.stdout, tmp_path) == (
+            "Configured Nauro for project 'proj':\n"
+            "\n"
+            "  {TMP}/repo: wrote nauro to .mcp.json\n"
+            "\n"
+            "Hooks:\n"
+            "  {TMP}/repo: wrote nauro hook to .claude/settings.json\n"
+            "\n"
+            "AGENTS.md:\n"
+            "  {TMP}/repo: regenerated AGENTS.md\n"
+            "\n" + CLAUDE_NEXT_LINE + "\n" + HOOKS_NOTICE_LINE + "\n" + TRY_IT_LINE
+        )
+        assert result.stderr == ""
+
+    def test_remove_after_plain_add(self, tmp_path: Path, monkeypatch):
+        """The remove path emits a Hooks section even when no hook was wired."""
+        _register_project(tmp_path, monkeypatch)
+        assert runner.invoke(app, ["setup", "claude-code"]).exit_code == 0
+
+        result = runner.invoke(app, ["setup", "claude-code", "--remove"])
+
+        assert result.exit_code == 0
+        assert _norm(result.stdout, tmp_path) == (
+            "Removed Nauro for project 'proj':\n"
+            "\n"
+            "  {TMP}/repo: removed nauro from .mcp.json\n"
+            "\n"
+            "Hooks:\n"
+            "  {TMP}/repo: no nauro hook to remove\n"
+        )
+        assert result.stderr == ""
+
+
+class TestCursorTranscripts:
+    def test_add(self, tmp_path: Path, monkeypatch):
+        _register_project(tmp_path, monkeypatch)
+
+        result = runner.invoke(app, ["setup", "cursor"])
+
+        assert result.exit_code == 0
+        assert _norm(result.stdout, tmp_path) == (
+            "Configured Nauro (Cursor) for project 'proj':\n"
+            "\n"
+            "  {TMP}/repo: wrote nauro to .cursor/mcp.json\n"
+            "\n" + CURSOR_NEXT_LINE + "\n" + TRY_IT_LINE
+        )
+        assert result.stderr == ""
+
+    def test_remove_after_add(self, tmp_path: Path, monkeypatch):
+        _register_project(tmp_path, monkeypatch)
+        assert runner.invoke(app, ["setup", "cursor"]).exit_code == 0
+
+        result = runner.invoke(app, ["setup", "cursor", "--remove"])
+
+        assert result.exit_code == 0
+        assert _norm(result.stdout, tmp_path) == (
+            "Removed Nauro (Cursor) for project 'proj':\n"
+            "\n"
+            "  {TMP}/repo: removed nauro from .cursor/mcp.json\n"
+        )
+        assert result.stderr == ""
+
+
+class TestCodexTranscripts:
+    def test_add(self, tmp_path: Path, monkeypatch):
+        _register_project(tmp_path, monkeypatch)
+
+        result = runner.invoke(app, ["setup", "codex"])
+
+        assert result.exit_code == 0
+        assert _norm(result.stdout, tmp_path) == (
+            "Codex: wrote nauro to {TMP}/.codex/config.toml\n"
+            "\n" + CODEX_NEXT_LINE + "\n" + TRY_IT_LINE
+        )
+        assert result.stderr == ""
+
+    def test_add_with_hooks(self, tmp_path: Path, monkeypatch):
+        _register_project(tmp_path, monkeypatch)
+
+        result = runner.invoke(app, ["setup", "codex", "--with-hooks"])
+
+        assert result.exit_code == 0
+        assert _norm(result.stdout, tmp_path) == (
+            "Codex: wrote nauro to {TMP}/.codex/config.toml\n"
+            "\n"
+            "Hooks:\n"
+            "  {TMP}/repo: wrote nauro hooks to .codex/hooks.json\n"
+            "\n" + CODEX_NEXT_LINE + "\n" + CODEX_HOOKS_NOTICE_LINE + "\n" + TRY_IT_LINE
+        )
+        assert result.stderr == ""
+
+    def test_remove_with_project_remaining_preserves_entry(self, tmp_path: Path, monkeypatch):
+        """With a project still registered, the user-global entry is preserved."""
+        _register_project(tmp_path, monkeypatch)
+        assert runner.invoke(app, ["setup", "codex", "--with-hooks"]).exit_code == 0
+
+        result = runner.invoke(app, ["setup", "codex", "--remove"])
+
+        assert result.exit_code == 0
+        assert _norm(result.stdout, tmp_path) == (
+            "Codex: preserved nauro entry in {TMP}/.codex/config.toml (1 nauro project"
+            " registered; run 'nauro setup all --remove' on the last project to clear this"
+            " user-global entry)\n"
+            "\n"
+            "Hooks:\n"
+            "  {TMP}/repo: removed nauro hooks from .codex/hooks.json\n"
+        )
+        assert result.stderr == ""
+        assert (tmp_path / ".codex" / "config.toml").is_file()
+
+    def test_remove_with_empty_registry_clears_entry(self, tmp_path: Path, monkeypatch):
+        """No registered projects: the entry is cleared and hook cleanup punts."""
+        add = runner.invoke(app, ["setup", "codex"])
+        assert add.exit_code == 0
+
+        result = runner.invoke(app, ["setup", "codex", "--remove"])
+
+        assert result.exit_code == 0
+        assert _norm(result.stdout, tmp_path) == (
+            "Codex: removed nauro from {TMP}/.codex/config.toml\n"
+            "\n"
+            "Hooks:\n"
+            "  Project-scoped Codex hooks were not removed because no Nauro project resolves"
+            " from this directory. Run this command from each wired repo to remove them.\n"
+        )
+        assert result.stderr == ""
+
+
+class TestSetupAllTranscripts:
+    def test_add_plain(self, tmp_path: Path, monkeypatch):
+        _register_project(tmp_path, monkeypatch)
+
+        result = runner.invoke(app, ["setup", "all"])
+
+        assert result.exit_code == 0
+        assert _norm(result.stdout, tmp_path) == _all_add_plain_expected()
+        assert result.stderr == ""
+
+    def test_add_full_flags(self, tmp_path: Path, monkeypatch):
+        _register_project(tmp_path, monkeypatch)
+
+        result = runner.invoke(
+            app, ["setup", "all", "--with-skills", "--with-subagents", "--with-hooks"]
+        )
+
+        assert result.exit_code == 0
+        assert _norm(result.stdout, tmp_path) == (
+            "Configured Nauro for project 'proj' across all surfaces:\n"
+            "\n"
+            "  {TMP}/repo: wrote nauro to .mcp.json\n"
+            "  wrote {TMP}/.claude/skills/nauro-adopt/SKILL.md\n"
+            "  wrote {TMP}/.claude/skills/nauro-ship-task/SKILL.md\n"
+            "  wrote {TMP}/.claude/skills/nauro-context/SKILL.md\n"
+            "  wrote {TMP}/.claude/skills/nauro-loop/SKILL.md\n"
+            "  installed {TMP}/.claude/agents/nauro-planner.md\n"
+            "  installed {TMP}/.claude/agents/nauro-executor.md\n"
+            "  installed {TMP}/.claude/agents/nauro-reviewer.md\n"
+            "  installed {TMP}/.claude/agents/nauro-tech-lead.md\n"
+            "  {TMP}/repo: wrote nauro hook to .claude/settings.json\n"
+            "  {TMP}/repo: wrote nauro to .cursor/mcp.json\n"
+            "  wrote {TMP}/repo/.cursor/rules/nauro-adopt.mdc\n"
+            "  wrote {TMP}/repo/.cursor/rules/nauro-ship-task.mdc\n"
+            "  wrote {TMP}/repo/.cursor/rules/nauro-context.mdc\n"
+            "  wrote {TMP}/repo/.cursor/rules/nauro-loop.mdc\n"
+            "Codex: wrote nauro to {TMP}/.codex/config.toml\n"
+            "  wrote {TMP}/.agents/skills/nauro-adopt/SKILL.md\n"
+            "  wrote {TMP}/.agents/skills/nauro-ship-task/SKILL.md\n"
+            "  wrote {TMP}/.agents/skills/nauro-context/SKILL.md\n"
+            "  wrote {TMP}/.agents/skills/nauro-loop/SKILL.md\n"
+            "  {TMP}/repo: wrote nauro hooks to .codex/hooks.json\n"
+            "  {TMP}/repo: regenerated AGENTS.md\n"
+            "\n"
+            + CONNECTOR_NOTICE_LINE
+            + "\n"
+            + HOOKS_NOTICE_LINE
+            + "\n"
+            + CODEX_HOOKS_NOTICE_LINE
+            + "\n"
+            + ALL_RESTART_LINE
+            + "\n"
+            + TRY_IT_LINE
+        )
+        assert result.stderr == ""
+
+    def test_remove_as_last_project(self, tmp_path: Path, monkeypatch):
+        """Last project on the machine: user-scope artifacts are cleared too."""
+        _register_project(tmp_path, monkeypatch)
+        assert runner.invoke(app, ["setup", "all"]).exit_code == 0
+
+        result = runner.invoke(app, ["setup", "all", "--remove"])
+
+        assert result.exit_code == 0
+        assert _norm(result.stdout, tmp_path) == (
+            "Removed Nauro for project 'proj' across all surfaces:\n"
+            "\n"
+            "  {TMP}/repo: removed nauro from .mcp.json\n"
+            "  removed {TMP}/.claude/skills/nauro-adopt/SKILL.md\n"
+            "  {TMP}/repo: no nauro hook to remove\n"
+            "  {TMP}/repo: removed nauro from .cursor/mcp.json\n"
+            "  removed {TMP}/repo/.cursor/rules/nauro-adopt.mdc\n"
+            "Codex: removed nauro from {TMP}/.codex/config.toml\n"
+            "  removed {TMP}/.agents/skills/nauro-adopt/SKILL.md\n"
+            "  {TMP}/repo: no nauro Codex hooks to remove\n"
+            "  {TMP}/repo: removed generated AGENTS.md\n"
+        )
+        assert result.stderr == ""
+
+    def test_remove_with_other_project_registered(self, tmp_path: Path, monkeypatch):
+        """Shared user-scope artifacts are preserved while another project remains."""
+        _register_project(tmp_path, monkeypatch)
+        other = tmp_path / "other"
+        other.mkdir()
+        register_project_v2("other", [other])
+        assert runner.invoke(app, ["setup", "all"]).exit_code == 0
+
+        result = runner.invoke(app, ["setup", "all", "--remove"])
+
+        assert result.exit_code == 0
+        assert _norm(result.stdout, tmp_path) == (
+            "Removed Nauro for project 'proj' across all surfaces:\n"
+            "\n"
+            "  {TMP}/repo: removed nauro from .mcp.json\n"
+            "  preserved ~/.claude/skills/nauro-* (other nauro projects still registered)\n"
+            "  {TMP}/repo: no nauro hook to remove\n"
+            "  {TMP}/repo: removed nauro from .cursor/mcp.json\n"
+            "  removed {TMP}/repo/.cursor/rules/nauro-adopt.mdc\n"
+            "Codex: preserved nauro entry in {TMP}/.codex/config.toml (other nauro projects"
+            " still registered)\n"
+            "  preserved ~/.agents/skills/nauro-* (other nauro projects still registered)\n"
+            "  {TMP}/repo: no nauro Codex hooks to remove\n"
+            "  {TMP}/repo: removed generated AGENTS.md\n"
+        )
+        assert result.stderr == ""
+        assert (tmp_path / ".claude" / "skills" / "nauro-adopt" / "SKILL.md").is_file()
+        assert (tmp_path / ".agents" / "skills" / "nauro-adopt" / "SKILL.md").is_file()
+
+    def test_add_multi_repo_interleaving(self, tmp_path: Path, monkeypatch):
+        """Per-repo ordering: all .mcp.json writes first, then per-repo Cursor pairs."""
+        _register_project(tmp_path, monkeypatch, repos=("repo1", "repo2"))
+
+        result = runner.invoke(app, ["setup", "all"])
+
+        assert result.exit_code == 0
+        assert _norm(result.stdout, tmp_path) == (
+            "Configured Nauro for project 'proj' across all surfaces:\n"
+            "\n"
+            "  {TMP}/repo1: wrote nauro to .mcp.json\n"
+            "  {TMP}/repo2: wrote nauro to .mcp.json\n"
+            "  wrote {TMP}/.claude/skills/nauro-adopt/SKILL.md\n"
+            "  {TMP}/repo1: wrote nauro to .cursor/mcp.json\n"
+            "  wrote {TMP}/repo1/.cursor/rules/nauro-adopt.mdc\n"
+            "  {TMP}/repo2: wrote nauro to .cursor/mcp.json\n"
+            "  wrote {TMP}/repo2/.cursor/rules/nauro-adopt.mdc\n"
+            "Codex: wrote nauro to {TMP}/.codex/config.toml\n"
+            "  wrote {TMP}/.agents/skills/nauro-adopt/SKILL.md\n"
+            "  {TMP}/repo1: regenerated AGENTS.md\n"
+            "  {TMP}/repo2: regenerated AGENTS.md\n"
+            "\n" + ALL_RESTART_LINE + "\n" + TRY_IT_LINE
+        )
+        assert result.stderr == ""
+
+    def test_add_with_skills_only(self, tmp_path: Path, monkeypatch):
+        """--with-skills alone installs opt-in skills but no subagents or hooks.
+
+        Opt-in skills land in both skill roots with their Cursor rules; no agents
+        are installed, no hooks wired, and the transcript warns that the ship-task
+        chain still needs --with-subagents.
+        """
+        _register_project(tmp_path, monkeypatch)
+
+        result = runner.invoke(app, ["setup", "all", "--with-skills"])
+
+        assert result.exit_code == 0
+        assert _norm(result.stdout, tmp_path) == (
+            "Configured Nauro for project 'proj' across all surfaces:\n"
+            "\n"
+            "  {TMP}/repo: wrote nauro to .mcp.json\n"
+            "  wrote {TMP}/.claude/skills/nauro-adopt/SKILL.md\n"
+            "  wrote {TMP}/.claude/skills/nauro-ship-task/SKILL.md\n"
+            "  wrote {TMP}/.claude/skills/nauro-context/SKILL.md\n"
+            "  wrote {TMP}/.claude/skills/nauro-loop/SKILL.md\n"
+            "  {TMP}/repo: wrote nauro to .cursor/mcp.json\n"
+            "  wrote {TMP}/repo/.cursor/rules/nauro-adopt.mdc\n"
+            "  wrote {TMP}/repo/.cursor/rules/nauro-ship-task.mdc\n"
+            "  wrote {TMP}/repo/.cursor/rules/nauro-context.mdc\n"
+            "  wrote {TMP}/repo/.cursor/rules/nauro-loop.mdc\n"
+            "Codex: wrote nauro to {TMP}/.codex/config.toml\n"
+            "  wrote {TMP}/.agents/skills/nauro-adopt/SKILL.md\n"
+            "  wrote {TMP}/.agents/skills/nauro-ship-task/SKILL.md\n"
+            "  wrote {TMP}/.agents/skills/nauro-context/SKILL.md\n"
+            "  wrote {TMP}/.agents/skills/nauro-loop/SKILL.md\n"
+            "  {TMP}/repo: regenerated AGENTS.md\n"
+            "\n" + SKILLS_NEEDS_SUBAGENTS_LINE + "\n" + ALL_RESTART_LINE + "\n" + TRY_IT_LINE
+        )
+        assert result.stderr == ""
+
+    def test_add_with_subagents_only(self, tmp_path: Path, monkeypatch):
+        """--with-subagents alone installs the four agents but no opt-in skills.
+
+        Only the adopt skill and rule are written, no hooks are wired, and the
+        transcript emits the connector-naming notice.
+        """
+        _register_project(tmp_path, monkeypatch)
+
+        result = runner.invoke(app, ["setup", "all", "--with-subagents"])
+
+        assert result.exit_code == 0
+        assert _norm(result.stdout, tmp_path) == (
+            "Configured Nauro for project 'proj' across all surfaces:\n"
+            "\n"
+            "  {TMP}/repo: wrote nauro to .mcp.json\n"
+            "  wrote {TMP}/.claude/skills/nauro-adopt/SKILL.md\n"
+            "  installed {TMP}/.claude/agents/nauro-planner.md\n"
+            "  installed {TMP}/.claude/agents/nauro-executor.md\n"
+            "  installed {TMP}/.claude/agents/nauro-reviewer.md\n"
+            "  installed {TMP}/.claude/agents/nauro-tech-lead.md\n"
+            "  {TMP}/repo: wrote nauro to .cursor/mcp.json\n"
+            "  wrote {TMP}/repo/.cursor/rules/nauro-adopt.mdc\n"
+            "Codex: wrote nauro to {TMP}/.codex/config.toml\n"
+            "  wrote {TMP}/.agents/skills/nauro-adopt/SKILL.md\n"
+            "  {TMP}/repo: regenerated AGENTS.md\n"
+            "\n" + CONNECTOR_NOTICE_LINE + "\n" + ALL_RESTART_LINE + "\n" + TRY_IT_LINE
+        )
+        assert result.stderr == ""
+
+    def test_add_with_hooks_only(self, tmp_path: Path, monkeypatch):
+        """--with-hooks alone wires the Claude and Codex hooks but no subagents.
+
+        Only the adopt skill and rule are written, and the transcript emits both
+        hook notices.
+        """
+        _register_project(tmp_path, monkeypatch)
+
+        result = runner.invoke(app, ["setup", "all", "--with-hooks"])
+
+        assert result.exit_code == 0
+        assert _norm(result.stdout, tmp_path) == (
+            "Configured Nauro for project 'proj' across all surfaces:\n"
+            "\n"
+            "  {TMP}/repo: wrote nauro to .mcp.json\n"
+            "  wrote {TMP}/.claude/skills/nauro-adopt/SKILL.md\n"
+            "  {TMP}/repo: wrote nauro hook to .claude/settings.json\n"
+            "  {TMP}/repo: wrote nauro to .cursor/mcp.json\n"
+            "  wrote {TMP}/repo/.cursor/rules/nauro-adopt.mdc\n"
+            "Codex: wrote nauro to {TMP}/.codex/config.toml\n"
+            "  wrote {TMP}/.agents/skills/nauro-adopt/SKILL.md\n"
+            "  {TMP}/repo: wrote nauro hooks to .codex/hooks.json\n"
+            "  {TMP}/repo: regenerated AGENTS.md\n"
+            "\n"
+            + HOOKS_NOTICE_LINE
+            + "\n"
+            + CODEX_HOOKS_NOTICE_LINE
+            + "\n"
+            + ALL_RESTART_LINE
+            + "\n"
+            + TRY_IT_LINE
+        )
+        assert result.stderr == ""
+
+    def test_subagents_rerun_refresh_saves_bak(self, tmp_path: Path, monkeypatch):
+        """Re-running --with-subagents over a user-edited agent stashes a .bak.
+
+        Without --force-overwrite the differing file is updated and its prior
+        content saved to <name>.md.bak; the unchanged agents report "unchanged".
+        """
+        _register_project(tmp_path, monkeypatch)
+        assert runner.invoke(app, ["setup", "all", "--with-subagents"]).exit_code == 0
+        (tmp_path / ".claude" / "agents" / "nauro-planner.md").write_text(
+            "USER EDIT\n", encoding="utf-8"
+        )
+
+        result = runner.invoke(app, ["setup", "all", "--with-subagents"])
+
+        assert result.exit_code == 0
+        assert _norm(result.stdout, tmp_path) == (
+            "Configured Nauro for project 'proj' across all surfaces:\n"
+            "\n"
+            "  {TMP}/repo: wrote nauro to .mcp.json\n"
+            "  wrote {TMP}/.claude/skills/nauro-adopt/SKILL.md\n"
+            "  updated {TMP}/.claude/agents/nauro-planner.md"
+            " (previous saved to nauro-planner.md.bak)\n"
+            "  unchanged {TMP}/.claude/agents/nauro-executor.md\n"
+            "  unchanged {TMP}/.claude/agents/nauro-reviewer.md\n"
+            "  unchanged {TMP}/.claude/agents/nauro-tech-lead.md\n"
+            "  {TMP}/repo: wrote nauro to .cursor/mcp.json\n"
+            "  wrote {TMP}/repo/.cursor/rules/nauro-adopt.mdc\n"
+            "Codex: nauro already configured in {TMP}/.codex/config.toml\n"
+            "  wrote {TMP}/.agents/skills/nauro-adopt/SKILL.md\n"
+            "  {TMP}/repo: regenerated AGENTS.md\n"
+            "\n" + CONNECTOR_NOTICE_LINE + "\n" + ALL_RESTART_LINE + "\n" + TRY_IT_LINE
+        )
+        assert result.stderr == ""
+        assert (tmp_path / ".claude" / "agents" / "nauro-planner.md.bak").read_text(
+            encoding="utf-8"
+        ) == "USER EDIT\n"
+
+    def test_subagents_rerun_force_overwrite_no_bak(self, tmp_path: Path, monkeypatch):
+        """--force-overwrite overwrites a user-edited agent in place with no .bak.
+
+        Re-running --with-subagents --force-overwrite replaces the differing file
+        directly and leaves no .bak sibling behind.
+        """
+        _register_project(tmp_path, monkeypatch)
+        assert runner.invoke(app, ["setup", "all", "--with-subagents"]).exit_code == 0
+        (tmp_path / ".claude" / "agents" / "nauro-planner.md").write_text(
+            "USER EDIT\n", encoding="utf-8"
+        )
+
+        result = runner.invoke(app, ["setup", "all", "--with-subagents", "--force-overwrite"])
+
+        assert result.exit_code == 0
+        assert _norm(result.stdout, tmp_path) == (
+            "Configured Nauro for project 'proj' across all surfaces:\n"
+            "\n"
+            "  {TMP}/repo: wrote nauro to .mcp.json\n"
+            "  wrote {TMP}/.claude/skills/nauro-adopt/SKILL.md\n"
+            "  overwrote {TMP}/.claude/agents/nauro-planner.md\n"
+            "  unchanged {TMP}/.claude/agents/nauro-executor.md\n"
+            "  unchanged {TMP}/.claude/agents/nauro-reviewer.md\n"
+            "  unchanged {TMP}/.claude/agents/nauro-tech-lead.md\n"
+            "  {TMP}/repo: wrote nauro to .cursor/mcp.json\n"
+            "  wrote {TMP}/repo/.cursor/rules/nauro-adopt.mdc\n"
+            "Codex: nauro already configured in {TMP}/.codex/config.toml\n"
+            "  wrote {TMP}/.agents/skills/nauro-adopt/SKILL.md\n"
+            "  {TMP}/repo: regenerated AGENTS.md\n"
+            "\n" + CONNECTOR_NOTICE_LINE + "\n" + ALL_RESTART_LINE + "\n" + TRY_IT_LINE
+        )
+        assert result.stderr == ""
+        assert not (tmp_path / ".claude" / "agents" / "nauro-planner.md.bak").exists()
+
+    def test_remove_orphans_optin_skills_and_subagents(self, tmp_path: Path, monkeypatch):
+        """Plain --remove orphans opt-in artifacts because it drops the flags.
+
+        Not re-passing the opt-in flags means teardown strips only the
+        always-installed adopt skill and rule; the opt-in skills (both skill
+        roots), their Cursor rules, and the four subagents are all left behind,
+        and the remove transcript is identical to a plain-add teardown. Changing
+        this is a named follow-up, not a silent move-time delta;
+        test_remove_with_flags_clears_optin_artifacts pins the complementary path
+        where the flags are re-passed.
+        """
+        _register_project(tmp_path, monkeypatch)
+        assert (
+            runner.invoke(app, ["setup", "all", "--with-skills", "--with-subagents"]).exit_code == 0
+        )
+
+        result = runner.invoke(app, ["setup", "all", "--remove"])
+
+        assert result.exit_code == 0
+        assert _norm(result.stdout, tmp_path) == (
+            "Removed Nauro for project 'proj' across all surfaces:\n"
+            "\n"
+            "  {TMP}/repo: removed nauro from .mcp.json\n"
+            "  removed {TMP}/.claude/skills/nauro-adopt/SKILL.md\n"
+            "  {TMP}/repo: no nauro hook to remove\n"
+            "  {TMP}/repo: removed nauro from .cursor/mcp.json\n"
+            "  removed {TMP}/repo/.cursor/rules/nauro-adopt.mdc\n"
+            "Codex: removed nauro from {TMP}/.codex/config.toml\n"
+            "  removed {TMP}/.agents/skills/nauro-adopt/SKILL.md\n"
+            "  {TMP}/repo: no nauro Codex hooks to remove\n"
+            "  {TMP}/repo: removed generated AGENTS.md\n"
+        )
+        assert result.stderr == ""
+        # The opt-in artifacts survive plain --remove (orphaned, by current design):
+        # opt-in skills in both skill roots, their Cursor rules, and all subagents.
+        for root in (".claude/skills", ".agents/skills"):
+            names = {p.name for p in (tmp_path / root).iterdir()}
+            assert names == {"nauro-ship-task", "nauro-context", "nauro-loop"}
+        rule_names = {p.name for p in (tmp_path / "repo" / ".cursor" / "rules").iterdir()}
+        assert rule_names == {
+            "nauro-ship-task.mdc",
+            "nauro-context.mdc",
+            "nauro-loop.mdc",
+        }
+        agent_names = {p.name for p in (tmp_path / ".claude" / "agents").iterdir()}
+        assert agent_names == {
+            "nauro-planner.md",
+            "nauro-executor.md",
+            "nauro-reviewer.md",
+            "nauro-tech-lead.md",
+        }
+
+    def test_remove_with_flags_clears_optin_artifacts(self, tmp_path: Path, monkeypatch):
+        """Re-passing the opt-in flags on remove clears every opt-in artifact.
+
+        Complement to the orphan case: --remove --with-skills --with-subagents
+        strips the opt-in skills (both roots), their Cursor rules, and the four
+        subagents alongside the always-installed adopt artifacts, leaving no
+        opt-in residue.
+        """
+        _register_project(tmp_path, monkeypatch)
+        assert (
+            runner.invoke(app, ["setup", "all", "--with-skills", "--with-subagents"]).exit_code == 0
+        )
+
+        result = runner.invoke(
+            app, ["setup", "all", "--remove", "--with-skills", "--with-subagents"]
+        )
+
+        assert result.exit_code == 0
+        assert _norm(result.stdout, tmp_path) == (
+            "Removed Nauro for project 'proj' across all surfaces:\n"
+            "\n"
+            "  {TMP}/repo: removed nauro from .mcp.json\n"
+            "  removed {TMP}/.claude/skills/nauro-adopt/SKILL.md\n"
+            "  removed {TMP}/.claude/skills/nauro-ship-task/SKILL.md\n"
+            "  removed {TMP}/.claude/skills/nauro-context/SKILL.md\n"
+            "  removed {TMP}/.claude/skills/nauro-loop/SKILL.md\n"
+            "  removed {TMP}/.claude/agents/nauro-planner.md\n"
+            "  removed {TMP}/.claude/agents/nauro-executor.md\n"
+            "  removed {TMP}/.claude/agents/nauro-reviewer.md\n"
+            "  removed {TMP}/.claude/agents/nauro-tech-lead.md\n"
+            "  {TMP}/repo: no nauro hook to remove\n"
+            "  {TMP}/repo: removed nauro from .cursor/mcp.json\n"
+            "  removed {TMP}/repo/.cursor/rules/nauro-adopt.mdc\n"
+            "  removed {TMP}/repo/.cursor/rules/nauro-ship-task.mdc\n"
+            "  removed {TMP}/repo/.cursor/rules/nauro-context.mdc\n"
+            "  removed {TMP}/repo/.cursor/rules/nauro-loop.mdc\n"
+            "Codex: removed nauro from {TMP}/.codex/config.toml\n"
+            "  removed {TMP}/.agents/skills/nauro-adopt/SKILL.md\n"
+            "  removed {TMP}/.agents/skills/nauro-ship-task/SKILL.md\n"
+            "  removed {TMP}/.agents/skills/nauro-context/SKILL.md\n"
+            "  removed {TMP}/.agents/skills/nauro-loop/SKILL.md\n"
+            "  {TMP}/repo: no nauro Codex hooks to remove\n"
+            "  {TMP}/repo: removed generated AGENTS.md\n"
+        )
+        assert result.stderr == ""
+        # No opt-in residue: skill roots gone, cursor rules dir emptied, no agents.
+        for root in (".claude/skills", ".agents/skills"):
+            d = tmp_path / root
+            assert not d.exists() or not any(d.iterdir())
+        rules_dir = tmp_path / "repo" / ".cursor" / "rules"
+        assert not rules_dir.exists() or not any(rules_dir.iterdir())
+        agents_dir = tmp_path / ".claude" / "agents"
+        assert not agents_dir.exists() or not any(agents_dir.iterdir())
+
+
+# ─── command-level idempotency ───────────────────────────────────────────────
+
+
+def _tree_bytes(root: Path) -> dict[str, bytes]:
+    return {rel: (root / rel).read_bytes() for rel in snapshot_tree(root)}
+
+
+_AGENTS_TS_PREFIX = "<!-- Auto-generated by Nauro ("
+
+
+def _mask_agents_md_timestamp(data: bytes) -> bytes:
+    """Mask the single UTC-timestamp comment line in an AGENTS.md body."""
+    lines = data.decode("utf-8").splitlines(keepends=True)
+    masked = [
+        "<!-- Auto-generated by Nauro ({TS}). -->\n" if line.startswith(_AGENTS_TS_PREFIX) else line
+        for line in lines
+    ]
+    return "".join(masked).encode("utf-8")
+
+
+def _assert_trees_identical(first: dict[str, bytes], second: dict[str, bytes]) -> None:
+    """Byte-identity across runs; AGENTS.md compared with its timestamp masked.
+
+    AGENTS.md is regenerated on every add run with a fresh UTC timestamp, so
+    it is the one artifact excluded from byte-equality.
+    """
+    assert sorted(first) == sorted(second)
+    for rel, before in first.items():
+        after = second[rel]
+        if rel.rsplit("/", 1)[-1] == "AGENTS.md":
+            assert _mask_agents_md_timestamp(before) == _mask_agents_md_timestamp(after), rel
+        else:
+            assert before == after, rel
+
+
+class TestCommandIdempotency:
+    def test_claude_code_rerun(self, tmp_path: Path, monkeypatch):
+        _register_project(tmp_path, monkeypatch)
+
+        first = runner.invoke(app, ["setup", "claude-code"])
+        assert first.exit_code == 0
+        tree_first = _tree_bytes(tmp_path)
+
+        second = runner.invoke(app, ["setup", "claude-code"])
+        assert second.exit_code == 0
+
+        _assert_trees_identical(tree_first, _tree_bytes(tmp_path))
+        # The second run re-reports "wrote"/"regenerated" rather than a no-op.
+        assert second.stdout == first.stdout
+        assert second.stderr == ""
+
+    def test_cursor_rerun(self, tmp_path: Path, monkeypatch):
+        _register_project(tmp_path, monkeypatch)
+
+        first = runner.invoke(app, ["setup", "cursor"])
+        assert first.exit_code == 0
+        tree_first = _tree_bytes(tmp_path)
+
+        second = runner.invoke(app, ["setup", "cursor"])
+        assert second.exit_code == 0
+
+        _assert_trees_identical(tree_first, _tree_bytes(tmp_path))
+        # The second run re-reports "wrote" rather than a no-op.
+        assert second.stdout == first.stdout
+        assert second.stderr == ""
+
+    def test_codex_rerun(self, tmp_path: Path, monkeypatch):
+        _register_project(tmp_path, monkeypatch)
+
+        first = runner.invoke(app, ["setup", "codex"])
+        assert first.exit_code == 0
+        tree_first = _tree_bytes(tmp_path)
+
+        second = runner.invoke(app, ["setup", "codex"])
+        assert second.exit_code == 0
+
+        _assert_trees_identical(tree_first, _tree_bytes(tmp_path))
+        # Unlike the JSON MCP sinks, codex reports an explicit no-op.
+        assert _norm(second.stdout, tmp_path) == (
+            "Codex: nauro already configured in {TMP}/.codex/config.toml\n"
+            "\n" + CODEX_NEXT_LINE + "\n" + TRY_IT_LINE
+        )
+        assert second.stderr == ""
+
+    def test_all_full_flags_rerun(self, tmp_path: Path, monkeypatch):
+        _register_project(tmp_path, monkeypatch)
+        args = ["setup", "all", "--with-skills", "--with-subagents", "--with-hooks"]
+
+        first = runner.invoke(app, args)
+        assert first.exit_code == 0
+        tree_first = _tree_bytes(tmp_path)
+
+        second = runner.invoke(app, args)
+        assert second.exit_code == 0
+
+        _assert_trees_identical(tree_first, _tree_bytes(tmp_path))
+        # The current mix: .mcp.json/.cursor/skills re-report "wrote", while
+        # agents, hooks, and codex report explicit no-op statuses.
+        assert _norm(second.stdout, tmp_path) == (
+            "Configured Nauro for project 'proj' across all surfaces:\n"
+            "\n"
+            "  {TMP}/repo: wrote nauro to .mcp.json\n"
+            "  wrote {TMP}/.claude/skills/nauro-adopt/SKILL.md\n"
+            "  wrote {TMP}/.claude/skills/nauro-ship-task/SKILL.md\n"
+            "  wrote {TMP}/.claude/skills/nauro-context/SKILL.md\n"
+            "  wrote {TMP}/.claude/skills/nauro-loop/SKILL.md\n"
+            "  unchanged {TMP}/.claude/agents/nauro-planner.md\n"
+            "  unchanged {TMP}/.claude/agents/nauro-executor.md\n"
+            "  unchanged {TMP}/.claude/agents/nauro-reviewer.md\n"
+            "  unchanged {TMP}/.claude/agents/nauro-tech-lead.md\n"
+            "  {TMP}/repo: nauro hook already present in .claude/settings.json\n"
+            "  {TMP}/repo: wrote nauro to .cursor/mcp.json\n"
+            "  wrote {TMP}/repo/.cursor/rules/nauro-adopt.mdc\n"
+            "  wrote {TMP}/repo/.cursor/rules/nauro-ship-task.mdc\n"
+            "  wrote {TMP}/repo/.cursor/rules/nauro-context.mdc\n"
+            "  wrote {TMP}/repo/.cursor/rules/nauro-loop.mdc\n"
+            "Codex: nauro already configured in {TMP}/.codex/config.toml\n"
+            "  wrote {TMP}/.agents/skills/nauro-adopt/SKILL.md\n"
+            "  wrote {TMP}/.agents/skills/nauro-ship-task/SKILL.md\n"
+            "  wrote {TMP}/.agents/skills/nauro-context/SKILL.md\n"
+            "  wrote {TMP}/.agents/skills/nauro-loop/SKILL.md\n"
+            "  {TMP}/repo: nauro hooks already present in .codex/hooks.json\n"
+            "  {TMP}/repo: regenerated AGENTS.md\n"
+            "\n"
+            + CONNECTOR_NOTICE_LINE
+            + "\n"
+            + HOOKS_NOTICE_LINE
+            + "\n"
+            + CODEX_HOOKS_NOTICE_LINE
+            + "\n"
+            + ALL_RESTART_LINE
+            + "\n"
+            + TRY_IT_LINE
+        )
+        assert second.stderr == ""
+
+
+# ─── partial failure end-to-end ──────────────────────────────────────────────
+
+
+class TestPartialFailure:
+    def test_cursor_symlink_in_one_repo_of_two(self, tmp_path: Path, monkeypatch):
+        """A symlinked .cursor in repo1 refuses only that repo's Cursor artifacts.
+
+        Everything else (both .mcp.json files, repo2's Cursor pair, codex,
+        skills, both AGENTS.md files) is still configured, and the command
+        exits 0.
+        """
+        _pid, _store, paths = _register_project(tmp_path, monkeypatch, repos=("repo1", "repo2"))
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (paths[0] / ".cursor").symlink_to(outside)
+
+        result = runner.invoke(app, ["setup", "all"])
+
+        assert result.exit_code == 0
+        assert _norm(result.stdout, tmp_path) == (
+            "Configured Nauro for project 'proj' across all surfaces:\n"
+            "\n"
+            "  {TMP}/repo1: wrote nauro to .mcp.json\n"
+            "  {TMP}/repo2: wrote nauro to .mcp.json\n"
+            "  wrote {TMP}/.claude/skills/nauro-adopt/SKILL.md\n"
+            "  {TMP}/repo1: refused to modify {TMP}/repo1/.cursor/mcp.json:"
+            " {TMP}/repo1/.cursor is a symlink; Nauro does not write through symlinks in a"
+            " repo checkout\n"
+            "  {TMP}/repo1: refused to modify {TMP}/repo1/.cursor/rules/nauro-adopt.mdc:"
+            " {TMP}/repo1/.cursor is a symlink; Nauro does not write through symlinks in a"
+            " repo checkout\n"
+            "  {TMP}/repo2: wrote nauro to .cursor/mcp.json\n"
+            "  wrote {TMP}/repo2/.cursor/rules/nauro-adopt.mdc\n"
+            "Codex: wrote nauro to {TMP}/.codex/config.toml\n"
+            "  wrote {TMP}/.agents/skills/nauro-adopt/SKILL.md\n"
+            "  {TMP}/repo1: regenerated AGENTS.md\n"
+            "  {TMP}/repo2: regenerated AGENTS.md\n"
+            "\n" + ALL_RESTART_LINE + "\n" + TRY_IT_LINE
+        )
+        assert result.stderr == ""
+        # Refused path untouched: nothing written through the planted link.
+        assert (paths[0] / ".cursor").is_symlink()
+        assert list(outside.iterdir()) == []
+        # Everything else configured.
+        assert (paths[0] / ".mcp.json").is_file()
+        assert (paths[0] / "AGENTS.md").is_file()
+        assert (paths[1] / ".cursor" / "mcp.json").is_file()
+        assert (paths[1] / ".cursor" / "rules" / "nauro-adopt.mdc").is_file()
+        assert (tmp_path / ".codex" / "config.toml").is_file()
+        assert (tmp_path / ".claude" / "skills" / "nauro-adopt" / "SKILL.md").is_file()
+
+    def test_mcp_json_symlink_single_repo(self, tmp_path: Path, monkeypatch):
+        """A symlinked .mcp.json refuses only that artifact; the rest proceeds."""
+        _pid, _store, paths = _register_project(tmp_path, monkeypatch)
+        outside = tmp_path / "outside.json"
+        outside.write_text("{}")
+        (paths[0] / ".mcp.json").symlink_to(outside)
+
+        result = runner.invoke(app, ["setup", "all"])
+
+        assert result.exit_code == 0
+        assert _norm(result.stdout, tmp_path) == (
+            "Configured Nauro for project 'proj' across all surfaces:\n"
+            "\n"
+            "  {TMP}/repo: refused to modify {TMP}/repo/.mcp.json: it is a symlink; Nauro"
+            " does not write through symlinks in a repo checkout\n"
+            "  wrote {TMP}/.claude/skills/nauro-adopt/SKILL.md\n"
+            "  {TMP}/repo: wrote nauro to .cursor/mcp.json\n"
+            "  wrote {TMP}/repo/.cursor/rules/nauro-adopt.mdc\n"
+            "Codex: wrote nauro to {TMP}/.codex/config.toml\n"
+            "  wrote {TMP}/.agents/skills/nauro-adopt/SKILL.md\n"
+            "  {TMP}/repo: regenerated AGENTS.md\n"
+            "\n" + ALL_RESTART_LINE + "\n" + TRY_IT_LINE
+        )
+        assert result.stderr == ""
+        assert (paths[0] / ".mcp.json").is_symlink()
+        assert outside.read_text() == "{}"
+        assert (paths[0] / ".cursor" / "mcp.json").is_file()
+        assert (paths[0] / "AGENTS.md").is_file()
+
+
+# ─── resolver warning shape ──────────────────────────────────────────────────
+
+
+def _interpreter_sibling() -> str:
+    """The nauro console script next to the running interpreter.
+
+    Mirrors the resolver's sibling discovery so the expected {NAURO_CMD}
+    value can be computed without importing the setup module. Both warning
+    variants resolve to the sibling when one exists; skip when the test
+    interpreter has none, since the resolver would then pick a different
+    fallback shape.
+    """
+    bindir = Path(sys.executable).parent
+    for name in ("nauro", "nauro.exe"):
+        candidate = bindir / name
+        if candidate.is_file():
+            return str(candidate)
+    pytest.skip("no nauro console script next to the test interpreter")
+
+
+class TestResolverWarningShape:
+    def test_fragile_path_warning_once_on_stderr(self, tmp_path: Path, monkeypatch):
+        """Nothing durable but the sibling runs: one fragile warning per invocation."""
+        from nauro.cli import utils as cli_utils
+
+        sibling = _interpreter_sibling()
+        monkeypatch.setattr(cli_utils, "_is_durable_install_path", lambda path: False)
+        _register_project(tmp_path, monkeypatch)
+
+        result = runner.invoke(app, ["setup", "all"])
+
+        assert result.exit_code == 0
+        assert _norm(result.stdout, tmp_path) == _all_add_plain_expected()
+        assert normalize_transcript(
+            result.stderr, {sibling: "{NAURO_CMD}", str(tmp_path): "{TMP}"}
+        ) == (
+            "WARNING: recording nauro from a project virtualenv ({NAURO_CMD}).\n"
+            "  This path breaks if the repo's virtualenv is rebuilt, moved, or corrupted,"
+            " silently killing Nauro's MCP server and hooks. Install nauro durably (pipx"
+            " install nauro, or uv tool install nauro) and re-run 'nauro setup all'.\n"
+        )
+
+    def test_unresolved_warning_once_on_stderr(self, tmp_path: Path, monkeypatch):
+        """No candidate runs at all: one unresolved warning per invocation."""
+        from nauro.cli import utils as cli_utils
+
+        sibling = _interpreter_sibling()
+        monkeypatch.setattr(cli_utils, "probe_nauro_command", lambda cmd, **kwargs: False)
+        _register_project(tmp_path, monkeypatch)
+
+        result = runner.invoke(app, ["setup", "all"])
+
+        assert result.exit_code == 0
+        assert _norm(result.stdout, tmp_path) == _all_add_plain_expected()
+        assert normalize_transcript(
+            result.stderr, {sibling: "{NAURO_CMD}", str(tmp_path): "{TMP}"}
+        ) == (
+            "WARNING: could not validate a working nauro; recorded '{NAURO_CMD}'.\n"
+            "  Nauro's MCP server and hooks will not work until nauro is installed on a"
+            " durable PATH (pipx install nauro, or uv tool install nauro), then re-run"
+            " 'nauro setup all'.\n"
+        )


### PR DESCRIPTION
## Why

The setup module is about to be restructured internally. This suite pins the current observable behavior of the `nauro setup` surface and the onboarding flows so the upcoming move-only PRs can be verified behavior-neutral against it. Behavior is pinned exactly as it stands, asymmetries included; nothing here is a judgment that the pinned behavior is right.

## What changed

Test-only; no source changes.

- `test_setup_characterization.py`: exact-equality transcript pins (stdout and stderr asserted separately, exact exit codes) for `setup claude-code` / `cursor` / `codex` / `all` across add, remove, and every flag variant. `setup all` is pinned plain, with all flags together, and with each opt-in flag on its own (`--with-skills`, `--with-subagents`, `--with-hooks`), so the conditional wiring each flag drives is characterized independently. Also pinned: `--with-subagents` re-run over a user-edited agent both saving a `.bak` and, under `--force-overwrite`, overwriting with none; and the two removal shapes that bracket a real asymmetry, where plain `--remove` orphans the opt-in skills, their Cursor rules, and the subagents (because it does not re-pass the flags) while `--remove --with-skills --with-subagents` clears them all. Command-level idempotency pins that a second run leaves every artifact byte-identical (AGENTS.md compared with its single UTC-timestamp header line masked) and pins the second-run transcript as it stands, including the asymmetry where JSON sinks re-report "wrote" while codex, hooks, and agents no-op. Partial-failure runs with planted symlinks pin exit 0, per-artifact refusal lines, other artifacts still configured, and refused paths untouched. Resolver-warning shapes (fragile and unresolved) each pin exactly one warning on stderr across a full `setup all` run. Expected strings are inline literals and the module imports nothing from the setup command module, so a refactor cannot rewrite the expectations it is checked against.
- `test_onboarding_inventories.py`: full filesystem inventories (set equality over repo + fake HOME) for `adopt` (default, `--with-skills --with-subagents`, `--no-setup-and-skills`), the `adopt --remove` round trip (teardown-inversion residue pinned: the intact store, registry/telemetry bookkeeping, and the emptied `~/.codex/config.toml`), `init` with a repo association, the `attach` happy path (store directory created empty, no scaffold), and `adopt --remove` of a project's last repo while a second project remains registered (user-scope artifacts preserved). Inventory assertions plus ordered section-marker checks; full transcripts are not pinned here because adopt requires a real git repo, whose hygiene notes vary with the environment.
- `conftest.py` (additive only): `normalize_transcript` (placeholder masking for volatile values such as the tmp dir and the resolved nauro entrypoint) and `snapshot_tree` (sorted relative POSIX file listing, `.git` subtrees excluded).

## Risk / what to review

- The two resolver-warning tests override the same probe seam (`cli_utils.probe_nauro_command` / `cli_utils._is_durable_install_path`) the autouse conftest fixture patches, and ride that fixture's existing retarget obligation; the module docstring flags this. They skip when no `nauro` console script sits next to the test interpreter, since the resolver would then take a different fallback shape.
- The inventory module clears `NAURO_TELEMETRY` so the default first-run bookkeeping (`config.json` + `config.lock` under NAURO_HOME) is pinned regardless of the developer's shell.

## Deferred

- Windows-shaped transcript pins: the characterization module is POSIX-only (path shapes, env-based home redirection, symlink fixtures), following the suite's existing nt-skip convention.
- Any behavior change for the pinned oddities (for example "wrote" re-reported on no-op re-runs, the emptied `~/.codex/config.toml` surviving last-project teardown, the Hooks section emitted on removes that never wired hooks, `setup claude-code --remove` leaving AGENTS.md in place, or plain `setup all --remove` orphaning opt-in skills/subagents). The pins record them; changing any is follow-up work with its own review.

## Test plan

- `packages/nauro/tests/ -q`: 1843 passed, 10 skipped (baseline 1807 + 36 new across the two files).
- `packages/nauro-core/tests/ -q`: 1073 passed.
- Determinism: both new files run twice back-to-back, 36/36 both times; the AGENTS.md timestamp line is masked in the idempotency comparisons so a second-boundary rollover cannot flake.
- Every pinned transcript and inventory was captured from real isolated-HOME CLI output, not constructed from the code under test.
- `ruff check packages/` and `ruff format --check packages/` clean.
