### PR TITLE
Release nauro 1.5.0 and nauro-core 1.2.0

### DIFF
--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro-core"
-version = "1.1.1"
+version = "1.2.0"
 description = "Shared pure-Python logic for Nauro: parsing, validation, context assembly, constants."
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro"
-version = "1.4.0"
+version = "1.5.0"
 description = "Human-approved project judgment and current state for connected AI agents, surfaced before work."
 readme = "README.md"
 license = "Apache-2.0"
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "nauro-core>=1.1.1,<2",
+    "nauro-core>=1.2.0,<2",
     "typer>=0.9",
     "httpx>=0.24",
     "mcp>=1.0",

--- a/server.json
+++ b/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Nauro-AI/nauro",
     "source": "github"
   },
-  "version": "1.4.0",
+  "version": "1.5.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "nauro",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -928,7 +928,7 @@ wheels = [
 
 [[package]]
 name = "nauro"
-version = "1.4.0"
+version = "1.5.0"
 source = { editable = "packages/nauro" }
 dependencies = [
     { name = "filelock" },
@@ -970,7 +970,7 @@ provides-extras = ["dev", "embeddings"]
 
 [[package]]
 name = "nauro-core"
-version = "1.1.1"
+version = "1.2.0"
 source = { editable = "packages/nauro-core" }
 dependencies = [
     { name = "bm25s" },


### PR DESCRIPTION
## Versions

- nauro: 1.4.0 → 1.5.0
- nauro-core: 1.1.1 → 1.2.0 (nauro's floor bumped to `nauro-core>=1.2.0,<2`)

## What ships

**nauro 1.5.0**

- `nauro reconnect`: connect or recover the project named by the repository config, with typed first-connect / missing-record / invalid-record / binding-conflict states across CLI and MCP.
- Validated machine-local external store bindings via the user-global registry, and staged, atomic cloud restoration shared by attach and reconnect.
- PostHog product telemetry removed; the frozen 1.x command tree keeps inert shims and legacy config is preserved until the 2.0 boundary.
- User-facing output standardized on ASCII hyphens.

**nauro-core 1.2.0**

- New public `disconnected_reason_code` renderer helper — the single discriminator for disconnected-error envelopes shared by downstream adapters.
- Minor output-normalization fixes.

## Checks

- `scripts/check_server_json_version.py` — server.json locked to 1.5.0.
- `scripts/check_single_sourced.py packages/nauro/src` — clean.
- `uv lock --check` and `uv sync --locked` for both packages — clean.

## Post-merge

Tag the squash commit `nauro-core-v1.2.0` and `nauro-v1.5.0`; the tags trigger the trusted-publish workflows (PyPI for both, MCP registry for nauro).
