### PR TITLE
Make decision frontmatter parsing read-tolerant of unknown keys

### DIFF
--- a/packages/nauro-core/src/nauro_core/decision_model.py
+++ b/packages/nauro-core/src/nauro_core/decision_model.py
@@ -24,9 +24,11 @@ Round-trip bound (precise):
   specialty-tag containers may be normalized, and unordered containers may
   serialize nondeterministically. Semantic value is preserved; exact bytes
   of an arbitrary value are not promised.
-- A value the writer cannot re-serialize fails loudly at rewrite rather than
-  being dropped: the JSON-mode dump gate raises on values PyYAML safe-dump
-  cannot emit (e.g. a non-UTF-8 `!!binary`).
+- A value the JSON-mode dump gate cannot process fails loudly at rewrite
+  rather than being dropped: `model_dump(mode="json")` raises on such a value
+  (e.g. non-UTF-8 bytes from a `!!binary`) *before* YAML serialization is
+  reached. YAML itself could represent those bytes, so the gate, not the YAML
+  writer, is the failing layer.
 - Byte-identity is guaranteed only for a *trailing* unknown key whose value
   has a deterministic representation, in an already-canonical nauro-authored
   file. An unknown key interleaved among known keys migrates to the end of
@@ -456,9 +458,10 @@ def format_decision(decision: Decision) -> str:
     captured on the tolerant reader (``model_extra``) are appended after the
     known block in first-seen order, so their values are never dropped; an
     interleaved unknown key migrates to the end on reformat. Value fidelity is
-    bounded by PyYAML safe-dump normalization, and a value safe-dump cannot
-    emit raises here rather than being silently lost. Byte-identity holds only
-    for a trailing unknown key with a deterministic representation in an
+    bounded by PyYAML safe-dump normalization, and a value the JSON-mode dump
+    gate cannot process (e.g. non-UTF-8 bytes) raises there — before YAML
+    emission — rather than being silently lost. Byte-identity holds only for a
+    trailing unknown key with a deterministic representation in an
     already-canonical file. See the module docstring for the full bound.
     """
     dumped = decision.model_dump(mode="json", exclude=_DERIVED_FIELDS)

--- a/packages/nauro-core/src/nauro_core/decision_model.py
+++ b/packages/nauro-core/src/nauro_core/decision_model.py
@@ -16,11 +16,22 @@ exactly such a rewrite path, so preservation is load-bearing, not cosmetic.
 Typos on required keys still fail loudly: omitting `confidence` while adding
 `confidance` is a missing-required error, not a tolerated unknown key.
 
-Round-trip bound: values of unknown keys always survive a read-modify-write.
-Unknown keys trailing the known frontmatter round-trip byte-identically. An
-unknown key interleaved among known keys migrates to the end of the
-frontmatter block on rewrite (the writer emits known keys in canonical order,
-then unknown keys in first-seen order); its value is unchanged.
+Round-trip bound (precise):
+
+- Unknown keys are never silently dropped. Their values pass back through
+  `format_decision` subject to PyYAML safe-load/safe-dump normalization —
+  scalar representation, quoting style, key ordering within a mapping, and
+  specialty-tag containers may be normalized, and unordered containers may
+  serialize nondeterministically. Semantic value is preserved; exact bytes
+  of an arbitrary value are not promised.
+- A value the writer cannot re-serialize fails loudly at rewrite rather than
+  being dropped: the JSON-mode dump gate raises on values PyYAML safe-dump
+  cannot emit (e.g. a non-UTF-8 `!!binary`).
+- Byte-identity is guaranteed only for a *trailing* unknown key whose value
+  has a deterministic representation, in an already-canonical nauro-authored
+  file. An unknown key interleaved among known keys migrates to the end of
+  the frontmatter block on rewrite (the writer emits known keys in canonical
+  order, then unknown keys in first-seen order).
 
 Supersession refs (`supersedes`, `superseded_by`) are validated as plain
 integer strings: "70", not "070" or "070-some-slug" or "D70".
@@ -443,9 +454,12 @@ def format_decision(decision: Decision) -> str:
 
     Known keys are emitted in canonical ``_FRONTMATTER_ORDER``. Unknown keys
     captured on the tolerant reader (``model_extra``) are appended after the
-    known block in first-seen order, so their values survive every rewrite.
-    An unknown key interleaved among known keys therefore migrates to the end
-    on reformat; a trailing unknown key round-trips byte-identically.
+    known block in first-seen order, so their values are never dropped; an
+    interleaved unknown key migrates to the end on reformat. Value fidelity is
+    bounded by PyYAML safe-dump normalization, and a value safe-dump cannot
+    emit raises here rather than being silently lost. Byte-identity holds only
+    for a trailing unknown key with a deterministic representation in an
+    already-canonical file. See the module docstring for the full bound.
     """
     dumped = decision.model_dump(mode="json", exclude=_DERIVED_FIELDS)
 

