### PR TITLE
Read decision and question numbers in ASCII only

### DIFF
--- a/packages/nauro-core/src/nauro_core/decision_model.py
+++ b/packages/nauro-core/src/nauro_core/decision_model.py
@@ -57,7 +57,7 @@ from enum import Enum
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
-from nauro_core.parsing import extract_decision_number
+from nauro_core.parsing import extract_decision_number, is_ascii_decimal
 
 # ── Enums (values match on-disk lowercase tokens verbatim) ──
 
@@ -173,7 +173,7 @@ class Decision(BaseModel):
         """
         if v is None:
             return v
-        if not v.isdigit():
+        if not is_ascii_decimal(v):
             raise ValueError(
                 f"supersession ref must be a plain integer string (e.g. '70'), got {v!r}"
             )
@@ -234,7 +234,11 @@ _FRONTMATTER_ORDER: tuple[str, ...] = (
 # ── Parser ──
 
 
-_H1_PATTERN = re.compile(r"^#\s+(\d+)\s+\u2014\s+(.+)$", re.MULTILINE)
+# ``[0-9]`` rather than ``\d``: the pattern is Unicode-aware by default, and a
+# heading numbered in another script names a number whose filename form is
+# ASCII, so the two could never match again. Such a heading is malformed here,
+# the same as a missing one.
+_H1_PATTERN = re.compile(r"^#\s+([0-9]+)\s+\u2014\s+(.+)$", re.MULTILINE)
 _SUBSECTION_SPLIT = re.compile(r"^###\s+(.+?)\s*$", re.MULTILINE)
 
 _DECISION_ANCHOR = "## Decision"

--- a/packages/nauro-core/src/nauro_core/parsing.py
+++ b/packages/nauro-core/src/nauro_core/parsing.py
@@ -99,6 +99,43 @@ def _cap_to_first_unit(body: str) -> str:
     return text[:cut].rstrip()
 
 
+_ASCII_DIGITS = "0123456789"
+
+
+def is_ascii_decimal(token: str) -> bool:
+    """True when ``token`` is a non-empty run of ASCII decimal digits.
+
+    The one test for "could this store have written that number". Every number
+    it renders - a decision's filename prefix, its H1, a ``D70`` reference, a
+    question's ``Q7`` id - is written in ASCII, so every reader here reads back
+    in ASCII, and one predicate keeps the readers from disagreeing.
+
+    ``str.isdigit`` is not that test. It is true across scripts, and the two
+    ways it goes wrong both matter: a superscript or circled digit passes it
+    and then makes ``int`` raise, and an Arabic-Indic run passes it and reads
+    as a number whose canonical written form is ASCII, so the value and the
+    text that carried it can never agree again.
+    """
+    return bool(token) and all(char in _ASCII_DIGITS for char in token)
+
+
+def _continues_a_number(char: str) -> bool:
+    """True when ``char`` could be one more digit of the number just read.
+
+    The right-boundary test for a number token, and deliberately narrower than
+    :func:`is_ascii_decimal`'s complement: ``str.isdecimal`` is true for exactly
+    the characters ``int`` accepts as digits, which is what "this number goes
+    on" means. So an Arabic-Indic digit after an ASCII run continues the number,
+    and the token is one number written in two scripts.
+
+    A superscript or circled digit is not one of them - ``int`` refuses it - so
+    it never continues a number. In a body it is a footnote marker after a
+    reference, and in a name it is simply where the number ended, the same as a
+    letter.
+    """
+    return char.isdecimal()
+
+
 def extract_decision_number(identifier: str) -> int | None:
     """Extract the decision number from a decision identifier.
 
@@ -108,24 +145,37 @@ def extract_decision_number(identifier: str) -> int | None:
     - prefixed: ``"D042"`` or ``"D42"``
     - bare integer: ``"42"``
 
