### PR TITLE
Record sync state when a cloud restore installs a store

### DIFF
--- a/packages/nauro/src/nauro/store/recovery.py
+++ b/packages/nauro/src/nauro/store/recovery.py
@@ -36,6 +36,7 @@ from nauro.store.registry import bind_project_store_v2, get_store_path_v2
 from nauro.store.repo_config import load_repo_config
 from nauro.store.resolution import RepoResolution
 from nauro.sync.cloud_projects import CloudProjectError, list_projects
+from nauro.sync.etag import content_md5
 from nauro.sync.remote import (
     PRESIGN_BATCH_LIMIT,
     PresignError,
@@ -43,6 +44,7 @@ from nauro.sync.remote import (
     fetch_via_presigned_url,
     request_presigned_urls,
 )
+from nauro.sync.state import FileState, SyncState, save_state
 from nauro.sync.transfer import NullReporter, Reporter, download_with_retry
 
 logger = logging.getLogger("nauro.store.recovery")
@@ -223,21 +225,6 @@ def _destination_is_available(destination: Path) -> bool:
     return next(destination.iterdir(), None) is None
 
 
-def _etag_md5(raw_etag: str) -> str | None:
-    """Return the ETag as a content MD5, or None when it cannot be one.
-
-    An S3 ETag equals the object's MD5 only for single-part, non-KMS-encrypted
-    uploads. Multipart ETags (``<md5>-<parts>``) and SSE-KMS/SSE-C ETags are
-    opaque, so they yield None and the caller skips the MD5 comparison rather
-    than failing a restore the sync pull path would have accepted. Size and
-    optional sha256 checks still apply to every file.
-    """
-    value = raw_etag.strip('"').lower()
-    if len(value) != 32 or any(ch not in "0123456789abcdef" for ch in value):
-        return None
-    return value
-
-
 class _IntegrityDefect(Enum):
     """Which manifest check a body failed. The value names it to the user."""
 
@@ -255,7 +242,7 @@ def _content_defect(content: bytes, entry: CloudManifestEntry) -> _IntegrityDefe
     """
     if entry.size is not None and len(content) != entry.size:
         return _IntegrityDefect.SIZE
-    expected_md5 = _etag_md5(entry.etag)
+    expected_md5 = content_md5(entry.etag)
     if (
         expected_md5 is not None
         and hashlib.md5(content, usedforsecurity=False).hexdigest() != expected_md5
@@ -651,6 +638,46 @@ def _install_staged_store(staging: Path, destination: Path) -> None:
         ) from exc
 
 
+def _seed_sync_state(area: _StagingArea) -> None:
+    """Record the assembled record as synced, inside the tree about to land.
+
+    A restore is the one moment a store is provably level with the server, and
+    nothing else can record it: ``.sync-state.json`` is never synced, so it
+    never arrives from the remote either. Left unwritten, every entry the next
+    pull reads is absent, absent reads as changed on both sides, and the run
+    backs the whole store up and downloads it again. A decision the server
+    edited fares worse: it reaches the collision gate untracked, and the stale
+    local copy wins a conflict it should never have been in.
+
+    The ledger is the source because it holds what actually landed - an ETag
+    the manifest published, and a digest of the bytes on disk under it, which
+    are ``remote_etag`` and ``local_sha256`` unchanged. It covers every
+    installed file whether this run downloaded it or resumed onto it, since a
+    staged file no ledger record backs is never kept.
+
+    The state is written into staging rather than onto the store, so it arrives
+    in the same rename as the files it describes and no instant exists in which
+    an installed store is untracked.
+    """
+    now = _utcnow().isoformat()
+    state = SyncState(
+        files={
+            relative: FileState(local_sha256=record.sha256, remote_etag=record.etag, last_sync=now)
+            for relative, record in area.ledger.files.items()
+        },
+        # Only a complete, validated tree reaches this line, so the store holds
+        # exactly what the manifest listed. That is the whole claim the stamp
+        # makes, and it gates nothing: two status surfaces read it. Reporting
+        # "never" for a store downloaded whole a moment ago would be the same
+        # untruth as the absent entries above.
+        last_full_sync=now,
+    )
+    try:
+        save_state(area.path, state)
+    except OSError as exc:
+        raise RecoveryError(f"Could not record the restored record's sync state: {exc}") from exc
+
+
 def _holds_complete_record(destination: Path) -> bool:
     """True when the destination already holds a complete, valid record."""
     try:
@@ -735,6 +762,13 @@ def restore_cloud_store(
             # badness, so the next run starts from nothing.
             area.discard()
             raise
+
+        # Nothing enumerates the staged tree between the validation above and
+        # the rename below, so a file added here is seen by nothing but the
+        # install: _install_staged_store empties the destination and renames,
+        # and that is all. A resume never inherits this file either, because
+        # the audit deletes every staged path the manifest does not name.
+        _seed_sync_state(area)
 
         # The content is verified from here. An install that fails now is a
         # local filesystem fault, not a bad record, so staging survives and the

--- a/packages/nauro/src/nauro/store/recovery.py
+++ b/packages/nauro/src/nauro/store/recovery.py
@@ -766,8 +766,8 @@ def restore_cloud_store(
         # Nothing enumerates the staged tree between the validation above and
         # the rename below, so a file added here is seen by nothing but the
         # install: _install_staged_store empties the destination and renames,
-        # and that is all. A resume never inherits this file either, because
-        # the audit deletes every staged path the manifest does not name.
+        # and that is all. A run that fails after this point and resumes writes
+        # the state again from the ledger it rebuilds, over whatever it left.
         _seed_sync_state(area)
 
         # The content is verified from here. An install that fails now is a

--- a/packages/nauro/src/nauro/sync/etag.py
+++ b/packages/nauro/src/nauro/sync/etag.py
@@ -1,0 +1,61 @@
+"""What an S3 ETag can and cannot say about a local file.
+
+An ETag equals the object's content MD5 only for a single-part upload that is
+not KMS-encrypted. A multipart ETag (``<md5>-<parts>``) and an SSE-KMS or SSE-C
+ETag are opaque, and a comparison against either means nothing. Both the cloud
+restore and the sync pull have to draw that line, so it is drawn once here
+rather than inside whichever of the two grew it first.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from enum import Enum, auto
+from pathlib import Path
+
+_MD5_HEX_DIGITS = 32
+
+
+def content_md5(raw_etag: str) -> str | None:
+    """Return the ETag as a content MD5, or None when it cannot be one.
+
+    An opaque ETag yields None so the caller skips the comparison rather than
+    failing on it. Every other check a caller has - a published size, a
+    published sha256 - still applies.
+    """
+    value = raw_etag.strip('"').lower()
+    if len(value) != _MD5_HEX_DIGITS or any(ch not in "0123456789abcdef" for ch in value):
+        return None
+    return value
+
+
+class ContentMatch(Enum):
+    """What comparing a local file against an ETag established.
+
+    ``unknown`` is not a near miss. It says the ETag carried no content digest,
+    so nothing was compared and nothing is known. Folding it into ``differs``
+    would let an opaque ETag pose as evidence that a file is out of date, which
+    is the shape of guess this type exists to refuse.
+    """
+
+    matches = auto()
+    differs = auto()
+    unknown = auto()
+
+
+def compare_local_file(path: Path, raw_etag: str) -> ContentMatch:
+    """Say whether ``path`` already holds the bytes the ETag describes.
+
+    A file this cannot read raises rather than answering. Every caller hashes
+    the same file a step later and would raise on the same fault, so catching
+    it here would buy nothing and cost the distinction: a reported IO error
+    would become a silent verdict about content nobody read.
+
+    Raises:
+        OSError: the file could not be read.
+    """
+    expected = content_md5(raw_etag)
+    if expected is None:
+        return ContentMatch.unknown
+    digest = hashlib.md5(path.read_bytes(), usedforsecurity=False).hexdigest()
+    return ContentMatch.matches if digest == expected else ContentMatch.differs

--- a/packages/nauro/src/nauro/sync/etag.py
+++ b/packages/nauro/src/nauro/sync/etag.py
@@ -1,15 +1,20 @@
 """What an S3 ETag can and cannot say about a local file.
 
 An ETag equals the object's content MD5 only for a single-part upload that is
-not KMS-encrypted. A multipart ETag (``<md5>-<parts>``) and an SSE-KMS or SSE-C
-ETag are opaque, and a comparison against either means nothing. Both the cloud
-restore and the sync pull have to draw that line, so it is drawn once here
-rather than inside whichever of the two grew it first.
+not encrypted with SSE-KMS or SSE-C. Only one of those exclusions is visible in
+the ETag itself: a multipart ETag wears its part count (``<md5>-<parts>``) and
+is rejected here. An encrypted object's ETag is 32 hexadecimal characters like
+any other, so nothing can tell it apart, and it is compared like any other. It
+simply never matches, which costs a fetch and is never a false match.
+
+Both the cloud restore and the sync pull have to draw that line, so it is drawn
+once here rather than inside whichever of the two grew it first.
 """
 
 from __future__ import annotations
 
 import hashlib
+from dataclasses import dataclass
 from enum import Enum, auto
 from pathlib import Path
 
@@ -19,9 +24,9 @@ _MD5_HEX_DIGITS = 32
 def content_md5(raw_etag: str) -> str | None:
     """Return the ETag as a content MD5, or None when it cannot be one.
 
-    An opaque ETag yields None so the caller skips the comparison rather than
-    failing on it. Every other check a caller has - a published size, a
-    published sha256 - still applies.
+    An ETag this can see is not a digest yields None, so the caller skips the
+    comparison rather than failing on it. Every other check a caller has - a
+    published size, a published sha256 - still applies.
     """
     value = raw_etag.strip('"').lower()
     if len(value) != _MD5_HEX_DIGITS or any(ch not in "0123456789abcdef" for ch in value):
@@ -34,8 +39,8 @@ class ContentMatch(Enum):
 
     ``unknown`` is not a near miss. It says the ETag carried no content digest,
     so nothing was compared and nothing is known. Folding it into ``differs``
-    would let an opaque ETag pose as evidence that a file is out of date, which
-    is the shape of guess this type exists to refuse.
+    would let an ETag that is not a digest pose as evidence that a file is out
+    of date, which is the shape of guess this type exists to refuse.
     """
 
     matches = auto()
@@ -43,7 +48,23 @@ class ContentMatch(Enum):
     unknown = auto()
 
 
-def compare_local_file(path: Path, raw_etag: str) -> ContentMatch:
+@dataclass(frozen=True)
+class LocalComparison:
+    """What one read of a local file established about it.
+
+    ``sha256`` is filled on ``matches`` alone, and it is taken from the same
+    read as the comparison, so the two provably describe one set of bytes. A
+    caller that hashed the file again to record it would leave a window between
+    the two reads: an edit landing there is recorded as already synced, and
+    then goes nowhere, because the push skips a file whose recorded digest
+    matches and the pull ignores one whose ETag has not moved.
+    """
+
+    match: ContentMatch
+    sha256: str = ""
+
+
+def compare_local_file(path: Path, raw_etag: str) -> LocalComparison:
     """Say whether ``path`` already holds the bytes the ETag describes.
 
     A file this cannot read raises rather than answering. Every caller hashes
@@ -56,6 +77,8 @@ def compare_local_file(path: Path, raw_etag: str) -> ContentMatch:
     """
     expected = content_md5(raw_etag)
     if expected is None:
-        return ContentMatch.unknown
-    digest = hashlib.md5(path.read_bytes(), usedforsecurity=False).hexdigest()
-    return ContentMatch.matches if digest == expected else ContentMatch.differs
+        return LocalComparison(ContentMatch.unknown)
+    content = path.read_bytes()
+    if hashlib.md5(content, usedforsecurity=False).hexdigest() != expected:
+        return LocalComparison(ContentMatch.differs)
+    return LocalComparison(ContentMatch.matches, hashlib.sha256(content).hexdigest())

--- a/packages/nauro/src/nauro/sync/pull.py
+++ b/packages/nauro/src/nauro/sync/pull.py
@@ -105,6 +105,21 @@ class _RemoteFile:
 
 
 @dataclass(frozen=True)
+class _AdoptedFile:
+    """A file already holding the server's bytes, and the digest that proved it.
+
+    The digest is the one the ETag comparison computed, not a fresh one. It
+    travels with the entry precisely so the run never hashes the file twice:
+    between two reads a local writer can land an edit, and recording the second
+    digest against the server's ETag would file that edit as already synced.
+    """
+
+    rel: str
+    etag: str
+    local_sha256: str
+
+
+@dataclass(frozen=True)
 class _Transfer:
     """One fetched manifest entry, ready to be applied to the store.
 
@@ -248,7 +263,7 @@ class _Worklists:
     decisions: list[_RemoteFile] = field(default_factory=list)
     pulls: list[_RemoteFile] = field(default_factory=list)
     conflicts: list[_RemoteFile] = field(default_factory=list)
-    adopted: list[_RemoteFile] = field(default_factory=list)
+    adopted: list[_AdoptedFile] = field(default_factory=list)
     skipped_permanent: int = 0
 
     def all_files(self) -> list[_RemoteFile]:
@@ -361,9 +376,22 @@ class _Route(Enum):
     conflict = auto()
 
 
+@dataclass(frozen=True)
+class _Routing:
+    """What one entry needs, plus whatever deciding that already established.
+
+    ``local_sha256`` is carried on :attr:`_Route.adopt` alone, where the ETag
+    comparison read the file and hashed it. Handing it to the caller is what
+    keeps the adoption to one read of the bytes it records.
+    """
+
+    route: _Route
+    local_sha256: str = ""
+
+
 def _route_entry(
     store_path: Path, entry: _ManifestEntry, state: SyncState, reporter: Reporter
-) -> _Route:
+) -> _Routing:
     """Decide what one manifest entry needs, naming the ones it refuses.
 
     The order is the substance. Every guard about where the bytes would land
@@ -388,49 +416,51 @@ def _route_entry(
     """
     rel = entry.path
     if should_skip(rel):
