### PR TITLE
Remove the vestigial git-union merge path from sync conflict resolution

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/sync.py
+++ b/packages/nauro/src/nauro/cli/commands/sync.py
@@ -1,6 +1,5 @@
 """nauro sync — Capture a snapshot and regenerate AGENTS.md in associated repos."""
 
-import logging
 from pathlib import Path
 
 import typer
@@ -14,8 +13,6 @@ from nauro.store.snapshot import capture_snapshot
 from nauro.store.validator import print_warnings, validate_store
 from nauro.sync.push import push_store_to_cloud
 from nauro.templates.agents_md_regen import warn_then_regen
-
-logger = logging.getLogger("nauro.sync")
 
 # Names retained for callers/tests that import the push helper from this
 # command module; the implementation now lives in ``nauro.sync.push``.
@@ -113,9 +110,7 @@ def _pull_from_cloud(project_id: str, store_path: Path) -> int:
 class _EchoReporter:
     """Pull reporter for ``nauro sync``.
 
-    Echoes progress to the terminal (warnings on stderr) and re-raises on a
-    union-merge failure so an explicit sync fails loud rather than reporting a
-    partial success.
+    Echoes progress to the terminal (warnings on stderr).
     """
 
     def info(self, msg: str) -> None:
@@ -124,20 +119,11 @@ class _EchoReporter:
     def warn(self, msg: str) -> None:
         typer.echo(f"  {msg}", err=True)
 
-    def on_merge_failure(self, relative_path: str, exc: Exception) -> bool:
-        logger.exception("Union merge failed for %s", relative_path)
-        typer.echo(
-            f"  Error: merge failed for {relative_path} ({exc}) - left unchanged",
-            err=True,
-        )
-        return True
-
 
 def _pull_via_presign(project_id: str, store_path: Path) -> int:
     """GET /sync/manifest → POST /sync/presign → S3 GETs.
 
-    Delegates to the shared pull core with an echo reporter; a union-merge
-    failure propagates so ``nauro sync`` exits nonzero.
+    Delegates to the shared pull core with an echo reporter.
     """
     from nauro.sync.pull import run_pull
 

--- a/packages/nauro/src/nauro/sync/hooks.py
+++ b/packages/nauro/src/nauro/sync/hooks.py
@@ -16,9 +16,9 @@ silent-no-op when either is missing. The two no-op cases are:
 
 The pull and push transport lives in ``nauro.sync.pull`` and
 ``nauro.sync.push`` and is shared with the ``nauro sync`` CLI command.
-These hooks supply a logging :class:`~nauro.sync.pull.Reporter` that
-never re-raises, so the shared core stays silent and crash-free here
-while the CLI surfaces failures.
+These hooks supply a logging :class:`~nauro.sync.pull.Reporter`, so the
+shared core stays silent and crash-free here while the CLI echoes
+progress to the terminal.
 
 Token refresh on 401 is handled inside ``request_presigned_urls`` and
 ``fetch_manifest`` via ``with_token_refresh``. ``AuthRefreshError``
@@ -37,9 +37,8 @@ logger = logging.getLogger("nauro.sync")
 class _LoggingReporter:
     """Pull reporter for the SessionStart hook.
 
-    Routes progress to ``logger`` at the appropriate level and swallows
-    union-merge failures (returns False) so auto-pull never crashes a
-    session start.
+    Routes progress to ``logger`` at the appropriate level so auto-pull
+    never writes to the session's terminal.
     """
 
     def info(self, msg: str) -> None:
@@ -47,10 +46,6 @@ class _LoggingReporter:
 
     def warn(self, msg: str) -> None:
         logger.warning("sync pull: %s", msg)
-
-    def on_merge_failure(self, relative_path: str, exc: Exception) -> bool:
-        logger.exception("sync pull: union merge failed for %s", relative_path)
-        return False
 
 
 def pull_before_session(project_id: str, store_path: Path) -> int:
@@ -74,8 +69,7 @@ def pull_before_session(project_id: str, store_path: Path) -> int:
     try:
         return run_pull(project_id, store_path, _LoggingReporter())
     except Exception:
-        # The logging reporter never re-raises union-merge failures, but a
-        # genuinely unexpected error must not escape session startup either.
+        # A genuinely unexpected error must not escape session startup.
         logger.exception("sync pull: unexpected failure for %s", project_id)
         return 0
 

