### PR TITLE
Release nauro 1.10.0 and nauro-core 1.5.0

### DIFF
--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro-core"
-version = "1.4.0"
+version = "1.5.0"
 description = "Shared pure-Python logic for Nauro: parsing, validation, context assembly, constants."
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro"
-version = "1.9.0"
+version = "1.10.0"
 description = "Human-approved project judgment and current state for connected AI agents, surfaced before work."
 readme = "README.md"
 license = "Apache-2.0"
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "nauro-core>=1.4.0,<2",
+    "nauro-core>=1.5.0,<2",
     "typer>=0.9",
     "httpx>=0.24",
     "mcp>=1.0",

--- a/server.json
+++ b/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Nauro-AI/nauro",
     "source": "github"
   },
-  "version": "1.9.0",
+  "version": "1.10.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "nauro",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -928,7 +928,7 @@ wheels = [
 
 [[package]]
 name = "nauro"
-version = "1.9.0"
+version = "1.10.0"
 source = { editable = "packages/nauro" }
 dependencies = [
     { name = "filelock" },
@@ -970,7 +970,7 @@ provides-extras = ["dev", "embeddings"]
 
 [[package]]
 name = "nauro-core"
-version = "1.4.0"
+version = "1.5.0"
 source = { editable = "packages/nauro-core" }
 dependencies = [
     { name = "bm25s" },


### PR DESCRIPTION
## Version moves

- **nauro**: 1.9.0 → 1.10.0 (minor)
- **nauro-core**: 1.4.0 → 1.5.0 (minor); nauro's floor bumped to `nauro-core>=1.5.0,<2`
- `server.json` re-locked to 1.10.0

## What ships

**nauro** (since 1.9.0):
- Decisions filed on the local write path now record the repo HEAD they were ratified against, as an optional trailing `base_commit` frontmatter key. Capture is transport-side and fail-open: no repo, no git, no commits, a bad cwd, or a timeout all resolve to the key being omitted — a filing is never blocked or delayed past a bounded 2-second cap (#394).
- Generated AGENTS.md deduplicates against MCP-delivered guidance and skips no-op regenerations (#392); the outcome-evidence rider section is included (#388).
- Question entries in rendered payloads are capped and the last two read tools render (#393).
- Invalid enum values are rejected at Tier 1 with a clear message; `nauro flag-question` takes its question positionally (#391).
- `init --demo` warning wording and pre-launch public-surface cleanup (#387, #390).

**nauro-core** (since 1.4.0):
- The propose-decision kernel accepts an optional provenance kwarg for the base-commit stamp; the default path is unchanged and the package remains subprocess-free (#394).
- Tier-1 validation rejects invalid enum values instead of erroring downstream (#391).
- Renderer caps for question entries (#393).

Compatibility note (in the release notes as well): stamped decision files rely on the tolerant frontmatter reader shipped in nauro 1.8.0 / nauro-core 1.4.0. Readers older than that treat a stamped decision as unparseable and drop it from retrieval — relevant only to multi-machine synced stores with a pre-1.8.0 client.

## Checks

- `check_server_json_version.py` and `check_single_sourced.py` pass locally
- `uv lock --check` clean; `uv sync --locked` passes for both packages on 3.12
- CI must be fully green before merge

## Post-merge

Tag the squash commit `nauro-core-v1.5.0` and `nauro-v1.10.0` and push both tags to trigger the trusted-publish workflows (PyPI + MCP registry), then create the GitHub Releases.
