### PR TITLE
Release nauro 1.12.0 and nauro-core 1.7.0

### DIFF
--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro-core"
-version = "1.6.0"
+version = "1.7.0"
 description = "Shared pure-Python logic for Nauro: parsing, validation, context assembly, constants."
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro"
-version = "1.11.0"
+version = "1.12.0"
 description = "Human-approved project judgment and current state for connected AI agents, surfaced before work."
 readme = "README.md"
 license = "Apache-2.0"
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "nauro-core>=1.6.0,<2",
+    "nauro-core>=1.7.0,<2",
     "typer>=0.9",
     "httpx>=0.24",
     "mcp>=1.0",

--- a/server.json
+++ b/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Nauro-AI/nauro",
     "source": "github"
   },
-  "version": "1.11.0",
+  "version": "1.12.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "nauro",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -928,7 +928,7 @@ wheels = [
 
 [[package]]
 name = "nauro"
-version = "1.11.0"
+version = "1.12.0"
 source = { editable = "packages/nauro" }
 dependencies = [
     { name = "filelock" },
@@ -970,7 +970,7 @@ provides-extras = ["dev", "embeddings"]
 
 [[package]]
 name = "nauro-core"
-version = "1.6.0"
+version = "1.7.0"
 source = { editable = "packages/nauro-core" }
 dependencies = [
     { name = "bm25s" },


### PR DESCRIPTION
## Version moves

- **nauro** 1.11.0 → 1.12.0 (minor)
- **nauro-core** 1.6.0 → 1.7.0 (minor)
- nauro's dependency floor rises to `nauro-core>=1.7.0,<2` — the CLI now imports the kernel's repair planner at command registration, so pairing new nauro with an older core would fail at startup, not just on the new command.
- `server.json` follows the nauro package to 1.12.0; `uv.lock` re-locked.

## What ships

**nauro-core 1.7.0** (additive; curated public API unchanged)
- `doctor` gains detection of the supersede backref orphan — an active decision whose `supersedes` target is still active with no reciprocal `superseded_by` — reported as a separate repairable class alongside the four blocking defect categories, with `is_clean` unchanged.
- New pure planning module `operations/repair.py`: at most one repair plan per store plus typed refusals with guidance for every ambiguous shape.

**nauro 1.12.0** (additive minor: one new CLI command)
- New `nauro repair` command: flips the single unambiguous supersede backref orphan after an interactive confirmation naming both decisions, under the decision write lock, journaled, followed by snapshot capture and AGENTS.md regeneration. Every other shape is reported with guidance and left untouched. No MCP tool added; the stdio contract is unchanged.
- `nauro doctor` renders the new orphan section with `nauro repair` named as the remedy; cloud restore logs the same remedy instead of failing.
- Public-contract snapshot: exactly one additive `repair` command block.

## Checks

- `check_server_json_version.py` and `check_single_sourced.py` pass locally
- `uv lock --check` clean; `uv sync --locked` passes for both packages on 3.12
- Full suites green on the feature merge this releases (nauro-core 1222; nauro 2233 passed, 10 skipped)

## Post-merge

Tag the squash commit `nauro-core-v1.7.0` and `nauro-v1.12.0` and push both tags to trigger the trusted-publish workflows (PyPI for both; MCP registry from the nauro tag), then create the GitHub Releases.