--- a/packages/nauro-core/src/nauro_core/decision_model.py
+++ b/packages/nauro-core/src/nauro_core/decision_model.py
@@ -4,9 +4,23 @@ The authoritative shape for a parsed decision. `parse_decision` reads a
 markdown file with YAML frontmatter and returns a validated `Decision`.
 `format_decision` goes the other way.
 
-Strict by design. Unknown enum values, missing required fields, malformed
-YAML, non-ISO dates, reasonless rejected alternatives on active decisions,
-and superseded decisions without a `superseded_by` ref all raise.
+Tolerant reader, known-key writer. Unknown enum values, missing required
+fields, malformed YAML, non-ISO dates, reasonless rejected alternatives on
+active decisions, and superseded decisions without a `superseded_by` ref all
+still raise. But an *unknown* frontmatter key (one this version has no field
+for) is accepted and preserved rather than rejected: a newer writer may have
+authored a key this reader does not model, and dropping it on a read-modify-
+write cycle would silently strip fields the newer version depends on — a
+worse failure than rejection, landing far from its cause. Supersession is
+exactly such a rewrite path, so preservation is load-bearing, not cosmetic.
+Typos on required keys still fail loudly: omitting `confidence` while adding
+`confidance` is a missing-required error, not a tolerated unknown key.
+
+Round-trip bound: values of unknown keys always survive a read-modify-write.
+Unknown keys trailing the known frontmatter round-trip byte-identically. An
+unknown key interleaved among known keys migrates to the end of the
+frontmatter block on rewrite (the writer emits known keys in canonical order,
+then unknown keys in first-seen order); its value is unchanged.
 
 Supersession refs (`supersedes`, `superseded_by`) are validated as plain
 integer strings: "70", not "070" or "070-some-slug" or "D70".
@@ -103,9 +117,13 @@ class Decision(BaseModel):
     Frontmatter fields round-trip through YAML. Derived fields (``num``,
     ``title``, ``rationale``, ``body``, ``content``) are populated by the
     parser from the markdown body and the filename.
+
+    ``extra="allow"``: unknown frontmatter keys are captured in
+    ``model_extra`` and preserved through ``format_decision`` rather than
+    rejected. See the module docstring for the tolerant-reader contract.
     """
 
-    model_config = ConfigDict(extra="forbid", validate_assignment=True)
+    model_config = ConfigDict(extra="allow", validate_assignment=True)
 
     # ── Frontmatter: required ──
     date: _date
@@ -220,9 +238,12 @@ _H1_FORMAT = "# {num:03d} \u2014 {title}"
 def parse_decision(text: str, filename: str) -> Decision:
     """Parse a decision markdown file into a validated ``Decision``.
 
-    Strict by design: raises ``ValueError`` (and propagates
-    ``pydantic.ValidationError``) on any deviation from the canonical
-    v2 format.
+    Strict on structure, tolerant on unknown frontmatter keys: raises
+    ``ValueError`` (and propagates ``pydantic.ValidationError``) on any
+    deviation from the canonical v2 format, but an unknown frontmatter key is
+    captured by ``Decision``'s ``extra="allow"`` config — the
+    ``Decision(**metadata, ...)`` call below absorbs it into ``model_extra``
+    automatically — and preserved on rewrite instead of rejected.
 
     Raises:
         ValueError: missing/unterminated frontmatter, missing H1, missing
@@ -419,6 +440,12 @@ def format_decision(decision: Decision) -> str:
         {reason}
 
     Idempotent with ``parse_decision``: format → parse → format is byte-identical.
