### PR TITLE
Retire v1 registry support: the id-keyed v2 registry is the only shape

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,13 +11,13 @@ Each package has its own `pyproject.toml` and test suite; `packages/nauro/` also
 
 ## The one architectural fact that matters
 
-The project store lives at `~/.nauro/projects/<project-name>/` — **not** inside any repo. This is the core design decision. A per-repo store would break cross-repo context, which is the problem Nauro exists to solve. The registry at `~/.nauro/registry.json` maps project names to one or more associated repo paths on the machine.
+The project store lives at `~/.nauro/projects/<project-id>/` — **not** inside any repo. This is the core design decision. A per-repo store would break cross-repo context, which is the problem Nauro exists to solve. The registry at `~/.nauro/registry.json` is keyed by project id (ULID); each entry carries the project name as metadata plus one or more associated repo paths on the machine.
 
 ```
 ~/.nauro/
-  registry.json                  # maps project names → repo paths
+  registry.json                  # id-keyed entries: name, mode, repo paths
   projects/
-    <project-name>/
+    <project-id>/
       project.md                 # stable: goals, non-goals, users, constraints
       state_current.md           # volatile: current sprint, blockers, recent completions
       state_history.md           # append-only history of completed work
@@ -34,7 +34,7 @@ All files are freeform markdown. No database. No JSON for content — JSON only 
 ## Cross-package architecture
 
 ```
-~/.nauro/projects/<name>/        Local store (flat markdown + JSON snapshots)
+~/.nauro/projects/<id>/          Local store (flat markdown + JSON snapshots)
         │
         ├── nauro CLI              reads/writes directly
         ├── local MCP (stdio)      reads/writes directly, spawned by Claude Code
@@ -154,9 +154,9 @@ packages/nauro/
       filesystem_store.py  # Store-protocol implementation backed by ~/.nauro/projects/
       reader.py            # read helpers
       snapshot.py          # capture, list, load snapshots
-      registry.py          # ~/.nauro/registry.json CRUD + resolve_project()
+      registry.py          # ~/.nauro/registry.json CRUD + resolve_v2_from_path()
       repo_config.py       # per-repo .nauro/config.json read/write
-      resolution.py        # project-name resolution from CWD
+      resolution.py        # project resolution from CWD
       config.py            # ~/.nauro/config.json read/write
       validator.py         # structural checks on store contents
     templates/

--- a/packages/nauro/CLAUDE.md
+++ b/packages/nauro/CLAUDE.md
@@ -4,13 +4,13 @@ Nauro is a local CLI + MCP server that maintains versioned project context for A
 
 ## The one architectural fact that matters
 
