### PR TITLE
Support Nauro workflows across Claude and Codex

### DIFF
--- a/.agents/skills/nauro-adopt/SKILL.md
+++ b/.agents/skills/nauro-adopt/SKILL.md
@@ -73,7 +73,7 @@ If the file is missing, try two fallbacks before aborting:
 1. **Worktree fallback.** Compare `git rev-parse --git-dir` and `git rev-parse --git-common-dir`. If they differ, the current checkout is a linked worktree, and `.nauro/` may only exist in the main worktree (common when a workspace tool gitignores `.nauro/` per-checkout). The main worktree path is the parent directory of `git rev-parse --path-format=absolute --git-common-dir`. Re-read `<main-worktree>/.nauro/config.json` there.
 2. **Registry fallback.** Read `~/.nauro/registry.json`. Schema v2 keys each project by its id under `projects` — the dict key **is** the project `id`; the entry stores `name`, `mode`, `repo_paths`, etc. If any entry's `repo_paths` contains the current repo root or the resolved main-worktree path, use that dict key as the `id` and the entry's `name` as the project handle.
 
-Abort only when both fallbacks miss, with: "This repo is not adopted yet. Run 'nauro adopt' from the repo root, restart this agent, then invoke /nauro-adopt again."
+Abort only when both fallbacks miss, with: "This repo is not adopted yet. Run 'nauro adopt' from the repo root, restart this agent, then invoke the nauro-adopt skill again."
 
 Pass `id` as the `project_id` argument on every subsequent MCP call (`propose_decision`, `update_state`, `flag_question`, `get_context`, `list_decisions`, `check_decision`, `get_decision`). Do not omit `project_id` even though the tool descriptions say it's optional — auto-resolve routes to the user's default project, which is **not** the project this skill is seeding when both local-mode and cloud-mode projects coexist.
 

--- a/.agents/skills/nauro-ship-task/SKILL.md
+++ b/.agents/skills/nauro-ship-task/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nauro-ship-task
-description: Run the full planner -> executor -> reviewer -> tech-lead -> user-confirm -> push chain for a non-trivial code change against Nauro's bundled @nauro-* subagents. Gates on the user whenever the planner or tech-lead will file a Nauro decision; the executor never files. Runs @nauro-tech-lead Mode C between reviewer-APPROVE and the push gate to catch doctrine drift the reviewer missed. A prompt that carries a detailed implementation spec or a pasted handoff is still chain input, not license to implement directly. Dispatches the bundled subagents on Claude Code only. Invoke explicitly with /nauro-ship-task <description>. Requires `nauro adopt --with-subagents` to have run.
+description: Run the full planner -> executor -> reviewer -> tech-lead -> user-confirm -> push chain for a non-trivial code change against Nauro's bundled @nauro-* subagents. Gates on the user whenever the planner or tech-lead will file a Nauro decision; the executor never files. Runs @nauro-tech-lead Mode C between reviewer-APPROVE and the push gate to catch doctrine drift the reviewer missed. A prompt that carries a detailed implementation spec or a pasted handoff is still chain input, not license to implement directly. Invoke explicitly with the surface's nauro-ship-task command. Requires `nauro adopt --with-subagents` to have run.
 ---
 
 # Nauro ship task skill
@@ -11,7 +11,20 @@ Take the user's task description from the prompt that invoked this skill. If the
 
 ## Prerequisites
 
-This skill invokes the bundled `@nauro-*` subagents by name. They install via `nauro adopt --with-subagents` (or `nauro setup all --with-subagents`) and dispatch on Claude Code only. If they are missing, or the current surface cannot spawn subagents, the chain cannot run; surface that to the user and stop. Do not reproduce the chain inline in the main session: the gates depend on the subagents' restricted tool access, and an inline imitation runs without those restrictions. The personal-subagent path (`@planner` / `@executor` / `@reviewer` without the `nauro-` prefix) is not a substitute either — the bundled subagents call Nauro's MCP tools by design, which is what makes the doctrine gates load-bearing.
+This skill invokes the installed `nauro-planner`, `nauro-executor`, `nauro-reviewer`, and `nauro-tech-lead` custom agents. They install under `~/.codex/agents/` via `nauro adopt --with-subagents` (or `nauro setup all --with-subagents`).
+
+### Codex dispatch capability check
+
+Before planning or changing files:
+
+1. Verify that all four `~/.codex/agents/nauro-*.toml` files exist.
+2. Inspect the callable subagent dispatcher schema. A `task_name` field labels a generic task; it does not prove that Codex loaded a same-named TOML definition.
+3. If the dispatcher exposes `agent_type` or an equivalent custom-agent selector, invoke each installed agent by its configured `name`.
+4. If the dispatcher cannot select custom agents, explain that a generic fallback would enforce the role only through task instructions, not through the TOML `developer_instructions` and `sandbox_mode` configuration layers. Ask: `Use the instruction-level Codex fallback for this run?` Do not plan, edit, file a decision, commit, or push before the user explicitly approves.
+5. On approval, read each installed TOML, start a separate generic subagent with no inherited conversation context, and pass that agent's exact `developer_instructions` together with only the task-local handoff. Never treat a matching `task_name` as custom-agent dispatch. Keep the planner, executor, reviewer, and tech-lead in separate contexts.
+6. Record that the instruction-level fallback was used. Include that fact in the push-gate summary and final receipt. If the user declines, or any agent definition is missing, stop before mutation.
+
+Do not reproduce the four roles inline in the parent session. The independent contexts and the human-controlled gates remain mandatory in both dispatch modes.
 
 The bundled subagents follow the session's model — chain quality tracks the model the session runs.
 

--- a/.claude/skills/nauro-adopt/SKILL.md
+++ b/.claude/skills/nauro-adopt/SKILL.md
@@ -73,7 +73,7 @@ If the file is missing, try two fallbacks before aborting:
 1. **Worktree fallback.** Compare `git rev-parse --git-dir` and `git rev-parse --git-common-dir`. If they differ, the current checkout is a linked worktree, and `.nauro/` may only exist in the main worktree (common when a workspace tool gitignores `.nauro/` per-checkout). The main worktree path is the parent directory of `git rev-parse --path-format=absolute --git-common-dir`. Re-read `<main-worktree>/.nauro/config.json` there.
 2. **Registry fallback.** Read `~/.nauro/registry.json`. Schema v2 keys each project by its id under `projects` — the dict key **is** the project `id`; the entry stores `name`, `mode`, `repo_paths`, etc. If any entry's `repo_paths` contains the current repo root or the resolved main-worktree path, use that dict key as the `id` and the entry's `name` as the project handle.
 
-Abort only when both fallbacks miss, with: "This repo is not adopted yet. Run 'nauro adopt' from the repo root, restart this agent, then invoke /nauro-adopt again."
+Abort only when both fallbacks miss, with: "This repo is not adopted yet. Run 'nauro adopt' from the repo root, restart this agent, then invoke the nauro-adopt skill again."
 
 Pass `id` as the `project_id` argument on every subsequent MCP call (`propose_decision`, `update_state`, `flag_question`, `get_context`, `list_decisions`, `check_decision`, `get_decision`). Do not omit `project_id` even though the tool descriptions say it's optional — auto-resolve routes to the user's default project, which is **not** the project this skill is seeding when both local-mode and cloud-mode projects coexist.
 

--- a/.claude/skills/nauro-ship-task/SKILL.md
+++ b/.claude/skills/nauro-ship-task/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nauro-ship-task
-description: Run the full planner -> executor -> reviewer -> tech-lead -> user-confirm -> push chain for a non-trivial code change against Nauro's bundled @nauro-* subagents. Gates on the user whenever the planner or tech-lead will file a Nauro decision; the executor never files. Runs @nauro-tech-lead Mode C between reviewer-APPROVE and the push gate to catch doctrine drift the reviewer missed. A prompt that carries a detailed implementation spec or a pasted handoff is still chain input, not license to implement directly. Dispatches the bundled subagents on Claude Code only. Invoke explicitly with /nauro-ship-task <description>. Requires `nauro adopt --with-subagents` to have run.
+description: Run the full planner -> executor -> reviewer -> tech-lead -> user-confirm -> push chain for a non-trivial code change against Nauro's bundled @nauro-* subagents. Gates on the user whenever the planner or tech-lead will file a Nauro decision; the executor never files. Runs @nauro-tech-lead Mode C between reviewer-APPROVE and the push gate to catch doctrine drift the reviewer missed. A prompt that carries a detailed implementation spec or a pasted handoff is still chain input, not license to implement directly. Invoke explicitly with the surface's nauro-ship-task command. Requires `nauro adopt --with-subagents` to have run.
 ---
 
 # Nauro ship task skill
@@ -11,7 +11,7 @@ Take the user's task description from the prompt that invoked this skill. If the
 
 ## Prerequisites
 
-This skill invokes the bundled `@nauro-*` subagents by name. They install via `nauro adopt --with-subagents` (or `nauro setup all --with-subagents`) and dispatch on Claude Code only. If they are missing, or the current surface cannot spawn subagents, the chain cannot run; surface that to the user and stop. Do not reproduce the chain inline in the main session: the gates depend on the subagents' restricted tool access, and an inline imitation runs without those restrictions. The personal-subagent path (`@planner` / `@executor` / `@reviewer` without the `nauro-` prefix) is not a substitute either — the bundled subagents call Nauro's MCP tools by design, which is what makes the doctrine gates load-bearing.
+This skill invokes the bundled `@nauro-*` subagents by name. They install via `nauro adopt --with-subagents` (or `nauro setup all --with-subagents`) and dispatch on Claude Code. If they are missing, or the current surface cannot spawn subagents, the chain cannot run; surface that to the user and stop. Do not reproduce the chain inline in the main session: the gates depend on the subagents' restricted tool access, and an inline imitation runs without those restrictions. The personal-subagent path (`@planner` / `@executor` / `@reviewer` without the `nauro-` prefix) is not a substitute either. The bundled subagents call Nauro's MCP tools by design, which is what makes the doctrine gates load-bearing.
 
 The bundled subagents follow the session's model — chain quality tracks the model the session runs.
 

--- a/.cursor/rules/nauro-adopt.mdc
+++ b/.cursor/rules/nauro-adopt.mdc
@@ -73,7 +73,7 @@ If the file is missing, try two fallbacks before aborting:
 1. **Worktree fallback.** Compare `git rev-parse --git-dir` and `git rev-parse --git-common-dir`. If they differ, the current checkout is a linked worktree, and `.nauro/` may only exist in the main worktree (common when a workspace tool gitignores `.nauro/` per-checkout). The main worktree path is the parent directory of `git rev-parse --path-format=absolute --git-common-dir`. Re-read `<main-worktree>/.nauro/config.json` there.
 2. **Registry fallback.** Read `~/.nauro/registry.json`. Schema v2 keys each project by its id under `projects` — the dict key **is** the project `id`; the entry stores `name`, `mode`, `repo_paths`, etc. If any entry's `repo_paths` contains the current repo root or the resolved main-worktree path, use that dict key as the `id` and the entry's `name` as the project handle.
 
-Abort only when both fallbacks miss, with: "This repo is not adopted yet. Run 'nauro adopt' from the repo root, restart this agent, then invoke /nauro-adopt again."
+Abort only when both fallbacks miss, with: "This repo is not adopted yet. Run 'nauro adopt' from the repo root, restart this agent, then invoke the nauro-adopt skill again."
 
 Pass `id` as the `project_id` argument on every subsequent MCP call (`propose_decision`, `update_state`, `flag_question`, `get_context`, `list_decisions`, `check_decision`, `get_decision`). Do not omit `project_id` even though the tool descriptions say it's optional — auto-resolve routes to the user's default project, which is **not** the project this skill is seeding when both local-mode and cloud-mode projects coexist.
 

--- a/.cursor/rules/nauro-ship-task.mdc
+++ b/.cursor/rules/nauro-ship-task.mdc
@@ -1,5 +1,5 @@
 ---
-description: Run the full planner -> executor -> reviewer -> tech-lead -> user-confirm -> push chain for a non-trivial code change against Nauro's bundled @nauro-* subagents. Gates on the user whenever the planner or tech-lead will file a Nauro decision; the executor never files. Runs @nauro-tech-lead Mode C between reviewer-APPROVE and the push gate to catch doctrine drift the reviewer missed. A prompt that carries a detailed implementation spec or a pasted handoff is still chain input, not license to implement directly. Dispatches the bundled subagents on Claude Code only. Invoke explicitly with /nauro-ship-task <description>. Requires `nauro adopt --with-subagents` to have run.
+description: Run the full planner -> executor -> reviewer -> tech-lead -> user-confirm -> push chain for a non-trivial code change against Nauro's bundled @nauro-* subagents. Gates on the user whenever the planner or tech-lead will file a Nauro decision; the executor never files. Runs @nauro-tech-lead Mode C between reviewer-APPROVE and the push gate to catch doctrine drift the reviewer missed. A prompt that carries a detailed implementation spec or a pasted handoff is still chain input, not license to implement directly. Invoke explicitly with the surface's nauro-ship-task command. Requires `nauro adopt --with-subagents` to have run.
 alwaysApply: false
 ---
 
@@ -11,7 +11,7 @@ Take the user's task description from the prompt that invoked this skill. If the
 
 ## Prerequisites
 
-This skill invokes the bundled `@nauro-*` subagents by name. They install via `nauro adopt --with-subagents` (or `nauro setup all --with-subagents`) and dispatch on Claude Code only. If they are missing, or the current surface cannot spawn subagents, the chain cannot run; surface that to the user and stop. Do not reproduce the chain inline in the main session: the gates depend on the subagents' restricted tool access, and an inline imitation runs without those restrictions. The personal-subagent path (`@planner` / `@executor` / `@reviewer` without the `nauro-` prefix) is not a substitute either — the bundled subagents call Nauro's MCP tools by design, which is what makes the doctrine gates load-bearing.
+This skill invokes the bundled `@nauro-*` subagents by name. They install via `nauro adopt --with-subagents` (or `nauro setup all --with-subagents`) and dispatch on Claude Code. If they are missing, or the current surface cannot spawn subagents, the chain cannot run; surface that to the user and stop. Do not reproduce the chain inline in the main session: the gates depend on the subagents' restricted tool access, and an inline imitation runs without those restrictions. The personal-subagent path (`@planner` / `@executor` / `@reviewer` without the `nauro-` prefix) is not a substitute either. The bundled subagents call Nauro's MCP tools by design, which is what makes the doctrine gates load-bearing.
 
 The bundled subagents follow the session's model — chain quality tracks the model the session runs.
 

