### PR TITLE
Sync the root command table with the repair command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 # CLAUDE.md — Nauro (monorepo)
 
+@AGENTS.md
+
 Nauro is a versioned project context system for AI coding agents. This is a `uv` workspace monorepo with two packages:
 
 | Package | Path | Python | Purpose |
@@ -70,7 +72,8 @@ Principal commands (run `nauro --help` for the full surface):
 - `nauro sync` — capture a snapshot, regenerate `AGENTS.md` in all associated repos
 - `nauro log` — list recent snapshots with metadata
 - `nauro status` — capability table for the current project (active surfaces, absolute store path)
-- `nauro doctor` — report deterministic store-integrity defects (unparseable decision files, dangling or cyclic supersession refs, status contradictions); report-only, always exits 0
+- `nauro doctor` — report deterministic store-integrity defects (unparseable decision files, dangling or cyclic supersession refs, status contradictions) plus repairable supersede backref orphans; report-only, always exits 0
+- `nauro repair` — flip the single unambiguous supersede backref orphan after interactive confirmation; every other shape is reported with guidance and left alone
 - `nauro graph` — render the decision graph to one self-contained HTML file in the store directory and open it
 - `nauro serve` — start the local MCP server (stdio transport)
 - `nauro import --memory-bank <path>` — migrate a Cline/Roo Code Memory Bank

--- a/packages/nauro-core/src/nauro_core/doctor.py
+++ b/packages/nauro-core/src/nauro_core/doctor.py
@@ -1,7 +1,7 @@
 """Deterministic store-integrity diagnosis for ``nauro doctor``.
 
 ``diagnose_store`` reads a project store through the :class:`Store` protocol
-and reports four kinds of structural defect in the decision set:
+and reports four kinds of *blocking* structural defect in the decision set:
 
     1. Unparseable decision files.
     2. Dangling supersession refs — a ``supersedes``/``superseded_by`` value
@@ -12,10 +12,18 @@ and reports four kinds of structural defect in the decision set:
        or a forward/back conflict where ``X.supersedes=Y`` while ``Y`` records
        ``superseded_by=Z`` naming a third, present decision.
 
+Alongside those it reports one *repairable* defect: a supersede backref orphan,
+an active decision whose ``supersedes`` target is itself still active and
+carries no reciprocal ``superseded_by``. Severity is split deliberately.
+:attr:`StoreDiagnosis.is_clean` stays bound to the four blocking categories
+above and is unmoved by an orphan, because an orphan is a recoverable
+half-write rather than a store a reader cannot trust; it is surfaced through
+:attr:`StoreDiagnosis.has_repairable_defects` instead, and ``nauro repair``
+is the gated action that closes it.
+
 It also surfaces unknown frontmatter keys — keys the reader tolerates and
 preserves but does not model. This is advisory, not a defect: the tolerant
-reader accepts them by design, so they do not make a store unclean
-(:attr:`StoreDiagnosis.is_clean` stays tied to the four defect categories).
+reader accepts them by design, so they do not make a store unclean.
 
 Every check is zero-false-positive by construction and the output is fully
 sorted, so two diagnoses over the same store are identical. The module stands
@@ -28,6 +36,8 @@ submodule-only and is deliberately not part of ``nauro_core.__all__``.
 
 from __future__ import annotations
 
+from collections import Counter
+from collections.abc import Mapping
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -92,6 +102,20 @@ class StatusContradiction(BaseModel):
     conflicting_with: int | None = None
 
 
+class SupersedeOrphan(BaseModel):
+    """A half-written supersession: the forward edge exists, the backref does not.
+
+    ``child`` is active and records ``supersedes=target``; ``target`` is still
+    active and carries no ``superseded_by``. Repairable rather than blocking —
+    see the module docstring for the severity split.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    child: int
+    target: int
+
+
 class UnknownFrontmatterKeys(BaseModel):
     """A parsed decision carrying frontmatter keys the reader does not model.
 
@@ -114,16 +138,23 @@ class StoreDiagnosis(BaseModel):
     dangling_refs: list[DanglingRef] = Field(default_factory=list)
     cycles: list[SupersessionCycle] = Field(default_factory=list)
     contradictions: list[StatusContradiction] = Field(default_factory=list)
+    supersede_orphans: list[SupersedeOrphan] = Field(default_factory=list)
     unknown_frontmatter_keys: list[UnknownFrontmatterKeys] = Field(default_factory=list)
 
     @property
     def is_clean(self) -> bool:
-        """True when no defect of any category was found.
+        """True when no blocking defect was found.
 
-        Unknown frontmatter keys are advisory, not a defect, so they never
-        make a store unclean.
+        Bound to the four blocking categories only. Unknown frontmatter keys
+        are advisory, and supersede backref orphans are repairable, so neither
+        makes a store unclean.
         """
         return not (self.unparseable or self.dangling_refs or self.cycles or self.contradictions)
+
+    @property
+    def has_repairable_defects(self) -> bool:
+        """True when the store carries a defect ``nauro repair`` can close."""
+        return bool(self.supersede_orphans)
 
 
 def diagnose_store(store: Store) -> StoreDiagnosis:
@@ -132,12 +163,15 @@ def diagnose_store(store: Store) -> StoreDiagnosis:
 
     # Existence is on-disk stems, not parsed nums: a present-but-unparseable
     # file still counts as existing, so a ref to it is reported once (as
