### PR TITLE
Add approval provenance and generation membership

### DIFF
--- a/packages/nauro-core/src/nauro_core/decision_model.py
+++ b/packages/nauro-core/src/nauro_core/decision_model.py
@@ -42,7 +42,8 @@ Field model:
     Required frontmatter: date, confidence.
     Defaulted frontmatter: version (1), status (active).
     Optional frontmatter: decision_type, reversibility, source, files_affected,
-                          supersedes, superseded_by.
+                          supersedes, superseded_by, and the selectively omitted
+                          approval-provenance group.
     Body-rendered: rejected (rendered as `## Rejected Alternatives` + `### name`
                    subsections, not in frontmatter).
     Derived (set by parse_decision): num, title, rationale, body, content.
@@ -57,7 +58,9 @@ from enum import Enum
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from nauro_core.identifiers import IdentifierKind, validate_identifier
 from nauro_core.parsing import extract_decision_number, is_ascii_decimal
+from nauro_core.provenance import validate_commit_sha, validate_utc_timestamp
 
 # ── Enums (values match on-disk lowercase tokens verbatim) ──
 
@@ -154,6 +157,13 @@ class Decision(BaseModel):
     supersedes: str | None = None
     superseded_by: str | None = None
 
+    # ── Frontmatter: current-version approval provenance ──
+    proposed_by: str | None = None
+    approved_by: str | None = None
+    approved_at: str | None = None
+    proposal_id: str | None = None
+    proposed_base_commit: str | None = None
+
     # ── Body-rendered ──
     rejected: list[RejectedAlternative] = Field(default_factory=list)
 
@@ -183,6 +193,49 @@ class Decision(BaseModel):
                 f"supersession ref must not have leading zeros, got {v!r}; expected {canonical!r}"
             )
         return v
