### PR TITLE
Render every write-envelope status truthfully on the stdio surface

### DIFF
--- a/packages/nauro/src/nauro/mcp/stdio_server.py
+++ b/packages/nauro/src/nauro/mcp/stdio_server.py
@@ -23,6 +23,13 @@ output. Write tools keep their existing single-value shape. A tool name
 missing from ``RENDERERS`` (an older installed nauro-core) falls back to
 a JSON dump of the envelope, so the wrapper degrades gracefully instead
 of crashing.
+
+The two write tools that answer with a flat string — ``flag_question``
+and ``update_state`` — route every envelope through
+``nauro.mcp.write_status.render_write_status``, which owns the
+status-to-line dispatch. Each wrapper supplies only the line for a write
+that committed. ``propose_decision`` returns the envelope itself and
+needs no such seam.
 """
 
 from __future__ import annotations
@@ -61,9 +68,9 @@ from nauro.mcp.tools import (
     tool_search_decisions,
     tool_update_state,
 )
+from nauro.mcp.write_status import render_write_status
 from nauro.onboarding import WELCOME_NO_PROJECT
 from nauro.store.journal import OriginDescriptor
-from nauro.store.post_commit import with_assessment
 from nauro.store.repo_head import resolve_repo_head
 from nauro.store.resolution import (
     DisconnectedProject,
@@ -476,15 +483,16 @@ def flag_question(
         resolved_by=resolved_by,
         origin=_origin_from_ctx(mcp_ctx),
     )
-    if result.get("status") == "rejected":
-        error = result.get("error") or {}
-        reason = str(error.get("reason", "Flag rejected."))
-        return reason
-    if resolved_by is not None:
-        return with_assessment("Question(s) resolved.", result)
-    if result.get("hint"):
-        return with_assessment(f"{result['hint']} The question has still been logged.", result)
-    return with_assessment("Question flagged.", result)
+
+    def flagged() -> str:
+        """The confirmation line for a question the kernel did write."""
+        if resolved_by is not None:
+            return "Question(s) resolved."
+        if result.get("hint"):
+            return f"{result['hint']} The question has still been logged."
+        return "Question flagged."
+
+    return render_write_status(result, flagged)
 
 
 @mcp.tool(**_spec_kwargs("update_state"))
@@ -500,9 +508,13 @@ def update_state(
     if err is not None:
         return err if disconnected_reason_code(err) is not None else err["guidance"]
     result = tool_update_state(store_path, delta, origin=_origin_from_ctx(mcp_ctx))
-    if result.get("warning"):
-        return with_assessment(f"State updated. {result['warning']}", result)
-    return with_assessment("State updated.", result)
+
+    def updated() -> str:
+        """The confirmation line for a state body the kernel did write."""
+        warning = result.get("warning")
+        return f"State updated. {warning}" if warning else "State updated."
+
+    return render_write_status(result, updated)
 
 
 def _pull_on_startup() -> None:

--- a/packages/nauro/src/nauro/mcp/write_status.py
+++ b/packages/nauro/src/nauro/mcp/write_status.py
@@ -8,9 +8,10 @@ string, so a kernel rejection, a noop, and a store-missing failure all told
 the agent the write had landed.
 
 The rule here is one line per status, and the wrapper's success renderer runs
-on ``ok`` alone. A status with nothing else to say still gets a line that
-names the outcome, and an unrecognised status renders the status itself
-rather than borrowing a neighbour's meaning.
+on the ``ok`` status and on nothing else. A status with nothing else to say
+still gets a line that names the outcome. An unrecognised status renders the
+status itself rather than borrowing a neighbour's meaning, and an envelope
+that carries no status at all reads as unconfirmed rather than as a success.
 
 Only the flat-string wrappers use this seam. ``propose_decision`` returns the
 envelope itself on every status, so it has nothing to flatten.
@@ -24,6 +25,12 @@ from pydantic import BaseModel, ConfigDict
 
 from nauro.store.post_commit import with_assessment
 
+# The committed status of every write tool this seam serves. It is not the
+# project-wide committed vocabulary: ``propose_decision`` commits under
+# ``confirmed`` (see ``ProposeDecisionResult``), and it returns the dict
+# envelope on every status, so it never routes here. A new string-rendering
+# write tool whose success status is not ``ok`` needs this constant widened
+# before it can use this seam.
 OK_STATUS = "ok"
 
 # The line for a status whose envelope carries no explanatory text of its own.
@@ -31,11 +38,20 @@ OK_STATUS = "ok"
 # the flat string exists to carry.
 _STATUS_FALLBACKS: dict[str, str] = {
     "rejected": "The write was rejected. Nothing was recorded.",
-    "noop": "No write was made. The store reported nothing to update.",
+    # ``noop`` has one producer today: ``update_state`` early-returns it when
+    # the store holds neither ``state_current.md`` nor the legacy
+    # ``state.md``, so the remedy can name that file. A second noop-emitting
+    # write tool has to revisit this line.
+    "noop": (
+        "No write was made. The store has no state file to update. "
+        "Run 'nauro status' for the store path, then restore state_current.md there."
+    ),
     "error": "The write did not run. Nothing was recorded.",
 }
 
 _UNKNOWN_STATUS = "Unexpected write status {status!r}. Treat the write as unconfirmed."
+
+_NO_STATUS = "The envelope carried no write status. Treat the write as unconfirmed."
 
 
 class EnvelopeError(BaseModel):
@@ -64,7 +80,10 @@ class WriteEnvelope(BaseModel):
 
     model_config = ConfigDict(frozen=True, extra="ignore")
 
-    status: str = OK_STATUS
+    # An envelope with no status is a broken envelope, not a success. The
+    # empty default reaches the unconfirmed line below, which is the whole
+    # point of this module one field over.
+    status: str = ""
     error: EnvelopeError | None = None
     guidance: str | None = None
 
@@ -72,11 +91,14 @@ class WriteEnvelope(BaseModel):
     def detail(self) -> str | None:
         """The envelope's own account of the outcome, if it carries one.
 
