### PR TITLE
Carry degraded post-commit steps to the stdio surface and write backups atomically

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/sync.py
+++ b/packages/nauro/src/nauro/cli/commands/sync.py
@@ -8,6 +8,7 @@ from nauro.cli.commands.auth import load_access_token
 from nauro.cli.integrations.outcomes import BridgeOutcome
 from nauro.cli.integrations.render import render
 from nauro.cli.utils import resolve_target_project
+from nauro.store._atomic import is_tmp_sibling
 from nauro.store.registry import is_cloud_project
 from nauro.store.snapshot import capture_snapshot
 from nauro.store.validator import print_warnings, validate_store
@@ -195,7 +196,13 @@ def _show_status(project_flag: str | None) -> None:
     if backup_dir.exists():
         # Quarantine backups live in the same directory but are already
         # reported above; counting them again would double-report one event.
+        # A tmp sibling stranded by a kill mid-write is not a backup at all,
+        # and reporting one would name a conflict that never happened.
         quarantine_names = {item.backup_path.name for item in list_quarantine_backups(store_path)}
-        backups = [path for path in backup_dir.iterdir() if path.name not in quarantine_names]
+        backups = [
+            path
+            for path in backup_dir.iterdir()
+            if path.name not in quarantine_names and not is_tmp_sibling(path.name)
+        ]
         if backups:
             typer.echo(f"  Conflict backups: {len(backups)}")

--- a/packages/nauro/src/nauro/mcp/stdio_server.py
+++ b/packages/nauro/src/nauro/mcp/stdio_server.py
@@ -63,6 +63,7 @@ from nauro.mcp.tools import (
 )
 from nauro.onboarding import WELCOME_NO_PROJECT
 from nauro.store.journal import OriginDescriptor
