### PR TITLE
Reject invalid enum values at Tier 1; make flag-question positional

### DIFF
--- a/packages/nauro-core/src/nauro_core/validation.py
+++ b/packages/nauro-core/src/nauro_core/validation.py
@@ -15,7 +15,12 @@ from nauro_core.constants import (
     MIN_RATIONALE_LENGTH,
     VALID_CONFIDENCES,
 )
-from nauro_core.decision_model import DecisionConfidence
+from nauro_core.decision_model import (
+    DECISION_TYPE_VALUES,
+    DecisionConfidence,
+    DecisionSource,
+    Reversibility,
+)
 from nauro_core.search import Bm25Hit, bm25_retrieve
 
 # Tier-2 BM25 defaults shared by local (nauro) and remote (mcp-server) surfaces.
@@ -143,6 +148,17 @@ def rejected_item_label(item: dict) -> str | None:
     return None
 
 
+# Optional enum-valued proposal fields and their allowed wire values. Each
+# must reject at Tier 1: the write path coerces them with the enum
+# constructor, so a non-member value that slips past screening raises an
+# uncaught ValueError after validation has already passed.
+_OPTIONAL_ENUM_FIELDS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("decision_type", DECISION_TYPE_VALUES),
+    ("reversibility", tuple(r.value for r in Reversibility)),
+    ("source", tuple(s.value for s in DecisionSource)),
+)
+
+
 def screen_structural(
     proposal: dict,
     existing_hashes: set[str],
@@ -150,7 +166,8 @@ def screen_structural(
 ) -> tuple[str, str | None]:
     """Run structural screening on a proposal. No I/O.
 
-    Checks: schema validation (title, rationale, confidence), minimum rationale
+    Checks: schema validation (title, rationale, confidence, the optional
+    enum fields decision_type / reversibility / source), minimum rationale
     length, rejected-alternative labels (each dict item must carry a non-empty
     'alternative' or 'name'), hash dedup against existing_hashes, and title
     dedup against active_decisions (same title as a decision still in force).
@@ -179,6 +196,19 @@ def screen_structural(
     confidence = proposal.get("confidence", DecisionConfidence.medium.value)
     if confidence not in VALID_CONFIDENCES:
         return ("reject", f"Invalid confidence: {confidence}. Must be one of: {VALID_CONFIDENCES}")
+
+    # None and blank strings coerce to unset on the write path, so only a
+    # non-blank non-member value rejects.
+    for field_name, allowed in _OPTIONAL_ENUM_FIELDS:
+        raw = proposal.get(field_name)
+        if raw is None:
+            continue
+        value = raw.strip() if isinstance(raw, str) else str(raw)
+        if value and value not in allowed:
+            return (
+                "reject",
+                f"Invalid {field_name}: {value}. Must be one of: {', '.join(allowed)}",
+            )
 
     if len(rationale) < MIN_RATIONALE_LENGTH:
         return (

--- a/packages/nauro-core/tests/operations/test_operations_propose_decision.py
+++ b/packages/nauro-core/tests/operations/test_operations_propose_decision.py
@@ -27,6 +27,7 @@ from nauro_core.constants import OPEN_QUESTIONS_MD
 from nauro_core.decision_model import (
     DECISION_TYPE_VALUES,
     DecisionStatus,
+    Reversibility,
 )
 from nauro_core.operations import (
     InMemoryStore,
@@ -922,6 +923,53 @@ def test_every_advertised_decision_type_commits(decision_type: str) -> None:
         decision_type=decision_type,
     )
     assert result.status == "confirmed"
+
+
+@pytest.mark.parametrize("reversibility", [r.value for r in Reversibility])
+def test_every_advertised_reversibility_commits(reversibility: str) -> None:
+    store = InMemoryStore()
+    result = propose_decision(
+        store,
+        title=f"Decision reversible as {reversibility}",
+        rationale="A rationale long enough to clear the minimum length threshold.",
+        confidence="medium",
+        reversibility=reversibility,
+    )
+    assert result.status == "confirmed"
+    body = store.read_decision(result.decision_id)
+    assert body is not None
+    assert f"reversibility: {reversibility}" in body
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "allowed_fragment"),
+    [
+        ("reversibility", "reversible", "easy, moderate, hard"),
+        ("reversibility", "banana", "easy, moderate, hard"),
+        ("decision_type", "banana", "architecture"),
+        ("source", "banana", "mcp"),
+    ],
+)
+def test_invalid_enum_value_rejected_at_tier_1(
+    field: str, value: str, allowed_fragment: str
+) -> None:
+    """A non-member enum value rejects with the clean Tier 1 envelope instead
+    of raising ValueError from the write path's enum coercion, and nothing is
+    written to the store."""
+    store = InMemoryStore()
+    result = propose_decision(
+        store,
+        title="Adopt Redis for hot caching",
+        rationale="In-memory cache for the hot read paths across the API tier.",
+        confidence="medium",
+        **{field: value},
+    )
+    assert result.status == "rejected"
+    assert result.tier == 1
+    assert result.operation == "reject"
+    assert f"Invalid {field}: {value}" in result.assessment
+    assert allowed_fragment in result.assessment
+    assert store.list_decisions() == []
 
 
 # ── Slug truncation goldens ─────────────────────────────────────────────

--- a/packages/nauro-core/tests/test_validation.py
+++ b/packages/nauro-core/tests/test_validation.py
@@ -236,6 +236,36 @@ class TestScreenStructural:
         action, _reason = screen_structural(proposal, set(), [])
         assert action == "pass"
 
+    def test_invalid_reversibility(self):
+        action, reason = screen_structural(self._proposal(reversibility="reversible"), set(), [])
+        assert action == "reject"
+        assert "Invalid reversibility: reversible" in reason
+        assert "easy, moderate, hard" in reason
+
+    def test_invalid_decision_type(self):
+        action, reason = screen_structural(self._proposal(decision_type="banana"), set(), [])
+        assert action == "reject"
+        assert "Invalid decision_type: banana" in reason
+        assert "architecture" in reason
+
+    def test_invalid_source(self):
+        action, reason = screen_structural(self._proposal(source="banana"), set(), [])
+        assert action == "reject"
+        assert "Invalid source: banana" in reason
+        assert "mcp" in reason
+
+    def test_valid_enum_fields_pass(self):
+        proposal = self._proposal(reversibility="moderate", decision_type="pattern", source="mcp")
+        action, reason = screen_structural(proposal, set(), [])
+        assert action == "pass"
+        assert reason is None
+
+    def test_none_and_blank_enum_fields_pass(self):
+        # None and blank coerce to unset on the write path; neither rejects.
+        proposal = self._proposal(reversibility=None, decision_type="  ", source="")
+        action, _reason = screen_structural(proposal, set(), [])
+        assert action == "pass"
+
     def test_none_title(self):
         action, reason = screen_structural(self._proposal(title=None), set(), [])
         assert action == "reject"

--- a/packages/nauro/src/nauro/cli/autogen.py
+++ b/packages/nauro/src/nauro/cli/autogen.py
@@ -15,6 +15,10 @@ them natively). ``list[dict]`` properties map to a single JSON-valued
 flag parsed at dispatch time by ``cli._json_input``; that helper raises
 ``typer.BadParameter`` on malformed input so Typer renders to stderr at
 exit 2 without ever invoking the adapter.
+
+Tools in ``AUTOGEN_PRIMARY_POSITIONAL`` additionally surface one declared
+optional string property as a positional argument alongside its option
+flag; the two spellings merge at dispatch.
 """
 
 from __future__ import annotations
@@ -53,6 +57,19 @@ AUTOGEN_ALLOWLIST: frozenset[str] = frozenset(
     }
 )
 
