### PR TITLE
Add shared identifier validators and the stack document cap

### DIFF
--- a/packages/nauro-core/src/nauro_core/constants.py
+++ b/packages/nauro-core/src/nauro_core/constants.py
@@ -159,6 +159,14 @@ MAX_APPROACH_LENGTH = 5_000
 # briefs run ~11-21 KB; 50 KiB leaves headroom without inviting storage bombs.
 MAX_BRIEF_BYTES = 50 * 1024
 
+# ── stack.md document cap (write path) ──
+# Ceiling on a complete stack.md document submitted through the typed stack
+# update operation. The value deliberately equals RAW_FILE_CHAR_BUDGET below,
+# the complete ordinary-file read ceiling, so every accepted document can be
+# returned whole by one authorized get_raw_file("stack.md") call. Moving
+# either value without the other breaks that guarantee.
+STACK_DOC_CHAR_LIMIT = 40_000
+
 # ── Bounded rendered reads (renderer channel only) ──
 # Character caps on the rendered agent-facing read surface: the stdio MCP
 # content[0] block and the CLI's --format text mode, applied inside

--- a/packages/nauro-core/src/nauro_core/identifiers.py
+++ b/packages/nauro-core/src/nauro_core/identifiers.py
@@ -1,0 +1,97 @@
+"""Shared shape validators for identifiers that cross the local/hosted seam.
+
+The provenance ruling requires one definition of every new identifier shape,
+used by local and hosted parsing alike, so journal targets, receipts,
+projection rows, and audit records cannot drift apart and every encoded
+identifier has a predictable maximum size. The alphabet-only local project-ID
+check is deliberately not reused here.
+
+The kinds:
+
+- ``ulid`` - server-generated identifiers (proposal, question event, report
+  event, audit event, receipt, generation, invitation): 26-character
+  uppercase Crockford ULIDs.
+- ``operation_id`` - client-supplied operation identifiers: 1 to 128
+  printable ASCII characters.
+- ``server_token`` - closed server-owned tokens (operation kinds, audit
+  actions, target kinds, system reasons, execution modes, transition
+  values): a lowercase letter followed by lowercase letters, digits,
+  or underscores, at most 64 characters.
+- ``audit_target_id`` - stable opaque audit target identifiers: 1 to 128
+  printable ASCII characters, never an alias or free text.
+
+Matching is always whole-value, so a trailing newline never passes.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+
+
+class IdentifierKind(str, Enum):
+    ulid = "ulid"
+    operation_id = "operation_id"
+    server_token = "server_token"
+    audit_target_id = "audit_target_id"
+
+
+@dataclass(frozen=True)
+class _Shape:
+    pattern: re.Pattern[str]
+    description: str
+
+
+_PRINTABLE_ASCII = _Shape(
+    re.compile(r"[\x20-\x7e]{1,128}"),
+    "1 to 128 printable ASCII characters",
+)
+
+_SHAPES: dict[IdentifierKind, _Shape] = {
+    IdentifierKind.ulid: _Shape(
+        re.compile(r"[0-7][0-9A-HJKMNP-TV-Z]{25}"),
+        "a 26-character uppercase Crockford ULID",
+    ),
+    IdentifierKind.operation_id: _PRINTABLE_ASCII,
+    IdentifierKind.server_token: _Shape(
+        re.compile(r"[a-z][a-z0-9_]{0,63}"),
+        "a lowercase server-owned token of at most 64 characters, starting with a letter",
+    ),
+    IdentifierKind.audit_target_id: _PRINTABLE_ASCII,
+}
+
+
+class InvalidIdentifier(ValueError):
+    """A value does not match the shape its identifier kind requires.
+
+    The message names the field and the observed length but never the
+    rejected value: rejected identifiers can carry caller-supplied content.
+    """
+
+    def __init__(self, kind: IdentifierKind, field: str, observed_length: int | None) -> None:
+        self.kind = kind
+        self.field = field
+        self.observed_length = observed_length
+        observed = (
+            "a non-string value"
+            if observed_length is None
+            else f"a {observed_length}-character value"
+        )
+        super().__init__(f"{field} must be {_SHAPES[kind].description}; got {observed}.")
+
+
+def is_identifier(kind: IdentifierKind, value: object) -> bool:
+    """Report whether *value* is a string matching *kind*'s shape."""
+    if not isinstance(value, str):
+        return False
+    return _SHAPES[kind].pattern.fullmatch(value) is not None
+
+
+def validate_identifier(kind: IdentifierKind, value: object, *, field: str) -> str:
+    """Return *value* when it matches *kind*, else raise ``InvalidIdentifier``."""
+    if isinstance(value, str):
+        if is_identifier(kind, value):
+            return value
+        raise InvalidIdentifier(kind, field, len(value))
+    raise InvalidIdentifier(kind, field, None)