-The project store lives at `~/.nauro/projects/<project-name>/` — **not** inside any repo. This is the core design decision. A per-repo store would break cross-repo context, which is the problem Nauro exists to solve. The registry at `~/.nauro/registry.json` maps project names to one or more associated repo paths on the machine.
+The project store lives at `~/.nauro/projects/<project-id>/` — **not** inside any repo. This is the core design decision. A per-repo store would break cross-repo context, which is the problem Nauro exists to solve. The registry at `~/.nauro/registry.json` is keyed by project id (ULID); each entry carries the project name as metadata plus one or more associated repo paths on the machine.
 
 ```
 ~/.nauro/
-  registry.json                  # maps project names → repo paths
+  registry.json                  # id-keyed entries: name, mode, repo paths
   projects/
-    <project-name>/
+    <project-id>/
       project.md                 # stable: goals, non-goals, users, constraints
       state_current.md           # volatile: current sprint, blockers, recent completions
       state_history.md           # append-only history of completed work
@@ -101,9 +101,9 @@ src/nauro/
     filesystem_store.py  # Store-protocol implementation backed by ~/.nauro/projects/
     reader.py            # read helpers
     snapshot.py          # capture, list, load snapshots
-    registry.py          # ~/.nauro/registry.json CRUD + resolve_project()
+    registry.py          # ~/.nauro/registry.json CRUD + resolve_v2_from_path()
     repo_config.py       # per-repo .nauro/config.json read/write
-    resolution.py        # project-name resolution from CWD
+    resolution.py        # project resolution from CWD
     config.py            # ~/.nauro/config.json read/write
     validator.py         # structural checks on store contents
   templates/

--- a/packages/nauro/src/nauro/cli/commands/sync.py
+++ b/packages/nauro/src/nauro/cli/commands/sync.py
@@ -46,7 +46,7 @@ def sync(
         return
 
     project_name, store_path = resolve_target_project(project)
-    # store_path.name is the project_id under v2 (id-keyed) or name under v1.
+    # store_path.name is the project_id (the store directory is id-keyed).
     project_key = store_path.name
     trigger = message or "manual sync"
 
@@ -96,9 +96,8 @@ def sync(
 def _pull_from_cloud(project_id: str, store_path: Path) -> int:
     """Pull remote changes via the manifest + presign endpoints.
 
-    No-op when the project is not v2 cloud-mode (v1 entries and v2
-    local-mode have no presign target) or when no Auth0 token is
-    configured.
+    No-op when the project is not v2 cloud-mode (local-mode has no
+    presign target) or when no Auth0 token is configured.
     """
     if not is_cloud_project(project_id):
         return 0

--- a/packages/nauro/src/nauro/cli/integrations/orchestrator.py
+++ b/packages/nauro/src/nauro/cli/integrations/orchestrator.py
@@ -103,7 +103,7 @@ def claude_code_surfaces(
 
     if not remove:
         # Regenerate AGENTS.md so context is fresh from the start. The store
-        # dir name is the v2 id (or v1 name) used by the registry-aware lookup.
+        # dir name is the project id used by the registry-aware lookup.
         # warn_then_regen surfaces missing-repo, symlink-refusal, and
         # git-hygiene warnings through the warn callback (stderr), never the
         # returned outcomes.
@@ -429,7 +429,7 @@ def setup_all_surfaces(
     Continues across per-handler errors so partial coverage still reports
     progress. Returns the cumulative status lines.
 
-    ``current_project_key`` is the registry key (v2 id or v1 name) for the
+    ``current_project_key`` is the registry key (project id) for the
     project being wired or torn down. When ``remove=True``, it is excluded
     from the "are there other projects?" check so per-project teardown only
     clears user-scope artifacts (Claude/Codex skill, ``~/.codex/config.toml``)

--- a/packages/nauro/src/nauro/cli/integrations/user_scope.py
+++ b/packages/nauro/src/nauro/cli/integrations/user_scope.py
@@ -2,15 +2,15 @@
 
 from __future__ import annotations
 
-from nauro.store.registry import RegistrySchemaError, load_registry, load_registry_v2
+from nauro.store.registry import RegistrySchemaError, load_registry_v2
 
 
 def _registered_project_keys() -> set[str]:
-    """Return the keys of every project in the registry (v2, v1 fallback)."""
+    """Return the keys of every project in the registry."""
     try:
         registry = load_registry_v2()
     except RegistrySchemaError:
-        registry = load_registry()
+        return set()
     return set(registry.get("projects", {}).keys())
 
 

--- a/packages/nauro/src/nauro/cli/utils.py
+++ b/packages/nauro/src/nauro/cli/utils.py
@@ -2,30 +2,26 @@
 
 Resolution priority for any command that needs a project context:
 
-  1. Explicit ``--project <name>`` flag (when the command takes one).
-     Looked up against the v2 registry by name; v1 registry is consulted
-     as a legacy fallback for unconverted callers and tests.
-  2. ``find_repo_config(cwd)`` — walks up from cwd looking for
-     ``.nauro/config.json`` and resolves the v2 registry by id.
-  3. v1 ``resolve_project(cwd)`` — name-keyed cwd resolution. Legacy
-     fallback retained while v1 callers remain in tree.
-  4. Error with helpful guidance.
+  1. Explicit ``--project <name>`` flag (when the command takes one),
+     looked up against the registry by name.
+  2. The cwd waterfall: ``.nauro/config.json`` walk-up, then the registry
+     matched by repo path.
+  3. Error with helpful guidance.
 """
 
 from __future__ import annotations
 
+import shlex
 from pathlib import Path
 
 import typer
 
+from nauro.constants import REPO_CONFIG_MODE_CLOUD
 from nauro.store.registry import (
     RegistrySchemaError,
     add_repo_v2,
     find_projects_by_name_v2,
-    get_project,
     get_project_v2,
-    get_store_path,
-    load_registry,
     load_registry_v2,
     register_project_v2,
     suggest_project_for_path,
@@ -103,16 +99,13 @@ def _v2_registry_or_empty() -> dict:
 
 
 def _available_project_names() -> list[str]:
-    """Return the sorted union of v1 and v2 project names, blanks removed.
+    """Return the sorted project names, blanks removed.
 
-    The empty-string is subtracted from the *combined* set so a v2 entry
-    missing its ``name`` field cannot leak a blank token into the
-    "Available projects:" listing.
+    The empty string is subtracted so an entry missing its ``name`` field
+    cannot leak a blank token into the "Available projects:" listing.
     """
-    registry = load_registry()
-    v2_names = {e.get("name", "") for e in _v2_registry_or_empty()["projects"].values()}
-    v1_names = set(registry["projects"].keys())
-    return sorted((v1_names | v2_names) - {""})
+    names = {e.get("name", "") for e in _v2_registry_or_empty()["projects"].values()}
+    return sorted(names - {""})
 
 
 def resolve_target_project(project_flag: str | None) -> tuple[str, Path]:
@@ -128,7 +121,7 @@ def resolve_target_project(project_flag: str | None) -> tuple[str, Path]:
         typer.Exit: If no project can be resolved.
     """
     if project_flag is not None:
-        # 1a — v2 by name (canonical)
+        # 1 — registry lookup by name
         matches = find_projects_by_name_v2(project_flag)
         if len(matches) > 1:
             # Show the full ULID, not a prefix: ULIDs minted seconds apart share
@@ -153,11 +146,6 @@ def resolve_target_project(project_flag: str | None) -> tuple[str, Path]:
             if connection is not None:
                 return project_flag, connection.store_path
 
-        # 1b — v1 fallback (legacy tests and unconverted callers)
-        entry = get_project(project_flag)
-        if entry is not None:
-            return project_flag, get_store_path(project_flag)
-
         available = _available_project_names()
         typer.echo(f"Unknown project '{project_flag}'.", err=True)
         if available:
@@ -166,7 +154,7 @@ def resolve_target_project(project_flag: str | None) -> tuple[str, Path]:
             typer.echo("No projects registered. Run 'nauro init' first.", err=True)
         raise typer.Exit(code=1)
 
-    # 2 — cwd waterfall: repo config walk-up → v2 registry by path → v1 legacy
+    # 2 — cwd waterfall: repo config walk-up → registry by repo path
     cwd = Path.cwd()
     resolution = resolve_from_cwd(cwd)
     if isinstance(resolution, DisconnectedProject):
@@ -181,14 +169,19 @@ def resolve_target_project(project_flag: str | None) -> tuple[str, Path]:
 
     suggestion = suggest_project_for_path(cwd)
     if suggestion:
+        pid, entry = suggestion
+        name = entry.get("name", "")
         typer.echo(
-            f"Hint: project '{suggestion}' exists but this path is not registered.",
+            f"Hint: project {name!r} exists but this path is not registered.",
             err=True,
         )
-        typer.echo(
-            f"  Run: nauro init {suggestion} --add-repo .",
-            err=True,
-        )
+        # init --add-repo intentionally rejects cloud-scoped projects; the
+        # documented association path for those is nauro attach. The name is
+        # shell-quoted because the line is meant to be copy-pasted.
+        if entry.get("mode") == REPO_CONFIG_MODE_CLOUD:
+            typer.echo(f"  Run: nauro attach {pid}", err=True)
+        else:
+            typer.echo(f"  Run: nauro init {shlex.quote(name)} --add-repo .", err=True)
     elif available:
         typer.echo(f"Available projects: {', '.join(available)}", err=True)
         typer.echo("Use --project <name> to target a specific project.", err=True)
@@ -201,8 +194,8 @@ def _resolve_project_entry(project_name: str, project_key: str) -> dict:
     """Resolve a registry entry that has at least one associated repo path.
 
     Args:
-        project_name: Display name (used for the v1 lookup and error message).
-        project_key: v2 project_id (store directory name) for the v2 lookup.
+        project_name: Display name (used in the error message).
+        project_key: project_id (store directory name) for the lookup.
 
     Returns:
         The resolved registry entry dict, guaranteed to carry ``repo_paths``.
@@ -210,14 +203,7 @@ def _resolve_project_entry(project_name: str, project_key: str) -> dict:
     Raises:
         typer.Exit: code 1 when no entry resolves or the entry has no repos.
     """
-    # Try v2 first (id-keyed), then fall back to v1 (name-keyed legacy)
-    try:
-        entry = get_project_v2(project_key)
-    except RegistrySchemaError:
-        entry = None
-    if entry is None:
-        entry = get_project(project_name)
-
+    entry = get_project_v2(project_key)
     if entry is None or not entry.get("repo_paths"):
         typer.echo(f"Project '{project_name}' has no associated repos.", err=True)
         raise typer.Exit(code=1)

--- a/packages/nauro/src/nauro/mcp/tools.py
+++ b/packages/nauro/src/nauro/mcp/tools.py
@@ -80,20 +80,16 @@ logger = logging.getLogger("nauro.mcp.tools")
 def _project_identity(store_path: Path) -> dict:
     """Best-effort project identity (name + id) for the response envelope.
 
-    The store directory name is the v2 project id (ULID) or, for a legacy v1
-    store, the project name itself. Resolve the human-readable name from the
-    registry when the store is v2; fall back to the directory name otherwise.
-    Never raises — identity is advisory, and a lookup failure must not break a
-    tool response.
+    The store directory name is the project id (ULID). Resolve the
+    human-readable name from the registry; fall back to the directory name
+    for a store with no registry entry. Never raises — identity is advisory,
+    and a lookup failure must not break a tool response.
     """
     key = store_path.name
     try:
-        from nauro.store.registry import RegistrySchemaError, get_project_v2
+        from nauro.store.registry import get_project_v2
 
-        try:
-            entry = get_project_v2(key)
-        except RegistrySchemaError:
-            entry = None
+        entry = get_project_v2(key)
         if entry is not None:
             return {"id": key, "name": entry.get("name") or key}
     except Exception:

--- a/packages/nauro/src/nauro/store/registry.py
+++ b/packages/nauro/src/nauro/store/registry.py
@@ -1,20 +1,16 @@
 """Project registry — manages ~/.nauro/registry.json.
 
-Two on-disk shapes are supported during the project-scoped migration:
+The registry is keyed by project_id (ULID) and tracks ``name``, ``mode``,
+``repo_paths``, an optional ``server_url``, and an optional external
+``store_path`` per project (schema_version 2). Store path:
+``~/.nauro/projects/<id>/``. Helpers: ``load_registry_v2``,
+``save_registry_v2``, ``register_project_v2``, ``get_store_path_v2``,
+``get_project_v2``, ``find_projects_by_name_v2``, ``resolve_v2_from_path``,
+``add_repo_v2``, ``rename_project_id_v2``.
 
-* **v1 (legacy)** — keyed by project name; store path ``~/.nauro/projects/<name>/``.
-  Helpers: ``load_registry``, ``save_registry``, ``register_project``,
-  ``resolve_project``, ``suggest_project_for_path``, ``get_project``,
-  ``get_store_path``.
-* **v2 (canonical post-migration)** — keyed by project_id (ULID), tracks
-  ``mode`` + optional ``server_url``. Store path ``~/.nauro/projects/<id>/``.
-  Helpers: ``load_registry_v2``, ``save_registry_v2``, ``register_project_v2``,
-  ``get_store_path_v2``, ``get_project_v2``, ``find_projects_by_name_v2``,
-  ``resolve_v2_from_path``, ``add_repo_v2``, ``rename_project_id_v2``.
-
-The two shapes are mutually exclusive on disk; ``load_registry_v2`` rejects
-v1 with a one-time manual migration message. v1 helpers are retained as
-legacy for callers that have not yet been migrated.
+The retired name-keyed schema_version 1 shape is no longer readable:
+``load_registry_v2`` rejects it with a manual-migration hint, and read
+paths degrade to an empty registry.
 
 Respects NAURO_HOME env var override (defaults to ~/.nauro/).
 """
@@ -22,7 +18,6 @@ Respects NAURO_HOME env var override (defaults to ~/.nauro/).
 import json
 import logging
 import os
-import re
 import shutil
 from contextlib import contextmanager
 from pathlib import Path
@@ -144,45 +139,10 @@ def _ensure_nauro_home() -> Path:
     return home
 
 
-def load_registry() -> dict:
-    """Read registry.json, return empty structure if it doesn't exist or is corrupt.
-
-    Returns:
-        Registry dict with a "projects" key mapping names to project entries.
-    """
-    rf = _registry_file()
-    if rf.exists():
-        try:
-            data = json.loads(rf.read_text())
-        except json.JSONDecodeError:
-            logger.warning("registry.json is corrupt - starting with empty registry")
-            return {"projects": {}, "schema_version": REGISTRY_SCHEMA_VERSION_V1}
-        if not isinstance(data, dict):
-            logger.warning("registry.json is corrupt - starting with empty registry")
-            return {"projects": {}, "schema_version": REGISTRY_SCHEMA_VERSION_V1}
-        data.setdefault("schema_version", REGISTRY_SCHEMA_VERSION_V1)
-        data.setdefault("projects", {})
-        return data  # type: ignore[no-any-return]
-    return {"projects": {}, "schema_version": REGISTRY_SCHEMA_VERSION_V1}
-
-
-def save_registry(data: dict) -> None:
-    """Write registry.json atomically (write-to-tmp + rename).
-
-    Args:
-        data: Full registry dict to persist.
-    """
-    data.setdefault("schema_version", REGISTRY_SCHEMA_VERSION_V1)
-    rf = _registry_file()
-    atomic_write_text(rf, json.dumps(data, indent=2) + "\n")
-
-
 # ── v2 registry (id-keyed) ───────────────────────────────────────────────────
 #
-# v2 introduces a project_id (ULID) primary key and tracks ``mode`` plus an
-# optional ``server_url`` per project. v2 is read/written by the
-# project-scoped commands; existing v1 commands continue to use
-# load_registry/save_registry above.
+# v2 uses a project_id (ULID) primary key and tracks ``mode`` plus an
+# optional ``server_url`` per project.
 #
 # v2 is a strict loader: it refuses to read a v1 registry and tells the user
 # to run the one-time manual migration documented in the release notes.
@@ -246,98 +206,6 @@ def save_registry_v2(data: dict) -> None:
         )
     rf = _registry_file()
     atomic_write_text(rf, json.dumps(data, indent=2) + "\n")
-
-
-def get_store_path(name: str) -> Path:
-    """Return the store directory path for a project name."""
-    return _projects_dir() / name
-
-
-def get_project(name: str) -> dict | None:
-    """Look up a project by name directly from the registry.
-
-    Args:
-        name: Project name to look up.
-
-    Returns:
-        Project entry dict or None if not found.
-    """
-    registry = load_registry()
-    return registry["projects"].get(name)  # type: ignore[no-any-return]
-
-
-def resolve_project(path: Path) -> str | None:
-    """Given a directory path, find which project it belongs to.
-
-    Walks up the directory tree and checks all registered repo paths for a match.
-
-    Args:
-        path: Directory path to resolve.
-
-    Returns:
-        Project name or None if no match found.
-    """
-    registry = load_registry()
-    path = path.resolve()
-    for name, entry in registry["projects"].items():
-        for repo in entry.get("repo_paths", []):
-            repo_resolved = Path(repo).resolve()
-            if path == repo_resolved or repo_resolved in path.parents:
-                return name  # type: ignore[no-any-return]
-    return None
-
-
-def register_project(name: str, repo_paths: list[Path]) -> Path:
-    """Add a project to the registry and create its store directory.
-
-    Args:
-        name: Project name.
-        repo_paths: List of associated repo paths.
-
-    Returns:
-        Path to the new project store directory.
-
-    Raises:
-        ValueError: If project already exists.
-    """
-    if not re.fullmatch(r"[a-zA-Z0-9_\-]+", name):
-        raise ValueError(
-            f"Invalid project name '{name}'. Use only letters, digits, hyphens, and underscores."
-        )
-
-    with _registry_lock():
-        registry = load_registry()
-        if name in registry["projects"]:
-            raise ValueError(f"Project '{name}' already exists in registry.")
-        registry["projects"][name] = {
-            "repo_paths": [str(p.resolve()) for p in repo_paths],
-        }
-        store_path = _projects_dir() / name
-        store_path.mkdir(parents=True, exist_ok=True)
-        save_registry(registry)
-    return store_path
-
-
-def suggest_project_for_path(path: Path) -> str | None:
-    """Suggest a project that might match a path based on directory name.
-
-    Useful when resolve_project() returns None — the repo may have moved.
-
-    Args:
-        path: Directory path to match.
-
-    Returns:
-        Project name if a plausible match is found, None otherwise.
-    """
-    registry = load_registry()
-    path = path.resolve()
-    dirname = path.name.lower()
-
-    for name in registry["projects"]:
-        if name.lower() == dirname:
-            return name  # type: ignore[no-any-return]
-
-    return None
 
 
 # ── v2 registry CRUD (id-keyed) ──────────────────────────────────────────────
@@ -643,12 +511,12 @@ def bind_project_store_v2(
 
 
 def _load_registry_v2_or_empty() -> dict:
-    """Read v2 registry; treat a v1-on-disk as 'no v2 entries'.
+    """Read v2 registry; treat a v1-shaped file on disk as 'no v2 entries'.
 
-    Read paths use this so that lookups silently fall back to v1 helpers
-    while a project is still on the v1 schema. Write paths continue to
-    call ``load_registry_v2`` directly, so v1 → v2 mutations fail loudly
-    rather than silently overwriting the v1 file.
+    Read paths use this so a leftover v1 registry degrades to the no-project
+    outcome instead of crashing. Write paths continue to call
+    ``load_registry_v2`` directly, so mutations against a v1 file fail loudly
+    rather than silently overwriting it.
     """
     try:
         return load_registry_v2()
@@ -671,17 +539,13 @@ def get_project_entry_v2(project_id: str) -> RegistryEntryV2 | None:
 
 
 def is_cloud_project(project_id: str) -> bool:
-    """True iff ``project_id`` is a v2 cloud-mode registry entry.
+    """True iff ``project_id`` is a cloud-mode registry entry.
 
-    v1 entries (no ``mode`` field) and v2 local-mode entries return False.
-    Used by the auto-sync hooks and the status command to gate presign
-    calls — v1 has no server-side ULID and v2 local-mode is not
-    remote-backed, so neither has a presign target.
+    Unknown ids and local-mode entries return False. Used by the auto-sync
+    hooks and the status command to gate presign calls; an id without a
+    cloud-mode record has no presign target.
     """
-    try:
-        entry = get_project_v2(project_id)
-    except RegistrySchemaError:
-        return False
+    entry = get_project_v2(project_id)
     if entry is None:
         return False
     return entry.get("mode") == REPO_CONFIG_MODE_CLOUD
@@ -701,27 +565,18 @@ def find_projects_by_name_v2(name: str) -> list[tuple[str, dict]]:
 
 
 def get_repo_paths(project_key: str) -> list[str]:
-    """Return repo paths for ``project_key`` from v2 (preferred) or v1 registry.
+    """Return repo paths for ``project_key`` (a project_id ULID).
 
-    ``project_key`` is a v2 project_id (ULID) or a v1 project name; v2 takes
-    priority with v1 as the legacy fallback. Returns an empty list when the
-    key is unknown in both schemas.
+    Returns an empty list when the key is unknown.
     """
-    try:
-        v2_entry = get_project_v2(project_key)
-    except RegistrySchemaError:
-        v2_entry = None
-    if v2_entry is not None:
-        return list(v2_entry.get("repo_paths", []))
-    registry = load_registry()
-    return list(registry["projects"].get(project_key, {}).get("repo_paths", []))
+    entry = get_project_v2(project_key)
+    if entry is None:
+        return []
+    return list(entry.get("repo_paths", []))
 
 
 def resolve_v2_from_path(path: Path) -> tuple[str, dict] | None:
-    """Walk up ``path`` and return (project_id, entry) for the matching v2 project.
-
-    Mirrors v1 ``resolve_project`` but on the id-keyed v2 registry.
-    """
+    """Walk up ``path`` and return (project_id, entry) for the matching project."""
     registry = _load_registry_v2_or_empty()
     path = path.resolve()
     for pid, entry in registry["projects"].items():
@@ -729,6 +584,28 @@ def resolve_v2_from_path(path: Path) -> tuple[str, dict] | None:
             repo_resolved = Path(repo).resolve()
             if path == repo_resolved or repo_resolved in path.parents:
                 return pid, entry
+    return None
+
+
+def suggest_project_for_path(path: Path) -> tuple[str, dict] | None:
+    """Suggest a project whose name matches ``path``'s directory name.
+
+    Useful when path-based resolution finds nothing (the repo may have
+    moved since it was registered). Returns ``(project_id, entry)`` only
+    when exactly one project matches, so the caller can render a
+    re-registration hint appropriate to the entry's mode; an ambiguous
+    name yields None because the hinted ``init --add-repo`` command
+    refuses duplicate names.
+    """
+    registry = _load_registry_v2_or_empty()
+    dirname = path.resolve().name.lower()
+    matches = [
+        (pid, entry)
+        for pid, entry in registry["projects"].items()
+        if entry.get("name", "") and entry["name"].lower() == dirname
+    ]
+    if len(matches) == 1:
+        return matches[0]
     return None
 
 

--- a/packages/nauro/src/nauro/store/resolution.py
+++ b/packages/nauro/src/nauro/store/resolution.py
@@ -8,9 +8,9 @@ whether to show the welcome screen or return a specific error message.
 Resolution order:
 
   1. cwd's ``.nauro/config.json`` walk-up (id-keyed v2 store).
-  2. ``project_id`` argument matched against v2 registry by name.
-  3. ``project_id`` argument matched against v1 registry by name (legacy).
-  4. ``cwd`` argument → v1 ``resolve_project`` (legacy).
+  2. ``project_id`` argument matched against the v2 registry by id, then
+     by name.
+  3. ``cwd`` argument matched against the v2 registry by repo path.
 
 The typed subclasses below let the wrappers reserve the
 ``WELCOME_NO_PROJECT`` onboarding screen for the genuinely-no-project case
@@ -31,10 +31,8 @@ from nauro.store.registry import (
     find_projects_by_name_v2,
     get_project_entry_v2,
     get_project_v2,
-    get_store_path,
     get_store_path_v2,
     registered_store_path_hint_v2,
-    resolve_project,
     resolve_registered_store_path_v2,
     resolve_v2_from_path,
     validate_registry_entry_v2,
@@ -104,11 +102,11 @@ class MultipleProjectsError(StoreResolutionError):
 class RepoResolution(NamedTuple):
     """A cwd resolved to a project store.
 
-    ``project_id`` is the store key: a ULID for v2 projects (from the repo
-    config or the v2 registry) or the legacy name for v1 projects. It is the
-    key the sync layer pulls under. ``display_name`` is the human-facing name
-    for CLI output. ``store_path`` is not existence-checked — each caller
-    decides how to treat a resolved-but-missing store.
+    ``project_id`` is the store key: a ULID from the repo config or the v2
+    registry. It is the key the sync layer pulls under. ``display_name`` is
+    the human-facing name for CLI output. ``store_path`` is not
+    existence-checked — each caller decides how to treat a
+    resolved-but-missing store.
     """
 
     store_path: Path
@@ -292,18 +290,14 @@ def resolve_via_repo_config(start: Path | None) -> tuple[str, Path] | None:
 def resolve_from_cwd(cwd: str | Path | None) -> RepoResolution | DisconnectedProject | None:
     """Resolve a cwd to a project store via the canonical waterfall.
 
-    Applies the three cwd-based tiers in order and returns the first match:
+    Applies the two cwd-based tiers in order and returns the first match:
 
       1. ``.nauro/config.json`` walk-up (id-keyed v2 store).
       2. v2 registry matched by repo path.
-      3. v1 ``resolve_project`` (legacy, name-keyed).
 
-    Returns a :class:`RepoResolution`, or ``None`` when no tier matches. The
-    v2 tiers surface missing or invalid stores as typed
-    :class:`DisconnectedProject` states; the v1 tier has no typed states, so
-    a v1 name whose store directory is gone falls through to ``None`` (the
-    no-project outcome) rather than resolving to a path that read tools would
-    treat as empty and write tools would silently recreate.
+    Returns a :class:`RepoResolution`, or ``None`` when no tier matches
+    (the no-project outcome). Both tiers surface missing or invalid stores
+    as typed :class:`DisconnectedProject` states.
     """
     start = Path(cwd) if cwd else Path.cwd()
 
@@ -316,12 +310,6 @@ def resolve_from_cwd(cwd: str | Path | None) -> RepoResolution | DisconnectedPro
     if v2_match is not None:
         pid, entry = v2_match
         return _connection_for_registry_entry(pid, entry)
-
-    name = resolve_project(start)
-    if name:
-        store_path = get_store_path(name)
-        if store_path.exists():
-            return RepoResolution(store_path, name, name)
 
     return None
 
@@ -369,15 +357,11 @@ def resolve_store(project_id: str | None, cwd: str | Path | None) -> Path:
                 f"Multiple v2 projects named {project_id!r}; pass an "
                 "unambiguous project_id (ULID) instead of the name."
             )
-        # v1 legacy fallback.
-        store_path = get_store_path(project_id)
-        if not store_path.exists():
-            raise ProjectNotFoundError(
-                f"No project named or keyed {project_id!r} found in the "
-                "registry. Run 'nauro init <name>' to create it, or check "
-                "NAURO_HOME if you expected an existing project."
-            )
-        return store_path
+        raise ProjectNotFoundError(
+            f"No project named or keyed {project_id!r} found in the "
+            "registry. Run 'nauro init <name>' to create it, or check "
+            "NAURO_HOME if you expected an existing project."
+        )
 
     if cwd:
         cwd_connection = resolve_from_cwd(cwd_path)

--- a/packages/nauro/src/nauro/sync/hooks.py
+++ b/packages/nauro/src/nauro/sync/hooks.py
@@ -10,9 +10,9 @@ silent-no-op when either is missing. The two no-op cases are:
 * Not authenticated. MCP writes happen on every tool call; nagging
   ``run nauro auth login`` on every write would be hostile. The user
   saw the prompt at session start (or onboarding) — here we just skip.
-* Project is not v2 cloud-mode. v1 entries have no server-side ULID
-  and v2 local-mode is not remote-backed. The presign endpoints can
-  address neither.
+* Project is not v2 cloud-mode. An id with no cloud-mode registry
+  record (unknown, or local-mode) has no presign target, so the hooks
+  no-op.
 
 The pull and push transport lives in ``nauro.sync.pull`` and
 ``nauro.sync.push`` and is shared with the ``nauro sync`` CLI command.

--- a/packages/nauro/src/nauro/sync/push.py
+++ b/packages/nauro/src/nauro/sync/push.py
@@ -29,7 +29,8 @@ def push_store_to_cloud(project_id: str, store_path: Path) -> bool:
 
     Cloud-mode projects with a token → presign push. Cloud-mode without
     a token → warn and return False (caller surfaces exit 1). Anything
-    else (v1, v2-local) → True since nothing was expected to upload.
+    else (local-mode or unknown id) → True since nothing was expected to
+    upload.
 
     A presign/auth-refresh failure during the push is reported and maps
     to False; per-file PUT failures are logged and skipped.

--- a/packages/nauro/src/nauro/templates/agents_md.py
+++ b/packages/nauro/src/nauro/templates/agents_md.py
@@ -83,8 +83,8 @@ def generate_agents_md(
         project_name: Name of the Nauro project.
         l0_payload: L0 context payload from build_l0_payload.
         manual_section: Preserved manual section content, or None.
-        project_id: v2 project id (ULID). When set, the store-routing block
-            tells agents which id to pass; omitted for legacy v1 projects.
+        project_id: Project id (ULID). When set, the store-routing block
+            tells agents which id to pass.
         skills_section: Preserved ``## Skills`` content, or None to omit.
         section_order: Order in which to emit preserved sections — list of
             ``"skills"`` and/or ``"manual"``. Defaults to source-appearance
@@ -218,8 +218,8 @@ def regenerate_agents_md_for_project(
     """Regenerate AGENTS.md in all repos associated with a project.
 
     Args:
-        project_key: Either a v2 project_id (ULID) or a v1 project name.
-            v2 takes priority — the v1 name lookup is the legacy fallback.
+        project_key: The project_id (ULID) whose registry entry lists the
+            associated repos.
         store_path: Path to the project store directory.
         overwrite_unmanaged: Replace an existing AGENTS.md even when Nauro
             did not generate it. Off by default: only ``nauro sync`` passes

--- a/packages/nauro/src/nauro/templates/agents_md_regen.py
+++ b/packages/nauro/src/nauro/templates/agents_md_regen.py
@@ -38,7 +38,7 @@ def warn_then_regen(
     """Warn on skipped repo paths, then regenerate ``AGENTS.md`` everywhere.
 
     Args:
-        project_key: Either a v2 project_id (ULID) or a v1 project name.
+        project_key: The project_id (ULID).
         store_path: Path to the project store directory.
         warn: Optional callback for skip and git-hygiene warnings. When
             ``None``, skipped repo paths are silent and git-hygiene checks

--- a/packages/nauro/tests/conftest.py
+++ b/packages/nauro/tests/conftest.py
@@ -101,8 +101,9 @@ def register_v2_repo(
     ``seed_decisions_into`` or a demo project). ``monkeypatch`` is required
     only when ``chdir`` is True.
 
-    This body is v2-only by design: v1 ``register_project`` seeders are left
-    untouched and must never be routed through here.
+    This factory is the canonical store seeder: the registry is v2-only, so
+    every test that needs a registered project routes through it or calls
+    ``register_project_v2`` directly.
     """
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/packages/nauro/tests/test_agents_md.py
+++ b/packages/nauro/tests/test_agents_md.py
@@ -193,11 +193,11 @@ def test_generate_without_manual_section():
 
 
 def test_sync_writes_agents_md(tmp_path: Path, monkeypatch):
-    from nauro.store.registry import register_project
+    from nauro.store.registry import register_project_v2
 
     repo = tmp_path / "repo"
     repo.mkdir()
-    store = register_project("myproj", [repo])
+    _pid, store = register_project_v2("myproj", [repo])
     scaffold_project_store("myproj", store)
     monkeypatch.chdir(repo)
 
@@ -219,11 +219,11 @@ def test_sync_agents_md_carries_project_scope_without_h1_stutter(tmp_path: Path,
     The file's own H1 is stripped by the L0 builder, so the payload must not
     stutter a "# myproj" heading directly under the section header.
     """
-    from nauro.store.registry import register_project
+    from nauro.store.registry import register_project_v2
 
     repo = tmp_path / "repo"
     repo.mkdir()
-    store = register_project("myproj", [repo])
+    _pid, store = register_project_v2("myproj", [repo])
     scaffold_project_store("myproj", store)
     (store / "project.md").write_text(
         "# myproj\n\n**One-liner:** Ships the thing.\n## Goals\n- Ship v1\n"
@@ -242,11 +242,11 @@ def test_sync_agents_md_carries_project_scope_without_h1_stutter(tmp_path: Path,
 
 def test_sync_agents_md_omits_scaffold_project_placeholders(tmp_path: Path, monkeypatch):
     """A freshly scaffolded store must not leak project.md placeholder prompts."""
-    from nauro.store.registry import register_project
+    from nauro.store.registry import register_project_v2
 
     repo = tmp_path / "repo"
     repo.mkdir()
-    store = register_project("myproj", [repo])
+    _pid, store = register_project_v2("myproj", [repo])
     scaffold_project_store("myproj", store)
     monkeypatch.chdir(repo)
 
@@ -261,13 +261,13 @@ def test_sync_agents_md_omits_scaffold_project_placeholders(tmp_path: Path, monk
 
 
 def test_sync_multi_repo(tmp_path: Path, monkeypatch):
-    from nauro.store.registry import register_project
+    from nauro.store.registry import register_project_v2
 
     repo1 = tmp_path / "repo1"
     repo2 = tmp_path / "repo2"
     repo1.mkdir()
     repo2.mkdir()
-    store = register_project("myproj", [repo1, repo2])
+    _pid, store = register_project_v2("myproj", [repo1, repo2])
     scaffold_project_store("myproj", store)
     monkeypatch.chdir(repo1)
 
@@ -280,11 +280,11 @@ def test_sync_multi_repo(tmp_path: Path, monkeypatch):
 
 
 def test_sync_skips_missing_repo(tmp_path: Path, monkeypatch):
-    from nauro.store.registry import register_project
+    from nauro.store.registry import register_project_v2
 
     real_repo = tmp_path / "real"
     real_repo.mkdir()
-    store = register_project("myproj", [real_repo, tmp_path / "nonexistent"])
+    _pid, store = register_project_v2("myproj", [real_repo, tmp_path / "nonexistent"])
     scaffold_project_store("myproj", store)
     monkeypatch.chdir(real_repo)
 
@@ -297,11 +297,11 @@ def test_sync_skips_missing_repo(tmp_path: Path, monkeypatch):
 
 
 def test_sync_preserves_manual_section(tmp_path: Path, monkeypatch):
-    from nauro.store.registry import register_project
+    from nauro.store.registry import register_project_v2
 
     repo = tmp_path / "repo"
     repo.mkdir()
-    store = register_project("myproj", [repo])
+    _pid, store = register_project_v2("myproj", [repo])
     scaffold_project_store("myproj", store)
 
     # Pre-populate an AGENTS.md with a manual section

--- a/packages/nauro/tests/test_agents_md.py
+++ b/packages/nauro/tests/test_agents_md.py
@@ -115,7 +115,7 @@ def test_routing_block_steers_to_local_stdio_with_project_id():
 
 
 def test_routing_block_omits_project_id_line_when_unknown():
-    """Legacy v1 projects have no id — the block still steers to local, no id line."""
+    """Without a project id the block still steers to local, no id line."""
     result = generate_agents_md("myproj", "payload")
     assert "## Nauro store for this repo" in result
     assert "`mcp__nauro__*`" in result

--- a/packages/nauro/tests/test_claude_bridge.py
+++ b/packages/nauro/tests/test_claude_bridge.py
@@ -34,7 +34,7 @@ from nauro.cli.integrations.outcomes import BridgeKind
 from nauro.cli.main import app
 from nauro.constants import CLAUDE_BRIDGE_MARKER, CLAUDE_MD
 from nauro.mcp.tools import tool_propose_decision
-from nauro.store.registry import register_project, register_project_v2
+from nauro.store.registry import register_project_v2
 from nauro.store.repo_config import save_repo_config
 from nauro.templates.scaffolds import scaffold_project_store
 
@@ -524,7 +524,7 @@ def test_sync_multi_repo_bridges_every_repo(tmp_path: Path, monkeypatch):
     repo2 = tmp_path / "repo2"
     repo1.mkdir()
     repo2.mkdir()
-    store = register_project("multi", [repo1, repo2])
+    _pid, store = register_project_v2("multi", [repo1, repo2])
     scaffold_project_store("multi", store)
     monkeypatch.chdir(repo1)
 
@@ -548,7 +548,7 @@ def test_sync_continues_when_one_repo_has_a_broken_claude_md(tmp_path: Path, mon
     repo1.mkdir()
     repo2.mkdir()
     (repo1 / CLAUDE_MD).mkdir()  # broken: a directory where the bridge would go
-    store = register_project("multi", [repo1, repo2])
+    _pid, store = register_project_v2("multi", [repo1, repo2])
     scaffold_project_store("multi", store)
     monkeypatch.chdir(repo2)
 

--- a/packages/nauro/tests/test_cli.py
+++ b/packages/nauro/tests/test_cli.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typer.testing import CliRunner
 
 from nauro.cli.main import app
-from nauro.store.registry import get_project, register_project
+from nauro.store.registry import get_project, register_project, register_project_v2
 from nauro.store.snapshot import capture_snapshot
 from nauro.templates.scaffolds import scaffold_project_store
 from tests._ansi import strip_ansi
@@ -59,7 +59,7 @@ def test_init_command(tmp_path: Path, monkeypatch):
 
 def test_note_command(tmp_path: Path, monkeypatch):
     """nauro note should accept a message."""
-    store = register_project("myproj", [tmp_path])
+    _pid, store = register_project_v2("myproj", [tmp_path])
     scaffold_project_store("myproj", store)
     monkeypatch.chdir(tmp_path)
 
@@ -72,7 +72,7 @@ def test_note_command(tmp_path: Path, monkeypatch):
 
 def test_sync_command(tmp_path: Path, monkeypatch):
     """nauro sync should capture a snapshot."""
-    store = register_project("myproj", [tmp_path])
+    _pid, store = register_project_v2("myproj", [tmp_path])
     scaffold_project_store("myproj", store)
     monkeypatch.chdir(tmp_path)
 
@@ -83,7 +83,7 @@ def test_sync_command(tmp_path: Path, monkeypatch):
 
 def test_log_command(tmp_path: Path, monkeypatch):
     """nauro log should list snapshots."""
-    store = register_project("myproj", [tmp_path])
+    _pid, store = register_project_v2("myproj", [tmp_path])
     scaffold_project_store("myproj", store)
     monkeypatch.chdir(tmp_path)
 
@@ -100,8 +100,8 @@ def test_log_command(tmp_path: Path, monkeypatch):
 def test_note_with_project_flag_overrides_cwd(tmp_path: Path, monkeypatch):
     """--project flag should resolve the named project regardless of cwd."""
     # Register two projects
-    store_a = register_project("alpha", [tmp_path / "repo_a"])
-    store_b = register_project("beta", [tmp_path / "repo_b"])
+    _pid_a, store_a = register_project_v2("alpha", [tmp_path / "repo_a"])
+    _pid_b, store_b = register_project_v2("beta", [tmp_path / "repo_b"])
     scaffold_project_store("alpha", store_a)
     scaffold_project_store("beta", store_b)
 
@@ -125,7 +125,7 @@ def test_note_with_project_flag_overrides_cwd(tmp_path: Path, monkeypatch):
 
 def test_project_flag_unknown_name_gives_error(tmp_path: Path, monkeypatch):
     """--project with an unknown name should error and list available projects."""
-    store = register_project("realproj", [tmp_path])
+    _pid, store = register_project_v2("realproj", [tmp_path])
     scaffold_project_store("realproj", store)
     monkeypatch.chdir(tmp_path)
 
@@ -137,7 +137,7 @@ def test_project_flag_unknown_name_gives_error(tmp_path: Path, monkeypatch):
 
 def test_no_project_flag_no_cwd_match_gives_error(tmp_path: Path, monkeypatch):
     """Missing --project and no cwd match should error with available projects."""
-    store = register_project("faraway", [tmp_path / "elsewhere"])
+    _pid, store = register_project_v2("faraway", [tmp_path / "elsewhere"])
     scaffold_project_store("faraway", store)
 
     # cwd doesn't match any registered repo
@@ -172,7 +172,7 @@ def test_no_cwd_match_suggests_project_by_dirname(tmp_path: Path, monkeypatch):
 
 def test_sync_with_project_flag(tmp_path: Path, monkeypatch):
     """nauro sync --project should target the named project."""
-    store = register_project("myproj", [tmp_path / "repo"])
+    _pid, store = register_project_v2("myproj", [tmp_path / "repo"])
     scaffold_project_store("myproj", store)
 
     # cwd is unrelated
@@ -187,7 +187,7 @@ def test_sync_with_project_flag(tmp_path: Path, monkeypatch):
 
 def test_log_with_project_flag(tmp_path: Path, monkeypatch):
     """nauro log --project should target the named project."""
-    store = register_project("myproj", [tmp_path / "repo"])
+    _pid, store = register_project_v2("myproj", [tmp_path / "repo"])
     scaffold_project_store("myproj", store)
     capture_snapshot(store, trigger="test")
 

--- a/packages/nauro/tests/test_cli.py
+++ b/packages/nauro/tests/test_cli.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typer.testing import CliRunner
 
 from nauro.cli.main import app
-from nauro.store.registry import get_project, register_project, register_project_v2
+from nauro.store.registry import register_project_v2
 from nauro.store.snapshot import capture_snapshot
 from nauro.templates.scaffolds import scaffold_project_store
 from tests._ansi import strip_ansi
@@ -153,10 +153,10 @@ def test_no_project_flag_no_cwd_match_gives_error(tmp_path: Path, monkeypatch):
 
 
 def test_no_cwd_match_suggests_project_by_dirname(tmp_path: Path, monkeypatch):
-    """When cwd dirname matches a project name, suggest adding the repo path."""
+    """When cwd dirname matches a local project name, suggest init --add-repo."""
     old_repo = tmp_path / "old_location" / "myapp"
     old_repo.mkdir(parents=True)
-    store = register_project("myapp", [old_repo])
+    _pid, store = register_project_v2("myapp", [old_repo])
     scaffold_project_store("myapp", store)
 
     # Clone/move to a new location with same dirname
@@ -168,6 +168,54 @@ def test_no_cwd_match_suggests_project_by_dirname(tmp_path: Path, monkeypatch):
     assert result.exit_code == 1
     assert "project 'myapp' exists but this path is not registered" in result.output
     assert "nauro init myapp --add-repo" in result.output
+
+
+def test_no_suggestion_for_ambiguous_project_name(tmp_path: Path, monkeypatch):
+    """Two projects sharing the matching name suppress the hint entirely:
+    the hinted init --add-repo command refuses duplicate names."""
+    repo_a = tmp_path / "a" / "myapp"
+    repo_a.mkdir(parents=True)
+    _pid_a, store_a = register_project_v2("myapp", [repo_a])
+    scaffold_project_store("myapp", store_a)
+    repo_b = tmp_path / "b" / "myapp"
+    repo_b.mkdir(parents=True)
+    _pid_b, store_b = register_project_v2("myapp", [repo_b])
+    scaffold_project_store("myapp", store_b)
+
+    elsewhere = tmp_path / "elsewhere" / "myapp"
+    elsewhere.mkdir(parents=True)
+    monkeypatch.chdir(elsewhere)
+
+    result = runner.invoke(app, ["note", "test"])
+    assert result.exit_code == 1
+    assert "exists but this path is not registered" not in result.output
+    assert "Available projects" in result.output
+
+
+def test_no_cwd_match_suggests_attach_for_cloud_project(tmp_path: Path, monkeypatch):
+    """A cloud-mode suggestion hints nauro attach, since init --add-repo
+    intentionally rejects cloud-scoped projects."""
+    from nauro.constants import REPO_CONFIG_MODE_CLOUD
+
+    old_repo = tmp_path / "old_location" / "cloudapp"
+    old_repo.mkdir(parents=True)
+    pid, store = register_project_v2(
+        "cloudapp",
+        [old_repo],
+        mode=REPO_CONFIG_MODE_CLOUD,
+        server_url="https://api.example.test",
+    )
+    scaffold_project_store("cloudapp", store)
+
+    new_repo = tmp_path / "new_location" / "cloudapp"
+    new_repo.mkdir(parents=True)
+    monkeypatch.chdir(new_repo)
+
+    result = runner.invoke(app, ["note", "test"])
+    assert result.exit_code == 1
+    assert "project 'cloudapp' exists but this path is not registered" in result.output
+    assert f"nauro attach {pid}" in result.output
+    assert "--add-repo" not in result.output
 
 
 def test_sync_with_project_flag(tmp_path: Path, monkeypatch):
@@ -198,16 +246,3 @@ def test_log_with_project_flag(tmp_path: Path, monkeypatch):
     result = runner.invoke(app, ["log", "--project", "myproj"])
     assert result.exit_code == 0
     assert "v001" in result.output
-
-
-def test_get_project_returns_entry(tmp_path: Path, monkeypatch):
-    """get_project should return the entry dict for a known project."""
-    register_project("proj", [tmp_path / "repo"])
-    entry = get_project("proj")
-    assert entry is not None
-    assert "repo_paths" in entry
-
-
-def test_get_project_returns_none_for_unknown(tmp_path: Path, monkeypatch):
-    """get_project should return None for unknown projects."""
-    assert get_project("nonexistent") is None

--- a/packages/nauro/tests/test_cli_doctor.py
+++ b/packages/nauro/tests/test_cli_doctor.py
@@ -14,7 +14,7 @@ from nauro_core.decision_model import Decision, format_decision
 from typer.testing import CliRunner
 
 from nauro.cli.main import app
-from nauro.store.registry import register_project
+from nauro.store.registry import register_project_v2
 from nauro.templates.scaffolds import scaffold_project_store
 from tests.conftest import write_decision_file
 
@@ -23,7 +23,7 @@ runner = CliRunner()
 
 def _new_store(tmp_path: Path, name: str = "docproj") -> Path:
     """Register and scaffold a project, returning its store path."""
-    store = register_project(name, [tmp_path])
+    _pid, store = register_project_v2(name, [tmp_path])
     scaffold_project_store(name, store)
     return store
 

--- a/packages/nauro/tests/test_cli_fs_errors.py
+++ b/packages/nauro/tests/test_cli_fs_errors.py
@@ -13,7 +13,7 @@ import pytest
 from typer.testing import CliRunner
 
 from nauro.cli.main import app
-from nauro.store.registry import register_project
+from nauro.store.registry import register_project_v2
 from nauro.templates.scaffolds import scaffold_project_store
 
 runner = CliRunner()
@@ -32,8 +32,7 @@ def _assert_clean_error(result):
 
 
 def test_note_on_read_only_store_reports_clean_error(tmp_path: Path, monkeypatch):
-    register_project("p", [tmp_path])
-    store_path = tmp_path / "projects" / "p"
+    _pid, store_path = register_project_v2("p", [tmp_path])
     scaffold_project_store("p", store_path)
     monkeypatch.chdir(tmp_path)
 

--- a/packages/nauro/tests/test_cli_graph.py
+++ b/packages/nauro/tests/test_cli_graph.py
@@ -20,7 +20,7 @@ from typer.testing import CliRunner
 
 from nauro.cli.main import app
 from nauro.constants import DECISIONS_DIR, OPEN_QUESTIONS_MD
-from nauro.store.registry import register_project
+from nauro.store.registry import register_project_v2
 from nauro.templates.scaffolds import scaffold_project_store
 from tests.conftest import write_decision_file
 
@@ -84,7 +84,7 @@ def _decision_md(
 
 def _new_store(tmp_path, monkeypatch, name: str = "graphproj") -> Path:
     """Register and scaffold a project, chdir into its repo, return the store."""
-    store = register_project(name, [tmp_path])
+    _pid, store = register_project_v2(name, [tmp_path])
     scaffold_project_store(name, store)
     monkeypatch.chdir(tmp_path)
     return store

--- a/packages/nauro/tests/test_cli_status.py
+++ b/packages/nauro/tests/test_cli_status.py
@@ -14,7 +14,7 @@ from nauro.cli.integrations.skills import (
     materialize_skills_codex,
 )
 from nauro.cli.main import app
-from nauro.store.registry import register_project
+from nauro.store.registry import register_project_v2
 from nauro.templates.agents_md import FOOTER_MARKER
 from nauro.templates.scaffolds import scaffold_project_store
 
@@ -29,7 +29,7 @@ def _setup_project(tmp_path, monkeypatch, repos=None):
     detection assertions.
     """
     repos = repos if repos is not None else [tmp_path]
-    store = register_project("testproj", repos)
+    _pid, store = register_project_v2("testproj", repos)
     scaffold_project_store("testproj", store)
     monkeypatch.chdir(repos[0])
     monkeypatch.setattr(

--- a/packages/nauro/tests/test_cli_status_divergence.py
+++ b/packages/nauro/tests/test_cli_status_divergence.py
@@ -17,7 +17,7 @@ from typer.testing import CliRunner
 from nauro.cli.main import app
 from nauro.constants import REPO_CONFIG_MODE_CLOUD, REPO_CONFIG_MODE_LOCAL
 from nauro.store.config import save_config
-from nauro.store.registry import register_project, register_project_v2
+from nauro.store.registry import register_project_v2
 from nauro.templates.scaffolds import scaffold_project_store
 
 runner = CliRunner()
@@ -26,9 +26,9 @@ CLOUD_PID = "01KQ6AZGNA0B3QBF67NBXP3S45"
 LOCAL_PID = "01KQ6AZGNA0B3QBF67NBXP3S46"
 
 
-def _setup_v1_project(tmp_path, monkeypatch):
-    """v1 project (legacy); status falls back to local-only reporting."""
-    store = register_project("testproj", [tmp_path])
+def _setup_local_project(tmp_path, monkeypatch):
+    """v2 local-mode project; status reports local-only."""
+    _pid, store = register_project_v2("testproj", [tmp_path])
     scaffold_project_store("testproj", store)
     monkeypatch.chdir(tmp_path)
     return store
@@ -58,8 +58,8 @@ def _setup_cloud_project(tmp_path, monkeypatch):
 
 
 def test_status_shows_local_decision_count_when_unauthenticated(tmp_path, monkeypatch):
-    """Sync inactive (v1 project, no token) → local count only."""
-    _setup_v1_project(tmp_path, monkeypatch)
+    """Sync inactive (local project, no token) → local count only."""
+    _setup_local_project(tmp_path, monkeypatch)
 
     result = runner.invoke(app, ["status"])
     assert result.exit_code == 0

--- a/packages/nauro/tests/test_cli_validate.py
+++ b/packages/nauro/tests/test_cli_validate.py
@@ -3,14 +3,14 @@
 from typer.testing import CliRunner
 
 from nauro.cli.main import app
-from nauro.store.registry import register_project
+from nauro.store.registry import register_project_v2
 from nauro.templates.scaffolds import scaffold_project_store
 
 runner = CliRunner()
 
 
 def _setup_project(tmp_path, monkeypatch):
-    store = register_project("testproj", [tmp_path])
+    _pid, store = register_project_v2("testproj", [tmp_path])
     scaffold_project_store("testproj", store)
     monkeypatch.chdir(tmp_path)
     return store
@@ -36,7 +36,7 @@ def test_validate_status_on_non_empty_store(tmp_path, monkeypatch):
 
 def test_validate_status_empty_store(tmp_path, monkeypatch):
     """An empty decisions set reports zero counts without error."""
-    store = register_project("emptyproj", [tmp_path])
+    _pid, store = register_project_v2("emptyproj", [tmp_path])
     scaffold_project_store("emptyproj", store)
     # Remove the seed decision so the store has no decisions.
     for decision in (store / "decisions").glob("*.md"):

--- a/packages/nauro/tests/test_envelope_rejection.py
+++ b/packages/nauro/tests/test_envelope_rejection.py
@@ -13,7 +13,7 @@ from unittest.mock import patch
 import pytest
 
 from nauro.mcp.tools import tool_flag_question, tool_propose_decision
-from nauro.store.registry import register_project
+from nauro.store.registry import register_project_v2
 from nauro.templates.scaffolds import scaffold_project_store
 
 OPEN_QUESTIONS = "open-questions.md"
@@ -22,7 +22,7 @@ OPEN_QUESTIONS = "open-questions.md"
 @pytest.fixture()
 def store(tmp_path: Path) -> Path:
     """A scaffolded project store registered against tmp_path."""
-    store_path = register_project("testproj", [tmp_path])
+    _pid, store_path = register_project_v2("testproj", [tmp_path])
     scaffold_project_store("testproj", store_path)
     return store_path
 

--- a/packages/nauro/tests/test_hook_command.py
+++ b/packages/nauro/tests/test_hook_command.py
@@ -20,7 +20,7 @@ from typer.testing import CliRunner
 from nauro.cli.commands import hook
 from nauro.cli.main import app
 from nauro.mcp.payloads import build_l0_payload
-from nauro.store.registry import register_project, register_project_v2
+from nauro.store.registry import register_project_v2
 from tests.conftest import register_v2_repo
 
 runner = CliRunner()
@@ -280,19 +280,19 @@ def test_missing_store_exits_zero_empty(tmp_path: Path):
     assert result.output == ""
 
 
-def test_v1_registry_project_resolves_for_hook(tmp_path: Path):
-    """A project registered only in the v1 (name-keyed) registry resolves.
+def test_v1_shaped_registry_yields_none_for_hook(tmp_path: Path):
+    """A retired v1-shaped (name-keyed) registry resolves to no project.
 
-    The hook's resolver delegates to the canonical ``resolve_from_cwd``
-    waterfall, whose third tier is the v1 legacy registry. Previously the hook
-    stopped after the repo-config and v2-by-path tiers, so a v1-only project
-    got no advisory context; now it resolves like every other surface.
+    v1 registry support was removed deliberately; the shape reads as an
+    empty registry, so the hook fails open with no advisory context.
     """
     repo = tmp_path / "v1repo"
     repo.mkdir()
-    store_path = register_project("v1only", [repo])
+    (tmp_path / "registry.json").write_text(
+        json.dumps({"schema_version": 1, "projects": {"v1only": {"repo_paths": [str(repo)]}}})
+    )
 
-    assert hook._resolve_store_path(repo) == store_path
+    assert hook._resolve_store_path(repo) is None
 
 
 def test_oversize_prompt_exits_zero_empty(tmp_path: Path):

--- a/packages/nauro/tests/test_import.py
+++ b/packages/nauro/tests/test_import.py
@@ -14,7 +14,7 @@ from nauro.cli.commands.import_cmd import (
 )
 from nauro.cli.main import app
 from nauro.mcp.payloads import build_l0_payload
-from nauro.store.registry import register_project
+from nauro.store.registry import register_project_v2
 from nauro.store.snapshot import list_snapshots
 from nauro.templates.scaffolds import scaffold_project_store
 
@@ -169,7 +169,7 @@ def test_import_preserves_existing_decisions(store: Path, full_memory_bank: Path
 
 
 def test_import_nonexistent_directory_cli(tmp_path: Path, monkeypatch):
-    store = register_project("myproj", [tmp_path])
+    _pid, store = register_project_v2("myproj", [tmp_path])
     scaffold_project_store("myproj", store)
     monkeypatch.chdir(tmp_path)
 
@@ -179,7 +179,7 @@ def test_import_nonexistent_directory_cli(tmp_path: Path, monkeypatch):
 
 
 def test_import_directory_without_project_brief_cli(tmp_path: Path, monkeypatch):
-    store = register_project("myproj", [tmp_path])
+    _pid, store = register_project_v2("myproj", [tmp_path])
     scaffold_project_store("myproj", store)
     monkeypatch.chdir(tmp_path)
 
@@ -195,7 +195,7 @@ def test_import_directory_without_project_brief_cli(tmp_path: Path, monkeypatch)
 
 
 def test_import_cli_full(tmp_path: Path, monkeypatch, full_memory_bank: Path):
-    store = register_project("myproj", [tmp_path])
+    _pid, store = register_project_v2("myproj", [tmp_path])
     scaffold_project_store("myproj", store)
     monkeypatch.chdir(tmp_path)
 
@@ -213,7 +213,7 @@ def test_import_cli_full(tmp_path: Path, monkeypatch, full_memory_bank: Path):
 
 
 def test_import_cli_partial(tmp_path: Path, monkeypatch, partial_memory_bank: Path):
-    store = register_project("myproj", [tmp_path])
+    _pid, store = register_project_v2("myproj", [tmp_path])
     scaffold_project_store("myproj", store)
     monkeypatch.chdir(tmp_path)
 
@@ -224,7 +224,7 @@ def test_import_cli_partial(tmp_path: Path, monkeypatch, partial_memory_bank: Pa
 
 
 def test_import_cli_no_flags(tmp_path: Path, monkeypatch):
-    store = register_project("myproj", [tmp_path])
+    _pid, store = register_project_v2("myproj", [tmp_path])
     scaffold_project_store("myproj", store)
     monkeypatch.chdir(tmp_path)
 
@@ -234,8 +234,7 @@ def test_import_cli_no_flags(tmp_path: Path, monkeypatch):
 
 
 def test_import_cli_with_project_flag(tmp_path: Path, monkeypatch, full_memory_bank: Path):
-    register_project("proj_a", [tmp_path / "a"])
-    store_a = tmp_path / "projects" / "proj_a"
+    _pid, store_a = register_project_v2("proj_a", [tmp_path / "a"])
     scaffold_project_store("proj_a", store_a)
     monkeypatch.chdir(tmp_path)
 
@@ -708,7 +707,7 @@ def test_import_adr_empty_directory(store: Path, tmp_path: Path):
 
 def test_import_adr_cli_integration(tmp_path: Path, monkeypatch, madr_directory: Path):
     """Test ADR import via CLI."""
-    store = register_project("myproj", [tmp_path])
+    _pid, store = register_project_v2("myproj", [tmp_path])
     scaffold_project_store("myproj", store)
     monkeypatch.chdir(tmp_path)
 
@@ -743,8 +742,7 @@ def test_import_adr_non_utf8_does_not_crash(store: Path, tmp_path: Path):
 def test_import_memory_bank_unparsed_decisionlog_warns(tmp_path: Path, monkeypatch):
     """A non-empty decisionLog in Cline's native (non '## Decision:') format
     imports zero decisions but must say so, not report a silent success."""
-    register_project("myproj", [tmp_path])
-    store = tmp_path / "projects" / "myproj"
+    _pid, store = register_project_v2("myproj", [tmp_path])
     scaffold_project_store("myproj", store)
     monkeypatch.chdir(tmp_path)
 
@@ -768,8 +766,7 @@ def test_import_memory_bank_proper_heading_no_warning(
     tmp_path: Path, monkeypatch, full_memory_bank: Path
 ):
     """A decisionLog that uses the expected heading imports without the warning."""
-    register_project("myproj", [tmp_path])
-    store = tmp_path / "projects" / "myproj"
+    _pid, store = register_project_v2("myproj", [tmp_path])
     scaffold_project_store("myproj", store)
     monkeypatch.chdir(tmp_path)
 
@@ -781,8 +778,7 @@ def test_import_memory_bank_proper_heading_no_warning(
 
 def test_import_adr_no_matching_files_warns(tmp_path: Path, monkeypatch):
     """An ADR dir with only non-'<NNN>-title.md' files imports nothing and says why."""
-    register_project("myproj", [tmp_path])
-    store = tmp_path / "projects" / "myproj"
+    _pid, store = register_project_v2("myproj", [tmp_path])
     scaffold_project_store("myproj", store)
     monkeypatch.chdir(tmp_path)
 

--- a/packages/nauro/tests/test_log_diff.py
+++ b/packages/nauro/tests/test_log_diff.py
@@ -356,28 +356,26 @@ class TestDiffCommand:
         assert "Not enough snapshots" in envelope["diff"]
 
     def test_diff_registered_but_missing_store(self, tmp_path: Path, monkeypatch):
-        """A v1 project whose store directory was deleted must exit nonzero
-        with actionable guidance, never an empty diff. Resolution no longer
-        yields a path for a missing legacy store — the cwd falls through to
-        the no-project outcome, so the CLI names the available projects
+        """A project whose store directory was deleted must exit nonzero
+        with actionable guidance, never an empty diff. The missing store
+        surfaces as a typed disconnected state with reconnect guidance
         instead of operating on a directory that does not exist.
         """
         import shutil
 
-        from nauro.store.registry import register_project
+        from nauro.store.registry import register_project_v2
 
-        store = register_project("myproj", [tmp_path])
+        _pid, store = register_project_v2("myproj", [tmp_path])
         scaffold_project_store("myproj", store)
         monkeypatch.chdir(tmp_path)
 
-        # Delete the project store directory; the registry still points
-        # at it, but cwd resolution treats the missing store as no project.
+        # Delete the project store directory; the registry still points at it.
         shutil.rmtree(store)
 
         result = runner.invoke(app, ["diff-since-last-session"])
         assert result.exit_code == 1
-        assert "No project found for current directory" in result.output
-        assert "myproj" in result.output
+        assert "was connected on this machine" in result.output
+        assert "nauro reconnect" in result.output
 
 
 # --- Helpers for time-based snapshot fixtures ---

--- a/packages/nauro/tests/test_log_diff.py
+++ b/packages/nauro/tests/test_log_diff.py
@@ -246,9 +246,9 @@ class TestDiffSinceLastSession:
 
 class TestLogCommand:
     def test_log_shows_snapshots(self, tmp_path: Path, monkeypatch):
-        from nauro.store.registry import register_project
+        from nauro.store.registry import register_project_v2
 
-        store = register_project("myproj", [tmp_path])
+        _pid, store = register_project_v2("myproj", [tmp_path])
         scaffold_project_store("myproj", store)
         monkeypatch.chdir(tmp_path)
 
@@ -263,9 +263,9 @@ class TestLogCommand:
         assert "second sync" in result.output
 
     def test_log_limit(self, tmp_path: Path, monkeypatch):
-        from nauro.store.registry import register_project
+        from nauro.store.registry import register_project_v2
 
-        store = register_project("myproj", [tmp_path])
+        _pid, store = register_project_v2("myproj", [tmp_path])
         scaffold_project_store("myproj", store)
         monkeypatch.chdir(tmp_path)
 
@@ -279,9 +279,9 @@ class TestLogCommand:
         assert "v001" not in result.output
 
     def test_log_full(self, tmp_path: Path, monkeypatch):
-        from nauro.store.registry import register_project
+        from nauro.store.registry import register_project_v2
 
-        store = register_project("myproj", [tmp_path])
+        _pid, store = register_project_v2("myproj", [tmp_path])
         scaffold_project_store("myproj", store)
         monkeypatch.chdir(tmp_path)
 
@@ -295,9 +295,9 @@ class TestLogCommand:
         assert "decisions/" in result.output
 
     def test_log_no_snapshots(self, tmp_path: Path, monkeypatch):
-        from nauro.store.registry import register_project
+        from nauro.store.registry import register_project_v2
 
-        store = register_project("myproj", [tmp_path])
+        _pid, store = register_project_v2("myproj", [tmp_path])
         scaffold_project_store("myproj", store)
         monkeypatch.chdir(tmp_path)
 
@@ -319,9 +319,9 @@ class TestLogCommand:
 class TestDiffCommand:
     def test_diff_no_args(self, tmp_path: Path, monkeypatch):
         """nauro diff-since-last-session — diff since last session."""
-        from nauro.store.registry import register_project
+        from nauro.store.registry import register_project_v2
 
-        store = register_project("myproj", [tmp_path])
+        _pid, store = register_project_v2("myproj", [tmp_path])
         scaffold_project_store("myproj", store)
         monkeypatch.chdir(tmp_path)
 
@@ -344,9 +344,9 @@ class TestDiffCommand:
 
     def test_diff_not_enough_snapshots(self, tmp_path: Path, monkeypatch):
         """nauro diff-since-last-session with < 2 snapshots shows helpful message."""
-        from nauro.store.registry import register_project
+        from nauro.store.registry import register_project_v2
 
-        store = register_project("myproj", [tmp_path])
+        _pid, store = register_project_v2("myproj", [tmp_path])
         scaffold_project_store("myproj", store)
         monkeypatch.chdir(tmp_path)
 

--- a/packages/nauro/tests/test_note.py
+++ b/packages/nauro/tests/test_note.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typer.testing import CliRunner
 
 from nauro.cli.main import app
-from nauro.store.registry import register_project
+from nauro.store.registry import register_project_v2
 from nauro.templates.agents_md import generate_agents_md
 from nauro.templates.scaffolds import scaffold_project_store
 
@@ -21,7 +21,7 @@ def test_note_decision_refreshes_agents_md(tmp_path: Path, monkeypatch):
     """A decision logged via `nauro note` shows up in the repo's AGENTS.md."""
     repo = tmp_path / "repo"
     repo.mkdir()
-    store = register_project("myproj", [repo])
+    _pid, store = register_project_v2("myproj", [repo])
     scaffold_project_store("myproj", store)
     monkeypatch.chdir(repo)
 
@@ -45,7 +45,7 @@ def test_note_question_refreshes_agents_md(tmp_path: Path, monkeypatch):
     """A question logged via `nauro note` shows up under Open Questions."""
     repo = tmp_path / "repo"
     repo.mkdir()
-    store = register_project("myproj", [repo])
+    _pid, store = register_project_v2("myproj", [repo])
     scaffold_project_store("myproj", store)
     monkeypatch.chdir(repo)
 
@@ -65,7 +65,7 @@ def test_note_decision_refreshes_all_associated_repos(tmp_path: Path, monkeypatc
     repo2 = tmp_path / "repo2"
     repo1.mkdir()
     repo2.mkdir()
-    store = register_project("myproj", [repo1, repo2])
+    _pid, store = register_project_v2("myproj", [repo1, repo2])
     scaffold_project_store("myproj", store)
     monkeypatch.chdir(repo1)
 
@@ -82,7 +82,7 @@ def test_note_preserves_unmanaged_agents_md(tmp_path: Path, monkeypatch):
     """An AGENTS.md without Nauro's markers stays byte-identical across note."""
     repo = tmp_path / "repo"
     repo.mkdir()
-    store = register_project("myproj", [repo])
+    _pid, store = register_project_v2("myproj", [repo])
     scaffold_project_store("myproj", store)
     monkeypatch.chdir(repo)
 
@@ -103,7 +103,7 @@ def test_note_refreshes_nauro_generated_agents_md(tmp_path: Path, monkeypatch):
     """A Nauro-generated AGENTS.md is still refreshed; `# Manual` survives."""
     repo = tmp_path / "repo"
     repo.mkdir()