+# Optional schema properties promoted to the command's positional argument.
+# The generic rule — only required properties become positionals — leaves a
+# tool whose primary payload is optional in the schema without a positional
+# form: flag_question's ``question`` may be omitted (the resolve action
+# passes ``resolved_by`` instead), yet ``nauro flag-question "..."`` is the
+# invocation the flag action naturally suggests. A tool named here surfaces
+# the designated string property both as an optional positional argument and
+# as its regular option flag; dispatch merges the two spellings and rejects
+# the call when both carry a value. The MCP schema is unchanged.
+AUTOGEN_PRIMARY_POSITIONAL: dict[str, str] = {
+    "flag_question": "question",
+}
+
 # Properties that should never reach the CLI surface. project_id is
 # replaced by ``--project NAME``; cwd is implicit from the working
 # directory.
@@ -75,15 +92,59 @@ def _bool_option_flag(property_name: str) -> str:
     return f"--{kebab}/--no-{kebab}"
 
 
+def _primary_option_alias(property_name: str) -> str:
+    """Signature name for the option spelling of a primary positional.
+
+    The rendered flag keeps the property's own name (``--question``); only
+    the Python parameter name is aliased so the positional and option
+    spellings can coexist in one signature. Dispatch merges the alias back
+    into the schema property.
+    """
+    return f"{property_name}_option"
+
+
+def _primary_positional_params(name: str, prop: dict[str, Any]) -> list[inspect.Parameter]:
+    """Build the two spellings of a primary-positional property."""
+    desc = prop.get("description", "")
+    positional = inspect.Parameter(
+        name=name,
+        kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        default=typer.Argument(None, help=desc),
+        annotation=str,
+    )
+    option = inspect.Parameter(
+        name=_primary_option_alias(name),
+        kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        default=typer.Option(
+            None,
+            _option_flag(name),
+            help=f"{desc} Equivalent to passing the value positionally.",
+        ),
+        annotation=str,
+    )
+    return [positional, option]
+
+
 def _schema_to_typer_params(spec: ToolSpec) -> list[inspect.Parameter]:
     """Translate an input_schema into ordered Typer parameters.
 
     Required string/integer properties become positional arguments;
-    everything else becomes an option. project_id and cwd are dropped.
+    everything else becomes an option, except a declared primary positional,
+    which surfaces as both. project_id and cwd are dropped.
     """
     schema = spec["input_schema"]
     properties: dict[str, Any] = schema.get("properties", {}) or {}
     required: list[str] = list(schema.get("required", []) or [])