-    # unparseable) and never double-reported as dangling.
-    existing_numbers = {
+    # unparseable) and never double-reported as dangling. The counts (not just
+    # the set) are kept because the orphan check needs to know a number is
+    # carried by exactly one file before it names that file repairable.
+    stem_counts = Counter(
         num
         for stem in store.list_decisions()
         if (num := extract_decision_number(stem)) is not None
-    }
+    )
+    existing_numbers = set(stem_counts)
     by_num = _index_by_num(parsed)
 
     unparseable = sorted(
@@ -147,6 +181,7 @@ def diagnose_store(store: Store) -> StoreDiagnosis:
     dangling_refs = _dangling_refs(parsed, existing_numbers)
     cycles = _cycles(parsed)
     contradictions = _contradictions(parsed, by_num, existing_numbers)
+    supersede_orphans = _supersede_orphans(parsed, by_num, stem_counts, cycles)
     unknown_frontmatter_keys = _unknown_frontmatter_keys(parsed)
 
     return StoreDiagnosis(
@@ -154,6 +189,7 @@ def diagnose_store(store: Store) -> StoreDiagnosis:
         dangling_refs=dangling_refs,
         cycles=cycles,
         contradictions=contradictions,
+        supersede_orphans=supersede_orphans,
         unknown_frontmatter_keys=unknown_frontmatter_keys,
     )
 
@@ -322,3 +358,48 @@ def _contradictions(
         rows,
         key=lambda r: (r.kind, r.decision, r.other, r.conflicting_with or 0),
     )
+
+
+def _supersede_orphans(
+    parsed: list[Decision],
+    by_num: dict[int, Decision],
+    stem_counts: Mapping[int, int],
+    cycles: list[SupersessionCycle],
+) -> list[SupersedeOrphan]:
+    """Half-written supersessions: forward edge present, backref absent. Sorted.
+
+    A row is emitted only when every one of these holds, so the finding names a
+    single unambiguous pair of files and nothing else:
+
+    - the child parses and is still active, and records ``supersedes=target``;
+    - ``target`` is not the child's own number (a self-reference is a cycle);
+    - exactly one on-disk stem carries each side's number, so both the file to
+      repair and the decision claiming it are unambiguous. The child-side guard
+      is what keeps one shape from reporting twice: two parseable files sharing
+      a number and a forward edge are one duplicate-number defect, not two
+      orphans;
+    - the target's file parses, is still active, and carries no
+      ``superseded_by``.
+
+    A candidate whose child or target belongs to a reported cycle is suppressed:
+    the cycle is the defect there, and every defect is reported once.
+    """
+    cycle_members = {member for cycle in cycles for member in cycle.members}
+    rows: list[SupersedeOrphan] = []
+    for d in parsed:
+        if d.status is not DecisionStatus.active or d.supersedes is None:
+            continue
+        target_num = int(d.supersedes)
+        if target_num == d.num:
+            continue
+        if stem_counts.get(d.num, 0) != 1 or stem_counts.get(target_num, 0) != 1:
+            continue
+        if d.num in cycle_members or target_num in cycle_members:
+            continue
+        target = by_num.get(target_num)
+        if target is None:
+            continue
+        if target.status is not DecisionStatus.active or target.superseded_by is not None:
+            continue
+        rows.append(SupersedeOrphan(child=d.num, target=target_num))
+    return sorted(rows, key=lambda row: (row.child, row.target))

--- a/packages/nauro-core/src/nauro_core/operations/repair.py
+++ b/packages/nauro-core/src/nauro_core/operations/repair.py
@@ -1,0 +1,427 @@
+"""Plan the one supersession repair a machine may make on a human's word.
+
+A supersede backref orphan is a half-written supersession: the newer decision
+records ``supersedes=<old>``, but the old decision was never flipped, so it
+still reads as active with no ``superseded_by``. ``nauro doctor`` names the
+shape; this module decides whether it can be closed without judgment, and
+renders the exact bytes that would close it.
+
+The bar is deliberately narrow. A plan is produced only when the whole store
+carries exactly one orphan and nothing else references either side of it. Every
+other shape — a target claimed by more than one child, a supersession cycle, a
+file that does not parse, a decision number carried by two files, a third
+decision already referencing either side — comes back as a typed
+:class:`RepairRefusal` with guidance and no plan, because rewriting
+supersession history on a heuristic is worse than leaving it visibly broken.
+
+One gap is named rather than papered over: there is no "target changed since
+the child was filed" refusal. A local store holds no evidence of when the
+target's bytes last moved relative to the child's filing, and inventing that
+evidence from snapshots or the journal would be a guess. The confirmation
+prompt compensates by showing the target's version, date, and status next to
+the child's, so the human judges recency before approving.
+
+Pure: reads only through the :class:`Store` protocol, takes no clock and no
+randomness, and writes nothing. The caller re-runs the plan under the write
+lock and compares :attr:`RepairPlan.pre_image_digest` before writing, which
+only works because the same store always yields the same plan. Imported
+submodule-only and deliberately not part of ``nauro_core.__all__``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections import Counter
+from datetime import date
+from typing import Literal, NamedTuple
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from nauro_core.decision_model import Decision, DecisionStatus, format_decision
+from nauro_core.doctor import SupersedeOrphan, SupersessionCycle, diagnose_store
+from nauro_core.operations.decision_lookup import scan_decisions
+from nauro_core.operations.store import Store
+from nauro_core.parsing import _decision_path, extract_decision_number
+
+RepairRefusalKind = Literal[
+    "multiple_children",
+    "cycle_member",
+    "unparseable_child",
+    "unparseable_target",
+    "duplicate_decision_number",
+    "competing_reference",
+]
+
+
+class RepairRefusal(BaseModel):
+    """One shape the planner will not touch, with the reason already worded.
+
+    ``decisions`` names every decision number the refusal implicates and
+    ``stems`` every file, both sorted. An empty ``decisions`` marks a
+    store-wide refusal: it implicates no particular pair and therefore blocks
+    every candidate. ``guidance`` is the rendered sentence a surface prints
+    verbatim, so the wording cannot drift between the CLI and any later caller.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    kind: RepairRefusalKind
+    decisions: tuple[int, ...] = ()
+    stems: tuple[str, ...] = ()
+    guidance: str
+
+    def blocks(self, orphan: SupersedeOrphan) -> bool:
+        """True when this refusal makes ``orphan`` unsafe to repair."""
+        if not self.decisions:
+            return True
+        return orphan.child in self.decisions or orphan.target in self.decisions
+
+
+class RepairPlan(BaseModel):
+    """The exact rewrite that would close one orphan, and the facts to judge it.
+
+    ``new_content`` is the target's full file after the flip. ``pre_image_digest``
+    is the sha256 of the target's current bytes, so a caller holding the write
+    lock can confirm nothing moved between planning and writing. The child's and
+    target's version and date, and the target's status, ride along for the
+    confirmation prompt: they are what a human needs to judge whether the newer
+    decision really does retire the older one.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    child_num: int
+    child_title: str
+    child_version: int
+    child_date: date
+    target_num: int
+    target_title: str
+    target_version: int
+    target_date: date
+    target_status: DecisionStatus
+    target_stem: str
+    target_path: str
+    new_content: str
+    pre_image_digest: str
+
+
+class RepairAssessment(BaseModel):
+    """What the planner found: at most one plan, plus everything it refused.
+
+    ``orphans`` is the full detected set, carried so a surface can explain a
+    missing plan when more than one orphan exists — the singleton rule is a
+    property of the store, not of any single candidate, so no refusal names it.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    plan: RepairPlan | None = None
+    refusals: list[RepairRefusal] = Field(default_factory=list)
+    orphans: tuple[SupersedeOrphan, ...] = ()
+
+
+class _Candidate(NamedTuple):
+    """A forward supersession edge whose backref is not already in place."""
+
+    child: int
+    target: int
+
+
+def plan_supersede_repair(store: Store) -> RepairAssessment:
+    """Assess the store and plan the single repairable orphan, if there is one."""
+    diagnosis = diagnose_store(store)
+    parsed, failures = scan_decisions(store)
+
+    by_num: dict[int, Decision] = {}
+    for decision in parsed:
+        by_num.setdefault(decision.num, decision)
+
+    stems_by_num: dict[int, list[str]] = {}
+    for stem in store.list_decisions():
+        num = extract_decision_number(stem)
+        if num is not None:
+            stems_by_num.setdefault(num, []).append(stem)
+    stem_counts = Counter({num: len(stems) for num, stems in stems_by_num.items()})
+    failed_stems = {failure.stem: failure.error for failure in failures}
+
+    candidates = _candidates(parsed, by_num, stem_counts)
+    refusals = _refusals(
+        candidates=candidates,
+        parsed=parsed,
+        cycles=diagnosis.cycles,
+        stems_by_num=stems_by_num,
+        stem_counts=stem_counts,
+        failed_stems=failed_stems,
+    )
+
+    orphans = tuple(diagnosis.supersede_orphans)
+    plan: RepairPlan | None = None
+    if len(orphans) == 1 and not any(refusal.blocks(orphans[0]) for refusal in refusals):
+        plan = _build_plan(orphans[0], by_num, stems_by_num)
+
+    return RepairAssessment(plan=plan, refusals=refusals, orphans=orphans)
+
+
+def _candidates(
+    parsed: list[Decision],
+    by_num: dict[int, Decision],
+    stem_counts: Counter[int],
+) -> list[_Candidate]:
+    """Forward supersession edges that still need a backref written. Sorted.
+
+    A settled pair — the target already records ``superseded_by`` naming this
+    child — is not a candidate, so a healthy store produces none and reports
+    nothing. An edge whose target has no file on disk is not a candidate
+    either: that is a dangling ref, which doctor already reports and repair
+    cannot close.
+
+    Deduplicated by number pair. Two files sharing a decision number and a
+    forward edge describe one pair, and the duplicate number is reported as its
+    own refusal; without this they would also render as rival children spelled
+    with the same label.
+    """
+    candidates: set[_Candidate] = set()
+    for decision in parsed:
+        if decision.supersedes is None:
+            continue
+        target_num = int(decision.supersedes)
+        if target_num == decision.num or stem_counts[target_num] == 0:
+            continue
+        target = by_num.get(target_num)
+        if target is not None and target.superseded_by == str(decision.num):
+            continue
+        candidates.add(_Candidate(child=decision.num, target=target_num))
+    return sorted(candidates)
+
+
+def _refusals(
+    *,
+    candidates: list[_Candidate],
+    parsed: list[Decision],
+    cycles: list[SupersessionCycle],
+    stems_by_num: dict[int, list[str]],
+    stem_counts: Counter[int],
+    failed_stems: dict[str, str],
+) -> list[RepairRefusal]:
+    """Every reason the planner will not act, deduplicated and sorted."""
+    if not candidates:
+        return []
+
+    by_num: dict[int, Decision] = {}
+    for decision in parsed:
+        by_num.setdefault(decision.num, decision)
+    cycle_by_member = {member: cycle for cycle in cycles for member in cycle.members}
+    children_by_target: dict[int, list[int]] = {}
+    for candidate in candidates:
+        children_by_target.setdefault(candidate.target, []).append(candidate.child)
+
+    rows: dict[tuple, RepairRefusal] = {}
+
+    def add(refusal: RepairRefusal) -> None:
+        rows.setdefault((refusal.kind, refusal.decisions, refusal.stems), refusal)
+
+    for candidate in candidates:
+        for num in (candidate.child, candidate.target):
+            if stem_counts[num] > 1:
+                add(_duplicate_number_refusal(num, stems_by_num[num]))
+            cycle = cycle_by_member.get(num)
+            if cycle is not None:
+                add(_cycle_refusal(cycle))
+
+        target_stems = stems_by_num[candidate.target]
+        if len(target_stems) == 1 and target_stems[0] in failed_stems:
+            add(_unparseable_target_refusal(candidate, target_stems[0]))
+
+        siblings = children_by_target[candidate.target]
+        if len(siblings) > 1:
+            add(_multiple_children_refusal(candidate.target, siblings))
+
+        competing = _competing_references(candidate, parsed, by_num)
+        if competing:
+            add(_competing_reference_refusal(candidate, competing))
+
+    # A file nobody could read might carry another forward edge, so no
+    # single-child claim can be certified while one exists. Files already named
+    # as an unparseable target are left to that refusal so each is reported once.
+    named_targets = {
+        stems_by_num[candidate.target][0]
+        for candidate in candidates
+        if len(stems_by_num[candidate.target]) == 1
+    }
+    unread = sorted(stem for stem in failed_stems if stem not in named_targets)
+    if unread:
+        add(_unparseable_child_refusal(unread))
+
+    return sorted(rows.values(), key=lambda row: (row.kind, row.decisions, row.stems))
+
+
+def _competing_references(
+    candidate: _Candidate,
+    parsed: list[Decision],
+    by_num: dict[int, Decision],
+) -> tuple[int, ...]:
+    """Decisions whose own refs compete with the backref that would be written.
+
+    Two shapes, both meaning the pair is not isolated:
+
+    - another decision already records ``superseded_by`` naming the target, so
+      the target is entangled in a supersession other than this one;
+    - the child is itself retired, or a third decision claims to supersede it,
+      so it is not settled enough to be recorded as anyone's replacement.
+
+    The child's own ``superseded_by`` counts as a competing reference under the
+    second shape and is reported as the child's own number.
+    """
+    competing: set[int] = set()
+    for decision in parsed:
+        if (
+            decision.num != candidate.child
+            and decision.superseded_by is not None
+            and int(decision.superseded_by) == candidate.target
+        ):
+            competing.add(decision.num)
+        if (
+            decision.num != candidate.target
+            and decision.supersedes is not None
+            and int(decision.supersedes) == candidate.child
+        ):
+            competing.add(decision.num)
+    child = by_num.get(candidate.child)
+    if child is not None and (
+        child.status is DecisionStatus.superseded or child.superseded_by is not None
+    ):
+        competing.add(child.num)
+    return tuple(sorted(competing))
+
+
+def _build_plan(
+    orphan: SupersedeOrphan,
+    by_num: dict[int, Decision],
+    stems_by_num: dict[int, list[str]],
+) -> RepairPlan:
+    """Render the flipped target for a candidate already cleared of refusals.
+
+    Only the two frontmatter fields move. The rewrite goes through the same
+    ``model_copy`` + ``format_decision`` transformation ``propose_decision``
+    applies on a supersede, so a repaired file is byte-identical to one the
+    write path would have produced — including any frontmatter key the reader
+    tolerates but does not model.
+    """
+    child = by_num[orphan.child]
+    target = by_num[orphan.target]
+    target_stem = stems_by_num[orphan.target][0]
+    flipped = target.model_copy(
+        update={
+            "status": DecisionStatus.superseded,
+            "superseded_by": str(orphan.child),
+        }
+    )
+    return RepairPlan(
+        child_num=child.num,
+        child_title=child.title,
+        child_version=child.version,
+        child_date=child.date,
+        target_num=target.num,
+        target_title=target.title,
+        target_version=target.version,
+        target_date=target.date,
+        target_status=target.status,
+        target_stem=target_stem,
+        target_path=_decision_path(target_stem),
+        new_content=format_decision(flipped),
+        pre_image_digest=hashlib.sha256(target.content.encode("utf-8")).hexdigest(),
+    )
+
+
+# ── Refusal constructors (one per kind, guidance worded once) ──
+
+
+def _label(num: int) -> str:
+    return f"D{num}"
+
+
+def _join(nums: tuple[int, ...] | list[int]) -> str:
+    return ", ".join(_label(num) for num in nums)
+
+
+def _duplicate_number_refusal(num: int, stems: list[str]) -> RepairRefusal:
+    return RepairRefusal(
+        kind="duplicate_decision_number",
+        decisions=(num,),
+        stems=tuple(sorted(stems)),
+        guidance=(
+            f"{_label(num)} is carried by more than one file "
+            f"({', '.join(sorted(stems))}); renumber or remove the duplicate "
+            "before repairing."
+        ),
+    )
+
+
+def _cycle_refusal(cycle: SupersessionCycle) -> RepairRefusal:
+    if len(cycle.members) == 1:
+        detail = f"{_label(cycle.members[0])} references itself"
+    else:
+        detail = f"{_join(cycle.members)} form a supersession cycle"
+    return RepairRefusal(
+        kind="cycle_member",
+        decisions=cycle.members,
+        guidance=f"{detail}; untangle it by hand before repairing.",
+    )
+
+
+def _unparseable_target_refusal(candidate: _Candidate, stem: str) -> RepairRefusal:
+    return RepairRefusal(
+        kind="unparseable_target",
+        decisions=(candidate.target, candidate.child),
+        stems=(stem,),
+        guidance=(
+            f"{_label(candidate.target)} ({stem}) does not parse, so its "
+            "frontmatter cannot be rewritten safely; fix the file first."
+        ),
+    )
+
+
+def _unparseable_child_refusal(stems: list[str]) -> RepairRefusal:
+    return RepairRefusal(
+        kind="unparseable_child",
+        stems=tuple(stems),
+        guidance=(
+            f"{', '.join(stems)} does not parse, so the decisions that claim to "
+            "supersede others cannot be fully enumerated; fix the file first."
+        ),
+    )
+
+
+def _multiple_children_refusal(target: int, children: list[int]) -> RepairRefusal:
+    return RepairRefusal(
+        kind="multiple_children",
+        decisions=tuple(sorted({target, *children})),
+        guidance=(
+            f"{_join(sorted(children))} all claim to supersede "
+            f"{_label(target)}; only a human can say which one retires it."
+        ),
+    )
+
+
+def _competing_reference_refusal(
+    candidate: _Candidate,
+    competing: tuple[int, ...],
+) -> RepairRefusal:
+    return RepairRefusal(
+        kind="competing_reference",
+        decisions=tuple(sorted({candidate.child, candidate.target, *competing})),
+        guidance=(
+            f"{_join(competing)} already reference "
+            f"{_label(candidate.child)} or {_label(candidate.target)}; the pair "
+            "is not isolated enough to rewrite automatically."
+        ),
+    )
+
+
+__all__ = [
+    "RepairAssessment",
+    "RepairPlan",
+    "RepairRefusal",
+    "RepairRefusalKind",
+    "plan_supersede_repair",
+]

--- a/packages/nauro-core/tests/operations/test_repair.py
+++ b/packages/nauro-core/tests/operations/test_repair.py
@@ -1,0 +1,345 @@
+"""Tests for ``nauro_core.operations.repair`` — the pure repair planner.
+
+Every fixture is built through ``format_decision`` so it cannot drift from the
+on-disk v2 format. The load-bearing properties are that a plan is emitted only
+for a single, wholly unambiguous orphan, that every other shape lands as a
+typed refusal, and that the rewritten target survives a full round-trip
+including frontmatter keys the reader does not model.
+"""
+
+from __future__ import annotations
+
+import ast
+from datetime import date
+from pathlib import Path
+
+from nauro_core.decision_model import (
+    Decision,
+    DecisionConfidence,
+    DecisionStatus,
+    format_decision,
+    parse_decision,
+)
+from nauro_core.operations import InMemoryStore
+from nauro_core.operations.repair import plan_supersede_repair
+
+
+def _stem(num: int, slug: str = "decision") -> str:
+    return f"{num:03d}-{slug}"
+
+
+def _body(
+    num: int,
+    *,
+    status: DecisionStatus = DecisionStatus.active,
+    supersedes: str | None = None,
+    superseded_by: str | None = None,
+    version: int = 1,
+    **extra: str,
+) -> str:
+    return format_decision(
+        Decision(
+            date=date(2026, 1, 1),
+            confidence=DecisionConfidence.medium,
+            status=status,
+            version=version,
+            supersedes=supersedes,
+            superseded_by=superseded_by,
+            num=num,
+            title=f"Decision {num}",
+            rationale=f"Rationale for decision {num}.",
+            **extra,
+        )
+    )
+
+
+def _orphan_store(**decisions: str) -> InMemoryStore:
+    base = {
+        _stem(20): _body(20, supersedes="19"),
+        _stem(19): _body(19),
+    }
+    base.update(decisions)
+    return InMemoryStore(decisions=base)
+
+
+def _kinds(assessment) -> list[str]:
+    return [refusal.kind for refusal in assessment.refusals]
+
+
+# ── The single repairable shape ──
+
+
+def test_plan_emitted_for_a_single_clean_orphan() -> None:
+    assessment = plan_supersede_repair(_orphan_store())
+    assert assessment.refusals == []
+    plan = assessment.plan
+    assert plan is not None
+    assert (plan.child_num, plan.target_num) == (20, 19)
+    assert plan.target_stem == _stem(19)
+    assert plan.target_path == f"decisions/{_stem(19)}.md"
+    assert plan.target_status is DecisionStatus.active
+    assert plan.child_title == "Decision 20"
+    assert plan.target_title == "Decision 19"
+    assert plan.target_version == 1
+    assert plan.target_date == date(2026, 1, 1)
+    assert plan.child_date == date(2026, 1, 1)
+    assert plan.pre_image_digest
+
+
+def test_planned_content_flips_only_status_and_backref() -> None:
+    store = _orphan_store()
+    plan = plan_supersede_repair(store).plan
+    assert plan is not None
+
+    before = parse_decision(store.read_decision(_stem(19)) or "", f"{_stem(19)}.md")
+    after = parse_decision(plan.new_content, f"{_stem(19)}.md")
+
+    assert after.status is DecisionStatus.superseded
+    assert after.superseded_by == "20"
+    unchanged = {"status", "superseded_by", "content"}
+    assert after.model_dump(exclude=unchanged) == before.model_dump(exclude=unchanged)
+
+
+def test_planned_content_round_trips_through_the_formatter() -> None:
+    plan = plan_supersede_repair(_orphan_store()).plan
+    assert plan is not None
+    reparsed = parse_decision(plan.new_content, f"{_stem(19)}.md")
+    assert format_decision(reparsed) == plan.new_content
+
+
+def test_unknown_frontmatter_keys_survive_the_rewrite() -> None:
+    store = _orphan_store(**{_stem(19): _body(19, base_commit="deadbeef")})
+    plan = plan_supersede_repair(store).plan
+    assert plan is not None
+    assert "base_commit: deadbeef" in plan.new_content
+    assert parse_decision(plan.new_content, f"{_stem(19)}.md").model_extra == {
+        "base_commit": "deadbeef"
+    }
+
+
+def test_no_orphan_yields_neither_plan_nor_refusal() -> None:
+    store = InMemoryStore(
+        decisions={
+            _stem(20): _body(20, supersedes="19"),
+            _stem(19): _body(19, status=DecisionStatus.superseded, superseded_by="20"),
+        }
+    )
+    assessment = plan_supersede_repair(store)
+    assert assessment.plan is None
+    assert assessment.refusals == []
+    assert assessment.orphans == ()
+
+
+def test_healthy_chain_draws_no_refusals() -> None:
+    # D30 retires D20, which already retired D10. Nothing is orphan-shaped, so
+    # a settled chain must stay silent rather than report competing references.
+    store = InMemoryStore(
+        decisions={
+            _stem(10): _body(10, status=DecisionStatus.superseded, superseded_by="20"),
+            _stem(20): _body(
+                20, status=DecisionStatus.superseded, superseded_by="30", supersedes="10"
+            ),
+            _stem(30): _body(30, supersedes="20"),
+        }
+    )
+    assessment = plan_supersede_repair(store)
+    assert assessment.plan is None
+    assert assessment.refusals == []
+
+
+# ── Refusals ──
+
+
+def test_multiple_children_refuses() -> None:
+    store = _orphan_store(**{_stem(21): _body(21, supersedes="19")})
+    assessment = plan_supersede_repair(store)
+    assert assessment.plan is None
+    assert len(assessment.orphans) == 2
+    refusal = next(r for r in assessment.refusals if r.kind == "multiple_children")
+    assert refusal.decisions == (19, 20, 21)
+    assert "D19" in refusal.guidance
+
+
+def test_cycle_member_refuses() -> None:
+    store = InMemoryStore(
+        decisions={
+            _stem(20): _body(20, supersedes="19"),
+            _stem(19): _body(19, supersedes="21"),
+            _stem(21): _body(21, supersedes="19"),
+        }
+    )
+    assessment = plan_supersede_repair(store)
+    assert assessment.plan is None
+    assert "cycle_member" in _kinds(assessment)
+
+
+def test_unparseable_target_refuses() -> None:
+    store = _orphan_store(**{_stem(19): "garbage that does not parse"})
+    assessment = plan_supersede_repair(store)
+    assert assessment.plan is None
+    refusal = next(r for r in assessment.refusals if r.kind == "unparseable_target")
+    assert refusal.stems == (_stem(19),)
+
+
+def test_unparseable_file_anywhere_refuses_as_a_possible_child() -> None:
+    store = _orphan_store(**{_stem(40, "broken"): "garbage that does not parse"})
+    assessment = plan_supersede_repair(store)
+    assert assessment.plan is None
+    refusal = next(r for r in assessment.refusals if r.kind == "unparseable_child")
+    assert refusal.stems == (_stem(40, "broken"),)
+    assert refusal.decisions == ()
+
+
+def test_duplicate_decision_number_refuses() -> None:
+    store = InMemoryStore(
+        decisions={
+            _stem(20): _body(20, supersedes="19"),
+            _stem(19, "first"): _body(19),
+            _stem(19, "second"): _body(19),
+        }
+    )
+    assessment = plan_supersede_repair(store)
+    assert assessment.plan is None
+    refusal = next(r for r in assessment.refusals if r.kind == "duplicate_decision_number")
+    assert refusal.decisions == (19,)
+    assert refusal.stems == (_stem(19, "first"), _stem(19, "second"))
+
+
+def test_duplicate_child_number_refuses_and_names_the_number_once() -> None:
+    # Two parseable files carry number 20 and the same forward edge. The
+    # duplicate is the defect; the pair must not also render as two rival
+    # children both spelled "D20".
+    store = InMemoryStore(
+        decisions={
+            _stem(20, "first"): _body(20, supersedes="19"),
+            _stem(20, "second"): _body(20, supersedes="19"),
+            _stem(19): _body(19),
+        }
+    )
+    assessment = plan_supersede_repair(store)
+    assert assessment.plan is None
+    assert assessment.orphans == ()
+    assert _kinds(assessment) == ["duplicate_decision_number"]
+    refusal = assessment.refusals[0]
+    assert refusal.decisions == (20,)
+    assert refusal.stems == (_stem(20, "first"), _stem(20, "second"))
+    assert "D20, D20" not in refusal.guidance
+
+
+def test_competing_reference_refuses_when_a_third_decision_names_the_target() -> None:
+    # D18 records that D19 retired it. D19 is therefore already referenced by a
+    # decision other than the child, so its rewrite is not unambiguous.
+    store = _orphan_store(
+        **{_stem(18): _body(18, status=DecisionStatus.superseded, superseded_by="19")}
+    )
+    assessment = plan_supersede_repair(store)
+    assert assessment.plan is None
+    refusal = next(r for r in assessment.refusals if r.kind == "competing_reference")
+    assert refusal.decisions == (18, 19, 20)
+
+
+def test_competing_reference_refuses_when_the_child_is_itself_superseded() -> None:
+    store = _orphan_store(
+        **{
+            _stem(20): _body(
+                20, status=DecisionStatus.superseded, superseded_by="21", supersedes="19"
+            ),
+            _stem(21): _body(21),
+        }
+    )
+    assessment = plan_supersede_repair(store)
+    assert assessment.plan is None
+    assert "competing_reference" in _kinds(assessment)
+
+
+def test_competing_reference_refuses_when_a_third_decision_claims_the_child() -> None:
+    store = _orphan_store(**{_stem(22): _body(22, supersedes="20")})
+    assessment = plan_supersede_repair(store)
+    assert assessment.plan is None
+    assert "competing_reference" in _kinds(assessment)
+
+
+def test_one_to_many_retirement_orphan_is_still_repairable() -> None:
+    # D4 retires D2, D3 and D5; only D2 carries the reciprocal forward edge and
+    # only D2's backref is missing. The other members reference the child, not
+    # the target, so the pair stays unambiguous.
+    store = InMemoryStore(
+        decisions={
+            _stem(4): _body(4, supersedes="2"),
+            _stem(2): _body(2),
+            _stem(3): _body(3, status=DecisionStatus.superseded, superseded_by="4"),
+            _stem(5): _body(5, status=DecisionStatus.superseded, superseded_by="4"),
+        }
+    )
+    assessment = plan_supersede_repair(store)
+    assert assessment.refusals == []
+    assert assessment.plan is not None
+    assert (assessment.plan.child_num, assessment.plan.target_num) == (4, 2)
+
+
+# ── Whole-store singleton rule ──
+
+
+def test_two_independent_orphans_block_the_plan() -> None:
+    store = _orphan_store(
+        **{
+            _stem(31): _body(31, supersedes="30"),
+            _stem(30): _body(30),
+        }
+    )
+    assessment = plan_supersede_repair(store)
+    assert assessment.plan is None
+    assert [(o.child, o.target) for o in assessment.orphans] == [(20, 19), (31, 30)]
+
+
+def test_a_refusal_on_another_pair_does_not_block_the_only_orphan() -> None:
+    # D41 is in a cycle with D42; the D20 -> D19 orphan is untouched by it.
+    store = _orphan_store(
+        **{
+            _stem(41): _body(41, supersedes="42"),
+            _stem(42): _body(42, supersedes="41"),
+        }
+    )
+    assessment = plan_supersede_repair(store)
+    assert "cycle_member" in _kinds(assessment)
+    assert assessment.plan is not None
+    assert (assessment.plan.child_num, assessment.plan.target_num) == (20, 19)
+
+
+def test_refusals_are_sorted_and_deterministic() -> None:
+    store = _orphan_store(
+        **{
+            _stem(21): _body(21, supersedes="19"),
+            _stem(40, "broken"): "garbage that does not parse",
+        }
+    )
+    first = plan_supersede_repair(store)
+    second = plan_supersede_repair(store)
+    assert first.model_dump() == second.model_dump()
+    assert _kinds(first) == sorted(_kinds(first))
+
+
+# ── Purity ──
+
+
+def test_repair_module_touches_no_filesystem_or_clock() -> None:
+    """The planner reads only through the Store protocol and takes no clock.
+
+    A repair plan must be reproducible: the same store yields byte-identical
+    content and the same digest, and the locked re-check in the CLI compares
+    the two directly. Filesystem or clock access here would break that.
+    """
+    module = Path(plan_supersede_repair.__code__.co_filename)
+    tree = ast.parse(module.read_text(encoding="utf-8"))
+    forbidden = {"os", "pathlib", "io", "shutil", "tempfile", "time", "random", "subprocess"}
+    imported: set[str] = set()
+    clock_reads: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            imported.add((node.module or "").split(".")[0])
+        elif isinstance(node, ast.Attribute) and node.attr in ("now", "today", "utcnow"):
+            clock_reads.add(node.attr)
+    assert imported & forbidden == set()
+    assert clock_reads == set()

--- a/packages/nauro-core/tests/test_doctor.py
+++ b/packages/nauro-core/tests/test_doctor.py
@@ -219,6 +219,157 @@ def test_deterministic_ordering() -> None:
     assert [(r.source, r.target) for r in diagnosis.dangling_refs] == [(5, 800), (20, 900)]
 
 
+# ── Supersede backref orphans (repairable, non-blocking) ──
+
+
+def test_supersede_orphan_reported() -> None:
+    store = InMemoryStore(
+        decisions={
+            _stem(20): _body(20, supersedes="19"),
+            _stem(19): _body(19),
+        }
+    )
+    diagnosis = diagnose_store(store)
+    assert [(row.child, row.target) for row in diagnosis.supersede_orphans] == [(20, 19)]
+
+
+def test_supersede_orphan_does_not_change_is_clean() -> None:
+    store = InMemoryStore(
+        decisions={
+            _stem(20): _body(20, supersedes="19"),
+            _stem(19): _body(19),
+        }
+    )
+    diagnosis = diagnose_store(store)
+    assert diagnosis.is_clean is True
+    assert diagnosis.has_repairable_defects is True
+
+
+def test_clean_store_has_no_repairable_defects() -> None:
+    store = InMemoryStore(
+        decisions={
+            _stem(1): _body(1),
+            _stem(2): _body(2, status=DecisionStatus.superseded, superseded_by="3"),
+            _stem(3): _body(3, supersedes="2"),
+        }
+    )
+    diagnosis = diagnose_store(store)
+    assert diagnosis.supersede_orphans == []
+    assert diagnosis.has_repairable_defects is False
+
+
+def test_target_carrying_backref_is_not_an_orphan() -> None:
+    store = InMemoryStore(
+        decisions={
+            _stem(20): _body(20, supersedes="19"),
+            _stem(19): _body(19, status=DecisionStatus.superseded, superseded_by="20"),
+        }
+    )
+    diagnosis = diagnose_store(store)
+    assert diagnosis.supersede_orphans == []
+
+
+def test_superseded_target_is_not_an_orphan() -> None:
+    # The target is already retired by a third decision, so its backref is not
+    # missing — it names someone else. That is a contradiction, not an orphan.
+    store = InMemoryStore(
+        decisions={
+            _stem(20): _body(20, supersedes="19"),
+            _stem(19): _body(19, status=DecisionStatus.superseded, superseded_by="21"),
+            _stem(21): _body(21),
+        }
+    )
+    diagnosis = diagnose_store(store)
+    assert diagnosis.supersede_orphans == []
+
+
+def test_superseded_child_is_not_an_orphan() -> None:
+    store = InMemoryStore(
+        decisions={
+            _stem(20): _body(
+                20, status=DecisionStatus.superseded, superseded_by="21", supersedes="19"
+            ),
+            _stem(19): _body(19),
+            _stem(21): _body(21),
+        }
+    )
+    diagnosis = diagnose_store(store)
+    assert diagnosis.supersede_orphans == []
+
+
+def test_self_referential_supersedes_is_not_an_orphan() -> None:
+    store = InMemoryStore(decisions={_stem(20): _body(20, supersedes="20")})
+    diagnosis = diagnose_store(store)
+    assert diagnosis.supersede_orphans == []
+
+
+def test_orphan_suppressed_when_child_or_target_is_in_a_cycle() -> None:
+    # D20 -> D19 is orphan-shaped, but D19 and D21 form a two-cycle that D20
+    # joins through D19. Each defect is reported once: the cycle wins.
+    store = InMemoryStore(
+        decisions={
+            _stem(20): _body(20, supersedes="19"),
+            _stem(19): _body(19, supersedes="21"),
+            _stem(21): _body(21, supersedes="19"),
+        }
+    )
+    diagnosis = diagnose_store(store)
+    assert [c.members for c in diagnosis.cycles] == [(19, 21)]
+    assert diagnosis.supersede_orphans == []
+
+
+def test_orphan_suppressed_when_target_number_is_duplicated() -> None:
+    store = InMemoryStore(
+        decisions={
+            _stem(20): _body(20, supersedes="19"),
+            _stem(19, "first"): _body(19),
+            _stem(19, "second"): _body(19),
+        }
+    )
+    diagnosis = diagnose_store(store)
+    assert diagnosis.supersede_orphans == []
+
+
+def test_orphan_suppressed_when_child_number_is_duplicated() -> None:
+    # Both files parse and carry the same forward edge. Without a child-side
+    # guard this reports the one shape twice; the pair is not unambiguous, so
+    # it is not an orphan finding at all.
+    store = InMemoryStore(
+        decisions={
+            _stem(20, "first"): _body(20, supersedes="19"),
+            _stem(20, "second"): _body(20, supersedes="19"),
+            _stem(19): _body(19),
+        }
+    )
+    diagnosis = diagnose_store(store)
+    assert diagnosis.supersede_orphans == []
+    assert diagnosis.has_repairable_defects is False
+
+
+def test_orphan_unaffected_by_an_unrelated_unparseable_file() -> None:
+    store = InMemoryStore(
+        decisions={
+            _stem(20): _body(20, supersedes="19"),
+            _stem(19): _body(19),
+            _stem(30, "broken"): "garbage that does not parse",
+        }
+    )
+    diagnosis = diagnose_store(store)
+    assert [(row.child, row.target) for row in diagnosis.supersede_orphans] == [(20, 19)]
+    assert diagnosis.is_clean is False
+
+
+def test_unparseable_target_is_not_an_orphan() -> None:
+    store = InMemoryStore(
+        decisions={
+            _stem(20): _body(20, supersedes="19"),
+            _stem(19, "broken"): "garbage that does not parse",
+        }
+    )
+    diagnosis = diagnose_store(store)
+    assert diagnosis.supersede_orphans == []
+
+
 # ── Unknown frontmatter keys (advisory) ──
 
 

--- a/packages/nauro/CLAUDE.md
+++ b/packages/nauro/CLAUDE.md
@@ -43,7 +43,8 @@ Principal commands (run `nauro --help` for the full surface):
 - `nauro sync` — capture a snapshot, regenerate `AGENTS.md` in all associated repos
 - `nauro log` — list recent snapshots with metadata
 - `nauro status` — capability table for the current project (active surfaces, absolute store path)
-- `nauro doctor` — report deterministic store-integrity defects (unparseable decision files, dangling or cyclic supersession refs, status contradictions); report-only, always exits 0
+- `nauro doctor` — report deterministic store-integrity defects (unparseable decision files, dangling or cyclic supersession refs, status contradictions) plus repairable supersede backref orphans; report-only, always exits 0
+- `nauro repair` — flip the single unambiguous supersede backref orphan after interactive confirmation; every other shape is reported with guidance and left alone
 - `nauro graph` — render the decision graph to one self-contained HTML file in the store directory and open it
 - `nauro serve` — start the local MCP server (stdio transport)
 - `nauro import --memory-bank <path>` — migrate a Cline/Roo Code Memory Bank

--- a/packages/nauro/README.md
+++ b/packages/nauro/README.md
@@ -62,7 +62,9 @@ If a small repo plus a reliable AGENTS.md or CLAUDE.md keeps agents oriented, Na
 
 `nauro graph` renders the store to one self-contained HTML file and opens it: a node-link map of every decision as the default view, plus drawn supersession lineage, a timeline, and a category browser. The demo store's consolidation, three retired decisions converging on the one that replaced them, draws as a fan. By default the file carries the full decision store, including each decision's body rendered as structured detail in the side panel, and lands in the store directory rather than your repo; `--no-include-bodies` produces a redacted titles-and-metadata artifact for wider sharing.
 
-`nauro doctor` checks the store for structural defects: unparseable decision files, dangling or cyclic supersession refs, and status contradictions. It is deterministic and report-only — it never edits the store and always exits 0.
+`nauro doctor` checks the store for structural defects: unparseable decision files, dangling or cyclic supersession refs, and status contradictions. It is deterministic and report-only — it never edits the store and always exits 0. It also names one repairable defect separately: a supersession recorded on the newer decision but never written back to the older one.
+
+`nauro repair` is the only command that acts on what doctor names, and it acts on that one shape. When a single decision in the store claims to supersede another that is still active with no reference back, it shows you both decisions with their versions and dates, states the exact field change, and asks. Anything less clear-cut — two decisions claiming the same predecessor, a cycle, a file that will not parse — is reported with guidance and left alone. Nothing is written without your answer, and there is no flag to skip the question.
 
 For real-project setup (`nauro init` / `nauro adopt`), cross-surface access, MCP tool reference, and architecture details, see the [main project README](https://github.com/nauro-ai/nauro#readme). Don't run `nauro setup` from `/tmp/nauro-demo`; that would wire the throwaway demo into your MCP client.
 

--- a/packages/nauro/src/nauro/cli/commands/doctor.py
+++ b/packages/nauro/src/nauro/cli/commands/doctor.py
@@ -6,6 +6,11 @@ contradictions. Report-only — it never edits the store — and it exits 0
 whether or not it finds defects, because a defect is information for the user,
 not a failed command.
 
+Supersede backref orphans are reported in their own section and counted
+separately: they are repairable rather than blocking, and the section names
+`nauro repair` as the remedy. Doctor still writes nothing itself — detection
+and the gated flip stay in different commands.
+
 Scope boundary: doctor reads only the decision store, so its findings can be
 deterministic with no false positives. Everything else that can be "off" on a
 machine — not connected, missing or dead wiring — is `nauro status`'s job;
@@ -42,12 +47,42 @@ def _render_unknown_keys(diagnosis: StoreDiagnosis) -> list[str]:
     return lines
 
 
+def _render_orphans(diagnosis: StoreDiagnosis) -> list[str]:
+    """Render the repairable supersede-orphan section, or nothing."""
+    if not diagnosis.supersede_orphans:
+        return []
+    lines = [
+        f"Supersede backref orphans ({len(diagnosis.supersede_orphans)}) "
+        "(repairable, not a blocking defect):"
+    ]
+    for row in diagnosis.supersede_orphans:
+        lines.append(
+            f"  {_label(row.child)} supersedes {_label(row.target)}, but "
+            f"{_label(row.target)} is still active with no superseded_by backref"
+        )
+    lines.append("  Fix: run 'nauro repair' to review and confirm the backref.")
+    lines.append("")
+    return lines
+
+
+def _render_repairable_total(diagnosis: StoreDiagnosis) -> list[str]:
+    """Count repairable defects on their own line, apart from blocking ones."""
+    if not diagnosis.supersede_orphans:
+        return []
+    return [f"Found {len(diagnosis.supersede_orphans)} repairable defect(s)."]
+
+
 def _render_report(diagnosis: StoreDiagnosis) -> list[str]:
     """Render a diagnosis as human-readable report lines."""
-    if diagnosis.is_clean:
-        return ["No integrity defects found.", *_render_unknown_keys(diagnosis)]
-
     lines: list[str] = []
+
+    if diagnosis.is_clean:
+        return [
+            "No integrity defects found.",
+            *_render_orphans(diagnosis),
+            *_render_unknown_keys(diagnosis),
+            *_render_repairable_total(diagnosis),
+        ]
 
     if diagnosis.unparseable:
         lines.append(f"Unparseable decision files ({len(diagnosis.unparseable)}):")
@@ -89,6 +124,7 @@ def _render_report(diagnosis: StoreDiagnosis) -> list[str]:
                 )
         lines.append("")
 
+    lines.extend(_render_orphans(diagnosis))
     lines.extend(_render_unknown_keys(diagnosis))
 
     total = (
@@ -98,6 +134,7 @@ def _render_report(diagnosis: StoreDiagnosis) -> list[str]:
         + len(diagnosis.contradictions)
     )
     lines.append(f"Found {total} defect(s).")
+    lines.extend(_render_repairable_total(diagnosis))
     return lines
 
 

--- a/packages/nauro/src/nauro/cli/commands/repair.py
+++ b/packages/nauro/src/nauro/cli/commands/repair.py
@@ -1,0 +1,255 @@
+"""nauro repair — flip one supersede backref after the user confirms it.
+
+`nauro doctor` detects and names; this command is the only place that acts on
+what it names, and it acts on exactly one shape: a decision that records
+`supersedes: N` where decision N is still active with no reciprocal
+`superseded_by`. Everything else the planner sees comes back as guidance with
+nothing written.
+
+The gate is the point. A repair rewrites canonical decision history, so it
+needs a human's word every time: the prompt names both decisions, states the
+exact field change, and shows each side's version, date, and status so the user
+can judge whether the newer decision really does retire the older one before
+answering. There is deliberately no flag to skip it — a bypass would leave the
+command's whole justification behind.
+
+Ordering, and why: the plan is computed, shown, and confirmed outside any lock,
+then recomputed and compared inside the decision write lock before the single
+write. Confirming against a stale plan is the failure this closes. The journal
+append happens only after the lock releases, keeping the store-wide invariant
+that the journal lock never nests inside a resource lock.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import typer
+from nauro_core.operations.repair import (
+    RepairAssessment,
+    RepairPlan,
+    plan_supersede_repair,
+)
+from pydantic import BaseModel, ConfigDict
+
+from nauro.cli.utils import cli_origin, resolve_target_project
+from nauro.store.decision_lock import decision_write_lock
+from nauro.store.filesystem_store import FilesystemStore
+from nauro.store.journal import record_event
+from nauro.store.registry import (
+    RegistryEntryV2,
+    StoreBindingError,
+    get_project_v2,
+    validate_registry_entry_v2,
+)
+from nauro.store.snapshot import capture_snapshot
+from nauro.templates.agents_md_regen import warn_then_regen
+
+REPAIR_OPERATION = "repair_supersede_backref"
+
+
+class StoreChangedDuringRepairError(RuntimeError):
+    """The store moved between the confirmed plan and the locked write."""
+
+
+class RepairEligibility(BaseModel):
+    """Whether this project's store may be rewritten from this machine."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    eligible: bool
+    guidance: str = ""
+
+
+def classify_repair_eligibility(entry: RegistryEntryV2 | None) -> RepairEligibility:
+    """Decide from the registry entry whether the local command may write.
+
+    Both registered modes proceed today. A local project owns its store
+    outright, and a cloud project's decisions are still plain markdown in the
+    same local store, which `nauro sync` publishes afterwards, so neither has a
+    store this command cannot legitimately rewrite.
+
+    The refusal covers a project this machine cannot identify: repair rewrites
+    canonical history, so it will not touch a store with no readable registry
+    entry behind it. A hosted project whose store stops being locally
+    authoritative attaches its refusal at the same point, routed to the hosted
+    owner session rather than to a local write.
+    """
+    if entry is None:
+        return RepairEligibility(
+            eligible=False,
+            guidance=(
+                "This store has no readable registry entry on this machine, so "
+                "repair cannot confirm which project owns it and will not "
+                "rewrite it. Run 'nauro status'."
+            ),
+        )
+    return RepairEligibility(eligible=True)
+
+
+def _registry_entry(project_key: str) -> RegistryEntryV2 | None:
+    """Return the validated registry entry for ``project_key``, or None."""
+    raw = get_project_v2(project_key)
+    if raw is None:
+        return None
+    try:
+        return validate_registry_entry_v2(project_key, raw)
+    except StoreBindingError:
+        return None
+
+
+def _label(num: int) -> str:
+    return f"D{num}"
+
+
+def _render_plan(plan: RepairPlan) -> list[str]:
+    """Render the proposed flip and both sides' provenance for the prompt."""
+    child = _label(plan.child_num)
+    target = _label(plan.target_num)
+    return [
+        "Supersede backref orphan found:",
+        "",
+        f"  Child:  {child} (v{plan.child_version}, {plan.child_date}) {plan.child_title}",
+        f"  Target: {target} (v{plan.target_version}, {plan.target_date}, "
+        f"{plan.target_status.value}) {plan.target_title}",
+        f"          {plan.target_path}",
+        "",
+        f"{child} records supersedes: {plan.target_num}, but {target} was never flipped.",
+        "",
+        f"This will set {target} status {plan.target_status.value} -> superseded, "
+        f"superseded_by -> {child}.",
+        "Nothing else in the file changes.",
+        "",
+    ]
+
+
+def _render_assessment(assessment: RepairAssessment) -> list[str]:
+    """Render everything the planner found, plan or not."""
+    lines: list[str] = []
+
+    # Rendered before the plan because a refusal on an unrelated pair does not
+    # block an otherwise isolated orphan: the user sees both, then answers.
+    if assessment.refusals:
+        lines.append(f"Left for manual review ({len(assessment.refusals)}):")
+        for refusal in assessment.refusals:
+            lines.append(f"  {refusal.guidance}")
+        lines.append("")
+
+    if assessment.plan is not None:
+        lines.extend(_render_plan(assessment.plan))
+        return lines
+
+    if len(assessment.orphans) > 1:
+        lines.append(f"Supersede backref orphans ({len(assessment.orphans)}):")
+        for orphan in assessment.orphans:
+            lines.append(f"  {_label(orphan.child)} supersedes {_label(orphan.target)}")
+        lines.append("")
+        lines.append("Repair acts only on a single unambiguous orphan; resolve these by hand.")
+        return lines
+
+    if assessment.refusals:
+        lines.append("Run 'nauro doctor' for the full store diagnosis.")
+    else:
+        lines.append("Nothing to repair: no supersede backref orphan found.")
+    return lines
+
+
+def _require_unchanged(planned: RepairPlan, current: RepairAssessment) -> None:
+    """Abort unless the locked re-plan is the plan the user confirmed."""
+    fresh = current.plan
+    if (
+        fresh is None
+        or (fresh.child_num, fresh.target_num) != (planned.child_num, planned.target_num)
+        or fresh.pre_image_digest != planned.pre_image_digest
+    ):
+        raise StoreChangedDuringRepairError(
+            "The decision store changed after the repair was shown; nothing was "
+            "written. Re-run 'nauro repair'."
+        )
+
+
+def _journal_repair(store_path: Path, plan: RepairPlan) -> None:
+    """Record the committed flip. Fail-open: never fails the repair."""
+    record_event(
+        store_path,
+        operation=REPAIR_OPERATION,
+        target=json.dumps(
+            {"child": plan.child_num, "target": plan.target_num},
+            sort_keys=True,
+            separators=(",", ":"),
+        ),
+        status="committed",
+        payload={
+            "child": plan.child_num,
+            "target": plan.target_num,
+            "target_stem": plan.target_stem,
+            "pre_image_digest": plan.pre_image_digest,
+        },
+        origin_factory=cli_origin,
+        decision_id=plan.target_stem,
+    )
+
+
+def repair(
+    project: str | None = typer.Option(
+        None,
+        "--project",
+        help="Target project name.",
+    ),
+) -> None:
+    """Repair a supersede backref orphan after confirming it.
+
+    Offers the single unambiguous case: one decision records 'supersedes: N'
+    while decision N is still active with no 'superseded_by' pointing back.
+    Every other shape is reported with guidance and left alone. Run
+    'nauro doctor' first to see the full store diagnosis.
+    """
+    project_name, store_path = resolve_target_project(project)
+    typer.echo(f"Project: {project_name}\n")
+
+    eligibility = classify_repair_eligibility(_registry_entry(store_path.name))
+    if not eligibility.eligible:
+        typer.echo(eligibility.guidance)
+        return
+
+    assessment = plan_supersede_repair(FilesystemStore(store_path))
+    for line in _render_assessment(assessment):
+        typer.echo(line)
+
+    plan = assessment.plan
+    if plan is None:
+        return
+
+    if not typer.confirm("Apply this repair?", default=False):
+        typer.echo("No changes written.")
+        return
+
+    try:
+        # One lock, taken once: decision_write_lock already holds
+        # decisions/.lock, and flock is not reentrant across descriptors, so a
+        # second lock on the same resource inside this block would deadlock.
+        with decision_write_lock(store_path):
+            _require_unchanged(plan, plan_supersede_repair(FilesystemStore(store_path)))
+            FilesystemStore(store_path).write_file(plan.target_path, plan.new_content)
+    except StoreChangedDuringRepairError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=1) from exc
+
+    _journal_repair(store_path, plan)
+
+    typer.echo(f"Repaired {_label(plan.target_num)}: now superseded by {_label(plan.child_num)}.")
+    typer.echo(f"  {store_path / plan.target_path}")
+
+    capture_snapshot(
+        store_path,
+        trigger=f"repair: {_label(plan.target_num)} superseded by {_label(plan.child_num)}",
+    )
+    updated_repos = warn_then_regen(
+        store_path.name,
+        store_path,
+        warn=lambda msg: typer.echo(msg, err=True),
+    )
+    for repo_path in updated_repos:
+        typer.echo(f"  Updated AGENTS.md: {repo_path}")
+    typer.echo("Run 'nauro sync' to publish this change.")

