### PR TITLE
Restore deleted files on pull, count every refusal, and sweep stranded writes

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/sync.py
+++ b/packages/nauro/src/nauro/cli/commands/sync.py
@@ -1,6 +1,9 @@
 """nauro sync — Capture a snapshot and regenerate AGENTS.md in associated repos."""
 
+from __future__ import annotations
+
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import typer
 
@@ -14,6 +17,9 @@ from nauro.store.snapshot import capture_snapshot
 from nauro.store.validator import print_warnings, validate_store
 from nauro.sync.push import push_store_to_cloud
 from nauro.templates.agents_md_regen import warn_then_regen
+
+if TYPE_CHECKING:  # the pull core pulls in httpx, so it stays off the CLI's import path
+    from nauro.sync.pull import PullReport
 
 # Names retained for callers/tests that import the push helper from this
 # command module; the implementation now lives in ``nauro.sync.push``.
@@ -41,6 +47,10 @@ def sync(
     state_current.md is not touched — use the MCP 'update_state' tool to
     record what changed. After a successful sync, structural store
     validation runs and any warnings are printed at the end.
+
+    Exit codes: 1 for a failure of the command itself (the snapshot, the push,
+    a store lock another sync holds), 2 when everything ran but the pull left
+    files it could not write for the next sync, 0 otherwise.
     """
     if status:
         _show_status(project)
@@ -51,7 +61,7 @@ def sync(
     project_key = store_path.name
     trigger = message or "manual sync"
 
-    _pull_from_cloud(project_key, store_path)
+    pulled = _pull_from_cloud(project_key, store_path)
 
     version = capture_snapshot(store_path, trigger=trigger)
 
@@ -93,17 +103,33 @@ def sync(
     if warnings:
         print_warnings(warnings)
 
+    if pulled.refused:
+        # Exit 2, after everything else ran: the snapshot, the regen, and the
+        # push all succeeded, so this is not the exit-1 failure of the command,
+        # but the store does not hold everything the server has and a script
+        # must not read that as a clean sync.
+        typer.echo(
+            f"Error: {pulled.refused} remote file(s) were not written this sync "
+            "(each one is reported above). Run 'nauro sync' again once the local "
+            "problem is fixed.",
+            err=True,
+        )
+        raise typer.Exit(code=2)
 
-def _pull_from_cloud(project_id: str, store_path: Path) -> int:
+
+def _pull_from_cloud(project_id: str, store_path: Path) -> PullReport:
     """Pull remote changes via the manifest + presign endpoints.
 
     No-op when the project is not v2 cloud-mode (local-mode has no
-    presign target) or when no Auth0 token is configured.
+    presign target) or when no Auth0 token is configured; an empty report
+    says the same thing as a run that found nothing.
     """
+    from nauro.sync.pull import PullReport
+
     if not is_cloud_project(project_id):
-        return 0
+        return PullReport()
     if not load_access_token():
-        return 0
+        return PullReport()
     return _pull_via_presign(project_id, store_path)
 
 
@@ -120,7 +146,7 @@ class _EchoReporter:
         typer.echo(f"  {msg}", err=True)
 
 
-def _pull_via_presign(project_id: str, store_path: Path) -> int:
+def _pull_via_presign(project_id: str, store_path: Path) -> PullReport:
     """GET /sync/manifest → POST /sync/presign → S3 GETs.
 
     Delegates to the shared pull core with an echo reporter. An explicit sync
@@ -184,6 +210,7 @@ def _show_status(project_flag: str | None) -> None:
     else:
         typer.echo("  Pending local changes: none")
 
+    from nauro.sync.merge import CONFLICT_BACKUP_DIR
     from nauro.sync.quarantine import list_quarantine_backups, unresolved_quarantines
 
     quarantined = unresolved_quarantines(store_path, state)
@@ -192,7 +219,7 @@ def _show_status(project_flag: str | None) -> None:
         for item in quarantined:
             typer.echo(f"    - {item.label} (remote copy: {item.backup_path.name})")
 
-    backup_dir = store_path / ".conflict-backup"
+    backup_dir = store_path / CONFLICT_BACKUP_DIR
     if backup_dir.exists():
         # Quarantine backups live in the same directory but are already
         # reported above; counting them again would double-report one event.

--- a/packages/nauro/src/nauro/cli/commands/sync.py
+++ b/packages/nauro/src/nauro/cli/commands/sync.py
@@ -103,18 +103,29 @@ def sync(
     if warnings:
         print_warnings(warnings)
 
-    if pulled.refused:
+    if pulled.left_work_behind:
         # Exit 2, after everything else ran: the snapshot, the regen, and the
         # push all succeeded, so this is not the exit-1 failure of the command,
         # but the store does not hold everything the server has and a script
         # must not read that as a clean sync.
         typer.echo(
-            f"Error: {pulled.refused} remote file(s) were not written this sync "
-            "(each one is reported above). Run 'nauro sync' again once the local "
-            "problem is fixed.",
+            f"Error: {_unfinished_pull_detail(pulled)}. The reason is reported "
+            "above. Run 'nauro sync' again once the problem is fixed.",
             err=True,
         )
         raise typer.Exit(code=2)
+
+
+def _unfinished_pull_detail(report: PullReport) -> str:
+    """Name what the pull left undone, in the terms that run knows it.
+
+    A run that never read the server's file list has no count to give: saying
+    zero files were missed would describe a store that is level with the
+    server, which is the one thing this run cannot claim.
+    """
+    if not report.manifest_read:
+        return "this sync could not read the server's file list, so it pulled nothing"
+    return f"{report.refused} remote file(s) were not written this sync"
 
 
 def _pull_from_cloud(project_id: str, store_path: Path) -> PullReport:

--- a/packages/nauro/src/nauro/sync/hooks.py
+++ b/packages/nauro/src/nauro/sync/hooks.py
@@ -68,12 +68,14 @@ def pull_before_session(project_id: str, store_path: Path) -> int:
         return 0
 
     try:
+        # The merged count only: session start has no exit code to carry a
+        # refusal, and the reporter above has already logged every one.
         return run_pull(
             project_id,
             store_path,
             _LoggingReporter(),
             lock_timeout=HOOK_SYNC_LOCK_TIMEOUT,
-        )
+        ).merged
     except SyncLockTimeoutError as exc:
         # Contention is an ordinary outcome here, not a failure: the other
         # process is doing this same work, and session start never waits.

--- a/packages/nauro/src/nauro/sync/merge.py
+++ b/packages/nauro/src/nauro/sync/merge.py
@@ -6,13 +6,13 @@ how to merge or which version wins.
 
 import logging
 from datetime import datetime, timezone
+from enum import Enum, auto
 from pathlib import Path
 
 from nauro.graph import DEFAULT_GRAPH_FILENAME
 from nauro.store._atomic import atomic_write_bytes, is_tmp_sibling
 from nauro.store.journal import JOURNAL_DIR
 from nauro.store.store_lock import DIR_LOCK_NAME, RMW_LOCK_SUFFIX
-from nauro.sync.state import SyncState
 
 logger = logging.getLogger("nauro.sync")
 
@@ -85,18 +85,6 @@ def should_skip(relative_path: str) -> bool:
     return basename == DIR_LOCK_NAME or normalized.endswith(LOCK_ARTIFACT_SUFFIXES)
 
 
-def detect_conflict(
-    relative_path: str, state: SyncState, local_sha256: str, remote_etag: str
-) -> bool:
-    """Conflict = local SHA256 differs from state AND remote ETag differs from state."""
-    fs = state.files.get(relative_path)
-    if fs is None:
-        return False
-    local_changed = local_sha256 != fs.local_sha256
-    remote_changed = remote_etag != fs.remote_etag
-    return local_changed and remote_changed
-
-
 def write_backup(project_path: Path, backup_name: str, content: bytes) -> Path:
     """Write ``content`` into ``.conflict-backup/`` under ``backup_name``.
 
@@ -125,30 +113,49 @@ def _save_conflict_backup(project_path: Path, relative_path: str, content: bytes
     return write_backup(project_path, f"{timestamp}-{filename}", content)
 
 
+class Side(Enum):
+    """Which copy of a file survives on disk when no merge is defined.
+
+    The caller decides, because the answer is about the path's history rather
+    than its content: a version this store published has an ancestor the two
+    sides share, and one it never published does not.
+    """
+
+    local = auto()
+    remote = auto()
+
+
 def resolve_conflict(
     project_path: Path,
     local_path: Path,
     remote_content: bytes,
     relative_path: str,
+    *,
+    keeps: Side,
 ) -> bytes:
     """Resolve a conflict between local and remote versions.
 
-    Files in ``_SET_UNION_PATHS`` merge by section-aware set-union.
-    Everything else: last-write-wins with backup of the losing version.
+    Files in ``_SET_UNION_PATHS`` merge by section-aware set-union, whatever
+    ``keeps`` asks for: a union drops nothing, so there is no losing side to
+    back up. Everything else keeps the side named and writes the other one to
+    ``.conflict-backup/``, so both versions survive either way.
     """
     local_content = local_path.read_bytes()
 
     if relative_path in _SET_UNION_PATHS:
         return _set_union_markdown(local_content, remote_content)
 
-    # Last-write-wins: keep local, back up remote
-    _save_conflict_backup(project_path, relative_path, remote_content)
-    logger.warning(
-        "Conflict on %s resolved by last-write-wins (kept local). "
-        "Remote version saved to .conflict-backup/",
-        relative_path,
+    loser, winner = (
+        (remote_content, local_content) if keeps is Side.local else (local_content, remote_content)
     )
-    return local_content
+    _save_conflict_backup(project_path, relative_path, loser)
+    logger.warning(
+        "Conflict on %s resolved by last-write-wins (kept %s). "
+        "The other version was saved to .conflict-backup/",
+        relative_path,
+        keeps.name,
+    )
+    return winner
 
 
 def _parse_sections(lines: list[str]) -> tuple[list[str], list[tuple[str, list[str]]]]:

--- a/packages/nauro/src/nauro/sync/pull.py
+++ b/packages/nauro/src/nauro/sync/pull.py
@@ -152,6 +152,10 @@ class _Tally:
     the opposite - a manifest row that resolves outside the store, a path an
     ordinary pull may not write, a quarantined collision - and retrying changes
     nothing about it, so it is reported and nothing more.
+
+    Both count manifest rows this run was asked to install, and only those.
+    Local files that were already irregular are the store's own hygiene: they
+    are warned about on every run and belong in neither count.
     """
 
     merged: int = 0
@@ -255,6 +259,7 @@ class _Destination:
     inside_store: bool
     inside_decisions: bool
     is_directory: bool
+    exists: bool
 
 
 def resolve_destination(store_path: Path, rel: str) -> _Destination:
@@ -283,6 +288,7 @@ def resolve_destination(store_path: Path, rel: str) -> _Destination:
         inside_store=resolved != root and resolved.is_relative_to(root),
         inside_decisions=resolved.is_relative_to(decisions_root),
         is_directory=resolved.is_dir(),
+        exists=resolved.exists(),
     )
 
 
@@ -296,14 +302,23 @@ def needs_decision_gate(rel: str, destination: _Destination, state: SyncState) -
 
     Either the spelling says decision or the destination does; the spelling
     check is the cheap one and the destination check is the honest one. The
