### PR TITLE
Draw the diagnostic boundary: doctor checks the store, status routes everything else

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/doctor.py
+++ b/packages/nauro/src/nauro/cli/commands/doctor.py
@@ -5,6 +5,14 @@ unparseable decision files, dangling or cyclic supersession refs, and status
 contradictions. Report-only — it never edits the store — and it exits 0
 whether or not it finds defects, because a defect is information for the user,
 not a failed command.
+
+Scope boundary: doctor reads only the decision store, so its findings can be
+deterministic with no false positives. Everything else that can be "off" on a
+machine — not connected, missing or dead wiring — is `nauro status`'s job;
+status names the remedy for each state (`nauro reconnect`, `nauro setup all`).
+On a machine where the project has never been connected, doctor itself exits
+through the shared resolution guidance rather than reporting on a store it
+cannot read.
 """
 
 from __future__ import annotations
@@ -84,7 +92,12 @@ def doctor(
         help="Target project name.",
     ),
 ) -> None:
-    """Report deterministic integrity defects in the project's decision store."""
+    """Report deterministic integrity defects in the project's decision store.
+
+    Checks only the store itself. For connection or wiring problems
+    (not connected on this machine, missing or broken MCP wiring), run
+    'nauro status', which names the remedy for each state.
+    """
     project_name, store_path = resolve_target_project(project)
 
     diagnosis = diagnose_store(FilesystemStore(store_path))

--- a/packages/nauro/src/nauro/cli/commands/reconnect.py
+++ b/packages/nauro/src/nauro/cli/commands/reconnect.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import typer
 
+from nauro.cli.integrations.json_mcp import recorded_mcp_commands
 from nauro.store.recovery import (
     RecoveryError,
     bind_local_store,
@@ -38,6 +39,18 @@ def _finish_connection(repo_root: Path, store_path: Path, project_id: str) -> No
     )
 
 
+def _echo_setup_hint_if_unwired(repo_root: Path) -> None:
+    """One next step when the connected repo has no MCP wiring on this machine.
+
+    Connection restores the project record; MCP wiring is machine-local and
+    regenerated per machine, so a fresh clone lands here connected but not
+    wired. The probe is read-only and soft-failing; wired repos stay silent.
+    """
+    if recorded_mcp_commands(repo_root):
+        return
+    typer.echo("Next: run 'nauro setup all' to wire this machine's agents.")
+
+
 def reconnect() -> None:
     """Connect or recover the project already named by this repository."""
     config_path = find_repo_config(start=Path.cwd())
@@ -53,6 +66,7 @@ def reconnect() -> None:
     if isinstance(connection, RepoResolution):
         typer.echo(f"Already connected to '{connection.display_name}'.")
         typer.echo(f"  Store: {connection.store_path}")
+        _echo_setup_hint_if_unwired(repo_root)
         return
     if not isinstance(connection, DisconnectedProject):
         typer.echo("The repository project config could not be validated.", err=True)
@@ -77,6 +91,7 @@ def reconnect() -> None:
             resolved = bind_local_store(repo_root, store_path)
             _finish_connection(repo_root, resolved.store_path, resolved.project_id)
             typer.echo(f"Connected '{resolved.display_name}' to {resolved.store_path}")
+            _echo_setup_hint_if_unwired(repo_root)
             return
 
         remote_name = require_cloud_membership(connection.project_id)
@@ -100,6 +115,7 @@ def reconnect() -> None:
         _finish_connection(repo_root, bound, connection.project_id)
         typer.echo(f"Restored and connected '{remote_name}'.")
         typer.echo(f"  Store: {bound}")
+        _echo_setup_hint_if_unwired(repo_root)
     except (RecoveryError, StoreBindingError, OSError, ValueError) as exc:
         typer.echo(f"Error: {exc}", err=True)
         raise typer.Exit(code=1) from exc

--- a/packages/nauro/tests/test_cli_doctor.py
+++ b/packages/nauro/tests/test_cli_doctor.py
@@ -73,3 +73,12 @@ def test_project_resolution_and_report_header(tmp_path: Path) -> None:
 def test_unknown_project_exits_nonzero(tmp_path: Path) -> None:
     result = runner.invoke(app, ["doctor", "--project", "nope"])
     assert result.exit_code == 1
+
+
+def test_help_states_store_only_scope_and_points_at_status() -> None:
+    """Doctor's help draws the boundary: store integrity here, everything
+    else (connection, wiring) is status's job."""
+    result = runner.invoke(app, ["doctor", "--help"])
+    assert result.exit_code == 0
+    assert "decision store" in result.stdout
+    assert "nauro status" in result.stdout

