### PR TITLE
Release nauro 1.4.0 and nauro-core 1.1.1

### DIFF
--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro-core"
-version = "1.1.0"
+version = "1.1.1"
 description = "Shared pure-Python logic for Nauro: parsing, validation, context assembly, constants."
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro"
-version = "1.3.0"
+version = "1.4.0"
 description = "Human-approved project judgment and current state for connected AI agents, surfaced before work."
 readme = "README.md"
 license = "Apache-2.0"
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "nauro-core>=1.1.0,<2",
+    "nauro-core>=1.1.1,<2",
     "typer>=0.9",
     "httpx>=0.24",
     "mcp>=1.0",

--- a/server.json
+++ b/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Nauro-AI/nauro",
     "source": "github"
   },
-  "version": "1.3.0",
+  "version": "1.4.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "nauro",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -1051,7 +1051,7 @@ wheels = [
 
 [[package]]
 name = "nauro"
-version = "1.3.0"
+version = "1.4.0"
 source = { editable = "packages/nauro" }
 dependencies = [
     { name = "filelock" },
@@ -1095,7 +1095,7 @@ provides-extras = ["dev", "embeddings"]
 
 [[package]]
 name = "nauro-core"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "packages/nauro-core" }
 dependencies = [
     { name = "bm25s" },


### PR DESCRIPTION
## Version moves

- nauro 1.3.0 -> 1.4.0 (minor)
- nauro-core 1.1.0 -> 1.1.1 (patch)
- nauro's nauro-core floor moves to >=1.1.1,<2
- server.json version-locked to nauro 1.4.0

## What ships

**nauro 1.4.0** — the setup subsystem hardening and decomposition (#334–#361):

- AGENTS.md preservation: no incidental regeneration path overwrites a hand-written AGENTS.md; `nauro sync` is the sole explicit overwrite path, and it says so in its help.
- Filesystem write safety: repo-scoped config writers refuse to traverse symlinks (directory components included), registration validates its write target before mutating registry or cloud state, teardown preflights every artifact, and external config writes are atomic with UTF-8 pinned on read and write.
- Codex config.toml writes preserve user comments and formatting (tomlkit replaces tomli-w); Nauro edits only the keys it owns inside `mcp_servers.nauro`.
- `setup claude-code --remove` no longer orphans the UserPromptSubmit hook; codex --remove messaging is accurate.
- Reliable Codex agent bootstrap and a validated, durable recorded command for MCP/hook wiring.
- Internal: `nauro setup` decomposed from one 1368-line module into artifact codecs and orchestration policy under `cli/integrations/` with typed outcomes end to end; a 37-test characterization oracle pins byte-identical user-facing output across the whole series; boundary models validate only the config Nauro owns.
- README rewritten around context and the full-record loop.

**nauro-core 1.1.1** — dead-code removal and comment trims only. The curated public API is unchanged since 1.1.0.

## Checks

- check_server_json_version.py, check_single_sourced.py, uv lock --check: pass locally
- uv sync --locked for both packages: pass locally
- Full CI (lint, import-linter, both test matrices 3.10–3.14) must be green before merge

## Post-merge

Tag the squash commit `nauro-v1.4.0` and `nauro-core-v1.1.1` (annotated) and push both tags to trigger the trusted-publish workflows; the nauro workflow also publishes server.json to the MCP registry. Then create the two GitHub Releases.
