### PR TITLE
Release nauro 1.6.0

### DIFF
--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro"
-version = "1.5.0"
+version = "1.6.0"
 description = "Human-approved project judgment and current state for connected AI agents, surfaced before work."
 readme = "README.md"
 license = "Apache-2.0"

--- a/server.json
+++ b/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Nauro-AI/nauro",
     "source": "github"
   },
-  "version": "1.5.0",
+  "version": "1.6.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "nauro",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -928,7 +928,7 @@ wheels = [
 
 [[package]]
 name = "nauro"
-version = "1.5.0"
+version = "1.6.0"
 source = { editable = "packages/nauro" }
 dependencies = [
     { name = "filelock" },


### PR DESCRIPTION
## Release

- `nauro` 1.5.0 -> 1.6.0 (minor)
- `nauro-core` does not release: no shippable source changes since 1.2.0

## What ships in nauro 1.6.0

- Cross-surface workflow onboarding: `nauro adopt --with-skills --with-subagents` installs the bundled skills and the four workflow agents for both Claude Code (`~/.claude/`) and Codex (`~/.agents/skills/`, TOML custom agents in `~/.codex/agents/`), with refresh-with-backup semantics and ownership-scoped migration of legacy `~/.codex/skills/nauro-*` copies (#373)
- Per-surface ship-task dispatch: the Codex rendering carries a dispatch capability check and an approval-gated instruction-level fallback (#373)
- `nauro status` gains Skills and Workflow rows (per-surface present/current counts, legacy-copy detection); `nauro doctor` stays store-integrity-only (#370, #373)
- An owned thin CLAUDE.md bridges Claude Code to the generated AGENTS.md (#372)
- Generated AGENTS.md tells unwired sessions the repo uses Nauro (#371)
- Identity-vs-wiring split enforced at adopt/setup time (#369)

## Checks

- `check_server_json_version.py`: server.json locked to 1.6.0
- `check_single_sourced.py`: clean
- `uv lock` re-run and committed; `uv lock --check` and `uv sync --locked` (both packages, Python 3.12) pass locally

## After merge

Tag the squash commit `nauro-v1.6.0` and push it to trigger the PyPI trusted publish and the MCP-registry publish. No `nauro-core` tag this release.