+
+    primary = AUTOGEN_PRIMARY_POSITIONAL.get(spec["name"])
+    if primary is not None and (
+        primary in required or properties.get(primary, {}).get("type") != "string"
+    ):
+        raise ValueError(
+            f"Primary positional {primary!r} for {spec['name']!r} must be an "
+            "optional string property in the tool schema. Fix "
+            "AUTOGEN_PRIMARY_POSITIONAL in cli/autogen.py."
+        )
 
     params: list[inspect.Parameter] = []
 
@@ -105,6 +166,9 @@ def _schema_to_typer_params(spec: ToolSpec) -> list[inspect.Parameter]:
     # Then options, in property-declaration order.
     for name, prop in properties.items():
         if name in _DROPPED_PROPERTIES or name in required:
+            continue
+        if name == primary:
+            params.extend(_primary_positional_params(name, prop))
             continue
         annotation, default = _optional_param(name, prop)
         params.append(
@@ -293,11 +357,17 @@ def _make_command(spec: ToolSpec) -> Callable[..., None]:
     adapter = _resolve_adapter(tool_name)
     params = _schema_to_typer_params(spec)
 
+    # The primary positional's option spelling is a signature-only alias:
+    # it is merged into the schema property at dispatch and never reaches
+    # the adapter under its alias name.
+    primary = AUTOGEN_PRIMARY_POSITIONAL.get(tool_name)
+    primary_alias = _primary_option_alias(primary) if primary is not None else None
+
     # Names of the schema-derived arguments, in dispatch order. These
     # are passed positionally to the adapter to match its
     # ``store_path, <required>, <optional>`` signature.
     schema_arg_names: list[str] = [
-        p.name for p in params if p.name not in {"project", "json_output"}
+        p.name for p in params if p.name not in {"project", "json_output", primary_alias}
     ]
 
     # Properties declared as ``array of object`` arrive as raw strings from
@@ -330,6 +400,16 @@ def _make_command(spec: ToolSpec) -> Callable[..., None]:
         project = kwargs.pop("project", None)
         # --json is a parity no-op; JSON is the only output mode.
         kwargs.pop("json_output", None)
+
+        if primary is not None:
+            option_value = kwargs.pop(primary_alias, None)
+            if option_value is not None:
+                if kwargs.get(primary) is not None:
+                    raise typer.BadParameter(
+                        f"Pass {primary.upper()} positionally or via "
+                        f"{_option_flag(primary)}, not both."
+                    )
+                kwargs[primary] = option_value
 
         _project_name, store_path = resolve_target_project(project)
 
@@ -371,6 +451,13 @@ def register_autogen_commands(app: typer.Typer) -> None:
         raise RuntimeError(
             f"Auto-gen allowlist references unknown tools: {sorted(unknown)}. "
             "Update AUTOGEN_ALLOWLIST in cli/autogen.py."
+        )
+    unknown_primary = set(AUTOGEN_PRIMARY_POSITIONAL) - AUTOGEN_ALLOWLIST
+    if unknown_primary:
+        raise RuntimeError(
+            f"Primary-positional map references non-allowlisted tools: "
+            f"{sorted(unknown_primary)}. Update AUTOGEN_PRIMARY_POSITIONAL "
+            "in cli/autogen.py."
         )
 
     for spec in ALL_TOOLS:

--- a/packages/nauro/tests/snapshots/public_contract_v1.json
+++ b/packages/nauro/tests/snapshots/public_contract_v1.json
@@ -332,11 +332,17 @@
             "type": "text"
           },
           {
+            "kind": "argument",
+            "name": "question",
+            "required": false,
+            "type": "text"
+          },
+          {
             "flags": [
               "--question"
             ],
             "kind": "option",
-            "name": "question",
+            "name": "question_option",
             "required": false,
             "type": "text"
           },

