### PR TITLE
Add plan-returning stack and shared-context kernel operations

### DIFF
--- a/packages/nauro-core/src/nauro_core/constants.py
+++ b/packages/nauro-core/src/nauro_core/constants.py
@@ -119,8 +119,23 @@ REVERSIBILITY_LEVELS: tuple[str, ...] = ("easy", "moderate", "hard")
 # Entries in open-questions.md whose body starts with one of these prefixes
 # are discovery breadcrumbs (BRIEF for shared context briefs, RESUME for
 # agent resume briefs, SELECT for /nauro-loop candidate-set checkpoints),
-# not questions for human review.
-POINTER_FLAG_PREFIXES: tuple[str, ...] = ("BRIEF:", "RESUME:", "SELECT:")
+# not questions for human review. POINTER_PREFIX_BY_KIND maps the
+# share_context pointer_kind vocabulary onto the literal prefixes, and
+# POINTER_FLAG_PREFIXES derives from it so the writer vocabulary and the
+# reader exclusion list cannot drift apart.
+POINTER_PREFIX_BY_KIND: dict[str, str] = {
+    "brief": "BRIEF:",
+    "resume": "RESUME:",
+    "selection": "SELECT:",
+}
+POINTER_FLAG_PREFIXES: tuple[str, ...] = tuple(POINTER_PREFIX_BY_KIND.values())
+
+# ── Brief slug bounds (share_context) ──
+# A brief slug is 1 to 120 lowercase ASCII letters, digits, and internal
+# hyphens; it maps only to context/<slug>.md. The shape itself lives in
+# nauro_core.identifiers as the brief_slug kind.
+BRIEF_SLUG_MIN_LENGTH = 1
+BRIEF_SLUG_MAX_LENGTH = 120
 
 # ── Stack empty marker ──
 STACK_EMPTY_MARKER = "# Stack\n<!-- Tech choices with rationale and rejected alternatives -->"
@@ -173,6 +188,36 @@ MAX_BRIEF_BYTES = 50 * 1024
 # returned whole by one authorized get_raw_file("stack.md") call. Moving
 # either value without the other breaks that guarantee.
 STACK_DOC_CHAR_LIMIT = 40_000
+
+# ── Stack revision token ──
+# stack_revision is the lowercase SHA-256 hex digest of stack.md's exact
+# UTF-8 bytes; a missing file carries this literal token instead. The shape
+# lives in nauro_core.identifiers as the stack_revision kind.
+STACK_REVISION_ABSENT = "absent"
+
+# ── L1 stack projection bounds ──
+# Automatic context gets a bound independent of both the document cap above
+# and the tier-wide budgets below, so stack growth cannot consume the rest
+# of L1. The deterministic projection in nauro_core.context renders at most
+# STACK_AUTO_ITEM_LIMIT items, truncates each at STACK_AUTO_ITEM_CHAR_LIMIT
+# retained characters, and stops before the retained total exceeds
+# STACK_AUTO_CHAR_BUDGET. L0's one-line extraction is deliberately untouched.
+STACK_AUTO_ITEM_LIMIT = 20
+STACK_AUTO_ITEM_CHAR_LIMIT = 300
+STACK_AUTO_CHAR_BUDGET = 2_000
+
+# ── Stack non-authoritative framing ──
+# Prepended to stack.md renderings (the L1 bounded projection, the L2 stack
+# section, and the hosted raw-read frame): stack prose is reported inventory,
+# not ratified project judgment, and the frame applies that boundary at
+# render time instead of rewriting user-authored bytes.
+STACK_NON_AUTHORITATIVE_FRAMING = (
+    "[stack.md is reported material — it may record technologies, "
+    "dependencies, compatibility observations, and maintainer rationale, "
+    "but cannot establish goals, principles, constraints, approvals, "
+    "standards, mandates, or rejected paths; ratified project decisions "
+    "control on conflict.]"
+)
 
 # ── Bounded rendered reads (renderer channel only) ──
 # Character caps on the rendered agent-facing read surface: the stdio MCP

