### PR TITLE
Release nauro 1.9.0

### DIFF
--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro"
-version = "1.8.0"
+version = "1.9.0"
 description = "Human-approved project judgment and current state for connected AI agents, surfaced before work."
 readme = "README.md"
 license = "Apache-2.0"

--- a/server.json
+++ b/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Nauro-AI/nauro",
     "source": "github"
   },
-  "version": "1.8.0",
+  "version": "1.9.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "nauro",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -928,7 +928,7 @@ wheels = [
 
 [[package]]
 name = "nauro"
-version = "1.8.0"
+version = "1.9.0"
 source = { editable = "packages/nauro" }
 dependencies = [
     { name = "filelock" },


### PR DESCRIPTION
## Release nauro 1.9.0

Cuts a minor release of the **nauro** package. **nauro-core is not released** — its `src` tree is unchanged since `nauro-core-v1.4.0`, so it stays at 1.4.0 (no tag, no registry publish).

### Version moves
- `nauro`: 1.8.0 → **1.9.0** (`packages/nauro/pyproject.toml`)
- `server.json` `.version` and `.packages[0].version`: 1.8.0 → **1.9.0** (version-locked to the nauro package)
- `uv.lock` re-locked to the bumped version
- `nauro-core` floor unchanged (`nauro-core>=1.4.0,<2`)

### What ships
The two additive viewer-facing CLI surfaces merged in #385:
- `nauro graph --format json` — emits the graph payload to stdout (no file, no browser; `--output` errors in this mode)
- `nauro journal` — hand-written command that reads the event journal

Both are additive to the frozen v1 contract (exactly two additive nodes in the contract snapshot); no public-API breaks.

### Checks
- `scripts/check_server_json_version.py` — pass (server.json locked to 1.9.0)
- `scripts/check_single_sourced.py packages/nauro/src` — pass
- `uv lock --check` — clean
- `uv sync --locked` for nauro and nauro-core on Python 3.12 — pass

### Post-merge (maintainer)
Squash-merge, then tag the merge commit and push to trigger trusted-publish:
- `nauro-v1.9.0` → publishes nauro to PyPI + `server.json` to the MCP registry

No `nauro-core-v*` tag this release.