--- a/packages/nauro/tests/test_cli_autogen.py
+++ b/packages/nauro/tests/test_cli_autogen.py
@@ -20,7 +20,7 @@ import pytest
 from nauro_core.mcp_tools import ALL_TOOLS
 from typer.testing import CliRunner
 
-from nauro.cli.autogen import AUTOGEN_ALLOWLIST
+from nauro.cli.autogen import AUTOGEN_ALLOWLIST, AUTOGEN_PRIMARY_POSITIONAL
 from nauro.cli.main import app
 from nauro.constants import REPO_CONFIG_MODE_LOCAL
 from nauro.demo import create_demo_project
@@ -104,6 +104,33 @@ class TestAutogenCoverage:
         relocation. It must stay out of the auto-gen allowlist so a future
         reintroduction in the registry does not silently surface a CLI."""
         assert "confirm_decision" not in AUTOGEN_ALLOWLIST
+
+    def test_positional_arguments_match_schema_plus_declared_primaries(self) -> None:
+        """Every command's positional arguments are exactly its required
+        schema properties plus any declared primary positional, in order.
+        Pins the argument shape of all ten commands so a primary-positional
+        designation cannot silently reshape another command."""
+        import click
+        import typer as typer_mod
+
+        command = typer_mod.main.get_command(app)
+        ctx = click.Context(command, info_name="nauro")
+        specs = {spec["name"]: spec for spec in ALL_TOOLS}
+        assert AUTOGEN_PRIMARY_POSITIONAL == {"flag_question": "question"}
+        for name in AUTOGEN_ALLOWLIST:
+            sub = command.get_command(ctx, name.replace("_", "-"))
+            assert sub is not None
+            # typer vendors its own click fork, so TyperArgument is not a
+            # click.Argument; param_type_name discriminates on either lineage.
+            arguments = [p.name for p in sub.params if p.param_type_name == "argument"]
+            schema = specs[name]["input_schema"]
+            expected = [r for r in schema.get("required", []) if r not in {"project_id", "cwd"}]
+            if name in AUTOGEN_PRIMARY_POSITIONAL:
+                expected.append(AUTOGEN_PRIMARY_POSITIONAL[name])
+            assert arguments == expected, (
+                f"'{name.replace('_', '-')}' positional arguments {arguments} "
+                f"drifted from the schema-derived shape {expected}."
+            )
 
 
 # ── Per-tool happy + error paths ────────────────────────────────────────────

--- a/packages/nauro/tests/test_journal.py
+++ b/packages/nauro/tests/test_journal.py
@@ -365,6 +365,26 @@ class TestToolJournaling:
         assert events[0].decision_id is None
         assert events[0].payload_hash
 
+    def test_invalid_enum_tier1_rejection_records_rejected_event(self, store: Path):
+        # A non-member enum value rejects at Tier 1 like any other structural
+        # defect, so it flows through the same rejected-event journaling
+        # instead of escaping as a raised ValueError.
+        result = tool_propose_decision(
+            store,
+            title="Adopt widgets",
+            rationale=_LONG_RATIONALE,
+            reversibility="reversible",
+            origin=_ORIGIN,
+        )
+        assert result["status"] == "rejected"
+        assert "Invalid reversibility" in result["assessment"]
+        events = read_events(store)
+        assert len(events) == 1
+        assert events[0].operation == "propose_decision"
+        assert events[0].status == "rejected"
+        assert events[0].decision_id is None
+        assert events[0].payload_hash
+
 
 # --- snapshot exclusion ------------------------------------------------------
 

--- a/packages/nauro/tests/test_write_command_autogen.py
+++ b/packages/nauro/tests/test_write_command_autogen.py
@@ -1,6 +1,6 @@
-"""End-to-end tests for the auto-generated ``propose-decision`` CLI command.
+"""End-to-end tests for the auto-generated write CLI commands.
 
-Three concerns are pinned here:
+Three concerns are pinned here for ``propose-decision``:
 
 * Happy paths through the write tool land the same envelope the adapter
   returns (auto-confirmed adds, supersedes with ``--operation supersede
@@ -14,6 +14,11 @@ Three concerns are pinned here:
   repeated-flag form and ``list[dict]`` (``--rejected``) literal /
   ``@file`` / ``-`` (stdin) sigil forms are exercised here so the
   framework convention is pinned at the CLI surface.
+
+``flag-question`` pins the primary-positional convention: the optional
+``question`` property accepts both the positional and ``--question``
+spellings, supplying both is a usage error, and the ``--resolved-by``
+resolve action still works with the positional omitted.
 """
 
 from __future__ import annotations
