### PR TITLE
Add the outcome-evidence rider section to generated AGENTS.md

### DIFF
--- a/packages/nauro/src/nauro/templates/agents_md.py
+++ b/packages/nauro/src/nauro/templates/agents_md.py
@@ -50,6 +50,21 @@ WRITE_TOOL_ROWS: list[tuple[str, str]] = [
 ]
 
 
+# Rendered in AGENTS.md only: the shared static block sits a few characters
+# under its 1,700-char truncation budget (MCP_INSTRUCTIONS_STATIC_MAX_CHARS in
+# the nauro-core constants tests), so it cannot carry this section.
+EVIDENCE_RIDER_SECTION = (
+    "## When to record outcome evidence\n"
+    "\n"
+    "When the world tests an existing decision, propose an update rider on it: "
+    "an exception is approved against it, an incident traces back to it, it "
+    "survives a real test, or it stops mattering. Open the rider with a dated "
+    "evidence marker, `*Evidence (<type>, <date>):*`, with types exception, "
+    "held, pain, and obsolete. The rider goes through the same draft-and-approve "
+    "flow as any proposal.\n"
+)
+
+
 def _render_tool_rows(rows: list[tuple[str, str]]) -> str:
     return "\n".join(f"- `{sig}` - {desc}" for sig, desc in rows)
 
@@ -112,6 +127,7 @@ def generate_agents_md(
         "across agents and suggest they run 'nauro status'. If the 'nauro' command is not "
         "installed, install it with 'uv tool install nauro'.\n"
     )
+    parts.append(EVIDENCE_RIDER_SECTION)
     parts.append(f"## Project: {project_name}\n\n{l0_payload}\n")
 
     # Store-routing block. This file lives in the working copy, so any agent

--- a/packages/nauro/tests/test_agents_md.py
+++ b/packages/nauro/tests/test_agents_md.py
@@ -59,6 +59,20 @@ def test_generate_includes_behavioral_instructions():
     assert "advisory conflict checks" not in result
 
 
+def test_generate_includes_evidence_rider_section():
+    result = generate_agents_md("myproj", "payload")
+    assert result.count("## When to record outcome evidence") == 1
+    assert "propose an update rider" in result
+    assert "`*Evidence (<type>, <date>):*`" in result
+    # Sits below the MCP-absent breadcrumb and above the project payload,
+    # leaving the canonical preflight block atomic.
+    breadcrumb_idx = result.index("If you have no Nauro MCP tools in this session")
+    evidence_idx = result.index("## When to record outcome evidence")
+    project_idx = result.index("## Project: myproj")
+    assert breadcrumb_idx < evidence_idx < project_idx
+    assert result.count(MCP_INSTRUCTIONS_STATIC) == 1
+
+
 def test_generate_frontloads_canonical_preflight_before_l0_payload():
     l0_payload = "**One-liner:** Stable project scope.\n\n## Current State\n\nActive work."
     result = generate_agents_md("myproj", l0_payload)

--- a/packages/nauro/tests/test_agents_md.py
+++ b/packages/nauro/tests/test_agents_md.py
@@ -106,7 +106,8 @@ def test_generate_breadcrumb_names_only_the_self_routing_entry_command():
     # Scoped to the rendered breadcrumb paragraph (its start through the next
     # section header): it must not name any downstream remedy that `nauro status`
     # routes to. Other sections may legitimately mention these commands.
-    paragraph = result[result.index(breadcrumb) : result.index("## Project:")]
+    breadcrumb_start = result.index(breadcrumb)
+    paragraph = result[breadcrumb_start : result.index("\n## ", breadcrumb_start)]
     assert "reconnect" not in paragraph
     assert "setup all" not in paragraph
     assert "sync" not in paragraph


### PR DESCRIPTION
## Why

The project record captures how decisions were made and revised, but confirmed outcomes (an exception approved against a decision, an incident traced back to it, a real test it survived, quiet obsolescence) had no prompt in the generated guidance, so they kept landing outside the store. The newly ratified convention records outcomes as versioned update riders on the affected decision, through the same draft-and-approve flow as any proposal.

## What changed

Generated AGENTS.md gains a "When to record outcome evidence" section directing agents to propose an evidence rider when the world tests an existing decision. It renders in AGENTS.md only: the shared MCP static block sits 5 characters under its 1,700-character truncation cap, so it cannot carry the section. The breadcrumb-scope test now bounds its slice at the next section header instead of hardcoding the project heading.

## Test plan

New placement test; full nauro and nauro-core suites pass (3,170 passed, 10 skipped); ruff lint and format clean.