### PR TITLE
Extract the skills codec into cli/integrations/

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/adopt.py
+++ b/packages/nauro/src/nauro/cli/commands/adopt.py
@@ -31,14 +31,13 @@ from pathlib import Path
 import typer
 
 from nauro.cli.commands.setup import (
-    OPT_IN_SKILL_NAMES,
     SHIP_TASK_NEEDS_SUBAGENTS_NOTICE,
-    SKILL_NAMES,
     SUBAGENTS_CONNECTOR_NAME_NOTICE,
     _find_nauro_command,
     setup_all_surfaces,
 )
 from nauro.cli.git_hygiene import public_surface_git_warnings
+from nauro.cli.integrations.skills import OPT_IN_SKILL_NAMES, SKILL_NAMES
 from nauro.cli.utils import refuse_global_config_collision, refuse_repo_config_symlink
 from nauro.constants import REGISTRY_SCHEMA_VERSION_V2, REPO_CONFIG_MODE_LOCAL
 from nauro.skills import load_adopt_body

--- a/packages/nauro/src/nauro/cli/commands/setup.py
+++ b/packages/nauro/src/nauro/cli/commands/setup.py
@@ -32,6 +32,11 @@ from nauro.cli._codex_hooks import (
     _validate_codex_hooks,
 )
 from nauro.cli.git_hygiene import public_surface_git_warnings
+from nauro.cli.integrations.skills import (
+    materialize_skills_claude_code,
+    materialize_skills_codex,
+    materialize_skills_cursor_for_repo,
+)
 from nauro.cli.utils import _resolve_project_entry, resolve_target_project
 from nauro.constants import CLAUDE_MD, NAURO_BLOCK_END, NAURO_BLOCK_START
 from nauro.store._atomic import atomic_write_text
