### PR TITLE
Release nauro 1.13.0 and nauro-core 1.8.0

### DIFF
--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro-core"
-version = "1.7.0"
+version = "1.8.0"
 description = "Shared pure-Python logic for Nauro: parsing, validation, context assembly, constants."
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro"
-version = "1.12.0"
+version = "1.13.0"
 description = "Human-approved project judgment and current state for connected AI agents, surfaced before work."
 readme = "README.md"
 license = "Apache-2.0"
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "nauro-core>=1.7.0,<2",
+    "nauro-core>=1.8.0,<2",
     "typer>=0.9",
     "httpx>=0.24",
     "mcp>=1.0",

--- a/server.json
+++ b/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Nauro-AI/nauro",
     "source": "github"
   },
-  "version": "1.12.0",
+  "version": "1.13.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "nauro",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -928,7 +928,7 @@ wheels = [
 
 [[package]]
 name = "nauro"
-version = "1.12.0"
+version = "1.13.0"
 source = { editable = "packages/nauro" }
 dependencies = [
     { name = "filelock" },
@@ -970,7 +970,7 @@ provides-extras = ["dev", "embeddings"]
 
 [[package]]
 name = "nauro-core"
-version = "1.7.0"
+version = "1.8.0"
 source = { editable = "packages/nauro-core" }
 dependencies = [
     { name = "bm25s" },


### PR DESCRIPTION
## Version moves

- **nauro** 1.12.0 → 1.13.0 (minor)
- **nauro-core** 1.7.0 → 1.8.0 (minor)
- nauro's dependency floor rises to `nauro-core>=1.8.0,<2` per the release convention.
- `server.json` follows the nauro package to 1.13.0; `uv.lock` re-locked.

## What ships

**nauro-core 1.8.0** (additive; curated public API unchanged, zero contract-snapshot delta)
- New `nauro_core.identifiers` module: shared validators for the cross-surface identifier shapes (server ULIDs, client operation ids, closed server tokens, audit target ids), whole-value matching, typed errors that never echo the rejected value. Submodule-only; consumed by the hosted server.
- `STACK_DOC_CHAR_LIMIT` constant with a test-pinned equality to the raw-file read ceiling.

**nauro 1.13.0**
- Post-commit steps are fail-open: once a write commits, a failure in the derived snapshot capture, AGENTS.md regeneration, or cloud push is reported as a degraded step and never converts a successful write into a failure. Fixes a path where an ancillary error after a committed decision destroyed its journal event and could steer a retrying agent into an unapproved duplicate. `nauro sync` and setup keep hard-fail semantics.
- `nauro import` reports its summary before ancillary work, so a committed import always announces itself.
- Root command-table documentation sync.

## Checks

- `check_server_json_version.py` and `check_single_sourced.py` pass locally
- `uv lock --check` clean; `uv sync --locked` passes for both packages on 3.12
- Full suites green on the merged feature PRs (nauro-core 1304; nauro 2251 passed, 10 skipped)

## Post-merge

Tag the squash commit `nauro-core-v1.8.0` and `nauro-v1.13.0` and push both tags to trigger the trusted-publish workflows (PyPI both; MCP registry from the nauro tag), then create the GitHub Releases and sync the claude-plugins lockstep pin.
