### PR TITLE
Release nauro 1.14.1

### DIFF
--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro"
-version = "1.14.0"
+version = "1.14.1"
 description = "Human-approved project judgment and current state for connected AI agents, surfaced before work."
 readme = "README.md"
 license = "Apache-2.0"

--- a/server.json
+++ b/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Nauro-AI/nauro",
     "source": "github"
   },
-  "version": "1.14.0",
+  "version": "1.14.1",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "nauro",
-      "version": "1.14.0",
+      "version": "1.14.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -945,7 +945,7 @@ wheels = [
 
 [[package]]
 name = "nauro"
-version = "1.14.0"
+version = "1.14.1"
 source = { editable = "packages/nauro" }
 dependencies = [
     { name = "filelock" },


### PR DESCRIPTION
## Why

Nauro 1.14.0 can resolve MCP Python SDK 2 on a fresh install, which prevents the local stdio server from starting. Main now contains the dependency cap, built-wheel release smoke, and the latest sync-correctness fixes.

## What changed

- Bump `nauro` from 1.14.0 to 1.14.1.
- Keep `nauro-core` at 1.11.0 because no core code changed.
- Update `server.json` and `uv.lock` to the same Nauro version.

## Test plan

- Ran `uv lock` and `uv lock --check`.
- Ran `scripts/check_server_json_version.py`.
- Built and fresh-installed the Nauro 1.14.1 wheel with published `nauro-core` 1.11.0.
- Passed the installed-wheel stdio smoke with MCP 1.29.0.
- Confirmed `nauro --version` reports 1.14.1.

## Release

After merge, push `nauro-v1.14.1`. The tag publishes PyPI first, then publishes the matching `server.json` to the MCP Registry. No `nauro-core` tag is required.
