### PR TITLE
Stamp new decisions with the repo HEAD they were ratified against

### DIFF
--- a/packages/nauro-core/src/nauro_core/operations/propose_decision.py
+++ b/packages/nauro-core/src/nauro_core/operations/propose_decision.py
@@ -123,6 +123,7 @@ def propose_decision(
     files_affected: list[str] | None = None,
     resolves_questions: list[str] | None = None,
     source: str | None = None,
+    base_commit: str | None = None,
 ) -> ProposeDecisionResult:
     """Run the proposal through the validation pipeline and commit on Tier 1 clean.
 
@@ -144,6 +145,7 @@ def propose_decision(
         "files_affected": files_affected,
         "resolves_questions": list(resolves_questions) if resolves_questions else [],
         "source": source,
+        "base_commit": base_commit,
     }
 
     # --- operation="update": reject metadata fields up front ---
@@ -283,6 +285,16 @@ def _write_decision_direct(store: Store, proposal: dict) -> str:
     filename = f"{_decision_number_prefix(next_num)}{slug}"
     rationale = proposal.get("rationale") or title
 
+    # base_commit rides the tolerant reader's unknown-key channel: passed as
+    # an extra constructor kwarg it lands in model_extra and renders as a
+    # trailing frontmatter key. It must be omitted entirely when unresolved —
+    # a modeled field (or an explicit None) would serialize ``base_commit:
+    # null`` into every file this writer touches.
+    provenance_kwargs: dict[str, str] = {}
+    base_commit = proposal.get("base_commit")
+    if base_commit:
+        provenance_kwargs["base_commit"] = base_commit
+
     decision = Decision(
         date=datetime.now(timezone.utc).date(),
         version=1,
@@ -298,6 +310,7 @@ def _write_decision_direct(store: Store, proposal: dict) -> str:
         num=next_num,
         title=title,
         rationale=rationale,
+        **provenance_kwargs,
     )
     store.write_file(_decision_path(filename), format_decision(decision))
 

--- a/packages/nauro-core/tests/operations/test_operations_propose_decision.py
+++ b/packages/nauro-core/tests/operations/test_operations_propose_decision.py
@@ -1010,3 +1010,166 @@ def test_slug_single_giant_word_hard_cuts_at_cap() -> None:
     )
     assert result.status == "confirmed"
     assert result.decision_id == "001-" + "x" * 60
+
+
+# ── base_commit provenance stamp ────────────────────────────────────────
+#
+# The stamp is captured by the local transports and threaded through the
+# optional ``base_commit`` kwarg. It rides the tolerant reader's unknown-key
+# channel (model_extra → trailing frontmatter key); the kernel never
+# resolves it and hosted callers never pass it, so every path without the
+# kwarg must produce files with no trace of the key.
+
+_SHA_A = "a" * 40
+_SHA_B = "b" * 40
+
+
+def _confirmed(result: ProposeDecisionResult) -> str:
+    assert result.status == "confirmed"
+    assert result.decision_id is not None
+    return result.decision_id
+
+
+class TestBaseCommitStamp:
+    def test_add_with_base_commit_stamps_trailing_frontmatter_key(self) -> None:
+        from nauro_core.decision_model import format_decision, parse_decision
+
+        store = InMemoryStore()
+        decision_id = _confirmed(
+            propose_decision(
+                store,
+                title="Adopt Redis",
+                rationale="In-memory cache for hot read paths across the API tier.",
+                confidence="medium",
+                base_commit=_SHA_A,
+            )
+        )
+        body = store.read_decision(decision_id)
+        assert body is not None
+        assert f"base_commit: {_SHA_A}" in body
+        # Round-trip: the stamp lands in model_extra and reformats
+        # byte-identically as a trailing unknown key.
+        parsed = parse_decision(body, f"{decision_id}.md")
+        assert parsed.model_extra == {"base_commit": _SHA_A}
+        assert format_decision(parsed) == body
+
+    def test_add_without_kwarg_writes_no_stamp(self) -> None:
+        store = InMemoryStore()
+        decision_id = _confirmed(
+            propose_decision(
+                store,
+                title="Adopt Redis",
+                rationale="In-memory cache for hot read paths across the API tier.",
+                confidence="medium",
+            )
+        )
+        body = store.read_decision(decision_id)
+        assert body is not None
+        assert "base_commit" not in body
+
+    def test_add_with_none_base_commit_writes_no_stamp(self) -> None:
+        # Explicit None must omit the key entirely — never ``base_commit: null``.
+        store = InMemoryStore()
+        decision_id = _confirmed(
+            propose_decision(
+                store,
+                title="Adopt Redis",
+                rationale="In-memory cache for hot read paths across the API tier.",
+                confidence="medium",
+                base_commit=None,
+            )
+        )
+        body = store.read_decision(decision_id)
+        assert body is not None
+        assert "base_commit" not in body
+
+    def test_update_preserves_stamp_and_never_restamps(self) -> None:
+        store = InMemoryStore()
+        decision_id = _confirmed(
+            propose_decision(
+                store,
+                title="Adopt Redis",
+                rationale="In-memory cache for hot read paths across the API tier.",
+                confidence="medium",
+                base_commit=_SHA_A,
+            )
+        )
+        result = propose_decision(
+            store,
+            title="",
+            rationale="Extended to cover the background job tier after the audit.",
+            operation="update",
+            affected_decision_id=decision_id,
+            base_commit=_SHA_B,
+        )
+        assert result.status == "confirmed"
+        body = store.read_decision(decision_id)
+        assert body is not None
+        assert f"base_commit: {_SHA_A}" in body
+        assert _SHA_B not in body
+        assert body.count("base_commit") == 1
+
+    def test_supersede_preserves_old_stamp_and_stamps_new(self) -> None:
+        store = InMemoryStore()
+        old_id = _confirmed(
+            propose_decision(
+                store,
+                title="Adopt Redis",
+                rationale="In-memory cache for hot read paths across the API tier.",
+                confidence="medium",
+                base_commit=_SHA_A,
+            )
+        )
+        result = propose_decision(
+            store,
+            title="Adopt Valkey",
+            rationale="Valkey replaces Redis after the licensing change upstream.",
+            operation="supersede",
+            affected_decision_id=old_id,
+            confidence="medium",
+            base_commit=_SHA_B,
+        )
+        new_id = _confirmed(result)
+        old_body = store.read_decision(old_id)
+        assert old_body is not None
+        # The flip rewrites the old file; its original stamp survives and is
+        # not replaced by the superseding call's stamp.
+        assert "status: superseded" in old_body
+        assert f"base_commit: {_SHA_A}" in old_body
+        assert _SHA_B not in old_body
+        new_body = store.read_decision(new_id)
+        assert new_body is not None
+        assert f"base_commit: {_SHA_B}" in new_body
+        assert _SHA_A not in new_body
+
+    def test_supersede_and_update_without_kwarg_stay_unstamped(self) -> None:
+        store = InMemoryStore()
+        old_id = _confirmed(
+            propose_decision(
+                store,
+                title="Adopt Redis",
+                rationale="In-memory cache for hot read paths across the API tier.",
+                confidence="medium",
+            )
+        )
+        supersede = propose_decision(
+            store,
+            title="Adopt Valkey",
+            rationale="Valkey replaces Redis after the licensing change upstream.",
+            operation="supersede",
+            affected_decision_id=old_id,
+            confidence="medium",
+        )
+        new_id = _confirmed(supersede)
+        update = propose_decision(
+            store,
+            title="",
+            rationale="Extended to cover the background job tier after the audit.",
+            operation="update",
+            affected_decision_id=new_id,
+        )
+        assert update.status == "confirmed"
+        for stem in (old_id, new_id):
+            body = store.read_decision(stem)
+            assert body is not None
+            assert "base_commit" not in body

--- a/packages/nauro-core/tests/test_decision_model.py
+++ b/packages/nauro-core/tests/test_decision_model.py
@@ -715,6 +715,31 @@ class TestUnknownFrontmatterKeys:
         assert "status: superseded" in formatted
         assert "superseded_by: '42'" in formatted
 
+    def test_base_commit_stamp_round_trips_byte_identically(self) -> None:
+        """The write-path provenance stamp is a trailing unknown key; a
+        stamped decision must reformat to the same bytes."""
+        sha = "4f3c2b1a" * 5
+        text = (
+            "---\n"
+            "date: 2026-04-01\n"
+            "version: 1\n"
+            "status: active\n"
+            "confidence: high\n"
+            "decision_type: null\n"
+            "reversibility: null\n"
+            "source: null\n"
+            "files_affected: []\n"
+            "supersedes: null\n"
+            "superseded_by: null\n"
+            f"base_commit: {sha}\n"
+            "---\n\n"
+            "# 001 \u2014 Stamped decision\n\n"
+            "## Decision\n\nChose A.\n"
+        )
+        decision = parse_decision(text, "001-test.md")
+        assert decision.model_extra == {"base_commit": sha}
+        assert format_decision(decision) == text
+
     @pytest.mark.parametrize("text,filename", ALL_FIXTURES)
     def test_no_extras_output_matches_prechange_bytes(self, text: str, filename: str) -> None:
         """With no unknown keys, the writer's output is byte-for-byte the