+from nauro.store.post_commit import with_assessment
 from nauro.store.repo_head import resolve_repo_head
 from nauro.store.resolution import (
     DisconnectedProject,
@@ -480,10 +481,10 @@ def flag_question(
         reason = str(error.get("reason", "Flag rejected."))
         return reason
     if resolved_by is not None:
-        return "Question(s) resolved."
+        return with_assessment("Question(s) resolved.", result)
     if result.get("hint"):
-        return f"{result['hint']} The question has still been logged."
-    return "Question flagged."
+        return with_assessment(f"{result['hint']} The question has still been logged.", result)
+    return with_assessment("Question flagged.", result)
 
 
 @mcp.tool(**_spec_kwargs("update_state"))
@@ -500,8 +501,8 @@ def update_state(
         return err if disconnected_reason_code(err) is not None else err["guidance"]
     result = tool_update_state(store_path, delta, origin=_origin_from_ctx(mcp_ctx))
     if result.get("warning"):
-        return f"State updated. {result['warning']}"
-    return "State updated."
+        return with_assessment(f"State updated. {result['warning']}", result)
+    return with_assessment("State updated.", result)
 
 
 def _pull_on_startup() -> None:

--- a/packages/nauro/src/nauro/store/post_commit.py
+++ b/packages/nauro/src/nauro/store/post_commit.py
@@ -180,3 +180,19 @@ def surface_post_commit(
     existing = envelope.get(ASSESSMENT_FIELD)
     envelope[ASSESSMENT_FIELD] = "\n\n".join([existing, *notes] if existing else notes)
     return envelope
+
+
+def with_assessment(message: str, envelope: dict) -> str:
+    """Return ``message`` carrying the envelope's assessment text, if it has any.
+
+    The counterpart of :func:`surface_post_commit` for a transport that renders
+    a write envelope down to a single string. Putting a degraded step in the
+    envelope is only half the job: a surface that then reports its own fixed
+    confirmation drops it again, one layer further out, and the agent is told
+    the write succeeded and nothing else.
+
+    A message with nothing to add comes back unchanged, so a clean run's wire
+    string stays exactly what it was.
+    """
+    assessment = envelope.get(ASSESSMENT_FIELD)
+    return f"{message}\n\n{assessment}" if assessment else message

--- a/packages/nauro/src/nauro/sync/merge.py
+++ b/packages/nauro/src/nauro/sync/merge.py
@@ -9,7 +9,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from nauro.graph import DEFAULT_GRAPH_FILENAME
-from nauro.store._atomic import is_tmp_sibling
+from nauro.store._atomic import atomic_write_bytes, is_tmp_sibling
 from nauro.store.journal import JOURNAL_DIR
 from nauro.store.store_lock import DIR_LOCK_NAME, RMW_LOCK_SUFFIX
 from nauro.sync.state import SyncState
@@ -103,11 +103,17 @@ def write_backup(project_path: Path, backup_name: str, content: bytes) -> Path:
     The single writer into the backup directory: the last-write-wins loser
     below names its file by timestamp, the quarantined remote decision in
     ``sync.quarantine`` names its file by remote version.
+
+    Written atomically, like everything else the pull lands. This file is the
+    only copy of content the pull declined to install, and the quarantine
+    writer keeps an existing backup for a remote version rather than writing it
+    again - so a half-written one would never be corrected, and what it was
+    holding would be gone.
     """
     backup_dir = project_path / CONFLICT_BACKUP_DIR
     backup_dir.mkdir(parents=True, exist_ok=True)
     backup_path = backup_dir / backup_name
-    backup_path.write_bytes(content)
+    atomic_write_bytes(backup_path, content)
     logger.info("Conflict backup saved: %s", backup_path)
     return backup_path
 

--- a/packages/nauro/tests/test_flag_question_parity.py
+++ b/packages/nauro/tests/test_flag_question_parity.py
@@ -70,13 +70,6 @@ def _cli_envelope(args: list[str]) -> tuple[int, dict | None, str]:
     return result.exit_code, envelope, result.output
 
 
-def _render_stdio_string(envelope: dict) -> str:
-    """Mirror the stdio surface's dict-to-string rendering rule."""
-    if envelope.get("hint"):
-        return f"{envelope['hint']} The question has still been logged."
-    return "Question flagged."
-
-
 def test_ok_envelope_matches_across_tool_and_cli(seeded_repo):
     pid, store_path = seeded_repo
 
@@ -90,7 +83,7 @@ def test_ok_envelope_matches_across_tool_and_cli(seeded_repo):
     assert cli_envelope == {"store": "local", "status": "ok"}
 
     stdio_string = stdio_flag_question(question="Should we ship Z?", project_id=pid)
-    assert stdio_string == _render_stdio_string({"status": "ok"})
+    assert stdio_string == "Question flagged."
 
 
 def test_missing_store_guidance_matches_across_surfaces(missing_store):
@@ -213,3 +206,79 @@ def test_neither_question_nor_resolved_by_rejects_across_tool_and_cli(seeded_rep
     exit_code, cli_envelope, output = _cli_envelope([])
     assert exit_code == 0, output
     assert cli_envelope == tool_envelope
+
+
+def _raise_oserror(*_args: object, **_kwargs: object) -> int:
+    raise OSError("disk full")
+
+
+class TestStdioCarriesTheAssessment:
+    """The flat stdio string must say what the envelope says.
+
+    The adapter reports a degraded snapshot, regeneration, or push in the
+    envelope's ``assessment``. This transport renders the envelope down to one
+    string, so anything it does not read is lost for good.
+    """
+
+    def test_a_degraded_append_names_the_step(self, seeded_repo, monkeypatch):
+        pid, _store_path = seeded_repo
+        monkeypatch.setattr("nauro.store.post_commit.capture_snapshot", _raise_oserror)
+
+        stdio_string = stdio_flag_question(question="Should we ship X?", project_id=pid)
+
+        assert stdio_string.startswith("Question flagged.")
+        assert "snapshot capture failed" in stdio_string
+        assert "disk full" in stdio_string
+
+    def test_a_degraded_resolve_names_the_step(self, seeded_repo, monkeypatch):
+        pid, store_path = seeded_repo
+        _seed_resolvable(store_path, "Q1")
+        monkeypatch.setattr("nauro.store.post_commit.capture_snapshot", _raise_oserror)
+
+        stdio_string = stdio_flag_question(resolved_by="D42", targets=["Q1"], project_id=pid)
+
+        assert stdio_string.startswith("Question(s) resolved.")
+        assert "snapshot capture failed" in stdio_string
+
+    @staticmethod
+    def _with_hint(monkeypatch) -> None:
+        """Force the similar-decision hint branch, which needs a scoring stub."""
+        monkeypatch.setattr(
+            mcp_tools,
+            "check_bm25_similarity",
+            lambda *_args, **_kwargs: (
+                "needs_review",
+                [{"number": 7, "title": "Existing decision", "similarity": 0.9}],
+            ),
+        )
+
+    def test_a_degraded_hint_branch_names_the_step(self, seeded_repo, monkeypatch):
+        pid, _store_path = seeded_repo
+        self._with_hint(monkeypatch)
+        monkeypatch.setattr("nauro.store.post_commit.capture_snapshot", _raise_oserror)
+
+        stdio_string = stdio_flag_question(question="Should we cache hot reads?", project_id=pid)
+
+        assert "The question has still been logged." in stdio_string
+        assert "snapshot capture failed" in stdio_string
+
+    def test_a_clean_hint_branch_is_byte_identical(self, seeded_repo, monkeypatch):
+        pid, store_path = seeded_repo
+        self._with_hint(monkeypatch)
+        envelope = tool_flag_question(store_path, "Should we cache hot reads?")
+        assert envelope["hint"]
+
+        stdio_string = stdio_flag_question(question="Should we cache hot reads?", project_id=pid)
+
+        assert stdio_string == f"{envelope['hint']} The question has still been logged."
+
+    def test_a_clean_run_is_byte_identical(self, seeded_repo):
+        pid, store_path = seeded_repo
+
+        assert stdio_flag_question(question="Should we ship X?", project_id=pid) == (
+            "Question flagged."
+        )
+        _seed_resolvable(store_path, "Q1")
+        assert stdio_flag_question(resolved_by="D42", targets=["Q1"], project_id=pid) == (
+            "Question(s) resolved."
+        )

--- a/packages/nauro/tests/test_propose_decision_parity.py
+++ b/packages/nauro/tests/test_propose_decision_parity.py
@@ -427,3 +427,28 @@ def test_confirmed_regen_preserves_unmanaged_agents_md(seeded_repo, monkeypatch)
     assert envelope["status"] == "confirmed"
     assert (repo / "AGENTS.md").read_bytes() == sentinel
     assert "existing AGENTS.md is not Nauro-generated" in envelope["assessment"]
+
+
+def test_stdio_propose_decision_keeps_the_degraded_step_in_the_envelope(seeded_repo, monkeypatch):
+    """This wrapper returns the envelope itself, so nothing has to be re-read.
+
+    Pinned because the two flat-string write wrappers next to it dropped the
+    same field, and a later refactor could flatten this one too.
+    """
+    pid, _store_path = seeded_repo
+
+    def _boom(*_args: object, **_kwargs: object) -> int:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(post_commit_module, "capture_snapshot", _boom)
+
+    envelope = stdio_propose_decision(
+        title="Use Redis for hot caching",
+        rationale="In-memory cache for the hot read paths across the API tier.",
+        confidence="medium",
+        project_id=pid,
+    )
+
+    assert isinstance(envelope, dict)
+    assert envelope["status"] == "confirmed"
+    assert "snapshot capture failed" in envelope["assessment"]

--- a/packages/nauro/tests/test_sync/test_merge.py
+++ b/packages/nauro/tests/test_sync/test_merge.py
@@ -1,14 +1,17 @@
 """Tests for nauro.sync.merge."""
 
+import pytest
 from nauro_core.decision_model import parse_decision
 
 from nauro.store import _atomic
 from nauro.store._atomic import atomic_write_bytes
 from nauro.sync.merge import (
+    CONFLICT_BACKUP_DIR,
     _set_union_markdown,
     detect_conflict,
     resolve_conflict,
     should_skip,
+    write_backup,
 )
 from nauro.sync.state import FileState, SyncState
 
@@ -482,3 +485,37 @@ class TestSetUnionMarkdown:
         assert result.count("- old-entry") == 1
         assert result.count("- old-resolved") == 1
         assert result.count("- old-active") == 1
+
+
+class TestWriteBackupIsAtomic:
+    """The backup is the only copy of the bytes the pull declined to install.
+
+    The quarantine writer skips a backup that already exists, keyed by remote
+    version. A truncated file under the right name is therefore never rewritten,
+    and the content it was holding is gone.
+    """
+
+    def test_a_dead_write_leaves_no_backup_at_all(self, tmp_path, monkeypatch):
+        def boom(src, dst):
+            raise OSError(28, "No space left on device")
+
+        monkeypatch.setattr(_atomic.os, "replace", boom)
+
+        with pytest.raises(OSError):
+            write_backup(tmp_path, "20260810T000000Z-stack.md", b"the whole remote file\n")
+
+        backup_dir = tmp_path / CONFLICT_BACKUP_DIR
+        assert list(backup_dir.iterdir()) == []
+
+    def test_a_dead_rewrite_leaves_the_existing_backup_whole(self, tmp_path, monkeypatch):
+        first = write_backup(tmp_path, "20260810T000000Z-stack.md", b"the first copy\n")
+
+        def boom(src, dst):
+            raise OSError(28, "No space left on device")
+
+        monkeypatch.setattr(_atomic.os, "replace", boom)
+        with pytest.raises(OSError):
+            write_backup(tmp_path, "20260810T000000Z-stack.md", b"short")
+
+        assert first.read_bytes() == b"the first copy\n"
+        assert list((tmp_path / CONFLICT_BACKUP_DIR).iterdir()) == [first]

--- a/packages/nauro/tests/test_sync/test_pull.py
+++ b/packages/nauro/tests/test_sync/test_pull.py
@@ -1188,6 +1188,51 @@ class TestWriteBarrier:
         assert allowed is True
 
 
+class TestQuarantineBackupSurvivesADeadWrite:
+    """A backup that dies mid-write must not look like a finished one.
+
+    The quarantine writer skips a backup that already exists for the same
+    remote version, so a truncated file under the right name would be kept
+    forever - and it is the only copy of the bytes the pull declined to
+    install.
+    """
+
+    def _quarantining_pull(self, store, reporter=None):
+        remote = decision_bytes(3, "Remote decision", "Chose B.")
+        return pull(store, [("decisions/003-remote.md", remote)], reporter=reporter)
+
+    def test_the_next_pull_writes_the_backup_the_dead_write_did_not(
+        self, collision_store, monkeypatch
+    ):
+        write_local_decision(collision_store, "003-local.md", decision_bytes(3, "Local decision"))
+        track(collision_store, "decisions/003-local.md")
+        backup_dir = collision_store / ".conflict-backup"
+        real_replace = os.replace
+        dying = {"first run"}
+
+        def die_on_backup(src, dst, **kwargs):
+            if Path(dst).parent.name == ".conflict-backup" and dying:
+                dying.clear()
+                raise OSError(28, "No space left on device")
+            return real_replace(src, dst, **kwargs)
+
+        monkeypatch.setattr("nauro.store._atomic.os.replace", die_on_backup)
+
+        merged, reporter = self._quarantining_pull(collision_store)
+
+        assert merged == 0
+        # No half-written evidence, and the run said something about it.
+        assert entry_names(backup_dir) == set()
+        assert reporter.warns
+
+        merged, _reporter = self._quarantining_pull(collision_store)
+
+        assert merged == 0
+        backups = [path for path in backup_dir.iterdir()]
+        assert len(backups) == 1
+        assert backups[0].read_bytes() == decision_bytes(3, "Remote decision", "Chose B.")
+
+
 class TestBackupIdentity:
     def test_two_spellings_of_one_path_keep_separate_backups(self, collision_store):
         """On a case-folding filesystem a name derived from the path alone

--- a/packages/nauro/tests/test_sync/test_sync_status.py
+++ b/packages/nauro/tests/test_sync/test_sync_status.py
@@ -8,6 +8,7 @@ authenticated → server URL + per-project sync info; not authenticated →
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from unittest.mock import patch
 
 from typer.testing import CliRunner
 
@@ -185,3 +186,33 @@ class TestQuarantinedCollisions:
         result = runner.invoke(app, ["sync", "--status"])
         assert result.exit_code == 0, result.output
         assert "Conflict backups: 1" in result.output
+
+    def test_an_orphaned_tmp_sibling_is_not_counted(self, tmp_path, monkeypatch):
+        """A kill between the tmp write and the replace strands a sibling.
+
+        It lands in the same directory as the backups, under a name nothing
+        reads. It is not a backup, and reporting it as one would tell the user
+        a conflict happened that did not.
+        """
+        from nauro.store import _atomic
+        from nauro.sync.merge import write_backup
+
+        store = _scaffold(repo=tmp_path)
+        save_config(
+            {
+                "auth": {
+                    "sub": "auth0|test",
+                    "access_token": "tok_orig",
+                    "refresh_token": "refresh_orig",
+                }
+            }
+        )
+        monkeypatch.chdir(tmp_path)
+        with patch.object(_atomic.os, "replace", lambda src, dst: None):
+            write_backup(store, "20260810T000000Z-project.md", b"losing side\n")
+        assert [path.name for path in (store / ".conflict-backup").iterdir()] != []
+
+        result = runner.invoke(app, ["sync", "--status"])
+
+        assert result.exit_code == 0, result.output
+        assert "Conflict backups" not in result.output

--- a/packages/nauro/tests/test_update_state_parity.py
+++ b/packages/nauro/tests/test_update_state_parity.py
@@ -98,15 +98,6 @@ def _cli_envelope(args: list[str]) -> tuple[int, dict | None, str]:
     return result.exit_code, envelope, result.output
 
 
-def _render_stdio_string(envelope: dict) -> str:
-    """Mirror the stdio surface's dict-to-string rendering rule."""
-    if envelope.get("status") == "error":
-        return envelope.get("guidance", "")
-    if envelope.get("warning"):
-        return f"State updated. {envelope['warning']}"
-    return "State updated."
-
-
 def test_ok_envelope_matches_across_tool_and_cli(seeded_repo):
     pid, store_path = seeded_repo
 
@@ -122,7 +113,7 @@ def test_ok_envelope_matches_across_tool_and_cli(seeded_repo):
     assert cli_envelope == {"store": "local", "status": "ok"}
 
     stdio_string = stdio_update_state(delta="Shipped the stdio surface", project_id=pid)
-    assert stdio_string == _render_stdio_string({"status": "ok"})
+    assert stdio_string == "State updated."
 
 
 def test_warning_envelope_matches_across_tool_and_cli(overlap_repo):
@@ -146,7 +137,8 @@ def test_warning_envelope_matches_across_tool_and_cli(overlap_repo):
         delta="Implemented OAuth refresh logic with PKCE",
         project_id=pid,
     )
-    assert stdio_string == _render_stdio_string(tool_envelope)
+    # The warning branch, clean: the kernel's advisory and nothing else.
+    assert stdio_string == f"State updated. {tool_envelope['warning']}"
 
 
 def test_missing_store_guidance_matches_across_surfaces(missing_store):
@@ -178,3 +170,40 @@ def test_length_rejection_matches_across_tool_and_cli(seeded_repo):
     # but still carries the rejection reason in the printed envelope.
     assert exit_code == 0, output
     assert cli_envelope == tool_envelope
+
+
+def _raise_oserror(*_args: object, **_kwargs: object) -> int:
+    raise OSError("disk full")
+
+
+class TestStdioCarriesTheAssessment:
+    """The flat stdio string must say what the envelope says."""
+
+    def test_a_degraded_run_names_the_step(self, seeded_repo, monkeypatch):
+        pid, _store_path = seeded_repo
+        monkeypatch.setattr("nauro.store.post_commit.capture_snapshot", _raise_oserror)
+
+        stdio_string = stdio_update_state(delta="Shipped the caching layer.", project_id=pid)
+
+        assert stdio_string.startswith("State updated.")
+        assert "snapshot capture failed" in stdio_string
+        assert "disk full" in stdio_string
+
+    def test_the_kernel_warning_and_the_degraded_step_both_survive(self, overlap_repo, monkeypatch):
+        pid, _store_path = overlap_repo
+        monkeypatch.setattr("nauro.store.post_commit.capture_snapshot", _raise_oserror)
+
+        stdio_string = stdio_update_state(
+            delta="Implemented OAuth refresh logic with PKCE", project_id=pid
+        )
+
+        assert stdio_string.startswith("State updated. ")
+        assert "keywords" in stdio_string.lower()
+        assert "snapshot capture failed" in stdio_string
+
+    def test_a_clean_run_is_byte_identical(self, seeded_repo):
+        pid, _store_path = seeded_repo
+
+        assert stdio_update_state(delta="Shipped the stdio surface", project_id=pid) == (
+            "State updated."
+        )


### PR DESCRIPTION
## Why

An earlier change made the MCP write tools report a degraded post-commit step.
A snapshot capture, an `AGENTS.md` regeneration, or a cloud push can fail after
the write itself is safely recorded. Before that change, the only record was a
debug log line. No local installation configures logging. Thus nothing was
reported.

That change put the report in the envelope, in the `assessment` field. The
stdio transport then removed it again. The `flag_question` and `update_state`
wrappers make one fixed string from the envelope. Neither string read the new
field. This is the same defect, one layer further out: the agent hears that the
write was successful, and hears nothing else. These are the 2 tools that an
agent calls most.

The second defect is in the backup directory. That directory holds the only
copy of content that a pull did not install. There are 2 such copies: the side
that loses a last-write-wins conflict, and the remote decision behind a
quarantined number collision. The backup was written with a plain write, which
first makes the file empty. If that write stops in the middle, a short file
stays under the correct name. Nothing corrects it. For a quarantine, the writer
keeps a backup that exists already for that remote version. Thus the short file
becomes the record, and the bytes are lost.

## What changed

There is now 1 helper that puts an envelope and a message together into 1 wire
string. If the envelope has assessment text, the helper adds it after the
message. If it does not, the helper gives back the message without a change.

Both stdio write wrappers use the helper. This applies to all 3 branches of
`flag_question` and to both branches of `update_state`. If nothing degraded,
each string stays the same, byte for byte.

The `propose_decision` wrapper gives back the envelope itself. It loses
nothing, and it did not change. It has a new test, so that a later change
cannot make it flat without a failure.

The backup writer now uses the atomic write primitive. This is the primitive
that the rest of the pull uses. Thus a backup file is complete, or it is not
there. If it is not there, the next sync writes it, because the writer finds no
backup to keep.

A stopped write can leave a temporary file in the backup directory. Such a file
is not a backup. `nauro sync --status` now does not count it, because a count
of 1 would name a conflict that did not occur.

## Test plan

Write the tests first. Each new test of a defect failed before the change.

- A degraded snapshot on the `flag_question` append leg puts the step name in
  the stdio string.
- A degraded snapshot on the `flag_question` resolve leg does the same.
- A degraded snapshot on the `flag_question` hint leg does the same.
- A degraded snapshot on `update_state` does the same.
- The kernel warning about keywords and the degraded step are both in the
  `update_state` string.
- If nothing degrades, each of the 5 strings is the same as before, byte for
  byte. This covers all 3 `flag_question` branches and both `update_state`
  branches.
- A degraded snapshot stays in the `propose_decision` envelope.
- If a backup write stops in the middle, there is no backup file.
- If a rewrite stops in the middle, the backup that exists stays complete.
- A quarantine whose backup write stops leaves the directory empty, and the
  next pull writes the complete backup.
- `nauro sync --status` does not count a stranded temporary file.

The tests no longer hold a copy of the rule that makes the stdio string. Such a
copy passed while the real rule changed under it. Each test now compares
against the text it expects, or against the envelope field that supplies it.

Results:

- `pytest packages/nauro-core/tests/` - 1526 passed
- `pytest packages/nauro/tests/` - 2496 passed, 10 skipped
- `ruff check` and `ruff format --check` - clean

## Risk

The stdio strings are longer when a step degrades. This is the purpose of the
change. A client that compares these strings to fixed text will see a
difference, but only after a failure, and such a client is already wrong.

The clean strings do not change. The tests hold all 5 of them byte for byte.

The backup write can now raise an error where the old write did not, because
the atomic write does more steps. The pull already holds each file write in a
guard. The guard reports the file and continues with the batch.

## Deferred

The 2 stdio write wrappers look only for the status `rejected`. Two other
statuses exist. A store directory that is absent gives the status `error`. An
`update_state` call with no state file to update gives the status `noop`. Both
now render as a string that reports success. This is the same defect class as
the one above, one step over, and it is older than this change. Fix it in a
separate change, with the status handling of all 3 wrappers together.