-        A rejection puts it in ``error.reason``; a store-missing failure puts
-        it in the top-level ``guidance``.
+        Most specific text first: a rejection puts it in ``error.reason``,
+        a rejection with a remedial action adds ``error.guidance``, and a
+        store-missing failure puts it in the top-level ``guidance``.
         """
-        if self.error is not None and self.error.reason:
-            return self.error.reason
+        if self.error is not None:
+            reason = self.error.reason or self.error.guidance
+            if reason:
+                return reason
         return self.guidance or None
 
     def line(self, success: Callable[[], str]) -> str:
@@ -86,8 +108,13 @@ class WriteEnvelope(BaseModel):
         fallback = _STATUS_FALLBACKS.get(self.status)
         if fallback is not None:
             return self.detail or fallback
-        unknown = _UNKNOWN_STATUS.format(status=self.status)
-        return f"{unknown} {self.detail}" if self.detail else unknown
+        # No status and an unreadable status are the same outcome to the
+        # caller: the store did not confirm the write.
+        unconfirmed = _UNKNOWN_STATUS.format(status=self.status) if self.status else _NO_STATUS
+        # A single space joins the two. Every ``detail`` that reaches here is
+        # envelope prose that starts its own sentence, so the seam reads as
+        # one paragraph even when the prose runs to several lines.
+        return f"{unconfirmed} {self.detail}" if self.detail else unconfirmed
 
 
 def render_write_status(envelope: dict, success: Callable[[], str]) -> str:

--- a/packages/nauro/src/nauro/mcp/write_status.py
+++ b/packages/nauro/src/nauro/mcp/write_status.py
@@ -1,0 +1,107 @@
+"""Render one local write envelope down to a single truthful line.
+
+The stdio transport answers a write tool with one advisory line rather than
+the dict envelope every other local surface returns. That flattening is the
+risk this module exists to remove: each wrapper used to test the one status
+it cared about and let every other status fall through to its own success
+string, so a kernel rejection, a noop, and a store-missing failure all told
+the agent the write had landed.
+
+The rule here is one line per status, and the wrapper's success renderer runs
+on ``ok`` alone. A status with nothing else to say still gets a line that
+names the outcome, and an unrecognised status renders the status itself
+rather than borrowing a neighbour's meaning.
+
+Only the flat-string wrappers use this seam. ``propose_decision`` returns the
+envelope itself on every status, so it has nothing to flatten.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from pydantic import BaseModel, ConfigDict
+
+from nauro.store.post_commit import with_assessment
+
+OK_STATUS = "ok"
+
+# The line for a status whose envelope carries no explanatory text of its own.
+# Every one of them says what happened to the write, because that is the fact
+# the flat string exists to carry.
+_STATUS_FALLBACKS: dict[str, str] = {
+    "rejected": "The write was rejected. Nothing was recorded.",
+    "noop": "No write was made. The store reported nothing to update.",
+    "error": "The write did not run. Nothing was recorded.",
+}
+
+_UNKNOWN_STATUS = "Unexpected write status {status!r}. Treat the write as unconfirmed."
+
+
+class EnvelopeError(BaseModel):
+    """The ``error`` block of a write envelope, read for its prose.
+
+    Deliberately looser than ``nauro_core.operations.ErrorPayload``, which
+    forbids extra keys and requires ``kind``. This is a presentation
+    boundary: a core release that adds a field to the error payload must not
+    turn a renderable envelope into an exception here.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="ignore")
+
+    reason: str | None = None
+    guidance: str | None = None
+
+
+class WriteEnvelope(BaseModel):
+    """The status-bearing fields of a local write envelope.
+
+    Parsed at the transport boundary so the dispatch reads typed attributes
+    instead of walking the raw dict. Extra keys are ignored on purpose: each
+    write tool carries its own payload (``warning``, ``hint``, ``project``)
+    that the status dispatch has no business knowing about.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="ignore")
+
+    status: str = OK_STATUS
+    error: EnvelopeError | None = None
+    guidance: str | None = None
+
+    @property
+    def detail(self) -> str | None:
+        """The envelope's own account of the outcome, if it carries one.
+
+        A rejection puts it in ``error.reason``; a store-missing failure puts
+        it in the top-level ``guidance``.
+        """
+        if self.error is not None and self.error.reason:
+            return self.error.reason
+        return self.guidance or None
+
+    def line(self, success: Callable[[], str]) -> str:
+        """The one line this envelope's status warrants."""
+        if self.status == OK_STATUS:
+            return success()
+        fallback = _STATUS_FALLBACKS.get(self.status)
+        if fallback is not None:
+            return self.detail or fallback
+        unknown = _UNKNOWN_STATUS.format(status=self.status)
+        return f"{unknown} {self.detail}" if self.detail else unknown
+
+
+def render_write_status(envelope: dict, success: Callable[[], str]) -> str:
+    """Render *envelope* as one line, calling *success* only on ``ok``.
+
+    Args:
+        envelope: The dict a write adapter in ``nauro.mcp.tools`` returned.
+        success: Builds the wrapper's own confirmation line. Called on the
+            ``ok`` status and on no other, so a wrapper cannot report a
+            write that did not happen.
+
+    Returns:
+        The line for the envelope's status, carrying any post-commit
+        assessment the envelope holds. A write that did not commit has no
+        assessment to carry, so the two compose without a special case.
+    """
+    return with_assessment(WriteEnvelope.model_validate(envelope).line(success), envelope)