--- a/README.md
+++ b/README.md
@@ -40,10 +40,12 @@ The top result is `D001`, **Amounts stored in integer cents, never floating poin
 
 ```bash
 cd your-repo
-nauro adopt
+nauro adopt --with-skills --with-subagents
 ```
 
-Restart your agent, then invoke `/nauro-adopt`. The skill reads project documentation and code, asks you about missing rationale, and seeds the project record without inventing decisions.
+Restart your agent, then invoke `/nauro-adopt` in Claude Code or `$nauro-adopt` in Codex. The skill reads project documentation and code, asks you about missing rationale, and seeds the project record without inventing decisions. The same onboarding command also installs the gated `nauro-ship-task` workflow and its planner, executor, reviewer, and tech-lead agents for both surfaces.
+
+Run `nauro status` to verify MCP plus the installed skills and workflow agents. Run `nauro doctor` to check the project store itself. Re-running the onboarding command refreshes Nauro-owned workflow files and keeps recoverable backups of differing copies. It never migrates or changes third-party skills.
 
 Nauro surfaces prior judgment for the agent to assess. Retrieval is advisory and never blocks a change. New or revised judgment is written only after your explicit approval. Local use needs no account. The local record is plain Markdown that you own. Cloud sync and remote MCP access are optional. Nauro sends no product analytics.
 

--- a/docs/adopt-prompt.md
+++ b/docs/adopt-prompt.md
@@ -92,7 +92,7 @@ If the file is missing, try two fallbacks before aborting:
 1. **Worktree fallback.** Compare `git rev-parse --git-dir` and `git rev-parse --git-common-dir`. If they differ, the current checkout is a linked worktree, and `.nauro/` may only exist in the main worktree (common when a workspace tool gitignores `.nauro/` per-checkout). The main worktree path is the parent directory of `git rev-parse --path-format=absolute --git-common-dir`. Re-read `<main-worktree>/.nauro/config.json` there.
 2. **Registry fallback.** Read `~/.nauro/registry.json`. Schema v2 keys each project by its id under `projects` — the dict key **is** the project `id`; the entry stores `name`, `mode`, `repo_paths`, etc. If any entry's `repo_paths` contains the current repo root or the resolved main-worktree path, use that dict key as the `id` and the entry's `name` as the project handle.
 
-Abort only when both fallbacks miss, with: "This repo is not adopted yet. Run 'nauro adopt' from the repo root, restart this agent, then invoke /nauro-adopt again."
+Abort only when both fallbacks miss, with: "This repo is not adopted yet. Run 'nauro adopt' from the repo root, restart this agent, then invoke the nauro-adopt skill again."
 
 Pass `id` as the `project_id` argument on every subsequent MCP call (`propose_decision`, `update_state`, `flag_question`, `get_context`, `list_decisions`, `check_decision`, `get_decision`). Do not omit `project_id` even though the tool descriptions say it's optional — auto-resolve routes to the user's default project, which is **not** the project this skill is seeding when both local-mode and cloud-mode projects coexist.
 