-    exemption is narrow: a canonically spelled decision that sync state already
-    tracks is an ordinary same-path update, changing no number and needing no
-    verdict. A path this store cannot enumerate is never exempt, however it is
-    tracked, because a legacy entry must not buy a file a pass around the gate.
+    exemption is narrow: a canonically spelled decision that sync state tracks
+    and whose file is still on disk is an ordinary same-path update, changing
+    no number and needing no verdict. A path this store cannot enumerate is
+    never exempt, however it is tracked, because a legacy entry must not buy a
+    file a pass around the gate.
+
+    The file has to be there for that reasoning to hold. Once the local copy is
+    gone the number it held is free, a local writer can mint a different file
+    onto it, and reinstalling the tracked path without a verdict would leave two
+    files claiming one number and push the duplicate. A missing decision is
+    always classified.
     """
     if not (_is_decision_path(rel) or destination.inside_decisions):
         return False
-    return not is_canonical_decision_path(rel) or rel not in state.files
+    if not is_canonical_decision_path(rel):
+        return True
+    return rel not in state.files or not destination.exists
 
 
 def _is_decision_path(rel: str) -> bool:
@@ -507,7 +522,7 @@ def _run_pull_locked(
                 mutating = True
                 corpus = DecisionCorpus.scan(store_path)
                 with _guarded_step(DECISIONS_DIR, _COMPLETION_FAILURE_DETAIL, reporter, tally):
-                    _report_completion(corpus, reporter, tally)
+                    _report_completion(corpus, reporter)
                 for item in work.decisions:
                     transfer = gated.get(item.rel)
                     if transfer is None:
@@ -589,6 +604,10 @@ _WRITE_FAILURE_DETAIL = (
     "problem - permissions, free space, a directory that disappeared - then run "
     "'nauro sync' again; it retries this file."
 )
+_NO_URL_DETAIL = (
+    "{rel}: the server minted no download URL for it, so this run could not fetch it. "
+    "It stays for the next sync."
+)
 _COMPLETION_FAILURE_DETAIL = (
     "the pass that finishes an interrupted renumber could not write here ({error}), so "
     "any half-applied rename was left as it was. Fix the local problem - permissions, "
@@ -667,9 +686,9 @@ def _presign(
 ) -> dict[str, str] | None:
     """Mint one GET URL per planned file, or None on a request failure.
 
-    A shortfall and an unreadable entry are warned about here but counted where
-    the planned file is consumed, so a file the server did not mint a URL for
-    is counted once rather than once per place that notices.
+    A shortfall and an unreadable entry are reported here as the totals they
+    are. The file each one costs is named and counted where that file is
+    consumed, so no file is counted twice and none goes unnamed.
     """
     if not planned:
         return {}
@@ -700,12 +719,13 @@ def _stream(
 
     The caller writes each one before the next is fetched, so only a single
     file's content is ever held. A planned file that yields nothing - no URL,
-    or a transfer that failed - is counted refused here, because the caller
-    only ever sees what arrived.
+    or a transfer that failed - is named and counted refused here, because the
+    caller only ever sees what arrived.
     """
     for item in items:
         url = urls.get(item.rel)
         if not url:
+            reporter.warn(_NO_URL_DETAIL.format(rel=item.rel))
             tally.refused += 1
             continue
         try:
@@ -735,11 +755,16 @@ def _spool(store_path: Path) -> Iterator[Path]:
 def _spool_batch(
     urls: dict[str, str], items: list[_RemoteFile], reporter: Reporter, spool: Path
 ) -> dict[str, _Transfer]:
-    """Fetch a batch onto disk, keyed by store-relative path."""
+    """Fetch a batch onto disk, keyed by store-relative path.
+
+    Names what it could not fetch but counts nothing: the caller counts one
+    refusal per decision missing from the batch, whichever leg lost it.
+    """
     spooled: dict[str, _Transfer] = {}
     for index, item in enumerate(items):
         url = urls.get(item.rel)
         if not url:
+            reporter.warn(_NO_URL_DETAIL.format(rel=item.rel))
             continue
         try:
             content = fetch_via_presigned_url(url)
@@ -767,17 +792,16 @@ _SKIP_DETAIL: dict[SkipReason, str] = {
 }
 
 
-def _report_completion(corpus: DecisionCorpus, reporter: Reporter, tally: _Tally) -> None:
+def _report_completion(corpus: DecisionCorpus, reporter: Reporter) -> None:
     """Run the crash-window completion pass and report what it did.
 
     What it declines to touch - a heading it cannot realign, a heading outside
-    the form it rewrites, a decision file it never reads - is counted permanent:
-    each one needs a hand on the store, not another sync.
+    the form it rewrites, a decision file it never reads - is a local file that
+    was already there, not something this run was asked to install. Each one is
+    warned about and none is counted: they are the store's own hygiene, and
+    folding them into the run's counts would make every sync report leftovers.
     """
     outcome = run_completion_pass(corpus)
-    tally.skipped_permanent += (
-        len(outcome.unrepairable) + len(outcome.quarantined) + len(corpus.irregular)
-    )
     for repair in outcome.repaired:
         reporter.info(
             f"Completed an interrupted renumber: {repair.path.name} heading "
@@ -948,12 +972,14 @@ def _quarantine(
 ) -> None:
     """Leave both sides alone, back up the remote bytes, and say so.
 
-    Counted permanent: the same pull runs the same way tomorrow, and the
-    quarantine has its own surface in ``nauro sync --status`` until a person
-    settles the number.
+    Counted permanent once the backup is safe: the same pull runs the same way
+    tomorrow, and the quarantine has its own surface in ``nauro sync --status``
+    until a person settles the number. A backup that could not be written is a
+    local write error instead, counted refused by the guard above this one, so
+    the count is taken after the write rather than before it.
     """
-    tally.skipped_permanent += 1
     backup = save_quarantine_backup(store_path, transfer.rel, transfer.content, transfer.etag)
+    tally.skipped_permanent += 1
     local_names = ", ".join(path.name for path in verdict.colliders)
     text = verdict.text()
     named = f" ({local_names})" if local_names else ""

--- a/packages/nauro/src/nauro/sync/pull.py
+++ b/packages/nauro/src/nauro/sync/pull.py
@@ -695,22 +695,36 @@ def _sweep_interrupted_writes(store_path: Path, reporter: Reporter) -> int:
     a sweep they accumulate for the life of the store, each one a full copy of
     whatever was being written. The pull is where they are collected because it
     already holds the sync lock and already walks the store.
+
+    Hygiene never costs the caller the sync it asked for. This is the first
+    thing a run does, before the manifest fetch, so an error escaping it would
+    abort a pull that had not started - and on the session-start hook, which
+    swallows everything, skip it in silence. The walk is guarded as well as
+    each file: the store is a directory other processes and the user write
+    into, so a directory can vanish underneath the traversal, and which errors
+    a walk raises rather than swallows differs across the Python versions this
+    supports. The guarantee has to be this function's, not the walk's.
     """
     cutoff = time.time() - _STRANDED_TMP_MIN_AGE_SECONDS
     removed = 0
-    for path in store_path.rglob("*"):
-        if not is_tmp_sibling(path.name) or not path.is_file():
-            continue
-        try:
-            if path.stat().st_mtime > cutoff:
+    try:
+        for path in store_path.rglob("*"):
+            if not is_tmp_sibling(path.name) or not path.is_file():
                 continue
-            path.unlink()
-        except OSError as exc:
-            # One dropping this run cannot remove is not a reason to refuse the
-            # pull that was asked for.
-            reporter.warn(f"could not remove the interrupted write {path}: {exc}")
-            continue
-        removed += 1
+            try:
+                if path.stat().st_mtime > cutoff:
+                    continue
+                path.unlink()
+            except OSError as exc:
+                # One dropping this run cannot remove is not a reason to refuse
+                # the pull that was asked for.
+                reporter.warn(f"could not remove the interrupted write {path}: {exc}")
+                continue
+            removed += 1
+    except OSError as exc:
+        # The walk stops where it broke. What it removed before that still
+        # counts, and the next run starts the sweep again.
+        reporter.warn(f"could not finish looking for interrupted writes: {exc}")
     if removed:
         reporter.info(f"Cleaned {removed} interrupted write(s)")
     return removed

--- a/packages/nauro/src/nauro/sync/pull.py
+++ b/packages/nauro/src/nauro/sync/pull.py
@@ -168,15 +168,25 @@ class _Tally:
 class PullReport:
     """What one pull run left behind, for a caller that must act on it.
 
-    ``nauro sync`` turns ``refused`` into a nonzero exit: a run that could not
-    write everything the server holds must not report success to a script.
-    ``skipped_permanent`` is reported to the user but never changes an exit
-    code, because no rerun resolves it.
+    ``nauro sync`` turns unfinished work into a nonzero exit: a run that could
+    not bring the store level with the server must not report success to a
+    script. Unfinished has two shapes, and a count describes only one of them.
+    ``refused`` counts files a later sync retries. ``manifest_read`` is False
+    when the run never learned what the server holds at all, which no file
+    count can stand in for - there is no denominator. ``skipped_permanent`` is
+    neither: it is reported to the user and never changes an exit code,
+    because no rerun resolves it.
     """
 
     merged: int = 0
     refused: int = 0
     skipped_permanent: int = 0
+    manifest_read: bool = True
+
+    @property
+    def left_work_behind(self) -> bool:
+        """True when the store is short of the server and a rerun can close it."""
+        return self.refused > 0 or not self.manifest_read
 
     @classmethod
     def _of(cls, tally: _Tally) -> PullReport:
@@ -463,9 +473,14 @@ def run_pull(
     changed set is hundreds of megabytes of snapshots is never held in memory
     and a local decision writer never waits on the whole batch.
 
-    Returns a :class:`PullReport`. Caller-facing failures (manifest/presign
-    auth-refresh or transport errors) are reported through ``reporter`` and map
-    to an empty report.
+    Returns a :class:`PullReport`. A transport or auth-refresh failure is
+    reported through ``reporter`` and then carried in that report, in the terms
+    the run can honestly give: a manifest fetch that failed returns
+    ``manifest_read=False``, because the run never learned what the server
+    holds and has no count to offer; a presign request that failed as a whole
+    counts every planned file as refused, because there the total is known.
+    Neither returns an empty report, which would say the store is already level
+    with the server.
 
     The write phase is crash-safe in both directions: a local filesystem error
     on one file is reported and the batch continues, and sync state is written
@@ -486,23 +501,33 @@ def _run_pull_locked(
 ) -> PullReport:
     _sweep_interrupted_writes(store_path, reporter)
 
+    # A run that could not read the file list did not sync anything and cannot
+    # say how much it missed. It reports that plainly rather than as a count of
+    # zero, which the caller would read as a store already level with the
+    # server. Nothing is written on the way out, so the last-full-sync stamp
+    # keeps the date of the last run that did finish.
     try:
         rows = fetch_manifest(project_id)
     except AuthRefreshError as exc:
         reporter.warn(str(exc))
-        return PullReport()
+        return PullReport(manifest_read=False)
     except PresignError as exc:
         reporter.warn(f"manifest fetch failed: {exc}")
-        return PullReport()
+        return PullReport(manifest_read=False)
 
     manifest = _parse_manifest(rows, reporter)
     state = load_state(store_path)
     work = _triage(store_path, manifest, state, reporter)
     tally = _Tally(skipped_permanent=manifest.unreadable_rows + work.skipped_permanent)
 
-    urls = _presign(project_id, work.all_files(), reporter)
+    planned = work.all_files()
+    urls = _presign(project_id, planned, reporter)
     if urls is None:
-        return PullReport._of(tally)
+        # The request failed as a whole, so every file it was for stays where
+        # it is. Here the denominator is known, so each one is counted: the
+        # cause is reported above and the total is reported below.
+        tally.refused += len(planned)
+        return _report_tally(tally, reporter)
 
     # Flipped the moment the decision lock is held, which is the moment this run
     # can start changing the store. Everything before it - the manifest, the
@@ -573,6 +598,15 @@ def _run_pull_locked(
         if mutating:
             save_state(store_path, state)
 
+    return _report_tally(tally, reporter)
+
+
+def _report_tally(tally: _Tally, reporter: Reporter) -> PullReport:
+    """Say what the run did, and hand the caller the same answer.
+
+    Every leg that stops early ends here too, so a run that fetched nothing
+    still names what it owes instead of falling silent.
+    """
     if tally.adopted:
         reporter.info(f"Adopted {tally.adopted} local file(s) already on the server")
     if tally.merged:
@@ -584,9 +618,10 @@ def _run_pull_locked(
         )
     if tally.refused:
         # Said last, after the warnings that explain each one. A run that could
-        # not write must never sign off as "No remote changes".
+        # not finish must never sign off as "No remote changes".
         reporter.info(
-            f"Left {tally.refused} item(s) for the next sync: this run could not write them"
+            f"Left {tally.refused} item(s) for the next sync: this run could not "
+            "fetch or write them"
         )
     elif not (tally.merged or tally.adopted or tally.skipped_permanent):
         reporter.info("No remote changes")

--- a/packages/nauro/src/nauro/sync/pull.py
+++ b/packages/nauro/src/nauro/sync/pull.py
@@ -31,10 +31,12 @@ from __future__ import annotations
 import os
 import shutil
 import tempfile
+import time
 from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from enum import Enum, auto
 from pathlib import Path
 from typing import Protocol
 
@@ -43,7 +45,7 @@ from pydantic import BaseModel, ConfigDict, ValidationError
 
 from nauro.cli.commands.auth import AuthRefreshError
 from nauro.constants import DECISIONS_DIR
-from nauro.store._atomic import atomic_write_bytes
+from nauro.store._atomic import atomic_write_bytes, is_tmp_sibling
 from nauro.sync.collisions import (
     DecisionOutcome,
     DecisionVerdict,
@@ -59,7 +61,7 @@ from nauro.sync.corpus import DecisionCorpus, SkipReason
 from nauro.sync.lock import CLI_SYNC_LOCK_TIMEOUT, decision_lock, sync_lock
 from nauro.sync.merge import (
     SPOOL_DIR_PREFIX,
-    detect_conflict,
+    Side,
     normalize_rel,
     resolve_conflict,
     should_skip,
@@ -142,14 +144,43 @@ class _Transfer:
 class _Tally:
     """What one run changed, in the terms it reports.
 
-    ``refused`` counts the subjects a local filesystem error stopped. They are
-    not failures of the run - each one is reported and the next sync retries it
-    - but they are the reason a run cannot claim to have synced the whole store.
+    Two counts describe what did not land, because they answer different
+    questions. ``refused`` is a subject the next sync retries: a local write
+    error, a fetch that failed, a presign URL that never arrived. Each one is
+    reported, none is a failure of the run, and together they are the reason a
+    run cannot claim to have synced the whole store. ``skipped_permanent`` is
+    the opposite - a manifest row that resolves outside the store, a path an
+    ordinary pull may not write, a quarantined collision - and retrying changes
+    nothing about it, so it is reported and nothing more.
     """
 
     merged: int = 0
     adopted: int = 0
     refused: int = 0
+    skipped_permanent: int = 0
+
+
+@dataclass(frozen=True)
+class PullReport:
+    """What one pull run left behind, for a caller that must act on it.
+
+    ``nauro sync`` turns ``refused`` into a nonzero exit: a run that could not
+    write everything the server holds must not report success to a script.
+    ``skipped_permanent`` is reported to the user but never changes an exit
+    code, because no rerun resolves it.
+    """
+
+    merged: int = 0
+    refused: int = 0
+    skipped_permanent: int = 0
+
+    @classmethod
+    def _of(cls, tally: _Tally) -> PullReport:
+        return cls(
+            merged=tally.merged,
+            refused=tally.refused,
+            skipped_permanent=tally.skipped_permanent,
+        )
 
 
 @dataclass(frozen=True)
@@ -159,6 +190,7 @@ class _Manifest:
     entries: tuple[_ManifestEntry, ...]
     paths: frozenset[str]
     decision_numbers: frozenset[int]
+    unreadable_rows: int = 0
 
 
 def _parse_manifest(rows: list[dict], reporter: Reporter) -> _Manifest:
@@ -170,11 +202,13 @@ def _parse_manifest(rows: list[dict], reporter: Reporter) -> _Manifest:
     so a local renumber never mints onto one.
     """
     entries: list[_ManifestEntry] = []
+    unreadable = 0
     for row in rows:
         try:
             entry = _ManifestEntry.model_validate(row)
         except ValidationError:
             reporter.warn(f"skipping unreadable manifest entry {row!r}")
+            unreadable += 1
             continue
         if entry.path:
             entries.append(entry)
@@ -190,6 +224,7 @@ def _parse_manifest(rows: list[dict], reporter: Reporter) -> _Manifest:
         entries=tuple(entries),
         paths=frozenset(paths),
         decision_numbers=frozenset(numbers),
+        unreadable_rows=unreadable,
     )
 
 
