### PR TITLE
Harden legacy sync transport sessions

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/auth.py
+++ b/packages/nauro/src/nauro/cli/commands/auth.py
@@ -174,7 +174,13 @@ _REFRESH_TIMEOUT_MESSAGE = (
 )
 
 
-def _exchange_refresh_token(domain: str, client_id: str, refresh_token: str) -> tuple[str, object]:
+def _exchange_refresh_token(
+    domain: str,
+    client_id: str,
+    refresh_token: str,
+    *,
+    client: httpx.Client | None = None,
+) -> tuple[str, object]:
     """Run the /oauth/token refresh exchange.
 
     Returns ``(new_access_token, rotated_refresh)`` where ``rotated_refresh`` is
@@ -184,7 +190,7 @@ def _exchange_refresh_token(domain: str, client_id: str, refresh_token: str) -> 
     """
     try:
         response = _post_with_429_retry(
-            lambda: httpx.post(
+            lambda: (client.post if client is not None else httpx.post)(
                 f"https://{domain}/oauth/token",
                 json={
                     "grant_type": "refresh_token",
@@ -219,7 +225,9 @@ def _exchange_refresh_token(domain: str, client_id: str, refresh_token: str) -> 
     return new_access_token, body.get("refresh_token")
 
 
-def refresh_access_token(stale_access_token: str | None = None) -> str:
+def refresh_access_token(
+    stale_access_token: str | None = None, *, client: httpx.Client | None = None
+) -> str:
     """Exchange the stored refresh token for a fresh access token.
 
     Single-flighted within the process by a module-level lock: one caller runs
@@ -272,7 +280,7 @@ def refresh_access_token(stale_access_token: str | None = None) -> str:
         # serializes us). Holding the filelock across the network call would
         # block every unrelated config writer for the whole retry tail.
         new_access_token, rotated_refresh = _exchange_refresh_token(
-            domain, client_id, refresh_token
+            domain, client_id, refresh_token, client=client
         )
 
         # COMMIT: re-validate under a bounded transaction. If the stored refresh
@@ -306,7 +314,9 @@ def refresh_access_token(stale_access_token: str | None = None) -> str:
         _REFRESH_LOCK.release()
 
 
-def with_token_refresh(call: Callable[[str], httpx.Response]) -> httpx.Response:
+def with_token_refresh(
+    call: Callable[[str], httpx.Response], *, client: httpx.Client | None = None
+) -> httpx.Response:
     """Run ``call(access_token)`` and refresh once on 401.
 
     The first 401 triggers a refresh and a single retry. A second 401 (or any
@@ -322,7 +332,7 @@ def with_token_refresh(call: Callable[[str], httpx.Response]) -> httpx.Response:
     if response.status_code != 401:
         return response
 
-    new_token = refresh_access_token(stale_access_token=token)
+    new_token = refresh_access_token(stale_access_token=token, client=client)
     return call(new_token)
 
 

--- a/packages/nauro/src/nauro/cli/commands/link.py
+++ b/packages/nauro/src/nauro/cli/commands/link.py
@@ -142,15 +142,13 @@ def link(
     # persisted. Pushing the store is best-effort: a transient presign/S3
     # failure must not roll back the promotion, so we warn and exit 0 and
     # let the user retry the upload with 'nauro sync'.
-    import httpx
-
     from nauro.cli.commands.auth import AuthRefreshError
     from nauro.sync.lock import SyncLockTimeoutError
     from nauro.sync.remote import PresignError
 
     try:
         pushed = push_changed_files(cloud_id, new_store)
-    except (AuthRefreshError, PresignError, SyncLockTimeoutError, httpx.HTTPError) as exc:
+    except (AuthRefreshError, PresignError, SyncLockTimeoutError) as exc:
         typer.echo(
             f"  Warning: linked, but the initial cloud push failed ({exc}).\n"
             "  Run 'nauro sync' to upload the project store.",
@@ -158,4 +156,13 @@ def link(
         )
         return
 
-    typer.echo(f"  Pushed {pushed} file(s) to cloud")
+    if not pushed.is_complete:
+        typer.echo(
+            f"  Warning: linked, but the initial cloud push was incomplete "
+            f"({pushed.warning}).\n"
+            "  Run 'nauro sync' to upload the project store.",
+            err=True,
+        )
+        return
+
+    typer.echo(f"  Pushed {len(pushed.verified)} file(s) to cloud")

--- a/packages/nauro/src/nauro/cli/commands/sync.py
+++ b/packages/nauro/src/nauro/cli/commands/sync.py
@@ -16,9 +16,10 @@ from nauro.store.registry import is_cloud_project
 from nauro.store.snapshot import capture_snapshot
 from nauro.store.validator import print_warnings, validate_store
 from nauro.sync.push import push_store_to_cloud
+from nauro.sync.remote import TransferSession, operation_session
 from nauro.templates.agents_md_regen import warn_then_regen
 
-if TYPE_CHECKING:  # the pull core pulls in httpx, so it stays off the CLI's import path
+if TYPE_CHECKING:
     from nauro.sync.pull import PullReport
 
 # Names retained for callers/tests that import the push helper from this
@@ -61,25 +62,35 @@ def sync(
     project_key = store_path.name
     trigger = message or "manual sync"
 
-    pulled = _pull_from_cloud(project_key, store_path)
+    with operation_session() as session:
+        pulled = _pull_from_cloud(project_key, store_path, session=session)
 
-    version = capture_snapshot(store_path, trigger=trigger)
+        version = capture_snapshot(store_path, trigger=trigger)
 
-    # The regen seam ensures the Claude Code bridge wherever AGENTS.md is
-    # written (before push, so local artifacts stay consistent even if the push
-    # fails); the sink collects those outcomes to echo on the success path.
-    bridge_outcomes: list[BridgeOutcome] = []
-    updated_repos = warn_then_regen(
-        project_key,
-        store_path,
-        warn=lambda msg: typer.echo(msg, err=True),
-        overwrite_unmanaged=True,
-        bridge_sink=bridge_outcomes,
-    )
+        # The regen seam ensures the Claude Code bridge wherever AGENTS.md is
+        # written (before push, so local artifacts stay consistent even if the push
+        # fails); the sink collects those outcomes to echo on the success path.
+        bridge_outcomes: list[BridgeOutcome] = []
+        updated_repos = warn_then_regen(
+            project_key,
+            store_path,
+            warn=lambda msg: typer.echo(msg, err=True),
+            overwrite_unmanaged=True,
+            bridge_sink=bridge_outcomes,
+        )
 
-    pushed = _push_to_cloud(project_key, store_path)
+        pushed = _push_to_cloud(project_key, store_path, session=session)
 
-    if pushed:
+    if pulled.origin_aborted:
+        typer.echo(
+            f"Error: sync stopped after a permanent remote origin failure for "
+            f"{project_name}; snapshot v{version:03d} was captured locally. "
+            "Fix the remote connection and run 'nauro sync' again.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    if pushed.is_complete:
         if is_cloud_project(project_key):
             typer.echo(f"Synced {project_name} - snapshot v{version:03d}")
         else:
@@ -128,7 +139,12 @@ def _unfinished_pull_detail(report: PullReport) -> str:
     return f"{report.refused} remote file(s) were not written this sync"
 
 
-def _pull_from_cloud(project_id: str, store_path: Path) -> PullReport:
+def _pull_from_cloud(
+    project_id: str,
+    store_path: Path,
+    *,
+    session: TransferSession | None = None,
+) -> PullReport:
     """Pull remote changes via the manifest + presign endpoints.
 
     No-op when the project is not v2 cloud-mode (local-mode has no
@@ -141,7 +157,7 @@ def _pull_from_cloud(project_id: str, store_path: Path) -> PullReport:
         return PullReport()
     if not load_access_token():
         return PullReport()
-    return _pull_via_presign(project_id, store_path)
+    return _pull_via_presign(project_id, store_path, session=session)
 
 
 class _EchoReporter:
@@ -157,7 +173,12 @@ class _EchoReporter:
         typer.echo(f"  {msg}", err=True)
 
 
-def _pull_via_presign(project_id: str, store_path: Path) -> PullReport:
+def _pull_via_presign(
+    project_id: str,
+    store_path: Path,
+    *,
+    session: TransferSession | None = None,
+) -> PullReport:
     """GET /sync/manifest → POST /sync/presign → S3 GETs.
 
     Delegates to the shared pull core with an echo reporter. An explicit sync
@@ -169,7 +190,7 @@ def _pull_via_presign(project_id: str, store_path: Path) -> PullReport:
 
     typer.echo("Pulling from remote...")
     try:
-        return run_pull(project_id, store_path, _EchoReporter())
+        return run_pull(project_id, store_path, _EchoReporter(), session=session)
     except SyncLockTimeoutError as exc:
         typer.echo(f"Error: {exc}. Try again once it finishes.", err=True)
         raise typer.Exit(code=1) from exc

--- a/packages/nauro/src/nauro/mcp/tools.py
+++ b/packages/nauro/src/nauro/mcp/tools.py
@@ -12,7 +12,7 @@ import inspect
 import logging
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from nauro_core.constants import (
     DECISIONS_DIR,
@@ -78,6 +78,9 @@ from nauro.store.snapshot import (
     resolve_diff_snapshots,
 )
 from nauro.store.store_lock import store_write_lock
+
+if TYPE_CHECKING:
+    from nauro.sync.push import PushReport
 
 logger = logging.getLogger("nauro.mcp.tools")
 
@@ -261,15 +264,18 @@ def _has_decisions(store_path: Path) -> bool:
     return any(decisions_dir.glob("*.md"))
 
 
-def _try_push(store_path: Path) -> None:
+def _try_push(store_path: Path) -> PushReport:
     """Best-effort push to S3 after a local write. Never raises."""
     try:
         from nauro.sync.hooks import push_after_write
 
         project_name = store_path.name
-        push_after_write(project_name, store_path)
+        return push_after_write(project_name, store_path)
     except Exception:
         logger.debug("sync push after write failed for %s", store_path.name, exc_info=True)
+        from nauro.sync.push import PushReport
+
+        return PushReport(failed=("unexpected failure",))
 
 
 def _coerce_level(level: int | str) -> int:

--- a/packages/nauro/src/nauro/store/post_commit.py
+++ b/packages/nauro/src/nauro/store/post_commit.py
@@ -29,11 +29,15 @@ import logging
 from collections.abc import Callable, Sequence
 from enum import Enum
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, ConfigDict
 
 from nauro.store.snapshot import capture_snapshot
 from nauro.templates.agents_md_regen import warn_then_regen
+
+if TYPE_CHECKING:
+    from nauro.sync.push import PushReport
 
 logger = logging.getLogger("nauro.store.post_commit")
 
@@ -88,7 +92,7 @@ def run_post_commit(
     regenerate_agents_md: bool = False,
     warn: Callable[[str], None] | None = None,
     surface_bridge_notices: bool = True,
-    push: Callable[[Path], None] | None = None,
+    push: Callable[[Path], PushReport | None] | None = None,
 ) -> PostCommitOutcome:
     """Run the ancillary steps for a write that already committed.
 
@@ -138,12 +142,15 @@ def run_post_commit(
 
     if push is not None:
         try:
-            push(store_path)
+            push_report = push(store_path)
         except Exception as exc:
             logger.debug("cloud push failed for %s", store_path.name, exc_info=True)
             degraded.append(
                 DegradedStep(step=AncillaryStep.PUSH, reason=f"{type(exc).__name__}: {exc}")
             )
+        else:
+            if push_report is not None and not push_report.is_complete:
+                degraded.append(DegradedStep(step=AncillaryStep.PUSH, reason=push_report.warning))
 
     return PostCommitOutcome(degraded=tuple(degraded), updated_repos=tuple(updated_repos))
 

--- a/packages/nauro/src/nauro/store/recovery.py
+++ b/packages/nauro/src/nauro/store/recovery.py
@@ -14,7 +14,6 @@ from enum import Enum
 from pathlib import Path
 from typing import Annotated, Literal
 
-import httpx
 from filelock import FileLock, Timeout
 from nauro_core.doctor import diagnose_store
 from pydantic import (
@@ -40,8 +39,10 @@ from nauro.sync.etag import content_md5
 from nauro.sync.remote import (
     PRESIGN_BATCH_LIMIT,
     PresignError,
+    TransferSession,
     fetch_manifest,
     fetch_via_presigned_url,
+    operation_session,
     request_presigned_urls,
 )
 from nauro.sync.state import FileState, SyncState, save_state
@@ -283,12 +284,16 @@ class _MintedBatch:
     deadline: datetime | None
 
 
-def _mint_download_urls(project_id: str, paths: Sequence[str]) -> _MintedBatch:
+def _mint_download_urls(
+    project_id: str, paths: Sequence[str], session: TransferSession
+) -> _MintedBatch:
     """Mint one download URL per path, or refuse the batch."""
     operations = [{"verb": "GET", "path": path} for path in paths]
     try:
-        results = _parse_presign_results(request_presigned_urls(project_id, operations))
-    except (AuthRefreshError, PresignError, httpx.HTTPError) as exc:
+        results = _parse_presign_results(
+            request_presigned_urls(project_id, operations, session=session)
+        )
+    except (AuthRefreshError, PresignError) as exc:
         raise RecoveryError(f"Cloud restore presign failed: {exc}") from exc
     urls: dict[str, str] = {}
     ceilings: list[datetime] = []
@@ -313,7 +318,13 @@ class _ChunkUrls:
     finish inside the margin. A stale-URL 403 re-mints through the same door.
     """
 
-    def __init__(self, project_id: str, paths: Sequence[str], reporter: Reporter) -> None:
+    def __init__(
+        self,
+        project_id: str,
+        paths: Sequence[str],
+        reporter: Reporter,
+        session: TransferSession,
+    ) -> None:
         self._project_id = project_id
         self._paths = list(paths)
         # Everything from the cursor on is still outstanding, so a re-mint
@@ -321,11 +332,14 @@ class _ChunkUrls:
         # thing that hands a path out, which is what keeps that true.
         self._cursor = 0
         self._reporter = reporter
+        self._session = session
         self._warned_undated = False
         self._mint()
 
     def _mint(self) -> None:
-        self._batch = _mint_download_urls(self._project_id, self._paths[self._cursor :])
+        self._batch = _mint_download_urls(
+            self._project_id, self._paths[self._cursor :], self._session
+        )
         if self._batch.deadline is None and not self._warned_undated:
             # Without a ceiling the restore cannot re-mint ahead of an expiry,
             # so it falls back to reacting to a refusal. Say so: a server that
@@ -412,11 +426,13 @@ def _open_staging(staging: Path) -> None:
         raise RecoveryError(f"Could not open the restore staging area {staging}: {exc}") from exc
 
 
-def _fetch_manifest_entries(project_id: str) -> dict[str, CloudManifestEntry]:
+def _fetch_manifest_entries(
+    project_id: str, session: TransferSession
+) -> dict[str, CloudManifestEntry]:
     """Return the remote record's files, keyed by store-relative path."""
     try:
-        rows = fetch_manifest(project_id)
-    except (AuthRefreshError, PresignError, httpx.HTTPError) as exc:
+        rows = fetch_manifest(project_id, session=session)
+    except (AuthRefreshError, PresignError) as exc:
         raise RecoveryError(f"Cloud manifest fetch failed: {exc}") from exc
     entries: dict[str, CloudManifestEntry] = {}
     for entry in _parse_manifest(rows):
@@ -600,15 +616,26 @@ def _download_pending(
     pending: Sequence[str],
     reporter: Reporter,
     progress: _Progress,
+    session: TransferSession,
 ) -> None:
     """Download every outstanding file into staging, one presign chunk at a time."""
     for start in range(0, len(pending), PRESIGN_BATCH_LIMIT):
-        chunk = _ChunkUrls(project_id, pending[start : start + PRESIGN_BATCH_LIMIT], reporter)
+        chunk = _ChunkUrls(
+            project_id,
+            pending[start : start + PRESIGN_BATCH_LIMIT],
+            reporter,
+            session,
+        )
         for relative in chunk.in_order():
             try:
-                content = download_with_retry(relative, chunk, fetch_via_presigned_url)
+                fetched = download_with_retry(
+                    relative,
+                    chunk,
+                    lambda url: fetch_via_presigned_url(url, session=session),
+                )
             except PresignError as exc:
                 raise RecoveryError(f"Cloud download failed for {relative}: {exc}") from exc
+            content = fetched.body
             entry = entries[relative]
             defect = _content_defect(content, entry)
             if defect is not None:
@@ -736,24 +763,33 @@ def restore_cloud_store(
             raise RecoveryError(f"Refusing to overwrite nonempty destination: {destination}.")
 
         _sweep_legacy_staging(project_id, destination.parent)
-        entries = _fetch_manifest_entries(project_id)
-        if not entries:
-            # A record that is not there cannot complete a partial restore,
-            # so nothing is kept to resume toward.
-            _discard_restore_state(project_id, destination)
-            raise EmptyCloudRecordError("Cloud project has no stored record to restore.")
+        with operation_session() as session:
+            entries = _fetch_manifest_entries(project_id, session)
+            if not entries:
+                # A record that is not there cannot complete a partial restore,
+                # so nothing is kept to resume toward.
+                _discard_restore_state(project_id, destination)
+                raise EmptyCloudRecordError("Cloud project has no stored record to restore.")
 
-        area = _open_staging_area(project_id, destination, surface)
-        staged = area.audit(entries)
-        pending = [relative for relative in entries if relative not in staged]
-        _report_start(entries, pending, surface)
+            area = _open_staging_area(project_id, destination, surface)
+            staged = area.audit(entries)
+            pending = [relative for relative in entries if relative not in staged]
+            _report_start(entries, pending, surface)
 
-        progress = _Progress(total=len(entries), done=len(staged))
-        try:
-            _download_pending(project_id, area, entries, pending, surface, progress)
-        except (RecoveryError, KeyboardInterrupt):
-            surface.warn(_kept_message(area.path, progress))
-            raise
+            progress = _Progress(total=len(entries), done=len(staged))
+            try:
+                _download_pending(
+                    project_id,
+                    area,
+                    entries,
+                    pending,
+                    surface,
+                    progress,
+                    session,
+                )
+            except (RecoveryError, KeyboardInterrupt):
+                surface.warn(_kept_message(area.path, progress))
+                raise
 
         try:
             _validate_restored_store(area.path)

--- a/packages/nauro/src/nauro/sync/hooks.py
+++ b/packages/nauro/src/nauro/sync/hooks.py
@@ -1,8 +1,8 @@
-"""Event-driven sync hooks — pull on session start, push after writes.
+"""Event-driven sync hooks: pull on session start, push after writes.
 
 Called by the MCP server (``stdio_server._pull_on_startup`` on entry,
 ``mcp/tools._try_push`` after each write). Never block or crash —
-failures are logged only.
+failures are logged, and post-write reports return to the post-commit surface.
 
 Both hooks gate on Auth0 token presence and v2 cloud-mode at entry and
 silent-no-op when either is missing. The two no-op cases are:
@@ -25,11 +25,17 @@ Token refresh on 401 is handled inside ``request_presigned_urls`` and
 escapes here as a swallowed log line.
 """
 
+from __future__ import annotations
+
 import logging
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from nauro.cli.commands.auth import load_access_token
 from nauro.store.registry import is_cloud_project
+
+if TYPE_CHECKING:
+    from nauro.sync.push import PushReport
 
 logger = logging.getLogger("nauro.sync")
 
@@ -87,18 +93,18 @@ def pull_before_session(project_id: str, store_path: Path) -> int:
         return 0
 
 
-def push_after_write(project_id: str, store_path: Path) -> int:
+def push_after_write(project_id: str, store_path: Path) -> PushReport:
     """Push changed local files after a write (decision, question, state).
 
     Silent no-op when not authenticated or when ``project_id`` is not a
-    v2 cloud-mode entry. Returns the number of files pushed, or 0 on any
-    swallowed failure. Never raises — auto-push must not surface errors
-    on every MCP tool call.
+    v2 cloud-mode entry. Returns a structured push report. Never raises.
     """
+    from nauro.sync.push import PushReport
+
     if not load_access_token():
-        return 0
+        return PushReport()
     if not is_cloud_project(project_id):
-        return 0
+        return PushReport()
 
     try:
         from nauro.cli.commands.auth import AuthRefreshError
@@ -106,7 +112,7 @@ def push_after_write(project_id: str, store_path: Path) -> int:
         from nauro.sync.push import push_changed_files
         from nauro.sync.remote import PresignError
     except ImportError:
-        return 0
+        return PushReport(failed=("sync import",))
 
     try:
         return push_changed_files(project_id, store_path, lock_timeout=HOOK_SYNC_LOCK_TIMEOUT)
@@ -114,13 +120,13 @@ def push_after_write(project_id: str, store_path: Path) -> int:
         # Post-write publication is a fail-open ancillary step: the changed
         # files stay changed and the next push picks them up.
         logger.info("sync push: skipped, %s", exc)
-        return 0
+        return PushReport(failed=("sync lock",))
     except AuthRefreshError as exc:
         logger.warning("sync push: %s", exc)
-        return 0
+        return PushReport(failed=("authentication",))
     except PresignError as exc:
         logger.warning("sync push: presign request failed: %s", exc)
-        return 0
+        return PushReport(failed=("transport",))
     except Exception:
         logger.exception("sync push: unexpected failure for %s", project_id)
-        return 0
+        return PushReport(failed=("unexpected failure",))

--- a/packages/nauro/src/nauro/sync/pull.py
+++ b/packages/nauro/src/nauro/sync/pull.py
@@ -70,8 +70,11 @@ from nauro.sync.merge import (
 from nauro.sync.quarantine import save_quarantine_backup
 from nauro.sync.remote import (
     PresignError,
+    TransferBoundaryError,
+    TransferSession,
     fetch_manifest,
     fetch_via_presigned_url,
+    operation_session,
     request_presigned_urls,
     urls_by_path,
 )
@@ -165,6 +168,7 @@ class _Tally:
     adopted: int = 0
     refused: int = 0
     skipped_permanent: int = 0
+    origin_aborted: set[str] = field(default_factory=set)
 
 
 @dataclass(frozen=True)
@@ -185,6 +189,7 @@ class PullReport:
     refused: int = 0
     skipped_permanent: int = 0
     manifest_read: bool = True
+    origin_aborted: tuple[str, ...] = ()
 
     @property
     def left_work_behind(self) -> bool:
@@ -197,6 +202,7 @@ class PullReport:
             merged=tally.merged,
             refused=tally.refused,
             skipped_permanent=tally.skipped_permanent,
+            origin_aborted=tuple(sorted(tally.origin_aborted)),
         )
 
 
@@ -524,6 +530,7 @@ def run_pull(
     reporter: Reporter,
     *,
     lock_timeout: float = CLI_SYNC_LOCK_TIMEOUT,
+    session: TransferSession | None = None,
 ) -> PullReport:
     """Pull remote changes for ``project_id`` into ``store_path``.
 
@@ -557,12 +564,17 @@ def run_pull(
             lock, or a local decision writer held the decision lock, for
             longer than ``lock_timeout``.
     """
-    with sync_lock(store_path, lock_timeout):
-        return _run_pull_locked(project_id, store_path, reporter, lock_timeout)
+    with operation_session(session) as active:
+        with sync_lock(store_path, lock_timeout):
+            return _run_pull_locked(project_id, store_path, reporter, lock_timeout, active)
 
 
 def _run_pull_locked(
-    project_id: str, store_path: Path, reporter: Reporter, lock_timeout: float
+    project_id: str,
+    store_path: Path,
+    reporter: Reporter,
+    lock_timeout: float,
+    session: TransferSession,
 ) -> PullReport:
     _sweep_interrupted_writes(store_path, reporter)
 
@@ -572,13 +584,16 @@ def _run_pull_locked(
     # server. Nothing is written on the way out, so the last-full-sync stamp
     # keeps the date of the last run that did finish.
     try:
-        rows = fetch_manifest(project_id)
+        rows = fetch_manifest(project_id, session=session)
     except AuthRefreshError as exc:
         reporter.warn(str(exc))
         return PullReport(manifest_read=False)
     except PresignError as exc:
         reporter.warn(f"manifest fetch failed: {exc}")
-        return PullReport(manifest_read=False)
+        return PullReport(
+            manifest_read=False,
+            origin_aborted=_aborted_origins(exc),
+        )
 
     manifest = _parse_manifest(rows, reporter)
     state = load_state(store_path)
@@ -586,7 +601,7 @@ def _run_pull_locked(
     tally = _Tally(skipped_permanent=manifest.unreadable_rows + work.skipped_permanent)
 
     planned = work.all_files()
-    urls = _presign(project_id, planned, reporter)
+    urls = _presign(project_id, planned, reporter, session, tally)
     if urls is None:
         # The request failed as a whole, so every file it was for stays where
         # it is. Here the denominator is known, so each one is counted: the
@@ -607,7 +622,7 @@ def _run_pull_locked(
         # held: a manifest is server-supplied input, and its total size is not a
         # number this process gets to be surprised by.
         with _spool(store_path) as spool:
-            gated = _spool_batch(urls, work.decisions, reporter, spool)
+            gated = _spool_batch(urls, work.decisions, reporter, spool, session, tally)
             with decision_lock(store_path, lock_timeout):
                 mutating = True
                 corpus = DecisionCorpus.scan(store_path)
@@ -631,7 +646,7 @@ def _run_pull_locked(
             update_file_state(state, adopted.rel, adopted.local_sha256, adopted.etag)
             tally.adopted += 1
 
-        for transfer in _stream(urls, work.pulls, reporter, tally):
+        for transfer in _stream(urls, work.pulls, reporter, tally, session):
             with _guarded_step(transfer.rel, _WRITE_FAILURE_DETAIL, reporter, tally):
                 if _generic_write_allowed(store_path, transfer, state, reporter):
                     target = store_path / transfer.rel
@@ -641,7 +656,7 @@ def _run_pull_locked(
                 else:
                     tally.skipped_permanent += 1
 
-        for transfer in _stream(urls, work.conflicts, reporter, tally):
+        for transfer in _stream(urls, work.conflicts, reporter, tally, session):
             with _guarded_step(transfer.rel, _WRITE_FAILURE_DETAIL, reporter, tally):
                 if _generic_write_allowed(store_path, transfer, state, reporter):
                     _resolve_and_record(
@@ -803,7 +818,11 @@ def _sweep_interrupted_writes(store_path: Path, reporter: Reporter) -> int:
 
 
 def _presign(
-    project_id: str, planned: list[_RemoteFile], reporter: Reporter
+    project_id: str,
+    planned: list[_RemoteFile],
+    reporter: Reporter,
+    session: TransferSession,
+    tally: _Tally,
 ) -> dict[str, str] | None:
     """Mint one GET URL per planned file, or None on a request failure.
 
@@ -816,11 +835,12 @@ def _presign(
 
     operations = [{"verb": "GET", "path": item.rel} for item in planned]
     try:
-        urls = request_presigned_urls(project_id, operations)
+        urls = request_presigned_urls(project_id, operations, session=session)
     except AuthRefreshError as exc:
         reporter.warn(str(exc))
         return None
     except PresignError as exc:
+        tally.origin_aborted.update(_aborted_origins(exc))
         reporter.warn(f"presign request failed: {exc}")
         return None
 
@@ -834,7 +854,11 @@ def _presign(
 
 
 def _stream(
-    urls: dict[str, str], items: list[_RemoteFile], reporter: Reporter, tally: _Tally
+    urls: dict[str, str],
+    items: list[_RemoteFile],
+    reporter: Reporter,
+    tally: _Tally,
+    session: TransferSession,
 ) -> Iterator[_Transfer]:
     """Yield each planned file's bytes, fetched one at a time.
 
@@ -850,12 +874,13 @@ def _stream(
             tally.refused += 1
             continue
         try:
-            content = fetch_via_presigned_url(url)
+            fetched = fetch_via_presigned_url(url, session=session)
         except PresignError as exc:
+            tally.origin_aborted.update(_aborted_origins(exc))
             reporter.warn(f"error pulling {item.rel}: {exc}")
             tally.refused += 1
             continue
-        yield _Transfer(rel=item.rel, etag=item.etag, _body=content)
+        yield _Transfer(rel=item.rel, etag=item.etag, _body=fetched.body)
 
 
 @contextmanager
@@ -874,7 +899,12 @@ def _spool(store_path: Path) -> Iterator[Path]:
 
 
 def _spool_batch(
-    urls: dict[str, str], items: list[_RemoteFile], reporter: Reporter, spool: Path
+    urls: dict[str, str],
+    items: list[_RemoteFile],
+    reporter: Reporter,
+    spool: Path,
+    session: TransferSession,
+    tally: _Tally,
 ) -> dict[str, _Transfer]:
     """Fetch a batch onto disk, keyed by store-relative path.
 
@@ -888,15 +918,25 @@ def _spool_batch(
             reporter.warn(_NO_URL_DETAIL.format(rel=item.rel))
             continue
         try:
-            content = fetch_via_presigned_url(url)
+            fetched = fetch_via_presigned_url(url, session=session)
         except PresignError as exc:
+            tally.origin_aborted.update(_aborted_origins(exc))
             reporter.warn(f"error pulling {item.rel}: {exc}")
             continue
+        content = fetched.body
         body = spool / f"{index:06d}"
         body.write_bytes(content)
         del content
         spooled[item.rel] = _Transfer(rel=item.rel, etag=item.etag, _spooled=body)
     return spooled
+
+
+def _aborted_origins(error: PresignError) -> tuple[str, ...]:
+    if not isinstance(error, TransferBoundaryError):
+        return ()
+    if not error.aborts_origin:
+        return ()
+    return (error.origin,)
 
 
 _SKIP_DETAIL: dict[SkipReason, str] = {

--- a/packages/nauro/src/nauro/sync/push.py
+++ b/packages/nauro/src/nauro/sync/push.py
@@ -1,4 +1,4 @@
-"""Store → cloud push over the presign transport.
+"""Store to cloud push over the legacy presign transport.
 
 Shared by ``nauro sync`` (push half of pull-then-push) and ``nauro link
 --cloud`` (the first push after promoting a local project). Both callers
@@ -12,20 +12,33 @@ network here.
 
 from __future__ import annotations
 
+import hashlib
 import logging
 from dataclasses import dataclass
+from enum import Enum
 from pathlib import Path
 
 import typer
 from nauro_core.constants import MAX_BRIEF_BYTES
 
-from nauro.cli.commands.auth import load_access_token
+from nauro.cli.commands.auth import AuthRefreshError, load_access_token
 from nauro.store.registry import is_cloud_project
-from nauro.sync.lock import CLI_SYNC_LOCK_TIMEOUT, sync_lock
+from nauro.sync.lock import CLI_SYNC_LOCK_TIMEOUT, SyncLockTimeoutError, sync_lock
 from nauro.sync.merge import CONFLICT_BACKUP_DIR, should_skip
+from nauro.sync.remote import (
+    PresignError,
+    RetryClassification,
+    TransferBoundaryError,
+    TransferSession,
+    WriteOutcome,
+    operation_session,
+)
 from nauro.sync.state import SyncState, compute_sha256
+from nauro.sync.transfer import backoff_delay, pause
 
 logger = logging.getLogger("nauro.sync")
+
+_PUT_MAX_ATTEMPTS = 4
 
 
 @dataclass(frozen=True)
@@ -45,6 +58,42 @@ class OversizedBrief:
 class PushPlan:
     candidates: tuple[PushCandidate, ...]
     oversized_briefs: tuple[OversizedBrief, ...]
+
+
+@dataclass(frozen=True)
+class PushReport:
+    """One truthful partition of the paths selected for upload."""
+
+    planned: tuple[str, ...] = ()
+    verified: tuple[str, ...] = ()
+    missing_urls: tuple[str, ...] = ()
+    failed: tuple[str, ...] = ()
+    ambiguous: tuple[str, ...] = ()
+    origin_aborted: tuple[str, ...] = ()
+
+    @property
+    def is_complete(self) -> bool:
+        return self.verified == self.planned and not (
+            self.missing_urls or self.failed or self.ambiguous or self.origin_aborted
+        )
+
+    @property
+    def pushed(self) -> int:
+        return len(self.verified)
+
+    @property
+    def warning(self) -> str:
+        parts = []
+        for label, values in (
+            ("verified", self.verified),
+            ("missing URL", self.missing_urls),
+            ("failed", self.failed),
+            ("pending observation", self.ambiguous),
+            ("origin aborted", self.origin_aborted),
+        ):
+            if values:
+                parts.append(f"{len(values)} {label}")
+        return f"cloud push incomplete ({', '.join(parts)})"
 
 
 def plan_push(store_path: Path, state: SyncState) -> PushPlan:
@@ -68,34 +117,22 @@ def plan_push(store_path: Path, state: SyncState) -> PushPlan:
             if size > MAX_BRIEF_BYTES:
                 oversized_briefs.append(OversizedBrief(rel, size))
                 continue
-
         local_sha = compute_sha256(local_file)
-        fs = state.files.get(rel)
-        if fs is None or fs.local_sha256 != local_sha:
+        file_state = state.files.get(rel)
+        if file_state is None or file_state.local_sha256 != local_sha:
             candidates.append(PushCandidate(rel, local_sha, local_file))
-
     return PushPlan(tuple(candidates), tuple(oversized_briefs))
 
 
-def push_store_to_cloud(project_id: str, store_path: Path) -> bool:
-    """Push store changes after a local sync.
-
-    Cloud-mode projects with a token → presign push. Cloud-mode without
-    a token → warn and return False (caller surfaces exit 1). Anything
-    else (local-mode or unknown id) → True since nothing was expected to
-    upload.
-
-    A presign/auth-refresh failure during the push is reported and maps
-    to False; per-file PUT failures are logged and skipped. A concurrent sync
-    holding the store lock past the bounded wait is also a reported failure:
-    an explicit sync must not report success for an upload it never attempted.
-    """
-    from nauro.cli.commands.auth import AuthRefreshError
-    from nauro.sync.lock import SyncLockTimeoutError
-    from nauro.sync.remote import PresignError
-
+def push_store_to_cloud(
+    project_id: str,
+    store_path: Path,
+    *,
+    session: TransferSession | None = None,
+) -> PushReport:
+    """Push store changes and render failures for an explicit sync."""
     if not is_cloud_project(project_id):
-        return True
+        return PushReport()
     if not load_access_token():
         typer.echo(
             "  Warning: this is a cloud-mode project but you're not authenticated.\n"
@@ -103,24 +140,24 @@ def push_store_to_cloud(project_id: str, store_path: Path) -> bool:
             "  Run 'nauro auth login' to configure credentials.",
             err=True,
         )
-        return False
-
+        return PushReport(failed=("authentication",))
     try:
-        pushed = push_changed_files(project_id, store_path)
+        report = push_changed_files(project_id, store_path, session=session)
     except SyncLockTimeoutError as exc:
         typer.echo(f"  Warning: {exc}", err=True)
-        return False
+        return PushReport(failed=("sync lock",))
     except AuthRefreshError as exc:
         typer.echo(f"  {exc}", err=True)
-        return False
+        return PushReport(failed=("authentication",))
     except PresignError as exc:
-        logger.exception("Failed to request presigned PUT URLs")
-        typer.echo(f"  Warning: presign request failed ({exc})", err=True)
-        return False
-
-    if pushed:
-        typer.echo(f"  Pushed {pushed} file(s) to S3")
-    return True
+        logger.warning("Cloud push boundary failed: %s", exc)
+        typer.echo(f"  Warning: cloud push failed ({exc})", err=True)
+        return PushReport(failed=("transport",))
+    if report.verified:
+        typer.echo(f"  Pushed {len(report.verified)} file(s) to S3")
+    if not report.is_complete:
+        typer.echo(f"  Warning: {report.warning}", err=True)
+    return report
 
 
 def push_changed_files(
@@ -128,36 +165,19 @@ def push_changed_files(
     store_path: Path,
     *,
     lock_timeout: float = CLI_SYNC_LOCK_TIMEOUT,
-) -> int:
-    """Upload every store file whose local sha differs from sync-state.
-
-    POSTs ``/sync/presign`` for the changed paths, then PUTs each one to
-    its presigned URL, recording the returned ETag in sync-state. Returns
-    the number of files successfully pushed.
-
-    Held under the store's sync lock for the whole run: a pull resolving a
-    decision-number collision renames local files, and a push scanning the
-    store mid-sequence would upload a half-applied rename.
-
-    Raises :class:`~nauro.cli.commands.auth.AuthRefreshError` or
-    :class:`~nauro.sync.remote.PresignError` if minting the presigned
-    URLs fails; per-file PUT failures are logged and skipped so a partial
-    upload still records the files that did land.
-    Raises :class:`~nauro.sync.lock.SyncLockTimeoutError` when another sync holds
-    the store lock for longer than ``lock_timeout``.
-    """
-    with sync_lock(store_path, lock_timeout):
-        return _push_changed_files_locked(project_id, store_path)
+    session: TransferSession | None = None,
+) -> PushReport:
+    """Upload changed files and checkpoint each verified result."""
+    with operation_session(session) as active:
+        with sync_lock(store_path, lock_timeout):
+            return _push_changed_files_locked(project_id, store_path, active)
 
 
-def _push_changed_files_locked(project_id: str, store_path: Path) -> int:
-    from nauro.sync.remote import (
-        PresignError,
-        put_via_presigned_url,
-        request_presigned_urls,
-        urls_by_path,
-    )
-    from nauro.sync.state import load_state, save_state, update_file_state
+def _push_changed_files_locked(
+    project_id: str, store_path: Path, session: TransferSession
+) -> PushReport:
+    from nauro.sync.remote import request_presigned_urls, urls_by_path
+    from nauro.sync.state import load_state, save_state
 
     state = load_state(store_path)
     plan = plan_push(store_path, state)
@@ -168,47 +188,209 @@ def _push_changed_files_locked(project_id: str, store_path: Path) -> int:
             "It stays on your machine; trim it under the cap and re-sync to share it.",
             err=True,
         )
-
+    planned = tuple(candidate.relative_path for candidate in plan.candidates)
     if not plan.candidates:
         save_state(store_path, state)
-        return 0
+        return PushReport(planned=planned)
 
-    operations = [{"verb": "PUT", "path": candidate.relative_path} for candidate in plan.candidates]
-    urls = request_presigned_urls(project_id, operations)
+    operations = [{"verb": "PUT", "path": path} for path in planned]
+    try:
+        urls = request_presigned_urls(project_id, operations, session=session)
+    except PresignError as exc:
+        aborted = planned if _origin_failure(exc) else ()
+        failed = () if aborted else planned
+        return PushReport(planned=planned, failed=failed, origin_aborted=aborted)
 
     if len(urls) < len(operations):
         logger.warning("Presign returned %d URLs for %d ops", len(urls), len(operations))
-
     url_by_path, skipped = urls_by_path(urls, "PUT")
     for entry in skipped:
-        logger.warning("Skipping unreadable presign entry %s", entry)
+        logger.warning("Skipping %s", entry)
 
-    pushed = 0
-    for candidate in plan.candidates:
-        url = url_by_path.get(candidate.relative_path)
+    verified: list[str] = []
+    missing: list[str] = []
+    failed: list[str] = []
+    ambiguous: list[str] = []
+    origin_aborted: list[str] = []
+
+    for index, candidate in enumerate(plan.candidates):
+        path = candidate.relative_path
+        url = url_by_path.get(path)
         if not url:
+            missing.append(path)
             continue
         try:
-            new_etag = put_via_presigned_url(url, candidate.local_file)
-            if new_etag:
-                update_file_state(
-                    state,
-                    candidate.relative_path,
-                    candidate.local_sha256,
-                    new_etag,
-                )
-                pushed += 1
-        except PresignError:
-            logger.exception("Failed to push %s", candidate.relative_path)
+            payload = candidate.local_file.read_bytes()
+        except OSError:
+            failed.append(path)
+            continue
+        payload_sha = hashlib.sha256(payload).hexdigest()
+        try:
+            result = _put_frozen(project_id, path, url, payload, session)
+        except TransferBoundaryError as exc:
+            if exc.aborts_origin:
+                origin_aborted.append(path)
+                continue
+            if exc.write_outcome is WriteOutcome.AMBIGUOUS:
+                outcome = _reconcile(project_id, path, payload_sha, session)
+                if outcome.kind is _ReconcileKind.VERIFIED:
+                    if not _checkpoint(store_path, state, path, payload_sha, outcome.etag):
+                        failed.extend(planned[index:])
+                        break
+                    verified.append(path)
+                elif outcome.kind is _ReconcileKind.DIVERGENT:
+                    failed.append(path)
+                else:
+                    ambiguous.append(path)
+                continue
+            failed.append(path)
+            continue
+        except AuthRefreshError:
+            failed.append(path)
+            continue
 
-    save_state(store_path, state)
-    return pushed
+        if result.outcome is WriteOutcome.WRITTEN_UNVERIFIED:
+            outcome = _reconcile(project_id, path, payload_sha, session)
+            if outcome.kind is _ReconcileKind.DIVERGENT:
+                failed.append(path)
+                continue
+            if outcome.kind is not _ReconcileKind.VERIFIED:
+                ambiguous.append(path)
+                continue
+            etag = outcome.etag
+        else:
+            etag = result.etag
+        if not _checkpoint(store_path, state, path, payload_sha, etag):
+            failed.extend(planned[index:])
+            break
+        verified.append(path)
+
+    return PushReport(
+        planned=planned,
+        verified=tuple(verified),
+        missing_urls=tuple(missing),
+        failed=tuple(failed),
+        ambiguous=tuple(ambiguous),
+        origin_aborted=tuple(origin_aborted),
+    )
+
+
+def _origin_failure(error: PresignError) -> bool:
+    return isinstance(error, TransferBoundaryError) and error.aborts_origin
+
+
+def _put_frozen(
+    project_id: str,
+    path: str,
+    initial_url: str,
+    payload: bytes,
+    session: TransferSession,
+):
+    from nauro.sync.remote import put_via_presigned_url, request_presigned_urls, urls_by_path
+
+    url = initial_url
+    failures = 0
+    reminted = False
+    while True:
+        try:
+            return put_via_presigned_url(url, payload, session=session)
+        except TransferBoundaryError as exc:
+            failures += 1
+            if (
+                exc.retry is RetryClassification.EXPIRED_CANDIDATE
+                and exc.write_outcome is WriteOutcome.NOT_WRITTEN
+                and not reminted
+            ):
+                reminted = True
+                failures = 0
+                rows = request_presigned_urls(
+                    project_id,
+                    [{"verb": "PUT", "path": path}],
+                    session=session,
+                )
+                urls, _skipped = urls_by_path(rows, "PUT")
+                replacement = urls.get(path)
+                if replacement is None:
+                    raise exc
+                url = replacement
+                continue
+            if (
+                exc.retry is not RetryClassification.TRANSIENT
+                or exc.write_outcome is not WriteOutcome.NOT_WRITTEN
+                or failures >= _PUT_MAX_ATTEMPTS
+            ):
+                raise
+            pause(backoff_delay(failures))
+
+
+class _ReconcileKind(Enum):
+    VERIFIED = "verified"
+    DIVERGENT = "divergent"
+    PENDING = "pending"
+
+
+@dataclass(frozen=True)
+class _ReconcileOutcome:
+    kind: _ReconcileKind
+    etag: str = ""
+
+
+def _reconcile(
+    project_id: str, path: str, payload_sha: str, session: TransferSession
+) -> _ReconcileOutcome:
+    from nauro.sync.remote import (
+        fetch_manifest,
+        fetch_via_presigned_url,
+        request_presigned_urls,
+        urls_by_path,
+    )
+
+    try:
+        manifest = fetch_manifest(project_id, session=session)
+        if not any(isinstance(row, dict) and row.get("path") == path for row in manifest):
+            return _ReconcileOutcome(_ReconcileKind.PENDING)
+        rows = request_presigned_urls(
+            project_id,
+            [{"verb": "GET", "path": path}],
+            session=session,
+        )
+        urls, _skipped = urls_by_path(rows, "GET")
+        url = urls.get(path)
+        if url is None:
+            return _ReconcileOutcome(_ReconcileKind.PENDING)
+        fetched = fetch_via_presigned_url(url, session=session)
+    except (AuthRefreshError, PresignError):
+        return _ReconcileOutcome(_ReconcileKind.PENDING)
+    if not fetched.etag:
+        return _ReconcileOutcome(_ReconcileKind.PENDING)
+    if hashlib.sha256(fetched.body).hexdigest() != payload_sha:
+        return _ReconcileOutcome(_ReconcileKind.DIVERGENT)
+    return _ReconcileOutcome(_ReconcileKind.VERIFIED, fetched.etag)
+
+
+def _checkpoint(
+    store_path: Path,
+    state: SyncState,
+    path: str,
+    payload_sha: str,
+    etag: str,
+) -> bool:
+    from nauro.sync.state import save_state, update_file_state
+
+    update_file_state(state, path, payload_sha, etag)
+    try:
+        save_state(store_path, state)
+    except OSError:
+        logger.exception("Failed to checkpoint cloud push state for %s", path)
+        return False
+    return True
 
 
 __all__ = [
     "OversizedBrief",
     "PushCandidate",
     "PushPlan",
+    "PushReport",
     "plan_push",
     "push_changed_files",
     "push_store_to_cloud",

--- a/packages/nauro/src/nauro/sync/remote.py
+++ b/packages/nauro/src/nauro/sync/remote.py
@@ -1,47 +1,134 @@
-"""Remote sync client — manifest + presign endpoints against the MCP server.
+"""Typed HTTP boundary for legacy manifest and presign sync."""
 
-The CLI obtains short-lived presigned URLs from the server and does the
-bulk transfer directly against S3. Auth is the Auth0 bearer; the
-``with_token_refresh`` wrapper handles 401-and-retry transparently.
-"""
+from __future__ import annotations
 
-import logging
 import os
-from pathlib import Path
+import ssl
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from enum import Enum
 from typing import Any
+from urllib.parse import urlsplit
 
 import httpx
 from pydantic import BaseModel, ConfigDict, ValidationError
 
-from nauro.cli.commands.auth import (
-    DEFAULT_API_URL,
-    with_token_refresh,
-)
+from nauro.cli.commands.auth import DEFAULT_API_URL, with_token_refresh
 from nauro.store.config import load_config
-
-logger = logging.getLogger("nauro.sync")
 
 _DEFAULT_API_TIMEOUT = 15.0
 _DEFAULT_TRANSFER_TIMEOUT = 60.0
+_CLIENT_LIMITS = httpx.Limits(max_connections=10, max_keepalive_connections=10)
+_TRANSIENT_STATUSES = frozenset({429, 500, 502, 503, 504})
+_EXPIRED_STATUS = 403
 
 
-# Enough of an error body to name the fault, never enough to flood a terminal.
-_BODY_EXCERPT_LIMIT = 200
+class TransferOperation(str, Enum):
+    MANIFEST = "manifest"
+    PRESIGN = "presign"
+    GET = "GET"
+    PUT = "PUT"
+
+
+class TransportFaultKind(str, Enum):
+    INVALID_URL = "invalid-url"
+    UNSUPPORTED_PROTOCOL = "unsupported-protocol"
+    POOL_TIMEOUT = "pool-timeout"
+    CONNECT_TIMEOUT = "connect-timeout"
+    CONNECT_ERROR = "connect-error"
+    TLS_CERTIFICATE = "tls-certificate"
+    WRITE_TIMEOUT = "write-timeout"
+    READ_TIMEOUT = "read-timeout"
+    WRITE_ERROR = "write-error"
+    READ_ERROR = "read-error"
+    REMOTE_PROTOCOL = "remote-protocol-error"
+    HTTP_STATUS = "http-status"
+    INVALID_RESPONSE = "invalid-response"
+    ORIGIN_ABORTED = "origin-aborted"
+    UNKNOWN = "unknown"
+
+
+class RetryClassification(str, Enum):
+    TRANSIENT = "transient"
+    EXPIRED_CANDIDATE = "expired-candidate"
+    PERMANENT = "permanent"
+
+
+class WriteOutcome(str, Enum):
+    NOT_APPLICABLE = "not-applicable"
+    NOT_WRITTEN = "not-written"
+    AMBIGUOUS = "ambiguous"
+    WRITTEN_UNVERIFIED = "written-unverified"
+    VERIFIED = "verified"
+
+
+@dataclass(frozen=True)
+class FaultClassification:
+    kind: TransportFaultKind
+    retry: RetryClassification
+    write_outcome: WriteOutcome
 
 
 class PresignError(Exception):
-    """Raised for unrecoverable failures hitting the manifest/presign endpoints."""
+    """Base class for the legacy sync HTTP boundary."""
 
 
-class PresignTransferError(PresignError):
-    """A presigned object transfer failed against object storage.
+class TransferBoundaryError(PresignError):
+    """One sanitized manifest, presign, GET, or PUT boundary failure."""
 
-    Subclasses :class:`PresignError`, so every existing handler keeps catching
-    it, and carries the two facts a retry policy needs: the HTTP status when
-    the server answered, and whether the request failed at the transport layer
-    before any response existed. :mod:`nauro.sync.transfer` owns the policy
-    that reads them; this class states facts only.
-    """
+    def __init__(
+        self,
+        *,
+        operation: str | TransferOperation,
+        origin: str,
+        kind: TransportFaultKind,
+        retry: RetryClassification,
+        write_outcome: WriteOutcome,
+        status: int | None = None,
+    ) -> None:
+        self.operation = TransferOperation(operation)
+        self.origin = origin
+        self.status = status
+        self.kind = kind
+        self.retry = retry
+        self.write_outcome = write_outcome
+        status_text = f", HTTP {status}" if status is not None else ""
+        super().__init__(
+            f"{self.operation.value} failed at {origin}{status_text}: "
+            f"{kind.value}, retry={retry.value}, write={write_outcome.value}"
+        )
+
+    @property
+    def transport(self) -> bool:
+        return self.status is None and self.kind not in {
+            TransportFaultKind.INVALID_RESPONSE,
+            TransportFaultKind.INVALID_URL,
+            TransportFaultKind.UNSUPPORTED_PROTOCOL,
+        }
+
+    @property
+    def detail(self) -> str:
+        return self.kind.value
+
+    @property
+    def aborts_origin(self) -> bool:
+        return self.kind in {
+            TransportFaultKind.TLS_CERTIFICATE,
+            TransportFaultKind.ORIGIN_ABORTED,
+        } or (
+            self.kind
+            in {
+                TransportFaultKind.HTTP_STATUS,
+                TransportFaultKind.INVALID_RESPONSE,
+            }
+            and self.retry is RetryClassification.PERMANENT
+            and self.operation in {TransferOperation.MANIFEST, TransferOperation.PRESIGN}
+        )
+
+
+class PresignTransferError(TransferBoundaryError):
+    """Compatibility constructor for callers that used the old GET error."""
 
     def __init__(
         self,
@@ -51,124 +138,412 @@ class PresignTransferError(PresignError):
         transport: bool = False,
         detail: str = "",
     ) -> None:
-        answered = f"({status})" if status is not None else "(no response)"
-        super().__init__(f"{action} failed {answered}{f': {detail}' if detail else ''}")
-        self.status = status
-        self.transport = transport
-        self.detail = detail
+        del detail
+        operation = TransferOperation.PUT if "PUT" in action else TransferOperation.GET
+        if status is not None:
+            classification = classify_status(status, operation=operation)
+        elif transport:
+            classification = FaultClassification(
+                TransportFaultKind.CONNECT_ERROR,
+                RetryClassification.TRANSIENT,
+                WriteOutcome.NOT_WRITTEN
+                if operation is TransferOperation.PUT
+                else WriteOutcome.NOT_APPLICABLE,
+            )
+        else:
+            classification = FaultClassification(
+                TransportFaultKind.INVALID_URL,
+                RetryClassification.PERMANENT,
+                WriteOutcome.NOT_WRITTEN
+                if operation is TransferOperation.PUT
+                else WriteOutcome.NOT_APPLICABLE,
+            )
+        super().__init__(
+            operation=operation,
+            origin="invalid-origin",
+            status=status,
+            kind=classification.kind,
+            retry=classification.retry,
+            write_outcome=classification.write_outcome,
+        )
+
+
+@dataclass(frozen=True)
+class FetchedObject:
+    body: bytes
+    etag: str
+
+
+@dataclass(frozen=True)
+class PutResult:
+    etag: str
+    outcome: WriteOutcome
+
+
+def _has_certificate_error(error: BaseException) -> bool:
+    seen: set[int] = set()
+    pending: list[BaseException] = [error]
+    while pending:
+        current = pending.pop()
+        identity = id(current)
+        if identity in seen:
+            continue
+        seen.add(identity)
+        if isinstance(current, ssl.SSLCertVerificationError):
+            return True
+        if current.__cause__ is not None:
+            pending.append(current.__cause__)
+        if current.__context__ is not None:
+            pending.append(current.__context__)
+    return False
+
+
+def _write_outcome(operation: str | TransferOperation, outcome: WriteOutcome) -> WriteOutcome:
+    if TransferOperation(operation) is TransferOperation.PUT:
+        return outcome
+    return WriteOutcome.NOT_APPLICABLE
+
+
+def classify_exception(
+    error: BaseException, *, operation: str | TransferOperation
+) -> FaultClassification:
+    """Classify retry value separately from PUT outcome evidence."""
+    if _has_certificate_error(error):
+        return FaultClassification(
+            TransportFaultKind.TLS_CERTIFICATE,
+            RetryClassification.PERMANENT,
+            _write_outcome(operation, WriteOutcome.NOT_WRITTEN),
+        )
+    if isinstance(error, httpx.InvalidURL):
+        kind = TransportFaultKind.INVALID_URL
+        retry = RetryClassification.PERMANENT
+        outcome = WriteOutcome.NOT_WRITTEN
+    elif isinstance(error, httpx.UnsupportedProtocol):
+        kind = TransportFaultKind.UNSUPPORTED_PROTOCOL
+        retry = RetryClassification.PERMANENT
+        outcome = WriteOutcome.NOT_WRITTEN
+    elif isinstance(error, httpx.PoolTimeout):
+        kind = TransportFaultKind.POOL_TIMEOUT
+        retry = RetryClassification.TRANSIENT
+        outcome = WriteOutcome.NOT_WRITTEN
+    elif isinstance(error, httpx.ConnectTimeout):
+        kind = TransportFaultKind.CONNECT_TIMEOUT
+        retry = RetryClassification.TRANSIENT
+        outcome = WriteOutcome.NOT_WRITTEN
+    elif isinstance(error, httpx.ConnectError):
+        kind = TransportFaultKind.CONNECT_ERROR
+        retry = RetryClassification.TRANSIENT
+        outcome = WriteOutcome.NOT_WRITTEN
+    elif isinstance(error, httpx.WriteTimeout):
+        kind = TransportFaultKind.WRITE_TIMEOUT
+        retry = RetryClassification.TRANSIENT
+        outcome = WriteOutcome.AMBIGUOUS
+    elif isinstance(error, httpx.ReadTimeout):
+        kind = TransportFaultKind.READ_TIMEOUT
+        retry = RetryClassification.TRANSIENT
+        outcome = WriteOutcome.AMBIGUOUS
+    elif isinstance(error, httpx.WriteError):
+        kind = TransportFaultKind.WRITE_ERROR
+        retry = RetryClassification.TRANSIENT
+        outcome = WriteOutcome.AMBIGUOUS
+    elif isinstance(error, httpx.ReadError):
+        kind = TransportFaultKind.READ_ERROR
+        retry = RetryClassification.TRANSIENT
+        outcome = WriteOutcome.AMBIGUOUS
+    elif isinstance(error, httpx.RemoteProtocolError):
+        kind = TransportFaultKind.REMOTE_PROTOCOL
+        retry = RetryClassification.TRANSIENT
+        outcome = WriteOutcome.AMBIGUOUS
+    else:
+        kind = TransportFaultKind.UNKNOWN
+        retry = RetryClassification.PERMANENT
+        outcome = WriteOutcome.AMBIGUOUS
+    return FaultClassification(kind, retry, _write_outcome(operation, outcome))
+
+
+def classify_status(status: int, *, operation: str | TransferOperation) -> FaultClassification:
+    operation = TransferOperation(operation)
+    retry = (
+        RetryClassification.EXPIRED_CANDIDATE
+        if status == _EXPIRED_STATUS and operation in {TransferOperation.GET, TransferOperation.PUT}
+        else RetryClassification.TRANSIENT
+        if status in _TRANSIENT_STATUSES
+        else RetryClassification.PERMANENT
+    )
+    if operation is not TransferOperation.PUT:
+        outcome = WriteOutcome.NOT_APPLICABLE
+    elif 400 <= status < 500:
+        outcome = WriteOutcome.NOT_WRITTEN
+    else:
+        outcome = WriteOutcome.AMBIGUOUS
+    return FaultClassification(TransportFaultKind.HTTP_STATUS, retry, outcome)
+
+
+def canonical_origin(url: str) -> str:
+    """Return scheme, lowercased host, and effective port without URL secrets."""
+    try:
+        parsed = urlsplit(url)
+        scheme = parsed.scheme.lower()
+        host = parsed.hostname
+        if not scheme or host is None:
+            return "invalid-origin"
+        port = parsed.port
+    except (TypeError, ValueError):
+        return "invalid-origin"
+    if port is None:
+        port = 443 if scheme == "https" else 80 if scheme == "http" else None
+    return f"{scheme}://{host.lower()}{f':{port}' if port is not None else ''}"
+
+
+class TransferSession:
+    """One bounded pooled HTTP client plus operation-scoped origin circuits."""
+
+    def __init__(self, client: httpx.Client | None = None) -> None:
+        self._owned = client is None
+        self.client = client or httpx.Client(limits=_CLIENT_LIMITS)
+        self._tripped_origins: set[str] = set()
+
+    def __enter__(self) -> TransferSession:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        self.close()
+
+    def close(self) -> None:
+        if self._owned:
+            self.client.close()
+
+    def is_tripped(self, url_or_origin: str) -> bool:
+        origin = (
+            url_or_origin
+            if "://" in url_or_origin and "/" not in url_or_origin.partition("://")[2]
+            else canonical_origin(url_or_origin)
+        )
+        return origin in self._tripped_origins
+
+    def trip(self, url: str) -> None:
+        self._tripped_origins.add(canonical_origin(url))
+
+    def guard(self, url: str, operation: str | TransferOperation) -> str:
+        origin = canonical_origin(url)
+        if origin in self._tripped_origins:
+            raise TransferBoundaryError(
+                operation=operation,
+                origin=origin,
+                kind=TransportFaultKind.ORIGIN_ABORTED,
+                retry=RetryClassification.PERMANENT,
+                write_outcome=_write_outcome(operation, WriteOutcome.NOT_WRITTEN),
+            )
+        return origin
+
+    def boundary_error(
+        self, url: str, operation: str | TransferOperation, error: BaseException
+    ) -> TransferBoundaryError:
+        origin = canonical_origin(url)
+        classification = classify_exception(error, operation=operation)
+        if classification.kind is TransportFaultKind.TLS_CERTIFICATE:
+            self.trip(url)
+        return TransferBoundaryError(
+            operation=operation,
+            origin=origin,
+            kind=classification.kind,
+            retry=classification.retry,
+            write_outcome=classification.write_outcome,
+        )
+
+
+@contextmanager
+def operation_session(session: TransferSession | None = None) -> Iterator[TransferSession]:
+    if session is not None:
+        yield session
+        return
+    with TransferSession() as owned:
+        yield owned
 
 
 def resolve_api_url() -> str:
-    """Resolve the remote MCP server base URL.
-
-    Precedence: ``NAURO_API_URL`` env var, then ``api_url`` in user config,
-    then the public default. Trailing slash stripped on every branch so
-    callers can append ``/path`` without doubling the separator.
-    """
     env_url = os.environ.get("NAURO_API_URL") or ""
     config_url = str(load_config().get("api_url") or "")
     return (env_url or config_url or DEFAULT_API_URL).rstrip("/")
 
 
-# The server batches up to 200 ops per /sync/presign call (see mcp-server
-# _PRESIGN_OPS_BATCH_LIMIT); the CLI chunks larger diffs to match.
 PRESIGN_BATCH_LIMIT = 200
 
 
-def fetch_manifest(project_id: str) -> list[dict]:
-    """Return every server-side file entry for ``project_id``.
+def _get(session: TransferSession, url: str, operation: TransferOperation, **kwargs: Any):
+    session.guard(url, operation)
+    try:
+        return session.client.get(url, **kwargs)
+    except Exception as exc:
+        error = session.boundary_error(url, operation, exc)
+    raise error from None
 
-    Each entry mirrors the server payload: ``{"path", "etag", "size",
-    "last_modified"}`` where ``path`` is project-root relative.
-    Pagination is collapsed for the caller — the cursor stays internal.
-    """
+
+def _post(session: TransferSession, url: str, operation: TransferOperation, **kwargs: Any):
+    session.guard(url, operation)
+    try:
+        return session.client.post(url, **kwargs)
+    except Exception as exc:
+        error = session.boundary_error(url, operation, exc)
+    raise error from None
+
+
+def _put(session: TransferSession, url: str, **kwargs: Any):
+    session.guard(url, TransferOperation.PUT)
+    try:
+        return session.client.put(url, **kwargs)
+    except Exception as exc:
+        error = session.boundary_error(url, TransferOperation.PUT, exc)
+    raise error from None
+
+
+def _status_error(
+    session: TransferSession,
+    url: str,
+    operation: TransferOperation,
+    status: int,
+) -> TransferBoundaryError:
+    classification = classify_status(status, operation=operation)
+    error = TransferBoundaryError(
+        operation=operation,
+        origin=canonical_origin(url),
+        status=status,
+        kind=classification.kind,
+        retry=classification.retry,
+        write_outcome=classification.write_outcome,
+    )
+    if error.aborts_origin:
+        session.trip(url)
+    return error
+
+
+def _invalid_response(
+    session: TransferSession,
+    url: str,
+    operation: TransferOperation,
+    status: int,
+) -> TransferBoundaryError:
+    error = TransferBoundaryError(
+        operation=operation,
+        origin=canonical_origin(url),
+        status=status,
+        kind=TransportFaultKind.INVALID_RESPONSE,
+        retry=RetryClassification.PERMANENT,
+        write_outcome=_write_outcome(operation, WriteOutcome.AMBIGUOUS),
+    )
+    if error.aborts_origin:
+        session.trip(url)
+    return error
+
+
+def fetch_manifest(project_id: str, *, session: TransferSession | None = None) -> list[dict]:
     api_url = resolve_api_url()
+    endpoint = f"{api_url}/sync/manifest"
     files: list[dict] = []
     cursor: str | None = None
+    with operation_session(session) as active:
+        while True:
+            params: dict[str, str] = {"project_id": project_id}
+            if cursor:
+                params["cursor"] = cursor
 
-    while True:
-        params: dict[str, str] = {"project_id": project_id}
-        if cursor:
-            params["cursor"] = cursor
+            def call(token: str, params=params) -> httpx.Response:
+                return _get(
+                    active,
+                    endpoint,
+                    TransferOperation.MANIFEST,
+                    params=params,
+                    headers={"Authorization": f"Bearer {token}"},
+                    timeout=_DEFAULT_API_TIMEOUT,
+                )
 
-        def _call(token: str, params=params) -> httpx.Response:
-            return httpx.get(
-                f"{api_url}/sync/manifest",
-                params=params,
-                headers={"Authorization": f"Bearer {token}"},
-                timeout=_DEFAULT_API_TIMEOUT,
-            )
-
-        response = with_token_refresh(_call)
-        if response.status_code != 200:
-            raise PresignError(
-                f"GET /sync/manifest failed ({response.status_code}): {response.text}"
-            )
-
-        try:
-            body = response.json()
-        except ValueError as exc:
-            raise PresignError(f"Manifest response was not JSON: {exc}") from exc
-
-        page_files = body.get("files") if isinstance(body, dict) else None
-        if not isinstance(page_files, list):
-            raise PresignError(f"Unexpected manifest shape: {body!r}")
-        files.extend(page_files)
-
-        next_cursor = body.get("next_cursor") if isinstance(body, dict) else None
-        if not next_cursor:
-            return files
-        cursor = str(next_cursor)
+            response = with_token_refresh(call, client=active.client)
+            if response.status_code != 200:
+                raise _status_error(
+                    active,
+                    endpoint,
+                    TransferOperation.MANIFEST,
+                    response.status_code,
+                )
+            try:
+                body = response.json()
+            except ValueError:
+                raise _invalid_response(
+                    active,
+                    endpoint,
+                    TransferOperation.MANIFEST,
+                    response.status_code,
+                ) from None
+            page_files = body.get("files") if isinstance(body, dict) else None
+            if not isinstance(page_files, list):
+                raise _invalid_response(
+                    active,
+                    endpoint,
+                    TransferOperation.MANIFEST,
+                    response.status_code,
+                )
+            files.extend(page_files)
+            next_cursor = body.get("next_cursor") if isinstance(body, dict) else None
+            if not next_cursor:
+                return files
+            cursor = str(next_cursor)
 
 
 def request_presigned_urls(
-    project_id: str, operations: list[dict[str, str]]
+    project_id: str,
+    operations: list[dict[str, str]],
+    *,
+    session: TransferSession | None = None,
 ) -> list[dict[str, Any]]:
-    """Mint presigned URLs for a batch of GET/PUT operations.
-
-    ``operations`` items are ``{"verb": "GET"|"PUT", "path": "..."}``. The
-    server caps each request at 200 ops; this helper chunks transparently
-    so the caller can pass an arbitrary diff.
-    """
     if not operations:
         return []
-
     api_url = resolve_api_url()
+    endpoint = f"{api_url}/sync/presign"
     all_urls: list[dict[str, Any]] = []
+    with operation_session(session) as active:
+        for start in range(0, len(operations), PRESIGN_BATCH_LIMIT):
+            chunk = operations[start : start + PRESIGN_BATCH_LIMIT]
 
-    for start in range(0, len(operations), PRESIGN_BATCH_LIMIT):
-        chunk = operations[start : start + PRESIGN_BATCH_LIMIT]
+            def call(token: str, chunk=chunk) -> httpx.Response:
+                return _post(
+                    active,
+                    endpoint,
+                    TransferOperation.PRESIGN,
+                    json={"project_id": project_id, "operations": chunk},
+                    headers={"Authorization": f"Bearer {token}"},
+                    timeout=_DEFAULT_API_TIMEOUT,
+                )
 
-        def _call(token: str, chunk=chunk) -> httpx.Response:
-            return httpx.post(
-                f"{api_url}/sync/presign",
-                json={"project_id": project_id, "operations": chunk},
-                headers={"Authorization": f"Bearer {token}"},
-                timeout=_DEFAULT_API_TIMEOUT,
-            )
-
-        response = with_token_refresh(_call)
-        if response.status_code != 200:
-            raise PresignError(
-                f"POST /sync/presign failed ({response.status_code}): {response.text}"
-            )
-
-        try:
-            body = response.json()
-        except ValueError as exc:
-            raise PresignError(f"Presign response was not JSON: {exc}") from exc
-
-        urls = body.get("urls") if isinstance(body, dict) else None
-        if not isinstance(urls, list):
-            raise PresignError(f"Unexpected presign shape: {body!r}")
-        all_urls.extend(urls)
-
+            response = with_token_refresh(call, client=active.client)
+            if response.status_code != 200:
+                raise _status_error(
+                    active,
+                    endpoint,
+                    TransferOperation.PRESIGN,
+                    response.status_code,
+                )
+            try:
+                body = response.json()
+            except ValueError:
+                raise _invalid_response(
+                    active,
+                    endpoint,
+                    TransferOperation.PRESIGN,
+                    response.status_code,
+                ) from None
+            urls = body.get("urls") if isinstance(body, dict) else None
+            if not isinstance(urls, list):
+                raise _invalid_response(
+                    active,
+                    endpoint,
+                    TransferOperation.PRESIGN,
+                    response.status_code,
+                )
+            all_urls.extend(urls)
     return all_urls
 
 
 class PresignedUrl(BaseModel):
-    """One minted URL from ``/sync/presign``, as far as the callers read it."""
-
     model_config = ConfigDict(extra="ignore")
 
     verb: str
@@ -176,73 +551,73 @@ class PresignedUrl(BaseModel):
     url: str
 
 
-def urls_by_path(entries: list[Any], verb: str) -> tuple[dict[str, str], tuple[str, ...]]:
-    """Index a presign response by store path for one verb.
+def _unreadable_entry(entry: Any) -> str:
+    if not isinstance(entry, dict):
+        return f"entry of type {type(entry).__name__}"
+    return f"entry verb={entry.get('verb')!r}, path={entry.get('path')!r}"
 
-    Returns the usable URLs and the entries that could not be read, which each
-    caller reports in its own idiom. Malformed rows are skipped rather than
-    fatal: a partial batch still transfers what it can, and the caller already
-    handles a short response.
-    """
+
+def urls_by_path(entries: list[Any], verb: str) -> tuple[dict[str, str], tuple[str, ...]]:
     usable: dict[str, str] = {}
     skipped: list[str] = []
     for entry in entries:
         try:
             parsed = PresignedUrl.model_validate(entry)
         except ValidationError:
-            skipped.append(repr(entry))
+            skipped.append(_unreadable_entry(entry))
             continue
         if parsed.verb == verb:
             usable[parsed.path] = parsed.url
     return usable, tuple(skipped)
 
 
-def _body_excerpt(response: httpx.Response) -> str:
-    """Collapse an error body to one short line."""
-    return " ".join(response.text.split())[:_BODY_EXCERPT_LIMIT]
-
-
-def fetch_via_presigned_url(url: str) -> bytes:
-    """GET ``url`` and return the body bytes (no local write).
-
-    Every failure surfaces as :class:`PresignTransferError`, transport faults
-    included: a caller guarding against ``PresignError`` must not have a bare
-    ``httpx.ConnectError`` escape past it, and a retry policy must classify on
-    the status rather than on the message text.
-    """
-    try:
-        response = httpx.get(url, timeout=_DEFAULT_TRANSFER_TIMEOUT)
-    except httpx.TransportError as exc:
-        # UnsupportedProtocol sits in the transport hierarchy but is not a
-        # transport fault: the client refused to send a URL it cannot read, so
-        # nothing was attempted and a retry cannot change the outcome.
-        attempted = not isinstance(exc, httpx.UnsupportedProtocol)
-        raise PresignTransferError("Presigned GET", transport=attempted, detail=str(exc)) from exc
-    except (httpx.HTTPError, httpx.InvalidURL) as exc:
-        raise PresignTransferError("Presigned GET", detail=str(exc)) from exc
-    if response.status_code != 200:
-        raise PresignTransferError(
-            "Presigned GET", status=response.status_code, detail=_body_excerpt(response)
+def fetch_via_presigned_url(url: str, *, session: TransferSession | None = None) -> FetchedObject:
+    with operation_session(session) as active:
+        response = _get(
+            active,
+            url,
+            TransferOperation.GET,
+            timeout=_DEFAULT_TRANSFER_TIMEOUT,
         )
-    return response.content
+    if response.status_code != 200:
+        raise _status_error(active, url, TransferOperation.GET, response.status_code)
+    return FetchedObject(response.content, response.headers.get("ETag", "").strip())
 
 
-def put_via_presigned_url(url: str, local_path: Path) -> str:
-    """PUT the bytes at ``local_path`` to ``url``. Returns the new ETag."""
-    data = local_path.read_bytes()
-    response = httpx.put(url, content=data, timeout=_DEFAULT_TRANSFER_TIMEOUT)
-    if response.status_code not in (200, 204):
-        raise PresignError(f"Presigned PUT failed ({response.status_code}) for {local_path}")
-    return response.headers.get("ETag", "")
+def put_via_presigned_url(
+    url: str, payload: bytes, *, session: TransferSession | None = None
+) -> PutResult:
+    with operation_session(session) as active:
+        response = _put(active, url, content=payload, timeout=_DEFAULT_TRANSFER_TIMEOUT)
+    if not 200 <= response.status_code < 300:
+        raise _status_error(active, url, TransferOperation.PUT, response.status_code)
+    etag = response.headers.get("ETag", "").strip()
+    return PutResult(
+        etag=etag,
+        outcome=WriteOutcome.VERIFIED if etag else WriteOutcome.WRITTEN_UNVERIFIED,
+    )
 
 
 __all__ = [
+    "FaultClassification",
+    "FetchedObject",
     "PRESIGN_BATCH_LIMIT",
     "PresignError",
     "PresignTransferError",
     "PresignedUrl",
+    "PutResult",
+    "RetryClassification",
+    "TransferBoundaryError",
+    "TransferOperation",
+    "TransferSession",
+    "TransportFaultKind",
+    "WriteOutcome",
+    "canonical_origin",
+    "classify_exception",
+    "classify_status",
     "fetch_manifest",
     "fetch_via_presigned_url",
+    "operation_session",
     "put_via_presigned_url",
     "request_presigned_urls",
     "resolve_api_url",

--- a/packages/nauro/src/nauro/sync/transfer.py
+++ b/packages/nauro/src/nauro/sync/transfer.py
@@ -17,18 +17,13 @@ import random
 import time
 from collections.abc import Callable
 from enum import Enum
-from typing import Protocol
+from typing import Protocol, TypeVar
 
-from nauro.sync.remote import PresignError, PresignTransferError
-
-# Object storage and the API edge answer overload and their own faults with
-# these; every other status names something the same request will not fix.
-_TRANSIENT_STATUSES = frozenset({429, 500, 502, 503, 504})
-
-# A presigned URL past its TTL answers 403, and so does a URL the caller was
-# never entitled to. The response cannot tell them apart, so the first 403
-# buys one fresh mint and a second 403 settles which one it was.
-_EXPIRED_STATUS = 403
+from nauro.sync.remote import (
+    PresignError,
+    RetryClassification,
+    TransferBoundaryError,
+)
 
 # Four attempts spans a few seconds of packet loss without holding a restore
 # open against a network that is simply down.
@@ -83,13 +78,11 @@ class UrlSource(Protocol):
 
 def classify_fault(error: PresignError) -> TransferFault:
     """Judge whether a failed download is worth another attempt."""
-    if not isinstance(error, PresignTransferError):
+    if not isinstance(error, TransferBoundaryError):
         return TransferFault.PERMANENT
-    if error.status is None:
-        return TransferFault.TRANSIENT if error.transport else TransferFault.PERMANENT
-    if error.status in _TRANSIENT_STATUSES:
+    if error.retry is RetryClassification.TRANSIENT:
         return TransferFault.TRANSIENT
-    if error.status == _EXPIRED_STATUS:
+    if error.retry is RetryClassification.EXPIRED_CANDIDATE:
         return TransferFault.EXPIRED_CANDIDATE
     return TransferFault.PERMANENT
 
@@ -110,7 +103,10 @@ def pause(seconds: float) -> None:
     time.sleep(seconds)
 
 
-def download_with_retry(path: str, urls: UrlSource, fetch: Callable[[str], bytes]) -> bytes:
+_T = TypeVar("_T")
+
+
+def download_with_retry(path: str, urls: UrlSource, fetch: Callable[[str], _T]) -> _T:
     """Download one object, retrying transient faults and one stale URL.
 
     A re-mint is a credential refresh, not a network fault, so it resets the

--- a/packages/nauro/tests/test_link_cloud.py
+++ b/packages/nauro/tests/test_link_cloud.py
@@ -106,8 +106,8 @@ def test_link_cloud_promotes_and_pushes_in_one_command(tmp_path, monkeypatch):
 
     with (
         patch.object(cloud_projects.httpx, "request", side_effect=_create_response()),
-        patch.object(remote.httpx, "post", side_effect=_presign_post),
-        patch.object(remote.httpx, "put", return_value=_ok_put()) as mock_put,
+        patch.object(remote.httpx.Client, "post", side_effect=_presign_post),
+        patch.object(remote.httpx.Client, "put", return_value=_ok_put()) as mock_put,
     ):
         result = runner.invoke(app, ["link", "--cloud"])
     assert result.exit_code == 0, result.output
@@ -154,8 +154,8 @@ def test_link_cloud_rekeys_external_store_binding(tmp_path, monkeypatch):
 
     with (
         patch.object(cloud_projects.httpx, "request", side_effect=_create_response()),
-        patch.object(remote.httpx, "post", side_effect=_presign_post),
-        patch.object(remote.httpx, "put", return_value=_ok_put()),
+        patch.object(remote.httpx.Client, "post", side_effect=_presign_post),
+        patch.object(remote.httpx.Client, "put", return_value=_ok_put()),
     ):
         result = runner.invoke(app, ["link", "--cloud"])
 
@@ -202,6 +202,27 @@ def test_link_cloud_push_failure_keeps_rekey(tmp_path, monkeypatch):
     assert cfg["id"] == CLOUD_PID
 
 
+def test_link_cloud_incomplete_push_warns_and_exits_zero(tmp_path, monkeypatch):
+    from nauro.sync.push import PushReport
+
+    _seed_token(monkeypatch, tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("NAURO_API_URL", "https://example.test")
+    assert runner.invoke(app, ["init", "linkproj"]).exit_code == 0
+    report = PushReport(planned=("stack.md",), ambiguous=("stack.md",))
+
+    with (
+        patch.object(cloud_projects.httpx, "request", side_effect=_create_response()),
+        patch("nauro.cli.commands.link.push_changed_files", return_value=report),
+    ):
+        result = runner.invoke(app, ["link", "--cloud"])
+
+    assert result.exit_code == 0, result.output
+    assert "initial cloud push was incomplete" in result.output
+    assert "nauro sync" in result.output
+    assert registry.get_project_v2(CLOUD_PID)["mode"] == "cloud"
+
+
 def test_link_cloud_on_already_cloud_repo_errors(tmp_path, monkeypatch):
     """A cloud-mode repo cannot be linked again."""
     _seed_token(monkeypatch, tmp_path)
@@ -238,8 +259,8 @@ def test_link_cloud_succeeds_with_only_auth_token(tmp_path, monkeypatch):
         patch.object(
             cloud_projects.httpx, "request", side_effect=_create_response("auth-only-link")
         ),
-        patch.object(remote.httpx, "post", side_effect=_presign_post),
-        patch.object(remote.httpx, "put", return_value=_ok_put()),
+        patch.object(remote.httpx.Client, "post", side_effect=_presign_post),
+        patch.object(remote.httpx.Client, "put", return_value=_ok_put()),
     ):
         result = runner.invoke(app, ["link", "--cloud"])
 
@@ -271,8 +292,8 @@ def test_link_cloud_warns_for_repo_config_git_hygiene(
 
     with (
         patch.object(cloud_projects.httpx, "request", side_effect=_create_response()),
-        patch.object(remote.httpx, "post", side_effect=_presign_post),
-        patch.object(remote.httpx, "put", return_value=_ok_put()),
+        patch.object(remote.httpx.Client, "post", side_effect=_presign_post),
+        patch.object(remote.httpx.Client, "put", return_value=_ok_put()),
     ):
         result = runner.invoke(app, ["link", "--cloud"])
 

--- a/packages/nauro/tests/test_post_commit.py
+++ b/packages/nauro/tests/test_post_commit.py
@@ -19,6 +19,7 @@ from nauro.mcp.tools import tool_flag_question, tool_propose_decision, tool_upda
 from nauro.store.journal import read_events
 from nauro.store.post_commit import AncillaryStep, run_post_commit
 from nauro.store.registry import register_project_v2
+from nauro.sync.push import PushReport
 from nauro.templates.scaffolds import scaffold_project_store
 
 SNAPSHOTS = "snapshots"
@@ -325,3 +326,20 @@ def test_a_clean_run_adds_no_assessment_to_the_short_envelopes(
 
     assert "assessment" not in flagged
     assert "assessment" not in updated
+
+
+def test_an_incomplete_nonraising_push_reaches_the_mcp_assessment(
+    adapter_store: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    report = PushReport(
+        planned=("stack.md",),
+        ambiguous=("stack.md",),
+    )
+    monkeypatch.setattr(mcp_tools, "_try_push", lambda _store: report)
+
+    envelope = tool_update_state(adapter_store, delta="Shipped the caching layer.")
+
+    assert envelope["status"] == "ok"
+    assert "cloud push failed" in envelope["assessment"]
+    assert "pending observation" in envelope["assessment"]
+    assert "stack.md" not in envelope["assessment"]

--- a/packages/nauro/tests/test_recovery.py
+++ b/packages/nauro/tests/test_recovery.py
@@ -11,6 +11,7 @@ from nauro.store import recovery
 from nauro.store.recovery import RecoveryError, bind_local_store, restore_cloud_store
 from nauro.store.registry import get_project_v2, get_store_path_v2
 from nauro.store.repo_config import save_repo_config
+from nauro.sync.remote import FetchedObject
 from nauro.sync.state import SYNC_STATE_FILE
 from nauro.templates.scaffolds import scaffold_project_store
 
@@ -50,11 +51,11 @@ def _mock_remote(monkeypatch, files: dict[str, bytes]) -> None:
         }
         for path, content in sorted(files.items())
     ]
-    monkeypatch.setattr(recovery, "fetch_manifest", lambda _pid: manifest)
+    monkeypatch.setattr(recovery, "fetch_manifest", lambda _pid, **_kwargs: manifest)
     monkeypatch.setattr(
         recovery,
         "request_presigned_urls",
-        lambda _pid, operations: [
+        lambda _pid, operations, **_kwargs: [
             {"verb": "GET", "path": op["path"], "url": f"memory://{op['path']}"}
             for op in operations
         ],
@@ -62,7 +63,10 @@ def _mock_remote(monkeypatch, files: dict[str, bytes]) -> None:
     monkeypatch.setattr(
         recovery,
         "fetch_via_presigned_url",
-        lambda url: files[url.removeprefix("memory://")],
+        lambda url, **_kwargs: FetchedObject(
+            body=files[url.removeprefix("memory://")],
+            etag=f'"{hashlib.md5(files[url.removeprefix("memory://")]).hexdigest()}"',
+        ),
     )
 
 
@@ -109,7 +113,7 @@ def test_restore_cloud_store_refuses_nonempty_destination_before_network(tmp_pat
     destination.mkdir()
     (destination / "keep.txt").write_text("keep")
 
-    def explode(_pid):
+    def explode(_pid, **_kwargs):
         raise AssertionError("network must not run")
 
     monkeypatch.setattr(recovery, "fetch_manifest", explode)
@@ -132,7 +136,7 @@ def test_restore_cloud_store_installs_nothing_on_hash_mismatch(tmp_path, monkeyp
     _mock_remote(monkeypatch, files)
     manifest = recovery.fetch_manifest(PID)
     manifest[0]["sha256"] = "0" * 64
-    monkeypatch.setattr(recovery, "fetch_manifest", lambda _pid: manifest)
+    monkeypatch.setattr(recovery, "fetch_manifest", lambda _pid, **_kwargs: manifest)
     destination = tmp_path / "projects" / PID
 
     with pytest.raises(RecoveryError, match="hash"):
@@ -156,7 +160,7 @@ def test_restore_cloud_store_skips_hash_check_for_opaque_etag(tmp_path, monkeypa
     _mock_remote(monkeypatch, files)
     manifest = recovery.fetch_manifest(PID)
     manifest[0]["etag"] = '"0123456789abcdef0123456789abcdef-2"'
-    monkeypatch.setattr(recovery, "fetch_manifest", lambda _pid: manifest)
+    monkeypatch.setattr(recovery, "fetch_manifest", lambda _pid, **_kwargs: manifest)
     destination = tmp_path / "projects" / PID
 
     result = restore_cloud_store(PID, destination)
@@ -180,7 +184,7 @@ def test_restore_cloud_store_still_catches_corruption_behind_opaque_etag(tmp_pat
     manifest = recovery.fetch_manifest(PID)
     manifest[0]["etag"] = '"0123456789abcdef0123456789abcdef-2"'
     manifest[0]["sha256"] = "0" * 64
-    monkeypatch.setattr(recovery, "fetch_manifest", lambda _pid: manifest)
+    monkeypatch.setattr(recovery, "fetch_manifest", lambda _pid, **_kwargs: manifest)
     destination = tmp_path / "projects" / PID
 
     with pytest.raises(RecoveryError, match="hash"):
@@ -205,7 +209,7 @@ def test_restore_accepts_default_store_path_under_symlinked_home(tmp_path, monke
     monkeypatch.setenv("NAURO_HOME", str(linked_home))
     destination = get_store_path_v2(PID)
     assert destination.resolve(strict=False) != destination
-    monkeypatch.setattr(recovery, "fetch_manifest", lambda _pid: [])
+    monkeypatch.setattr(recovery, "fetch_manifest", lambda _pid, **_kwargs: [])
 
     with pytest.raises(recovery.EmptyCloudRecordError):
         restore_cloud_store(PID, destination)
@@ -244,7 +248,7 @@ def test_restore_cloud_store_refuses_unsafe_manifest_without_partial_record(
     path, tmp_path, monkeypatch
 ):
     manifest = [{"path": path, "etag": "e", "size": 1}]
-    monkeypatch.setattr(recovery, "fetch_manifest", lambda _pid: manifest)
+    monkeypatch.setattr(recovery, "fetch_manifest", lambda _pid, **_kwargs: manifest)
     destination = tmp_path / "projects" / PID
 
     with pytest.raises(RecoveryError):
@@ -262,7 +266,7 @@ def test_restore_cloud_store_refuses_unsafe_manifest_without_partial_record(
     ],
 )
 def test_restore_cloud_store_rejects_malformed_manifest_types(entry, tmp_path, monkeypatch):
-    monkeypatch.setattr(recovery, "fetch_manifest", lambda _pid: [entry])
+    monkeypatch.setattr(recovery, "fetch_manifest", lambda _pid, **_kwargs: [entry])
     destination = tmp_path / "projects" / PID
 
     with pytest.raises(RecoveryError, match="manifest"):
@@ -287,7 +291,9 @@ def test_restore_cloud_store_rejects_malformed_presign_result(tmp_path, monkeypa
     monkeypatch.setattr(
         recovery,
         "request_presigned_urls",
-        lambda _pid, operations: [{"verb": "GET", "path": operations[0]["path"], "url": 42}],
+        lambda _pid, operations, **_kwargs: [
+            {"verb": "GET", "path": operations[0]["path"], "url": 42}
+        ],
     )
     destination = tmp_path / "projects" / PID
 

--- a/packages/nauro/tests/test_recovery_resume.py
+++ b/packages/nauro/tests/test_recovery_resume.py
@@ -13,7 +13,7 @@ from filelock import FileLock
 from nauro.store import recovery
 from nauro.store.recovery import RecoveryError, RestoreBusyError, restore_cloud_store
 from nauro.sync import transfer
-from nauro.sync.remote import PresignTransferError
+from nauro.sync.remote import FetchedObject, PresignTransferError
 from nauro.sync.state import SYNC_STATE_FILE
 from nauro.templates.scaffolds import scaffold_project_store
 from tests.test_recovery import PID, _decision_bytes, _store_files
@@ -59,7 +59,7 @@ class _Cloud:
         monkeypatch.setattr(recovery, "fetch_via_presigned_url", self.fetch)
         monkeypatch.setattr(transfer, "pause", self.waits.append)
 
-    def manifest(self, _project_id: str) -> list[dict]:
+    def manifest(self, _project_id: str, **_kwargs) -> list[dict]:
         rows = []
         for path, content in sorted(self.files.items()):
             if path in self.opaque:
@@ -76,7 +76,7 @@ class _Cloud:
             )
         return rows
 
-    def presign(self, _project_id: str, operations: list[dict[str, str]]) -> list[dict]:
+    def presign(self, _project_id: str, operations: list[dict[str, str]], **_kwargs) -> list[dict]:
         self.generation += 1
         self.mints.append([operation["path"] for operation in operations])
         row: dict[str, str] = {}
@@ -93,7 +93,7 @@ class _Cloud:
             for operation in operations
         ]
 
-    def fetch(self, url: str) -> bytes:
+    def fetch(self, url: str, **_kwargs) -> FetchedObject:
         _generation, _, path = url.removeprefix("memory://").partition("/")
         self.fetched.append(path)
         queued = self.faults.get(path)
@@ -102,7 +102,7 @@ class _Cloud:
         standing = self.always_fail.get(path)
         if standing is not None:
             raise standing
-        return self.files[path]
+        return FetchedObject(self.files[path], f'"{hashlib.md5(self.files[path]).hexdigest()}"')
 
 
 class _RecordingReporter:

--- a/packages/nauro/tests/test_sync/conftest.py
+++ b/packages/nauro/tests/test_sync/conftest.py
@@ -183,8 +183,8 @@ def pull_report(store, entries, *, reporter=None, etags=None):
         return httpx.Response(200, content=bodies[url.split("/GET/", 1)[1]])
 
     with (
-        patch("nauro.sync.remote.httpx.get", side_effect=fake_get),
-        patch("nauro.sync.remote.httpx.post", return_value=presign),
+        patch("nauro.sync.remote.httpx.Client.get", side_effect=fake_get),
+        patch("nauro.sync.remote.httpx.Client.post", return_value=presign),
     ):
         report = run_pull(CLOUD_PID, store, reporter)
     return report, reporter

--- a/packages/nauro/tests/test_sync/test_hooks.py
+++ b/packages/nauro/tests/test_sync/test_hooks.py
@@ -24,6 +24,7 @@ from nauro.sync.hooks import (
     pull_before_session,
     push_after_write,
 )
+from nauro.sync.push import PushReport
 from nauro.sync.state import (
     FileState,
     SyncState,
@@ -61,7 +62,7 @@ class TestSilentNoOpGating:
         store = _scaffolded_cloud_project("noauth", tmp_path, project_id=CLOUD_PID)
         # no _seed_token() — load_access_token() returns None
 
-        with patch("nauro.sync.remote.httpx.get") as mock_get:
+        with patch("nauro.sync.remote.httpx.Client.get") as mock_get:
             result = pull_before_session(CLOUD_PID, store)
 
         assert result == 0
@@ -71,10 +72,10 @@ class TestSilentNoOpGating:
         store = _scaffolded_cloud_project("noauth", tmp_path, project_id=CLOUD_PID)
         # no _seed_token()
 
-        with patch("nauro.sync.remote.httpx.post") as mock_post:
+        with patch("nauro.sync.remote.httpx.Client.post") as mock_post:
             result = push_after_write(CLOUD_PID, store)
 
-        assert result == 0
+        assert result == PushReport()
         mock_post.assert_not_called()
 
     def _seed_v1_shaped_registry(self, tmp_path) -> Path:
@@ -97,7 +98,7 @@ class TestSilentNoOpGating:
         store = self._seed_v1_shaped_registry(tmp_path)
         _seed_token()
 
-        with patch("nauro.sync.remote.httpx.get") as mock_get:
+        with patch("nauro.sync.remote.httpx.Client.get") as mock_get:
             result = pull_before_session("v1proj", store)
 
         assert result == 0
@@ -107,10 +108,10 @@ class TestSilentNoOpGating:
         store = self._seed_v1_shaped_registry(tmp_path)
         _seed_token()
 
-        with patch("nauro.sync.remote.httpx.post") as mock_post:
+        with patch("nauro.sync.remote.httpx.Client.post") as mock_post:
             result = push_after_write("v1proj", store)
 
-        assert result == 0
+        assert result == PushReport()
         mock_post.assert_not_called()
 
     def test_pull_silent_for_v2_local_mode(self, tmp_path):
@@ -127,7 +128,7 @@ class TestSilentNoOpGating:
         scaffold_project_store("localproj", store)
         _seed_token()
 
-        with patch("nauro.sync.remote.httpx.get") as mock_get:
+        with patch("nauro.sync.remote.httpx.Client.get") as mock_get:
             result = pull_before_session(local_pid, store)
 
         assert result == 0
@@ -146,10 +147,10 @@ class TestSilentNoOpGating:
         scaffold_project_store("localproj", store)
         _seed_token()
 
-        with patch("nauro.sync.remote.httpx.post") as mock_post:
+        with patch("nauro.sync.remote.httpx.Client.post") as mock_post:
             result = push_after_write(local_pid, store)
 
-        assert result == 0
+        assert result == PushReport()
         mock_post.assert_not_called()
 
 
@@ -186,8 +187,8 @@ class TestPullBeforeSessionPresign:
         empty = self._manifest([])
 
         with (
-            patch("nauro.sync.remote.httpx.get", return_value=empty),
-            patch("nauro.sync.remote.httpx.post") as mock_post,
+            patch("nauro.sync.remote.httpx.Client.get", return_value=empty),
+            patch("nauro.sync.remote.httpx.Client.post") as mock_post,
         ):
             result = pull_before_session(CLOUD_PID, cloud_store)
 
@@ -209,8 +210,8 @@ class TestPullBeforeSessionPresign:
             return httpx.Response(200, content=b"# 099\nfresh remote body\n")
 
         with (
-            patch("nauro.sync.remote.httpx.get", side_effect=fake_get),
-            patch("nauro.sync.remote.httpx.post", return_value=presign),
+            patch("nauro.sync.remote.httpx.Client.get", side_effect=fake_get),
+            patch("nauro.sync.remote.httpx.Client.post", return_value=presign),
         ):
             result = pull_before_session(CLOUD_PID, cloud_store)
 
@@ -222,7 +223,7 @@ class TestPullBeforeSessionPresign:
     def test_pull_swallows_presign_error(self, cloud_store):
         """A failed manifest fetch logs and returns 0, never raises."""
         bad_manifest = httpx.Response(500, content=b"server error")
-        with patch("nauro.sync.remote.httpx.get", return_value=bad_manifest):
+        with patch("nauro.sync.remote.httpx.Client.get", return_value=bad_manifest):
             result = pull_before_session(CLOUD_PID, cloud_store)
         assert result == 0
 
@@ -231,7 +232,7 @@ class TestPullBeforeSessionPresign:
         unauthorized = httpx.Response(401, content=b'{"error":"unauthorized"}')
         save_config({"auth": {"access_token": "tok", "sub": "x"}})
 
-        with patch("nauro.sync.remote.httpx.get", return_value=unauthorized):
+        with patch("nauro.sync.remote.httpx.Client.get", return_value=unauthorized):
             result = pull_before_session(CLOUD_PID, cloud_store)
 
         assert result == 0
@@ -280,12 +281,12 @@ class TestPushAfterWritePresign:
         self._seed_synced_state(cloud_store)
 
         with (
-            patch("nauro.sync.remote.httpx.post") as mock_post,
-            patch("nauro.sync.remote.httpx.put") as mock_put,
+            patch("nauro.sync.remote.httpx.Client.post") as mock_post,
+            patch("nauro.sync.remote.httpx.Client.put") as mock_put,
         ):
             result = push_after_write(CLOUD_PID, cloud_store)
 
-        assert result == 0
+        assert result == PushReport()
         mock_post.assert_not_called()
         mock_put.assert_not_called()
 
@@ -301,12 +302,12 @@ class TestPushAfterWritePresign:
             return self._presign(kwargs["json"]["operations"])
 
         with (
-            patch("nauro.sync.remote.httpx.post", side_effect=fake_post) as mock_post,
-            patch("nauro.sync.remote.httpx.put", return_value=put_response) as mock_put,
+            patch("nauro.sync.remote.httpx.Client.post", side_effect=fake_post) as mock_post,
+            patch("nauro.sync.remote.httpx.Client.put", return_value=put_response) as mock_put,
         ):
             result = push_after_write(CLOUD_PID, cloud_store)
 
-        assert result == 1
+        assert result.verified == ("stack.md",)
         body = mock_post.call_args.kwargs["json"]
         assert body["project_id"] == CLOUD_PID
         assert body["operations"] == [{"verb": "PUT", "path": "stack.md"}]
@@ -320,10 +321,10 @@ class TestPushAfterWritePresign:
         (cloud_store / "stack.md").write_text("modified\n")
 
         bad = httpx.Response(500, content=b"server error")
-        with patch("nauro.sync.remote.httpx.post", return_value=bad):
+        with patch("nauro.sync.remote.httpx.Client.post", return_value=bad):
             result = push_after_write(CLOUD_PID, cloud_store)
 
-        assert result == 0
+        assert result.is_complete is False
 
     def test_push_swallows_auth_refresh_error(self, cloud_store):
         self._seed_synced_state(cloud_store)
@@ -332,10 +333,10 @@ class TestPushAfterWritePresign:
         unauthorized = httpx.Response(401, content=b'{"error":"unauthorized"}')
         save_config({"auth": {"access_token": "tok", "sub": "x"}})
 
-        with patch("nauro.sync.remote.httpx.post", return_value=unauthorized):
+        with patch("nauro.sync.remote.httpx.Client.post", return_value=unauthorized):
             result = push_after_write(CLOUD_PID, cloud_store)
 
-        assert result == 0
+        assert result.is_complete is False
 
     def test_push_after_write_delegates_to_push_changed_files(self, cloud_store):
         """The hook is a thin wrapper over the shared push module — it must
@@ -344,10 +345,11 @@ class TestPushAfterWritePresign:
         self._seed_synced_state(cloud_store)
         (cloud_store / "stack.md").write_text("changed\n")
 
-        with patch("nauro.sync.push.push_changed_files", return_value=2) as mock_push:
+        report = PushReport(planned=("a", "b"), verified=("a", "b"))
+        with patch("nauro.sync.push.push_changed_files", return_value=report) as mock_push:
             result = push_after_write(CLOUD_PID, cloud_store)
 
-        assert result == 2
+        assert result == report
         assert mock_push.call_count == 1
         assert mock_push.call_args.args == (CLOUD_PID, cloud_store)
 

--- a/packages/nauro/tests/test_sync/test_journal_excluded.py
+++ b/packages/nauro/tests/test_sync/test_journal_excluded.py
@@ -53,7 +53,7 @@ def test_push_does_not_enumerate_journal(tmp_path):
 
     captured: dict[str, list] = {}
 
-    def fake_presign(project_id, operations):
+    def fake_presign(project_id, operations, **_kwargs):
         captured["ops"] = operations
         return []  # no URLs → nothing is uploaded
 
@@ -79,7 +79,7 @@ def test_pull_skips_remote_journal_path(tmp_path):
         raise AssertionError("journal path must never be fetched")
 
     reporter = _RecordingReporter()
-    with patch("nauro.sync.remote.httpx.get", side_effect=fake_get):
+    with patch("nauro.sync.remote.httpx.Client.get", side_effect=fake_get):
         merged = run_pull(CLOUD_PID, store, reporter).merged
 
     assert merged == 0

--- a/packages/nauro/tests/test_sync/test_post_restore_sync.py
+++ b/packages/nauro/tests/test_sync/test_post_restore_sync.py
@@ -29,7 +29,7 @@ from nauro.store.repo_config import save_repo_config
 from nauro.sync.merge import CONFLICT_BACKUP_DIR, should_skip
 from nauro.sync.pull import PullReport, run_pull
 from nauro.sync.quarantine import list_quarantine_backups
-from nauro.sync.remote import PresignTransferError
+from nauro.sync.remote import FetchedObject, PresignTransferError
 from nauro.sync.state import SYNC_STATE_FILE, load_state
 from nauro.templates.scaffolds import scaffold_project_store
 from tests.test_sync.conftest import (
@@ -71,7 +71,7 @@ class _Remote:
 
     # --- the restore's three calls ---
 
-    def rows(self, _project_id: str | None = None) -> list[dict]:
+    def rows(self, _project_id: str | None = None, **_kwargs) -> list[dict]:
         return [
             {
                 "path": path,
@@ -82,19 +82,21 @@ class _Remote:
             for path, content in sorted(self.files.items())
         ]
 
-    def _presigned(self, _project_id: str, operations: list[dict[str, str]]) -> list[dict]:
+    def _presigned(
+        self, _project_id: str, operations: list[dict[str, str]], **_kwargs
+    ) -> list[dict]:
         return [
             {"verb": "GET", "path": op["path"], "url": f"memory://{op['path']}"}
             for op in operations
         ]
 
-    def _fetch(self, url: str) -> bytes:
+    def _fetch(self, url: str, **_kwargs) -> FetchedObject:
         path = url.removeprefix("memory://")
         self.fetched.append(path)
         fault = self.faults.get(path)
         if fault is not None:
             raise fault
-        return self.files[path]
+        return FetchedObject(self.files[path], f'"{hashlib.md5(self.files[path]).hexdigest()}"')
 
     def install(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(recovery, "fetch_manifest", self.rows)
@@ -116,8 +118,8 @@ class _Remote:
             return _presign(kwargs["json"]["operations"])
 
         with (
-            patch("nauro.sync.remote.httpx.get", side_effect=get),
-            patch("nauro.sync.remote.httpx.post", side_effect=post),
+            patch("nauro.sync.remote.httpx.Client.get", side_effect=get),
+            patch("nauro.sync.remote.httpx.Client.post", side_effect=post),
         ):
             yield
 

--- a/packages/nauro/tests/test_sync/test_pull.py
+++ b/packages/nauro/tests/test_sync/test_pull.py
@@ -84,8 +84,8 @@ class TestRunPullCleanPull:
 
         reporter = _RecordingReporter()
         with (
-            patch("nauro.sync.remote.httpx.get", side_effect=fake_get),
-            patch("nauro.sync.remote.httpx.post", return_value=presign),
+            patch("nauro.sync.remote.httpx.Client.get", side_effect=fake_get),
+            patch("nauro.sync.remote.httpx.Client.post", return_value=presign),
         ):
             merged = run_pull(CLOUD_PID, cloud_store, reporter).merged
 
@@ -107,8 +107,8 @@ class TestRunPullCleanPull:
             return httpx.Response(200, content=_STAMPED_DECISION)
 
         with (
-            patch("nauro.sync.remote.httpx.get", side_effect=fake_get),
-            patch("nauro.sync.remote.httpx.post", return_value=presign),
+            patch("nauro.sync.remote.httpx.Client.get", side_effect=fake_get),
+            patch("nauro.sync.remote.httpx.Client.post", return_value=presign),
         ):
             merged = run_pull(CLOUD_PID, cloud_store, _RecordingReporter()).merged
 
@@ -128,8 +128,8 @@ class TestRunPullCleanPull:
 
         reporter = _RecordingReporter()
         with (
-            patch("nauro.sync.remote.httpx.get", return_value=manifest),
-            patch("nauro.sync.remote.httpx.post") as mock_post,
+            patch("nauro.sync.remote.httpx.Client.get", return_value=manifest),
+            patch("nauro.sync.remote.httpx.Client.post") as mock_post,
         ):
             report = run_pull(CLOUD_PID, cloud_store, reporter)
 
@@ -146,8 +146,8 @@ class TestRunPullCleanPull:
 
         reporter = _RecordingReporter()
         with (
-            patch("nauro.sync.remote.httpx.get", return_value=manifest),
-            patch("nauro.sync.remote.httpx.post") as mock_post,
+            patch("nauro.sync.remote.httpx.Client.get", return_value=manifest),
+            patch("nauro.sync.remote.httpx.Client.post") as mock_post,
         ):
             report = run_pull(CLOUD_PID, cloud_store, reporter)
 
@@ -180,8 +180,8 @@ class TestRunPullCleanPull:
 
         reporter = _RecordingReporter()
         with (
-            patch("nauro.sync.remote.httpx.get", side_effect=fake_get),
-            patch("nauro.sync.remote.httpx.post", return_value=presign),
+            patch("nauro.sync.remote.httpx.Client.get", side_effect=fake_get),
+            patch("nauro.sync.remote.httpx.Client.post", return_value=presign),
         ):
             merged = run_pull(CLOUD_PID, cloud_store, reporter).merged
 
@@ -785,9 +785,9 @@ class TestTransferShape:
         seen_on_disk: list[int] = []
         real_fetch = pull_module.fetch_via_presigned_url
 
-        def counting_fetch(url):
+        def counting_fetch(url, **kwargs):
             seen_on_disk.append(len(list(collision_store.glob("stream-*.json"))))
-            return real_fetch(url)
+            return real_fetch(url, **kwargs)
 
         with patch.object(pull_module, "fetch_via_presigned_url", counting_fetch):
             merged, _reporter = pull(collision_store, entries)
@@ -801,13 +801,13 @@ class TestTransferShape:
         acquired: list[bool] = []
         real_fetch = pull_module.fetch_via_presigned_url
 
-        def probing_fetch(url):
+        def probing_fetch(url, **kwargs):
             try:
                 with decision_lock(collision_store, 0.05):
                     acquired.append(True)
             except SyncLockTimeoutError:
                 acquired.append(False)
-            return real_fetch(url)
+            return real_fetch(url, **kwargs)
 
         with patch.object(pull_module, "fetch_via_presigned_url", probing_fetch):
             merged, _reporter = pull(collision_store, self._ordinary_files(2))
@@ -929,12 +929,12 @@ class TestDecisionBatchSpool:
         spooled_before_fetch: list[int] = []
         real_fetch = pull_module.fetch_via_presigned_url
 
-        def counting_fetch(url):
+        def counting_fetch(url, **kwargs):
             spooled = self._spool_dirs(collision_store)
             spooled_before_fetch.append(
                 len(list((collision_store / spooled[0]).iterdir())) if spooled else 0
             )
-            return real_fetch(url)
+            return real_fetch(url, **kwargs)
 
         with patch.object(pull_module, "fetch_via_presigned_url", counting_fetch):
             merged, _reporter = pull(collision_store, self._entries(3))
@@ -1918,7 +1918,7 @@ class TestLocalWriteFailures:
         store short of the server while the stamp said the two agreed.
         """
 
-        def refuse(_url):
+        def refuse(_url, **_kwargs):
             raise PresignError("connection reset by peer")
 
         monkeypatch.setattr(pull_module, "fetch_via_presigned_url", refuse)
@@ -1933,7 +1933,7 @@ class TestLocalWriteFailures:
         self, collision_store, monkeypatch
     ):
         """A URL the server never minted leaves its file unfetched."""
-        monkeypatch.setattr(pull_module, "request_presigned_urls", lambda *_args: [])
+        monkeypatch.setattr(pull_module, "request_presigned_urls", lambda *_args, **_kwargs: [])
 
         merged, reporter = pull(
             collision_store, [("decisions/016-remote.md", decision_bytes(16, "Unfetched"))]
@@ -2000,7 +2000,7 @@ class TestServerOutOfReach:
     def test_a_manifest_failure_says_the_run_never_saw_the_server(
         self, collision_store, monkeypatch
     ):
-        def refuse(_project_id):
+        def refuse(_project_id, **_kwargs):
             raise PresignError("503 service unavailable")
 
         monkeypatch.setattr(pull_module, "fetch_manifest", refuse)
@@ -2014,7 +2014,7 @@ class TestServerOutOfReach:
         assert any("manifest fetch failed" in warning for warning in reporter.warns)
 
     def test_an_auth_failure_on_the_manifest_reads_the_same_way(self, collision_store, monkeypatch):
-        def refuse(_project_id):
+        def refuse(_project_id, **_kwargs):
             raise AuthRefreshError("session expired; run 'nauro auth login'")
 
         monkeypatch.setattr(pull_module, "fetch_manifest", refuse)
@@ -2027,7 +2027,7 @@ class TestServerOutOfReach:
     def test_a_total_presign_failure_counts_every_planned_file(self, collision_store, monkeypatch):
         """Here the run does know what it missed, so it says how much."""
 
-        def refuse(*_args):
+        def refuse(*_args, **_kwargs):
             raise PresignError("403 forbidden")
 
         monkeypatch.setattr(pull_module, "request_presigned_urls", refuse)

--- a/packages/nauro/tests/test_sync/test_sync_command.py
+++ b/packages/nauro/tests/test_sync/test_sync_command.py
@@ -9,6 +9,7 @@ from typer.testing import CliRunner
 from nauro.cli.main import app
 from nauro.store.registry import register_project_v2
 from nauro.sync.pull import PullReport
+from nauro.sync.push import PushReport
 from nauro.templates.scaffolds import scaffold_project_store
 from tests.conftest import seed_auth_config
 from tests.test_sync.conftest import _scaffolded_cloud_project
@@ -31,17 +32,20 @@ class TestSyncPullBeforePush:
     def test_sync_with_s3_calls_pull_before_push(self, project_store, monkeypatch):
         """When S3 is configured, sync should pull then push."""
         call_order = []
+        sessions = []
 
         # We need to patch at the module level where they're defined
         from nauro.cli.commands import sync as sync_mod
 
-        def mock_pull(project_name, store_path):
+        def mock_pull(project_name, store_path, **kwargs):
             call_order.append("pull")
+            sessions.append(kwargs["session"])
             return PullReport()
 
-        def mock_push(project_name, store_path):
+        def mock_push(project_name, store_path, **kwargs):
             call_order.append("push")
-            return True
+            sessions.append(kwargs["session"])
+            return PushReport()
 
         monkeypatch.setattr(sync_mod, "_pull_from_cloud", mock_pull)
         monkeypatch.setattr(sync_mod, "_push_to_cloud", mock_push)
@@ -49,6 +53,7 @@ class TestSyncPullBeforePush:
         result = runner.invoke(app, ["sync"])
         assert result.exit_code == 0
         assert call_order == ["pull", "push"]
+        assert sessions[0] is sessions[1]
 
     def test_sync_without_s3_unchanged(self, project_store, monkeypatch):
         """When S3 is not configured, sync should still work (pull is a no-op)."""
@@ -71,7 +76,7 @@ class TestSyncExitCode:
     def _stub_pull(monkeypatch, report: PullReport) -> None:
         from nauro.cli.commands import sync as sync_mod
 
-        monkeypatch.setattr(sync_mod, "_pull_from_cloud", lambda *_args: report)
+        monkeypatch.setattr(sync_mod, "_pull_from_cloud", lambda *_args, **_kwargs: report)
 
     def test_a_clean_pull_exits_zero(self, project_store, monkeypatch):
         self._stub_pull(monkeypatch, PullReport(merged=3))
@@ -97,19 +102,40 @@ class TestSyncExitCode:
         assert result.exit_code == 2, result.output
         assert "could not read the server's file list" in result.output
 
+    def test_a_permanent_pull_origin_abort_exits_one_without_success(
+        self, project_store, monkeypatch
+    ):
+        from nauro.cli.commands import sync as sync_mod
+
+        self._stub_pull(
+            monkeypatch,
+            PullReport(
+                manifest_read=False,
+                origin_aborted=("https://api.example:443",),
+            ),
+        )
+        monkeypatch.setattr(sync_mod, "is_cloud_project", lambda _project: True)
+        monkeypatch.setattr(sync_mod, "_push_to_cloud", lambda *_args, **_kwargs: PushReport())
+
+        result = runner.invoke(app, ["sync"])
+
+        assert result.exit_code == 1, result.output
+        assert "permanent remote origin failure" in result.output
+        assert "Synced testproj" not in result.output
+
     def test_the_push_still_runs_before_that_exit(self, project_store, monkeypatch):
         """The push order is unchanged: the snapshot is local work worth keeping."""
         from nauro.cli.commands import sync as sync_mod
 
         call_order = []
 
-        def mock_pull(_project_name, _store_path):
+        def mock_pull(_project_name, _store_path, **_kwargs):
             call_order.append("pull")
             return PullReport(manifest_read=False)
 
-        def mock_push(_project_name, _store_path):
+        def mock_push(_project_name, _store_path, **_kwargs):
             call_order.append("push")
-            return True
+            return PushReport()
 
         monkeypatch.setattr(sync_mod, "_pull_from_cloud", mock_pull)
         monkeypatch.setattr(sync_mod, "_push_to_cloud", mock_push)
@@ -131,13 +157,18 @@ class TestSyncExitCode:
         from nauro.cli.commands import sync as sync_mod
 
         self._stub_pull(monkeypatch, PullReport(refused=1))
-        monkeypatch.setattr(sync_mod, "_push_to_cloud", lambda *_args: False)
+        monkeypatch.setattr(
+            sync_mod,
+            "_push_to_cloud",
+            lambda *_args, **_kwargs: PushReport(failed=("transport",)),
+        )
 
         result = runner.invoke(app, ["sync"])
 
         # The command's own failure outranks the pull's unfinished business.
         assert result.exit_code == 1, result.output
         assert "cloud push failed" in result.output
+        assert "Synced testproj" not in result.output
 
 
 class TestSyncSnapshotIsPrimaryWork:
@@ -346,11 +377,11 @@ class TestSyncHonesty:
 
         with (
             patch(
-                "nauro.sync.remote.httpx.get",
+                "nauro.sync.remote.httpx.Client.get",
                 return_value=ok({"files": [], "next_cursor": None}),
             ),
-            patch("nauro.sync.remote.httpx.post", side_effect=fake_post),
-            patch("nauro.sync.remote.httpx.put", return_value=put_response),
+            patch("nauro.sync.remote.httpx.Client.post", side_effect=fake_post),
+            patch("nauro.sync.remote.httpx.Client.put", return_value=put_response),
         ):
             result = runner.invoke(app, ["sync", "--project", "cloudwithauth"])
 
@@ -358,6 +389,75 @@ class TestSyncHonesty:
         assert result.exit_code == 0, combined
         assert "Synced cloudwithauth" in result.output
         assert "Warning: this is a cloud-mode project" not in combined
+
+    @pytest.mark.parametrize(
+        ("failure", "expected_pull_posts"),
+        [
+            ("manifest-malformed-json", 0),
+            ("presign-invalid-shape", 1),
+        ],
+    )
+    def test_invalid_pull_api_response_blocks_same_origin_push_and_success(
+        self,
+        failure,
+        expected_pull_posts,
+        tmp_path,
+        monkeypatch,
+    ):
+        import httpx
+
+        _scaffolded_cloud_project("invalidpull", tmp_path)
+        seed_auth_config(variant="sync")
+        monkeypatch.setenv("NAURO_API_URL", "https://api.test")
+        manifest = httpx.Response(
+            200,
+            json={
+                "files": [{"path": "project.md", "etag": '"remote"'}],
+                "next_cursor": None,
+            },
+        )
+        invalid_manifest = httpx.Response(200, content=b"{not json")
+        invalid_presign = httpx.Response(200, json={"urls": {}})
+
+        def fake_get(url, **_kwargs):
+            assert "/sync/manifest" in url
+            return invalid_manifest if failure == "manifest-malformed-json" else manifest
+
+        post_calls = 0
+
+        def fake_post(_url, **kwargs):
+            nonlocal post_calls
+            post_calls += 1
+            if failure == "presign-invalid-shape" and post_calls == 1:
+                return invalid_presign
+            operations = kwargs["json"]["operations"]
+            return httpx.Response(
+                200,
+                json={
+                    "urls": [
+                        {
+                            "verb": operation["verb"],
+                            "path": operation["path"],
+                            "url": f"https://objects.test/{operation['path']}",
+                        }
+                        for operation in operations
+                    ]
+                },
+            )
+
+        put_response = httpx.Response(200, headers={"ETag": '"uploaded"'})
+        with (
+            patch("nauro.sync.remote.httpx.Client.get", side_effect=fake_get),
+            patch("nauro.sync.remote.httpx.Client.post", side_effect=fake_post) as mock_post,
+            patch("nauro.sync.remote.httpx.Client.put", return_value=put_response) as mock_put,
+        ):
+            result = runner.invoke(app, ["sync", "--project", "invalidpull"])
+
+        assert result.exit_code == 1, result.output
+        assert "permanent remote origin failure" in result.output
+        assert "Synced invalidpull" not in result.output
+        assert mock_post.call_count == expected_pull_posts
+        mock_put.assert_not_called()
 
 
 class TestSyncPullSurfacesAndMerges:
@@ -425,9 +525,9 @@ class TestSyncPullSurfacesAndMerges:
         put_response.headers = {"ETag": '"e_pushed"'}
 
         with (
-            patch("nauro.sync.remote.httpx.get", side_effect=fake_get),
-            patch("nauro.sync.remote.httpx.post", side_effect=fake_post),
-            patch("nauro.sync.remote.httpx.put", return_value=put_response),
+            patch("nauro.sync.remote.httpx.Client.get", side_effect=fake_get),
+            patch("nauro.sync.remote.httpx.Client.post", side_effect=fake_post),
+            patch("nauro.sync.remote.httpx.Client.put", return_value=put_response),
         ):
             result = runner.invoke(app, ["sync", "--project", "mergedcount"])
 

--- a/packages/nauro/tests/test_sync/test_sync_lock.py
+++ b/packages/nauro/tests/test_sync/test_sync_lock.py
@@ -26,7 +26,7 @@ from nauro.sync.lock import (
 )
 from nauro.sync.merge import should_skip
 from nauro.sync.pull import run_pull
-from nauro.sync.push import push_changed_files
+from nauro.sync.push import PushReport, push_changed_files
 from tests.test_sync.conftest import (
     CLOUD_PID,
     _ok,
@@ -82,7 +82,7 @@ class TestContendedCallers:
     def test_run_pull_raises_before_touching_the_network(self, cloud_store):
         lock = _hold(cloud_store)
         try:
-            with patch("nauro.sync.remote.httpx.get") as get:
+            with patch("nauro.sync.remote.httpx.Client.get") as get:
                 with pytest.raises(SyncLockTimeoutError):
                     run_pull(CLOUD_PID, cloud_store, _RecordingReporter(), lock_timeout=0.05)
             assert get.call_count == 0
@@ -114,7 +114,7 @@ class TestContendedCallers:
                 pushed = push_after_write(CLOUD_PID, cloud_store)
         finally:
             lock.release()
-        assert pushed == 0
+        assert pushed == PushReport(failed=("sync lock",))
         assert any("skipped" in record.getMessage() for record in caplog.records)
 
     def test_cli_sync_fails_loud(self, cloud_store, tmp_path, monkeypatch):
@@ -173,7 +173,7 @@ class TestBoundedDecisionLock:
         lock = self._hold_decisions(cloud_store)
         try:
             with (
-                patch("nauro.sync.remote.httpx.get", return_value=manifest),
+                patch("nauro.sync.remote.httpx.Client.get", return_value=manifest),
                 caplog.at_level(logging.INFO, logger="nauro.sync"),
             ):
                 pulled = pull_before_session(CLOUD_PID, cloud_store)
@@ -194,7 +194,7 @@ class TestBoundedDecisionLock:
         )
         lock = self._hold_decisions(cloud_store)
         try:
-            with patch("nauro.sync.remote.httpx.get", return_value=manifest):
+            with patch("nauro.sync.remote.httpx.Client.get", return_value=manifest):
                 result = runner.invoke(app, ["sync"])
         finally:
             lock.release()

--- a/packages/nauro/tests/test_sync/test_sync_presign.py
+++ b/packages/nauro/tests/test_sync/test_sync_presign.py
@@ -63,10 +63,10 @@ class TestModeDetection:
 
         with (
             patch(
-                "nauro.sync.remote.httpx.get",
+                "nauro.sync.remote.httpx.Client.get",
                 return_value=_ok(200, {"files": [], "next_cursor": None}),
             ) as mock_get,
-            patch("nauro.sync.remote.httpx.post") as mock_post,
+            patch("nauro.sync.remote.httpx.Client.post") as mock_post,
         ):
             from nauro.cli.commands.sync import _pull_from_cloud
 
@@ -83,7 +83,7 @@ class TestModeDetection:
         from nauro.cli.commands.sync import _push_to_cloud
 
         ok = _push_to_cloud(store.name, store)
-        assert ok is False
+        assert ok.is_complete is False
 
     def test_stale_legacy_config_keys_load_cleanly(self, tmp_path, monkeypatch):
         """A user who upgraded from the legacy direct-S3 path still has
@@ -115,7 +115,7 @@ class TestModeDetection:
 
         with (
             patch(
-                "nauro.sync.remote.httpx.get",
+                "nauro.sync.remote.httpx.Client.get",
                 return_value=_ok(200, {"files": [], "next_cursor": None}),
             ) as mock_get,
         ):
@@ -180,9 +180,9 @@ class TestPullViaPresign:
         from nauro.sync import remote
 
         with (
-            patch.object(remote.httpx, "get", side_effect=fake_get),
+            patch.object(remote.httpx.Client, "get", side_effect=fake_get),
             patch.object(
-                remote.httpx,
+                remote.httpx.Client,
                 "post",
                 return_value=self._presign_response(
                     [
@@ -222,8 +222,8 @@ class TestPullViaPresign:
         from nauro.sync import remote
 
         with (
-            patch.object(remote.httpx, "get", return_value=manifest),
-            patch.object(remote.httpx, "post") as mock_post,
+            patch.object(remote.httpx.Client, "get", return_value=manifest),
+            patch.object(remote.httpx.Client, "post") as mock_post,
         ):
             from nauro.cli.commands.sync import _pull_from_cloud
 
@@ -248,8 +248,8 @@ class TestPullViaPresign:
         from nauro.sync import remote
 
         with (
-            patch.object(remote.httpx, "get", side_effect=fake_get),
-            patch.object(remote.httpx, "post", return_value=presign) as mock_post,
+            patch.object(remote.httpx.Client, "get", side_effect=fake_get),
+            patch.object(remote.httpx.Client, "post", return_value=presign) as mock_post,
         ):
             from nauro.cli.commands.sync import _pull_from_cloud
 
@@ -299,8 +299,8 @@ class TestPullViaPresign:
         from nauro.sync import remote
 
         with (
-            patch.object(remote.httpx, "get", side_effect=fake_get),
-            patch.object(remote.httpx, "post", return_value=presign),
+            patch.object(remote.httpx.Client, "get", side_effect=fake_get),
+            patch.object(remote.httpx.Client, "post", return_value=presign),
         ):
             from nauro.cli.commands.sync import _pull_from_cloud
 
@@ -337,8 +337,8 @@ class TestPullViaPresign:
         from nauro.sync import remote
 
         with (
-            patch.object(remote.httpx, "get", side_effect=fake_get) as mock_get,
-            patch.object(remote.httpx, "post", side_effect=fake_post) as mock_post,
+            patch.object(remote.httpx.Client, "get", side_effect=fake_get) as mock_get,
+            patch.object(remote.httpx.Client, "post", side_effect=fake_post) as mock_post,
         ):
             from nauro.cli.commands.sync import _pull_from_cloud
 
@@ -375,8 +375,8 @@ class TestPullViaPresign:
         from nauro.sync import remote
 
         with (
-            patch.object(remote.httpx, "get", side_effect=fake_get),
-            patch.object(remote.httpx, "post", side_effect=fake_post) as mock_post,
+            patch.object(remote.httpx.Client, "get", side_effect=fake_get),
+            patch.object(remote.httpx.Client, "post", side_effect=fake_post) as mock_post,
         ):
             from nauro.cli.commands.sync import _pull_from_cloud
 
@@ -446,14 +446,14 @@ class TestPushViaPresign:
         from nauro.sync import remote
 
         with (
-            patch.object(remote.httpx, "post", side_effect=fake_post) as mock_post,
-            patch.object(remote.httpx, "put", return_value=put_response) as mock_put,
+            patch.object(remote.httpx.Client, "post", side_effect=fake_post) as mock_post,
+            patch.object(remote.httpx.Client, "put", return_value=put_response) as mock_put,
         ):
             from nauro.cli.commands.sync import _push_to_cloud
 
             ok = _push_to_cloud(cloud_store.name, cloud_store)
 
-        assert ok is True
+        assert ok.is_complete is True
         # Presign payload carries project_id + a single PUT op for the modified path.
         body = mock_post.call_args.kwargs["json"]
         assert body["project_id"] == CLOUD_PID
@@ -511,12 +511,12 @@ class TestPushViaPresign:
         from nauro.sync import remote
 
         with (
-            patch.object(remote.httpx, "post", side_effect=fake_post) as mock_post,
-            patch.object(remote.httpx, "put", return_value=put_response),
+            patch.object(remote.httpx.Client, "post", side_effect=fake_post) as mock_post,
+            patch.object(remote.httpx.Client, "put", return_value=put_response),
         ):
             pushed = push_changed_files(CLOUD_PID, cloud_store)
 
-        assert pushed == len(plan.candidates)
+        assert len(pushed.verified) == len(plan.candidates)
         assert mock_post.call_args.kwargs["json"]["operations"] == [
             {"verb": "PUT", "path": candidate.relative_path} for candidate in plan.candidates
         ]
@@ -543,12 +543,12 @@ class TestPushViaPresign:
         from nauro.sync.push import push_changed_files
 
         with (
-            patch.object(remote.httpx, "post", side_effect=fake_post),
-            patch.object(remote.httpx, "put", return_value=put_response) as mock_put,
+            patch.object(remote.httpx.Client, "post", side_effect=fake_post),
+            patch.object(remote.httpx.Client, "put", return_value=put_response) as mock_put,
         ):
             pushed = push_changed_files(CLOUD_PID, cloud_store)
 
-        assert pushed == 1
+        assert pushed.verified == (rel,)
         assert mock_put.call_args.kwargs["content"] == _STAMPED_DECISION
 
     def test_oversize_context_brief_skipped_loudly_and_retained(self, cloud_store, capsys):
@@ -579,14 +579,14 @@ class TestPushViaPresign:
         from nauro.sync import remote
 
         with (
-            patch.object(remote.httpx, "post", side_effect=fake_post) as mock_post,
-            patch.object(remote.httpx, "put", return_value=put_response),
+            patch.object(remote.httpx.Client, "post", side_effect=fake_post) as mock_post,
+            patch.object(remote.httpx.Client, "put", return_value=put_response),
         ):
             from nauro.cli.commands.sync import _push_to_cloud
 
             ok = _push_to_cloud(cloud_store.name, cloud_store)
 
-        assert ok is True
+        assert ok.is_complete is True
         # The in-cap brief is presigned; the over-cap one is excluded entirely.
         pushed = {op["path"] for op in mock_post.call_args.kwargs["json"]["operations"]}
         assert "context/codex-notes-20260605-c3d4.md" in pushed
@@ -625,14 +625,14 @@ class TestPushViaPresign:
         from nauro.sync import remote
 
         with (
-            patch.object(remote.httpx, "post", side_effect=fake_post) as mock_post,
-            patch.object(remote.httpx, "put", return_value=put_response),
+            patch.object(remote.httpx.Client, "post", side_effect=fake_post) as mock_post,
+            patch.object(remote.httpx.Client, "put", return_value=put_response),
         ):
             from nauro.cli.commands.sync import _push_to_cloud
 
             ok = _push_to_cloud(cloud_store.name, cloud_store)
 
-        assert ok is True
+        assert ok.is_complete is True
         pushed = {op["path"] for op in mock_post.call_args.kwargs["json"]["operations"]}
         assert "context/codex-edge-20260605-e5f6.md" in pushed
         state = load_state(cloud_store)
@@ -644,14 +644,14 @@ class TestPushViaPresign:
         from nauro.sync import remote
 
         with (
-            patch.object(remote.httpx, "post") as mock_post,
-            patch.object(remote.httpx, "put") as mock_put,
+            patch.object(remote.httpx.Client, "post") as mock_post,
+            patch.object(remote.httpx.Client, "put") as mock_put,
         ):
             from nauro.cli.commands.sync import _push_to_cloud
 
             ok = _push_to_cloud(cloud_store.name, cloud_store)
 
-        assert ok is True
+        assert ok.is_complete is True
         mock_post.assert_not_called()
         mock_put.assert_not_called()
 
@@ -679,14 +679,14 @@ class TestPushViaPresign:
         from nauro.sync import remote
 
         with (
-            patch.object(remote.httpx, "post", side_effect=fake_post) as mock_post,
-            patch.object(remote.httpx, "put", return_value=put_response),
+            patch.object(remote.httpx.Client, "post", side_effect=fake_post) as mock_post,
+            patch.object(remote.httpx.Client, "put", return_value=put_response),
         ):
             from nauro.cli.commands.sync import _push_to_cloud
 
             ok = _push_to_cloud(cloud_store.name, cloud_store)
 
-        assert ok is True
+        assert ok.is_complete is True
         # Initial 401 + retry against /sync/presign, plus one /oauth/token refresh.
         presign_calls = [c for c in mock_post.call_args_list if "/sync/presign" in c.args[0]]
         refresh_calls = [c for c in mock_post.call_args_list if "/oauth/token" in c.args[0]]
@@ -750,10 +750,10 @@ class TestPresignedGetFailures:
     """Every download fault leaves the client as one typed PresignError."""
 
     def test_a_transport_fault_never_escapes_as_a_raw_httpx_error(self):
-        from nauro.sync.remote import PresignError, PresignTransferError, fetch_via_presigned_url
+        from nauro.sync.remote import PresignError, TransferBoundaryError, fetch_via_presigned_url
 
-        with patch.object(httpx, "get", side_effect=httpx.ConnectError("no route")):
-            with pytest.raises(PresignTransferError) as caught:
+        with patch.object(httpx.Client, "get", side_effect=httpx.ConnectError("no route")):
+            with pytest.raises(TransferBoundaryError) as caught:
                 fetch_via_presigned_url("https://s3/a")
 
         # The pull core guards its transfers with `except PresignError`; a bare
@@ -762,21 +762,21 @@ class TestPresignedGetFailures:
         assert caught.value.transport is True
         assert caught.value.status is None
 
-    def test_a_refused_status_carries_the_code_and_a_body_excerpt(self):
-        from nauro.sync.remote import PresignTransferError, fetch_via_presigned_url
+    def test_a_refused_status_carries_the_code_without_the_response_body(self):
+        from nauro.sync.remote import TransferBoundaryError, fetch_via_presigned_url
 
         refusal = httpx.Response(403, content=b"<Error>\n  <Code>AccessDenied</Code>\n</Error>")
-        with patch.object(httpx, "get", return_value=refusal):
-            with pytest.raises(PresignTransferError) as caught:
+        with patch.object(httpx.Client, "get", return_value=refusal):
+            with pytest.raises(TransferBoundaryError) as caught:
                 fetch_via_presigned_url("https://s3/a")
 
         assert caught.value.status == 403
-        assert "AccessDenied" in caught.value.detail
+        assert caught.value.kind.value == "http-status"
 
     def test_an_unsendable_url_is_typed_rather_than_thrown(self):
-        from nauro.sync.remote import PresignTransferError, fetch_via_presigned_url
+        from nauro.sync.remote import TransferBoundaryError, fetch_via_presigned_url
 
-        with pytest.raises(PresignTransferError) as caught:
+        with pytest.raises(TransferBoundaryError) as caught:
             fetch_via_presigned_url("not-a-url")
 
         assert caught.value.status is None

--- a/packages/nauro/tests/test_sync/test_transport_session.py
+++ b/packages/nauro/tests/test_sync/test_transport_session.py
@@ -1,0 +1,637 @@
+from __future__ import annotations
+
+import hashlib
+import ssl
+import traceback
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from tests.conftest import seed_auth_config
+
+
+def _response(status: int = 200, *, content: bytes = b"", etag: str = '"etag"'):
+    return httpx.Response(status, content=content, headers={"ETag": etag})
+
+
+def test_operation_session_reuses_and_closes_one_client(monkeypatch):
+    from nauro.sync.remote import TransferSession, fetch_via_presigned_url
+
+    client = MagicMock(spec=httpx.Client)
+    client.get.side_effect = [_response(content=b"one"), _response(content=b"two")]
+    monkeypatch.setattr(httpx, "Client", lambda **_kwargs: client)
+
+    with TransferSession() as session:
+        first = fetch_via_presigned_url("https://objects.example/one?secret=one", session=session)
+        second = fetch_via_presigned_url("https://objects.example/two?secret=two", session=session)
+
+    assert first.body == b"one"
+    assert second.body == b"two"
+    assert client.get.call_count == 2
+    client.close.assert_called_once_with()
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("https://Objects.Example/path?secret=value", "https://objects.example:443"),
+        ("http://API.Example:8080/path", "http://api.example:8080"),
+    ],
+)
+def test_canonical_origin_uses_lowercase_host_and_effective_port(url, expected):
+    from nauro.sync.remote import canonical_origin
+
+    assert canonical_origin(url) == expected
+
+
+def test_one_session_reuses_the_client_across_api_and_object_calls(monkeypatch):
+    from nauro.sync.remote import (
+        TransferSession,
+        fetch_manifest,
+        fetch_via_presigned_url,
+        request_presigned_urls,
+    )
+
+    seed_auth_config(variant="sync")
+    client = MagicMock(spec=httpx.Client)
+    client.get.side_effect = [
+        httpx.Response(200, json={"files": [], "next_cursor": None}),
+        _response(content=b"body"),
+    ]
+    client.post.return_value = httpx.Response(
+        200,
+        json={
+            "urls": [
+                {
+                    "verb": "GET",
+                    "path": "stack.md",
+                    "url": "https://objects.test/stack?signature=secret",
+                }
+            ]
+        },
+    )
+    monkeypatch.setattr(httpx, "Client", lambda **_kwargs: client)
+
+    with TransferSession() as session:
+        assert fetch_manifest("project", session=session) == []
+        urls = request_presigned_urls(
+            "project", [{"verb": "GET", "path": "stack.md"}], session=session
+        )
+        fetched = fetch_via_presigned_url(urls[0]["url"], session=session)
+
+    assert fetched.body == b"body"
+    assert client.get.call_count == 2
+    assert client.post.call_count == 1
+    client.close.assert_called_once_with()
+
+
+def test_invalid_api_response_keeps_its_http_status_without_rendering_body(monkeypatch):
+    from nauro.sync.remote import TransferBoundaryError, TransferSession, fetch_manifest
+
+    seed_auth_config(variant="sync")
+    client = MagicMock(spec=httpx.Client)
+    client.get.return_value = httpx.Response(200, content=b"secret response body")
+    monkeypatch.setattr(httpx, "Client", lambda **_kwargs: client)
+
+    with TransferSession() as session:
+        with pytest.raises(TransferBoundaryError) as caught:
+            fetch_manifest("project", session=session)
+
+    assert caught.value.status == 200
+    assert caught.value.kind.value == "invalid-response"
+    assert "secret response body" not in str(caught.value)
+
+
+def test_put_accepts_any_success_status_and_marks_a_missing_etag_unverified():
+    from nauro.sync.remote import TransferSession, WriteOutcome, put_via_presigned_url
+
+    client = MagicMock(spec=httpx.Client)
+    client.put.return_value = httpx.Response(201)
+
+    with TransferSession(client=client) as session:
+        result = put_via_presigned_url(
+            "https://objects.test/stack?signature=secret",
+            b"body",
+            session=session,
+        )
+
+    assert result.outcome is WriteOutcome.WRITTEN_UNVERIFIED
+
+
+def test_certificate_failure_trips_only_its_origin_and_sanitizes_error(monkeypatch):
+    from nauro.sync.remote import TransferBoundaryError, TransferSession, fetch_via_presigned_url
+
+    certificate_error = ssl.SSLCertVerificationError("certificate rejected secret=leaked")
+    nested = httpx.ConnectError("connect failed", request=httpx.Request("GET", "https://a.test"))
+    nested.__cause__ = certificate_error
+
+    client = MagicMock(spec=httpx.Client)
+    client.get.side_effect = [nested, _response(content=b"other")]
+    monkeypatch.setattr(httpx, "Client", lambda **_kwargs: client)
+    first_url = "https://a.test/object?X-Amz-Signature=secret"
+    second_url = "https://a.test/other?X-Amz-Signature=other"
+    other_url = "https://b.test/object?token=still-secret"
+
+    with TransferSession() as session:
+        with pytest.raises(TransferBoundaryError) as first:
+            fetch_via_presigned_url(first_url, session=session)
+        with pytest.raises(TransferBoundaryError) as second:
+            fetch_via_presigned_url(second_url, session=session)
+        fetched = fetch_via_presigned_url(other_url, session=session)
+
+    assert first.value.origin == "https://a.test:443"
+    assert first.value.kind.value == "tls-certificate"
+    assert first.value.__cause__ is None
+    assert first.value.__context__ is None
+    assert second.value.kind.value == "origin-aborted"
+    assert fetched.body == b"other"
+    assert client.get.call_count == 2
+    rendered = f"{first.value!r} {first.value} {second.value!r} {second.value}"
+    rendered += "".join(
+        traceback.format_exception(type(first.value), first.value, first.value.__traceback__)
+    )
+    assert "X-Amz" not in rendered
+    assert "secret" not in rendered
+
+
+def test_permanent_manifest_http_failure_blocks_same_origin_push_but_not_other_origin(
+    tmp_path, monkeypatch
+):
+    from nauro.sync.pull import run_pull
+    from nauro.sync.push import push_changed_files
+    from nauro.sync.remote import TransferSession, fetch_via_presigned_url
+    from nauro.sync.transfer import NullReporter
+
+    seed_auth_config(variant="sync")
+    monkeypatch.setenv("NAURO_API_URL", "https://api.test")
+    store = tmp_path / "store"
+    store.mkdir()
+    (store / "stack.md").write_bytes(b"local")
+    client = MagicMock(spec=httpx.Client)
+    client.get.side_effect = [
+        httpx.Response(403),
+        _response(content=b"other"),
+    ]
+    client.post.return_value = httpx.Response(
+        200,
+        json={
+            "urls": [
+                {
+                    "verb": "PUT",
+                    "path": "stack.md",
+                    "url": "https://api.test/stack",
+                }
+            ]
+        },
+    )
+    client.put.return_value = _response()
+
+    with TransferSession(client=client) as session:
+        pull_report = run_pull("project", store, NullReporter(), session=session)
+        push_report = push_changed_files("project", store, session=session)
+        other = fetch_via_presigned_url("https://objects.test/other", session=session)
+
+    assert pull_report.origin_aborted == ("https://api.test:443",)
+    assert push_report.origin_aborted == ("stack.md",)
+    client.post.assert_not_called()
+    client.put.assert_not_called()
+    assert other.body == b"other"
+
+
+def test_object_404_does_not_trip_the_origin_for_another_object():
+    from nauro.sync.remote import TransferBoundaryError, TransferSession, fetch_via_presigned_url
+
+    client = MagicMock(spec=httpx.Client)
+    client.get.side_effect = [
+        httpx.Response(404),
+        _response(content=b"present"),
+    ]
+
+    with TransferSession(client=client) as session:
+        with pytest.raises(TransferBoundaryError) as caught:
+            fetch_via_presigned_url("https://objects.test/missing", session=session)
+        fetched = fetch_via_presigned_url("https://objects.test/present", session=session)
+
+    assert caught.value.status == 404
+    assert not caught.value.aborts_origin
+    assert fetched.body == b"present"
+    assert client.get.call_count == 2
+
+
+@pytest.mark.parametrize(
+    ("error", "retry", "put_outcome"),
+    [
+        (httpx.PoolTimeout("pool"), "transient", "not-written"),
+        (httpx.WriteTimeout("write"), "transient", "ambiguous"),
+        (httpx.ReadError("read"), "transient", "ambiguous"),
+        (httpx.RemoteProtocolError("protocol"), "transient", "ambiguous"),
+        (RuntimeError("unknown"), "permanent", "ambiguous"),
+    ],
+)
+def test_retry_and_put_outcome_classification_are_independent(error, retry, put_outcome):
+    from nauro.sync.remote import classify_exception
+
+    classification = classify_exception(error, operation="PUT")
+
+    assert classification.retry.value == retry
+    assert classification.write_outcome.value == put_outcome
+
+
+def test_only_presigned_transfer_operations_treat_403_as_an_expiry_candidate():
+    from nauro.sync.remote import TransferOperation, classify_status
+
+    assert classify_status(403, operation=TransferOperation.GET).retry.value == "expired-candidate"
+    assert classify_status(403, operation=TransferOperation.PUT).retry.value == "expired-candidate"
+    assert classify_status(403, operation=TransferOperation.MANIFEST).retry.value == "permanent"
+    assert classify_status(403, operation=TransferOperation.PRESIGN).retry.value == "permanent"
+
+
+def test_push_binds_state_to_the_exact_payload_and_leaves_a_later_edit_pending(
+    tmp_path, monkeypatch
+):
+    from nauro.sync.push import plan_push, push_changed_files
+    from nauro.sync.remote import PutResult, WriteOutcome
+    from nauro.sync.state import load_state
+
+    store = tmp_path / "store"
+    store.mkdir()
+    target = store / "stack.md"
+    target.write_bytes(b"sent")
+    seen: list[bytes] = []
+
+    monkeypatch.setattr(
+        "nauro.sync.remote.request_presigned_urls",
+        lambda *_args, **_kwargs: [
+            {"verb": "PUT", "path": "stack.md", "url": "https://objects.test/stack"}
+        ],
+    )
+
+    def put(_url: str, payload: bytes, **_kwargs):
+        seen.append(payload)
+        target.write_bytes(b"later")
+        return PutResult(etag='"sent"', outcome=WriteOutcome.VERIFIED)
+
+    monkeypatch.setattr("nauro.sync.remote.put_via_presigned_url", put)
+
+    report = push_changed_files("project", store)
+
+    assert report.verified == ("stack.md",)
+    assert seen == [b"sent"]
+    assert load_state(store).files["stack.md"].local_sha256 == hashlib.sha256(b"sent").hexdigest()
+
+    next_plan = plan_push(store, load_state(store))
+    assert tuple(item.relative_path for item in next_plan.candidates) == ("stack.md",)
+
+
+def test_push_report_is_complete_only_when_every_planned_item_is_verified():
+    from nauro.sync.push import PushReport
+
+    assert not PushReport(planned=("stack.md",)).is_complete
+    assert not PushReport(planned=("stack.md",), verified=("other.md",)).is_complete
+    assert PushReport(planned=("stack.md",), verified=("stack.md",)).is_complete
+
+
+def test_pre_send_put_fault_retries_the_frozen_payload_within_the_budget(monkeypatch):
+    from nauro.sync.push import _put_frozen
+    from nauro.sync.remote import (
+        PutResult,
+        TransferBoundaryError,
+        TransferSession,
+        WriteOutcome,
+        classify_exception,
+    )
+
+    classification = classify_exception(httpx.ConnectTimeout("connect"), operation="PUT")
+    error = TransferBoundaryError(
+        operation="PUT",
+        origin="https://objects.test:443",
+        kind=classification.kind,
+        retry=classification.retry,
+        write_outcome=classification.write_outcome,
+    )
+    put = MagicMock(
+        side_effect=[
+            error,
+            error,
+            PutResult(etag='"etag"', outcome=WriteOutcome.VERIFIED),
+        ]
+    )
+    waits: list[float] = []
+    monkeypatch.setattr("nauro.sync.remote.put_via_presigned_url", put)
+    monkeypatch.setattr("nauro.sync.push.pause", waits.append)
+    monkeypatch.setattr("nauro.sync.push.backoff_delay", lambda failures: float(failures))
+
+    with TransferSession(client=MagicMock(spec=httpx.Client)) as session:
+        result = _put_frozen(
+            "project",
+            "stack.md",
+            "https://objects.test/stack",
+            b"frozen",
+            session,
+        )
+
+    assert result.outcome is WriteOutcome.VERIFIED
+    assert [call.args[1] for call in put.call_args_list] == [b"frozen"] * 3
+    assert waits == [1.0, 2.0]
+
+
+def test_put_403_remints_once_before_retrying(monkeypatch):
+    from nauro.sync.push import _put_frozen
+    from nauro.sync.remote import (
+        PutResult,
+        TransferBoundaryError,
+        TransferSession,
+        WriteOutcome,
+        classify_status,
+    )
+
+    classification = classify_status(403, operation="PUT")
+    error = TransferBoundaryError(
+        operation="PUT",
+        origin="https://objects.test:443",
+        status=403,
+        kind=classification.kind,
+        retry=classification.retry,
+        write_outcome=classification.write_outcome,
+    )
+    put = MagicMock(side_effect=[error, PutResult(etag='"etag"', outcome=WriteOutcome.VERIFIED)])
+    presign = MagicMock(
+        return_value=[
+            {
+                "verb": "PUT",
+                "path": "stack.md",
+                "url": "https://objects.test/replacement",
+            }
+        ]
+    )
+    monkeypatch.setattr("nauro.sync.remote.put_via_presigned_url", put)
+    monkeypatch.setattr("nauro.sync.remote.request_presigned_urls", presign)
+
+    with TransferSession(client=MagicMock(spec=httpx.Client)) as session:
+        result = _put_frozen(
+            "project",
+            "stack.md",
+            "https://objects.test/original",
+            b"frozen",
+            session,
+        )
+
+    assert result.outcome is WriteOutcome.VERIFIED
+    assert [call.args[0] for call in put.call_args_list] == [
+        "https://objects.test/original",
+        "https://objects.test/replacement",
+    ]
+    presign.assert_called_once()
+
+
+def test_unverified_put_reconciles_from_one_get_response_and_ignores_manifest_etag(
+    tmp_path, monkeypatch
+):
+    from nauro.sync.push import push_changed_files
+    from nauro.sync.remote import FetchedObject, PutResult, WriteOutcome
+    from nauro.sync.state import load_state
+
+    store = tmp_path / "store"
+    store.mkdir()
+    (store / "stack.md").write_bytes(b"sent")
+    presigns = iter(
+        [
+            [{"verb": "PUT", "path": "stack.md", "url": "https://objects.test/put"}],
+            [{"verb": "GET", "path": "stack.md", "url": "https://objects.test/get"}],
+        ]
+    )
+    monkeypatch.setattr(
+        "nauro.sync.remote.request_presigned_urls", lambda *_args, **_kwargs: next(presigns)
+    )
+    monkeypatch.setattr(
+        "nauro.sync.remote.put_via_presigned_url",
+        lambda *_args, **_kwargs: PutResult(etag="", outcome=WriteOutcome.WRITTEN_UNVERIFIED),
+    )
+    monkeypatch.setattr(
+        "nauro.sync.remote.fetch_manifest",
+        lambda *_args, **_kwargs: [{"path": "stack.md", "etag": '"manifest"'}],
+    )
+    monkeypatch.setattr(
+        "nauro.sync.remote.fetch_via_presigned_url",
+        lambda *_args, **_kwargs: FetchedObject(body=b"sent", etag='"response"'),
+    )
+
+    report = push_changed_files("project", store)
+
+    assert report.verified == ("stack.md",)
+    assert load_state(store).files["stack.md"].remote_etag == '"response"'
+
+
+def test_divergent_reconciliation_fails_without_advancing_state(tmp_path, monkeypatch):
+    from nauro.sync.push import plan_push, push_changed_files
+    from nauro.sync.remote import FetchedObject, PutResult, WriteOutcome
+    from nauro.sync.state import load_state
+
+    store = tmp_path / "store"
+    store.mkdir()
+    (store / "stack.md").write_bytes(b"sent")
+    presigns = iter(
+        [
+            [{"verb": "PUT", "path": "stack.md", "url": "https://objects.test/put"}],
+            [{"verb": "GET", "path": "stack.md", "url": "https://objects.test/get"}],
+        ]
+    )
+    monkeypatch.setattr(
+        "nauro.sync.remote.request_presigned_urls", lambda *_args, **_kwargs: next(presigns)
+    )
+    monkeypatch.setattr(
+        "nauro.sync.remote.put_via_presigned_url",
+        lambda *_args, **_kwargs: PutResult(etag="", outcome=WriteOutcome.WRITTEN_UNVERIFIED),
+    )
+    monkeypatch.setattr(
+        "nauro.sync.remote.fetch_manifest",
+        lambda *_args, **_kwargs: [{"path": "stack.md", "etag": '"manifest"'}],
+    )
+    monkeypatch.setattr(
+        "nauro.sync.remote.fetch_via_presigned_url",
+        lambda *_args, **_kwargs: FetchedObject(body=b"different", etag='"response"'),
+    )
+
+    report = push_changed_files("project", store)
+    state = load_state(store)
+
+    assert report.failed == ("stack.md",)
+    assert "stack.md" not in state.files
+    assert tuple(item.relative_path for item in plan_push(store, state).candidates) == ("stack.md",)
+
+
+@pytest.mark.parametrize(
+    "source_error",
+    [
+        httpx.WriteTimeout("write"),
+        httpx.ReadTimeout("read"),
+        httpx.WriteError("write"),
+        httpx.ReadError("read"),
+        httpx.RemoteProtocolError("protocol"),
+        RuntimeError("unknown"),
+    ],
+)
+def test_ambiguous_put_faults_are_observed_without_a_blind_retry(
+    source_error, tmp_path, monkeypatch
+):
+    from nauro.sync.push import push_changed_files
+    from nauro.sync.remote import (
+        TransferBoundaryError,
+        classify_exception,
+    )
+
+    store = tmp_path / "store"
+    store.mkdir()
+    (store / "stack.md").write_bytes(b"sent")
+    monkeypatch.setattr(
+        "nauro.sync.remote.request_presigned_urls",
+        lambda *_args, **_kwargs: [
+            {"verb": "PUT", "path": "stack.md", "url": "https://objects.test/stack"}
+        ],
+    )
+    classification = classify_exception(source_error, operation="PUT")
+    error = TransferBoundaryError(
+        operation="PUT",
+        origin="https://objects.test:443",
+        kind=classification.kind,
+        retry=classification.retry,
+        write_outcome=classification.write_outcome,
+    )
+    calls = 0
+
+    def put(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        raise error
+
+    monkeypatch.setattr("nauro.sync.remote.put_via_presigned_url", put)
+    monkeypatch.setattr("nauro.sync.remote.fetch_manifest", lambda *_args, **_kwargs: [])
+
+    report = push_changed_files("project", store)
+
+    assert calls == 1
+    assert report.ambiguous == ("stack.md",)
+
+
+def test_http_5xx_put_is_ambiguous_and_is_not_blindly_retried(tmp_path, monkeypatch):
+    from nauro.sync.push import push_changed_files
+    from nauro.sync.remote import TransferBoundaryError, classify_status
+
+    store = tmp_path / "store"
+    store.mkdir()
+    (store / "stack.md").write_bytes(b"sent")
+    monkeypatch.setattr(
+        "nauro.sync.remote.request_presigned_urls",
+        lambda *_args, **_kwargs: [
+            {"verb": "PUT", "path": "stack.md", "url": "https://objects.test/stack"}
+        ],
+    )
+    classification = classify_status(503, operation="PUT")
+    error = TransferBoundaryError(
+        operation="PUT",
+        origin="https://objects.test:443",
+        status=503,
+        kind=classification.kind,
+        retry=classification.retry,
+        write_outcome=classification.write_outcome,
+    )
+    put = MagicMock(side_effect=error)
+    monkeypatch.setattr("nauro.sync.remote.put_via_presigned_url", put)
+    monkeypatch.setattr("nauro.sync.remote.fetch_manifest", lambda *_args, **_kwargs: [])
+
+    report = push_changed_files("project", store)
+
+    put.assert_called_once()
+    assert report.ambiguous == ("stack.md",)
+
+
+@pytest.mark.parametrize(
+    ("case", "expected", "etag"),
+    [
+        ("matching", "verified", '"response"'),
+        ("missing-etag", "pending", ""),
+        ("divergent", "divergent", ""),
+        ("absent", "pending", ""),
+        ("failed", "pending", ""),
+    ],
+)
+def test_reconciliation_outcomes_use_one_get_response(case, expected, etag, monkeypatch):
+    from nauro.sync.push import _reconcile
+    from nauro.sync.remote import FetchedObject, PresignError, TransferSession
+
+    payload_sha = hashlib.sha256(b"sent").hexdigest()
+    monkeypatch.setattr(
+        "nauro.sync.remote.fetch_manifest",
+        lambda *_args, **_kwargs: (
+            [] if case == "absent" else [{"path": "stack.md", "etag": '"manifest"'}]
+        ),
+    )
+    monkeypatch.setattr(
+        "nauro.sync.remote.request_presigned_urls",
+        lambda *_args, **_kwargs: [
+            {"verb": "GET", "path": "stack.md", "url": "https://objects.test/get"}
+        ],
+    )
+
+    def fetch(*_args, **_kwargs):
+        if case == "failed":
+            raise PresignError("observation failed")
+        body = b"different" if case == "divergent" else b"sent"
+        response_etag = "" if case == "missing-etag" else '"response"'
+        return FetchedObject(body, response_etag)
+
+    monkeypatch.setattr("nauro.sync.remote.fetch_via_presigned_url", fetch)
+
+    with TransferSession(client=MagicMock(spec=httpx.Client)) as session:
+        outcome = _reconcile("project", "stack.md", payload_sha, session)
+
+    assert outcome.kind.value == expected
+    assert outcome.etag == etag
+
+
+def test_checkpoint_failure_stops_the_batch_and_preserves_prior_state(tmp_path, monkeypatch):
+    from nauro.sync import state as state_module
+    from nauro.sync.push import push_changed_files
+    from nauro.sync.remote import PutResult, WriteOutcome
+
+    store = tmp_path / "store"
+    store.mkdir()
+    for name in ("a.md", "b.md", "c.md"):
+        (store / name).write_text(name)
+    monkeypatch.setattr(
+        "nauro.sync.remote.request_presigned_urls",
+        lambda _project, operations, **_kwargs: [
+            {
+                "verb": "PUT",
+                "path": operation["path"],
+                "url": f"https://objects.test/{operation['path']}",
+            }
+            for operation in operations
+        ],
+    )
+    put = MagicMock(
+        side_effect=lambda url, *_args, **_kwargs: PutResult(
+            etag=f'"{url.rsplit("/", 1)[1]}"', outcome=WriteOutcome.VERIFIED
+        )
+    )
+    monkeypatch.setattr("nauro.sync.remote.put_via_presigned_url", put)
+    real_save = state_module.save_state
+    saves = 0
+
+    def save(store_path, state):
+        nonlocal saves
+        saves += 1
+        if saves == 2:
+            raise OSError("disk full")
+        real_save(store_path, state)
+
+    monkeypatch.setattr(state_module, "save_state", save)
+
+    report = push_changed_files("project", store)
+
+    assert report.verified == report.planned[:1]
+    assert report.failed == report.planned[1:]
+    assert put.call_count == 2
+    persisted = state_module.load_state(store)
+    assert tuple(persisted.files) == report.verified


### PR DESCRIPTION
## Why

Legacy sync created a new HTTP client for each request. This amplified resolver and TLS failures during large syncs. The PUT path could also retry or lose track of writes whose result was uncertain.

## What changed

- Reuse one bounded HTTP client for each sync, restore, session-start pull, post-write push, and initial link push.
- Classify transport faults separately from PUT write outcomes. Sanitize boundary errors and stop calls to an origin after a TLS certificate failure or permanent API endpoint failure, including malformed or invalid API responses.
- Keep object-specific HTTP failures scoped to their object instead of tripping the whole object origin.
- Freeze each PUT payload before transmission. Retry only proven pre-send failures, and re-mint an expired presigned URL once.
- Reconcile ambiguous and unverified writes through a fresh manifest and GET response before advancing sync state.
- Return structured push reports, checkpoint each verified item, and surface incomplete publication through CLI and MCP outcomes.

## Test plan

- `ruff format --check packages/ benchmarks/`
- `ruff check packages/ benchmarks/`
- Full package suite: 2,634 passed, 10 skipped.
- `python scripts/check_single_sourced.py packages/nauro/src`
- `python scripts/check_server_json_version.py`
- `python -m build packages/nauro/`

## Risk / what to review

Review the transport classification matrix, origin circuit scope, PUT reconciliation rules, operation-scoped client lifetime, and incomplete-report propagation. These paths decide when a write can retry and when local sync state may advance.

## Deferred

This change does not alter the generation transport or hosted server transport. S3 writes and local sync-state writes remain non-atomic. Per-item checkpoints reduce that existing exposure.