--- a/packages/nauro/tests/test_flag_question_parity.py
+++ b/packages/nauro/tests/test_flag_question_parity.py
@@ -288,6 +288,29 @@ class TestStdioCarriesTheAssessment:
 class TestStdioNamesEveryStatus:
     """A status that wrote nothing must never read as a flagged question."""
 
+    def test_an_over_length_question_reports_the_rejection(self, seeded_repo):
+        pid, store_path = seeded_repo
+        overlong = "x" * 10_000
+        before = (store_path / "open-questions.md").read_text()
+
+        stdio_string = stdio_flag_question(question=overlong, project_id=pid)
+
+        assert "Question flagged." not in stdio_string
+        assert stdio_string == tool_flag_question(store_path, overlong)["error"]["reason"]
+        assert (store_path / "open-questions.md").read_text() == before
+
+    def test_an_envelope_fragment_reports_the_rejection(self, seeded_repo):
+        pid, store_path = seeded_repo
+        leaked = "Should we ship X?</parameter>"
+        before = (store_path / "open-questions.md").read_text()
+
+        stdio_string = stdio_flag_question(question=leaked, project_id=pid)
+
+        assert "Question flagged." not in stdio_string
+        assert stdio_string == tool_flag_question(store_path, leaked)["error"]["reason"]
+        assert "</parameter>" in stdio_string
+        assert (store_path / "open-questions.md").read_text() == before
+
     def test_a_store_lost_after_resolution_reports_the_guidance(
         self, seeded_repo, tmp_path, monkeypatch
     ):
