### PR TITLE
Inline triage headers on check_decision hits

### DIFF
--- a/.agents/skills/nauro-adopt/SKILL.md
+++ b/.agents/skills/nauro-adopt/SKILL.md
@@ -39,7 +39,7 @@ Per card, the agent prepares:
 
 ### Step 0.2: Pre-check and classify each card
 
-Before presenting the batch, the agent runs Step 7 steps 1–3 for each card: call `check_decision(proposed_approach=<title plus the one-line summary>, project_id=...)` **once per card**, read every related decision, classify the operation, and prepare the complete operation-specific proposal. Annotate each card with the related decisions and assessment from the pre-pass. Doing this up front lets the batch show the exact proposed write and any overlap before confirmation.
+Before presenting the batch, the agent runs Step 7 steps 1–3 for each card: call `check_decision(proposed_approach=<title plus the one-line summary>, project_id=...)` **once per card**, triage the inline headers, read in full the decisions that bear on the card, classify the operation, and prepare the complete operation-specific proposal. Annotate each card with the related decisions and assessment from the pre-pass. Doing this up front lets the batch show the exact proposed write and any overlap before confirmation.
 
 ### Step 0.3 — One batch confirm
 
@@ -162,7 +162,7 @@ Languages, frameworks, package managers, license, lint tooling, and similar fact
 For each kept candidate from 6a and each rationale-supplied 6b answer, the agent runs the full propose protocol:
 
 1. Call `check_decision(proposed_approach=<for a 6a candidate: the title plus the one-line summary; for a 6b candidate: the observed fact plus the core of the rationale the user supplied>, project_id=...)`. `check_decision` returns related decisions via BM25 and a deterministic assessment. It does NOT judge conflicts.
-2. When related decisions appear, call `get_decision` on each before proposing: `mode=header` to triage and `mode=full` for those you reason about. Call signature: `get_decision(number=N, project_id=...)`.
+2. Related hits carry their triage headers inline; before proposing, call `get_decision` (`mode=full`) on each decision you reason about. Call signature: `get_decision(number=N, project_id=...)`.
 3. Classify the operation:
     - **add** (default; new ground, no existing decision covers it).
     - **update** when the candidate augments an existing decision's rationale only. The server consumes only `rationale` on update; `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, and `rejected` are rejected at the boundary — use supersede if any of those must change.

--- a/.agents/skills/nauro-ship-task/SKILL.md
+++ b/.agents/skills/nauro-ship-task/SKILL.md
@@ -38,7 +38,7 @@ Before invoking `@nauro-planner`, the parent session confirms the planner will r
 
 ### 1. Plan
 
