### PR TITLE
Release nauro 1.7.0 and nauro-core 1.3.0

### DIFF
--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro-core"
-version = "1.2.0"
+version = "1.3.0"
 description = "Shared pure-Python logic for Nauro: parsing, validation, context assembly, constants."
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro"
-version = "1.6.0"
+version = "1.7.0"
 description = "Human-approved project judgment and current state for connected AI agents, surfaced before work."
 readme = "README.md"
 license = "Apache-2.0"
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "nauro-core>=1.2.0,<2",
+    "nauro-core>=1.3.0,<2",
     "typer>=0.9",
     "httpx>=0.24",
     "mcp>=1.0",

--- a/server.json
+++ b/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Nauro-AI/nauro",
     "source": "github"
   },
-  "version": "1.6.0",
+  "version": "1.7.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "nauro",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -928,7 +928,7 @@ wheels = [
 
 [[package]]
 name = "nauro"
-version = "1.6.0"
+version = "1.7.0"
 source = { editable = "packages/nauro" }
 dependencies = [
     { name = "filelock" },
@@ -970,7 +970,7 @@ provides-extras = ["dev", "embeddings"]
 
 [[package]]
 name = "nauro-core"
-version = "1.2.0"
+version = "1.3.0"
 source = { editable = "packages/nauro-core" }
 dependencies = [
     { name = "bm25s" },


### PR DESCRIPTION
## Versions

- nauro: 1.6.0 → 1.7.0
- nauro-core: 1.2.0 → 1.3.0 (nauro's floor bumped to `nauro-core>=1.3.0,<2`)

## What ships

**nauro 1.7.0**

- The planner and tech-lead agents present decision proposals as one canonical human-readable Markdown template (operation, affected decision, title, full rationale, confidence, type, reversibility, files affected, rejected alternatives, resolves-questions row, related decisions, doctrine assessment) with end-turn sequencing: the proposal is the final text of the agent's turn and approval comes from the user's next reply.
- The tech-lead's standalone approval channel is two-step: the full proposal first, the approval prompt only once the proposal is on screen.
- The ship-task chain pastes the originating agent's rendered proposal verbatim at all three decision gates, mirroring the existing verbatim PR-body rule at the push gate.

**nauro-core 1.3.0**

- The shared approval wording carries the visibility kernel on every spliced surface: present the draft as readable Markdown, end the turn with the draft, collect explicit approval from the user's next reply.
- The `propose_decision` tool description adds the detail rules: never couple the draft with an approval prompt in the same turn, structured arguments stay internal, raw JSON only on an explicit debugging request.

## Checks

- `scripts/check_server_json_version.py`: server.json locked to 1.7.0.
- `scripts/check_single_sourced.py packages/nauro/src`: clean.
- `uv lock --check`: clean; lock diff is confined to the two package version entries.
- Full nauro and nauro-core suites: 3131 passed, 10 skipped; ruff check and format clean.

## Post-merge

Tag the squash commit `nauro-core-v1.3.0` and `nauro-v1.7.0`; the tags trigger the trusted-publish workflows (PyPI for both, MCP registry for nauro).
