### PR TITLE
Classify pull-time decision-number collisions

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/link.py
+++ b/packages/nauro/src/nauro/cli/commands/link.py
@@ -145,11 +145,12 @@ def link(
     import httpx
 
     from nauro.cli.commands.auth import AuthRefreshError
+    from nauro.sync.lock import SyncLockTimeoutError
     from nauro.sync.remote import PresignError
 
     try:
         pushed = push_changed_files(cloud_id, new_store)
-    except (AuthRefreshError, PresignError, httpx.HTTPError) as exc:
+    except (AuthRefreshError, PresignError, SyncLockTimeoutError, httpx.HTTPError) as exc:
         typer.echo(
             f"  Warning: linked, but the initial cloud push failed ({exc}).\n"
             "  Run 'nauro sync' to upload the project store.",

--- a/packages/nauro/src/nauro/cli/commands/status.py
+++ b/packages/nauro/src/nauro/cli/commands/status.py
@@ -476,6 +476,14 @@ def _repo_paths(project_id: str) -> list[Path]:
 
 
 @dataclass(frozen=True)
+class _QuarantineReport:
+    """Quarantined collisions, or the fact that they could not be listed."""
+
+    collisions: tuple[str, ...] = ()
+    readable: bool = True
+
+
+@dataclass(frozen=True)
 class _StatusFacts:
     """Everything one status run observed, gathered before any output."""
 
@@ -489,6 +497,7 @@ class _StatusFacts:
     local_decisions: int
     remote_decisions: int | None
     last_full_sync: str | None
+    quarantine: _QuarantineReport
 
     @property
     def project_id(self) -> str:
@@ -540,7 +549,27 @@ def _collect_status(project_name: str, store_path: Path, *, no_probe: bool) -> _
         local_decisions=len(_list_decisions(store_path)),
         remote_decisions=remote_decisions,
         last_full_sync=last_full_sync,
+        quarantine=_quarantined_collisions(store_path),
     )
+
+
+def _quarantined_collisions(store_path: Path) -> _QuarantineReport:
+    """Remote decisions a pull quarantined and no later pull installed.
+
+    A quarantine records no sync state by design, so the pull warning scrolls
+    away with the session that saw it; naming the collisions here is what keeps
+    an unresolved one visible until someone acts on it. A failure to list them
+    is reported as such rather than as "none": a corrupt sync-state file would
+    otherwise hide exactly the collisions this line exists to surface.
+    """
+    try:
+        from nauro.sync.quarantine import unresolved_quarantines
+
+        return _QuarantineReport(
+            collisions=tuple(item.label for item in unresolved_quarantines(store_path))
+        )
+    except Exception:
+        return _QuarantineReport(readable=False)
 
 
 # ── Human table emission ────────────────────────────────────────────────────
@@ -564,6 +593,7 @@ def _emit_human_status(facts: _StatusFacts) -> None:
     typer.echo(_workflow_agents_status_line(facts.snapshot))
     typer.echo(_agents_status_line(facts.snapshot))
     _emit_decision_status(facts)
+    _emit_quarantine_status(facts)
 
 
 def _emit_sync_status(facts: _StatusFacts) -> None:
@@ -599,6 +629,22 @@ def _emit_decision_status(facts: _StatusFacts) -> None:
 
     if local_count != remote_count:
         typer.echo("  Run `nauro sync` to reconcile.")
+
+
+def _emit_quarantine_status(facts: _StatusFacts) -> None:
+    if not facts.quarantine.readable:
+        typer.echo(
+            "\n  Quarantined decision-number collisions: could not be read"
+            " - run `nauro sync` for the full report."
+        )
+        return
+    quarantined = facts.quarantine.collisions
+    if not quarantined:
+        return
+    typer.echo(f"\n  Quarantined decision-number collisions: {len(quarantined)}")
+    for remote_path in quarantined:
+        typer.echo(f"    - {remote_path} was not installed; a local file holds that number")
+    typer.echo("  Run `nauro sync` for the full report on each one.")
 
 
 # ── JSON payload ────────────────────────────────────────────────────────────
@@ -653,6 +699,7 @@ class _DecisionsPayload(BaseModel):
     remote: int | None
     in_sync: bool | None
     last_full_sync: str | None
+    quarantined_collisions: list[str] | None
 
 
 class StatusPayload(BaseModel):
@@ -758,6 +805,9 @@ def _build_status_payload(facts: _StatusFacts) -> StatusPayload:
                 else facts.local_decisions == facts.remote_decisions
             ),
             last_full_sync=facts.last_full_sync,
+            quarantined_collisions=(
+                list(facts.quarantine.collisions) if facts.quarantine.readable else None
+            ),
         ),
     )
 

--- a/packages/nauro/src/nauro/cli/commands/sync.py
+++ b/packages/nauro/src/nauro/cli/commands/sync.py
@@ -122,12 +122,19 @@ class _EchoReporter:
 def _pull_via_presign(project_id: str, store_path: Path) -> int:
     """GET /sync/manifest → POST /sync/presign → S3 GETs.
 
-    Delegates to the shared pull core with an echo reporter.
+    Delegates to the shared pull core with an echo reporter. An explicit sync
+    fails loud when another sync holds the store lock: silently skipping the
+    pull would push stale content over whatever the other run is landing.
     """
+    from nauro.sync.lock import SyncLockTimeoutError
     from nauro.sync.pull import run_pull
 
     typer.echo("Pulling from remote...")
-    return run_pull(project_id, store_path, _EchoReporter())
+    try:
+        return run_pull(project_id, store_path, _EchoReporter())
+    except SyncLockTimeoutError as exc:
+        typer.echo(f"Error: {exc}. Try again once it finishes.", err=True)
+        raise typer.Exit(code=1) from exc
 
 
 def _show_status(project_flag: str | None) -> None:
@@ -176,8 +183,19 @@ def _show_status(project_flag: str | None) -> None:
     else:
         typer.echo("  Pending local changes: none")
 
+    from nauro.sync.quarantine import list_quarantine_backups, unresolved_quarantines
+
+    quarantined = unresolved_quarantines(store_path, state)
+    if quarantined:
+        typer.echo(f"  Quarantined decision-number collisions: {len(quarantined)}")
+        for item in quarantined:
+            typer.echo(f"    - {item.label} (remote copy: {item.backup_path.name})")
+
     backup_dir = store_path / ".conflict-backup"
     if backup_dir.exists():
-        backups = list(backup_dir.iterdir())
+        # Quarantine backups live in the same directory but are already
+        # reported above; counting them again would double-report one event.
+        quarantine_names = {item.backup_path.name for item in list_quarantine_backups(store_path)}
+        backups = [path for path in backup_dir.iterdir() if path.name not in quarantine_names]
         if backups:
             typer.echo(f"  Conflict backups: {len(backups)}")