--- a/packages/nauro/src/nauro/sync/merge.py
+++ b/packages/nauro/src/nauro/sync/merge.py
@@ -5,9 +5,6 @@ how to merge or which version wins.
 """
 
 import logging
-import shutil
-import subprocess
-import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -17,19 +14,11 @@ from nauro.sync.state import SyncState
 
 logger = logging.getLogger("nauro.sync")
 
-
-class UnionMergeError(Exception):
-    """Raised when ``git merge-file --union`` exits with a nonzero status.
-
-    Signals that the merged content cannot be trusted. Callers decide
-    whether to surface the failure or skip the file untouched.
-    """
-
-
-# Append-only logs where a set-union merge is safe. Decisions are not
-# append-only. An interleaving union merge would corrupt them, so decision
-# conflicts resolve by last-write-wins with a recoverable backup instead.
-APPEND_ONLY_PATTERNS = ("open-questions.md", "state_history.md")
+# Append-only logs where a set-union merge is safe. Everything else,
+# including decision files (mutable single records rewritten in place by
+# update/supersede), resolves by last-write-wins with a recoverable backup,
+# because no automatic merge of two divergent rewrites is correct.
+_SET_UNION_PATHS = ("open-questions.md", "state_history.md")
 
 # Files that are never synced. The graph command's default output lands in the
 # store directory; its generation timestamp changes every run, so its sha never
@@ -70,16 +59,6 @@ def detect_conflict(
     return local_changed and remote_changed
 
 
-def _is_append_only(relative_path: str) -> bool:
-    """Check if a file uses append-only merge strategy."""
-    return any(relative_path.startswith(p) or relative_path == p for p in APPEND_ONLY_PATTERNS)
-
-
-def _git_available() -> bool:
-    """Check if git is available on PATH."""
-    return shutil.which("git") is not None
-
-
 def _save_conflict_backup(project_path: Path, relative_path: str, content: bytes) -> Path:
     """Save the losing version to .conflict-backup/."""
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
@@ -92,31 +71,21 @@ def _save_conflict_backup(project_path: Path, relative_path: str, content: bytes
     return backup_path
 
 
-_SET_UNION_PATHS = ("open-questions.md", "state_history.md")
-
-
 def resolve_conflict(
     project_path: Path,
     local_path: Path,
     remote_content: bytes,
     relative_path: str,
-    state: SyncState,
 ) -> bytes:
     """Resolve a conflict between local and remote versions.
 
-    For append-only files: git merge-file --union (falls back to LWW if git unavailable).
-    For everything else: last-write-wins with backup of the losing version.
+    Files in ``_SET_UNION_PATHS`` merge by section-aware set-union.
+    Everything else: last-write-wins with backup of the losing version.
     """
     local_content = local_path.read_bytes()
 
     if relative_path in _SET_UNION_PATHS:
         return _set_union_markdown(local_content, remote_content)
-
-    if _is_append_only(relative_path) and _git_available():
-        return _union_merge(local_content, remote_content, relative_path, state)
-
-    if _is_append_only(relative_path) and not _git_available():
-        logger.warning("git not available - falling back to last-write-wins for %s", relative_path)
 
     # Last-write-wins: keep local, back up remote
     _save_conflict_backup(project_path, relative_path, remote_content)
@@ -126,47 +95,6 @@ def resolve_conflict(
         relative_path,
     )
     return local_content
-
-
-def _union_merge(
-    local_content: bytes, remote_content: bytes, relative_path: str, state: SyncState
-) -> bytes:
-    """Use git merge-file --union for append-only files.
-
-    The common base is always empty (we do not persist the last-synced
-    content), so ``--union`` degenerates to an append-only union: every
-    line unique to either side is retained, with no conflict markers.
-
-    A nonzero exit from git signals a genuine failure (IO/stat error, or
-    a signal kill) rather than a resolved conflict — union resolution
-    returns 0 in that case. On a nonzero status the merged file cannot be
-    trusted, so this raises ``UnionMergeError`` instead of returning
-    possibly-corrupt content.
-    """
-    with tempfile.TemporaryDirectory() as tmpdir:
-        tmp = Path(tmpdir)
-        local_tmp = tmp / "local"
-        base_tmp = tmp / "base"
-        remote_tmp = tmp / "remote"
-
-        local_tmp.write_bytes(local_content)
-        remote_tmp.write_bytes(remote_content)
-        base_tmp.write_bytes(b"")
-
-        result = subprocess.run(
-            ["git", "merge-file", "--union", str(local_tmp), str(base_tmp), str(remote_tmp)],
-            capture_output=True,
-        )
-
-        if result.returncode != 0:
-            raise UnionMergeError(
-                f"git merge-file --union failed for {relative_path} "
-                f"(exit code {result.returncode}): {result.stderr.decode(errors='replace')}"
-            )
-
-        merged = local_tmp.read_bytes()
-        logger.info("Union merge completed for %s (exit code %d)", relative_path, result.returncode)
-        return merged
 
 
 def _parse_sections(lines: list[str]) -> tuple[list[str], list[tuple[str, list[str]]]]:

--- a/packages/nauro/src/nauro/sync/pull.py
+++ b/packages/nauro/src/nauro/sync/pull.py
@@ -6,11 +6,10 @@ server manifest, diff it against sync-state, mint presigned GET URLs, and
 transfer changed files directly from S3 — then renumber colliding
 decisions and merge conflicting append-only files.
 
-The two callers differ only in how they surface progress and how they
-react to a union-merge failure: the CLI echoes to the terminal and must
-fail loud on a bad merge; the hook logs quietly and must never raise.
-That asymmetry is injected through the :class:`Reporter` protocol rather
-than branched inside the pull core, so the two paths cannot drift again.
+The two callers differ only in how they surface progress: the CLI echoes
+to the terminal; the hook logs quietly and must never raise. That
+asymmetry is injected through the :class:`Reporter` protocol rather than
+branched inside the pull core, so the two paths cannot drift again.
 """
 
 from __future__ import annotations