+
+    Known keys are emitted in canonical ``_FRONTMATTER_ORDER``. Unknown keys
+    captured on the tolerant reader (``model_extra``) are appended after the
+    known block in first-seen order, so their values survive every rewrite.
+    An unknown key interleaved among known keys therefore migrates to the end
+    on reformat; a trailing unknown key round-trips byte-identically.
     """
     dumped = decision.model_dump(mode="json", exclude=_DERIVED_FIELDS)
 
@@ -431,6 +458,8 @@ def format_decision(decision: Decision) -> str:
         dumped["date"] = _date.fromisoformat(dumped["date"])
 
     ordered = {k: dumped[k] for k in _FRONTMATTER_ORDER if k in dumped}
+    for key, value in (decision.model_extra or {}).items():
+        ordered[key] = value
 
     yaml_block = yaml.safe_dump(
         ordered,

--- a/packages/nauro-core/src/nauro_core/doctor.py
+++ b/packages/nauro-core/src/nauro_core/doctor.py
@@ -12,6 +12,11 @@ and reports four kinds of structural defect in the decision set:
        or a forward/back conflict where ``X.supersedes=Y`` while ``Y`` records
        ``superseded_by=Z`` naming a third, present decision.
 
+It also surfaces unknown frontmatter keys — keys the reader tolerates and
+preserves but does not model. This is advisory, not a defect: the tolerant
+reader accepts them by design, so they do not make a store unclean
+(:attr:`StoreDiagnosis.is_clean` stays tied to the four defect categories).
+
 Every check is zero-false-positive by construction and the output is fully
 sorted, so two diagnoses over the same store are identical. The module stands
 apart from ``graph.py``: that builder's edge collection keeps only live
@@ -87,6 +92,19 @@ class StatusContradiction(BaseModel):
     conflicting_with: int | None = None
 
 
+class UnknownFrontmatterKeys(BaseModel):
+    """A parsed decision carrying frontmatter keys the reader does not model.
+
+    Advisory only: the tolerant reader preserves these keys, so their presence
+    is not an integrity defect. ``keys`` is sorted.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    number: int
+    keys: tuple[str, ...]
+
+
 class StoreDiagnosis(BaseModel):
     """The full result of :func:`diagnose_store`. Every list is sorted."""
 
@@ -96,10 +114,15 @@ class StoreDiagnosis(BaseModel):
     dangling_refs: list[DanglingRef] = Field(default_factory=list)
     cycles: list[SupersessionCycle] = Field(default_factory=list)
     contradictions: list[StatusContradiction] = Field(default_factory=list)
+    unknown_frontmatter_keys: list[UnknownFrontmatterKeys] = Field(default_factory=list)
 
     @property
     def is_clean(self) -> bool:
-        """True when no defect of any category was found."""
+        """True when no defect of any category was found.
+
+        Unknown frontmatter keys are advisory, not a defect, so they never
+        make a store unclean.
+        """
         return not (self.unparseable or self.dangling_refs or self.cycles or self.contradictions)
 
 
@@ -124,13 +147,25 @@ def diagnose_store(store: Store) -> StoreDiagnosis:
     dangling_refs = _dangling_refs(parsed, existing_numbers)
     cycles = _cycles(parsed)
     contradictions = _contradictions(parsed, by_num, existing_numbers)
+    unknown_frontmatter_keys = _unknown_frontmatter_keys(parsed)
 
     return StoreDiagnosis(
         unparseable=unparseable,
         dangling_refs=dangling_refs,
         cycles=cycles,
         contradictions=contradictions,
+        unknown_frontmatter_keys=unknown_frontmatter_keys,
     )
+
+
+def _unknown_frontmatter_keys(parsed: list[Decision]) -> list[UnknownFrontmatterKeys]:
+    """Decisions carrying tolerated-but-unmodeled frontmatter keys. Sorted."""
+    rows: list[UnknownFrontmatterKeys] = []
+    for d in parsed:
+        extras = d.model_extra or {}
+        if extras:
+            rows.append(UnknownFrontmatterKeys(number=d.num, keys=tuple(sorted(extras))))
+    return sorted(rows, key=lambda row: row.number)
 
 
 def _index_by_num(parsed: list[Decision]) -> dict[int, Decision]:

--- a/packages/nauro-core/tests/test_decision_model.py
+++ b/packages/nauro-core/tests/test_decision_model.py
@@ -639,19 +639,90 @@ class TestNegativeValidation:
         with pytest.raises(ValidationError, match="superseded_by"):
             parse_decision(text, "001-test.md")
 
