### PR TITLE
Export normalize_title and the hosted store format version

### DIFF
--- a/packages/nauro-core/src/nauro_core/__init__.py
+++ b/packages/nauro-core/src/nauro_core/__init__.py
@@ -16,6 +16,9 @@ from nauro_core.constants import (
     DECISIONS_DIR as DECISIONS_DIR,
 )
 from nauro_core.constants import (
+    HOSTED_STORE_FORMAT_VERSION as HOSTED_STORE_FORMAT_VERSION,
+)
+from nauro_core.constants import (
     L0_DECISIONS_SUMMARY_LIMIT as L0_DECISIONS_SUMMARY_LIMIT,
 )
 from nauro_core.constants import (
@@ -322,6 +325,9 @@ from nauro_core.validation import (
     is_scaffold_seed as is_scaffold_seed,
 )
 from nauro_core.validation import (
+    normalize_title as normalize_title,
+)
+from nauro_core.validation import (
     screen_structural as screen_structural,
 )
 
@@ -351,8 +357,9 @@ __all__ = [
     "build_l0",
     "build_l1",
     "build_l2",
-    # Hashing.
+    # Hashing and title normalization for dedup.
     "compute_hash",
+    "normalize_title",
     # MCP tool contract, remote instructions, and snapshot serialization.
     "ALL_TOOLS",
     "build_remote_instructions",
@@ -377,6 +384,7 @@ __all__ = [
     "MIN_RATIONALE_LENGTH",
     # Store-format constants.
     "SNAPSHOT_SCHEMA_VERSION",
+    "HOSTED_STORE_FORMAT_VERSION",
     "DECISIONS_DIR",
     "SNAPSHOTS_DIR",
     "DECISION_HASHES_FILE",

--- a/packages/nauro-core/src/nauro_core/constants.py
+++ b/packages/nauro-core/src/nauro_core/constants.py
@@ -38,6 +38,13 @@ DECISION_HASHES_FILE = ".decision-hashes.json"
 SNAPSHOT_SCHEMA_VERSION = 1
 LEGACY_SCHEMA_VERSION = 0
 
+# ── Hosted store format versioning ──
+# Versions the hosted store format contract, stamped as the
+# store_format_version field of the hosted generation pointer. Distinct from
+# SNAPSHOT_SCHEMA_VERSION, which versions the snapshot JSON shape: the two
+# must be able to move independently, so neither may stand in for the other.
+HOSTED_STORE_FORMAT_VERSION = 1
+
 # ── Token heuristic ──
 CHARS_PER_TOKEN = 4  # rough chars-per-token for GPT/Claude family models
 

--- a/packages/nauro-core/src/nauro_core/validation.py
+++ b/packages/nauro-core/src/nauro_core/validation.py
@@ -124,7 +124,7 @@ def compute_hash(title: str, rationale: str) -> str:
     return hashlib.sha256(content.encode()).hexdigest()
 
 
-def _normalize_title(title: str) -> str:
+def normalize_title(title: str) -> str:
     """Collapse whitespace and lowercase for title comparison."""
     return " ".join(title.lower().split())
 
@@ -236,7 +236,7 @@ def screen_structural(
     # supersede target). Entries may be either Decision objects or lightweight
     # dicts (the mcp-server tier-1 path loads just title+num from S3 without
     # full parsing). Handle both shapes.
-    title_normalized = _normalize_title(title)
+    title_normalized = normalize_title(title)
     for d in active_decisions:
         if hasattr(d, "title"):
             existing_title = d.title
@@ -244,7 +244,7 @@ def screen_structural(
         else:
             existing_title = d.get("title", "")
             existing_num = d.get("num", "?")
-        if _normalize_title(existing_title) == title_normalized:
+        if normalize_title(existing_title) == title_normalized:
             return (
                 "reject",
                 f"An active decision already has this title: D{existing_num}. "

--- a/packages/nauro-core/tests/test_constants.py
+++ b/packages/nauro-core/tests/test_constants.py
@@ -4,6 +4,7 @@ from nauro_core import DECISION_TYPES
 from nauro_core.constants import (
     DECISION_HASHES_FILE,
     DECISIONS_DIR,
+    HOSTED_STORE_FORMAT_VERSION,
     L0_DECISIONS_SUMMARY_LIMIT,
     L0_QUESTIONS_LIMIT,
     L1_DECISIONS_LIMIT,
@@ -81,6 +82,17 @@ class TestSizeLimits:
         every accepted stack.md can be returned whole by one get_raw_file call.
         Moving either value forces a conscious look at the other."""
         assert STACK_DOC_CHAR_LIMIT == RAW_FILE_CHAR_BUDGET
+
+
+class TestHostedStoreFormatVersion:
+    def test_current_version_is_one(self):
+        assert HOSTED_STORE_FORMAT_VERSION == 1
+
+    def test_exported_from_top_level(self):
+        import nauro_core
+
+        assert nauro_core.HOSTED_STORE_FORMAT_VERSION == HOSTED_STORE_FORMAT_VERSION
+        assert "HOSTED_STORE_FORMAT_VERSION" in nauro_core.__all__
 
 
 class TestValidValues:

--- a/packages/nauro-core/tests/test_validation.py
+++ b/packages/nauro-core/tests/test_validation.py
@@ -15,6 +15,7 @@ from nauro_core.validation import (
     compute_hash,
     envelope_token_message,
     find_envelope_token,
+    normalize_title,
     screen_structural,
 )
 
@@ -44,6 +45,32 @@ class TestComputeHash:
         h = compute_hash("Title", "Rationale")
         assert isinstance(h, str)
         assert len(h) == 64  # SHA-256 hex
+
+
+class TestNormalizeTitle:
+    def test_lowercases(self):
+        assert normalize_title("Use FastAPI") == "use fastapi"
+
+    def test_collapses_and_strips_whitespace(self):
+        # split() collapses runs of any whitespace (tabs, newlines) and
+        # drops leading/trailing whitespace entirely.
+        assert normalize_title("  Use\t FastAPI \n now ") == "use fastapi now"
+
+    def test_normalized_titles_compare_equal(self):
+        assert normalize_title("Use  FastAPI") == normalize_title("use fastapi")
+
+    def test_importable_from_top_level(self):
+        import nauro_core
+
+        assert nauro_core.normalize_title is normalize_title
+        assert "normalize_title" in nauro_core.__all__
+
+    def test_private_name_is_gone(self):
+        """The public name is a true rename, not an alias: a restored private
+        implementation with a public wrapper would let the two drift apart."""
+        from nauro_core import validation
+
+        assert not hasattr(validation, "_normalize_title")
 
 
 class TestCheckBm25Similarity:

--- a/packages/nauro/tests/snapshots/public_contract_v1.json
+++ b/packages/nauro/tests/snapshots/public_contract_v1.json
@@ -1688,6 +1688,7 @@
     "DECISION_HASHES_FILE",
     "DECISION_TYPES",
     "GET_DECISION_BEFORE_PROPOSING",
+    "HOSTED_STORE_FORMAT_VERSION",
     "MAX_APPROACH_LENGTH",
     "MAX_BRIEF_BYTES",
     "MAX_CONTEXT_LENGTH",
@@ -1717,6 +1718,7 @@
     "extract_decision_number",
     "extract_stack_summary",
     "format_decision",
+    "normalize_title",
     "parse_decision",
     "sanitize_sub",
     "serialize_snapshot"


### PR DESCRIPTION
## Why

The hosted server needs the kernel's title normalization for active-title dedup rather than reimplementing it; a server-side copy could drift, letting the same proposal pass on one surface and reject on the other. Separately, the hosted generation pointer stamps a `store_format_version` field, and that value needs one canonical source shared by the writer and every reader. Both belong in nauro-core's public API. This ships in the next nauro-core release, and the server's dependency floor bump follows that release.

## What changed

- `validation.py`: the private `_normalize_title` becomes public `normalize_title`. It is a rename, not an alias, and behavior is unchanged.
- `constants.py`: `HOSTED_STORE_FORMAT_VERSION = 1`, the canonical value for the hosted generation pointer's `store_format_version` field. Deliberately distinct from `SNAPSHOT_SCHEMA_VERSION`: the two version different contracts and must move independently.
- `__init__.py`: both names exported through the top-level API and added to `__all__`.
- The frozen public-contract snapshot in the nauro package is regenerated; the diff is exactly the two additive entries.

## Test plan

- New tests pin `normalize_title` behavior (lowercasing, whitespace collapse and strip), the constant's value, both top-level exports including `__all__` membership, and the absence of the old private name; written failing first.
- Full suites green: nauro-core 1311 passed, nauro 2251 passed / 10 skipped; `ruff check` and `ruff format --check` clean.

## Risk / what to review

The public-contract snapshot is a surface frozen at 1.0, so confirm the regenerated diff is purely additive (it adds only the two new names). No version bumps here; the release flow owns those.