@@ -311,4 +334,7 @@ class TestStdioNamesEveryStatus:
         stdio_string = stdio_flag_question(resolved_by="D42", targets=["Q1"], project_id=pid)
 
         assert "Question(s) resolved." not in stdio_string
-        assert "nauro init" in stdio_string
+        assert (
+            stdio_string
+            == tool_flag_question(vanished, resolved_by="D42", targets=["Q1"])["guidance"]
+        )

--- a/packages/nauro/tests/test_flag_question_parity.py
+++ b/packages/nauro/tests/test_flag_question_parity.py
@@ -26,6 +26,7 @@ import pytest
 from typer.testing import CliRunner
 
 from nauro.cli.main import app as cli_app
+from nauro.mcp import stdio_server as stdio_module
 from nauro.mcp import tools as mcp_tools
 from nauro.mcp.stdio_server import flag_question as stdio_flag_question
 from nauro.mcp.tools import tool_flag_question
@@ -282,3 +283,32 @@ class TestStdioCarriesTheAssessment:
         assert stdio_flag_question(resolved_by="D42", targets=["Q1"], project_id=pid) == (
             "Question(s) resolved."
         )
+
+
+class TestStdioNamesEveryStatus:
+    """A status that wrote nothing must never read as a flagged question."""
+
+    def test_a_store_lost_after_resolution_reports_the_guidance(
+        self, seeded_repo, tmp_path, monkeypatch
+    ):
+        """The store-missing race: resolution succeeded, then the store went."""
+        pid, _store_path = seeded_repo
+        vanished = tmp_path / "vanished-store"
+        monkeypatch.setattr(stdio_module, "_resolve_store", lambda *_a, **_kw: vanished)
+
+        stdio_string = stdio_flag_question(question="Should we ship X?", project_id=pid)
+
+        assert "Question flagged." not in stdio_string
+        assert stdio_string == tool_flag_question(vanished, "Should we ship X?")["guidance"]
+
+    def test_a_lost_store_does_not_read_as_a_resolve_either(
+        self, seeded_repo, tmp_path, monkeypatch
+    ):
+        pid, _store_path = seeded_repo
+        vanished = tmp_path / "vanished-store"
+        monkeypatch.setattr(stdio_module, "_resolve_store", lambda *_a, **_kw: vanished)
+
+        stdio_string = stdio_flag_question(resolved_by="D42", targets=["Q1"], project_id=pid)
+
+        assert "Question(s) resolved." not in stdio_string
+        assert "nauro init" in stdio_string