-    store = register_project("myproj", [repo])
+    _pid, store = register_project_v2("myproj", [repo])
     scaffold_project_store("myproj", store)
     monkeypatch.chdir(repo)
 
@@ -130,7 +130,7 @@ def test_note_warns_about_missing_repo_paths(tmp_path: Path, monkeypatch):
     live_repo = tmp_path / "live"
     stale_repo = tmp_path / "stale"  # never mkdir'd
     live_repo.mkdir()
-    store = register_project("myproj", [live_repo, stale_repo])
+    _pid, store = register_project_v2("myproj", [live_repo, stale_repo])
     scaffold_project_store("myproj", store)
     monkeypatch.chdir(live_repo)
 
@@ -147,7 +147,7 @@ def test_note_warns_about_missing_repo_paths(tmp_path: Path, monkeypatch):
 
 def test_note_question_with_rationale_warns(tmp_path: Path, monkeypatch):
     """--rationale on the question path is ignored, and the user is told so."""
-    store = register_project("myproj", [tmp_path])
+    _pid, store = register_project_v2("myproj", [tmp_path])
     scaffold_project_store("myproj", store)
     monkeypatch.chdir(tmp_path)
 
@@ -162,7 +162,7 @@ def test_note_question_with_rationale_warns(tmp_path: Path, monkeypatch):
 
 def test_note_question_with_confidence_warns(tmp_path: Path, monkeypatch):
     """A non-default --confidence on the question path triggers the warning."""