--- a/packages/nauro-core/tests/test_kernel_purity.py
+++ b/packages/nauro-core/tests/test_kernel_purity.py
@@ -1,0 +1,46 @@
+"""Kernel purity guard: nauro-core must never spawn processes or touch git.
+
+The hosted Lambda bundles nauro-core, so any subprocess use here would ship
+to the server. Provenance that requires git (the ``base_commit`` stamp) is
+captured in the local transports and reaches the kernel only as an optional
+string kwarg; this guard keeps that boundary honest by construction — no
+subprocess import and no git binding (git, pygit2, dulwich) anywhere in the
+kernel tree.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parents[1] / "src" / "nauro_core"
+
+_FORBIDDEN_MODULES = frozenset({"subprocess", "git", "pygit2", "dulwich"})
+
+
+def _forbidden_imports(tree: ast.Module) -> set[str]:
+    found: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            found.update(
+                alias.name.split(".")[0]
+                for alias in node.names
+                if alias.name.split(".")[0] in _FORBIDDEN_MODULES
+            )
+        elif isinstance(node, ast.ImportFrom):
+            module = (node.module or "").split(".")[0]
+            if module in _FORBIDDEN_MODULES:
+                found.add(module)
+    return found
+
+
+def test_kernel_tree_never_imports_subprocess_or_git() -> None:
+    offenders = []
+    for path in sorted(_SRC.rglob("*.py")):
+        found = _forbidden_imports(ast.parse(path.read_text(encoding="utf-8")))
+        if found:
+            offenders.append(f"{path.relative_to(_SRC)}: {sorted(found)}")
+    assert offenders == [], (
+        f"nauro-core imports process/git modules: {offenders}; process "
+        "spawning and git access belong to the local transports, never the kernel."
+    )

--- a/packages/nauro/src/nauro/cli/autogen.py
+++ b/packages/nauro/src/nauro/cli/autogen.py
@@ -35,6 +35,7 @@ from nauro_core.mcp_tools import ALL_TOOLS, ToolSpec
 from nauro.cli._json_input import parse_json_list_of_dicts
 from nauro.cli.utils import cli_origin, resolve_target_project
 from nauro.mcp import tools as mcp_tools
+from nauro.store.repo_head import resolve_process_repo_head
 
 # Tools that should auto-generate a CLI command. list_projects is
 # excluded — local installs auto-resolve to a single project and do not
@@ -392,9 +393,13 @@ def _make_command(spec: ToolSpec) -> Callable[..., None]:
     ]
 
     # Write adapters accept a keyword-only ``origin`` so the CLI can stamp the
-    # transport; read adapters do not. Detect it once so the command stamps
-    # only the surfaces that record provenance.
-    accepts_origin = "origin" in inspect.signature(adapter).parameters
+    # transport; read adapters do not. The decision write adapter additionally
+    # accepts ``base_commit``, stamping the HEAD of the repository enclosing
+    # the CLI process cwd. Detect both once so the command stamps only the
+    # surfaces that record provenance.
+    adapter_params = inspect.signature(adapter).parameters
+    accepts_origin = "origin" in adapter_params
+    accepts_base_commit = "base_commit" in adapter_params
 
     def command(**kwargs: Any) -> None:
         project = kwargs.pop("project", None)
@@ -427,6 +432,8 @@ def _make_command(spec: ToolSpec) -> Callable[..., None]:
         adapter_kwargs = {name: kwargs[name] for name in schema_arg_names if name in kwargs}
         if accepts_origin:
             adapter_kwargs["origin"] = cli_origin()
+        if accepts_base_commit:
+            adapter_kwargs["base_commit"] = resolve_process_repo_head()
         envelope = adapter(store_path, **adapter_kwargs)
         _emit_envelope(envelope)
         _exit_for_envelope(envelope)

--- a/packages/nauro/src/nauro/mcp/stdio_server.py
+++ b/packages/nauro/src/nauro/mcp/stdio_server.py
@@ -58,6 +58,7 @@ from nauro.mcp.tools import (
 )
 from nauro.onboarding import WELCOME_NO_PROJECT
 from nauro.store.journal import OriginDescriptor
+from nauro.store.repo_head import resolve_repo_head
 from nauro.store.resolution import (
     DisconnectedProject,
     DisconnectedProjectError,
@@ -420,6 +421,7 @@ def propose_decision(
         files_affected=files_affected,
         resolves_questions=resolves_questions,
         origin=_origin_from_ctx(mcp_ctx),
+        base_commit=resolve_repo_head(cwd),
     )
 
 

--- a/packages/nauro/src/nauro/mcp/tools.py
+++ b/packages/nauro/src/nauro/mcp/tools.py
@@ -145,9 +145,10 @@ def journaled(*, operation: str, target: str) -> Callable[..., Any]:
     hash and append are wrapped so a journaling defect can never turn a
     successful write into a failure.
 
-    The payload hashed is the adapter's logical arguments with ``store_path``
-    and ``origin`` removed — ``origin`` is provenance, not payload, and
-    ``store_path`` is environment. ``committed`` events carry ``decision_id``
+    The payload hashed is the adapter's logical arguments with ``store_path``,
+    ``origin``, and ``base_commit`` removed — ``origin`` and ``base_commit``
+    are provenance, not payload, and ``store_path`` is environment.
+    ``committed`` events carry ``decision_id``
     when the envelope reports one; ``rejected`` events carry the payload hash
     and no decision id.
     """
