### PR TITLE
Trim README to the core onboarding path

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,21 +4,17 @@
 
 Nauro keeps current state, open questions, and human-approved project judgment in one record, ready for every agent you connect.
 
-That record combines project scope, current state, and open questions with human-approved project judgment, including intent, goals, decisions, rationale, tradeoffs, and rejected paths.
-
-Project judgment is the human-ratified part of the record. Context is the slice Nauro gives an agent for the work in front of it. Before connected agents plan or change work, Nauro surfaces that context. New or revised judgment becomes project truth only after you approve it.
-
-The record belongs to the project and is available from Claude, Cursor, Codex, Perplexity, and other MCP clients.
+The record combines project scope, state, open questions, and the rationale behind decisions. Nauro surfaces the relevant slice before work, then carries approved judgment and reported progress into later sessions and connected tools.
 
 [![PyPI](https://img.shields.io/pypi/v/nauro.svg)](https://pypi.org/project/nauro/) [![Python](https://img.shields.io/pypi/pyversions/nauro.svg)](https://pypi.org/project/nauro/) [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 
 **Status:** Stable (1.x). Semantic versioning covers the CLI, local stdio MCP contract, on-disk store format, and curated `nauro-core` import API. Cloud sync and hosted MCP are versioned separately.
 
-## Pareto example
+## See it in practice
 
 https://github.com/user-attachments/assets/9e6c475b-c584-470b-84c2-12f01b3a425a
 
-*A real Codex session in Pareto, a reproducible mock project. Nauro retrieves the existing concurrency cap before the agent recommends a top-tier override. After approval, the agent records the decision and changes the code. This is one controlled example; recurring value in other projects remains unproven.*
+*A real Codex session in Pareto, a reproducible mock project. Nauro retrieves an existing concurrency cap before the agent recommends an override. After approval, the agent records the decision and changes the code. This is one controlled example. Recurring value in other projects remains unproven.*
 
 ## Install
 
@@ -26,13 +22,11 @@ https://github.com/user-attachments/assets/9e6c475b-c584-470b-84c2-12f01b3a425a
 uv tool install nauro
 ```
 
-`uv` fetches its own Python, so Python does not need to be pre-installed. Install `uv` with `curl -LsSf https://astral.sh/uv/install.sh | sh` on macOS or Linux, or follow the [PowerShell instructions](https://docs.astral.sh/uv/getting-started/installation/) on Windows. If Python 3.10 or newer is already installed, `pipx install nauro` and `pip install nauro` also work.
+Install `uv` with `curl -LsSf https://astral.sh/uv/install.sh | sh` on macOS or Linux, or use the [Windows instructions](https://docs.astral.sh/uv/getting-started/installation/). With Python 3.10 or newer, `pipx install nauro` also works.
 
-Nauro does not send product analytics. The `nauro telemetry` commands remain as inert compatibility shims during 1.x and will be removed in 2.0. Existing `telemetry` sections in `~/.nauro/config.json` are ignored and left untouched.
+## Try Pennykeep
 
-## Try it in 30 seconds
-
-The Pennykeep demo needs no account, MCP wiring, or agent restart:
+The local demo needs no account or agent setup:
 
 ```bash
 mkdir -p /tmp/nauro-demo && cd /tmp/nauro-demo
@@ -40,96 +34,30 @@ nauro init --demo
 nauro check-decision "Store dollar amounts as decimal numbers"
 ```
 
-Pennykeep is a fictional local-first budgeting project with thirteen decisions. Its top match is:
+The top result is `D001`, **Amounts stored in integer cents, never floating point**. Its rationale explains why floating point makes money totals drift.
 
-```text
-D001 "Amounts stored in integer cents, never floating point"
-```
-
-The stored decision says to use integer cents because binary floating point cannot represent values such as 0.10 exactly. The agent reads the decision body, including its rationale and rejected path, and judges its relevance.
-
-`check-decision` uses deterministic BM25 keyword retrieval and ranks results by keyword overlap rather than semantic meaning. It never blocks a change. The MCP `check_decision` tool returns the same result directly to a connected agent before planning.
-
-## Use Nauro on a real repo
-
-Run adoption from the root of an existing Git repository:
+## Use it on your repo
 
 ```bash
 cd your-repo
 nauro adopt
 ```
 
-The command registers the project, writes `.nauro/config.json`, and wires local MCP access plus the adoption skill for Claude Code, Cursor, and Codex. Restart the agent, then invoke `/nauro-adopt`.
+Restart your agent, then invoke `/nauro-adopt`. The skill reads project documentation and code, asks you about missing rationale, and seeds the project record without inventing decisions.
 
-The skill reads project documentation for rationale and inspects the repository as supporting evidence. When the files show what the project does but not why, it asks you instead of inventing a decision.
+Nauro surfaces prior judgment for the agent to assess. Retrieval is advisory and never blocks a change. New or revised judgment is written only after your explicit approval. Local use needs no account. The local record is plain Markdown that you own. Cloud sync and remote MCP access are optional. Nauro sends no product analytics.
 
-Review `.nauro/config.json` and commit it with the repo. Setup variants and optional tooling are covered in the [quickstart](https://nauro.ai/docs/quickstart) and [agents and skills guide](https://nauro.ai/docs/agents-and-skills).
+Adoption, setup, and incidental regeneration preserve an unmanaged `AGENTS.md` and warn. `nauro sync` is the sole explicit overwrite path. A `# Manual` section survives replacement.
 
-If the repo already has a hand-written AGENTS.md, adoption and setup leave it in place and warn. Running `nauro sync` is the one action that overwrites it; a `# Manual` section survives the rewrite.
-
-## How the loop works
-
-1. Nauro orients the agent with project scope, current state, open questions, and relevant prior judgment.
-2. You and the agent clarify missing intent, constraints, or tradeoffs.
-3. If the work needs new or revised judgment, the agent drafts it and waits for your explicit approval.
-4. The agent plans, recommends, or implements with that context in view.
-5. The agent explains how the context shaped the result. You can accept or correct it, grant an exception, or reopen and supersede prior judgment.
-6. The agent reports meaningful completed progress as current state, so later connected agents inherit the updated state and approved judgment.
-
-`check_decision` surfaces related records before a technical choice. `propose_decision` commits only the draft you have approved.
-
-No model decides what your project believes. Retrieval remains advisory, and agent output cannot silently change project judgment. Current state and open questions share the record, but they do not use the judgment approval contract. The local record is plain Markdown in a folder you own, and cloud sync is optional.
-
-## When it fits
+## Fit
 
 If a small repo plus a reliable AGENTS.md or CLAUDE.md keeps agents oriented, Nauro may be more than you need.
 
-Nauro is intended for longer-lived work where context can be lost between sessions or needs to move between tools and repositories. If agents reliably consult committed decision files, those files may be enough. Built-in memories remain tied to one product; Nauro keeps the project record independent of the connected client.
+Nauro is intended for longer-lived work where context can decay across sessions, tools, repositories, machines, or repeated handoffs.
 
-Current limits:
-
-- The project record is necessarily partial. Nauro can surface only what has been recorded. Retrieval does not establish that an agent understands the project or that a decision still applies unchanged.
-- Keyword retrieval can miss a relevant decision phrased in different language. An optional embeddings index adds synonym matching.
-- Each connected-agent check adds an MCP read and remains advisory. Nauro does not force an agent to honor a result.
-- Nauro is not a backlog, task orchestrator, code indexer, or replacement for Git history.
-- Hosted projects are single-owner today. Nauro does not provide team governance or concurrent multi-writer authority.
-
-## Local and cloud access
-
-Local use needs no account or cloud service. The record stays as plain Markdown on your machine unless you enable cloud sync. The hosted connector at `https://mcp.nauro.ai/mcp` and cloud setup are documented in [Connect your agent](https://nauro.ai/docs/connect).
-
-Codex remote users must set `mcp_oauth_callback_port = 8765` at the top of `~/.codex/config.toml`. Without it, Codex selects a random callback port that Auth0 cannot accept.
-
-## Inspect the record
-
-`nauro graph` writes one self-contained HTML file with Graph, Lineage, Timeline, and Browse views. By default, it embeds decision titles, metadata, open-question summaries, and full decision bodies. With `--no-include-bodies`, it keeps the titles, metadata, and question summaries but omits full decision bodies.
-
-`nauro doctor` reports structural defects without editing the store.
-
-Connected agents can request L0 for a concise orientation, L1 for a bounded working set, or L2 for a full dump. On mature stores, L2 can reach hundreds of thousands of tokens, so agents should start with L0 and retrieve exact records as needed.
-
-## Documentation
-
-- [Quickstart](https://nauro.ai/docs/quickstart): installation, demo, adoption, imports, and setup variants
-- [Connect your agent](https://nauro.ai/docs/connect): local MCP, remote MCP, chat surfaces, and cloud sync
-- [Agents and skills](https://nauro.ai/docs/agents-and-skills): optional workflow tooling, including `nauro setup all --with-subagents`
-- [Core concepts](https://nauro.ai/docs/concepts) and [store guide](https://nauro.ai/docs/store): judgment, context, retrieval, and files
-- [CLI reference](https://nauro.ai/docs/cli) and [MCP reference](https://nauro.ai/docs/mcp): commands, tools, schemas, and examples
-- [Data storage](https://nauro.ai/docs/data-storage): local and hosted storage boundaries
-
-## Uninstall
-
-From an adopted repo:
-
-```bash
-nauro adopt --remove
-```
-
-This reverses adoption for the current repo. The Markdown store stays on disk unless you explicitly pass `--purge-store` for the project's last repo. Remove the CLI with `uv tool uninstall nauro`.
+Read the [documentation](https://nauro.ai/docs) for setup variants, concepts, command references, storage, and cloud access.
 
 ## Development
-
-The monorepo contains the `nauro` CLI and the reusable `nauro-core` library. See [CLAUDE.md](CLAUDE.md) for the architecture.
 
 ```bash
 uv sync --all-packages --all-extras
@@ -139,6 +67,4 @@ uv run pytest packages/nauro/tests/ -x -q
 
 Report bugs and request features in [GitHub Issues](https://github.com/Nauro-AI/nauro/issues).
 
-Apache 2.0.
-
-Named for Peter Naur's *Programming as Theory Building* (1985).
+Apache 2.0. Named for Peter Naur's *Programming as Theory Building* (1985).

--- a/packages/nauro/tests/test_distribution_copy.py
+++ b/packages/nauro/tests/test_distribution_copy.py
@@ -40,15 +40,15 @@ PUBLIC_COPY_PATHS = (
 )
 
 
-def test_readme_uses_stable_context_and_setup_claims() -> None:
+def test_root_readme_stays_within_first_use_scope() -> None:
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
-    assert "L0 for a concise orientation" in readme
-    assert "L1 for a bounded working set" in readme
-    assert "L2 for a full dump" in readme
-    assert "hundreds of thousands of tokens" in readme
-    assert "nauro setup all --with-subagents" in readme
-    assert "tests across" not in readme
-    assert "o200k_base" not in readme
+    assert 400 <= len(readme.split()) <= 520
+    assert "uv tool install nauro" in readme
+    assert "nauro init --demo" in readme
+    assert 'nauro check-decision "Store dollar amounts as decimal numbers"' in readme
+    assert "D001" in readme
+    assert "nauro adopt" in readme
+    assert "/nauro-adopt" in readme
 
 
 def test_readmes_carry_headline_support_line_and_fit_boundary() -> None:

--- a/packages/nauro/tests/test_stdio_server.py
+++ b/packages/nauro/tests/test_stdio_server.py
@@ -2,8 +2,11 @@
 
 import json
 import os
+import queue
 import subprocess
 import sys
+import threading
+import time
 from pathlib import Path
 from typing import Literal, get_args, get_origin, get_type_hints
 from unittest.mock import patch
@@ -417,7 +420,7 @@ def test_stdio_handshake_and_tool_call_emit_no_product_analytics_output(tmp_path
     env["NAURO_HOME"] = str(nauro_home)
     payload = "".join(json.dumps(message) + "\n" for message in messages)
 
-    result = subprocess.run(
+    process = subprocess.Popen(
         [
             sys.executable,
             "-c",
@@ -425,17 +428,74 @@ def test_stdio_handshake_and_tool_call_emit_no_product_analytics_output(tmp_path
         ],
         cwd=tmp_path,
         env=env,
-        input=payload,
-        capture_output=True,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
         text=True,
-        timeout=30,
     )
+    stdout_lines: queue.Queue[str | None] = queue.Queue()
+    complete_stdout: list[str] = []
+    stderr_lines: list[str] = []
+    stdout_reader = None
+    stderr_reader = None
 
-    assert result.returncode == 0, result.stderr
-    responses = [json.loads(line) for line in result.stdout.splitlines()]
-    assert [response["id"] for response in responses] == [1, 2]
-    assert "posthog" not in result.stderr.lower()
-    assert "us.i.posthog.com" not in result.stderr.lower()
+    def read_stdout() -> None:
+        for line in process.stdout:
+            complete_stdout.append(line)
+            stdout_lines.put(line)
+        stdout_lines.put(None)
+
+    try:
+        assert process.stdin is not None
+        assert process.stdout is not None
+        assert process.stderr is not None
+
+        stdout_reader = threading.Thread(target=read_stdout)
+        stderr_reader = threading.Thread(target=lambda: stderr_lines.extend(process.stderr))
+        stdout_reader.start()
+        stderr_reader.start()
+
+        process.stdin.write(payload)
+        process.stdin.flush()
+        expected_ids = [1, 2]
+        response_ids = []
+        deadline = time.monotonic() + 30
+        while response_ids != expected_ids:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                pytest.fail("timed out waiting for both stdio responses")
+            try:
+                line = stdout_lines.get(timeout=remaining)
+            except queue.Empty:
+                pytest.fail("timed out waiting for both stdio responses")
+            assert line is not None, "stdio server exited before emitting both responses"
+            message = json.loads(line)
+            if "id" in message:
+                response_ids.append(message["id"])
+                assert response_ids == expected_ids[: len(response_ids)]
+    finally:
+        if process.stdin is not None:
+            try:
+                process.stdin.close()
+            except OSError:
+                pass
+        try:
+            process.wait(timeout=30)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=30)
+
+        if stdout_reader is not None:
+            stdout_reader.join()
+        if stderr_reader is not None:
+            stderr_reader.join()
+
+    stderr = "".join(stderr_lines)
+    assert process.returncode == 0, stderr
+    responses = [json.loads(line) for line in complete_stdout]
+    assert [response.get("id") for response in responses] == [1, 2]
+    assert "posthog" not in stderr.lower()
+    assert "us.i.posthog.com" not in stderr.lower()
 
 
 class TestToolSpecDescriptionsReachAgent:


### PR DESCRIPTION
## Why

The root README had grown into a detailed reference that obscured the installation, demo, and repository-adoption path. The documentation site is the better home for mechanics and extended reference material.

## What changed

- Reduce the root README to a 443-word first-use document.
- Keep the approved headline and support line, qualified Pareto example, canonical installation, Pennykeep demo, adoption path, trust boundaries, fit boundary, 1.x stability, `AGENTS.md` ownership contract, development commands, issues, license, and naming.
- Narrow distribution-copy tests to durable shared copy invariants, the root word budget, and the canonical install, demo, and adopt commands.
- Leave the PyPI README unchanged.

## Test plan

- `wc -w README.md` - 443 words
- `uv run pytest packages/nauro/tests/test_distribution_copy.py -q` - 5 passed
- `uv run ruff check packages/nauro/tests/test_distribution_copy.py` - passed
- `git diff --check` - passed

## Risk / what to review

This README commit has been replayed onto the current `origin/main` after the product-telemetry dependency merged.

Review that the shorter README still carries every public trust, fit, stability, installation, demo, and adoption invariant without restoring reference-level detail.

## Deferred

- Rewriting `packages/nauro/README.md` for PyPI
- Detailed retrieval mechanics, limits, callbacks, graph and doctor behavior, context levels, telemetry compatibility details, and uninstall instructions