@@ -704,169 +709,8 @@ def codex(
         typer.echo(f"\n{CHECK_HINT_LINE}")
 
 
-# ─── Skill materialization ──────────────────────────────────────────────────
-
-
-# Skills are rendered from canonical bodies in nauro.skills and written into
-# the user's surface directories. Claude Code and Codex skills are user-global;
-# Cursor skills ship per-project (Cursor's "User Rules" live in the IDE
-# Settings UI, not a file path).
-#
-# ``SKILL_NAMES`` is the always-installed set — the core onboarding skill.
-# ``OPT_IN_SKILL_NAMES`` is materialized only when the caller passes
-# ``with_skills=True``. ``nauro-ship-task`` references the bundled ``@nauro-*``
-# subagents and is opt-in for that reason, so the ``--with-subagents`` notice
-# stays scoped to it. ``nauro-loop`` dispatches ``/nauro-ship-task``
-# byte-for-byte, so it carries the same subagent dependency transitively.
-# ``nauro-context`` composes only existing MCP tools (plus the agent's own
-# filesystem write) with no subagent dependency, so it carries no such notice.
-
-SKILL_NAMES: tuple[str, ...] = ("nauro-adopt",)
-OPT_IN_SKILL_NAMES: tuple[str, ...] = ("nauro-ship-task", "nauro-context", "nauro-loop")
-
-
-def _claude_skill_dir() -> Path:
-    return Path.home() / ".claude" / "skills"
-
-
-def _codex_skill_dir() -> Path:
-    return Path.home() / ".agents" / "skills"
-
-
 def _claude_agent_dir() -> Path:
     return Path.home() / ".claude" / "agents"
-
-
-def _materialize_skill_file(target: Path, content: str) -> str:
-    refusal = find_file_symlink(target)
-    if refusal is not None:
-        return f"  {refusal.message}"
-    target.parent.mkdir(parents=True, exist_ok=True)
-    target.write_text(content, encoding="utf-8")
-    return f"  wrote {target}"
-
-
-def _remove_skill_file(target: Path, *, stop_above: Path) -> str:
-    """Unlink ``target`` and prune empty parents, but never above ``stop_above``.
-
-    Without the bound the parent walk could rmdir the surface base
-    (``~/.claude/skills/``, ``<repo>/.cursor/rules/``, etc.) or — worse —
-    keep going if those happen to be empty after MCP config also got removed.
-    """
-    refusal = find_file_symlink(target)
-    if refusal is not None:
-        return f"  {refusal.message}"
-    if not target.is_file():
-        return f"  no skill at {target}"
-    target.unlink()
-    stop_resolved = stop_above.resolve()
-    parent = target.parent
-    while parent.is_dir() and not any(parent.iterdir()):
-        if parent.resolve() == stop_resolved:
-            break
-        parent.rmdir()
-        parent = parent.parent
-    return f"  removed {target}"
-
-
-def _resolved_skill_names(with_skills: bool) -> tuple[str, ...]:
-    """Return the union of always-installed skills and opt-in skills.
-
-    ``with_skills=False`` (the default for callers that pre-date the flag)
-    installs only the core onboarding skills in ``SKILL_NAMES``.
-    ``with_skills=True`` extends with ``OPT_IN_SKILL_NAMES`` so future opt-in
-    skills can ride alongside ``nauro-ship-task`` under the same flag.
-    """
-    return SKILL_NAMES + OPT_IN_SKILL_NAMES if with_skills else SKILL_NAMES
-
-
-def materialize_skills_claude_code(
-    *,
-    remove: bool,
-    clear_user_scope: bool = True,
-    with_skills: bool = False,
-) -> list[str]:
-    """Install or remove the Nauro skill(s) under ``~/.claude/skills/``.
-
-    ``clear_user_scope`` gates the remove path: when False, the skill files
-    are preserved because other registered nauro projects still depend on
-    them. Defaults to True so direct unit callers and the add path retain
-    their previous behavior. ``with_skills`` extends the install/remove set
-    with ``OPT_IN_SKILL_NAMES`` (``nauro-ship-task``, ``nauro-context``, and
-    ``nauro-loop``).
-    """
-    from nauro.skills import render_skill
-
-    base = _claude_skill_dir()
-    if remove and not clear_user_scope:
-        return ["  preserved ~/.claude/skills/nauro-* (other nauro projects still registered)"]
-
-    results: list[str] = []
-    for name in _resolved_skill_names(with_skills):
-        target = base / name / "SKILL.md"
-        if remove:
-            results.append(_remove_skill_file(target, stop_above=base))
-        else:
-            results.append(_materialize_skill_file(target, render_skill("claude_code", name)))
-    return results
-
-
-def materialize_skills_codex(
-    *,
-    remove: bool,
-    clear_user_scope: bool = True,
-    with_skills: bool = False,
-) -> list[str]:
-    """Install or remove the Nauro skill(s) under ``~/.agents/skills/``.
-
-    ``clear_user_scope`` gates the remove path: when False, the skill files
-    are preserved because other registered nauro projects still depend on
-    them. Defaults to True so direct unit callers and the add path retain
-    their previous behavior. ``with_skills`` extends the install/remove set
-    with ``OPT_IN_SKILL_NAMES`` (``nauro-ship-task``, ``nauro-context``, and
-    ``nauro-loop``).
-    """
-    from nauro.skills import render_skill
-
-    base = _codex_skill_dir()
-    if remove and not clear_user_scope:
-        return ["  preserved ~/.agents/skills/nauro-* (other nauro projects still registered)"]
-
-    results: list[str] = []
-    for name in _resolved_skill_names(with_skills):
-        target = base / name / "SKILL.md"
-        if remove:
-            results.append(_remove_skill_file(target, stop_above=base))
-        else:
-            results.append(_materialize_skill_file(target, render_skill("codex", name)))
-    return results
-
-
-def materialize_skills_cursor_for_repo(
-    repo: Path,
-    *,
-    remove: bool,
-    with_skills: bool = False,
-) -> list[str]:
-    """Install or remove Cursor rules under ``<repo>/.cursor/rules/``.
-
-    ``with_skills`` extends the install/remove set with ``OPT_IN_SKILL_NAMES``.
-    """
-    from nauro.skills import render_skill
-
-    base = repo / ".cursor" / "rules"
-    results: list[str] = []
-    for name in _resolved_skill_names(with_skills):
-        refusal = find_symlink(repo, f".cursor/rules/{name}.mdc")
-        if refusal is not None:
-            results.append(f"  {repo}: {refusal.message}")
-            continue
-        target = base / f"{name}.mdc"
-        if remove:
-            results.append(_remove_skill_file(target, stop_above=base))
-        else:
-            results.append(_materialize_skill_file(target, render_skill("cursor", name)))
-    return results
 
 
 # ─── Agent materialization ──────────────────────────────────────────────────

--- a/packages/nauro/src/nauro/cli/integrations/__init__.py
+++ b/packages/nauro/src/nauro/cli/integrations/__init__.py
@@ -1,0 +1,1 @@
+"""Artifact codecs and orchestration policy for the setup surface."""

--- a/packages/nauro/src/nauro/cli/integrations/skills.py
+++ b/packages/nauro/src/nauro/cli/integrations/skills.py
@@ -1,0 +1,164 @@
+"""Skill artifact codec for the setup surface."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from nauro.store.write_safety import find_file_symlink, find_symlink
+
+# Skills are rendered from canonical bodies in nauro.skills and written into
+# the user's surface directories. Claude Code and Codex skills are user-global;
+# Cursor skills ship per-project (Cursor's "User Rules" live in the IDE
+# Settings UI, not a file path).
+#
+# ``SKILL_NAMES`` is the always-installed set — the core onboarding skill.
+# ``OPT_IN_SKILL_NAMES`` is materialized only when the caller passes
+# ``with_skills=True``. ``nauro-ship-task`` references the bundled ``@nauro-*``
+# subagents and is opt-in for that reason, so the ``--with-subagents`` notice
+# stays scoped to it. ``nauro-loop`` dispatches ``/nauro-ship-task``
+# byte-for-byte, so it carries the same subagent dependency transitively.
+# ``nauro-context`` composes only existing MCP tools (plus the agent's own
+# filesystem write) with no subagent dependency, so it carries no such notice.
+
+SKILL_NAMES: tuple[str, ...] = ("nauro-adopt",)
+OPT_IN_SKILL_NAMES: tuple[str, ...] = ("nauro-ship-task", "nauro-context", "nauro-loop")
+
+
+def _claude_skill_dir() -> Path:
+    return Path.home() / ".claude" / "skills"
+
+
+def _codex_skill_dir() -> Path:
+    return Path.home() / ".agents" / "skills"
+
+
+def _materialize_skill_file(target: Path, content: str) -> str:
+    refusal = find_file_symlink(target)
+    if refusal is not None:
+        return f"  {refusal.message}"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content, encoding="utf-8")
+    return f"  wrote {target}"
+
+
+def _remove_skill_file(target: Path, *, stop_above: Path) -> str:
+    """Unlink ``target`` and prune empty parents, but never above ``stop_above``.
+
+    Without the bound the parent walk could rmdir the surface base
+    (``~/.claude/skills/``, ``<repo>/.cursor/rules/``, etc.) or — worse —
+    keep going if those happen to be empty after MCP config also got removed.
+    """
+    refusal = find_file_symlink(target)
+    if refusal is not None:
+        return f"  {refusal.message}"
+    if not target.is_file():
+        return f"  no skill at {target}"
+    target.unlink()
+    stop_resolved = stop_above.resolve()
+    parent = target.parent
+    while parent.is_dir() and not any(parent.iterdir()):
+        if parent.resolve() == stop_resolved:
+            break
+        parent.rmdir()
+        parent = parent.parent
+    return f"  removed {target}"
+
+
+def _resolved_skill_names(with_skills: bool) -> tuple[str, ...]:
+    """Return the union of always-installed skills and opt-in skills.
+
+    ``with_skills=False`` (the default for callers that pre-date the flag)
+    installs only the core onboarding skills in ``SKILL_NAMES``.
+    ``with_skills=True`` extends with ``OPT_IN_SKILL_NAMES`` so future opt-in
+    skills can ride alongside ``nauro-ship-task`` under the same flag.
+    """
+    return SKILL_NAMES + OPT_IN_SKILL_NAMES if with_skills else SKILL_NAMES
+
+
+def materialize_skills_claude_code(
+    *,
+    remove: bool,
+    clear_user_scope: bool = True,
+    with_skills: bool = False,
+) -> list[str]:
+    """Install or remove the Nauro skill(s) under ``~/.claude/skills/``.
+
+    ``clear_user_scope`` gates the remove path: when False, the skill files
+    are preserved because other registered nauro projects still depend on
+    them. Defaults to True so direct unit callers and the add path retain
+    their previous behavior. ``with_skills`` extends the install/remove set
+    with ``OPT_IN_SKILL_NAMES`` (``nauro-ship-task``, ``nauro-context``, and
+    ``nauro-loop``).
+    """
+    from nauro.skills import render_skill
+
+    base = _claude_skill_dir()
+    if remove and not clear_user_scope:
+        return ["  preserved ~/.claude/skills/nauro-* (other nauro projects still registered)"]
+
+    results: list[str] = []
+    for name in _resolved_skill_names(with_skills):
+        target = base / name / "SKILL.md"
+        if remove:
+            results.append(_remove_skill_file(target, stop_above=base))
+        else:
+            results.append(_materialize_skill_file(target, render_skill("claude_code", name)))
+    return results
+
+
+def materialize_skills_codex(
+    *,
+    remove: bool,
+    clear_user_scope: bool = True,
+    with_skills: bool = False,
+) -> list[str]:
+    """Install or remove the Nauro skill(s) under ``~/.agents/skills/``.
+
+    ``clear_user_scope`` gates the remove path: when False, the skill files
+    are preserved because other registered nauro projects still depend on
+    them. Defaults to True so direct unit callers and the add path retain
+    their previous behavior. ``with_skills`` extends the install/remove set
+    with ``OPT_IN_SKILL_NAMES`` (``nauro-ship-task``, ``nauro-context``, and
+    ``nauro-loop``).
+    """
+    from nauro.skills import render_skill
+
+    base = _codex_skill_dir()
+    if remove and not clear_user_scope:
+        return ["  preserved ~/.agents/skills/nauro-* (other nauro projects still registered)"]
+
+    results: list[str] = []
+    for name in _resolved_skill_names(with_skills):
+        target = base / name / "SKILL.md"
+        if remove:
+            results.append(_remove_skill_file(target, stop_above=base))
+        else:
+            results.append(_materialize_skill_file(target, render_skill("codex", name)))
+    return results
+
+
+def materialize_skills_cursor_for_repo(
+    repo: Path,
+    *,
+    remove: bool,
+    with_skills: bool = False,
+) -> list[str]:
+    """Install or remove Cursor rules under ``<repo>/.cursor/rules/``.
+
+    ``with_skills`` extends the install/remove set with ``OPT_IN_SKILL_NAMES``.
+    """
+    from nauro.skills import render_skill
+
+    base = repo / ".cursor" / "rules"
+    results: list[str] = []
+    for name in _resolved_skill_names(with_skills):
+        refusal = find_symlink(repo, f".cursor/rules/{name}.mdc")
+        if refusal is not None:
+            results.append(f"  {repo}: {refusal.message}")
+            continue
+        target = base / f"{name}.mdc"
+        if remove:
+            results.append(_remove_skill_file(target, stop_above=base))
+        else:
+            results.append(_materialize_skill_file(target, render_skill("cursor", name)))
+    return results

--- a/packages/nauro/tests/test_setup_extended.py
+++ b/packages/nauro/tests/test_setup_extended.py
@@ -16,8 +16,8 @@ from nauro.cli.commands.setup import (
     _configure_codex,
     _configure_cursor_for_repo,
     _prune_redundant_user_scope_mcp,
-    materialize_skills_cursor_for_repo,
 )
+from nauro.cli.integrations.skills import materialize_skills_cursor_for_repo
 from nauro.cli.main import app
 from nauro.store.registry import register_project_v2
 from nauro.templates.scaffolds import scaffold_project_store
@@ -374,7 +374,7 @@ def test_setup_all_remove_clears_everything(tmp_path: Path, monkeypatch):
 
 def test_remove_skill_file_does_not_walk_above_base(tmp_path: Path):
     """``_remove_skill_file`` must stop at ``stop_above`` — never delete the surface root."""
-    from nauro.cli.commands.setup import _remove_skill_file
+    from nauro.cli.integrations.skills import _remove_skill_file
 
     base = tmp_path / ".claude" / "skills"
     skill_dir = base / "nauro-adopt"
@@ -393,7 +393,7 @@ def test_remove_skill_file_does_not_walk_above_base(tmp_path: Path):
 
 def test_remove_skill_file_preserves_sibling_skills(tmp_path: Path):
     """If `~/.claude/skills/` has other skills, removing nauro must not touch them."""
-    from nauro.cli.commands.setup import _remove_skill_file
+    from nauro.cli.integrations.skills import _remove_skill_file
 
     base = tmp_path / ".claude" / "skills"
     nauro_skill = base / "nauro-adopt" / "SKILL.md"

--- a/packages/nauro/tests/test_setup_user_write_safety.py
+++ b/packages/nauro/tests/test_setup_user_write_safety.py
@@ -24,11 +24,10 @@ import tomlkit
 from nauro.cli.commands.setup import (
     _configure_codex,
     _find_nauro_command,
-    _materialize_skill_file,
     _prune_redundant_user_scope_mcp,
-    _remove_skill_file,
     materialize_agents,
 )
+from nauro.cli.integrations.skills import _materialize_skill_file, _remove_skill_file
 
 if sys.version_info >= (3, 11):
     import tomllib


### PR DESCRIPTION
## Why

`cli/commands/setup.py` has grown into a monolith that mixes surface orchestration with the codecs that render and materialize onboarding artifacts. This PR opens the decomposition by establishing a dedicated `cli/integrations/` package and moving the skills artifact codec into `cli/integrations/skills.py`, so each unit is named for one job.

## What changed

- New `cli/integrations/` package (`__init__.py` documents it as artifact codecs and orchestration policy for the setup surface).
- Moved the skills codec verbatim into `cli/integrations/skills.py`: `SKILL_NAMES`, `OPT_IN_SKILL_NAMES`, the skill-dir helpers, the materialize/remove file helpers, `_resolved_skill_names`, and the three `materialize_skills_*` entry points. Function bodies are byte-identical to their originals; the lazy `render_skill` imports remain inside each function to preserve import-cycle behavior.
- Retargeted every internal importer in this PR: `setup.py` imports only the three functions it calls, `adopt.py` pulls the two name tuples from the new module, and the two test modules that exercise the codec directly import from it. No re-export shim is left in `setup.py`.

This is a pure move with no behavior change. The 36 setup behavior-oracle tests pass unmodified.

## Deferred

The rest of the setup decomposition series: extracting the agent codec (`_claude_agent_dir`, `materialize_agents`), the MCP/hook config codecs, the command resolvers, and the surface-orchestration policy into their own modules land in follow-up PRs.

## Test plan

- `pytest packages/nauro/tests/test_setup_characterization.py packages/nauro/tests/test_onboarding_inventories.py` → 36 passed, unmodified
- `pytest packages/nauro/tests/` → 1843 passed, 10 skipped
- `pytest packages/nauro-core/tests/` → 1073 passed
- `ruff check packages/` and `ruff format --check packages/` clean