--- a/packages/nauro/src/nauro/cli/main.py
+++ b/packages/nauro/src/nauro/cli/main.py
@@ -70,6 +70,7 @@ def _register_commands() -> None:
         questions,
         reconnect,
         render_plugin,
+        repair,
         serve,
         setup,
         status,
@@ -97,6 +98,7 @@ def _register_commands() -> None:
     app.add_typer(setup.setup_app, name="setup")
     app.command(name="status")(status.status)
     app.command(name="doctor")(doctor.doctor)
+    app.command(name="repair")(repair.repair)
     app.add_typer(config.config_app, name="config")
     app.add_typer(validate.validate_app, name="validate")
     app.add_typer(auth.auth_app, name="auth")

--- a/packages/nauro/src/nauro/store/recovery.py
+++ b/packages/nauro/src/nauro/store/recovery.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import logging
 import os
 import shutil
 import tempfile
@@ -35,6 +36,8 @@ from nauro.sync.remote import (
     fetch_via_presigned_url,
     request_presigned_urls,
 )
+
+logger = logging.getLogger("nauro.store.recovery")
 
 
 class RecoveryError(RuntimeError):
@@ -162,6 +165,14 @@ def _validate_restored_store(store_path: Path) -> None:
     diagnosis = diagnose_store(FilesystemStore(store_path))
     if not diagnosis.is_clean:
         raise RecoveryError("Cloud record failed decision-store integrity validation.")
