### PR TITLE
Extract the Claude and Codex hook codecs into cli/integrations/

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/setup.py
+++ b/packages/nauro/src/nauro/cli/commands/setup.py
@@ -10,22 +10,15 @@ Subcommands:
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
 import typer
 
-from nauro.cli._codex_hooks import (
-    _CodexHookConfigError,
-    _format_codex_hooks,
-    _parse_codex_hooks,
-    _transform_codex_hooks,
-    _validate_codex_hooks,
-)
-from nauro.cli.git_hygiene import public_surface_git_warnings
 from nauro.cli.integrations.agents import materialize_agents
+from nauro.cli.integrations.claude_hooks import materialize_hooks_claude_code
 from nauro.cli.integrations.claude_user_config import _prune_redundant_user_scope_mcp
 from nauro.cli.integrations.codex_config import _configure_codex, _default_codex_config_path
+from nauro.cli.integrations.codex_hooks import _nearest_codex_hooks_repo, materialize_hooks_codex
 from nauro.cli.integrations.json_mcp import _configure_cursor_for_repo, _configure_mcp
 from nauro.cli.integrations.legacy import _remove_claude_md
 from nauro.cli.integrations.skills import (
@@ -34,12 +27,9 @@ from nauro.cli.integrations.skills import (
     materialize_skills_cursor_for_repo,
 )
 from nauro.cli.integrations.user_scope import _registered_project_keys, _user_scope_safe_to_clear
-from nauro.cli.nauro_command import _find_nauro_codex_hook_command, _find_nauro_command
 from nauro.cli.utils import _resolve_project_entry, resolve_target_project
-from nauro.store._atomic import atomic_write_text
 from nauro.store.registry import get_repo_paths
 from nauro.store.resolution import resolve_from_cwd
-from nauro.store.write_safety import find_symlink
 from nauro.templates.agents_md import remove_generated_agents_md
 from nauro.templates.agents_md_regen import warn_then_regen
 
@@ -182,17 +172,6 @@ def cursor(
 # Docs: https://developers.openai.com/codex/mcp
 
 
-def _nearest_codex_hooks_repo(start: Path) -> Path | None:
-    resolved = start.resolve()
-    home = Path.home().resolve()
-    for candidate in (resolved, *resolved.parents):
-        if candidate == home:
-            break
-        if (candidate / ".codex" / "hooks.json").is_file():
-            return candidate
-    return None
-
-
 @setup_app.command(name="codex")
 def codex(
     remove: bool = typer.Option(
@@ -271,205 +250,6 @@ def codex(
         if with_hooks:
             typer.echo(f"\n{CODEX_HOOKS_NOTICE}")
         typer.echo(f"\n{CHECK_HINT_LINE}")
-
-
-# ─── Hook materialization ─────────────────────────────────────────────────────
-
-
-# Claude Code reads hooks from project-scope ``<repo>/.claude/settings.json``.
-# The advisory UserPromptSubmit hook runs ``nauro hook user-prompt-submit`` on
-# each turn; it surfaces related decisions as context and never blocks a turn.
-# The MVP hook is BM25-floor only — it does not set ``NAURO_EMBEDDINGS`` — so the
-# install incurs no embedding model load. The hook still resolves the embeddings
-# flag internally, so the follow-up that re-admits cosine-gated embedding hits
-# can flip the backend on without changing the installed command.
-#
-HOOK_EVENT_NAME = "UserPromptSubmit"
-# The subcommand the hook entry runs; the full command is built at install time
-# by prefixing the resolved absolute nauro path (see _nauro_hook_entry), so the
-# hook fires even when nauro is not on the agent's launch PATH.
-HOOK_SUBCOMMAND = "hook user-prompt-submit"
-HOOK_TIMEOUT_SECONDS = 10
-
-# Substring that identifies a nauro-authored hook entry on the remove path, so a
-# user's own UserPromptSubmit hooks are preserved. Matches the subcommand rather
-# than "nauro " so it holds regardless of how the entrypoint resolves — a bare
-# "nauro", an absolute POSIX path, or a Windows "nauro.exe".
-_HOOK_COMMAND_MARKER = HOOK_SUBCOMMAND
-
-
-def _claude_settings_path(repo: Path) -> Path:
-    return repo / ".claude" / "settings.json"
-
-
-def materialize_hooks_claude_code(repo: Path, *, remove: bool) -> str:
-    """Add or remove the Nauro advisory hook in ``<repo>/.claude/settings.json``.
-
-    Add path: idempotently append the hook entry to
-    ``hooks.UserPromptSubmit[].hooks[]`` only when no nauro-authored entry is
-    already present. Remove path: strip only the nauro-authored entry (matched on
-    the command containing ``nauro hook``), preserving any user-authored hooks
-    and the surrounding structure.
-
-    Returns a one-line status string (indented for ``setup_all_surfaces``).
-    """
-    refusal = find_symlink(repo, ".claude/settings.json")
-    if refusal is not None:
-        return f"  {repo}: {refusal.message}"
-    settings_path = _claude_settings_path(repo)
-
-    if settings_path.exists():
-        try:
-            settings = json.loads(settings_path.read_text(encoding="utf-8"))
-        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-            return f"  {repo}: could not parse .claude/settings.json - {exc}"
-        if not isinstance(settings, dict):
-            return f"  {repo}: .claude/settings.json is not a JSON object, skipped"
-    else:
-        settings = {}
-
-    if remove:
-        return _remove_hook_entry(settings_path, settings, repo)
-    return _add_hook_entry(settings_path, settings, repo)
-
-
-def _nauro_hook_entry() -> dict:
-    return {
-        "type": "command",
-        "command": f"{_find_nauro_command()} {HOOK_SUBCOMMAND}",
-        "timeout": HOOK_TIMEOUT_SECONDS,
-    }
-
-
-def _is_nauro_hook(entry: object) -> bool:
-    return (
-        isinstance(entry, dict)
-        and isinstance(entry.get("command"), str)
-        and _HOOK_COMMAND_MARKER in entry["command"]
-    )
-
-
-def _add_hook_entry(settings_path: Path, settings: dict, repo: Path) -> str:
-    hooks = settings.setdefault("hooks", {})
-    if not isinstance(hooks, dict):
-        return f"  {repo}: hooks key is not a JSON object, skipped"
-    event_matchers = hooks.setdefault(HOOK_EVENT_NAME, [])
-    if not isinstance(event_matchers, list):
-        return f"  {repo}: hooks.{HOOK_EVENT_NAME} is not a JSON array, skipped"
-
-    # Idempotent: if any matcher already carries a nauro hook, do nothing.
-    for matcher in event_matchers:
-        if isinstance(matcher, dict):
-            for entry in matcher.get("hooks", []):
-                if _is_nauro_hook(entry):
-                    return f"  {repo}: nauro hook already present in .claude/settings.json"
-
-    event_matchers.append({"hooks": [_nauro_hook_entry()]})
-    settings_path.parent.mkdir(parents=True, exist_ok=True)
-    atomic_write_text(settings_path, json.dumps(settings, indent=2) + "\n")
-    lines = [f"  {repo}: wrote nauro hook to .claude/settings.json"]
-    lines.extend(public_surface_git_warnings(repo, ".claude/settings.json"))
-    return "\n".join(lines)
-
-
-def _remove_hook_entry(settings_path: Path, settings: dict, repo: Path) -> str:
-    hooks = settings.get("hooks")
-    if not isinstance(hooks, dict):
-        return f"  {repo}: no nauro hook to remove"
-    event_matchers = hooks.get(HOOK_EVENT_NAME)
-    if not isinstance(event_matchers, list):
-        return f"  {repo}: no nauro hook to remove"
-
-    removed = False
-    surviving_matchers = []
-    for matcher in event_matchers:
-        if not isinstance(matcher, dict):
-            surviving_matchers.append(matcher)
-            continue
-        entries = matcher.get("hooks", [])
-        kept = [e for e in entries if not _is_nauro_hook(e)]
-        removed_here = len(entries) - len(kept)
-        if removed_here:
-            removed = True
-        if removed_here == 0:
-            surviving_matchers.append(matcher)
-        elif kept:
-            matcher = {**matcher, "hooks": kept}
-            surviving_matchers.append(matcher)
-        elif set(matcher) - {"hooks"}:
-            surviving_matchers.append({**matcher, "hooks": []})
-        # Drop only the installer-owned matcher shell with no user metadata.
-
-    if not removed:
-        return f"  {repo}: no nauro hook to remove"
-
-    if surviving_matchers:
-        hooks[HOOK_EVENT_NAME] = surviving_matchers
-    else:
-        hooks.pop(HOOK_EVENT_NAME, None)
-    if not hooks:
-        settings.pop("hooks", None)
-
-    if settings:
-        atomic_write_text(settings_path, json.dumps(settings, indent=2) + "\n")
-    else:
-        settings_path.unlink()
-    return f"  {repo}: removed nauro hook from .claude/settings.json"
-
-
-def _codex_hooks_path(repo: Path) -> Path:
-    return repo / ".codex" / "hooks.json"
-
-
-def materialize_hooks_codex(repo: Path, *, remove: bool) -> str:
-    """Add or remove project-scoped Codex lifecycle hooks for ``repo``."""
-    refusal = find_symlink(repo, ".codex/hooks.json")
-    if refusal is not None:
-        return f"  {repo}: {refusal.message}"
-    hooks_path = _codex_hooks_path(repo)
-    existing_text: str | None = None
-    if hooks_path.exists():
-        try:
-            existing_text = hooks_path.read_text(encoding="utf-8")
-            config = _parse_codex_hooks(existing_text)
-        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-            return f"  {repo}: could not parse .codex/hooks.json - {exc}"
-        except _CodexHookConfigError as exc:
-            return f"  {repo}: {exc}"
-    else:
-        config = {}
-
-    try:
-        _validate_codex_hooks(config)
-    except _CodexHookConfigError as exc:
-        return f"  {repo}: {exc}"
-
-    command = None if remove else _find_nauro_codex_hook_command()
-    if not remove and command is None:
-        return f"  {repo}: Codex hook wiring skipped; no compatible Nauro command"
-
-    try:
-        transformed = _transform_codex_hooks(config, command=command)
-    except _CodexHookConfigError as exc:
-        return f"  {repo}: {exc}"
-
-    if remove:
-        if transformed.removed == 0:
-            return f"  {repo}: no nauro Codex hooks to remove"
-        if transformed.config:
-            atomic_write_text(hooks_path, _format_codex_hooks(transformed.config))
-        else:
-            hooks_path.unlink()
-        return f"  {repo}: removed nauro hooks from .codex/hooks.json"
-
-    rendered = _format_codex_hooks(transformed.config)
-    if existing_text == rendered:
-        return f"  {repo}: nauro hooks already present in .codex/hooks.json"
-    hooks_path.parent.mkdir(parents=True, exist_ok=True)
-    atomic_write_text(hooks_path, rendered)
-    lines = [f"  {repo}: wrote nauro hooks to .codex/hooks.json"]
-    lines.extend(public_surface_git_warnings(repo, ".codex/hooks.json"))
-    return "\n".join(lines)
 
 
 # ─── nauro setup all ────────────────────────────────────────────────────────

--- a/packages/nauro/src/nauro/cli/integrations/claude_hooks.py
+++ b/packages/nauro/src/nauro/cli/integrations/claude_hooks.py
@@ -1,0 +1,151 @@
+"""Claude Code UserPromptSubmit hook codec (.claude/settings.json) for the setup surface."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from nauro.cli.git_hygiene import public_surface_git_warnings
+from nauro.cli.nauro_command import _find_nauro_command
+from nauro.store._atomic import atomic_write_text
+from nauro.store.write_safety import find_symlink
+
+# Claude Code reads hooks from project-scope ``<repo>/.claude/settings.json``.
+# The advisory UserPromptSubmit hook runs ``nauro hook user-prompt-submit`` on
+# each turn; it surfaces related decisions as context and never blocks a turn.
+# The MVP hook is BM25-floor only — it does not set ``NAURO_EMBEDDINGS`` — so the
+# install incurs no embedding model load. The hook still resolves the embeddings
+# flag internally, so the follow-up that re-admits cosine-gated embedding hits
+# can flip the backend on without changing the installed command.
+#
+HOOK_EVENT_NAME = "UserPromptSubmit"
+# The subcommand the hook entry runs; the full command is built at install time
+# by prefixing the resolved absolute nauro path (see _nauro_hook_entry), so the
+# hook fires even when nauro is not on the agent's launch PATH.
+HOOK_SUBCOMMAND = "hook user-prompt-submit"
+HOOK_TIMEOUT_SECONDS = 10
+
+# Substring that identifies a nauro-authored hook entry on the remove path, so a
+# user's own UserPromptSubmit hooks are preserved. Matches the subcommand rather
+# than "nauro " so it holds regardless of how the entrypoint resolves — a bare
+# "nauro", an absolute POSIX path, or a Windows "nauro.exe".
+_HOOK_COMMAND_MARKER = HOOK_SUBCOMMAND
+
+
+def _claude_settings_path(repo: Path) -> Path:
+    return repo / ".claude" / "settings.json"
+
+
+def materialize_hooks_claude_code(repo: Path, *, remove: bool) -> str:
+    """Add or remove the Nauro advisory hook in ``<repo>/.claude/settings.json``.
+
+    Add path: idempotently append the hook entry to
+    ``hooks.UserPromptSubmit[].hooks[]`` only when no nauro-authored entry is
+    already present. Remove path: strip only the nauro-authored entry (matched on
+    the command containing ``nauro hook``), preserving any user-authored hooks
+    and the surrounding structure.
+
+    Returns a one-line status string (indented for ``setup_all_surfaces``).
+    """
+    refusal = find_symlink(repo, ".claude/settings.json")
+    if refusal is not None:
+        return f"  {repo}: {refusal.message}"
+    settings_path = _claude_settings_path(repo)
+
+    if settings_path.exists():
+        try:
+            settings = json.loads(settings_path.read_text(encoding="utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            return f"  {repo}: could not parse .claude/settings.json - {exc}"
+        if not isinstance(settings, dict):
+            return f"  {repo}: .claude/settings.json is not a JSON object, skipped"
+    else:
+        settings = {}
+
+    if remove:
+        return _remove_hook_entry(settings_path, settings, repo)
+    return _add_hook_entry(settings_path, settings, repo)
+
+
+def _nauro_hook_entry() -> dict:
+    return {
+        "type": "command",
+        "command": f"{_find_nauro_command()} {HOOK_SUBCOMMAND}",
+        "timeout": HOOK_TIMEOUT_SECONDS,
+    }
+
+
+def _is_nauro_hook(entry: object) -> bool:
+    return (
+        isinstance(entry, dict)
+        and isinstance(entry.get("command"), str)
+        and _HOOK_COMMAND_MARKER in entry["command"]
+    )
+
+
+def _add_hook_entry(settings_path: Path, settings: dict, repo: Path) -> str:
+    hooks = settings.setdefault("hooks", {})
+    if not isinstance(hooks, dict):
+        return f"  {repo}: hooks key is not a JSON object, skipped"
+    event_matchers = hooks.setdefault(HOOK_EVENT_NAME, [])
+    if not isinstance(event_matchers, list):
+        return f"  {repo}: hooks.{HOOK_EVENT_NAME} is not a JSON array, skipped"
+
+    # Idempotent: if any matcher already carries a nauro hook, do nothing.
+    for matcher in event_matchers:
+        if isinstance(matcher, dict):
+            for entry in matcher.get("hooks", []):
+                if _is_nauro_hook(entry):
+                    return f"  {repo}: nauro hook already present in .claude/settings.json"
+
+    event_matchers.append({"hooks": [_nauro_hook_entry()]})
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    atomic_write_text(settings_path, json.dumps(settings, indent=2) + "\n")
+    lines = [f"  {repo}: wrote nauro hook to .claude/settings.json"]
+    lines.extend(public_surface_git_warnings(repo, ".claude/settings.json"))
+    return "\n".join(lines)
+
+
+def _remove_hook_entry(settings_path: Path, settings: dict, repo: Path) -> str:
+    hooks = settings.get("hooks")
+    if not isinstance(hooks, dict):
+        return f"  {repo}: no nauro hook to remove"
+    event_matchers = hooks.get(HOOK_EVENT_NAME)
+    if not isinstance(event_matchers, list):
+        return f"  {repo}: no nauro hook to remove"
+
+    removed = False
+    surviving_matchers = []
+    for matcher in event_matchers:
+        if not isinstance(matcher, dict):
+            surviving_matchers.append(matcher)
+            continue
+        entries = matcher.get("hooks", [])
+        kept = [e for e in entries if not _is_nauro_hook(e)]
+        removed_here = len(entries) - len(kept)
+        if removed_here:
+            removed = True
+        if removed_here == 0:
+            surviving_matchers.append(matcher)
+        elif kept:
+            matcher = {**matcher, "hooks": kept}
+            surviving_matchers.append(matcher)
+        elif set(matcher) - {"hooks"}:
+            surviving_matchers.append({**matcher, "hooks": []})
+        # Drop only the installer-owned matcher shell with no user metadata.
+
+    if not removed:
+        return f"  {repo}: no nauro hook to remove"
+
+    if surviving_matchers:
+        hooks[HOOK_EVENT_NAME] = surviving_matchers
+    else:
+        hooks.pop(HOOK_EVENT_NAME, None)
+    if not hooks:
+        settings.pop("hooks", None)
+
+    if settings:
+        atomic_write_text(settings_path, json.dumps(settings, indent=2) + "\n")
+    else:
+        settings_path.unlink()
+    return f"  {repo}: removed nauro hook from .claude/settings.json"

--- a/packages/nauro/src/nauro/cli/integrations/codex_hooks.py
+++ b/packages/nauro/src/nauro/cli/integrations/codex_hooks.py
@@ -1,0 +1,84 @@
+"""Codex hooks codec (.codex/hooks.json) for the setup surface; renders via cli/_codex_hooks."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from nauro.cli._codex_hooks import (
+    _CodexHookConfigError,
+    _format_codex_hooks,
+    _parse_codex_hooks,
+    _transform_codex_hooks,
+    _validate_codex_hooks,
+)
+from nauro.cli.git_hygiene import public_surface_git_warnings
+from nauro.cli.nauro_command import _find_nauro_codex_hook_command
+from nauro.store._atomic import atomic_write_text
+from nauro.store.write_safety import find_symlink
+
+
+def _nearest_codex_hooks_repo(start: Path) -> Path | None:
+    resolved = start.resolve()
+    home = Path.home().resolve()
+    for candidate in (resolved, *resolved.parents):
+        if candidate == home:
+            break
+        if (candidate / ".codex" / "hooks.json").is_file():
+            return candidate
+    return None
+
+
+def _codex_hooks_path(repo: Path) -> Path:
+    return repo / ".codex" / "hooks.json"
+
+
+def materialize_hooks_codex(repo: Path, *, remove: bool) -> str:
+    """Add or remove project-scoped Codex lifecycle hooks for ``repo``."""
+    refusal = find_symlink(repo, ".codex/hooks.json")
+    if refusal is not None:
+        return f"  {repo}: {refusal.message}"
+    hooks_path = _codex_hooks_path(repo)
+    existing_text: str | None = None
+    if hooks_path.exists():
+        try:
+            existing_text = hooks_path.read_text(encoding="utf-8")
+            config = _parse_codex_hooks(existing_text)
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            return f"  {repo}: could not parse .codex/hooks.json - {exc}"
+        except _CodexHookConfigError as exc:
+            return f"  {repo}: {exc}"
+    else:
+        config = {}
+
+    try:
+        _validate_codex_hooks(config)
+    except _CodexHookConfigError as exc:
+        return f"  {repo}: {exc}"
+
+    command = None if remove else _find_nauro_codex_hook_command()
+    if not remove and command is None:
+        return f"  {repo}: Codex hook wiring skipped; no compatible Nauro command"
+
+    try:
+        transformed = _transform_codex_hooks(config, command=command)
+    except _CodexHookConfigError as exc:
+        return f"  {repo}: {exc}"
+
+    if remove:
+        if transformed.removed == 0:
+            return f"  {repo}: no nauro Codex hooks to remove"
+        if transformed.config:
+            atomic_write_text(hooks_path, _format_codex_hooks(transformed.config))
+        else:
+            hooks_path.unlink()
+        return f"  {repo}: removed nauro hooks from .codex/hooks.json"
+
+    rendered = _format_codex_hooks(transformed.config)
+    if existing_text == rendered:
+        return f"  {repo}: nauro hooks already present in .codex/hooks.json"
+    hooks_path.parent.mkdir(parents=True, exist_ok=True)
+    atomic_write_text(hooks_path, rendered)
+    lines = [f"  {repo}: wrote nauro hooks to .codex/hooks.json"]
+    lines.extend(public_surface_git_warnings(repo, ".codex/hooks.json"))
+    return "\n".join(lines)

--- a/packages/nauro/tests/test_setup_atomic_writes.py
+++ b/packages/nauro/tests/test_setup_atomic_writes.py
@@ -27,14 +27,14 @@ from nauro.cli._codex_hooks import (
     _format_codex_hooks,
     _render_nauro_hook,
 )
-from nauro.cli.commands.setup import (
+from nauro.cli.integrations.claude_hooks import (
     HOOK_EVENT_NAME,
     HOOK_SUBCOMMAND,
     HOOK_TIMEOUT_SECONDS,
     materialize_hooks_claude_code,
-    materialize_hooks_codex,
 )
 from nauro.cli.integrations.claude_user_config import _prune_redundant_user_scope_mcp
+from nauro.cli.integrations.codex_hooks import materialize_hooks_codex
 from nauro.cli.integrations.json_mcp import _configure_mcp
 from nauro.cli.nauro_command import _find_nauro_command
 from nauro.store import _atomic

--- a/packages/nauro/tests/test_setup_hooks.py
+++ b/packages/nauro/tests/test_setup_hooks.py
@@ -15,14 +15,14 @@ import pytest
 from typer.testing import CliRunner
 
 from nauro.cli._codex_hooks import _CODEX_HOOK_EVENTS, _CODEX_HOOK_SUBCOMMAND
-from nauro.cli.commands.setup import (
+from nauro.cli.commands.setup import setup_all_surfaces
+from nauro.cli.integrations.claude_hooks import (
     HOOK_EVENT_NAME,
     HOOK_SUBCOMMAND,
     HOOK_TIMEOUT_SECONDS,
     materialize_hooks_claude_code,
-    materialize_hooks_codex,
-    setup_all_surfaces,
 )
+from nauro.cli.integrations.codex_hooks import materialize_hooks_codex
 from nauro.cli.main import app
 from tests.conftest import register_v2_repo
 
@@ -743,7 +743,7 @@ def test_is_nauro_hook_matches_regardless_of_entrypoint_name():
     """The remove/idempotency marker must recognise the nauro hook however the
     entrypoint resolved — bare name, absolute POSIX path, or Windows .exe —
     otherwise --remove orphans the entry and re-running setup duplicates it."""
-    from nauro.cli.commands.setup import _is_nauro_hook
+    from nauro.cli.integrations.claude_hooks import _is_nauro_hook
 
     for cmd in (
         "nauro hook user-prompt-submit",


### PR DESCRIPTION
## Why

`setup.py` carried the full hook-materialization surface alongside the setup command wiring. This continues the per-surface decomposition of that module: the two hook codecs move into their own modules under `cli/integrations/`, shrinking `setup.py` and putting the Claude `UserPromptSubmit` hook and the Codex lifecycle hooks next to the other per-surface codecs (`json_mcp`, `codex_config`, `skills`, `agents`).

## What changed

Pure verbatim relocation, no behavior change:

- `cli/integrations/claude_hooks.py` (new): the `.claude/settings.json` codec. The `HOOK_*` constants, `materialize_hooks_claude_code`, and the add/remove/inspect helpers, moved character-for-character. The plugin-hook coexistence check (a nauro hook is matched by its command marker) is unchanged.
- `cli/integrations/codex_hooks.py` (new): the `.codex/hooks.json` codec. `_nearest_codex_hooks_repo`, `_codex_hooks_path`, and `materialize_hooks_codex`, rendering through the unchanged pure `cli/_codex_hooks` module, which stays in place (it is already pure; moving it would be churn).
- `setup.py` now imports the three symbols it still calls directly and drops the imports the moved code took with it (`json`, `find_symlink`, `atomic_write_text`, the command finders, and the `_codex_hooks` render helpers). No re-export shim.
- The two test modules that exercise these symbols import them from their new locations. Assertions are unchanged.

## Deferred

The surface-orchestration policy (`setup_all_surfaces` and the per-command bodies) is the last relocation, landing in the next PR of the series.

## Test plan

- 36 characterization and onboarding oracle tests pass, and both oracle files are byte-for-byte unchanged.
- `test_setup_hooks.py` and `test_setup_atomic_writes.py` pass, covering the full hook contract on both surfaces (including plugin-hook preservation and the atomic-write path).
- Full suites green: `packages/nauro/tests/` 1843 passed, 10 skipped; `packages/nauro-core/tests/` 1073 passed.
- `ruff check` and `ruff format --check` clean across `packages/`.