+    The number is ASCII decimal (see :func:`is_ascii_decimal`); an identifier
+    numbered in any other script is one no writer here produced, and reads as
+    no number rather than as an error. Callers already handle that answer: it
+    is the same one a name like ``notes.md`` gets.
+
+    The whole number token is judged, not just its first characters. A run
+    that stops where the number continues in another script (see
+    :func:`_continues_a_number`) is one number written two ways, so it names
+    nothing here - reading the ASCII part alone would let such a name claim
+    decision 12, which it does not spell. A run that stops anywhere else is the
+    ordinary shape: the number ended and the rest is slug, so ``12x-foo.md``
+    still reads 12.
+
     Returns None if the identifier doesn't match a known shape.
     """
     s = identifier.removesuffix(".md")
     low = s.lower()
     if low.startswith("decision-"):
         s = s[len("decision-") :]
-    elif low.startswith("d") and len(s) > 1 and s[1].isdigit():
+    elif low.startswith("d") and len(s) > 1 and is_ascii_decimal(s[1]):
         s = s[1:]
     leading = ""
     for ch in s:
-        if ch.isdigit():
+        if is_ascii_decimal(ch):
             leading += ch
-        else:
-            break
+            continue
+        if _continues_a_number(ch):
+            return None
+        break
     return int(leading) if leading else None
 
-
-_ASCII_DIGITS = "0123456789"
 
 # Body reference prefixes, lowercased. ``extract_decision_number`` accepts the
 # same forms for a single identifier; this scanner finds every occurrence in a
@@ -182,7 +232,12 @@ def _scan_prefix(text: str, low: str, prefix: str, found: set[int], max_number: 
         digit_start = i
         while i < n and text[i] in _ASCII_DIGITS:
             i += 1
-        if i > digit_start:
+        # Right boundary, same rule as ``extract_decision_number``: a run that
+        # stops at a digit from another script is one number written in two
+        # scripts and references nothing, while a run that stops at a letter or
+        # a space is an ordinary reference that ends there.
+        mixed_script = i < n and _continues_a_number(text[i])
+        if i > digit_start and not mixed_script:
             value = int(text[digit_start:i])
             if 1 <= value <= max_number:
                 found.add(value)

--- a/packages/nauro-core/src/nauro_core/questions.py
+++ b/packages/nauro-core/src/nauro_core/questions.py
@@ -32,6 +32,7 @@ from typing import Annotated, Literal
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from nauro_core.constants import POINTER_FLAG_PREFIXES, QUESTION_ENTRY_CHAR_BUDGET
+from nauro_core.parsing import is_ascii_decimal
 
 _TIMESTAMP_FMT = "%Y-%m-%d %H:%M UTC"
 _RESOLVED_HEADER = "## Resolved"
@@ -808,7 +809,7 @@ def _parse_q_id(text: str) -> int | None:
     if len(text) < 2 or text[0] != "Q":
         return None
     digits = text[1:]
-    if not digits.isdigit():
+    if not is_ascii_decimal(digits):
         return None
     num = int(digits)
     if num < 1:
@@ -825,6 +826,8 @@ def _parse_resolved_prefix(text: str) -> ResolvedRef | None:
     if sep_idx < 1:
         return None
     num_str = rest[:sep_idx]
+    if not is_ascii_decimal(num_str):
+        return None
     date_str = rest[sep_idx + len(_RESOLVED_PREFIX_SEP) :].strip()
     try:
         return ResolvedRef(decision_num=int(num_str), date=_date.fromisoformat(date_str))

--- a/packages/nauro-core/src/nauro_core/renderers.py
+++ b/packages/nauro-core/src/nauro_core/renderers.py
@@ -46,7 +46,7 @@ from nauro_core.constants import (
     LEXICAL_RANK_CAVEAT,
     NO_RELATED_DECISIONS,
 )
-from nauro_core.parsing import _decision_label
+from nauro_core.parsing import _decision_label, is_ascii_decimal
 
 # Width target for the rendered text blocks. Picked to fit standard
 # terminal widths and Markdown chat clients without horizontal scroll.
@@ -59,7 +59,7 @@ def _id_to_label(decision_id: str) -> str:
     prefix = "decision-"
     if decision_id.startswith(prefix):
         suffix = decision_id[len(prefix) :]
-        if suffix.isdigit():
+        if is_ascii_decimal(suffix):
             return _decision_label(int(suffix))
     return decision_id
 

--- a/packages/nauro-core/tests/test_decision_model.py
+++ b/packages/nauro-core/tests/test_decision_model.py
@@ -585,6 +585,38 @@ class TestNegativeValidation:
         with pytest.raises(ValueError, match="missing or malformed H1"):
             parse_decision(text, "001-test.md")
 
+    def test_non_ascii_h1_number_raises(self) -> None:
+        """The H1 number is read in ASCII, like the filename it must match.
+
+        An Arabic-Indic run is a decimal digit to a Unicode-aware pattern, so
+        it used to parse as 12 - a number whose canonical filename is ASCII and
+        which no writer here could have produced.
+        """
+        text = (
+            "---\n"
+            "date: 2026-04-01\n"
+            "confidence: high\n"
+            "---\n\n"
+            "# \u0661\u0662 \u2014 Arabic-Indic heading number\n\n"
+            "## Decision\n\nSomething.\n"
+        )
+        with pytest.raises(ValueError, match="missing or malformed H1"):
+            parse_decision(text, "012-test.md")
+
+    def test_mixed_script_h1_number_raises(self) -> None:
+        # The pattern needs a separator after the digits, so a number that
+        # continues in another script never matched. Pinned.
+        text = (
+            "---\n"
+            "date: 2026-04-01\n"
+            "confidence: high\n"
+            "---\n\n"
+            "# 12\u0661 \u2014 Mixed-script heading number\n\n"
+            "## Decision\n\nSomething.\n"
+        )
+        with pytest.raises(ValueError, match="missing or malformed H1"):
+            parse_decision(text, "012-test.md")
+
     def test_missing_decision_section_raises(self) -> None:
         text = (
             "---\n"
@@ -822,6 +854,12 @@ class TestSupersessionRefValidator:
         d = _minimal_decision(supersedes=None, superseded_by=None)
         assert d.supersedes is None
         assert d.superseded_by is None
+
+    def test_non_ascii_digits_rejected_as_not_an_integer_string(self) -> None:
+        # "\u0661\u0662" is a digit run to str.isdigit and 12 to int, so it used
+        # to fail as a leading-zeros problem, which is not what is wrong with it.
+        with pytest.raises(ValidationError, match="plain integer string"):
+            _minimal_decision(supersedes="\u0661\u0662")
 
     def test_leading_zeros_rejected(self) -> None:
         with pytest.raises(ValidationError, match="leading zeros"):

--- a/packages/nauro-core/tests/test_parsing.py
+++ b/packages/nauro-core/tests/test_parsing.py
@@ -15,6 +15,7 @@ from nauro_core.parsing import (
     _stem_from_decision_path,
     extract_decision_number,
     first_sentence_end,
+    is_ascii_decimal,
     is_scaffold_project_md,
     scan_decision_references,
     strip_leading_h1,
@@ -57,6 +58,66 @@ class TestExtractDecisionNumber:
 
     def test_decision_without_number_returns_none(self):
         assert extract_decision_number("decision-") is None
+
+
+class TestOnlyAsciiDigitsAreDecisionNumbers:
+    """A decision number is written in ASCII, so it is only read in ASCII.
+
+    ``str.isdigit`` is true across scripts. Some of those characters make
+    ``int`` raise, and the rest name a number whose canonical filename form is
+    ASCII, which no store could have written. Both are read as no number at
+    all, the same answer as any other name that is not a decision.
+    """
+
+    @pytest.mark.parametrize(
+        "identifier",
+        [
+            "\u00b2-x.md",  # superscript two: int() raises on it
+            "\u0661\u0662-y.md",  # Arabic-Indic 12: int() accepts it
+            "\u136912-z.md",  # Ethiopic digit one, then ASCII digits
+            "\u2460-w.md",  # circled digit one
+        ],
+    )
+    def test_a_non_ascii_number_token_is_not_a_decision(self, identifier):
+        assert extract_decision_number(identifier) is None
+
+    @pytest.mark.parametrize("identifier", ["D\u0661\u0662", "d\u00b2", "decision-\u0661\u0662"])
+    def test_a_non_ascii_number_survives_every_prefix_form(self, identifier):
+        assert extract_decision_number(identifier) is None
+
+    @pytest.mark.parametrize(
+        "identifier",
+        [
+            "12\u0661-x.md",  # ASCII 12, then Arabic-Indic 1
+            "12\u0661",
+            "D12\u0661",
+            "decision-12\u0661",
+        ],
+    )
+    def test_a_number_that_continues_in_another_script_is_not_a_decision(self, identifier):
+        # The run used to be cut at the first character it could not read, so
+        # this named decision 12 - and would have contested the real one.
+        assert extract_decision_number(identifier) is None
+
+    def test_a_run_that_ends_on_a_non_digit_keeps_its_old_reading(self):
+        # Long-standing behavior, unchanged here: the number ends where the
+        # digits end, and letters after it are part of the slug.
+        assert extract_decision_number("12x-foo.md") == 12
+        assert extract_decision_number("042-some-title.md") == 42
+
+    def test_a_footnote_marker_after_the_number_is_where_it_ends(self):
+        # A superscript is not a digit int() accepts, so it never continues a
+        # number: in a name it ends one, exactly as a letter does. The scanner
+        # reads "D118\u00b9" as 118 for the same reason.
+        assert extract_decision_number("12\u00b9-x.md") == 12
+        assert scan_decision_references("see D12\u00b9 here", 100) == {12}
+
+    def test_is_ascii_decimal_reads_the_token_not_the_script(self):
+        assert is_ascii_decimal("0042") is True
+        assert is_ascii_decimal("") is False
+        assert is_ascii_decimal("4 2") is False
+        assert is_ascii_decimal("\u0661\u0662") is False
+        assert is_ascii_decimal("\u00b2") is False
 
 
 class TestStripLeadingH1:
@@ -153,6 +214,16 @@ class TestScanDecisionReferences:
 
     def test_lowercase_d_form(self):
         assert scan_decision_references("see d70 there", 100) == {70}
+
+    def test_a_reference_that_continues_in_another_script_is_not_read(self):
+        # Same rule as the identifier reader: the digit run is cut at the first
+        # character it cannot read, so this used to register decision 12.
+        assert scan_decision_references("see D12\u0661 here", 100) == set()
+        assert scan_decision_references("per decision-12\u0661 there", 100) == set()
+
+    def test_a_reference_that_ends_on_a_non_digit_keeps_its_old_reading(self):
+        # Long-standing behavior, unchanged here.
+        assert scan_decision_references("see D12x here", 100) == {12}
 
     def test_prefix_collision_full_run_read(self):
         # The only "D1" in the body is the prefix of "D118"; reading the whole

--- a/packages/nauro-core/tests/test_questions.py
+++ b/packages/nauro-core/tests/test_questions.py
@@ -593,6 +593,35 @@ class TestParseQForm:
         )
         assert OpenQuestionsFile.parse(content).format() == content
 
+    def test_non_ascii_q_number_is_not_an_entry(self):
+        """A non-ASCII id is not an entry this file could have written.
+
+        The superscript form used to raise out of the parser; the Arabic-Indic
+        form used to parse as 12 and take that id.
+        """
+        for identifier in ("Q\u00b2", "Q\u0661\u0662"):
+            file = OpenQuestionsFile.parse(f"# Open Questions\n\n- [{identifier}] body\n")
+            assert file.open_ids == []
+            assert [b for b in file.blocks if isinstance(b, EntryBlock)] == []
+
+    def test_non_ascii_resolver_number_does_not_resolve(self):
+        content = "# Open Questions\n\n- [Resolved by D\u0661\u0662 on 2026-05-19] [Q3] body\n"
+        file = OpenQuestionsFile.parse(content)
+        entry_blocks = [b for b in file.blocks if isinstance(b, EntryBlock)]
+        assert entry_blocks == [] or entry_blocks[0].entry.resolved_by is None
+
+    def test_a_mixed_script_q_number_is_not_an_entry(self):
+        # The id readers test the whole token, so a number that continues in
+        # another script was already refused. Pinned so it stays that way.
+        file = OpenQuestionsFile.parse("# Open Questions\n\n- [Q12\u0661] body\n")
+        assert file.open_ids == []
+
+    def test_a_mixed_script_resolver_number_does_not_resolve(self):
+        content = "# Open Questions\n\n- [Resolved by D12\u0661 on 2026-05-19] [Q3] body\n"
+        file = OpenQuestionsFile.parse(content)
+        entry_blocks = [b for b in file.blocks if isinstance(b, EntryBlock)]
+        assert entry_blocks == [] or entry_blocks[0].entry.resolved_by is None
+
     def test_mixed_grammar_parse(self):
         """Both id forms parse from a single file."""
         content = (

--- a/packages/nauro-core/tests/test_renderers.py
+++ b/packages/nauro-core/tests/test_renderers.py
@@ -17,6 +17,7 @@ from nauro_core.operations.diff_since_last_session import (
     ONE_SNAPSHOT_COVERS_RANGE,
 )
 from nauro_core.renderers import (
+    _id_to_label,
     render_check_decision,
     render_diff_since_last_session,
     render_get_context,
@@ -996,3 +997,19 @@ class TestRenderDiffSinceLastSession:
             "reason_code": "connected_record_missing",
         }
         assert render_diff_since_last_session(result) == result["guidance"]
+
+
+class TestIdToLabel:
+    def test_ascii_id_becomes_a_label(self):
+        assert _id_to_label("decision-145") == "D145"
+
+    def test_a_non_ascii_number_falls_back_to_the_raw_id(self):
+        # str.isdigit passes these; int() raises on the first one and reads the
+        # second as 12, a number no id here could have been written with.
+        assert _id_to_label("decision-\u00b2") == "decision-\u00b2"
+        assert _id_to_label("decision-\u0661\u0662") == "decision-\u0661\u0662"
+
+    def test_a_mixed_script_number_falls_back_to_the_raw_id(self):
+        # The suffix is tested whole, so a number that continues in another
+        # script was already refused rather than cut short.
+        assert _id_to_label("decision-12\u0661") == "decision-12\u0661"

--- a/packages/nauro/tests/test_sync/test_collisions.py
+++ b/packages/nauro/tests/test_sync/test_collisions.py
@@ -110,6 +110,7 @@ class TestHeadingPrimitives:
             "١٢٣",  # Arabic-Indic 123
             "፩",  # Ethiopic digit one
             "①",  # circled digit one
+            "12١",  # ASCII 12 continuing in another script
         ],
     )
     def test_a_non_ascii_digit_heading_claims_no_number(self, digits):

--- a/packages/nauro/tests/test_sync/test_pull.py
+++ b/packages/nauro/tests/test_sync/test_pull.py
@@ -587,6 +587,80 @@ class TestAdoptionSiblings:
         assert any("letter case" in warning for warning in reporter.warns)
 
 
+class TestNonAsciiFilenameNumbers:
+    """A local file whose name carries a non-ASCII number is not a decision.
+
+    The corpus reads a number from every name in the directory, and the read
+    used to raise on a character that ``str.isdigit`` accepts but ``int`` does
+    not. That happens while the pull is still planning, before the lock and
+    before the per-file guard, so one such file aborted the whole sync.
+    """
+
+    def test_a_file_with_a_non_ascii_number_does_not_crash_the_pull(self, collision_store):
+        stray = collision_store / "decisions" / "\u00b2-x.md"
+        stray.parent.mkdir(parents=True, exist_ok=True)
+        stray.write_bytes(decision_bytes(2, "Stray"))
+
+        merged, reporter = pull(
+            collision_store, [("decisions/017-fine.md", decision_bytes(17, "Fine"))]
+        )
+
+        assert merged == 1
+        assert (collision_store / "decisions/017-fine.md").exists()
+        assert stray.read_bytes() == decision_bytes(2, "Stray")
+        assert reporter.warns == []
+
+    def test_it_claims_no_number_so_a_remote_decision_still_installs(self, collision_store):
+        # An Arabic-Indic name reads as 12 to the old parser, which would have
+        # made this file a collider for a number it does not spell.
+        stray = collision_store / "decisions" / "\u0661\u0662-y.md"
+        stray.parent.mkdir(parents=True, exist_ok=True)
+        stray.write_bytes(decision_bytes(12, "Stray"))
+
+        merged, _reporter = pull(
+            collision_store, [("decisions/012-remote.md", decision_bytes(12, "Remote"))]
+        )
+
+        assert merged == 1
+        assert (collision_store / "decisions/012-remote.md").exists()
+        assert stray.read_bytes() == decision_bytes(12, "Stray")
+
+    def test_a_number_continuing_in_another_script_contests_nothing(self, collision_store):
+        # The reader used to stop at the character it could not read and call
+        # this decision 12, so it contested a real decision it does not name.
+        stray = collision_store / "decisions" / "12\u0661-x.md"
+        stray.parent.mkdir(parents=True, exist_ok=True)
+        stray.write_bytes(decision_bytes(12, "Stray"))
+
+        corpus = DecisionCorpus.scan(collision_store)
+        assert corpus.holders(12) == ()
+        assert "12\u0661-x.md" not in {entry.path.name for entry in corpus.files}
+
+        merged, _reporter = pull(
+            collision_store, [("decisions/012-remote.md", decision_bytes(12, "Remote"))]
+        )
+
+        assert merged == 1
+        assert (collision_store / "decisions/012-remote.md").exists()
+        assert stray.read_bytes() == decision_bytes(12, "Stray")
+
+    def test_the_corpus_scan_skips_it(self, collision_store):
+        stray = collision_store / "decisions" / "\u00b2-x.md"
+        stray.parent.mkdir(parents=True, exist_ok=True)
+        stray.write_bytes(decision_bytes(2, "Stray"))
+
+        corpus = DecisionCorpus.scan(collision_store)
+
+        assert "\u00b2-x.md" not in {entry.path.name for entry in corpus.files}
+        # A plain skip, not an irregular entry: those exist to hold back a
+        # remote decision claiming the number a name occupies, and this name
+        # claims none.
+        assert corpus.irregular == ()
+        # It is still a name the store knows about, so a remote file cannot
+        # land on it unseen.
+        assert corpus.has_name("\u00b2-x.md") is True
+
+
 class TestIrregularEntries:
     """A directory or symlink named like a decision is never read or changed."""
 


### PR DESCRIPTION
## Why

The reader of decision identifiers accepted digits from all scripts. It used
`str.isdigit`, then `int`. These 2 tests do not agree.

Some characters pass `isdigit`, but `int` refuses them. A superscript digit is
one example. A file named `decisions/²-x.md` made the corpus scan raise. The
scan runs when a pull makes its plan. This is before the lock, and before the
per-file guard. Thus 1 file stopped a full `nauro sync` with a traceback.

Other characters pass both tests. Arabic-Indic digits are one example. A file
named `decisions/١٢-y.md` read as number 12. This store writes the number 12 as
ASCII in a filename. Thus the value and the name can never agree again.

The question parser had the same 2 shapes. A hand-written `[Q²]` in
`open-questions.md` raised a ValueError from the parser. Callers can supply a
question reference to the hosted tools, so a caller could reach that error. The
parser gives no such promise: it must degrade to an unparsable block. A
reference like `D٧٠` did the other thing. It resolved to decision 70 in
silence, although no writer here wrote that reference.

The same defect in decision headings shipped in an earlier change. This change
closes the filename side, and the question side.

## What changed

There is now 1 test for a valid number token: `is_ascii_decimal`. It accepts a
non-empty run of ASCII decimal digits only. It uses the digit set that the
body-reference scanner already used. That scanner was correct before this
change.

These readers now use the shared test:

- the identifier reader, for filenames and ids
- the H1 pattern in the decision parser
- the validator for supersession references
- the question id reader and its resolver reference
- the label renderer for `decision-145`

The readers judge the full number token. Before, the identifier reader and the
body-reference scanner read only the first ASCII digits. Thus a name like
`12١-x.md` read as decision 12, and it contested the real decision 12. If a
number token continues in a different script, the readers now find no number.

A token that stops at a character that is not a digit keeps its old behavior.
The number ends there. Thus `12x-foo.md` still reads 12. A superscript is not a
digit that `int` accepts, so it also ends a number. Thus a footnote mark after
a reference, as in `D118¹`, still reads as decision 118.

If a name has a number in a different script, the reader returns no number. It
does not raise. This is the same answer that a name like `notes.md` gets. The
corpus scan then skips the name, and reports nothing about it. Silence is
correct here. The scan reports an unreadable name only because such a name
holds back a remote decision that claims its number. A name with no number
claims nothing.

The 2 question cases now degrade through paths that exist already. A bad
question id gives a rejected envelope that names the id. A bad resolver
reference gives the unknown-question guidance.

## Test plan

Write the tests first. Each new test failed before the change.

- The identifier reader returns no number for 4 filename forms and 3 prefix
  forms with non-ASCII digits.
- The identifier reader returns no number for 4 mixed-script forms, such as
  `12١-x.md` and `D12١`.
- The body-reference scanner does not read `D12١` or `decision-12١`.
- The decision parser refuses a heading with Arabic-Indic digits, and a heading
  with a mixed-script number.
- The validator refuses a supersession reference with Arabic-Indic digits.
- The question parser makes no entry from `[Q²]`, `[Q١٢]`, or `[Q12١]`.
- The question parser does not resolve an entry from `D١٢` or `D12١`.
- The label renderer returns the raw id for a non-ASCII id and for a
  mixed-script id.
- A pull completes if the store holds `decisions/²-x.md`. The file stays as it
  is. There are no warnings.
- The corpus scan skips such a file, keeps the name, and lists no irregular
  entry.
- A file named `decisions/12١-x.md` holds no number, so a remote decision 12
  still installs.
- Scope pins, which passed before this change and still pass: `12x-foo.md`
  reads 12, `D12x` reads 12, `12¹-x.md` reads 12, and `D118¹` reads 118.

Results:

- `pytest packages/nauro-core/tests/` - 1526 passed
- `pytest packages/nauro/tests/` - 2483 passed, 10 skipped
- `ruff check` and `ruff format --check` - clean

## Risk

The H1 pattern used `\d`. In Python, `\d` matches digits from all scripts. The
pattern now uses `[0-9]`. This is a deliberate change of behavior, not a
cleanup. Before this change, a decision file with a heading number in a
different script parsed without an error. The parser reads the number from the
filename, and does not use the number from the heading. Such a file now fails
to parse. It raises the same error as a file with no heading. `nauro doctor`
reports it in the existing unparseable category. This is correct: a heading
number that the filename can never carry is malformed data.

The change also makes other readers stricter. Files that parsed before can now
fail to parse. Each such file has a number that this store could not have
written.

## Deferred

`strip_number_prefix` in the sync package still removes a non-ASCII digit
prefix from a filename, although the number readers now refuse such a prefix.
There is no defect that a caller can reach. Colliders and the slug repair build
their names only from files in the corpus, and the corpus no longer holds such
a file. This is the last digit reader that is not aligned.

The sync package also keeps its own copy of the ASCII test, for headings. The 2
copies agree. To use 1 copy in both packages, a version floor must change. Do
the floor change, this consolidation, and `strip_number_prefix` together in a
separate change.
