### PR TITLE
Release nauro-core 1.10.0

### DIFF
--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro-core"
-version = "1.9.0"
+version = "1.10.0"
 description = "Shared pure-Python logic for Nauro: parsing, validation, context assembly, constants."
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -970,7 +970,7 @@ provides-extras = ["dev", "embeddings"]
 
 [[package]]
 name = "nauro-core"
-version = "1.9.0"
+version = "1.10.0"
 source = { editable = "packages/nauro-core" }
 dependencies = [
     { name = "bm25s" },


### PR DESCRIPTION
## Version moves

- **nauro-core: 1.9.0 → 1.10.0** (minor)
- nauro: not releasing (no shippable changes since 1.13.0)
- server.json: untouched (version-locked to the nauro package, which is not releasing)

## What ships in nauro-core 1.10.0

One change set since 1.9.0 (#411): the kernel side of the hosted typed write operations.

- Plan-returning kernel operations for full-document stack curation and the
  shared-context brief carrier, with shared planning plumbing and typed
  Tier-1 rejections
- Brief-slug and stack-revision validators following the existing
  shape-kind pattern
- Bounded L1 stack projection (ordered and unordered lists, fence-aware,
  budget-accounted) with the non-authoritative framing line; L0 and
  generated AGENTS.md are byte-identical
- Shared question allocator/composer, with the flag-question path
  refactored onto it behavior-preservingly
- Six hosted operation outcome models and a submodule-public hosted tool
  registry; the curated top-level public API is unchanged

## Checks

- `uv lock` re-run and committed; `uv lock --check` passes
- `uv sync --locked` passes for both packages
- Single-source guard clean

## Post-merge

Tag the squash commit `nauro-core-v1.10.0` (annotated) and push it to
trigger the trusted-publish workflow; then create the GitHub Release.
No nauro tag and no MCP-registry publish this train.
