### PR TITLE
Extract the nauro command resolver into cli/nauro_command.py

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/adopt.py
+++ b/packages/nauro/src/nauro/cli/commands/adopt.py
@@ -33,11 +33,11 @@ import typer
 from nauro.cli.commands.setup import (
     SHIP_TASK_NEEDS_SUBAGENTS_NOTICE,
     SUBAGENTS_CONNECTOR_NAME_NOTICE,
-    _find_nauro_command,
     setup_all_surfaces,
 )
 from nauro.cli.git_hygiene import public_surface_git_warnings
 from nauro.cli.integrations.skills import OPT_IN_SKILL_NAMES, SKILL_NAMES
+from nauro.cli.nauro_command import _find_nauro_command
 from nauro.cli.utils import refuse_global_config_collision, refuse_repo_config_symlink
 from nauro.constants import REGISTRY_SCHEMA_VERSION_V2, REPO_CONFIG_MODE_LOCAL
 from nauro.skills import load_adopt_body

--- a/packages/nauro/src/nauro/cli/commands/setup.py
+++ b/packages/nauro/src/nauro/cli/commands/setup.py
@@ -10,10 +10,7 @@ Subcommands:
 
 from __future__ import annotations
 
-import functools
 import json
-import shutil
-import sys
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -22,9 +19,7 @@ import typer
 from tomlkit.exceptions import ParseError as TOMLParseError
 from tomlkit.items import InlineTable
 
