### PR TITLE
Bound the rendered read surface: L2 context gate and per-file raw budgets

### DIFF
--- a/packages/nauro-core/src/nauro_core/bounded_read.py
+++ b/packages/nauro-core/src/nauro_core/bounded_read.py
@@ -1,0 +1,428 @@
+"""Bounded rendering of raw store file reads.
+
+Pure, total helpers behind :mod:`nauro_core.renderers`: given a file's
+content and its canonical store-relative path, produce the bounded form the
+rendered agent channel emits (the stdio MCP ``content[0]`` block and the CLI
+``--format text`` mode). The CLI's default json output never routes through
+here - it stays the uncapped local recovery channel.
+
+Guarantees:
+
+* Content at or under its budget passes through byte-verbatim.
+* Budgets bound retained file content only; elision markers are additional
+  bounded-constant annotations naming the exact omitted char count and the
+  recovery paths.
+* Cuts land on the nearest newline inside the retained window (last newline
+  for head windows, first for tail windows), with a hard cut at exactly the
+  budget when the window contains no newline.
+* An extraction-eligible discovery-pointer entry is either fully retained in
+  a window or fully omitted, never split: when one intersects a retained
+  window's cut, the cut shifts to exclude the entire entry.
+* Total: never raises. Content that defeats the structure-aware
+  open-questions split falls back to the plain head-keep rule.
+
+``open-questions.md`` gets a structure-aware split driven by the parsed
+:class:`~nauro_core.questions.OpenQuestionsFile` block model, with a local
+exact-header scan (a header line whose stripped text equals ``## Resolved``)
+instead of the parser's "contains resolved" divider heuristic - so a header
+like ``## Unresolved threads`` never classifies content as resolved history.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from nauro_core.constants import (
+    BOUNDED_READ_RECOVERY,
+    CONTEXT_FILE_CHAR_BUDGET,
+    OPEN_PREAMBLE_HEAD_CHARS,
+    OPEN_PREAMBLE_TAIL_CHARS,
+    OPEN_QUESTIONS_MD,
+    OPEN_QUESTIONS_MID_ELISION_MARKER,
+    OPEN_QUESTIONS_POST_CUT_MARKER,
+    OPEN_QUESTIONS_POST_ELIDED_MARKER,
+    OPEN_QUESTIONS_RESOLVED_ELIDED_MARKER,
+    POINTER_BLOCK_HEADER,
+    POINTER_EXTRACT_LIMIT,
+    POINTER_OVERFLOW_TRAILER,
+    RAW_FILE_CHAR_BUDGET,
+    RAW_FILE_HEAD_CUT_MARKER,
+    RAW_FILE_TAIL_CUT_MARKER,
+    TAIL_KEEP_FILENAMES,
+)
+from nauro_core.questions import (
+    EntryBlock,
+    OpenQuestionsFile,
+    QuestionEntry,
+    truncate_entry_text,
+)
+
+_RESOLVED_HEADER_EXACT = "## Resolved"
+_UNKNOWN_PATH_PLACEHOLDER = "<path>"
+_CONTEXT_DIR_PREFIX = "context/"
+
+
+def render_bounded_file(content: str, path: str | None) -> str:
+    """Bounded render of one raw-file read, classified by canonical path.
+
+    ``path`` is the canonical store-relative path (or ``None`` when the
+    calling surface did not thread one, in which case the generic head-keep
+    rule applies). Content at or under its budget returns byte-verbatim.
+    """
+    budget = _budget_for(path)
+    if len(content) <= budget:
+        return content
+    if path == OPEN_QUESTIONS_MD:
+        try:
+            return _bounded_open_questions(content, path)
+        except Exception:
+            # Totality contract: a structural split failure must never
+            # propagate into the renderer fallback (which would emit the
+            # full unbounded envelope). Degrade to the plain head-keep rule.
+            return _head_keep(content, budget, path)
+    if path in TAIL_KEEP_FILENAMES:
+        return _tail_keep(content, budget, path)
+    return _head_keep(content, budget, path)
+
+
+def _budget_for(path: str | None) -> int:
+    if path is not None and path.startswith(_CONTEXT_DIR_PREFIX) and path.endswith(".md"):
+        return CONTEXT_FILE_CHAR_BUDGET
+    return RAW_FILE_CHAR_BUDGET
+
+
+def _display_path(path: str | None) -> str:
+    return path if path is not None else _UNKNOWN_PATH_PLACEHOLDER
+
+
+def _recovery(path: str | None) -> str:
+    return BOUNDED_READ_RECOVERY.format(path=_display_path(path))
+
+
+def _head_keep(content: str, budget: int, path: str | None) -> str:
+    window = content[:budget]
+    newline = window.rfind("\n")
+    end = newline if newline != -1 else budget
+    marker = RAW_FILE_HEAD_CUT_MARKER.format(
+        omitted=f"{len(content) - end:,}",
+        path=_display_path(path),
+        recovery=_recovery(path),
+    )
+    return content[:end] + "\n" + marker
+
+
+def _tail_keep(content: str, budget: int, path: str | None) -> str:
+    naive = len(content) - budget
+    window = content[naive:]
+    newline = window.find("\n")
+    start = naive + newline + 1 if newline != -1 else naive
+    marker = RAW_FILE_TAIL_CUT_MARKER.format(
+        omitted=f"{start:,}",
+        path=_display_path(path),
+        recovery=_recovery(path),
+    )
+    return marker + "\n" + content[start:]
+
+
+@dataclass(frozen=True)
+class _Span:
+    """Half-open character span ``[start, end)`` in the source text."""
+
+    start: int
+    end: int
+
+    @property
+    def length(self) -> int:
+        return self.end - self.start
+
+
+@dataclass(frozen=True)
+class _Window:
+    """Retained sub-span ``[start, end)`` of one region."""
+
+    start: int
+    end: int
+
+    @property
+    def length(self) -> int:
+        return self.end - self.start
+
+    def contains(self, span: _Span) -> bool:
+        return span.start >= self.start and span.end <= self.end
+
+
+@dataclass(frozen=True)
+class _LocatedPointer:
+    """An extraction-eligible discovery-pointer entry and its source span.
+
+    Eligible means: an open (no ``resolved_by`` annotation) discovery-pointer
+    entry sitting in open content - entries physically under ``## Resolved``
+    are retired history and never extracted.
+    """
+
+    span: _Span
+    entry: QuestionEntry
+
+
+@dataclass(frozen=True)
+class _Layout:
+    """Region map of open-questions.md content under the exact-header rule.
+
+    ``preamble`` is the open content before the ``## Resolved`` header (the
+    whole file when no exact header exists). ``resolved`` runs from that
+    header to the next section header, exclusive. ``post`` is everything
+    after the resolved section. The three spans tile the source text.
+    """
+
+    preamble: _Span
+    resolved: _Span | None
+    post: _Span | None
+    post_section_count: int
+    pointers: tuple[_LocatedPointer, ...]
+
+
+@dataclass(frozen=True)
+class _ElidedSpan:
+    """One elision point: its marker plus the pointers omitted with it."""
+
+    marker: str
+    pointers: tuple[_LocatedPointer, ...]
+
+
+def _bounded_open_questions(content: str, path: str) -> str:
+    layout = _locate_layout(content)
+    if layout is None:
+        return _head_keep(content, RAW_FILE_CHAR_BUDGET, path)
+    recovery = _recovery(path)
+
+    preamble = layout.preamble
+    preamble_pointers = [p for p in layout.pointers if p.span.end <= preamble.end]
+    post_pointers = (
+        [p for p in layout.pointers if p.span.start >= layout.post.start]
+        if layout.post is not None
+        else []
+    )
+
+    pieces: list[str | _ElidedSpan] = []
+
+    if preamble.length <= RAW_FILE_CHAR_BUDGET:
+        rendered_preamble = preamble.length
+        pieces.append(content[preamble.start : preamble.end])
+    else:
+        head = _head_window(content, preamble, OPEN_PREAMBLE_HEAD_CHARS, preamble_pointers)
+        tail = _tail_window(content, preamble, OPEN_PREAMBLE_TAIL_CHARS, preamble_pointers)
+        rendered_preamble = head.length + tail.length
+        omitted = preamble.length - rendered_preamble
+        mid_pointers = tuple(
+            p for p in preamble_pointers if not (head.contains(p.span) or tail.contains(p.span))
+        )
+        if head.length:
+            pieces.append(content[head.start : head.end])
+        pieces.append(
+            _ElidedSpan(
+                marker=OPEN_QUESTIONS_MID_ELISION_MARKER.format(
+                    omitted=f"{omitted:,}", recovery=recovery
+                ),
+                pointers=mid_pointers,
+            )
+        )
+        if tail.length:
+            pieces.append(content[tail.start : tail.end])
+
+    if layout.resolved is not None:
+        pieces.append(
+            OPEN_QUESTIONS_RESOLVED_ELIDED_MARKER.format(
+                omitted=f"{layout.resolved.length:,}", recovery=recovery
+            )
+        )
+
+    if layout.post is not None:
+        post = layout.post
+        remaining = RAW_FILE_CHAR_BUDGET - rendered_preamble
+        if remaining <= 0:
+            pieces.append(
+                _ElidedSpan(
+                    marker=OPEN_QUESTIONS_POST_ELIDED_MARKER.format(
+                        count=layout.post_section_count,
+                        omitted=f"{post.length:,}",
+                        recovery=recovery,
+                    ),
+                    pointers=tuple(post_pointers),
+                )
+            )
+        elif post.length <= remaining:
+            pieces.append(content[post.start : post.end])
+        else:
+            head = _head_window(content, post, remaining, post_pointers)
+            omitted = post.length - head.length
+            cut_pointers = tuple(p for p in post_pointers if not head.contains(p.span))
+            if head.length:
+                pieces.append(content[head.start : head.end])
+            pieces.append(
+                _ElidedSpan(
+                    marker=OPEN_QUESTIONS_POST_CUT_MARKER.format(
+                        omitted=f"{omitted:,}", recovery=recovery
+                    ),
+                    pointers=cut_pointers,
+                )
+            )
+
+    return _assemble(pieces, recovery)
+
+
+def _locate_layout(content: str) -> _Layout | None:
+    """Map the parsed block model back onto character spans of the source.
+
+    Alignment relies on every block covering exactly ``len(render_lines())``
+    source lines (the parser consumes lines one-to-one). When the model does
+    not tile the source, return ``None`` and let the caller fall back to the
+    plain head-keep rule.
+    """
+    lines = content.split("\n")
+    parsed = OpenQuestionsFile.parse(content)
+
+    offsets: list[int] = []
+    position = 0
+    for line in lines:
+        offsets.append(position)
+        position += len(line) + 1
+
+    cursor = _header_line_count(lines)
+    ranges: list[tuple[int, int]] = []
+    for block in parsed.blocks:
+        count = len(block.render_lines())
+        ranges.append((cursor, cursor + count))
+        cursor += count
+    if cursor != len(lines):
+        return None
+
+    total = len(content)
+
+    def entry_span(block_idx: int) -> _Span:
+        first_line, end_line = ranges[block_idx]
+        return _Span(offsets[first_line], offsets[end_line - 1] + len(lines[end_line - 1]))
+
+    # Exact-header rule over source lines, not parsed HeaderBlocks: the
+    # comparison is whitespace-stripped, and the parser only mints a
+    # HeaderBlock for lines that begin directly with "## " — an indented
+    # "  ## Resolved" satisfies the rule but never becomes a block. The
+    # section still ends at the next section-header line, exclusive.
+    resolved_line: int | None = None
+    for idx, line in enumerate(lines):
+        if line.strip() == _RESOLVED_HEADER_EXACT:
+            resolved_line = idx
+            break
+
+    post_line: int | None = None
+    if resolved_line is not None:
+        for idx in range(resolved_line + 1, len(lines)):
+            if lines[idx].lstrip().startswith("## "):
+                post_line = idx
+                break
+
+    if resolved_line is None:
+        preamble = _Span(0, total)
+        resolved = None
+        post = None
+        section_count = 0
+    else:
+        resolved_start = offsets[resolved_line]
+        preamble = _Span(0, resolved_start)
+        if post_line is None:
+            resolved = _Span(resolved_start, total)
+            post = None
+            section_count = 0
+        else:
+            post_start = offsets[post_line]
+            resolved = _Span(resolved_start, post_start)
+            post = _Span(post_start, total)
+            section_count = sum(1 for line in lines[post_line:] if line.lstrip().startswith("## "))
+
+    pointers: list[_LocatedPointer] = []
+    for idx, block in enumerate(parsed.blocks):
+        if not isinstance(block, EntryBlock):
+            continue
+        entry = block.entry
+        if entry.resolved_by is not None or not entry.is_discovery_pointer:
+            continue
+        span = entry_span(idx)
+        in_resolved_region = resolved is not None and resolved.start <= span.start < resolved.end
+        if in_resolved_region:
+            continue
+        pointers.append(_LocatedPointer(span=span, entry=entry))
+
+    return _Layout(preamble, resolved, post, section_count, tuple(pointers))
+
+
+def _header_line_count(lines: list[str]) -> int:
+    """Lines the parser consumes before the first block (blanks + ``# `` header)."""
+    i = 0
+    while i < len(lines) and not lines[i].strip():
+        i += 1
+    if i < len(lines) and lines[i].startswith("# ") and not lines[i].startswith("## "):
+        i += 1
+    return i
+
+
+def _head_window(
+    content: str, region: _Span, budget: int, pointers: list[_LocatedPointer]
+) -> _Window:
+    """Retained head window of ``region``: newline-aligned cut, whole-entry safe."""
+    if budget <= 0:
+        return _Window(region.start, region.start)
+    if region.length <= budget:
+        return _Window(region.start, region.end)
+    window_text = content[region.start : region.start + budget]
+    newline = window_text.rfind("\n")
+    cut = region.start + (newline if newline != -1 else budget)
+    for pointer in pointers:
+        if pointer.span.start < cut < pointer.span.end:
+            cut = max(region.start, pointer.span.start - 1)
+            break
+    return _Window(region.start, cut)
+
+
+def _tail_window(
+    content: str, region: _Span, budget: int, pointers: list[_LocatedPointer]
+) -> _Window:
+    """Retained tail window ending at ``region``'s last character."""
+    if budget <= 0:
+        return _Window(region.end, region.end)
+    if region.length <= budget:
+        return _Window(region.start, region.end)
+    naive = region.end - budget
+    window_text = content[naive : region.end]
+    newline = window_text.find("\n")
+    start = naive + newline + 1 if newline != -1 else naive
+    for pointer in pointers:
+        if pointer.span.start < start < pointer.span.end:
+            start = min(region.end, pointer.span.end + 1)
+            break
+    return _Window(start, region.end)
+
+
+def _assemble(pieces: list[str | _ElidedSpan], recovery: str) -> str:
+    """Join retained text, markers, and per-span pointer blocks in file order.
+
+    The global :data:`POINTER_EXTRACT_LIMIT` is allocated across spans in
+    file order; a single trailer line reports any overflow.
+    """
+    parts: list[str] = []
+    slots = POINTER_EXTRACT_LIMIT
+    overflow = 0
+    for piece in pieces:
+        if isinstance(piece, str):
+            if piece:
+                parts.append(piece)
+            continue
+        parts.append(piece.marker)
+        extracted = piece.pointers[:slots] if slots > 0 else ()
+        overflow += len(piece.pointers) - len(extracted)
+        slots -= len(extracted)
+        if extracted:
+            block_lines = [POINTER_BLOCK_HEADER]
+            block_lines.extend(truncate_entry_text("\n".join(p.entry.render())) for p in extracted)
+            parts.append("\n".join(block_lines))
+    if overflow:
+        parts.append(POINTER_OVERFLOW_TRAILER.format(overflow=overflow, recovery=recovery))
+    return "\n".join(parts)

--- a/packages/nauro-core/src/nauro_core/constants.py
+++ b/packages/nauro-core/src/nauro_core/constants.py
@@ -159,6 +159,72 @@ MAX_APPROACH_LENGTH = 5_000
 # briefs run ~11-21 KB; 50 KiB leaves headroom without inviting storage bombs.
 MAX_BRIEF_BYTES = 50 * 1024
 
+# ── Bounded rendered reads (renderer channel only) ──
+# Character caps on the rendered agent-facing read surface: the stdio MCP
+# content[0] block and the CLI's --format text mode, applied inside
+# nauro_core.renderers. The CLI's default json output stays uncapped - it is
+# the local recovery channel. Budgets key off characters; reported token
+# estimates are chars / CHARS_PER_TOKEN. Budgets bound retained file content
+# only: elision markers are additional bounded-constant annotations.
+L2_CHAR_BUDGET = 200_000
+RAW_FILE_CHAR_BUDGET = 40_000
+# context/*.md shared briefs get their own ceiling. Sync pushes are bounded
+# at MAX_BRIEF_BYTES (50 KiB), so every sync-valid brief renders whole; only
+# a locally-retained oversized brief is bounded.
+CONTEXT_FILE_CHAR_BUDGET = 51_200
+# Over-budget open-questions.md: the open preamble keeps a head window plus
+# an unconditionally reserved tail window ending at its last character, so
+# the newest appended entries always render.
+OPEN_PREAMBLE_HEAD_CHARS = 30_000
+OPEN_PREAMBLE_TAIL_CHARS = 10_000
+# Cap on discovery-pointer entries re-surfaced from elided open-questions
+# spans, total across all spans in file order.
+POINTER_EXTRACT_LIMIT = 20
+# Files whose newest content appends at the end render tail-first.
+TAIL_KEEP_FILENAMES: tuple[str, ...] = (STATE_HISTORY_FILENAME,)
+
+# Recovery clause spliced into every bounded-read elision marker. {path} is
+# the canonical store-relative path when known, or a placeholder otherwise.
+BOUNDED_READ_RECOVERY = (
+    "full text: `nauro get-raw-file {path}` (default json output is unbounded; "
+    "redirect it to a file) or the store file itself"
+)
+RAW_FILE_HEAD_CUT_MARKER = "[... {omitted} chars omitted from the end of {path} - {recovery}]"
+RAW_FILE_TAIL_CUT_MARKER = "[... {omitted} chars omitted from the start of {path} - {recovery}]"
+OPEN_QUESTIONS_MID_ELISION_MARKER = (
+    "[... {omitted} chars of older open entries omitted here - {recovery}]"
+)
+OPEN_QUESTIONS_RESOLVED_ELIDED_MARKER = (
+    "[## Resolved section elided ({omitted} chars) - {recovery}]"
+)
+OPEN_QUESTIONS_POST_CUT_MARKER = (
+    "[... {omitted} chars omitted from the sections after ## Resolved - {recovery}]"
+)
+OPEN_QUESTIONS_POST_ELIDED_MARKER = (
+    "[{count} section(s) after ## Resolved elided ({omitted} chars) - {recovery}]"
+)
+POINTER_BLOCK_HEADER = "[discovery pointers from the omitted content above:]"
+POINTER_OVERFLOW_TRAILER = (
+    "[... {overflow} more omitted discovery pointers not shown - {recovery}]"
+)
+
+# Guard report returned instead of an over-budget get_context body. Size-keyed,
+# not level-keyed: any over-budget body gates on every transport; {level_clause}
+# names the requested level only when the surface threaded it.
+CONTEXT_GUARD_REPORT = (
+    "Context withheld: the assembled get_context{level_clause} payload is "
+    "{chars} chars (~{tokens} tokens estimated), over the {budget}-char "
+    "rendered budget. Returning it inline would flood the session context.\n"
+    "\n"
+    "Recover incrementally instead:\n"
+    "- get_context level L1 - the bounded working set\n"
+    "- get_raw_file per store file (project.md, stack.md, state_current.md, "
+    "state_history.md, open-questions.md, context/*.md)\n"
+    "- get_decision / list_decisions (include_superseded=true) for decision history\n"
+    "- on a local install: `nauro get-context --level 2` prints the complete "
+    "json envelope - redirect it to a file"
+)
+
 # ── MCP server instructions ──
 # Delivered via the MCP `initialize` response to every connected client.
 # Single source of truth: both local (stdio) and remote (HTTP) servers

--- a/packages/nauro-core/src/nauro_core/renderers.py
+++ b/packages/nauro-core/src/nauro_core/renderers.py
@@ -38,7 +38,14 @@ from __future__ import annotations
 
 import textwrap
 
-from nauro_core.constants import LEXICAL_RANK_CAVEAT, NO_RELATED_DECISIONS
+from nauro_core.bounded_read import render_bounded_file
+from nauro_core.constants import (
+    CHARS_PER_TOKEN,
+    CONTEXT_GUARD_REPORT,
+    L2_CHAR_BUDGET,
+    LEXICAL_RANK_CAVEAT,
+    NO_RELATED_DECISIONS,
+)
 from nauro_core.parsing import _decision_label
 
 # Width target for the rendered text blocks. Picked to fit standard
@@ -92,8 +99,16 @@ def _guidance(result: dict) -> str:
     repo that has not run ``nauro init`` returns the actionable welcome text
     instead of an empty string (``get_context``/``get_decision``) or a
     misleading "no results" line (``check_decision``/``search_decisions``).
+
+    A non-string ``guidance`` value is ignored: guidance is advisory
+    metadata, and raising on a malformed field would trigger the callers'
+    full-envelope JSON fallback — which, with an oversized body alongside,
+    would bypass the bounded-read guards entirely.
     """
-    return (result.get("guidance") or "").strip()
+    guidance = result.get("guidance")
+    if not isinstance(guidance, str):
+        return ""
+    return guidance.strip()
 
 
 def disconnected_reason_code(result: dict) -> str | None:
@@ -360,7 +375,7 @@ def render_list_decisions(result: dict) -> str:
     return "\n".join(lines).rstrip()
 
 
-def render_get_context(result: dict) -> str:
+def render_get_context(result: dict, level: str | int | None = None) -> str:
     """Render context. The kernel already assembles human-readable markdown;
     pass it through, with structured errors surfaced explicitly.
 
@@ -368,21 +383,55 @@ def render_get_context(result: dict) -> str:
     surfaces the assembled markdown under ``context``; the local stdio
     server uses ``content`` (the kernel ``GetContextResult`` field name).
     Accept either so a single renderer covers both transports.
+
+    A body over :data:`L2_CHAR_BUDGET` chars is withheld behind a compact
+    guard report instead. The gate is size-keyed, not level-keyed: any
+    over-budget body gates on every transport, with or without the ``level``
+    renderer kwarg - ``level``, where threaded, only tailors the report's
+    wording. At or under budget the rendering is byte-identical to the
+    pre-guard passthrough.
     """
     if guidance := _connection_guidance(result):
         return guidance
     if "error" in result:
         return _error_block(result["error"])
     body = result.get("context") or result.get("content") or ""
+    if not isinstance(body, str):
+        body = str(body)
+    if len(body) > L2_CHAR_BUDGET:
+        return _context_guard_report(len(body), level)
     return body.rstrip() or _guidance(result)
 
 
-def render_get_raw_file(result: dict) -> str:
+def _context_guard_report(size: int, level: str | int | None) -> str:
+    """Compact size-and-recovery report replacing an over-budget context body."""
+    if isinstance(level, bool):
+        level_clause = ""
+    elif isinstance(level, int):
+        level_clause = f" (level L{level})"
+    elif isinstance(level, str) and level.strip():
+        level_clause = f" (level {level.strip()})"
+    else:
+        level_clause = ""
+    return CONTEXT_GUARD_REPORT.format(
+        level_clause=level_clause,
+        chars=f"{size:,}",
+        tokens=f"{size // CHARS_PER_TOKEN:,}",
+        budget=f"{L2_CHAR_BUDGET:,}",
+    )
+
+
+def render_get_raw_file(result: dict, path: str | None = None) -> str:
     """Render a raw-file read.
 
-    On a hit the file content passes through verbatim — it is already the
-    primary human-readable payload. On a miss the error line renders
-    first (``Error: File not found: <path>``), then the adapter-composed
+    On a hit the file content renders through the bounded-read rules of
+    :func:`nauro_core.bounded_read.render_bounded_file`: byte-verbatim at or
+    under its budget, head/tail/structure-aware truncation with elision
+    markers over it. ``path`` is the canonical store-relative path threaded
+    as a renderer kwarg by the local surfaces (it never enters the result
+    envelope); a surface that threads none gets the generic head-keep rule.
+    On a miss the error line renders first
+    (``Error: File not found: <path>``), then the adapter-composed
     ``available_files`` hint in its exact order — the ordering (canonical
     root files, remaining root markdown, per-directory anchors) is a
     cross-surface contract, never reorder it here.
@@ -391,16 +440,28 @@ def render_get_raw_file(result: dict) -> str:
         return guidance
     if "error" in result:
         lines = [_error_block(result["error"])]
-        available = result.get("available_files") or []
-        if available:
+        # Tolerate a malformed hint: a non-list value or non-string entries
+        # are dropped rather than raised on — a raising renderer would fall
+        # back to the full JSON envelope and defeat the bounded render.
+        available = result.get("available_files")
+        hint_paths = (
+            [entry for entry in available if isinstance(entry, str)]
+            if isinstance(available, (list, tuple))
+            else []
+        )
+        if hint_paths:
             lines.append("")
             lines.append("Available files:")
-            lines.extend(f"  - {path}" for path in available)
+            lines.extend(f"  - {path}" for path in hint_paths)
         return "\n".join(lines)
     content = result.get("content")
     if content is None:
         return _guidance(result)
-    return content
+    if not isinstance(content, str):
+        content = str(content)
+    if not isinstance(path, str):
+        path = None
+    return render_bounded_file(content, path)
 
 
 def render_diff_since_last_session(result: dict) -> str:

--- a/packages/nauro-core/tests/test_bounded_read.py
+++ b/packages/nauro-core/tests/test_bounded_read.py
@@ -1,0 +1,443 @@
+"""Bounded rendered reads: truncation matrix, open-questions split, context gate.
+
+Pins the renderer-channel guards:
+
+* ``render_get_raw_file`` bounds file content by canonical path: head-keep
+  by default, tail-keep for append-at-end files, a larger per-brief budget
+  for ``context/*.md``, and a structure-aware split for
+  ``open-questions.md`` (exact ``## Resolved`` header rule, reserved
+  preamble tail window, whole-entry discovery-pointer extraction).
+* ``render_get_context`` withholds an over-budget body behind a compact
+  guard report; the gate is size-keyed, not level-keyed.
+* Both renderers are total: malformed envelopes, absent kwargs, and
+  non-string bodies never raise (a raising renderer would trigger the
+  full-envelope JSON fallback, which is exactly what the guards exist to
+  prevent).
+"""
+
+from __future__ import annotations
+
+from nauro_core.constants import (
+    BOUNDED_READ_RECOVERY,
+    CHARS_PER_TOKEN,
+    CONTEXT_FILE_CHAR_BUDGET,
+    CONTEXT_GUARD_REPORT,
+    L2_CHAR_BUDGET,
+    OPEN_QUESTIONS_MID_ELISION_MARKER,
+    OPEN_QUESTIONS_RESOLVED_ELIDED_MARKER,
+    POINTER_BLOCK_HEADER,
+    POINTER_EXTRACT_LIMIT,
+    POINTER_OVERFLOW_TRAILER,
+    QUESTION_ENTRY_CHAR_BUDGET,
+    RAW_FILE_CHAR_BUDGET,
+    RAW_FILE_HEAD_CUT_MARKER,
+    RAW_FILE_TAIL_CUT_MARKER,
+)
+from nauro_core.questions import QUESTION_TRUNCATION_POINTER, OpenQuestionsFile
+from nauro_core.renderers import RENDERERS, render_get_context, render_get_raw_file
+
+OQ = "open-questions.md"
+
+
+def _raw(content: str, path: str | None = None) -> str:
+    return render_get_raw_file({"store": "local", "content": content}, path=path)
+
+
+def _recovery(path: str) -> str:
+    return BOUNDED_READ_RECOVERY.format(path=path)
+
+
+def _head_marker(omitted: int, path: str) -> str:
+    return RAW_FILE_HEAD_CUT_MARKER.format(
+        omitted=f"{omitted:,}", path=path, recovery=_recovery(path)
+    )
+
+
+def _tail_marker(omitted: int, path: str) -> str:
+    return RAW_FILE_TAIL_CUT_MARKER.format(
+        omitted=f"{omitted:,}", path=path, recovery=_recovery(path)
+    )
+
+
+def _lines(count: int, tag: str = "x", width: int = 100) -> str:
+    """``count`` newline-terminated lines of exactly ``width`` chars each."""
+    out = []
+    for i in range(count):
+        body = f"{tag}{i:05d} " + "q" * width
+        out.append(body[: width - 1] + "\n")
+    return "".join(out)
+
+
+class TestHeadKeep:
+    def test_exact_budget_is_byte_verbatim(self):
+        content = _lines(400)
+        assert len(content) == RAW_FILE_CHAR_BUDGET
+        assert _raw(content, "stack.md") == content
+
+    def test_budget_plus_one_truncates_at_last_newline(self):
+        content = _lines(400) + "z"
+        expected = content[:39_999] + "\n" + _head_marker(2, "stack.md")
+        assert _raw(content, "stack.md") == expected
+
+    def test_no_newline_hard_cut_at_exact_budget(self):
+        content = "a" * (RAW_FILE_CHAR_BUDGET + 123)
+        expected = content[:RAW_FILE_CHAR_BUDGET] + "\n" + _head_marker(123, "stack.md")
+        assert _raw(content, "stack.md") == expected
+
+    def test_unknown_path_bounded_under_default_budget(self):
+        content = "a" * (RAW_FILE_CHAR_BUDGET + 1)
+        out = _raw(content, None)
+        assert out == content[:RAW_FILE_CHAR_BUDGET] + "\n" + _head_marker(1, "<path>")
+
+
+class TestTailKeep:
+    def test_exact_budget_is_byte_verbatim(self):
+        content = _lines(400)
+        assert _raw(content, "state_history.md") == content
+
+    def test_budget_plus_one_keeps_tail_from_first_newline(self):
+        content = "z" + _lines(400)
+        expected = _tail_marker(101, "state_history.md") + "\n" + content[101:]
+        assert _raw(content, "state_history.md") == expected
+
+    def test_no_newline_hard_cut_keeps_exactly_budget(self):
+        content = "a" * (RAW_FILE_CHAR_BUDGET + 50)
+        expected = _tail_marker(50, "state_history.md") + "\n" + content[50:]
+        assert _raw(content, "state_history.md") == expected
+
+
+class TestBriefBudget:
+    def test_brief_at_cap_renders_whole(self):
+        content = "b" * CONTEXT_FILE_CHAR_BUDGET
+        assert _raw(content, "context/shared-brief.md") == content
+
+    def test_brief_over_cap_is_bounded(self):
+        path = "context/shared-brief.md"
+        content = "b" * (CONTEXT_FILE_CHAR_BUDGET + 1)
+        expected = content[:CONTEXT_FILE_CHAR_BUDGET] + "\n" + _head_marker(1, path)
+        assert _raw(content, path) == expected
+
+    def test_oversized_locally_retained_brief_is_bounded(self):
+        path = "context/big.md"
+        content = _lines(700)  # 70,000 chars: over the sync push cap, kept locally
+        expected = content[:51_199] + "\n" + _head_marker(18_801, path)
+        assert _raw(content, path) == expected
+
+
+class TestContextGate:
+    def test_at_budget_is_byte_identical(self):
+        body = "c" * L2_CHAR_BUDGET
+        assert render_get_context({"store": "local", "content": body}) == body
+
+    def test_over_budget_returns_guard_report(self):
+        size = L2_CHAR_BUDGET + 1
+        body = "c" * size
+        expected = CONTEXT_GUARD_REPORT.format(
+            level_clause="",
+            chars=f"{size:,}",
+            tokens=f"{size // CHARS_PER_TOKEN:,}",
+            budget=f"{L2_CHAR_BUDGET:,}",
+        )
+        assert render_get_context({"store": "local", "content": body}) == expected
+
+    def test_gate_is_size_keyed_not_level_keyed(self):
+        body = "c" * (L2_CHAR_BUDGET + 5)
+        out = render_get_context({"content": body}, level="L0")
+        assert "(level L0)" in out
+        assert "c" * 100 not in out
+
+    def test_int_level_tailors_wording(self):
+        body = "c" * (L2_CHAR_BUDGET + 5)
+        assert "(level L2)" in render_get_context({"content": body}, level=2)
+
+    def test_remote_context_key_gates_and_passes(self):
+        big = "c" * (L2_CHAR_BUDGET + 1)
+        assert "Context withheld" in render_get_context({"context": big})
+        assert render_get_context({"context": "small body"}) == "small body"
+
+    def test_under_budget_with_level_kwarg_unchanged(self):
+        assert render_get_context({"content": "hello"}, level="L2") == "hello"
+
+
+class TestTotality:
+    def test_empty_envelope_get_raw_file(self):
+        assert render_get_raw_file({}) == ""
+
+    def test_non_string_content_get_raw_file(self):
+        assert render_get_raw_file({"content": 42}, path="stack.md") == "42"
+        render_get_raw_file({"content": ["a", "b"]}, path=None)
+
+    def test_non_string_path_treated_as_absent(self):
+        out = render_get_raw_file({"content": "x" * 50_000}, path=123)
+        assert "<path>" in out
+
+    def test_non_string_context_body(self):
+        render_get_context({"content": {"k": 1}})
+        render_get_context({"context": 7})
+
+    def test_weird_level_over_budget_never_raises(self):
+        out = render_get_context({"content": "x" * (L2_CHAR_BUDGET + 1)}, level=object())
+        assert "Context withheld" in out
+        assert "(level" not in out
+
+    def test_malformed_open_questions_never_raises(self):
+        _raw("\x00" * 50_000, OQ)
+        _raw("- [broken\n" * 8_000, OQ)
+        _raw(("### topic\nbody\n" + "- [Q0] bad num\n") * 3_000, OQ)
+
+    def test_registry_renderers_accept_no_kwargs(self):
+        assert RENDERERS["get_raw_file"]({"content": "hi"}) == "hi"
+        assert RENDERERS["get_context"]({"content": "hi"}) == "hi"
+
+    def test_malformed_guidance_never_bypasses_raw_file_bound(self):
+        # A non-string guidance field must not raise: a raising renderer
+        # falls back to the full JSON envelope, which with an oversized
+        # content field would bypass the bound entirely.
+        out = render_get_raw_file({"guidance": 42, "content": "a" * 50_000}, path="stack.md")
+        assert "chars omitted from the end of stack.md" in out
+        assert len(out) < 41_000
+
+    def test_malformed_guidance_ignored_when_body_empty(self):
+        assert render_get_raw_file({"guidance": 42}) == ""
+        assert render_get_context({"guidance": ["not", "a", "string"]}) == ""
+
+    def test_malformed_available_files_never_triggers_json_fallback(self):
+        envelope = {
+            "error": {"kind": "error", "reason": "File not found: nope.md"},
+            "available_files": 7,
+            "content": "a" * 100_000,
+        }
+        out = render_get_raw_file(envelope)
+        assert out == "Error: File not found: nope.md"
+
+    def test_non_string_available_files_entries_dropped(self):
+        envelope = {
+            "error": {"kind": "error", "reason": "File not found: nope.md"},
+            "available_files": ["project.md", 5, None],
+        }
+        out = render_get_raw_file(envelope)
+        assert "  - project.md" in out
+        assert "5" not in out
+
+    def test_malformed_guidance_never_bypasses_context_gate(self):
+        out = render_get_context({"guidance": 42, "content": "c" * (L2_CHAR_BUDGET + 1)})
+        assert "Context withheld" in out
+        assert "c" * 100 not in out
+
+
+class TestOpenQuestionsSplit:
+    def test_no_divider_two_region_split_exact(self):
+        # 50,000 chars of open content, no ## Resolved header: whole file is
+        # open, split into the 30K head window and the reserved 10K tail
+        # window ending at the file's last character.
+        content = _lines(500)
+        mid = OPEN_QUESTIONS_MID_ELISION_MARKER.format(
+            omitted=f"{10_101:,}", recovery=_recovery(OQ)
+        )
+        expected = content[:29_999] + "\n" + mid + "\n" + content[40_100:]
+        out = _raw(content, OQ)
+        assert out == expected
+        assert "Resolved section elided" not in out
+
+    def test_unresolved_threads_header_is_not_a_divider(self):
+        content = (
+            "# Open Questions\n" + _lines(250, "a") + "## Unresolved threads\n" + _lines(250, "b")
+        )
+        # Premise: the parser's substring heuristic WOULD treat this header
+        # as the resolved divider; the bounded read must not.
+        assert OpenQuestionsFile.parse(content).resolved_divider_idx is not None
+        out = _raw(content, OQ)
+        assert "Resolved section elided" not in out
+        assert "## Unresolved threads" in out
+        assert "b00249" in out  # newest entries survive in the reserved tail
+
+    def test_indented_resolved_header_still_divides(self):
+        # The exact-header rule is a whitespace-stripped comparison over
+        # source lines: "  ## Resolved  " divides even though the parser
+        # never mints a HeaderBlock for an indented header line.
+        content = (
+            "# Open Questions\n"
+            + _lines(200, "p")
+            + "  ## Resolved  \n"
+            + "- [Q60] BRIEF: context/q.md - retired pointer\n"
+            + _lines(300, "r")
+        )
+        resolved_start = content.index("  ## Resolved")
+        out = _raw(content, OQ)
+        assert (
+            OPEN_QUESTIONS_RESOLVED_ELIDED_MARKER.format(
+                omitted=f"{len(content) - resolved_start:,}", recovery=_recovery(OQ)
+            )
+            in out
+        )
+        assert "[Q60]" not in out  # under the divider: retired, never extracted
+        assert POINTER_BLOCK_HEADER not in out
+        assert "p00199" in out  # open preamble renders whole
+        assert "r00000" not in out
+
+    def test_post_resolved_active_section_retained_exact(self):
+        preamble = "# Open Questions\n" + _lines(50, "p")  # 5,017
+        resolved = "## Resolved\n" + _lines(400, "r")  # 40,012
+        post = "## Active\n" + _lines(20, "c")  # 2,010
+        content = preamble + resolved + post
+        marker = OPEN_QUESTIONS_RESOLVED_ELIDED_MARKER.format(
+            omitted=f"{40_012:,}", recovery=_recovery(OQ)
+        )
+        expected = content[:5_017] + "\n" + marker + "\n" + content[5_017 + 40_012 :]
+        out = _raw(content, OQ)
+        assert out == expected
+        assert "## Active" in out
+        assert "c00019" in out
+
+    def test_realistic_merge_fixture_extracts_stranded_pointer(self):
+        # Local preamble > 30K, then a remote-only run opening with a fresh
+        # discovery pointer followed by > 10K of older remote-only entries,
+        # then > 10K resolved history: the pointer lands outside both windows
+        # and must survive via the extraction block.
+        pointer_line = "- [Q900] BRIEF: context/shared-brief.md - " + "d" * 600 + "\n"
+        content = (
+            "# Open Questions\n"
+            + _lines(310, "lo")
+            + pointer_line
+            + _lines(120, "rm")
+            + "## Resolved\n"
+            + _lines(120, "rs")
+        )
+        out = _raw(content, OQ)
+
+        assert out.count("- [Q900]") == 1
+        assert QUESTION_TRUNCATION_POINTER in out  # entry > 480 chars, truncated
+        assert "d" * 600 not in out
+        assert "rs00000" not in out  # resolved history elided
+        assert (
+            OPEN_QUESTIONS_RESOLVED_ELIDED_MARKER.format(
+                omitted=f"{12_012:,}", recovery=_recovery(OQ)
+            )
+            in out
+        )
+
+        mid_idx = out.index(" chars of older open entries omitted here")
+        block_idx = out.index(POINTER_BLOCK_HEADER)
+        pointer_idx = out.index("- [Q900]")
+        tail_idx = out.index("rm00119")
+        assert mid_idx < block_idx < pointer_idx < tail_idx
+
+    def test_head_boundary_straddling_pointer_excluded_whole(self):
+        entry = (
+            "- [Q800] BRIEF: context/x.md - "
+            + "e" * 118
+            + "\n"  # 150 chars
+            + ("  cont " + "f" * 142 + "\n") * 3  # 3 x 150 chars
+        )
+        content = _lines(298, "ha") + entry + _lines(150, "hb")
+        out = _raw(content, OQ)
+        # Newline-aligned head cut (29,949) falls inside the entry; the cut
+        # shifts back to exclude the whole entry, which is extracted once.
+        assert out.count("- [Q800]") == 1
+        assert out.index(POINTER_BLOCK_HEADER) < out.index("- [Q800]")
+        assert "  cont" in out
+        assert QUESTION_TRUNCATION_POINTER in out  # 599-char entry truncated at 480
+        assert "ha00297" in out  # head window ends at the filler boundary
+        assert (
+            OPEN_QUESTIONS_MID_ELISION_MARKER.format(omitted=f"{5_701:,}", recovery=_recovery(OQ))
+            in out
+        )
+
+    def test_tail_boundary_straddling_pointer_excluded_whole(self):
+        entry = (
+            "- [Q801] RESUME: context/y.md - "
+            + "e" * 117
+            + "\n"  # 150 chars
+            + ("  cont " + "f" * 142 + "\n") * 3  # 3 x 150 chars
+        )
+        content = _lines(350, "ta") + entry + _lines(97, "tb")
+        out = _raw(content, OQ)
+        # The tail window's aligned start (35,450) falls inside the entry;
+        # the start shifts past the entry, which is extracted once.
+        assert out.count("- [Q801]") == 1
+        assert out.index(POINTER_BLOCK_HEADER) < out.index("- [Q801]")
+        assert out.index("- [Q801]") < out.index("tb00000")
+        assert (
+            OPEN_QUESTIONS_MID_ELISION_MARKER.format(omitted=f"{5_601:,}", recovery=_recovery(OQ))
+            in out
+        )
+
+    def test_pointer_inside_retained_window_not_extracted(self):
+        pointer_line = "- [Q810] BRIEF: context/z.md - fully retained pointer\n"
+        content = pointer_line + _lines(450)
+        out = _raw(content, OQ)
+        assert out.count("- [Q810]") == 1
+        assert POINTER_BLOCK_HEADER not in out
+        assert out.index("- [Q810]") < out.index(" chars of older open entries omitted here")
+
+    def test_resolved_and_annotated_pointers_not_extracted(self):
+        annotated = "- [Resolved by D10 on 2026-01-01] [Q51] BRIEF: context/y.md - old\n"
+        content = (
+            "# Open Questions\n"
+            + _lines(305, "ra")
+            + annotated
+            + _lines(110, "rb")
+            + "## Resolved\n"
+            + "- [Q50] BRIEF: context/z.md - retired\n"
+            + _lines(30, "rc")
+        )
+        out = _raw(content, OQ)
+        assert "[Q51]" not in out  # resolved_by-annotated: elided, never extracted
+        assert "[Q50]" not in out  # physically under ## Resolved: retired history
+        assert POINTER_BLOCK_HEADER not in out
+
+    def test_extraction_capped_at_twenty_in_file_order_with_trailer(self):
+        pointers = "".join(
+            f"- [Q{100 + i}] BRIEF: context/p{i}.md - stranded item number {i}\n"
+            for i in range(23)
+        )
+        content = _lines(302, "oa") + pointers + _lines(110, "ob")
+        out = _raw(content, OQ)
+
+        for i in range(POINTER_EXTRACT_LIMIT):
+            assert out.count(f"- [Q{100 + i}]") == 1
+        for i in range(POINTER_EXTRACT_LIMIT, 23):
+            assert f"[Q{100 + i}]" not in out
+        assert POINTER_OVERFLOW_TRAILER.format(overflow=3, recovery=_recovery(OQ)) in out
+        assert out.index("- [Q100]") < out.index("- [Q101]") < out.index("- [Q119]")
+
+        block_start = out.index(POINTER_BLOCK_HEADER)
+        block_end = out.index("ob00", block_start)
+        per_entry_ceiling = QUESTION_ENTRY_CHAR_BUDGET + len(QUESTION_TRUNCATION_POINTER) + 2
+        assert block_end - block_start <= (
+            len(POINTER_BLOCK_HEADER) + POINTER_EXTRACT_LIMIT * per_entry_ceiling
+        )
+
+    def test_combined_region_post_cut_pointers_in_post_span(self):
+        post = (
+            "## Later notes\n"
+            + "- [Q700] BRIEF: context/a.md - fresh follow-up\n"
+            + _lines(120, "pb")
+            + "- [Q701] SELECT: context/b.md - candidate set\n"
+        )
+        content = _lines(450, "pa") + "## Resolved\n" + _lines(100, "pr") + post
+        out = _raw(content, OQ)
+
+        # The preamble tail reservation holds even with post-resolved content.
+        assert "pa00449" in out  # last preamble line (tail window)
+        assert "pa00351" in out  # first line of the reserved tail
+        assert "pa00350" not in out.split(POINTER_BLOCK_HEADER)[0]  # elided middle
+
+        assert (
+            OPEN_QUESTIONS_RESOLVED_ELIDED_MARKER.format(
+                omitted=f"{10_012:,}", recovery=_recovery(OQ)
+            )
+            in out
+        )
+        assert "pr00000" not in out
+        assert "## Later notes" in out
+
+        post_marker_idx = out.index(" chars omitted from the sections after ## Resolved")
+        assert out.count(POINTER_BLOCK_HEADER) == 1
+        assert post_marker_idx < out.index(POINTER_BLOCK_HEADER)
+        # Q700 fits inside the remaining post budget and stays retained ahead
+        # of the cut; Q701 sits in the elided post span and surfaces in that
+        # span's extraction block after the marker. Neither is duplicated.
+        assert out.index("- [Q700]") < post_marker_idx < out.index("- [Q701]")
+        assert out.count("- [Q700]") == 1
+        assert out.count("- [Q701]") == 1

--- a/packages/nauro/src/nauro/cli/autogen.py
+++ b/packages/nauro/src/nauro/cli/autogen.py
@@ -36,7 +36,7 @@ from nauro_core.mcp_tools import ALL_TOOLS, ToolSpec
 from nauro.cli._json_input import parse_json_list_of_dicts
 from nauro.cli.utils import cli_origin, resolve_target_project
 from nauro.mcp import tools as mcp_tools
-from nauro.mcp.rendering import try_render_envelope
+from nauro.mcp.rendering import resolve_renderer_kwargs, try_render_envelope
 from nauro.store.repo_head import resolve_process_repo_head
 
 # Tools that should auto-generate a CLI command. list_projects is
@@ -84,16 +84,6 @@ class OutputFormat(str, enum.Enum):
 
     json = "json"
     text = "text"
-
-
-# Schema properties threaded to the tool's renderer as kwargs in text mode,
-# mirroring the stdio server's per-tool threading: ``get_decision`` passes the
-# requested mode; ``search_decisions`` passes the query the kernel envelope
-# intentionally omits.
-_RENDERER_KWARG_PROPERTIES: dict[str, tuple[str, ...]] = {
-    "get_decision": ("mode",),
-    "search_decisions": ("query",),
-}
 
 
 def _command_name(tool_name: str) -> str:
@@ -470,8 +460,6 @@ def _make_command(spec: ToolSpec) -> Callable[..., None]:
     accepts_origin = "origin" in adapter_params
     accepts_base_commit = "base_commit" in adapter_params
 
-    renderer_kwarg_names = _RENDERER_KWARG_PROPERTIES.get(tool_name, ())
-
     def command(**kwargs: Any) -> None:
         project = kwargs.pop("project", None)
         # --json is a parity no-op; --format selects the output mode.
@@ -509,9 +497,9 @@ def _make_command(spec: ToolSpec) -> Callable[..., None]:
         envelope = _resolve_adapter(tool_name)(store_path, **adapter_kwargs)
 
         if output_format is OutputFormat.text:
-            renderer_kwargs = {
-                name: kwargs[name] for name in renderer_kwarg_names if name in kwargs
-            }
+            # Same per-tool renderer-kwarg threading as the stdio server,
+            # through the shared resolver so the surfaces cannot drift.
+            renderer_kwargs = resolve_renderer_kwargs(tool_name, kwargs, store_path)
             # A renderer failure falls back silently to json-mode streams;
             # a traceback on stderr would break the stream contract.
             rendered = try_render_envelope(tool_name, envelope, renderer_kwargs).text

--- a/packages/nauro/src/nauro/mcp/rendering.py
+++ b/packages/nauro/src/nauro/mcp/rendering.py
@@ -15,9 +15,12 @@ logging it here.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any, NamedTuple
 
 from nauro_core.renderers import RENDERERS
+
+from nauro.store.filesystem_store import canonical_store_relative_path
 
 
 class RenderOutcome(NamedTuple):
@@ -31,6 +34,45 @@ class RenderOutcome(NamedTuple):
 
     text: str | None
     failure: Exception | None
+
+
+def resolve_renderer_kwargs(
+    tool_name: str, request_args: dict[str, Any], store_path: Path | None
+) -> dict[str, Any]:
+    """Per-tool renderer kwargs for a read-tool call.
+
+    The single source both local text surfaces (the stdio server and the CLI
+    ``--format text`` mode) use to thread request context to the shared
+    renderers, so the two surfaces cannot drift:
+
+    * ``get_decision`` — the requested ``mode``.
+    * ``search_decisions`` — the ``query`` the kernel envelope omits.
+    * ``get_context`` — the requested ``level``. Tailors the wording of the
+      over-budget guard report only; the size gate itself is level-blind.
+    * ``get_raw_file`` — the canonical store-relative ``path`` that selects
+      the bounded-read rule (so ``context/../open-questions.md`` routes to
+      the open-questions rule). Renderer-side only; the canonical path is
+      never placed on the result envelope.
+
+    Total: unknown tools, absent or mistyped args, a missing store path, or
+    a path that does not resolve inside the store simply omit the kwarg.
+    """
+    if tool_name == "get_decision":
+        mode = request_args.get("mode")
+        return {"mode": mode} if isinstance(mode, str) else {}
+    if tool_name == "search_decisions":
+        query = request_args.get("query")
+        return {"query": query} if isinstance(query, str) else {}
+    if tool_name == "get_context":
+        level = request_args.get("level")
+        return {"level": level} if isinstance(level, (str, int)) else {}
+    if tool_name == "get_raw_file":
+        raw_path = request_args.get("path")
+        if store_path is None or not isinstance(raw_path, str):
+            return {}
+        canonical = canonical_store_relative_path(store_path, raw_path)
+        return {"path": canonical} if canonical is not None else {}
+    return {}
 
 
 def try_render_envelope(

--- a/packages/nauro/src/nauro/mcp/stdio_server.py
+++ b/packages/nauro/src/nauro/mcp/stdio_server.py
@@ -48,7 +48,7 @@ from nauro_core.renderers import disconnected_reason_code
 from pydantic import Field
 
 from nauro import __version__
-from nauro.mcp.rendering import try_render_envelope
+from nauro.mcp.rendering import resolve_renderer_kwargs, try_render_envelope
 from nauro.mcp.tools import (
     tool_check_decision,
     tool_diff_since_last_session,
@@ -248,7 +248,11 @@ def get_context(
     store_path, err = _resolve_or_error(project_id, cwd)
     # tool_get_context accepts both int and string levels.
     result = err if err is not None else tool_get_context(store_path, level)
-    return _wrap_with_renderer("get_context", result)
+    return _wrap_with_renderer(
+        "get_context",
+        result,
+        resolve_renderer_kwargs("get_context", {"level": level}, store_path),
+    )
 
 
 @mcp.tool(**_spec_kwargs("get_raw_file"))
@@ -261,7 +265,11 @@ def get_raw_file(
 ) -> CallToolResult:
     store_path, err = _resolve_or_error(project_id, cwd)
     result = err if err is not None else tool_get_raw_file(store_path, path)
-    return _wrap_with_renderer("get_raw_file", result)
+    return _wrap_with_renderer(
+        "get_raw_file",
+        result,
+        resolve_renderer_kwargs("get_raw_file", {"path": path}, store_path),
+    )
 
 
 @mcp.tool(**_spec_kwargs("list_decisions"))
@@ -293,7 +301,11 @@ def get_decision(
 ) -> CallToolResult:
     store_path, err = _resolve_or_error(project_id, cwd)
     result = err if err is not None else tool_get_decision(store_path, number, mode)
-    return _wrap_with_renderer("get_decision", result, {"mode": mode})
+    return _wrap_with_renderer(
+        "get_decision",
+        result,
+        resolve_renderer_kwargs("get_decision", {"mode": mode}, store_path),
+    )
 
 
 @mcp.tool(**_spec_kwargs("diff_since_last_session"))
@@ -333,7 +345,11 @@ def search_decisions(
     # The kernel envelope omits the echoed query; thread it to the renderer
     # so the local header shows the term, matching the remote transport,
     # which carries query in its envelope.
-    return _wrap_with_renderer("search_decisions", result, {"query": query})
+    return _wrap_with_renderer(
+        "search_decisions",
+        result,
+        resolve_renderer_kwargs("search_decisions", {"query": query}, store_path),
+    )
 
 
 @mcp.tool(**_spec_kwargs("check_decision"))

--- a/packages/nauro/src/nauro/store/filesystem_store.py
+++ b/packages/nauro/src/nauro/store/filesystem_store.py
@@ -15,6 +15,25 @@ from nauro_core.constants import DECISIONS_DIR
 from nauro.store.reader import read_text_lenient
 
 
+def canonical_store_relative_path(store_path: Path, path: str) -> str | None:
+    """Resolve ``path`` against the store root to its canonical relative form.
+
+    Returns the POSIX-style store-relative path
+    (``context/../open-questions.md`` resolves to ``open-questions.md``) or
+    ``None`` when the path escapes the store or cannot be resolved.
+    Read-side companion to :meth:`FilesystemStore._resolve_within`:
+    consumers that key per-file rules off the requested path (the
+    bounded-read renderer kwargs) classify on this canonical form so alias
+    spellings cannot dodge a rule. The escape rejection on the read/write
+    path itself stays in :meth:`FilesystemStore._resolve_within`.
+    """
+    try:
+        target = (store_path / path).resolve()
+        return target.relative_to(store_path.resolve()).as_posix()
+    except (ValueError, OSError):
+        return None
+
+
 class FilesystemStore:
     """Concrete ``Store`` rooted at a single project's on-disk directory.
 

--- a/packages/nauro/tests/test_bounded_read_surfaces.py
+++ b/packages/nauro/tests/test_bounded_read_surfaces.py
@@ -1,0 +1,190 @@
+"""Local-surface wiring for bounded rendered reads.
+
+Pins the two consumers of the shared renderer-kwarg resolver:
+
+* The stdio MCP server returns the context guard report as the sole
+  ``content[0]`` block for an oversized L2 payload, and threads the
+  canonical file path so alias spellings reach the right bounded-read rule.
+* The CLI ``--format text`` mode is capped through the same resolver while
+  the default ``--format json`` envelope stays byte-complete - the local
+  recovery channel.
+
+Canonicalization itself (``canonical_store_relative_path``) is pinned here
+too, including the ``context/../open-questions.md`` alias.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from mcp.types import CallToolResult
+from typer.testing import CliRunner
+
+from nauro.cli.main import app
+from nauro.constants import REPO_CONFIG_MODE_LOCAL
+from nauro.mcp.rendering import resolve_renderer_kwargs, try_render_envelope
+from nauro.mcp.stdio_server import get_context, get_raw_file
+from nauro.store.filesystem_store import canonical_store_relative_path
+from nauro.store.registry import register_project_v2
+from nauro.store.repo_config import save_repo_config
+from nauro.templates.scaffolds import scaffold_project_store
+
+runner = CliRunner()
+
+# An open-questions file over the 40,000-char render budget whose resolved
+# section only elides when the canonical path routes it to the hot-file rule
+# (generic head-keep would retain the preamble and cut inside the resolved
+# body instead of eliding it behind the section marker).
+_OQ_PREAMBLE = "# Open Questions\n" + ("p" * 99 + "\n") * 200
+_OQ_RESOLVED = "## Resolved\n" + ("r" * 99 + "\n") * 300
+_OQ_CONTENT = _OQ_PREAMBLE + _OQ_RESOLVED
+
+
+@pytest.fixture
+def bounded_repo(tmp_path: Path, monkeypatch) -> Path:
+    """Registered local-mode project with cwd inside its repo."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    pid, store_path = register_project_v2("bounded", [repo], mode=REPO_CONFIG_MODE_LOCAL)
+    save_repo_config(repo, {"mode": REPO_CONFIG_MODE_LOCAL, "id": pid, "name": "bounded"})
+    scaffold_project_store("bounded", store_path)
+    monkeypatch.chdir(repo)
+    return store_path
+
+
+class TestCanonicalStoreRelativePath:
+    def test_parent_alias_resolves_to_hot_file(self, tmp_path: Path):
+        assert (
+            canonical_store_relative_path(tmp_path, "context/../open-questions.md")
+            == "open-questions.md"
+        )
+
+    def test_plain_paths_pass_through(self, tmp_path: Path):
+        assert canonical_store_relative_path(tmp_path, "state_history.md") == "state_history.md"
+        assert canonical_store_relative_path(tmp_path, "context/brief.md") == "context/brief.md"
+
+    def test_escapes_yield_none(self, tmp_path: Path):
+        assert canonical_store_relative_path(tmp_path, "../outside.md") is None
+        assert canonical_store_relative_path(tmp_path, "/etc/passwd") is None
+
+
+class TestRendererKwargResolver:
+    def test_get_raw_file_threads_canonical_path(self, tmp_path: Path):
+        kwargs = resolve_renderer_kwargs(
+            "get_raw_file", {"path": "context/../open-questions.md"}, tmp_path
+        )
+        assert kwargs == {"path": "open-questions.md"}
+
+    def test_get_raw_file_escape_omits_kwarg(self, tmp_path: Path):
+        assert resolve_renderer_kwargs("get_raw_file", {"path": "../x.md"}, tmp_path) == {}
+
+    def test_get_raw_file_without_store_omits_kwarg(self):
+        assert resolve_renderer_kwargs("get_raw_file", {"path": "stack.md"}, None) == {}
+
+    def test_get_context_threads_level(self, tmp_path: Path):
+        assert resolve_renderer_kwargs("get_context", {"level": "L2"}, tmp_path) == {"level": "L2"}
+
+    def test_mode_and_query_thread_as_before(self, tmp_path: Path):
+        assert resolve_renderer_kwargs("get_decision", {"mode": "header"}, tmp_path) == {
+            "mode": "header"
+        }
+        assert resolve_renderer_kwargs("search_decisions", {"query": "q"}, tmp_path) == {
+            "query": "q"
+        }
+
+    def test_unknown_tool_and_absent_args_yield_empty(self, tmp_path: Path):
+        assert resolve_renderer_kwargs("list_decisions", {}, tmp_path) == {}
+        assert resolve_renderer_kwargs("get_context", {}, tmp_path) == {}
+
+
+class TestNoJsonFallbackOnMalformedMetadata:
+    """A malformed envelope field must never raise out of the renderer.
+
+    Both local surfaces fall back to dumping the complete JSON envelope when
+    a renderer raises; with an oversized body alongside malformed metadata
+    that fallback would bypass the bounded render entirely.
+    """
+
+    def test_malformed_guidance_with_oversized_content_stays_bounded(self):
+        outcome = try_render_envelope(
+            "get_raw_file", {"guidance": 42, "content": "a" * 50_000}, {"path": "stack.md"}
+        )
+        assert outcome.failure is None
+        assert outcome.text is not None
+        assert len(outcome.text) < 41_000
+
+    def test_malformed_available_files_stays_rendered(self):
+        envelope = {
+            "error": {"kind": "error", "reason": "File not found: nope.md"},
+            "available_files": 7,
+            "content": "a" * 100_000,
+        }
+        outcome = try_render_envelope("get_raw_file", envelope, {})
+        assert outcome.failure is None
+        assert outcome.text == "Error: File not found: nope.md"
+
+
+class TestStdioSurface:
+    def test_oversized_l2_returns_guard_report_as_sole_block(self, bounded_repo: Path):
+        (bounded_repo / "state_history.md").write_text(("h" * 99 + "\n") * 2_500)
+        result = get_context(project_id="bounded", level=2)
+        assert isinstance(result, CallToolResult)
+        assert len(result.content) == 1
+        text = result.content[0].text
+        assert "Context withheld" in text
+        assert "(level L2)" in text
+        assert len(text) < 2_000
+        assert "h" * 99 not in text
+
+    def test_l0_under_budget_not_gated(self, bounded_repo: Path):
+        result = get_context(project_id="bounded", level=0)
+        assert "Context withheld" not in result.content[0].text
+
+    def test_raw_file_alias_routes_to_open_questions_rule(self, bounded_repo: Path):
+        (bounded_repo / "open-questions.md").write_text(_OQ_CONTENT)
+        result = get_raw_file(path="context/../open-questions.md", project_id="bounded")
+        text = result.content[0].text
+        assert "Resolved section elided" in text
+        assert "r" * 99 not in text
+        assert "p" * 99 in text
+
+
+class TestCliSurface:
+    def test_text_capped_while_default_json_byte_complete(self, bounded_repo: Path):
+        content = ("h" * 99 + "\n") * 600  # 60,000 chars
+        (bounded_repo / "state_history.md").write_text(content)
+
+        json_run = runner.invoke(app, ["get-raw-file", "state_history.md", "--format", "json"])
+        assert json_run.exit_code == 0, json_run.output
+        assert json.loads(json_run.stdout)["content"] == content
+
+        text_run = runner.invoke(app, ["get-raw-file", "state_history.md", "--format", "text"])
+        assert text_run.exit_code == 0, text_run.output
+        assert "chars omitted from the start of state_history.md" in text_run.stdout
+        assert len(text_run.stdout) < 41_000
+
+    def test_alias_reaches_hot_file_rule_in_text_mode(self, bounded_repo: Path):
+        (bounded_repo / "open-questions.md").write_text(_OQ_CONTENT)
+        argv = ["get-raw-file", "context/../open-questions.md"]
+
+        text_run = runner.invoke(app, [*argv, "--format", "text"])
+        assert text_run.exit_code == 0, text_run.output
+        assert "Resolved section elided" in text_run.stdout
+
+        json_run = runner.invoke(app, [*argv, "--format", "json"])
+        assert json_run.exit_code == 0, json_run.output
+        assert json.loads(json_run.stdout)["content"] == _OQ_CONTENT
+
+    def test_l2_guard_in_text_mode_json_stays_uncapped(self, bounded_repo: Path):
+        (bounded_repo / "state_history.md").write_text(("h" * 99 + "\n") * 2_500)
+
+        text_run = runner.invoke(app, ["get-context", "--level", "L2", "--format", "text"])
+        assert text_run.exit_code == 0, text_run.output
+        assert "Context withheld" in text_run.stdout
+        assert "(level L2)" in text_run.stdout
+
+        json_run = runner.invoke(app, ["get-context", "--level", "L2", "--format", "json"])
+        assert json_run.exit_code == 0, json_run.output
+        assert len(json.loads(json_run.stdout)["content"]) > 200_000


### PR DESCRIPTION
## Why

The agent-facing read channel had two unbounded payloads. `get_context` L2 returns the full store dump - 2.18M chars (~545K estimated tokens) on this repo's own store - and `get_raw_file` returns append-heavy hot files whole (`state_history.md` at 218K chars, `open-questions.md` at 122K), so a single tool call could flood a session's context window. This lands the bounded-reads pattern: guards live in the rendered agent channel only (the shared renderers behind the stdio MCP server and the CLI's `--format text` mode), never in kernel operations or payload assembly, and the CLI's default json output stays byte-identical and uncapped as the local recovery channel.

## What changed

- **Context gate** (`render_get_context`): a body over 200,000 chars is withheld behind a compact guard report naming the actual size, estimated tokens, and an incremental-recovery menu (L1, per-file `get_raw_file`, decision tools, local uncapped-json redirect). Size-keyed, not level-keyed: it fires on every transport, kwargs or none; a threaded `level` only tailors the wording. At or under budget the rendering is byte-identical to before.
- **Bounded raw reads** (`render_get_raw_file` + new `nauro_core/bounded_read.py`): content is classified by its canonical resolved store path - head-keep at 40,000 chars by default, tail-keep for `state_history.md` (newest appends last), a 51,200-char budget for `context/*.md` briefs (every sync-valid brief renders whole), and a structure-aware `open-questions.md` split: the resolved section (exact whitespace-stripped `## Resolved` line match over the source, not the parser's substring heuristic, so an indented header still divides and `## Unresolved threads` never does) is always elided behind a size marker; the open preamble keeps a 30,000-char head window plus an unconditionally reserved 10,000-char tail window ending at its last character; post-resolved sections render head-keep in the remainder; up to 20 discovery-pointer entries stranded in elided open spans are re-surfaced whole - never split across a cut - in per-span extraction blocks, with an overflow trailer.
- **Canonical-path threading**: a new `canonical_store_relative_path` helper beside the store-boundary guard, plus a shared `resolve_renderer_kwargs` resolver consumed by both the stdio server and the CLI autogen so the two surfaces cannot drift. `context/../open-questions.md` routes to the open-questions rule; the canonical path never enters the result envelope.
- **Totality hardening**: the renderers tolerate malformed envelope metadata as well as malformed bodies - non-string `guidance` is ignored and a malformed `available_files` hint is dropped - because a raising renderer falls back to the full JSON envelope, which with an oversized body alongside would bypass the bound entirely.
- All markers carry the exact omitted char count and the recovery paths. New constants stay out of the curated public API; the frozen contract snapshot is unchanged.

## Test plan

- New nauro-core suite (40 tests): full truncation matrix (exact-budget byte-verbatim, budget+1, no-newline hard cuts, exact omitted counts, exact two-region split arithmetic), size-keyed gate at every level and both envelope shapes, totality (malformed envelopes, absent kwargs, non-string bodies, non-string guidance, malformed available_files - never raises, and oversized envelopes with malformed metadata still return the bounded render), realistic merged-store fixture with a stranded pointer surviving via extraction, `## Unresolved threads` non-divider, indented `## Resolved` divider, post-resolved `## Active` retention, boundary-straddling multi-line pointers excluded whole on both windows, resolved/annotated pointers never extracted, 21+ pointer overflow with block-size arithmetic, and brief cap boundaries.
- New nauro suite (17 tests): stdio returns the guard report as sole `content[0]` for an oversized L2; CLI `--format text` capped while default `--format json` is byte-complete; alias canonicalization on both surfaces; resolver unit coverage; `try_render_envelope` proven not to fall back to JSON on malformed metadata.
- Full runs: nauro-core 1190 passed; nauro 2216 passed, 10 skipped. `ruff check` / `ruff format --check` clean.
- Measured on this repo's real store: L2 2,181,796 chars now returns a 594-char report; `state_history.md` 218,495 -> 40,089 chars; `open-questions.md` 121,999 -> 39,646 chars with all 17 in-window discovery pointers retained.

## Risk / what to review

- The open-questions window arithmetic (newline alignment, whole-entry pointer exclusion, exact omitted counts) is the densest logic; it is exact-string-pinned in `test_bounded_read.py`.
- The totality fallback: a structural-split failure degrades to plain head-keep rather than raising into the full-envelope JSON fallback.

## Deferred

- The remote dispatcher inherits the size gates at the next core pin bump; threading level/path kwargs there for rule parity is a follow-up.
- The stale scale-guidance sentence in the `get_context` tool description (`nauro_core/mcp_tools.py`) is a follow-up now that the sibling schema-trims branch has merged.