-    store = register_project("myproj", [tmp_path])
+    _pid, store = register_project_v2("myproj", [tmp_path])
     scaffold_project_store("myproj", store)
     monkeypatch.chdir(tmp_path)
 
@@ -173,7 +173,7 @@ def test_note_question_with_confidence_warns(tmp_path: Path, monkeypatch):
 
 def test_note_both_question_and_decision_warns(tmp_path: Path, monkeypatch):
     """--question and --decision together warn that --question wins."""
-    store = register_project("myproj", [tmp_path])
+    _pid, store = register_project_v2("myproj", [tmp_path])
     scaffold_project_store("myproj", store)
     monkeypatch.chdir(tmp_path)
 
@@ -185,7 +185,7 @@ def test_note_both_question_and_decision_warns(tmp_path: Path, monkeypatch):
 
 def test_note_plain_decision_no_warning(tmp_path: Path, monkeypatch):
     """The decision path with --rationale emits no flag-usage warning."""
-    store = register_project("myproj", [tmp_path])
+    _pid, store = register_project_v2("myproj", [tmp_path])
     scaffold_project_store("myproj", store)
     monkeypatch.chdir(tmp_path)
 
@@ -197,7 +197,7 @@ def test_note_plain_decision_no_warning(tmp_path: Path, monkeypatch):
 
 def test_note_empty_string_rejects(tmp_path: Path, monkeypatch):
     """Empty text is rejected before any store write."""
