### PR TITLE
Release nauro 1.11.0 and nauro-core 1.6.0

### DIFF
--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro-core"
-version = "1.5.0"
+version = "1.6.0"
 description = "Shared pure-Python logic for Nauro: parsing, validation, context assembly, constants."
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro"
-version = "1.10.0"
+version = "1.11.0"
 description = "Human-approved project judgment and current state for connected AI agents, surfaced before work."
 readme = "README.md"
 license = "Apache-2.0"
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "nauro-core>=1.5.0,<2",
+    "nauro-core>=1.6.0,<2",
     "typer>=0.9",
     "httpx>=0.24",
     "mcp>=1.0",

--- a/packages/nauro/src/nauro/onboarding.py
+++ b/packages/nauro/src/nauro/onboarding.py
@@ -11,11 +11,7 @@ existing callers use.
 """
 
 from nauro_core.constants import NO_DECISIONS_TO_CHECK as NO_DECISIONS_TO_CHECK
-
-# Underscore alias, not the public APPROVAL_BEFORE_PROPOSE name: the public
-# re-export landed after the current nauro-core floor (>=1.5.0), so switching
-# is gated on raising the floor to nauro-core>=1.6.0 at the next release.
-from nauro_core.protocol import _APPROVAL_BEFORE_PROPOSE
+from nauro_core.protocol import APPROVAL_BEFORE_PROPOSE
 
 WELCOME_NO_PROJECT = (
     "Welcome to Nauro! No project store found.\n"
@@ -38,7 +34,7 @@ NO_CONTEXT_YET = (
     "- Use propose_decision to record architectural decisions\n"
     "- Use update_state to track current progress\n"
     "\n"
-    f"{_APPROVAL_BEFORE_PROPOSE}"
+    f"{APPROVAL_BEFORE_PROPOSE}"
 )
 
 

--- a/packages/nauro/src/nauro/templates/agents_md.py
+++ b/packages/nauro/src/nauro/templates/agents_md.py
@@ -14,10 +14,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-# Underscore alias, not the public APPROVAL_BEFORE_PROPOSE name: the public
-# re-export landed after the current nauro-core floor (>=1.5.0), so switching
-# is gated on raising the floor to nauro-core>=1.6.0 at the next release.
-from nauro_core.protocol import _APPROVAL_BEFORE_PROPOSE
+from nauro_core.protocol import APPROVAL_BEFORE_PROPOSE
 
 from nauro.constants import AGENTS_MD, MANUAL_SECTION_HEADER, SKILLS_SECTION_HEADER
 from nauro.store.reader import read_text_lenient
@@ -56,7 +53,7 @@ PROTOCOL_DIGEST = (
     # The fragment no longer names the write call, so this surface supplies
     # the anchor: without MCP the boundary applies to `nauro propose-decision`.
     f"Before `propose_decision` (or `nauro propose-decision`): "
-    f"{_APPROVAL_BEFORE_PROPOSE}\n"
+    f"{APPROVAL_BEFORE_PROPOSE}\n"
 )
 
 

--- a/server.json
+++ b/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Nauro-AI/nauro",
     "source": "github"
   },
-  "version": "1.10.0",
+  "version": "1.11.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "nauro",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -928,7 +928,7 @@ wheels = [
 
 [[package]]
 name = "nauro"
-version = "1.10.0"
+version = "1.11.0"
 source = { editable = "packages/nauro" }
 dependencies = [
     { name = "filelock" },
@@ -970,7 +970,7 @@ provides-extras = ["dev", "embeddings"]
 
 [[package]]
 name = "nauro-core"
-version = "1.5.0"
+version = "1.6.0"
 source = { editable = "packages/nauro-core" }
 dependencies = [
     { name = "bm25s" },


### PR DESCRIPTION
## Version moves

- **nauro**: 1.10.0 → 1.11.0 (minor)
- **nauro-core**: 1.5.0 → 1.6.0 (minor); nauro's floor bumped to `nauro-core>=1.6.0,<2`
- `server.json` re-locked to 1.11.0

## What ships

**nauro** (since 1.10.0):
- The CLI is plain-text for agents: Rich help rendering is off globally (`nauro --help` is 59% smaller), the ten tool-mirror commands gain `--format json|text` reusing the shared MCP renderers, and `status` and `log` gain `--json` with curated, typed payloads (#397).
- `check_decision` results carry inline triage headers (decision type, confidence, supersession links, and a lede per hit), retiring the per-hit header lookup round-trip (#396).
- Rendered reads are bounded: a size-keyed gate on the L2 context dump (a guard report replaces multi-megabyte payloads), per-file budgets on raw-file reads with structure-aware handling for the append-only files (#399).
- AGENTS.md generation and onboarding text now use the public approval-fragment export from nauro-core (floor raised accordingly).

**nauro-core** (since 1.5.0):
- MCP tool-schema prose trimmed at the shared-registry source (−25% schema tokens) and the approval fragment exported publicly (#398).
- Related-decision hits carry the header projection inline, shared between check and propose paths (#396).
- Bounded-read primitives: the L2 gate, per-file char budgets with canonical-path classification, and renderers for the last two read tools (#399, #393 follow-through).

Dev-environment only: the lockfile's transitive `cryptography` moved to 50.0.0 for a security advisory (#400); published package constraints are unchanged.

## Checks

- `check_server_json_version.py` and `check_single_sourced.py` pass locally
- `uv lock --check` clean; both suites pass against the bumped workspace (nauro-core 1190; nauro 2216 + 10 skipped); ruff clean
- CI must be fully green before merge

## Post-merge

Tag the squash commit `nauro-core-v1.6.0` and `nauro-v1.11.0` and push both tags to trigger the trusted-publish workflows (PyPI + MCP registry), then create the GitHub Releases. After PyPI shows 1.11.0, bump `plugin.json` in Nauro-AI/claude-plugins to 1.11.0 (its version-sync CI asserts equality with the latest published nauro). The hosted server's floor raise and kwarg threading follow in its own repo.
