### PR TITLE
Release nauro 1.14.0 and nauro-core 1.11.0

### DIFF
--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro-core"
-version = "1.10.0"
+version = "1.11.0"
 description = "Shared pure-Python logic for Nauro: parsing, validation, context assembly, constants."
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro"
-version = "1.13.0"
+version = "1.14.0"
 description = "Human-approved project judgment and current state for connected AI agents, surfaced before work."
 readme = "README.md"
 license = "Apache-2.0"

--- a/server.json
+++ b/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Nauro-AI/nauro",
     "source": "github"
   },
-  "version": "1.13.0",
+  "version": "1.14.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "nauro",
-      "version": "1.13.0",
+      "version": "1.14.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -928,7 +928,7 @@ wheels = [
 
 [[package]]
 name = "nauro"
-version = "1.13.0"
+version = "1.14.0"
 source = { editable = "packages/nauro" }
 dependencies = [
     { name = "filelock" },
@@ -970,7 +970,7 @@ provides-extras = ["dev", "embeddings"]
 
 [[package]]
 name = "nauro-core"
-version = "1.10.0"
+version = "1.11.0"
 source = { editable = "packages/nauro-core" }
 dependencies = [
     { name = "bm25s" },


### PR DESCRIPTION
## Versions

- `nauro` 1.13.0 to 1.14.0 (minor)
- `nauro-core` 1.10.0 to 1.11.0 (minor)

The `nauro-core` floor in `packages/nauro/pyproject.toml` already reads
`>=1.11.0,<2`. That floor names a version that does not exist yet, so `main`
cannot be installed today. This release publishes 1.11.0 and repairs it.

## What ships in nauro-core 1.11.0

9 source files changed, 156 insertions, 19 deletions.

- Decision and question numbers parse as ASCII decimals only. A non-ASCII digit
  is rejected instead of reaching `int()`. The H1 pattern uses `[0-9]` in place
  of `\d`.
- `OPEN_QUESTIONS_DEFAULT_BODY` is exported, so both surfaces read one constant.
- The `share_context` summary rejects control characters that store one way and
  render another.

The curated public API gains 1 name and removes none. The only behavior change
narrows number parsing to ASCII, which fixes a crash.

## What ships in nauro 1.14.0

25 source files changed, 3905 insertions, 369 deletions.

- Pull-time decision-number collisions are classified. Identical unpublished
  records canonicalize, isolated unpublished colliders renumber, and anything
  published, referenced, or ambiguous is quarantined.
- Sync pulls are crash-safe. Each file write is a classified outcome, writes are
  atomic, and sync state is saved even when the run fails part way.
- A locally deleted file is restored on the next pull. Every refusal shape is
  counted, and a refusal holds back the full-sync timestamp.
- Interrupted writes stranded in the backup directory are swept.
- A degraded post-commit step now reaches the agent. All 4 MCP write adapters
  report it, and the stdio transport carries it instead of flattening it away.
- Every write-envelope status renders truthfully on the stdio surface. A
  rejected write no longer reports success.
- Conflict backups are written atomically.
- The cloud restore is resumable and retry-safe. It retries transient transport
  faults, reports progress, mints presigned URLs per chunk against their expiry,
  and resumes a partial restore instead of starting again.

## Behavior change to note

`nauro sync` exits 2 when the pull left refused files behind. A clean sync still
exits 0 and a hard failure still exits 1. Before this release the command exited
0 while reporting refusals only on stderr, so a supervising script read a partial
sync as a success.

## Checks

- `scripts/check_server_json_version.py`: server.json is locked to nauro 1.14.0,
  description 96 of 100 characters.
- `scripts/check_single_sourced.py packages/nauro/src`: no re-introduced
  nauro-core helpers.
- `uv lock --check`: the committed lock matches the bumped versions.
- `uv sync --locked` passes for both packages on Python 3.12.
- The diff touches 4 files: both `pyproject.toml` files, `server.json`, and
  `uv.lock`.

## After merge

Tag the squash-merge commit and push both tags. Each tag triggers its
trusted-publish workflow. The `nauro-v1.14.0` tag also publishes `server.json`
to the MCP registry.

```
git tag -a nauro-core-v1.11.0 <merge-sha> -m "nauro-core 1.11.0"
git tag -a nauro-v1.14.0      <merge-sha> -m "nauro 1.14.0"
git push origin nauro-core-v1.11.0 nauro-v1.14.0
```
