### PR TITLE
Distinguish first connection from disconnected recovery

### DIFF
--- a/packages/nauro-core/src/nauro_core/renderers.py
+++ b/packages/nauro-core/src/nauro_core/renderers.py
@@ -87,6 +87,12 @@ def _guidance(result: dict) -> str:
     return (result.get("guidance") or "").strip()
 
 
+def _connection_guidance(result: dict) -> str:
+    if result.get("status") == "error" and result.get("reason_code"):
+        return _guidance(result)
+    return ""
+
+
 def render_check_decision(result: dict) -> str:
     """Render a related-decision result for chat-UI consumption.
 
@@ -95,6 +101,8 @@ def render_check_decision(result: dict) -> str:
     top-match marker and rationale preview render even when an upstream
     assessment-string edit drifts.
     """
+    if guidance := _connection_guidance(result):
+        return guidance
     if "error" in result:
         return _error_block(result["error"])
 
@@ -167,6 +175,8 @@ def render_get_decision(result: dict, mode: str = "full") -> str:
     projection (triage frontmatter + title + lede), so emit it as-is — a
     second title header would duplicate the projection's own title line.
     """
+    if guidance := _connection_guidance(result):
+        return guidance
     if "error" in result:
         return _error_block(result["error"])
 
@@ -211,6 +221,8 @@ def render_search_decisions(result: dict, query: str | None = None) -> str:
     it takes precedence; the remote transport, whose wire envelope still
     carries ``query``, keeps rendering via the dict fallback.
     """
+    if guidance := _connection_guidance(result):
+        return guidance
     if "error" in result:
         return _error_block(result["error"])
 
@@ -251,6 +263,8 @@ def render_search_decisions(result: dict, query: str | None = None) -> str:
 
 def render_list_decisions(result: dict) -> str:
     """Render the project's decision list."""
+    if guidance := _connection_guidance(result):
+        return guidance
     if "error" in result:
         return _error_block(result["error"])
 
@@ -288,6 +302,8 @@ def render_get_context(result: dict) -> str:
     server uses ``content`` (the kernel ``GetContextResult`` field name).
     Accept either so a single renderer covers both transports.
     """
+    if guidance := _connection_guidance(result):
+        return guidance
     if "error" in result:
         return _error_block(result["error"])
     body = result.get("context") or result.get("content") or ""

--- a/packages/nauro-core/src/nauro_core/renderers.py
+++ b/packages/nauro-core/src/nauro_core/renderers.py
@@ -87,8 +87,24 @@ def _guidance(result: dict) -> str:
     return (result.get("guidance") or "").strip()
 
 
+def disconnected_reason_code(result: dict) -> str | None:
+    """Return the reason code when ``result`` is a disconnected-error envelope.
+
+    The single definition of the envelope's discriminator (``status ==
+    "error"`` with a nonempty ``reason_code``), shared by every adapter that
+    routes disconnected states differently from plain errors — so a change to
+    the envelope shape lands in one place instead of drifting across surfaces.
+    """
+    if result.get("status") != "error":
+        return None
+    reason_code = result.get("reason_code")
+    if isinstance(reason_code, str) and reason_code:
+        return reason_code
+    return None
+
+
 def _connection_guidance(result: dict) -> str:
-    if result.get("status") == "error" and result.get("reason_code"):
+    if disconnected_reason_code(result) is not None:
         return _guidance(result)
     return ""
 
@@ -346,6 +362,7 @@ RENDERERS = {
 
 __all__ = [
     "RENDERERS",
+    "disconnected_reason_code",
     "render_check_decision",
     "render_get_context",
     "render_get_decision",

--- a/packages/nauro-core/tests/test_renderers.py
+++ b/packages/nauro-core/tests/test_renderers.py
@@ -680,3 +680,24 @@ class TestNoProjectGuidance:
             "guidance": "No decisions recorded yet for this project.",
         }
         assert "No decisions recorded yet" in render_list_decisions(result)
+
+
+class TestDisconnectedProjectGuidance:
+    def test_renderers_prefer_exact_connection_guidance(self):
+        result = {
+            "store": "local",
+            "status": "error",
+            "error": {"kind": "error", "reason": "internal structured reason"},
+            "guidance": "Run `nauro reconnect` to restore this project.",
+            "project_id": "01KQ6AZGNA0B3QBF67NBXP3S45",
+            "project_name": "Pareto",
+            "project_mode": "local",
+            "reason_code": "connected_record_missing",
+            "recovery_actions": ["locate", "continue"],
+        }
+
+        assert render_get_context(result) == result["guidance"]
+        assert render_get_decision(result) == result["guidance"]
+        assert render_check_decision(result) == result["guidance"]
+        assert render_search_decisions(result) == result["guidance"]
+        assert render_list_decisions(result) == result["guidance"]

--- a/packages/nauro/src/nauro/cli/commands/adopt.py
+++ b/packages/nauro/src/nauro/cli/commands/adopt.py
@@ -48,8 +48,8 @@ from nauro.store.registry import (
     find_projects_by_name_v2,
     get_project_v2,
     get_repo_paths,
-    get_store_path_v2,
     register_project_v2,
+    registered_store_path_hint_v2,
     remove_project_v2,
     remove_repo_v2,
     resolve_registered_store_path_v2,
@@ -272,11 +272,16 @@ def _remove_adoption(repo_root: Path, *, purge_store: bool, assume_yes: bool) ->
             store_path = resolve_registered_store_path_v2(pid)
         except StoreBindingError as exc:
             entry = get_project_v2(pid) or {}
-            raw_store_path = entry.get("store_path")
-            store_path = Path(raw_store_path) if raw_store_path else get_store_path_v2(pid)
+            store_path = registered_store_path_hint_v2(pid, entry)
             if purge_store and exc.reason_code != "connected_record_missing":
                 typer.echo(f"Error: --purge-store refused: {exc}", err=True)
                 raise typer.Exit(code=1) from exc
+            if store_path is None:
+                typer.echo(
+                    "Warning: the registered store path is invalid; any store data "
+                    "will be left untouched.",
+                    err=True,
+                )
         except (KeyError, ValueError):
             store_path = None
     is_last_repo = not other_repos

--- a/packages/nauro/src/nauro/cli/commands/adopt.py
+++ b/packages/nauro/src/nauro/cli/commands/adopt.py
@@ -44,12 +44,15 @@ from nauro.constants import REPO_CONFIG_MODE_LOCAL
 from nauro.skills import load_adopt_body
 from nauro.store.registry import (
     RegistrySchemaError,
+    StoreBindingError,
     find_projects_by_name_v2,
+    get_project_v2,
     get_repo_paths,
     get_store_path_v2,
     register_project_v2,
     remove_project_v2,
     remove_repo_v2,
+    resolve_registered_store_path_v2,
 )
 from nauro.store.repo_config import RepoConfigSchemaError, load_repo_config, save_repo_config
 from nauro.store.write_safety import SymlinkRefusal, find_symlink
@@ -266,8 +269,15 @@ def _remove_adoption(repo_root: Path, *, purge_store: bool, assume_yes: bool) ->
     if pid:
         other_repos = [p for p in get_repo_paths(pid) if str(Path(p).resolve()) != repo_resolved]
         try:
-            store_path = get_store_path_v2(pid)
-        except ValueError:
+            store_path = resolve_registered_store_path_v2(pid)
+        except StoreBindingError as exc:
+            entry = get_project_v2(pid) or {}
+            raw_store_path = entry.get("store_path")
+            store_path = Path(raw_store_path) if raw_store_path else get_store_path_v2(pid)
+            if purge_store and exc.reason_code != "connected_record_missing":
+                typer.echo(f"Error: --purge-store refused: {exc}", err=True)
+                raise typer.Exit(code=1) from exc
+        except (KeyError, ValueError):
             store_path = None
     is_last_repo = not other_repos
 

--- a/packages/nauro/src/nauro/cli/commands/attach.py
+++ b/packages/nauro/src/nauro/cli/commands/attach.py
@@ -19,10 +19,12 @@ from nauro.cli.commands.auth import DEFAULT_API_URL
 from nauro.cli.git_hygiene import public_surface_git_warnings
 from nauro.cli.utils import refuse_global_config_collision, refuse_repo_config_symlink
 from nauro.constants import REPO_CONFIG_MODE_CLOUD
+from nauro.store.recovery import RecoveryError, require_cloud_membership, restore_cloud_store
 from nauro.store.registry import (
-    add_repo_v2,
+    StoreBindingError,
+    bind_project_store_v2,
     get_project_v2,
-    register_project_v2,
+    get_store_path_v2,
     resolve_v2_from_path,
 )
 from nauro.store.repo_config import (
@@ -31,7 +33,7 @@ from nauro.store.repo_config import (
     repo_config_path,
     save_repo_config,
 )
-from nauro.sync.cloud_projects import CloudProjectError, list_projects
+from nauro.store.resolution import DisconnectedProject, resolve_registered_project
 from nauro.templates.agents_md_regen import warn_then_regen
 
 _Opt_repo_path = typer.Option(
@@ -89,36 +91,29 @@ def attach(
     refuse_repo_config_symlink(repo_path)
     _refuse_attach_collision(repo_path, project_id)
     try:
-        projects = list_projects()
-    except CloudProjectError as exc:
+        name = require_cloud_membership(project_id)
+        existing = get_project_v2(project_id)
+        server_url = existing.get("server_url", DEFAULT_API_URL) if existing else DEFAULT_API_URL
+        connection = resolve_registered_project(project_id)
+        if isinstance(connection, DisconnectedProject):
+            if connection.reason_code != "connected_record_missing":
+                raise RecoveryError(connection.guidance)
+            store_path = restore_cloud_store(project_id, connection.store_path)
+        elif connection is None:
+            store_path = restore_cloud_store(project_id, get_store_path_v2(project_id))
+        else:
+            store_path = connection.store_path
+        bind_project_store_v2(
+            project_id=project_id,
+            name=name,
+            mode=REPO_CONFIG_MODE_CLOUD,
+            repo_path=repo_path,
+            store_path=store_path,
+            server_url=server_url,
+        )
+    except (RecoveryError, StoreBindingError, OSError, ValueError) as exc:
         typer.echo(f"Error: {exc}", err=True)
         raise typer.Exit(code=1) from exc
-
-    match = next((p for p in projects if p["project_id"] == project_id), None)
-    if match is None:
-        typer.echo(
-            f"Project id {project_id!r} not found among your cloud projects.\n"
-            "  Check the id, or run 'nauro auth login' to refresh credentials.",
-            err=True,
-        )
-        raise typer.Exit(code=1)
-
-    name = match["name"]
-
-    existing = get_project_v2(project_id)
-    if existing is None:
-        _pid, store_path = register_project_v2(
-            name,
-            [repo_path],
-            mode=REPO_CONFIG_MODE_CLOUD,
-            project_id=project_id,
-            server_url=DEFAULT_API_URL,
-        )
-    else:
-        add_repo_v2(project_id, repo_path)
-        from nauro.store.registry import get_store_path_v2
-
-        store_path = get_store_path_v2(project_id)
 
     save_repo_config(
         repo_path,
@@ -126,7 +121,7 @@ def attach(
             "mode": REPO_CONFIG_MODE_CLOUD,
             "id": project_id,
             "name": name,
-            "server_url": DEFAULT_API_URL,
+            "server_url": server_url,
         },
     )
     for warning in public_surface_git_warnings(repo_path, ".nauro/config.json"):

--- a/packages/nauro/src/nauro/cli/commands/attach.py
+++ b/packages/nauro/src/nauro/cli/commands/attach.py
@@ -19,11 +19,17 @@ from nauro.cli.commands.auth import DEFAULT_API_URL
 from nauro.cli.git_hygiene import public_surface_git_warnings
 from nauro.cli.utils import refuse_global_config_collision, refuse_repo_config_symlink
 from nauro.constants import REPO_CONFIG_MODE_CLOUD
-from nauro.store.recovery import RecoveryError, require_cloud_membership, restore_cloud_store
+from nauro.store.recovery import (
+    EmptyCloudRecordError,
+    RecoveryError,
+    require_cloud_membership,
+    restore_cloud_store,
+    scaffold_empty_store,
+)
 from nauro.store.registry import (
     StoreBindingError,
     bind_project_store_v2,
-    get_project_v2,
+    get_project_entry_v2,
     get_store_path_v2,
     resolve_v2_from_path,
 )
@@ -92,15 +98,27 @@ def attach(
     _refuse_attach_collision(repo_path, project_id)
     try:
         name = require_cloud_membership(project_id)
-        existing = get_project_v2(project_id)
-        server_url = existing.get("server_url", DEFAULT_API_URL) if existing else DEFAULT_API_URL
+        entry = get_project_entry_v2(project_id)
+        server_url = (entry.server_url if entry else None) or DEFAULT_API_URL
+
         connection = resolve_registered_project(project_id)
         if isinstance(connection, DisconnectedProject):
             if connection.reason_code != "connected_record_missing":
                 raise RecoveryError(connection.guidance)
+            # A previously connected machine lost its record: this is
+            # recovery, so an empty remote stays a hard stop — a blank
+            # directory must never stand in for a lost record.
             store_path = restore_cloud_store(project_id, connection.store_path)
         elif connection is None:
-            store_path = restore_cloud_store(project_id, get_store_path_v2(project_id))
+            try:
+                store_path = restore_cloud_store(project_id, get_store_path_v2(project_id))
+            except EmptyCloudRecordError:
+                # First connection on this machine to a cloud project whose
+                # record was never pushed. Attach's long-standing contract
+                # applies: the store directory is created empty and files
+                # arrive via sync. Nothing is being replaced — the empty
+                # mirror matches the remote state.
+                store_path = scaffold_empty_store(get_store_path_v2(project_id))
         else:
             store_path = connection.store_path
         bind_project_store_v2(
@@ -110,6 +128,10 @@ def attach(
             repo_path=repo_path,
             store_path=store_path,
             server_url=server_url,
+            # The name was just verified against the cloud, which is
+            # authoritative for cloud-mode projects; a server-side rename
+            # reconciles the registry instead of conflicting.
+            update_name=True,
         )
     except (RecoveryError, StoreBindingError, OSError, ValueError) as exc:
         typer.echo(f"Error: {exc}", err=True)

--- a/packages/nauro/src/nauro/cli/commands/hook.py
+++ b/packages/nauro/src/nauro/cli/commands/hook.py
@@ -183,10 +183,10 @@ def _resolve_store_path(cwd: Path) -> Path | None:
     cwd rather than the process cwd and returns None instead of raising — the
     hook never errors a turn over an unresolvable directory.
     """
-    from nauro.store.resolution import resolve_from_cwd
+    from nauro.store.resolution import RepoResolution, resolve_from_cwd
 
     resolution = resolve_from_cwd(cwd)
-    return resolution.store_path if resolution is not None else None
+    return resolution.store_path if isinstance(resolution, RepoResolution) else None
 
 
 def _check(store_path: Path, prompt: str) -> list[dict]:

--- a/packages/nauro/src/nauro/cli/commands/init.py
+++ b/packages/nauro/src/nauro/cli/commands/init.py
@@ -32,7 +32,6 @@ from nauro.constants import (
 from nauro.store.registry import (
     add_repo_v2,
     find_projects_by_name_v2,
-    get_store_path_v2,
     register_project_v2,
     resolve_v2_from_path,
 )
@@ -42,6 +41,7 @@ from nauro.store.repo_config import (
     repo_config_path,
     save_repo_config,
 )
+from nauro.store.resolution import DisconnectedProject, resolve_registered_project
 from nauro.sync.cloud_projects import CloudProjectError, create_project
 from nauro.templates.agents_md_regen import warn_then_regen
 from nauro.templates.scaffolds import scaffold_project_store
@@ -209,7 +209,14 @@ def _init_demo(name: str, repo_paths: list[Path], force: bool) -> None:
     existing = find_projects_by_name_v2(name)
     if existing:
         pid, _entry = existing[0]
-        store_path = get_store_path_v2(pid)
+        connection = resolve_registered_project(pid)
+        if isinstance(connection, DisconnectedProject):
+            typer.echo(connection.guidance, err=True)
+            raise typer.Exit(code=1)
+        if connection is None:
+            typer.echo(f"Project id {pid!r} is no longer registered.", err=True)
+            raise typer.Exit(code=1)
+        store_path = connection.store_path
         for rp in repo_paths:
             _refuse_if_repo_already_claimed(rp, allowed_project_id=pid)
         for rp in repo_paths:
@@ -358,7 +365,14 @@ def init(
                     err=True,
                 )
                 raise typer.Exit(code=1)
-            store_path = get_store_path_v2(pid)
+            connection = resolve_registered_project(pid)
+            if isinstance(connection, DisconnectedProject):
+                typer.echo(connection.guidance, err=True)
+                raise typer.Exit(code=1)
+            if connection is None:
+                typer.echo(f"Project id {pid!r} is no longer registered.", err=True)
+                raise typer.Exit(code=1)
+            store_path = connection.store_path
             # Pre-check every target repo before any state changes.
             for rp in repo_paths:
                 refuse_repo_config_symlink(rp)

--- a/packages/nauro/src/nauro/cli/commands/link.py
+++ b/packages/nauro/src/nauro/cli/commands/link.py
@@ -31,6 +31,7 @@ from nauro.store.repo_config import (
     load_repo_config,
     save_repo_config,
 )
+from nauro.store.resolution import DisconnectedProject, resolve_registered_project
 from nauro.sync.cloud_projects import CloudProjectError, create_project
 from nauro.sync.push import push_changed_files
 
@@ -87,6 +88,10 @@ def link(
             "Did you migrate ~/.nauro/registry.json?",
             err=True,
         )
+        raise typer.Exit(code=1)
+    connection = resolve_registered_project(local_id)
+    if isinstance(connection, DisconnectedProject):
+        typer.echo(connection.guidance, err=True)
         raise typer.Exit(code=1)
 
     if not load_access_token():

--- a/packages/nauro/src/nauro/cli/commands/projects.py
+++ b/packages/nauro/src/nauro/cli/commands/projects.py
@@ -13,6 +13,7 @@ second entry for a repo that is already claimed.
 from __future__ import annotations
 
 from collections import Counter
+from pathlib import Path
 
 import typer
 
@@ -85,8 +86,11 @@ def remove_project(
     ),
 ) -> None:
     """Remove a project's registry entry, leaving its on-disk store intact."""
+    registry = load_registry_v2()
+    entry = registry["projects"].get(project_id) or {}
+    raw_store_path = entry.get("store_path")
     try:
-        store_path = get_store_path_v2(project_id)
+        store_path = Path(raw_store_path) if raw_store_path else get_store_path_v2(project_id)
     except ValueError as exc:
         # A project_id that escapes the projects root (e.g. ``..`` or an
         # absolute path) trips the containment guard; reject it cleanly

--- a/packages/nauro/src/nauro/cli/commands/projects.py
+++ b/packages/nauro/src/nauro/cli/commands/projects.py
@@ -13,13 +13,12 @@ second entry for a repo that is already claimed.
 from __future__ import annotations
 
 from collections import Counter
-from pathlib import Path
 
 import typer
 
 from nauro.store.registry import (
-    get_store_path_v2,
     load_registry_v2,
+    registered_store_path_hint_v2,
     remove_project_v2,
 )
 
