### PR TITLE
Add typed-outcome pipeline scaffolding for setup codecs

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/adopt.py
+++ b/packages/nauro/src/nauro/cli/commands/adopt.py
@@ -36,6 +36,7 @@ from nauro.cli.integrations.orchestrator import (
     SUBAGENTS_CONNECTOR_NAME_NOTICE,
     setup_all_surfaces,
 )
+from nauro.cli.integrations.render import render
 from nauro.cli.integrations.skills import OPT_IN_SKILL_NAMES, SKILL_NAMES
 from nauro.cli.nauro_command import _find_nauro_command
 from nauro.cli.utils import refuse_global_config_collision, refuse_repo_config_symlink
@@ -175,14 +176,15 @@ def _install_into_adopted_repo(
     bundled artifacts to an existing adoption instead of aborting.
     """
     typer.echo("Repo already adopted. Installing requested artifacts across surfaces:\n")
-    for line in setup_all_surfaces(
+    for outcome in setup_all_surfaces(
         [repo_root],
         remove=False,
         with_subagents=with_subagents,
         force_overwrite=force_overwrite,
         with_skills=with_skills,
     ):
-        typer.echo(line)
+        for line in render(outcome):
+            typer.echo(line)
     if with_skills and not with_subagents:
         typer.echo(f"\n{SHIP_TASK_NEEDS_SUBAGENTS_NOTICE}")
     if with_subagents:
@@ -308,7 +310,7 @@ def _remove_adoption(repo_root: Path, *, purge_store: bool, assume_yes: bool) ->
     # (absent artifacts are a no-op) and the shared-user-scope guard still
     # protects subagents/skills/codex when other projects remain.
     typer.echo("\nRemoving Nauro integration across surfaces:")
-    for line in setup_all_surfaces(
+    for outcome in setup_all_surfaces(
         [repo_root],
         remove=True,
         current_project_key=pid,
@@ -317,7 +319,8 @@ def _remove_adoption(repo_root: Path, *, purge_store: bool, assume_yes: bool) ->
         with_hooks=True,
         clear_user_scope_override=None if is_last_repo else False,
     ):
-        typer.echo(line)
+        for line in render(outcome):
+            typer.echo(line)
 
     # ── delete the per-repo config (and the .nauro dir if it is now empty) ──
     try:
@@ -570,7 +573,7 @@ def adopt(
     # ── wire MCP + materialize skills ──────────────────────────────────────
     if not no_setup_and_skills:
         typer.echo("\nWiring MCP and installing skills across surfaces:")
-        for line in setup_all_surfaces(
+        for outcome in setup_all_surfaces(
             [repo_root],
             remove=False,
             current_project_key=pid,
@@ -579,7 +582,8 @@ def adopt(
             force_overwrite=force_overwrite,
             with_skills=with_skills,
         ):
-            typer.echo(line)
+            for line in render(outcome):
+                typer.echo(line)
 
         if with_skills and not with_subagents:
             typer.echo(f"\n{SHIP_TASK_NEEDS_SUBAGENTS_NOTICE}")

--- a/packages/nauro/src/nauro/cli/commands/setup.py
+++ b/packages/nauro/src/nauro/cli/commands/setup.py
@@ -22,6 +22,7 @@ from nauro.cli.integrations.orchestrator import (
     cursor_surfaces,
     setup_all_surfaces,
 )
+from nauro.cli.integrations.render import render
 from nauro.cli.utils import _resolve_project_entry, resolve_target_project
 
 setup_app = typer.Typer(help="Configure tool integrations.")
@@ -58,7 +59,7 @@ def claude_code(
 
     action = "Removed" if remove else "Configured"
     typer.echo(f"{action} Nauro for project '{project_name}':\n")
-    for line in claude_code_surfaces(
+    for outcome in claude_code_surfaces(
         project_repos,
         remove=remove,
         with_hooks=with_hooks,
@@ -66,7 +67,8 @@ def claude_code(
         store_path=_store_path,
         warn=lambda msg: typer.echo(msg, err=True),
     ):
-        typer.echo(line)
+        for line in render(outcome):
+            typer.echo(line)
 
     if not remove:
         typer.echo(
@@ -103,8 +105,9 @@ def cursor(
 
     action = "Removed" if remove else "Configured"
     typer.echo(f"{action} Nauro (Cursor) for project '{project_name}':\n")
-    for line in cursor_surfaces(project_repos, remove=remove):
-        typer.echo(line)
+    for outcome in cursor_surfaces(project_repos, remove=remove):
+        for line in render(outcome):
+            typer.echo(line)
 
     if not remove:
         typer.echo("\nNext: open this repo in Cursor and start a chat — Nauro MCP will connect.")
@@ -135,8 +138,9 @@ def codex(
     ),
 ) -> None:
     """Configure Codex CLI to use Nauro (writes '~/.codex/config.toml')."""
-    for line in codex_surfaces(remove=remove, with_hooks=with_hooks):
-        typer.echo(line)
+    for outcome in codex_surfaces(remove=remove, with_hooks=with_hooks):
+        for line in render(outcome):
+            typer.echo(line)
 
     if not remove:
         typer.echo("\nNext: run a Codex session — it reads ~/.codex/config.toml on start.")
@@ -221,7 +225,7 @@ def all_(
     project_repos = [Path(rp) for rp in entry["repo_paths"]]
     action = "Removed" if remove else "Configured"
     typer.echo(f"{action} Nauro for project '{project_name}' across all surfaces:\n")
-    for line in setup_all_surfaces(
+    for outcome in setup_all_surfaces(
         project_repos,
         remove=remove,
         current_project_key=_store_path.name,
@@ -231,7 +235,8 @@ def all_(
         with_skills=with_skills,
         with_hooks=with_hooks,
     ):
-        typer.echo(line)
+        for line in render(outcome):
+            typer.echo(line)
 
     if not remove and with_skills and not with_subagents:
         typer.echo(f"\n{SHIP_TASK_NEEDS_SUBAGENTS_NOTICE}")

--- a/packages/nauro/src/nauro/cli/integrations/orchestrator.py
+++ b/packages/nauro/src/nauro/cli/integrations/orchestrator.py
@@ -12,6 +12,7 @@ from nauro.cli.integrations.codex_config import _configure_codex, _default_codex
 from nauro.cli.integrations.codex_hooks import _nearest_codex_hooks_repo, materialize_hooks_codex
 from nauro.cli.integrations.json_mcp import _configure_cursor_for_repo, _configure_mcp
 from nauro.cli.integrations.legacy import _remove_claude_md
+from nauro.cli.integrations.outcomes import ArtifactOutcome, RawLine
 from nauro.cli.integrations.skills import (
     materialize_skills_claude_code,
     materialize_skills_codex,
@@ -33,7 +34,7 @@ def claude_code_surfaces(
     store_name: str,
     store_path: Path,
     warn: Callable[[str], None],
-) -> list[str]:
+) -> list[ArtifactOutcome]:
     """Wire Claude Code MCP + hooks per repo and regenerate AGENTS.md.
 
     Returns the flat status lines the command echoes to stdout, in order:
@@ -65,42 +66,43 @@ def claude_code_surfaces(
         if pruned:
             mcp_results.append(pruned)
 
-    lines: list[str] = list(mcp_results)
+    outcomes: list[ArtifactOutcome] = [RawLine(result) for result in mcp_results]
 
     if hook_results:
-        lines.append("\nHooks:")
-        lines.extend(hook_results)
+        outcomes.append(RawLine("\nHooks:"))
+        outcomes.extend(RawLine(result) for result in hook_results)
 
     if legacy_results:
-        lines.append("\nLegacy cleanup:")
-        lines.extend(legacy_results)
+        outcomes.append(RawLine("\nLegacy cleanup:"))
+        outcomes.extend(RawLine(result) for result in legacy_results)
 
     if not remove:
         # Regenerate AGENTS.md so context is fresh from the start. The store
         # dir name is the v2 id (or v1 name) used by the registry-aware lookup.
         # warn_then_regen surfaces missing-repo, symlink-refusal, and
-        # git-hygiene warnings through the warn callback.
+        # git-hygiene warnings through the warn callback (stderr), never the
+        # returned outcomes.
         updated_repos = warn_then_regen(store_name, store_path, warn=warn)
         if updated_repos:
-            lines.append("\nAGENTS.md:")
+            outcomes.append(RawLine("\nAGENTS.md:"))
             for repo_path in updated_repos:
-                lines.append(f"  {repo_path}: regenerated AGENTS.md")
+                outcomes.append(RawLine(f"  {repo_path}: regenerated AGENTS.md"))
 
-    return lines
+    return outcomes
 
 
-def cursor_surfaces(project_repos: list[Path], *, remove: bool) -> list[str]:
+def cursor_surfaces(project_repos: list[Path], *, remove: bool) -> list[ArtifactOutcome]:
     """Wire Cursor MCP per repo. Returns the per-repo status lines."""
-    lines: list[str] = []
+    outcomes: list[ArtifactOutcome] = []
     for repo_path in project_repos:
         if not repo_path.is_dir():
-            lines.append(f"  {repo_path}: repo path missing, skipped")
+            outcomes.append(RawLine(f"  {repo_path}: repo path missing, skipped"))
             continue
-        lines.append(_configure_cursor_for_repo(repo_path, remove=remove))
-    return lines
+        outcomes.append(RawLine(_configure_cursor_for_repo(repo_path, remove=remove)))
+    return outcomes
 
 
-def codex_surfaces(*, remove: bool, with_hooks: bool) -> list[str]:
+def codex_surfaces(*, remove: bool, with_hooks: bool) -> list[ArtifactOutcome]:
     """Wire the user-global Codex MCP entry and per-repo Codex hooks.
 
     Resolves the project internally (Codex config is user-global and shared by
@@ -114,7 +116,7 @@ def codex_surfaces(*, remove: bool, with_hooks: bool) -> list[str]:
         entry = _resolve_project_entry(project_name, store_path.name)
         hook_repos = [Path(repo_path) for repo_path in entry["repo_paths"]]
 
-    lines: list[str] = []
+    outcomes: list[ArtifactOutcome] = []
 
     # Standalone codex wiring is user-global and shared by every registered
     # project, so this teardown preserves the entry while any project remains
@@ -126,13 +128,15 @@ def codex_surfaces(*, remove: bool, with_hooks: bool) -> list[str]:
         count_phrase = (
             "1 nauro project" if registered_count == 1 else f"{registered_count} nauro projects"
         )
-        lines.append(
-            f"Codex: preserved nauro entry in {config_path} ({count_phrase} registered; "
-            "run 'nauro setup all --remove' on the last project to clear this "
-            "user-global entry)"
+        outcomes.append(
+            RawLine(
+                f"Codex: preserved nauro entry in {config_path} ({count_phrase} registered; "
+                "run 'nauro setup all --remove' on the last project to clear this "
+                "user-global entry)"
+            )
         )
     else:
-        lines.append(_configure_codex(remove=remove))
+        outcomes.append(RawLine(_configure_codex(remove=remove)))
 
     hook_cleanup_unresolved = False
     if remove:
@@ -151,23 +155,25 @@ def codex_surfaces(*, remove: bool, with_hooks: bool) -> list[str]:
             hook_cleanup_unresolved = True
 
     if with_hooks or remove:
-        lines.append("\nHooks:")
+        outcomes.append(RawLine("\nHooks:"))
         if hook_cleanup_unresolved:
-            lines.append(
-                "  Project-scoped Codex hooks were not removed because no Nauro "
-                "project resolves from this directory. Run this command from each "
-                "wired repo to remove them."
+            outcomes.append(
+                RawLine(
+                    "  Project-scoped Codex hooks were not removed because no Nauro "
+                    "project resolves from this directory. Run this command from each "
+                    "wired repo to remove them."
+                )
             )
         for repo_path in hook_repos:
             if not repo_path.is_dir():
-                lines.append(f"  {repo_path}: repo path missing, skipped")
+                outcomes.append(RawLine(f"  {repo_path}: repo path missing, skipped"))
                 continue
             try:
-                lines.append(materialize_hooks_codex(repo_path, remove=remove))
+                outcomes.append(RawLine(materialize_hooks_codex(repo_path, remove=remove)))
             except Exception as exc:
-                lines.append(f"  {repo_path}: Codex hook wiring error - {exc}")
+                outcomes.append(RawLine(f"  {repo_path}: Codex hook wiring error - {exc}"))
 
-    return lines
+    return outcomes
 
 
 def _all_claude_code_lines(
@@ -179,43 +185,45 @@ def _all_claude_code_lines(
     force_overwrite: bool,
     with_skills: bool,
     with_hooks: bool,
-) -> list[str]:
+) -> list[ArtifactOutcome]:
     """Claude Code surface lines for ``setup_all_surfaces``.
 
     MCP per-repo (direct ``.mcp.json`` write), user-scope prune on add, skills
     global, optional subagents, then the per-repo advisory hook.
     """
-    lines: list[str] = []
+    outcomes: list[ArtifactOutcome] = []
     for repo in project_repos:
         if not repo.is_dir():
-            lines.append(f"  {repo}: repo path missing, skipped")
+            outcomes.append(RawLine(f"  {repo}: repo path missing, skipped"))
             continue
         try:
-            lines.append(_configure_mcp(repo, remove=remove))
+            outcomes.append(RawLine(_configure_mcp(repo, remove=remove)))
         except Exception as exc:
-            lines.append(f"Claude Code MCP ({repo}): error - {exc}")
+            outcomes.append(RawLine(f"Claude Code MCP ({repo}): error - {exc}"))
     if not remove:
         try:
             pruned = _prune_redundant_user_scope_mcp()
             if pruned:
-                lines.append(pruned)
+                outcomes.append(RawLine(pruned))
         except Exception as exc:  # never let cleanup break wiring
-            lines.append(f"Claude Code MCP (user-scope cleanup): error - {exc}")
+            outcomes.append(RawLine(f"Claude Code MCP (user-scope cleanup): error - {exc}"))
     try:
-        lines.extend(
-            materialize_skills_claude_code(
+        outcomes.extend(
+            RawLine(line)
+            for line in materialize_skills_claude_code(
                 remove=remove,
                 clear_user_scope=clear_user_scope,
                 with_skills=with_skills,
             )
         )
     except Exception as exc:
-        lines.append(f"Claude Code skills: error - {exc}")
+        outcomes.append(RawLine(f"Claude Code skills: error - {exc}"))
 
     if with_subagents:
         try:
-            lines.extend(
-                materialize_agents(
+            outcomes.extend(
+                RawLine(line)
+                for line in materialize_agents(
                     "claude_code",
                     remove=remove,
                     force_overwrite=force_overwrite,
@@ -223,36 +231,41 @@ def _all_claude_code_lines(
                 )
             )
         except Exception as exc:
-            lines.append(f"Claude Code agents: error - {exc}")
+            outcomes.append(RawLine(f"Claude Code agents: error - {exc}"))
 
     if with_hooks or remove:
         for repo in project_repos:
             if not repo.is_dir():
                 continue
             try:
-                lines.append(materialize_hooks_claude_code(repo, remove=remove))
+                outcomes.append(RawLine(materialize_hooks_claude_code(repo, remove=remove)))
             except Exception as exc:
-                lines.append(f"Claude Code hook ({repo}): error - {exc}")
-    return lines
+                outcomes.append(RawLine(f"Claude Code hook ({repo}): error - {exc}"))
+    return outcomes
 
 
-def _all_cursor_lines(project_repos: list[Path], *, remove: bool, with_skills: bool) -> list[str]:
+def _all_cursor_lines(
+    project_repos: list[Path], *, remove: bool, with_skills: bool
+) -> list[ArtifactOutcome]:
     """Cursor surface lines for ``setup_all_surfaces``: MCP per repo + skills per repo."""
-    lines: list[str] = []
+    outcomes: list[ArtifactOutcome] = []
     for repo in project_repos:
         if not repo.is_dir():
             continue
         try:
-            lines.append(_configure_cursor_for_repo(repo, remove=remove))
+            outcomes.append(RawLine(_configure_cursor_for_repo(repo, remove=remove)))
         except Exception as exc:
-            lines.append(f"Cursor MCP ({repo}): error - {exc}")
+            outcomes.append(RawLine(f"Cursor MCP ({repo}): error - {exc}"))
         try:
-            lines.extend(
-                materialize_skills_cursor_for_repo(repo, remove=remove, with_skills=with_skills)
+            outcomes.extend(
+                RawLine(line)
+                for line in materialize_skills_cursor_for_repo(
+                    repo, remove=remove, with_skills=with_skills
+                )
             )
         except Exception as exc:
-            lines.append(f"Cursor skills ({repo}): error - {exc}")
-    return lines
+            outcomes.append(RawLine(f"Cursor skills ({repo}): error - {exc}"))
+    return outcomes
 
 
 def _all_codex_lines(
@@ -262,33 +275,34 @@ def _all_codex_lines(
     clear_user_scope: bool,
     with_skills: bool,
     with_hooks: bool,
-) -> list[str]:
+) -> list[ArtifactOutcome]:
     """Codex surface lines for ``setup_all_surfaces``: MCP global, skills global, optional hooks."""
-    lines: list[str] = []
+    outcomes: list[ArtifactOutcome] = []
     try:
-        lines.append(_configure_codex(remove=remove, clear_user_scope=clear_user_scope))
+        outcomes.append(RawLine(_configure_codex(remove=remove, clear_user_scope=clear_user_scope)))
     except Exception as exc:
-        lines.append(f"Codex MCP: error - {exc}")
+        outcomes.append(RawLine(f"Codex MCP: error - {exc}"))
     try:
-        lines.extend(
-            materialize_skills_codex(
+        outcomes.extend(
+            RawLine(line)
+            for line in materialize_skills_codex(
                 remove=remove,
                 clear_user_scope=clear_user_scope,
                 with_skills=with_skills,
             )
         )
     except Exception as exc:
-        lines.append(f"Codex skills: error - {exc}")
+        outcomes.append(RawLine(f"Codex skills: error - {exc}"))
 
     if with_hooks or remove:
         for repo in project_repos:
             if not repo.is_dir():
                 continue
             try:
-                lines.append(materialize_hooks_codex(repo, remove=remove))
+                outcomes.append(RawLine(materialize_hooks_codex(repo, remove=remove)))
             except Exception as exc:
-                lines.append(f"Codex hooks ({repo}): error - {exc}")
-    return lines
+                outcomes.append(RawLine(f"Codex hooks ({repo}): error - {exc}"))
+    return outcomes
 
 
 def _all_agents_md_lines(
@@ -297,7 +311,7 @@ def _all_agents_md_lines(
     remove: bool,
     current_project_key: str | None,
     store_path: Path | None,
-) -> list[str]:
+) -> list[ArtifactOutcome]:
     """AGENTS.md regen (add) and teardown (remove) lines for ``setup_all_surfaces``.
 
     On the add path ``warn_then_regen`` routes missing-repo, symlink-refusal,
@@ -305,18 +319,22 @@ def _all_agents_md_lines(
     helper's own returned list so those warnings surface on stdout in the same
     position the inline code produced them.
     """
-    lines: list[str] = []
+    outcomes: list[ArtifactOutcome] = []
     # Regenerate AGENTS.md once so context is fresh from the start on every
     # entry point that wires surfaces. Guarded on the add path and on having a
     # store to read from. warn_then_regen routes missing-repo, symlink-refusal,
     # and git-hygiene warnings into the status lines.
     if not remove and current_project_key is not None and store_path is not None:
         try:
-            updated = warn_then_regen(current_project_key, store_path, warn=lines.append)
+            updated = warn_then_regen(
+                current_project_key,
+                store_path,
+                warn=lambda message: outcomes.append(RawLine(message)),
+            )
             for repo_path in updated:
-                lines.append(f"  {repo_path}: regenerated AGENTS.md")
+                outcomes.append(RawLine(f"  {repo_path}: regenerated AGENTS.md"))
         except Exception as exc:
-            lines.append(f"AGENTS.md regeneration: error - {exc}")
+            outcomes.append(RawLine(f"AGENTS.md regeneration: error - {exc}"))
 
     # Mirror of the regen above: strip the generated AGENTS.md on teardown so a
     # removed integration leaves no orphaned context file. User content in a
@@ -328,10 +346,10 @@ def _all_agents_md_lines(
             try:
                 removed_line = remove_generated_agents_md(repo)
                 if removed_line:
-                    lines.append(removed_line)
+                    outcomes.append(RawLine(removed_line))
             except Exception as exc:
-                lines.append(f"AGENTS.md removal ({repo}) failed: {exc}")
-    return lines
+                outcomes.append(RawLine(f"AGENTS.md removal ({repo}) failed: {exc}"))
+    return outcomes
 
 
 def setup_all_surfaces(
@@ -345,7 +363,7 @@ def setup_all_surfaces(
     with_skills: bool = False,
     with_hooks: bool = False,
     clear_user_scope_override: bool | None = None,
-) -> list[str]:
+) -> list[ArtifactOutcome]:
     """Wire MCP and materialize skills across Claude Code, Cursor, Codex.
 
     Continues across per-handler errors so partial coverage still reports
@@ -396,8 +414,8 @@ def setup_all_surfaces(
     else:
         clear_user_scope = _user_scope_safe_to_clear(current_project_key) if remove else True
 
-    lines: list[str] = []
-    lines.extend(
+    outcomes: list[ArtifactOutcome] = []
+    outcomes.extend(
         _all_claude_code_lines(
             project_repos,
             remove=remove,
@@ -408,8 +426,8 @@ def setup_all_surfaces(
             with_hooks=with_hooks,
         )
     )
-    lines.extend(_all_cursor_lines(project_repos, remove=remove, with_skills=with_skills))
-    lines.extend(
+    outcomes.extend(_all_cursor_lines(project_repos, remove=remove, with_skills=with_skills))
+    outcomes.extend(
         _all_codex_lines(
             project_repos,
             remove=remove,
@@ -418,7 +436,7 @@ def setup_all_surfaces(
             with_hooks=with_hooks,
         )
     )
-    lines.extend(
+    outcomes.extend(
         _all_agents_md_lines(
             project_repos,
             remove=remove,
@@ -426,7 +444,7 @@ def setup_all_surfaces(
             store_path=store_path,
         )
     )
-    return lines
+    return outcomes
 
 
 SHIP_TASK_NEEDS_SUBAGENTS_NOTICE = (

--- a/packages/nauro/src/nauro/cli/integrations/outcomes.py
+++ b/packages/nauro/src/nauro/cli/integrations/outcomes.py
@@ -1,0 +1,17 @@
+"""Typed outcomes the setup codecs return for the render layer to emit."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RawLine:
+    """A pre-rendered advisory or status string carried verbatim."""
+
+    text: str
+
+
+# Single-member for now; later increments widen this into a union as each
+# codec gains its own structured outcome type.
+ArtifactOutcome = RawLine

--- a/packages/nauro/src/nauro/cli/integrations/render.py
+++ b/packages/nauro/src/nauro/cli/integrations/render.py
@@ -1,0 +1,12 @@
+"""Render typed setup outcomes back into the status lines commands echo."""
+
+from __future__ import annotations
+
+from nauro.cli.integrations.outcomes import ArtifactOutcome, RawLine
+
+
+def render(outcome: ArtifactOutcome) -> list[str]:
+    """Flatten one outcome into the status lines a command echoes."""
+    if isinstance(outcome, RawLine):
+        return [outcome.text]
+    raise TypeError(f"unrenderable outcome: {outcome!r}")

--- a/packages/nauro/tests/test_integration_outcomes.py
+++ b/packages/nauro/tests/test_integration_outcomes.py
@@ -1,0 +1,20 @@
+"""Typed-outcome pipeline scaffolding: RawLine carrier and render dispatch."""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from nauro.cli.integrations.outcomes import RawLine
+from nauro.cli.integrations.render import render
+
+
+def test_render_rawline_returns_verbatim_text():
+    assert render(RawLine("x")) == ["x"]
+
+
+def test_rawline_is_frozen():
+    line = RawLine("x")
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        line.text = "y"

--- a/packages/nauro/tests/test_setup_hooks.py
+++ b/packages/nauro/tests/test_setup_hooks.py
@@ -681,7 +681,7 @@ def test_setup_codex_remove_cleans_orphaned_repo_hooks(tmp_path: Path, monkeypat
 def test_setup_all_with_hooks_wires_claude_code_and_codex(tmp_path: Path):
     repo, _store = _make_project(tmp_path)
     lines = setup_all_surfaces([repo], with_hooks=True)
-    assert any("nauro hook" in line for line in lines)
+    assert any("nauro hook" in line.text for line in lines)
 
     settings = json.loads(_settings(repo).read_text())
     assert len(_nauro_entries(settings)) == 1
@@ -716,7 +716,7 @@ def test_setup_all_hook_failure_does_not_abort(tmp_path: Path, monkeypatch):
 
     # Must not raise; the rest of setup still produces its lines.
     lines = setup_all_surfaces([repo], with_hooks=True)
-    assert any("hook" in line and "error" in line for line in lines)
+    assert any("hook" in line.text and "error" in line.text for line in lines)
     # MCP wiring still happened despite the hook failure.
     assert (repo / ".mcp.json").is_file()
 


### PR DESCRIPTION
## Why

The setup orchestrator returned bare status strings that the command layer echoed directly, leaving no seam to attach structured, per-codec results to. This lands the end-to-end typed pipeline that later increments build on, as a behavior-neutral first step so the wiring can be reviewed in isolation before any codec starts emitting structured outcomes.

## What changed

- New `cli/integrations/outcomes.py`: a frozen `RawLine` dataclass carrying a pre-rendered status string verbatim, plus an `ArtifactOutcome` alias (a single member for now, widened into a per-codec union by later increments).
- New `cli/integrations/render.py`: `render(outcome) -> list[str]`, a dispatch that flattens `RawLine` back into its status line. It imports no codec and no typer, so it stays a pure boundary between orchestration and the command layer.
- The four orchestrator entry points and four `_all_*` helpers now return `list[ArtifactOutcome]`. Every string previously appended is wrapped in `RawLine(...)`. The stdout-routed AGENTS.md warnings keep their position by wrapping the warn callback as `RawLine`; the Claude Code stderr warn callback is not part of the returned list and is left untouched.
- The setup and adopt commands render each outcome before echoing: `for outcome in surface_fn(...): for line in render(outcome): typer.echo(line)`.

## Test plan

- The 37-test setup characterization oracle (`test_setup_characterization.py` + `test_onboarding_inventories.py`) passes unmodified, run twice for determinism. `render(RawLine(x))` returns `[x]`, so stdout, stderr, exit codes, and filesystem trees are byte-identical. This is the neutrality proof.
- Full nauro suite: 1846 passed, 10 skipped (adds two tests for the new carrier and render dispatch). nauro-core: 1073 passed.
- `ruff check` and `ruff format --check` clean.
- No codec module is modified; two direct-call unit-test assertions on the orchestrator return were updated to read `.text` off the returned outcome.