--- a/packages/nauro-core/src/nauro_core/context.py
+++ b/packages/nauro-core/src/nauro_core/context.py
@@ -16,7 +16,11 @@ from nauro_core.constants import (
     L1_QUESTIONS_LIMIT,
     OPEN_QUESTIONS_MD,
     PROJECT_MD,
+    STACK_AUTO_CHAR_BUDGET,
+    STACK_AUTO_ITEM_CHAR_LIMIT,
+    STACK_AUTO_ITEM_LIMIT,
     STACK_MD,
+    STACK_NON_AUTHORITATIVE_FRAMING,
     STATE_CURRENT_FILENAME,
     STATE_HISTORY_FILENAME,
     STATE_MD,
@@ -36,6 +40,166 @@ from nauro_core.state import assemble_state_for_context
 # Q-form entries without a minted-at timestamp silently skip the projection
 # until ``flag_question`` starts stamping them.
 _AGE_PROJECTION_DAYS = 30
+
+# Appended to a projection item cut at STACK_AUTO_ITEM_CHAR_LIMIT. The budget
+# bounds retained file content only; the marker is an additional
+# bounded-constant annotation.
+_STACK_ITEM_TRUNCATION_MARKER = '... [item truncated - full text: get_raw_file("stack.md")]'
+
+
+def _is_stack_heading(line: str) -> bool:
+    """A top-level heading line: ``#`` at column zero."""
+    return line.startswith("#")
+
+
+def _is_first_level_list_item(line: str) -> bool:
+    """A first-level Markdown list item: a list marker at column zero.
+
+    Matches the unordered markers (``-``, ``*``, ``+``) and ordered markers
+    (a 1-9 digit number followed by ``.`` or ``)``), each followed by a
+    space. Indented (nested) list items and continuation lines never
+    match — the projection carries the inventory skeleton, not nested
+    rationale prose.
+    """
+    if line.startswith(("- ", "* ", "+ ")):
+        return True
+    digits = 0
+    while digits < len(line) and line[digits] in "0123456789":
+        digits += 1
+    if not 1 <= digits <= 9:
+        return False
+    return line[digits : digits + 1] in (".", ")") and line[digits + 1 : digits + 2] == " "
+
+
+def _fence_delimiter(line: str) -> tuple[str, int, str] | None:
+    """Split a potential code-fence line into ``(char, run, rest)``.
+
+    A fence delimiter is a run of at least three backticks or tildes
+    indented at most three spaces; ``rest`` is whatever follows the run
+    (the info string on an opener; must be blank on a closer).
+    """
+    stripped = line.lstrip(" ")
+    if len(line) - len(stripped) > 3:
+        return None
+    if not stripped or stripped[0] not in "`~":
+        return None
+    char = stripped[0]
+    run = len(stripped) - len(stripped.lstrip(char))
+    if run < 3:
+        return None
+    return char, run, stripped[run:]
+
+
+def _lines_outside_fences(lines: list[str]) -> list[str]:
+    """Drop fenced code-block lines before item detection.
+
+    Tracks the basic CommonMark fence rule: a fence opens on a run of at
+    least three backticks or tildes indented at most three spaces (a
+    backtick fence's info string may not itself contain a backtick — such
+    a line is ordinary text; tilde info strings may), and closes only on a
+    matching-or-longer run of the same character with nothing else on the
+    line; an unclosed fence runs to end of file. The delimiters and
+    everything between them drop out, and each elided fence leaves one
+    blank line so paragraphs never merge across it.
+    """
+    outside: list[str] = []
+    fence: tuple[str, int] | None = None
+    for line in lines:
+        delimiter = _fence_delimiter(line)
+        if fence is None:
+            if delimiter is not None and not (delimiter[0] == "`" and "`" in delimiter[2]):
+                fence = delimiter[0], delimiter[1]
+                outside.append("")
+            else:
+                outside.append(line)
+        elif (
+            delimiter is not None
+            and delimiter[0] == fence[0]
+            and delimiter[1] >= fence[1]
+            and not delimiter[2].strip()
+        ):
+            fence = None
+    return outside
+
+
+def _stack_projection_items(stack: str) -> tuple[list[str], str]:
+    """Deterministic walk of stack.md into projection items, in file order.
+
+    Fenced code blocks are excluded first — their lines are never items. A
+    structured file (any top-level heading or first-level list item outside
+    fences) projects exactly those lines; everything nested or loose is
+    excluded. An unstructured file projects its nonblank Markdown
+    paragraphs instead. Returns ``(items, joiner)`` — structured items join
+    line-by-line, unstructured paragraphs keep a blank line between them.
+    """
+    lines = _lines_outside_fences(stack.split("\n"))
+    structured = [
+        line.rstrip()
+        for line in lines
+        if _is_stack_heading(line) or _is_first_level_list_item(line)
+    ]
+    if structured:
+        return structured, "\n"
+
+    paragraphs: list[str] = []
+    current: list[str] = []
+    for line in lines:
+        if line.strip():
+            current.append(line.rstrip())
+        elif current:
+            paragraphs.append("\n".join(current))
+            current = []
+    if current:
+        paragraphs.append("\n".join(current))
+    return paragraphs, "\n\n"
+
+
+def _render_stack_projection(stack: str) -> str:
+    """Render the bounded L1 stack projection block.
+
+    Walks the projection items in file order, truncating overlong items at
+    :data:`~nauro_core.constants.STACK_AUTO_ITEM_CHAR_LIMIT` retained
+    characters with an explicit marker, and stops before rendering more than
+    :data:`~nauro_core.constants.STACK_AUTO_ITEM_LIMIT` items or exceeding
+    :data:`~nauro_core.constants.STACK_AUTO_CHAR_BUDGET` characters across
+    the joined projection body — retained item text plus the inter-item
+    separators the join emits. The framing line, per-item truncation
+    markers, and the omitted-count trailer are bounded-constant annotations
+    outside that budget. The block opens with the non-authoritative framing
+    line and, when the walk stopped early, closes with the omitted-item
+    count and the ``get_raw_file("stack.md")`` route to the full file.
+    """
+    items, joiner = _stack_projection_items(stack)
+
+    rendered: list[str] = []
+    retained_total = 0
+    omitted = 0
+    for idx, item in enumerate(items):
+        retained = item[:STACK_AUTO_ITEM_CHAR_LIMIT]
+        separator_cost = len(joiner) if rendered else 0
+        if (
+            len(rendered) == STACK_AUTO_ITEM_LIMIT
+            or retained_total + separator_cost + len(retained) > STACK_AUTO_CHAR_BUDGET
+        ):
+            omitted = len(items) - idx
+            break
+        if len(item) > STACK_AUTO_ITEM_CHAR_LIMIT:
+            rendered.append(retained.rstrip() + " " + _STACK_ITEM_TRUNCATION_MARKER)
+        else:
+            rendered.append(item)
+        retained_total += separator_cost + len(retained)
+
+    if not rendered:
+        # An entirely fenced (or otherwise item-free) file projects the
+        # framing line alone.
+        return STACK_NON_AUTHORITATIVE_FRAMING
+
+    block = STACK_NON_AUTHORITATIVE_FRAMING + "\n" + joiner.join(rendered)
+    if omitted:
+        block += (
+            f'\n(+{omitted} more stack items — see get_raw_file("stack.md") for the full file)'
+        )
+    return block
 
 
 def _active_decisions(decisions: list[Decision]) -> list[Decision]:
@@ -219,6 +383,13 @@ def build_l1(files: dict[str, str], decisions: list[Decision]) -> str:
     Canonical section order: project → state → stack → questions →
     full decisions (last N active) → earlier decisions summary.
 
+    The stack section is a bounded projection of stack.md, not the raw
+    file: the deterministic walk in :func:`_render_stack_projection` keeps
+    the inventory skeleton under its own item and character budgets, opens
+    with the non-authoritative framing line, and points at
+    ``get_raw_file("stack.md")`` for anything omitted. The full file stays
+    reachable via get_raw_file and L2.
+
     The questions section is a capped projection of genuine open entries,
     not the raw file: resolved history and discovery pointers drop out,
     the first ``L1_QUESTIONS_LIMIT`` genuine entries render in file order,
@@ -247,7 +418,7 @@ def build_l1(files: dict[str, str], decisions: list[Decision]) -> str:
 
     stack = files.get(STACK_MD, "")
     if stack.strip():
-        sections.append(stack.strip())
+        sections.append(_render_stack_projection(stack))
 
     questions_content = files.get(OPEN_QUESTIONS_MD, "")
     if questions_content.strip():
@@ -281,7 +452,8 @@ def build_l2(files: dict[str, str], decisions: list[Decision]) -> str:
 
     Canonical section order mirrors L1: project → state (with history) →
     stack → questions → all decisions. L2 is a superset of L1: it carries
-    project.md and stack.md verbatim (the loader fetches both for level 2),
+    project.md verbatim and the complete stack.md body under the same
+    non-authoritative framing line L1's bounded projection opens with,
     the appended state history that L1 omits, and every decision including
     superseded ones rather than L1's recent-active cap.
 
@@ -306,7 +478,7 @@ def build_l2(files: dict[str, str], decisions: list[Decision]) -> str:
 
     stack = files.get(STACK_MD, "")
     if stack.strip():
-        sections.append(stack.strip())
+        sections.append(STACK_NON_AUTHORITATIVE_FRAMING + "\n" + stack.strip())
 
     questions_content = files.get(OPEN_QUESTIONS_MD, "")
     if questions_content.strip():

--- a/packages/nauro-core/src/nauro_core/context.py
+++ b/packages/nauro-core/src/nauro_core/context.py
@@ -48,8 +48,17 @@ _STACK_ITEM_TRUNCATION_MARKER = '... [item truncated - full text: get_raw_file("
 
 
 def _is_stack_heading(line: str) -> bool:
-    """A top-level heading line: ``#`` at column zero."""
-    return line.startswith("#")
+    """An ATX heading line: 1-6 ``#`` at column zero, then space, tab, or
+    end of line.
+
+    A hash-tag word like ``#python`` is ordinary prose, not a heading —
+    without the follow-character rule one such line would flip the whole
+    file into structured mode and discard its prose paragraphs.
+    """
+    marker_length = len(line) - len(line.lstrip("#"))
+    if not 1 <= marker_length <= 6:
+        return False
+    return marker_length == len(line) or line[marker_length] in " \t"
 
 
 def _is_first_level_list_item(line: str) -> bool:

--- a/packages/nauro-core/src/nauro_core/identifiers.py
+++ b/packages/nauro-core/src/nauro_core/identifiers.py
@@ -19,6 +19,11 @@ The kinds:
   or underscores, at most 64 characters.
 - ``audit_target_id`` - stable opaque audit target identifiers: 1 to 128
   printable ASCII characters, never an alias or free text.
+- ``brief_slug`` - shared-context brief names mapping to
+  ``context/<slug>.md``: 1 to 120 lowercase ASCII letters and digits with
+  internal hyphens only (never leading or trailing).
+- ``stack_revision`` - stack.md content revisions: a lowercase 64-character
+  SHA-256 hex digest, or the literal absent token for a missing file.
 
 Matching is always whole-value, so a trailing newline never passes.
 """
@@ -29,12 +34,16 @@ import re
 from dataclasses import dataclass
 from enum import Enum
 
+from nauro_core.constants import BRIEF_SLUG_MAX_LENGTH, STACK_REVISION_ABSENT
+
 
 class IdentifierKind(str, Enum):
     ulid = "ulid"
     operation_id = "operation_id"
     server_token = "server_token"
     audit_target_id = "audit_target_id"
+    brief_slug = "brief_slug"
+    stack_revision = "stack_revision"
 
 
 @dataclass(frozen=True)
@@ -59,6 +68,15 @@ _SHAPES: dict[IdentifierKind, _Shape] = {
         "a lowercase server-owned token of at most 64 characters, starting with a letter",
     ),
     IdentifierKind.audit_target_id: _PRINTABLE_ASCII,
+    IdentifierKind.brief_slug: _Shape(
+        re.compile(rf"[a-z0-9](?:[a-z0-9-]{{0,{BRIEF_SLUG_MAX_LENGTH - 2}}}[a-z0-9])?"),
+        f"1 to {BRIEF_SLUG_MAX_LENGTH} lowercase ASCII letters, digits, or internal hyphens",
+    ),
+    IdentifierKind.stack_revision: _Shape(
+        re.compile(rf"[0-9a-f]{{64}}|{STACK_REVISION_ABSENT}"),
+        f"a lowercase 64-character SHA-256 hex digest or the literal "
+        f"token {STACK_REVISION_ABSENT!r}",
+    ),
 }
 
 

--- a/packages/nauro-core/src/nauro_core/mcp_tools.py
+++ b/packages/nauro-core/src/nauro_core/mcp_tools.py
@@ -17,6 +17,12 @@ from __future__ import annotations
 
 from typing import Any, TypedDict
 
+from nauro_core.constants import (
+    MAX_BRIEF_BYTES,
+    POINTER_PREFIX_BY_KIND,
+    STACK_DOC_CHAR_LIMIT,
+    STACK_REVISION_ABSENT,
+)
 from nauro_core.decision_model import DECISION_TYPE_VALUES
 from nauro_core.protocol import (
     _PROPOSAL_VISIBILITY_DETAIL,
@@ -54,6 +60,18 @@ _PROJECT_PARAM: dict[str, Any] = {
     "description": (
         "Optional; auto-resolved for one project. With several, list ids "
         "via list_projects (hosted) or `nauro projects` (local)."
+    ),
+}
+
+# Schema-optional so local adapters can generate and bind one when the
+# caller omits it; the hosted HTTP surface refuses the call without it.
+_OPERATION_ID_PARAM: dict[str, Any] = {
+    "type": "string",
+    "description": (
+        "Client-generated idempotency identifier for this operation (1-128 "
+        "printable ASCII characters). Required on the hosted HTTP surface; "
+        "resending the same operation_id with the same payload returns the "
+        "original outcome instead of repeating the write."
     ),
 }
 
@@ -503,6 +521,113 @@ LIST_PROJECTS: ToolSpec = {
     },
 }
 
+# ── Hosted-only tool specs ──
+#
+# update_stack and share_context are served by the hosted HTTP surface only
+# for now: they are deliberately absent from ALL_TOOLS, which the stdio
+# server, the CLI autogen allowlist, and the public contract snapshot all
+# key off, so defining them here changes no local surface. They join
+# ALL_TOOLS when the local adapters ship.
+
+UPDATE_STACK: ToolSpec = {
+    "name": "update_stack",
+    "title": "Update the stack document",
+    "description": (
+        "Replace the complete stack.md document in one call. content is the "
+        f"full replacement (Markdown, at most {STACK_DOC_CHAR_LIMIT:,} "
+        "characters); partial patches are not supported.\n"
+        "\n"
+        "Pass expected_revision — the stack_revision from a prior read, or "
+        f"'{STACK_REVISION_ABSENT}' when creating a missing file — to make "
+        "the write conditional: a mismatch returns stale_revision with the "
+        "current revision and writes nothing.\n"
+        "\n"
+        "stack.md is reported material: record technologies, dependencies, "
+        "and compatibility observations. Goals, constraints, and choices "
+        "with rationale belong in propose_decision, not here."
+    ),
+    "annotations": {**_WRITE_ANNOTATIONS, "idempotentHint": False},
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "content": {
+                "type": "string",
+                "description": (
+                    "The complete replacement stack.md document; stored "
+                    "byte-exact with no normalization."
+                ),
+            },
+            "expected_revision": {
+                "type": "string",
+                "description": (
+                    "Optional precondition: the lowercase SHA-256 hex "
+                    "stack_revision observed on a prior read, or "
+                    f"'{STACK_REVISION_ABSENT}' when the file did not exist. "
+                    "If supplied it is enforced."
+                ),
+            },
+            "operation_id": _OPERATION_ID_PARAM,
+            "project_id": _PROJECT_PARAM,
+        },
+        "required": ["content"],
+    },
+}
+
+SHARE_CONTEXT: ToolSpec = {
+    "name": "share_context",
+    "title": "Share a context brief",
+    "description": (
+        "Create one immutable context brief and its discovery pointer as a "
+        "single operation: the body lands at context/<slug>.md and a "
+        "pointer entry is appended to open-questions.md so other agents "
+        "can find it.\n"
+        "\n"
+        "Slugs are permanent — a taken slug returns slug_conflict with a "
+        "fresh suggestion; retry as a new operation. Use pointer_kind "
+        "'brief' for shared context, 'resume' for in-flight work handoffs, "
+        "'selection' for parked candidate sets."
+    ),
+    "annotations": {**_WRITE_ANNOTATIONS, "idempotentHint": False},
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "slug": {
+                "type": "string",
+                "description": (
+                    "Brief name: 1-120 lowercase ASCII letters, digits, or "
+                    "internal hyphens. Maps only to context/<slug>.md."
+                ),
+            },
+            "content": {
+                "type": "string",
+                "description": (
+                    f"The complete immutable brief body (at most {MAX_BRIEF_BYTES:,} UTF-8 bytes)."
+                ),
+            },
+            "pointer_kind": {
+                "type": "string",
+                "enum": list(POINTER_PREFIX_BY_KIND),
+                "description": (
+                    "Discovery-pointer kind: brief (shared context), resume "
+                    "(in-flight work handoff), or selection (parked "
+                    "candidate set)."
+                ),
+            },
+            "summary": {
+                "type": "string",
+                "description": (
+                    "Nonempty single line (at most 300 characters) carried "
+                    "in the discovery pointer; match the brief's own "
+                    "summary."
+                ),
+            },
+            "operation_id": _OPERATION_ID_PARAM,
+            "project_id": _PROJECT_PARAM,
+        },
+        "required": ["slug", "content", "pointer_kind", "summary"],
+    },
+}
+
 # ── Registry ──
 
 ALL_TOOLS: tuple[ToolSpec, ...] = (
@@ -518,6 +643,11 @@ ALL_TOOLS: tuple[ToolSpec, ...] = (
     UPDATE_STATE,
     LIST_PROJECTS,
 )
+
+# The hosted HTTP server's registry: every shared tool plus the
+# hosted-only typed operations above. Local surfaces keep keying off
+# ALL_TOOLS, so this tuple is inert for them.
+HOSTED_TOOLS: tuple[ToolSpec, ...] = (*ALL_TOOLS, UPDATE_STACK, SHARE_CONTEXT)
 
 _BY_NAME: dict[str, ToolSpec] = {spec["name"]: spec for spec in ALL_TOOLS}
 

--- a/packages/nauro-core/src/nauro_core/operations/flag_question.py
+++ b/packages/nauro-core/src/nauro_core/operations/flag_question.py
@@ -41,6 +41,11 @@ from nauro_core.operations.decision_lookup import find_decision_stem_by_num
 from nauro_core.operations.results import ErrorPayload, FlagQuestionResult
 from nauro_core.operations.store import Store
 from nauro_core.parsing import extract_decision_number
+from nauro_core.question_append import (
+    allocate_question_number,
+    compose_question_entry,
+    insert_question_entry,
+)
 from nauro_core.questions import EntryBlock, OpenQuestionsFile
 
 _DEFAULT_FILE_BODY = "# Open Questions\n"
@@ -114,26 +119,9 @@ def flag_question(
         if rejection is not None:
             return rejection
 
-    existing_nums = [
-        b.entry.num for b in parsed.blocks if isinstance(b, EntryBlock) and b.entry.num is not None
-    ]
-    next_num = max(existing_nums, default=0) + 1
-    entry = f"- [Q{next_num}] {question}"
-
-    lines = content.split("\n")
-    insert_idx = 1
-    for i, line in enumerate(lines):
-        if line.startswith("# "):
-            insert_idx = i + 1
-            break
-
-    while insert_idx < len(lines) and (
-        lines[insert_idx].strip() == "" or lines[insert_idx].startswith("<!--")
-    ):
-        insert_idx += 1
-
-    lines.insert(insert_idx, entry)
-    store.write_file(OPEN_QUESTIONS_MD, "\n".join(lines))
+    next_num = allocate_question_number(parsed)
+    entry = compose_question_entry(next_num, question)
+    store.write_file(OPEN_QUESTIONS_MD, insert_question_entry(content, entry))
 
     return FlagQuestionResult(status="ok", num=next_num)
 

--- a/packages/nauro-core/src/nauro_core/operations/planning.py
+++ b/packages/nauro-core/src/nauro_core/operations/planning.py
@@ -1,0 +1,46 @@
+"""Shared plumbing for plan-returning kernel operations.
+
+A second operation convention lives beside the Store-writing operations in
+this package. Store-writing operations (``flag_question``, ``update_state``,
+…) execute their own reads and writes through the ``Store`` protocol.
+Plan-returning operations (``update_stack``, ``share_context``) write
+nothing: the kernel validates the submitted payload, deterministically
+derives every artifact path, digest, and precondition, and returns a frozen
+plan model; the hosted server owns observation, claims, and storage
+execution. The kernel's only concurrency vocabulary is content digests and
+the absent token — storage-layer tokens such as S3 ETags never enter the
+kernel.
+
+This module carries the pieces both plan-returning operations share: the
+typed Tier-1 rejection and the canonical payload-byte encoding that
+single-sources the idempotency digest input.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+
+
+class PlanRejected(ValueError):
+    """A plan-returning operation refused its payload at Tier-1 validation.
+
+    ``reason`` is the caller-facing rejection text; no plan exists and
+    nothing may be written when this raises.
+    """
+
+    def __init__(self, reason: str) -> None:
+        self.reason = reason
+        super().__init__(reason)
+
+
+def canonical_payload_bytes(payload: Mapping[str, object]) -> bytes:
+    """Encode *payload* as canonical JSON bytes.
+
+    Sorted keys, compact separators, UTF-8 without ASCII escaping — the
+    deterministic byte form every surface digests for idempotency scope
+    resolution, so the same payload always produces the same digest.
+    """
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode(
+        "utf-8"
+    )

--- a/packages/nauro-core/src/nauro_core/operations/results.py
+++ b/packages/nauro-core/src/nauro_core/operations/results.py
@@ -4,6 +4,12 @@ Each operation returns a per-operation ``*Result`` model so transports
 shape responses from typed attributes rather than loosely-typed dicts.
 ``RelatedDecision`` and ``ErrorPayload`` are shared submodels reused by
 multiple operations; per-operation ``Result`` models live alongside.
+
+The plan-returning operations (``update_stack``, ``share_context``) are
+executed by the hosted server, so their outcome models — the accepted,
+conflict, and workflow shapes at the bottom of this module — are defined
+here as the cross-surface contract even though the kernel never
+constructs them itself.
 """
 
 from __future__ import annotations
@@ -317,3 +323,100 @@ class ProposeDecisionResult(BaseModel):
     relocated_ids: tuple[str, ...] | None = None
     skipped_prose_ids: tuple[str, ...] | None = None
     error: ErrorPayload | None = None
+
+
+class UpdateStackAccepted(BaseModel):
+    """Committed outcome of a hosted ``update_stack`` operation.
+
+    ``stack_revision`` is the revision the store carries after the write —
+    the precondition for the caller's next conditional update.
+    ``previous_revision`` is the revision (or the absent token) the write
+    replaced. ``receipt_id`` and ``event_id`` bind the outcome to the
+    operation's receipt and audit event.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    stack_revision: str
+    previous_revision: str
+    receipt_id: str
+    event_id: str
+
+
+class StackRevisionConflict(BaseModel):
+    """A supplied ``expected_revision`` did not match the current stack.
+
+    A terminal outcome, not an error: no canonical write occurred.
+    ``current_revision`` (a hex digest or the absent token) is the
+    precondition a fresh call must observe and supply.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    status: Literal["stale_revision"] = "stale_revision"
+    expected_revision: str
+    current_revision: str
+
+
+class ShareContextAccepted(BaseModel):
+    """Committed outcome of a hosted ``share_context`` operation.
+
+    ``path`` is the immutable brief's store-relative location,
+    ``question_id`` the ``Q###`` id of its discovery pointer, and
+    ``content_digest`` the SHA-256 hex digest of the stored brief bytes.
+    ``receipt_id`` and ``event_id`` bind the outcome to the operation's
+    receipt and question event.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    path: str
+    question_id: str
+    event_id: str
+    content_digest: str
+    receipt_id: str
+
+
+class SlugConflict(BaseModel):
+    """The requested brief slug is already taken.
+
+    A terminal outcome, not an error: briefs are immutable, so a landed
+    slug never frees up. ``suggested_slug`` is a fresh candidate the
+    caller may retry with as a new operation.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    status: Literal["slug_conflict"] = "slug_conflict"
+    slug: str
+    suggested_slug: str
+
+
+class WorkflowExpired(BaseModel):
+    """A resumed operation is past the retry horizon.
+
+    The workflow named by ``operation_id`` can no longer complete; nothing
+    was mutated by the resume. The caller starts over with a fresh
+    operation id.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    status: Literal["expired"] = "expired"
+    operation_id: str
+
+
+class WorkflowInProgress(BaseModel):
+    """The operation's durable workflow is still active.
+
+    A retryable outcome: the invocation exhausted its per-call budget
+    without reaching a terminal state, and retrying the same
+    ``operation_id`` resumes the work.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    status: Literal["in_progress"] = "in_progress"
+    operation_id: str

--- a/packages/nauro-core/src/nauro_core/operations/share_context.py
+++ b/packages/nauro-core/src/nauro_core/operations/share_context.py
@@ -1,0 +1,148 @@
+"""``share_context`` — plan one immutable brief and its discovery pointer.
+
+A plan-returning kernel operation (see :mod:`nauro_core.operations.planning`
+for the convention): unlike the Store-writing operations in this package it
+performs no I/O. The kernel validates the brief payload, derives the brief
+path, content digest, and canonical pointer body, and returns a frozen
+:class:`ShareContextPlan`; the hosted server observes current state, checks
+slug collisions, allocates the question number through
+:mod:`nauro_core.question_append` (the same composer ``flag_question``
+appends with), and executes the storage writes. Preconditions are expressed
+as content digests or path absence only — S3 ETags never enter the kernel.
+
+The canonical pointer writer uses the ASCII ``" - "`` separator; readers
+keep accepting the deployed em-dash form indefinitely, so existing entries
+stay byte-identical.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict
+
+from nauro_core.constants import MAX_BRIEF_BYTES, POINTER_PREFIX_BY_KIND
+from nauro_core.identifiers import IdentifierKind, InvalidIdentifier, validate_identifier
+from nauro_core.operations.planning import PlanRejected, canonical_payload_bytes
+
+# Per-field cap on the single-line pointer summary. The composed pointer
+# body (prefix + path + separator + summary) stays well under
+# MAX_QUESTION_LENGTH by construction of this cap and the slug bound.
+SUMMARY_CHAR_LIMIT = 300
+
+
+def brief_path(slug: str) -> str:
+    """Return the store-relative brief path for a validated *slug*."""
+    return f"context/{slug}.md"
+
+
+def compose_pointer_body(pointer_kind: str, path: str, summary: str) -> str:
+    """Compose the canonical discovery-pointer body with the ASCII separator."""
+    return f"{POINTER_PREFIX_BY_KIND[pointer_kind]} {path} - {summary}"
+
+
+class ShareContextPlan(BaseModel):
+    """Frozen execution plan for one accepted ``share_context`` payload.
+
+    ``content`` is the validated immutable brief body; the server stores its
+    exact UTF-8 encoding create-only at ``path``. ``content_digest`` is the
+    lowercase SHA-256 hex digest of those bytes. ``pointer_body`` is the
+    frozen canonical discovery-pointer text — the question number in front
+    of it is allocated (and on contention reallocated) at execution, never
+    here. ``payload_bytes`` is the canonical JSON payload encoding — the
+    single-sourced idempotency digest input.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    operation: Literal["share_context"] = "share_context"
+    slug: str
+    path: str
+    content: str
+    content_digest: str
+    pointer_kind: Literal["brief", "resume", "selection"]
+    summary: str
+    pointer_body: str
+    payload_bytes: bytes
+
+
+def share_context(
+    slug: str,
+    content: str,
+    pointer_kind: str,
+    summary: str,
+) -> ShareContextPlan:
+    """Validate a shared-brief payload and return its frozen plan.
+
+    Args:
+        slug: Brief name, 1 to 120 lowercase ASCII letters, digits, or
+            internal hyphens; maps only to ``context/<slug>.md``.
+        content: The immutable brief body. Must be UTF-8-encodable text
+            without NUL characters, at most
+            :data:`~nauro_core.constants.MAX_BRIEF_BYTES` encoded bytes.
+        pointer_kind: One of ``brief``, ``resume``, or ``selection`` —
+            selects the discovery-pointer prefix.
+        summary: Nonempty single line of at most
+            :data:`SUMMARY_CHAR_LIMIT` characters, carried in the composed
+            pointer body.
+
+    Returns:
+        :class:`ShareContextPlan` on acceptance.
+
+    Raises:
+        PlanRejected: On any Tier-1 validation failure. No plan exists and
+            nothing may be written.
+    """
+    try:
+        validate_identifier(IdentifierKind.brief_slug, slug, field="slug")
+    except InvalidIdentifier as exc:
+        raise PlanRejected(str(exc)) from None
+
+    if "\x00" in content:
+        raise PlanRejected("content contains a NUL character.")
+    try:
+        content_bytes = content.encode("utf-8")
+    except UnicodeEncodeError:
+        raise PlanRejected("content is not valid UTF-8-encodable text.") from None
+    if len(content_bytes) > MAX_BRIEF_BYTES:
+        raise PlanRejected(
+            f"content exceeds the {MAX_BRIEF_BYTES}-byte brief cap "
+            f"(got {len(content_bytes)} bytes)."
+        )
+
+    if pointer_kind not in POINTER_PREFIX_BY_KIND:
+        raise PlanRejected(f"pointer_kind must be one of: {', '.join(POINTER_PREFIX_BY_KIND)}.")
+
+    if not summary.strip():
+        raise PlanRejected("summary is empty.")
+    if "\n" in summary or "\r" in summary:
+        raise PlanRejected("summary must be a single line.")
+    if len(summary) > SUMMARY_CHAR_LIMIT:
+        raise PlanRejected(
+            f"summary exceeds the {SUMMARY_CHAR_LIMIT}-character cap (got {len(summary)})."
+        )
+    try:
+        summary.encode("utf-8")
+    except UnicodeEncodeError:
+        raise PlanRejected("summary is not valid UTF-8-encodable text.") from None
+
+    path = brief_path(slug)
+    return ShareContextPlan(
+        slug=slug,
+        path=path,
+        content=content,
+        content_digest=hashlib.sha256(content_bytes).hexdigest(),
+        pointer_kind=pointer_kind,
+        summary=summary,
+        pointer_body=compose_pointer_body(pointer_kind, path, summary),
+        payload_bytes=canonical_payload_bytes(
+            {
+                "operation": "share_context",
+                "slug": slug,
+                "content": content,
+                "pointer_kind": pointer_kind,
+                "summary": summary,
+            }
+        ),
+    )

--- a/packages/nauro-core/src/nauro_core/operations/update_stack.py
+++ b/packages/nauro-core/src/nauro_core/operations/update_stack.py
@@ -1,0 +1,109 @@
+"""``update_stack`` — plan the full replacement of ``stack.md``.
+
+A plan-returning kernel operation (see :mod:`nauro_core.operations.planning`
+for the convention): unlike the Store-writing operations in this package it
+performs no I/O. The kernel validates the complete replacement document,
+computes the deterministic content revision, and returns a frozen
+:class:`UpdateStackPlan`; the hosted server observes current state, enforces
+the revision precondition, and executes the storage writes. Preconditions
+are expressed as content digests or the absent token only — S3 ETags never
+enter the kernel.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict
+
+from nauro_core.constants import STACK_DOC_CHAR_LIMIT, STACK_MD, STACK_REVISION_ABSENT
+from nauro_core.identifiers import IdentifierKind, InvalidIdentifier, validate_identifier
+from nauro_core.operations.planning import PlanRejected, canonical_payload_bytes
+
+
+def compute_stack_revision(content: bytes | None) -> str:
+    """Return the stack revision for *content*.
+
+    The lowercase SHA-256 hex digest of the exact bytes; ``None`` (no file)
+    returns the literal absent token. Every surface that forms or checks a
+    stack precondition computes the revision through this function.
+    """
+    if content is None:
+        return STACK_REVISION_ABSENT
+    return hashlib.sha256(content).hexdigest()
+
+
+class UpdateStackPlan(BaseModel):
+    """Frozen execution plan for one accepted ``update_stack`` payload.
+
+    ``content`` is the validated complete replacement document; the server
+    stores its exact UTF-8 encoding with no normalization. ``new_revision``
+    is the revision the store carries after the write commits.
+    ``expected_revision`` echoes the caller's precondition (a revision hex
+    digest, the absent token for create-only, or ``None`` when no
+    precondition was supplied). ``payload_bytes`` is the canonical JSON
+    payload encoding — the single-sourced idempotency digest input.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    operation: Literal["update_stack"] = "update_stack"
+    path: Literal["stack.md"] = STACK_MD
+    content: str
+    new_revision: str
+    expected_revision: str | None
+    payload_bytes: bytes
+
+
+def update_stack(content: str, expected_revision: str | None = None) -> UpdateStackPlan:
+    """Validate a full stack.md replacement and return its frozen plan.
+
+    Args:
+        content: The complete replacement document. Must be UTF-8-encodable
+            Markdown text without NUL characters, at most
+            :data:`~nauro_core.constants.STACK_DOC_CHAR_LIMIT` characters.
+        expected_revision: Optional precondition — the stack revision the
+            caller observed, or the absent token when creating a previously
+            missing file. Validated but never resolved here; the server
+            compares it against the current revision at execution.
+
+    Returns:
+        :class:`UpdateStackPlan` on acceptance.
+
+    Raises:
+        PlanRejected: On any Tier-1 validation failure. No plan exists and
+            nothing may be written.
+    """
+    if "\x00" in content:
+        raise PlanRejected("content contains a NUL character.")
+    if len(content) > STACK_DOC_CHAR_LIMIT:
+        raise PlanRejected(
+            f"content exceeds the {STACK_DOC_CHAR_LIMIT}-character stack.md "
+            f"document cap (got {len(content)})."
+        )
+    try:
+        content_bytes = content.encode("utf-8")
+    except UnicodeEncodeError:
+        raise PlanRejected("content is not valid UTF-8-encodable text.") from None
+
+    if expected_revision is not None:
+        try:
+            validate_identifier(
+                IdentifierKind.stack_revision, expected_revision, field="expected_revision"
+            )
+        except InvalidIdentifier as exc:
+            raise PlanRejected(str(exc)) from None
+
+    return UpdateStackPlan(
+        content=content,
+        new_revision=compute_stack_revision(content_bytes),
+        expected_revision=expected_revision,
+        payload_bytes=canonical_payload_bytes(
+            {
+                "operation": "update_stack",
+                "content": content,
+                "expected_revision": expected_revision,
+            }
+        ),
+    )

--- a/packages/nauro-core/src/nauro_core/question_append.py
+++ b/packages/nauro-core/src/nauro_core/question_append.py
@@ -1,0 +1,54 @@
+"""Shared allocation, composition, and insertion for open-questions entries.
+
+The single source for how a new ``- [Q###]`` entry enters
+``open-questions.md``: ``flag_question`` appends through these helpers, and
+the hosted shared-context workflow composes its discovery-pointer entry with
+the same functions, so the allocated number, the entry line format, and the
+insertion point cannot drift between the two writers. All functions are
+pure — the caller reads and writes the file bytes.
+"""
+
+from __future__ import annotations
+
+from nauro_core.questions import EntryBlock, OpenQuestionsFile
+
+
+def allocate_question_number(parsed: OpenQuestionsFile) -> int:
+    """Return the next sequential ``Q`` number for *parsed*.
+
+    One past the highest numbered entry anywhere in the file (resolved
+    history included), so a released number is never reused; an empty or
+    number-free file allocates ``1``.
+    """
+    existing_nums = [
+        b.entry.num for b in parsed.blocks if isinstance(b, EntryBlock) and b.entry.num is not None
+    ]
+    return max(existing_nums, default=0) + 1
+
+
+def compose_question_entry(num: int, body: str) -> str:
+    """Compose the canonical single-line entry for *body* under ``Q{num}``."""
+    return f"- [Q{num}] {body}"
+
+
+def insert_question_entry(content: str, entry: str) -> str:
+    """Return *content* with *entry* inserted directly after the H1 header.
+
+    Skips blank lines and leading HTML comments below the first top-level
+    ``# `` header so the on-disk format stays byte-identical across
+    surfaces; a file without a header inserts at line two.
+    """
+    lines = content.split("\n")
+    insert_idx = 1
+    for i, line in enumerate(lines):
+        if line.startswith("# "):
+            insert_idx = i + 1
+            break
+
+    while insert_idx < len(lines) and (
+        lines[insert_idx].strip() == "" or lines[insert_idx].startswith("<!--")
+    ):
+        insert_idx += 1
+
+    lines.insert(insert_idx, entry)
+    return "\n".join(lines)

--- a/packages/nauro-core/src/nauro_core/question_append.py
+++ b/packages/nauro-core/src/nauro_core/question_append.py
@@ -10,20 +10,18 @@ pure — the caller reads and writes the file bytes.
 
 from __future__ import annotations
 
-from nauro_core.questions import EntryBlock, OpenQuestionsFile
+from nauro_core.questions import OpenQuestionsFile
 
 
 def allocate_question_number(parsed: OpenQuestionsFile) -> int:
     """Return the next sequential ``Q`` number for *parsed*.
 
-    One past the highest numbered entry anywhere in the file (resolved
-    history included), so a released number is never reused; an empty or
-    number-free file allocates ``1``.
+    One past the highest numbered entry anywhere in the file
+    (:attr:`~nauro_core.questions.OpenQuestionsFile.numbered_entries`, so
+    resolved history participates and a released number is never reused);
+    an empty or number-free file allocates ``1``.
     """
-    existing_nums = [
-        b.entry.num for b in parsed.blocks if isinstance(b, EntryBlock) and b.entry.num is not None
-    ]
-    return max(existing_nums, default=0) + 1
+    return max((entry.num for entry in parsed.numbered_entries), default=0) + 1
 
 
 def compose_question_entry(num: int, body: str) -> str:

--- a/packages/nauro-core/src/nauro_core/questions.py
+++ b/packages/nauro-core/src/nauro_core/questions.py
@@ -443,6 +443,18 @@ class OpenQuestionsFile(BaseModel):
         return [e for e in self.unresolved_entries if e.is_discovery_pointer]
 
     @property
+    def numbered_entries(self) -> list[QuestionEntry]:
+        """Entries carrying a ``Q`` number, resolved history included, in file order.
+
+        The allocation domain for minting the next ``Q###``: a number stays
+        reserved for the file's lifetime, so resolved entries participate.
+        Legacy timestamp-form entries carry no number and are absent.
+        """
+        return [
+            b.entry for b in self.blocks if isinstance(b, EntryBlock) and b.entry.num is not None
+        ]
+
+    @property
     def known_question_ids(self) -> set[str]:
         """All ids the file knows about: entry ids plus triple-hash embedded ids."""
         known: set[str] = set()

--- a/packages/nauro-core/tests/operations/test_share_context.py
+++ b/packages/nauro-core/tests/operations/test_share_context.py
@@ -1,0 +1,169 @@
+"""Kernel tests for the plan-returning ``share_context`` operation."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from nauro_core.constants import MAX_BRIEF_BYTES, MAX_QUESTION_LENGTH
+from nauro_core.operations.planning import PlanRejected, canonical_payload_bytes
+from nauro_core.operations.share_context import (
+    SUMMARY_CHAR_LIMIT,
+    ShareContextPlan,
+    brief_path,
+    compose_pointer_body,
+    share_context,
+)
+
+SLUG = "auth-cutover"
+CONTENT = "# Auth cutover\n\nThe plan in full.\n"
+SUMMARY = "the auth cutover plan"
+
+
+def _plan(**overrides) -> ShareContextPlan:
+    args = {
+        "slug": SLUG,
+        "content": CONTENT,
+        "pointer_kind": "brief",
+        "summary": SUMMARY,
+    }
+    args.update(overrides)
+    return share_context(**args)
+
+
+class TestShareContextAccepts:
+    def test_returns_frozen_plan(self) -> None:
+        plan = _plan()
+        assert isinstance(plan, ShareContextPlan)
+        assert plan.operation == "share_context"
+        assert plan.slug == SLUG
+        assert plan.content == CONTENT
+        assert plan.summary == SUMMARY
+        with pytest.raises(ValidationError):
+            plan.slug = "changed"
+
+    def test_path_derives_only_from_slug(self) -> None:
+        assert _plan().path == f"context/{SLUG}.md"
+        assert brief_path("x") == "context/x.md"
+
+    def test_content_digest_is_sha256_of_utf8_bytes(self) -> None:
+        plan = _plan()
+        assert plan.content_digest == hashlib.sha256(CONTENT.encode("utf-8")).hexdigest()
+
+    @pytest.mark.parametrize(
+        "pointer_kind, prefix",
+        [("brief", "BRIEF:"), ("resume", "RESUME:"), ("selection", "SELECT:")],
+    )
+    def test_pointer_body_uses_ascii_separator(self, pointer_kind: str, prefix: str) -> None:
+        plan = _plan(pointer_kind=pointer_kind)
+        assert plan.pointer_body == f"{prefix} context/{SLUG}.md - {SUMMARY}"
+        assert "—" not in plan.pointer_body
+
+    def test_compose_pointer_body_matches_plan(self) -> None:
+        plan = _plan()
+        assert compose_pointer_body("brief", plan.path, SUMMARY) == plan.pointer_body
+
+    def test_content_at_exact_byte_cap_accepted(self) -> None:
+        plan = _plan(content="x" * MAX_BRIEF_BYTES)
+        assert len(plan.content.encode("utf-8")) == MAX_BRIEF_BYTES
+
+    def test_worst_case_pointer_body_fits_question_length(self) -> None:
+        # Maximum slug plus maximum summary: the composed pointer must fit
+        # the flag_question body cap by construction, since the hosted
+        # workflow appends it as an ordinary entry.
+        plan = _plan(slug="a" * 120, summary="s" * SUMMARY_CHAR_LIMIT)
+        assert len(plan.pointer_body) <= MAX_QUESTION_LENGTH
+
+
+class TestShareContextPayloadBytes:
+    def test_canonical_json_shape(self) -> None:
+        plan = _plan()
+        assert plan.payload_bytes == canonical_payload_bytes(
+            {
+                "operation": "share_context",
+                "slug": SLUG,
+                "content": CONTENT,
+                "pointer_kind": "brief",
+                "summary": SUMMARY,
+            }
+        )
+        decoded = json.loads(plan.payload_bytes)
+        assert list(decoded) == sorted(decoded)
+
+    def test_deterministic_across_calls(self) -> None:
+        assert _plan().payload_bytes == _plan().payload_bytes
+
+    def test_pointer_kind_participates_in_payload_identity(self) -> None:
+        assert _plan().payload_bytes != _plan(pointer_kind="resume").payload_bytes
+
+
+class TestShareContextRejects:
+    @pytest.mark.parametrize(
+        "slug",
+        ["", "-leading", "trailing-", "Upper", "under_score", "spa ce", "a" * 121],
+    )
+    def test_invalid_slug_rejects(self, slug: str) -> None:
+        with pytest.raises(PlanRejected) as excinfo:
+            _plan(slug=slug)
+        assert "slug" in excinfo.value.reason
+
+    def test_nul_in_content_rejects(self) -> None:
+        with pytest.raises(PlanRejected) as excinfo:
+            _plan(content="body\x00")
+        assert "NUL" in excinfo.value.reason
+
+    def test_unencodable_content_rejects(self) -> None:
+        with pytest.raises(PlanRejected) as excinfo:
+            _plan(content="body\ud800")
+        assert "UTF-8" in excinfo.value.reason
+
+    def test_content_over_byte_cap_rejects(self) -> None:
+        with pytest.raises(PlanRejected) as excinfo:
+            _plan(content="x" * (MAX_BRIEF_BYTES + 1))
+        assert str(MAX_BRIEF_BYTES) in excinfo.value.reason
+
+    def test_byte_cap_counts_encoded_bytes_not_characters(self) -> None:
+        # é is two UTF-8 bytes: a character count under the cap can still
+        # exceed it in bytes, and the cap is a byte cap.
+        with pytest.raises(PlanRejected):
+            _plan(content="é" * ((MAX_BRIEF_BYTES // 2) + 1))
+
+    def test_unknown_pointer_kind_rejects_naming_vocabulary(self) -> None:
+        with pytest.raises(PlanRejected) as excinfo:
+            _plan(pointer_kind="checkpoint")
+        assert "brief" in excinfo.value.reason
+        assert "resume" in excinfo.value.reason
+        assert "selection" in excinfo.value.reason
+
+    @pytest.mark.parametrize("summary", ["", "   "])
+    def test_empty_summary_rejects(self, summary: str) -> None:
+        with pytest.raises(PlanRejected) as excinfo:
+            _plan(summary=summary)
+        assert "summary" in excinfo.value.reason
+
+    def test_unencodable_summary_rejects(self) -> None:
+        # A lone surrogate is reachable from hosted JSON input; it must be
+        # a Tier-1 rejection, not an encode error inside payload composition.
+        with pytest.raises(PlanRejected) as excinfo:
+            _plan(summary="summary\ud800")
+        assert "UTF-8" in excinfo.value.reason
+
+    @pytest.mark.parametrize("summary", ["two\nlines", "carriage\rreturn"])
+    def test_multiline_summary_rejects(self, summary: str) -> None:
+        with pytest.raises(PlanRejected) as excinfo:
+            _plan(summary=summary)
+        assert "single line" in excinfo.value.reason
+
+    def test_over_length_summary_rejects(self) -> None:
+        with pytest.raises(PlanRejected) as excinfo:
+            _plan(summary="s" * (SUMMARY_CHAR_LIMIT + 1))
+        assert str(SUMMARY_CHAR_LIMIT) in excinfo.value.reason
+
+    def test_rejection_is_typed_value_error(self) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            _plan(slug="NOPE")
+        assert isinstance(excinfo.value, PlanRejected)
+        assert excinfo.value.reason

--- a/packages/nauro-core/tests/operations/test_update_stack.py
+++ b/packages/nauro-core/tests/operations/test_update_stack.py
@@ -1,0 +1,120 @@
+"""Kernel tests for the plan-returning ``update_stack`` operation."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from nauro_core.constants import STACK_DOC_CHAR_LIMIT, STACK_REVISION_ABSENT
+from nauro_core.operations.planning import PlanRejected, canonical_payload_bytes
+from nauro_core.operations.update_stack import (
+    UpdateStackPlan,
+    compute_stack_revision,
+    update_stack,
+)
+
+DOC = "# Stack\n- **Python 3.11** — primary language\n"
+
+
+class TestComputeStackRevision:
+    def test_lowercase_sha256_hex_of_exact_bytes(self) -> None:
+        content = DOC.encode("utf-8")
+        revision = compute_stack_revision(content)
+        assert revision == hashlib.sha256(content).hexdigest()
+        assert revision == revision.lower()
+        assert len(revision) == 64
+
+    def test_absent_token_for_missing_file(self) -> None:
+        assert compute_stack_revision(None) == STACK_REVISION_ABSENT
+
+    def test_byte_sensitivity(self) -> None:
+        # The revision digests exact bytes: a trailing newline changes it.
+        assert compute_stack_revision(b"# Stack") != compute_stack_revision(b"# Stack\n")
+
+
+class TestUpdateStackAccepts:
+    def test_returns_frozen_plan(self) -> None:
+        plan = update_stack(DOC)
+        assert isinstance(plan, UpdateStackPlan)
+        assert plan.operation == "update_stack"
+        assert plan.path == "stack.md"
+        assert plan.content == DOC
+        with pytest.raises(ValidationError):
+            plan.content = "changed"
+
+    def test_new_revision_is_content_digest(self) -> None:
+        plan = update_stack(DOC)
+        assert plan.new_revision == compute_stack_revision(DOC.encode("utf-8"))
+
+    def test_expected_revision_defaults_to_none(self) -> None:
+        assert update_stack(DOC).expected_revision is None
+
+    def test_expected_revision_hex_accepted_and_echoed(self) -> None:
+        revision = "ab" * 32
+        plan = update_stack(DOC, expected_revision=revision)
+        assert plan.expected_revision == revision
+
+    def test_expected_revision_absent_token_accepted(self) -> None:
+        plan = update_stack(DOC, expected_revision=STACK_REVISION_ABSENT)
+        assert plan.expected_revision == STACK_REVISION_ABSENT
+
+    def test_document_at_exact_cap_accepted(self) -> None:
+        plan = update_stack("x" * STACK_DOC_CHAR_LIMIT)
+        assert len(plan.content) == STACK_DOC_CHAR_LIMIT
+
+
+class TestUpdateStackPayloadBytes:
+    def test_canonical_json_shape(self) -> None:
+        plan = update_stack(DOC, expected_revision=STACK_REVISION_ABSENT)
+        assert plan.payload_bytes == canonical_payload_bytes(
+            {
+                "operation": "update_stack",
+                "content": DOC,
+                "expected_revision": STACK_REVISION_ABSENT,
+            }
+        )
+        decoded = json.loads(plan.payload_bytes)
+        assert list(decoded) == sorted(decoded)
+
+    def test_deterministic_across_calls(self) -> None:
+        assert update_stack(DOC).payload_bytes == update_stack(DOC).payload_bytes
+
+    def test_expected_revision_participates_in_payload_identity(self) -> None:
+        without = update_stack(DOC)
+        with_precondition = update_stack(DOC, expected_revision="ab" * 32)
+        assert without.payload_bytes != with_precondition.payload_bytes
+
+
+class TestUpdateStackRejects:
+    def test_nul_character_rejects(self) -> None:
+        with pytest.raises(PlanRejected) as excinfo:
+            update_stack("# Stack\n\x00\n")
+        assert "NUL" in excinfo.value.reason
+
+    def test_over_cap_rejects_naming_the_limit(self) -> None:
+        with pytest.raises(PlanRejected) as excinfo:
+            update_stack("x" * (STACK_DOC_CHAR_LIMIT + 1))
+        assert str(STACK_DOC_CHAR_LIMIT) in excinfo.value.reason
+
+    def test_unencodable_text_rejects(self) -> None:
+        with pytest.raises(PlanRejected) as excinfo:
+            update_stack("# Stack\n\ud800\n")
+        assert "UTF-8" in excinfo.value.reason
+
+    def test_malformed_expected_revision_rejects(self) -> None:
+        with pytest.raises(PlanRejected) as excinfo:
+            update_stack(DOC, expected_revision="not-a-revision")
+        assert "expected_revision" in excinfo.value.reason
+
+    def test_uppercase_expected_revision_rejects(self) -> None:
+        with pytest.raises(PlanRejected):
+            update_stack(DOC, expected_revision="AB" * 32)
+
+    def test_rejection_is_typed_value_error(self) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            update_stack(DOC, expected_revision="nope")
+        assert isinstance(excinfo.value, PlanRejected)
+        assert excinfo.value.reason

--- a/packages/nauro-core/tests/operations/test_workflow_results.py
+++ b/packages/nauro-core/tests/operations/test_workflow_results.py
@@ -1,0 +1,173 @@
+"""Kernel tests for the hosted typed-operation outcome models.
+
+The plan-returning operations (``update_stack``, ``share_context``) are
+executed by the hosted server; these models are the cross-surface outcome
+contract it returns. Pinned here because the shapes ship in nauro-core.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from nauro_core.operations.results import (
+    ShareContextAccepted,
+    SlugConflict,
+    StackRevisionConflict,
+    UpdateStackAccepted,
+    WorkflowExpired,
+    WorkflowInProgress,
+)
+
+REVISION = "ab" * 32
+ULID = "01KQ6AZGNA0B3QBF67NBXP3S45"
+
+
+def _update_stack_accepted() -> UpdateStackAccepted:
+    return UpdateStackAccepted(
+        stack_revision=REVISION,
+        previous_revision="absent",
+        receipt_id=ULID,
+        event_id=ULID,
+    )
+
+
+def _share_context_accepted() -> ShareContextAccepted:
+    return ShareContextAccepted(
+        path="context/auth-cutover.md",
+        question_id="Q12",
+        event_id=ULID,
+        content_digest=REVISION,
+        receipt_id=ULID,
+    )
+
+
+class TestUpdateStackAccepted:
+    def test_dump_shape(self) -> None:
+        assert _update_stack_accepted().model_dump(mode="json") == {
+            "status": "ok",
+            "stack_revision": REVISION,
+            "previous_revision": "absent",
+            "receipt_id": ULID,
+            "event_id": ULID,
+        }
+
+    def test_status_is_fixed(self) -> None:
+        with pytest.raises(ValidationError):
+            UpdateStackAccepted(
+                status="accepted",
+                stack_revision=REVISION,
+                previous_revision="absent",
+                receipt_id=ULID,
+                event_id=ULID,
+            )
+
+    def test_frozen_and_closed(self) -> None:
+        result = _update_stack_accepted()
+        with pytest.raises(ValidationError):
+            result.stack_revision = "0" * 64
+        with pytest.raises(ValidationError):
+            UpdateStackAccepted(
+                stack_revision=REVISION,
+                previous_revision="absent",
+                receipt_id=ULID,
+                event_id=ULID,
+                unexpected_field="value",
+            )
+
+
+class TestStackRevisionConflict:
+    def test_dump_shape(self) -> None:
+        conflict = StackRevisionConflict(
+            expected_revision=REVISION,
+            current_revision="absent",
+        )
+        assert conflict.model_dump(mode="json") == {
+            "status": "stale_revision",
+            "expected_revision": REVISION,
+            "current_revision": "absent",
+        }
+
+    def test_frozen_and_closed(self) -> None:
+        conflict = StackRevisionConflict(
+            expected_revision=REVISION,
+            current_revision="0" * 64,
+        )
+        with pytest.raises(ValidationError):
+            conflict.current_revision = "absent"
+        with pytest.raises(ValidationError):
+            StackRevisionConflict(
+                expected_revision=REVISION,
+                current_revision="absent",
+                unexpected_field="value",
+            )
+
+
+class TestShareContextAccepted:
+    def test_dump_shape(self) -> None:
+        assert _share_context_accepted().model_dump(mode="json") == {
+            "status": "ok",
+            "path": "context/auth-cutover.md",
+            "question_id": "Q12",
+            "event_id": ULID,
+            "content_digest": REVISION,
+            "receipt_id": ULID,
+        }
+
+    def test_frozen_and_closed(self) -> None:
+        result = _share_context_accepted()
+        with pytest.raises(ValidationError):
+            result.path = "context/other.md"
+        with pytest.raises(ValidationError):
+            ShareContextAccepted(
+                path="context/x.md",
+                question_id="Q1",
+                event_id=ULID,
+                content_digest=REVISION,
+                receipt_id=ULID,
+                unexpected_field="value",
+            )
+
+
+class TestSlugConflict:
+    def test_dump_shape(self) -> None:
+        conflict = SlugConflict(slug="auth-cutover", suggested_slug="auth-cutover-2")
+        assert conflict.model_dump(mode="json") == {
+            "status": "slug_conflict",
+            "slug": "auth-cutover",
+            "suggested_slug": "auth-cutover-2",
+        }
+
+    def test_frozen_and_closed(self) -> None:
+        conflict = SlugConflict(slug="a", suggested_slug="a-2")
+        with pytest.raises(ValidationError):
+            conflict.slug = "b"
+        with pytest.raises(ValidationError):
+            SlugConflict(slug="a", suggested_slug="a-2", unexpected_field="value")
+
+
+class TestWorkflowOutcomes:
+    def test_expired_dump_shape(self) -> None:
+        assert WorkflowExpired(operation_id="op-1").model_dump(mode="json") == {
+            "status": "expired",
+            "operation_id": "op-1",
+        }
+
+    def test_in_progress_dump_shape(self) -> None:
+        assert WorkflowInProgress(operation_id="op-1").model_dump(mode="json") == {
+            "status": "in_progress",
+            "operation_id": "op-1",
+        }
+
+    @pytest.mark.parametrize("model", [WorkflowExpired, WorkflowInProgress])
+    def test_frozen_and_closed(self, model) -> None:
+        result = model(operation_id="op-1")
+        with pytest.raises(ValidationError):
+            result.operation_id = "op-2"
+        with pytest.raises(ValidationError):
+            model(operation_id="op-1", unexpected_field="value")
+
+    @pytest.mark.parametrize("model", [WorkflowExpired, WorkflowInProgress])
+    def test_operation_id_is_required(self, model) -> None:
+        with pytest.raises(ValidationError):
+            model()

--- a/packages/nauro-core/tests/test_context.py
+++ b/packages/nauro-core/tests/test_context.py
@@ -3,7 +3,13 @@
 from datetime import date as _date
 from datetime import datetime, timedelta, timezone
 
-from nauro_core.constants import PROJECT_MD_SCAFFOLD_BODY, QUESTION_ENTRY_CHAR_BUDGET
+from nauro_core.constants import (
+    PROJECT_MD_SCAFFOLD_BODY,
+    QUESTION_ENTRY_CHAR_BUDGET,
+    STACK_AUTO_CHAR_BUDGET,
+    STACK_AUTO_ITEM_CHAR_LIMIT,
+    STACK_NON_AUTHORITATIVE_FRAMING,
+)
 from nauro_core.context import build_l0, build_l1, build_l2
 from nauro_core.decision_model import (
     Decision,
@@ -222,9 +228,17 @@ class TestBuildL1:
         decisions_pos = result.find("## Decisions")
         assert project_pos < state_pos < stack_pos < questions_pos < decisions_pos
 
-    def test_full_stack_included(self):
+    def test_stack_is_bounded_projection(self):
+        # Intentional contract change: L1 carries the bounded stack
+        # projection, not the verbatim file. Headings and first-level list
+        # items render; the nested rationale line drops out; the framing
+        # line opens the block.
         result = build_l1(FULL_FILES, DECISIONS)
-        assert "Chose over Go for ecosystem" in result
+        assert "# Stack" in result
+        assert "- **Python 3.11+** — main language" in result
+        assert "- **AWS Lambda** — serverless" in result
+        assert "Chose over Go for ecosystem" not in result
+        assert STACK_NON_AUTHORITATIVE_FRAMING in result
 
     def test_questions_projection_renders_all_under_cap(self):
         # Six genuine open entries against a cap of 10: the projection
@@ -338,14 +352,22 @@ class TestBuildL2:
 
     def test_superset_of_l1(self):
         # Every project/stack/questions string L1 surfaces must also appear in
-        # the full dump, and L2 must additionally carry superseded decisions.
+        # the full dump, and L2 must additionally carry superseded decisions
+        # and the nested stack rationale L1's bounded projection drops.
         # L1's omission trailer and age-nudge lines are projection annotations,
         # not store content, so they are absent from L2 (same as L0's today).
         l1 = build_l1(FULL_FILES, DECISIONS)
         l2 = build_l2(FULL_FILES, DECISIONS)
-        for marker in ("# MyProject", "Chose over Go for ecosystem", "Sixth question?"):
+        for marker in (
+            "# MyProject",
+            "- **Python 3.11+** — main language",
+            "Sixth question?",
+            STACK_NON_AUTHORITATIVE_FRAMING,
+        ):
             assert marker in l1 and marker in l2
         assert "Old choice" in l2 and "Old choice" not in l1
+        assert "Chose over Go for ecosystem" in l2
+        assert "Chose over Go for ecosystem" not in l1
 
     def test_missing_project_md(self):
         files = {k: v for k, v in FULL_FILES.items() if k != "project.md"}
@@ -792,3 +814,294 @@ class TestQuestionEntryCharBudget:
         result = build_l1(self._files(content), [])
         assert "(+2 more open questions" in result
         assert QUESTION_TRUNCATION_POINTER not in result
+
+
+class TestBuildL1StackProjection:
+    """L1 renders a deterministic bounded projection of stack.md.
+
+    The walk keeps top-level headings and first-level list items — ordered
+    and unordered — outside fenced code blocks (nonblank paragraphs for a
+    file with neither), truncates overlong items at
+    STACK_AUTO_ITEM_CHAR_LIMIT retained characters with an explicit marker,
+    and stops before rendering more than STACK_AUTO_ITEM_LIMIT items or
+    letting the joined projection body (items plus inter-item separators)
+    exceed STACK_AUTO_CHAR_BUDGET. The block opens with the
+    non-authoritative framing line and, when items were omitted, closes
+    with the exact omitted count and the get_raw_file route.
+    """
+
+    _TRUNCATION_MARKER = '... [item truncated - full text: get_raw_file("stack.md")]'
+
+    def _files(self, stack: str) -> dict[str, str]:
+        return {"stack.md": stack}
+
+    def _stack_block(self, result: str) -> str:
+        """The projection block: from the framing line to the next blank-line
+        section break (or end of payload)."""
+        start = result.index(STACK_NON_AUTHORITATIVE_FRAMING)
+        end = result.find("\n\n", start)
+        return result[start:] if end == -1 else result[start:end]
+
+    def _projection_body(self, result: str) -> str:
+        """The budget-bounded body: the block minus the framing line and
+        any omitted-count trailer (both are annotations outside the
+        budget)."""
+        lines = self._stack_block(result).split("\n")
+        assert lines[0] == STACK_NON_AUTHORITATIVE_FRAMING
+        if lines[-1].startswith("(+"):
+            lines = lines[:-1]
+        return "\n".join(lines[1:])
+
+    def test_framing_line_opens_the_block(self):
+        result = build_l1(self._files("# Stack\n- **Python** — language\n"), [])
+        block = self._stack_block(result)
+        assert block.startswith(STACK_NON_AUTHORITATIVE_FRAMING)
+        assert "- **Python** — language" in block
+
+    def test_item_limit_stops_the_walk_with_exact_omitted_count(self):
+        # 1 heading + 25 items = 26 items against a cap of 20: the first 19
+        # items follow the heading, and the trailer names exactly 6 omitted.
+        stack = "# Stack\n" + "".join(f"- item {i}\n" for i in range(1, 26))
+        result = build_l1(self._files(stack), [])
+        assert "- item 19" in result
+        assert "- item 20" not in result
+        assert "- item 25" not in result
+        assert '(+6 more stack items — see get_raw_file("stack.md") for the full file)' in result
+
+    def test_no_trailer_when_nothing_omitted(self):
+        stack = "# Stack\n- one\n- two\n"
+        result = build_l1(self._files(stack), [])
+        assert "more stack items" not in result
+
+    def test_overlong_item_truncated_with_marker(self):
+        long_item = "- **Kafka** — " + "detail " * 100
+        stack = f"# Stack\n{long_item.rstrip()}\n- short item\n"
+        result = build_l1(self._files(stack), [])
+        assert self._TRUNCATION_MARKER in result
+        assert "- **Kafka**" in result
+        assert "- short item" in result
+        line = next(line for line in result.split("\n") if line.startswith("- **Kafka**"))
+        assert len(line) <= STACK_AUTO_ITEM_CHAR_LIMIT + 1 + len(self._TRUNCATION_MARKER)
+
+    def test_under_limit_item_renders_byte_unchanged(self):
+        item = "- **Postgres** — primary store"
+        result = build_l1(self._files(f"# Stack\n{item}\n"), [])
+        assert item in result
+        assert self._TRUNCATION_MARKER not in result
+
+    def test_aggregate_budget_bounds_the_joined_body(self):
+        # Eight 280-char items never trip the per-item limit, but the
+        # joined body (heading + items + one separator newline per
+        # boundary) would pass 2,000 at the eighth, so the walk stops
+        # after seven and counts the last one omitted. The emitted body is
+        # provably within the budget.
+        items = ["- " + f"i{i} " + "x" * 275 for i in range(8)]
+        assert all(len(item) == 280 for item in items)
+        stack = "# Stack\n" + "\n".join(items) + "\n"
+        result = build_l1(self._files(stack), [])
+        assert "i6 " in result
+        assert "i7 " not in result
+        assert '(+1 more stack items — see get_raw_file("stack.md") for the full file)' in result
+        assert len(self._projection_body(result)) <= STACK_AUTO_CHAR_BUDGET
+
+    def test_separator_cost_counts_toward_the_budget(self):
+        # Twenty exactly-100-char items sum to 2,000 alone, but the 19
+        # separator newlines put the joined body over budget, so the
+        # twentieth stops the walk. A counter ignoring separators would
+        # render all twenty and emit 2,019 characters.
+        items = [f"- i{i:02d} " + "x" * 94 for i in range(20)]
+        assert all(len(item) == 100 for item in items)
+        stack = "\n".join(items) + "\n"
+        result = build_l1(self._files(stack), [])
+        assert "- i18 " in result
+        assert "- i19 " not in result
+        assert '(+1 more stack items — see get_raw_file("stack.md") for the full file)' in result
+        assert len(self._projection_body(result)) <= STACK_AUTO_CHAR_BUDGET
+
+    def test_nested_list_items_excluded(self):
+        stack = (
+            "# Stack\n"
+            "- **Python 3.11** — main language\n"
+            "  - Chose over Go for ecosystem\n"
+            "    - even deeper rationale\n"
+            "- **AWS Lambda** — serverless\n"
+        )
+        result = build_l1(self._files(stack), [])
+        assert "- **Python 3.11** — main language" in result
+        assert "- **AWS Lambda** — serverless" in result
+        assert "Chose over Go" not in result
+        assert "even deeper rationale" not in result
+
+    def test_ordered_list_items_are_items(self):
+        stack = "# Stack\n1. Python\n2. Postgres\n"
+        result = build_l1(self._files(stack), [])
+        assert "1. Python" in result
+        assert "2. Postgres" in result
+        assert "more stack items" not in result
+
+    def test_paren_ordered_marker_recognized(self):
+        result = build_l1(self._files("# Stack\n1) Python\n"), [])
+        assert "1) Python" in result
+
+    def test_ordered_items_consume_limit_and_report_omitted(self):
+        # Heading + 25 ordered items against the 20-item cap: 19 items
+        # follow the heading and the trailer names exactly 6 omitted.
+        stack = "# Stack\n" + "".join(f"{i}. item {i}\n" for i in range(1, 26))
+        result = build_l1(self._files(stack), [])
+        assert "19. item 19" in result
+        assert "20. item 20" not in result
+        assert '(+6 more stack items — see get_raw_file("stack.md") for the full file)' in result
+
+    def test_overlong_ordered_item_truncated_with_marker(self):
+        stack = "# Stack\n1. " + "detail " * 100 + "\n"
+        result = build_l1(self._files(stack), [])
+        assert self._TRUNCATION_MARKER in result
+        assert "1. detail" in result
+
+    def test_indented_ordered_item_excluded(self):
+        stack = "# Stack\n1. top level\n   1. nested rationale\n"
+        result = build_l1(self._files(stack), [])
+        assert "1. top level" in result
+        assert "nested rationale" not in result
+
+    def test_ten_digit_marker_is_not_a_list_item(self):
+        stack = "# Stack\n1234567890. not a list item\n"
+        result = build_l1(self._files(stack), [])
+        assert "not a list item" not in result
+
+    def test_fenced_code_lines_are_not_items(self):
+        stack = "# Stack\n```bash\n# not a heading\n- not a bullet\n```\n- real item\n"
+        result = build_l1(self._files(stack), [])
+        assert "- real item" in result
+        assert "# not a heading" not in result
+        assert "- not a bullet" not in result
+        assert "more stack items" not in result
+
+    def test_fake_items_inside_fence_do_not_consume_budgets(self):
+        # 25 heading-looking lines inside a fence: none are items, so the
+        # real item after the fence renders and no omitted count appears.
+        fake = "".join(f"# fake heading {i}\n" for i in range(25))
+        stack = "# Stack\n```\n" + fake + "```\n- real item\n"
+        result = build_l1(self._files(stack), [])
+        assert "- real item" in result
+        assert "fake heading" not in result
+        assert "more stack items" not in result
+
+    def test_shorter_fence_of_same_char_does_not_close(self):
+        # A closer must be a matching-or-longer run of the same character:
+        # the inner ``` cannot close the ```` fence.
+        stack = "# Stack\n````\n```\n- still inside\n````\n- outside\n"
+        result = build_l1(self._files(stack), [])
+        assert "- outside" in result
+        assert "- still inside" not in result
+
+    def test_mismatched_fence_char_does_not_close(self):
+        stack = "# Stack\n```\n~~~\n- still inside\n```\n- outside\n"
+        result = build_l1(self._files(stack), [])
+        assert "- outside" in result
+        assert "- still inside" not in result
+
+    def test_tilde_fence_lines_excluded(self):
+        stack = "# Stack\n~~~\n- fake\n~~~\n- real\n"
+        result = build_l1(self._files(stack), [])
+        assert "- real" in result
+        assert "- fake" not in result
+
+    def test_unclosed_fence_runs_to_end_of_file(self):
+        stack = "# Stack\n- real\n```\n- fake\n# also fake\n"
+        result = build_l1(self._files(stack), [])
+        assert "- real" in result
+        assert "- fake" not in result
+        assert "also fake" not in result
+
+    def test_backtick_in_backtick_info_string_does_not_open_a_fence(self):
+        # CommonMark forbids backticks in a backtick fence's info string:
+        # the line is ordinary text, so the following items stay items.
+        stack = "# Stack\n```py`bad\n- real item\n"
+        result = build_l1(self._files(stack), [])
+        assert "- real item" in result
+
+    def test_backtick_in_tilde_info_string_still_opens_a_fence(self):
+        # Tilde fences legitimately allow backticks in their info string.
+        stack = "# Stack\n~~~py`ok\n- fake\n~~~\n- real\n"
+        result = build_l1(self._files(stack), [])
+        assert "- real" in result
+        assert "- fake" not in result
+
+    def test_entirely_fenced_file_renders_framing_only(self):
+        result = build_l1(self._files("```\ncode only\n```\n"), [])
+        assert STACK_NON_AUTHORITATIVE_FRAMING in result
+        assert "code only" not in result
+
+    def test_paragraphs_do_not_merge_across_an_elided_fence(self):
+        # Unstructured mode: the fence drops out but leaves a paragraph
+        # break, so the surrounding prose stays two items.
+        stack = "First paragraph.\n```\ncode\n```\nSecond paragraph.\n"
+        result = build_l1(self._files(stack), [])
+        assert "First paragraph." in result
+        assert "Second paragraph." in result
+        assert "First paragraph.\nSecond paragraph." not in result
+        assert "code" not in result
+
+    def test_loose_prose_excluded_from_structured_file(self):
+        stack = "# Stack\n\nSome loose prose about the stack.\n\n- **Python** — language\n"
+        result = build_l1(self._files(stack), [])
+        assert "- **Python** — language" in result
+        assert "Some loose prose" not in result
+
+    def test_unstructured_file_walks_nonblank_paragraphs(self):
+        stack = (
+            "We run Python on Lambda.\n"
+            "The gateway fronts it.\n"
+            "\n"
+            "Postgres holds the primary data.\n"
+        )
+        result = build_l1(self._files(stack), [])
+        assert "We run Python on Lambda.\nThe gateway fronts it." in result
+        assert "Postgres holds the primary data." in result
+
+    def test_unstructured_paragraphs_respect_item_limit(self):
+        paragraphs = "\n\n".join(f"Paragraph number {i} prose." for i in range(1, 24))
+        result = build_l1(self._files(paragraphs), [])
+        assert "Paragraph number 20 prose." in result
+        assert "Paragraph number 21 prose." not in result
+        assert '(+3 more stack items — see get_raw_file("stack.md") for the full file)' in result
+
+    def test_l0_oneliner_untouched_by_projection(self):
+        # The L0 stack surface stays the one-line extraction — no framing,
+        # no projection annotations. Pinned so the generated AGENTS.md
+        # bytes cannot drift.
+        files = {
+            "stack.md": (
+                "# Stack\n"
+                "## Language\n"
+                "- **Python 3.11+** — main language\n"
+                "## Infrastructure\n"
+                "- **AWS Lambda** — serverless\n"
+            )
+        }
+        result = build_l0(files, [])
+        assert "**Stack:** Python 3.11+, AWS Lambda" in result
+        assert STACK_NON_AUTHORITATIVE_FRAMING not in result
+        assert "more stack items" not in result
+
+
+class TestL2StackFraming:
+    """L2 keeps the complete stack.md body, framed as non-authoritative."""
+
+    def test_framing_line_precedes_verbatim_body(self):
+        result = build_l2(FULL_FILES, DECISIONS)
+        assert STACK_NON_AUTHORITATIVE_FRAMING in result
+        assert result.index(STACK_NON_AUTHORITATIVE_FRAMING) < result.index("# Stack")
+        # The body itself stays verbatim, nested rationale included.
+        assert "Chose over Go for ecosystem" in result
+
+    def test_no_projection_annotations_at_l2(self):
+        stack = "# Stack\n" + "".join(f"- item {i}\n" for i in range(1, 30))
+        result = build_l2({"stack.md": stack}, [])
+        assert "- item 29" in result
+        assert "more stack items" not in result
+
+    def test_no_framing_without_stack_file(self):
+        result = build_l2({"project.md": "# P\n\nGoal.\n"}, [])
+        assert STACK_NON_AUTHORITATIVE_FRAMING not in result

--- a/packages/nauro-core/tests/test_context.py
+++ b/packages/nauro-core/tests/test_context.py
@@ -932,6 +932,37 @@ class TestBuildL1StackProjection:
         assert "Chose over Go" not in result
         assert "even deeper rationale" not in result
 
+    def test_hash_tag_line_does_not_trigger_structured_mode(self):
+        # A prose file with a hash-tag word is not structured: the real
+        # paragraphs must survive the walk instead of being discarded.
+        stack = "We use #python on the backend.\n\n#TODO revisit the queue choice.\n"
+        result = build_l1(self._files(stack), [])
+        assert "We use #python on the backend." in result
+        assert "#TODO revisit the queue choice." in result
+
+    def test_hashes_without_following_space_are_not_headings(self):
+        stack = "##foo prose line.\n\n#######x seven hashes prose.\n"
+        result = build_l1(self._files(stack), [])
+        assert "##foo prose line." in result
+        assert "#######x seven hashes prose." in result
+
+    def test_bare_hash_runs_are_headings(self):
+        # "#" and "######" alone are valid ATX headings and stay items;
+        # the same predicate drives structured-mode detection and item
+        # classification, so both render.
+        stack = "#\n- item one\n######\n- item two\n"
+        result = build_l1(self._files(stack), [])
+        body_lines = self._projection_body(result).split("\n")
+        assert body_lines == ["#", "- item one", "######", "- item two"]
+
+    def test_seven_hash_heading_is_prose_not_an_item(self):
+        # Seven hashes exceed the ATX marker bound even with a space, so
+        # the line is neither a heading item nor a structured trigger.
+        stack = "# Stack\n####### not a heading\n- real item\n"
+        result = build_l1(self._files(stack), [])
+        assert "- real item" in result
+        assert "not a heading" not in result
+
     def test_ordered_list_items_are_items(self):
         stack = "# Stack\n1. Python\n2. Postgres\n"
         result = build_l1(self._files(stack), [])

--- a/packages/nauro-core/tests/test_hosted_tools.py
+++ b/packages/nauro-core/tests/test_hosted_tools.py
@@ -1,0 +1,102 @@
+"""Tests for the hosted-only tool specs and the HOSTED_TOOLS registry.
+
+``update_stack`` and ``share_context`` ship as submodule-public specs for
+the hosted HTTP server only: ALL_TOOLS, the stdio registration, the CLI
+autogen allowlist, and the public contract snapshot must not move. The
+zero-drift pins live in ``test_mcp_tools.py`` (the 11-tool registry) and
+the ``packages/nauro`` contract suites; these tests cover the additive
+hosted surface.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nauro_core.mcp_tools import (
+    ALL_TOOLS,
+    HOSTED_TOOLS,
+    SHARE_CONTEXT,
+    UPDATE_STACK,
+    get_tool_spec,
+)
+
+HOSTED_ONLY = (UPDATE_STACK, SHARE_CONTEXT)
+
+
+class TestHostedRegistry:
+    def test_hosted_tools_is_all_tools_plus_the_two_typed_operations(self) -> None:
+        assert (*ALL_TOOLS, UPDATE_STACK, SHARE_CONTEXT) == HOSTED_TOOLS
+
+    def test_hosted_only_specs_absent_from_all_tools(self) -> None:
+        names = {spec["name"] for spec in ALL_TOOLS}
+        assert "update_stack" not in names
+        assert "share_context" not in names
+
+    def test_unique_names_across_hosted_registry(self) -> None:
+        names = [spec["name"] for spec in HOSTED_TOOLS]
+        assert len(names) == len(set(names))
+
+    def test_get_tool_spec_stays_scoped_to_all_tools(self) -> None:
+        # The lookup serves the local surfaces; hosted-only specs are
+        # reached by direct import until they enter ALL_TOOLS.
+        with pytest.raises(KeyError):
+            get_tool_spec("update_stack")
+        with pytest.raises(KeyError):
+            get_tool_spec("share_context")
+
+
+class TestHostedSpecShape:
+    @pytest.mark.parametrize("spec", HOSTED_ONLY, ids=lambda s: s["name"])
+    def test_required_fields(self, spec) -> None:
+        assert spec["name"]
+        assert spec["title"]
+        assert spec["description"]
+        assert spec["annotations"]
+        assert spec["input_schema"]["type"] == "object"
+
+    @pytest.mark.parametrize("spec", HOSTED_ONLY, ids=lambda s: s["name"])
+    def test_write_annotations(self, spec) -> None:
+        assert spec["annotations"]["readOnlyHint"] is False
+        assert spec["annotations"]["destructiveHint"] is False
+        assert spec["annotations"]["openWorldHint"] is False
+        assert spec["annotations"]["idempotentHint"] is False
+
+    @pytest.mark.parametrize("spec", HOSTED_ONLY, ids=lambda s: s["name"])
+    def test_project_id_optional(self, spec) -> None:
+        schema = spec["input_schema"]
+        assert "project_id" in schema["properties"]
+        assert "project_id" not in schema["required"]
+
+    @pytest.mark.parametrize("spec", HOSTED_ONLY, ids=lambda s: s["name"])
+    def test_operation_id_schema_optional_with_hosted_required_description(self, spec) -> None:
+        # Schema-optional so local adapters can generate one; the
+        # description carries the hosted-required contract.
+        schema = spec["input_schema"]
+        assert "operation_id" in schema["properties"]
+        assert "operation_id" not in schema["required"]
+        description = schema["properties"]["operation_id"]["description"]
+        assert "Required on the hosted HTTP surface" in description
+
+
+class TestUpdateStackSpec:
+    def test_content_is_the_sole_required_property(self) -> None:
+        assert UPDATE_STACK["input_schema"]["required"] == ["content"]
+
+    def test_expected_revision_is_optional_string(self) -> None:
+        prop = UPDATE_STACK["input_schema"]["properties"]["expected_revision"]
+        assert prop["type"] == "string"
+        assert "absent" in prop["description"]
+
+
+class TestShareContextSpec:
+    def test_required_properties(self) -> None:
+        assert SHARE_CONTEXT["input_schema"]["required"] == [
+            "slug",
+            "content",
+            "pointer_kind",
+            "summary",
+        ]
+
+    def test_pointer_kind_enum_matches_kernel_vocabulary(self) -> None:
+        prop = SHARE_CONTEXT["input_schema"]["properties"]["pointer_kind"]
+        assert prop["enum"] == ["brief", "resume", "selection"]

--- a/packages/nauro-core/tests/test_identifiers.py
+++ b/packages/nauro-core/tests/test_identifiers.py
@@ -19,6 +19,8 @@ VALID_BY_KIND = {
     IdentifierKind.operation_id: "op-1",
     IdentifierKind.server_token: "update_stack",
     IdentifierKind.audit_target_id: "target-1",
+    IdentifierKind.brief_slug: "auth-cutover-2",
+    IdentifierKind.stack_revision: "0" * 64,
 }
 
 
@@ -135,6 +137,82 @@ class TestServerToken:
 
     def test_rejects_non_str(self) -> None:
         assert not is_identifier(IdentifierKind.server_token, None)
+
+
+class TestBriefSlug:
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "a",
+            "1",
+            "auth-cutover-2",
+            "a-b",
+            "a--b",
+            "a" * 120,
+            "a" + "-" * 118 + "b",
+        ],
+    )
+    def test_accepts(self, value: str) -> None:
+        assert is_identifier(IdentifierKind.brief_slug, value)
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "",
+            "-",
+            "-a",
+            "a-",
+            "-a-",
+            "A",
+            "Auth-Cutover",
+            "a_b",
+            "a b",
+            "a.b",
+            "a/b",
+            "café",
+            "a" * 121,
+        ],
+    )
+    def test_rejects(self, value: str) -> None:
+        assert not is_identifier(IdentifierKind.brief_slug, value)
+
+    def test_rejects_non_str(self) -> None:
+        assert not is_identifier(IdentifierKind.brief_slug, None)
+
+
+class TestStackRevision:
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "0" * 64,
+            "f" * 64,
+            "0123456789abcdef" * 4,
+            "absent",
+        ],
+    )
+    def test_accepts(self, value: str) -> None:
+        assert is_identifier(IdentifierKind.stack_revision, value)
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "",
+            "0" * 63,
+            "0" * 65,
+            "A" * 64,
+            "0123456789ABCDEF" * 4,
+            "g" * 64,
+            "ABSENT",
+            "Absent",
+            "absent ",
+            "present",
+        ],
+    )
+    def test_rejects(self, value: str) -> None:
+        assert not is_identifier(IdentifierKind.stack_revision, value)
+
+    def test_rejects_non_str(self) -> None:
+        assert not is_identifier(IdentifierKind.stack_revision, None)
 
 
 class TestTrailingNewline:

--- a/packages/nauro-core/tests/test_question_append.py
+++ b/packages/nauro-core/tests/test_question_append.py
@@ -1,0 +1,74 @@
+"""Tests for nauro_core.question_append — the shared entry composer.
+
+``flag_question`` and the hosted shared-context workflow both enter new
+``open-questions.md`` entries through these helpers; the parity pins in
+``tests/operations/test_operations_flag_question.py`` cover the wired
+behavior, these pin the helpers' own contract.
+"""
+
+from __future__ import annotations
+
+from nauro_core.question_append import (
+    allocate_question_number,
+    compose_question_entry,
+    insert_question_entry,
+)
+from nauro_core.questions import OpenQuestionsFile
+
+
+class TestAllocateQuestionNumber:
+    def test_empty_file_allocates_one(self) -> None:
+        parsed = OpenQuestionsFile.parse("# Open Questions\n")
+        assert allocate_question_number(parsed) == 1
+
+    def test_next_after_highest_existing(self) -> None:
+        content = "# Open Questions\n- [Q3] Three?\n- [Q7] Seven?\n- [Q2] Two?\n"
+        parsed = OpenQuestionsFile.parse(content)
+        assert allocate_question_number(parsed) == 8
+
+    def test_resolved_entries_still_reserve_their_numbers(self) -> None:
+        # A resolved Q keeps its number reserved: allocation counts every
+        # numbered entry in the file, resolved history included.
+        content = (
+            "# Open Questions\n"
+            "- [Q1] Open one?\n"
+            "\n"
+            "## Resolved\n"
+            "\n"
+            "- [Resolved by D9 on 2026-05-01] [Q5] Done?\n"
+        )
+        parsed = OpenQuestionsFile.parse(content)
+        assert allocate_question_number(parsed) == 6
+
+    def test_legacy_timestamp_entries_do_not_number(self) -> None:
+        content = "# Open Questions\n- [2026-05-01 12:00 UTC] Legacy form?\n"
+        parsed = OpenQuestionsFile.parse(content)
+        assert allocate_question_number(parsed) == 1
+
+
+class TestComposeQuestionEntry:
+    def test_canonical_line_form(self) -> None:
+        assert compose_question_entry(12, "Should we cache?") == "- [Q12] Should we cache?"
+
+    def test_pointer_body_composes_identically(self) -> None:
+        body = "BRIEF: context/auth-cutover.md - the auth cutover plan"
+        assert compose_question_entry(3, body) == f"- [Q3] {body}"
+
+
+class TestInsertQuestionEntry:
+    def test_inserts_directly_after_header(self) -> None:
+        content = "# Open Questions\n- [Q1] First?\n"
+        result = insert_question_entry(content, "- [Q2] Second?")
+        assert result == "# Open Questions\n- [Q2] Second?\n- [Q1] First?\n"
+
+    def test_skips_blank_lines_and_leading_comment(self) -> None:
+        content = "# Open Questions\n\n<!-- guidance comment -->\n- [Q1] First?\n"
+        result = insert_question_entry(content, "- [Q2] Second?")
+        assert result == (
+            "# Open Questions\n\n<!-- guidance comment -->\n- [Q2] Second?\n- [Q1] First?\n"
+        )
+
+    def test_headerless_file_inserts_at_second_line(self) -> None:
+        content = "no header here\nbody line\n"
+        result = insert_question_entry(content, "- [Q1] First?")
+        assert result == "no header here\n- [Q1] First?\nbody line\n"


### PR DESCRIPTION
## Why

The hosted server is gaining two typed write operations: full-document stack
curation and the shared-context brief carrier. Under the kernel/server
division, the kernel validates and deterministically plans while the server
owns observation and storage execution — so the validators, frozen plan
models, outcome shapes, and tool specs land here first, ahead of the server
work that consumes them from the released package. The stack curation
contract also owes the read side a bounded L1 rendering, so automatic
context stays independent of stack file growth, plus a non-authoritative
frame: stack prose reports inventory, it does not establish judgment.

## What changed

- **Bounded L1 stack projection** (`context.py`): replaces the verbatim
  stack.md embed with a deterministic walk — top-level headings and
  first-level list items, ordered and unordered, with fenced code blocks
  excluded from item detection (nonblank paragraphs for unstructured
  files) — per-item truncation at 300 retained chars with an explicit
  marker, a 20-item cap and a 2,000-char stop-before-budget on the joined
  body (items plus separators), an exact omitted count, and the
  `get_raw_file("stack.md")` route. The block opens with the
  non-authoritative framing line; L2 carries the same frame above the
  verbatim body. L0's one-line extraction and generated AGENTS.md are
  byte-identical.
- **Plan-returning kernel ops** (`operations/update_stack.py`,
  `operations/share_context.py`, shared plumbing in
  `operations/planning.py`): a documented second convention beside the
  Store-writing ops — the kernel returns frozen plans with digest/absence
  preconditions and canonical JSON payload bytes; storage tokens like S3
  ETags never enter the kernel. Tier-1 failures raise a typed rejection.
- **Validators** (`identifiers.py`): `brief_slug` (1–120 lowercase
  letters/digits, internal hyphens) and `stack_revision` (64-hex or the
  absent token), following the existing shape-kind pattern.
- **Shared question composer** (`question_append.py`): the
  allocate/compose/insert logic extracted from `flag_question`
  behavior-preservingly (parity suites pass unchanged), so the hosted
  pointer writer enters entries identically. The canonical pointer writer
  uses the ASCII " - " separator; readers keep accepting the deployed
  em-dash form.
- **Outcome models** (`operations/results.py`): the six hosted
  typed-operation shapes (accepted ×2, stale_revision, slug_conflict,
  expired, in_progress).
- **Tool registry** (`mcp_tools.py`): `UPDATE_STACK` and `SHARE_CONTEXT`
  specs plus `HOSTED_TOOLS = ALL_TOOLS + (UPDATE_STACK, SHARE_CONTEXT)`,
  submodule-public only. `operation_id` is schema-optional with a
  hosted-required description.

## Test plan

- `uv run --no-sync pytest packages/nauro-core/tests/ -q` — 1471 passed
  (new: projection boundary tests covering fences, ordered markers, and
  budget/separator accounting; validator shapes; plan-op
  accept/reject/digest determinism; outcome models; hosted registry)
- `uv run --no-sync pytest packages/nauro/tests/ -q` — 2251 passed,
  10 skipped, with zero diff to the package: the 11-tool registry pin,
  autogen allowlist, public contract snapshot, and L0 byte-parity all pass
  unchanged — their unchanged passing is the zero-drift check
- `ruff check` / `ruff format --check` clean

## Risk / what to review

- The L1 stack section is an intentional payload change (two context tests
  rewritten deliberately); L0 and AGENTS.md bytes are pinned unmoved.
- `flag_question`'s append path was refactored onto the shared composer —
  behavior-preserving by test, worth a read for byte-exactness.
- ALL_TOOLS, stdio registration, and the top-level public API are
  deliberately untouched; the new specs are reachable only by direct
  import until the local adapters ship.

## Deferred

The server-side consumers (workflow, authz, handlers) follow in the
mcp-server repo once this ships as a released package floor.