-    def test_extra_frontmatter_key_raises(self) -> None:
-        """extra='forbid' on Decision means typos fail loudly."""
+    def test_unknown_frontmatter_key_is_preserved(self) -> None:
+        """extra='allow': an unknown key (alongside valid confidence) is
+        captured in model_extra and round-trips rather than raising."""
         text = (
             "---\n"
             "date: 2026-04-01\n"
             "confidence: high\n"
-            "confidance: high\n"  # typo
+            "confidance: high\n"  # unknown key sitting next to the real one
             "---\n\n"
-            "# 001 \u2014 Typo in frontmatter\n\n"
+            "# 001 \u2014 Unknown key in frontmatter\n\n"
+            "## Decision\n\nSomething.\n"
+        )
+        decision = parse_decision(text, "001-test.md")
+        assert decision.model_extra == {"confidance": "high"}
+        assert "confidance: high" in format_decision(decision)
+
+    def test_required_key_typo_still_raises(self) -> None:
+        """A typo that omits a required key (confidence) fails loudly: the
+        unknown 'confidance' is tolerated, but the missing 'confidence' is a
+        missing-required error, not a tolerated unknown key."""
+        text = (
+            "---\n"
+            "date: 2026-04-01\n"
+            "confidance: high\n"  # only the typo \u2014 real key absent
+            "---\n\n"
+            "# 001 \u2014 Required key typo\n\n"
             "## Decision\n\nSomething.\n"
         )
         with pytest.raises(ValidationError):
             parse_decision(text, "001-test.md")
+
+
+class TestUnknownFrontmatterKeys:
+    """Tolerant-reader contract: unknown frontmatter keys survive round-trip."""
+
+    _TRAILING_UNKNOWN = (
+        "---\n"
+        "date: 2026-04-01\n"
+        "version: 1\n"
+        "status: active\n"
+        "confidence: high\n"
+        "decision_type: null\n"
+        "reversibility: null\n"
+        "source: null\n"
+        "files_affected: []\n"
+        "supersedes: null\n"
+        "superseded_by: null\n"
+        "origin: codex-1.2.3\n"
+        "---\n\n"
+        "# 001 \u2014 Trailing unknown key\n\n"
+        "## Decision\n\nChose A.\n"
+    )
+
+    def test_trailing_unknown_key_round_trips_byte_identically(self) -> None:
+        """A canonical frontmatter with a trailing unknown key reformats to
+        the same bytes: the writer appends unknown keys after the known block."""
+        decision = parse_decision(self._TRAILING_UNKNOWN, "001-test.md")
+        assert decision.model_extra == {"origin": "codex-1.2.3"}
+        assert format_decision(decision) == self._TRAILING_UNKNOWN
+
+    def test_unknown_key_survives_model_copy_supersede_flip(self) -> None:
+        """The supersede rewrite path uses model_copy(update=...); an unknown
+        key on the old decision must survive the flip and re-emit."""
+        decision = parse_decision(self._TRAILING_UNKNOWN, "001-test.md")
+        flipped = decision.model_copy(
+            update={
+                "status": DecisionStatus.superseded,
+                "superseded_by": "42",
+            }
+        )
+        assert flipped.model_extra == {"origin": "codex-1.2.3"}
+        formatted = format_decision(flipped)
+        assert "origin: codex-1.2.3" in formatted
+        assert "status: superseded" in formatted
+        assert "superseded_by: '42'" in formatted
+
+    def test_no_extras_output_is_byte_identical(self) -> None:
+        """With no unknown keys, output is unchanged from the pre-tolerance
+        writer: the extras loop adds nothing."""
+        decision = parse_decision(MINIMAL_V2, MINIMAL_V2_FILENAME)
+        assert decision.model_extra in (None, {})
+        assert format_decision(decision) == format_decision(
+            parse_decision(format_decision(decision), MINIMAL_V2_FILENAME)
+        )
 
 
 # ── Model-level construction tests (no parsing) ──

--- a/packages/nauro-core/tests/test_decision_model.py
+++ b/packages/nauro-core/tests/test_decision_model.py
@@ -715,14 +715,16 @@ class TestUnknownFrontmatterKeys:
         assert "status: superseded" in formatted
         assert "superseded_by: '42'" in formatted
 
-    def test_no_extras_output_is_byte_identical(self) -> None:
-        """With no unknown keys, output is unchanged from the pre-tolerance
-        writer: the extras loop adds nothing."""
-        decision = parse_decision(MINIMAL_V2, MINIMAL_V2_FILENAME)
+    @pytest.mark.parametrize("text,filename", ALL_FIXTURES)
+    def test_no_extras_output_matches_prechange_bytes(self, text: str, filename: str) -> None:
+        """With no unknown keys, the writer's output is byte-for-byte the
+        pre-tolerance output. The checked-in fixtures were authored in
+        canonical form and predate this change, so each fixture IS pre-change
+        writer output; asserting ``format(parse(fixture)) == fixture`` pins the
+        formatter against a golden captured before the extras loop existed."""
+        decision = parse_decision(text, filename)
         assert decision.model_extra in (None, {})