--- a/packages/nauro/src/nauro/sync/collisions.py
+++ b/packages/nauro/src/nauro/sync/collisions.py
@@ -139,8 +139,8 @@ _REASON_TEXT: dict[QuarantineReason, _ReasonText] = {
         _LOCAL_GUIDANCE,
     ),
     QuarantineReason.irregular_entry: _ReasonText(
-        "that number is claimed by an entry that is not a regular file "
-        "(a directory or a symlink), which this tool never reads or changes",
+        "that number is claimed by an entry this tool never reads - either not a "
+        "regular file, or not a name decision readers recognise",
         _LOCAL_GUIDANCE,
     ),
     QuarantineReason.non_canonical_path: _ReasonText(

--- a/packages/nauro/src/nauro/sync/collisions.py
+++ b/packages/nauro/src/nauro/sync/collisions.py
@@ -1,0 +1,758 @@
+"""Classification of every decision file a pull is about to write.
+
+A remote decision whose number is already taken by a differently named local
+file is not a content conflict: two independent records claim one identity. The
+remote number is shared state other machines already reference, so it is never
+the side that moves. Instead the local collider is classified, with the fetched
+remote bytes in hand, into exactly one of:
+
+* **canonicalize** - the local file is byte-identical to the remote one and was
+  never published, so it is one record under two names; renaming the local file
+  onto the remote name reunites them.
+* **renumber local** - the local file is provably unpublished, unreferenced,
+  and rewritable, so it moves to a free number and the remote file installs.
+* **quarantine** - anything published, referenced, malformed, or ambiguous.
+  Nothing local is touched and nothing is installed.
+
+Provably unpublished means both that no sync-state entry tracks the local path
+and that the path is absent from the current server manifest: a push that
+uploaded a file and crashed before saving state leaves a published file with no
+state entry, and only the manifest reveals it.
+
+Every untracked decision write goes through this gate, not just the ones that
+looked like collisions when the pull planned its transfers. Two remote files can
+carry one number, and a local writer can mint a number between the plan and the
+write, so a verdict taken at planning time is not a verdict at all. The gate
+runs against the corpus the writer keeps current, immediately before the write
+it authorizes, under the decision lock.
+
+The renumber writes in a fixed order - rename, then heading rewrite, then hash
+index, then install - so every crash window leaves a state the next pull heals:
+a rename with a stale heading is repaired by :func:`run_completion_pass`, and an
+installed file with no state entry is adopted by the same-path leg below. No
+window can re-collide and mint a duplicate. The heading rewrite is computed and
+checked before the rename, so only a file that will certainly come out
+consistent enters that sequence at all.
+
+There is deliberately no multi-file reference rewrite. A local file that any
+other decision or question resolution names is quarantined, because rebinding
+those references to an unrelated remote decision cannot be detected afterwards.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections import Counter
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+from nauro_core import extract_decision_number
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+from nauro.constants import DECISION_HASHES_FILE, DECISIONS_DIR
+from nauro.store._atomic import atomic_write_text
+from nauro.store.reader import read_text_lenient
+from nauro.sync.corpus import DecisionCorpus, DecisionFile
+from nauro.sync.headings import (
+    has_rewritable_heading,
+    heading_number,
+    rewrite_decision_heading,
+    strip_number_prefix,
+)
+from nauro.sync.state import SyncState
+
+
+class DecisionOutcome(str, Enum):
+    """What the pull should do with one remote decision file."""
+
+    install = "install"
+    adopt = "adopt"
+    resolve_conflict = "resolve-conflict"
+    canonicalize = "canonicalize"
+    renumber_local = "renumber-local"
+    quarantine = "quarantine"
+
+
+class QuarantineReason(str, Enum):
+    """Why a decision could not be installed or resolved automatically."""
+
+    tracked_locally = "tracked-locally"
+    published_remotely = "published-remotely"
+    ambiguous_colliders = "ambiguous-colliders"
+    unparseable_collider = "unparseable-collider"
+    store_unverifiable = "store-unverifiable"
+    referenced = "referenced"
+    question_reference = "question-reference"
+    heading_not_rewritable = "heading-not-rewritable"
+    irregular_entry = "irregular-entry"
+    non_canonical_path = "non-canonical-path"
+    case_variant_present = "case-variant-present"
+    destination_occupied = "destination-occupied"
+
+
+# A collider the server already holds is published on both sides, and this
+# transport moves whole files by path: it cannot rename or delete a remote
+# object, so no client-side sequence resolves it. Everything else is an
+# unpublished local file the owner renames or removes.
+_PUBLISHED_GUIDANCE = (
+    "Both sides are published, so no client-side resolution exists; "
+    "resolve it through the Nauro app as the project owner."
+)
+_LOCAL_GUIDANCE = "Rename or remove the local file, then run 'nauro sync' again."
+
+
+@dataclass(frozen=True)
+class _ReasonText:
+    detail: str
+    guidance: str
+
+
+# Every reason declares its own wording, so a new one cannot inherit the wrong
+# resolution route by falling through to a default.
+_REASON_TEXT: dict[QuarantineReason, _ReasonText] = {
+    QuarantineReason.tracked_locally: _ReasonText(
+        "the local file is tracked in sync state (already published)", _PUBLISHED_GUIDANCE
+    ),
+    QuarantineReason.published_remotely: _ReasonText(
+        "the local file's path is also in the server manifest", _PUBLISHED_GUIDANCE
+    ),
+    QuarantineReason.ambiguous_colliders: _ReasonText(
+        "more than one local file claims that number", _LOCAL_GUIDANCE
+    ),
+    QuarantineReason.unparseable_collider: _ReasonText(
+        "the local file does not parse as a decision", _LOCAL_GUIDANCE
+    ),
+    QuarantineReason.store_unverifiable: _ReasonText(
+        "another store file could not be read, so references to that number cannot be verified",
+        _LOCAL_GUIDANCE,
+    ),
+    QuarantineReason.referenced: _ReasonText(
+        "the local file takes part in a supersession", _LOCAL_GUIDANCE
+    ),
+    QuarantineReason.question_reference: _ReasonText(
+        "an open question records that number as its resolution", _LOCAL_GUIDANCE
+    ),
+    QuarantineReason.heading_not_rewritable: _ReasonText(
+        "the local file's heading is not in the canonical form this tool can renumber",
+        _LOCAL_GUIDANCE,
+    ),
+    QuarantineReason.irregular_entry: _ReasonText(
+        "that number is claimed by an entry that is not a regular file "
+        "(a directory or a symlink), which this tool never reads or changes",
+        _LOCAL_GUIDANCE,
+    ),
+    QuarantineReason.non_canonical_path: _ReasonText(
+        "its remote path is not spelled 'decisions/<name>.md', the one spelling "
+        "this store reads and writes",
+        "Nothing local was changed. Re-upload the decision under the canonical "
+        "path from the machine that published it.",
+    ),
+    QuarantineReason.case_variant_present: _ReasonText(
+        "a local file differs from it only by letter case, which some "
+        "filesystems treat as the same file",
+        _LOCAL_GUIDANCE,
+    ),
+    QuarantineReason.destination_occupied: _ReasonText(
+        "the name it would be renamed to is already taken locally", _LOCAL_GUIDANCE
+    ),
+}
+
+
+class RenumberRefusedError(Exception):
+    """A local renumber was refused before anything on disk was touched.
+
+    Each subclass carries the quarantine reason the caller reports, so a
+    refusal can never be attributed to the wrong cause.
+    """
+
+    reason: QuarantineReason
+
+
+class HeadingRewriteError(RenumberRefusedError):
+    """The heading is not in the form the rewriter can address."""
+
+    reason = QuarantineReason.heading_not_rewritable
+
+
+class DestinationOccupiedError(RenumberRefusedError):
+    """The name the local file would move to is already taken."""
+
+    reason = QuarantineReason.destination_occupied
+
+
+@dataclass(frozen=True)
+class DecisionVerdict:
+    """One classification of one remote decision file."""
+
+    outcome: DecisionOutcome
+    colliders: tuple[Path, ...] = ()
+    reason: QuarantineReason | None = None
+
+    @property
+    def collider(self) -> Path:
+        """The single local file this verdict acts on."""
+        return self.colliders[0]
+
+    def quarantined_as(self, reason: QuarantineReason) -> DecisionVerdict:
+        """This verdict's colliders, re-cast as a quarantine."""
+        return DecisionVerdict(DecisionOutcome.quarantine, self.colliders, reason)
+
+    def text(self) -> _ReasonText:
+        assert self.reason is not None  # only quarantine verdicts carry a reason
+        return _REASON_TEXT[self.reason]
+
+
+@dataclass(frozen=True)
+class RenumberResult:
+    """The completed local renumber behind one installed remote decision."""
+
+    old_path: Path
+    new_path: Path
+    old_num: int
+    new_num: int
+
+
+@dataclass(frozen=True)
+class HeadingRepair:
+    """One decision file whose heading was realigned with its filename."""
+
+    path: Path
+    from_num: int
+    to_num: int
+
+
+class _CompletionRefusal(Enum):
+    """Why the completion pass left a mismatched heading alone."""
+
+    store_state = "store-state"
+    heading_not_rewritable = "heading-not-rewritable"
+
+
+@dataclass(frozen=True)
+class CompletionOutcome:
+    """What the idempotent completion pass found and healed.
+
+    ``unrepairable`` and ``quarantined`` are both report-only, and they differ
+    in what a human can do about them: an unrepairable file needs the store
+    graph untangled first, while a quarantined one only needs its heading or
+    its name put right, exactly like a quarantined collision.
+    """
+
+    repaired: tuple[HeadingRepair, ...] = ()
+    unrepairable: tuple[Path, ...] = ()
+    quarantined: tuple[Path, ...] = ()
+    retargeted_stems: tuple[str, ...] = ()
+
+
+# ── Isolation ──────────────────────────────────────────────────────────────
+
+
+def _isolation_defect(
+    corpus: DecisionCorpus, candidate: DecisionFile, numbers: tuple[int, ...]
+) -> QuarantineReason | None:
+    """Return why ``candidate`` is not isolated, or None when it is.
+
+    Isolated means the file parses, takes part in no supersession in either
+    direction, is named by no question resolution, and sits in a store where
+    every other record could be read to establish that.
+    """
+    if candidate.parsed().failed:
+        return QuarantineReason.unparseable_collider
+    references = corpus.references()
+    if not references.verifiable:
+        return QuarantineReason.store_unverifiable
+    decision = candidate.parsed().decision
+    assert decision is not None  # the failed parse returned above
+    if decision.supersedes is not None or decision.superseded_by is not None:
+        return QuarantineReason.referenced
+    if any(num in references.supersession_refs for num in numbers):
+        return QuarantineReason.referenced
+    if any(num in references.question_refs for num in numbers):
+        return QuarantineReason.question_reference
+    return None
+
+
+# ── Hash index ─────────────────────────────────────────────────────────────
+
+
+class _HashIndexEntry(BaseModel):
+    """One entry of the propose_decision content-hash index.
+
+    Unknown keys are kept: the entry is rewritten in place through its raw
+    dict, so nothing outside ``decision_id`` is disturbed.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    decision_id: str
+
+
+def _load_hash_index(store_path: Path) -> dict | None:
+    path = store_path / DECISION_HASHES_FILE
+    if not path.is_file():
+        return None
+    try:
+        loaded = json.loads(read_text_lenient(path))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return loaded if isinstance(loaded, dict) else None
+
+
+def _save_hash_index(store_path: Path, index: dict) -> None:
+    atomic_write_text(
+        store_path / DECISION_HASHES_FILE, json.dumps(index, indent=2) + "\n", newline="\n"
+    )
+
+
+def _entry_stem(value: object) -> str | None:
+    try:
+        return _HashIndexEntry.model_validate(value).decision_id
+    except ValidationError:
+        return None
+
+
+def _retarget_hash_index(store_path: Path, old_stem: str, new_stem: str) -> int:
+    """Point every hash-index entry naming ``old_stem`` at ``new_stem``."""
+    index = _load_hash_index(store_path)
+    if index is None:
+        return 0
+    changed = 0
+    for value in index.values():
+        if _entry_stem(value) != old_stem:
+            continue
+        value["decision_id"] = new_stem
+        changed += 1
+    if changed:
+        _save_hash_index(store_path, index)
+    return changed
+
+
+def _repair_dangling_stems(corpus: DecisionCorpus) -> tuple[str, ...]:
+    """Retarget hash-index entries whose decision file was renumbered away.
+
+    Covers the crash window between the heading rewrite and the hash-index
+    update: the entry still names a stem that no longer exists on disk. It is
+    retargeted only when exactly one decision file carries the same slug, so an
+    entry for a genuinely deleted decision is left alone.
+    """
+    index = _load_hash_index(corpus.store_path)
+    if index is None:
+        return ()
+    on_disk = {entry.stem for entry in corpus.files}
+    by_slug: dict[str, list[str]] = {}
+    for entry in corpus.files:
+        by_slug.setdefault(strip_number_prefix(entry.stem), []).append(entry.stem)
+
+    retargeted: list[str] = []
+    for value in index.values():
+        stem = _entry_stem(value)
+        if stem is None or stem in on_disk:
+            continue
+        candidates = by_slug.get(strip_number_prefix(stem), [])
+        if len(candidates) != 1:
+            continue
+        value["decision_id"] = candidates[0]
+        retargeted.append(stem)
+    if retargeted:
+        _save_hash_index(corpus.store_path, index)
+    return tuple(retargeted)
+
+
+# ── Classification ─────────────────────────────────────────────────────────
+
+
+# The names the store's own writers produce. ``_slugify`` lowercases the
+# title and keeps only alphanumerics, joining the rest with hyphens, so a
+# minted filename is ``NNN-slug.md`` in lowercase; the extension contributes
+# the only dot. Underscores are admitted because a hand-placed file may carry
+# one and nothing about it is ambiguous. Alphanumeric is Unicode-aware here for
+# the same reason it is in the writer: a title in another script slugifies to
+# that script, and refusing it would quarantine a decision Nauro itself wrote.
+_CANONICAL_EXTRA_CHARS = frozenset("-._")
+
+# Windows resolves these basenames to devices whatever the extension, so a file
+# by that name is not a file. They can only arrive from a server, never from a
+# local mint, and are refused rather than handed to open(). The superscript
+# digits are not decoration: Windows treats COM\u00b9 and COM\u00b2 as the same
+# devices as COM1 and COM2, and they pass an alphanumeric check. This is spelled
+# out rather than delegated to ``PureWindowsPath.is_reserved`` because that
+# method is deprecated from 3.13 and this package supports 3.10 upward.
+_DEVICE_DIGITS = tuple("123456789") + ("\u00b9", "\u00b2", "\u00b3")
+_RESERVED_DEVICE_NAMES = frozenset(
+    {"CON", "PRN", "AUX", "NUL"}
+    | {f"COM{digit}" for digit in _DEVICE_DIGITS}
+    | {f"LPT{digit}" for digit in _DEVICE_DIGITS}
+)
+
+
+def _is_canonical_filename(filename: str) -> bool:
+    """True for a filename the store's writers could have minted."""
+    if not filename.endswith(".md"):
+        return False
+    stem = filename[: -len(".md")]
+    if not stem or filename != filename.lower():
+        return False
+    if not any(char.isalnum() for char in stem):
+        return False
+    if not all(char.isalnum() or char in _CANONICAL_EXTRA_CHARS for char in stem):
+        return False
+    return stem.split(".")[0].upper() not in _RESERVED_DEVICE_NAMES
+
+
+def is_canonical_decision_path(rel: str) -> bool:
+    """True only for the exact spelling this store reads and writes.
+
+    Everything else that enumerates the directory - the corpus scan here,
+    ``list_decisions`` in the store, the kernel's number allocation - matches a
+    flat, lowercase ``decisions/<name>.md`` literally. A path that merely
+    *resolves* to that shape is not the same thing: ``decisions//x.md``,
+    ``decisions/./x.md`` and ``decisions/x.md/`` all normalise onto an existing
+    decision, so accepting them would overwrite a record without the classifier
+    ever comparing it, and ``decisions/sub/x.md`` installs a file the allocator
+    cannot see but the push scan still uploads.
+
+    So the parse is structural rather than a suffix test: exactly two nonempty
+    components, the first literally ``decisions``, the second a filename the
+    store's own writers could have minted, and the two joined back together
+    byte-identical to the input. The filename rule is an allowlist rather than
+    a denylist of the characters that have bitten other tools - a colon opens
+    an alternate data stream on NTFS, a reserved basename resolves to a device
+    - because the set of such characters is not knowable in advance and the set
+    the writer emits is.
+    """
+    parts = rel.split("/")
+    if len(parts) != 2:
+        return False
+    directory, filename = parts
+    if directory != DECISIONS_DIR or not _is_canonical_filename(filename):
+        return False
+    return f"{DECISIONS_DIR}/{filename}" == rel
+
+
+def classify_decision(
+    corpus: DecisionCorpus,
+    remote_path: str,
+    remote_content: bytes,
+    state: SyncState,
+    manifest_paths: frozenset[str],
+) -> DecisionVerdict:
+    """Decide what to do with one untracked remote decision file.
+
+    Called immediately before the write it authorizes, against the corpus as
+    the writer has maintained it: an earlier decision in the same pull may have
+    installed the file this one now collides with, or moved the file it would
+    have collided with.
+    """
+    if not is_canonical_decision_path(remote_path):
+        # Routed here rather than dropped, but never written: the corpus scan
+        # and the kernel's number allocation both enumerate lowercase
+        # ``decisions/*.md`` only, so a file installed under any other spelling
+        # would be invisible to the very allocator that must not reuse its
+        # number, and state recorded under that spelling would not match the
+        # path the push scan reports.
+        return DecisionVerdict(DecisionOutcome.quarantine, (), QuarantineReason.non_canonical_path)
+    filename = remote_path.split("/", 1)[1]
+    if corpus.has_name(filename):
+        return _classify_same_path(corpus, filename, remote_content, state, manifest_paths)
+    variant = corpus.case_variant(filename)
+    if variant is not None:
+        # Some filesystems fold case, so writing this name could silently
+        # overwrite the local file instead of creating a new one.
+        return DecisionVerdict(
+            DecisionOutcome.quarantine,
+            (corpus.store_path / f"decisions/{variant}",),
+            QuarantineReason.case_variant_present,
+        )
+    return _classify_number(corpus, filename, remote_content, state, manifest_paths)
+
+
+def _classify_same_path(
+    corpus: DecisionCorpus,
+    filename: str,
+    remote_content: bytes,
+    state: SyncState,
+    manifest_paths: frozenset[str],
+) -> DecisionVerdict:
+    """The server holds this exact file and nothing here tracks it.
+
+    A push that uploaded and crashed before saving state leaves that shape, as
+    does a collision resolved into place by an interrupted pull. Adopting it is
+    only safe once nothing else claims its number: a sibling holding the same
+    number would be ratified as a duplicate by the very state entry adoption
+    writes, and would then push as a second remote record.
+    """
+    local = corpus.store_path / DECISIONS_DIR / filename
+    if corpus.is_irregular(filename):
+        return DecisionVerdict(
+            DecisionOutcome.quarantine, (local,), QuarantineReason.irregular_entry
+        )
+
+    entry = corpus.file_named(filename)
+    if entry is not None:
+        sibling = _sibling_defect(corpus, entry, remote_content, state, manifest_paths)
+        if sibling is not None:
+            return sibling
+
+    # A file with no parseable number claims no number, so there is nothing to
+    # contest: its bytes alone decide.
+    local_bytes = _read_bytes(local)
+    if local_bytes is None:
+        return DecisionVerdict(
+            DecisionOutcome.quarantine, (local,), QuarantineReason.store_unverifiable
+        )
+    if local_bytes == remote_content:
+        return DecisionVerdict(DecisionOutcome.adopt, (local,))
+    return DecisionVerdict(DecisionOutcome.resolve_conflict, (local,))
+
+
+def _sibling_defect(
+    corpus: DecisionCorpus,
+    entry: DecisionFile,
+    remote_content: bytes,
+    state: SyncState,
+    manifest_paths: frozenset[str],
+) -> DecisionVerdict | None:
+    """Refuse the same-path leg while another local file claims its number."""
+    siblings = tuple(
+        holder.path for holder in corpus.holders(entry.number) if holder.path != entry.path
+    )
+    irregular = corpus.irregular_holders(entry.number)
+    if irregular:
+        return DecisionVerdict(
+            DecisionOutcome.quarantine, (entry.path,), QuarantineReason.irregular_entry
+        )
+    if not siblings:
+        return None
+    if len(siblings) > 1:
+        return DecisionVerdict(
+            DecisionOutcome.quarantine, siblings, QuarantineReason.ambiguous_colliders
+        )
+    sibling = next(holder for holder in corpus.files if holder.path == siblings[0])
+    verdict = _classify_collider(
+        corpus, sibling, entry.number, remote_content, state, manifest_paths
+    )
+    if verdict.outcome is DecisionOutcome.renumber_local:
+        # The sibling can move out of the way; the caller re-classifies after
+        # it does, and the same-path leg then proceeds against a free number.
+        return verdict
+    if verdict.outcome is DecisionOutcome.canonicalize:
+        # The sibling is a second copy of the same record, and the name it
+        # would take is the one already holding it.
+        return verdict.quarantined_as(QuarantineReason.destination_occupied)
+    if verdict.reason is not None:
+        return verdict
+    return verdict.quarantined_as(QuarantineReason.ambiguous_colliders)
+
+
+def _classify_number(
+    corpus: DecisionCorpus,
+    filename: str,
+    remote_content: bytes,
+    state: SyncState,
+    manifest_paths: frozenset[str],
+) -> DecisionVerdict:
+    """No local file has this name: decide whether its number is free."""
+    number = extract_decision_number(filename)
+    if number is None:
+        return DecisionVerdict(DecisionOutcome.install)
+
+    irregular = corpus.irregular_holders(number)
+    if irregular:
+        return DecisionVerdict(
+            DecisionOutcome.quarantine,
+            (corpus.store_path / f"decisions/{irregular[0].name}",),
+            QuarantineReason.irregular_entry,
+        )
+
+    colliding = corpus.holders(number)
+    if not colliding:
+        return DecisionVerdict(DecisionOutcome.install)
+    if len(colliding) > 1:
+        return DecisionVerdict(
+            DecisionOutcome.quarantine,
+            tuple(entry.path for entry in colliding),
+            QuarantineReason.ambiguous_colliders,
+        )
+    return _classify_collider(corpus, colliding[0], number, remote_content, state, manifest_paths)
+
+
+def _classify_collider(
+    corpus: DecisionCorpus,
+    collider: DecisionFile,
+    number: int,
+    remote_content: bytes,
+    state: SyncState,
+    manifest_paths: frozenset[str],
+) -> DecisionVerdict:
+    """Apply the collision matrix to the one local file holding ``number``."""
+    colliders = (collider.path,)
+    if collider.relative_path in state.files:
+        return DecisionVerdict(
+            DecisionOutcome.quarantine, colliders, QuarantineReason.tracked_locally
+        )
+    if collider.relative_path in manifest_paths:
+        return DecisionVerdict(
+            DecisionOutcome.quarantine, colliders, QuarantineReason.published_remotely
+        )
+
+    local_bytes = _read_bytes(collider.path)
+    if local_bytes is None:
+        return DecisionVerdict(
+            DecisionOutcome.quarantine, colliders, QuarantineReason.store_unverifiable
+        )
+    if local_bytes == remote_content:
+        return DecisionVerdict(DecisionOutcome.canonicalize, colliders)
+
+    defect = _isolation_defect(corpus, collider, (number,))
+    if defect is not None:
+        return DecisionVerdict(DecisionOutcome.quarantine, colliders, defect)
+    text = collider.text()
+    if text is None or not has_rewritable_heading(text, number):
+        return DecisionVerdict(
+            DecisionOutcome.quarantine, colliders, QuarantineReason.heading_not_rewritable
+        )
+    return DecisionVerdict(DecisionOutcome.renumber_local, colliders)
+
+
+def _read_bytes(path: Path) -> bytes | None:
+    try:
+        return path.read_bytes()
+    except OSError:
+        return None
+
+
+# ── Mutation ───────────────────────────────────────────────────────────────
+
+
+def apply_canonicalize(corpus: DecisionCorpus, collider: Path, remote_path: str) -> Path:
+    """Rename the byte-identical local collider onto the remote filename.
+
+    The number does not change, so the heading is already correct; only the
+    hash index, which keys on the file stem, follows the rename.
+    """
+    destination = corpus.store_path / remote_path
+    text = read_text_lenient(collider)
+    os.rename(collider, destination)
+    _retarget_hash_index(corpus.store_path, collider.stem, destination.stem)
+    corpus.record_renamed(collider, destination, text)
+    return destination
+
+
+def apply_renumber(
+    corpus: DecisionCorpus, collider: Path, number: int, reserved_numbers: frozenset[int]
+) -> RenumberResult:
+    """Move the local collider to a free number so the remote one can install.
+
+    ``reserved_numbers`` are the decision numbers the server manifest already
+    holds: minting above them keeps the renumbered file from colliding with a
+    remote decision that has not been transferred yet.
+
+    The heading rewrite is computed and verified before the rename, so a file
+    whose heading the rewriter cannot address is refused with nothing on disk
+    touched. Only a file that will certainly come out consistent enters the
+    rename-first sequence, which keeps the crash window between the rename and
+    the heading write repairable by :func:`run_completion_pass`.
+
+    Raises:
+        RenumberRefusedError: the free name is already taken, or the heading could
+            not be rewritten to the new number. Nothing was mutated in either
+            case; the caller quarantines the remote file under the reason the
+            refusal names.
+    """
+    new_num = max(corpus.claimed_numbers() | reserved_numbers) + 1
+    destination = collider.with_name(f"{new_num:03d}-{strip_number_prefix(collider.name)}")
+    if corpus.has_name(destination.name):
+        raise DestinationOccupiedError(f"{destination.name}: that name is already taken locally")
+
+    current = read_text_lenient(collider)
+    rewritten = rewrite_decision_heading(current, number, new_num)
+    if heading_number(rewritten) != new_num:
+        raise HeadingRewriteError(
+            f"{collider.name}: heading could not be rewritten to {new_num:03d}"
+        )
+
+    os.rename(collider, destination)
+    atomic_write_text(destination, rewritten, newline="\n")
+
+    _retarget_hash_index(corpus.store_path, collider.stem, destination.stem)
+    corpus.record_renamed(collider, destination, rewritten)
+    return RenumberResult(old_path=collider, new_path=destination, old_num=number, new_num=new_num)
+
+
+def _complete_heading(
+    corpus: DecisionCorpus, entry: DecisionFile, heading: int, *, contested: bool
+) -> HeadingRepair | _CompletionRefusal:
+    """Realign one half-renamed file's heading, or say why it was left alone."""
+    if contested or _isolation_defect(corpus, entry, (entry.number, heading)) is not None:
+        return _CompletionRefusal.store_state
+    text = entry.text()
+    if text is None or not has_rewritable_heading(text, heading):
+        return _CompletionRefusal.heading_not_rewritable
+    rewritten = rewrite_decision_heading(text, heading, entry.number)
+    atomic_write_text(entry.path, rewritten, newline="\n")
+    corpus.record_rewritten(entry.path, rewritten)
+    return HeadingRepair(path=entry.path, from_num=heading, to_num=entry.number)
+
+
+def run_completion_pass(corpus: DecisionCorpus) -> CompletionOutcome:
+    """Finish any renumber that crashed between its steps.
+
+    The filename carries a decision's identity, so a file whose heading names a
+    different number is a half-applied rename. It is completed when the number
+    on its filename is held by no other file and the file is isolated by the
+    same criteria a renumber requires; anything else is reported and left
+    alone. Hash-index entries orphaned by a completed rename are retargeted in
+    the same pass. Idempotent: a store with nothing half-applied is unchanged,
+    and a file it declines to repair is reported the same way on every run
+    rather than rewritten a little more each time.
+
+    Detection reads each file only as far as its heading, so a store with
+    nothing to heal never loads a decision body.
+    """
+    mismatched = [
+        (entry, heading)
+        for entry in corpus.files
+        if (heading := entry.heading_number()) is not None and heading != entry.number
+    ]
+    repaired: list[HeadingRepair] = []
+    refused: dict[_CompletionRefusal, list[Path]] = {reason: [] for reason in _CompletionRefusal}
+    if mismatched:
+        # Irregular entries count as claims. They are never read, so a
+        # directory or symlink sitting on the number is exactly the ambiguity
+        # that must stop a repair, not a claim to overlook because it has no
+        # readable content.
+        holders = Counter(entry.number for entry in corpus.files)
+        for entry, heading in mismatched:
+            contested = holders[entry.number] > 1 or bool(corpus.irregular_holders(entry.number))
+            outcome = _complete_heading(corpus, entry, heading, contested=contested)
+            if isinstance(outcome, HeadingRepair):
+                repaired.append(outcome)
+            else:
+                refused[outcome].append(entry.path)
+
+    return CompletionOutcome(
+        repaired=tuple(repaired),
+        unrepairable=tuple(refused[_CompletionRefusal.store_state]),
+        quarantined=tuple(refused[_CompletionRefusal.heading_not_rewritable]),
+        retargeted_stems=_repair_dangling_stems(corpus),
+    )
+
+
+__all__ = [
+    "CompletionOutcome",
+    "DestinationOccupiedError",
+    "DecisionOutcome",
+    "DecisionVerdict",
+    "HeadingRepair",
+    "HeadingRewriteError",
+    "RenumberRefusedError",
+    "QuarantineReason",
+    "RenumberResult",
+    "apply_canonicalize",
+    "apply_renumber",
+    "classify_decision",
+    "is_canonical_decision_path",
+    "run_completion_pass",
+]

--- a/packages/nauro/src/nauro/sync/corpus.py
+++ b/packages/nauro/src/nauro/sync/corpus.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass, field
+from enum import Enum
 from pathlib import Path
 
 from nauro_core import Decision, extract_decision_number, parse_decision
@@ -147,12 +148,28 @@ class ReferenceIndex:
         return not self.unparseable and self.questions_readable
 
 
+class SkipReason(str, Enum):
+    """Why an entry under ``decisions/`` is listed but never read."""
+
+    not_a_regular_file = "not-a-regular-file"
+    unreadable_name = "unreadable-name"
+
+
 @dataclass(frozen=True)
 class IrregularEntry:
-    """A ``decisions/*.md`` entry that is not a regular file."""
+    """An entry under ``decisions/`` this layer will not read or modify.
+
+    Either it is not a regular file, or its name is not one the store's readers
+    recognise - ``list_decisions`` and the kernel's allocator match a lowercase
+    ``.md`` suffix literally, so a file named ``007-x.MD`` is invisible to them
+    however readable it is here. Both shapes still claim their number, because a
+    number claimed by something nothing can read is exactly the ambiguity that
+    must hold a remote decision back rather than let it land alongside.
+    """
 
     name: str
     number: int | None
+    reason: SkipReason
 
 
 @dataclass
@@ -180,14 +197,30 @@ class DecisionCorpus:
         except (FileNotFoundError, NotADirectoryError):
             return corpus
         for entry in entries:
-            if not entry.name.endswith(".md"):
+            # Case-folded, so a file the store's own readers cannot see is at
+            # least visible here: it still occupies its number and its name is
+            # still a case variant of something the server may send.
+            if not entry.name.casefold().endswith(".md"):
                 continue
             names.add(entry.name)
             number = extract_decision_number(entry.name)
             # follow_symlinks=False: a symlink is not a file this layer reads,
             # follows, or rewrites, whatever it points at.
             if not entry.is_file(follow_symlinks=False):
-                irregular.append(IrregularEntry(name=entry.name, number=number))
+                irregular.append(
+                    IrregularEntry(
+                        name=entry.name,
+                        number=number,
+                        reason=SkipReason.not_a_regular_file,
+                    )
+                )
+                continue
+            if not entry.name.endswith(".md"):
+                irregular.append(
+                    IrregularEntry(
+                        name=entry.name, number=number, reason=SkipReason.unreadable_name
+                    )
+                )
                 continue
             if number is None:
                 continue
@@ -319,6 +352,7 @@ def _read_question_references(store_path: Path) -> tuple[frozenset[int], bool]:
 
 __all__ = [
     "PARSE_FAILURES",
+    "SkipReason",
     "DecisionCorpus",
     "DecisionFile",
     "IrregularEntry",

--- a/packages/nauro/src/nauro/sync/corpus.py
+++ b/packages/nauro/src/nauro/sync/corpus.py
@@ -1,0 +1,327 @@
+"""One view of ``decisions/`` for the lifetime of one sync run.
+
+Every collision verdict is taken against the store as it stands at that moment,
+which naively means rescanning and reparsing the whole corpus once per verdict.
+On a store with hundreds of decisions and a handful of collisions that is
+hundreds of thousands of parses. This module keeps the guarantee and drops the
+cost: the pull scans ``decisions/`` once inside the decision lock, reads each
+file only as far as the question being asked requires, and tells the corpus
+about every mutation it makes, so the in-memory view stays identical to the disk
+without re-reading it.
+
+Three levels of detail, each paid for only when asked:
+
+* the **listing** - filenames and the numbers they claim - comes from one
+  ``scandir`` with no file reads, and answers "who claims this number?" and
+  "does this exact name exist?";
+* a file's **heading number** is read by scanning lines until the H1, so a
+  filename/heading mismatch is detected without loading bodies;
+* a file's **parse** is done at most once, and the reference index folded from
+  those parses is rebuilt (never re-read) after a mutation.
+
+Entries that are not regular files - a directory, a symlink, a broken link -
+are never read, followed, or modified. They are recorded as irregular, counted
+as claiming their number so nothing is minted or installed on top of them, and
+reported. A symlink's target can change outside every lock this layer holds, so
+no proof about its content would survive the write it authorizes.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from nauro_core import Decision, extract_decision_number, parse_decision
+from nauro_core.questions import EntryBlock, OpenQuestionsFile
+
+from nauro.constants import DECISIONS_DIR, OPEN_QUESTIONS_MD
+from nauro.store.reader import read_text_lenient
+from nauro.sync.headings import heading_line_number, heading_number
+
+# Reading a store file can fail on content (a malformed decision) or on the
+# filesystem (a permission change mid-run). Neither may abort a sync: both mean
+# "this record cannot be verified", which the classifier answers with a
+# quarantine. TypeError is in the set because the decision model takes some
+# frontmatter keys as constructor arguments, so a file carrying a reserved key
+# such as ``num:`` raises TypeError rather than ValueError.
+PARSE_FAILURES = (OSError, TypeError, ValueError)
+
+
+@dataclass(frozen=True)
+class ParsedDecision:
+    """One decision file's parse, or the record that it has none."""
+
+    decision: Decision | None
+    refs: frozenset[int] = frozenset()
+
+    @property
+    def failed(self) -> bool:
+        return self.decision is None
+
+
+_UNPARSEABLE = ParsedDecision(decision=None)
+
+
+@dataclass
+class DecisionFile:
+    """One regular decision file, with the reads it has needed so far."""
+
+    path: Path
+    number: int
+    _text: str | None = None
+    _heading: int | None = None
+    _heading_known: bool = False
+    _parsed: ParsedDecision | None = None
+
+    @property
+    def name(self) -> str:
+        return self.path.name
+
+    @property
+    def stem(self) -> str:
+        return self.path.stem
+
+    @property
+    def relative_path(self) -> str:
+        return f"{DECISIONS_DIR}/{self.path.name}"
+
+    def text(self) -> str | None:
+        """The file's content, read once. None when it cannot be read."""
+        if self._text is None:
+            try:
+                self._text = read_text_lenient(self.path)
+            except OSError:
+                return None
+        return self._text
+
+    def heading_number(self) -> int | None:
+        """The number this file's H1 claims, scanning no further than the H1."""
+        if self._heading_known:
+            return self._heading
+        self._heading_known = True
+        if self._text is not None:
+            self._heading = heading_number(self._text)
+            return self._heading
+        try:
+            with self.path.open(encoding="utf-8", errors="replace") as handle:
+                for line in handle:
+                    found = heading_line_number(line.rstrip("\n"))
+                    if found is not None:
+                        self._heading = found
+                        break
+        except OSError:
+            self._heading = None
+        return self._heading
+
+    def parsed(self) -> ParsedDecision:
+        """This file's parse, done at most once per view of the file."""
+        if self._parsed is None:
+            self._parsed = _parse(self.path, self.text())
+        return self._parsed
+
+
+def _parse(path: Path, text: str | None) -> ParsedDecision:
+    if text is None:
+        return _UNPARSEABLE
+    try:
+        decision = parse_decision(text, path.name)
+    except PARSE_FAILURES:
+        return _UNPARSEABLE
+    refs = {int(ref) for ref in (decision.supersedes, decision.superseded_by) if ref is not None}
+    return ParsedDecision(decision=decision, refs=frozenset(refs))
+
+
+@dataclass(frozen=True)
+class ReferenceIndex:
+    """Every place a decision number is named, folded from the parsed corpus."""
+
+    unparseable: frozenset[Path]
+    supersession_refs: frozenset[int]
+    question_refs: frozenset[int]
+    questions_readable: bool
+
+    @property
+    def verifiable(self) -> bool:
+        """True when every record that could name a number could be read."""
+        return not self.unparseable and self.questions_readable
+
+
+@dataclass(frozen=True)
+class IrregularEntry:
+    """A ``decisions/*.md`` entry that is not a regular file."""
+
+    name: str
+    number: int | None
+
+
+@dataclass
+class DecisionCorpus:
+    """The decision store as one sync run sees it, kept current by its writer."""
+
+    store_path: Path
+    _files: dict[str, DecisionFile] = field(default_factory=dict)
+    _irregular: tuple[IrregularEntry, ...] = ()
+    _irregular_names: frozenset[str] = frozenset()
+    _names: frozenset[str] = frozenset()
+    _references: ReferenceIndex | None = None
+    _questions: tuple[frozenset[int], bool] | None = None
+
+    @classmethod
+    def scan(cls, store_path: Path) -> DecisionCorpus:
+        """List ``decisions/`` without reading a single file."""
+        corpus = cls(store_path=store_path)
+        directory = store_path / DECISIONS_DIR
+        names: set[str] = set()
+        irregular: list[IrregularEntry] = []
+        try:
+            with os.scandir(directory) as listing:
+                entries = sorted(listing, key=lambda entry: entry.name)
+        except (FileNotFoundError, NotADirectoryError):
+            return corpus
+        for entry in entries:
+            if not entry.name.endswith(".md"):
+                continue
+            names.add(entry.name)
+            number = extract_decision_number(entry.name)
+            # follow_symlinks=False: a symlink is not a file this layer reads,
+            # follows, or rewrites, whatever it points at.
+            if not entry.is_file(follow_symlinks=False):
+                irregular.append(IrregularEntry(name=entry.name, number=number))
+                continue
+            if number is None:
+                continue
+            corpus._files[entry.name] = DecisionFile(path=Path(entry.path), number=number)
+        corpus._names = frozenset(names)
+        corpus._irregular = tuple(irregular)
+        corpus._irregular_names = frozenset(item.name for item in irregular)
+        return corpus
+
+    # ── Listing ────────────────────────────────────────────────────────────
+
+    @property
+    def files(self) -> tuple[DecisionFile, ...]:
+        return tuple(self._files.values())
+
+    @property
+    def irregular(self) -> tuple[IrregularEntry, ...]:
+        return self._irregular
+
+    def holders(self, number: int) -> tuple[DecisionFile, ...]:
+        """Regular decision files claiming ``number``."""
+        return tuple(entry for entry in self._files.values() if entry.number == number)
+
+    def irregular_holders(self, number: int) -> tuple[IrregularEntry, ...]:
+        return tuple(entry for entry in self._irregular if entry.number == number)
+
+    def claimed_numbers(self) -> frozenset[int]:
+        """Every number claimed on disk, including by entries never read."""
+        return frozenset(
+            {entry.number for entry in self._files.values()}
+            | {entry.number for entry in self._irregular if entry.number is not None}
+        )
+
+    def file_named(self, name: str) -> DecisionFile | None:
+        """The numbered regular file under this exact name, if there is one."""
+        return self._files.get(name)
+
+    def is_irregular(self, name: str) -> bool:
+        """True when this listed name is not a regular file."""
+        return name in self._irregular_names
+
+    def has_name(self, name: str) -> bool:
+        """True when ``decisions/`` holds this exact filename, case included."""
+        return name in self._names
+
+    def case_variant(self, name: str) -> str | None:
+        """A listed name differing from ``name`` only by case, if there is one."""
+        if name in self._names:
+            return None
+        folded = name.lower()
+        for listed in sorted(self._names):
+            if listed.lower() == folded:
+                return listed
+        return None
+
+    # ── Parsed view ────────────────────────────────────────────────────────
+
+    def references(self) -> ReferenceIndex:
+        """Every supersession and question reference the store records.
+
+        Folded from per-file parses, so a rebuild after a mutation reparses
+        only the files that mutation created or changed.
+        """
+        if self._references is None:
+            unparseable: set[Path] = set()
+            refs: set[int] = set()
+            for entry in self._files.values():
+                parsed = entry.parsed()
+                if parsed.failed:
+                    unparseable.add(entry.path)
+                    continue
+                refs |= parsed.refs
+            question_refs, readable = self._question_references()
+            self._references = ReferenceIndex(
+                unparseable=frozenset(unparseable),
+                supersession_refs=frozenset(refs),
+                question_refs=question_refs,
+                questions_readable=readable,
+            )
+        return self._references
+
+    def _question_references(self) -> tuple[frozenset[int], bool]:
+        if self._questions is None:
+            self._questions = _read_question_references(self.store_path)
+        return self._questions
+
+    # ── Mutation notices ───────────────────────────────────────────────────
+
+    def record_added(self, path: Path, text: str) -> None:
+        """Note a decision file this run created, with the bytes it wrote."""
+        self._names = self._names | {path.name}
+        self._replace(path, text)
+
+    def record_renamed(self, old_path: Path, new_path: Path, text: str) -> None:
+        """Note a decision file this run moved, with the bytes now at the new path."""
+        self._files.pop(old_path.name, None)
+        self._names = (self._names - {old_path.name}) | {new_path.name}
+        self._replace(new_path, text)
+
+    def record_rewritten(self, path: Path, text: str) -> None:
+        """Note new bytes this run wrote to a decision file already listed."""
+        self._replace(path, text)
+
+    def _replace(self, path: Path, text: str) -> None:
+        number = extract_decision_number(path.name)
+        if number is not None:
+            self._files[path.name] = DecisionFile(path=path, number=number, _text=text)
+        self._references = None
+
+
+def _read_question_references(store_path: Path) -> tuple[frozenset[int], bool]:
+    """Decision numbers named as question resolutions, and whether that is known."""
+    path = store_path / OPEN_QUESTIONS_MD
+    if not path.is_file():
+        return frozenset(), True
+    try:
+        parsed = OpenQuestionsFile.parse(read_text_lenient(path))
+    except PARSE_FAILURES:
+        return frozenset(), False
+    return (
+        frozenset(
+            block.entry.resolved_by.decision_num
+            for block in parsed.blocks
+            if isinstance(block, EntryBlock) and block.entry.resolved_by is not None
+        ),
+        True,
+    )
+
+
+__all__ = [
+    "PARSE_FAILURES",
+    "DecisionCorpus",
+    "DecisionFile",
+    "IrregularEntry",
+    "ParsedDecision",
+    "ReferenceIndex",
+]

--- a/packages/nauro/src/nauro/sync/headings.py
+++ b/packages/nauro/src/nauro/sync/headings.py
@@ -1,0 +1,101 @@
+"""Decision-heading format primitives shared by the sync corpus and classifier.
+
+A decision file's identity is its filename number; its H1 repeats that number.
+The writer emits one canonical shape, ``# NNN — Title`` with the number
+zero-padded to three digits, while the parser is deliberately laxer and accepts
+an unpadded or over-padded number and arbitrary leading whitespace. Renumbering
+has to respect the narrower shape: a file whose heading is not in the canonical
+form is one this layer must not rewrite, because a partial or missed rewrite
+would leave a decision whose heading and filename disagree.
+
+Both questions - "what number does this heading claim?" and "may I rewrite
+it?" - are answered here, from one matcher, so the classification gate and the
+write can never drift apart.
+"""
+
+from __future__ import annotations
+
+_HEADING_SEPARATORS = ("—", "-")
+
+
+def heading_number(text: str) -> int | None:
+    """Return the number in the first decision H1, if the text has one.
+
+    Deliberately as lax as the decision parser: any digit run counts, so a
+    heading this module refuses to rewrite is still *read* correctly and a
+    filename/heading disagreement is detected rather than missed.
+    """
+    for line in text.splitlines():
+        number = heading_line_number(line)
+        if number is not None:
+            return number
+    return None
+
+
+def heading_line_number(line: str) -> int | None:
+    """Return the decision number one line claims as an H1, if it is one."""
+    if not line.startswith("#"):
+        return None
+    after_hash = line[1:]
+    rest = after_hash.lstrip(" ")
+    if len(rest) == len(after_hash):
+        # No space after the hash: "#Not a heading", or a deeper "## " level.
+        return None
+    head, _, tail = rest.partition(" ")
+    if not head.isdigit() or not tail.startswith(_HEADING_SEPARATORS):
+        return None
+    return int(head)
+
+
+def _rewritable_index(lines: list[str], num: int) -> int | None:
+    """Index of the first heading line the rewriter may address, if any."""
+    prefix = f"# {num:03d}"
+    for i, line in enumerate(lines):
+        if line.startswith(f"{prefix} —") or line.startswith(f"{prefix} -"):
+            return i
+    return None
+
+
+def has_rewritable_heading(text: str, num: int) -> bool:
+    """True when :func:`rewrite_decision_heading` would change this text's H1."""
+    return _rewritable_index(text.splitlines(keepends=True), num) is not None
+
+
+def rewrite_decision_heading(text: str, old_num: int, new_num: int) -> str:
+    """Rewrite the first canonical ``# NNN —`` / ``# NNN -`` H1 to ``new_num``.
+
+    Only the first line in canonical form is rewritten; the separator and the
+    rest of the line are preserved byte-for-byte. Text with no such line is
+    returned unchanged, so callers verify the result rather than assuming the
+    rewrite landed.
+    """
+    lines = text.splitlines(keepends=True)
+    index = _rewritable_index(lines, old_num)
+    if index is None:
+        return text
+    old_prefix = f"# {old_num:03d}"
+    lines[index] = f"# {new_num:03d}" + lines[index][len(old_prefix) :]
+    return "".join(lines)
+
+
+def strip_number_prefix(filename: str) -> str:
+    """Drop a leading ``NNN-`` decision-number prefix from a filename.
+
+    The leading digit run plus the single hyphen that immediately follows it
+    are removed. A digit run with no trailing hyphen is left intact.
+    """
+    idx = 0
+    while idx < len(filename) and filename[idx].isdigit():
+        idx += 1
+    if idx > 0 and idx < len(filename) and filename[idx] == "-":
+        return filename[idx + 1 :]
+    return filename
+
+
+__all__ = [
+    "has_rewritable_heading",
+    "heading_line_number",
+    "heading_number",
+    "rewrite_decision_heading",
+    "strip_number_prefix",
+]

--- a/packages/nauro/src/nauro/sync/hooks.py
+++ b/packages/nauro/src/nauro/sync/hooks.py
@@ -62,12 +62,23 @@ def pull_before_session(project_id: str, store_path: Path) -> int:
         return 0
 
     try:
+        from nauro.sync.lock import HOOK_SYNC_LOCK_TIMEOUT, SyncLockTimeoutError
         from nauro.sync.pull import run_pull
     except ImportError:
         return 0
 
     try:
-        return run_pull(project_id, store_path, _LoggingReporter())
+        return run_pull(
+            project_id,
+            store_path,
+            _LoggingReporter(),
+            lock_timeout=HOOK_SYNC_LOCK_TIMEOUT,
+        )
+    except SyncLockTimeoutError as exc:
+        # Contention is an ordinary outcome here, not a failure: the other
+        # process is doing this same work, and session start never waits.
+        logger.info("sync pull: skipped, %s", exc)
+        return 0
     except Exception:
         # A genuinely unexpected error must not escape session startup.
         logger.exception("sync pull: unexpected failure for %s", project_id)
@@ -89,13 +100,19 @@ def push_after_write(project_id: str, store_path: Path) -> int:
 
     try:
         from nauro.cli.commands.auth import AuthRefreshError
+        from nauro.sync.lock import HOOK_SYNC_LOCK_TIMEOUT, SyncLockTimeoutError
         from nauro.sync.push import push_changed_files
         from nauro.sync.remote import PresignError
     except ImportError:
         return 0
 
     try:
-        return push_changed_files(project_id, store_path)
+        return push_changed_files(project_id, store_path, lock_timeout=HOOK_SYNC_LOCK_TIMEOUT)
+    except SyncLockTimeoutError as exc:
+        # Post-write publication is a fail-open ancillary step: the changed
+        # files stay changed and the next push picks them up.
+        logger.info("sync push: skipped, %s", exc)
+        return 0
     except AuthRefreshError as exc:
         logger.warning("sync push: %s", exc)
         return 0

--- a/packages/nauro/src/nauro/sync/lock.py
+++ b/packages/nauro/src/nauro/sync/lock.py
@@ -1,0 +1,116 @@
+"""Store-scoped lock serializing sync pull and push.
+
+The pull core classifies a colliding decision, renames the local file, rewrites
+its heading, updates the hash index, and installs the remote file as a sequence
+of separate filesystem steps. A concurrent pull or push observing the store
+mid-sequence would classify against a half-applied state, so both directions
+take one lock per store for the whole run.
+
+Unlike :func:`~nauro.store.store_lock.store_write_lock`, which blocks
+indefinitely, every acquisition here carries a finite timeout: an explicit
+``nauro sync`` fails loud when another sync holds the store, and the
+SessionStart hook skips its pull rather than delaying session start.
+
+The lock file sits next to ``.sync-state.json`` and ends in ``.json.lock``, so
+``should_skip`` already excludes it from both the push scan and the manifest
+walk. Lock order is one-way: this lock is taken outside
+``decision_write_lock``, never inside it, so a sync holding the store can still
+mint a decision number while a kernel writer taking only the decision lock can
+never block on a sync.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+
+from filelock import FileLock, Timeout
+
+from nauro.constants import DECISIONS_DIR
+from nauro.store.store_lock import rmw_lock_path
+from nauro.sync.state import SYNC_STATE_FILE
+
+SYNC_LOCK_FILE = SYNC_STATE_FILE + ".lock"
+
+# An explicit `nauro sync` waits out a short overlapping sync (a SessionStart
+# pull, an MCP post-write push) rather than failing on a routine race.
+CLI_SYNC_LOCK_TIMEOUT = 10.0
+
+# Background paths never wait: session startup must not stall behind another
+# process's transfer, and a post-write push is a fail-open ancillary step.
+HOOK_SYNC_LOCK_TIMEOUT = 1.0
+
+
+class SyncLockTimeoutError(Exception):
+    """A lock a sync needs was held by someone else past the timeout."""
+
+    def __init__(self, store_path: Path, timeout: float, resource: str = "store") -> None:
+        super().__init__(
+            f"another writer is busy with {store_path.name}; "
+            f"waited {timeout:g}s for the {resource} lock"
+        )
+        self.store_path = store_path
+        self.timeout = timeout
+        self.resource = resource
+
+
+@contextmanager
+def _bounded(lock_path: Path, store_path: Path, timeout: float, resource: str):
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock = FileLock(str(lock_path), timeout=timeout)
+    try:
+        lock.acquire()
+    except Timeout as exc:
+        raise SyncLockTimeoutError(store_path, timeout, resource) from exc
+    try:
+        yield
+    finally:
+        lock.release()
+
+
+@contextmanager
+def sync_lock(store_path: Path, timeout: float):
+    """Hold the store's sync lock for the duration of the block.
+
+    Raises:
+        SyncLockTimeoutError: the lock was not acquired within ``timeout``.
+    """
+    with _bounded(store_path / SYNC_LOCK_FILE, store_path, timeout, "store"):
+        yield
+
+
+@contextmanager
+def decision_lock(store_path: Path, timeout: float):
+    """Hold the decision allocation lock, bounded by the caller's policy.
+
+    Same lock file as :func:`~nauro.store.decision_lock.decision_write_lock`,
+    so a sync and a kernel writer still exclude each other. The difference is
+    the wait: a kernel writer blocks until the store is free, which is right
+    for a user-initiated write, but would let a suspended writer hold session
+    start open indefinitely once the sync lock is already in hand. Every sync
+    acquisition is therefore finite and surfaces as
+    :class:`SyncLockTimeoutError`, which the CLI reports and the hooks skip on.
+
+    Taken inside the sync lock, never outside it, and never around a network
+    call: the kernel path takes only this lock, so the one-way order holds.
+
+    Raises:
+        SyncLockTimeoutError: the lock was not acquired within ``timeout``.
+    """
+    with _bounded(
+        rmw_lock_path(store_path, DECISIONS_DIR, is_directory=True),
+        store_path,
+        timeout,
+        "decisions",
+    ):
+        yield
+
+
+__all__ = [
+    "CLI_SYNC_LOCK_TIMEOUT",
+    "HOOK_SYNC_LOCK_TIMEOUT",
+    "SYNC_LOCK_FILE",
+    "SyncLockTimeoutError",
+    "decision_lock",
+    "sync_lock",
+]

--- a/packages/nauro/src/nauro/sync/merge.py
+++ b/packages/nauro/src/nauro/sync/merge.py
@@ -21,6 +21,16 @@ logger = logging.getLogger("nauro.sync")
 # because no automatic merge of two divergent rewrites is correct.
 _SET_UNION_PATHS = ("open-questions.md", "state_history.md")
 
+# Scratch directory a pull creates for the decision bodies it must hold before
+# taking the decision lock. Removed at the end of the run; the prefix keeps a
+# directory orphaned by a kill signal out of both sync directions.
+SPOOL_DIR_PREFIX = ".pull-spool-"
+
+# Recovery drop-box for content the pull declined to install: the losing side
+# of a last-write-wins conflict, and the remote decision behind a quarantined
+# number collision.
+CONFLICT_BACKUP_DIR = ".conflict-backup"
+
 # Files that are never synced. The graph command's default output lands in the
 # store directory; its generation timestamp changes every run, so its sha never
 # settles and syncing it would re-push the artifact on every run and fan it out
@@ -51,6 +61,8 @@ def should_skip(relative_path: str) -> bool:
     normalized = relative_path.replace("\\", "/")
     if normalized in NEVER_SYNC:
         return True
+    if normalized.split("/", 1)[0].startswith(SPOOL_DIR_PREFIX):
+        return True
     # The write-path provenance journal is store-local by design: it is
     # excluded from cloud sync in v1 (both its events log and its lock).
     if normalized.startswith(JOURNAL_DIR + "/"):
@@ -71,16 +83,26 @@ def detect_conflict(
     return local_changed and remote_changed
 
 
+def write_backup(project_path: Path, backup_name: str, content: bytes) -> Path:
+    """Write ``content`` into ``.conflict-backup/`` under ``backup_name``.
+
+    The single writer into the backup directory: the last-write-wins loser
+    below names its file by timestamp, the quarantined remote decision in
+    ``sync.quarantine`` names its file by remote version.
+    """
+    backup_dir = project_path / CONFLICT_BACKUP_DIR
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    backup_path = backup_dir / backup_name
+    backup_path.write_bytes(content)
+    logger.info("Conflict backup saved: %s", backup_path)
+    return backup_path
+
+
 def _save_conflict_backup(project_path: Path, relative_path: str, content: bytes) -> Path:
     """Save the losing version to .conflict-backup/."""
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     filename = relative_path.replace("/", "_")
-    backup_dir = project_path / ".conflict-backup"
-    backup_dir.mkdir(parents=True, exist_ok=True)
-    backup_path = backup_dir / f"{timestamp}-{filename}"
-    backup_path.write_bytes(content)
-    logger.info("Conflict backup saved: %s", backup_path)
-    return backup_path
+    return write_backup(project_path, f"{timestamp}-{filename}", content)
 
 
 def resolve_conflict(

--- a/packages/nauro/src/nauro/sync/merge.py
+++ b/packages/nauro/src/nauro/sync/merge.py
@@ -50,15 +50,20 @@ NEVER_SYNC = (".sync-state.json", DEFAULT_GRAPH_FILENAME)
 LOCK_ARTIFACT_SUFFIXES = (".md.lock", ".json.lock", RMW_LOCK_SUFFIX)
 
 
-def should_skip(relative_path: str) -> bool:
-    """Return True if this file should never be synced.
+def normalize_rel(relative_path: str) -> str:
+    """Return a store-relative path with POSIX separators.
 
-    Backslashes are normalized to forward slashes first: the push scan builds
-    relative paths via ``str(relative_to(...))``, which yields ``\\`` separators
-    on Windows, so every prefix/basename/suffix check below operates on a
-    POSIX-normalized path and stays cross-platform.
+    The push scan builds relative paths via ``str(relative_to(...))``, which
+    yields ``\\`` separators on Windows, and a manifest can carry either. Every
+    prefix and suffix check in the sync layer operates on the normalized form
+    so none of them has to remember which it was handed.
     """
-    normalized = relative_path.replace("\\", "/")
+    return relative_path.replace("\\", "/")
+
+
+def should_skip(relative_path: str) -> bool:
+    """Return True if this file should never be synced."""
+    normalized = normalize_rel(relative_path)
     if normalized in NEVER_SYNC:
         return True
     if normalized.split("/", 1)[0].startswith(SPOOL_DIR_PREFIX):

--- a/packages/nauro/src/nauro/sync/pull.py
+++ b/packages/nauro/src/nauro/sync/pull.py
@@ -54,11 +54,12 @@ from nauro.sync.collisions import (
     is_canonical_decision_path,
     run_completion_pass,
 )
-from nauro.sync.corpus import DecisionCorpus
+from nauro.sync.corpus import DecisionCorpus, SkipReason
 from nauro.sync.lock import CLI_SYNC_LOCK_TIMEOUT, decision_lock, sync_lock
 from nauro.sync.merge import (
     SPOOL_DIR_PREFIX,
     detect_conflict,
+    normalize_rel,
     resolve_conflict,
     should_skip,
 )
@@ -68,6 +69,7 @@ from nauro.sync.remote import (
     fetch_manifest,
     fetch_via_presigned_url,
     request_presigned_urls,
+    urls_by_path,
 )
 from nauro.sync.state import (
     SyncState,
@@ -210,11 +212,6 @@ class _Destination:
     inside_decisions: bool
     is_directory: bool
 
-    @property
-    def writable_generically(self) -> bool:
-        """True only where an untyped write may land."""
-        return self.inside_store and not self.inside_decisions and not self.is_directory
-
 
 def resolve_destination(store_path: Path, rel: str) -> _Destination:
     """Resolve a manifest path to the file it would really write.
@@ -233,7 +230,7 @@ def resolve_destination(store_path: Path, rel: str) -> _Destination:
     either crash on hashing a directory or, on a store that has none yet,
     create a regular file under the name every future decision write needs.
     """
-    normalized = rel.replace("\\", "/")
+    normalized = normalize_rel(rel)
     root = Path(os.path.realpath(store_path))
     decisions_root = Path(os.path.realpath(store_path / DECISIONS_DIR))
     resolved = Path(os.path.realpath(store_path / normalized))
@@ -243,6 +240,26 @@ def resolve_destination(store_path: Path, rel: str) -> _Destination:
         inside_decisions=resolved.is_relative_to(decisions_root),
         is_directory=resolved.is_dir(),
     )
+
+
+def needs_decision_gate(rel: str, destination: _Destination, state: SyncState) -> bool:
+    """True when this entry must be classified rather than written directly.
+
+    The planner routes on it and the write barrier refuses on it, so the two
+    cannot answer differently - which is exactly how a tracked decision once
+    ended up routed to an ordinary pull that the barrier then refused, leaving
+    every update after a decision's first sync stranded.
+
+    Either the spelling says decision or the destination does; the spelling
+    check is the cheap one and the destination check is the honest one. The
+    exemption is narrow: a canonically spelled decision that sync state already
+    tracks is an ordinary same-path update, changing no number and needing no
+    verdict. A path this store cannot enumerate is never exempt, however it is
+    tracked, because a legacy entry must not buy a file a pass around the gate.
+    """
+    if not (_is_decision_path(rel) or destination.inside_decisions):
+        return False
+    return not is_canonical_decision_path(rel) or rel not in state.files
 
 
 def _is_decision_path(rel: str) -> bool:
@@ -300,15 +317,7 @@ def _triage(
         if not destination.inside_store:
             reporter.warn(f"skipping manifest entry {rel!r}: it resolves outside the store")
             continue
-        # Either the spelling says decision or the destination does. The
-        # spelling check is the cheap one and the destination check is the
-        # honest one; a path only the latter recognises is exactly the kind
-        # this gate exists for. The tracked-state exemption comes last, so a
-        # legacy entry recorded under a spelling this store cannot enumerate
-        # never buys the file a pass around the gate.
-        if (_is_decision_path(rel) or destination.inside_decisions) and (
-            not is_canonical_decision_path(rel) or rel not in state.files
-        ):
+        if needs_decision_gate(rel, destination, state):
             number = extract_decision_number(_decision_name(rel))
             claimed = number is not None and bool(listing.holders(number))
             (contested if claimed else work.decisions).append(item)
@@ -400,7 +409,7 @@ def _run_pull_locked(
                     _apply_decision(corpus, transfer, state, manifest, reporter, tally)
 
     for transfer in _stream(urls, work.pulls, reporter):
-        if not _generic_write_allowed(store_path, transfer, reporter):
+        if not _generic_write_allowed(store_path, transfer, state, reporter):
             continue
         target = store_path / transfer.rel
         target.parent.mkdir(parents=True, exist_ok=True)
@@ -409,7 +418,7 @@ def _run_pull_locked(
         tally.merged += 1
 
     for transfer in _stream(urls, work.conflicts, reporter):
-        if not _generic_write_allowed(store_path, transfer, reporter):
+        if not _generic_write_allowed(store_path, transfer, state, reporter):
             continue
         _resolve_and_record(store_path, transfer, state)
         tally.merged += 1
@@ -447,11 +456,10 @@ def _presign(
     if len(urls) < len(operations):
         reporter.warn(f"presign returned {len(urls)} URLs for {len(operations)} ops")
 
-    return {
-        entry["path"]: entry["url"]
-        for entry in urls
-        if isinstance(entry, dict) and entry.get("verb") == "GET"
-    }
+    usable, skipped = urls_by_path(urls, "GET")
+    for entry in skipped:
+        reporter.warn(f"skipping unreadable presign entry {entry}")
+    return usable
 
 
 def _stream(
@@ -510,6 +518,20 @@ def _spool_batch(
     return spooled
 
 
+_SKIP_DETAIL: dict[SkipReason, str] = {
+    SkipReason.not_a_regular_file: (
+        "not a regular file (a directory or a symlink). Nauro never reads or changes "
+        "it, and holds back any remote decision claiming its number. Remove it or "
+        "replace it with a regular file."
+    ),
+    SkipReason.unreadable_name: (
+        "not a name Nauro reads - decision files end in a lowercase '.md'. It holds "
+        "back any remote decision claiming its number. Rename it to the lowercase "
+        "suffix so it becomes a decision again."
+    ),
+}
+
+
 def _report_completion(corpus: DecisionCorpus, reporter: Reporter) -> None:
     """Run the crash-window completion pass and report what it did."""
     outcome = run_completion_pass(corpus)
@@ -532,11 +554,7 @@ def _report_completion(corpus: DecisionCorpus, reporter: Reporter) -> None:
             "heading by hand, then run 'nauro sync' again"
         )
     for entry in corpus.irregular:
-        reporter.warn(
-            f"decisions/{entry.name} is not a regular file (a directory or a symlink); "
-            "Nauro never reads or changes it, and holds back any remote decision "
-            "claiming its number. Remove or replace it with a regular file."
-        )
+        reporter.warn(f"decisions/{entry.name}: {_SKIP_DETAIL[entry.reason]}")
     if outcome.retargeted_stems:
         reporter.info(
             f"Repointed {len(outcome.retargeted_stems)} decision-hash entr"
@@ -544,22 +562,35 @@ def _report_completion(corpus: DecisionCorpus, reporter: Reporter) -> None:
         )
 
 
-def _generic_write_allowed(store_path: Path, transfer: _Transfer, reporter: Reporter) -> bool:
+def _generic_write_allowed(
+    store_path: Path, transfer: _Transfer, state: SyncState, reporter: Reporter
+) -> bool:
     """Refuse an untyped write that would land somewhere it may not.
 
     The last check before bytes hit the disk, and the one that does not depend
-    on having predicted the spelling: planning routes by destination too, so
-    reaching here with a decision destination means the two disagreed, and the
-    write is the wrong place to resolve that.
+    on having predicted the spelling. It asks the same question the planner
+    asked, so reaching here with an entry that needed the gate means the two
+    disagreed, and the write is the wrong place to resolve that.
     """
     destination = resolve_destination(store_path, transfer.rel)
-    if destination.writable_generically:
-        return True
-    reporter.warn(
-        f"refusing to write {transfer.rel!r}: it resolves to {destination.path}, "
-        "which is not a path an ordinary pull may write"
-    )
-    return False
+    if not destination.inside_store:
+        reporter.warn(
+            f"refusing to write {transfer.rel!r}: it resolves to {destination.path}, "
+            "outside the store"
+        )
+        return False
+    if destination.is_directory:
+        reporter.warn(
+            f"refusing to write {transfer.rel!r}: it resolves to the directory {destination.path}"
+        )
+        return False
+    if needs_decision_gate(transfer.rel, destination, state):
+        reporter.warn(
+            f"refusing to write {transfer.rel!r}: it resolves to {destination.path}, "
+            "which is not a path an ordinary pull may write"
+        )
+        return False
+    return True
 
 
 def _resolve_and_record(store_path: Path, transfer: _Transfer, state: SyncState) -> None:
@@ -644,10 +675,7 @@ def _apply_decision(
     target.parent.mkdir(parents=True, exist_ok=True)
     target.write_bytes(transfer.content)
     update_file_state(state, transfer.rel, compute_sha256(target), transfer.etag)
-    if target.parent == store_path / DECISIONS_DIR:
-        # A manifest path that only spells the directory like decisions/ is not
-        # part of the corpus this run maintains, whatever the filesystem folds.
-        corpus.record_added(target, transfer.content.decode("utf-8", errors="replace"))
+    corpus.record_added(target, transfer.content.decode("utf-8", errors="replace"))
     tally.merged += 1
 
 

--- a/packages/nauro/src/nauro/sync/pull.py
+++ b/packages/nauro/src/nauro/sync/pull.py
@@ -3,29 +3,66 @@
 Shared by ``nauro sync`` (the pull half of pull-then-push) and the
 SessionStart hook (``pull_before_session``). Both callers fetch the
 server manifest, diff it against sync-state, mint presigned GET URLs, and
-transfer changed files directly from S3 — then renumber colliding
-decisions and merge conflicting append-only files.
+transfer changed files directly from S3 — then classify every untracked
+decision file before it lands and merge conflicting append-only files.
 
 The two callers differ only in how they surface progress: the CLI echoes
 to the terminal; the hook logs quietly and must never raise. That
 asymmetry is injected through the :class:`Reporter` protocol rather than
 branched inside the pull core, so the two paths cannot drift again.
+
+A run has two phases. It plans and fetches under the store's sync lock, which
+keeps two syncs off one store; then it writes everything under the decision
+lock as well, which keeps a local decision writer from minting a number into
+the middle of the batch. Nothing in the write phase touches the network, so the
+lock a local writer waits on is held for the length of a few file writes rather
+than the length of a transfer. Both acquisitions are bounded by the caller's
+policy: the CLI fails loud after a bounded wait, the hook skips its pull rather
+than delaying session start.
+
+Every decision file the store does not already track is written through the
+classifier, not just the ones that looked like collisions when the run planned
+its transfers - two remote files can claim one number, and a local writer can
+mint one between the plan and the write.
 """
 
 from __future__ import annotations
 
+import os
+import shutil
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Protocol
 
 from nauro_core import extract_decision_number
+from pydantic import BaseModel, ConfigDict, ValidationError
 
 from nauro.cli.commands.auth import AuthRefreshError
+from nauro.constants import DECISIONS_DIR
+from nauro.sync.collisions import (
+    DecisionOutcome,
+    DecisionVerdict,
+    QuarantineReason,
+    RenumberRefusedError,
+    apply_canonicalize,
+    apply_renumber,
+    classify_decision,
+    is_canonical_decision_path,
+    run_completion_pass,
+)
+from nauro.sync.corpus import DecisionCorpus
+from nauro.sync.lock import CLI_SYNC_LOCK_TIMEOUT, decision_lock, sync_lock
 from nauro.sync.merge import (
+    SPOOL_DIR_PREFIX,
     detect_conflict,
     resolve_conflict,
     should_skip,
 )
+from nauro.sync.quarantine import save_quarantine_backup
 from nauro.sync.remote import (
     PresignError,
     fetch_manifest,
@@ -33,6 +70,7 @@ from nauro.sync.remote import (
     request_presigned_urls,
 )
 from nauro.sync.state import (
+    SyncState,
     compute_sha256,
     file_changed_locally,
     file_changed_remotely,
@@ -56,110 +94,281 @@ class Reporter(Protocol):
         """Report a recoverable anomaly (presign URL shortfall, bad manifest)."""
 
 
-def _renumber_decision_if_collision(
+class _ManifestEntry(BaseModel):
+    """One server manifest row, as far as the pull core reads it."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    path: str
+    etag: str = ""
+
+
+@dataclass(frozen=True)
+class _RemoteFile:
+    """One manifest entry the pull decided to transfer."""
+
+    rel: str
+    etag: str
+
+
+@dataclass(frozen=True)
+class _Transfer:
+    """One fetched manifest entry, ready to be applied to the store.
+
+    A streamed transfer carries its bytes: it is written before the next one is
+    fetched, so only one body is ever live. A spooled transfer carries a path
+    instead and reads the body back when asked, so the gated decision batch -
+    which must be fetched in full before the lock is taken - costs one file's
+    memory rather than the whole batch's.
+    """
+
+    rel: str
+    etag: str
+    _body: bytes | None = None
+    _spooled: Path | None = None
+
+    @property
+    def content(self) -> bytes:
+        if self._spooled is not None:
+            return self._spooled.read_bytes()
+        assert self._body is not None  # one of the two is always set
+        return self._body
+
+
+@dataclass
+class _Tally:
+    """What one run changed, in the terms it reports."""
+
+    merged: int = 0
+    adopted: int = 0
+
+
+@dataclass(frozen=True)
+class _Manifest:
+    """The server's file list, parsed once into the views triage needs."""
+
+    entries: tuple[_ManifestEntry, ...]
+    paths: frozenset[str]
+    decision_numbers: frozenset[int]
+
+
+def _parse_manifest(rows: list[dict], reporter: Reporter) -> _Manifest:
+    """Parse the manifest into typed entries plus the path and number views.
+
+    The path set answers "could the server already hold this local file?" for
+    the collision classifier, so it spans every entry, including the ones
+    triage skips. The number set reserves the decision numbers the server holds
+    so a local renumber never mints onto one.
+    """
+    entries: list[_ManifestEntry] = []
+    for row in rows:
+        try:
+            entry = _ManifestEntry.model_validate(row)
+        except ValidationError:
+            reporter.warn(f"skipping unreadable manifest entry {row!r}")
+            continue
+        if entry.path:
+            entries.append(entry)
+
+    paths = {entry.path for entry in entries}
+    numbers = set()
+    for path in paths:
+        if _is_decision_path(path):
+            num = extract_decision_number(_decision_name(path))
+            if num is not None:
+                numbers.add(num)
+    return _Manifest(
+        entries=tuple(entries),
+        paths=frozenset(paths),
+        decision_numbers=frozenset(numbers),
+    )
+
+
+@dataclass
+class _Worklists:
+    """Manifest entries split by the treatment each one needs.
+
+    ``decisions`` holds every decision file the store does not track, whatever
+    it looked like at planning time; each one is classified again against the
+    live corpus before it is written.
+    """
+
+    decisions: list[_RemoteFile] = field(default_factory=list)
+    pulls: list[_RemoteFile] = field(default_factory=list)
+    conflicts: list[_RemoteFile] = field(default_factory=list)
+
+    def all_files(self) -> list[_RemoteFile]:
+        return self.decisions + self.pulls + self.conflicts
+
+
+@dataclass(frozen=True)
+class _Destination:
+    """Where a manifest path would actually put bytes on this machine."""
+
+    path: Path
+    inside_store: bool
+    inside_decisions: bool
+    is_directory: bool
+
+    @property
+    def writable_generically(self) -> bool:
+        """True only where an untyped write may land."""
+        return self.inside_store and not self.inside_decisions and not self.is_directory
+
+
+def resolve_destination(store_path: Path, rel: str) -> _Destination:
+    """Resolve a manifest path to the file it would really write.
+
+    The safety question is not how the manifest spelled a path but where the
+    bytes land, and the two come apart in more ways than a predicate can
+    enumerate: ``./decisions/x.md`` and ``.//decisions/x.md`` normalise into
+    the decisions directory, a backslash key is a separator on Windows (and the
+    push scan emits them there), and a symlink can point anywhere. Separators
+    are normalised the way ``should_skip`` already normalises them, then the
+    join is resolved through symlinks so the answer describes the filesystem
+    rather than the string.
+
+    The decisions directory counts as inside itself. An entry named exactly
+    ``decisions`` resolves to it, and treating that as an ordinary file would
+    either crash on hashing a directory or, on a store that has none yet,
+    create a regular file under the name every future decision write needs.
+    """
+    normalized = rel.replace("\\", "/")
+    root = Path(os.path.realpath(store_path))
+    decisions_root = Path(os.path.realpath(store_path / DECISIONS_DIR))
+    resolved = Path(os.path.realpath(store_path / normalized))
+    return _Destination(
+        path=resolved,
+        inside_store=resolved != root and resolved.is_relative_to(root),
+        inside_decisions=resolved.is_relative_to(decisions_root),
+        is_directory=resolved.is_dir(),
+    )
+
+
+def _is_decision_path(rel: str) -> bool:
+    """True for anything the manifest places under the decisions directory.
+
+    Deliberately wider than what may be written. Routing has to catch every
+    spelling that could name a decision on some filesystem - a folded case
+    (``Decisions/007-x.MD``), a trailing dot Windows strips
+    (``decisions/007-x.md.``), a path that normalises onto a real file
+    (``decisions//007-x.md``) - because the alternative for anything it misses
+    is the untyped path, which writes wherever the manifest points. What may
+    actually be written is decided by :func:`is_canonical_decision_path`, and
+    everything else under this directory is quarantined.
+    """
+    head, slash, _name = rel.partition("/")
+    return bool(slash) and head.casefold() == DECISIONS_DIR
+
+
+def _decision_name(rel: str) -> str:
+    """The filename part of a decision path, whatever the directory's spelling."""
+    return rel.partition("/")[2]
+
+
+def _triage(
     store_path: Path,
-    rel: str,
-    content: bytes,
-) -> tuple[str, bytes]:
-    """If a pulled decision file's number collides with an existing local file, renumber it.
+    manifest: _Manifest,
+    state: SyncState,
+    reporter: Reporter,
+) -> _Worklists:
+    """Split the manifest into gated decision writes, clean pulls, and conflicts.
 
-    Returns ``(possibly_renamed_rel, possibly_updated_content)``. Non-decision
-    files, files with no parseable number, an exact-filename match, or no
-    collision all pass through unchanged.
+    Planning only: it decides what to fetch, never what to write. The order it
+    puts decisions in is a preference, not a verdict - entries whose number an
+    existing local file already claims go first, so a collision is judged
+    against the store the user has rather than one this same run has written
+    unrelated files into.
     """
-    if not rel.startswith("decisions/"):
-        return rel, content
+    work = _Worklists()
+    listing = DecisionCorpus.scan(store_path)
+    contested: list[_RemoteFile] = []
+    for entry in manifest.entries:
+        rel = entry.path
+        if should_skip(rel):
+            continue
+        # Server validates per-op on presign, but the manifest itself is
+        # currently trusted — drop suspicious entries before they hit disk.
+        if ".." in Path(rel).parts or rel.startswith("/"):
+            reporter.warn(f"skipping suspicious manifest entry {rel!r}")
+            continue
+        if not file_changed_remotely(entry.etag, rel, state):
+            continue
 
-    filename = rel.split("/", 1)[1]
-    incoming_num = extract_decision_number(filename)
-    if incoming_num is None:
-        return rel, content
-    decisions_dir = store_path / "decisions"
-    if not decisions_dir.exists():
-        return rel, content
+        item = _RemoteFile(rel, entry.etag)
+        destination = resolve_destination(store_path, rel)
+        if not destination.inside_store:
+            reporter.warn(f"skipping manifest entry {rel!r}: it resolves outside the store")
+            continue
+        # Either the spelling says decision or the destination does. The
+        # spelling check is the cheap one and the destination check is the
+        # honest one; a path only the latter recognises is exactly the kind
+        # this gate exists for. The tracked-state exemption comes last, so a
+        # legacy entry recorded under a spelling this store cannot enumerate
+        # never buys the file a pass around the gate.
+        if (_is_decision_path(rel) or destination.inside_decisions) and (
+            not is_canonical_decision_path(rel) or rel not in state.files
+        ):
+            number = extract_decision_number(_decision_name(rel))
+            claimed = number is not None and bool(listing.holders(number))
+            (contested if claimed else work.decisions).append(item)
+            continue
 
-    if (decisions_dir / filename).exists():
-        return rel, content
+        if destination.is_directory:
+            # Nothing a manifest names as a file may land on a directory: the
+            # local-change probe below would hash it and raise.
+            reporter.warn(
+                f"skipping manifest entry {rel!r}: it resolves to the directory {destination.path}"
+            )
+            continue
 
-    collision = False
-    for f in decisions_dir.glob("*.md"):
-        n = extract_decision_number(f.name)
-        if n is not None and n == incoming_num:
-            collision = True
-            break
+        local_file = store_path / rel
+        if not file_changed_locally(store_path, rel, state):
+            work.pulls.append(item)
+            continue
 
-    if not collision:
-        return rel, content
+        local_sha = compute_sha256(local_file) if local_file.exists() else ""
+        if detect_conflict(rel, state, local_sha, entry.etag):
+            work.conflicts.append(item)
 
-    existing_nums = set()
-    for f in decisions_dir.glob("*.md"):
-        n = extract_decision_number(f.name)
-        if n is not None:
-            existing_nums.add(n)
-
-    next_num = max(existing_nums) + 1 if existing_nums else 1
-
-    slug = _strip_number_prefix(filename)
-    new_filename = f"{next_num:03d}-{slug}"
-    new_rel = f"decisions/{new_filename}"
-
-    text = content.decode("utf-8", errors="replace")
-    text = _rewrite_decision_heading(text, incoming_num, next_num)
-    content = text.encode("utf-8")
-
-    return new_rel, content
-
-
-def _strip_number_prefix(filename: str) -> str:
-    """Drop a leading ``NNN-`` decision-number prefix from a filename.
-
-    Mirrors ``re.sub(r"^\\d+-", "", filename)``: the leading digit run plus the
-    single hyphen that immediately follows it are removed. A digit run with no
-    trailing hyphen is left intact.
-    """
-    idx = 0
-    while idx < len(filename) and filename[idx].isdigit():
-        idx += 1
-    if idx > 0 and idx < len(filename) and filename[idx] == "-":
-        return filename[idx + 1 :]
-    return filename
-
-
-def _rewrite_decision_heading(text: str, incoming_num: int, next_num: int) -> str:
-    """Rewrite the first ``# NNN —`` / ``# NNN -`` decision H1 to the new number.
-
-    Mirrors ``re.sub(rf"^# {incoming_num:03d}( [—-])", ..., count=1,
-    flags=re.MULTILINE)``: only the first line whose start matches ``# NNN``
-    followed by a space and an em-dash or hyphen is rewritten; the separator and
-    the rest of the line are preserved byte-for-byte.
-    """
-    old_prefix = f"# {incoming_num:03d}"
-    new_prefix = f"# {next_num:03d}"
-    lines = text.splitlines(keepends=True)
-    for i, line in enumerate(lines):
-        if line.startswith(f"{old_prefix} —") or line.startswith(f"{old_prefix} -"):
-            lines[i] = new_prefix + line[len(old_prefix) :]
-            break
-    return "".join(lines)
+    work.decisions[:0] = contested
+    return work
 
 
 def run_pull(
     project_id: str,
     store_path: Path,
     reporter: Reporter,
+    *,
+    lock_timeout: float = CLI_SYNC_LOCK_TIMEOUT,
 ) -> int:
     """Pull remote changes for ``project_id`` into ``store_path``.
 
-    Walks the server manifest, fetches every changed file in memory (so a
-    colliding decision can be renumbered before it touches disk), then writes
-    clean pulls and resolves conflicting append-only files. Returns the number
-    of files merged.
+    Walks the server manifest, then applies it in two phases. Untracked
+    decision files are fetched together and written under the decision lock,
+    each classified immediately before its own write. Everything else streams:
+    fetched and written one file at a time, outside that lock, so a store whose
+    changed set is hundreds of megabytes of snapshots is never held in memory
+    and a local decision writer never waits on the whole batch.
 
-    Caller-facing failures (manifest/presign auth-refresh or transport errors)
-    are reported through ``reporter`` and map to a 0 return.
+    Returns the number of files merged. Caller-facing failures
+    (manifest/presign auth-refresh or transport errors) are reported through
+    ``reporter`` and map to a 0 return.
+
+    Raises:
+        ~nauro.sync.lock.SyncLockTimeoutError: another sync held the store
+            lock, or a local decision writer held the decision lock, for
+            longer than ``lock_timeout``.
     """
+    with sync_lock(store_path, lock_timeout):
+        return _run_pull_locked(project_id, store_path, reporter, lock_timeout)
+
+
+def _run_pull_locked(
+    project_id: str, store_path: Path, reporter: Reporter, lock_timeout: float
+) -> int:
     try:
-        manifest = fetch_manifest(project_id)
+        rows = fetch_manifest(project_id)
     except AuthRefreshError as exc:
         reporter.warn(str(exc))
         return 0
@@ -167,117 +376,297 @@ def run_pull(
         reporter.warn(f"manifest fetch failed: {exc}")
         return 0
 
+    manifest = _parse_manifest(rows, reporter)
     state = load_state(store_path)
+    work = _triage(store_path, manifest, state, reporter)
 
-    pulls: list[tuple[str, str]] = []
-    conflicts: list[tuple[str, str]] = []
-    for entry in manifest:
-        rel = entry.get("path", "") if isinstance(entry, dict) else ""
-        if not rel or should_skip(rel):
-            continue
-        # Server validates per-op on presign, but the manifest itself is
-        # currently trusted — drop suspicious entries before they hit disk.
-        if ".." in Path(rel).parts or rel.startswith("/"):
-            reporter.warn(f"skipping suspicious manifest entry {rel!r}")
-            continue
-        remote_etag = entry.get("etag", "")
-        if not file_changed_remotely(remote_etag, rel, state):
-            continue
-
-        local_file = store_path / rel
-        local_changed = file_changed_locally(store_path, rel, state)
-        if not local_changed:
-            pulls.append((rel, remote_etag))
-            continue
-
-        local_sha = compute_sha256(local_file) if local_file.exists() else ""
-        if detect_conflict(rel, state, local_sha, remote_etag):
-            conflicts.append((rel, remote_etag))
-
-    if not pulls and not conflicts:
-        state.last_full_sync = datetime.now(timezone.utc).isoformat()
-        save_state(store_path, state)
-        reporter.info("No remote changes")
+    urls = _presign(project_id, work.all_files(), reporter)
+    if urls is None:
         return 0
 
-    operations = [{"verb": "GET", "path": rel} for rel, _etag in pulls + conflicts]
+    tally = _Tally()
+    # The gated batch has to be complete before the lock is taken, because the
+    # lock must not span a transfer. It is spooled to disk rather than held:
+    # a manifest is server-supplied input, and its total size is not a number
+    # this process gets to be surprised by.
+    with _spool(store_path) as spool:
+        gated = _spool_batch(urls, work.decisions, reporter, spool)
+        with decision_lock(store_path, lock_timeout):
+            corpus = DecisionCorpus.scan(store_path)
+            _report_completion(corpus, reporter)
+            for item in work.decisions:
+                transfer = gated.get(item.rel)
+                if transfer is not None:
+                    _apply_decision(corpus, transfer, state, manifest, reporter, tally)
+
+    for transfer in _stream(urls, work.pulls, reporter):
+        if not _generic_write_allowed(store_path, transfer, reporter):
+            continue
+        target = store_path / transfer.rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(transfer.content)
+        update_file_state(state, transfer.rel, compute_sha256(target), transfer.etag)
+        tally.merged += 1
+
+    for transfer in _stream(urls, work.conflicts, reporter):
+        if not _generic_write_allowed(store_path, transfer, reporter):
+            continue
+        _resolve_and_record(store_path, transfer, state)
+        tally.merged += 1
+
+    state.last_full_sync = datetime.now(timezone.utc).isoformat()
+    save_state(store_path, state)
+
+    if tally.adopted:
+        reporter.info(f"Adopted {tally.adopted} local file(s) already on the server")
+    if tally.merged:
+        reporter.info(f"Merged {tally.merged} file(s) from remote")
+    elif not tally.adopted:
+        reporter.info("No remote changes")
+
+    return tally.merged
+
+
+def _presign(
+    project_id: str, planned: list[_RemoteFile], reporter: Reporter
+) -> dict[str, str] | None:
+    """Mint one GET URL per planned file, or None on a request failure."""
+    if not planned:
+        return {}
+
+    operations = [{"verb": "GET", "path": item.rel} for item in planned]
     try:
         urls = request_presigned_urls(project_id, operations)
     except AuthRefreshError as exc:
         reporter.warn(str(exc))
-        return 0
+        return None
     except PresignError as exc:
         reporter.warn(f"presign request failed: {exc}")
-        return 0
+        return None
 
     if len(urls) < len(operations):
         reporter.warn(f"presign returned {len(urls)} URLs for {len(operations)} ops")
 
-    url_by_path = {
+    return {
         entry["path"]: entry["url"]
         for entry in urls
         if isinstance(entry, dict) and entry.get("verb") == "GET"
     }
 
-    merged = 0
 
-    for rel, remote_etag in pulls:
-        url = url_by_path.get(rel)
+def _stream(
+    urls: dict[str, str], items: list[_RemoteFile], reporter: Reporter
+) -> Iterator[_Transfer]:
+    """Yield each planned file's bytes, fetched one at a time.
+
+    The caller writes each one before the next is fetched, so only a single
+    file's content is ever held.
+    """
+    for item in items:
+        url = urls.get(item.rel)
         if not url:
             continue
         try:
-            remote_content = fetch_via_presigned_url(url)
+            content = fetch_via_presigned_url(url)
         except PresignError as exc:
-            reporter.warn(f"error pulling {rel}: {exc}")
+            reporter.warn(f"error pulling {item.rel}: {exc}")
             continue
-        actual_rel, remote_content = _renumber_decision_if_collision(
-            store_path, rel, remote_content
-        )
-        actual_file = store_path / actual_rel
-        actual_file.parent.mkdir(parents=True, exist_ok=True)
-        actual_file.write_bytes(remote_content)
-        local_sha = compute_sha256(actual_file)
-        update_file_state(state, actual_rel, local_sha, remote_etag)
-        merged += 1
+        yield _Transfer(rel=item.rel, etag=item.etag, _body=content)
 
-    for rel, remote_etag in conflicts:
-        url = url_by_path.get(rel)
+
+@contextmanager
+def _spool(store_path: Path) -> Iterator[Path]:
+    """A scratch directory for fetched decision bodies, removed on the way out.
+
+    It lives in the store so it shares the store's filesystem, and its name
+    carries the prefix ``should_skip`` excludes, so a directory left behind by
+    a kill signal is never pushed or pulled.
+    """
+    directory = Path(tempfile.mkdtemp(prefix=SPOOL_DIR_PREFIX, dir=store_path))
+    try:
+        yield directory
+    finally:
+        shutil.rmtree(directory, ignore_errors=True)
+
+
+def _spool_batch(
+    urls: dict[str, str], items: list[_RemoteFile], reporter: Reporter, spool: Path
+) -> dict[str, _Transfer]:
+    """Fetch a batch onto disk, keyed by store-relative path."""
+    spooled: dict[str, _Transfer] = {}
+    for index, item in enumerate(items):
+        url = urls.get(item.rel)
         if not url:
             continue
         try:
-            remote_content = fetch_via_presigned_url(url)
+            content = fetch_via_presigned_url(url)
         except PresignError as exc:
-            reporter.warn(f"error resolving conflict for {rel}: {exc}")
+            reporter.warn(f"error pulling {item.rel}: {exc}")
             continue
-        actual_rel, remote_content = _renumber_decision_if_collision(
-            store_path, rel, remote_content
+        body = spool / f"{index:06d}"
+        body.write_bytes(content)
+        del content
+        spooled[item.rel] = _Transfer(rel=item.rel, etag=item.etag, _spooled=body)
+    return spooled
+
+
+def _report_completion(corpus: DecisionCorpus, reporter: Reporter) -> None:
+    """Run the crash-window completion pass and report what it did."""
+    outcome = run_completion_pass(corpus)
+    for repair in outcome.repaired:
+        reporter.info(
+            f"Completed an interrupted renumber: {repair.path.name} heading "
+            f"{repair.from_num:03d} -> {repair.to_num:03d}"
         )
-        if actual_rel != rel:
-            # Decision-number collision, not a content conflict — write as a new file.
-            actual_file = store_path / actual_rel
-            actual_file.parent.mkdir(parents=True, exist_ok=True)
-            actual_file.write_bytes(remote_content)
-            local_sha = compute_sha256(actual_file)
-            update_file_state(state, actual_rel, local_sha, remote_etag)
-            merged += 1
-            continue
+    for path in outcome.unrepairable:
+        reporter.warn(
+            f"{path.name}: its heading number and filename number disagree, and it "
+            "cannot be realigned because another file claims that number, another "
+            "record references it, or the store could not be read. Rename the file "
+            "to match its heading, or resolve the other claim first."
+        )
+    for path in outcome.quarantined:
+        reporter.warn(
+            f"{path.name}: its heading number and filename number disagree, and its "
+            "heading is not in the canonical form this tool rewrites; correct the "
+            "heading by hand, then run 'nauro sync' again"
+        )
+    for entry in corpus.irregular:
+        reporter.warn(
+            f"decisions/{entry.name} is not a regular file (a directory or a symlink); "
+            "Nauro never reads or changes it, and holds back any remote decision "
+            "claiming its number. Remove or replace it with a regular file."
+        )
+    if outcome.retargeted_stems:
+        reporter.info(
+            f"Repointed {len(outcome.retargeted_stems)} decision-hash entr"
+            f"{'y' if len(outcome.retargeted_stems) == 1 else 'ies'} at renamed files"
+        )
 
-        local_file = store_path / rel
-        merged_content = resolve_conflict(store_path, local_file, remote_content, rel)
-        local_file.write_bytes(merged_content)
-        local_sha = compute_sha256(local_file)
-        update_file_state(state, rel, local_sha, remote_etag)
-        merged += 1
 
-    state.last_full_sync = datetime.now(timezone.utc).isoformat()
-    save_state(store_path, state)
+def _generic_write_allowed(store_path: Path, transfer: _Transfer, reporter: Reporter) -> bool:
+    """Refuse an untyped write that would land somewhere it may not.
 
-    if merged:
-        reporter.info(f"Merged {merged} file(s) from remote")
-    else:
-        reporter.info("No remote changes")
+    The last check before bytes hit the disk, and the one that does not depend
+    on having predicted the spelling: planning routes by destination too, so
+    reaching here with a decision destination means the two disagreed, and the
+    write is the wrong place to resolve that.
+    """
+    destination = resolve_destination(store_path, transfer.rel)
+    if destination.writable_generically:
+        return True
+    reporter.warn(
+        f"refusing to write {transfer.rel!r}: it resolves to {destination.path}, "
+        "which is not a path an ordinary pull may write"
+    )
+    return False
 
-    return merged
+
+def _resolve_and_record(store_path: Path, transfer: _Transfer, state: SyncState) -> None:
+    """Apply the last-write-wins conflict policy and record the result."""
+    local_file = store_path / transfer.rel
+    merged_content = resolve_conflict(store_path, local_file, transfer.content, transfer.rel)
+    local_file.write_bytes(merged_content)
+    update_file_state(state, transfer.rel, compute_sha256(local_file), transfer.etag)
+
+
+def _apply_decision(
+    corpus: DecisionCorpus,
+    transfer: _Transfer,
+    state: SyncState,
+    manifest: _Manifest,
+    reporter: Reporter,
+    tally: _Tally,
+) -> None:
+    """Classify one untracked remote decision and act on the verdict.
+
+    A renumber frees the contested number without settling what happens to the
+    remote file, so the verdict is taken again once the local file has moved.
+    The second pass is against a number nothing claims, so it cannot ask for
+    another renumber; a store that still contests the number after one move has
+    more than one claim on it and is quarantined.
+    """
+    store_path = corpus.store_path
+    verdict = classify_decision(corpus, transfer.rel, transfer.content, state, manifest.paths)
+    if verdict.outcome is DecisionOutcome.renumber_local:
+        number = extract_decision_number(_decision_name(transfer.rel))
+        assert number is not None  # a renumber verdict names a numbered collider
+        try:
+            renumber = apply_renumber(corpus, verdict.collider, number, manifest.decision_numbers)
+        except RenumberRefusedError as exc:
+            # Refused before anything was renamed or written, and the refusal
+            # names its own reason rather than borrowing the heading's.
+            reporter.warn(str(exc))
+            _quarantine(store_path, transfer, verdict.quarantined_as(exc.reason), reporter)
+            return
+        reporter.info(
+            f"Renumbered unpublished local decision {renumber.old_num:03d} -> "
+            f"{renumber.new_num:03d} ({renumber.new_path.name}) to free the "
+            f"number for {transfer.rel}"
+        )
+        verdict = classify_decision(corpus, transfer.rel, transfer.content, state, manifest.paths)
+        if verdict.outcome is DecisionOutcome.renumber_local:
+            _quarantine(
+                store_path,
+                transfer,
+                verdict.quarantined_as(QuarantineReason.ambiguous_colliders),
+                reporter,
+            )
+            return
+
+    if verdict.outcome is DecisionOutcome.quarantine:
+        _quarantine(store_path, transfer, verdict, reporter)
+        return
+
+    if verdict.outcome is DecisionOutcome.canonicalize:
+        renamed = apply_canonicalize(corpus, verdict.collider, transfer.rel)
+        update_file_state(state, transfer.rel, compute_sha256(renamed), transfer.etag)
+        reporter.info(
+            f"Adopted local {verdict.collider.name} as {renamed.name}: "
+            "same decision under two names"
+        )
+        tally.adopted += 1
+        return
+
+    if verdict.outcome is DecisionOutcome.adopt:
+        update_file_state(state, transfer.rel, compute_sha256(verdict.collider), transfer.etag)
+        tally.adopted += 1
+        return
+
+    if verdict.outcome is DecisionOutcome.resolve_conflict:
+        # Last-write-wins keeps the local decision, so the file on disk is
+        # byte-unchanged and the corpus still describes it.
+        _resolve_and_record(store_path, transfer, state)
+        tally.merged += 1
+        return
+
+    target = store_path / transfer.rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(transfer.content)
+    update_file_state(state, transfer.rel, compute_sha256(target), transfer.etag)
+    if target.parent == store_path / DECISIONS_DIR:
+        # A manifest path that only spells the directory like decisions/ is not
+        # part of the corpus this run maintains, whatever the filesystem folds.
+        corpus.record_added(target, transfer.content.decode("utf-8", errors="replace"))
+    tally.merged += 1
+
+
+def _quarantine(
+    store_path: Path,
+    transfer: _Transfer,
+    verdict: DecisionVerdict,
+    reporter: Reporter,
+) -> None:
+    """Leave both sides alone, back up the remote bytes, and say so."""
+    backup = save_quarantine_backup(store_path, transfer.rel, transfer.content, transfer.etag)
+    local_names = ", ".join(path.name for path in verdict.colliders)
+    text = verdict.text()
+    named = f" ({local_names})" if local_names else ""
+    reporter.warn(
+        f"Decision-number collision: remote {transfer.rel} was not installed because "
+        f"{text.detail}{named}. {text.guidance} "
+        f"The remote version is saved at {backup}."
+    )
 
 
 __all__ = ["Reporter", "run_pull"]

--- a/packages/nauro/src/nauro/sync/push.py
+++ b/packages/nauro/src/nauro/sync/push.py
@@ -104,6 +104,7 @@ def _push_changed_files_locked(project_id: str, store_path: Path) -> int:
         PresignError,
         put_via_presigned_url,
         request_presigned_urls,
+        urls_by_path,
     )
     from nauro.sync.state import compute_sha256, load_state, save_state, update_file_state
 
@@ -157,11 +158,9 @@ def _push_changed_files_locked(project_id: str, store_path: Path) -> int:
     if len(urls) < len(operations):
         logger.warning("Presign returned %d URLs for %d ops", len(urls), len(operations))
 
-    url_by_path = {
-        entry["path"]: entry["url"]
-        for entry in urls
-        if isinstance(entry, dict) and entry.get("verb") == "PUT"
-    }
+    url_by_path, skipped = urls_by_path(urls, "PUT")
+    for entry in skipped:
+        logger.warning("Skipping unreadable presign entry %s", entry)
 
     pushed = 0
     for rel, local_sha, local_file in changed:

--- a/packages/nauro/src/nauro/sync/push.py
+++ b/packages/nauro/src/nauro/sync/push.py
@@ -20,6 +20,7 @@ from nauro_core.constants import MAX_BRIEF_BYTES
 
 from nauro.cli.commands.auth import load_access_token
 from nauro.store.registry import is_cloud_project
+from nauro.sync.lock import CLI_SYNC_LOCK_TIMEOUT, sync_lock
 
 logger = logging.getLogger("nauro.sync")
 
@@ -33,9 +34,12 @@ def push_store_to_cloud(project_id: str, store_path: Path) -> bool:
     upload.
 
     A presign/auth-refresh failure during the push is reported and maps
-    to False; per-file PUT failures are logged and skipped.
+    to False; per-file PUT failures are logged and skipped. A concurrent sync
+    holding the store lock past the bounded wait is also a reported failure:
+    an explicit sync must not report success for an upload it never attempted.
     """
     from nauro.cli.commands.auth import AuthRefreshError
+    from nauro.sync.lock import SyncLockTimeoutError
     from nauro.sync.remote import PresignError
 
     if not is_cloud_project(project_id):
@@ -51,6 +55,9 @@ def push_store_to_cloud(project_id: str, store_path: Path) -> bool:
 
     try:
         pushed = push_changed_files(project_id, store_path)
+    except SyncLockTimeoutError as exc:
+        typer.echo(f"  Warning: {exc}", err=True)
+        return False
     except AuthRefreshError as exc:
         typer.echo(f"  {exc}", err=True)
         return False
@@ -64,18 +71,34 @@ def push_store_to_cloud(project_id: str, store_path: Path) -> bool:
     return True
 
 
-def push_changed_files(project_id: str, store_path: Path) -> int:
+def push_changed_files(
+    project_id: str,
+    store_path: Path,
+    *,
+    lock_timeout: float = CLI_SYNC_LOCK_TIMEOUT,
+) -> int:
     """Upload every store file whose local sha differs from sync-state.
 
     POSTs ``/sync/presign`` for the changed paths, then PUTs each one to
     its presigned URL, recording the returned ETag in sync-state. Returns
     the number of files successfully pushed.
 
+    Held under the store's sync lock for the whole run: a pull resolving a
+    decision-number collision renames local files, and a push scanning the
+    store mid-sequence would upload a half-applied rename.
+
     Raises :class:`~nauro.cli.commands.auth.AuthRefreshError` or
     :class:`~nauro.sync.remote.PresignError` if minting the presigned
     URLs fails; per-file PUT failures are logged and skipped so a partial
     upload still records the files that did land.
+    Raises :class:`~nauro.sync.lock.SyncLockTimeoutError` when another sync holds
+    the store lock for longer than ``lock_timeout``.
     """
+    with sync_lock(store_path, lock_timeout):
+        return _push_changed_files_locked(project_id, store_path)
+
+
+def _push_changed_files_locked(project_id: str, store_path: Path) -> int:
     from nauro.sync.merge import should_skip
     from nauro.sync.remote import (
         PresignError,

--- a/packages/nauro/src/nauro/sync/quarantine.py
+++ b/packages/nauro/src/nauro/sync/quarantine.py
@@ -66,10 +66,14 @@ class QuarantinedCollision:
         return self.remote_path if self.complete_path else f"{self.remote_path}..."
 
 
+def _digest(material: bytes) -> str:
+    """The fixed-width, filename-safe key this module identifies things by."""
+    return hashlib.sha256(material).hexdigest()[:_KEY_LENGTH]
+
+
 def quarantine_key(remote_etag: str, remote_content: bytes) -> str:
     """Return the backup key identifying one remote version of a decision."""
-    material = remote_etag.encode("utf-8") if remote_etag else remote_content
-    return hashlib.sha256(material).hexdigest()[:_KEY_LENGTH]
+    return _digest(remote_etag.encode("utf-8") if remote_etag else remote_content)
 
 
 def path_key(remote_path: str) -> str:
@@ -82,7 +86,7 @@ def path_key(remote_path: str) -> str:
     bytes and renders as lowercase hex, which no filesystem folds together, so
     distinct paths always get distinct files.
     """
-    return hashlib.sha256(remote_path.encode("utf-8")).hexdigest()[:_KEY_LENGTH]
+    return _digest(remote_path.encode("utf-8"))
 
 
 def _encode_path(remote_path: str) -> str:
@@ -113,7 +117,7 @@ def _decode_path(encoded: str) -> str:
     index = 0
     while index < len(encoded):
         char = encoded[index]
-        if char == "%" and index + 2 < len(encoded) + 1:
+        if char == "%" and index + 2 <= len(encoded):
             hex_digits = encoded[index + 1 : index + 3]
             if len(hex_digits) == 2:
                 try:

--- a/packages/nauro/src/nauro/sync/quarantine.py
+++ b/packages/nauro/src/nauro/sync/quarantine.py
@@ -1,0 +1,237 @@
+"""Quarantine records for decision-number collisions the pull cannot resolve.
+
+A quarantined collision leaves the local decision file untouched and never
+records sync state for the remote file, so the collision is re-detected and
+re-reported on every pull until a human resolves it. The only durable artifact
+is the remote file's bytes, dropped into ``.conflict-backup/`` under a name
+keyed by the remote version rather than the wall clock: re-pulling the same
+remote decision reproduces the same name, so repeated SessionStart pulls leave
+exactly one backup instead of one per session.
+
+The same naming makes the backup directory the state surface both status
+commands read. A quarantine counts as resolved once the remote path it names
+carries a sync-state entry, which happens only when a later pull installed that
+file for real.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import string
+from dataclasses import dataclass
+from pathlib import Path
+
+from nauro.sync.collisions import is_canonical_decision_path
+from nauro.sync.merge import CONFLICT_BACKUP_DIR, write_backup
+from nauro.sync.state import SyncState, load_state
+
+_BACKUP_PREFIX = "number-collision-"
+
+# Characters a backup filename may carry unescaped. Everything else is
+# percent-encoded, so the name is a single flat component on every filesystem.
+_SAFE_NAME_CHARS = frozenset(string.ascii_letters + string.digits + "._-")
+
+# The two digests plus the prefix and separators account for 51 characters, so
+# this keeps the whole component under 200 - well inside the 255-byte limit
+# common to every filesystem this runs on.
+_MAX_ENCODED_PATH = 145
+
+# The remote ETag is a header value: it carries quotes, may be absent, and is
+# not a safe filename on every platform. A fixed-width digest of it keys the
+# backup instead: same one-name-per-remote-version property, always a legal
+# filename.
+_KEY_LENGTH = 16
+
+
+@dataclass(frozen=True)
+class QuarantinedCollision:
+    """One quarantined remote decision, recovered from its backup filename.
+
+    ``remote_path`` is for display and may be a prefix of the path the server
+    held, since a very long name is capped in the filename. ``path_digest`` is
+    over the whole path and is what identity is decided on.
+    """
+
+    remote_path: str
+    path_digest: str
+    backup_path: Path
+
+    @property
+    def complete_path(self) -> bool:
+        """False when the displayed path was capped in the backup filename."""
+        return path_key(self.remote_path) == self.path_digest
+
+    @property
+    def label(self) -> str:
+        return self.remote_path if self.complete_path else f"{self.remote_path}..."
+
+
+def quarantine_key(remote_etag: str, remote_content: bytes) -> str:
+    """Return the backup key identifying one remote version of a decision."""
+    material = remote_etag.encode("utf-8") if remote_etag else remote_content
+    return hashlib.sha256(material).hexdigest()[:_KEY_LENGTH]
+
+
+def path_key(remote_path: str) -> str:
+    """Return the key identifying one exact remote path.
+
+    The encoded path already appears in the filename, but on a case-folding
+    filesystem two paths that differ only in case name one physical file - so
+    two distinct quarantines would share a backup, and installing the canonical
+    one would appear to resolve the other. This digest is over the path's exact
+    bytes and renders as lowercase hex, which no filesystem folds together, so
+    distinct paths always get distinct files.
+    """
+    return hashlib.sha256(remote_path.encode("utf-8")).hexdigest()[:_KEY_LENGTH]
+
+
+def _encode_path(remote_path: str) -> str:
+    """Flatten a store path into one filename component without losing it.
+
+    Percent-encoding over an allowlist rather than escaping the separators we
+    happened to think of: a quarantined path is server-supplied and can carry
+    anything, and everything outside the safe set is a filename hazard
+    somewhere - a backslash is a separator on Windows and would send the write
+    into a directory that does not exist, a colon opens an alternate data
+    stream, a trailing dot or space is silently stripped. Encoding by byte also
+    keeps a non-ASCII path from depending on the filesystem's normalisation.
+    """
+    encoded = "".join(
+        chr(byte) if chr(byte) in _SAFE_NAME_CHARS else f"%{byte:02X}"
+        for byte in remote_path.encode("utf-8")
+    )
+    if encoded.endswith("."):
+        # Windows strips a trailing dot, so the name written would not be the
+        # name computed and the backup would multiply on every pull.
+        encoded = encoded[:-1] + "%2E"
+    return encoded
+
+
+def _decode_path(encoded: str) -> str:
+    """Inverse of :func:`_encode_path`, tolerant of a truncated tail."""
+    out = bytearray()
+    index = 0
+    while index < len(encoded):
+        char = encoded[index]
+        if char == "%" and index + 2 < len(encoded) + 1:
+            hex_digits = encoded[index + 1 : index + 3]
+            if len(hex_digits) == 2:
+                try:
+                    out.append(int(hex_digits, 16))
+                except ValueError:
+                    out.extend(char.encode("utf-8"))
+                    index += 1
+                    continue
+                index += 3
+                continue
+        out.extend(char.encode("utf-8"))
+        index += 1
+    return out.decode("utf-8", errors="replace")
+
+
+def _truncate_encoded(encoded: str) -> str:
+    """Cap the encoded path so the whole filename stays well inside any limit.
+
+    Identity lives in the two digests, so a capped tail costs display
+    completeness and nothing else. The cut never lands inside a percent escape,
+    which would decode to a different byte than the one encoded.
+    """
+    if len(encoded) <= _MAX_ENCODED_PATH:
+        return encoded
+    cut = _MAX_ENCODED_PATH
+    for start in range(cut - 2, cut):
+        if 0 <= start < len(encoded) and encoded[start] == "%":
+            cut = start
+            break
+    return encoded[:cut]
+
+
+def backup_name(remote_path: str, key: str) -> str:
+    encoded = _truncate_encoded(_encode_path(remote_path))
+    return f"{_BACKUP_PREFIX}{key}-{path_key(remote_path)}-{encoded}"
+
+
+def save_quarantine_backup(
+    store_path: Path, remote_path: str, remote_content: bytes, remote_etag: str
+) -> Path:
+    """Drop the quarantined remote decision into the backup directory.
+
+    An existing backup for the same remote version is left as it is, so the
+    idempotent re-pull neither rewrites nor multiplies it.
+    """
+    name = backup_name(remote_path, quarantine_key(remote_etag, remote_content))
+    existing = store_path / CONFLICT_BACKUP_DIR / name
+    if existing.exists():
+        return existing
+    return write_backup(store_path, name, remote_content)
+
+
+def _parse_backup_name(name: str) -> tuple[str, str] | None:
+    """Recover the path digest and displayable path from a backup filename.
+
+    Only this module writes the prefix, so the prefix and key shape are enough
+    to tell a quarantine copy from a last-write-wins backup; the path itself is
+    whatever was encoded, including spellings this store would never write.
+    """
+    if not name.startswith(_BACKUP_PREFIX):
+        return None
+    rest = name[len(_BACKUP_PREFIX) :]
+    keys: list[str] = []
+    for _position in range(2):
+        if len(rest) <= _KEY_LENGTH or rest[_KEY_LENGTH] != "-":
+            return None
+        keys.append(rest[:_KEY_LENGTH])
+        rest = rest[_KEY_LENGTH + 1 :]
+    decoded = _decode_path(rest)
+    if not decoded:
+        return None
+    return keys[1], decoded
+
+
+def list_quarantine_backups(store_path: Path) -> list[QuarantinedCollision]:
+    """Every quarantine backup on disk, resolved or not, sorted by remote path."""
+    backup_dir = store_path / CONFLICT_BACKUP_DIR
+    if not backup_dir.is_dir():
+        return []
+    found = []
+    for entry in backup_dir.iterdir():
+        if not entry.is_file():
+            continue
+        parsed = _parse_backup_name(entry.name)
+        if parsed is not None:
+            digest, remote_path = parsed
+            found.append(
+                QuarantinedCollision(remote_path=remote_path, path_digest=digest, backup_path=entry)
+            )
+    return sorted(found, key=lambda item: (item.remote_path, item.backup_path.name))
+
+
+def unresolved_quarantines(
+    store_path: Path, state: SyncState | None = None
+) -> list[QuarantinedCollision]:
+    """Quarantined collisions whose remote decision is still not installed.
+
+    Matched on the path digest rather than the displayed path, which may have
+    been capped in the backup filename. Only a canonically spelled path can be
+    resolved at all, because only a canonical path can ever be installed: a
+    quarantine raised against any other spelling stays listed however the state
+    file reads, since a legacy entry recorded under that spelling is exactly the
+    stale record the quarantine exists to surface, and letting it mark its own
+    collision resolved would hide it.
+    """
+    backups = list_quarantine_backups(store_path)
+    if not backups:
+        return []
+    tracked = (state or load_state(store_path)).files
+    installed = {path_key(rel) for rel in tracked if is_canonical_decision_path(rel)}
+    return [item for item in backups if item.path_digest not in installed]
+
+
+__all__ = [
+    "QuarantinedCollision",
+    "backup_name",
+    "list_quarantine_backups",
+    "quarantine_key",
+    "save_quarantine_backup",
+    "unresolved_quarantines",
+]

--- a/packages/nauro/src/nauro/sync/remote.py
+++ b/packages/nauro/src/nauro/sync/remote.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any
 
 import httpx
+from pydantic import BaseModel, ConfigDict, ValidationError
 
 from nauro.cli.commands.auth import (
     DEFAULT_API_URL,
@@ -136,6 +137,37 @@ def request_presigned_urls(
     return all_urls
 
 
+class PresignedUrl(BaseModel):
+    """One minted URL from ``/sync/presign``, as far as the callers read it."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    verb: str
+    path: str
+    url: str
+
+
+def urls_by_path(entries: list[Any], verb: str) -> tuple[dict[str, str], tuple[str, ...]]:
+    """Index a presign response by store path for one verb.
+
+    Returns the usable URLs and the entries that could not be read, which each
+    caller reports in its own idiom. Malformed rows are skipped rather than
+    fatal: a partial batch still transfers what it can, and the caller already
+    handles a short response.
+    """
+    usable: dict[str, str] = {}
+    skipped: list[str] = []
+    for entry in entries:
+        try:
+            parsed = PresignedUrl.model_validate(entry)
+        except ValidationError:
+            skipped.append(repr(entry))
+            continue
+        if parsed.verb == verb:
+            usable[parsed.path] = parsed.url
+    return usable, tuple(skipped)
+
+
 def fetch_via_presigned_url(url: str) -> bytes:
     """GET ``url`` and return the body bytes (no local write)."""
     response = httpx.get(url, timeout=_DEFAULT_TRANSFER_TIMEOUT)
@@ -155,9 +187,11 @@ def put_via_presigned_url(url: str, local_path: Path) -> str:
 
 __all__ = [
     "PresignError",
+    "PresignedUrl",
     "fetch_manifest",
     "fetch_via_presigned_url",
     "put_via_presigned_url",
     "request_presigned_urls",
     "resolve_api_url",
+    "urls_by_path",
 ]

--- a/packages/nauro/src/nauro/sync/state.py
+++ b/packages/nauro/src/nauro/sync/state.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 
+from nauro.store._atomic import atomic_write_text
+
 logger = logging.getLogger("nauro.sync")
 
 SYNC_STATE_FILE = ".sync-state.json"
@@ -46,7 +48,15 @@ def load_state(project_path: Path) -> SyncState:
 
 
 def save_state(project_path: Path, state: SyncState) -> None:
-    """Write .sync-state.json to project directory."""
+    """Write .sync-state.json to project directory.
+
+    Written through a tmp sibling and ``os.replace``: a crash during the write
+    must leave the previous state readable rather than a truncated file, since
+    an unreadable state file makes every tracked path look untracked and
+    reopens the published-versus-unpublished question the collision classifier
+    answers from it. The serialized shape is unchanged, so an older binary
+    reads entries written here without adaptation.
+    """
     data = {
         "files": {
             rel_path: {
@@ -58,8 +68,7 @@ def save_state(project_path: Path, state: SyncState) -> None:
         },
         "last_full_sync": state.last_full_sync,
     }
-    state_file = project_path / SYNC_STATE_FILE
-    state_file.write_text(json.dumps(data, indent=2) + "\n")
+    atomic_write_text(project_path / SYNC_STATE_FILE, json.dumps(data, indent=2) + "\n")
 
 
 def compute_sha256(file_path: Path) -> str:

--- a/packages/nauro/tests/test_cli_status.py
+++ b/packages/nauro/tests/test_cli_status.py
@@ -517,3 +517,54 @@ def test_status_no_project_shows_friendly_message(tmp_path, monkeypatch):
     result = runner.invoke(app, ["status"])
     assert result.exit_code == 1
     assert "No project found. Run 'nauro init <name>' to get started." in result.output
+
+
+def _write_quarantine_backup(store, remote_path: str, content: bytes = b"remote body\n") -> None:
+    from nauro.sync.quarantine import save_quarantine_backup
+
+    save_quarantine_backup(store, remote_path, content, '"etag"')
+
+
+def test_status_names_unresolved_quarantined_collisions(tmp_path, monkeypatch):
+    """A quarantine records no sync state, so status is what keeps it visible."""
+    store = _setup_project(tmp_path, monkeypatch)
+    _write_quarantine_backup(store, "decisions/003-remote.md")
+
+    result = runner.invoke(app, ["status"])
+    assert result.exit_code == 0, result.output
+    assert "Quarantined decision-number collisions: 1" in result.output
+    assert "decisions/003-remote.md" in result.output
+
+
+def test_status_drops_a_quarantine_once_the_remote_file_is_tracked(tmp_path, monkeypatch):
+    from nauro.sync.state import FileState, SyncState, save_state
+
+    store = _setup_project(tmp_path, monkeypatch)
+    _write_quarantine_backup(store, "decisions/003-remote.md")
+    state = SyncState()
+    state.files["decisions/003-remote.md"] = FileState(local_sha256="abc", remote_etag='"e"')
+    save_state(store, state)
+
+    result = runner.invoke(app, ["status"])
+    assert result.exit_code == 0, result.output
+    assert "Quarantined decision-number collisions" not in result.output
+
+
+def test_status_says_nothing_about_quarantines_when_there_are_none(tmp_path, monkeypatch):
+    _setup_project(tmp_path, monkeypatch)
+
+    result = runner.invoke(app, ["status"])
+    assert result.exit_code == 0, result.output
+    assert "Quarantined" not in result.output
+
+
+def test_status_says_quarantines_are_unreadable_rather_than_absent(tmp_path, monkeypatch):
+    """A broken sync-state file must not silently turn a real quarantine into
+    a clean report."""
+    store = _setup_project(tmp_path, monkeypatch)
+    _write_quarantine_backup(store, "decisions/003-remote.md")
+    (store / ".sync-state.json").write_text("[]")
+
+    result = runner.invoke(app, ["status"])
+    assert result.exit_code == 0, result.output
+    assert "Quarantined decision-number collisions: could not be read" in result.output

--- a/packages/nauro/tests/test_cli_status_json.py
+++ b/packages/nauro/tests/test_cli_status_json.py
@@ -115,7 +115,13 @@ def test_status_json_happy_path_golden_payload(tmp_path, monkeypatch):
         "agents_md": {"repo_count": 1, "generated_repos": 0},
         # Local-only project: no remote comparison. The scaffold seeds one
         # decision.
-        "decisions": {"local": 1, "remote": None, "in_sync": None, "last_full_sync": None},
+        "decisions": {
+            "local": 1,
+            "remote": None,
+            "in_sync": None,
+            "last_full_sync": None,
+            "quarantined_collisions": [],
+        },
     }
 
 
@@ -292,3 +298,30 @@ def test_status_survives_non_string_last_full_sync(tmp_path, monkeypatch, bad_va
     payload = json.loads(as_json.stdout)
     assert payload["decisions"]["remote"] == 1
     assert payload["decisions"]["last_full_sync"] is None
+
+
+def test_status_json_lists_unresolved_quarantined_collisions(tmp_path, monkeypatch):
+    from nauro.sync.quarantine import save_quarantine_backup
+
+    store, _repo = _setup_project(tmp_path, monkeypatch)
+    save_quarantine_backup(store, "decisions/003-remote.md", b"remote body\n", '"etag"')
+
+    result = runner.invoke(app, ["status", "--json"])
+    assert result.exit_code == 0, result.output
+
+    payload = json.loads(result.stdout)
+    assert payload["decisions"]["quarantined_collisions"] == ["decisions/003-remote.md"]
+
+
+def test_status_json_reports_null_when_quarantines_cannot_be_listed(tmp_path, monkeypatch):
+    from nauro.sync.quarantine import save_quarantine_backup
+
+    store, _repo = _setup_project(tmp_path, monkeypatch)
+    save_quarantine_backup(store, "decisions/003-remote.md", b"remote body\n", '"etag"')
+    (store / ".sync-state.json").write_text("[]")
+
+    result = runner.invoke(app, ["status", "--json"])
+    assert result.exit_code == 0, result.output
+
+    payload = json.loads(result.stdout)
+    assert payload["decisions"]["quarantined_collisions"] is None

--- a/packages/nauro/tests/test_dash_convention.py
+++ b/packages/nauro/tests/test_dash_convention.py
@@ -22,9 +22,10 @@ ALLOWLIST = {
     # Byte-matched marker for legacy CLAUDE.md block cleanup; blocks with
     # this exact text are already deployed on user machines.
     ("nauro/constants.py", "NAURO_BLOCK_START"),
-    # Input matching, not output: collision renumbering must recognize the
-    # em-dash decision headings nauro-core writes ("# NNN — Title").
-    ("nauro/sync/pull.py", "old_prefix"),
+    # Input matching, not output: the sync layer must recognize the em-dash
+    # decision headings nauro-core writes ("# NNN — Title").
+    ("nauro/sync/headings.py", "_HEADING_SEPARATORS"),
+    ("nauro/sync/headings.py", "line.startswith"),
 }
 
 

--- a/packages/nauro/tests/test_link_cloud.py
+++ b/packages/nauro/tests/test_link_cloud.py
@@ -327,3 +327,30 @@ def test_link_cloud_with_no_repo_config_errors(tmp_path, monkeypatch):
 
     assert result.exit_code == 1
     assert "Not a nauro repo" in result.output
+
+
+def test_link_cloud_lock_contention_keeps_rekey(tmp_path, monkeypatch):
+    """A concurrent sync holding the store lock is a best-effort push failure,
+    not a traceback over an irreversible promotion."""
+    from nauro.sync.lock import SyncLockTimeoutError
+
+    _seed_token(monkeypatch, tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("NAURO_API_URL", "https://example.test")
+
+    init_result = runner.invoke(app, ["init", "linkproj"])
+    assert init_result.exit_code == 0, init_result.output
+
+    busy = SyncLockTimeoutError(tmp_path / CLOUD_PID, 10.0)
+
+    with (
+        patch.object(cloud_projects.httpx, "request", side_effect=_create_response()),
+        patch("nauro.cli.commands.link.push_changed_files", side_effect=busy),
+    ):
+        result = runner.invoke(app, ["link", "--cloud"])
+
+    assert result.exit_code == 0, result.output
+    assert "nauro sync" in result.output
+    new_entry = registry.get_project_v2(CLOUD_PID)
+    assert new_entry is not None
+    assert new_entry["mode"] == "cloud"

--- a/packages/nauro/tests/test_sync/conftest.py
+++ b/packages/nauro/tests/test_sync/conftest.py
@@ -1,12 +1,25 @@
-"""Shared helpers for the test_sync test suite."""
+"""Shared helpers for the test_sync test suite.
+
+The fake server, the canonical decision bodies, and the store-shaping helpers
+live here rather than in whichever test module happened to define them first:
+four modules build the same fixtures, and importing them from a sibling test
+made the import graph say something about the tests that is not true.
+"""
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
+from unittest.mock import patch
+
+import httpx
 
 from nauro.constants import REPO_CONFIG_MODE_CLOUD
 from nauro.store.registry import register_project_v2
+from nauro.sync.pull import run_pull
+from nauro.sync.state import FileState, compute_sha256, load_state, save_state
 from nauro.templates.scaffolds import scaffold_project_store
+from tests.conftest import seed_auth_config
 
 CLOUD_PID = "01KQ6AZGNA0B3QBF67NBXP3S45"
 
@@ -30,3 +43,166 @@ def _scaffolded_cloud_project(name: str, repo_path: Path, project_id: str | None
     )
     scaffold_project_store(name, store)
     return store
+
+
+def _ok(status: int, payload: dict) -> httpx.Response:
+    return httpx.Response(
+        status,
+        content=json.dumps(payload).encode("utf-8"),
+        headers={"content-type": "application/json"},
+    )
+
+
+def _seed_token() -> None:
+    seed_auth_config(variant="sync")
+
+
+def _manifest(files, next_cursor=None) -> httpx.Response:
+    return _ok(200, {"files": files, "next_cursor": next_cursor})
+
+
+def _presign(ops) -> httpx.Response:
+    return _ok(
+        200,
+        {
+            "urls": [
+                {
+                    "verb": op["verb"],
+                    "path": op["path"],
+                    "url": f"https://s3.example/{op['verb']}/{op['path']}",
+                    "expires_at": "2026-05-16T13:00:00Z",
+                }
+                for op in ops
+            ]
+        },
+    )
+
+
+# A canonical decision carrying the base_commit provenance stamp as its
+# trailing frontmatter key. Sync moves raw bytes, so stamped files must
+# round-trip byte-identically like any other decision.
+_STAMPED_SHA = "a1b2c3d4" * 5
+_STAMPED_DECISION = (
+    "---\n"
+    "date: 2026-08-05\n"
+    "version: 1\n"
+    "status: active\n"
+    "confidence: high\n"
+    "decision_type: null\n"
+    "reversibility: null\n"
+    "source: null\n"
+    "files_affected: []\n"
+    "supersedes: null\n"
+    "superseded_by: null\n"
+    f"base_commit: {_STAMPED_SHA}\n"
+    "---\n\n"
+    "# 099 — Remote stamped decision\n\n"
+    "## Decision\n\nChose A.\n"
+).encode()
+
+
+class _RecordingReporter:
+    """Records reported messages."""
+
+    def __init__(self) -> None:
+        self.infos: list[str] = []
+        self.warns: list[str] = []
+
+    def info(self, msg: str) -> None:
+        self.infos.append(msg)
+
+    def warn(self, msg: str) -> None:
+        self.warns.append(msg)
+
+
+def decision_bytes(
+    num: int,
+    title: str,
+    rationale: str = "Chose A.",
+    *,
+    status: str = "active",
+    supersedes: str | None = None,
+    superseded_by: str | None = None,
+    separator: str = "—",
+) -> bytes:
+    """A canonical decision file body, parseable by ``parse_decision``."""
+    return (
+        "---\n"
+        "date: 2026-08-10\n"
+        "version: 1\n"
+        f"status: {status}\n"
+        "confidence: high\n"
+        "decision_type: null\n"
+        "reversibility: null\n"
+        "source: null\n"
+        "files_affected: []\n"
+        f"supersedes: {repr(supersedes) if supersedes else 'null'}\n"
+        f"superseded_by: {repr(superseded_by) if superseded_by else 'null'}\n"
+        "---\n\n"
+        f"# {num:03d} {separator} {title}\n\n"
+        "## Decision\n\n"
+        f"{rationale}\n"
+    ).encode()
+
+
+def write_local_decision(store, filename: str, content: bytes) -> object:
+    decisions = store / "decisions"
+    decisions.mkdir(exist_ok=True)
+    path = decisions / filename
+    path.write_bytes(content)
+    return path
+
+
+def pull(store, entries, *, reporter=None, etags=None):
+    """Run one pull against a fake server holding exactly ``entries``.
+
+    ``entries`` is an ordered list of ``(path, body)`` pairs so the tests can
+    pin manifest order where order is the thing under test.
+    """
+    reporter = reporter or _RecordingReporter()
+    etags = etags or {}
+    bodies = dict(entries)
+    manifest = _manifest(
+        [
+            {
+                "path": rel,
+                "etag": etags.get(rel, f'"{rel}-v1"'),
+                "size": len(body),
+                "last_modified": "x",
+            }
+            for rel, body in entries
+        ]
+    )
+    presign = _presign([{"verb": "GET", "path": rel} for rel, _body in entries])
+
+    def fake_get(url, **kwargs):
+        if "/sync/manifest" in url:
+            return manifest
+        return httpx.Response(200, content=bodies[url.split("/GET/", 1)[1]])
+
+    with (
+        patch("nauro.sync.remote.httpx.get", side_effect=fake_get),
+        patch("nauro.sync.remote.httpx.post", return_value=presign),
+    ):
+        merged = run_pull(CLOUD_PID, store, reporter)
+    return merged, reporter
+
+
+def entry_names(directory) -> set[str]:
+    """Actual on-disk entry names.
+
+    ``Path.exists()`` folds case on macOS and Windows, so an assertion about
+    what a pull did or did not write has to read the directory itself.
+    """
+    return {entry.name for entry in directory.iterdir()} if directory.is_dir() else set()
+
+
+def track(store, rel: str) -> None:
+    """Record a sync-state entry for a local file, as a completed push would."""
+    state = load_state(store)
+    state.files[rel] = FileState(
+        local_sha256=compute_sha256(store / rel),
+        remote_etag='"pushed"',
+        last_sync="2026-08-10T00:00:00Z",
+    )
+    save_state(store, state)

--- a/packages/nauro/tests/test_sync/test_collisions.py
+++ b/packages/nauro/tests/test_sync/test_collisions.py
@@ -1,0 +1,658 @@
+"""Tests for the decision-number collision classifier and its crash windows.
+
+The renumber sequence is rename, heading rewrite, hash-index update, install,
+state save. Every window between two of those steps is simulated here by
+building the on-disk state a crash would leave and asserting the next pull
+recovers it without minting a second number.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+
+import pytest
+
+from nauro.constants import DECISION_HASHES_FILE
+from nauro.sync import corpus as corpus_module
+from nauro.sync.collisions import (
+    DecisionOutcome,
+    DestinationOccupiedError,
+    QuarantineReason,
+    apply_renumber,
+    classify_decision,
+    is_canonical_decision_path,
+    run_completion_pass,
+)
+from nauro.sync.corpus import DecisionCorpus
+from nauro.sync.headings import (
+    has_rewritable_heading,
+    heading_number,
+    rewrite_decision_heading,
+    strip_number_prefix,
+)
+from nauro.sync.quarantine import (
+    _parse_backup_name,
+    backup_name,
+    list_quarantine_backups,
+    path_key,
+    save_quarantine_backup,
+    unresolved_quarantines,
+)
+from nauro.sync.state import FileState, SyncState, load_state, save_state
+from tests.test_sync.conftest import _scaffolded_cloud_project
+from tests.test_sync.test_pull import (
+    _seed_token,
+    decision_bytes,
+    pull,
+    write_local_decision,
+)
+
+_STAMPED_SHA = "a1b2c3d4" * 5
+_STAMPED_DECISION = (
+    "---\n"
+    "date: 2026-08-05\n"
+    "version: 1\n"
+    "status: active\n"
+    "confidence: high\n"
+    "decision_type: null\n"
+    "reversibility: null\n"
+    "source: null\n"
+    "files_affected: []\n"
+    "supersedes: null\n"
+    "superseded_by: null\n"
+    f"base_commit: {_STAMPED_SHA}\n"
+    "---\n\n"
+    "# 099 — Remote stamped decision\n\n"
+    "## Decision\n\nChose A.\n"
+)
+
+
+@pytest.fixture()
+def store(tmp_path):
+    project_store = _scaffolded_cloud_project("collisionunit", tmp_path)
+    _seed_token()
+    return project_store
+
+
+def _write_hash_index(store, entries: dict[str, str]) -> None:
+    (store / DECISION_HASHES_FILE).write_text(
+        json.dumps(
+            {
+                content_hash: {"decision_id": stem, "timestamp": "2026-08-10T00:00:00Z"}
+                for content_hash, stem in entries.items()
+            },
+            indent=2,
+        )
+        + "\n"
+    )
+
+
+def _read_hash_index(store) -> dict:
+    return json.loads((store / DECISION_HASHES_FILE).read_text())
+
+
+def _decision_names(store) -> list[str]:
+    return sorted(path.name for path in (store / "decisions").glob("*.md"))
+
+
+# --- heading and filename primitives ---------------------------------------
+
+
+class TestHeadingPrimitives:
+    def test_strip_number_prefix_drops_leading_run_and_hyphen(self):
+        assert strip_number_prefix("003-local-decision.md") == "local-decision.md"
+
+    def test_strip_number_prefix_keeps_digits_without_a_hyphen(self):
+        assert strip_number_prefix("003local.md") == "003local.md"
+
+    @pytest.mark.parametrize("separator", ["—", "-"])
+    def test_heading_number_reads_both_separators(self, separator):
+        assert heading_number(f"# 008 {separator} Title\n") == 8
+
+    def test_heading_number_reads_the_lax_forms_the_parser_accepts(self):
+        # As lax as parse_decision, so a filename/heading mismatch is detected
+        # even on a heading this layer refuses to rewrite.
+        assert heading_number("#  008 — Title\n") == 8
+        assert heading_number("# 8 — Title\n") == 8
+        assert heading_number("## 008 — Title\n") is None
+        assert heading_number("#Not a heading\n") is None
+
+    def test_rewritable_is_narrower_than_readable(self):
+        assert has_rewritable_heading("# 008 — Title\n", 8) is True
+        assert has_rewritable_heading("#  008 — Title\n", 8) is False
+        assert has_rewritable_heading("# 8 — Title\n", 8) is False
+
+    def test_rewrite_preserves_the_separator_and_the_rest_of_the_line(self):
+        assert rewrite_decision_heading("# 008 - Remote\n\nBody\n", 8, 9) == (
+            "# 009 - Remote\n\nBody\n"
+        )
+
+    def test_rewrite_touches_only_the_heading(self):
+        rewritten = rewrite_decision_heading(_STAMPED_DECISION, 99, 100)
+        assert rewritten == _STAMPED_DECISION.replace("# 099 ", "# 100 ")
+        assert f"base_commit: {_STAMPED_SHA}" in rewritten
+
+
+# --- classification --------------------------------------------------------
+
+
+class TestClassify:
+    def _classify(self, store, remote_content, *, state=None, manifest=frozenset()):
+        return classify_decision(
+            DecisionCorpus.scan(store),
+            "decisions/003-remote.md",
+            remote_content,
+            state or SyncState(),
+            manifest,
+        )
+
+    def test_no_collider_installs(self, store):
+        verdict = self._classify(store, decision_bytes(3, "Remote"))
+        assert verdict.outcome is DecisionOutcome.install
+
+    def test_identical_bytes_canonicalize(self, store):
+        body = decision_bytes(3, "Shared")
+        write_local_decision(store, "003-local.md", body)
+        verdict = self._classify(store, body)
+        assert verdict.outcome is DecisionOutcome.canonicalize
+        assert verdict.collider.name == "003-local.md"
+
+    def test_isolated_difference_renumbers_local(self, store):
+        write_local_decision(store, "003-local.md", decision_bytes(3, "Local"))
+        verdict = self._classify(store, decision_bytes(3, "Remote", "Chose B."))
+        assert verdict.outcome is DecisionOutcome.renumber_local
+
+    def test_tracked_collider_outranks_identical_bytes(self, store):
+        body = decision_bytes(3, "Shared")
+        write_local_decision(store, "003-local.md", body)
+        state = SyncState()
+        state.files["decisions/003-local.md"] = FileState(local_sha256="x", remote_etag='"y"')
+        verdict = self._classify(store, body, state=state)
+        assert verdict.outcome is DecisionOutcome.quarantine
+        assert verdict.reason is QuarantineReason.tracked_locally
+
+    def test_manifest_membership_outranks_identical_bytes(self, store):
+        body = decision_bytes(3, "Shared")
+        write_local_decision(store, "003-local.md", body)
+        verdict = self._classify(store, body, manifest=frozenset({"decisions/003-local.md"}))
+        assert verdict.outcome is DecisionOutcome.quarantine
+        assert verdict.reason is QuarantineReason.published_remotely
+
+    def test_backref_from_the_collider_quarantines(self, store):
+        write_local_decision(
+            store,
+            "003-local.md",
+            decision_bytes(3, "Local", superseded_by="4", status="superseded"),
+        )
+        verdict = self._classify(store, decision_bytes(3, "Remote", "Chose B."))
+        assert verdict.reason is QuarantineReason.referenced
+
+    def test_unrelated_unparseable_file_blocks_verification(self, store):
+        write_local_decision(store, "003-local.md", decision_bytes(3, "Local"))
+        write_local_decision(store, "009-broken.md", b"not a decision\n")
+        verdict = self._classify(store, decision_bytes(3, "Remote", "Chose B."))
+        assert verdict.reason is QuarantineReason.store_unverifiable
+
+
+# --- crash windows ---------------------------------------------------------
+
+
+class TestRenumberCrashWindows:
+    """Each test builds the store a crash would leave, then pulls again."""
+
+    def test_rename_landed_but_heading_did_not(self, store):
+        # Window between the rename and the heading rewrite.
+        write_local_decision(store, "004-local.md", decision_bytes(3, "Local decision"))
+        _write_hash_index(store, {"hash-a": "003-local"})
+        remote = decision_bytes(3, "Remote decision", "Chose B.")
+
+        merged, reporter = pull(store, [("decisions/003-remote.md", remote)])
+
+        assert merged == 1
+        assert _decision_names(store) == [
+            "001-initial-setup.md",
+            "003-remote.md",
+            "004-local.md",
+        ]
+        assert (store / "decisions/004-local.md").read_bytes() == decision_bytes(
+            4, "Local decision"
+        )
+        assert _read_hash_index(store)["hash-a"]["decision_id"] == "004-local"
+        assert reporter.warns == []
+        assert any("Completed an interrupted renumber" in info for info in reporter.infos)
+
+    def test_heading_landed_but_hash_index_did_not(self, store):
+        # Window between the heading rewrite and the hash-index update.
+        write_local_decision(store, "004-local.md", decision_bytes(4, "Local decision"))
+        _write_hash_index(store, {"hash-a": "003-local"})
+        remote = decision_bytes(3, "Remote decision", "Chose B.")
+
+        merged, reporter = pull(store, [("decisions/003-remote.md", remote)])
+
+        assert merged == 1
+        assert _read_hash_index(store)["hash-a"]["decision_id"] == "004-local"
+        assert reporter.warns == []
+
+    def test_install_landed_but_state_save_did_not(self, store):
+        # Window between installing the remote file and saving sync state.
+        remote = decision_bytes(3, "Remote decision", "Chose B.")
+        write_local_decision(store, "004-local.md", decision_bytes(4, "Local decision"))
+        write_local_decision(store, "003-remote.md", remote)
+
+        merged, reporter = pull(store, [("decisions/003-remote.md", remote)])
+
+        assert merged == 0
+        assert _decision_names(store) == [
+            "001-initial-setup.md",
+            "003-remote.md",
+            "004-local.md",
+        ]
+        assert "decisions/003-remote.md" in load_state(store).files
+        assert reporter.warns == []
+
+    def test_heading_rewrite_failure_quarantines_without_mutating(self, store, monkeypatch):
+        """The rewrite is verified before the rename, so a rewrite that would
+        not land leaves the store exactly as it was."""
+        body = decision_bytes(3, "Local decision")
+        write_local_decision(store, "003-local.md", body)
+        monkeypatch.setattr(
+            "nauro.sync.collisions.rewrite_decision_heading",
+            lambda text, old_num, new_num: text,
+        )
+
+        merged, reporter = pull(
+            store, [("decisions/003-remote.md", decision_bytes(3, "Remote", "Chose B."))]
+        )
+
+        assert merged == 0
+        assert not (store / "decisions/003-remote.md").exists()
+        assert _decision_names(store) == ["001-initial-setup.md", "003-local.md"]
+        assert (store / "decisions/003-local.md").read_bytes() == body
+        assert any("could not be rewritten" in warning for warning in reporter.warns)
+
+
+class TestCompletionPass:
+    def test_clean_store_is_untouched_and_reports_nothing(self, store):
+        write_local_decision(store, "004-local.md", decision_bytes(4, "Local"))
+        before = (store / "decisions/004-local.md").read_bytes()
+
+        outcome = run_completion_pass(DecisionCorpus.scan(store))
+
+        assert outcome == run_completion_pass(DecisionCorpus.scan(store))
+        assert outcome.repaired == ()
+        assert outcome.unrepairable == ()
+        assert outcome.retargeted_stems == ()
+        assert (store / "decisions/004-local.md").read_bytes() == before
+
+    def test_repair_is_idempotent(self, store):
+        path = write_local_decision(store, "004-local.md", decision_bytes(3, "Local"))
+
+        first = run_completion_pass(DecisionCorpus.scan(store))
+        repaired_bytes = path.read_bytes()
+        second = run_completion_pass(DecisionCorpus.scan(store))
+
+        assert [(r.from_num, r.to_num) for r in first.repaired] == [(3, 4)]
+        assert second.repaired == ()
+        assert path.read_bytes() == repaired_bytes == decision_bytes(4, "Local")
+
+    def test_referenced_mismatch_is_reported_not_repaired(self, store):
+        path = write_local_decision(store, "004-local.md", decision_bytes(3, "Local"))
+        write_local_decision(store, "005-child.md", decision_bytes(5, "Child", supersedes="4"))
+        before = path.read_bytes()
+
+        outcome = run_completion_pass(DecisionCorpus.scan(store))
+
+        assert outcome.repaired == ()
+        assert outcome.unrepairable == (path,)
+        assert path.read_bytes() == before
+
+    def test_contested_filename_number_is_reported_not_repaired(self, store):
+        path = write_local_decision(store, "004-local.md", decision_bytes(3, "Local"))
+        write_local_decision(store, "004-other.md", decision_bytes(4, "Other"))
+        before = path.read_bytes()
+
+        outcome = run_completion_pass(DecisionCorpus.scan(store))
+
+        assert outcome.unrepairable == (path,)
+        assert path.read_bytes() == before
+
+    def test_dangling_stem_with_two_slug_matches_is_left_alone(self, store):
+        write_local_decision(store, "004-local.md", decision_bytes(4, "Local"))
+        write_local_decision(store, "005-local.md", decision_bytes(5, "Local"))
+        _write_hash_index(store, {"hash-a": "003-local"})
+
+        outcome = run_completion_pass(DecisionCorpus.scan(store))
+
+        assert outcome.retargeted_stems == ()
+        assert _read_hash_index(store)["hash-a"]["decision_id"] == "003-local"
+
+    def test_dangling_stem_for_a_deleted_decision_is_left_alone(self, store):
+        _write_hash_index(store, {"hash-a": "003-deleted-outright"})
+
+        outcome = run_completion_pass(DecisionCorpus.scan(store))
+
+        assert outcome.retargeted_stems == ()
+        assert _read_hash_index(store)["hash-a"]["decision_id"] == "003-deleted-outright"
+
+    def test_unrelated_hash_index_keys_survive_a_retarget(self, store):
+        write_local_decision(store, "004-local.md", decision_bytes(4, "Local"))
+        (store / DECISION_HASHES_FILE).write_text(
+            json.dumps(
+                {
+                    "hash-a": {
+                        "decision_id": "003-local",
+                        "timestamp": "2026-08-10T00:00:00Z",
+                        "extra": "kept",
+                    }
+                },
+                indent=2,
+            )
+            + "\n"
+        )
+
+        run_completion_pass(DecisionCorpus.scan(store))
+
+        entry = _read_hash_index(store)["hash-a"]
+        assert entry == {
+            "decision_id": "004-local",
+            "timestamp": "2026-08-10T00:00:00Z",
+            "extra": "kept",
+        }
+
+
+class TestNonCanonicalHeadingNumbers:
+    """The decision parser accepts headings the rewriter must not touch.
+
+    ``parse_decision`` reads any digit run, so an unpadded ``# 42`` or an
+    over-padded ``# 0042`` heading yields a perfectly valid, isolated,
+    unpublished collider. The rewriter only addresses the canonical
+    zero-padded form, so those files quarantine instead of renumbering -
+    and, critically, nothing on disk moves first.
+    """
+
+    @pytest.mark.parametrize("heading", ["# 42", "# 0042"])
+    def test_collider_quarantines_with_nothing_mutated(self, store, heading):
+        body = decision_bytes(42, "Local decision").replace(b"\n# 042", heading.encode())
+        write_local_decision(store, "042-local.md", body)
+        remote = decision_bytes(42, "Remote decision", "Chose B.")
+
+        merged, reporter = pull(store, [("decisions/042-remote.md", remote)])
+
+        assert merged == 0
+        assert _decision_names(store) == ["001-initial-setup.md", "042-local.md"]
+        assert (store / "decisions/042-local.md").read_bytes() == body
+        assert not (store / "decisions/042-remote.md").exists()
+        assert "decisions/042-remote.md" not in load_state(store).files
+        assert any("canonical form" in warning for warning in reporter.warns)
+
+    @pytest.mark.parametrize("heading", ["# 42", "# 0042"])
+    def test_classifier_names_the_heading_as_the_reason(self, store, heading):
+        body = decision_bytes(42, "Local decision").replace(b"\n# 042", heading.encode())
+        write_local_decision(store, "042-local.md", body)
+
+        verdict = classify_decision(
+            DecisionCorpus.scan(store),
+            "decisions/042-remote.md",
+            decision_bytes(42, "Remote", "Chose B."),
+            SyncState(),
+            frozenset(),
+        )
+
+        assert verdict.outcome is DecisionOutcome.quarantine
+        assert verdict.reason is QuarantineReason.heading_not_rewritable
+
+    @pytest.mark.parametrize("heading", ["# 42", "# 0042"])
+    def test_completion_pass_reports_a_quarantine_not_an_unrepairable(self, store, heading):
+        """A filename/heading mismatch the rewriter cannot address is reported
+        as a quarantine with a human fix, identically on every run."""
+        body = decision_bytes(42, "Local decision").replace(b"\n# 042", heading.encode())
+        path = write_local_decision(store, "043-local.md", body)
+
+        first = run_completion_pass(DecisionCorpus.scan(store))
+        second = run_completion_pass(DecisionCorpus.scan(store))
+
+        assert first.quarantined == (path,)
+        assert first.unrepairable == ()
+        assert first.repaired == ()
+        assert second == first
+        assert path.read_bytes() == body
+
+    def test_pull_reports_the_quarantined_mismatch_every_run(self, store):
+        body = decision_bytes(42, "Local decision").replace(b"\n# 042", b"\n# 42")
+        write_local_decision(store, "043-local.md", body)
+
+        for _ in range(2):
+            merged, reporter = pull(store, [])
+            assert merged == 0
+            assert any("canonical form" in warning for warning in reporter.warns)
+        assert (store / "decisions/043-local.md").read_bytes() == body
+
+
+class TestCorpusIsReadOnce:
+    """Freshness per verdict must not mean a full reparse per verdict."""
+
+    @staticmethod
+    def _seed(store, count: int) -> None:
+        for num in range(3, 3 + count):
+            write_local_decision(store, f"{num:03d}-local.md", decision_bytes(num, f"Local {num}"))
+
+    def test_no_decision_file_is_parsed_twice_in_one_pull(self, store, monkeypatch):
+        collisions = 6
+        self._seed(store, collisions)
+
+        parses: Counter[str] = Counter()
+        real_parse = corpus_module.parse_decision
+
+        def counting_parse(text, filename):
+            parses[filename] += 1
+            return real_parse(text, filename)
+
+        monkeypatch.setattr(corpus_module, "parse_decision", counting_parse)
+
+        entries = [
+            (f"decisions/{num:03d}-remote.md", decision_bytes(num, f"Remote {num}", "Chose B."))
+            for num in range(3, 3 + collisions)
+        ]
+        merged, reporter = pull(store, entries)
+
+        assert merged == collisions
+        assert reporter.warns == []
+        # The invariant, not an aggregate: one parse per file per run, however
+        # many verdicts consulted the reference index.
+        assert parses and max(parses.values()) == 1
+
+    def test_a_pull_scans_the_decisions_directory_exactly_twice(self, store, monkeypatch):
+        self._seed(store, 3)
+
+        scans: list[str] = []
+        real_scan = DecisionCorpus.scan
+
+        def counting_scan(store_path):
+            scans.append(str(store_path))
+            return real_scan(store_path)
+
+        monkeypatch.setattr(DecisionCorpus, "scan", staticmethod(counting_scan))
+
+        merged, _reporter = pull(
+            store, [("decisions/003-remote.md", decision_bytes(3, "Remote", "Chose B."))]
+        )
+
+        assert merged == 1
+        # One scan while planning, outside the decision lock, to order the
+        # worklist; one inside it, which is the authoritative view every
+        # verdict is taken against and the writer keeps current from there.
+        assert len(scans) == 2
+
+    def test_a_pull_with_nothing_to_heal_reads_no_decision_bodies(self, store, monkeypatch):
+        self._seed(store, 4)
+
+        reads: list[str] = []
+        real_read = corpus_module.read_text_lenient
+
+        def counting_read(path):
+            reads.append(path.name)
+            return real_read(path)
+
+        monkeypatch.setattr(corpus_module, "read_text_lenient", counting_read)
+
+        merged, reporter = pull(store, [])
+
+        assert merged == 0
+        assert reporter.warns == []
+        # The completion pass reads headings line by line, never whole bodies.
+        assert reads == []
+
+
+class TestIrregularHoldersContestANumber:
+    """An entry Nauro never reads is still a claim on the number.
+
+    The completion pass repairs a heading only while the number it repairs
+    toward is uncontested. An entry with no readable content is exactly the
+    ambiguity that must stop it, not a claim to overlook for lack of content.
+    """
+
+    def test_a_directory_on_the_number_stops_a_heading_repair(self, store):
+        moved = write_local_decision(store, "005-moved.md", decision_bytes(3, "Moved"))
+        (store / "decisions" / "005-blocker.md").mkdir()
+        before = moved.read_bytes()
+
+        outcome = run_completion_pass(DecisionCorpus.scan(store))
+
+        assert outcome.repaired == ()
+        assert outcome.unrepairable == (moved,)
+        assert moved.read_bytes() == before
+
+    def test_a_symlink_on_the_number_stops_a_heading_repair(self, store):
+        target = write_local_decision(store, "009-target.md", decision_bytes(9, "Target"))
+        moved = write_local_decision(store, "005-moved.md", decision_bytes(3, "Moved"))
+        (store / "decisions" / "005-blocker.md").symlink_to(target)
+        before = moved.read_bytes()
+
+        outcome = run_completion_pass(DecisionCorpus.scan(store))
+
+        assert outcome.repaired == ()
+        assert outcome.unrepairable == (moved,)
+        assert moved.read_bytes() == before
+
+    def test_an_irregular_entry_on_another_number_does_not_stop_the_repair(self, store):
+        moved = write_local_decision(store, "005-moved.md", decision_bytes(3, "Moved"))
+        (store / "decisions" / "007-blocker.md").mkdir()
+
+        outcome = run_completion_pass(DecisionCorpus.scan(store))
+
+        assert [(repair.from_num, repair.to_num) for repair in outcome.repaired] == [(3, 5)]
+        assert outcome.unrepairable == ()
+        assert moved.read_bytes() == decision_bytes(5, "Moved")
+
+
+class TestRenumberRefusalReasons:
+    def test_a_taken_destination_name_is_not_blamed_on_the_heading(self, store, monkeypatch):
+        write_local_decision(store, "003-local.md", decision_bytes(3, "Local"))
+        write_local_decision(store, "001-local.md", decision_bytes(1, "Taken"))
+        # Force the mint onto a name that is already on disk.
+        monkeypatch.setattr(
+            DecisionCorpus, "claimed_numbers", lambda self: frozenset({0}), raising=True
+        )
+        corpus = DecisionCorpus.scan(store)
+
+        with pytest.raises(DestinationOccupiedError) as excinfo:
+            apply_renumber(corpus, store / "decisions/003-local.md", 3, frozenset())
+
+        assert excinfo.value.reason is QuarantineReason.destination_occupied
+        assert (store / "decisions/003-local.md").exists()
+
+
+class TestReservedDeviceNames:
+    """Windows resolves a device basename whatever the extension, and the
+    superscript digits are the same devices as the ASCII ones."""
+
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            "com1.md",
+            "com¹.md",
+            "com².md",
+            "com³.md",
+            "lpt¹.md",
+            "lpt².md",
+            "lpt³.md",
+            "con.md",
+            "nul.md",
+        ],
+    )
+    def test_a_device_name_is_not_canonical(self, filename):
+        assert is_canonical_decision_path(f"decisions/{filename}") is False
+
+    @pytest.mark.parametrize("filename", ["240-com¹x.md", "240-con.md", "001-initial-setup.md"])
+    def test_a_name_merely_containing_one_is_fine(self, filename):
+        assert is_canonical_decision_path(f"decisions/{filename}") is True
+
+    def test_the_explicit_set_agrees_with_windows(self):
+        """Pinned against the platform rule this stands in for, since
+        ``PureWindowsPath.is_reserved`` is deprecated from 3.13 and this
+        package supports 3.10 upward."""
+        from pathlib import PureWindowsPath
+
+        for stem in ("com1", "com¹", "com²", "com³", "lpt¹", "con", "nul"):
+            assert PureWindowsPath(f"{stem}.md").is_reserved() is True
+            assert is_canonical_decision_path(f"decisions/{stem}.md") is False
+        for stem in ("240-fine", "240-com¹x"):
+            assert PureWindowsPath(f"{stem}.md").is_reserved() is False
+            assert is_canonical_decision_path(f"decisions/{stem}.md") is True
+
+
+class TestBackupFilenames:
+    @pytest.mark.parametrize(
+        "remote_path",
+        [
+            "decisions/003-x.md",
+            "decisions\\003-x.md",
+            "decisions/003-x:stream.md",
+            "decisions/003-café.md",
+            "decisions/003-x.md.",
+            "Decisions/003-X.MD",
+            "decisions/a%2Fb.md",
+        ],
+    )
+    def test_a_path_round_trips_through_a_flat_safe_filename(self, remote_path):
+        name = backup_name(remote_path, "k" * 16)
+
+        assert "/" not in name and "\\" not in name and ":" not in name
+        assert not name.endswith(".")
+        digest, decoded = _parse_backup_name(name)
+        assert decoded == remote_path
+        assert digest == path_key(remote_path)
+
+    def test_an_encoded_path_is_written_and_read_back(self, store):
+        remote_path = "decisions\\003-x.md"
+
+        saved = save_quarantine_backup(store, remote_path, b"body\n", '"etag"')
+
+        assert saved.is_file()
+        assert saved.read_bytes() == b"body\n"
+        assert [item.remote_path for item in list_quarantine_backups(store)] == [remote_path]
+
+    def test_a_very_long_path_stays_inside_the_filename_limit(self, store):
+        remote_path = f"decisions/{'a' * 193}.md"
+
+        saved = save_quarantine_backup(store, remote_path, b"body\n", '"etag"')
+
+        assert len(saved.name.encode("utf-8")) < 255
+        listed = list_quarantine_backups(store)
+        assert len(listed) == 1
+        # The display is capped and says so; identity is the digest.
+        assert listed[0].complete_path is False
+        assert listed[0].label.endswith("...")
+        assert listed[0].path_digest == path_key(remote_path)
+
+    def test_a_capped_path_still_resolves_once_installed(self, store):
+        remote_path = f"decisions/{'a' * 193}.md"
+        save_quarantine_backup(store, remote_path, b"body\n", '"etag"')
+        assert len(unresolved_quarantines(store)) == 1
+
+        state = SyncState()
+        state.files[remote_path] = FileState(local_sha256="abc", remote_etag='"etag"')
+        save_state(store, state)
+
+        assert unresolved_quarantines(store) == []

--- a/packages/nauro/tests/test_sync/test_collisions.py
+++ b/packages/nauro/tests/test_sync/test_collisions.py
@@ -12,6 +12,7 @@ import json
 from collections import Counter
 
 import pytest
+from nauro_core import parse_decision
 
 from nauro.constants import DECISION_HASHES_FILE
 from nauro.sync import corpus as corpus_module
@@ -40,31 +41,14 @@ from nauro.sync.quarantine import (
     unresolved_quarantines,
 )
 from nauro.sync.state import FileState, SyncState, load_state, save_state
-from tests.test_sync.conftest import _scaffolded_cloud_project
-from tests.test_sync.test_pull import (
+from tests.test_sync.conftest import (
+    _STAMPED_DECISION,
+    _STAMPED_SHA,
+    _scaffolded_cloud_project,
     _seed_token,
     decision_bytes,
     pull,
     write_local_decision,
-)
-
-_STAMPED_SHA = "a1b2c3d4" * 5
-_STAMPED_DECISION = (
-    "---\n"
-    "date: 2026-08-05\n"
-    "version: 1\n"
-    "status: active\n"
-    "confidence: high\n"
-    "decision_type: null\n"
-    "reversibility: null\n"
-    "source: null\n"
-    "files_affected: []\n"
-    "supersedes: null\n"
-    "superseded_by: null\n"
-    f"base_commit: {_STAMPED_SHA}\n"
-    "---\n\n"
-    "# 099 — Remote stamped decision\n\n"
-    "## Decision\n\nChose A.\n"
 )
 
 
@@ -129,8 +113,11 @@ class TestHeadingPrimitives:
         )
 
     def test_rewrite_touches_only_the_heading(self):
-        rewritten = rewrite_decision_heading(_STAMPED_DECISION, 99, 100)
-        assert rewritten == _STAMPED_DECISION.replace("# 099 ", "# 100 ")
+        stamped = _STAMPED_DECISION.decode("utf-8")
+
+        rewritten = rewrite_decision_heading(stamped, 99, 100)
+
+        assert rewritten == stamped.replace("# 099 ", "# 100 ")
         assert f"base_commit: {_STAMPED_SHA}" in rewritten
 
 
@@ -656,3 +643,78 @@ class TestBackupFilenames:
         save_state(store, state)
 
         assert unresolved_quarantines(store) == []
+
+
+class TestHeadingFormsStayBound:
+    """The lax reader and the strict rewriter must not drift apart.
+
+    Two modules describe the same heading: the kernel's parser decides what a
+    decision file is, and this layer's rewriter decides which of those it may
+    renumber. If the strict form ever stopped being a subset of the parsed one,
+    a renumber would produce a file the kernel no longer reads - so the
+    relationship is asserted rather than assumed.
+    """
+
+    _HEADINGS = [
+        "# 003 — Em dash",
+        "# 003 - Hyphen",
+        "#  003 — Extra space",
+        "# 3 — Unpadded",
+        "# 0003 — Over padded",
+        "## 003 — Wrong level",
+        "#003 — No space",
+        "# 003 : Wrong separator",
+    ]
+
+    @pytest.mark.parametrize("heading", _HEADINGS)
+    def test_strict_is_a_subset_of_lax(self, heading):
+        text = f"{heading}\nbody\n"
+
+        if has_rewritable_heading(text, 3):
+            assert heading_number(text) == 3
+
+    @pytest.mark.parametrize("heading", _HEADINGS)
+    def test_a_rewrite_never_makes_a_readable_decision_unreadable(self, heading):
+        """The invariant a renumber depends on: if the kernel could read the
+        file before, it can read it after, and its heading agrees with the
+        filename the rename gives it."""
+        body = (
+            "---\ndate: 2026-08-11\nversion: 1\nstatus: active\nconfidence: high\n"
+            "decision_type: null\nreversibility: null\nsource: null\nfiles_affected: []\n"
+            "supersedes: null\nsuperseded_by: null\n---\n\n"
+            f"{heading}\n\n## Decision\n\nBody.\n"
+        )
+        try:
+            parse_decision(body, "003-x.md")
+        except ValueError:
+            return
+        if not has_rewritable_heading(body, 3):
+            return
+
+        rewritten = rewrite_decision_heading(body, 3, 44)
+
+        assert heading_number(rewritten) == 44
+        parsed = parse_decision(rewritten, "044-renamed.md")
+        assert parsed.num == 44
+        assert heading_number(parsed.content) == 44
+
+    def test_the_kernel_reads_every_heading_the_rewriter_accepts(self):
+        """The em-dash form is the one nauro-core's parser requires; the
+        rewriter also accepts a hyphen, which the parser does not. That gap is
+        deliberate and one-directional: a hyphen heading is renumberable but
+        was never a parseable decision to begin with, so no renumber can turn a
+        readable file into an unreadable one."""
+        em_dash = "# 003 — Title\n\n## Decision\n\nBody.\n"
+        frontmatter = (
+            "---\ndate: 2026-08-11\nversion: 1\nstatus: active\nconfidence: high\n"
+            "decision_type: null\nreversibility: null\nsource: null\nfiles_affected: []\n"
+            "supersedes: null\nsuperseded_by: null\n---\n\n"
+        )
+
+        assert has_rewritable_heading(em_dash, 3) is True
+        assert parse_decision(frontmatter + em_dash, "003-x.md").num == 3
+
+        hyphen = "# 003 - Title\n\n## Decision\n\nBody.\n"
+        assert has_rewritable_heading(hyphen, 3) is True
+        with pytest.raises(ValueError):
+            parse_decision(frontmatter + hyphen, "003-x.md")

--- a/packages/nauro/tests/test_sync/test_pull.py
+++ b/packages/nauro/tests/test_sync/test_pull.py
@@ -12,7 +12,6 @@ classifier and its crash windows are unit-tested in ``test_collisions.py``.
 
 from __future__ import annotations
 
-import json
 from unittest.mock import patch
 
 import httpx
@@ -37,79 +36,20 @@ from nauro.sync.state import (
     load_state,
     save_state,
 )
-from tests.conftest import seed_auth_config
-from tests.test_sync.conftest import CLOUD_PID, _scaffolded_cloud_project
-
-
-def _ok(status: int, payload: dict) -> httpx.Response:
-    return httpx.Response(
-        status,
-        content=json.dumps(payload).encode("utf-8"),
-        headers={"content-type": "application/json"},
-    )
-
-
-def _seed_token() -> None:
-    seed_auth_config(variant="sync")
-
-
-def _manifest(files, next_cursor=None) -> httpx.Response:
-    return _ok(200, {"files": files, "next_cursor": next_cursor})
-
-
-def _presign(ops) -> httpx.Response:
-    return _ok(
-        200,
-        {
-            "urls": [
-                {
-                    "verb": op["verb"],
-                    "path": op["path"],
-                    "url": f"https://s3.example/{op['verb']}/{op['path']}",
-                    "expires_at": "2026-05-16T13:00:00Z",
-                }
-                for op in ops
-            ]
-        },
-    )
-
-
-# A canonical decision carrying the base_commit provenance stamp as its
-# trailing frontmatter key. Sync moves raw bytes, so stamped files must
-# round-trip byte-identically like any other decision.
-_STAMPED_SHA = "a1b2c3d4" * 5
-_STAMPED_DECISION = (
-    "---\n"
-    "date: 2026-08-05\n"
-    "version: 1\n"
-    "status: active\n"
-    "confidence: high\n"
-    "decision_type: null\n"
-    "reversibility: null\n"
-    "source: null\n"
-    "files_affected: []\n"
-    "supersedes: null\n"
-    "superseded_by: null\n"
-    f"base_commit: {_STAMPED_SHA}\n"
-    "---\n\n"
-    "# 099 — Remote stamped decision\n\n"
-    "## Decision\n\nChose A.\n"
-).encode()
-
-
-class _RecordingReporter:
-    """Records reported messages."""
-
-    def __init__(self) -> None:
-        self.infos: list[str] = []
-        self.warns: list[str] = []
-
-    def info(self, msg: str) -> None:
-        self.infos.append(msg)
-
-    def warn(self, msg: str) -> None:
-        self.warns.append(msg)
-
+from tests.test_sync.conftest import (
+    _STAMPED_DECISION,
+    CLOUD_PID,
+    _manifest,
+    _presign,
+    _RecordingReporter,
+    _scaffolded_cloud_project,
+    _seed_token,
+    decision_bytes,
+    entry_names,
+    pull,
+    track,
+    write_local_decision,
+)
 
 # --- run_pull happy path ---
 
@@ -204,99 +144,6 @@ class TestRunPullCleanPull:
 
 
 # --- decision-number collisions: one classification per remote file ---
-
-
-def decision_bytes(
-    num: int,
-    title: str,
-    rationale: str = "Chose A.",
-    *,
-    status: str = "active",
-    supersedes: str | None = None,
-    superseded_by: str | None = None,
-    separator: str = "—",
-) -> bytes:
-    """A canonical decision file body, parseable by ``parse_decision``."""
-    return (
-        "---\n"
-        "date: 2026-08-10\n"
-        "version: 1\n"
-        f"status: {status}\n"
-        "confidence: high\n"
-        "decision_type: null\n"
-        "reversibility: null\n"
-        "source: null\n"
-        "files_affected: []\n"
-        f"supersedes: {repr(supersedes) if supersedes else 'null'}\n"
-        f"superseded_by: {repr(superseded_by) if superseded_by else 'null'}\n"
-        "---\n\n"
-        f"# {num:03d} {separator} {title}\n\n"
-        "## Decision\n\n"
-        f"{rationale}\n"
-    ).encode()
-
-
-def write_local_decision(store, filename: str, content: bytes) -> object:
-    decisions = store / "decisions"
-    decisions.mkdir(exist_ok=True)
-    path = decisions / filename
-    path.write_bytes(content)
-    return path
-
-
-def pull(store, entries, *, reporter=None, etags=None):
-    """Run one pull against a fake server holding exactly ``entries``.
-
-    ``entries`` is an ordered list of ``(path, body)`` pairs so the tests can
-    pin manifest order where order is the thing under test.
-    """
-    reporter = reporter or _RecordingReporter()
-    etags = etags or {}
-    bodies = dict(entries)
-    manifest = _manifest(
-        [
-            {
-                "path": rel,
-                "etag": etags.get(rel, f'"{rel}-v1"'),
-                "size": len(body),
-                "last_modified": "x",
-            }
-            for rel, body in entries
-        ]
-    )
-    presign = _presign([{"verb": "GET", "path": rel} for rel, _body in entries])
-
-    def fake_get(url, **kwargs):
-        if "/sync/manifest" in url:
-            return manifest
-        return httpx.Response(200, content=bodies[url.split("/GET/", 1)[1]])
-
-    with (
-        patch("nauro.sync.remote.httpx.get", side_effect=fake_get),
-        patch("nauro.sync.remote.httpx.post", return_value=presign),
-    ):
-        merged = run_pull(CLOUD_PID, store, reporter)
-    return merged, reporter
-
-
-def entry_names(directory) -> set[str]:
-    """Actual on-disk entry names.
-
-    ``Path.exists()`` folds case on macOS and Windows, so an assertion about
-    what a pull did or did not write has to read the directory itself.
-    """
-    return {entry.name for entry in directory.iterdir()} if directory.is_dir() else set()
-
-
-def track(store, rel: str) -> None:
-    """Record a sync-state entry for a local file, as a completed push would."""
-    state = load_state(store)
-    state.files[rel] = FileState(
-        local_sha256=compute_sha256(store / rel),
-        remote_etag='"pushed"',
-        last_sync="2026-08-10T00:00:00Z",
-    )
-    save_state(store, state)
 
 
 @pytest.fixture()
@@ -1246,7 +1093,10 @@ class TestWriteBarrier:
         """The barrier is asserted directly, not through a contrived planner:
         it is the last check before bytes land and has to hold on its own."""
         allowed = pull_module._generic_write_allowed(
-            collision_store, _Transfer(rel=rel, etag='"e"', _body=b""), _RecordingReporter()
+            collision_store,
+            _Transfer(rel=rel, etag='"e"', _body=b""),
+            SyncState(),
+            _RecordingReporter(),
         )
 
         assert allowed is False
@@ -1255,6 +1105,7 @@ class TestWriteBarrier:
         allowed = pull_module._generic_write_allowed(
             collision_store,
             _Transfer(rel="snapshots/v001.json", etag='"e"', _body=b""),
+            SyncState(),
             _RecordingReporter(),
         )
 
@@ -1339,3 +1190,125 @@ class TestDirectoryDestinations:
         assert merged == 0
         assert (collision_store / "snapshots").is_dir()
         assert any("directory" in warning for warning in reporter.warns)
+
+
+class TestTrackedDecisionUpdates:
+    """A decision's second sync and every one after it.
+
+    The gate exists to stop a write from creating a duplicate number. A remote
+    update to a decision the store already tracks, arriving at its own path,
+    creates nothing: it is the ordinary pull that carries a rider or a
+    supersession flip from one machine to another. Routing it through the
+    classifier would be worse than pointless - the same-path leg resolves
+    differing bytes by keeping the local copy, so a clean remote update would
+    be dropped on the floor.
+    """
+
+    @pytest.fixture()
+    def tracked(self, collision_store):
+        rel = "decisions/003-shared.md"
+        write_local_decision(collision_store, "003-shared.md", decision_bytes(3, "Shared", "v1."))
+        track(collision_store, rel)
+        return rel
+
+    def test_a_remote_update_lands(self, collision_store, tracked):
+        updated = decision_bytes(3, "Shared", "v2, with a rider from the other machine.")
+
+        merged, reporter = pull(collision_store, [(tracked, updated)], etags={tracked: '"v2"'})
+
+        assert merged == 1
+        assert (collision_store / tracked).read_bytes() == updated
+        assert load_state(collision_store).files[tracked].remote_etag == '"v2"'
+        assert reporter.warns == []
+
+    def test_a_two_sided_change_keeps_local_and_backs_up_remote(self, collision_store, tracked):
+        local_edit = decision_bytes(3, "Shared", "v2 edited here.")
+        (collision_store / tracked).write_bytes(local_edit)
+        remote_edit = decision_bytes(3, "Shared", "v2 edited there.")
+
+        merged, _reporter = pull(collision_store, [(tracked, remote_edit)], etags={tracked: '"v2"'})
+
+        # The existing last-write-wins policy for decision files, unchanged.
+        assert merged == 1
+        assert (collision_store / tracked).read_bytes() == local_edit
+        backups = [path.read_bytes() for path in (collision_store / ".conflict-backup").iterdir()]
+        assert backups == [remote_edit]
+
+    def test_the_barrier_admits_the_update_but_still_refuses_a_nested_path(
+        self, collision_store, tracked
+    ):
+        state = load_state(collision_store)
+
+        assert (
+            pull_module._generic_write_allowed(
+                collision_store,
+                _Transfer(rel=tracked, etag='"v2"', _body=b""),
+                state,
+                _RecordingReporter(),
+            )
+            is True
+        )
+        for rel in ("decisions/sub/003-shared.md", "decisions/003-untracked.md"):
+            assert (
+                pull_module._generic_write_allowed(
+                    collision_store,
+                    _Transfer(rel=rel, etag='"v2"', _body=b""),
+                    state,
+                    _RecordingReporter(),
+                )
+                is False
+            )
+
+    def test_a_non_canonical_tracked_path_is_still_quarantined(self, collision_store):
+        legacy = "decisions/004-old.MD"
+        write_local_decision(collision_store, "004-old.MD", b"legacy\n")
+        track(collision_store, legacy)
+
+        merged, reporter = pull(collision_store, [(legacy, b"newer\n")], etags={legacy: '"v2"'})
+
+        assert merged == 0
+        assert (collision_store / "decisions/004-old.MD").read_bytes() == b"legacy\n"
+        assert any("decisions/<name>.md" in warning for warning in reporter.warns)
+
+
+class TestUnreadableLocalNames:
+    """A local file the store's own readers cannot see still claims its number.
+
+    ``list_decisions`` and the kernel's allocator match a lowercase ``.md``
+    literally, so ``007-x.MD`` is invisible to them. If the corpus were blind to
+    it too, a remote decision would land beside it and the allocator would go on
+    to mint its number a third time.
+    """
+
+    def test_it_holds_back_a_remote_decision_claiming_its_number(self, collision_store):
+        local = write_local_decision(collision_store, "007-local.MD", decision_bytes(7, "Local"))
+
+        merged, reporter = pull(
+            collision_store, [("decisions/007-remote.md", decision_bytes(7, "Remote"))]
+        )
+
+        assert merged == 0
+        assert local.read_bytes() == decision_bytes(7, "Local")
+        assert "007-remote.md" not in entry_names(collision_store / "decisions")
+        assert any("lowercase '.md'" in warning for warning in reporter.warns)
+
+    def test_it_is_a_case_variant_of_the_name_the_server_sends(self, collision_store):
+        write_local_decision(collision_store, "007-remote.MD", decision_bytes(7, "Local"))
+
+        merged, reporter = pull(
+            collision_store, [("decisions/007-remote.md", decision_bytes(7, "Remote"))]
+        )
+
+        assert merged == 0
+        assert "007-remote.md" not in entry_names(collision_store / "decisions")
+        assert reporter.warns
+
+    def test_an_unrelated_number_is_unaffected(self, collision_store):
+        write_local_decision(collision_store, "007-local.MD", decision_bytes(7, "Local"))
+
+        merged, _reporter = pull(
+            collision_store, [("decisions/008-remote.md", decision_bytes(8, "Remote"))]
+        )
+
+        assert merged == 1
+        assert "008-remote.md" in entry_names(collision_store / "decisions")

--- a/packages/nauro/tests/test_sync/test_pull.py
+++ b/packages/nauro/tests/test_sync/test_pull.py
@@ -4,8 +4,10 @@
 ``nauro sync`` and the SessionStart hook. The two callers differ only in
 their :class:`~nauro.sync.pull.Reporter`: the CLI echoes to the terminal,
 the hook logs quietly. These tests drive the core directly with a
-recording stub, and pin the renumber-on-collision helper byte-for-byte
-against the canonical cases the hook previously owned.
+recording stub.
+
+The decision-number collision matrix is exercised end to end here; the
+classifier and its crash windows are unit-tested in ``test_collisions.py``.
 """
 
 from __future__ import annotations
@@ -15,9 +17,19 @@ from unittest.mock import patch
 
 import httpx
 import pytest
+from nauro_core.operations.propose_decision import _next_decision_num
 
-from nauro.store.registry import register_project_v2
-from nauro.sync.pull import _renumber_decision_if_collision, run_pull
+from nauro.store.filesystem_store import FilesystemStore
+from nauro.sync import pull as pull_module
+from nauro.sync.corpus import DecisionCorpus
+from nauro.sync.lock import SyncLockTimeoutError, decision_lock
+from nauro.sync.merge import SPOOL_DIR_PREFIX, should_skip
+from nauro.sync.pull import _Transfer, run_pull
+from nauro.sync.quarantine import (
+    list_quarantine_backups,
+    save_quarantine_backup,
+    unresolved_quarantines,
+)
 from nauro.sync.state import (
     FileState,
     SyncState,
@@ -25,7 +37,6 @@ from nauro.sync.state import (
     load_state,
     save_state,
 )
-from nauro.templates.scaffolds import scaffold_project_store
 from tests.conftest import seed_auth_config
 from tests.test_sync.conftest import CLOUD_PID, _scaffolded_cloud_project
 
@@ -192,164 +203,1139 @@ class TestRunPullCleanPull:
         assert reporter.warns == []
 
 
-# --- the bug-fix pin: decision-number collision renumbers, never overwrites ---
+# --- decision-number collisions: one classification per remote file ---
 
 
-class TestRunPullDecisionCollision:
-    @pytest.fixture()
-    def cloud_store(self, tmp_path):
-        store = _scaffolded_cloud_project("collisioncore", tmp_path)
-        _seed_token()
-        return store
+def decision_bytes(
+    num: int,
+    title: str,
+    rationale: str = "Chose A.",
+    *,
+    status: str = "active",
+    supersedes: str | None = None,
+    superseded_by: str | None = None,
+    separator: str = "—",
+) -> bytes:
+    """A canonical decision file body, parseable by ``parse_decision``."""
+    return (
+        "---\n"
+        "date: 2026-08-10\n"
+        "version: 1\n"
+        f"status: {status}\n"
+        "confidence: high\n"
+        "decision_type: null\n"
+        "reversibility: null\n"
+        "source: null\n"
+        "files_affected: []\n"
+        f"supersedes: {repr(supersedes) if supersedes else 'null'}\n"
+        f"superseded_by: {repr(superseded_by) if superseded_by else 'null'}\n"
+        "---\n\n"
+        f"# {num:03d} {separator} {title}\n\n"
+        "## Decision\n\n"
+        f"{rationale}\n"
+    ).encode()
 
-    def test_colliding_decision_written_as_next_sequential_file_echo_reporter(self, cloud_store):
-        """The CLI (echo) reporter is the reconciled path that previously
-        overwrote. A pulled decision whose number collides with a local one is
-        written as the NEXT sequential file with its H1 body number rewritten;
-        the local file is left untouched."""
-        from nauro.cli.commands.sync import _EchoReporter
 
-        decisions_dir = cloud_store / "decisions"
-        decisions_dir.mkdir(exist_ok=True)
-        local_file = decisions_dir / "003-local-decision.md"
-        local_file.write_bytes(b"# 003 \xe2\x80\x94 Local decision\n\nLocal body\n")
-        local_original = local_file.read_bytes()
+def write_local_decision(store, filename: str, content: bytes) -> object:
+    decisions = store / "decisions"
+    decisions.mkdir(exist_ok=True)
+    path = decisions / filename
+    path.write_bytes(content)
+    return path
 
-        rel = "decisions/003-remote-decision.md"
-        manifest = _manifest([{"path": rel, "etag": '"new"', "size": 1, "last_modified": "x"}])
-        presign = _presign([{"verb": "GET", "path": rel}])
 
-        remote_body = b"# 003 \xe2\x80\x94 Remote decision\n\nRemote body\n"
+def pull(store, entries, *, reporter=None, etags=None):
+    """Run one pull against a fake server holding exactly ``entries``.
 
-        def fake_get(url, **kwargs):
-            if "/sync/manifest" in url:
-                return manifest
-            return httpx.Response(200, content=remote_body)
+    ``entries`` is an ordered list of ``(path, body)`` pairs so the tests can
+    pin manifest order where order is the thing under test.
+    """
+    reporter = reporter or _RecordingReporter()
+    etags = etags or {}
+    bodies = dict(entries)
+    manifest = _manifest(
+        [
+            {
+                "path": rel,
+                "etag": etags.get(rel, f'"{rel}-v1"'),
+                "size": len(body),
+                "last_modified": "x",
+            }
+            for rel, body in entries
+        ]
+    )
+    presign = _presign([{"verb": "GET", "path": rel} for rel, _body in entries])
 
-        with (
-            patch("nauro.sync.remote.httpx.get", side_effect=fake_get),
-            patch("nauro.sync.remote.httpx.post", return_value=presign),
-        ):
-            merged = run_pull(CLOUD_PID, cloud_store, _EchoReporter())
+    def fake_get(url, **kwargs):
+        if "/sync/manifest" in url:
+            return manifest
+        return httpx.Response(200, content=bodies[url.split("/GET/", 1)[1]])
+
+    with (
+        patch("nauro.sync.remote.httpx.get", side_effect=fake_get),
+        patch("nauro.sync.remote.httpx.post", return_value=presign),
+    ):
+        merged = run_pull(CLOUD_PID, store, reporter)
+    return merged, reporter
+
+
+def entry_names(directory) -> set[str]:
+    """Actual on-disk entry names.
+
+    ``Path.exists()`` folds case on macOS and Windows, so an assertion about
+    what a pull did or did not write has to read the directory itself.
+    """
+    return {entry.name for entry in directory.iterdir()} if directory.is_dir() else set()
+
+
+def track(store, rel: str) -> None:
+    """Record a sync-state entry for a local file, as a completed push would."""
+    state = load_state(store)
+    state.files[rel] = FileState(
+        local_sha256=compute_sha256(store / rel),
+        remote_etag='"pushed"',
+        last_sync="2026-08-10T00:00:00Z",
+    )
+    save_state(store, state)
+
+
+@pytest.fixture()
+def collision_store(tmp_path):
+    store = _scaffolded_cloud_project("collisioncore", tmp_path)
+    _seed_token()
+    return store
+
+
+class TestQuarantine:
+    """Published, referenced, or ambiguous colliders are never auto-resolved."""
+
+    def test_tracked_collider_quarantines(self, collision_store):
+        local = write_local_decision(
+            collision_store, "003-local.md", decision_bytes(3, "Local decision")
+        )
+        original = local.read_bytes()
+        track(collision_store, "decisions/003-local.md")
+
+        remote = decision_bytes(3, "Remote decision", "Chose B.")
+        merged, reporter = pull(collision_store, [("decisions/003-remote.md", remote)])
+
+        assert merged == 0
+        assert local.read_bytes() == original
+        assert not (collision_store / "decisions/003-remote.md").exists()
+        assert "decisions/003-remote.md" not in load_state(collision_store).files
+        assert len(reporter.warns) == 1
+        assert "already published" in reporter.warns[0]
+        assert "Nauro app" in reporter.warns[0]
+
+    def test_collider_in_manifest_quarantines(self, collision_store):
+        """The push-crash shape: the PUT landed, the state save did not."""
+        local = write_local_decision(
+            collision_store, "003-local.md", decision_bytes(3, "Local decision")
+        )
+        original = local.read_bytes()
+
+        merged, reporter = pull(
+            collision_store,
+            [
+                ("decisions/003-remote.md", decision_bytes(3, "Remote decision", "Chose B.")),
+                ("decisions/003-local.md", original),
+            ],
+        )
+
+        assert local.read_bytes() == original
+        assert not (collision_store / "decisions/003-remote.md").exists()
+        assert merged == 0
+        assert any("server manifest" in warning for warning in reporter.warns)
+        # The same run adopts the local file the server already holds.
+        assert "decisions/003-local.md" in load_state(collision_store).files
+
+    def test_supersede_lineage_collider_quarantines(self, collision_store):
+        write_local_decision(collision_store, "003-local.md", decision_bytes(3, "Local decision"))
+        write_local_decision(
+            collision_store,
+            "004-child.md",
+            decision_bytes(4, "Child decision", supersedes="3"),
+        )
+
+        merged, reporter = pull(
+            collision_store,
+            [("decisions/003-remote.md", decision_bytes(3, "Remote decision", "Chose B."))],
+        )
+
+        assert merged == 0
+        assert (collision_store / "decisions/003-local.md").exists()
+        assert any("supersession" in warning for warning in reporter.warns)
+
+    def test_question_resolution_reference_quarantines(self, collision_store):
+        write_local_decision(collision_store, "003-local.md", decision_bytes(3, "Local decision"))
+        (collision_store / "open-questions.md").write_text(
+            "# Open Questions\n\n- [Resolved by D3 on 2026-08-01] [Q7] Which storage layout?\n"
+        )
+
+        merged, reporter = pull(
+            collision_store,
+            [("decisions/003-remote.md", decision_bytes(3, "Remote decision", "Chose B."))],
+        )
+
+        assert merged == 0
+        assert (collision_store / "decisions/003-local.md").exists()
+        assert any("open question" in warning for warning in reporter.warns)
+
+    def test_two_colliders_quarantine(self, collision_store):
+        write_local_decision(collision_store, "003-a.md", decision_bytes(3, "A"))
+        write_local_decision(collision_store, "003-b.md", decision_bytes(3, "B"))
+
+        merged, reporter = pull(
+            collision_store,
+            [("decisions/003-remote.md", decision_bytes(3, "Remote decision", "Chose B."))],
+        )
+
+        assert merged == 0
+        assert any("more than one local file" in warning for warning in reporter.warns)
+
+    def test_unparseable_collider_quarantines(self, collision_store):
+        write_local_decision(collision_store, "003-local.md", b"not a decision at all\n")
+
+        merged, reporter = pull(
+            collision_store,
+            [("decisions/003-remote.md", decision_bytes(3, "Remote decision", "Chose B."))],
+        )
+
+        assert merged == 0
+        assert (collision_store / "decisions/003-local.md").read_bytes() == (
+            b"not a decision at all\n"
+        )
+        assert any("does not parse" in warning for warning in reporter.warns)
+
+    def test_collider_without_rewritable_heading_quarantines(self, collision_store):
+        # The decision parser tolerates extra whitespace after the hash; the
+        # heading rewriter's canonical form does not. The file is otherwise
+        # isolated, so only the unrewritable heading holds the renumber back.
+        body = decision_bytes(3, "Local decision").replace(b"\n# 003", b"\n#  003")
+        write_local_decision(collision_store, "003-local.md", body)
+
+        merged, reporter = pull(
+            collision_store,
+            [("decisions/003-remote.md", decision_bytes(3, "Remote decision", "Chose B."))],
+        )
+
+        assert merged == 0
+        assert any("canonical form" in warning for warning in reporter.warns)
+        # Nothing moved: the refusal happens before any rename.
+        assert (collision_store / "decisions/003-local.md").read_bytes() == body
+
+    def test_backup_written_once_across_repeated_pulls(self, collision_store):
+        write_local_decision(collision_store, "003-local.md", decision_bytes(3, "Local decision"))
+        track(collision_store, "decisions/003-local.md")
+        remote = decision_bytes(3, "Remote decision", "Chose B.")
+
+        for _ in range(3):
+            merged, reporter = pull(collision_store, [("decisions/003-remote.md", remote)])
+            assert merged == 0
+            # The warning re-fires every pull; the backup does not multiply.
+            assert len(reporter.warns) == 1
+
+        backups = list_quarantine_backups(collision_store)
+        assert len(backups) == 1
+        assert backups[0].remote_path == "decisions/003-remote.md"
+        assert backups[0].backup_path.read_bytes() == remote
+
+
+class TestCanonicalize:
+    def test_identical_unpublished_collider_is_renamed_onto_the_remote_name(self, collision_store):
+        body = decision_bytes(3, "One decision")
+        write_local_decision(collision_store, "003-local-name.md", body)
+
+        merged, reporter = pull(collision_store, [("decisions/003-remote-name.md", body)])
+
+        assert not (collision_store / "decisions/003-local-name.md").exists()
+        assert (collision_store / "decisions/003-remote-name.md").read_bytes() == body
+        state = load_state(collision_store)
+        assert "decisions/003-remote-name.md" in state.files
+        assert "decisions/003-local-name.md" not in state.files
+        # Nothing was transferred onto disk, so nothing counts as merged - but
+        # the run did act, so it must not sign off as "No remote changes".
+        assert merged == 0
+        assert reporter.warns == []
+        assert any("two names" in info for info in reporter.infos)
+        assert "Adopted 1 local file(s) already on the server" in reporter.infos
+        assert "No remote changes" not in reporter.infos
+
+    def test_crash_before_state_save_is_healed_by_the_adoption_leg(self, collision_store):
+        """The canonicalize landed but the state save was lost: the next pull
+        finds the exact file untracked and adopts it without a transfer."""
+        body = decision_bytes(3, "One decision")
+        write_local_decision(collision_store, "003-remote-name.md", body)
+
+        merged, reporter = pull(collision_store, [("decisions/003-remote-name.md", body)])
+
+        assert merged == 0
+        assert (collision_store / "decisions/003-remote-name.md").read_bytes() == body
+        assert "decisions/003-remote-name.md" in load_state(collision_store).files
+        assert any("Adopted 1 local file" in info for info in reporter.infos)
+
+
+class TestRenumberLocal:
+    def test_isolated_collider_moves_and_the_remote_installs(self, collision_store):
+        local = write_local_decision(
+            collision_store, "003-local.md", decision_bytes(3, "Local decision")
+        )
+        remote = decision_bytes(3, "Remote decision", "Chose B.")
+
+        merged, reporter = pull(collision_store, [("decisions/003-remote.md", remote)])
 
         assert merged == 1
-        # Local decision untouched — this is the data-loss bug the fix closes.
-        assert local_file.read_bytes() == local_original
-        # Remote landed as the next sequential file with the H1 number rewritten.
-        new_file = decisions_dir / "004-remote-decision.md"
-        assert new_file.exists()
-        new_bytes = new_file.read_bytes()
-        assert new_bytes == b"# 004 \xe2\x80\x94 Remote decision\n\nRemote body\n"
-        # State keys the renumbered path, not the colliding incoming one.
-        state = load_state(cloud_store)
-        assert "decisions/004-remote-decision.md" in state.files
-        assert rel not in state.files
+        assert not local.exists()
+        # The scaffold seeds 001, so the next free number is 004 once the
+        # server's own 003 is reserved.
+        renamed = collision_store / "decisions/004-local.md"
+        assert renamed.read_bytes() == decision_bytes(4, "Local decision")
+        assert (collision_store / "decisions/003-remote.md").read_bytes() == remote
 
+        state = load_state(collision_store)
+        assert "decisions/003-remote.md" in state.files
+        # The renumbered local file was never published, so it stays untracked
+        # and the next push uploads it.
+        assert "decisions/004-local.md" not in state.files
+        assert reporter.warns == []
 
-# --- renumber helper: byte-identical to the canonical pre-port cases ---
+    def test_mint_skips_numbers_the_server_already_holds(self, collision_store):
+        write_local_decision(collision_store, "003-local.md", decision_bytes(3, "Local decision"))
 
-
-class TestRenumberDecisionIfCollision:
-    @pytest.fixture()
-    def project_store(self, tmp_path):
-        _pid, store = register_project_v2("renumproj", [tmp_path])
-        scaffold_project_store("renumproj", store)
-        return store
-
-    def test_no_collision_passes_through(self, project_store):
-        decisions_dir = project_store / "decisions"
-        decisions_dir.mkdir(exist_ok=True)
-        (decisions_dir / "001-existing.md").write_text("# 001 — Existing")
-
-        content = b"# 002 \xe2\x80\x94 New decision\n\nSome content"
-        rel, out = _renumber_decision_if_collision(project_store, "decisions/002-new.md", content)
-
-        assert rel == "decisions/002-new.md"
-        assert out == content
-
-    def test_collision_renumbers(self, project_store):
-        decisions_dir = project_store / "decisions"
-        decisions_dir.mkdir(exist_ok=True)
-        (decisions_dir / "003-local-decision.md").write_text("# 003 — Local decision")
-
-        content = b"# 003 \xe2\x80\x94 Remote decision\n\nRemote content"
-        rel, out = _renumber_decision_if_collision(
-            project_store,
-            "decisions/003-remote-decision.md",
-            content,
+        merged, _reporter = pull(
+            collision_store,
+            [
+                ("decisions/003-remote.md", decision_bytes(3, "Remote decision", "Chose B.")),
+                ("decisions/009-unrelated.md", decision_bytes(9, "Unrelated")),
+            ],
         )
 
-        assert rel == "decisions/004-remote-decision.md"
-        # Byte-identical to the old regex rewrite: only the number changed.
-        assert out == b"# 004 \xe2\x80\x94 Remote decision\n\nRemote content"
+        assert merged == 2
+        # 009 is in the manifest, so the local file may not mint onto it.
+        assert (collision_store / "decisions/010-local.md").exists()
+        assert (collision_store / "decisions/009-unrelated.md").exists()
 
-    def test_collision_skips_multiple_taken_numbers(self, project_store):
-        decisions_dir = project_store / "decisions"
-        decisions_dir.mkdir(exist_ok=True)
-        (decisions_dir / "005-a.md").write_text("# 005 — A")
-        (decisions_dir / "006-b.md").write_text("# 006 — B")
 
-        content = b"# 005 \xe2\x80\x94 Incoming\n\nContent"
-        rel, out = _renumber_decision_if_collision(
-            project_store,
-            "decisions/005-incoming.md",
-            content,
+class TestDualRemoteSameNumber:
+    """Two remote decisions claiming one number: one installs, one quarantines."""
+
+    @staticmethod
+    def _entries(order):
+        first = ("decisions/003-first.md", decision_bytes(3, "First remote", "Chose B."))
+        second = ("decisions/003-second.md", decision_bytes(3, "Second remote", "Chose C."))
+        return [first, second] if order == "forward" else [second, first]
+
+    @pytest.mark.parametrize("order", ["forward", "reverse"])
+    def test_exactly_one_installs(self, collision_store, order):
+        write_local_decision(collision_store, "003-local.md", decision_bytes(3, "Local decision"))
+
+        merged, reporter = pull(collision_store, self._entries(order))
+
+        assert merged == 1
+        installed = sorted(path.name for path in (collision_store / "decisions").glob("003-*.md"))
+        assert len(installed) == 1
+        assert len(reporter.warns) == 1
+        # The loser's collider is the winner's freshly installed file, so the
+        # quarantine is the published-versus-published one with no local route.
+        assert "Nauro app" in reporter.warns[0]
+        assert len(list_quarantine_backups(collision_store)) == 1
+
+
+class TestAdoptionLeg:
+    def test_identical_local_file_is_adopted_without_a_rewrite(self, collision_store):
+        body = decision_bytes(5, "Already pushed")
+        path = write_local_decision(collision_store, "005-already-pushed.md", body)
+
+        merged, reporter = pull(collision_store, [("decisions/005-already-pushed.md", body)])
+
+        assert merged == 0
+        assert path.read_bytes() == body
+        assert "decisions/005-already-pushed.md" in load_state(collision_store).files
+        assert reporter.warns == []
+
+    def test_differing_local_file_keeps_local_and_backs_up_remote(self, collision_store):
+        local_body = decision_bytes(5, "Already pushed", "Local rationale.")
+        remote_body = decision_bytes(5, "Already pushed", "Remote rationale.")
+        path = write_local_decision(collision_store, "005-already-pushed.md", local_body)
+
+        merged, _reporter = pull(
+            collision_store, [("decisions/005-already-pushed.md", remote_body)]
         )
 
-        assert rel == "decisions/007-incoming.md"
-        assert out == b"# 007 \xe2\x80\x94 Incoming\n\nContent"
+        assert merged == 1
+        assert path.read_bytes() == local_body
+        backups = list((collision_store / ".conflict-backup").iterdir())
+        assert len(backups) == 1
+        assert backups[0].read_bytes() == remote_body
+        assert "decisions/005-already-pushed.md" in load_state(collision_store).files
 
-    def test_collision_renumbers_hyphen_separator_heading(self, project_store):
-        """The old regex group ``( [—-])`` also matched a plain ASCII hyphen
-        separator; the string-ops rewrite must too."""
-        decisions_dir = project_store / "decisions"
-        decisions_dir.mkdir(exist_ok=True)
-        (decisions_dir / "008-local.md").write_text("# 008 - Local")
 
-        content = b"# 008 - Remote decision\n\nRemote content"
-        rel, out = _renumber_decision_if_collision(
-            project_store,
-            "decisions/008-remote.md",
-            content,
+class TestFreshStoreConvergence:
+    """A store that pulls both the original and a previously renumbered copy
+    records one file each and never re-collides."""
+
+    @pytest.mark.parametrize("order", ["forward", "reverse"])
+    def test_both_orders_converge(self, tmp_path, order):
+        store = _scaffolded_cloud_project(f"fresh{order}", tmp_path)
+        _seed_token()
+        entries = [
+            ("decisions/003-shared-slug.md", decision_bytes(3, "Shared slug", "Remote rationale.")),
+            ("decisions/004-shared-slug.md", decision_bytes(4, "Shared slug", "Local rationale.")),
+            ("decisions/010-unrelated.md", decision_bytes(10, "Unrelated")),
+        ]
+        if order == "reverse":
+            entries.reverse()
+
+        merged, reporter = pull(store, entries)
+
+        assert merged == 3
+        assert reporter.warns == []
+        names = sorted(path.name for path in (store / "decisions").glob("*.md"))
+        assert names == [
+            "001-initial-setup.md",
+            "003-shared-slug.md",
+            "004-shared-slug.md",
+            "010-unrelated.md",
+        ]
+
+        # A second pull of the same manifest is a no-op.
+        merged_again, reporter_again = pull(store, entries)
+        assert merged_again == 0
+        assert reporter_again.warns == []
+
+
+class TestEveryDecisionWriteIsGated:
+    """The gate is at the write, not at the plan.
+
+    A verdict taken while the run was deciding what to fetch is not a verdict:
+    a second remote file can claim the same number, and a local writer can mint
+    one in the meantime. Both are re-checked immediately before the write.
+    """
+
+    def test_two_remote_files_one_number_on_a_fresh_store(self, collision_store):
+        merged, reporter = pull(
+            collision_store,
+            [
+                ("decisions/003-first.md", decision_bytes(3, "First remote", "Chose A.")),
+                ("decisions/003-second.md", decision_bytes(3, "Second remote", "Chose B.")),
+            ],
         )
 
-        assert rel == "decisions/009-remote.md"
-        assert out == b"# 009 - Remote decision\n\nRemote content"
+        assert merged == 1
+        installed = sorted(path.name for path in (collision_store / "decisions").glob("003-*.md"))
+        assert installed == ["003-first.md"]
+        assert len(reporter.warns) == 1
+        assert "Nauro app" in reporter.warns[0]
+        assert len(list_quarantine_backups(collision_store)) == 1
 
-    def test_exact_filename_match_is_not_collision(self, project_store):
-        decisions_dir = project_store / "decisions"
-        decisions_dir.mkdir(exist_ok=True)
-        (decisions_dir / "003-same-slug.md").write_text("# 003 — Same slug")
+    @pytest.mark.parametrize("order", ["forward", "reverse"])
+    def test_the_manifest_order_picks_the_winner_deterministically(self, collision_store, order):
+        entries = [
+            ("decisions/003-first.md", decision_bytes(3, "First remote", "Chose A.")),
+            ("decisions/003-second.md", decision_bytes(3, "Second remote", "Chose B.")),
+        ]
+        if order == "reverse":
+            entries.reverse()
 
-        content = b"# 003 \xe2\x80\x94 Same slug\n\nUpdated content"
-        rel, out = _renumber_decision_if_collision(
-            project_store,
-            "decisions/003-same-slug.md",
-            content,
+        merged, _reporter = pull(collision_store, entries)
+
+        assert merged == 1
+        installed = sorted(path.name for path in (collision_store / "decisions").glob("003-*.md"))
+        assert installed == [entries[0][0].split("/")[1]]
+
+    def test_a_number_minted_after_the_plan_is_caught_before_the_write(self, collision_store):
+        """A local writer mints the contested number between the plan and the
+        write; the gate re-runs and applies the matrix instead of duplicating."""
+        remote = decision_bytes(5, "Remote decision", "Chose B.")
+        mint = decision_bytes(5, "Locally minted", "Chose C.")
+
+        real_scan = DecisionCorpus.scan
+        calls = {"n": 0}
+
+        def scan_then_mint(store_path):
+            # The first scan is the planner's; the writer's scan must see the
+            # file that landed in between.
+            corpus = real_scan(store_path)
+            calls["n"] += 1
+            if calls["n"] == 1:
+                write_local_decision(collision_store, "005-locally-minted.md", mint)
+            return corpus
+
+        with patch.object(DecisionCorpus, "scan", staticmethod(scan_then_mint)):
+            merged, reporter = pull(collision_store, [("decisions/005-remote.md", remote)])
+
+        assert merged == 1
+        # The late mint was renumbered out of the way rather than duplicated.
+        assert (collision_store / "decisions/005-remote.md").read_bytes() == remote
+        numbers = sorted(
+            int(path.name.split("-")[0]) for path in (collision_store / "decisions").glob("*.md")
+        )
+        assert len(numbers) == len(set(numbers))
+        assert reporter.warns == []
+
+
+class TestAdoptionSiblings:
+    def test_a_sibling_holding_the_number_is_renumbered_before_adopting(self, collision_store):
+        body = decision_bytes(5, "Already pushed")
+        exact = write_local_decision(collision_store, "005-already-pushed.md", body)
+        sibling = write_local_decision(
+            collision_store, "005-other.md", decision_bytes(5, "Other", "Chose C.")
         )
 
-        assert rel == "decisions/003-same-slug.md"
-        assert out == content
+        merged, reporter = pull(collision_store, [("decisions/005-already-pushed.md", body)])
 
-    def test_collision_renumber_preserves_base_commit_stamp(self, project_store):
-        decisions_dir = project_store / "decisions"
-        decisions_dir.mkdir(exist_ok=True)
-        (decisions_dir / "099-local.md").write_text("# 099 — Local")
+        assert exact.read_bytes() == body
+        assert not sibling.exists()
+        assert (collision_store / "decisions/006-other.md").exists()
+        assert "decisions/005-already-pushed.md" in load_state(collision_store).files
+        assert merged == 0
+        assert reporter.warns == []
 
-        rel, out = _renumber_decision_if_collision(
-            project_store,
-            "decisions/099-remote-stamped.md",
-            _STAMPED_DECISION,
+    def test_an_unresolvable_sibling_blocks_the_adoption(self, collision_store):
+        body = decision_bytes(5, "Already pushed")
+        write_local_decision(collision_store, "005-already-pushed.md", body)
+        sibling = write_local_decision(
+            collision_store, "005-other.md", decision_bytes(5, "Other", "Chose C.")
+        )
+        track(collision_store, "decisions/005-other.md")
+
+        merged, reporter = pull(collision_store, [("decisions/005-already-pushed.md", body)])
+
+        assert merged == 0
+        assert sibling.exists()
+        # No state recorded, so the warning re-fires until the duplicate is gone.
+        assert "decisions/005-already-pushed.md" not in load_state(collision_store).files
+        assert len(reporter.warns) == 1
+        assert "005-other.md" in reporter.warns[0]
+
+    def test_a_case_only_name_difference_is_never_adopted(self, collision_store):
+        """On a case-folding filesystem the remote name resolves to the local
+        file, so writing it would overwrite content instead of adding a record.
+        The listing's own spelling decides, not the OS, and the mismatch is
+        handed to the human rather than renamed automatically."""
+        local_body = decision_bytes(7, "Local casing", "Chose A.")
+        local = write_local_decision(collision_store, "007-Thing.md", local_body)
+        remote = decision_bytes(7, "Remote casing", "Chose B.")
+
+        merged, reporter = pull(collision_store, [("decisions/007-thing.md", remote)])
+
+        assert merged == 0
+        assert local.read_bytes() == local_body
+        assert "decisions/007-thing.md" not in load_state(collision_store).files
+        assert any("letter case" in warning for warning in reporter.warns)
+        assert len(list_quarantine_backups(collision_store)) == 1
+
+    def test_an_unnumbered_case_variant_is_quarantined(self, collision_store):
+        # The remote name is one the writer could have minted; only the local
+        # file's spelling differs, so this is the case-variant cell rather than
+        # the non-canonical one.
+        write_local_decision(collision_store, "NOTES.md", b"local notes\n")
+
+        merged, reporter = pull(collision_store, [("decisions/notes.md", b"remote notes\n")])
+
+        assert merged == 0
+        assert "notes.md" not in entry_names(collision_store / "decisions")
+        assert any("letter case" in warning for warning in reporter.warns)
+
+
+class TestIrregularEntries:
+    """A directory or symlink named like a decision is never read or changed."""
+
+    def test_a_directory_named_like_a_decision_does_not_crash_the_pull(self, collision_store):
+        (collision_store / "decisions" / "009-broken.md").mkdir(parents=True)
+
+        merged, reporter = pull(
+            collision_store, [("decisions/010-fine.md", decision_bytes(10, "Fine"))]
         )
 
-        assert rel == "decisions/100-remote-stamped.md"
-        # Only the H1 number changed; the stamp line is untouched.
-        assert out == _STAMPED_DECISION.replace(b"# 099 ", b"# 100 ")
-        assert f"base_commit: {_STAMPED_SHA}".encode() in out
+        assert merged == 1
+        assert (collision_store / "decisions/010-fine.md").exists()
+        assert any("not a regular file" in warning for warning in reporter.warns)
 
-    def test_non_decision_files_pass_through(self, project_store):
-        content = b"some content"
-        rel, out = _renumber_decision_if_collision(project_store, "state.md", content)
+    def test_a_broken_symlink_does_not_crash_the_pull(self, collision_store):
+        link = collision_store / "decisions" / "011-dangling.md"
+        link.parent.mkdir(parents=True, exist_ok=True)
+        link.symlink_to(collision_store / "decisions" / "nothing-here.md")
 
-        assert rel == "state.md"
-        assert out == content
+        merged, reporter = pull(
+            collision_store, [("decisions/012-fine.md", decision_bytes(12, "Fine"))]
+        )
+
+        assert merged == 1
+        assert any("not a regular file" in warning for warning in reporter.warns)
+
+    def test_a_remote_decision_claiming_a_symlinked_number_is_quarantined(self, collision_store):
+        target = write_local_decision(
+            collision_store, "013-target.md", decision_bytes(13, "Target")
+        )
+        link = collision_store / "decisions" / "014-link.md"
+        link.symlink_to(target)
+
+        merged, reporter = pull(
+            collision_store, [("decisions/014-remote.md", decision_bytes(14, "Remote"))]
+        )
+
+        assert merged == 0
+        assert not (collision_store / "decisions/014-remote.md").exists()
+        assert link.is_symlink()
+        assert any("not a regular file" in warning for warning in reporter.warns)
+
+    def test_reserved_frontmatter_keys_quarantine_instead_of_crashing(self, collision_store):
+        # `num` is a decision-model constructor argument, so a file carrying it
+        # raises TypeError rather than ValueError when parsed.
+        poisoned = decision_bytes(3, "Local").replace(b"supersedes: null", b"num: 99")
+        write_local_decision(collision_store, "003-local.md", poisoned)
+
+        merged, reporter = pull(
+            collision_store,
+            [("decisions/003-remote.md", decision_bytes(3, "Remote", "Chose B."))],
+        )
+
+        assert merged == 0
+        assert (collision_store / "decisions/003-local.md").read_bytes() == poisoned
+        assert any("does not parse" in warning for warning in reporter.warns)
+
+
+class TestTransferShape:
+    """Decision files are batched; everything else streams.
+
+    The gate needs the fetched bytes of every decision file it will judge, so
+    those are held together for the length of one lock hold. Snapshots and
+    briefs have no such requirement, and a first pull of a real store is
+    hundreds of megabytes of them: they are fetched and written one at a time,
+    outside the lock, so neither memory nor a local writer pays for the batch.
+    """
+
+    def _snapshots(self, count: int) -> list[tuple[str, bytes]]:
+        return [(f"snapshots/v{n:03d}.json", f'{{"v": {n}}}'.encode()) for n in range(1, count + 1)]
+
+    def test_non_decision_transfers_are_written_before_the_next_is_fetched(self, collision_store):
+        entries = self._snapshots(3)
+        seen_on_disk: list[int] = []
+        real_fetch = pull_module.fetch_via_presigned_url
+
+        def counting_fetch(url):
+            seen_on_disk.append(len(list((collision_store / "snapshots").glob("*.json"))))
+            return real_fetch(url)
+
+        with patch.object(pull_module, "fetch_via_presigned_url", counting_fetch):
+            merged, _reporter = pull(collision_store, entries)
+
+        assert merged == 3
+        # Each fetch happens after the previous file already landed, so at most
+        # one transfer is in memory at a time.
+        assert seen_on_disk == [0, 1, 2]
+
+    def test_the_decision_lock_is_free_while_non_decision_files_are_written(self, collision_store):
+        acquired: list[bool] = []
+        real_fetch = pull_module.fetch_via_presigned_url
+
+        def probing_fetch(url):
+            try:
+                with decision_lock(collision_store, 0.05):
+                    acquired.append(True)
+            except SyncLockTimeoutError:
+                acquired.append(False)
+            return real_fetch(url)
+
+        with patch.object(pull_module, "fetch_via_presigned_url", probing_fetch):
+            merged, _reporter = pull(collision_store, self._snapshots(2))
+
+        assert merged == 2
+        assert acquired == [True, True]
+
+    def test_the_decision_lock_is_held_while_a_decision_is_classified(self, collision_store):
+        held: list[bool] = []
+        real_classify = pull_module.classify_decision
+
+        def probing_classify(*args, **kwargs):
+            try:
+                with decision_lock(collision_store, 0.05):
+                    held.append(False)
+            except SyncLockTimeoutError:
+                held.append(True)
+            return real_classify(*args, **kwargs)
+
+        with patch.object(pull_module, "classify_decision", probing_classify):
+            merged, _reporter = pull(
+                collision_store, [("decisions/003-remote.md", decision_bytes(3, "Remote"))]
+            )
+
+        assert merged == 1
+        assert held == [True]
+
+
+class TestManifestPathCasing:
+    """Only one spelling of a decision path is ever written.
+
+    The pull routes every case spelling to the classifier, because a manifest
+    entry spelled ``Decisions/007-x.MD`` names the same local file as
+    ``decisions/007-x.md`` wherever the filesystem folds case, and letting it
+    fall through to the untyped path dropped it silently. But routing is not
+    permission: everything else that enumerates the directory - the corpus
+    scan, ``list_decisions``, the kernel's number allocation - matches
+    lowercase ``decisions/`` and ``.md`` literally, so a file written under any
+    other spelling would be invisible to the allocator that must not reuse its
+    number, and state recorded under it would not match the path the push scan
+    reports. Non-canonical spellings are quarantined, never installed.
+    """
+
+    @pytest.mark.parametrize("remote_path", ["decisions/007-thing.MD", "Decisions/007-thing.md"])
+    def test_non_canonical_paths_aliasing_a_local_file_are_quarantined(
+        self, collision_store, remote_path
+    ):
+        local_body = decision_bytes(7, "Local casing", "Chose A.")
+        local = write_local_decision(collision_store, "007-Thing.md", local_body)
+
+        merged, reporter = pull(
+            collision_store, [(remote_path, decision_bytes(7, "Remote casing", "Chose B."))]
+        )
+
+        assert merged == 0
+        assert local.read_bytes() == local_body
+        assert remote_path.split("/")[1] not in entry_names(collision_store / "decisions")
+        assert "Decisions" not in entry_names(collision_store)
+        assert load_state(collision_store).files == {}
+        assert any("decisions/<name>.md" in warning for warning in reporter.warns)
+
+    def test_a_non_canonical_path_never_reaches_the_disk_or_the_allocator(self, collision_store):
+        """Nothing local claims the number, so the only thing stopping an
+        install is the spelling - and it has to, because a file the allocator
+        cannot see is a number it will hand out again."""
+        before = FilesystemStore(collision_store).list_decisions()
+
+        merged, reporter = pull(
+            collision_store, [("decisions/002-remote.MD", decision_bytes(2, "Remote"))]
+        )
+
+        assert merged == 0
+        assert "002-remote.MD" not in entry_names(collision_store / "decisions")
+        assert load_state(collision_store).files == {}
+        assert any("decisions/<name>.md" in warning for warning in reporter.warns)
+        # The allocator sees exactly what it saw before, so its next mint is
+        # the same number it would have minted without this pull.
+        store = FilesystemStore(collision_store)
+        assert store.list_decisions() == before
+        assert _next_decision_num(store) == 2
+
+    def test_a_non_canonical_directory_does_not_block_its_canonical_neighbours(
+        self, collision_store
+    ):
+        merged, reporter = pull(
+            collision_store,
+            [
+                ("Decisions/031-elsewhere.md", decision_bytes(31, "Elsewhere")),
+                ("decisions/032-canonical.md", decision_bytes(32, "Canonical")),
+            ],
+        )
+
+        assert merged == 1
+        assert "Decisions" not in entry_names(collision_store)
+        assert (collision_store / "decisions/032-canonical.md").exists()
+        assert list(load_state(collision_store).files) == ["decisions/032-canonical.md"]
+        assert len(reporter.warns) == 1
+        assert len(list_quarantine_backups(collision_store)) == 1
+
+
+class TestDecisionBatchSpool:
+    """The gated batch is complete before the lock, but never resident.
+
+    A manifest is server-supplied input; its total size is not something this
+    process may be surprised by. Decision bodies are parked on disk between the
+    fetch and the classification, so the batch costs one file's memory.
+    """
+
+    def _entries(self, count: int) -> list[tuple[str, bytes]]:
+        return [
+            (f"decisions/{n:03d}-remote.md", decision_bytes(n, f"Remote {n}"))
+            for n in range(10, 10 + count)
+        ]
+
+    def _spool_dirs(self, store) -> list[str]:
+        return [name for name in entry_names(store) if name.startswith(SPOOL_DIR_PREFIX)]
+
+    def test_each_body_is_on_disk_before_the_next_is_fetched(self, collision_store):
+        spooled_before_fetch: list[int] = []
+        real_fetch = pull_module.fetch_via_presigned_url
+
+        def counting_fetch(url):
+            spooled = self._spool_dirs(collision_store)
+            spooled_before_fetch.append(
+                len(list((collision_store / spooled[0]).iterdir())) if spooled else 0
+            )
+            return real_fetch(url)
+
+        with patch.object(pull_module, "fetch_via_presigned_url", counting_fetch):
+            merged, _reporter = pull(collision_store, self._entries(3))
+
+        assert merged == 3
+        assert spooled_before_fetch == [0, 1, 2]
+
+    def test_the_spool_is_removed_when_the_run_finishes(self, collision_store):
+        merged, _reporter = pull(collision_store, self._entries(2))
+
+        assert merged == 2
+        assert self._spool_dirs(collision_store) == []
+
+    def test_the_spool_is_removed_when_the_run_fails(self, collision_store):
+        boom = RuntimeError("classification exploded")
+
+        with (
+            patch.object(pull_module, "classify_decision", side_effect=boom),
+            pytest.raises(RuntimeError),
+        ):
+            pull(collision_store, self._entries(2))
+
+        assert self._spool_dirs(collision_store) == []
+
+    def test_a_stray_spool_directory_is_never_synced(self, collision_store):
+        assert should_skip(f"{SPOOL_DIR_PREFIX}abc123/000000") is True
+        assert should_skip(f"{SPOOL_DIR_PREFIX}abc123") is True
+
+
+# Every spelling a manifest could use for something under decisions/, and
+# whether this store is willing to write it. The rejected forms are the point:
+# three of them normalise onto a real local decision, one installs where the
+# allocator cannot see it, and one is stripped to a real path by Windows.
+_SPELLINGS = [
+    ("decisions/240-fine.md", True),
+    ("decisions/sub/240-fine.md", False),
+    ("decisions//240-fine.md", False),
+    ("decisions/./240-fine.md", False),
+    ("decisions/../240-fine.md", False),
+    ("decisions/240-fine.md/", False),
+    ("decisions/240-fine.md.", False),
+    ("decisions/240-fine.MD", False),
+    ("Decisions/240-fine.md", False),
+    ("decisions/notes.txt", False),
+]
+
+
+class TestDecisionPathSpelling:
+    """Only a flat, lowercase ``decisions/<name>.md`` is ever written.
+
+    A suffix test is not enough: ``decisions//x.md``, ``decisions/./x.md`` and
+    ``decisions/x.md/`` all resolve to the same file as ``decisions/x.md``, so
+    accepting them would overwrite a decision without the classifier ever
+    comparing it; ``decisions/sub/x.md`` installs a file the corpus and the
+    kernel's allocator never enumerate but the push scan still uploads; and
+    Windows strips the trailing dot from ``decisions/x.md.`` onto a real name.
+    """
+
+    @staticmethod
+    def _disk(store) -> dict[str, bytes]:
+        """Every store file that is content, not sync plumbing."""
+        return {
+            rel: path.read_bytes()
+            for path in sorted(store.rglob("*"))
+            if path.is_file()
+            and ".conflict-backup" not in path.parts
+            and not should_skip(rel := str(path.relative_to(store)))
+        }
+
+    @pytest.mark.parametrize(("remote_path", "accepted"), _SPELLINGS)
+    def test_only_the_canonical_spelling_is_written(self, collision_store, remote_path, accepted):
+        local_body = decision_bytes(240, "Local", "Chose A.")
+        write_local_decision(collision_store, "240-fine.md", local_body)
+        before = self._disk(collision_store)
+
+        merged, reporter = pull(
+            collision_store, [(remote_path, decision_bytes(240, "Remote", "Chose B."))]
+        )
+
+        if accepted:
+            # The canonical spelling reaches the matrix, which sees an
+            # untracked local file of that name and applies the existing
+            # last-write-wins policy: local kept, remote backed up, state
+            # recorded under the path the store actually enumerates.
+            assert merged == 1
+            assert (collision_store / remote_path).read_bytes() == local_body
+            assert list(load_state(collision_store).files) == [remote_path]
+            return
+        assert merged == 0
+        # Nothing outside the backup drop-box moved: in particular the local
+        # decision the aliasing forms would have overwritten.
+        assert self._disk(collision_store) == before
+        assert (collision_store / "decisions/240-fine.md").read_bytes() == local_body
+        assert load_state(collision_store).files == {}
+
+    def test_a_traversal_spelling_is_refused_before_it_is_even_fetched(self, collision_store):
+        """The manifest guard already drops it, so it never reaches the gate
+        and there is nothing to back up."""
+        merged, reporter = pull(collision_store, [("decisions/../240-fine.md", b"remote body\n")])
+
+        assert merged == 0
+        assert list_quarantine_backups(collision_store) == []
+        assert any("suspicious" in warning for warning in reporter.warns)
+
+    @pytest.mark.parametrize(
+        "remote_path",
+        # The traversal form never gets this far; it has its own test above.
+        [path for path, ok in _SPELLINGS if not ok and ".." not in path],
+    )
+    def test_a_rejected_spelling_is_named_accurately_in_its_backup(
+        self, collision_store, remote_path
+    ):
+        merged, _reporter = pull(collision_store, [(remote_path, b"remote body\n")])
+
+        assert merged == 0
+        backups = list_quarantine_backups(collision_store)
+        # A lossy backup name would have status report a path the server never
+        # held; the separators survive the round trip.
+        assert [item.remote_path for item in backups] == [remote_path]
+        assert backups[0].backup_path.read_bytes() == b"remote body\n"
+        assert unresolved_quarantines(collision_store) == backups
+
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            "240-x:stream.md",  # a colon opens an alternate data stream on NTFS
+            "CON.md",  # a reserved device basename, whatever the extension
+            "con.md",
+            "com1.md",
+            "240-Mixed.md",  # the writer lowercases every name it mints
+            ".md",  # no stem at all
+            "..md",
+        ],
+    )
+    def test_a_filename_the_writer_could_not_have_minted_is_refused(
+        self, collision_store, filename
+    ):
+        """The filename rule is an allowlist, not a denylist of the characters
+        that have bitten other tools: that set is not knowable in advance, and
+        the set this store's own writer emits is."""
+        before = self._disk(collision_store)
+
+        merged, reporter = pull(collision_store, [(f"decisions/{filename}", b"remote\n")])
+
+        assert merged == 0
+        assert self._disk(collision_store) == before
+        assert any("decisions/<name>.md" in warning for warning in reporter.warns)
+
+    @pytest.mark.parametrize(
+        "filename", ["240-fine.md", "001-initial-setup.md", "240-caf\u00e9-choice.md", "240-a_b.md"]
+    )
+    def test_names_the_writer_does_mint_are_admitted(self, collision_store, filename):
+        """Including a slug in another script: the writer keeps alphanumerics
+        whatever their alphabet, so refusing them would quarantine decisions
+        Nauro itself wrote."""
+        merged, reporter = pull(
+            collision_store, [(f"decisions/{filename}", decision_bytes(240, "Remote"))]
+        )
+
+        assert merged == 1
+        assert filename in entry_names(collision_store / "decisions")
+        assert reporter.warns == []
+
+
+class TestTrackedNonCanonicalPaths:
+    """A state entry is not a licence to skip the gate."""
+
+    def test_a_tracked_non_canonical_path_is_quarantined_on_change(self, collision_store):
+        legacy = "decisions/002-old.MD"
+        local = write_local_decision(collision_store, "002-old.MD", b"legacy local\n")
+        state = SyncState()
+        state.files[legacy] = FileState(
+            local_sha256=compute_sha256(local),
+            remote_etag='"old"',
+            last_sync="2026-08-10T00:00:00Z",
+        )
+        save_state(collision_store, state)
+
+        merged, reporter = pull(
+            collision_store, [(legacy, b"new remote body\n")], etags={legacy: '"changed"'}
+        )
+
+        assert merged == 0
+        assert local.read_bytes() == b"legacy local\n"
+        # The stale entry is left exactly as it was: not refreshed, not removed.
+        assert load_state(collision_store).files[legacy].remote_etag == '"old"'
+        assert any("decisions/<name>.md" in warning for warning in reporter.warns)
+
+    def test_the_stale_entry_does_not_mark_the_quarantine_resolved(self, collision_store):
+        """Resolution keys on a canonical path, because only a canonical path
+        can ever be installed. The legacy entry is the stale record the
+        quarantine exists to surface, so it cannot clear its own warning."""
+        legacy = "decisions/002-old.MD"
+        write_local_decision(collision_store, "002-old.MD", b"legacy local\n")
+        state = SyncState()
+        state.files[legacy] = FileState(local_sha256="stale", remote_etag='"old"')
+        save_state(collision_store, state)
+
+        pull(collision_store, [(legacy, b"new remote body\n")], etags={legacy: '"changed"'})
+
+        unresolved = unresolved_quarantines(collision_store)
+        assert [item.remote_path for item in unresolved] == [legacy]
+
+
+class TestWriteBarrier:
+    """The guard is where the bytes land, not where the manifest spelled it.
+
+    A spelling predicate can only refuse what it was taught to recognise, and
+    the ways a path can name a decision without looking like one are open
+    ended: ``./decisions/x.md`` normalises into the directory, a backslash key
+    is a separator on Windows and the push scan emits them there, a symlink
+    points wherever it points. Resolving the destination answers the question
+    the predicate was only approximating.
+    """
+
+    @staticmethod
+    def _content(store) -> dict[str, bytes]:
+        return {
+            rel: path.read_bytes()
+            for path in sorted(store.rglob("*"))
+            if path.is_file()
+            and ".conflict-backup" not in path.parts
+            and not should_skip(rel := str(path.relative_to(store)))
+        }
+
+    @pytest.mark.parametrize(
+        "remote_path",
+        ["./decisions/240-local.md", ".//decisions/240-local.md", "decisions\\240-local.md"],
+    )
+    def test_a_path_that_resolves_into_decisions_never_writes_generically(
+        self, collision_store, remote_path
+    ):
+        local_body = decision_bytes(240, "Local", "Chose A.")
+        write_local_decision(collision_store, "240-local.md", local_body)
+        before = self._content(collision_store)
+
+        merged, reporter = pull(
+            collision_store, [(remote_path, decision_bytes(240, "Remote", "Chose B."))]
+        )
+
+        assert merged == 0
+        assert self._content(collision_store) == before
+        assert (collision_store / "decisions/240-local.md").read_bytes() == local_body
+        assert load_state(collision_store).files == {}
+        # Quarantined under the spelling the server actually used.
+        assert [item.remote_path for item in list_quarantine_backups(collision_store)] == [
+            remote_path
+        ]
+
+    def test_a_destination_outside_the_store_is_refused(self, collision_store):
+        # A symlink is the shape that survives the manifest guard: the path has
+        # no dot segments, so only resolving it reveals where it points.
+        outside = collision_store.parent / "outside"
+        outside.mkdir()
+        (outside / "victim.md").write_bytes(b"untouched\n")
+        (collision_store / "escape").symlink_to(outside)
+
+        merged, reporter = pull(collision_store, [("escape/victim.md", b"overwritten\n")])
+
+        assert merged == 0
+        assert (outside / "victim.md").read_bytes() == b"untouched\n"
+        assert any("outside the store" in warning for warning in reporter.warns)
+
+    def test_ordinary_files_are_unaffected(self, collision_store):
+        merged, reporter = pull(
+            collision_store,
+            [("snapshots/v001.json", b'{"v": 1}'), ("context/brief.md", b"# Brief\n")],
+        )
+
+        assert merged == 2
+        assert (collision_store / "snapshots/v001.json").read_bytes() == b'{"v": 1}'
+        assert (collision_store / "context/brief.md").read_bytes() == b"# Brief\n"
+        assert reporter.warns == []
+
+    @pytest.mark.parametrize(
+        "rel",
+        ["./decisions/x.md", ".//decisions/x.md", "decisions\\x.md", "decisions/x.md"],
+    )
+    def test_the_barrier_itself_refuses_every_decision_destination(self, collision_store, rel):
+        """The barrier is asserted directly, not through a contrived planner:
+        it is the last check before bytes land and has to hold on its own."""
+        allowed = pull_module._generic_write_allowed(
+            collision_store, _Transfer(rel=rel, etag='"e"', _body=b""), _RecordingReporter()
+        )
+
+        assert allowed is False
+
+    def test_the_barrier_admits_an_ordinary_store_path(self, collision_store):
+        allowed = pull_module._generic_write_allowed(
+            collision_store,
+            _Transfer(rel="snapshots/v001.json", etag='"e"', _body=b""),
+            _RecordingReporter(),
+        )
+
+        assert allowed is True
+
+
+class TestBackupIdentity:
+    def test_two_spellings_of_one_path_keep_separate_backups(self, collision_store):
+        """On a case-folding filesystem a name derived from the path alone
+        collapses, so one quarantine would overwrite the other's evidence and
+        installing the canonical file would appear to resolve both."""
+        etag = '"same-version"'
+        # A published local file holding the number, so the canonical spelling
+        # quarantines too and both copies are kept at the same remote version.
+        write_local_decision(collision_store, "007-local.md", decision_bytes(7, "Local"))
+        track(collision_store, "decisions/007-local.md")
+        spellings = ["decisions/007-remote.md", "Decisions/007-Remote.MD"]
+
+        merged, _reporter = pull(
+            collision_store,
+            [(path, decision_bytes(7, "Remote")) for path in spellings],
+            etags=dict.fromkeys(spellings, etag),
+        )
+
+        assert merged == 0
+        backups = list_quarantine_backups(collision_store)
+        names = {item.backup_path.name for item in backups}
+        assert len(names) == 2
+        # Distinct without relying on the host filesystem's case behaviour.
+        assert len({name.lower() for name in names}) == 2
+        assert {item.remote_path for item in backups} == set(spellings)
+
+    def test_installing_the_canonical_file_clears_only_its_own_quarantine(self, collision_store):
+        state = SyncState()
+        state.files["decisions/007-remote.md"] = FileState(
+            local_sha256="abc", remote_etag='"installed"'
+        )
+        save_state(collision_store, state)
+        save_quarantine_backup(collision_store, "decisions/007-remote.md", b"one\n", '"a"')
+        save_quarantine_backup(collision_store, "Decisions/007-Remote.MD", b"two\n", '"a"')
+
+        unresolved = unresolved_quarantines(collision_store)
+
+        assert [item.remote_path for item in unresolved] == ["Decisions/007-Remote.MD"]
+
+
+class TestDirectoryDestinations:
+    """A manifest entry naming a directory is not a file, however it is spelled.
+
+    ``decisions`` is the one that matters: written as an ordinary file it
+    either crashes the local-change probe on a directory hash or, on a store
+    that has none yet, creates a regular file under the name every future
+    decision write needs.
+    """
+
+    @pytest.mark.parametrize("remote_path", ["decisions", "decisions/"])
+    @pytest.mark.parametrize("directory_exists", [True, False])
+    def test_the_decisions_directory_is_never_written_as_a_file(
+        self, collision_store, remote_path, directory_exists
+    ):
+        decisions = collision_store / "decisions"
+        if not directory_exists:
+            for child in decisions.iterdir():
+                child.unlink()
+            decisions.rmdir()
+
+        merged, reporter = pull(collision_store, [(remote_path, b"not a directory\n")])
+
+        assert merged == 0
+        assert reporter.warns
+        # Whether it was there to begin with or the decision lock recreated it,
+        # the name is a directory and never a regular file: a file there would
+        # block every future decision write.
+        assert not decisions.is_file()
+        assert decisions.is_dir() or not decisions.exists()
+
+    def test_another_directory_destination_is_skipped_not_hashed(self, collision_store):
+        (collision_store / "snapshots").mkdir(exist_ok=True)
+
+        merged, reporter = pull(collision_store, [("snapshots", b"not a directory\n")])
+
+        assert merged == 0
+        assert (collision_store / "snapshots").is_dir()
+        assert any("directory" in warning for warning in reporter.warns)

--- a/packages/nauro/tests/test_sync/test_state.py
+++ b/packages/nauro/tests/test_sync/test_state.py
@@ -1,5 +1,7 @@
 """Tests for nauro.sync.state."""
 
+import json
+
 import pytest
 
 from nauro.sync.state import (
@@ -49,6 +51,42 @@ class TestLoadSaveState:
         (project_dir / ".sync-state.json").write_text("not json{{{")
         state = load_state(project_dir)
         assert state.files == {}
+
+    def test_save_leaves_no_temporary_siblings(self, project_dir):
+        state = SyncState(last_full_sync="2026-08-10T10:00:00Z")
+        state.files["project.md"] = FileState(local_sha256="abc123")
+        save_state(project_dir, state)
+
+        assert [path.name for path in project_dir.iterdir()] == [".sync-state.json"]
+
+    def test_save_replaces_the_previous_file_wholesale(self, project_dir):
+        first = SyncState()
+        first.files["a.md"] = FileState(local_sha256="a")
+        save_state(project_dir, first)
+
+        second = SyncState()
+        second.files["b.md"] = FileState(local_sha256="b")
+        save_state(project_dir, second)
+
+        assert set(load_state(project_dir).files) == {"b.md"}
+
+    def test_written_state_still_reads_under_the_three_field_loader(self, project_dir):
+        """Mixed versions: an older binary reads what this one writes."""
+        state = SyncState(last_full_sync="2026-08-10T10:00:00Z")
+        state.files["decisions/003-remote.md"] = FileState(
+            local_sha256="abc123",
+            remote_etag='"etag"',
+            last_sync="2026-08-10T09:00:00Z",
+        )
+        save_state(project_dir, state)
+
+        data = json.loads((project_dir / ".sync-state.json").read_text())
+        assert data["last_full_sync"] == "2026-08-10T10:00:00Z"
+        assert data["files"]["decisions/003-remote.md"] == {
+            "local_sha256": "abc123",
+            "remote_etag": '"etag"',
+            "last_sync": "2026-08-10T09:00:00Z",
+        }
 
 
 class TestChangeDetection:

--- a/packages/nauro/tests/test_sync/test_sync_lock.py
+++ b/packages/nauro/tests/test_sync/test_sync_lock.py
@@ -1,0 +1,198 @@
+"""Tests for the store-scoped sync lock.
+
+The lock serializes pull and push per store with finite timeouts. The two
+callers differ in what contention means: an explicit ``nauro sync`` fails loud,
+the SessionStart hook skips its pull and logs, because session start must never
+wait on another process.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import patch
+
+import pytest
+from filelock import FileLock
+from typer.testing import CliRunner
+
+from nauro.cli.main import app
+from nauro.store.store_lock import rmw_lock_path
+from nauro.sync.hooks import pull_before_session, push_after_write
+from nauro.sync.lock import (
+    SYNC_LOCK_FILE,
+    SyncLockTimeoutError,
+    decision_lock,
+    sync_lock,
+)
+from nauro.sync.merge import should_skip
+from nauro.sync.pull import run_pull
+from nauro.sync.push import push_changed_files
+from tests.test_sync.conftest import CLOUD_PID, _scaffolded_cloud_project
+from tests.test_sync.test_pull import _ok, _RecordingReporter, _seed_token
+
+runner = CliRunner()
+
+
+@pytest.fixture()
+def cloud_store(tmp_path):
+    store = _scaffolded_cloud_project("lockproj", tmp_path, project_id=CLOUD_PID)
+    _seed_token()
+    return store
+
+
+def _hold(store):
+    """Acquire the store's sync lock the way another process would."""
+    lock = FileLock(str(store / SYNC_LOCK_FILE))
+    lock.acquire()
+    return lock
+
+
+class TestLockFile:
+    def test_lock_artifact_is_never_synced(self):
+        assert should_skip(SYNC_LOCK_FILE) is True
+
+    def test_uncontended_acquisition_runs_the_block(self, cloud_store):
+        with sync_lock(cloud_store, 0.1):
+            assert (cloud_store / SYNC_LOCK_FILE).exists()
+
+    def test_contended_acquisition_raises_with_the_store_named(self, cloud_store):
+        lock = _hold(cloud_store)
+        try:
+            with pytest.raises(SyncLockTimeoutError) as excinfo:
+                with sync_lock(cloud_store, 0.05):
+                    pytest.fail("the lock should not have been granted")
+        finally:
+            lock.release()
+        assert cloud_store.name in str(excinfo.value)
+
+    def test_lock_is_released_when_the_block_raises(self, cloud_store):
+        with pytest.raises(RuntimeError):
+            with sync_lock(cloud_store, 0.1):
+                raise RuntimeError("boom")
+        with sync_lock(cloud_store, 0.1):
+            pass
+
+
+class TestContendedCallers:
+    def test_run_pull_raises_before_touching_the_network(self, cloud_store):
+        lock = _hold(cloud_store)
+        try:
+            with patch("nauro.sync.remote.httpx.get") as get:
+                with pytest.raises(SyncLockTimeoutError):
+                    run_pull(CLOUD_PID, cloud_store, _RecordingReporter(), lock_timeout=0.05)
+            assert get.call_count == 0
+        finally:
+            lock.release()
+
+    def test_push_changed_files_raises(self, cloud_store):
+        lock = _hold(cloud_store)
+        try:
+            with pytest.raises(SyncLockTimeoutError):
+                push_changed_files(CLOUD_PID, cloud_store, lock_timeout=0.05)
+        finally:
+            lock.release()
+
+    def test_session_start_hook_skips_and_logs(self, cloud_store, caplog):
+        lock = _hold(cloud_store)
+        try:
+            with caplog.at_level(logging.INFO, logger="nauro.sync"):
+                pulled = pull_before_session(CLOUD_PID, cloud_store)
+        finally:
+            lock.release()
+        assert pulled == 0
+        assert any("skipped" in record.getMessage() for record in caplog.records)
+
+    def test_post_write_push_hook_skips_and_logs(self, cloud_store, caplog):
+        lock = _hold(cloud_store)
+        try:
+            with caplog.at_level(logging.INFO, logger="nauro.sync"):
+                pushed = push_after_write(CLOUD_PID, cloud_store)
+        finally:
+            lock.release()
+        assert pushed == 0
+        assert any("skipped" in record.getMessage() for record in caplog.records)
+
+    def test_cli_sync_fails_loud(self, cloud_store, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        # Same lock, same error, without spending the CLI's real bounded wait.
+        monkeypatch.setattr(
+            "nauro.sync.pull.sync_lock", lambda store_path, _timeout: sync_lock(store_path, 0.05)
+        )
+        lock = _hold(cloud_store)
+        try:
+            result = runner.invoke(app, ["sync"])
+        finally:
+            lock.release()
+        assert result.exit_code == 1, result.output
+        assert "another writer is busy" in result.output
+
+
+class TestBoundedDecisionLock:
+    """The store lock is not the only lock a pull takes.
+
+    The write phase also takes the decision allocation lock, whose kernel-side
+    acquisition waits forever by design. A sync must never inherit that wait:
+    once the store lock is in hand, a suspended local writer would otherwise
+    hold session start open indefinitely.
+    """
+
+    def _hold_decisions(self, store):
+        lock = FileLock(str(rmw_lock_path(store, "decisions", is_directory=True)))
+        lock.acquire()
+        return lock
+
+    def test_sync_decision_lock_is_bounded(self, cloud_store):
+        lock = self._hold_decisions(cloud_store)
+        try:
+            with pytest.raises(SyncLockTimeoutError) as excinfo:
+                with decision_lock(cloud_store, 0.05):
+                    pytest.fail("the lock should not have been granted")
+        finally:
+            lock.release()
+        assert "decisions" in str(excinfo.value)
+
+    def test_kernel_writers_keep_their_unbounded_wait(self):
+        """The bounded acquisition is the sync layer's own policy; the kernel
+        path must not have been narrowed with it."""
+        import inspect
+
+        from nauro.store import store_lock
+
+        source = inspect.getsource(store_lock.store_write_lock)
+        assert "timeout" not in source
+
+    def test_session_start_hook_skips_when_a_decision_writer_holds_the_lock(
+        self, cloud_store, caplog
+    ):
+        manifest = _ok(200, {"files": [], "next_cursor": None})
+        lock = self._hold_decisions(cloud_store)
+        try:
+            with (
+                patch("nauro.sync.remote.httpx.get", return_value=manifest),
+                caplog.at_level(logging.INFO, logger="nauro.sync"),
+            ):
+                pulled = pull_before_session(CLOUD_PID, cloud_store)
+        finally:
+            lock.release()
+
+        assert pulled == 0
+        assert any("skipped" in record.getMessage() for record in caplog.records)
+
+    def test_cli_sync_fails_loud_when_a_decision_writer_holds_the_lock(
+        self, cloud_store, tmp_path, monkeypatch
+    ):
+        manifest = _ok(200, {"files": [], "next_cursor": None})
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(
+            "nauro.sync.pull.decision_lock",
+            lambda store_path, _timeout: decision_lock(store_path, 0.05),
+        )
+        lock = self._hold_decisions(cloud_store)
+        try:
+            with patch("nauro.sync.remote.httpx.get", return_value=manifest):
+                result = runner.invoke(app, ["sync"])
+        finally:
+            lock.release()
+
+        assert result.exit_code == 1, result.output
+        assert "decisions lock" in result.output

--- a/packages/nauro/tests/test_sync/test_sync_lock.py
+++ b/packages/nauro/tests/test_sync/test_sync_lock.py
@@ -27,8 +27,13 @@ from nauro.sync.lock import (
 from nauro.sync.merge import should_skip
 from nauro.sync.pull import run_pull
 from nauro.sync.push import push_changed_files
-from tests.test_sync.conftest import CLOUD_PID, _scaffolded_cloud_project
-from tests.test_sync.test_pull import _ok, _RecordingReporter, _seed_token
+from tests.test_sync.conftest import (
+    CLOUD_PID,
+    _ok,
+    _RecordingReporter,
+    _scaffolded_cloud_project,
+    _seed_token,
+)
 
 runner = CliRunner()
 

--- a/packages/nauro/tests/test_sync/test_sync_presign.py
+++ b/packages/nauro/tests/test_sync/test_sync_presign.py
@@ -471,7 +471,7 @@ class TestPushViaPresign:
     def test_stamped_decision_pushed_byte_identical(self, cloud_store):
         """A decision carrying the base_commit stamp uploads verbatim; the
         push path never rewrites decision bytes."""
-        from tests.test_sync.test_pull import _STAMPED_DECISION
+        from tests.test_sync.conftest import _STAMPED_DECISION
 
         self._seed_synced_state(cloud_store)
         rel = "decisions/099-remote-stamped.md"
@@ -638,3 +638,55 @@ class TestPushViaPresign:
         refresh_calls = [c for c in mock_post.call_args_list if "/oauth/token" in c.args[0]]
         assert len(presign_calls) == 2
         assert len(refresh_calls) == 1
+
+
+class TestPresignResponseTyping:
+    """Both transfer directions read the presign response through one model.
+
+    Typing one remote response and dict-walking the other is how the two drift;
+    a malformed row is skipped and reported either way, which is the lenient
+    behaviour both directions already had.
+    """
+
+    def test_well_formed_entries_are_indexed_by_path(self):
+        from nauro.sync.remote import urls_by_path
+
+        usable, skipped = urls_by_path(
+            [
+                {"verb": "GET", "path": "a.md", "url": "https://s3/a", "expires_at": "x"},
+                {"verb": "PUT", "path": "b.md", "url": "https://s3/b"},
+            ],
+            "GET",
+        )
+
+        assert usable == {"a.md": "https://s3/a"}
+        assert skipped == ()
+
+    @pytest.mark.parametrize(
+        "entry",
+        [
+            "not a mapping",
+            {"verb": "GET", "path": "a.md"},
+            {"verb": "GET", "url": "https://s3/a"},
+            {"path": "a.md", "url": "https://s3/a"},
+            None,
+        ],
+    )
+    def test_a_malformed_entry_is_skipped_and_named(self, entry):
+        from nauro.sync.remote import urls_by_path
+
+        usable, skipped = urls_by_path([entry], "GET")
+
+        assert usable == {}
+        assert len(skipped) == 1
+
+    def test_a_malformed_entry_does_not_lose_its_neighbours(self):
+        from nauro.sync.remote import urls_by_path
+
+        usable, skipped = urls_by_path(
+            [{"verb": "GET", "path": "a.md"}, {"verb": "GET", "path": "b.md", "url": "u"}],
+            "GET",
+        )
+
+        assert usable == {"b.md": "u"}
+        assert len(skipped) == 1

--- a/packages/nauro/tests/test_sync/test_sync_status.py
+++ b/packages/nauro/tests/test_sync/test_sync_status.py
@@ -133,3 +133,55 @@ class TestLastSyncTime:
         result = runner.invoke(app, ["sync", "--status"])
         assert result.exit_code == 0, result.output
         assert "Last successful sync: never" in result.output
+
+
+class TestQuarantinedCollisions:
+    def test_status_names_each_unresolved_collision(self, tmp_path, monkeypatch):
+        from nauro.sync.quarantine import save_quarantine_backup
+
+        store = _scaffold(repo=tmp_path)
+        save_config(
+            {
+                "auth": {
+                    "sub": "auth0|test",
+                    "access_token": "tok_orig",
+                    "refresh_token": "refresh_orig",
+                }
+            }
+        )
+        monkeypatch.chdir(tmp_path)
+        save_quarantine_backup(store, "decisions/003-remote.md", b"remote body\n", '"etag"')
+
+        result = runner.invoke(app, ["sync", "--status"])
+        assert result.exit_code == 0, result.output
+        assert "Quarantined decision-number collisions: 1" in result.output
+        assert "decisions/003-remote.md" in result.output
+
+    def test_quarantine_backups_are_not_counted_twice(self, tmp_path, monkeypatch):
+        """The quarantine copy lives in the conflict-backup directory, so the
+        generic total must exclude what the line above already named."""
+        from nauro.sync.merge import write_backup
+        from nauro.sync.quarantine import save_quarantine_backup
+
+        store = _scaffold(repo=tmp_path)
+        save_config(
+            {
+                "auth": {
+                    "sub": "auth0|test",
+                    "access_token": "tok_orig",
+                    "refresh_token": "refresh_orig",
+                }
+            }
+        )
+        monkeypatch.chdir(tmp_path)
+        save_quarantine_backup(store, "decisions/003-remote.md", b"remote body\n", '"etag"')
+
+        result = runner.invoke(app, ["sync", "--status"])
+        assert result.exit_code == 0, result.output
+        assert "Quarantined decision-number collisions: 1" in result.output
+        assert "Conflict backups" not in result.output
+
+        write_backup(store, "20260810T000000Z-project.md", b"losing side\n")
+        result = runner.invoke(app, ["sync", "--status"])
+        assert result.exit_code == 0, result.output
+        assert "Conflict backups: 1" in result.output


### PR DESCRIPTION
## Why

A sync pull minted a decision byte-identical to one already in the store. Both
collision branches of the pull core keyed sync state under the *renamed local*
path, so the remote key never entered sync state: every pull re-fetched,
re-collided, and minted another duplicate, while the renamed file's sha-matched
entry blocked its own push forever.

Review found the deeper defect underneath the bug. Renumbering the incoming
remote file moves the wrong side. The remote number is shared state other
machines already reference; a never-published local number is the cheapest
thing in the system to change. Every repair built on aliasing the renamed file
fails structurally - kernel mutations cannot see the alias, snapshots leak it,
and older binaries drop it at load and upload the file anyway.

This implements the collision-classification rule ratified for pull-time number
collisions, which supersedes renumber-the-incoming.

## What changed

**A pull now has two phases.** It plans and fetches under the store's sync
lock, then writes. The untracked decision files - the ones a verdict governs -
are written under the decision lock as well, each classified immediately before
its own write. Everything else streams: fetched and written one file at a time,
outside that lock. A first pull of a real store is hundreds of megabytes of
snapshots, and neither memory nor a local `propose_decision` should pay for
that. The gated batch does have to be complete before the lock is taken, since
the lock must not span a transfer, so it is spooled to a scratch directory in
the store and read back at classification time: a manifest is server-supplied
input, and its total size is not a number this process gets to be surprised by.
The scratch directory is removed on the way out, including on failure, and its
name carries a prefix the sync skip list excludes so a directory orphaned by a
kill signal is never pushed or pulled.

**The gate is at the write, not at the plan.** Every decision file the store
does not already track goes through the classifier against a corpus the writer
keeps current. That distinction is load-bearing: two remote files can claim one
number, and a local writer can mint one between the plan and the write, so a
verdict taken while planning is not a verdict at all.

**The matrix.** With the fetched bytes in hand, a local file claiming the
number is:

- **quarantined** if sync state tracks it or its path is in the current
  manifest. Both mean published or possibly published - a push that uploaded
  and crashed before saving state leaves exactly that shape, which is why
  absence of a state entry alone is not proof.
- **renamed onto the remote name** if it is byte-identical and unpublished:
  one record under two names.
- **renumbered** if it is unpublished, isolated, and its heading is in the
  canonical form the rewriter addresses. Isolated means it parses, takes part
  in no supersession in either direction, is named by no question resolution,
  and sits in a store where every other record could be read to establish that.
- **quarantined** in every other case. The local file is untouched, the remote
  bytes go to `.conflict-backup/` under a name keyed by remote version so
  repeated SessionStart pulls leave one backup, no state is recorded so the
  warning re-fires each pull, and the guidance splits by who can resolve it:
  rename or remove the local file, or, when both sides are published, the
  owner-only route through the app, because this transport cannot rename or
  delete a remote object.

There is no multi-file reference rewrite: anything referenced quarantines,
which excludes silent rebinding by construction.

**The same-path leg** is part of the same gate. A decision file sitting at its
exact manifest path with no state entry is adopted on identical bytes and falls
back to the existing last-write-wins-with-backup on different bytes - but only
once nothing else claims its number. A sibling holding the same number is
renumbered out of the way first where the matrix allows it, and otherwise
blocks the adoption entirely: recording state would ratify one of two
same-numbered records, and the duplicate would then push.

**Admission is decided where the bytes land.** A manifest path can name a
decision without looking like one, and the ways it can do that are open ended:
`./decisions/x.md` normalises into the directory, a backslash key is a
separator on Windows and the push scan emits them there, a symlink points
wherever it points. So before any untyped write, the destination is resolved
through symlinks and checked for containment - outside the store is refused,
inside the decisions directory by any spelling (including the bare directory
itself) is handed to the gate instead of written. The spelling predicates
remain as a cheap first pass, but the resolution is the guard, at the effect
site rather than at the description.

What may then be written is one flat, lowercase `decisions/<name>.md`, parsed
structurally: exactly two components, the first literally `decisions`, and a
filename the store's own writer could have minted. That last rule is an
allowlist rather than a denylist, because the characters that bite other tools
are not knowable in advance while the writer's output is - a colon opens an
alternate data stream on NTFS, a reserved basename resolves to a device, and
neither is something `_slugify` can produce. Alphanumerics stay Unicode-aware
for the same reason: a title in another script slugifies to that script, and
refusing it would quarantine a decision Nauro itself wrote.

The spelling check runs before the tracked-state check, so a legacy entry
recorded under a spelling this store cannot enumerate does not buy the file a
pass around the gate; because only a canonical path can ever be installed, such
a quarantine is never marked resolved by that same stale entry.

Quarantine backups carry a digest of the exact remote path alongside the
version digest, so two spellings of one path keep separate evidence on a
case-folding filesystem. The path itself is encoded onto an allowlist of
filename-safe characters - everything else percent-encoded by byte, which
covers a backslash separator, a colon opening an alternate data stream, a
trailing dot Windows strips, and any non-ASCII normalisation in one rule
rather than a list of remembered hazards - and capped so the filename stays
well inside every filesystem's limit. Identity therefore rides the digests:
resolution matches on the path digest, and a capped display path is shown as
capped rather than passed off as complete.

**One definition of a rewritable heading.** The decision parser accepts an
unpadded `# 42` or over-padded `# 0042` heading; the rewriter only addresses the
canonical zero-padded form the writer emits. `sync/headings.py` owns both
questions, so the gate and the write cannot drift.

**Crash windows.** The renumber writes rename, then heading rewrite, then hash
index, then install, then state save - and the heading rewrite is computed and
verified before the rename, so only a file that will certainly come out
consistent enters the sequence. A refusal names its own cause: a taken
destination name is not reported as a heading problem. An idempotent completion
pass at the start of every pull that reaches the write phase realigns a heading
that disagrees with its filename (filename is identity) when the file is
isolated and no other entry claims that number, and retargets hash-index entries
orphaned by a completed rename. The same-path leg picks up an installed file
whose state save was lost. Between them, no window can re-collide and mint.

**Nothing irregular is read, followed, or modified.** A directory or symlink
named like a decision used to crash the corpus scan on every pull. It is now
listed, never opened, and counted as a claim on its number - holding back both a
remote decision that would land there and a heading repair that would settle the
ambiguity - and reported. Parse failures, including the `TypeError` a reserved
frontmatter key such as `num:` raises, resolve to a quarantine rather than an
aborted sync.

**Locks.** `sync/lock.py` serializes pull and push per store, and the decision
write phase additionally takes the decision allocation lock. Both acquisitions
are finite and follow the caller's policy: the CLI fails loud after a bounded
wait, the SessionStart hook and the post-write push skip and log rather than
delaying session start. The kernel's own unbounded acquire is untouched - a
suspended local writer must not be able to hold session start open once the
store lock is already in hand. Lock order is one-way (store lock outer,
decisions inner), and the lock file ends in `.json.lock`, which the existing
skip list already excludes from sync.

**Cost.** A verdict per write, each against the live store, naively means a full
rescan and reparse per verdict - hundreds of thousands of parses on a large
store. `sync/corpus.py` keeps the guarantee and drops the cost: two directory
scans per pull with no file reads, heading numbers read by scanning only as far
as the H1, each file parsed at most once, and mutations recorded rather than
rescanned. A pull with nothing to heal reads no decision body at all. Both
invariants are pinned by tests.

**Surfacing.** A quarantine records no state, so the pull warning would scroll
away with the session. `nauro sync --status` and `nauro status` both name
unresolved collisions; a quarantine stops being reported once the canonical
remote path it names is installed; a listing failure is reported as unreadable
rather than as none, so a corrupt state file cannot hide the collisions the line
exists to surface; and the quarantine copy is excluded from the generic
conflict-backup total so one event is not counted twice.

**Atomic state save.** `save_state` writes through a tmp sibling and
`os.replace`. Same serialized shape, so an older binary reads it unchanged.

## Test plan

`uv run --no-sync pytest packages/nauro/tests/ -q` (2452 passed, 10 skipped),
`uv run --no-sync pytest packages/nauro-core/tests/ -q` (1475 passed),
`uv run ruff check packages/`, `uv run ruff format --check packages/`.

New coverage, by the property it pins:

- **The matrix**: every cell, including the tracked-collider and
  manifest-present (push-crash) quarantines, referenced colliders via supersede
  lineage and via a question resolution, and the ambiguous, unparseable,
  unrewritable-heading, irregular-entry and case-variant quarantines.
- **The gate is at the write**: two remote files claiming one number on a fresh
  store, in both orders; a number minted between the plan and the write.
- **The same-path leg**: identical adopt, differing last-write-wins, a sibling
  renumbered before adopting, and an unresolvable sibling blocking it.
- **The write barrier**: `./decisions/x.md`, `.//decisions/x.md` and a
  backslash key each leave every content file byte-identical and quarantine
  under their original spelling; a manifest entry naming the bare `decisions`
  directory quarantines with the directory present or absent; a symlinked
  destination outside the store is refused; ordinary store paths are
  unaffected; and the barrier function itself is asserted directly, since it
  is the last check before bytes land.
- **Spelling and filename**, property-style over the adversarial set
  (`decisions/sub/x.md`, `//`, `./`, `../`, trailing `/`, trailing `.`, `.MD`,
  `Decisions/`, `notes.txt`): every rejected form leaves each content file
  byte-identical - explicitly including the local decision the aliasing forms
  resolve onto - records no state, and names its path exactly in its backup.
  Plus the filename allowlist: a colon stream, `CON.md`/`con.md`/`com1.md`,
  the superscript-digit device aliases, a mixed-case name, `.md` and `..md`
  all refused - with the explicit reserved set pinned against the platform
  rule - while `001-initial-setup.md`, a slug in another script, and an
  underscore name are admitted. Assertions read the directory listing, since
  `Path.exists()` folds case on the platforms this guards.
- **Backup identity**: two spellings of one path at one ETag keep distinct
  physical backups, asserted on the filenames rather than by probing the
  filesystem; a backslash path writes a flat, valid backup; a maximum-length
  canonical name stays inside the filename component limit and its quarantine
  persists and resolves; installing the canonical path clears only its own
  quarantine.
- **Transfer shape**: non-decision files written before the next is fetched, the
  decision lock free during those writes and held during a classification, each
  decision body on disk before the next is fetched, and the spool removed after
  a successful run and after a failure.
- **Crash windows**: the full renumber sequence and each internal window
  recovering with zero mints; canonicalize and its crash before the state save;
  unpadded and over-padded headings refused with nothing on disk mutated; a
  taken destination name refused under its own reason; completion-pass
  idempotency for every shape it declines to repair.
- **Never crash a sync**: a directory, a broken symlink, a symlinked number and
  a reserved frontmatter key each reported rather than raising; a directory and
  a symlink each stopping a heading repair, with an irregular entry on another
  number as the control that still repairs.
- **Cost**: no decision file parsed twice in one pull; exactly two directory
  scans; no bodies read when there is nothing to heal.
- **Locks**: contention on both locks for every caller, including the
  post-promotion push in `link --cloud`, and the kernel's unbounded acquire left
  intact.
- **Surfacing**: quarantine listing, resolution, double-count and unreadable
  degradation on both status commands; mixed-version state readability.
- **A decision's second sync**: a plain remote update to a tracked decision
  lands and updates state; a two-sided change keeps local and backs up the
  remote per the existing policy; the barrier admits the update while still
  refusing a nested or untracked path. One predicate answers for both the
  planner and the barrier, so the exemption cannot exist in one and not the
  other.
- **A local name the store's readers cannot see** still claims its number, so a
  remote decision cannot land beside it.
- **The heading forms stay bound**: the rewriter's strict form is a subset of
  the kernel's parse, a rewrite never makes a readable decision unreadable, and
  the one deliberate divergence is recorded.
- **The presign response** is parsed through one typed model in both transfer
  directions; malformed rows are skipped and named without losing their
  neighbours.

## Risk / what to review

The pinned renumber-the-incoming regression test asserted the superseded
mechanism and is replaced by the matrix tests; that flip is part of the ratified
change. Everything else in the existing pull, merge, and hook suites passes
unchanged.

Worth a close look:

- **The filename allowlist admits non-ASCII alphanumerics**, matching the
  writer rather than an ASCII class. `_slugify` keeps `isalnum()` on a
  lowercased title, so a title in another script produces a slug in that
  script; an ASCII-only rule would quarantine decisions Nauro wrote. It does
  reject uppercase, since no writer in this codebase mints one.
- **A non-`.md` file under `decisions/` now quarantines instead of syncing.**
  Routing had to widen to every entry under that directory to catch spellings
  that alias a decision without ending in `.md`, and the strict write rule then
  applies to all of them. It fails safe - the remote copy is kept and nothing
  local is touched - but it is narrower than main.
- **A case-only name difference quarantines rather than canonicalizing.** The
  matrix would allow renaming a byte-identical local file onto the server's
  spelling, which would resolve the divergence without human action. This takes
  the narrower option deliberately, because a case-only rename is not uniformly
  supported and a failure would land mid-mutation.
- **A legacy state entry at a non-canonical path is never refreshed and never
  clears its own quarantine.** Resolution keys on canonical paths only, since
  only a canonical path can be installed. Such a store keeps warning until the
  server-side path is fixed and the backup removed.
- **Local-change detection for tracked files is still computed at triage**, and
  the window between that and the write is wider than before: planning,
  presign, the spooled fetch, and the gated decision phase now sit in between.
  The sync lock keeps another sync out of it, but not a local editor. The gate
  does not cover this path because a tracked same-path write changes no number,
  but it is the one check whose input can age within a run.
- **Ordering.** Decisions whose number an existing local file already claims are
  written first, so a collision is judged against the store the user has rather
  than one this same run has written unrelated files into. Correctness does not
  depend on it - every write is re-gated - but the outcome for a given manifest
  does.
- **Minting** goes above every number the server manifest holds, not just the
  local maximum, so a renumbered file cannot land on a remote decision that has
  not been transferred yet.
- **The corpus is trusted between mutations**, scanned inside the decision lock
  and updated by the writer, so nothing external can change `decisions/`
  underneath it for the length of the write phase.
- **A question resolution arriving in the same pull is not consulted** by a
  verdict taken in that pull; the criterion is about the store as it stands, and
  quarantine remains the safety net.
- **A presign failure skips the completion pass** for that run. No network, no
  writes; it runs on the next successful pull.
- **The bar this was built to, deliberately.** Every scenario reachable through
  Nauro's own writers or a realistic store is closed and tested: the collision
  matrix, the crash windows, the spellings a manifest can use for a decision,
  the names the writer can mint, directory destinations, and the paths that
  resolve somewhere other than they read. Beyond that the posture is
  best-effort rather than exhaustive - an adversarial manifest is met by
  refusing the write or quarantining the entry, not by an enumeration of every
  exotic key a server could invent. The write barrier is what makes that
  posture safe: it guards where the bytes land, so a spelling nobody predicted
  fails closed instead of falling through. It and the planner consult one
  predicate, because the first version of this had the tracked-decision
  exemption in the planner only and refused every update a decision received
  after its first sync.

## Deferred

The general silent-drop leg for non-decision files that exist locally with no
state entry is untouched; only `decisions/` gained the same-path leg. Extending
`nauro doctor` to detect a filename/heading disagreement is deliberately not in
this PR - the completion pass reports those cases itself, with self-contained
guidance. No size cap is enforced on manifest entries: the spool removes the
memory exposure, and `size` is server-reported.
