### PR TITLE
Decompose long setup orchestration and codec methods

### DIFF
--- a/packages/nauro/src/nauro/cli/integrations/agents.py
+++ b/packages/nauro/src/nauro/cli/integrations/agents.py
@@ -80,35 +80,49 @@ def materialize_agents(
             continue
         bundled = render_agent("claude_code", name)
         if remove:
-            if not target.is_file():
-                results.append(f"  no agent at {target}")
-                continue
-            current = target.read_text(encoding="utf-8")
-            if current == bundled:
-                target.unlink()
-                results.append(f"  removed {target}")
-            else:
-                results.append(f"  preserved {target} (locally modified)")
-            continue
-
-        if target.is_file():
-            current = target.read_text(encoding="utf-8")
-            if current == bundled:
-                results.append(f"  unchanged {target}")
-            elif force_overwrite:
-                target.write_text(bundled, encoding="utf-8")
-                results.append(f"  overwrote {target}")
-            else:
-                backup = target.parent / (target.name + ".bak")
-                backup_refusal = find_file_symlink(backup)
-                if backup_refusal is not None:
-                    results.append(f"  {backup_refusal.message}")
-                    continue
-                backup.write_text(current, encoding="utf-8")
-                target.write_text(bundled, encoding="utf-8")
-                results.append(f"  updated {target} (previous saved to {backup.name})")
+            results.append(_remove_bundled_agent(target, bundled))
         else:
-            target.parent.mkdir(parents=True, exist_ok=True)
-            target.write_text(bundled, encoding="utf-8")
-            results.append(f"  installed {target}")
+            results.append(_install_bundled_agent(target, bundled, force_overwrite=force_overwrite))
     return results
+
+
+def _install_bundled_agent(target: Path, bundled: str, *, force_overwrite: bool) -> str:
+    """Install or refresh one bundled agent file, returning its status line.
+
+    Absent → write the bundled body. Byte-equal → no-op. ``force_overwrite`` →
+    overwrite in place. Otherwise the differing file is refreshed and its prior
+    content stashed to ``<name>.md.bak`` (unless that backup path is a refused
+    symlink).
+    """
+    if target.is_file():
+        current = target.read_text(encoding="utf-8")
+        if current == bundled:
+            return f"  unchanged {target}"
+        if force_overwrite:
+            target.write_text(bundled, encoding="utf-8")
+            return f"  overwrote {target}"
+        backup = target.parent / (target.name + ".bak")
+        backup_refusal = find_file_symlink(backup)
+        if backup_refusal is not None:
+            return f"  {backup_refusal.message}"
+        backup.write_text(current, encoding="utf-8")
+        target.write_text(bundled, encoding="utf-8")
+        return f"  updated {target} (previous saved to {backup.name})"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(bundled, encoding="utf-8")
+    return f"  installed {target}"
+
+
+def _remove_bundled_agent(target: Path, bundled: str) -> str:
+    """Remove one bundled agent file, returning its status line.
+
+    Absent → skip note. Byte-equal to the bundle → unlink. Differs → preserve
+    (locally modified).
+    """
+    if not target.is_file():
+        return f"  no agent at {target}"
+    current = target.read_text(encoding="utf-8")
+    if current == bundled:
+        target.unlink()
+        return f"  removed {target}"
+    return f"  preserved {target} (locally modified)"

--- a/packages/nauro/src/nauro/cli/integrations/claude_hooks.py
+++ b/packages/nauro/src/nauro/cli/integrations/claude_hooks.py
@@ -99,7 +99,6 @@ def _add_hook_entry(settings_path: Path, settings: dict, repo: Path) -> str:
                     return f"  {repo}: nauro hook already present in .claude/settings.json"
 
     event_matchers.append({"hooks": [_nauro_hook_entry()]})
-    settings_path.parent.mkdir(parents=True, exist_ok=True)
     atomic_write_text(settings_path, json.dumps(settings, indent=2) + "\n")
     lines = [f"  {repo}: wrote nauro hook to .claude/settings.json"]
     lines.extend(public_surface_git_warnings(repo, ".claude/settings.json"))

--- a/packages/nauro/src/nauro/cli/integrations/codex_config.py
+++ b/packages/nauro/src/nauro/cli/integrations/codex_config.py
@@ -48,6 +48,44 @@ def _parse_codex_nauro_entry(entry: object) -> _CodexNauroEntry:
     )
 
 
