### PR TITLE
Add deterministic judgment commit planning

### DIFF
--- a/packages/nauro-core/src/nauro_core/decision_model.py
+++ b/packages/nauro-core/src/nauro_core/decision_model.py
@@ -42,7 +42,8 @@ Field model:
     Required frontmatter: date, confidence.
     Defaulted frontmatter: version (1), status (active).
     Optional frontmatter: decision_type, reversibility, source, files_affected,
-                          supersedes, superseded_by.
+                          supersedes, superseded_by, and the selectively omitted
+                          approval-provenance group.
     Body-rendered: rejected (rendered as `## Rejected Alternatives` + `### name`
                    subsections, not in frontmatter).
     Derived (set by parse_decision): num, title, rationale, body, content.
@@ -57,7 +58,9 @@ from enum import Enum
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from nauro_core.identifiers import IdentifierKind, validate_identifier
 from nauro_core.parsing import extract_decision_number, is_ascii_decimal
+from nauro_core.provenance import validate_commit_sha, validate_utc_timestamp
 
 # ── Enums (values match on-disk lowercase tokens verbatim) ──
 
@@ -154,6 +157,13 @@ class Decision(BaseModel):
     supersedes: str | None = None
     superseded_by: str | None = None
 
+    # ── Frontmatter: current-version approval provenance ──
+    proposed_by: str | None = None
+    approved_by: str | None = None
+    approved_at: str | None = None
+    proposal_id: str | None = None
+    proposed_base_commit: str | None = None
+
     # ── Body-rendered ──
     rejected: list[RejectedAlternative] = Field(default_factory=list)
 
@@ -183,6 +193,49 @@ class Decision(BaseModel):
                 f"supersession ref must not have leading zeros, got {v!r}; expected {canonical!r}"
             )
         return v
