### PR TITLE
Make post-commit snapshot, regen, and push fail open

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/import_cmd.py
+++ b/packages/nauro/src/nauro/cli/commands/import_cmd.py
@@ -19,7 +19,7 @@ from nauro.constants import DECISIONS_DIR, PROJECT_MD, STACK_MD
 from nauro.store.decision_lock import decision_write_lock
 from nauro.store.filesystem_store import FilesystemStore
 from nauro.store.journal import record_event
-from nauro.store.snapshot import capture_snapshot
+from nauro.store.post_commit import run_post_commit
 from nauro.store.store_lock import store_write_lock
 
 
@@ -50,7 +50,7 @@ def _import_append_decision(
     }
     # Hold the allocation lock across the number computation and the write so
     # concurrent local writers cannot mint the same decision number. The
-    # post-loop capture_snapshot stays outside the lock.
+    # post-loop snapshot capture stays outside the lock.
     with decision_write_lock(store_path):
         decision_id = _write_decision_direct(FilesystemStore(store_path), proposal)
     record_event(
@@ -633,7 +633,6 @@ def import_cmd(
             raise typer.Exit(code=1)
 
         counts = _import_memory_bank(mb, store_path)
-        capture_snapshot(store_path, trigger="import: memory-bank")
 
         typer.echo(f"Imported Memory Bank into {project_name}:")
         typer.echo(f"  Store: {store_path}")
@@ -649,6 +648,10 @@ def import_cmd(
             )
         typer.echo("  Next: run 'nauro sync' to update AGENTS.md in associated repos")
 
+        outcome = run_post_commit(store_path, snapshot_trigger="import: memory-bank")
+        for line in outcome.warnings:
+            typer.echo(line, err=True)
+
     if adr is not None:
         adr_path = Path(adr)
         if not adr_path.is_dir():
@@ -656,7 +659,6 @@ def import_cmd(
             raise typer.Exit(code=1)
 
         adr_counts = _import_adrs(adr_path, store_path)
-        capture_snapshot(store_path, trigger="import: adr")
 
         typer.echo(f"Imported ADRs into {project_name}:")
         typer.echo(f"  Store: {store_path}")
@@ -671,3 +673,7 @@ def import_cmd(
                 err=True,
             )
         typer.echo("  Next: run 'nauro sync' to update AGENTS.md in associated repos")
+
+        outcome = run_post_commit(store_path, snapshot_trigger="import: adr")
+        for line in outcome.warnings:
+            typer.echo(line, err=True)

--- a/packages/nauro/src/nauro/cli/commands/note.py
+++ b/packages/nauro/src/nauro/cli/commands/note.py
@@ -10,8 +10,8 @@ from nauro.cli.utils import cli_origin, resolve_target_project
 from nauro.store.decision_lock import decision_write_lock
 from nauro.store.filesystem_store import FilesystemStore
 from nauro.store.journal import record_event
+from nauro.store.post_commit import run_post_commit
 from nauro.store.store_lock import store_write_lock
-from nauro.templates.agents_md_regen import warn_then_regen
 
 
 def _validate_confidence(value: str) -> str:
@@ -142,13 +142,14 @@ def note(
         typer.echo(f"  {filepath}")
 
     # Refresh AGENTS.md so MCP-disconnected agents see the update without
-    # requiring a separate `nauro sync`. Mirrors the warn-then-regen
-    # sequence in `nauro sync`.
-    project_key = store_path.name
-    updated_repos = warn_then_regen(
-        project_key,
+    # requiring a separate `nauro sync`. The write above has already committed,
+    # so this trails it through the fail-open seam.
+    outcome = run_post_commit(
         store_path,
+        regenerate_agents_md=True,
         warn=lambda msg: typer.echo(msg, err=True),
     )
-    for repo_path in updated_repos:
+    for line in outcome.warnings:
+        typer.echo(line, err=True)
+    for repo_path in outcome.updated_repos:
         typer.echo(f"  Updated AGENTS.md: {repo_path}")

--- a/packages/nauro/src/nauro/cli/commands/questions.py
+++ b/packages/nauro/src/nauro/cli/commands/questions.py
@@ -14,7 +14,7 @@ from nauro_core.questions import OpenQuestionsFile
 
 from nauro.cli.utils import resolve_target_project
 from nauro.store.filesystem_store import FilesystemStore
-from nauro.templates.agents_md_regen import warn_then_regen
+from nauro.store.post_commit import run_post_commit
 
 questions_app = typer.Typer(help="Maintenance commands for open-questions.md.")
 
@@ -60,10 +60,12 @@ def migrate(
 
     # Refresh AGENTS.md so MCP-disconnected agents see the new ids without a
     # separate `nauro sync`. Mirrors `nauro note`.
-    updated_repos = warn_then_regen(
-        store_path.name,
+    outcome = run_post_commit(
         store_path,
+        regenerate_agents_md=True,
         warn=lambda msg: typer.echo(msg, err=True),
     )
-    for repo_path in updated_repos:
+    for line in outcome.warnings:
+        typer.echo(line, err=True)
+    for repo_path in outcome.updated_repos:
         typer.echo(f"  Updated AGENTS.md: {repo_path}")

--- a/packages/nauro/src/nauro/cli/commands/repair.py
+++ b/packages/nauro/src/nauro/cli/commands/repair.py
@@ -37,14 +37,13 @@ from nauro.cli.utils import cli_origin, resolve_target_project
 from nauro.store.decision_lock import decision_write_lock
 from nauro.store.filesystem_store import FilesystemStore
 from nauro.store.journal import record_event
+from nauro.store.post_commit import run_post_commit
 from nauro.store.registry import (
     RegistryEntryV2,
     StoreBindingError,
     get_project_v2,
     validate_registry_entry_v2,
 )
-from nauro.store.snapshot import capture_snapshot
-from nauro.templates.agents_md_regen import warn_then_regen
 
 REPAIR_OPERATION = "repair_supersede_backref"
 
@@ -241,15 +240,16 @@ def repair(
     typer.echo(f"Repaired {_label(plan.target_num)}: now superseded by {_label(plan.child_num)}.")
     typer.echo(f"  {store_path / plan.target_path}")
 
-    capture_snapshot(
+    outcome = run_post_commit(
         store_path,
-        trigger=f"repair: {_label(plan.target_num)} superseded by {_label(plan.child_num)}",
-    )
-    updated_repos = warn_then_regen(
-        store_path.name,
-        store_path,
+        snapshot_trigger=(
+            f"repair: {_label(plan.target_num)} superseded by {_label(plan.child_num)}"
+        ),
+        regenerate_agents_md=True,
         warn=lambda msg: typer.echo(msg, err=True),
     )
-    for repo_path in updated_repos:
+    for line in outcome.warnings:
+        typer.echo(line, err=True)
+    for repo_path in outcome.updated_repos:
         typer.echo(f"  Updated AGENTS.md: {repo_path}")
     typer.echo("Run 'nauro sync' to publish this change.")

--- a/packages/nauro/src/nauro/mcp/tools.py
+++ b/packages/nauro/src/nauro/mcp/tools.py
@@ -70,15 +70,14 @@ from nauro.store.journal import (
     OriginDescriptor,
     record_event,
 )
+from nauro.store.post_commit import run_post_commit
 from nauro.store.reader import read_text_lenient
 from nauro.store.snapshot import (
-    capture_snapshot,
     list_snapshots,
     load_snapshot,
     resolve_diff_snapshots,
 )
 from nauro.store.store_lock import store_write_lock
-from nauro.templates.agents_md_regen import warn_then_regen
 
 logger = logging.getLogger("nauro.mcp.tools")
 
@@ -486,21 +485,21 @@ def tool_propose_decision(
     response: dict = {"store": "local", **dumped}
 
     if result.status == "confirmed":
-        capture_snapshot(store_path, trigger=f"decision: {result.decision_id}")
-        if touched:
-            regen_warnings: list[str] = []
+        regen_warnings: list[str] = []
+        outcome = run_post_commit(
+            store_path,
+            snapshot_trigger=f"decision: {result.decision_id}",
+            regenerate_agents_md=bool(touched),
+            warn=regen_warnings.append,
             # Stay protocol-silent about the Claude Code bridge on this stdio
             # path: the bridge is still ensured, just not narrated into the
             # tool response.
-            warn_then_regen(
-                store_path.name,
-                store_path,
-                warn=regen_warnings.append,
-                surface_bridge_notices=False,
-            )
-            if regen_warnings:
-                response["assessment"] = "\n\n".join([response["assessment"], *regen_warnings])
-        _try_push(store_path)
+            surface_bridge_notices=False,
+            push=_try_push,
+        )
+        notes = [*regen_warnings, *outcome.warnings]
+        if notes:
+            response["assessment"] = "\n\n".join([response["assessment"], *notes])
 
     return response
 
@@ -652,10 +651,9 @@ def tool_flag_question(
         # so the on-disk store stays untouched and observers see a clean reject.
         return response
 
-    capture_snapshot(store_path, trigger=f"question: {question}")
     if hint:
         response["hint"] = hint
-    _try_push(store_path)
+    run_post_commit(store_path, snapshot_trigger=f"question: {question}", push=_try_push)
     return response
 
 
@@ -691,8 +689,11 @@ def _flag_question_resolve(
     if result.status == "rejected":
         return response
 
-    capture_snapshot(store_path, trigger=f"resolved by {resolved_by}: {targets or []}")
-    _try_push(store_path)
+    run_post_commit(
+        store_path,
+        snapshot_trigger=f"resolved by {resolved_by}: {targets or []}",
+        push=_try_push,
+    )
     return response
 
 
@@ -898,8 +899,10 @@ def tool_update_state(
     # Adapter-side side effects only run on the success path. ``noop``
     # means the kernel had no existing state file to update — skip the
     # snapshot/push since nothing was written.
+    # A degraded ancillary step is logged, not surfaced: ``warning`` is the
+    # kernel's own keyword-overlap advisory, and writing adapter text into it
+    # would repurpose a pinned field the same way a new field would.
     if result.status != "noop":
-        capture_snapshot(store_path, trigger=f"state: {delta}")
-        _try_push(store_path)
+        run_post_commit(store_path, snapshot_trigger=f"state: {delta}", push=_try_push)
 
     return envelope

--- a/packages/nauro/src/nauro/store/post_commit.py
+++ b/packages/nauro/src/nauro/store/post_commit.py
@@ -1,0 +1,148 @@
+"""Fail-open runner for the ancillary steps that trail a committed write.
+
+Once a judgment write has committed to the local store, the artifacts derived
+from it are ancillary: the snapshot capture, the ``AGENTS.md`` regeneration,
+and the cloud push. A failure in one of them is reported and never converted
+into a failure of the write that already succeeded. The CLI names the degraded
+step and exits 0, and the MCP adapters keep their success envelope. Every
+remaining step still runs when an earlier one degrades, and each derived
+artifact self-heals on the next write or on ``nauro sync``.
+
+Every step is guarded here, including the injected push. The push is fail-open
+at its own definition too, and the double guard is deliberate: this module owns
+the posture for whatever a caller injects, rather than trusting each callee to
+keep its own promise.
+
+The guard catches ``Exception`` rather than ``OSError`` alone: the fail-soft
+regeneration path narrowed to ``OSError`` and drifted from the filesystem-error
+promise its own docstring made.
+
+Boundary: ``nauro sync`` and the setup wiring paths are deliberately not routed
+through this seam. There the snapshot capture or the regeneration is the
+command's primary work rather than a tail on a judgment write, so a failure
+stays a failure and exits nonzero.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from enum import Enum
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict
+
+from nauro.store.snapshot import capture_snapshot
+from nauro.templates.agents_md_regen import warn_then_regen
+
+logger = logging.getLogger("nauro.store.post_commit")
+
+
+class AncillaryStep(str, Enum):
+    """The derived-artifact steps that run after a write has committed."""
+
+    SNAPSHOT = "snapshot capture"
+    AGENTS_MD = "AGENTS.md regeneration"
+    PUSH = "cloud push"
+
+
+class DegradedStep(BaseModel):
+    """One ancillary step that did not complete, and why."""
+
+    model_config = ConfigDict(frozen=True)
+
+    step: AncillaryStep
+    reason: str
+
+    @property
+    def warning(self) -> str:
+        """The human-facing line naming the degraded step."""
+        return (
+            f"  Warning: the write was recorded, but {self.step.value} failed: {self.reason}\n"
+            "  Run 'nauro sync' to rebuild the derived files."
+        )
+
+
+class PostCommitOutcome(BaseModel):
+    """What the ancillary steps did for one committed write."""
+
+    model_config = ConfigDict(frozen=True)
+
+    degraded: tuple[DegradedStep, ...] = ()
+    updated_repos: tuple[Path, ...] = ()
+
+    @property
+    def is_degraded(self) -> bool:
+        return bool(self.degraded)
+
+    @property
+    def warnings(self) -> tuple[str, ...]:
+        """One line per degraded step, in the order the steps ran."""
+        return tuple(item.warning for item in self.degraded)
+
+
+def run_post_commit(
+    store_path: Path,
+    *,
+    snapshot_trigger: str | None = None,
+    regenerate_agents_md: bool = False,
+    warn: Callable[[str], None] | None = None,
+    surface_bridge_notices: bool = True,
+    push: Callable[[Path], None] | None = None,
+) -> PostCommitOutcome:
+    """Run the ancillary steps for a write that already committed.
+
+    Args:
+        store_path: Path to the project store directory.
+        snapshot_trigger: Trigger label for the snapshot. ``None`` skips the
+            capture (the caller's write does not warrant a new snapshot).
+        regenerate_agents_md: Refresh ``AGENTS.md`` in the associated repos.
+        warn: Forwarded to :func:`warn_then_regen` for its own per-repo skip and
+            git-hygiene warnings. Degraded steps are *not* reported through this
+            channel. They come back on the outcome so each surface routes them
+            to the channel it owns (stderr for the CLI, the assessment text for
+            the MCP adapters).
+        surface_bridge_notices: Forwarded to :func:`warn_then_regen`.
+        push: Optional cloud push, invoked with ``store_path``. Runs last, and
+            regardless of an earlier degraded step.
+
+    Returns:
+        The outcome naming every degraded step and the repos whose
+        ``AGENTS.md`` was regenerated.
+    """
+    degraded: list[DegradedStep] = []
+    updated_repos: list[Path] = []
+
+    if snapshot_trigger is not None:
+        try:
+            capture_snapshot(store_path, trigger=snapshot_trigger)
+        except Exception as exc:
+            logger.debug("snapshot capture failed for %s", store_path.name, exc_info=True)
+            degraded.append(
+                DegradedStep(step=AncillaryStep.SNAPSHOT, reason=f"{type(exc).__name__}: {exc}")
+            )
+
+    if regenerate_agents_md:
+        try:
+            updated_repos = warn_then_regen(
+                store_path.name,
+                store_path,
+                warn=warn,
+                surface_bridge_notices=surface_bridge_notices,
+            )
+        except Exception as exc:
+            logger.debug("AGENTS.md regeneration failed for %s", store_path.name, exc_info=True)
+            degraded.append(
+                DegradedStep(step=AncillaryStep.AGENTS_MD, reason=f"{type(exc).__name__}: {exc}")
+            )
+
+    if push is not None:
+        try:
+            push(store_path)
+        except Exception as exc:
+            logger.debug("cloud push failed for %s", store_path.name, exc_info=True)
+            degraded.append(
+                DegradedStep(step=AncillaryStep.PUSH, reason=f"{type(exc).__name__}: {exc}")
+            )
+
+    return PostCommitOutcome(degraded=tuple(degraded), updated_repos=tuple(updated_repos))

--- a/packages/nauro/tests/test_cli_repair.py
+++ b/packages/nauro/tests/test_cli_repair.py
@@ -157,6 +157,44 @@ def test_journal_failure_does_not_fail_the_repair(
     assert read_events(store) == []
 
 
+def test_snapshot_failure_does_not_fail_the_repair(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = _new_store(tmp_path)
+    _seed_orphan(store)
+
+    def _boom(*_args: object, **_kwargs: object) -> int:
+        raise OSError("disk full")
+
+    monkeypatch.setattr("nauro.store.post_commit.capture_snapshot", _boom)
+
+    result = runner.invoke(app, ["repair", "--project", "repairproj"], input="y\n")
+
+    assert result.exit_code == 0
+    assert "Repaired D19" in result.stdout
+    assert "snapshot capture failed" in result.stderr
+    assert "status: superseded" in _target_body(store)
+
+
+def test_regen_failure_does_not_fail_the_repair(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = _new_store(tmp_path)
+    _seed_orphan(store)
+
+    def _boom(*_args: object, **_kwargs: object) -> list[Path]:
+        raise ValueError("registry entry is malformed")
+
+    monkeypatch.setattr("nauro.store.post_commit.warn_then_regen", _boom)
+
+    result = runner.invoke(app, ["repair", "--project", "repairproj"], input="y\n")
+
+    assert result.exit_code == 0
+    assert "Repaired D19" in result.stdout
+    assert "AGENTS.md regeneration failed" in result.stderr
+    assert "status: superseded" in _target_body(store)
+
+
 def test_store_changing_under_a_confirmed_plan_aborts_without_writing(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/packages/nauro/tests/test_import.py
+++ b/packages/nauro/tests/test_import.py
@@ -212,6 +212,37 @@ def test_import_cli_full(tmp_path: Path, monkeypatch, full_memory_bank: Path):
     assert snaps[0]["trigger"] == "import: memory-bank"
 
 
+@pytest.mark.parametrize(
+    ("flag", "source_fixture", "summary"),
+    [
+        ("--memory-bank", "full_memory_bank", "Imported Memory Bank into myproj"),
+        ("--adr", "madr_directory", "Imported ADRs into myproj"),
+    ],
+)
+def test_import_reports_the_merge_when_the_snapshot_fails(
+    tmp_path: Path, monkeypatch, request, flag: str, source_fixture: str, summary: str
+):
+    """A committed import always reports itself, so nobody re-runs it blind."""
+    source = request.getfixturevalue(source_fixture)
+    _pid, store = register_project_v2("myproj", [tmp_path])
+    scaffold_project_store("myproj", store)
+    monkeypatch.chdir(tmp_path)
+
+    def _boom(*_args, **_kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr("nauro.store.post_commit.capture_snapshot", _boom)
+
+    result = runner.invoke(app, ["import", flag, str(source)])
+
+    assert result.exit_code == 0
+    assert summary in result.stdout
+    assert "snapshot capture failed" in result.stderr
+    imported = [f for f in (store / "decisions").glob("*.md") if f.name != "001-initial-setup.md"]
+    assert imported
+    assert list_snapshots(store) == []
+
+
 def test_import_cli_partial(tmp_path: Path, monkeypatch, partial_memory_bank: Path):
     _pid, store = register_project_v2("myproj", [tmp_path])
     scaffold_project_store("myproj", store)

--- a/packages/nauro/tests/test_note.py
+++ b/packages/nauro/tests/test_note.py
@@ -237,3 +237,25 @@ def test_note_nonempty_text_succeeds(tmp_path: Path, monkeypatch):
     new_files = [f for f in decisions_dir.glob("*.md") if f.name != "001-initial-setup.md"]
     assert len(new_files) == 1
     assert "use-redis-for-session-storage" in new_files[0].name
+
+
+def test_note_survives_a_failing_agents_md_regen(tmp_path: Path, monkeypatch):
+    """The decision is recorded and reported even when the regen fails."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _pid, store = register_project_v2("myproj", [repo])
+    scaffold_project_store("myproj", store)
+    monkeypatch.chdir(repo)
+
+    def _boom(*_args, **_kwargs):
+        raise OSError("AGENTS.md is not writable")
+
+    monkeypatch.setattr("nauro.store.post_commit.warn_then_regen", _boom)
+
+    result = runner.invoke(app, ["note", "Use Postgres for v2 storage"])
+
+    assert result.exit_code == 0, result.output
+    assert "Decision recorded" in result.stdout
+    assert "AGENTS.md regeneration failed" in result.stderr
+    new_files = [f for f in (store / "decisions").glob("*.md") if f.name != "001-initial-setup.md"]
+    assert len(new_files) == 1

--- a/packages/nauro/tests/test_post_commit.py
+++ b/packages/nauro/tests/test_post_commit.py
@@ -1,0 +1,284 @@
+"""The post-commit seam runs every ancillary step and never raises.
+
+Covers the runner in isolation (a clean run, a degraded snapshot capture, a
+degraded AGENTS.md regeneration raising something other than ``OSError``, a
+raising push callable, and the ordering guarantee that a degraded step does not
+skip the ones after it), then the MCP write adapters that route through it: a
+degraded ancillary step must leave the success envelope and the journal event
+intact. The CLI surfaces are covered alongside their own commands.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nauro.mcp import tools as mcp_tools
+from nauro.mcp.tools import tool_flag_question, tool_propose_decision, tool_update_state
+from nauro.store.journal import read_events
+from nauro.store.post_commit import AncillaryStep, run_post_commit
+from nauro.store.registry import register_project_v2
+from nauro.templates.scaffolds import scaffold_project_store
+
+SNAPSHOTS = "snapshots"
+
+
+def _project(tmp_path: Path) -> tuple[Path, Path]:
+    """Register a project whose single repo path is a real directory."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _pid, store_path = register_project_v2("postcommitproj", [repo])
+    scaffold_project_store("postcommitproj", store_path)
+    return store_path, repo
+
+
+def test_clean_run_reports_no_degradation_and_the_regenerated_repos(tmp_path: Path) -> None:
+    store_path, repo = _project(tmp_path)
+
+    outcome = run_post_commit(
+        store_path,
+        snapshot_trigger="decision: 001-x",
+        regenerate_agents_md=True,
+    )
+
+    assert outcome.is_degraded is False
+    assert outcome.degraded == ()
+    assert outcome.warnings == ()
+    assert outcome.updated_repos == (repo,)
+    assert list((store_path / SNAPSHOTS).glob("v*.json"))
+    assert (repo / "AGENTS.md").exists()
+
+
+def test_snapshot_oserror_degrades_the_step_without_raising(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store_path, repo = _project(tmp_path)
+
+    def _boom(*_args: object, **_kwargs: object) -> int:
+        raise OSError("disk full")
+
+    monkeypatch.setattr("nauro.store.post_commit.capture_snapshot", _boom)
+
+    outcome = run_post_commit(
+        store_path,
+        snapshot_trigger="decision: 001-x",
+        regenerate_agents_md=True,
+    )
+
+    assert [d.step for d in outcome.degraded] == [AncillaryStep.SNAPSHOT]
+    assert "disk full" in outcome.degraded[0].reason
+    assert any("snapshot capture" in line for line in outcome.warnings)
+    # The next step still ran.
+    assert outcome.updated_repos == (repo,)
+    assert (repo / "AGENTS.md").exists()
+
+
+def test_non_oserror_from_regen_degrades_the_step_without_raising(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store_path, _repo = _project(tmp_path)
+
+    def _boom(*_args: object, **_kwargs: object) -> list[Path]:
+        raise ValueError("registry entry is malformed")
+
+    monkeypatch.setattr("nauro.store.post_commit.warn_then_regen", _boom)
+
+    outcome = run_post_commit(
+        store_path,
+        snapshot_trigger="decision: 001-x",
+        regenerate_agents_md=True,
+    )
+
+    assert [d.step for d in outcome.degraded] == [AncillaryStep.AGENTS_MD]
+    assert "registry entry is malformed" in outcome.degraded[0].reason
+    assert outcome.updated_repos == ()
+    # The earlier step still committed its artifact.
+    assert list((store_path / SNAPSHOTS).glob("v*.json"))
+
+
+def test_every_step_runs_when_the_earlier_ones_degrade(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store_path, _repo = _project(tmp_path)
+    pushed: list[Path] = []
+
+    def _snapshot_boom(*_args: object, **_kwargs: object) -> int:
+        raise OSError("disk full")
+
+    def _regen_boom(*_args: object, **_kwargs: object) -> list[Path]:
+        raise ValueError("registry entry is malformed")
+
+    monkeypatch.setattr("nauro.store.post_commit.capture_snapshot", _snapshot_boom)
+    monkeypatch.setattr("nauro.store.post_commit.warn_then_regen", _regen_boom)
+
+    outcome = run_post_commit(
+        store_path,
+        snapshot_trigger="decision: 001-x",
+        regenerate_agents_md=True,
+        push=pushed.append,
+    )
+
+    assert [d.step for d in outcome.degraded] == [AncillaryStep.SNAPSHOT, AncillaryStep.AGENTS_MD]
+    assert len(outcome.warnings) == 2
+    assert pushed == [store_path]
+
+
+def test_a_raising_push_degrades_the_step_without_raising(tmp_path: Path) -> None:
+    """The seam guards whatever a caller injects, not just its own two steps."""
+    store_path, repo = _project(tmp_path)
+
+    def _boom(_store_path: Path) -> None:
+        raise RuntimeError("S3 credentials expired")
+
+    outcome = run_post_commit(
+        store_path,
+        snapshot_trigger="decision: 001-x",
+        regenerate_agents_md=True,
+        push=_boom,
+    )
+
+    assert [d.step for d in outcome.degraded] == [AncillaryStep.PUSH]
+    assert "S3 credentials expired" in outcome.degraded[0].reason
+    assert any("cloud push" in line for line in outcome.warnings)
+    # The steps before it kept their artifacts.
+    assert list((store_path / SNAPSHOTS).glob("v*.json"))
+    assert outcome.updated_repos == (repo,)
+
+
+def test_warn_channel_is_threaded_into_the_regeneration(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _pid, store_path = register_project_v2("postcommitwarn", [repo])
+    scaffold_project_store("postcommitwarn", store_path)
+    warnings: list[str] = []
+
+    outcome = run_post_commit(store_path, regenerate_agents_md=True, warn=warnings.append)
+
+    assert outcome.is_degraded is False
+    assert any("repo path does not exist" in line for line in warnings)
+
+
+# ── MCP write adapters ───────────────────────────────────────────────────
+
+
+RATIONALE = "In-memory cache for the hot read paths across the API tier and pub/sub channels."
+
+
+@pytest.fixture()
+def adapter_store(tmp_path: Path) -> Path:
+    store_path = tmp_path / "projects" / "adapterproj"
+    scaffold_project_store("adapterproj", store_path)
+    return store_path
+
+
+@pytest.fixture()
+def no_push(monkeypatch: pytest.MonkeyPatch) -> list[Path]:
+    """Record the cloud push instead of attempting it."""
+    pushed: list[Path] = []
+    monkeypatch.setattr(mcp_tools, "_try_push", pushed.append)
+    return pushed
+
+
+def _raise_oserror(*_args: object, **_kwargs: object) -> int:
+    raise OSError("disk full")
+
+
+def test_degraded_snapshot_keeps_the_propose_envelope_and_the_journal_event(
+    adapter_store: Path, monkeypatch: pytest.MonkeyPatch, no_push: list[Path]
+) -> None:
+    monkeypatch.setattr("nauro.store.post_commit.capture_snapshot", _raise_oserror)
+
+    envelope = tool_propose_decision(
+        adapter_store,
+        title="Use Redis for hot caching",
+        rationale=RATIONALE,
+        confidence="medium",
+    )
+
+    assert envelope["status"] == "confirmed"
+    assert envelope["decision_id"]
+    # The journal decorator emits after the adapter returns, so an ancillary
+    # exception used to destroy the event for a decision that had committed.
+    events = read_events(adapter_store)
+    assert [e.status for e in events] == ["committed"]
+    assert events[0].decision_id == envelope["decision_id"]
+    assert no_push == [adapter_store]
+
+
+def test_a_raising_push_keeps_the_propose_envelope_and_the_journal_event(
+    adapter_store: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def _boom(_store_path: Path) -> None:
+        raise RuntimeError("S3 credentials expired")
+
+    monkeypatch.setattr(mcp_tools, "_try_push", _boom)
+
+    envelope = tool_propose_decision(
+        adapter_store,
+        title="Use Redis for hot caching",
+        rationale=RATIONALE,
+        confidence="medium",
+    )
+
+    assert envelope["status"] == "confirmed"
+    assert "cloud push failed" in envelope["assessment"]
+    assert [e.status for e in read_events(adapter_store)] == ["committed"]
+
+
+def test_degraded_regen_notes_the_step_in_the_assessment_and_still_pushes(
+    adapter_store: Path, monkeypatch: pytest.MonkeyPatch, no_push: list[Path]
+) -> None:
+    def _boom(*_args: object, **_kwargs: object) -> list[Path]:
+        raise ValueError("registry entry is malformed")
+
+    monkeypatch.setattr("nauro.store.post_commit.warn_then_regen", _boom)
+
+    envelope = tool_propose_decision(
+        adapter_store,
+        title="Use Redis for hot caching",
+        rationale=RATIONALE,
+        confidence="medium",
+    )
+
+    assert envelope["status"] == "confirmed"
+    assert "AGENTS.md regeneration failed" in envelope["assessment"]
+    assert "registry entry is malformed" in envelope["assessment"]
+    assert set(envelope) <= {
+        "store",
+        "project",
+        "status",
+        "tier",
+        "operation",
+        "assessment",
+        "decision_id",
+        "similar_decisions",
+        "resolved_questions",
+        "relocated_ids",
+        "skipped_prose_ids",
+        "error",
+    }
+    assert no_push == [adapter_store]
+
+
+def test_degraded_snapshot_keeps_the_flag_question_envelope(
+    adapter_store: Path, monkeypatch: pytest.MonkeyPatch, no_push: list[Path]
+) -> None:
+    monkeypatch.setattr("nauro.store.post_commit.capture_snapshot", _raise_oserror)
+
+    envelope = tool_flag_question(adapter_store, question="Should the cache be write-through?")
+
+    assert envelope["status"] == "ok"
+    assert [e.status for e in read_events(adapter_store)] == ["committed"]
+    assert no_push == [adapter_store]
+
+
+def test_degraded_snapshot_keeps_the_update_state_envelope(
+    adapter_store: Path, monkeypatch: pytest.MonkeyPatch, no_push: list[Path]
+) -> None:
+    monkeypatch.setattr("nauro.store.post_commit.capture_snapshot", _raise_oserror)
+
+    envelope = tool_update_state(adapter_store, delta="Shipped the caching layer.")
+
+    assert envelope["status"] == "ok"
+    assert [e.status for e in read_events(adapter_store)] == ["committed"]
+    assert no_push == [adapter_store]

--- a/packages/nauro/tests/test_propose_decision_parity.py
+++ b/packages/nauro/tests/test_propose_decision_parity.py
@@ -33,6 +33,7 @@ import pytest
 from nauro.mcp import tools as mcp_tools
 from nauro.mcp.stdio_server import propose_decision as stdio_propose_decision
 from nauro.mcp.tools import tool_propose_decision
+from nauro.store import post_commit as post_commit_module
 from nauro.templates.agents_md_regen import warn_then_regen
 from tests._writer_compat import append_decision
 from tests.conftest import register_v2_repo
@@ -47,13 +48,13 @@ def _no_push(monkeypatch):
 @pytest.fixture(autouse=True)
 def _no_regen(monkeypatch):
     """Suppress AGENTS.md regen so the parity layer stays local."""
-    monkeypatch.setattr(mcp_tools, "warn_then_regen", lambda *args, **kwargs: [])
+    monkeypatch.setattr(post_commit_module, "warn_then_regen", lambda *args, **kwargs: [])
 
 
 @pytest.fixture(autouse=True)
 def _no_snapshot(monkeypatch):
     """Suppress snapshot capture so the parity layer doesn't touch snapshots/."""
-    monkeypatch.setattr(mcp_tools, "capture_snapshot", lambda *args, **kwargs: None)
+    monkeypatch.setattr(post_commit_module, "capture_snapshot", lambda *args, **kwargs: None)
 
 
 @pytest.fixture
@@ -332,7 +333,7 @@ def test_snapshot_runs_only_on_confirmed(seeded_repo, monkeypatch):
     def _capture(*args, **kwargs):
         snapshots_called.append((args, kwargs))
 
-    monkeypatch.setattr(mcp_tools, "capture_snapshot", _capture)
+    monkeypatch.setattr(post_commit_module, "capture_snapshot", _capture)
 
     # Tier 1 reject — no snapshot.
     tool_propose_decision(
@@ -362,7 +363,7 @@ def test_regen_runs_only_on_confirmed(seeded_repo, monkeypatch):
         return []
 
     # Test-local override takes precedence over the autouse fixture's stub.
-    monkeypatch.setattr(mcp_tools, "warn_then_regen", _regen)
+    monkeypatch.setattr(post_commit_module, "warn_then_regen", _regen)
 
     # Tier 1 reject — no regen.
     tool_propose_decision(
@@ -395,7 +396,7 @@ def test_confirmed_regen_surfaces_tracked_agents_warning(seeded_repo, monkeypatc
     warn_then_regen(store_path.name, store_path)
     assert (repo / "AGENTS.md").is_file()
     subprocess.run(["git", "add", "AGENTS.md"], cwd=repo, check=True)
-    monkeypatch.setattr(mcp_tools, "warn_then_regen", warn_then_regen)
+    monkeypatch.setattr(post_commit_module, "warn_then_regen", warn_then_regen)
 
     envelope = tool_propose_decision(
         store_path,
@@ -414,7 +415,7 @@ def test_confirmed_regen_preserves_unmanaged_agents_md(seeded_repo, monkeypatch)
     repo = Path.cwd()
     sentinel = b"# Hand-written agent rules\n\nKeep these instructions.\n"
     (repo / "AGENTS.md").write_bytes(sentinel)
-    monkeypatch.setattr(mcp_tools, "warn_then_regen", warn_then_regen)
+    monkeypatch.setattr(post_commit_module, "warn_then_regen", warn_then_regen)
 
     envelope = tool_propose_decision(
         store_path,

--- a/packages/nauro/tests/test_questions_migrate.py
+++ b/packages/nauro/tests/test_questions_migrate.py
@@ -131,3 +131,20 @@ def test_migrate_unknown_project_rejected(tmp_path: Path, monkeypatch):
     result = runner.invoke(app, ["questions", "migrate", "--project", "nope"])
     assert result.exit_code == 1
     assert "Unknown project 'nope'." in result.output
+
+
+def test_migrate_survives_a_failing_agents_md_regen(tmp_path: Path, monkeypatch):
+    """The renumbered file is written and reported even when the regen fails."""
+    store = _setup_project(tmp_path, monkeypatch, _LEGACY_FILE)
+
+    def _boom(*_args, **_kwargs):
+        raise OSError("AGENTS.md is not writable")
+
+    monkeypatch.setattr("nauro.store.post_commit.warn_then_regen", _boom)
+
+    result = runner.invoke(app, ["questions", "migrate"])
+
+    assert result.exit_code == 0, result.output
+    assert "Migrated 2 entry(ies)" in result.stdout
+    assert "AGENTS.md regeneration failed" in result.stderr
+    assert "[Q1]" in (store / OPEN_QUESTIONS_MD).read_text()

--- a/packages/nauro/tests/test_sync/test_sync_command.py
+++ b/packages/nauro/tests/test_sync/test_sync_command.py
@@ -58,6 +58,25 @@ class TestSyncPullBeforePush:
         assert "Pulling from remote" not in result.output
 
 
+class TestSyncSnapshotIsPrimaryWork:
+    """The snapshot is sync's own work, so a failure there is a real failure.
+
+    The post-commit seam makes an ancillary snapshot or regen fail open on the
+    write commands; sync sits outside that boundary and must stay hard-fail.
+    """
+
+    def test_snapshot_failure_exits_nonzero(self, project_store, monkeypatch):
+        def _boom(*_args, **_kwargs):
+            raise OSError("disk full")
+
+        monkeypatch.setattr("nauro.cli.commands.sync.capture_snapshot", _boom)
+
+        result = runner.invoke(app, ["sync"])
+
+        assert result.exit_code == 1
+        assert "local-only project; nothing to upload" not in result.output
+
+
 class TestSyncPullNoConfig:
     """Verify pull is a no-op when S3 is not configured."""
 

--- a/packages/nauro/tests/test_write_command_autogen.py
+++ b/packages/nauro/tests/test_write_command_autogen.py
@@ -32,6 +32,7 @@ from typer.testing import CliRunner
 
 from nauro.cli.main import app
 from nauro.mcp import tools as mcp_tools
+from nauro.store import post_commit as post_commit_module
 from tests._ansi import strip_ansi
 from tests._writer_compat import append_decision
 from tests.conftest import register_v2_repo
@@ -48,13 +49,13 @@ def _no_push(monkeypatch):
 @pytest.fixture(autouse=True)
 def _no_regen(monkeypatch):
     """Suppress AGENTS.md regen so the CLI layer stays local."""
-    monkeypatch.setattr(mcp_tools, "warn_then_regen", lambda *args, **kwargs: [])
+    monkeypatch.setattr(post_commit_module, "warn_then_regen", lambda *args, **kwargs: [])
 
 
 @pytest.fixture(autouse=True)
 def _no_snapshot(monkeypatch):
     """Suppress snapshot capture so the CLI layer doesn't touch snapshots/."""
-    monkeypatch.setattr(mcp_tools, "capture_snapshot", lambda *args, **kwargs: None)
+    monkeypatch.setattr(post_commit_module, "capture_snapshot", lambda *args, **kwargs: None)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Why

Once a judgment write has committed to the local store, everything derived from it — the
snapshot, the regenerated AGENTS.md, the cloud push — is ancillary. A failure in one of those
should never be reported to the user as a failure of the write that already landed. That was
already the posture for the cloud push, for journal emission, and for the hosted snapshot
capture. The local snapshot capture and AGENTS.md regeneration were the outliers: bare calls
whose filesystem errors propagated straight out of `nauro repair`, `nauro note`,
`nauro questions migrate`, `nauro import`, and all four MCP write adapters.

On the CLI the damage was cosmetic but contradictory: the terminal printed the success line and
the process then exited 1. On `import` it was worse — the capture ran before the summary, so a
committed merge reported nothing at all and invited a second run.

The MCP path was the expensive one. The journal decorator emits its provenance event after the
adapter returns, so an ancillary exception destroyed the event for a decision that had already
committed, and the calling agent got a tool error instead of an envelope. An agent that retried
verbatim was caught by content-hash dedup; an agent that retried with a reworded title passed
Tier 1 and committed a duplicate the user never approved. A transient disk error could
therefore produce store corruption.

## What changed

A new `nauro/store/post_commit.py` owns the posture in one place. `run_post_commit` executes the
ancillary steps for a committed write and returns a typed outcome naming which step degraded and
why — no sentinel strings, no bare bools. It catches `Exception` rather than `OSError` alone,
because the existing fail-soft regeneration path narrowed to `OSError` and drifted from the
promise its own docstring made. One step degrading never skips the next.

Call sites migrated: `repair`, `note`, `questions migrate`, `import`, and the five MCP adapter
sites. The CLI prints the degraded step on stderr and exits 0. The MCP adapters keep their
success envelope and append the note to the existing `assessment` text on `propose_decision`;
`flag_question` and `update_state` have no assessment channel, so a degraded step there is
logged and not surfaced. The pinned envelope shape is unchanged either way, and the frozen
public contract snapshot is untouched. The cloud push now runs even when an earlier step
degraded, where before a regen failure skipped it entirely, and it runs inside the same guard
as the other two steps: `_try_push` keeps its own fail-open behaviour, but the seam does not
depend on it, so a future caller injecting a raising push cannot break a committed write.

`import` also moves its snapshot capture below the success summary, so a committed merge always
reports itself.

`nauro sync` and the setup wiring paths are deliberately not migrated: there the snapshot or the
regeneration *is* the command's primary work, not a tail on a judgment write, so a failure stays
a failure and exits nonzero. A test pins that boundary.

## Test plan

`uv run pytest packages/nauro/tests/` — 2251 passed, 10 skipped.
`uv run pytest packages/nauro-core/tests/` — 1222 passed.
`ruff check packages/` and `ruff format --check packages/` — clean.

New coverage:
- The seam in isolation: clean run, `OSError` from the capture, a non-`OSError` from the regen,
  a raising push callable recording a degraded push step, and the ordering guarantee that every
  later step still runs.
- CLI failure injection on `repair` (both steps), `note`, `questions migrate`, and `import`
  (both `--memory-bank` and `--adr`): exit 0, the success line on stdout, the named degraded
  step on stderr, and the store change on disk.
- MCP adapters: a degraded capture leaves the confirmed envelope *and* the committed journal
  event intact (the regression that motivated this); a degraded regen leaves the envelope
  confirmed with the note in `assessment` and the push still fired; a raising push leaves the
  envelope confirmed with the journal event intact; `flag_question` and `update_state` keep
  their success envelopes.
- A boundary pin so a later refactor cannot quietly extend the seam to `nauro sync`.

## Risk / what to review

The envelope shape is the thing to check: on `propose_decision` the degraded note rides the
existing `assessment` string rather than a new field, and `tests/snapshots/public_contract_v1.json`
is unchanged. On `update_state` the kernel's `warning` field was deliberately left alone — it is
the kernel's keyword-overlap advisory, and adapter text in it would repurpose a pinned field's
meaning; there is a comment at that site so the silence does not read as an oversight. Two
existing test modules had their monkeypatch targets repointed from `nauro.mcp.tools` to
`nauro.store.post_commit` because the adapters no longer import those symbols directly — worth a
glance that the suppression they provide still covers what it did before.