+def _apply_nauro_entry(
+    servers: dict,
+    entry: object,
+    current: _CodexNauroEntry,
+    desired: _CodexNauroEntry,
+) -> None:
+    """Write ``desired`` into the ``mcp_servers.nauro`` value, in place.
+
+    Three shapes, matching the existing entry: a present table gets a per-key
+    update so a key whose value already matches keeps its formatting and
+    comments; an inline parent gets an inline child; otherwise a fresh block
+    table appended without a leading blank line.
+    """
+    if isinstance(entry, dict):
+        # Per-key update: a key whose value already matches keeps its
+        # formatting and comments (e.g. a multiline args array).
+        if current.command != desired.command:
+            entry["command"] = desired.command
+        if current.args != desired.args:
+            entry["args"] = desired.args
+    elif isinstance(servers, InlineTable):
+        # A block table nested inside an inline parent renders invalid
+        # TOML; match the user's inline style instead.
+        inline = tomlkit.inline_table()
+        inline["command"] = desired.command
+        inline["args"] = desired.args
+        servers["nauro"] = inline
+    else:
+        table = tomlkit.table()
+        table["command"] = desired.command
+        table["args"] = desired.args
+        servers["nauro"] = table
+        # Appended without a leading blank line: a reparse attributes the
+        # separator to the preceding entry, which would strand a stray
+        # blank line once a later remove deletes the block.
+        table.trivia.indent = ""
+
+
 def _configure_codex(
     *,
     remove: bool,
@@ -118,29 +156,7 @@ def _configure_codex(
         current = _parse_codex_nauro_entry(entry)
         if current == desired:
             return f"Codex: nauro already configured in {config_path}"
-        if isinstance(entry, dict):
-            # Per-key update: a key whose value already matches keeps its
-            # formatting and comments (e.g. a multiline args array).
-            if current.command != desired.command:
-                entry["command"] = desired.command
-            if current.args != desired.args:
-                entry["args"] = desired.args
-        elif isinstance(servers, InlineTable):
-            # A block table nested inside an inline parent renders invalid
-            # TOML; match the user's inline style instead.
-            inline = tomlkit.inline_table()
-            inline["command"] = desired.command
-            inline["args"] = desired.args
-            servers["nauro"] = inline
-        else:
-            table = tomlkit.table()
-            table["command"] = desired.command
-            table["args"] = desired.args
-            servers["nauro"] = table
-            # Appended without a leading blank line: a reparse attributes the
-            # separator to the preceding entry, which would strand a stray
-            # blank line once a later remove deletes the block.
-            table.trivia.indent = ""
+        _apply_nauro_entry(servers, entry, current, desired)
         status = f"Codex: wrote nauro to {config_path}"
 
     rendered = tomlkit.dumps(document)

--- a/packages/nauro/src/nauro/cli/integrations/codex_hooks.py
+++ b/packages/nauro/src/nauro/cli/integrations/codex_hooks.py
@@ -77,7 +77,6 @@ def materialize_hooks_codex(repo: Path, *, remove: bool) -> str:
     rendered = _format_codex_hooks(transformed.config)
     if existing_text == rendered:
         return f"  {repo}: nauro hooks already present in .codex/hooks.json"
-    hooks_path.parent.mkdir(parents=True, exist_ok=True)
     atomic_write_text(hooks_path, rendered)
     lines = [f"  {repo}: wrote nauro hooks to .codex/hooks.json"]
     lines.extend(public_surface_git_warnings(repo, ".codex/hooks.json"))

--- a/packages/nauro/src/nauro/cli/integrations/json_mcp.py
+++ b/packages/nauro/src/nauro/cli/integrations/json_mcp.py
@@ -66,7 +66,6 @@ def _configure_json_mcp(
     if not isinstance(servers, dict):
         return f"  {repo_path}: mcpServers in {label} is not a JSON object, skipped"
     servers["nauro"] = nauro_entry
-    config_path.parent.mkdir(parents=True, exist_ok=True)
     atomic_write_text(config_path, json.dumps(config, indent=2) + "\n")
     lines = [f"  {repo_path}: wrote nauro to {label}"]
     lines.extend(public_surface_git_warnings(repo_path, config_rel_path))

--- a/packages/nauro/src/nauro/cli/integrations/orchestrator.py
+++ b/packages/nauro/src/nauro/cli/integrations/orchestrator.py
@@ -170,6 +170,170 @@ def codex_surfaces(*, remove: bool, with_hooks: bool) -> list[str]:
     return lines
 
 
+def _all_claude_code_lines(
+    project_repos: list[Path],
+    *,
+    remove: bool,
+    clear_user_scope: bool,
+    with_subagents: bool,
+    force_overwrite: bool,
+    with_skills: bool,
+    with_hooks: bool,
+) -> list[str]:
+    """Claude Code surface lines for ``setup_all_surfaces``.
+
+    MCP per-repo (direct ``.mcp.json`` write), user-scope prune on add, skills
+    global, optional subagents, then the per-repo advisory hook.
+    """
+    lines: list[str] = []
+    for repo in project_repos:
+        if not repo.is_dir():
+            lines.append(f"  {repo}: repo path missing, skipped")
+            continue
+        try:
+            lines.append(_configure_mcp(repo, remove=remove))
+        except Exception as exc:
+            lines.append(f"Claude Code MCP ({repo}): error - {exc}")
+    if not remove:
+        try:
+            pruned = _prune_redundant_user_scope_mcp()
+            if pruned:
+                lines.append(pruned)
+        except Exception as exc:  # never let cleanup break wiring
+            lines.append(f"Claude Code MCP (user-scope cleanup): error - {exc}")
+    try:
+        lines.extend(
+            materialize_skills_claude_code(
+                remove=remove,
+                clear_user_scope=clear_user_scope,
+                with_skills=with_skills,
+            )
+        )
+    except Exception as exc:
+        lines.append(f"Claude Code skills: error - {exc}")
+
+    if with_subagents:
+        try:
+            lines.extend(
+                materialize_agents(
+                    "claude_code",
+                    remove=remove,
+                    force_overwrite=force_overwrite,
+                    clear_user_scope=clear_user_scope,
+                )
+            )
+        except Exception as exc:
+            lines.append(f"Claude Code agents: error - {exc}")
+
+    if with_hooks or remove:
+        for repo in project_repos:
+            if not repo.is_dir():
+                continue
+            try:
+                lines.append(materialize_hooks_claude_code(repo, remove=remove))
+            except Exception as exc:
+                lines.append(f"Claude Code hook ({repo}): error - {exc}")
+    return lines
+
+
+def _all_cursor_lines(project_repos: list[Path], *, remove: bool, with_skills: bool) -> list[str]:
+    """Cursor surface lines for ``setup_all_surfaces``: MCP per repo + skills per repo."""
+    lines: list[str] = []
+    for repo in project_repos:
+        if not repo.is_dir():
+            continue
+        try:
+            lines.append(_configure_cursor_for_repo(repo, remove=remove))
+        except Exception as exc:
+            lines.append(f"Cursor MCP ({repo}): error - {exc}")
+        try:
+            lines.extend(
+                materialize_skills_cursor_for_repo(repo, remove=remove, with_skills=with_skills)
+            )
+        except Exception as exc:
+            lines.append(f"Cursor skills ({repo}): error - {exc}")
+    return lines
+
+
+def _all_codex_lines(
+    project_repos: list[Path],
+    *,
+    remove: bool,
+    clear_user_scope: bool,
+    with_skills: bool,
+    with_hooks: bool,
+) -> list[str]:
+    """Codex surface lines for ``setup_all_surfaces``: MCP global, skills global, optional hooks."""
+    lines: list[str] = []
+    try:
+        lines.append(_configure_codex(remove=remove, clear_user_scope=clear_user_scope))
+    except Exception as exc:
+        lines.append(f"Codex MCP: error - {exc}")
+    try:
+        lines.extend(
+            materialize_skills_codex(
+                remove=remove,
+                clear_user_scope=clear_user_scope,
+                with_skills=with_skills,
+            )
+        )
+    except Exception as exc:
+        lines.append(f"Codex skills: error - {exc}")
+
+    if with_hooks or remove:
+        for repo in project_repos:
+            if not repo.is_dir():
+                continue
+            try:
+                lines.append(materialize_hooks_codex(repo, remove=remove))
+            except Exception as exc:
+                lines.append(f"Codex hooks ({repo}): error - {exc}")
+    return lines
+
+
+def _all_agents_md_lines(
+    project_repos: list[Path],
+    *,
+    remove: bool,
+    current_project_key: str | None,
+    store_path: Path | None,
+) -> list[str]:
+    """AGENTS.md regen (add) and teardown (remove) lines for ``setup_all_surfaces``.
+
+    On the add path ``warn_then_regen`` routes missing-repo, symlink-refusal,
+    and git-hygiene warnings into ``warn``; the callback appends into this
+    helper's own returned list so those warnings surface on stdout in the same
+    position the inline code produced them.
+    """
+    lines: list[str] = []
+    # Regenerate AGENTS.md once so context is fresh from the start on every
+    # entry point that wires surfaces. Guarded on the add path and on having a
+    # store to read from. warn_then_regen routes missing-repo, symlink-refusal,
+    # and git-hygiene warnings into the status lines.
+    if not remove and current_project_key is not None and store_path is not None:
+        try:
+            updated = warn_then_regen(current_project_key, store_path, warn=lines.append)
+            for repo_path in updated:
+                lines.append(f"  {repo_path}: regenerated AGENTS.md")
+        except Exception as exc:
+            lines.append(f"AGENTS.md regeneration: error - {exc}")
+
+    # Mirror of the regen above: strip the generated AGENTS.md on teardown so a
+    # removed integration leaves no orphaned context file. User content in a
+    # ``# Manual`` section is preserved (the file is kept) by the helper.
+    if remove:
+        for repo in project_repos:
+            if not repo.is_dir():
+                continue
+            try:
+                removed_line = remove_generated_agents_md(repo)
+                if removed_line:
+                    lines.append(removed_line)
+            except Exception as exc:
+                lines.append(f"AGENTS.md removal ({repo}) failed: {exc}")
+    return lines
+
+
 def setup_all_surfaces(
     project_repos: list[Path],
     *,
@@ -233,122 +397,35 @@ def setup_all_surfaces(
         clear_user_scope = _user_scope_safe_to_clear(current_project_key) if remove else True
 
     lines: list[str] = []
-
-    # Claude Code (MCP per-repo via direct `.mcp.json` write + skills global)
-    for repo in project_repos:
-        if not repo.is_dir():
-            lines.append(f"  {repo}: repo path missing, skipped")
-            continue
-        try:
-            lines.append(_configure_mcp(repo, remove=remove))
-        except Exception as exc:
-            lines.append(f"Claude Code MCP ({repo}): error - {exc}")
-    if not remove:
-        try:
-            pruned = _prune_redundant_user_scope_mcp()
-            if pruned:
-                lines.append(pruned)
-        except Exception as exc:  # never let cleanup break wiring
-            lines.append(f"Claude Code MCP (user-scope cleanup): error - {exc}")
-    try:
-        lines.extend(
-            materialize_skills_claude_code(
-                remove=remove,
-                clear_user_scope=clear_user_scope,
-                with_skills=with_skills,
-            )
+    lines.extend(
+        _all_claude_code_lines(
+            project_repos,
+            remove=remove,
+            clear_user_scope=clear_user_scope,
+            with_subagents=with_subagents,
+            force_overwrite=force_overwrite,
+            with_skills=with_skills,
+            with_hooks=with_hooks,
         )
-    except Exception as exc:
-        lines.append(f"Claude Code skills: error - {exc}")
-
-    if with_subagents:
-        try:
-            lines.extend(
-                materialize_agents(
-                    "claude_code",
-                    remove=remove,
-                    force_overwrite=force_overwrite,
-                    clear_user_scope=clear_user_scope,
-                )
-            )
-        except Exception as exc:
-            lines.append(f"Claude Code agents: error - {exc}")
-
-    if with_hooks or remove:
-        for repo in project_repos:
-            if not repo.is_dir():
-                continue
-            try:
-                lines.append(materialize_hooks_claude_code(repo, remove=remove))
-            except Exception as exc:
-                lines.append(f"Claude Code hook ({repo}): error - {exc}")
-
-    # Cursor (MCP per-repo + skills per-repo)
-    for repo in project_repos:
-        if not repo.is_dir():
-            continue
-        try:
-            lines.append(_configure_cursor_for_repo(repo, remove=remove))
-        except Exception as exc:
-            lines.append(f"Cursor MCP ({repo}): error - {exc}")
-        try:
-            lines.extend(
-                materialize_skills_cursor_for_repo(repo, remove=remove, with_skills=with_skills)
-            )
-        except Exception as exc:
-            lines.append(f"Cursor skills ({repo}): error - {exc}")
-
-    # Codex (MCP global + skills global)
-    try:
-        lines.append(_configure_codex(remove=remove, clear_user_scope=clear_user_scope))
-    except Exception as exc:
-        lines.append(f"Codex MCP: error - {exc}")
-    try:
-        lines.extend(
-            materialize_skills_codex(
-                remove=remove,
-                clear_user_scope=clear_user_scope,
-                with_skills=with_skills,
-            )
+    )
+    lines.extend(_all_cursor_lines(project_repos, remove=remove, with_skills=with_skills))
+    lines.extend(
+        _all_codex_lines(
+            project_repos,
+            remove=remove,
+            clear_user_scope=clear_user_scope,
+            with_skills=with_skills,
+            with_hooks=with_hooks,
         )
-    except Exception as exc:
-        lines.append(f"Codex skills: error - {exc}")
-
-    if with_hooks or remove:
-        for repo in project_repos:
-            if not repo.is_dir():
-                continue
-            try:
-                lines.append(materialize_hooks_codex(repo, remove=remove))
-            except Exception as exc:
-                lines.append(f"Codex hooks ({repo}): error - {exc}")
-
-    # Regenerate AGENTS.md once so context is fresh from the start on every
-    # entry point that wires surfaces. Guarded on the add path and on having a
-    # store to read from. warn_then_regen routes missing-repo, symlink-refusal,
-    # and git-hygiene warnings into the status lines.
-    if not remove and current_project_key is not None and store_path is not None:
-        try:
-            updated = warn_then_regen(current_project_key, store_path, warn=lines.append)
-            for repo_path in updated:
-                lines.append(f"  {repo_path}: regenerated AGENTS.md")
-        except Exception as exc:
-            lines.append(f"AGENTS.md regeneration: error - {exc}")
-
-    # Mirror of the regen above: strip the generated AGENTS.md on teardown so a
-    # removed integration leaves no orphaned context file. User content in a
-    # ``# Manual`` section is preserved (the file is kept) by the helper.
-    if remove:
-        for repo in project_repos:
-            if not repo.is_dir():
-                continue
-            try:
-                removed_line = remove_generated_agents_md(repo)
-                if removed_line:
-                    lines.append(removed_line)
-            except Exception as exc:
-                lines.append(f"AGENTS.md removal ({repo}) failed: {exc}")
-
+    )
+    lines.extend(
+        _all_agents_md_lines(
+            project_repos,
+            remove=remove,
+            current_project_key=current_project_key,
+            store_path=store_path,
+        )
+    )
     return lines
 
 


### PR DESCRIPTION
## Why

Three methods in cli/integrations/ had grown long enough that their line ordering was hard to audit at a glance: setup_all_surfaces was a ~180-line procedural orchestrator, _configure_codex carried a three-way tomlkit branch inline, and materialize_agents inlined both its install and remove policies in one loop. This is a readability pass to make each one read as designed. It also drops three parent.mkdir calls that duplicate work atomic_write_text already does.

## What changed

- setup_all_surfaces builds its status lines by extending with four per-surface helpers (_all_claude_code_lines, _all_cursor_lines, _all_codex_lines, _all_agents_md_lines), called in the original order so the concatenation is identical. The AGENTS.md helper routes warn_then_regen warnings into its own returned list, preserving the previous stdout ordering.
- _configure_codex extracts the per-key / inline-table / block-table branching into _apply_nauro_entry, which mutates the tomlkit entry in place. The command body stays linear: load, guard, compare, apply, render, atomic-write.
- materialize_agents extracts its per-agent install and remove branches into _install_bundled_agent and _remove_bundled_agent, each returning the same status line as before.
- Removes three redundant parent.mkdir(...) calls that immediately preceded atomic_write_text (json_mcp, claude_hooks, codex_hooks); atomic_write_text already creates the parent directory. The mkdir calls ahead of the plain write_text paths (agents, skills) are unaffected and stay.

No output strings, public signatures, or return types change.

## Test plan

- The 37-test setup characterization oracle (test_setup_characterization.py + test_onboarding_inventories.py) passes unmodified, guarding byte-identical stdout/stderr/exit codes and filesystem trees.
- Full suites green: packages/nauro (1844 passed, 10 skipped) and packages/nauro-core (1073 passed), with no test files edited.
- ruff check and ruff format --check both clean.