--- a/packages/nauro/tests/test_mcp_write_status.py
+++ b/packages/nauro/tests/test_mcp_write_status.py
@@ -26,9 +26,29 @@ def test_ok_returns_the_wrapper_success_line():
     assert render_write_status({"store": "local", "status": "ok"}, _success) == "Committed."
 
 
-def test_a_missing_status_reads_as_ok():
-    """Adapters always stamp a status; an envelope without one is a success."""
-    assert render_write_status({"store": "local"}, _success) == "Committed."
+def test_an_envelope_with_no_status_is_not_a_success():
+    """Every adapter stamps a status. One that does not is a broken envelope."""
+    assert render_write_status({"store": "local"}, _explode) == (
+        "The envelope carried no write status. Treat the write as unconfirmed."
+    )
+
+
+def test_an_envelope_with_no_status_still_carries_its_text():
+    envelope = {"store": "local", "guidance": "Run 'nauro init <name>'."}
+    assert render_write_status(envelope, _explode) == (
+        "The envelope carried no write status. Treat the write as unconfirmed. "
+        "Run 'nauro init <name>'."
+    )
+
+
+def test_a_rejection_falls_back_to_its_remedial_guidance():
+    """``error.guidance`` is read when the payload carries no reason text."""
+    envelope = {
+        "store": "local",
+        "status": "rejected",
+        "error": {"kind": "rejected", "reason": "", "guidance": "Shorten the delta."},
+    }
+    assert render_write_status(envelope, _explode) == "Shorten the delta."
 
 
 def test_rejected_returns_the_error_reason_alone():
@@ -49,7 +69,11 @@ def test_error_returns_the_guidance():
     ("status", "expected"),
     [
         ("rejected", "The write was rejected. Nothing was recorded."),
-        ("noop", "No write was made. The store reported nothing to update."),
+        (
+            "noop",
+            "No write was made. The store has no state file to update. "
+            "Run 'nauro status' for the store path, then restore state_current.md there.",
+        ),
         ("error", "The write did not run. Nothing was recorded."),
     ],
 )