@@ -23,7 +22,6 @@ from nauro_core import extract_decision_number
 
 from nauro.cli.commands.auth import AuthRefreshError
 from nauro.sync.merge import (
-    UnionMergeError,
     detect_conflict,
     resolve_conflict,
     should_skip,
@@ -45,11 +43,10 @@ from nauro.sync.state import (
 
 
 class Reporter(Protocol):
-    """Surface for pull progress and merge-failure policy.
+    """Surface for pull progress.
 
-    The CLI implementation echoes to the terminal and re-raises on a union
-    merge failure (``nauro sync`` must exit nonzero). The hook implementation
-    logs quietly and swallows the failure (session startup must never crash).
+    The CLI implementation echoes to the terminal; the hook implementation
+    logs quietly (session startup must never crash).
     """
 
     def info(self, msg: str) -> None:
@@ -57,13 +54,6 @@ class Reporter(Protocol):
 
     def warn(self, msg: str) -> None:
         """Report a recoverable anomaly (presign URL shortfall, bad manifest)."""
-
-    def on_merge_failure(self, relative_path: str, exc: Exception) -> bool:
-        """Handle a union-merge failure for ``relative_path``.
-
-        Return True to re-raise (surface the failure to the caller) or False
-        to swallow it and leave the local file untouched.
-        """
 
 
 def _renumber_decision_if_collision(
@@ -166,9 +156,7 @@ def run_pull(
     of files merged.
 
     Caller-facing failures (manifest/presign auth-refresh or transport errors)
-    are reported through ``reporter`` and map to a 0 return. A union-merge
-    failure is routed to ``reporter.on_merge_failure`` — re-raised when it
-    returns True (the CLI), swallowed when it returns False (the hook).
+    are reported through ``reporter`` and map to a 0 return.
     """
     try:
         manifest = fetch_manifest(project_id)
@@ -275,14 +263,7 @@ def run_pull(
             continue
 
         local_file = store_path / rel
-        try:
-            merged_content = resolve_conflict(store_path, local_file, remote_content, rel, state)
-        except UnionMergeError as exc:
-            # Leave the local file untouched rather than overwrite it with
-            # possibly-corrupt bytes. The reporter decides whether to surface.
-            if reporter.on_merge_failure(rel, exc):
-                raise
-            continue
+        merged_content = resolve_conflict(store_path, local_file, remote_content, rel)
         local_file.write_bytes(merged_content)
         local_sha = compute_sha256(local_file)
         update_file_state(state, rel, local_sha, remote_etag)

--- a/packages/nauro/tests/test_sync/test_hooks.py
+++ b/packages/nauro/tests/test_sync/test_hooks.py
@@ -222,57 +222,6 @@ class TestPullBeforeSessionPresign:
 
         assert result == 0
 
-    def test_pull_swallows_union_merge_error_and_leaves_file_untouched(
-        self, cloud_store, monkeypatch
-    ):
-        """SessionStart auto-pull must not crash on a failed union merge.
-
-        The failing file is skipped (left on disk as-is), the rest of the
-        pull continues, and the call returns normally.
-        """
-        from nauro.sync.merge import UnionMergeError
-
-        rel = "decisions/050-conflicted.md"
-        local_file = cloud_store / rel
-        local_file.parent.mkdir(parents=True, exist_ok=True)
-        local_file.write_bytes(b"# 050\nlocal body\n")
-        original = local_file.read_bytes()
-
-        # Diverged from last-synced state on both sides → conflict, not pull.
-        state = SyncState()
-        state.files[rel] = FileState(
-            local_sha256="old_sha",
-            remote_etag='"old_etag"',
-            last_sync="2026-05-16T00:00:00Z",
-        )
-        save_state(cloud_store, state)
-
-        manifest = self._manifest(
-            [{"path": rel, "etag": '"new_etag"', "size": 1, "last_modified": "x"}],
-        )
-        presign = self._presign([{"verb": "GET", "path": rel}])
-
-        def fake_get(url, **kwargs):
-            if "/sync/manifest" in url:
-                return manifest
-            return httpx.Response(200, content=b"# 050\nremote body\n")
-
-        def boom(*args, **kwargs):
-            raise UnionMergeError("simulated git failure")
-
-        monkeypatch.setattr("nauro.sync.pull.resolve_conflict", boom)
-
-        with (
-            patch("nauro.sync.remote.httpx.get", side_effect=fake_get),
-            patch("nauro.sync.remote.httpx.post", return_value=presign),
-        ):
-            # Must not raise.
-            result = pull_before_session(CLOUD_PID, cloud_store)
-
-        assert result == 0
-        # The local file was left untouched rather than overwritten.
-        assert local_file.read_bytes() == original
-
 
 # --- push happy path ---
 

--- a/packages/nauro/tests/test_sync/test_merge.py
+++ b/packages/nauro/tests/test_sync/test_merge.py
@@ -1,16 +1,9 @@
 """Tests for nauro.sync.merge."""
 
-import shutil
-import subprocess
-
-import pytest
 from nauro_core.decision_model import parse_decision
 
 from nauro.sync.merge import (
-    UnionMergeError,
-    _is_append_only,
     _set_union_markdown,
-    _union_merge,
     detect_conflict,
     resolve_conflict,
     should_skip,
@@ -56,26 +49,6 @@ class TestShouldSkip:
         assert should_skip("uv.lock") is False
 
 
-class TestIsAppendOnly:
-    def test_decision_file(self):
-        assert _is_append_only("decisions/001-foo.md") is False
-
-    def test_open_questions(self):
-        assert _is_append_only("open-questions.md") is True
-
-    def test_project_md(self):
-        assert _is_append_only("project.md") is False
-
-    def test_state_md(self):
-        assert _is_append_only("state.md") is False
-
-    def test_state_current_md(self):
-        assert _is_append_only("state_current.md") is False
-
-    def test_state_history_md(self):
-        assert _is_append_only("state_history.md") is True
-
-
 class TestDetectConflict:
     def test_no_previous_state(self):
         state = SyncState()
@@ -106,8 +79,7 @@ class TestResolveConflict:
         local_file.write_text("local state content")
         remote_content = b"remote state content"
 
-        state = SyncState()
-        result = resolve_conflict(project_path, local_file, remote_content, "state.md", state)
+        result = resolve_conflict(project_path, local_file, remote_content, "state.md")
 
         assert result == b"local state content"
         backup_dir = project_path / ".conflict-backup"
@@ -124,8 +96,7 @@ class TestResolveConflict:
         local_file.write_text("local project content")
         remote_content = b"remote project content"
 
-        state = SyncState()
-        result = resolve_conflict(project_path, local_file, remote_content, "project.md", state)
+        result = resolve_conflict(project_path, local_file, remote_content, "project.md")
 
         assert result == b"local project content"
         backup_dir = project_path / ".conflict-backup"
@@ -140,10 +111,7 @@ class TestResolveConflict:
         local_file.write_text('{"local": true}')
         remote_content = b'{"remote": true}'
 
-        state = SyncState()
-        result = resolve_conflict(
-            project_path, local_file, remote_content, "snapshots/v001.json", state
-        )
+        result = resolve_conflict(project_path, local_file, remote_content, "snapshots/v001.json")
 
         assert result == b'{"local": true}'
 
@@ -161,10 +129,7 @@ class TestResolveConflict:
         local_file.write_text("# Decision 001\nLocal addition\n")
         remote_content = b"# Decision 001\nRemote addition\n"
 
-        state = SyncState()
-        result = resolve_conflict(
-            project_path, local_file, remote_content, "decisions/001-foo.md", state
-        )
+        result = resolve_conflict(project_path, local_file, remote_content, "decisions/001-foo.md")
 
         # Local copy is kept whole, never interleaved with remote.
         assert result == b"# Decision 001\nLocal addition\n"
@@ -221,9 +186,8 @@ class TestResolveConflict:
         local_file.write_text(local_text)
         remote_content = remote_text.encode("utf-8")
 
-        state = SyncState()
         result = resolve_conflict(
-            project_path, local_file, remote_content, "decisions/042-cache-layer.md", state
+            project_path, local_file, remote_content, "decisions/042-cache-layer.md"
         )
 
         # The survivor is the local rewrite, whole and parseable as ONE decision.
@@ -238,87 +202,20 @@ class TestResolveConflict:
         assert len(backups) == 1
         assert backups[0].read_bytes() == remote_content
 
-    @pytest.mark.skipif(not shutil.which("git"), reason="git not available")
-    def test_union_merge_for_open_questions(self, tmp_path):
-        """open-questions.md uses git merge-file --union."""
+    def test_set_union_for_open_questions(self, tmp_path):
+        """open-questions.md merges by set-union: lines unique to each side survive."""
         project_path = tmp_path / "project"
         project_path.mkdir()
         local_file = project_path / "open-questions.md"
         local_file.write_text("- Question 1\n- Local question\n")
         remote_content = b"- Question 1\n- Remote question\n"
 
-        state = SyncState()
-        result = resolve_conflict(
-            project_path, local_file, remote_content, "open-questions.md", state
-        )
+        result = resolve_conflict(project_path, local_file, remote_content, "open-questions.md")
 
         result_str = result.decode()
-        assert "Question 1" in result_str
-
-
-class TestUnionMergeFailLoud:
-    """``_union_merge`` raises on a genuine git failure, not on benign stderr."""
-
-    def test_nonzero_exit_raises(self, monkeypatch):
-        """A nonzero git exit (command-not-found territory) raises UnionMergeError."""
-
-        def fake_run(*args, **kwargs):
-            return subprocess.CompletedProcess(args=args[0], returncode=127, stdout=b"", stderr=b"")
-
-        monkeypatch.setattr("nauro.sync.merge.subprocess.run", fake_run)
-
-        with pytest.raises(UnionMergeError):
-            _union_merge(b"local\n", b"remote\n", "decisions/001-foo.md", SyncState())
-
-    def test_io_error_exit_raises_with_stderr(self, monkeypatch):
-        """A 255 IO/stat error raises, and the decoded stderr is in the message."""
-
-        def fake_run(*args, **kwargs):
-            return subprocess.CompletedProcess(
-                args=args[0], returncode=255, stdout=b"", stderr=b"error: cannot stat 'local'"
-            )
-
-        monkeypatch.setattr("nauro.sync.merge.subprocess.run", fake_run)
-
-        with pytest.raises(UnionMergeError) as excinfo:
-            _union_merge(b"local\n", b"remote\n", "decisions/001-foo.md", SyncState())
-
-        message = str(excinfo.value)
-        assert "255" in message
-        assert "error: cannot stat 'local'" in message
-
-    def test_rc_zero_with_stderr_does_not_raise(self, monkeypatch):
-        """git emits benign ``warning:`` lines with rc=0 — those must not raise.
-
-        The predicate is returncode-only; the merged bytes are still returned.
-        """
-
-        def fake_run(*args, **kwargs):
-            # args[0] is the git argv: [..., local_tmp, base_tmp, remote_tmp].
-            # The function reads back the local temp file, so leave it untouched.
-            return subprocess.CompletedProcess(
-                args=args[0], returncode=0, stdout=b"", stderr=b"warning: something benign"
-            )
-
-        monkeypatch.setattr("nauro.sync.merge.subprocess.run", fake_run)
-
-        result = _union_merge(
-            b"local body\n", b"remote body\n", "decisions/001-foo.md", SyncState()
-        )
-        # No raise; the local temp content is returned untouched.
-        assert result == b"local body\n"
-
-    @pytest.mark.skipif(not shutil.which("git"), reason="git not available")
-    def test_benign_union_merges_unique_lines(self):
-        """Real git merge-file --union retains lines unique to each side."""
-        local = b"# Decision 001\n- local-only line\n"
-        remote = b"# Decision 001\n- remote-only line\n"
-
-        result = _union_merge(local, remote, "decisions/001-foo.md", SyncState())
-        result_str = result.decode()
-
-        assert "- local-only line" in result_str
-        assert "- remote-only line" in result_str
+        assert result_str.count("Question 1") == 1
+        assert "- Local question" in result_str
+        assert "- Remote question" in result_str
 
 
 class TestSetUnionMarkdown:
@@ -462,8 +359,7 @@ class TestSetUnionMarkdown:
 
         monkeypatch.setattr("nauro.sync.merge._set_union_markdown", spy)
 
-        state = SyncState()
-        resolve_conflict(project_path, local_file, remote_content, "decisions/001-foo.md", state)
+        resolve_conflict(project_path, local_file, remote_content, "decisions/001-foo.md")
 
         assert calls == []
         # Last-write-wins backs the remote loser up rather than interleaving it.
@@ -487,10 +383,7 @@ class TestSetUnionMarkdown:
 
         monkeypatch.setattr("nauro.sync.merge._set_union_markdown", spy)
 
-        state = SyncState()
-        result = resolve_conflict(
-            project_path, local_file, remote_content, "open-questions.md", state
-        )
+        result = resolve_conflict(project_path, local_file, remote_content, "open-questions.md")
 
         assert result == b"merged"
         assert len(calls) == 1
@@ -513,10 +406,7 @@ class TestSetUnionMarkdown:
 
         monkeypatch.setattr("nauro.sync.merge._set_union_markdown", spy)
 
-        state = SyncState()
-        result = resolve_conflict(
-            project_path, local_file, remote_content, "state_history.md", state
-        )
+        result = resolve_conflict(project_path, local_file, remote_content, "state_history.md")
 
         assert result == b"merged"
         assert len(calls) == 1

--- a/packages/nauro/tests/test_sync/test_pull.py
+++ b/packages/nauro/tests/test_sync/test_pull.py
@@ -2,11 +2,10 @@
 
 ``run_pull`` is the single pull-and-merge implementation behind both
 ``nauro sync`` and the SessionStart hook. The two callers differ only in
-their :class:`~nauro.sync.pull.Reporter`: the CLI echoes and re-raises on
-a union-merge failure, the hook logs and swallows. These tests drive the
-core directly with both reporter flavors plus a recording stub, and pin
-the renumber-on-collision helper byte-for-byte against the canonical
-cases the hook previously owned.
+their :class:`~nauro.sync.pull.Reporter`: the CLI echoes to the terminal,
+the hook logs quietly. These tests drive the core directly with a
+recording stub, and pin the renumber-on-collision helper byte-for-byte
+against the canonical cases the hook previously owned.
 """
 
 from __future__ import annotations
@@ -18,7 +17,6 @@ import httpx
 import pytest
 
 from nauro.store.registry import register_project
-from nauro.sync.merge import UnionMergeError
 from nauro.sync.pull import _renumber_decision_if_collision, run_pull
 from nauro.sync.state import (
     FileState,
@@ -66,13 +64,11 @@ def _presign(ops) -> httpx.Response:
 
 
 class _RecordingReporter:
-    """Records messages; ``on_merge_failure`` returns the configured policy."""
+    """Records reported messages."""
 
-    def __init__(self, *, reraise: bool) -> None:
-        self.reraise = reraise
+    def __init__(self) -> None:
         self.infos: list[str] = []
         self.warns: list[str] = []
-        self.merge_failures: list[tuple[str, Exception]] = []
 
     def info(self, msg: str) -> None:
         self.infos.append(msg)
@@ -80,12 +76,8 @@ class _RecordingReporter:
     def warn(self, msg: str) -> None:
         self.warns.append(msg)
 
-    def on_merge_failure(self, relative_path: str, exc: Exception) -> bool:
-        self.merge_failures.append((relative_path, exc))
-        return self.reraise
 
-
-# --- run_pull happy path (both reporter policies behave identically here) ---
+# --- run_pull happy path ---
 
 
 class TestRunPullCleanPull:
@@ -95,8 +87,7 @@ class TestRunPullCleanPull:
         _seed_token()
         return store
 
-    @pytest.mark.parametrize("reraise", [True, False])
-    def test_clean_pull_writes_file_and_updates_state(self, cloud_store, reraise):
+    def test_clean_pull_writes_file_and_updates_state(self, cloud_store):
         rel = "decisions/099-remote.md"
         manifest = _manifest([{"path": rel, "etag": '"new"', "size": 1, "last_modified": "x"}])
         presign = _presign([{"verb": "GET", "path": rel}])
@@ -106,7 +97,7 @@ class TestRunPullCleanPull:
                 return manifest
             return httpx.Response(200, content=b"# 099\nfresh remote body\n")
 
-        reporter = _RecordingReporter(reraise=reraise)
+        reporter = _RecordingReporter()
         with (
             patch("nauro.sync.remote.httpx.get", side_effect=fake_get),
             patch("nauro.sync.remote.httpx.post", return_value=presign),
@@ -120,8 +111,7 @@ class TestRunPullCleanPull:
         assert reporter.infos == ["Merged 1 file(s) from remote"]
         assert reporter.warns == []
 
-    @pytest.mark.parametrize("reraise", [True, False])
-    def test_append_only_conflict_invokes_resolve_and_writes_merge(self, cloud_store, reraise):
+    def test_append_only_conflict_invokes_resolve_and_writes_merge(self, cloud_store):
         # state_history.md is append-only with section-aware set-union merge.
         rel = "state_history.md"
         local = cloud_store / rel
@@ -144,7 +134,7 @@ class TestRunPullCleanPull:
                 return manifest
             return httpx.Response(200, content=b"## History\n\nremote entry\n")
 
-        reporter = _RecordingReporter(reraise=reraise)
+        reporter = _RecordingReporter()
         with (
             patch("nauro.sync.remote.httpx.get", side_effect=fake_get),
             patch("nauro.sync.remote.httpx.post", return_value=presign),
@@ -157,7 +147,7 @@ class TestRunPullCleanPull:
         assert b"local entry" in merged_bytes
         assert b"remote entry" in merged_bytes
         assert compute_sha256(local) != local_sha
-        assert reporter.merge_failures == []
+        assert reporter.warns == []
 
 
 # --- the bug-fix pin: decision-number collision renumbers, never overwrites ---
@@ -212,86 +202,6 @@ class TestRunPullDecisionCollision:
         state = load_state(cloud_store)
         assert "decisions/004-remote-decision.md" in state.files
         assert rel not in state.files
-
-
-# --- union-merge routing: one test per reporter policy ---
-
-
-class TestRunPullUnionMergeRouting:
-    @pytest.fixture()
-    def cloud_store(self, tmp_path):
-        store = _scaffolded_cloud_project("mergecore", tmp_path)
-        _seed_token()
-        return store
-
-    def _setup_conflict(self, cloud_store):
-        rel = "decisions/050-conflicted.md"
-        local_file = cloud_store / rel
-        local_file.parent.mkdir(parents=True, exist_ok=True)
-        local_file.write_bytes(b"# 050\nlocal body\n")
-
-        state = SyncState()
-        state.files[rel] = FileState(
-            local_sha256="old_sha",
-            remote_etag='"old_etag"',
-            last_sync="2026-05-16T00:00:00Z",
-        )
-        save_state(cloud_store, state)
-
-        manifest = _manifest([{"path": rel, "etag": '"new_etag"', "size": 1, "last_modified": "x"}])
-        presign = _presign([{"verb": "GET", "path": rel}])
-
-        def fake_get(url, **kwargs):
-            if "/sync/manifest" in url:
-                return manifest
-            return httpx.Response(200, content=b"# 050\nremote body\n")
-
-        return rel, local_file, fake_get, presign
-
-    def test_echo_reporter_reraises_on_union_merge_failure(self, cloud_store, monkeypatch):
-        """The echo reporter returns True from on_merge_failure → run_pull
-        re-raises so nauro sync fails loud. The local file is left untouched."""
-        from nauro.cli.commands.sync import _EchoReporter
-
-        rel, local_file, fake_get, presign = self._setup_conflict(cloud_store)
-        original = local_file.read_bytes()
-
-        def boom(*args, **kwargs):
-            raise UnionMergeError("simulated git failure")
-
-        monkeypatch.setattr("nauro.sync.pull.resolve_conflict", boom)
-
-        with (
-            patch("nauro.sync.remote.httpx.get", side_effect=fake_get),
-            patch("nauro.sync.remote.httpx.post", return_value=presign),
-            pytest.raises(UnionMergeError),
-        ):
-            run_pull(CLOUD_PID, cloud_store, _EchoReporter())
-
-        assert local_file.read_bytes() == original
-
-    def test_logging_reporter_swallows_union_merge_failure(self, cloud_store, monkeypatch):
-        """The logging reporter returns False → run_pull swallows the failure,
-        returns without raising, and leaves the file byte-identical."""
-        from nauro.sync.hooks import _LoggingReporter
-
-        rel, local_file, fake_get, presign = self._setup_conflict(cloud_store)
-        original = local_file.read_bytes()
-
-        def boom(*args, **kwargs):
-            raise UnionMergeError("simulated git failure")
-
-        monkeypatch.setattr("nauro.sync.pull.resolve_conflict", boom)
-
-        with (
-            patch("nauro.sync.remote.httpx.get", side_effect=fake_get),
-            patch("nauro.sync.remote.httpx.post", return_value=presign),
-        ):
-            merged = run_pull(CLOUD_PID, cloud_store, _LoggingReporter())
-
-        # The failed file was skipped, not counted, and never raised.
-        assert merged == 0
-        assert local_file.read_bytes() == original
 
 
 # --- renumber helper: byte-identical to the canonical pre-port cases ---

--- a/packages/nauro/tests/test_sync/test_sync_command.py
+++ b/packages/nauro/tests/test_sync/test_sync_command.py
@@ -263,8 +263,7 @@ class TestSyncHonesty:
 class TestSyncPullSurfacesAndMerges:
     """End-to-end ``nauro sync`` pull behaviour through the shared core.
 
-    A clean pull echoes a "Merged N file(s)" line; a union-merge failure
-    surfaces and exits nonzero rather than reporting a partial success.
+    A clean pull echoes a "Merged N file(s)" line.
     """
 
     @staticmethod
@@ -334,70 +333,6 @@ class TestSyncPullSurfacesAndMerges:
 
         assert result.exit_code == 0, result.output + (result.stderr or "")
         assert "Merged 1 file(s) from remote" in result.output
-
-    def test_union_merge_failure_exits_one(self, tmp_path, monkeypatch):
-        import httpx
-
-        from nauro.sync.merge import UnionMergeError
-        from nauro.sync.state import FileState, SyncState, save_state
-
-        store, _json = self._seed_cloud_auth("mergefail", tmp_path)
-        rel = "decisions/051-conflicted.md"
-        local_file = store / rel
-        local_file.parent.mkdir(parents=True, exist_ok=True)
-        local_file.write_bytes(b"# 051\nlocal body\n")
-
-        state = SyncState()
-        state.files[rel] = FileState(
-            local_sha256="old_sha",
-            remote_etag='"old_etag"',
-            last_sync="2026-05-16T00:00:00Z",
-        )
-        save_state(store, state)
-
-        def fake_get(url, **kwargs):
-            if "/sync/manifest" in url:
-                return self._http_ok(
-                    {
-                        "files": [
-                            {"path": rel, "etag": '"new_etag"', "size": 1, "last_modified": "x"}
-                        ],
-                        "next_cursor": None,
-                    },
-                    _json,
-                )
-            return httpx.Response(200, content=b"# 051\nremote body\n")
-
-        def fake_post(url, **kwargs):
-            ops = kwargs.get("json", {}).get("operations", [])
-            return self._http_ok(
-                {
-                    "urls": [
-                        {
-                            "verb": op["verb"],
-                            "path": op["path"],
-                            "url": f"https://s3.example/{op['verb']}/{op['path']}",
-                            "expires_at": "2026-05-16T13:00:00Z",
-                        }
-                        for op in ops
-                    ]
-                },
-                _json,
-            )
-
-        def boom(*args, **kwargs):
-            raise UnionMergeError("simulated git failure")
-
-        monkeypatch.setattr("nauro.sync.pull.resolve_conflict", boom)
-
-        with (
-            patch("nauro.sync.remote.httpx.get", side_effect=fake_get),
-            patch("nauro.sync.remote.httpx.post", side_effect=fake_post),
-        ):
-            result = runner.invoke(app, ["sync", "--project", "mergefail"])
-
-        assert result.exit_code == 1
-        assert isinstance(result.exception, UnionMergeError)
 
 
 class TestLinkCloudRefusesWithoutAuth:

--- a/packages/nauro/tests/test_sync/test_sync_presign.py
+++ b/packages/nauro/tests/test_sync/test_sync_presign.py
@@ -313,65 +313,6 @@ class TestPullViaPresign:
         backups = list((cloud_store / ".conflict-backup").iterdir())
         assert any("stack.md" in b.name for b in backups)
 
-    def test_union_merge_failure_surfaces_and_leaves_file_untouched(
-        self, cloud_store, monkeypatch, capsys
-    ):
-        """Explicit ``nauro sync`` must fail loud on a failed merge.
-
-        The echo reporter re-raises the ``UnionMergeError`` so the pull does
-        not report a partial success; the failure is echoed to stderr and the
-        file is left untouched on disk.
-        """
-        from nauro.sync.merge import UnionMergeError
-
-        rel = "decisions/051-conflicted.md"
-        local_file = cloud_store / rel
-        local_file.parent.mkdir(parents=True, exist_ok=True)
-        local_file.write_bytes(b"# 051\nlocal body\n")
-        original = local_file.read_bytes()
-
-        state = SyncState()
-        state.files[rel] = FileState(
-            local_sha256="old_sha",
-            remote_etag='"old_etag"',
-            last_sync="2026-05-16T00:00:00Z",
-        )
-        save_state(cloud_store, state)
-
-        manifest = self._manifest_response(
-            [{"path": rel, "etag": '"new_etag"', "size": 1, "last_modified": "x"}],
-            next_cursor=None,
-        )
-        presign = self._presign_response([{"verb": "GET", "path": rel}])
-
-        def fake_get(url, **kwargs):
-            if "/sync/manifest" in url:
-                return manifest
-            return httpx.Response(200, content=b"# 051\nremote body\n")
-
-        def boom(*args, **kwargs):
-            raise UnionMergeError("simulated git failure")
-
-        monkeypatch.setattr("nauro.sync.pull.resolve_conflict", boom)
-
-        from nauro.sync import remote
-
-        with (
-            patch.object(remote.httpx, "get", side_effect=fake_get),
-            patch.object(remote.httpx, "post", return_value=presign),
-            pytest.raises(UnionMergeError),
-        ):
-            from nauro.cli.commands.sync import _pull_from_cloud
-
-            _pull_from_cloud(cloud_store.name, cloud_store)
-
-        # A clear error line was surfaced to stderr before the re-raise.
-        err = capsys.readouterr().err
-        assert rel in err
-        assert "merge failed" in err
-        # The local file was left untouched.
-        assert local_file.read_bytes() == original
-
     def test_manifest_401_refresh_then_retry_succeeds(self, cloud_store):
         manifest_ok = self._manifest_response(
             [{"path": "decisions/001.md", "etag": '"e1"', "size": 1, "last_modified": "x"}],


### PR DESCRIPTION
## Why

The `git merge-file --union` branch in sync conflict resolution became unreachable once decision-file conflicts moved to last-write-wins: the two remaining append-only files (`open-questions.md`, `state_history.md`) route through the pure-Python section-aware set-union branch, which is checked first. That left ~90 lines of subprocess machinery, a fail-loud error class, and a reporter hook guarding a path no real store file can reach, plus a pair of identical-looking constants that gated two different merge strategies and kept tripping cleanup audits.

## What changed

- `sync/merge.py`: removed `_union_merge`, `UnionMergeError`, `_git_available`, `_is_append_only`, and `APPEND_ONLY_PATTERNS`. Section-aware set-union is the only append-only merge strategy, everything else resolves by last-write-wins with a recoverable backup, and sync no longer shells out to git. `resolve_conflict` drops its unused `state` parameter.
- `sync/pull.py` and the two reporters: the `on_merge_failure` hook is gone from the Reporter protocol and both implementations; the pull core no longer catches an error that can no longer be raised.
- Tests: the union-merge simulation tests and direct unit tests are removed; the existing set-union routing tests pin the surviving behavior, and the git-dependent skipif test became an unconditional set-union test.

## Test plan

Full suite: 2037 passed, 10 skipped. `ruff check` and `ruff format --check` clean.