-        assert format_decision(decision) == format_decision(
-            parse_decision(format_decision(decision), MINIMAL_V2_FILENAME)
-        )
+        assert format_decision(decision) == text
 
 
 # ── Model-level construction tests (no parsing) ──

--- a/packages/nauro-core/tests/test_doctor.py
+++ b/packages/nauro-core/tests/test_doctor.py
@@ -17,7 +17,7 @@ from nauro_core.decision_model import (
     format_decision,
 )
 from nauro_core.doctor import diagnose_store
-from nauro_core.operations import InMemoryStore
+from nauro_core.operations import InMemoryStore, propose_decision
 
 
 def _stem(num: int, slug: str = "decision") -> str:
@@ -217,3 +217,64 @@ def test_deterministic_ordering() -> None:
         _stem(30, "zeta"),
     ]
     assert [(r.source, r.target) for r in diagnosis.dangling_refs] == [(5, 800), (20, 900)]
+
+
+# ── Unknown frontmatter keys (advisory) ──
+
+
+def _inject_unknown(body: str, line: str) -> str:
+    """Insert a raw ``key: value`` frontmatter line before the closing fence."""
+    close = body.find("\n---\n", len("---\n"))
+    return body[:close] + f"\n{line}" + body[close:]
+
+
+def test_unknown_frontmatter_key_surfaced() -> None:
+    store = InMemoryStore(decisions={_stem(12): _inject_unknown(_body(12), "origin: codex-1.2.3")})
+    diagnosis = diagnose_store(store)
+    assert len(diagnosis.unknown_frontmatter_keys) == 1
+    row = diagnosis.unknown_frontmatter_keys[0]
+    assert row.number == 12
+    assert row.keys == ("origin",)
+
+
+def test_unknown_frontmatter_key_does_not_make_store_unclean() -> None:
+    store = InMemoryStore(decisions={_stem(12): _inject_unknown(_body(12), "origin: codex-1.2.3")})
+    diagnosis = diagnose_store(store)
+    # The only finding is the advisory unknown key; the store stays clean.
+    assert diagnosis.unparseable == []
+    assert diagnosis.dangling_refs == []
+    assert diagnosis.cycles == []
+    assert diagnosis.contradictions == []
+    assert diagnosis.is_clean is True
+
+
+def test_supersede_preserves_unknown_key_on_flipped_old_file() -> None:
+    # An old decision carries an unknown key; superseding it flips status and
+    # writes superseded_by via model_copy. The unknown key must survive that
+    # rewrite — a reader that dropped it would strip newer-version fields.
+    old_stem = "001-adopt-postgresql-primary-database"
+    canonical = format_decision(
+        Decision(
+            date=date(2026, 1, 1),
+            confidence=DecisionConfidence.medium,
+            num=1,
+            title="Adopt PostgreSQL primary database",
+            rationale="Mature ecosystem with strong JSON support.",
+        )
+    )
+    store = InMemoryStore(decisions={old_stem: _inject_unknown(canonical, "origin: codex-1.2.3")})
+
+    result = propose_decision(
+        store,
+        title="Switch to managed PostgreSQL provider",
+        rationale="Reduces operational burden; the self-hosting rationale no longer applies.",
+        confidence="medium",
+        operation="supersede",
+        affected_decision_id="decision-001",
+    )
+    assert result.status == "confirmed"
+
+    flipped = store.read_decision(old_stem)
+    assert flipped is not None
+    assert "status: superseded" in flipped
+    assert "origin: codex-1.2.3" in flipped

--- a/packages/nauro/src/nauro/cli/commands/doctor.py
+++ b/packages/nauro/src/nauro/cli/commands/doctor.py
@@ -28,10 +28,24 @@ def _label(number: int) -> str:
     return f"D{number}"
 
 
+def _render_unknown_keys(diagnosis: StoreDiagnosis) -> list[str]:
+    """Render the advisory unknown-frontmatter-keys section, or nothing."""
+    if not diagnosis.unknown_frontmatter_keys:
+        return []
+    lines = [
+        f"Unknown frontmatter keys ({len(diagnosis.unknown_frontmatter_keys)}) "
+        "(advisory, preserved on rewrite, not a defect):"
+    ]
+    for row in diagnosis.unknown_frontmatter_keys:
+        lines.append(f"  {_label(row.number)}: {', '.join(row.keys)}")
+    lines.append("")
+    return lines
+
+
 def _render_report(diagnosis: StoreDiagnosis) -> list[str]:
     """Render a diagnosis as human-readable report lines."""
     if diagnosis.is_clean:
-        return ["No integrity defects found."]
+        return ["No integrity defects found.", *_render_unknown_keys(diagnosis)]
 
     lines: list[str] = []
 
@@ -74,6 +88,8 @@ def _render_report(diagnosis: StoreDiagnosis) -> list[str]:
                     f"superseded_by={_label(row.conflicting_with)}"
                 )
         lines.append("")
+
+    lines.extend(_render_unknown_keys(diagnosis))
 
     total = (
         len(diagnosis.unparseable)

--- a/packages/nauro/tests/test_cli_doctor.py
+++ b/packages/nauro/tests/test_cli_doctor.py
@@ -63,6 +63,24 @@ def test_defective_store_exits_zero_and_renders_defects(tmp_path: Path) -> None:
     assert "D999" in result.stdout
 
 
+def test_unknown_frontmatter_key_renders_advisory_on_clean_store(tmp_path: Path) -> None:
+    """An unknown key is advisory: the store is still clean (exit 0, the
+    clean message prints) and the advisory section prints alongside it."""
+    store = _new_store(tmp_path)
+    canonical = _decision_md(12)
+    close = canonical.find("\n---\n", len("---\n"))
+    with_unknown = canonical[:close] + "\norigin: codex-1.2.3" + canonical[close:]
+    write_decision_file(store, 12, "unknown-key", with_unknown)
+
+    result = runner.invoke(app, ["doctor", "--project", "docproj"])
+
+    assert result.exit_code == 0
+    assert "No integrity defects found." in result.stdout
+    assert "Unknown frontmatter keys" in result.stdout
+    assert "D12" in result.stdout
+    assert "origin" in result.stdout
+
+
 def test_project_resolution_and_report_header(tmp_path: Path) -> None:
     _new_store(tmp_path, name="another")
     result = runner.invoke(app, ["doctor", "--project", "another"])


### PR DESCRIPTION
## Why

Decision-file frontmatter parsing rejected any key the model did not
recognize. That turns format evolution into far-from-cause read failures:
a newer writer authors a key an older reader has never seen, and the older
reader refuses the whole file.

Worse, the supersede path rewrites the *old* decision file to record
`superseded_by`. A reader that merely ignored an unknown key would drop it
on that rewrite — silently stripping a field a newer version depends on.
Silent data loss is strictly worse than a loud rejection.

This flips the reader to tolerant and makes preservation load-bearing:
unknown keys survive every read-modify-write cycle. Doing it now is
deliberate — the install base is near zero, so the aging window for
tolerant readers is at its widest and only shrinks from here. That aging
is what later clears the path for carrying provenance on committed
decisions without breaking already-shipped readers.

## What changed

- `Decision` frontmatter parsing switches from `extra="forbid"` to
  `extra="allow"`. Unknown keys are captured in `model_extra` and preserved.
- The writer still emits only known keys, in canonical order; unknown keys
  are appended after the known block in first-seen order. Unknown keys are
  never silently dropped; values round-trip subject to YAML safe-load /
  safe-dump normalization, a value the serialization gate cannot process
  fails loudly at rewrite rather than vanishing, byte-identity holds for
  trailing unknown keys with deterministic representations in canonical
  files, and an interleaved unknown key migrates to the end on rewrite.
- Strictness relocates, it does not vanish: `nauro doctor` reports unknown
  frontmatter keys as an advisory finding (not a defect — it does not make a
  store unclean), and typos on *required* keys still fail loudly through
  missing-required validation.
- Tolerance is scoped to decision-file frontmatter only. Result shapes,
  registry, and config models stay strict; `RejectedAlternative` stays
  strict (it is parser-constructed from body subsections, not frontmatter).

## Test plan

- nauro-core and nauro suites green; ruff check + format clean.
- Formatter output pinned against pre-change golden bytes: the checked-in
  canonical decision fixtures (authored before this change) round-trip
  through parse + format byte-for-byte, proving no-extras output is
  byte-identical to the previous formatter.
- New coverage: byte-identical trailing round-trip, unknown key surviving a
  `model_copy` supersede flip, required-key typo still raising, doctor
  surfacing unknown keys while `is_clean` stays True, and an end-to-end
  supersede preserving an unknown key on the flipped old file.
- The public-contract test passes without the update escape hatch: no
  snapshot regeneration, no public-API or CLI-tree change.