-    store = register_project("myproj", [tmp_path])
+    _pid, store = register_project_v2("myproj", [tmp_path])
     scaffold_project_store("myproj", store)
     monkeypatch.chdir(tmp_path)
 
@@ -211,7 +211,7 @@ def test_note_empty_string_rejects(tmp_path: Path, monkeypatch):
 
 def test_note_whitespace_only_rejects(tmp_path: Path, monkeypatch):
     """Whitespace-only text is rejected before any store write."""
-    store = register_project("myproj", [tmp_path])
+    _pid, store = register_project_v2("myproj", [tmp_path])
     scaffold_project_store("myproj", store)
     monkeypatch.chdir(tmp_path)
 
@@ -225,7 +225,7 @@ def test_note_whitespace_only_rejects(tmp_path: Path, monkeypatch):
 
 def test_note_nonempty_text_succeeds(tmp_path: Path, monkeypatch):
     """Non-empty text records a decision — the guard does not block valid input."""
-    store = register_project("myproj", [tmp_path])
+    _pid, store = register_project_v2("myproj", [tmp_path])
     scaffold_project_store("myproj", store)
     monkeypatch.chdir(tmp_path)
 

--- a/packages/nauro/tests/test_questions_migrate.py
+++ b/packages/nauro/tests/test_questions_migrate.py
@@ -13,7 +13,7 @@ from nauro_core.constants import OPEN_QUESTIONS_MD
 from typer.testing import CliRunner
 
 from nauro.cli.main import app
