### PR TITLE
Polish the CLI for agent consumers: plain help, --format, and --json reports

### DIFF
--- a/packages/nauro/src/nauro/cli/autogen.py
+++ b/packages/nauro/src/nauro/cli/autogen.py
@@ -3,8 +3,9 @@
 Walks ``nauro_core.mcp_tools.ALL_TOOLS`` and, for each tool name in the
 allowlist, registers a Typer command that calls the matching
 ``tool_<name>`` adapter in ``nauro.mcp.tools`` and prints the resulting
-envelope as JSON. Auto-generation keeps the CLI surface in lockstep
-with the MCP surface.
+envelope as JSON (the default) or, under ``--format text``, renders it
+through the shared read-tool renderers with a JSON fallback.
+Auto-generation keeps the CLI surface in lockstep with the MCP surface.
 
 The allowlist is explicit (not derived from the ``readOnlyHint``
 annotation) so future additions to the registry — read or write —
@@ -35,6 +36,7 @@ from nauro_core.mcp_tools import ALL_TOOLS, ToolSpec
 from nauro.cli._json_input import parse_json_list_of_dicts
 from nauro.cli.utils import cli_origin, resolve_target_project
 from nauro.mcp import tools as mcp_tools
+from nauro.mcp.rendering import try_render_envelope
 from nauro.store.repo_head import resolve_process_repo_head
 
 # Tools that should auto-generate a CLI command. list_projects is
@@ -75,6 +77,23 @@ AUTOGEN_PRIMARY_POSITIONAL: dict[str, str] = {
 # replaced by ``--project NAME``; cwd is implicit from the working
 # directory.
 _DROPPED_PROPERTIES: frozenset[str] = frozenset({"project_id", "cwd"})
+
+
+class OutputFormat(str, enum.Enum):
+    """Value set of the ``--format`` flag shared by every auto-gen command."""
+
+    json = "json"
+    text = "text"
+
+
+# Schema properties threaded to the tool's renderer as kwargs in text mode,
+# mirroring the stdio server's per-tool threading: ``get_decision`` passes the
+# requested mode; ``search_decisions`` passes the query the kernel envelope
+# intentionally omits.
+_RENDERER_KWARG_PROPERTIES: dict[str, tuple[str, ...]] = {
+    "get_decision": ("mode",),
+    "search_decisions": ("query",),
+}
 
 
 def _command_name(tool_name: str) -> str:
@@ -195,6 +214,24 @@ def _schema_to_typer_params(spec: ToolSpec) -> list[inspect.Parameter]:
         )
     )
 