--- a/packages/nauro/tests/test_reconnect.py
+++ b/packages/nauro/tests/test_reconnect.py
@@ -78,6 +78,8 @@ def test_reconnect_cloud_restore_uses_same_binding_service(tmp_path, monkeypatch
 
     assert result.exit_code == 0, result.output
     assert "Restored and connected 'Pareto'" in result.output
+    # Restore lands on an unwired fresh machine, so the next step is named.
+    assert "run 'nauro setup all' to wire this machine" in result.output
     assert registry.get_project_v2(PID)["mode"] == "cloud"
 
 
@@ -125,8 +127,7 @@ def test_reconnect_restore_reconciles_server_side_rename(tmp_path, monkeypatch):
     assert resolved.store_path == target
 
 
-def test_reconnect_healthy_project_is_silent_about_recovery(tmp_path, monkeypatch):
-    repo = _local_repo(tmp_path)
+def _bind_healthy(repo):
     store = registry.get_store_path_v2(PID)
     scaffold_project_store("Pareto", store)
     registry.bind_project_store_v2(
@@ -136,12 +137,53 @@ def test_reconnect_healthy_project_is_silent_about_recovery(tmp_path, monkeypatc
         repo_path=repo,
         store_path=store,
     )
+    return store
+
+
+def test_reconnect_healthy_project_is_silent_about_recovery(tmp_path, monkeypatch):
+    repo = _local_repo(tmp_path)
+    store = _bind_healthy(repo)
+    # Wired repo: the connected-but-unwired next-step hint must stay silent.
+    (repo / ".mcp.json").write_text(
+        '{"mcpServers": {"nauro": {"command": "/opt/nauro", "args": ["serve", "--stdio"]}}}\n',
+        encoding="utf-8",
+    )
     monkeypatch.chdir(repo)
 
     result = runner.invoke(app, ["reconnect"])
 
     assert result.exit_code == 0, result.output
     assert result.output == f"Already connected to 'Pareto'.\n  Store: {store}\n"
+
+
+def test_reconnect_connected_but_unwired_points_at_setup(tmp_path, monkeypatch):
+    """A connected repo with no MCP wiring on this machine gets one next step.
+
+    Connection restores the record; wiring is machine-local, so a fresh
+    machine lands here connected but unwired.
+    """
+    repo = _local_repo(tmp_path)
+    _bind_healthy(repo)
+    monkeypatch.chdir(repo)
+
+    result = runner.invoke(app, ["reconnect"])
+
+    assert result.exit_code == 0, result.output
+    assert "Already connected to 'Pareto'." in result.output
+    assert "run 'nauro setup all' to wire this machine" in result.output
+
+
+def test_reconnect_locate_on_unwired_machine_points_at_setup(tmp_path, monkeypatch):
+    repo = _local_repo(tmp_path)
+    store = tmp_path / "external" / PID
+    scaffold_project_store("Pareto", store)
+    monkeypatch.chdir(repo)
+
+    result = runner.invoke(app, ["reconnect"], input=f"locate\n{store}\n")
+
+    assert result.exit_code == 0, result.output
+    assert f"Connected 'Pareto' to {store}" in result.output
+    assert "run 'nauro setup all' to wire this machine" in result.output
 
 
 def test_reconnect_without_repo_config_does_not_adopt(tmp_path, monkeypatch):


### PR DESCRIPTION
## Why

Three commands can plausibly claim the "something is off" moment, and their boundary was undocumented. Doctor's value is that its findings are deterministic with zero false positives, which only holds while it reads nothing but the decision store. Status already diagnoses every other broken state and names the remedy per row (reconnect for disconnected, setup for unwired or broken wiring, sync for a missing context file). And a freshly connected machine was left silently unwired: connection restores the project record, but wiring is machine-local and must be regenerated per machine, and nothing said so at the moment it mattered.

## What changed

- Doctor's module docs and `--help` state its permanent scope — store-internal integrity only — and point connection or wiring problems at `nauro status`. No behavior change; on a never-connected machine doctor already exits through the shared typed guidance.
- Reconnect's three success paths (already-connected, locate, cloud-restore) emit one next-step line — run 'nauro setup all' — only when the connected repo has no recorded MCP wiring, using the existing read-only presence inspector. Wired repos stay silent; the continue and error paths never hint.

## Test plan

- Exact-output pin proving a wired repo gets no hint; hint assertions on all three success paths against unwired repos
- Doctor help test pinning the boundary wording
- Full suite: 1904 passed; ruff check + format clean

## Risk

- Output-only change. One new line on reconnect success for unwired repos; scripts parsing exact reconnect output would see it (none exist in-repo; the one exact-output test was updated deliberately).

## Deferred

- The generated AGENTS.md troubleshooting breadcrumb that names the status entry point for fresh clones is the follow-on item.
- Codex-global-only wiring still triggers the hint by design; `nauro setup all` is idempotent, so the suggested step is safe when partially wired.