### PR TITLE
Trim MCP tool-schema prose and export the approval fragment publicly

### DIFF
--- a/packages/nauro-core/src/nauro_core/__init__.py
+++ b/packages/nauro-core/src/nauro_core/__init__.py
@@ -196,6 +196,9 @@ from nauro_core.parsing import (
     scan_decision_references as scan_decision_references,
 )
 from nauro_core.protocol import (
+    APPROVAL_BEFORE_PROPOSE as APPROVAL_BEFORE_PROPOSE,
+)
+from nauro_core.protocol import (
     CANONICAL_FRAGMENTS as CANONICAL_FRAGMENTS,
 )
 from nauro_core.protocol import (
@@ -355,6 +358,7 @@ __all__ = [
     "build_remote_instructions",
     "serialize_snapshot",
     "MCP_INSTRUCTIONS_STATIC",
+    "APPROVAL_BEFORE_PROPOSE",
     "CHECK_DECISION_RETURNS",
     "GET_DECISION_BEFORE_PROPOSING",
     "NO_INVENT_RATIONALE",

--- a/packages/nauro-core/src/nauro_core/constants.py
+++ b/packages/nauro-core/src/nauro_core/constants.py
@@ -6,7 +6,7 @@ defaults, and similarity thresholds.
 """
 
 from nauro_core.protocol import (
-    _APPROVAL_BEFORE_PROPOSE,
+    APPROVAL_BEFORE_PROPOSE,
     CHECK_DECISION_RETURNS,
     GET_DECISION_BEFORE_PROPOSING,
     NO_INVENT_RATIONALE,
@@ -62,7 +62,7 @@ NO_DECISIONS_TO_CHECK = (
     "Use propose_decision to record your first architectural decision, "
     "then check_decision can surface related records for new approaches.\n"
     "\n"
-    f"{_APPROVAL_BEFORE_PROPOSE}"
+    f"{APPROVAL_BEFORE_PROPOSE}"
 )
 
 # ── No-keyword-match assessment (used in check_decision) ──
@@ -171,7 +171,7 @@ MAX_BRIEF_BYTES = 50 * 1024
 # UPDATE_SUPERSEDE_CARE, and RESOLVES_OPEN_QUESTIONS fragments are
 # deliberately omitted here — they are bound to the `propose_decision`
 # ToolSpec parameter descriptions instead, where the agent reads them at the
-# moment of use. The private approval fragment remains here because both
+# moment of use. The approval fragment remains here because both
 # servers must deliver the human-authority boundary at initialization. For the
 # same budget reason the `update_state` "meaningful
 # unit of work" guidance and the `get_context` "do not call list_decisions
@@ -203,7 +203,7 @@ MCP_INSTRUCTIONS_STATIC = (
     "or removes a dependency, establishes a pattern, or cuts scope. Record it "
     "when decided, not at session end, and include what was rejected and why.\n"
     "\n"
-    f"{_APPROVAL_BEFORE_PROPOSE}\n"
+    f"{APPROVAL_BEFORE_PROPOSE}\n"
     "\n"
     f"{NO_INVENT_RATIONALE} Do NOT propose decisions for obvious bug fixes, "
     "adding tests for existing behavior, or renaming variables.\n"

--- a/packages/nauro-core/src/nauro_core/instructions.py
+++ b/packages/nauro-core/src/nauro_core/instructions.py
@@ -29,8 +29,9 @@ MAX_INLINE_PROJECTS = 3
 
 # The 0-project composition must fit entirely under the claude.ai
 # initialize.instructions truncation point (2,023 chars). The static block is
-# capped at 1,700 characters, so this copy targets at most 195 characters and
-# leaves headroom for the two joining newlines.
+# capped at 1,635 characters, leaving 386 characters for this copy plus the
+# two joining newlines; the copy targets at most 195 to keep slack for
+# multi-project compositions.
 WELCOME_NO_PROJECT = (
     "`nauro auth login` before cloud ops. "
     "`nauro init <name>` (local), `nauro init --cloud <name>`, or "

--- a/packages/nauro-core/src/nauro_core/mcp_tools.py
+++ b/packages/nauro-core/src/nauro_core/mcp_tools.py
@@ -19,8 +19,8 @@ from typing import Any, TypedDict
 
 from nauro_core.decision_model import DECISION_TYPE_VALUES
 from nauro_core.protocol import (
-    _APPROVAL_BEFORE_PROPOSE,
     _PROPOSAL_VISIBILITY_DETAIL,
+    APPROVAL_BEFORE_PROPOSE,
     GET_DECISION_BEFORE_PROPOSING,
     PROPOSE_DECISION_OPERATIONS,
     RESOLVES_OPEN_QUESTIONS,
@@ -52,8 +52,8 @@ class ToolSpec(TypedDict):
 _PROJECT_PARAM: dict[str, Any] = {
     "type": "string",
     "description": (
-        "Optional; auto-resolved when you have one project. With multiple, "
-        "list ids via list_projects (hosted) or `nauro projects` (local)."
+        "Optional; auto-resolved for one project. With several, list ids "
+        "via list_projects (hosted) or `nauro projects` (local)."
     ),
 }
 
@@ -78,20 +78,17 @@ GET_CONTEXT: ToolSpec = {
     "description": (
         "Return project context at the requested detail level.\n"
         "\n"
-        "L0 (concise) includes project summary, current state, top open "
-        "questions, and the last 10 active decisions with titles and dates. "
-        "L1 (working set) adds full decision bodies for recent decisions. "
-        "L2 (full dump) includes everything in the store.\n"
+        "L0 (concise): summary, current state, top open questions, last 10 "
+        "active decisions. L1 adds full bodies for recent decisions. L2 "
+        "includes everything in the store.\n"
         "\n"
-        "Payload sizes scale with the store: L1 is a bounded working set; "
-        "L2 is the full dump and can exceed hundreds of thousands of tokens "
-        "on a mature store. Default to L0 plus targeted get_decision "
+        "Payloads scale with the store: L1 is a bounded working set; L2 can "
+        "run past 100k tokens. Default to L0 plus targeted get_decision "
         "lookups.\n"
         "\n"
-        "Call this at session start or when you need to understand the "
-        "project's goals, constraints, and recent history. Do NOT call "
-        "list_decisions after get_context unless you need decisions beyond "
-        "the last 10 or need the include_superseded filter."
+        "Call at session start. Do NOT call list_decisions after "
+        "get_context unless you need decisions beyond the last 10 or the "
+        "include_superseded filter."
     ),
     "annotations": {**_READ_ANNOTATIONS, "idempotentHint": True},
     "input_schema": {
@@ -115,13 +112,10 @@ GET_RAW_FILE: ToolSpec = {
     "description": (
         "Return the raw markdown content of any file in the Nauro project store.\n"
         "\n"
-        "Valid paths include: project.md, state_current.md, stack.md, open-questions.md, "
-        "decisions/042-some-decision.md\n"
-        "\n"
-        "This is a low-level escape hatch. For most use cases, prefer:\n"
-        "- get_context for project overview, state, questions, recent decisions\n"
-        "- get_decision for a specific decision by number\n"
-        "- search_decisions for finding decisions by topic"
+        "A low-level escape hatch: prefer get_context for overview, "
+        "get_decision for one decision, search_decisions for topics. Valid "
+        "paths: project.md, state_current.md, stack.md, open-questions.md, "
+        "decisions/042-some-decision.md"
     ),
     "annotations": {**_READ_ANNOTATIONS, "idempotentHint": True},
     "input_schema": {
@@ -130,8 +124,8 @@ GET_RAW_FILE: ToolSpec = {
             "path": {
                 "type": "string",
                 "description": (
-                    "File path relative to project store root "
-                    "(e.g., 'project.md', 'decisions/001-initial-architecture.md')."
+                    "Path relative to store root (e.g. 'project.md', "
+                    "'decisions/001-initial-architecture.md')."
                 ),
             },
             "project_id": _PROJECT_PARAM,
@@ -144,9 +138,9 @@ LIST_DECISIONS: ToolSpec = {
     "name": "list_decisions",
     "title": "List decision history",
     "description": (
-        "Browse the full decision history. Use when you need decisions beyond "
-        "the last 10 included in get_context, or when you need the "
-        "include_superseded filter. For topical lookups, prefer search_decisions."
+        "Browse the full decision history. Use for decisions beyond the last "
+        "10 in get_context or for the include_superseded filter; for topical "
+        "lookups, prefer search_decisions."
     ),
     "annotations": {**_READ_ANNOTATIONS, "idempotentHint": True},
     "input_schema": {
@@ -174,15 +168,12 @@ GET_DECISION: ToolSpec = {
     "description": (
         "Return a specific decision by its number.\n"
         "\n"
-        "mode=header (compact) returns the triage frontmatter (status, "
-        "supersession, date, type, confidence), the title, and a short lede "
-        "from the rationale — enough to decide whether a decision is worth a "
-        "full read. mode=full (default) returns the complete markdown: "
-        "metadata, full rationale, and rejected alternatives. Use header as "
-        "the standalone triage read for decisions surfaced by "
-        "search_decisions or list_decisions (check_decision hits already "
-        "carry these headers inline), then full for the ones you actually "
-        "reason about."
+        "mode=header returns the triage frontmatter (status, supersession, "
+        "date, type, confidence), the title, and a short rationale lede. "
+        "mode=full (default) returns the complete markdown. Use header to "
+        "triage decisions surfaced by search_decisions or list_decisions "
+        "(check_decision hits already carry headers inline), then full for "
+        "the ones you actually reason about."
     ),
     "annotations": {**_READ_ANNOTATIONS, "idempotentHint": True},
     "input_schema": {
@@ -196,10 +187,7 @@ GET_DECISION: ToolSpec = {
                 "type": "string",
                 "enum": ["header", "full"],
                 "default": "full",
-                "description": (
-                    "header: triage projection (frontmatter + title + lede). "
-                    "full: complete decision body. Default full."
-                ),
+                "description": "header: triage projection; full: complete body. Default full.",
             },
             "project_id": _PROJECT_PARAM,
         },
@@ -213,10 +201,9 @@ DIFF_SINCE_LAST_SESSION: ToolSpec = {
     "description": (
         "Show what changed in the project context since the last snapshot.\n"
         "\n"
-        "When days is omitted, diffs the two most recent snapshots "
-        "(session-scoped). When days is provided, finds the nearest snapshot "
-        "to N days ago and diffs against the current state. Useful for "
-        "catching up on changes made in other sessions or on other machines."
+        "Omitting days diffs the two most recent snapshots (session-scoped); "
+        "with days, diffs the nearest snapshot to N days ago against current "
+        "state. Useful for catching up on other sessions or machines."
     ),
     "annotations": {**_READ_ANNOTATIONS, "idempotentHint": True},
     "input_schema": {
@@ -224,10 +211,7 @@ DIFF_SINCE_LAST_SESSION: ToolSpec = {
         "properties": {
             "days": {
                 "type": "integer",
-                "description": (
-                    "Optional: number of days to look back. Finds the nearest "
-                    "snapshot to N days ago and diffs against the latest."
-                ),
+                "description": "Optional: days to look back.",
             },
             "project_id": _PROJECT_PARAM,
         },
@@ -239,16 +223,13 @@ SEARCH_DECISIONS: ToolSpec = {
     "name": "search_decisions",
     "title": "Search decisions",
     "description": (
-        "Search across all project decisions using BM25 relevance ranking "
-        "against titles and rationale. Returns active decisions by default; "
-        "pass include_superseded=true to include superseded ones.\n"
+        "Search all project decisions with BM25 ranking against titles and "
+        "rationale. Active decisions by default; pass include_superseded=true "
+        "to include superseded ones.\n"
         "\n"
-        "Use when you need to find decisions about a specific topic rather "
-        "than browsing the full list. More token-efficient than list_decisions "
-        "for targeted lookups.\n"
-        "\n"
-        "Returns decision number, title, date, status, and a relevance "
-        "snippet from the matching rationale. Requires a non-empty query."
+        "More token-efficient than list_decisions for topical lookups. "
+        "Returns number, title, date, status, and a relevance snippet; the "
+        "query must be non-empty."
     ),
     "annotations": {**_READ_ANNOTATIONS, "idempotentHint": True},
     "input_schema": {
@@ -284,11 +265,10 @@ CHECK_DECISION: ToolSpec = {
         "\n"
         f"This tool does NOT judge conflicts. {GET_DECISION_BEFORE_PROPOSING}\n"
         "\n"
-        "Use this to consult the project's decision history before committing "
-        'to an approach — especially when the user asks "should we...", '
-        '"what if we...", "can we...", or "check if...". If check_decision '
-        "returns no related decisions and the choice should be recorded, "
-        f"follow this approval boundary: {_APPROVAL_BEFORE_PROPOSE}"
+        "Consult before committing to any approach, especially on "
+        '"should we / what if / can we / check if" asks. If no related '
+        "decisions return and the choice should be recorded, follow this "
+        f"approval boundary before `propose_decision`: {APPROVAL_BEFORE_PROPOSE}"
     ),
     "annotations": {**_READ_ANNOTATIONS, "idempotentHint": True},
     "input_schema": {
@@ -300,9 +280,7 @@ CHECK_DECISION: ToolSpec = {
             },
             "context": {
                 "type": "string",
-                "description": (
-                    "Optional additional context about why you're considering this approach."
-                ),
+                "description": "Optional context on why you're considering this approach.",
             },
             "project_id": _PROJECT_PARAM,
         },
@@ -317,16 +295,15 @@ PROPOSE_DECISION: ToolSpec = {
         "Record an architectural decision. The write commits in a single "
         "call once structural validation passes.\n"
         "\n"
-        "Similarity hits are advisory: they return on similar_decisions and "
-        "never block the write.\n"
+        "Similarity hits are advisory: returned on similar_decisions, never "
+        "blocking the write.\n"
         "\n"
-        f"{_APPROVAL_BEFORE_PROPOSE}\n"
+        f"{APPROVAL_BEFORE_PROPOSE}\n"
         "\n"
         f"{_PROPOSAL_VISIBILITY_DETAIL}\n"
         "\n"
-        "Call this when you choose between two or more approaches, replace "
-        "or remove a dependency, establish a new pattern, or cut scope. "
-        "Always include what was rejected and why."
+        "Use for approach choices, dependency swaps, new patterns, and "
+        "scope cuts; include what was rejected and why."
     ),
     "annotations": {**_WRITE_ANNOTATIONS, "idempotentHint": False},
     "input_schema": {
@@ -336,12 +313,9 @@ PROPOSE_DECISION: ToolSpec = {
                 "type": "string",
                 "default": "",
                 "description": (
-                    "Short title for the decision. Required non-empty for "
-                    "operation=add and operation=supersede: an empty title is "
-                    "structurally rejected. Omit (or leave empty) for "
-                    "operation=update, which appends rationale only and "
-                    "rejects a non-empty title; the target decision keeps its "
-                    "existing title."
+                    "Short title for the decision. Required non-empty for add "
+                    "and supersede; omit for update, which appends rationale "
+                    "only and rejects a non-empty title."
                 ),
             },
             "rationale": {
@@ -354,17 +328,13 @@ PROPOSE_DECISION: ToolSpec = {
                 "type": "string",
                 "enum": ["add", "update", "supersede"],
                 "default": "add",
-                "description": (
-                    f"How this proposal relates to existing decisions. "
-                    f"{PROPOSE_DECISION_OPERATIONS}\n\n"
-                    f"{UPDATE_SUPERSEDE_CARE}"
-                ),
+                "description": (f"{PROPOSE_DECISION_OPERATIONS}\n\n{UPDATE_SUPERSEDE_CARE}"),
             },
             "affected_decision_id": {
                 "type": "string",
                 "description": (
-                    "Required when operation is 'update' or 'supersede'. The id "
-                    "(e.g. 'decision-042') of the decision being modified."
+                    "Required for update and supersede: the id "
+                    "(e.g. 'decision-042') being modified."
                 ),
             },
             "rejected": {
@@ -377,10 +347,9 @@ PROPOSE_DECISION: ToolSpec = {
                     },
                 },
                 "description": (
-                    "Alternatives considered and rejected. Each item must "
-                    "carry a non-empty 'alternative' key (legacy alias: "
-                    "'name') plus a 'reason'; items without one are rejected "
-                    "at the boundary."
+                    "Alternatives considered and rejected. Each item needs a "
+                    "non-empty 'alternative' key (legacy alias: 'name') plus "
+                    "a 'reason'."
                 ),
             },
             "confidence": {
@@ -393,47 +362,38 @@ PROPOSE_DECISION: ToolSpec = {
                 # CLI autogen surface) materialise "medium", which the kernel
                 # then rejects as a disallowed metadata change on update.
                 "description": (
-                    "Author's confidence: 'high' only when a source "
-                    "explicitly approves; 'medium' when best available given "
-                    "known tradeoffs; 'low' for a working assumption that "
-                    "may be revisited."
+                    "Author's confidence: 'high' only with explicit source "
+                    "approval; 'medium' best available; 'low' working "
+                    "assumption."
                 ),
             },
             "decision_type": {
                 "type": "string",
                 "enum": list(DECISION_TYPE_VALUES),
                 "description": (
-                    "Optional architectural category for the decision. Helps "
-                    "downstream filtering and reporting; omit when none "
-                    "applies cleanly."
+                    "Optional architectural category; omit when none applies cleanly."
                 ),
             },
             "reversibility": {
                 "type": "string",
                 "enum": ["easy", "moderate", "hard"],
                 "description": (
-                    "How costly it would be to reverse this decision later. "
-                    "'easy' = config or one-file change; 'moderate' = "
-                    "multi-day migration; 'hard' = irreversible without "
-                    "significant rework."
+                    "Cost to reverse later: 'easy' = config or one-file "
+                    "change; 'moderate' = multi-day migration; 'hard' = "
+                    "major rework."
                 ),
             },
             "files_affected": {
                 "type": "array",
                 "items": {"type": "string"},
                 "description": (
-                    "Optional list of repo-relative paths most affected by "
-                    "this decision. Anchors the decision to specific code "
-                    "for future reviewers."
+                    "Optional repo-relative paths most affected, anchoring the decision to code."
                 ),
             },
             "resolves_questions": {
                 "type": "array",
                 "items": {"type": "string"},
-                "description": (
-                    f"{RESOLVES_OPEN_QUESTIONS} Call get_context "
-                    "(L0 surfaces the open questions) to discover the ids."
-                ),
+                "description": (f"{RESOLVES_OPEN_QUESTIONS} get_context L0 lists the ids."),
             },
             "project_id": _PROJECT_PARAM,
         },
@@ -453,20 +413,14 @@ FLAG_QUESTION: ToolSpec = {
         "questions against a decision. Writes to open-questions.md in the "
         "project store.\n"
         "\n"
-        "To flag: pass `question`. Before writing, checks whether the "
-        "question is already addressed by an existing decision — if so, the "
-        "response includes a hint pointing to that decision (the question is "
-        "still logged).\n"
+        "To flag: pass `question`; if an existing decision already addresses "
+        "it, the response hints at it (the question is still logged).\n"
         "\n"
-        "To resolve: pass `resolved_by` (a decision id) and the entry ids to "
-        "stamp in `targets`. Each named entry is stamped resolved and, when "
-        "the move is prose-safe, relocated below `## Resolved`; entries with "
-        "detached body paragraphs are stamped in place. No new entry is "
-        "appended. The response names any entries relocated.\n"
+        "To resolve: pass `resolved_by` and the entry ids in `targets`; each "
+        "is stamped resolved and, when prose-safe, moved below "
+        "`## Resolved`.\n"
         "\n"
-        "Pass exactly one of `question` or `resolved_by`. Use the flag action "
-        "for ambiguities a human should weigh in on; use the resolve action "
-        "once a decision has answered open questions."
+        "Pass exactly one of `question` or `resolved_by`."
     ),
     "annotations": {**_WRITE_ANNOTATIONS, "idempotentHint": False},
     "input_schema": {
@@ -474,10 +428,7 @@ FLAG_QUESTION: ToolSpec = {
         "properties": {
             "question": {
                 "type": "string",
-                "description": (
-                    "The question to flag. Pass for the flag action; omit when "
-                    "passing resolved_by."
-                ),
+                "description": "The question to flag; omit when passing resolved_by.",
             },
             "context": {
                 "type": "string",
@@ -487,23 +438,18 @@ FLAG_QUESTION: ToolSpec = {
                 "type": "array",
                 "items": {"type": "string"},
                 "description": (
-                    "Question ids (Q### or legacy timestamp form). On the flag "
-                    "action, an optional list of candidates this flag may "
-                    "duplicate: when any named id is already resolved by a "
-                    "decision, the server short-circuits without appending and "
-                    "the response names the resolving decision. On the resolve "
-                    "action (resolved_by set), the entries to stamp as resolved "
-                    "— every id must exist in open-questions.md or the call is "
-                    "rejected."
+                    "Question ids (Q### or legacy timestamp form). On flag: "
+                    "optional duplicate candidates - if any is already "
+                    "resolved, the call short-circuits without appending. On "
+                    "resolve: the entries to stamp; every id must exist."
                 ),
             },
             "resolved_by": {
                 "type": "string",
                 "description": (
-                    "Decision id (e.g. D123) that resolves the entries named in "
-                    "targets. When set, the call resolves instead of appending; "
-                    "the id must resolve to a decision that exists in the store. "
-                    "Pass exactly one of question or resolved_by."
+                    "Decision id (e.g. D123) resolving the entries in "
+                    "targets; when set, the call resolves instead of "
+                    "appending."
                 ),
             },
             "project_id": _PROJECT_PARAM,
@@ -517,12 +463,12 @@ UPDATE_STATE: ToolSpec = {
     "title": "Update project state",
     "description": (
         "Update the project's current state with a progress delta and trigger "
-        "a snapshot. Before writing, checks whether the delta appears to "
-        "repeat work already recorded in recent state entries and returns a "
-        "warning if found (the update is still applied).\n"
+        "a snapshot.\n"
         "\n"
-        "Use when you complete a meaningful unit of work — a feature, a "
-        "refactor, a bug fix — so the next session starts with current context."
+        "If the delta appears to repeat recent state entries, a warning "
+        "returns (the update still applies). Use when you complete a "
+        "meaningful unit of work so the next session starts with current "
+        "context."
     ),
     "annotations": {**_WRITE_ANNOTATIONS, "idempotentHint": False},
     "input_schema": {
@@ -545,9 +491,9 @@ LIST_PROJECTS: ToolSpec = {
     "name": "list_projects",
     "title": "List projects",
     "description": (
-        "Return the projects this user has access to. Other tools auto-resolve "
-        "to your project when you have one — call list_projects only if you "
-        "have multiple and need to pick a specific project_id to pass."
+        "Return the projects this user has access to. Call only when you "
+        "have multiple projects and need a project_id to pass; other tools "
+        "auto-resolve when you have one."
     ),
     "annotations": {**_READ_ANNOTATIONS, "idempotentHint": True},
     "input_schema": {

--- a/packages/nauro-core/src/nauro_core/protocol.py
+++ b/packages/nauro-core/src/nauro_core/protocol.py
@@ -35,19 +35,17 @@ GET_DECISION_BEFORE_PROPOSING = (
 
 PROPOSE_DECISION_OPERATIONS = (
     "Pick the right `operation`:\n"
-    "- `add` (default) — genuinely new ground; no existing decision is being changed.\n"
-    "- `update` — rationale-only; provide `affected_decision_id`. The "
+    "- `add` (default) - genuinely new ground.\n"
+    "- `update` - rationale-only; needs `affected_decision_id`. The "
     "server rejects `title`, `confidence`, `decision_type`, `reversibility`, "
-    "`files_affected`, and `rejected` at the boundary — use supersede for any "
-    "of those.\n"
-    "- `supersede` — replace an existing decision with one that contradicts or "
-    "wholly subsumes it. Provide `affected_decision_id`."
+    "`files_affected`, and `rejected` - use supersede for those.\n"
+    "- `supersede` - replace a decision this one contradicts or wholly "
+    "subsumes; needs `affected_decision_id`."
 )
 
 UPDATE_SUPERSEDE_CARE = (
-    "Default to `add` when uncertain — a later proposal can update or "
-    "supersede it once context clarifies. A wrongly-confirmed supersede is "
-    "hard to reverse."
+    "Default to `add` when uncertain - a later proposal can update or "
+    "supersede it; a wrong supersede is hard to reverse."
 )
 
 NO_INVENT_RATIONALE = (
@@ -55,28 +53,29 @@ NO_INVENT_RATIONALE = (
     "reasoning that supports it."
 )
 
-_APPROVAL_BEFORE_PROPOSE = (
-    "Before `propose_decision`, present the complete add, update, or supersede "
-    "draft as readable Markdown with any related decisions, end the turn with "
-    "the draft, and collect explicit user approval from the user's next reply. "
-    "The call commits immediately after validation."
+APPROVAL_BEFORE_PROPOSE = (
+    "Present the complete add, update, or supersede draft as readable "
+    "Markdown with related decisions, end the turn, and get explicit user "
+    "approval from the user's next reply; the call commits immediately after "
+    "validation."
 )
 
+# Compat alias for consumers pinned to pre-1.6.0 nauro-core; excluded from
+# __all__. Remove once every in-repo import moves to the public name.
+_APPROVAL_BEFORE_PROPOSE = APPROVAL_BEFORE_PROPOSE
+
 _PROPOSAL_VISIBILITY_DETAIL = (
-    "Never couple the draft with an approval prompt (such as AskUserQuestion) "
-    "in the same turn: text emitted before a tool call may never render, so "
-    "the user would approve a draft they cannot see. An approval prompt may "
-    "carry the choice only once the full draft is on screen from a prior turn. "
-    "Structured `propose_decision` arguments stay internal; show raw JSON only "
-    "on an explicit debugging request."
+    "Never pair the draft with an approval prompt (AskUserQuestion) in the "
+    "same turn - text before a tool call may never render. Prompt only once "
+    "the draft is on screen from a prior turn. Arguments stay internal; show "
+    "raw JSON only when debugging is requested."
 )
 
 RESOLVES_OPEN_QUESTIONS = (
-    "When a proposal closes one of `get_context`'s open questions, include "
-    "the question's `[Q###]` id (legacy timestamp ids are accepted) in "
-    "`resolves_questions`. Named entries are stamped with a back-reference to "
-    "the new decision and, when the move is prose-safe, relocated under "
-    "`## Resolved`; unknown or ambiguous ids reject at the boundary."
+    "When a proposal closes an open question, include its `[Q###]` id "
+    "(legacy timestamp ids accepted) in `resolves_questions`. Named entries "
+    "get a back-reference and, when prose-safe, move under `## Resolved`; "
+    "unknown or ambiguous ids reject."
 )
 
 CANONICAL_FRAGMENTS: dict[str, str] = {
@@ -146,6 +145,7 @@ def protocol_tokens_in(text: str, *, only_unknown: bool = False) -> list[str]:
 
 
 __all__ = [
+    "APPROVAL_BEFORE_PROPOSE",
     "CANONICAL_FRAGMENTS",
     "CHECK_DECISION_RETURNS",
     "GET_DECISION_BEFORE_PROPOSING",

--- a/packages/nauro-core/tests/test_constants.py
+++ b/packages/nauro-core/tests/test_constants.py
@@ -24,7 +24,7 @@ from nauro_core.constants import (
 from nauro_core.decision_model import DecisionType
 from nauro_core.instructions import build_remote_instructions
 from nauro_core.protocol import (
-    _APPROVAL_BEFORE_PROPOSE,
+    APPROVAL_BEFORE_PROPOSE,
     GET_DECISION_BEFORE_PROPOSING,
     PROPOSE_DECISION_OPERATIONS,
     RESOLVES_OPEN_QUESTIONS,
@@ -42,7 +42,9 @@ from nauro_core.protocol import (
 # matching ToolSpec descriptions, which tools/list delivers intact past the
 # cliff — that durable home is what makes static-tail loss acceptable.
 MCP_INSTRUCTIONS_TRUNCATION_LIMIT = 2023
-MCP_INSTRUCTIONS_STATIC_MAX_CHARS = 1700
+# Ratcheted down from 1,700 when the approval fragment was trimmed; a future
+# edit that grows the block past the landed size forces a conscious bump.
+MCP_INSTRUCTIONS_STATIC_MAX_CHARS = 1635
 
 
 class TestLimits:
@@ -114,7 +116,7 @@ class TestFilenames:
 class TestMcpInstructions:
     def test_human_authority_and_approval_contract_are_present(self):
         assert "human-ratified project judgment" in MCP_INSTRUCTIONS_STATIC
-        assert _APPROVAL_BEFORE_PROPOSE in MCP_INSTRUCTIONS_STATIC
+        assert APPROVAL_BEFORE_PROPOSE in MCP_INSTRUCTIONS_STATIC
 
     def test_check_decision_section_is_a_precondition(self):
         """The check_decision guidance must explicitly forbid the skip-on-rejection

--- a/packages/nauro-core/tests/test_mcp_tools.py
+++ b/packages/nauro-core/tests/test_mcp_tools.py
@@ -9,7 +9,7 @@ from nauro_core.instructions import (
     build_remote_instructions,
 )
 from nauro_core.mcp_tools import ALL_TOOLS, get_tool_spec
-from nauro_core.protocol import _APPROVAL_BEFORE_PROPOSE
+from nauro_core.protocol import APPROVAL_BEFORE_PROPOSE
 
 # Real-shaped 26-char ULIDs for the inline-rendering tests.
 ULID_ALPHA = "01AAAAAAAAAAAAAAAAAAAAAAAA"
@@ -133,7 +133,15 @@ class TestLookup:
 
     @pytest.mark.parametrize("name", ["check_decision", "propose_decision"])
     def test_decision_write_guidance_carries_approval_boundary(self, name: str) -> None:
-        assert _APPROVAL_BEFORE_PROPOSE in get_tool_spec(name)["description"]
+        assert APPROVAL_BEFORE_PROPOSE in get_tool_spec(name)["description"]
+
+    def test_check_decision_anchors_approval_boundary_to_propose_decision(self) -> None:
+        """The fragment itself no longer names the write call, so every
+        surface must supply the anchor adjacently. check_decision composes
+        it directly before the fragment; a reword that drops the anchor
+        would leave "the call commits" pointing at nothing."""
+        composed = f"before `propose_decision`: {APPROVAL_BEFORE_PROPOSE}"
+        assert composed in get_tool_spec("check_decision")["description"]
 
 
 class TestGetContextLevel:

--- a/packages/nauro-core/tests/test_protocol.py
+++ b/packages/nauro-core/tests/test_protocol.py
@@ -13,8 +13,8 @@ from nauro_core import protocol
 from nauro_core.constants import MCP_INSTRUCTIONS_STATIC
 from nauro_core.mcp_tools import get_tool_spec
 from nauro_core.protocol import (
-    _APPROVAL_BEFORE_PROPOSE,
     _PROPOSAL_VISIBILITY_DETAIL,
+    APPROVAL_BEFORE_PROPOSE,
     CANONICAL_FRAGMENTS,
     CHECK_DECISION_RETURNS,
     GET_DECISION_BEFORE_PROPOSING,
@@ -32,17 +32,17 @@ from nauro_core.protocol import (
 
 
 class TestFragmentAnchors:
-    def test_private_approval_fragment_pins_human_authority(self) -> None:
+    def test_approval_fragment_pins_human_authority(self) -> None:
         for operation in ("add", "update", "supersede"):
-            assert operation in _APPROVAL_BEFORE_PROPOSE
-        assert "related decisions" in _APPROVAL_BEFORE_PROPOSE
-        assert "explicit user approval" in _APPROVAL_BEFORE_PROPOSE
-        assert "commits immediately after validation" in _APPROVAL_BEFORE_PROPOSE
+            assert operation in APPROVAL_BEFORE_PROPOSE
+        assert "related decisions" in APPROVAL_BEFORE_PROPOSE
+        assert "explicit user approval" in APPROVAL_BEFORE_PROPOSE
+        assert "commits immediately after validation" in APPROVAL_BEFORE_PROPOSE
         # Visibility kernel: the draft renders as readable Markdown, the turn
         # ends with it, and approval is the user's next reply.
-        assert "readable Markdown" in _APPROVAL_BEFORE_PROPOSE
-        assert "end the turn" in _APPROVAL_BEFORE_PROPOSE
-        assert "next reply" in _APPROVAL_BEFORE_PROPOSE
+        assert "readable Markdown" in APPROVAL_BEFORE_PROPOSE
+        assert "end the turn" in APPROVAL_BEFORE_PROPOSE
+        assert "next reply" in APPROVAL_BEFORE_PROPOSE
 
     def test_visibility_detail_fragment_forbids_same_turn_prompt_coupling(self) -> None:
         assert "same turn" in _PROPOSAL_VISIBILITY_DETAIL
@@ -54,8 +54,18 @@ class TestFragmentAnchors:
         assert "stay internal" in _PROPOSAL_VISIBILITY_DETAIL
         assert "raw JSON only" in _PROPOSAL_VISIBILITY_DETAIL
 
-    def test_approval_fragments_are_not_public_protocol_api(self) -> None:
+    def test_approval_fragment_public_name_and_compat_alias(self) -> None:
+        """The approval fragment is public API (re-exported for downstream
+        composition); the underscore name survives only as a compat alias
+        for consumers pinned to pre-1.6.0 nauro-core."""
+        import nauro_core
+
+        assert "APPROVAL_BEFORE_PROPOSE" in protocol.__all__
+        assert "APPROVAL_BEFORE_PROPOSE" in nauro_core.__all__
         assert "_APPROVAL_BEFORE_PROPOSE" not in protocol.__all__
+        assert protocol._APPROVAL_BEFORE_PROPOSE is protocol.APPROVAL_BEFORE_PROPOSE
+        assert nauro_core.APPROVAL_BEFORE_PROPOSE is protocol.APPROVAL_BEFORE_PROPOSE
+        # Neither approval fragment is a markdown-substitution token.
         assert "APPROVAL_BEFORE_PROPOSE" not in CANONICAL_FRAGMENTS
         assert "_PROPOSAL_VISIBILITY_DETAIL" not in protocol.__all__
         assert "PROPOSAL_VISIBILITY_DETAIL" not in CANONICAL_FRAGMENTS
@@ -225,8 +235,8 @@ class TestMcpInstructionsComposition:
     def test_mcp_static_contains_fragment_verbatim(self, fragment: str) -> None:
         assert fragment in MCP_INSTRUCTIONS_STATIC
 
-    def test_mcp_static_contains_private_approval_fragment(self) -> None:
-        assert _APPROVAL_BEFORE_PROPOSE in MCP_INSTRUCTIONS_STATIC
+    def test_mcp_static_contains_approval_fragment(self) -> None:
+        assert APPROVAL_BEFORE_PROPOSE in MCP_INSTRUCTIONS_STATIC
         assert "human-ratified project judgment" in MCP_INSTRUCTIONS_STATIC
 
     def test_mcp_static_has_no_unresolved_tokens(self) -> None:

--- a/packages/nauro/src/nauro/mcp/stdio_server.py
+++ b/packages/nauro/src/nauro/mcp/stdio_server.py
@@ -218,12 +218,17 @@ def _origin_from_ctx(mcp_ctx: Context | None) -> OriginDescriptor | None:
 # ``cwd`` exists only on the local transport (the hosted server has no
 # filesystem to resolve against), so its description lives here rather than
 # in the shared ToolSpec registry, which would surface it on remote schemas.
+# The parameter stays despite the server-side os.getcwd() fallback: MCP
+# clients spawn this server outside the workspace (Claude Desktop observed
+# live at cwd=/; Cursor and the Claude Code desktop app spawn without a
+# workspace cwd), and propose_decision feeds cwd into resolve_repo_head for
+# the base-commit stamp.
 _CWD_PARAM = Annotated[
     str | None,
     Field(
         description=(
-            "Optional. The caller's absolute working directory; resolves "
-            "the project from the local registry when project_id is omitted."
+            "Optional. Absolute working directory used to resolve the "
+            "project when project_id is omitted."
         )
     ),
 ]

--- a/packages/nauro/src/nauro/onboarding.py
+++ b/packages/nauro/src/nauro/onboarding.py
@@ -11,6 +11,10 @@ existing callers use.
 """
 
 from nauro_core.constants import NO_DECISIONS_TO_CHECK as NO_DECISIONS_TO_CHECK
+
+# Underscore alias, not the public APPROVAL_BEFORE_PROPOSE name: the public
+# re-export landed after the current nauro-core floor (>=1.5.0), so switching
+# is gated on raising the floor to nauro-core>=1.6.0 at the next release.
 from nauro_core.protocol import _APPROVAL_BEFORE_PROPOSE
 
 WELCOME_NO_PROJECT = (

--- a/packages/nauro/src/nauro/templates/agents_md.py
+++ b/packages/nauro/src/nauro/templates/agents_md.py
@@ -14,6 +14,9 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+# Underscore alias, not the public APPROVAL_BEFORE_PROPOSE name: the public
+# re-export landed after the current nauro-core floor (>=1.5.0), so switching
+# is gated on raising the floor to nauro-core>=1.6.0 at the next release.
 from nauro_core.protocol import _APPROVAL_BEFORE_PROPOSE
 
 from nauro.constants import AGENTS_MD, MANUAL_SECTION_HEADER, SKILLS_SECTION_HEADER
@@ -50,13 +53,16 @@ PROTOCOL_DIGEST = (
     "inline, without judging conflicts; before proposing, read the ones you "
     "reason about in full with `get_decision`.\n"
     "\n"
+    # The fragment no longer names the write call, so this surface supplies
+    # the anchor: without MCP the boundary applies to `nauro propose-decision`.
+    f"Before `propose_decision` (or `nauro propose-decision`): "
     f"{_APPROVAL_BEFORE_PROPOSE}\n"
 )
 
 
-# Rendered in AGENTS.md only: the shared static block sits a few characters
-# under its 1,700-char truncation budget (MCP_INSTRUCTIONS_STATIC_MAX_CHARS in
-# the nauro-core constants tests), so it cannot carry this section.
+# Rendered in AGENTS.md only: the shared static block sits at its 1,635-char
+# truncation budget (MCP_INSTRUCTIONS_STATIC_MAX_CHARS in the nauro-core
+# constants tests), so it cannot carry this section.
 EVIDENCE_RIDER_SECTION = (
     "## When to record outcome evidence\n"
     "\n"

--- a/packages/nauro/tests/snapshots/public_contract_v1.json
+++ b/packages/nauro/tests/snapshots/public_contract_v1.json
@@ -1667,6 +1667,7 @@
   "contract_version": 1,
   "nauro_core_public_api": [
     "ALL_TOOLS",
+    "APPROVAL_BEFORE_PROPOSE",
     "CHECK_DECISION_RETURNS",
     "DECISIONS_DIR",
     "DECISION_HASHES_FILE",

--- a/packages/nauro/tests/test_agents_md.py
+++ b/packages/nauro/tests/test_agents_md.py
@@ -44,8 +44,14 @@ def test_generate_includes_behavioral_instructions():
     assert result.count(public_artifacts_rule) == 1
     # The digest keeps the check_decision preflight rule.
     assert "call `check_decision` with the proposal" in result
-    # The human-authority boundary survives verbatim: a no-MCP session can
-    # still reach `nauro propose-decision` (single-call commit) via shell.
+    # The human-authority boundary survives verbatim, and the digest supplies
+    # the write-call anchor the fragment itself no longer carries: a no-MCP
+    # session can still reach `nauro propose-decision` (single-call commit)
+    # via shell.
+    anchored_boundary = (
+        f"Before `propose_decision` (or `nauro propose-decision`): {_APPROVAL_BEFORE_PROPOSE}"
+    )
+    assert result.count(anchored_boundary) == 1
     assert result.count(_APPROVAL_BEFORE_PROPOSE) == 1
     assert "advisory conflict checks" not in result
 

--- a/packages/nauro/tests/test_stdio_server.py
+++ b/packages/nauro/tests/test_stdio_server.py
@@ -641,6 +641,53 @@ class TestToolSpecDescriptionsReachAgent:
         )
 
 
+class TestCwdParamReachesAgent:
+    """Every locally registered tool must advertise an optional ``cwd``.
+
+    ``cwd`` exists only in the FastMCP wrapper annotations (the shared
+    ToolSpec registry deliberately omits it so it never surfaces on remote
+    schemas), so the frozen-contract snapshot cannot see it - this test is
+    the guard for its emitted shape. The parameter is load-bearing: MCP
+    clients spawn this server outside the workspace (Claude Desktop observed
+    live at cwd=/), and propose_decision feeds cwd into resolve_repo_head
+    for the base-commit stamp.
+    """
+
+    LOCAL_TOOLS = (
+        "get_context",
+        "get_raw_file",
+        "list_decisions",
+        "get_decision",
+        "diff_since_last_session",
+        "search_decisions",
+        "check_decision",
+        "propose_decision",
+        "flag_question",
+        "update_state",
+    )
+
+    @pytest.fixture
+    def schemas_by_name(self):
+        import asyncio
+
+        tools = asyncio.run(mcp.list_tools())
+        return {t.name: t.inputSchema for t in tools}
+
+    def test_covers_every_registered_tool(self, schemas_by_name):
+        assert set(schemas_by_name) == set(self.LOCAL_TOOLS)
+
+    @pytest.mark.parametrize("tool", LOCAL_TOOLS)
+    def test_cwd_is_optional_nullable_string(self, schemas_by_name, tool):
+        schema = schemas_by_name[tool]
+        assert "cwd" in schema["properties"], f"{tool} does not advertise cwd"
+        cwd = schema["properties"]["cwd"]
+        assert "cwd" not in schema.get("required", []), f"{tool} must not require cwd"
+        assert {option["type"] for option in cwd["anyOf"]} == {"string", "null"}, (
+            f"{tool} cwd must be string-or-null, got: {cwd!r}"
+        )
+        assert cwd["default"] is None
+
+
 class TestContentSizeLimits:
     """H3 STRIDE fix: local tools must reject oversized inputs."""
 


### PR DESCRIPTION
## Why

The ten local MCP tool schemas ship on every connected session, so their description and parameter prose is a recurring ambient token cost. The wording had grown restatement-heavy: operation semantics, resolve mechanics, and empty-state guidance were each saying the same thing at two levels of detail. This applies the shared-registry trim pattern: compress the prose once at the source (the shared tool registry and the protocol fragments both servers splice from) so every transport inherits the cut.

## What changed

- Prose-tightened all 10 local tool schemas plus the hosted-only list_projects in `nauro_core.mcp_tools`, and the five protocol fragments they compose from. Measured with the cl100k tokenizer: per-tool description+parameter prose drops from 2,371 to 1,789 tokens (-25%; 11,253 -> 8,223 chars). No tool name, parameter name, type, required set, enum, default, or annotation changed anywhere; every first paragraph stays self-sufficient (it is the CLI mirror's help line, enforced by the help-equality test).
- The approval-boundary fragment becomes public API (`APPROVAL_BEFORE_PROPOSE` in `nauro_core.protocol` and the curated `nauro_core` `__all__`) via the frozen-contract additive export path; the underscore name survives as a compat alias, excluded from `__all__`, because the downstream composition in the nauro package is pinned to the current nauro-core floor. Those two import sites carry comments gating the switch on the next release's floor raise. The contract snapshot diff is exactly the one added `__all__` line.
- The trimmed approval fragment shrinks the static initialize-instructions block 1,685 -> 1,635 chars; its ceiling in the constants tests is consciously ratcheted down to the landed size, and both stale 1,700-char comment references (AGENTS.md template, instructions module) now match the new numbers.
- The fragment no longer opens by naming the write call, so every consuming surface anchors it adjacently: check_decision's description directs "follow this approval boundary before `propose_decision`:", and the AGENTS.md protocol digest supplies its own anchor line covering the shell path too. Both compositions are pinned by tests (anchor + fragment adjacency, not bare containment).
- New structural test: a live tools/list against the stdio server must emit, on all ten tools, an optional string-or-null `cwd` with default None. `cwd` exists only in the FastMCP annotations, so the frozen-contract snapshot cannot see it; it is load-bearing because MCP clients spawn the server outside the workspace (Claude Desktop observed live at cwd=/), and the decision write path resolves the repo HEAD stamp from it. The trimmed `cwd` description keeps a comment recording that evidence.
- Runtime texts that compose from these constants (the empty-store check response, the packaged propose adapter docstring) inherit the trims with no code change.

## Test plan

- `uv run --no-sync pytest packages/nauro-core/tests/` - 1151 passed
- `uv run --no-sync pytest packages/nauro/tests/` - 2199 passed, 10 skipped
- `NAURO_UPDATE_CONTRACT=1` regen + snapshot diff reviewed: exactly one added line (the new public export)
- `ruff check` / `ruff format --check` clean

## Risk / what to review

- The trims touch a frozen surface's prose only; the snapshot diff proves schema shape is untouched. Worth a skim: the reworded approval and visibility fragments (all substring pins from the fragment anchor tests survive verbatim or were updated in the same commit), and the check_decision description, which keeps both the broad "consult before committing to any approach" trigger and the compact trigger-phrase cue.

## Deferred

- The two nauro-package import sites stay on the underscore alias until the nauro-core floor rises at the next release; switching them is a two-line follow-up gated on that bump.