+
+    @field_validator("proposed_by", "approved_by", "proposal_id")
+    @classmethod
+    def _validate_provenance_identifier(cls, v: str | None, info) -> str | None:
+        if v is None:
+            return None
+        return validate_identifier(IdentifierKind.ulid, v, field=info.field_name)
+
+    @field_validator("approved_at")
+    @classmethod
+    def _validate_approved_at(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        return validate_utc_timestamp(v, field="approved_at")
+
+    @field_validator("proposed_base_commit")
+    @classmethod
+    def _validate_proposed_base_commit(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        return validate_commit_sha(v, field="proposed_base_commit")
+
+    @model_validator(mode="after")
+    def require_complete_approval_provenance(self) -> Decision:
+        values = (
+            self.proposed_by,
+            self.approved_by,
+            self.approved_at,
+            self.proposal_id,
+            self.proposed_base_commit,
+        )
+        if not any(value is not None for value in values):
+            return self
+        missing = [
+            field
+            for field in ("proposed_by", "approved_by", "approved_at", "proposal_id")
+            if getattr(self, field) is None
+        ]
+        if missing:
+            raise ValueError(
+                "partial approval provenance is invalid; missing " + ", ".join(missing) + "."
+            )
+        return self
 
     @model_validator(mode="after")
     def require_reasons_on_active(self) -> Decision:
@@ -228,6 +281,19 @@ _FRONTMATTER_ORDER: tuple[str, ...] = (
     "files_affected",
     "supersedes",
     "superseded_by",
+    "proposed_by",
+    "approved_by",
+    "approved_at",
+    "proposal_id",
+    "proposed_base_commit",
+)
+
+_PROVENANCE_FIELDS: tuple[str, ...] = (
+    "proposed_by",
+    "approved_by",
+    "approved_at",
+    "proposal_id",
+    "proposed_base_commit",
 )
 
 
@@ -469,6 +535,10 @@ def format_decision(decision: Decision) -> str:
     already-canonical file. See the module docstring for the full bound.
     """
     dumped = decision.model_dump(mode="json", exclude=_DERIVED_FIELDS)
+
+    for key in _PROVENANCE_FIELDS:
+        if dumped.get(key) is None:
+            dumped.pop(key, None)
 
     # Rejected is body-rendered, not frontmatter.
     dumped.pop("rejected", None)

--- a/packages/nauro-core/src/nauro_core/operations/_decision_transitions.py
+++ b/packages/nauro-core/src/nauro_core/operations/_decision_transitions.py
@@ -1,0 +1,175 @@
+"""Pure decision and question transitions shared by local and hosted planning."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import date
+
+from nauro_core.decision_model import (
+    Decision,
+    DecisionConfidence,
+    DecisionSource,
+    DecisionStatus,
+    DecisionType,
+    RejectedAlternative,
+    Reversibility,
+)
+from nauro_core.questions import OpenQuestionsFile
+
+_SLUG_MAX_LENGTH = 60
+_PROVENANCE_FIELDS = (
+    "proposed_by",
+    "approved_by",
+    "approved_at",
+    "proposal_id",
+    "proposed_base_commit",
+)
+
+
+@dataclass(frozen=True)
+class DecisionProvenance:
+    proposed_by: str
+    approved_by: str
+    approved_at: str
+    proposal_id: str
+    proposed_base_commit: str | None = None
+
+
+@dataclass(frozen=True)
+class QuestionResolveTransition:
+    content: str
+    resolved_ids: tuple[str, ...] = ()
+    relocated_ids: tuple[str, ...] = ()
+    skipped_prose_ids: tuple[str, ...] = ()
+
+
+def slugify_decision_title(title: str) -> str:
+    """Return the existing canonical decision filename slug."""
+    out_chars: list[str] = []
+    prev_dash = False
+    for char in title.lower():
+        if char.isalnum():
+            out_chars.append(char)
+            prev_dash = False
+        elif not prev_dash:
+            out_chars.append("-")
+            prev_dash = True
+    slug = "".join(out_chars).strip("-")
+    if len(slug) > _SLUG_MAX_LENGTH:
+        truncated = slug[:_SLUG_MAX_LENGTH]
+        trimmed = truncated.rsplit("-", 1)[0]
+        slug = trimmed if len(trimmed) >= _SLUG_MAX_LENGTH // 2 else truncated
+    return slug
+
+
+def build_new_decision(
+    *,
+    number: int,
+    decision_date: date,
+    title: str,
+    rationale: str,
+    confidence: DecisionConfidence,
+    decision_type: DecisionType | None,
+    reversibility: Reversibility | None,
+    source: DecisionSource | None,
+    files_affected: Sequence[str],
+    rejected: Sequence[RejectedAlternative],
+    provenance: DecisionProvenance | None,
+    extra_frontmatter: Mapping[str, object] | None = None,
+) -> Decision:
+    """Build a new current decision from explicit frozen inputs."""
+    fields: dict[str, object] = dict(extra_frontmatter or {})
+    if provenance is not None:
+        fields.update(
+            proposed_by=provenance.proposed_by,
+            approved_by=provenance.approved_by,
+            approved_at=provenance.approved_at,
+            proposal_id=provenance.proposal_id,
+            proposed_base_commit=provenance.proposed_base_commit,
+        )
+    return Decision(
+        date=decision_date,
+        version=1,
+        status=DecisionStatus.active,
+        confidence=confidence,
+        decision_type=decision_type,
+        reversibility=reversibility,
+        source=source,
+        files_affected=list(files_affected),
+        rejected=list(rejected),
+        num=number,
+        title=title,
+        rationale=rationale,
+        **fields,
+    )
+
+
+def apply_current_version_provenance(
+    decision: Decision,
+    provenance: DecisionProvenance | None,
+) -> Decision:
+    """Apply one complete approval group, or clear a group for a new local version."""
+    update = {field: None for field in _PROVENANCE_FIELDS}
+    if provenance is not None:
+        update.update(
+            proposed_by=provenance.proposed_by,
+            approved_by=provenance.approved_by,
+            approved_at=provenance.approved_at,
+            proposal_id=provenance.proposal_id,
+            proposed_base_commit=provenance.proposed_base_commit,
+        )
+    return decision.model_copy(update=update)
+
+
+def append_decision_update(
+    decision: Decision,
+    *,
+    additional_rationale: str,
+    update_date: date,
+    provenance: DecisionProvenance | None,
+) -> Decision:
+    """Append one dated rationale version and replace current-version provenance."""
+    version = decision.version + 1
+    rationale = (
+        f"{decision.rationale.strip()}\n\n"
+        f"*Update (v{version}) — {update_date.isoformat()}:* {additional_rationale.strip()}"
+    )
+    updated = decision.model_copy(update={"version": version, "rationale": rationale})
+    return apply_current_version_provenance(updated, provenance)
+
+
+def attach_supersedes(decision: Decision, target_number: int) -> Decision:
+    """Attach the derived backlink to the newly replacing decision."""
+    return decision.model_copy(update={"supersedes": str(target_number)})
+
+
+def mark_superseded(decision: Decision, replacement_number: int) -> Decision:
+    """Flip a target while preserving every field of its last current version."""
+    return decision.model_copy(
+        update={
+            "status": DecisionStatus.superseded,
+            "superseded_by": str(replacement_number),
+        }
+    )
+
+
+def resolve_questions_content(
+    content: str,
+    *,
+    question_ids: Sequence[str],
+    decision_number: int,
+    resolved_date: date,
+) -> QuestionResolveTransition:
+    """Resolve and normalize questions from explicit content and date inputs."""
+    if not question_ids:
+        return QuestionResolveTransition(content=content)
+    questions = OpenQuestionsFile.parse(content)
+    resolved = questions.resolve(list(question_ids), decision_number, resolved_date)
+    normalized = resolved.file.normalize()
+    return QuestionResolveTransition(
+        content=normalized.file.format(),
+        resolved_ids=resolved.moved_ids,
+        relocated_ids=normalized.relocated_ids,
+        skipped_prose_ids=normalized.skipped_prose_ids,
+    )

--- a/packages/nauro-core/src/nauro_core/operations/_proposal_evaluation.py
+++ b/packages/nauro-core/src/nauro_core/operations/_proposal_evaluation.py
@@ -1,0 +1,212 @@
+"""Pure proposal validation and similarity evaluation over parsed inputs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from nauro_core.constants import MIN_RATIONALE_LENGTH
+from nauro_core.decision_model import Decision, DecisionStatus
+from nauro_core.operations.related_hits import to_related_decisions
+from nauro_core.operations.results import ProposeDecisionResult, RelatedDecision
+from nauro_core.questions import EntryBlock, OpenQuestionsFile
+from nauro_core.validation import check_bm25_similarity, screen_structural
+
+_UPDATE_DISALLOWED_FIELDS: tuple[str, ...] = (
+    "title",
+    "rejected",
+    "files_affected",
+    "decision_type",
+    "reversibility",
+    "confidence",
+)
+
+
+@dataclass(frozen=True)
+class ProposalEvaluation:
+    similar_decisions: tuple[RelatedDecision, ...]
+    assessment: str
+
+
+def validate_proposal_request(
+    proposal: dict,
+    *,
+    operation: Literal["add", "update", "supersede"],
+    questions_file: OpenQuestionsFile | None,
+) -> ProposeDecisionResult | None:
+    """Validate request fields that do not require the decision corpus."""
+    metadata_rejection = validate_update_metadata(proposal, operation=operation)
+    if metadata_rejection is not None:
+        return metadata_rejection
+    question_rejection = validate_question_resolves(
+        proposal,
+        operation=operation,
+        questions_file=questions_file,
+    )
+    if question_rejection is not None:
+        return question_rejection
+    return validate_update_rationale(proposal, operation=operation)
+
+
+def validate_update_metadata(
+    proposal: dict,
+    *,
+    operation: Literal["add", "update", "supersede"],
+) -> ProposeDecisionResult | None:
+    """Reject metadata that rationale-only update cannot consume."""
+    if operation == "update":
+        disallowed = [
+            name
+            for name in _UPDATE_DISALLOWED_FIELDS
+            if proposal.get(name)
+            and (not isinstance(proposal.get(name), str) or proposal.get(name).strip())
+        ]
+        if disallowed:
+            return ProposeDecisionResult(
+                status="rejected",
+                tier=0,
+                operation="update",
+                assessment=(
+                    'operation="update" appends rationale only; cannot change '
+                    f"{', '.join(disallowed)}. "
+                    'Use operation="supersede" to replace the decision with new metadata.'
+                ),
+            )
+    return None
+
+
+def validate_question_resolves(
+    proposal: dict,
+    *,
+    operation: Literal["add", "update", "supersede"],
+    questions_file: OpenQuestionsFile | None,
+) -> ProposeDecisionResult | None:
+    """Validate question identifiers against one parsed questions file."""
+    requested = list(proposal.get("resolves_questions") or [])
+    if requested:
+        unknown = _unknown_question_ids(requested, questions_file)
+        if unknown:
+            return ProposeDecisionResult(
+                status="rejected",
+                tier=0,
+                operation=operation,
+                assessment=(
+                    "resolves_questions contains unknown id(s): "
+                    + ", ".join(repr(value) for value in unknown)
+                    + ". Call get_context (L0 lists every open question) to "
+                    "see the canonical ids in open-questions.md."
+                ),
+            )
+        ambiguous = _ambiguous_question_ids(requested, questions_file)
+        if ambiguous:
+            offenders = "; ".join(
+                f"{requested_id!r} matches {len(counterparts)} entries — disambiguate "
+                f"to one of: {', '.join(counterparts)}"
+                for requested_id, counterparts in ambiguous.items()
+            )
+            return ProposeDecisionResult(
+                status="rejected",
+                tier=0,
+                operation=operation,
+                assessment="resolves_questions contains ambiguous id(s): " + offenders + ".",
+            )
+    return None
+
+
+def validate_update_rationale(
+    proposal: dict,
+    *,
+    operation: Literal["add", "update", "supersede"],
+) -> ProposeDecisionResult | None:
+    """Apply the update-specific Tier 1 rationale check without corpus reads."""
+    if operation != "update":
+        return None
+    rationale = (proposal.get("rationale") or "").strip()
+    if not rationale:
+        reason = "Rationale is empty."
+    elif len(rationale) < MIN_RATIONALE_LENGTH:
+        reason = f"Rationale too short ({len(rationale)} chars). Minimum {MIN_RATIONALE_LENGTH}."
+    else:
+        return None
+    return ProposeDecisionResult(
+        status="rejected",
+        tier=1,
+        operation="reject",
+        assessment=reason,
+    )
+
+
+def evaluate_parsed_proposal(
+    proposal: dict,
+    *,
+    operation: Literal["add", "update", "supersede"],
+    decisions: list[Decision],
+    existing_hashes: set[str],
+    affected_number: int | None,
+    enforce_claim_conflicts: bool,
+) -> ProposalEvaluation | ProposeDecisionResult:
+    """Evaluate structure and similarity over one immutable parsed corpus."""
+    if operation != "update":
+        active = (
+            [
+                decision
+                for decision in decisions
+                if decision.status is DecisionStatus.active and decision.num != affected_number
+            ]
+            if enforce_claim_conflicts
+            else []
+        )
+        action, reason = screen_structural(
+            proposal,
+            existing_hashes if enforce_claim_conflicts else set(),
+            active,
+        )
+        if action == "reject":
+            return ProposeDecisionResult(
+                status="rejected",
+                tier=1,
+                operation="reject",
+                assessment=reason or "Structural validation failed.",
+            )
+
+    _action, similar_raw = check_bm25_similarity(proposal, decisions)
+    similar = tuple(to_related_decisions(similar_raw, decisions))
+    assessment = (
+        "Tier 2 surfaced similar decisions; review them and confirm with the "
+        "user before proposing further related writes."
+        if similar
+        else "No similar existing decisions found."
+    )
+    return ProposalEvaluation(similar_decisions=similar, assessment=assessment)
+
+
+def _unknown_question_ids(
+    ids: list[str],
+    questions_file: OpenQuestionsFile | None,
+) -> list[str]:
+    if questions_file is None:
+        return list(ids)
+    known = questions_file.known_question_ids
+    return [value for value in ids if value not in known]
+
+
+def _ambiguous_question_ids(
+    ids: list[str],
+    questions_file: OpenQuestionsFile | None,
+) -> dict[str, list[str]]:
+    if questions_file is None:
+        return {}
+    collisions = questions_file.ambiguous_ids
+    requested = [value for value in ids if value in collisions]
+    if not requested:
+        return {}
+    counterparts: dict[str, list[str]] = {value: [] for value in requested}
+    for block in questions_file.blocks:
+        if not isinstance(block, EntryBlock):
+            continue
+        entry_id = block.entry.id
+        if entry_id in counterparts:
+            counterparts[entry_id].append(
+                f"Q{block.entry.num}" if block.entry.num is not None else "<no-Q-id>"
+            )
+    return counterparts

--- a/packages/nauro-core/src/nauro_core/operations/commit_plan.py
+++ b/packages/nauro-core/src/nauro_core/operations/commit_plan.py
@@ -1,0 +1,1407 @@
+"""Pure two-phase planning for hosted judgment commits."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from datetime import date
+from typing import Annotated, Literal, TypeAlias
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    StrictInt,
+    StrictStr,
+    TypeAdapter,
+    ValidationError,
+    computed_field,
+    field_validator,
+    model_validator,
+)
+
+from nauro_core.constants import MAX_RATIONALE_LENGTH, MAX_TITLE_LENGTH
+from nauro_core.decision_model import (
+    Decision,
+    DecisionConfidence,
+    DecisionSource,
+    DecisionType,
+    RejectedAlternative,
+    Reversibility,
+    format_decision,
+    parse_decision,
+)
+from nauro_core.identifiers import IdentifierKind, validate_identifier
+from nauro_core.operations._decision_transitions import (
+    DecisionProvenance,
+    append_decision_update,
+    attach_supersedes,
+    build_new_decision,
+    mark_superseded,
+    resolve_questions_content,
+    slugify_decision_title,
+)
+from nauro_core.operations._proposal_evaluation import (
+    ProposalEvaluation,
+    evaluate_parsed_proposal,
+    validate_proposal_request,
+)
+from nauro_core.operations.results import ErrorPayload, ProposeDecisionResult, RelatedDecision
+from nauro_core.parsing import _decision_number_prefix
+from nauro_core.protected_generation_membership import (
+    is_hosted_snapshot_content_member,
+    validate_protected_generation_path,
+)
+from nauro_core.provenance import validate_commit_sha, validate_utc_timestamp
+from nauro_core.questions import OpenQuestionsFile
+from nauro_core.snapshot import serialize_snapshot
+from nauro_core.validation import compute_hash, normalize_title
+
+_SHA256_HEX_LENGTH = 64
+
+
+class JudgmentCommitError(ValueError):
+    """Base class for deterministic judgment-commit planning failures."""
+
+
+class CanonicalPayloadRejected(JudgmentCommitError):
+    """Approved payload bytes are invalid or noncanonical."""
+
+
+class ApprovalAttestationRejected(JudgmentCommitError):
+    """Approval attestation conflicts with the approved payload."""
+
+
+class ApprovedPayloadDigestMismatch(JudgmentCommitError):
+    """The checked expected digest does not match the approved bytes."""
+
+
+class ApprovedBaseStale(JudgmentCommitError):
+    """The approved base is not the observed committed generation."""
+
+
+class CommittedGenerationCorrupt(JudgmentCommitError):
+    """The committed artifact corpus violates generation invariants."""
+
+
+class ProposalRejected(JudgmentCommitError):
+    """Proposal evaluation produced the existing rejected result shape."""
+
+    def __init__(self, result: ProposeDecisionResult) -> None:
+        self.result = result
+        super().__init__(result.assessment)
+
+
+class ClaimObservationError(JudgmentCommitError):
+    """Claim observations cannot finalize the prepared plan."""
+
+
+class MissingClaimObservation(ClaimObservationError):
+    pass
+
+
+class UnexpectedClaimObservation(ClaimObservationError):
+    pass
+
+
+class DuplicateClaimObservation(ClaimObservationError):
+    pass
+
+
+class MalformedClaimObservation(ClaimObservationError):
+    pass
+
+
+class MismatchedClaimObservation(ClaimObservationError):
+    pass
+
+
+class ClaimUnavailable(ClaimObservationError):
+    pass
+
+
+class TitleClaimConflict(ClaimObservationError):
+    pass
+
+
+class ContentClaimConflict(ClaimObservationError):
+    pass
+
+
+def _sha256(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def _validate_sha256(value: object, *, field: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{field} must be a lowercase SHA-256 digest.")
+    if len(value) != _SHA256_HEX_LENGTH or any(char not in "0123456789abcdef" for char in value):
+        raise ValueError(f"{field} must be a lowercase SHA-256 digest.")
+    return value
+
+
+class _FrozenModel(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+
+class _ImmutableResultList(list):
+    def _reject_mutation(self, *args: object, **kwargs: object) -> None:
+        raise TypeError("immutable result sequence")
+
+    __delitem__ = _reject_mutation
+    __iadd__ = _reject_mutation
+    __imul__ = _reject_mutation
+    __setitem__ = _reject_mutation
+    append = _reject_mutation
+    clear = _reject_mutation
+    extend = _reject_mutation
+    insert = _reject_mutation
+    pop = _reject_mutation
+    remove = _reject_mutation
+    reverse = _reject_mutation
+    sort = _reject_mutation
+
+
+class _CommittedResultProjection(_FrozenModel):
+    status: Literal["confirmed", "rejected"]
+    tier: StrictInt
+    operation: Literal["add", "update", "supersede", "reject"]
+    similar_decisions: tuple[RelatedDecision, ...]
+    assessment: StrictStr
+    decision_id: StrictStr | None
+    touched_decisions: tuple[StrictStr, ...]
+    resolved_questions: tuple[StrictStr, ...]
+    relocated_ids: tuple[StrictStr, ...] | None
+    skipped_prose_ids: tuple[StrictStr, ...] | None
+    error: ErrorPayload | None
+
+    @classmethod
+    def from_result(cls, result: ProposeDecisionResult) -> _CommittedResultProjection:
+        return cls.model_validate(result.model_dump())
+
+    def materialize(self) -> ProposeDecisionResult:
+        return ProposeDecisionResult.model_construct(
+            status=self.status,
+            tier=self.tier,
+            operation=self.operation,
+            similar_decisions=_ImmutableResultList(self.similar_decisions),
+            assessment=self.assessment,
+            decision_id=self.decision_id,
+            touched_decisions=_ImmutableResultList(self.touched_decisions),
+            resolved_questions=_ImmutableResultList(self.resolved_questions),
+            relocated_ids=self.relocated_ids,
+            skipped_prose_ids=self.skipped_prose_ids,
+            error=self.error,
+        )
+
+
+class RejectedSelection(_FrozenModel):
+    alternative: StrictStr
+    reason: StrictStr
+
+    @field_validator("alternative", "reason")
+    @classmethod
+    def _nonempty(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("rejected alternative and reason must be non-empty.")
+        return value
+
+
+class JudgmentContent(_FrozenModel):
+    operation: Literal["add", "update", "supersede"]
+    affected_decision_id: StrictStr | None
+    title: StrictStr | None
+    rationale: StrictStr
+    rejected: tuple[RejectedSelection, ...]
+    confidence: Literal["high", "medium", "low"] | None
+    decision_type: (
+        Literal[
+            "architecture", "api_design", "infrastructure", "pattern", "refactor", "data_model"
+        ]
+        | None
+    )
+    reversibility: Literal["easy", "moderate", "hard"] | None
+    files_affected: tuple[StrictStr, ...]
+    resolves_questions: tuple[StrictStr, ...]
+
+    @model_validator(mode="after")
+    def _validate_operation_fields(self) -> JudgmentContent:
+        if len(self.rationale) > MAX_RATIONALE_LENGTH:
+            raise ValueError(f"rationale exceeds {MAX_RATIONALE_LENGTH} characters.")
+        if len(set(self.resolves_questions)) != len(self.resolves_questions):
+            raise ValueError("resolves_questions contains duplicate ids.")
+        if any(not value for value in self.files_affected):
+            raise ValueError("files_affected values must be non-empty strings.")
+        if self.operation == "add":
+            if self.affected_decision_id is not None:
+                raise ValueError("add requires affected_decision_id to be null.")
+        elif not self.affected_decision_id:
+            raise ValueError(f"{self.operation} requires affected_decision_id.")
+        if self.operation == "update":
+            return self
+        if self.title is not None and len(self.title) > MAX_TITLE_LENGTH:
+            raise ValueError(f"title exceeds {MAX_TITLE_LENGTH} characters.")
+        if self.confidence is None:
+            raise ValueError(f"{self.operation} requires an effective confidence value.")
+        return self
+
+
+class HostedPreTeamApprovalPayloadV1(_FrozenModel):
+    payload_schema: Literal["nauro.judgment_commit.pre_team.v1"]
+    approval_mode: Literal["pre_team_session"]
+    base_generation_id: StrictStr
+    base_decision_counter: StrictInt = Field(ge=0)
+    proposed_base_commit: None
+    content: JudgmentContent
+
+    @field_validator("base_generation_id")
+    @classmethod
+    def _generation_id(cls, value: str) -> str:
+        return validate_identifier(IdentifierKind.ulid, value, field="base_generation_id")
+
+
+class TeamProposalPayloadV1(_FrozenModel):
+    payload_schema: Literal["nauro.judgment_commit.team_proposal.v1"]
+    approval_mode: Literal["team_ratification"]
+    proposal_id: StrictStr
+    proposal_revision: StrictInt = Field(ge=1)
+    proposed_by: StrictStr
+    contributor_operation_id: StrictStr
+    base_generation_id: StrictStr
+    base_decision_counter: StrictInt = Field(ge=0)
+    proposed_base_commit: StrictStr | None
+    content: JudgmentContent
+
+    @field_validator("proposal_id", "proposed_by", "base_generation_id")
+    @classmethod
+    def _ulids(cls, value: str, info) -> str:
+        return validate_identifier(IdentifierKind.ulid, value, field=info.field_name)
+
+    @field_validator("contributor_operation_id")
+    @classmethod
+    def _operation_id(cls, value: str) -> str:
+        return validate_identifier(
+            IdentifierKind.operation_id, value, field="contributor_operation_id"
+        )
+
+    @field_validator("proposed_base_commit")
+    @classmethod
+    def _base_commit(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return validate_commit_sha(value, field="proposed_base_commit")
+
+
+ApprovedPayload: TypeAlias = Annotated[
+    HostedPreTeamApprovalPayloadV1 | TeamProposalPayloadV1,
+    Field(discriminator="payload_schema"),
+]
+_PAYLOAD_ADAPTER = TypeAdapter(ApprovedPayload)
+
+
+class PreTeamApprovalAttestation(_FrozenModel):
+    actor_id: StrictStr
+    operation_id: StrictStr
+    request_received_at: StrictStr
+
+    @field_validator("actor_id")
+    @classmethod
+    def _actor_id(cls, value: str) -> str:
+        return validate_identifier(IdentifierKind.ulid, value, field="actor_id")
+
+    @field_validator("operation_id")
+    @classmethod
+    def _operation_id(cls, value: str) -> str:
+        return validate_identifier(IdentifierKind.operation_id, value, field="operation_id")
+
+    @field_validator("request_received_at")
+    @classmethod
+    def _timestamp(cls, value: str) -> str:
+        return validate_utc_timestamp(value, field="request_received_at")
+
+
+class TeamRatificationAttestation(_FrozenModel):
+    approved_by: StrictStr
+    approved_at: StrictStr
+    ratification_action_id: StrictStr
+
+    @field_validator("approved_by", "ratification_action_id")
+    @classmethod
+    def _ulids(cls, value: str, info) -> str:
+        return validate_identifier(IdentifierKind.ulid, value, field=info.field_name)
+
+    @field_validator("approved_at")
+    @classmethod
+    def _timestamp(cls, value: str) -> str:
+        return validate_utc_timestamp(value, field="approved_at")
+
+
+ApprovalAttestation: TypeAlias = PreTeamApprovalAttestation | TeamRatificationAttestation
+
+
+class CommittedArtifact(_FrozenModel):
+    path: StrictStr
+    content: bytes
+    manifest_artifact_digest: StrictStr
+
+    @model_validator(mode="after")
+    def _validate_artifact(self) -> CommittedArtifact:
+        validate_protected_generation_path(self.path)
+        _validate_sha256(self.manifest_artifact_digest, field="manifest_artifact_digest")
+        if _sha256(self.content) != self.manifest_artifact_digest:
+            raise ValueError(f"artifact digest mismatch for {self.path!r}.")
+        return self
+
+
+class CommittedGeneration(_FrozenModel):
+    generation_id: StrictStr
+    decision_counter: StrictInt = Field(ge=0)
+    observed_manifest_digest: StrictStr
+    artifacts: tuple[CommittedArtifact, ...]
+
+    @field_validator("generation_id")
+    @classmethod
+    def _generation_id(cls, value: str) -> str:
+        return validate_identifier(IdentifierKind.ulid, value, field="generation_id")
+
+    @field_validator("observed_manifest_digest")
+    @classmethod
+    def _manifest_digest(cls, value: str) -> str:
+        return _validate_sha256(value, field="observed_manifest_digest")
+
+    @model_validator(mode="after")
+    def _unique_paths(self) -> CommittedGeneration:
+        paths = [artifact.path for artifact in self.artifacts]
+        if len(set(paths)) != len(paths):
+            raise ValueError("committed generation contains duplicate artifact paths.")
+        return self
+
+
+class PreparedBase(_FrozenModel):
+    generation_id: StrictStr
+    decision_counter: StrictInt = Field(ge=0)
+    observed_manifest_digest: StrictStr
+
+    @field_validator("generation_id")
+    @classmethod
+    def _generation_id(cls, value: str) -> str:
+        return validate_identifier(IdentifierKind.ulid, value, field="generation_id")
+
+    @field_validator("observed_manifest_digest")
+    @classmethod
+    def _manifest_digest(cls, value: str) -> str:
+        return _validate_sha256(value, field="observed_manifest_digest")
+
+
+class PlannedArtifact(_FrozenModel):
+    path: StrictStr
+    content: bytes
+
+    @field_validator("path")
+    @classmethod
+    def _path(cls, value: str) -> str:
+        return validate_protected_generation_path(value)
+
+    @computed_field
+    @property
+    def sha256(self) -> str:
+        return _sha256(self.content)
+
+    @computed_field
+    @property
+    def length(self) -> int:
+        return len(self.content)
+
+
+class PlannedSnapshot(_FrozenModel):
+    content: bytes
+
+    @computed_field
+    @property
+    def sha256(self) -> str:
+        return _sha256(self.content)
+
+    @computed_field
+    @property
+    def length(self) -> int:
+        return len(self.content)
+
+
+class PrimaryDecision(_FrozenModel):
+    decision_id: StrictStr
+    path: StrictStr
+    sha256: StrictStr
+
+    @field_validator("sha256")
+    @classmethod
+    def _digest(cls, value: str) -> str:
+        return _validate_sha256(value, field="primary_decision.sha256")
+
+    @model_validator(mode="after")
+    def _path_matches_id(self) -> PrimaryDecision:
+        if self.path != f"decisions/{self.decision_id}.md":
+            raise ValueError("primary decision path must derive from decision_id.")
+        return self
+
+
+def _validate_normalized_title(value: str) -> str:
+    if not value or normalize_title(value) != value:
+        raise ValueError("normalized_title must be non-empty canonical normalized title text.")
+    return value
+
+
+class AbsentTitleClaimProbe(_FrozenModel):
+    kind: Literal["absent_title"] = "absent_title"
+    normalized_title: StrictStr
+
+    _normalized = field_validator("normalized_title")(_validate_normalized_title)
+
+
+class OwnedTitleClaimProbe(_FrozenModel):
+    kind: Literal["owned_title"] = "owned_title"
+    normalized_title: StrictStr
+    expected_owner_decision_number: StrictInt = Field(gt=0)
+
+    _normalized = field_validator("normalized_title")(_validate_normalized_title)
+
+
+class AbsentContentClaimProbe(_FrozenModel):
+    kind: Literal["absent_content"] = "absent_content"
+    content_hash: StrictStr
+
+    @field_validator("content_hash")
+    @classmethod
+    def _content_hash(cls, value: str) -> str:
+        return _validate_sha256(value, field="content_hash")
+
+
+ClaimProbe: TypeAlias = Annotated[
+    AbsentTitleClaimProbe | OwnedTitleClaimProbe | AbsentContentClaimProbe,
+    Field(discriminator="kind"),
+]
+
+
+class AbsentTitleClaimObservation(_FrozenModel):
+    kind: Literal["absent_title"] = "absent_title"
+    normalized_title: StrictStr
+
+    _normalized = field_validator("normalized_title")(_validate_normalized_title)
+
+
+class CommittedTitleClaimObservation(_FrozenModel):
+    kind: Literal["committed_title"] = "committed_title"
+    normalized_title: StrictStr
+    owner_decision_number: StrictInt = Field(gt=0)
+
+    _normalized = field_validator("normalized_title")(_validate_normalized_title)
+
+
+class UnavailableTitleClaimObservation(_FrozenModel):
+    kind: Literal["unavailable_title"] = "unavailable_title"
+    normalized_title: StrictStr
+    reason: Literal["reserved", "recovery_required"]
+
+    _normalized = field_validator("normalized_title")(_validate_normalized_title)
+
+
+class AbsentContentClaimObservation(_FrozenModel):
+    kind: Literal["absent_content"] = "absent_content"
+    content_hash: StrictStr
+
+    @field_validator("content_hash")
+    @classmethod
+    def _content_hash(cls, value: str) -> str:
+        return _validate_sha256(value, field="content_hash")
+
+
+class CommittedContentClaimObservation(_FrozenModel):
+    kind: Literal["committed_content"] = "committed_content"
+    content_hash: StrictStr
+
+    @field_validator("content_hash")
+    @classmethod
+    def _content_hash(cls, value: str) -> str:
+        return _validate_sha256(value, field="content_hash")
+
+
+class UnavailableContentClaimObservation(_FrozenModel):
+    kind: Literal["unavailable_content"] = "unavailable_content"
+    content_hash: StrictStr
+    reason: Literal["reserved", "recovery_required"]
+
+    @field_validator("content_hash")
+    @classmethod
+    def _content_hash(cls, value: str) -> str:
+        return _validate_sha256(value, field="content_hash")
+
+
+ClaimObservation: TypeAlias = Annotated[
+    AbsentTitleClaimObservation
+    | CommittedTitleClaimObservation
+    | UnavailableTitleClaimObservation
+    | AbsentContentClaimObservation
+    | CommittedContentClaimObservation
+    | UnavailableContentClaimObservation,
+    Field(discriminator="kind"),
+]
+_OBSERVATION_ADAPTER = TypeAdapter(ClaimObservation)
+
+
+class ClaimIntent(_FrozenModel):
+    kind: Literal[
+        "acquire_new_title",
+        "hold_owned_title",
+        "acquire_title_transfer",
+        "acquire_new_content_hash",
+        "commit_title_owner",
+        "retain_title_owner",
+        "release_title_owner",
+        "transfer_title_owner",
+        "commit_content_hash",
+    ]
+    normalized_title: StrictStr | None = None
+    content_hash: StrictStr | None = None
+    owner_decision_number: StrictInt | None = Field(default=None, gt=0)
+    from_owner_decision_number: StrictInt | None = Field(default=None, gt=0)
+    to_owner_decision_number: StrictInt | None = Field(default=None, gt=0)
+
+
+class ClaimIntents(_FrozenModel):
+    entry: tuple[ClaimIntent, ...]
+    publication: tuple[ClaimIntent, ...]
+
+
+class FinalizedClaimPlan(_FrozenModel):
+    entry: tuple[ClaimIntent, ...]
+    publication: tuple[ClaimIntent, ...]
+
+
+class PreparedJudgmentCommit(_FrozenModel):
+    schema_version: Literal[1] = 1
+    transformation_version: Literal[1] = 1
+    payload_bytes: bytes
+    payload_digest: StrictStr
+    payload: ApprovedPayload
+    approval_attestation: ApprovalAttestation
+    base: PreparedBase
+    effective_at: StrictStr
+    decision_provenance: DecisionProvenance | None
+    assigned_decision_number: StrictInt | None = Field(default=None, gt=0)
+    new_decision_counter: StrictInt = Field(ge=0)
+    planned_artifacts: tuple[PlannedArtifact, ...]
+    snapshot: PlannedSnapshot
+    primary_decision: PrimaryDecision
+    claim_probes: tuple[ClaimProbe, ...]
+    claim_intents: ClaimIntents
+    result_projection: _CommittedResultProjection
+
+    @property
+    def committed_result(self) -> ProposeDecisionResult:
+        return self.result_projection.materialize()
+
+    @model_validator(mode="after")
+    def _cross_validate(self) -> PreparedJudgmentCommit:
+        if _sha256(self.payload_bytes) != self.payload_digest:
+            raise ValueError("payload digest does not derive from payload bytes.")
+        if _parse_payload(self.payload_bytes) != self.payload:
+            raise ValueError("parsed payload does not derive from payload bytes.")
+        if (
+            self.payload.base_generation_id != self.base.generation_id
+            or self.payload.base_decision_counter != self.base.decision_counter
+        ):
+            raise ValueError("prepared base does not match the approved payload.")
+        effective_at, provenance = _provenance(self.payload, self.approval_attestation)
+        if effective_at != self.effective_at or provenance != self.decision_provenance:
+            raise ValueError("approval attestation does not match effective provenance.")
+        paths = [artifact.path for artifact in self.planned_artifacts]
+        if paths != sorted(paths) or len(paths) != len(set(paths)):
+            raise ValueError("planned artifacts must be unique and path-sorted.")
+        primary = next(
+            (
+                artifact
+                for artifact in self.planned_artifacts
+                if artifact.path == self.primary_decision.path
+            ),
+            None,
+        )
+        if primary is None or primary.sha256 != self.primary_decision.sha256:
+            raise ValueError("primary decision does not match planned artifact bytes.")
+        primary_model = parse_decision(
+            primary.content.decode("utf-8"),
+            self.primary_decision.path.removeprefix("decisions/"),
+        )
+        target_model = None
+        if self.payload.content.affected_decision_id is not None:
+            target_path = f"decisions/{self.payload.content.affected_decision_id}.md"
+            target_artifact = next(
+                (artifact for artifact in self.planned_artifacts if artifact.path == target_path),
+                None,
+            )
+            if target_artifact is None:
+                raise ValueError("affected decision is absent from planned artifacts.")
+            target_model = parse_decision(
+                target_artifact.content.decode("utf-8"),
+                target_path.removeprefix("decisions/"),
+            )
+        probes, intents = _claim_contract(
+            self.payload.content.operation,
+            target_model,
+            primary_model,
+        )
+        if probes != self.claim_probes or intents != self.claim_intents:
+            raise ValueError("claim probes and intents do not derive from planned artifacts.")
+        if (
+            _derive_snapshot_bytes(
+                self.planned_artifacts,
+                payload=self.payload,
+                effective_at=self.effective_at,
+            )
+            != self.snapshot.content
+        ):
+            raise ValueError("snapshot bytes do not derive from planned artifacts.")
+        expected_counter = self.base.decision_counter + (
+            1 if self.payload.content.operation in ("add", "supersede") else 0
+        )
+        if self.new_decision_counter != expected_counter:
+            raise ValueError("new decision counter does not match the operation.")
+        if self.payload.content.operation in ("add", "supersede"):
+            if self.assigned_decision_number != expected_counter:
+                raise ValueError("assigned number must equal counter plus one.")
+        elif self.assigned_decision_number is not None:
+            raise ValueError("update must not assign a decision number.")
+        expected_touched = [self.primary_decision.decision_id]
+        if self.payload.content.operation == "supersede":
+            assert self.payload.content.affected_decision_id is not None
+            expected_touched.append(self.payload.content.affected_decision_id)
+        if (
+            self.committed_result.status != "confirmed"
+            or self.committed_result.tier != 2
+            or self.committed_result.operation != self.payload.content.operation
+            or self.committed_result.decision_id != self.primary_decision.decision_id
+            or self.committed_result.touched_decisions != expected_touched
+            or self.committed_result.error is not None
+        ):
+            raise ValueError("committed result does not match the planned transition.")
+        return self
+
+
+class JudgmentCommitPlan(_FrozenModel):
+    schema_version: Literal[1] = 1
+    prepared: PreparedJudgmentCommit
+    validated_claim_observations: tuple[ClaimObservation, ...]
+    claim_plan: FinalizedClaimPlan
+    plan_record_bytes: bytes
+
+    @computed_field
+    @property
+    def plan_record_digest(self) -> str:
+        return _sha256(self.plan_record_bytes)
+
+    @property
+    def committed_result(self) -> ProposeDecisionResult:
+        return self.prepared.committed_result
+
+    @model_validator(mode="after")
+    def _verify_record(self) -> JudgmentCommitPlan:
+        if tuple(_observation_key(value) for value in self.validated_claim_observations) != tuple(
+            _probe_key(value) for value in self.prepared.claim_probes
+        ):
+            raise ValueError("validated observations do not match prepared probe order.")
+        for probe, observation in zip(
+            self.prepared.claim_probes,
+            self.validated_claim_observations,
+            strict=True,
+        ):
+            _validate_observation(probe, observation)
+        if self.claim_plan.entry != self.prepared.claim_intents.entry or (
+            self.claim_plan.publication != self.prepared.claim_intents.publication
+        ):
+            raise ValueError("finalized claim plan does not derive from prepared intents.")
+        if self.plan_record_bytes != _plan_record(
+            self.prepared, self.validated_claim_observations
+        ):
+            raise ValueError("plan record bytes do not derive from the prepared plan.")
+        return self
+
+
+def canonical_judgment_payload_bytes(payload: Mapping[str, object]) -> bytes:
+    """Serialize the only accepted approved payload byte representation."""
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise CanonicalPayloadRejected(f"approved payload contains duplicate key {key!r}.")
+        result[key] = value
+    return result
+
+
+def _parse_payload(payload_bytes: bytes) -> ApprovedPayload:
+    try:
+        text = payload_bytes.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise CanonicalPayloadRejected("approved payload must be valid UTF-8.") from exc
+    try:
+        raw = json.loads(
+            text,
+            object_pairs_hook=_reject_duplicate_keys,
+            parse_constant=lambda value: (_ for _ in ()).throw(
+                CanonicalPayloadRejected(f"approved payload contains invalid number {value}.")
+            ),
+        )
+    except CanonicalPayloadRejected:
+        raise
+    except (json.JSONDecodeError, TypeError) as exc:
+        raise CanonicalPayloadRejected("approved payload must be valid JSON.") from exc
+    try:
+        payload = _PAYLOAD_ADAPTER.validate_python(raw)
+    except ValidationError as exc:
+        raise CanonicalPayloadRejected(f"approved payload is invalid: {exc}") from exc
+    try:
+        canonical = canonical_judgment_payload_bytes(payload.model_dump(mode="json"))
+    except UnicodeEncodeError as exc:
+        raise CanonicalPayloadRejected(
+            "approved payload cannot be serialized as canonical UTF-8 JSON."
+        ) from exc
+    if canonical != payload_bytes:
+        raise CanonicalPayloadRejected("approved payload bytes are not canonical JSON.")
+    return payload
+
+
+def _parse_committed_generation(
+    generation: CommittedGeneration,
+) -> tuple[dict[str, bytes], list[Decision], dict[int, str]]:
+    artifact_bytes: dict[str, bytes] = {}
+    decisions: list[Decision] = []
+    stems_by_number: dict[int, str] = {}
+    for artifact in sorted(generation.artifacts, key=lambda value: value.path):
+        validate_protected_generation_path(artifact.path)
+        try:
+            text = artifact.content.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise CommittedGenerationCorrupt(
+                f"committed artifact {artifact.path!r} is not valid UTF-8."
+            ) from exc
+        artifact_bytes[artifact.path] = bytes(artifact.content)
+        if not artifact.path.startswith("decisions/"):
+            continue
+        filename = artifact.path[len("decisions/") :]
+        try:
+            decision = parse_decision(text, filename)
+        except Exception as exc:
+            raise CommittedGenerationCorrupt(
+                f"committed decision {artifact.path!r} does not parse."
+            ) from exc
+        if decision.num <= 0:
+            raise CommittedGenerationCorrupt(
+                f"committed decision {artifact.path!r} has no positive number."
+            )
+        if decision.num in stems_by_number:
+            raise CommittedGenerationCorrupt(
+                f"committed generation contains duplicate decision number {decision.num}."
+            )
+        decisions.append(decision)
+        stems_by_number[decision.num] = filename.removesuffix(".md")
+    maximum = max(stems_by_number, default=0)
+    if maximum > generation.decision_counter:
+        raise CommittedGenerationCorrupt(
+            f"published decision number {maximum} exceeds counter {generation.decision_counter}."
+        )
+    return artifact_bytes, decisions, stems_by_number
+
+
+def _rejected_result(
+    tier: int,
+    operation: Literal["add", "update", "supersede"],
+    assessment: str,
+) -> ProposalRejected:
+    result_operation: Literal["add", "update", "supersede", "reject"]
+    result_operation = "reject" if tier == 1 else operation
+    return ProposalRejected(
+        ProposeDecisionResult(
+            status="rejected",
+            tier=tier,
+            operation=result_operation,
+            assessment=assessment,
+        )
+    )
+
+
+def _target(
+    content: JudgmentContent,
+    decisions: list[Decision],
+    stems_by_number: dict[int, str],
+) -> tuple[Decision | None, str | None]:
+    if content.operation == "add":
+        return None, None
+    target_stem = content.affected_decision_id
+    assert target_stem is not None
+    target = next(
+        (decision for decision in decisions if stems_by_number[decision.num] == target_stem),
+        None,
+    )
+    if target is None:
+        raise _rejected_result(
+            1,
+            content.operation,
+            f"{content.operation} target {target_stem!r} not found in committed generation.",
+        )
+    return target, target_stem
+
+
+def _provenance(
+    payload: ApprovedPayload,
+    attestation: ApprovalAttestation,
+) -> tuple[str, DecisionProvenance | None]:
+    if isinstance(payload, HostedPreTeamApprovalPayloadV1):
+        if not isinstance(attestation, PreTeamApprovalAttestation):
+            raise CanonicalPayloadRejected(
+                "pre-team payload requires pre-team approval attestation."
+            )
+        return attestation.request_received_at, None
+    if not isinstance(attestation, TeamRatificationAttestation):
+        raise CanonicalPayloadRejected("team payload requires team ratification attestation.")
+    if payload.contributor_operation_id == attestation.ratification_action_id:
+        raise ApprovalAttestationRejected(
+            "team contributor_operation_id and ratification_action_id must be distinct."
+        )
+    return (
+        attestation.approved_at,
+        DecisionProvenance(
+            proposed_by=payload.proposed_by,
+            approved_by=attestation.approved_by,
+            approved_at=attestation.approved_at,
+            proposal_id=payload.proposal_id,
+            proposed_base_commit=payload.proposed_base_commit,
+        ),
+    )
+
+
+def _derive_snapshot_bytes(
+    artifacts: tuple[PlannedArtifact, ...],
+    *,
+    payload: ApprovedPayload,
+    effective_at: str,
+) -> bytes:
+    snapshot_files = {
+        artifact.path: artifact.content.decode("utf-8")
+        for artifact in artifacts
+        if is_hosted_snapshot_content_member(artifact.path)
+    }
+    title = payload.content.title or ""
+    trigger = {
+        "add": f"decision: {title}",
+        "update": "update: ",
+        "supersede": f"supersede: {title}",
+    }[payload.content.operation]
+    snapshot = serialize_snapshot(
+        timestamp=effective_at,
+        trigger=trigger,
+        files=dict(sorted(snapshot_files.items())),
+    )
+    return json.dumps(
+        snapshot,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _build_artifacts(
+    *,
+    payload: ApprovedPayload,
+    provenance: DecisionProvenance | None,
+    effective_at: str,
+    generation: CommittedGeneration,
+    current: dict[str, bytes],
+    evaluation: ProposalEvaluation,
+    target: Decision | None,
+    target_stem: str | None,
+) -> tuple[
+    tuple[PlannedArtifact, ...],
+    PlannedSnapshot,
+    PrimaryDecision,
+    ProposeDecisionResult,
+    int | None,
+    int,
+    Decision,
+]:
+    content = payload.content
+    decision_date = date.fromisoformat(effective_at[:10])
+    assigned = (
+        generation.decision_counter + 1 if content.operation in ("add", "supersede") else None
+    )
+    new_counter = generation.decision_counter + (1 if assigned is not None else 0)
+    planned = dict(current)
+
+    rejected = tuple(
+        RejectedAlternative(name=item.alternative, reason=item.reason) for item in content.rejected
+    )
+    if content.operation == "update":
+        assert target is not None and target_stem is not None
+        primary_model = append_decision_update(
+            target,
+            additional_rationale=content.rationale,
+            update_date=decision_date,
+            provenance=provenance,
+        )
+        primary_stem = target_stem
+        primary_path = f"decisions/{primary_stem}.md"
+        planned[primary_path] = format_decision(primary_model).encode("utf-8")
+        touched = [primary_stem]
+    else:
+        assert (
+            assigned is not None and content.title is not None and content.confidence is not None
+        )
+        primary_model = build_new_decision(
+            number=assigned,
+            decision_date=decision_date,
+            title=content.title,
+            rationale=content.rationale,
+            confidence=DecisionConfidence(content.confidence),
+            decision_type=DecisionType(content.decision_type) if content.decision_type else None,
+            reversibility=Reversibility(content.reversibility) if content.reversibility else None,
+            source=DecisionSource.mcp,
+            files_affected=content.files_affected,
+            rejected=rejected,
+            provenance=provenance,
+        )
+        if content.operation == "supersede":
+            assert target is not None and target_stem is not None
+            primary_model = attach_supersedes(primary_model, target.num)
+        primary_stem = (
+            f"{_decision_number_prefix(assigned)}{slugify_decision_title(content.title)}"
+        )
+        primary_path = f"decisions/{primary_stem}.md"
+        planned[primary_path] = format_decision(primary_model).encode("utf-8")
+        touched = [primary_stem]
+        if content.operation == "supersede":
+            assert target is not None and target_stem is not None
+            old_path = f"decisions/{target_stem}.md"
+            planned[old_path] = format_decision(mark_superseded(target, assigned)).encode("utf-8")
+            touched.append(target_stem)
+
+    questions_path = "open-questions.md"
+    questions_body = planned.get(questions_path, b"").decode("utf-8")
+    resolution = resolve_questions_content(
+        questions_body,
+        question_ids=content.resolves_questions,
+        decision_number=primary_model.num,
+        resolved_date=decision_date,
+    )
+    if content.resolves_questions:
+        planned[questions_path] = resolution.content.encode("utf-8")
+
+    result = ProposeDecisionResult(
+        status="confirmed",
+        tier=2,
+        operation=content.operation,
+        assessment=evaluation.assessment,
+        similar_decisions=list(evaluation.similar_decisions),
+        decision_id=primary_stem,
+        touched_decisions=touched,
+        resolved_questions=list(resolution.resolved_ids),
+        relocated_ids=resolution.relocated_ids or None,
+        skipped_prose_ids=resolution.skipped_prose_ids or None,
+    )
+    artifacts = tuple(
+        PlannedArtifact(path=path, content=body) for path, body in sorted(planned.items())
+    )
+    snapshot = PlannedSnapshot(
+        content=_derive_snapshot_bytes(artifacts, payload=payload, effective_at=effective_at)
+    )
+    primary_bytes = planned[primary_path]
+    primary = PrimaryDecision(
+        decision_id=primary_stem,
+        path=primary_path,
+        sha256=_sha256(primary_bytes),
+    )
+    return artifacts, snapshot, primary, result, assigned, new_counter, primary_model
+
+
+def _claim_contract(
+    operation: str,
+    target: Decision | None,
+    primary: Decision,
+) -> tuple[tuple[ClaimProbe, ...], ClaimIntents]:
+    new_number = primary.num
+    new_title = normalize_title(primary.title)
+    content_hash = compute_hash(primary.title, primary.rationale)
+    content_probe = AbsentContentClaimProbe(content_hash=content_hash)
+    acquire_content = ClaimIntent(kind="acquire_new_content_hash", content_hash=content_hash)
+    commit_content = ClaimIntent(kind="commit_content_hash", content_hash=content_hash)
+    if operation == "add":
+        probes: tuple[ClaimProbe, ...] = (
+            AbsentTitleClaimProbe(normalized_title=new_title),
+            content_probe,
+        )
+        intents = ClaimIntents(
+            entry=(
+                ClaimIntent(
+                    kind="acquire_new_title",
+                    normalized_title=new_title,
+                    owner_decision_number=new_number,
+                ),
+                acquire_content,
+            ),
+            publication=(
+                ClaimIntent(
+                    kind="commit_title_owner",
+                    normalized_title=new_title,
+                    owner_decision_number=new_number,
+                ),
+                commit_content,
+            ),
+        )
+        return probes, intents
+    assert target is not None
+    old_title = normalize_title(target.title)
+    if operation == "update":
+        probes = (
+            OwnedTitleClaimProbe(
+                normalized_title=old_title,
+                expected_owner_decision_number=target.num,
+            ),
+            content_probe,
+        )
+        intents = ClaimIntents(
+            entry=(
+                ClaimIntent(
+                    kind="hold_owned_title",
+                    normalized_title=old_title,
+                    owner_decision_number=target.num,
+                ),
+                acquire_content,
+            ),
+            publication=(
+                ClaimIntent(
+                    kind="retain_title_owner",
+                    normalized_title=old_title,
+                    owner_decision_number=target.num,
+                ),
+                commit_content,
+            ),
+        )
+        return probes, intents
+    if new_title == old_title:
+        probes = (
+            OwnedTitleClaimProbe(
+                normalized_title=old_title,
+                expected_owner_decision_number=target.num,
+            ),
+            content_probe,
+        )
+        intents = ClaimIntents(
+            entry=(
+                ClaimIntent(
+                    kind="acquire_title_transfer",
+                    normalized_title=old_title,
+                    from_owner_decision_number=target.num,
+                    to_owner_decision_number=new_number,
+                ),
+                acquire_content,
+            ),
+            publication=(
+                ClaimIntent(
+                    kind="transfer_title_owner",
+                    normalized_title=old_title,
+                    from_owner_decision_number=target.num,
+                    to_owner_decision_number=new_number,
+                ),
+                commit_content,
+            ),
+        )
+        return probes, intents
+    probes = (
+        OwnedTitleClaimProbe(
+            normalized_title=old_title,
+            expected_owner_decision_number=target.num,
+        ),
+        AbsentTitleClaimProbe(normalized_title=new_title),
+        content_probe,
+    )
+    intents = ClaimIntents(
+        entry=(
+            ClaimIntent(
+                kind="hold_owned_title",
+                normalized_title=old_title,
+                owner_decision_number=target.num,
+            ),
+            ClaimIntent(
+                kind="acquire_new_title",
+                normalized_title=new_title,
+                owner_decision_number=new_number,
+            ),
+            acquire_content,
+        ),
+        publication=(
+            ClaimIntent(
+                kind="release_title_owner",
+                normalized_title=old_title,
+                owner_decision_number=target.num,
+            ),
+            ClaimIntent(
+                kind="commit_title_owner",
+                normalized_title=new_title,
+                owner_decision_number=new_number,
+            ),
+            commit_content,
+        ),
+    )
+    return probes, intents
+
+
+def prepare_judgment_commit(
+    payload_bytes: bytes,
+    approval_attestation: ApprovalAttestation,
+    committed_generation: CommittedGeneration,
+    expected_payload_digest: str | None = None,
+) -> PreparedJudgmentCommit:
+    """Prepare immutable artifacts and semantic claim reads without I/O."""
+    payload_bytes = bytes(payload_bytes)
+    digest = _sha256(payload_bytes)
+    if expected_payload_digest is not None:
+        _validate_sha256(expected_payload_digest, field="expected_payload_digest")
+        if digest != expected_payload_digest:
+            raise ApprovedPayloadDigestMismatch(
+                "expected payload digest does not match approved payload bytes."
+            )
+    payload = _parse_payload(payload_bytes)
+    if (
+        payload.base_generation_id != committed_generation.generation_id
+        or payload.base_decision_counter != committed_generation.decision_counter
+    ):
+        raise ApprovedBaseStale(
+            "approved base generation and counter do not match the observed committed generation."
+        )
+    current, decisions, stems_by_number = _parse_committed_generation(committed_generation)
+    target, target_stem = _target(payload.content, decisions, stems_by_number)
+    questions_bytes = current.get("open-questions.md")
+    proposal = {
+        "title": payload.content.title,
+        "rationale": payload.content.rationale,
+        "rejected": [
+            {"alternative": value.alternative, "reason": value.reason}
+            for value in payload.content.rejected
+        ],
+        "confidence": payload.content.confidence,
+        "decision_type": payload.content.decision_type,
+        "reversibility": payload.content.reversibility,
+        "files_affected": list(payload.content.files_affected),
+        "resolves_questions": list(payload.content.resolves_questions),
+        "source": DecisionSource.mcp.value,
+        "base_commit": None,
+    }
+    questions_file = (
+        OpenQuestionsFile.parse(questions_bytes.decode("utf-8"))
+        if questions_bytes is not None and payload.content.resolves_questions
+        else None
+    )
+    request_rejection = validate_proposal_request(
+        proposal,
+        operation=payload.content.operation,
+        questions_file=questions_file,
+    )
+    if request_rejection is not None:
+        raise ProposalRejected(request_rejection)
+    evaluation = evaluate_parsed_proposal(
+        proposal,
+        operation=payload.content.operation,
+        decisions=decisions,
+        existing_hashes=set(),
+        affected_number=target.num if target is not None else None,
+        enforce_claim_conflicts=False,
+    )
+    if isinstance(evaluation, ProposeDecisionResult):
+        raise ProposalRejected(evaluation)
+    effective_at, provenance = _provenance(payload, approval_attestation)
+    artifacts, snapshot, primary, result, assigned, new_counter, primary_model = _build_artifacts(
+        payload=payload,
+        provenance=provenance,
+        effective_at=effective_at,
+        generation=committed_generation,
+        current=current,
+        evaluation=evaluation,
+        target=target,
+        target_stem=target_stem,
+    )
+    probes, intents = _claim_contract(payload.content.operation, target, primary_model)
+    return PreparedJudgmentCommit(
+        payload_bytes=payload_bytes,
+        payload_digest=digest,
+        payload=payload,
+        approval_attestation=approval_attestation,
+        base=PreparedBase(
+            generation_id=committed_generation.generation_id,
+            decision_counter=committed_generation.decision_counter,
+            observed_manifest_digest=committed_generation.observed_manifest_digest,
+        ),
+        effective_at=effective_at,
+        decision_provenance=provenance,
+        assigned_decision_number=assigned,
+        new_decision_counter=new_counter,
+        planned_artifacts=artifacts,
+        snapshot=snapshot,
+        primary_decision=primary,
+        claim_probes=probes,
+        claim_intents=intents,
+        result_projection=_CommittedResultProjection.from_result(result),
+    )
+
+
+def _probe_key(probe: ClaimProbe) -> tuple[str, str]:
+    if isinstance(probe, AbsentContentClaimProbe):
+        return ("content", probe.content_hash)
+    return ("title", probe.normalized_title)
+
+
+def _observation_key(observation: ClaimObservation) -> tuple[str, str]:
+    if isinstance(
+        observation,
+        (
+            AbsentContentClaimObservation,
+            CommittedContentClaimObservation,
+            UnavailableContentClaimObservation,
+        ),
+    ):
+        return ("content", observation.content_hash)
+    return ("title", observation.normalized_title)
+
+
+def _validate_observation(probe: ClaimProbe, observation: ClaimObservation) -> None:
+    if isinstance(
+        observation, (UnavailableTitleClaimObservation, UnavailableContentClaimObservation)
+    ):
+        raise ClaimUnavailable(f"claim {_observation_key(observation)!r} is {observation.reason}.")
+    if isinstance(probe, AbsentTitleClaimProbe):
+        if isinstance(observation, AbsentTitleClaimObservation):
+            return
+        if isinstance(observation, CommittedTitleClaimObservation):
+            raise TitleClaimConflict(
+                "normalized title is already owned by decision "
+                f"{observation.owner_decision_number}."
+            )
+    elif isinstance(probe, OwnedTitleClaimProbe):
+        if isinstance(observation, CommittedTitleClaimObservation) and (
+            observation.owner_decision_number == probe.expected_owner_decision_number
+        ):
+            return
+        raise MismatchedClaimObservation(
+            "owned title claim does not match the expected committed owner."
+        )
+    elif isinstance(observation, AbsentContentClaimObservation):
+        return
+    elif isinstance(observation, CommittedContentClaimObservation):
+        raise ContentClaimConflict("content hash is already present in decision history.")
+    raise MismatchedClaimObservation("claim observation does not match its prepared probe.")
+
+
+def _artifact_inventory(prepared: PreparedJudgmentCommit) -> dict[str, object]:
+    descriptors = [
+        {"length": artifact.length, "path": artifact.path, "sha256": artifact.sha256}
+        for artifact in prepared.planned_artifacts
+    ]
+    inventory = {"artifacts": descriptors, "schema": "nauro.artifact_inventory.v1"}
+    inventory_bytes = canonical_judgment_payload_bytes(inventory)
+    return {
+        "artifact_count": len(descriptors),
+        "digest": _sha256(inventory_bytes),
+        "schema": "nauro.artifact_inventory.v1",
+        "total_byte_count": sum(descriptor["length"] for descriptor in descriptors),
+    }
+
+
+def _plan_record(
+    prepared: PreparedJudgmentCommit,
+    observations: tuple[ClaimObservation, ...],
+) -> bytes:
+    content = prepared.payload.content
+    provenance = (
+        {
+            "approved_at": prepared.decision_provenance.approved_at,
+            "approved_by": prepared.decision_provenance.approved_by,
+            "proposal_id": prepared.decision_provenance.proposal_id,
+            "proposed_base_commit": prepared.decision_provenance.proposed_base_commit,
+            "proposed_by": prepared.decision_provenance.proposed_by,
+        }
+        if prepared.decision_provenance is not None
+        else None
+    )
+    record = {
+        "affected_decision_id": content.affected_decision_id,
+        "approval_mode": prepared.payload.approval_mode,
+        "approval": prepared.approval_attestation.model_dump(mode="json"),
+        "artifact_inventory": _artifact_inventory(prepared),
+        "base": prepared.base.model_dump(mode="json"),
+        "claim_plan": {
+            "entry": [value.model_dump(mode="json") for value in prepared.claim_intents.entry],
+            "observations": [value.model_dump(mode="json") for value in observations],
+            "probes": [value.model_dump(mode="json") for value in prepared.claim_probes],
+            "publication": [
+                value.model_dump(mode="json") for value in prepared.claim_intents.publication
+            ],
+        },
+        "committed_result": prepared.committed_result.model_dump(mode="json"),
+        "decision_provenance": provenance,
+        "new_decision_counter": prepared.new_decision_counter,
+        "operation": content.operation,
+        "payload_digest": prepared.payload_digest,
+        "payload_schema": prepared.payload.payload_schema,
+        "primary_decision": prepared.primary_decision.model_dump(mode="json"),
+        "record_schema": "nauro.judgment_commit.plan_record.v1",
+        "snapshot": {
+            "length": prepared.snapshot.length,
+            "sha256": prepared.snapshot.sha256,
+        },
+        "transform_version": prepared.transformation_version,
+    }
+    return canonical_judgment_payload_bytes(record)
+
+
+def finalize_judgment_commit(
+    prepared: PreparedJudgmentCommit,
+    claim_observations: Sequence[ClaimObservation | Mapping[str, object]],
+) -> JudgmentCommitPlan:
+    """Validate claim observations and finalize the storage-neutral plan."""
+    parsed: list[ClaimObservation] = []
+    for raw in claim_observations:
+        try:
+            parsed.append(_OBSERVATION_ADAPTER.validate_python(raw))
+        except ValidationError as exc:
+            raise MalformedClaimObservation("claim observation is malformed.") from exc
+    observed_by_key: dict[tuple[str, str], ClaimObservation] = {}
+    for observation in parsed:
+        key = _observation_key(observation)
+        if key in observed_by_key:
+            raise DuplicateClaimObservation(f"duplicate claim observation for {key!r}.")
+        observed_by_key[key] = observation
+    probe_keys = {_probe_key(probe) for probe in prepared.claim_probes}
+    extra = set(observed_by_key) - probe_keys
+    if extra:
+        raise UnexpectedClaimObservation(f"unexpected claim observation(s): {sorted(extra)!r}.")
+    missing = probe_keys - set(observed_by_key)
+    if missing:
+        raise MissingClaimObservation(f"missing claim observation(s): {sorted(missing)!r}.")
+    ordered = tuple(observed_by_key[_probe_key(probe)] for probe in prepared.claim_probes)
+    for probe, observation in zip(prepared.claim_probes, ordered, strict=True):
+        _validate_observation(probe, observation)
+    claim_plan = FinalizedClaimPlan(
+        entry=prepared.claim_intents.entry,
+        publication=prepared.claim_intents.publication,
+    )
+    record_bytes = _plan_record(prepared, ordered)
+    return JudgmentCommitPlan(
+        prepared=prepared,
+        validated_claim_observations=ordered,
+        claim_plan=claim_plan,
+        plan_record_bytes=record_bytes,
+    )

--- a/packages/nauro-core/src/nauro_core/operations/propose_decision.py
+++ b/packages/nauro-core/src/nauro_core/operations/propose_decision.py
@@ -35,26 +35,36 @@ from typing import Literal
 
 from nauro_core.constants import (
     DECISION_HASHES_FILE,
-    MIN_RATIONALE_LENGTH,
     OPEN_QUESTIONS_MD,
 )
 from nauro_core.decision_model import (
-    Decision,
     DecisionConfidence,
     DecisionSource,
-    DecisionStatus,
     DecisionType,
     RejectedAlternative,
     Reversibility,
     format_decision,
     parse_decision,
 )
+from nauro_core.operations._decision_transitions import (
+    append_decision_update,
+    attach_supersedes,
+    build_new_decision,
+    mark_superseded,
+    resolve_questions_content,
+    slugify_decision_title,
+)
+from nauro_core.operations._proposal_evaluation import (
+    evaluate_parsed_proposal,
+    validate_question_resolves,
+    validate_update_metadata,
+    validate_update_rationale,
+)
 from nauro_core.operations.decision_lookup import (
     find_decision_stem_by_id,
     find_decision_stem_by_num,
     parse_all_decisions,
 )
-from nauro_core.operations.related_hits import to_related_decisions
 from nauro_core.operations.results import (
     ErrorPayload,
     ProposeDecisionResult,
@@ -66,29 +76,11 @@ from nauro_core.parsing import (
     _decision_path,
     extract_decision_number,
 )
-from nauro_core.questions import EntryBlock, OpenQuestionsFile
+from nauro_core.questions import OpenQuestionsFile
 from nauro_core.validation import (
-    check_bm25_similarity,
     compute_hash,
     rejected_item_label,
-    screen_structural,
 )
-
-# operation="update" appends rationale only — update_decision reads only
-# affected_decision_id + rationale. Any value in these fields would be
-# silently dropped on local stdio (and rejected on remote MCP); reject
-# loudly at the boundary so the wording in PROPOSE_DECISION_OPERATIONS holds
-# on both transports.
-_UPDATE_DISALLOWED_FIELDS: tuple[str, ...] = (
-    "title",
-    "rejected",
-    "files_affected",
-    "decision_type",
-    "reversibility",
-    "confidence",
-)
-
-_SLUG_MAX_LENGTH = 60
 
 
 @dataclass(frozen=True)
@@ -146,93 +138,37 @@ def propose_decision(
         "base_commit": base_commit,
     }
 
-    # --- operation="update": reject metadata fields up front ---
-    if operation == "update":
-        disallowed = [
-            name
-            for name in _UPDATE_DISALLOWED_FIELDS
-            if proposal.get(name)
-            and (not isinstance(proposal.get(name), str) or proposal.get(name).strip())
-        ]
-        if disallowed:
-            return ProposeDecisionResult(
-                status="rejected",
-                tier=0,
-                operation="update",
-                assessment=(
-                    'operation="update" appends rationale only; cannot change '
-                    f"{', '.join(disallowed)}. "
-                    'Use operation="supersede" to replace the decision with new metadata.'
-                ),
-            )
-
-    # --- resolves_questions: unknown / ambiguous ids reject at boundary ---
     requested_resolves = list(proposal.get("resolves_questions") or [])
-    if requested_resolves:
-        questions_file = _load_questions_file(store)
-        unknown = _unknown_question_ids(requested_resolves, questions_file)
-        if unknown:
-            return ProposeDecisionResult(
-                status="rejected",
-                tier=0,
-                operation=operation,
-                assessment=(
-                    "resolves_questions contains unknown id(s): "
-                    + ", ".join(repr(x) for x in unknown)
-                    + ". Call get_context (L0 lists every open question) to "
-                    "see the canonical ids in open-questions.md."
-                ),
-            )
-        ambiguous = _ambiguous_question_ids(requested_resolves, questions_file)
-        if ambiguous:
-            offenders = "; ".join(
-                f"{requested!r} matches {len(counterparts)} entries — disambiguate "
-                f"to one of: {', '.join(counterparts)}"
-                for requested, counterparts in ambiguous.items()
-            )
-            return ProposeDecisionResult(
-                status="rejected",
-                tier=0,
-                operation=operation,
-                assessment="resolves_questions contains ambiguous id(s): " + offenders + ".",
-            )
+    request_rejection = validate_update_metadata(proposal, operation=operation)
+    if request_rejection is not None:
+        return request_rejection
+    request_rejection = validate_question_resolves(
+        proposal,
+        operation=operation,
+        questions_file=_load_questions_file(store) if requested_resolves else None,
+    )
+    if request_rejection is not None:
+        return request_rejection
+    request_rejection = validate_update_rationale(proposal, operation=operation)
+    if request_rejection is not None:
+        return request_rejection
 
-    # --- Tier 1: structural screening ---
-    # ``parsed`` is the single corpus scan shared between Tier 1 active-title
-    # dedup and Tier 2 BM25. It stays None on the update early-reject path so a
-    # short-rationale update rejects without scanning the corpus at all.
-    parsed: list[Decision] | None = None
-    if operation == "update":
-        rationale_stripped = (proposal.get("rationale") or "").strip()
-        if not rationale_stripped:
-            action, reason = "reject", "Rationale is empty."
-        elif len(rationale_stripped) < MIN_RATIONALE_LENGTH:
-            action, reason = (
-                "reject",
-                f"Rationale too short ({len(rationale_stripped)} chars). "
-                f"Minimum {MIN_RATIONALE_LENGTH}.",
-            )
-        else:
-            action, reason = "pass", None
-    else:
-        parsed = parse_all_decisions(store)
-        action, reason = _screen_structural(store, proposal, parsed, affected_decision_id)
+    parsed = parse_all_decisions(store)
+    evaluation = evaluate_parsed_proposal(
+        proposal,
+        operation=operation,
+        decisions=parsed,
+        existing_hashes=set(_load_hash_index(store)) if operation != "update" else set(),
+        affected_number=(
+            extract_decision_number(affected_decision_id) if affected_decision_id else None
+        ),
+        enforce_claim_conflicts=True,
+    )
+    if isinstance(evaluation, ProposeDecisionResult):
+        return evaluation
 
-    if action == "reject":
-        return ProposeDecisionResult(
-            status="rejected",
-            tier=1,
-            operation="reject",
-            assessment=reason or "Structural validation failed.",
-        )
+    similar_models = list(evaluation.similar_decisions)
 
-    # --- Tier 2: BM25 similarity (advisory only — does not gate the write) ---
-    if parsed is None:
-        parsed = parse_all_decisions(store)
-    _t2_action, similar_raw = check_bm25_similarity(proposal, parsed)
-    similar_models = to_related_decisions(similar_raw, parsed)
-
-    # --- Commit ---
     decision_id, actual_operation, touched, resolve_outcome, error = _execute_operation(
         store, operation, proposal, affected_decision_id
     )
@@ -247,19 +183,11 @@ def propose_decision(
             similar_decisions=similar_models,
         )
 
-    if similar_models:
-        assessment = (
-            "Tier 2 surfaced similar decisions; review them and confirm with the "
-            "user before proposing further related writes."
-        )
-    else:
-        assessment = "No similar existing decisions found."
-
     return ProposeDecisionResult(
         status="confirmed",
         tier=2,
         operation=actual_operation,
-        assessment=assessment,
+        assessment=evaluation.assessment,
         similar_decisions=similar_models,
         decision_id=decision_id,
         touched_decisions=list(touched),
@@ -279,7 +207,7 @@ def _write_decision_direct(store: Store, proposal: dict) -> str:
     """
     next_num = _next_decision_num(store)
     title = proposal.get("title", "Untitled")
-    slug = _slugify(title)
+    slug = slugify_decision_title(title)
     filename = f"{_decision_number_prefix(next_num)}{slug}"
     rationale = proposal.get("rationale") or title
 
@@ -293,10 +221,11 @@ def _write_decision_direct(store: Store, proposal: dict) -> str:
     if base_commit:
         provenance_kwargs["base_commit"] = base_commit
 
-    decision = Decision(
-        date=datetime.now(timezone.utc).date(),
-        version=1,
-        status=DecisionStatus.active,
+    decision = build_new_decision(
+        number=next_num,
+        decision_date=datetime.now(timezone.utc).date(),
+        title=title,
+        rationale=rationale,
         confidence=DecisionConfidence(
             proposal.get("confidence") or DecisionConfidence.medium.value
         ),
@@ -305,46 +234,13 @@ def _write_decision_direct(store: Store, proposal: dict) -> str:
         source=_optional_enum(proposal.get("source"), DecisionSource),
         files_affected=_coerce_files_affected(proposal.get("files_affected")),
         rejected=_coerce_rejected(proposal.get("rejected")),
-        num=next_num,
-        title=title,
-        rationale=rationale,
-        **provenance_kwargs,
+        provenance=None,
+        extra_frontmatter=provenance_kwargs,
     )
     store.write_file(_decision_path(filename), format_decision(decision))
 
     _update_hash_index(store, title, rationale, filename)
     return filename
-
-
-# ── Tier 1 helpers ────────────────────────────────────────────────────────
-
-
-def _screen_structural(
-    store: Store,
-    proposal: dict,
-    parsed: list[Decision],
-    affected_decision_id: str | None,
-) -> tuple[str, str | None]:
-    """Run Tier 1 structural screening with hashes + active-title dedup.
-
-    Title dedup keys on active status, not recency: an add or supersede whose
-    normalized title matches any active decision is rejected regardless of the
-    matched decision's age. ``parsed`` is the shared corpus scan reused for
-    Tier 2 BM25, so this does not re-read the store.
-
-    The supersede target is excluded from the dedup set. Screening runs before
-    the supersede flip, so the target is still active at this point; without
-    the exclusion a same-title supersede of an established decision would
-    self-reject. A supersede whose new title collides with a *different* active
-    decision still rejects.
-    """
-    hash_index = _load_hash_index(store)
-    existing_hashes = set(hash_index.keys())
-    affected_num = extract_decision_number(affected_decision_id) if affected_decision_id else None
-    dedup_decisions = [
-        d for d in parsed if d.status is DecisionStatus.active and d.num != affected_num
-    ]
-    return screen_structural(proposal, existing_hashes, dedup_decisions)
 
 
 def _load_hash_index(store: Store) -> dict:
@@ -440,7 +336,7 @@ def _do_supersede(
             ),
         )
     new_decision = parse_decision(new_body, _decision_filename(new_decision_id))
-    new_decision_rewritten = new_decision.model_copy(update={"supersedes": str(old_num)})
+    new_decision_rewritten = attach_supersedes(new_decision, old_num)
     store.write_file(
         _decision_path(new_decision_id),
         format_decision(new_decision_rewritten),
@@ -481,12 +377,7 @@ def _do_supersede(
         )
     try:
         old_decision = parse_decision(old_body, _decision_filename(old_stem))
-        old_rewritten = old_decision.model_copy(
-            update={
-                "status": DecisionStatus.superseded,
-                "superseded_by": str(new_num),
-            }
-        )
+        old_rewritten = mark_superseded(old_decision, new_num)
         store.write_file(
             _decision_path(old_stem),
             format_decision(old_rewritten),
@@ -549,17 +440,11 @@ def _do_update(
             ),
         )
     target = parse_decision(body, _decision_filename(target_stem))
-    date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-    additional = (proposal.get("rationale") or "").strip()
-    appended_rationale = (
-        f"{target.rationale.strip()}\n\n"
-        f"*Update (v{target.version + 1}) — {date_str}:* {additional}"
-    )
-    updated = target.model_copy(
-        update={
-            "version": target.version + 1,
-            "rationale": appended_rationale,
-        }
+    updated = append_decision_update(
+        target,
+        additional_rationale=proposal.get("rationale") or "",
+        update_date=datetime.now(timezone.utc).date(),
+        provenance=None,
     )
     store.write_file(_decision_path(target_stem), format_decision(updated))
 
@@ -595,10 +480,13 @@ def _apply_question_resolves(
         return _QuestionResolveOutcome(), None
     try:
         content = store.read_file(OPEN_QUESTIONS_MD) or ""
-        questions_file = OpenQuestionsFile.parse(content)
-        result = questions_file.resolve(ids, num, datetime.now(timezone.utc).date())
-        normalized = result.file.normalize()
-        store.write_file(OPEN_QUESTIONS_MD, normalized.file.format())
+        transition = resolve_questions_content(
+            content,
+            question_ids=ids,
+            decision_number=num,
+            resolved_date=datetime.now(timezone.utc).date(),
+        )
+        store.write_file(OPEN_QUESTIONS_MD, transition.content)
     except Exception as exc:
         return _QuestionResolveOutcome(), ErrorPayload(
             kind="error",
@@ -609,15 +497,12 @@ def _apply_question_resolves(
         )
     return (
         _QuestionResolveOutcome(
-            resolved_ids=result.moved_ids,
-            relocated_ids=normalized.relocated_ids,
-            skipped_prose_ids=normalized.skipped_prose_ids,
+            resolved_ids=transition.resolved_ids,
+            relocated_ids=transition.relocated_ids,
+            skipped_prose_ids=transition.skipped_prose_ids,
         ),
         None,
     )
-
-
-# ── Question-id boundary helpers ──────────────────────────────────────────
 
 
 def _load_questions_file(store: Store) -> OpenQuestionsFile | None:
@@ -625,38 +510,6 @@ def _load_questions_file(store: Store) -> OpenQuestionsFile | None:
     if content is None:
         return None
     return OpenQuestionsFile.parse(content)
-
-
-def _unknown_question_ids(
-    ids: list[str],
-    questions_file: OpenQuestionsFile | None,
-) -> list[str]:
-    if questions_file is None:
-        return list(ids)
-    known = questions_file.known_question_ids
-    return [tid for tid in ids if tid not in known]
-
-
-def _ambiguous_question_ids(
-    ids: list[str],
-    questions_file: OpenQuestionsFile | None,
-) -> dict[str, list[str]]:
-    if questions_file is None:
-        return {}
-    collisions = questions_file.ambiguous_ids
-    requested_ambiguous = [tid for tid in ids if tid in collisions]
-    if not requested_ambiguous:
-        return {}
-
-    counterparts: dict[str, list[str]] = {tid: [] for tid in requested_ambiguous}
-    for block in questions_file.blocks:
-        if not isinstance(block, EntryBlock):
-            continue
-        eid = block.entry.id
-        if eid in counterparts:
-            slot = f"Q{block.entry.num}" if block.entry.num is not None else "<no-Q-id>"
-            counterparts[eid].append(slot)
-    return counterparts
 
 
 # ── Decision write plumbing ───────────────────────────────────────────────
@@ -670,27 +523,6 @@ def _next_decision_num(store: Store) -> int:
         if n is not None:
             nums.append(n)
     return max(nums, default=0) + 1
-
-
-def _slugify(title: str) -> str:
-    out_chars: list[str] = []
-    prev_dash = False
-    for ch in title.lower():
-        if ch.isalnum():
-            out_chars.append(ch)
-            prev_dash = False
-        elif not prev_dash:
-            out_chars.append("-")
-            prev_dash = True
-    slug = "".join(out_chars).strip("-")
-    if len(slug) > _SLUG_MAX_LENGTH:
-        truncated = slug[:_SLUG_MAX_LENGTH]
-        # Prefer cutting at a word boundary, but only while that keeps at
-        # least half the cap: a title whose only dash sits early would
-        # otherwise collapse to a near-empty slug (and filename).
-        trimmed = truncated.rsplit("-", 1)[0]
-        slug = trimmed if len(trimmed) >= _SLUG_MAX_LENGTH // 2 else truncated
-    return slug
 
 
 def _optional_enum(raw, enum_cls):

--- a/packages/nauro-core/src/nauro_core/protected_generation_membership.py
+++ b/packages/nauro-core/src/nauro_core/protected_generation_membership.py
@@ -1,0 +1,85 @@
+"""Closed membership rules for protected generations and hosted snapshots."""
+
+from __future__ import annotations
+
+from nauro_core.identifiers import IdentifierKind, is_identifier
+
+_TOP_LEVEL_GENERATION_MEMBERS = frozenset(
+    {
+        "project.md",
+        "state.md",
+        "state_current.md",
+        "state_history.md",
+        "stack.md",
+        "open-questions.md",
+        "questions-provenance.json",
+    }
+)
+_SNAPSHOT_TOP_LEVEL_MEMBERS = _TOP_LEVEL_GENERATION_MEMBERS - {"questions-provenance.json"}
+
+
+class InvalidGenerationPath(ValueError):
+    """Base class for paths refused by protected-generation classification."""
+
+
+class NoncanonicalGenerationPath(InvalidGenerationPath):
+    """A path uses syntax that cannot name a canonical store member."""
+
+
+class UnknownGenerationPath(InvalidGenerationPath):
+    """A canonical path does not belong to the protected generation set."""
+
+
+def _require_canonical_path(path: object) -> str:
+    if not isinstance(path, str) or not path:
+        raise NoncanonicalGenerationPath("generation path must be a non-empty string.")
+    if path.startswith("/") or "\\" in path:
+        raise NoncanonicalGenerationPath(f"noncanonical generation path: {path!r}.")
+    segments = path.split("/")
+    if any(segment in ("", ".", "..") for segment in segments):
+        raise NoncanonicalGenerationPath(f"noncanonical generation path: {path!r}.")
+    return path
+
+
+def _is_decision_member(path: str) -> bool:
+    if not path.startswith("decisions/") or not path.endswith(".md"):
+        return False
+    rest = path[len("decisions/") : -len(".md")]
+    return bool(rest) and "/" not in rest
+
+
+def _is_context_member(path: str) -> bool:
+    if not path.startswith("context/") or not path.endswith(".md"):
+        return False
+    slug = path[len("context/") : -len(".md")]
+    return "/" not in slug and is_identifier(IdentifierKind.brief_slug, slug)
+
+
+def is_protected_generation_member(path: object) -> bool:
+    """Report whether *path* is a canonical protected-generation artifact."""
+    try:
+        canonical = _require_canonical_path(path)
+    except NoncanonicalGenerationPath:
+        return False
+    return (
+        canonical in _TOP_LEVEL_GENERATION_MEMBERS
+        or _is_decision_member(canonical)
+        or _is_context_member(canonical)
+    )
+
+
+def is_hosted_snapshot_content_member(path: object) -> bool:
+    """Report whether *path* belongs in a hosted judgment snapshot."""
+    try:
+        canonical = _require_canonical_path(path)
+    except NoncanonicalGenerationPath:
+        return False
+    return canonical in _SNAPSHOT_TOP_LEVEL_MEMBERS or _is_decision_member(canonical)
+
+
+def validate_protected_generation_path(path: object) -> str:
+    """Return a protected-generation path, rejecting unknown paths closed."""
+    canonical = _require_canonical_path(path)
+    if not is_protected_generation_member(canonical):
+        raise UnknownGenerationPath(f"path is not a protected generation member: {canonical!r}.")
+    return canonical

--- a/packages/nauro-core/src/nauro_core/provenance.py
+++ b/packages/nauro-core/src/nauro_core/provenance.py
@@ -1,0 +1,41 @@
+"""Validation for provenance values shared across local and hosted writers."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+
+class InvalidCommitSha(ValueError):
+    """A repository commit is not a canonical full SHA-1 or SHA-256 value."""
+
+
+class InvalidUtcTimestamp(ValueError):
+    """A timestamp is not the pinned RFC3339 UTC representation."""
+
+
+def validate_commit_sha(value: object, *, field: str) -> str:
+    """Return a lowercase 40- or 64-character hexadecimal commit SHA."""
+    if not isinstance(value, str):
+        raise InvalidCommitSha(f"{field} must be a string.")
+    if len(value) not in (40, 64) or any(char not in "0123456789abcdef" for char in value):
+        raise InvalidCommitSha(
+            f"{field} must be a 40- or 64-character lowercase hexadecimal commit SHA."
+        )
+    return value
+
+
+def validate_utc_timestamp(value: object, *, field: str) -> str:
+    """Return a timestamp in exact ``YYYY-MM-DDTHH:MM:SS.ffffffZ`` form."""
+    if not isinstance(value, str) or len(value) != 27:
+        raise InvalidUtcTimestamp(f"{field} must use YYYY-MM-DDTHH:MM:SS.ffffffZ.")
+    if value[10] != "T" or value[19] != "." or value[-1] != "Z":
+        raise InvalidUtcTimestamp(f"{field} must use YYYY-MM-DDTHH:MM:SS.ffffffZ.")
+    try:
+        parsed = datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ")
+    except ValueError as exc:
+        raise InvalidUtcTimestamp(
+            f"{field} must be a valid UTC timestamp in YYYY-MM-DDTHH:MM:SS.ffffffZ form."
+        ) from exc
+    if parsed.strftime("%Y-%m-%dT%H:%M:%S.%fZ") != value:
+        raise InvalidUtcTimestamp(f"{field} must use canonical YYYY-MM-DDTHH:MM:SS.ffffffZ form.")
+    return value

--- a/packages/nauro-core/tests/operations/test_commit_plan.py
+++ b/packages/nauro-core/tests/operations/test_commit_plan.py
@@ -1,0 +1,767 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import date
+
+import pytest
+from pydantic import ValidationError
+
+from nauro_core.decision_model import (
+    Decision,
+    DecisionConfidence,
+    DecisionStatus,
+    format_decision,
+    parse_decision,
+)
+from nauro_core.operations.commit_plan import (
+    AbsentContentClaimObservation,
+    AbsentTitleClaimObservation,
+    ApprovalAttestationRejected,
+    ApprovedBaseStale,
+    ApprovedPayloadDigestMismatch,
+    CanonicalPayloadRejected,
+    ClaimUnavailable,
+    CommittedArtifact,
+    CommittedContentClaimObservation,
+    CommittedGeneration,
+    CommittedTitleClaimObservation,
+    ContentClaimConflict,
+    DuplicateClaimObservation,
+    MalformedClaimObservation,
+    MismatchedClaimObservation,
+    MissingClaimObservation,
+    PlannedSnapshot,
+    PreparedJudgmentCommit,
+    PreTeamApprovalAttestation,
+    ProposalRejected,
+    TeamRatificationAttestation,
+    TitleClaimConflict,
+    UnavailableContentClaimObservation,
+    UnexpectedClaimObservation,
+    canonical_judgment_payload_bytes,
+    finalize_judgment_commit,
+    prepare_judgment_commit,
+)
+from nauro_core.snapshot import serialize_snapshot
+
+GENERATION_ID = "01K00000000000000000000000"
+PROPOSAL_ID = "01K00000000000000000000001"
+AUTHOR_ID = "01K00000000000000000000002"
+RATIFIER_ID = "01K00000000000000000000003"
+ACTION_ID = "01K00000000000000000000004"
+TIMESTAMP = "2026-08-14T09:10:11.123456Z"
+_UNSET = object()
+
+
+def _decision(
+    num: int,
+    title: str,
+    *,
+    status: DecisionStatus = DecisionStatus.active,
+    superseded_by: str | None = None,
+    proposed_by: str | None = None,
+    approved_by: str | None = None,
+    approved_at: str | None = None,
+    proposal_id: str | None = None,
+) -> tuple[str, bytes]:
+    stem = f"{num:03d}-{title.lower().replace(' ', '-')}"
+    model = Decision(
+        date=date(2026, 1, 1),
+        confidence=DecisionConfidence.medium,
+        status=status,
+        superseded_by=superseded_by,
+        num=num,
+        title=title,
+        rationale="Existing rationale with enough text for validation.",
+        proposed_by=proposed_by,
+        approved_by=approved_by,
+        approved_at=approved_at,
+        proposal_id=proposal_id,
+    )
+    return f"decisions/{stem}.md", format_decision(model).encode()
+
+
+def _generation(*entries: tuple[str, bytes], counter: int | None = None) -> CommittedGeneration:
+    artifacts = tuple(
+        CommittedArtifact(
+            path=path,
+            content=content,
+            manifest_artifact_digest=hashlib.sha256(content).hexdigest(),
+        )
+        for path, content in entries
+    )
+    numbers = [
+        int(path.removeprefix("decisions/")[:3])
+        for path, _ in entries
+        if path.startswith("decisions/")
+    ]
+    return CommittedGeneration(
+        generation_id=GENERATION_ID,
+        decision_counter=max(numbers, default=0) if counter is None else counter,
+        observed_manifest_digest="a" * 64,
+        artifacts=artifacts,
+    )
+
+
+def _content(
+    *,
+    operation: str = "add",
+    target: str | None = None,
+    title: str | None | object = _UNSET,
+    rationale: str = "SQLite provides durable local state with simple operational ownership.",
+    resolves_questions: list[str] | None = None,
+) -> dict[str, object]:
+    effective_title = (
+        (None if operation == "update" else "Use SQLite for durable local state")
+        if title is _UNSET
+        else title
+    )
+    return {
+        "affected_decision_id": target,
+        "confidence": None if operation == "update" else "medium",
+        "decision_type": None,
+        "files_affected": [],
+        "operation": operation,
+        "rationale": rationale,
+        "rejected": [],
+        "resolves_questions": resolves_questions or [],
+        "reversibility": None,
+        "title": effective_title,
+    }
+
+
+def _preteam_payload(generation: CommittedGeneration, **content_overrides: object) -> bytes:
+    content = _content(**content_overrides)
+    return canonical_judgment_payload_bytes(
+        {
+            "approval_mode": "pre_team_session",
+            "base_decision_counter": generation.decision_counter,
+            "base_generation_id": generation.generation_id,
+            "content": content,
+            "payload_schema": "nauro.judgment_commit.pre_team.v1",
+            "proposed_base_commit": None,
+        }
+    )
+
+
+def _team_payload(
+    generation: CommittedGeneration,
+    *,
+    contributor_operation_id: str = "client-op-1",
+    **content_overrides: object,
+) -> bytes:
+    return canonical_judgment_payload_bytes(
+        {
+            "approval_mode": "team_ratification",
+            "base_decision_counter": generation.decision_counter,
+            "base_generation_id": generation.generation_id,
+            "content": _content(**content_overrides),
+            "contributor_operation_id": contributor_operation_id,
+            "payload_schema": "nauro.judgment_commit.team_proposal.v1",
+            "proposal_id": PROPOSAL_ID,
+            "proposal_revision": 1,
+            "proposed_base_commit": "b" * 40,
+            "proposed_by": AUTHOR_ID,
+        }
+    )
+
+
+def _preteam_attestation(
+    operation_id: str = "client-op-1",
+) -> PreTeamApprovalAttestation:
+    return PreTeamApprovalAttestation(
+        actor_id=AUTHOR_ID,
+        operation_id=operation_id,
+        request_received_at=TIMESTAMP,
+    )
+
+
+def _team_attestation() -> TeamRatificationAttestation:
+    return TeamRatificationAttestation(
+        approved_by=RATIFIER_ID,
+        approved_at=TIMESTAMP,
+        ratification_action_id=ACTION_ID,
+    )
+
+
+def test_prepare_and_finalize_add_are_deterministic_and_storage_neutral() -> None:
+    generation = _generation(("project.md", b"# Test\n"), counter=4)
+    payload = _preteam_payload(generation)
+
+    first = prepare_judgment_commit(payload, _preteam_attestation(), generation)
+    second = prepare_judgment_commit(payload, _preteam_attestation(), generation)
+
+    assert first == second
+    assert first.assigned_decision_number == 5
+    assert first.new_decision_counter == 5
+    assert [probe.kind for probe in first.claim_probes] == [
+        "absent_title",
+        "absent_content",
+    ]
+    observations = [
+        AbsentContentClaimObservation(content_hash=first.claim_probes[1].content_hash),
+        AbsentTitleClaimObservation(normalized_title=first.claim_probes[0].normalized_title),
+    ]
+    plan = finalize_judgment_commit(first, observations)
+    replay = finalize_judgment_commit(second, list(reversed(observations)))
+    assert plan.plan_record_bytes == replay.plan_record_bytes
+    assert plan.plan_record_digest == hashlib.sha256(plan.plan_record_bytes).hexdigest()
+    assert json.loads(plan.plan_record_bytes)["transform_version"] == first.transformation_version
+    assert plan.committed_result.status == "confirmed"
+    assert plan.committed_result.operation == "add"
+
+
+def test_prepare_rejects_noncanonical_payload_and_digest_mismatch() -> None:
+    generation = _generation(("project.md", b"# Test\n"))
+    canonical = _preteam_payload(generation)
+    noncanonical = json.dumps(json.loads(canonical), indent=2).encode()
+    with pytest.raises(CanonicalPayloadRejected, match="canonical"):
+        prepare_judgment_commit(noncanonical, _preteam_attestation(), generation)
+    with pytest.raises(ApprovedPayloadDigestMismatch):
+        prepare_judgment_commit(
+            canonical,
+            _preteam_attestation(),
+            generation,
+            expected_payload_digest="f" * 64,
+        )
+
+
+def test_prepare_rejects_duplicate_json_keys() -> None:
+    generation = _generation(("project.md", b"# Test\n"))
+    payload = _preteam_payload(generation)
+    duplicate = payload[:-1] + b',"payload_schema":"nauro.judgment_commit.pre_team.v1"}'
+    with pytest.raises(CanonicalPayloadRejected, match="duplicate"):
+        prepare_judgment_commit(duplicate, _preteam_attestation(), generation)
+
+
+def test_team_preparation_rejects_reused_submission_and_ratification_ids() -> None:
+    generation = _generation(("project.md", b"# Test\n"))
+    with pytest.raises(ApprovalAttestationRejected, match="must be distinct"):
+        prepare_judgment_commit(
+            _team_payload(generation, contributor_operation_id=ACTION_ID),
+            _team_attestation(),
+            generation,
+        )
+
+
+def test_team_preparation_accepts_distinct_submission_and_ratification_ids() -> None:
+    generation = _generation(("project.md", b"# Test\n"))
+    prepared = prepare_judgment_commit(_team_payload(generation), _team_attestation(), generation)
+    assert prepared.payload.contributor_operation_id == "client-op-1"
+    assert prepared.approval_attestation.ratification_action_id == ACTION_ID
+
+
+def test_preteam_preparation_does_not_apply_team_action_id_distinction() -> None:
+    generation = _generation(("project.md", b"# Test\n"))
+    prepared = prepare_judgment_commit(
+        _preteam_payload(generation),
+        _preteam_attestation(operation_id=ACTION_ID),
+        generation,
+    )
+    assert prepared.approval_attestation.operation_id == ACTION_ID
+
+
+def test_prepare_rejects_escaped_unpaired_surrogate_as_non_utf8_canonical_data() -> None:
+    generation = _generation(("project.md", b"# Test\n"))
+    raw = json.loads(_preteam_payload(generation))
+    raw["content"]["title"] = "Invalid \ud800 title"
+    escaped = json.dumps(raw, sort_keys=True, separators=(",", ":")).encode()
+    with pytest.raises(CanonicalPayloadRejected, match="canonical UTF-8"):
+        prepare_judgment_commit(escaped, _preteam_attestation(), generation)
+
+
+def test_prepare_round_trips_canonical_non_ascii_payload() -> None:
+    generation = _generation(("project.md", b"# Test\n"))
+    payload = _preteam_payload(
+        generation,
+        title="Use SQLite for durable café state",
+    )
+    prepared = prepare_judgment_commit(payload, _preteam_attestation(), generation)
+    assert prepared.payload_bytes == payload
+    assert prepared.payload.content.title == "Use SQLite for durable café state"
+    assert b"caf\xc3\xa9" in next(
+        artifact.content
+        for artifact in prepared.planned_artifacts
+        if artifact.path == prepared.primary_decision.path
+    )
+
+
+@pytest.mark.parametrize(
+    ("content_overrides", "tier", "operation", "assessment"),
+    [
+        ({"title": ""}, 1, "reject", "Title is empty."),
+        (
+            {"rationale": "too short"},
+            1,
+            "reject",
+            "Rationale too short (9 chars). Minimum 20.",
+        ),
+        (
+            {"resolves_questions": ["Q404"]},
+            0,
+            "add",
+            "resolves_questions contains unknown id(s): 'Q404'. Call get_context "
+            "(L0 lists every open question) to see the canonical ids in "
+            "open-questions.md.",
+        ),
+    ],
+)
+def test_semantic_payload_rejections_preserve_existing_result_semantics(
+    content_overrides: dict[str, object],
+    tier: int,
+    operation: str,
+    assessment: str,
+) -> None:
+    generation = _generation(("project.md", b"# Test\n"))
+    with pytest.raises(ProposalRejected) as raised:
+        prepare_judgment_commit(
+            _preteam_payload(generation, **content_overrides),
+            _preteam_attestation(),
+            generation,
+        )
+    assert raised.value.result.model_dump(mode="json") == {
+        "assessment": assessment,
+        "decision_id": None,
+        "error": None,
+        "operation": operation,
+        "relocated_ids": None,
+        "resolved_questions": [],
+        "similar_decisions": [],
+        "skipped_prose_ids": None,
+        "status": "rejected",
+        "tier": tier,
+        "touched_decisions": [],
+    }
+
+
+def test_update_disallowed_fields_are_semantic_tier_zero_rejection() -> None:
+    existing = _decision(1, "Existing decision")
+    generation = _generation(existing, counter=1)
+    target = existing[0].removeprefix("decisions/").removesuffix(".md")
+    with pytest.raises(ProposalRejected) as raised:
+        prepare_judgment_commit(
+            _preteam_payload(
+                generation,
+                operation="update",
+                target=target,
+                title="Replacement title",
+            ),
+            _preteam_attestation(),
+            generation,
+        )
+    assert raised.value.result.model_dump(mode="json") == {
+        "assessment": (
+            'operation="update" appends rationale only; cannot change title. '
+            'Use operation="supersede" to replace the decision with new metadata.'
+        ),
+        "decision_id": None,
+        "error": None,
+        "operation": "update",
+        "relocated_ids": None,
+        "resolved_questions": [],
+        "similar_decisions": [],
+        "skipped_prose_ids": None,
+        "status": "rejected",
+        "tier": 0,
+        "touched_decisions": [],
+    }
+
+
+def test_prepare_rejects_stale_generation_or_counter_without_plan() -> None:
+    generation = _generation(("project.md", b"# Test\n"), counter=2)
+    payload = json.loads(_preteam_payload(generation))
+    payload["base_decision_counter"] = 1
+    with pytest.raises(ApprovedBaseStale):
+        prepare_judgment_commit(
+            canonical_judgment_payload_bytes(payload),
+            _preteam_attestation(),
+            generation,
+        )
+
+
+def test_counter_gaps_remain_reserved_and_add_uses_counter_plus_one() -> None:
+    generation = _generation(_decision(2, "Existing decision"), counter=9)
+    prepared = prepare_judgment_commit(
+        _preteam_payload(generation), _preteam_attestation(), generation
+    )
+    assert prepared.assigned_decision_number == 10
+    assert prepared.new_decision_counter == 10
+
+
+def test_counter_below_published_number_is_corruption() -> None:
+    generation = _generation(_decision(4, "Existing decision"), counter=3)
+    with pytest.raises(ValueError, match="counter"):
+        prepare_judgment_commit(_preteam_payload(generation), _preteam_attestation(), generation)
+
+
+def test_team_add_applies_complete_provenance_and_exact_snapshot_bytes() -> None:
+    generation = _generation(("project.md", b"# Test\n"), ("context/brief-one.md", b"private\n"))
+    prepared = prepare_judgment_commit(_team_payload(generation), _team_attestation(), generation)
+    body = next(
+        artifact.content.decode()
+        for artifact in prepared.planned_artifacts
+        if artifact.path == prepared.primary_decision.path
+    )
+    decision = parse_decision(body, prepared.primary_decision.path.removeprefix("decisions/"))
+    assert decision.proposed_by == AUTHOR_ID
+    assert decision.approved_by == RATIFIER_ID
+    assert decision.approved_at == TIMESTAMP
+    assert decision.proposal_id == PROPOSAL_ID
+    assert decision.proposed_base_commit == "b" * 40
+    assert b"context/brief-one.md" not in prepared.snapshot.content
+    files = {
+        artifact.path: artifact.content.decode()
+        for artifact in prepared.planned_artifacts
+        if artifact.path in {"project.md", prepared.primary_decision.path}
+    }
+    expected = serialize_snapshot(
+        timestamp=TIMESTAMP,
+        trigger="decision: Use SQLite for durable local state",
+        files=dict(sorted(files.items())),
+    )
+    assert (
+        prepared.snapshot.content
+        == json.dumps(
+            expected, separators=(",", ":"), ensure_ascii=False, allow_nan=False
+        ).encode()
+    )
+
+
+def test_preteam_add_emits_no_team_provenance() -> None:
+    generation = _generation(("project.md", b"# Test\n"))
+    prepared = prepare_judgment_commit(
+        _preteam_payload(generation), _preteam_attestation(), generation
+    )
+    body = next(
+        artifact.content.decode()
+        for artifact in prepared.planned_artifacts
+        if artifact.path == prepared.primary_decision.path
+    )
+    assert "proposed_by:" not in body
+    assert "approved_by:" not in body
+    assert "approved_at:" not in body
+    assert "proposal_id:" not in body
+    assert "proposed_base_commit:" not in body
+
+
+def test_team_update_replaces_provenance_and_preteam_update_clears_it() -> None:
+    existing = _decision(
+        1,
+        "Existing decision",
+        proposed_by=AUTHOR_ID,
+        approved_by=RATIFIER_ID,
+        approved_at=TIMESTAMP,
+        proposal_id=PROPOSAL_ID,
+    )
+    generation = _generation(existing, counter=1)
+    target = existing[0].removeprefix("decisions/").removesuffix(".md")
+
+    team = prepare_judgment_commit(
+        _team_payload(generation, operation="update", target=target),
+        _team_attestation(),
+        generation,
+    )
+    team_body = next(a.content.decode() for a in team.planned_artifacts if a.path == existing[0])
+    team_decision = parse_decision(team_body, existing[0].removeprefix("decisions/"))
+    assert team_decision.proposed_base_commit == "b" * 40
+
+    preteam = prepare_judgment_commit(
+        _preteam_payload(generation, operation="update", target=target),
+        _preteam_attestation(),
+        generation,
+    )
+    preteam_body = next(
+        a.content.decode() for a in preteam.planned_artifacts if a.path == existing[0]
+    )
+    assert "proposed_by:" not in preteam_body
+    assert "approved_by:" not in preteam_body
+
+
+def test_supersede_preserves_target_provenance_and_same_title_has_one_probe() -> None:
+    existing = _decision(
+        1,
+        "Existing decision",
+        proposed_by=AUTHOR_ID,
+        approved_by=RATIFIER_ID,
+        approved_at=TIMESTAMP,
+        proposal_id=PROPOSAL_ID,
+    )
+    generation = _generation(existing, counter=1)
+    target = existing[0].removeprefix("decisions/").removesuffix(".md")
+    prepared = prepare_judgment_commit(
+        _team_payload(
+            generation,
+            operation="supersede",
+            target=target,
+            title="Existing decision",
+        ),
+        _team_attestation(),
+        generation,
+    )
+    assert [probe.kind for probe in prepared.claim_probes] == [
+        "owned_title",
+        "absent_content",
+    ]
+    assert prepared.claim_intents.entry[0].kind == "acquire_title_transfer"
+    old_body = next(
+        a.content.decode() for a in prepared.planned_artifacts if a.path == existing[0]
+    )
+    old = parse_decision(old_body, existing[0].removeprefix("decisions/"))
+    assert old.proposal_id == PROPOSAL_ID
+    assert old.status is DecisionStatus.superseded
+
+
+def test_different_title_supersede_has_hold_acquire_release_commit_contract() -> None:
+    existing = _decision(1, "Existing decision")
+    generation = _generation(existing, counter=1)
+    target = existing[0].removeprefix("decisions/").removesuffix(".md")
+    prepared = prepare_judgment_commit(
+        _preteam_payload(
+            generation,
+            operation="supersede",
+            target=target,
+            title="Replacement decision",
+        ),
+        _preteam_attestation(),
+        generation,
+    )
+    assert [probe.kind for probe in prepared.claim_probes] == [
+        "owned_title",
+        "absent_title",
+        "absent_content",
+    ]
+    assert [intent.kind for intent in prepared.claim_intents.entry] == [
+        "hold_owned_title",
+        "acquire_new_title",
+        "acquire_new_content_hash",
+    ]
+    assert [intent.kind for intent in prepared.claim_intents.publication] == [
+        "release_title_owner",
+        "commit_title_owner",
+        "commit_content_hash",
+    ]
+
+
+def test_update_claim_contract_keeps_counter_and_title_owner() -> None:
+    existing = _decision(3, "Existing decision")
+    generation = _generation(existing, counter=8)
+    target = existing[0].removeprefix("decisions/").removesuffix(".md")
+    prepared = prepare_judgment_commit(
+        _preteam_payload(generation, operation="update", target=target),
+        _preteam_attestation(),
+        generation,
+    )
+    assert prepared.assigned_decision_number is None
+    assert prepared.new_decision_counter == 8
+    assert [probe.kind for probe in prepared.claim_probes] == [
+        "owned_title",
+        "absent_content",
+    ]
+    assert [intent.kind for intent in prepared.claim_intents.publication] == [
+        "retain_title_owner",
+        "commit_content_hash",
+    ]
+
+
+def test_finalize_rejects_missing_extra_duplicate_malformed_and_unavailable() -> None:
+    generation = _generation(("project.md", b"# Test\n"))
+    prepared = prepare_judgment_commit(
+        _preteam_payload(generation), _preteam_attestation(), generation
+    )
+    title = prepared.claim_probes[0].normalized_title
+    content_hash = prepared.claim_probes[1].content_hash
+    title_observation = AbsentTitleClaimObservation(normalized_title=title)
+    content_observation = AbsentContentClaimObservation(content_hash=content_hash)
+
+    with pytest.raises(MissingClaimObservation):
+        finalize_judgment_commit(prepared, [title_observation])
+    with pytest.raises(UnexpectedClaimObservation):
+        finalize_judgment_commit(
+            prepared,
+            [
+                title_observation,
+                content_observation,
+                AbsentTitleClaimObservation(normalized_title="other"),
+            ],
+        )
+    with pytest.raises(DuplicateClaimObservation):
+        finalize_judgment_commit(
+            prepared, [title_observation, title_observation, content_observation]
+        )
+    with pytest.raises(MalformedClaimObservation):
+        finalize_judgment_commit(prepared, [{"kind": "wrong"}])
+    with pytest.raises(ClaimUnavailable):
+        finalize_judgment_commit(
+            prepared,
+            [
+                title_observation,
+                UnavailableContentClaimObservation(
+                    content_hash=content_hash,
+                    reason="reserved",
+                ),
+            ],
+        )
+
+
+def test_finalize_rejects_committed_title_conflict() -> None:
+    generation = _generation(("project.md", b"# Test\n"))
+    prepared = prepare_judgment_commit(
+        _preteam_payload(generation), _preteam_attestation(), generation
+    )
+    with pytest.raises(TitleClaimConflict):
+        finalize_judgment_commit(
+            prepared,
+            [
+                CommittedTitleClaimObservation(
+                    normalized_title=prepared.claim_probes[0].normalized_title,
+                    owner_decision_number=7,
+                ),
+                AbsentContentClaimObservation(content_hash=prepared.claim_probes[1].content_hash),
+            ],
+        )
+
+
+def test_finalize_rejects_historical_content_and_wrong_owned_title() -> None:
+    existing = _decision(1, "Existing decision")
+    generation = _generation(existing, counter=1)
+    target = existing[0].removeprefix("decisions/").removesuffix(".md")
+    prepared = prepare_judgment_commit(
+        _preteam_payload(generation, operation="update", target=target),
+        _preteam_attestation(),
+        generation,
+    )
+    title_probe, content_probe = prepared.claim_probes
+    with pytest.raises(MismatchedClaimObservation):
+        finalize_judgment_commit(
+            prepared,
+            [
+                CommittedTitleClaimObservation(
+                    normalized_title=title_probe.normalized_title,
+                    owner_decision_number=2,
+                ),
+                AbsentContentClaimObservation(content_hash=content_probe.content_hash),
+            ],
+        )
+    with pytest.raises(ContentClaimConflict, match="history"):
+        finalize_judgment_commit(
+            prepared,
+            [
+                CommittedTitleClaimObservation(
+                    normalized_title=title_probe.normalized_title,
+                    owner_decision_number=1,
+                ),
+                CommittedContentClaimObservation(content_hash=content_probe.content_hash),
+            ],
+        )
+
+
+def test_plan_record_is_bounded_and_excludes_transient_bytes() -> None:
+    generation = _generation(("project.md", b"# Test\n"))
+    prepared = prepare_judgment_commit(
+        _preteam_payload(generation), _preteam_attestation(), generation
+    )
+    plan = finalize_judgment_commit(
+        prepared,
+        [
+            AbsentTitleClaimObservation(
+                normalized_title=prepared.claim_probes[0].normalized_title
+            ),
+            AbsentContentClaimObservation(content_hash=prepared.claim_probes[1].content_hash),
+        ],
+    )
+    record = json.loads(plan.plan_record_bytes)
+    assert record["record_schema"] == "nauro.judgment_commit.plan_record.v1"
+    assert record["approval_mode"] == "pre_team_session"
+    assert "artifacts" not in record["artifact_inventory"]
+    assert "payload_bytes" not in record
+    assert "generation_id" not in record.get("primary_decision", {})
+    assert prepared.payload_bytes not in plan.plan_record_bytes
+
+
+def test_title_claim_models_require_canonical_normalized_text() -> None:
+    with pytest.raises(ValidationError, match="normalized_title"):
+        AbsentTitleClaimObservation(normalized_title="  Existing  Decision ")
+
+
+def test_models_are_deeply_immutable_at_collection_boundaries() -> None:
+    generation = _generation(("project.md", b"# Test\n"))
+    prepared = prepare_judgment_commit(
+        _preteam_payload(generation), _preteam_attestation(), generation
+    )
+    assert isinstance(prepared.planned_artifacts, tuple)
+    with pytest.raises(ValidationError):
+        prepared.new_decision_counter = 99
+
+
+def test_result_materialization_cannot_diverge_from_prepared_or_final_plan() -> None:
+    generation = _generation(("project.md", b"# Test\n"))
+    prepared = prepare_judgment_commit(
+        _preteam_payload(generation), _preteam_attestation(), generation
+    )
+    plan = finalize_judgment_commit(
+        prepared,
+        [
+            AbsentTitleClaimObservation(
+                normalized_title=prepared.claim_probes[0].normalized_title
+            ),
+            AbsentContentClaimObservation(content_hash=prepared.claim_probes[1].content_hash),
+        ],
+    )
+    artifacts_before = prepared.planned_artifacts
+    record_before = plan.plan_record_bytes
+    digest_before = plan.plan_record_digest
+    result_before = plan.committed_result.model_dump(mode="json")
+
+    for field in ("similar_decisions", "touched_decisions", "resolved_questions"):
+        sequence = getattr(plan.committed_result, field)
+        with pytest.raises(TypeError, match="immutable"):
+            sequence.append("tamper")
+
+    assert prepared.planned_artifacts == artifacts_before
+    assert plan.plan_record_bytes == record_before
+    assert plan.plan_record_digest == digest_before
+    assert prepared.committed_result.model_dump(mode="json") == result_before
+    assert plan.committed_result.model_dump(mode="json") == result_before
+
+
+def test_prepared_constructor_rejects_divergent_derived_snapshot() -> None:
+    generation = _generation(("project.md", b"# Test\n"))
+    prepared = prepare_judgment_commit(
+        _preteam_payload(generation), _preteam_attestation(), generation
+    )
+    fields = {name: getattr(prepared, name) for name in PreparedJudgmentCommit.model_fields}
+    fields["snapshot"] = PlannedSnapshot(content=b"{}")
+    with pytest.raises(ValidationError, match="snapshot bytes"):
+        PreparedJudgmentCommit(**fields)
+
+
+def test_prepared_constructor_rejects_unknown_transformation_version() -> None:
+    generation = _generation(("project.md", b"# Test\n"))
+    prepared = prepare_judgment_commit(
+        _preteam_payload(generation), _preteam_attestation(), generation
+    )
+    fields = {name: getattr(prepared, name) for name in PreparedJudgmentCommit.model_fields}
+    fields["transformation_version"] = 2
+    with pytest.raises(ValidationError, match="transformation_version"):
+        PreparedJudgmentCommit(**fields)
+
+
+def test_final_plan_constructor_rejects_tampered_record_bytes() -> None:
+    generation = _generation(("project.md", b"# Test\n"))
+    prepared = prepare_judgment_commit(
+        _preteam_payload(generation), _preteam_attestation(), generation
+    )
+    plan = finalize_judgment_commit(
+        prepared,
+        [
+            AbsentTitleClaimObservation(
+                normalized_title=prepared.claim_probes[0].normalized_title
+            ),
+            AbsentContentClaimObservation(content_hash=prepared.claim_probes[1].content_hash),
+        ],
+    )
+    fields = {name: getattr(plan, name) for name in plan.__class__.model_fields}
+    fields["plan_record_bytes"] = b"{}"
+    with pytest.raises(ValidationError, match="plan record bytes"):
+        plan.__class__(**fields)

--- a/packages/nauro-core/tests/operations/test_operations_propose_decision.py
+++ b/packages/nauro-core/tests/operations/test_operations_propose_decision.py
@@ -26,8 +26,10 @@ from pydantic import ValidationError
 from nauro_core.constants import OPEN_QUESTIONS_MD
 from nauro_core.decision_model import (
     DECISION_TYPE_VALUES,
+    Decision,
     DecisionStatus,
     Reversibility,
+    format_decision,
 )
 from nauro_core.operations import (
     InMemoryStore,
@@ -546,6 +548,57 @@ def test_update_disallowed_field_rejected_loudly() -> None:
     assert result.tier == 0
     assert result.operation == "update"
     assert "title" in result.assessment
+
+
+def test_update_disallowed_fields_reject_before_questions_are_parsed() -> None:
+    store = _store_with(
+        _seed_decision(1, "Adopt PostgreSQL", "ACID transactional semantics."),
+        **{OPEN_QUESTIONS_MD: "- [Q1] malformed without a heading\n"},
+    )
+    result = propose_decision(
+        store,
+        title="A new title",
+        rationale="A sufficiently long rationale that comfortably exceeds the minimum.",
+        operation="update",
+        affected_decision_id="decision-001",
+        resolves_questions=["Q1"],
+    )
+    assert result.status == "rejected"
+    assert result.tier == 0
+    assert "title" in result.assessment
+
+
+def test_local_update_clears_team_provenance_but_preserves_legacy_extra() -> None:
+    decision = Decision(
+        date=date(2026, 1, 1),
+        confidence="medium",
+        num=1,
+        title="Adopt PostgreSQL",
+        rationale="Mature ecosystem with strong JSON support and excellent tooling.",
+        proposed_by="01K00000000000000000000002",
+        approved_by="01K00000000000000000000003",
+        approved_at="2026-08-14T09:10:11.123456Z",
+        proposal_id="01K00000000000000000000001",
+        proposed_base_commit="a" * 40,
+        base_commit="b" * 40,
+    )
+    store = InMemoryStore(decisions={"001-adopt-postgresql": format_decision(decision)})
+    result = propose_decision(
+        store,
+        title=None,
+        rationale="Add a managed-extensions clause after production evidence.",
+        operation="update",
+        affected_decision_id="decision-001",
+    )
+    assert result.status == "confirmed"
+    body = store.read_decision("001-adopt-postgresql")
+    assert body is not None
+    assert "proposed_by:" not in body
+    assert "approved_by:" not in body
+    assert "approved_at:" not in body
+    assert "proposal_id:" not in body
+    assert "proposed_base_commit:" not in body
+    assert f"base_commit: {'b' * 40}" in body
 
 
 # ── Tier 1 structural rejection ─────────────────────────────────────────

--- a/packages/nauro-core/tests/test_decision_model.py
+++ b/packages/nauro-core/tests/test_decision_model.py
@@ -1005,3 +1005,38 @@ class TestEnumValueBytes:
 
     def test_confidence_medium_value(self) -> None:
         assert DecisionConfidence.medium.value == "medium"
+
+
+class TestApprovalProvenance:
+    def test_complete_group_serializes_after_existing_frontmatter(self) -> None:
+        decision = _minimal_decision(
+            proposed_by="01K00000000000000000000002",
+            approved_by="01K00000000000000000000003",
+            approved_at="2026-08-14T09:10:11.123456Z",
+            proposal_id="01K00000000000000000000001",
+            proposed_base_commit="a" * 40,
+        )
+        formatted = format_decision(decision)
+        assert formatted.index("superseded_by:") < formatted.index("proposed_by:")
+        assert formatted.index("proposed_by:") < formatted.index("approved_by:")
+        assert formatted.index("approved_by:") < formatted.index("approved_at:")
+        assert formatted.index("approved_at:") < formatted.index("proposal_id:")
+        assert formatted.index("proposal_id:") < formatted.index("proposed_base_commit:")
+        assert format_decision(parse_decision(formatted, "001-test.md")) == formatted
+
+    def test_absent_group_omits_only_new_fields(self) -> None:
+        formatted = format_decision(_minimal_decision())
+        for field in (
+            "proposed_by",
+            "approved_by",
+            "approved_at",
+            "proposal_id",
+            "proposed_base_commit",
+        ):
+            assert f"{field}:" not in formatted
+        assert "decision_type: null" in formatted
+        assert "files_affected: []" in formatted
+
+    def test_partial_group_rejects(self) -> None:
+        with pytest.raises(ValidationError, match="partial approval provenance"):
+            _minimal_decision(proposed_by="01K00000000000000000000002")

--- a/packages/nauro-core/tests/test_protected_generation_membership.py
+++ b/packages/nauro-core/tests/test_protected_generation_membership.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import pytest
+
+from nauro_core.protected_generation_membership import (
+    NoncanonicalGenerationPath,
+    UnknownGenerationPath,
+    is_hosted_snapshot_content_member,
+    is_protected_generation_member,
+    validate_protected_generation_path,
+)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "project.md",
+        "state.md",
+        "state_current.md",
+        "state_history.md",
+        "stack.md",
+        "open-questions.md",
+        "questions-provenance.json",
+        "decisions/001-use-sqlite.md",
+        "context/handoff-one.md",
+    ],
+)
+def test_protected_generation_members_are_closed(path: str) -> None:
+    assert is_protected_generation_member(path)
+    assert validate_protected_generation_path(path) == path
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "project.md",
+        "state.md",
+        "state_current.md",
+        "state_history.md",
+        "stack.md",
+        "open-questions.md",
+        "decisions/001-use-sqlite.md",
+    ],
+)
+def test_snapshot_members_are_independent(path: str) -> None:
+    assert is_hosted_snapshot_content_member(path)
+
+
+@pytest.mark.parametrize("path", ["questions-provenance.json", "context/handoff-one.md"])
+def test_snapshot_excludes_private_projection_content(path: str) -> None:
+    assert is_protected_generation_member(path)
+    assert not is_hosted_snapshot_content_member(path)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        ".decision-hashes.json",
+        "snapshots/v001.json",
+        "journal/events.jsonl",
+        "reports/report.md",
+        "decisions/nested/001-bad.md",
+        "unknown.md",
+    ],
+)
+def test_unknown_paths_fail_closed(path: str) -> None:
+    assert not is_protected_generation_member(path)
+    with pytest.raises(UnknownGenerationPath):
+        validate_protected_generation_path(path)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/project.md",
+        "context//brief.md",
+        "context/../brief.md",
+        "context/./brief.md",
+        "context\\brief.md",
+    ],
+)
+def test_noncanonical_paths_reject_before_classification(path: str) -> None:
+    with pytest.raises(NoncanonicalGenerationPath):
+        validate_protected_generation_path(path)

--- a/packages/nauro-core/tests/test_provenance.py
+++ b/packages/nauro-core/tests/test_provenance.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import pytest
+
+from nauro_core.provenance import (
+    InvalidCommitSha,
+    InvalidUtcTimestamp,
+    validate_commit_sha,
+    validate_utc_timestamp,
+)
+
+
+@pytest.mark.parametrize("value", ["a" * 40, "b" * 64])
+def test_validate_commit_sha_accepts_lowercase_full_hashes(value: str) -> None:
+    assert validate_commit_sha(value, field="proposed_base_commit") == value
+
+
+@pytest.mark.parametrize("value", ["A" * 40, "a" * 39, "g" * 40, "a" * 41])
+def test_validate_commit_sha_rejects_noncanonical_hashes(value: str) -> None:
+    with pytest.raises(InvalidCommitSha):
+        validate_commit_sha(value, field="proposed_base_commit")
+
+
+def test_validate_utc_timestamp_accepts_pinned_microsecond_form() -> None:
+    value = "2026-08-14T09:10:11.123456Z"
+    assert validate_utc_timestamp(value, field="approved_at") == value
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "2026-08-14T09:10:11Z",
+        "2026-08-14T09:10:11.123456+00:00",
+        "2026-02-30T09:10:11.123456Z",
+        "2026-08-14t09:10:11.123456Z",
+    ],
+)
+def test_validate_utc_timestamp_rejects_noncanonical_values(value: str) -> None:
+    with pytest.raises(InvalidUtcTimestamp):
+        validate_utc_timestamp(value, field="approved_at")

