### PR TITLE
Convert setup codecs to typed outcomes and consolidate status readers

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/status.py
+++ b/packages/nauro/src/nauro/cli/commands/status.py
@@ -1,6 +1,5 @@
 """nauro status — Show capability table for the current project."""
 
-import json
 import os
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -15,6 +14,7 @@ from nauro.cli._codex_hooks import (
     _inspect_codex_hooks,
     _parse_codex_hooks,
 )
+from nauro.cli.integrations import codex_config, json_mcp
 from nauro.cli.utils import resolve_target_project
 
 
@@ -63,67 +63,6 @@ def _count_remote_decisions(project_id: str) -> int | None:
         and entry.get("path", "").startswith("decisions/")
         and entry.get("path", "").endswith(".md")
     )
-
-
-def _codex_config_path() -> Path:
-    """User-global Codex config path (same location setup.py writes)."""
-    return Path.home() / ".codex" / "config.toml"
-
-
-def _repo_recorded_commands(repo: Path) -> list[str | None]:
-    """Recorded nauro MCP commands in this repo's configs, one entry per wired config.
-
-    Single read of ``.mcp.json`` and ``.cursor/mcp.json`` each — presence
-    ("the repo is wired" iff the list is non-empty) and the recorded command
-    both derive from the same parse. A wired config whose nauro entry carries a
-    missing or empty command contributes ``None``: it still counts as wired,
-    but there is nothing to probe. Read-only and soft-failing: a missing,
-    unreadable, or malformed config contributes nothing — status must never
-    crash on someone else's config file.
-    """
-    commands: list[str | None] = []
-    for rel in (".mcp.json", ".cursor/mcp.json"):
-        try:
-            config = json.loads((repo / rel).read_text(encoding="utf-8"))
-        except Exception:
-            continue
-        if not isinstance(config, dict):
-            continue
-        servers = config.get("mcpServers")
-        if not isinstance(servers, dict) or "nauro" not in servers:
-            continue
-        entry = servers["nauro"]
-        cmd = entry.get("command") if isinstance(entry, dict) else None
-        commands.append(cmd if isinstance(cmd, str) and cmd else None)
-    return commands
-
-
-def _codex_recorded_command() -> tuple[bool, str | None]:
-    """Return ``(wired, recorded command)`` for the user-global Codex config.
-
-    Single read of ``~/.codex/config.toml``, same parse approach as setup.py.
-    ``(True, None)`` means a nauro entry exists but records no usable command —
-    wired for presence, nothing to probe. Any read or parse failure counts as
-    not wired.
-    """
-    import sys
-
-    if sys.version_info >= (3, 11):
-        import tomllib
-    else:
-        import tomli as tomllib
-
-    try:
-        with _codex_config_path().open("rb") as f:
-            config = tomllib.load(f)
-    except Exception:
-        return (False, None)
-    servers = config.get("mcp_servers")
-    if not isinstance(servers, dict) or "nauro" not in servers:
-        return (False, None)
-    entry = servers["nauro"]
-    cmd = entry.get("command") if isinstance(entry, dict) else None
-    return (True, cmd if isinstance(cmd, str) and cmd else None)
 
 
 def _probe_distinct_commands(
@@ -194,11 +133,11 @@ class _WiringProbeResults:
 
 def _collect_wiring(repo_paths: list[Path]) -> _WiringSnapshot:
     try:
-        repo_commands = [_repo_recorded_commands(repo) for repo in repo_paths]
+        repo_commands = [json_mcp.recorded_mcp_commands(repo) for repo in repo_paths]
     except Exception:
         repo_commands = []
     try:
-        codex_global, codex_command = _codex_recorded_command()
+        codex_global, codex_command = codex_config.recorded_codex_command()
     except Exception:
         codex_global, codex_command = False, None
     try:

--- a/packages/nauro/src/nauro/cli/integrations/_json_config.py
+++ b/packages/nauro/src/nauro/cli/integrations/_json_config.py
@@ -1,0 +1,21 @@
+"""Shared atomic writer for the JSON config sinks in ``nauro setup``.
+
+``.mcp.json``, ``.cursor/mcp.json``, ``.claude/settings.json``, and the
+user-scope ``~/.claude.json`` prune all serialize the same way: two-space
+indent with a trailing newline, written atomically. One writer keeps that
+serialization in a single place. Codex config (tomlkit, ``newline="\\n"``)
+and Codex hooks (``_format_codex_hooks``) have their own serializers and are
+deliberately not routed through here.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from nauro.store._atomic import atomic_write_text
+
+
+def write_json_config(path: Path, config: object) -> None:
+    """Serialize ``config`` as indented JSON and write it atomically."""
+    atomic_write_text(path, json.dumps(config, indent=2) + "\n")

--- a/packages/nauro/src/nauro/cli/integrations/agents.py
+++ b/packages/nauro/src/nauro/cli/integrations/agents.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from nauro.cli.integrations.outcomes import AgentKind, AgentOutcome
 from nauro.store.write_safety import find_file_symlink
 
 
@@ -30,7 +31,7 @@ def materialize_agents(
     remove: bool,
     force_overwrite: bool = False,
     clear_user_scope: bool = True,
-) -> list[str]:
+) -> list[AgentOutcome]:
     """Install or remove the bundled ``nauro-*`` subagent files.
 
     Currently only the Claude Code surface is implemented. Cursor and Codex
@@ -63,20 +64,20 @@ def materialize_agents(
             # stops raising, the stub message goes away naturally.
             render_agent(surface, AGENT_NAMES[0])
         except NotImplementedError:
-            return [f"  skipped ~/.{surface} agents (not yet implemented)"]
+            return [AgentOutcome(AgentKind.SURFACE_NOT_IMPLEMENTED, surface=surface)]
         except ValueError as exc:
-            return [f"  skipped agents on surface {surface!r}: {exc}"]
+            return [AgentOutcome(AgentKind.SURFACE_INVALID, surface=surface, detail=str(exc))]
 
     base = _claude_agent_dir()
     if remove and not clear_user_scope:
-        return ["  preserved ~/.claude/agents/nauro-* (other nauro projects still registered)"]
+        return [AgentOutcome(AgentKind.PRESERVED)]
 
-    results: list[str] = []
+    results: list[AgentOutcome] = []
     for name in AGENT_NAMES:
         target = base / f"{name}.md"
         refusal = find_file_symlink(target)
         if refusal is not None:
-            results.append(f"  {refusal.message}")
+            results.append(AgentOutcome(AgentKind.REFUSED_SYMLINK, refusal=refusal))
             continue
         bundled = render_agent("claude_code", name)
         if remove:
@@ -86,8 +87,8 @@ def materialize_agents(
     return results
 
 
-def _install_bundled_agent(target: Path, bundled: str, *, force_overwrite: bool) -> str:
-    """Install or refresh one bundled agent file, returning its status line.
+def _install_bundled_agent(target: Path, bundled: str, *, force_overwrite: bool) -> AgentOutcome:
+    """Install or refresh one bundled agent file, returning its outcome.
 
     Absent → write the bundled body. Byte-equal → no-op. ``force_overwrite`` →
     overwrite in place. Otherwise the differing file is refreshed and its prior
@@ -97,32 +98,32 @@ def _install_bundled_agent(target: Path, bundled: str, *, force_overwrite: bool)
     if target.is_file():
         current = target.read_text(encoding="utf-8")
         if current == bundled:
-            return f"  unchanged {target}"
+            return AgentOutcome(AgentKind.UNCHANGED, target=target)
         if force_overwrite:
             target.write_text(bundled, encoding="utf-8")
-            return f"  overwrote {target}"
+            return AgentOutcome(AgentKind.OVERWROTE, target=target)
         backup = target.parent / (target.name + ".bak")
         backup_refusal = find_file_symlink(backup)
         if backup_refusal is not None:
-            return f"  {backup_refusal.message}"
+            return AgentOutcome(AgentKind.REFUSED_SYMLINK, refusal=backup_refusal)
         backup.write_text(current, encoding="utf-8")
         target.write_text(bundled, encoding="utf-8")
-        return f"  updated {target} (previous saved to {backup.name})"
+        return AgentOutcome(AgentKind.UPDATED, target=target, backup_name=backup.name)
     target.parent.mkdir(parents=True, exist_ok=True)
     target.write_text(bundled, encoding="utf-8")
-    return f"  installed {target}"
+    return AgentOutcome(AgentKind.INSTALLED, target=target)
 
 
-def _remove_bundled_agent(target: Path, bundled: str) -> str:
-    """Remove one bundled agent file, returning its status line.
+def _remove_bundled_agent(target: Path, bundled: str) -> AgentOutcome:
+    """Remove one bundled agent file, returning its outcome.
 
     Absent → skip note. Byte-equal to the bundle → unlink. Differs → preserve
     (locally modified).
     """
     if not target.is_file():
-        return f"  no agent at {target}"
+        return AgentOutcome(AgentKind.ABSENT, target=target)
     current = target.read_text(encoding="utf-8")
     if current == bundled:
         target.unlink()
-        return f"  removed {target}"
-    return f"  preserved {target} (locally modified)"
+        return AgentOutcome(AgentKind.REMOVED, target=target)
+    return AgentOutcome(AgentKind.PRESERVED_MODIFIED, target=target)

--- a/packages/nauro/src/nauro/cli/integrations/claude_hooks.py
+++ b/packages/nauro/src/nauro/cli/integrations/claude_hooks.py
@@ -36,33 +36,43 @@ HOOK_TIMEOUT_SECONDS = 10
 _HOOK_COMMAND_MARKER = HOOK_SUBCOMMAND
 
 
-class HookEntry(BaseModel):
-    """One hook command entry. Only Nauro-owned keys are typed; user keys survive."""
+class HooksMap(BaseModel):
+    """The event-keyed hook map inside ``.claude/settings.json``.
+
+    Only ``UserPromptSubmit`` — the single event Nauro installs into — is
+    validated, and only far enough to confirm it is a JSON array when present.
+    Its entries stay opaque (``list[object]``) and are scanned leniently at use.
+    Every sibling event is opaque extra content: Nauro does not own it, so it is
+    neither validated nor rewritten. Bound to the exact ``UserPromptSubmit``
+    alias only (no populate_by_name), so an unrelated snake_case key is never
+    mistaken for the event.
+
+    The field carries a default list rather than allowing ``None``: an absent
+    key falls back to the default (nothing to scan), while a *present* key —
+    including an explicit JSON ``null`` — is validated against ``list[object]``
+    and a non-array value raises, routing to the EVENT_NOT_ARRAY skip. That
+    distinction is why the type is not ``| None``: ``None`` would swallow an
+    explicit null and let the add path append to it and crash.
+    """
 
     model_config = ConfigDict(extra="allow")
 
-    type: str | None = None
-    command: str | None = None
-    timeout: int | None = None
-
-
-class HookMatcher(BaseModel):
-    """One matcher block: an optional ``hooks`` list plus any user metadata."""
-
-    model_config = ConfigDict(extra="allow")
-
-    hooks: list[HookEntry] | None = None
+    user_prompt_submit: list[object] = Field(default_factory=list, alias=HOOK_EVENT_NAME)
 
 
 class ClaudeHookSettings(BaseModel):
-    """Boundary view of ``.claude/settings.json`` — an event-keyed hook map."""
+    """Boundary view of ``.claude/settings.json``.
+
+    Only what Nauro touches is validated: the ``hooks`` container is a JSON
+    object (an explicit null or scalar is routed to the HOOKS_NOT_OBJECT skip by
+    :func:`_parse_hook_settings` before this model runs), and its
+    ``UserPromptSubmit`` value is a JSON array when present. See
+    :class:`HooksMap`.
+    """
 
     model_config = ConfigDict(extra="allow")
 
-    # Non-optional: a missing key defaults to an empty map, while an explicit
-    # JSON null or a scalar is a shape violation the boundary parser routes to
-    # the HOOKS_NOT_OBJECT skip rather than letting it crash a raw mutation.
-    hooks: dict[str, list[HookMatcher]] = Field(default_factory=dict)
+    hooks: HooksMap = Field(default_factory=HooksMap)
 
 
 class HookShape(Enum):
@@ -147,12 +157,19 @@ def _is_nauro_hook(entry: object) -> bool:
 
 
 def _has_nauro_hook(settings: ClaudeHookSettings) -> bool:
-    event_matchers = settings.hooks.get(HOOK_EVENT_NAME) or []
-    return any(
-        entry.command is not None and _HOOK_COMMAND_MARKER in entry.command
-        for matcher in event_matchers
-        for entry in (matcher.hooks or [])
-    )
+    """True iff a nauro-authored entry already sits in UserPromptSubmit.
+
+    Non-dict matchers and non-nauro entries are skipped, matching main's lenient
+    scan; the same :func:`_is_nauro_hook` predicate identifies the entry on the
+    remove path, so add and remove agree on what a nauro hook is.
+    """
+    for matcher in settings.hooks.user_prompt_submit:
+        if not isinstance(matcher, dict):
+            continue
+        for entry in matcher.get("hooks") or []:
+            if _is_nauro_hook(entry):
+                return True
+    return False
 
 
 def _add_hook_entry(settings_path: Path, raw: dict, repo: Path) -> ClaudeHookOutcome:
@@ -167,11 +184,8 @@ def _add_hook_entry(settings_path: Path, raw: dict, repo: Path) -> ClaudeHookOut
     if _has_nauro_hook(settings):
         return ClaudeHookOutcome(ClaudeHookKind.ALREADY_PRESENT, repo)
 
-    # Defense in depth: the parse above already rejects a non-object hooks
-    # container, but never mutate a present-but-non-dict one (an explicit null
-    # makes setdefault return it, so ``None.setdefault(...)`` would raise).
-    if "hooks" in raw and not isinstance(raw["hooks"], dict):
-        return ClaudeHookOutcome(ClaudeHookKind.HOOKS_NOT_OBJECT, repo)
+    # The parse guarantees hooks is absent or an object and UserPromptSubmit is
+    # absent or an array, so both setdefaults land on the right container type.
     raw.setdefault("hooks", {}).setdefault(HOOK_EVENT_NAME, []).append(
         {"hooks": [_nauro_hook_entry()]}
     )

--- a/packages/nauro/src/nauro/cli/integrations/claude_hooks.py
+++ b/packages/nauro/src/nauro/cli/integrations/claude_hooks.py
@@ -3,11 +3,15 @@
 from __future__ import annotations
 
 import json
+from enum import Enum, auto
 from pathlib import Path
 
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
 from nauro.cli.git_hygiene import public_surface_git_warnings
+from nauro.cli.integrations._json_config import write_json_config
+from nauro.cli.integrations.outcomes import ClaudeHookKind, ClaudeHookOutcome
 from nauro.cli.nauro_command import _find_nauro_command
-from nauro.store._atomic import atomic_write_text
 from nauro.store.write_safety import find_symlink
 
 # Claude Code reads hooks from project-scope ``<repo>/.claude/settings.json``.
@@ -32,11 +36,72 @@ HOOK_TIMEOUT_SECONDS = 10
 _HOOK_COMMAND_MARKER = HOOK_SUBCOMMAND
 
 
+class HookEntry(BaseModel):
+    """One hook command entry. Only Nauro-owned keys are typed; user keys survive."""
+
+    model_config = ConfigDict(extra="allow")
+
+    type: str | None = None
+    command: str | None = None
+    timeout: int | None = None
+
+
+class HookMatcher(BaseModel):
+    """One matcher block: an optional ``hooks`` list plus any user metadata."""
+
+    model_config = ConfigDict(extra="allow")
+
+    hooks: list[HookEntry] | None = None
+
+
+class ClaudeHookSettings(BaseModel):
+    """Boundary view of ``.claude/settings.json`` — an event-keyed hook map."""
+
+    model_config = ConfigDict(extra="allow")
+
+    # Non-optional: a missing key defaults to an empty map, while an explicit
+    # JSON null or a scalar is a shape violation the boundary parser routes to
+    # the HOOKS_NOT_OBJECT skip rather than letting it crash a raw mutation.
+    hooks: dict[str, list[HookMatcher]] = Field(default_factory=dict)
+
+
+class HookShape(Enum):
+    TOP_LEVEL_NOT_OBJECT = auto()
+    HOOKS_NOT_OBJECT = auto()
+    EVENT_NOT_ARRAY = auto()
+
+
+class HookShapeError(ValueError):
+    """The settings top level, ``hooks``, or an event value is off-shape."""
+
+    def __init__(self, shape: HookShape) -> None:
+        super().__init__(shape.name)
+        self.shape = shape
+
+
+def _parse_hook_settings(raw: object) -> ClaudeHookSettings:
+    """Validate ``raw`` into :class:`ClaudeHookSettings` or raise typed.
+
+    ``hooks`` being a non-object is reported distinctly from an event value
+    that is not an array, matching the two guards on the original add path.
+    """
+    if not isinstance(raw, dict):
+        raise HookShapeError(HookShape.TOP_LEVEL_NOT_OBJECT)
+    # A present ``hooks`` that is null or a scalar is HOOKS_NOT_OBJECT, distinct
+    # from a valid map whose event value is off-shape (EVENT_NOT_ARRAY below).
+    if "hooks" in raw and not isinstance(raw["hooks"], dict):
+        raise HookShapeError(HookShape.HOOKS_NOT_OBJECT)
+    try:
+        return ClaudeHookSettings.model_validate(raw)
+    except ValidationError as exc:
+        raise HookShapeError(HookShape.EVENT_NOT_ARRAY) from exc
+
+
 def _claude_settings_path(repo: Path) -> Path:
     return repo / ".claude" / "settings.json"
 
 
-def materialize_hooks_claude_code(repo: Path, *, remove: bool) -> str:
+def materialize_hooks_claude_code(repo: Path, *, remove: bool) -> ClaudeHookOutcome:
     """Add or remove the Nauro advisory hook in ``<repo>/.claude/settings.json``.
 
     Add path: idempotently append the hook entry to
@@ -44,27 +109,25 @@ def materialize_hooks_claude_code(repo: Path, *, remove: bool) -> str:
     already present. Remove path: strip only the nauro-authored entry (matched on
     the command containing ``nauro hook``), preserving any user-authored hooks
     and the surrounding structure.
-
-    Returns a one-line status string (indented for ``setup_all_surfaces``).
     """
     refusal = find_symlink(repo, ".claude/settings.json")
     if refusal is not None:
-        return f"  {repo}: {refusal.message}"
+        return ClaudeHookOutcome(ClaudeHookKind.REFUSED_SYMLINK, repo, refusal=refusal)
     settings_path = _claude_settings_path(repo)
 
     if settings_path.exists():
         try:
-            settings = json.loads(settings_path.read_text(encoding="utf-8"))
+            raw = json.loads(settings_path.read_text(encoding="utf-8"))
         except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-            return f"  {repo}: could not parse .claude/settings.json - {exc}"
-        if not isinstance(settings, dict):
-            return f"  {repo}: .claude/settings.json is not a JSON object, skipped"
+            return ClaudeHookOutcome(ClaudeHookKind.PARSE_ERROR, repo, detail=str(exc))
+        if not isinstance(raw, dict):
+            return ClaudeHookOutcome(ClaudeHookKind.NOT_JSON_OBJECT, repo)
     else:
-        settings = {}
+        raw = {}
 
     if remove:
-        return _remove_hook_entry(settings_path, settings, repo)
-    return _add_hook_entry(settings_path, settings, repo)
+        return _remove_hook_entry(settings_path, raw, repo)
+    return _add_hook_entry(settings_path, raw, repo)
 
 
 def _nauro_hook_entry() -> dict:
@@ -83,35 +146,47 @@ def _is_nauro_hook(entry: object) -> bool:
     )
 
 
-def _add_hook_entry(settings_path: Path, settings: dict, repo: Path) -> str:
-    hooks = settings.setdefault("hooks", {})
-    if not isinstance(hooks, dict):
-        return f"  {repo}: hooks key is not a JSON object, skipped"
-    event_matchers = hooks.setdefault(HOOK_EVENT_NAME, [])
-    if not isinstance(event_matchers, list):
-        return f"  {repo}: hooks.{HOOK_EVENT_NAME} is not a JSON array, skipped"
+def _has_nauro_hook(settings: ClaudeHookSettings) -> bool:
+    event_matchers = settings.hooks.get(HOOK_EVENT_NAME) or []
+    return any(
+        entry.command is not None and _HOOK_COMMAND_MARKER in entry.command
+        for matcher in event_matchers
+        for entry in (matcher.hooks or [])
+    )
+
+
+def _add_hook_entry(settings_path: Path, raw: dict, repo: Path) -> ClaudeHookOutcome:
+    try:
+        settings = _parse_hook_settings(raw)
+    except HookShapeError as exc:
+        if exc.shape is HookShape.HOOKS_NOT_OBJECT:
+            return ClaudeHookOutcome(ClaudeHookKind.HOOKS_NOT_OBJECT, repo)
+        return ClaudeHookOutcome(ClaudeHookKind.EVENT_NOT_ARRAY, repo)
 
     # Idempotent: if any matcher already carries a nauro hook, do nothing.
-    for matcher in event_matchers:
-        if isinstance(matcher, dict):
-            for entry in matcher.get("hooks", []):
-                if _is_nauro_hook(entry):
-                    return f"  {repo}: nauro hook already present in .claude/settings.json"
+    if _has_nauro_hook(settings):
+        return ClaudeHookOutcome(ClaudeHookKind.ALREADY_PRESENT, repo)
 
-    event_matchers.append({"hooks": [_nauro_hook_entry()]})
-    atomic_write_text(settings_path, json.dumps(settings, indent=2) + "\n")
-    lines = [f"  {repo}: wrote nauro hook to .claude/settings.json"]
-    lines.extend(public_surface_git_warnings(repo, ".claude/settings.json"))
-    return "\n".join(lines)
+    # Defense in depth: the parse above already rejects a non-object hooks
+    # container, but never mutate a present-but-non-dict one (an explicit null
+    # makes setdefault return it, so ``None.setdefault(...)`` would raise).
+    if "hooks" in raw and not isinstance(raw["hooks"], dict):
+        return ClaudeHookOutcome(ClaudeHookKind.HOOKS_NOT_OBJECT, repo)
+    raw.setdefault("hooks", {}).setdefault(HOOK_EVENT_NAME, []).append(
+        {"hooks": [_nauro_hook_entry()]}
+    )
+    write_json_config(settings_path, raw)
+    git_warnings = tuple(public_surface_git_warnings(repo, ".claude/settings.json"))
+    return ClaudeHookOutcome(ClaudeHookKind.WROTE, repo, git_warnings=git_warnings)
 
 
-def _remove_hook_entry(settings_path: Path, settings: dict, repo: Path) -> str:
-    hooks = settings.get("hooks")
+def _remove_hook_entry(settings_path: Path, raw: dict, repo: Path) -> ClaudeHookOutcome:
+    hooks = raw.get("hooks")
     if not isinstance(hooks, dict):
-        return f"  {repo}: no nauro hook to remove"
+        return ClaudeHookOutcome(ClaudeHookKind.NOTHING_TO_REMOVE, repo)
     event_matchers = hooks.get(HOOK_EVENT_NAME)
     if not isinstance(event_matchers, list):
-        return f"  {repo}: no nauro hook to remove"
+        return ClaudeHookOutcome(ClaudeHookKind.NOTHING_TO_REMOVE, repo)
 
     removed = False
     surviving_matchers = []
@@ -134,17 +209,17 @@ def _remove_hook_entry(settings_path: Path, settings: dict, repo: Path) -> str:
         # Drop only the installer-owned matcher shell with no user metadata.
 
     if not removed:
-        return f"  {repo}: no nauro hook to remove"
+        return ClaudeHookOutcome(ClaudeHookKind.NOTHING_TO_REMOVE, repo)
 
     if surviving_matchers:
         hooks[HOOK_EVENT_NAME] = surviving_matchers
     else:
         hooks.pop(HOOK_EVENT_NAME, None)
     if not hooks:
-        settings.pop("hooks", None)
+        raw.pop("hooks", None)
 
-    if settings:
-        atomic_write_text(settings_path, json.dumps(settings, indent=2) + "\n")
+    if raw:
+        write_json_config(settings_path, raw)
     else:
         settings_path.unlink()
-    return f"  {repo}: removed nauro hook from .claude/settings.json"
+    return ClaudeHookOutcome(ClaudeHookKind.REMOVED, repo)

--- a/packages/nauro/src/nauro/cli/integrations/claude_user_config.py
+++ b/packages/nauro/src/nauro/cli/integrations/claude_user_config.py
@@ -24,8 +24,8 @@ def _prune_redundant_user_scope_mcp() -> ClaudeUserConfigOutcome | None:
     Only the HTTP-transport entry is pruned — a user-scope ``nauro`` defined as
     a stdio command is the user's own choice and is left alone. Soft-fails
     (never raises) so a malformed or absent file cannot break wiring. Returns a
-    status line when something was removed or when the file is not valid
-    UTF-8, otherwise ``None``.
+    status line when something was removed, when the file is not valid UTF-8, or
+    when its top level is not a JSON object, otherwise ``None``.
     """
     config_path = Path.home() / ".claude.json"
     if not config_path.exists():
@@ -39,6 +39,11 @@ def _prune_redundant_user_scope_mcp() -> ClaudeUserConfigOutcome | None:
         return ClaudeUserConfigOutcome(ClaudeUserConfigKind.INVALID_UTF8)
     except (json.JSONDecodeError, OSError):
         return None
+    # A hand-mangled ~/.claude.json can parse to a non-object top level (an
+    # explicit null, an array, or a scalar); ``.get`` would raise on it. Skip
+    # gracefully, mirroring the shape guard the write codecs apply.
+    if not isinstance(config, dict):
+        return ClaudeUserConfigOutcome(ClaudeUserConfigKind.NOT_JSON_OBJECT)
     servers = config.get("mcpServers")
     if not isinstance(servers, dict):
         return None

--- a/packages/nauro/src/nauro/cli/integrations/claude_user_config.py
+++ b/packages/nauro/src/nauro/cli/integrations/claude_user_config.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from nauro.store._atomic import atomic_write_text
+from nauro.cli.integrations._json_config import write_json_config
+from nauro.cli.integrations.outcomes import ClaudeUserConfigKind, ClaudeUserConfigOutcome
 from nauro.store.write_safety import find_file_symlink
 
 
-def _prune_redundant_user_scope_mcp() -> str | None:
+def _prune_redundant_user_scope_mcp() -> ClaudeUserConfigOutcome | None:
     """Remove a redundant user-scope HTTP ``nauro`` entry from ``~/.claude.json``.
 
     On a machine with a local working copy, the stdio server is the canonical
@@ -31,11 +32,11 @@ def _prune_redundant_user_scope_mcp() -> str | None:
         return None
     refusal = find_file_symlink(config_path)
     if refusal is not None:
-        return f"  skipped user-scope prune: {refusal.message}"
+        return ClaudeUserConfigOutcome(ClaudeUserConfigKind.REFUSED_SYMLINK, refusal=refusal)
     try:
         config = json.loads(config_path.read_text(encoding="utf-8"))
     except UnicodeDecodeError:
-        return "  skipped user-scope prune: ~/.claude.json is not valid UTF-8"
+        return ClaudeUserConfigOutcome(ClaudeUserConfigKind.INVALID_UTF8)
     except (json.JSONDecodeError, OSError):
         return None
     servers = config.get("mcpServers")
@@ -50,10 +51,7 @@ def _prune_redundant_user_scope_mcp() -> str | None:
     if not servers:
         config.pop("mcpServers", None)
     try:
-        atomic_write_text(config_path, json.dumps(config, indent=2) + "\n")
+        write_json_config(config_path, config)
     except OSError:
         return None
-    return (
-        "  removed redundant user-scope HTTP nauro entry from ~/.claude.json "
-        "(project-scope stdio is canonical)"
-    )
+    return ClaudeUserConfigOutcome(ClaudeUserConfigKind.PRUNED)

--- a/packages/nauro/src/nauro/cli/integrations/codex_config.py
+++ b/packages/nauro/src/nauro/cli/integrations/codex_config.py
@@ -9,12 +9,13 @@ import tomlkit
 from tomlkit.exceptions import ParseError as TOMLParseError
 from tomlkit.items import InlineTable
 
+from nauro.cli.integrations.outcomes import CodexConfigKind, CodexConfigOutcome
 from nauro.cli.nauro_command import _find_nauro_command
 from nauro.store._atomic import atomic_write_text
 from nauro.store.write_safety import find_file_symlink
 
 
-def _default_codex_config_path() -> Path:
+def codex_config_path() -> Path:
     return Path.home() / ".codex" / "config.toml"
 
 
@@ -91,7 +92,7 @@ def _configure_codex(
     remove: bool,
     config_path: Path | None = None,
     clear_user_scope: bool = True,
-) -> str:
+) -> CodexConfigOutcome:
     """Add or remove the Nauro MCP entry in ``~/.codex/config.toml``.
 
     The file is hand-maintained user config, so edits go through tomlkit:
@@ -106,16 +107,14 @@ def _configure_codex(
     on it. Defaults to True so direct unit callers and the add path retain
     their previous behavior.
     """
-    config_path = config_path or _default_codex_config_path()
+    config_path = config_path or codex_config_path()
 
     if remove and not clear_user_scope:
-        return (
-            f"Codex: preserved nauro entry in {config_path} (other nauro projects still registered)"
-        )
+        return CodexConfigOutcome(CodexConfigKind.PRESERVED_OTHER_PROJECTS, config_path)
 
     refusal = find_file_symlink(config_path)
     if refusal is not None:
-        return f"Codex: {refusal.message}"
+        return CodexConfigOutcome(CodexConfigKind.REFUSED_SYMLINK, config_path, refusal=refusal)
 
     original: bytes | None
     if config_path.exists():
@@ -123,11 +122,13 @@ def _configure_codex(
         try:
             document = tomlkit.parse(original.decode("utf-8"))
         except UnicodeDecodeError:
-            return f"Codex: could not parse {config_path} - not valid UTF-8"
+            return CodexConfigOutcome(CodexConfigKind.PARSE_ERROR_UTF8, config_path)
         except TOMLParseError as exc:
-            return f"Codex: could not parse {config_path} - {exc}"
+            return CodexConfigOutcome(
+                CodexConfigKind.PARSE_ERROR_TOML, config_path, detail=str(exc)
+            )
     elif remove:
-        return f"Codex: no nauro entry to remove in {config_path}"
+        return CodexConfigOutcome(CodexConfigKind.NOTHING_TO_REMOVE, config_path)
     else:
         original = None
         document = tomlkit.document()
@@ -137,16 +138,16 @@ def _configure_codex(
     # string); mutating it would raise. Skip with a clear message, not a crash.
     if servers is not None and not isinstance(servers, dict):
         if remove:
-            return f"Codex: no nauro entry to remove in {config_path}"
-        return f"Codex: mcp_servers in {config_path} is not a table, skipped"
+            return CodexConfigOutcome(CodexConfigKind.NOTHING_TO_REMOVE, config_path)
+        return CodexConfigOutcome(CodexConfigKind.MCPSERVERS_NOT_TABLE, config_path)
 
     if remove:
         if servers is None or "nauro" not in servers:
-            return f"Codex: no nauro entry to remove in {config_path}"
+            return CodexConfigOutcome(CodexConfigKind.NOTHING_TO_REMOVE, config_path)
         # The emptied parent table is deliberately left in place: popping it
         # would rewrite user formatting beyond the entry being removed.
         del servers["nauro"]
-        status = f"Codex: removed nauro from {config_path}"
+        status = CodexConfigOutcome(CodexConfigKind.REMOVED, config_path)
     else:
         desired = _CodexNauroEntry(command=_find_nauro_command(), args=["serve", "--stdio"])
         if servers is None:
@@ -155,9 +156,9 @@ def _configure_codex(
         entry = servers.get("nauro")
         current = _parse_codex_nauro_entry(entry)
         if current == desired:
-            return f"Codex: nauro already configured in {config_path}"
+            return CodexConfigOutcome(CodexConfigKind.ALREADY_CONFIGURED, config_path)
         _apply_nauro_entry(servers, entry, current, desired)
-        status = f"Codex: wrote nauro to {config_path}"
+        status = CodexConfigOutcome(CodexConfigKind.WROTE, config_path)
 
     rendered = tomlkit.dumps(document)
     if original is not None and rendered.encode("utf-8") == original:
@@ -166,3 +167,30 @@ def _configure_codex(
     # line endings as literal characters, so translation would corrupt CRLF.
     atomic_write_text(config_path, rendered, newline="\n")
     return status
+
+
+def recorded_codex_command() -> tuple[bool, str | None]:
+    """Return ``(wired, recorded command)`` for the user-global Codex config.
+
+    Single read of ``~/.codex/config.toml``. ``(True, None)`` means a nauro
+    entry exists but records no usable command — wired for presence, nothing
+    to probe. Any read or parse failure counts as not wired.
+    """
+    import sys
+
+    if sys.version_info >= (3, 11):
+        import tomllib
+    else:
+        import tomli as tomllib
+
+    try:
+        with codex_config_path().open("rb") as f:
+            config = tomllib.load(f)
+    except Exception:
+        return (False, None)
+    servers = config.get("mcp_servers")
+    if not isinstance(servers, dict) or "nauro" not in servers:
+        return (False, None)
+    entry = servers["nauro"]
+    cmd = entry.get("command") if isinstance(entry, dict) else None
+    return (True, cmd if isinstance(cmd, str) and cmd else None)

--- a/packages/nauro/src/nauro/cli/integrations/codex_hooks.py
+++ b/packages/nauro/src/nauro/cli/integrations/codex_hooks.py
@@ -13,6 +13,7 @@ from nauro.cli._codex_hooks import (
     _validate_codex_hooks,
 )
 from nauro.cli.git_hygiene import public_surface_git_warnings
+from nauro.cli.integrations.outcomes import CodexHookKind, CodexHookOutcome
 from nauro.cli.nauro_command import _find_nauro_codex_hook_command
 from nauro.store._atomic import atomic_write_text
 from nauro.store.write_safety import find_symlink
@@ -33,11 +34,11 @@ def _codex_hooks_path(repo: Path) -> Path:
     return repo / ".codex" / "hooks.json"
 
 
-def materialize_hooks_codex(repo: Path, *, remove: bool) -> str:
+def materialize_hooks_codex(repo: Path, *, remove: bool) -> CodexHookOutcome:
     """Add or remove project-scoped Codex lifecycle hooks for ``repo``."""
     refusal = find_symlink(repo, ".codex/hooks.json")
     if refusal is not None:
-        return f"  {repo}: {refusal.message}"
+        return CodexHookOutcome(CodexHookKind.REFUSED_SYMLINK, repo, refusal=refusal)
     hooks_path = _codex_hooks_path(repo)
     existing_text: str | None = None
     if hooks_path.exists():
@@ -45,39 +46,38 @@ def materialize_hooks_codex(repo: Path, *, remove: bool) -> str:
             existing_text = hooks_path.read_text(encoding="utf-8")
             config = _parse_codex_hooks(existing_text)
         except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-            return f"  {repo}: could not parse .codex/hooks.json - {exc}"
+            return CodexHookOutcome(CodexHookKind.PARSE_ERROR, repo, detail=str(exc))
         except _CodexHookConfigError as exc:
-            return f"  {repo}: {exc}"
+            return CodexHookOutcome(CodexHookKind.CONFIG_ERROR, repo, detail=str(exc))
     else:
         config = {}
 
     try:
         _validate_codex_hooks(config)
     except _CodexHookConfigError as exc:
-        return f"  {repo}: {exc}"
+        return CodexHookOutcome(CodexHookKind.CONFIG_ERROR, repo, detail=str(exc))
 
     command = None if remove else _find_nauro_codex_hook_command()
     if not remove and command is None:
-        return f"  {repo}: Codex hook wiring skipped; no compatible Nauro command"
+        return CodexHookOutcome(CodexHookKind.NO_COMMAND, repo)
 
     try:
         transformed = _transform_codex_hooks(config, command=command)
     except _CodexHookConfigError as exc:
-        return f"  {repo}: {exc}"
+        return CodexHookOutcome(CodexHookKind.CONFIG_ERROR, repo, detail=str(exc))
 
     if remove:
         if transformed.removed == 0:
-            return f"  {repo}: no nauro Codex hooks to remove"
+            return CodexHookOutcome(CodexHookKind.NOTHING_TO_REMOVE, repo)
         if transformed.config:
             atomic_write_text(hooks_path, _format_codex_hooks(transformed.config))
         else:
             hooks_path.unlink()
-        return f"  {repo}: removed nauro hooks from .codex/hooks.json"
+        return CodexHookOutcome(CodexHookKind.REMOVED, repo)
 
     rendered = _format_codex_hooks(transformed.config)
     if existing_text == rendered:
-        return f"  {repo}: nauro hooks already present in .codex/hooks.json"
+        return CodexHookOutcome(CodexHookKind.ALREADY_PRESENT, repo)
     atomic_write_text(hooks_path, rendered)
-    lines = [f"  {repo}: wrote nauro hooks to .codex/hooks.json"]
-    lines.extend(public_surface_git_warnings(repo, ".codex/hooks.json"))
-    return "\n".join(lines)
+    git_warnings = tuple(public_surface_git_warnings(repo, ".codex/hooks.json"))
+    return CodexHookOutcome(CodexHookKind.WROTE, repo, git_warnings=git_warnings)

--- a/packages/nauro/src/nauro/cli/integrations/json_mcp.py
+++ b/packages/nauro/src/nauro/cli/integrations/json_mcp.py
@@ -15,32 +15,29 @@ from nauro.cli.nauro_command import _find_nauro_command
 from nauro.store.write_safety import find_symlink
 
 
-class McpServerEntry(BaseModel):
-    """One ``mcpServers`` value. Only ``command``/``args`` are Nauro's; any
-    other keys the user added survive because unknown keys are allowed."""
-
-    model_config = ConfigDict(extra="allow")
-
-    command: str | None = None
-    args: list[str] | None = None
-
-
 class McpConfigDocument(BaseModel):
     """Boundary view of a hand-editable ``.mcp.json`` / ``.cursor/mcp.json``.
 
-    ``mcpServers`` is optional and, when present, must be an object map of
-    server entries. Unknown top-level keys are preserved. The document is
-    used to validate shape and read facts; writes go back into the raw
-    ``json.loads`` dict so key order and untouched content are byte-preserved.
+    Only the container shape Nauro owns is validated: ``mcpServers`` is optional
+    and, when present, must be a JSON object. Its entry *values* stay opaque
+    (``dict[str, object]``) so a malformed sibling server the user wrote never
+    blocks Nauro from wiring or reading its own entry — Nauro does not own those
+    entries and must not reject the file over them. Unknown top-level keys are
+    preserved. The document validates shape and reads the entry set; writes go
+    back into the raw ``json.loads`` dict so key order and untouched content are
+    byte-preserved.
     """
 
-    model_config = ConfigDict(extra="allow", populate_by_name=True)
+    model_config = ConfigDict(extra="allow")
 
     # Non-optional: a missing key defaults to an empty map (matching the
     # original ``config.get("mcpServers", {})``), while an explicit JSON null
-    # or a scalar is a shape violation the boundary parser routes to a
-    # graceful skip rather than letting it crash a raw-dict mutation.
-    mcp_servers: dict[str, McpServerEntry] = Field(default_factory=dict, alias="mcpServers")
+    # or a scalar is a shape violation the boundary parser routes to a graceful
+    # skip rather than letting it crash a raw-dict mutation. Bound to the exact
+    # ``mcpServers`` alias only (no populate_by_name), so an unrelated snake_case
+    # ``mcp_servers`` key the user wrote stays opaque extra content and is never
+    # mistaken for Nauro's map.
+    mcp_servers: dict[str, object] = Field(default_factory=dict, alias="mcpServers")
 
 
 class McpShape(Enum):
@@ -57,7 +54,12 @@ class McpShapeError(ValueError):
 
 
 def _parse_mcp_document(raw: object) -> McpConfigDocument:
-    """Validate ``raw`` into an :class:`McpConfigDocument` or raise typed."""
+    """Validate ``raw`` into an :class:`McpConfigDocument` or raise typed.
+
+    The only shape violation the model surfaces is a present-but-non-object
+    ``mcpServers`` (null or scalar); its entry values are opaque, so a malformed
+    sibling entry parses cleanly and never routes to the skip.
+    """
     if not isinstance(raw, dict):
         raise McpShapeError(McpShape.TOP_LEVEL_NOT_OBJECT)
     try:
@@ -126,12 +128,9 @@ def _configure_json_mcp(
             config_path.unlink()
         return JsonMcpOutcome(JsonMcpKind.REMOVED, repo_path, label)
 
-    # Defense in depth: the parse above already rejects a non-object
-    # mcpServers, but never mutate a present-but-non-dict container (an
-    # explicit null makes setdefault return it, so ``None["nauro"] = ...``
-    # would raise). Route it to the same graceful skip instead.
-    if "mcpServers" in raw and not isinstance(raw["mcpServers"], dict):
-        return JsonMcpOutcome(JsonMcpKind.MCPSERVERS_NOT_OBJECT, repo_path, label)
+    # The parse guarantees mcpServers is absent or an object here, so setdefault
+    # always lands on a dict. Overwrite only Nauro's own entry; every sibling
+    # entry stays byte-identical because Nauro does not own it.
     raw.setdefault("mcpServers", {})["nauro"] = nauro_entry
     write_json_config(config_path, raw)
     git_warnings = tuple(public_surface_git_warnings(repo_path, config_rel_path))
@@ -169,10 +168,13 @@ def recorded_mcp_commands(repo: Path) -> list[str | None]:
     Single read of ``.mcp.json`` and ``.cursor/mcp.json`` each — presence
     ("the repo is wired" iff the list is non-empty) and the recorded command
     both derive from the same parse via :class:`McpConfigDocument`. A wired
-    config whose nauro entry carries a missing or empty command contributes
-    ``None``: it still counts as wired, but there is nothing to probe.
-    Read-only and soft-failing: a missing, unreadable, or off-shape config
-    contributes nothing — status must never crash on someone else's config.
+    config whose nauro entry carries a missing, empty, or non-string command
+    contributes ``None``: it still counts as wired, but there is nothing to
+    probe. Read-only and soft-failing: a missing, unreadable, or off-container
+    config contributes nothing — status must never crash on someone else's
+    config. Only the entry's ``command`` is read: a malformed sibling entry, or
+    a malformed ``args`` on the nauro entry itself, never suppresses a usable
+    command, since Nauro does not act on that content here.
     """
     commands: list[str | None] = []
     for rel in (".mcp.json", ".cursor/mcp.json"):
@@ -184,6 +186,7 @@ def recorded_mcp_commands(repo: Path) -> list[str | None]:
         servers = document.mcp_servers
         if "nauro" not in servers:
             continue
-        command = servers["nauro"].command
-        commands.append(command if command else None)
+        entry = servers["nauro"]
+        command = entry.get("command") if isinstance(entry, dict) else None
+        commands.append(command if isinstance(command, str) and command else None)
     return commands

--- a/packages/nauro/src/nauro/cli/integrations/json_mcp.py
+++ b/packages/nauro/src/nauro/cli/integrations/json_mcp.py
@@ -3,12 +3,67 @@
 from __future__ import annotations
 
 import json
+from enum import Enum, auto
 from pathlib import Path
 
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
 from nauro.cli.git_hygiene import public_surface_git_warnings
+from nauro.cli.integrations._json_config import write_json_config
+from nauro.cli.integrations.outcomes import JsonMcpKind, JsonMcpOutcome
 from nauro.cli.nauro_command import _find_nauro_command
-from nauro.store._atomic import atomic_write_text
 from nauro.store.write_safety import find_symlink
+
+
+class McpServerEntry(BaseModel):
+    """One ``mcpServers`` value. Only ``command``/``args`` are Nauro's; any
+    other keys the user added survive because unknown keys are allowed."""
+
+    model_config = ConfigDict(extra="allow")
+
+    command: str | None = None
+    args: list[str] | None = None
+
+
+class McpConfigDocument(BaseModel):
+    """Boundary view of a hand-editable ``.mcp.json`` / ``.cursor/mcp.json``.
+
+    ``mcpServers`` is optional and, when present, must be an object map of
+    server entries. Unknown top-level keys are preserved. The document is
+    used to validate shape and read facts; writes go back into the raw
+    ``json.loads`` dict so key order and untouched content are byte-preserved.
+    """
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    # Non-optional: a missing key defaults to an empty map (matching the
+    # original ``config.get("mcpServers", {})``), while an explicit JSON null
+    # or a scalar is a shape violation the boundary parser routes to a
+    # graceful skip rather than letting it crash a raw-dict mutation.
+    mcp_servers: dict[str, McpServerEntry] = Field(default_factory=dict, alias="mcpServers")
+
+
+class McpShape(Enum):
+    TOP_LEVEL_NOT_OBJECT = auto()
+    MCPSERVERS_NOT_OBJECT = auto()
+
+
+class McpShapeError(ValueError):
+    """The config's top level or ``mcpServers`` is off-shape."""
+
+    def __init__(self, shape: McpShape) -> None:
+        super().__init__(shape.name)
+        self.shape = shape
+
+
+def _parse_mcp_document(raw: object) -> McpConfigDocument:
+    """Validate ``raw`` into an :class:`McpConfigDocument` or raise typed."""
+    if not isinstance(raw, dict):
+        raise McpShapeError(McpShape.TOP_LEVEL_NOT_OBJECT)
+    try:
+        return McpConfigDocument.model_validate(raw)
+    except ValidationError as exc:
+        raise McpShapeError(McpShape.MCPSERVERS_NOT_OBJECT) from exc
 
 
 def _configure_json_mcp(
@@ -17,7 +72,7 @@ def _configure_json_mcp(
     config_rel_path: str,
     label: str,
     remove: bool,
-) -> str:
+) -> JsonMcpOutcome:
     """Add or remove the Nauro MCP entry in a JSON config file at ``repo_path / config_rel_path``.
 
     Shared shape behind ``_configure_mcp`` (``.mcp.json``) and
@@ -26,60 +81,69 @@ def _configure_json_mcp(
     name and entry shape, so the only per-surface variation is the relative
     path and the human-readable ``label`` used in status messages.
 
-    Returns a one-line status string (indented for ``setup_all_surfaces``).
+    Shape validation runs through :class:`McpConfigDocument`, but the write
+    mutates the raw ``json.loads`` dict so key order and sibling entries stay
+    byte-identical.
     """
     refusal = find_symlink(repo_path, config_rel_path)
     if refusal is not None:
-        return f"  {repo_path}: {refusal.message}"
+        return JsonMcpOutcome(JsonMcpKind.REFUSED_SYMLINK, repo_path, label, refusal=refusal)
     config_path = repo_path / config_rel_path
     nauro_cmd = _find_nauro_command()
     nauro_entry = {"command": nauro_cmd, "args": ["serve", "--stdio"]}
 
     if config_path.exists():
         try:
-            config = json.loads(config_path.read_text(encoding="utf-8"))
+            raw = json.loads(config_path.read_text(encoding="utf-8"))
         except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-            return f"  {repo_path}: could not parse {label} - {exc}"
+            return JsonMcpOutcome(JsonMcpKind.PARSE_ERROR, repo_path, label, detail=str(exc))
     else:
-        config = {}
+        raw = {}
 
     # A hand-mangled config can have a non-object top level (e.g. a JSON array)
     # or an mcpServers that isn't an object; mutating it would raise. Skip with a
     # clear message instead of a traceback, mirroring the hook path's guard.
-    if not isinstance(config, dict):
-        return f"  {repo_path}: {label} is not a JSON object, skipped"
+    try:
+        document = _parse_mcp_document(raw)
+    except McpShapeError as exc:
+        if exc.shape is McpShape.TOP_LEVEL_NOT_OBJECT:
+            return JsonMcpOutcome(JsonMcpKind.NOT_JSON_OBJECT, repo_path, label)
+        if remove:
+            return JsonMcpOutcome(JsonMcpKind.NOTHING_TO_REMOVE, repo_path, label)
+        return JsonMcpOutcome(JsonMcpKind.MCPSERVERS_NOT_OBJECT, repo_path, label)
 
+    servers = document.mcp_servers
     if remove:
-        servers = config.get("mcpServers", {})
-        if not isinstance(servers, dict) or "nauro" not in servers:
-            return f"  {repo_path}: no nauro entry to remove"
-        del servers["nauro"]
-        if not servers:
-            config.pop("mcpServers", None)
-        if config:
-            atomic_write_text(config_path, json.dumps(config, indent=2) + "\n")
+        if "nauro" not in servers:
+            return JsonMcpOutcome(JsonMcpKind.NOTHING_TO_REMOVE, repo_path, label)
+        raw_servers = raw["mcpServers"]
+        del raw_servers["nauro"]
+        if not raw_servers:
+            raw.pop("mcpServers", None)
+        if raw:
+            write_json_config(config_path, raw)
         else:
             config_path.unlink()
-        return f"  {repo_path}: removed nauro from {label}"
+        return JsonMcpOutcome(JsonMcpKind.REMOVED, repo_path, label)
 
-    servers = config.setdefault("mcpServers", {})
-    if not isinstance(servers, dict):
-        return f"  {repo_path}: mcpServers in {label} is not a JSON object, skipped"
-    servers["nauro"] = nauro_entry
-    atomic_write_text(config_path, json.dumps(config, indent=2) + "\n")
-    lines = [f"  {repo_path}: wrote nauro to {label}"]
-    lines.extend(public_surface_git_warnings(repo_path, config_rel_path))
-    return "\n".join(lines)
+    # Defense in depth: the parse above already rejects a non-object
+    # mcpServers, but never mutate a present-but-non-dict container (an
+    # explicit null makes setdefault return it, so ``None["nauro"] = ...``
+    # would raise). Route it to the same graceful skip instead.
+    if "mcpServers" in raw and not isinstance(raw["mcpServers"], dict):
+        return JsonMcpOutcome(JsonMcpKind.MCPSERVERS_NOT_OBJECT, repo_path, label)
+    raw.setdefault("mcpServers", {})["nauro"] = nauro_entry
+    write_json_config(config_path, raw)
+    git_warnings = tuple(public_surface_git_warnings(repo_path, config_rel_path))
+    return JsonMcpOutcome(JsonMcpKind.WROTE, repo_path, label, git_warnings=git_warnings)
 
 
-def _configure_mcp(repo_path: Path, *, remove: bool = False) -> str:
+def _configure_mcp(repo_path: Path, *, remove: bool = False) -> JsonMcpOutcome:
     """Add or remove the Nauro MCP entry in the repo's project-scope ``.mcp.json``.
 
     Writes the file directly. Mirrors how ``_configure_cursor_for_repo``
     handles ``.cursor/mcp.json`` and ``_configure_codex`` handles
     ``~/.codex/config.toml``, so all three surface handlers share one shape.
-
-    Returns a one-line status string (indented for ``setup_all_surfaces``).
     """
     return _configure_json_mcp(
         repo_path,
@@ -89,7 +153,7 @@ def _configure_mcp(repo_path: Path, *, remove: bool = False) -> str:
     )
 
 
-def _configure_cursor_for_repo(repo_path: Path, *, remove: bool) -> str:
+def _configure_cursor_for_repo(repo_path: Path, *, remove: bool) -> JsonMcpOutcome:
     """Add or remove the Nauro MCP entry in this repo's ``.cursor/mcp.json``."""
     return _configure_json_mcp(
         repo_path,
@@ -97,3 +161,29 @@ def _configure_cursor_for_repo(repo_path: Path, *, remove: bool) -> str:
         label=".cursor/mcp.json",
         remove=remove,
     )
+
+
+def recorded_mcp_commands(repo: Path) -> list[str | None]:
+    """Recorded nauro MCP commands in this repo's configs, one entry per wired config.
+
+    Single read of ``.mcp.json`` and ``.cursor/mcp.json`` each — presence
+    ("the repo is wired" iff the list is non-empty) and the recorded command
+    both derive from the same parse via :class:`McpConfigDocument`. A wired
+    config whose nauro entry carries a missing or empty command contributes
+    ``None``: it still counts as wired, but there is nothing to probe.
+    Read-only and soft-failing: a missing, unreadable, or off-shape config
+    contributes nothing — status must never crash on someone else's config.
+    """
+    commands: list[str | None] = []
+    for rel in (".mcp.json", ".cursor/mcp.json"):
+        try:
+            raw = json.loads((repo / rel).read_text(encoding="utf-8"))
+            document = _parse_mcp_document(raw)
+        except Exception:
+            continue
+        servers = document.mcp_servers
+        if "nauro" not in servers:
+            continue
+        command = servers["nauro"].command
+        commands.append(command if command else None)
+    return commands

--- a/packages/nauro/src/nauro/cli/integrations/legacy.py
+++ b/packages/nauro/src/nauro/cli/integrations/legacy.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from nauro.cli.integrations.outcomes import LegacyKind, LegacyOutcome
 from nauro.constants import CLAUDE_MD, NAURO_BLOCK_END, NAURO_BLOCK_START
 from nauro.store.reader import read_text_lenient
 from nauro.store.write_safety import find_symlink
@@ -13,14 +14,15 @@ CLAUDE_MD_START = NAURO_BLOCK_START
 CLAUDE_MD_END = NAURO_BLOCK_END
 
 
-def _remove_claude_md(repo_path: Path) -> str | None:
+def _remove_claude_md(repo_path: Path) -> LegacyOutcome | None:
     """Remove a legacy Nauro block from CLAUDE.md if present.
 
-    Returns a status string if a block was removed, or None if no block found.
+    Returns an outcome if a block was removed or the write was refused, or
+    None if there is no CLAUDE.md or no legacy block to remove.
     """
     refusal = find_symlink(repo_path, CLAUDE_MD)
     if refusal is not None:
-        return f"  {repo_path}: {refusal.message}"
+        return LegacyOutcome(LegacyKind.REFUSED_SYMLINK, repo_path, refusal=refusal)
     claude_md = repo_path / CLAUDE_MD
     if not claude_md.exists():
         return None
@@ -35,7 +37,7 @@ def _remove_claude_md(repo_path: Path) -> str | None:
 
     if not remaining:
         claude_md.unlink()
-        return f"  {repo_path}: removed legacy Nauro block (deleted empty {CLAUDE_MD})"
+        return LegacyOutcome(LegacyKind.REMOVED_DELETED_FILE, repo_path)
     else:
         claude_md.write_text(remaining + "\n", encoding="utf-8")
-        return f"  {repo_path}: removed legacy Nauro block from {CLAUDE_MD}"
+        return LegacyOutcome(LegacyKind.REMOVED_BLOCK, repo_path)

--- a/packages/nauro/src/nauro/cli/integrations/orchestrator.py
+++ b/packages/nauro/src/nauro/cli/integrations/orchestrator.py
@@ -8,11 +8,11 @@ from pathlib import Path
 from nauro.cli.integrations.agents import materialize_agents
 from nauro.cli.integrations.claude_hooks import materialize_hooks_claude_code
 from nauro.cli.integrations.claude_user_config import _prune_redundant_user_scope_mcp
-from nauro.cli.integrations.codex_config import _configure_codex, _default_codex_config_path
+from nauro.cli.integrations.codex_config import _configure_codex, codex_config_path
 from nauro.cli.integrations.codex_hooks import _nearest_codex_hooks_repo, materialize_hooks_codex
 from nauro.cli.integrations.json_mcp import _configure_cursor_for_repo, _configure_mcp
 from nauro.cli.integrations.legacy import _remove_claude_md
-from nauro.cli.integrations.outcomes import ArtifactOutcome, RawLine
+from nauro.cli.integrations.outcomes import ArtifactOutcome, HandlerErrorOutcome, RawLine
 from nauro.cli.integrations.skills import (
     materialize_skills_claude_code,
     materialize_skills_codex,
@@ -44,12 +44,12 @@ def claude_code_surfaces(
     ``warn_then_regen`` route through ``warn`` (stderr), never the returned
     list.
     """
-    legacy_results: list[str] = []
-    mcp_results: list[str] = []
-    hook_results: list[str] = []
+    legacy_results: list[ArtifactOutcome] = []
+    mcp_results: list[ArtifactOutcome] = []
+    hook_results: list[ArtifactOutcome] = []
     for repo_path in project_repos:
         if not repo_path.is_dir():
-            mcp_results.append(f"  {repo_path}: repo path missing, skipped")
+            mcp_results.append(RawLine(f"  {repo_path}: repo path missing, skipped"))
             continue
         legacy = _remove_claude_md(repo_path)
         if legacy:
@@ -59,22 +59,24 @@ def claude_code_surfaces(
             try:
                 hook_results.append(materialize_hooks_claude_code(repo_path, remove=remove))
             except Exception as exc:
-                hook_results.append(f"  {repo_path}: hook wiring error - {exc}")
+                hook_results.append(
+                    HandlerErrorOutcome(f"  {repo_path}: hook wiring error - {exc}")
+                )
 
     if not remove:
         pruned = _prune_redundant_user_scope_mcp()
         if pruned:
             mcp_results.append(pruned)
 
-    outcomes: list[ArtifactOutcome] = [RawLine(result) for result in mcp_results]
+    outcomes: list[ArtifactOutcome] = list(mcp_results)
 
     if hook_results:
         outcomes.append(RawLine("\nHooks:"))
-        outcomes.extend(RawLine(result) for result in hook_results)
+        outcomes.extend(hook_results)
 
     if legacy_results:
         outcomes.append(RawLine("\nLegacy cleanup:"))
-        outcomes.extend(RawLine(result) for result in legacy_results)
+        outcomes.extend(legacy_results)
 
     if not remove:
         # Regenerate AGENTS.md so context is fresh from the start. The store
@@ -98,7 +100,7 @@ def cursor_surfaces(project_repos: list[Path], *, remove: bool) -> list[Artifact
         if not repo_path.is_dir():
             outcomes.append(RawLine(f"  {repo_path}: repo path missing, skipped"))
             continue
-        outcomes.append(RawLine(_configure_cursor_for_repo(repo_path, remove=remove)))
+        outcomes.append(_configure_cursor_for_repo(repo_path, remove=remove))
     return outcomes
 
 
@@ -124,7 +126,7 @@ def codex_surfaces(*, remove: bool, with_hooks: bool) -> list[ArtifactOutcome]:
     # last project goes through 'nauro setup all --remove'.
     registered_count = len(_registered_project_keys()) if remove else 0
     if registered_count:
-        config_path = _default_codex_config_path()
+        config_path = codex_config_path()
         count_phrase = (
             "1 nauro project" if registered_count == 1 else f"{registered_count} nauro projects"
         )
@@ -136,7 +138,7 @@ def codex_surfaces(*, remove: bool, with_hooks: bool) -> list[ArtifactOutcome]:
             )
         )
     else:
-        outcomes.append(RawLine(_configure_codex(remove=remove)))
+        outcomes.append(_configure_codex(remove=remove))
 
     hook_cleanup_unresolved = False
     if remove:
@@ -169,9 +171,11 @@ def codex_surfaces(*, remove: bool, with_hooks: bool) -> list[ArtifactOutcome]:
                 outcomes.append(RawLine(f"  {repo_path}: repo path missing, skipped"))
                 continue
             try:
-                outcomes.append(RawLine(materialize_hooks_codex(repo_path, remove=remove)))
+                outcomes.append(materialize_hooks_codex(repo_path, remove=remove))
             except Exception as exc:
-                outcomes.append(RawLine(f"  {repo_path}: Codex hook wiring error - {exc}"))
+                outcomes.append(
+                    HandlerErrorOutcome(f"  {repo_path}: Codex hook wiring error - {exc}")
+                )
 
     return outcomes
 
@@ -197,33 +201,33 @@ def _all_claude_code_lines(
             outcomes.append(RawLine(f"  {repo}: repo path missing, skipped"))
             continue
         try:
-            outcomes.append(RawLine(_configure_mcp(repo, remove=remove)))
+            outcomes.append(_configure_mcp(repo, remove=remove))
         except Exception as exc:
-            outcomes.append(RawLine(f"Claude Code MCP ({repo}): error - {exc}"))
+            outcomes.append(HandlerErrorOutcome(f"Claude Code MCP ({repo}): error - {exc}"))
     if not remove:
         try:
             pruned = _prune_redundant_user_scope_mcp()
             if pruned:
-                outcomes.append(RawLine(pruned))
+                outcomes.append(pruned)
         except Exception as exc:  # never let cleanup break wiring
-            outcomes.append(RawLine(f"Claude Code MCP (user-scope cleanup): error - {exc}"))
+            outcomes.append(
+                HandlerErrorOutcome(f"Claude Code MCP (user-scope cleanup): error - {exc}")
+            )
     try:
         outcomes.extend(
-            RawLine(line)
-            for line in materialize_skills_claude_code(
+            materialize_skills_claude_code(
                 remove=remove,
                 clear_user_scope=clear_user_scope,
                 with_skills=with_skills,
             )
         )
     except Exception as exc:
-        outcomes.append(RawLine(f"Claude Code skills: error - {exc}"))
+        outcomes.append(HandlerErrorOutcome(f"Claude Code skills: error - {exc}"))
 
     if with_subagents:
         try:
             outcomes.extend(
-                RawLine(line)
-                for line in materialize_agents(
+                materialize_agents(
                     "claude_code",
                     remove=remove,
                     force_overwrite=force_overwrite,
@@ -231,16 +235,16 @@ def _all_claude_code_lines(
                 )
             )
         except Exception as exc:
-            outcomes.append(RawLine(f"Claude Code agents: error - {exc}"))
+            outcomes.append(HandlerErrorOutcome(f"Claude Code agents: error - {exc}"))
 
     if with_hooks or remove:
         for repo in project_repos:
             if not repo.is_dir():
                 continue
             try:
-                outcomes.append(RawLine(materialize_hooks_claude_code(repo, remove=remove)))
+                outcomes.append(materialize_hooks_claude_code(repo, remove=remove))
             except Exception as exc:
-                outcomes.append(RawLine(f"Claude Code hook ({repo}): error - {exc}"))
+                outcomes.append(HandlerErrorOutcome(f"Claude Code hook ({repo}): error - {exc}"))
     return outcomes
 
 
@@ -253,18 +257,15 @@ def _all_cursor_lines(
         if not repo.is_dir():
             continue
         try:
-            outcomes.append(RawLine(_configure_cursor_for_repo(repo, remove=remove)))
+            outcomes.append(_configure_cursor_for_repo(repo, remove=remove))
         except Exception as exc:
-            outcomes.append(RawLine(f"Cursor MCP ({repo}): error - {exc}"))
+            outcomes.append(HandlerErrorOutcome(f"Cursor MCP ({repo}): error - {exc}"))
         try:
             outcomes.extend(
-                RawLine(line)
-                for line in materialize_skills_cursor_for_repo(
-                    repo, remove=remove, with_skills=with_skills
-                )
+                materialize_skills_cursor_for_repo(repo, remove=remove, with_skills=with_skills)
             )
         except Exception as exc:
-            outcomes.append(RawLine(f"Cursor skills ({repo}): error - {exc}"))
+            outcomes.append(HandlerErrorOutcome(f"Cursor skills ({repo}): error - {exc}"))
     return outcomes
 
 
@@ -279,29 +280,28 @@ def _all_codex_lines(
     """Codex surface lines for ``setup_all_surfaces``: MCP global, skills global, optional hooks."""
     outcomes: list[ArtifactOutcome] = []
     try:
-        outcomes.append(RawLine(_configure_codex(remove=remove, clear_user_scope=clear_user_scope)))
+        outcomes.append(_configure_codex(remove=remove, clear_user_scope=clear_user_scope))
     except Exception as exc:
-        outcomes.append(RawLine(f"Codex MCP: error - {exc}"))
+        outcomes.append(HandlerErrorOutcome(f"Codex MCP: error - {exc}"))
     try:
         outcomes.extend(
-            RawLine(line)
-            for line in materialize_skills_codex(
+            materialize_skills_codex(
                 remove=remove,
                 clear_user_scope=clear_user_scope,
                 with_skills=with_skills,
             )
         )
     except Exception as exc:
-        outcomes.append(RawLine(f"Codex skills: error - {exc}"))
+        outcomes.append(HandlerErrorOutcome(f"Codex skills: error - {exc}"))
 
     if with_hooks or remove:
         for repo in project_repos:
             if not repo.is_dir():
                 continue
             try:
-                outcomes.append(RawLine(materialize_hooks_codex(repo, remove=remove)))
+                outcomes.append(materialize_hooks_codex(repo, remove=remove))
             except Exception as exc:
-                outcomes.append(RawLine(f"Codex hooks ({repo}): error - {exc}"))
+                outcomes.append(HandlerErrorOutcome(f"Codex hooks ({repo}): error - {exc}"))
     return outcomes
 
 
@@ -334,7 +334,7 @@ def _all_agents_md_lines(
             for repo_path in updated:
                 outcomes.append(RawLine(f"  {repo_path}: regenerated AGENTS.md"))
         except Exception as exc:
-            outcomes.append(RawLine(f"AGENTS.md regeneration: error - {exc}"))
+            outcomes.append(HandlerErrorOutcome(f"AGENTS.md regeneration: error - {exc}"))
 
     # Mirror of the regen above: strip the generated AGENTS.md on teardown so a
     # removed integration leaves no orphaned context file. User content in a
@@ -348,7 +348,7 @@ def _all_agents_md_lines(
                 if removed_line:
                     outcomes.append(RawLine(removed_line))
             except Exception as exc:
-                outcomes.append(RawLine(f"AGENTS.md removal ({repo}) failed: {exc}"))
+                outcomes.append(HandlerErrorOutcome(f"AGENTS.md removal ({repo}) failed: {exc}"))
     return outcomes
 
 

--- a/packages/nauro/src/nauro/cli/integrations/outcomes.py
+++ b/packages/nauro/src/nauro/cli/integrations/outcomes.py
@@ -1,8 +1,25 @@
-"""Typed outcomes the setup codecs return for the render layer to emit."""
+"""Typed outcomes the setup codecs return for the render layer to emit.
+
+Each codec reports what it did as a structured value rather than a
+pre-formatted status string: a small frozen dataclass carrying the facts a
+status line needs, tagged by a per-codec ``Kind`` enum. ``render`` (in
+``render.py``) is the single place that turns these back into the exact
+lines the setup commands echo, so the wording lives in one layer and the
+codecs stay free of presentation and of Typer.
+
+``RawLine`` remains for the orchestrator's own policy text (section headers,
+advisory paragraphs, the standalone codex count-phrase) that no codec owns.
+``HandlerErrorOutcome`` carries the message an orchestrator ``except`` arm
+built at the catch site.
+"""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import Enum, auto
+from pathlib import Path
+
+from nauro.store.write_safety import SymlinkRefusal, UserSymlinkRefusal
 
 
 @dataclass(frozen=True)
@@ -12,6 +29,185 @@ class RawLine:
     text: str
 
 
-# Single-member for now; later increments widen this into a union as each
-# codec gains its own structured outcome type.
-ArtifactOutcome = RawLine
+class JsonMcpKind(Enum):
+    REFUSED_SYMLINK = auto()
+    PARSE_ERROR = auto()
+    NOT_JSON_OBJECT = auto()
+    MCPSERVERS_NOT_OBJECT = auto()
+    WROTE = auto()
+    REMOVED = auto()
+    NOTHING_TO_REMOVE = auto()
+
+
+@dataclass(frozen=True)
+class JsonMcpOutcome:
+    """Result of wiring the Nauro MCP entry in a repo JSON config."""
+
+    kind: JsonMcpKind
+    repo_path: Path
+    label: str
+    refusal: SymlinkRefusal | None = None
+    detail: str | None = None
+    git_warnings: tuple[str, ...] = ()
+
+
+class ClaudeHookKind(Enum):
+    REFUSED_SYMLINK = auto()
+    PARSE_ERROR = auto()
+    NOT_JSON_OBJECT = auto()
+    HOOKS_NOT_OBJECT = auto()
+    EVENT_NOT_ARRAY = auto()
+    ALREADY_PRESENT = auto()
+    WROTE = auto()
+    REMOVED = auto()
+    NOTHING_TO_REMOVE = auto()
+
+
+@dataclass(frozen=True)
+class ClaudeHookOutcome:
+    """Result of wiring the advisory Claude Code UserPromptSubmit hook."""
+
+    kind: ClaudeHookKind
+    repo: Path
+    refusal: SymlinkRefusal | None = None
+    detail: str | None = None
+    git_warnings: tuple[str, ...] = ()
+
+
+class ClaudeUserConfigKind(Enum):
+    REFUSED_SYMLINK = auto()
+    INVALID_UTF8 = auto()
+    PRUNED = auto()
+
+
+@dataclass(frozen=True)
+class ClaudeUserConfigOutcome:
+    """Result of the user-scope ``~/.claude.json`` MCP prune."""
+
+    kind: ClaudeUserConfigKind
+    refusal: UserSymlinkRefusal | None = None
+
+
+class LegacyKind(Enum):
+    REFUSED_SYMLINK = auto()
+    REMOVED_BLOCK = auto()
+    REMOVED_DELETED_FILE = auto()
+
+
+@dataclass(frozen=True)
+class LegacyOutcome:
+    """Result of removing a legacy Nauro block from CLAUDE.md."""
+
+    kind: LegacyKind
+    repo_path: Path
+    refusal: SymlinkRefusal | None = None
+
+
+class CodexConfigKind(Enum):
+    PRESERVED_OTHER_PROJECTS = auto()
+    REFUSED_SYMLINK = auto()
+    PARSE_ERROR_UTF8 = auto()
+    PARSE_ERROR_TOML = auto()
+    NOTHING_TO_REMOVE = auto()
+    MCPSERVERS_NOT_TABLE = auto()
+    REMOVED = auto()
+    ALREADY_CONFIGURED = auto()
+    WROTE = auto()
+
+
+@dataclass(frozen=True)
+class CodexConfigOutcome:
+    """Result of wiring the user-global Codex MCP entry."""
+
+    kind: CodexConfigKind
+    config_path: Path
+    refusal: UserSymlinkRefusal | None = None
+    detail: str | None = None
+
+
+class CodexHookKind(Enum):
+    REFUSED_SYMLINK = auto()
+    PARSE_ERROR = auto()
+    CONFIG_ERROR = auto()
+    NO_COMMAND = auto()
+    ALREADY_PRESENT = auto()
+    WROTE = auto()
+    REMOVED = auto()
+    NOTHING_TO_REMOVE = auto()
+
+
+@dataclass(frozen=True)
+class CodexHookOutcome:
+    """Result of wiring project-scoped Codex lifecycle hooks."""
+
+    kind: CodexHookKind
+    repo: Path
+    refusal: SymlinkRefusal | None = None
+    detail: str | None = None
+    git_warnings: tuple[str, ...] = ()
+
+
+class SkillKind(Enum):
+    REFUSED_SYMLINK = auto()
+    PRESERVED = auto()
+    WROTE = auto()
+    REMOVED = auto()
+    ABSENT = auto()
+
+
+@dataclass(frozen=True)
+class SkillOutcome:
+    """Result of materializing or removing one skill artifact."""
+
+    kind: SkillKind
+    target: Path | None = None
+    refusal: SymlinkRefusal | UserSymlinkRefusal | None = None
+    repo: Path | None = None
+    base_label: str | None = None
+
+
+class AgentKind(Enum):
+    REFUSED_SYMLINK = auto()
+    PRESERVED = auto()
+    PRESERVED_MODIFIED = auto()
+    SURFACE_NOT_IMPLEMENTED = auto()
+    SURFACE_INVALID = auto()
+    UNCHANGED = auto()
+    OVERWROTE = auto()
+    UPDATED = auto()
+    INSTALLED = auto()
+    ABSENT = auto()
+    REMOVED = auto()
+
+
+@dataclass(frozen=True)
+class AgentOutcome:
+    """Result of installing or removing one bundled subagent file."""
+
+    kind: AgentKind
+    target: Path | None = None
+    refusal: UserSymlinkRefusal | None = None
+    surface: str | None = None
+    detail: str | None = None
+    backup_name: str | None = None
+
+
+@dataclass(frozen=True)
+class HandlerErrorOutcome:
+    """A caught per-handler failure the orchestrator reports as one line."""
+
+    message: str
+
+
+ArtifactOutcome = (
+    RawLine
+    | JsonMcpOutcome
+    | ClaudeHookOutcome
+    | ClaudeUserConfigOutcome
+    | LegacyOutcome
+    | CodexConfigOutcome
+    | CodexHookOutcome
+    | SkillOutcome
+    | AgentOutcome
+    | HandlerErrorOutcome
+)

--- a/packages/nauro/src/nauro/cli/integrations/outcomes.py
+++ b/packages/nauro/src/nauro/cli/integrations/outcomes.py
@@ -77,6 +77,7 @@ class ClaudeHookOutcome:
 class ClaudeUserConfigKind(Enum):
     REFUSED_SYMLINK = auto()
     INVALID_UTF8 = auto()
+    NOT_JSON_OBJECT = auto()
     PRUNED = auto()
 
 

--- a/packages/nauro/src/nauro/cli/integrations/render.py
+++ b/packages/nauro/src/nauro/cli/integrations/render.py
@@ -73,6 +73,8 @@ def _render_json_mcp(o: JsonMcpOutcome) -> list[str]:
             return [f"  {o.repo_path}: removed nauro from {o.label}"]
         case JsonMcpKind.WROTE:
             return [f"  {o.repo_path}: wrote nauro to {o.label}", *o.git_warnings]
+        case _:
+            raise TypeError(f"unrenderable JsonMcpOutcome kind: {o.kind!r}")
 
 
 def _render_claude_hook(o: ClaudeHookOutcome) -> list[str]:
@@ -95,6 +97,8 @@ def _render_claude_hook(o: ClaudeHookOutcome) -> list[str]:
             return [f"  {o.repo}: no nauro hook to remove"]
         case ClaudeHookKind.REMOVED:
             return [f"  {o.repo}: removed nauro hook from .claude/settings.json"]
+        case _:
+            raise TypeError(f"unrenderable ClaudeHookOutcome kind: {o.kind!r}")
 
 
 def _render_claude_user_config(o: ClaudeUserConfigOutcome) -> list[str]:
@@ -103,11 +107,15 @@ def _render_claude_user_config(o: ClaudeUserConfigOutcome) -> list[str]:
             return [f"  skipped user-scope prune: {o.refusal.message}"]
         case ClaudeUserConfigKind.INVALID_UTF8:
             return ["  skipped user-scope prune: ~/.claude.json is not valid UTF-8"]
+        case ClaudeUserConfigKind.NOT_JSON_OBJECT:
+            return ["  skipped user-scope prune: ~/.claude.json is not a JSON object"]
         case ClaudeUserConfigKind.PRUNED:
             return [
                 "  removed redundant user-scope HTTP nauro entry from ~/.claude.json "
                 "(project-scope stdio is canonical)"
             ]
+        case _:
+            raise TypeError(f"unrenderable ClaudeUserConfigOutcome kind: {o.kind!r}")
 
 
 def _render_legacy(o: LegacyOutcome) -> list[str]:
@@ -118,6 +126,8 @@ def _render_legacy(o: LegacyOutcome) -> list[str]:
             return [f"  {o.repo_path}: removed legacy Nauro block (deleted empty CLAUDE.md)"]
         case LegacyKind.REMOVED_BLOCK:
             return [f"  {o.repo_path}: removed legacy Nauro block from CLAUDE.md"]
+        case _:
+            raise TypeError(f"unrenderable LegacyOutcome kind: {o.kind!r}")
 
 
 def _render_codex_config(o: CodexConfigOutcome) -> list[str]:
@@ -143,6 +153,8 @@ def _render_codex_config(o: CodexConfigOutcome) -> list[str]:
             return [f"Codex: nauro already configured in {o.config_path}"]
         case CodexConfigKind.WROTE:
             return [f"Codex: wrote nauro to {o.config_path}"]
+        case _:
+            raise TypeError(f"unrenderable CodexConfigOutcome kind: {o.kind!r}")
 
 
 def _render_codex_hook(o: CodexHookOutcome) -> list[str]:
@@ -163,6 +175,8 @@ def _render_codex_hook(o: CodexHookOutcome) -> list[str]:
             return [f"  {o.repo}: nauro hooks already present in .codex/hooks.json"]
         case CodexHookKind.WROTE:
             return [f"  {o.repo}: wrote nauro hooks to .codex/hooks.json", *o.git_warnings]
+        case _:
+            raise TypeError(f"unrenderable CodexHookOutcome kind: {o.kind!r}")
 
 
 def _render_skill(o: SkillOutcome) -> list[str]:
@@ -179,6 +193,8 @@ def _render_skill(o: SkillOutcome) -> list[str]:
             return [f"  removed {o.target}"]
         case SkillKind.ABSENT:
             return [f"  no skill at {o.target}"]
+        case _:
+            raise TypeError(f"unrenderable SkillOutcome kind: {o.kind!r}")
 
 
 def _render_agent(o: AgentOutcome) -> list[str]:
@@ -205,3 +221,5 @@ def _render_agent(o: AgentOutcome) -> list[str]:
             return [f"  removed {o.target}"]
         case AgentKind.PRESERVED_MODIFIED:
             return [f"  preserved {o.target} (locally modified)"]
+        case _:
+            raise TypeError(f"unrenderable AgentOutcome kind: {o.kind!r}")

--- a/packages/nauro/src/nauro/cli/integrations/render.py
+++ b/packages/nauro/src/nauro/cli/integrations/render.py
@@ -1,12 +1,207 @@
-"""Render typed setup outcomes back into the status lines commands echo."""
+"""Render typed setup outcomes back into the status lines commands echo.
+
+Presentation lives here alone: every codec reports a typed outcome and this
+module maps it to the exact lines the setup commands print. A command echoes
+each returned string on its own ``typer.echo`` call, so a multi-line block
+(a write plus its git-hygiene warnings) is returned as separate elements and
+lands byte-identically to a single echo of the joined text.
+"""
 
 from __future__ import annotations
 
-from nauro.cli.integrations.outcomes import ArtifactOutcome, RawLine
+from nauro.cli.integrations.outcomes import (
+    AgentKind,
+    AgentOutcome,
+    ArtifactOutcome,
+    ClaudeHookKind,
+    ClaudeHookOutcome,
+    ClaudeUserConfigKind,
+    ClaudeUserConfigOutcome,
+    CodexConfigKind,
+    CodexConfigOutcome,
+    CodexHookKind,
+    CodexHookOutcome,
+    HandlerErrorOutcome,
+    JsonMcpKind,
+    JsonMcpOutcome,
+    LegacyKind,
+    LegacyOutcome,
+    RawLine,
+    SkillKind,
+    SkillOutcome,
+)
 
 
 def render(outcome: ArtifactOutcome) -> list[str]:
     """Flatten one outcome into the status lines a command echoes."""
     if isinstance(outcome, RawLine):
         return [outcome.text]
+    if isinstance(outcome, HandlerErrorOutcome):
+        return [outcome.message]
+    if isinstance(outcome, JsonMcpOutcome):
+        return _render_json_mcp(outcome)
+    if isinstance(outcome, ClaudeHookOutcome):
+        return _render_claude_hook(outcome)
+    if isinstance(outcome, ClaudeUserConfigOutcome):
+        return _render_claude_user_config(outcome)
+    if isinstance(outcome, LegacyOutcome):
+        return _render_legacy(outcome)
+    if isinstance(outcome, CodexConfigOutcome):
+        return _render_codex_config(outcome)
+    if isinstance(outcome, CodexHookOutcome):
+        return _render_codex_hook(outcome)
+    if isinstance(outcome, SkillOutcome):
+        return _render_skill(outcome)
+    if isinstance(outcome, AgentOutcome):
+        return _render_agent(outcome)
     raise TypeError(f"unrenderable outcome: {outcome!r}")
+
+
+def _render_json_mcp(o: JsonMcpOutcome) -> list[str]:
+    match o.kind:
+        case JsonMcpKind.REFUSED_SYMLINK:
+            return [f"  {o.repo_path}: {o.refusal.message}"]
+        case JsonMcpKind.PARSE_ERROR:
+            return [f"  {o.repo_path}: could not parse {o.label} - {o.detail}"]
+        case JsonMcpKind.NOT_JSON_OBJECT:
+            return [f"  {o.repo_path}: {o.label} is not a JSON object, skipped"]
+        case JsonMcpKind.MCPSERVERS_NOT_OBJECT:
+            return [f"  {o.repo_path}: mcpServers in {o.label} is not a JSON object, skipped"]
+        case JsonMcpKind.NOTHING_TO_REMOVE:
+            return [f"  {o.repo_path}: no nauro entry to remove"]
+        case JsonMcpKind.REMOVED:
+            return [f"  {o.repo_path}: removed nauro from {o.label}"]
+        case JsonMcpKind.WROTE:
+            return [f"  {o.repo_path}: wrote nauro to {o.label}", *o.git_warnings]
+
+
+def _render_claude_hook(o: ClaudeHookOutcome) -> list[str]:
+    match o.kind:
+        case ClaudeHookKind.REFUSED_SYMLINK:
+            return [f"  {o.repo}: {o.refusal.message}"]
+        case ClaudeHookKind.PARSE_ERROR:
+            return [f"  {o.repo}: could not parse .claude/settings.json - {o.detail}"]
+        case ClaudeHookKind.NOT_JSON_OBJECT:
+            return [f"  {o.repo}: .claude/settings.json is not a JSON object, skipped"]
+        case ClaudeHookKind.HOOKS_NOT_OBJECT:
+            return [f"  {o.repo}: hooks key is not a JSON object, skipped"]
+        case ClaudeHookKind.EVENT_NOT_ARRAY:
+            return [f"  {o.repo}: hooks.UserPromptSubmit is not a JSON array, skipped"]
+        case ClaudeHookKind.ALREADY_PRESENT:
+            return [f"  {o.repo}: nauro hook already present in .claude/settings.json"]
+        case ClaudeHookKind.WROTE:
+            return [f"  {o.repo}: wrote nauro hook to .claude/settings.json", *o.git_warnings]
+        case ClaudeHookKind.NOTHING_TO_REMOVE:
+            return [f"  {o.repo}: no nauro hook to remove"]
+        case ClaudeHookKind.REMOVED:
+            return [f"  {o.repo}: removed nauro hook from .claude/settings.json"]
+
+
+def _render_claude_user_config(o: ClaudeUserConfigOutcome) -> list[str]:
+    match o.kind:
+        case ClaudeUserConfigKind.REFUSED_SYMLINK:
+            return [f"  skipped user-scope prune: {o.refusal.message}"]
+        case ClaudeUserConfigKind.INVALID_UTF8:
+            return ["  skipped user-scope prune: ~/.claude.json is not valid UTF-8"]
+        case ClaudeUserConfigKind.PRUNED:
+            return [
+                "  removed redundant user-scope HTTP nauro entry from ~/.claude.json "
+                "(project-scope stdio is canonical)"
+            ]
+
+
+def _render_legacy(o: LegacyOutcome) -> list[str]:
+    match o.kind:
+        case LegacyKind.REFUSED_SYMLINK:
+            return [f"  {o.repo_path}: {o.refusal.message}"]
+        case LegacyKind.REMOVED_DELETED_FILE:
+            return [f"  {o.repo_path}: removed legacy Nauro block (deleted empty CLAUDE.md)"]
+        case LegacyKind.REMOVED_BLOCK:
+            return [f"  {o.repo_path}: removed legacy Nauro block from CLAUDE.md"]
+
+
+def _render_codex_config(o: CodexConfigOutcome) -> list[str]:
+    match o.kind:
+        case CodexConfigKind.PRESERVED_OTHER_PROJECTS:
+            return [
+                f"Codex: preserved nauro entry in {o.config_path} "
+                "(other nauro projects still registered)"
+            ]
+        case CodexConfigKind.REFUSED_SYMLINK:
+            return [f"Codex: {o.refusal.message}"]
+        case CodexConfigKind.PARSE_ERROR_UTF8:
+            return [f"Codex: could not parse {o.config_path} - not valid UTF-8"]
+        case CodexConfigKind.PARSE_ERROR_TOML:
+            return [f"Codex: could not parse {o.config_path} - {o.detail}"]
+        case CodexConfigKind.NOTHING_TO_REMOVE:
+            return [f"Codex: no nauro entry to remove in {o.config_path}"]
+        case CodexConfigKind.MCPSERVERS_NOT_TABLE:
+            return [f"Codex: mcp_servers in {o.config_path} is not a table, skipped"]
+        case CodexConfigKind.REMOVED:
+            return [f"Codex: removed nauro from {o.config_path}"]
+        case CodexConfigKind.ALREADY_CONFIGURED:
+            return [f"Codex: nauro already configured in {o.config_path}"]
+        case CodexConfigKind.WROTE:
+            return [f"Codex: wrote nauro to {o.config_path}"]
+
+
+def _render_codex_hook(o: CodexHookOutcome) -> list[str]:
+    match o.kind:
+        case CodexHookKind.REFUSED_SYMLINK:
+            return [f"  {o.repo}: {o.refusal.message}"]
+        case CodexHookKind.PARSE_ERROR:
+            return [f"  {o.repo}: could not parse .codex/hooks.json - {o.detail}"]
+        case CodexHookKind.CONFIG_ERROR:
+            return [f"  {o.repo}: {o.detail}"]
+        case CodexHookKind.NO_COMMAND:
+            return [f"  {o.repo}: Codex hook wiring skipped; no compatible Nauro command"]
+        case CodexHookKind.NOTHING_TO_REMOVE:
+            return [f"  {o.repo}: no nauro Codex hooks to remove"]
+        case CodexHookKind.REMOVED:
+            return [f"  {o.repo}: removed nauro hooks from .codex/hooks.json"]
+        case CodexHookKind.ALREADY_PRESENT:
+            return [f"  {o.repo}: nauro hooks already present in .codex/hooks.json"]
+        case CodexHookKind.WROTE:
+            return [f"  {o.repo}: wrote nauro hooks to .codex/hooks.json", *o.git_warnings]
+
+
+def _render_skill(o: SkillOutcome) -> list[str]:
+    match o.kind:
+        case SkillKind.REFUSED_SYMLINK:
+            if o.repo is not None:
+                return [f"  {o.repo}: {o.refusal.message}"]
+            return [f"  {o.refusal.message}"]
+        case SkillKind.PRESERVED:
+            return [f"  preserved {o.base_label}/nauro-* (other nauro projects still registered)"]
+        case SkillKind.WROTE:
+            return [f"  wrote {o.target}"]
+        case SkillKind.REMOVED:
+            return [f"  removed {o.target}"]
+        case SkillKind.ABSENT:
+            return [f"  no skill at {o.target}"]
+
+
+def _render_agent(o: AgentOutcome) -> list[str]:
+    match o.kind:
+        case AgentKind.SURFACE_NOT_IMPLEMENTED:
+            return [f"  skipped ~/.{o.surface} agents (not yet implemented)"]
+        case AgentKind.SURFACE_INVALID:
+            return [f"  skipped agents on surface {o.surface!r}: {o.detail}"]
+        case AgentKind.PRESERVED:
+            return ["  preserved ~/.claude/agents/nauro-* (other nauro projects still registered)"]
+        case AgentKind.REFUSED_SYMLINK:
+            return [f"  {o.refusal.message}"]
+        case AgentKind.UNCHANGED:
+            return [f"  unchanged {o.target}"]
+        case AgentKind.OVERWROTE:
+            return [f"  overwrote {o.target}"]
+        case AgentKind.UPDATED:
+            return [f"  updated {o.target} (previous saved to {o.backup_name})"]
+        case AgentKind.INSTALLED:
+            return [f"  installed {o.target}"]
+        case AgentKind.ABSENT:
+            return [f"  no agent at {o.target}"]
+        case AgentKind.REMOVED:
+            return [f"  removed {o.target}"]
+        case AgentKind.PRESERVED_MODIFIED:
+            return [f"  preserved {o.target} (locally modified)"]

--- a/packages/nauro/src/nauro/cli/integrations/skills.py
+++ b/packages/nauro/src/nauro/cli/integrations/skills.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from nauro.cli.integrations.outcomes import SkillKind, SkillOutcome
 from nauro.store.write_safety import find_file_symlink, find_symlink
 
 # Skills are rendered from canonical bodies in nauro.skills and written into
@@ -32,16 +33,16 @@ def _codex_skill_dir() -> Path:
     return Path.home() / ".agents" / "skills"
 
 
-def _materialize_skill_file(target: Path, content: str) -> str:
+def _materialize_skill_file(target: Path, content: str) -> SkillOutcome:
     refusal = find_file_symlink(target)
     if refusal is not None:
-        return f"  {refusal.message}"
+        return SkillOutcome(SkillKind.REFUSED_SYMLINK, target=target, refusal=refusal)
     target.parent.mkdir(parents=True, exist_ok=True)
     target.write_text(content, encoding="utf-8")
-    return f"  wrote {target}"
+    return SkillOutcome(SkillKind.WROTE, target=target)
 
 
-def _remove_skill_file(target: Path, *, stop_above: Path) -> str:
+def _remove_skill_file(target: Path, *, stop_above: Path) -> SkillOutcome:
     """Unlink ``target`` and prune empty parents, but never above ``stop_above``.
 
     Without the bound the parent walk could rmdir the surface base
@@ -50,9 +51,9 @@ def _remove_skill_file(target: Path, *, stop_above: Path) -> str:
     """
     refusal = find_file_symlink(target)
     if refusal is not None:
-        return f"  {refusal.message}"
+        return SkillOutcome(SkillKind.REFUSED_SYMLINK, target=target, refusal=refusal)
     if not target.is_file():
-        return f"  no skill at {target}"
+        return SkillOutcome(SkillKind.ABSENT, target=target)
     target.unlink()
     stop_resolved = stop_above.resolve()
     parent = target.parent
@@ -61,7 +62,7 @@ def _remove_skill_file(target: Path, *, stop_above: Path) -> str:
             break
         parent.rmdir()
         parent = parent.parent
-    return f"  removed {target}"
+    return SkillOutcome(SkillKind.REMOVED, target=target)
 
 
 def _resolved_skill_names(with_skills: bool) -> tuple[str, ...]:
@@ -80,7 +81,7 @@ def materialize_skills_claude_code(
     remove: bool,
     clear_user_scope: bool = True,
     with_skills: bool = False,
-) -> list[str]:
+) -> list[SkillOutcome]:
     """Install or remove the Nauro skill(s) under ``~/.claude/skills/``.
 
     ``clear_user_scope`` gates the remove path: when False, the skill files
@@ -94,9 +95,9 @@ def materialize_skills_claude_code(
 
     base = _claude_skill_dir()
     if remove and not clear_user_scope:
-        return ["  preserved ~/.claude/skills/nauro-* (other nauro projects still registered)"]
+        return [SkillOutcome(SkillKind.PRESERVED, base_label="~/.claude/skills")]
 
-    results: list[str] = []
+    results: list[SkillOutcome] = []
     for name in _resolved_skill_names(with_skills):
         target = base / name / "SKILL.md"
         if remove:
@@ -111,7 +112,7 @@ def materialize_skills_codex(
     remove: bool,
     clear_user_scope: bool = True,
     with_skills: bool = False,
-) -> list[str]:
+) -> list[SkillOutcome]:
     """Install or remove the Nauro skill(s) under ``~/.agents/skills/``.
 
     ``clear_user_scope`` gates the remove path: when False, the skill files
@@ -125,9 +126,9 @@ def materialize_skills_codex(
 
     base = _codex_skill_dir()
     if remove and not clear_user_scope:
-        return ["  preserved ~/.agents/skills/nauro-* (other nauro projects still registered)"]
+        return [SkillOutcome(SkillKind.PRESERVED, base_label="~/.agents/skills")]
 
-    results: list[str] = []
+    results: list[SkillOutcome] = []
     for name in _resolved_skill_names(with_skills):
         target = base / name / "SKILL.md"
         if remove:
@@ -142,7 +143,7 @@ def materialize_skills_cursor_for_repo(
     *,
     remove: bool,
     with_skills: bool = False,
-) -> list[str]:
+) -> list[SkillOutcome]:
     """Install or remove Cursor rules under ``<repo>/.cursor/rules/``.
 
     ``with_skills`` extends the install/remove set with ``OPT_IN_SKILL_NAMES``.
@@ -150,11 +151,11 @@ def materialize_skills_cursor_for_repo(
     from nauro.skills import render_skill
 
     base = repo / ".cursor" / "rules"
-    results: list[str] = []
+    results: list[SkillOutcome] = []
     for name in _resolved_skill_names(with_skills):
         refusal = find_symlink(repo, f".cursor/rules/{name}.mdc")
         if refusal is not None:
-            results.append(f"  {repo}: {refusal.message}")
+            results.append(SkillOutcome(SkillKind.REFUSED_SYMLINK, refusal=refusal, repo=repo))
             continue
         target = base / f"{name}.mdc"
         if remove:

--- a/packages/nauro/tests/test_cli_status.py
+++ b/packages/nauro/tests/test_cli_status.py
@@ -7,6 +7,7 @@ from typer.testing import CliRunner
 import nauro.cli.commands.status as status_mod
 from nauro.cli import nauro_command
 from nauro.cli._codex_hooks import _CODEX_HOOK_PROBE_ARGS
+from nauro.cli.integrations import codex_config
 from nauro.cli.main import app
 from nauro.store.registry import register_project
 from nauro.templates.agents_md import FOOTER_MARKER
@@ -27,7 +28,7 @@ def _setup_project(tmp_path, monkeypatch, repos=None):
     scaffold_project_store("testproj", store)
     monkeypatch.chdir(repos[0])
     monkeypatch.setattr(
-        status_mod, "_codex_config_path", lambda: tmp_path / "codex-home" / "config.toml"
+        codex_config, "codex_config_path", lambda: tmp_path / "codex-home" / "config.toml"
     )
     return store
 

--- a/packages/nauro/tests/test_integration_outcomes.py
+++ b/packages/nauro/tests/test_integration_outcomes.py
@@ -1,13 +1,46 @@
-"""Typed-outcome pipeline scaffolding: RawLine carrier and render dispatch."""
+"""Typed-outcome pipeline: RawLine carrier, render dispatch, and a wording table.
+
+The table below pins ``render()``'s exact string output for every outcome kind
+across every codec — the happy-path WROTE/REMOVED lines and each error/skip
+branch. It is the guard that makes a future wording edit fail a test rather than
+silently changing what ``nauro setup`` prints.
+"""
 
 from __future__ import annotations
 
 import dataclasses
+from pathlib import Path
 
 import pytest
 
-from nauro.cli.integrations.outcomes import RawLine
+from nauro.cli.integrations.outcomes import (
+    AgentKind,
+    AgentOutcome,
+    ClaudeHookKind,
+    ClaudeHookOutcome,
+    ClaudeUserConfigKind,
+    ClaudeUserConfigOutcome,
+    CodexConfigKind,
+    CodexConfigOutcome,
+    CodexHookKind,
+    CodexHookOutcome,
+    HandlerErrorOutcome,
+    JsonMcpKind,
+    JsonMcpOutcome,
+    LegacyKind,
+    LegacyOutcome,
+    RawLine,
+    SkillKind,
+    SkillOutcome,
+)
 from nauro.cli.integrations.render import render
+from nauro.store.write_safety import SymlinkRefusal, UserSymlinkRefusal
+
+REPO = Path("/repo")
+CFG = Path("/home/.codex/config.toml")
+TARGET = Path("/t/nauro-adopt/SKILL.md")
+REPO_REFUSAL = SymlinkRefusal(REPO / ".mcp.json", REPO / ".mcp.json")
+USER_REFUSAL = UserSymlinkRefusal(Path("/home/.claude.json"))
 
 
 def test_render_rawline_returns_verbatim_text():
@@ -18,3 +51,278 @@ def test_rawline_is_frozen():
     line = RawLine("x")
     with pytest.raises(dataclasses.FrozenInstanceError):
         line.text = "y"
+
+
+# One entry per (outcome, exact rendered lines). Covers every Kind member of
+# every codec, so a wording change to any branch fails here.
+RENDER_CASES = [
+    (RawLine("verbatim"), ["verbatim"]),
+    (HandlerErrorOutcome("handler blew up"), ["handler blew up"]),
+    # ── JsonMcp ──
+    (
+        JsonMcpOutcome(JsonMcpKind.REFUSED_SYMLINK, REPO, ".mcp.json", refusal=REPO_REFUSAL),
+        [f"  {REPO}: {REPO_REFUSAL.message}"],
+    ),
+    (
+        JsonMcpOutcome(JsonMcpKind.PARSE_ERROR, REPO, ".mcp.json", detail="boom"),
+        [f"  {REPO}: could not parse .mcp.json - boom"],
+    ),
+    (
+        JsonMcpOutcome(JsonMcpKind.NOT_JSON_OBJECT, REPO, ".mcp.json"),
+        [f"  {REPO}: .mcp.json is not a JSON object, skipped"],
+    ),
+    (
+        JsonMcpOutcome(JsonMcpKind.MCPSERVERS_NOT_OBJECT, REPO, ".mcp.json"),
+        [f"  {REPO}: mcpServers in .mcp.json is not a JSON object, skipped"],
+    ),
+    (
+        JsonMcpOutcome(JsonMcpKind.NOTHING_TO_REMOVE, REPO, ".mcp.json"),
+        [f"  {REPO}: no nauro entry to remove"],
+    ),
+    (
+        JsonMcpOutcome(JsonMcpKind.REMOVED, REPO, ".mcp.json"),
+        [f"  {REPO}: removed nauro from .mcp.json"],
+    ),
+    (
+        JsonMcpOutcome(JsonMcpKind.WROTE, REPO, ".mcp.json"),
+        [f"  {REPO}: wrote nauro to .mcp.json"],
+    ),
+    (
+        JsonMcpOutcome(JsonMcpKind.WROTE, REPO, ".mcp.json", git_warnings=("  a git note",)),
+        [f"  {REPO}: wrote nauro to .mcp.json", "  a git note"],
+    ),
+    # ── ClaudeHook ──
+    (
+        ClaudeHookOutcome(ClaudeHookKind.REFUSED_SYMLINK, REPO, refusal=REPO_REFUSAL),
+        [f"  {REPO}: {REPO_REFUSAL.message}"],
+    ),
+    (
+        ClaudeHookOutcome(ClaudeHookKind.PARSE_ERROR, REPO, detail="boom"),
+        [f"  {REPO}: could not parse .claude/settings.json - boom"],
+    ),
+    (
+        ClaudeHookOutcome(ClaudeHookKind.NOT_JSON_OBJECT, REPO),
+        [f"  {REPO}: .claude/settings.json is not a JSON object, skipped"],
+    ),
+    (
+        ClaudeHookOutcome(ClaudeHookKind.HOOKS_NOT_OBJECT, REPO),
+        [f"  {REPO}: hooks key is not a JSON object, skipped"],
+    ),
+    (
+        ClaudeHookOutcome(ClaudeHookKind.EVENT_NOT_ARRAY, REPO),
+        [f"  {REPO}: hooks.UserPromptSubmit is not a JSON array, skipped"],
+    ),
+    (
+        ClaudeHookOutcome(ClaudeHookKind.ALREADY_PRESENT, REPO),
+        [f"  {REPO}: nauro hook already present in .claude/settings.json"],
+    ),
+    (
+        ClaudeHookOutcome(ClaudeHookKind.WROTE, REPO),
+        [f"  {REPO}: wrote nauro hook to .claude/settings.json"],
+    ),
+    (
+        ClaudeHookOutcome(ClaudeHookKind.NOTHING_TO_REMOVE, REPO),
+        [f"  {REPO}: no nauro hook to remove"],
+    ),
+    (
+        ClaudeHookOutcome(ClaudeHookKind.REMOVED, REPO),
+        [f"  {REPO}: removed nauro hook from .claude/settings.json"],
+    ),
+    # ── ClaudeUserConfig ──
+    (
+        ClaudeUserConfigOutcome(ClaudeUserConfigKind.REFUSED_SYMLINK, refusal=USER_REFUSAL),
+        [f"  skipped user-scope prune: {USER_REFUSAL.message}"],
+    ),
+    (
+        ClaudeUserConfigOutcome(ClaudeUserConfigKind.INVALID_UTF8),
+        ["  skipped user-scope prune: ~/.claude.json is not valid UTF-8"],
+    ),
+    (
+        ClaudeUserConfigOutcome(ClaudeUserConfigKind.NOT_JSON_OBJECT),
+        ["  skipped user-scope prune: ~/.claude.json is not a JSON object"],
+    ),
+    (
+        ClaudeUserConfigOutcome(ClaudeUserConfigKind.PRUNED),
+        [
+            "  removed redundant user-scope HTTP nauro entry from ~/.claude.json "
+            "(project-scope stdio is canonical)"
+        ],
+    ),
+    # ── Legacy ──
+    (
+        LegacyOutcome(LegacyKind.REFUSED_SYMLINK, REPO, refusal=REPO_REFUSAL),
+        [f"  {REPO}: {REPO_REFUSAL.message}"],
+    ),
+    (
+        LegacyOutcome(LegacyKind.REMOVED_DELETED_FILE, REPO),
+        [f"  {REPO}: removed legacy Nauro block (deleted empty CLAUDE.md)"],
+    ),
+    (
+        LegacyOutcome(LegacyKind.REMOVED_BLOCK, REPO),
+        [f"  {REPO}: removed legacy Nauro block from CLAUDE.md"],
+    ),
+    # ── CodexConfig ──
+    (
+        CodexConfigOutcome(CodexConfigKind.PRESERVED_OTHER_PROJECTS, CFG),
+        [f"Codex: preserved nauro entry in {CFG} (other nauro projects still registered)"],
+    ),
+    (
+        CodexConfigOutcome(CodexConfigKind.REFUSED_SYMLINK, CFG, refusal=USER_REFUSAL),
+        [f"Codex: {USER_REFUSAL.message}"],
+    ),
+    (
+        CodexConfigOutcome(CodexConfigKind.PARSE_ERROR_UTF8, CFG),
+        [f"Codex: could not parse {CFG} - not valid UTF-8"],
+    ),
+    (
+        CodexConfigOutcome(CodexConfigKind.PARSE_ERROR_TOML, CFG, detail="boom"),
+        [f"Codex: could not parse {CFG} - boom"],
+    ),
+    (
+        CodexConfigOutcome(CodexConfigKind.NOTHING_TO_REMOVE, CFG),
+        [f"Codex: no nauro entry to remove in {CFG}"],
+    ),
+    (
+        CodexConfigOutcome(CodexConfigKind.MCPSERVERS_NOT_TABLE, CFG),
+        [f"Codex: mcp_servers in {CFG} is not a table, skipped"],
+    ),
+    (
+        CodexConfigOutcome(CodexConfigKind.REMOVED, CFG),
+        [f"Codex: removed nauro from {CFG}"],
+    ),
+    (
+        CodexConfigOutcome(CodexConfigKind.ALREADY_CONFIGURED, CFG),
+        [f"Codex: nauro already configured in {CFG}"],
+    ),
+    (
+        CodexConfigOutcome(CodexConfigKind.WROTE, CFG),
+        [f"Codex: wrote nauro to {CFG}"],
+    ),
+    # ── CodexHook ──
+    (
+        CodexHookOutcome(CodexHookKind.REFUSED_SYMLINK, REPO, refusal=REPO_REFUSAL),
+        [f"  {REPO}: {REPO_REFUSAL.message}"],
+    ),
+    (
+        CodexHookOutcome(CodexHookKind.PARSE_ERROR, REPO, detail="boom"),
+        [f"  {REPO}: could not parse .codex/hooks.json - boom"],
+    ),
+    (
+        CodexHookOutcome(CodexHookKind.CONFIG_ERROR, REPO, detail="bad config"),
+        [f"  {REPO}: bad config"],
+    ),
+    (
+        CodexHookOutcome(CodexHookKind.NO_COMMAND, REPO),
+        [f"  {REPO}: Codex hook wiring skipped; no compatible Nauro command"],
+    ),
+    (
+        CodexHookOutcome(CodexHookKind.NOTHING_TO_REMOVE, REPO),
+        [f"  {REPO}: no nauro Codex hooks to remove"],
+    ),
+    (
+        CodexHookOutcome(CodexHookKind.REMOVED, REPO),
+        [f"  {REPO}: removed nauro hooks from .codex/hooks.json"],
+    ),
+    (
+        CodexHookOutcome(CodexHookKind.ALREADY_PRESENT, REPO),
+        [f"  {REPO}: nauro hooks already present in .codex/hooks.json"],
+    ),
+    (
+        CodexHookOutcome(CodexHookKind.WROTE, REPO),
+        [f"  {REPO}: wrote nauro hooks to .codex/hooks.json"],
+    ),
+    # ── Skill ──
+    (
+        SkillOutcome(SkillKind.REFUSED_SYMLINK, repo=REPO, refusal=REPO_REFUSAL),
+        [f"  {REPO}: {REPO_REFUSAL.message}"],
+    ),
+    (
+        SkillOutcome(SkillKind.REFUSED_SYMLINK, refusal=REPO_REFUSAL),
+        [f"  {REPO_REFUSAL.message}"],
+    ),
+    (
+        SkillOutcome(SkillKind.PRESERVED, base_label="~/.claude/skills"),
+        ["  preserved ~/.claude/skills/nauro-* (other nauro projects still registered)"],
+    ),
+    (SkillOutcome(SkillKind.WROTE, target=TARGET), [f"  wrote {TARGET}"]),
+    (SkillOutcome(SkillKind.REMOVED, target=TARGET), [f"  removed {TARGET}"]),
+    (SkillOutcome(SkillKind.ABSENT, target=TARGET), [f"  no skill at {TARGET}"]),
+    # ── Agent ──
+    (
+        AgentOutcome(AgentKind.SURFACE_NOT_IMPLEMENTED, surface="cursor"),
+        ["  skipped ~/.cursor agents (not yet implemented)"],
+    ),
+    (
+        AgentOutcome(AgentKind.SURFACE_INVALID, surface="x", detail="bad"),
+        [f"  skipped agents on surface {'x'!r}: bad"],
+    ),
+    (
+        AgentOutcome(AgentKind.PRESERVED),
+        ["  preserved ~/.claude/agents/nauro-* (other nauro projects still registered)"],
+    ),
+    (
+        AgentOutcome(AgentKind.REFUSED_SYMLINK, refusal=USER_REFUSAL),
+        [f"  {USER_REFUSAL.message}"],
+    ),
+    (AgentOutcome(AgentKind.UNCHANGED, target=TARGET), [f"  unchanged {TARGET}"]),
+    (AgentOutcome(AgentKind.OVERWROTE, target=TARGET), [f"  overwrote {TARGET}"]),
+    (
+        AgentOutcome(AgentKind.UPDATED, target=TARGET, backup_name="SKILL.md.bak"),
+        [f"  updated {TARGET} (previous saved to SKILL.md.bak)"],
+    ),
+    (AgentOutcome(AgentKind.INSTALLED, target=TARGET), [f"  installed {TARGET}"]),
+    (AgentOutcome(AgentKind.ABSENT, target=TARGET), [f"  no agent at {TARGET}"]),
+    (AgentOutcome(AgentKind.REMOVED, target=TARGET), [f"  removed {TARGET}"]),
+    (
+        AgentOutcome(AgentKind.PRESERVED_MODIFIED, target=TARGET),
+        [f"  preserved {TARGET} (locally modified)"],
+    ),
+]
+
+
+@pytest.mark.parametrize("outcome, expected", RENDER_CASES)
+def test_render_exact_lines(outcome, expected):
+    assert render(outcome) == expected
+
+
+def test_render_covers_every_kind_member():
+    """The table must exercise every Kind member so no branch goes unpinned."""
+    kind_enums = [
+        JsonMcpKind,
+        ClaudeHookKind,
+        ClaudeUserConfigKind,
+        LegacyKind,
+        CodexConfigKind,
+        CodexHookKind,
+        SkillKind,
+        AgentKind,
+    ]
+    covered = {outcome.kind for outcome, _ in RENDER_CASES if hasattr(outcome, "kind")}
+    for enum in kind_enums:
+        for member in enum:
+            assert member in covered, f"{enum.__name__}.{member.name} is not pinned"
+
+
+def test_render_rejects_unknown_outcome_type():
+    with pytest.raises(TypeError):
+        render(object())  # type: ignore[arg-type]
+
+
+# One malformed outcome per codec dispatch: a kind outside its enum must raise
+# from the inner match's ``case _`` arm, never fall through to a None echo.
+UNRENDERABLE = [
+    JsonMcpOutcome(object(), REPO, ".mcp.json"),  # type: ignore[arg-type]
+    ClaudeHookOutcome(object(), REPO),  # type: ignore[arg-type]
+    ClaudeUserConfigOutcome(object()),  # type: ignore[arg-type]
+    LegacyOutcome(object(), REPO),  # type: ignore[arg-type]
+    CodexConfigOutcome(object(), CFG),  # type: ignore[arg-type]
+    CodexHookOutcome(object(), REPO),  # type: ignore[arg-type]
+    SkillOutcome(object()),  # type: ignore[arg-type]
+    AgentOutcome(object()),  # type: ignore[arg-type]
+]
+
+
+@pytest.mark.parametrize("outcome", UNRENDERABLE)
+def test_render_unknown_kind_raises(outcome):
+    with pytest.raises(TypeError):
+        render(outcome)

--- a/packages/nauro/tests/test_setup.py
+++ b/packages/nauro/tests/test_setup.py
@@ -413,6 +413,94 @@ class TestMalformedConfigGuards:
         (tmp_path / ".mcp.json").write_text('{"mcpServers": null}')
         assert recorded_mcp_commands(tmp_path) == []
 
+    def test_add_wires_nauro_alongside_malformed_sibling_entry(self, tmp_path: Path):
+        """A malformed sibling server (not Nauro's) must not block wiring; the
+        container is a valid object, so add wires nauro and preserves the
+        sibling byte-for-byte."""
+        (tmp_path / ".mcp.json").write_text(json.dumps({"mcpServers": {"other": "not-a-dict"}}))
+        line = _configure_mcp(tmp_path, remove=False)
+        assert line.kind is JsonMcpKind.WROTE
+        config = json.loads((tmp_path / ".mcp.json").read_text())
+        assert config["mcpServers"]["other"] == "not-a-dict"
+        assert "nauro" in config["mcpServers"]
+
+    def test_remove_deletes_nauro_beside_malformed_sibling_entry(self, tmp_path: Path):
+        """Remove strips nauro and leaves the malformed sibling in place — the
+        message must match the file state, never claim nauro survived."""
+        (tmp_path / ".mcp.json").write_text(
+            json.dumps({"mcpServers": {"other": "not-a-dict", "nauro": {"command": "/x"}}})
+        )
+        line = _configure_mcp(tmp_path, remove=True)
+        assert line.kind is JsonMcpKind.REMOVED
+        config = json.loads((tmp_path / ".mcp.json").read_text())
+        assert "nauro" not in config["mcpServers"]
+        assert config["mcpServers"]["other"] == "not-a-dict"
+
+    def test_recorded_mcp_commands_counts_nauro_beside_malformed_sibling(self, tmp_path: Path):
+        """The status inspector still reports a wired repo when an unrelated
+        sibling entry is off-shape."""
+        (tmp_path / ".mcp.json").write_text(
+            json.dumps({"mcpServers": {"other": "not-a-dict", "nauro": {"command": "/bin/nauro"}}})
+        )
+        assert recorded_mcp_commands(tmp_path) == ["/bin/nauro"]
+
+    def test_recorded_mcp_commands_malformed_nauro_entry_counts_as_wired(self, tmp_path: Path):
+        """A non-object nauro entry counts as wired with nothing to probe."""
+        (tmp_path / ".mcp.json").write_text(json.dumps({"mcpServers": {"nauro": "not-a-dict"}}))
+        assert recorded_mcp_commands(tmp_path) == [None]
+
+    def test_recorded_mcp_commands_reads_command_despite_malformed_args(self, tmp_path: Path):
+        """The inspector reads only the command; a malformed ``args`` on the
+        nauro entry must not suppress a usable command (status still probes it)."""
+        (tmp_path / ".mcp.json").write_text(
+            json.dumps(
+                {"mcpServers": {"nauro": {"command": "/usr/local/bin/nauro", "args": "serve"}}}
+            )
+        )
+        assert recorded_mcp_commands(tmp_path) == ["/usr/local/bin/nauro"]
+
+    def test_add_overwrites_nauro_entry_with_malformed_args(self, tmp_path: Path):
+        """The add path never reads the existing entry's args, so a malformed
+        ``args`` cannot block the write; nauro's entry is overwritten with the
+        canonical command and args."""
+        (tmp_path / ".mcp.json").write_text(
+            json.dumps({"mcpServers": {"nauro": {"command": "/old", "args": "serve"}}})
+        )
+        line = _configure_mcp(tmp_path, remove=False)
+        assert line.kind is JsonMcpKind.WROTE
+        config = json.loads((tmp_path / ".mcp.json").read_text())
+        assert config["mcpServers"]["nauro"]["args"] == ["serve", "--stdio"]
+
+    def test_unrelated_snake_case_mcp_servers_key_is_ignored(self, tmp_path: Path):
+        """A top-level ``mcp_servers`` (snake_case) is unrelated to the
+        camelCase ``mcpServers`` this format uses. Add ignores it, wires nauro
+        under the real key, and never mutates the user's key."""
+        (tmp_path / ".mcp.json").write_text(
+            json.dumps({"mcp_servers": {"nauro": {"command": "USER"}}})
+        )
+        line = _configure_mcp(tmp_path, remove=False)
+        assert line.kind is JsonMcpKind.WROTE
+        config = json.loads((tmp_path / ".mcp.json").read_text())
+        assert config["mcp_servers"] == {"nauro": {"command": "USER"}}
+        assert "nauro" in config["mcpServers"]
+
+    def test_unrelated_snake_case_mcp_servers_key_remove_is_noop(self, tmp_path: Path):
+        """Remove must not read the snake_case key as Nauro's map (a KeyError
+        trap): with no real ``mcpServers``, there is nothing to remove."""
+        original = json.dumps({"mcp_servers": {"nauro": {"command": "USER"}}})
+        (tmp_path / ".mcp.json").write_text(original)
+        line = _configure_mcp(tmp_path, remove=True)
+        assert line.kind is JsonMcpKind.NOTHING_TO_REMOVE
+        assert (tmp_path / ".mcp.json").read_text() == original
+
+    def test_unrelated_snake_case_mcp_servers_key_reports_unwired(self, tmp_path: Path):
+        """The inspector must not report false wiring from an unrelated
+        snake_case key."""
+        (tmp_path / ".mcp.json").write_text(
+            json.dumps({"mcp_servers": {"nauro": {"command": "USER"}}})
+        )
+        assert recorded_mcp_commands(tmp_path) == []
+
     def test_codex_non_table_mcp_servers_is_skipped(self, tmp_path: Path):
         cfg = tmp_path / "config.toml"
         cfg.write_text('mcp_servers = "oops"\n')

--- a/packages/nauro/tests/test_setup.py
+++ b/packages/nauro/tests/test_setup.py
@@ -8,8 +8,9 @@ import pytest
 from typer.testing import CliRunner
 
 from nauro.cli.integrations.codex_config import _configure_codex
-from nauro.cli.integrations.json_mcp import _configure_mcp
+from nauro.cli.integrations.json_mcp import _configure_mcp, recorded_mcp_commands
 from nauro.cli.integrations.legacy import CLAUDE_MD_END, CLAUDE_MD_START
+from nauro.cli.integrations.outcomes import CodexConfigKind, JsonMcpKind
 from nauro.cli.main import app
 from nauro.store.registry import register_project, register_project_v2
 from nauro.store.repo_config import save_repo_config
@@ -49,7 +50,7 @@ class TestMCPConfigDirectWrite:
         entry = config["mcpServers"]["nauro"]
         assert entry["args"] == ["serve", "--stdio"]
         assert isinstance(entry["command"], str) and entry["command"]
-        assert "wrote nauro to .mcp.json" in result
+        assert result.kind is JsonMcpKind.WROTE
 
     def test_add_preserves_existing_servers(self, tmp_path: Path):
         """Existing servers in `.mcp.json` are preserved when we add nauro."""
@@ -63,7 +64,7 @@ class TestMCPConfigDirectWrite:
         config = json.loads((repo / ".mcp.json").read_text())
         assert config["mcpServers"]["other"] == existing["mcpServers"]["other"]
         assert "nauro" in config["mcpServers"]
-        assert "wrote nauro to .mcp.json" in result
+        assert result.kind is JsonMcpKind.WROTE
 
     def test_add_overwrites_stale_nauro_entry(self, tmp_path: Path):
         """A pre-existing `nauro` entry is overwritten with the current command path."""
@@ -87,7 +88,7 @@ class TestMCPConfigDirectWrite:
 
         result = _configure_mcp(repo, remove=False)
 
-        assert "could not parse .mcp.json" in result
+        assert result.kind is JsonMcpKind.PARSE_ERROR
         assert (repo / ".mcp.json").read_text() == "{not json"
 
     def test_add_surfaces_invalid_utf8_without_clobbering(self, tmp_path: Path):
@@ -100,7 +101,7 @@ class TestMCPConfigDirectWrite:
 
         result = _configure_mcp(repo, remove=False)
 
-        assert "could not parse .mcp.json" in result
+        assert result.kind is JsonMcpKind.PARSE_ERROR
         assert (repo / ".mcp.json").read_bytes() == raw
 
     def test_add_round_trips_non_ascii_content_as_utf8(self, tmp_path: Path):
@@ -116,7 +117,7 @@ class TestMCPConfigDirectWrite:
 
         result = _configure_mcp(repo, remove=False)
 
-        assert "wrote nauro to .mcp.json" in result
+        assert result.kind is JsonMcpKind.WROTE
         data = json.loads((repo / ".mcp.json").read_bytes().decode("utf-8"))
         assert data["mcpServers"]["other"]["command"] == "café"
         assert "nauro" in data["mcpServers"]
@@ -131,7 +132,7 @@ class TestMCPConfigDirectWrite:
 
         result = _configure_mcp(repo, remove=True)
 
-        assert "removed nauro from .mcp.json" in result
+        assert result.kind is JsonMcpKind.REMOVED
         assert not (repo / ".mcp.json").exists()
 
     def test_remove_preserves_other_servers(self, tmp_path: Path):
@@ -151,7 +152,7 @@ class TestMCPConfigDirectWrite:
 
         result = _configure_mcp(repo, remove=True)
 
-        assert "removed nauro from .mcp.json" in result
+        assert result.kind is JsonMcpKind.REMOVED
         config = json.loads((repo / ".mcp.json").read_text())
         assert "nauro" not in config["mcpServers"]
         assert "other" in config["mcpServers"]
@@ -163,7 +164,7 @@ class TestMCPConfigDirectWrite:
 
         result = _configure_mcp(repo, remove=True)
 
-        assert "no nauro entry to remove" in result
+        assert result.kind is JsonMcpKind.NOTHING_TO_REMOVE
         assert not (repo / ".mcp.json").exists()
 
     def test_remove_skips_when_nauro_absent_from_mcp_json(self, tmp_path: Path):
@@ -175,7 +176,7 @@ class TestMCPConfigDirectWrite:
 
         result = _configure_mcp(repo, remove=True)
 
-        assert "no nauro entry to remove" in result
+        assert result.kind is JsonMcpKind.NOTHING_TO_REMOVE
         assert (repo / ".mcp.json").read_text() == original
 
     def test_remove_handles_malformed_mcp_json(self, tmp_path: Path):
@@ -186,7 +187,7 @@ class TestMCPConfigDirectWrite:
 
         result = _configure_mcp(repo, remove=True)
 
-        assert "could not parse .mcp.json" in result
+        assert result.kind is JsonMcpKind.PARSE_ERROR
 
     def test_setup_all_iterates_per_repo(self, tmp_path: Path, monkeypatch):
         """Multi-repo project: `setup all` writes `.mcp.json` once per repo."""
@@ -376,7 +377,7 @@ class TestMalformedConfigGuards:
     def test_json_top_level_array_is_skipped(self, tmp_path: Path):
         (tmp_path / ".mcp.json").write_text("[]")
         line = _configure_mcp(tmp_path, remove=False)
-        assert "not a JSON object" in line
+        assert line.kind is JsonMcpKind.NOT_JSON_OBJECT
         # Left untouched, not crashed or clobbered.
         assert (tmp_path / ".mcp.json").read_text().strip() == "[]"
 
@@ -384,20 +385,39 @@ class TestMalformedConfigGuards:
         original = '{"mcpServers": "oops"}'
         (tmp_path / ".mcp.json").write_text(original)
         line = _configure_mcp(tmp_path, remove=False)
-        assert "mcpServers" in line and "not a JSON object" in line
+        assert line.kind is JsonMcpKind.MCPSERVERS_NOT_OBJECT
         # The off-shape add path must not clobber the file.
         assert (tmp_path / ".mcp.json").read_text() == original
 
     def test_mcpservers_non_object_remove_is_noop(self, tmp_path: Path):
         (tmp_path / ".mcp.json").write_text('{"mcpServers": "oops"}')
         line = _configure_mcp(tmp_path, remove=True)
-        assert "no nauro entry to remove" in line
+        assert line.kind is JsonMcpKind.NOTHING_TO_REMOVE
+
+    def test_mcpservers_null_add_is_skipped(self, tmp_path: Path):
+        """An explicit JSON null mcpServers is a graceful shape-skip, not a crash."""
+        original = '{"mcpServers": null}'
+        (tmp_path / ".mcp.json").write_text(original)
+        line = _configure_mcp(tmp_path, remove=False)
+        assert line.kind is JsonMcpKind.MCPSERVERS_NOT_OBJECT
+        # The present-but-null container must not be mutated or clobbered.
+        assert (tmp_path / ".mcp.json").read_text() == original
+
+    def test_mcpservers_null_remove_is_noop(self, tmp_path: Path):
+        (tmp_path / ".mcp.json").write_text('{"mcpServers": null}')
+        line = _configure_mcp(tmp_path, remove=True)
+        assert line.kind is JsonMcpKind.NOTHING_TO_REMOVE
+
+    def test_recorded_mcp_commands_null_mcpservers_is_empty(self, tmp_path: Path):
+        """The status inspector treats a null mcpServers as unwired, never crashes."""
+        (tmp_path / ".mcp.json").write_text('{"mcpServers": null}')
+        assert recorded_mcp_commands(tmp_path) == []
 
     def test_codex_non_table_mcp_servers_is_skipped(self, tmp_path: Path):
         cfg = tmp_path / "config.toml"
         cfg.write_text('mcp_servers = "oops"\n')
         line = _configure_codex(remove=False, config_path=cfg)
-        assert "not a table" in line
+        assert line.kind is CodexConfigKind.MCPSERVERS_NOT_TABLE
         # Original content preserved.
         assert 'mcp_servers = "oops"' in cfg.read_text()
 
@@ -405,5 +425,5 @@ class TestMalformedConfigGuards:
         cfg = tmp_path / "config.toml"
         cfg.write_text('mcp_servers = "oops"\n')
         line = _configure_codex(remove=True, config_path=cfg)
-        assert "no nauro entry to remove" in line
+        assert line.kind is CodexConfigKind.NOTHING_TO_REMOVE
         assert 'mcp_servers = "oops"' in cfg.read_text()

--- a/packages/nauro/tests/test_setup_extended.py
+++ b/packages/nauro/tests/test_setup_extended.py
@@ -15,6 +15,12 @@ from nauro.cli.commands.setup import CHECK_HINT_LINE
 from nauro.cli.integrations.claude_user_config import _prune_redundant_user_scope_mcp
 from nauro.cli.integrations.codex_config import _configure_codex
 from nauro.cli.integrations.json_mcp import _configure_cursor_for_repo
+from nauro.cli.integrations.outcomes import (
+    ClaudeUserConfigKind,
+    CodexConfigKind,
+    JsonMcpKind,
+    SkillKind,
+)
 from nauro.cli.integrations.skills import materialize_skills_cursor_for_repo
 from nauro.cli.main import app
 from nauro.store.registry import register_project_v2
@@ -113,7 +119,7 @@ def test_configure_cursor_add_surfaces_parse_error_without_clobbering(tmp_path: 
 
     msg = _configure_cursor_for_repo(repo, remove=False)
 
-    assert "could not parse .cursor/mcp.json" in msg
+    assert msg.kind is JsonMcpKind.PARSE_ERROR
     assert (repo / ".cursor" / "mcp.json").read_text() == "{not json"
 
 
@@ -125,7 +131,7 @@ def test_configure_cursor_remove_surfaces_parse_error(tmp_path: Path):
 
     msg = _configure_cursor_for_repo(repo, remove=True)
 
-    assert "could not parse .cursor/mcp.json" in msg
+    assert msg.kind is JsonMcpKind.PARSE_ERROR
 
 
 @pytest.mark.skipif(os.name == "nt", reason="symlink creation requires extra Windows privileges")
@@ -140,8 +146,8 @@ def test_cursor_surfaces_refuse_symlinked_cursor_dir(tmp_path: Path):
     mcp_line = _configure_cursor_for_repo(repo, remove=False)
     skill_lines = materialize_skills_cursor_for_repo(repo, remove=False, with_skills=True)
 
-    assert "refused to modify" in mcp_line
-    assert skill_lines and all("refused to modify" in line for line in skill_lines)
+    assert mcp_line.kind is JsonMcpKind.REFUSED_SYMLINK
+    assert skill_lines and all(line.kind is SkillKind.REFUSED_SYMLINK for line in skill_lines)
     # Nothing written through the link; the link itself untouched.
     assert list(elsewhere.iterdir()) == []
     assert (repo / ".cursor").is_symlink()
@@ -156,7 +162,7 @@ def test_setup_codex_writes_config_toml(tmp_path: Path):
 
     msg = _configure_codex(remove=False, config_path=config_path)
 
-    assert "wrote nauro" in msg
+    assert msg.kind is CodexConfigKind.WROTE
     assert config_path.is_file()
     with config_path.open("rb") as f:
         data = tomllib.load(f)
@@ -169,7 +175,7 @@ def test_setup_codex_remove_clears_entry(tmp_path: Path):
 
     msg = _configure_codex(remove=True, config_path=config_path)
 
-    assert "removed nauro" in msg
+    assert msg.kind is CodexConfigKind.REMOVED
     with config_path.open("rb") as f:
         data = tomllib.load(f)
     assert "mcp_servers" not in data or "nauro" not in data.get("mcp_servers", {})
@@ -193,7 +199,7 @@ def test_setup_codex_no_op_when_remove_and_no_entry(tmp_path: Path):
     """`--remove` when no entry exists is idempotent and reports clearly."""
     config_path = tmp_path / ".codex" / "config.toml"
     msg = _configure_codex(remove=True, config_path=config_path)
-    assert "no nauro entry to remove" in msg
+    assert msg.kind is CodexConfigKind.NOTHING_TO_REMOVE
 
 
 def test_configure_codex_remove_does_not_resolve_command(tmp_path: Path, monkeypatch):
@@ -214,7 +220,7 @@ def test_configure_codex_remove_does_not_resolve_command(tmp_path: Path, monkeyp
 
     msg = _configure_codex(remove=True, config_path=config_path)
 
-    assert "removed nauro from" in msg
+    assert msg.kind is CodexConfigKind.REMOVED
 
 
 def test_configure_codex_add_surfaces_parse_error(tmp_path: Path):
@@ -226,8 +232,8 @@ def test_configure_codex_add_surfaces_parse_error(tmp_path: Path):
 
     msg = _configure_codex(remove=False, config_path=config_path)
 
-    assert "Codex: could not parse" in msg
-    assert str(config_path) in msg
+    assert msg.kind is CodexConfigKind.PARSE_ERROR_TOML
+    assert msg.config_path == config_path
     # File left untouched.
     assert config_path.read_text() == "this is not = valid [toml"
 
@@ -240,8 +246,8 @@ def test_configure_codex_remove_surfaces_parse_error(tmp_path: Path):
 
     msg = _configure_codex(remove=True, config_path=config_path)
 
-    assert "Codex: could not parse" in msg
-    assert str(config_path) in msg
+    assert msg.kind is CodexConfigKind.PARSE_ERROR_TOML
+    assert msg.config_path == config_path
 
 
 # ─── claude-code regression ──────────────────────────────────────────────────
@@ -380,8 +386,9 @@ def test_remove_skill_file_does_not_walk_above_base(tmp_path: Path):
     target = skill_dir / "SKILL.md"
     target.write_text("body")
 
-    _remove_skill_file(target, stop_above=base)
+    outcome = _remove_skill_file(target, stop_above=base)
 
+    assert outcome.kind is SkillKind.REMOVED
     assert not target.exists()
     assert not skill_dir.exists()  # subdir was empty → pruned
     assert base.is_dir()  # base preserved
@@ -401,8 +408,9 @@ def test_remove_skill_file_preserves_sibling_skills(tmp_path: Path):
     other_skill.parent.mkdir(parents=True)
     other_skill.write_text("user-other")
 
-    _remove_skill_file(nauro_skill, stop_above=base)
+    outcome = _remove_skill_file(nauro_skill, stop_above=base)
 
+    assert outcome.kind is SkillKind.REMOVED
     assert not nauro_skill.exists()
     assert not nauro_skill.parent.exists()  # nauro subdir pruned
     assert other_skill.exists()  # other skill untouched
@@ -711,7 +719,7 @@ def test_prune_removes_http_nauro_entry(tmp_path: Path, monkeypatch):
     )
 
     msg = _prune_redundant_user_scope_mcp()
-    assert msg is not None and "~/.claude.json" in msg
+    assert msg is not None and msg.kind is ClaudeUserConfigKind.PRUNED
 
     config = json.loads(path.read_text())
     assert "nauro" not in config["mcpServers"]
@@ -757,8 +765,7 @@ def test_prune_reports_invalid_utf8_claude_json(tmp_path: Path, monkeypatch):
     msg = _prune_redundant_user_scope_mcp()
 
     assert msg is not None
-    assert "~/.claude.json" in msg
-    assert "UTF-8" in msg
+    assert msg.kind is ClaudeUserConfigKind.INVALID_UTF8
     assert (tmp_path / ".claude.json").read_bytes() == raw
 
 

--- a/packages/nauro/tests/test_setup_hooks.py
+++ b/packages/nauro/tests/test_setup_hooks.py
@@ -23,6 +23,12 @@ from nauro.cli.integrations.claude_hooks import (
 )
 from nauro.cli.integrations.codex_hooks import materialize_hooks_codex
 from nauro.cli.integrations.orchestrator import setup_all_surfaces
+from nauro.cli.integrations.outcomes import (
+    ClaudeHookKind,
+    ClaudeHookOutcome,
+    CodexHookKind,
+    HandlerErrorOutcome,
+)
 from nauro.cli.main import app
 from tests.conftest import register_v2_repo
 
@@ -69,7 +75,7 @@ def test_materialize_writes_correct_structure(tmp_path: Path):
     repo = tmp_path / "repo"
     repo.mkdir()
     line = materialize_hooks_claude_code(repo, remove=False)
-    assert "wrote nauro hook" in line
+    assert line.kind is ClaudeHookKind.WROTE
 
     settings = json.loads(_settings(repo).read_text())
     entries = _nauro_entries(settings)
@@ -92,7 +98,7 @@ def test_materialize_is_idempotent(tmp_path: Path):
     repo.mkdir()
     materialize_hooks_claude_code(repo, remove=False)
     line = materialize_hooks_claude_code(repo, remove=False)
-    assert "already present" in line
+    assert line.kind is ClaudeHookKind.ALREADY_PRESENT
 
     settings = json.loads(_settings(repo).read_text())
     assert len(_nauro_entries(settings)) == 1
@@ -110,8 +116,34 @@ def test_materialize_surfaces_invalid_utf8_settings(tmp_path: Path):
 
     line = materialize_hooks_claude_code(repo, remove=False)
 
-    assert "could not parse .claude/settings.json" in line
+    assert line.kind is ClaudeHookKind.PARSE_ERROR
     assert settings_path.read_bytes() == raw
+
+
+def test_materialize_null_hooks_add_is_skipped(tmp_path: Path):
+    """An explicit JSON null hooks container is a graceful shape-skip, not a crash."""
+    repo = tmp_path / "repo"
+    settings_path = _settings(repo)
+    settings_path.parent.mkdir(parents=True)
+    original = '{"hooks": null}'
+    settings_path.write_text(original, encoding="utf-8")
+
+    line = materialize_hooks_claude_code(repo, remove=False)
+
+    assert line.kind is ClaudeHookKind.HOOKS_NOT_OBJECT
+    # The present-but-null container must not be mutated or clobbered.
+    assert settings_path.read_text(encoding="utf-8") == original
+
+
+def test_materialize_null_hooks_remove_is_noop(tmp_path: Path):
+    repo = tmp_path / "repo"
+    settings_path = _settings(repo)
+    settings_path.parent.mkdir(parents=True)
+    settings_path.write_text('{"hooks": null}', encoding="utf-8")
+
+    line = materialize_hooks_claude_code(repo, remove=True)
+
+    assert line.kind is ClaudeHookKind.NOTHING_TO_REMOVE
 
 
 # ── direct helper: remove path ─────────────────────────────────────────────────
@@ -140,7 +172,7 @@ def test_remove_strips_only_nauro_entry(tmp_path: Path):
     assert len(_nauro_entries(after_add)) == 1
 
     line = materialize_hooks_claude_code(repo, remove=True)
-    assert "removed nauro hook" in line
+    assert line.kind is ClaudeHookKind.REMOVED
 
     after_remove = json.loads(settings_path.read_text())
     assert _nauro_entries(after_remove) == []
@@ -155,7 +187,7 @@ def test_remove_when_absent_is_noop(tmp_path: Path):
     repo = tmp_path / "repo"
     repo.mkdir()
     line = materialize_hooks_claude_code(repo, remove=True)
-    assert "no nauro hook to remove" in line
+    assert line.kind is ClaudeHookKind.NOTHING_TO_REMOVE
 
 
 def test_remove_deletes_empty_settings_file(tmp_path: Path):
@@ -198,8 +230,8 @@ def test_claude_hook_add_and_remove_refuse_symlinked_settings(tmp_path: Path):
     add_line = materialize_hooks_claude_code(repo, remove=False)
     remove_line = materialize_hooks_claude_code(repo, remove=True)
 
-    assert "refused to modify" in add_line
-    assert "refused to modify" in remove_line
+    assert add_line.kind is ClaudeHookKind.REFUSED_SYMLINK
+    assert remove_line.kind is ClaudeHookKind.REFUSED_SYMLINK
     assert outside.read_text() == "{}"
     assert (repo / ".claude" / "settings.json").is_symlink()
 
@@ -215,8 +247,8 @@ def test_codex_hooks_refuse_symlinked_hooks_json(tmp_path: Path):
     add_line = materialize_hooks_codex(repo, remove=False)
     remove_line = materialize_hooks_codex(repo, remove=True)
 
-    assert "refused to modify" in add_line
-    assert "refused to modify" in remove_line
+    assert add_line.kind is CodexHookKind.REFUSED_SYMLINK
+    assert remove_line.kind is CodexHookKind.REFUSED_SYMLINK
     assert outside.read_text() == "{}"
     assert (repo / ".codex" / "hooks.json").is_symlink()
 
@@ -253,7 +285,7 @@ def test_materialize_codex_writes_both_lifecycle_events(tmp_path: Path, monkeypa
     nauro_command._find_nauro_codex_hook_command.cache_clear()
     line = materialize_hooks_codex(repo, remove=False)
 
-    assert "wrote nauro hooks" in line
+    assert line.kind is CodexHookKind.WROTE
     config = json.loads(_codex_hooks(repo).read_text())
     for event in _CODEX_HOOK_EVENTS:
         entries = _codex_nauro_entries(config, event)
@@ -278,8 +310,10 @@ def test_materialize_codex_warns_for_untracked_hooks_file(tmp_path: Path):
 
     line = materialize_hooks_codex(repo, remove=False)
 
-    assert ".codex/hooks.json is untracked and not git-ignored" in line
-    assert "local Nauro wiring" in line
+    assert line.kind is CodexHookKind.WROTE
+    warnings = "\n".join(line.git_warnings)
+    assert ".codex/hooks.json is untracked and not git-ignored" in warnings
+    assert "local Nauro wiring" in warnings
 
 
 def test_materialize_codex_uses_current_install_when_durable_command_is_too_old(
@@ -304,7 +338,7 @@ def test_materialize_codex_uses_current_install_when_durable_command_is_too_old(
 
     line = materialize_hooks_codex(repo, remove=False)
 
-    assert "wrote nauro hooks" in line
+    assert line.kind is CodexHookKind.WROTE
     config = json.loads(_codex_hooks(repo).read_text())
     entry = _codex_nauro_entries(config, "SessionStart")[0]
     assert "/repo/.venv/bin/nauro" in entry["command"]
@@ -326,7 +360,7 @@ def test_materialize_codex_skips_when_no_compatible_command(tmp_path: Path, monk
 
     line = materialize_hooks_codex(repo, remove=False)
 
-    assert line == f"  {repo}: Codex hook wiring skipped; no compatible Nauro command"
+    assert line.kind is CodexHookKind.NO_COMMAND
     assert not _codex_hooks(repo).exists()
 
 
@@ -347,7 +381,8 @@ def test_materialize_codex_validates_config_before_resolving_command(tmp_path: P
 
     line = materialize_hooks_codex(repo, remove=False)
 
-    assert line == (f"  {repo}: hooks key in .codex/hooks.json is not a JSON object, skipped")
+    assert line.kind is CodexHookKind.CONFIG_ERROR
+    assert line.detail == "hooks key in .codex/hooks.json is not a JSON object, skipped"
 
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX command guard")
@@ -438,7 +473,7 @@ def test_materialize_codex_is_idempotent_and_preserves_user_hooks(tmp_path: Path
     monkeypatch.setattr(Path, "write_text", count_hook_writes)
     line = materialize_hooks_codex(repo, remove=False)
 
-    assert "already present" in line
+    assert line.kind is CodexHookKind.ALREADY_PRESENT
     assert writes == 0
     config = json.loads(hooks_path.read_text())
     for event in _CODEX_HOOK_EVENTS:
@@ -483,7 +518,7 @@ def test_materialize_codex_refreshes_recorded_command(tmp_path: Path, monkeypatc
 
     line = materialize_hooks_codex(repo, remove=False)
 
-    assert "wrote nauro hooks" in line
+    assert line.kind is CodexHookKind.WROTE
     config = json.loads(_codex_hooks(repo).read_text())
     for event in _CODEX_HOOK_EVENTS:
         entries = _codex_nauro_entries(config, event)
@@ -510,7 +545,7 @@ def test_remove_codex_strips_only_nauro_entries(tmp_path: Path):
 
     line = materialize_hooks_codex(repo, remove=True)
 
-    assert "removed nauro hooks" in line
+    assert line.kind is CodexHookKind.REMOVED
     config = json.loads(hooks_path.read_text())
     assert config["hooks"] == {
         "SessionStart": [{"hooks": [{"type": "command", "command": "load-notes"}]}]
@@ -681,7 +716,9 @@ def test_setup_codex_remove_cleans_orphaned_repo_hooks(tmp_path: Path, monkeypat
 def test_setup_all_with_hooks_wires_claude_code_and_codex(tmp_path: Path):
     repo, _store = _make_project(tmp_path)
     lines = setup_all_surfaces([repo], with_hooks=True)
-    assert any("nauro hook" in line.text for line in lines)
+    assert any(
+        isinstance(line, ClaudeHookOutcome) and line.kind is ClaudeHookKind.WROTE for line in lines
+    )
 
     settings = json.loads(_settings(repo).read_text())
     assert len(_nauro_entries(settings)) == 1
@@ -716,7 +753,10 @@ def test_setup_all_hook_failure_does_not_abort(tmp_path: Path, monkeypatch):
 
     # Must not raise; the rest of setup still produces its lines.
     lines = setup_all_surfaces([repo], with_hooks=True)
-    assert any("hook" in line.text and "error" in line.text for line in lines)
+    assert any(
+        isinstance(line, HandlerErrorOutcome) and "hook" in line.message and "error" in line.message
+        for line in lines
+    )
     # MCP wiring still happened despite the hook failure.
     assert (repo / ".mcp.json").is_file()
 

--- a/packages/nauro/tests/test_setup_hooks.py
+++ b/packages/nauro/tests/test_setup_hooks.py
@@ -146,6 +146,105 @@ def test_materialize_null_hooks_remove_is_noop(tmp_path: Path):
     assert line.kind is ClaudeHookKind.NOTHING_TO_REMOVE
 
 
+def test_materialize_scalar_hooks_container_is_skipped(tmp_path: Path):
+    """A scalar hooks container is HOOKS_NOT_OBJECT, not a crash or a clobber."""
+    repo = tmp_path / "repo"
+    settings_path = _settings(repo)
+    settings_path.parent.mkdir(parents=True)
+    original = '{"hooks": 5}'
+    settings_path.write_text(original, encoding="utf-8")
+
+    line = materialize_hooks_claude_code(repo, remove=False)
+
+    assert line.kind is ClaudeHookKind.HOOKS_NOT_OBJECT
+    assert settings_path.read_text(encoding="utf-8") == original
+
+
+def test_materialize_add_ignores_malformed_unrelated_event(tmp_path: Path):
+    """A malformed hook event Nauro does not own (e.g. PostToolUse) must not
+    block the add: nauro is written under UserPromptSubmit and the unrelated
+    event is left byte-identical."""
+    repo = tmp_path / "repo"
+    settings_path = _settings(repo)
+    settings_path.parent.mkdir(parents=True)
+    settings_path.write_text(json.dumps({"hooks": {"PostToolUse": "oops"}}), encoding="utf-8")
+
+    line = materialize_hooks_claude_code(repo, remove=False)
+
+    assert line.kind is ClaudeHookKind.WROTE
+    settings = json.loads(settings_path.read_text())
+    assert settings["hooks"]["PostToolUse"] == "oops"
+    assert len(_nauro_entries(settings)) == 1
+
+
+def test_materialize_add_skips_non_dict_matcher_in_event_array(tmp_path: Path):
+    """A non-dict matcher already in UserPromptSubmit is skipped during the
+    idempotency scan, and the nauro matcher is appended, exactly as main did."""
+    repo = tmp_path / "repo"
+    settings_path = _settings(repo)
+    settings_path.parent.mkdir(parents=True)
+    settings_path.write_text(
+        json.dumps({"hooks": {HOOK_EVENT_NAME: ["garbage-string"]}}), encoding="utf-8"
+    )
+
+    line = materialize_hooks_claude_code(repo, remove=False)
+
+    assert line.kind is ClaudeHookKind.WROTE
+    settings = json.loads(settings_path.read_text())
+    matchers = settings["hooks"][HOOK_EVENT_NAME]
+    # The non-dict matcher is preserved and the nauro matcher is appended once.
+    assert "garbage-string" in matchers
+    nauro_matchers = [
+        m
+        for m in matchers
+        if isinstance(m, dict)
+        and any(HOOK_SUBCOMMAND in e.get("command", "") for e in m.get("hooks", []))
+    ]
+    assert len(nauro_matchers) == 1
+
+
+def test_materialize_non_array_user_prompt_submit_is_skipped(tmp_path: Path):
+    """A non-array UserPromptSubmit value is EVENT_NOT_ARRAY; after re-scoping,
+    that skip fires only for the event Nauro installs into."""
+    repo = tmp_path / "repo"
+    settings_path = _settings(repo)
+    settings_path.parent.mkdir(parents=True)
+    original = json.dumps({"hooks": {HOOK_EVENT_NAME: "oops"}})
+    settings_path.write_text(original, encoding="utf-8")
+
+    line = materialize_hooks_claude_code(repo, remove=False)
+
+    assert line.kind is ClaudeHookKind.EVENT_NOT_ARRAY
+    assert settings_path.read_text(encoding="utf-8") == original
+
+
+def test_materialize_null_user_prompt_submit_add_is_skipped(tmp_path: Path):
+    """An explicit JSON null UserPromptSubmit is a present-but-non-array value:
+    it must route to EVENT_NOT_ARRAY, never append to None and crash."""
+    repo = tmp_path / "repo"
+    settings_path = _settings(repo)
+    settings_path.parent.mkdir(parents=True)
+    original = json.dumps({"hooks": {HOOK_EVENT_NAME: None}})
+    settings_path.write_text(original, encoding="utf-8")
+
+    line = materialize_hooks_claude_code(repo, remove=False)
+
+    assert line.kind is ClaudeHookKind.EVENT_NOT_ARRAY
+    # The present-but-null event must not be mutated or clobbered.
+    assert settings_path.read_text(encoding="utf-8") == original
+
+
+def test_materialize_null_user_prompt_submit_remove_is_noop(tmp_path: Path):
+    repo = tmp_path / "repo"
+    settings_path = _settings(repo)
+    settings_path.parent.mkdir(parents=True)
+    settings_path.write_text(json.dumps({"hooks": {HOOK_EVENT_NAME: None}}), encoding="utf-8")
+
+    line = materialize_hooks_claude_code(repo, remove=True)
+
+    assert line.kind is ClaudeHookKind.NOTHING_TO_REMOVE
+
+
 # ── direct helper: remove path ─────────────────────────────────────────────────
 
 

--- a/packages/nauro/tests/test_setup_user_write_safety.py
+++ b/packages/nauro/tests/test_setup_user_write_safety.py
@@ -352,6 +352,21 @@ def test_prune_skips_symlinked_claude_json(tmp_path: Path, monkeypatch):
     assert real.read_text(encoding="utf-8") == raw
 
 
+@pytest.mark.parametrize("body", ["null", "[1, 2, 3]", "42"])
+def test_prune_skips_non_object_claude_json_without_crash(tmp_path: Path, monkeypatch, body: str):
+    """A ~/.claude.json whose top level is a JSON null, array, or scalar must
+    degrade to a graceful skip, never a traceback, and never a write."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    config_path = tmp_path / ".claude.json"
+    config_path.write_text(body, encoding="utf-8")
+
+    msg = _prune_redundant_user_scope_mcp()
+
+    assert msg is not None
+    assert msg.kind is ClaudeUserConfigKind.NOT_JSON_OBJECT
+    assert config_path.read_text(encoding="utf-8") == body
+
+
 @symlinks_required
 def test_skill_add_refuses_symlinked_target(tmp_path: Path):
     real = tmp_path / "real-skill.md"

--- a/packages/nauro/tests/test_setup_user_write_safety.py
+++ b/packages/nauro/tests/test_setup_user_write_safety.py
@@ -24,6 +24,12 @@ import tomlkit
 from nauro.cli.integrations.agents import materialize_agents
 from nauro.cli.integrations.claude_user_config import _prune_redundant_user_scope_mcp
 from nauro.cli.integrations.codex_config import _configure_codex
+from nauro.cli.integrations.outcomes import (
+    AgentKind,
+    ClaudeUserConfigKind,
+    CodexConfigKind,
+    SkillKind,
+)
 from nauro.cli.integrations.skills import _materialize_skill_file, _remove_skill_file
 from nauro.cli.nauro_command import _find_nauro_command
 
@@ -68,7 +74,7 @@ def test_codex_add_preserves_commented_config_outside_nauro_entry(tmp_path: Path
 
     msg = _configure_codex(remove=False, config_path=config_path)
 
-    assert "wrote nauro" in msg
+    assert msg.kind is CodexConfigKind.WROTE
     text = config_path.read_text(encoding="utf-8")
     # Everything before the appended entry is byte-identical to the seed.
     assert text.startswith(COMMENTED_SEED)
@@ -84,7 +90,7 @@ def test_codex_add_then_remove_is_byte_identical_with_existing_table(tmp_path: P
     _configure_codex(remove=False, config_path=config_path)
     msg = _configure_codex(remove=True, config_path=config_path)
 
-    assert "removed nauro" in msg
+    assert msg.kind is CodexConfigKind.REMOVED
     assert config_path.read_bytes() == COMMENTED_SEED.encode("utf-8")
 
 
@@ -108,7 +114,8 @@ def test_codex_second_identical_add_skips_render_and_write(tmp_path: Path):
 
     msg = _configure_codex(remove=False, config_path=config_path)
 
-    assert msg == f"Codex: nauro already configured in {config_path}"
+    assert msg.kind is CodexConfigKind.ALREADY_CONFIGURED
+    assert msg.config_path == config_path
     assert config_path.read_bytes() == before
     assert config_path.stat().st_mtime == MTIME_SENTINEL
 
@@ -119,7 +126,7 @@ def test_codex_remove_without_entry_leaves_commented_file_untouched(tmp_path: Pa
 
     msg = _configure_codex(remove=True, config_path=config_path)
 
-    assert "no nauro entry to remove" in msg
+    assert msg.kind is CodexConfigKind.NOTHING_TO_REMOVE
     assert config_path.read_bytes() == COMMENTED_SEED.encode("utf-8")
     assert config_path.stat().st_mtime == MTIME_SENTINEL
 
@@ -132,7 +139,8 @@ def test_codex_add_refuses_invalid_utf8_without_writing(tmp_path: Path):
 
     msg = _configure_codex(remove=False, config_path=config_path)
 
-    assert msg == f"Codex: could not parse {config_path} - not valid UTF-8"
+    assert msg.kind is CodexConfigKind.PARSE_ERROR_UTF8
+    assert msg.config_path == config_path
     assert config_path.read_bytes() == raw
 
 
@@ -144,7 +152,8 @@ def test_codex_remove_refuses_invalid_utf8_without_writing(tmp_path: Path):
 
     msg = _configure_codex(remove=True, config_path=config_path)
 
-    assert msg == f"Codex: could not parse {config_path} - not valid UTF-8"
+    assert msg.kind is CodexConfigKind.PARSE_ERROR_UTF8
+    assert msg.config_path == config_path
     assert config_path.read_bytes() == raw
 
 
@@ -153,7 +162,7 @@ def test_codex_new_entry_renders_as_standard_table_not_inline(tmp_path: Path):
 
     msg = _configure_codex(remove=False, config_path=config_path)
 
-    assert "wrote nauro" in msg
+    assert msg.kind is CodexConfigKind.WROTE
     text = config_path.read_text(encoding="utf-8")
     assert "[mcp_servers.nauro]" in text
     assert "nauro = {" not in text
@@ -175,7 +184,7 @@ def test_codex_command_drift_rewrite_preserves_user_keys_and_comments(tmp_path: 
 
     msg = _configure_codex(remove=False, config_path=config_path)
 
-    assert "wrote nauro" in msg
+    assert msg.kind is CodexConfigKind.WROTE
     text = config_path.read_text(encoding="utf-8")
     assert "# tuned for my machine" in text
     entry = tomllib.loads(text)["mcp_servers"]["nauro"]
@@ -195,7 +204,7 @@ def test_codex_command_only_drift_leaves_matching_args_bytes_untouched(tmp_path:
 
     msg = _configure_codex(remove=False, config_path=config_path)
 
-    assert "wrote nauro" in msg
+    assert msg.kind is CodexConfigKind.WROTE
     text = config_path.read_text(encoding="utf-8")
     assert args_block in text
     entry = tomlkit.parse(text)["mcp_servers"]["nauro"]
@@ -217,7 +226,7 @@ def test_codex_add_into_empty_inline_mcp_servers(tmp_path: Path):
 
     msg = _configure_codex(remove=False, config_path=config_path)
 
-    assert "wrote nauro" in msg
+    assert msg.kind is CodexConfigKind.WROTE
     text = config_path.read_text(encoding="utf-8")
     reparsed = tomlkit.parse(text)
     assert reparsed["mcp_servers"]["nauro"]["command"] == _find_nauro_command()
@@ -233,7 +242,7 @@ def test_codex_add_into_inline_mcp_servers_preserves_sibling(tmp_path: Path):
 
     msg = _configure_codex(remove=False, config_path=config_path)
 
-    assert "wrote nauro" in msg
+    assert msg.kind is CodexConfigKind.WROTE
     text = config_path.read_text(encoding="utf-8")
     assert '{ command = "c", args = [] }' in text
     reparsed = tomlkit.parse(text)
@@ -248,7 +257,7 @@ def test_codex_add_replaces_non_table_nauro_inside_inline_parent(tmp_path: Path)
 
     msg = _configure_codex(remove=False, config_path=config_path)
 
-    assert "wrote nauro" in msg
+    assert msg.kind is CodexConfigKind.WROTE
     text = config_path.read_text(encoding="utf-8")
     reparsed = tomlkit.parse(text)
     assert reparsed["mcp_servers"]["nauro"]["command"] == _find_nauro_command()
@@ -263,7 +272,7 @@ def test_codex_add_then_remove_on_inline_mcp_servers_round_trips(tmp_path: Path)
     _configure_codex(remove=False, config_path=config_path)
     msg = _configure_codex(remove=True, config_path=config_path)
 
-    assert "removed nauro" in msg
+    assert msg.kind is CodexConfigKind.REMOVED
     text = config_path.read_text(encoding="utf-8")
     reparsed = tomlkit.parse(text)
     assert "nauro" not in reparsed["mcp_servers"]
@@ -285,8 +294,8 @@ def test_codex_add_refuses_symlinked_config(tmp_path: Path):
 
     msg = _configure_codex(remove=False, config_path=link)
 
-    assert msg.startswith(f"Codex: refused to modify {link}")
-    assert "symlink" in msg
+    assert msg.kind is CodexConfigKind.REFUSED_SYMLINK
+    assert msg.refusal.target == link
     assert link.is_symlink()
     assert real.read_text(encoding="utf-8") == seed
 
@@ -302,7 +311,8 @@ def test_codex_remove_refuses_symlinked_config(tmp_path: Path):
 
     msg = _configure_codex(remove=True, config_path=link)
 
-    assert msg.startswith(f"Codex: refused to modify {link}")
+    assert msg.kind is CodexConfigKind.REFUSED_SYMLINK
+    assert msg.refusal.target == link
     assert link.is_symlink()
     assert real.read_text(encoding="utf-8") == seed
 
@@ -319,7 +329,7 @@ def test_codex_writes_through_symlinked_parent_dir(tmp_path: Path):
 
     msg = _configure_codex(remove=False, config_path=config_path)
 
-    assert "wrote nauro" in msg
+    assert msg.kind is CodexConfigKind.WROTE
     assert codex_dir.is_symlink()
     with (real_dir / "config.toml").open("rb") as f:
         data = tomllib.load(f)
@@ -337,7 +347,7 @@ def test_prune_skips_symlinked_claude_json(tmp_path: Path, monkeypatch):
     msg = _prune_redundant_user_scope_mcp()
 
     assert msg is not None
-    assert msg.startswith("  skipped user-scope prune: refused to modify")
+    assert msg.kind is ClaudeUserConfigKind.REFUSED_SYMLINK
     assert (tmp_path / ".claude.json").is_symlink()
     assert real.read_text(encoding="utf-8") == raw
 
@@ -352,7 +362,7 @@ def test_skill_add_refuses_symlinked_target(tmp_path: Path):
 
     line = _materialize_skill_file(target, "new body")
 
-    assert "refused to modify" in line
+    assert line.kind is SkillKind.REFUSED_SYMLINK
     assert target.is_symlink()
     assert real.read_text(encoding="utf-8") == "original"
 
@@ -368,7 +378,7 @@ def test_skill_remove_refuses_symlinked_target(tmp_path: Path):
 
     line = _remove_skill_file(target, stop_above=base)
 
-    assert "refused to modify" in line
+    assert line.kind is SkillKind.REFUSED_SYMLINK
     assert target.is_symlink()
     assert real.read_text(encoding="utf-8") == "original"
 
@@ -383,7 +393,8 @@ def test_skill_writes_through_symlinked_parent_dir(tmp_path: Path):
 
     line = _materialize_skill_file(target, "body")
 
-    assert line == f"  wrote {target}"
+    assert line.kind is SkillKind.WROTE
+    assert line.target == target
     assert base.is_symlink()
     assert (real_dir / "nauro-adopt" / "SKILL.md").read_text(encoding="utf-8") == "body"
 
@@ -402,9 +413,9 @@ def test_agent_materialization_refuses_symlinked_target(tmp_path: Path, monkeypa
 
     add_lines = materialize_agents("claude_code", remove=False)
 
-    add_refusals = [line for line in add_lines if "refused to modify" in line]
+    add_refusals = [line for line in add_lines if line.kind is AgentKind.REFUSED_SYMLINK]
     assert len(add_refusals) == 1
-    assert str(linked) in add_refusals[0]
+    assert add_refusals[0].refusal.target == linked
     assert linked.is_symlink()
     assert real.read_text(encoding="utf-8") == "mine"
     for name in AGENT_NAMES[1:]:
@@ -412,7 +423,7 @@ def test_agent_materialization_refuses_symlinked_target(tmp_path: Path, monkeypa
 
     remove_lines = materialize_agents("claude_code", remove=True)
 
-    remove_refusals = [line for line in remove_lines if "refused to modify" in line]
+    remove_refusals = [line for line in remove_lines if line.kind is AgentKind.REFUSED_SYMLINK]
     assert len(remove_refusals) == 1
     assert linked.is_symlink()
     assert real.read_text(encoding="utf-8") == "mine"
@@ -429,5 +440,5 @@ def test_codex_write_preserves_permission_bits(tmp_path: Path):
 
     msg = _configure_codex(remove=False, config_path=config_path)
 
-    assert "wrote nauro" in msg
+    assert msg.kind is CodexConfigKind.WROTE
     assert oct(config_path.stat().st_mode & 0o777) == "0o640"


### PR DESCRIPTION
## Why

The setup codecs returned pre-formatted status strings, so wording, git-hygiene warnings, and error phrasing were scattered across nine modules and impossible to type-check. status.py separately re-implemented the same MCP/Codex config reads with isinstance/.get() ladders. This is the final increment of the setup decomposition: every codec now reports a structured outcome and one render layer owns the wording, so downstream logic operates on typed objects and the codecs are free of presentation and of Typer.

## What changed

- outcomes.py widens ArtifactOutcome into a union of one frozen dataclass per codec, each tagged by a per-codec Kind enum, plus HandlerErrorOutcome. RawLine remains for orchestrator-owned policy text.
- render.py gains a per-codec branch that reproduces every current status line; it imports only from outcomes (no codec, no Typer). Each inner match raises on an unhandled kind, and a wording table pins render's exact output for every outcome kind across every codec.
- All eight codecs return typed outcomes. JSON MCP and Claude hook configs are parsed through Pydantic boundary models (McpConfigDocument, ClaudeHookSettings) that validate only what Nauro owns: the container shape plus the entry (mcpServers.nauro) or event (UserPromptSubmit) Nauro writes. Third-party entries and events are opaque content, preserved byte-identically; the write mutates the raw json.loads dict in place so key order and untouched content stay byte-identical.
- A shared write_json_config helper backs the four JSON config sinks. Codex config (tomlkit, newline-preserving) and Codex hooks keep their own serializers.
- The orchestrator appends codec outcomes directly and keeps RawLine only for its own policy strings; caught per-handler failures become HandlerErrorOutcome.
- status.py drops its private tomllib/json readers and repoints to codec inspectors (json_mcp.recorded_mcp_commands, codex_config.recorded_codex_command); the Codex config path is exposed as the public codex_config.codex_config_path.
- The user-scope ~/.claude.json prune guards a non-object top level (null, array, or scalar) with a graceful skip, fixing a latent crash that predates this branch.

## Test plan

- The setup characterization (30) and onboarding inventory (7) oracles pass byte-identical and unmodified (empty diff on both).
- Unit tests that asserted on codec return strings now assert on the typed outcome kind and its fields. New regression tests cover the third-party-tolerant semantics: malformed sibling MCP entries on add/remove/status, an unrelated snake_case mcp_servers key, malformed unrelated hook events, non-dict matchers, explicit-null shapes on both add and remove paths, and non-object ~/.claude.json top levels.
- Full packages/nauro (1939 passed, 10 skipped) and packages/nauro-core (1073 passed) suites green; ruff check and ruff format clean.

## Risk / what to review

Well-formed configs are unaffected: user-facing output is byte-identical (the 37-test characterization + onboarding oracle passes unmodified), and the write paths still mutate the original loaded dict, never model_dump.

The boundary models now validate only what Nauro owns — the mcpServers / hooks container shape and the single entry (nauro) or event (UserPromptSubmit) Nauro writes. For third-party content the strictness delta versus main is now essentially zero:

- A malformed sibling MCP server entry ({"other": "not-a-dict"}) is preserved byte-for-byte on add, does not block removal of the nauro entry, and does not hide a wired repo in `nauro status`.
- A malformed hook event Nauro does not install into (e.g. PostToolUse) and a non-dict matcher inside UserPromptSubmit are left untouched and no longer block the add; the "not a JSON array" skip can now only name UserPromptSubmit.
- An unrelated top-level snake_case `mcp_servers` key is treated as opaque content: it is never mistaken for Nauro's map, so removal cannot KeyError and status cannot report false wiring.

Residual behavior differences from main, all strict improvements on hand-corrupted files (no well-formed config reaches them):

- A null/scalar mcpServers or hooks container, and a non-array UserPromptSubmit, still degrade to the same graceful per-artifact skip messages main already emitted — these were NOT newly made graceful (main skipped explicit-null containers with identical wording; an earlier draft's claim otherwise was incorrect and has been removed).
- An explicit JSON null UserPromptSubmit (and any other present-but-non-array value) degrades to the same EVENT_NOT_ARRAY skip main emitted, rather than crashing the add path — a defect introduced and fixed within this branch.
- The user-scope ~/.claude.json prune now degrades to a graceful skip ("skipped user-scope prune: ~/.claude.json is not a JSON object") when its top level is a JSON null, array, or scalar. On main this case raised an uncaught AttributeError mid-run (a pre-existing latent crash, not a #361 regression); this PR fixes it as a rider to the re-scope.

Reviewer focus: confirm the models validate only the owned container + owned entry (no sibling recursion), and that render's per-codec wording table pins the exact strings.
