### PR TITLE
Add write-path provenance journal (journal-only, capture ahead of any viewer)

### DIFF
--- a/packages/nauro/src/nauro/cli/autogen.py
+++ b/packages/nauro/src/nauro/cli/autogen.py
@@ -29,7 +29,7 @@ import typer
 from nauro_core.mcp_tools import ALL_TOOLS, ToolSpec
 
 from nauro.cli._json_input import parse_json_list_of_dicts
-from nauro.cli.utils import resolve_target_project
+from nauro.cli.utils import cli_origin, resolve_target_project
 from nauro.mcp import tools as mcp_tools
 
 # Tools that should auto-generate a CLI command. list_projects is
@@ -321,6 +321,11 @@ def _make_command(spec: ToolSpec) -> Callable[..., None]:
         name for name in schema_arg_names if props.get(name, {}).get("enum")
     ]
 
+    # Write adapters accept a keyword-only ``origin`` so the CLI can stamp the
+    # transport; read adapters do not. Detect it once so the command stamps
+    # only the surfaces that record provenance.
+    accepts_origin = "origin" in inspect.signature(adapter).parameters
+
     def command(**kwargs: Any) -> None:
         project = kwargs.pop("project", None)
         # --json is a parity no-op; JSON is the only output mode.
@@ -340,6 +345,8 @@ def _make_command(spec: ToolSpec) -> Callable[..., None]:
                 kwargs[name] = value.value
 
         adapter_kwargs = {name: kwargs[name] for name in schema_arg_names if name in kwargs}
+        if accepts_origin:
+            adapter_kwargs["origin"] = cli_origin()
         envelope = adapter(store_path, **adapter_kwargs)
         _emit_envelope(envelope)
         _exit_for_envelope(envelope)

--- a/packages/nauro/src/nauro/cli/commands/import_cmd.py
+++ b/packages/nauro/src/nauro/cli/commands/import_cmd.py
@@ -18,7 +18,7 @@ from nauro.cli.utils import cli_origin, resolve_target_project
 from nauro.constants import DECISIONS_DIR, PROJECT_MD, STACK_MD
 from nauro.store.decision_lock import decision_write_lock
 from nauro.store.filesystem_store import FilesystemStore
-from nauro.store.journal import JournalEvent, append_event, payload_hash
+from nauro.store.journal import record_event
 from nauro.store.snapshot import capture_snapshot
 from nauro.store.store_lock import store_write_lock
 
