### PR TITLE
Release nauro 1.8.0 and nauro-core 1.4.0

### DIFF
--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro-core"
-version = "1.3.0"
+version = "1.4.0"
 description = "Shared pure-Python logic for Nauro: parsing, validation, context assembly, constants."
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro"
-version = "1.7.0"
+version = "1.8.0"
 description = "Human-approved project judgment and current state for connected AI agents, surfaced before work."
 readme = "README.md"
 license = "Apache-2.0"
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "nauro-core>=1.3.0,<2",
+    "nauro-core>=1.4.0,<2",
     "typer>=0.9",
     "httpx>=0.24",
     "mcp>=1.0",

--- a/server.json
+++ b/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Nauro-AI/nauro",
     "source": "github"
   },
-  "version": "1.7.0",
+  "version": "1.8.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "nauro",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -928,7 +928,7 @@ wheels = [
 
 [[package]]
 name = "nauro"
-version = "1.7.0"
+version = "1.8.0"
 source = { editable = "packages/nauro" }
 dependencies = [
     { name = "filelock" },
@@ -970,7 +970,7 @@ provides-extras = ["dev", "embeddings"]
 
 [[package]]
 name = "nauro-core"
-version = "1.3.0"
+version = "1.4.0"
 source = { editable = "packages/nauro-core" }
 dependencies = [
     { name = "bm25s" },


### PR DESCRIPTION
## Version moves

- nauro 1.7.0 → 1.8.0 (nauro-core floor raised to >=1.4.0,<2)
- nauro-core 1.3.0 → 1.4.0
- server.json version-locked to nauro 1.8.0

## What ships

**nauro 1.8.0**
- Write-path provenance journal: every write-path action (MCP tools, autogenerated CLI commands, note, import) appends an origin-stamped event to a local append-only journal under the store directory. Fail-open end-to-end, excluded from cloud sync and snapshots. (#381)
- Doctor renders the new unknown-frontmatter-keys advisory. (#382)
- Sync internals: vestigial git-union merge path removed (#378); v1 registry dead code retired (#379).

**nauro-core 1.4.0**
- Decision frontmatter parsing is read-tolerant: unknown keys are captured and preserved on rewrite instead of rejected; the writer still emits only known keys; required-key typos still fail loudly. (#382)
- Doctor gains the unknown-frontmatter-keys advisory category (does not affect store cleanliness). (#382)

No breaking changes: the frozen CLI/stdio/store contract is untouched (contract test passes without regeneration on both feature PRs).

## Checks

- `check_server_json_version.py` and `check_single_sourced.py` pass locally
- `uv lock --check` clean; `uv sync --locked` passes for both packages on 3.12

## Post-merge steps

1. Tag the squash-merge commit: `nauro-core-v1.4.0`, `nauro-v1.8.0`
2. Push tags to trigger the trusted-publish workflows (PyPI + MCP registry)
3. Create the two GitHub Releases