-        return _Route.ignore
+        return _Routing(_Route.ignore)
     # Server validates per-op on presign, but the manifest itself is
     # currently trusted — drop suspicious entries before they hit disk.
     if ".." in Path(rel).parts or rel.startswith("/"):
         reporter.warn(f"skipping suspicious manifest entry {rel!r}")
-        return _Route.unusable
+        return _Routing(_Route.unusable)
 
     destination = resolve_destination(store_path, rel)
     if not destination.inside_store:
         reporter.warn(f"skipping manifest entry {rel!r}: it resolves outside the store")
-        return _Route.unusable
+        return _Routing(_Route.unusable)
 
     local_file = store_path / rel
     local_exists = local_file.exists()
     if local_exists and not file_changed_remotely(entry.etag, rel, state):
-        return _Route.ignore
+        return _Routing(_Route.ignore)
 
     if needs_decision_gate(rel, destination, state):
-        return _Route.gate
+        return _Routing(_Route.gate)
     if destination.is_directory:
         # Nothing a manifest names as a file may land on a directory: the
         # local-change probe below would hash it and raise.
         reporter.warn(
             f"skipping manifest entry {rel!r}: it resolves to the directory {destination.path}"
         )
-        return _Route.unusable
+        return _Routing(_Route.unusable)
     if not local_exists:
         # A file the user deleted is not a conflict: a conflict protects local
         # content and there is none.