--- a/packages/nauro/src/nauro/store/repo_head.py
+++ b/packages/nauro/src/nauro/store/repo_head.py
@@ -11,13 +11,11 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
+from nauro_core.provenance import InvalidCommitSha, validate_commit_sha
+
 # Bounds the capture cost on every decision write; a repository that cannot
 # answer rev-parse within this window resolves to absence.
 _GIT_TIMEOUT_SECONDS = 2
-
-# Full object names only: 40 hex chars (SHA-1) or 64 (SHA-256 repositories).
-_SHA_LENGTHS = frozenset({40, 64})
-_HEX_DIGITS = frozenset("0123456789abcdef")
 
 
 def resolve_repo_head(cwd: str | Path | None) -> str | None:
@@ -44,9 +42,10 @@ def resolve_repo_head(cwd: str | Path | None) -> str | None:
     if completed.returncode != 0:
         return None
     sha = completed.stdout.strip()
-    if len(sha) not in _SHA_LENGTHS or not set(sha) <= _HEX_DIGITS:
+    try:
+        return validate_commit_sha(sha, field="HEAD")
+    except InvalidCommitSha:
         return None
-    return sha
 
 
 def resolve_process_repo_head() -> str | None:


### PR DESCRIPTION
## Why

Hosted judgment publication needs one deterministic core contract before a server saga can execute approved work. The existing core owns local sequential writes but does not freeze approved bytes, whole-generation inputs, claim semantics, provenance, generated artifacts, snapshots, and result behavior as one recoverable plan.

