### PR TITLE
Pin MCP SDK 1 and smoke built wheels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
         with:
           python-version: "3.12"
       - run: pip install ruff==0.15.8
-      - run: ruff check packages/ benchmarks/
-      - run: ruff format --check packages/ benchmarks/
+      - run: ruff check packages/ benchmarks/ scripts/
+      - run: ruff format --check packages/ benchmarks/ scripts/
       - run: python scripts/check_single_sourced.py packages/nauro/src
       - run: python scripts/check_server_json_version.py
 
@@ -53,3 +53,63 @@ jobs:
       - run: uv python install ${{ matrix.python-version }}
       - run: uv sync --locked --package nauro --all-extras --python ${{ matrix.python-version }}
       - run: uv run --no-sync --package nauro pytest packages/nauro/tests/ --ignore=packages/nauro/tests/cross_surface -v --tb=short
+
+  distribution:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v6
+      - run: uv python install 3.12
+      - run: |
+          UV_PROJECT_ENVIRONMENT="$RUNNER_TEMP/nauro-build-env" \
+            uv sync --locked --package nauro --extra dev --no-install-workspace --python 3.12
+      - name: Build wheels from locked tooling
+        run: |
+          mkdir "$RUNNER_TEMP/nauro-wheel-build"
+          uv build --package nauro-core --wheel --no-build-isolation \
+            --python "$RUNNER_TEMP/nauro-build-env/bin/python" \
+            --out-dir "$RUNNER_TEMP/nauro-wheel-build"
+          uv build --package nauro --wheel --no-build-isolation \
+            --python "$RUNNER_TEMP/nauro-build-env/bin/python" \
+            --out-dir "$RUNNER_TEMP/nauro-wheel-build"
+      - name: Smoke test the built wheel
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          wheel_paths=("$RUNNER_TEMP"/nauro-wheel-build/nauro-*.whl)
+          core_wheel_paths=("$RUNNER_TEMP"/nauro-wheel-build/nauro_core-*.whl)
+          if (( ${#wheel_paths[@]} != 1 )); then
+            echo "expected one nauro wheel, found ${#wheel_paths[@]}" >&2
+            exit 1
+          fi
+          if (( ${#core_wheel_paths[@]} != 1 )); then
+            echo "expected one nauro-core wheel, found ${#core_wheel_paths[@]}" >&2
+            exit 1
+          fi
+          smoke_root="$(mktemp -d "$RUNNER_TEMP/nauro-wheel-smoke.XXXXXX")"
+          smoke_env="$smoke_root/venv"
+          requirements="$smoke_root/requirements.txt"
+          uv export --quiet --locked --package nauro --no-dev --no-emit-workspace \
+            --output-file "$requirements"
+          uv venv --python 3.12 "$smoke_env"
+          uv pip install --python "$smoke_env/bin/python" --require-hashes \
+            --requirements "$requirements"
+          uv pip install --python "$smoke_env/bin/python" --no-deps \
+            "${core_wheel_paths[0]}" "${wheel_paths[0]}"
+          wheel_name="$(basename "${wheel_paths[0]}")"
+          core_wheel_name="$(basename "${core_wheel_paths[0]}")"
+          expected_version="${wheel_name#nauro-}"
+          expected_version="${expected_version%%-*}"
+          expected_core_version="${core_wheel_name#nauro_core-}"
+          expected_core_version="${expected_core_version%%-*}"
+          mkdir "$smoke_root/home" "$smoke_root/work"
+          cd "$smoke_root/work"
+          EXPECTED_NAURO_VERSION="$expected_version" \
+            EXPECTED_CORE_VERSION="$expected_core_version" \
+            "$smoke_env/bin/python" -c \
+            'import nauro, nauro_core, os; from importlib.metadata import version; from pathlib import Path; checkout = Path(os.environ["GITHUB_WORKSPACE"]).resolve(); sources = [Path(module.__file__).resolve() for module in (nauro, nauro_core)]; assert all(checkout not in source.parents for source in sources), sources; assert version("nauro") == os.environ["EXPECTED_NAURO_VERSION"]; assert version("nauro-core") == os.environ["EXPECTED_CORE_VERSION"]'
+          env -u PYTHONPATH NAURO_HOME="$smoke_root/home" \
+            "$smoke_env/bin/python" \
+            "$GITHUB_WORKSPACE/scripts/smoke_nauro_wheel_stdio.py" \
+            "$smoke_env/bin/nauro"

--- a/.github/workflows/publish-nauro.yml
+++ b/.github/workflows/publish-nauro.yml
@@ -12,7 +12,7 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
       - run: uv python install 3.12
       - run: uv build --package nauro --python 3.12 --out-dir packages/nauro/dist
       - name: Smoke test the built wheel

--- a/.github/workflows/publish-nauro.yml
+++ b/.github/workflows/publish-nauro.yml
@@ -12,11 +12,30 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-      - run: pip install build
-      - run: python -m build packages/nauro/
+      - uses: astral-sh/setup-uv@v6
+      - run: uv python install 3.12
+      - run: uv build --package nauro --python 3.12 --out-dir packages/nauro/dist
+      - name: Smoke test the built wheel
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          wheel_paths=("$GITHUB_WORKSPACE"/packages/nauro/dist/nauro-*.whl)
+          if (( ${#wheel_paths[@]} != 1 )); then
+            echo "expected one nauro wheel, found ${#wheel_paths[@]}" >&2
+            exit 1
+          fi
+          smoke_root="$(mktemp -d "$RUNNER_TEMP/nauro-wheel-smoke.XXXXXX")"
+          uv venv --python 3.12 "$smoke_root/venv"
+          uv pip install --python "$smoke_root/venv/bin/python" "${wheel_paths[0]}"
+          mkdir "$smoke_root/home" "$smoke_root/work"
+          cd "$smoke_root/work"
+          "$smoke_root/venv/bin/python" -c \
+            'import nauro, os; from pathlib import Path; source = Path(nauro.__file__).resolve(); checkout = Path(os.environ["GITHUB_WORKSPACE"]).resolve(); assert checkout not in source.parents, source'
+          env -u PYTHONPATH NAURO_HOME="$smoke_root/home" \
+            "$smoke_root/venv/bin/python" \
+            "$GITHUB_WORKSPACE/scripts/smoke_nauro_wheel_stdio.py" \
+            "$smoke_root/venv/bin/nauro"
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: packages/nauro/dist/

--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "nauro-core>=1.11.0,<2",
     "typer>=0.9",
     "httpx>=0.24",
-    "mcp>=1.0",
+    "mcp>=1.0,<2",
     "filelock>=3.20.3",
     "tomli>=2.0; python_version<'3.11'",
     "tomlkit>=0.13.2",
@@ -33,6 +33,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+    "hatchling",
     "pytest>=7.0",
     "pytest-asyncio>=0.21",
     "ruff>=0.1",

--- a/scripts/smoke_nauro_wheel_stdio.py
+++ b/scripts/smoke_nauro_wheel_stdio.py
@@ -1,0 +1,268 @@
+import argparse
+import json
+import os
+import queue
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+TIMEOUT_SECONDS = 30
+EXPECTED_CONTEXT_MARKER = "wheel-smoke project resolved through installed wheel"
+EXPECTED_TOOLS = {
+    "check_decision",
+    "diff_since_last_session",
+    "flag_question",
+    "get_context",
+    "get_decision",
+    "get_raw_file",
+    "list_decisions",
+    "propose_decision",
+    "search_decisions",
+    "update_state",
+}
+
+
+class SmokeFailure(RuntimeError):
+    pass
+
+
+class StdioSession:
+    def __init__(self, executable: str, cwd: Path, env: dict[str, str]) -> None:
+        self.process = subprocess.Popen(
+            [executable, "serve", "--stdio"],
+            cwd=cwd,
+            env=env,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+        )
+        self.stdout_lines: queue.Queue[str | None] = queue.Queue()
+        self.stderr_lines: list[str] = []
+        self.stdout_reader = threading.Thread(target=self._read_stdout, daemon=True)
+        self.stderr_reader = threading.Thread(target=self._read_stderr, daemon=True)
+        self.stdout_reader.start()
+        self.stderr_reader.start()
+
+    def _read_stdout(self) -> None:
+        assert self.process.stdout is not None
+        for line in self.process.stdout:
+            self.stdout_lines.put(line)
+        self.stdout_lines.put(None)
+
+    def _read_stderr(self) -> None:
+        assert self.process.stderr is not None
+        self.stderr_lines.extend(self.process.stderr)
+
+    def send(self, message: dict[str, Any]) -> None:
+        if self.process.stdin is None:
+            raise SmokeFailure("stdio server stdin is unavailable")
+        self.process.stdin.write(json.dumps(message, separators=(",", ":")) + "\n")
+        self.process.stdin.flush()
+
+    def request(self, request_id: int, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        self.send(
+            {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "method": method,
+                "params": params,
+            }
+        )
+        response = self._receive(request_id)
+        if "error" in response:
+            raise SmokeFailure(f"{method} returned an error: {response['error']!r}")
+        result = response.get("result")
+        if not isinstance(result, dict):
+            raise SmokeFailure(f"{method} returned an invalid result: {result!r}")
+        return result
+
+    def _receive(self, request_id: int) -> dict[str, Any]:
+        deadline = time.monotonic() + TIMEOUT_SECONDS
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise SmokeFailure(f"timed out waiting for JSON-RPC response {request_id}")
+            try:
+                line = self.stdout_lines.get(timeout=remaining)
+            except queue.Empty as exc:
+                raise SmokeFailure(
+                    f"timed out waiting for JSON-RPC response {request_id}"
+                ) from exc
+            if line is None:
+                raise SmokeFailure(f"stdio server exited before JSON-RPC response {request_id}")
+            try:
+                message = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise SmokeFailure(f"stdio server emitted non-JSON output: {line!r}") from exc
+            if not isinstance(message, dict):
+                raise SmokeFailure(f"stdio server emitted an invalid message: {message!r}")
+            if message.get("id") == request_id:
+                return message
+            if "id" in message:
+                raise SmokeFailure(
+                    f"expected JSON-RPC response {request_id}, got {message.get('id')!r}"
+                )
+
+    def close(self) -> None:
+        if self.process.stdin is not None and not self.process.stdin.closed:
+            self.process.stdin.close()
+        try:
+            return_code = self.process.wait(timeout=TIMEOUT_SECONDS)
+        except subprocess.TimeoutExpired as exc:
+            self.process.kill()
+            self.process.wait(timeout=TIMEOUT_SECONDS)
+            raise SmokeFailure("stdio server did not exit after stdin closed") from exc
+        self.stdout_reader.join(timeout=TIMEOUT_SECONDS)
+        self.stderr_reader.join(timeout=TIMEOUT_SECONDS)
+        if self.stdout_reader.is_alive() or self.stderr_reader.is_alive():
+            raise SmokeFailure("stdio reader did not stop after the server exited")
+        if return_code != 0:
+            raise SmokeFailure(f"stdio server exited with status {return_code}")
+
+    def stderr(self) -> str:
+        return "".join(self.stderr_lines).strip()
+
+
+def initialize_project(executable: str, cwd: Path, env: dict[str, str]) -> None:
+    try:
+        completed = subprocess.run(
+            [executable, "init", "wheel-smoke"],
+            cwd=cwd,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=TIMEOUT_SECONDS,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise SmokeFailure("nauro init timed out") from exc
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip()
+        raise SmokeFailure(f"nauro init failed with status {completed.returncode}: {detail}")
+    try:
+        completed = subprocess.run(
+            [executable, "update-state", EXPECTED_CONTEXT_MARKER],
+            cwd=cwd,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=TIMEOUT_SECONDS,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise SmokeFailure("nauro update-state timed out") from exc
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip()
+        raise SmokeFailure(
+            f"nauro update-state failed with status {completed.returncode}: {detail}"
+        )
+
+
+def run_smoke(executable: str) -> None:
+    nauro_home_value = os.environ.get("NAURO_HOME")
+    if not nauro_home_value:
+        raise SmokeFailure("NAURO_HOME must point to a clean test directory")
+    nauro_home = Path(nauro_home_value)
+    nauro_home.mkdir(parents=True, exist_ok=True)
+    if any(nauro_home.iterdir()):
+        raise SmokeFailure("NAURO_HOME must be empty before the smoke test")
+
+    env = os.environ.copy()
+    env.pop("PYTHONPATH", None)
+    with tempfile.TemporaryDirectory(prefix="nauro-wheel-smoke-") as workspace_value:
+        workspace = Path(workspace_value)
+        initialize_project(executable, workspace, env)
+        session = StdioSession(executable, workspace, env)
+        failure: Exception | None = None
+        try:
+            initialize_result = session.request(
+                1,
+                "initialize",
+                {
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {},
+                    "clientInfo": {"name": "nauro-wheel-smoke", "version": "1"},
+                },
+            )
+            if initialize_result.get("protocolVersion") != "2025-11-25":
+                raise SmokeFailure(
+                    "initialize did not negotiate legacy protocol version 2025-11-25"
+                )
+            if not isinstance(initialize_result.get("serverInfo"), dict):
+                raise SmokeFailure("initialize result is missing serverInfo")
+
+            session.send({"jsonrpc": "2.0", "method": "notifications/initialized"})
+            tools_result = session.request(2, "tools/list", {})
+            tools = tools_result.get("tools")
+            if not isinstance(tools, list):
+                raise SmokeFailure("tools/list result is missing tools")
+            tool_names = {
+                tool.get("name") for tool in tools if isinstance(tool, dict) and tool.get("name")
+            }
+            if len(tools) != len(EXPECTED_TOOLS) or tool_names != EXPECTED_TOOLS:
+                raise SmokeFailure(
+                    f"tools/list returned {sorted(tool_names)!r}; "
+                    f"expected {sorted(EXPECTED_TOOLS)!r}"
+                )
+
+            context_result = session.request(
+                3,
+                "tools/call",
+                {
+                    "name": "get_context",
+                    "arguments": {"cwd": str(workspace), "level": "L0"},
+                },
+            )
+            if context_result.get("isError") is True:
+                raise SmokeFailure(f"get_context returned an error: {context_result!r}")
+            content = context_result.get("content")
+            context_text = (
+                "\n".join(
+                    item["text"]
+                    for item in content
+                    if isinstance(item, dict)
+                    and item.get("type") == "text"
+                    and isinstance(item.get("text"), str)
+                )
+                if isinstance(content, list)
+                else ""
+            )
+            if EXPECTED_CONTEXT_MARKER not in context_text:
+                raise SmokeFailure(
+                    "get_context did not return the state seeded for the wheel-smoke project: "
+                    f"{content!r}"
+                )
+        except Exception as exc:
+            failure = exc
+        try:
+            session.close()
+        except Exception as exc:
+            if failure is None:
+                failure = exc
+        if failure is not None:
+            stderr = session.stderr()
+            detail = f"\nstdio server stderr:\n{stderr}" if stderr else ""
+            raise SmokeFailure(f"{failure}{detail}") from failure
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("nauro_executable")
+    args = parser.parse_args()
+    try:
+        run_smoke(args.nauro_executable)
+    except (OSError, SmokeFailure) as exc:
+        print(f"nauro wheel stdio smoke failed: {exc}", file=sys.stderr)
+        return 1
+    print("nauro wheel stdio smoke passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/uv.lock
+++ b/uv.lock
@@ -450,6 +450,23 @@ wheels = [
 ]
 
 [[package]]
+name = "hatchling"
+version = "1.32.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pluggy" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "tomlkit" },
+    { name = "trove-classifiers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/08/33331757185504aae48b8d9bd78cec03a76e3aecfb52e549d05a2347c0dd/hatchling-1.32.0.tar.gz", hash = "sha256:0bdbde4a52b06c37e3eca395f85a762bf0ef06fe374fd8ae429dc6be10230f5f", size = 57783, upload-time = "2026-08-11T05:03:44.114Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/84/1798b6d85ecde0e31546004efd25c5de1b1f49250644a60cce460e12593a/hatchling-1.32.0-py3-none-any.whl", hash = "sha256:0e17c9c3b9aa7c625acc8d0f5b622f107d5049af9ecf5ada4de1aada5be7cdbc", size = 78435, upload-time = "2026-08-11T05:03:42.644Z" },
+]
+
+[[package]]
 name = "hf-xet"
 version = "1.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -942,6 +959,7 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "hatchling" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -954,8 +972,9 @@ embeddings = [
 [package.metadata]
 requires-dist = [
     { name = "filelock", specifier = ">=3.20.3" },
+    { name = "hatchling", marker = "extra == 'dev'" },
     { name = "httpx", specifier = ">=0.24" },
-    { name = "mcp", specifier = ">=1.0" },
+    { name = "mcp", specifier = ">=1.0,<2" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0" },
     { name = "nauro-core", editable = "packages/nauro-core" },
     { name = "nauro-core", extras = ["embeddings"], marker = "extra == 'embeddings'", editable = "packages/nauro-core" },
@@ -2098,6 +2117,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/87/d7/0535a28b1f5f24f6612fb3ff1e89fb1a8d160fee0f976e0aa6803862134b/tqdm-4.68.3.tar.gz", hash = "sha256:00dfa48452b6b6cfae3dd9885636c23d3422d1ec97c66d96818cbd5e0821d482", size = 170596, upload-time = "2026-06-17T07:36:52.105Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d8/8e/bb97bb0c71802080bfc8952937d174e49cfc50de5c951dd47b2496f0dcdb/tqdm-4.68.3-py3-none-any.whl", hash = "sha256:39832cc2def2789a6f29df83f172db7416cea70052c0907a57801c5f2fdccb03", size = 78337, upload-time = "2026-06-17T07:36:50.132Z" },
+]
+
+[[package]]
+name = "trove-classifiers"
+version = "2026.6.1.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/e3/7ca82ee24c82d344584abd5b8637b3bd056f2900226e8d82fc22f1184b92/trove_classifiers-2026.6.1.19.tar.gz", hash = "sha256:c5132b4b61a829d11cfbd2d72e97f20a45ed6edb95e45c5efdeb5e00836b2745", size = 17059, upload-time = "2026-06-01T19:41:34.649Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/a4/81502f486f01db95bc8320646a8a12511f5e556cb63d5e224d91816605c4/trove_classifiers-2026.6.1.19-py3-none-any.whl", hash = "sha256:ab4c4ec93cc4a4e7815fa759906e05e6bb3f2fbd92ea0f897288c6a43efd15b3", size = 14211, upload-time = "2026-06-01T19:41:33.434Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

Fresh installs can resolve MCP Python SDK 2 against the local server's FastMCP implementation. `nauro serve --stdio` then crashes before the initialize handshake. The locked test environment and the existing publish workflow did not test a freshly resolved built wheel.

## What changed

- Constrain the published `nauro` package to `mcp>=1.0,<2` and refresh the lock file.
- Add Hatchling to the existing development extra so PR build tooling is pinned in `uv.lock`.
- Add a standalone stdlib JSON-RPC smoke for the installed `nauro` executable.
- Seed a unique state marker in the temporary `wheel-smoke` project and require `get_context` to return that marker.
- Add a Python 3.12 distribution job that syncs build tooling from the committed lock without installing workspace packages.
- Build exact local `nauro-core` and `nauro` wheels with build isolation disabled.
- Export hashed runtime requirements from the committed lock, install them in an external uv environment, and install both local wheels with `--no-deps`.
- Assert that both installed package versions match their wheel filenames and that both import from outside the checkout.
- Build publish artifacts with uv, install the `nauro` wheel with fresh dependency resolution, and run the smoke before upload.
- Include repository scripts in Ruff checks.

## Test plan

- Ran `uv lock`.
- Ran Ruff 0.15.8 format and lint checks for `packages/` and `scripts/`.
- Parsed both changed workflow files as YAML.
- Ran the focused stdio suite: 81 passed.
- Ran the full Nauro suite excluding `cross_surface`: 2,634 passed.
- Simulated the PR distribution job. Hatchling and runtime dependencies came from the committed lock, both workspace wheels built without build isolation, MCP resolved to 1.28.1, package paths and versions matched the installed artifacts, and the wheel smoke passed.
- Simulated the publish job with fresh dependency resolution. MCP resolved to 1.29.0, the package imported outside the checkout, and the wheel smoke passed.
- Confirmed the pre-fix wheel resolved MCP 2.0.0 and failed at the `FastMCP` import.

## Risk / what to review

PR CI installs no workspace package from PyPI. It builds both workspace wheels locally, which supports a same-PR unpublished `nauro-core` version. Build tooling and runtime dependencies come from the committed lock. Hashed exported requirements prevent dependency drift.

The publish job deliberately resolves `nauro-core` from PyPI because the release sequence publishes core first.

The smoke initializes a temporary project through the installed executable, seeds a unique state marker, and starts that same executable with `serve --stdio`. It uses bounded timeouts and includes server stderr in failures.

## Deferred

The MCP SDK 2 migration remains separate. It must cover the modern protocol, provenance and error semantics, worker-thread concurrency, and offline OpenTelemetry behavior. The hosted hand-written JSON-RPC runtime remains unchanged.