-        return _Route.install
-    if compare_local_file(local_file, entry.etag) is ContentMatch.matches:
+        return _Routing(_Route.install)
+    comparison = compare_local_file(local_file, entry.etag)
+    if comparison.match is ContentMatch.matches:
         # The two sides are the same file. Recording that is the whole of the
         # work, and it is also what makes the run converge: a store restored
         # from the cloud, or a push that crashed before its state save, would
-        # otherwise re-answer this question on every pull forever.
-        return _Route.adopt
+        # otherwise re-answer this question on every pull forever. The digest
+        # travels with the verdict, from the read that reached it.
+        return _Routing(_Route.adopt, comparison.sha256)
     if file_changed_locally(store_path, rel, state):
         # Reaching here with a local file means the remote moved too, so both
         # sides have content the other does not - whether or not sync state
         # tracks the file. An untracked one used to match no list at all and be
         # dropped in silence, which lost the remote version without a backup.
-        return _Route.conflict
-    return _Route.install
+        return _Routing(_Route.conflict)
+    return _Routing(_Route.install)
 
 
 def _triage(
@@ -451,11 +481,15 @@ def _triage(
     listing = DecisionCorpus.scan(store_path)
     contested: list[_RemoteFile] = []
     for entry in manifest.entries:
-        route = _route_entry(store_path, entry, state, reporter)
+        routing = _route_entry(store_path, entry, state, reporter)
+        route = routing.route
         if route is _Route.ignore:
             continue
         if route is _Route.unusable:
             work.skipped_permanent += 1
+            continue
+        if route is _Route.adopt:
+            work.adopted.append(_AdoptedFile(entry.path, entry.etag, routing.local_sha256))
             continue
 
         item = _RemoteFile(entry.path, entry.etag)
@@ -465,8 +499,6 @@ def _triage(
             (contested if claimed else work.decisions).append(item)
         elif route is _Route.install:
             work.pulls.append(item)
-        elif route is _Route.adopt:
-            work.adopted.append(item)
         else:
             work.conflicts.append(item)
 
@@ -580,14 +612,12 @@ def _run_pull_locked(
                     with _guarded_step(item.rel, _WRITE_FAILURE_DETAIL, reporter, tally):
                         _apply_decision(corpus, transfer, state, manifest, reporter, tally)
 
-        for item in work.adopted:
-            # Nothing is fetched and nothing lands on disk: these files already
-            # hold the bytes the server published, and only the record of it
-            # was missing. The guard still applies, because the digest this
-            # records is read from the file.
-            with _guarded_step(item.rel, _WRITE_FAILURE_DETAIL, reporter, tally):
-                update_file_state(state, item.rel, compute_sha256(store_path / item.rel), item.etag)
-                tally.adopted += 1
+        for adopted in work.adopted:
+            # No fetch, no write, and no second read of the file: these already
+            # hold the bytes the server published, and triage kept the digest
+            # that proved it. Nothing here can fail, so nothing here is guarded.
+            update_file_state(state, adopted.rel, adopted.local_sha256, adopted.etag)
+            tally.adopted += 1
 
         for transfer in _stream(urls, work.pulls, reporter, tally):
             with _guarded_step(transfer.rel, _WRITE_FAILURE_DETAIL, reporter, tally):

--- a/packages/nauro/src/nauro/sync/pull.py
+++ b/packages/nauro/src/nauro/sync/pull.py
@@ -58,6 +58,7 @@ from nauro.sync.collisions import (
     run_completion_pass,
 )
 from nauro.sync.corpus import DecisionCorpus, SkipReason
+from nauro.sync.etag import ContentMatch, compare_local_file
 from nauro.sync.lock import CLI_SYNC_LOCK_TIMEOUT, decision_lock, sync_lock
 from nauro.sync.merge import (
     SPOOL_DIR_PREFIX,
@@ -237,11 +238,17 @@ class _Worklists:
     it looked like at planning time; each one is classified again against the
     live corpus before it is written. ``skipped_permanent`` counts the entries
     triage refused outright, which no worklist carries and no rerun recovers.
+
+    ``adopted`` is the one list that needs no bytes from the server: those
+    files already hold what the server published, and only the record of it is
+    missing. It is deliberately absent from :meth:`all_files`, which is what
+    the run presigns and fetches.
     """
 
     decisions: list[_RemoteFile] = field(default_factory=list)
     pulls: list[_RemoteFile] = field(default_factory=list)
     conflicts: list[_RemoteFile] = field(default_factory=list)
+    adopted: list[_RemoteFile] = field(default_factory=list)
     skipped_permanent: int = 0
 
     def all_files(self) -> list[_RemoteFile]:
@@ -350,6 +357,7 @@ class _Route(Enum):
     unusable = auto()
     gate = auto()
     install = auto()
+    adopt = auto()
     conflict = auto()
 
 
@@ -364,6 +372,19 @@ def _route_entry(
     shortcut then applies only when the local file is still there: the remote
     store is the record for a tracked file, so an entry the user deleted
     locally is reinstalled whether or not its etag moved.
+
+    Below the decision gate sits the other question sync state cannot answer.
+    Where state has no entry for a path, it is not saying the file changed; it
+    is saying nothing at all, and the conflict route below reads that silence
+    as both sides having moved. So the run settles it from the bytes instead:
+    an ETag that carries a content MD5 is compared against the file on disk,
+    and a file that already holds what the server published is adopted rather
+    than fought over. An opaque ETag compares nothing and changes nothing.
+
+    That leg stays below the gate on purpose. A decision adopts through the
+    classifier, never here, because only the classifier can see that a sibling
+    already claims the same number - and adopting under that shape would ratify
+    a duplicate. Here there is nothing to weigh but the bytes.
     """
     rel = entry.path
     if should_skip(rel):
@@ -379,7 +400,8 @@ def _route_entry(
         reporter.warn(f"skipping manifest entry {rel!r}: it resolves outside the store")
         return _Route.unusable
 
-    local_exists = (store_path / rel).exists()
+    local_file = store_path / rel
+    local_exists = local_file.exists()
     if local_exists and not file_changed_remotely(entry.etag, rel, state):
         return _Route.ignore
 
@@ -396,6 +418,12 @@ def _route_entry(
         # A file the user deleted is not a conflict: a conflict protects local
         # content and there is none.
         return _Route.install
+    if compare_local_file(local_file, entry.etag) is ContentMatch.matches:
+        # The two sides are the same file. Recording that is the whole of the
+        # work, and it is also what makes the run converge: a store restored
+        # from the cloud, or a push that crashed before its state save, would
+        # otherwise re-answer this question on every pull forever.
+        return _Route.adopt
     if file_changed_locally(store_path, rel, state):
         # Reaching here with a local file means the remote moved too, so both
         # sides have content the other does not - whether or not sync state
@@ -437,6 +465,8 @@ def _triage(
             (contested if claimed else work.decisions).append(item)
         elif route is _Route.install:
             work.pulls.append(item)
+        elif route is _Route.adopt:
+            work.adopted.append(item)
         else:
             work.conflicts.append(item)
 
@@ -459,6 +489,10 @@ def run_pull(
     fetched and written one file at a time, outside that lock, so a store whose
     changed set is hundreds of megabytes of snapshots is never held in memory
     and a local decision writer never waits on the whole batch.
+
+    A file already holding the bytes the server published is neither, and is
+    never fetched at all: the ETag settled it during triage, so the run records
+    that and moves on.
 
     Returns a :class:`PullReport`. A transport or auth-refresh failure is
     reported through ``reporter`` and then carried in that report, in the terms
@@ -545,6 +579,15 @@ def _run_pull_locked(
                         continue
                     with _guarded_step(item.rel, _WRITE_FAILURE_DETAIL, reporter, tally):
                         _apply_decision(corpus, transfer, state, manifest, reporter, tally)
+
+        for item in work.adopted:
+            # Nothing is fetched and nothing lands on disk: these files already
+            # hold the bytes the server published, and only the record of it
+            # was missing. The guard still applies, because the digest this
+            # records is read from the file.
+            with _guarded_step(item.rel, _WRITE_FAILURE_DETAIL, reporter, tally):
+                update_file_state(state, item.rel, compute_sha256(store_path / item.rel), item.etag)
+                tally.adopted += 1
 
         for transfer in _stream(urls, work.pulls, reporter, tally):
             with _guarded_step(transfer.rel, _WRITE_FAILURE_DETAIL, reporter, tally):

--- a/packages/nauro/tests/test_recovery.py
+++ b/packages/nauro/tests/test_recovery.py
@@ -11,6 +11,7 @@ from nauro.store import recovery
 from nauro.store.recovery import RecoveryError, bind_local_store, restore_cloud_store
 from nauro.store.registry import get_project_v2, get_store_path_v2
 from nauro.store.repo_config import save_repo_config
+from nauro.sync.state import SYNC_STATE_FILE
 from nauro.templates.scaffolds import scaffold_project_store
 
 PID = "01KQ6AZGNA0B3QBF67NBXP3S45"
@@ -88,11 +89,16 @@ def test_restore_cloud_store_installs_complete_record_atomically(tmp_path, monke
     restored = restore_cloud_store(PID, destination)
 
     assert restored == destination
-    assert {
+    installed = {
         path.relative_to(destination).as_posix(): path.read_bytes()
         for path in destination.rglob("*")
         if path.is_file()
-    } == files
+    }
+    # The restore adds exactly one file to the record it downloaded: the sync
+    # state saying the store is level with the server. Popping it keeps this
+    # assertion as strict as it was about everything else.
+    assert installed.pop(SYNC_STATE_FILE)
+    assert installed == files
     # A completed install consumes its staging directory.
     assert not _staging(destination).exists()
     assert _legacy_staging(destination) == []
@@ -161,6 +167,7 @@ def test_restore_cloud_store_skips_hash_check_for_opaque_etag(tmp_path, monkeypa
         for path in destination.rglob("*")
         if path.is_file()
     }
+    assert restored.pop(SYNC_STATE_FILE)
     assert restored == files
 
 

--- a/packages/nauro/tests/test_recovery_resume.py
+++ b/packages/nauro/tests/test_recovery_resume.py
@@ -14,6 +14,7 @@ from nauro.store import recovery
 from nauro.store.recovery import RecoveryError, RestoreBusyError, restore_cloud_store
 from nauro.sync import transfer
 from nauro.sync.remote import PresignTransferError
+from nauro.sync.state import SYNC_STATE_FILE
 from nauro.templates.scaffolds import scaffold_project_store
 from tests.test_recovery import PID, _decision_bytes, _store_files
 
@@ -478,7 +479,7 @@ def test_resume_removes_a_tmp_sibling_a_kill_stranded(tmp_path, monkeypatch):
         path.relative_to(destination).as_posix()
         for path in destination.rglob("*")
         if path.is_file()
-    ) == sorted(files)
+    ) == sorted([*files, SYNC_STATE_FILE])
 
 
 def test_a_file_squatting_on_the_staging_path_is_cleared(tmp_path, monkeypatch):

--- a/packages/nauro/tests/test_sync/test_post_restore_sync.py
+++ b/packages/nauro/tests/test_sync/test_post_restore_sync.py
@@ -1,0 +1,270 @@
+"""What the first sync after a cloud restore does.
+
+A restore downloads and verifies every file the server holds, then installs
+them. Nothing but this seam records that fact, because ``.sync-state.json`` is
+never synced and so never arrives from the remote either. Without it the next
+pull reads "no entry" as "changed on both sides" for the whole store, and these
+tests hold that shut end to end: through ``restore_cloud_store`` itself, through
+``nauro reconnect``, and across a restore that had to resume.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import patch
+
+import httpx
+import pytest
+from typer.testing import CliRunner
+
+from nauro.cli.main import app
+from nauro.constants import REPO_CONFIG_MODE_CLOUD
+from nauro.store import recovery
+from nauro.store.recovery import RecoveryError, restore_cloud_store
+from nauro.store.registry import get_store_path_v2, register_project_v2
+from nauro.store.repo_config import save_repo_config
+from nauro.sync.merge import CONFLICT_BACKUP_DIR, should_skip
+from nauro.sync.pull import PullReport, run_pull
+from nauro.sync.quarantine import list_quarantine_backups
+from nauro.sync.remote import PresignTransferError
+from nauro.sync.state import SYNC_STATE_FILE, load_state
+from nauro.templates.scaffolds import scaffold_project_store
+from tests.test_sync.conftest import (
+    CLOUD_PID,
+    _manifest,
+    _presign,
+    _RecordingReporter,
+    _seed_token,
+    decision_bytes,
+)
+
+runner = CliRunner()
+
+_DECISION = "decisions/042-a-ruling.md"
+
+
+def _scaffolded_bytes(root: Path) -> dict[str, bytes]:
+    """Every file of a freshly scaffolded store, keyed store-relative."""
+    scaffold_project_store("nauro", root)
+    return {
+        path.relative_to(root).as_posix(): path.read_bytes()
+        for path in root.rglob("*")
+        if path.is_file()
+    }
+
+
+class _Remote:
+    """One remote record behind both the restore's calls and the pull's.
+
+    The restore and the pull reach the server through different seams, so the
+    fake serves both from one dict of bytes. That is what lets a test change a
+    file on the server between the two and see what the pull makes of it.
+    """
+
+    def __init__(self, files: dict[str, bytes]) -> None:
+        self.files = files
+        self.fetched: list[str] = []
+        self.faults: dict[str, Exception] = {}
+
+    # --- the restore's three calls ---
+
+    def rows(self, _project_id: str | None = None) -> list[dict]:
+        return [
+            {
+                "path": path,
+                "etag": f'"{hashlib.md5(content).hexdigest()}"',
+                "size": len(content),
+                "last_modified": "2026-08-12T00:00:00Z",
+            }
+            for path, content in sorted(self.files.items())
+        ]
+
+    def _presigned(self, _project_id: str, operations: list[dict[str, str]]) -> list[dict]:
+        return [
+            {"verb": "GET", "path": op["path"], "url": f"memory://{op['path']}"}
+            for op in operations
+        ]
+
+    def _fetch(self, url: str) -> bytes:
+        path = url.removeprefix("memory://")
+        self.fetched.append(path)
+        fault = self.faults.get(path)
+        if fault is not None:
+            raise fault
+        return self.files[path]
+
+    def install(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(recovery, "fetch_manifest", self.rows)
+        monkeypatch.setattr(recovery, "request_presigned_urls", self._presigned)
+        monkeypatch.setattr(recovery, "fetch_via_presigned_url", self._fetch)
+
+    # --- the pull's two calls ---
+
+    @contextmanager
+    def serving_pull(self) -> Iterator[None]:
+        def get(url: str, **_kwargs) -> httpx.Response:
+            if "/sync/manifest" in url:
+                return _manifest(self.rows())
+            path = url.split("/GET/", 1)[1]
+            self.fetched.append(path)
+            return httpx.Response(200, content=self.files[path])
+
+        def post(_url: str, **kwargs) -> httpx.Response:
+            return _presign(kwargs["json"]["operations"])
+
+        with (
+            patch("nauro.sync.remote.httpx.get", side_effect=get),
+            patch("nauro.sync.remote.httpx.post", side_effect=post),
+        ):
+            yield
+
+
+@pytest.fixture()
+def remote(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> _Remote:
+    files = _scaffolded_bytes(tmp_path / "source")
+    files[_DECISION] = decision_bytes(42, "A ruling", "Chose A.")
+    served = _Remote(files)
+    served.install(monkeypatch)
+    _seed_token()
+    return served
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> Path:
+    """The registered cloud store path, with nothing on disk yet."""
+    _project_id, store_path = register_project_v2(
+        "nauro",
+        [tmp_path / "repo"],
+        mode=REPO_CONFIG_MODE_CLOUD,
+        server_url="https://example.test",
+        project_id=CLOUD_PID,
+    )
+    return store_path
+
+
+def _pull(store_path: Path, remote: _Remote) -> tuple[PullReport, _RecordingReporter]:
+    reporter = _RecordingReporter()
+    remote.fetched.clear()
+    with remote.serving_pull():
+        return run_pull(CLOUD_PID, store_path, reporter), reporter
+
+
+def _backups(store_path: Path) -> list[str]:
+    return sorted(
+        path.name for path in (store_path / CONFLICT_BACKUP_DIR).rglob("*") if path.is_file()
+    )
+
+
+class TestPullAfterRestore:
+    def test_remote_decision_edit_lands_on_the_pull_after_a_restore(self, remote, store):
+        """The worst shape this defect had, held shut end to end.
+
+        An untracked decision reaches the collision gate, and a remote body that
+        moved on is judged a two-sided conflict there: the stale local copy
+        wins, the server's copy goes to the backup directory, and the pull then
+        records the new ETag against the file it did not update, so no later
+        pull ever fetches it again. A decision edited on another machine simply
+        never arrived.
+        """
+        restore_cloud_store(CLOUD_PID, store)
+        updated = decision_bytes(42, "A ruling", "Chose A. Rider: held under load.")
+        remote.files[_DECISION] = updated
+
+        report, _reporter = _pull(store, remote)
+
+        assert (store / _DECISION).read_bytes() == updated
+        assert _backups(store) == []
+        assert list_quarantine_backups(store) == []
+        assert report.merged == 1
+        assert report.refused == 0
+
+    def test_restore_then_pull_writes_nothing_and_fetches_nothing(self, remote, store):
+        restore_cloud_store(CLOUD_PID, store)
+
+        report, reporter = _pull(store, remote)
+
+        assert remote.fetched == []
+        assert _backups(store) == []
+        assert report == PullReport()
+        assert reporter.infos == ["No remote changes"]
+        assert reporter.warns == []
+
+    def test_reconnect_restore_then_pull_fetches_nothing(self, remote, tmp_path, monkeypatch):
+        """The other command that restores, driven through its own surface.
+
+        Registration is left to ``reconnect`` here: the command exists for a
+        repo whose store this machine does not have, so a pre-registered store
+        would send it down a different branch entirely.
+        """
+        repo = tmp_path / "unconnected-repo"
+        repo.mkdir()
+        save_repo_config(
+            repo,
+            {
+                "mode": "cloud",
+                "id": CLOUD_PID,
+                "name": "nauro",
+                "server_url": "https://example.test",
+            },
+        )
+        monkeypatch.chdir(repo)
+
+        with patch("nauro.cli.commands.reconnect.require_cloud_membership", return_value="nauro"):
+            result = runner.invoke(app, ["reconnect"], input="restore\n")
+        assert result.exit_code == 0, result.output
+        store = get_store_path_v2(CLOUD_PID)
+
+        report, _reporter = _pull(store, remote)
+
+        assert remote.fetched == []
+        assert _backups(store) == []
+        assert report == PullReport()
+
+
+class TestSeededState:
+    def test_seeded_state_is_installed_and_never_pushed(self, remote, store):
+        restore_cloud_store(CLOUD_PID, store)
+
+        state = load_state(store)
+        assert set(state.files) == set(remote.files)
+        for rel, content in remote.files.items():
+            entry = state.files[rel]
+            assert entry.remote_etag == f'"{hashlib.md5(content).hexdigest()}"'
+            assert entry.local_sha256 == hashlib.sha256(content).hexdigest()
+            assert entry.last_sync
+        # The store is level with the server at this instant, which is the one
+        # thing the stamp claims.
+        assert state.last_full_sync
+        # The file is in the store, and the sync layer refuses to carry it.
+        assert (store / SYNC_STATE_FILE).is_file()
+        assert should_skip(SYNC_STATE_FILE)
+
+    def test_a_restore_that_fails_before_install_leaves_no_state(self, remote, store):
+        remote.faults[_DECISION] = PresignTransferError("Presigned GET", status=404, detail="gone")
+
+        with pytest.raises(RecoveryError):
+            restore_cloud_store(CLOUD_PID, store)
+
+        assert not (store / SYNC_STATE_FILE).exists()
+        staging = store.parent / f".{CLOUD_PID}.restore"
+        assert staging.is_dir()
+        assert not (staging / SYNC_STATE_FILE).exists()
+
+    def test_a_resumed_restore_seeds_every_installed_file(self, remote, store):
+        remote.faults[_DECISION] = PresignTransferError("Presigned GET", status=404, detail="gone")
+        with pytest.raises(RecoveryError):
+            restore_cloud_store(CLOUD_PID, store)
+        staged_first = set(remote.fetched)
+        assert len(staged_first) > 1
+
+        remote.faults.clear()
+        remote.fetched.clear()
+        restore_cloud_store(CLOUD_PID, store)
+
+        # The second run downloaded only what the first one never staged, so a
+        # seed built from that run alone would track almost nothing.
+        assert set(remote.fetched) < set(remote.files)
+        assert set(load_state(store).files) == set(remote.files)

--- a/packages/nauro/tests/test_sync/test_pull.py
+++ b/packages/nauro/tests/test_sync/test_pull.py
@@ -20,9 +20,11 @@ from unittest.mock import patch
 
 import httpx
 import pytest
+from nauro_core import extract_decision_number
 from nauro_core.operations.propose_decision import _next_decision_num
 
 from nauro.cli.commands.auth import AuthRefreshError
+from nauro.constants import DECISIONS_DIR
 from nauro.store import _atomic
 from nauro.store._atomic import atomic_write_bytes, is_tmp_sibling
 from nauro.store.filesystem_store import FilesystemStore
@@ -1707,6 +1709,45 @@ class TestUntrackedLocalFilesAlreadyLevel:
         assert (collision_store / "stack.md").read_bytes() == remote
         backups = list((collision_store / CONFLICT_BACKUP_DIR).iterdir())
         assert [path.read_bytes() for path in backups] == [b"# Stack\n\nlocal only\n"]
+
+    def test_a_sibling_claiming_the_number_is_moved_before_the_adoption(self, collision_store):
+        """The adoption leg stays below the decision gate, and this proves it.
+
+        Adoption records a state entry, and a state entry on a decision is what
+        marks its number as taken. Where a second local file claims that number,
+        recording the entry ratifies the duplicate, and the store then pushes
+        two files for one number. Only the classifier can see the sibling, so
+        only the classifier may adopt a decision.
+
+        Read from the top of ``_route_entry``, the ordering is what routes this
+        entry to the gate rather than to the adoption leg, and the gate then
+        moves the sibling out of the way before the record is adopted. Lift the
+        adoption leg above the gate and this test fails on both assertions.
+        """
+        body = decision_bytes(42, "A ruling")
+        write_local_decision(collision_store, "042-a-ruling.md", body)
+        write_local_decision(collision_store, "042-other.md", decision_bytes(42, "Another ruling"))
+
+        _report, reporter, _fetches = self._pull_counting_fetches(
+            collision_store,
+            [("decisions/042-a-ruling.md", body)],
+            etags={"decisions/042-a-ruling.md": self._md5_etag(body)},
+        )
+
+        # The index file the writer keeps alongside the decisions claims no
+        # number, so it is dropped rather than counted as a second nameless one.
+        numbers = [
+            number
+            for number in (
+                extract_decision_number(name)
+                for name in entry_names(collision_store / DECISIONS_DIR)
+            )
+            if number is not None
+        ]
+        assert sorted(numbers) == [1, 42, 43]
+        assert any(
+            "Renumbered unpublished local decision 042 -> 043" in line for line in reporter.infos
+        )
 
     def test_an_opaque_etag_never_skips_a_file(self, collision_store):
         """A multipart ETag answers nothing, and nothing is what it is read as.

--- a/packages/nauro/tests/test_sync/test_pull.py
+++ b/packages/nauro/tests/test_sync/test_pull.py
@@ -12,6 +12,7 @@ classifier and its crash windows are unit-tested in ``test_collisions.py``.
 
 from __future__ import annotations
 
+import hashlib
 import os
 import time
 from pathlib import Path
@@ -29,7 +30,7 @@ from nauro.sync import pull as pull_module
 from nauro.sync.corpus import DecisionCorpus
 from nauro.sync.lock import SyncLockTimeoutError, decision_lock
 from nauro.sync.merge import CONFLICT_BACKUP_DIR, SPOOL_DIR_PREFIX, should_skip
-from nauro.sync.pull import _Transfer, run_pull
+from nauro.sync.pull import PullReport, _Transfer, run_pull
 from nauro.sync.quarantine import (
     list_quarantine_backups,
     save_quarantine_backup,
@@ -1650,6 +1651,82 @@ class TestUntrackedLocalFiles:
         assert (collision_store / "stack.md").read_bytes() == b"# Stack\n\nlocal rewrite\n"
         backups = list((collision_store / CONFLICT_BACKUP_DIR).iterdir())
         assert [path.read_bytes() for path in backups] == [b"# Stack\n\nremote rewrite\n"]
+
+
+class TestUntrackedLocalFilesAlreadyLevel:
+    """An untracked file the server already holds is adopted, not fought over.
+
+    Absent sync state says nothing about a file's content, and the conflict
+    route treats it as though it said the file changed. Where the manifest ETag
+    is a content MD5 the run can settle the question outright, so it does: a
+    file whose bytes are the server's bytes is recorded and left alone, with no
+    fetch and no backup. Where the ETag is opaque nothing was compared, and the
+    run keeps the conflict it would have had.
+    """
+
+    @staticmethod
+    def _md5_etag(body: bytes) -> str:
+        return f'"{hashlib.md5(body, usedforsecurity=False).hexdigest()}"'
+
+    def _pull_counting_fetches(self, store, entries, *, etags=None):
+        with patch.object(
+            pull_module, "fetch_via_presigned_url", wraps=pull_module.fetch_via_presigned_url
+        ) as fetch:
+            report, reporter = pull_report(store, entries, etags=etags)
+        return report, reporter, fetch.call_count
+
+    def test_a_matching_untracked_file_is_adopted_without_a_fetch(self, collision_store):
+        body = b"# Stack\n\nthe same bytes the server holds\n"
+        (collision_store / "stack.md").write_bytes(body)
+
+        report, reporter, fetches = self._pull_counting_fetches(
+            collision_store, [("stack.md", body)], etags={"stack.md": self._md5_etag(body)}
+        )
+
+        assert fetches == 0
+        assert report == PullReport()
+        assert (collision_store / "stack.md").read_bytes() == body
+        assert entry_names(collision_store / CONFLICT_BACKUP_DIR) == set()
+        assert reporter.infos == ["Adopted 1 local file(s) already on the server"]
+        # Recording it is what makes the next pull cheap: without the entry the
+        # run would re-hash the same file forever.
+        state = load_state(collision_store)
+        assert state.files["stack.md"].remote_etag == self._md5_etag(body)
+        assert state.files["stack.md"].local_sha256 == compute_sha256(collision_store / "stack.md")
+
+    def test_a_differing_untracked_file_still_conflicts(self, collision_store):
+        (collision_store / "stack.md").write_bytes(b"# Stack\n\nlocal only\n")
+        remote = b"# Stack\n\nremote\n"
+
+        report, _reporter, fetches = self._pull_counting_fetches(
+            collision_store, [("stack.md", remote)], etags={"stack.md": self._md5_etag(remote)}
+        )
+
+        assert fetches == 1
+        assert report.merged == 1
+        assert (collision_store / "stack.md").read_bytes() == remote
+        backups = list((collision_store / CONFLICT_BACKUP_DIR).iterdir())
+        assert [path.read_bytes() for path in backups] == [b"# Stack\n\nlocal only\n"]
+
+    def test_an_opaque_etag_never_skips_a_file(self, collision_store):
+        """A multipart ETag answers nothing, and nothing is what it is read as.
+
+        The local bytes here are the remote bytes, so a run that mistook an
+        opaque ETag for a mismatch-free comparison would skip the file. One
+        that mistakes it for evidence of anything at all would be guessing, and
+        the conflict it would otherwise have had is the honest outcome.
+        """
+        body = b"# Stack\n\nthe same bytes the server holds\n"
+        (collision_store / "stack.md").write_bytes(body)
+        multipart = f'"{hashlib.md5(body, usedforsecurity=False).hexdigest()}-2"'
+
+        report, _reporter, fetches = self._pull_counting_fetches(
+            collision_store, [("stack.md", body)], etags={"stack.md": multipart}
+        )
+
+        assert fetches == 1
+        assert report.merged == 1
+        assert entry_names(collision_store / CONFLICT_BACKUP_DIR) != set()
 
 
 class TestLocalWriteFailures:


### PR DESCRIPTION
## Why

`nauro attach` and `nauro reconnect` restore a store from the cloud. The restore downloads every file, verifies each one against the manifest, and installs the tree. It records nothing about that. `.sync-state.json` is in the never-sync list, so it never arrives from the remote either.

The next pull therefore has no entry for any file. Both state predicates translate that silence into a definite answer: `file_changed_locally` and `file_changed_remotely` each return `True` when there is no entry. Every file then looks changed on both sides.

I reproduced 3 symptoms on a 6-file store.

1. The pull re-downloads every file and writes a backup for each one it overwrites. It reports `Merged 4 file(s) from remote` on a store that was already correct. On a 483-decision store that is hundreds of backup files and a full re-download.
2. A decision the server edited never arrives. It reaches the collision gate untracked, and the gate judges it a two-sided conflict. The stale local copy wins, the server's copy goes to `.conflict-backup/`, and the run then records the new ETag against the file it did not update. No later pull fetches it again.
3. The store is also re-uploaded whole. `push_changed_files` treats a file with no state entry as changed. `nauro sync` hides this, because its pull runs first and records an entry for every file it just re-downloaded. The post-write push hook has no pull in front of it, so the first decision, question, or state write after `nauro attach` sends the whole store back to the server it was just downloaded from. Measured: 6 of 6 files re-uploaded without the seed, 0 with it.

Symptom 2 is the reason this is worth fixing now. No data is lost, because both copies stay on disk, but a person has to know to look in the backup directory.

## What changed

**The restore records what it installed.** The staging ledger already holds an ETag and a sha256 for every staged file. Those are `remote_etag` and `local_sha256` unchanged, so the seed is bookkeeping and not new work. The state is written into the staging tree after validation and before the install, so it lands with the store in the same rename. No instant exists in which an installed store is untracked. A resumed restore covers every installed file, not only the last run's downloads, because a staged file with no ledger record is never kept.

The seed sets `last_full_sync`. Only a complete and validated tree reaches that line, which is the same condition the pull uses when it stamps the field. The field gates no write and no route. Two status surfaces read it, and reporting "never" for a store downloaded whole a moment ago is the same untruth as the absent entries.

**The pull stops guessing.** Absent state does not mean a file changed. It means nothing is known. Where the manifest ETag carries a content MD5, the run compares it against the file on disk and settles the question. A file already holding the server's bytes is adopted: its state is recorded, and it is never fetched. Recording it is what makes the run converge. Without the entry the next pull asks the same question again.

The comparison reads the file once and returns both digests from that read: the MD5 it compared, and the sha256 the record needs. Hashing a second time at write time would leave a window in which a local write lands between the 2 reads and is then recorded as already synced. That would strand the write, because the push skips a file whose recorded digest matches and the pull ignores one whose ETag has not moved.

**One shared module.** `sync/etag.py` now owns what an S3 ETag can and cannot say about a local file. The restore's private MD5 helper moved there whole. The comparison returns a 3-state result, so an ETag with no digest in it reports `unknown` rather than posing as a mismatch. A file that cannot be read raises instead of answering, which is what the caller's next step already does. The module claims only what it can detect: a multipart ETag wears its part count and is rejected, while an encrypted object's ETag is 32 hexadecimal characters like any other and is simply compared, where it never matches.

## Risk / what to review

The adoption leg sits below the decision gate, and that ordering is load-bearing. A state entry on a decision marks its number as taken, so adopting one while a second local file claims that number would ratify the duplicate. Only the classifier can see the sibling. A test now pins the ordering, built from a local decision that matches the remote plus a sibling claiming its number. I verified the test discriminates: with the leg in place the sibling is renumbered from 042 to 043 and the decisions hold numbers 1, 42, 43; with the leg lifted above the gate the test fails and 2 files claim 42. I ran that move and reverted it, once before the digest refactor and once after.

The adoption leg changes routing for every file, not only for a restored store. It fires only on an exact content-MD5 match, which is the same evidence the restore already accepts when it admits a downloaded file into a store. Where the ETag carries no digest nothing is compared and behavior is unchanged.

3 existing restore tests asserted that the installed file set equals the manifest exactly. They now name the seeded state file and stay as strict about everything else.

`load_state` still returns an empty `SyncState` when the file is corrupt. That is out of scope here, and the adoption leg makes the case recoverable rather than destructive: the next pull re-establishes each entry from the bytes instead of backing the store up.

## Test plan

- 9 new tests. Each was written failing first.
  - After a restore, a decision edited on the server lands on the next pull, with no backup and no quarantine.
  - Restore then pull fetches nothing, writes nothing, and reports no remote changes.
  - The same through `nauro reconnect`, driven through the command.
  - The seeded state is in the installed store, and the sync layer refuses to push it.
  - A restore that fails before the install leaves no state behind.
  - A resumed restore seeds every installed file.
  - An untracked file matching the remote is adopted, recorded, and not fetched.
  - A sibling claiming the number is renumbered before the adoption, so no 2 decisions hold one number.
  - An untracked file differing from the remote still conflicts and still gets a backup.
  - An opaque multipart ETag still conflicts, so no file is skipped on a guess.
- `uv run --no-sync pytest packages/nauro/tests/ -q` gave 2588 passed, 10 skipped.
- `uv run --no-sync pytest packages/nauro-core/tests/ -q` gave 1526 passed.
- `uv run ruff check packages/` and `ruff format --check` are clean.

No release and no deploy. This rides the next train.
