### PR TITLE
Make the cloud restore resumable and retry-safe

### DIFF
--- a/packages/nauro/src/nauro/cli/_reporters.py
+++ b/packages/nauro/src/nauro/cli/_reporters.py
@@ -1,0 +1,23 @@
+"""Terminal progress surfaces shared by the commands that run transfers.
+
+Both ``attach`` and ``reconnect`` print their result to stdout and their
+progress to stderr, so a caller reading the result of the command never has to
+filter the running commentary out of it.
+"""
+
+from __future__ import annotations
+
+import typer
+
+
+class StderrReporter:
+    """Reporter that keeps transfer progress off stdout."""
+
+    def info(self, msg: str) -> None:
+        typer.echo(f"  {msg}", err=True)
+
+    def warn(self, msg: str) -> None:
+        typer.echo(f"  {msg}", err=True)
+
+
+__all__ = ["StderrReporter"]

--- a/packages/nauro/src/nauro/cli/commands/attach.py
+++ b/packages/nauro/src/nauro/cli/commands/attach.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 import typer
 
+from nauro.cli._reporters import StderrReporter
 from nauro.cli.commands.auth import DEFAULT_API_URL
 from nauro.cli.git_hygiene import public_surface_git_warnings
 from nauro.cli.utils import refuse_global_config_collision, refuse_repo_config_symlink