@@ -199,12 +234,14 @@ class _Worklists:
 
     ``decisions`` holds every decision file the store does not track, whatever
     it looked like at planning time; each one is classified again against the
-    live corpus before it is written.
+    live corpus before it is written. ``skipped_permanent`` counts the entries
+    triage refused outright, which no worklist carries and no rerun recovers.
     """
 
     decisions: list[_RemoteFile] = field(default_factory=list)
     pulls: list[_RemoteFile] = field(default_factory=list)
     conflicts: list[_RemoteFile] = field(default_factory=list)
+    skipped_permanent: int = 0
 
     def all_files(self) -> list[_RemoteFile]:
         return self.decisions + self.pulls + self.conflicts
@@ -290,6 +327,72 @@ def _decision_name(rel: str) -> str:
     return rel.partition("/")[2]
 
 
+class _Route(Enum):
+    """What one manifest entry needs, before any worklist is built.
+
+    The reasoning lives in :func:`_route_entry` alone, so the collection step
+    reads as a table rather than as a second copy of it.
+    """
+
+    ignore = auto()
+    unusable = auto()
+    gate = auto()
+    install = auto()
+    conflict = auto()
+
+
+def _route_entry(
+    store_path: Path, entry: _ManifestEntry, state: SyncState, reporter: Reporter
+) -> _Route:
+    """Decide what one manifest entry needs, naming the ones it refuses.
+
+    The order is the substance. Every guard about where the bytes would land
+    runs before anything about whether they are wanted, so a refusal is always
+    reported rather than hidden behind a shortcut. The unchanged-remote
+    shortcut then applies only when the local file is still there: the remote
+    store is the record for a tracked file, so an entry the user deleted
+    locally is reinstalled whether or not its etag moved.
+    """
+    rel = entry.path
+    if should_skip(rel):
+        return _Route.ignore
+    # Server validates per-op on presign, but the manifest itself is
+    # currently trusted — drop suspicious entries before they hit disk.
+    if ".." in Path(rel).parts or rel.startswith("/"):
+        reporter.warn(f"skipping suspicious manifest entry {rel!r}")
+        return _Route.unusable
+
+    destination = resolve_destination(store_path, rel)
+    if not destination.inside_store:
+        reporter.warn(f"skipping manifest entry {rel!r}: it resolves outside the store")
+        return _Route.unusable
+
+    local_exists = (store_path / rel).exists()
+    if local_exists and not file_changed_remotely(entry.etag, rel, state):
+        return _Route.ignore
+
+    if needs_decision_gate(rel, destination, state):
+        return _Route.gate
+    if destination.is_directory:
+        # Nothing a manifest names as a file may land on a directory: the
+        # local-change probe below would hash it and raise.
+        reporter.warn(
+            f"skipping manifest entry {rel!r}: it resolves to the directory {destination.path}"
+        )
+        return _Route.unusable
+    if not local_exists:
+        # A file the user deleted is not a conflict: a conflict protects local
+        # content and there is none.
+        return _Route.install
+    if file_changed_locally(store_path, rel, state):
+        # Reaching here with a local file means the remote moved too, so both
+        # sides have content the other does not - whether or not sync state
+        # tracks the file. An untracked one used to match no list at all and be
+        # dropped in silence, which lost the remote version without a backup.
+        return _Route.conflict
+    return _Route.install
+
+
 def _triage(
     store_path: Path,
     manifest: _Manifest,
@@ -308,48 +411,21 @@ def _triage(
     listing = DecisionCorpus.scan(store_path)
     contested: list[_RemoteFile] = []
     for entry in manifest.entries:
-        rel = entry.path
-        if should_skip(rel):
+        route = _route_entry(store_path, entry, state, reporter)
+        if route is _Route.ignore:
             continue
-        # Server validates per-op on presign, but the manifest itself is
-        # currently trusted — drop suspicious entries before they hit disk.
-        if ".." in Path(rel).parts or rel.startswith("/"):
-            reporter.warn(f"skipping suspicious manifest entry {rel!r}")
-            continue
-        if not file_changed_remotely(entry.etag, rel, state):
+        if route is _Route.unusable:
+            work.skipped_permanent += 1
             continue
 
-        item = _RemoteFile(rel, entry.etag)
-        destination = resolve_destination(store_path, rel)
-        if not destination.inside_store:
-            reporter.warn(f"skipping manifest entry {rel!r}: it resolves outside the store")
-            continue
-        if needs_decision_gate(rel, destination, state):
-            number = extract_decision_number(_decision_name(rel))
+        item = _RemoteFile(entry.path, entry.etag)
+        if route is _Route.gate:
+            number = extract_decision_number(_decision_name(entry.path))
             claimed = number is not None and bool(listing.holders(number))
             (contested if claimed else work.decisions).append(item)
-            continue
-
-        if destination.is_directory:
-            # Nothing a manifest names as a file may land on a directory: the
-            # local-change probe below would hash it and raise.
-            reporter.warn(
-                f"skipping manifest entry {rel!r}: it resolves to the directory {destination.path}"
-            )
-            continue
-
-        local_file = store_path / rel
-        if not local_file.exists():
-            # A tracked file the user deleted is not a conflict: a conflict
-            # protects local content and there is none. The remote store is
-            # append-only, so the file comes back on this pull.
+        elif route is _Route.install:
             work.pulls.append(item)
-            continue
-        if not file_changed_locally(store_path, rel, state):
-            work.pulls.append(item)
-            continue
-
-        if detect_conflict(rel, state, compute_sha256(local_file), entry.etag):
+        else:
             work.conflicts.append(item)
 
     work.decisions[:0] = contested
@@ -362,7 +438,7 @@ def run_pull(
     reporter: Reporter,
     *,
     lock_timeout: float = CLI_SYNC_LOCK_TIMEOUT,
-) -> int:
+) -> PullReport:
     """Pull remote changes for ``project_id`` into ``store_path``.
 
     Walks the server manifest, then applies it in two phases. Untracked