## What changed

Added a pure two-phase judgment-commit planner. Preparation validates canonical approved bytes, the observed generation and monotonic counter, proposal semantics, provenance, complete artifacts, snapshots, and exact claim probes. Finalization validates closed storage-neutral claim observations and derives publication intents plus a bounded plan record.

Canonical JSON and schema failures remain `CanonicalPayloadRejected`. Semantic proposal failures return `ProposalRejected` with the exact existing `ProposeDecisionResult` Tier 0 or Tier 1 semantics. Prepared and finalized results materialize from an immutable internal projection, so nested result sequences cannot diverge from artifacts, plan-record bytes, or its digest.

Team preparation rejects a contributor submission operation ID that equals the web ratification action ID. The implemented transformation version is closed to version 1. Canonical payloads with an unpaired Unicode surrogate fail with the typed canonical-payload error.

Added modeled current-version approval provenance with shared ULID, UTC timestamp, and commit validators. Serialization omits only the five new provenance fields when absent and keeps legacy decision bytes stable.

Added protected-generation and hosted-snapshot membership rules, including the question-provenance sidecar and private context artifacts. Unknown and noncanonical paths fail closed.

Extracted pure proposal evaluation and decision transitions from the local write path. Local calls retain their existing number source, clock reads, write order, hash-index behavior, half-state results, and response model. A local update clears stale team approval provenance from the new current version while preserving unrelated legacy extras.

## Test plan

- Judgment-commit planner: 31 passed
- Full `nauro-core`: 1,602 passed
- Relevant local `nauro`: 63 passed, 1 skipped
- Public-contract snapshot: 1 passed
- Ruff check and format passed
- Import contracts: 2 kept
- Single-source and server-version consistency checks passed
- Focused configured mypy check passed
- Broad mypy matched the existing baseline, with no new errors
- `git diff --check` passed
- Built the nauro-core and nauro wheels with locked build tooling

## Risk / what to review

Review the trust split between approved payload bytes and server attestations, whole-generation counter invariants, distinct team action identities, same-title ownership transfer, selective provenance replacement and clearing, snapshot membership, and plan-record derivation. The new hosted planner has no production consumer in this change.

## Deferred

Server saga storage, leases, fencing, recovery, publication composition, routes, migration activation, invitations, and team-mode enablement remain deferred.