@@ -199,7 +200,9 @@ def _emit_write_event(
     if not isinstance(store_path, Path):
         return
 
-    payload = {k: v for k, v in bound.arguments.items() if k not in ("store_path", "origin")}
+    payload = {
+        k: v for k, v in bound.arguments.items() if k not in ("store_path", "origin", "base_commit")
+    }
     # The transport already built the descriptor before this adapter ran; the
     # factory just hands it back inside record_event's guard, keeping a single
     # emission interface across every call site.
@@ -384,6 +387,7 @@ def tool_propose_decision(
     resolves_questions: list[str] | None = None,
     *,
     origin: OriginDescriptor | None = None,
+    base_commit: str | None = None,
 ) -> dict:
     """Propose a new decision through the validation pipeline."""
     guidance = _check_store_exists(store_path)
@@ -463,6 +467,7 @@ def tool_propose_decision(
             files_affected=files_affected,
             resolves_questions=resolves_questions,
             source="mcp",
+            base_commit=base_commit,
         )
 
     dumped = result.model_dump(mode="json", exclude_none=True)

--- a/packages/nauro/src/nauro/store/repo_head.py
+++ b/packages/nauro/src/nauro/store/repo_head.py
@@ -1,0 +1,63 @@
+"""Resolve the HEAD commit of the repository enclosing a directory.
+
+Provenance capture for the decision write path: the local transports stamp
+the resolved SHA into new decision frontmatter. Resolution is fail-open —
+no repository, no git binary, no commits, a bad cwd, or a timeout all
+resolve to ``None`` and the stamp is simply omitted, never written as null.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+# Bounds the capture cost on every decision write; a repository that cannot
+# answer rev-parse within this window resolves to absence.
+_GIT_TIMEOUT_SECONDS = 2
+
+# Full object names only: 40 hex chars (SHA-1) or 64 (SHA-256 repositories).
+_SHA_LENGTHS = frozenset({40, 64})
+_HEX_DIGITS = frozenset("0123456789abcdef")
+
+
+def resolve_repo_head(cwd: str | Path | None) -> str | None:
+    """Return the HEAD SHA of the innermost repository enclosing ``cwd``.
+
+    Never raises: any resolution failure returns ``None``.
+    """
+    if cwd is None:
+        return None
+    try:
+        completed = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_GIT_TIMEOUT_SECONDS,
+        )
+    except Exception:
+        # Never raises: beyond OSError and SubprocessError, subprocess.run
+        # raises ValueError on a NUL byte in the client-supplied cwd and
+        # text mode can raise UnicodeDecodeError; every failure is absence.
+        return None
+    if completed.returncode != 0:
+        return None
+    sha = completed.stdout.strip()
+    if len(sha) not in _SHA_LENGTHS or not set(sha) <= _HEX_DIGITS:
+        return None
+    return sha
+
+
+def resolve_process_repo_head() -> str | None:
+    """Return the HEAD SHA of the repository enclosing the process cwd.
+
+    Never raises: ``Path.cwd()`` itself raises when the process working
+    directory has been deleted, and capture must resolve to absence, not
+    abort the filing.
+    """
+    try:
+        cwd = Path.cwd()
+    except Exception:
+        return None
+    return resolve_repo_head(cwd)

--- a/packages/nauro/tests/test_base_commit_stamp.py
+++ b/packages/nauro/tests/test_base_commit_stamp.py
@@ -1,0 +1,207 @@
+"""Cross-surface wiring for the ``base_commit`` provenance stamp.
+
+The stdio wrapper derives the stamp from its ``cwd`` parameter and the CLI
+from the process cwd; both land it as a trailing frontmatter key on newly
+written decisions. Absence is fail-open — the key is omitted entirely, never
+written as null — and the stamp is provenance, not payload: the journal's
+payload hash must be invariant to it. No tool schema or CLI flag carries it.
+"""
+
+from __future__ import annotations
+
+import inspect
+import subprocess
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from nauro.cli.main import app
+from nauro.mcp import tools
+from nauro.mcp.stdio_server import mcp, propose_decision
+from nauro.store import repo_head
+from nauro.store.journal import read_events
+from nauro.store.registry import register_project_v2
+from nauro.templates.scaffolds import scaffold_project_store
+from tests.test_repo_head import _repo_with_commit
+
+runner = CliRunner()
+
+_LONG_RATIONALE = "Adopt the widget subsystem because it is measurably better here. " * 3
+
+
+def _sole_decision_text(store_path: Path) -> str:
+    """Text of the decision the test filed (the scaffold seeds 001 itself)."""
+    files = list((store_path / "decisions").glob("*-adopt-widgets.md"))
+    assert len(files) == 1
+    return files[0].read_text(encoding="utf-8")
+
+
+@pytest.fixture
+def store(tmp_path: Path, monkeypatch) -> Path:
+    monkeypatch.setattr(tools, "_try_push", lambda _store_path: None)
+    _pid, store_path = register_project_v2("stampproj", [tmp_path / "repo"])
+    scaffold_project_store("stampproj", store_path)
+    return store_path
+
+
+def _propose_via_stdio(cwd: str | None) -> dict:
+    kwargs = {} if cwd is None else {"cwd": cwd}
+    return propose_decision(
+        project_id="stampproj",
+        title="Adopt widgets",
+        rationale=_LONG_RATIONALE,
+        **kwargs,
+    )
+
+
+# --- stdio wrapper: stamp derived from the cwd param -------------------------
+
+
+class TestStdioStamp:
+    def test_stamps_head_of_repo_enclosing_cwd(self, store: Path, tmp_path: Path):
+        repo = tmp_path / "gitrepo"
+        sha = _repo_with_commit(repo)
+        result = _propose_via_stdio(str(repo))
+        assert result["status"] == "confirmed"
+        text = _sole_decision_text(store)
+        assert f"base_commit: {sha}" in text
+        # Trailing frontmatter key: inside the frontmatter block, after the
+        # known keys.
+        frontmatter = text.split("---\n")[1]
+        assert frontmatter.rstrip().endswith(f"base_commit: {sha}")
+
+
+# --- fail-open absence: the key is omitted, never null -----------------------
+
+
+class TestFailOpenAbsence:
+    def _assert_unstamped(self, store: Path, result: dict) -> None:
+        assert result["status"] == "confirmed"
+        assert "base_commit" not in _sole_decision_text(store)
+
+    def test_cwd_omitted(self, store: Path):
+        self._assert_unstamped(store, _propose_via_stdio(None))
+
+    def test_cwd_outside_any_repo(self, store: Path, tmp_path: Path):
+        plain = tmp_path / "plain"
+        plain.mkdir()
+        self._assert_unstamped(store, _propose_via_stdio(str(plain)))
+
+    def test_git_absent(self, store: Path, tmp_path: Path, monkeypatch):
+        repo = tmp_path / "gitrepo"
+        _repo_with_commit(repo)
+
+        def raise_missing(*args, **kwargs):
+            raise FileNotFoundError("git")
+
+        monkeypatch.setattr(repo_head.subprocess, "run", raise_missing)
+        self._assert_unstamped(store, _propose_via_stdio(str(repo)))
+
+    def test_empty_repo(self, store: Path, tmp_path: Path):
+        repo = tmp_path / "gitrepo"
+        repo.mkdir()
+        subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+        self._assert_unstamped(store, _propose_via_stdio(str(repo)))
+
+    def test_timeout(self, store: Path, tmp_path: Path, monkeypatch):
+        repo = tmp_path / "gitrepo"
+        _repo_with_commit(repo)
+
+        def raise_timeout(*args, **kwargs):
+            raise subprocess.TimeoutExpired(cmd=["git", "rev-parse", "HEAD"], timeout=2)
+
+        monkeypatch.setattr(repo_head.subprocess, "run", raise_timeout)
+        self._assert_unstamped(store, _propose_via_stdio(str(repo)))
+
+
+# --- CLI: stamp derived from the process cwd ---------------------------------
+
+
+class TestCliStamp:
+    def _project(self, tmp_path: Path, monkeypatch) -> tuple[Path, Path]:
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _pid, store = register_project_v2("clistamp", [repo])
+        scaffold_project_store("clistamp", store)
+        monkeypatch.chdir(repo)
+        return repo, store
+
+    def test_propose_decision_stamps_process_cwd_head(self, tmp_path: Path, monkeypatch):
+        repo, store = self._project(tmp_path, monkeypatch)
+        sha = _repo_with_commit(repo)
+        result = runner.invoke(
+            app,
+            ["propose-decision", _LONG_RATIONALE, "--title", "Adopt widgets"],
+        )
+        assert result.exit_code == 0, result.output
+        assert f"base_commit: {sha}" in _sole_decision_text(store)
+
+    def test_propose_decision_outside_repo_is_unstamped(self, tmp_path: Path, monkeypatch):
+        _repo, store = self._project(tmp_path, monkeypatch)
+        result = runner.invoke(
+            app,
+            ["propose-decision", _LONG_RATIONALE, "--title", "Adopt widgets"],
+        )
+        assert result.exit_code == 0, result.output
+        assert "base_commit" not in _sole_decision_text(store)
+
+
+# --- journal: provenance, not payload ----------------------------------------
+
+
+class TestJournal:
+    def test_stamped_filing_emits_committed_event(self, store: Path, tmp_path: Path):
+        repo = tmp_path / "gitrepo"
+        _repo_with_commit(repo)
+        result = _propose_via_stdio(str(repo))
+        assert result["status"] == "confirmed"
+        events = read_events(store)
+        assert len(events) == 1
+        event = events[0]
+        assert event.operation == "propose_decision"
+        assert event.status == "committed"
+        assert event.decision_id == result["decision_id"]
+        assert event.payload_hash
+
+    def test_payload_hash_invariant_across_base_commit(self, store: Path):
+        first = tools.tool_propose_decision(
+            store,
+            title="Adopt widgets",
+            rationale=_LONG_RATIONALE,
+            base_commit="a" * 40,
+        )
+        assert first["status"] == "confirmed"
+        # Identical payload, different stamp: the duplicate rejection still
+        # journals its payload hash, which must match the committed attempt.
+        second = tools.tool_propose_decision(
+            store,
+            title="Adopt widgets",
+            rationale=_LONG_RATIONALE,
+            base_commit="b" * 40,
+        )
+        assert second["status"] == "rejected"
+        events = read_events(store)
+        assert len(events) == 2
+        assert events[0].status == "committed"
+        assert events[1].status == "rejected"
+        assert events[0].payload_hash == events[1].payload_hash
+
+
+# --- no new surface ----------------------------------------------------------
+
+
+class TestNoNewSurface:
+    def test_base_commit_absent_from_every_tool_schema(self):
+        for tool in mcp._tool_manager.list_tools():
+            props = tool.parameters.get("properties", {})
+            assert "base_commit" not in props, tool.name
+
+    def test_other_write_adapters_do_not_accept_base_commit(self):
+        for adapter in (tools.tool_flag_question, tools.tool_update_state):
+            assert "base_commit" not in inspect.signature(adapter).parameters
+
+    def test_cli_has_no_base_commit_flag(self):
+        result = runner.invoke(app, ["propose-decision", "--help"])
+        assert result.exit_code == 0
+        assert "base-commit" not in result.output

--- a/packages/nauro/tests/test_repo_head.py
+++ b/packages/nauro/tests/test_repo_head.py
@@ -1,0 +1,169 @@
+"""Tests for ``nauro.store.repo_head.resolve_repo_head``.
+
+Stamp-correctness cases run against real git repositories built under
+``tmp_path``; fail-open cases cover every absence branch — the resolver
+must return ``None`` and never raise.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+from nauro.store import repo_head
+from nauro.store.repo_head import resolve_process_repo_head, resolve_repo_head
+
+# Deterministic commit identity: the autouse HOME sandbox has no gitconfig.
+_GIT_ENV = {
+    "GIT_AUTHOR_NAME": "Test",
+    "GIT_AUTHOR_EMAIL": "test@example.com",
+    "GIT_COMMITTER_NAME": "Test",
+    "GIT_COMMITTER_EMAIL": "test@example.com",
+}
+
+
+def _git(cwd: Path, *args: str) -> str:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        env={**os.environ, **_GIT_ENV},
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return completed.stdout.strip()
+
+
+def _repo_with_commit(path: Path, filename: str = "a.txt") -> str:
+    """Init a repository at ``path`` with one commit; return the HEAD SHA."""
+    path.mkdir(parents=True, exist_ok=True)
+    _git(path, "init", "-q")
+    (path / filename).write_text("content\n")
+    _git(path, "add", filename)
+    _git(path, "commit", "-q", "-m", "initial")
+    return _git(path, "rev-parse", "HEAD")
+
+
+class TestStampCorrectness:
+    def test_normal_repo_resolves_head(self, tmp_path: Path):
+        sha = _repo_with_commit(tmp_path / "repo")
+        assert resolve_repo_head(tmp_path / "repo") == sha
+
+    def test_accepts_str_cwd(self, tmp_path: Path):
+        sha = _repo_with_commit(tmp_path / "repo")
+        assert resolve_repo_head(str(tmp_path / "repo")) == sha
+
+    def test_subdirectory_resolves_enclosing_repo(self, tmp_path: Path):
+        sha = _repo_with_commit(tmp_path / "repo")
+        sub = tmp_path / "repo" / "src" / "pkg"
+        sub.mkdir(parents=True)
+        assert resolve_repo_head(sub) == sha
+
+    def test_dirty_worktree_still_resolves_head(self, tmp_path: Path):
+        repo = tmp_path / "repo"
+        sha = _repo_with_commit(repo)
+        (repo / "a.txt").write_text("uncommitted change\n")
+        (repo / "untracked.txt").write_text("new\n")
+        assert resolve_repo_head(repo) == sha
+
+    def test_detached_head_resolves(self, tmp_path: Path):
+        repo = tmp_path / "repo"
+        first = _repo_with_commit(repo)
+        (repo / "b.txt").write_text("second\n")
+        _git(repo, "add", "b.txt")
+        _git(repo, "commit", "-q", "-m", "second")
+        _git(repo, "checkout", "-q", "--detach", first)
+        assert resolve_repo_head(repo) == first
+
+    def test_linked_worktree_resolves_its_own_head(self, tmp_path: Path):
+        repo = tmp_path / "repo"
+        first = _repo_with_commit(repo)
+        (repo / "b.txt").write_text("second\n")
+        _git(repo, "add", "b.txt")
+        _git(repo, "commit", "-q", "-m", "second")
+        second = _git(repo, "rev-parse", "HEAD")
+        worktree = tmp_path / "wt"
+        _git(repo, "worktree", "add", "-q", "--detach", str(worktree), first)
+        assert resolve_repo_head(worktree) == first
+        assert resolve_repo_head(repo) == second
+
+    def test_nested_repo_innermost_wins(self, tmp_path: Path):
+        outer = tmp_path / "outer"
+        outer_sha = _repo_with_commit(outer)
+        inner_sha = _repo_with_commit(outer / "inner", filename="b.txt")
+        assert resolve_repo_head(outer / "inner") == inner_sha
+        assert resolve_repo_head(outer) == outer_sha
+        assert inner_sha != outer_sha
+
+
+class TestFailOpen:
+    def test_none_cwd(self):
+        assert resolve_repo_head(None) is None
+
+    def test_nonexistent_cwd(self, tmp_path: Path):
+        assert resolve_repo_head(tmp_path / "does-not-exist") is None
+
+    def test_directory_outside_any_repo(self, tmp_path: Path):
+        assert resolve_repo_head(tmp_path) is None
+
+    def test_empty_repo_no_commits(self, tmp_path: Path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _git(repo, "init", "-q")
+        assert resolve_repo_head(repo) is None
+
+    def test_git_binary_absent(self, tmp_path: Path, monkeypatch):
+        def raise_missing(*args, **kwargs):
+            raise FileNotFoundError("git")
+
+        monkeypatch.setattr(repo_head.subprocess, "run", raise_missing)
+        assert resolve_repo_head(tmp_path) is None
+
+    def test_timeout_expired(self, tmp_path: Path, monkeypatch):
+        def raise_timeout(*args, **kwargs):
+            raise subprocess.TimeoutExpired(cmd=["git", "rev-parse", "HEAD"], timeout=2)
+
+        monkeypatch.setattr(repo_head.subprocess, "run", raise_timeout)
+        assert resolve_repo_head(tmp_path) is None
+
+    def test_nul_byte_in_cwd(self, tmp_path: Path):
+        # subprocess.run raises ValueError on an embedded NUL; the cwd is
+        # client-supplied over stdio, so this must resolve to absence.
+        assert resolve_repo_head(str(tmp_path) + "/x\x00y") is None
+
+    def test_value_error_from_run(self, tmp_path: Path, monkeypatch):
+        def raise_value_error(*args, **kwargs):
+            raise ValueError("embedded null byte")
+
+        monkeypatch.setattr(repo_head.subprocess, "run", raise_value_error)
+        assert resolve_repo_head(tmp_path) is None
+
+    def test_process_cwd_gone(self, monkeypatch):
+        # Path.cwd() raises when the process working directory was deleted;
+        # the process-level resolver must absorb it.
+        def raise_missing(*args, **kwargs):
+            raise FileNotFoundError("cwd deleted")
+
+        monkeypatch.setattr(repo_head.Path, "cwd", raise_missing)
+        assert resolve_process_repo_head() is None
+
+    def test_process_resolver_delegates_to_repo_head(self, tmp_path: Path, monkeypatch):
+        sha = _repo_with_commit(tmp_path / "repo")
+        monkeypatch.chdir(tmp_path / "repo")
+        assert resolve_process_repo_head() == sha
+
+    def test_non_sha_stdout_is_rejected(self, tmp_path: Path, monkeypatch):
+        def fake_run(*args, **kwargs):
+            return SimpleNamespace(returncode=0, stdout="HEAD\n", stderr="")
+
+        monkeypatch.setattr(repo_head.subprocess, "run", fake_run)
+        assert resolve_repo_head(tmp_path) is None
+
+    def test_truncated_sha_is_rejected(self, tmp_path: Path, monkeypatch):
+        def fake_run(*args, **kwargs):
+            return SimpleNamespace(returncode=0, stdout="a" * 12 + "\n", stderr="")
+
+        monkeypatch.setattr(repo_head.subprocess, "run", fake_run)
+        assert resolve_repo_head(tmp_path) is None

--- a/packages/nauro/tests/test_sync/test_pull.py
+++ b/packages/nauro/tests/test_sync/test_pull.py
@@ -63,6 +63,29 @@ def _presign(ops) -> httpx.Response:
     )
 
 
+# A canonical decision carrying the base_commit provenance stamp as its
+# trailing frontmatter key. Sync moves raw bytes, so stamped files must
+# round-trip byte-identically like any other decision.
+_STAMPED_SHA = "a1b2c3d4" * 5
+_STAMPED_DECISION = (
+    "---\n"
+    "date: 2026-08-05\n"
+    "version: 1\n"
+    "status: active\n"
+    "confidence: high\n"
+    "decision_type: null\n"
+    "reversibility: null\n"
+    "source: null\n"
+    "files_affected: []\n"
+    "supersedes: null\n"
+    "superseded_by: null\n"
+    f"base_commit: {_STAMPED_SHA}\n"
+    "---\n\n"
+    "# 099 — Remote stamped decision\n\n"
+    "## Decision\n\nChose A.\n"
+).encode()
+
+
 class _RecordingReporter:
     """Records reported messages."""
 
@@ -110,6 +133,25 @@ class TestRunPullCleanPull:
         assert state.files[rel].remote_etag == '"new"'
         assert reporter.infos == ["Merged 1 file(s) from remote"]
         assert reporter.warns == []
+
+    def test_clean_pull_of_stamped_decision_is_byte_identical(self, cloud_store):
+        rel = "decisions/099-remote-stamped.md"
+        manifest = _manifest([{"path": rel, "etag": '"new"', "size": 1, "last_modified": "x"}])
+        presign = _presign([{"verb": "GET", "path": rel}])
+
+        def fake_get(url, **kwargs):
+            if "/sync/manifest" in url:
+                return manifest
+            return httpx.Response(200, content=_STAMPED_DECISION)
+
+        with (
+            patch("nauro.sync.remote.httpx.get", side_effect=fake_get),
+            patch("nauro.sync.remote.httpx.post", return_value=presign),
+        ):
+            merged = run_pull(CLOUD_PID, cloud_store, _RecordingReporter())
+
+        assert merged == 1
+        assert (cloud_store / rel).read_bytes() == _STAMPED_DECISION
 
     def test_append_only_conflict_invokes_resolve_and_writes_merge(self, cloud_store):
         # state_history.md is append-only with section-aware set-union merge.
@@ -288,6 +330,22 @@ class TestRenumberDecisionIfCollision:
 
         assert rel == "decisions/003-same-slug.md"
         assert out == content
+
+    def test_collision_renumber_preserves_base_commit_stamp(self, project_store):
+        decisions_dir = project_store / "decisions"
+        decisions_dir.mkdir(exist_ok=True)
+        (decisions_dir / "099-local.md").write_text("# 099 — Local")
+
+        rel, out = _renumber_decision_if_collision(
+            project_store,
+            "decisions/099-remote-stamped.md",
+            _STAMPED_DECISION,
+        )
+
+        assert rel == "decisions/100-remote-stamped.md"
+        # Only the H1 number changed; the stamp line is untouched.
+        assert out == _STAMPED_DECISION.replace(b"# 099 ", b"# 100 ")
+        assert f"base_commit: {_STAMPED_SHA}".encode() in out
 
     def test_non_decision_files_pass_through(self, project_store):
         content = b"some content"

--- a/packages/nauro/tests/test_sync/test_sync_presign.py
+++ b/packages/nauro/tests/test_sync/test_sync_presign.py
@@ -468,6 +468,35 @@ class TestPushViaPresign:
         assert state.files["stack.md"].local_sha256 == new_sha
         assert state.files["stack.md"].remote_etag == '"e_pushed"'
 
+    def test_stamped_decision_pushed_byte_identical(self, cloud_store):
+        """A decision carrying the base_commit stamp uploads verbatim; the
+        push path never rewrites decision bytes."""
+        from tests.test_sync.test_pull import _STAMPED_DECISION
+
+        self._seed_synced_state(cloud_store)
+        rel = "decisions/099-remote-stamped.md"
+        (cloud_store / "decisions").mkdir(exist_ok=True)
+        (cloud_store / rel).write_bytes(_STAMPED_DECISION)
+
+        put_response = MagicMock(spec=httpx.Response)
+        put_response.status_code = 200
+        put_response.headers = {"ETag": '"e_pushed"'}
+
+        def fake_post(url, **kwargs):
+            return self._presign_response(kwargs["json"]["operations"])
+
+        from nauro.sync import remote
+        from nauro.sync.push import push_changed_files
+
+        with (
+            patch.object(remote.httpx, "post", side_effect=fake_post),
+            patch.object(remote.httpx, "put", return_value=put_response) as mock_put,
+        ):
+            pushed = push_changed_files(CLOUD_PID, cloud_store)
+
+        assert pushed == 1
+        assert mock_put.call_args.kwargs["content"] == _STAMPED_DECISION
+
     def test_oversize_context_brief_skipped_loudly_and_retained(self, cloud_store, capsys):
         """An over-cap context/*.md is skipped from the push with a loud
         warning and left on disk, while other changed files still upload.


### PR DESCRIPTION
## Why

Decisions decay against the code they describe, and the report-only staleness
audit has no record of what code a decision was written against. Backfilling
isn't possible, so capture starts now. This ships the stamp only; the audit
that consumes it is separate work.

## What changed

- Each decision filed on the local write path gains one optional trailing
  frontmatter key, `base_commit`, carrying the HEAD SHA of the repository
  enclosing the caller's working directory at filing time.
- Capture is transport-side and fail-open. A new store-layer helper
  (`store/repo_head.py`) runs `git rev-parse HEAD` with a 2-second timeout and
  full-hex validation; the stdio MCP wrapper resolves from its client-supplied
  `cwd` parameter, the CLI from the process cwd. No repo, no git, no commits, a
  bad cwd, or a timeout all resolve to absence — the key is omitted entirely,
  never written as null.
- The SHA threads through the adapter into the kernel as one optional kwarg and
  lands in the tolerant reader's unknown-key channel only when resolved, so
  legacy files rewritten by supersede flips or updates never gain the key, and
  update/supersede never restamp an existing file. `nauro note` and import
  paths stay unstamped.
- The hosted path never passes the kwarg and no-ops; a guard test keeps the
  kernel tree free of subprocess and git imports by construction.
- The journal excludes the stamp from payload hashing alongside `origin`:
  provenance, not payload.

## Test plan

- New resolver suite against real git repositories: normal, dirty worktree,
  detached HEAD, linked worktree, and nested-repo (innermost wins) all stamp
  correctly; every fail-open branch returns None without raising.
- Cross-surface wiring suite: stdio stamps from its cwd param, the CLI from the
  process cwd; all five absence cases assert the literal string `base_commit`
  never appears in the written file; journal payload hash is invariant across
  two attempts differing only in the stamp; no tool schema, CLI flag, or other
  write adapter gained surface.
- Kernel suite: stamped add round-trips byte-identically; update and supersede
  preserve existing stamps and never restamp; add/update/supersede without the
  kwarg leave no trace of the key.
- Sync: stamped decision files push and pull byte-identically; collision
  renumbering preserves the stamp.
- Full suites green: nauro-core 1135 passed; nauro 2133 passed, 10 skipped.
  Public-contract snapshot test passes without regeneration. Lint clean.

## Risk / what to review

- The stamp rides `model_extra` (extra="allow"): readers older than nauro
  1.8.0 / nauro-core 1.4.0 parse stamped decisions as failures. This exposure
  was accepted with the design and belongs in the release notes; before any
  cloud-linked store starts stamping, the private server's nauro-core pin must
  be verified at or above 1.4.0.
- `_write_decision_direct` must never receive `base_commit=None` as a
  constructor kwarg (would serialize `base_commit: null`); the truthy guard and
  the explicit-None kernel test pin this.