@@ -53,16 +53,32 @@ def _import_append_decision(
     # post-loop capture_snapshot stays outside the lock.
     with decision_write_lock(store_path):
         decision_id = _write_decision_direct(FilesystemStore(store_path), proposal)
-    append_event(
+    record_event(
         store_path,
-        JournalEvent(
-            operation="propose_decision",
-            target=DECISIONS_DIR,
-            status="committed",
-            decision_id=decision_id,
-            origin=cli_origin(),
-            payload_hash=payload_hash(proposal),
-        ),
+        operation="propose_decision",
+        target=DECISIONS_DIR,
+        status="committed",
+        payload=proposal,
+        origin=cli_origin(),
+        decision_id=decision_id,
+    )
+
+
+def _journal_import_merge(store_path: Path, target: str, content: str) -> None:
+    """Record a committed write-path event for a Memory Bank file merge.
+
+    projectBrief.md → project.md and techContext.md → stack.md mutate store
+    content, so they carry provenance like every other write path. The
+    ``import_merge`` operation names the action; ``target`` names the file
+    touched.
+    """
+    record_event(
+        store_path,
+        operation="import_merge",
+        target=target,
+        status="committed",
+        payload={"content": content},
+        origin=cli_origin(),
     )
 
 
@@ -95,19 +111,17 @@ def _import_memory_bank(memory_bank: Path, store_path: Path) -> dict[str, int]:
     # projectBrief.md → project.md
     brief_path = memory_bank / "projectBrief.md"
     if brief_path.exists():
-        _append_to_store_file(
-            store_path / PROJECT_MD,
-            _read(brief_path),
-        )
+        brief = _read(brief_path)
+        if _append_to_store_file(store_path / PROJECT_MD, brief):
+            _journal_import_merge(store_path, PROJECT_MD, brief)
         counts["files_merged"] += 1
 
     # techContext.md → stack.md
     tech_path = memory_bank / "techContext.md"
     if tech_path.exists():
-        _append_to_store_file(
-            store_path / STACK_MD,
-            _read(tech_path),
-        )
+        tech = _read(tech_path)
+        if _append_to_store_file(store_path / STACK_MD, tech):
+            _journal_import_merge(store_path, STACK_MD, tech)
         counts["files_merged"] += 1
 
     # decisionLog.md → decisions/NNN-title.md
@@ -140,15 +154,13 @@ def _import_memory_bank(memory_bank: Path, store_path: Path) -> dict[str, int]:
         with store_write_lock(store_path, STATE_CURRENT_FILENAME):
             state_result = _update_state_op(FilesystemStore(store_path), delta)
         if state_result.status != "noop":
-            append_event(
+            record_event(
                 store_path,
-                JournalEvent(
-                    operation="update_state",
-                    target=STATE_CURRENT_FILENAME,
-                    status="committed",
-                    origin=cli_origin(),
-                    payload_hash=payload_hash({"delta": delta}),
-                ),
+                operation="update_state",
+                target=STATE_CURRENT_FILENAME,
+                status="committed",
+                payload={"delta": delta},
+                origin=cli_origin(),
             )
 
     return counts
@@ -188,22 +200,25 @@ def _compose_state_delta(active_body: str | None, progress_items: list[str]) -> 
     return None
 
 
-def _append_to_store_file(target: Path, content: str) -> None:
+def _append_to_store_file(target: Path, content: str) -> bool:
     """Append imported content to an existing store markdown file.
 
     Adds a ## Imported from Memory Bank header before the content.
     If the file doesn't exist, creates it with just the imported content.
+    Returns True when a write occurred, False when the content was empty and
+    the file was left untouched.
     """
     header = "\n\n## Imported from Memory Bank\n\n"
     stripped = content.strip()
     if not stripped:
-        return
+        return False
 
     if target.exists():
         existing = _read(target)
         target.write_text(existing.rstrip() + header + stripped + "\n", encoding="utf-8")
     else:
         target.write_text(header.lstrip() + stripped + "\n", encoding="utf-8")
+    return True
 
 
 def _parse_and_import_decisions(content: str, store_path: Path) -> int:

--- a/packages/nauro/src/nauro/cli/commands/import_cmd.py
+++ b/packages/nauro/src/nauro/cli/commands/import_cmd.py
@@ -59,7 +59,7 @@ def _import_append_decision(
         target=DECISIONS_DIR,
         status="committed",
         payload=proposal,
-        origin=cli_origin(),
+        origin_factory=cli_origin,
         decision_id=decision_id,
     )
 
@@ -78,7 +78,7 @@ def _journal_import_merge(store_path: Path, target: str, content: str) -> None:
         target=target,
         status="committed",
         payload={"content": content},
-        origin=cli_origin(),
+        origin_factory=cli_origin,
     )
 
 
@@ -160,7 +160,7 @@ def _import_memory_bank(memory_bank: Path, store_path: Path) -> dict[str, int]:
                 target=STATE_CURRENT_FILENAME,
                 status="committed",
                 payload={"delta": delta},
-                origin=cli_origin(),
+                origin_factory=cli_origin,
             )
 
     return counts

--- a/packages/nauro/src/nauro/cli/commands/import_cmd.py
+++ b/packages/nauro/src/nauro/cli/commands/import_cmd.py
@@ -14,10 +14,11 @@ from nauro_core.constants import STATE_CURRENT_FILENAME
 from nauro_core.operations import update_state as _update_state_op
 from nauro_core.operations.propose_decision import _write_decision_direct
 
-from nauro.cli.utils import resolve_target_project
-from nauro.constants import PROJECT_MD, STACK_MD
+from nauro.cli.utils import cli_origin, resolve_target_project
+from nauro.constants import DECISIONS_DIR, PROJECT_MD, STACK_MD
 from nauro.store.decision_lock import decision_write_lock
 from nauro.store.filesystem_store import FilesystemStore
+from nauro.store.journal import JournalEvent, append_event, payload_hash
 from nauro.store.snapshot import capture_snapshot
 from nauro.store.store_lock import store_write_lock
 
@@ -41,19 +42,28 @@ def _import_append_decision(
     confidence: str = "medium",
 ) -> None:
     """Adapter for the import paths: write a decision via the kernel."""
+    proposal = {
+        "title": title,
+        "rationale": rationale,
+        "rejected": rejected,
+        "confidence": confidence,
+    }
     # Hold the allocation lock across the number computation and the write so
     # concurrent local writers cannot mint the same decision number. The
     # post-loop capture_snapshot stays outside the lock.
     with decision_write_lock(store_path):
-        _write_decision_direct(
-            FilesystemStore(store_path),
-            {
-                "title": title,
-                "rationale": rationale,
-                "rejected": rejected,
-                "confidence": confidence,
-            },
-        )
+        decision_id = _write_decision_direct(FilesystemStore(store_path), proposal)
+    append_event(
+        store_path,
+        JournalEvent(
+            operation="propose_decision",
+            target=DECISIONS_DIR,
+            status="committed",
+            decision_id=decision_id,
+            origin=cli_origin(),
+            payload_hash=payload_hash(proposal),
+        ),
+    )
 
 
 def _import_memory_bank(memory_bank: Path, store_path: Path) -> dict[str, int]:
@@ -128,7 +138,18 @@ def _import_memory_bank(memory_bank: Path, store_path: Path) -> dict[str, int]:
         # state_history.md; hold one lock across the whole kernel call so a
         # concurrent local writer cannot drop an update on either file.
         with store_write_lock(store_path, STATE_CURRENT_FILENAME):
-            _update_state_op(FilesystemStore(store_path), delta)
+            state_result = _update_state_op(FilesystemStore(store_path), delta)
+        if state_result.status != "noop":
+            append_event(
+                store_path,
+                JournalEvent(
+                    operation="update_state",
+                    target=STATE_CURRENT_FILENAME,
+                    status="committed",
+                    origin=cli_origin(),
+                    payload_hash=payload_hash({"delta": delta}),
+                ),
+            )
 
     return counts
 

--- a/packages/nauro/src/nauro/cli/commands/note.py
+++ b/packages/nauro/src/nauro/cli/commands/note.py
@@ -110,7 +110,7 @@ def note(
             target=OPEN_QUESTIONS_MD,
             status="committed",
             payload={"question": text},
-            origin=cli_origin(),
+            origin_factory=cli_origin,
         )
         typer.echo(f"Question added to {project_name}:")
         typer.echo(f"  {text}")
@@ -134,7 +134,7 @@ def note(
             target=DECISIONS_DIR,
             status="committed",
             payload={"title": text, "rationale": rationale, "confidence": confidence},
-            origin=cli_origin(),
+            origin_factory=cli_origin,
             decision_id=decision_id,
         )
         filepath = store_path / DECISIONS_DIR / f"{decision_id}.md"

--- a/packages/nauro/src/nauro/cli/commands/note.py
+++ b/packages/nauro/src/nauro/cli/commands/note.py
@@ -6,9 +6,10 @@ from nauro_core.decision_model import DecisionConfidence
 from nauro_core.operations import flag_question as _flag_question_op
 from nauro_core.operations.propose_decision import _write_decision_direct
 
-from nauro.cli.utils import resolve_target_project
+from nauro.cli.utils import cli_origin, resolve_target_project
 from nauro.store.decision_lock import decision_write_lock
 from nauro.store.filesystem_store import FilesystemStore
+from nauro.store.journal import JournalEvent, append_event, payload_hash
 from nauro.store.store_lock import store_write_lock
 from nauro.templates.agents_md_regen import warn_then_regen
 
@@ -103,6 +104,16 @@ def note(
         # already wraps decision_write_lock. AGENTS.md regen stays outside.
         with store_write_lock(store_path, OPEN_QUESTIONS_MD):
             _flag_question_op(fs_store, text, None)
+        append_event(
+            store_path,
+            JournalEvent(
+                operation="flag_question",
+                target=OPEN_QUESTIONS_MD,
+                status="committed",
+                origin=cli_origin(),
+                payload_hash=payload_hash({"question": text}),
+            ),
+        )
         typer.echo(f"Question added to {project_name}:")
         typer.echo(f"  {text}")
         typer.echo(f"  File: {store_path / 'open-questions.md'}")
@@ -119,6 +130,19 @@ def note(
                     "confidence": confidence,
                 },
             )
+        append_event(
+            store_path,
+            JournalEvent(
+                operation="propose_decision",
+                target=DECISIONS_DIR,
+                status="committed",
+                decision_id=decision_id,
+                origin=cli_origin(),
+                payload_hash=payload_hash(
+                    {"title": text, "rationale": rationale, "confidence": confidence}
+                ),
+            ),
+        )
         filepath = store_path / DECISIONS_DIR / f"{decision_id}.md"
         typer.echo(f"Decision recorded in {project_name}:")
         typer.echo(f"  {filepath}")

--- a/packages/nauro/src/nauro/cli/commands/note.py
+++ b/packages/nauro/src/nauro/cli/commands/note.py
@@ -9,7 +9,7 @@ from nauro_core.operations.propose_decision import _write_decision_direct
 from nauro.cli.utils import cli_origin, resolve_target_project
 from nauro.store.decision_lock import decision_write_lock
 from nauro.store.filesystem_store import FilesystemStore
-from nauro.store.journal import JournalEvent, append_event, payload_hash
+from nauro.store.journal import record_event
 from nauro.store.store_lock import store_write_lock
 from nauro.templates.agents_md_regen import warn_then_regen
 
@@ -104,15 +104,13 @@ def note(
         # already wraps decision_write_lock. AGENTS.md regen stays outside.
         with store_write_lock(store_path, OPEN_QUESTIONS_MD):
             _flag_question_op(fs_store, text, None)
-        append_event(
+        record_event(
             store_path,
-            JournalEvent(
-                operation="flag_question",
-                target=OPEN_QUESTIONS_MD,
-                status="committed",
-                origin=cli_origin(),
-                payload_hash=payload_hash({"question": text}),
-            ),
+            operation="flag_question",
+            target=OPEN_QUESTIONS_MD,
+            status="committed",
+            payload={"question": text},
+            origin=cli_origin(),
         )
         typer.echo(f"Question added to {project_name}:")
         typer.echo(f"  {text}")
@@ -130,18 +128,14 @@ def note(
                     "confidence": confidence,
                 },
             )
-        append_event(
+        record_event(
             store_path,
-            JournalEvent(
-                operation="propose_decision",
-                target=DECISIONS_DIR,
-                status="committed",
-                decision_id=decision_id,
-                origin=cli_origin(),
-                payload_hash=payload_hash(
-                    {"title": text, "rationale": rationale, "confidence": confidence}
-                ),
-            ),
+            operation="propose_decision",
+            target=DECISIONS_DIR,
+            status="committed",
+            payload={"title": text, "rationale": rationale, "confidence": confidence},
+            origin=cli_origin(),
+            decision_id=decision_id,
         )
         filepath = store_path / DECISIONS_DIR / f"{decision_id}.md"
         typer.echo(f"Decision recorded in {project_name}:")

--- a/packages/nauro/src/nauro/cli/utils.py
+++ b/packages/nauro/src/nauro/cli/utils.py
@@ -41,18 +41,24 @@ class DisconnectedProjectExit(typer.Exit):
     """CLI resolution already rendered typed reconnect guidance."""
 
 
-def cli_origin() -> OriginDescriptor:
+def cli_origin() -> OriginDescriptor | None:
     """Origin descriptor stamped on every write-path event from the CLI surface.
 
     Shared by the auto-generated write commands and the hand-written direct-write
     commands (``note``, ``import``) so the transport attribution is identical
-    across both.
+    across both. Total by construction: origin is provenance, never load-bearing
+    for the write, so any failure yields ``None`` rather than raising. The direct
+    commands additionally pass this as an ``origin_factory`` so even a defective
+    override is caught inside the journal's fail-open guard.
     """
-    return OriginDescriptor(
-        transport="cli",
-        client_name="nauro-cli",
-        client_version=__version__,
-    )
+    try:
+        return OriginDescriptor(
+            transport="cli",
+            client_name="nauro-cli",
+            client_version=__version__,
+        )
+    except Exception:
+        return None
 
 
 def refuse_global_config_collision(repo_root: Path) -> None:

--- a/packages/nauro/src/nauro/cli/utils.py
+++ b/packages/nauro/src/nauro/cli/utils.py
@@ -16,7 +16,9 @@ from pathlib import Path
 
 import typer
 
+from nauro import __version__
 from nauro.constants import REPO_CONFIG_MODE_CLOUD
+from nauro.store.journal import OriginDescriptor
 from nauro.store.registry import (
     RegistrySchemaError,
     add_repo_v2,
@@ -37,6 +39,20 @@ from nauro.store.write_safety import find_symlink
 
 class DisconnectedProjectExit(typer.Exit):
     """CLI resolution already rendered typed reconnect guidance."""
+
+
+def cli_origin() -> OriginDescriptor:
+    """Origin descriptor stamped on every write-path event from the CLI surface.
+
+    Shared by the auto-generated write commands and the hand-written direct-write
+    commands (``note``, ``import``) so the transport attribution is identical
+    across both.
+    """
+    return OriginDescriptor(
+        transport="cli",
+        client_name="nauro-cli",
+        client_version=__version__,
+    )
 
 
 def refuse_global_config_collision(repo_root: Path) -> None:
@@ -213,6 +229,7 @@ def _resolve_project_entry(project_name: str, project_key: str) -> dict:
 # Re-exported for callers that need to write or extend v2 entries directly
 __all__ = [
     "add_repo_v2",
+    "cli_origin",
     "DisconnectedProjectExit",
     "refuse_global_config_collision",
     "refuse_repo_config_symlink",

--- a/packages/nauro/src/nauro/mcp/stdio_server.py
+++ b/packages/nauro/src/nauro/mcp/stdio_server.py
@@ -32,6 +32,7 @@ from pathlib import Path
 from typing import Annotated, Any, Literal
 
 from mcp.server import FastMCP
+from mcp.server.fastmcp import Context
 from mcp.types import CallToolResult, TextContent, ToolAnnotations
 from nauro_core.constants import MCP_INSTRUCTIONS
 from nauro_core.mcp_tools import ToolSpec, get_tool_spec
@@ -54,6 +55,7 @@ from nauro.mcp.tools import (
     tool_update_state,
 )
 from nauro.onboarding import WELCOME_NO_PROJECT
+from nauro.store.journal import OriginDescriptor
 from nauro.store.resolution import (
     DisconnectedProject,
     DisconnectedProjectError,
@@ -179,6 +181,31 @@ def _resolve_or_error(project_id, cwd) -> tuple[Path | None, dict | None]:
         }
     except StoreResolutionError as exc:
         return None, {"store": "local", "status": "error", "guidance": str(exc)}
+
+
+def _origin_from_ctx(mcp_ctx: Context | None) -> OriginDescriptor:
+    """Build the stdio-MCP origin descriptor from the request Context.
+
+    ``clientInfo`` comes from the client's unauthenticated ``initialize``
+    metadata, reachable at request time via
+    ``ctx.session.client_params.clientInfo``. Every hop is guarded so a client
+    that sent no ``clientInfo`` (or a Context absent entirely, as in a direct
+    unit test) still yields a well-formed descriptor with the name/version
+    unset. The descriptor bounds and sanitizes the strings itself.
+    """
+    client_name: str | None = None
+    client_version: str | None = None
+    session = getattr(mcp_ctx, "session", None) if mcp_ctx is not None else None
+    client_params = getattr(session, "client_params", None) if session is not None else None
+    client_info = getattr(client_params, "clientInfo", None) if client_params is not None else None
+    if client_info is not None:
+        client_name = getattr(client_info, "name", None)
+        client_version = getattr(client_info, "version", None)
+    return OriginDescriptor(
+        transport="stdio-mcp",
+        client_name=client_name,
+        client_version=client_version,
+    )
 
 
 # ``cwd`` exists only on the local transport (the hosted server has no
@@ -369,6 +396,7 @@ def propose_decision(
         Field(description=_param_desc("propose_decision", "project_id")),
     ] = None,
     cwd: _CWD_PARAM = None,
+    mcp_ctx: Context | None = None,
 ) -> dict:
     store_path, err = _resolve_or_error(project_id, cwd)
     if err is not None:
@@ -385,6 +413,7 @@ def propose_decision(
         reversibility=reversibility,
         files_affected=files_affected,
         resolves_questions=resolves_questions,
+        origin=_origin_from_ctx(mcp_ctx),
     )
 
 
@@ -406,12 +435,18 @@ def flag_question(
         str | None, Field(description=_param_desc("flag_question", "project_id"))
     ] = None,
     cwd: _CWD_PARAM = None,
+    mcp_ctx: Context | None = None,
 ) -> str | dict:
     store_path, err = _resolve_or_error(project_id, cwd)
     if err is not None:
         return err if disconnected_reason_code(err) is not None else err["guidance"]
     result = tool_flag_question(
-        store_path, question, context, targets=targets, resolved_by=resolved_by
+        store_path,
+        question,
+        context,
+        targets=targets,
+        resolved_by=resolved_by,
+        origin=_origin_from_ctx(mcp_ctx),
     )
     if result.get("status") == "rejected":
         error = result.get("error") or {}
@@ -431,11 +466,12 @@ def update_state(
         str | None, Field(description=_param_desc("update_state", "project_id"))
     ] = None,
     cwd: _CWD_PARAM = None,
+    mcp_ctx: Context | None = None,
 ) -> str | dict:
     store_path, err = _resolve_or_error(project_id, cwd)
     if err is not None:
         return err if disconnected_reason_code(err) is not None else err["guidance"]
-    result = tool_update_state(store_path, delta)
+    result = tool_update_state(store_path, delta, origin=_origin_from_ctx(mcp_ctx))
     if result.get("warning"):
         return f"State updated. {result['warning']}"
     return "State updated."

--- a/packages/nauro/src/nauro/mcp/stdio_server.py
+++ b/packages/nauro/src/nauro/mcp/stdio_server.py
@@ -183,7 +183,7 @@ def _resolve_or_error(project_id, cwd) -> tuple[Path | None, dict | None]:
         return None, {"store": "local", "status": "error", "guidance": str(exc)}
 
 
-def _origin_from_ctx(mcp_ctx: Context | None) -> OriginDescriptor:
+def _origin_from_ctx(mcp_ctx: Context | None) -> OriginDescriptor | None:
     """Build the stdio-MCP origin descriptor from the request Context.
 
     ``clientInfo`` comes from the client's unauthenticated ``initialize``
@@ -191,21 +191,27 @@ def _origin_from_ctx(mcp_ctx: Context | None) -> OriginDescriptor:
     ``ctx.session.client_params.clientInfo``. Every hop is guarded so a client
     that sent no ``clientInfo`` (or a Context absent entirely, as in a direct
     unit test) still yields a well-formed descriptor with the name/version
-    unset. The descriptor bounds and sanitizes the strings itself.
+    unset. Total by construction: origin is provenance, never load-bearing for
+    the write, so any failure yields ``None`` rather than raising.
     """
-    client_name: str | None = None
-    client_version: str | None = None
-    session = getattr(mcp_ctx, "session", None) if mcp_ctx is not None else None
-    client_params = getattr(session, "client_params", None) if session is not None else None
-    client_info = getattr(client_params, "clientInfo", None) if client_params is not None else None
-    if client_info is not None:
-        client_name = getattr(client_info, "name", None)
-        client_version = getattr(client_info, "version", None)
-    return OriginDescriptor(
-        transport="stdio-mcp",
-        client_name=client_name,
-        client_version=client_version,
-    )
+    try:
+        client_name: str | None = None
+        client_version: str | None = None
+        session = getattr(mcp_ctx, "session", None) if mcp_ctx is not None else None
+        client_params = getattr(session, "client_params", None) if session is not None else None
+        client_info = (
+            getattr(client_params, "clientInfo", None) if client_params is not None else None
+        )
+        if client_info is not None:
+            client_name = getattr(client_info, "name", None)
+            client_version = getattr(client_info, "version", None)
+        return OriginDescriptor(
+            transport="stdio-mcp",
+            client_name=client_name,
+            client_version=client_version,
+        )
+    except Exception:
+        return None
 
 
 # ``cwd`` exists only on the local transport (the hosted server has no

--- a/packages/nauro/src/nauro/mcp/tools.py
+++ b/packages/nauro/src/nauro/mcp/tools.py
@@ -200,13 +200,16 @@ def _emit_write_event(
         return
 
     payload = {k: v for k, v in bound.arguments.items() if k not in ("store_path", "origin")}
+    # The transport already built the descriptor before this adapter ran; the
+    # factory just hands it back inside record_event's guard, keeping a single
+    # emission interface across every call site.
     record_event(
         store_path,
         operation=operation,
         target=target,
         status=journal_status,
         payload=payload,
-        origin=origin,
+        origin_factory=lambda: origin,
         decision_id=decision_id,
     )
 

--- a/packages/nauro/src/nauro/mcp/tools.py
+++ b/packages/nauro/src/nauro/mcp/tools.py
@@ -67,10 +67,8 @@ from nauro.store.config import resolve_embeddings_flag
 from nauro.store.decision_lock import decision_write_lock
 from nauro.store.filesystem_store import FilesystemStore
 from nauro.store.journal import (
-    JournalEvent,
     OriginDescriptor,
-    append_event,
-    payload_hash,
+    record_event,
 )
 from nauro.store.reader import read_text_lenient
 from nauro.store.snapshot import (
@@ -202,15 +200,15 @@ def _emit_write_event(
         return
 
     payload = {k: v for k, v in bound.arguments.items() if k not in ("store_path", "origin")}
-    event = JournalEvent(
+    record_event(
+        store_path,
         operation=operation,
         target=target,
         status=journal_status,
-        decision_id=decision_id,
+        payload=payload,
         origin=origin,
-        payload_hash=payload_hash(payload),
+        decision_id=decision_id,
     )
-    append_event(store_path, event)
 
 
 def _reject_if_too_long(value: str, label: str, max_length: int) -> dict | None:

--- a/packages/nauro/src/nauro/mcp/tools.py
+++ b/packages/nauro/src/nauro/mcp/tools.py
@@ -8,12 +8,14 @@ converts flag_question and update_state to strings for FastMCP compatibility).
 from __future__ import annotations
 
 import functools
+import inspect
 import logging
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
 from nauro_core.constants import (
+    DECISIONS_DIR,
     MAX_CONTEXT_LENGTH,
     MAX_DELTA_LENGTH,
     MAX_QUESTION_LENGTH,
@@ -64,6 +66,12 @@ from nauro.onboarding import (
 from nauro.store.config import resolve_embeddings_flag
 from nauro.store.decision_lock import decision_write_lock
 from nauro.store.filesystem_store import FilesystemStore
+from nauro.store.journal import (
+    JournalEvent,
+    OriginDescriptor,
+    append_event,
+    payload_hash,
+)
 from nauro.store.reader import read_text_lenient
 from nauro.store.snapshot import (
     capture_snapshot,
@@ -120,6 +128,89 @@ def _stamp_identity(func: Callable[..., Any]) -> Callable[..., Any]:
         return result
 
     return wrapper
+
+
+# Map a tool envelope ``status`` to a journal event status. ``committed`` and
+# ``rejected`` are the only two journalled outcomes; every other status (a
+# store-missing ``error`` guidance envelope, an ``update_state`` ``noop``) is a
+# non-event and records nothing.
+_COMMITTED_STATUSES: frozenset[str] = frozenset({"confirmed", "ok"})
+_REJECTED_STATUSES: frozenset[str] = frozenset({"rejected"})
+
+
+def journaled(*, operation: str, target: str) -> Callable[..., Any]:
+    """Append a write-path provenance event after the wrapped adapter returns.
+
+    The event is emitted *after* the adapter has returned — the adapter's own
+    resource lock (decision/store write lock) is released by then, so the
+    journal's dedicated lock never nests inside it. Emission is fail-open: the
+    hash and append are wrapped so a journaling defect can never turn a
+    successful write into a failure.
+
+    The payload hashed is the adapter's logical arguments with ``store_path``
+    and ``origin`` removed — ``origin`` is provenance, not payload, and
+    ``store_path`` is environment. ``committed`` events carry ``decision_id``
+    when the envelope reports one; ``rejected`` events carry the payload hash
+    and no decision id.
+    """
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        sig = inspect.signature(func)
+
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            result = func(*args, **kwargs)
+            try:
+                _emit_write_event(func, sig, operation, target, args, kwargs, result)
+            except Exception:
+                logger.debug("journal event emission failed for %s", operation, exc_info=True)
+            return result
+
+        return wrapper
+
+    return decorator
+
+
+def _emit_write_event(
+    func: Callable[..., Any],
+    sig: inspect.Signature,
+    operation: str,
+    target: str,
+    args: tuple,
+    kwargs: dict,
+    result: Any,
+) -> None:
+    """Build and append the journal event for a completed write-path call."""
+    if not isinstance(result, dict):
+        return
+    status = result.get("status")
+    if status in _COMMITTED_STATUSES:
+        journal_status = "committed"
+        decision_id = result.get("decision_id")
+    elif status in _REJECTED_STATUSES:
+        journal_status = "rejected"
+        decision_id = None
+    else:
+        # error guidance, noop, or an unrecognised status: nothing to record.
+        return
+
+    bound = sig.bind(*args, **kwargs)
+    bound.apply_defaults()
+    store_path = bound.arguments.get("store_path")
+    origin = bound.arguments.get("origin")
+    if not isinstance(store_path, Path):
+        return
+
+    payload = {k: v for k, v in bound.arguments.items() if k not in ("store_path", "origin")}
+    event = JournalEvent(
+        operation=operation,
+        target=target,
+        status=journal_status,
+        decision_id=decision_id,
+        origin=origin,
+        payload_hash=payload_hash(payload),
+    )
+    append_event(store_path, event)
 
 
 def _reject_if_too_long(value: str, label: str, max_length: int) -> dict | None:
@@ -277,6 +368,7 @@ def tool_get_context(store_path: Path, level: int | str = "L0") -> dict:
 
 
 @_stamp_identity
+@journaled(operation="propose_decision", target=DECISIONS_DIR)
 def tool_propose_decision(
     store_path: Path,
     title: str = "",
@@ -289,6 +381,8 @@ def tool_propose_decision(
     reversibility: str | None = None,
     files_affected: list[str] | None = None,
     resolves_questions: list[str] | None = None,
+    *,
+    origin: OriginDescriptor | None = None,
 ) -> dict:
     """Propose a new decision through the validation pipeline."""
     guidance = _check_store_exists(store_path)
@@ -469,12 +563,15 @@ Surface related existing decisions without writing anything.
 
 
 @_stamp_identity
+@journaled(operation="flag_question", target=OPEN_QUESTIONS_MD)
 def tool_flag_question(
     store_path: Path,
     question: str | None = None,
     context: str | None = None,
     targets: list[str] | None = None,
     resolved_by: str | None = None,
+    *,
+    origin: OriginDescriptor | None = None,
 ) -> dict:
     """Flag an open question, or resolve existing entries against a decision.
 
@@ -766,7 +863,13 @@ def tool_search_decisions(
 
 
 @_stamp_identity
-def tool_update_state(store_path: Path, delta: str) -> dict:
+@journaled(operation="update_state", target=STATE_CURRENT_FILENAME)
+def tool_update_state(
+    store_path: Path,
+    delta: str,
+    *,
+    origin: OriginDescriptor | None = None,
+) -> dict:
     """Update current project state. Returns a warning on keyword overlap."""
     guidance = _check_store_exists(store_path)
     if guidance:

--- a/packages/nauro/src/nauro/store/journal.py
+++ b/packages/nauro/src/nauro/store/journal.py
@@ -122,13 +122,49 @@ def payload_hash(payload: dict) -> str:
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
+def record_event(
+    store_path: Path,
+    *,
+    operation: str,
+    target: str,
+    status: str,
+    payload: dict,
+    origin: OriginDescriptor | None = None,
+    decision_id: str | None = None,
+) -> None:
+    """Construct, hash, and append a write-path event — fully fail-open.
+
+    Hashing and event construction join the append inside a single guarded
+    region: a journaling defect (an unhashable payload, a bad status) must never
+    escape into the caller after the underlying store write has already
+    committed. Callers pass raw ingredients rather than a pre-built event so no
+    construction happens outside the guard.
+    """
+    try:
+        event = JournalEvent(
+            operation=operation,
+            target=target,
+            status=status,  # type: ignore[arg-type]
+            decision_id=decision_id,
+            origin=origin,
+            payload_hash=payload_hash(payload),
+        )
+        append_event(store_path, event)
+    except Exception:
+        logger.debug("journal event emission failed for %s", operation, exc_info=True)
+
+
 def append_event(store_path: Path, event: JournalEvent) -> None:
-    """Append one event to the store's journal. Never raises (fail-open).
+    """Append one already-built event to the store's journal. Never raises.
 
     A journaling failure must never fail or block the underlying store write,
     so every error here is swallowed with a debug log. The dedicated journal
     lock is acquired after the caller's resource lock has been released, so it
     never nests inside a store or decision write lock.
+
+    The line is serialized with ``ensure_ascii=True`` so no raw non-ASCII byte
+    (including the Unicode line separators U+0085/U+2028/U+2029) can ever land
+    in the file and corrupt the one-event-per-line framing.
 
     Rotation is deliberately deferred: the journal grows unbounded in 1.x.
     """
@@ -136,7 +172,9 @@ def append_event(store_path: Path, event: JournalEvent) -> None:
         journal_dir = store_path / JOURNAL_DIR
         journal_dir.mkdir(parents=True, exist_ok=True)
         lock_path = journal_dir / JOURNAL_LOCK_NAME
-        line = event.model_dump_json(exclude_none=True) + "\n"
+        line = (
+            json.dumps(event.model_dump(mode="json", exclude_none=True), ensure_ascii=True) + "\n"
+        )
         with FileLock(str(lock_path)):
             with (journal_dir / JOURNAL_EVENTS_FILENAME).open("a", encoding="utf-8") as fh:
                 fh.write(line)
@@ -147,20 +185,21 @@ def append_event(store_path: Path, event: JournalEvent) -> None:
 def read_events(store_path: Path) -> list[JournalEvent]:
     """Read all parseable events from the store's journal.
 
-    Internal reader — not wired to any CLI or MCP surface. Tolerates a
-    truncated final record (an interrupted append leaves a partial last line):
-    any line that fails to parse or validate is skipped rather than raising.
+    Internal reader — not wired to any CLI or MCP surface. The file is read as
+    bytes and split on ``b"\\n"`` so a truncated final record — an interrupted
+    append can leave a partial multibyte UTF-8 character — is decoded per line
+    inside the tolerated path: any line that fails to decode, parse, or validate
+    is skipped rather than raising.
     """
     events_file = store_path / JOURNAL_DIR / JOURNAL_EVENTS_FILENAME
     if not events_file.exists():
         return []
     events: list[JournalEvent] = []
-    for line in events_file.read_text(encoding="utf-8").splitlines():
-        stripped = line.strip()
-        if not stripped:
+    for chunk in events_file.read_bytes().split(b"\n"):
+        if not chunk.strip():
             continue
         try:
-            events.append(JournalEvent.model_validate(json.loads(stripped)))
-        except (json.JSONDecodeError, ValidationError):
+            events.append(JournalEvent.model_validate(json.loads(chunk.decode("utf-8"))))
+        except (UnicodeDecodeError, json.JSONDecodeError, ValidationError):
             continue
     return events

--- a/packages/nauro/src/nauro/store/journal.py
+++ b/packages/nauro/src/nauro/store/journal.py
@@ -23,7 +23,9 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import os
 import uuid
+from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Literal
@@ -129,18 +131,21 @@ def record_event(
     target: str,
     status: str,
     payload: dict,
-    origin: OriginDescriptor | None = None,
+    origin_factory: Callable[[], OriginDescriptor | None] | None = None,
     decision_id: str | None = None,
 ) -> None:
     """Construct, hash, and append a write-path event — fully fail-open.
 
-    Hashing and event construction join the append inside a single guarded
-    region: a journaling defect (an unhashable payload, a bad status) must never
-    escape into the caller after the underlying store write has already
-    committed. Callers pass raw ingredients rather than a pre-built event so no
-    construction happens outside the guard.
+    The origin is built by ``origin_factory`` *inside* the guard rather than
+    passed as a value: an argument expression is evaluated before the call, so
+    passing a constructed descriptor would leave its construction outside the
+    fail-open region. Hashing, origin construction, and event construction all
+    join the append inside one ``try``: a journaling defect (an unhashable
+    payload, a bad status, a raising origin builder) must never escape into the
+    caller after the underlying store write has already committed.
     """
     try:
+        origin = origin_factory() if origin_factory is not None else None
         event = JournalEvent(
             operation=operation,
             target=target,
@@ -166,6 +171,11 @@ def append_event(store_path: Path, event: JournalEvent) -> None:
     (including the Unicode line separators U+0085/U+2028/U+2029) can ever land
     in the file and corrupt the one-event-per-line framing.
 
+    A crash mid-append can leave a final record with no trailing newline;
+    before appending, the file is checked and a newline is inserted first if
+    needed, so a new committed event never concatenates onto a corrupt partial
+    line and drag both into unreadability.
+
     Rotation is deliberately deferred: the journal grows unbounded in 1.x.
     """
     try:
@@ -175,9 +185,14 @@ def append_event(store_path: Path, event: JournalEvent) -> None:
         line = (
             json.dumps(event.model_dump(mode="json", exclude_none=True), ensure_ascii=True) + "\n"
         )
+        events_path = journal_dir / JOURNAL_EVENTS_FILENAME
         with FileLock(str(lock_path)):
-            with (journal_dir / JOURNAL_EVENTS_FILENAME).open("a", encoding="utf-8") as fh:
-                fh.write(line)
+            with events_path.open("a+b") as fh:
+                if fh.seek(0, os.SEEK_END) > 0:
+                    fh.seek(-1, os.SEEK_END)
+                    if fh.read(1) != b"\n":
+                        fh.write(b"\n")
+                fh.write(line.encode("utf-8"))
     except Exception:
         logger.debug("journal append failed for %s", store_path, exc_info=True)
 

--- a/packages/nauro/src/nauro/store/journal.py
+++ b/packages/nauro/src/nauro/store/journal.py
@@ -1,0 +1,166 @@
+"""Write-path provenance journal — append-only, store-local, journal-only.
+
+Every write-path action (a decision proposal, a question flag, a state update)
+appends one origin-stamped event to ``journal/events.jsonl`` under the project
+store. The journal is store data, not telemetry: it records *which surface*
+originated a write so the provenance axis is auditable later. It is deliberately
+narrow in 1.x — capture only, no viewer, no rotation, no cloud sync, no snapshot
+capture.
+
+Attempt markers, not deltas: the recorded ``payload_hash`` proves two payloads
+differed; it does not preserve a proposed-vs-ratified delta.
+
+Author identity is not captured. The origin descriptor reserves an ``actor``
+slot additively, but pre-team stores are single-owner so that axis stays
+recoverable, and team-identity capture is barred until retention is proven.
+
+Fail-open is a hard invariant: :func:`append_event` never raises. A journaling
+failure must never fail or block the underlying store write.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Literal
+
+from filelock import FileLock
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+
+logger = logging.getLogger("nauro.store.journal")
+
+# Journal layout under the store root. Non-public, internal to this surface:
+# these names must never enter the frozen public-contract constant set or
+# nauro_core.__all__.
+JOURNAL_DIR = "journal"
+JOURNAL_EVENTS_FILENAME = "events.jsonl"
+# Dedicated lock, distinct from every resource lock (decisions/.lock,
+# <file>.rmwlock). It lives inside journal/, so the sync journal/ prefix rule
+# already excludes it from cloud sync.
+JOURNAL_LOCK_NAME = ".lock"
+
+# Bound for client-supplied origin strings. MCP ``initialize`` metadata is
+# client-supplied and unauthenticated, so both fields are length-bounded and
+# stripped of control characters before they are recorded.
+_MAX_ORIGIN_FIELD_LEN = 256
+
+
+def _sanitize_client_string(value: str) -> str:
+    """Strip control characters and bound the length of a client-supplied string."""
+    cleaned = "".join(ch for ch in value if ord(ch) >= 32 and ord(ch) != 127)
+    return cleaned[:_MAX_ORIGIN_FIELD_LEN]
+
+
+def _utc_now_rfc3339() -> str:
+    """Current UTC time as an RFC3339 timestamp."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+class OriginDescriptor(BaseModel):
+    """Where a write-path action originated.
+
+    ``transport`` is the only enumerated axis; ``client_name`` and
+    ``client_version`` are free-form recorded values with no vendor
+    enumeration. ``actor`` is a reserved slot for a future author-identity
+    axis — it is defined additively but left unset, because team-identity
+    capture is barred until retention is proven.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    transport: Literal["cli", "stdio-mcp", "hosted-mcp"]
+    client_name: str | None = None
+    client_version: str | None = None
+    actor: str | None = None
+
+    @field_validator("client_name", "client_version", "actor")
+    @classmethod
+    def _bound_and_sanitize(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return _sanitize_client_string(value)
+
+
+class JournalEvent(BaseModel):
+    """One append-only write-path provenance record.
+
+    ``status`` is ``committed`` when the underlying write executed and
+    ``rejected`` when the action was attempted but refused (a Tier-1 or kernel
+    rejection). ``decision_id`` is present only on a committed decision write.
+    ``payload_hash`` is an attempt marker over a canonical serialization of the
+    action payload, named by ``hash_algorithm`` / ``serialization``.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    event_version: int = 1
+    event_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    timestamp: str = Field(default_factory=_utc_now_rfc3339)
+    event_type: str = "write"
+    operation: str
+    target: str
+    status: Literal["committed", "rejected"]
+    decision_id: str | None = None
+    origin: OriginDescriptor | None = None
+    payload_hash: str
+    hash_algorithm: str = "sha256"
+    serialization: str = "json-sorted-compact-utf8"
+
+
+def payload_hash(payload: dict) -> str:
+    """Return the sha256 hex digest of ``payload`` under a canonical serialization.
+
+    The serialization is JSON with sorted keys and compact separators, encoded
+    UTF-8. It is key-order independent by construction, so two payloads that
+    differ only in dict ordering hash identically.
+    """
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def append_event(store_path: Path, event: JournalEvent) -> None:
+    """Append one event to the store's journal. Never raises (fail-open).
+
+    A journaling failure must never fail or block the underlying store write,
+    so every error here is swallowed with a debug log. The dedicated journal
+    lock is acquired after the caller's resource lock has been released, so it
+    never nests inside a store or decision write lock.
+
+    Rotation is deliberately deferred: the journal grows unbounded in 1.x.
+    """
+    try:
+        journal_dir = store_path / JOURNAL_DIR
+        journal_dir.mkdir(parents=True, exist_ok=True)
+        lock_path = journal_dir / JOURNAL_LOCK_NAME
+        line = event.model_dump_json(exclude_none=True) + "\n"
+        with FileLock(str(lock_path)):
+            with (journal_dir / JOURNAL_EVENTS_FILENAME).open("a", encoding="utf-8") as fh:
+                fh.write(line)
+    except Exception:
+        logger.debug("journal append failed for %s", store_path, exc_info=True)
+
+
+def read_events(store_path: Path) -> list[JournalEvent]:
+    """Read all parseable events from the store's journal.
+
+    Internal reader — not wired to any CLI or MCP surface. Tolerates a
+    truncated final record (an interrupted append leaves a partial last line):
+    any line that fails to parse or validate is skipped rather than raising.
+    """
+    events_file = store_path / JOURNAL_DIR / JOURNAL_EVENTS_FILENAME
+    if not events_file.exists():
+        return []
+    events: list[JournalEvent] = []
+    for line in events_file.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            events.append(JournalEvent.model_validate(json.loads(stripped)))
+        except (json.JSONDecodeError, ValidationError):
+            continue
+    return events

--- a/packages/nauro/src/nauro/sync/merge.py
+++ b/packages/nauro/src/nauro/sync/merge.py
@@ -41,15 +41,22 @@ LOCK_ARTIFACT_SUFFIXES = (".md.lock", ".json.lock", RMW_LOCK_SUFFIX)
 
 
 def should_skip(relative_path: str) -> bool:
-    """Return True if this file should never be synced."""
-    if relative_path in NEVER_SYNC:
+    """Return True if this file should never be synced.
+
+    Backslashes are normalized to forward slashes first: the push scan builds
+    relative paths via ``str(relative_to(...))``, which yields ``\\`` separators
+    on Windows, so every prefix/basename/suffix check below operates on a
+    POSIX-normalized path and stays cross-platform.
+    """
+    normalized = relative_path.replace("\\", "/")
+    if normalized in NEVER_SYNC:
         return True
     # The write-path provenance journal is store-local by design: it is
     # excluded from cloud sync in v1 (both its events log and its lock).
-    if relative_path.startswith(JOURNAL_DIR + "/"):
+    if normalized.startswith(JOURNAL_DIR + "/"):
         return True
-    basename = relative_path.rsplit("/", 1)[-1]
-    return basename == DIR_LOCK_NAME or relative_path.endswith(LOCK_ARTIFACT_SUFFIXES)
+    basename = normalized.rsplit("/", 1)[-1]
+    return basename == DIR_LOCK_NAME or normalized.endswith(LOCK_ARTIFACT_SUFFIXES)
 
 
 def detect_conflict(

--- a/packages/nauro/src/nauro/sync/merge.py
+++ b/packages/nauro/src/nauro/sync/merge.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from nauro.graph import DEFAULT_GRAPH_FILENAME
+from nauro.store.journal import JOURNAL_DIR
 from nauro.store.store_lock import DIR_LOCK_NAME, RMW_LOCK_SUFFIX
 from nauro.sync.state import SyncState
 
@@ -42,6 +43,10 @@ LOCK_ARTIFACT_SUFFIXES = (".md.lock", ".json.lock", RMW_LOCK_SUFFIX)
 def should_skip(relative_path: str) -> bool:
     """Return True if this file should never be synced."""
     if relative_path in NEVER_SYNC:
+        return True
+    # The write-path provenance journal is store-local by design: it is
+    # excluded from cloud sync in v1 (both its events log and its lock).
+    if relative_path.startswith(JOURNAL_DIR + "/"):
         return True
     basename = relative_path.rsplit("/", 1)[-1]
     return basename == DIR_LOCK_NAME or relative_path.endswith(LOCK_ARTIFACT_SUFFIXES)

--- a/packages/nauro/tests/test_journal.py
+++ b/packages/nauro/tests/test_journal.py
@@ -1,0 +1,256 @@
+"""Tests for the write-path provenance journal.
+
+Covers the ``nauro.store.journal`` module (hashing, append/read, fail-open,
+lock placement) and the ``@journaled`` wiring on the three write adapters
+(committed vs rejected events, the no-event branches, and the fail-open
+guarantee that a journaling defect never breaks a store write).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nauro.mcp import tools
+from nauro.mcp.tools import tool_flag_question, tool_propose_decision, tool_update_state
+from nauro.store.journal import (
+    JOURNAL_DIR,
+    JOURNAL_EVENTS_FILENAME,
+    JOURNAL_LOCK_NAME,
+    JournalEvent,
+    OriginDescriptor,
+    append_event,
+    payload_hash,
+    read_events,
+)
+from nauro.store.registry import register_project_v2
+from nauro.store.snapshot import capture_snapshot, load_snapshot
+from nauro.store.store_lock import rmw_lock_path
+from nauro.templates.scaffolds import scaffold_project_store
+
+_ORIGIN = OriginDescriptor(transport="stdio-mcp", client_name="claude-code", client_version="1.2.3")
+
+_LONG_RATIONALE = "Adopt the widget subsystem because it is measurably better here. " * 3
+
+
+@pytest.fixture
+def store(tmp_path: Path, monkeypatch) -> Path:
+    """Scaffolded project store with the best-effort cloud push disabled."""
+    monkeypatch.setattr(tools, "_try_push", lambda _store_path: None)
+    _pid, store_path = register_project_v2("journalproj", [tmp_path / "repo"])
+    scaffold_project_store("journalproj", store_path)
+    return store_path
+
+
+def _events_file(store_path: Path) -> Path:
+    return store_path / JOURNAL_DIR / JOURNAL_EVENTS_FILENAME
+
+
+# --- payload hashing ---------------------------------------------------------
+
+
+class TestPayloadHash:
+    def test_key_order_independent(self):
+        assert payload_hash({"a": 1, "b": 2, "c": [3, 4]}) == payload_hash(
+            {"c": [3, 4], "b": 2, "a": 1}
+        )
+
+    def test_distinct_payloads_differ(self):
+        assert payload_hash({"title": "x"}) != payload_hash({"title": "y"})
+
+    def test_is_sha256_hex(self):
+        digest = payload_hash({"k": "v"})
+        assert len(digest) == 64
+        assert all(c in "0123456789abcdef" for c in digest)
+
+
+# --- append / read -----------------------------------------------------------
+
+
+class TestAppendReadEvents:
+    def test_one_append_is_one_line(self, store: Path):
+        append_event(
+            store,
+            JournalEvent(
+                operation="update_state",
+                target="state_current.md",
+                status="committed",
+                origin=_ORIGIN,
+                payload_hash=payload_hash({"delta": "x"}),
+            ),
+        )
+        lines = _events_file(store).read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 1
+        events = read_events(store)
+        assert len(events) == 1
+        assert events[0].operation == "update_state"
+
+    def test_read_missing_journal_is_empty(self, store: Path):
+        assert read_events(store) == []
+
+    def test_truncated_final_line_is_tolerated(self, store: Path):
+        for i in range(2):
+            append_event(
+                store,
+                JournalEvent(
+                    operation="flag_question",
+                    target="open-questions.md",
+                    status="committed",
+                    origin=_ORIGIN,
+                    payload_hash=payload_hash({"question": f"q{i}"}),
+                ),
+            )
+        # Simulate an interrupted append: a partial, unterminated final record.
+        with _events_file(store).open("a", encoding="utf-8") as fh:
+            fh.write('{"operation": "flag_question", "target": "open-que')
+        events = read_events(store)
+        assert len(events) == 2
+
+
+# --- lock placement ----------------------------------------------------------
+
+
+class TestJournalLockPath:
+    def test_journal_lock_distinct_from_resource_locks(self, store: Path):
+        journal_lock = store / JOURNAL_DIR / JOURNAL_LOCK_NAME
+        decisions_lock = rmw_lock_path(store, "decisions", is_directory=True)
+        questions_lock = rmw_lock_path(store, "open-questions.md")
+        state_lock = rmw_lock_path(store, "state_current.md")
+        assert journal_lock not in {decisions_lock, questions_lock, state_lock}
+        # The journal lock lives inside its own directory, not the store root
+        # or any resource directory.
+        assert journal_lock.parent == store / JOURNAL_DIR
+
+
+# --- fail-open ---------------------------------------------------------------
+
+
+class TestFailOpen:
+    def test_append_swallows_internal_error(self, store: Path):
+        # An event whose serialization blows up must not surface from append.
+        class Boom:
+            def model_dump_json(self, **_kwargs):
+                raise RuntimeError("serialize boom")
+
+        # append_event must never raise, whatever it is handed.
+        append_event(store, Boom())  # type: ignore[arg-type]
+        assert not _events_file(store).exists()
+
+    def test_write_survives_a_raising_journal_append(self, store: Path, monkeypatch):
+        def boom(*_args, **_kwargs):
+            raise RuntimeError("append boom")
+
+        monkeypatch.setattr(tools, "append_event", boom)
+
+        propose = tool_propose_decision(
+            store, title="Ship the widget", rationale=_LONG_RATIONALE, origin=_ORIGIN
+        )
+        assert propose["status"] == "confirmed"
+
+        flag = tool_flag_question(store, question="Should we ship?", origin=_ORIGIN)
+        assert flag["status"] == "ok"
+
+        update = tool_update_state(store, delta="Shipped the widget", origin=_ORIGIN)
+        assert update["status"] == "ok"
+
+
+# --- adapter wiring: committed / rejected / no-event -------------------------
+
+
+class TestToolJournaling:
+    def test_committed_decision_carries_hash_and_decision_id(self, store: Path):
+        result = tool_propose_decision(
+            store, title="Adopt widgets", rationale=_LONG_RATIONALE, origin=_ORIGIN
+        )
+        assert result["status"] == "confirmed"
+        events = read_events(store)
+        assert len(events) == 1
+        event = events[0]
+        assert event.operation == "propose_decision"
+        assert event.status == "committed"
+        assert event.decision_id == result["decision_id"]
+        assert event.payload_hash
+        assert event.origin is not None
+        assert event.origin.transport == "stdio-mcp"
+
+    def test_flag_question_commits_without_decision_id(self, store: Path):
+        result = tool_flag_question(store, question="Do we cache reads?", origin=_ORIGIN)
+        assert result["status"] == "ok"
+        events = read_events(store)
+        assert len(events) == 1
+        assert events[0].operation == "flag_question"
+        assert events[0].status == "committed"
+        assert events[0].decision_id is None
+        assert events[0].payload_hash
+
+    def test_update_state_commits(self, store: Path):
+        (store / "state_current.md").write_text("- prior state\n")
+        result = tool_update_state(store, delta="Completed the migration", origin=_ORIGIN)
+        assert result["status"] == "ok"
+        events = read_events(store)
+        assert len(events) == 1
+        assert events[0].operation == "update_state"
+        assert events[0].status == "committed"
+
+    def test_update_state_noop_records_no_event(self, store: Path):
+        # No state_current.md and no legacy state.md → kernel returns noop.
+        (store / "state_current.md").unlink(missing_ok=True)
+        result = tool_update_state(store, delta="Nothing to attach to", origin=_ORIGIN)
+        assert result["status"] == "noop"
+        assert read_events(store) == []
+
+    def test_store_missing_records_no_event(self, tmp_path: Path):
+        missing = tmp_path / "does-not-exist"
+        result = tool_propose_decision(
+            missing, title="X", rationale=_LONG_RATIONALE, origin=_ORIGIN
+        )
+        assert result["status"] == "error"
+        assert read_events(missing) == []
+
+    def test_tier1_rejection_records_rejected_event(self, store: Path):
+        oversize = "T" * 5000
+        result = tool_propose_decision(
+            store, title=oversize, rationale=_LONG_RATIONALE, origin=_ORIGIN
+        )
+        assert result["status"] == "rejected"
+        events = read_events(store)
+        assert len(events) == 1
+        assert events[0].operation == "propose_decision"
+        assert events[0].status == "rejected"
+        assert events[0].decision_id is None
+        assert events[0].payload_hash
+
+
+# --- snapshot exclusion ------------------------------------------------------
+
+
+class TestSnapshotExclusion:
+    def test_snapshot_capture_omits_journal(self, store: Path):
+        append_event(
+            store,
+            JournalEvent(
+                operation="propose_decision",
+                target="decisions",
+                status="committed",
+                origin=_ORIGIN,
+                payload_hash=payload_hash({"title": "x"}),
+            ),
+        )
+        version = capture_snapshot(store, trigger="test")
+        snapshot = load_snapshot(store, version)
+        assert not any(key.startswith(JOURNAL_DIR) for key in snapshot.get("files", {}))
+
+
+# --- origin sanitization -----------------------------------------------------
+
+
+class TestOriginSanitization:
+    def test_control_characters_stripped_and_length_bounded(self):
+        origin = OriginDescriptor(
+            transport="stdio-mcp",
+            client_name="cli\x00ent\nname",
+            client_version="v" * 1000,
+        )
+        assert origin.client_name == "clientname"
+        assert len(origin.client_version) == 256

--- a/packages/nauro/tests/test_journal.py
+++ b/packages/nauro/tests/test_journal.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from typer.testing import CliRunner
 
 from nauro.mcp import tools
 from nauro.mcp.tools import tool_flag_question, tool_propose_decision, tool_update_state
@@ -106,6 +107,27 @@ class TestAppendReadEvents:
             fh.write('{"operation": "flag_question", "target": "open-que')
         events = read_events(store)
         assert len(events) == 2
+
+    def test_append_after_unterminated_tail_stays_readable(self, store: Path):
+        # A crash mid-append can leave a final line with no trailing newline.
+        # The next append must not concatenate onto that corrupt fragment and
+        # render the new (valid) event unreadable too.
+        journal = store / JOURNAL_DIR
+        journal.mkdir(parents=True, exist_ok=True)
+        _events_file(store).write_bytes(b'{"operation": "flag_question", "target": "open-que')
+        append_event(
+            store,
+            JournalEvent(
+                operation="update_state",
+                target="state_current.md",
+                status="committed",
+                origin=_ORIGIN,
+                payload_hash=payload_hash({"delta": "x"}),
+            ),
+        )
+        events = read_events(store)
+        assert len(events) == 1
+        assert events[0].operation == "update_state"
 
     def test_truncated_final_multibyte_character_is_tolerated(self, store: Path):
         append_event(
@@ -231,9 +253,50 @@ class TestFailOpen:
             target="state_current.md",
             status="committed",
             payload={"delta": "x"},
-            origin=_ORIGIN,
+            origin_factory=lambda: _ORIGIN,
         )
         assert read_events(store) == []
+
+    def test_record_event_swallows_raising_origin_factory(self, store: Path):
+        # A raising origin factory is invoked inside the guard, so nothing
+        # escapes and nothing is written.
+        from nauro.store.journal import record_event
+
+        def boom():
+            raise RuntimeError("origin boom")
+
+        record_event(
+            store,
+            operation="update_state",
+            target="state_current.md",
+            status="committed",
+            payload={"delta": "x"},
+            origin_factory=boom,
+        )
+        assert read_events(store) == []
+
+    def test_note_write_survives_raising_origin_factory(self, tmp_path: Path, monkeypatch):
+        # The origin is constructed inside record_event's guard, so a defective
+        # cli_origin override cannot escape after the note has committed.
+        from nauro.cli.commands import note as note_cmd
+        from nauro.cli.main import app
+
+        def boom():
+            raise RuntimeError("cli_origin boom")
+
+        monkeypatch.setattr(note_cmd, "cli_origin", boom)
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _pid, store_path = register_project_v2("noteproj", [repo])
+        scaffold_project_store("noteproj", store_path)
+        monkeypatch.chdir(repo)
+
+        result = CliRunner().invoke(app, ["note", "Use Postgres for v2 storage"])
+        assert result.exit_code == 0, result.output
+        # The decision landed; the journal simply recorded nothing for it.
+        assert any(store_path.glob("decisions/*postgres*.md"))
+        assert read_events(store_path) == []
 
 
 # --- adapter wiring: committed / rejected / no-event -------------------------

--- a/packages/nauro/tests/test_journal.py
+++ b/packages/nauro/tests/test_journal.py
@@ -107,6 +107,54 @@ class TestAppendReadEvents:
         events = read_events(store)
         assert len(events) == 2
 
+    def test_truncated_final_multibyte_character_is_tolerated(self, store: Path):
+        append_event(
+            store,
+            JournalEvent(
+                operation="update_state",
+                target="state_current.md",
+                status="committed",
+                origin=_ORIGIN,
+                payload_hash=payload_hash({"delta": "x"}),
+            ),
+        )
+        # A crash mid-append can leave a partial multibyte UTF-8 sequence as the
+        # final bytes: the first byte of "€" (\xe2\x82\xac) with the rest lost.
+        with _events_file(store).open("ab") as fh:
+            fh.write(b'{"delta": "\xe2')
+        events = read_events(store)
+        assert len(events) == 1
+
+    def test_line_separator_in_client_name_does_not_break_framing(self, store: Path):
+        # U+2028 is a Unicode line separator that str.splitlines() would treat
+        # as a record boundary; ensure_ascii serialization escapes it, so the
+        # single event still round-trips as one line.
+        evil_name = "evil" + chr(0x2028) + "client"
+        origin = OriginDescriptor(
+            transport="stdio-mcp",
+            client_name=evil_name,
+            client_version="1.0",
+        )
+        append_event(
+            store,
+            JournalEvent(
+                operation="flag_question",
+                target="open-questions.md",
+                status="committed",
+                origin=origin,
+                payload_hash=payload_hash({"question": "q"}),
+            ),
+        )
+        raw = _events_file(store).read_bytes()
+        # No raw U+2028 byte sequence landed, and exactly one physical line
+        # was written (the separator did not split the record).
+        assert b"\xe2\x80\xa8" not in raw
+        assert raw.count(b"\n") == 1
+        events = read_events(store)
+        assert len(events) == 1
+        assert events[0].origin is not None
+        assert events[0].origin.client_name == evil_name
+
 
 # --- lock placement ----------------------------------------------------------
 
@@ -130,18 +178,18 @@ class TestFailOpen:
     def test_append_swallows_internal_error(self, store: Path):
         # An event whose serialization blows up must not surface from append.
         class Boom:
-            def model_dump_json(self, **_kwargs):
+            def model_dump(self, **_kwargs):
                 raise RuntimeError("serialize boom")
 
         # append_event must never raise, whatever it is handed.
         append_event(store, Boom())  # type: ignore[arg-type]
         assert not _events_file(store).exists()
 
-    def test_write_survives_a_raising_journal_append(self, store: Path, monkeypatch):
+    def test_write_survives_a_raising_journal_record(self, store: Path, monkeypatch):
         def boom(*_args, **_kwargs):
-            raise RuntimeError("append boom")
+            raise RuntimeError("record boom")
 
-        monkeypatch.setattr(tools, "append_event", boom)
+        monkeypatch.setattr(tools, "record_event", boom)
 
         propose = tool_propose_decision(
             store, title="Ship the widget", rationale=_LONG_RATIONALE, origin=_ORIGIN
@@ -153,6 +201,39 @@ class TestFailOpen:
 
         update = tool_update_state(store, delta="Shipped the widget", origin=_ORIGIN)
         assert update["status"] == "ok"
+
+    def test_write_survives_event_construction_failure(self, store: Path, monkeypatch):
+        # A failure inside event construction/hashing (not just the file append)
+        # must be swallowed end-to-end: record_event guards the whole region.
+        def boom(*_args, **_kwargs):
+            raise RuntimeError("construct boom")
+
+        monkeypatch.setattr("nauro.store.journal.payload_hash", boom)
+
+        propose = tool_propose_decision(
+            store, title="Ship the widget", rationale=_LONG_RATIONALE, origin=_ORIGIN
+        )
+        assert propose["status"] == "confirmed"
+        assert read_events(store) == []
+
+    def test_record_event_swallows_construction_failure(self, store: Path, monkeypatch):
+        # Direct record_event coverage: a raising JournalEvent constructor is
+        # caught, and nothing is written.
+        def boom(*_args, **_kwargs):
+            raise RuntimeError("construct boom")
+
+        monkeypatch.setattr("nauro.store.journal.JournalEvent", boom)
+        from nauro.store.journal import record_event
+
+        record_event(
+            store,
+            operation="update_state",
+            target="state_current.md",
+            status="committed",
+            payload={"delta": "x"},
+            origin=_ORIGIN,
+        )
+        assert read_events(store) == []
 
 
 # --- adapter wiring: committed / rejected / no-event -------------------------

--- a/packages/nauro/tests/test_provenance_wiring.py
+++ b/packages/nauro/tests/test_provenance_wiring.py
@@ -1,0 +1,170 @@
+"""Cross-surface wiring for write-path provenance.
+
+Asserts each transport stamps the right origin (stdio-MCP reads the injected
+Context's clientInfo; the CLI stamps ``transport: cli``), that the injected
+Context parameter stays out of the derived tool schema, and that adding
+provenance capture added no new tool or CLI surface.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from typer.testing import CliRunner
+
+from nauro.cli.autogen import AUTOGEN_ALLOWLIST
+from nauro.cli.main import app
+from nauro.mcp import stdio_server, tools
+from nauro.mcp.stdio_server import mcp, propose_decision
+from nauro.store.journal import read_events
+from nauro.store.registry import register_project_v2
+from nauro.templates.scaffolds import scaffold_project_store
+
+runner = CliRunner()
+
+_LONG_RATIONALE = "Adopt the widget subsystem because it is measurably better here. " * 3
+
+_WRITE_TOOLS = ("propose_decision", "flag_question", "update_state")
+
+
+def _fake_ctx(name: str | None, version: str | None) -> SimpleNamespace:
+    """A stand-in FastMCP Context exposing session.client_params.clientInfo."""
+    client_info = SimpleNamespace(name=name, version=version)
+    client_params = SimpleNamespace(clientInfo=client_info)
+    session = SimpleNamespace(client_params=client_params)
+    return SimpleNamespace(session=session)
+
+
+@pytest.fixture
+def store(tmp_path: Path, monkeypatch) -> Path:
+    monkeypatch.setattr(tools, "_try_push", lambda _store_path: None)
+    _pid, store_path = register_project_v2("provproj", [tmp_path / "repo"])
+    scaffold_project_store("provproj", store_path)
+    return store_path
+
+
+# --- stdio-MCP origin --------------------------------------------------------
+
+
+class TestStdioOrigin:
+    def test_client_info_recorded_and_sanitized(self, store: Path):
+        ctx = _fake_ctx("Claude\x00 Code", "1." + "9" * 400)
+        result = propose_decision(
+            project_id="provproj",
+            title="Adopt widgets",
+            rationale=_LONG_RATIONALE,
+            mcp_ctx=ctx,
+        )
+        assert result["status"] == "confirmed"
+        events = read_events(store)
+        assert len(events) == 1
+        origin = events[0].origin
+        assert origin is not None
+        assert origin.transport == "stdio-mcp"
+        assert origin.client_name == "Claude Code"  # NUL stripped
+        assert len(origin.client_version) == 256  # length bounded
+
+    def test_none_safe_when_client_params_absent(self, store: Path):
+        # A Context with no client_params, and no Context at all, both yield a
+        # well-formed stdio-mcp descriptor with the name/version unset.
+        for ctx in (SimpleNamespace(session=SimpleNamespace(client_params=None)), None):
+            origin = stdio_server._origin_from_ctx(ctx)
+            assert origin.transport == "stdio-mcp"
+            assert origin.client_name is None
+            assert origin.client_version is None
+
+
+# --- schema invariance -------------------------------------------------------
+
+
+class TestSchemaInvariance:
+    @pytest.fixture
+    def tools_by_name(self):
+        return {t.name: t for t in mcp._tool_manager.list_tools()}
+
+    @pytest.mark.parametrize("name", _WRITE_TOOLS)
+    def test_mcp_ctx_absent_from_schema(self, tools_by_name, name):
+        props = tools_by_name[name].parameters.get("properties", {})
+        assert "mcp_ctx" not in props
+
+    def test_flag_question_still_advertises_context(self, tools_by_name):
+        props = tools_by_name["flag_question"].parameters["properties"]
+        assert "context" in props
+
+
+# --- CLI attribution ---------------------------------------------------------
+
+
+class TestCliAttribution:
+    def _project(self, tmp_path: Path, monkeypatch) -> tuple[Path, Path]:
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _pid, store = register_project_v2("cliproj", [repo])
+        scaffold_project_store("cliproj", store)
+        monkeypatch.chdir(repo)
+        return repo, store
+
+    def test_autogen_propose_decision_stamps_cli(self, tmp_path: Path, monkeypatch):
+        _repo, store = self._project(tmp_path, monkeypatch)
+        result = runner.invoke(
+            app,
+            ["propose-decision", _LONG_RATIONALE, "--title", "Adopt widgets"],
+        )
+        assert result.exit_code == 0, result.output
+        events = read_events(store)
+        assert len(events) == 1
+        assert events[0].operation == "propose_decision"
+        assert events[0].origin is not None
+        assert events[0].origin.transport == "cli"
+        assert events[0].origin.client_name == "nauro-cli"
+
+    def test_note_stamps_cli(self, tmp_path: Path, monkeypatch):
+        _repo, store = self._project(tmp_path, monkeypatch)
+        result = runner.invoke(app, ["note", "Use Postgres for v2 storage"])
+        assert result.exit_code == 0, result.output
+        events = read_events(store)
+        assert len(events) == 1
+        assert events[0].operation == "propose_decision"
+        assert events[0].origin.transport == "cli"
+        assert events[0].origin.client_name == "nauro-cli"
+
+    def test_import_adr_stamps_cli(self, tmp_path: Path, monkeypatch):
+        _repo, store = self._project(tmp_path, monkeypatch)
+        adr_dir = tmp_path / "adrs"
+        adr_dir.mkdir()
+        (adr_dir / "001-use-postgres.md").write_text(
+            "# Use Postgres\n\n## Context\n\nWe need a relational store.\n"
+        )
+        result = runner.invoke(app, ["import", "--adr", str(adr_dir)])
+        assert result.exit_code == 0, result.output
+        events = read_events(store)
+        assert len(events) == 1
+        assert events[0].operation == "propose_decision"
+        assert events[0].origin.transport == "cli"
+        assert events[0].origin.client_name == "nauro-cli"
+
+
+# --- no new surface ----------------------------------------------------------
+
+
+class TestNoNewSurface:
+    def test_ten_tools_still_registered(self):
+        assert len(mcp._tool_manager.list_tools()) == 10
+
+    def test_autogen_allowlist_unchanged(self):
+        assert AUTOGEN_ALLOWLIST == frozenset(
+            {
+                "get_context",
+                "get_raw_file",
+                "list_decisions",
+                "get_decision",
+                "diff_since_last_session",
+                "search_decisions",
+                "check_decision",
+                "update_state",
+                "flag_question",
+                "propose_decision",
+            }
+        )

--- a/packages/nauro/tests/test_provenance_wiring.py
+++ b/packages/nauro/tests/test_provenance_wiring.py
@@ -145,6 +145,27 @@ class TestCliAttribution:
         assert events[0].origin.transport == "cli"
         assert events[0].origin.client_name == "nauro-cli"
 
+    def test_import_memory_bank_journals_file_merges(self, tmp_path: Path, monkeypatch):
+        # projectBrief.md → project.md and techContext.md → stack.md mutate
+        # store content, so each merge must journal a committed import_merge
+        # event — a valid import never leaves the journal empty.
+        _repo, store = self._project(tmp_path, monkeypatch)
+        mb = tmp_path / "memory-bank"
+        mb.mkdir()
+        (mb / "projectBrief.md").write_text("# Brief\n\nWe are building a widget.\n")
+        (mb / "techContext.md").write_text("# Tech\n\nPython and Postgres.\n")
+        result = runner.invoke(app, ["import", "--memory-bank", str(mb)])
+        assert result.exit_code == 0, result.output
+        events = read_events(store)
+        merges = [e for e in events if e.operation == "import_merge"]
+        targets = {e.target for e in merges}
+        assert targets == {"project.md", "stack.md"}
+        for event in merges:
+            assert event.status == "committed"
+            assert event.origin is not None
+            assert event.origin.transport == "cli"
+            assert event.origin.client_name == "nauro-cli"
+
 
 # --- no new surface ----------------------------------------------------------
 

--- a/packages/nauro/tests/test_sync/test_journal_excluded.py
+++ b/packages/nauro/tests/test_sync/test_journal_excluded.py
@@ -1,0 +1,87 @@
+"""The write-path provenance journal is excluded from cloud sync (push + pull).
+
+The unit rule lives in ``test_merge.py::TestShouldSkip``; these drive the real
+push enumeration and pull manifest walk to prove the journal never leaves — nor
+lands on — a machine over sync.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import httpx
+
+from nauro.sync.pull import run_pull
+from nauro.sync.push import push_changed_files
+from tests.conftest import seed_auth_config
+from tests.test_sync.conftest import CLOUD_PID, _scaffolded_cloud_project
+
+
+def _ok(status: int, payload: dict) -> httpx.Response:
+    return httpx.Response(
+        status,
+        content=json.dumps(payload).encode("utf-8"),
+        headers={"content-type": "application/json"},
+    )
+
+
+class _RecordingReporter:
+    def __init__(self) -> None:
+        self.infos: list[str] = []
+        self.warns: list[str] = []
+
+    def info(self, msg: str) -> None:
+        self.infos.append(msg)
+
+    def warn(self, msg: str) -> None:
+        self.warns.append(msg)
+
+
+def _seed_journal(store: Path) -> None:
+    journal = store / "journal"
+    journal.mkdir(parents=True, exist_ok=True)
+    (journal / "events.jsonl").write_text('{"operation": "update_state"}\n', encoding="utf-8")
+    (journal / ".lock").write_text("", encoding="utf-8")
+
+
+def test_push_does_not_enumerate_journal(tmp_path):
+    store = _scaffolded_cloud_project("pushj", tmp_path, project_id=CLOUD_PID)
+    seed_auth_config(variant="sync")
+    _seed_journal(store)
+
+    captured: dict[str, list] = {}
+
+    def fake_presign(project_id, operations):
+        captured["ops"] = operations
+        return []  # no URLs → nothing is uploaded
+
+    with patch("nauro.sync.remote.request_presigned_urls", side_effect=fake_presign):
+        push_changed_files(CLOUD_PID, store)
+
+    paths = [op["path"] for op in captured["ops"]]
+    # A normal store file is enumerated; nothing under journal/ ever is.
+    assert "project.md" in paths
+    assert not any(p.startswith("journal/") for p in paths)
+
+
+def test_pull_skips_remote_journal_path(tmp_path):
+    store = _scaffolded_cloud_project("pullj", tmp_path, project_id=CLOUD_PID)
+    seed_auth_config(variant="sync")
+
+    rel = "journal/events.jsonl"
+    manifest = _ok(200, {"files": [{"path": rel, "etag": '"new"', "size": 1}], "next_cursor": None})
+
+    def fake_get(url, **kwargs):
+        if "/sync/manifest" in url:
+            return manifest
+        raise AssertionError("journal path must never be fetched")
+
+    reporter = _RecordingReporter()
+    with patch("nauro.sync.remote.httpx.get", side_effect=fake_get):
+        merged = run_pull(CLOUD_PID, store, reporter)
+
+    assert merged == 0
+    assert not (store / rel).exists()
+    assert reporter.warns == []

--- a/packages/nauro/tests/test_sync/test_merge.py
+++ b/packages/nauro/tests/test_sync/test_merge.py
@@ -54,6 +54,12 @@ class TestShouldSkip:
         assert should_skip("journal/events.jsonl") is True
         assert should_skip("journal/.lock") is True
 
+    def test_journal_skip_normalizes_windows_separators(self):
+        # The push scan builds relative paths via str(relative_to(...)), which
+        # yields backslash separators on Windows; the rule must still match.
+        assert should_skip("journal\\events.jsonl") is True
+        assert should_skip("decisions\\.lock") is True
+
 
 class TestDetectConflict:
     def test_no_previous_state(self):

--- a/packages/nauro/tests/test_sync/test_merge.py
+++ b/packages/nauro/tests/test_sync/test_merge.py
@@ -48,6 +48,12 @@ class TestShouldSkip:
         assert should_skip("context/poetry.lock") is False
         assert should_skip("uv.lock") is False
 
+    def test_journal_is_never_synced(self):
+        # The write-path provenance journal is store-local in v1: its events
+        # log and its lock are both excluded from cloud sync.
+        assert should_skip("journal/events.jsonl") is True
+        assert should_skip("journal/.lock") is True
+
 
 class TestDetectConflict:
     def test_no_previous_state(self):


### PR DESCRIPTION
## Why

Originating-surface provenance is unbackfillable: until capture ships, which
surface produced any given write is permanently unauditable. Today the MCP tool
layer hardcodes a single source, the autogenerated propose-decision CLI command
routes through that same adapter and is misattributed, and note/import/question
flags carry no source at all. A doctrine operations viewer is planned, but
capture has no viewer dependency — so it ships first as a normal minor release,
journal-only.

## What changed

- New store-local, append-only JSONL journal (journal/events.jsonl). Each
  write-path action appends one origin-stamped event: event id, RFC3339
  timestamp, operation + target, committed/rejected status, decision id when
  present, an origin descriptor (transport + free-form client name/version,
  plus a reserved-but-unset actor slot), and a payload hash under a named
  canonical serialization. The hash is an attempt marker — it proves two
  payloads differed, it does not preserve a proposed-vs-ratified delta.
- Emission lives in the transport adapters, not the kernel: Tier-1 rejections
  occur before the kernel runs (so only the adapter can record attempts), and
  the kernel's per-resource locks do not serialize journal appends, so the
  journal takes its own dedicated lock acquired after the resource lock is
  released. Emission is fail-open end-to-end — origin construction, hashing,
  event construction, and the append all sit inside one guarded region, so a
  journaling failure never blocks or fails the underlying write.
- Per-transport origin: stdio MCP reads clientInfo through a schema-invisible
  FastMCP Context parameter; the CLI stamps transport cli at the command layer,
  including the hand-written note and import direct-write paths (import also
  journals its project/stack merges).
- Durable framing: written lines are ASCII-escaped so client-supplied Unicode
  line separators cannot split records; the reader splits on newline bytes
  only, decodes per line, and tolerates a truncated final record; an append
  after a crash-truncated unterminated tail isolates the fragment on its own
  line instead of concatenating into the new event.
- The journal is store data, not telemetry: excluded from cloud sync via a new
  journal/ prefix rule (separator-normalized, so Windows paths are covered),
  and already outside snapshot capture.

Author identity is not captured (the descriptor reserves the slot additively).
Decision-file frontmatter was deliberately not used as the carrier — the strict
parser forbids unknown keys, so an additive field would break every
already-shipped reader; that path is deferred to a store-format major or an
explicit reader-tolerance rollout. Journal rotation is deferred.

## Test plan

- New tests: payload-hash key-order determinism, one-append/one-line, truncated
  final-line and truncated-multibyte tolerance, unterminated-tail append
  readability, U+2028-in-client-name framing, journal lock path distinct from
  resource locks, committed vs rejected event fields, noop/store-missing
  no-event branches, fail-open end-to-end (raising append, raising event
  construction, and raising origin factory all leave the write successful),
  origin sanitization, stdio clientInfo capture + None-safety, schema
  invariance (mcp_ctx absent, context retained), CLI attribution for
  propose/note/import, import project/stack merge events, push+pull journal
  exclusion incl. Windows separators, snapshot exclusion, and no-new-surface.
- Full suites: nauro 2070 passed / 10 skipped; nauro-core 1077 passed.
- ruff check + format clean; the frozen public-contract test passes without
  regeneration.

## Risk / what to review

The frozen 1.0 public contract is unchanged and its test passes without
regeneration: the added adapter kwarg is internal and the injected Context
parameter is excluded from the derived tool schema (asserted by a new
schema-invariance test). Worth a look: the decorator's status→event mapping and
the after-lock emission ordering.

## Deferred

Decision-file frontmatter carrier, journal rotation, author-identity axis, and
the hosted-server origin mapping are intentionally out of scope for this
journal-only 1.x change.
