### PR TITLE
Add graph JSON emission and the journal read command for the D456 viewer

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/graph.py
+++ b/packages/nauro/src/nauro/cli/commands/graph.py
@@ -14,10 +14,19 @@ background context reads at a glance. ``--no-include-bodies`` drops the bodies
 for a redacted artifact (titles and metadata only) that is safe to share more
 widely. The store-directory output default still keeps the file out of git
 working trees in both modes.
+
+``--format json`` emits the graph payload as a JSON document on stdout instead
+of writing an HTML file: it builds the same payload, creates no file, and never
+opens a browser (``--open`` is inapplicable and unconditionally skipped). It is
+the machine-read the D456 desktop viewer consumes. ``--output`` is not honored
+in JSON mode and errors, because JSON is a stdout contract; shell redirection
+covers a human who wants a file.
 """
 
 from __future__ import annotations
 
+import enum
+import json
 import webbrowser
 from datetime import datetime, timezone
 from pathlib import Path
@@ -33,6 +42,13 @@ from nauro.constants import DECISIONS_DIR
 from nauro.graph import DEFAULT_GRAPH_FILENAME, render_html
 from nauro.store._atomic import atomic_write_text
 from nauro.store.reader import read_text_lenient
+
+
+class GraphFormat(str, enum.Enum):
+    """Output format for the graph command."""
+
+    html = "html"
+    json = "json"
 
 
 def _read_decisions_lenient(store_path: Path) -> list[Decision]:
@@ -101,12 +117,20 @@ def graph(
     output: Path | None = typer.Option(
         None,
         "--output",
-        help="Write the HTML here instead of the store directory.",
+        help="Write the HTML here instead of the store directory. "
+        "Not valid with --format json (JSON goes to stdout; redirect it to a file).",
+    ),
+    format: GraphFormat = typer.Option(
+        GraphFormat.html,
+        "--format",
+        help="html writes a self-contained HTML file; json emits the graph "
+        "payload to stdout (no file, no browser).",
     ),
     open_browser: bool = typer.Option(
         True,
         "--open/--no-open",
-        help="Open the generated file in a browser (default on).",
+        help="Open the generated file in a browser (default on). "
+        "Inapplicable and skipped with --format json.",
     ),
     include_bodies: bool = typer.Option(
         True,
@@ -115,7 +139,15 @@ def graph(
         "Use --no-include-bodies for a redacted titles-and-metadata artifact.",
     ),
 ) -> None:
-    """Render the project's decision graph to a self-contained HTML file."""
+    """Render the project's decision graph to a self-contained HTML file, or to
+    a JSON document on stdout with --format json."""
+    if format is GraphFormat.json and output is not None:
+        raise typer.BadParameter(
+            "--output is not valid with --format json; JSON is written to stdout, "
+            "so redirect it to a file instead.",
+            param_hint="--output",
+        )
+
     project_name, store_path = resolve_target_project(project)
 
     decisions = _read_decisions_lenient(store_path)