@@ -88,9 +87,8 @@ def remove_project(
     """Remove a project's registry entry, leaving its on-disk store intact."""
     registry = load_registry_v2()
     entry = registry["projects"].get(project_id) or {}
-    raw_store_path = entry.get("store_path")
     try:
-        store_path = Path(raw_store_path) if raw_store_path else get_store_path_v2(project_id)
+        store_path = registered_store_path_hint_v2(project_id, entry)
     except ValueError as exc:
         # A project_id that escapes the projects root (e.g. ``..`` or an
         # absolute path) trips the containment guard; reject it cleanly
@@ -98,9 +96,14 @@ def remove_project(
         typer.echo(f"Invalid project id {project_id!r}: {exc}", err=True)
         raise typer.Exit(code=1) from None
     if not yes:
+        store_description = (
+            str(store_path)
+            if store_path is not None
+            else "the invalid path recorded in the registry"
+        )
         typer.confirm(
             f"Remove registry entry for {project_id}? "
-            f"The store at {store_path} will be left intact.",
+            f"The store at {store_description} will be left intact.",
             abort=True,
         )
     removed = remove_project_v2(project_id)
@@ -108,4 +111,7 @@ def remove_project(
         typer.echo(f"No project registered with id {project_id!r}.", err=True)
         raise typer.Exit(code=1)
     typer.echo(f"Removed registry entry for {project_id}.")
-    typer.echo(f"  Store left intact: {store_path}")
+    if store_path is None:
+        typer.echo("  Store left untouched: the registered path was invalid.")
+    else:
+        typer.echo(f"  Store left intact: {store_path}")

--- a/packages/nauro/src/nauro/cli/commands/reconnect.py
+++ b/packages/nauro/src/nauro/cli/commands/reconnect.py
@@ -12,8 +12,8 @@ from nauro.store.recovery import (
     require_cloud_membership,
     restore_cloud_store,
 )
-from nauro.store.registry import StoreBindingError
-from nauro.store.repo_config import find_repo_config
+from nauro.store.registry import StoreBindingError, bind_project_store_v2
+from nauro.store.repo_config import find_repo_config, load_repo_config, save_repo_config
 from nauro.store.resolution import DisconnectedProject, RepoResolution, resolve_from_cwd
 from nauro.templates.agents_md_regen import warn_then_regen
 
@@ -80,16 +80,26 @@ def reconnect() -> None:
             return
 
         remote_name = require_cloud_membership(connection.project_id)
-        if remote_name != connection.display_name:
-            raise RecoveryError(
-                f"Cloud project name {remote_name!r} conflicts with repository name "
-                f"{connection.display_name!r}."
-            )
         store_path = restore_cloud_store(connection.project_id, connection.store_path)
-        resolved = bind_local_store(repo_root, store_path)
-        _finish_connection(repo_root, resolved.store_path, resolved.project_id)
-        typer.echo(f"Restored and connected '{resolved.display_name}'.")
-        typer.echo(f"  Store: {resolved.store_path}")
+        config = load_repo_config(repo_root)
+        # Membership was just verified, so the cloud name is authoritative:
+        # a server-side rename reconciles the registry and repo config here
+        # rather than leaving every later resolution in a binding conflict.
+        bound = bind_project_store_v2(
+            project_id=connection.project_id,
+            name=remote_name,
+            mode=config["mode"],
+            repo_path=repo_root,
+            store_path=store_path,
+            server_url=config.get("server_url"),
+            update_name=True,
+        )
+        if remote_name != config.get("name"):
+            typer.echo(f"Cloud project is now named {remote_name!r}; updating the local records.")
+            save_repo_config(repo_root, {**config, "name": remote_name})
+        _finish_connection(repo_root, bound, connection.project_id)
+        typer.echo(f"Restored and connected '{remote_name}'.")
+        typer.echo(f"  Store: {bound}")
     except (RecoveryError, StoreBindingError, OSError, ValueError) as exc:
         typer.echo(f"Error: {exc}", err=True)
         raise typer.Exit(code=1) from exc

--- a/packages/nauro/src/nauro/cli/commands/reconnect.py
+++ b/packages/nauro/src/nauro/cli/commands/reconnect.py
@@ -1,0 +1,95 @@
+"""nauro reconnect: connect a repository's known project record."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+from nauro.store.recovery import (
+    RecoveryError,
+    bind_local_store,
+    require_cloud_membership,
+    restore_cloud_store,
+)
+from nauro.store.registry import StoreBindingError
+from nauro.store.repo_config import find_repo_config
+from nauro.store.resolution import DisconnectedProject, RepoResolution, resolve_from_cwd
+from nauro.templates.agents_md_regen import warn_then_regen
+
+
+def _render_actions(actions: tuple[str, ...]) -> None:
+    typer.echo("\nAvailable actions:")
+    labels = {
+        "locate": "Locate an existing local record",
+        "restore": "Restore the latest eligible cloud record",
+        "continue": "Continue without Nauro for now",
+    }
+    for action in actions:
+        typer.echo(f"  {action}: {labels[action]}")
+
+
+def _finish_connection(repo_root: Path, store_path: Path, project_id: str) -> None:
+    warn_then_regen(
+        project_id,
+        store_path,
+        warn=lambda message: typer.echo(message, err=True),
+        fail_soft=True,
+    )
+
+
+def reconnect() -> None:
+    """Connect or recover the project already named by this repository."""
+    config_path = find_repo_config(start=Path.cwd())
+    if config_path is None:
+        typer.echo(
+            "No Nauro project config found in this directory. Run this command from an "
+            "adopted repository.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+    repo_root = config_path.parent.parent
+    connection = resolve_from_cwd(repo_root)
+    if isinstance(connection, RepoResolution):
+        typer.echo(f"Already connected to '{connection.display_name}'.")
+        typer.echo(f"  Store: {connection.store_path}")
+        return
+    if not isinstance(connection, DisconnectedProject):
+        typer.echo("The repository project config could not be validated.", err=True)
+        raise typer.Exit(code=1)
+
+    typer.echo(connection.guidance)
+    _render_actions(connection.recovery_actions)
+    action = typer.prompt("Action", default="continue").strip().lower()
+    if action not in connection.recovery_actions:
+        typer.echo(
+            f"Unknown action {action!r}. Choose one of: " + ", ".join(connection.recovery_actions),
+            err=True,
+        )
+        raise typer.Exit(code=1)
+    if action == "continue":
+        typer.echo("No changes made. Nauro-dependent workflows remain unavailable.")
+        return
+
+    try:
+        if action == "locate":
+            store_path = Path(typer.prompt("Absolute store path"))
+            resolved = bind_local_store(repo_root, store_path)
+            _finish_connection(repo_root, resolved.store_path, resolved.project_id)
+            typer.echo(f"Connected '{resolved.display_name}' to {resolved.store_path}")
+            return
+
+        remote_name = require_cloud_membership(connection.project_id)
+        if remote_name != connection.display_name:
+            raise RecoveryError(
+                f"Cloud project name {remote_name!r} conflicts with repository name "
+                f"{connection.display_name!r}."
+            )
+        store_path = restore_cloud_store(connection.project_id, connection.store_path)
+        resolved = bind_local_store(repo_root, store_path)
+        _finish_connection(repo_root, resolved.store_path, resolved.project_id)
+        typer.echo(f"Restored and connected '{resolved.display_name}'.")
+        typer.echo(f"  Store: {resolved.store_path}")
+    except (RecoveryError, StoreBindingError, OSError, ValueError) as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=1) from exc

--- a/packages/nauro/src/nauro/cli/commands/status.py
+++ b/packages/nauro/src/nauro/cli/commands/status.py
@@ -15,7 +15,7 @@ from nauro.cli._codex_hooks import (
     _parse_codex_hooks,
 )
 from nauro.cli.integrations import codex_config, json_mcp
-from nauro.cli.utils import resolve_target_project
+from nauro.cli.utils import DisconnectedProjectExit, resolve_target_project
 
 
 def _is_windows() -> bool:
@@ -336,7 +336,8 @@ def status(
     try:
         project_name, store_path = resolve_target_project(project)
     except typer.Exit as exc:
-        typer.echo("No project found. Run 'nauro init <name>' to get started.", err=True)
+        if not isinstance(exc, DisconnectedProjectExit):
+            typer.echo("No project found. Run 'nauro init <name>' to get started.", err=True)
         raise typer.Exit(exc.exit_code) from exc
 
     typer.echo(f"Project: {project_name}")

--- a/packages/nauro/src/nauro/cli/main.py
+++ b/packages/nauro/src/nauro/cli/main.py
@@ -62,6 +62,7 @@ def _register_commands() -> None:
         note,
         projects,
         questions,
+        reconnect,
         render_plugin,
         serve,
         setup,
@@ -74,6 +75,7 @@ def _register_commands() -> None:
     app.command(name="init")(init.init)
     app.command(name="adopt")(adopt.adopt)
     app.command(name="attach")(attach.attach)
+    app.command(name="reconnect")(reconnect.reconnect)
     app.command(name="link")(link.link)
     app.command(name="note")(note.note)
     app.add_typer(projects.projects_app, name="projects")

--- a/packages/nauro/src/nauro/cli/utils.py
+++ b/packages/nauro/src/nauro/cli/utils.py
@@ -25,15 +25,22 @@ from nauro.store.registry import (
     get_project,
     get_project_v2,
     get_store_path,
-    get_store_path_v2,
     load_registry,
     load_registry_v2,
     register_project_v2,
     suggest_project_for_path,
 )
 from nauro.store.repo_config import collides_with_global_config
-from nauro.store.resolution import resolve_from_cwd
+from nauro.store.resolution import (
+    DisconnectedProject,
+    resolve_from_cwd,
+    resolve_registered_project,
+)
 from nauro.store.write_safety import find_symlink
+
+
+class DisconnectedProjectExit(typer.Exit):
+    """CLI resolution already rendered typed reconnect guidance."""
 
 
 def refuse_global_config_collision(repo_root: Path) -> None:
@@ -139,7 +146,12 @@ def resolve_target_project(project_flag: str | None) -> tuple[str, Path]:
             raise typer.Exit(code=1)
         if len(matches) == 1:
             pid, _entry = matches[0]
-            return project_flag, get_store_path_v2(pid)
+            connection = resolve_registered_project(pid)
+            if isinstance(connection, DisconnectedProject):
+                typer.echo(connection.guidance, err=True)
+                raise DisconnectedProjectExit(code=1)
+            if connection is not None:
+                return project_flag, connection.store_path
 
         # 1b — v1 fallback (legacy tests and unconverted callers)
         entry = get_project(project_flag)
@@ -157,6 +169,9 @@ def resolve_target_project(project_flag: str | None) -> tuple[str, Path]:
     # 2 — cwd waterfall: repo config walk-up → v2 registry by path → v1 legacy
     cwd = Path.cwd()
     resolution = resolve_from_cwd(cwd)
+    if isinstance(resolution, DisconnectedProject):
+        typer.echo(resolution.guidance, err=True)
+        raise DisconnectedProjectExit(code=1)
     if resolution is not None:
         return resolution.display_name, resolution.store_path
 
@@ -212,6 +227,7 @@ def _resolve_project_entry(project_name: str, project_key: str) -> dict:
 # Re-exported for callers that need to write or extend v2 entries directly
 __all__ = [
     "add_repo_v2",
+    "DisconnectedProjectExit",
     "refuse_global_config_collision",
     "refuse_repo_config_symlink",
     "register_project_v2",

--- a/packages/nauro/src/nauro/mcp/stdio_server.py
+++ b/packages/nauro/src/nauro/mcp/stdio_server.py
@@ -85,18 +85,32 @@ def _wrap_with_renderer(
 
     ``renderer_kwargs`` threads renderer-specific options (e.g.
     ``get_decision``'s requested ``mode``) without storing them on the
-    result envelope.
+    result envelope. Disconnected-project errors also retain their existing
+    structured envelope so clients can act on stable recovery metadata while
+    humans still receive the rendered guidance.
     """
     json_text = json.dumps(result, indent=2, default=str)
+    structured_content = (
+        result if result.get("status") == "error" and result.get("reason_code") else None
+    )
     renderer = _RENDERERS.get(tool_name)
     if renderer is None:
-        return CallToolResult(content=[TextContent(type="text", text=json_text)])
+        return CallToolResult(
+            content=[TextContent(type="text", text=json_text)],
+            structuredContent=structured_content,
+        )
     try:
         rendered = renderer(result, **(renderer_kwargs or {}))
     except Exception:
         logger.exception("renderer failed for tool=%s; falling back to JSON-only", tool_name)
-        return CallToolResult(content=[TextContent(type="text", text=json_text)])
-    return CallToolResult(content=[TextContent(type="text", text=rendered)])
+        return CallToolResult(
+            content=[TextContent(type="text", text=json_text)],
+            structuredContent=structured_content,
+        )
+    return CallToolResult(
+        content=[TextContent(type="text", text=rendered)],
+        structuredContent=structured_content,
+    )
 
 
 def _spec_kwargs(name: str) -> dict[str, Any]:

--- a/packages/nauro/src/nauro/mcp/stdio_server.py
+++ b/packages/nauro/src/nauro/mcp/stdio_server.py
@@ -37,6 +37,7 @@ from nauro_core.constants import MCP_INSTRUCTIONS
 from nauro_core.mcp_tools import ToolSpec, get_tool_spec
 from nauro_core.operations import ErrorPayload
 from nauro_core.renderers import RENDERERS as _RENDERERS
+from nauro_core.renderers import disconnected_reason_code
 from pydantic import Field
 
 from nauro import __version__
@@ -90,9 +91,7 @@ def _wrap_with_renderer(
     humans still receive the rendered guidance.
     """
     json_text = json.dumps(result, indent=2, default=str)
-    structured_content = (
-        result if result.get("status") == "error" and result.get("reason_code") else None
-    )
+    structured_content = result if disconnected_reason_code(result) is not None else None
     renderer = _RENDERERS.get(tool_name)
     if renderer is None:
         return CallToolResult(
@@ -410,7 +409,7 @@ def flag_question(
 ) -> str | dict:
     store_path, err = _resolve_or_error(project_id, cwd)
     if err is not None:
-        return err if err.get("reason_code") else err["guidance"]
+        return err if disconnected_reason_code(err) is not None else err["guidance"]
     result = tool_flag_question(
         store_path, question, context, targets=targets, resolved_by=resolved_by
     )
@@ -435,7 +434,7 @@ def update_state(
 ) -> str | dict:
     store_path, err = _resolve_or_error(project_id, cwd)
     if err is not None:
-        return err if err.get("reason_code") else err["guidance"]
+        return err if disconnected_reason_code(err) is not None else err["guidance"]
     result = tool_update_state(store_path, delta)
     if result.get("warning"):
         return f"State updated. {result['warning']}"

--- a/packages/nauro/src/nauro/mcp/stdio_server.py
+++ b/packages/nauro/src/nauro/mcp/stdio_server.py
@@ -35,6 +35,7 @@ from mcp.server import FastMCP
 from mcp.types import CallToolResult, TextContent, ToolAnnotations
 from nauro_core.constants import MCP_INSTRUCTIONS
 from nauro_core.mcp_tools import ToolSpec, get_tool_spec
+from nauro_core.operations import ErrorPayload
 from nauro_core.renderers import RENDERERS as _RENDERERS
 from pydantic import Field
 
@@ -53,7 +54,10 @@ from nauro.mcp.tools import (
 )
 from nauro.onboarding import WELCOME_NO_PROJECT
 from nauro.store.resolution import (
+    DisconnectedProject,
+    DisconnectedProjectError,
     NoProjectError,
+    RepoResolution,
     StoreResolutionError,
     resolve_from_cwd,
     resolve_store,
@@ -145,6 +149,21 @@ def _resolve_or_error(project_id, cwd) -> tuple[Path | None, dict | None]:
         return _resolve_store(project_id, cwd), None
     except NoProjectError:
         return None, {"store": "local", "status": "error", "guidance": WELCOME_NO_PROJECT}
+    except DisconnectedProjectError as exc:
+        state = exc.state
+        return None, {
+            "store": "local",
+            "status": "error",
+            "error": ErrorPayload(kind="error", reason=state.guidance).model_dump(
+                exclude_none=True
+            ),
+            "guidance": state.guidance,
+            "project_id": state.project_id,
+            "project_name": state.display_name,
+            "project_mode": state.mode,
+            "reason_code": state.reason_code,
+            "recovery_actions": list(state.recovery_actions),
+        }
     except StoreResolutionError as exc:
         return None, {"store": "local", "status": "error", "guidance": str(exc)}
 
@@ -374,16 +393,16 @@ def flag_question(
         str | None, Field(description=_param_desc("flag_question", "project_id"))
     ] = None,
     cwd: _CWD_PARAM = None,
-) -> str:
+) -> str | dict:
     store_path, err = _resolve_or_error(project_id, cwd)
     if err is not None:
-        return err["guidance"]
+        return err if err.get("reason_code") else err["guidance"]
     result = tool_flag_question(
         store_path, question, context, targets=targets, resolved_by=resolved_by
     )
     if result.get("status") == "rejected":
         error = result.get("error") or {}
-        reason = error.get("reason", "Flag rejected.")
+        reason = str(error.get("reason", "Flag rejected."))
         return reason
     if resolved_by is not None:
         return "Question(s) resolved."
@@ -399,10 +418,10 @@ def update_state(
         str | None, Field(description=_param_desc("update_state", "project_id"))
     ] = None,
     cwd: _CWD_PARAM = None,
-) -> str:
+) -> str | dict:
     store_path, err = _resolve_or_error(project_id, cwd)
     if err is not None:
-        return err["guidance"]
+        return err if err.get("reason_code") else err["guidance"]
     result = tool_update_state(store_path, delta)
     if result.get("warning"):
         return f"State updated. {result['warning']}"
@@ -419,9 +438,10 @@ def _pull_on_startup() -> None:
     """
     try:
         resolution = resolve_from_cwd(Path(os.getcwd()))
-        if resolution is None:
+        if resolution is None or isinstance(resolution, DisconnectedProject):
             logger.debug("session-start pull: no project found in cwd, skipping")
             return
+        assert isinstance(resolution, RepoResolution)
         project_key, store_path = resolution.project_id, resolution.store_path
         if not store_path.exists():
             logger.debug("session-start pull: store not found for %s, skipping", project_key)

--- a/packages/nauro/src/nauro/onboarding.py
+++ b/packages/nauro/src/nauro/onboarding.py
@@ -36,3 +36,40 @@ NO_CONTEXT_YET = (
     "\n"
     f"{_APPROVAL_BEFORE_PROPOSE}"
 )
+
+
+def disconnected_project_guidance(reason_code: str, mode: str) -> str:
+    """Return the approved user copy for a disconnected project state."""
+    if reason_code == "not_connected_on_this_machine" and mode == "cloud":
+        return (
+            "This cloud project has not been connected on this machine. "
+            "Run `nauro reconnect` to verify access and restore its latest synced record."
+        )
+    if reason_code == "not_connected_on_this_machine":
+        return (
+            "This repository names a local Nauro project that has not been connected on this "
+            "machine. If you have the project record, run `nauro reconnect` and locate it. "
+            "Otherwise, the record remains on the machine where the project was adopted.\n\n"
+            "The project owner can run `nauro link --cloud`, commit the updated project config, "
+            "and push it. After pulling that change, other machines can attach and restore the "
+            "cloud record."
+        )
+    if reason_code == "connected_record_missing":
+        return (
+            "Nauro was connected on this machine, but the local project record is no longer at "
+            "its registered location. Run `nauro reconnect` to locate it or restore an eligible "
+            "cloud copy."
+        )
+    if reason_code == "connected_record_invalid":
+        return (
+            "Nauro found the registered project record, but it could not validate it. Nauro will "
+            "not replace or repair it automatically. Run `nauro reconnect` to inspect the record "
+            "and available recovery options."
+        )
+    if reason_code == "connected_binding_conflict":
+        return (
+            "Nauro found conflicting local records for this project. It will not choose or "
+            "overwrite either. Run `nauro reconnect` to inspect the conflict and available "
+            "recovery options."
+        )
+    raise ValueError(f"Unknown disconnected-project reason: {reason_code!r}.")

--- a/packages/nauro/src/nauro/store/recovery.py
+++ b/packages/nauro/src/nauro/store/recovery.py
@@ -25,7 +25,7 @@ from pydantic import (
 from nauro.cli.commands.auth import AuthRefreshError
 from nauro.constants import DECISIONS_DIR, PROJECT_MD
 from nauro.store.filesystem_store import FilesystemStore
-from nauro.store.registry import bind_project_store_v2
+from nauro.store.registry import bind_project_store_v2, get_store_path_v2
 from nauro.store.repo_config import load_repo_config
 from nauro.store.resolution import RepoResolution
 from nauro.sync.cloud_projects import CloudProjectError, list_projects
@@ -39,6 +39,17 @@ from nauro.sync.remote import (
 
 class RecoveryError(RuntimeError):
     """A recovery action cannot complete without risking local state."""
+
+
+class EmptyCloudRecordError(RecoveryError):
+    """The cloud project exists but has no stored record to restore.
+
+    Distinct from :class:`RecoveryError` so first-connection flows (attach)
+    can fall back to the pre-existing empty-store-then-sync contract, while
+    recovery flows (reconnect) keep treating an empty remote as a hard stop —
+    a machine recovering a lost record must not mistake "nothing was ever
+    pushed" for a successful restore.
+    """
 
 
 class CloudManifestEntry(BaseModel):
@@ -126,6 +137,18 @@ def bind_local_store(repo_path: Path, store_path: Path) -> RepoResolution:
     return RepoResolution(bound, config["id"], config["name"])
 
 
+def scaffold_empty_store(destination: Path) -> Path:
+    """Create the empty store directory for a cloud project with no record yet.
+
+    Preserves attach's pre-recovery contract: the directory is created empty
+    and files arrive via sync. Only first-connection flows call this, and only
+    after the cloud has confirmed the remote record is empty — it is a mirror
+    of the remote state, never a replacement for a lost local record.
+    """
+    destination.mkdir(parents=True, exist_ok=True)
+    return destination
+
+
 def _validate_restored_store(store_path: Path) -> None:
     project_file = store_path / PROJECT_MD
     decisions_dir = store_path / DECISIONS_DIR
@@ -149,16 +172,34 @@ def _destination_is_available(destination: Path) -> bool:
     return next(destination.iterdir(), None) is None
 
 
-def _etag_md5(raw_etag: str, relative: str) -> str:
+def _etag_md5(raw_etag: str) -> str | None:
+    """Return the ETag as a content MD5, or None when it cannot be one.
+
+    An S3 ETag equals the object's MD5 only for single-part, non-KMS-encrypted
+    uploads. Multipart ETags (``<md5>-<parts>``) and SSE-KMS/SSE-C ETags are
+    opaque, so they yield None and the caller skips the MD5 comparison rather
+    than failing a restore the sync pull path would have accepted. Size and
+    optional sha256 checks still apply to every file.
+    """
     value = raw_etag.strip('"').lower()
     if len(value) != 32 or any(ch not in "0123456789abcdef" for ch in value):
-        raise RecoveryError(f"Cloud manifest has an unusable content hash for {relative}.")
+        return None
     return value
 
 
 def restore_cloud_store(project_id: str, destination: Path) -> Path:
     """Restore a complete remote record into an absent or empty destination."""
-    if not destination.is_absolute() or destination.resolve(strict=False) != destination:
+    if not destination.is_absolute():
+        raise RecoveryError(f"Restore destination must be absolute: {destination}.")
+    # The canonical constraint is an external-binding rule: a mapped
+    # store_path must be canonical so the registry never records a
+    # symlink-relative location. The default home path is exempt — it is
+    # derived, never recorded, and legitimately non-canonical wherever
+    # NAURO_HOME or the user's home traverses a symlink (macOS $TMPDIR).
+    if (
+        destination != get_store_path_v2(project_id)
+        and destination.resolve(strict=False) != destination
+    ):
         raise RecoveryError(f"Restore destination must be canonical and absolute: {destination}.")
     if not _destination_is_available(destination):
         raise RecoveryError(f"Refusing to overwrite nonempty destination: {destination}.")
@@ -172,7 +213,7 @@ def restore_cloud_store(project_id: str, destination: Path) -> Path:
         except (AuthRefreshError, PresignError, httpx.HTTPError) as exc:
             raise RecoveryError(f"Cloud manifest fetch failed: {exc}") from exc
         if not manifest:
-            raise RecoveryError("Cloud project has no stored record to restore.")
+            raise EmptyCloudRecordError("Cloud project has no stored record to restore.")
 
         entries: dict[str, CloudManifestEntry] = {}
         for entry in manifest:
@@ -202,11 +243,14 @@ def restore_cloud_store(project_id: str, destination: Path) -> Path:
             expected_size = entry.size
             if expected_size is not None and len(content) != expected_size:
                 raise RecoveryError(f"Cloud size validation failed for {relative}.")
-            if hashlib.md5(content).hexdigest() != _etag_md5(entry.etag, relative):
+            expected_md5 = _etag_md5(entry.etag)
+            if (
+                expected_md5 is not None
+                and hashlib.md5(content, usedforsecurity=False).hexdigest() != expected_md5
+            ):
                 raise RecoveryError(f"Cloud content-hash validation failed for {relative}.")
-            digest = hashlib.sha256(content).hexdigest()
             expected_hash = entry.sha256
-            if expected_hash is not None and digest != expected_hash:
+            if expected_hash is not None and hashlib.sha256(content).hexdigest() != expected_hash:
                 raise RecoveryError(f"Cloud hash validation failed for {relative}.")
             target = staging / relative
             try:
@@ -216,6 +260,17 @@ def restore_cloud_store(project_id: str, destination: Path) -> Path:
                 raise RecoveryError(f"Could not stage cloud file {relative}: {exc}") from exc
 
         _validate_restored_store(staging)
+        # os.replace cannot move a directory onto an existing directory on
+        # Windows (even an empty one _destination_is_available admitted).
+        # rmdir only succeeds on an empty directory, so this also re-enforces
+        # the emptiness precondition at install time.
+        if destination.exists():
+            try:
+                destination.rmdir()
+            except OSError as exc:
+                raise RecoveryError(
+                    f"Refusing to overwrite nonempty destination: {destination}."
+                ) from exc
         os.replace(staging, destination)
         installed = True
         return destination
@@ -225,8 +280,10 @@ def restore_cloud_store(project_id: str, destination: Path) -> Path:
 
 
 __all__ = [
+    "EmptyCloudRecordError",
     "RecoveryError",
     "bind_local_store",
     "require_cloud_membership",
     "restore_cloud_store",
+    "scaffold_empty_store",
 ]

--- a/packages/nauro/src/nauro/store/recovery.py
+++ b/packages/nauro/src/nauro/store/recovery.py
@@ -7,9 +7,20 @@ import os
 import shutil
 import tempfile
 from pathlib import Path
+from typing import Annotated, Literal
 
 import httpx
 from nauro_core.doctor import diagnose_store
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    StrictInt,
+    StrictStr,
+    TypeAdapter,
+    ValidationError,
+    field_validator,
+)
 
 from nauro.cli.commands.auth import AuthRefreshError
 from nauro.constants import DECISIONS_DIR, PROJECT_MD
@@ -30,17 +41,73 @@ class RecoveryError(RuntimeError):
     """A recovery action cannot complete without risking local state."""
 
 
+class CloudManifestEntry(BaseModel):
+    """Validated cloud manifest entry used during staged restoration."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    path: StrictStr
+    etag: StrictStr
+    size: Annotated[StrictInt, Field(ge=0)] | None = None
+    sha256: StrictStr | None = None
+
+    @field_validator("path")
+    @classmethod
+    def validate_path(cls, raw_path: str) -> str:
+        if not raw_path or "\\" in raw_path:
+            raise ValueError("manifest path must be a nonempty POSIX path")
+        path = Path(raw_path)
+        if path.is_absolute() or ".." in path.parts or path.as_posix() != raw_path:
+            raise ValueError("manifest path must stay within the project store")
+        return raw_path
+
+
+class CloudPresignResult(BaseModel):
+    """Validated download URL returned by the cloud presign endpoint."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    verb: Literal["GET"]
+    path: StrictStr
+    url: StrictStr
+
+    @field_validator("path", "url")
+    @classmethod
+    def validate_nonempty(cls, value: str) -> str:
+        if not value:
+            raise ValueError("presign fields must be nonempty")
+        return value
+
+
+_MANIFEST_ADAPTER = TypeAdapter(list[CloudManifestEntry])
+_PRESIGN_ADAPTER = TypeAdapter(list[CloudPresignResult])
+
+
+def _parse_manifest(raw_manifest: object) -> list[CloudManifestEntry]:
+    try:
+        return _MANIFEST_ADAPTER.validate_python(raw_manifest)
+    except ValidationError as exc:
+        raise RecoveryError("Invalid cloud manifest payload.") from exc
+
+
+def _parse_presign_results(raw_results: object) -> list[CloudPresignResult]:
+    try:
+        return _PRESIGN_ADAPTER.validate_python(raw_results)
+    except ValidationError as exc:
+        raise RecoveryError("Invalid cloud restore presign payload.") from exc
+
+
 def require_cloud_membership(project_id: str) -> str:
     """Return the cloud project name after verifying current membership."""
     try:
         projects = list_projects()
     except CloudProjectError as exc:
         raise RecoveryError(str(exc)) from exc
-    match = next((project for project in projects if project.get("project_id") == project_id), None)
+    match = next((project for project in projects if project["project_id"] == project_id), None)
     if match is None:
         raise RecoveryError(f"Project id {project_id!r} not found among your cloud projects.")
-    name = match.get("name")
-    if not isinstance(name, str) or not name:
+    name = match["name"]
+    if not name:
         raise RecoveryError(f"Cloud project {project_id!r} has no valid name.")
     return name
 
@@ -57,15 +124,6 @@ def bind_local_store(repo_path: Path, store_path: Path) -> RepoResolution:
         server_url=config.get("server_url"),
     )
     return RepoResolution(bound, config["id"], config["name"])
-
-
-def _validate_manifest_path(raw_path: object) -> str:
-    if not isinstance(raw_path, str) or not raw_path or "\\" in raw_path:
-        raise RecoveryError(f"Invalid cloud manifest path: {raw_path!r}.")
-    path = Path(raw_path)
-    if path.is_absolute() or ".." in path.parts or path.as_posix() != raw_path:
-        raise RecoveryError(f"Unsafe cloud manifest path: {raw_path!r}.")
-    return raw_path
 
 
 def _validate_restored_store(store_path: Path) -> None:
@@ -91,9 +149,7 @@ def _destination_is_available(destination: Path) -> bool:
     return next(destination.iterdir(), None) is None
 
 
-def _etag_md5(raw_etag: object, relative: str) -> str:
-    if not isinstance(raw_etag, str):
-        raise RecoveryError(f"Cloud manifest has no content hash for {relative}.")
+def _etag_md5(raw_etag: str, relative: str) -> str:
     value = raw_etag.strip('"').lower()
     if len(value) != 32 or any(ch not in "0123456789abcdef" for ch in value):
         raise RecoveryError(f"Cloud manifest has an unusable content hash for {relative}.")
@@ -112,34 +168,29 @@ def restore_cloud_store(project_id: str, destination: Path) -> Path:
     installed = False
     try:
         try:
-            manifest = fetch_manifest(project_id)
+            manifest = _parse_manifest(fetch_manifest(project_id))
         except (AuthRefreshError, PresignError, httpx.HTTPError) as exc:
             raise RecoveryError(f"Cloud manifest fetch failed: {exc}") from exc
         if not manifest:
             raise RecoveryError("Cloud project has no stored record to restore.")
 
-        entries: dict[str, dict] = {}
-        for raw_entry in manifest:
-            if not isinstance(raw_entry, dict):
-                raise RecoveryError(f"Invalid cloud manifest entry: {raw_entry!r}.")
-            relative = _validate_manifest_path(raw_entry.get("path"))
+        entries: dict[str, CloudManifestEntry] = {}
+        for entry in manifest:
+            relative = entry.path
             if relative in entries:
                 raise RecoveryError(f"Duplicate cloud manifest path: {relative!r}.")
-            entries[relative] = raw_entry
+            entries[relative] = entry
 
         operations = [{"verb": "GET", "path": path} for path in entries]
         try:
-            urls = request_presigned_urls(project_id, operations)
+            urls = _parse_presign_results(request_presigned_urls(project_id, operations))
         except (AuthRefreshError, PresignError, httpx.HTTPError) as exc:
             raise RecoveryError(f"Cloud restore presign failed: {exc}") from exc
         url_by_path: dict[str, str] = {}
         for item in urls:
-            if not isinstance(item, dict) or item.get("verb") != "GET":
-                continue
-            path = item.get("path")
-            url = item.get("url")
-            if isinstance(path, str) and isinstance(url, str) and path not in url_by_path:
-                url_by_path[path] = url
+            if item.path in url_by_path:
+                raise RecoveryError(f"Duplicate cloud restore URL for {item.path!r}.")
+            url_by_path[item.path] = item.url
         if set(url_by_path) != set(entries):
             raise RecoveryError("Cloud restore did not receive one download URL per manifest file.")
 
@@ -148,14 +199,14 @@ def restore_cloud_store(project_id: str, destination: Path) -> Path:
                 content = fetch_via_presigned_url(url_by_path[relative])
             except (PresignError, httpx.HTTPError) as exc:
                 raise RecoveryError(f"Cloud download failed for {relative}: {exc}") from exc
-            expected_size = entry.get("size")
-            if isinstance(expected_size, int) and len(content) != expected_size:
+            expected_size = entry.size
+            if expected_size is not None and len(content) != expected_size:
                 raise RecoveryError(f"Cloud size validation failed for {relative}.")
-            if hashlib.md5(content).hexdigest() != _etag_md5(entry.get("etag"), relative):
+            if hashlib.md5(content).hexdigest() != _etag_md5(entry.etag, relative):
                 raise RecoveryError(f"Cloud content-hash validation failed for {relative}.")
             digest = hashlib.sha256(content).hexdigest()
-            expected_hash = entry.get("sha256")
-            if isinstance(expected_hash, str) and digest != expected_hash:
+            expected_hash = entry.sha256
+            if expected_hash is not None and digest != expected_hash:
                 raise RecoveryError(f"Cloud hash validation failed for {relative}.")
             target = staging / relative
             try:

--- a/packages/nauro/src/nauro/store/recovery.py
+++ b/packages/nauro/src/nauro/store/recovery.py
@@ -1,0 +1,181 @@
+"""Validated local binding and atomic cloud-store restoration."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+import httpx
+from nauro_core.doctor import diagnose_store
+
+from nauro.cli.commands.auth import AuthRefreshError
+from nauro.constants import DECISIONS_DIR, PROJECT_MD
+from nauro.store.filesystem_store import FilesystemStore
+from nauro.store.registry import bind_project_store_v2
+from nauro.store.repo_config import load_repo_config
+from nauro.store.resolution import RepoResolution
+from nauro.sync.cloud_projects import CloudProjectError, list_projects
+from nauro.sync.remote import (
+    PresignError,
+    fetch_manifest,
+    fetch_via_presigned_url,
+    request_presigned_urls,
+)
+
+
+class RecoveryError(RuntimeError):
+    """A recovery action cannot complete without risking local state."""
+
+
+def require_cloud_membership(project_id: str) -> str:
+    """Return the cloud project name after verifying current membership."""
+    try:
+        projects = list_projects()
+    except CloudProjectError as exc:
+        raise RecoveryError(str(exc)) from exc
+    match = next((project for project in projects if project.get("project_id") == project_id), None)
+    if match is None:
+        raise RecoveryError(f"Project id {project_id!r} not found among your cloud projects.")
+    name = match.get("name")
+    if not isinstance(name, str) or not name:
+        raise RecoveryError(f"Cloud project {project_id!r} has no valid name.")
+    return name
+
+
+def bind_local_store(repo_path: Path, store_path: Path) -> RepoResolution:
+    """Bind an existing store using identity from the repository config."""
+    config = load_repo_config(repo_path)
+    bound = bind_project_store_v2(
+        project_id=config["id"],
+        name=config["name"],
+        mode=config["mode"],
+        repo_path=repo_path,
+        store_path=store_path,
+        server_url=config.get("server_url"),
+    )
+    return RepoResolution(bound, config["id"], config["name"])
+
+
+def _validate_manifest_path(raw_path: object) -> str:
+    if not isinstance(raw_path, str) or not raw_path or "\\" in raw_path:
+        raise RecoveryError(f"Invalid cloud manifest path: {raw_path!r}.")
+    path = Path(raw_path)
+    if path.is_absolute() or ".." in path.parts or path.as_posix() != raw_path:
+        raise RecoveryError(f"Unsafe cloud manifest path: {raw_path!r}.")
+    return raw_path
+
+
+def _validate_restored_store(store_path: Path) -> None:
+    project_file = store_path / PROJECT_MD
+    decisions_dir = store_path / DECISIONS_DIR
+    if (
+        not project_file.is_file()
+        or project_file.is_symlink()
+        or not decisions_dir.is_dir()
+        or decisions_dir.is_symlink()
+    ):
+        raise RecoveryError("Cloud record is not a complete Nauro store.")
+    diagnosis = diagnose_store(FilesystemStore(store_path))
+    if not diagnosis.is_clean:
+        raise RecoveryError("Cloud record failed decision-store integrity validation.")
+
+
+def _destination_is_available(destination: Path) -> bool:
+    if not destination.exists():
+        return True
+    if not destination.is_dir():
+        return False
+    return next(destination.iterdir(), None) is None
+
+
+def _etag_md5(raw_etag: object, relative: str) -> str:
+    if not isinstance(raw_etag, str):
+        raise RecoveryError(f"Cloud manifest has no content hash for {relative}.")
+    value = raw_etag.strip('"').lower()
+    if len(value) != 32 or any(ch not in "0123456789abcdef" for ch in value):
+        raise RecoveryError(f"Cloud manifest has an unusable content hash for {relative}.")
+    return value
+
+
+def restore_cloud_store(project_id: str, destination: Path) -> Path:
+    """Restore a complete remote record into an absent or empty destination."""
+    if not destination.is_absolute() or destination.resolve(strict=False) != destination:
+        raise RecoveryError(f"Restore destination must be canonical and absolute: {destination}.")
+    if not _destination_is_available(destination):
+        raise RecoveryError(f"Refusing to overwrite nonempty destination: {destination}.")
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    staging = Path(tempfile.mkdtemp(prefix=f".{project_id}.restore-", dir=destination.parent))
+    installed = False
+    try:
+        try:
+            manifest = fetch_manifest(project_id)
+        except (AuthRefreshError, PresignError, httpx.HTTPError) as exc:
+            raise RecoveryError(f"Cloud manifest fetch failed: {exc}") from exc
+        if not manifest:
+            raise RecoveryError("Cloud project has no stored record to restore.")
+
+        entries: dict[str, dict] = {}
+        for raw_entry in manifest:
+            if not isinstance(raw_entry, dict):
+                raise RecoveryError(f"Invalid cloud manifest entry: {raw_entry!r}.")
+            relative = _validate_manifest_path(raw_entry.get("path"))
+            if relative in entries:
+                raise RecoveryError(f"Duplicate cloud manifest path: {relative!r}.")
+            entries[relative] = raw_entry
+
+        operations = [{"verb": "GET", "path": path} for path in entries]
+        try:
+            urls = request_presigned_urls(project_id, operations)
+        except (AuthRefreshError, PresignError, httpx.HTTPError) as exc:
+            raise RecoveryError(f"Cloud restore presign failed: {exc}") from exc
+        url_by_path: dict[str, str] = {}
+        for item in urls:
+            if not isinstance(item, dict) or item.get("verb") != "GET":
+                continue
+            path = item.get("path")
+            url = item.get("url")
+            if isinstance(path, str) and isinstance(url, str) and path not in url_by_path:
+                url_by_path[path] = url
+        if set(url_by_path) != set(entries):
+            raise RecoveryError("Cloud restore did not receive one download URL per manifest file.")
+
+        for relative, entry in entries.items():
+            try:
+                content = fetch_via_presigned_url(url_by_path[relative])
+            except (PresignError, httpx.HTTPError) as exc:
+                raise RecoveryError(f"Cloud download failed for {relative}: {exc}") from exc
+            expected_size = entry.get("size")
+            if isinstance(expected_size, int) and len(content) != expected_size:
+                raise RecoveryError(f"Cloud size validation failed for {relative}.")
+            if hashlib.md5(content).hexdigest() != _etag_md5(entry.get("etag"), relative):
+                raise RecoveryError(f"Cloud content-hash validation failed for {relative}.")
+            digest = hashlib.sha256(content).hexdigest()
+            expected_hash = entry.get("sha256")
+            if isinstance(expected_hash, str) and digest != expected_hash:
+                raise RecoveryError(f"Cloud hash validation failed for {relative}.")
+            target = staging / relative
+            try:
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_bytes(content)
+            except OSError as exc:
+                raise RecoveryError(f"Could not stage cloud file {relative}: {exc}") from exc
+
+        _validate_restored_store(staging)
+        os.replace(staging, destination)
+        installed = True
+        return destination
+    finally:
+        if not installed and staging.exists():
+            shutil.rmtree(staging)
+
+
+__all__ = [
+    "RecoveryError",
+    "bind_local_store",
+    "require_cloud_membership",
+    "restore_cloud_store",
+]

--- a/packages/nauro/src/nauro/store/registry.py
+++ b/packages/nauro/src/nauro/store/registry.py
@@ -474,11 +474,16 @@ def _validate_store_structure(
             "connected_record_invalid",
             f"Registered store path is not a directory: {store_path}.",
         )
+    # Symlinked store components are refused in BOTH modes: tolerance for
+    # the managed default path means components may be absent, never that a
+    # pre-planted link may redirect store reads or sync writes elsewhere.
+    if (store_path / PROJECT_MD).is_symlink() or (store_path / DECISIONS_DIR).is_symlink():
+        raise StoreBindingError(
+            "connected_record_invalid",
+            f"Store components must not be symlinks: {store_path}.",
+        )
     if strict_store and (
-        not (store_path / PROJECT_MD).is_file()
-        or (store_path / PROJECT_MD).is_symlink()
-        or not (store_path / DECISIONS_DIR).is_dir()
-        or (store_path / DECISIONS_DIR).is_symlink()
+        not (store_path / PROJECT_MD).is_file() or not (store_path / DECISIONS_DIR).is_dir()
     ):
         raise StoreBindingError(
             "connected_record_invalid",
@@ -498,12 +503,18 @@ def resolve_registered_store_path_v2(
     if entry is None:
         raise KeyError(f"Project id {project_id!r} not found in v2 registry.")
 
+    # Strict structural validation is an external-binding rule: a
+    # mapped path must contain a valid Nauro store. The default home path is
+    # Nauro-managed and keeps its pre-recovery tolerance — an existing but
+    # structurally incomplete default store resolves, and downstream tools
+    # degrade gracefully, instead of dead-ending every command in a
+    # connected_record_invalid state that reconnect cannot restore.
     if not entry.has_store_path:
         return _validate_store_structure(
             project_id,
             get_store_path_v2(project_id),
             require_store=require_store,
-            strict_store=True,
+            strict_store=False,
         )
 
     raw_store_path = entry.store_path
@@ -542,19 +553,31 @@ def bind_project_store_v2(
     repo_path: Path,
     store_path: Path,
     server_url: str | None = None,
+    update_name: bool = False,
 ) -> Path:
-    """Bind a validated local store to a v2 project without creating a store."""
+    """Bind a validated local store to a v2 project without creating a store.
+
+    ``update_name`` lets a caller holding the authoritative current name (the
+    cloud, via membership verification) reconcile a server-side rename instead
+    of conflicting. Callers whose name comes from repository config must leave
+    it False — repo content never overwrites registry identity.
+    """
     name = _validate_project_name(name)
     if mode not in _VALID_MODES_V2:
         raise ValueError(f"Invalid mode {mode!r}; expected one of {_VALID_MODES_V2}.")
     if mode == REPO_CONFIG_MODE_CLOUD and not server_url:
         raise ValueError("Cloud-mode v2 binding requires a server_url.")
-    if store_path == get_store_path_v2(project_id):
+    default_store = get_store_path_v2(project_id)
+    if store_path == default_store:
+        # The default home path keeps its pre-recovery tolerance (see
+        # resolve_registered_store_path_v2): binding it requires existence,
+        # not full structure, so first connection to an empty cloud record
+        # can bind the empty mirror directory that sync will populate.
         store_path = _validate_store_structure(
             project_id,
             store_path,
             require_store=True,
-            strict_store=True,
+            strict_store=False,
         )
     else:
         store_path = _validate_registered_store_path(
@@ -569,7 +592,7 @@ def bind_project_store_v2(
         raw_existing = registry["projects"].get(project_id)
         if raw_existing is not None:
             existing = validate_registry_entry_v2(project_id, raw_existing)
-            if existing.name != name or existing.mode != mode:
+            if existing.mode != mode or (existing.name != name and not update_name):
                 raise StoreBindingError(
                     "connected_binding_conflict",
                     f"Registry identity for {project_id!r} conflicts with the repository config.",
@@ -595,6 +618,8 @@ def bind_project_store_v2(
                     f"Project {project_id!r} is already bound to {current}.",
                 )
             entry = existing.model_dump(mode="json", exclude_unset=True)
+            if update_name:
+                entry["name"] = name
             repo_paths = list(existing.repo_paths)
         else:
             entry = {"name": name, "mode": mode, "repo_paths": []}
@@ -608,7 +633,7 @@ def bind_project_store_v2(
             entry["server_url"] = server_url
         else:
             entry.pop("server_url", None)
-        if store_path == get_store_path_v2(project_id):
+        if store_path == default_store:
             entry.pop("store_path", None)
         else:
             entry["store_path"] = str(store_path)

--- a/packages/nauro/src/nauro/store/registry.py
+++ b/packages/nauro/src/nauro/store/registry.py
@@ -413,6 +413,21 @@ def _validate_registered_store_path(
             f"Both the registered external store and default store exist for {project_id!r}.",
         )
 
+    return _validate_store_structure(
+        project_id,
+        store_path,
+        require_store=require_store,
+        strict_store=strict_store,
+    )
+
+
+def _validate_store_structure(
+    project_id: str,
+    store_path: Path,
+    *,
+    require_store: bool,
+    strict_store: bool,
+) -> Path:
     if not store_path.exists():
         if require_store:
             raise StoreBindingError(
@@ -447,13 +462,26 @@ def resolve_registered_store_path_v2(
     entry = get_project_v2(project_id)
     if entry is None:
         raise KeyError(f"Project id {project_id!r} not found in v2 registry.")
-    raw_store_path = entry.get("store_path")
-    store_path = Path(raw_store_path) if raw_store_path else get_store_path_v2(project_id)
+
+    if "store_path" not in entry:
+        return _validate_store_structure(
+            project_id,
+            get_store_path_v2(project_id),
+            require_store=require_store,
+            strict_store=True,
+        )
+
+    raw_store_path = entry["store_path"]
+    if not isinstance(raw_store_path, str) or not raw_store_path.strip():
+        raise StoreBindingError(
+            "connected_record_invalid",
+            f"Registered store path for {project_id!r} must be a nonempty string.",
+        )
     return _validate_registered_store_path(
         project_id,
-        store_path,
+        Path(raw_store_path),
         require_store=require_store,
-        strict_store=raw_store_path is not None,
+        strict_store=True,
     )
 
 
@@ -472,12 +500,20 @@ def bind_project_store_v2(
         raise ValueError(f"Invalid mode {mode!r}; expected one of {_VALID_MODES_V2}.")
     if mode == REPO_CONFIG_MODE_CLOUD and not server_url:
         raise ValueError("Cloud-mode v2 binding requires a server_url.")
-    store_path = _validate_registered_store_path(
-        project_id,
-        store_path,
-        require_store=True,
-        strict_store=True,
-    )
+    if store_path == get_store_path_v2(project_id):
+        store_path = _validate_store_structure(
+            project_id,
+            store_path,
+            require_store=True,
+            strict_store=True,
+        )
+    else:
+        store_path = _validate_registered_store_path(
+            project_id,
+            store_path,
+            require_store=True,
+            strict_store=True,
+        )
 
     with _registry_lock():
         registry = load_registry_v2()
@@ -759,14 +795,27 @@ def rename_project_id_v2(
             raise ValueError(f"Project id {new_id!r} is already registered.")
 
         entry = dict(registry["projects"].pop(old_id))
-        raw_store_path = entry.get("store_path")
-        old_store = Path(raw_store_path) if raw_store_path else get_store_path_v2(old_id)
-        _validate_registered_store_path(
-            old_id,
-            old_store,
-            require_store=rename_store,
-            strict_store=raw_store_path is not None,
-        )
+        if "store_path" not in entry:
+            raw_store_path = None
+            old_store = _validate_store_structure(
+                old_id,
+                get_store_path_v2(old_id),
+                require_store=rename_store,
+                strict_store=True,
+            )
+        else:
+            raw_store_path = entry["store_path"]
+            if not isinstance(raw_store_path, str) or not raw_store_path.strip():
+                raise StoreBindingError(
+                    "connected_record_invalid",
+                    f"Registered store path for {old_id!r} must be a nonempty string.",
+                )
+            old_store = _validate_registered_store_path(
+                old_id,
+                Path(raw_store_path),
+                require_store=rename_store,
+                strict_store=True,
+            )
         if mode is not None:
             if mode not in _VALID_MODES_V2:
                 raise ValueError(f"Invalid mode {mode!r}; expected one of {_VALID_MODES_V2}.")

--- a/packages/nauro/src/nauro/store/registry.py
+++ b/packages/nauro/src/nauro/store/registry.py
@@ -485,6 +485,16 @@ def resolve_registered_store_path_v2(
     )
 
 
+def registered_store_path_hint_v2(project_id: str, entry: dict) -> Path | None:
+    """Return a display-only store hint without trusting malformed registry data."""
+    if "store_path" not in entry:
+        return get_store_path_v2(project_id)
+    raw_store_path = entry["store_path"]
+    if not isinstance(raw_store_path, str) or not raw_store_path.strip():
+        return None
+    return Path(raw_store_path)
+
+
 def bind_project_store_v2(
     *,
     project_id: str,

--- a/packages/nauro/src/nauro/store/registry.py
+++ b/packages/nauro/src/nauro/store/registry.py
@@ -29,6 +29,7 @@ from pathlib import Path
 from typing import Literal
 
 from filelock import FileLock
+from pydantic import BaseModel, ConfigDict, StrictStr, ValidationError, model_validator
 
 from nauro.constants import (
     DECISIONS_DIR,
@@ -65,6 +66,39 @@ class StoreBindingError(ValueError):
     def __init__(self, reason_code: StoreBindingReason, message: str) -> None:
         super().__init__(message)
         self.reason_code = reason_code
+
+
+class RegistryEntryV2(BaseModel):
+    """Validated in-memory view of one schema-v2 registry entry."""
+
+    model_config = ConfigDict(extra="allow", frozen=True)
+
+    name: StrictStr
+    mode: Literal["local", "cloud"]
+    repo_paths: tuple[StrictStr, ...] = ()
+    server_url: StrictStr | None = None
+    store_path: StrictStr | None = None
+
+    @model_validator(mode="after")
+    def validate_cloud_server(self) -> "RegistryEntryV2":
+        if self.mode == REPO_CONFIG_MODE_CLOUD and not (self.server_url or "").strip():
+            raise ValueError("cloud registry entries require a nonempty server_url")
+        return self
+
+    @property
+    def has_store_path(self) -> bool:
+        return "store_path" in self.model_fields_set
+
+
+def validate_registry_entry_v2(project_id: str, raw_entry: object) -> RegistryEntryV2:
+    """Parse an untrusted registry entry into its typed in-memory form."""
+    try:
+        return RegistryEntryV2.model_validate(raw_entry)
+    except ValidationError as exc:
+        raise StoreBindingError(
+            "connected_record_invalid",
+            f"Registry entry for {project_id!r} has an invalid schema.",
+        ) from exc
 
 
 @contextmanager
@@ -457,13 +491,14 @@ def resolve_registered_store_path_v2(
     project_id: str,
     *,
     require_store: bool = True,
+    registry_entry: RegistryEntryV2 | None = None,
 ) -> Path:
     """Resolve a v2 entry through the registry-aware store boundary."""
-    entry = get_project_v2(project_id)
+    entry = registry_entry or get_project_entry_v2(project_id)
     if entry is None:
         raise KeyError(f"Project id {project_id!r} not found in v2 registry.")
 
-    if "store_path" not in entry:
+    if not entry.has_store_path:
         return _validate_store_structure(
             project_id,
             get_store_path_v2(project_id),
@@ -471,8 +506,8 @@ def resolve_registered_store_path_v2(
             strict_store=True,
         )
 
-    raw_store_path = entry["store_path"]
-    if not isinstance(raw_store_path, str) or not raw_store_path.strip():
+    raw_store_path = entry.store_path
+    if raw_store_path is None or not raw_store_path.strip():
         raise StoreBindingError(
             "connected_record_invalid",
             f"Registered store path for {project_id!r} must be a nonempty string.",
@@ -485,12 +520,16 @@ def resolve_registered_store_path_v2(
     )
 
 
-def registered_store_path_hint_v2(project_id: str, entry: dict) -> Path | None:
+def registered_store_path_hint_v2(project_id: str, entry: object) -> Path | None:
     """Return a display-only store hint without trusting malformed registry data."""
-    if "store_path" not in entry:
+    try:
+        typed_entry = validate_registry_entry_v2(project_id, entry)
+    except StoreBindingError:
+        return None
+    if not typed_entry.has_store_path:
         return get_store_path_v2(project_id)
-    raw_store_path = entry["store_path"]
-    if not isinstance(raw_store_path, str) or not raw_store_path.strip():
+    raw_store_path = typed_entry.store_path
+    if raw_store_path is None or not raw_store_path.strip():
         return None
     return Path(raw_store_path)
 
@@ -527,20 +566,25 @@ def bind_project_store_v2(
 
     with _registry_lock():
         registry = load_registry_v2()
-        existing = registry["projects"].get(project_id)
-        if existing is not None:
-            if existing.get("name") != name or existing.get("mode") != mode:
+        raw_existing = registry["projects"].get(project_id)
+        if raw_existing is not None:
+            existing = validate_registry_entry_v2(project_id, raw_existing)
+            if existing.name != name or existing.mode != mode:
                 raise StoreBindingError(
                     "connected_binding_conflict",
                     f"Registry identity for {project_id!r} conflicts with the repository config.",
                 )
-            if mode == REPO_CONFIG_MODE_CLOUD and existing.get("server_url") != server_url:
+            if mode == REPO_CONFIG_MODE_CLOUD and existing.server_url != server_url:
                 raise StoreBindingError(
                     "connected_binding_conflict",
                     f"Registry server for {project_id!r} conflicts with the repository config.",
                 )
             try:
-                current = resolve_registered_store_path_v2(project_id, require_store=False)
+                current = resolve_registered_store_path_v2(
+                    project_id,
+                    require_store=False,
+                    registry_entry=existing,
+                )
             except StoreBindingError as exc:
                 if exc.reason_code == "connected_binding_conflict":
                     raise
@@ -550,12 +594,13 @@ def bind_project_store_v2(
                     "connected_binding_conflict",
                     f"Project {project_id!r} is already bound to {current}.",
                 )
-            entry = dict(existing)
+            entry = existing.model_dump(mode="json", exclude_unset=True)
+            repo_paths = list(existing.repo_paths)
         else:
             entry = {"name": name, "mode": mode, "repo_paths": []}
+            repo_paths = []
 
         resolved_repo = str(repo_path.resolve())
-        repo_paths = list(entry.get("repo_paths", []))
         if resolved_repo not in repo_paths:
             repo_paths.append(resolved_repo)
         entry["repo_paths"] = repo_paths
@@ -590,6 +635,14 @@ def get_project_v2(project_id: str) -> dict | None:
     """Look up a v2 project entry by its project_id (ULID)."""
     registry = _load_registry_v2_or_empty()
     return registry["projects"].get(project_id)  # type: ignore[no-any-return]
+
+
+def get_project_entry_v2(project_id: str) -> RegistryEntryV2 | None:
+    """Return one v2 registry entry after validating its boundary shape."""
+    entry = get_project_v2(project_id)
+    if entry is None:
+        return None
+    return validate_registry_entry_v2(project_id, entry)
 
 
 def is_cloud_project(project_id: str) -> bool:
@@ -804,8 +857,9 @@ def rename_project_id_v2(
         if new_id != old_id and new_id in registry["projects"]:
             raise ValueError(f"Project id {new_id!r} is already registered.")
 
-        entry = dict(registry["projects"].pop(old_id))
-        if "store_path" not in entry:
+        existing = validate_registry_entry_v2(old_id, registry["projects"].pop(old_id))
+        entry = existing.model_dump(mode="json", exclude_unset=True)
+        if not existing.has_store_path:
             raw_store_path = None
             old_store = _validate_store_structure(
                 old_id,
@@ -814,8 +868,8 @@ def rename_project_id_v2(
                 strict_store=True,
             )
         else:
-            raw_store_path = entry["store_path"]
-            if not isinstance(raw_store_path, str) or not raw_store_path.strip():
+            raw_store_path = existing.store_path
+            if raw_store_path is None or not raw_store_path.strip():
                 raise StoreBindingError(
                     "connected_record_invalid",
                     f"Registered store path for {old_id!r} must be a nonempty string.",
@@ -830,12 +884,17 @@ def rename_project_id_v2(
             if mode not in _VALID_MODES_V2:
                 raise ValueError(f"Invalid mode {mode!r}; expected one of {_VALID_MODES_V2}.")
             entry["mode"] = mode
+        updated_mode = mode or existing.mode
+        updated_server_url = server_url if server_url is not None else existing.server_url
+        if updated_mode == REPO_CONFIG_MODE_CLOUD and not updated_server_url:
+            raise ValueError("Cloud-mode entry requires a server_url.")
         if server_url is not None:
             entry["server_url"] = server_url
-        if entry.get("mode") == REPO_CONFIG_MODE_CLOUD and not entry.get("server_url"):
-            raise ValueError("Cloud-mode entry requires a server_url.")
-        if entry.get("mode") == REPO_CONFIG_MODE_LOCAL:
+        if updated_mode == REPO_CONFIG_MODE_LOCAL:
             entry.pop("server_url", None)
+        entry = validate_registry_entry_v2(old_id, entry).model_dump(
+            mode="json", exclude_unset=True
+        )
 
         new_store = old_store.with_name(new_id) if raw_store_path else get_store_path_v2(new_id)
         if raw_store_path and get_store_path_v2(new_id).exists():

--- a/packages/nauro/src/nauro/store/registry.py
+++ b/packages/nauro/src/nauro/store/registry.py
@@ -26,12 +26,15 @@ import re
 import shutil
 from contextlib import contextmanager
 from pathlib import Path
+from typing import Literal
 
 from filelock import FileLock
 
 from nauro.constants import (
+    DECISIONS_DIR,
     DEFAULT_NAURO_HOME,
     NAURO_HOME_ENV,
+    PROJECT_MD,
     PROJECTS_DIR,
     REGISTRY_FILENAME,
     REGISTRY_SCHEMA_VERSION_V1,
@@ -47,6 +50,21 @@ logger = logging.getLogger("nauro.registry")
 
 class RegistrySchemaError(Exception):
     """Raised when registry.json advertises a schema_version this build cannot read."""
+
+
+StoreBindingReason = Literal[
+    "connected_record_missing",
+    "connected_record_invalid",
+    "connected_binding_conflict",
+]
+
+
+class StoreBindingError(ValueError):
+    """A registry store binding cannot be used safely."""
+
+    def __init__(self, reason_code: StoreBindingReason, message: str) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
 
 
 @contextmanager
@@ -349,6 +367,165 @@ def get_store_path_v2(project_id: str) -> Path:
     return store_path
 
 
+def _first_symlink_component(path: Path) -> Path | None:
+    current = Path(path.anchor)
+    for part in path.parts[1:]:
+        current /= part
+        if current.is_symlink():
+            return current
+    return None
+
+
+def _validate_registered_store_path(
+    project_id: str,
+    store_path: Path,
+    *,
+    require_store: bool,
+    strict_store: bool,
+) -> Path:
+    if not store_path.is_absolute():
+        raise StoreBindingError(
+            "connected_record_invalid",
+            f"Registered store path for {project_id!r} must be absolute.",
+        )
+    resolved = store_path.resolve(strict=False)
+    if resolved != store_path:
+        raise StoreBindingError(
+            "connected_record_invalid",
+            f"Registered store path for {project_id!r} is not canonical: {store_path}.",
+        )
+    symlink = _first_symlink_component(store_path)
+    if symlink is not None:
+        raise StoreBindingError(
+            "connected_record_invalid",
+            f"Registered store path for {project_id!r} traverses symlink {symlink}.",
+        )
+    if store_path.name != project_id:
+        raise StoreBindingError(
+            "connected_record_invalid",
+            f"Registered store path must end in project id {project_id!r}.",
+        )
+
+    default_store = get_store_path_v2(project_id)
+    if store_path != default_store and default_store.exists():
+        raise StoreBindingError(
+            "connected_binding_conflict",
+            f"Both the registered external store and default store exist for {project_id!r}.",
+        )
+
+    if not store_path.exists():
+        if require_store:
+            raise StoreBindingError(
+                "connected_record_missing",
+                f"Registered store path does not exist: {store_path}.",
+            )
+        return store_path
+    if not store_path.is_dir():
+        raise StoreBindingError(
+            "connected_record_invalid",
+            f"Registered store path is not a directory: {store_path}.",
+        )
+    if strict_store and (
+        not (store_path / PROJECT_MD).is_file()
+        or (store_path / PROJECT_MD).is_symlink()
+        or not (store_path / DECISIONS_DIR).is_dir()
+        or (store_path / DECISIONS_DIR).is_symlink()
+    ):
+        raise StoreBindingError(
+            "connected_record_invalid",
+            f"Registered path does not contain a valid Nauro store: {store_path}.",
+        )
+    return store_path
+
+
+def resolve_registered_store_path_v2(
+    project_id: str,
+    *,
+    require_store: bool = True,
+) -> Path:
+    """Resolve a v2 entry through the registry-aware store boundary."""
+    entry = get_project_v2(project_id)
+    if entry is None:
+        raise KeyError(f"Project id {project_id!r} not found in v2 registry.")
+    raw_store_path = entry.get("store_path")
+    store_path = Path(raw_store_path) if raw_store_path else get_store_path_v2(project_id)
+    return _validate_registered_store_path(
+        project_id,
+        store_path,
+        require_store=require_store,
+        strict_store=raw_store_path is not None,
+    )
+
+
+def bind_project_store_v2(
+    *,
+    project_id: str,
+    name: str,
+    mode: str,
+    repo_path: Path,
+    store_path: Path,
+    server_url: str | None = None,
+) -> Path:
+    """Bind a validated local store to a v2 project without creating a store."""
+    name = _validate_project_name(name)
+    if mode not in _VALID_MODES_V2:
+        raise ValueError(f"Invalid mode {mode!r}; expected one of {_VALID_MODES_V2}.")
+    if mode == REPO_CONFIG_MODE_CLOUD and not server_url:
+        raise ValueError("Cloud-mode v2 binding requires a server_url.")
+    store_path = _validate_registered_store_path(
+        project_id,
+        store_path,
+        require_store=True,
+        strict_store=True,
+    )
+
+    with _registry_lock():
+        registry = load_registry_v2()
+        existing = registry["projects"].get(project_id)
+        if existing is not None:
+            if existing.get("name") != name or existing.get("mode") != mode:
+                raise StoreBindingError(
+                    "connected_binding_conflict",
+                    f"Registry identity for {project_id!r} conflicts with the repository config.",
+                )
+            if mode == REPO_CONFIG_MODE_CLOUD and existing.get("server_url") != server_url:
+                raise StoreBindingError(
+                    "connected_binding_conflict",
+                    f"Registry server for {project_id!r} conflicts with the repository config.",
+                )
+            try:
+                current = resolve_registered_store_path_v2(project_id, require_store=False)
+            except StoreBindingError as exc:
+                if exc.reason_code == "connected_binding_conflict":
+                    raise
+                current = None
+            if current is not None and current != store_path and current.exists():
+                raise StoreBindingError(
+                    "connected_binding_conflict",
+                    f"Project {project_id!r} is already bound to {current}.",
+                )
+            entry = dict(existing)
+        else:
+            entry = {"name": name, "mode": mode, "repo_paths": []}
+
+        resolved_repo = str(repo_path.resolve())
+        repo_paths = list(entry.get("repo_paths", []))
+        if resolved_repo not in repo_paths:
+            repo_paths.append(resolved_repo)
+        entry["repo_paths"] = repo_paths
+        if mode == REPO_CONFIG_MODE_CLOUD:
+            entry["server_url"] = server_url
+        else:
+            entry.pop("server_url", None)
+        if store_path == get_store_path_v2(project_id):
+            entry.pop("store_path", None)
+        else:
+            entry["store_path"] = str(store_path)
+        registry["projects"][project_id] = entry
+        save_registry_v2(registry)
+    return store_path
+
+
 def _load_registry_v2_or_empty() -> dict:
     """Read v2 registry; treat a v1-on-disk as 'no v2 entries'.
 
@@ -582,6 +759,14 @@ def rename_project_id_v2(
             raise ValueError(f"Project id {new_id!r} is already registered.")
 
         entry = dict(registry["projects"].pop(old_id))
+        raw_store_path = entry.get("store_path")
+        old_store = Path(raw_store_path) if raw_store_path else get_store_path_v2(old_id)
+        _validate_registered_store_path(
+            old_id,
+            old_store,
+            require_store=rename_store,
+            strict_store=raw_store_path is not None,
+        )
         if mode is not None:
             if mode not in _VALID_MODES_V2:
                 raise ValueError(f"Invalid mode {mode!r}; expected one of {_VALID_MODES_V2}.")
@@ -592,14 +777,21 @@ def rename_project_id_v2(
             raise ValueError("Cloud-mode entry requires a server_url.")
         if entry.get("mode") == REPO_CONFIG_MODE_LOCAL:
             entry.pop("server_url", None)
-        registry["projects"][new_id] = entry
 
-        old_store = get_store_path_v2(old_id)
-        new_store = get_store_path_v2(new_id)
+        new_store = old_store.with_name(new_id) if raw_store_path else get_store_path_v2(new_id)
+        if raw_store_path and get_store_path_v2(new_id).exists():
+            raise StoreBindingError(
+                "connected_binding_conflict",
+                f"Default store already exists for new project id {new_id!r}.",
+            )
         if rename_store and old_id != new_id and old_store.exists():
             if new_store.exists():
                 raise ValueError(f"Cannot rename store: destination already exists at {new_store}.")
             shutil.move(str(old_store), str(new_store))
-        new_store.mkdir(parents=True, exist_ok=True)
+        if raw_store_path:
+            entry["store_path"] = str(new_store)
+        else:
+            entry.pop("store_path", None)
+        registry["projects"][new_id] = entry
         save_registry_v2(registry)
     return new_store

--- a/packages/nauro/src/nauro/store/resolution.py
+++ b/packages/nauro/src/nauro/store/resolution.py
@@ -191,6 +191,13 @@ def _disconnected(
     )
 
 
+def _store_path_hint(entry: dict, project_id: str) -> Path:
+    raw_path = entry.get("store_path")
+    if isinstance(raw_path, str) and raw_path.strip():
+        return Path(raw_path)
+    return get_store_path_v2(project_id)
+
+
 def _connection_for_config(cfg: dict) -> RepoResolution | DisconnectedProject:
     project_id = cfg["id"]
     entry = get_project_v2(project_id)
@@ -206,15 +213,15 @@ def _connection_for_config(cfg: dict) -> RepoResolution | DisconnectedProject:
         or entry.get("mode") != cfg.get("mode")
         or (cfg.get("mode") == "cloud" and entry.get("server_url") != configured_server)
     ):
-        raw_path = entry.get("store_path")
-        store_path = Path(raw_path) if raw_path else get_store_path_v2(project_id)
-        return _disconnected(cfg, "connected_binding_conflict", store_path)
+        return _disconnected(
+            cfg,
+            "connected_binding_conflict",
+            _store_path_hint(entry, project_id),
+        )
     try:
         store_path = resolve_registered_store_path_v2(project_id)
     except StoreBindingError as exc:
-        return _disconnected(
-            cfg, exc.reason_code, Path(entry.get("store_path") or get_store_path_v2(project_id))
-        )
+        return _disconnected(cfg, exc.reason_code, _store_path_hint(entry, project_id))
     return RepoResolution(store_path, project_id, cfg.get("name") or project_id)
 
 
@@ -232,9 +239,7 @@ def _connection_for_registry_entry(
     try:
         store_path = resolve_registered_store_path_v2(project_id)
     except StoreBindingError as exc:
-        return _disconnected(
-            cfg, exc.reason_code, Path(entry.get("store_path") or get_store_path_v2(project_id))
-        )
+        return _disconnected(cfg, exc.reason_code, _store_path_hint(entry, project_id))
     return RepoResolution(store_path, project_id, cfg["name"])
 
 

--- a/packages/nauro/src/nauro/store/resolution.py
+++ b/packages/nauro/src/nauro/store/resolution.py
@@ -26,8 +26,10 @@ from typing import Literal, NamedTuple
 
 from nauro.onboarding import disconnected_project_guidance
 from nauro.store.registry import (
+    RegistryEntryV2,
     StoreBindingError,
     find_projects_by_name_v2,
+    get_project_entry_v2,
     get_project_v2,
     get_store_path,
     get_store_path_v2,
@@ -35,6 +37,7 @@ from nauro.store.registry import (
     resolve_project,
     resolve_registered_store_path_v2,
     resolve_v2_from_path,
+    validate_registry_entry_v2,
 )
 from nauro.store.repo_config import (
     RepoConfigSchemaError,
@@ -192,13 +195,20 @@ def _disconnected(
     )
 
 
-def _store_path_hint(entry: dict, project_id: str) -> Path:
+def _store_path_hint(entry: RegistryEntryV2, project_id: str) -> Path:
     return registered_store_path_hint_v2(project_id, entry) or get_store_path_v2(project_id)
 
 
 def _connection_for_config(cfg: dict) -> RepoResolution | DisconnectedProject:
     project_id = cfg["id"]
-    entry = get_project_v2(project_id)
+    try:
+        entry = get_project_entry_v2(project_id)
+    except StoreBindingError:
+        return _disconnected(
+            cfg,
+            "connected_record_invalid",
+            get_store_path_v2(project_id),
+        )
     if entry is None:
         return _disconnected(
             cfg,
@@ -207,9 +217,9 @@ def _connection_for_config(cfg: dict) -> RepoResolution | DisconnectedProject:
         )
     configured_server = cfg.get("server_url")
     if (
-        entry.get("name") != cfg.get("name")
-        or entry.get("mode") != cfg.get("mode")
-        or (cfg.get("mode") == "cloud" and entry.get("server_url") != configured_server)
+        entry.name != cfg.get("name")
+        or entry.mode != cfg.get("mode")
+        or (cfg.get("mode") == "cloud" and entry.server_url != configured_server)
     ):
         return _disconnected(
             cfg,
@@ -217,7 +227,7 @@ def _connection_for_config(cfg: dict) -> RepoResolution | DisconnectedProject:
             _store_path_hint(entry, project_id),
         )
     try:
-        store_path = resolve_registered_store_path_v2(project_id)
+        store_path = resolve_registered_store_path_v2(project_id, registry_entry=entry)
     except StoreBindingError as exc:
         return _disconnected(cfg, exc.reason_code, _store_path_hint(entry, project_id))
     return RepoResolution(store_path, project_id, cfg.get("name") or project_id)
@@ -225,17 +235,26 @@ def _connection_for_config(cfg: dict) -> RepoResolution | DisconnectedProject:
 
 def _connection_for_registry_entry(
     project_id: str,
-    entry: dict,
+    raw_entry: object,
 ) -> RepoResolution | DisconnectedProject:
+    try:
+        entry = validate_registry_entry_v2(project_id, raw_entry)
+    except StoreBindingError:
+        cfg = {"id": project_id, "name": project_id, "mode": "local"}
+        return _disconnected(
+            cfg,
+            "connected_record_invalid",
+            get_store_path_v2(project_id),
+        )
     cfg = {
         "id": project_id,
-        "name": entry.get("name") or project_id,
-        "mode": entry.get("mode") or "local",
+        "name": entry.name,
+        "mode": entry.mode,
     }
-    if entry.get("server_url"):
-        cfg["server_url"] = entry["server_url"]
+    if entry.server_url:
+        cfg["server_url"] = entry.server_url
     try:
-        store_path = resolve_registered_store_path_v2(project_id)
+        store_path = resolve_registered_store_path_v2(project_id, registry_entry=entry)
     except StoreBindingError as exc:
         return _disconnected(cfg, exc.reason_code, _store_path_hint(entry, project_id))
     return RepoResolution(store_path, project_id, cfg["name"])

--- a/packages/nauro/src/nauro/store/resolution.py
+++ b/packages/nauro/src/nauro/store/resolution.py
@@ -31,6 +31,7 @@ from nauro.store.registry import (
     get_project_v2,
     get_store_path,
     get_store_path_v2,
+    registered_store_path_hint_v2,
     resolve_project,
     resolve_registered_store_path_v2,
     resolve_v2_from_path,
@@ -192,10 +193,7 @@ def _disconnected(
 
 
 def _store_path_hint(entry: dict, project_id: str) -> Path:
-    raw_path = entry.get("store_path")
-    if isinstance(raw_path, str) and raw_path.strip():
-        return Path(raw_path)
-    return get_store_path_v2(project_id)
+    return registered_store_path_hint_v2(project_id, entry) or get_store_path_v2(project_id)
 
 
 def _connection_for_config(cfg: dict) -> RepoResolution | DisconnectedProject:

--- a/packages/nauro/src/nauro/store/resolution.py
+++ b/packages/nauro/src/nauro/store/resolution.py
@@ -20,14 +20,19 @@ and surface specific diagnostics for the other failure modes.
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from pathlib import Path
-from typing import NamedTuple
+from typing import Literal, NamedTuple
 
+from nauro.onboarding import disconnected_project_guidance
 from nauro.store.registry import (
+    StoreBindingError,
     find_projects_by_name_v2,
+    get_project_v2,
     get_store_path,
     get_store_path_v2,
     resolve_project,
+    resolve_registered_store_path_v2,
     resolve_v2_from_path,
 )
 from nauro.store.repo_config import (
@@ -71,6 +76,14 @@ class StoreMissingError(StoreResolutionError):
     """
 
 
+class DisconnectedProjectError(StoreResolutionError):
+    """A repository identifies a project whose record is unavailable."""
+
+    def __init__(self, state: DisconnectedProject) -> None:
+        super().__init__(state.guidance)
+        self.state = state
+
+
 class ProjectIdMismatchError(StoreResolutionError):
     """Caller's ``project_id`` does not match the cwd config id. Surface
     the mismatch so the caller can decide whether the cwd or the handle
@@ -99,10 +112,32 @@ class RepoResolution(NamedTuple):
     display_name: str
 
 
+DisconnectedReason = Literal[
+    "not_connected_on_this_machine",
+    "connected_record_missing",
+    "connected_record_invalid",
+    "connected_binding_conflict",
+]
+RecoveryAction = Literal["locate", "restore", "continue"]
+
+
+@dataclass(frozen=True)
+class DisconnectedProject:
+    """Typed negative result for a repository with valid project identity."""
+
+    store_path: Path
+    project_id: str
+    display_name: str
+    mode: str
+    reason_code: DisconnectedReason
+    recovery_actions: tuple[RecoveryAction, ...]
+    guidance: str
+
+
 def _resolve_repo_config_from_cwd(start: Path | None) -> tuple[dict, Path] | None:
     """Walk up from ``start`` for ``.nauro/config.json`` and load it.
 
-    Returns ``(config, store_path)`` or ``None`` when no config is found or the
+    Returns ``(config, repo_root)`` or ``None`` when no config is found or the
     config is unreadable. Both ``RepoConfigSchemaError`` (schema mismatch, or a
     corrupt-JSON error the reader remaps to it) and ``OSError`` (an unreadable
     file) degrade to ``None`` so a resolution failure surfaces the no-project
@@ -124,7 +159,93 @@ def _resolve_repo_config_from_cwd(start: Path | None) -> tuple[dict, Path] | Non
         cfg = load_repo_config(repo_root)
     except (RepoConfigSchemaError, OSError):
         return None
-    return cfg, get_store_path_v2(cfg["id"])
+    return cfg, repo_root
+
+
+def _recovery_actions(
+    mode: str,
+    reason_code: DisconnectedReason,
+) -> tuple[RecoveryAction, ...]:
+    if mode == "cloud" and reason_code in {
+        "not_connected_on_this_machine",
+        "connected_record_missing",
+    }:
+        return ("locate", "restore", "continue")
+    return ("locate", "continue")
+
+
+def _disconnected(
+    cfg: dict,
+    reason_code: DisconnectedReason,
+    store_path: Path,
+) -> DisconnectedProject:
+    mode = cfg["mode"]
+    return DisconnectedProject(
+        store_path=store_path,
+        project_id=cfg["id"],
+        display_name=cfg.get("name") or cfg["id"],
+        mode=mode,
+        reason_code=reason_code,
+        recovery_actions=_recovery_actions(mode, reason_code),
+        guidance=disconnected_project_guidance(reason_code, mode),
+    )
+
+
+def _connection_for_config(cfg: dict) -> RepoResolution | DisconnectedProject:
+    project_id = cfg["id"]
+    entry = get_project_v2(project_id)
+    if entry is None:
+        return _disconnected(
+            cfg,
+            "not_connected_on_this_machine",
+            get_store_path_v2(project_id),
+        )
+    configured_server = cfg.get("server_url")
+    if (
+        entry.get("name") != cfg.get("name")
+        or entry.get("mode") != cfg.get("mode")
+        or (cfg.get("mode") == "cloud" and entry.get("server_url") != configured_server)
+    ):
+        raw_path = entry.get("store_path")
+        store_path = Path(raw_path) if raw_path else get_store_path_v2(project_id)
+        return _disconnected(cfg, "connected_binding_conflict", store_path)
+    try:
+        store_path = resolve_registered_store_path_v2(project_id)
+    except StoreBindingError as exc:
+        return _disconnected(
+            cfg, exc.reason_code, Path(entry.get("store_path") or get_store_path_v2(project_id))
+        )
+    return RepoResolution(store_path, project_id, cfg.get("name") or project_id)
+
+
+def _connection_for_registry_entry(
+    project_id: str,
+    entry: dict,
+) -> RepoResolution | DisconnectedProject:
+    cfg = {
+        "id": project_id,
+        "name": entry.get("name") or project_id,
+        "mode": entry.get("mode") or "local",
+    }
+    if entry.get("server_url"):
+        cfg["server_url"] = entry["server_url"]
+    try:
+        store_path = resolve_registered_store_path_v2(project_id)
+    except StoreBindingError as exc:
+        return _disconnected(
+            cfg, exc.reason_code, Path(entry.get("store_path") or get_store_path_v2(project_id))
+        )
+    return RepoResolution(store_path, project_id, cfg["name"])
+
+
+def resolve_registered_project(
+    project_id: str,
+) -> RepoResolution | DisconnectedProject | None:
+    """Resolve one v2 registry entry through the shared connection boundary."""
+    entry = get_project_v2(project_id)
+    if entry is None:
+        return None
+    return _connection_for_registry_entry(project_id, entry)
 
 
 def resolve_via_repo_config(start: Path | None) -> tuple[str, Path] | None:
@@ -136,11 +257,12 @@ def resolve_via_repo_config(start: Path | None) -> tuple[str, Path] | None:
     resolved = _resolve_repo_config_from_cwd(start)
     if resolved is None:
         return None
-    cfg, store_path = resolved
-    return cfg["id"], store_path
+    cfg, _repo_root = resolved
+    connection = _connection_for_config(cfg)
+    return cfg["id"], connection.store_path
 
 
-def resolve_from_cwd(cwd: str | Path | None) -> RepoResolution | None:
+def resolve_from_cwd(cwd: str | Path | None) -> RepoResolution | DisconnectedProject | None:
     """Resolve a cwd to a project store via the canonical waterfall.
 
     Applies the three cwd-based tiers in order and returns the first match:
@@ -157,14 +279,13 @@ def resolve_from_cwd(cwd: str | Path | None) -> RepoResolution | None:
 
     resolved = _resolve_repo_config_from_cwd(start)
     if resolved is not None:
-        cfg, store_path = resolved
-        pid = cfg["id"]
-        return RepoResolution(store_path, pid, cfg.get("name") or pid)
+        cfg, _repo_root = resolved
+        return _connection_for_config(cfg)
 
     v2_match = resolve_v2_from_path(start)
     if v2_match is not None:
         pid, entry = v2_match
-        return RepoResolution(get_store_path_v2(pid), pid, entry.get("name", pid))
+        return _connection_for_registry_entry(pid, entry)
 
     name = resolve_project(start)
     if name:
@@ -182,10 +303,11 @@ def resolve_store(project_id: str | None, cwd: str | Path | None) -> Path:
     catch the base class (or :class:`ValueError`) and ignore the subtype.
     """
     cwd_path = Path(cwd) if cwd else Path.cwd()
-    via_config = resolve_via_repo_config(cwd_path)
+    config_resolution = _resolve_repo_config_from_cwd(cwd_path)
 
-    if project_id and via_config is not None:
-        config_id, store_path = via_config
+    if project_id and config_resolution is not None:
+        cfg, _repo_root = config_resolution
+        config_id = cfg["id"]
         if project_id != config_id:
             matches = find_projects_by_name_v2(project_id)
             if not any(pid == config_id for pid, _ in matches):
@@ -193,35 +315,32 @@ def resolve_store(project_id: str | None, cwd: str | Path | None) -> Path:
                     f"Supplied project_id {project_id!r} does not match the "
                     f"repo config id {config_id!r} in {cwd_path}."
                 )
-        if not store_path.exists():
-            raise StoreMissingError(
-                f"Project store not found for id {config_id!r}. "
-                "The cwd .nauro/config.json resolves but the store is "
-                "missing from NAURO_HOME - was the home changed since init?"
-            )
-        return store_path
+        connection = _connection_for_config(cfg)
+        if isinstance(connection, DisconnectedProject):
+            raise DisconnectedProjectError(connection)
+        return connection.store_path
 
-    if via_config is not None:
-        _pid, store_path = via_config
-        if not store_path.exists():
-            raise StoreMissingError(
-                f"Project store not found at {store_path}. The cwd "
-                ".nauro/config.json resolves but the store is missing "
-                "from NAURO_HOME - was the home changed since init?"
-            )
-        return store_path
+    if config_resolution is not None:
+        cfg, _repo_root = config_resolution
+        connection = _connection_for_config(cfg)
+        if isinstance(connection, DisconnectedProject):
+            raise DisconnectedProjectError(connection)
+        return connection.store_path
 
     if project_id:
+        direct_entry = get_project_v2(project_id)
+        if direct_entry is not None:
+            connection = _connection_for_registry_entry(project_id, direct_entry)
+            if isinstance(connection, DisconnectedProject):
+                raise DisconnectedProjectError(connection)
+            return connection.store_path
         matches = find_projects_by_name_v2(project_id)
         if len(matches) == 1:
-            pid, _entry = matches[0]
-            store_path = get_store_path_v2(pid)
-            if not store_path.exists():
-                raise StoreMissingError(
-                    f"Project store not found for {project_id!r} (id {pid!r}). "
-                    "The registry resolves but the store is missing from NAURO_HOME."
-                )
-            return store_path
+            pid, entry = matches[0]
+            connection = _connection_for_registry_entry(pid, entry)
+            if isinstance(connection, DisconnectedProject):
+                raise DisconnectedProjectError(connection)
+            return connection.store_path
         if len(matches) > 1:
             raise MultipleProjectsError(
                 f"Multiple v2 projects named {project_id!r}; pass an "
@@ -238,17 +357,11 @@ def resolve_store(project_id: str | None, cwd: str | Path | None) -> Path:
         return store_path
 
     if cwd:
-        name = resolve_project(cwd_path)
-        if name:
-            store_path = get_store_path(name)
-            if store_path.exists():
-                return store_path
-        v2_match = resolve_v2_from_path(cwd_path)
-        if v2_match is not None:
-            pid, _entry = v2_match
-            store_path = get_store_path_v2(pid)
-            if store_path.exists():
-                return store_path
+        cwd_connection = resolve_from_cwd(cwd_path)
+        if isinstance(cwd_connection, DisconnectedProject):
+            raise DisconnectedProjectError(cwd_connection)
+        if cwd_connection is not None:
+            return cwd_connection.store_path
 
     raise NoProjectError(
         "No Nauro project found. Run 'nauro init <name>' in the current "
@@ -258,6 +371,9 @@ def resolve_store(project_id: str | None, cwd: str | Path | None) -> Path:
 
 
 __all__ = [
+    "DisconnectedProject",
+    "DisconnectedProjectError",
+    "DisconnectedReason",
     "MultipleProjectsError",
     "NoProjectError",
     "ProjectIdMismatchError",
@@ -266,6 +382,7 @@ __all__ = [
     "StoreMissingError",
     "StoreResolutionError",
     "resolve_from_cwd",
+    "resolve_registered_project",
     "resolve_store",
     "resolve_via_repo_config",
 ]

--- a/packages/nauro/src/nauro/store/resolution.py
+++ b/packages/nauro/src/nauro/store/resolution.py
@@ -199,6 +199,19 @@ def _store_path_hint(entry: RegistryEntryV2, project_id: str) -> Path:
     return registered_store_path_hint_v2(project_id, entry) or get_store_path_v2(project_id)
 
 
+def _resolve_validated_entry(
+    cfg: dict,
+    project_id: str,
+    entry: RegistryEntryV2,
+) -> RepoResolution | DisconnectedProject:
+    """Shared tail of both connection classifiers: resolve or map to disconnected."""
+    try:
+        store_path = resolve_registered_store_path_v2(project_id, registry_entry=entry)
+    except StoreBindingError as exc:
+        return _disconnected(cfg, exc.reason_code, _store_path_hint(entry, project_id))
+    return RepoResolution(store_path, project_id, cfg.get("name") or project_id)
+
+
 def _connection_for_config(cfg: dict) -> RepoResolution | DisconnectedProject:
     project_id = cfg["id"]
     try:
@@ -226,11 +239,7 @@ def _connection_for_config(cfg: dict) -> RepoResolution | DisconnectedProject:
             "connected_binding_conflict",
             _store_path_hint(entry, project_id),
         )
-    try:
-        store_path = resolve_registered_store_path_v2(project_id, registry_entry=entry)
-    except StoreBindingError as exc:
-        return _disconnected(cfg, exc.reason_code, _store_path_hint(entry, project_id))
-    return RepoResolution(store_path, project_id, cfg.get("name") or project_id)
+    return _resolve_validated_entry(cfg, project_id, entry)
 
 
 def _connection_for_registry_entry(
@@ -253,11 +262,7 @@ def _connection_for_registry_entry(
     }
     if entry.server_url:
         cfg["server_url"] = entry.server_url
-    try:
-        store_path = resolve_registered_store_path_v2(project_id, registry_entry=entry)
-    except StoreBindingError as exc:
-        return _disconnected(cfg, exc.reason_code, _store_path_hint(entry, project_id))
-    return RepoResolution(store_path, project_id, cfg["name"])
+    return _resolve_validated_entry(cfg, project_id, entry)
 
 
 def resolve_registered_project(
@@ -293,9 +298,12 @@ def resolve_from_cwd(cwd: str | Path | None) -> RepoResolution | DisconnectedPro
       2. v2 registry matched by repo path.
       3. v1 ``resolve_project`` (legacy, name-keyed).
 
-    Returns a :class:`RepoResolution`, or ``None`` when no tier matches. Does
-    NOT check that ``store_path`` exists — each caller decides how to treat a
-    resolved-but-missing store.
+    Returns a :class:`RepoResolution`, or ``None`` when no tier matches. The
+    v2 tiers surface missing or invalid stores as typed
+    :class:`DisconnectedProject` states; the v1 tier has no typed states, so
+    a v1 name whose store directory is gone falls through to ``None`` (the
+    no-project outcome) rather than resolving to a path that read tools would
+    treat as empty and write tools would silently recreate.
     """
     start = Path(cwd) if cwd else Path.cwd()
 
@@ -311,9 +319,18 @@ def resolve_from_cwd(cwd: str | Path | None) -> RepoResolution | DisconnectedPro
 
     name = resolve_project(start)
     if name:
-        return RepoResolution(get_store_path(name), name, name)
+        store_path = get_store_path(name)
+        if store_path.exists():
+            return RepoResolution(store_path, name, name)
 
     return None
+
+
+def _store_path_or_raise(connection: RepoResolution | DisconnectedProject) -> Path:
+    """Unwrap a connection result, raising the typed error for disconnected states."""
+    if isinstance(connection, DisconnectedProject):
+        raise DisconnectedProjectError(connection)
+    return connection.store_path
 
 
 def resolve_store(project_id: str | None, cwd: str | Path | None) -> Path:
@@ -327,42 +344,26 @@ def resolve_store(project_id: str | None, cwd: str | Path | None) -> Path:
     cwd_path = Path(cwd) if cwd else Path.cwd()
     config_resolution = _resolve_repo_config_from_cwd(cwd_path)
 
-    if project_id and config_resolution is not None:
+    if config_resolution is not None:
         cfg, _repo_root = config_resolution
         config_id = cfg["id"]
-        if project_id != config_id:
+        if project_id and project_id != config_id:
             matches = find_projects_by_name_v2(project_id)
             if not any(pid == config_id for pid, _ in matches):
                 raise ProjectIdMismatchError(
                     f"Supplied project_id {project_id!r} does not match the "
                     f"repo config id {config_id!r} in {cwd_path}."
                 )
-        connection = _connection_for_config(cfg)
-        if isinstance(connection, DisconnectedProject):
-            raise DisconnectedProjectError(connection)
-        return connection.store_path
-
-    if config_resolution is not None:
-        cfg, _repo_root = config_resolution
-        connection = _connection_for_config(cfg)
-        if isinstance(connection, DisconnectedProject):
-            raise DisconnectedProjectError(connection)
-        return connection.store_path
+        return _store_path_or_raise(_connection_for_config(cfg))
 
     if project_id:
-        direct_entry = get_project_v2(project_id)
-        if direct_entry is not None:
-            connection = _connection_for_registry_entry(project_id, direct_entry)
-            if isinstance(connection, DisconnectedProject):
-                raise DisconnectedProjectError(connection)
-            return connection.store_path
+        connection = resolve_registered_project(project_id)
+        if connection is not None:
+            return _store_path_or_raise(connection)
         matches = find_projects_by_name_v2(project_id)
         if len(matches) == 1:
             pid, entry = matches[0]
-            connection = _connection_for_registry_entry(pid, entry)
-            if isinstance(connection, DisconnectedProject):
-                raise DisconnectedProjectError(connection)
-            return connection.store_path
+            return _store_path_or_raise(_connection_for_registry_entry(pid, entry))
         if len(matches) > 1:
             raise MultipleProjectsError(
                 f"Multiple v2 projects named {project_id!r}; pass an "
@@ -380,10 +381,8 @@ def resolve_store(project_id: str | None, cwd: str | Path | None) -> Path:
 
     if cwd:
         cwd_connection = resolve_from_cwd(cwd_path)
-        if isinstance(cwd_connection, DisconnectedProject):
-            raise DisconnectedProjectError(cwd_connection)
         if cwd_connection is not None:
-            return cwd_connection.store_path
+            return _store_path_or_raise(cwd_connection)
 
     raise NoProjectError(
         "No Nauro project found. Run 'nauro init <name>' in the current "

--- a/packages/nauro/tests/conftest.py
+++ b/packages/nauro/tests/conftest.py
@@ -10,7 +10,7 @@ from typing import Any, NamedTuple
 import pytest
 from nauro_core.decision_model import Decision, format_decision
 
-from nauro.constants import DECISIONS_DIR, REPO_CONFIG_MODE_LOCAL
+from nauro.constants import DECISIONS_DIR, PROJECT_MD, REPO_CONFIG_MODE_LOCAL
 from nauro.mcp.tools import tool_get_context
 from nauro.store.config import save_config
 from nauro.store.registry import register_project_v2
@@ -96,9 +96,10 @@ def register_v2_repo(
     Creates ``tmp_path/"repo"``, registers a v2 project, optionally writes the
     per-repo config, seeds the store, and chdirs into the repo. ``seed`` selects
     the store body: ``"scaffold"`` runs ``scaffold_project_store``, ``"mkdir"``
-    just creates the store directory, and ``"none"`` leaves it to the caller
-    (which then writes its own content, e.g. via ``seed_decisions_into`` or a
-    demo project). ``monkeypatch`` is required only when ``chdir`` is True.
+    creates the minimal valid empty-store structure, and ``"none"`` leaves it
+    to the caller (which then writes its own content, e.g. via
+    ``seed_decisions_into`` or a demo project). ``monkeypatch`` is required
+    only when ``chdir`` is True.
 
     This body is v2-only by design: v1 ``register_project`` seeders are left
     untouched and must never be routed through here.
@@ -112,6 +113,8 @@ def register_v2_repo(
         scaffold_project_store(name, store_path)
     elif seed == "mkdir":
         store_path.mkdir(parents=True, exist_ok=True)
+        (store_path / PROJECT_MD).touch()
+        (store_path / DECISIONS_DIR).mkdir()
     if chdir:
         monkeypatch.chdir(repo)
     return V2Repo(pid, store_path, repo)
@@ -123,6 +126,8 @@ def seed_decisions_into(store_path: Path, *decisions: Decision) -> None:
     Filenames follow the ``NNN-slugified-title.md`` rule the context and search
     parity fixtures both relied on.
     """
+    store_path.mkdir(parents=True, exist_ok=True)
+    (store_path / PROJECT_MD).touch(exist_ok=True)
     decisions_dir = store_path / "decisions"
     decisions_dir.mkdir(parents=True, exist_ok=True)
     for d in decisions:

--- a/packages/nauro/tests/snapshots/public_contract_v1.json
+++ b/packages/nauro/tests/snapshots/public_contract_v1.json
@@ -1037,6 +1037,11 @@
         "params": []
       },
       {
+        "kind": "command",
+        "name": "reconnect",
+        "params": []
+      },
+      {
         "hidden": true,
         "kind": "command",
         "name": "render-plugin",

--- a/packages/nauro/tests/test_adopt_remove.py
+++ b/packages/nauro/tests/test_adopt_remove.py
@@ -70,6 +70,32 @@ def test_remove_purge_store_deletes_store(tmp_path, monkeypatch):
     result = runner.invoke(app, ["adopt", "--remove", "--purge-store", "--yes"])
     assert result.exit_code == 0, result.output
     assert not store_path.exists()
+
+
+def test_remove_purge_store_deletes_external_bound_store(tmp_path, monkeypatch):
+    repo = _adopt_env(monkeypatch, tmp_path)
+    result = runner.invoke(app, ["adopt", "--name", "alpha"])
+    assert result.exit_code == 0, result.output
+    pid = _pid_of(repo)
+    default_store = get_store_path_v2(pid)
+    external_store = tmp_path / "external" / pid
+    external_store.parent.mkdir()
+    default_store.rename(external_store)
+    from nauro.store.registry import bind_project_store_v2
+
+    bind_project_store_v2(
+        project_id=pid,
+        name="alpha",
+        mode="local",
+        repo_path=repo,
+        store_path=external_store,
+    )
+
+    result = runner.invoke(app, ["adopt", "--remove", "--purge-store", "--yes"])
+
+    assert result.exit_code == 0, result.output
+    assert not external_store.exists()
+    assert not default_store.exists()
     assert "deleted store" in result.output
 
 

--- a/packages/nauro/tests/test_adopt_remove.py
+++ b/packages/nauro/tests/test_adopt_remove.py
@@ -11,6 +11,7 @@ import pytest
 from typer.testing import CliRunner
 
 from nauro.cli.main import app
+from nauro.store import registry
 from nauro.store.registry import (
     add_repo_v2,
     find_projects_by_name_v2,
@@ -97,6 +98,44 @@ def test_remove_purge_store_deletes_external_bound_store(tmp_path, monkeypatch):
     assert not external_store.exists()
     assert not default_store.exists()
     assert "deleted store" in result.output
+
+
+def test_remove_with_malformed_store_path_leaves_store_untouched(tmp_path, monkeypatch):
+    repo = _adopt_env(monkeypatch, tmp_path)
+    assert runner.invoke(app, ["adopt", "--name", "alpha"]).exit_code == 0
+    pid = _pid_of(repo)
+    default_store = get_store_path_v2(pid)
+    data = registry.load_registry_v2()
+    data["projects"][pid]["store_path"] = 42
+    registry.save_registry_v2(data)
+
+    result = runner.invoke(app, ["adopt", "--remove", "--yes"])
+
+    assert result.exit_code == 0, result.output
+    assert "registered store path is invalid" in result.output
+    assert default_store.is_dir()
+    assert registry.get_project_v2(pid) is None
+
+
+def test_remove_purge_refuses_malformed_store_path(tmp_path, monkeypatch):
+    repo = _adopt_env(monkeypatch, tmp_path)
+    assert runner.invoke(app, ["adopt", "--name", "alpha"]).exit_code == 0
+    pid = _pid_of(repo)
+    default_store = get_store_path_v2(pid)
+    data = registry.load_registry_v2()
+    data["projects"][pid]["store_path"] = 42
+    registry.save_registry_v2(data)
+
+    result = runner.invoke(
+        app,
+        ["adopt", "--remove", "--purge-store", "--yes"],
+    )
+
+    assert result.exit_code == 1, result.output
+    assert "purge-store refused" in result.output
+    assert default_store.is_dir()
+    assert registry.get_project_v2(pid) is not None
+    assert (repo / ".nauro" / "config.json").is_file()
 
 
 def test_remove_on_unadopted_repo_errors(tmp_path, monkeypatch):

--- a/packages/nauro/tests/test_attach.py
+++ b/packages/nauro/tests/test_attach.py
@@ -16,7 +16,7 @@ from typer.testing import CliRunner
 
 from nauro.cli.main import app
 from nauro.store import registry
-from nauro.store.recovery import RecoveryError
+from nauro.store.recovery import EmptyCloudRecordError, RecoveryError
 from nauro.store.repo_config import load_repo_config, save_repo_config
 from nauro.sync import cloud_projects
 from nauro.templates.scaffolds import scaffold_project_store
@@ -233,6 +233,139 @@ def test_attach_non_member_writes_nothing(tmp_path, monkeypatch):
     assert registry.get_project_v2(EXAMPLE_PID) is None
     assert not (tmp_path / ".nauro" / "config.json").exists()
     assert not (tmp_path / "projects" / EXAMPLE_PID).exists()
+
+
+def test_attach_scaffolds_empty_store_when_cloud_record_is_empty(tmp_path, monkeypatch):
+    """First connection to a cloud project whose record was never pushed
+    keeps attach's contract: the store directory is created empty, the repo
+    config is written, and files arrive via sync.
+    """
+    _seed_token(monkeypatch, tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("NAURO_API_URL", "https://example.test")
+    handler = _list_response(
+        [
+            {
+                "project_id": EXAMPLE_PID,
+                "name": "team-proj",
+                "role": "viewer",
+                "created_at": "2026-04-27T00:00:00Z",
+            }
+        ]
+    )
+
+    with (
+        patch.object(cloud_projects.httpx, "request", side_effect=handler),
+        patch(
+            "nauro.cli.commands.attach.restore_cloud_store",
+            side_effect=EmptyCloudRecordError("Cloud project has no stored record to restore."),
+        ),
+    ):
+        result = runner.invoke(app, ["attach", EXAMPLE_PID])
+
+    assert result.exit_code == 0, result.output
+    store_path = tmp_path / "projects" / EXAMPLE_PID
+    assert store_path.is_dir()
+    assert next(store_path.iterdir(), None) is None
+    entry = registry.get_project_v2(EXAMPLE_PID)
+    assert entry is not None
+    assert entry["mode"] == "cloud"
+    cfg = load_repo_config(tmp_path)
+    assert cfg["id"] == EXAMPLE_PID
+
+
+def test_attach_missing_record_keeps_hard_error_on_empty_cloud(tmp_path, monkeypatch):
+    """A previously connected machine whose record is gone is in recovery:
+    an empty remote must stay a hard stop, never a silently scaffolded blank
+    directory standing in for the lost record.
+    """
+    _seed_token(monkeypatch, tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("NAURO_API_URL", "https://example.test")
+    registry.save_registry_v2(
+        {
+            "schema_version": 2,
+            "projects": {
+                EXAMPLE_PID: {
+                    "name": "team-proj",
+                    "mode": "cloud",
+                    "repo_paths": [str(tmp_path / "elsewhere")],
+                    "server_url": "https://api.nauro.dev",
+                }
+            },
+        }
+    )
+    handler = _list_response(
+        [
+            {
+                "project_id": EXAMPLE_PID,
+                "name": "team-proj",
+                "role": "viewer",
+                "created_at": "2026-04-27T00:00:00Z",
+            }
+        ]
+    )
+
+    with (
+        patch.object(cloud_projects.httpx, "request", side_effect=handler),
+        patch(
+            "nauro.cli.commands.attach.restore_cloud_store",
+            side_effect=EmptyCloudRecordError("Cloud project has no stored record to restore."),
+        ),
+    ):
+        result = runner.invoke(app, ["attach", EXAMPLE_PID])
+
+    assert result.exit_code == 1
+    assert "no stored record" in result.output
+    assert not (tmp_path / "projects" / EXAMPLE_PID).exists()
+    assert not (tmp_path / ".nauro" / "config.json").exists()
+
+
+def test_attach_reconciles_server_side_rename(tmp_path, monkeypatch):
+    """Attaching a repo to an already-registered project adopts the current
+    cloud name instead of failing with a binding conflict after a
+    server-side rename — membership verification makes the cloud name
+    authoritative for cloud-mode projects.
+    """
+    _seed_token(monkeypatch, tmp_path)
+    repo = tmp_path / "second-repo"
+    repo.mkdir()
+    monkeypatch.chdir(repo)
+    monkeypatch.setenv("NAURO_API_URL", "https://example.test")
+    store = registry.get_store_path_v2(EXAMPLE_PID)
+    scaffold_project_store("old-name", store)
+    registry.save_registry_v2(
+        {
+            "schema_version": 2,
+            "projects": {
+                EXAMPLE_PID: {
+                    "name": "old-name",
+                    "mode": "cloud",
+                    "repo_paths": [str(tmp_path / "first-repo")],
+                    "server_url": "https://api.nauro.dev",
+                }
+            },
+        }
+    )
+    handler = _list_response(
+        [
+            {
+                "project_id": EXAMPLE_PID,
+                "name": "new-name",
+                "role": "viewer",
+                "created_at": "2026-04-27T00:00:00Z",
+            }
+        ]
+    )
+
+    with patch.object(cloud_projects.httpx, "request", side_effect=handler):
+        result = runner.invoke(app, ["attach", EXAMPLE_PID])
+
+    assert result.exit_code == 0, result.output
+    entry = registry.get_project_v2(EXAMPLE_PID)
+    assert entry["name"] == "new-name"
+    cfg = load_repo_config(repo)
+    assert cfg["name"] == "new-name"
 
 
 def test_attach_restore_failure_writes_no_registry_or_repo_config(tmp_path, monkeypatch):

--- a/packages/nauro/tests/test_attach.py
+++ b/packages/nauro/tests/test_attach.py
@@ -16,8 +16,10 @@ from typer.testing import CliRunner
 
 from nauro.cli.main import app
 from nauro.store import registry
+from nauro.store.recovery import RecoveryError
 from nauro.store.repo_config import load_repo_config, save_repo_config
 from nauro.sync import cloud_projects
+from nauro.templates.scaffolds import scaffold_project_store
 from tests.conftest import seed_auth_config
 
 runner = CliRunner()
@@ -34,6 +36,11 @@ def _list_response(projects):
         return httpx.Response(200, json=projects, request=httpx.Request(method, url))
 
     return handler
+
+
+def _restore_project(_project_id, destination):
+    scaffold_project_store("team-proj", destination)
+    return destination
 
 
 def test_attach_happy_path(tmp_path, monkeypatch):
@@ -53,7 +60,10 @@ def test_attach_happy_path(tmp_path, monkeypatch):
         ]
     )
 
-    with patch.object(cloud_projects.httpx, "request", side_effect=handler):
+    with (
+        patch.object(cloud_projects.httpx, "request", side_effect=handler),
+        patch("nauro.cli.commands.attach.restore_cloud_store", side_effect=_restore_project),
+    ):
         result = runner.invoke(app, ["attach", EXAMPLE_PID])
 
     assert result.exit_code == 0, result.output
@@ -70,6 +80,7 @@ def test_attach_happy_path(tmp_path, monkeypatch):
 
     store_path = tmp_path / "projects" / EXAMPLE_PID
     assert store_path.is_dir()
+    assert (store_path / "project.md").is_file()
     assert (tmp_path / "AGENTS.md").is_file()
     assert "## Project: team-proj" in (tmp_path / "AGENTS.md").read_text()
 
@@ -91,7 +102,10 @@ def test_attach_preserves_hand_authored_agents_md(tmp_path, monkeypatch):
         ]
     )
 
-    with patch.object(cloud_projects.httpx, "request", side_effect=handler):
+    with (
+        patch.object(cloud_projects.httpx, "request", side_effect=handler),
+        patch("nauro.cli.commands.attach.restore_cloud_store", side_effect=_restore_project),
+    ):
         result = runner.invoke(app, ["attach", EXAMPLE_PID])
 
     assert result.exit_code == 0, result.output
@@ -219,3 +233,34 @@ def test_attach_non_member_writes_nothing(tmp_path, monkeypatch):
     assert registry.get_project_v2(EXAMPLE_PID) is None
     assert not (tmp_path / ".nauro" / "config.json").exists()
     assert not (tmp_path / "projects" / EXAMPLE_PID).exists()
+
+
+def test_attach_restore_failure_writes_no_registry_or_repo_config(tmp_path, monkeypatch):
+    _seed_token(monkeypatch, tmp_path)
+    monkeypatch.chdir(tmp_path)
+    handler = _list_response(
+        [
+            {
+                "project_id": EXAMPLE_PID,
+                "name": "team-proj",
+                "role": "viewer",
+                "created_at": "2026-04-27T00:00:00Z",
+            }
+        ]
+    )
+
+    with (
+        patch.object(cloud_projects.httpx, "request", side_effect=handler),
+        patch(
+            "nauro.cli.commands.attach.restore_cloud_store",
+            side_effect=RecoveryError("download failed"),
+        ),
+    ):
+        result = runner.invoke(app, ["attach", EXAMPLE_PID])
+
+    assert result.exit_code == 1
+    assert "download failed" in result.output
+    assert registry.get_project_v2(EXAMPLE_PID) is None
+    assert not (tmp_path / ".nauro" / "config.json").exists()
+    assert not (tmp_path / "projects" / EXAMPLE_PID).exists()
+    assert not (tmp_path / "AGENTS.md").exists()

--- a/packages/nauro/tests/test_cli_autogen.py
+++ b/packages/nauro/tests/test_cli_autogen.py
@@ -305,4 +305,6 @@ class TestAutogenInvariants:
         shutil.rmtree(store_path)
         result = runner.invoke(app, ["list-decisions"])
         assert result.exit_code == 1
-        assert "Welcome to Nauro" in result.output
+        assert "was connected on this machine" in result.output
+        assert "nauro reconnect" in result.output
+        assert "Welcome to Nauro" not in result.output

--- a/packages/nauro/tests/test_get_context_parity.py
+++ b/packages/nauro/tests/test_get_context_parity.py
@@ -79,6 +79,8 @@ def empty_repo(tmp_path, monkeypatch):
     pid, store_path = register_project_v2("empty-context", [repo], mode=REPO_CONFIG_MODE_LOCAL)
     save_repo_config(repo, {"mode": REPO_CONFIG_MODE_LOCAL, "id": pid, "name": "empty-context"})
     store_path.mkdir(parents=True, exist_ok=True)
+    (store_path / "project.md").touch()
+    (store_path / "decisions").mkdir()
     monkeypatch.chdir(repo)
     return pid, store_path
 

--- a/packages/nauro/tests/test_link_cloud.py
+++ b/packages/nauro/tests/test_link_cloud.py
@@ -133,6 +133,40 @@ def test_link_cloud_promotes_and_pushes_in_one_command(tmp_path, monkeypatch):
     assert cfg["id"] == CLOUD_PID
 
 
+def test_link_cloud_rekeys_external_store_binding(tmp_path, monkeypatch):
+    _seed_token(monkeypatch, tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("NAURO_API_URL", "https://example.test")
+    result = runner.invoke(app, ["init", "linkproj"])
+    assert result.exit_code == 0, result.output
+    local_id, _entry = registry.find_projects_by_name_v2("linkproj")[0]
+    default_store = registry.get_store_path_v2(local_id)
+    external_store = tmp_path / "external" / local_id
+    external_store.parent.mkdir()
+    default_store.rename(external_store)
+    registry.bind_project_store_v2(
+        project_id=local_id,
+        name="linkproj",
+        mode="local",
+        repo_path=tmp_path,
+        store_path=external_store,
+    )
+
+    with (
+        patch.object(cloud_projects.httpx, "request", side_effect=_create_response()),
+        patch.object(remote.httpx, "post", side_effect=_presign_post),
+        patch.object(remote.httpx, "put", return_value=_ok_put()),
+    ):
+        result = runner.invoke(app, ["link", "--cloud"])
+
+    assert result.exit_code == 0, result.output
+    new_store = external_store.parent / CLOUD_PID
+    assert new_store.is_dir()
+    assert not external_store.exists()
+    entry = registry.get_project_v2(CLOUD_PID)
+    assert entry["store_path"] == str(new_store)
+
+
 def test_link_cloud_push_failure_keeps_rekey(tmp_path, monkeypatch):
     """A transient push failure warns + exits 0; the promotion persists."""
     _seed_token(monkeypatch, tmp_path)

--- a/packages/nauro/tests/test_list_decisions_parity.py
+++ b/packages/nauro/tests/test_list_decisions_parity.py
@@ -138,6 +138,7 @@ def test_exclude_none_strips_unset_type_across_surfaces(tmp_path, monkeypatch):
     save_repo_config(repo, {"mode": REPO_CONFIG_MODE_LOCAL, "id": pid, "name": "no-type-project"})
     decisions_dir = store_path / "decisions"
     decisions_dir.mkdir(parents=True, exist_ok=True)
+    (store_path / "project.md").touch()
     body = format_decision(
         Decision(
             date=date(2026, 1, 1),

--- a/packages/nauro/tests/test_log_diff.py
+++ b/packages/nauro/tests/test_log_diff.py
@@ -356,13 +356,11 @@ class TestDiffCommand:
         assert "Not enough snapshots" in envelope["diff"]
 
     def test_diff_registered_but_missing_store(self, tmp_path: Path, monkeypatch):
-        """A registered project whose store directory was deleted must
-        surface the WELCOME_NO_PROJECT guidance on stderr and exit
-        nonzero. The auto-gen command routes through
-        ``tool_diff_since_last_session`` which short-circuits with an
-        error envelope when ``store_path.exists()`` is False; the CLI
-        respects that envelope rather than swallowing it as an empty
-        diff string.
+        """A v1 project whose store directory was deleted must exit nonzero
+        with actionable guidance, never an empty diff. Resolution no longer
+        yields a path for a missing legacy store — the cwd falls through to
+        the no-project outcome, so the CLI names the available projects
+        instead of operating on a directory that does not exist.
         """
         import shutil
 
@@ -373,13 +371,13 @@ class TestDiffCommand:
         monkeypatch.chdir(tmp_path)
 
         # Delete the project store directory; the registry still points
-        # at it, so resolve_target_project succeeds but the store is gone.
+        # at it, but cwd resolution treats the missing store as no project.
         shutil.rmtree(store)
 
         result = runner.invoke(app, ["diff-since-last-session"])
         assert result.exit_code == 1
-        assert "Welcome to Nauro" in result.output
-        assert "nauro init" in result.output
+        assert "No project found for current directory" in result.output
+        assert "myproj" in result.output
 
 
 # --- Helpers for time-based snapshot fixtures ---

--- a/packages/nauro/tests/test_onboarding_inventories.py
+++ b/packages/nauro/tests/test_onboarding_inventories.py
@@ -25,6 +25,7 @@ from typer.testing import CliRunner
 from nauro.cli.main import app
 from nauro.store.registry import register_project_v2
 from nauro.sync import cloud_projects
+from nauro.templates.scaffolds import scaffold_project_store
 from tests.conftest import seed_auth_config, snapshot_tree
 
 runner = CliRunner()
@@ -242,12 +243,7 @@ def test_init_with_repo_association_inventory(tmp_path: Path, monkeypatch):
 
 
 def test_attach_happy_path_inventory(tmp_path: Path, monkeypatch):
-    """Cloud attach writes repo config + AGENTS.md; the store stays empty.
-
-    Unlike init/adopt, attach does not scaffold the store: the directory is
-    created empty (files arrive via sync), so nothing under ``projects/``
-    shows up in the inventory.
-    """
+    """Cloud attach installs a complete record before local registration."""
     seed_auth_config()
     repo = tmp_path / "repo"
     repo.mkdir()
@@ -268,12 +264,21 @@ def test_attach_happy_path_inventory(tmp_path: Path, monkeypatch):
             request=httpx.Request(method, url),
         )
 
-    with patch.object(cloud_projects.httpx, "request", side_effect=handler):
+    def restore(_project_id, destination):
+        scaffold_project_store("team-proj", destination)
+        return destination
+
+    with (
+        patch.object(cloud_projects.httpx, "request", side_effect=handler),
+        patch("nauro.cli.commands.attach.restore_cloud_store", side_effect=restore),
+    ):
         result = runner.invoke(app, ["attach", EXAMPLE_PID])
 
     assert result.exit_code == 0
     assert snapshot_tree(tmp_path) == sorted(
-        BOOKKEEPING | {"config.json", "repo/.nauro/config.json", "repo/AGENTS.md"}
+        BOOKKEEPING
+        | {"config.json", "repo/.nauro/config.json", "repo/AGENTS.md"}
+        | _store_files(EXAMPLE_PID)
     )
     _assert_markers_in_order(
         result.stdout,

--- a/packages/nauro/tests/test_projects_cmd.py
+++ b/packages/nauro/tests/test_projects_cmd.py
@@ -57,6 +57,21 @@ def test_projects_rm_removes_entry_leaves_store(tmp_path, monkeypatch):
     assert registry.get_project_v2(pid_b) is not None
 
 
+def test_projects_rm_handles_malformed_store_path_without_touching_store(tmp_path, monkeypatch):
+    pid, _other_pid = _seed_two_projects(tmp_path)
+    default_store = get_store_path_v2(pid)
+    data = registry.load_registry_v2()
+    data["projects"][pid]["store_path"] = 42
+    registry.save_registry_v2(data)
+
+    result = runner.invoke(app, ["projects", "rm", pid, "--yes"])
+
+    assert result.exit_code == 0, result.output
+    assert "registered path was invalid" in result.output
+    assert registry.get_project_v2(pid) is None
+    assert default_store.is_dir()
+
+
 def test_projects_rm_missing_id_exits_1(tmp_path, monkeypatch):
     """`rm <missing-id>` exits 1 with a clear message."""
     _seed_two_projects(tmp_path)

--- a/packages/nauro/tests/test_reconnect.py
+++ b/packages/nauro/tests/test_reconnect.py
@@ -81,6 +81,50 @@ def test_reconnect_cloud_restore_uses_same_binding_service(tmp_path, monkeypatch
     assert registry.get_project_v2(PID)["mode"] == "cloud"
 
 
+def test_reconnect_restore_reconciles_server_side_rename(tmp_path, monkeypatch):
+    """A cloud rename between adoption and recovery must not dead-end the
+    restore: membership verification makes the cloud name authoritative, so
+    reconnect adopts it into the registry and the repo config instead of
+    conflicting forever.
+    """
+    from nauro.store.repo_config import load_repo_config
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    save_repo_config(
+        repo,
+        {
+            "mode": "cloud",
+            "id": PID,
+            "name": "Pareto",
+            "server_url": "https://example.test",
+        },
+    )
+    monkeypatch.chdir(repo)
+    target = registry.get_store_path_v2(PID)
+
+    def restore(_pid, destination):
+        scaffold_project_store("Pareto-Renamed", destination)
+        return destination
+
+    with (
+        patch(
+            "nauro.cli.commands.reconnect.require_cloud_membership",
+            return_value="Pareto-Renamed",
+        ),
+        patch("nauro.cli.commands.reconnect.restore_cloud_store", side_effect=restore),
+    ):
+        result = runner.invoke(app, ["reconnect"], input="restore\n")
+
+    assert result.exit_code == 0, result.output
+    assert "now named 'Pareto-Renamed'" in result.output
+    assert registry.get_project_v2(PID)["name"] == "Pareto-Renamed"
+    assert load_repo_config(repo)["name"] == "Pareto-Renamed"
+    resolved = resolve_from_cwd(repo)
+    assert isinstance(resolved, RepoResolution)
+    assert resolved.store_path == target
+
+
 def test_reconnect_healthy_project_is_silent_about_recovery(tmp_path, monkeypatch):
     repo = _local_repo(tmp_path)
     store = registry.get_store_path_v2(PID)

--- a/packages/nauro/tests/test_reconnect.py
+++ b/packages/nauro/tests/test_reconnect.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from nauro.cli.main import app
+from nauro.store import registry
+from nauro.store.repo_config import save_repo_config
+from nauro.store.resolution import RepoResolution, resolve_from_cwd
+from nauro.templates.scaffolds import scaffold_project_store
+
+runner = CliRunner()
+PID = "01KQ6AZGNA0B3QBF67NBXP3S45"
+
+
+def _local_repo(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    save_repo_config(repo, {"mode": "local", "id": PID, "name": "Pareto"})
+    return repo
+
+
+def test_reconnect_continue_changes_no_persistent_state(tmp_path, monkeypatch):
+    repo = _local_repo(tmp_path)
+    monkeypatch.chdir(repo)
+
+    result = runner.invoke(app, ["reconnect"], input="continue\n")
+
+    assert result.exit_code == 0, result.output
+    assert "has not been connected on this machine" in result.output
+    assert "nauro link --cloud" in result.output
+    assert "No changes made" in result.output
+    assert registry.get_project_v2(PID) is None
+
+
+def test_reconnect_locates_and_binds_existing_store(tmp_path, monkeypatch):
+    repo = _local_repo(tmp_path)
+    store = tmp_path / "external" / PID
+    scaffold_project_store("Pareto", store)
+    monkeypatch.chdir(repo)
+
+    result = runner.invoke(app, ["reconnect"], input=f"locate\n{store}\n")
+
+    assert result.exit_code == 0, result.output
+    assert f"Connected 'Pareto' to {store}" in result.output
+    resolved = resolve_from_cwd(repo)
+    assert isinstance(resolved, RepoResolution)
+    assert resolved.store_path == store
+
+
+def test_reconnect_cloud_restore_uses_same_binding_service(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    save_repo_config(
+        repo,
+        {
+            "mode": "cloud",
+            "id": PID,
+            "name": "Pareto",
+            "server_url": "https://example.test",
+        },
+    )
+    monkeypatch.chdir(repo)
+    target = registry.get_store_path_v2(PID)
+
+    def restore(_pid, destination):
+        assert _pid == PID
+        assert destination == target
+        scaffold_project_store("Pareto", destination)
+        return destination
+
+    with (
+        patch("nauro.cli.commands.reconnect.require_cloud_membership", return_value="Pareto"),
+        patch("nauro.cli.commands.reconnect.restore_cloud_store", side_effect=restore),
+    ):
+        result = runner.invoke(app, ["reconnect"], input="restore\n")
+
+    assert result.exit_code == 0, result.output
+    assert "Restored and connected 'Pareto'" in result.output
+    assert registry.get_project_v2(PID)["mode"] == "cloud"
+
+
+def test_reconnect_healthy_project_is_silent_about_recovery(tmp_path, monkeypatch):
+    repo = _local_repo(tmp_path)
+    store = registry.get_store_path_v2(PID)
+    scaffold_project_store("Pareto", store)
+    registry.bind_project_store_v2(
+        project_id=PID,
+        name="Pareto",
+        mode="local",
+        repo_path=repo,
+        store_path=store,
+    )
+    monkeypatch.chdir(repo)
+
+    result = runner.invoke(app, ["reconnect"])
+
+    assert result.exit_code == 0, result.output
+    assert result.output == f"Already connected to 'Pareto'.\n  Store: {store}\n"
+
+
+def test_reconnect_without_repo_config_does_not_adopt(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["reconnect"])
+
+    assert result.exit_code == 1
+    assert "No Nauro project config found" in result.output
+    assert registry.load_registry_v2()["projects"] == {}

--- a/packages/nauro/tests/test_recovery.py
+++ b/packages/nauro/tests/test_recovery.py
@@ -142,6 +142,43 @@ def test_restore_cloud_store_refuses_unsafe_manifest_without_partial_record(
     assert not destination.exists()
 
 
+@pytest.mark.parametrize(
+    "entry",
+    [
+        {"path": "project.md", "etag": "0" * 32, "size": "1"},
+        {"path": "project.md", "etag": 42, "size": 1},
+        {"path": 42, "etag": "0" * 32, "size": 1},
+    ],
+)
+def test_restore_cloud_store_rejects_malformed_manifest_types(entry, tmp_path, monkeypatch):
+    monkeypatch.setattr(recovery, "fetch_manifest", lambda _pid: [entry])
+    destination = tmp_path / "projects" / PID
+
+    with pytest.raises(RecoveryError, match="manifest"):
+        restore_cloud_store(PID, destination)
+
+    assert not destination.exists()
+    assert not list(destination.parent.glob(f".{PID}.restore-*"))
+
+
+def test_restore_cloud_store_rejects_malformed_presign_result(tmp_path, monkeypatch):
+    source = tmp_path / "source"
+    files = _store_files(source)
+    _mock_remote(monkeypatch, files)
+    monkeypatch.setattr(
+        recovery,
+        "request_presigned_urls",
+        lambda _pid, operations: [{"verb": "GET", "path": operations[0]["path"], "url": 42}],
+    )
+    destination = tmp_path / "projects" / PID
+
+    with pytest.raises(RecoveryError, match="presign"):
+        restore_cloud_store(PID, destination)
+
+    assert not destination.exists()
+    assert not list(destination.parent.glob(f".{PID}.restore-*"))
+
+
 def test_restore_cloud_store_rejects_damaged_decision_graph(tmp_path, monkeypatch):
     source = tmp_path / "source"
     files = _store_files(source)

--- a/packages/nauro/tests/test_recovery.py
+++ b/packages/nauro/tests/test_recovery.py
@@ -112,7 +112,12 @@ def test_restore_cloud_store_cleans_staging_on_hash_mismatch(tmp_path, monkeypat
     assert not list(destination.parent.glob(f".{PID}.restore-*"))
 
 
-def test_restore_cloud_store_rejects_multipart_etag(tmp_path, monkeypatch):
+def test_restore_cloud_store_skips_hash_check_for_opaque_etag(tmp_path, monkeypatch):
+    """Multipart and SSE-KMS ETags are not content MD5s.
+
+    Restore must fall back to the size and sha256 checks for such entries
+    instead of failing a record the sync pull path would have accepted.
+    """
     source = tmp_path / "source"
     files = _store_files(source)
     _mock_remote(monkeypatch, files)
@@ -121,11 +126,83 @@ def test_restore_cloud_store_rejects_multipart_etag(tmp_path, monkeypatch):
     monkeypatch.setattr(recovery, "fetch_manifest", lambda _pid: manifest)
     destination = tmp_path / "projects" / PID
 
-    with pytest.raises(RecoveryError, match="unusable content hash"):
+    result = restore_cloud_store(PID, destination)
+
+    assert result == destination
+    restored = {
+        path.relative_to(destination).as_posix(): path.read_bytes()
+        for path in destination.rglob("*")
+        if path.is_file()
+    }
+    assert restored == files
+
+
+def test_restore_cloud_store_still_catches_corruption_behind_opaque_etag(tmp_path, monkeypatch):
+    """An opaque ETag skips only the MD5 comparison — the sha256 check still
+    rejects corrupted content for that entry."""
+    source = tmp_path / "source"
+    files = _store_files(source)
+    _mock_remote(monkeypatch, files)
+    manifest = recovery.fetch_manifest(PID)
+    manifest[0]["etag"] = '"0123456789abcdef0123456789abcdef-2"'
+    manifest[0]["sha256"] = "0" * 64
+    monkeypatch.setattr(recovery, "fetch_manifest", lambda _pid: manifest)
+    destination = tmp_path / "projects" / PID
+
+    with pytest.raises(RecoveryError, match="hash"):
         restore_cloud_store(PID, destination)
 
     assert not destination.exists()
     assert not list(destination.parent.glob(f".{PID}.restore-*"))
+
+
+def test_restore_accepts_default_store_path_under_symlinked_home(tmp_path, monkeypatch):
+    """The default home path is exempt from the canonical-destination rule.
+
+    NAURO_HOME legitimately traverses a symlink on macOS ($TMPDIR) and
+    similar hosts; first connection and restore must not refuse the derived
+    default path there. Reaching the empty-manifest error proves the
+    destination guard passed.
+    """
+    real_home = tmp_path / "real-home"
+    real_home.mkdir()
+    linked_home = tmp_path / "linked-home"
+    linked_home.symlink_to(real_home, target_is_directory=True)
+    monkeypatch.setenv("NAURO_HOME", str(linked_home))
+    destination = get_store_path_v2(PID)
+    assert destination.resolve(strict=False) != destination
+    monkeypatch.setattr(recovery, "fetch_manifest", lambda _pid: [])
+
+    with pytest.raises(recovery.EmptyCloudRecordError):
+        restore_cloud_store(PID, destination)
+
+
+def test_restore_rejects_non_canonical_external_destination(tmp_path, monkeypatch):
+    """External destinations keep the canonical rule so the registry never
+    records a symlink-relative location."""
+    real_dir = tmp_path / "real-dir"
+    real_dir.mkdir()
+    linked_dir = tmp_path / "linked-dir"
+    linked_dir.symlink_to(real_dir, target_is_directory=True)
+    destination = linked_dir / "elsewhere" / PID
+
+    with pytest.raises(RecoveryError, match="canonical"):
+        restore_cloud_store(PID, destination)
+
+
+def test_restore_installs_into_preexisting_empty_destination(tmp_path, monkeypatch):
+    """A leftover empty destination directory (e.g. from an aborted attach)
+    must not fail the final install step."""
+    source = tmp_path / "source"
+    files = _store_files(source)
+    _mock_remote(monkeypatch, files)
+    destination = tmp_path / "projects" / PID
+    destination.mkdir(parents=True)
+
+    result = restore_cloud_store(PID, destination)
+
+    assert result == destination
+    assert (destination / "project.md").is_file()
 
 
 @pytest.mark.parametrize("path", ["../escape", "/absolute"])

--- a/packages/nauro/tests/test_recovery.py
+++ b/packages/nauro/tests/test_recovery.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from nauro.store import recovery
+from nauro.store.recovery import RecoveryError, bind_local_store, restore_cloud_store
+from nauro.store.registry import get_project_v2, get_store_path_v2
+from nauro.store.repo_config import save_repo_config
+from nauro.templates.scaffolds import scaffold_project_store
+
+PID = "01KQ6AZGNA0B3QBF67NBXP3S45"
+
+
+def _store_files(root: Path) -> dict[str, bytes]:
+    scaffold_project_store("nauro", root)
+    files: dict[str, bytes] = {}
+    for path in root.rglob("*"):
+        if path.is_file():
+            files[path.relative_to(root).as_posix()] = path.read_bytes()
+    return files
+
+
+def _mock_remote(monkeypatch, files: dict[str, bytes]) -> None:
+    manifest = [
+        {
+            "path": path,
+            "etag": f'"{hashlib.md5(content).hexdigest()}"',
+            "size": len(content),
+            "sha256": hashlib.sha256(content).hexdigest(),
+        }
+        for path, content in sorted(files.items())
+    ]
+    monkeypatch.setattr(recovery, "fetch_manifest", lambda _pid: manifest)
+    monkeypatch.setattr(
+        recovery,
+        "request_presigned_urls",
+        lambda _pid, operations: [
+            {"verb": "GET", "path": op["path"], "url": f"memory://{op['path']}"}
+            for op in operations
+        ],
+    )
+    monkeypatch.setattr(
+        recovery,
+        "fetch_via_presigned_url",
+        lambda url: files[url.removeprefix("memory://")],
+    )
+
+
+def test_bind_local_store_registers_repo_without_copying_store(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    save_repo_config(repo, {"mode": "local", "id": PID, "name": "nauro"})
+    store = tmp_path / "external" / PID
+    scaffold_project_store("nauro", store)
+
+    result = bind_local_store(repo, store)
+
+    assert result.store_path == store
+    assert get_project_v2(PID)["store_path"] == str(store)
+    assert not get_store_path_v2(PID).exists()
+
+
+def test_restore_cloud_store_installs_complete_record_atomically(tmp_path, monkeypatch):
+    source = tmp_path / "source"
+    files = _store_files(source)
+    _mock_remote(monkeypatch, files)
+    destination = tmp_path / "projects" / PID
+
+    restored = restore_cloud_store(PID, destination)
+
+    assert restored == destination
+    assert {
+        path.relative_to(destination).as_posix(): path.read_bytes()
+        for path in destination.rglob("*")
+        if path.is_file()
+    } == files
+    assert not list(destination.parent.glob(f".{PID}.restore-*"))
+
+
+def test_restore_cloud_store_refuses_nonempty_destination_before_network(tmp_path, monkeypatch):
+    destination = tmp_path / PID
+    destination.mkdir()
+    (destination / "keep.txt").write_text("keep")
+
+    def explode(_pid):
+        raise AssertionError("network must not run")
+
+    monkeypatch.setattr(recovery, "fetch_manifest", explode)
+
+    with pytest.raises(RecoveryError, match="nonempty"):
+        restore_cloud_store(PID, destination)
+
+    assert (destination / "keep.txt").read_text() == "keep"
+
+
+def test_restore_cloud_store_cleans_staging_on_hash_mismatch(tmp_path, monkeypatch):
+    source = tmp_path / "source"
+    files = _store_files(source)
+    _mock_remote(monkeypatch, files)
+    manifest = recovery.fetch_manifest(PID)
+    manifest[0]["sha256"] = "0" * 64
+    monkeypatch.setattr(recovery, "fetch_manifest", lambda _pid: manifest)
+    destination = tmp_path / "projects" / PID
+
+    with pytest.raises(RecoveryError, match="hash"):
+        restore_cloud_store(PID, destination)
+
+    assert not destination.exists()
+    assert not list(destination.parent.glob(f".{PID}.restore-*"))
+
+
+def test_restore_cloud_store_rejects_multipart_etag(tmp_path, monkeypatch):
+    source = tmp_path / "source"
+    files = _store_files(source)
+    _mock_remote(monkeypatch, files)
+    manifest = recovery.fetch_manifest(PID)
+    manifest[0]["etag"] = '"0123456789abcdef0123456789abcdef-2"'
+    monkeypatch.setattr(recovery, "fetch_manifest", lambda _pid: manifest)
+    destination = tmp_path / "projects" / PID
+
+    with pytest.raises(RecoveryError, match="unusable content hash"):
+        restore_cloud_store(PID, destination)
+
+    assert not destination.exists()
+    assert not list(destination.parent.glob(f".{PID}.restore-*"))
+
+
+@pytest.mark.parametrize("path", ["../escape", "/absolute"])
+def test_restore_cloud_store_refuses_unsafe_manifest_without_partial_record(
+    path, tmp_path, monkeypatch
+):
+    manifest = [{"path": path, "etag": "e", "size": 1}]
+    monkeypatch.setattr(recovery, "fetch_manifest", lambda _pid: manifest)
+    destination = tmp_path / "projects" / PID
+
+    with pytest.raises(RecoveryError):
+        restore_cloud_store(PID, destination)
+
+    assert not destination.exists()
+
+
+def test_restore_cloud_store_rejects_damaged_decision_graph(tmp_path, monkeypatch):
+    source = tmp_path / "source"
+    files = _store_files(source)
+    decision = next(path for path in files if path.startswith("decisions/"))
+    files[decision] = files[decision].replace(b"superseded_by: null", b"superseded_by: '999'")
+    _mock_remote(monkeypatch, files)
+    destination = tmp_path / "projects" / PID
+
+    with pytest.raises(RecoveryError, match="integrity"):
+        restore_cloud_store(PID, destination)
+
+    assert not destination.exists()

--- a/packages/nauro/tests/test_registry_v2.py
+++ b/packages/nauro/tests/test_registry_v2.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import os
+from pathlib import Path
 
 import pytest
 
@@ -15,12 +17,16 @@ from nauro.constants import (
 from nauro.store import registry
 from nauro.store.registry import (
     RegistrySchemaError,
+    StoreBindingError,
+    bind_project_store_v2,
     is_cloud_project,
     load_registry_v2,
     register_project,
     register_project_v2,
+    resolve_registered_store_path_v2,
     save_registry_v2,
 )
+from nauro.templates.scaffolds import scaffold_project_store
 
 
 def test_load_v2_empty_when_missing(tmp_path, monkeypatch):
@@ -50,6 +56,129 @@ def test_v2_round_trip(tmp_path, monkeypatch):
     save_registry_v2(data)
     loaded = load_registry_v2()
     assert loaded == data
+
+
+def test_v2_round_trip_preserves_optional_external_store_path(tmp_path, monkeypatch):
+    pid = "01KQ6AZGNA0B3QBF67NBXP3S45"
+    store_path = tmp_path / "external" / pid
+    data = {
+        "projects": {
+            pid: {
+                "name": "nauro",
+                "mode": "local",
+                "repo_paths": [str(tmp_path / "repo")],
+                "store_path": str(store_path),
+            }
+        },
+        "schema_version": REGISTRY_SCHEMA_VERSION_V2,
+    }
+
+    save_registry_v2(data)
+
+    assert load_registry_v2() == data
+
+
+def test_bind_external_store_records_validated_absolute_path(tmp_path, monkeypatch):
+    pid = "01KQ6AZGNA0B3QBF67NBXP3S45"
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    store_path = tmp_path / "external" / pid
+    scaffold_project_store("nauro", store_path)
+
+    bound = bind_project_store_v2(
+        project_id=pid,
+        name="nauro",
+        mode="local",
+        repo_path=repo,
+        store_path=store_path,
+    )
+
+    assert bound == store_path
+    entry = load_registry_v2()["projects"][pid]
+    assert entry["store_path"] == str(store_path)
+    assert entry["repo_paths"] == [str(repo.resolve())]
+    assert resolve_registered_store_path_v2(pid) == store_path
+
+
+def test_bind_default_store_omits_optional_store_path(tmp_path, monkeypatch):
+    pid = "01KQ6AZGNA0B3QBF67NBXP3S45"
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    store_path = registry.get_store_path_v2(pid)
+    scaffold_project_store("nauro", store_path)
+
+    bind_project_store_v2(
+        project_id=pid,
+        name="nauro",
+        mode="local",
+        repo_path=repo,
+        store_path=store_path,
+    )
+
+    assert "store_path" not in load_registry_v2()["projects"][pid]
+
+
+def test_bind_external_store_refuses_conflicting_default_store(tmp_path, monkeypatch):
+    pid = "01KQ6AZGNA0B3QBF67NBXP3S45"
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    scaffold_project_store("default", registry.get_store_path_v2(pid))
+    external = tmp_path / "external" / pid
+    scaffold_project_store("external", external)
+
+    with pytest.raises(StoreBindingError) as exc:
+        bind_project_store_v2(
+            project_id=pid,
+            name="nauro",
+            mode="local",
+            repo_path=repo,
+            store_path=external,
+        )
+
+    assert exc.value.reason_code == "connected_binding_conflict"
+    assert load_registry_v2()["projects"] == {}
+
+
+@pytest.mark.skipif(os.name == "nt", reason="symlink creation requires extra Windows privileges")
+def test_bind_external_store_refuses_symlink_component(tmp_path, monkeypatch):
+    pid = "01KQ6AZGNA0B3QBF67NBXP3S45"
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    real_parent = tmp_path / "real"
+    store_path = real_parent / pid
+    scaffold_project_store("nauro", store_path)
+    linked_parent = tmp_path / "linked"
+    linked_parent.symlink_to(real_parent, target_is_directory=True)
+
+    with pytest.raises(StoreBindingError) as exc:
+        bind_project_store_v2(
+            project_id=pid,
+            name="nauro",
+            mode="local",
+            repo_path=repo,
+            store_path=Path(linked_parent / pid),
+        )
+
+    assert exc.value.reason_code == "connected_record_invalid"
+
+
+def test_bind_external_store_refuses_wrong_identity_basename(tmp_path, monkeypatch):
+    pid = "01KQ6AZGNA0B3QBF67NBXP3S45"
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    store_path = tmp_path / "external" / "different-id"
+    scaffold_project_store("nauro", store_path)
+
+    with pytest.raises(StoreBindingError) as exc:
+        bind_project_store_v2(
+            project_id=pid,
+            name="nauro",
+            mode="local",
+            repo_path=repo,
+            store_path=store_path,
+        )
+
+    assert exc.value.reason_code == "connected_record_invalid"
 
 
 def test_v2_save_stamps_schema_version(tmp_path, monkeypatch):

--- a/packages/nauro/tests/test_registry_v2.py
+++ b/packages/nauro/tests/test_registry_v2.py
@@ -157,6 +157,73 @@ def test_bind_default_store_omits_optional_store_path(tmp_path, monkeypatch):
     assert "store_path" not in load_registry_v2()["projects"][pid]
 
 
+def test_bind_update_name_reconciles_rename(tmp_path, monkeypatch):
+    """A caller holding the authoritative current name (cloud membership)
+    reconciles a rename into the registry instead of conflicting."""
+    pid = "01KQ6AZGNA0B3QBF67NBXP3S45"
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    store_path = registry.get_store_path_v2(pid)
+    scaffold_project_store("old-name", store_path)
+    bind_project_store_v2(
+        project_id=pid, name="old-name", mode="local", repo_path=repo, store_path=store_path
+    )
+
+    bind_project_store_v2(
+        project_id=pid,
+        name="new-name",
+        mode="local",
+        repo_path=repo,
+        store_path=store_path,
+        update_name=True,
+    )
+
+    assert load_registry_v2()["projects"][pid]["name"] == "new-name"
+
+
+def test_bind_without_update_name_conflicts_on_rename(tmp_path, monkeypatch):
+    """A name that only comes from repository config never overwrites
+    registry identity — the mismatch stays a typed binding conflict."""
+    pid = "01KQ6AZGNA0B3QBF67NBXP3S45"
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    store_path = registry.get_store_path_v2(pid)
+    scaffold_project_store("old-name", store_path)
+    bind_project_store_v2(
+        project_id=pid, name="old-name", mode="local", repo_path=repo, store_path=store_path
+    )
+
+    with pytest.raises(StoreBindingError) as excinfo:
+        bind_project_store_v2(
+            project_id=pid,
+            name="new-name",
+            mode="local",
+            repo_path=repo,
+            store_path=store_path,
+        )
+    assert excinfo.value.reason_code == "connected_binding_conflict"
+    assert load_registry_v2()["projects"][pid]["name"] == "old-name"
+
+
+def test_bind_default_store_tolerates_incomplete_structure(tmp_path, monkeypatch):
+    """Binding the Nauro-managed default path requires existence, not full
+    structure, so first connection to an empty cloud record can bind the
+    empty mirror directory that sync will populate. External paths keep the
+    strict rule (covered by the external-store tests)."""
+    pid = "01KQ6AZGNA0B3QBF67NBXP3S45"
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    store_path = registry.get_store_path_v2(pid)
+    store_path.mkdir(parents=True)
+
+    bound = bind_project_store_v2(
+        project_id=pid, name="nauro", mode="local", repo_path=repo, store_path=store_path
+    )
+
+    assert bound == store_path
+    assert load_registry_v2()["projects"][pid]["name"] == "nauro"
+
+
 def test_bind_external_store_refuses_conflicting_default_store(tmp_path, monkeypatch):
     pid = "01KQ6AZGNA0B3QBF67NBXP3S45"
     repo = tmp_path / "repo"

--- a/packages/nauro/tests/test_registry_v2.py
+++ b/packages/nauro/tests/test_registry_v2.py
@@ -16,6 +16,7 @@ from nauro.constants import (
 )
 from nauro.store import registry
 from nauro.store.registry import (
+    RegistryEntryV2,
     RegistrySchemaError,
     StoreBindingError,
     bind_project_store_v2,
@@ -25,6 +26,7 @@ from nauro.store.registry import (
     register_project_v2,
     resolve_registered_store_path_v2,
     save_registry_v2,
+    validate_registry_entry_v2,
 )
 from nauro.templates.scaffolds import scaffold_project_store
 
@@ -76,6 +78,43 @@ def test_v2_round_trip_preserves_optional_external_store_path(tmp_path, monkeypa
     save_registry_v2(data)
 
     assert load_registry_v2() == data
+
+
+def test_registry_entry_boundary_normalizes_lists_without_changing_json_shape():
+    raw = {
+        "name": "nauro",
+        "mode": "local",
+        "repo_paths": ["/work/nauro"],
+        "future_field": {"enabled": True},
+    }
+
+    entry = validate_registry_entry_v2("01KQ6AZGNA0B3QBF67NBXP3S45", raw)
+
+    assert isinstance(entry, RegistryEntryV2)
+    assert entry.repo_paths == ("/work/nauro",)
+    assert entry.model_dump(mode="json", exclude_unset=True) == raw
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("mode", "remote"),
+        ("repo_paths", [42]),
+        ("store_path", 42),
+    ],
+)
+def test_registry_entry_boundary_rejects_malformed_typed_fields(field, value):
+    raw = {
+        "name": "nauro",
+        "mode": "local",
+        "repo_paths": ["/work/nauro"],
+        field: value,
+    }
+
+    with pytest.raises(StoreBindingError) as exc:
+        validate_registry_entry_v2("01KQ6AZGNA0B3QBF67NBXP3S45", raw)
+
+    assert exc.value.reason_code == "connected_record_invalid"
 
 
 def test_bind_external_store_records_validated_absolute_path(tmp_path, monkeypatch):

--- a/packages/nauro/tests/test_resolution_v2.py
+++ b/packages/nauro/tests/test_resolution_v2.py
@@ -396,8 +396,16 @@ def test_registered_invalid_external_store_is_typed_invalid(tmp_path, monkeypatc
     assert "doctor" not in result.guidance
 
 
-def test_registered_invalid_default_store_is_typed_invalid(tmp_path, monkeypatch):
-    from nauro.store.resolution import DisconnectedProject, resolve_from_cwd
+def test_incomplete_default_store_resolves_tolerantly(tmp_path, monkeypatch):
+    """The Nauro-managed default store keeps its pre-recovery tolerance.
+
+    An existing but structurally incomplete default-home store (e.g. created
+    empty by an older attach whose sync never completed) must resolve so
+    downstream tools can degrade gracefully — not dead-end every command in a
+    connected_record_invalid state whose recovery menu cannot restore. Strict
+    structural validation applies only to externally mapped store paths.
+    """
+    from nauro.store.resolution import RepoResolution, resolve_from_cwd
 
     repo = tmp_path / "repo"
     repo.mkdir()
@@ -419,8 +427,63 @@ def test_registered_invalid_default_store_is_typed_invalid(tmp_path, monkeypatch
 
     result = resolve_from_cwd(repo)
 
+    assert isinstance(result, RepoResolution)
+    assert result.store_path == registry.get_store_path_v2(pid)
+
+
+def test_default_store_with_symlinked_component_is_typed_invalid(tmp_path, monkeypatch):
+    """Tolerance for the managed default path means components may be
+    absent — never that a pre-planted symlink may redirect store reads or
+    sync writes outside the store.
+    """
+    from nauro.store.resolution import DisconnectedProject, resolve_from_cwd
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    pid = "01KQ6AZGNA0B3QBF67NBXP3S45"
+    store = registry.get_store_path_v2(pid)
+    store.mkdir(parents=True)
+    (store / "project.md").write_text("# Pareto\n")
+    outside = tmp_path / "outside-decisions"
+    outside.mkdir()
+    (store / "decisions").symlink_to(outside, target_is_directory=True)
+    registry.save_registry_v2(
+        {
+            "schema_version": 2,
+            "projects": {
+                pid: {
+                    "name": "Pareto",
+                    "mode": "local",
+                    "repo_paths": [str(repo)],
+                }
+            },
+        }
+    )
+    save_repo_config(repo, {"mode": "local", "id": pid, "name": "Pareto"})
+
+    result = resolve_from_cwd(repo)
+
     assert isinstance(result, DisconnectedProject)
     assert result.reason_code == "connected_record_invalid"
+
+
+def test_v1_project_with_missing_store_yields_no_project(tmp_path, monkeypatch):
+    """A legacy name-keyed project whose store directory is gone falls
+    through to the no-project outcome — never a path that read tools would
+    treat as an empty store and write tools would silently recreate.
+    """
+    import shutil
+
+    from nauro.store.registry import register_project
+    from nauro.store.resolution import resolve_from_cwd
+
+    repo = tmp_path / "v1repo"
+    repo.mkdir()
+    store = register_project("legacy", [repo])
+    if store.exists():
+        shutil.rmtree(store)
+
+    assert resolve_from_cwd(repo) is None
 
 
 @pytest.mark.parametrize("raw_store_path", [42, "", None])

--- a/packages/nauro/tests/test_resolution_v2.py
+++ b/packages/nauro/tests/test_resolution_v2.py
@@ -61,7 +61,7 @@ def _post_migration_state(tmp_path, monkeypatch):
     cloud_pid = "01KQ6AZGNA0B3QBF67NBXP3S45"
     repo_root = tmp_path / "cloud_repo"
     repo_root.mkdir()
-    (tmp_path / "projects" / cloud_pid).mkdir(parents=True)
+    scaffold_project_store("nauro", tmp_path / "projects" / cloud_pid)
     (tmp_path / REGISTRY_FILENAME).write_text(
         json.dumps(
             {
@@ -121,6 +121,7 @@ def test_explicit_project_flag_overrides_repo_config(tmp_path, monkeypatch):
         [tmp_path / "beta_repo"],
         mode="local",
     )
+    scaffold_project_store("beta", _store)
     (tmp_path / "beta_repo").mkdir()
     monkeypatch.chdir(repo_root)
     name, store = resolve_target_project("beta")
@@ -393,6 +394,95 @@ def test_registered_invalid_external_store_is_typed_invalid(tmp_path, monkeypatc
     assert result.reason_code == "connected_record_invalid"
     assert "Run `nauro reconnect`" in result.guidance
     assert "doctor" not in result.guidance
+
+
+def test_registered_invalid_default_store_is_typed_invalid(tmp_path, monkeypatch):
+    from nauro.store.resolution import DisconnectedProject, resolve_from_cwd
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    pid = "01KQ6AZGNA0B3QBF67NBXP3S45"
+    registry.get_store_path_v2(pid).mkdir(parents=True)
+    registry.save_registry_v2(
+        {
+            "schema_version": 2,
+            "projects": {
+                pid: {
+                    "name": "Pareto",
+                    "mode": "local",
+                    "repo_paths": [str(repo)],
+                }
+            },
+        }
+    )
+    save_repo_config(repo, {"mode": "local", "id": pid, "name": "Pareto"})
+
+    result = resolve_from_cwd(repo)
+
+    assert isinstance(result, DisconnectedProject)
+    assert result.reason_code == "connected_record_invalid"
+
+
+@pytest.mark.parametrize("raw_store_path", [42, "", None])
+def test_malformed_registered_store_path_is_typed_invalid(tmp_path, monkeypatch, raw_store_path):
+    from nauro.store.resolution import DisconnectedProject, resolve_from_cwd
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    pid = "01KQ6AZGNA0B3QBF67NBXP3S45"
+    registry.save_registry_v2(
+        {
+            "schema_version": 2,
+            "projects": {
+                pid: {
+                    "name": "Pareto",
+                    "mode": "local",
+                    "repo_paths": [str(repo)],
+                    "store_path": raw_store_path,
+                }
+            },
+        }
+    )
+    save_repo_config(repo, {"mode": "local", "id": pid, "name": "Pareto"})
+
+    result = resolve_from_cwd(repo)
+
+    assert isinstance(result, DisconnectedProject)
+    assert result.reason_code == "connected_record_invalid"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="symlink creation requires extra Windows privileges")
+def test_default_store_preserves_symlinked_nauro_home(tmp_path, monkeypatch):
+    from nauro.store.resolution import RepoResolution, resolve_from_cwd
+
+    real_home = tmp_path / "real-home"
+    real_home.mkdir()
+    linked_home = tmp_path / "linked-home"
+    linked_home.symlink_to(real_home, target_is_directory=True)
+    monkeypatch.setenv("NAURO_HOME", str(linked_home))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    pid = "01KQ6AZGNA0B3QBF67NBXP3S45"
+    store_path = registry.get_store_path_v2(pid)
+    scaffold_project_store("Pareto", store_path)
+    registry.save_registry_v2(
+        {
+            "schema_version": 2,
+            "projects": {
+                pid: {
+                    "name": "Pareto",
+                    "mode": "local",
+                    "repo_paths": [str(repo)],
+                }
+            },
+        }
+    )
+    save_repo_config(repo, {"mode": "local", "id": pid, "name": "Pareto"})
+
+    result = resolve_from_cwd(repo)
+
+    assert isinstance(result, RepoResolution)
+    assert result.store_path == store_path
 
 
 def test_conflicting_default_and_external_stores_is_typed_conflict(tmp_path, monkeypatch):

--- a/packages/nauro/tests/test_resolution_v2.py
+++ b/packages/nauro/tests/test_resolution_v2.py
@@ -32,6 +32,7 @@ from nauro.constants import (
 from nauro.mcp.stdio_server import _resolve_store
 from nauro.store import registry
 from nauro.store.repo_config import load_repo_config, save_repo_config
+from nauro.templates.scaffolds import scaffold_project_store
 
 runner = CliRunner()
 
@@ -293,6 +294,168 @@ def test_resolve_from_cwd_repo_config_tier(tmp_path, monkeypatch):
     assert resolution.store_path == tmp_path / "projects" / cloud_pid
     assert resolution.project_id == cloud_pid
     assert resolution.display_name == "nauro"
+
+
+def test_valid_repo_config_without_registry_is_typed_first_connection(tmp_path, monkeypatch):
+    from nauro.store.resolution import DisconnectedProject, resolve_from_cwd
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    pid = "01KQ6AZGNA0B3QBF67NBXP3S45"
+    save_repo_config(repo, {"mode": "local", "id": pid, "name": "Pareto"})
+
+    result = resolve_from_cwd(repo)
+
+    assert isinstance(result, DisconnectedProject)
+    assert result.project_id == pid
+    assert result.reason_code == "not_connected_on_this_machine"
+    assert result.recovery_actions == ("locate", "continue")
+    assert "has not been connected on this machine" in result.guidance
+    assert "nauro link --cloud" in result.guidance
+    assert "Welcome to Nauro" not in result.guidance
+
+
+def test_cloud_first_connection_offers_eligible_restore(tmp_path, monkeypatch):
+    from nauro.store.resolution import DisconnectedProject, resolve_from_cwd
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    pid = "01KQ6AZGNA0B3QBF67NBXP3S45"
+    save_repo_config(
+        repo,
+        {
+            "mode": "cloud",
+            "id": pid,
+            "name": "Pareto",
+            "server_url": "https://mcp.nauro.ai",
+        },
+    )
+
+    result = resolve_from_cwd(repo)
+
+    assert isinstance(result, DisconnectedProject)
+    assert result.reason_code == "not_connected_on_this_machine"
+    assert result.recovery_actions == ("locate", "restore", "continue")
+    assert result.guidance == (
+        "This cloud project has not been connected on this machine. "
+        "Run `nauro reconnect` to verify access and restore its latest synced record."
+    )
+
+
+def test_registered_missing_store_is_typed_prior_connection_loss(tmp_path, monkeypatch):
+    from nauro.store.resolution import DisconnectedProject, resolve_from_cwd
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    pid = "01KQ6AZGNA0B3QBF67NBXP3S45"
+    registry.save_registry_v2(
+        {
+            "schema_version": 2,
+            "projects": {pid: {"name": "Pareto", "mode": "local", "repo_paths": [str(repo)]}},
+        }
+    )
+    save_repo_config(repo, {"mode": "local", "id": pid, "name": "Pareto"})
+
+    result = resolve_from_cwd(repo)
+
+    assert isinstance(result, DisconnectedProject)
+    assert result.reason_code == "connected_record_missing"
+    assert "was connected on this machine" in result.guidance
+    assert "Welcome to Nauro" not in result.guidance
+
+
+def test_registered_invalid_external_store_is_typed_invalid(tmp_path, monkeypatch):
+    from nauro.store.resolution import DisconnectedProject, resolve_from_cwd
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    pid = "01KQ6AZGNA0B3QBF67NBXP3S45"
+    invalid = tmp_path / "external" / pid
+    invalid.mkdir(parents=True)
+    registry.save_registry_v2(
+        {
+            "schema_version": 2,
+            "projects": {
+                pid: {
+                    "name": "Pareto",
+                    "mode": "local",
+                    "repo_paths": [str(repo)],
+                    "store_path": str(invalid),
+                }
+            },
+        }
+    )
+    save_repo_config(repo, {"mode": "local", "id": pid, "name": "Pareto"})
+
+    result = resolve_from_cwd(repo)
+
+    assert isinstance(result, DisconnectedProject)
+    assert result.reason_code == "connected_record_invalid"
+    assert "Run `nauro reconnect`" in result.guidance
+    assert "doctor" not in result.guidance
+
+
+def test_conflicting_default_and_external_stores_is_typed_conflict(tmp_path, monkeypatch):
+    from nauro.store.resolution import DisconnectedProject, resolve_from_cwd
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    pid = "01KQ6AZGNA0B3QBF67NBXP3S45"
+    external = tmp_path / "external" / pid
+    scaffold_project_store("Pareto", external)
+    scaffold_project_store("Pareto", registry.get_store_path_v2(pid))
+    registry.save_registry_v2(
+        {
+            "schema_version": 2,
+            "projects": {
+                pid: {
+                    "name": "Pareto",
+                    "mode": "local",
+                    "repo_paths": [str(repo)],
+                    "store_path": str(external),
+                }
+            },
+        }
+    )
+    save_repo_config(repo, {"mode": "local", "id": pid, "name": "Pareto"})
+
+    result = resolve_from_cwd(repo)
+
+    assert isinstance(result, DisconnectedProject)
+    assert result.reason_code == "connected_binding_conflict"
+    assert "will not choose or overwrite either" in result.guidance
+
+
+def test_valid_external_store_resolves_through_registry_binding(tmp_path, monkeypatch):
+    from nauro.store.recovery import bind_local_store
+    from nauro.store.resolution import RepoResolution, resolve_from_cwd
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    pid = "01KQ6AZGNA0B3QBF67NBXP3S45"
+    external = tmp_path / "external" / pid
+    scaffold_project_store("Pareto", external)
+    save_repo_config(repo, {"mode": "local", "id": pid, "name": "Pareto"})
+    bind_local_store(repo, external)
+
+    result = resolve_from_cwd(repo)
+
+    assert isinstance(result, RepoResolution)
+    assert result.store_path == external
+
+
+def test_resolve_store_raises_typed_disconnected_error(tmp_path, monkeypatch):
+    from nauro.store.resolution import DisconnectedProjectError
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    pid = "01KQ6AZGNA0B3QBF67NBXP3S45"
+    save_repo_config(repo, {"mode": "local", "id": pid, "name": "Pareto"})
+
+    with pytest.raises(DisconnectedProjectError) as exc:
+        _resolve_store(None, repo)
+
+    assert exc.value.state.reason_code == "not_connected_on_this_machine"
 
 
 def test_resolve_from_cwd_v2_registry_by_path_tier(tmp_path, monkeypatch):

--- a/packages/nauro/tests/test_search_decisions_parity.py
+++ b/packages/nauro/tests/test_search_decisions_parity.py
@@ -73,6 +73,8 @@ def empty_repo(tmp_path, monkeypatch):
     pid, store_path = register_project_v2("empty-search", [repo], mode=REPO_CONFIG_MODE_LOCAL)
     save_repo_config(repo, {"mode": REPO_CONFIG_MODE_LOCAL, "id": pid, "name": "empty-search"})
     store_path.mkdir(parents=True, exist_ok=True)
+    (store_path / "project.md").touch()
+    (store_path / "decisions").mkdir()
     monkeypatch.chdir(repo)
     return pid, store_path
 

--- a/packages/nauro/tests/test_setup_extended.py
+++ b/packages/nauro/tests/test_setup_extended.py
@@ -258,7 +258,8 @@ def test_setup_claude_code_subcommand_unchanged(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("HOME", str(tmp_path))  # divert ~/.claude search
     repo = tmp_path / "myrepo"
     repo.mkdir()
-    register_project_v2("myproj", [repo])
+    _, store_path = register_project_v2("myproj", [repo])
+    scaffold_project_store("myproj", store_path)
     monkeypatch.chdir(repo)
 
     result = runner.invoke(app, ["setup", "claude-code"])
@@ -551,7 +552,8 @@ def test_setup_claude_code_advertises_check_decision(tmp_path: Path, monkeypatch
     monkeypatch.setenv("HOME", str(tmp_path))
     repo = tmp_path / "myrepo"
     repo.mkdir()
-    register_project_v2("myproj", [repo])
+    _, store_path = register_project_v2("myproj", [repo])
+    scaffold_project_store("myproj", store_path)
     monkeypatch.chdir(repo)
 
     result = runner.invoke(app, ["setup", "claude-code"])
@@ -564,7 +566,8 @@ def test_setup_claude_code_remove_does_not_advertise_check_decision(tmp_path: Pa
     monkeypatch.setenv("HOME", str(tmp_path))
     repo = tmp_path / "myrepo"
     repo.mkdir()
-    register_project_v2("myproj", [repo])
+    _, store_path = register_project_v2("myproj", [repo])
+    scaffold_project_store("myproj", store_path)
     monkeypatch.chdir(repo)
 
     result = runner.invoke(app, ["setup", "claude-code", "--remove"])
@@ -1050,7 +1053,8 @@ def test_setup_claude_code_still_prints_restart_line(tmp_path: Path, monkeypatch
     monkeypatch.setenv("HOME", str(tmp_path))
     repo = tmp_path / "myrepo"
     repo.mkdir()
-    register_project_v2("myproj", [repo])
+    _, store_path = register_project_v2("myproj", [repo])
+    scaffold_project_store("myproj", store_path)
     monkeypatch.chdir(repo)
 
     result = runner.invoke(app, ["setup", "claude-code"])

--- a/packages/nauro/tests/test_stdio_renderer_wrap.py
+++ b/packages/nauro/tests/test_stdio_renderer_wrap.py
@@ -33,6 +33,7 @@ from nauro.mcp.stdio_server import (
 )
 from nauro.store.filesystem_store import FilesystemStore
 from nauro.store.registry import register_project
+from nauro.store.repo_config import save_repo_config
 from nauro.templates.scaffolds import scaffold_project_store
 from tests._writer_compat import append_decision
 
@@ -111,8 +112,7 @@ class TestSingleBlockReadTools:
 
 
 class TestNoStructuredContent:
-    """Renderer-scoped read tools must not emit ``structuredContent`` —
-    the wire shape is a single text block carrying the renderer output."""
+    """Healthy renderer-scoped reads stay single-block text responses."""
 
     def test_get_context_has_no_structured_content(self, seeded_store: Path):
         result = get_context(project_id="blockshape", level=0)
@@ -136,6 +136,53 @@ class TestNoStructuredContent:
             project_id="blockshape",
         )
         assert result.structuredContent is None
+
+
+@pytest.mark.parametrize(
+    ("tool", "kwargs"),
+    [
+        (get_context, {"level": 0}),
+        (list_decisions, {}),
+        (get_decision, {"number": 1}),
+        (search_decisions, {"query": "typed recovery"}),
+        (check_decision, {"proposed_approach": "Use typed recovery"}),
+    ],
+)
+def test_disconnected_renderer_reads_preserve_full_structured_envelope(
+    tool, kwargs, tmp_path, monkeypatch
+):
+    repo = tmp_path / "disconnected"
+    repo.mkdir()
+    project_id = "01KQ6AZGNA0B3QBF67NBXP3S45"
+    save_repo_config(repo, {"mode": "local", "id": project_id, "name": "Pareto"})
+
+    result = tool(cwd=str(repo), **kwargs)
+
+    assert isinstance(result, CallToolResult)
+    assert result.structuredContent is not None
+    assert set(result.structuredContent) == {
+        "store",
+        "status",
+        "error",
+        "guidance",
+        "project_id",
+        "project_name",
+        "project_mode",
+        "reason_code",
+        "recovery_actions",
+    }
+    assert result.structuredContent["store"] == "local"
+    assert result.structuredContent["status"] == "error"
+    assert result.structuredContent["error"] == {
+        "kind": "error",
+        "reason": result.structuredContent["guidance"],
+    }
+    assert result.structuredContent["project_id"] == project_id
+    assert result.structuredContent["project_name"] == "Pareto"
+    assert result.structuredContent["project_mode"] == "local"
+    assert result.structuredContent["reason_code"] == "not_connected_on_this_machine"
+    assert result.structuredContent["recovery_actions"] == ["locate", "continue"]
+    assert result.content[0].text == result.structuredContent["guidance"]
 
 
 class TestSingleBlockReads:

--- a/packages/nauro/tests/test_stdio_server.py
+++ b/packages/nauro/tests/test_stdio_server.py
@@ -241,6 +241,30 @@ class TestWelcomeDisambiguation:
         assert result["status"] == "error"
         assert "Welcome to Nauro" in result["guidance"]
 
+    def test_disconnected_project_returns_structured_recovery_envelope(self, tmp_path, monkeypatch):
+        from nauro.store.repo_config import save_repo_config
+
+        repo = tmp_path / "disconnected"
+        repo.mkdir()
+        pid = "01KQ6AZGNA0B3QBF67NBXP3S45"
+        save_repo_config(repo, {"mode": "local", "id": pid, "name": "Pareto"})
+
+        result = get_raw_file(path="project.md", cwd=str(repo))
+
+        assert result["status"] == "error"
+        assert result["error"]["kind"] == "error"
+        assert result["error"]["reason"] == result["guidance"]
+        assert result["project_id"] == pid
+        assert result["project_name"] == "Pareto"
+        assert result["project_mode"] == "local"
+        assert result["reason_code"] == "not_connected_on_this_machine"
+        assert result["recovery_actions"] == ["locate", "continue"]
+        assert "Welcome to Nauro" not in result["guidance"]
+
+        write_result = update_state(delta="anything", cwd=str(repo))
+        assert isinstance(write_result, dict)
+        assert write_result["reason_code"] == "not_connected_on_this_machine"
+
 
 class TestCheckDecision:
     def test_check_no_conflicts(self, store: Path):


### PR DESCRIPTION
## Why

Repositories can carry valid committed project identity while their machine-local record lives outside the default Nauro home or is unavailable. Existing resolution could collapse that state into onboarding or an unknown project, blocking multi-repository use and suggesting the wrong recovery path.

## What changed

- Added typed first-connect, missing-record, invalid-record, and binding-conflict states with consistent CLI and MCP guidance.
- Added validated machine-local external store bindings and `nauro reconnect`.
- Shared membership validation, local binding, and staged atomic cloud restoration across attach and reconnect.
- Routed status, hooks, initialization, linking, adoption removal, and project removal through the registry-aware boundary.
- Repaired recovery-boundary regressions surfaced in review: canonical-destination and strict-structure rules now bind externally mapped paths only, so the managed default path restores under a symlinked NAURO_HOME and an incomplete default store resolves tolerantly (symlinked store components stay refused in both modes); attach falls back to its empty-store-then-sync contract only on first connection to a confirmed-empty cloud record, while recovery paths keep the hard stop; missing legacy v1 stores fall through to the no-project outcome instead of resolving to a phantom path; attach and reconnect reconcile server-side renames under verified cloud membership without letting repository config rewrite registry identity.
- Regenerated the public CLI contract and added focused regression coverage.

## Test plan

- `pytest -q packages/nauro/tests packages/nauro-core/tests --ignore=packages/nauro/tests/cross_surface`
- `ruff check packages benchmarks`
- `ruff format --check packages benchmarks`
- Reset the Pareto fixture twice at one stable output and verify its registry binding and expected retrieval.
- Validate the persistent clean Pareto fixture from its repository without an explicit project ID.

## Risk / what to review

- External bindings fail closed when a default-home record for the same project also exists.
- Cloud restoration stages beside the destination, validates size, sha256 when the manifest carries it, store structure, and store integrity; the content-MD5 comparison runs only when the ETag is a usable single-part MD5 (multipart and SSE ETags are opaque). It refuses nonempty targets and installs atomically, replacing a leftover empty destination directory on every platform.
- Older clients ignore the optional registry field and cannot silently select an external record.
- The rename reconciliation is gated: only membership-verified callers pass `update_name`, mode divergences still conflict unconditionally, and repository-config-derived binding never rewrites registry identity.

## Deferred

Doctor remains focused on store integrity. Setup wiring, machine-local gitignore policy, and the explicit start-over flow after confirmed data loss remain separate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