@@ -383,3 +388,49 @@ class TestFlagShapes:
         assert result.exit_code == 2, result.output
         assert "supersede" in strip_ansi(result.output)
         assert '"store"' not in result.stdout
+
+
+# ── flag-question argument shapes ───────────────────────────────────────────
+
+
+def _seed_resolvable(store_path: Path) -> None:
+    """Seed one open question and one decision the resolve action can target."""
+    (store_path / "open-questions.md").write_text("# Open Questions\n\n- [Q1] needs a decision\n")
+    decisions = store_path / "decisions"
+    decisions.mkdir(exist_ok=True)
+    (decisions / "042-some-decision.md").write_text("# Decision 42\n")
+
+
+class TestFlagQuestionArgumentShapes:
+    def test_positional_question(self, seeded_repo) -> None:
+        result = runner.invoke(app, ["flag-question", "Should we cache reads?"])
+        assert result.exit_code == 0, result.output
+        envelope = json.loads(result.stdout)
+        assert envelope["store"] == "local"
+        assert envelope["status"] == "ok"
+
+    def test_question_flag_matches_positional(self, seeded_repo) -> None:
+        positional = runner.invoke(app, ["flag-question", "Should we cache reads?"])
+        flagged = runner.invoke(app, ["flag-question", "--question", "Should we cache writes?"])
+        assert positional.exit_code == 0, positional.output
+        assert flagged.exit_code == 0, flagged.output
+        assert json.loads(positional.stdout) == json.loads(flagged.stdout)
+
+    def test_both_spellings_exit_two(self, seeded_repo) -> None:
+        result = runner.invoke(
+            app,
+            ["flag-question", "Should we cache reads?", "--question", "Should we cache writes?"],
+        )
+        # Usage error rendered by Typer at exit 2; the adapter never runs.
+        assert result.exit_code == 2, result.output
+        assert "--question" in strip_ansi(result.output)
+        assert '"store"' not in result.stdout
+
+    def test_resolved_by_without_question(self, seeded_repo) -> None:
+        _pid, store_path, _repo = seeded_repo
+        _seed_resolvable(store_path)
+        result = runner.invoke(app, ["flag-question", "--resolved-by", "D42", "--targets", "Q1"])
+        assert result.exit_code == 0, result.output
+        envelope = json.loads(result.stdout)
+        assert envelope["status"] == "ok"
+        assert "[Resolved by D42 on " in (store_path / "open-questions.md").read_text()