--- a/packages/nauro-core/tests/test_constants.py
+++ b/packages/nauro-core/tests/test_constants.py
@@ -15,8 +15,10 @@ from nauro_core.constants import (
     OPEN_QUESTIONS_MD,
     POINTER_FLAG_PREFIXES,
     PROJECT_MD,
+    RAW_FILE_CHAR_BUDGET,
     REVERSIBILITY_LEVELS,
     SNAPSHOTS_DIR,
+    STACK_DOC_CHAR_LIMIT,
     STACK_MD,
     STATE_MD,
     VALID_CONFIDENCES,
@@ -70,6 +72,15 @@ class TestSizeLimits:
         warn-and-skip gate and the nauro-context skill prose both reference
         this single value, so a careless change must trip a test."""
         assert MAX_BRIEF_BYTES == 50 * 1024
+
+    def test_stack_doc_char_limit_is_40k(self):
+        assert STACK_DOC_CHAR_LIMIT == 40_000
+
+    def test_stack_doc_cap_matches_raw_file_read_ceiling(self):
+        """The stack write cap is tied to the complete raw-file read ceiling so
+        every accepted stack.md can be returned whole by one get_raw_file call.
+        Moving either value forces a conscious look at the other."""
+        assert STACK_DOC_CHAR_LIMIT == RAW_FILE_CHAR_BUDGET
 
 
 class TestValidValues:

--- a/packages/nauro-core/tests/test_identifiers.py
+++ b/packages/nauro-core/tests/test_identifiers.py
@@ -1,0 +1,189 @@
+"""Tests for nauro_core.identifiers - the shared identifier validators."""
+
+from __future__ import annotations
+
+import pytest
+
+from nauro_core.identifiers import (
+    IdentifierKind,
+    InvalidIdentifier,
+    is_identifier,
+    validate_identifier,
+)
+
+VALID_ULID = "01KQ6AZGNA0B3QBF67NBXP3S45"
+ULID_BODY = VALID_ULID[1:]
+
+VALID_BY_KIND = {
+    IdentifierKind.ulid: VALID_ULID,
+    IdentifierKind.operation_id: "op-1",
+    IdentifierKind.server_token: "update_stack",
+    IdentifierKind.audit_target_id: "target-1",
+}
+
+
+class TestUlid:
+    @pytest.mark.parametrize(
+        "value",
+        [
+            VALID_ULID,
+            "0" + ULID_BODY,
+            "7" + ULID_BODY,
+            "0" + "0" * 25,
+            "7ZZZZZZZZZZZZZZZZZZZZZZZZZ",
+        ],
+    )
+    def test_accepts(self, value: str) -> None:
+        assert is_identifier(IdentifierKind.ulid, value)
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            VALID_ULID.lower(),
+            "8" + ULID_BODY,
+            "9" + ULID_BODY,
+            "A" + ULID_BODY,
+            "0I" + ULID_BODY[1:],
+            "0L" + ULID_BODY[1:],
+            "0O" + ULID_BODY[1:],
+            "0U" + ULID_BODY[1:],
+            VALID_ULID[:25],
+            VALID_ULID + "Z",
+            "",
+        ],
+    )
+    def test_rejects(self, value: str) -> None:
+        assert not is_identifier(IdentifierKind.ulid, value)
+
+    @pytest.mark.parametrize("value", [None, 1, b"01KQ6AZGNA0B3QBF67NBXP3S45", ["x"]])
+    def test_rejects_non_str(self, value: object) -> None:
+        assert not is_identifier(IdentifierKind.ulid, value)
+
+
+class TestPrintableAsciiKinds:
+    """operation_id and audit_target_id share the 1 to 128 printable ASCII shape."""
+
+    KINDS = [IdentifierKind.operation_id, IdentifierKind.audit_target_id]
+
+    @pytest.mark.parametrize("kind", KINDS)
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "x",
+            "x" * 128,
+            " ",
+            "~",
+            "01KQ6AZGNA0B3QBF67NBXP3S45",
+            "a b~c/d.e",
+        ],
+    )
+    def test_accepts(self, kind: IdentifierKind, value: str) -> None:
+        assert is_identifier(kind, value)
+
+    @pytest.mark.parametrize("kind", KINDS)
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "",
+            "x" * 129,
+            "a\tb",
+            "a\nb",
+            "a\x7fb",
+            "\x7f",
+            "café",
+            "é",
+        ],
+    )
+    def test_rejects(self, kind: IdentifierKind, value: str) -> None:
+        assert not is_identifier(kind, value)
+
+    @pytest.mark.parametrize("kind", KINDS)
+    def test_rejects_non_str(self, kind: IdentifierKind) -> None:
+        assert not is_identifier(kind, None)
+
+
+class TestServerToken:
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "a",
+            "a" * 64,
+            "update_stack",
+            "stack_",
+            "sha256_v2",
+            "a1",
+        ],
+    )
+    def test_accepts(self, value: str) -> None:
+        assert is_identifier(IdentifierKind.server_token, value)
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "1stack",
+            "_stack",
+            "Stack",
+            "update_Stack",
+            "update-stack",
+            "a" * 65,
+            "",
+            "update stack",
+        ],
+    )
+    def test_rejects(self, value: str) -> None:
+        assert not is_identifier(IdentifierKind.server_token, value)
+
+    def test_rejects_non_str(self) -> None:
+        assert not is_identifier(IdentifierKind.server_token, None)
+
+
+class TestTrailingNewline:
+    """Every kind matches whole values: a trailing newline never slips through."""
+
+    @pytest.mark.parametrize("kind", list(IdentifierKind))
+    def test_trailing_newline_rejects(self, kind: IdentifierKind) -> None:
+        assert is_identifier(kind, VALID_BY_KIND[kind])
+        assert not is_identifier(kind, VALID_BY_KIND[kind] + "\n")
+
+
+class TestValidateIdentifier:
+    @pytest.mark.parametrize("kind", list(IdentifierKind))
+    def test_returns_the_value_unchanged(self, kind: IdentifierKind) -> None:
+        value = VALID_BY_KIND[kind]
+        assert validate_identifier(kind, value, field="target_id") == value
+
+    def test_raises_value_error_subclass(self) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            validate_identifier(IdentifierKind.ulid, "nope", field="event_id")
+        assert isinstance(excinfo.value, InvalidIdentifier)
+
+    def test_error_exposes_kind_field_and_length(self) -> None:
+        with pytest.raises(InvalidIdentifier) as excinfo:
+            validate_identifier(IdentifierKind.server_token, "Stack", field="operation_kind")
+        error = excinfo.value
+        assert error.kind is IdentifierKind.server_token
+        assert error.field == "operation_kind"
+        assert error.observed_length == 5
+
+    def test_error_on_non_str_reports_no_length(self) -> None:
+        with pytest.raises(InvalidIdentifier) as excinfo:
+            validate_identifier(IdentifierKind.ulid, None, field="event_id")
+        assert excinfo.value.observed_length is None
+
+    @pytest.mark.parametrize(
+        "kind, value",
+        [
+            (IdentifierKind.ulid, "0iiiiSECRETiiii"),
+            (IdentifierKind.operation_id, "SECRET\n"),
+            (IdentifierKind.server_token, "SECRET"),
+            (IdentifierKind.audit_target_id, "SECRET\t"),
+        ],
+    )
+    def test_message_never_echoes_the_rejected_value(
+        self, kind: IdentifierKind, value: str
+    ) -> None:
+        with pytest.raises(InvalidIdentifier) as excinfo:
+            validate_identifier(kind, value, field="secret_field")
+        message = str(excinfo.value)
+        assert "SECRET" not in message
+        assert "secret_field" in message


### PR DESCRIPTION
## Why

Two pieces of already-ratified groundwork that later teams work builds on, landed
ahead of any call sites so the shapes are fixed before anything depends on them.

The provenance ruling mandates one shared validator for every new cross-surface
identifier: server-generated ULIDs, client-supplied operation ids, closed
server-owned tokens, and audit target ids. Local and hosted parsing have to agree
on those shapes, or journal targets, receipts, projection rows, and audit records
drift and encoded sizes stop being predictable. The ruling also says the
alphabet-only local project-id check is not the thing to reuse, so this is a new
module rather than an extension of the existing identity helper.

The stack-curation ruling caps a submitted stack.md at 40,000 characters, chosen
to equal the complete raw-file read ceiling so any accepted document can be
returned whole by one authorized read. That tie is the whole point of the number,
and it is easy to break by moving one value and not the other.

## What changed

A new `nauro_core.identifiers` module, pure and stdlib-only: `IdentifierKind`,
`is_identifier`, `validate_identifier`, and a typed `InvalidIdentifier` (a
`ValueError` subclass) that exposes the kind, the field name, and the observed
length. Error messages name the field and the length but never echo the rejected
value, matching the existing validation convention, since a rejected identifier
can carry caller-supplied content. Matching is always whole-value, so a trailing
newline cannot slip past a shape.

`STACK_DOC_CHAR_LIMIT` joins the content and write limits in constants, with a
comment recording that its equality with the raw-file read ceiling is deliberate.

No call sites are wired yet, and the curated public import surface is unchanged:
consumers reach the validators through the submodule.

## Test plan

`pytest packages/nauro-core/tests/` (1304 passed) and `pytest packages/nauro/tests/`
(2251 passed, 10 skipped). `ruff check` and `ruff format --check` clean across
packages. The nauro-core import-linter contracts both pass, and the kernel purity
guard covers the new module automatically.

New coverage is table-driven per kind: ULID acceptance and the Crockford
exclusions, both printable-ASCII bounds including the exact 1 and 128 edges plus
tab, newline, DEL and non-ASCII rejection, the token grammar including the 64 and
65 character boundary, a trailing-newline guard across all four kinds, and error
typing including the no-echo rule. Two constants tests pin the cap and the tie to
the read ceiling, so moving either value forces a conscious choice.

## Risk / what to review

The frozen public contract snapshot is untouched and `test_public_contract` stays
green, which is the intended outcome for a submodule-only addition. Worth a look:
the four patterns against the filed shapes, and that `fullmatch` (not `match`
with an anchor) is used everywhere.
