### PR TITLE
Make sync pulls crash-safe and surface degraded post-commit steps

### DIFF
--- a/packages/nauro/src/nauro/mcp/tools.py
+++ b/packages/nauro/src/nauro/mcp/tools.py
@@ -70,7 +70,7 @@ from nauro.store.journal import (
     OriginDescriptor,
     record_event,
 )
-from nauro.store.post_commit import run_post_commit
+from nauro.store.post_commit import run_post_commit, surface_post_commit
 from nauro.store.reader import read_text_lenient
 from nauro.store.snapshot import (
     list_snapshots,
@@ -497,9 +497,7 @@ def tool_propose_decision(
             surface_bridge_notices=False,
             push=_try_push,
         )
-        notes = [*regen_warnings, *outcome.warnings]
-        if notes:
-            response["assessment"] = "\n\n".join([response["assessment"], *notes])
+        surface_post_commit(response, outcome, extra_warnings=regen_warnings)
 
     return response
 
@@ -653,8 +651,8 @@ def tool_flag_question(
 
     if hint:
         response["hint"] = hint
-    run_post_commit(store_path, snapshot_trigger=f"question: {question}", push=_try_push)
-    return response
+    outcome = run_post_commit(store_path, snapshot_trigger=f"question: {question}", push=_try_push)
+    return surface_post_commit(response, outcome)
 
 
 def _flag_question_resolve(
@@ -689,12 +687,12 @@ def _flag_question_resolve(
     if result.status == "rejected":
         return response
 
-    run_post_commit(
+    outcome = run_post_commit(
         store_path,
         snapshot_trigger=f"resolved by {resolved_by}: {targets or []}",
         push=_try_push,
     )
-    return response
+    return surface_post_commit(response, outcome)
 
 
 # Composed adapter-locally rather than exported from nauro-core: the fixed
@@ -899,10 +897,11 @@ def tool_update_state(
     # Adapter-side side effects only run on the success path. ``noop``
     # means the kernel had no existing state file to update — skip the
     # snapshot/push since nothing was written.
-    # A degraded ancillary step is logged, not surfaced: ``warning`` is the
-    # kernel's own keyword-overlap advisory, and writing adapter text into it
-    # would repurpose a pinned field the same way a new field would.
+    # A degraded ancillary step surfaces in ``assessment``, never in
+    # ``warning``: that field is the kernel's own keyword-overlap advisory, and
+    # writing adapter text into it would repurpose a pinned field.
     if result.status != "noop":
-        run_post_commit(store_path, snapshot_trigger=f"state: {delta}", push=_try_push)
+        outcome = run_post_commit(store_path, snapshot_trigger=f"state: {delta}", push=_try_push)
+        surface_post_commit(envelope, outcome)
 
     return envelope

--- a/packages/nauro/src/nauro/store/_atomic.py
+++ b/packages/nauro/src/nauro/store/_atomic.py
@@ -1,11 +1,17 @@
-"""Atomic text-write primitive for store files.
+"""Atomic write primitives for store files.
 
 The single tmp-write-then-``os.replace`` primitive used by the control-plane
-JSON writers (``registry.json``, ``config.json``, per-repo ``config.json``) and
-by the graph command for its rendered HTML. Durability scope is atomic-replace
-only: the rename is atomic on a single filesystem, so a reader never observes a
-partially written target. There is deliberately no ``fsync`` — that matches
-every existing call site, and crash-durability is an explicit non-goal here.
+JSON writers (``registry.json``, ``config.json``, per-repo ``config.json``), by
+the graph command for its rendered HTML, and by the sync pull for the remote
+bytes it lands. Durability scope is atomic-replace only: the rename is atomic on
+a single filesystem, so a reader never observes a partially written target.
+There is deliberately no ``fsync`` — that matches every existing call site, and
+crash-durability is an explicit non-goal here.
+
+The text and bytes entry points differ only in how they fill the tmp file. Both
+matter for the same reason: a plain write truncates the target first, so a write
+that fails halfway leaves a shortened file that still looks like content to
+every reader, including the next sync's push.
 """
 
 import os
@@ -16,6 +22,33 @@ from pathlib import Path
 _TMP_OPEN_FLAGS = (
     os.O_CREAT | os.O_EXCL | os.O_WRONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_BINARY", 0)
 )
+
+# The tmp sibling's name: a leading dot, the target's name, a random token, and
+# this suffix. Minted and recognised through the two functions below rather than
+# spelled out anywhere else, because a reader that has to identify an orphan -
+# the sync layer, deciding what may be pushed - must not carry its own copy of
+# the shape this module writes.
+TMP_SUFFIX = ".tmp"
+_TMP_TOKEN_BYTES = 8
+_HEX = frozenset("0123456789abcdef")
+
+
+def _tmp_name(name: str) -> str:
+    """The name a tmp sibling of ``name`` is born under."""
+    return f".{name}.{secrets.token_hex(_TMP_TOKEN_BYTES)}{TMP_SUFFIX}"
+
+
+def is_tmp_sibling(name: str) -> bool:
+    """True for a basename this module could have minted as a tmp sibling.
+
+    A write is removed on any failure, but a kill signal lands between the write
+    and the replace often enough to matter, and what it leaves behind is a
+    complete-looking file under a name nothing else claims.
+    """
+    if not (name.startswith(".") and name.endswith(TMP_SUFFIX)):
+        return False
+    token = name[: -len(TMP_SUFFIX)].rsplit(".", 1)[-1]
+    return len(token) == _TMP_TOKEN_BYTES * 2 and set(token) <= _HEX
 
 
 def _open_random_tmp(path: Path, creation_mode: int) -> tuple[int, Path]:
@@ -30,11 +63,64 @@ def _open_random_tmp(path: Path, creation_mode: int) -> tuple[int, Path]:
     other thread creating files.
     """
     while True:
-        tmp = path.parent / f".{path.name}.{secrets.token_hex(8)}.tmp"
+        tmp = path.parent / _tmp_name(path.name)
         try:
             return os.open(tmp, _TMP_OPEN_FLAGS, creation_mode), tmp
         except FileExistsError:  # pragma: no cover - 64-bit-random collision
             continue
+
+
+def _resolve_modes(path: Path, mode: int | None) -> tuple[int | None, int]:
+    """The bits the final file must carry, and the bits the tmp is born with.
+
+    When ``mode`` is given, or when an existing target's bits are being
+    preserved, the tmp is created owner-only so the contents are never
+    momentarily more readable than the final file — this matters for the auth
+    token, which is written at ``0o600``. A brand-new modeless file is instead
+    created at the default umask mode directly (the kernel applies the umask at
+    creation), matching a plain write for non-sensitive files without any
+    process-global umask manipulation.
+    """
+    if mode is not None:
+        return mode, 0o600
+    try:
+        return stat.S_IMODE(path.stat().st_mode), 0o600
+    except FileNotFoundError:
+        # No existing file: the umask-applied creation mode is already the
+        # final mode, no chmod needed. Any other stat error (permissions,
+        # not-a-directory) propagates rather than silently dropping an
+        # existing target's bits.
+        return None, 0o666
+
+
+def _replace(tmp: Path, path: Path, final_mode: int | None) -> None:
+    """Put the finished tmp file in place under the mode it must carry."""
+    if final_mode is not None and final_mode != 0o600:
+        os.chmod(tmp, final_mode)
+    os.replace(tmp, path)
+
+
+def atomic_write_bytes(path: Path, data: bytes) -> None:
+    """Write ``data`` to ``path`` atomically via a tmp sibling and ``os.replace``.
+
+    The bytes counterpart of :func:`atomic_write_text`, with the same tmp-file
+    and permission handling; an existing target keeps its permission bits.
+
+    Callers that land content they did not author — the sync pull, writing
+    bytes fetched from the server — need this rather than ``write_bytes``: a
+    truncating write that fails partway leaves a file that is neither the old
+    version nor the new one, and nothing downstream can tell the difference.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    final_mode, creation_mode = _resolve_modes(path, None)
+    fd, tmp = _open_random_tmp(path, creation_mode)
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(data)
+        _replace(tmp, path, final_mode)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
 
 
 def atomic_write_text(
@@ -62,40 +148,19 @@ def atomic_write_text(
     Every write goes through a tmp sibling with a random, unguessable name
     opened ``O_CREAT|O_EXCL``, so a symlink pre-planted at a predictable tmp
     path can neither redirect nor clobber the write, and the tmp file is
-    removed on any failure. When ``mode`` is given, or when an existing
-    target's bits are being preserved, the tmp is created owner-only so the
-    contents are never momentarily more readable than the final file — this
-    matters for the auth token, which is written at ``0o600``. A brand-new
-    modeless file is instead created at the default umask mode directly (the
-    kernel applies the umask at creation), matching plain ``write_text`` for
-    non-sensitive control-plane JSON without any process-global umask
-    manipulation. Guarantees are atomic-replace only: concurrent writers each
-    land a complete file (last replace wins, intermediate read-modify-write
-    updates can still be lost), and crash durability remains out of scope.
+    removed on any failure. The permission handling is
+    :func:`_resolve_modes`. Guarantees are atomic-replace only: concurrent
+    writers each land a complete file (last replace wins, intermediate
+    read-modify-write updates can still be lost), and crash durability remains
+    out of scope.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
-    final_mode: int | None
-    if mode is not None:
-        final_mode = mode
-        creation_mode = 0o600
-    else:
-        try:
-            final_mode = stat.S_IMODE(path.stat().st_mode)
-            creation_mode = 0o600
-        except FileNotFoundError:
-            # No existing file: the umask-applied creation mode is already the
-            # final mode, no chmod needed. Any other stat error (permissions,
-            # not-a-directory) propagates rather than silently dropping an
-            # existing target's bits.
-            final_mode = None
-            creation_mode = 0o666
+    final_mode, creation_mode = _resolve_modes(path, mode)
     fd, tmp = _open_random_tmp(path, creation_mode)
     try:
         with os.fdopen(fd, "w", encoding="utf-8", newline=newline) as handle:
             handle.write(text)
-        if final_mode is not None and final_mode != 0o600:
-            os.chmod(tmp, final_mode)
-        os.replace(tmp, path)
+        _replace(tmp, path, final_mode)
     except BaseException:
         tmp.unlink(missing_ok=True)
         raise

--- a/packages/nauro/src/nauro/store/post_commit.py
+++ b/packages/nauro/src/nauro/store/post_commit.py
@@ -26,7 +26,7 @@ stays a failure and exits nonzero.
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from enum import Enum
 from pathlib import Path
 
@@ -146,3 +146,37 @@ def run_post_commit(
             )
 
     return PostCommitOutcome(degraded=tuple(degraded), updated_repos=tuple(updated_repos))
+
+
+# The one free-text field every MCP write envelope shares. Degraded steps ride
+# here rather than in a field of their own: the envelope shapes are pinned, and
+# a new key would be a contract change for a condition that is not a failure of
+# the write.
+ASSESSMENT_FIELD = "assessment"
+
+
+def surface_post_commit(
+    envelope: dict,
+    outcome: PostCommitOutcome,
+    *,
+    extra_warnings: Sequence[str] = (),
+) -> dict:
+    """Route a post-commit outcome's warnings into one write tool's envelope.
+
+    The single place the MCP adapters turn a degraded ancillary step into
+    something the agent can read. Without it the outcome was returned and
+    dropped, and the only record was a debug log line no local install
+    configures - so a store whose snapshot, ``AGENTS.md``, or cloud push had
+    stopped working said nothing at all.
+
+    The envelope is mutated in place and returned. The key appears only when
+    there is a warning to carry, so a clean run's envelope is byte-identical to
+    what a surface that never degrades would return, and any assessment the
+    caller already wrote keeps its place at the front.
+    """
+    notes = [*extra_warnings, *outcome.warnings]
+    if not notes:
+        return envelope
+    existing = envelope.get(ASSESSMENT_FIELD)
+    envelope[ASSESSMENT_FIELD] = "\n\n".join([existing, *notes] if existing else notes)
+    return envelope

--- a/packages/nauro/src/nauro/sync/headings.py
+++ b/packages/nauro/src/nauro/sync/headings.py
@@ -21,8 +21,8 @@ _HEADING_SEPARATORS = ("—", "-")
 def heading_number(text: str) -> int | None:
     """Return the number in the first decision H1, if the text has one.
 
-    Deliberately as lax as the decision parser: any digit run counts, so a
-    heading this module refuses to rewrite is still *read* correctly and a
+    Deliberately as lax as the decision parser: any ASCII digit run counts, so
+    a heading this module refuses to rewrite is still *read* correctly and a
     filename/heading disagreement is detected rather than missed.
     """
     for line in text.splitlines():
@@ -42,7 +42,15 @@ def heading_line_number(line: str) -> int | None:
         # No space after the hash: "#Not a heading", or a deeper "## " level.
         return None
     head, _, tail = rest.partition(" ")
-    if not head.isdigit() or not tail.startswith(_HEADING_SEPARATORS):
+    # ASCII decimal only, because a heading number is only useful if the rest of
+    # the pipeline can round-trip it. ``str.isdigit`` is true across scripts: a
+    # superscript or circled digit passes it and then makes ``int`` raise, and
+    # ``isdecimal`` - the narrower predicate ``int`` does accept - still admits
+    # an Arabic-Indic run, whose number renders back into a filename in ASCII.
+    # That is a heading and a name this module would then read as disagreeing
+    # and try to repair. Neither is a number this store can carry, so the line
+    # claims none.
+    if not (head.isascii() and head.isdigit()) or not tail.startswith(_HEADING_SEPARATORS):
         return None
     return int(head)
 

--- a/packages/nauro/src/nauro/sync/merge.py
+++ b/packages/nauro/src/nauro/sync/merge.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from nauro.graph import DEFAULT_GRAPH_FILENAME
+from nauro.store._atomic import is_tmp_sibling
 from nauro.store.journal import JOURNAL_DIR
 from nauro.store.store_lock import DIR_LOCK_NAME, RMW_LOCK_SUFFIX
 from nauro.sync.state import SyncState
@@ -73,6 +74,14 @@ def should_skip(relative_path: str) -> bool:
     if normalized.startswith(JOURNAL_DIR + "/"):
         return True
     basename = normalized.rsplit("/", 1)[-1]
+    # A half-written sibling from the atomic write primitive. The write removes
+    # its own tmp file on failure, but a kill signal between the write and the
+    # replace strands a complete-looking copy of a store file under a name
+    # nothing reads - and syncing it would publish a version the user never had
+    # and install it for every collaborator. The shape is recognised by
+    # ``_atomic`` itself, so the writer and this exclusion cannot drift.
+    if is_tmp_sibling(basename):
+        return True
     return basename == DIR_LOCK_NAME or normalized.endswith(LOCK_ARTIFACT_SUFFIXES)
 
 

--- a/packages/nauro/src/nauro/sync/pull.py
+++ b/packages/nauro/src/nauro/sync/pull.py
@@ -43,6 +43,7 @@ from pydantic import BaseModel, ConfigDict, ValidationError
 
 from nauro.cli.commands.auth import AuthRefreshError
 from nauro.constants import DECISIONS_DIR
+from nauro.store._atomic import atomic_write_bytes
 from nauro.sync.collisions import (
     DecisionOutcome,
     DecisionVerdict,
@@ -139,10 +140,16 @@ class _Transfer:
 
 @dataclass
 class _Tally:
-    """What one run changed, in the terms it reports."""
+    """What one run changed, in the terms it reports.
+
+    ``refused`` counts the subjects a local filesystem error stopped. They are
+    not failures of the run - each one is reported and the next sync retries it
+    - but they are the reason a run cannot claim to have synced the whole store.
+    """
 
     merged: int = 0
     adopted: int = 0
+    refused: int = 0
 
 
 @dataclass(frozen=True)
@@ -332,12 +339,17 @@ def _triage(
             continue
 
         local_file = store_path / rel
+        if not local_file.exists():
+            # A tracked file the user deleted is not a conflict: a conflict
+            # protects local content and there is none. The remote store is
+            # append-only, so the file comes back on this pull.
+            work.pulls.append(item)
+            continue
         if not file_changed_locally(store_path, rel, state):
             work.pulls.append(item)
             continue
 
-        local_sha = compute_sha256(local_file) if local_file.exists() else ""
-        if detect_conflict(rel, state, local_sha, entry.etag):
+        if detect_conflict(rel, state, compute_sha256(local_file), entry.etag):
             work.conflicts.append(item)
 
     work.decisions[:0] = contested
@@ -363,6 +375,11 @@ def run_pull(
     Returns the number of files merged. Caller-facing failures
     (manifest/presign auth-refresh or transport errors) are reported through
     ``reporter`` and map to a 0 return.
+
+    The write phase is crash-safe in both directions: a local filesystem error
+    on one file is reported and the batch continues, and sync state is written
+    whatever happens, so what landed is always recorded even when the run does
+    not reach the end.
 
     Raises:
         ~nauro.sync.lock.SyncLockTimeoutError: another sync held the store
@@ -394,46 +411,121 @@ def _run_pull_locked(
         return 0
 
     tally = _Tally()
-    # The gated batch has to be complete before the lock is taken, because the
-    # lock must not span a transfer. It is spooled to disk rather than held:
-    # a manifest is server-supplied input, and its total size is not a number
-    # this process gets to be surprised by.
-    with _spool(store_path) as spool:
-        gated = _spool_batch(urls, work.decisions, reporter, spool)
-        with decision_lock(store_path, lock_timeout):
-            corpus = DecisionCorpus.scan(store_path)
-            _report_completion(corpus, reporter)
-            for item in work.decisions:
-                transfer = gated.get(item.rel)
-                if transfer is not None:
-                    _apply_decision(corpus, transfer, state, manifest, reporter, tally)
+    # Flipped the moment the decision lock is held, which is the moment this run
+    # can start changing the store. Everything before it - the manifest, the
+    # triage, the presign, the transfers, the wait for the lock - leaves the
+    # store exactly as it found it, and a failure there must not rewrite sync
+    # state: a state file that failed to parse loads as empty, and persisting
+    # that emptiness would untrack a whole store on a lock timeout.
+    mutating = False
+    try:
+        # The gated batch has to be complete before the lock is taken, because
+        # the lock must not span a transfer. It is spooled to disk rather than
+        # held: a manifest is server-supplied input, and its total size is not a
+        # number this process gets to be surprised by.
+        with _spool(store_path) as spool:
+            gated = _spool_batch(urls, work.decisions, reporter, spool)
+            with decision_lock(store_path, lock_timeout):
+                mutating = True
+                corpus = DecisionCorpus.scan(store_path)
+                with _guarded_step(DECISIONS_DIR, _COMPLETION_FAILURE_DETAIL, reporter, tally):
+                    _report_completion(corpus, reporter)
+                for item in work.decisions:
+                    transfer = gated.get(item.rel)
+                    if transfer is None:
+                        continue
+                    with _guarded_step(item.rel, _WRITE_FAILURE_DETAIL, reporter, tally):
+                        _apply_decision(corpus, transfer, state, manifest, reporter, tally)
 
-    for transfer in _stream(urls, work.pulls, reporter):
-        if not _generic_write_allowed(store_path, transfer, state, reporter):
-            continue
-        target = store_path / transfer.rel
-        target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_bytes(transfer.content)
-        update_file_state(state, transfer.rel, compute_sha256(target), transfer.etag)
-        tally.merged += 1
+        for transfer in _stream(urls, work.pulls, reporter):
+            with _guarded_step(transfer.rel, _WRITE_FAILURE_DETAIL, reporter, tally):
+                if _generic_write_allowed(store_path, transfer, state, reporter):
+                    target = store_path / transfer.rel
+                    atomic_write_bytes(target, transfer.content)
+                    update_file_state(state, transfer.rel, compute_sha256(target), transfer.etag)
+                    tally.merged += 1
 
-    for transfer in _stream(urls, work.conflicts, reporter):
-        if not _generic_write_allowed(store_path, transfer, state, reporter):
-            continue
-        _resolve_and_record(store_path, transfer, state)
-        tally.merged += 1
+        for transfer in _stream(urls, work.conflicts, reporter):
+            with _guarded_step(transfer.rel, _WRITE_FAILURE_DETAIL, reporter, tally):
+                if _generic_write_allowed(store_path, transfer, state, reporter):
+                    _resolve_and_record(store_path, transfer, state)
+                    tally.merged += 1
 
-    state.last_full_sync = datetime.now(timezone.utc).isoformat()
-    save_state(store_path, state)
+        if not tally.refused:
+            # The timestamp says this run walked the whole store and wrote
+            # everything it found, so it advances only when every leg ran and
+            # no file was left behind by a local write failure.
+            state.last_full_sync = datetime.now(timezone.utc).isoformat()
+    finally:
+        # Sync state records what actually landed, so once this run could have
+        # landed something it is written whatever happens above. A run that
+        # stopped early leaves a truthful partial record rather than none at
+        # all, which is what keeps the next run from replaying into a store the
+        # state no longer describes.
+        if mutating:
+            save_state(store_path, state)
 
     if tally.adopted:
         reporter.info(f"Adopted {tally.adopted} local file(s) already on the server")
     if tally.merged:
         reporter.info(f"Merged {tally.merged} file(s) from remote")
-    elif not tally.adopted:
+    if tally.refused:
+        # Said last, after the warnings that explain each one. A run that could
+        # not write must never sign off as "No remote changes".
+        reporter.info(
+            f"Left {tally.refused} item(s) for the next sync: this run could not write them"
+        )
+    elif not (tally.merged or tally.adopted):
         reporter.info("No remote changes")
 
     return tally.merged
+
+
+# What a step that could not write says for itself. Same shape as _SKIP_DETAIL
+# above - what happened to this one subject, and what the user does about it -
+# because each message is printed on its own and speaks only for the file or
+# the pass it names.
+_WRITE_FAILURE_DETAIL = (
+    "a local filesystem error stopped the write ({error}), so nothing was recorded for "
+    "it and anything half-applied was left for the next run to finish. Fix the local "
+    "problem - permissions, free space, a directory that disappeared - then run "
+    "'nauro sync' again; it retries this file."
+)
+_COMPLETION_FAILURE_DETAIL = (
+    "the pass that finishes an interrupted renumber could not write here ({error}), so "
+    "any half-applied rename was left as it was. Fix the local problem - permissions, "
+    "free space - then run 'nauro sync' again; the pass runs on every sync."
+)
+
+
+@contextmanager
+def _guarded_step(subject: str, detail: str, reporter: Reporter, tally: _Tally) -> Iterator[None]:
+    """Run one mutation step, turning a local filesystem error into its outcome.
+
+    A pull mutates many files under one lock, and a store the run cannot write
+    - a read-only decision, a full disk, a directory removed underfoot - is a
+    property of one path, not of the batch. Before this guard, that path's
+    ``OSError`` escaped the whole run, so every file already written went
+    unrecorded and the next run replayed into a store its own state no longer
+    described.
+
+    So an ``OSError`` here is reported against the subject that raised it and
+    the batch carries on with the next file. That is only safe because every
+    step it wraps leaves a state the next run heals rather than a half-written
+    one: the remote bytes land through an atomic replace, so a file is either
+    its old version or its new one and never a truncation the push would then
+    upload over the good remote copy; an interrupted renumber is completed by
+    the next pull's completion pass; and a file written without a state entry
+    is adopted on its next classification.
+
+    Failures are counted on the tally, because a run that could not write
+    everything it found has not fully synced the store.
+    """
+    try:
+        yield
+    except OSError as exc:
+        tally.refused += 1
+        reporter.warn(f"{subject}: {detail.format(error=exc)}")
 
 
 def _presign(
@@ -597,7 +689,7 @@ def _resolve_and_record(store_path: Path, transfer: _Transfer, state: SyncState)
     """Apply the last-write-wins conflict policy and record the result."""
     local_file = store_path / transfer.rel
     merged_content = resolve_conflict(store_path, local_file, transfer.content, transfer.rel)
-    local_file.write_bytes(merged_content)
+    atomic_write_bytes(local_file, merged_content)
     update_file_state(state, transfer.rel, compute_sha256(local_file), transfer.etag)
 
 
@@ -672,8 +764,7 @@ def _apply_decision(
         return
 
     target = store_path / transfer.rel
-    target.parent.mkdir(parents=True, exist_ok=True)
-    target.write_bytes(transfer.content)
+    atomic_write_bytes(target, transfer.content)
     update_file_state(state, transfer.rel, compute_sha256(target), transfer.etag)
     corpus.record_added(target, transfer.content.decode("utf-8", errors="replace"))
     tally.merged += 1

--- a/packages/nauro/tests/test_atomic.py
+++ b/packages/nauro/tests/test_atomic.py
@@ -1,4 +1,4 @@
-"""Tests for the atomic text-write primitive in ``nauro.store._atomic``."""
+"""Tests for the atomic write primitives in ``nauro.store._atomic``."""
 
 import threading
 from pathlib import Path
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 from nauro.store import _atomic
-from nauro.store._atomic import atomic_write_text
+from nauro.store._atomic import atomic_write_bytes, atomic_write_text
 
 
 def test_round_trip_exact_bytes(tmp_path):
@@ -168,3 +168,42 @@ def test_sensitive_write_leaves_no_tmp_behind(tmp_path):
     target = tmp_path / "config.json"
     atomic_write_text(target, "x\n", mode=0o600)
     assert [p.name for p in tmp_path.iterdir()] == ["config.json"]
+
+
+def test_bytes_round_trip_and_overwrite(tmp_path):
+    p = tmp_path / "remote.md"
+    atomic_write_bytes(p, b"first\n")
+    atomic_write_bytes(p, b"second\n")
+    assert p.read_bytes() == b"second\n"
+    assert list(tmp_path.iterdir()) == [p]
+
+
+def test_bytes_creates_missing_parent_dirs(tmp_path):
+    p = tmp_path / "decisions" / "007-x.md"
+    atomic_write_bytes(p, b"body\n")
+    assert p.read_bytes() == b"body\n"
+
+
+def test_bytes_leave_the_existing_file_whole_when_the_write_dies(tmp_path, monkeypatch):
+    """The reason the pull needs this: a truncating write that fails halfway
+    leaves a file that is neither version, and the next push uploads it."""
+    p = tmp_path / "stack.md"
+    p.write_bytes(b"the whole local file\n")
+
+    def boom(src, dst):
+        raise OSError(28, "No space left on device")
+
+    monkeypatch.setattr(_atomic.os, "replace", boom)
+    with pytest.raises(OSError):
+        atomic_write_bytes(p, b"short")
+
+    assert p.read_bytes() == b"the whole local file\n"
+    assert list(tmp_path.iterdir()) == [p]
+
+
+def test_bytes_preserve_existing_permissions(tmp_path):
+    p = tmp_path / "stack.md"
+    p.write_bytes(b"old\n")
+    p.chmod(0o640)
+    atomic_write_bytes(p, b"new\n")
+    assert (p.stat().st_mode & 0o777) == 0o640

--- a/packages/nauro/tests/test_post_commit.py
+++ b/packages/nauro/tests/test_post_commit.py
@@ -268,8 +268,32 @@ def test_degraded_snapshot_keeps_the_flag_question_envelope(
     envelope = tool_flag_question(adapter_store, question="Should the cache be write-through?")
 
     assert envelope["status"] == "ok"
+    assert "snapshot capture failed" in envelope["assessment"]
+    assert "disk full" in envelope["assessment"]
     assert [e.status for e in read_events(adapter_store)] == ["committed"]
     assert no_push == [adapter_store]
+
+
+def test_degraded_push_reaches_the_flag_question_resolve_envelope(
+    adapter_store: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (adapter_store / "open-questions.md").write_text(
+        "# Open Questions\n\n- [Q1] Should the cache be write-through?\n"
+    )
+    decisions = adapter_store / "decisions"
+    decisions.mkdir(exist_ok=True)
+    (decisions / "042-caching.md").write_text("# 042 — Caching\n")
+
+    def _boom(_store_path: Path) -> None:
+        raise RuntimeError("S3 credentials expired")
+
+    monkeypatch.setattr(mcp_tools, "_try_push", _boom)
+
+    envelope = tool_flag_question(adapter_store, resolved_by="D42", targets=["Q1"])
+
+    assert envelope["status"] == "ok"
+    assert "cloud push failed" in envelope["assessment"]
+    assert "S3 credentials expired" in envelope["assessment"]
 
 
 def test_degraded_snapshot_keeps_the_update_state_envelope(
@@ -280,5 +304,24 @@ def test_degraded_snapshot_keeps_the_update_state_envelope(
     envelope = tool_update_state(adapter_store, delta="Shipped the caching layer.")
 
     assert envelope["status"] == "ok"
+    assert "snapshot capture failed" in envelope["assessment"]
+    assert "disk full" in envelope["assessment"]
+    # The kernel's own advisory field is untouched: adapter text never lands in it.
+    assert "snapshot" not in envelope.get("warning", "")
     assert [e.status for e in read_events(adapter_store)] == ["committed"]
     assert no_push == [adapter_store]
+
+
+def test_a_clean_run_adds_no_assessment_to_the_short_envelopes(
+    adapter_store: Path, no_push: list[Path]
+) -> None:
+    """The degraded channel is silent when nothing degraded.
+
+    ``assessment`` is a field these two envelopes do not otherwise carry, so it
+    may only appear when there is something to say.
+    """
+    flagged = tool_flag_question(adapter_store, question="Should the cache be write-through?")
+    updated = tool_update_state(adapter_store, delta="Shipped the caching layer.")
+
+    assert "assessment" not in flagged
+    assert "assessment" not in updated

--- a/packages/nauro/tests/test_sync/test_collisions.py
+++ b/packages/nauro/tests/test_sync/test_collisions.py
@@ -28,6 +28,7 @@ from nauro.sync.collisions import (
 from nauro.sync.corpus import DecisionCorpus
 from nauro.sync.headings import (
     has_rewritable_heading,
+    heading_line_number,
     heading_number,
     rewrite_decision_heading,
     strip_number_prefix,
@@ -101,6 +102,23 @@ class TestHeadingPrimitives:
         assert heading_number("# 8 — Title\n") == 8
         assert heading_number("## 008 — Title\n") is None
         assert heading_number("#Not a heading\n") is None
+
+    @pytest.mark.parametrize(
+        "digits",
+        [
+            "²",  # superscript two
+            "١٢٣",  # Arabic-Indic 123
+            "፩",  # Ethiopic digit one
+            "①",  # circled digit one
+        ],
+    )
+    def test_a_non_ascii_digit_heading_claims_no_number(self, digits):
+        # ``str.isdigit`` is true for a whole zoo of characters ``int`` refuses,
+        # and the ones it accepts (Arabic-Indic) name a number whose canonical
+        # filename form is ASCII, so the heading and the name would then read as
+        # disagreeing.
+        assert heading_line_number(f"# {digits} — Title") is None
+        assert heading_number(f"# {digits} — Title\n") is None
 
     def test_rewritable_is_narrower_than_readable(self):
         assert has_rewritable_heading("# 008 — Title\n", 8) is True
@@ -404,6 +422,18 @@ class TestNonCanonicalHeadingNumbers:
         assert first.repaired == ()
         assert second == first
         assert path.read_bytes() == body
+
+    def test_a_non_ascii_digit_heading_does_not_break_the_pull(self, store):
+        # One decision file whose H1 carries a non-ASCII digit used to abort
+        # every sync from inside the completion pass, which runs on every pull.
+        body = decision_bytes(44, "Local decision").replace(b"\n# 044", "\n# ²".encode())
+        write_local_decision(store, "044-local.md", body)
+
+        merged, _reporter = pull(store, [("decisions/045-remote.md", decision_bytes(45, "Remote"))])
+
+        assert merged == 1
+        assert (store / "decisions/044-local.md").read_bytes() == body
+        assert (store / "decisions/045-remote.md").exists()
 
     def test_pull_reports_the_quarantined_mismatch_every_run(self, store):
         body = decision_bytes(42, "Local decision").replace(b"\n# 042", b"\n# 42")

--- a/packages/nauro/tests/test_sync/test_merge.py
+++ b/packages/nauro/tests/test_sync/test_merge.py
@@ -2,6 +2,8 @@
 
 from nauro_core.decision_model import parse_decision
 
+from nauro.store import _atomic
+from nauro.store._atomic import atomic_write_bytes
 from nauro.sync.merge import (
     _set_union_markdown,
     detect_conflict,
@@ -41,6 +43,27 @@ class TestShouldSkip:
         assert should_skip("snapshots/.lock") is True
         # write_file's one non-markdown target, the decision-hash index.
         assert should_skip(".decision-hashes.json.lock") is True
+
+    def test_an_orphaned_atomic_tmp_sibling_is_skipped(self, tmp_path, monkeypatch):
+        """A kill between the tmp write and the replace strands a sibling.
+
+        It is a complete-looking copy of a store file under a name nothing
+        reads, so pushing it would publish a version the user never had. The
+        name comes from the real writer rather than a hand-spelled pattern.
+        """
+        monkeypatch.setattr(_atomic.os, "replace", lambda src, dst: None)
+        atomic_write_bytes(tmp_path / "stack.md", b"# Stack\n")
+        orphan = next(entry.name for entry in tmp_path.iterdir())
+
+        assert orphan.startswith(".stack.md.") and orphan.endswith(".tmp")
+        assert should_skip(orphan) is True
+        assert should_skip(f"decisions/{orphan}") is True
+
+    def test_ordinary_tmp_names_still_sync(self):
+        # The shape is narrow: the store's own tmp siblings carry a random hex
+        # token, so a file the user happens to name .notes.tmp is content.
+        assert should_skip(".notes.tmp") is False
+        assert should_skip("context/draft.tmp") is False
 
     def test_non_artifact_lock_names_still_sync(self):
         # Only the store's own artifact shapes are skipped; user content that

--- a/packages/nauro/tests/test_sync/test_pull.py
+++ b/packages/nauro/tests/test_sync/test_pull.py
@@ -12,6 +12,8 @@ classifier and its crash windows are unit-tested in ``test_collisions.py``.
 
 from __future__ import annotations
 
+import os
+from pathlib import Path
 from unittest.mock import patch
 
 import httpx
@@ -1312,3 +1314,265 @@ class TestUnreadableLocalNames:
 
         assert merged == 1
         assert "008-remote.md" in entry_names(collision_store / "decisions")
+
+
+class TestLocallyDeletedFiles:
+    """A tracked file the user deleted is not a conflict.
+
+    A conflict exists to protect local content from being overwritten. There is
+    no local content here, and the remote store is append-only, so the pull
+    reinstalls the file. Treating the absence as a conflict made the resolver
+    read a file that is not there, which aborted the whole run - including the
+    state save for everything the same run had already written.
+    """
+
+    def test_a_deleted_tracked_file_is_reinstalled(self, collision_store):
+        (collision_store / "stack.md").write_text("# Stack\n\nlocal\n")
+        track(collision_store, "stack.md")
+        (collision_store / "stack.md").unlink()
+
+        merged, reporter = pull(
+            collision_store,
+            [("stack.md", b"# Stack\n\nremote\n")],
+            etags={"stack.md": '"v2"'},
+        )
+
+        assert merged == 1
+        assert (collision_store / "stack.md").read_bytes() == b"# Stack\n\nremote\n"
+        state = load_state(collision_store)
+        assert state.files["stack.md"].remote_etag == '"v2"'
+        assert state.last_full_sync
+        assert reporter.warns == []
+
+    def test_a_deleted_tracked_decision_is_reinstalled(self, collision_store):
+        rel = "decisions/003-shared.md"
+        write_local_decision(collision_store, "003-shared.md", decision_bytes(3, "Shared", "v1."))
+        track(collision_store, rel)
+        (collision_store / rel).unlink()
+        updated = decision_bytes(3, "Shared", "v2.")
+
+        merged, reporter = pull(collision_store, [(rel, updated)], etags={rel: '"v2"'})
+
+        assert merged == 1
+        assert (collision_store / rel).read_bytes() == updated
+        assert load_state(collision_store).files[rel].remote_etag == '"v2"'
+        assert reporter.warns == []
+
+    def test_the_rest_of_the_batch_still_lands_and_is_recorded(self, collision_store):
+        (collision_store / "stack.md").write_text("# Stack\n\nlocal\n")
+        track(collision_store, "stack.md")
+        (collision_store / "stack.md").unlink()
+
+        merged, _reporter = pull(
+            collision_store,
+            [
+                ("decisions/009-remote.md", decision_bytes(9, "Remote")),
+                ("stack.md", b"# Stack\n\nremote\n"),
+            ],
+            etags={"stack.md": '"v2"'},
+        )
+
+        assert merged == 2
+        state = load_state(collision_store)
+        assert "decisions/009-remote.md" in state.files
+        assert "stack.md" in state.files
+
+
+class TestLocalWriteFailures:
+    """A local filesystem error stops one file, not the run.
+
+    Everything a pull mutates happens under the decision lock, and the record
+    of what landed is written at the end. An escaping OSError therefore lost
+    that record for every file the run had already written, and the next run
+    replayed into a store it no longer described.
+    """
+
+    @staticmethod
+    def _refuse(monkeypatch, name: str, *, once: bool = False) -> None:
+        """Fail the store write for one filename, as a full disk would."""
+        real = pull_module.atomic_write_bytes
+        pending = {name}
+
+        def guarded(path, data):
+            if path.name == name and (pending or not once):
+                pending.clear()
+                raise PermissionError(13, "Permission denied")
+            return real(path, data)
+
+        monkeypatch.setattr(pull_module, "atomic_write_bytes", guarded)
+
+    def test_a_failed_write_is_reported_and_the_batch_continues(self, collision_store, monkeypatch):
+        self._refuse(monkeypatch, "010-remote.md")
+
+        merged, reporter = pull(
+            collision_store,
+            [
+                ("decisions/010-remote.md", decision_bytes(10, "Refused")),
+                ("decisions/011-remote.md", decision_bytes(11, "Fine")),
+            ],
+        )
+
+        assert merged == 1
+        state = load_state(collision_store)
+        assert "decisions/011-remote.md" in state.files
+        assert "decisions/010-remote.md" not in state.files
+        assert any("010-remote.md" in warning for warning in reporter.warns)
+
+    def test_the_next_run_retries_the_file_that_failed(self, collision_store, monkeypatch):
+        self._refuse(monkeypatch, "010-remote.md", once=True)
+        entries = [("decisions/010-remote.md", decision_bytes(10, "Refused"))]
+
+        pull(collision_store, entries)
+        merged, _reporter = pull(collision_store, entries)
+
+        assert merged == 1
+        assert (collision_store / "decisions/010-remote.md").exists()
+        assert "decisions/010-remote.md" in load_state(collision_store).files
+
+    def test_a_failed_generic_write_keeps_the_state_of_what_landed(
+        self, collision_store, monkeypatch
+    ):
+        (collision_store / "stack.md").write_text("# Stack\n\nlocal\n")
+        track(collision_store, "stack.md")
+        self._refuse(monkeypatch, "stack.md")
+
+        merged, reporter = pull(
+            collision_store,
+            [
+                ("stack.md", b"# Stack\n\nremote\n"),
+                ("decisions/012-remote.md", decision_bytes(12, "Fine")),
+            ],
+            etags={"stack.md": '"v2"'},
+        )
+
+        assert merged == 1
+        state = load_state(collision_store)
+        assert "decisions/012-remote.md" in state.files
+        assert state.files["stack.md"].remote_etag != '"v2"'
+        assert any("stack.md" in warning for warning in reporter.warns)
+
+    def test_a_failing_completion_pass_does_not_abort_the_run(self, collision_store, monkeypatch):
+        def refuse(*_args, **_kwargs):
+            raise PermissionError(13, "Permission denied")
+
+        monkeypatch.setattr(pull_module, "run_completion_pass", refuse)
+
+        merged, reporter = pull(
+            collision_store, [("decisions/013-remote.md", decision_bytes(13, "Remote"))]
+        )
+
+        assert merged == 1
+        assert "decisions/013-remote.md" in load_state(collision_store).files
+        assert any("decisions:" in warning for warning in reporter.warns)
+
+    def test_a_refused_file_holds_back_the_full_sync_timestamp(self, collision_store, monkeypatch):
+        self._refuse(monkeypatch, "014-remote.md")
+
+        _merged, reporter = pull(
+            collision_store, [("decisions/014-remote.md", decision_bytes(14, "Refused"))]
+        )
+
+        # The store was not fully synced: one file is still owed.
+        assert load_state(collision_store).last_full_sync == ""
+        # And the run says so rather than signing off as a quiet no-op.
+        assert "No remote changes" not in reporter.infos
+        assert any("next sync" in line for line in reporter.infos)
+
+    def test_a_lock_timeout_leaves_an_unreadable_state_file_alone(
+        self, collision_store, monkeypatch
+    ):
+        """A run that never reached the write phase does not rewrite state.
+
+        An unreadable state file loads as an empty one, so a save on the way
+        out of a run that wrote nothing would untrack the whole store and hand
+        the corruption a permanent form.
+        """
+        corrupt = b'{"files": {"stack.md": '
+        (collision_store / ".sync-state.json").write_bytes(corrupt)
+
+        def refuse_lock(store_path, timeout, *_args, **_kwargs):
+            raise SyncLockTimeoutError(store_path, timeout, "decision")
+
+        monkeypatch.setattr(pull_module, "decision_lock", refuse_lock)
+
+        with pytest.raises(SyncLockTimeoutError):
+            pull(collision_store, [("decisions/015-remote.md", decision_bytes(15, "Remote"))])
+
+        assert (collision_store / ".sync-state.json").read_bytes() == corrupt
+
+
+class TestPartialWrites:
+    """A write that dies halfway must not leave a shortened file behind.
+
+    A plain write truncates the target first, so an error partway through
+    leaves bytes that are neither version. Nothing downstream can tell: the
+    next push reads the file as a local change and uploads the truncation over
+    the good remote copy, and there is no backup of what it replaced.
+    """
+
+    def test_a_dead_write_leaves_the_original_file_and_its_state_entry(
+        self, collision_store, monkeypatch
+    ):
+        original = b"# Stack\n\nthe local version, in full\n"
+        (collision_store / "stack.md").write_bytes(original)
+        track(collision_store, "stack.md")
+        before = load_state(collision_store).files["stack.md"]
+
+        real_replace = os.replace
+
+        def die_on_stack(src, dst, **kwargs):
+            if Path(dst).name == "stack.md":
+                raise OSError(28, "No space left on device")
+            return real_replace(src, dst, **kwargs)
+
+        monkeypatch.setattr("nauro.store._atomic.os.replace", die_on_stack)
+
+        merged, reporter = pull(
+            collision_store,
+            [("stack.md", b"# Stack\n\nthe remote version\n")],
+            etags={"stack.md": '"v2"'},
+        )
+
+        assert merged == 0
+        assert (collision_store / "stack.md").read_bytes() == original
+        after = load_state(collision_store).files["stack.md"]
+        assert (after.local_sha256, after.remote_etag) == (before.local_sha256, before.remote_etag)
+        assert any("stack.md" in warning for warning in reporter.warns)
+        # The half-written sibling is not left lying in the store either.
+        assert not list(collision_store.glob(".stack.md.*.tmp"))
+
+    def test_a_dead_decision_install_lands_nothing_and_retries(self, collision_store, monkeypatch):
+        """The install leg has the worst chain if a truncation survives.
+
+        A shortened decision file is untracked, so the next run classifies it
+        as a local record, keeps it over the remote one, and pushes it - the
+        store's own copy of that decision, silently replaced by a fragment.
+        """
+        rel = "decisions/016-remote.md"
+        body = decision_bytes(16, "Remote")
+        real_replace = os.replace
+        dying = {rel}
+
+        def die_on_install(src, dst, **kwargs):
+            if Path(dst).name == "016-remote.md" and dying:
+                dying.clear()
+                raise OSError(28, "No space left on device")
+            return real_replace(src, dst, **kwargs)
+
+        monkeypatch.setattr("nauro.store._atomic.os.replace", die_on_install)
+
+        merged, reporter = pull(collision_store, [(rel, body)])
+
+        assert merged == 0
+        assert "016-remote.md" not in entry_names(collision_store / "decisions")
+        assert rel not in load_state(collision_store).files
+        assert not list((collision_store / "decisions").glob(".016-remote.md.*.tmp"))
+        assert any("016-remote.md" in warning for warning in reporter.warns)
+
+        # Nothing about the store now argues against the remote decision, so
+        # the next run installs it whole.
+        merged, _reporter = pull(collision_store, [(rel, body)])
+
+        assert merged == 1
+        assert (collision_store / rel).read_bytes() == body
+        assert rel in load_state(collision_store).files


### PR DESCRIPTION
## Why

The review found 3 defects in the sync and MCP write paths. All 3 fail
silently or block the store. None fails loudly.

Defect 1. If a decision H1 contains a digit that is not ASCII, the heading
reader crashes. The code checks `str.isdigit()` and then calls `int()`. These
2 functions do not agree on 95 characters in the low Unicode range. The
superscript `²` is one of them. The crash occurs in the completion pass for
interrupted renumbers. This pass runs on each cloud pull. As a result, 1 bad
file anywhere in the store stops the full command.

Defect 2. If a user deletes a tracked file locally, the pull classifies the
file as a conflict. The conflict resolver then tries to read the missing file.
The `FileNotFoundError` stops the full run. The run saves sync state only at
the end. As a result, no write made under the decision lock is recorded. These
writes include renumbers, installs, heading rewrites, and hash-index retargets.
The next run crashes at the same point. The store stays blocked until a person
finds and restores the correct file manually.

Defect 3. The MCP tools `flag_question` and `update_state` ran the post-commit
steps and discarded the result. If the snapshot capture, the `AGENTS.md`
regeneration, or the cloud push failed, the only record was a debug log line.
A local install does not configure logging. As a result, the agent got a
success answer and no other information. These 2 tools are the tools an agent
calls most often in a session.

## What changed

**Heading numbers are ASCII decimal.** The pipeline must carry a heading
number back into a filename. Only ASCII decimal digits survive this round
trip. `isdecimal()` is not a correct fix: it accepts Arabic-Indic digits, and
their numeric value renders back into an ASCII filename. The heading and the
filename then disagree, and the repair pass tries to repair a file that is not
broken. A digit run that is not ASCII now claims no number. The completion
pass already skips that shape.

**A locally missing file is not a conflict.** A conflict protects local
content. A missing file has no local content. The remote store is append-only
by design, so the next pull undoes a local deletion. The pull now routes the
file to a normal install. The empty-hash placeholder that fed the conflict
detector is removed.

**The pull write phase is crash-safe.** Remote bytes now land through a tmp
sibling and an atomic replace. A plain `write_bytes` first truncates the file
and then writes. If the write dies between these 2 steps, a shortened file
remains and looks like real content. The next push then reads it as a local
change and uploads it over the good remote copy, with no backup. The atomic
replace keeps the old file whole. The other sync mutations already write this
way.

This guarantee makes the new guard safe. The guard changes a filesystem error
on 1 file into a reported outcome. The batch then continues. It does not die.

The run now writes sync state in a `finally` block, because state records only
writes that landed. The save arms only after the run holds the decision lock.
As a result, a lock timeout does not touch the state file. This matters
because an unreadable state file loads as empty, and a save of that empty
state would untrack the full store. The full-sync timestamp advances only when
the run completes with no refused file. If the run cannot write all files, it
reports this. It does not report "no changes".

If the process dies between the tmp write and the replace, the tmp sibling
remains on disk. This change adds 3 such writes to the busiest path. Sync now
excludes this name shape in both directions. A dead sibling looks like a
complete store file. Without the exclusion, the next push publishes it and
each collaborator installs it. The write primitive mints the name and also
recognizes it. As a result, the writer and the exclusion cannot drift apart.

**Degraded post-commit steps reach the agent.** One helper applies a
post-commit outcome to a write tool envelope. It appends the warnings to the
assessment text. The post-commit module already names this channel for the MCP
surfaces. All 4 write adapters call the helper. `propose_decision` had its own
inline version; the helper replaced it with identical behavior. The key
appears only when a step degraded. As a result, clean envelopes do not change.

## Test plan

Missing negative-path tests let all 3 defects through. Each fix starts with
these tests.

- Heading primitives over superscript, Arabic-Indic, Ethiopic, and circled
  digits. A pull over a store that holds a poisoned decision file.
- A deleted tracked file and a deleted tracked decision. Each is reinstalled,
  its state is recorded, and the rest of the batch lands. A write failure
  injected mid-batch: the run completes, the state of landed files survives,
  the failure is reported, and the next run retries and installs the file. A
  failing completion pass no longer stops the run. A refused file holds back
  the full-sync timestamp and the summary line. A lock timeout leaves an
  unreadable state file untouched.
- A write that dies at the replace, on the ordinary pull leg and on the
  decision-install leg: the original file and its state entry stay intact, no
  tmp sibling remains, and the next run retries the file. Unit tests cover the
  new atomic bytes primitive.
- An orphaned tmp sibling, produced by the real writer with the replace
  stubbed out: sync skips it. Ordinary `.tmp` names still sync.
- A failing snapshot and a failing push on each adapter that was silent
  before: the status stays "ok" and the warning text appears in the
  assessment. On a clean run, the key is absent.

`pytest packages/nauro-core/tests/`: 1500 passed.
`pytest packages/nauro/tests/`: 2478 passed, 10 skipped.
`ruff check` and `ruff format --check`: clean.

## Risk / what to review

Read the state-save boundary with the most care. A state write on the way out
of a failed run is correct only if the run could change something. For this
reason, the save is gated on the decision lock, not on run completion.

The per-file guard catches `OSError` broadly. A filesystem-shaped bug in a
mutation step now reports as a skipped file. It does not raise a traceback.
This is the intended trade, because a blocked store is worse. The trade holds
only while each guarded step leaves a healable state, and the atomic write
supplies that state. If you change one half later, check the other half again.

One semantics change: the atomic replace swaps the target file. The old
`write_bytes` wrote through a symlink or into an existing inode. A store file
that is a symlink or a hardlink is now replaced, not followed. This matches
the other store writes and is the safer default. It is a behavior change, not
a detail.

## Deferred

The decision-number reader in the sync layer is now stricter than the shared
parser in nauro-core. The shared parser keeps the lax `isdigit`-then-`int`
shape. As a result, a filename such as `²-x.md` still raises from the corpus
scan, and an Arabic-Indic filename still reads as a number. That fix belongs
in the core package and gets its own change.