-from nauro.store.registry import register_project
+from nauro.store.registry import register_project_v2
 from nauro.templates.scaffolds import scaffold_project_store
 
 runner = CliRunner()
@@ -29,7 +29,7 @@ _LEGACY_FILE = (
 def _setup_project(tmp_path: Path, monkeypatch, questions: str) -> Path:
     repo = tmp_path / "repo"
     repo.mkdir()
-    store = register_project("myproj", [repo])
+    _pid, store = register_project_v2("myproj", [repo])
     scaffold_project_store("myproj", store)
     (store / OPEN_QUESTIONS_MD).write_text(questions)
     monkeypatch.chdir(repo)
@@ -82,7 +82,7 @@ def test_migrate_refreshes_agents_md(tmp_path: Path, monkeypatch):
     """Open questions surface in AGENTS.md, so the migrated ids must too."""
     repo = tmp_path / "repo"
     repo.mkdir()
-    store = register_project("myproj", [repo])
+    _pid, store = register_project_v2("myproj", [repo])
     scaffold_project_store("myproj", store)
     (store / OPEN_QUESTIONS_MD).write_text(
         "# Open Questions\n\n- [2026-05-12 20:18 UTC] surfaced question\n"
@@ -124,7 +124,7 @@ def test_migrate_continues_past_existing_q_ids(tmp_path: Path, monkeypatch):
 def test_migrate_unknown_project_rejected(tmp_path: Path, monkeypatch):
     repo = tmp_path / "repo"
     repo.mkdir()
-    store = register_project("myproj", [repo])
+    _pid, store = register_project_v2("myproj", [repo])
     scaffold_project_store("myproj", store)
     monkeypatch.chdir(repo)
 

--- a/packages/nauro/tests/test_read_encoding.py
+++ b/packages/nauro/tests/test_read_encoding.py
@@ -18,7 +18,7 @@ from nauro.demo import create_demo_project
 from nauro.mcp.tools import tool_get_context, tool_get_raw_file
 from nauro.store.filesystem_store import FilesystemStore
 from nauro.store.reader import _list_decisions, read_text_lenient
-from nauro.store.registry import register_project
+from nauro.store.registry import register_project_v2
 from nauro.store.snapshot import capture_snapshot
 from nauro.templates.agents_md import (
     parse_preserved_sections,
@@ -115,13 +115,13 @@ def test_regenerate_survives_poisoned_existing_agents_md(tmp_path: Path):
     # is required to exercise the rewrite.
     repo = tmp_path / "repo"
     repo.mkdir()
-    store = register_project("myproj", [repo])
+    pid, store = register_project_v2("myproj", [repo])
     scaffold_project_store("myproj", store)
 
     agents_md = repo / "AGENTS.md"
     agents_md.write_bytes(b"# AGENTS.md\n\nOld auto content\n\n# Manual\n\nKeep caf\xe9 note\n")
 
-    updated = regenerate_agents_md_for_project("myproj", store, overwrite_unmanaged=True)
+    updated = regenerate_agents_md_for_project(pid, store, overwrite_unmanaged=True)
 
     assert repo in updated
     regenerated = read_text_lenient(agents_md)
@@ -147,10 +147,10 @@ def test_scaffold_writes_utf8_bytes(tmp_path: Path):
 def test_agents_md_write_emits_utf8_bytes(tmp_path: Path):
     repo = tmp_path / "repo"
     repo.mkdir()
-    store = register_project("myproj", [repo])
+    pid, store = register_project_v2("myproj", [repo])
     scaffold_project_store("myproj", store)
 
-    regenerate_agents_md_for_project("myproj", store)
+    regenerate_agents_md_for_project(pid, store)
 
     agents_md = repo / "AGENTS.md"
     raw = agents_md.read_bytes()

--- a/packages/nauro/tests/test_registry.py
+++ b/packages/nauro/tests/test_registry.py
@@ -10,87 +10,40 @@ from nauro.store import registry
 from nauro.store.repo_config import load_repo_config
 from nauro.templates.scaffolds import scaffold_project_store
 
-# --- Registry CRUD ---
-
-
-def test_load_registry_empty(tmp_path, monkeypatch):
-    data = registry.load_registry()
-    assert data == {"projects": {}, "schema_version": 1}
-
-
-def test_save_and_load_registry(tmp_path, monkeypatch):
-    data = {"projects": {"myproj": {"repo_paths": ["/tmp/repo"]}}}
-    registry.save_registry(data)
-    loaded = registry.load_registry()
-    assert loaded["projects"] == data["projects"]
-    assert loaded["schema_version"] == 1
-
-
-def test_register_project(tmp_path, monkeypatch):
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    store_path = registry.register_project("proj1", [repo])
-    assert store_path.exists()
-    assert store_path.name == "proj1"
-    data = registry.load_registry()
-    assert "proj1" in data["projects"]
-    assert str(repo.resolve()) in data["projects"]["proj1"]["repo_paths"]
-
-
-def test_register_duplicate_raises(tmp_path, monkeypatch):
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    registry.register_project("dup", [repo])
-    with pytest.raises(ValueError):
-        registry.register_project("dup", [repo])
-
-
-# --- resolve_project ---
-
-
-def test_resolve_project_exact(tmp_path, monkeypatch):
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    registry.register_project("proj", [repo])
-    assert registry.resolve_project(repo) == "proj"
-
-
-def test_resolve_project_nested(tmp_path, monkeypatch):
-    repo = tmp_path / "repo"
-    nested = repo / "src" / "pkg"
-    nested.mkdir(parents=True)
-    registry.register_project("proj", [repo])
-    assert registry.resolve_project(nested) == "proj"
-
-
-def test_resolve_project_no_match(tmp_path, monkeypatch):
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    registry.register_project("proj", [repo])
-    other = tmp_path / "other"
-    other.mkdir()
-    assert registry.resolve_project(other) is None
-
-
 # --- suggest_project_for_path ---
 
 
 def test_suggest_project_matching_dirname(tmp_path, monkeypatch):
     repo = tmp_path / "myapp"
     repo.mkdir()
-    registry.register_project("myapp", [repo])
+    pid, _store = registry.register_project_v2("myapp", [repo])
     # Different path, same directory name
     other = tmp_path / "clones" / "myapp"
     other.mkdir(parents=True)
-    assert registry.suggest_project_for_path(other) == "myapp"
+    suggested_pid, entry = registry.suggest_project_for_path(other)
+    assert suggested_pid == pid
+    assert entry["name"] == "myapp"
 
 
 def test_suggest_project_no_match(tmp_path, monkeypatch):
     repo = tmp_path / "myapp"
     repo.mkdir()
-    registry.register_project("myapp", [repo])
+    registry.register_project_v2("myapp", [repo])
     other = tmp_path / "unrelated"
     other.mkdir()
+    assert registry.suggest_project_for_path(other) is None
+
+
+def test_suggest_project_ambiguous_name_yields_none(tmp_path, monkeypatch):
+    """Duplicate v2 names produce no suggestion: the hinted command refuses them."""
+    repo_a = tmp_path / "a" / "myapp"
+    repo_a.mkdir(parents=True)
+    registry.register_project_v2("myapp", [repo_a])
+    repo_b = tmp_path / "b" / "myapp"
+    repo_b.mkdir(parents=True)
+    registry.register_project_v2("myapp", [repo_b])
+    other = tmp_path / "clones" / "myapp"
+    other.mkdir(parents=True)
     assert registry.suggest_project_for_path(other) is None
 
 
@@ -294,16 +247,9 @@ def test_init_add_repo_to_existing_writes_per_repo_config(tmp_path, monkeypatch)
 # --- Corrupt-shape tolerance ---
 
 
-def test_load_registry_non_dict_returns_empty(tmp_path, monkeypatch):
+def test_load_registry_v2_non_dict_returns_empty(tmp_path, monkeypatch):
     """A registry.json that parses to a non-dict (valid JSON, wrong shape)
     falls back to the empty-registry default rather than crashing downstream."""
-    (tmp_path / "registry.json").write_text("[]")
-    data = registry.load_registry()
-    assert data == {"projects": {}, "schema_version": 1}
-
-
-def test_load_registry_v2_non_dict_returns_empty(tmp_path, monkeypatch):
-    """The v2 loader applies the same non-dict guard as the v1 loader."""
     (tmp_path / "registry.json").write_text("[]")
     data = registry.load_registry_v2()
     assert data == {"projects": {}, "schema_version": 2}

--- a/packages/nauro/tests/test_registry_v2.py
+++ b/packages/nauro/tests/test_registry_v2.py
@@ -22,7 +22,6 @@ from nauro.store.registry import (
     bind_project_store_v2,
     is_cloud_project,
     load_registry_v2,
-    register_project,
     register_project_v2,
     resolve_registered_store_path_v2,
     save_registry_v2,
@@ -294,12 +293,20 @@ def test_v2_save_stamps_schema_version(tmp_path, monkeypatch):
     assert raw["schema_version"] == REGISTRY_SCHEMA_VERSION_V2
 
 
+def _write_v1_registry(tmp_path, projects: dict) -> None:
+    """Write a v1-shaped (name-keyed, schema_version 1) registry.json.
+
+    The v1 writer is gone; the reject and degradation pins below seed the
+    retired shape directly.
+    """
+    (tmp_path / REGISTRY_FILENAME).write_text(
+        json.dumps({"schema_version": 1, "projects": projects}) + "\n"
+    )
+
+
 def test_v2_loader_rejects_v1_with_migration_hint(tmp_path, monkeypatch):
     """A v1 registry on disk surfaces the manual-migration message."""
-    # Write a v1 registry via the legacy writer.
-    registry.save_registry(
-        {"projects": {"oldproj": {"repo_paths": ["/tmp/old"]}}, "schema_version": 1}
-    )
+    _write_v1_registry(tmp_path, {"oldproj": {"repo_paths": ["/tmp/old"]}})
     with pytest.raises(RegistrySchemaError) as exc:
         load_registry_v2()
     msg = str(exc.value)
@@ -323,8 +330,8 @@ def test_v2_save_rejects_non_v2_schema_version(tmp_path, monkeypatch):
 
 class TestIsCloudProject:
     """Gate predicate for auto-sync and the status report. The presign
-    transport has no path for v1 entries (no server-side ULID) or v2
-    local-mode entries (not remote-backed), so both must return False."""
+    transport has no path for unknown ids or local-mode entries (not
+    remote-backed), so both must return False."""
 
     def test_returns_true_for_v2_cloud(self, tmp_path, monkeypatch):
         pid = "01KQ6AZGNA0B3QBF67NBXP3S45"
@@ -350,6 +357,8 @@ class TestIsCloudProject:
     def test_returns_false_for_missing_entry(self, tmp_path, monkeypatch):
         assert is_cloud_project("01KMISSING00000000000000000") is False
 
-    def test_returns_false_for_v1_name(self, tmp_path, monkeypatch):
-        register_project("v1name", [tmp_path])
+    def test_returns_false_for_v1_shaped_registry(self, tmp_path, monkeypatch):
+        """A v1-shaped registry.json reads as an empty v2 registry, so the
+        gate degrades to False rather than crashing."""
+        _write_v1_registry(tmp_path, {"v1name": {"repo_paths": [str(tmp_path)]}})
         assert is_cloud_project("v1name") is False

--- a/packages/nauro/tests/test_resolution_v2.py
+++ b/packages/nauro/tests/test_resolution_v2.py
@@ -2,9 +2,9 @@
 
 The CLI's ``resolve_target_project`` and the local MCP servers'
 ``_resolve_store`` share the same priority order: explicit ``--project``
-flag → cwd ``.nauro/config.json`` walk-up → v1 legacy fallback. These
-tests pin that behavior end-to-end so a regression cannot silently flip
-the precedence.
+flag → cwd ``.nauro/config.json`` walk-up → registry matched by repo
+path. These tests pin that behavior end-to-end so a regression cannot
+silently flip the precedence.
 
 Also covers the integration scenario where two projects coexist (one
 cloud-style preconfigured, one freshly created via `nauro init`) and
@@ -467,23 +467,34 @@ def test_default_store_with_symlinked_component_is_typed_invalid(tmp_path, monke
     assert result.reason_code == "connected_record_invalid"
 
 
-def test_v1_project_with_missing_store_yields_no_project(tmp_path, monkeypatch):
-    """A legacy name-keyed project whose store directory is gone falls
-    through to the no-project outcome — never a path that read tools would
-    treat as an empty store and write tools would silently recreate.
-    """
-    import shutil
+def test_v1_shaped_registry_resolves_to_no_project(tmp_path, monkeypatch):
+    """A retired v1-shaped (name-keyed) registry.json resolves to nothing.
 
-    from nauro.store.registry import register_project
+    v1 registry support was removed deliberately: the shape reads as an
+    empty v2 registry, so a matching repo path falls through to the
+    no-project outcome instead of resolving or crashing.
+    """
     from nauro.store.resolution import resolve_from_cwd
 
     repo = tmp_path / "v1repo"
     repo.mkdir()
-    store = register_project("legacy", [repo])
-    if store.exists():
-        shutil.rmtree(store)
+    _write_registry(tmp_path, 1, {"legacy": {"repo_paths": [str(repo.resolve())]}})
 
     assert resolve_from_cwd(repo) is None
+
+
+def test_v1_shaped_registry_reaches_welcome_screen(tmp_path, monkeypatch):
+    """The stdio transport surfaces a v1-shaped registry as the welcome
+    screen (typed NoProjectError), never a crash."""
+    from nauro.store.resolution import NoProjectError
+
+    repo = tmp_path / "v1repo"
+    repo.mkdir()
+    _write_registry(tmp_path, 1, {"legacy": {"repo_paths": [str(repo.resolve())]}})
+    monkeypatch.chdir(repo)
+
+    with pytest.raises(NoProjectError, match="No Nauro project found"):
+        _resolve_store(None, None)
 
 
 @pytest.mark.parametrize("raw_store_path", [42, "", None])
@@ -627,22 +638,6 @@ def test_resolve_from_cwd_v2_registry_by_path_tier(tmp_path, monkeypatch):
     assert resolution.display_name == "byname"
 
 
-def test_resolve_from_cwd_v1_legacy_tier(tmp_path, monkeypatch):
-    """Tier 3: neither a repo config nor a v2 path match; the v1 registry wins."""
-    from nauro.store.resolution import resolve_from_cwd
-
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    store = registry.register_project("legacy", [repo])
-
-    resolution = resolve_from_cwd(repo)
-
-    assert resolution is not None
-    assert resolution.store_path == store
-    assert resolution.project_id == "legacy"
-    assert resolution.display_name == "legacy"
-
-
 def test_resolve_from_cwd_repo_config_precedes_v2_registry(tmp_path, monkeypatch):
     """Tier 1 wins over tier 2: the repo config id is honored even when the same
     cwd is also a registered v2 repo path pointing at a different project."""
@@ -705,7 +700,7 @@ def test_resolve_from_cwd_declines_symlinked_nauro_dir(tmp_path, monkeypatch):
 
 
 def test_resolve_from_cwd_none_when_nothing_matches(tmp_path, monkeypatch):
-    """No repo config, no v2 path, no v1 match: the waterfall returns None."""
+    """No repo config and no registry path match: the waterfall returns None."""
     from nauro.store.resolution import resolve_from_cwd
 
     isolated = tmp_path / "isolated"
@@ -779,13 +774,9 @@ def test_two_projects_each_resolve_to_own_store(tmp_path, monkeypatch):
 
 # ── available-project listing excludes blank tokens ──────────────────────────
 #
-# The listing unions v1 names (registry ``projects`` keys) with v2 names
-# (``name`` field of each v2 entry). A blank token can enter from either side:
-# a v2 entry missing ``name`` resolves to "", and a malformed v1 entry can have
-# a "" key. The old ``set(v1) | set(v2) - {""}`` grouping only stripped the
-# blank from the v2 operand (``-`` binds tighter than ``|``), so a blank on the
-# v1 side leaked into "Available projects:". These tests drive a blank in on
-# the v1 side so they fail against the old grouping and pass against the fix.
+# The listing collects the ``name`` field of each registry entry; an entry
+# missing ``name`` resolves to "" and must not leak an empty token into
+# "Available projects:".
 
 
 def _write_registry(tmp_path, schema_version: int, projects: dict) -> None:
@@ -795,20 +786,17 @@ def _write_registry(tmp_path, schema_version: int, projects: dict) -> None:
     )
 
 
-def test_available_project_names_excludes_blank_from_combined_set(tmp_path, monkeypatch):
-    """A blank entry on the v1 side must not leak into the available list.
-
-    Pins the operator-precedence fix: the blank is subtracted from the
-    *combined* v1 ∪ v2 set, not just the v2 operand.
-    """
+def test_available_project_names_excludes_blank(tmp_path, monkeypatch):
+    """An entry missing its ``name`` field must not leak into the listing."""
     from nauro.cli.utils import _available_project_names
 
     _write_registry(
         tmp_path,
-        1,
+        2,
         {
-            "alpha": {"repo_paths": []},
-            "": {"repo_paths": []},  # malformed blank-named v1 entry
+            "01KQ6AZGNA0B3QBF67NBXP3S45": {"name": "alpha", "mode": "local", "repo_paths": []},
+            # malformed entry with no name → blank token candidate
+            "01KQ6AZGNA0B3QBF67NBXP3S46": {"mode": "local", "repo_paths": []},
         },
     )
     monkeypatch.chdir(tmp_path)
@@ -819,17 +807,14 @@ def test_available_project_names_excludes_blank_from_combined_set(tmp_path, monk
 
 
 def test_unknown_project_listing_has_no_blank_token(tmp_path, monkeypatch, capsys):
-    """The ``--project`` error path lists only real names, never a blank.
-
-    A blank-named entry previously leaked an empty token into
-    "Available projects:" because ``-`` bound tighter than ``|``.
-    """
+    """The ``--project`` error path lists only real names, never a blank."""
     _write_registry(
         tmp_path,
-        1,
+        2,
         {
-            "alpha": {"repo_paths": []},
-            "": {"repo_paths": []},  # malformed blank-named v1 entry
+            "01KQ6AZGNA0B3QBF67NBXP3S45": {"name": "alpha", "mode": "local", "repo_paths": []},
+            # malformed entry with no name → blank token candidate
+            "01KQ6AZGNA0B3QBF67NBXP3S46": {"mode": "local", "repo_paths": []},
         },
     )
     isolated = tmp_path / "isolated"
@@ -847,11 +832,11 @@ def test_unknown_project_listing_has_no_blank_token(tmp_path, monkeypatch, capsy
     assert "" not in parsed
 
 
-# ── _resolve_project_entry: v2-first, v1-fallback, repo_paths guard ──────────
+# ── _resolve_project_entry: id-keyed lookup + repo_paths guard ────────────────
 
 
-def test_resolve_project_entry_v2_first(tmp_path, monkeypatch):
-    """A v2 entry is resolved by its id-keyed project_key."""
+def test_resolve_project_entry_by_id(tmp_path, monkeypatch):
+    """An entry is resolved by its id-keyed project_key."""
     from nauro.cli.utils import _resolve_project_entry
 
     repo = tmp_path / "repo"
@@ -864,29 +849,32 @@ def test_resolve_project_entry_v2_first(tmp_path, monkeypatch):
     assert entry["repo_paths"] == [str(repo.resolve())]
 
 
-def test_resolve_project_entry_v1_fallback(tmp_path, monkeypatch):
-    """A v1 (name-keyed legacy) entry is resolved when no v2 entry matches."""
+def test_resolve_project_entry_v1_shape_does_not_resolve(tmp_path, monkeypatch, capsys):
+    """A retired v1 name-keyed entry no longer resolves; the caller gets the
+    no-repos exit instead of a legacy fallback."""
     from nauro.cli.utils import _resolve_project_entry
 
     repo = tmp_path / "repo"
     repo.mkdir()
-    registry.register_project("beta", [repo])
+    _write_registry(tmp_path, 1, {"beta": {"repo_paths": [str(repo.resolve())]}})
 
-    # The v2 lookup misses (no id-keyed entry); the name-keyed v1 entry wins.
-    entry = _resolve_project_entry("beta", "01MISSINGV2KEY0000000000")
+    with pytest.raises(typer.Exit) as excinfo:
+        _resolve_project_entry("beta", "01MISSINGV2KEY0000000000")
+    assert excinfo.value.exit_code == 1
 
-    assert entry == registry.get_project("beta")
-    assert entry["repo_paths"] == [str(repo.resolve())]
+    err = capsys.readouterr().err
+    assert "Project 'beta' has no associated repos." in err
 
 
 def test_resolve_project_entry_no_repos_exits(tmp_path, monkeypatch, capsys):
     """An entry with no repo_paths exits 1 with the exact message on stderr."""
     from nauro.cli.utils import _resolve_project_entry
 
-    _write_registry(tmp_path, 1, {"gamma": {"repo_paths": []}})
+    pid = "01KQ6AZGNA0B3QBF67NBXP3S45"
+    _write_registry(tmp_path, 2, {pid: {"name": "gamma", "mode": "local", "repo_paths": []}})
 
     with pytest.raises(typer.Exit) as excinfo:
-        _resolve_project_entry("gamma", "gamma")
+        _resolve_project_entry("gamma", pid)
     assert excinfo.value.exit_code == 1
 
     err = capsys.readouterr().err

--- a/packages/nauro/tests/test_setup.py
+++ b/packages/nauro/tests/test_setup.py
@@ -14,7 +14,7 @@ from nauro.cli.integrations.json_mcp import _configure_mcp, recorded_mcp_command
 from nauro.cli.integrations.legacy import CLAUDE_MD_END, CLAUDE_MD_START
 from nauro.cli.integrations.outcomes import CodexConfigKind, JsonMcpKind
 from nauro.cli.main import app
-from nauro.store.registry import register_project, register_project_v2
+from nauro.store.registry import register_project_v2
 from nauro.store.repo_config import save_repo_config
 from nauro.templates.scaffolds import scaffold_project_store
 
@@ -26,7 +26,7 @@ def _setup_project(tmp_path: Path, monkeypatch, repo_paths: list[Path] | None = 
     if repo_paths is None:
         repo_paths = [tmp_path / "repo"]
         repo_paths[0].mkdir()
-    store = register_project("testproj", repo_paths)
+    _pid, store = register_project_v2("testproj", repo_paths)
     scaffold_project_store("testproj", store)
     monkeypatch.chdir(repo_paths[0])
     return repo_paths
@@ -288,9 +288,9 @@ class TestProjectResolution:
         repo_a.mkdir()
         repo_b.mkdir()
 
-        store_a = register_project("proj-a", [repo_a])
+        _pid_a, store_a = register_project_v2("proj-a", [repo_a])
         scaffold_project_store("proj-a", store_a)
-        store_b = register_project("proj-b", [repo_b])
+        _pid_b, store_b = register_project_v2("proj-b", [repo_b])
         scaffold_project_store("proj-b", store_b)
 
         monkeypatch.chdir(repo_a)

--- a/packages/nauro/tests/test_snapshot_corruption.py
+++ b/packages/nauro/tests/test_snapshot_corruption.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typer.testing import CliRunner
 
 from nauro.cli.main import app
-from nauro.store.registry import register_project
+from nauro.store.registry import register_project_v2
 from nauro.store.snapshot import (
     capture_snapshot,
     find_snapshot_near_date,
@@ -98,8 +98,7 @@ def test_bad_timestamp_snapshot_skipped_by_date_search_and_prune(tmp_path: Path)
 
 
 def test_nauro_log_does_not_crash_on_corrupt_snapshot(tmp_path: Path, monkeypatch):
-    register_project("p", [tmp_path])
-    store_path = tmp_path / "projects" / "p"
+    _pid, store_path = register_project_v2("p", [tmp_path])
     scaffold_project_store("p", store_path)
     capture_snapshot(store_path, trigger="ok")
     _snap(store_path, 2).write_text("{ broken")

--- a/packages/nauro/tests/test_stdio_renderer_wrap.py
+++ b/packages/nauro/tests/test_stdio_renderer_wrap.py
@@ -32,7 +32,7 @@ from nauro.mcp.stdio_server import (
     update_state,
 )
 from nauro.store.filesystem_store import FilesystemStore
-from nauro.store.registry import register_project
+from nauro.store.registry import register_project_v2
 from nauro.store.repo_config import save_repo_config
 from nauro.templates.scaffolds import scaffold_project_store
 from tests._writer_compat import append_decision
@@ -41,7 +41,7 @@ from tests._writer_compat import append_decision
 @pytest.fixture
 def seeded_store(tmp_path: Path, monkeypatch) -> Path:
     """Pre-scaffolded project store with one decision and one question."""
-    store_path = register_project("blockshape", [tmp_path / "repo"])
+    _pid, store_path = register_project_v2("blockshape", [tmp_path / "repo"])
     scaffold_project_store("blockshape", store_path)
     (store_path / "stack.md").write_text(
         "# Stack\n- **Python 3.11** — primary language\n- **FastAPI** — HTTP framework\n"

--- a/packages/nauro/tests/test_stdio_server.py
+++ b/packages/nauro/tests/test_stdio_server.py
@@ -28,7 +28,7 @@ from nauro.mcp.stdio_server import (
     update_state,
 )
 from nauro.store.filesystem_store import FilesystemStore
-from nauro.store.registry import register_project
+from nauro.store.registry import register_project_v2
 from nauro.templates.scaffolds import scaffold_project_store
 from tests._writer_compat import append_decision
 
@@ -53,7 +53,7 @@ def _append_question(store_path: Path, question: str) -> None:
 @pytest.fixture
 def store(tmp_path: Path, monkeypatch) -> Path:
     """Pre-scaffolded project store with known content."""
-    store_path = register_project("testproj", [tmp_path / "repo"])
+    _pid, store_path = register_project_v2("testproj", [tmp_path / "repo"])
     scaffold_project_store("testproj", store_path)
 
     (store_path / "stack.md").write_text(
@@ -723,7 +723,8 @@ class TestPullOnStartup:
 
         with patch("nauro.sync.hooks.pull_before_session", return_value=3) as mock_pull:
             _pull_on_startup()
-            mock_pull.assert_called_once_with("testproj", store)
+            # The id-keyed store directory name is the project id.
+            mock_pull.assert_called_once_with(store.name, store)
 
     def test_does_not_raise_on_pull_failure(self, store: Path, monkeypatch, tmp_path):
         """Server startup continues even if hooks throws."""

--- a/packages/nauro/tests/test_stdio_server.py
+++ b/packages/nauro/tests/test_stdio_server.py
@@ -77,8 +77,8 @@ class TestResolveStore:
         assert result == store
 
     def test_raises_on_unknown_project(self, store: Path):
-        # Unknown name in v2 falls through to v1 legacy; if also missing
-        # there, ProjectNotFoundError carries the "registry" anchor.
+        # An unknown name matches nothing in the registry;
+        # ProjectNotFoundError carries the "registry" anchor.
         from nauro.store.resolution import ProjectNotFoundError
 
         with pytest.raises(ProjectNotFoundError, match="registry"):

--- a/packages/nauro/tests/test_store.py
+++ b/packages/nauro/tests/test_store.py
@@ -765,9 +765,9 @@ def _minimal_v2_decision(path: Path, num: int, title: str) -> None:
 
 
 def test_note_decision_cli(tmp_path: Path, monkeypatch):
-    from nauro.store.registry import register_project
+    from nauro.store.registry import register_project_v2
 
-    store = register_project("myproj", [tmp_path])
+    _pid, store = register_project_v2("myproj", [tmp_path])
     scaffold_project_store("myproj", store)
     monkeypatch.chdir(tmp_path)
 
@@ -778,9 +778,9 @@ def test_note_decision_cli(tmp_path: Path, monkeypatch):
 
 
 def test_note_question_auto_detect(tmp_path: Path, monkeypatch):
-    from nauro.store.registry import register_project
+    from nauro.store.registry import register_project_v2
 
-    store = register_project("myproj", [tmp_path])
+    _pid, store = register_project_v2("myproj", [tmp_path])
     scaffold_project_store("myproj", store)
     monkeypatch.chdir(tmp_path)
 
@@ -790,9 +790,9 @@ def test_note_question_auto_detect(tmp_path: Path, monkeypatch):
 
 
 def test_note_question_flag(tmp_path: Path, monkeypatch):
-    from nauro.store.registry import register_project
+    from nauro.store.registry import register_project_v2
 
-    store = register_project("myproj", [tmp_path])
+    _pid, store = register_project_v2("myproj", [tmp_path])
     scaffold_project_store("myproj", store)
     monkeypatch.chdir(tmp_path)
 
@@ -813,9 +813,9 @@ def test_note_no_project(tmp_path: Path, monkeypatch):
 
 
 def test_sync_cli(tmp_path: Path, monkeypatch):
-    from nauro.store.registry import register_project
+    from nauro.store.registry import register_project_v2
 
-    store = register_project("myproj", [tmp_path])
+    _pid, store = register_project_v2("myproj", [tmp_path])
     scaffold_project_store("myproj", store)
     monkeypatch.chdir(tmp_path)
 
@@ -826,9 +826,9 @@ def test_sync_cli(tmp_path: Path, monkeypatch):
 
 
 def test_sync_with_message(tmp_path: Path, monkeypatch):
-    from nauro.store.registry import register_project
+    from nauro.store.registry import register_project_v2
 
-    store = register_project("myproj", [tmp_path])
+    _pid, store = register_project_v2("myproj", [tmp_path])
     scaffold_project_store("myproj", store)
     monkeypatch.chdir(tmp_path)
 

--- a/packages/nauro/tests/test_store_write_lock.py
+++ b/packages/nauro/tests/test_store_write_lock.py
@@ -33,7 +33,7 @@ from typer.testing import CliRunner
 from nauro.cli.main import app
 from nauro.store.decision_lock import decision_write_lock
 from nauro.store.filesystem_store import FilesystemStore
-from nauro.store.registry import register_project
+from nauro.store.registry import register_project_v2
 from nauro.store.store_lock import RMW_LOCK_SUFFIX, rmw_lock_path, store_write_lock
 from nauro.templates.scaffolds import scaffold_project_store
 
@@ -44,7 +44,7 @@ def _make_store(tmp_path, monkeypatch) -> Path:
     """Point NAURO_HOME/HOME into tmp_path and return a scaffolded store dir."""
     monkeypatch.setenv("NAURO_HOME", str(tmp_path / "nauro_home"))
     monkeypatch.setenv("HOME", str(tmp_path / "home"))
-    store = register_project("proj", [tmp_path / "repo"])
+    _pid, store = register_project_v2("proj", [tmp_path / "repo"])
     scaffold_project_store("proj", store)
     return store
 
@@ -173,7 +173,7 @@ def test_note_question_branch_exits_zero_and_persists(tmp_path, monkeypatch):
     """``nauro note`` question branch exits 0 and the entry lands on disk."""
     repo = tmp_path / "repo"
     repo.mkdir()
-    store = register_project("myproj", [repo])
+    _pid, store = register_project_v2("myproj", [repo])
     scaffold_project_store("myproj", store)
     monkeypatch.chdir(repo)
 

--- a/packages/nauro/tests/test_sync/test_hooks.py
+++ b/packages/nauro/tests/test_sync/test_hooks.py
@@ -3,7 +3,7 @@
 After the cutover to presign, ``hooks.py`` gates on:
 
 * Auth0 access token (no token → silent no-op so MCP writes never nag).
-* v2 cloud-mode registry entry (v1 or local-mode → silent no-op).
+* v2 cloud-mode registry entry (unknown id or local-mode → silent no-op).
 
 The happy paths exercise the manifest/presign helpers via httpx mocks
 matching the patterns in ``test_sync_presign.py``.
@@ -19,7 +19,7 @@ import httpx
 import pytest
 
 from nauro.store.config import save_config
-from nauro.store.registry import register_project, register_project_v2
+from nauro.store.registry import register_project_v2
 from nauro.sync.hooks import (
     pull_before_session,
     push_after_write,
@@ -54,7 +54,8 @@ def _seed_token() -> None:
 class TestSilentNoOpGating:
     """The hooks must silent-no-op when not authenticated or when the
     project is not v2 cloud-mode. Nagging the user on every MCP write
-    would be hostile; v1/local projects have no presign target."""
+    would be hostile; unknown ids and local projects have no presign
+    target."""
 
     def test_pull_silent_when_not_authenticated(self, tmp_path):
         store = _scaffolded_cloud_project("noauth", tmp_path, project_id=CLOUD_PID)
@@ -76,10 +77,24 @@ class TestSilentNoOpGating:
         assert result == 0
         mock_post.assert_not_called()
 
-    def test_pull_silent_for_v1_project(self, tmp_path):
-        """v1 entries have no v2 registry record → is_cloud_project False."""
-        store = register_project("v1proj", [tmp_path])
+    def _seed_v1_shaped_registry(self, tmp_path) -> Path:
+        """Seed the retired v1 (name-keyed) registry shape plus a store dir.
+
+        The shape reads as an empty v2 registry, so ``is_cloud_project``
+        is False and the hooks keep their silent no-op.
+        """
+        (tmp_path / "registry.json").write_text(
+            json.dumps(
+                {"schema_version": 1, "projects": {"v1proj": {"repo_paths": [str(tmp_path)]}}}
+            )
+        )
+        store = tmp_path / "projects" / "v1proj"
         scaffold_project_store("v1proj", store)
+        return store
+
+    def test_pull_silent_for_v1_shaped_registry(self, tmp_path):
+        """A v1-shaped registry has no v2 record → is_cloud_project False."""
+        store = self._seed_v1_shaped_registry(tmp_path)
         _seed_token()
 
         with patch("nauro.sync.remote.httpx.get") as mock_get:
@@ -88,9 +103,8 @@ class TestSilentNoOpGating:
         assert result == 0
         mock_get.assert_not_called()
 
-    def test_push_silent_for_v1_project(self, tmp_path):
-        store = register_project("v1proj", [tmp_path])
-        scaffold_project_store("v1proj", store)
+    def test_push_silent_for_v1_shaped_registry(self, tmp_path):
+        store = self._seed_v1_shaped_registry(tmp_path)
         _seed_token()
 
         with patch("nauro.sync.remote.httpx.post") as mock_post:

--- a/packages/nauro/tests/test_sync/test_pull.py
+++ b/packages/nauro/tests/test_sync/test_pull.py
@@ -16,7 +16,7 @@ from unittest.mock import patch
 import httpx
 import pytest
 
-from nauro.store.registry import register_project
+from nauro.store.registry import register_project_v2
 from nauro.sync.pull import _renumber_decision_if_collision, run_pull
 from nauro.sync.state import (
     FileState,
@@ -210,7 +210,7 @@ class TestRunPullDecisionCollision:
 class TestRenumberDecisionIfCollision:
     @pytest.fixture()
     def project_store(self, tmp_path):
-        store = register_project("renumproj", [tmp_path])
+        _pid, store = register_project_v2("renumproj", [tmp_path])
         scaffold_project_store("renumproj", store)
         return store
 

--- a/packages/nauro/tests/test_sync/test_sync_command.py
+++ b/packages/nauro/tests/test_sync/test_sync_command.py
@@ -7,7 +7,7 @@ import pytest
 from typer.testing import CliRunner
 
 from nauro.cli.main import app
-from nauro.store.registry import register_project
+from nauro.store.registry import register_project_v2
 from nauro.templates.scaffolds import scaffold_project_store
 from tests.conftest import seed_auth_config
 from tests.test_sync.conftest import _scaffolded_cloud_project
@@ -18,7 +18,7 @@ runner = CliRunner()
 @pytest.fixture()
 def project_store(tmp_path: Path, monkeypatch):
     """Set up a project store for testing."""
-    store = register_project("testproj", [tmp_path])
+    _pid, store = register_project_v2("testproj", [tmp_path])
     scaffold_project_store("testproj", store)
     monkeypatch.chdir(tmp_path)
     return store

--- a/packages/nauro/tests/test_sync/test_sync_status.py
+++ b/packages/nauro/tests/test_sync/test_sync_status.py
@@ -13,7 +13,7 @@ from typer.testing import CliRunner
 
 from nauro.cli.main import app
 from nauro.store.config import save_config
-from nauro.store.registry import register_project
+from nauro.store.registry import register_project_v2
 from nauro.sync.state import SyncState, save_state
 from nauro.templates.scaffolds import scaffold_project_store
 
@@ -21,7 +21,7 @@ runner = CliRunner()
 
 
 def _scaffold(name: str = "statusproj", *, repo):
-    store = register_project(name, [repo])
+    _pid, store = register_project_v2(name, [repo])
     scaffold_project_store(name, store)
     return store
 

--- a/packages/nauro/tests/test_tool_update_state.py
+++ b/packages/nauro/tests/test_tool_update_state.py
@@ -10,12 +10,12 @@ import pytest
 
 from nauro.mcp import tools
 from nauro.mcp.tools import tool_update_state
-from nauro.store.registry import register_project
+from nauro.store.registry import register_project_v2
 from nauro.templates.scaffolds import scaffold_project_store
 
 
 def _setup_store(tmp_path) -> Path:
-    store = register_project("testproj", [tmp_path])
+    _pid, store = register_project_v2("testproj", [tmp_path])
     scaffold_project_store("testproj", store)
     return store
 

--- a/packages/nauro/tests/test_tools_store_field.py
+++ b/packages/nauro/tests/test_tools_store_field.py
@@ -8,12 +8,12 @@ from nauro.mcp.tools import (
     tool_propose_decision,
     tool_update_state,
 )
-from nauro.store.registry import register_project
+from nauro.store.registry import register_project_v2
 from nauro.templates.scaffolds import scaffold_project_store
 
 
 def _setup_store(tmp_path, monkeypatch) -> Path:
-    store = register_project("testproj", [tmp_path])
+    _pid, store = register_project_v2("testproj", [tmp_path])
     scaffold_project_store("testproj", store)
     return store
 
@@ -58,10 +58,12 @@ class TestProjectIdentityPresent:
     """
 
     def test_check_decision_includes_project_identity(self, tmp_path, monkeypatch):
-        store = _setup_store(tmp_path, monkeypatch)
+        pid, store = register_project_v2("testproj", [tmp_path])
+        scaffold_project_store("testproj", store)
         result = tool_check_decision(store, proposed_approach="Use a REST API")
-        # v1 store: the directory name is the project name, no separate id.
-        assert result["project"] == {"id": None, "name": "testproj"}
+        # id-keyed store: the directory name is the project id; the registry
+        # entry supplies the display name.
+        assert result["project"] == {"id": pid, "name": "testproj"}
 
     def test_error_envelope_also_carries_project(self, tmp_path, monkeypatch):
         missing = tmp_path / "absent-store"


### PR DESCRIPTION
## Why

The name-keyed v1 registry has had no real population since the id-keyed v2 shape shipped pre-publicity, and v1 readability was never part of the frozen 1.0 contract (no registry filename, schema-version, or entry-shape pins exist in the enforced surface). Keeping it cost five fallback sites across three modules, a dead helper family, and ~95 test seeds locked on a dead shape; a refactor had also once re-enabled v1 resolution on the hook surface by accident.

## What changed

- **registry.py**: the v1 helper family (`load_registry`, `save_registry`, `get_store_path`, `get_project`, `resolve_project`, `register_project`) is deleted. The hard reject in `load_registry_v2` stays as the single permanent tombstone: a v1-shaped `registry.json` gets the manual-migration message on write paths and degrades to an empty registry on read paths. `get_repo_paths` and `is_cloud_project` lose their v1 legs.
- **suggest_project_for_path** is ported to the v2 registry (it previously matched only v1 entries, so the "did you mean" hint had gone dead against v2 populations) and hardened in the process: it returns a match only when exactly one project carries the name, the hint is mode-aware (cloud projects get `nauro attach <project_id>`, since `init --add-repo` intentionally rejects cloud scope), and the copy-paste command shell-quotes the name.
- **resolution.py**: the cwd waterfall drops its v1 tier; `resolve_store`'s project_id branch drops the v1 fallback and now raises `ProjectNotFoundError` directly.
- **cli/utils.py**: `--project` lookup, the available-projects listing, and the setup entry lookup are v2-only. `user_scope.py`'s clear-safety check likewise treats a v1-shaped registry as empty.
- **Tests**: all remaining v1 seeders migrated to `register_project_v2` (staged as its own green commit while v1 code still existed); v1 CRUD/tier tests deleted; the tombstone and degradation behaviors are re-pinned with raw v1-shaped JSON seeds (reject message, welcome-screen resolution, hook fail-open, silent sync no-op, cloud-gate False). The hook pin for v1-only project resolution is removed deliberately, not regressed: that tier no longer exists.
- **Docs**: CLAUDE.md (root + package) now describe the registry as id-keyed with the name kept as entry metadata.

## Test plan

- `pytest packages/nauro/tests -q`: 2047 passed, 10 skipped (each commit green independently)
- `pytest packages/nauro-core/tests -q`: 1077 passed (untouched)
- `ruff check` / `ruff format --check`: clean
- Frozen surface untouched: no snapshot diffs, `test_public_contract` passes; grep confirms no v1 symbols remain in production

## Risk / what to review

- The one behavior surface worth eyes: a leftover v1-shaped `registry.json` now resolves to *no project* on every read path (welcome screen / fail-open) instead of resolving stores by name; only `load_registry_v2` still names the migration. This is the decided contract, not an accident.
- `user_scope.py` was not in the original scope map but carried a v1 fallback; it now degrades to "no projects", which slightly widens user-scope artifact clearing for a hypothetical v1-only machine.
