### PR TITLE
Align legacy snapshot sync planning

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/sync.py
+++ b/packages/nauro/src/nauro/cli/commands/sync.py
@@ -212,17 +212,21 @@ def _show_status(project_flag: str | None) -> None:
     typer.echo(f"  Files tracked: {len(state.files)}")
     typer.echo(f"  Last successful sync: {state.last_full_sync or 'never'}")
 
-    pending_local = [
-        candidate.relative_path for candidate in plan_push(store_path, state).candidates
-    ]
-    if pending_local:
-        typer.echo(f"  Pending local changes: {len(pending_local)}")
-        for p in pending_local[:5]:
-            typer.echo(f"    - {p}")
-        if len(pending_local) > 5:
-            typer.echo(f"    ... and {len(pending_local) - 5} more")
+    try:
+        pending_local = [
+            candidate.relative_path for candidate in plan_push(store_path, state).candidates
+        ]
+    except OSError as exc:
+        typer.echo(f"  Pending local changes: unknown (store scan failed: {exc})")
     else:
-        typer.echo("  Pending local changes: none")
+        if pending_local:
+            typer.echo(f"  Pending local changes: {len(pending_local)}")
+            for p in pending_local[:5]:
+                typer.echo(f"    - {p}")
+            if len(pending_local) > 5:
+                typer.echo(f"    ... and {len(pending_local) - 5} more")
+        else:
+            typer.echo("  Pending local changes: none")
 
     from nauro.sync.merge import CONFLICT_BACKUP_DIR
     from nauro.sync.quarantine import list_quarantine_backups, unresolved_quarantines

--- a/packages/nauro/src/nauro/cli/commands/sync.py
+++ b/packages/nauro/src/nauro/cli/commands/sync.py
@@ -203,7 +203,8 @@ def _show_status(project_flag: str | None) -> None:
             raise
         return
 
-    from nauro.sync.state import file_changed_locally, load_state
+    from nauro.sync.push import plan_push
+    from nauro.sync.state import load_state
 
     state = load_state(store_path)
 
@@ -211,7 +212,9 @@ def _show_status(project_flag: str | None) -> None:
     typer.echo(f"  Files tracked: {len(state.files)}")
     typer.echo(f"  Last successful sync: {state.last_full_sync or 'never'}")
 
-    pending_local = [rel for rel in state.files if file_changed_locally(store_path, rel, state)]
+    pending_local = [
+        candidate.relative_path for candidate in plan_push(store_path, state).candidates
+    ]
     if pending_local:
         typer.echo(f"  Pending local changes: {len(pending_local)}")
         for p in pending_local[:5]:

--- a/packages/nauro/src/nauro/sync/pull.py
+++ b/packages/nauro/src/nauro/sync/pull.py
@@ -44,7 +44,7 @@ from nauro_core import extract_decision_number
 from pydantic import BaseModel, ConfigDict, ValidationError
 
 from nauro.cli.commands.auth import AuthRefreshError
