### PR TITLE
Generated AGENTS.md tells unwired sessions the repo uses Nauro

### DIFF
--- a/packages/nauro/src/nauro/templates/agents_md.py
+++ b/packages/nauro/src/nauro/templates/agents_md.py
@@ -97,6 +97,15 @@ def generate_agents_md(
     ]
 
     parts.append(MCP_INSTRUCTIONS_STATIC + "\n")
+    # Reaches sessions the local MCP server never wired into: a fresh clone
+    # ships this committed file but no live server, so name the single command
+    # that self-routes the rest of setup.
+    parts.append(
+        "If you have no Nauro MCP tools in this session (no `mcp__nauro__*` tools "
+        "available), tell the user this repository uses Nauro to share project decisions "
+        "across agents and suggest they run 'nauro status'. If the 'nauro' command is not "
+        "installed, install it with 'uv tool install nauro'.\n"
+    )
     parts.append(f"## Project: {project_name}\n\n{l0_payload}\n")
 
     # Store-routing block. This file lives in the working copy, so any agent

--- a/packages/nauro/tests/test_agents_md.py
+++ b/packages/nauro/tests/test_agents_md.py
@@ -63,9 +63,39 @@ def test_generate_frontloads_canonical_preflight_before_l0_payload():
     l0_payload = "**One-liner:** Stable project scope.\n\n## Current State\n\nActive work."
     result = generate_agents_md("myproj", l0_payload)
 
-    expected = f"{MCP_INSTRUCTIONS_STATIC}\n\n## Project: myproj\n\n{l0_payload}\n"
-    assert expected in result
+    preflight_idx = result.index(MCP_INSTRUCTIONS_STATIC)
+    breadcrumb_idx = result.index("If you have no Nauro MCP tools in this session")
+    project_idx = result.index("## Project: myproj")
+    payload_idx = result.index(l0_payload)
+
+    assert preflight_idx < breadcrumb_idx < project_idx < payload_idx
     assert result.count(MCP_INSTRUCTIONS_STATIC) == 1
+
+
+def test_generate_breadcrumb_names_only_the_self_routing_entry_command():
+    """An unwired session is told the repo uses Nauro and pointed at one command.
+
+    The breadcrumb names only the single self-routing entry command (and the
+    install fallback) - never the downstream remedies that command routes to.
+    """
+    result = generate_agents_md("myproj", "payload")
+    breadcrumb = (
+        "If you have no Nauro MCP tools in this session (no `mcp__nauro__*` tools "
+        "available), tell the user this repository uses Nauro to share project decisions "
+        "across agents and suggest they run 'nauro status'. If the 'nauro' command is not "
+        "installed, install it with 'uv tool install nauro'."
+    )
+    assert result.count(breadcrumb) == 1
+    # The entry command and the install fallback both reach the generated body.
+    assert "nauro status" in result
+    assert "uv tool install nauro" in result
+    # Scoped to the rendered breadcrumb paragraph (its start through the next
+    # section header): it must not name any downstream remedy that `nauro status`
+    # routes to. Other sections may legitimately mention these commands.
+    paragraph = result[result.index(breadcrumb) : result.index("## Project:")]
+    assert "reconnect" not in paragraph
+    assert "setup all" not in paragraph
+    assert "sync" not in paragraph
 
 
 def test_generated_footer_names_human_ratified_judgment():


### PR DESCRIPTION
## Why

Nauro's MCP wiring is machine-local and gitignored, so a fresh clone ships no
live MCP server. The committed AGENTS.md is the only Nauro artifact that reaches
every clone — which makes it the sole surface able to reach a session where no
`mcp__nauro__*` tools are present. Until now that session had no signal that the
repo even uses Nauro, and no pointer to the one command that gets it wired.

## What changed

Added a single generated paragraph to AGENTS.md, in the auto-generated region
above `# Manual`, between the canonical preflight block and `## Project:`. It is
one atomic conditional: when a session has no `mcp__nauro__*` tools, tell the
user the repo uses Nauro and point them at `nauro status`, with a
`uv tool install nauro` fallback if the CLI is absent. It names only that single
self-routing entry command — not the downstream remedies it routes to — so the
guidance stays stable as routing evolves.

Tests: rewrote the preflight-ordering test from a brittle contiguous-string match
to an ordering assertion (preflight < breadcrumb < `## Project:` < payload), and
added a test pinning the exact breadcrumb: it appears exactly once, surfaces
`nauro status` and `uv tool install nauro`, and the rendered slice between the
breadcrumb and `## Project:` names no downstream remedy.

## Test plan

- Full nauro suite (excluding cross_surface): 1902 passed.
- Preservation and ownership suites: green — regen, teardown, and section
  preservation are untouched.
- `ruff check` and `ruff format --check` on `packages/nauro`: clean.

## Risk / what to review

The breadcrumb is static prose in the generated region. Preservation markers,
`warn_then_regen`, teardown, and the symlink refusal path are unchanged; the new
text lives entirely above `# Manual`, so it never enters the preserved region.
The negative test assertions are scoped to the breadcrumb's rendered region on
purpose, so other sections can still mention other commands without breaking it.

## Deferred

- Relocating the existing shell-fallback line to a truncation-safe position.
- CLAUDE.md-bridge work: Claude Code does not read AGENTS.md natively; wired
  adopters already get context via MCP.