@@ -123,6 +155,10 @@ def graph(
     payload = build_graph_payload(
         decisions, questions, project=project_name, include_bodies=include_bodies
     )
+
+    if format is GraphFormat.json:
+        typer.echo(json.dumps(payload, indent=2, ensure_ascii=False))
+        return
 
     generated_at = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
     html = render_html(payload, generated_at=generated_at)

--- a/packages/nauro/src/nauro/cli/commands/journal.py
+++ b/packages/nauro/src/nauro/cli/commands/journal.py
@@ -1,0 +1,37 @@
+"""nauro journal: emit the write-path provenance journal as JSON on stdout.
+
+Reads the store-local D455 event journal and writes every parseable event as a
+single JSON array to stdout, oldest first (append order). It is the machine-read
+the D456 desktop viewer's operations log consumes; it is deliberately a
+hand-written CLI command, not an MCP tool, because it serves a local GUI read
+and does not belong on the frozen stdio tool contract.
+
+The reader tolerates a truncated or corrupt final record by skipping it, so a
+crash mid-append never denies the whole log. A missing or empty journal emits an
+empty array and exits 0. Windowing and filtering are display concerns the app
+owns, so the command carries only ``--project``.
+"""
+
+from __future__ import annotations
+
+import json
+
+import typer
+
+from nauro.cli.utils import resolve_target_project
+from nauro.store.journal import read_events
+
+
+def journal(
+    project: str | None = typer.Option(
+        None,
+        "--project",
+        help="Target project name.",
+    ),
+) -> None:
+    """Emit the project's write-path provenance journal as a JSON array on stdout."""
+    _project_name, store_path = resolve_target_project(project)
+
+    events = read_events(store_path)
+    records = [event.model_dump(mode="json", exclude_none=True) for event in events]
+    typer.echo(json.dumps(records, indent=2, ensure_ascii=False))

--- a/packages/nauro/src/nauro/cli/main.py
+++ b/packages/nauro/src/nauro/cli/main.py
@@ -57,6 +57,7 @@ def _register_commands() -> None:
         hook,
         import_cmd,
         init,
+        journal,
         link,
         log,
         note,
@@ -83,6 +84,7 @@ def _register_commands() -> None:
     app.add_typer(hook.hook_app, name="hook")
     app.command(name="sync")(sync.sync)
     app.command(name="graph")(graph.graph)
+    app.command(name="journal")(journal.journal)
     app.command(name="log")(log.log)
     app.command(name="import")(import_cmd.import_cmd)
     app.command(name="serve")(serve.serve)

--- a/packages/nauro/tests/snapshots/public_contract_v1.json
+++ b/packages/nauro/tests/snapshots/public_contract_v1.json
@@ -488,6 +488,20 @@
         "name": "graph",
         "params": [
           {
+            "choices": [
+              "html",
+              "json"
+            ],
+            "default": "html",
+            "flags": [
+              "--format"
+            ],
+            "kind": "option",
+            "name": "format",
+            "required": false,
+            "type": "choice"
+          },
+          {
             "default": true,
             "flags": [
               "--include-bodies",
@@ -631,6 +645,21 @@
           {
             "kind": "argument",
             "name": "name",
+            "required": false,
+            "type": "text"
+          }
+        ]
+      },
+      {
+        "kind": "command",
+        "name": "journal",
+        "params": [
+          {
+            "flags": [
+              "--project"
+            ],
+            "kind": "option",
+            "name": "project",
             "required": false,
             "type": "text"
           }

--- a/packages/nauro/tests/test_cli_graph.py
+++ b/packages/nauro/tests/test_cli_graph.py
@@ -1700,3 +1700,85 @@ def test_largest_consolidation_cluster_takes_origin(tmp_path, monkeypatch):
 
     # Determinism: same input renders identical positions.
     assert build_graph_layout(payload, priority_center=100)["positions"] == prioritized["positions"]
+
+
+# ── JSON emission (--format json) ──
+
+
+def test_json_format_emits_payload_to_stdout(tmp_path, monkeypatch):
+    """--format json prints the graph payload as parseable JSON on stdout."""
+    _populated_store(tmp_path, monkeypatch)
+
+    result = runner.invoke(app, ["graph", "--format", "json"])
+    assert result.exit_code == 0
+
+    payload = json.loads(result.stdout)
+    assert payload["payload_version"] == 2
+    numbers = {n["number"] for n in payload["nodes"]}
+    assert numbers == {2, 3, 4}
+
+
+def test_json_format_writes_no_html_file(tmp_path, monkeypatch):
+    """JSON mode creates no HTML file in the store directory."""
+    store = _populated_store(tmp_path, monkeypatch)
+
+    result = runner.invoke(app, ["graph", "--format", "json"])
+    assert result.exit_code == 0
+    assert not (store / "nauro-graph.html").exists()
+    assert next(tmp_path.glob("**/nauro-graph.html"), None) is None
+
+
+def test_json_format_never_opens_browser(tmp_path, monkeypatch, _no_browser):
+    """JSON mode never opens a browser, even with --open default on."""
+    _populated_store(tmp_path, monkeypatch)
+
+    result = runner.invoke(app, ["graph", "--format", "json"])
+    assert result.exit_code == 0
+    assert _no_browser == []
+
+
+def test_json_format_bodies_default_on_and_redact(tmp_path, monkeypatch):
+    """Bodies ride on nodes by default; --no-include-bodies drops them in JSON."""
+    store = _new_store(tmp_path, monkeypatch)
+    body = "The full rationale that rides on the node body by default."
+    write_decision_file(store, 2, "with-body", _decision_md(2, "A decision", body=body))
+
+    result = runner.invoke(app, ["graph", "--format", "json"])
+    assert result.exit_code == 0
+    node = next(n for n in json.loads(result.stdout)["nodes"] if n["number"] == 2)
+    assert body in node["body"]
+
+    result = runner.invoke(app, ["graph", "--format", "json", "--no-include-bodies"])
+    assert result.exit_code == 0
+    node = next(n for n in json.loads(result.stdout)["nodes"] if n["number"] == 2)
+    assert "body" not in node
+
+
+def test_json_format_with_output_exits_2(tmp_path, monkeypatch):
+    """--output combined with --format json is a usage error (exit 2)."""
+    _populated_store(tmp_path, monkeypatch)
+    target = tmp_path / "out.json"
+
+    result = runner.invoke(app, ["graph", "--format", "json", "--output", str(target)])
+    assert result.exit_code == 2
+    assert not target.exists()
+
+
+def test_json_format_is_byte_identical_across_runs(tmp_path, monkeypatch):
+    """Two JSON runs over the same store produce byte-identical stdout."""
+    _populated_store(tmp_path, monkeypatch)
+
+    first = runner.invoke(app, ["graph", "--format", "json"])
+    second = runner.invoke(app, ["graph", "--format", "json"])
+    assert first.exit_code == 0
+    assert second.exit_code == 0
+    assert first.stdout == second.stdout
+
+
+def test_default_format_html_still_writes_file(tmp_path, monkeypatch):
+    """The default (no --format) path still writes the HTML file to the store."""
+    store = _populated_store(tmp_path, monkeypatch)
+
+    result = runner.invoke(app, ["graph", "--no-open"])
+    assert result.exit_code == 0
+    assert (store / "nauro-graph.html").exists()

--- a/packages/nauro/tests/test_cli_journal.py
+++ b/packages/nauro/tests/test_cli_journal.py
@@ -1,0 +1,114 @@
+"""Tests for the ``nauro journal`` command.
+
+The command reads the store-local D455 event journal and emits every parseable
+event as a JSON array on stdout, oldest first. A missing or empty journal emits
+``[]``; a truncated final record is skipped by the tolerant reader.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from nauro.cli.main import app
+from nauro.store.journal import (
+    JOURNAL_DIR,
+    JOURNAL_EVENTS_FILENAME,
+    JournalEvent,
+    OriginDescriptor,
+    append_event,
+)
+from nauro.store.registry import register_project_v2
+from nauro.templates.scaffolds import scaffold_project_store
+
+runner = CliRunner()
+
+_ORIGIN = OriginDescriptor(transport="cli", client_name="nauro-cli", client_version="1.8.0")
+
+
+def _new_store(tmp_path, monkeypatch, name: str = "journalproj") -> Path:
+    """Register and scaffold a project, chdir into its repo, return the store."""
+    _pid, store = register_project_v2(name, [tmp_path])
+    scaffold_project_store(name, store)
+    monkeypatch.chdir(tmp_path)
+    return store
+
+
+def _event(operation: str, target: str, status: str = "committed") -> JournalEvent:
+    return JournalEvent(
+        operation=operation,
+        target=target,
+        status=status,  # type: ignore[arg-type]
+        origin=_ORIGIN,
+        payload_hash="0" * 64,
+    )
+
+
+def _events_file(store: Path) -> Path:
+    return store / JOURNAL_DIR / JOURNAL_EVENTS_FILENAME
+
+
+def test_missing_journal_emits_empty_array(tmp_path, monkeypatch):
+    store = _new_store(tmp_path, monkeypatch)
+    assert not _events_file(store).exists()
+
+    result = runner.invoke(app, ["journal"])
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == []
+
+
+def test_empty_journal_file_emits_empty_array(tmp_path, monkeypatch):
+    store = _new_store(tmp_path, monkeypatch)
+    events_file = _events_file(store)
+    events_file.parent.mkdir(parents=True, exist_ok=True)
+    events_file.write_text("", encoding="utf-8")
+
+    result = runner.invoke(app, ["journal"])
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == []
+
+
+def test_populated_journal_emits_events_in_append_order(tmp_path, monkeypatch):
+    store = _new_store(tmp_path, monkeypatch)
+    written = [
+        _event("propose_decision", "decisions"),
+        _event("flag_question", "open_questions"),
+        _event("update_state", "state", status="rejected"),
+    ]
+    for event in written:
+        append_event(store, event)
+
+    result = runner.invoke(app, ["journal"])
+    assert result.exit_code == 0
+
+    emitted = json.loads(result.stdout)
+    expected = [e.model_dump(mode="json", exclude_none=True) for e in written]
+    assert emitted == expected
+
+
+def test_truncated_final_record_is_skipped(tmp_path, monkeypatch):
+    store = _new_store(tmp_path, monkeypatch)
+    good = _event("propose_decision", "decisions")
+    append_event(store, good)
+
+    events_file = _events_file(store)
+    partial = json.dumps({"operation": "flag_question", "target": "open_q"})[:20]
+    with events_file.open("a", encoding="utf-8") as fh:
+        fh.write(partial)
+
+    result = runner.invoke(app, ["journal"])
+    assert result.exit_code == 0
+
+    emitted = json.loads(result.stdout)
+    assert emitted == [good.model_dump(mode="json", exclude_none=True)]
+
+
+def test_unknown_project_exits_1(tmp_path, monkeypatch):
+    isolated = tmp_path / "isolated"
+    isolated.mkdir()
+    monkeypatch.chdir(isolated)
+
+    result = runner.invoke(app, ["journal", "--project", "does-not-exist"])
+    assert result.exit_code == 1


### PR DESCRIPTION
## Why

The D456 desktop doctrine viewer needs two local, machine-readable CLI reads to
consume the decision graph and the write-path provenance journal. This PR
delivers both and resolves the build-time specifics D456 deferred, so the app
PR can build against a stable read surface. Both ship as additive-minor CLI
surface; nauro-core is untouched (the payload builder and the journal reader
already exist).

## What changed

- `nauro graph` gains `--format {html|json}` (default `html`; existing HTML
  behavior unchanged). JSON mode builds the same graph payload and writes it to
  stdout as an indented JSON document: it creates no file, never opens a
  browser, and reads no clock, so output is deterministic. `--output` combined
  with `--format json` is a usage error (exit 2) rather than being honored or
  silently ignored, because JSON is a stdout contract and honoring a path would
  resurrect the store-dump-into-a-repo footgun; shell redirection covers a human
  who wants a file. `--open` is inapplicable in JSON mode and unconditionally
  skipped. Bodies stay default-ON so the app's decision-detail view gets the
  full markdown including rejected alternatives; `--no-include-bodies` still
  yields a redacted payload.
- New hand-written `nauro journal` command emits the store-local provenance
  journal as a single JSON array of events, oldest first, each serialized to
  match the journal's own line shape. It reuses the tolerant reader, so a
  truncated final record is skipped; a missing or empty journal yields `[]` at
  exit 0. It is deliberately not an MCP tool and not on the autogen allowlist:
  it serves a local GUI read and does not belong on the frozen stdio tool
  contract. It carries only `--project`; windowing and filtering are display
  concerns the app owns.
- Regenerated the public-contract snapshot via the sanctioned update path. The
  drift is exactly the graph `--format` param and the new `journal` command
  node.

## Test plan

- New graph JSON tests: stdout parses as JSON with payload_version 2; no HTML
  file written; browser never opened; bodies default-on and dropped under
  `--no-include-bodies`; `--output` errors exit 2; two runs are byte-identical;
  the default HTML path still writes its file.
- New journal tests: missing and empty journals emit `[]` at exit 0; a
  populated journal returns the written events in append order; a truncated
  final record is skipped; an unknown project exits 1.
- Full nauro and nauro-core suites pass; ruff check and format clean.

## Risk / what to review

The regenerated contract snapshot is a frozen-surface change under D318. The
drift is purely additive (a new optional param and a new command), so it is a
minor, not a 2.0. Confirm the snapshot diff is exactly those two additions.