-from nauro.constants import DECISIONS_DIR
+from nauro.constants import DECISIONS_DIR, SNAPSHOTS_DIR
 from nauro.store._atomic import atomic_write_bytes, is_tmp_sibling
 from nauro.sync.collisions import (
     DecisionOutcome,
@@ -376,6 +376,16 @@ class _Route(Enum):
     conflict = auto()
 
 
+def _is_canonical_snapshot_path(rel: str) -> bool:
+    head, slash, tail = rel.partition("/")
+    return bool(
+        slash
+        and tail
+        and head == SNAPSHOTS_DIR
+        and all(part not in {"", ".", ".."} for part in tail.split("/"))
+    )
+
+
 @dataclass(frozen=True)
 class _Routing:
     """What one entry needs, plus whatever deciding that already established.
@@ -427,6 +437,8 @@ def _route_entry(
     if not destination.inside_store:
         reporter.warn(f"skipping manifest entry {rel!r}: it resolves outside the store")
         return _Routing(_Route.unusable)
+    if _is_canonical_snapshot_path(rel):
+        return _Routing(_Route.ignore)
 
     local_file = store_path / rel
     local_exists = local_file.exists()
@@ -517,10 +529,10 @@ def run_pull(
 
     Walks the server manifest, then applies it in two phases. Untracked
     decision files are fetched together and written under the decision lock,
-    each classified immediately before its own write. Everything else streams:
-    fetched and written one file at a time, outside that lock, so a store whose
-    changed set is hundreds of megabytes of snapshots is never held in memory
-    and a local decision writer never waits on the whole batch.
+    each classified immediately before its own write. Everything else streams.
+    Large ordinary files are fetched and written one at a time, outside that
+    lock, so the batch is never held in memory and a local decision writer
+    never waits on the whole transfer.
 
     A file already holding the bytes the server published is neither, and is
     never fetched at all: the ETag settled it during triage, so the run records

--- a/packages/nauro/src/nauro/sync/push.py
+++ b/packages/nauro/src/nauro/sync/push.py
@@ -13,6 +13,7 @@ network here.
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from pathlib import Path
 
 import typer
@@ -21,8 +22,59 @@ from nauro_core.constants import MAX_BRIEF_BYTES
 from nauro.cli.commands.auth import load_access_token
 from nauro.store.registry import is_cloud_project
 from nauro.sync.lock import CLI_SYNC_LOCK_TIMEOUT, sync_lock
+from nauro.sync.merge import CONFLICT_BACKUP_DIR, should_skip
+from nauro.sync.state import SyncState, compute_sha256
 
 logger = logging.getLogger("nauro.sync")
+
+
+@dataclass(frozen=True)
+class PushCandidate:
+    relative_path: str
+    local_sha256: str
+    local_file: Path
+
+
+@dataclass(frozen=True)
+class OversizedBrief:
+    relative_path: str
+    size: int
+
+
+@dataclass(frozen=True)
+class PushPlan:
+    candidates: tuple[PushCandidate, ...]
+    oversized_briefs: tuple[OversizedBrief, ...]
+
+
+def plan_push(store_path: Path, state: SyncState) -> PushPlan:
+    """Select existing local files that the legacy PUT path can send."""
+    candidates: list[PushCandidate] = []
+    oversized_briefs: list[OversizedBrief] = []
+    for local_file in store_path.rglob("*"):
+        if not local_file.is_file():
+            continue
+        try:
+            rel = str(local_file.relative_to(store_path))
+        except ValueError:
+            continue
+        if should_skip(rel) or rel.startswith(CONFLICT_BACKUP_DIR) or rel.startswith("__pycache__"):
+            continue
+
+        # Filesystem-authored briefs bypass the MCP write size limit, so sync
+        # applies the same limit before they enter the upload plan.
+        if rel.startswith("context/") and rel.endswith(".md"):
+            size = local_file.stat().st_size
+            if size > MAX_BRIEF_BYTES:
+                oversized_briefs.append(OversizedBrief(rel, size))
+                continue
+
+        local_sha = compute_sha256(local_file)
+        fs = state.files.get(rel)
+        if fs is None or fs.local_sha256 != local_sha:
+            candidates.append(PushCandidate(rel, local_sha, local_file))
+
+    return PushPlan(tuple(candidates), tuple(oversized_briefs))
 
 
 def push_store_to_cloud(project_id: str, store_path: Path) -> bool:
@@ -99,60 +151,29 @@ def push_changed_files(
 
 
 def _push_changed_files_locked(project_id: str, store_path: Path) -> int:
-    from nauro.sync.merge import CONFLICT_BACKUP_DIR, should_skip
     from nauro.sync.remote import (
         PresignError,
         put_via_presigned_url,
         request_presigned_urls,
         urls_by_path,
     )
-    from nauro.sync.state import compute_sha256, load_state, save_state, update_file_state
+    from nauro.sync.state import load_state, save_state, update_file_state
 
     state = load_state(store_path)
+    plan = plan_push(store_path, state)
+    for brief in plan.oversized_briefs:
+        typer.echo(
+            f"  Warning: brief {brief.relative_path} is {brief.size:,} bytes, over the "
+            f"{MAX_BRIEF_BYTES:,}-byte limit, and was not pushed. "
+            "It stays on your machine; trim it under the cap and re-sync to share it.",
+            err=True,
+        )
 
-    changed: list[tuple[str, str, Path]] = []
-    for local_file in store_path.rglob("*"):
-        if not local_file.is_file():
-            continue
-        try:
-            rel = str(local_file.relative_to(store_path))
-        except ValueError:
-            continue
-        if should_skip(rel) or rel.startswith(CONFLICT_BACKUP_DIR) or rel.startswith("__pycache__"):
-            continue
-
-        # Shared briefs (context/*.md) are written via the agent's filesystem
-        # tool + sync, bypassing the MCP write-tool size caps, so the push path
-        # is the only place MAX_BRIEF_BYTES can be enforced. An over-cap brief is
-        # skipped loudly and left on disk (never silently dropped, never recorded
-        # in sync-state) so it keeps warning until trimmed, and so it cannot make
-        # the agent believe it shared context that never propagated. The skip is
-        # per-file: other store files still sync. Scoped to ``.md`` because the
-        # skill writes briefs only as ``<slug>.md``; non-``.md`` content under
-        # ``context/`` falls back to the (uncapped) general store behavior, same
-        # as every other store file — it is not a new storage-bomb surface.
-        if rel.startswith("context/") and rel.endswith(".md"):
-            size = local_file.stat().st_size
-            if size > MAX_BRIEF_BYTES:
-                typer.echo(
-                    f"  Warning: brief {rel} is {size:,} bytes, over the "
-                    f"{MAX_BRIEF_BYTES:,}-byte limit, and was not pushed. "
-                    "It stays on your machine; trim it under the cap and "
-                    "re-sync to share it.",
-                    err=True,
-                )
-                continue
-
-        local_sha = compute_sha256(local_file)
-        fs = state.files.get(rel)
-        if fs is None or fs.local_sha256 != local_sha:
-            changed.append((rel, local_sha, local_file))
-
-    if not changed:
+    if not plan.candidates:
         save_state(store_path, state)
         return 0
 
-    operations = [{"verb": "PUT", "path": rel} for rel, _sha, _path in changed]
+    operations = [{"verb": "PUT", "path": candidate.relative_path} for candidate in plan.candidates]
     urls = request_presigned_urls(project_id, operations)
 
     if len(urls) < len(operations):
@@ -163,20 +184,32 @@ def _push_changed_files_locked(project_id: str, store_path: Path) -> int:
         logger.warning("Skipping unreadable presign entry %s", entry)
 
     pushed = 0
-    for rel, local_sha, local_file in changed:
-        url = url_by_path.get(rel)
+    for candidate in plan.candidates:
+        url = url_by_path.get(candidate.relative_path)
         if not url:
             continue
         try:
-            new_etag = put_via_presigned_url(url, local_file)
+            new_etag = put_via_presigned_url(url, candidate.local_file)
             if new_etag:
-                update_file_state(state, rel, local_sha, new_etag)
+                update_file_state(
+                    state,
+                    candidate.relative_path,
+                    candidate.local_sha256,
+                    new_etag,
+                )
                 pushed += 1
         except PresignError:
-            logger.exception("Failed to push %s", rel)
+            logger.exception("Failed to push %s", candidate.relative_path)
 
     save_state(store_path, state)
     return pushed
 
 
-__all__ = ["push_changed_files", "push_store_to_cloud"]
+__all__ = [
+    "OversizedBrief",
+    "PushCandidate",
+    "PushPlan",
+    "plan_push",
+    "push_changed_files",
+    "push_store_to_cloud",
+]

--- a/packages/nauro/tests/test_sync/test_pull.py
+++ b/packages/nauro/tests/test_sync/test_pull.py
@@ -115,6 +115,46 @@ class TestRunPullCleanPull:
         assert merged == 1
         assert (cloud_store / rel).read_bytes() == _STAMPED_DECISION
 
+    def test_remote_snapshot_is_ignored_before_presign(self, cloud_store):
+        rel = "snapshots/v001.json"
+        original = FileState(
+            local_sha256="pruned-local-sha",
+            remote_etag='"old"',
+            last_sync="2026-05-16T00:00:00Z",
+        )
+        state = SyncState(files={rel: original})
+        save_state(cloud_store, state)
+        manifest = _manifest([{"path": rel, "etag": '"new"', "size": 1, "last_modified": "x"}])
+
+        reporter = _RecordingReporter()
+        with (
+            patch("nauro.sync.remote.httpx.get", return_value=manifest),
+            patch("nauro.sync.remote.httpx.post") as mock_post,
+        ):
+            report = run_pull(CLOUD_PID, cloud_store, reporter)
+
+        assert report == PullReport()
+        mock_post.assert_not_called()
+        assert not (cloud_store / rel).exists()
+        assert load_state(cloud_store).files[rel] == original
+        assert reporter.infos == ["No remote changes"]
+        assert reporter.warns == []
+
+    def test_unsafe_snapshot_path_is_still_refused(self, cloud_store):
+        rel = "snapshots/../../outside.json"
+        manifest = _manifest([{"path": rel, "etag": '"new"', "size": 1, "last_modified": "x"}])
+
+        reporter = _RecordingReporter()
+        with (
+            patch("nauro.sync.remote.httpx.get", return_value=manifest),
+            patch("nauro.sync.remote.httpx.post") as mock_post,
+        ):
+            report = run_pull(CLOUD_PID, cloud_store, reporter)
+
+        assert report == PullReport(skipped_permanent=1)
+        mock_post.assert_not_called()
+        assert any("suspicious manifest entry" in warning for warning in reporter.warns)
+
     def test_append_only_conflict_invokes_resolve_and_writes_merge(self, cloud_store):
         # state_history.md is append-only with section-aware set-union merge.
         rel = "state_history.md"
@@ -732,22 +772,21 @@ class TestTransferShape:
     """Decision files are batched; everything else streams.
 
     The gate needs the fetched bytes of every decision file it will judge, so
-    those are held together for the length of one lock hold. Snapshots and
-    briefs have no such requirement, and a first pull of a real store is
-    hundreds of megabytes of them: they are fetched and written one at a time,
+    those are held together for the length of one lock hold. Other store files
+    have no such requirement. They are fetched and written one at a time,
     outside the lock, so neither memory nor a local writer pays for the batch.
     """
 
-    def _snapshots(self, count: int) -> list[tuple[str, bytes]]:
-        return [(f"snapshots/v{n:03d}.json", f'{{"v": {n}}}'.encode()) for n in range(1, count + 1)]
+    def _ordinary_files(self, count: int) -> list[tuple[str, bytes]]:
+        return [(f"stream-{n:03d}.json", f'{{"v": {n}}}'.encode()) for n in range(1, count + 1)]
 
     def test_non_decision_transfers_are_written_before_the_next_is_fetched(self, collision_store):
-        entries = self._snapshots(3)
+        entries = self._ordinary_files(3)
         seen_on_disk: list[int] = []
         real_fetch = pull_module.fetch_via_presigned_url
 
         def counting_fetch(url):
-            seen_on_disk.append(len(list((collision_store / "snapshots").glob("*.json"))))
+            seen_on_disk.append(len(list(collision_store.glob("stream-*.json"))))
             return real_fetch(url)
 
         with patch.object(pull_module, "fetch_via_presigned_url", counting_fetch):
@@ -771,7 +810,7 @@ class TestTransferShape:
             return real_fetch(url)
 
         with patch.object(pull_module, "fetch_via_presigned_url", probing_fetch):
-            merged, _reporter = pull(collision_store, self._snapshots(2))
+            merged, _reporter = pull(collision_store, self._ordinary_files(2))
 
         assert merged == 2
         assert acquired == [True, True]
@@ -1162,11 +1201,11 @@ class TestWriteBarrier:
     def test_ordinary_files_are_unaffected(self, collision_store):
         merged, reporter = pull(
             collision_store,
-            [("snapshots/v001.json", b'{"v": 1}'), ("context/brief.md", b"# Brief\n")],
+            [("metrics.json", b'{"v": 1}'), ("context/brief.md", b"# Brief\n")],
         )
 
         assert merged == 2
-        assert (collision_store / "snapshots/v001.json").read_bytes() == b'{"v": 1}'
+        assert (collision_store / "metrics.json").read_bytes() == b'{"v": 1}'
         assert (collision_store / "context/brief.md").read_bytes() == b"# Brief\n"
         assert reporter.warns == []
 
@@ -1189,7 +1228,7 @@ class TestWriteBarrier:
     def test_the_barrier_admits_an_ordinary_store_path(self, collision_store):
         allowed = pull_module._generic_write_allowed(
             collision_store,
-            _Transfer(rel="snapshots/v001.json", etag='"e"', _body=b""),
+            _Transfer(rel="metrics.json", etag='"e"', _body=b""),
             SyncState(),
             _RecordingReporter(),
         )

--- a/packages/nauro/tests/test_sync/test_snapshot_convergence.py
+++ b/packages/nauro/tests/test_sync/test_snapshot_convergence.py
@@ -1,0 +1,62 @@
+"""Regression coverage for legacy snapshot convergence."""
+
+from __future__ import annotations
+
+import json
+
+from nauro_core.snapshot import serialize_snapshot
+
+from nauro.store.snapshot import capture_snapshot
+from nauro.sync.pull import PullReport
+from tests.test_sync.conftest import (
+    _scaffolded_cloud_project,
+    _seed_token,
+    pull_report,
+)
+
+
+def _snapshot(version: int, timestamp: str) -> bytes:
+    return (
+        json.dumps(
+            serialize_snapshot(
+                version=version,
+                timestamp=timestamp,
+                trigger="test",
+                files={},
+            )
+        )
+        + "\n"
+    ).encode()
+
+
+def test_pull_capture_prune_pull_converges(tmp_path):
+    store = _scaffolded_cloud_project("snapshot-convergence", tmp_path)
+    _seed_token()
+    snapshots = store / "snapshots"
+    local_v1 = _snapshot(1, "2025-01-01T00:00:00+00:00")
+    local_v2 = _snapshot(2, "2025-01-20T00:00:00+00:00")
+    (snapshots / "v001.json").write_bytes(local_v1)
+    (snapshots / "v002.json").write_bytes(local_v2)
+    remote = [
+        ("snapshots/v001.json", b'{"remote": 1}\n'),
+        ("snapshots/v002.json", b'{"remote": 2}\n'),
+    ]
+
+    first, _reporter = pull_report(store, remote)
+
+    assert first == PullReport()
+    assert not (store / ".conflict-backup").exists()
+    assert (snapshots / "v001.json").read_bytes() == local_v1
+    assert (snapshots / "v002.json").read_bytes() == local_v2
+
+    assert capture_snapshot(store, trigger="test") == 3
+    assert not (snapshots / "v001.json").exists()
+    assert (snapshots / "v002.json").exists()
+    assert (snapshots / "v003.json").exists()
+
+    second, _reporter = pull_report(store, remote)
+
+    assert second == PullReport()
+    assert not (snapshots / "v001.json").exists()
+    assert (snapshots / "v002.json").read_bytes() == local_v2
+    assert (snapshots / "v003.json").exists()

--- a/packages/nauro/tests/test_sync/test_sync_presign.py
+++ b/packages/nauro/tests/test_sync/test_sync_presign.py
@@ -468,6 +468,60 @@ class TestPushViaPresign:
         assert state.files["stack.md"].local_sha256 == new_sha
         assert state.files["stack.md"].remote_etag == '"e_pushed"'
 
+    def test_new_and_modified_local_snapshots_are_in_the_push_plan(self, cloud_store):
+        from nauro.sync.push import plan_push
+
+        modified = cloud_store / "snapshots/v001.json"
+        modified.write_text('{"version": 1}\n')
+        self._seed_synced_state(cloud_store)
+        modified.write_text('{"version": 1, "updated": true}\n')
+        (cloud_store / "snapshots/v002.json").write_text('{"version": 2}\n')
+
+        plan = plan_push(cloud_store, load_state(cloud_store))
+
+        assert sorted(candidate.relative_path for candidate in plan.candidates) == [
+            "snapshots/v001.json",
+            "snapshots/v002.json",
+        ]
+        assert plan.oversized_briefs == ()
+
+    def test_presign_candidates_match_the_push_plan(self, cloud_store, capsys):
+        from nauro.sync.push import plan_push, push_changed_files
+
+        self._seed_synced_state(cloud_store)
+        (cloud_store / "stack.md").write_text("modified\n")
+        (cloud_store / "snapshots/v001.json").write_text('{"version": 1}\n')
+        context_dir = cloud_store / "context"
+        context_dir.mkdir()
+        oversized = context_dir / "too-large.md"
+        oversized.write_text("x" * (MAX_BRIEF_BYTES + 1))
+
+        plan = plan_push(cloud_store, load_state(cloud_store))
+
+        assert capsys.readouterr().err == ""
+        assert [brief.relative_path for brief in plan.oversized_briefs] == ["context/too-large.md"]
+
+        put_response = MagicMock(spec=httpx.Response)
+        put_response.status_code = 200
+        put_response.headers = {"ETag": '"e_pushed"'}
+
+        def fake_post(url, **kwargs):
+            return self._presign_response(kwargs["json"]["operations"])
+
+        from nauro.sync import remote
+
+        with (
+            patch.object(remote.httpx, "post", side_effect=fake_post) as mock_post,
+            patch.object(remote.httpx, "put", return_value=put_response),
+        ):
+            pushed = push_changed_files(CLOUD_PID, cloud_store)
+
+        assert pushed == len(plan.candidates)
+        assert mock_post.call_args.kwargs["json"]["operations"] == [
+            {"verb": "PUT", "path": candidate.relative_path} for candidate in plan.candidates
+        ]
+        assert "too-large.md" in capsys.readouterr().err
+
     def test_stamped_decision_pushed_byte_identical(self, cloud_store):
         """A decision carrying the base_commit stamp uploads verbatim; the
         push path never rewrites decision bytes."""

--- a/packages/nauro/tests/test_sync/test_sync_status.py
+++ b/packages/nauro/tests/test_sync/test_sync_status.py
@@ -10,12 +10,13 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from unittest.mock import patch
 
+from nauro_core.constants import MAX_BRIEF_BYTES
 from typer.testing import CliRunner
 
 from nauro.cli.main import app
 from nauro.store.config import save_config
 from nauro.store.registry import register_project_v2
-from nauro.sync.state import SyncState, save_state
+from nauro.sync.state import FileState, SyncState, compute_sha256, save_state
 from nauro.templates.scaffolds import scaffold_project_store
 
 runner = CliRunner()
@@ -134,6 +135,76 @@ class TestLastSyncTime:
         result = runner.invoke(app, ["sync", "--status"])
         assert result.exit_code == 0, result.output
         assert "Last successful sync: never" in result.output
+
+
+class TestPendingLocalChanges:
+    def test_status_matches_push_eligible_existing_files(self, tmp_path, monkeypatch):
+        store = _scaffold(repo=tmp_path)
+        save_config(
+            {
+                "auth": {
+                    "sub": "auth0|test",
+                    "access_token": "tok_orig",
+                    "refresh_token": "refresh_orig",
+                }
+            }
+        )
+        monkeypatch.chdir(tmp_path)
+
+        state = SyncState()
+        for path in store.rglob("*"):
+            if path.is_file():
+                relative_path = str(path.relative_to(store))
+                state.files[relative_path] = FileState(
+                    local_sha256=compute_sha256(path),
+                    remote_etag='"synced"',
+                    last_sync="2026-05-16T00:00:00Z",
+                )
+
+        deleted = store / "deleted.md"
+        deleted.write_text("gone\n")
+        state.files["deleted.md"] = FileState(
+            local_sha256=compute_sha256(deleted),
+            remote_etag='"synced"',
+            last_sync="2026-05-16T00:00:00Z",
+        )
+        deleted.unlink()
+        save_state(store, state)
+
+        (store / "stack.md").write_text("modified\n")
+        context_dir = store / "context"
+        context_dir.mkdir()
+        (context_dir / "new.md").write_text("new\n")
+        (context_dir / "too-large.md").write_text("x" * (MAX_BRIEF_BYTES + 1))
+        (context_dir / "draft.md.lock").write_text("local lock\n")
+        journal_dir = store / "journal"
+        journal_dir.mkdir()
+        (journal_dir / "events.jsonl").write_text("{}\n")
+        scratch_dir = store / ".pull-spool-dead"
+        scratch_dir.mkdir()
+        (scratch_dir / "000000").write_text("scratch\n")
+        backup_dir = store / ".conflict-backup"
+        backup_dir.mkdir()
+        (backup_dir / "loser.md").write_text("backup\n")
+        (store / "nauro-graph.html").write_text("generated\n")
+
+        result = runner.invoke(app, ["sync", "--status"])
+
+        assert result.exit_code == 0, result.output
+        assert "Pending local changes: 2" in result.output
+        assert "    - stack.md" in result.output
+        assert "    - context/new.md" in result.output
+        for excluded in (
+            "deleted.md",
+            "context/too-large.md",
+            "context/draft.md.lock",
+            "journal/events.jsonl",
+            ".pull-spool-dead/000000",
+            ".conflict-backup/loser.md",
+            "nauro-graph.html",
+        ):
+            assert excluded not in result.output
+        assert "not pushed" not in result.output
 
 
 class TestQuarantinedCollisions:

--- a/packages/nauro/tests/test_sync/test_sync_status.py
+++ b/packages/nauro/tests/test_sync/test_sync_status.py
@@ -206,6 +206,37 @@ class TestPendingLocalChanges:
             assert excluded not in result.output
         assert "not pushed" not in result.output
 
+    def test_status_reports_unknown_and_continues_when_store_scan_fails(
+        self, tmp_path, monkeypatch
+    ):
+        store = _scaffold(repo=tmp_path)
+        save_config(
+            {
+                "auth": {
+                    "sub": "auth0|test",
+                    "access_token": "tok_orig",
+                    "refresh_token": "refresh_orig",
+                }
+            }
+        )
+        monkeypatch.chdir(tmp_path)
+        backup_dir = store / ".conflict-backup"
+        backup_dir.mkdir()
+        (backup_dir / "loser.md").write_text("backup\n")
+
+        with patch(
+            "nauro.sync.push.compute_sha256",
+            side_effect=FileNotFoundError("file disappeared during scan"),
+        ):
+            result = runner.invoke(app, ["sync", "--status"])
+
+        assert result.exit_code == 0, result.output
+        assert (
+            "Pending local changes: unknown "
+            "(store scan failed: file disappeared during scan)" in result.output
+        )
+        assert "Conflict backups: 1" in result.output
+
 
 class TestQuarantinedCollisions:
     def test_status_names_each_unresolved_collision(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## Why

Legacy pull restored remote snapshot archives after local retention pruned them. This caused the same snapshots to transfer again after each capture and prune cycle. `nauro sync --status` also reported tracked deletions and excluded local files that the push path could not send, while it missed new eligible files.

## What changed

Legacy pull now completes path-safety checks and then ignores canonical remote paths under `snapshots/`. It does not presign, download, write, count, or update sync state for those archive entries. Local snapshots remain eligible for upload.

Push now builds one read-only local plan for new and modified eligible files, with oversized briefs returned separately. Push keeps its existing warnings and network behavior. Status reads the same candidates without warnings, so it excludes tracked deletions and all push-excluded paths.

Regression coverage verifies remote snapshot exclusion, pull and prune convergence, local snapshot upload eligibility, push and presign parity, and status parity.

## Test plan

- `pytest packages/nauro/tests/test_sync/test_pull.py packages/nauro/tests/test_sync/test_sync_presign.py packages/nauro/tests/test_sync/test_sync_status.py packages/nauro/tests/test_sync/test_snapshot_convergence.py -q`
- `pytest packages/nauro/tests/ --ignore=packages/nauro/tests/cross_surface -q`
- `ruff check packages/ benchmarks/`
- `ruff format --check packages/ benchmarks/`
- `python scripts/check_single_sourced.py packages/nauro/src`
- `python scripts/check_server_json_version.py`
- `uv build --package nauro`
