### PR TITLE
Report omitted open questions in L0 context

### DIFF
--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro-core"
-version = "1.11.0"
+version = "1.12.0"
 description = "Shared pure-Python logic for Nauro: parsing, validation, context assembly, constants."
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/nauro-core/src/nauro_core/context.py
+++ b/packages/nauro-core/src/nauro_core/context.py
@@ -280,13 +280,13 @@ def _render_open_questions(
 
 
 def _render_l0_open_questions(content: str) -> str:
-    """Render the L0 open-questions body: top 3 genuine entries, no trailer."""
+    """Render the L0 open-questions body with its capped omission report."""
     if not content.strip():
         return ""
     return _render_open_questions(
         OpenQuestionsFile.parse(content),
         L0_QUESTIONS_LIMIT,
-        include_omission_trailer=False,
+        include_omission_trailer=True,
     )
 
 

--- a/packages/nauro-core/tests/test_context.py
+++ b/packages/nauro-core/tests/test_context.py
@@ -4,6 +4,7 @@ from datetime import date as _date
 from datetime import datetime, timedelta, timezone
 
 from nauro_core.constants import (
+    L0_QUESTIONS_LIMIT,
     PROJECT_MD_SCAFFOLD_BODY,
     QUESTION_ENTRY_CHAR_BUDGET,
     STACK_AUTO_CHAR_BUDGET,
@@ -354,8 +355,8 @@ class TestBuildL2:
         # Every project/stack/questions string L1 surfaces must also appear in
         # the full dump, and L2 must additionally carry superseded decisions
         # and the nested stack rationale L1's bounded projection drops.
-        # L1's omission trailer and age-nudge lines are projection annotations,
-        # not store content, so they are absent from L2 (same as L0's today).
+        # L0/L1 omission trailers and age-nudge lines are projection annotations,
+        # not store content, so they are absent from L2.
         l1 = build_l1(FULL_FILES, DECISIONS)
         l2 = build_l2(FULL_FILES, DECISIONS)
         for marker in (
@@ -438,7 +439,7 @@ class TestBuildL0OpenQuestionsAgeProjection:
         assert self._PROJECTION_PREFIX not in result
 
     def test_only_first_three_open_entries_render(self):
-        # Honours L0_QUESTIONS_LIMIT (3). The fourth open entry is dropped
+        # Honours L0_QUESTIONS_LIMIT (3). The fourth open entry is omitted
         # even when older than 30 days; the projection doesn't expand the cap.
         today = self._today()
         content = (
@@ -454,6 +455,10 @@ class TestBuildL0OpenQuestionsAgeProjection:
         assert "second?" in result
         assert "third?" in result
         assert "fourth?" not in result
+        assert (
+            '(+1 more open questions — see get_raw_file("open-questions.md") '
+            "for the full file, including resolved history)"
+        ) in result
 
     def test_resolved_entries_skipped_in_l0(self):
         # Entries physically under ## Resolved (position-based partition)
@@ -551,8 +556,8 @@ class TestBuildL0DiscoveryPointerExclusion:
         assert "SELECT:" not in result
 
     def test_pointer_does_not_consume_limit_slot(self):
-        # With limit = 3, three genuine questions plus two pointers should all
-        # three genuine questions appear (pointers do not count toward the cap).
+        # The three pointers consume no slots, and the trailer counts only the
+        # fourth genuine question omitted beyond the cap.
         content = (
             "# Open Questions\n"
             "\n"
@@ -562,6 +567,7 @@ class TestBuildL0DiscoveryPointerExclusion:
             "- [Q4] RESUME: context/b.md — pointer two\n"
             "- [Q5] Third genuine question?\n"
             "- [Q6] Fourth genuine question — should be cut by limit?\n"
+            "- [Q7] SELECT: context/c.md — pointer three\n"
         )
         result = build_l0(self._files(content), [])
         assert "First genuine question?" in result
@@ -570,6 +576,11 @@ class TestBuildL0DiscoveryPointerExclusion:
         assert "Fourth genuine question" not in result
         assert "BRIEF:" not in result
         assert "RESUME:" not in result
+        assert "SELECT:" not in result
+        assert (
+            '(+1 more open questions — see get_raw_file("open-questions.md") '
+            "for the full file, including resolved history)"
+        ) in result
 
     def test_pointer_free_file_unaffected(self):
         content = (
@@ -732,12 +743,36 @@ class TestBuildL1OpenQuestionsProjection:
         assert "(open 45 days; consider closing or deferring)" in result
         assert "Stale at L1?" in result
 
-    def test_l0_never_carries_trailer(self):
-        # The trailer is an L1 annotation only; L0 output stays byte-stable
-        # (the surface parity baseline pins L0 bytes).
-        content = "# Open Questions\n\n" + self._genuine(12)
+    def test_l0_cap_enforced_with_exact_trailer(self):
+        content = "# Open Questions\n\n" + self._genuine(5)
         result = build_l0(self._files(content), [])
-        assert "more open questions" not in result
+
+        assert L0_QUESTIONS_LIMIT == 3
+        for i in range(1, 4):
+            assert f"Genuine question {i}?" in result
+        assert "Genuine question 4?" not in result
+        assert "Genuine question 5?" not in result
+        assert self._TRAILER_2 in result
+        assert result.count("more open questions") == 1
+
+    def test_l0_trailer_absent_at_or_below_cap(self):
+        for count in (L0_QUESTIONS_LIMIT - 1, L0_QUESTIONS_LIMIT):
+            content = "# Open Questions\n\n" + self._genuine(count)
+            result = build_l0(self._files(content), [])
+
+            assert f"Genuine question {count}?" in result
+            assert "more open questions" not in result
+
+    def test_l0_and_l1_use_identical_trailer_for_same_omitted_count(self):
+        l0 = build_l0(
+            self._files("# Open Questions\n\n" + self._genuine(L0_QUESTIONS_LIMIT + 2)),
+            [],
+        )
+        l1 = build_l1(self._files("# Open Questions\n\n" + self._genuine(12)), [])
+
+        l0_trailer = next(line for line in l0.splitlines() if line.startswith("(+"))
+        l1_trailer = next(line for line in l1.splitlines() if line.startswith("(+"))
+        assert l0_trailer == l1_trailer == self._TRAILER_2
 
 
 class TestQuestionEntryCharBudget:

--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "nauro-core>=1.11.0,<2",
+    "nauro-core>=1.12.0,<2",
     "typer>=0.9",
     "httpx>=0.24",
     "mcp>=1.0,<2",

--- a/packages/nauro/tests/test_agents_md.py
+++ b/packages/nauro/tests/test_agents_md.py
@@ -333,6 +333,31 @@ def test_sync_agents_md_truncates_over_budget_question_like_l0(tmp_path: Path, m
     assert "UNIQUE-TAIL-MARKER" not in content
 
 
+def test_sync_agents_md_carries_l0_question_omission_trailer(tmp_path: Path, monkeypatch):
+    from nauro.store.registry import register_project_v2
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _pid, store = register_project_v2("myproj", [repo])
+    scaffold_project_store("myproj", store)
+    questions = "".join(f"- [Q{i}] Genuine question {i}?\n" for i in range(1, 6))
+    (store / "open-questions.md").write_text("# Open Questions\n\n" + questions)
+    monkeypatch.chdir(repo)
+
+    result = runner.invoke(app, ["sync"])
+    assert result.exit_code == 0
+
+    content = (repo / "AGENTS.md").read_text()
+    assert "Genuine question 1?" in content
+    assert "Genuine question 3?" in content
+    assert "Genuine question 4?" not in content
+    assert "Genuine question 5?" not in content
+    assert (
+        '(+2 more open questions — see get_raw_file("open-questions.md") '
+        "for the full file, including resolved history)"
+    ) in content
+
+
 def test_sync_multi_repo(tmp_path: Path, monkeypatch):
     from nauro.store.registry import register_project_v2
 

--- a/packages/nauro/tests/test_get_context_parity.py
+++ b/packages/nauro/tests/test_get_context_parity.py
@@ -24,12 +24,14 @@ from datetime import date
 from pathlib import Path
 
 import pytest
+from nauro_core.constants import L0_QUESTIONS_LIMIT
 from nauro_core.decision_model import (
     Decision,
     DecisionConfidence,
     DecisionStatus,
     format_decision,
 )
+from nauro_core.questions import OpenQuestionsFile
 from nauro_core.renderers import RENDERERS
 
 from nauro.constants import REPO_CONFIG_MODE_LOCAL
@@ -243,5 +245,8 @@ def _seed_baseline_store(store_path: Path) -> None:
 def test_l0_content_matches_main_byte_for_byte(tmp_path):
     store_path = tmp_path / "store"
     _seed_baseline_store(store_path)
+    questions = OpenQuestionsFile.parse((store_path / "open-questions.md").read_text())
+
+    assert len(questions.genuine_open_entries) < L0_QUESTIONS_LIMIT
     envelope = tool_get_context(store_path, 0)
     assert envelope["content"] == _BASELINE_L0

--- a/uv.lock
+++ b/uv.lock
@@ -989,7 +989,7 @@ provides-extras = ["dev", "embeddings"]
 
 [[package]]
 name = "nauro-core"
-version = "1.11.0"
+version = "1.12.0"
 source = { editable = "packages/nauro-core" }
 dependencies = [
     { name = "bm25s" },


### PR DESCRIPTION
## Why

L0 context showed the first three genuine open questions without indicating when more existed. Generated `AGENTS.md` carried the same incomplete view.

## What changed

L0 now appends the existing shared omission trailer when genuine questions exceed the three-question cap. Discovery pointers and resolved entries remain excluded from the cap and omitted count.

Regression coverage pins the exact trailer, cap behavior, L0 and L1 equality, baseline parity, and generated `AGENTS.md` output. `nauro-core` is now 1.12.0, and `nauro` requires `nauro-core>=1.12.0,<2`.

## Risk / what to review

Publish `nauro-core` 1.12.0 before the next `nauro` release. Until then, non-workspace source installs cannot resolve the raised dependency floor.

The first sync with this behavior rewrites generated `AGENTS.md` in each wired repository and reruns the write-coupled Claude bridge once per actual rewrite. A later unchanged sync remains a no-op.

## Test plan

- Targeted regression tests: 6 passed.
- Full suites: 1,528 `nauro-core` tests passed; 2,635 `nauro` tests passed and 10 skipped.
- The standalone public-contract test and Ruff check and format checks passed.
- `public_contract_v1.json` remained unchanged.
- Both wheels built successfully. Metadata confirmed `nauro-core` 1.12.0 and `nauro` 1.14.1 with `nauro-core>=1.12.0,<2`.
- Live-store acceptance rendered the exact `+27` omission trailer.
