### PR TITLE
Cap rendered question entries and add the two missing read-tool renderers

### DIFF
--- a/packages/nauro-core/src/nauro_core/constants.py
+++ b/packages/nauro-core/src/nauro_core/constants.py
@@ -19,6 +19,11 @@ L1_DECISIONS_LIMIT = 10
 L1_DECISIONS_SUMMARY_LIMIT = 10
 # L1 working-set cap on genuine open questions, mirrors L1_DECISIONS_LIMIT.
 L1_QUESTIONS_LIMIT = 10
+# Per-entry character cap on rendered open-question text in the L0/L1
+# payloads and the session diff. A presentation limit only: L2 and
+# get_raw_file keep the full file verbatim, and truncated entries carry
+# an explicit pointer at the full text.
+QUESTION_ENTRY_CHAR_BUDGET = 480
 
 # ── Validation thresholds ──
 VALID_CONFIDENCES: set[str] = {"high", "medium", "low"}

--- a/packages/nauro-core/src/nauro_core/context.py
+++ b/packages/nauro-core/src/nauro_core/context.py
@@ -29,7 +29,7 @@ from nauro_core.parsing import (
     is_scaffold_project_md,
     strip_leading_h1,
 )
-from nauro_core.questions import EntryBlock, OpenQuestionsFile
+from nauro_core.questions import EntryBlock, OpenQuestionsFile, truncate_entry_text
 from nauro_core.state import assemble_state_for_context
 
 # Open questions older than this nudge the reader to close or defer.