### PR DESCRIPTION
## Why

Two write-surface bugs found in a behavior audit. First, `propose_decision` with an invalid enum value (e.g. `reversibility="reversible"`) passed Tier 1 structural screening and then raised an uncaught `ValueError` from the enum coercion inside the write path — after validation had already said yes — instead of returning the clean rejection envelope every other invalid input gets, and the failure escaped the journal's rejected-event classification. Second, `nauro flag-question "some question?"` exited 2: the CLI generator only promotes required schema properties to positional arguments, and `question` is optional in the schema (the resolve action passes `resolved_by` instead), so the invocation the command naturally suggests — mirroring `nauro note` — was unparseable.

## What changed

- `screen_structural` now validates the optional enum-valued fields (`decision_type`, `reversibility`, `source`) where the other Tier 1 checks live, with allowed values derived from the enums so validator and schema cannot drift. A non-member value returns the standard Tier 1 rejection naming the field and its allowed values; None and blank still coerce to unset. The write path's fail-loud coercion is unchanged for callers that bypass validation. The shared kernel means the remote server inherits the fix at its next dependency bump.
- The CLI generator gains an explicit primary-positional designation (`AUTOGEN_PRIMARY_POSITIONAL`, declared data beside the allowlist, verified at import). `flag-question` now accepts the question positionally and via `--question`; supplying both is a usage error (exit 2), and the `--resolved-by`-only resolve form is untouched. MCP tool schemas are unchanged.
- The frozen public-contract snapshot is regenerated for the flag-question shape change, and a new test pins every autogen command's positional arguments to the schema-derived shape.

## Risk / what to review

- `public_contract_v1.json` is a surface frozen at 1.0. The diff is additive on the user surface: a new optional positional for flag-question plus the internal rename of the recorded option param (`question` → `question_option`); the `--question` flag itself is unchanged, as is every other command.
- The enum validation includes `source`, which adapters stamp rather than callers supply — included so all enum-valued proposal fields reject at the same boundary.

## Test plan

- New kernel tests: each invalid enum value returns the Tier 1 rejection envelope (no exception), names the field and allowed values, writes nothing; every advertised reversibility value commits and lands in frontmatter (mirroring the existing decision_type lockstep guard).
- New journal test: an invalid-enum attempt records a `rejected` event like other Tier 1 rejections.
- New CLI tests: positional flag-question works; `--question` yields an identical envelope; both spellings exit 2 before the adapter runs; resolve-only works end-to-end; a shape-pinning test locks all ten autogen commands' positional arguments.
- Full suites: nauro-core 1098 passed; nauro 2090 passed, 10 skipped. Ruff clean.
