### PR TITLE
Extract the JSON MCP codec into cli/integrations/

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/setup.py
+++ b/packages/nauro/src/nauro/cli/commands/setup.py
@@ -29,6 +29,7 @@ from nauro.cli._codex_hooks import (
 from nauro.cli.git_hygiene import public_surface_git_warnings
 from nauro.cli.integrations.agents import materialize_agents
 from nauro.cli.integrations.claude_user_config import _prune_redundant_user_scope_mcp
+from nauro.cli.integrations.json_mcp import _configure_cursor_for_repo, _configure_mcp
 from nauro.cli.integrations.legacy import _remove_claude_md
 from nauro.cli.integrations.skills import (
     materialize_skills_claude_code,
@@ -52,85 +53,6 @@ setup_app = typer.Typer(help="Configure tool integrations.")
 # against the local store, so users don't have to wait for an agent
 # restart to see Nauro do something useful.
 CHECK_HINT_LINE = 'Try it now from this shell: nauro check-decision "<approach>"'
-
-
-def _configure_json_mcp(
-    repo_path: Path,
-    *,
-    config_rel_path: str,
-    label: str,
-    remove: bool,
-) -> str:
-    """Add or remove the Nauro MCP entry in a JSON config file at ``repo_path / config_rel_path``.
-
-    Shared shape behind ``_configure_mcp`` (``.mcp.json``) and
-    ``_configure_cursor_for_repo`` (``.cursor/mcp.json``): load → parse →
-    mutate ``mcpServers["nauro"]`` → write. Both surfaces use the same key
-    name and entry shape, so the only per-surface variation is the relative
-    path and the human-readable ``label`` used in status messages.
-
-    Returns a one-line status string (indented for ``setup_all_surfaces``).
-    """
-    refusal = find_symlink(repo_path, config_rel_path)
-    if refusal is not None:
-        return f"  {repo_path}: {refusal.message}"
-    config_path = repo_path / config_rel_path
-    nauro_cmd = _find_nauro_command()
-    nauro_entry = {"command": nauro_cmd, "args": ["serve", "--stdio"]}
-
-    if config_path.exists():
-        try:
-            config = json.loads(config_path.read_text(encoding="utf-8"))
-        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-            return f"  {repo_path}: could not parse {label} - {exc}"
-    else:
-        config = {}
-
-    # A hand-mangled config can have a non-object top level (e.g. a JSON array)
-    # or an mcpServers that isn't an object; mutating it would raise. Skip with a
-    # clear message instead of a traceback, mirroring the hook path's guard.
-    if not isinstance(config, dict):
-        return f"  {repo_path}: {label} is not a JSON object, skipped"
-
-    if remove:
-        servers = config.get("mcpServers", {})
-        if not isinstance(servers, dict) or "nauro" not in servers:
-            return f"  {repo_path}: no nauro entry to remove"
-        del servers["nauro"]
-        if not servers:
-            config.pop("mcpServers", None)
-        if config:
-            atomic_write_text(config_path, json.dumps(config, indent=2) + "\n")
-        else:
-            config_path.unlink()
-        return f"  {repo_path}: removed nauro from {label}"
-
-    servers = config.setdefault("mcpServers", {})
-    if not isinstance(servers, dict):
-        return f"  {repo_path}: mcpServers in {label} is not a JSON object, skipped"
-    servers["nauro"] = nauro_entry
-    config_path.parent.mkdir(parents=True, exist_ok=True)
-    atomic_write_text(config_path, json.dumps(config, indent=2) + "\n")
-    lines = [f"  {repo_path}: wrote nauro to {label}"]
-    lines.extend(public_surface_git_warnings(repo_path, config_rel_path))
-    return "\n".join(lines)
-
-
-def _configure_mcp(repo_path: Path, *, remove: bool = False) -> str:
-    """Add or remove the Nauro MCP entry in the repo's project-scope ``.mcp.json``.
-
-    Writes the file directly. Mirrors how ``_configure_cursor_for_repo``
-    handles ``.cursor/mcp.json`` and ``_configure_codex`` handles
-    ``~/.codex/config.toml``, so all three surface handlers share one shape.
-
-    Returns a one-line status string (indented for ``setup_all_surfaces``).
-    """
-    return _configure_json_mcp(
-        repo_path,
-        config_rel_path=".mcp.json",
-        label=".mcp.json",
-        remove=remove,
-    )
 
 
 @setup_app.command(name="claude-code")
@@ -226,16 +148,6 @@ def claude_code(
 # User-global "Rules for AI" live in the IDE Settings UI, not a file path —
 # so MCP wiring is per-project here.
 # Docs: https://cursor.com/docs
-
-
-def _configure_cursor_for_repo(repo_path: Path, *, remove: bool) -> str:
-    """Add or remove the Nauro MCP entry in this repo's ``.cursor/mcp.json``."""
-    return _configure_json_mcp(
-        repo_path,
-        config_rel_path=".cursor/mcp.json",
-        label=".cursor/mcp.json",
-        remove=remove,
-    )
 
 
 @setup_app.command(name="cursor")

--- a/packages/nauro/src/nauro/cli/integrations/json_mcp.py
+++ b/packages/nauro/src/nauro/cli/integrations/json_mcp.py
@@ -1,0 +1,100 @@
+"""JSON MCP config codec (.mcp.json and .cursor/mcp.json) for the setup surface."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from nauro.cli.git_hygiene import public_surface_git_warnings
+from nauro.cli.nauro_command import _find_nauro_command
+from nauro.store._atomic import atomic_write_text
+from nauro.store.write_safety import find_symlink
+
+
+def _configure_json_mcp(
+    repo_path: Path,
+    *,
+    config_rel_path: str,
+    label: str,
+    remove: bool,
+) -> str:
+    """Add or remove the Nauro MCP entry in a JSON config file at ``repo_path / config_rel_path``.
+
+    Shared shape behind ``_configure_mcp`` (``.mcp.json``) and
+    ``_configure_cursor_for_repo`` (``.cursor/mcp.json``): load → parse →
+    mutate ``mcpServers["nauro"]`` → write. Both surfaces use the same key
+    name and entry shape, so the only per-surface variation is the relative
+    path and the human-readable ``label`` used in status messages.
+
+    Returns a one-line status string (indented for ``setup_all_surfaces``).
+    """
+    refusal = find_symlink(repo_path, config_rel_path)
+    if refusal is not None:
+        return f"  {repo_path}: {refusal.message}"
+    config_path = repo_path / config_rel_path
+    nauro_cmd = _find_nauro_command()
+    nauro_entry = {"command": nauro_cmd, "args": ["serve", "--stdio"]}
+
+    if config_path.exists():
+        try:
+            config = json.loads(config_path.read_text(encoding="utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            return f"  {repo_path}: could not parse {label} - {exc}"
+    else:
+        config = {}
+
+    # A hand-mangled config can have a non-object top level (e.g. a JSON array)
+    # or an mcpServers that isn't an object; mutating it would raise. Skip with a
+    # clear message instead of a traceback, mirroring the hook path's guard.
+    if not isinstance(config, dict):
+        return f"  {repo_path}: {label} is not a JSON object, skipped"
+
+    if remove:
+        servers = config.get("mcpServers", {})
+        if not isinstance(servers, dict) or "nauro" not in servers:
+            return f"  {repo_path}: no nauro entry to remove"
+        del servers["nauro"]
+        if not servers:
+            config.pop("mcpServers", None)
+        if config:
+            atomic_write_text(config_path, json.dumps(config, indent=2) + "\n")
+        else:
+            config_path.unlink()
+        return f"  {repo_path}: removed nauro from {label}"
+
+    servers = config.setdefault("mcpServers", {})
+    if not isinstance(servers, dict):
+        return f"  {repo_path}: mcpServers in {label} is not a JSON object, skipped"
+    servers["nauro"] = nauro_entry
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    atomic_write_text(config_path, json.dumps(config, indent=2) + "\n")
+    lines = [f"  {repo_path}: wrote nauro to {label}"]
+    lines.extend(public_surface_git_warnings(repo_path, config_rel_path))
+    return "\n".join(lines)
+
+
+def _configure_mcp(repo_path: Path, *, remove: bool = False) -> str:
+    """Add or remove the Nauro MCP entry in the repo's project-scope ``.mcp.json``.
+
+    Writes the file directly. Mirrors how ``_configure_cursor_for_repo``
+    handles ``.cursor/mcp.json`` and ``_configure_codex`` handles
+    ``~/.codex/config.toml``, so all three surface handlers share one shape.
+
+    Returns a one-line status string (indented for ``setup_all_surfaces``).
+    """
+    return _configure_json_mcp(
+        repo_path,
+        config_rel_path=".mcp.json",
+        label=".mcp.json",
+        remove=remove,
+    )
+
+
+def _configure_cursor_for_repo(repo_path: Path, *, remove: bool) -> str:
+    """Add or remove the Nauro MCP entry in this repo's ``.cursor/mcp.json``."""
+    return _configure_json_mcp(
+        repo_path,
+        config_rel_path=".cursor/mcp.json",
+        label=".cursor/mcp.json",
+        remove=remove,
+    )

--- a/packages/nauro/tests/test_setup.py
+++ b/packages/nauro/tests/test_setup.py
@@ -9,8 +9,8 @@ from typer.testing import CliRunner
 
 from nauro.cli.commands.setup import (
     _configure_codex,
-    _configure_mcp,
 )
+from nauro.cli.integrations.json_mcp import _configure_mcp
 from nauro.cli.integrations.legacy import CLAUDE_MD_END, CLAUDE_MD_START
 from nauro.cli.main import app
 from nauro.store.registry import register_project, register_project_v2

--- a/packages/nauro/tests/test_setup_atomic_writes.py
+++ b/packages/nauro/tests/test_setup_atomic_writes.py
@@ -31,11 +31,11 @@ from nauro.cli.commands.setup import (
     HOOK_EVENT_NAME,
     HOOK_SUBCOMMAND,
     HOOK_TIMEOUT_SECONDS,
-    _configure_mcp,
     materialize_hooks_claude_code,
     materialize_hooks_codex,
 )
 from nauro.cli.integrations.claude_user_config import _prune_redundant_user_scope_mcp
+from nauro.cli.integrations.json_mcp import _configure_mcp
 from nauro.cli.nauro_command import _find_nauro_command
 from nauro.store import _atomic
 

--- a/packages/nauro/tests/test_setup_extended.py
+++ b/packages/nauro/tests/test_setup_extended.py
@@ -14,9 +14,9 @@ from typer.testing import CliRunner
 from nauro.cli.commands.setup import (
     CHECK_HINT_LINE,
     _configure_codex,
-    _configure_cursor_for_repo,
 )
 from nauro.cli.integrations.claude_user_config import _prune_redundant_user_scope_mcp
+from nauro.cli.integrations.json_mcp import _configure_cursor_for_repo
 from nauro.cli.integrations.skills import materialize_skills_cursor_for_repo
 from nauro.cli.main import app
 from nauro.store.registry import register_project_v2


### PR DESCRIPTION
## Why

`setup.py` is the setup command surface, but it was also hosting the JSON MCP config codec: the load/parse/mutate/write logic for `.mcp.json` and `.cursor/mcp.json`. That codec is a self-contained unit with no dependency on the command surface, so it belongs in `cli/integrations/` alongside the other surface handlers (agents, skills, legacy, claude_user_config, user_scope). This continues the setup-subsystem decomposition, shrinking `setup.py` toward just its Typer commands.

## What changed

- New module `cli/integrations/json_mcp.py` holding `_configure_json_mcp` and its two thin wrappers `_configure_mcp` (`.mcp.json`) and `_configure_cursor_for_repo` (`.cursor/mcp.json`), moved verbatim.
- `setup.py` drops the three definitions and imports the two wrappers it calls directly. No re-export shim.
- Three test modules retarget their imports of the two wrappers to the new module; no assertions changed.

This is a pure move: the three function bodies are byte-for-byte identical to their previous form (verified against the base revision). No behavior change.

## Deferred

- The status-inspector consolidation touching `status.py` is a separate later step; `status.py` is untouched here.

## Test plan

- `pytest packages/nauro/tests/`: 1843 passed, 10 skipped (unchanged).
- `pytest packages/nauro-core/tests/`: 1073 passed (unchanged).
- Oracle suites (`test_setup_characterization.py`, `test_onboarding_inventories.py`) unmodified and green: 36 passed.
- `ruff check` and `ruff format --check` clean across `packages/`.
