### PR TITLE
Render decision proposals as readable Markdown at the approval gate

### DIFF
--- a/.agents/skills/nauro-ship-task/SKILL.md
+++ b/.agents/skills/nauro-ship-task/SKILL.md
@@ -40,13 +40,13 @@ Before invoking `@nauro-planner`, the parent session confirms the planner will r
 
 Invoke the `@nauro-planner` subagent with the task description. The planner runs `check_decision` against the proposed approach, classifies as GREEN / AMBER / RED, reads related decision bodies via `get_decision`, investigates the code, and returns a plan in the plan shape (Why / Approach / What changes / What's deferred / Test plan), plus the verdict line and any complete decision draft awaiting approval.
 
-If the planner returns RED with a supersede draft, the chain pauses here. Surface the complete draft to the user. Only on explicit user approval does the parent re-invoke the planner with that approval to file the exact draft. An explicit "override RED on the cited decision, proceed" may continue without filing, but it is not approval to call `propose_decision`.
+If the planner returns RED with a supersede draft, the chain pauses here. Surface the complete draft to the user: paste the planner's complete rendered proposal exactly as returned, no reserialization to JSON, no abbreviation, no pointer to output above, immediately before the approval ask. Only on explicit user approval does the parent re-invoke the planner with that approval to file the exact draft. An explicit "override RED on the cited decision, proceed" may continue without filing, but it is not approval to call `propose_decision`.
 
 ### 2. GATE — plan approval (always when `propose_decision` is in play)
 
 The Nauro chain gates the plan whenever the planner indicates it will file a decision via `propose_decision` for any architectural choice, or whenever the plan records an `add`, `update`, or `supersede` draft. There is no "low-stakes auto-proceed" path when doctrine writes are pending. The user's judgment is the gate on what enters the decision log.
 
-This gate covers all three operations: `add`, `update`, and `supersede`. Surface the complete proposal draft, including its operation and affected decision when applicable. After explicit approval of that exact draft, re-invoke the planner with that approval so it can file. Rejecting or modifying the draft returns it to the planner; any changed draft requires fresh approval. The parent never files a subagent's draft itself.
+This gate covers all three operations: `add`, `update`, and `supersede`. Surface the complete proposal draft, including its operation and affected decision when applicable: paste the planner's complete rendered proposal exactly as returned, no reserialization to JSON, no abbreviation, no pointer to output above, immediately before the approval ask. After explicit approval of that exact draft, re-invoke the planner with that approval so it can file. Rejecting or modifying the draft returns it to the planner; any changed draft requires fresh approval. The parent never files a subagent's draft itself.
 
 A change additionally always gates if any of the following apply:
 
@@ -78,7 +78,7 @@ If the reviewer returns BLOCK, hand the hard-rule failures back to the `@nauro-e
 
 When the reviewer returns APPROVE or APPROVE WITH NITS, invoke `@nauro-tech-lead` in Mode C on the same local diff. The invocation explicitly carries the chain context the parent already holds: the task description, the planner's verdict and any decision filed at plan time (or deliberately not filed), and the reviewer's verdict with its nits. The tech-lead does not re-infer chain state from the diff alone. It reads decisions, scans the diff for architectural choices, and returns GREEN / AMBER / RED with any complete `add`, `update`, or `supersede` draft awaiting user approval.
 
-Any decision draft pauses the chain before step 7. Surface the complete draft to the user. After explicit approval of that exact draft, re-invoke the tech-lead with that approval so it can file. Rejecting or modifying the draft returns it to the tech-lead; any changed draft requires fresh approval. The parent never files a subagent's draft itself.
+Any decision draft pauses the chain before step 7. Surface the complete draft to the user: paste the tech-lead's complete rendered proposal exactly as returned, no reserialization to JSON, no abbreviation, no pointer to output above, immediately before the approval ask. After explicit approval of that exact draft, re-invoke the tech-lead with that approval so it can file. Rejecting or modifying the draft returns it to the tech-lead; any changed draft requires fresh approval. The parent never files a subagent's draft itself.
 
 - **GREEN** — proceed to the push gate (step 7).
 - **AMBER** — surface the constraints to the user alongside the push gate; user decides whether to address before push or document as a follow-up.

--- a/.claude/skills/nauro-ship-task/SKILL.md
+++ b/.claude/skills/nauro-ship-task/SKILL.md
@@ -27,13 +27,13 @@ Before invoking `@nauro-planner`, the parent session confirms the planner will r
 
 Invoke the `@nauro-planner` subagent with the task description. The planner runs `check_decision` against the proposed approach, classifies as GREEN / AMBER / RED, reads related decision bodies via `get_decision`, investigates the code, and returns a plan in the plan shape (Why / Approach / What changes / What's deferred / Test plan), plus the verdict line and any complete decision draft awaiting approval.
 
-If the planner returns RED with a supersede draft, the chain pauses here. Surface the complete draft to the user. Only on explicit user approval does the parent re-invoke the planner with that approval to file the exact draft. An explicit "override RED on the cited decision, proceed" may continue without filing, but it is not approval to call `propose_decision`.
+If the planner returns RED with a supersede draft, the chain pauses here. Surface the complete draft to the user: paste the planner's complete rendered proposal exactly as returned, no reserialization to JSON, no abbreviation, no pointer to output above, immediately before the approval ask. Only on explicit user approval does the parent re-invoke the planner with that approval to file the exact draft. An explicit "override RED on the cited decision, proceed" may continue without filing, but it is not approval to call `propose_decision`.
 
 ### 2. GATE — plan approval (always when `propose_decision` is in play)
 
 The Nauro chain gates the plan whenever the planner indicates it will file a decision via `propose_decision` for any architectural choice, or whenever the plan records an `add`, `update`, or `supersede` draft. There is no "low-stakes auto-proceed" path when doctrine writes are pending. The user's judgment is the gate on what enters the decision log.
 
-This gate covers all three operations: `add`, `update`, and `supersede`. Surface the complete proposal draft, including its operation and affected decision when applicable. After explicit approval of that exact draft, re-invoke the planner with that approval so it can file. Rejecting or modifying the draft returns it to the planner; any changed draft requires fresh approval. The parent never files a subagent's draft itself.
+This gate covers all three operations: `add`, `update`, and `supersede`. Surface the complete proposal draft, including its operation and affected decision when applicable: paste the planner's complete rendered proposal exactly as returned, no reserialization to JSON, no abbreviation, no pointer to output above, immediately before the approval ask. After explicit approval of that exact draft, re-invoke the planner with that approval so it can file. Rejecting or modifying the draft returns it to the planner; any changed draft requires fresh approval. The parent never files a subagent's draft itself.
 
 A change additionally always gates if any of the following apply:
 
@@ -65,7 +65,7 @@ If the reviewer returns BLOCK, hand the hard-rule failures back to the `@nauro-e
 
 When the reviewer returns APPROVE or APPROVE WITH NITS, invoke `@nauro-tech-lead` in Mode C on the same local diff. The invocation explicitly carries the chain context the parent already holds: the task description, the planner's verdict and any decision filed at plan time (or deliberately not filed), and the reviewer's verdict with its nits. The tech-lead does not re-infer chain state from the diff alone. It reads decisions, scans the diff for architectural choices, and returns GREEN / AMBER / RED with any complete `add`, `update`, or `supersede` draft awaiting user approval.
 
-Any decision draft pauses the chain before step 7. Surface the complete draft to the user. After explicit approval of that exact draft, re-invoke the tech-lead with that approval so it can file. Rejecting or modifying the draft returns it to the tech-lead; any changed draft requires fresh approval. The parent never files a subagent's draft itself.
+Any decision draft pauses the chain before step 7. Surface the complete draft to the user: paste the tech-lead's complete rendered proposal exactly as returned, no reserialization to JSON, no abbreviation, no pointer to output above, immediately before the approval ask. After explicit approval of that exact draft, re-invoke the tech-lead with that approval so it can file. Rejecting or modifying the draft returns it to the tech-lead; any changed draft requires fresh approval. The parent never files a subagent's draft itself.
 
 - **GREEN** — proceed to the push gate (step 7).
 - **AMBER** — surface the constraints to the user alongside the push gate; user decides whether to address before push or document as a follow-up.

--- a/.cursor/rules/nauro-ship-task.mdc
+++ b/.cursor/rules/nauro-ship-task.mdc
@@ -27,13 +27,13 @@ Before invoking `@nauro-planner`, the parent session confirms the planner will r
 
 Invoke the `@nauro-planner` subagent with the task description. The planner runs `check_decision` against the proposed approach, classifies as GREEN / AMBER / RED, reads related decision bodies via `get_decision`, investigates the code, and returns a plan in the plan shape (Why / Approach / What changes / What's deferred / Test plan), plus the verdict line and any complete decision draft awaiting approval.
 
-If the planner returns RED with a supersede draft, the chain pauses here. Surface the complete draft to the user. Only on explicit user approval does the parent re-invoke the planner with that approval to file the exact draft. An explicit "override RED on the cited decision, proceed" may continue without filing, but it is not approval to call `propose_decision`.
+If the planner returns RED with a supersede draft, the chain pauses here. Surface the complete draft to the user: paste the planner's complete rendered proposal exactly as returned, no reserialization to JSON, no abbreviation, no pointer to output above, immediately before the approval ask. Only on explicit user approval does the parent re-invoke the planner with that approval to file the exact draft. An explicit "override RED on the cited decision, proceed" may continue without filing, but it is not approval to call `propose_decision`.
 
 ### 2. GATE — plan approval (always when `propose_decision` is in play)
 
 The Nauro chain gates the plan whenever the planner indicates it will file a decision via `propose_decision` for any architectural choice, or whenever the plan records an `add`, `update`, or `supersede` draft. There is no "low-stakes auto-proceed" path when doctrine writes are pending. The user's judgment is the gate on what enters the decision log.
 
-This gate covers all three operations: `add`, `update`, and `supersede`. Surface the complete proposal draft, including its operation and affected decision when applicable. After explicit approval of that exact draft, re-invoke the planner with that approval so it can file. Rejecting or modifying the draft returns it to the planner; any changed draft requires fresh approval. The parent never files a subagent's draft itself.
+This gate covers all three operations: `add`, `update`, and `supersede`. Surface the complete proposal draft, including its operation and affected decision when applicable: paste the planner's complete rendered proposal exactly as returned, no reserialization to JSON, no abbreviation, no pointer to output above, immediately before the approval ask. After explicit approval of that exact draft, re-invoke the planner with that approval so it can file. Rejecting or modifying the draft returns it to the planner; any changed draft requires fresh approval. The parent never files a subagent's draft itself.
 
 A change additionally always gates if any of the following apply:
 
@@ -65,7 +65,7 @@ If the reviewer returns BLOCK, hand the hard-rule failures back to the `@nauro-e
 
 When the reviewer returns APPROVE or APPROVE WITH NITS, invoke `@nauro-tech-lead` in Mode C on the same local diff. The invocation explicitly carries the chain context the parent already holds: the task description, the planner's verdict and any decision filed at plan time (or deliberately not filed), and the reviewer's verdict with its nits. The tech-lead does not re-infer chain state from the diff alone. It reads decisions, scans the diff for architectural choices, and returns GREEN / AMBER / RED with any complete `add`, `update`, or `supersede` draft awaiting user approval.
 
-Any decision draft pauses the chain before step 7. Surface the complete draft to the user. After explicit approval of that exact draft, re-invoke the tech-lead with that approval so it can file. Rejecting or modifying the draft returns it to the tech-lead; any changed draft requires fresh approval. The parent never files a subagent's draft itself.
+Any decision draft pauses the chain before step 7. Surface the complete draft to the user: paste the tech-lead's complete rendered proposal exactly as returned, no reserialization to JSON, no abbreviation, no pointer to output above, immediately before the approval ask. After explicit approval of that exact draft, re-invoke the tech-lead with that approval so it can file. Rejecting or modifying the draft returns it to the tech-lead; any changed draft requires fresh approval. The parent never files a subagent's draft itself.
 
 - **GREEN** — proceed to the push gate (step 7).
 - **AMBER** — surface the constraints to the user alongside the push gate; user decides whether to address before push or document as a follow-up.

--- a/packages/nauro-core/src/nauro_core/mcp_tools.py
+++ b/packages/nauro-core/src/nauro_core/mcp_tools.py
@@ -20,6 +20,7 @@ from typing import Any, TypedDict
 from nauro_core.decision_model import DECISION_TYPE_VALUES
 from nauro_core.protocol import (
     _APPROVAL_BEFORE_PROPOSE,
+    _PROPOSAL_VISIBILITY_DETAIL,
     GET_DECISION_BEFORE_PROPOSING,
     PROPOSE_DECISION_OPERATIONS,
     RESOLVES_OPEN_QUESTIONS,
@@ -318,6 +319,8 @@ PROPOSE_DECISION: ToolSpec = {
         "never block the write.\n"
         "\n"
         f"{_APPROVAL_BEFORE_PROPOSE}\n"
+        "\n"
+        f"{_PROPOSAL_VISIBILITY_DETAIL}\n"
         "\n"
         "Call this when you choose between two or more approaches, replace "
         "or remove a dependency, establish a new pattern, or cut scope. "

--- a/packages/nauro-core/src/nauro_core/protocol.py
+++ b/packages/nauro-core/src/nauro_core/protocol.py
@@ -58,8 +58,18 @@ NO_INVENT_RATIONALE = (
 
 _APPROVAL_BEFORE_PROPOSE = (
     "Before `propose_decision`, present the complete add, update, or supersede "
-    "draft with any related decisions and obtain explicit user approval. The "
-    "call commits immediately after validation."
+    "draft as readable Markdown with any related decisions, end the turn with "
+    "the draft, and collect explicit user approval from the user's next reply. "
+    "The call commits immediately after validation."
+)
+
+_PROPOSAL_VISIBILITY_DETAIL = (
+    "Never couple the draft with an approval prompt (such as AskUserQuestion) "
+    "in the same turn: text emitted before a tool call may never render, so "
+    "the user would approve a draft they cannot see. An approval prompt may "
+    "carry the choice only once the full draft is on screen from a prior turn. "
+    "Structured `propose_decision` arguments stay internal; show raw JSON only "
+    "on an explicit debugging request."
 )
 
 RESOLVES_OPEN_QUESTIONS = (

--- a/packages/nauro-core/tests/test_protocol.py
+++ b/packages/nauro-core/tests/test_protocol.py
@@ -14,6 +14,7 @@ from nauro_core.constants import MCP_INSTRUCTIONS_STATIC
 from nauro_core.mcp_tools import get_tool_spec
 from nauro_core.protocol import (
     _APPROVAL_BEFORE_PROPOSE,
+    _PROPOSAL_VISIBILITY_DETAIL,
     CANONICAL_FRAGMENTS,
     CHECK_DECISION_RETURNS,
     GET_DECISION_BEFORE_PROPOSING,
@@ -37,10 +38,27 @@ class TestFragmentAnchors:
         assert "related decisions" in _APPROVAL_BEFORE_PROPOSE
         assert "explicit user approval" in _APPROVAL_BEFORE_PROPOSE
         assert "commits immediately after validation" in _APPROVAL_BEFORE_PROPOSE
+        # Visibility kernel: the draft renders as readable Markdown, the turn
+        # ends with it, and approval is the user's next reply.
+        assert "readable Markdown" in _APPROVAL_BEFORE_PROPOSE
+        assert "end the turn" in _APPROVAL_BEFORE_PROPOSE
+        assert "next reply" in _APPROVAL_BEFORE_PROPOSE
 
-    def test_approval_fragment_is_not_public_protocol_api(self) -> None:
+    def test_visibility_detail_fragment_forbids_same_turn_prompt_coupling(self) -> None:
+        assert "same turn" in _PROPOSAL_VISIBILITY_DETAIL
+        assert "AskUserQuestion" in _PROPOSAL_VISIBILITY_DETAIL
+        assert "may never render" in _PROPOSAL_VISIBILITY_DETAIL
+        # The prompt may carry the choice only once the draft is on screen
+        # from a prior turn.
+        assert "on screen from a prior turn" in _PROPOSAL_VISIBILITY_DETAIL
+        assert "stay internal" in _PROPOSAL_VISIBILITY_DETAIL
+        assert "raw JSON only" in _PROPOSAL_VISIBILITY_DETAIL
+
+    def test_approval_fragments_are_not_public_protocol_api(self) -> None:
         assert "_APPROVAL_BEFORE_PROPOSE" not in protocol.__all__
         assert "APPROVAL_BEFORE_PROPOSE" not in CANONICAL_FRAGMENTS
+        assert "_PROPOSAL_VISIBILITY_DETAIL" not in protocol.__all__
+        assert "PROPOSAL_VISIBILITY_DETAIL" not in CANONICAL_FRAGMENTS
 
     def test_check_decision_returns_names_bm25_and_deterministic(self) -> None:
         assert "BM25" in CHECK_DECISION_RETURNS
@@ -237,6 +255,20 @@ class TestMcpInstructionsComposition:
         spec = get_tool_spec("propose_decision")
         op_desc = spec["input_schema"]["properties"]["operation"]["description"]
         assert UPDATE_SUPERSEDE_CARE in op_desc
+
+    def test_proposal_visibility_detail_not_in_static(self) -> None:
+        """The detail fragment lives on the propose_decision ToolSpec
+        description, not the static block, for the same truncation-budget
+        reason as the relocated operation fragments; the compact kernel in
+        the approval fragment is what the static block carries."""
+        assert _PROPOSAL_VISIBILITY_DETAIL not in MCP_INSTRUCTIONS_STATIC
+
+    def test_proposal_visibility_detail_in_propose_decision_description(self) -> None:
+        """Relocation guard: the fragment must appear verbatim on the
+        ``propose_decision`` ToolSpec description so the agent reads the
+        same-turn prompt-coupling prohibition at the moment of use."""
+        spec = get_tool_spec("propose_decision")
+        assert _PROPOSAL_VISIBILITY_DETAIL in spec["description"]
 
     def test_resolves_open_questions_in_resolves_questions_parameter(self) -> None:
         """Relocation guard: the fragment must appear verbatim on the

--- a/packages/nauro/src/nauro/agents/nauro-planner.md
+++ b/packages/nauro/src/nauro/agents/nauro-planner.md
@@ -27,7 +27,7 @@ Every decision proposal uses the same approval rule for all three operations: `a
 
     A RED verdict means the proposal cannot ship without an explicit doctrine move. Pick one path:
 
-    - **Draft the supersede** (default). Title, rationale, what's being replaced, what's being rejected from the prior decision. Surface the draft at the *top* of the plan output, not in a footnote.
+    - **Draft the supersede** (default). Title, rationale, what's being replaced, what's being rejected from the prior decision. Render it in the proposal template below and surface it at the *top* of the plan output, not in a footnote.
 
     - **Refuse to draft** (decision-spam path). Skip the supersede draft only when **all four** of these hold:
         1. The related decision was filed within the last 7 days,
@@ -49,9 +49,40 @@ Every decision proposal uses the same approval rule for all three operations: `a
     - **What's deferred** — anything intentionally out of scope
     - **Test plan** — what proves it works
 
-5. **Draft a decision if non-trivial, then gate the write.** When the plan chooses between approaches, replaces a dependency, establishes a pattern, or cuts scope, prepare the complete `propose_decision` payload and include what was rejected and why. Pick `operation`: `add` for new ground, `update` to augment existing rationale (provide `affected_decision_id`), or `supersede` to replace an existing decision (provide `affected_decision_id`). Prefer `add` when uncertain. Return the draft with the related decisions and assessment from `check_decision`, marked as awaiting explicit user approval. If a later invocation carries explicit approval for that exact draft and those surfaced overlaps, call `propose_decision` once and report the result. A changed draft requires fresh approval.
+5. **Draft a decision if non-trivial, then gate the write.** When the plan chooses between approaches, replaces a dependency, establishes a pattern, or cuts scope, prepare the complete `propose_decision` payload and include what was rejected and why. Pick `operation`: `add` for new ground, `update` to augment existing rationale (provide `affected_decision_id`), or `supersede` to replace an existing decision (provide `affected_decision_id`). Prefer `add` when uncertain. Return the draft rendered in the proposal template below, with the related decisions and assessment from `check_decision`, marked as awaiting explicit user approval. If a later invocation carries explicit approval for that exact draft and those surfaced overlaps, call `propose_decision` once and report the result. A changed draft requires fresh approval.
 
 6. **Return.** Give the plan, the verdict, and either the complete draft awaiting approval or the decision number from an explicitly approved write. State which Bash commands the executor will need (lint, tests, build).
+
+## Decision proposal template
+
+Render every decision draft for approval in exactly this shape, as plain Markdown in the message body, never inside a tool argument:
+
+```
+## Decision proposal (awaiting approval)
+
+**Operation:** add | update | supersede
+**Affected decision:** <decision number for update or supersede; omit for add>
+**Title:** <title exactly as it will be filed>
+
+**Rationale (as it will be filed):**
+
+<the complete rationale text, in full>
+
+**Confidence:** high | medium | low
+**Type:** <decision_type, or none>
+**Reversibility:** easy | moderate | hard
+**Files affected:** <repo-relative paths, or none>
+
+**Rejected alternatives:**
+- <alternative>: <why it was rejected>
+
+**Related decisions (from check_decision):**
+- <decision>: <what it says and how it bears on this proposal>
+
+**Doctrine assessment:** <the check_decision assessment string plus your reading of it>
+```
+
+Sequencing: the rendered proposal is the final text of the turn, the turn ends with it, and approval is the user's next input. Never combine the proposal with an approval prompt (such as AskUserQuestion) in the same turn: text emitted before a tool call may never render, so the user would approve a draft they cannot see. An approval prompt may carry the choice only in a later turn, once the full proposal is already on screen. A subagent invocation returns this template block to the parent for verbatim surfacing; the parent pastes it exactly as returned.
 
 ## Hard rules
 

--- a/packages/nauro/src/nauro/agents/nauro-tech-lead.md
+++ b/packages/nauro/src/nauro/agents/nauro-tech-lead.md
@@ -7,7 +7,38 @@ model: inherit
 
 You set and maintain project direction. You have authority on doctrine: when a plan, a session, or a PR drifts from active decisions, you call it; when an emergent pattern needs a decision, you draft it and file only after approval. @nauro-planner, @nauro-executor, and @nauro-reviewer defer to you on architectural direction. The human keeps the final override: every `add`, `update`, and `supersede` passes through explicit user approval before you call `propose_decision`. The kernel commits immediately on Tier 1 clean; there is no separate confirm step.
 
-The approval channel depends on how you were invoked. The complete draft includes its operation, full payload, and the related decisions and assessment from `check_decision`. **Standalone with a direct user channel**: present that draft through the surface's user-question tool (`AskUserQuestion` on Claude Code) with options `Approve and file` / `Reject` / `Modify draft`, then file only on `Approve and file`. **Inside the `nauro-ship-task` chain, or on a surface without a direct user channel**: the parent session owns the user gate, so return the complete draft to the parent and do not file in-run. After the parent gets explicit user approval, it re-invokes you with that approval so you can file the exact draft. The parent never files your draft itself. This channel rule covers every `add`, `update`, and `supersede`.
+The approval channel depends on how you were invoked. The complete draft includes its operation, full payload, and the related decisions and assessment from `check_decision`, rendered in the proposal template below. **Standalone with a direct user channel**: present the full rendered proposal as the final text of its turn and end the turn there. In a later turn, once the proposal is on screen, the surface's user-question tool (`AskUserQuestion` on Claude Code) may carry the choice with options `Approve and file` / `Reject` / `Modify draft`; file only on `Approve and file`. **Inside the `nauro-ship-task` chain, or on a surface without a direct user channel**: the parent session owns the user gate, so return the complete draft to the parent and do not file in-run. After the parent gets explicit user approval, it re-invokes you with that approval so you can file the exact draft. The parent never files your draft itself. This channel rule covers every `add`, `update`, and `supersede`.
+
+## Decision proposal template
+
+Render every decision draft for approval in exactly this shape, as plain Markdown in the message body, never inside a tool argument:
+
+```
+## Decision proposal (awaiting approval)
+
+**Operation:** add | update | supersede
+**Affected decision:** <decision number for update or supersede; omit for add>
+**Title:** <title exactly as it will be filed>
+
+**Rationale (as it will be filed):**
+
+<the complete rationale text, in full>
+
+**Confidence:** high | medium | low
+**Type:** <decision_type, or none>
+**Reversibility:** easy | moderate | hard
+**Files affected:** <repo-relative paths, or none>
+
+**Rejected alternatives:**
+- <alternative>: <why it was rejected>
+
+**Related decisions (from check_decision):**
+- <decision>: <what it says and how it bears on this proposal>
+
+**Doctrine assessment:** <the check_decision assessment string plus your reading of it>
+```
+
+Sequencing: the rendered proposal is the final text of the turn, the turn ends with it, and approval is the user's next input. Never combine the proposal with an approval prompt (such as AskUserQuestion) in the same turn: text emitted before a tool call may never render, so the user would approve a draft they cannot see. An approval prompt may carry the choice only in a later turn, once the full proposal is already on screen. A subagent invocation returns this template block to the parent for verbatim surfacing; the parent pastes it exactly as returned.
 
 ## How to run — three modes
 

--- a/packages/nauro/src/nauro/skills/ship_task_body.md
+++ b/packages/nauro/src/nauro/skills/ship_task_body.md
@@ -29,13 +29,13 @@ Before invoking `@nauro-planner`, the parent session confirms the planner will r
 
 Invoke the `@nauro-planner` subagent with the task description. The planner runs `check_decision` against the proposed approach, classifies as GREEN / AMBER / RED, reads related decision bodies via `get_decision`, investigates the code, and returns a plan in the plan shape (Why / Approach / What changes / What's deferred / Test plan), plus the verdict line and any complete decision draft awaiting approval.
 
-If the planner returns RED with a supersede draft, the chain pauses here. Surface the complete draft to the user. Only on explicit user approval does the parent re-invoke the planner with that approval to file the exact draft. An explicit "override RED on the cited decision, proceed" may continue without filing, but it is not approval to call `propose_decision`.
+If the planner returns RED with a supersede draft, the chain pauses here. Surface the complete draft to the user: paste the planner's complete rendered proposal exactly as returned, no reserialization to JSON, no abbreviation, no pointer to output above, immediately before the approval ask. Only on explicit user approval does the parent re-invoke the planner with that approval to file the exact draft. An explicit "override RED on the cited decision, proceed" may continue without filing, but it is not approval to call `propose_decision`.
 
 ### 2. GATE — plan approval (always when `propose_decision` is in play)
 
 The Nauro chain gates the plan whenever the planner indicates it will file a decision via `propose_decision` for any architectural choice, or whenever the plan records an `add`, `update`, or `supersede` draft. There is no "low-stakes auto-proceed" path when doctrine writes are pending. The user's judgment is the gate on what enters the decision log.
 
-This gate covers all three operations: `add`, `update`, and `supersede`. Surface the complete proposal draft, including its operation and affected decision when applicable. After explicit approval of that exact draft, re-invoke the planner with that approval so it can file. Rejecting or modifying the draft returns it to the planner; any changed draft requires fresh approval. The parent never files a subagent's draft itself.
+This gate covers all three operations: `add`, `update`, and `supersede`. Surface the complete proposal draft, including its operation and affected decision when applicable: paste the planner's complete rendered proposal exactly as returned, no reserialization to JSON, no abbreviation, no pointer to output above, immediately before the approval ask. After explicit approval of that exact draft, re-invoke the planner with that approval so it can file. Rejecting or modifying the draft returns it to the planner; any changed draft requires fresh approval. The parent never files a subagent's draft itself.
 
 A change additionally always gates if any of the following apply:
 
@@ -67,7 +67,7 @@ If the reviewer returns BLOCK, hand the hard-rule failures back to the `@nauro-e
 
 When the reviewer returns APPROVE or APPROVE WITH NITS, invoke `@nauro-tech-lead` in Mode C on the same local diff. The invocation explicitly carries the chain context the parent already holds: the task description, the planner's verdict and any decision filed at plan time (or deliberately not filed), and the reviewer's verdict with its nits. The tech-lead does not re-infer chain state from the diff alone. It reads decisions, scans the diff for architectural choices, and returns GREEN / AMBER / RED with any complete `add`, `update`, or `supersede` draft awaiting user approval.
 
-Any decision draft pauses the chain before step 7. Surface the complete draft to the user. After explicit approval of that exact draft, re-invoke the tech-lead with that approval so it can file. Rejecting or modifying the draft returns it to the tech-lead; any changed draft requires fresh approval. The parent never files a subagent's draft itself.
+Any decision draft pauses the chain before step 7. Surface the complete draft to the user: paste the tech-lead's complete rendered proposal exactly as returned, no reserialization to JSON, no abbreviation, no pointer to output above, immediately before the approval ask. After explicit approval of that exact draft, re-invoke the tech-lead with that approval so it can file. Rejecting or modifying the draft returns it to the tech-lead; any changed draft requires fresh approval. The parent never files a subagent's draft itself.
 
 - **GREEN** — proceed to the push gate (step 7).
 - **AMBER** — surface the constraints to the user alongside the push gate; user decides whether to address before push or document as a follow-up.

--- a/packages/nauro/tests/test_agents_drift.py
+++ b/packages/nauro/tests/test_agents_drift.py
@@ -78,6 +78,11 @@ def test_render_agent_claude_code_returns_body(name: str) -> None:
 # that no longer exists.
 RETIRED_AGENT_PHRASES: tuple[tuple[str, str], ...] = (
     ("confirm_decision", "confirm_decision was removed; propose_decision is a single-call commit"),
+    (
+        "present that draft through the surface's user-question tool",
+        "the one-step draft-plus-prompt channel was retired; the proposal renders as "
+        "final turn text first, and the approval prompt follows in a later turn",
+    ),
 )
 
 
@@ -288,6 +293,84 @@ def test_tech_lead_gates_every_decision_operation_on_explicit_user_approval() ->
     assert "For each real architectural decision identified in step 3" in body
     assert "If the transcript has no `check_decision` precedent" in body
     assert "For an existing or retroactive check, call `get_decision`" in body
+
+
+# The proposal template and its end-turn sequencing rule ship byte-identically
+# in the two filing agents (planner and tech-lead). The block starts at the
+# section heading and ends with the verbatim-surfacing sentence; extracting it
+# from the planner body and asserting it verbatim in every rendered body
+# enforces byte-parity without a third maintained copy.
+PROPOSAL_TEMPLATE_START = "## Decision proposal template"
+PROPOSAL_TEMPLATE_END = "the parent pastes it exactly as returned.\n"
+
+PROPOSAL_TEMPLATE_ANCHORS: tuple[str, ...] = (
+    "## Decision proposal (awaiting approval)",
+    "**Operation:** add | update | supersede",
+    "**Affected decision:**",
+    "**Title:**",
+    "**Rationale (as it will be filed):**",
+    "**Confidence:** high | medium | low",
+    "**Reversibility:** easy | moderate | hard",
+    "**Files affected:**",
+    "**Rejected alternatives:**",
+    "**Related decisions (from check_decision):**",
+    "**Doctrine assessment:**",
+)
+
+PROPOSAL_SEQUENCING_PHRASES: tuple[str, ...] = (
+    "final text of the turn",
+    "the turn ends with it",
+    "approval is the user's next input",
+    "in the same turn",
+    "may never render",
+    "only in a later turn",
+    "already on screen",
+    "verbatim surfacing",
+)
+
+FILING_AGENTS = ("nauro-planner", "nauro-tech-lead")
+
+
+def _rendered_agent_bodies(name: str) -> dict[str, str]:
+    return {
+        "claude_code": render_agent("claude_code", name),
+        "codex": tomllib.loads(render_agent("codex", name))["developer_instructions"],
+    }
+
+
+def _proposal_template_block() -> str:
+    body = load_agent_body("nauro-planner")
+    start = body.index(PROPOSAL_TEMPLATE_START)
+    end = body.index(PROPOSAL_TEMPLATE_END) + len(PROPOSAL_TEMPLATE_END)
+    return body[start:end]
+
+
+@pytest.mark.parametrize("name", FILING_AGENTS)
+@pytest.mark.parametrize("surface", ["claude_code", "codex"])
+def test_filing_agent_carries_proposal_template_and_sequencing(name: str, surface: str) -> None:
+    body = _rendered_agent_bodies(name)[surface]
+    for anchor in PROPOSAL_TEMPLATE_ANCHORS:
+        assert anchor in body, f"missing template anchor {anchor!r} in {name} ({surface})"
+    for phrase in PROPOSAL_SEQUENCING_PHRASES:
+        assert phrase in body, f"missing sequencing phrase {phrase!r} in {name} ({surface})"
+
+
+@pytest.mark.parametrize("name", FILING_AGENTS)
+@pytest.mark.parametrize("surface", ["claude_code", "codex"])
+def test_proposal_template_block_is_byte_identical(name: str, surface: str) -> None:
+    block = _proposal_template_block()
+    assert block.startswith(PROPOSAL_TEMPLATE_START)
+    body = _rendered_agent_bodies(name)[surface]
+    assert block in body, (
+        f"{name} ({surface}) has drifted from the planner's proposal template "
+        "block; the template must stay byte-identical in both filing agents"
+    )
+
+
+def test_planner_steps_reference_the_proposal_template() -> None:
+    body = load_agent_body("nauro-planner")
+    assert body.count("Render it in the proposal template below") == 1
+    assert body.count("Return the draft rendered in the proposal template below") == 1
 
 
 def test_tech_lead_mode_c_preserves_surface_first_merge_posture() -> None:

--- a/packages/nauro/tests/test_skills_drift.py
+++ b/packages/nauro/tests/test_skills_drift.py
@@ -320,6 +320,22 @@ def test_ship_task_routes_all_decision_drafts_through_parent_approval():
     assert "The parent never files a subagent's draft itself." in body
 
 
+@pytest.mark.parametrize("surface", ["claude_code", "codex"])
+def test_ship_task_surfaces_decision_drafts_verbatim(surface: str):
+    """Each of the three decision gates (step 1 RED pause, step 2 plan gate,
+    step 6 doctrine pass) mandates a verbatim paste of the originating
+    agent's rendered proposal, mirroring the step 7 verbatim-PR-body rule."""
+    verbatim_rule = (
+        "complete rendered proposal exactly as returned, no reserialization "
+        "to JSON, no abbreviation, no pointer to output above, immediately "
+        "before the approval ask"
+    )
+    body = load_ship_task_body(surface)
+    assert body.count(verbatim_rule) == 3
+    assert body.count("paste the planner's " + verbatim_rule) == 2
+    assert body.count("paste the tech-lead's " + verbatim_rule) == 1
+
+
 # --- render_skill produces frontmatter + body ---
 
 


### PR DESCRIPTION
## Why

At the decision-approval gate the human could end up approving a draft they never saw: when a proposal and an approval prompt (such as AskUserQuestion) share one turn, text emitted before the tool call may never render, and drafts returned by subagents could scroll away or reach the gate reserialized or abbreviated. A gate the human cannot read is not a gate.

## What changed

- The shared approval wording in nauro-core now carries the visibility kernel: present the draft as readable Markdown, end the turn with the draft, and collect explicit approval from the user's next reply. A new private fragment with the detail rules (never couple the draft with an approval prompt in the same turn; structured arguments stay internal; raw JSON only on an explicit debugging request) is spliced into the `propose_decision` tool description, following the existing relocation idiom. Any MCP-connected agent inherits both by transport.
- The planner and tech-lead agents ship one byte-identical Markdown proposal template (operation, affected decision, title, full rationale, confidence, type, reversibility, files affected, rejected alternatives, related decisions, doctrine assessment) plus the end-turn sequencing rule. The tech-lead's standalone approval channel is now two-step: full proposal as the final text of its turn first, then the approval prompt in a later turn once the proposal is on screen.
- The ship-task chain pastes the originating agent's rendered proposal verbatim (no reserialization to JSON, no abbreviation, no pointer to output above) at its three decision gates, mirroring the existing verbatim PR-body rule at the push gate. Dogfood renders regenerated for all three surfaces.
- Drift tests pin the new fragment onto the tool surface, the template's byte-parity across both filing agents on both rendered surfaces, the verbatim-paste rule at all three gates, and the retired one-step channel wording.

## Test plan

Full nauro-core and nauro suites pass (3131 passed, 10 skipped); ruff check and format are clean. The MCP static instructions block measures 1695 chars, under its existing 1700 ceiling, and the truncation-survival tiers hold.
