### PR TITLE
Isolate HOME in the nauro test suite

### DIFF
--- a/packages/nauro/tests/conftest.py
+++ b/packages/nauro/tests/conftest.py
@@ -340,3 +340,22 @@ def _isolate_nauro_home(tmp_path, monkeypatch):
     later setenv wins.
     """
     monkeypatch.setenv("NAURO_HOME", str(tmp_path))
+
+
+@pytest.fixture(autouse=True)
+def _isolate_home(tmp_path, monkeypatch):
+    """Point HOME at a per-test sandbox so user-global writers never touch it.
+
+    NAURO_HOME only covers the store; the user-global artifact writers
+    (``~/.codex/config.toml``, ``~/.claude.json``, ``~/.claude/skills``,
+    ``~/.agents/skills``) resolve through ``Path.home()``. A test that
+    exercises them without its own HOME patch rewrites the developer's real
+    config — a full suite run did exactly that to ``~/.codex/config.toml``
+    before this guard existed. CI never catches the escape because runner
+    homes are throwaway. The sandbox is a subdirectory so tests that pin
+    filesystem inventories over ``tmp_path`` and set ``HOME`` themselves
+    (later setenv wins) keep their own layout. The sandbox is not
+    pre-created: several tests assert exact ``tmp_path`` contents, and the
+    user-global writers create their own parents.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))


### PR DESCRIPTION
## Why

A full local run of the nauro test suite mutates the developer's real user-global config: `test_setup_all_with_hooks_wires_claude_code_and_codex` calls `setup_all_surfaces(with_hooks=True)` without patching HOME, so the Codex TOML writer records the test-run interpreter's nauro into the real `~/.codex/config.toml`, and the skill materializers overwrite `~/.claude/skills/nauro-adopt/SKILL.md` and `~/.agents/skills/nauro-adopt/SKILL.md`. Verified with a canary HOME: those three files are written by that single test; the rest of the suite is clean. CI cannot catch this class of escape because runner homes are throwaway.

## What changed

- A new autouse `_isolate_home` fixture in `packages/nauro/tests/conftest.py` points HOME at a per-test sandbox (`tmp_path/home`), alongside the existing NAURO_HOME and cwd isolation fixtures. Tests that set HOME themselves override it (later setenv wins on the same monkeypatch instance). The sandbox is not pre-created because several tests assert exact `tmp_path` contents.
- No individual test changes: the structural guard covers the escaping test and makes the whole class impossible for future tests.

## Test plan

- Full suite against a canary HOME: 1939 passed, 10 skipped; zero files written outside the per-test sandboxes (previously: `.codex/config.toml` plus two SKILL.md files).
- Characterization and onboarding oracles unmodified and green.
- nauro-core suite 1073 passed; ruff check and format clean.