+
+    @field_validator("proposed_by", "approved_by", "proposal_id")
+    @classmethod
+    def _validate_provenance_identifier(cls, v: str | None, info) -> str | None:
+        if v is None:
+            return None
+        return validate_identifier(IdentifierKind.ulid, v, field=info.field_name)
+
+    @field_validator("approved_at")
+    @classmethod
+    def _validate_approved_at(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        return validate_utc_timestamp(v, field="approved_at")
+
+    @field_validator("proposed_base_commit")
+    @classmethod
+    def _validate_proposed_base_commit(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        return validate_commit_sha(v, field="proposed_base_commit")
+
+    @model_validator(mode="after")
+    def require_complete_approval_provenance(self) -> Decision:
+        values = (
+            self.proposed_by,
+            self.approved_by,
+            self.approved_at,
+            self.proposal_id,
+            self.proposed_base_commit,
+        )
+        if not any(value is not None for value in values):
+            return self
+        missing = [
+            field
+            for field in ("proposed_by", "approved_by", "approved_at", "proposal_id")
+            if getattr(self, field) is None
+        ]
+        if missing:
+            raise ValueError(
+                "partial approval provenance is invalid; missing " + ", ".join(missing) + "."
+            )
+        return self
 
     @model_validator(mode="after")
     def require_reasons_on_active(self) -> Decision:
@@ -228,6 +281,19 @@ _FRONTMATTER_ORDER: tuple[str, ...] = (
     "files_affected",
     "supersedes",
     "superseded_by",
+    "proposed_by",
+    "approved_by",
+    "approved_at",
+    "proposal_id",
+    "proposed_base_commit",
+)
+
+_PROVENANCE_FIELDS: tuple[str, ...] = (
+    "proposed_by",
+    "approved_by",
+    "approved_at",
+    "proposal_id",
+    "proposed_base_commit",
 )
 
 
@@ -469,6 +535,10 @@ def format_decision(decision: Decision) -> str:
     already-canonical file. See the module docstring for the full bound.
     """
     dumped = decision.model_dump(mode="json", exclude=_DERIVED_FIELDS)
+
+    for key in _PROVENANCE_FIELDS:
+        if dumped.get(key) is None:
+            dumped.pop(key, None)
 
     # Rejected is body-rendered, not frontmatter.
     dumped.pop("rejected", None)

--- a/packages/nauro-core/src/nauro_core/operations/_decision_transitions.py
+++ b/packages/nauro-core/src/nauro_core/operations/_decision_transitions.py
@@ -2,14 +2,38 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import date
 
-from nauro_core.decision_model import Decision, DecisionStatus
+from nauro_core.decision_model import (
+    Decision,
+    DecisionConfidence,
+    DecisionSource,
+    DecisionStatus,
+    DecisionType,
+    RejectedAlternative,
+    Reversibility,
+)
 from nauro_core.questions import OpenQuestionsFile
 
 _SLUG_MAX_LENGTH = 60
+_PROVENANCE_FIELDS = (
+    "proposed_by",
+    "approved_by",
+    "approved_at",
+    "proposal_id",
+    "proposed_base_commit",
+)
+
+
+@dataclass(frozen=True)
+class DecisionProvenance:
+    proposed_by: str
+    approved_by: str
+    approved_at: str
+    proposal_id: str
+    proposed_base_commit: str | None = None
 
 
 @dataclass(frozen=True)
@@ -37,6 +61,82 @@ def slugify_decision_title(title: str) -> str:
         trimmed = truncated.rsplit("-", 1)[0]
         slug = trimmed if len(trimmed) >= _SLUG_MAX_LENGTH // 2 else truncated
     return slug
+
+
+def build_new_decision(
+    *,
+    number: int,
+    decision_date: date,
+    title: str,
+    rationale: str,
+    confidence: DecisionConfidence,
+    decision_type: DecisionType | None,
+    reversibility: Reversibility | None,
+    source: DecisionSource | None,
+    files_affected: Sequence[str],
+    rejected: Sequence[RejectedAlternative],
+    provenance: DecisionProvenance | None,
+    extra_frontmatter: Mapping[str, object] | None = None,
+) -> Decision:
+    """Build a new current decision from explicit frozen inputs."""
+    fields: dict[str, object] = dict(extra_frontmatter or {})
+    if provenance is not None:
+        fields.update(
+            proposed_by=provenance.proposed_by,
+            approved_by=provenance.approved_by,
+            approved_at=provenance.approved_at,
+            proposal_id=provenance.proposal_id,
+            proposed_base_commit=provenance.proposed_base_commit,
+        )
+    return Decision(
+        date=decision_date,
+        version=1,
+        status=DecisionStatus.active,
+        confidence=confidence,
+        decision_type=decision_type,
+        reversibility=reversibility,
+        source=source,
+        files_affected=list(files_affected),
+        rejected=list(rejected),
+        num=number,
+        title=title,
+        rationale=rationale,
+        **fields,
+    )
+
+
+def apply_current_version_provenance(
+    decision: Decision,
+    provenance: DecisionProvenance | None,
+) -> Decision:
+    """Apply one complete approval group, or clear a group for a new local version."""
+    update = {field: None for field in _PROVENANCE_FIELDS}
+    if provenance is not None:
+        update.update(
+            proposed_by=provenance.proposed_by,
+            approved_by=provenance.approved_by,
+            approved_at=provenance.approved_at,
+            proposal_id=provenance.proposal_id,
+            proposed_base_commit=provenance.proposed_base_commit,
+        )
+    return decision.model_copy(update=update)
+
+
+def append_decision_update(
+    decision: Decision,
+    *,
+    additional_rationale: str,
+    update_date: date,
+    provenance: DecisionProvenance | None,
+) -> Decision:
+    """Append one dated rationale version and replace current-version provenance."""
+    version = decision.version + 1
+    rationale = (
+        f"{decision.rationale.strip()}\n\n"
+        f"*Update (v{version}) — {update_date.isoformat()}:* {additional_rationale.strip()}"
+    )
+    updated = decision.model_copy(update={"version": version, "rationale": rationale})
+    return apply_current_version_provenance(updated, provenance)
 
 
 def attach_supersedes(decision: Decision, target_number: int) -> Decision:

--- a/packages/nauro-core/src/nauro_core/operations/_decision_transitions.py
+++ b/packages/nauro-core/src/nauro_core/operations/_decision_transitions.py
@@ -1,0 +1,75 @@
+"""Pure decision and question transitions shared by local and hosted planning."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import date
+
+from nauro_core.decision_model import Decision, DecisionStatus
+from nauro_core.questions import OpenQuestionsFile
+
+_SLUG_MAX_LENGTH = 60
+
+
+@dataclass(frozen=True)
+class QuestionResolveTransition:
+    content: str
+    resolved_ids: tuple[str, ...] = ()
+    relocated_ids: tuple[str, ...] = ()
+    skipped_prose_ids: tuple[str, ...] = ()
+
+
+def slugify_decision_title(title: str) -> str:
+    """Return the existing canonical decision filename slug."""
+    out_chars: list[str] = []
+    prev_dash = False
+    for char in title.lower():
+        if char.isalnum():
+            out_chars.append(char)
+            prev_dash = False
+        elif not prev_dash:
+            out_chars.append("-")
+            prev_dash = True
+    slug = "".join(out_chars).strip("-")
+    if len(slug) > _SLUG_MAX_LENGTH:
+        truncated = slug[:_SLUG_MAX_LENGTH]
+        trimmed = truncated.rsplit("-", 1)[0]
+        slug = trimmed if len(trimmed) >= _SLUG_MAX_LENGTH // 2 else truncated
+    return slug
+
+
+def attach_supersedes(decision: Decision, target_number: int) -> Decision:
+    """Attach the derived backlink to the newly replacing decision."""
+    return decision.model_copy(update={"supersedes": str(target_number)})
+
+
+def mark_superseded(decision: Decision, replacement_number: int) -> Decision:
+    """Flip a target while preserving every field of its last current version."""
+    return decision.model_copy(
+        update={
+            "status": DecisionStatus.superseded,
+            "superseded_by": str(replacement_number),
+        }
+    )
+
+
+def resolve_questions_content(
+    content: str,
+    *,
+    question_ids: Sequence[str],
+    decision_number: int,
+    resolved_date: date,
+) -> QuestionResolveTransition:
+    """Resolve and normalize questions from explicit content and date inputs."""
+    if not question_ids:
+        return QuestionResolveTransition(content=content)
+    questions = OpenQuestionsFile.parse(content)
+    resolved = questions.resolve(list(question_ids), decision_number, resolved_date)
+    normalized = resolved.file.normalize()
+    return QuestionResolveTransition(
+        content=normalized.file.format(),
+        resolved_ids=resolved.moved_ids,
+        relocated_ids=normalized.relocated_ids,
+        skipped_prose_ids=normalized.skipped_prose_ids,
+    )

--- a/packages/nauro-core/src/nauro_core/operations/_proposal_evaluation.py
+++ b/packages/nauro-core/src/nauro_core/operations/_proposal_evaluation.py
@@ -1,0 +1,212 @@
+"""Pure proposal validation and similarity evaluation over parsed inputs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from nauro_core.constants import MIN_RATIONALE_LENGTH
+from nauro_core.decision_model import Decision, DecisionStatus
+from nauro_core.operations.related_hits import to_related_decisions
+from nauro_core.operations.results import ProposeDecisionResult, RelatedDecision
+from nauro_core.questions import EntryBlock, OpenQuestionsFile
+from nauro_core.validation import check_bm25_similarity, screen_structural
+
+_UPDATE_DISALLOWED_FIELDS: tuple[str, ...] = (
+    "title",
+    "rejected",
+    "files_affected",
+    "decision_type",
+    "reversibility",
+    "confidence",
+)
+
+
+@dataclass(frozen=True)
+class ProposalEvaluation:
+    similar_decisions: tuple[RelatedDecision, ...]
+    assessment: str
+
+
+def validate_proposal_request(
+    proposal: dict,
+    *,
+    operation: Literal["add", "update", "supersede"],
+    questions_file: OpenQuestionsFile | None,
+) -> ProposeDecisionResult | None:
+    """Validate request fields that do not require the decision corpus."""
+    metadata_rejection = validate_update_metadata(proposal, operation=operation)
+    if metadata_rejection is not None:
+        return metadata_rejection
+    question_rejection = validate_question_resolves(
+        proposal,
+        operation=operation,
+        questions_file=questions_file,
+    )
+    if question_rejection is not None:
+        return question_rejection
+    return validate_update_rationale(proposal, operation=operation)
+
+
+def validate_update_metadata(
+    proposal: dict,
+    *,
+    operation: Literal["add", "update", "supersede"],
+) -> ProposeDecisionResult | None:
+    """Reject metadata that rationale-only update cannot consume."""
+    if operation == "update":
+        disallowed = [
+            name
+            for name in _UPDATE_DISALLOWED_FIELDS
+            if proposal.get(name)
+            and (not isinstance(proposal.get(name), str) or proposal.get(name).strip())
+        ]
+        if disallowed:
+            return ProposeDecisionResult(
+                status="rejected",
+                tier=0,
+                operation="update",
+                assessment=(
+                    'operation="update" appends rationale only; cannot change '
+                    f"{', '.join(disallowed)}. "
+                    'Use operation="supersede" to replace the decision with new metadata.'
+                ),
+            )
+    return None
+
+
+def validate_question_resolves(
+    proposal: dict,
+    *,
+    operation: Literal["add", "update", "supersede"],
+    questions_file: OpenQuestionsFile | None,
+) -> ProposeDecisionResult | None:
+    """Validate question identifiers against one parsed questions file."""
+    requested = list(proposal.get("resolves_questions") or [])
+    if requested:
+        unknown = _unknown_question_ids(requested, questions_file)
+        if unknown:
+            return ProposeDecisionResult(
+                status="rejected",
+                tier=0,
+                operation=operation,
+                assessment=(
+                    "resolves_questions contains unknown id(s): "
+                    + ", ".join(repr(value) for value in unknown)
+                    + ". Call get_context (L0 lists every open question) to "
+                    "see the canonical ids in open-questions.md."
+                ),
+            )
+        ambiguous = _ambiguous_question_ids(requested, questions_file)
+        if ambiguous:
+            offenders = "; ".join(
+                f"{requested_id!r} matches {len(counterparts)} entries — disambiguate "
+                f"to one of: {', '.join(counterparts)}"
+                for requested_id, counterparts in ambiguous.items()
+            )
+            return ProposeDecisionResult(
+                status="rejected",
+                tier=0,
+                operation=operation,
+                assessment="resolves_questions contains ambiguous id(s): " + offenders + ".",
+            )
+    return None
+
+
+def validate_update_rationale(
+    proposal: dict,
+    *,
+    operation: Literal["add", "update", "supersede"],
+) -> ProposeDecisionResult | None:
+    """Apply the update-specific Tier 1 rationale check without corpus reads."""
+    if operation != "update":
+        return None
+    rationale = (proposal.get("rationale") or "").strip()
+    if not rationale:
+        reason = "Rationale is empty."
+    elif len(rationale) < MIN_RATIONALE_LENGTH:
+        reason = f"Rationale too short ({len(rationale)} chars). Minimum {MIN_RATIONALE_LENGTH}."
+    else:
+        return None
+    return ProposeDecisionResult(
+        status="rejected",
+        tier=1,
+        operation="reject",
+        assessment=reason,
+    )
+
+
+def evaluate_parsed_proposal(
+    proposal: dict,
+    *,
+    operation: Literal["add", "update", "supersede"],
+    decisions: list[Decision],
+    existing_hashes: set[str],
+    affected_number: int | None,
+    enforce_claim_conflicts: bool,
+) -> ProposalEvaluation | ProposeDecisionResult:
+    """Evaluate structure and similarity over one immutable parsed corpus."""
+    if operation != "update":
+        active = (
+            [
+                decision
+                for decision in decisions
+                if decision.status is DecisionStatus.active and decision.num != affected_number
+            ]
+            if enforce_claim_conflicts
+            else []
+        )
+        action, reason = screen_structural(
+            proposal,
+            existing_hashes if enforce_claim_conflicts else set(),
+            active,
+        )
+        if action == "reject":
+            return ProposeDecisionResult(
+                status="rejected",
+                tier=1,
+                operation="reject",
+                assessment=reason or "Structural validation failed.",
+            )
+
+    _action, similar_raw = check_bm25_similarity(proposal, decisions)
+    similar = tuple(to_related_decisions(similar_raw, decisions))
+    assessment = (
+        "Tier 2 surfaced similar decisions; review them and confirm with the "
+        "user before proposing further related writes."
+        if similar
+        else "No similar existing decisions found."
+    )
+    return ProposalEvaluation(similar_decisions=similar, assessment=assessment)
+
+
+def _unknown_question_ids(
+    ids: list[str],
+    questions_file: OpenQuestionsFile | None,
+) -> list[str]:
+    if questions_file is None:
+        return list(ids)
+    known = questions_file.known_question_ids
+    return [value for value in ids if value not in known]
+
+
+def _ambiguous_question_ids(
+    ids: list[str],
+    questions_file: OpenQuestionsFile | None,
+) -> dict[str, list[str]]:
+    if questions_file is None:
+        return {}
+    collisions = questions_file.ambiguous_ids
+    requested = [value for value in ids if value in collisions]
+    if not requested:
+        return {}
+    counterparts: dict[str, list[str]] = {value: [] for value in requested}
+    for block in questions_file.blocks:
+        if not isinstance(block, EntryBlock):
+            continue
+        entry_id = block.entry.id
+        if entry_id in counterparts:
+            counterparts[entry_id].append(
+                f"Q{block.entry.num}" if block.entry.num is not None else "<no-Q-id>"
+            )
+    return counterparts

--- a/packages/nauro-core/src/nauro_core/operations/propose_decision.py
+++ b/packages/nauro-core/src/nauro_core/operations/propose_decision.py
@@ -38,10 +38,8 @@ from nauro_core.constants import (
     OPEN_QUESTIONS_MD,
 )
 from nauro_core.decision_model import (
-    Decision,
     DecisionConfidence,
     DecisionSource,
-    DecisionStatus,
     DecisionType,
     RejectedAlternative,
     Reversibility,
@@ -49,7 +47,9 @@ from nauro_core.decision_model import (
     parse_decision,
 )
 from nauro_core.operations._decision_transitions import (
+    append_decision_update,
     attach_supersedes,
+    build_new_decision,
     mark_superseded,
     resolve_questions_content,
     slugify_decision_title,
@@ -221,10 +221,11 @@ def _write_decision_direct(store: Store, proposal: dict) -> str:
     if base_commit:
         provenance_kwargs["base_commit"] = base_commit
 
-    decision = Decision(
-        date=datetime.now(timezone.utc).date(),
-        version=1,
-        status=DecisionStatus.active,
+    decision = build_new_decision(
+        number=next_num,
+        decision_date=datetime.now(timezone.utc).date(),
+        title=title,
+        rationale=rationale,
         confidence=DecisionConfidence(
             proposal.get("confidence") or DecisionConfidence.medium.value
         ),
@@ -233,10 +234,8 @@ def _write_decision_direct(store: Store, proposal: dict) -> str:
         source=_optional_enum(proposal.get("source"), DecisionSource),
         files_affected=_coerce_files_affected(proposal.get("files_affected")),
         rejected=_coerce_rejected(proposal.get("rejected")),
-        num=next_num,
-        title=title,
-        rationale=rationale,
-        **provenance_kwargs,
+        provenance=None,
+        extra_frontmatter=provenance_kwargs,
     )
     store.write_file(_decision_path(filename), format_decision(decision))
 
@@ -441,17 +440,11 @@ def _do_update(
             ),
         )
     target = parse_decision(body, _decision_filename(target_stem))
-    date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-    additional = (proposal.get("rationale") or "").strip()
-    appended_rationale = (
-        f"{target.rationale.strip()}\n\n"
-        f"*Update (v{target.version + 1}) — {date_str}:* {additional}"
-    )
-    updated = target.model_copy(
-        update={
-            "version": target.version + 1,
-            "rationale": appended_rationale,
-        }
+    updated = append_decision_update(
+        target,
+        additional_rationale=proposal.get("rationale") or "",
+        update_date=datetime.now(timezone.utc).date(),
+        provenance=None,
     )
     store.write_file(_decision_path(target_stem), format_decision(updated))
 

--- a/packages/nauro-core/src/nauro_core/operations/propose_decision.py
+++ b/packages/nauro-core/src/nauro_core/operations/propose_decision.py
@@ -35,7 +35,6 @@ from typing import Literal
 
 from nauro_core.constants import (
     DECISION_HASHES_FILE,
-    MIN_RATIONALE_LENGTH,
     OPEN_QUESTIONS_MD,
 )
 from nauro_core.decision_model import (
@@ -49,12 +48,23 @@ from nauro_core.decision_model import (
     format_decision,
     parse_decision,
 )
+from nauro_core.operations._decision_transitions import (
+    attach_supersedes,
+    mark_superseded,
+    resolve_questions_content,
+    slugify_decision_title,
+)
+from nauro_core.operations._proposal_evaluation import (
+    evaluate_parsed_proposal,
+    validate_question_resolves,
+    validate_update_metadata,
+    validate_update_rationale,
+)
 from nauro_core.operations.decision_lookup import (
     find_decision_stem_by_id,
     find_decision_stem_by_num,
     parse_all_decisions,
 )
-from nauro_core.operations.related_hits import to_related_decisions
 from nauro_core.operations.results import (
     ErrorPayload,
     ProposeDecisionResult,
@@ -66,29 +76,11 @@ from nauro_core.parsing import (
     _decision_path,
     extract_decision_number,
 )
-from nauro_core.questions import EntryBlock, OpenQuestionsFile
+from nauro_core.questions import OpenQuestionsFile
 from nauro_core.validation import (
-    check_bm25_similarity,
     compute_hash,
     rejected_item_label,
-    screen_structural,
 )
-
-# operation="update" appends rationale only — update_decision reads only
-# affected_decision_id + rationale. Any value in these fields would be
-# silently dropped on local stdio (and rejected on remote MCP); reject
-# loudly at the boundary so the wording in PROPOSE_DECISION_OPERATIONS holds
-# on both transports.
-_UPDATE_DISALLOWED_FIELDS: tuple[str, ...] = (
-    "title",
-    "rejected",
-    "files_affected",
-    "decision_type",
-    "reversibility",
-    "confidence",
-)
-
-_SLUG_MAX_LENGTH = 60
 
 
 @dataclass(frozen=True)
@@ -146,93 +138,37 @@ def propose_decision(
         "base_commit": base_commit,
     }
 
-    # --- operation="update": reject metadata fields up front ---
-    if operation == "update":
-        disallowed = [
-            name
-            for name in _UPDATE_DISALLOWED_FIELDS
-            if proposal.get(name)
-            and (not isinstance(proposal.get(name), str) or proposal.get(name).strip())
-        ]
-        if disallowed:
-            return ProposeDecisionResult(
-                status="rejected",
-                tier=0,
-                operation="update",
-                assessment=(
-                    'operation="update" appends rationale only; cannot change '
-                    f"{', '.join(disallowed)}. "
-                    'Use operation="supersede" to replace the decision with new metadata.'
-                ),
-            )
-
-    # --- resolves_questions: unknown / ambiguous ids reject at boundary ---
     requested_resolves = list(proposal.get("resolves_questions") or [])
-    if requested_resolves:
-        questions_file = _load_questions_file(store)
-        unknown = _unknown_question_ids(requested_resolves, questions_file)
-        if unknown:
-            return ProposeDecisionResult(
-                status="rejected",
-                tier=0,
-                operation=operation,
-                assessment=(
-                    "resolves_questions contains unknown id(s): "
-                    + ", ".join(repr(x) for x in unknown)
-                    + ". Call get_context (L0 lists every open question) to "
-                    "see the canonical ids in open-questions.md."
-                ),
-            )
-        ambiguous = _ambiguous_question_ids(requested_resolves, questions_file)
-        if ambiguous:
-            offenders = "; ".join(
-                f"{requested!r} matches {len(counterparts)} entries — disambiguate "
-                f"to one of: {', '.join(counterparts)}"
-                for requested, counterparts in ambiguous.items()
-            )
-            return ProposeDecisionResult(
-                status="rejected",
-                tier=0,
-                operation=operation,
-                assessment="resolves_questions contains ambiguous id(s): " + offenders + ".",
-            )
+    request_rejection = validate_update_metadata(proposal, operation=operation)
+    if request_rejection is not None:
+        return request_rejection
+    request_rejection = validate_question_resolves(
+        proposal,
+        operation=operation,
+        questions_file=_load_questions_file(store) if requested_resolves else None,
+    )
+    if request_rejection is not None:
+        return request_rejection
+    request_rejection = validate_update_rationale(proposal, operation=operation)
+    if request_rejection is not None:
+        return request_rejection
 
-    # --- Tier 1: structural screening ---
-    # ``parsed`` is the single corpus scan shared between Tier 1 active-title
-    # dedup and Tier 2 BM25. It stays None on the update early-reject path so a
-    # short-rationale update rejects without scanning the corpus at all.
-    parsed: list[Decision] | None = None
-    if operation == "update":
-        rationale_stripped = (proposal.get("rationale") or "").strip()
-        if not rationale_stripped:
-            action, reason = "reject", "Rationale is empty."
-        elif len(rationale_stripped) < MIN_RATIONALE_LENGTH:
-            action, reason = (
-                "reject",
-                f"Rationale too short ({len(rationale_stripped)} chars). "
-                f"Minimum {MIN_RATIONALE_LENGTH}.",
-            )
-        else:
-            action, reason = "pass", None
-    else:
-        parsed = parse_all_decisions(store)
-        action, reason = _screen_structural(store, proposal, parsed, affected_decision_id)
+    parsed = parse_all_decisions(store)
+    evaluation = evaluate_parsed_proposal(
+        proposal,
+        operation=operation,
+        decisions=parsed,
+        existing_hashes=set(_load_hash_index(store)) if operation != "update" else set(),
+        affected_number=(
+            extract_decision_number(affected_decision_id) if affected_decision_id else None
+        ),
+        enforce_claim_conflicts=True,
+    )
+    if isinstance(evaluation, ProposeDecisionResult):
+        return evaluation
 
-    if action == "reject":
-        return ProposeDecisionResult(
-            status="rejected",
-            tier=1,
-            operation="reject",
-            assessment=reason or "Structural validation failed.",
-        )
+    similar_models = list(evaluation.similar_decisions)
 
-    # --- Tier 2: BM25 similarity (advisory only — does not gate the write) ---
-    if parsed is None:
-        parsed = parse_all_decisions(store)
-    _t2_action, similar_raw = check_bm25_similarity(proposal, parsed)
-    similar_models = to_related_decisions(similar_raw, parsed)
-
-    # --- Commit ---
     decision_id, actual_operation, touched, resolve_outcome, error = _execute_operation(
         store, operation, proposal, affected_decision_id
     )
@@ -247,19 +183,11 @@ def propose_decision(
             similar_decisions=similar_models,
         )
 
-    if similar_models:
-        assessment = (
-            "Tier 2 surfaced similar decisions; review them and confirm with the "
-            "user before proposing further related writes."
-        )
-    else:
-        assessment = "No similar existing decisions found."
-
     return ProposeDecisionResult(
         status="confirmed",
         tier=2,
         operation=actual_operation,
-        assessment=assessment,
+        assessment=evaluation.assessment,
         similar_decisions=similar_models,
         decision_id=decision_id,
         touched_decisions=list(touched),
@@ -279,7 +207,7 @@ def _write_decision_direct(store: Store, proposal: dict) -> str:
     """
     next_num = _next_decision_num(store)
     title = proposal.get("title", "Untitled")
-    slug = _slugify(title)
+    slug = slugify_decision_title(title)
     filename = f"{_decision_number_prefix(next_num)}{slug}"
     rationale = proposal.get("rationale") or title
 
@@ -314,37 +242,6 @@ def _write_decision_direct(store: Store, proposal: dict) -> str:
 
     _update_hash_index(store, title, rationale, filename)
     return filename
-
-
-# ── Tier 1 helpers ────────────────────────────────────────────────────────
-
-
-def _screen_structural(
-    store: Store,
-    proposal: dict,
-    parsed: list[Decision],
-    affected_decision_id: str | None,
-) -> tuple[str, str | None]:
-    """Run Tier 1 structural screening with hashes + active-title dedup.
-
-    Title dedup keys on active status, not recency: an add or supersede whose
-    normalized title matches any active decision is rejected regardless of the
-    matched decision's age. ``parsed`` is the shared corpus scan reused for
-    Tier 2 BM25, so this does not re-read the store.
-
-    The supersede target is excluded from the dedup set. Screening runs before
-    the supersede flip, so the target is still active at this point; without
-    the exclusion a same-title supersede of an established decision would
-    self-reject. A supersede whose new title collides with a *different* active
-    decision still rejects.
-    """
-    hash_index = _load_hash_index(store)
-    existing_hashes = set(hash_index.keys())
-    affected_num = extract_decision_number(affected_decision_id) if affected_decision_id else None
-    dedup_decisions = [
-        d for d in parsed if d.status is DecisionStatus.active and d.num != affected_num
-    ]
-    return screen_structural(proposal, existing_hashes, dedup_decisions)
 
 
 def _load_hash_index(store: Store) -> dict:
@@ -440,7 +337,7 @@ def _do_supersede(
             ),
         )
     new_decision = parse_decision(new_body, _decision_filename(new_decision_id))
-    new_decision_rewritten = new_decision.model_copy(update={"supersedes": str(old_num)})
+    new_decision_rewritten = attach_supersedes(new_decision, old_num)
     store.write_file(
         _decision_path(new_decision_id),
         format_decision(new_decision_rewritten),
@@ -481,12 +378,7 @@ def _do_supersede(
         )
     try:
         old_decision = parse_decision(old_body, _decision_filename(old_stem))
-        old_rewritten = old_decision.model_copy(
-            update={
-                "status": DecisionStatus.superseded,
-                "superseded_by": str(new_num),
-            }
-        )
+        old_rewritten = mark_superseded(old_decision, new_num)
         store.write_file(
             _decision_path(old_stem),
             format_decision(old_rewritten),
@@ -595,10 +487,13 @@ def _apply_question_resolves(
         return _QuestionResolveOutcome(), None
     try:
         content = store.read_file(OPEN_QUESTIONS_MD) or ""
-        questions_file = OpenQuestionsFile.parse(content)
-        result = questions_file.resolve(ids, num, datetime.now(timezone.utc).date())
-        normalized = result.file.normalize()
-        store.write_file(OPEN_QUESTIONS_MD, normalized.file.format())
+        transition = resolve_questions_content(
+            content,
+            question_ids=ids,
+            decision_number=num,
+            resolved_date=datetime.now(timezone.utc).date(),
+        )
+        store.write_file(OPEN_QUESTIONS_MD, transition.content)
     except Exception as exc:
         return _QuestionResolveOutcome(), ErrorPayload(
             kind="error",
@@ -609,15 +504,12 @@ def _apply_question_resolves(
         )
     return (
         _QuestionResolveOutcome(
-            resolved_ids=result.moved_ids,
-            relocated_ids=normalized.relocated_ids,
-            skipped_prose_ids=normalized.skipped_prose_ids,
+            resolved_ids=transition.resolved_ids,
+            relocated_ids=transition.relocated_ids,
+            skipped_prose_ids=transition.skipped_prose_ids,
         ),
         None,
     )
-
-
-# ── Question-id boundary helpers ──────────────────────────────────────────
 
 
 def _load_questions_file(store: Store) -> OpenQuestionsFile | None:
@@ -625,38 +517,6 @@ def _load_questions_file(store: Store) -> OpenQuestionsFile | None:
     if content is None:
         return None
     return OpenQuestionsFile.parse(content)
-
-
-def _unknown_question_ids(
-    ids: list[str],
-    questions_file: OpenQuestionsFile | None,
-) -> list[str]:
-    if questions_file is None:
-        return list(ids)
-    known = questions_file.known_question_ids
-    return [tid for tid in ids if tid not in known]
-
-
-def _ambiguous_question_ids(
-    ids: list[str],
-    questions_file: OpenQuestionsFile | None,
-) -> dict[str, list[str]]:
-    if questions_file is None:
-        return {}
-    collisions = questions_file.ambiguous_ids
-    requested_ambiguous = [tid for tid in ids if tid in collisions]
-    if not requested_ambiguous:
-        return {}
-
-    counterparts: dict[str, list[str]] = {tid: [] for tid in requested_ambiguous}
-    for block in questions_file.blocks:
-        if not isinstance(block, EntryBlock):
-            continue
-        eid = block.entry.id
-        if eid in counterparts:
-            slot = f"Q{block.entry.num}" if block.entry.num is not None else "<no-Q-id>"
-            counterparts[eid].append(slot)
-    return counterparts
 
 
 # ── Decision write plumbing ───────────────────────────────────────────────
@@ -670,27 +530,6 @@ def _next_decision_num(store: Store) -> int:
         if n is not None:
             nums.append(n)
     return max(nums, default=0) + 1
-
-
-def _slugify(title: str) -> str:
-    out_chars: list[str] = []
-    prev_dash = False
-    for ch in title.lower():
-        if ch.isalnum():
-            out_chars.append(ch)
-            prev_dash = False
-        elif not prev_dash:
-            out_chars.append("-")
-            prev_dash = True
-    slug = "".join(out_chars).strip("-")
-    if len(slug) > _SLUG_MAX_LENGTH:
-        truncated = slug[:_SLUG_MAX_LENGTH]
-        # Prefer cutting at a word boundary, but only while that keeps at
-        # least half the cap: a title whose only dash sits early would
-        # otherwise collapse to a near-empty slug (and filename).
-        trimmed = truncated.rsplit("-", 1)[0]
-        slug = trimmed if len(trimmed) >= _SLUG_MAX_LENGTH // 2 else truncated
-    return slug
 
 
 def _optional_enum(raw, enum_cls):

--- a/packages/nauro-core/src/nauro_core/protected_generation_membership.py
+++ b/packages/nauro-core/src/nauro_core/protected_generation_membership.py
@@ -1,0 +1,85 @@
+"""Closed membership rules for protected generations and hosted snapshots."""
+
+from __future__ import annotations
+
+from nauro_core.identifiers import IdentifierKind, is_identifier
+
+_TOP_LEVEL_GENERATION_MEMBERS = frozenset(
+    {
+        "project.md",
+        "state.md",
+        "state_current.md",
+        "state_history.md",
+        "stack.md",
+        "open-questions.md",
+        "questions-provenance.json",
+    }
+)
+_SNAPSHOT_TOP_LEVEL_MEMBERS = _TOP_LEVEL_GENERATION_MEMBERS - {"questions-provenance.json"}
+
+
+class InvalidGenerationPath(ValueError):
+    """Base class for paths refused by protected-generation classification."""
+
+
+class NoncanonicalGenerationPath(InvalidGenerationPath):
+    """A path uses syntax that cannot name a canonical store member."""
+
+
+class UnknownGenerationPath(InvalidGenerationPath):
+    """A canonical path does not belong to the protected generation set."""
+
+
+def _require_canonical_path(path: object) -> str:
+    if not isinstance(path, str) or not path:
+        raise NoncanonicalGenerationPath("generation path must be a non-empty string.")
+    if path.startswith("/") or "\\" in path:
+        raise NoncanonicalGenerationPath(f"noncanonical generation path: {path!r}.")
+    segments = path.split("/")
+    if any(segment in ("", ".", "..") for segment in segments):
+        raise NoncanonicalGenerationPath(f"noncanonical generation path: {path!r}.")
+    return path
+
+
+def _is_decision_member(path: str) -> bool:
+    if not path.startswith("decisions/") or not path.endswith(".md"):
+        return False
+    rest = path[len("decisions/") : -len(".md")]
+    return bool(rest) and "/" not in rest
+
+
+def _is_context_member(path: str) -> bool:
+    if not path.startswith("context/") or not path.endswith(".md"):
+        return False
+    slug = path[len("context/") : -len(".md")]
+    return "/" not in slug and is_identifier(IdentifierKind.brief_slug, slug)
+
+
+def is_protected_generation_member(path: object) -> bool:
+    """Report whether *path* is a canonical protected-generation artifact."""
+    try:
+        canonical = _require_canonical_path(path)
+    except NoncanonicalGenerationPath:
+        return False
+    return (
+        canonical in _TOP_LEVEL_GENERATION_MEMBERS
+        or _is_decision_member(canonical)
+        or _is_context_member(canonical)
+    )
+
+
+def is_hosted_snapshot_content_member(path: object) -> bool:
+    """Report whether *path* belongs in a hosted judgment snapshot."""
+    try:
+        canonical = _require_canonical_path(path)
+    except NoncanonicalGenerationPath:
+        return False
+    return canonical in _SNAPSHOT_TOP_LEVEL_MEMBERS or _is_decision_member(canonical)
+
+
+def validate_protected_generation_path(path: object) -> str:
+    """Return a protected-generation path, rejecting unknown paths closed."""
+    canonical = _require_canonical_path(path)
+    if not is_protected_generation_member(canonical):
+        raise UnknownGenerationPath(f"path is not a protected generation member: {canonical!r}.")
+    return canonical

--- a/packages/nauro-core/src/nauro_core/provenance.py
+++ b/packages/nauro-core/src/nauro_core/provenance.py
@@ -1,0 +1,41 @@
+"""Validation for provenance values shared across local and hosted writers."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+
+class InvalidCommitSha(ValueError):
+    """A repository commit is not a canonical full SHA-1 or SHA-256 value."""
+
+
+class InvalidUtcTimestamp(ValueError):
+    """A timestamp is not the pinned RFC3339 UTC representation."""
+
+
+def validate_commit_sha(value: object, *, field: str) -> str:
+    """Return a lowercase 40- or 64-character hexadecimal commit SHA."""
+    if not isinstance(value, str):
+        raise InvalidCommitSha(f"{field} must be a string.")
+    if len(value) not in (40, 64) or any(char not in "0123456789abcdef" for char in value):
+        raise InvalidCommitSha(
+            f"{field} must be a 40- or 64-character lowercase hexadecimal commit SHA."
+        )
+    return value
+
+
+def validate_utc_timestamp(value: object, *, field: str) -> str:
+    """Return a timestamp in exact ``YYYY-MM-DDTHH:MM:SS.ffffffZ`` form."""
+    if not isinstance(value, str) or len(value) != 27:
+        raise InvalidUtcTimestamp(f"{field} must use YYYY-MM-DDTHH:MM:SS.ffffffZ.")
+    if value[10] != "T" or value[19] != "." or value[-1] != "Z":
+        raise InvalidUtcTimestamp(f"{field} must use YYYY-MM-DDTHH:MM:SS.ffffffZ.")
+    try:
+        parsed = datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ")
+    except ValueError as exc:
+        raise InvalidUtcTimestamp(
+            f"{field} must be a valid UTC timestamp in YYYY-MM-DDTHH:MM:SS.ffffffZ form."
+        ) from exc
+    if parsed.strftime("%Y-%m-%dT%H:%M:%S.%fZ") != value:
+        raise InvalidUtcTimestamp(f"{field} must use canonical YYYY-MM-DDTHH:MM:SS.ffffffZ form.")
+    return value

--- a/packages/nauro-core/tests/operations/test_operations_propose_decision.py
+++ b/packages/nauro-core/tests/operations/test_operations_propose_decision.py
@@ -548,6 +548,24 @@ def test_update_disallowed_field_rejected_loudly() -> None:
     assert "title" in result.assessment
 
 
+def test_update_disallowed_fields_reject_before_questions_are_parsed() -> None:
+    store = _store_with(
+        _seed_decision(1, "Adopt PostgreSQL", "ACID transactional semantics."),
+        **{OPEN_QUESTIONS_MD: "- [Q1] malformed without a heading\n"},
+    )
+    result = propose_decision(
+        store,
+        title="A new title",
+        rationale="A sufficiently long rationale that comfortably exceeds the minimum.",
+        operation="update",
+        affected_decision_id="decision-001",
+        resolves_questions=["Q1"],
+    )
+    assert result.status == "rejected"
+    assert result.tier == 0
+    assert "title" in result.assessment
+
+
 # ── Tier 1 structural rejection ─────────────────────────────────────────
 
 

--- a/packages/nauro-core/tests/operations/test_operations_propose_decision.py
+++ b/packages/nauro-core/tests/operations/test_operations_propose_decision.py
@@ -26,8 +26,10 @@ from pydantic import ValidationError
 from nauro_core.constants import OPEN_QUESTIONS_MD
 from nauro_core.decision_model import (
     DECISION_TYPE_VALUES,
+    Decision,
     DecisionStatus,
     Reversibility,
+    format_decision,
 )
 from nauro_core.operations import (
     InMemoryStore,
@@ -564,6 +566,39 @@ def test_update_disallowed_fields_reject_before_questions_are_parsed() -> None:
     assert result.status == "rejected"
     assert result.tier == 0
     assert "title" in result.assessment
+
+
+def test_local_update_clears_team_provenance_but_preserves_legacy_extra() -> None:
+    decision = Decision(
+        date=date(2026, 1, 1),
+        confidence="medium",
+        num=1,
+        title="Adopt PostgreSQL",
+        rationale="Mature ecosystem with strong JSON support and excellent tooling.",
+        proposed_by="01K00000000000000000000002",
+        approved_by="01K00000000000000000000003",
+        approved_at="2026-08-14T09:10:11.123456Z",
+        proposal_id="01K00000000000000000000001",
+        proposed_base_commit="a" * 40,
+        base_commit="b" * 40,
+    )
+    store = InMemoryStore(decisions={"001-adopt-postgresql": format_decision(decision)})
+    result = propose_decision(
+        store,
+        title=None,
+        rationale="Add a managed-extensions clause after production evidence.",
+        operation="update",
+        affected_decision_id="decision-001",
+    )
+    assert result.status == "confirmed"
+    body = store.read_decision("001-adopt-postgresql")
+    assert body is not None
+    assert "proposed_by:" not in body
+    assert "approved_by:" not in body
+    assert "approved_at:" not in body
+    assert "proposal_id:" not in body
+    assert "proposed_base_commit:" not in body
+    assert f"base_commit: {'b' * 40}" in body
 
 
 # ── Tier 1 structural rejection ─────────────────────────────────────────

--- a/packages/nauro-core/tests/test_decision_model.py
+++ b/packages/nauro-core/tests/test_decision_model.py
@@ -1005,3 +1005,38 @@ class TestEnumValueBytes:
 
     def test_confidence_medium_value(self) -> None:
         assert DecisionConfidence.medium.value == "medium"
+
+
+class TestApprovalProvenance:
+    def test_complete_group_serializes_after_existing_frontmatter(self) -> None:
+        decision = _minimal_decision(
+            proposed_by="01K00000000000000000000002",
+            approved_by="01K00000000000000000000003",
+            approved_at="2026-08-14T09:10:11.123456Z",
+            proposal_id="01K00000000000000000000001",
+            proposed_base_commit="a" * 40,
+        )
+        formatted = format_decision(decision)
+        assert formatted.index("superseded_by:") < formatted.index("proposed_by:")
+        assert formatted.index("proposed_by:") < formatted.index("approved_by:")
+        assert formatted.index("approved_by:") < formatted.index("approved_at:")
+        assert formatted.index("approved_at:") < formatted.index("proposal_id:")
+        assert formatted.index("proposal_id:") < formatted.index("proposed_base_commit:")
+        assert format_decision(parse_decision(formatted, "001-test.md")) == formatted
+
+    def test_absent_group_omits_only_new_fields(self) -> None:
+        formatted = format_decision(_minimal_decision())
+        for field in (
+            "proposed_by",
+            "approved_by",
+            "approved_at",
+            "proposal_id",
+            "proposed_base_commit",
+        ):
+            assert f"{field}:" not in formatted
+        assert "decision_type: null" in formatted
+        assert "files_affected: []" in formatted
+
+    def test_partial_group_rejects(self) -> None:
+        with pytest.raises(ValidationError, match="partial approval provenance"):
+            _minimal_decision(proposed_by="01K00000000000000000000002")

--- a/packages/nauro-core/tests/test_protected_generation_membership.py
+++ b/packages/nauro-core/tests/test_protected_generation_membership.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import pytest
+
+from nauro_core.protected_generation_membership import (
+    NoncanonicalGenerationPath,
+    UnknownGenerationPath,
+    is_hosted_snapshot_content_member,
+    is_protected_generation_member,
+    validate_protected_generation_path,
+)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "project.md",
+        "state.md",
+        "state_current.md",
+        "state_history.md",
+        "stack.md",
+        "open-questions.md",
+        "questions-provenance.json",
+        "decisions/001-use-sqlite.md",
+        "context/handoff-one.md",
+    ],
+)
+def test_protected_generation_members_are_closed(path: str) -> None:
+    assert is_protected_generation_member(path)
+    assert validate_protected_generation_path(path) == path
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "project.md",
+        "state.md",
+        "state_current.md",
+        "state_history.md",
+        "stack.md",
+        "open-questions.md",
+        "decisions/001-use-sqlite.md",
+    ],
+)
+def test_snapshot_members_are_independent(path: str) -> None:
+    assert is_hosted_snapshot_content_member(path)
+
+
+@pytest.mark.parametrize("path", ["questions-provenance.json", "context/handoff-one.md"])
+def test_snapshot_excludes_private_projection_content(path: str) -> None:
+    assert is_protected_generation_member(path)
+    assert not is_hosted_snapshot_content_member(path)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        ".decision-hashes.json",
+        "snapshots/v001.json",
+        "journal/events.jsonl",
+        "reports/report.md",
+        "decisions/nested/001-bad.md",
+        "unknown.md",
+    ],
+)
+def test_unknown_paths_fail_closed(path: str) -> None:
+    assert not is_protected_generation_member(path)
+    with pytest.raises(UnknownGenerationPath):
+        validate_protected_generation_path(path)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/project.md",
+        "context//brief.md",
+        "context/../brief.md",
+        "context/./brief.md",
+        "context\\brief.md",
+    ],
+)
+def test_noncanonical_paths_reject_before_classification(path: str) -> None:
+    with pytest.raises(NoncanonicalGenerationPath):
+        validate_protected_generation_path(path)

--- a/packages/nauro-core/tests/test_provenance.py
+++ b/packages/nauro-core/tests/test_provenance.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import pytest
+
+from nauro_core.provenance import (
+    InvalidCommitSha,
+    InvalidUtcTimestamp,
+    validate_commit_sha,
+    validate_utc_timestamp,
+)
+
+
+@pytest.mark.parametrize("value", ["a" * 40, "b" * 64])
+def test_validate_commit_sha_accepts_lowercase_full_hashes(value: str) -> None:
+    assert validate_commit_sha(value, field="proposed_base_commit") == value
+
+
+@pytest.mark.parametrize("value", ["A" * 40, "a" * 39, "g" * 40, "a" * 41])
+def test_validate_commit_sha_rejects_noncanonical_hashes(value: str) -> None:
+    with pytest.raises(InvalidCommitSha):
+        validate_commit_sha(value, field="proposed_base_commit")
+
+
+def test_validate_utc_timestamp_accepts_pinned_microsecond_form() -> None:
+    value = "2026-08-14T09:10:11.123456Z"
+    assert validate_utc_timestamp(value, field="approved_at") == value
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "2026-08-14T09:10:11Z",
+        "2026-08-14T09:10:11.123456+00:00",
+        "2026-02-30T09:10:11.123456Z",
+        "2026-08-14t09:10:11.123456Z",
+    ],
+)
+def test_validate_utc_timestamp_rejects_noncanonical_values(value: str) -> None:
+    with pytest.raises(InvalidUtcTimestamp):
+        validate_utc_timestamp(value, field="approved_at")

--- a/packages/nauro/src/nauro/store/repo_head.py
+++ b/packages/nauro/src/nauro/store/repo_head.py
@@ -11,13 +11,11 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
+from nauro_core.provenance import InvalidCommitSha, validate_commit_sha
+
 # Bounds the capture cost on every decision write; a repository that cannot
 # answer rev-parse within this window resolves to absence.
 _GIT_TIMEOUT_SECONDS = 2
-
-# Full object names only: 40 hex chars (SHA-1) or 64 (SHA-256 repositories).
-_SHA_LENGTHS = frozenset({40, 64})
-_HEX_DIGITS = frozenset("0123456789abcdef")
 
 
 def resolve_repo_head(cwd: str | Path | None) -> str | None:
@@ -44,9 +42,10 @@ def resolve_repo_head(cwd: str | Path | None) -> str | None:
     if completed.returncode != 0:
         return None
     sha = completed.stdout.strip()
-    if len(sha) not in _SHA_LENGTHS or not set(sha) <= _HEX_DIGITS:
+    try:
+        return validate_commit_sha(sha, field="HEAD")
+    except InvalidCommitSha:
         return None
-    return sha
 
 
 def resolve_process_repo_head() -> str | None:


### PR DESCRIPTION
## Why

Deterministic hosted planning needs validated approval provenance and one fail-closed definition of protected generation content. These foundations must land without changing existing local serialization or write sequencing.

## What changed

- Added shared validators for canonical commit SHAs and UTC timestamps.
- Added five optional approval-provenance fields to decisions, with complete-group validation, canonical ordering, and selective omission limited to those fields.
- Added separate protected-generation and hosted-snapshot membership classifiers, including private question provenance and context brief rules.
- Added provenance-aware decision construction and update transitions.
- Kept local numbering, clock use, write order, and hash-index updates unchanged.
- Cleared stale team provenance on a new local decision version while preserving tolerant-reader extras such as `base_commit`.
- Reused the shared commit validator for repository HEAD capture while preserving fail-open behavior.

## Test plan

- Focused provenance, membership, decision-model, proposal, and repository-head tests passed: 192.
- Focused configured mypy for `repo_head.py` passed.
- Full `nauro-core` suite passed: 1,573.
- Local `nauro` suite passed: 2,635.
- Focused parity and provenance suite passed: 63, with one existing private-server skip.
- Legacy decision byte-identity tests passed: 6.
- Public-contract snapshot test passed.
- Ruff, import contracts, repository consistency checks, and `git diff --check` passed.

## Risk

The main risk is serialization drift in legacy decision files. Review the selective omission logic, provenance field order, complete-group validation, and preservation of unknown frontmatter. Also review the fail-closed generation path classifier and the distinction between generation and snapshot membership.

## Deferred

The deterministic commit planner, plan-record projection, claim contract, server saga, publication consumer, and all public surfaces remain out of scope.