+    # --format selects the output rendering; json (the default) is
+    # byte-identical to the historical JSON-only surface.
+    params.append(
+        inspect.Parameter(
+            name="output_format",
+            kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            default=typer.Option(
+                OutputFormat.json,
+                "--format",
+                help=(
+                    "Output format: json prints the machine-readable envelope; "
+                    "text renders it for human reading."
+                ),
+            ),
+            annotation=OutputFormat,
+        )
+    )
+
     # --json no-op preserved for parity with hand-written commands.
     params.append(
         inspect.Parameter(
@@ -203,7 +240,7 @@ def _schema_to_typer_params(spec: ToolSpec) -> list[inspect.Parameter]:
             default=typer.Option(
                 True,
                 "--json/--no-json",
-                help="Compatibility no-op; JSON is the only output format.",
+                help="Compatibility no-op; use --format to choose the output format.",
             ),
             annotation=bool,
         )
@@ -330,31 +367,61 @@ def _emit_envelope(envelope: dict) -> None:
     typer.echo(json.dumps(envelope, indent=2))
 
 
-def _exit_for_envelope(envelope: dict) -> None:
-    """If the envelope signals an error, print guidance to stderr and exit 1.
+def _exit_code_for_envelope(envelope: dict) -> int:
+    """Map an envelope to its exit code, independent of output format.
 
     Caller-fixable rejections (``status: "rejected"``) carry a structured
     ``error`` payload but stay exit 0 — they are not transport-level errors
     and the envelope on stdout already carries the reason.
     """
     if envelope.get("status") == "error":
-        guidance = envelope.get("guidance") or ""
-        if guidance:
-            typer.echo(guidance, err=True)
-        raise typer.Exit(code=1)
+        return 1
     if envelope.get("status") == "rejected":
-        return
+        return 0
     if envelope.get("error"):
-        err = envelope["error"]
+        return 1
+    return 0
+
+
+def _error_guidance(envelope: dict) -> str:
+    """The stderr guidance text an error envelope carries, or an empty string.
+
+    Emitted only in json mode — in text mode the rendered stdout is the sole
+    carrier of the error prose, so echoing it again on stderr would duplicate
+    the message.
+    """
+    if envelope.get("status") == "error":
+        return envelope.get("guidance") or ""
+    if envelope.get("status") == "rejected":
+        return ""
+    err = envelope.get("error")
+    if err:
         reason = err.get("reason") if isinstance(err, dict) else str(err)
-        if reason:
-            typer.echo(reason, err=True)
-        raise typer.Exit(code=1)
+        return reason or ""
+    return ""
+
+
+def _emit_json_mode(envelope: dict) -> None:
+    """Emit the envelope with json-mode streams and raise on error exit codes.
+
+    Also the fallback for text mode when no renderer applies (write tools)
+    or the renderer raised: envelope on stdout, guidance on stderr,
+    format-independent exit code.
+    """
+    _emit_envelope(envelope)
+    guidance = _error_guidance(envelope)
+    if guidance:
+        typer.echo(guidance, err=True)
+    code = _exit_code_for_envelope(envelope)
+    if code:
+        raise typer.Exit(code=code)
 
 
 def _make_command(spec: ToolSpec) -> Callable[..., None]:
     """Build the Typer callback that dispatches to the matching adapter."""
     tool_name = spec["name"]
+    # Resolved at build time to fail loudly on a broken allowlist entry, and
+    # again at dispatch so a patched adapter (tests) is honored.
     adapter = _resolve_adapter(tool_name)
     params = _schema_to_typer_params(spec)
 
@@ -368,7 +435,9 @@ def _make_command(spec: ToolSpec) -> Callable[..., None]:
     # are passed positionally to the adapter to match its
     # ``store_path, <required>, <optional>`` signature.
     schema_arg_names: list[str] = [
-        p.name for p in params if p.name not in {"project", "json_output", primary_alias}
+        p.name
+        for p in params
+        if p.name not in {"project", "json_output", "output_format", primary_alias}
     ]
 
     # Properties declared as ``array of object`` arrive as raw strings from
@@ -401,10 +470,13 @@ def _make_command(spec: ToolSpec) -> Callable[..., None]:
     accepts_origin = "origin" in adapter_params
     accepts_base_commit = "base_commit" in adapter_params
 
+    renderer_kwarg_names = _RENDERER_KWARG_PROPERTIES.get(tool_name, ())
+
     def command(**kwargs: Any) -> None:
         project = kwargs.pop("project", None)
-        # --json is a parity no-op; JSON is the only output mode.
+        # --json is a parity no-op; --format selects the output mode.
         kwargs.pop("json_output", None)
+        output_format = kwargs.pop("output_format", OutputFormat.json)
 
         if primary is not None:
             option_value = kwargs.pop(primary_alias, None)
@@ -434,9 +506,24 @@ def _make_command(spec: ToolSpec) -> Callable[..., None]:
             adapter_kwargs["origin"] = cli_origin()
         if accepts_base_commit:
             adapter_kwargs["base_commit"] = resolve_process_repo_head()
-        envelope = adapter(store_path, **adapter_kwargs)
-        _emit_envelope(envelope)
-        _exit_for_envelope(envelope)
+        envelope = _resolve_adapter(tool_name)(store_path, **adapter_kwargs)
+
+        if output_format is OutputFormat.text:
+            renderer_kwargs = {
+                name: kwargs[name] for name in renderer_kwarg_names if name in kwargs
+            }
+            # A renderer failure falls back silently to json-mode streams;
+            # a traceback on stderr would break the stream contract.
+            rendered = try_render_envelope(tool_name, envelope, renderer_kwargs).text
+            if rendered is not None:
+                # Rendered stdout is the sole carrier of error/guidance prose;
+                # no stderr duplicate. Exit codes stay format-independent.
+                typer.echo(rendered)
+                code = _exit_code_for_envelope(envelope)
+                if code:
+                    raise typer.Exit(code=code)
+                return
+        _emit_json_mode(envelope)
 
     command.__signature__ = inspect.Signature(parameters=params)  # type: ignore[attr-defined]
     command.__name__ = f"autogen_{tool_name}"

--- a/packages/nauro/src/nauro/cli/commands/log.py
+++ b/packages/nauro/src/nauro/cli/commands/log.py
@@ -1,5 +1,6 @@
 """nauro log — List recent snapshots with metadata."""
 
+import json
 from pathlib import Path
 
 import typer
@@ -31,6 +32,11 @@ def log(
         "--project",
         help="Target project name. Overrides cwd resolution.",
     ),
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit the listing as machine-readable JSON.",
+    ),
 ) -> None:
     """List recent snapshots with version, timestamp, and trigger.
 
@@ -39,10 +45,20 @@ def log(
     _project_name, store_path = resolve_target_project(project)
 
     if decisions:
-        _show_decisions(store_path, show_all=all_decisions)
+        if json_output:
+            _emit_decisions_json(store_path, show_all=all_decisions)
+        else:
+            _show_decisions(store_path, show_all=all_decisions)
         return
 
     snapshots = list_snapshots(store_path)
+
+    if json_output:
+        shown = snapshots[:limit]
+        if full:
+            shown = [load_snapshot(store_path, snap["version"]) for snap in shown]
+        typer.echo(json.dumps(shown, indent=2))
+        return
 
     if not snapshots:
         typer.echo("No snapshots yet. Run 'nauro sync' to create the first one.")
@@ -56,6 +72,25 @@ def log(
         _show_summary(store_path, shown)
 
 
+def _decision_rows(store_path: Path, *, show_all: bool) -> list[dict]:
+    """Decision listing rows, superseded entries filtered unless ``show_all``."""
+    return [
+        {
+            "num": d.num,
+            "status": str(d.status.value),
+            "version": d.version,
+            "title": d.title,
+            "superseded_by": d.superseded_by,
+        }
+        for d in _list_decisions(store_path)
+        if show_all or str(d.status.value) != "superseded"
+    ]
+
+
+def _emit_decisions_json(store_path: Path, *, show_all: bool) -> None:
+    typer.echo(json.dumps(_decision_rows(store_path, show_all=show_all), indent=2))
+
+
 def _show_decisions(store_path: Path, show_all: bool = False) -> None:
     """Display decision list with status."""
     all_decs = _list_decisions(store_path)
@@ -65,7 +100,7 @@ def _show_decisions(store_path: Path, show_all: bool = False) -> None:
         return
 
     typer.echo(f"{'ID':<8} {'Status':<14} {'V':<4} {'Title'}")
-    typer.echo("─" * 70)
+    typer.echo("-" * 70)
 
     for d in all_decs:
         status = str(d.status.value)
@@ -82,7 +117,7 @@ def _show_decisions(store_path: Path, show_all: bool = False) -> None:
 def _show_summary(store_path: Path, snapshots: list[dict]) -> None:
     """Display snapshot metadata table."""
     typer.echo(f"{'Version':<10} {'Timestamp':<22} {'Trigger'}")
-    typer.echo("─" * 60)
+    typer.echo("-" * 60)
 
     for snap in snapshots:
         version = f"v{snap['version']:03d}"
@@ -99,7 +134,7 @@ def _show_full(store_path: Path, snapshots: list[dict]) -> None:
     """Display full snapshot content."""
     for i, snap_meta in enumerate(snapshots):
         if i > 0:
-            typer.echo("\n" + "═" * 60 + "\n")
+            typer.echo("\n" + "=" * 60 + "\n")
 
         snap = load_snapshot(store_path, snap_meta["version"])
         version = f"v{snap['version']:03d}"
@@ -107,7 +142,7 @@ def _show_full(store_path: Path, snapshots: list[dict]) -> None:
         trigger = snap.get("trigger", "") or "-"
 
         typer.echo(f"Snapshot {version}  |  {ts}  |  {trigger}")
-        typer.echo("─" * 60)
+        typer.echo("-" * 60)
 
         files = snap.get("files", {})
         for filename in sorted(files):

--- a/packages/nauro/src/nauro/cli/commands/status.py
+++ b/packages/nauro/src/nauro/cli/commands/status.py
@@ -1,11 +1,13 @@
 """nauro status — Show capability table for the current project."""
 
+import json
 import os
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 
 import typer
+from pydantic import BaseModel
 
 from nauro.cli import nauro_command
 from nauro.cli._codex_hooks import (
@@ -15,7 +17,12 @@ from nauro.cli._codex_hooks import (
     _parse_codex_hooks,
 )
 from nauro.cli.integrations import codex_config, json_mcp
-from nauro.cli.utils import DisconnectedProjectExit, resolve_target_project
+from nauro.cli.utils import (
+    RESOLUTION_NO_PROJECT,
+    DisconnectedProjectExit,
+    ProjectResolutionExit,
+    resolve_target_project,
+)
 
 
 def _is_windows() -> bool:
@@ -446,53 +453,17 @@ def _workflow_agents_status_line(snapshot: _WiringSnapshot) -> str:
     return f"  Workflow      active ({detail})"
 
 
-def _render_wiring_status(repo_paths: list[Path], *, no_probe: bool) -> None:
-    snapshot = _collect_wiring(repo_paths)
-    probes = _probe_wiring(snapshot, no_probe=no_probe)
-    typer.echo(_mcp_status_line(snapshot, probes))
-    typer.echo(_codex_hooks_status_line(snapshot, probes))
-    typer.echo(_skills_status_line(snapshot))
-    typer.echo(_workflow_agents_status_line(snapshot))
-    typer.echo(_agents_status_line(snapshot))
-
-
-def _warn_if_project_name_shared(project_name: str, project_id: str) -> None:
+def _count_shared_names(project_name: str, project_id: str) -> int:
     try:
         from nauro.store.registry import find_projects_by_name_v2
 
-        shared = [
-            candidate_id
+        return sum(
+            1
             for candidate_id, _ in find_projects_by_name_v2(project_name)
             if candidate_id != project_id
-        ]
+        )
     except Exception:
-        shared = []
-    if shared:
-        typer.echo(
-            f"  Warning: {len(shared)} other local project(s) share the name "
-            f"'{project_name}'. They are separate stores - run `nauro projects` "
-            "to inspect.\n",
-            err=True,
-        )
-
-
-def _render_sync_status(project_id: str) -> bool:
-    from nauro.cli.commands.auth import load_access_token
-    from nauro.store.registry import is_cloud_project
-
-    has_token = bool(load_access_token())
-    is_cloud = is_cloud_project(project_id)
-    if has_token and is_cloud:
-        typer.echo("  Sync          active (event-driven, presign)")
-        return True
-    if not is_cloud:
-        typer.echo(
-            "  Sync          inactive - local-only project."
-            " Enable with 'nauro auth login', then 'nauro link --cloud'."
-        )
-    else:
-        typer.echo("  Sync          inactive - run 'nauro auth login' to enable")
-    return False
+        return 0
 
 
 def _repo_paths(project_id: str) -> list[Path]:
@@ -504,15 +475,116 @@ def _repo_paths(project_id: str) -> list[Path]:
         return []
 
 
-def _render_decision_status(store_path: Path, project_id: str, *, sync_enabled: bool) -> None:
-    from nauro.store.reader import _list_decisions
+@dataclass(frozen=True)
+class _StatusFacts:
+    """Everything one status run observed, gathered before any output."""
 
-    local_count = len(_list_decisions(store_path))
-    if not sync_enabled:
+    project_name: str
+    store_path: Path
+    shared_name_count: int
+    authenticated: bool
+    cloud: bool
+    snapshot: _WiringSnapshot
+    probes: _WiringProbeResults
+    local_decisions: int
+    remote_decisions: int | None
+    last_full_sync: str | None
+
+    @property
+    def project_id(self) -> str:
+        return self.store_path.name
+
+    @property
+    def sync_enabled(self) -> bool:
+        return self.authenticated and self.cloud
+
+
+def _collect_status(project_name: str, store_path: Path, *, no_probe: bool) -> _StatusFacts:
+    """Gather every fact the human table and the JSON payload render from."""
+    from nauro.cli.commands.auth import load_access_token
+    from nauro.store.reader import _list_decisions
+    from nauro.store.registry import is_cloud_project
+
+    project_id = store_path.name
+    authenticated = bool(load_access_token())
+    cloud = is_cloud_project(project_id)
+    sync_enabled = authenticated and cloud
+    snapshot = _collect_wiring(_repo_paths(project_id))
+    probes = _probe_wiring(snapshot, no_probe=no_probe)
+
+    remote_decisions = _count_remote_decisions(project_id) if sync_enabled else None
+    last_full_sync: str | None = None
+    if sync_enabled:
+        from nauro.sync.state import load_state
+
+        # load_state only guards JSON decode errors: valid JSON of the wrong
+        # shape raises AttributeError, an unreadable file PermissionError,
+        # non-UTF-8 bytes UnicodeDecodeError. And a parseable state object
+        # passes any last_full_sync value through untyped, so a non-string
+        # would later crash both output modes. A broken sync-state file must
+        # degrade to "no recorded sync", never crash status.
+        try:
+            recorded = load_state(store_path).last_full_sync
+        except Exception:
+            recorded = None
+        last_full_sync = recorded if isinstance(recorded, str) and recorded else None
+
+    return _StatusFacts(
+        project_name=project_name,
+        store_path=store_path,
+        shared_name_count=_count_shared_names(project_name, project_id),
+        authenticated=authenticated,
+        cloud=cloud,
+        snapshot=snapshot,
+        probes=probes,
+        local_decisions=len(_list_decisions(store_path)),
+        remote_decisions=remote_decisions,
+        last_full_sync=last_full_sync,
+    )
+
+
+# ── Human table emission ────────────────────────────────────────────────────
+
+
+def _emit_human_status(facts: _StatusFacts) -> None:
+    typer.echo(f"Project: {facts.project_name}")
+    typer.echo(f"Store:   {facts.store_path}\n")
+
+    if facts.shared_name_count:
+        typer.echo(
+            f"  Warning: {facts.shared_name_count} other local project(s) share the name "
+            f"'{facts.project_name}'. They are separate stores - run `nauro projects` "
+            "to inspect.\n",
+            err=True,
+        )
+    _emit_sync_status(facts)
+    typer.echo(_mcp_status_line(facts.snapshot, facts.probes))
+    typer.echo(_codex_hooks_status_line(facts.snapshot, facts.probes))
+    typer.echo(_skills_status_line(facts.snapshot))
+    typer.echo(_workflow_agents_status_line(facts.snapshot))
+    typer.echo(_agents_status_line(facts.snapshot))
+    _emit_decision_status(facts)
+
+
+def _emit_sync_status(facts: _StatusFacts) -> None:
+    if facts.sync_enabled:
+        typer.echo("  Sync          active (event-driven, presign)")
+    elif not facts.cloud:
+        typer.echo(
+            "  Sync          inactive - local-only project."
+            " Enable with 'nauro auth login', then 'nauro link --cloud'."
+        )
+    else:
+        typer.echo("  Sync          inactive - run 'nauro auth login' to enable")
+
+
+def _emit_decision_status(facts: _StatusFacts) -> None:
+    local_count = facts.local_decisions
+    if not facts.sync_enabled:
         typer.echo(f"\n  Decisions: {local_count} local")
         return
 
-    remote_count = _count_remote_decisions(project_id)
+    remote_count = facts.remote_decisions
     if remote_count is None:
         typer.echo(f"\n  Decisions: {local_count} local (could not reach remote)")
         return
@@ -520,16 +592,177 @@ def _render_decision_status(store_path: Path, project_id: str, *, sync_enabled: 
     sync_label = "in sync" if local_count == remote_count else "out of sync"
     typer.echo(f"\n  Decisions: {local_count} local, {remote_count} remote ({sync_label})")
 
-    from nauro.sync.state import load_state
-
-    sync_state = load_state(store_path)
-    if sync_state.last_full_sync:
-        time_ago = _format_time_ago(sync_state.last_full_sync)
-        timestamp = sync_state.last_full_sync[:19].replace("T", " ") + " UTC"
+    if facts.last_full_sync:
+        time_ago = _format_time_ago(facts.last_full_sync)
+        timestamp = facts.last_full_sync[:19].replace("T", " ") + " UTC"
         typer.echo(f"  Last sync: {timestamp} ({time_ago})")
 
     if local_count != remote_count:
         typer.echo("  Run `nauro sync` to reconcile.")
+
+
+# ── JSON payload ────────────────────────────────────────────────────────────
+
+
+class _CountsPayload(BaseModel):
+    present: int
+    current: int
+    expected: int
+
+
+class _SurfaceCountsPayload(BaseModel):
+    claude: _CountsPayload
+    codex: _CountsPayload
+
+
+class _SyncPayload(BaseModel):
+    cloud: bool
+    authenticated: bool
+    active: bool
+
+
+class _McpPayload(BaseModel):
+    repo_count: int
+    wired_repos: int
+    codex_global: bool
+    probed: bool
+    healthy: bool | None
+
+
+class _CodexHooksPayload(BaseModel):
+    repo_count: int
+    configured_repos: int
+    complete: bool | None
+    probed: bool
+    healthy: bool | None
+
+
+class _SkillsPayload(BaseModel):
+    core: _SurfaceCountsPayload
+    opt_in: _SurfaceCountsPayload
+    legacy_codex_copies: int
+
+
+class _AgentsMdPayload(BaseModel):
+    repo_count: int
+    generated_repos: int
+
+
+class _DecisionsPayload(BaseModel):
+    local: int
+    remote: int | None
+    in_sync: bool | None
+    last_full_sync: str | None
+
+
+class StatusPayload(BaseModel):
+    """Curated machine-readable projection of one status run.
+
+    Internal wiring state (recorded command strings, per-repo hook tuples)
+    stays out deliberately: the payload carries capability facts, not the
+    probe plumbing.
+    """
+
+    project: str
+    project_id: str
+    store_path: str
+    shared_name_count: int
+    sync: _SyncPayload
+    mcp: _McpPayload
+    codex_hooks: _CodexHooksPayload
+    skills: _SkillsPayload
+    workflow_agents: _SurfaceCountsPayload
+    agents_md: _AgentsMdPayload
+    decisions: _DecisionsPayload
+
+
+def _counts_payload(counts: _ArtifactCounts) -> _CountsPayload:
+    return _CountsPayload(present=counts.present, current=counts.current, expected=counts.expected)
+
+
+def _surface_counts_payload(pair: _SurfacePair) -> _SurfaceCountsPayload:
+    return _SurfaceCountsPayload(
+        claude=_counts_payload(pair.claude), codex=_counts_payload(pair.codex)
+    )
+
+
+def _build_status_payload(facts: _StatusFacts) -> StatusPayload:
+    snapshot, probes = facts.snapshot, facts.probes
+
+    mcp_probed = not probes.skipped and probes.mcp is not None
+    mcp_healthy = (
+        all(probes.mcp.get(command, True) for command in snapshot.mcp_commands)
+        if mcp_probed
+        else None
+    )
+
+    configured = snapshot.configured_hooks
+    # Null when nothing is configured — completeness is not applicable, same
+    # idiom as the healthy fields when nothing was probed.
+    hooks_complete = (
+        all(
+            state.complete and state.recorded_commands and all(state.recorded_commands)
+            for state in configured
+        )
+        if configured
+        else None
+    )
+    hooks_probed = not probes.skipped and probes.hooks is not None
+    hooks_healthy = (
+        all(probes.hooks.get(command, True) for command in snapshot.hook_commands)
+        if hooks_probed
+        else None
+    )
+
+    workflow = snapshot.workflow
+    return StatusPayload(
+        project=facts.project_name,
+        project_id=facts.project_id,
+        store_path=str(facts.store_path),
+        shared_name_count=facts.shared_name_count,
+        sync=_SyncPayload(
+            cloud=facts.cloud,
+            authenticated=facts.authenticated,
+            active=facts.sync_enabled,
+        ),
+        mcp=_McpPayload(
+            repo_count=snapshot.repo_count,
+            wired_repos=snapshot.mcp_wired,
+            codex_global=snapshot.codex_global,
+            probed=mcp_probed,
+            healthy=mcp_healthy,
+        ),
+        codex_hooks=_CodexHooksPayload(
+            repo_count=snapshot.repo_count,
+            configured_repos=len(configured),
+            complete=hooks_complete,
+            probed=hooks_probed,
+            healthy=hooks_healthy,
+        ),
+        skills=_SkillsPayload(
+            core=_surface_counts_payload(workflow.core_skills),
+            opt_in=_surface_counts_payload(workflow.opt_in_skills),
+            legacy_codex_copies=workflow.legacy_codex_skills,
+        ),
+        workflow_agents=_surface_counts_payload(workflow.agents),
+        agents_md=_AgentsMdPayload(
+            repo_count=snapshot.repo_count,
+            generated_repos=snapshot.agents_generated,
+        ),
+        decisions=_DecisionsPayload(
+            local=facts.local_decisions,
+            remote=facts.remote_decisions,
+            in_sync=(
+                None
+                if facts.remote_decisions is None
+                else facts.local_decisions == facts.remote_decisions
+            ),
+            last_full_sync=facts.last_full_sync,
+        ),
+    )
+
+
+_STATUS_NO_PROJECT_MESSAGE = "No project found. Run 'nauro init <name>' to get started."
 
 
 def status(
@@ -543,20 +776,31 @@ def status(
         "--no-probe",
         help="Skip executable liveness probes; report wiring presence only.",
     ),
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit the capability report as machine-readable JSON.",
+    ),
 ) -> None:
     """Show which Nauro capabilities are active or inactive."""
     try:
         project_name, store_path = resolve_target_project(project)
     except typer.Exit as exc:
         if not isinstance(exc, DisconnectedProjectExit):
-            typer.echo("No project found. Run 'nauro init <name>' to get started.", err=True)
+            typer.echo(_STATUS_NO_PROJECT_MESSAGE, err=True)
+        if json_output:
+            # A plain typer.Exit without resolution fields should not occur;
+            # map it defensively to the no-project reason.
+            if isinstance(exc, ProjectResolutionExit):
+                reason, guidance = exc.reason, exc.guidance
+            else:
+                reason, guidance = RESOLUTION_NO_PROJECT, _STATUS_NO_PROJECT_MESSAGE
+            envelope = {"status": "error", "error": {"reason": reason, "guidance": guidance}}
+            typer.echo(json.dumps(envelope, indent=2))
         raise typer.Exit(exc.exit_code) from exc
 
-    typer.echo(f"Project: {project_name}")
-    typer.echo(f"Store:   {store_path}\n")
-
-    project_id = store_path.name
-    _warn_if_project_name_shared(project_name, project_id)
-    sync_enabled = _render_sync_status(project_id)
-    _render_wiring_status(_repo_paths(project_id), no_probe=no_probe)
-    _render_decision_status(store_path, project_id, sync_enabled=sync_enabled)
+    facts = _collect_status(project_name, store_path, no_probe=no_probe)
+    if json_output:
+        typer.echo(json.dumps(_build_status_payload(facts).model_dump(), indent=2))
+        return
+    _emit_human_status(facts)

--- a/packages/nauro/src/nauro/cli/main.py
+++ b/packages/nauro/src/nauro/cli/main.py
@@ -19,6 +19,9 @@ def _version_callback(value: bool) -> None:
         raise typer.Exit()
 
 
+# rich_markup_mode=None renders plain Click help (no box-drawing panels),
+# which agent consumers parse more cheaply than the Rich layout. Sub-apps
+# inherit the mode at render time.
 app = typer.Typer(
     name="nauro",
     help=(
@@ -26,6 +29,8 @@ app = typer.Typer(
         "surfaced before work."
     ),
     no_args_is_help=True,
+    rich_markup_mode=None,
+    pretty_exceptions_enable=False,
 )
 
 

--- a/packages/nauro/src/nauro/cli/utils.py
+++ b/packages/nauro/src/nauro/cli/utils.py
@@ -36,9 +36,33 @@ from nauro.store.resolution import (
 )
 from nauro.store.write_safety import find_symlink
 
+# Pinned vocabulary for ProjectResolutionExit.reason. Machine-readable
+# consumers (e.g. ``nauro status --json``) surface these values verbatim.
+RESOLUTION_AMBIGUOUS_PROJECT = "ambiguous_project"
+RESOLUTION_UNKNOWN_PROJECT = "unknown_project"
+RESOLUTION_DISCONNECTED_PROJECT = "disconnected_project"
+RESOLUTION_NO_PROJECT = "no_project"
 
-class DisconnectedProjectExit(typer.Exit):
+
+class ProjectResolutionExit(typer.Exit):
+    """Project resolution failed; the guidance was already printed to stderr.
+
+    ``reason`` is one of the pinned vocabulary values above; ``guidance`` is
+    the exact message the raise site printed, so structured consumers can
+    re-surface it without re-deriving the prose.
+    """
+
+    def __init__(self, reason: str, guidance: str) -> None:
+        super().__init__(code=1)
+        self.reason = reason
+        self.guidance = guidance
+
+
+class DisconnectedProjectExit(ProjectResolutionExit):
     """CLI resolution already rendered typed reconnect guidance."""
+
+    def __init__(self, guidance: str) -> None:
+        super().__init__(RESOLUTION_DISCONNECTED_PROJECT, guidance)
 
 
 def cli_origin() -> OriginDescriptor | None:
@@ -140,7 +164,8 @@ def resolve_target_project(project_flag: str | None) -> tuple[str, Path]:
         (project_display_name, store_path) tuple.
 
     Raises:
-        typer.Exit: If no project can be resolved.
+        ProjectResolutionExit: If no project can be resolved. The exception
+        carries the pinned reason value and the printed guidance.
     """
     if project_flag is not None:
         # 1 — registry lookup by name
@@ -154,62 +179,61 @@ def resolve_target_project(project_flag: str | None) -> tuple[str, Path]:
                 for pid, _entry in matches[:5]
                 for name in [_entry.get("name", "?")]
             )
-            typer.echo(
-                f"Multiple projects named '{project_flag}'. Disambiguate by id: {ids}",
-                err=True,
-            )
-            raise typer.Exit(code=1)
+            message = f"Multiple projects named '{project_flag}'. Disambiguate by id: {ids}"
+            typer.echo(message, err=True)
+            raise ProjectResolutionExit(RESOLUTION_AMBIGUOUS_PROJECT, message)
         if len(matches) == 1:
             pid, _entry = matches[0]
             connection = resolve_registered_project(pid)
             if isinstance(connection, DisconnectedProject):
                 typer.echo(connection.guidance, err=True)
-                raise DisconnectedProjectExit(code=1)
+                raise DisconnectedProjectExit(connection.guidance)
             if connection is not None:
                 return project_flag, connection.store_path
 
         available = _available_project_names()
-        typer.echo(f"Unknown project '{project_flag}'.", err=True)
+        lines = [f"Unknown project '{project_flag}'."]
         if available:
-            typer.echo(f"Available projects: {', '.join(available)}", err=True)
+            lines.append(f"Available projects: {', '.join(available)}")
         else:
-            typer.echo("No projects registered. Run 'nauro init' first.", err=True)
-        raise typer.Exit(code=1)
+            lines.append("No projects registered. Run 'nauro init' first.")
+        message = "\n".join(lines)
+        typer.echo(message, err=True)
+        raise ProjectResolutionExit(RESOLUTION_UNKNOWN_PROJECT, message)
 
     # 2 — cwd waterfall: repo config walk-up → registry by repo path
     cwd = Path.cwd()
     resolution = resolve_from_cwd(cwd)
     if isinstance(resolution, DisconnectedProject):
         typer.echo(resolution.guidance, err=True)
-        raise DisconnectedProjectExit(code=1)
+        raise DisconnectedProjectExit(resolution.guidance)
     if resolution is not None:
         return resolution.display_name, resolution.store_path
 
     # 3 — error
     available = _available_project_names()
-    typer.echo("No project found for current directory.", err=True)
+    lines = ["No project found for current directory."]
 
     suggestion = suggest_project_for_path(cwd)
     if suggestion:
         pid, entry = suggestion
         name = entry.get("name", "")
-        typer.echo(
-            f"Hint: project {name!r} exists but this path is not registered.",
-            err=True,
-        )
+        lines.append(f"Hint: project {name!r} exists but this path is not registered.")
         # init --add-repo intentionally rejects cloud-scoped projects; the
         # documented association path for those is nauro attach. The name is
         # shell-quoted because the line is meant to be copy-pasted.
         if entry.get("mode") == REPO_CONFIG_MODE_CLOUD:
-            typer.echo(f"  Run: nauro attach {pid}", err=True)
+            lines.append(f"  Run: nauro attach {pid}")
         else:
-            typer.echo(f"  Run: nauro init {shlex.quote(name)} --add-repo .", err=True)
+            lines.append(f"  Run: nauro init {shlex.quote(name)} --add-repo .")
     elif available:
-        typer.echo(f"Available projects: {', '.join(available)}", err=True)
-        typer.echo("Use --project <name> to target a specific project.", err=True)
+        lines.append(f"Available projects: {', '.join(available)}")
+        lines.append("Use --project <name> to target a specific project.")
     else:
-        typer.echo("Run 'nauro init' first.", err=True)
-    raise typer.Exit(code=1)
+        lines.append("Run 'nauro init' first.")
+    message = "\n".join(lines)
+    typer.echo(message, err=True)
+    raise ProjectResolutionExit(RESOLUTION_NO_PROJECT, message)
 
 
 def _resolve_project_entry(project_name: str, project_key: str) -> dict:
@@ -237,6 +261,7 @@ __all__ = [
     "add_repo_v2",
     "cli_origin",
     "DisconnectedProjectExit",
+    "ProjectResolutionExit",
     "refuse_global_config_collision",
     "refuse_repo_config_symlink",
     "register_project_v2",

--- a/packages/nauro/src/nauro/mcp/rendering.py
+++ b/packages/nauro/src/nauro/mcp/rendering.py
@@ -1,0 +1,51 @@
+"""Shared render-or-fallback step for read-tool envelopes.
+
+Both local text surfaces — the stdio MCP server's ``content[0]`` block and
+the CLI's ``--format text`` mode — render an envelope through
+``nauro_core.renderers.RENDERERS`` with the same failure contract: a tool
+with no renderer mapped, or a renderer that raises, must never swallow the
+response. This module owns that step so the two surfaces cannot drift.
+
+Diagnostics stay with the caller: the stdio server logs a renderer failure
+to its server log, while the CLI falls back silently with json-mode
+streams — a traceback on the CLI's stderr would break the documented
+stream contract. The outcome therefore carries the failure instead of
+logging it here.
+"""
+
+from __future__ import annotations
+
+from typing import Any, NamedTuple
+
+from nauro_core.renderers import RENDERERS
+
+
+class RenderOutcome(NamedTuple):
+    """Result of one render attempt.
+
+    ``text`` is the rendered block, or ``None`` when the caller must fall
+    back to its own JSON emission of the envelope. ``failure`` carries the
+    renderer's exception when one raised (``None`` for the no-renderer
+    case), so callers can attach their own diagnostics.
+    """
+
+    text: str | None
+    failure: Exception | None
+
+
+def try_render_envelope(
+    tool_name: str, envelope: dict, renderer_kwargs: dict[str, Any] | None = None
+) -> RenderOutcome:
+    """Render ``envelope`` through the tool's registered renderer.
+
+    ``renderer_kwargs`` threads renderer-specific options (e.g.
+    ``get_decision``'s requested ``mode``) without storing them on the
+    envelope.
+    """
+    renderer = RENDERERS.get(tool_name)
+    if renderer is None:
+        return RenderOutcome(None, None)
+    try:
+        return RenderOutcome(renderer(envelope, **(renderer_kwargs or {})), None)
+    except Exception as exc:
+        return RenderOutcome(None, exc)

--- a/packages/nauro/src/nauro/mcp/stdio_server.py
+++ b/packages/nauro/src/nauro/mcp/stdio_server.py
@@ -39,11 +39,16 @@ from mcp.types import CallToolResult, TextContent, ToolAnnotations
 from nauro_core.constants import MCP_INSTRUCTIONS
 from nauro_core.mcp_tools import ToolSpec, get_tool_spec
 from nauro_core.operations import ErrorPayload
-from nauro_core.renderers import RENDERERS as _RENDERERS
+
+# Back-compat re-export — tests patch the registry through this name. It is
+# the same dict object nauro.mcp.rendering renders from, so an in-place patch
+# here reaches the shared render step.
+from nauro_core.renderers import RENDERERS as _RENDERERS  # noqa: F401
 from nauro_core.renderers import disconnected_reason_code
 from pydantic import Field
 
 from nauro import __version__
+from nauro.mcp.rendering import try_render_envelope
 from nauro.mcp.tools import (
     tool_check_decision,
     tool_diff_since_last_session,
@@ -95,24 +100,17 @@ def _wrap_with_renderer(
     structured envelope so clients can act on stable recovery metadata while
     humans still receive the rendered guidance.
     """
-    json_text = json.dumps(result, indent=2, default=str)
     structured_content = result if disconnected_reason_code(result) is not None else None
-    renderer = _RENDERERS.get(tool_name)
-    if renderer is None:
-        return CallToolResult(
-            content=[TextContent(type="text", text=json_text)],
-            structuredContent=structured_content,
+    outcome = try_render_envelope(tool_name, result, renderer_kwargs)
+    if outcome.failure is not None:
+        logger.error(
+            "renderer failed for tool=%s; falling back to JSON-only",
+            tool_name,
+            exc_info=outcome.failure,
         )
-    try:
-        rendered = renderer(result, **(renderer_kwargs or {}))
-    except Exception:
-        logger.exception("renderer failed for tool=%s; falling back to JSON-only", tool_name)
-        return CallToolResult(
-            content=[TextContent(type="text", text=json_text)],
-            structuredContent=structured_content,
-        )
+    text = outcome.text if outcome.text is not None else json.dumps(result, indent=2, default=str)
     return CallToolResult(
-        content=[TextContent(type="text", text=rendered)],
+        content=[TextContent(type="text", text=text)],
         structuredContent=structured_content,
     )
 

--- a/packages/nauro/tests/snapshots/public_contract_v1.json
+++ b/packages/nauro/tests/snapshots/public_contract_v1.json
@@ -194,6 +194,20 @@
             "type": "boolean"
           },
           {
+            "choices": [
+              "json",
+              "text"
+            ],
+            "default": "json",
+            "flags": [
+              "--format"
+            ],
+            "kind": "option",
+            "name": "output_format",
+            "required": false,
+            "type": "choice"
+          },
+          {
             "flags": [
               "--project"
             ],
@@ -272,6 +286,20 @@
             "type": "boolean"
           },
           {
+            "choices": [
+              "json",
+              "text"
+            ],
+            "default": "json",
+            "flags": [
+              "--format"
+            ],
+            "kind": "option",
+            "name": "output_format",
+            "required": false,
+            "type": "choice"
+          },
+          {
             "flags": [
               "--project"
             ],
@@ -321,6 +349,20 @@
             "name": "json_output",
             "required": false,
             "type": "boolean"
+          },
+          {
+            "choices": [
+              "json",
+              "text"
+            ],
+            "default": "json",
+            "flags": [
+              "--format"
+            ],
+            "kind": "option",
+            "name": "output_format",
+            "required": false,
+            "type": "choice"
           },
           {
             "flags": [
@@ -399,6 +441,20 @@
             "type": "choice"
           },
           {
+            "choices": [
+              "json",
+              "text"
+            ],
+            "default": "json",
+            "flags": [
+              "--format"
+            ],
+            "kind": "option",
+            "name": "output_format",
+            "required": false,
+            "type": "choice"
+          },
+          {
             "flags": [
               "--project"
             ],
@@ -446,6 +502,20 @@
             "type": "integer"
           },
           {
+            "choices": [
+              "json",
+              "text"
+            ],
+            "default": "json",
+            "flags": [
+              "--format"
+            ],
+            "kind": "option",
+            "name": "output_format",
+            "required": false,
+            "type": "choice"
+          },
+          {
             "flags": [
               "--project"
             ],
@@ -471,6 +541,20 @@
             "name": "json_output",
             "required": false,
             "type": "boolean"
+          },
+          {
+            "choices": [
+              "json",
+              "text"
+            ],
+            "default": "json",
+            "flags": [
+              "--format"
+            ],
+            "kind": "option",
+            "name": "output_format",
+            "required": false,
+            "type": "choice"
           },
           {
             "kind": "argument",
@@ -727,6 +811,20 @@
             "type": "integer"
           },
           {
+            "choices": [
+              "json",
+              "text"
+            ],
+            "default": "json",
+            "flags": [
+              "--format"
+            ],
+            "kind": "option",
+            "name": "output_format",
+            "required": false,
+            "type": "choice"
+          },
+          {
             "flags": [
               "--project"
             ],
@@ -771,6 +869,17 @@
             "is_flag": true,
             "kind": "option",
             "name": "full",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "default": false,
+            "flags": [
+              "--json"
+            ],
+            "is_flag": true,
+            "kind": "option",
+            "name": "json_output",
             "required": false,
             "type": "boolean"
           },
@@ -979,6 +1088,20 @@
             "type": "choice"
           },
           {
+            "choices": [
+              "json",
+              "text"
+            ],
+            "default": "json",
+            "flags": [
+              "--format"
+            ],
+            "kind": "option",
+            "name": "output_format",
+            "required": false,
+            "type": "choice"
+          },
+          {
             "flags": [
               "--project"
             ],
@@ -1137,6 +1260,20 @@
             "name": "limit",
             "required": false,
             "type": "integer"
+          },
+          {
+            "choices": [
+              "json",
+              "text"
+            ],
+            "default": "json",
+            "flags": [
+              "--format"
+            ],
+            "kind": "option",
+            "name": "output_format",
+            "required": false,
+            "type": "choice"
           },
           {
             "flags": [
@@ -1347,6 +1484,17 @@
           {
             "default": false,
             "flags": [
+              "--json"
+            ],
+            "is_flag": true,
+            "kind": "option",
+            "name": "json_output",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "default": false,
+            "flags": [
               "--no-probe"
             ],
             "is_flag": true,
@@ -1451,6 +1599,20 @@
             "name": "json_output",
             "required": false,
             "type": "boolean"
+          },
+          {
+            "choices": [
+              "json",
+              "text"
+            ],
+            "default": "json",
+            "flags": [
+              "--format"
+            ],
+            "kind": "option",
+            "name": "output_format",
+            "required": false,
+            "type": "choice"
           },
           {
             "flags": [

--- a/packages/nauro/tests/test_cli_autogen.py
+++ b/packages/nauro/tests/test_cli_autogen.py
@@ -208,7 +208,9 @@ class TestGetDecision:
         assert result.exit_code == 0, result.output
         assert "header" in result.output
         assert "full" in result.output
-        assert "[default: full]" in result.output
+        # Plain Click help wraps at the option column, so normalize whitespace
+        # before asserting the default marker.
+        assert "[default: full]" in " ".join(result.output.split())
 
     def test_mode_header_happy_path(self, demo_repo) -> None:
         result = runner.invoke(app, ["get-decision", "1", "--mode", "header"])

--- a/packages/nauro/tests/test_cli_format.py
+++ b/packages/nauro/tests/test_cli_format.py
@@ -1,0 +1,167 @@
+"""Tests for the ``--format`` flag on the auto-generated tool-mirror commands.
+
+The contract under test:
+
+- ``--format json`` (the default) is byte-identical to the historical
+  JSON-only surface, pinned across all ten commands with static mocked
+  adapters (write envelopes embed minted ids/timestamps, so a real store
+  cannot give byte identity).
+- ``--format text`` renders the envelope through
+  ``nauro_core.renderers.RENDERERS`` with the same per-tool kwargs the
+  stdio server threads, and the rendered stdout is the sole carrier of
+  error/guidance prose (no stderr duplicate).
+- Write tools and raised renderers fall back to the JSON envelope with
+  json-mode streams. Exit codes are format-independent.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from nauro_core.renderers import RENDERERS
+from typer.testing import CliRunner
+
+from nauro.cli.main import app
+from nauro.constants import REPO_CONFIG_MODE_LOCAL
+from nauro.demo import create_demo_project
+from nauro.mcp import tools as mcp_tools
+from nauro.store.registry import register_project_v2
+from nauro.store.repo_config import save_repo_config
+
+runner = CliRunner()
+
+# Minimal happy-path argv per auto-gen command.
+COMMAND_ARGS: dict[str, list[str]] = {
+    "get_context": [],
+    "get_raw_file": ["project.md"],
+    "list_decisions": [],
+    "get_decision": ["1"],
+    "diff_since_last_session": [],
+    "search_decisions": ["budget"],
+    "check_decision": ["Store dollar amounts as decimal numbers"],
+    "update_state": ["Shipped the format-flag matrix"],
+    "flag_question": ["Should the cache invalidate on write?"],
+    "propose_decision": ["A rationale long enough for the format-matrix run."],
+}
+
+WRITE_TOOLS = frozenset({"update_state", "flag_question", "propose_decision"})
+READ_TOOLS = frozenset(COMMAND_ARGS) - WRITE_TOOLS
+
+
+def _argv(tool_name: str) -> list[str]:
+    return [tool_name.replace("_", "-"), *COMMAND_ARGS[tool_name]]
+
+
+@pytest.fixture
+def demo_repo(tmp_path: Path, monkeypatch) -> Path:
+    """Local-mode demo project rooted at tmp_path/repo with cwd inside it."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    pid, store_path = register_project_v2("demo-project", [repo], mode=REPO_CONFIG_MODE_LOCAL)
+    save_repo_config(repo, {"mode": REPO_CONFIG_MODE_LOCAL, "id": pid, "name": "demo-project"})
+    create_demo_project(store_path)
+    monkeypatch.chdir(repo)
+    return store_path
+
+
+class TestJsonModeByteIdentity:
+    @pytest.mark.parametrize("tool_name", sorted(COMMAND_ARGS))
+    def test_default_output_matches_format_json(self, tool_name, demo_repo, monkeypatch) -> None:
+        canned = {"store": "local", "status": "ok", "tool": tool_name}
+        monkeypatch.setattr(
+            mcp_tools, f"tool_{tool_name}", lambda store_path, *a, **k: dict(canned)
+        )
+        default = runner.invoke(app, _argv(tool_name))
+        explicit = runner.invoke(app, [*_argv(tool_name), "--format", "json"])
+        assert default.exit_code == 0, default.output
+        assert explicit.exit_code == 0, explicit.output
+        expected = json.dumps(canned, indent=2) + "\n"
+        assert default.stdout == expected
+        assert explicit.stdout == expected
+
+
+class TestTextMode:
+    @pytest.mark.parametrize("tool_name", sorted(READ_TOOLS))
+    def test_text_mode_equals_renderer_output(self, tool_name, demo_repo) -> None:
+        json_run = runner.invoke(app, [*_argv(tool_name), "--format", "json"])
+        assert json_run.exit_code == 0, json_run.output
+        envelope = json.loads(json_run.stdout)
+        renderer_kwargs = {}
+        if tool_name == "get_decision":
+            renderer_kwargs = {"mode": "full"}
+        if tool_name == "search_decisions":
+            renderer_kwargs = {"query": COMMAND_ARGS[tool_name][0]}
+        expected = RENDERERS[tool_name](envelope, **renderer_kwargs)
+        text_run = runner.invoke(app, [*_argv(tool_name), "--format", "text"])
+        assert text_run.exit_code == 0, text_run.output
+        assert text_run.stdout == expected + "\n"
+
+    def test_get_decision_mode_threads_to_renderer(self, demo_repo) -> None:
+        argv = ["get-decision", "1", "--mode", "header"]
+        envelope = json.loads(runner.invoke(app, [*argv, "--format", "json"]).stdout)
+        expected = RENDERERS["get_decision"](envelope, mode="header")
+        result = runner.invoke(app, [*argv, "--format", "text"])
+        assert result.exit_code == 0, result.output
+        assert result.stdout == expected + "\n"
+
+    def test_search_decisions_query_threads_to_renderer(self, demo_repo) -> None:
+        result = runner.invoke(app, ["search-decisions", "budget", "--format", "text"])
+        assert result.exit_code == 0, result.output
+        # The rendered header echoes the query only when it is threaded
+        # through renderer kwargs; the kernel envelope omits it.
+        assert 'for "budget"' in result.stdout
+
+    def test_error_envelope_renders_without_stderr_duplicate(self, demo_repo) -> None:
+        result = runner.invoke(app, ["get-decision", "9999", "--format", "text"])
+        assert result.exit_code == 1
+        assert result.stdout.startswith("Error:")
+        assert result.stderr == ""
+
+    def test_error_envelope_json_mode_keeps_stderr_guidance(self, demo_repo) -> None:
+        result = runner.invoke(app, ["get-decision", "9999", "--format", "json"])
+        assert result.exit_code == 1
+        assert json.loads(result.stdout).get("error")
+        assert result.stderr.strip()
+
+
+class TestJsonFallback:
+    def test_write_tool_text_mode_falls_back_to_json_streams(self, demo_repo, monkeypatch) -> None:
+        canned = {"store": "local", "status": "ok"}
+        monkeypatch.setattr(
+            mcp_tools, "tool_update_state", lambda store_path, *a, **k: dict(canned)
+        )
+        text = runner.invoke(app, ["update-state", "delta text", "--format", "text"])
+        json_mode = runner.invoke(app, ["update-state", "delta text", "--format", "json"])
+        assert text.exit_code == 0
+        assert text.stdout == json_mode.stdout
+        assert json.loads(text.stdout) == canned
+
+    def test_rejected_envelope_exits_zero_with_json_fallback(self, demo_repo, monkeypatch) -> None:
+        rejected = {
+            "store": "local",
+            "status": "rejected",
+            "error": {"kind": "rejected", "reason": "Rationale too short."},
+        }
+        monkeypatch.setattr(
+            mcp_tools, "tool_propose_decision", lambda store_path, **k: dict(rejected)
+        )
+        result = runner.invoke(app, ["propose-decision", "some rationale", "--format", "text"])
+        assert result.exit_code == 0
+        assert json.loads(result.stdout)["status"] == "rejected"
+        assert result.stderr == ""
+
+    def test_raised_renderer_falls_back_to_json(self, demo_repo, monkeypatch) -> None:
+        def explode(envelope, **kwargs):
+            raise RuntimeError("renderer kaboom")
+
+        monkeypatch.setitem(RENDERERS, "list_decisions", explode)
+        result = runner.invoke(app, ["list-decisions", "--format", "text"])
+        assert result.exit_code == 0, result.output
+        envelope = json.loads(result.stdout)
+        assert envelope["store"] == "local"
+        assert "decisions" in envelope
+        # The fallback is silent: json-mode streams only, no traceback or
+        # log line on stderr.
+        assert result.stderr == ""

--- a/packages/nauro/tests/test_cli_log_json.py
+++ b/packages/nauro/tests/test_cli_log_json.py
@@ -1,0 +1,204 @@
+"""Tests for ``nauro log --json`` and the ASCII table rules.
+
+Three JSON modes: default emits the snapshot metadata list exactly as
+``list_snapshots`` returns it; ``--decisions`` emits curated decision
+rows; ``--full`` emits complete loaded snapshots including the files
+map. Flag precedence mirrors the human surface exactly: ``--decisions``
+wins over ``--full`` and ``--all`` only applies under ``--decisions``.
+An empty store emits ``[]`` at exit 0.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+from pathlib import Path
+
+from nauro_core.decision_model import Decision, DecisionStatus
+from typer.testing import CliRunner
+
+from nauro.cli.main import app
+from nauro.store.registry import register_project_v2
+from nauro.store.snapshot import capture_snapshot, list_snapshots, load_snapshot
+from nauro.templates.scaffolds import scaffold_project_store
+from tests.conftest import seed_decisions_into
+
+runner = CliRunner()
+
+SNAPSHOT_KEYS = {"version", "timestamp", "trigger", "trigger_detail", "token_count"}
+DECISION_KEYS = {"num", "status", "version", "title", "superseded_by"}
+
+
+def _setup_project(tmp_path, monkeypatch, *, scaffold=True) -> Path:
+    _pid, store = register_project_v2("myproj", [tmp_path])
+    if scaffold:
+        scaffold_project_store("myproj", store)
+    monkeypatch.chdir(tmp_path)
+    return store
+
+
+def _seed_supersession_pair(store: Path) -> None:
+    seed_decisions_into(
+        store,
+        Decision(
+            date=date(2026, 1, 1),
+            confidence="medium",
+            num=1,
+            title="Old storage choice",
+            rationale="The original storage engine selection.",
+            status=DecisionStatus.superseded,
+            superseded_by="2",
+        ),
+        Decision(
+            date=date(2026, 1, 2),
+            confidence="medium",
+            num=2,
+            title="New storage choice",
+            rationale="Replaces the original storage engine selection.",
+            supersedes="1",
+        ),
+    )
+
+
+class TestLogJsonSnapshots:
+    def test_default_matches_list_snapshots(self, tmp_path, monkeypatch):
+        store = _setup_project(tmp_path, monkeypatch)
+        capture_snapshot(store, trigger="first sync")
+        capture_snapshot(store, trigger="second sync")
+
+        result = runner.invoke(app, ["log", "--json"])
+        assert result.exit_code == 0, result.output
+
+        rows = json.loads(result.stdout)
+        assert rows == list_snapshots(store)
+        assert [set(row) for row in rows] == [SNAPSHOT_KEYS, SNAPSHOT_KEYS]
+        assert [row["version"] for row in rows] == [2, 1]
+
+    def test_limit_applies(self, tmp_path, monkeypatch):
+        store = _setup_project(tmp_path, monkeypatch)
+        for i in range(5):
+            capture_snapshot(store, trigger=f"snap-{i}")
+
+        result = runner.invoke(app, ["log", "--json", "--limit", "2"])
+        assert result.exit_code == 0, result.output
+        assert [row["version"] for row in json.loads(result.stdout)] == [5, 4]
+
+    def test_full_includes_files_map(self, tmp_path, monkeypatch):
+        store = _setup_project(tmp_path, monkeypatch)
+        capture_snapshot(store, trigger="with files")
+
+        result = runner.invoke(app, ["log", "--full", "--json"])
+        assert result.exit_code == 0, result.output
+
+        rows = json.loads(result.stdout)
+        assert len(rows) == 1
+        assert rows[0] == load_snapshot(store, 1)
+        assert "project.md" in rows[0]["files"]
+
+    def test_empty_store_emits_empty_list(self, tmp_path, monkeypatch):
+        _setup_project(tmp_path, monkeypatch)
+
+        result = runner.invoke(app, ["log", "--json"])
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.stdout) == []
+
+
+class TestLogJsonDecisions:
+    def test_decisions_rows_filter_superseded(self, tmp_path, monkeypatch):
+        store = _setup_project(tmp_path, monkeypatch, scaffold=False)
+        _seed_supersession_pair(store)
+
+        result = runner.invoke(app, ["log", "--decisions", "--json"])
+        assert result.exit_code == 0, result.output
+
+        rows = json.loads(result.stdout)
+        assert [set(row) for row in rows] == [DECISION_KEYS]
+        assert rows[0] == {
+            "num": 2,
+            "status": "active",
+            "version": 1,
+            "title": "New storage choice",
+            "superseded_by": None,
+        }
+
+    def test_decisions_all_includes_superseded(self, tmp_path, monkeypatch):
+        store = _setup_project(tmp_path, monkeypatch, scaffold=False)
+        _seed_supersession_pair(store)
+
+        result = runner.invoke(app, ["log", "--decisions", "--all", "--json"])
+        assert result.exit_code == 0, result.output
+
+        rows = json.loads(result.stdout)
+        assert [row["num"] for row in rows] == [1, 2]
+        assert rows[0]["status"] == "superseded"
+        assert rows[0]["superseded_by"] == "2"
+
+    def test_empty_store_emits_empty_list(self, tmp_path, monkeypatch):
+        _setup_project(tmp_path, monkeypatch, scaffold=False)
+
+        result = runner.invoke(app, ["log", "--decisions", "--json"])
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.stdout) == []
+
+
+class TestLogFlagPrecedence:
+    def test_json_decisions_wins_over_full(self, tmp_path, monkeypatch):
+        store = _setup_project(tmp_path, monkeypatch, scaffold=False)
+        _seed_supersession_pair(store)
+        capture_snapshot(store, trigger="snap")
+
+        result = runner.invoke(app, ["log", "--decisions", "--full", "--json"])
+        assert result.exit_code == 0, result.output
+
+        rows = json.loads(result.stdout)
+        # Decision rows, not snapshot bodies: --full is silently ignored.
+        assert [set(row) for row in rows] == [DECISION_KEYS]
+
+    def test_json_all_without_decisions_is_ignored(self, tmp_path, monkeypatch):
+        store = _setup_project(tmp_path, monkeypatch)
+        capture_snapshot(store, trigger="snap")
+
+        with_all = runner.invoke(app, ["log", "--all", "--json"])
+        without = runner.invoke(app, ["log", "--json"])
+        assert with_all.exit_code == 0
+        assert with_all.stdout == without.stdout
+
+    def test_human_decisions_wins_over_full(self, tmp_path, monkeypatch):
+        store = _setup_project(tmp_path, monkeypatch, scaffold=False)
+        _seed_supersession_pair(store)
+        capture_snapshot(store, trigger="snap")
+
+        result = runner.invoke(app, ["log", "--decisions", "--full"])
+        assert result.exit_code == 0, result.output
+        assert "New storage choice" in result.output
+        assert "Snapshot v001" not in result.output
+
+    def test_human_all_without_decisions_is_ignored(self, tmp_path, monkeypatch):
+        store = _setup_project(tmp_path, monkeypatch)
+        capture_snapshot(store, trigger="snap")
+
+        with_all = runner.invoke(app, ["log", "--all"])
+        without = runner.invoke(app, ["log"])
+        assert with_all.exit_code == 0
+        assert with_all.stdout == without.stdout
+
+
+class TestLogHumanAsciiRules:
+    def test_summary_and_decision_tables_use_ascii_rules(self, tmp_path, monkeypatch):
+        store = _setup_project(tmp_path, monkeypatch, scaffold=False)
+        _seed_supersession_pair(store)
+        capture_snapshot(store, trigger="first")
+        capture_snapshot(store, trigger="second")
+
+        summary = runner.invoke(app, ["log"])
+        assert "-" * 60 in summary.output
+
+        decisions = runner.invoke(app, ["log", "--decisions"])
+        assert "-" * 70 in decisions.output
+
+        full = runner.invoke(app, ["log", "--full"])
+        assert "=" * 60 in full.output
+
+        for output in (summary.output, decisions.output, full.output):
+            assert "─" not in output
+            assert "═" not in output

--- a/packages/nauro/tests/test_cli_plain_help.py
+++ b/packages/nauro/tests/test_cli_plain_help.py
@@ -1,0 +1,38 @@
+"""Help output renders as plain Click text, not Rich panels.
+
+``rich_markup_mode=None`` on the root app makes every ``--help`` surface —
+the root, hand-written sub-apps, and the auto-generated tool mirrors —
+render the classic ``Usage:``-prefixed layout without box-drawing
+characters. Agent consumers parse that layout far more cheaply than the
+Rich panel output.
+"""
+
+from __future__ import annotations
+
+import pytest
+from typer.testing import CliRunner
+
+from nauro.cli.main import app
+
+runner = CliRunner()
+
+# The Rich help layout's frame and rule characters. None of them may
+# appear in plain help output.
+_BOX_DRAWING_CHARS = "╭╮╰╯│─━┏┓┗┛┃═"
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["--help"],
+        ["projects", "--help"],
+        ["get-context", "--help"],
+    ],
+    ids=["root", "sub-app", "autogen"],
+)
+def test_help_is_plain_text(argv: list[str]) -> None:
+    result = runner.invoke(app, argv)
+    assert result.exit_code == 0, result.output
+    assert result.output.startswith("Usage:")
+    present = [ch for ch in _BOX_DRAWING_CHARS if ch in result.output]
+    assert not present, f"Rich box-drawing characters in help output: {present}"

--- a/packages/nauro/tests/test_cli_status_json.py
+++ b/packages/nauro/tests/test_cli_status_json.py
@@ -1,0 +1,294 @@
+"""Tests for ``nauro status --json``.
+
+The payload is a curated projection of one status run: capability facts
+only, never the internal wiring state (recorded command strings, per-repo
+hook tuples). The key set is pinned exactly so additions are deliberate.
+Resolution failures keep the pinned exit 1 and stderr message and add a
+structured error envelope on stdout using the resolution reason
+vocabulary.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from nauro.agents import AGENT_NAMES
+from nauro.cli.integrations import codex_config
+from nauro.cli.integrations.skills import OPT_IN_SKILL_NAMES, SKILL_NAMES
+from nauro.cli.main import app
+from nauro.constants import REPO_CONFIG_MODE_CLOUD
+from nauro.store.config import save_config
+from nauro.store.registry import register_project_v2
+from nauro.templates.scaffolds import scaffold_project_store
+
+runner = CliRunner()
+
+
+def _setup_project(tmp_path, monkeypatch, name="testproj"):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _pid, store = register_project_v2(name, [repo])
+    scaffold_project_store(name, store)
+    monkeypatch.chdir(repo)
+    monkeypatch.setattr(
+        codex_config, "codex_config_path", lambda: tmp_path / "codex-home" / "config.toml"
+    )
+    return store, repo
+
+
+def _wire_repo_mcp(repo):
+    (repo / ".mcp.json").write_text(json.dumps({"mcpServers": {"nauro": {"command": "nauro"}}}))
+
+
+def _wire_codex_hooks(repo, *, command="nauro", events=("SessionStart", "SubagentStart")):
+    entry = {
+        "type": "command",
+        "command": f"test -x {command} || exit 0; exec {command} hook codex-bootstrap",
+    }
+    hooks = {event: [{"hooks": [entry]}] for event in events}
+    path = repo / ".codex" / "hooks.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"hooks": hooks}))
+
+
+def _absent_counts(expected: int) -> dict:
+    """Counts for a bundled artifact set that is not installed at all."""
+    return {"present": 0, "current": 0, "expected": expected}
+
+
+def test_status_json_happy_path_golden_payload(tmp_path, monkeypatch):
+    """Full golden comparison of the payload on a fresh local project.
+
+    Pins the exact key set and every value at once — an added, removed, or
+    silently changed field fails here, not just a key-set drift. The
+    isolated HOME has no skills or agents installed, nothing wired, and no
+    cloud sync, so every fact is deterministic.
+    """
+    store, _repo = _setup_project(tmp_path, monkeypatch)
+
+    result = runner.invoke(app, ["status", "--json"])
+    assert result.exit_code == 0, result.output
+
+    payload = json.loads(result.stdout)
+    assert payload == {
+        "project": "testproj",
+        "project_id": store.name,
+        "store_path": str(store),
+        "shared_name_count": 0,
+        "sync": {"cloud": False, "authenticated": False, "active": False},
+        # Nothing wired means nothing to probe: probed False, healthy null.
+        "mcp": {
+            "repo_count": 1,
+            "wired_repos": 0,
+            "codex_global": False,
+            "probed": False,
+            "healthy": None,
+        },
+        # No hooks configured: completeness is not applicable.
+        "codex_hooks": {
+            "repo_count": 1,
+            "configured_repos": 0,
+            "complete": None,
+            "probed": False,
+            "healthy": None,
+        },
+        "skills": {
+            "core": {
+                "claude": _absent_counts(len(SKILL_NAMES)),
+                "codex": _absent_counts(len(SKILL_NAMES)),
+            },
+            "opt_in": {
+                "claude": _absent_counts(len(OPT_IN_SKILL_NAMES)),
+                "codex": _absent_counts(len(OPT_IN_SKILL_NAMES)),
+            },
+            "legacy_codex_copies": 0,
+        },
+        "workflow_agents": {
+            "claude": _absent_counts(len(AGENT_NAMES)),
+            "codex": _absent_counts(len(AGENT_NAMES)),
+        },
+        "agents_md": {"repo_count": 1, "generated_repos": 0},
+        # Local-only project: no remote comparison. The scaffold seeds one
+        # decision.
+        "decisions": {"local": 1, "remote": None, "in_sync": None, "last_full_sync": None},
+    }
+
+
+def test_status_json_probed_and_healthy_when_wired(tmp_path, monkeypatch):
+    _store, repo = _setup_project(tmp_path, monkeypatch)
+    _wire_repo_mcp(repo)
+
+    result = runner.invoke(app, ["status", "--json"])
+    assert result.exit_code == 0, result.output
+
+    payload = json.loads(result.stdout)
+    assert payload["mcp"]["repo_count"] == 1
+    assert payload["mcp"]["wired_repos"] == 1
+    # The conftest probe stub reports every recorded command healthy.
+    assert payload["mcp"]["probed"] is True
+    assert payload["mcp"]["healthy"] is True
+
+
+def test_status_json_no_probe_yields_null_health(tmp_path, monkeypatch):
+    _store, repo = _setup_project(tmp_path, monkeypatch)
+    _wire_repo_mcp(repo)
+
+    result = runner.invoke(app, ["status", "--json", "--no-probe"])
+    assert result.exit_code == 0, result.output
+
+    payload = json.loads(result.stdout)
+    assert payload["mcp"]["wired_repos"] == 1
+    assert payload["mcp"]["probed"] is False
+    assert payload["mcp"]["healthy"] is None
+    assert payload["codex_hooks"]["probed"] is False
+    assert payload["codex_hooks"]["healthy"] is None
+
+
+def test_status_json_hooks_complete_when_configured(tmp_path, monkeypatch):
+    """With hooks configured, complete carries the real completeness bool.
+
+    Completeness is null only when nothing is configured; a fully wired
+    lifecycle reports True.
+    """
+    _store, repo = _setup_project(tmp_path, monkeypatch)
+    _wire_codex_hooks(repo)
+
+    result = runner.invoke(app, ["status", "--json"])
+    assert result.exit_code == 0, result.output
+
+    payload = json.loads(result.stdout)
+    assert payload["codex_hooks"]["configured_repos"] == 1
+    assert payload["codex_hooks"]["complete"] is True
+
+
+def test_status_json_no_project_error_envelope(tmp_path, monkeypatch):
+    isolated = tmp_path / "isolated"
+    isolated.mkdir()
+    monkeypatch.chdir(isolated)
+
+    result = runner.invoke(app, ["status", "--json"])
+    assert result.exit_code == 1
+
+    payload = json.loads(result.stdout)
+    assert set(payload) == {"status", "error"}
+    assert payload["status"] == "error"
+    assert set(payload["error"]) == {"reason", "guidance"}
+    assert payload["error"]["reason"] == "no_project"
+    assert payload["error"]["guidance"].startswith("No project found for current directory.")
+    # The pinned stderr message is unchanged.
+    assert "No project found. Run 'nauro init <name>' to get started." in result.stderr
+
+
+def test_status_json_unknown_project_error_envelope(tmp_path, monkeypatch):
+    _setup_project(tmp_path, monkeypatch)
+
+    result = runner.invoke(app, ["status", "--project", "nope", "--json"])
+    assert result.exit_code == 1
+
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "error"
+    assert payload["error"]["reason"] == "unknown_project"
+    assert payload["error"]["guidance"].startswith("Unknown project 'nope'.")
+
+
+def test_status_json_ambiguous_project_error_envelope(tmp_path, monkeypatch):
+    _setup_project(tmp_path, monkeypatch)
+    register_project_v2("dup", [tmp_path / "a"])
+    register_project_v2("dup", [tmp_path / "b"])
+
+    result = runner.invoke(app, ["status", "--project", "dup", "--json"])
+    assert result.exit_code == 1
+
+    payload = json.loads(result.stdout)
+    assert payload["error"]["reason"] == "ambiguous_project"
+    assert payload["error"]["guidance"].startswith("Multiple projects named 'dup'.")
+
+
+def test_status_json_disconnected_project_error_envelope(tmp_path, monkeypatch):
+    _setup_project(tmp_path, monkeypatch)
+    _pid, gone_store = register_project_v2("gone", [tmp_path / "elsewhere"])
+    shutil.rmtree(gone_store)
+
+    result = runner.invoke(app, ["status", "--project", "gone", "--json"])
+    assert result.exit_code == 1
+
+    payload = json.loads(result.stdout)
+    assert payload["error"]["reason"] == "disconnected_project"
+    assert "nauro reconnect" in payload["error"]["guidance"]
+    # Disconnected keeps its typed guidance; the generic no-project line stays out.
+    assert "No project found. Run 'nauro init <name>'" not in result.stderr
+
+
+def _setup_cloud_project(tmp_path, monkeypatch):
+    """Authed cloud-mode project, so the sync-state read path is active."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _pid, store = register_project_v2(
+        "cloudproj",
+        [repo],
+        mode=REPO_CONFIG_MODE_CLOUD,
+        project_id="01KQ6AZGNA0B3QBF67NBXP3S45",
+        server_url="https://example.test",
+    )
+    scaffold_project_store("cloudproj", store)
+    save_config({"auth": {"access_token": "tok", "sub": "x"}})
+    monkeypatch.chdir(repo)
+    monkeypatch.setattr(
+        codex_config, "codex_config_path", lambda: tmp_path / "codex-home" / "config.toml"
+    )
+    return store
+
+
+def test_status_survives_wrong_shape_sync_state(tmp_path, monkeypatch):
+    """A broken .sync-state.json never crashes status.
+
+    load_state only guards JSON decode errors — valid JSON of the wrong
+    shape raises AttributeError. With sync active and the remote count
+    unavailable, the pre-existing behavior was exit 0 without touching the
+    sync-state file; the collect pass now reads it, so the read must
+    degrade to "no recorded sync" in both output modes.
+    """
+    store = _setup_cloud_project(tmp_path, monkeypatch)
+    (store / ".sync-state.json").write_text(json.dumps(["wrong", "shape"]))
+
+    with patch("nauro.cli.commands.status._count_remote_decisions", return_value=None):
+        human = runner.invoke(app, ["status"])
+        as_json = runner.invoke(app, ["status", "--json"])
+
+    assert human.exit_code == 0, human.output
+    assert "could not reach remote" in human.output
+    assert as_json.exit_code == 0, as_json.output
+    payload = json.loads(as_json.stdout)
+    assert payload["decisions"]["remote"] is None
+    assert payload["decisions"]["last_full_sync"] is None
+
+
+@pytest.mark.parametrize("bad_value", [12345, ["not", "a", "string"]], ids=["int", "list"])
+def test_status_survives_non_string_last_full_sync(tmp_path, monkeypatch, bad_value):
+    """A parseable state file with a non-string last_full_sync never crashes.
+
+    load_state passes the value through untyped, so it crosses the
+    exception guard; without the isinstance sanitization the JSON path dies
+    on payload validation and the human path on rendering the timestamp.
+    The remote count is reachable here so the human path actually reaches
+    its last-sync branch.
+    """
+    store = _setup_cloud_project(tmp_path, monkeypatch)
+    (store / ".sync-state.json").write_text(json.dumps({"files": {}, "last_full_sync": bad_value}))
+
+    with patch("nauro.cli.commands.status._count_remote_decisions", return_value=1):
+        human = runner.invoke(app, ["status"])
+        as_json = runner.invoke(app, ["status", "--json"])
+
+    assert human.exit_code == 0, human.output
+    assert "Decisions: 1 local, 1 remote (in sync)" in human.output
+    assert "Last sync:" not in human.output
+    assert as_json.exit_code == 0, as_json.output
+    payload = json.loads(as_json.stdout)
+    assert payload["decisions"]["remote"] == 1
+    assert payload["decisions"]["last_full_sync"] is None

--- a/packages/nauro/tests/test_resolution_exit_reasons.py
+++ b/packages/nauro/tests/test_resolution_exit_reasons.py
@@ -1,0 +1,97 @@
+"""Reason/guidance metadata on ``resolve_target_project`` failures.
+
+Every raise site in ``resolve_target_project`` attaches a pinned reason
+value and the exact stderr message as ``guidance``, so structured
+consumers (``nauro status --json``) can re-surface the failure without
+re-deriving the prose. Stderr output, exit codes, and the
+``DisconnectedProjectExit`` isinstance identity are unchanged — the
+existing resolution tests pin that separately.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from nauro.cli.utils import (
+    RESOLUTION_AMBIGUOUS_PROJECT,
+    RESOLUTION_DISCONNECTED_PROJECT,
+    RESOLUTION_NO_PROJECT,
+    RESOLUTION_UNKNOWN_PROJECT,
+    DisconnectedProjectExit,
+    ProjectResolutionExit,
+    resolve_target_project,
+)
+from nauro.store.registry import register_project_v2
+from nauro.store.repo_config import save_repo_config
+
+
+def _resolution_failure(capsys, project_flag: str | None) -> tuple[ProjectResolutionExit, str]:
+    with pytest.raises(ProjectResolutionExit) as excinfo:
+        resolve_target_project(project_flag)
+    return excinfo.value, capsys.readouterr().err
+
+
+def test_ambiguous_project(tmp_path: Path, capsys) -> None:
+    register_project_v2("dup", [tmp_path / "a"])
+    register_project_v2("dup", [tmp_path / "b"])
+
+    exc, err = _resolution_failure(capsys, "dup")
+
+    assert exc.reason == RESOLUTION_AMBIGUOUS_PROJECT
+    assert exc.exit_code == 1
+    assert exc.guidance.startswith("Multiple projects named 'dup'. Disambiguate by id:")
+    assert err == exc.guidance + "\n"
+
+
+def test_unknown_project(tmp_path: Path, capsys) -> None:
+    register_project_v2("known", [tmp_path / "a"])
+
+    exc, err = _resolution_failure(capsys, "missing")
+
+    assert exc.reason == RESOLUTION_UNKNOWN_PROJECT
+    assert exc.exit_code == 1
+    assert exc.guidance == "Unknown project 'missing'.\nAvailable projects: known"
+    assert err == exc.guidance + "\n"
+
+
+def test_disconnected_project_via_project_flag(tmp_path: Path, capsys) -> None:
+    _pid, store_path = register_project_v2("gone", [tmp_path / "a"])
+    shutil.rmtree(store_path)
+
+    exc, err = _resolution_failure(capsys, "gone")
+
+    assert isinstance(exc, DisconnectedProjectExit)
+    assert exc.reason == RESOLUTION_DISCONNECTED_PROJECT
+    assert exc.exit_code == 1
+    assert "nauro reconnect" in exc.guidance
+    assert err == exc.guidance + "\n"
+
+
+def test_disconnected_project_via_cwd(tmp_path: Path, monkeypatch, capsys) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    save_repo_config(repo, {"mode": "local", "id": "01KQ6AZGNA0B3QBF67NBXP3S45", "name": "Pareto"})
+    monkeypatch.chdir(repo)
+
+    exc, err = _resolution_failure(capsys, None)
+
+    assert isinstance(exc, DisconnectedProjectExit)
+    assert exc.reason == RESOLUTION_DISCONNECTED_PROJECT
+    assert exc.exit_code == 1
+    assert err == exc.guidance + "\n"
+
+
+def test_no_project(tmp_path: Path, monkeypatch, capsys) -> None:
+    isolated = tmp_path / "isolated"
+    isolated.mkdir()
+    monkeypatch.chdir(isolated)
+
+    exc, err = _resolution_failure(capsys, None)
+
+    assert exc.reason == RESOLUTION_NO_PROJECT
+    assert exc.exit_code == 1
+    assert exc.guidance == "No project found for current directory.\nRun 'nauro init' first."
+    assert err == exc.guidance + "\n"

--- a/packages/nauro/tests/test_telemetry_subcommand.py
+++ b/packages/nauro/tests/test_telemetry_subcommand.py
@@ -68,5 +68,8 @@ def test_telemetry_no_args_keeps_frozen_subcommand_tree(nauro_home):
 
     result = CliRunner().invoke(app, ["telemetry"])
 
+    # Plain Click routes no-args help to stderr (exit 2, unchanged); the
+    # frozen property under test is the subcommand tree itself.
+    help_text = result.stdout + result.stderr
     for command in ("status", "enable", "disable", "reset"):
-        assert command in result.stdout
+        assert command in help_text


### PR DESCRIPTION
## Why

The CLI's heaviest consumers are coding agents, and three surfaces made them pay for
human decoration or scrape human prose. Rich help panels spend tokens on box-drawing
frames without adding information: `nauro --help` is 6724 characters decorated and
2775 plain, a 59% cut. The ten tool-mirror commands spoke only JSON even though the
MCP surface already renders the same envelopes as human-readable text. And `status`
and `log` spoke only human tables, so anything programmatic had to parse prose.

## What changed

- **Plain help globally.** The root Typer app sets `rich_markup_mode=None` and
  disables pretty exceptions; sub-apps inherit at render time. One consequence of the
  plain-Click layout: invoking a command group with no arguments now prints its help
  to stderr (exit 2, unchanged), matching standard Click behavior.
- **`--format json|text` on the ten auto-generated tool mirrors.** `json` (the
  default) is byte-identical to the previous output, pinned by a mocked-adapter
  matrix across all ten commands. `text` renders the envelope through the shared
  read-tool renderers with the same per-tool kwargs the stdio server threads
  (`get_decision` mode, `search_decisions` query). In text mode the rendered stdout
  is the sole carrier of error prose (no stderr duplicate); exit codes are
  format-independent (error 1, rejected 0, clean 0). Write tools and raising
  renderers fall back to the JSON envelope with json-mode streams. The fallback is
  silent on the CLI - renderer diagnostics stay in the stdio server's log, never on
  the CLI's stderr. The render-or-fallback step lives in a new `nauro.mcp.rendering`
  module shared with the stdio server, whose behavior is unchanged. `--json` stays
  as a compatibility no-op pointing at `--format`.
- **`--json` on `status` and `log`.** `status` was restructured to collect-then-emit:
  one collection pass feeds both the unchanged human rows and a curated pydantic
  payload (capability facts only; probe internals and recorded command strings stay
  out; `healthy` is null unless a probe actually ran). `log --json` mirrors the human
  flag precedence exactly across its three modes (snapshot metadata, `--decisions`
  rows, `--full` bodies) and emits `[]` on an empty store. Log's table rules switch
  to ASCII.
- **Structured resolution failures.** The five failure paths in project resolution
  now attach a pinned reason (`ambiguous_project`, `unknown_project`,
  `disconnected_project`, `no_project`) and the exact printed guidance to the raised
  exception. Stderr text, exit codes, and existing callers are unchanged;
  `status --json` uses it to return `{"status": "error", "error": {reason, guidance}}`
  on stdout while keeping the pinned exit 1 and stderr message.
- The frozen public-contract snapshot regenerates additively: ten `--format` blocks
  and two `--json` blocks, nothing else.

## Test plan

Both package suites green (2188 + 1150 passed), ruff format and check clean. New
coverage: a plain-help guard (no box-drawing characters, `Usage:` prefix) across
root, sub-app, and autogen help; a ten-command byte-identity matrix for json mode
with static mocked adapters; per-tool text-mode equality against the renderers,
including kwargs threading, error/rejection/write/raising-renderer fallbacks and
stream assertions; a five-site reason/guidance matrix for resolution failures with
stderr equality; a full golden-payload equality test for status (every key and value
pinned against a deterministic fixture), probed and `--no-probe` variants, all four
resolution error reasons, and regression tests that a wrong-shape or
malformed-field `.sync-state.json` under active sync leaves status at exit 0 in both
output modes; and the three log JSON modes plus flag-precedence combos in both
output modes. Existing status and log human-output tests pass unmodified, pinning
byte-identical rendering.

## Risk / what to review

- The no-args help stream change (stdout to stderr for command groups) is the one
  user-visible behavior delta outside the flags; exit codes are unchanged.
- The status payload key set is a new machine-readable surface; the exact-key tests
  make additions deliberate, but the curation choices (what stayed out, and that
  `codex_hooks.complete` - like the `healthy` fields - is null when nothing is
  configured rather than vacuously true) deserve a look.