--- a/packages/nauro/README.md
+++ b/packages/nauro/README.md
@@ -66,7 +66,7 @@ If a small repo plus a reliable AGENTS.md or CLAUDE.md keeps agents oriented, Na
 
 For real-project setup (`nauro init` / `nauro adopt`), cross-surface access, MCP tool reference, and architecture details, see the [main project README](https://github.com/nauro-ai/nauro#readme). Don't run `nauro setup` from `/tmp/nauro-demo`; that would wire the throwaway demo into your MCP client.
 
-`nauro adopt --with-subagents` additionally installs Nauro's bundled Claude Code workflow subagents (`@nauro-planner`, `@nauro-executor`, `@nauro-reviewer`, `@nauro-tech-lead`) into `~/.claude/agents/`. Off by default to avoid overwriting locally-customized files; pass `--force-overwrite` to replace customized files.
+For full Claude Code and Codex onboarding, run `nauro adopt --with-skills --with-subagents`. This installs the gated `nauro-ship-task` workflow and Nauro's bundled planner, executor, reviewer, and tech-lead agents into `~/.claude/agents/` and `~/.codex/agents/`. Re-running the command refreshes Nauro-owned workflow files and saves differing copies as backups. It leaves third-party skills and agents untouched. Pass `--force-overwrite` only when you do not want backups.
 
 ## Why Nauro?
 

--- a/packages/nauro/src/nauro/agents/__init__.py
+++ b/packages/nauro/src/nauro/agents/__init__.py
@@ -9,14 +9,13 @@ unchanged on the Claude Code surface — no per-surface frontmatter
 wrapping is needed.
 
 ``render_agent(surface, name)`` is the single source of truth for what
-the materializer writes into ``~/.claude/agents/<name>.md``. Cursor and
-Codex stubs exist so opt-in install across surfaces is wired symmetrically;
-they raise ``NotImplementedError`` because their subagent equivalents
-(if any) are not yet shipped.
+the materializer writes into ``~/.claude/agents/<name>.md`` and
+``~/.codex/agents/<name>.toml``. Cursor remains unsupported.
 """
 
 from __future__ import annotations
 
+import json
 from importlib import resources
 from pathlib import Path
 from typing import Literal
@@ -28,6 +27,14 @@ AGENT_NAMES: tuple[str, ...] = (
     "nauro-executor",
     "nauro-reviewer",
     "nauro-tech-lead",
+)
+
+_CODEX_READ_ONLY_AGENTS: frozenset[str] = frozenset(
+    {
+        "nauro-planner",
+        "nauro-reviewer",
+        "nauro-tech-lead",
+    }
 )
 
 
@@ -47,16 +54,45 @@ def load_agent_body(name: str) -> str:
 def render_agent(surface: str, name: str) -> str:
     """Return the per-surface file content for an agent.
 
-    Claude Code returns the body verbatim. Cursor and Codex are stub
-    surfaces — the markdown shape needed there is not yet defined, so
-    callers receive ``NotImplementedError`` and the install path skips
-    that surface rather than crashing.
+    Claude Code returns the body verbatim. Codex renders the same description
+    and instruction body as a standalone custom-agent TOML file. Cursor has no
+    bundled subagent format and remains unsupported.
     """
+    body = load_agent_body(name)
     if surface == "claude_code":
-        return load_agent_body(name)
-    if surface in ("cursor", "codex"):
+        return body
+    if surface == "codex":
+        return _render_codex_agent(name, body)
+    if surface == "cursor":
         raise NotImplementedError(f"surface {surface!r} not yet implemented for subagents")
     raise ValueError(f"unknown surface: {surface!r}")
+
+
+def _render_codex_agent(name: str, claude_body: str) -> str:
+    """Translate one canonical Claude agent file into Codex TOML."""
+    end = claude_body.find("\n---\n", 4)
+    if not claude_body.startswith("---\n") or end < 0:
+        raise ValueError(f"agent {name!r} has invalid frontmatter")
+
+    frontmatter = claude_body[4:end]
+    fields = {
+        key.strip(): value.strip()
+        for line in frontmatter.splitlines()
+        if ":" in line
+        for key, value in (line.split(":", 1),)
+    }
+    if fields.get("name") != name or not fields.get("description"):
+        raise ValueError(f"agent {name!r} has incomplete frontmatter")
+
+    instructions = claude_body[end + len("\n---\n") :]
+    lines = [
+        f"name = {json.dumps(name, ensure_ascii=False)}",
+        f"description = {json.dumps(fields['description'], ensure_ascii=False)}",
+    ]
+    if name in _CODEX_READ_ONLY_AGENTS:
+        lines.append('sandbox_mode = "read-only"')
+    lines.append(f"developer_instructions = {json.dumps(instructions, ensure_ascii=False)}")
+    return "\n".join(lines) + "\n"
 
 
 def emit_plugin_agents(dest: Path) -> list[Path]:

--- a/packages/nauro/src/nauro/agents/nauro-tech-lead.md
+++ b/packages/nauro/src/nauro/agents/nauro-tech-lead.md
@@ -7,7 +7,7 @@ model: inherit
 
 You set and maintain project direction. You have authority on doctrine: when a plan, a session, or a PR drifts from active decisions, you call it; when an emergent pattern needs a decision, you draft it and file only after approval. @nauro-planner, @nauro-executor, and @nauro-reviewer defer to you on architectural direction. The human keeps the final override: every `add`, `update`, and `supersede` passes through explicit user approval before you call `propose_decision`. The kernel commits immediately on Tier 1 clean; there is no separate confirm step.
 
-The approval channel depends on how you were invoked. The complete draft includes its operation, full payload, and the related decisions and assessment from `check_decision`. **Standalone** (the human called you directly): present that draft through `AskUserQuestion` with options `Approve and file` / `Reject` / `Modify draft`, then file only on `Approve and file`. **Inside the `/nauro-ship-task` chain**: the parent session owns the user gate, so return the complete draft to the parent and do not file in-run or fire `AskUserQuestion`. After the parent gets explicit user approval, it re-invokes you with that approval so you can file the exact draft. The parent never files your draft itself. This channel rule covers every `add`, `update`, and `supersede`.
+The approval channel depends on how you were invoked. The complete draft includes its operation, full payload, and the related decisions and assessment from `check_decision`. **Standalone with a direct user channel**: present that draft through the surface's user-question tool (`AskUserQuestion` on Claude Code) with options `Approve and file` / `Reject` / `Modify draft`, then file only on `Approve and file`. **Inside the `nauro-ship-task` chain, or on a surface without a direct user channel**: the parent session owns the user gate, so return the complete draft to the parent and do not file in-run. After the parent gets explicit user approval, it re-invokes you with that approval so you can file the exact draft. The parent never files your draft itself. This channel rule covers every `add`, `update`, and `supersede`.
 
 ## How to run — three modes
 
@@ -19,11 +19,12 @@ The approval channel depends on how you were invoked. The complete draft include
 4. Return verdict: GREEN (no doctrine concern, proceed), AMBER (proceed with the listed constraints), RED (contradicts active doctrine — redirect or supersede first).
 5. If the direction establishes new doctrine or changes existing doctrine, draft the complete `add`, `update`, or `supersede` payload and route it through the approval channel above. Call `propose_decision` only after explicit approval of that exact draft. The kernel commits immediately on Tier 1 clean.
 
-**Mode B: Session audit and file (post-session).** Caller provides a Claude Code session ID. Transcript lives at:
+**Mode B: Session audit and file (post-session).** Caller provides an agent session ID. Transcripts live at:
 
-`~/.claude/projects/<encoded-cwd>/<session-id>.jsonl`
+- Codex: `~/.codex/sessions/<YYYY>/<MM>/<DD>/rollout-*<session-id>*.jsonl`
+- Claude Code: `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl`
 
-`<encoded-cwd>` is the absolute working directory with each `/` replaced by `-`. Derive from `pwd` if not given; if still ambiguous, list candidate directories under `~/.claude/projects/` and ask.
+For Claude Code, `<encoded-cwd>` is the absolute working directory with each `/` replaced by `-`. Derive it from `pwd` if not given. If the location is still ambiguous, list candidate files by date for Codex or candidate directories under `~/.claude/projects/` for Claude Code, then ask.
 
 1. Inspect transcript structure with `Read` (limit ~50 lines).
 2. Filter with `jq -c` or `grep` against the raw JSONL — never load the whole file into context.

--- a/packages/nauro/src/nauro/cli/commands/adopt.py
+++ b/packages/nauro/src/nauro/cli/commands/adopt.py
@@ -399,18 +399,17 @@ def adopt(
         help=(
             "Install Nauro's bundled workflow subagents (@nauro-planner, "
             "@nauro-executor, @nauro-reviewer, @nauro-tech-lead) into "
-            "~/.claude/agents/. Off by default to avoid overwriting "
-            "customized files."
+            "~/.claude/agents/ for Claude Code and ~/.codex/agents/ for Codex. "
+            "Off by default."
         ),
     ),
     force_overwrite: bool = typer.Option(
         False,
         "--force-overwrite",
         help=(
-            "Overwrite ~/.claude/agents/nauro-*.md in place without saving a "
-            ".bak, when --with-subagents is passed. By default, install "
-            "refreshes a differing bundled file and stashes its prior content "
-            "to <name>.md.bak."
+            "Overwrite differing bundled Nauro skills and agent definitions "
+            "without saving .bak files. By default, refresh preserves the "
+            "previous content in a sibling backup."
         ),
     ),
     with_skills: bool = typer.Option(
@@ -418,8 +417,8 @@ def adopt(
         "--with-skills",
         help=(
             "Install Nauro's bundled opt-in skills "
-            "(/nauro-ship-task, /nauro-context, /nauro-loop) alongside the "
-            "always-installed /nauro-adopt skill. Independent of --with-subagents."
+            "(nauro-ship-task, nauro-context, nauro-loop) alongside the "
+            "always-installed nauro-adopt skill. Independent of --with-subagents."
         ),
     ),
     remove: bool = typer.Option(
@@ -613,8 +612,9 @@ def adopt(
             typer.echo(warning, err=True)
 
     typer.echo(
-        "\nNext: restart your agent and invoke /nauro-adopt to seed context "
-        "from this repo. Cursor users: if you `git add "
+        "\nNext: restart your agent and invoke the nauro-adopt skill to seed "
+        "context from this repo. Use /nauro-adopt in Claude Code or "
+        "$nauro-adopt in Codex. Cursor users: if you `git add "
         ".cursor/rules/nauro-adopt.mdc`, collaborators on this repo get the "
         "/nauro-adopt rule."
     )

--- a/packages/nauro/src/nauro/cli/commands/setup.py
+++ b/packages/nauro/src/nauro/cli/commands/setup.py
@@ -167,7 +167,8 @@ CODEX_HOOKS_NOTICE = (
 # already-open session won't see the new wiring until it restarts. The
 # single-tool `setup claude-code` prints its own equivalent line.
 ALL_RESTART_NOTICE = (
-    "Next: start a fresh agent session (Claude Code/Cursor) - MCP config is read at session start."
+    "Next: start a fresh agent session (Claude Code, Cursor, or Codex) - "
+    "MCP config and installed workflow files are read at session start."
 )
 
 
@@ -185,18 +186,17 @@ def all_(
         help=(
             "Install Nauro's bundled workflow subagents (@nauro-planner, "
             "@nauro-executor, @nauro-reviewer, @nauro-tech-lead) into "
-            "~/.claude/agents/. Off by default to avoid overwriting "
-            "customized files."
+            "~/.claude/agents/ for Claude Code and ~/.codex/agents/ for Codex. "
+            "Off by default."
         ),
     ),
     force_overwrite: bool = typer.Option(
         False,
         "--force-overwrite",
         help=(
-            "Overwrite ~/.claude/agents/nauro-*.md in place without saving a "
-            ".bak, when --with-subagents is passed. By default, install "
-            "refreshes a differing bundled file and stashes its prior content "
-            "to <name>.md.bak."
+            "Overwrite differing bundled Nauro skills and agent definitions "
+            "without saving .bak files. By default, refresh preserves the "
+            "previous content in a sibling backup."
         ),
     ),
     with_skills: bool = typer.Option(
@@ -204,8 +204,8 @@ def all_(
         "--with-skills",
         help=(
             "Install Nauro's bundled opt-in skills "
-            "(/nauro-ship-task, /nauro-context, /nauro-loop) alongside the "
-            "always-installed /nauro-adopt skill. Independent of --with-subagents."
+            "(nauro-ship-task, nauro-context, nauro-loop) alongside the "
+            "always-installed nauro-adopt skill. Independent of --with-subagents."
         ),
     ),
     with_hooks: bool = typer.Option(

--- a/packages/nauro/src/nauro/cli/commands/status.py
+++ b/packages/nauro/src/nauro/cli/commands/status.py
@@ -102,6 +102,72 @@ def _repo_codex_hook_state(repo: Path) -> _CodexHookState:
 
 
 @dataclass(frozen=True)
+class _ArtifactCounts:
+    """Tally of one bundled artifact set on one surface."""
+
+    expected: int
+    present: int
+    current: int
+
+
+_NO_COUNTS = _ArtifactCounts(expected=0, present=0, current=0)
+
+
+@dataclass(frozen=True)
+class _SurfacePair:
+    """The same artifact set tallied on the Claude Code and Codex surfaces."""
+
+    claude: _ArtifactCounts
+    codex: _ArtifactCounts
+
+    @property
+    def present(self) -> int:
+        return self.claude.present + self.codex.present
+
+    @property
+    def current(self) -> int:
+        return self.claude.current + self.codex.current
+
+    @property
+    def expected(self) -> int:
+        return self.claude.expected + self.codex.expected
+
+    @property
+    def stale(self) -> int:
+        return self.present - self.current
+
+    @property
+    def fully_current(self) -> bool:
+        return self.current == self.expected
+
+
+_NO_PAIR = _SurfacePair(claude=_NO_COUNTS, codex=_NO_COUNTS)
+
+
+@dataclass(frozen=True)
+class _WorkflowArtifacts:
+    """Nauro-owned skills and workflow agents across both user surfaces.
+
+    Core skills install on every adopt/setup-all run; opt-in skills and
+    workflow agents install only behind their flags, so their absence is a
+    chosen state, not a wiring defect.
+    """
+
+    core_skills: _SurfacePair
+    opt_in_skills: _SurfacePair
+    agents: _SurfacePair
+    legacy_codex_skills: int
+
+
+_NO_WORKFLOW_ARTIFACTS = _WorkflowArtifacts(
+    core_skills=_NO_PAIR,
+    opt_in_skills=_NO_PAIR,
+    agents=_NO_PAIR,
+    legacy_codex_skills=0,
+)
+
+
+@dataclass(frozen=True)
 class _WiringSnapshot:
     repo_count: int
     mcp_wired: int
@@ -109,6 +175,7 @@ class _WiringSnapshot:
     mcp_commands: frozenset[str]
     hook_states: tuple[_CodexHookState, ...]
     agents_generated: int
+    workflow: _WorkflowArtifacts
 
     @property
     def configured_hooks(self) -> tuple[_CodexHookState, ...]:
@@ -131,6 +198,69 @@ class _WiringProbeResults:
     hooks: dict[str, bool] | None
 
 
+def _count_artifacts(expected: dict[Path, str]) -> _ArtifactCounts:
+    """Tally how many bundled artifacts are present and byte-current on disk."""
+    present = 0
+    current = 0
+    for path, bundled in expected.items():
+        try:
+            content = path.read_text(encoding="utf-8")
+        except Exception:
+            continue
+        present += 1
+        if content == bundled:
+            current += 1
+    return _ArtifactCounts(expected=len(expected), present=present, current=current)
+
+
+def _count_skills(surface: str, base: Path, names: tuple[str, ...]) -> _ArtifactCounts:
+    from nauro.skills import render_skill
+
+    return _count_artifacts(
+        {base / name / "SKILL.md": render_skill(surface, name) for name in names}
+    )
+
+
+def _workflow_artifacts() -> _WorkflowArtifacts:
+    """Inspect Nauro-owned skills and workflow agents on both user surfaces."""
+    from nauro.agents import AGENT_NAMES, render_agent
+    from nauro.cli.integrations.skills import OPT_IN_SKILL_NAMES, SKILL_NAMES
+
+    claude_skill_base = Path.home() / ".claude" / "skills"
+    codex_skill_base = Path.home() / ".agents" / "skills"
+    claude_agent_base = Path.home() / ".claude" / "agents"
+    codex_agent_base = Path.home() / ".codex" / "agents"
+
+    agents = _SurfacePair(
+        claude=_count_artifacts(
+            {
+                claude_agent_base / f"{name}.md": render_agent("claude_code", name)
+                for name in AGENT_NAMES
+            }
+        ),
+        codex=_count_artifacts(
+            {codex_agent_base / f"{name}.toml": render_agent("codex", name) for name in AGENT_NAMES}
+        ),
+    )
+    legacy_codex_skills = sum(
+        1
+        for name in SKILL_NAMES + OPT_IN_SKILL_NAMES
+        if (Path.home() / ".codex" / "skills" / name / "SKILL.md").is_file()
+    )
+    return _WorkflowArtifacts(
+        core_skills=_SurfacePair(
+            claude=_count_skills("claude_code", claude_skill_base, SKILL_NAMES),
+            codex=_count_skills("codex", codex_skill_base, SKILL_NAMES),
+        ),
+        opt_in_skills=_SurfacePair(
+            claude=_count_skills("claude_code", claude_skill_base, OPT_IN_SKILL_NAMES),
+            codex=_count_skills("codex", codex_skill_base, OPT_IN_SKILL_NAMES),
+        ),
+        agents=agents,
+        legacy_codex_skills=legacy_codex_skills,
+    )
+
+
 def _collect_wiring(repo_paths: list[Path]) -> _WiringSnapshot:
     try:
         repo_commands = [json_mcp.recorded_mcp_commands(repo) for repo in repo_paths]
@@ -148,6 +278,10 @@ def _collect_wiring(repo_paths: list[Path]) -> _WiringSnapshot:
         agents_generated = sum(1 for repo in repo_paths if _repo_has_generated_agents_md(repo))
     except Exception:
         agents_generated = 0
+    try:
+        workflow = _workflow_artifacts()
+    except Exception:
+        workflow = _NO_WORKFLOW_ARTIFACTS
 
     mcp_commands = {command for commands in repo_commands for command in commands if command}
     if codex_command:
@@ -159,6 +293,7 @@ def _collect_wiring(repo_paths: list[Path]) -> _WiringSnapshot:
         mcp_commands=frozenset(mcp_commands),
         hook_states=hook_states,
         agents_generated=agents_generated,
+        workflow=workflow,
     )
 
 
@@ -236,11 +371,88 @@ def _agents_status_line(snapshot: _WiringSnapshot) -> str:
     return "  AGENTS.md     inactive - run 'nauro sync'"
 
 
+def _surface_detail(*pairs: _SurfacePair) -> str:
+    """Per-surface current/expected summary across one or more artifact sets."""
+    claude_current = sum(pair.claude.current for pair in pairs)
+    claude_expected = sum(pair.claude.expected for pair in pairs)
+    codex_current = sum(pair.codex.current for pair in pairs)
+    codex_expected = sum(pair.codex.expected for pair in pairs)
+    return f"Claude {claude_current}/{claude_expected}; Codex {codex_current}/{codex_expected}"
+
+
+_SKILLS_INACTIVE_LINE = (
+    "  Skills        inactive - run 'nauro setup all' (--with-skills adds the opt-in skills)"
+)
+
+
+def _skills_status_line(snapshot: _WiringSnapshot) -> str:
+    """Render the Skills row.
+
+    Core skills install unconditionally, so a gap there is a wiring defect;
+    opt-in skills absent in full is a chosen state and stays inside an
+    "active" row. Stale files and legacy ~/.codex/skills copies are BROKEN.
+    """
+    workflow = snapshot.workflow
+    core, opt_in = workflow.core_skills, workflow.opt_in_skills
+    if workflow.legacy_codex_skills:
+        count = workflow.legacy_codex_skills
+        plural = "copy" if count == 1 else "copies"
+        return (
+            f"  Skills        BROKEN - {count} legacy Nauro skill {plural} under "
+            "~/.codex/skills; migrate with 'nauro setup all --with-skills' or remove manually"
+        )
+    if core.stale or opt_in.stale:
+        remedy = "nauro setup all --with-skills" if opt_in.stale else "nauro setup all"
+        return (
+            f"  Skills        BROKEN - {_surface_detail(core, opt_in)}; installed Nauro "
+            f"skill files differ from this release; run '{remedy}'"
+        )
+    if core.expected == 0:
+        return _SKILLS_INACTIVE_LINE
+    if not core.fully_current:
+        if core.present == 0 and opt_in.present == 0:
+            return _SKILLS_INACTIVE_LINE
+        return f"  Skills        partial ({_surface_detail(core, opt_in)}) - run 'nauro setup all'"
+    if opt_in.present == 0:
+        return (
+            "  Skills        active (core installed; opt-in skills not installed - "
+            "'nauro setup all --with-skills' adds them)"
+        )
+    if not opt_in.fully_current:
+        return (
+            f"  Skills        partial ({_surface_detail(core, opt_in)}) - "
+            "run 'nauro setup all --with-skills'"
+        )
+    return f"  Skills        active ({_surface_detail(core, opt_in)})"
+
+
+def _workflow_agents_status_line(snapshot: _WiringSnapshot) -> str:
+    """Render the Workflow row. The agents are opt-in, so full absence is a
+    stated choice; a partial or stale install is a defect."""
+    agents = snapshot.workflow.agents
+    detail = _surface_detail(agents)
+    if agents.stale:
+        return (
+            f"  Workflow      BROKEN - {detail}; installed Nauro agent files differ from "
+            "this release; run 'nauro setup all --with-subagents'"
+        )
+    if agents.present == 0:
+        return (
+            "  Workflow      not installed (opt-in) - "
+            "'nauro setup all --with-subagents' adds the workflow agents"
+        )
+    if not agents.fully_current:
+        return f"  Workflow      partial ({detail}) - run 'nauro setup all --with-subagents'"
+    return f"  Workflow      active ({detail})"
+
+
 def _render_wiring_status(repo_paths: list[Path], *, no_probe: bool) -> None:
     snapshot = _collect_wiring(repo_paths)
     probes = _probe_wiring(snapshot, no_probe=no_probe)
     typer.echo(_mcp_status_line(snapshot, probes))
     typer.echo(_codex_hooks_status_line(snapshot, probes))
+    typer.echo(_skills_status_line(snapshot))
+    typer.echo(_workflow_agents_status_line(snapshot))
     typer.echo(_agents_status_line(snapshot))
 
 

--- a/packages/nauro/src/nauro/cli/integrations/agents.py
+++ b/packages/nauro/src/nauro/cli/integrations/agents.py
@@ -12,14 +12,27 @@ def _claude_agent_dir() -> Path:
     return Path.home() / ".claude" / "agents"
 
 
+def _codex_agent_dir() -> Path:
+    return Path.home() / ".codex" / "agents"
+
+
+def _agent_target(surface: str, name: str) -> Path:
+    if surface == "claude_code":
+        return _claude_agent_dir() / f"{name}.md"
+    if surface == "codex":
+        return _codex_agent_dir() / f"{name}.toml"
+    raise ValueError(f"unknown surface: {surface!r}")
+
+
 # Subagents are rendered from canonical bodies in nauro.agents and written into
-# the user's surface directories. On Claude Code, that's ``~/.claude/agents/``.
+# the user's surface directories: ``~/.claude/agents/`` for Claude Code and
+# ``~/.codex/agents/`` for Codex.
 # Unlike skills, agents are namespaced (``nauro-*``) and opt-in. The
 # ``nauro-`` namespace is bundle-owned: on install, the current bundle
 # wins, so a published body change (e.g. dropping a removed MCP tool) actually
 # reaches users who installed an earlier version. A pre-existing
-# ``nauro-<name>.md`` that differs from the bundle is refreshed; its prior
-# content is stashed to ``<name>.md.bak`` so the rare hand-customization is
+# A bundled agent file that differs from the current render is refreshed; its
+# prior content is stashed to a sibling ``.bak`` so the rare hand-customization is
 # recoverable. ``force_overwrite=True`` skips the ``.bak`` and overwrites in
 # place. User-authored files without the ``nauro-`` prefix (e.g. a personal
 # ``~/.claude/agents/planner.md``) are never touched.
@@ -34,17 +47,16 @@ def materialize_agents(
 ) -> list[AgentOutcome]:
     """Install or remove the bundled ``nauro-*`` subagent files.
 
-    Currently only the Claude Code surface is implemented. Cursor and Codex
-    surfaces emit a single "skipped" line rather than crashing so the
-    install path can call this unconditionally per the user's flag choice.
+    Claude Code and Codex are implemented. Cursor emits a single "skipped"
+    line rather than crashing.
 
     Add path (per agent):
       - file absent → write bundled body.
       - file present and byte-equal → no-op.
       - file present and differs → refresh from the bundle, stashing the prior
-        content to ``<name>.md.bak`` (the nauro-* namespace is bundle-owned, so
-        a differing file is almost always a stale earlier bundle). Pass
-        ``force_overwrite=True`` to overwrite in place without the ``.bak``.
+        content to a sibling ``.bak`` (the nauro-* namespace is bundle-owned,
+        so a differing file is almost always a stale earlier bundle). Pass
+        ``force_overwrite=True`` to overwrite in place without the backup.
 
     Remove path (per agent):
       - file absent → skip.
@@ -57,29 +69,33 @@ def materialize_agents(
     """
     from nauro.agents import AGENT_NAMES, render_agent
 
-    if surface != "claude_code":
+    if surface == "cursor":
         try:
-            # Exercise the stub so a future surface implementation doesn't
-            # need to remember to remove this branch — once render_agent
-            # stops raising, the stub message goes away naturally.
             render_agent(surface, AGENT_NAMES[0])
         except NotImplementedError:
             return [AgentOutcome(AgentKind.SURFACE_NOT_IMPLEMENTED, surface=surface)]
         except ValueError as exc:
             return [AgentOutcome(AgentKind.SURFACE_INVALID, surface=surface, detail=str(exc))]
+    elif surface not in ("claude_code", "codex"):
+        return [
+            AgentOutcome(
+                AgentKind.SURFACE_INVALID,
+                surface=surface,
+                detail=f"unknown surface: {surface!r}",
+            )
+        ]
 
-    base = _claude_agent_dir()
     if remove and not clear_user_scope:
-        return [AgentOutcome(AgentKind.PRESERVED)]
+        return [AgentOutcome(AgentKind.PRESERVED, surface=surface)]
 
     results: list[AgentOutcome] = []
     for name in AGENT_NAMES:
-        target = base / f"{name}.md"
+        target = _agent_target(surface, name)
         refusal = find_file_symlink(target)
         if refusal is not None:
             results.append(AgentOutcome(AgentKind.REFUSED_SYMLINK, refusal=refusal))
             continue
-        bundled = render_agent("claude_code", name)
+        bundled = render_agent(surface, name)
         if remove:
             results.append(_remove_bundled_agent(target, bundled))
         else:
@@ -92,7 +108,7 @@ def _install_bundled_agent(target: Path, bundled: str, *, force_overwrite: bool)
 
     Absent → write the bundled body. Byte-equal → no-op. ``force_overwrite`` →
     overwrite in place. Otherwise the differing file is refreshed and its prior
-    content stashed to ``<name>.md.bak`` (unless that backup path is a refused
+    content stashed to a sibling ``.bak`` (unless that backup path is a refused
     symlink).
     """
     if target.is_file():

--- a/packages/nauro/src/nauro/cli/integrations/orchestrator.py
+++ b/packages/nauro/src/nauro/cli/integrations/orchestrator.py
@@ -249,6 +249,7 @@ def _all_claude_code_lines(
                 remove=remove,
                 clear_user_scope=clear_user_scope,
                 with_skills=with_skills,
+                force_overwrite=force_overwrite,
             )
         )
     except Exception as exc:
@@ -279,7 +280,7 @@ def _all_claude_code_lines(
 
 
 def _all_cursor_lines(
-    project_repos: list[Path], *, remove: bool, with_skills: bool
+    project_repos: list[Path], *, remove: bool, with_skills: bool, force_overwrite: bool
 ) -> list[ArtifactOutcome]:
     """Cursor surface lines for ``setup_all_surfaces``: MCP per repo + skills per repo."""
     outcomes: list[ArtifactOutcome] = []
@@ -292,7 +293,12 @@ def _all_cursor_lines(
             outcomes.append(HandlerErrorOutcome(f"Cursor MCP ({repo}): error - {exc}"))
         try:
             outcomes.extend(
-                materialize_skills_cursor_for_repo(repo, remove=remove, with_skills=with_skills)
+                materialize_skills_cursor_for_repo(
+                    repo,
+                    remove=remove,
+                    with_skills=with_skills,
+                    force_overwrite=force_overwrite,
+                )
             )
         except Exception as exc:
             outcomes.append(HandlerErrorOutcome(f"Cursor skills ({repo}): error - {exc}"))
@@ -304,10 +310,12 @@ def _all_codex_lines(
     *,
     remove: bool,
     clear_user_scope: bool,
+    with_subagents: bool,
+    force_overwrite: bool,
     with_skills: bool,
     with_hooks: bool,
 ) -> list[ArtifactOutcome]:
-    """Codex surface lines for ``setup_all_surfaces``: MCP global, skills global, optional hooks."""
+    """Codex surface lines: MCP, skills, optional subagents, then hooks."""
     outcomes: list[ArtifactOutcome] = []
     try:
         outcomes.append(_configure_codex(remove=remove, clear_user_scope=clear_user_scope))
@@ -319,10 +327,24 @@ def _all_codex_lines(
                 remove=remove,
                 clear_user_scope=clear_user_scope,
                 with_skills=with_skills,
+                force_overwrite=force_overwrite,
             )
         )
     except Exception as exc:
         outcomes.append(HandlerErrorOutcome(f"Codex skills: error - {exc}"))
+
+    if with_subagents:
+        try:
+            outcomes.extend(
+                materialize_agents(
+                    "codex",
+                    remove=remove,
+                    force_overwrite=force_overwrite,
+                    clear_user_scope=clear_user_scope,
+                )
+            )
+        except Exception as exc:
+            outcomes.append(HandlerErrorOutcome(f"Codex agents: error - {exc}"))
 
     if with_hooks or remove:
         for repo in project_repos:
@@ -420,11 +442,11 @@ def setup_all_surfaces(
     fallback layer the most, yet only ``setup claude-code`` used to write it.
 
     ``with_subagents`` opts into installing or removing the bundled
-    ``nauro-*`` workflow subagents under ``~/.claude/agents/``. Off by
-    default so existing flows that pre-date the subagent bundle keep
-    their previous behavior. ``force_overwrite`` is only meaningful when
-    ``with_subagents`` is True and ``remove`` is False — it replaces
-    locally-modified bundled files instead of preserving them.
+    ``nauro-*`` workflow subagents under ``~/.claude/agents/`` and
+    ``~/.codex/agents/``. Off by default so existing flows that pre-date the
+    subagent bundle keep their previous behavior. ``force_overwrite`` is only
+    meaningful when ``remove`` is False. It replaces locally modified bundled
+    skill and agent files instead of backing them up first.
 
     ``with_skills`` opts into installing the bundled opt-in skills
     (``nauro-ship-task``, ``nauro-context``, ``nauro-loop``). Independent of
@@ -464,12 +486,21 @@ def setup_all_surfaces(
             with_hooks=with_hooks,
         )
     )
-    outcomes.extend(_all_cursor_lines(project_repos, remove=remove, with_skills=with_skills))
+    outcomes.extend(
+        _all_cursor_lines(
+            project_repos,
+            remove=remove,
+            with_skills=with_skills,
+            force_overwrite=force_overwrite,
+        )
+    )
     outcomes.extend(
         _all_codex_lines(
             project_repos,
             remove=remove,
             clear_user_scope=clear_user_scope,
+            with_subagents=with_subagents,
+            force_overwrite=force_overwrite,
             with_skills=with_skills,
             with_hooks=with_hooks,
         )
@@ -490,11 +521,11 @@ SHIP_TASK_NEEDS_SUBAGENTS_NOTICE = (
     "dispatches that chain); pass `--with-subagents` to install them too."
 )
 
-# The bundled subagents allow the cloud tools by the fixed name
+# The bundled Claude Code subagents allow the cloud tools by the fixed name
 # `mcp__claude_ai_Nauro__*`. That prefix only resolves when the remote
 # connector is named exactly `Nauro`, so surface the requirement whenever
 # subagents are installed.
 SUBAGENTS_CONNECTOR_NAME_NOTICE = (
-    "Cloud users: name the remote MCP connector exactly `Nauro` so the bundled "
+    "Claude Code cloud users: name the remote MCP connector exactly `Nauro` so the bundled "
     "@nauro-* subagents' `mcp__claude_ai_Nauro__*` tools resolve."
 )

--- a/packages/nauro/src/nauro/cli/integrations/outcomes.py
+++ b/packages/nauro/src/nauro/cli/integrations/outcomes.py
@@ -186,7 +186,12 @@ class CodexHookOutcome:
 class SkillKind(Enum):
     REFUSED_SYMLINK = auto()
     PRESERVED = auto()
+    PRESERVED_MODIFIED = auto()
     WROTE = auto()
+    UNCHANGED = auto()
+    OVERWROTE = auto()
+    UPDATED = auto()
+    MIGRATED_LEGACY = auto()
     REMOVED = auto()
     ABSENT = auto()
 
@@ -200,6 +205,9 @@ class SkillOutcome:
     refusal: SymlinkRefusal | UserSymlinkRefusal | None = None
     repo: Path | None = None
     base_label: str | None = None
+    source: Path | None = None
+    backup_path: Path | None = None
+    backup_name: str | None = None
 
 
 class AgentKind(Enum):

--- a/packages/nauro/src/nauro/cli/integrations/render.py
+++ b/packages/nauro/src/nauro/cli/integrations/render.py
@@ -320,8 +320,18 @@ def _render_skill(o: SkillOutcome) -> list[str]:
             return [f"  {o.refusal.message}"]
         case SkillKind.PRESERVED:
             return [f"  preserved {o.base_label}/nauro-* (other nauro projects still registered)"]
+        case SkillKind.PRESERVED_MODIFIED:
+            return [f"  preserved {o.target} (locally modified)"]
         case SkillKind.WROTE:
             return [f"  wrote {o.target}"]
+        case SkillKind.UNCHANGED:
+            return [f"  unchanged {o.target}"]
+        case SkillKind.OVERWROTE:
+            return [f"  overwrote {o.target}"]
+        case SkillKind.UPDATED:
+            return [f"  updated {o.target} (previous saved to {o.backup_name})"]
+        case SkillKind.MIGRATED_LEGACY:
+            return [f"  moved legacy skill {o.source} to {o.backup_path}"]
         case SkillKind.REMOVED:
             return [f"  removed {o.target}"]
         case SkillKind.ABSENT:
@@ -337,7 +347,8 @@ def _render_agent(o: AgentOutcome) -> list[str]:
         case AgentKind.SURFACE_INVALID:
             return [f"  skipped agents on surface {o.surface!r}: {o.detail}"]
         case AgentKind.PRESERVED:
-            return ["  preserved ~/.claude/agents/nauro-* (other nauro projects still registered)"]
+            base = "~/.codex/agents" if o.surface == "codex" else "~/.claude/agents"
+            return [f"  preserved {base}/nauro-* (other nauro projects still registered)"]
         case AgentKind.REFUSED_SYMLINK:
             return [f"  {o.refusal.message}"]
         case AgentKind.UNCHANGED:

--- a/packages/nauro/src/nauro/cli/integrations/skills.py
+++ b/packages/nauro/src/nauro/cli/integrations/skills.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 from pathlib import Path
 
 from nauro.cli.integrations.outcomes import SkillKind, SkillOutcome
-from nauro.store.write_safety import find_file_symlink, find_symlink
+from nauro.store.write_safety import (
+    SymlinkRefusal,
+    UserSymlinkRefusal,
+    find_file_symlink,
+    find_symlink,
+)
 
 # Skills are rendered from canonical bodies in nauro.skills and written into
 # the user's surface directories. Claude Code and Codex skills are user-global;
@@ -33,7 +38,14 @@ def _codex_skill_dir() -> Path:
     return Path.home() / ".agents" / "skills"
 
 
+def _skill_refusal(target: Path, repo: Path | None) -> SymlinkRefusal | UserSymlinkRefusal | None:
+    if repo is None:
+        return find_file_symlink(target)
+    return find_symlink(repo, target.relative_to(repo).as_posix())
+
+
 def _materialize_skill_file(target: Path, content: str) -> SkillOutcome:
+    """Write an arbitrary user-scope skill file for compatibility callers."""
     refusal = find_file_symlink(target)
     if refusal is not None:
         return SkillOutcome(SkillKind.REFUSED_SYMLINK, target=target, refusal=refusal)
@@ -42,12 +54,84 @@ def _materialize_skill_file(target: Path, content: str) -> SkillOutcome:
     return SkillOutcome(SkillKind.WROTE, target=target)
 
 
-def _remove_skill_file(target: Path, *, stop_above: Path) -> SkillOutcome:
+def _install_bundled_skill(
+    target: Path,
+    bundled: str,
+    *,
+    force_overwrite: bool,
+    repo: Path | None = None,
+) -> SkillOutcome:
+    refusal = _skill_refusal(target, repo)
+    if refusal is not None:
+        return SkillOutcome(SkillKind.REFUSED_SYMLINK, target=target, refusal=refusal, repo=repo)
+
+    if target.is_file():
+        current = target.read_text(encoding="utf-8")
+        if current == bundled:
+            return SkillOutcome(SkillKind.UNCHANGED, target=target, repo=repo)
+        if force_overwrite:
+            target.write_text(bundled, encoding="utf-8")
+            return SkillOutcome(SkillKind.OVERWROTE, target=target, repo=repo)
+        backup = target.with_name(target.name + ".bak")
+        backup_refusal = _skill_refusal(backup, repo)
+        if backup_refusal is not None:
+            return SkillOutcome(
+                SkillKind.REFUSED_SYMLINK,
+                target=target,
+                refusal=backup_refusal,
+                repo=repo,
+            )
+        backup.write_text(current, encoding="utf-8")
+        target.write_text(bundled, encoding="utf-8")
+        return SkillOutcome(
+            SkillKind.UPDATED,
+            target=target,
+            repo=repo,
+            backup_name=backup.name,
+        )
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(bundled, encoding="utf-8")
+    return SkillOutcome(SkillKind.WROTE, target=target, repo=repo)
+
+
+def _remove_bundled_skill(
+    target: Path,
+    bundled: str,
+    *,
+    stop_above: Path,
+    repo: Path | None = None,
+) -> SkillOutcome:
     """Unlink ``target`` and prune empty parents, but never above ``stop_above``.
 
     Without the bound the parent walk could rmdir the surface base
     (``~/.claude/skills/``, ``<repo>/.cursor/rules/``, etc.) or — worse —
     keep going if those happen to be empty after MCP config also got removed.
+    """
+    refusal = _skill_refusal(target, repo)
+    if refusal is not None:
+        return SkillOutcome(SkillKind.REFUSED_SYMLINK, target=target, refusal=refusal, repo=repo)
+    if not target.is_file():
+        return SkillOutcome(SkillKind.ABSENT, target=target, repo=repo)
+    if target.read_text(encoding="utf-8") != bundled:
+        return SkillOutcome(SkillKind.PRESERVED_MODIFIED, target=target, repo=repo)
+    target.unlink()
+    stop_resolved = stop_above.resolve()
+    parent = target.parent
+    while parent.is_dir() and not any(parent.iterdir()):
+        if parent.resolve() == stop_resolved:
+            break
+        parent.rmdir()
+        parent = parent.parent
+    return SkillOutcome(SkillKind.REMOVED, target=target, repo=repo)
+
+
+def _remove_skill_file(target: Path, *, stop_above: Path) -> SkillOutcome:
+    """Remove an arbitrary skill file for compatibility with codec callers.
+
+    Bundle teardown uses ``_remove_bundled_skill`` so modified Nauro files are
+    preserved. This lower-level helper retains the original bounded-prune
+    contract for callers that already selected an exact disposable target.
     """
     refusal = find_file_symlink(target)
     if refusal is not None:
@@ -63,6 +147,39 @@ def _remove_skill_file(target: Path, *, stop_above: Path) -> SkillOutcome:
         parent.rmdir()
         parent = parent.parent
     return SkillOutcome(SkillKind.REMOVED, target=target)
+
+
+def _migrate_legacy_codex_skill(name: str) -> SkillOutcome | None:
+    source = Path.home() / ".codex" / "skills" / name
+    if source.is_symlink():
+        return SkillOutcome(
+            SkillKind.REFUSED_SYMLINK,
+            source=source,
+            refusal=UserSymlinkRefusal(source),
+        )
+    skill_file = source / "SKILL.md"
+    if skill_file.is_symlink():
+        return SkillOutcome(
+            SkillKind.REFUSED_SYMLINK,
+            source=source,
+            refusal=UserSymlinkRefusal(skill_file),
+        )
+    if not skill_file.is_file():
+        return None
+
+    backup_root = Path.home() / ".codex" / "nauro-skill-backups"
+    backup_root.mkdir(parents=True, exist_ok=True)
+    backup = backup_root / name
+    suffix = 1
+    while backup.exists() or backup.is_symlink():
+        backup = backup_root / f"{name}.{suffix}"
+        suffix += 1
+    source.rename(backup)
+    return SkillOutcome(
+        SkillKind.MIGRATED_LEGACY,
+        source=source,
+        backup_path=backup,
+    )
 
 
 def _resolved_skill_names(with_skills: bool) -> tuple[str, ...]:
@@ -81,6 +198,7 @@ def materialize_skills_claude_code(
     remove: bool,
     clear_user_scope: bool = True,
     with_skills: bool = False,
+    force_overwrite: bool = False,
 ) -> list[SkillOutcome]:
     """Install or remove the Nauro skill(s) under ``~/.claude/skills/``.
 
@@ -100,10 +218,17 @@ def materialize_skills_claude_code(
     results: list[SkillOutcome] = []
     for name in _resolved_skill_names(with_skills):
         target = base / name / "SKILL.md"
+        bundled = render_skill("claude_code", name)
         if remove:
-            results.append(_remove_skill_file(target, stop_above=base))
+            results.append(_remove_bundled_skill(target, bundled, stop_above=base))
         else:
-            results.append(_materialize_skill_file(target, render_skill("claude_code", name)))
+            results.append(
+                _install_bundled_skill(
+                    target,
+                    bundled,
+                    force_overwrite=force_overwrite,
+                )
+            )
     return results
 
 
@@ -112,6 +237,7 @@ def materialize_skills_codex(
     remove: bool,
     clear_user_scope: bool = True,
     with_skills: bool = False,
+    force_overwrite: bool = False,
 ) -> list[SkillOutcome]:
     """Install or remove the Nauro skill(s) under ``~/.agents/skills/``.
 
@@ -131,10 +257,20 @@ def materialize_skills_codex(
     results: list[SkillOutcome] = []
     for name in _resolved_skill_names(with_skills):
         target = base / name / "SKILL.md"
+        bundled = render_skill("codex", name)
         if remove:
-            results.append(_remove_skill_file(target, stop_above=base))
+            results.append(_remove_bundled_skill(target, bundled, stop_above=base))
         else:
-            results.append(_materialize_skill_file(target, render_skill("codex", name)))
+            installed = _install_bundled_skill(
+                target,
+                bundled,
+                force_overwrite=force_overwrite,
+            )
+            results.append(installed)
+            if installed.kind is not SkillKind.REFUSED_SYMLINK:
+                migrated = _migrate_legacy_codex_skill(name)
+                if migrated is not None:
+                    results.append(migrated)
     return results
 
 
@@ -143,6 +279,7 @@ def materialize_skills_cursor_for_repo(
     *,
     remove: bool,
     with_skills: bool = False,
+    force_overwrite: bool = False,
 ) -> list[SkillOutcome]:
     """Install or remove Cursor rules under ``<repo>/.cursor/rules/``.
 
@@ -153,13 +290,24 @@ def materialize_skills_cursor_for_repo(
     base = repo / ".cursor" / "rules"
     results: list[SkillOutcome] = []
     for name in _resolved_skill_names(with_skills):
-        refusal = find_symlink(repo, f".cursor/rules/{name}.mdc")
-        if refusal is not None:
-            results.append(SkillOutcome(SkillKind.REFUSED_SYMLINK, refusal=refusal, repo=repo))
-            continue
         target = base / f"{name}.mdc"
+        bundled = render_skill("cursor", name)
         if remove:
-            results.append(_remove_skill_file(target, stop_above=base))
+            results.append(
+                _remove_bundled_skill(
+                    target,
+                    bundled,
+                    stop_above=base,
+                    repo=repo,
+                )
+            )
         else:
-            results.append(_materialize_skill_file(target, render_skill("cursor", name)))
+            results.append(
+                _install_bundled_skill(
+                    target,
+                    bundled,
+                    force_overwrite=force_overwrite,
+                    repo=repo,
+                )
+            )
     return results

--- a/packages/nauro/src/nauro/skills/__init__.py
+++ b/packages/nauro/src/nauro/skills/__init__.py
@@ -24,6 +24,50 @@ from nauro_core.protocol import substitute_protocol_fragments
 Surface = Literal["claude_code", "cursor", "codex"]
 SkillName = Literal["nauro-adopt", "nauro-ship-task", "nauro-context", "nauro-loop"]
 
+_SHIP_TASK_PREREQUISITES_TOKEN = "<!-- surface:SHIP_TASK_PREREQUISITES -->"
+
+_CLAUDE_SHIP_TASK_PREREQUISITES = (
+    "This skill invokes the bundled `@nauro-*` subagents by name. They install via "
+    "`nauro adopt --with-subagents` (or `nauro setup all --with-subagents`) and "
+    "dispatch on Claude Code. If they are missing, or the current surface cannot "
+    "spawn subagents, the chain cannot run; surface that to the user and stop. Do "
+    "not reproduce the chain inline in the main session: the gates depend on the "
+    "subagents' restricted tool access, and an inline imitation runs without those "
+    "restrictions. The personal-subagent path (`@planner` / `@executor` / `@reviewer` "
+    "without the `nauro-` prefix) is not a substitute either. The bundled subagents "
+    "call Nauro's MCP tools by design, which is what makes the doctrine gates "
+    "load-bearing."
+)
+
+_CODEX_SHIP_TASK_PREREQUISITES = (
+    "This skill invokes the installed `nauro-planner`, `nauro-executor`, "
+    "`nauro-reviewer`, and `nauro-tech-lead` custom agents. They install under "
+    "`~/.codex/agents/` via `nauro adopt --with-subagents` (or `nauro setup all "
+    "--with-subagents`).\n\n"
+    "### Codex dispatch capability check\n\n"
+    "Before planning or changing files:\n\n"
+    "1. Verify that all four `~/.codex/agents/nauro-*.toml` files exist.\n"
+    "2. Inspect the callable subagent dispatcher schema. A `task_name` field labels "
+    "a generic task; it does not prove that Codex loaded a same-named TOML definition.\n"
+    "3. If the dispatcher exposes `agent_type` or an equivalent custom-agent selector, "
+    "invoke each installed agent by its configured `name`.\n"
+    "4. If the dispatcher cannot select custom agents, explain that a generic fallback "
+    "would enforce the role only through task instructions, not through the TOML "
+    "`developer_instructions` and `sandbox_mode` configuration layers. Ask: `Use the "
+    "instruction-level Codex fallback for this run?` Do not plan, edit, file a "
+    "decision, commit, or push before the user explicitly approves.\n"
+    "5. On approval, read each installed TOML, start a separate generic subagent with "
+    "no inherited conversation context, and pass that agent's exact "
+    "`developer_instructions` together with only the task-local handoff. Never treat a "
+    "matching `task_name` as custom-agent dispatch. Keep the planner, executor, "
+    "reviewer, and tech-lead in separate contexts.\n"
+    "6. Record that the instruction-level fallback was used. Include that fact in the "
+    "push-gate summary and final receipt. If the user declines, or any agent definition "
+    "is missing, stop before mutation.\n\n"
+    "Do not reproduce the four roles inline in the parent session. The independent "
+    "contexts and the human-controlled gates remain mandatory in both dispatch modes."
+)
+
 SKILL_DESCRIPTIONS: dict[str, str] = {
     "nauro-adopt": (
         "Seeds Nauro's project store from an existing repo. Use after "
@@ -42,9 +86,8 @@ SKILL_DESCRIPTIONS: dict[str, str] = {
         "files. Runs @nauro-tech-lead Mode C between reviewer-APPROVE and the "
         "push gate to catch doctrine drift the reviewer missed. A prompt that "
         "carries a detailed implementation spec or a pasted handoff is still "
-        "chain input, not license to implement directly. Dispatches the "
-        "bundled subagents on Claude Code only. Invoke explicitly with "
-        "/nauro-ship-task <description>. Requires `nauro adopt "
+        "chain input, not license to implement directly. Invoke explicitly "
+        "with the surface's nauro-ship-task command. Requires `nauro adopt "
         "--with-subagents` to have run."
     ),
     "nauro-context": (
@@ -112,14 +155,21 @@ def load_adopt_body() -> str:
     return substitute_protocol_fragments(_strip_template_header(raw))
 
 
-def load_ship_task_body() -> str:
+def load_ship_task_body(surface: str = "claude_code") -> str:
     """Return the canonical ``/nauro-ship-task`` skill body (no frontmatter).
 
     The body has no protocol-fragment tokens today, but goes through the same
     substitution pass so future canonical claims can be added at the source.
     """
     raw = resources.files(__package__).joinpath("ship_task_body.md").read_text(encoding="utf-8")
-    return substitute_protocol_fragments(_strip_template_header(raw))
+    body = substitute_protocol_fragments(_strip_template_header(raw))
+    if surface == "codex":
+        prerequisites = _CODEX_SHIP_TASK_PREREQUISITES
+    elif surface in ("claude_code", "cursor"):
+        prerequisites = _CLAUDE_SHIP_TASK_PREREQUISITES
+    else:
+        raise ValueError(f"unknown surface: {surface!r}")
+    return body.replace(_SHIP_TASK_PREREQUISITES_TOKEN, prerequisites)
 
 
 def load_context_body() -> str:
@@ -142,11 +192,11 @@ def load_loop_body() -> str:
     return substitute_protocol_fragments(_strip_template_header(raw))
 
 
-def _load_body(skill_name: str) -> str:
+def _load_body(surface: str, skill_name: str) -> str:
     if skill_name == "nauro-adopt":
         return load_adopt_body()
     if skill_name == "nauro-ship-task":
-        return load_ship_task_body()
+        return load_ship_task_body(surface)
     if skill_name == "nauro-context":
         return load_context_body()
     if skill_name == "nauro-loop":
@@ -173,7 +223,7 @@ def render_skill(surface: str, skill_name: str) -> str:
     committed dogfood files at the repo root — drift tests assert each
     dogfood file equals ``render_skill(...)`` byte-for-byte.
     """
-    return _frontmatter(surface, skill_name) + _load_body(skill_name)
+    return _frontmatter(surface, skill_name) + _load_body(surface, skill_name)
 
 
 __all__ = [

--- a/packages/nauro/src/nauro/skills/adopt_body.md
+++ b/packages/nauro/src/nauro/skills/adopt_body.md
@@ -74,7 +74,7 @@ If the file is missing, try two fallbacks before aborting:
 1. **Worktree fallback.** Compare `git rev-parse --git-dir` and `git rev-parse --git-common-dir`. If they differ, the current checkout is a linked worktree, and `.nauro/` may only exist in the main worktree (common when a workspace tool gitignores `.nauro/` per-checkout). The main worktree path is the parent directory of `git rev-parse --path-format=absolute --git-common-dir`. Re-read `<main-worktree>/.nauro/config.json` there.
 2. **Registry fallback.** Read `~/.nauro/registry.json`. Schema v2 keys each project by its id under `projects` — the dict key **is** the project `id`; the entry stores `name`, `mode`, `repo_paths`, etc. If any entry's `repo_paths` contains the current repo root or the resolved main-worktree path, use that dict key as the `id` and the entry's `name` as the project handle.
 
-Abort only when both fallbacks miss, with: "This repo is not adopted yet. Run 'nauro adopt' from the repo root, restart this agent, then invoke /nauro-adopt again."
+Abort only when both fallbacks miss, with: "This repo is not adopted yet. Run 'nauro adopt' from the repo root, restart this agent, then invoke the nauro-adopt skill again."
 
 Pass `id` as the `project_id` argument on every subsequent MCP call (`propose_decision`, `update_state`, `flag_question`, `get_context`, `list_decisions`, `check_decision`, `get_decision`). Do not omit `project_id` even though the tool descriptions say it's optional — auto-resolve routes to the user's default project, which is **not** the project this skill is seeding when both local-mode and cloud-mode projects coexist.
 

--- a/packages/nauro/src/nauro/skills/ship_task_body.md
+++ b/packages/nauro/src/nauro/skills/ship_task_body.md
@@ -13,7 +13,7 @@ Take the user's task description from the prompt that invoked this skill. If the
 
 ## Prerequisites
 
-This skill invokes the bundled `@nauro-*` subagents by name. They install via `nauro adopt --with-subagents` (or `nauro setup all --with-subagents`) and dispatch on Claude Code only. If they are missing, or the current surface cannot spawn subagents, the chain cannot run; surface that to the user and stop. Do not reproduce the chain inline in the main session: the gates depend on the subagents' restricted tool access, and an inline imitation runs without those restrictions. The personal-subagent path (`@planner` / `@executor` / `@reviewer` without the `nauro-` prefix) is not a substitute either — the bundled subagents call Nauro's MCP tools by design, which is what makes the doctrine gates load-bearing.
+<!-- surface:SHIP_TASK_PREREQUISITES -->
 
 The bundled subagents follow the session's model — chain quality tracks the model the session runs.
 

--- a/packages/nauro/tests/test_adopt.py
+++ b/packages/nauro/tests/test_adopt.py
@@ -186,12 +186,16 @@ def test_adopt_already_adopted_with_subagents_installs_instead_of_aborting(
     # Fresh adopt without the flag installs no subagents.
     for n in AGENT_NAMES:
         assert not _agent_path(tmp_path, n).exists()
+        assert not _codex_agent_path(tmp_path, n).exists()
 
     result = runner.invoke(app, ["adopt", "--with-subagents"])
     assert result.exit_code == 0, result.output
     assert "already adopted" not in result.output.lower() or "Installing" in result.output
     for n in AGENT_NAMES:
         assert _agent_path(tmp_path, n).is_file(), f"missing {n} after re-adopt --with-subagents"
+        assert _codex_agent_path(tmp_path, n).is_file(), (
+            f"missing Codex {n} after re-adopt --with-subagents"
+        )
 
 
 def test_adopt_already_adopted_with_skills_installs_and_notices(tmp_path: Path, monkeypatch):
@@ -327,6 +331,10 @@ def _agent_path(home: Path, agent: str) -> Path:
     return home / ".claude" / "agents" / f"{agent}.md"
 
 
+def _codex_agent_path(home: Path, agent: str) -> Path:
+    return home / ".codex" / "agents" / f"{agent}.toml"
+
+
 def test_adopt_default_does_not_install_subagents(tmp_path: Path, monkeypatch):
     """``nauro adopt`` without ``--with-subagents`` must not write any nauro-* agents."""
     _adopt_env(monkeypatch, tmp_path)
@@ -336,6 +344,7 @@ def test_adopt_default_does_not_install_subagents(tmp_path: Path, monkeypatch):
 
     for name in AGENT_NAMES:
         assert not _agent_path(tmp_path, name).exists()
+        assert not _codex_agent_path(tmp_path, name).exists()
 
 
 def test_adopt_with_subagents_installs_all_four(tmp_path: Path, monkeypatch):
@@ -346,9 +355,10 @@ def test_adopt_with_subagents_installs_all_four(tmp_path: Path, monkeypatch):
     assert result.exit_code == 0, result.output
 
     for name in AGENT_NAMES:
-        target = _agent_path(tmp_path, name)
-        assert target.is_file(), f"missing {target}"
-        assert target.read_text(encoding="utf-8") == render_agent("claude_code", name)
+        claude = _agent_path(tmp_path, name)
+        codex = _codex_agent_path(tmp_path, name)
+        assert claude.read_text(encoding="utf-8") == render_agent("claude_code", name)
+        assert codex.read_text(encoding="utf-8") == render_agent("codex", name)
 
 
 def test_adopt_with_subagents_refreshes_differing_file_with_backup(tmp_path: Path, monkeypatch):

--- a/packages/nauro/tests/test_agents_drift.py
+++ b/packages/nauro/tests/test_agents_drift.py
@@ -8,18 +8,25 @@ user's surface directory.
 
 Subagent markdown ships with full Claude Code frontmatter inline, so
 ``render_agent("claude_code", name)`` returns the body unchanged; there
-is no per-surface wrapping. Cursor and Codex are stub surfaces and raise
-``NotImplementedError`` until a target shape is defined.
+is no per-surface wrapping. Codex renders the canonical instructions into
+custom-agent TOML. Cursor raises ``NotImplementedError`` until a target shape
+is defined.
 """
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 import pytest
 from typer.testing import CliRunner
 
 from nauro.agents import AGENT_NAMES, emit_plugin_agents, load_agent_body, render_agent
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 AGENTS_DIR = Path(__file__).resolve().parents[1] / "src" / "nauro" / "agents"
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -89,9 +96,25 @@ def test_render_agent_cursor_raises_not_implemented(name: str) -> None:
 
 
 @pytest.mark.parametrize("name", list(AGENT_NAMES))
-def test_render_agent_codex_raises_not_implemented(name: str) -> None:
-    with pytest.raises(NotImplementedError):
-        render_agent("codex", name)
+def test_render_agent_codex_preserves_canonical_instructions(name: str) -> None:
+    rendered = render_agent("codex", name)
+    data = tomllib.loads(rendered)
+    canonical = load_agent_body(name)
+    end = canonical.find("\n---\n", 4)
+    frontmatter = canonical[4:end]
+    description = next(
+        line.split(":", 1)[1].strip()
+        for line in frontmatter.splitlines()
+        if line.startswith("description:")
+    )
+
+    assert data["name"] == name
+    assert data["description"] == description
+    assert data["developer_instructions"] == canonical[end + len("\n---\n") :]
+    if name == "nauro-executor":
+        assert "sandbox_mode" not in data
+    else:
+        assert data["sandbox_mode"] == "read-only"
 
 
 def test_render_agent_unknown_surface_raises_value_error() -> None:
@@ -258,7 +281,7 @@ def test_tech_lead_gates_every_decision_operation_on_explicit_user_approval() ->
     assert "every `add`, `update`, and `supersede`" in body
     assert "Standalone" in body
     assert "AskUserQuestion" in body
-    assert "Inside the `/nauro-ship-task` chain" in body
+    assert "Inside the `nauro-ship-task` chain" in body
     assert "return the complete draft to the parent and do not file in-run" in body
     assert "Mode B never files an `add` directly from the transcript." in body
     assert "related decisions and assessment from `check_decision`" in body

--- a/packages/nauro/tests/test_cli_status.py
+++ b/packages/nauro/tests/test_cli_status.py
@@ -8,6 +8,11 @@ import nauro.cli.commands.status as status_mod
 from nauro.cli import nauro_command
 from nauro.cli._codex_hooks import _CODEX_HOOK_PROBE_ARGS
 from nauro.cli.integrations import codex_config
+from nauro.cli.integrations.agents import materialize_agents
+from nauro.cli.integrations.skills import (
+    materialize_skills_claude_code,
+    materialize_skills_codex,
+)
 from nauro.cli.main import app
 from nauro.store.registry import register_project
 from nauro.templates.agents_md import FOOTER_MARKER
@@ -50,6 +55,13 @@ def _wire_codex_hooks(repo, *, command="nauro", events=("SessionStart", "Subagen
     path.write_text(json.dumps({"hooks": hooks}))
 
 
+def _install_workflow_artifacts() -> None:
+    materialize_skills_claude_code(remove=False, with_skills=True)
+    materialize_skills_codex(remove=False, with_skills=True)
+    materialize_agents("claude_code", remove=False)
+    materialize_agents("codex", remove=False)
+
+
 def test_status_mcp_and_agents_inactive_when_nothing_wired(tmp_path, monkeypatch):
     """No MCP config anywhere and no generated AGENTS.md → both rows inactive."""
     _setup_project(tmp_path, monkeypatch)
@@ -58,8 +70,96 @@ def test_status_mcp_and_agents_inactive_when_nothing_wired(tmp_path, monkeypatch
     assert result.exit_code == 0
     assert "MCP           inactive - run 'nauro setup all'" in result.output
     assert "Codex hooks   inactive - run 'nauro setup codex --with-hooks'" in result.output
+    assert (
+        "Skills        inactive - run 'nauro setup all' "
+        "(--with-skills adds the opt-in skills)" in result.output
+    )
+    assert (
+        "Workflow      not installed (opt-in) - "
+        "'nauro setup all --with-subagents' adds the workflow agents" in result.output
+    )
     assert "AGENTS.md     inactive - run 'nauro sync'" in result.output
     assert "Decisions:" in result.output
+
+
+def test_status_reports_current_skills_and_agents_on_both_surfaces(tmp_path, monkeypatch):
+    _setup_project(tmp_path, monkeypatch)
+    _install_workflow_artifacts()
+
+    result = runner.invoke(app, ["status"])
+
+    assert result.exit_code == 0
+    assert "Skills        active (Claude 4/4; Codex 4/4)" in result.output
+    assert "Workflow      active (Claude 4/4; Codex 4/4)" in result.output
+
+
+def test_status_reports_stale_skill_and_legacy_codex_copy(tmp_path, monkeypatch):
+    _setup_project(tmp_path, monkeypatch)
+    _install_workflow_artifacts()
+    home = tmp_path / "home"
+    (home / ".agents" / "skills" / "nauro-ship-task" / "SKILL.md").write_text(
+        "stale\n", encoding="utf-8"
+    )
+    legacy = home / ".codex" / "skills" / "nauro-ship-task" / "SKILL.md"
+    legacy.parent.mkdir(parents=True)
+    legacy.write_text("legacy\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["status"])
+
+    assert result.exit_code == 0
+    assert "Skills        BROKEN" in result.output
+    assert "1 legacy Nauro skill copy under ~/.codex/skills" in result.output
+    assert "migrate with 'nauro setup all --with-skills' or remove manually" in result.output
+
+
+def test_status_reports_stale_skill_without_legacy_copy(tmp_path, monkeypatch):
+    """A differing installed skill file alone → BROKEN with the refresh remedy."""
+    _setup_project(tmp_path, monkeypatch)
+    _install_workflow_artifacts()
+    home = tmp_path / "home"
+    (home / ".agents" / "skills" / "nauro-ship-task" / "SKILL.md").write_text(
+        "stale\n", encoding="utf-8"
+    )
+
+    result = runner.invoke(app, ["status"])
+
+    assert result.exit_code == 0
+    assert "Skills        BROKEN - Claude 4/4; Codex 3/4" in result.output
+    assert "differ from this release; run 'nauro setup all --with-skills'" in result.output
+
+
+def test_status_bare_adopt_states_optin_absence_without_degrading(tmp_path, monkeypatch):
+    """Core skill installed, no opt-ins, no agents → active row + stated choice."""
+    _setup_project(tmp_path, monkeypatch)
+    materialize_skills_claude_code(remove=False, with_skills=False)
+    materialize_skills_codex(remove=False, with_skills=False)
+
+    result = runner.invoke(app, ["status"])
+
+    assert result.exit_code == 0
+    assert (
+        "Skills        active (core installed; opt-in skills not installed - "
+        "'nauro setup all --with-skills' adds them)" in result.output
+    )
+    assert (
+        "Workflow      not installed (opt-in) - "
+        "'nauro setup all --with-subagents' adds the workflow agents" in result.output
+    )
+
+
+def test_status_partial_optin_skills_prompt_completion(tmp_path, monkeypatch):
+    """Opt-in skills on one surface only → partial with the --with-skills remedy."""
+    _setup_project(tmp_path, monkeypatch)
+    materialize_skills_claude_code(remove=False, with_skills=True)
+    materialize_skills_codex(remove=False, with_skills=False)
+
+    result = runner.invoke(app, ["status"])
+
+    assert result.exit_code == 0
+    assert (
+        "Skills        partial (Claude 4/4; Codex 1/4) - "
+        "run 'nauro setup all --with-skills'" in result.output
+    )
 
 
 def test_status_mcp_partial_repo_wiring(tmp_path, monkeypatch):

--- a/packages/nauro/tests/test_integration_outcomes.py
+++ b/packages/nauro/tests/test_integration_outcomes.py
@@ -465,7 +465,25 @@ RENDER_CASES = [
         SkillOutcome(SkillKind.PRESERVED, base_label="~/.claude/skills"),
         ["  preserved ~/.claude/skills/nauro-* (other nauro projects still registered)"],
     ),
+    (
+        SkillOutcome(SkillKind.PRESERVED_MODIFIED, target=TARGET),
+        [f"  preserved {TARGET} (locally modified)"],
+    ),
     (SkillOutcome(SkillKind.WROTE, target=TARGET), [f"  wrote {TARGET}"]),
+    (SkillOutcome(SkillKind.UNCHANGED, target=TARGET), [f"  unchanged {TARGET}"]),
+    (SkillOutcome(SkillKind.OVERWROTE, target=TARGET), [f"  overwrote {TARGET}"]),
+    (
+        SkillOutcome(SkillKind.UPDATED, target=TARGET, backup_name="SKILL.md.bak"),
+        [f"  updated {TARGET} (previous saved to SKILL.md.bak)"],
+    ),
+    (
+        SkillOutcome(
+            SkillKind.MIGRATED_LEGACY,
+            source=REPO / "legacy-skill",
+            backup_path=REPO / "skill-backup",
+        ),
+        [f"  moved legacy skill {REPO / 'legacy-skill'} to {REPO / 'skill-backup'}"],
+    ),
     (SkillOutcome(SkillKind.REMOVED, target=TARGET), [f"  removed {TARGET}"]),
     (SkillOutcome(SkillKind.ABSENT, target=TARGET), [f"  no skill at {TARGET}"]),
     # ── Agent ──

--- a/packages/nauro/tests/test_onboarding_inventories.py
+++ b/packages/nauro/tests/test_onboarding_inventories.py
@@ -114,7 +114,7 @@ def test_adopt_default_inventory(tmp_path: Path, monkeypatch):
             "Codex: wrote nauro to ",
             "regenerated AGENTS.md",
             "CLAUDE.md imports AGENTS.md (Claude Code bridge)",
-            "Next: restart your agent and invoke /nauro-adopt",
+            "Next: restart your agent and invoke the nauro-adopt skill",
         ],
     )
 
@@ -142,6 +142,10 @@ def test_adopt_with_skills_and_subagents_inventory(tmp_path: Path, monkeypatch):
             ".claude/skills/nauro-context/SKILL.md",
             ".claude/skills/nauro-loop/SKILL.md",
             ".claude/skills/nauro-ship-task/SKILL.md",
+            ".codex/agents/nauro-executor.toml",
+            ".codex/agents/nauro-planner.toml",
+            ".codex/agents/nauro-reviewer.toml",
+            ".codex/agents/nauro-tech-lead.toml",
             ".codex/config.toml",
             "repo/.cursor/mcp.json",
             "repo/.cursor/rules/nauro-adopt.mdc",
@@ -162,8 +166,8 @@ def test_adopt_with_skills_and_subagents_inventory(tmp_path: Path, monkeypatch):
             "Wiring MCP and installing skills across surfaces:",
             "wrote nauro to .mcp.json",
             "installed ",
-            "Cloud users: name the remote MCP connector exactly `Nauro`",
-            "Next: restart your agent and invoke /nauro-adopt",
+            "Claude Code cloud users: name the remote MCP connector exactly `Nauro`",
+            "Next: restart your agent and invoke the nauro-adopt skill",
         ],
     )
 
@@ -183,7 +187,7 @@ def test_adopt_no_setup_and_skills_inventory(tmp_path: Path, monkeypatch):
         result.stdout,
         [
             "Adopted project 'proj' (id: ",
-            "Next: restart your agent and invoke /nauro-adopt",
+            "Next: restart your agent and invoke the nauro-adopt skill",
         ],
     )
     assert "Wiring MCP and installing skills across surfaces:" not in result.stdout

--- a/packages/nauro/tests/test_setup_characterization.py
+++ b/packages/nauro/tests/test_setup_characterization.py
@@ -64,8 +64,8 @@ CURSOR_NEXT_LINE = "Next: open this repo in Cursor and start a chat - Nauro MCP 
 CODEX_NEXT_LINE = "Next: run a Codex session - it reads ~/.codex/config.toml on start.\n"
 
 ALL_RESTART_LINE = (
-    "Next: start a fresh agent session (Claude Code/Cursor) - MCP config is read at"
-    " session start.\n"
+    "Next: start a fresh agent session (Claude Code, Cursor, or Codex) - MCP config and"
+    " installed workflow files are read at session start.\n"
 )
 
 HOOKS_NOTICE_LINE = (
@@ -80,8 +80,8 @@ CODEX_HOOKS_NOTICE_LINE = (
 )
 
 CONNECTOR_NOTICE_LINE = (
-    "Cloud users: name the remote MCP connector exactly `Nauro` so the bundled @nauro-*"
-    " subagents' `mcp__claude_ai_Nauro__*` tools resolve.\n"
+    "Claude Code cloud users: name the remote MCP connector exactly `Nauro` so the bundled"
+    " @nauro-* subagents' `mcp__claude_ai_Nauro__*` tools resolve.\n"
 )
 
 SKILLS_NEEDS_SUBAGENTS_LINE = (
@@ -388,6 +388,10 @@ class TestSetupAllTranscripts:
             "  wrote {TMP}/.agents/skills/nauro-ship-task/SKILL.md\n"
             "  wrote {TMP}/.agents/skills/nauro-context/SKILL.md\n"
             "  wrote {TMP}/.agents/skills/nauro-loop/SKILL.md\n"
+            "  installed {TMP}/.codex/agents/nauro-planner.toml\n"
+            "  installed {TMP}/.codex/agents/nauro-executor.toml\n"
+            "  installed {TMP}/.codex/agents/nauro-reviewer.toml\n"
+            "  installed {TMP}/.codex/agents/nauro-tech-lead.toml\n"
             "  {TMP}/repo: wrote nauro hooks to .codex/hooks.json\n"
             "  {TMP}/repo: regenerated AGENTS.md\n"
             + _bridge_line()
@@ -553,6 +557,10 @@ class TestSetupAllTranscripts:
             "  wrote {TMP}/repo/.cursor/rules/nauro-adopt.mdc\n"
             "Codex: wrote nauro to {TMP}/.codex/config.toml\n"
             "  wrote {TMP}/.agents/skills/nauro-adopt/SKILL.md\n"
+            "  installed {TMP}/.codex/agents/nauro-planner.toml\n"
+            "  installed {TMP}/.codex/agents/nauro-executor.toml\n"
+            "  installed {TMP}/.codex/agents/nauro-reviewer.toml\n"
+            "  installed {TMP}/.codex/agents/nauro-tech-lead.toml\n"
             "  {TMP}/repo: regenerated AGENTS.md\n"
             + _bridge_line()
             + "\n"
@@ -618,16 +626,20 @@ class TestSetupAllTranscripts:
             "Configured Nauro for project 'proj' across all surfaces:\n"
             "\n"
             "  {TMP}/repo: wrote nauro to .mcp.json\n"
-            "  wrote {TMP}/.claude/skills/nauro-adopt/SKILL.md\n"
+            "  unchanged {TMP}/.claude/skills/nauro-adopt/SKILL.md\n"
             "  updated {TMP}/.claude/agents/nauro-planner.md"
             " (previous saved to nauro-planner.md.bak)\n"
             "  unchanged {TMP}/.claude/agents/nauro-executor.md\n"
             "  unchanged {TMP}/.claude/agents/nauro-reviewer.md\n"
             "  unchanged {TMP}/.claude/agents/nauro-tech-lead.md\n"
             "  {TMP}/repo: wrote nauro to .cursor/mcp.json\n"
-            "  wrote {TMP}/repo/.cursor/rules/nauro-adopt.mdc\n"
+            "  unchanged {TMP}/repo/.cursor/rules/nauro-adopt.mdc\n"
             "Codex: nauro already configured in {TMP}/.codex/config.toml\n"
-            "  wrote {TMP}/.agents/skills/nauro-adopt/SKILL.md\n"
+            "  unchanged {TMP}/.agents/skills/nauro-adopt/SKILL.md\n"
+            "  unchanged {TMP}/.codex/agents/nauro-planner.toml\n"
+            "  unchanged {TMP}/.codex/agents/nauro-executor.toml\n"
+            "  unchanged {TMP}/.codex/agents/nauro-reviewer.toml\n"
+            "  unchanged {TMP}/.codex/agents/nauro-tech-lead.toml\n"
             "  {TMP}/repo: regenerated AGENTS.md\n"
             + _bridge_line()
             + "\n"
@@ -661,15 +673,19 @@ class TestSetupAllTranscripts:
             "Configured Nauro for project 'proj' across all surfaces:\n"
             "\n"
             "  {TMP}/repo: wrote nauro to .mcp.json\n"
-            "  wrote {TMP}/.claude/skills/nauro-adopt/SKILL.md\n"
+            "  unchanged {TMP}/.claude/skills/nauro-adopt/SKILL.md\n"
             "  overwrote {TMP}/.claude/agents/nauro-planner.md\n"
             "  unchanged {TMP}/.claude/agents/nauro-executor.md\n"
             "  unchanged {TMP}/.claude/agents/nauro-reviewer.md\n"
             "  unchanged {TMP}/.claude/agents/nauro-tech-lead.md\n"
             "  {TMP}/repo: wrote nauro to .cursor/mcp.json\n"
-            "  wrote {TMP}/repo/.cursor/rules/nauro-adopt.mdc\n"
+            "  unchanged {TMP}/repo/.cursor/rules/nauro-adopt.mdc\n"
             "Codex: nauro already configured in {TMP}/.codex/config.toml\n"
-            "  wrote {TMP}/.agents/skills/nauro-adopt/SKILL.md\n"
+            "  unchanged {TMP}/.agents/skills/nauro-adopt/SKILL.md\n"
+            "  unchanged {TMP}/.codex/agents/nauro-planner.toml\n"
+            "  unchanged {TMP}/.codex/agents/nauro-executor.toml\n"
+            "  unchanged {TMP}/.codex/agents/nauro-reviewer.toml\n"
+            "  unchanged {TMP}/.codex/agents/nauro-tech-lead.toml\n"
             "  {TMP}/repo: regenerated AGENTS.md\n"
             + _bridge_line()
             + "\n"
@@ -734,6 +750,13 @@ class TestSetupAllTranscripts:
             "nauro-reviewer.md",
             "nauro-tech-lead.md",
         }
+        codex_agent_names = {p.name for p in (tmp_path / ".codex" / "agents").iterdir()}
+        assert codex_agent_names == {
+            "nauro-planner.toml",
+            "nauro-executor.toml",
+            "nauro-reviewer.toml",
+            "nauro-tech-lead.toml",
+        }
 
     def test_remove_with_flags_clears_optin_artifacts(self, tmp_path: Path, monkeypatch):
         """Re-passing the opt-in flags on remove clears every opt-in artifact.
@@ -776,6 +799,10 @@ class TestSetupAllTranscripts:
             "  removed {TMP}/.agents/skills/nauro-ship-task/SKILL.md\n"
             "  removed {TMP}/.agents/skills/nauro-context/SKILL.md\n"
             "  removed {TMP}/.agents/skills/nauro-loop/SKILL.md\n"
+            "  removed {TMP}/.codex/agents/nauro-planner.toml\n"
+            "  removed {TMP}/.codex/agents/nauro-executor.toml\n"
+            "  removed {TMP}/.codex/agents/nauro-reviewer.toml\n"
+            "  removed {TMP}/.codex/agents/nauro-tech-lead.toml\n"
             "  {TMP}/repo: no nauro Codex hooks to remove\n"
             "  {TMP}/repo: removed generated AGENTS.md\n"
             "  {TMP}/repo: removed CLAUDE.md bridge\n"
@@ -789,6 +816,8 @@ class TestSetupAllTranscripts:
         assert not rules_dir.exists() or not any(rules_dir.iterdir())
         agents_dir = tmp_path / ".claude" / "agents"
         assert not agents_dir.exists() or not any(agents_dir.iterdir())
+        codex_agents_dir = tmp_path / ".codex" / "agents"
+        assert not codex_agents_dir.exists() or not any(codex_agents_dir.iterdir())
 
 
 # ─── command-level idempotency ───────────────────────────────────────────────
@@ -887,31 +916,35 @@ class TestCommandIdempotency:
         assert second.exit_code == 0
 
         _assert_trees_identical(tree_first, _tree_bytes(tmp_path))
-        # The current mix: .mcp.json/.cursor/skills re-report "wrote", while
-        # agents, hooks, and codex report explicit no-op statuses.
+        # MCP JSON sinks re-report "wrote". Skills, agents, hooks, and Codex
+        # report explicit no-op statuses.
         assert _norm(second.stdout, tmp_path) == (
             "Configured Nauro for project 'proj' across all surfaces:\n"
             "\n"
             "  {TMP}/repo: wrote nauro to .mcp.json\n"
-            "  wrote {TMP}/.claude/skills/nauro-adopt/SKILL.md\n"
-            "  wrote {TMP}/.claude/skills/nauro-ship-task/SKILL.md\n"
-            "  wrote {TMP}/.claude/skills/nauro-context/SKILL.md\n"
-            "  wrote {TMP}/.claude/skills/nauro-loop/SKILL.md\n"
+            "  unchanged {TMP}/.claude/skills/nauro-adopt/SKILL.md\n"
+            "  unchanged {TMP}/.claude/skills/nauro-ship-task/SKILL.md\n"
+            "  unchanged {TMP}/.claude/skills/nauro-context/SKILL.md\n"
+            "  unchanged {TMP}/.claude/skills/nauro-loop/SKILL.md\n"
             "  unchanged {TMP}/.claude/agents/nauro-planner.md\n"
             "  unchanged {TMP}/.claude/agents/nauro-executor.md\n"
             "  unchanged {TMP}/.claude/agents/nauro-reviewer.md\n"
             "  unchanged {TMP}/.claude/agents/nauro-tech-lead.md\n"
             "  {TMP}/repo: nauro hook already present in .claude/settings.local.json\n"
             "  {TMP}/repo: wrote nauro to .cursor/mcp.json\n"
-            "  wrote {TMP}/repo/.cursor/rules/nauro-adopt.mdc\n"
-            "  wrote {TMP}/repo/.cursor/rules/nauro-ship-task.mdc\n"
-            "  wrote {TMP}/repo/.cursor/rules/nauro-context.mdc\n"
-            "  wrote {TMP}/repo/.cursor/rules/nauro-loop.mdc\n"
+            "  unchanged {TMP}/repo/.cursor/rules/nauro-adopt.mdc\n"
+            "  unchanged {TMP}/repo/.cursor/rules/nauro-ship-task.mdc\n"
+            "  unchanged {TMP}/repo/.cursor/rules/nauro-context.mdc\n"
+            "  unchanged {TMP}/repo/.cursor/rules/nauro-loop.mdc\n"
             "Codex: nauro already configured in {TMP}/.codex/config.toml\n"
-            "  wrote {TMP}/.agents/skills/nauro-adopt/SKILL.md\n"
-            "  wrote {TMP}/.agents/skills/nauro-ship-task/SKILL.md\n"
-            "  wrote {TMP}/.agents/skills/nauro-context/SKILL.md\n"
-            "  wrote {TMP}/.agents/skills/nauro-loop/SKILL.md\n"
+            "  unchanged {TMP}/.agents/skills/nauro-adopt/SKILL.md\n"
+            "  unchanged {TMP}/.agents/skills/nauro-ship-task/SKILL.md\n"
+            "  unchanged {TMP}/.agents/skills/nauro-context/SKILL.md\n"
+            "  unchanged {TMP}/.agents/skills/nauro-loop/SKILL.md\n"
+            "  unchanged {TMP}/.codex/agents/nauro-planner.toml\n"
+            "  unchanged {TMP}/.codex/agents/nauro-executor.toml\n"
+            "  unchanged {TMP}/.codex/agents/nauro-reviewer.toml\n"
+            "  unchanged {TMP}/.codex/agents/nauro-tech-lead.toml\n"
             "  {TMP}/repo: nauro hooks already present in .codex/hooks.json\n"
             "  {TMP}/repo: regenerated AGENTS.md\n"
             + _bridge_line()

--- a/packages/nauro/tests/test_setup_extended.py
+++ b/packages/nauro/tests/test_setup_extended.py
@@ -624,8 +624,7 @@ def test_setup_codex_advertises_check_decision(tmp_path: Path, monkeypatch):
 
 
 def test_setup_all_with_subagents_installs_and_removes_files(tmp_path: Path, monkeypatch):
-    """Round-trip: ``setup all --with-subagents`` writes nauro-*.md files;
-    ``setup all --remove --with-subagents`` clears them when no other projects remain."""
+    """Round-trip installs and removes Claude Markdown and Codex TOML agents."""
     from nauro.agents import AGENT_NAMES, render_agent
 
     monkeypatch.setenv("HOME", str(tmp_path))
@@ -637,14 +636,16 @@ def test_setup_all_with_subagents_installs_and_removes_files(tmp_path: Path, mon
 
     runner.invoke(app, ["setup", "all", "--with-subagents"])
     for name in AGENT_NAMES:
-        target = tmp_path / ".claude" / "agents" / f"{name}.md"
-        assert target.is_file()
-        assert target.read_text(encoding="utf-8") == render_agent("claude_code", name)
+        claude = tmp_path / ".claude" / "agents" / f"{name}.md"
+        codex = tmp_path / ".codex" / "agents" / f"{name}.toml"
+        assert claude.read_text(encoding="utf-8") == render_agent("claude_code", name)
+        assert codex.read_text(encoding="utf-8") == render_agent("codex", name)
 
     result = runner.invoke(app, ["setup", "all", "--remove", "--with-subagents"])
     assert result.exit_code == 0, result.output
     for name in AGENT_NAMES:
         assert not (tmp_path / ".claude" / "agents" / f"{name}.md").exists()
+        assert not (tmp_path / ".codex" / "agents" / f"{name}.toml").exists()
 
 
 def test_setup_all_with_subagents_remove_preserves_customized_files(tmp_path: Path, monkeypatch):
@@ -664,20 +665,25 @@ def test_setup_all_with_subagents_remove_preserves_customized_files(tmp_path: Pa
 
     runner.invoke(app, ["setup", "all", "--with-subagents"])
 
-    target = tmp_path / ".claude" / "agents" / "nauro-planner.md"
-    custom = "---\nname: nauro-planner\n---\n\nlocal tweak\n"
-    target.write_text(custom, encoding="utf-8")
+    claude_target = tmp_path / ".claude" / "agents" / "nauro-planner.md"
+    codex_target = tmp_path / ".codex" / "agents" / "nauro-planner.toml"
+    claude_custom = "---\nname: nauro-planner\n---\n\nlocal tweak\n"
+    codex_custom = 'name = "nauro-planner"\ndeveloper_instructions = "local tweak"\n'
+    claude_target.write_text(claude_custom, encoding="utf-8")
+    codex_target.write_text(codex_custom, encoding="utf-8")
 
     result = runner.invoke(app, ["setup", "all", "--remove", "--with-subagents"])
     assert result.exit_code == 0, result.output
 
     # nauro-planner was modified → preserved
-    assert target.read_text(encoding="utf-8") == custom
+    assert claude_target.read_text(encoding="utf-8") == claude_custom
+    assert codex_target.read_text(encoding="utf-8") == codex_custom
     # The other three matched the bundled content → unlinked
     for name in AGENT_NAMES:
         if name == "nauro-planner":
             continue
         assert not (tmp_path / ".claude" / "agents" / f"{name}.md").exists()
+        assert not (tmp_path / ".codex" / "agents" / f"{name}.toml").exists()
     assert "preserved" in result.output
     assert "locally modified" in result.output
 
@@ -697,6 +703,7 @@ def test_setup_all_default_does_not_install_subagents(tmp_path: Path, monkeypatc
     assert result.exit_code == 0, result.output
     for name in AGENT_NAMES:
         assert not (tmp_path / ".claude" / "agents" / f"{name}.md").exists()
+        assert not (tmp_path / ".codex" / "agents" / f"{name}.toml").exists()
 
 
 def test_setup_all_help_lists_with_subagents():
@@ -878,6 +885,100 @@ def test_setup_all_with_skills_installs_ship_task_everywhere(tmp_path: Path, mon
     assert not claude.exists()
     assert not codex.exists()
     assert not cursor.exists()
+
+
+def test_setup_all_with_skills_migrates_only_legacy_nauro_skill(tmp_path: Path, monkeypatch):
+    """Codex legacy cleanup moves owned Nauro skill names and leaves third-party skills."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    _, store_path = register_project_v2("myproj", [repo])
+    scaffold_project_store("myproj", store_path)
+    monkeypatch.chdir(repo)
+
+    legacy = tmp_path / ".codex" / "skills" / "nauro-ship-task"
+    legacy.mkdir(parents=True)
+    (legacy / "SKILL.md").write_text("old bundled copy\n", encoding="utf-8")
+    (legacy / "local-note.txt").write_text("keep with backup\n", encoding="utf-8")
+    third_party = tmp_path / ".codex" / "skills" / "third-party" / "SKILL.md"
+    third_party.parent.mkdir(parents=True)
+    third_party.write_text("third party\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["setup", "all", "--with-skills"])
+
+    assert result.exit_code == 0, result.output
+    backup = tmp_path / ".codex" / "nauro-skill-backups" / "nauro-ship-task"
+    assert not legacy.exists()
+    assert (backup / "SKILL.md").read_text(encoding="utf-8") == "old bundled copy\n"
+    assert (backup / "local-note.txt").read_text(encoding="utf-8") == "keep with backup\n"
+    assert third_party.read_text(encoding="utf-8") == "third party\n"
+    assert "moved legacy skill" in result.output
+
+
+def test_setup_all_with_skills_refreshes_differing_files_with_backups(tmp_path: Path, monkeypatch):
+    from nauro.skills import render_skill
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    _, store_path = register_project_v2("myproj", [repo])
+    scaffold_project_store("myproj", store_path)
+    monkeypatch.chdir(repo)
+
+    claude = tmp_path / ".claude" / "skills" / "nauro-ship-task" / "SKILL.md"
+    codex = tmp_path / ".agents" / "skills" / "nauro-ship-task" / "SKILL.md"
+    claude.parent.mkdir(parents=True)
+    codex.parent.mkdir(parents=True)
+    claude.write_text("old claude\n", encoding="utf-8")
+    codex.write_text("old codex\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["setup", "all", "--with-skills"])
+
+    assert result.exit_code == 0, result.output
+    assert claude.read_text(encoding="utf-8") == render_skill("claude_code", "nauro-ship-task")
+    assert codex.read_text(encoding="utf-8") == render_skill("codex", "nauro-ship-task")
+    assert claude.with_name("SKILL.md.bak").read_text(encoding="utf-8") == "old claude\n"
+    assert codex.with_name("SKILL.md.bak").read_text(encoding="utf-8") == "old codex\n"
+
+
+def test_setup_all_with_skills_force_overwrite_skips_skill_backup(tmp_path: Path, monkeypatch):
+    from nauro.skills import render_skill
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    _, store_path = register_project_v2("myproj", [repo])
+    scaffold_project_store("myproj", store_path)
+    monkeypatch.chdir(repo)
+
+    target = tmp_path / ".agents" / "skills" / "nauro-ship-task" / "SKILL.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("old codex\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["setup", "all", "--with-skills", "--force-overwrite"])
+
+    assert result.exit_code == 0, result.output
+    assert target.read_text(encoding="utf-8") == render_skill("codex", "nauro-ship-task")
+    assert not target.with_name("SKILL.md.bak").exists()
+
+
+def test_setup_all_remove_preserves_modified_skill(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    _, store_path = register_project_v2("myproj", [repo])
+    scaffold_project_store("myproj", store_path)
+    monkeypatch.chdir(repo)
+
+    runner.invoke(app, ["setup", "all", "--with-skills"])
+    target = tmp_path / ".agents" / "skills" / "nauro-ship-task" / "SKILL.md"
+    target.write_text("local customization\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["setup", "all", "--remove", "--with-skills"])
+
+    assert result.exit_code == 0, result.output
+    assert target.read_text(encoding="utf-8") == "local customization\n"
+    assert f"preserved {target} (locally modified)" in result.output
 
 
 def test_setup_all_with_skills_installs_context_everywhere(tmp_path: Path, monkeypatch):
@@ -1077,7 +1178,7 @@ def test_setup_all_prints_restart_line(tmp_path: Path, monkeypatch):
 
     result = runner.invoke(app, ["setup", "all"])
     assert result.exit_code == 0, result.output
-    assert "MCP config is read at session start" in result.output
+    assert "MCP config and installed workflow files are read at session start" in result.output
 
 
 def test_setup_claude_code_still_prints_restart_line(tmp_path: Path, monkeypatch):

--- a/packages/nauro/tests/test_skills_drift.py
+++ b/packages/nauro/tests/test_skills_drift.py
@@ -359,6 +359,19 @@ def test_render_skill_cursor_ship_task_frontmatter():
     assert body == load_ship_task_body()
 
 
+def test_render_skill_codex_ship_task_requires_approved_dispatch_fallback():
+    rendered = render_skill("codex", "nauro-ship-task")
+    body = rendered.split("\n---\n", 1)[1].lstrip("\n")
+
+    assert body == load_ship_task_body("codex")
+    assert "Codex dispatch capability check" in body
+    assert "A `task_name` field labels a generic task" in body
+    assert "Use the instruction-level Codex fallback for this run?" in body
+    assert "Do not plan, edit, file a decision, commit, or push" in body
+    assert "Record that the instruction-level fallback was used" in body
+    assert body != load_ship_task_body("claude_code")
+
+
 def test_render_skill_claude_code_context_frontmatter():
     rendered = render_skill("claude_code", "nauro-context")
     assert rendered.startswith("---\nname: nauro-context\n")


### PR DESCRIPTION
## Why

Nauro onboarding installed its gated workflow agents only for Claude Code and could leave stale or duplicate Codex skill copies behind. Codex sessions also need an explicit capability check so the ship workflow can use custom agents when available and a user-approved instruction-level fallback when the current dispatcher cannot select them.

## What changed

- Render and install the four bundled Nauro agents as Codex custom-agent TOML files, with planner, reviewer, and tech-lead restricted to read-only filesystem access.
- Render surface-specific ship-task prerequisites for Claude Code and Codex.
- Refresh stale Nauro-owned skills and agents during onboarding while preserving the previous content in sibling backup files.
- Migrate legacy Nauro skills out of the old Codex skills directory so only the current installation remains active.
- Report core skills, opt-in skills, workflow agents, stale files, and legacy copies in `nauro status`.
- Update onboarding documentation and the drift, characterization, migration, status, and write-safety tests.

## User impact

Running `nauro adopt --with-skills --with-subagents` now installs the current gated workflow for both Claude Code and Codex. Re-running onboarding converges Nauro-owned artifacts to the latest bundled version, preserves differing copies for recovery, and leaves unrelated third-party skills and agents untouched.

Codex custom agents retain their configured filesystem sandbox while inheriting Nauro MCP access. A live smoke test confirmed that a read-only tech-lead could not write a workspace sentinel but could file an explicitly approved decision through Nauro MCP.

## Validation

- Rebased onto current `main` after PR #372 and preserved both the CLAUDE.md bridge and surface-neutral onboarding behavior
- Conflict-overlap suite: 325 passed
- `pytest packages/nauro/tests -q`: 2,039 passed, 10 skipped
- `ruff check`: passed
- `ruff format --check`: 281 files already formatted
- `git diff --check`: passed
- Real onboarding and second-run idempotence check: every installed Claude and Codex skill and agent byte-matched the current bundle
- Live Codex smoke: read-only filesystem denial confirmed, Nauro MCP decision write verified on disk, store doctor clean

## Compatibility note

Codex task and display labels accept underscores rather than hyphens. The live run retried with an underscore-safe label while retaining the hyphenated custom-agent type and completed successfully.