@@ -372,9 +448,9 @@ def run_pull(
     changed set is hundreds of megabytes of snapshots is never held in memory
     and a local decision writer never waits on the whole batch.
 
-    Returns the number of files merged. Caller-facing failures
-    (manifest/presign auth-refresh or transport errors) are reported through
-    ``reporter`` and map to a 0 return.
+    Returns a :class:`PullReport`. Caller-facing failures (manifest/presign
+    auth-refresh or transport errors) are reported through ``reporter`` and map
+    to an empty report.
 
     The write phase is crash-safe in both directions: a local filesystem error
     on one file is reported and the batch continues, and sync state is written
@@ -392,25 +468,27 @@ def run_pull(
 
 def _run_pull_locked(
     project_id: str, store_path: Path, reporter: Reporter, lock_timeout: float
-) -> int:
+) -> PullReport:
+    _sweep_interrupted_writes(store_path, reporter)
+
     try:
         rows = fetch_manifest(project_id)
     except AuthRefreshError as exc:
         reporter.warn(str(exc))
-        return 0
+        return PullReport()
     except PresignError as exc:
         reporter.warn(f"manifest fetch failed: {exc}")
-        return 0
+        return PullReport()
 
     manifest = _parse_manifest(rows, reporter)
     state = load_state(store_path)
     work = _triage(store_path, manifest, state, reporter)
+    tally = _Tally(skipped_permanent=manifest.unreadable_rows + work.skipped_permanent)
 
     urls = _presign(project_id, work.all_files(), reporter)
     if urls is None:
-        return 0
+        return PullReport._of(tally)
 
-    tally = _Tally()
     # Flipped the moment the decision lock is held, which is the moment this run
     # can start changing the store. Everything before it - the manifest, the
     # triage, the presign, the transfers, the wait for the lock - leaves the
@@ -429,32 +507,47 @@ def _run_pull_locked(
                 mutating = True
                 corpus = DecisionCorpus.scan(store_path)
                 with _guarded_step(DECISIONS_DIR, _COMPLETION_FAILURE_DETAIL, reporter, tally):
-                    _report_completion(corpus, reporter)
+                    _report_completion(corpus, reporter, tally)
                 for item in work.decisions:
                     transfer = gated.get(item.rel)
                     if transfer is None:
+                        # No URL, or a fetch that failed - both already warned
+                        # about, and both counted here rather than where they
+                        # happened so one absent decision is counted once.
+                        tally.refused += 1
                         continue
                     with _guarded_step(item.rel, _WRITE_FAILURE_DETAIL, reporter, tally):
                         _apply_decision(corpus, transfer, state, manifest, reporter, tally)
 
-        for transfer in _stream(urls, work.pulls, reporter):
+        for transfer in _stream(urls, work.pulls, reporter, tally):
             with _guarded_step(transfer.rel, _WRITE_FAILURE_DETAIL, reporter, tally):
                 if _generic_write_allowed(store_path, transfer, state, reporter):
                     target = store_path / transfer.rel
                     atomic_write_bytes(target, transfer.content)
                     update_file_state(state, transfer.rel, compute_sha256(target), transfer.etag)
                     tally.merged += 1
+                else:
+                    tally.skipped_permanent += 1
 
-        for transfer in _stream(urls, work.conflicts, reporter):
+        for transfer in _stream(urls, work.conflicts, reporter, tally):
             with _guarded_step(transfer.rel, _WRITE_FAILURE_DETAIL, reporter, tally):
                 if _generic_write_allowed(store_path, transfer, state, reporter):
-                    _resolve_and_record(store_path, transfer, state)
+                    _resolve_and_record(
+                        store_path, transfer, state, _conflict_side(transfer.rel, state)
+                    )
                     tally.merged += 1
+                else:
+                    tally.skipped_permanent += 1
 
         if not tally.refused:
-            # The timestamp says this run walked the whole store and wrote
-            # everything it found, so it advances only when every leg ran and
-            # no file was left behind by a local write failure.
+            # The stamp says every file this run found is on disk. Only a
+            # transient refusal holds it back - a local write error, a fetch
+            # that failed, a presign URL that never arrived - because only
+            # those come back on the next run. A permanently skipped entry is
+            # reported on its own and never resolves by retrying, so gating on
+            # one would freeze the stamp for good. The stamp is pull-scoped: a
+            # push failure is the command's own exit-1 outcome and never
+            # reaches this line.
             state.last_full_sync = datetime.now(timezone.utc).isoformat()
     finally:
         # Sync state records what actually landed, so once this run could have
@@ -469,16 +562,21 @@ def _run_pull_locked(
         reporter.info(f"Adopted {tally.adopted} local file(s) already on the server")
     if tally.merged:
         reporter.info(f"Merged {tally.merged} file(s) from remote")
+    if tally.skipped_permanent:
+        reporter.info(
+            f"Skipped {tally.skipped_permanent} item(s) this sync cannot install: "
+            "each one is named above, and another run changes nothing"
+        )
     if tally.refused:
         # Said last, after the warnings that explain each one. A run that could
         # not write must never sign off as "No remote changes".
         reporter.info(
             f"Left {tally.refused} item(s) for the next sync: this run could not write them"
         )
-    elif not (tally.merged or tally.adopted):
+    elif not (tally.merged or tally.adopted or tally.skipped_permanent):
         reporter.info("No remote changes")
 
-    return tally.merged
+    return PullReport._of(tally)
 
 
 # What a step that could not write says for itself. Same shape as _SKIP_DETAIL
@@ -528,10 +626,51 @@ def _guarded_step(subject: str, detail: str, reporter: Reporter, tally: _Tally) 
         reporter.warn(f"{subject}: {detail.format(error=exc)}")
 
 
+# How old a tmp sibling must be before the sweep treats it as garbage. An
+# atomic write lives for the length of one write, so a minute-old tmp file is
+# one a kill signal stranded. The floor is what keeps the sweep off a write in
+# progress: store writers take the decision lock, but the store is a directory
+# the user can also write into, and this runs while only the sync lock is held.
+_STRANDED_TMP_MIN_AGE_SECONDS = 60.0
+
+
+def _sweep_interrupted_writes(store_path: Path, reporter: Reporter) -> int:
+    """Remove the tmp siblings killed writes stranded, and say how many.
+
+    Nothing reads these files and both sync directions exclude them, so without
+    a sweep they accumulate for the life of the store, each one a full copy of
+    whatever was being written. The pull is where they are collected because it
+    already holds the sync lock and already walks the store.
+    """
+    cutoff = time.time() - _STRANDED_TMP_MIN_AGE_SECONDS
+    removed = 0
+    for path in store_path.rglob("*"):
+        if not is_tmp_sibling(path.name) or not path.is_file():
+            continue
+        try:
+            if path.stat().st_mtime > cutoff:
+                continue
+            path.unlink()
+        except OSError as exc:
+            # One dropping this run cannot remove is not a reason to refuse the
+            # pull that was asked for.
+            reporter.warn(f"could not remove the interrupted write {path}: {exc}")
+            continue
+        removed += 1
+    if removed:
+        reporter.info(f"Cleaned {removed} interrupted write(s)")
+    return removed
+
+
 def _presign(
     project_id: str, planned: list[_RemoteFile], reporter: Reporter
 ) -> dict[str, str] | None:
-    """Mint one GET URL per planned file, or None on a request failure."""
+    """Mint one GET URL per planned file, or None on a request failure.
+
+    A shortfall and an unreadable entry are warned about here but counted where
+    the planned file is consumed, so a file the server did not mint a URL for
+    is counted once rather than once per place that notices.
+    """
     if not planned:
         return {}
 
@@ -555,21 +694,25 @@ def _presign(
 
 
 def _stream(
-    urls: dict[str, str], items: list[_RemoteFile], reporter: Reporter
+    urls: dict[str, str], items: list[_RemoteFile], reporter: Reporter, tally: _Tally
 ) -> Iterator[_Transfer]:
     """Yield each planned file's bytes, fetched one at a time.
 
     The caller writes each one before the next is fetched, so only a single
-    file's content is ever held.
+    file's content is ever held. A planned file that yields nothing - no URL,
+    or a transfer that failed - is counted refused here, because the caller
+    only ever sees what arrived.
     """
     for item in items:
         url = urls.get(item.rel)
         if not url:
+            tally.refused += 1
             continue
         try:
             content = fetch_via_presigned_url(url)
         except PresignError as exc:
             reporter.warn(f"error pulling {item.rel}: {exc}")
+            tally.refused += 1
             continue
         yield _Transfer(rel=item.rel, etag=item.etag, _body=content)
 
@@ -624,9 +767,17 @@ _SKIP_DETAIL: dict[SkipReason, str] = {
 }
 
 
-def _report_completion(corpus: DecisionCorpus, reporter: Reporter) -> None:
-    """Run the crash-window completion pass and report what it did."""
+def _report_completion(corpus: DecisionCorpus, reporter: Reporter, tally: _Tally) -> None:
+    """Run the crash-window completion pass and report what it did.
+
+    What it declines to touch - a heading it cannot realign, a heading outside
+    the form it rewrites, a decision file it never reads - is counted permanent:
+    each one needs a hand on the store, not another sync.
+    """
     outcome = run_completion_pass(corpus)
+    tally.skipped_permanent += (
+        len(outcome.unrepairable) + len(outcome.quarantined) + len(corpus.irregular)
+    )
     for repair in outcome.repaired:
         reporter.info(
             f"Completed an interrupted renumber: {repair.path.name} heading "
@@ -685,10 +836,26 @@ def _generic_write_allowed(
     return True
 
 
-def _resolve_and_record(store_path: Path, transfer: _Transfer, state: SyncState) -> None:
-    """Apply the last-write-wins conflict policy and record the result."""
+def _conflict_side(rel: str, state: SyncState) -> Side:
+    """Which copy of a contested path stays on disk.
+
+    A tracked path's two versions descend from a copy this store published, so
+    last-write-wins keeps the one the user is looking at. An untracked path was
+    never published from here and has no shared ancestor: the server's copy is
+    the record for it, and the local bytes go to the backup directory instead.
+    Neither side is lost either way; only which one needs a rename to recover.
+    """
+    return Side.local if rel in state.files else Side.remote
+
+
+def _resolve_and_record(
+    store_path: Path, transfer: _Transfer, state: SyncState, keeps: Side
+) -> None:
+    """Apply the conflict policy for one path and record the result."""
     local_file = store_path / transfer.rel
-    merged_content = resolve_conflict(store_path, local_file, transfer.content, transfer.rel)
+    merged_content = resolve_conflict(
+        store_path, local_file, transfer.content, transfer.rel, keeps=keeps
+    )
     atomic_write_bytes(local_file, merged_content)
     update_file_state(state, transfer.rel, compute_sha256(local_file), transfer.etag)
 
@@ -720,7 +887,7 @@ def _apply_decision(
             # Refused before anything was renamed or written, and the refusal
             # names its own reason rather than borrowing the heading's.
             reporter.warn(str(exc))
-            _quarantine(store_path, transfer, verdict.quarantined_as(exc.reason), reporter)
+            _quarantine(store_path, transfer, verdict.quarantined_as(exc.reason), reporter, tally)
             return
         reporter.info(
             f"Renumbered unpublished local decision {renumber.old_num:03d} -> "
@@ -734,11 +901,12 @@ def _apply_decision(
                 transfer,
                 verdict.quarantined_as(QuarantineReason.ambiguous_colliders),
                 reporter,
+                tally,
             )
             return
 
     if verdict.outcome is DecisionOutcome.quarantine:
-        _quarantine(store_path, transfer, verdict, reporter)
+        _quarantine(store_path, transfer, verdict, reporter, tally)
         return
 
     if verdict.outcome is DecisionOutcome.canonicalize:
@@ -757,9 +925,10 @@ def _apply_decision(
         return
 
     if verdict.outcome is DecisionOutcome.resolve_conflict:
-        # Last-write-wins keeps the local decision, so the file on disk is
-        # byte-unchanged and the corpus still describes it.
-        _resolve_and_record(store_path, transfer, state)
+        # The local decision stays, whatever sync state says about the path: the
+        # file on disk is byte-unchanged, so the corpus still describes it and
+        # the number it holds does not move underneath this batch.
+        _resolve_and_record(store_path, transfer, state, Side.local)
         tally.merged += 1
         return
 
@@ -775,8 +944,15 @@ def _quarantine(
     transfer: _Transfer,
     verdict: DecisionVerdict,
     reporter: Reporter,
+    tally: _Tally,
 ) -> None:
-    """Leave both sides alone, back up the remote bytes, and say so."""
+    """Leave both sides alone, back up the remote bytes, and say so.
+
+    Counted permanent: the same pull runs the same way tomorrow, and the
+    quarantine has its own surface in ``nauro sync --status`` until a person
+    settles the number.
+    """
+    tally.skipped_permanent += 1
     backup = save_quarantine_backup(store_path, transfer.rel, transfer.content, transfer.etag)
     local_names = ", ".join(path.name for path in verdict.colliders)
     text = verdict.text()
@@ -788,4 +964,4 @@ def _quarantine(
     )
 
 
-__all__ = ["Reporter", "run_pull"]
+__all__ = ["PullReport", "Reporter", "run_pull"]

--- a/packages/nauro/src/nauro/sync/push.py
+++ b/packages/nauro/src/nauro/sync/push.py
@@ -99,7 +99,7 @@ def push_changed_files(
 
 
 def _push_changed_files_locked(project_id: str, store_path: Path) -> int:
-    from nauro.sync.merge import should_skip
+    from nauro.sync.merge import CONFLICT_BACKUP_DIR, should_skip
     from nauro.sync.remote import (
         PresignError,
         put_via_presigned_url,
@@ -118,7 +118,7 @@ def _push_changed_files_locked(project_id: str, store_path: Path) -> int:
             rel = str(local_file.relative_to(store_path))
         except ValueError:
             continue
-        if should_skip(rel) or rel.startswith(".conflict-backup") or rel.startswith("__pycache__"):
+        if should_skip(rel) or rel.startswith(CONFLICT_BACKUP_DIR) or rel.startswith("__pycache__"):
             continue
 
         # Shared briefs (context/*.md) are written via the agent's filesystem

--- a/packages/nauro/tests/test_sync/conftest.py
+++ b/packages/nauro/tests/test_sync/conftest.py
@@ -153,11 +153,13 @@ def write_local_decision(store, filename: str, content: bytes) -> object:
     return path
 
 
-def pull(store, entries, *, reporter=None, etags=None):
+def pull_report(store, entries, *, reporter=None, etags=None):
     """Run one pull against a fake server holding exactly ``entries``.
 
     ``entries`` is an ordered list of ``(path, body)`` pairs so the tests can
-    pin manifest order where order is the thing under test.
+    pin manifest order where order is the thing under test. Returns the full
+    :class:`~nauro.sync.pull.PullReport`; :func:`pull` is the merged-count form
+    most tests want.
     """
     reporter = reporter or _RecordingReporter()
     etags = etags or {}
@@ -184,8 +186,14 @@ def pull(store, entries, *, reporter=None, etags=None):
         patch("nauro.sync.remote.httpx.get", side_effect=fake_get),
         patch("nauro.sync.remote.httpx.post", return_value=presign),
     ):
-        merged = run_pull(CLOUD_PID, store, reporter)
-    return merged, reporter
+        report = run_pull(CLOUD_PID, store, reporter)
+    return report, reporter
+
+
+def pull(store, entries, *, reporter=None, etags=None):
+    """Run one pull, returning ``(merged count, reporter)``."""
+    report, reporter = pull_report(store, entries, reporter=reporter, etags=etags)
+    return report.merged, reporter
 
 
 def entry_names(directory) -> set[str]:

--- a/packages/nauro/tests/test_sync/test_journal_excluded.py
+++ b/packages/nauro/tests/test_sync/test_journal_excluded.py
@@ -80,7 +80,7 @@ def test_pull_skips_remote_journal_path(tmp_path):
 
     reporter = _RecordingReporter()
     with patch("nauro.sync.remote.httpx.get", side_effect=fake_get):
-        merged = run_pull(CLOUD_PID, store, reporter)
+        merged = run_pull(CLOUD_PID, store, reporter).merged
 
     assert merged == 0
     assert not (store / rel).exists()

--- a/packages/nauro/tests/test_sync/test_merge.py
+++ b/packages/nauro/tests/test_sync/test_merge.py
@@ -7,13 +7,12 @@ from nauro.store import _atomic
 from nauro.store._atomic import atomic_write_bytes
 from nauro.sync.merge import (
     CONFLICT_BACKUP_DIR,
+    Side,
     _set_union_markdown,
-    detect_conflict,
     resolve_conflict,
     should_skip,
     write_backup,
 )
-from nauro.sync.state import FileState, SyncState
 
 
 class TestShouldSkip:
@@ -87,27 +86,6 @@ class TestShouldSkip:
         assert should_skip("decisions\\.lock") is True
 
 
-class TestDetectConflict:
-    def test_no_previous_state(self):
-        state = SyncState()
-        assert detect_conflict("new.md", state, "sha1", '"etag1"') is False
-
-    def test_only_local_changed(self):
-        state = SyncState()
-        state.files["test.md"] = FileState(local_sha256="old_sha", remote_etag='"same_etag"')
-        assert detect_conflict("test.md", state, "new_sha", '"same_etag"') is False
-
-    def test_only_remote_changed(self):
-        state = SyncState()
-        state.files["test.md"] = FileState(local_sha256="same_sha", remote_etag='"old_etag"')
-        assert detect_conflict("test.md", state, "same_sha", '"new_etag"') is False
-
-    def test_both_changed(self):
-        state = SyncState()
-        state.files["test.md"] = FileState(local_sha256="old_sha", remote_etag='"old_etag"')
-        assert detect_conflict("test.md", state, "new_sha", '"new_etag"') is True
-
-
 class TestResolveConflict:
     def test_lww_for_state_md(self, tmp_path):
         """state.md uses last-write-wins with backup."""
@@ -117,7 +95,9 @@ class TestResolveConflict:
         local_file.write_text("local state content")
         remote_content = b"remote state content"
 
-        result = resolve_conflict(project_path, local_file, remote_content, "state.md")
+        result = resolve_conflict(
+            project_path, local_file, remote_content, "state.md", keeps=Side.local
+        )
 
         assert result == b"local state content"
         backup_dir = project_path / ".conflict-backup"
@@ -134,7 +114,9 @@ class TestResolveConflict:
         local_file.write_text("local project content")
         remote_content = b"remote project content"
 
-        result = resolve_conflict(project_path, local_file, remote_content, "project.md")
+        result = resolve_conflict(
+            project_path, local_file, remote_content, "project.md", keeps=Side.local
+        )
 
         assert result == b"local project content"
         backup_dir = project_path / ".conflict-backup"
@@ -149,7 +131,9 @@ class TestResolveConflict:
         local_file.write_text('{"local": true}')
         remote_content = b'{"remote": true}'
 
-        result = resolve_conflict(project_path, local_file, remote_content, "snapshots/v001.json")
+        result = resolve_conflict(
+            project_path, local_file, remote_content, "snapshots/v001.json", keeps=Side.local
+        )
 
         assert result == b'{"local": true}'
 
@@ -167,7 +151,9 @@ class TestResolveConflict:
         local_file.write_text("# Decision 001\nLocal addition\n")
         remote_content = b"# Decision 001\nRemote addition\n"
 
-        result = resolve_conflict(project_path, local_file, remote_content, "decisions/001-foo.md")
+        result = resolve_conflict(
+            project_path, local_file, remote_content, "decisions/001-foo.md", keeps=Side.local
+        )
 
         # Local copy is kept whole, never interleaved with remote.
         assert result == b"# Decision 001\nLocal addition\n"
@@ -225,7 +211,11 @@ class TestResolveConflict:
         remote_content = remote_text.encode("utf-8")
 
         result = resolve_conflict(
-            project_path, local_file, remote_content, "decisions/042-cache-layer.md"
+            project_path,
+            local_file,
+            remote_content,
+            "decisions/042-cache-layer.md",
+            keeps=Side.local,
         )
 
         # The survivor is the local rewrite, whole and parseable as ONE decision.
@@ -248,7 +238,9 @@ class TestResolveConflict:
         local_file.write_text("- Question 1\n- Local question\n")
         remote_content = b"- Question 1\n- Remote question\n"
 
-        result = resolve_conflict(project_path, local_file, remote_content, "open-questions.md")
+        result = resolve_conflict(
+            project_path, local_file, remote_content, "open-questions.md", keeps=Side.local
+        )
 
         result_str = result.decode()
         assert result_str.count("Question 1") == 1
@@ -397,7 +389,9 @@ class TestSetUnionMarkdown:
 
         monkeypatch.setattr("nauro.sync.merge._set_union_markdown", spy)
 
-        resolve_conflict(project_path, local_file, remote_content, "decisions/001-foo.md")
+        resolve_conflict(
+            project_path, local_file, remote_content, "decisions/001-foo.md", keeps=Side.local
+        )
 
         assert calls == []
         # Last-write-wins backs the remote loser up rather than interleaving it.
@@ -421,7 +415,9 @@ class TestSetUnionMarkdown:
 
         monkeypatch.setattr("nauro.sync.merge._set_union_markdown", spy)
 
-        result = resolve_conflict(project_path, local_file, remote_content, "open-questions.md")
+        result = resolve_conflict(
+            project_path, local_file, remote_content, "open-questions.md", keeps=Side.local
+        )
 
         assert result == b"merged"
         assert len(calls) == 1
@@ -444,7 +440,9 @@ class TestSetUnionMarkdown:
 
         monkeypatch.setattr("nauro.sync.merge._set_union_markdown", spy)
 
-        result = resolve_conflict(project_path, local_file, remote_content, "state_history.md")
+        result = resolve_conflict(
+            project_path, local_file, remote_content, "state_history.md", keeps=Side.local
+        )
 
         assert result == b"merged"
         assert len(calls) == 1

--- a/packages/nauro/tests/test_sync/test_pull.py
+++ b/packages/nauro/tests/test_sync/test_pull.py
@@ -21,6 +21,7 @@ import httpx
 import pytest
 from nauro_core.operations.propose_decision import _next_decision_num
 
+from nauro.cli.commands.auth import AuthRefreshError
 from nauro.store import _atomic
 from nauro.store._atomic import atomic_write_bytes, is_tmp_sibling
 from nauro.store.filesystem_store import FilesystemStore
@@ -1829,6 +1830,73 @@ class TestLocalWriteFailures:
             pull(collision_store, [("decisions/015-remote.md", decision_bytes(15, "Remote"))])
 
         assert (collision_store / ".sync-state.json").read_bytes() == corrupt
+
+
+class TestServerOutOfReach:
+    """A run that fetched nothing must not read as a store already in step.
+
+    Both legs returned an empty report, which counts zero refusals and says
+    zero files are owed. The command then exited 0 and pushed over a pull that
+    never happened.
+    """
+
+    def test_a_manifest_failure_says_the_run_never_saw_the_server(
+        self, collision_store, monkeypatch
+    ):
+        def refuse(_project_id):
+            raise PresignError("503 service unavailable")
+
+        monkeypatch.setattr(pull_module, "fetch_manifest", refuse)
+        reporter = _RecordingReporter()
+
+        report = run_pull(CLOUD_PID, collision_store, reporter)
+
+        assert report.manifest_read is False
+        assert report.left_work_behind is True
+        assert load_state(collision_store).last_full_sync == ""
+        assert any("manifest fetch failed" in warning for warning in reporter.warns)
+
+    def test_an_auth_failure_on_the_manifest_reads_the_same_way(self, collision_store, monkeypatch):
+        def refuse(_project_id):
+            raise AuthRefreshError("session expired; run 'nauro auth login'")
+
+        monkeypatch.setattr(pull_module, "fetch_manifest", refuse)
+
+        report = run_pull(CLOUD_PID, collision_store, _RecordingReporter())
+
+        assert report.manifest_read is False
+        assert report.left_work_behind is True
+
+    def test_a_total_presign_failure_counts_every_planned_file(self, collision_store, monkeypatch):
+        """Here the run does know what it missed, so it says how much."""
+
+        def refuse(*_args):
+            raise PresignError("403 forbidden")
+
+        monkeypatch.setattr(pull_module, "request_presigned_urls", refuse)
+
+        report, reporter = pull_report(
+            collision_store,
+            [
+                ("decisions/018-remote.md", decision_bytes(18, "Unfetched")),
+                ("stack.md", b"# Stack\n\nremote\n"),
+            ],
+        )
+
+        assert report.refused == 2
+        assert report.merged == 0
+        assert report.manifest_read is True
+        assert report.left_work_behind is True
+        assert not (collision_store / "decisions/018-remote.md").exists()
+        assert load_state(collision_store).last_full_sync == ""
+        assert any("presign request failed" in warning for warning in reporter.warns)
+        assert any("Left 2 item(s) for the next sync" in line for line in reporter.infos)
+
+    def test_a_clean_run_says_it_read_the_server(self, collision_store):
+        report, _reporter = pull_report(collision_store, [])
+
+        assert report.manifest_read is True
+        assert report.left_work_behind is False
 
 
 class TestPartialWrites:

--- a/packages/nauro/tests/test_sync/test_pull.py
+++ b/packages/nauro/tests/test_sync/test_pull.py
@@ -13,6 +13,7 @@ classifier and its crash windows are unit-tested in ``test_collisions.py``.
 from __future__ import annotations
 
 import os
+import time
 from pathlib import Path
 from unittest.mock import patch
 
@@ -20,17 +21,20 @@ import httpx
 import pytest
 from nauro_core.operations.propose_decision import _next_decision_num
 
+from nauro.store import _atomic
+from nauro.store._atomic import atomic_write_bytes, is_tmp_sibling
 from nauro.store.filesystem_store import FilesystemStore
 from nauro.sync import pull as pull_module
 from nauro.sync.corpus import DecisionCorpus
 from nauro.sync.lock import SyncLockTimeoutError, decision_lock
-from nauro.sync.merge import SPOOL_DIR_PREFIX, should_skip
+from nauro.sync.merge import CONFLICT_BACKUP_DIR, SPOOL_DIR_PREFIX, should_skip
 from nauro.sync.pull import _Transfer, run_pull
 from nauro.sync.quarantine import (
     list_quarantine_backups,
     save_quarantine_backup,
     unresolved_quarantines,
 )
+from nauro.sync.remote import PresignError
 from nauro.sync.state import (
     FileState,
     SyncState,
@@ -49,6 +53,7 @@ from tests.test_sync.conftest import (
     decision_bytes,
     entry_names,
     pull,
+    pull_report,
     track,
     write_local_decision,
 )
@@ -78,7 +83,7 @@ class TestRunPullCleanPull:
             patch("nauro.sync.remote.httpx.get", side_effect=fake_get),
             patch("nauro.sync.remote.httpx.post", return_value=presign),
         ):
-            merged = run_pull(CLOUD_PID, cloud_store, reporter)
+            merged = run_pull(CLOUD_PID, cloud_store, reporter).merged
 
         assert merged == 1
         assert (cloud_store / rel).read_bytes() == b"# 099\nfresh remote body\n"
@@ -101,7 +106,7 @@ class TestRunPullCleanPull:
             patch("nauro.sync.remote.httpx.get", side_effect=fake_get),
             patch("nauro.sync.remote.httpx.post", return_value=presign),
         ):
-            merged = run_pull(CLOUD_PID, cloud_store, _RecordingReporter())
+            merged = run_pull(CLOUD_PID, cloud_store, _RecordingReporter()).merged
 
         assert merged == 1
         assert (cloud_store / rel).read_bytes() == _STAMPED_DECISION
@@ -134,7 +139,7 @@ class TestRunPullCleanPull:
             patch("nauro.sync.remote.httpx.get", side_effect=fake_get),
             patch("nauro.sync.remote.httpx.post", return_value=presign),
         ):
-            merged = run_pull(CLOUD_PID, cloud_store, reporter)
+            merged = run_pull(CLOUD_PID, cloud_store, reporter).merged
 
         assert merged == 1
         merged_bytes = local.read_bytes()
@@ -1496,6 +1501,105 @@ class TestLocallyDeletedFiles:
         assert "decisions/009-remote.md" in state.files
         assert "stack.md" in state.files
 
+    def test_a_deleted_file_comes_back_when_the_remote_never_moved(self, collision_store):
+        """Deleting a local file changes nothing on the server.
+
+        The etag comparison ran first and matched, so the entry was dropped
+        before anything looked at the disk - on that sync and on every sync
+        after it. The remote store is the record for a file it holds, so a
+        missing local copy asks for the file whatever the etag says.
+        """
+        (collision_store / "stack.md").write_text("# Stack\n\nshared\n")
+        track(collision_store, "stack.md")
+        (collision_store / "stack.md").unlink()
+
+        merged, reporter = pull(
+            collision_store,
+            [("stack.md", b"# Stack\n\nshared\n")],
+            etags={"stack.md": '"pushed"'},
+        )
+
+        assert merged == 1
+        assert (collision_store / "stack.md").read_bytes() == b"# Stack\n\nshared\n"
+        assert reporter.warns == []
+
+    def test_a_deleted_decision_comes_back_when_the_remote_never_moved(self, collision_store):
+        rel = "decisions/004-shared.md"
+        body = decision_bytes(4, "Shared")
+        write_local_decision(collision_store, "004-shared.md", body)
+        track(collision_store, rel)
+        (collision_store / rel).unlink()
+
+        merged, reporter = pull(collision_store, [(rel, body)], etags={rel: '"pushed"'})
+
+        assert merged == 1
+        assert (collision_store / rel).read_bytes() == body
+        assert reporter.warns == []
+
+    def test_an_unchanged_entry_whose_local_copy_is_there_is_still_skipped(self, collision_store):
+        """The shortcut still holds where it was right: no file, no fetch."""
+        (collision_store / "stack.md").write_text("# Stack\n\nshared\n")
+        track(collision_store, "stack.md")
+
+        merged, reporter = pull(
+            collision_store,
+            [("stack.md", b"# Stack\n\nshared\n")],
+            etags={"stack.md": '"pushed"'},
+        )
+
+        assert merged == 0
+        assert reporter.infos == ["No remote changes"]
+
+
+class TestUntrackedLocalFiles:
+    """A file sync state never recorded still has bytes worth keeping.
+
+    The local-change probe reads an untracked file as changed and the conflict
+    probe read it as unchanged, so an entry with local content and a changed
+    remote matched no worklist at all: nothing was written, nothing was warned
+    about, and the remote version was never seen again.
+    """
+
+    def test_the_remote_lands_and_the_local_bytes_go_to_the_backup(self, collision_store):
+        (collision_store / "stack.md").write_bytes(b"# Stack\n\nnever pushed\n")
+
+        merged, _reporter = pull(collision_store, [("stack.md", b"# Stack\n\nremote\n")])
+
+        assert merged == 1
+        assert (collision_store / "stack.md").read_bytes() == b"# Stack\n\nremote\n"
+        backups = list((collision_store / CONFLICT_BACKUP_DIR).iterdir())
+        assert [path.read_bytes() for path in backups] == [b"# Stack\n\nnever pushed\n"]
+        assert load_state(collision_store).files["stack.md"].remote_etag == '"stack.md-v1"'
+
+    def test_an_append_only_file_merges_both_sides_instead(self, collision_store):
+        (collision_store / "open-questions.md").write_text("## Open\n\n- local question\n")
+
+        merged, _reporter = pull(
+            collision_store, [("open-questions.md", b"## Open\n\n- remote question\n")]
+        )
+
+        assert merged == 1
+        text = (collision_store / "open-questions.md").read_text()
+        assert "- local question" in text
+        assert "- remote question" in text
+
+    def test_a_tracked_file_still_keeps_its_local_side(self, collision_store):
+        """A published path's policy is unchanged: the local rewrite wins."""
+        (collision_store / "stack.md").write_bytes(b"# Stack\n\npushed\n")
+        track(collision_store, "stack.md")
+        (collision_store / "stack.md").write_bytes(b"# Stack\n\nlocal rewrite\n")
+
+        merged, _reporter = pull(
+            collision_store,
+            [("stack.md", b"# Stack\n\nremote rewrite\n")],
+            etags={"stack.md": '"v2"'},
+        )
+
+        assert merged == 1
+        assert (collision_store / "stack.md").read_bytes() == b"# Stack\n\nlocal rewrite\n"
+        backups = list((collision_store / CONFLICT_BACKUP_DIR).iterdir())
+        assert [path.read_bytes() for path in backups] == [b"# Stack\n\nremote rewrite\n"]
+
 
 class TestLocalWriteFailures:
     """A local filesystem error stops one file, not the run.
@@ -1597,6 +1701,63 @@ class TestLocalWriteFailures:
         assert "No remote changes" not in reporter.infos
         assert any("next sync" in line for line in reporter.infos)
 
+    def test_a_failed_transfer_holds_back_the_full_sync_timestamp(
+        self, collision_store, monkeypatch
+    ):
+        """A fetch that never arrived is a file the next sync still owes.
+
+        Only a local write error was counted, so a transport failure left the
+        store short of the server while the stamp said the two agreed.
+        """
+
+        def refuse(_url):
+            raise PresignError("connection reset by peer")
+
+        monkeypatch.setattr(pull_module, "fetch_via_presigned_url", refuse)
+
+        merged, reporter = pull(collision_store, [("stack.md", b"# Stack\n\nremote\n")])
+
+        assert merged == 0
+        assert load_state(collision_store).last_full_sync == ""
+        assert any("next sync" in line for line in reporter.infos)
+
+    def test_a_presign_shortfall_holds_back_the_full_sync_timestamp(
+        self, collision_store, monkeypatch
+    ):
+        """A URL the server never minted leaves its file unfetched."""
+        monkeypatch.setattr(pull_module, "request_presigned_urls", lambda *_args: [])
+
+        merged, reporter = pull(
+            collision_store, [("decisions/016-remote.md", decision_bytes(16, "Unfetched"))]
+        )
+
+        assert merged == 0
+        assert not (collision_store / "decisions/016-remote.md").exists()
+        assert load_state(collision_store).last_full_sync == ""
+        assert any("next sync" in line for line in reporter.infos)
+
+    def test_a_quarantine_does_not_hold_back_the_full_sync_timestamp(self, collision_store):
+        """A collision no rerun resolves must not freeze the stamp for good.
+
+        The quarantined decision is reported on its own and surfaced by
+        ``nauro sync --status`` until a person settles the number. Holding the
+        stamp until then would say nothing about the rest of the store, which
+        this run did write in full.
+        """
+        write_local_decision(collision_store, "003-local.md", decision_bytes(3, "Local decision"))
+        track(collision_store, "decisions/003-local.md")
+
+        report, reporter = pull_report(
+            collision_store,
+            [("decisions/003-remote.md", decision_bytes(3, "Remote decision", "Chose B."))],
+        )
+
+        assert report.merged == 0
+        assert report.refused == 0
+        assert report.skipped_permanent == 1
+        assert load_state(collision_store).last_full_sync
+        assert any("cannot install" in line for line in reporter.infos)
+
     def test_a_lock_timeout_leaves_an_unreadable_state_file_alone(
         self, collision_store, monkeypatch
     ):
@@ -1695,3 +1856,65 @@ class TestPartialWrites:
         assert merged == 1
         assert (collision_store / rel).read_bytes() == body
         assert rel in load_state(collision_store).files
+
+
+class TestStrandedTmpSiblings:
+    """A kill between an atomic write and its rename strands a full copy.
+
+    Nothing reads the file and both sync directions exclude it, so no command
+    counted or removed one and a store kept them for its whole life. The pull
+    sweeps them because it already holds the sync lock and already walks the
+    store.
+    """
+
+    @staticmethod
+    def _strand(path: Path, content: bytes, *, age_seconds: float) -> Path:
+        """Leave a tmp sibling of ``path`` behind, as a killed write would."""
+        with patch.object(_atomic.os, "replace", lambda src, dst: None):
+            atomic_write_bytes(path, content)
+        orphan = next(entry for entry in path.parent.iterdir() if is_tmp_sibling(entry.name))
+        stranded_at = time.time() - age_seconds
+        os.utime(orphan, (stranded_at, stranded_at))
+        return orphan
+
+    def test_old_siblings_anywhere_in_the_store_are_swept_and_reported(self, collision_store):
+        backup_dir = collision_store / CONFLICT_BACKUP_DIR
+        backup_dir.mkdir(parents=True, exist_ok=True)
+        in_backups = self._strand(backup_dir / "losing-side.md", b"a backup\n", age_seconds=600)
+        in_store = self._strand(collision_store / "stack.md", b"# Stack\n", age_seconds=600)
+
+        _merged, reporter = pull(collision_store, [])
+
+        assert not in_backups.exists()
+        assert not in_store.exists()
+        assert "Cleaned 2 interrupted write(s)" in reporter.infos
+
+    def test_a_fresh_sibling_is_left_alone(self, collision_store):
+        """The age floor is what keeps the sweep off a write in progress."""
+        live = self._strand(collision_store / "stack.md", b"# Stack\n", age_seconds=0)
+
+        _merged, reporter = pull(collision_store, [])
+
+        assert live.exists()
+        assert not any("interrupted write" in line for line in reporter.infos)
+
+    def test_a_sibling_it_cannot_remove_warns_and_the_pull_carries_on(
+        self, collision_store, monkeypatch
+    ):
+        stranded = self._strand(collision_store / "stack.md", b"# Stack\n", age_seconds=600)
+        real_unlink = Path.unlink
+
+        def refuse(self, *args, **kwargs):
+            if is_tmp_sibling(self.name):
+                raise PermissionError(13, "Permission denied")
+            return real_unlink(self, *args, **kwargs)
+
+        monkeypatch.setattr(pull_module.Path, "unlink", refuse)
+
+        merged, reporter = pull(
+            collision_store, [("decisions/017-remote.md", decision_bytes(17, "Remote"))]
+        )
+
+        assert merged == 1
+        assert stranded.exists()
+        assert any("interrupted write" in warning for warning in reporter.warns)

--- a/packages/nauro/tests/test_sync/test_pull.py
+++ b/packages/nauro/tests/test_sync/test_pull.py
@@ -2036,3 +2036,33 @@ class TestStrandedTmpSiblings:
         assert merged == 1
         assert stranded.exists()
         assert any("interrupted write" in warning for warning in reporter.warns)
+
+    def test_a_walk_that_breaks_partway_still_lets_the_pull_run(self, collision_store, monkeypatch):
+        """The sweep is best-effort hygiene, not a gate on the sync.
+
+        It runs before the manifest fetch, so an error escaping the traversal
+        aborts a pull that never started, and the session-start hook swallows
+        that into a silently skipped sync. A directory can vanish underneath
+        the walk at any time: the store is one other processes write into.
+        """
+        stranded = self._strand(collision_store / "stack.md", b"# Stack\n", age_seconds=600)
+        real_rglob = Path.rglob
+
+        def break_partway(self, *args, **kwargs):
+            if self != collision_store:
+                yield from real_rglob(self, *args, **kwargs)
+                return
+            yield stranded
+            raise OSError(5, "Input/output error")
+
+        monkeypatch.setattr(pull_module.Path, "rglob", break_partway)
+
+        merged, reporter = pull(
+            collision_store, [("decisions/020-remote.md", decision_bytes(20, "Remote"))]
+        )
+
+        assert merged == 1
+        assert (collision_store / "decisions/020-remote.md").exists()
+        # What the walk reached before it broke was still cleaned up.
+        assert not stranded.exists()
+        assert any("could not finish looking" in warning for warning in reporter.warns)

--- a/packages/nauro/tests/test_sync/test_pull.py
+++ b/packages/nauro/tests/test_sync/test_pull.py
@@ -1550,6 +1550,56 @@ class TestLocallyDeletedFiles:
         assert merged == 0
         assert reporter.infos == ["No remote changes"]
 
+    def test_a_locally_modified_file_with_an_unchanged_remote_is_left_alone(self, collision_store):
+        """An unmoved remote has nothing to say about a local edit.
+
+        The shortcut is what protects work in progress. Moving the local-change
+        probe above it would fetch the entry, call the edit a conflict, and
+        rewrite or back up a file the server never changed.
+        """
+        (collision_store / "stack.md").write_text("# Stack\n\npushed\n")
+        track(collision_store, "stack.md")
+        recorded = load_state(collision_store).files["stack.md"].local_sha256
+        (collision_store / "stack.md").write_text("# Stack\n\nlocal edit\n")
+
+        merged, reporter = pull(
+            collision_store,
+            [("stack.md", b"# Stack\n\npushed\n")],
+            etags={"stack.md": '"pushed"'},
+        )
+
+        assert merged == 0
+        assert (collision_store / "stack.md").read_text() == "# Stack\n\nlocal edit\n"
+        assert not (collision_store / CONFLICT_BACKUP_DIR).exists()
+        assert load_state(collision_store).files["stack.md"].local_sha256 == recorded
+        assert reporter.infos == ["No remote changes"]
+
+    def test_a_deleted_decision_is_classified_before_it_is_reinstalled(self, collision_store):
+        """Deleting a decision frees the number a local writer can then mint.
+
+        Sync state still tracks the path, and a tracked canonical decision is
+        exempt from the classifier as an ordinary same-path update. That holds
+        only while the file is there: reinstalling it without a verdict would
+        put two files on one number and push the duplicate.
+        """
+        rel = "decisions/004-foo.md"
+        body = decision_bytes(4, "Foo")
+        write_local_decision(collision_store, "004-foo.md", body)
+        track(collision_store, rel)
+        (collision_store / rel).unlink()
+        # A local writer takes the freed number before the next sync.
+        write_local_decision(collision_store, "004-bar.md", decision_bytes(4, "Bar", "Chose B."))
+
+        merged, reporter = pull(collision_store, [(rel, body)], etags={rel: '"pushed"'})
+
+        names = entry_names(collision_store / "decisions")
+        assert merged == 1
+        assert (collision_store / rel).read_bytes() == body
+        assert "004-bar.md" not in names
+        assert [name for name in names if name.startswith("004-")] == ["004-foo.md"]
+        assert any(name.endswith("-bar.md") for name in names)
+        assert any("Renumbered" in line for line in reporter.infos)
+
 
 class TestUntrackedLocalFiles:
     """A file sync state never recorded still has bytes worth keeping.

--- a/packages/nauro/tests/test_sync/test_sync_command.py
+++ b/packages/nauro/tests/test_sync/test_sync_command.py
@@ -88,6 +88,37 @@ class TestSyncExitCode:
         assert result.exit_code == 2, result.output
         assert "2 remote file(s) were not written" in result.output
 
+    def test_a_pull_that_never_read_the_server_exits_two(self, project_store, monkeypatch):
+        """An empty report used to say the same thing as a store in step."""
+        self._stub_pull(monkeypatch, PullReport(manifest_read=False))
+
+        result = runner.invoke(app, ["sync"])
+
+        assert result.exit_code == 2, result.output
+        assert "could not read the server's file list" in result.output
+
+    def test_the_push_still_runs_before_that_exit(self, project_store, monkeypatch):
+        """The push order is unchanged: the snapshot is local work worth keeping."""
+        from nauro.cli.commands import sync as sync_mod
+
+        call_order = []
+
+        def mock_pull(_project_name, _store_path):
+            call_order.append("pull")
+            return PullReport(manifest_read=False)
+
+        def mock_push(_project_name, _store_path):
+            call_order.append("push")
+            return True
+
+        monkeypatch.setattr(sync_mod, "_pull_from_cloud", mock_pull)
+        monkeypatch.setattr(sync_mod, "_push_to_cloud", mock_push)
+
+        result = runner.invoke(app, ["sync"])
+
+        assert call_order == ["pull", "push"]
+        assert result.exit_code == 2, result.output
+
     def test_a_permanent_skip_alone_exits_zero(self, project_store, monkeypatch):
         """A quarantined collision has its own surface and no retry to offer."""
         self._stub_pull(monkeypatch, PullReport(skipped_permanent=1))

--- a/packages/nauro/tests/test_sync/test_sync_command.py
+++ b/packages/nauro/tests/test_sync/test_sync_command.py
@@ -8,6 +8,7 @@ from typer.testing import CliRunner
 
 from nauro.cli.main import app
 from nauro.store.registry import register_project_v2
+from nauro.sync.pull import PullReport
 from nauro.templates.scaffolds import scaffold_project_store
 from tests.conftest import seed_auth_config
 from tests.test_sync.conftest import _scaffolded_cloud_project
@@ -36,7 +37,7 @@ class TestSyncPullBeforePush:
 
         def mock_pull(project_name, store_path):
             call_order.append("pull")
-            return 0
+            return PullReport()
 
         def mock_push(project_name, store_path):
             call_order.append("push")
@@ -56,6 +57,56 @@ class TestSyncPullBeforePush:
         assert "local-only project; nothing to upload" in result.output
         # No "Pulling from remote" because sync is not configured
         assert "Pulling from remote" not in result.output
+
+
+class TestSyncExitCode:
+    """The exit code says whether the store now holds what the server has.
+
+    A pull that could not write a file used to exit 0, so a script that syncs
+    and then reads the store had no way to know it was reading a store the run
+    itself knew was short.
+    """
+
+    @staticmethod
+    def _stub_pull(monkeypatch, report: PullReport) -> None:
+        from nauro.cli.commands import sync as sync_mod
+
+        monkeypatch.setattr(sync_mod, "_pull_from_cloud", lambda *_args: report)
+
+    def test_a_clean_pull_exits_zero(self, project_store, monkeypatch):
+        self._stub_pull(monkeypatch, PullReport(merged=3))
+
+        result = runner.invoke(app, ["sync"])
+
+        assert result.exit_code == 0, result.output
+
+    def test_a_refused_file_exits_two(self, project_store, monkeypatch):
+        self._stub_pull(monkeypatch, PullReport(merged=1, refused=2))
+
+        result = runner.invoke(app, ["sync"])
+
+        assert result.exit_code == 2, result.output
+        assert "2 remote file(s) were not written" in result.output
+
+    def test_a_permanent_skip_alone_exits_zero(self, project_store, monkeypatch):
+        """A quarantined collision has its own surface and no retry to offer."""
+        self._stub_pull(monkeypatch, PullReport(skipped_permanent=1))
+
+        result = runner.invoke(app, ["sync"])
+
+        assert result.exit_code == 0, result.output
+
+    def test_a_push_failure_still_exits_one(self, project_store, monkeypatch):
+        from nauro.cli.commands import sync as sync_mod
+
+        self._stub_pull(monkeypatch, PullReport(refused=1))
+        monkeypatch.setattr(sync_mod, "_push_to_cloud", lambda *_args: False)
+
+        result = runner.invoke(app, ["sync"])
+
+        # The command's own failure outranks the pull's unfinished business.
+        assert result.exit_code == 1, result.output
+        assert "cloud push failed" in result.output
 
 
 class TestSyncSnapshotIsPrimaryWork:
@@ -80,12 +131,11 @@ class TestSyncSnapshotIsPrimaryWork:
 class TestSyncPullNoConfig:
     """Verify pull is a no-op when S3 is not configured."""
 
-    def test_pull_returns_zero_when_not_configured(self, project_store):
-        """_pull_from_cloud should return 0 when sync is not configured."""
+    def test_pull_returns_an_empty_report_when_not_configured(self, project_store):
+        """_pull_from_cloud reports nothing done when sync is not configured."""
         from nauro.cli.commands.sync import _pull_from_cloud
 
-        result = _pull_from_cloud("testproj", project_store)
-        assert result == 0
+        assert _pull_from_cloud("testproj", project_store) == PullReport()
 
 
 class TestSyncPreservesState:

--- a/packages/nauro/tests/test_sync/test_sync_presign.py
+++ b/packages/nauro/tests/test_sync/test_sync_presign.py
@@ -194,7 +194,7 @@ class TestPullViaPresign:
         ):
             from nauro.cli.commands.sync import _pull_from_cloud
 
-            merged = _pull_from_cloud(cloud_store.name, cloud_store)
+            merged = _pull_from_cloud(cloud_store.name, cloud_store).merged
 
         # Both files came back through the diff.
         assert merged == 2
@@ -227,7 +227,7 @@ class TestPullViaPresign:
         ):
             from nauro.cli.commands.sync import _pull_from_cloud
 
-            merged = _pull_from_cloud(cloud_store.name, cloud_store)
+            merged = _pull_from_cloud(cloud_store.name, cloud_store).merged
 
         assert merged == 0
         mock_post.assert_not_called()
@@ -253,7 +253,7 @@ class TestPullViaPresign:
         ):
             from nauro.cli.commands.sync import _pull_from_cloud
 
-            merged = _pull_from_cloud(cloud_store.name, cloud_store)
+            merged = _pull_from_cloud(cloud_store.name, cloud_store).merged
 
         # Presign request: payload carries project_id and the GET op.
         assert mock_post.call_count == 1
@@ -304,7 +304,7 @@ class TestPullViaPresign:
         ):
             from nauro.cli.commands.sync import _pull_from_cloud
 
-            merged = _pull_from_cloud(cloud_store.name, cloud_store)
+            merged = _pull_from_cloud(cloud_store.name, cloud_store).merged
 
         assert merged == 1
         # last-write-wins kept the local body — verify by sha
@@ -342,7 +342,7 @@ class TestPullViaPresign:
         ):
             from nauro.cli.commands.sync import _pull_from_cloud
 
-            merged = _pull_from_cloud(cloud_store.name, cloud_store)
+            merged = _pull_from_cloud(cloud_store.name, cloud_store).merged
 
         assert merged == 1
         # The 401 forced a refresh and a retry of the manifest call.
@@ -380,7 +380,7 @@ class TestPullViaPresign:
         ):
             from nauro.cli.commands.sync import _pull_from_cloud
 
-            merged = _pull_from_cloud(cloud_store.name, cloud_store)
+            merged = _pull_from_cloud(cloud_store.name, cloud_store).merged
 
         assert merged == 1
         presign_calls = [c for c in mock_post.call_args_list if "/sync/presign" in c.args[0]]


### PR DESCRIPTION
## Why

Five defects in the sync pull let it report success over work it did not do.

A file the user deletes locally does not change anything on the server. The pull compared etags before it looked at the disk, so it skipped the entry. The file stayed deleted on that sync and on every sync after it.

An untracked local file with a changed remote matched no worklist at all. The local-change probe called it changed. The conflict probe called it unchanged. The pull wrote nothing, warned about nothing, and the remote version was gone.

The tally that holds back the "last full sync" stamp counted local write errors only. A failed transfer, a presign URL the server did not mint, or a gated decision that never arrived all let the stamp advance over files that never landed. `nauro sync` then exited 0 in every one of these cases.

A kill between an atomic write and its rename strands a full copy of the file under a name nothing reads. No command counted, cleaned, or reported one, so a store kept them for its whole life.

## What changed

**Triage order.** The pull now resolves the local path and runs its safety guards first. It skips an unchanged remote entry only when the local file is still there. A missing local copy asks for the file whatever the etag says, because the remote store is the record for a file it holds.

A missing decision file goes through the classifier, never straight to disk. The gate used to exempt a canonical path that sync state tracks, as an ordinary same-path update. That is only true while the file exists. Once it is gone the number is free, a local writer can mint a different file onto it, and a plain reinstall would leave two files on one number and push the duplicate. The gate now asks for the file on disk as well, in the predicate both the planner and the write barrier call, so the two cannot answer differently.

**Untracked local files.** These route through the conflict path. The remote copy installs and the local bytes go to `.conflict-backup`, because an untracked path was never published from here and has no shared ancestor. Append-only files still merge both sides. A tracked file keeps its existing policy: last-write-wins keeps the local copy.

**Two counts, not one.** `refused` holds transient shapes a later sync can fix: a local write error, a failed fetch, a presign shortfall, a gated decision with no transfer. These hold back the stamp. `skipped_permanent` holds shapes no rerun resolves: a path outside the store, a path an ordinary pull may not write, a quarantined collision. These are reported and nothing more, because holding the stamp for one would freeze it for good.

Both counts cover manifest rows this run was asked to install. A local file that was already irregular is the store's own hygiene: it keeps its warning on every run and enters neither count.

**Exit code.** `run_pull` returns a typed report. `nauro sync` exits 2 when the pull left work behind. That covers two shapes. Files it could not fetch or write are counted. A run that could not read the server's file list at all carries no count, because it never learned how much it missed, so the report says that directly instead of reporting zero files owed. Before this, both shapes exited 0 and the command pushed over a pull that never ran. A failure of the command itself still exits 1 and outranks both. Permanent skips do not change the exit code. The session-start hook is unchanged: it takes the merged count and swallows everything, as before.

A presign request that fails as a whole now counts every planned file. The run summary also runs for a leg that stops early, so the count reaches the user instead of the run falling silent after one warning.

**Sweep.** At pull start, under the sync lock, the pull removes tmp siblings older than 60 seconds and reports how many. An atomic write lives for milliseconds, so a minute-old tmp file is garbage. The age floor keeps the sweep off a write in progress. One file it cannot remove is a warning, not an aborted pull.

Also: `.conflict-backup` comes from the shared constant in two places that spelled it by hand.

## Risk / what to review

The untracked-local conflict now keeps the remote side. This is the one behavior choice in the change. Both copies survive either way, so nothing is lost, but the file on disk after the pull differs from before. The tracked case is byte-identical to today, and the decision classifier still passes the local side explicitly.

`nauro sync` can now exit 2 where it exited 0. Any script that treats a nonzero exit as a hard failure will see the difference on a store the pull could not finish. The push order is unchanged.

`detect_conflict` is gone. The reorder removed its last caller, and it was half of the untracked defect: it answered the same question as the local change probe and gave a different answer. The pull now asks once.

## Test plan

`uv run pytest packages/nauro/tests/ -q`: 2517 passed, 10 skipped.
`uv run pytest packages/nauro-core/tests/ -q`: 1526 passed.
`uv run ruff check packages/` and `ruff format --check packages/`: clean.

New coverage:

- A deleted local file comes back when the etag never moved, for a plain store file and for a decision.
- A tracked decision deleted locally, with the number re-minted by a local writer and the etag unmoved: the restored file lands, the local file moves off the number, and one file holds it.
- An unchanged entry whose local copy is present is still skipped.
- A locally modified file with an unchanged remote is left completely alone: no fetch, no backup, no overwrite.
- An untracked local file: the remote lands, the local bytes reach the backup directory, an append-only file merges both sides instead, and a tracked file still keeps its local side.
- A failed transfer and a presign shortfall each hold back the stamp and report the file for the next sync.
- A manifest fetch failure and an auth failure both report that the run never read the server's file list. The stamp is held and the command exits 2 with the push still run.
- A presign request that fails as a whole counts every planned file, holds the stamp, and reports the total.
- A quarantine does not hold back the stamp and reports itself as a permanent skip.
- Stranded tmp siblings in the store root and in `.conflict-backup` are swept and reported. A fresh one survives. One the pull cannot remove warns, and the pull carries on.
- A walk that breaks partway still lets the pull run. The sweep keeps what it reached, reports the failure, and the sync completes.
- `nauro sync` exits 2 on a refused file, 0 on a clean pull, 0 on a permanent skip alone, and 1 when the push fails.

## Merge order

This branch and the attach restore branch both touch `packages/nauro/src/nauro/sync/pull.py` and `tests/test_sync/test_sync_presign.py`. Merge this one first.