-from nauro.cli import utils as cli_utils
 from nauro.cli._codex_hooks import (
-    _CODEX_HOOK_PROBE_ARGS,
     _CodexHookConfigError,
     _format_codex_hooks,
     _parse_codex_hooks,
@@ -41,6 +36,7 @@ from nauro.cli.integrations.skills import (
     materialize_skills_cursor_for_repo,
 )
 from nauro.cli.integrations.user_scope import _registered_project_keys, _user_scope_safe_to_clear
+from nauro.cli.nauro_command import _find_nauro_codex_hook_command, _find_nauro_command
 from nauro.cli.utils import _resolve_project_entry, resolve_target_project
 from nauro.store._atomic import atomic_write_text
 from nauro.store.registry import get_repo_paths
@@ -56,100 +52,6 @@ setup_app = typer.Typer(help="Configure tool integrations.")
 # against the local store, so users don't have to wait for an agent
 # restart to see Nauro do something useful.
 CHECK_HINT_LINE = 'Try it now from this shell: nauro check-decision "<approach>"'
-
-
-def _interpreter_sibling_candidate() -> str | None:
-    """Return the absolute path to a ``nauro`` console script next to the running
-    interpreter, or None when there isn't one.
-
-    This is the install the user actually invoked, which pipx/uv-tool layouts
-    keep off the PATH that GUI-launched agents see — recording its absolute path
-    is what makes the spawned stdio server and per-turn hook independent of the
-    agent's launch environment.
-    """
-    bindir = Path(sys.executable).parent
-    for name in ("nauro", "nauro.exe"):
-        candidate = bindir / name
-        if candidate.is_file():
-            return str(candidate)
-    return None
-
-
-_FRAGILE_COMMAND_WARNING = (
-    "WARNING: recording nauro from a project virtualenv ({command}).\n"
-    "  This path breaks if the repo's virtualenv is rebuilt, moved, or "
-    "corrupted, silently killing Nauro's MCP server and hooks. Install nauro "
-    "durably (pipx install nauro, or uv tool install nauro) and re-run "
-    "'nauro setup all'."
-)
-
-_UNRESOLVED_COMMAND_WARNING = (
-    "WARNING: could not validate a working nauro; recorded '{command}'.\n"
-    "  Nauro's MCP server and hooks will not work until nauro is installed on a "
-    "durable PATH (pipx install nauro, or uv tool install nauro), then re-run "
-    "'nauro setup all'."
-)
-
-
-@functools.cache
-def _find_nauro_command() -> str:
-    """Resolve — and cache for the process — the nauro entrypoint recorded into
-    MCP and hook configs.
-
-    Cached so `setup all` validates the entrypoint once rather than once per
-    sink (five subprocess probes collapse to one). Warnings surface on the
-    cache-miss resolution only; tests reset via
-    ``_find_nauro_command.cache_clear()``.
-    """
-    return _resolve_nauro_command()
-
-
-def _resolve_nauro_command() -> str:
-    """Pick the nauro entrypoint to record into MCP/hook configs.
-
-    Prefers a validated, durable install so the recorded command keeps working
-    after a project virtualenv is rebuilt, moved, or corrupted (the observed
-    failure: a ``uv run`` / ``.venv``-invoked setup recorded a fragile
-    repo-venv path that later died). Resolution order:
-
-      1. Interpreter-sibling that both runs and looks durable — the fast path,
-         byte-identical to the historical behavior for pipx/uv-tool/desktop.
-      2. Otherwise a PATH-resolved absolute shim that runs and looks durable —
-         diverts away from a dead or fragile project venv.
-      3. Otherwise the sibling if it merely runs (fragile but working) —
-         recorded with a loud warning naming the project-venv fragility.
-      4. Otherwise the best absolute path we have (else bare ``nauro``), with a
-         loud warning that MCP will not work until nauro is on a durable PATH.
-
-    An absolute path is always preferred over bare ``nauro``; bare ``nauro`` is
-    only the terminal fallback, because GUI-launched agents start with an empty
-    PATH. Durability checks run before the (subprocess) probe so a non-durable
-    candidate short-circuits without spawning.
-    """
-    sibling = _interpreter_sibling_candidate()
-    which = shutil.which("nauro")
-
-    if (
-        sibling is not None
-        and cli_utils._is_durable_install_path(sibling)
-        and cli_utils.probe_nauro_command(sibling)
-    ):
-        return sibling
-
-    if (
-        which is not None
-        and cli_utils._is_durable_install_path(which)
-        and cli_utils.probe_nauro_command(which)
-    ):
-        return which
-
-    if sibling is not None and cli_utils.probe_nauro_command(sibling):
-        typer.echo(_FRAGILE_COMMAND_WARNING.format(command=sibling), err=True)
-        return sibling
-
-    fallback = sibling or which or "nauro"
-    typer.echo(_UNRESOLVED_COMMAND_WARNING.format(command=fallback), err=True)
-    return fallback
 
 
 def _configure_json_mcp(
@@ -746,35 +648,6 @@ def _remove_hook_entry(settings_path: Path, settings: dict, repo: Path) -> str:
 
 def _codex_hooks_path(repo: Path) -> Path:
     return repo / ".codex" / "hooks.json"
-
-
-@functools.cache
-def _find_nauro_codex_hook_command() -> str | None:
-    command = _find_nauro_command()
-    if cli_utils.probe_nauro_command(command, args=_CODEX_HOOK_PROBE_ARGS):
-        return command
-
-    sibling = _interpreter_sibling_candidate()
-    if (
-        sibling is not None
-        and sibling != command
-        and cli_utils.probe_nauro_command(sibling, args=_CODEX_HOOK_PROBE_ARGS)
-    ):
-        typer.echo(
-            f"WARNING: '{command}' does not support Codex bootstrap hooks. "
-            f"Recording the current Nauro install at '{sibling}' instead. "
-            "Update the durable Nauro install and re-run 'nauro setup all --with-hooks'.",
-            err=True,
-        )
-        return sibling
-
-    typer.echo(
-        "WARNING: no installed Nauro command supports Codex bootstrap hooks. "
-        "Codex hook wiring was skipped; update Nauro and re-run "
-        "'nauro setup all --with-hooks'.",
-        err=True,
-    )
-    return None
 
 
 def materialize_hooks_codex(repo: Path, *, remove: bool) -> str:

--- a/packages/nauro/src/nauro/cli/commands/status.py
+++ b/packages/nauro/src/nauro/cli/commands/status.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import typer
 
-from nauro.cli import utils as cli_utils
+from nauro.cli import nauro_command
 from nauro.cli._codex_hooks import (
     _CODEX_HOOK_PROBE_ARGS,
     _CodexHookState,
@@ -135,7 +135,7 @@ def _probe_distinct_commands(
     a single short probe. ``probe_nauro_command`` soft-fails by contract, so a
     dead command costs at most its timeout, never an exception.
     """
-    return {cmd: cli_utils.probe_nauro_command(cmd, args=args) for cmd in commands}
+    return {cmd: nauro_command.probe_nauro_command(cmd, args=args) for cmd in commands}
 
 
 def _repo_has_generated_agents_md(repo: Path) -> bool:

--- a/packages/nauro/src/nauro/cli/nauro_command.py
+++ b/packages/nauro/src/nauro/cli/nauro_command.py
@@ -1,0 +1,183 @@
+"""Resolve and validate the durable nauro command for recorded MCP/hook wiring."""
+
+from __future__ import annotations
+
+import functools
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import typer
+
+from nauro.cli._codex_hooks import _CODEX_HOOK_PROBE_ARGS
+
+
+def probe_nauro_command(
+    cmd: str,
+    *,
+    args: tuple[str, ...] = ("--version",),
+    timeout: float = 1.5,
+) -> bool:
+    """Return True iff ``[cmd, *args]`` launches and exits 0.
+
+    The single subprocess seam for validating a recorded MCP/hook command: the
+    setup resolver calls it before recording a command, and ``nauro status``
+    calls it to probe wired commands for liveness. A launch failure (missing
+    binary or permission error), a hang past ``timeout``, or a non-zero exit
+    all count as "won't run". Soft-fails and never raises, so callers can treat
+    the boolean as authoritative. Centralized here so tests mock exactly one
+    function and no test ever spawns a real binary.
+    """
+    try:
+        proc = subprocess.run(
+            [cmd, *args],
+            timeout=timeout,
+            capture_output=True,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return proc.returncode == 0
+
+
+_DURABLE_PATH_MARKERS: tuple[tuple[str, str], ...] = (("pipx", "venvs"), ("uv", "tools"))
+_FRAGILE_VENV_DIRS = frozenset({".venv", "venv", "env"})
+
+
+def _is_durable_install_path(path: str) -> bool:
+    """Heuristic: does ``path`` look like a durable, tool-managed install?
+
+    Separator-agnostic via ``Path.parts`` so Windows ``Scripts\\nauro.exe``
+    layouts read the same as POSIX ``bin/nauro``. pipx (``.../pipx/venvs/...``)
+    and uv-tool (``.../uv/tools/...``) installs live outside any single repo and
+    survive that repo's virtualenv being rebuilt or corrupted, so they count as
+    durable. A path whose grandparent directory is a bare ``.venv``/``venv``/
+    ``env`` is a project-local virtualenv that dies with the checkout, so it
+    counts as fragile. Any other shape (system, Homebrew, conda) is treated as
+    durable. This is only a resolver tiebreaker — a fragile path that still runs
+    is recorded with a warning, never dropped.
+    """
+    parts = [p.lower() for p in Path(path).parts]
+    for first, second in _DURABLE_PATH_MARKERS:
+        for i in range(len(parts) - 1):
+            if parts[i] == first and parts[i + 1] == second:
+                return True
+    if len(parts) >= 3 and parts[-3] in _FRAGILE_VENV_DIRS:
+        return False
+    return True
+
+
+def _interpreter_sibling_candidate() -> str | None:
+    """Return the absolute path to a ``nauro`` console script next to the running
+    interpreter, or None when there isn't one.
+
+    This is the install the user actually invoked, which pipx/uv-tool layouts
+    keep off the PATH that GUI-launched agents see — recording its absolute path
+    is what makes the spawned stdio server and per-turn hook independent of the
+    agent's launch environment.
+    """
+    bindir = Path(sys.executable).parent
+    for name in ("nauro", "nauro.exe"):
+        candidate = bindir / name
+        if candidate.is_file():
+            return str(candidate)
+    return None
+
+
+_FRAGILE_COMMAND_WARNING = (
+    "WARNING: recording nauro from a project virtualenv ({command}).\n"
+    "  This path breaks if the repo's virtualenv is rebuilt, moved, or "
+    "corrupted, silently killing Nauro's MCP server and hooks. Install nauro "
+    "durably (pipx install nauro, or uv tool install nauro) and re-run "
+    "'nauro setup all'."
+)
+
+_UNRESOLVED_COMMAND_WARNING = (
+    "WARNING: could not validate a working nauro; recorded '{command}'.\n"
+    "  Nauro's MCP server and hooks will not work until nauro is installed on a "
+    "durable PATH (pipx install nauro, or uv tool install nauro), then re-run "
+    "'nauro setup all'."
+)
+
+
+@functools.cache
+def _find_nauro_command() -> str:
+    """Resolve — and cache for the process — the nauro entrypoint recorded into
+    MCP and hook configs.
+
+    Cached so `setup all` validates the entrypoint once rather than once per
+    sink (five subprocess probes collapse to one). Warnings surface on the
+    cache-miss resolution only; tests reset via
+    ``_find_nauro_command.cache_clear()``.
+    """
+    return _resolve_nauro_command()
+
+
+def _resolve_nauro_command() -> str:
+    """Pick the nauro entrypoint to record into MCP/hook configs.
+
+    Prefers a validated, durable install so the recorded command keeps working
+    after a project virtualenv is rebuilt, moved, or corrupted (the observed
+    failure: a ``uv run`` / ``.venv``-invoked setup recorded a fragile
+    repo-venv path that later died). Resolution order:
+
+      1. Interpreter-sibling that both runs and looks durable — the fast path,
+         byte-identical to the historical behavior for pipx/uv-tool/desktop.
+      2. Otherwise a PATH-resolved absolute shim that runs and looks durable —
+         diverts away from a dead or fragile project venv.
+      3. Otherwise the sibling if it merely runs (fragile but working) —
+         recorded with a loud warning naming the project-venv fragility.
+      4. Otherwise the best absolute path we have (else bare ``nauro``), with a
+         loud warning that MCP will not work until nauro is on a durable PATH.
+
+    An absolute path is always preferred over bare ``nauro``; bare ``nauro`` is
+    only the terminal fallback, because GUI-launched agents start with an empty
+    PATH. Durability checks run before the (subprocess) probe so a non-durable
+    candidate short-circuits without spawning.
+    """
+    sibling = _interpreter_sibling_candidate()
+    which = shutil.which("nauro")
+
+    if sibling is not None and _is_durable_install_path(sibling) and probe_nauro_command(sibling):
+        return sibling
+
+    if which is not None and _is_durable_install_path(which) and probe_nauro_command(which):
+        return which
+
+    if sibling is not None and probe_nauro_command(sibling):
+        typer.echo(_FRAGILE_COMMAND_WARNING.format(command=sibling), err=True)
+        return sibling
+
+    fallback = sibling or which or "nauro"
+    typer.echo(_UNRESOLVED_COMMAND_WARNING.format(command=fallback), err=True)
+    return fallback
+
+
+@functools.cache
+def _find_nauro_codex_hook_command() -> str | None:
+    command = _find_nauro_command()
+    if probe_nauro_command(command, args=_CODEX_HOOK_PROBE_ARGS):
+        return command
+
+    sibling = _interpreter_sibling_candidate()
+    if (
+        sibling is not None
+        and sibling != command
+        and probe_nauro_command(sibling, args=_CODEX_HOOK_PROBE_ARGS)
+    ):
+        typer.echo(
+            f"WARNING: '{command}' does not support Codex bootstrap hooks. "
+            f"Recording the current Nauro install at '{sibling}' instead. "
+            "Update the durable Nauro install and re-run 'nauro setup all --with-hooks'.",
+            err=True,
+        )
+        return sibling
+
+    typer.echo(
+        "WARNING: no installed Nauro command supports Codex bootstrap hooks. "
+        "Codex hook wiring was skipped; update Nauro and re-run "
+        "'nauro setup all --with-hooks'.",
+        err=True,
+    )
+    return None

--- a/packages/nauro/src/nauro/cli/utils.py
+++ b/packages/nauro/src/nauro/cli/utils.py
@@ -14,7 +14,6 @@ Resolution priority for any command that needs a project context:
 
 from __future__ import annotations
 
-import subprocess
 from pathlib import Path
 
 import typer
@@ -35,61 +34,6 @@ from nauro.store.registry import (
 from nauro.store.repo_config import collides_with_global_config
 from nauro.store.resolution import resolve_from_cwd
 from nauro.store.write_safety import find_symlink
-
-
-def probe_nauro_command(
-    cmd: str,
-    *,
-    args: tuple[str, ...] = ("--version",),
-    timeout: float = 1.5,
-) -> bool:
-    """Return True iff ``[cmd, *args]`` launches and exits 0.
-
-    The single subprocess seam for validating a recorded MCP/hook command: the
-    setup resolver calls it before recording a command, and ``nauro status``
-    calls it to probe wired commands for liveness. A launch failure (missing
-    binary or permission error), a hang past ``timeout``, or a non-zero exit
-    all count as "won't run". Soft-fails and never raises, so callers can treat
-    the boolean as authoritative. Centralized here so tests mock exactly one
-    function and no test ever spawns a real binary.
-    """
-    try:
-        proc = subprocess.run(
-            [cmd, *args],
-            timeout=timeout,
-            capture_output=True,
-            check=False,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return False
-    return proc.returncode == 0
-
-
-_DURABLE_PATH_MARKERS: tuple[tuple[str, str], ...] = (("pipx", "venvs"), ("uv", "tools"))
-_FRAGILE_VENV_DIRS = frozenset({".venv", "venv", "env"})
-
-
-def _is_durable_install_path(path: str) -> bool:
-    """Heuristic: does ``path`` look like a durable, tool-managed install?
-
-    Separator-agnostic via ``Path.parts`` so Windows ``Scripts\\nauro.exe``
-    layouts read the same as POSIX ``bin/nauro``. pipx (``.../pipx/venvs/...``)
-    and uv-tool (``.../uv/tools/...``) installs live outside any single repo and
-    survive that repo's virtualenv being rebuilt or corrupted, so they count as
-    durable. A path whose grandparent directory is a bare ``.venv``/``venv``/
-    ``env`` is a project-local virtualenv that dies with the checkout, so it
-    counts as fragile. Any other shape (system, Homebrew, conda) is treated as
-    durable. This is only a resolver tiebreaker — a fragile path that still runs
-    is recorded with a warning, never dropped.
-    """
-    parts = [p.lower() for p in Path(path).parts]
-    for first, second in _DURABLE_PATH_MARKERS:
-        for i in range(len(parts) - 1):
-            if parts[i] == first and parts[i + 1] == second:
-                return True
-    if len(parts) >= 3 and parts[-3] in _FRAGILE_VENV_DIRS:
-        return False
-    return True
 
 
 def refuse_global_config_collision(repo_root: Path) -> None:
@@ -268,7 +212,6 @@ def _resolve_project_entry(project_name: str, project_key: str) -> dict:
 # Re-exported for callers that need to write or extend v2 entries directly
 __all__ = [
     "add_repo_v2",
-    "probe_nauro_command",
     "refuse_global_config_collision",
     "refuse_repo_config_symlink",
     "register_project_v2",

--- a/packages/nauro/tests/conftest.py
+++ b/packages/nauro/tests/conftest.py
@@ -308,7 +308,7 @@ def _neutralize_nauro_command_probe(monkeypatch):
     """Never spawn a real nauro binary, and reset the resolver cache per test.
 
     ``_find_nauro_command`` (setup) and ``nauro status`` liveness both go through
-    ``nauro.cli.utils.probe_nauro_command`` — the single subprocess seam. Default
+    ``nauro.cli.nauro_command.probe_nauro_command`` — the single subprocess seam. Default
     it to "runs fine" and mark every path durable so surface-wiring tests take
     the historical fast path (record the interpreter-sibling, no warning) and get
     a valid absolute command without a subprocess. Tests that exercise
@@ -319,16 +319,15 @@ def _neutralize_nauro_command_probe(monkeypatch):
     Probe/durability unit tests capture the real functions at import time (before
     this fixture patches) and call them directly, so they are unaffected.
     """
-    from nauro.cli import utils as cli_utils
-    from nauro.cli.commands import setup as setup_mod
+    from nauro.cli import nauro_command
 
-    monkeypatch.setattr(cli_utils, "probe_nauro_command", lambda cmd, **kwargs: True)
-    monkeypatch.setattr(cli_utils, "_is_durable_install_path", lambda path: True)
-    setup_mod._find_nauro_command.cache_clear()
-    setup_mod._find_nauro_codex_hook_command.cache_clear()
+    monkeypatch.setattr(nauro_command, "probe_nauro_command", lambda cmd, **kwargs: True)
+    monkeypatch.setattr(nauro_command, "_is_durable_install_path", lambda path: True)
+    nauro_command._find_nauro_command.cache_clear()
+    nauro_command._find_nauro_codex_hook_command.cache_clear()
     yield
-    setup_mod._find_nauro_codex_hook_command.cache_clear()
-    setup_mod._find_nauro_command.cache_clear()
+    nauro_command._find_nauro_codex_hook_command.cache_clear()
+    nauro_command._find_nauro_command.cache_clear()
 
 
 @pytest.fixture(autouse=True)

--- a/packages/nauro/tests/test_cli_status.py
+++ b/packages/nauro/tests/test_cli_status.py
@@ -5,7 +5,7 @@ import json
 from typer.testing import CliRunner
 
 import nauro.cli.commands.status as status_mod
-from nauro.cli import utils as cli_utils
+from nauro.cli import nauro_command
 from nauro.cli._codex_hooks import _CODEX_HOOK_PROBE_ARGS
 from nauro.cli.main import app
 from nauro.store.registry import register_project
@@ -164,7 +164,7 @@ def test_status_mcp_broken_when_recorded_command_dead(tmp_path, monkeypatch):
     """Wired but the recorded command fails the liveness probe → BROKEN, exit 0."""
     _setup_project(tmp_path, monkeypatch)
     _wire_repo_mcp(tmp_path)
-    monkeypatch.setattr(cli_utils, "probe_nauro_command", lambda cmd, **kwargs: False)
+    monkeypatch.setattr(nauro_command, "probe_nauro_command", lambda cmd, **kwargs: False)
 
     result = runner.invoke(app, ["status"])
     assert result.exit_code == 0
@@ -179,7 +179,7 @@ def test_status_no_probe_skips_liveness(tmp_path, monkeypatch):
     _wire_repo_mcp(tmp_path)
     calls: list[str] = []
     monkeypatch.setattr(
-        cli_utils, "probe_nauro_command", lambda cmd, **kwargs: calls.append(cmd) or True
+        nauro_command, "probe_nauro_command", lambda cmd, **kwargs: calls.append(cmd) or True
     )
 
     result = runner.invoke(app, ["status", "--no-probe"])
@@ -203,7 +203,9 @@ def test_status_codex_hooks_no_probe_reports_configured(tmp_path, monkeypatch):
     _wire_codex_hooks(tmp_path)
     calls: list[str] = []
     monkeypatch.setattr(
-        cli_utils, "probe_nauro_command", lambda command, **kwargs: calls.append(command) or True
+        nauro_command,
+        "probe_nauro_command",
+        lambda command, **kwargs: calls.append(command) or True,
     )
 
     result = runner.invoke(app, ["status", "--no-probe"])
@@ -216,7 +218,7 @@ def test_status_codex_hooks_no_probe_reports_configured(tmp_path, monkeypatch):
 def test_status_codex_hooks_broken_when_command_is_dead(tmp_path, monkeypatch):
     _setup_project(tmp_path, monkeypatch)
     _wire_codex_hooks(tmp_path, command="/gone/nauro")
-    monkeypatch.setattr(cli_utils, "probe_nauro_command", lambda command, **kwargs: False)
+    monkeypatch.setattr(nauro_command, "probe_nauro_command", lambda command, **kwargs: False)
 
     result = runner.invoke(app, ["status"])
 
@@ -246,7 +248,9 @@ def test_status_codex_hooks_broken_when_event_is_missing(tmp_path, monkeypatch):
     _wire_codex_hooks(tmp_path, events=("SessionStart",))
     calls: list[str] = []
     monkeypatch.setattr(
-        cli_utils, "probe_nauro_command", lambda command, **kwargs: calls.append(command) or True
+        nauro_command,
+        "probe_nauro_command",
+        lambda command, **kwargs: calls.append(command) or True,
     )
 
     result = runner.invoke(app, ["status", "--no-probe"])
@@ -263,7 +267,7 @@ def test_status_probes_shared_mcp_and_hook_command_for_each_purpose(tmp_path, mo
     _wire_codex_hooks(tmp_path)
     calls: list[tuple[str, tuple[str, ...]]] = []
     monkeypatch.setattr(
-        cli_utils,
+        nauro_command,
         "probe_nauro_command",
         lambda command, **kwargs: calls.append((command, kwargs["args"])) or True,
     )
@@ -281,7 +285,7 @@ def test_status_shared_command_can_have_healthy_mcp_and_broken_hooks(tmp_path, m
     _wire_repo_mcp(tmp_path)
     _wire_codex_hooks(tmp_path)
     monkeypatch.setattr(
-        cli_utils,
+        nauro_command,
         "probe_nauro_command",
         lambda _command, **kwargs: kwargs["args"] == ("--version",),
     )
@@ -298,7 +302,7 @@ def test_status_shared_command_can_have_broken_mcp_and_healthy_hooks(tmp_path, m
     _wire_repo_mcp(tmp_path)
     _wire_codex_hooks(tmp_path)
     monkeypatch.setattr(
-        cli_utils,
+        nauro_command,
         "probe_nauro_command",
         lambda _command, **kwargs: kwargs["args"] == _CODEX_HOOK_PROBE_ARGS,
     )
@@ -389,7 +393,7 @@ def test_status_dedupes_shared_command_to_one_probe(tmp_path, monkeypatch):
     _wire_repo_mcp(repo2)
     calls: list[str] = []
     monkeypatch.setattr(
-        cli_utils, "probe_nauro_command", lambda cmd, **kwargs: calls.append(cmd) or True
+        nauro_command, "probe_nauro_command", lambda cmd, **kwargs: calls.append(cmd) or True
     )
 
     result = runner.invoke(app, ["status"])

--- a/packages/nauro/tests/test_command_resolution.py
+++ b/packages/nauro/tests/test_command_resolution.py
@@ -21,12 +21,11 @@ import subprocess
 
 import pytest
 
-from nauro.cli import utils as cli_utils
-from nauro.cli.commands import setup as setup_mod
+from nauro.cli import nauro_command
 
 # Real implementations captured before the autouse fixture patches them.
-_REAL_PROBE = cli_utils.probe_nauro_command
-_REAL_DURABLE = cli_utils._is_durable_install_path
+_REAL_PROBE = nauro_command.probe_nauro_command
+_REAL_DURABLE = nauro_command._is_durable_install_path
 
 
 # ── probe_nauro_command ────────────────────────────────────────────────────────
@@ -38,12 +37,12 @@ class _FakeProc:
 
 
 def test_probe_true_on_exit_zero(monkeypatch):
-    monkeypatch.setattr(cli_utils.subprocess, "run", lambda *a, **k: _FakeProc(0))
+    monkeypatch.setattr(nauro_command.subprocess, "run", lambda *a, **k: _FakeProc(0))
     assert _REAL_PROBE("nauro") is True
 
 
 def test_probe_false_on_nonzero_exit(monkeypatch):
-    monkeypatch.setattr(cli_utils.subprocess, "run", lambda *a, **k: _FakeProc(1))
+    monkeypatch.setattr(nauro_command.subprocess, "run", lambda *a, **k: _FakeProc(1))
     assert _REAL_PROBE("nauro") is False
 
 
@@ -51,7 +50,7 @@ def test_probe_false_on_missing_binary(monkeypatch):
     def boom(*a, **k):
         raise FileNotFoundError("nauro")
 
-    monkeypatch.setattr(cli_utils.subprocess, "run", boom)
+    monkeypatch.setattr(nauro_command.subprocess, "run", boom)
     assert _REAL_PROBE("/gone/nauro") is False
 
 
@@ -59,7 +58,7 @@ def test_probe_false_on_timeout(monkeypatch):
     def boom(*a, **k):
         raise subprocess.TimeoutExpired(cmd="nauro", timeout=1.5)
 
-    monkeypatch.setattr(cli_utils.subprocess, "run", boom)
+    monkeypatch.setattr(nauro_command.subprocess, "run", boom)
     assert _REAL_PROBE("nauro") is False
 
 
@@ -70,7 +69,7 @@ def test_probe_invokes_version_subcommand(monkeypatch):
         seen["cmd"] = cmd
         return _FakeProc(0)
 
-    monkeypatch.setattr(cli_utils.subprocess, "run", capture)
+    monkeypatch.setattr(nauro_command.subprocess, "run", capture)
     _REAL_PROBE("/opt/nauro")
     assert seen["cmd"] == ["/opt/nauro", "--version"]
 
@@ -82,7 +81,7 @@ def test_probe_accepts_a_specific_subcommand(monkeypatch):
         seen["cmd"] = cmd
         return _FakeProc(0)
 
-    monkeypatch.setattr(cli_utils.subprocess, "run", capture)
+    monkeypatch.setattr(nauro_command.subprocess, "run", capture)
     result = _REAL_PROBE("/opt/nauro", args=("hook", "codex-bootstrap", "--help"))
 
     assert result is True
@@ -121,10 +120,10 @@ def test_is_durable_install_path(path, expected):
 
 def _wire_resolver(monkeypatch, *, sibling, which, probe, durable):
     """Point the resolver at controlled candidates and seam functions."""
-    monkeypatch.setattr(setup_mod, "_interpreter_sibling_candidate", lambda: sibling)
-    monkeypatch.setattr(setup_mod.shutil, "which", lambda name: which)
-    monkeypatch.setattr(cli_utils, "probe_nauro_command", probe)
-    monkeypatch.setattr(cli_utils, "_is_durable_install_path", durable)
+    monkeypatch.setattr(nauro_command, "_interpreter_sibling_candidate", lambda: sibling)
+    monkeypatch.setattr(nauro_command.shutil, "which", lambda name: which)
+    monkeypatch.setattr(nauro_command, "probe_nauro_command", probe)
+    monkeypatch.setattr(nauro_command, "_is_durable_install_path", durable)
 
 
 def test_resolver_records_durable_sibling_without_warning(monkeypatch, capsys):
@@ -140,7 +139,7 @@ def test_resolver_records_durable_sibling_without_warning(monkeypatch, capsys):
         probe=lambda cmd, **k: True,
         durable=lambda p: True,
     )
-    assert setup_mod._resolve_nauro_command() == sibling
+    assert nauro_command._resolve_nauro_command() == sibling
     assert capsys.readouterr().err == ""
 
 
@@ -155,7 +154,7 @@ def test_resolver_diverts_to_which_when_sibling_dead(monkeypatch, capsys):
         probe=lambda cmd, **k: cmd == which,  # sibling crashes on import
         durable=lambda p: p == which,  # sibling is fragile, which is durable
     )
-    assert setup_mod._resolve_nauro_command() == which
+    assert nauro_command._resolve_nauro_command() == which
     # Silent divert — no warning when a durable replacement is found.
     assert capsys.readouterr().err == ""
 
@@ -170,7 +169,7 @@ def test_resolver_records_fragile_sibling_with_warning(monkeypatch, capsys):
         probe=lambda cmd, **k: True,  # sibling runs
         durable=lambda p: False,  # ...but is fragile
     )
-    assert setup_mod._resolve_nauro_command() == sibling
+    assert nauro_command._resolve_nauro_command() == sibling
     err = capsys.readouterr().err
     assert "WARNING" in err
     assert "virtualenv" in err
@@ -187,7 +186,7 @@ def test_resolver_falls_back_with_loud_warning_when_nothing_runs(monkeypatch, ca
         probe=lambda cmd, **k: False,  # nothing runs
         durable=lambda p: False,
     )
-    assert setup_mod._resolve_nauro_command() == sibling
+    assert nauro_command._resolve_nauro_command() == sibling
     err = capsys.readouterr().err
     assert "WARNING" in err
     assert "will not work" in err
@@ -202,7 +201,7 @@ def test_resolver_bare_nauro_only_as_last_resort(monkeypatch, capsys):
         probe=lambda cmd, **k: False,
         durable=lambda p: False,
     )
-    assert setup_mod._resolve_nauro_command() == "nauro"
+    assert nauro_command._resolve_nauro_command() == "nauro"
     assert "WARNING" in capsys.readouterr().err
 
 
@@ -216,7 +215,7 @@ def test_resolver_never_prefers_bare_over_absolute(monkeypatch, capsys):
         probe=lambda cmd, **k: False,  # neither validates
         durable=lambda p: False,
     )
-    result = setup_mod._resolve_nauro_command()
+    result = nauro_command._resolve_nauro_command()
     assert result != "nauro"
     assert result == sibling  # best absolute path retained
     capsys.readouterr()
@@ -234,16 +233,16 @@ def test_find_nauro_command_memoizes_resolution(monkeypatch):
         return True
 
     monkeypatch.setattr(
-        setup_mod, "_interpreter_sibling_candidate", lambda: "/opt/pipx/venvs/nauro/bin/nauro"
+        nauro_command, "_interpreter_sibling_candidate", lambda: "/opt/pipx/venvs/nauro/bin/nauro"
     )
-    monkeypatch.setattr(setup_mod.shutil, "which", lambda name: None)
-    monkeypatch.setattr(cli_utils, "probe_nauro_command", counting_probe)
-    monkeypatch.setattr(cli_utils, "_is_durable_install_path", lambda p: True)
-    setup_mod._find_nauro_command.cache_clear()
+    monkeypatch.setattr(nauro_command.shutil, "which", lambda name: None)
+    monkeypatch.setattr(nauro_command, "probe_nauro_command", counting_probe)
+    monkeypatch.setattr(nauro_command, "_is_durable_install_path", lambda p: True)
+    nauro_command._find_nauro_command.cache_clear()
 
-    first = setup_mod._find_nauro_command()
+    first = nauro_command._find_nauro_command()
     after_first = len(calls)
-    second = setup_mod._find_nauro_command()
+    second = nauro_command._find_nauro_command()
 
     assert first == second == "/opt/pipx/venvs/nauro/bin/nauro"
     assert len(calls) == after_first  # no re-probe on the cached call
@@ -261,14 +260,14 @@ def test_setup_all_resolves_command_once(tmp_path, monkeypatch):
 
     calls: list[str] = []
     monkeypatch.setattr(
-        setup_mod, "_interpreter_sibling_candidate", lambda: "/opt/pipx/venvs/nauro/bin/nauro"
+        nauro_command, "_interpreter_sibling_candidate", lambda: "/opt/pipx/venvs/nauro/bin/nauro"
     )
-    monkeypatch.setattr(setup_mod.shutil, "which", lambda name: None)
+    monkeypatch.setattr(nauro_command.shutil, "which", lambda name: None)
     monkeypatch.setattr(
-        cli_utils, "probe_nauro_command", lambda cmd, **k: calls.append(cmd) or True
+        nauro_command, "probe_nauro_command", lambda cmd, **k: calls.append(cmd) or True
     )
-    monkeypatch.setattr(cli_utils, "_is_durable_install_path", lambda p: True)
-    setup_mod._find_nauro_command.cache_clear()
+    monkeypatch.setattr(nauro_command, "_is_durable_install_path", lambda p: True)
+    nauro_command._find_nauro_command.cache_clear()
 
     setup_all_surfaces([repo1, repo2], remove=False)
 

--- a/packages/nauro/tests/test_setup_atomic_writes.py
+++ b/packages/nauro/tests/test_setup_atomic_writes.py
@@ -32,11 +32,11 @@ from nauro.cli.commands.setup import (
     HOOK_SUBCOMMAND,
     HOOK_TIMEOUT_SECONDS,
     _configure_mcp,
-    _find_nauro_command,
     materialize_hooks_claude_code,
     materialize_hooks_codex,
 )
 from nauro.cli.integrations.claude_user_config import _prune_redundant_user_scope_mcp
+from nauro.cli.nauro_command import _find_nauro_command
 from nauro.store import _atomic
 
 pytestmark = pytest.mark.skipif(

--- a/packages/nauro/tests/test_setup_characterization.py
+++ b/packages/nauro/tests/test_setup_characterization.py
@@ -21,7 +21,7 @@ Rules for this module:
   dir as ``{TMP}`` and the resolved nauro entrypoint as ``{NAURO_CMD}``.
 
 Seam note: the resolver-warning tests override the conftest probe seam
-(``cli_utils.probe_nauro_command`` / ``cli_utils._is_durable_install_path``)
+(``nauro_command.probe_nauro_command`` / ``nauro_command._is_durable_install_path``)
 patched by the autouse ``_neutralize_nauro_command_probe`` fixture. They ride
 that fixture's existing retarget obligation: if the seam moves, retarget
 these overrides together with the fixture.
@@ -949,10 +949,10 @@ def _interpreter_sibling() -> str:
 class TestResolverWarningShape:
     def test_fragile_path_warning_once_on_stderr(self, tmp_path: Path, monkeypatch):
         """Nothing durable but the sibling runs: one fragile warning per invocation."""
-        from nauro.cli import utils as cli_utils
+        from nauro.cli import nauro_command
 
         sibling = _interpreter_sibling()
-        monkeypatch.setattr(cli_utils, "_is_durable_install_path", lambda path: False)
+        monkeypatch.setattr(nauro_command, "_is_durable_install_path", lambda path: False)
         _register_project(tmp_path, monkeypatch)
 
         result = runner.invoke(app, ["setup", "all"])
@@ -970,10 +970,10 @@ class TestResolverWarningShape:
 
     def test_unresolved_warning_once_on_stderr(self, tmp_path: Path, monkeypatch):
         """No candidate runs at all: one unresolved warning per invocation."""
-        from nauro.cli import utils as cli_utils
+        from nauro.cli import nauro_command
 
         sibling = _interpreter_sibling()
-        monkeypatch.setattr(cli_utils, "probe_nauro_command", lambda cmd, **kwargs: False)
+        monkeypatch.setattr(nauro_command, "probe_nauro_command", lambda cmd, **kwargs: False)
         _register_project(tmp_path, monkeypatch)
 
         result = runner.invoke(app, ["setup", "all"])

--- a/packages/nauro/tests/test_setup_extended.py
+++ b/packages/nauro/tests/test_setup_extended.py
@@ -202,7 +202,7 @@ def test_configure_codex_remove_does_not_resolve_command(tmp_path: Path, monkeyp
     """The remove path never resolves the nauro entrypoint. Resolution can
     probe subprocesses and print install warnings, none of which belong in
     a teardown that only deletes an entry."""
-    import nauro.cli.commands.setup as setup_mod
+    from nauro.cli import nauro_command
 
     config_path = tmp_path / ".codex" / "config.toml"
     config_path.parent.mkdir()
@@ -211,8 +211,8 @@ def test_configure_codex_remove_does_not_resolve_command(tmp_path: Path, monkeyp
     def _fail() -> str:
         raise AssertionError("command resolution must not run on remove")
 
-    monkeypatch.setattr(setup_mod, "_resolve_nauro_command", _fail)
-    setup_mod._find_nauro_command.cache_clear()
+    monkeypatch.setattr(nauro_command, "_resolve_nauro_command", _fail)
+    nauro_command._find_nauro_command.cache_clear()
 
     msg = _configure_codex(remove=True, config_path=config_path)
 

--- a/packages/nauro/tests/test_setup_hooks.py
+++ b/packages/nauro/tests/test_setup_hooks.py
@@ -246,11 +246,11 @@ def test_materialize_codex_writes_both_lifecycle_events(tmp_path: Path, monkeypa
     repo.mkdir()
     command = "/opt/Nauro Tool/bin/nauro"
 
-    import nauro.cli.commands.setup as setup_mod
+    from nauro.cli import nauro_command
 
-    monkeypatch.setattr(setup_mod, "_resolve_nauro_command", lambda: command)
-    setup_mod._find_nauro_command.cache_clear()
-    setup_mod._find_nauro_codex_hook_command.cache_clear()
+    monkeypatch.setattr(nauro_command, "_resolve_nauro_command", lambda: command)
+    nauro_command._find_nauro_command.cache_clear()
+    nauro_command._find_nauro_codex_hook_command.cache_clear()
     line = materialize_hooks_codex(repo, remove=False)
 
     assert "wrote nauro hooks" in line
@@ -288,19 +288,19 @@ def test_materialize_codex_uses_current_install_when_durable_command_is_too_old(
     repo = tmp_path / "repo"
     repo.mkdir()
 
-    import nauro.cli.commands.setup as setup_mod
+    from nauro.cli import nauro_command
 
-    monkeypatch.setattr(setup_mod, "_resolve_nauro_command", lambda: "/opt/old/nauro")
+    monkeypatch.setattr(nauro_command, "_resolve_nauro_command", lambda: "/opt/old/nauro")
     monkeypatch.setattr(
-        setup_mod, "_interpreter_sibling_candidate", lambda: "/repo/.venv/bin/nauro"
+        nauro_command, "_interpreter_sibling_candidate", lambda: "/repo/.venv/bin/nauro"
     )
     monkeypatch.setattr(
-        setup_mod.cli_utils,
+        nauro_command,
         "probe_nauro_command",
         lambda command, **kwargs: command == "/repo/.venv/bin/nauro",
     )
-    setup_mod._find_nauro_command.cache_clear()
-    setup_mod._find_nauro_codex_hook_command.cache_clear()
+    nauro_command._find_nauro_command.cache_clear()
+    nauro_command._find_nauro_codex_hook_command.cache_clear()
 
     line = materialize_hooks_codex(repo, remove=False)
 
@@ -316,13 +316,13 @@ def test_materialize_codex_skips_when_no_compatible_command(tmp_path: Path, monk
     repo = tmp_path / "repo"
     repo.mkdir()
 
-    import nauro.cli.commands.setup as setup_mod
+    from nauro.cli import nauro_command
 
-    monkeypatch.setattr(setup_mod, "_resolve_nauro_command", lambda: "/opt/old/nauro")
-    monkeypatch.setattr(setup_mod, "_interpreter_sibling_candidate", lambda: None)
-    monkeypatch.setattr(setup_mod.cli_utils, "probe_nauro_command", lambda command, **kwargs: False)
-    setup_mod._find_nauro_command.cache_clear()
-    setup_mod._find_nauro_codex_hook_command.cache_clear()
+    monkeypatch.setattr(nauro_command, "_resolve_nauro_command", lambda: "/opt/old/nauro")
+    monkeypatch.setattr(nauro_command, "_interpreter_sibling_candidate", lambda: None)
+    monkeypatch.setattr(nauro_command, "probe_nauro_command", lambda command, **kwargs: False)
+    nauro_command._find_nauro_command.cache_clear()
+    nauro_command._find_nauro_codex_hook_command.cache_clear()
 
     line = materialize_hooks_codex(repo, remove=False)
 
@@ -336,11 +336,11 @@ def test_materialize_codex_validates_config_before_resolving_command(tmp_path: P
     hooks_path.parent.mkdir(parents=True)
     hooks_path.write_text('{"hooks": []}', encoding="utf-8")
 
-    import nauro.cli.commands.setup as setup_mod
+    from nauro.cli import nauro_command
 
-    monkeypatch.setattr(setup_mod, "_interpreter_sibling_candidate", lambda: "/opt/nauro")
+    monkeypatch.setattr(nauro_command, "_interpreter_sibling_candidate", lambda: "/opt/nauro")
     monkeypatch.setattr(
-        setup_mod.cli_utils,
+        nauro_command,
         "probe_nauro_command",
         lambda *args, **kwargs: pytest.fail("command resolution should not run"),
     )
@@ -356,11 +356,11 @@ def test_codex_hook_missing_binary_guard_exits_zero(tmp_path: Path, monkeypatch)
     repo.mkdir()
     missing = tmp_path / "missing nauro"
 
-    import nauro.cli.commands.setup as setup_mod
+    from nauro.cli import nauro_command
 
-    monkeypatch.setattr(setup_mod, "_resolve_nauro_command", lambda: str(missing))
-    setup_mod._find_nauro_command.cache_clear()
-    setup_mod._find_nauro_codex_hook_command.cache_clear()
+    monkeypatch.setattr(nauro_command, "_resolve_nauro_command", lambda: str(missing))
+    nauro_command._find_nauro_command.cache_clear()
+    nauro_command._find_nauro_codex_hook_command.cache_clear()
     materialize_hooks_codex(repo, remove=False)
     config = json.loads(_codex_hooks(repo).read_text())
     entry = _codex_nauro_entries(config, "SessionStart")[0]
@@ -377,11 +377,11 @@ def test_codex_hook_bare_command_guard_checks_path(tmp_path: Path, monkeypatch):
     repo = tmp_path / "repo"
     repo.mkdir()
 
-    import nauro.cli.commands.setup as setup_mod
+    from nauro.cli import nauro_command
 
-    monkeypatch.setattr(setup_mod, "_resolve_nauro_command", lambda: "nauro")
-    setup_mod._find_nauro_command.cache_clear()
-    setup_mod._find_nauro_codex_hook_command.cache_clear()
+    monkeypatch.setattr(nauro_command, "_resolve_nauro_command", lambda: "nauro")
+    nauro_command._find_nauro_command.cache_clear()
+    nauro_command._find_nauro_codex_hook_command.cache_clear()
     materialize_hooks_codex(repo, remove=False)
     config = json.loads(_codex_hooks(repo).read_text())
     entry = _codex_nauro_entries(config, "SessionStart")[0]
@@ -471,15 +471,15 @@ def test_materialize_codex_refreshes_recorded_command(tmp_path: Path, monkeypatc
     repo = tmp_path / "repo"
     repo.mkdir()
 
-    import nauro.cli.commands.setup as setup_mod
+    from nauro.cli import nauro_command
 
-    monkeypatch.setattr(setup_mod, "_resolve_nauro_command", lambda: "/old/nauro")
-    setup_mod._find_nauro_command.cache_clear()
-    setup_mod._find_nauro_codex_hook_command.cache_clear()
+    monkeypatch.setattr(nauro_command, "_resolve_nauro_command", lambda: "/old/nauro")
+    nauro_command._find_nauro_command.cache_clear()
+    nauro_command._find_nauro_codex_hook_command.cache_clear()
     materialize_hooks_codex(repo, remove=False)
-    monkeypatch.setattr(setup_mod, "_resolve_nauro_command", lambda: "/new/nauro")
-    setup_mod._find_nauro_command.cache_clear()
-    setup_mod._find_nauro_codex_hook_command.cache_clear()
+    monkeypatch.setattr(nauro_command, "_resolve_nauro_command", lambda: "/new/nauro")
+    nauro_command._find_nauro_command.cache_clear()
+    nauro_command._find_nauro_codex_hook_command.cache_clear()
 
     line = materialize_hooks_codex(repo, remove=False)
 

--- a/packages/nauro/tests/test_setup_user_write_safety.py
+++ b/packages/nauro/tests/test_setup_user_write_safety.py
@@ -21,13 +21,11 @@ from pathlib import Path
 import pytest
 import tomlkit
 
-from nauro.cli.commands.setup import (
-    _configure_codex,
-    _find_nauro_command,
-)
+from nauro.cli.commands.setup import _configure_codex
 from nauro.cli.integrations.agents import materialize_agents
 from nauro.cli.integrations.claude_user_config import _prune_redundant_user_scope_mcp
 from nauro.cli.integrations.skills import _materialize_skill_file, _remove_skill_file
+from nauro.cli.nauro_command import _find_nauro_command
 
 if sys.version_info >= (3, 11):
     import tomllib


### PR DESCRIPTION
## Why

The MCP/hook command resolution and validation seam was split across `cli/utils.py` (the subprocess probe and durability heuristic) and `cli/commands/setup.py` (the interpreter-sibling lookup, warning strings, and the cached resolver entrypoints). Callers reached across both modules to resolve the command recorded into MCP and hook configs. This move gathers the whole seam into one purpose-named module so command resolution has a single home, continuing the setup-subsystem decomposition. It carries the command-resolution decision's rider.

## What changed

New module `cli/nauro_command.py` holds the full seam: `probe_nauro_command`, `_is_durable_install_path` (plus its marker constants), `_interpreter_sibling_candidate`, the fragile/unresolved warning constants, the cached `_find_nauro_command` / `_resolve_nauro_command`, and `_find_nauro_codex_hook_command`.

- `utils.py` and `setup.py` drop the moved symbols and their now-dead imports; `probe_nauro_command` is removed from `utils.__all__`. No re-export shims.
- `status` and `adopt` retarget to `nauro_command`.
- The autouse test fixture and the resolver tests patch `nauro_command` in place of `utils`/`setup`.

This is a pure relocation with no behavior change. Every moved body is byte-identical to its origin, except that `_resolve_nauro_command` and `_find_nauro_codex_hook_command` drop the now-redundant `cli_utils.` prefix on the two colocated helpers (a formatting pass then collapses two conditionals that became short enough to fit on one line, with identical boolean logic).

## Deferred

The remaining artifact codecs (JSON MCP, Codex TOML, hooks) and the surface-orchestration policy land in follow-up PRs of the series.

## Test plan

- Full suites green: nauro 1843 passed / 10 skipped, nauro-core 1073 passed.
- Characterization oracle unchanged: `test_onboarding_inventories.py` has no diff; `test_setup_characterization.py` changes only the seam-note docstring and two tests' patch targets (no assertion changes).
- `ruff check` and `ruff format --check` clean across `packages/`.
