### PR TITLE
Pre-launch cleanup: public-surface hygiene and README wording

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ AGENTS.md
 **/.claude/settings.local.json
 .cursor/
 .mcp.json
+
+# >>> nauro: machine-local wiring (regenerated per machine) >>>
+/.codex/hooks.json
+# <<< nauro <<<

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The record combines project scope, state, open questions, and the rationale behi
 
 https://github.com/user-attachments/assets/f75ede99-db11-4460-bc09-801c86df1e19
 
-*A real Codex session and then a Claude session in Pareto, the mock project Nauro is developed against.*
+*A real Codex session, then a Claude session in Pareto, Nauro's development mock project.*
 
 ## Install
 
@@ -30,7 +30,7 @@ Install `uv` with `curl -LsSf https://astral.sh/uv/install.sh | sh` on macOS or 
 
 ## Try the demo
 
-Pennykeep, the tiny bundled demo project, needs no account or agent setup:
+Pennykeep, the bundled demo, needs no account or agent setup:
 
 ```bash
 mkdir -p /tmp/nauro-demo && cd /tmp/nauro-demo

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The record combines project scope, state, open questions, and the rationale behi
 
 https://github.com/user-attachments/assets/f75ede99-db11-4460-bc09-801c86df1e19
 
-*A real Codex session and then a Claude session in Pareto, a reproducible mock project.*
+*A real Codex session and then a Claude session in Pareto, the mock project Nauro is developed against.*
 
 ## Install
 
@@ -28,9 +28,9 @@ uv tool install nauro
 
 Install `uv` with `curl -LsSf https://astral.sh/uv/install.sh | sh` on macOS or Linux, or use the [Windows instructions](https://docs.astral.sh/uv/getting-started/installation/). With Python 3.10 or newer, `pipx install nauro` also works.
 
-## Try Pennykeep
+## Try the demo
 
