### PR TITLE
Show resolves_questions in the decision proposal template

### DIFF
--- a/packages/nauro/src/nauro/agents/nauro-planner.md
+++ b/packages/nauro/src/nauro/agents/nauro-planner.md
@@ -76,6 +76,9 @@ Render every decision draft for approval in exactly this shape, as plain Markdow
 **Rejected alternatives:**
 - <alternative>: <why it was rejected>
 
+**Resolves questions (only when the call will carry resolves_questions; omit when empty):**
+- <question id>: <one-line gloss of the question it closes>
+
 **Related decisions (from check_decision):**
 - <decision>: <what it says and how it bears on this proposal>
 

--- a/packages/nauro/src/nauro/agents/nauro-tech-lead.md
+++ b/packages/nauro/src/nauro/agents/nauro-tech-lead.md
@@ -32,6 +32,9 @@ Render every decision draft for approval in exactly this shape, as plain Markdow
 **Rejected alternatives:**
 - <alternative>: <why it was rejected>
 
+**Resolves questions (only when the call will carry resolves_questions; omit when empty):**
+- <question id>: <one-line gloss of the question it closes>
+
 **Related decisions (from check_decision):**
 - <decision>: <what it says and how it bears on this proposal>
 

--- a/packages/nauro/tests/test_agents_drift.py
+++ b/packages/nauro/tests/test_agents_drift.py
@@ -313,6 +313,7 @@ PROPOSAL_TEMPLATE_ANCHORS: tuple[str, ...] = (
     "**Reversibility:** easy | moderate | hard",
     "**Files affected:**",
     "**Rejected alternatives:**",
+    "**Resolves questions (only when the call will carry resolves_questions; omit when empty):**",
     "**Related decisions (from check_decision):**",
     "**Doctrine assessment:**",
 )


### PR DESCRIPTION
## Why

A propose_decision call can close open questions at filing time via the resolves_questions argument, but the approval-gate template had no row for it, so the user could approve a draft without seeing which questions it closes. This completes the readable-gate contract from #375.

## What changed

The proposal template gains a resolves-questions row between rejected alternatives and related decisions: each question id with a one-line gloss of the question it closes, omitted when the argument is empty. The row lands byte-identically in the planner and tech-lead bodies, and a new drift-test anchor pins it on both rendered surfaces.

## Test plan

Full nauro + nauro-core suites (3131 passed, 10 skipped) plus ruff check/format, all green.