--- a/packages/nauro/tests/test_mcp_write_status.py
+++ b/packages/nauro/tests/test_mcp_write_status.py
@@ -1,0 +1,88 @@
+"""Unit pins for the stdio write-status renderer.
+
+``render_write_status`` is the one place the stdio transport turns a write
+envelope into the single line it is allowed to return. The parity suites
+drive it through the real adapters; these tests drive it directly with
+synthetic envelopes, which is the only way to reach a status no adapter
+emits today.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nauro.mcp.write_status import render_write_status
+
+
+def _success() -> str:
+    return "Committed."
+
+
+def _explode() -> str:
+    raise AssertionError("the success renderer ran off the ok path")
+
+
+def test_ok_returns_the_wrapper_success_line():
+    assert render_write_status({"store": "local", "status": "ok"}, _success) == "Committed."
+
+
+def test_a_missing_status_reads_as_ok():
+    """Adapters always stamp a status; an envelope without one is a success."""
+    assert render_write_status({"store": "local"}, _success) == "Committed."
+
+
+def test_rejected_returns_the_error_reason_alone():
+    envelope = {
+        "store": "local",
+        "status": "rejected",
+        "error": {"kind": "rejected", "reason": "Delta exceeds 8000 characters."},
+    }
+    assert render_write_status(envelope, _explode) == "Delta exceeds 8000 characters."
+
+
+def test_error_returns_the_guidance():
+    envelope = {"store": "local", "status": "error", "guidance": "Run 'nauro init <name>'."}
+    assert render_write_status(envelope, _explode) == "Run 'nauro init <name>'."
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        ("rejected", "The write was rejected. Nothing was recorded."),
+        ("noop", "No write was made. The store reported nothing to update."),
+        ("error", "The write did not run. Nothing was recorded."),
+    ],
+)
+def test_a_silent_envelope_still_names_the_outcome(status, expected):
+    """No reason and no guidance still yields a line about the write."""
+    assert render_write_status({"store": "local", "status": status}, _explode) == expected
+
+
+def test_an_unknown_status_names_itself():
+    envelope = {"store": "local", "status": "quarantined"}
+    assert render_write_status(envelope, _explode) == (
+        "Unexpected write status 'quarantined'. Treat the write as unconfirmed."
+    )
+
+
+def test_an_unknown_status_carries_whatever_text_it_has():
+    envelope = {
+        "store": "local",
+        "status": "quarantined",
+        "error": {"kind": "error", "reason": "The record awaits review."},
+    }
+    assert render_write_status(envelope, _explode) == (
+        "Unexpected write status 'quarantined'. Treat the write as unconfirmed. "
+        "The record awaits review."
+    )
+
+
+def test_the_assessment_rides_along_on_the_success_line():
+    envelope = {"store": "local", "status": "ok", "assessment": "  Warning: push failed"}
+    assert render_write_status(envelope, _success) == "Committed.\n\n  Warning: push failed"
+
+
+def test_an_unrelated_envelope_key_is_ignored():
+    """Per-tool payload must not reach the status dispatch."""
+    envelope = {"store": "local", "status": "ok", "warning": "overlap", "project": {"id": "X"}}
+    assert render_write_status(envelope, _success) == "Committed."

--- a/packages/nauro/tests/test_update_state_parity.py
+++ b/packages/nauro/tests/test_update_state_parity.py
@@ -27,6 +27,7 @@ from typer.testing import CliRunner
 
 from nauro.cli.main import app as cli_app
 from nauro.constants import REPO_CONFIG_MODE_LOCAL
+from nauro.mcp import stdio_server as stdio_module
 from nauro.mcp import tools as mcp_tools
 from nauro.mcp.stdio_server import update_state as stdio_update_state
 from nauro.mcp.tools import tool_update_state
@@ -207,3 +208,51 @@ class TestStdioCarriesTheAssessment:
         assert stdio_update_state(delta="Shipped the stdio surface", project_id=pid) == (
             "State updated."
         )
+
+
+class TestStdioNamesEveryStatus:
+    """A status that wrote nothing must never read as a completed write.
+
+    The stdio surface answers with one line, so a status it does not read is
+    a status the agent never learns about. Each cell below wrote nothing to
+    the store, and each one used to answer "State updated."
+    """
+
+    def test_an_over_length_delta_reports_the_rejection(self, seeded_repo):
+        pid, store_path = seeded_repo
+        before = (store_path / "state_current.md").read_text()
+
+        stdio_string = stdio_update_state(delta="x" * 10_000, project_id=pid)
+
+        assert "State updated." not in stdio_string
+        assert "exceeds" in stdio_string.lower()
+        # The kernel's own reason, and nothing bolted on.
+        rejection = tool_update_state(store_path, "x" * 10_000)
+        assert stdio_string == rejection["error"]["reason"]
+        assert (store_path / "state_current.md").read_text() == before
+
+    def test_a_noop_reports_that_nothing_was_written(self, seeded_repo):
+        pid, store_path = seeded_repo
+        # No state_current.md and no legacy state.md: the kernel early-returns
+        # without writing.
+        (store_path / "state_current.md").unlink()
+
+        stdio_string = stdio_update_state(delta="Shipped the stdio surface", project_id=pid)
+
+        assert tool_update_state(store_path, "probe")["status"] == "noop"
+        assert "State updated." not in stdio_string
+        assert stdio_string == "No write was made. The store reported nothing to update."
+        assert not (store_path / "state_current.md").exists()
+
+    def test_a_store_lost_after_resolution_reports_the_guidance(
+        self, seeded_repo, tmp_path, monkeypatch
+    ):
+        """The store-missing race: resolution succeeded, then the store went."""
+        pid, _store_path = seeded_repo
+        vanished = tmp_path / "vanished-store"
+        monkeypatch.setattr(stdio_module, "_resolve_store", lambda *_a, **_kw: vanished)
+
+        stdio_string = stdio_update_state(delta="Shipped the stdio surface", project_id=pid)
+
+        assert "State updated." not in stdio_string
+        assert stdio_string == tool_update_state(vanished, "probe")["guidance"]

--- a/packages/nauro/tests/test_update_state_parity.py
+++ b/packages/nauro/tests/test_update_state_parity.py
@@ -241,7 +241,10 @@ class TestStdioNamesEveryStatus:
 
         assert tool_update_state(store_path, "probe")["status"] == "noop"
         assert "State updated." not in stdio_string
-        assert stdio_string == "No write was made. The store reported nothing to update."
+        assert stdio_string == (
+            "No write was made. The store has no state file to update. "
+            "Run 'nauro status' for the store path, then restore state_current.md there."
+        )
         assert not (store_path / "state_current.md").exists()
 
     def test_a_store_lost_after_resolution_reports_the_guidance(


### PR DESCRIPTION
## Problem

The stdio MCP write tools answer with one line of text. The other local surfaces return the full envelope, but this transport does not.

Each wrapper read only the status that it cared about. Every other status fell through to the success line. Three cells lied to the agent:

- An over-length delta was rejected by the kernel. Nothing was written. The tool answered "State updated."
- A store with no state file gave a noop. Nothing was written. The tool answered "State updated."
- A missing store gave an error. Nothing was written. `flag_question` answered "Question flagged."

The agent then told the user that the write had completed.

## Change

A new module, `nauro/mcp/write_status.py`, holds the status-to-line rule. The rule is one line for each status:

| Status | Line |
|---|---|
| `ok` | the wrapper's own success line, unchanged |
| `rejected` | the reason from the envelope |
| `noop` | a line that says that no write was made, and the remedy |
| `error` | the guidance from the envelope |
| anything else | the status name, and any text the envelope holds |
| no status at all | a line that says that the write is unconfirmed |

The module parses the envelope into a small model. The dispatch then reads typed fields. It does not walk the raw dictionary.

Each wrapper now supplies only the line for a write that did commit. The module calls that line for the `ok` status and for no other status. A wrapper can no longer report a write that did not happen.

An envelope with no status is a broken envelope, not a success. It gets the unconfirmed line, for the same reason as the rest of this change.

Post-commit assessment notes still ride out on every line. An envelope that did not commit holds no assessment, so the two rules compose.

`propose_decision` returns the envelope for every status. It has nothing to flatten, and this change does not touch it. Its success status is `confirmed`, which this seam does not know. A comment in the module records that limit.

## Compatibility

The clean paths stay byte for byte the same:

- `State updated.` and `State updated. <warning>`
- `Question flagged.` and `Question(s) resolved.`
- `<hint> The question has still been logged.`
- the rejection reason for `flag_question`
- each degraded variant that carries the assessment text

## Testing

- New unit tests drive the renderer with synthetic envelopes. They pin each status, the fallback line for an envelope with no text, the unknown-status line, the no-status line, the remedial-guidance fallback, and the assessment pass-through.
- New parity tests drive the real adapters through the stdio wrapper:
  - an over-length delta gives the kernel reason, and the state file does not change
  - a store with no state file gives the noop line, and no file is made
  - an over-length question and a leaked envelope fragment each give the kernel reason, and the question file does not change
  - a store that goes away after resolution gives the guidance, for `update_state` and for `flag_question`, on the append path and on the resolve path
- The existing parity pins stay green. This includes the dictionary pins for `propose_decision`.
- `pytest packages/nauro/tests/`: 2516 passed, 10 skipped.
- `pytest packages/nauro-core/tests/`: 1526 passed.
- `ruff check packages/` and `ruff format --check packages/`: clean.