-Invoke the `@nauro-planner` subagent with the task description. The planner runs `check_decision` against the proposed approach, classifies as GREEN / AMBER / RED, reads related decision bodies via `get_decision`, investigates the code, and returns a plan in the plan shape (Why / Approach / What changes / What's deferred / Test plan), plus the verdict line and any complete decision draft awaiting approval.
+Invoke the `@nauro-planner` subagent with the task description. The planner runs `check_decision` against the proposed approach, classifies as GREEN / AMBER / RED, triages the inline headers, reads the decisions that inform the approach via `get_decision`, investigates the code, and returns a plan in the plan shape (Why / Approach / What changes / What's deferred / Test plan), plus the verdict line and any complete decision draft awaiting approval.
 
 If the planner returns RED with a supersede draft, the chain pauses here. Surface the complete draft to the user: paste the planner's complete rendered proposal exactly as returned, no reserialization to JSON, no abbreviation, no pointer to output above, immediately before the approval ask. Only on explicit user approval does the parent re-invoke the planner with that approval to file the exact draft. An explicit "override RED on the cited decision, proceed" may continue without filing, but it is not approval to call `propose_decision`.
 

--- a/.claude/skills/nauro-adopt/SKILL.md
+++ b/.claude/skills/nauro-adopt/SKILL.md
@@ -39,7 +39,7 @@ Per card, the agent prepares:
 
 ### Step 0.2: Pre-check and classify each card
 
-Before presenting the batch, the agent runs Step 7 steps 1–3 for each card: call `check_decision(proposed_approach=<title plus the one-line summary>, project_id=...)` **once per card**, read every related decision, classify the operation, and prepare the complete operation-specific proposal. Annotate each card with the related decisions and assessment from the pre-pass. Doing this up front lets the batch show the exact proposed write and any overlap before confirmation.
+Before presenting the batch, the agent runs Step 7 steps 1–3 for each card: call `check_decision(proposed_approach=<title plus the one-line summary>, project_id=...)` **once per card**, triage the inline headers, read in full the decisions that bear on the card, classify the operation, and prepare the complete operation-specific proposal. Annotate each card with the related decisions and assessment from the pre-pass. Doing this up front lets the batch show the exact proposed write and any overlap before confirmation.
 
 ### Step 0.3 — One batch confirm
 
@@ -162,7 +162,7 @@ Languages, frameworks, package managers, license, lint tooling, and similar fact
 For each kept candidate from 6a and each rationale-supplied 6b answer, the agent runs the full propose protocol:
 
 1. Call `check_decision(proposed_approach=<for a 6a candidate: the title plus the one-line summary; for a 6b candidate: the observed fact plus the core of the rationale the user supplied>, project_id=...)`. `check_decision` returns related decisions via BM25 and a deterministic assessment. It does NOT judge conflicts.
-2. When related decisions appear, call `get_decision` on each before proposing: `mode=header` to triage and `mode=full` for those you reason about. Call signature: `get_decision(number=N, project_id=...)`.
+2. Related hits carry their triage headers inline; before proposing, call `get_decision` (`mode=full`) on each decision you reason about. Call signature: `get_decision(number=N, project_id=...)`.
 3. Classify the operation:
     - **add** (default; new ground, no existing decision covers it).
     - **update** when the candidate augments an existing decision's rationale only. The server consumes only `rationale` on update; `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, and `rejected` are rejected at the boundary — use supersede if any of those must change.

--- a/.claude/skills/nauro-ship-task/SKILL.md
+++ b/.claude/skills/nauro-ship-task/SKILL.md
@@ -25,7 +25,7 @@ Before invoking `@nauro-planner`, the parent session confirms the planner will r
 
 ### 1. Plan
 
-Invoke the `@nauro-planner` subagent with the task description. The planner runs `check_decision` against the proposed approach, classifies as GREEN / AMBER / RED, reads related decision bodies via `get_decision`, investigates the code, and returns a plan in the plan shape (Why / Approach / What changes / What's deferred / Test plan), plus the verdict line and any complete decision draft awaiting approval.
+Invoke the `@nauro-planner` subagent with the task description. The planner runs `check_decision` against the proposed approach, classifies as GREEN / AMBER / RED, triages the inline headers, reads the decisions that inform the approach via `get_decision`, investigates the code, and returns a plan in the plan shape (Why / Approach / What changes / What's deferred / Test plan), plus the verdict line and any complete decision draft awaiting approval.
 
 If the planner returns RED with a supersede draft, the chain pauses here. Surface the complete draft to the user: paste the planner's complete rendered proposal exactly as returned, no reserialization to JSON, no abbreviation, no pointer to output above, immediately before the approval ask. Only on explicit user approval does the parent re-invoke the planner with that approval to file the exact draft. An explicit "override RED on the cited decision, proceed" may continue without filing, but it is not approval to call `propose_decision`.
 

--- a/.cursor/rules/nauro-adopt.mdc
+++ b/.cursor/rules/nauro-adopt.mdc
@@ -39,7 +39,7 @@ Per card, the agent prepares:
 
 ### Step 0.2: Pre-check and classify each card
 
-Before presenting the batch, the agent runs Step 7 steps 1–3 for each card: call `check_decision(proposed_approach=<title plus the one-line summary>, project_id=...)` **once per card**, read every related decision, classify the operation, and prepare the complete operation-specific proposal. Annotate each card with the related decisions and assessment from the pre-pass. Doing this up front lets the batch show the exact proposed write and any overlap before confirmation.
+Before presenting the batch, the agent runs Step 7 steps 1–3 for each card: call `check_decision(proposed_approach=<title plus the one-line summary>, project_id=...)` **once per card**, triage the inline headers, read in full the decisions that bear on the card, classify the operation, and prepare the complete operation-specific proposal. Annotate each card with the related decisions and assessment from the pre-pass. Doing this up front lets the batch show the exact proposed write and any overlap before confirmation.
 
 ### Step 0.3 — One batch confirm
 
@@ -162,7 +162,7 @@ Languages, frameworks, package managers, license, lint tooling, and similar fact
 For each kept candidate from 6a and each rationale-supplied 6b answer, the agent runs the full propose protocol:
 
 1. Call `check_decision(proposed_approach=<for a 6a candidate: the title plus the one-line summary; for a 6b candidate: the observed fact plus the core of the rationale the user supplied>, project_id=...)`. `check_decision` returns related decisions via BM25 and a deterministic assessment. It does NOT judge conflicts.
-2. When related decisions appear, call `get_decision` on each before proposing: `mode=header` to triage and `mode=full` for those you reason about. Call signature: `get_decision(number=N, project_id=...)`.
+2. Related hits carry their triage headers inline; before proposing, call `get_decision` (`mode=full`) on each decision you reason about. Call signature: `get_decision(number=N, project_id=...)`.
 3. Classify the operation:
     - **add** (default; new ground, no existing decision covers it).
     - **update** when the candidate augments an existing decision's rationale only. The server consumes only `rationale` on update; `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, and `rejected` are rejected at the boundary — use supersede if any of those must change.

--- a/.cursor/rules/nauro-ship-task.mdc
+++ b/.cursor/rules/nauro-ship-task.mdc
@@ -25,7 +25,7 @@ Before invoking `@nauro-planner`, the parent session confirms the planner will r
 
 ### 1. Plan
 
-Invoke the `@nauro-planner` subagent with the task description. The planner runs `check_decision` against the proposed approach, classifies as GREEN / AMBER / RED, reads related decision bodies via `get_decision`, investigates the code, and returns a plan in the plan shape (Why / Approach / What changes / What's deferred / Test plan), plus the verdict line and any complete decision draft awaiting approval.
+Invoke the `@nauro-planner` subagent with the task description. The planner runs `check_decision` against the proposed approach, classifies as GREEN / AMBER / RED, triages the inline headers, reads the decisions that inform the approach via `get_decision`, investigates the code, and returns a plan in the plan shape (Why / Approach / What changes / What's deferred / Test plan), plus the verdict line and any complete decision draft awaiting approval.
 
 If the planner returns RED with a supersede draft, the chain pauses here. Surface the complete draft to the user: paste the planner's complete rendered proposal exactly as returned, no reserialization to JSON, no abbreviation, no pointer to output above, immediately before the approval ask. Only on explicit user approval does the parent re-invoke the planner with that approval to file the exact draft. An explicit "override RED on the cited decision, proceed" may continue without filing, but it is not approval to call `propose_decision`.
 

--- a/docs/adopt-prompt.md
+++ b/docs/adopt-prompt.md
@@ -58,7 +58,7 @@ Per card, the agent prepares:
 
 ### Step 0.2: Pre-check and classify each card
 
-Before presenting the batch, the agent runs Step 7 steps 1–3 for each card: call `check_decision(proposed_approach=<title plus the one-line summary>, project_id=...)` **once per card**, read every related decision, classify the operation, and prepare the complete operation-specific proposal. Annotate each card with the related decisions and assessment from the pre-pass. Doing this up front lets the batch show the exact proposed write and any overlap before confirmation.
+Before presenting the batch, the agent runs Step 7 steps 1–3 for each card: call `check_decision(proposed_approach=<title plus the one-line summary>, project_id=...)` **once per card**, triage the inline headers, read in full the decisions that bear on the card, classify the operation, and prepare the complete operation-specific proposal. Annotate each card with the related decisions and assessment from the pre-pass. Doing this up front lets the batch show the exact proposed write and any overlap before confirmation.
 
 ### Step 0.3 — One batch confirm
 
@@ -181,7 +181,7 @@ Languages, frameworks, package managers, license, lint tooling, and similar fact
 For each kept candidate from 6a and each rationale-supplied 6b answer, the agent runs the full propose protocol:
 
 1. Call `check_decision(proposed_approach=<for a 6a candidate: the title plus the one-line summary; for a 6b candidate: the observed fact plus the core of the rationale the user supplied>, project_id=...)`. `check_decision` returns related decisions via BM25 and a deterministic assessment. It does NOT judge conflicts.
-2. When related decisions appear, call `get_decision` on each before proposing: `mode=header` to triage and `mode=full` for those you reason about. Call signature: `get_decision(number=N, project_id=...)`.
+2. Related hits carry their triage headers inline; before proposing, call `get_decision` (`mode=full`) on each decision you reason about. Call signature: `get_decision(number=N, project_id=...)`.
 3. Classify the operation:
     - **add** (default; new ground, no existing decision covers it).
     - **update** when the candidate augments an existing decision's rationale only. The server consumes only `rationale` on update; `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, and `rejected` are rejected at the boundary — use supersede if any of those must change.

--- a/packages/nauro-core/src/nauro_core/mcp_tools.py
+++ b/packages/nauro-core/src/nauro_core/mcp_tools.py
@@ -178,9 +178,11 @@ GET_DECISION: ToolSpec = {
         "supersession, date, type, confidence), the title, and a short lede "
         "from the rationale — enough to decide whether a decision is worth a "
         "full read. mode=full (default) returns the complete markdown: "
-        "metadata, full rationale, and rejected alternatives. Read header to "
-        "triage a list of related decisions, then full for the ones you "
-        "actually reason about."
+        "metadata, full rationale, and rejected alternatives. Use header as "
+        "the standalone triage read for decisions surfaced by "
+        "search_decisions or list_decisions (check_decision hits already "
+        "carry these headers inline), then full for the ones you actually "
+        "reason about."
     ),
     "annotations": {**_READ_ANNOTATIONS, "idempotentHint": True},
     "input_schema": {

--- a/packages/nauro-core/src/nauro_core/operations/check_decision.py
+++ b/packages/nauro-core/src/nauro_core/operations/check_decision.py
@@ -19,20 +19,16 @@ from nauro_core.constants import (
     NO_DECISIONS_TO_CHECK,
     NO_RELATED_DECISIONS,
 )
-from nauro_core.decision_model import Decision, DecisionStatus
 from nauro_core.operations.decision_lookup import parse_all_decisions
+from nauro_core.operations.related_hits import to_related_decisions
 from nauro_core.operations.results import (
     CheckDecisionResult,
     ErrorPayload,
     RelatedDecision,
 )
 from nauro_core.operations.store import Store
-from nauro_core.parsing import (
-    _canonical_decision_id,
-    _decision_label,
-    extract_decision_number,
-)
-from nauro_core.search import Bm25Hit, union_retrieve
+from nauro_core.parsing import _decision_label, extract_decision_number
+from nauro_core.search import union_retrieve
 from nauro_core.validation import check_content_length, is_scaffold_seed
 
 # Extended stopword list for ``check_decision`` retrieval. Mirrors the
@@ -96,32 +92,11 @@ def check_decision(
     if not hits:
         return CheckDecisionResult(assessment=NO_RELATED_DECISIONS)
 
-    by_num = {d.num: d for d in decisions}
-    related = [_hit_to_related(hit, by_num) for hit in hits]
+    related = to_related_decisions(hits, decisions)
 
     return CheckDecisionResult(
         related_decisions=related,
         assessment=_assessment(related),
-    )
-
-
-def _hit_to_related(hit: Bm25Hit, by_num: dict[int, Decision]) -> RelatedDecision:
-    """Lift a ``bm25_retrieve`` hit into the canonical retrieval-hit shape."""
-    num = hit["number"]
-    decision = by_num.get(num)
-    canonical_id = _canonical_decision_id(num)
-    status = decision.status.value if decision else DecisionStatus.active.value
-    date = decision.date.isoformat() if decision and decision.date else ""
-    # Embedding-sourced hits carry similarity=None (no BM25 score); surface 0.0
-    # so the score field stays a float and signals "not a BM25 match".
-    similarity = hit.get("similarity")
-    return RelatedDecision(
-        id=canonical_id,
-        title=hit.get("title", ""),
-        score=similarity if similarity is not None else 0.0,
-        status=status,
-        date=date,
-        rationale_preview=hit.get("rationale_preview", ""),
     )
 
 
@@ -146,8 +121,12 @@ def _assessment(related: list[RelatedDecision]) -> str:
     )
     if len(related) == 1:
         target = f"get_decision({top_num})" if top_num is not None else "get_decision"
-        return f"{top_line} {LEXICAL_RANK_CAVEAT} Call {target} before proposing."
+        return (
+            f"{top_line} {LEXICAL_RANK_CAVEAT} Its triage header is inline."
+            f" Call {target} (mode=full) before proposing."
+        )
     return (
         f"Found {len(related)} related decisions. {top_line} {LEXICAL_RANK_CAVEAT}"
-        " Call get_decision on each related decision before proposing."
+        " Triage headers are inline. Call get_decision (mode=full) on each"
+        " decision you reason about before proposing."
     )

--- a/packages/nauro-core/src/nauro_core/operations/get_decision.py
+++ b/packages/nauro-core/src/nauro_core/operations/get_decision.py
@@ -11,9 +11,10 @@ the lookup itself is shared by construction.
 * ``"full"`` (default) — the verbatim markdown body, unchanged.
 * ``"header"`` — a compact projection (triage frontmatter fields, the
   title, and a short lede from the ``## Decision`` section) for cheap
-  triage of the related-decision list a check returns. The projection
-  rides in the existing ``content`` field; the result model shape is the
-  same for both modes.
+  standalone triage of decisions surfaced by ``search_decisions`` or
+  ``list_decisions`` (``check_decision`` hits carry these headers
+  inline). The projection rides in the existing ``content`` field; the
+  result model shape is the same for both modes.
 """
 
 from __future__ import annotations
@@ -22,6 +23,7 @@ from typing import Literal
 
 from nauro_core.decision_model import Decision
 from nauro_core.operations.decision_lookup import parse_decision_or_none
+from nauro_core.operations.related_hits import decision_lede, frontmatter_value
 from nauro_core.operations.results import ErrorPayload, GetDecisionResult
 from nauro_core.operations.store import Store
 from nauro_core.parsing import _decision_filename, extract_decision_number
@@ -38,11 +40,6 @@ _HEADER_FRONTMATTER_FIELDS: tuple[str, ...] = (
     "decision_type",
     "confidence",
 )
-
-# Lede budget. The first paragraph of the ``## Decision`` section is the
-# load-bearing sentence(s); cap it so the projection stays compact while
-# still carrying enough rationale to triage on.
-_LEDE_MAX_CHARS = 300
 
 
 def get_decision(
@@ -106,48 +103,15 @@ def _project_header(decision: Decision) -> str:
     """
     frontmatter_lines: list[str] = []
     for field in _HEADER_FRONTMATTER_FIELDS:
-        value = _frontmatter_value(decision, field)
+        value = frontmatter_value(decision, field)
         if value:
             frontmatter_lines.append(f"{field}: {value}")
 
     blocks: list[str] = ["\n".join(frontmatter_lines)]
     blocks.append(f"# {decision.num:03d} — {decision.title}")
 
-    lede = _lede(decision.rationale)
+    lede = decision_lede(decision.rationale)
     if lede:
         blocks.append(lede)
 
     return "\n\n".join(blocks)
-
-
-def _frontmatter_value(decision, field: str) -> str:
-    """Return the on-disk string for a triage frontmatter field, or ``""``.
-
-    Enum-valued fields (``status``, ``decision_type``, ``confidence``)
-    serialize to their underlying token; ``date`` to ISO format;
-    supersession refs are already plain integer strings.
-    """
-    raw = getattr(decision, field, None)
-    if raw is None:
-        return ""
-    if field == "date":
-        return raw.isoformat()
-    value = getattr(raw, "value", raw)
-    return str(value)
-
-
-def _lede(rationale: str) -> str:
-    """Return the first paragraph of the rationale, truncated to the budget.
-
-    Returns ``""`` when the rationale is empty or opens with whitespace
-    only, so the projection omits the lede block entirely.
-    """
-    stripped = rationale.strip()
-    if not stripped:
-        return ""
-    paragraph = stripped.split("\n\n", 1)[0].strip()
-    if not paragraph:
-        return ""
-    if len(paragraph) <= _LEDE_MAX_CHARS:
-        return paragraph
-    return paragraph[: _LEDE_MAX_CHARS - 1].rstrip() + "…"

--- a/packages/nauro-core/src/nauro_core/operations/propose_decision.py
+++ b/packages/nauro-core/src/nauro_core/operations/propose_decision.py
@@ -54,21 +54,19 @@ from nauro_core.operations.decision_lookup import (
     find_decision_stem_by_num,
     parse_all_decisions,
 )
+from nauro_core.operations.related_hits import to_related_decisions
 from nauro_core.operations.results import (
     ErrorPayload,
     ProposeDecisionResult,
-    RelatedDecision,
 )
 from nauro_core.operations.store import Store
 from nauro_core.parsing import (
-    _canonical_decision_id,
     _decision_filename,
     _decision_number_prefix,
     _decision_path,
     extract_decision_number,
 )
 from nauro_core.questions import EntryBlock, OpenQuestionsFile
-from nauro_core.search import Bm25Hit
 from nauro_core.validation import (
     check_bm25_similarity,
     compute_hash,
@@ -232,7 +230,7 @@ def propose_decision(
     if parsed is None:
         parsed = parse_all_decisions(store)
     _t2_action, similar_raw = check_bm25_similarity(proposal, parsed)
-    similar_models = _to_related_decisions(similar_raw, parsed)
+    similar_models = to_related_decisions(similar_raw, parsed)
 
     # --- Commit ---
     decision_id, actual_operation, touched, resolve_outcome, error = _execute_operation(
@@ -374,39 +372,6 @@ def _update_hash_index(store: Store, title: str, rationale: str, decision_id: st
         "timestamp": datetime.now(timezone.utc).isoformat(),
     }
     _save_hash_index(store, index)
-
-
-# ── Tier 2 result reshape ─────────────────────────────────────────────────
-
-
-def _to_related_decisions(
-    raw_hits: list[Bm25Hit],
-    parsed_decisions: list[Decision],
-) -> list[RelatedDecision]:
-    """Lift the ``bm25_retrieve`` dict shape into :class:`RelatedDecision`.
-
-    Matches the unified shape ``check_decision`` already returns; the
-    BM25 row dict is normalized into :class:`RelatedDecision` at the
-    kernel boundary so every transport renders the same hit.
-    """
-    by_num: dict[int, Decision] = {d.num: d for d in parsed_decisions}
-    out: list[RelatedDecision] = []
-    for hit in raw_hits:
-        num = hit["number"]
-        decision = by_num.get(num)
-        status = decision.status.value if decision else DecisionStatus.active.value
-        date = decision.date.isoformat() if decision and decision.date else ""
-        out.append(
-            RelatedDecision(
-                id=_canonical_decision_id(num),
-                title=hit.get("title", ""),
-                score=hit.get("similarity", 0.0),
-                status=status,
-                date=date,
-                rationale_preview=hit.get("rationale_preview", ""),
-            )
-        )
-    return out
 
 
 # ── Operation execution ───────────────────────────────────────────────────

--- a/packages/nauro-core/src/nauro_core/operations/related_hits.py
+++ b/packages/nauro-core/src/nauro_core/operations/related_hits.py
@@ -1,0 +1,108 @@
+"""Shared triage projection for retrieval hits and decision headers.
+
+``check_decision`` and ``propose_decision`` both lift raw BM25 hit dicts
+into the canonical :class:`RelatedDecision` shape, and ``get_decision``'s
+header mode projects the same triage fields for a single decision. This
+module owns the shared primitives — the lede budget, the first-paragraph
+lede extraction, the frontmatter serialization rules, and the hit lifting
+itself — so the enriched hit and the header projection cannot drift.
+"""
+
+from __future__ import annotations
+
+from nauro_core.decision_model import Decision, DecisionStatus
+from nauro_core.operations.results import RelatedDecision
+from nauro_core.parsing import _canonical_decision_id
+from nauro_core.search import Bm25Hit
+
+# Lede budget. The first paragraph of the rationale is the load-bearing
+# sentence(s); cap it so triage projections stay compact while still
+# carrying enough rationale to triage on.
+LEDE_MAX_CHARS = 300
+
+
+def decision_lede(rationale: str) -> str:
+    """Return the first paragraph of the rationale, truncated to the budget.
+
+    Returns ``""`` when the rationale is empty or opens with whitespace
+    only, so triage surfaces omit the lede block entirely.
+    """
+    stripped = rationale.strip()
+    if not stripped:
+        return ""
+    paragraph = stripped.split("\n\n", 1)[0].strip()
+    if not paragraph:
+        return ""
+    if len(paragraph) <= LEDE_MAX_CHARS:
+        return paragraph
+    return paragraph[: LEDE_MAX_CHARS - 1].rstrip() + "…"
+
+
+def frontmatter_value(decision: Decision, field: str) -> str:
+    """Return the on-disk string for a triage frontmatter field, or ``""``.
+
+    Enum-valued fields (``status``, ``decision_type``, ``confidence``)
+    serialize to their underlying token; ``date`` to ISO format;
+    supersession refs are already plain integer strings.
+    """
+    raw = getattr(decision, field, None)
+    if raw is None:
+        return ""
+    if field == "date":
+        return raw.isoformat()
+    value = getattr(raw, "value", raw)
+    return str(value)
+
+
+def to_related_decisions(
+    hits: list[Bm25Hit],
+    decisions: list[Decision],
+) -> list[RelatedDecision]:
+    """Lift ``bm25_retrieve``/``union_retrieve`` hits into :class:`RelatedDecision`.
+
+    The single hit-lifting path shared by ``check_decision`` and
+    ``propose_decision``: both call sites already hold the parsed corpus, so
+    the enrichment (status, date, type, confidence, supersession refs, lede)
+    costs no extra I/O. The BM25 row dict is normalized at the kernel
+    boundary so every transport renders the same hit.
+    """
+    by_num: dict[int, Decision] = {d.num: d for d in decisions}
+    return [_hit_to_related(hit, by_num) for hit in hits]
+
+
+def _hit_to_related(hit: Bm25Hit, by_num: dict[int, Decision]) -> RelatedDecision:
+    num = hit["number"]
+    decision = by_num.get(num)
+    status = decision.status.value if decision else DecisionStatus.active.value
+    date = decision.date.isoformat() if decision and decision.date else ""
+    # The preview carries the same lede the header projection shows: first
+    # paragraph of the rationale under the shared budget. Fall back to the
+    # raw hit preview only on the defensive miss (hit without a parsed
+    # decision, e.g. a backend racing a delete against enumeration).
+    preview = decision_lede(decision.rationale) if decision else hit.get("rationale_preview", "")
+    # Embedding-sourced hits carry similarity=None (no BM25 score); surface 0.0
+    # so the score field stays a float and signals "not a BM25 match".
+    similarity = hit.get("similarity")
+    return RelatedDecision(
+        id=_canonical_decision_id(num),
+        title=hit.get("title", ""),
+        score=similarity if similarity is not None else 0.0,
+        status=status,
+        date=date,
+        rationale_preview=preview,
+        decision_type=_optional_frontmatter(decision, "decision_type"),
+        confidence=_optional_frontmatter(decision, "confidence"),
+        supersedes=_optional_frontmatter(decision, "supersedes"),
+        superseded_by=_optional_frontmatter(decision, "superseded_by"),
+    )
+
+
+def _optional_frontmatter(decision: Decision | None, field: str) -> str | None:
+    """Frontmatter string for enrichment fields; ``None`` when absent.
+
+    ``None`` (rather than ``""``) keeps unset fields out of serialized
+    envelopes via the adapters' ``exclude_none=True`` dumps.
+    """
+    if decision is None:
+        return None
+    return frontmatter_value(decision, field) or None

--- a/packages/nauro-core/src/nauro_core/operations/results.py
+++ b/packages/nauro-core/src/nauro_core/operations/results.py
@@ -16,9 +16,16 @@ from pydantic import BaseModel, ConfigDict, Field
 class RelatedDecision(BaseModel):
     """A decision surfaced by retrieval as related to a proposed approach.
 
-    The canonical retrieval-hit shape: enriched with status/date and a
-    rationale preview so any transport can render the same hit without
+    The canonical retrieval-hit shape: enriched with the triage-header
+    fields (status, date, type, confidence, supersession refs) and a
+    rationale lede so any transport can render the same hit without
     re-fetching the underlying decision body.
+
+    ``decision_type``, ``confidence``, ``supersedes``, and
+    ``superseded_by`` stay optional so hits whose decision omits those
+    frontmatter fields still serialize; the adapter's ``exclude_none=True``
+    template choice drops the keys when they are unset (the
+    :class:`DecisionSummary`/:class:`SearchHit` key-omission contract).
     """
 
     model_config = ConfigDict(frozen=True, extra="forbid")
@@ -29,6 +36,10 @@ class RelatedDecision(BaseModel):
     status: str
     date: str
     rationale_preview: str
+    decision_type: str | None = None
+    confidence: str | None = None
+    supersedes: str | None = None
+    superseded_by: str | None = None
 
 
 class ErrorPayload(BaseModel):

--- a/packages/nauro-core/src/nauro_core/protocol.py
+++ b/packages/nauro-core/src/nauro_core/protocol.py
@@ -29,9 +29,8 @@ CHECK_DECISION_RETURNS = (
 )
 
 GET_DECISION_BEFORE_PROPOSING = (
-    "When related decisions appear, call `get_decision` on each before "
-    "proposing: `mode=header` to triage and `mode=full` for those you reason "
-    "about."
+    "Related hits carry their triage headers inline; before proposing, call "
+    "`get_decision` (`mode=full`) on each decision you reason about."
 )
 
 PROPOSE_DECISION_OPERATIONS = (

--- a/packages/nauro-core/src/nauro_core/renderers.py
+++ b/packages/nauro-core/src/nauro_core/renderers.py
@@ -12,9 +12,11 @@ would. They must not mutate the input dict.
 Per-tool surface area:
 
 * ``check_decision`` — a single honest lead line (count + call-to-action +
-  lexical-rank caveat), then the hit list: top hit with rationale preview +
-  lower hits as a short list. The agent-facing call-to-action in the lead
-  comes from the upstream ``assessment`` field.
+  lexical-rank caveat), then a header-equivalent triage block per hit:
+  label/status/score line, untruncated title, date + type + confidence
+  line, supersession refs when present, and the rationale lede as a
+  wrapped paragraph. The agent-facing call-to-action in the lead comes
+  from the upstream ``assessment`` field.
 * ``get_decision`` — light header on top of the markdown body the kernel
   already returns.
 * ``search_decisions`` — query echo, then a ranked short list of hits
@@ -33,6 +35,8 @@ Per-tool surface area:
 """
 
 from __future__ import annotations
+
+import textwrap
 
 from nauro_core.constants import LEXICAL_RANK_CAVEAT, NO_RELATED_DECISIONS
 from nauro_core.parsing import _decision_label
@@ -119,7 +123,7 @@ def render_check_decision(result: dict) -> str:
 
     Empty-store and zero-hit assessments flow through unchanged. The
     rendered list pulls structure from ``related_decisions`` so the
-    top-match marker and rationale preview render even when an upstream
+    top-match marker and triage headers render even when an upstream
     assessment-string edit drifts.
     """
     if guidance := _connection_guidance(result):
@@ -145,7 +149,7 @@ def render_check_decision(result: dict) -> str:
     # generic prompt.
     cta = (
         _extract_call_to_action(assessment)
-        or "Call get_decision on each related decision before proposing."
+        or "Call get_decision (mode=full) on each decision you reason about before proposing."
     )
     lead = (
         f"{count} related {'decision' if count == 1 else 'decisions'}. {cta} {LEXICAL_RANK_CAVEAT}"
@@ -154,24 +158,66 @@ def render_check_decision(result: dict) -> str:
     lines.append("")
 
     for idx, hit in enumerate(related):
-        label = _id_to_label(hit.get("id", ""))
-        status = hit.get("status", "")
-        score = hit.get("score", 0.0)
-        title = hit.get("title", "") or "(no title)"
-        is_top = idx == 0
-        score_str = f"BM25 {score:5.2f}" if isinstance(score, (int, float)) else "BM25 ?"
-        marker = "    <- top match" if is_top else ""
-        header = f"  - {label}  [{status}]  {score_str}{marker}"
-        lines.append(header)
-        lines.append(f"    {_truncate(title, _TITLE_BUDGET)}")
-        if is_top:
-            preview = (hit.get("rationale_preview") or "").strip()
-            if preview:
-                preview_line = _truncate(preview.replace("\n", " "), _WIDTH - 6)
-                lines.append(f'    "{preview_line}"')
+        lines.extend(_check_hit_block(hit, is_top=idx == 0))
         lines.append("")
 
     return "\n".join(lines).rstrip()
+
+
+def _check_hit_block(hit: dict, *, is_top: bool) -> list[str]:
+    """Render one hit as a header-equivalent triage block.
+
+    Layout mirrors ``get_decision``'s header mode so the inline hit is a
+    full substitute for a ``mode=header`` follow-up call: label/status/
+    score line, the untruncated title (deliberately exempt from the
+    tabular ``_TITLE_BUDGET`` — parity with the header projection requires
+    the whole title), the date/type/confidence line, supersession refs
+    only when present, and the rationale lede as a wrapped paragraph.
+    """
+    label = _id_to_label(hit.get("id", ""))
+    status = hit.get("status", "")
+    score = hit.get("score", 0.0)
+    title = hit.get("title", "") or "(no title)"
+    score_str = f"BM25 {score:5.2f}" if isinstance(score, (int, float)) else "BM25 ?"
+    marker = "    <- top match" if is_top else ""
+
+    lines = [f"  - {label}  [{status}]  {score_str}{marker}", f"    {title}"]
+
+    triage_parts = [
+        f"{prefix} {value}"
+        for prefix, value in (
+            ("decided", hit.get("date", "")),
+            ("type", hit.get("decision_type", "")),
+            ("confidence", hit.get("confidence", "")),
+        )
+        if value
+    ]
+    if triage_parts:
+        lines.append(f"    {'  '.join(triage_parts)}")
+
+    supersession_parts = [
+        f"{prefix} {value}"
+        for prefix, value in (
+            ("supersedes", hit.get("supersedes", "")),
+            ("superseded_by", hit.get("superseded_by", "")),
+        )
+        if value
+    ]
+    if supersession_parts:
+        lines.append(f"    {'  '.join(supersession_parts)}")
+
+    preview = (hit.get("rationale_preview") or "").strip()
+    if preview:
+        # Keep paths and long identifiers intact: never split inside a word
+        # or at a hyphen, even when that costs an overlong line.
+        wrapped = textwrap.wrap(
+            preview.replace("\n", " "),
+            _WIDTH - 4,
+            break_long_words=False,
+            break_on_hyphens=False,
+        )
+        lines.extend(f"    {segment}" for segment in wrapped)
+    return lines
 
 
 def _extract_call_to_action(assessment: str) -> str:

--- a/packages/nauro-core/tests/operations/test_check_decision.py
+++ b/packages/nauro-core/tests/operations/test_check_decision.py
@@ -88,6 +88,16 @@ def test_related_decision_canonical_id_and_status_enrichment() -> None:
     assert hit.date == "2026-04-16"
     assert hit.score > 0.0
     assert "PostgreSQL" in hit.rationale_preview
+    # Inline triage headers: the hit carries the same fields header mode
+    # projects. The seed's confidence default is medium; unset frontmatter
+    # stays None and drops out of exclude_none dumps.
+    assert hit.confidence == "medium"
+    assert hit.decision_type is None
+    assert hit.supersedes is None
+    assert hit.superseded_by is None
+    dumped = hit.model_dump(mode="json", exclude_none=True)
+    assert "decision_type" not in dumped
+    assert "superseded_by" not in dumped
 
 
 def test_assessment_single_match_directs_to_get_decision() -> None:
@@ -98,7 +108,8 @@ def test_assessment_single_match_directs_to_get_decision() -> None:
     assert result.error is None
     assert "Top match: D007" in result.assessment
     assert LEXICAL_RANK_CAVEAT in result.assessment
-    assert "Call get_decision(7) before proposing." in result.assessment
+    assert "Its triage header is inline." in result.assessment
+    assert "Call get_decision(7) (mode=full) before proposing." in result.assessment
 
 
 def test_assessment_multi_match_directs_to_each() -> None:
@@ -111,7 +122,11 @@ def test_assessment_multi_match_directs_to_each() -> None:
     assert len(result.related_decisions) >= 2
     assert "Found" in result.assessment
     assert LEXICAL_RANK_CAVEAT in result.assessment
-    assert "Call get_decision on each related decision before proposing." in result.assessment
+    assert "Triage headers are inline." in result.assessment
+    assert (
+        "Call get_decision (mode=full) on each decision you reason about before proposing."
+        in result.assessment
+    )
 
 
 def test_superseded_decisions_are_excluded_from_hits() -> None:

--- a/packages/nauro-core/tests/operations/test_get_decision.py
+++ b/packages/nauro-core/tests/operations/test_get_decision.py
@@ -24,7 +24,7 @@ from nauro_core.operations import (
     InMemoryStore,
     get_decision,
 )
-from nauro_core.operations.get_decision import _LEDE_MAX_CHARS
+from nauro_core.operations.related_hits import LEDE_MAX_CHARS
 
 
 def test_returns_result_type() -> None:
@@ -224,12 +224,12 @@ def test_header_lede_truncates_at_boundary() -> None:
 
     lede = header.rsplit("\n\n", 1)[-1]
     assert lede.endswith("…")
-    assert len(lede) <= _LEDE_MAX_CHARS
+    assert len(lede) <= LEDE_MAX_CHARS
 
 
 def test_header_just_under_budget_is_not_truncated() -> None:
     """A first paragraph exactly at the budget keeps its final character."""
-    para = "x" * _LEDE_MAX_CHARS
+    para = "x" * LEDE_MAX_CHARS
     stem, body = _full_decision(100, "At budget", para)
     store = _store_with((stem, body))
     header = get_decision(store, 100, mode="header").content

--- a/packages/nauro-core/tests/operations/test_related_hits.py
+++ b/packages/nauro-core/tests/operations/test_related_hits.py
@@ -1,0 +1,160 @@
+"""Kernel tests for the shared triage projection in ``operations.related_hits``.
+
+The module is the single hit-lifting path behind ``check_decision`` and
+``propose_decision`` and owns the lede/frontmatter primitives that
+``get_decision``'s header mode shares. These tests pin the enrichment
+contract at the helper level; each operation's own suite covers the
+call-site wiring.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+from conftest import _seed_decision, _store_with, make_decision
+
+from nauro_core.decision_model import (
+    Decision,
+    DecisionConfidence,
+    DecisionStatus,
+    DecisionType,
+)
+from nauro_core.operations import check_decision, propose_decision
+from nauro_core.operations.related_hits import (
+    LEDE_MAX_CHARS,
+    decision_lede,
+    to_related_decisions,
+)
+
+
+def _decision(**overrides) -> Decision:
+    defaults = dict(
+        date=date(2026, 4, 16),
+        confidence=DecisionConfidence.high,
+        status=DecisionStatus.active,
+        decision_type=DecisionType.architecture,
+        supersedes="7",
+        num=42,
+        title="Adopt PostgreSQL",
+        rationale="ACID semantics for the platform.",
+    )
+    defaults.update(overrides)
+    return Decision(**defaults)
+
+
+def _hit(num: int = 42, **overrides) -> dict:
+    defaults = dict(
+        number=num,
+        title="Adopt PostgreSQL",
+        similarity=3.5,
+        rationale_preview="raw hit preview",
+    )
+    defaults.update(overrides)
+    return defaults
+
+
+def test_lift_enriches_triage_fields_from_parsed_decision() -> None:
+    [related] = to_related_decisions([_hit()], [_decision()])
+    assert related.id == "decision-042"
+    assert related.score == 3.5
+    assert related.status == "active"
+    assert related.date == "2026-04-16"
+    assert related.decision_type == "architecture"
+    assert related.confidence == "high"
+    assert related.supersedes == "7"
+    assert related.superseded_by is None
+
+
+def test_lift_preview_is_the_header_lede_not_the_raw_hit_preview() -> None:
+    """The preview carries the same first-paragraph lede the header mode
+    projects, so the inline hit substitutes for a ``mode=header`` call."""
+    rationale = "Lead paragraph carries the decision.\n\nSecond paragraph is detail."
+    [related] = to_related_decisions([_hit()], [_decision(rationale=rationale)])
+    assert related.rationale_preview == "Lead paragraph carries the decision."
+    assert related.rationale_preview == decision_lede(rationale)
+
+
+def test_lift_lede_truncates_at_shared_budget() -> None:
+    rationale = "y" * (LEDE_MAX_CHARS + 100)
+    [related] = to_related_decisions([_hit()], [_decision(rationale=rationale)])
+    assert len(related.rationale_preview) <= LEDE_MAX_CHARS
+    assert related.rationale_preview.endswith("…")
+    assert related.rationale_preview == decision_lede(rationale)
+
+
+def test_lift_unset_optionals_stay_none_and_drop_on_exclude_none() -> None:
+    plain = _decision(decision_type=None, supersedes=None)
+    [related] = to_related_decisions([_hit()], [plain])
+    dumped = related.model_dump(mode="json", exclude_none=True)
+    assert "decision_type" not in dumped
+    assert "supersedes" not in dumped
+    assert "superseded_by" not in dumped
+    assert dumped["confidence"] == "high"
+
+
+def test_lift_missing_decision_falls_back_to_raw_preview_and_none_fields() -> None:
+    """Defensive miss (hit without a parsed decision, e.g. a backend racing
+    a delete against enumeration): keep the raw hit preview, leave every
+    enrichment field unset."""
+    [related] = to_related_decisions([_hit(num=999)], [_decision()])
+    assert related.id == "decision-999"
+    assert related.status == "active"
+    assert related.date == ""
+    assert related.rationale_preview == "raw hit preview"
+    assert related.decision_type is None
+    assert related.confidence is None
+    assert related.supersedes is None
+    assert related.superseded_by is None
+
+
+def test_lift_embedding_hit_without_similarity_scores_zero() -> None:
+    [related] = to_related_decisions([_hit(similarity=None)], [_decision()])
+    assert related.score == 0.0
+
+
+def test_check_and_propose_call_sites_produce_identical_hit_shape() -> None:
+    """Both operations lift through the shared helper: the same underlying
+    decision surfaces with identical fields (score excepted — the two
+    retrieval queries differ by construction)."""
+    seed = _seed_decision(
+        1,
+        "Adopt PostgreSQL primary database",
+        "Mature ecosystem with strong JSON support and excellent tooling.",
+        confidence=DecisionConfidence.high,
+        decision_type=DecisionType.architecture,
+        decision_date=date(2026, 4, 16),
+    )
+
+    check_result = check_decision(
+        _store_with(seed), "Use PostgreSQL for the primary database layer"
+    )
+    propose_result = propose_decision(
+        _store_with(seed),
+        title="Use PostgreSQL for the data layer",
+        rationale="Better JSON handling than alternatives for our application data.",
+        confidence="medium",
+    )
+
+    check_hits = {h.id: h for h in check_result.related_decisions}
+    propose_hits = {h.id: h for h in propose_result.similar_decisions}
+    assert "decision-001" in check_hits
+    assert "decision-001" in propose_hits
+
+    check_dump = check_hits["decision-001"].model_dump(mode="json", exclude_none=True)
+    propose_dump = propose_hits["decision-001"].model_dump(mode="json", exclude_none=True)
+    assert check_dump.keys() == propose_dump.keys()
+    check_dump.pop("score")
+    propose_dump.pop("score")
+    assert check_dump == propose_dump
+    assert check_dump["decision_type"] == "architecture"
+    assert check_dump["confidence"] == "high"
+
+
+def test_make_decision_helper_supersedes_field_flows_through() -> None:
+    """An active decision that supersedes an older one carries the ref;
+    ``superseded_by`` stays absent on active hits."""
+    superseding = make_decision(3, "Adopt gRPC", "Replace REST on the internal mesh.")
+    superseding = superseding.model_copy(update={"supersedes": "2"})
+    [related] = to_related_decisions([_hit(num=3, title="Adopt gRPC")], [superseding])
+    assert related.supersedes == "2"
+    assert related.superseded_by is None

--- a/packages/nauro-core/tests/operations/test_results.py
+++ b/packages/nauro-core/tests/operations/test_results.py
@@ -30,7 +30,7 @@ def test_related_decision_model_dump_shape() -> None:
         date="2026-01-01",
         rationale_preview="ACID compliance trumps document flexibility for this workload.",
     )
-    dumped = hit.model_dump(mode="json")
+    dumped = hit.model_dump(mode="json", exclude_none=True)
     assert dumped == {
         "id": "decision-042",
         "title": "Use Postgres",
@@ -39,6 +39,26 @@ def test_related_decision_model_dump_shape() -> None:
         "date": "2026-01-01",
         "rationale_preview": "ACID compliance trumps document flexibility for this workload.",
     }
+
+
+def test_related_decision_triage_fields_serialize_when_set() -> None:
+    hit = RelatedDecision(
+        id="decision-042",
+        title="Use Postgres",
+        score=1.5,
+        status="active",
+        date="2026-01-01",
+        rationale_preview="ACID compliance.",
+        decision_type="architecture",
+        confidence="high",
+        supersedes="7",
+        superseded_by="99",
+    )
+    dumped = hit.model_dump(mode="json", exclude_none=True)
+    assert dumped["decision_type"] == "architecture"
+    assert dumped["confidence"] == "high"
+    assert dumped["supersedes"] == "7"
+    assert dumped["superseded_by"] == "99"
 
 
 def test_related_decision_rejects_unknown_fields() -> None:

--- a/packages/nauro-core/tests/test_constants.py
+++ b/packages/nauro-core/tests/test_constants.py
@@ -181,15 +181,14 @@ class TestMcpInstructions:
         remote = build_remote_instructions(MCP_INSTRUCTIONS_STATIC, [])
         assert remote.endswith(MCP_INSTRUCTIONS)
 
-    def test_header_first_hydration_fragment_present_and_bounded(self) -> None:
-        """The reworded hydration sentence is spliced into the static block
-        and stays compact. The leading fetch mandate must precede the
-        mode guidance so the sentence cannot read as "skip fetching"."""
+    def test_inline_header_fragment_present_and_bounded(self) -> None:
+        """The inline-header sentence is spliced into the static block and
+        stays compact. Hits carry their triage headers inline, so the only
+        follow-up read the static block directs is the full body."""
         assert GET_DECISION_BEFORE_PROPOSING in MCP_INSTRUCTIONS_STATIC
-        assert "`mode=header`" in MCP_INSTRUCTIONS_STATIC
-        assert GET_DECISION_BEFORE_PROPOSING.index("before proposing") < (
-            GET_DECISION_BEFORE_PROPOSING.index("`mode=header`")
-        )
+        assert "inline" in MCP_INSTRUCTIONS_STATIC
+        assert "`mode=full`" in MCP_INSTRUCTIONS_STATIC
+        assert "`mode=header`" not in MCP_INSTRUCTIONS_STATIC
         # The reword must not exceed the original sentence's length, so the
         # static block holds at or below its pre-change ceiling.
         assert len(GET_DECISION_BEFORE_PROPOSING) <= 200

--- a/packages/nauro-core/tests/test_protocol.py
+++ b/packages/nauro-core/tests/test_protocol.py
@@ -67,16 +67,14 @@ class TestFragmentAnchors:
 
     def test_get_decision_before_proposing_says_before_proposing(self) -> None:
         assert "`get_decision`" in GET_DECISION_BEFORE_PROPOSING
-        # The fetch mandate stays the leading clause so the fragment cannot
+        # The fetch mandate must survive rewording so the fragment cannot
         # read as "you may skip fetching" — the check-before-propose gate.
         assert "before proposing" in GET_DECISION_BEFORE_PROPOSING
-        assert GET_DECISION_BEFORE_PROPOSING.index("on each before proposing") < (
-            GET_DECISION_BEFORE_PROPOSING.index("`mode=header`")
-        )
-        # Header-first selective hydration: triage on header, hydrate the
-        # ones worth reasoning about on full.
-        assert "`mode=header`" in GET_DECISION_BEFORE_PROPOSING
+        # Inline-header triage: hits carry their headers, so the only
+        # follow-up read the fragment directs is the full body.
+        assert "inline" in GET_DECISION_BEFORE_PROPOSING
         assert "`mode=full`" in GET_DECISION_BEFORE_PROPOSING
+        assert "`mode=header`" not in GET_DECISION_BEFORE_PROPOSING
 
     def test_propose_decision_operations_names_all_three_and_metadata_rule(self) -> None:
         for op in ("add", "update", "supersede"):

--- a/packages/nauro-core/tests/test_renderers.py
+++ b/packages/nauro-core/tests/test_renderers.py
@@ -64,12 +64,14 @@ class TestRenderCheckDecision:
                     "status": "active",
                     "date": "2026-05-10",
                     "rationale_preview": "Planner cache_control set to ttl: 1h.",
+                    "confidence": "high",
                 }
             ],
             "assessment": (
                 'Top match: D145 "Adopt 1-hour prompt cache tier for planner" '
                 "(status active, decided 2026-05-10, BM25 19.1). "
-                "Call get_decision(145) before proposing."
+                "Its triage header is inline. "
+                "Call get_decision(145) (mode=full) before proposing."
             ),
         }
         text = render_check_decision(result)
@@ -78,6 +80,9 @@ class TestRenderCheckDecision:
         assert "19.07" in text or "19.1" in text
         assert "Adopt 1-hour prompt cache tier" in text
         assert "Planner cache_control" in text
+        # The triage line carries the header fields the hit provides.
+        assert "decided 2026-05-10" in text
+        assert "confidence high" in text
         # Lead-line call-to-action must mention get_decision
         assert "get_decision" in text
 
@@ -120,7 +125,8 @@ class TestRenderCheckDecision:
                 "Found 3 related decisions. "
                 'Top match: D145 "Adopt 1-hour prompt cache tier for planner" '
                 "(status active, decided 2026-05-10, BM25 19.1). "
-                "Call get_decision on each related decision before proposing."
+                "Triage headers are inline. Call get_decision (mode=full) on "
+                "each decision you reason about before proposing."
             ),
         }
         text = render_check_decision(result)
@@ -135,10 +141,11 @@ class TestRenderCheckDecision:
         assert "Adopt 1-hour prompt cache tier" in text
         assert "Prompt cache strategy" in text
         assert "Retire monolithic-agent mode" in text
-        # Top hit shows rationale preview; lower hits do not
+        # Every hit renders its rationale lede — the inline triage block
+        # replaces the old top-hit-only preview.
         assert "Pareto sets the planner" in text
-        assert "Cache per role" not in text
-        assert "Modes go away" not in text
+        assert "Cache per role" in text
+        assert "Modes go away" in text
         # Lead-line call-to-action mentions get_decision
         assert "get_decision" in text
 
@@ -170,7 +177,8 @@ class TestRenderCheckDecision:
                 "Found 2 related decisions. "
                 'Top match: D145 "Adopt 1-hour prompt cache tier for planner" '
                 "(status active, decided 2026-05-10, BM25 19.1). "
-                "Call get_decision on each related decision before proposing."
+                "Triage headers are inline. Call get_decision (mode=full) on "
+                "each decision you reason about before proposing."
             ),
         }
         text = render_check_decision(result)
@@ -181,7 +189,10 @@ class TestRenderCheckDecision:
         # The lexical-rank caveat now reaches the rendered surface.
         assert LEXICAL_RANK_CAVEAT in text
 
-    def test_long_title_does_not_blow_up(self):
+    def test_long_title_renders_untruncated(self):
+        """check_decision hits are header-equivalent: the title renders in
+        full, exempt from the tabular _TITLE_BUDGET truncation that
+        list_decisions / search_decisions keep."""
         long_title = "x" * 200
         result = {
             "store": "remote",
@@ -198,8 +209,8 @@ class TestRenderCheckDecision:
             "assessment": "...",
         }
         text = render_check_decision(result)
-        # Renderer must not crash; the title should appear in some form.
         assert "D001" in text
+        assert long_title in text
 
     def test_unicode_in_title(self):
         result = {
@@ -243,6 +254,170 @@ class TestRenderCheckDecision:
         text = render_check_decision(result)
         assert text.startswith("Error:")
         assert "Proposed approach exceeds" in text
+
+    def test_lead_extracts_cta_from_reworded_assessment(self):
+        """_extract_call_to_action keys off the literal "Call " prefix; the
+        inline-header rewording keeps a trailing "Call ..." sentence, so the
+        lead line carries the kernel CTA instead of the renderer fallback."""
+        from nauro_core.renderers import _extract_call_to_action
+
+        assessment = (
+            "Found 2 related decisions. "
+            'Top match: D010 "First" (status active, decided 2026-05-10, BM25 9.0). '
+            f"{LEXICAL_RANK_CAVEAT} "
+            "Triage headers are inline. Call get_decision (mode=full) on each "
+            "decision you reason about before proposing."
+        )
+        assert _extract_call_to_action(assessment) == (
+            "Call get_decision (mode=full) on each decision you reason about before proposing."
+        )
+
+    def test_every_hit_renders_a_triage_block(self):
+        """Each hit carries its own header-equivalent block: date/type/
+        confidence line and the rationale lede, not just the top hit."""
+        result = {
+            "store": "remote",
+            "related_decisions": [
+                {
+                    "id": "decision-010",
+                    "title": "First",
+                    "score": 9.0,
+                    "status": "active",
+                    "date": "2026-05-10",
+                    "rationale_preview": "First lede paragraph.",
+                    "decision_type": "architecture",
+                    "confidence": "high",
+                },
+                {
+                    "id": "decision-011",
+                    "title": "Second",
+                    "score": 4.0,
+                    "status": "active",
+                    "date": "2026-06-01",
+                    "rationale_preview": "Second lede paragraph.",
+                    "confidence": "medium",
+                },
+            ],
+            "assessment": "...",
+        }
+        text = render_check_decision(result)
+        assert "decided 2026-05-10  type architecture  confidence high" in text
+        assert "decided 2026-06-01  confidence medium" in text
+        assert "First lede paragraph." in text
+        assert "Second lede paragraph." in text
+
+    def test_supersession_line_only_when_present(self):
+        result = {
+            "store": "remote",
+            "related_decisions": [
+                {
+                    "id": "decision-010",
+                    "title": "Superseding",
+                    "score": 9.0,
+                    "status": "active",
+                    "date": "2026-05-10",
+                    "rationale_preview": "Lede.",
+                    "supersedes": "7",
+                },
+                {
+                    "id": "decision-011",
+                    "title": "Plain",
+                    "score": 4.0,
+                    "status": "active",
+                    "date": "2026-06-01",
+                    "rationale_preview": "Lede.",
+                },
+            ],
+            "assessment": "...",
+        }
+        text = render_check_decision(result)
+        assert text.count("supersedes 7") == 1
+        assert "superseded_by" not in text
+
+    def test_long_lede_wraps_untruncated(self):
+        """A full 300-char lede renders whole as a wrapped paragraph — no
+        single-line truncation, no dropped characters."""
+        lede = ("word " * 70).strip()[:299] + "z"
+        assert len(lede) == 300
+        result = {
+            "store": "remote",
+            "related_decisions": [
+                {
+                    "id": "decision-010",
+                    "title": "Long lede",
+                    "score": 9.0,
+                    "status": "active",
+                    "date": "2026-05-10",
+                    "rationale_preview": lede,
+                }
+            ],
+            "assessment": "...",
+        }
+        text = render_check_decision(result)
+        hit_lines = [ln.strip() for ln in text.splitlines() if ln.startswith("    ")]
+        # Drop the title line, rejoin the wrapped lede lines.
+        assert hit_lines[0] == "Long lede"
+        rejoined = " ".join(hit_lines[2:])
+        assert rejoined == lede
+        # Wrapped lede lines respect the 80-column render width.
+        assert all(len(ln) <= 80 for ln in text.splitlines() if ln.startswith("    "))
+
+    def test_empty_lede_omits_paragraph(self):
+        """Empty-lede omission parity with header mode: a hit whose lede is
+        empty renders no lede block at all."""
+        result = {
+            "store": "remote",
+            "related_decisions": [
+                {
+                    "id": "decision-010",
+                    "title": "No lede",
+                    "score": 9.0,
+                    "status": "active",
+                    "date": "2026-05-10",
+                    "rationale_preview": "",
+                }
+            ],
+            "assessment": "...",
+        }
+        text = render_check_decision(result)
+        lines = text.splitlines()
+        hit_lines = [ln for ln in lines if ln.startswith("    ")]
+        assert hit_lines == ["    No lede", "    decided 2026-05-10"]
+
+    def test_hit_title_matches_header_mode_title_bytes(self):
+        """A >70-char title renders byte-identical to the title header mode
+        projects for the same decision — the inline block is a full
+        substitute for a mode=header follow-up."""
+        from datetime import date as _date
+
+        from conftest import _seed_decision, _store_with
+
+        from nauro_core.operations import check_decision, get_decision
+
+        long_title = (
+            "Adopt a very long deliberately verbose decision title that exceeds the budget"
+        )
+        assert len(long_title) > 70
+        store = _store_with(
+            _seed_decision(
+                42,
+                long_title,
+                "Verbose deliberately long budget decision rationale.",
+                decision_date=_date(2026, 5, 10),
+            ),
+        )
+        header = get_decision(store, 42, mode="header").content
+        assert header is not None
+        header_title = header.split("# 042 — ", 1)[1].split("\n", 1)[0]
+
+        check_result = check_decision(store, "Adopt a deliberately verbose decision title")
+        envelope = {
+            "store": "local",
+            **check_result.model_dump(mode="json", exclude_none=True),
+        }
+        text = render_check_decision(envelope)
+        assert f"    {header_title}" in text.splitlines()
+        assert header_title == long_title
 
 
 class TestRenderGetDecision:

--- a/packages/nauro/src/nauro/agents/nauro-planner.md
+++ b/packages/nauro/src/nauro/agents/nauro-planner.md
@@ -18,7 +18,7 @@ Every decision proposal uses the same approval rule for all three operations: `a
     Call `check_decision` with the proposed approach. Classify the response:
 
     - **GREEN** — no related decisions, or the related decisions are clearly off-topic once you read the titles and the assessment string. Spot-check the top one or two hits via `get_decision` to confirm, then proceed.
-    - **AMBER** — related decisions appear adjacent (touch the same surface area, name the same dependency, or share keywords with the proposed change) but don't directly contradict it. `get_decision` on every related decision; spot-check adjacent contested areas via `search_decisions` for terms not in the original query. The plan must name which decisions inform the approach.
+    - **AMBER** — related decisions appear adjacent (touch the same surface area, name the same dependency, or share keywords with the proposed change) but don't directly contradict it. Triage the inline headers, then `get_decision` in full on every decision that informs the plan; spot-check adjacent contested areas via `search_decisions` for terms not in the original query. The plan must name which decisions inform the approach.
     - **RED** — at least one related decision *directly contradicts* the proposed change, OR the proposal would supersede an active decision. `get_decision` on every related decision is mandatory and must be read in full — the assessment string does not judge for you.
 
     The verdict goes in the plan as a one-line header before "Why" — the verdict word plus a comma-separated list of the decision numbers it touches. The reader sees the doctrine cost upfront.

--- a/packages/nauro/src/nauro/agents/nauro-tech-lead.md
+++ b/packages/nauro/src/nauro/agents/nauro-tech-lead.md
@@ -48,7 +48,7 @@ Sequencing: the rendered proposal is the final text of the turn, the turn ends w
 **Mode A: Direction-setting (pre-work consult).** A planner or the human is about to start substantive architectural work. The caller passes a description of the proposed change.
 
 1. `check_decision` with the proposed change.
-2. `get_decision` on every related result. Do not act on the assessment string alone; the body has the rationale and supersession state.
+2. `get_decision` on every related result. Do not act on the assessment string alone: the body has the full rationale and rejected alternatives.
 3. Cross-reference adjacent surface area via `search_decisions` if the change touches a known contested area.
 4. Return verdict: GREEN (no doctrine concern, proceed), AMBER (proceed with the listed constraints), RED (contradicts active doctrine — redirect or supersede first).
 5. If the direction establishes new doctrine or changes existing doctrine, draft the complete `add`, `update`, or `supersede` payload and route it through the approval channel above. Call `propose_decision` only after explicit approval of that exact draft. The kernel commits immediately on Tier 1 clean.

--- a/packages/nauro/src/nauro/skills/adopt_body.md
+++ b/packages/nauro/src/nauro/skills/adopt_body.md
@@ -40,7 +40,7 @@ Per card, the agent prepares:
 
 ### Step 0.2: Pre-check and classify each card
 
-Before presenting the batch, the agent runs Step 7 steps 1–3 for each card: call `check_decision(proposed_approach=<title plus the one-line summary>, project_id=...)` **once per card**, read every related decision, classify the operation, and prepare the complete operation-specific proposal. Annotate each card with the related decisions and assessment from the pre-pass. Doing this up front lets the batch show the exact proposed write and any overlap before confirmation.
+Before presenting the batch, the agent runs Step 7 steps 1–3 for each card: call `check_decision(proposed_approach=<title plus the one-line summary>, project_id=...)` **once per card**, triage the inline headers, read in full the decisions that bear on the card, classify the operation, and prepare the complete operation-specific proposal. Annotate each card with the related decisions and assessment from the pre-pass. Doing this up front lets the batch show the exact proposed write and any overlap before confirmation.
 
 ### Step 0.3 — One batch confirm
 

--- a/packages/nauro/src/nauro/skills/ship_task_body.md
+++ b/packages/nauro/src/nauro/skills/ship_task_body.md
@@ -27,7 +27,7 @@ Before invoking `@nauro-planner`, the parent session confirms the planner will r
 
 ### 1. Plan
 
-Invoke the `@nauro-planner` subagent with the task description. The planner runs `check_decision` against the proposed approach, classifies as GREEN / AMBER / RED, reads related decision bodies via `get_decision`, investigates the code, and returns a plan in the plan shape (Why / Approach / What changes / What's deferred / Test plan), plus the verdict line and any complete decision draft awaiting approval.
+Invoke the `@nauro-planner` subagent with the task description. The planner runs `check_decision` against the proposed approach, classifies as GREEN / AMBER / RED, triages the inline headers, reads the decisions that inform the approach via `get_decision`, investigates the code, and returns a plan in the plan shape (Why / Approach / What changes / What's deferred / Test plan), plus the verdict line and any complete decision draft awaiting approval.
 
 If the planner returns RED with a supersede draft, the chain pauses here. Surface the complete draft to the user: paste the planner's complete rendered proposal exactly as returned, no reserialization to JSON, no abbreviation, no pointer to output above, immediately before the approval ask. Only on explicit user approval does the parent re-invoke the planner with that approval to file the exact draft. An explicit "override RED on the cited decision, proceed" may continue without filing, but it is not approval to call `propose_decision`.
 

--- a/packages/nauro/src/nauro/templates/agents_md.py
+++ b/packages/nauro/src/nauro/templates/agents_md.py
@@ -46,8 +46,9 @@ PROTOCOL_DIGEST = (
     "Before responding to any technical change request - architecture, "
     "library choice, API design, data model, infrastructure, a vendor swap - "
     "call `check_decision` with the proposal, even when you intend to push "
-    "back or refuse. It surfaces related decisions without judging conflicts; "
-    "read them with `get_decision` before proposing.\n"
+    "back or refuse. It surfaces related decisions with their triage headers "
+    "inline, without judging conflicts; before proposing, read the ones you "
+    "reason about in full with `get_decision`.\n"
     "\n"
     f"{_APPROVAL_BEFORE_PROPOSE}\n"
 )

--- a/packages/nauro/tests/cross_surface/test_check_decision_cross_surface.py
+++ b/packages/nauro/tests/cross_surface/test_check_decision_cross_surface.py
@@ -119,6 +119,29 @@ def test_active_decision_surfaces_in_both_stores(both_stores):
         assert "decision-002" not in ids
 
 
+def test_enriched_triage_keys_match_across_stores(both_stores):
+    """The inline triage-header enrichment serializes with identical key sets
+    from both surfaces, and ``superseded_by`` stays absent on active hits
+    (unset fields drop under ``exclude_none``)."""
+    fs_store, cloud = both_stores
+
+    fs_result = check_decision(fs_store, PROPOSED_APPROACH)
+    cloud_result = check_decision(cloud, PROPOSED_APPROACH)
+
+    fs_hits = {hit.id: hit for hit in fs_result.related_decisions}
+    cloud_hits = {hit.id: hit for hit in cloud_result.related_decisions}
+    assert fs_hits.keys() == cloud_hits.keys()
+
+    for hit_id, fs_hit in fs_hits.items():
+        fs_dump = fs_hit.model_dump(mode="json", exclude_none=True)
+        cloud_dump = cloud_hits[hit_id].model_dump(mode="json", exclude_none=True)
+        assert fs_dump.keys() == cloud_dump.keys()
+        assert fs_dump == cloud_dump
+        # Every seeded hit is active: no superseded_by key may serialize.
+        assert "superseded_by" not in fs_dump
+        assert fs_dump["confidence"] == "high"
+
+
 def test_rejection_envelope_matches_across_stores(both_stores):
     """Over-length inputs produce the same ``error`` payload from each surface."""
     from nauro_core.constants import MAX_APPROACH_LENGTH

--- a/packages/nauro/tests/snapshots/check_decision_schema.json
+++ b/packages/nauro/tests/snapshots/check_decision_schema.json
@@ -39,11 +39,35 @@
       },
       "RelatedDecision": {
         "additionalProperties": false,
-        "description": "A decision surfaced by retrieval as related to a proposed approach.\n\nThe canonical retrieval-hit shape: enriched with status/date and a\nrationale preview so any transport can render the same hit without\nre-fetching the underlying decision body.",
+        "description": "A decision surfaced by retrieval as related to a proposed approach.\n\nThe canonical retrieval-hit shape: enriched with the triage-header\nfields (status, date, type, confidence, supersession refs) and a\nrationale lede so any transport can render the same hit without\nre-fetching the underlying decision body.\n\n``decision_type``, ``confidence``, ``supersedes``, and\n``superseded_by`` stay optional so hits whose decision omits those\nfrontmatter fields still serialize; the adapter's ``exclude_none=True``\ntemplate choice drops the keys when they are unset (the\n:class:`DecisionSummary`/:class:`SearchHit` key-omission contract).",
         "properties": {
+          "confidence": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Confidence"
+          },
           "date": {
             "title": "Date",
             "type": "string"
+          },
+          "decision_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Decision Type"
           },
           "id": {
             "title": "Id",
@@ -60,6 +84,30 @@
           "status": {
             "title": "Status",
             "type": "string"
+          },
+          "superseded_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Superseded By"
+          },
+          "supersedes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Supersedes"
           },
           "title": {
             "title": "Title",
@@ -110,11 +158,35 @@
   },
   "RelatedDecision": {
     "additionalProperties": false,
-    "description": "A decision surfaced by retrieval as related to a proposed approach.\n\nThe canonical retrieval-hit shape: enriched with status/date and a\nrationale preview so any transport can render the same hit without\nre-fetching the underlying decision body.",
+    "description": "A decision surfaced by retrieval as related to a proposed approach.\n\nThe canonical retrieval-hit shape: enriched with the triage-header\nfields (status, date, type, confidence, supersession refs) and a\nrationale lede so any transport can render the same hit without\nre-fetching the underlying decision body.\n\n``decision_type``, ``confidence``, ``supersedes``, and\n``superseded_by`` stay optional so hits whose decision omits those\nfrontmatter fields still serialize; the adapter's ``exclude_none=True``\ntemplate choice drops the keys when they are unset (the\n:class:`DecisionSummary`/:class:`SearchHit` key-omission contract).",
     "properties": {
+      "confidence": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Confidence"
+      },
       "date": {
         "title": "Date",
         "type": "string"
+      },
+      "decision_type": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Decision Type"
       },
       "id": {
         "title": "Id",
@@ -131,6 +203,30 @@
       "status": {
         "title": "Status",
         "type": "string"
+      },
+      "superseded_by": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Superseded By"
+      },
+      "supersedes": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Supersedes"
       },
       "title": {
         "title": "Title",


### PR DESCRIPTION
## Why

Acting on a check_decision response used to cost one get_decision
mode=header round trip per hit before an agent could decide what to read
in full. The kernel already holds the parsed decisions when it lifts the
retrieval hits, so the triage headers can ride on the hits themselves and
the only follow-up read left is the full body of the decisions the agent
actually reasons about.

## What changed

- Related hits carry the triage-header fields inline: type, confidence,
  and supersession refs join the hit shape as optional fields that drop
  from the envelope when unset, and the rationale preview now carries the
  same first-paragraph lede (300-char cap) the header projection shows.
- One shared lifter (new operations/related_hits.py) replaces the
  separate check_decision and propose_decision copies; the lede and
  frontmatter helpers are shared with get_decision's header mode so the
  inline hit and the header projection cannot drift. propose_decision's
  advisory similar_decisions inherit the enrichment on both paths,
  deliberately.
- The rendered check_decision block gives every hit a header-equivalent
  triage block: untruncated title, date/type/confidence line,
  supersession refs only when present, and the lede as a wrapped
  paragraph. Tabular renderers (list_decisions, search_decisions) keep
  their title truncation. The pinned takeaway lead line is unchanged.
- Assessment CTAs and the instruction surfaces (MCP protocol fragment,
  get_decision tool description, the generated AGENTS.md digest, the
  adopt and ship-task skills, the planner and tech-lead agents) now say
  headers are inline and direct mode=full reads; get_decision's header
  mode is retargeted as the standalone triage read after search or list.
  Dogfood skill files and docs/adopt-prompt.md re-rendered.

## Test plan

- `uv run --no-sync pytest packages/nauro-core/tests/ -q`: 1150 passed.
- `uv run --no-sync pytest packages/nauro/tests/ -q`: 2133 passed, 10
  skipped (the pre-existing cloud-store cross-surface skips; the new
  enriched-key parity test runs where mcp_server is installed).
- `ruff check` and `ruff format --check` clean.
- Schema snapshot regenerated; the diff is the four additive optional
  fields plus the model docstring. public_contract_v1.json untouched.
- Token measurement (cl100k via tiktoken) against this repo's live
  store, before vs after:

  | hits | old render | new render | old render + header follow-ups | net |
  |---|---|---|---|---|
  | 1 | 95 | 192 | 231 | -39 |
  | 2 | 116 | 235 | 281 | -46 |
  | 3 | 149 | 432 | 494 | -62 |
  | 4 | 183 | 583 | 664 | -81 |
  | 5 | 225 | 633 | 748 | -115 |

  The enriched render costs +97..+408 tokens at 1-5 hits but nets
  cheaper than the render plus the per-hit mode=header follow-ups it
  replaces, with zero extra tool calls. propose_decision's 5-hit
  advisory payload grows 547 -> 677 tokens. Header-mode responses are
  byte-identical before and after.

## Risk / what to review

- The hit preview field now carries the header lede instead of the raw
  rationale prefix on both check and propose responses: a value-level
  change to an existing wire field, made so the inline hit is a faithful
  substitute for a header read.
- The lede wraps without splitting words or hyphenated tokens, so paths
  stay intact at the cost of a rare overlong line.