-The local demo needs no account or agent setup:
+Pennykeep, the tiny bundled demo project, needs no account or agent setup:
 
 ```bash
 mkdir -p /tmp/nauro-demo && cd /tmp/nauro-demo

--- a/packages/nauro-core/tests/test_context.py
+++ b/packages/nauro-core/tests/test_context.py
@@ -515,7 +515,7 @@ class TestBuildL0DiscoveryPointerExclusion:
         assert "RESUME:" not in result
 
     def test_select_pointer_excluded(self):
-        # SELECT: checkpoints (nauro-loop candidate sets, D322) are discovery
+        # SELECT: checkpoints (nauro-loop candidate sets) are discovery
         # pointers too and must not surface as L0 open questions.
         content = (
             "# Open Questions\n"

--- a/packages/nauro/src/nauro/cli/commands/graph.py
+++ b/packages/nauro/src/nauro/cli/commands/graph.py
@@ -18,7 +18,7 @@ working trees in both modes.
 ``--format json`` emits the graph payload as a JSON document on stdout instead
 of writing an HTML file: it builds the same payload, creates no file, and never
 opens a browser (``--open`` is inapplicable and unconditionally skipped). It is
-the machine-read the D456 desktop viewer consumes. ``--output`` is not honored
+the machine-read the desktop viewer consumes. ``--output`` is not honored
 in JSON mode and errors, because JSON is a stdout contract; shell redirection
 covers a human who wants a file.
 """

--- a/packages/nauro/src/nauro/cli/commands/journal.py
+++ b/packages/nauro/src/nauro/cli/commands/journal.py
@@ -1,8 +1,8 @@
 """nauro journal: emit the write-path provenance journal as JSON on stdout.
 
-Reads the store-local D455 event journal and writes every parseable event as a
+Reads the store-local event journal and writes every parseable event as a
 single JSON array to stdout, oldest first (append order). It is the machine-read
-the D456 desktop viewer's operations log consumes; it is deliberately a
+the desktop viewer's operations log consumes; it is deliberately a
 hand-written CLI command, not an MCP tool, because it serves a local GUI read
 and does not belong on the frozen stdio tool contract.
 

--- a/packages/nauro/src/nauro/graph/html_render.py
+++ b/packages/nauro/src/nauro/graph/html_render.py
@@ -1192,7 +1192,7 @@ def _render_insight_labels(
 
     A label is a dark rounded pill behind stroked text so it reads on the dark
     canvas without bulk. The named top story (the largest consolidation, flagged
-    ``primary``) gets the stronger ``short`` form ("D297 · retires 13") as its
+    ``primary``) gets the stronger ``short`` form ("D42 · retires 13") as its
     at-rest headline; the others get the compact "D<n>" form. This is
     informational labelling, not a selection state, so the default view stays
     even-emphasis. The whole group is ``pointer-events: none`` in CSS so labels
@@ -1441,8 +1441,9 @@ def _barycentric_rows(
     Column 0 (the oldest generation, the retired leaves) keeps rows ascending by
     number. For every later column the row is the mean of the rows of the nodes
     the node supersedes (its predecessors one column to the left), so a retirer
-    sits vertically centered on the children that converge into it: D297 lands
-    centered on its 13 leaves, D208 centered between the D105 chain and D73.
+    sits vertically centered on the children that converge into it: a retirer
+    of 13 leaves lands centered on that fan, one with two predecessors lands
+    midway between them.
 
     Collisions within a column are resolved deterministically. Nodes are ordered
     by ``(barycenter, number)`` and then walked top to bottom, pushing each down

--- a/packages/nauro/tests/test_adopt_remove.py
+++ b/packages/nauro/tests/test_adopt_remove.py
@@ -57,7 +57,7 @@ def test_remove_unadopts_repo_and_keeps_store(tmp_path, monkeypatch):
     # surface wiring + generated AGENTS.md gone (the .mcp.json had only nauro)
     assert not (repo / ".mcp.json").exists()
     assert not (repo / "AGENTS.md").exists()
-    # store left intact (D248: never delete decisions as a teardown side effect)
+    # store left intact (never delete decisions as a teardown side effect)
     assert store_path.is_dir()
     assert "store left intact" in result.output
 

--- a/packages/nauro/tests/test_cli_graph.py
+++ b/packages/nauro/tests/test_cli_graph.py
@@ -730,7 +730,7 @@ def test_timeline_marks_positioned_by_date_not_index(tmp_path, monkeypatch):
 
 
 def test_bodies_default_on_and_no_include_bodies_redacts(tmp_path, monkeypatch):
-    """Decision bodies render by default (D331); --no-include-bodies redacts them.
+    """Decision bodies render by default; --no-include-bodies redacts them.
 
     By default the body key is embedded and the rationale renders as structured
     HTML in the detail panel. --no-include-bodies drops the body key and the

--- a/packages/nauro/tests/test_cli_journal.py
+++ b/packages/nauro/tests/test_cli_journal.py
@@ -1,6 +1,6 @@
 """Tests for the ``nauro journal`` command.
 
-The command reads the store-local D455 event journal and emits every parseable
+The command reads the store-local event journal and emits every parseable
 event as a JSON array on stdout, oldest first. A missing or empty journal emits
 ``[]``; a truncated final record is skipped by the tolerant reader.
 """

--- a/packages/nauro/tests/test_public_contract.py
+++ b/packages/nauro/tests/test_public_contract.py
@@ -1,6 +1,6 @@
-"""Frozen-contract snapshot for the 1.0 public surface (D318).
+"""Frozen-contract snapshot for the 1.0 public surface.
 
-D318 took ``nauro`` and ``nauro-core`` to 1.0.0 and froze the *local product
+The 1.0 release took ``nauro`` and ``nauro-core`` to 1.0.0 and froze the *local product
 surface*: the stdio MCP tool contract (names + schemas), the CLI command tree
 (commands + flags), the on-disk store-format constants, and ``nauro-core``'s
 curated public import API. After 1.0, breaking any of these requires a major
@@ -18,7 +18,7 @@ can disagree with the code, which is exactly what a freeze needs.
 The test never decides major-vs-minor. It makes a contract change **loud**: an
 intentional change is a deliberate snapshot regen, and the resulting diff (e.g.
 ``+ "required": ["proposed_approach", "scope"]``) is the trigger to ask "is this
-a 2.0?" — a question for review (the @nauro-reviewer pass) against D318, not for
+a 2.0?" — a question for review (the @nauro-reviewer pass) against the freeze, not for
 this assertion.
 
 What is frozen here:
@@ -30,7 +30,8 @@ What is frozen here:
   - ``cli_autogen_commands`` — the explicit set of tools mirrored as CLI
                                commands (``AUTOGEN_ALLOWLIST``).
   - ``nauro_core_public_api``— ``nauro_core.__all__``, the curated import surface
-                               D318 promised (vs. the ~107 incidental exports).
+                               the 1.0 freeze promised (vs. the ~107 incidental
+                               exports).
   - ``public_constant_values``— the *values* of the store-format filenames,
                                schema version, size limits, and decision types
                                (renaming ``project.md`` breaks every store).
@@ -321,7 +322,7 @@ def test_public_contract_matches_snapshot() -> None:
             diff = diff[:8000] + "\n... (diff truncated)"
         raise AssertionError(
             "The 1.0 public contract has drifted from the checked-in snapshot "
-            f"({SNAPSHOT_PATH.name}). This is a frozen surface under D318: a change "
+            f"({SNAPSHOT_PATH.name}). This is a surface frozen at 1.0: a change "
             "here is a major-version (2.0) concern unless it is purely additive and "
             "you have confirmed so. If the change is intentional and reviewed, "
             f"regenerate with `{_UPDATE_ENV}=1 .venv/bin/python -m pytest "

--- a/packages/nauro/tests/test_skills_drift.py
+++ b/packages/nauro/tests/test_skills_drift.py
@@ -278,7 +278,7 @@ def test_adopt_body_step0_mandates_two_citations_batch_confirm_and_precheck():
     assert "propose_decision" in body
     assert "direct-write bypass" in body
 
-    # Capture status; confirm does not imply filed (D272 active-title dedup can
+    # Capture status; confirm does not imply filed (active-title dedup can
     # reject a card colliding with one written earlier in the same batch).
     assert "captures the `propose_decision` return status" in body
     assert "does not assume confirm means filed" in body


### PR DESCRIPTION
Three small changes ahead of tonight's launch posts:

- Ignore the machine-local `.codex/hooks.json` wiring file.
- Paraphrase internal decision references out of shipped docstrings and comments. Fixture data and the id-grammar examples in nauro-core stay, since they document the product's own reference format rather than pointing anywhere.
- README: caption the walkthrough video as Pareto, the mock project Nauro is developed against, and introduce the quickstart as the bundled Pennykeep demo, so the two mock projects on one page read as distinct.

No behavior changes. Both test suites pass (nauro-core 1086, nauro 2084 + 10 skipped), ruff check and format clean.