@@ -108,10 +109,12 @@ def attach(
             # A previously connected machine lost its record: this is
             # recovery, so an empty remote stays a hard stop — a blank
             # directory must never stand in for a lost record.
-            store_path = restore_cloud_store(project_id, connection.store_path)
+            store_path = restore_cloud_store(project_id, connection.store_path, StderrReporter())
         elif connection is None:
             try:
-                store_path = restore_cloud_store(project_id, get_store_path_v2(project_id))
+                store_path = restore_cloud_store(
+                    project_id, get_store_path_v2(project_id), StderrReporter()
+                )
             except EmptyCloudRecordError:
                 # First connection on this machine to a cloud project whose
                 # record was never pushed. Attach's long-standing contract

--- a/packages/nauro/src/nauro/cli/commands/reconnect.py
+++ b/packages/nauro/src/nauro/cli/commands/reconnect.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import typer
 
+from nauro.cli._reporters import StderrReporter
 from nauro.cli.integrations.json_mcp import recorded_mcp_commands
 from nauro.store.recovery import (
     RecoveryError,
@@ -95,7 +96,9 @@ def reconnect() -> None:
             return
 
         remote_name = require_cloud_membership(connection.project_id)
-        store_path = restore_cloud_store(connection.project_id, connection.store_path)
+        store_path = restore_cloud_store(
+            connection.project_id, connection.store_path, StderrReporter()
+        )
         config = load_repo_config(repo_root)
         # Membership was just verified, so the cloud name is authoritative:
         # a server-side rename reconciles the registry and repo config here

--- a/packages/nauro/src/nauro/store/recovery.py
+++ b/packages/nauro/src/nauro/store/recovery.py
@@ -54,6 +54,7 @@ logger = logging.getLogger("nauro.store.recovery")
 _STAGING_SUFFIX = ".restore"
 _LEGACY_STAGING_GLOB_SUFFIX = _STAGING_SUFFIX + "-*"
 _STAGING_LOCK_SUFFIX = _STAGING_SUFFIX + ".lock"
+_STAGING_LEDGER_SUFFIX = _STAGING_SUFFIX + ".ledger.json"
 
 # Two restores of one project would fight over the same staging tree. The wait
 # is short: the second run has a human in front of it.
@@ -438,40 +439,21 @@ def _fetch_manifest_entries(project_id: str) -> dict[str, CloudManifestEntry]:
     return entries
 
 
-def _audit_staged_files(staging: Path, entries: dict[str, CloudManifestEntry]) -> set[str]:
-    """Return the staged paths a resume may keep, deleting every other one.
+class StagedFile(BaseModel):
+    """What one staged file held, recorded by the run that wrote it."""
 
-    A staged file is kept only when the fresh manifest still lists it and it
-    passes the checks a download must pass, so a resumed run can assemble
-    nothing but the record the server holds now. Everything else — a
-    mismatch, an unreadable file, a path the manifest dropped, anything that
-    is not a regular file — goes, and the run downloads it again.
-    """
-    kept: set[str] = set()
-    try:
-        for path in sorted(staging.rglob("*")):
-            if path.is_dir() and not path.is_symlink():
-                continue
-            relative = path.relative_to(staging).as_posix()
-            entry = entries.get(relative)
-            if entry is not None and _staged_body_matches(path, entry):
-                kept.add(relative)
-                continue
-            path.unlink(missing_ok=True)
-        _prune_empty_directories(staging)
-    except OSError as exc:
-        raise RecoveryError(f"Could not audit the partial restore at {staging}: {exc}") from exc
-    return kept
+    model_config = ConfigDict(extra="ignore")
+
+    etag: StrictStr
+    sha256: StrictStr
 
 
-def _staged_body_matches(path: Path, entry: CloudManifestEntry) -> bool:
-    if not path.is_file() or path.is_symlink():
-        return False
-    try:
-        content = path.read_bytes()
-    except OSError:
-        return False
-    return _content_defect(content, entry) is None
+class StagingLedger(BaseModel):
+    """The staged files a resume may trust, keyed by store-relative path."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    files: dict[str, StagedFile] = Field(default_factory=dict)
 
 
 def _prune_empty_directories(staging: Path) -> None:
@@ -481,19 +463,129 @@ def _prune_empty_directories(staging: Path) -> None:
             path.rmdir()
 
 
-def _stage_file(staging: Path, relative: str, content: bytes) -> None:
-    """Land one downloaded file in staging, whole or not at all.
+@dataclass
+class _StagingArea:
+    """The staging directory plus the record of what this run put in it.
 
-    A truncating write that a kill interrupts leaves a short file that still
-    looks like content, and the resume audit clears only what it can prove
-    wrong: an entry carrying neither a size nor a single-part ETag has nothing
-    to check against, so a partial write would install. The tmp-then-rename
-    primitive removes the case instead of narrowing it.
+    The manifest alone cannot decide whether a staged file is still good. An
+    entry with an opaque multipart ETag and no size gives the audit nothing to
+    compare against, so a same-size corruption would pass it. The bytes are in
+    hand at download time, so the run records their sha256 next to the ETag it
+    downloaded them under, and the resume checks both: the digest catches local
+    damage, and the ETag catches a remote file that has moved on since.
+
+    The record lives beside the staging directory rather than inside it. That
+    keeps it out of the tree the install renames onto the store, and keeps it
+    alive through an install-phase failure that keeps staging for a resume.
     """
-    try:
-        atomic_write_bytes(staging / relative, content)
-    except OSError as exc:
-        raise RecoveryError(f"Could not stage cloud file {relative}: {exc}") from exc
+
+    path: Path
+    ledger_path: Path
+    ledger: StagingLedger
+
+    def audit(self, entries: dict[str, CloudManifestEntry]) -> set[str]:
+        """Return the staged paths a resume may keep, deleting every other one.
+
+        Everything else — an unrecorded file, a rotated remote, local damage, a
+        path the manifest dropped, anything that is not a regular file — goes,
+        and the run downloads it again.
+        """
+        kept: set[str] = set()
+        try:
+            for path in sorted(self.path.rglob("*")):
+                if path.is_dir() and not path.is_symlink():
+                    continue
+                relative = path.relative_to(self.path).as_posix()
+                entry = entries.get(relative)
+                if entry is not None and self._still_good(path, relative, entry):
+                    kept.add(relative)
+                    continue
+                path.unlink(missing_ok=True)
+            _prune_empty_directories(self.path)
+        except OSError as exc:
+            raise RecoveryError(
+                f"Could not audit the partial restore at {self.path}: {exc}"
+            ) from exc
+        self.ledger.files = {rel: rec for rel, rec in self.ledger.files.items() if rel in kept}
+        return kept
+
+    def _still_good(self, path: Path, relative: str, entry: CloudManifestEntry) -> bool:
+        record = self.ledger.files.get(relative)
+        if record is None or record.etag != entry.etag:
+            return False
+        if not path.is_file() or path.is_symlink():
+            return False
+        try:
+            content = path.read_bytes()
+        except OSError:
+            return False
+        if hashlib.sha256(content).hexdigest() != record.sha256:
+            return False
+        return _content_defect(content, entry) is None
+
+    def accept(self, relative: str, entry: CloudManifestEntry, content: bytes) -> None:
+        """Land one downloaded file and record what it is.
+
+        The file is written whole or not at all: a truncating write that a kill
+        interrupts leaves a short file that still looks like content.
+
+        The record is rewritten after every file rather than in batches. It
+        must never name a file that is not on disk, and writing it second keeps
+        it one step behind the filesystem at every instant — a kill between the
+        two costs one re-download, never a false trust. Batching would trade
+        that for a saving measured against the download it accompanies, on a
+        record of hundreds of files.
+        """
+        try:
+            atomic_write_bytes(self.path / relative, content)
+        except OSError as exc:
+            raise RecoveryError(f"Could not stage cloud file {relative}: {exc}") from exc
+        self.ledger.files[relative] = StagedFile(
+            etag=entry.etag, sha256=hashlib.sha256(content).hexdigest()
+        )
+        self._save()
+
+    def _save(self) -> None:
+        try:
+            atomic_write_bytes(self.ledger_path, self.ledger.model_dump_json().encode("utf-8"))
+        except OSError as exc:
+            raise RecoveryError(f"Could not record the partial restore: {exc}") from exc
+
+    def discard(self) -> None:
+        """Remove the staging tree and the record that described it."""
+        _discard(self.path)
+        _discard(self.ledger_path)
+
+
+def _ledger_path(project_id: str, destination: Path) -> Path:
+    return destination.parent / f".{project_id}{_STAGING_LEDGER_SUFFIX}"
+
+
+def _discard_restore_state(project_id: str, destination: Path) -> None:
+    """Remove any staging tree and record this project left beside ``destination``."""
+    _discard(_staging_path(project_id, destination))
+    _discard(_ledger_path(project_id, destination))
+
+
+def _open_staging_area(project_id: str, destination: Path, reporter: Reporter) -> _StagingArea:
+    """Open the staging directory and read whatever record accompanies it.
+
+    An unreadable record is reported and treated as empty: the cost is a full
+    re-download, never a file trusted on a record that could not be read.
+    """
+    staging = _staging_path(project_id, destination)
+    ledger_path = _ledger_path(project_id, destination)
+    _open_staging(staging)
+    ledger = StagingLedger()
+    if ledger_path.exists():
+        try:
+            ledger = StagingLedger.model_validate_json(ledger_path.read_bytes())
+        except (OSError, ValidationError) as exc:
+            reporter.warn(
+                f"The record of the partial restore could not be read ({exc}); "
+                "every staged file will be downloaded again."
+            )
+    return _StagingArea(staging, ledger_path, ledger)
 
 
 def _human_bytes(total: int) -> str:
@@ -516,7 +608,7 @@ def _report_start(
 
 def _download_pending(
     project_id: str,
-    staging: Path,
+    area: _StagingArea,
     entries: dict[str, CloudManifestEntry],
     pending: Sequence[str],
     reporter: Reporter,
@@ -530,16 +622,16 @@ def _download_pending(
                 content = download_with_retry(relative, chunk, fetch_via_presigned_url)
             except PresignError as exc:
                 raise RecoveryError(f"Cloud download failed for {relative}: {exc}") from exc
-            defect = _content_defect(content, entries[relative])
+            entry = entries[relative]
+            defect = _content_defect(content, entry)
             if defect is not None:
                 raise RecoveryError(f"Cloud {defect.value} validation failed for {relative}.")
-            _stage_file(staging, relative, content)
+            area.accept(relative, entry, content)
             progress.record(reporter)
 
 
 def _install_staged_store(staging: Path, destination: Path) -> None:
-    """Validate the assembled tree and move it onto the destination."""
-    _validate_restored_store(staging)
+    """Move the verified tree onto the destination."""
     # os.replace cannot move a directory onto an existing directory on
     # Windows (even an empty one _destination_is_available admitted).
     # rmdir only succeeds on an empty directory, so this also re-enforces
@@ -551,7 +643,29 @@ def _install_staged_store(staging: Path, destination: Path) -> None:
             raise RecoveryError(
                 f"Refusing to overwrite nonempty destination: {destination}."
             ) from exc
-    os.replace(staging, destination)
+    try:
+        os.replace(staging, destination)
+    except OSError as exc:
+        raise RecoveryError(
+            f"Could not install the restored record at {destination}: {exc}"
+        ) from exc
+
+
+def _holds_complete_record(destination: Path) -> bool:
+    """True when the destination already holds a complete, valid record."""
+    try:
+        _validate_restored_store(destination)
+    except RecoveryError:
+        return False
+    return True
+
+
+def _kept_message(staging: Path, progress: _Progress) -> str:
+    return (
+        f"Partial restore kept at {staging} "
+        f"({progress.done} of {progress.total} files ready). "
+        "Run the same command again to resume it, or delete that directory to start over."
+    )
 
 
 def restore_cloud_store(
@@ -583,43 +697,54 @@ def restore_cloud_store(
         raise RecoveryError(f"Refusing to overwrite nonempty destination: {destination}.")
 
     destination.parent.mkdir(parents=True, exist_ok=True)
-    staging = _staging_path(project_id, destination)
     with _restore_lock(project_id, destination):
+        # The check above is stale by the time the lock is in hand: a run that
+        # waited here may find the record already installed by the run it
+        # waited for. That is the outcome it wanted, so it is not a failure.
+        if not _destination_is_available(destination):
+            _discard_restore_state(project_id, destination)
+            if _holds_complete_record(destination):
+                surface.info("Another restore completed this record first.")
+                return destination
+            raise RecoveryError(f"Refusing to overwrite nonempty destination: {destination}.")
+
         _sweep_legacy_staging(project_id, destination.parent)
         entries = _fetch_manifest_entries(project_id)
         if not entries:
             # A record that is not there cannot complete a partial restore,
             # so nothing is kept to resume toward.
-            _discard(staging)
+            _discard_restore_state(project_id, destination)
             raise EmptyCloudRecordError("Cloud project has no stored record to restore.")
 
-        _open_staging(staging)
-        staged = _audit_staged_files(staging, entries)
+        area = _open_staging_area(project_id, destination, surface)
+        staged = area.audit(entries)
         pending = [relative for relative in entries if relative not in staged]
         _report_start(entries, pending, surface)
 
         progress = _Progress(total=len(entries), done=len(staged))
         try:
-            _download_pending(project_id, staging, entries, pending, surface, progress)
+            _download_pending(project_id, area, entries, pending, surface, progress)
         except (RecoveryError, KeyboardInterrupt):
-            surface.warn(
-                f"Partial restore kept at {staging} "
-                f"({progress.done} of {progress.total} files ready). "
-                "Run the same command again to resume it, or delete that directory "
-                "to start over."
-            )
+            surface.warn(_kept_message(area.path, progress))
             raise
 
-        # Past this point staging is either installed or discarded: a tree
-        # that fails validation is a bad record, and rebuilding the same
-        # badness on the next run helps nobody.
-        installed = False
         try:
-            _install_staged_store(staging, destination)
-            installed = True
-        finally:
-            if not installed:
-                _discard(staging)
+            _validate_restored_store(area.path)
+        except RecoveryError:
+            # The assembled record is bad. Resuming would rebuild the same
+            # badness, so the next run starts from nothing.
+            area.discard()
+            raise
+
+        # The content is verified from here. An install that fails now is a
+        # local filesystem fault, not a bad record, so staging survives and the
+        # next run installs it without downloading anything twice.
+        try:
+            _install_staged_store(area.path, destination)
+        except RecoveryError:
+            surface.warn(_kept_message(area.path, progress))
+            raise
+        _discard(area.ledger_path)
         surface.info(f"Restored {len(entries)} files.")
         return destination
 

--- a/packages/nauro/src/nauro/store/recovery.py
+++ b/packages/nauro/src/nauro/store/recovery.py
@@ -1,4 +1,4 @@
-"""Validated local binding and atomic cloud-store restoration."""
+"""Validated local binding and resumable cloud-store restoration."""
 
 from __future__ import annotations
 
@@ -6,11 +6,16 @@ import hashlib
 import logging
 import os
 import shutil
-import tempfile
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from enum import Enum
 from pathlib import Path
 from typing import Annotated, Literal
 
 import httpx
+from filelock import FileLock, Timeout
 from nauro_core.doctor import diagnose_store
 from pydantic import (
     BaseModel,
@@ -31,17 +36,41 @@ from nauro.store.repo_config import load_repo_config
 from nauro.store.resolution import RepoResolution
 from nauro.sync.cloud_projects import CloudProjectError, list_projects
 from nauro.sync.remote import (
+    PRESIGN_BATCH_LIMIT,
     PresignError,
     fetch_manifest,
     fetch_via_presigned_url,
     request_presigned_urls,
 )
+from nauro.sync.transfer import Reporter, download_with_retry
 
 logger = logging.getLogger("nauro.store.recovery")
+
+# Staging is a fixed per-project sibling of the destination, so a run that
+# dies partway leaves work a later run can find and finish. The trailing
+# hyphen in the legacy glob is what separates the random mkdtemp names an
+# older restore stranded from the fixed name this one uses.
+_STAGING_SUFFIX = ".restore"
+_LEGACY_STAGING_GLOB_SUFFIX = _STAGING_SUFFIX + "-*"
+_STAGING_LOCK_SUFFIX = _STAGING_SUFFIX + ".lock"
+
+# Two restores of one project would fight over the same staging tree. The wait
+# is short: the second run has a human in front of it.
+_RESTORE_LOCK_TIMEOUT = 5.0
+
+# A batch's presigned URLs are re-minted this far before their ceiling, so a
+# download never starts against a URL that expires while it runs.
+_EXPIRY_MARGIN = timedelta(seconds=60)
+
+_PROGRESS_INTERVAL = 25
 
 
 class RecoveryError(RuntimeError):
     """A recovery action cannot complete without risking local state."""
+
+
+class RestoreBusyError(RecoveryError):
+    """Another process holds this project's restore staging directory."""
 
 
 class EmptyCloudRecordError(RecoveryError):
@@ -84,6 +113,7 @@ class CloudPresignResult(BaseModel):
     verb: Literal["GET"]
     path: StrictStr
     url: StrictStr
+    expires_at: datetime | None = None
 
     @field_validator("path", "url")
     @classmethod
@@ -91,6 +121,14 @@ class CloudPresignResult(BaseModel):
         if not value:
             raise ValueError("presign fields must be nonempty")
         return value
+
+    @field_validator("expires_at")
+    @classmethod
+    def as_utc(cls, value: datetime | None) -> datetime | None:
+        """Read a zoneless ceiling as UTC — the server stamps UTC."""
+        if value is None or value.tzinfo is not None:
+            return value
+        return value.replace(tzinfo=timezone.utc)
 
 
 _MANIFEST_ADAPTER = TypeAdapter(list[CloudManifestEntry])
@@ -198,8 +236,289 @@ def _etag_md5(raw_etag: str) -> str | None:
     return value
 
 
-def restore_cloud_store(project_id: str, destination: Path) -> Path:
-    """Restore a complete remote record into an absent or empty destination."""
+class _IntegrityDefect(Enum):
+    """Which manifest check a body failed. The value names it to the user."""
+
+    SIZE = "size"
+    CONTENT_HASH = "content-hash"
+    HASH = "hash"
+
+
+def _content_defect(content: bytes, entry: CloudManifestEntry) -> _IntegrityDefect | None:
+    """Return the check ``content`` fails for ``entry``, or None when it passes.
+
+    One judgment serves both callers: a fresh download that fails it is a
+    corrupt transfer and stops the restore, and a staged file that fails it is
+    a leftover the resume re-downloads.
+    """
+    if entry.size is not None and len(content) != entry.size:
+        return _IntegrityDefect.SIZE
+    expected_md5 = _etag_md5(entry.etag)
+    if (
+        expected_md5 is not None
+        and hashlib.md5(content, usedforsecurity=False).hexdigest() != expected_md5
+    ):
+        return _IntegrityDefect.CONTENT_HASH
+    if entry.sha256 is not None and hashlib.sha256(content).hexdigest() != entry.sha256:
+        return _IntegrityDefect.HASH
+    return None
+
+
+class _NullReporter:
+    """Progress surface for callers that surface nothing (library use, hooks)."""
+
+    def info(self, msg: str) -> None:
+        """Discard routine progress."""
+
+    def warn(self, msg: str) -> None:
+        """Discard anomaly reports."""
+
+
+@dataclass
+class _Progress:
+    """Files staged so far against the number this run set out to download."""
+
+    total: int
+    done: int = 0
+
+    def record(self, reporter: Reporter) -> None:
+        self.done += 1
+        if self.done % _PROGRESS_INTERVAL == 0:
+            reporter.info(f"{self.done}/{self.total} files")
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+@dataclass(frozen=True)
+class _MintedBatch:
+    """One presign response: a URL per path, plus the batch's TTL ceiling."""
+
+    urls: dict[str, str]
+    deadline: datetime | None
+
+
+def _mint_download_urls(project_id: str, paths: Sequence[str]) -> _MintedBatch:
+    """Mint one download URL per path, or refuse the batch."""
+    operations = [{"verb": "GET", "path": path} for path in paths]
+    try:
+        results = _parse_presign_results(request_presigned_urls(project_id, operations))
+    except (AuthRefreshError, PresignError, httpx.HTTPError) as exc:
+        raise RecoveryError(f"Cloud restore presign failed: {exc}") from exc
+    urls: dict[str, str] = {}
+    ceilings: list[datetime] = []
+    for item in results:
+        if item.path in urls:
+            raise RecoveryError(f"Duplicate cloud restore URL for {item.path!r}.")
+        urls[item.path] = item.url
+        if item.expires_at is not None:
+            ceilings.append(item.expires_at)
+    if set(urls) != set(paths):
+        raise RecoveryError("Cloud restore did not receive one download URL per manifest file.")
+    return _MintedBatch(urls, min(ceilings) if ceilings else None)
+
+
+class _ChunkUrls:
+    """Presigned GET URLs for one download chunk, re-minted as the chunk drains.
+
+    Minting immediately before a chunk downloads keeps a whole record off one
+    TTL clock, which a slow network or a large record outlives. The server
+    stamps one ceiling across a batch, so the chunk carries a single deadline
+    and re-mints what is left rather than starting a download it cannot
+    finish inside the margin. A stale-URL 403 re-mints through the same door.
+    """
+
+    def __init__(self, project_id: str, paths: Sequence[str]) -> None:
+        self._project_id = project_id
+        self._paths = list(paths)
+        self._cursor = 0
+        self._batch = _mint_download_urls(project_id, self._paths)
+
+    def url_for(self, path: str) -> str:
+        return self._batch.urls[path]
+
+    def remint(self) -> None:
+        self._batch = _mint_download_urls(self._project_id, self._paths[self._cursor :])
+
+    def in_order(self) -> Iterator[str]:
+        """Yield each path behind a URL that is not about to expire."""
+        for index, path in enumerate(self._paths):
+            self._cursor = index
+            deadline = self._batch.deadline
+            if deadline is not None and deadline - _utcnow() <= _EXPIRY_MARGIN:
+                self.remint()
+            yield path
+
+
+def _staging_path(project_id: str, destination: Path) -> Path:
+    return destination.parent / f".{project_id}{_STAGING_SUFFIX}"
+
+
+@contextmanager
+def _restore_lock(project_id: str, destination: Path) -> Iterator[None]:
+    """Hold the project's restore lock, or refuse to start a second restore."""
+    lock = FileLock(
+        str(destination.parent / f".{project_id}{_STAGING_LOCK_SUFFIX}"),
+        timeout=_RESTORE_LOCK_TIMEOUT,
+    )
+    try:
+        lock.acquire()
+    except Timeout as exc:
+        raise RestoreBusyError(f"Another restore is in progress for project {project_id}.") from exc
+    try:
+        yield
+    finally:
+        lock.release()
+
+
+def _sweep_legacy_staging(project_id: str, parent: Path) -> None:
+    """Remove staging directories a killed pre-resume run stranded.
+
+    Those runs staged into a random ``mkdtemp`` name that no later run could
+    find, so nothing but this sweep ever collects them.
+    """
+    for stranded in parent.glob(f".{project_id}{_LEGACY_STAGING_GLOB_SUFFIX}"):
+        shutil.rmtree(stranded, ignore_errors=True)
+
+
+def _fetch_manifest_entries(project_id: str) -> dict[str, CloudManifestEntry]:
+    """Return the remote record's files, keyed by store-relative path."""
+    try:
+        rows = fetch_manifest(project_id)
+    except (AuthRefreshError, PresignError, httpx.HTTPError) as exc:
+        raise RecoveryError(f"Cloud manifest fetch failed: {exc}") from exc
+    entries: dict[str, CloudManifestEntry] = {}
+    for entry in _parse_manifest(rows):
+        if entry.path in entries:
+            raise RecoveryError(f"Duplicate cloud manifest path: {entry.path!r}.")
+        entries[entry.path] = entry
+    return entries
+
+
+def _audit_staged_files(staging: Path, entries: dict[str, CloudManifestEntry]) -> set[str]:
+    """Return the staged paths a resume may keep, deleting every other one.
+
+    A staged file is kept only when the fresh manifest still lists it and it
+    passes the checks a download must pass, so a resumed run can assemble
+    nothing but the record the server holds now. Everything else — a
+    mismatch, an unreadable file, a path the manifest dropped, anything that
+    is not a regular file — goes, and the run downloads it again.
+    """
+    kept: set[str] = set()
+    try:
+        for path in sorted(staging.rglob("*")):
+            if path.is_dir() and not path.is_symlink():
+                continue
+            relative = path.relative_to(staging).as_posix()
+            entry = entries.get(relative)
+            if entry is not None and _staged_body_matches(path, entry):
+                kept.add(relative)
+                continue
+            path.unlink(missing_ok=True)
+        _prune_empty_directories(staging)
+    except OSError as exc:
+        raise RecoveryError(f"Could not audit the partial restore at {staging}: {exc}") from exc
+    return kept
+
+
+def _staged_body_matches(path: Path, entry: CloudManifestEntry) -> bool:
+    if not path.is_file() or path.is_symlink():
+        return False
+    try:
+        content = path.read_bytes()
+    except OSError:
+        return False
+    return _content_defect(content, entry) is None
+
+
+def _prune_empty_directories(staging: Path) -> None:
+    """Drop directories the audit emptied, so no phantom directory installs."""
+    for path in sorted(staging.rglob("*"), reverse=True):
+        if path.is_dir() and not path.is_symlink() and next(path.iterdir(), None) is None:
+            path.rmdir()
+
+
+def _stage_file(staging: Path, relative: str, content: bytes) -> None:
+    target = staging / relative
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(content)
+    except OSError as exc:
+        raise RecoveryError(f"Could not stage cloud file {relative}: {exc}") from exc
+
+
+def _human_bytes(total: int) -> str:
+    if total >= 1_048_576:
+        return f"{total / 1_048_576:.1f} MB"
+    if total >= 1024:
+        return f"{total / 1024:.1f} KB"
+    return f"{total} bytes"
+
+
+def _report_start(
+    entries: dict[str, CloudManifestEntry], pending: Sequence[str], reporter: Reporter
+) -> None:
+    total_bytes = sum(entry.size or 0 for entry in entries.values())
+    reporter.info(f"Restoring {len(entries)} files ({_human_bytes(total_bytes)}).")
+    resumed = len(entries) - len(pending)
+    if resumed:
+        reporter.info(f"Resuming a partial restore: {resumed} of {len(entries)} files are staged.")
+
+
+def _download_pending(
+    project_id: str,
+    staging: Path,
+    entries: dict[str, CloudManifestEntry],
+    pending: Sequence[str],
+    reporter: Reporter,
+    progress: _Progress,
+) -> None:
+    """Download every outstanding file into staging, one presign chunk at a time."""
+    for start in range(0, len(pending), PRESIGN_BATCH_LIMIT):
+        chunk = _ChunkUrls(project_id, pending[start : start + PRESIGN_BATCH_LIMIT])
+        for relative in chunk.in_order():
+            try:
+                content = download_with_retry(relative, chunk, fetch_via_presigned_url)
+            except PresignError as exc:
+                raise RecoveryError(f"Cloud download failed for {relative}: {exc}") from exc
+            defect = _content_defect(content, entries[relative])
+            if defect is not None:
+                raise RecoveryError(f"Cloud {defect.value} validation failed for {relative}.")
+            _stage_file(staging, relative, content)
+            progress.record(reporter)
+
+
+def _install_staged_store(staging: Path, destination: Path) -> None:
+    """Validate the assembled tree and move it onto the destination."""
+    _validate_restored_store(staging)
+    # os.replace cannot move a directory onto an existing directory on
+    # Windows (even an empty one _destination_is_available admitted).
+    # rmdir only succeeds on an empty directory, so this also re-enforces
+    # the emptiness precondition at install time.
+    if destination.exists():
+        try:
+            destination.rmdir()
+        except OSError as exc:
+            raise RecoveryError(
+                f"Refusing to overwrite nonempty destination: {destination}."
+            ) from exc
+    os.replace(staging, destination)
+
+
+def restore_cloud_store(
+    project_id: str, destination: Path, reporter: Reporter | None = None
+) -> Path:
+    """Restore a complete remote record into an absent or empty destination.
+
+    The restore resumes. It stages into a fixed per-project directory beside
+    the destination and keeps that directory when a run fails partway, so the
+    next run re-verifies what is there against a fresh manifest and downloads
+    only the rest — a dropped connection halfway through a large record costs
+    the remaining files, not all of them. Only a complete, validated tree
+    installs, and the install stays one rename.
+    """
+    surface: Reporter = reporter if reporter is not None else _NullReporter()
     if not destination.is_absolute():
         raise RecoveryError(f"Restore destination must be absolute: {destination}.")
     # The canonical constraint is an external-binding rule: a mapped
@@ -216,83 +535,49 @@ def restore_cloud_store(project_id: str, destination: Path) -> Path:
         raise RecoveryError(f"Refusing to overwrite nonempty destination: {destination}.")
 
     destination.parent.mkdir(parents=True, exist_ok=True)
-    staging = Path(tempfile.mkdtemp(prefix=f".{project_id}.restore-", dir=destination.parent))
-    installed = False
-    try:
-        try:
-            manifest = _parse_manifest(fetch_manifest(project_id))
-        except (AuthRefreshError, PresignError, httpx.HTTPError) as exc:
-            raise RecoveryError(f"Cloud manifest fetch failed: {exc}") from exc
-        if not manifest:
+    staging = _staging_path(project_id, destination)
+    with _restore_lock(project_id, destination):
+        _sweep_legacy_staging(project_id, destination.parent)
+        entries = _fetch_manifest_entries(project_id)
+        if not entries:
+            # A record that is not there cannot complete a partial restore,
+            # so nothing is kept to resume toward.
+            shutil.rmtree(staging, ignore_errors=True)
             raise EmptyCloudRecordError("Cloud project has no stored record to restore.")
 
-        entries: dict[str, CloudManifestEntry] = {}
-        for entry in manifest:
-            relative = entry.path
-            if relative in entries:
-                raise RecoveryError(f"Duplicate cloud manifest path: {relative!r}.")
-            entries[relative] = entry
+        staging.mkdir(parents=True, exist_ok=True)
+        staged = _audit_staged_files(staging, entries)
+        pending = [relative for relative in entries if relative not in staged]
+        _report_start(entries, pending, surface)
 
-        operations = [{"verb": "GET", "path": path} for path in entries]
+        progress = _Progress(total=len(pending))
         try:
-            urls = _parse_presign_results(request_presigned_urls(project_id, operations))
-        except (AuthRefreshError, PresignError, httpx.HTTPError) as exc:
-            raise RecoveryError(f"Cloud restore presign failed: {exc}") from exc
-        url_by_path: dict[str, str] = {}
-        for item in urls:
-            if item.path in url_by_path:
-                raise RecoveryError(f"Duplicate cloud restore URL for {item.path!r}.")
-            url_by_path[item.path] = item.url
-        if set(url_by_path) != set(entries):
-            raise RecoveryError("Cloud restore did not receive one download URL per manifest file.")
+            _download_pending(project_id, staging, entries, pending, surface, progress)
+        except (RecoveryError, KeyboardInterrupt):
+            surface.warn(
+                f"Partial restore kept ({progress.done} of {progress.total} files downloaded). "
+                "Run the same command again to resume it."
+            )
+            raise
 
-        for relative, entry in entries.items():
-            try:
-                content = fetch_via_presigned_url(url_by_path[relative])
-            except (PresignError, httpx.HTTPError) as exc:
-                raise RecoveryError(f"Cloud download failed for {relative}: {exc}") from exc
-            expected_size = entry.size
-            if expected_size is not None and len(content) != expected_size:
-                raise RecoveryError(f"Cloud size validation failed for {relative}.")
-            expected_md5 = _etag_md5(entry.etag)
-            if (
-                expected_md5 is not None
-                and hashlib.md5(content, usedforsecurity=False).hexdigest() != expected_md5
-            ):
-                raise RecoveryError(f"Cloud content-hash validation failed for {relative}.")
-            expected_hash = entry.sha256
-            if expected_hash is not None and hashlib.sha256(content).hexdigest() != expected_hash:
-                raise RecoveryError(f"Cloud hash validation failed for {relative}.")
-            target = staging / relative
-            try:
-                target.parent.mkdir(parents=True, exist_ok=True)
-                target.write_bytes(content)
-            except OSError as exc:
-                raise RecoveryError(f"Could not stage cloud file {relative}: {exc}") from exc
-
-        _validate_restored_store(staging)
-        # os.replace cannot move a directory onto an existing directory on
-        # Windows (even an empty one _destination_is_available admitted).
-        # rmdir only succeeds on an empty directory, so this also re-enforces
-        # the emptiness precondition at install time.
-        if destination.exists():
-            try:
-                destination.rmdir()
-            except OSError as exc:
-                raise RecoveryError(
-                    f"Refusing to overwrite nonempty destination: {destination}."
-                ) from exc
-        os.replace(staging, destination)
-        installed = True
+        # Past this point staging is either installed or discarded: a tree
+        # that fails validation is a bad record, and rebuilding the same
+        # badness on the next run helps nobody.
+        installed = False
+        try:
+            _install_staged_store(staging, destination)
+            installed = True
+        finally:
+            if not installed:
+                shutil.rmtree(staging, ignore_errors=True)
+        surface.info(f"Restored {len(entries)} files.")
         return destination
-    finally:
-        if not installed and staging.exists():
-            shutil.rmtree(staging)
 
 
 __all__ = [
     "EmptyCloudRecordError",
     "RecoveryError",
+    "RestoreBusyError",
     "bind_local_store",
     "require_cloud_membership",
     "restore_cloud_store",

--- a/packages/nauro/src/nauro/store/recovery.py
+++ b/packages/nauro/src/nauro/store/recovery.py
@@ -7,7 +7,7 @@ import logging
 import os
 import shutil
 from collections.abc import Iterator, Sequence
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from enum import Enum
@@ -30,6 +30,7 @@ from pydantic import (
 
 from nauro.cli.commands.auth import AuthRefreshError
 from nauro.constants import DECISIONS_DIR, PROJECT_MD
+from nauro.store._atomic import atomic_write_bytes
 from nauro.store.filesystem_store import FilesystemStore
 from nauro.store.registry import bind_project_store_v2, get_store_path_v2
 from nauro.store.repo_config import load_repo_config
@@ -42,7 +43,7 @@ from nauro.sync.remote import (
     fetch_via_presigned_url,
     request_presigned_urls,
 )
-from nauro.sync.transfer import Reporter, download_with_retry
+from nauro.sync.transfer import NullReporter, Reporter, download_with_retry
 
 logger = logging.getLogger("nauro.store.recovery")
 
@@ -264,19 +265,14 @@ def _content_defect(content: bytes, entry: CloudManifestEntry) -> _IntegrityDefe
     return None
 
 
-class _NullReporter:
-    """Progress surface for callers that surface nothing (library use, hooks)."""
-
-    def info(self, msg: str) -> None:
-        """Discard routine progress."""
-
-    def warn(self, msg: str) -> None:
-        """Discard anomaly reports."""
-
-
 @dataclass
 class _Progress:
-    """Files staged so far against the number this run set out to download."""
+    """Files in hand against the whole manifest, not against this run's share.
+
+    A resumed run starts at the count it inherited from the staging directory,
+    so ``k of N`` answers the question the user is actually asking: how much of
+    the record is on disk.
+    """
 
     total: int
     done: int = 0
@@ -329,17 +325,35 @@ class _ChunkUrls:
     finish inside the margin. A stale-URL 403 re-mints through the same door.
     """
 
-    def __init__(self, project_id: str, paths: Sequence[str]) -> None:
+    def __init__(self, project_id: str, paths: Sequence[str], reporter: Reporter) -> None:
         self._project_id = project_id
         self._paths = list(paths)
+        # Everything from the cursor on is still outstanding, so a re-mint
+        # covers exactly the tail. in_order() owns the cursor and is the only
+        # thing that hands a path out, which is what keeps that true.
         self._cursor = 0
-        self._batch = _mint_download_urls(project_id, self._paths)
+        self._reporter = reporter
+        self._warned_undated = False
+        self._mint()
+
+    def _mint(self) -> None:
+        self._batch = _mint_download_urls(self._project_id, self._paths[self._cursor :])
+        if self._batch.deadline is None and not self._warned_undated:
+            # Without a ceiling the restore cannot re-mint ahead of an expiry,
+            # so it falls back to reacting to a refusal. Say so: a server that
+            # stops stamping expiries would otherwise disable the proactive
+            # path in silence.
+            self._warned_undated = True
+            self._reporter.warn(
+                "The presign response carried no expiry, so this restore cannot renew "
+                "a download URL before it lapses."
+            )
 
     def url_for(self, path: str) -> str:
         return self._batch.urls[path]
 
     def remint(self) -> None:
-        self._batch = _mint_download_urls(self._project_id, self._paths[self._cursor :])
+        self._mint()
 
     def in_order(self) -> Iterator[str]:
         """Yield each path behind a URL that is not about to expire."""
@@ -372,6 +386,19 @@ def _restore_lock(project_id: str, destination: Path) -> Iterator[None]:
         lock.release()
 
 
+def _discard(path: Path) -> None:
+    """Remove ``path``, whatever kind of file occupies it.
+
+    Best effort by design: every caller is either cleaning up after a failure
+    it is about to report, or opening a staging area it recreates immediately.
+    """
+    if path.is_dir() and not path.is_symlink():
+        shutil.rmtree(path, ignore_errors=True)
+        return
+    with suppress(OSError):
+        path.unlink(missing_ok=True)
+
+
 def _sweep_legacy_staging(project_id: str, parent: Path) -> None:
     """Remove staging directories a killed pre-resume run stranded.
 
@@ -379,7 +406,22 @@ def _sweep_legacy_staging(project_id: str, parent: Path) -> None:
     find, so nothing but this sweep ever collects them.
     """
     for stranded in parent.glob(f".{project_id}{_LEGACY_STAGING_GLOB_SUFFIX}"):
-        shutil.rmtree(stranded, ignore_errors=True)
+        _discard(stranded)
+
+
+def _open_staging(staging: Path) -> None:
+    """Make the staging path a directory, whatever is sitting on it.
+
+    Only a directory this restore can resume from may occupy the path. A file
+    there is not a partial restore under any reading, so it goes rather than
+    stopping a recovery on something no run of this code could have left.
+    """
+    if staging.exists() and not (staging.is_dir() and not staging.is_symlink()):
+        _discard(staging)
+    try:
+        staging.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise RecoveryError(f"Could not open the restore staging area {staging}: {exc}") from exc
 
 
 def _fetch_manifest_entries(project_id: str) -> dict[str, CloudManifestEntry]:
@@ -440,10 +482,16 @@ def _prune_empty_directories(staging: Path) -> None:
 
 
 def _stage_file(staging: Path, relative: str, content: bytes) -> None:
-    target = staging / relative
+    """Land one downloaded file in staging, whole or not at all.
+
+    A truncating write that a kill interrupts leaves a short file that still
+    looks like content, and the resume audit clears only what it can prove
+    wrong: an entry carrying neither a size nor a single-part ETag has nothing
+    to check against, so a partial write would install. The tmp-then-rename
+    primitive removes the case instead of narrowing it.
+    """
     try:
-        target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_bytes(content)
+        atomic_write_bytes(staging / relative, content)
     except OSError as exc:
         raise RecoveryError(f"Could not stage cloud file {relative}: {exc}") from exc
 
@@ -476,7 +524,7 @@ def _download_pending(
 ) -> None:
     """Download every outstanding file into staging, one presign chunk at a time."""
     for start in range(0, len(pending), PRESIGN_BATCH_LIMIT):
-        chunk = _ChunkUrls(project_id, pending[start : start + PRESIGN_BATCH_LIMIT])
+        chunk = _ChunkUrls(project_id, pending[start : start + PRESIGN_BATCH_LIMIT], reporter)
         for relative in chunk.in_order():
             try:
                 content = download_with_retry(relative, chunk, fetch_via_presigned_url)
@@ -518,7 +566,7 @@ def restore_cloud_store(
     the remaining files, not all of them. Only a complete, validated tree
     installs, and the install stays one rename.
     """
-    surface: Reporter = reporter if reporter is not None else _NullReporter()
+    surface: Reporter = reporter if reporter is not None else NullReporter()
     if not destination.is_absolute():
         raise RecoveryError(f"Restore destination must be absolute: {destination}.")
     # The canonical constraint is an external-binding rule: a mapped
@@ -542,21 +590,23 @@ def restore_cloud_store(
         if not entries:
             # A record that is not there cannot complete a partial restore,
             # so nothing is kept to resume toward.
-            shutil.rmtree(staging, ignore_errors=True)
+            _discard(staging)
             raise EmptyCloudRecordError("Cloud project has no stored record to restore.")
 
-        staging.mkdir(parents=True, exist_ok=True)
+        _open_staging(staging)
         staged = _audit_staged_files(staging, entries)
         pending = [relative for relative in entries if relative not in staged]
         _report_start(entries, pending, surface)
 
-        progress = _Progress(total=len(pending))
+        progress = _Progress(total=len(entries), done=len(staged))
         try:
             _download_pending(project_id, staging, entries, pending, surface, progress)
         except (RecoveryError, KeyboardInterrupt):
             surface.warn(
-                f"Partial restore kept ({progress.done} of {progress.total} files downloaded). "
-                "Run the same command again to resume it."
+                f"Partial restore kept at {staging} "
+                f"({progress.done} of {progress.total} files ready). "
+                "Run the same command again to resume it, or delete that directory "
+                "to start over."
             )
             raise
 
@@ -569,7 +619,7 @@ def restore_cloud_store(
             installed = True
         finally:
             if not installed:
-                shutil.rmtree(staging, ignore_errors=True)
+                _discard(staging)
         surface.info(f"Restored {len(entries)} files.")
         return destination
 

--- a/packages/nauro/src/nauro/sync/pull.py
+++ b/packages/nauro/src/nauro/sync/pull.py
@@ -8,8 +8,9 @@ decision file before it lands and merge conflicting append-only files.
 
 The two callers differ only in how they surface progress: the CLI echoes
 to the terminal; the hook logs quietly and must never raise. That
-asymmetry is injected through the :class:`Reporter` protocol rather than
-branched inside the pull core, so the two paths cannot drift again.
+asymmetry is injected through the shared
+:class:`~nauro.sync.transfer.Reporter` protocol rather than branched inside
+the pull core, so the two paths cannot drift again.
 
 A run has two phases. It plans and fetches under the store's sync lock, which
 keeps two syncs off one store; then it writes everything under the decision
@@ -38,7 +39,6 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum, auto
 from pathlib import Path
-from typing import Protocol
 
 from nauro_core import extract_decision_number
 from pydantic import BaseModel, ConfigDict, ValidationError
@@ -83,20 +83,7 @@ from nauro.sync.state import (
     save_state,
     update_file_state,
 )
-
-
-class Reporter(Protocol):
-    """Surface for pull progress.
-
-    The CLI implementation echoes to the terminal; the hook implementation
-    logs quietly (session startup must never crash).
-    """
-
-    def info(self, msg: str) -> None:
-        """Report routine progress (file written, nothing to pull)."""
-
-    def warn(self, msg: str) -> None:
-        """Report a recoverable anomaly (presign URL shortfall, bad manifest)."""
+from nauro.sync.transfer import Reporter
 
 
 class _ManifestEntry(BaseModel):
@@ -1039,4 +1026,4 @@ def _quarantine(
     )
 
 
-__all__ = ["PullReport", "Reporter", "run_pull"]
+__all__ = ["PullReport", "run_pull"]

--- a/packages/nauro/src/nauro/sync/remote.py
+++ b/packages/nauro/src/nauro/sync/remote.py
@@ -25,8 +25,37 @@ _DEFAULT_API_TIMEOUT = 15.0
 _DEFAULT_TRANSFER_TIMEOUT = 60.0
 
 
+# Enough of an error body to name the fault, never enough to flood a terminal.
+_BODY_EXCERPT_LIMIT = 200
+
+
 class PresignError(Exception):
     """Raised for unrecoverable failures hitting the manifest/presign endpoints."""
+
+
+class PresignTransferError(PresignError):
+    """A presigned object transfer failed against object storage.
+
+    Subclasses :class:`PresignError`, so every existing handler keeps catching
+    it, and carries the two facts a retry policy needs: the HTTP status when
+    the server answered, and whether the request failed at the transport layer
+    before any response existed. :mod:`nauro.sync.transfer` owns the policy
+    that reads them; this class states facts only.
+    """
+
+    def __init__(
+        self,
+        action: str,
+        *,
+        status: int | None = None,
+        transport: bool = False,
+        detail: str = "",
+    ) -> None:
+        answered = f"({status})" if status is not None else "(no response)"
+        super().__init__(f"{action} failed {answered}{f': {detail}' if detail else ''}")
+        self.status = status
+        self.transport = transport
+        self.detail = detail
 
 
 def resolve_api_url() -> str:
@@ -43,7 +72,7 @@ def resolve_api_url() -> str:
 
 # The server batches up to 200 ops per /sync/presign call (see mcp-server
 # _PRESIGN_OPS_BATCH_LIMIT); the CLI chunks larger diffs to match.
-_PRESIGN_BATCH_LIMIT = 200
+PRESIGN_BATCH_LIMIT = 200
 
 
 def fetch_manifest(project_id: str) -> list[dict]:
@@ -107,8 +136,8 @@ def request_presigned_urls(
     api_url = resolve_api_url()
     all_urls: list[dict[str, Any]] = []
 
-    for start in range(0, len(operations), _PRESIGN_BATCH_LIMIT):
-        chunk = operations[start : start + _PRESIGN_BATCH_LIMIT]
+    for start in range(0, len(operations), PRESIGN_BATCH_LIMIT):
+        chunk = operations[start : start + PRESIGN_BATCH_LIMIT]
 
         def _call(token: str, chunk=chunk) -> httpx.Response:
             return httpx.post(
@@ -168,11 +197,33 @@ def urls_by_path(entries: list[Any], verb: str) -> tuple[dict[str, str], tuple[s
     return usable, tuple(skipped)
 
 
+def _body_excerpt(response: httpx.Response) -> str:
+    """Collapse an error body to one short line."""
+    return " ".join(response.text.split())[:_BODY_EXCERPT_LIMIT]
+
+
 def fetch_via_presigned_url(url: str) -> bytes:
-    """GET ``url`` and return the body bytes (no local write)."""
-    response = httpx.get(url, timeout=_DEFAULT_TRANSFER_TIMEOUT)
+    """GET ``url`` and return the body bytes (no local write).
+
+    Every failure surfaces as :class:`PresignTransferError`, transport faults
+    included: a caller guarding against ``PresignError`` must not have a bare
+    ``httpx.ConnectError`` escape past it, and a retry policy must classify on
+    the status rather than on the message text.
+    """
+    try:
+        response = httpx.get(url, timeout=_DEFAULT_TRANSFER_TIMEOUT)
+    except httpx.TransportError as exc:
+        # UnsupportedProtocol sits in the transport hierarchy but is not a
+        # transport fault: the client refused to send a URL it cannot read, so
+        # nothing was attempted and a retry cannot change the outcome.
+        attempted = not isinstance(exc, httpx.UnsupportedProtocol)
+        raise PresignTransferError("Presigned GET", transport=attempted, detail=str(exc)) from exc
+    except (httpx.HTTPError, httpx.InvalidURL) as exc:
+        raise PresignTransferError("Presigned GET", detail=str(exc)) from exc
     if response.status_code != 200:
-        raise PresignError(f"Presigned GET failed ({response.status_code})")
+        raise PresignTransferError(
+            "Presigned GET", status=response.status_code, detail=_body_excerpt(response)
+        )
     return response.content
 
 
@@ -186,7 +237,9 @@ def put_via_presigned_url(url: str, local_path: Path) -> str:
 
 
 __all__ = [
+    "PRESIGN_BATCH_LIMIT",
     "PresignError",
+    "PresignTransferError",
     "PresignedUrl",
     "fetch_manifest",
     "fetch_via_presigned_url",

--- a/packages/nauro/src/nauro/sync/transfer.py
+++ b/packages/nauro/src/nauro/sync/transfer.py
@@ -1,0 +1,135 @@
+"""Retry policy for presigned object downloads.
+
+A restore pulls a whole record over one network, so a single dropped
+connection must not cost the run. What counts as retryable, how long to wait,
+and when a presigned URL is stale are one judgment, so they live here rather
+than at the call sites: the store layer decides what to do with the bytes, and
+this module decides whether there are bytes to have.
+
+Classification takes the same posture as the server-side storage classifier: a
+fault we cannot name is a fault we cannot promise a retry will fix, so
+anything unrecognized is permanent.
+"""
+
+from __future__ import annotations
+
+import random
+import time
+from collections.abc import Callable
+from enum import Enum
+from typing import Protocol
+
+from nauro.sync.remote import PresignError, PresignTransferError
+
+# Object storage and the API edge answer overload and their own faults with
+# these; every other status names something the same request will not fix.
+_TRANSIENT_STATUSES = frozenset({429, 500, 502, 503, 504})
+
+# A presigned URL past its TTL answers 403, and so does a URL the caller was
+# never entitled to. The response cannot tell them apart, so the first 403
+# buys one fresh mint and a second 403 settles which one it was.
+_EXPIRED_STATUS = 403
+
+# Four attempts spans a few seconds of packet loss without holding a restore
+# open against a network that is simply down.
+_MAX_ATTEMPTS = 4
+_BASE_DELAY_SECONDS = 0.5
+_MAX_DELAY_SECONDS = 8.0
+
+
+class TransferFault(Enum):
+    """What a failed download says about trying again."""
+
+    TRANSIENT = "transient"
+    EXPIRED_CANDIDATE = "expired-candidate"
+    PERMANENT = "permanent"
+
+
+class Reporter(Protocol):
+    """Surface for transfer progress.
+
+    Structurally the pull core's reporter (:class:`nauro.sync.pull.Reporter`),
+    so one CLI implementation serves both paths.
+    """
+
+    def info(self, msg: str) -> None:
+        """Report routine progress (a start line, a file count, a completion)."""
+
+    def warn(self, msg: str) -> None:
+        """Report a recoverable anomaly (a kept partial transfer)."""
+
+
+class UrlSource(Protocol):
+    """The presigned URLs for one batch, re-mintable while the batch drains."""
+
+    def url_for(self, path: str) -> str:
+        """Return the current download URL for ``path``."""
+
+    def remint(self) -> None:
+        """Mint fresh URLs for every path in the batch still outstanding."""
+
+
+def classify_fault(error: PresignError) -> TransferFault:
+    """Judge whether a failed download is worth another attempt."""
+    if not isinstance(error, PresignTransferError):
+        return TransferFault.PERMANENT
+    if error.status is None:
+        return TransferFault.TRANSIENT if error.transport else TransferFault.PERMANENT
+    if error.status in _TRANSIENT_STATUSES:
+        return TransferFault.TRANSIENT
+    if error.status == _EXPIRED_STATUS:
+        return TransferFault.EXPIRED_CANDIDATE
+    return TransferFault.PERMANENT
+
+
+def backoff_delay(failures: int) -> float:
+    """Return the wait before the retry that follows ``failures`` failures.
+
+    Full jitter, not a fixed exponential step: a whole record's files fail
+    together when a network drops, and equal waits would retry them in
+    lockstep against the endpoint that just refused them.
+    """
+    ceiling = min(_MAX_DELAY_SECONDS, _BASE_DELAY_SECONDS * 2 ** (failures - 1))
+    return random.uniform(0.0, ceiling)
+
+
+def pause(seconds: float) -> None:
+    """Wait between attempts. A seam: tests replace it to run at full speed."""
+    time.sleep(seconds)
+
+
+def download_with_retry(path: str, urls: UrlSource, fetch: Callable[[str], bytes]) -> bytes:
+    """Download one object, retrying transient faults and one stale URL.
+
+    Raises:
+        ~nauro.sync.remote.PresignError: the last failure, once the fault is
+            permanent or the attempt budget is spent.
+    """
+    failures = 0
+    reminted = False
+    while True:
+        try:
+            return fetch(urls.url_for(path))
+        except PresignError as exc:
+            failures += 1
+            fault = classify_fault(exc)
+            if fault is TransferFault.EXPIRED_CANDIDATE and not reminted:
+                # A URL minted seconds ago that still answers 403 is refused,
+                # not expired, so the mint is offered exactly once.
+                reminted = True
+                urls.remint()
+                continue
+            if fault is not TransferFault.TRANSIENT or failures >= _MAX_ATTEMPTS:
+                raise
+            pause(backoff_delay(failures))
+
+
+__all__ = [
+    "Reporter",
+    "TransferFault",
+    "UrlSource",
+    "backoff_delay",
+    "classify_fault",
+    "download_with_retry",
+    "pause",
+]

--- a/packages/nauro/src/nauro/sync/transfer.py
+++ b/packages/nauro/src/nauro/sync/transfer.py
@@ -46,17 +46,29 @@ class TransferFault(Enum):
 
 
 class Reporter(Protocol):
-    """Surface for transfer progress.
+    """Surface for transfer progress, shared by every path that moves bytes.
 
-    Structurally the pull core's reporter (:class:`nauro.sync.pull.Reporter`),
-    so one CLI implementation serves both paths.
+    The pull core and the cloud restore both report through it, and the CLI,
+    the hooks, and the tests each supply their own implementation: the CLI
+    echoes to the terminal, the hook logs quietly (session startup must never
+    crash), and a caller that surfaces nothing takes :class:`NullReporter`.
     """
 
     def info(self, msg: str) -> None:
-        """Report routine progress (a start line, a file count, a completion)."""
+        """Report routine progress (a file written, a count, a completion)."""
 
     def warn(self, msg: str) -> None:
-        """Report a recoverable anomaly (a kept partial transfer)."""
+        """Report a recoverable anomaly (a URL shortfall, a kept partial run)."""
+
+
+class NullReporter:
+    """Reporter for callers that surface nothing (library use, tests)."""
+
+    def info(self, msg: str) -> None:
+        """Discard routine progress."""
+
+    def warn(self, msg: str) -> None:
+        """Discard anomaly reports."""
 
 
 class UrlSource(Protocol):
@@ -125,6 +137,7 @@ def download_with_retry(path: str, urls: UrlSource, fetch: Callable[[str], bytes
 
 
 __all__ = [
+    "NullReporter",
     "Reporter",
     "TransferFault",
     "UrlSource",

--- a/packages/nauro/src/nauro/sync/transfer.py
+++ b/packages/nauro/src/nauro/sync/transfer.py
@@ -113,6 +113,14 @@ def pause(seconds: float) -> None:
 def download_with_retry(path: str, urls: UrlSource, fetch: Callable[[str], bytes]) -> bytes:
     """Download one object, retrying transient faults and one stale URL.
 
+    A re-mint is a credential refresh, not a network fault, so it resets the
+    transient budget instead of spending from it: the URL that failed and the
+    URL that replaces it are different requests, and the second one has to be
+    able to ride out a dropped connection too. The total stays bounded because
+    ``reminted`` is a one-time latch - at worst a full budget before the mint
+    and a full budget after it, then the second refusal falls through as
+    permanent.
+
     Raises:
         ~nauro.sync.remote.PresignError: the last failure, once the fault is
             permanent or the attempt budget is spent.
@@ -129,6 +137,7 @@ def download_with_retry(path: str, urls: UrlSource, fetch: Callable[[str], bytes
                 # A URL minted seconds ago that still answers 403 is refused,
                 # not expired, so the mint is offered exactly once.
                 reminted = True
+                failures = 0
                 urls.remint()
                 continue
             if fault is not TransferFault.TRANSIENT or failures >= _MAX_ATTEMPTS:

--- a/packages/nauro/tests/test_attach.py
+++ b/packages/nauro/tests/test_attach.py
@@ -38,7 +38,7 @@ def _list_response(projects):
     return handler
 
 
-def _restore_project(_project_id, destination):
+def _restore_project(_project_id, destination, _reporter=None):
     scaffold_project_store("team-proj", destination)
     return destination
 

--- a/packages/nauro/tests/test_onboarding_inventories.py
+++ b/packages/nauro/tests/test_onboarding_inventories.py
@@ -278,7 +278,7 @@ def test_attach_happy_path_inventory(tmp_path: Path, monkeypatch):
             request=httpx.Request(method, url),
         )
 
-    def restore(_project_id, destination):
+    def restore(_project_id, destination, _reporter=None):
         scaffold_project_store("team-proj", destination)
         return destination
 

--- a/packages/nauro/tests/test_reconnect.py
+++ b/packages/nauro/tests/test_reconnect.py
@@ -64,7 +64,7 @@ def test_reconnect_cloud_restore_uses_same_binding_service(tmp_path, monkeypatch
     monkeypatch.chdir(repo)
     target = registry.get_store_path_v2(PID)
 
-    def restore(_pid, destination):
+    def restore(_pid, destination, _reporter=None):
         assert _pid == PID
         assert destination == target
         scaffold_project_store("Pareto", destination)
@@ -105,7 +105,7 @@ def test_reconnect_restore_reconciles_server_side_rename(tmp_path, monkeypatch):
     monkeypatch.chdir(repo)
     target = registry.get_store_path_v2(PID)
 
-    def restore(_pid, destination):
+    def restore(_pid, destination, _reporter=None):
         scaffold_project_store("Pareto-Renamed", destination)
         return destination
 

--- a/packages/nauro/tests/test_recovery.py
+++ b/packages/nauro/tests/test_recovery.py
@@ -16,6 +16,20 @@ from nauro.templates.scaffolds import scaffold_project_store
 PID = "01KQ6AZGNA0B3QBF67NBXP3S45"
 
 
+def _staging(destination: Path) -> Path:
+    """The fixed staging directory a restore of ``destination`` resumes from.
+
+    Asserted against by path rather than by a ``.restore*`` glob, because the
+    lock file the restore leaves beside it wears the same prefix.
+    """
+    return destination.parent / f".{PID}.restore"
+
+
+def _legacy_staging(destination: Path) -> list[Path]:
+    """Staging directories under the pre-resume random-suffix pattern."""
+    return list(destination.parent.glob(f".{PID}.restore-*"))
+
+
 def _store_files(root: Path) -> dict[str, bytes]:
     scaffold_project_store("nauro", root)
     files: dict[str, bytes] = {}
@@ -79,7 +93,9 @@ def test_restore_cloud_store_installs_complete_record_atomically(tmp_path, monke
         for path in destination.rglob("*")
         if path.is_file()
     } == files
-    assert not list(destination.parent.glob(f".{PID}.restore-*"))
+    # A completed install consumes its staging directory.
+    assert not _staging(destination).exists()
+    assert _legacy_staging(destination) == []
 
 
 def test_restore_cloud_store_refuses_nonempty_destination_before_network(tmp_path, monkeypatch):
@@ -98,7 +114,13 @@ def test_restore_cloud_store_refuses_nonempty_destination_before_network(tmp_pat
     assert (destination / "keep.txt").read_text() == "keep"
 
 
-def test_restore_cloud_store_cleans_staging_on_hash_mismatch(tmp_path, monkeypatch):
+def test_restore_cloud_store_installs_nothing_on_hash_mismatch(tmp_path, monkeypatch):
+    """A corrupt download stops the restore and installs nothing.
+
+    Staging survives, because a hash mismatch is a download-phase failure: the
+    file that failed is never written, and the resume re-fetches it against a
+    fresh manifest rather than making the user download the record again.
+    """
     source = tmp_path / "source"
     files = _store_files(source)
     _mock_remote(monkeypatch, files)
@@ -111,7 +133,10 @@ def test_restore_cloud_store_cleans_staging_on_hash_mismatch(tmp_path, monkeypat
         restore_cloud_store(PID, destination)
 
     assert not destination.exists()
-    assert not list(destination.parent.glob(f".{PID}.restore-*"))
+    staging = _staging(destination)
+    assert staging.is_dir()
+    assert not (staging / manifest[0]["path"]).exists()
+    assert _legacy_staging(destination) == []
 
 
 def test_restore_cloud_store_skips_hash_check_for_opaque_etag(tmp_path, monkeypatch):
@@ -155,7 +180,7 @@ def test_restore_cloud_store_still_catches_corruption_behind_opaque_etag(tmp_pat
         restore_cloud_store(PID, destination)
 
     assert not destination.exists()
-    assert not list(destination.parent.glob(f".{PID}.restore-*"))
+    assert not (_staging(destination) / manifest[0]["path"]).exists()
 
 
 def test_restore_accepts_default_store_path_under_symlinked_home(tmp_path, monkeypatch):
@@ -237,10 +262,18 @@ def test_restore_cloud_store_rejects_malformed_manifest_types(entry, tmp_path, m
         restore_cloud_store(PID, destination)
 
     assert not destination.exists()
-    assert not list(destination.parent.glob(f".{PID}.restore-*"))
+    # An unreadable manifest is refused before staging opens.
+    assert not _staging(destination).exists()
+    assert _legacy_staging(destination) == []
 
 
 def test_restore_cloud_store_rejects_malformed_presign_result(tmp_path, monkeypatch):
+    """An unreadable presign response stops the restore with nothing staged.
+
+    Staging is already open by then, so it stays: a bad server response says
+    nothing about the files already on disk, and the next run re-verifies them
+    anyway. Nothing was downloaded under it here, so it stays empty.
+    """
     source = tmp_path / "source"
     files = _store_files(source)
     _mock_remote(monkeypatch, files)
@@ -255,7 +288,9 @@ def test_restore_cloud_store_rejects_malformed_presign_result(tmp_path, monkeypa
         restore_cloud_store(PID, destination)
 
     assert not destination.exists()
-    assert not list(destination.parent.glob(f".{PID}.restore-*"))
+    staging = _staging(destination)
+    assert staging.is_dir()
+    assert list(staging.iterdir()) == []
 
 
 def _decision_bytes(num: int, *, supersedes: str | None = None) -> bytes:
@@ -305,3 +340,6 @@ def test_restore_cloud_store_rejects_damaged_decision_graph(tmp_path, monkeypatc
         restore_cloud_store(PID, destination)
 
     assert not destination.exists()
+    # The whole record downloaded and still failed validation. Resuming would
+    # rebuild the same bad store, so staging is discarded for a clean restart.
+    assert not _staging(destination).exists()

--- a/packages/nauro/tests/test_recovery_resume.py
+++ b/packages/nauro/tests/test_recovery_resume.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import hashlib
+from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 
 import pytest
 from filelock import FileLock
@@ -12,6 +14,7 @@ from nauro.store import recovery
 from nauro.store.recovery import RecoveryError, RestoreBusyError, restore_cloud_store
 from nauro.sync import transfer
 from nauro.sync.remote import PresignTransferError
+from nauro.templates.scaffolds import scaffold_project_store
 from tests.test_recovery import PID, _decision_bytes, _store_files
 
 
@@ -44,6 +47,10 @@ class _Cloud:
         self.faults: dict[str, list[Exception]] = {}
         self.always_fail: dict[str, Exception] = {}
         self.waits: list[float] = []
+        # Paths served with a multipart ETag and no size, the shape that gives
+        # the manifest nothing to check a staged body against.
+        self.opaque: set[str] = set()
+        self.etag_revision = 0
 
     def install(self, monkeypatch) -> None:
         monkeypatch.setattr(recovery, "fetch_manifest", self.manifest)
@@ -52,14 +59,21 @@ class _Cloud:
         monkeypatch.setattr(transfer, "pause", self.waits.append)
 
     def manifest(self, _project_id: str) -> list[dict]:
-        return [
-            {
-                "path": path,
-                "etag": f'"{hashlib.md5(content).hexdigest()}"',
-                "size": len(content),
-            }
-            for path, content in sorted(self.files.items())
-        ]
+        rows = []
+        for path, content in sorted(self.files.items()):
+            if path in self.opaque:
+                rows.append(
+                    {"path": path, "etag": f'"{"0" * 31}{self.etag_revision}-2"'},
+                )
+                continue
+            rows.append(
+                {
+                    "path": path,
+                    "etag": f'"{hashlib.md5(content).hexdigest()}"',
+                    "size": len(content),
+                }
+            )
+        return rows
 
     def presign(self, _project_id: str, operations: list[dict[str, str]]) -> list[dict]:
         self.generation += 1
@@ -102,7 +116,7 @@ class _RecordingReporter:
         self.warn_lines.append(msg)
 
 
-def _staging(destination) -> object:
+def _staging(destination: Path) -> Path:
     return destination.parent / f".{PID}.restore"
 
 
@@ -202,17 +216,23 @@ def test_aborted_restore_keeps_staging_and_a_rerun_fetches_only_the_rest(tmp_pat
     assert f"Resuming a partial restore: 3 of {len(files)} files are staged." in resumed.info_lines
 
 
+def _abort_after_staging_all_but_last(cloud: _Cloud, destination: Path) -> Path:
+    """Leave a genuine partial restore behind: four files staged, one to go."""
+    cloud.always_fail["state_current.md"] = _http_fault(404)
+    with pytest.raises(RecoveryError):
+        restore_cloud_store(PID, destination)
+    cloud.always_fail.clear()
+    cloud.fetched.clear()
+    return _staging(destination)
+
+
 @pytest.mark.parametrize("damage", ["shorter", "same-size"])
 def test_resume_redownloads_a_corrupt_staged_file(damage, tmp_path, monkeypatch):
     files = _store_files(tmp_path / "source")
     cloud = _Cloud(files)
     cloud.install(monkeypatch)
     destination = tmp_path / "projects" / PID
-    staging = _staging(destination)
-    for relative, content in files.items():
-        target = staging / relative
-        target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_bytes(content)
+    staging = _abort_after_staging_all_but_last(cloud, destination)
     corrupt = b"x" if damage == "shorter" else b"x" * len(files["stack.md"])
     (staging / "stack.md").write_bytes(corrupt)
     (staging / "dropped.md").write_bytes(b"absent from the manifest")
@@ -220,9 +240,74 @@ def test_resume_redownloads_a_corrupt_staged_file(damage, tmp_path, monkeypatch)
     result = restore_cloud_store(PID, destination)
 
     assert result == destination
-    assert cloud.fetched == ["stack.md"]
+    assert cloud.fetched == ["stack.md", "state_current.md"]
     assert (destination / "stack.md").read_bytes() == files["stack.md"]
     assert not (destination / "dropped.md").exists()
+
+
+def test_resume_redownloads_a_same_size_corruption_behind_an_opaque_etag(tmp_path, monkeypatch):
+    """The manifest alone cannot catch this one.
+
+    A multipart ETag is not a content MD5 and the server sends no size for it,
+    so nothing in the manifest disagrees with a same-length corruption. The
+    digest this run recorded when it wrote the file is what catches it.
+    """
+    files = _store_files(tmp_path / "source")
+    cloud = _Cloud(files)
+    cloud.opaque.add("stack.md")
+    cloud.install(monkeypatch)
+    destination = tmp_path / "projects" / PID
+    staging = _abort_after_staging_all_but_last(cloud, destination)
+    (staging / "stack.md").write_bytes(b"x" * len(files["stack.md"]))
+
+    result = restore_cloud_store(PID, destination)
+
+    assert result == destination
+    assert cloud.fetched == ["stack.md", "state_current.md"]
+    assert (destination / "stack.md").read_bytes() == files["stack.md"]
+
+
+def test_resume_redownloads_a_file_the_remote_rotated(tmp_path, monkeypatch):
+    """A staged file that is intact locally but stale remotely is refetched.
+
+    The ETag recorded at download time is compared against the fresh manifest,
+    so a remote file that moved on is re-downloaded even when the staged bytes
+    are exactly what this run wrote.
+    """
+    files = _store_files(tmp_path / "source")
+    cloud = _Cloud(files)
+    cloud.opaque.add("stack.md")
+    cloud.install(monkeypatch)
+    destination = tmp_path / "projects" / PID
+    _abort_after_staging_all_but_last(cloud, destination)
+    # Same length, new content, new opaque ETag: only the recorded ETag differs.
+    cloud.files["stack.md"] = b"y" * len(files["stack.md"])
+    cloud.etag_revision += 1
+
+    result = restore_cloud_store(PID, destination)
+
+    assert result == destination
+    assert cloud.fetched == ["stack.md", "state_current.md"]
+    assert (destination / "stack.md").read_bytes() == cloud.files["stack.md"]
+
+
+def test_the_restore_record_never_reaches_the_store(tmp_path, monkeypatch):
+    files = _store_files(tmp_path / "source")
+    cloud = _Cloud(files)
+    cloud.install(monkeypatch)
+    destination = tmp_path / "projects" / PID
+    ledger = destination.parent / f".{PID}.restore.ledger.json"
+
+    _abort_after_staging_all_but_last(cloud, destination)
+
+    # It exists while a partial restore is resumable, and it is not staged.
+    assert ledger.is_file()
+    assert not (_staging(destination) / ledger.name).exists()
+
+    restore_cloud_store(PID, destination)
+
+    assert not ledger.exists()
+    assert [path.name for path in destination.rglob("*") if "ledger" in path.name] == []
 
 
 def test_a_deadline_inside_the_margin_remints_before_each_download(tmp_path, monkeypatch):
@@ -297,7 +382,8 @@ def test_staging_writes_go_through_the_atomic_primitive(tmp_path, monkeypatch):
     real_write = recovery.atomic_write_bytes
 
     def counted(path, data):
-        written.append(path.name)
+        if "ledger" not in path.name:
+            written.append(path.name)
         real_write(path, data)
 
     monkeypatch.setattr(recovery, "atomic_write_bytes", counted)
@@ -381,6 +467,115 @@ def test_legacy_staging_directories_are_swept(tmp_path, monkeypatch):
     restore_cloud_store(PID, destination)
 
     assert not list(destination.parent.glob(f".{PID}.restore-*"))
+
+
+def test_a_failed_install_keeps_the_verified_tree_for_a_resume(tmp_path, monkeypatch):
+    """A filesystem fault at install time is not a reason to download again.
+
+    The content passed every check by then. The next run installs what is
+    already staged and fetches nothing.
+    """
+    files = _store_files(tmp_path / "source")
+    cloud = _Cloud(files)
+    cloud.install(monkeypatch)
+    destination = tmp_path / "projects" / PID
+    reporter = _RecordingReporter()
+
+    staging = _staging(destination)
+    real_replace = recovery.os.replace
+
+    def refuse_the_install_rename(source, target):
+        # Only the install moves the staging directory itself; the atomic
+        # staging writes rename tmp siblings and must keep working.
+        if Path(source) == staging:
+            raise OSError("cross-device link")
+        return real_replace(source, target)
+
+    monkeypatch.setattr(recovery.os, "replace", refuse_the_install_rename)
+
+    with pytest.raises(RecoveryError, match="install"):
+        restore_cloud_store(PID, destination, reporter)
+
+    assert staging.is_dir()
+    assert any("Partial restore kept" in line for line in reporter.warn_lines)
+    assert cloud.fetched == sorted(files)
+
+    monkeypatch.undo()
+    cloud.install(monkeypatch)
+    cloud.fetched.clear()
+
+    result = restore_cloud_store(PID, destination)
+
+    assert result == destination
+    assert cloud.fetched == []
+    assert (destination / "project.md").read_bytes() == files["project.md"]
+    assert not staging.exists()
+
+
+def test_a_store_that_fails_validation_discards_the_staging_tree(tmp_path, monkeypatch):
+    """A bad assembled record must not resume into the same bad record."""
+    files = _store_files(tmp_path / "source")
+    decision = next(path for path in files if path.startswith("decisions/"))
+    files[decision] = files[decision].replace(b"superseded_by: null", b"superseded_by: '999'")
+    cloud = _Cloud(files)
+    cloud.install(monkeypatch)
+    destination = tmp_path / "projects" / PID
+
+    with pytest.raises(RecoveryError, match="integrity"):
+        restore_cloud_store(PID, destination)
+
+    assert not _staging(destination).exists()
+    assert not (destination.parent / f".{PID}.restore.ledger.json").exists()
+
+
+def _lock_that_lets_another_run_finish(populate) -> object:
+    """A restore lock whose waiter finds the destination already taken."""
+    real_lock = recovery._restore_lock
+
+    @contextmanager
+    def racing_lock(project_id, destination):
+        with real_lock(project_id, destination):
+            populate(destination)
+            yield
+
+    return racing_lock
+
+
+def test_a_waiter_accepts_the_record_the_winner_installed(tmp_path, monkeypatch):
+    files = _store_files(tmp_path / "source")
+    cloud = _Cloud(files)
+    cloud.install(monkeypatch)
+    destination = tmp_path / "projects" / PID
+    reporter = _RecordingReporter()
+    monkeypatch.setattr(
+        recovery,
+        "_restore_lock",
+        _lock_that_lets_another_run_finish(lambda path: scaffold_project_store("nauro", path)),
+    )
+
+    result = restore_cloud_store(PID, destination, reporter)
+
+    assert result == destination
+    assert cloud.fetched == []
+    assert any("Another restore completed" in line for line in reporter.info_lines)
+
+
+def test_a_waiter_refuses_a_destination_that_is_not_a_record(tmp_path, monkeypatch):
+    files = _store_files(tmp_path / "source")
+    cloud = _Cloud(files)
+    cloud.install(monkeypatch)
+    destination = tmp_path / "projects" / PID
+
+    def litter(path):
+        path.mkdir(parents=True, exist_ok=True)
+        (path / "unrelated.txt").write_bytes(b"not a record")
+
+    monkeypatch.setattr(recovery, "_restore_lock", _lock_that_lets_another_run_finish(litter))
+
+    with pytest.raises(RecoveryError, match="nonempty destination"):
+        restore_cloud_store(PID, destination)
+
+    assert cloud.fetched == []
 
 
 def test_a_second_restore_refuses_while_one_is_running(tmp_path, monkeypatch):

--- a/packages/nauro/tests/test_recovery_resume.py
+++ b/packages/nauro/tests/test_recovery_resume.py
@@ -137,6 +137,46 @@ def test_transient_transport_fault_retries_with_backoff_and_restores(tmp_path, m
     assert len(cloud.waits) == 2
 
 
+def test_a_transient_fault_gets_four_attempts_and_no_more(tmp_path, monkeypatch):
+    files = _store_files(tmp_path / "source")
+    cloud = _Cloud(files)
+    cloud.always_fail["project.md"] = _transport_fault()
+    cloud.install(monkeypatch)
+    destination = tmp_path / "projects" / PID
+
+    with pytest.raises(RecoveryError, match="download failed"):
+        restore_cloud_store(PID, destination)
+
+    assert cloud.fetched.count("project.md") == 4
+    assert len(cloud.waits) == 3
+
+
+def test_a_remint_does_not_spend_the_transient_budget(tmp_path, monkeypatch):
+    """A re-mint refreshes a credential; it is not a failed network attempt.
+
+    The URL that replaces a stale one has to be able to ride out a dropped
+    connection too, so the fresh URL starts with the whole budget.
+    """
+    files = _store_files(tmp_path / "source")
+    cloud = _Cloud(files)
+    cloud.faults["project.md"] = [
+        _http_fault(403),
+        _transport_fault(),
+        _transport_fault(),
+        _transport_fault(),
+    ]
+    cloud.install(monkeypatch)
+    destination = tmp_path / "projects" / PID
+
+    result = restore_cloud_store(PID, destination)
+
+    assert result == destination
+    # One refusal, then a full budget of three retries and the success.
+    assert cloud.fetched.count("project.md") == 5
+    assert len(cloud.mints) == 2
+    assert len(cloud.waits) == 3
+
+
 def test_permanent_http_fault_aborts_on_the_first_attempt(tmp_path, monkeypatch):
     files = _store_files(tmp_path / "source")
     cloud = _Cloud(files)

--- a/packages/nauro/tests/test_recovery_resume.py
+++ b/packages/nauro/tests/test_recovery_resume.py
@@ -31,7 +31,11 @@ class _Cloud:
     fetches, and backoff waits are all recorded.
     """
 
-    def __init__(self, files: dict[str, bytes], ttl: timedelta | None = None) -> None:
+    # The deployed presign endpoint stamps a 900-second ceiling on every URL,
+    # so that is the default here; ``ttl=None`` models a server that stopped.
+    def __init__(
+        self, files: dict[str, bytes], ttl: timedelta | None = timedelta(seconds=900)
+    ) -> None:
         self.files = files
         self.ttl = ttl
         self.generation = 0
@@ -178,18 +182,24 @@ def test_aborted_restore_keeps_staging_and_a_rerun_fetches_only_the_rest(tmp_pat
     assert sorted(
         path.relative_to(staging).as_posix() for path in staging.rglob("*") if path.is_file()
     ) == ["decisions/001-initial-setup.md", "open-questions.md", "project.md"]
-    assert any("Partial restore kept" in line for line in reporter.warn_lines)
+    # The count is against the whole record, and it names the kept directory.
+    assert reporter.warn_lines == [
+        f"Partial restore kept at {staging} (3 of {len(files)} files ready). "
+        "Run the same command again to resume it, or delete that directory to start over."
+    ]
 
     cloud.always_fail.clear()
     cloud.fetched.clear()
     cloud.mints.clear()
+    resumed = _RecordingReporter()
 
-    result = restore_cloud_store(PID, destination)
+    result = restore_cloud_store(PID, destination, resumed)
 
     assert result == destination
     assert cloud.fetched == ["stack.md", "state_current.md"]
     assert cloud.mints == [["stack.md", "state_current.md"]]
     assert not staging.exists()
+    assert f"Resuming a partial restore: 3 of {len(files)} files are staged." in resumed.info_lines
 
 
 @pytest.mark.parametrize("damage", ["shorter", "same-size"])
@@ -239,6 +249,22 @@ def test_a_deadline_beyond_the_margin_mints_once(tmp_path, monkeypatch):
     assert len(cloud.mints) == 1
 
 
+def test_a_batch_without_an_expiry_warns_once(tmp_path, monkeypatch):
+    """A server that stops stamping expiries must not disable the renewal quietly."""
+    files = _store_files(tmp_path / "source")
+    cloud = _Cloud(files, ttl=None)
+    cloud.install(monkeypatch)
+    destination = tmp_path / "projects" / PID
+    reporter = _RecordingReporter()
+
+    assert restore_cloud_store(PID, destination, reporter) == destination
+    assert [line for line in reporter.warn_lines if "no expiry" in line] == [
+        "The presign response carried no expiry, so this restore cannot renew "
+        "a download URL before it lapses."
+    ]
+    assert len(cloud.mints) == 1
+
+
 def test_progress_reports_start_cadence_and_completion(tmp_path, monkeypatch):
     files = _store_files(tmp_path / "source")
     for number in range(100, 130):
@@ -256,6 +282,91 @@ def test_progress_reports_start_cadence_and_completion(tmp_path, monkeypatch):
     assert reporter.warn_lines == []
 
 
+def test_staging_writes_go_through_the_atomic_primitive(tmp_path, monkeypatch):
+    """Every staged file lands by tmp-then-rename, never by a truncating write.
+
+    A manifest entry with no size and an opaque ETag gives the resume audit
+    nothing to check, so a short file would pass the audit and install as
+    content. The primitive removes the case rather than narrowing it.
+    """
+    files = _store_files(tmp_path / "source")
+    cloud = _Cloud(files)
+    cloud.install(monkeypatch)
+    destination = tmp_path / "projects" / PID
+    written: list[str] = []
+    real_write = recovery.atomic_write_bytes
+
+    def counted(path, data):
+        written.append(path.name)
+        real_write(path, data)
+
+    monkeypatch.setattr(recovery, "atomic_write_bytes", counted)
+
+    restore_cloud_store(PID, destination)
+
+    assert recovery.atomic_write_bytes is counted
+    assert len(written) == len(files)
+    assert (destination / "project.md").read_bytes() == files["project.md"]
+
+
+def test_a_kill_mid_restore_keeps_only_whole_files(tmp_path, monkeypatch):
+    """An interrupt keeps the staging directory, and every survivor is complete."""
+    files = _store_files(tmp_path / "source")
+    cloud = _Cloud(files)
+    cloud.always_fail["project.md"] = KeyboardInterrupt()
+    cloud.install(monkeypatch)
+    destination = tmp_path / "projects" / PID
+    reporter = _RecordingReporter()
+
+    with pytest.raises(KeyboardInterrupt):
+        restore_cloud_store(PID, destination, reporter)
+
+    staging = _staging(destination)
+    survivors = {
+        path.relative_to(staging).as_posix(): path.read_bytes()
+        for path in staging.rglob("*")
+        if path.is_file()
+    }
+    assert survivors == {relative: files[relative] for relative in survivors}
+    assert survivors
+    assert any(str(staging) in line for line in reporter.warn_lines)
+
+
+def test_resume_removes_a_tmp_sibling_a_kill_stranded(tmp_path, monkeypatch):
+    """The audit deletes every staged path the manifest does not list.
+
+    A tmp sibling from an interrupted atomic write is one of those paths, so
+    the resume clears it instead of installing it into the store.
+    """
+    files = _store_files(tmp_path / "source")
+    cloud = _Cloud(files)
+    cloud.install(monkeypatch)
+    destination = tmp_path / "projects" / PID
+    staging = _staging(destination)
+    staging.mkdir(parents=True)
+    (staging / ".project.md.0123456789abcdef.tmp").write_bytes(b"half a file")
+
+    restore_cloud_store(PID, destination)
+
+    assert sorted(
+        path.relative_to(destination).as_posix()
+        for path in destination.rglob("*")
+        if path.is_file()
+    ) == sorted(files)
+
+
+def test_a_file_squatting_on_the_staging_path_is_cleared(tmp_path, monkeypatch):
+    files = _store_files(tmp_path / "source")
+    cloud = _Cloud(files)
+    cloud.install(monkeypatch)
+    destination = tmp_path / "projects" / PID
+    destination.parent.mkdir(parents=True)
+    _staging(destination).write_bytes(b"not a staging directory")
+
+    assert restore_cloud_store(PID, destination) == destination
+    assert (destination / "project.md").read_bytes() == files["project.md"]
+
+
 def test_legacy_staging_directories_are_swept(tmp_path, monkeypatch):
     files = _store_files(tmp_path / "source")
     cloud = _Cloud(files)
@@ -264,6 +375,8 @@ def test_legacy_staging_directories_are_swept(tmp_path, monkeypatch):
     stranded = destination.parent / f".{PID}.restore-ab12cd"
     stranded.mkdir(parents=True)
     (stranded / "project.md").write_bytes(b"orphaned by a killed run")
+    # A file wearing the same pattern is litter under the same reading.
+    (destination.parent / f".{PID}.restore-ef34gh").write_bytes(b"orphan")
 
     restore_cloud_store(PID, destination)
 

--- a/packages/nauro/tests/test_recovery_resume.py
+++ b/packages/nauro/tests/test_recovery_resume.py
@@ -1,0 +1,289 @@
+"""Restore behavior over an unreliable network: retry, re-mint, and resume."""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from filelock import FileLock
+
+from nauro.store import recovery
+from nauro.store.recovery import RecoveryError, RestoreBusyError, restore_cloud_store
+from nauro.sync import transfer
+from nauro.sync.remote import PresignTransferError
+from tests.test_recovery import PID, _decision_bytes, _store_files
+
+
+def _http_fault(status: int) -> PresignTransferError:
+    return PresignTransferError("Presigned GET", status=status, detail="refused")
+
+
+def _transport_fault() -> PresignTransferError:
+    return PresignTransferError("Presigned GET", transport=True, detail="connection reset")
+
+
+class _Cloud:
+    """A scriptable remote record behind the restore's three network calls.
+
+    Every minted URL carries its mint generation, so a test can prove a
+    download ran against re-minted URLs rather than stale ones. Presign calls,
+    fetches, and backoff waits are all recorded.
+    """
+
+    def __init__(self, files: dict[str, bytes], ttl: timedelta | None = None) -> None:
+        self.files = files
+        self.ttl = ttl
+        self.generation = 0
+        self.mints: list[list[str]] = []
+        self.fetched: list[str] = []
+        self.faults: dict[str, list[Exception]] = {}
+        self.always_fail: dict[str, Exception] = {}
+        self.waits: list[float] = []
+
+    def install(self, monkeypatch) -> None:
+        monkeypatch.setattr(recovery, "fetch_manifest", self.manifest)
+        monkeypatch.setattr(recovery, "request_presigned_urls", self.presign)
+        monkeypatch.setattr(recovery, "fetch_via_presigned_url", self.fetch)
+        monkeypatch.setattr(transfer, "pause", self.waits.append)
+
+    def manifest(self, _project_id: str) -> list[dict]:
+        return [
+            {
+                "path": path,
+                "etag": f'"{hashlib.md5(content).hexdigest()}"',
+                "size": len(content),
+            }
+            for path, content in sorted(self.files.items())
+        ]
+
+    def presign(self, _project_id: str, operations: list[dict[str, str]]) -> list[dict]:
+        self.generation += 1
+        self.mints.append([operation["path"] for operation in operations])
+        row: dict[str, str] = {}
+        if self.ttl is not None:
+            expires = datetime.now(timezone.utc) + self.ttl
+            row["expires_at"] = expires.strftime("%Y-%m-%dT%H:%M:%SZ")
+        return [
+            {
+                "verb": "GET",
+                "path": operation["path"],
+                "url": f"memory://{self.generation}/{operation['path']}",
+                **row,
+            }
+            for operation in operations
+        ]
+
+    def fetch(self, url: str) -> bytes:
+        _generation, _, path = url.removeprefix("memory://").partition("/")
+        self.fetched.append(path)
+        queued = self.faults.get(path)
+        if queued:
+            raise queued.pop(0)
+        standing = self.always_fail.get(path)
+        if standing is not None:
+            raise standing
+        return self.files[path]
+
+
+class _RecordingReporter:
+    def __init__(self) -> None:
+        self.info_lines: list[str] = []
+        self.warn_lines: list[str] = []
+
+    def info(self, msg: str) -> None:
+        self.info_lines.append(msg)
+
+    def warn(self, msg: str) -> None:
+        self.warn_lines.append(msg)
+
+
+def _staging(destination) -> object:
+    return destination.parent / f".{PID}.restore"
+
+
+def test_transient_transport_fault_retries_with_backoff_and_restores(tmp_path, monkeypatch):
+    files = _store_files(tmp_path / "source")
+    cloud = _Cloud(files)
+    cloud.faults["project.md"] = [_transport_fault(), _transport_fault()]
+    cloud.install(monkeypatch)
+    destination = tmp_path / "projects" / PID
+
+    result = restore_cloud_store(PID, destination)
+
+    assert result == destination
+    assert (destination / "project.md").read_bytes() == files["project.md"]
+    assert cloud.fetched.count("project.md") == 3
+    # Full jitter: each wait falls inside the doubling ceiling, never above it.
+    assert [wait <= ceiling for wait, ceiling in zip(cloud.waits, [0.5, 1.0])] == [True, True]
+    assert len(cloud.waits) == 2
+
+
+def test_permanent_http_fault_aborts_on_the_first_attempt(tmp_path, monkeypatch):
+    files = _store_files(tmp_path / "source")
+    cloud = _Cloud(files)
+    cloud.always_fail["project.md"] = _http_fault(404)
+    cloud.install(monkeypatch)
+    destination = tmp_path / "projects" / PID
+
+    with pytest.raises(RecoveryError, match="download failed"):
+        restore_cloud_store(PID, destination)
+
+    assert cloud.fetched.count("project.md") == 1
+    assert cloud.waits == []
+    assert not destination.exists()
+
+
+def test_stale_url_remints_the_rest_of_the_chunk_and_succeeds(tmp_path, monkeypatch):
+    files = _store_files(tmp_path / "source")
+    cloud = _Cloud(files)
+    cloud.faults["project.md"] = [_http_fault(403)]
+    cloud.install(monkeypatch)
+    destination = tmp_path / "projects" / PID
+
+    result = restore_cloud_store(PID, destination)
+
+    assert result == destination
+    # The re-mint covers the files still outstanding, not the whole record.
+    assert cloud.mints[1] == ["project.md", "stack.md", "state_current.md"]
+    assert cloud.waits == []
+
+
+def test_second_refusal_after_a_fresh_mint_is_permanent(tmp_path, monkeypatch):
+    files = _store_files(tmp_path / "source")
+    cloud = _Cloud(files)
+    cloud.always_fail["project.md"] = _http_fault(403)
+    cloud.install(monkeypatch)
+    destination = tmp_path / "projects" / PID
+
+    with pytest.raises(RecoveryError, match="download failed"):
+        restore_cloud_store(PID, destination)
+
+    assert cloud.fetched.count("project.md") == 2
+    assert len(cloud.mints) == 2
+
+
+def test_aborted_restore_keeps_staging_and_a_rerun_fetches_only_the_rest(tmp_path, monkeypatch):
+    files = _store_files(tmp_path / "source")
+    cloud = _Cloud(files)
+    cloud.always_fail["stack.md"] = _http_fault(404)
+    cloud.install(monkeypatch)
+    destination = tmp_path / "projects" / PID
+    reporter = _RecordingReporter()
+
+    with pytest.raises(RecoveryError):
+        restore_cloud_store(PID, destination, reporter)
+
+    staging = _staging(destination)
+    assert sorted(
+        path.relative_to(staging).as_posix() for path in staging.rglob("*") if path.is_file()
+    ) == ["decisions/001-initial-setup.md", "open-questions.md", "project.md"]
+    assert any("Partial restore kept" in line for line in reporter.warn_lines)
+
+    cloud.always_fail.clear()
+    cloud.fetched.clear()
+    cloud.mints.clear()
+
+    result = restore_cloud_store(PID, destination)
+
+    assert result == destination
+    assert cloud.fetched == ["stack.md", "state_current.md"]
+    assert cloud.mints == [["stack.md", "state_current.md"]]
+    assert not staging.exists()
+
+
+@pytest.mark.parametrize("damage", ["shorter", "same-size"])
+def test_resume_redownloads_a_corrupt_staged_file(damage, tmp_path, monkeypatch):
+    files = _store_files(tmp_path / "source")
+    cloud = _Cloud(files)
+    cloud.install(monkeypatch)
+    destination = tmp_path / "projects" / PID
+    staging = _staging(destination)
+    for relative, content in files.items():
+        target = staging / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(content)
+    corrupt = b"x" if damage == "shorter" else b"x" * len(files["stack.md"])
+    (staging / "stack.md").write_bytes(corrupt)
+    (staging / "dropped.md").write_bytes(b"absent from the manifest")
+
+    result = restore_cloud_store(PID, destination)
+
+    assert result == destination
+    assert cloud.fetched == ["stack.md"]
+    assert (destination / "stack.md").read_bytes() == files["stack.md"]
+    assert not (destination / "dropped.md").exists()
+
+
+def test_a_deadline_inside_the_margin_remints_before_each_download(tmp_path, monkeypatch):
+    files = _store_files(tmp_path / "source")
+    cloud = _Cloud(files, ttl=timedelta(seconds=30))
+    cloud.install(monkeypatch)
+    destination = tmp_path / "projects" / PID
+
+    result = restore_cloud_store(PID, destination)
+
+    assert result == destination
+    # One mint opens the chunk; every file then starts inside the margin.
+    assert len(cloud.mints) == 1 + len(files)
+    assert cloud.mints[-1] == ["state_current.md"]
+
+
+def test_a_deadline_beyond_the_margin_mints_once(tmp_path, monkeypatch):
+    files = _store_files(tmp_path / "source")
+    cloud = _Cloud(files, ttl=timedelta(seconds=900))
+    cloud.install(monkeypatch)
+    destination = tmp_path / "projects" / PID
+
+    assert restore_cloud_store(PID, destination) == destination
+    assert len(cloud.mints) == 1
+
+
+def test_progress_reports_start_cadence_and_completion(tmp_path, monkeypatch):
+    files = _store_files(tmp_path / "source")
+    for number in range(100, 130):
+        files[f"decisions/{number}-extra.md"] = _decision_bytes(number)
+    cloud = _Cloud(files)
+    cloud.install(monkeypatch)
+    destination = tmp_path / "projects" / PID
+    reporter = _RecordingReporter()
+
+    restore_cloud_store(PID, destination, reporter)
+
+    assert reporter.info_lines[0].startswith(f"Restoring {len(files)} files (")
+    assert f"25/{len(files)} files" in reporter.info_lines
+    assert reporter.info_lines[-1] == f"Restored {len(files)} files."
+    assert reporter.warn_lines == []
+
+
+def test_legacy_staging_directories_are_swept(tmp_path, monkeypatch):
+    files = _store_files(tmp_path / "source")
+    cloud = _Cloud(files)
+    cloud.install(monkeypatch)
+    destination = tmp_path / "projects" / PID
+    stranded = destination.parent / f".{PID}.restore-ab12cd"
+    stranded.mkdir(parents=True)
+    (stranded / "project.md").write_bytes(b"orphaned by a killed run")
+
+    restore_cloud_store(PID, destination)
+
+    assert not list(destination.parent.glob(f".{PID}.restore-*"))
+
+
+def test_a_second_restore_refuses_while_one_is_running(tmp_path, monkeypatch):
+    files = _store_files(tmp_path / "source")
+    cloud = _Cloud(files)
+    cloud.install(monkeypatch)
+    monkeypatch.setattr(recovery, "_RESTORE_LOCK_TIMEOUT", 0.05)
+    destination = tmp_path / "projects" / PID
+    destination.parent.mkdir(parents=True)
+    held = FileLock(str(destination.parent / f".{PID}.restore.lock"))
+    held.acquire()
+
+    try:
+        with pytest.raises(RestoreBusyError, match="in progress"):
+            restore_cloud_store(PID, destination)
+    finally:
+        held.release()
+
+    assert cloud.fetched == []

--- a/packages/nauro/tests/test_sync/test_sync_presign.py
+++ b/packages/nauro/tests/test_sync/test_sync_presign.py
@@ -690,3 +690,83 @@ class TestPresignResponseTyping:
 
         assert usable == {"b.md": "u"}
         assert len(skipped) == 1
+
+
+class TestPresignedGetFailures:
+    """Every download fault leaves the client as one typed PresignError."""
+
+    def test_a_transport_fault_never_escapes_as_a_raw_httpx_error(self):
+        from nauro.sync.remote import PresignError, PresignTransferError, fetch_via_presigned_url
+
+        with patch.object(httpx, "get", side_effect=httpx.ConnectError("no route")):
+            with pytest.raises(PresignTransferError) as caught:
+                fetch_via_presigned_url("https://s3/a")
+
+        # The pull core guards its transfers with `except PresignError`; a bare
+        # ConnectError past that guard used to crash the whole sync.
+        assert isinstance(caught.value, PresignError)
+        assert caught.value.transport is True
+        assert caught.value.status is None
+
+    def test_a_refused_status_carries_the_code_and_a_body_excerpt(self):
+        from nauro.sync.remote import PresignTransferError, fetch_via_presigned_url
+
+        refusal = httpx.Response(403, content=b"<Error>\n  <Code>AccessDenied</Code>\n</Error>")
+        with patch.object(httpx, "get", return_value=refusal):
+            with pytest.raises(PresignTransferError) as caught:
+                fetch_via_presigned_url("https://s3/a")
+
+        assert caught.value.status == 403
+        assert "AccessDenied" in caught.value.detail
+
+    def test_an_unsendable_url_is_typed_rather_than_thrown(self):
+        from nauro.sync.remote import PresignTransferError, fetch_via_presigned_url
+
+        with pytest.raises(PresignTransferError) as caught:
+            fetch_via_presigned_url("not-a-url")
+
+        assert caught.value.status is None
+        assert caught.value.transport is False
+
+
+class TestTransferPolicy:
+    """Classification decides what a retry may promise."""
+
+    @pytest.mark.parametrize("status", [429, 500, 502, 503, 504])
+    def test_overload_statuses_are_transient(self, status):
+        from nauro.sync.remote import PresignTransferError
+        from nauro.sync.transfer import TransferFault, classify_fault
+
+        fault = classify_fault(PresignTransferError("Presigned GET", status=status))
+
+        assert fault is TransferFault.TRANSIENT
+
+    @pytest.mark.parametrize("status", [400, 404, 409, 418])
+    def test_an_unnamed_status_is_permanent(self, status):
+        from nauro.sync.remote import PresignTransferError
+        from nauro.sync.transfer import TransferFault, classify_fault
+
+        fault = classify_fault(PresignTransferError("Presigned GET", status=status))
+
+        assert fault is TransferFault.PERMANENT
+
+    def test_a_refusal_is_an_expiry_candidate(self):
+        from nauro.sync.remote import PresignTransferError
+        from nauro.sync.transfer import TransferFault, classify_fault
+
+        fault = classify_fault(PresignTransferError("Presigned GET", status=403))
+
+        assert fault is TransferFault.EXPIRED_CANDIDATE
+
+    def test_a_plain_presign_error_is_permanent(self):
+        from nauro.sync.remote import PresignError
+        from nauro.sync.transfer import TransferFault, classify_fault
+
+        assert classify_fault(PresignError("something else")) is TransferFault.PERMANENT
+
+    def test_the_backoff_ceiling_doubles_and_then_caps(self):
+        from nauro.sync.transfer import backoff_delay
+
+        assert all(backoff_delay(1) <= 0.5 for _ in range(50))
+        assert all(backoff_delay(2) <= 1.0 for _ in range(50))
+        assert all(backoff_delay(20) <= 8.0 for _ in range(50))


### PR DESCRIPTION
## Problem

The `nauro attach` and `nauro reconnect` cloud restore downloaded each file one time. It did not retry. It showed no progress. The first failure deleted all downloaded files. One dropped packet in a large record caused a full re-download.

The restore also minted all presigned URLs at the start. The server gives each batch a 900-second life. A slow network outlives that life, and the client discarded the expiry time that the server sent.

A hard kill left a staging directory with a random name. No later run could find that directory.

## Solution

A new module `nauro/sync/transfer.py` holds the download policy:

- It sorts each failure into one of three classes: transient, expired-URL candidate, or permanent.
- Transport faults and the statuses 429, 500, 502, 503, and 504 are transient.
- The status 403 is an expired-URL candidate. The restore mints a new URL one time. A second 403 is permanent.
- An unknown fault is permanent. Do not promise that a retry corrects a fault that you cannot name.
- A transient fault gets a maximum of 4 attempts. The wait uses full jitter with a 0.5-second base and an 8.0-second cap.
- A new URL after a refusal starts with the full attempt budget, because a re-mint refreshes a credential and is not a failed attempt.

The presigned GET now puts every fault into a typed error. That error is a subclass of `PresignError`. It carries the HTTP status and a short body excerpt. This change also corrects a live defect: a connection error during a sync pull escaped `run_pull` and stopped the sync.

The `Reporter` protocol moves to the transfer module. The pull core imports it from there. One protocol now serves the pull and the restore.

The restore mints presigned URLs one chunk of 200 files at a time. It mints each chunk immediately before it downloads that chunk. It mints new URLs when the deadline of the batch comes within 60 seconds. It also mints new URLs one time when a URL gives a 403. It warns when a batch carries no expiry, because renewal ahead of an expiry is not possible then.

Staging moves to a fixed directory for each project: `<parent>/.<project-id>.restore`. A lock file guards it. A second restore of the same project stops with a clear message. The restore re-checks the destination after it takes the lock. A run that waited for the lock accepts a complete record that the other run installed, and it does not download anything.

Each staged file lands through a tmp file and a rename, so a kill cannot leave a short file that looks like content. The run also records the sha256 of each staged file next to the ETag it downloaded the file under. The manifest cannot always catch a damaged file: a multipart ETag is not a content MD5, and the server sends no size with one. The resume compares the recorded digest to catch local damage, and the recorded ETag to catch a remote file that moved on. The record sits beside the staging directory, so it never reaches the store.

A run that fails during the download keeps the staging directory. The message names that directory and gives the count against the full record. The next run gets a new manifest, verifies each staged file against it, deletes each file that does not agree, and downloads only the remainder. A record that fails store validation is discarded, because a bad record must not resume into the same bad record. A record that passes validation but that the filesystem refuses to install is kept, because the content is good and only the local move failed.

Each restore start also deletes the staging directories that older runs stranded.

`attach` and `reconnect` now print progress to stderr: one start line with the file count and the total size, one line for each 25 files, and one completion line. Other callers stay silent.

## Testing

New behavior tests in `packages/nauro/tests/test_recovery_resume.py`:

- `test_transient_transport_fault_retries_with_backoff_and_restores`
- `test_permanent_http_fault_aborts_on_the_first_attempt`
- `test_stale_url_remints_the_rest_of_the_chunk_and_succeeds`
- `test_second_refusal_after_a_fresh_mint_is_permanent`
- `test_a_remint_does_not_spend_the_transient_budget`
- `test_a_transient_fault_gets_four_attempts_and_no_more`
- `test_aborted_restore_keeps_staging_and_a_rerun_fetches_only_the_rest`
- `test_resume_redownloads_a_corrupt_staged_file`
- `test_resume_redownloads_a_same_size_corruption_behind_an_opaque_etag`
- `test_resume_redownloads_a_file_the_remote_rotated`
- `test_the_restore_record_never_reaches_the_store`
- `test_a_failed_install_keeps_the_verified_tree_for_a_resume`
- `test_a_store_that_fails_validation_discards_the_staging_tree`
- `test_a_waiter_accepts_the_record_the_winner_installed`
- `test_a_waiter_refuses_a_destination_that_is_not_a_record`
- `test_a_deadline_inside_the_margin_remints_before_each_download`
- `test_a_deadline_beyond_the_margin_mints_once`
- `test_a_batch_without_an_expiry_warns_once`
- `test_progress_reports_start_cadence_and_completion`
- `test_staging_writes_go_through_the_atomic_primitive`
- `test_a_kill_mid_restore_keeps_only_whole_files`
- `test_resume_removes_a_tmp_sibling_a_kill_stranded`
- `test_a_file_squatting_on_the_staging_path_is_cleared`
- `test_legacy_staging_directories_are_swept`
- `test_a_second_restore_refuses_while_one_is_running`

New transport and policy tests in `packages/nauro/tests/test_sync/test_sync_presign.py`: `TestPresignedGetFailures` proves that no raw httpx error escapes the presigned GET, and `TestTransferPolicy` pins the classification table and the backoff ceiling.

The existing recovery tests keep their coverage. Five of them asserted against the old random-suffix staging name. Each one now states whether the case keeps or discards the staging directory.

Full results: 2537 passed and 10 skipped for `nauro`, 1526 passed for `nauro-core`, and clean `ruff check` and `ruff format --check`.

## Merge order

This branch and the sync residuals branch both touch `packages/nauro/src/nauro/sync/pull.py` and `tests/test_sync/test_sync_presign.py`. Merge the sync branch first, then rebase this one.