@@ -59,8 +59,12 @@ def _render_open_questions(
     A ``(open NN days; consider closing or deferring)`` line is prepended
     when ``entry.timestamp`` is set and the entry is older than
     :data:`_AGE_PROJECTION_DAYS`. Q-form entries without a timestamp
-    render without the projection. Entries render whole — the limit never
-    cuts mid-entry.
+    render without the projection. The limit never cuts mid-entry, but
+    each entry's joined rendered text is capped at
+    :data:`~nauro_core.constants.QUESTION_ENTRY_CHAR_BUDGET` characters
+    via :func:`~nauro_core.questions.truncate_entry_text`; entries at or
+    under the budget render byte-unchanged, over-budget entries end with
+    an explicit pointer at ``get_raw_file("open-questions.md")``.
 
     When ``include_omission_trailer`` is set and genuine entries were
     omitted beyond the limit, one trailer line reports the omitted count
@@ -90,7 +94,7 @@ def _render_open_questions(
             age_days = (today - entry.timestamp.date()).days
             if age_days > _AGE_PROJECTION_DAYS:
                 lines.append(f"(open {age_days} days; consider closing or deferring)")
-        lines.extend(entry.render())
+        lines.append(truncate_entry_text("\n".join(entry.render())))
         rendered += 1
 
     if include_omission_trailer and omitted:

--- a/packages/nauro-core/src/nauro_core/operations/diff_since_last_session.py
+++ b/packages/nauro-core/src/nauro_core/operations/diff_since_last_session.py
@@ -27,6 +27,7 @@ from nauro_core.constants import (
 from nauro_core.operations.results import DiffSinceLastSessionResult
 from nauro_core.operations.store import Store
 from nauro_core.parsing import _is_top_level_bullet
+from nauro_core.questions import truncate_entry_text
 
 # Success-path sentinels rendered when the adapter cannot supply a usable
 # (baseline, latest) pair. Exposed as module constants so adapters can
@@ -256,7 +257,14 @@ def _diff_stack(old: str, new: str) -> list[str]:
 
 
 def _diff_questions(old: str, new: str) -> list[str]:
-    """Diff open-questions.md semantically."""
+    """Diff open-questions.md semantically.
+
+    Each rendered bullet is capped at
+    :data:`~nauro_core.constants.QUESTION_ENTRY_CHAR_BUDGET` characters
+    via :func:`~nauro_core.questions.truncate_entry_text`, matching the
+    L0/L1 question projection; bullets at or under the budget render
+    byte-unchanged.
+    """
     changes: list[str] = []
 
     def extract_questions(content: str) -> list[str]:
@@ -269,9 +277,9 @@ def _diff_questions(old: str, new: str) -> list[str]:
     removed = [q for q in old_qs if q not in new_qs]
 
     for q in added:
-        changes.append(f"+ New question: {q.removeprefix('- ')}")
+        changes.append(truncate_entry_text(f"+ New question: {q.removeprefix('- ')}"))
     for q in removed:
-        changes.append(f"- Resolved/removed: {q.removeprefix('- ')}")
+        changes.append(truncate_entry_text(f"- Resolved/removed: {q.removeprefix('- ')}"))
 
     return changes
 

--- a/packages/nauro-core/src/nauro_core/questions.py
+++ b/packages/nauro-core/src/nauro_core/questions.py
@@ -31,13 +31,30 @@ from typing import Annotated, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from nauro_core.constants import POINTER_FLAG_PREFIXES
+from nauro_core.constants import POINTER_FLAG_PREFIXES, QUESTION_ENTRY_CHAR_BUDGET
 
 _TIMESTAMP_FMT = "%Y-%m-%d %H:%M UTC"
 _RESOLVED_HEADER = "## Resolved"
 _DEFAULT_HEADER = "# Open Questions"
 _RESOLVED_PREFIX_TOKEN = "Resolved by D"
 _RESOLVED_PREFIX_SEP = " on "
+
+# Appended to over-budget entry text by :func:`truncate_entry_text` so a
+# capped payload never silently hides content.
+QUESTION_TRUNCATION_POINTER = '... [truncated - full text: get_raw_file("open-questions.md")]'
+
+
+def truncate_entry_text(text: str) -> str:
+    """Cap rendered question-entry text at :data:`QUESTION_ENTRY_CHAR_BUDGET`.
+
+    Text at or under the budget is returned byte-unchanged. Over-budget
+    text is cut at the budget (trailing whitespace stripped) and ends
+    with :data:`QUESTION_TRUNCATION_POINTER`, pointing the reader at the
+    full file.
+    """
+    if len(text) <= QUESTION_ENTRY_CHAR_BUDGET:
+        return text
+    return text[:QUESTION_ENTRY_CHAR_BUDGET].rstrip() + " " + QUESTION_TRUNCATION_POINTER
 
 
 class ResolvedRef(BaseModel):

--- a/packages/nauro-core/src/nauro_core/renderers.py
+++ b/packages/nauro-core/src/nauro_core/renderers.py
@@ -23,6 +23,11 @@ Per-tool surface area:
   rows. Empty-state guidance flows through unchanged.
 * ``get_context`` — passthrough; the kernel-assembled markdown is already
   human-readable.
+* ``get_raw_file`` — hit: the file content verbatim; miss: the
+  ``Error: File not found`` line plus the ``available_files`` hint in
+  its composed order.
+* ``diff_since_last_session`` — passthrough of the rendered diff body,
+  including the canonical sentinel strings byte-for-byte.
 * ``list_projects`` — short tabular list of ``(name, role, project_id)``
   rows so the agent can disambiguate without re-fetching.
 """
@@ -326,6 +331,49 @@ def render_get_context(result: dict) -> str:
     return body.rstrip() or _guidance(result)
 
 
+def render_get_raw_file(result: dict) -> str:
+    """Render a raw-file read.
+
+    On a hit the file content passes through verbatim — it is already the
+    primary human-readable payload. On a miss the error line renders
+    first (``Error: File not found: <path>``), then the adapter-composed
+    ``available_files`` hint in its exact order — the ordering (canonical
+    root files, remaining root markdown, per-directory anchors) is a
+    cross-surface contract, never reorder it here.
+    """
+    if guidance := _connection_guidance(result):
+        return guidance
+    if "error" in result:
+        lines = [_error_block(result["error"])]
+        available = result.get("available_files") or []
+        if available:
+            lines.append("")
+            lines.append("Available files:")
+            lines.extend(f"  - {path}" for path in available)
+        return "\n".join(lines)
+    content = result.get("content")
+    if content is None:
+        return _guidance(result)
+    return content
+
+
+def render_diff_since_last_session(result: dict) -> str:
+    """Render a session diff.
+
+    The kernel/adapter ``diff`` body is already human-readable text and
+    passes through verbatim: the canonical sentinel strings ("No
+    snapshots available.", "Not enough snapshots...", "Only one snapshot
+    covers...") and the anchor line are cross-surface contracts, so the
+    renderer must stay byte-transparent to them.
+    """
+    if guidance := _connection_guidance(result):
+        return guidance
+    if "error" in result:
+        return _error_block(result["error"])
+    diff = result.get("diff") or ""
+    return diff or _guidance(result)
+
+
 def render_list_projects(result: dict) -> str:
     """Render the user's project list as a short tabular block."""
     projects = result.get("projects") or []
@@ -346,16 +394,16 @@ def render_list_projects(result: dict) -> str:
     return "\n".join(lines).rstrip()
 
 
-# Renderer registry used by the dispatcher. Only read tools whose JSON
-# envelope is unhelpful as primary content appear here; ``get_raw_file``
-# and ``diff_since_last_session`` already return user-rendered bodies and
-# are intentionally absent.
+# Renderer registry used by the dispatcher: every read tool renders a
+# single human-readable text block through it.
 RENDERERS = {
     "check_decision": render_check_decision,
     "get_decision": render_get_decision,
     "search_decisions": render_search_decisions,
     "list_decisions": render_list_decisions,
     "get_context": render_get_context,
+    "get_raw_file": render_get_raw_file,
+    "diff_since_last_session": render_diff_since_last_session,
     "list_projects": render_list_projects,
 }
 
@@ -364,8 +412,10 @@ __all__ = [
     "RENDERERS",
     "disconnected_reason_code",
     "render_check_decision",
+    "render_diff_since_last_session",
     "render_get_context",
     "render_get_decision",
+    "render_get_raw_file",
     "render_list_decisions",
     "render_list_projects",
     "render_search_decisions",

--- a/packages/nauro-core/tests/operations/test_diff_since_last_session.py
+++ b/packages/nauro-core/tests/operations/test_diff_since_last_session.py
@@ -383,3 +383,72 @@ def test_new_decision_title_keeps_leading_hash() -> None:
         "  + New file: decisions/002-hotfix.md\n"
         "    #1 priority hotfix"
     )
+
+
+# ── Question bullets honour the per-entry character budget ──
+
+
+def test_over_budget_added_question_truncates_with_pointer() -> None:
+    from nauro_core.constants import QUESTION_ENTRY_CHAR_BUDGET
+    from nauro_core.questions import QUESTION_TRUNCATION_POINTER
+
+    long_q = "- [Q2] Adopt the long option? " + "detail " * 120
+    snap_a = _snapshot(
+        1,
+        "2026-05-01T10:00:00+00:00",
+        {"open-questions.md": "# Open Questions\n- [Q1] Pick a queue?\n"},
+    )
+    snap_b = _snapshot(
+        2,
+        "2026-05-02T10:00:00+00:00",
+        {"open-questions.md": f"# Open Questions\n- [Q1] Pick a queue?\n{long_q.rstrip()}\n"},
+    )
+    result = diff_since_last_session(InMemoryStore(), snap_a, snap_b)
+    assert result.diff is not None
+    bullet = next(
+        line for line in result.diff.split("\n") if line.lstrip().startswith("+ New question:")
+    )
+    assert bullet.rstrip().endswith(QUESTION_TRUNCATION_POINTER)
+    assert len(bullet.strip()) <= QUESTION_ENTRY_CHAR_BUDGET + 1 + len(QUESTION_TRUNCATION_POINTER)
+
+
+def test_under_budget_question_bullets_render_byte_unchanged() -> None:
+    from nauro_core.questions import QUESTION_TRUNCATION_POINTER
+
+    snap_a = _snapshot(
+        1,
+        "2026-05-01T10:00:00+00:00",
+        {"open-questions.md": "# Open Questions\n- [Q1] Pick a queue?\n"},
+    )
+    snap_b = _snapshot(
+        2,
+        "2026-05-02T10:00:00+00:00",
+        {"open-questions.md": "# Open Questions\n- [Q2] Choose a broker?\n"},
+    )
+    result = diff_since_last_session(InMemoryStore(), snap_a, snap_b)
+    assert result.diff is not None
+    assert "    + New question: [Q2] Choose a broker?" in result.diff
+    assert "    - Resolved/removed: [Q1] Pick a queue?" in result.diff
+    assert QUESTION_TRUNCATION_POINTER not in result.diff
+
+
+def test_over_budget_removed_question_truncates_with_pointer() -> None:
+    from nauro_core.questions import QUESTION_TRUNCATION_POINTER
+
+    long_q = "- [Q1] Retired long question? " + "context " * 120
+    snap_a = _snapshot(
+        1,
+        "2026-05-01T10:00:00+00:00",
+        {"open-questions.md": f"# Open Questions\n{long_q.rstrip()}\n"},
+    )
+    snap_b = _snapshot(
+        2,
+        "2026-05-02T10:00:00+00:00",
+        {"open-questions.md": "# Open Questions\n"},
+    )
+    result = diff_since_last_session(InMemoryStore(), snap_a, snap_b)
+    assert result.diff is not None
+    bullet = next(
+        line for line in result.diff.split("\n") if line.lstrip().startswith("- Resolved/removed:")
+    )
+    assert bullet.rstrip().endswith(QUESTION_TRUNCATION_POINTER)

--- a/packages/nauro-core/tests/test_context.py
+++ b/packages/nauro-core/tests/test_context.py
@@ -3,13 +3,14 @@
 from datetime import date as _date
 from datetime import datetime, timedelta, timezone
 
-from nauro_core.constants import PROJECT_MD_SCAFFOLD_BODY
+from nauro_core.constants import PROJECT_MD_SCAFFOLD_BODY, QUESTION_ENTRY_CHAR_BUDGET
 from nauro_core.context import build_l0, build_l1, build_l2
 from nauro_core.decision_model import (
     Decision,
     DecisionConfidence,
     DecisionStatus,
 )
+from nauro_core.questions import QUESTION_TRUNCATION_POINTER
 
 
 def _make_decision(num, title, status="active", date="2026-04-01", rationale="Reason."):
@@ -715,3 +716,79 @@ class TestBuildL1OpenQuestionsProjection:
         content = "# Open Questions\n\n" + self._genuine(12)
         result = build_l0(self._files(content), [])
         assert "more open questions" not in result
+
+
+class TestQuestionEntryCharBudget:
+    """Each question entry's rendered text is capped at
+    QUESTION_ENTRY_CHAR_BUDGET characters in L0 and L1.
+
+    Entries at or under the budget render byte-unchanged; over-budget
+    entries are cut and end with the pointer at the full file. L2 dumps
+    open-questions.md verbatim and stays uncapped.
+    """
+
+    def _files(self, content: str) -> dict[str, str]:
+        return {"open-questions.md": content}
+
+    def _over_budget_entry(self) -> str:
+        body = "Should we adopt the long option? " + "detail " * 100
+        return f"- [Q1] {body.strip()}\n"
+
+    def test_under_budget_entry_renders_byte_unchanged_at_l0(self):
+        entry = "- [Q1] Short and sweet?"
+        content = f"# Open Questions\n\n{entry}\n"
+        result = build_l0(self._files(content), [])
+        assert entry in result
+        assert QUESTION_TRUNCATION_POINTER not in result
+
+    def test_over_budget_entry_truncates_at_l0(self):
+        content = "# Open Questions\n\n" + self._over_budget_entry()
+        result = build_l0(self._files(content), [])
+        assert QUESTION_TRUNCATION_POINTER in result
+        assert "detail detail detail detail" in result  # leading text survives
+        section = result[result.index("## Open Questions") :]
+        entry_line = section.split("\n")[1]
+        assert len(entry_line) <= QUESTION_ENTRY_CHAR_BUDGET + 1 + len(QUESTION_TRUNCATION_POINTER)
+
+    def test_over_budget_entry_truncates_at_l1(self):
+        content = "# Open Questions\n\n" + self._over_budget_entry()
+        result = build_l1(self._files(content), [])
+        assert QUESTION_TRUNCATION_POINTER in result
+
+    def test_l0_and_l1_truncate_identically(self):
+        content = "# Open Questions\n\n" + self._over_budget_entry()
+        l0 = build_l0(self._files(content), [])
+        l1 = build_l1(self._files(content), [])
+        l0_line = next(line for line in l0.split("\n") if line.startswith("- [Q1]"))
+        l1_line = next(line for line in l1.split("\n") if line.startswith("- [Q1]"))
+        assert l0_line == l1_line
+
+    def test_l2_keeps_full_text_verbatim(self):
+        content = "# Open Questions\n\n" + self._over_budget_entry()
+        result = build_l2(self._files(content), [])
+        assert content.strip() in result
+        assert QUESTION_TRUNCATION_POINTER not in result
+
+    def test_multiline_entry_capped_on_joined_text(self):
+        # The budget applies to the entry's joined rendered text (head plus
+        # continuation lines), so a long continuation tail is cut too.
+        long_tail = "  " + "tail " * 150
+        content = f"# Open Questions\n\n- [Q1] Multi-line head?\n{long_tail}\n"
+        result = build_l1(self._files(content), [])
+        assert QUESTION_TRUNCATION_POINTER in result
+        assert "Multi-line head?" in result
+
+    def test_cap_leaves_age_projection_untouched(self):
+        target = datetime.now(timezone.utc).date() - timedelta(days=45)
+        body = "Old and long? " + "padding " * 100
+        content = f"# Open Questions\n\n- [{_legacy_id(target)}] {body.strip()}\n"
+        result = build_l0(self._files(content), [])
+        assert "(open 45 days; consider closing or deferring)" in result
+        assert QUESTION_TRUNCATION_POINTER in result
+
+    def test_cap_leaves_omission_trailer_untouched(self):
+        entries = "".join(f"- [Q{i}] Genuine question {i}?\n" for i in range(1, 13))
+        content = "# Open Questions\n\n" + entries
+        result = build_l1(self._files(content), [])
+        assert "(+2 more open questions" in result
+        assert QUESTION_TRUNCATION_POINTER not in result

--- a/packages/nauro-core/tests/test_questions.py
+++ b/packages/nauro-core/tests/test_questions.py
@@ -5,7 +5,9 @@ from datetime import date, datetime
 import pytest
 from pydantic import ValidationError
 
+from nauro_core.constants import QUESTION_ENTRY_CHAR_BUDGET
 from nauro_core.questions import (
+    QUESTION_TRUNCATION_POINTER,
     EntryBlock,
     HeaderBlock,
     MigrationRename,
@@ -16,6 +18,7 @@ from nauro_core.questions import (
     ResolvedRef,
     TripleHashBlock,
     UnparsableBlock,
+    truncate_entry_text,
 )
 
 
@@ -1200,3 +1203,44 @@ class TestNormalize:
         assert result.relocated_ids == ()
         assert result.skipped_prose_ids == ("Q5",)
         assert result.file is parsed
+
+
+class TestTruncateEntryText:
+    """Per-entry character cap on rendered question text.
+
+    Pure helper shared by the L0/L1 question projection and the session
+    diff's question bullets. Text at or under the budget is byte-unchanged;
+    over-budget text is cut at the budget and ends with the pointer at the
+    full file.
+    """
+
+    def test_under_budget_is_byte_unchanged(self):
+        text = "- [Q1] Short question?"
+        assert truncate_entry_text(text) is text
+
+    def test_exactly_at_budget_is_byte_unchanged(self):
+        text = "x" * QUESTION_ENTRY_CHAR_BUDGET
+        assert truncate_entry_text(text) == text
+
+    def test_one_over_budget_truncates_with_pointer(self):
+        text = "x" * (QUESTION_ENTRY_CHAR_BUDGET + 1)
+        result = truncate_entry_text(text)
+        assert result == "x" * QUESTION_ENTRY_CHAR_BUDGET + " " + QUESTION_TRUNCATION_POINTER
+        assert result.endswith(QUESTION_TRUNCATION_POINTER)
+
+    def test_pointer_names_the_raw_file(self):
+        assert 'get_raw_file("open-questions.md")' in QUESTION_TRUNCATION_POINTER
+        assert "[truncated" in QUESTION_TRUNCATION_POINTER
+
+    def test_cut_strips_trailing_whitespace_before_pointer(self):
+        # A cut landing on whitespace must not leave a double space before
+        # the pointer.
+        text = "word " * 200  # 1000 chars; position 480 falls inside "word "
+        result = truncate_entry_text(text)
+        cut = text[:QUESTION_ENTRY_CHAR_BUDGET].rstrip()
+        assert result == cut + " " + QUESTION_TRUNCATION_POINTER
+
+    def test_output_length_is_bounded(self):
+        text = "y" * 100_000
+        result = truncate_entry_text(text)
+        assert len(result) <= QUESTION_ENTRY_CHAR_BUDGET + 1 + len(QUESTION_TRUNCATION_POINTER)

--- a/packages/nauro-core/tests/test_renderers.py
+++ b/packages/nauro-core/tests/test_renderers.py
@@ -11,10 +11,17 @@ from __future__ import annotations
 import json
 
 from nauro_core.constants import LEXICAL_RANK_CAVEAT, NO_RELATED_DECISIONS
+from nauro_core.operations.diff_since_last_session import (
+    NO_SNAPSHOTS_AVAILABLE,
+    NOT_ENOUGH_SNAPSHOTS,
+    ONE_SNAPSHOT_COVERS_RANGE,
+)
 from nauro_core.renderers import (
     render_check_decision,
+    render_diff_since_last_session,
     render_get_context,
     render_get_decision,
+    render_get_raw_file,
     render_list_decisions,
     render_list_projects,
     render_search_decisions,
@@ -701,3 +708,116 @@ class TestDisconnectedProjectGuidance:
         assert render_check_decision(result) == result["guidance"]
         assert render_search_decisions(result) == result["guidance"]
         assert render_list_decisions(result) == result["guidance"]
+
+
+class TestRenderGetRawFile:
+    def test_hit_passes_content_through_verbatim(self):
+        content = "# Stack\n\n- **Python 3.11** - primary language\n"
+        result = {"store": "local", "content": content}
+        assert render_get_raw_file(result) == content
+
+    def test_empty_file_renders_empty_string(self):
+        result = {"store": "local", "content": ""}
+        assert render_get_raw_file(result) == ""
+
+    def test_miss_renders_error_line_then_hint_in_order(self):
+        result = {
+            "store": "local",
+            "error": {"kind": "error", "reason": "File not found: nope.md"},
+            "available_files": [
+                "project.md",
+                "state_current.md",
+                "stack.md",
+                "decisions/002-use-fastapi.md",
+                "decisions/ (2 files)",
+            ],
+        }
+        text = render_get_raw_file(result)
+        lines = text.split("\n")
+        assert lines[0] == "Error: File not found: nope.md"
+        assert lines[1] == ""
+        assert lines[2] == "Available files:"
+        # The adapter-composed hint order is a contract: canonical root files
+        # first, then remaining root markdown, then per-directory anchors.
+        assert lines[3:] == [
+            "  - project.md",
+            "  - state_current.md",
+            "  - stack.md",
+            "  - decisions/002-use-fastapi.md",
+            "  - decisions/ (2 files)",
+        ]
+
+    def test_error_without_hint_renders_error_line_only(self):
+        result = {
+            "store": "local",
+            "error": {"kind": "error", "reason": "Invalid path: ../../etc/passwd"},
+        }
+        assert render_get_raw_file(result) == "Error: Invalid path: ../../etc/passwd"
+
+    def test_no_project_guidance_surfaces(self):
+        result = {"store": "local", "status": "error", "guidance": "Welcome to Nauro."}
+        assert render_get_raw_file(result) == "Welcome to Nauro."
+
+    def test_disconnected_guidance_preferred(self):
+        result = {
+            "store": "local",
+            "status": "error",
+            "error": {"kind": "error", "reason": "internal structured reason"},
+            "guidance": "Run `nauro reconnect` to restore this project.",
+            "reason_code": "connected_record_missing",
+        }
+        assert render_get_raw_file(result) == result["guidance"]
+
+
+class TestRenderDiffSinceLastSession:
+    def test_diff_body_passes_through_verbatim(self):
+        diff = (
+            "Changes from v001 → v002\n"
+            "  (2026-05-01T10:00:00 → 2026-05-02T10:00:00)\n"
+            "\n"
+            "  ~ stack.md\n"
+            "    + - PostgreSQL"
+        )
+        result = {"store": "local", "diff": diff}
+        assert render_diff_since_last_session(result) == diff
+
+    def test_sentinels_pass_through_byte_identical(self):
+        # The canonical sentinel strings are a cross-surface contract; the
+        # renderer must stay byte-transparent to them.
+        for sentinel in (
+            NO_SNAPSHOTS_AVAILABLE,
+            NOT_ENOUGH_SNAPSHOTS,
+            ONE_SNAPSHOT_COVERS_RANGE,
+        ):
+            result = {"store": "local", "diff": sentinel}
+            assert render_diff_since_last_session(result) == sentinel
+
+    def test_anchor_line_passes_through(self):
+        diff = (
+            "Changes from v001 → v002\n"
+            "Anchor: requested ≤ 2026-04-24T10:00:00+00:00; resolved to baseline "
+            "2026-05-01T10:00:00 (most-recent snapshot at-or-before cutoff; "
+            "oldest-snapshot fallback)\n"
+            "\n"
+            "  No changes detected."
+        )
+        result = {"store": "local", "diff": diff, "cutoff_date_used": "2026-04-24T10:00:00+00:00"}
+        assert render_diff_since_last_session(result) == diff
+
+    def test_error_renders_error_line(self):
+        result = {"store": "local", "error": {"kind": "error", "reason": "boom"}}
+        assert render_diff_since_last_session(result) == "Error: boom"
+
+    def test_no_project_guidance_surfaces(self):
+        result = {"store": "local", "status": "error", "guidance": "Welcome to Nauro."}
+        assert render_diff_since_last_session(result) == "Welcome to Nauro."
+
+    def test_disconnected_guidance_preferred(self):
+        result = {
+            "store": "local",
+            "status": "error",
+            "error": {"kind": "error", "reason": "internal structured reason"},
+            "guidance": "Run `nauro reconnect` to restore this project.",
+            "reason_code": "connected_record_missing",
+        }
+        assert render_diff_since_last_session(result) == result["guidance"]

--- a/packages/nauro/src/nauro/mcp/stdio_server.py
+++ b/packages/nauro/src/nauro/mcp/stdio_server.py
@@ -17,10 +17,12 @@ The shared `nauro_core.mcp_tools.ALL_TOOLS` registry contains 11 tools.
 single project store, so the discovery tool is not registered here.
 
 Renderer-scoped read tools listed in ``nauro_core.renderers.RENDERERS``
-return a ``CallToolResult`` with a single ``TextContent`` block:
-``content[0]`` carries the renderer output. Other tools — write tools,
-``get_raw_file``, ``diff_since_last_session`` — keep their existing
-single-block shape.
+— all seven read tools registered here — return a ``CallToolResult``
+with a single ``TextContent`` block: ``content[0]`` carries the renderer
+output. Write tools keep their existing single-value shape. A tool name
+missing from ``RENDERERS`` (an older installed nauro-core) falls back to
+a JSON dump of the envelope, so the wrapper degrades gracefully instead
+of crashing.
 """
 
 from __future__ import annotations
@@ -252,11 +254,10 @@ def get_raw_file(
         str | None, Field(description=_param_desc("get_raw_file", "project_id"))
     ] = None,
     cwd: _CWD_PARAM = None,
-) -> dict:
+) -> CallToolResult:
     store_path, err = _resolve_or_error(project_id, cwd)
-    if err is not None:
-        return err
-    return tool_get_raw_file(store_path, path)
+    result = err if err is not None else tool_get_raw_file(store_path, path)
+    return _wrap_with_renderer("get_raw_file", result)
 
 
 @mcp.tool(**_spec_kwargs("list_decisions"))
@@ -301,11 +302,10 @@ def diff_since_last_session(
     days: Annotated[
         int | None, Field(description=_param_desc("diff_since_last_session", "days"))
     ] = None,
-) -> dict:
+) -> CallToolResult:
     store_path, err = _resolve_or_error(project_id, cwd)
-    if err is not None:
-        return err
-    return tool_diff_since_last_session(store_path, days)
+    result = err if err is not None else tool_diff_since_last_session(store_path, days)
+    return _wrap_with_renderer("diff_since_last_session", result)
 
 
 @mcp.tool(**_spec_kwargs("search_decisions"))

--- a/packages/nauro/tests/test_agents_md.py
+++ b/packages/nauro/tests/test_agents_md.py
@@ -297,6 +297,36 @@ def test_sync_agents_md_omits_scaffold_project_placeholders(tmp_path: Path, monk
     assert "[Hard limits" not in content
 
 
+def test_sync_agents_md_truncates_over_budget_question_like_l0(tmp_path: Path, monkeypatch):
+    """An over-budget question entry truncates identically in AGENTS.md and L0.
+
+    AGENTS.md embeds the L0 payload via build_l0_payload, so the capped
+    entry bytes (cut at the budget, ending with the pointer) must appear
+    verbatim — never the full over-budget tail.
+    """
+    from nauro_core.questions import QUESTION_TRUNCATION_POINTER, truncate_entry_text
+
+    from nauro.store.registry import register_project_v2
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _pid, store = register_project_v2("myproj", [repo])
+    scaffold_project_store("myproj", store)
+    body = "Should we adopt the long option? " + "detail " * 120 + "UNIQUE-TAIL-MARKER"
+    entry_line = f"- [Q1] {body}"
+    (store / "open-questions.md").write_text(f"# Open Questions\n\n{entry_line}\n")
+    monkeypatch.chdir(repo)
+
+    result = runner.invoke(app, ["sync"])
+    assert result.exit_code == 0
+
+    content = (repo / "AGENTS.md").read_text()
+    # The exact truncated bytes the L0 builder produces appear in AGENTS.md.
+    assert truncate_entry_text(entry_line) in content
+    assert QUESTION_TRUNCATION_POINTER in content
+    assert "UNIQUE-TAIL-MARKER" not in content
+
+
 def test_sync_multi_repo(tmp_path: Path, monkeypatch):
     from nauro.store.registry import register_project_v2
 

--- a/packages/nauro/tests/test_diff_since_last_session_parity.py
+++ b/packages/nauro/tests/test_diff_since_last_session_parity.py
@@ -4,7 +4,11 @@ After the kernel cutover, every local surface that exposes
 ``diff_since_last_session`` must produce the same envelope for the same
 arguments against the same store. The two wirings under test here are
 the ``tool_diff_since_last_session`` direct call and the stdio MCP
-wrapper that maps ``project_id`` onto a store path.
+wrapper that maps ``project_id`` onto a store path. The stdio wrapper
+is renderer-scoped: its single ``content[0]`` block must equal the
+shared ``RENDERERS["diff_since_last_session"]`` rendering of the
+direct-tool envelope — a verbatim passthrough of the ``diff`` body,
+including the canonical sentinel strings byte-for-byte.
 
 Two compressions vs. the ``check_decision`` parity test:
 
@@ -23,6 +27,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
+from nauro_core.renderers import RENDERERS
 
 from nauro.constants import REPO_CONFIG_MODE_LOCAL, SNAPSHOTS_DIR
 from nauro.mcp.stdio_server import diff_since_last_session as stdio_diff_since_last_session
@@ -110,57 +115,61 @@ def missing_store(tmp_path, monkeypatch):
     return nonexistent
 
 
-def _stdio_envelope(pid: str, days: int | None = None) -> dict:
-    return stdio_diff_since_last_session(project_id=pid, days=days)
+def _stdio_rendered(pid: str, days: int | None = None) -> str:
+    """Rendered stdio surface text for the parity comparison.
+
+    ``diff_since_last_session`` is renderer-scoped: the wrapper returns a
+    single ``content[0]`` block carrying the renderer output.
+    """
+    result = stdio_diff_since_last_session(project_id=pid, days=days)
+    assert len(result.content) == 1
+    assert result.structuredContent is None
+    return result.content[0].text
 
 
 def _tool_envelope(store_path: Path, days: int | None = None) -> dict:
     return tool_diff_since_last_session(store_path, days)
 
 
-def _clock_invariant(envelope: dict) -> dict:
-    """Strip clock-derived parts so two independent calls compare equal.
+def _strip_anchor(text: str) -> str:
+    """Strip the clock-derived anchor line so two independent calls compare.
 
-    The days-based ``cutoff_date_used`` is the REQUESTED cutoff
-    (``now - N days``), recomputed from ``datetime.now()`` on every call,
-    and that same value is interpolated into the rendered ``Anchor:`` line.
-    Two independent surface calls therefore differ by microseconds in the
-    cutoff field and the anchor line, so parity is asserted on everything
-    else; the cutoff's own consistency is checked separately.
+    The days-based cutoff is the REQUESTED cutoff (``now - N days``),
+    recomputed from ``datetime.now()`` on every call and interpolated into
+    the rendered ``Anchor:`` line. Two independent surface calls therefore
+    differ by microseconds in that line, so parity is asserted on
+    everything else; the cutoff's own consistency is checked separately.
     """
-    out = {k: v for k, v in envelope.items() if k != "cutoff_date_used"}
-    if isinstance(out.get("diff"), str):
-        out["diff"] = "\n".join(
-            line for line in out["diff"].split("\n") if not line.startswith("Anchor:")
-        )
-    return out
+    return "\n".join(line for line in text.split("\n") if not line.startswith("Anchor:"))
 
 
 def test_session_scoped_envelope_matches_across_surfaces(seeded_repo):
     pid, store_path = seeded_repo
-    stdio = _stdio_envelope(pid)
     tool = _tool_envelope(store_path)
-    assert stdio == tool
-    assert stdio["store"] == "local"
-    assert "v001" in stdio["diff"]
-    assert "v002" in stdio["diff"]
+    rendered = _stdio_rendered(pid)
+    assert rendered == RENDERERS["diff_since_last_session"](tool)
+    # The renderer passes the diff body through verbatim.
+    assert rendered == tool["diff"]
+    assert tool["store"] == "local"
+    assert "v001" in rendered
+    assert "v002" in rendered
     # Session-scoped diffs do not surface a cutoff_date_used field.
-    assert "cutoff_date_used" not in stdio
+    assert "cutoff_date_used" not in tool
 
 
 def test_time_based_envelope_matches_across_surfaces(time_indexed_repo):
     pid, store_path = time_indexed_repo
-    stdio = _stdio_envelope(pid, days=7)
     tool = _tool_envelope(store_path, days=7)
+    rendered = _stdio_rendered(pid, days=7)
     # The cutoff is now() - N days, recomputed per call, so the two
     # independent surfaces agree on everything but that clock-derived value.
-    assert _clock_invariant(stdio) == _clock_invariant(tool)
-    assert stdio["store"] == "local"
-    assert "v001" in stdio["diff"]
-    assert "v002" in stdio["diff"]
+    assert _strip_anchor(rendered) == _strip_anchor(RENDERERS["diff_since_last_session"](tool))
+    assert tool["store"] == "local"
+    assert "v001" in rendered
+    assert "v002" in rendered
     # Days-based path threads the REQUESTED cutoff (now - N days) through as
     # cutoff_date_used — not the (older) resolved baseline timestamp.
-    assert stdio["cutoff_date_used"]
+    assert tool["cutoff_date_used"]
 
 
 def test_days_based_surfaces_anchor_line(time_indexed_repo):
@@ -168,16 +177,18 @@ def test_days_based_surfaces_anchor_line(time_indexed_repo):
     # days-based path surfaces the requested-cutoff anchor header on both the
     # auto-generated CLI and the stdio MCP surface with no adapter change.
     pid, store_path = time_indexed_repo
-    stdio = _stdio_envelope(pid, days=7)
     tool = _tool_envelope(store_path, days=7)
-    assert _clock_invariant(stdio) == _clock_invariant(tool)
-    assert "Anchor: requested ≤ " in stdio["diff"]
-    assert "most-recent snapshot at-or-before cutoff" in stdio["diff"]
-    assert stdio["cutoff_date_used"] in stdio["diff"]
+    rendered = _stdio_rendered(pid, days=7)
+    assert _strip_anchor(rendered) == _strip_anchor(RENDERERS["diff_since_last_session"](tool))
+    assert "Anchor: requested ≤ " in rendered
+    assert "most-recent snapshot at-or-before cutoff" in rendered
+    # Envelope-level self-consistency: the threaded cutoff surfaces in the
+    # same call's rendered anchor line.
+    assert tool["cutoff_date_used"] in tool["diff"]
 
     # The anchor's "requested ≤" value is the REQUESTED cutoff (now - 7d),
     # parsing within a few seconds of it — not the resolved baseline.
-    cutoff = datetime.fromisoformat(stdio["cutoff_date_used"])
+    cutoff = datetime.fromisoformat(tool["cutoff_date_used"])
     expected_cutoff = datetime.now(timezone.utc) - timedelta(days=7)
     assert abs((cutoff - expected_cutoff).total_seconds()) < 60
 
@@ -185,35 +196,34 @@ def test_days_based_surfaces_anchor_line(time_indexed_repo):
     # fixture backdates the baseline (v001) to 14 days ago, so the requested
     # cutoff (7 days ago) and the "resolved to baseline <ts>" value differ.
     baseline_ts = load_snapshot(store_path, 1)["timestamp"]
-    assert stdio["cutoff_date_used"] != baseline_ts
-    assert f"resolved to baseline {baseline_ts[:19]}" in stdio["diff"]
-    assert f"requested ≤ {stdio['cutoff_date_used']}" in stdio["diff"]
+    assert tool["cutoff_date_used"] != baseline_ts
+    assert f"resolved to baseline {baseline_ts[:19]}" in tool["diff"]
+    assert f"requested ≤ {tool['cutoff_date_used']}" in tool["diff"]
 
 
 def test_session_scoped_diff_omits_anchor_line(seeded_repo):
     # The no-arg session diff carries no cutoff, so the anchor header must be
     # absent — keeping that output byte-identical to pre-anchor behaviour.
     pid, _store_path = seeded_repo
-    stdio = _stdio_envelope(pid)
-    assert "Anchor:" not in stdio["diff"]
+    assert "Anchor:" not in _stdio_rendered(pid)
 
 
 def test_empty_store_session_scoped_envelope_matches(empty_repo):
     pid, store_path = empty_repo
-    stdio = _stdio_envelope(pid)
     tool = _tool_envelope(store_path)
-    assert stdio == tool
-    assert stdio["store"] == "local"
-    assert "Not enough snapshots" in stdio["diff"]
+    rendered = _stdio_rendered(pid)
+    assert rendered == RENDERERS["diff_since_last_session"](tool)
+    assert tool["store"] == "local"
+    assert rendered == "Not enough snapshots to compute a diff (need at least 2)."
 
 
 def test_empty_store_days_based_envelope_matches(empty_repo):
     pid, store_path = empty_repo
-    stdio = _stdio_envelope(pid, days=7)
     tool = _tool_envelope(store_path, days=7)
-    assert stdio == tool
-    assert stdio["store"] == "local"
-    assert "No snapshots" in stdio["diff"]
+    rendered = _stdio_rendered(pid, days=7)
+    assert rendered == RENDERERS["diff_since_last_session"](tool)
+    assert tool["store"] == "local"
+    assert rendered == "No snapshots available."
 
 
 def test_days_based_one_snapshot_covers_range_matches_across_surfaces(single_snapshot_repo):
@@ -222,13 +232,13 @@ def test_days_based_one_snapshot_covers_range_matches_across_surfaces(single_sna
     # one-snapshot-covers-range sentinel (byte-identical to pre-cutover
     # output) on both the auto-generated CLI path and the stdio MCP path.
     pid, store_path = single_snapshot_repo
-    stdio = _stdio_envelope(pid, days=7)
     tool = _tool_envelope(store_path, days=7)
-    # The sentinel diff carries no anchor line, but the envelope still
-    # surfaces the (clock-derived) requested cutoff, so compare modulo it.
-    assert _clock_invariant(stdio) == _clock_invariant(tool)
-    assert stdio["store"] == "local"
-    assert stdio["diff"] == "Only one snapshot covers the requested time range — no diff available."
+    rendered = _stdio_rendered(pid, days=7)
+    # The sentinel diff carries no anchor line; the envelope still surfaces
+    # the (clock-derived) requested cutoff, which the rendered text omits.
+    assert rendered == RENDERERS["diff_since_last_session"](tool)
+    assert tool["store"] == "local"
+    assert rendered == "Only one snapshot covers the requested time range — no diff available."
 
 
 def test_missing_store_guidance_matches_across_surfaces(missing_store):

--- a/packages/nauro/tests/test_get_raw_file_parity.py
+++ b/packages/nauro/tests/test_get_raw_file_parity.py
@@ -2,8 +2,10 @@
 
 After the kernel cutover, every local surface that exposes
 ``get_raw_file`` must produce the same envelope for the same path
-against the same store. This file pins that envelope shape across the
-two adapter wirings that exist today.
+against the same store. This file pins the direct-tool envelope shape
+and the stdio transport's rendered surface: the stdio wrapper is
+renderer-scoped, so its ``content[0]`` text must equal the shared
+``RENDERERS["get_raw_file"]`` rendering of the direct-tool envelope.
 
 Two compressions vs. the ``check_decision`` parity test:
 
@@ -22,6 +24,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from nauro_core.renderers import RENDERERS
 
 from nauro.constants import REPO_CONFIG_MODE_LOCAL
 from nauro.demo import create_demo_project
@@ -47,8 +50,16 @@ def demo_repo(tmp_path, monkeypatch):
     return pid, store_path
 
 
-def _stdio_envelope(pid: str, path: str) -> dict:
-    return stdio_get_raw_file(path=path, project_id=pid)
+def _stdio_rendered(pid: str, path: str) -> str:
+    """Rendered stdio surface text for the parity comparison.
+
+    ``get_raw_file`` is renderer-scoped: the wrapper returns a single
+    ``content[0]`` block carrying the renderer output.
+    """
+    result = stdio_get_raw_file(path=path, project_id=pid)
+    assert len(result.content) == 1
+    assert result.structuredContent is None
+    return result.content[0].text
 
 
 def _tool_envelope(store_path: Path, path: str) -> dict:
@@ -58,14 +69,16 @@ def _tool_envelope(store_path: Path, path: str) -> dict:
 
 def test_stdio_and_tool_match_on_success_path(demo_repo):
     pid, store_path = demo_repo
-    stdio = _stdio_envelope(pid, EXISTING_PATH)
     tool = _tool_envelope(store_path, EXISTING_PATH)
-    assert stdio == tool
+    rendered = _stdio_rendered(pid, EXISTING_PATH)
+    assert rendered == RENDERERS["get_raw_file"](tool)
+    # Hit path renders the file content verbatim.
+    assert rendered == tool["content"]
 
 
 def test_success_envelope_carries_content(demo_repo):
-    pid, _ = demo_repo
-    envelope = _stdio_envelope(pid, EXISTING_PATH)
+    _pid, store_path = demo_repo
+    envelope = _tool_envelope(store_path, EXISTING_PATH)
     assert envelope["store"] == "local"
     assert "content" in envelope
     assert envelope["content"]
@@ -76,34 +89,40 @@ def test_success_envelope_carries_content(demo_repo):
 
 def test_not_found_envelope_matches_across_surfaces(demo_repo):
     pid, store_path = demo_repo
-    stdio = _stdio_envelope(pid, MISSING_PATH)
     tool = _tool_envelope(store_path, MISSING_PATH)
-    assert stdio == tool
+    rendered = _stdio_rendered(pid, MISSING_PATH)
+    assert rendered == RENDERERS["get_raw_file"](tool)
     # Locked miss envelope shape.
-    assert stdio["store"] == "local"
-    assert "content" not in stdio
-    assert stdio["error"]["kind"] == "error"
-    assert stdio["error"]["reason"] == f"File not found: {MISSING_PATH}"
+    assert tool["store"] == "local"
+    assert "content" not in tool
+    assert tool["error"]["kind"] == "error"
+    assert tool["error"]["reason"] == f"File not found: {MISSING_PATH}"
     # Adapter adds the available_files hint as a sibling field, not
     # inside the error reason — kept structured so clients can render
     # the hint independently of the error message.
-    assert isinstance(stdio["available_files"], list)
-    assert all(isinstance(p, str) for p in stdio["available_files"])
-    assert EXISTING_PATH in stdio["available_files"]
+    assert isinstance(tool["available_files"], list)
+    assert all(isinstance(p, str) for p in tool["available_files"])
+    assert EXISTING_PATH in tool["available_files"]
+    # Rendered surface: error line first, then the hint entries in the
+    # adapter-composed order — the ordering is a contract.
+    assert rendered.startswith(f"Error: File not found: {MISSING_PATH}")
+    hint_lines = [line for line in rendered.split("\n") if line.startswith("  - ")]
+    assert hint_lines == [f"  - {p}" for p in tool["available_files"]]
 
 
 def test_traversal_envelope_matches_across_surfaces(demo_repo):
     pid, store_path = demo_repo
-    stdio = _stdio_envelope(pid, TRAVERSAL_PATH)
     tool = _tool_envelope(store_path, TRAVERSAL_PATH)
-    assert stdio == tool
+    rendered = _stdio_rendered(pid, TRAVERSAL_PATH)
+    assert rendered == RENDERERS["get_raw_file"](tool)
     # Traversal is rejected by the adapter before any kernel call;
     # reason text is distinct from the kernel-side "File not found".
-    assert stdio["store"] == "local"
-    assert "content" not in stdio
-    assert "available_files" not in stdio
-    assert stdio["error"]["kind"] == "error"
-    assert stdio["error"]["reason"] == f"Invalid path: {TRAVERSAL_PATH}"
+    assert tool["store"] == "local"
+    assert "content" not in tool
+    assert "available_files" not in tool
+    assert tool["error"]["kind"] == "error"
+    assert tool["error"]["reason"] == f"Invalid path: {TRAVERSAL_PATH}"
+    assert rendered == f"Error: Invalid path: {TRAVERSAL_PATH}"
 
 
 def test_nul_path_returns_rejection_not_raw_traceback(demo_repo):
@@ -117,5 +136,5 @@ def test_nul_path_returns_rejection_not_raw_traceback(demo_repo):
     assert "content" not in tool
     assert tool["error"]["kind"] == "error"
     assert tool["error"]["reason"] == f"Invalid path: {nul_path}"
-    # Same clean envelope across surfaces.
-    assert _stdio_envelope(pid, nul_path) == tool
+    # Same clean rejection across surfaces.
+    assert _stdio_rendered(pid, nul_path) == RENDERERS["get_raw_file"](tool)

--- a/packages/nauro/tests/test_stdio_renderer_wrap.py
+++ b/packages/nauro/tests/test_stdio_renderer_wrap.py
@@ -1,10 +1,10 @@
 """Block-shape contract for the local stdio MCP read tools.
 
 Renderer-scoped read tools listed in ``nauro_core.renderers.RENDERERS``
-return a ``CallToolResult`` with a single ``TextContent`` block:
-``content[0]`` carries the renderer output. Write tools,
-``get_raw_file``, ``diff_since_last_session``, and pre-resolution error
-responses stay single-block (or stay strings).
+— all seven read tools on this transport — return a ``CallToolResult``
+with a single ``TextContent`` block: ``content[0]`` carries the renderer
+output. Write tools and pre-resolution error responses stay single-block
+(or stay strings).
 
 Mirrors ``TestContentBlockShape`` from the remote MCP router so both
 transports stay in sync.
@@ -146,6 +146,8 @@ class TestNoStructuredContent:
         (get_decision, {"number": 1}),
         (search_decisions, {"query": "typed recovery"}),
         (check_decision, {"proposed_approach": "Use typed recovery"}),
+        (get_raw_file, {"path": "stack.md"}),
+        (diff_since_last_session, {}),
     ],
 )
 def test_disconnected_renderer_reads_preserve_full_structured_envelope(
@@ -186,20 +188,28 @@ def test_disconnected_renderer_reads_preserve_full_structured_envelope(
 
 
 class TestSingleBlockReads:
-    """Pass-through read tools keep the single-value shape — ``get_raw_file``
-    returns a dict (no renderer registered), ``diff_since_last_session`` likewise."""
+    """``get_raw_file`` and ``diff_since_last_session`` are renderer-scoped
+    like the other five read tools: a single rendered ``content[0]`` block."""
 
-    def test_get_raw_file_returns_dict(self, seeded_store: Path):
+    def test_get_raw_file_returns_rendered_block(self, seeded_store: Path):
         result = get_raw_file(path="stack.md", project_id="blockshape")
-        # No renderer scope; the FastMCP layer converts the dict to its own
-        # single content block at the MCP wire boundary. Direct Python
-        # callers see the dict envelope unchanged.
-        assert isinstance(result, dict)
-        assert result["content"].startswith("# Stack")
+        assert isinstance(result, CallToolResult)
+        blocks = result.content
+        assert len(blocks) == 1
+        assert isinstance(blocks[0], TextContent) and blocks[0].type == "text"
+        # Hit path passes the file content through verbatim.
+        assert blocks[0].text.startswith("# Stack")
+        assert result.structuredContent is None
 
-    def test_diff_since_last_session_returns_dict(self, seeded_store: Path):
+    def test_diff_since_last_session_returns_rendered_block(self, seeded_store: Path):
         result = diff_since_last_session(project_id="blockshape")
-        assert isinstance(result, dict)
+        assert isinstance(result, CallToolResult)
+        blocks = result.content
+        assert len(blocks) == 1
+        # The seeded store has no snapshots; the canonical sentinel passes
+        # through byte-identical.
+        assert blocks[0].text == "Not enough snapshots to compute a diff (need at least 2)."
+        assert result.structuredContent is None
 
 
 class TestSingleBlockWrites:

--- a/packages/nauro/tests/test_stdio_server.py
+++ b/packages/nauro/tests/test_stdio_server.py
@@ -217,13 +217,12 @@ class TestWelcomeDisambiguation:
     caller already has a (mis-)configured project."""
 
     def test_unknown_project_id_surfaces_specific_error(self, store: Path):
-        """Bogus project_id keyword on a dict-returning tool → guidance
-        names the registry, not the welcome screen."""
-        result = get_raw_file(path="project.md", project_id="does-not-exist")
-        assert result["status"] == "error"
-        assert "Welcome to Nauro" not in result["guidance"]
+        """Bogus project_id keyword on a renderer-scoped tool → rendered
+        guidance names the registry, not the welcome screen."""
+        rendered = _rendered(get_raw_file(path="project.md", project_id="does-not-exist"))
+        assert "Welcome to Nauro" not in rendered
         # ProjectNotFoundError surfaces the registry-lookup framing.
-        assert "registry" in result["guidance"].lower() or "not found" in result["guidance"].lower()
+        assert "registry" in rendered.lower() or "not found" in rendered.lower()
 
     def test_unknown_project_id_string_tool_surfaces_specific_error(self, store: Path):
         """Same disambiguation on a string-returning tool: a non-welcome
@@ -240,9 +239,8 @@ class TestWelcomeDisambiguation:
         from nauro.store.registry import _registry_file
 
         _registry_file().write_text('{"projects": {}, "schema_version": 2}\n')
-        result = get_raw_file(path="project.md")
-        assert result["status"] == "error"
-        assert "Welcome to Nauro" in result["guidance"]
+        rendered = _rendered(get_raw_file(path="project.md"))
+        assert "Welcome to Nauro" in rendered
 
     def test_disconnected_project_returns_structured_recovery_envelope(self, tmp_path, monkeypatch):
         from nauro.store.repo_config import save_repo_config
@@ -254,15 +252,20 @@ class TestWelcomeDisambiguation:
 
         result = get_raw_file(path="project.md", cwd=str(repo))
 
-        assert result["status"] == "error"
-        assert result["error"]["kind"] == "error"
-        assert result["error"]["reason"] == result["guidance"]
-        assert result["project_id"] == pid
-        assert result["project_name"] == "Pareto"
-        assert result["project_mode"] == "local"
-        assert result["reason_code"] == "not_connected_on_this_machine"
-        assert result["recovery_actions"] == ["locate", "continue"]
-        assert "Welcome to Nauro" not in result["guidance"]
+        # Renderer-scoped tool: the disconnected envelope survives as
+        # structuredContent while content[0] carries the rendered guidance.
+        envelope = result.structuredContent
+        assert envelope is not None
+        assert envelope["status"] == "error"
+        assert envelope["error"]["kind"] == "error"
+        assert envelope["error"]["reason"] == envelope["guidance"]
+        assert envelope["project_id"] == pid
+        assert envelope["project_name"] == "Pareto"
+        assert envelope["project_mode"] == "local"
+        assert envelope["reason_code"] == "not_connected_on_this_machine"
+        assert envelope["recovery_actions"] == ["locate", "continue"]
+        assert "Welcome to Nauro" not in envelope["guidance"]
+        assert _rendered(result) == envelope["guidance"]
 
         write_result = update_state(delta="anything", cwd=str(repo))
         assert isinstance(write_result, dict)


### PR DESCRIPTION
## Why

A single runaway open-question entry (long context blocks are common in real
stores) could dominate every generated AGENTS.md and L0/L1 context payload:
question entries rendered whole with no per-entry bound, so the ambient token
cost scaled with the longest entry rather than the entry count. Separately,
`get_raw_file` and `diff_since_last_session` were the only local read tools
whose primary chat content was still a raw JSON envelope instead of a rendered
text block.

## What changed

**Per-entry question cap (nauro-core).** Question entries rendered into the
L0/L1 payloads and the session-diff question bullets now cap at 480 characters
per entry through one shared pure helper (`truncate_entry_text` in
`nauro_core.questions`, budget in `constants`). Truncated entries end with an
explicit pointer at `get_raw_file("open-questions.md")`. Entries at or under
the budget are byte-unchanged. Untouched: the L2 verbatim dump, `get_raw_file`,
the 30-day age nudge, the omission trailer, and the diff's canonical sentinel
strings and anchor line.

**The two missing renderers.** `render_get_raw_file` passes file content
through verbatim on a hit; on a miss it renders the error line plus the
`available_files` hint in its exact composed order (the ordering is a
cross-surface contract). `render_diff_since_last_session` passes the diff body
through verbatim, byte-transparent to the sentinels. Both are registered in
`RENDERERS`, and the stdio wrappers for both tools now return a single rendered
`content[0]` block like the other five read tools, preserving the
disconnected-envelope `structuredContent` path and the graceful JSON fallback
when an older installed nauro-core lacks a renderer.

All additions stay off the frozen nauro-core facade: the public-contract
snapshot passes without regeneration. AGENTS.md truncation parity is automatic
via the shared L0 builder; `templates/agents_md.py` is untouched.

## Test plan

- nauro-core: 1127 passed, with new coverage for the truncation helper (at/over
  budget, bounded length, whitespace at the cut), cap propagation to L0/L1 and
  the diff bullets, L0/L1 identical truncation, L2 verbatim, and renderer units
  (hit passthrough, miss + hint order, sentinel/anchor byte-passthrough,
  guidance and error branches).
- nauro: 2098 passed, 10 skipped. The two parity suites migrated to the
  renderer-parity pattern used by the other five read tools; block-shape tests
  now assert rendered single-block output and the disconnected structured
  envelope for both tools; a sync-level test proves an over-budget entry
  truncates to identical bytes in AGENTS.md and L0, and the pre-change L0 byte
  baselines still pass, pinning under-budget output as byte-identical.
- `ruff check` and `ruff format --check` clean.

## Risk / what to review

- Sentinel byte-parity on the diff renderer and the miss-hint ordering on
  `get_raw_file` are cross-surface contracts; both are pinned by byte-exact
  tests.
- The truncation pointer is appended after the 480-char cut, so a truncated
  entry's total length is capped at 543 chars (budget plus the 63-char pointer
  suffix), a hard bound chosen over reserving pointer space inside the budget.

## Deferred

- nauro-core minor version bump and nauro's nauro-core floor raise happen at
  the next release, not here.
- CLI autogen JSON output is unchanged by design (the CLI mirrors call the
  tool adapters directly, not the stdio wrappers).