+    # A supersede backref orphan is repairable, not a reason to reject a
+    # restore: the record is readable and every decision is intact. Name it
+    # and the command that closes it rather than failing the recovery.
+    if diagnosis.has_repairable_defects:
+        logger.warning(
+            "Restored record carries %d supersede backref orphan(s); run 'nauro repair'.",
+            len(diagnosis.supersede_orphans),
+        )
 
 
 def _destination_is_available(destination: Path) -> bool:

--- a/packages/nauro/tests/snapshots/public_contract_v1.json
+++ b/packages/nauro/tests/snapshots/public_contract_v1.json
@@ -1225,6 +1225,21 @@
       },
       {
         "kind": "command",
+        "name": "repair",
+        "params": [
+          {
+            "flags": [
+              "--project"
+            ],
+            "kind": "option",
+            "name": "project",
+            "required": false,
+            "type": "text"
+          }
+        ]
+      },
+      {
+        "kind": "command",
         "name": "search-decisions",
         "params": [
           {

--- a/packages/nauro/tests/test_cli_doctor.py
+++ b/packages/nauro/tests/test_cli_doctor.py
@@ -81,6 +81,33 @@ def test_unknown_frontmatter_key_renders_advisory_on_clean_store(tmp_path: Path)
     assert "origin" in result.stdout
 
 
+def test_supersede_orphan_renders_its_own_section_and_repair_remedy(tmp_path: Path) -> None:
+    """An orphan is repairable, not blocking: the store still reads clean, the
+    orphan gets its own counted section, and the section names the remedy."""
+    store = _new_store(tmp_path)
+    write_decision_file(store, 20, "child", _decision_md(20, supersedes="19"))
+    write_decision_file(store, 19, "target", _decision_md(19))
+
+    result = runner.invoke(app, ["doctor", "--project", "docproj"])
+
+    assert result.exit_code == 0
+    assert "No integrity defects found." in result.stdout
+    assert "Supersede backref orphans (1)" in result.stdout
+    assert "D20 supersedes D19" in result.stdout
+    assert "nauro repair" in result.stdout
+    assert "Found 1 repairable defect(s)." in result.stdout
+
+
+def test_clean_store_report_is_unchanged_by_the_orphan_section(tmp_path: Path) -> None:
+    store = _new_store(tmp_path)
+    write_decision_file(store, 1, "settled", _decision_md(1))
+
+    result = runner.invoke(app, ["doctor", "--project", "docproj"])
+
+    assert result.exit_code == 0
+    assert result.stdout == "Project: docproj\n\nNo integrity defects found.\n"
+
+
 def test_project_resolution_and_report_header(tmp_path: Path) -> None:
     _new_store(tmp_path, name="another")
     result = runner.invoke(app, ["doctor", "--project", "another"])

--- a/packages/nauro/tests/test_cli_repair.py
+++ b/packages/nauro/tests/test_cli_repair.py
@@ -1,0 +1,235 @@
+"""Tests for the ``nauro repair`` command.
+
+Command-and-adapter behaviour: the confirmation gate, what reaches disk, the
+journal record, and the abort when the store moves under a confirmed plan.
+Which shapes are repairable and which are refused is pinned in the nauro-core
+suite and is not re-asserted here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from nauro_core.decision_model import Decision, format_decision
+from typer.testing import CliRunner
+
+import nauro.cli.commands.repair as repair_module
+from nauro.cli.main import app
+from nauro.store.journal import read_events
+from nauro.store.registry import RegistryEntryV2, register_project_v2
+from nauro.templates.scaffolds import scaffold_project_store
+from tests.conftest import write_decision_file
+
+runner = CliRunner()
+
+CHILD_STEM = "020-child"
+TARGET_STEM = "019-target"
+
+
+def _decision_md(num: int, *, supersedes: str | None = None) -> str:
+    return format_decision(
+        Decision(
+            date="2026-03-15",
+            confidence="high",
+            num=num,
+            title=f"Decision {num}",
+            rationale=f"Rationale for decision {num}.",
+            supersedes=supersedes,
+        )
+    )
+
+
+def _new_store(tmp_path: Path, name: str = "repairproj") -> Path:
+    _pid, store = register_project_v2(name, [tmp_path])
+    scaffold_project_store(name, store)
+    return store
+
+
+def _seed_orphan(store: Path) -> None:
+    write_decision_file(store, 20, "child", _decision_md(20, supersedes="19"))
+    write_decision_file(store, 19, "target", _decision_md(19))
+
+
+def _target_body(store: Path) -> str:
+    return (store / "decisions" / f"{TARGET_STEM}.md").read_text(encoding="utf-8")
+
+
+def test_nothing_to_repair_writes_nothing_and_exits_zero(tmp_path: Path) -> None:
+    store = _new_store(tmp_path)
+    write_decision_file(store, 1, "settled", _decision_md(1))
+    before = (store / "decisions" / "001-settled.md").read_text(encoding="utf-8")
+
+    result = runner.invoke(app, ["repair", "--project", "repairproj"])
+
+    assert result.exit_code == 0
+    assert "Nothing to repair" in result.stdout
+    assert (store / "decisions" / "001-settled.md").read_text(encoding="utf-8") == before
+
+
+def test_prompt_names_both_decisions_and_the_exact_field_change(tmp_path: Path) -> None:
+    store = _new_store(tmp_path)
+    _seed_orphan(store)
+
+    result = runner.invoke(app, ["repair", "--project", "repairproj"], input="n\n")
+
+    assert result.exit_code == 0
+    assert "D20" in result.stdout
+    assert "D19" in result.stdout
+    assert "status active -> superseded" in result.stdout
+    assert "superseded_by -> D20" in result.stdout
+    assert "Apply this repair?" in result.stdout
+
+
+def test_declining_writes_nothing(tmp_path: Path) -> None:
+    store = _new_store(tmp_path)
+    _seed_orphan(store)
+    before = _target_body(store)
+
+    result = runner.invoke(app, ["repair", "--project", "repairproj"], input="n\n")
+
+    assert result.exit_code == 0
+    assert "No changes written." in result.stdout
+    assert _target_body(store) == before
+
+
+def test_confirming_flips_the_target_frontmatter(tmp_path: Path) -> None:
+    store = _new_store(tmp_path)
+    _seed_orphan(store)
+    child_before = (store / "decisions" / f"{CHILD_STEM}.md").read_text(encoding="utf-8")
+
+    result = runner.invoke(app, ["repair", "--project", "repairproj"], input="y\n")
+
+    assert result.exit_code == 0
+    after = _target_body(store)
+    assert "status: superseded" in after
+    assert "superseded_by: '20'" in after
+    assert "Rationale for decision 19." in after
+    # Only the target moves: the child that named it is untouched.
+    assert (store / "decisions" / f"{CHILD_STEM}.md").read_text(encoding="utf-8") == child_before
+    assert "Run 'nauro sync' to publish this change." in result.stdout
+
+
+def test_repair_is_idempotent(tmp_path: Path) -> None:
+    store = _new_store(tmp_path)
+    _seed_orphan(store)
+    runner.invoke(app, ["repair", "--project", "repairproj"], input="y\n")
+    after_first = _target_body(store)
+
+    second = runner.invoke(app, ["repair", "--project", "repairproj"], input="y\n")
+
+    assert second.exit_code == 0
+    assert "Nothing to repair" in second.stdout
+    assert _target_body(store) == after_first
+
+
+def test_journal_records_the_repair_with_cli_origin(tmp_path: Path) -> None:
+    store = _new_store(tmp_path)
+    _seed_orphan(store)
+
+    runner.invoke(app, ["repair", "--project", "repairproj"], input="y\n")
+
+    events = [e for e in read_events(store) if e.operation == repair_module.REPAIR_OPERATION]
+    assert len(events) == 1
+    event = events[0]
+    assert event.status == "committed"
+    assert event.target == '{"child":20,"target":19}'
+    assert event.decision_id == TARGET_STEM
+    assert event.origin is not None
+    assert event.origin.transport == "cli"
+
+
+def test_journal_failure_does_not_fail_the_repair(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = _new_store(tmp_path)
+    _seed_orphan(store)
+
+    def _boom(*_args: object, **_kwargs: object) -> None:
+        raise OSError("journal unavailable")
+
+    monkeypatch.setattr("nauro.store.journal.append_event", _boom)
+
+    result = runner.invoke(app, ["repair", "--project", "repairproj"], input="y\n")
+
+    assert result.exit_code == 0
+    assert "status: superseded" in _target_body(store)
+    assert read_events(store) == []
+
+
+def test_store_changing_under_a_confirmed_plan_aborts_without_writing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = _new_store(tmp_path)
+    _seed_orphan(store)
+    real_planner = repair_module.plan_supersede_repair
+    calls = {"count": 0}
+
+    def _mutating_planner(fs_store):
+        calls["count"] += 1
+        if calls["count"] == 2:
+            target = store / "decisions" / f"{TARGET_STEM}.md"
+            target.write_text(
+                target.read_text(encoding="utf-8") + "\nA later edit.\n", encoding="utf-8"
+            )
+        return real_planner(fs_store)
+
+    monkeypatch.setattr(repair_module, "plan_supersede_repair", _mutating_planner)
+
+    result = runner.invoke(app, ["repair", "--project", "repairproj"], input="y\n")
+
+    assert result.exit_code == 1
+    after = _target_body(store)
+    assert "status: active" in after
+    assert "A later edit." in after
+
+
+def test_refusal_prints_guidance_and_writes_nothing(tmp_path: Path) -> None:
+    store = _new_store(tmp_path)
+    _seed_orphan(store)
+    write_decision_file(store, 21, "rival", _decision_md(21, supersedes="19"))
+    before = _target_body(store)
+
+    result = runner.invoke(app, ["repair", "--project", "repairproj"], input="y\n")
+
+    assert result.exit_code == 0
+    assert "Left for manual review" in result.stdout
+    assert "all claim to supersede D19" in result.stdout
+    assert "Apply this repair?" not in result.stdout
+    assert _target_body(store) == before
+
+
+def test_two_independent_orphans_report_and_write_nothing(tmp_path: Path) -> None:
+    store = _new_store(tmp_path)
+    _seed_orphan(store)
+    write_decision_file(store, 31, "other-child", _decision_md(31, supersedes="30"))
+    write_decision_file(store, 30, "other-target", _decision_md(30))
+    before = _target_body(store)
+
+    result = runner.invoke(app, ["repair", "--project", "repairproj"], input="y\n")
+
+    assert result.exit_code == 0
+    assert "Supersede backref orphans (2)" in result.stdout
+    assert "resolve these by hand" in result.stdout
+    assert _target_body(store) == before
+
+
+def test_unknown_project_exits_nonzero(tmp_path: Path) -> None:
+    result = runner.invoke(app, ["repair", "--project", "nope"])
+    assert result.exit_code == 1
+
+
+@pytest.mark.parametrize("mode", ["local", "cloud"])
+def test_both_registered_modes_are_eligible(mode: str) -> None:
+    entry = RegistryEntryV2(
+        name="repairproj",
+        mode=mode,
+        server_url="https://example.invalid" if mode == "cloud" else None,
+    )
+    assert repair_module.classify_repair_eligibility(entry).eligible is True
+
+
+def test_store_without_a_registry_entry_is_refused() -> None:
+    eligibility = repair_module.classify_repair_eligibility(None)
+    assert eligibility.eligible is False
+    assert "nauro status" in eligibility.guidance

--- a/packages/nauro/tests/test_recovery.py
+++ b/packages/nauro/tests/test_recovery.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import hashlib
+import logging
 from pathlib import Path
 
 import pytest
+from nauro_core.decision_model import Decision, format_decision
 
 from nauro.store import recovery
 from nauro.store.recovery import RecoveryError, bind_local_store, restore_cloud_store
@@ -254,6 +256,41 @@ def test_restore_cloud_store_rejects_malformed_presign_result(tmp_path, monkeypa
 
     assert not destination.exists()
     assert not list(destination.parent.glob(f".{PID}.restore-*"))
+
+
+def _decision_bytes(num: int, *, supersedes: str | None = None) -> bytes:
+    return format_decision(
+        Decision(
+            date="2026-03-15",
+            confidence="high",
+            num=num,
+            title=f"Decision {num}",
+            rationale=f"Rationale for decision {num}.",
+            supersedes=supersedes,
+        )
+    ).encode("utf-8")
+
+
+def test_restore_accepts_a_repairable_orphan_and_names_the_repair_command(
+    tmp_path, monkeypatch, caplog
+):
+    """A missing supersession backref is recoverable, not a corrupt record.
+
+    The restore must still install (integrity validation is unmoved by it) and
+    must say which command closes it."""
+    source = tmp_path / "source"
+    files = _store_files(source)
+    files["decisions/019-target.md"] = _decision_bytes(19)
+    files["decisions/020-child.md"] = _decision_bytes(20, supersedes="19")
+    _mock_remote(monkeypatch, files)
+    destination = tmp_path / "projects" / PID
+
+    with caplog.at_level(logging.WARNING, logger="nauro.store.recovery"):
+        result = restore_cloud_store(PID, destination)
+
+    assert result == destination
+    assert (destination / "decisions" / "019-target.md").is_file()
+    assert "nauro repair" in caplog.text
 
 
 def test_restore_cloud_store_rejects_damaged_decision_graph(tmp_path, monkeypatch):


### PR DESCRIPTION
Doc-only. The root CLAUDE.md command table gains the `nauro repair` line and doctor's updated description, matching the package-level CLAUDE.md updated in #403, and carries the `@AGENTS.md` include already present in the working tree.