### PR TITLE
Extract the setup orchestration policy into cli/integrations/

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/adopt.py
+++ b/packages/nauro/src/nauro/cli/commands/adopt.py
@@ -30,12 +30,12 @@ from pathlib import Path
 
 import typer
 
-from nauro.cli.commands.setup import (
+from nauro.cli.git_hygiene import public_surface_git_warnings
+from nauro.cli.integrations.orchestrator import (
     SHIP_TASK_NEEDS_SUBAGENTS_NOTICE,
     SUBAGENTS_CONNECTOR_NAME_NOTICE,
     setup_all_surfaces,
 )
-from nauro.cli.git_hygiene import public_surface_git_warnings
 from nauro.cli.integrations.skills import OPT_IN_SKILL_NAMES, SKILL_NAMES
 from nauro.cli.nauro_command import _find_nauro_command
 from nauro.cli.utils import refuse_global_config_collision, refuse_repo_config_symlink

--- a/packages/nauro/src/nauro/cli/commands/setup.py
+++ b/packages/nauro/src/nauro/cli/commands/setup.py
@@ -14,24 +14,15 @@ from pathlib import Path
 
 import typer
 
-from nauro.cli.integrations.agents import materialize_agents
-from nauro.cli.integrations.claude_hooks import materialize_hooks_claude_code
-from nauro.cli.integrations.claude_user_config import _prune_redundant_user_scope_mcp
-from nauro.cli.integrations.codex_config import _configure_codex, _default_codex_config_path
-from nauro.cli.integrations.codex_hooks import _nearest_codex_hooks_repo, materialize_hooks_codex
-from nauro.cli.integrations.json_mcp import _configure_cursor_for_repo, _configure_mcp
-from nauro.cli.integrations.legacy import _remove_claude_md
-from nauro.cli.integrations.skills import (
-    materialize_skills_claude_code,
-    materialize_skills_codex,
-    materialize_skills_cursor_for_repo,
+from nauro.cli.integrations.orchestrator import (
+    SHIP_TASK_NEEDS_SUBAGENTS_NOTICE,
+    SUBAGENTS_CONNECTOR_NAME_NOTICE,
+    claude_code_surfaces,
+    codex_surfaces,
+    cursor_surfaces,
+    setup_all_surfaces,
 )
-from nauro.cli.integrations.user_scope import _registered_project_keys, _user_scope_safe_to_clear
 from nauro.cli.utils import _resolve_project_entry, resolve_target_project
-from nauro.store.registry import get_repo_paths
-from nauro.store.resolution import resolve_from_cwd
-from nauro.templates.agents_md import remove_generated_agents_md
-from nauro.templates.agents_md_regen import warn_then_regen
 
 setup_app = typer.Typer(help="Configure tool integrations.")
 
@@ -63,62 +54,21 @@ def claude_code(
     """Configure Claude Code to use Nauro during sessions."""
     project_name, _store_path = resolve_target_project(project)
     entry = _resolve_project_entry(project_name, _store_path.name)
-
-    # Clean up legacy CLAUDE.md blocks (behavioral guidance now delivered
-    # via MCP server instructions, so the injected block is no longer needed).
-    legacy_results = []
-    mcp_results = []
-    hook_results = []
-    for repo_str in entry["repo_paths"]:
-        repo_path = Path(repo_str)
-        if not repo_path.is_dir():
-            mcp_results.append(f"  {repo_path}: repo path missing, skipped")
-            continue
-        legacy = _remove_claude_md(repo_path)
-        if legacy:
-            legacy_results.append(legacy)
-        mcp_results.append(_configure_mcp(repo_path, remove=remove))
-        if with_hooks or remove:
-            try:
-                hook_results.append(materialize_hooks_claude_code(repo_path, remove=remove))
-            except Exception as exc:
-                hook_results.append(f"  {repo_path}: hook wiring error - {exc}")
-
-    if not remove:
-        pruned = _prune_redundant_user_scope_mcp()
-        if pruned:
-            mcp_results.append(pruned)
+    project_repos = [Path(rp) for rp in entry["repo_paths"]]
 
     action = "Removed" if remove else "Configured"
     typer.echo(f"{action} Nauro for project '{project_name}':\n")
-    for line in mcp_results:
+    for line in claude_code_surfaces(
+        project_repos,
+        remove=remove,
+        with_hooks=with_hooks,
+        store_name=_store_path.name,
+        store_path=_store_path,
+        warn=lambda msg: typer.echo(msg, err=True),
+    ):
         typer.echo(line)
 
-    if hook_results:
-        typer.echo("\nHooks:")
-        for line in hook_results:
-            typer.echo(line)
-
-    if legacy_results:
-        typer.echo("\nLegacy cleanup:")
-        for line in legacy_results:
-            typer.echo(line)
-
     if not remove:
-        # Regenerate AGENTS.md so context is fresh from the start. The store
-        # dir name is the v2 id (or v1 name) used by the registry-aware lookup.
-        # warn_then_regen surfaces missing-repo, symlink-refusal, and
-        # git-hygiene warnings through the warn callback.
-        updated_repos = warn_then_regen(
-            _store_path.name,
-            _store_path,
-            warn=lambda msg: typer.echo(msg, err=True),
-        )
-        if updated_repos:
-            typer.echo("\nAGENTS.md:")
-            for repo_path in updated_repos:
-                typer.echo(f"  {repo_path}: regenerated AGENTS.md")
-
         typer.echo(
             "\nNext: start a Claude Code session in one of the repos."
             " The MCP server will start automatically."
@@ -149,15 +99,12 @@ def cursor(
     """Configure Cursor to use Nauro for this project's repos."""
     project_name, _store_path = resolve_target_project(project)
     entry = _resolve_project_entry(project_name, _store_path.name)
+    project_repos = [Path(rp) for rp in entry["repo_paths"]]
 
     action = "Removed" if remove else "Configured"
     typer.echo(f"{action} Nauro (Cursor) for project '{project_name}':\n")
-    for repo_str in entry["repo_paths"]:
-        repo_path = Path(repo_str)
-        if not repo_path.is_dir():
-            typer.echo(f"  {repo_path}: repo path missing, skipped")
-            continue
-        typer.echo(_configure_cursor_for_repo(repo_path, remove=remove))
+    for line in cursor_surfaces(project_repos, remove=remove):
+        typer.echo(line)
 
     if not remove:
         typer.echo("\nNext: open this repo in Cursor and start a chat — Nauro MCP will connect.")
@@ -188,62 +135,8 @@ def codex(
     ),
 ) -> None:
     """Configure Codex CLI to use Nauro (writes '~/.codex/config.toml')."""
-    hook_repos: list[Path] = []
-    if with_hooks and not remove:
-        project_name, store_path = resolve_target_project(None)
-        entry = _resolve_project_entry(project_name, store_path.name)
-        hook_repos = [Path(repo_path) for repo_path in entry["repo_paths"]]
-
-    # Standalone codex wiring is user-global and shared by every registered
-    # project, so this teardown preserves the entry while any project remains
-    # in the registry (it clears only on an empty registry). Clearing on the
-    # last project goes through 'nauro setup all --remove'.
-    registered_count = len(_registered_project_keys()) if remove else 0
-    if registered_count:
-        config_path = _default_codex_config_path()
-        count_phrase = (
-            "1 nauro project" if registered_count == 1 else f"{registered_count} nauro projects"
-        )
-        typer.echo(
-            f"Codex: preserved nauro entry in {config_path} ({count_phrase} registered; "
-            "run 'nauro setup all --remove' on the last project to clear this "
-            "user-global entry)"
-        )
-    else:
-        typer.echo(_configure_codex(remove=remove))
-
-    hook_cleanup_unresolved = False
-    if remove:
-        try:
-            resolution = resolve_from_cwd(Path.cwd())
-            hook_repos = (
-                [Path(repo_path) for repo_path in get_repo_paths(resolution.project_id)]
-                if resolution is not None
-                else []
-            )
-            nearest_hooks_repo = _nearest_codex_hooks_repo(Path.cwd())
-            if nearest_hooks_repo is not None and nearest_hooks_repo not in hook_repos:
-                hook_repos.append(nearest_hooks_repo)
-            hook_cleanup_unresolved = not hook_repos
-        except Exception:
-            hook_cleanup_unresolved = True
-
-    if with_hooks or remove:
-        typer.echo("\nHooks:")
-        if hook_cleanup_unresolved:
-            typer.echo(
-                "  Project-scoped Codex hooks were not removed because no Nauro "
-                "project resolves from this directory. Run this command from each "
-                "wired repo to remove them."
-            )
-        for repo_path in hook_repos:
-            if not repo_path.is_dir():
-                typer.echo(f"  {repo_path}: repo path missing, skipped")
-                continue
-            try:
-                typer.echo(materialize_hooks_codex(repo_path, remove=remove))
-            except Exception as exc:
-                typer.echo(f"  {repo_path}: Codex hook wiring error - {exc}")
+    for line in codex_surfaces(remove=remove, with_hooks=with_hooks):
+        typer.echo(line)
 
     if not remove:
         typer.echo("\nNext: run a Codex session — it reads ~/.codex/config.toml on start.")
@@ -254,202 +147,6 @@ def codex(
 
 # ─── nauro setup all ────────────────────────────────────────────────────────
 
-
-def setup_all_surfaces(
-    project_repos: list[Path],
-    *,
-    remove: bool = False,
-    current_project_key: str | None = None,
-    store_path: Path | None = None,
-    with_subagents: bool = False,
-    force_overwrite: bool = False,
-    with_skills: bool = False,
-    with_hooks: bool = False,
-    clear_user_scope_override: bool | None = None,
-) -> list[str]:
-    """Wire MCP and materialize skills across Claude Code, Cursor, Codex.
-
-    Continues across per-handler errors so partial coverage still reports
-    progress. Returns the cumulative status lines.
-
-    ``current_project_key`` is the registry key (v2 id or v1 name) for the
-    project being wired or torn down. When ``remove=True``, it is excluded
-    from the "are there other projects?" check so per-project teardown only
-    clears user-scope artifacts (Claude/Codex skill, ``~/.codex/config.toml``)
-    when this is the last project on the machine.
-
-    On the add path, when both ``current_project_key`` and ``store_path`` are
-    supplied, AGENTS.md is regenerated once across the project's repos so every
-    entry point (``setup claude-code``, ``setup all``, ``adopt``) produces the
-    cross-tool context file. The MCP-less Cursor/Codex surfaces depend on this
-    fallback layer the most, yet only ``setup claude-code`` used to write it.
-
-    ``with_subagents`` opts into installing or removing the bundled
-    ``nauro-*`` workflow subagents under ``~/.claude/agents/``. Off by
-    default so existing flows that pre-date the subagent bundle keep
-    their previous behavior. ``force_overwrite`` is only meaningful when
-    ``with_subagents`` is True and ``remove`` is False — it replaces
-    locally-modified bundled files instead of preserving them.
-
-    ``with_skills`` opts into installing the bundled opt-in skills
-    (``nauro-ship-task``, ``nauro-context``, ``nauro-loop``). Independent of
-    ``with_subagents`` so users
-    can adopt skills and subagents on separate cadences, though
-    ``nauro-ship-task`` references the bundled ``@nauro-*`` subagents in
-    its body — and ``nauro-loop`` dispatches that chain — so a caller that
-    surfaces ``with_skills`` without ``with_subagents`` should warn the user.
-
-    ``with_hooks`` opts into wiring the advisory Claude Code
-    ``UserPromptSubmit`` hook and the Codex ``SessionStart`` and
-    ``SubagentStart`` hooks into each repo's project-scope configuration. Off
-    by default. A hook-wiring failure is caught and reported as a status line
-    so it never aborts the rest of setup.
-
-    ``clear_user_scope_override`` forces the shared-user-scope decision instead
-    of deriving it from the registry. ``nauro adopt --remove`` passes ``False``
-    when it un-adopts one repo of a multi-repo project: the default
-    ``_user_scope_safe_to_clear`` check is project-granular, so it would wrongly
-    clear codex/skill/agent artifacts that the project's other repos still need.
-    Leave ``None`` for the default behavior.
-    """
-    if clear_user_scope_override is not None:
-        clear_user_scope = clear_user_scope_override
-    else:
-        clear_user_scope = _user_scope_safe_to_clear(current_project_key) if remove else True
-
-    lines: list[str] = []
-
-    # Claude Code (MCP per-repo via direct `.mcp.json` write + skills global)
-    for repo in project_repos:
-        if not repo.is_dir():
-            lines.append(f"  {repo}: repo path missing, skipped")
-            continue
-        try:
-            lines.append(_configure_mcp(repo, remove=remove))
-        except Exception as exc:
-            lines.append(f"Claude Code MCP ({repo}): error - {exc}")
-    if not remove:
-        try:
-            pruned = _prune_redundant_user_scope_mcp()
-            if pruned:
-                lines.append(pruned)
-        except Exception as exc:  # never let cleanup break wiring
-            lines.append(f"Claude Code MCP (user-scope cleanup): error - {exc}")
-    try:
-        lines.extend(
-            materialize_skills_claude_code(
-                remove=remove,
-                clear_user_scope=clear_user_scope,
-                with_skills=with_skills,
-            )
-        )
-    except Exception as exc:
-        lines.append(f"Claude Code skills: error - {exc}")
-
-    if with_subagents:
-        try:
-            lines.extend(
-                materialize_agents(
-                    "claude_code",
-                    remove=remove,
-                    force_overwrite=force_overwrite,
-                    clear_user_scope=clear_user_scope,
-                )
-            )
-        except Exception as exc:
-            lines.append(f"Claude Code agents: error - {exc}")
-
-    if with_hooks or remove:
-        for repo in project_repos:
-            if not repo.is_dir():
-                continue
-            try:
-                lines.append(materialize_hooks_claude_code(repo, remove=remove))
-            except Exception as exc:
-                lines.append(f"Claude Code hook ({repo}): error - {exc}")
-
-    # Cursor (MCP per-repo + skills per-repo)
-    for repo in project_repos:
-        if not repo.is_dir():
-            continue
-        try:
-            lines.append(_configure_cursor_for_repo(repo, remove=remove))
-        except Exception as exc:
-            lines.append(f"Cursor MCP ({repo}): error - {exc}")
-        try:
-            lines.extend(
-                materialize_skills_cursor_for_repo(repo, remove=remove, with_skills=with_skills)
-            )
-        except Exception as exc:
-            lines.append(f"Cursor skills ({repo}): error - {exc}")
-
-    # Codex (MCP global + skills global)
-    try:
-        lines.append(_configure_codex(remove=remove, clear_user_scope=clear_user_scope))
-    except Exception as exc:
-        lines.append(f"Codex MCP: error - {exc}")
-    try:
-        lines.extend(
-            materialize_skills_codex(
-                remove=remove,
-                clear_user_scope=clear_user_scope,
-                with_skills=with_skills,
-            )
-        )
-    except Exception as exc:
-        lines.append(f"Codex skills: error - {exc}")
-
-    if with_hooks or remove:
-        for repo in project_repos:
-            if not repo.is_dir():
-                continue
-            try:
-                lines.append(materialize_hooks_codex(repo, remove=remove))
-            except Exception as exc:
-                lines.append(f"Codex hooks ({repo}): error - {exc}")
-
-    # Regenerate AGENTS.md once so context is fresh from the start on every
-    # entry point that wires surfaces. Guarded on the add path and on having a
-    # store to read from. warn_then_regen routes missing-repo, symlink-refusal,
-    # and git-hygiene warnings into the status lines.
-    if not remove and current_project_key is not None and store_path is not None:
-        try:
-            updated = warn_then_regen(current_project_key, store_path, warn=lines.append)
-            for repo_path in updated:
-                lines.append(f"  {repo_path}: regenerated AGENTS.md")
-        except Exception as exc:
-            lines.append(f"AGENTS.md regeneration: error - {exc}")
-
-    # Mirror of the regen above: strip the generated AGENTS.md on teardown so a
-    # removed integration leaves no orphaned context file. User content in a
-    # ``# Manual`` section is preserved (the file is kept) by the helper.
-    if remove:
-        for repo in project_repos:
-            if not repo.is_dir():
-                continue
-            try:
-                removed_line = remove_generated_agents_md(repo)
-                if removed_line:
-                    lines.append(removed_line)
-            except Exception as exc:
-                lines.append(f"AGENTS.md removal ({repo}) failed: {exc}")
-
-    return lines
-
-
-SHIP_TASK_NEEDS_SUBAGENTS_NOTICE = (
-    "nauro-ship-task references the bundled @nauro-* subagents (and nauro-loop "
-    "dispatches that chain); pass `--with-subagents` to install them too."
-)
-
-# The bundled subagents allow the cloud tools by the fixed name
-# `mcp__claude_ai_Nauro__*`. That prefix only resolves when the remote
-# connector is named exactly `Nauro`, so surface the requirement whenever
-# subagents are installed.
-SUBAGENTS_CONNECTOR_NAME_NOTICE = (
-    "Cloud users: name the remote MCP connector exactly `Nauro` so the bundled "
-    "@nauro-* subagents' `mcp__claude_ai_Nauro__*` tools resolve."
-)
 
 HOOKS_NOTICE = (
     "The advisory hook surfaces related decisions as context on each turn "

--- a/packages/nauro/src/nauro/cli/integrations/orchestrator.py
+++ b/packages/nauro/src/nauro/cli/integrations/orchestrator.py
@@ -1,0 +1,367 @@
+"""Cross-surface setup orchestration policy shared by the setup commands and adopt."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+from nauro.cli.integrations.agents import materialize_agents
+from nauro.cli.integrations.claude_hooks import materialize_hooks_claude_code
+from nauro.cli.integrations.claude_user_config import _prune_redundant_user_scope_mcp
+from nauro.cli.integrations.codex_config import _configure_codex, _default_codex_config_path
+from nauro.cli.integrations.codex_hooks import _nearest_codex_hooks_repo, materialize_hooks_codex
+from nauro.cli.integrations.json_mcp import _configure_cursor_for_repo, _configure_mcp
+from nauro.cli.integrations.legacy import _remove_claude_md
+from nauro.cli.integrations.skills import (
+    materialize_skills_claude_code,
+    materialize_skills_codex,
+    materialize_skills_cursor_for_repo,
+)
+from nauro.cli.integrations.user_scope import _registered_project_keys, _user_scope_safe_to_clear
+from nauro.cli.utils import _resolve_project_entry, resolve_target_project
+from nauro.store.registry import get_repo_paths
+from nauro.store.resolution import resolve_from_cwd
+from nauro.templates.agents_md import remove_generated_agents_md
+from nauro.templates.agents_md_regen import warn_then_regen
+
+
+def claude_code_surfaces(
+    project_repos: list[Path],
+    *,
+    remove: bool,
+    with_hooks: bool,
+    store_name: str,
+    store_path: Path,
+    warn: Callable[[str], None],
+) -> list[str]:
+    """Wire Claude Code MCP + hooks per repo and regenerate AGENTS.md.
+
+    Returns the flat status lines the command echoes to stdout, in order:
+    the per-repo MCP lines (plus the user-scope prune note on add), then a
+    ``Hooks:`` section, a ``Legacy cleanup:`` section, and an ``AGENTS.md:``
+    section when each has data. Skip and git-hygiene warnings from
+    ``warn_then_regen`` route through ``warn`` (stderr), never the returned
+    list.
+    """
+    legacy_results: list[str] = []
+    mcp_results: list[str] = []
+    hook_results: list[str] = []
+    for repo_path in project_repos:
+        if not repo_path.is_dir():
+            mcp_results.append(f"  {repo_path}: repo path missing, skipped")
+            continue
+        legacy = _remove_claude_md(repo_path)
+        if legacy:
+            legacy_results.append(legacy)
+        mcp_results.append(_configure_mcp(repo_path, remove=remove))
+        if with_hooks or remove:
+            try:
+                hook_results.append(materialize_hooks_claude_code(repo_path, remove=remove))
+            except Exception as exc:
+                hook_results.append(f"  {repo_path}: hook wiring error - {exc}")
+
+    if not remove:
+        pruned = _prune_redundant_user_scope_mcp()
+        if pruned:
+            mcp_results.append(pruned)
+
+    lines: list[str] = list(mcp_results)
+
+    if hook_results:
+        lines.append("\nHooks:")
+        lines.extend(hook_results)
+
+    if legacy_results:
+        lines.append("\nLegacy cleanup:")
+        lines.extend(legacy_results)
+
+    if not remove:
+        # Regenerate AGENTS.md so context is fresh from the start. The store
+        # dir name is the v2 id (or v1 name) used by the registry-aware lookup.
+        # warn_then_regen surfaces missing-repo, symlink-refusal, and
+        # git-hygiene warnings through the warn callback.
+        updated_repos = warn_then_regen(store_name, store_path, warn=warn)
+        if updated_repos:
+            lines.append("\nAGENTS.md:")
+            for repo_path in updated_repos:
+                lines.append(f"  {repo_path}: regenerated AGENTS.md")
+
+    return lines
+
+
+def cursor_surfaces(project_repos: list[Path], *, remove: bool) -> list[str]:
+    """Wire Cursor MCP per repo. Returns the per-repo status lines."""
+    lines: list[str] = []
+    for repo_path in project_repos:
+        if not repo_path.is_dir():
+            lines.append(f"  {repo_path}: repo path missing, skipped")
+            continue
+        lines.append(_configure_cursor_for_repo(repo_path, remove=remove))
+    return lines
+
+
+def codex_surfaces(*, remove: bool, with_hooks: bool) -> list[str]:
+    """Wire the user-global Codex MCP entry and per-repo Codex hooks.
+
+    Resolves the project internally (Codex config is user-global and shared by
+    every registered project). Returns the flat status lines the command
+    echoes: the config line, then a ``Hooks:`` section when hooks are wired or
+    torn down.
+    """
+    hook_repos: list[Path] = []
+    if with_hooks and not remove:
+        project_name, store_path = resolve_target_project(None)
+        entry = _resolve_project_entry(project_name, store_path.name)
+        hook_repos = [Path(repo_path) for repo_path in entry["repo_paths"]]
+
+    lines: list[str] = []
+
+    # Standalone codex wiring is user-global and shared by every registered
+    # project, so this teardown preserves the entry while any project remains
+    # in the registry (it clears only on an empty registry). Clearing on the
+    # last project goes through 'nauro setup all --remove'.
+    registered_count = len(_registered_project_keys()) if remove else 0
+    if registered_count:
+        config_path = _default_codex_config_path()
+        count_phrase = (
+            "1 nauro project" if registered_count == 1 else f"{registered_count} nauro projects"
+        )
+        lines.append(
+            f"Codex: preserved nauro entry in {config_path} ({count_phrase} registered; "
+            "run 'nauro setup all --remove' on the last project to clear this "
+            "user-global entry)"
+        )
+    else:
+        lines.append(_configure_codex(remove=remove))
+
+    hook_cleanup_unresolved = False
+    if remove:
+        try:
+            resolution = resolve_from_cwd(Path.cwd())
+            hook_repos = (
+                [Path(repo_path) for repo_path in get_repo_paths(resolution.project_id)]
+                if resolution is not None
+                else []
+            )
+            nearest_hooks_repo = _nearest_codex_hooks_repo(Path.cwd())
+            if nearest_hooks_repo is not None and nearest_hooks_repo not in hook_repos:
+                hook_repos.append(nearest_hooks_repo)
+            hook_cleanup_unresolved = not hook_repos
+        except Exception:
+            hook_cleanup_unresolved = True
+
+    if with_hooks or remove:
+        lines.append("\nHooks:")
+        if hook_cleanup_unresolved:
+            lines.append(
+                "  Project-scoped Codex hooks were not removed because no Nauro "
+                "project resolves from this directory. Run this command from each "
+                "wired repo to remove them."
+            )
+        for repo_path in hook_repos:
+            if not repo_path.is_dir():
+                lines.append(f"  {repo_path}: repo path missing, skipped")
+                continue
+            try:
+                lines.append(materialize_hooks_codex(repo_path, remove=remove))
+            except Exception as exc:
+                lines.append(f"  {repo_path}: Codex hook wiring error - {exc}")
+
+    return lines
+
+
+def setup_all_surfaces(
+    project_repos: list[Path],
+    *,
+    remove: bool = False,
+    current_project_key: str | None = None,
+    store_path: Path | None = None,
+    with_subagents: bool = False,
+    force_overwrite: bool = False,
+    with_skills: bool = False,
+    with_hooks: bool = False,
+    clear_user_scope_override: bool | None = None,
+) -> list[str]:
+    """Wire MCP and materialize skills across Claude Code, Cursor, Codex.
+
+    Continues across per-handler errors so partial coverage still reports
+    progress. Returns the cumulative status lines.
+
+    ``current_project_key`` is the registry key (v2 id or v1 name) for the
+    project being wired or torn down. When ``remove=True``, it is excluded
+    from the "are there other projects?" check so per-project teardown only
+    clears user-scope artifacts (Claude/Codex skill, ``~/.codex/config.toml``)
+    when this is the last project on the machine.
+
+    On the add path, when both ``current_project_key`` and ``store_path`` are
+    supplied, AGENTS.md is regenerated once across the project's repos so every
+    entry point (``setup claude-code``, ``setup all``, ``adopt``) produces the
+    cross-tool context file. The MCP-less Cursor/Codex surfaces depend on this
+    fallback layer the most, yet only ``setup claude-code`` used to write it.
+
+    ``with_subagents`` opts into installing or removing the bundled
+    ``nauro-*`` workflow subagents under ``~/.claude/agents/``. Off by
+    default so existing flows that pre-date the subagent bundle keep
+    their previous behavior. ``force_overwrite`` is only meaningful when
+    ``with_subagents`` is True and ``remove`` is False — it replaces
+    locally-modified bundled files instead of preserving them.
+
+    ``with_skills`` opts into installing the bundled opt-in skills
+    (``nauro-ship-task``, ``nauro-context``, ``nauro-loop``). Independent of
+    ``with_subagents`` so users
+    can adopt skills and subagents on separate cadences, though
+    ``nauro-ship-task`` references the bundled ``@nauro-*`` subagents in
+    its body — and ``nauro-loop`` dispatches that chain — so a caller that
+    surfaces ``with_skills`` without ``with_subagents`` should warn the user.
+
+    ``with_hooks`` opts into wiring the advisory Claude Code
+    ``UserPromptSubmit`` hook and the Codex ``SessionStart`` and
+    ``SubagentStart`` hooks into each repo's project-scope configuration. Off
+    by default. A hook-wiring failure is caught and reported as a status line
+    so it never aborts the rest of setup.
+
+    ``clear_user_scope_override`` forces the shared-user-scope decision instead
+    of deriving it from the registry. ``nauro adopt --remove`` passes ``False``
+    when it un-adopts one repo of a multi-repo project: the default
+    ``_user_scope_safe_to_clear`` check is project-granular, so it would wrongly
+    clear codex/skill/agent artifacts that the project's other repos still need.
+    Leave ``None`` for the default behavior.
+    """
+    if clear_user_scope_override is not None:
+        clear_user_scope = clear_user_scope_override
+    else:
+        clear_user_scope = _user_scope_safe_to_clear(current_project_key) if remove else True
+
+    lines: list[str] = []
+
+    # Claude Code (MCP per-repo via direct `.mcp.json` write + skills global)
+    for repo in project_repos:
+        if not repo.is_dir():
+            lines.append(f"  {repo}: repo path missing, skipped")
+            continue
+        try:
+            lines.append(_configure_mcp(repo, remove=remove))
+        except Exception as exc:
+            lines.append(f"Claude Code MCP ({repo}): error - {exc}")
+    if not remove:
+        try:
+            pruned = _prune_redundant_user_scope_mcp()
+            if pruned:
+                lines.append(pruned)
+        except Exception as exc:  # never let cleanup break wiring
+            lines.append(f"Claude Code MCP (user-scope cleanup): error - {exc}")
+    try:
+        lines.extend(
+            materialize_skills_claude_code(
+                remove=remove,
+                clear_user_scope=clear_user_scope,
+                with_skills=with_skills,
+            )
+        )
+    except Exception as exc:
+        lines.append(f"Claude Code skills: error - {exc}")
+
+    if with_subagents:
+        try:
+            lines.extend(
+                materialize_agents(
+                    "claude_code",
+                    remove=remove,
+                    force_overwrite=force_overwrite,
+                    clear_user_scope=clear_user_scope,
+                )
+            )
+        except Exception as exc:
+            lines.append(f"Claude Code agents: error - {exc}")
+
+    if with_hooks or remove:
+        for repo in project_repos:
+            if not repo.is_dir():
+                continue
+            try:
+                lines.append(materialize_hooks_claude_code(repo, remove=remove))
+            except Exception as exc:
+                lines.append(f"Claude Code hook ({repo}): error - {exc}")
+
+    # Cursor (MCP per-repo + skills per-repo)
+    for repo in project_repos:
+        if not repo.is_dir():
+            continue
+        try:
+            lines.append(_configure_cursor_for_repo(repo, remove=remove))
+        except Exception as exc:
+            lines.append(f"Cursor MCP ({repo}): error - {exc}")
+        try:
+            lines.extend(
+                materialize_skills_cursor_for_repo(repo, remove=remove, with_skills=with_skills)
+            )
+        except Exception as exc:
+            lines.append(f"Cursor skills ({repo}): error - {exc}")
+
+    # Codex (MCP global + skills global)
+    try:
+        lines.append(_configure_codex(remove=remove, clear_user_scope=clear_user_scope))
+    except Exception as exc:
+        lines.append(f"Codex MCP: error - {exc}")
+    try:
+        lines.extend(
+            materialize_skills_codex(
+                remove=remove,
+                clear_user_scope=clear_user_scope,
+                with_skills=with_skills,
+            )
+        )
+    except Exception as exc:
+        lines.append(f"Codex skills: error - {exc}")
+
+    if with_hooks or remove:
+        for repo in project_repos:
+            if not repo.is_dir():
+                continue
+            try:
+                lines.append(materialize_hooks_codex(repo, remove=remove))
+            except Exception as exc:
+                lines.append(f"Codex hooks ({repo}): error - {exc}")
+
+    # Regenerate AGENTS.md once so context is fresh from the start on every
+    # entry point that wires surfaces. Guarded on the add path and on having a
+    # store to read from. warn_then_regen routes missing-repo, symlink-refusal,
+    # and git-hygiene warnings into the status lines.
+    if not remove and current_project_key is not None and store_path is not None:
+        try:
+            updated = warn_then_regen(current_project_key, store_path, warn=lines.append)
+            for repo_path in updated:
+                lines.append(f"  {repo_path}: regenerated AGENTS.md")
+        except Exception as exc:
+            lines.append(f"AGENTS.md regeneration: error - {exc}")
+
+    # Mirror of the regen above: strip the generated AGENTS.md on teardown so a
+    # removed integration leaves no orphaned context file. User content in a
+    # ``# Manual`` section is preserved (the file is kept) by the helper.
+    if remove:
+        for repo in project_repos:
+            if not repo.is_dir():
+                continue
+            try:
+                removed_line = remove_generated_agents_md(repo)
+                if removed_line:
+                    lines.append(removed_line)
+            except Exception as exc:
+                lines.append(f"AGENTS.md removal ({repo}) failed: {exc}")
+
+    return lines
+
+
+SHIP_TASK_NEEDS_SUBAGENTS_NOTICE = (
+    "nauro-ship-task references the bundled @nauro-* subagents (and nauro-loop "
+    "dispatches that chain); pass `--with-subagents` to install them too."
+)
+
+# The bundled subagents allow the cloud tools by the fixed name
+# `mcp__claude_ai_Nauro__*`. That prefix only resolves when the remote
+# connector is named exactly `Nauro`, so surface the requirement whenever
+# subagents are installed.
+SUBAGENTS_CONNECTOR_NAME_NOTICE = (
+    "Cloud users: name the remote MCP connector exactly `Nauro` so the bundled "
+    "@nauro-* subagents' `mcp__claude_ai_Nauro__*` tools resolve."
+)

--- a/packages/nauro/tests/test_command_resolution.py
+++ b/packages/nauro/tests/test_command_resolution.py
@@ -250,7 +250,7 @@ def test_find_nauro_command_memoizes_resolution(monkeypatch):
 
 def test_setup_all_resolves_command_once(tmp_path, monkeypatch):
     """`setup all` validates the entrypoint once across all five sinks."""
-    from nauro.cli.commands.setup import setup_all_surfaces
+    from nauro.cli.integrations.orchestrator import setup_all_surfaces
 
     repo1 = tmp_path / "repo1"
     repo2 = tmp_path / "repo2"

--- a/packages/nauro/tests/test_setup.py
+++ b/packages/nauro/tests/test_setup.py
@@ -190,7 +190,7 @@ class TestMCPConfigDirectWrite:
 
     def test_setup_all_iterates_per_repo(self, tmp_path: Path, monkeypatch):
         """Multi-repo project: `setup all` writes `.mcp.json` once per repo."""
-        from nauro.cli.commands.setup import setup_all_surfaces
+        from nauro.cli.integrations.orchestrator import setup_all_surfaces
 
         repo1 = tmp_path / "repo1"
         repo2 = tmp_path / "repo2"

--- a/packages/nauro/tests/test_setup_characterization.py
+++ b/packages/nauro/tests/test_setup_characterization.py
@@ -203,6 +203,37 @@ class TestClaudeCodeTranscripts:
         )
         assert result.stderr == ""
 
+    def test_add_preserves_handwritten_agents_md_warns_on_stderr(self, tmp_path: Path, monkeypatch):
+        """A marker-less AGENTS.md is preserved and warned about on stderr.
+
+        The only claude_code path that emits stderr routes warn_then_regen's
+        warn callback (``typer.echo(msg, err=True)``). A hand-written AGENTS.md
+        without Nauro's generation markers is left unchanged, no ``AGENTS.md:``
+        stdout section is printed, and the preserve warning lands on stderr.
+        Both streams are pinned separately so the warn routing is verified, not
+        assumed.
+        """
+        _pid, _store, paths = _register_project(tmp_path, monkeypatch)
+        (paths[0] / "AGENTS.md").write_text("# My AGENTS\n\nhand-written\n", encoding="utf-8")
+
+        result = runner.invoke(app, ["setup", "claude-code"])
+
+        assert result.exit_code == 0
+        assert _norm(result.stdout, tmp_path) == (
+            "Configured Nauro for project 'proj':\n"
+            "\n"
+            "  {TMP}/repo: wrote nauro to .mcp.json\n"
+            "\n" + CLAUDE_NEXT_LINE + "\n" + TRY_IT_LINE
+        )
+        assert _norm(result.stderr, tmp_path) == (
+            "  Warning: existing AGENTS.md is not Nauro-generated; "
+            "left unchanged: {TMP}/repo/AGENTS.md\n"
+        )
+        # The hand-written file is preserved byte-for-byte.
+        assert (paths[0] / "AGENTS.md").read_text(
+            encoding="utf-8"
+        ) == "# My AGENTS\n\nhand-written\n"
+
 
 class TestCursorTranscripts:
     def test_add(self, tmp_path: Path, monkeypatch):

--- a/packages/nauro/tests/test_setup_extended.py
+++ b/packages/nauro/tests/test_setup_extended.py
@@ -973,7 +973,7 @@ def test_setup_all_writes_agents_md(tmp_path: Path, monkeypatch):
 
 def test_setup_all_regenerates_agents_md_exactly_once(tmp_path: Path, monkeypatch):
     """A single `setup all` invocation writes AGENTS.md once — no double-regen."""
-    import nauro.cli.commands.setup as setup_mod
+    import nauro.cli.integrations.orchestrator as orchestrator_mod
 
     monkeypatch.setenv("HOME", str(tmp_path))
     repo = tmp_path / "myrepo"
@@ -983,13 +983,13 @@ def test_setup_all_regenerates_agents_md_exactly_once(tmp_path: Path, monkeypatc
     monkeypatch.chdir(repo)
 
     calls: list[tuple] = []
-    real = setup_mod.warn_then_regen
+    real = orchestrator_mod.warn_then_regen
 
     def _counting(project_key, store, **kwargs):
         calls.append((project_key, store))
         return real(project_key, store, **kwargs)
 
-    monkeypatch.setattr(setup_mod, "warn_then_regen", _counting)
+    monkeypatch.setattr(orchestrator_mod, "warn_then_regen", _counting)
 
     result = runner.invoke(app, ["setup", "all"])
     assert result.exit_code == 0, result.output
@@ -998,7 +998,7 @@ def test_setup_all_regenerates_agents_md_exactly_once(tmp_path: Path, monkeypatc
 
 def test_setup_all_remove_does_not_write_agents_md(tmp_path: Path, monkeypatch):
     """The remove path must not regenerate AGENTS.md."""
-    import nauro.cli.commands.setup as setup_mod
+    import nauro.cli.integrations.orchestrator as orchestrator_mod
 
     monkeypatch.setenv("HOME", str(tmp_path))
     repo = tmp_path / "myrepo"
@@ -1009,7 +1009,7 @@ def test_setup_all_remove_does_not_write_agents_md(tmp_path: Path, monkeypatch):
 
     calls: list[tuple] = []
     monkeypatch.setattr(
-        setup_mod,
+        orchestrator_mod,
         "warn_then_regen",
         lambda *a, **k: calls.append(a) or [],
     )

--- a/packages/nauro/tests/test_setup_hooks.py
+++ b/packages/nauro/tests/test_setup_hooks.py
@@ -15,7 +15,6 @@ import pytest
 from typer.testing import CliRunner
 
 from nauro.cli._codex_hooks import _CODEX_HOOK_EVENTS, _CODEX_HOOK_SUBCOMMAND
-from nauro.cli.commands.setup import setup_all_surfaces
 from nauro.cli.integrations.claude_hooks import (
     HOOK_EVENT_NAME,
     HOOK_SUBCOMMAND,
@@ -23,6 +22,7 @@ from nauro.cli.integrations.claude_hooks import (
     materialize_hooks_claude_code,
 )
 from nauro.cli.integrations.codex_hooks import materialize_hooks_codex
+from nauro.cli.integrations.orchestrator import setup_all_surfaces
 from nauro.cli.main import app
 from tests.conftest import register_v2_repo
 
@@ -707,12 +707,12 @@ def test_setup_all_hook_failure_does_not_abort(tmp_path: Path, monkeypatch):
     """A hook-wiring failure is caught and reported, not propagated."""
     repo, _store = _make_project(tmp_path)
 
-    import nauro.cli.commands.setup as setup_mod
+    import nauro.cli.integrations.orchestrator as orchestrator_mod
 
     def boom(repo, *, remove):
         raise RuntimeError("simulated wiring failure")
 
-    monkeypatch.setattr(setup_mod, "materialize_hooks_claude_code", boom)
+    monkeypatch.setattr(orchestrator_mod, "materialize_hooks_claude_code", boom)
 
     # Must not raise; the rest of setup still produces its lines.
     lines = setup_all_surfaces([repo], with_hooks=True)


### PR DESCRIPTION
## Why

The four `nauro setup` commands and `nauro adopt` shared their cross-surface wiring through `setup_all_surfaces`, which lived inside the setup command module, so adopt reached across into a sibling command to reuse it. Each single-surface command also carried its own orchestration inline, mixing flag handling, per-repo write loops, and output assembly in one body.

This move lifts the orchestration into `cli/integrations/orchestrator.py`. The command bodies collapse to a thin shape: parse flags, resolve the project, echo the header, echo the surface function's status lines, echo the trailing copy. Adopt now depends on the integrations layer instead of a command module.

## What changed

- New `cli/integrations/orchestrator.py` holds the cross-surface policy: `setup_all_surfaces` moved verbatim (byte-identical); `claude_code_surfaces`, `cursor_surfaces`, `codex_surfaces` extract each single-surface command's orchestration, each returning the flat `list[str]` the command echoes; the two notices shared by `setup all` and `adopt` move here; the three notices used only by the thin commands stay in the command module.
- `commands/setup.py` drops from 552 to 248 lines: all codec imports removed, the four commands rewritten thin.
- Claude Code's stderr warning routing (`warn_then_regen`'s warn callback) is threaded through an explicit `warn` parameter, so the command body still owns the `err=True` sink.
- `adopt.py` and four test modules retarget their `setup_all_surfaces` import (and three `monkeypatch.setattr` seams) to the orchestrator module.

## Deferred

The typed end state (surface functions returning validated outcomes instead of `list[str]`, section-header rendering pulled fully back into the command, Typer-free codecs, typed errors) lands as its own separately reviewed change in the following PR.

## Test plan

- Added a permanent oracle test pinning a claude_code case with non-empty stderr: a hand-written, marker-less `AGENTS.md` is preserved and the "not Nauro-generated; left unchanged" warning is asserted on stderr, with stdout pinned separately. This verifies the warn callback survives the move rather than trusting it by construction.
- The 36 pre-existing setup characterization and onboarding oracle tests are byte-unmodified and pass; the full suite (37) is deterministic across runs.
- `packages/nauro/tests/`: 1844 passed, 10 skipped. `packages/nauro-core/tests/`: 1073 passed.
- `ruff check` and `ruff format --check`: clean.

## Risk / what to review

The surface functions are extractions, not byte-identical moves; the proof of neutrality is the oracle (stdout and stderr asserted separately) plus the new stderr pin, not byte-identity. The one permitted timing change: claude_code's stderr warnings now fire during the surface-fn call, before the stdout echo loop, invisible to the oracle since the streams are captured separately.
