### PR TITLE
Release nauro-core 1.9.0

### DIFF
--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro-core"
-version = "1.8.0"
+version = "1.9.0"
 description = "Shared pure-Python logic for Nauro: parsing, validation, context assembly, constants."
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -970,7 +970,7 @@ provides-extras = ["dev", "embeddings"]
 
 [[package]]
 name = "nauro-core"
-version = "1.8.0"
+version = "1.9.0"
 source = { editable = "packages/nauro-core" }
 dependencies = [
     { name = "bm25s" },


### PR DESCRIPTION
## What ships

nauro-core 1.8.0 -> 1.9.0. This carries the public `normalize_title` export and the `HOSTED_STORE_FORMAT_VERSION` constant merged in #409, both additive to the curated public API. The nauro package and server.json are untouched; no nauro release ships from this PR.

## Checks

- `check_single_sourced.py`: clean
- `uv lock --check`: lock current with the bumped version
- `uv sync --locked` for both packages on 3.12: pass

## Post-merge steps

Tag the squash commit `nauro-core-v1.9.0` (annotated) and push it to trigger the trusted-publish workflow, then create the GitHub Release. Only the nauro-core tag is pushed; the MCP registry is not involved in a core-only release.
