### PR TITLE
Reword the init --demo git-repo warning to name the demo project

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/init.py
+++ b/packages/nauro/src/nauro/cli/commands/init.py
@@ -261,7 +261,7 @@ def _init_demo(name: str, repo_paths: list[Path], force: bool) -> None:
     if cwd_is_git:
         typer.echo(
             "  Warning: this directory is a git repo; the demo config will steer "
-            "its resolution to the demo doctrine.",
+            "its resolution to the demo project.",
             err=True,
         )
     typer.echo(


### PR DESCRIPTION
## Why

The `init --demo` git-repo warning said the demo config would steer resolution to "the demo doctrine". No CLI or docs surface defines that term for a new user, and resolution resolves to a project, not to a body of decisions.

## What changed

The warning now says "the demo project". Output wording only; no behavior change.

## Test plan

`packages/nauro/tests/test_init_demo_and_next_steps.py`: 7 passed (no test pinned the old phrase). Ruff clean on the changed file.
