### PR TITLE
Split judgment commit implementation modules

### DIFF
--- a/packages/nauro-core/src/nauro_core/operations/_commit_finalize.py
+++ b/packages/nauro-core/src/nauro_core/operations/_commit_finalize.py
@@ -1,0 +1,167 @@
+"""Finalization implementation for hosted judgment commit planning."""
+
+from __future__ import annotations
+
+from . import commit_plan as contract
+
+
+def _probe_key_impl(probe: contract.ClaimProbe) -> tuple[str, str]:
+    if isinstance(probe, contract.AbsentContentClaimProbe):
+        return ("content", probe.content_hash)
+    return ("title", probe.normalized_title)
+
+
+def _observation_key_impl(observation: contract.ClaimObservation) -> tuple[str, str]:
+    if isinstance(
+        observation,
+        (
+            contract.AbsentContentClaimObservation,
+            contract.CommittedContentClaimObservation,
+            contract.UnavailableContentClaimObservation,
+        ),
+    ):
+        return ("content", observation.content_hash)
+    return ("title", observation.normalized_title)
+
+
+def _validate_observation_impl(
+    probe: contract.ClaimProbe, observation: contract.ClaimObservation
+) -> None:
+    if isinstance(
+        observation,
+        (contract.UnavailableTitleClaimObservation, contract.UnavailableContentClaimObservation),
+    ):
+        raise contract.ClaimUnavailable(
+            f"claim {contract._observation_key(observation)!r} is {observation.reason}."
+        )
+    if isinstance(probe, contract.AbsentTitleClaimProbe):
+        if isinstance(observation, contract.AbsentTitleClaimObservation):
+            return
+        if isinstance(observation, contract.CommittedTitleClaimObservation):
+            raise contract.TitleClaimConflict(
+                "normalized title is already owned by decision "
+                f"{observation.owner_decision_number}."
+            )
+    elif isinstance(probe, contract.OwnedTitleClaimProbe):
+        if isinstance(observation, contract.CommittedTitleClaimObservation) and (
+            observation.owner_decision_number == probe.expected_owner_decision_number
+        ):
+            return
+        raise contract.MismatchedClaimObservation(
+            "owned title claim does not match the expected committed owner."
+        )
+    elif isinstance(observation, contract.AbsentContentClaimObservation):
+        return
+    elif isinstance(observation, contract.CommittedContentClaimObservation):
+        raise contract.ContentClaimConflict("content hash is already present in decision history.")
+    raise contract.MismatchedClaimObservation(
+        "claim observation does not match its prepared probe."
+    )
+
+
+def _artifact_inventory_impl(prepared: contract.PreparedJudgmentCommit) -> dict[str, object]:
+    descriptors = [
+        {"length": artifact.length, "path": artifact.path, "sha256": artifact.sha256}
+        for artifact in prepared.planned_artifacts
+    ]
+    inventory = {"artifacts": descriptors, "schema": "nauro.artifact_inventory.v1"}
+    inventory_bytes = contract.canonical_judgment_payload_bytes(inventory)
+    return {
+        "artifact_count": len(descriptors),
+        "digest": contract._sha256(inventory_bytes),
+        "schema": "nauro.artifact_inventory.v1",
+        "total_byte_count": sum(descriptor["length"] for descriptor in descriptors),
+    }
+
+
+def _plan_record_impl(
+    prepared: contract.PreparedJudgmentCommit,
+    observations: tuple[contract.ClaimObservation, ...],
+) -> bytes:
+    content = prepared.payload.content
+    provenance = (
+        {
+            "approved_at": prepared.decision_provenance.approved_at,
+            "approved_by": prepared.decision_provenance.approved_by,
+            "proposal_id": prepared.decision_provenance.proposal_id,
+            "proposed_base_commit": prepared.decision_provenance.proposed_base_commit,
+            "proposed_by": prepared.decision_provenance.proposed_by,
+        }
+        if prepared.decision_provenance is not None
+        else None
+    )
+    record = {
+        "affected_decision_id": content.affected_decision_id,
+        "approval_mode": prepared.payload.approval_mode,
+        "approval": prepared.approval_attestation.model_dump(mode="json"),
+        "artifact_inventory": contract._artifact_inventory(prepared),
+        "base": prepared.base.model_dump(mode="json"),
+        "claim_plan": {
+            "entry": [value.model_dump(mode="json") for value in prepared.claim_intents.entry],
+            "observations": [value.model_dump(mode="json") for value in observations],
+            "probes": [value.model_dump(mode="json") for value in prepared.claim_probes],
+            "publication": [
+                value.model_dump(mode="json") for value in prepared.claim_intents.publication
+            ],
+        },
+        "committed_result": prepared.committed_result.model_dump(mode="json"),
+        "decision_provenance": provenance,
+        "new_decision_counter": prepared.new_decision_counter,
+        "operation": content.operation,
+        "payload_digest": prepared.payload_digest,
+        "payload_schema": prepared.payload.payload_schema,
+        "primary_decision": prepared.primary_decision.model_dump(mode="json"),
+        "record_schema": "nauro.judgment_commit.plan_record.v1",
+        "snapshot": {
+            "length": prepared.snapshot.length,
+            "sha256": prepared.snapshot.sha256,
+        },
+        "transform_version": prepared.transformation_version,
+    }
+    return contract.canonical_judgment_payload_bytes(record)
+
+
+def finalize_judgment_commit_impl(
+    prepared: contract.PreparedJudgmentCommit,
+    claim_observations: contract.Sequence[
+        contract.ClaimObservation | contract.Mapping[str, object]
+    ],
+) -> contract.JudgmentCommitPlan:
+    """Validate claim observations and finalize the storage-neutral plan."""
+    parsed: list[contract.ClaimObservation] = []
+    for raw in claim_observations:
+        try:
+            parsed.append(contract._OBSERVATION_ADAPTER.validate_python(raw))
+        except contract.ValidationError as exc:
+            raise contract.MalformedClaimObservation("claim observation is malformed.") from exc
+    observed_by_key: dict[tuple[str, str], contract.ClaimObservation] = {}
+    for observation in parsed:
+        key = contract._observation_key(observation)
+        if key in observed_by_key:
+            raise contract.DuplicateClaimObservation(f"duplicate claim observation for {key!r}.")
+        observed_by_key[key] = observation
+    probe_keys = {contract._probe_key(probe) for probe in prepared.claim_probes}
+    extra = set(observed_by_key) - probe_keys
+    if extra:
+        raise contract.UnexpectedClaimObservation(
+            f"unexpected claim observation(s): {sorted(extra)!r}."
+        )
+    missing = probe_keys - set(observed_by_key)
+    if missing:
+        raise contract.MissingClaimObservation(
+            f"missing claim observation(s): {sorted(missing)!r}."
+        )
+    ordered = tuple(observed_by_key[contract._probe_key(probe)] for probe in prepared.claim_probes)
+    for probe, observation in zip(prepared.claim_probes, ordered, strict=True):
+        contract._validate_observation(probe, observation)
+    claim_plan = contract.FinalizedClaimPlan(
+        entry=prepared.claim_intents.entry,
+        publication=prepared.claim_intents.publication,
+    )
+    record_bytes = contract._plan_record(prepared, ordered)
+    return contract.JudgmentCommitPlan(
+        prepared=prepared,
+        validated_claim_observations=ordered,
+        claim_plan=claim_plan,
+        plan_record_bytes=record_bytes,
+    )

--- a/packages/nauro-core/src/nauro_core/operations/_commit_prepare.py
+++ b/packages/nauro-core/src/nauro_core/operations/_commit_prepare.py
@@ -1,0 +1,548 @@
+"""Preparation implementation for hosted judgment commit planning."""
+
+from __future__ import annotations
+
+from . import commit_plan as contract
+
+
+def _reject_duplicate_keys_impl(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise contract.CanonicalPayloadRejected(
+                f"approved payload contains duplicate key {key!r}."
+            )
+        result[key] = value
+    return result
+
+
+def _parse_payload_impl(payload_bytes: bytes) -> contract.ApprovedPayload:
+    try:
+        text = payload_bytes.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise contract.CanonicalPayloadRejected("approved payload must be valid UTF-8.") from exc
+    try:
+        raw = contract.json.loads(
+            text,
+            object_pairs_hook=contract._reject_duplicate_keys,
+            parse_constant=lambda value: (_ for _ in ()).throw(
+                contract.CanonicalPayloadRejected(
+                    f"approved payload contains invalid number {value}."
+                )
+            ),
+        )
+    except contract.CanonicalPayloadRejected:
+        raise
+    except (contract.json.JSONDecodeError, TypeError) as exc:
+        raise contract.CanonicalPayloadRejected("approved payload must be valid JSON.") from exc
+    try:
+        payload = contract._PAYLOAD_ADAPTER.validate_python(raw)
+    except contract.ValidationError as exc:
+        raise contract.CanonicalPayloadRejected(f"approved payload is invalid: {exc}") from exc
+    try:
+        canonical = contract.canonical_judgment_payload_bytes(payload.model_dump(mode="json"))
+    except UnicodeEncodeError as exc:
+        raise contract.CanonicalPayloadRejected(
+            "approved payload cannot be serialized as canonical UTF-8 JSON."
+        ) from exc
+    if canonical != payload_bytes:
+        raise contract.CanonicalPayloadRejected("approved payload bytes are not canonical JSON.")
+    return payload
+
+
+def _parse_committed_generation_impl(
+    generation: contract.CommittedGeneration,
+) -> tuple[dict[str, bytes], list[contract.Decision], dict[int, str]]:
+    artifact_bytes: dict[str, bytes] = {}
+    decisions: list[contract.Decision] = []
+    stems_by_number: dict[int, str] = {}
+    for artifact in sorted(generation.artifacts, key=lambda value: value.path):
+        contract.validate_protected_generation_path(artifact.path)
+        try:
+            text = artifact.content.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise contract.CommittedGenerationCorrupt(
+                f"committed artifact {artifact.path!r} is not valid UTF-8."
+            ) from exc
+        artifact_bytes[artifact.path] = bytes(artifact.content)
+        if not artifact.path.startswith("decisions/"):
+            continue
+        filename = artifact.path[len("decisions/") :]
+        try:
+            decision = contract.parse_decision(text, filename)
+        except Exception as exc:
+            raise contract.CommittedGenerationCorrupt(
+                f"committed decision {artifact.path!r} does not parse."
+            ) from exc
+        if decision.num <= 0:
+            raise contract.CommittedGenerationCorrupt(
+                f"committed decision {artifact.path!r} has no positive number."
+            )
+        if decision.num in stems_by_number:
+            raise contract.CommittedGenerationCorrupt(
+                f"committed generation contains duplicate decision number {decision.num}."
+            )
+        decisions.append(decision)
+        stems_by_number[decision.num] = filename.removesuffix(".md")
+    maximum = max(stems_by_number, default=0)
+    if maximum > generation.decision_counter:
+        raise contract.CommittedGenerationCorrupt(
+            f"published decision number {maximum} exceeds counter {generation.decision_counter}."
+        )
+    return artifact_bytes, decisions, stems_by_number
+
+
+def _rejected_result_impl(
+    tier: int,
+    operation: str,
+    assessment: str,
+) -> contract.ProposalRejected:
+    result_operation = "reject" if tier == 1 else operation
+    return contract.ProposalRejected(
+        contract.ProposeDecisionResult(
+            status="rejected",
+            tier=tier,
+            operation=result_operation,
+            assessment=assessment,
+        )
+    )
+
+
+def _target_impl(
+    content: contract.JudgmentContent,
+    decisions: list[contract.Decision],
+    stems_by_number: dict[int, str],
+) -> tuple[contract.Decision | None, str | None]:
+    if content.operation == "add":
+        return None, None
+    target_stem = content.affected_decision_id
+    assert target_stem is not None
+    target = next(
+        (decision for decision in decisions if stems_by_number[decision.num] == target_stem),
+        None,
+    )
+    if target is None:
+        raise contract._rejected_result(
+            1,
+            content.operation,
+            f"{content.operation} target {target_stem!r} not found in committed generation.",
+        )
+    return target, target_stem
+
+
+def _provenance_impl(
+    payload: contract.ApprovedPayload,
+    attestation: contract.ApprovalAttestation,
+) -> tuple[str, contract.DecisionProvenance | None]:
+    if isinstance(payload, contract.HostedPreTeamApprovalPayloadV1):
+        if not isinstance(attestation, contract.PreTeamApprovalAttestation):
+            raise contract.ApprovalAttestationRejected(
+                "pre-team payload requires pre-team approval attestation."
+            )
+        return attestation.request_received_at, None
+    if not isinstance(attestation, contract.TeamRatificationAttestation):
+        raise contract.ApprovalAttestationRejected(
+            "team payload requires team ratification attestation."
+        )
+    if payload.contributor_operation_id == attestation.ratification_action_id:
+        raise contract.ApprovalAttestationRejected(
+            "team contributor_operation_id and ratification_action_id must be distinct."
+        )
+    return (
+        attestation.approved_at,
+        contract.DecisionProvenance(
+            proposed_by=payload.proposed_by,
+            approved_by=attestation.approved_by,
+            approved_at=attestation.approved_at,
+            proposal_id=payload.proposal_id,
+            proposed_base_commit=payload.proposed_base_commit,
+        ),
+    )
+
+
+def _derive_snapshot_bytes_impl(
+    artifacts: tuple[contract.PlannedArtifact, ...],
+    *,
+    payload: contract.ApprovedPayload,
+    effective_at: str,
+) -> bytes:
+    snapshot_files = {
+        artifact.path: artifact.content.decode("utf-8")
+        for artifact in artifacts
+        if contract.is_hosted_snapshot_content_member(artifact.path)
+    }
+    title = payload.content.title or ""
+    trigger = {
+        "add": f"decision: {title}",
+        "update": "update: ",
+        "supersede": f"supersede: {title}",
+    }[payload.content.operation]
+    snapshot = contract.serialize_snapshot(
+        timestamp=effective_at,
+        trigger=trigger,
+        files=dict(sorted(snapshot_files.items())),
+    )
+    return contract.json.dumps(
+        snapshot,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _build_artifacts_impl(
+    *,
+    payload: contract.ApprovedPayload,
+    provenance: contract.DecisionProvenance | None,
+    effective_at: str,
+    generation: contract.CommittedGeneration,
+    current: dict[str, bytes],
+    evaluation: contract.ProposalEvaluation,
+    target: contract.Decision | None,
+    target_stem: str | None,
+) -> tuple[
+    tuple[contract.PlannedArtifact, ...],
+    contract.PlannedSnapshot,
+    contract.PrimaryDecision,
+    contract.ProposeDecisionResult,
+    int | None,
+    int,
+    contract.Decision,
+]:
+    content = payload.content
+    decision_date = contract.date.fromisoformat(effective_at[:10])
+    assigned = (
+        generation.decision_counter + 1 if content.operation in ("add", "supersede") else None
+    )
+    new_counter = generation.decision_counter + (1 if assigned is not None else 0)
+    planned = dict(current)
+
+    rejected = tuple(
+        contract.RejectedAlternative(name=item.alternative, reason=item.reason)
+        for item in content.rejected
+    )
+    if content.operation == "update":
+        assert target is not None and target_stem is not None
+        primary_model = contract.append_decision_update(
+            target,
+            additional_rationale=content.rationale,
+            update_date=decision_date,
+            provenance=provenance,
+        )
+        primary_stem = target_stem
+        primary_path = f"decisions/{primary_stem}.md"
+        planned[primary_path] = contract.format_decision(primary_model).encode("utf-8")
+        touched = [primary_stem]
+    else:
+        assert (
+            assigned is not None and content.title is not None and content.confidence is not None
+        )
+        primary_model = contract.build_new_decision(
+            number=assigned,
+            decision_date=decision_date,
+            title=content.title,
+            rationale=content.rationale,
+            confidence=contract.DecisionConfidence(content.confidence),
+            decision_type=contract.DecisionType(content.decision_type)
+            if content.decision_type
+            else None,
+            reversibility=contract.Reversibility(content.reversibility)
+            if content.reversibility
+            else None,
+            source=contract.DecisionSource.mcp,
+            files_affected=content.files_affected,
+            rejected=rejected,
+            provenance=provenance,
+        )
+        if content.operation == "supersede":
+            assert target is not None and target_stem is not None
+            primary_model = contract.attach_supersedes(primary_model, target.num)
+        primary_stem = (
+            f"{contract._decision_number_prefix(assigned)}"
+            f"{contract.slugify_decision_title(content.title)}"
+        )
+        primary_path = f"decisions/{primary_stem}.md"
+        planned[primary_path] = contract.format_decision(primary_model).encode("utf-8")
+        touched = [primary_stem]
+        if content.operation == "supersede":
+            assert target is not None and target_stem is not None
+            old_path = f"decisions/{target_stem}.md"
+            planned[old_path] = contract.format_decision(
+                contract.mark_superseded(target, assigned)
+            ).encode("utf-8")
+            touched.append(target_stem)
+
+    questions_path = "open-questions.md"
+    questions_body = planned.get(questions_path, b"").decode("utf-8")
+    resolution = contract.resolve_questions_content(
+        questions_body,
+        question_ids=content.resolves_questions,
+        decision_number=primary_model.num,
+        resolved_date=decision_date,
+    )
+    if content.resolves_questions:
+        planned[questions_path] = resolution.content.encode("utf-8")
+
+    result = contract.ProposeDecisionResult(
+        status="confirmed",
+        tier=2,
+        operation=content.operation,
+        assessment=evaluation.assessment,
+        similar_decisions=list(evaluation.similar_decisions),
+        decision_id=primary_stem,
+        touched_decisions=touched,
+        resolved_questions=list(resolution.resolved_ids),
+        relocated_ids=resolution.relocated_ids or None,
+        skipped_prose_ids=resolution.skipped_prose_ids or None,
+    )
+    artifacts = tuple(
+        contract.PlannedArtifact(path=path, content=body) for path, body in sorted(planned.items())
+    )
+    snapshot = contract.PlannedSnapshot(
+        content=contract._derive_snapshot_bytes(
+            artifacts, payload=payload, effective_at=effective_at
+        )
+    )
+    primary_bytes = planned[primary_path]
+    primary = contract.PrimaryDecision(
+        decision_id=primary_stem,
+        path=primary_path,
+        sha256=contract._sha256(primary_bytes),
+    )
+    return artifacts, snapshot, primary, result, assigned, new_counter, primary_model
+
+
+def _claim_contract_impl(
+    operation: str,
+    target: contract.Decision | None,
+    primary: contract.Decision,
+) -> tuple[tuple[contract.ClaimProbe, ...], contract.ClaimIntents]:
+    new_number = primary.num
+    new_title = contract.normalize_title(primary.title)
+    content_hash = contract.compute_hash(primary.title, primary.rationale)
+    content_probe = contract.AbsentContentClaimProbe(content_hash=content_hash)
+    acquire_content = contract.ClaimIntent(
+        kind="acquire_new_content_hash", content_hash=content_hash
+    )
+    commit_content = contract.ClaimIntent(kind="commit_content_hash", content_hash=content_hash)
+    if operation == "add":
+        probes: tuple[contract.ClaimProbe, ...] = (
+            contract.AbsentTitleClaimProbe(normalized_title=new_title),
+            content_probe,
+        )
+        intents = contract.ClaimIntents(
+            entry=(
+                contract.ClaimIntent(
+                    kind="acquire_new_title",
+                    normalized_title=new_title,
+                    owner_decision_number=new_number,
+                ),
+                acquire_content,
+            ),
+            publication=(
+                contract.ClaimIntent(
+                    kind="commit_title_owner",
+                    normalized_title=new_title,
+                    owner_decision_number=new_number,
+                ),
+                commit_content,
+            ),
+        )
+        return probes, intents
+    assert target is not None
+    old_title = contract.normalize_title(target.title)
+    if operation == "update":
+        probes = (
+            contract.OwnedTitleClaimProbe(
+                normalized_title=old_title,
+                expected_owner_decision_number=target.num,
+            ),
+            content_probe,
+        )
+        intents = contract.ClaimIntents(
+            entry=(
+                contract.ClaimIntent(
+                    kind="hold_owned_title",
+                    normalized_title=old_title,
+                    owner_decision_number=target.num,
+                ),
+                acquire_content,
+            ),
+            publication=(
+                contract.ClaimIntent(
+                    kind="retain_title_owner",
+                    normalized_title=old_title,
+                    owner_decision_number=target.num,
+                ),
+                commit_content,
+            ),
+        )
+        return probes, intents
+    if new_title == old_title:
+        probes = (
+            contract.OwnedTitleClaimProbe(
+                normalized_title=old_title,
+                expected_owner_decision_number=target.num,
+            ),
+            content_probe,
+        )
+        intents = contract.ClaimIntents(
+            entry=(
+                contract.ClaimIntent(
+                    kind="acquire_title_transfer",
+                    normalized_title=old_title,
+                    from_owner_decision_number=target.num,
+                    to_owner_decision_number=new_number,
+                ),
+                acquire_content,
+            ),
+            publication=(
+                contract.ClaimIntent(
+                    kind="transfer_title_owner",
+                    normalized_title=old_title,
+                    from_owner_decision_number=target.num,
+                    to_owner_decision_number=new_number,
+                ),
+                commit_content,
+            ),
+        )
+        return probes, intents
+    probes = (
+        contract.OwnedTitleClaimProbe(
+            normalized_title=old_title,
+            expected_owner_decision_number=target.num,
+        ),
+        contract.AbsentTitleClaimProbe(normalized_title=new_title),
+        content_probe,
+    )
+    intents = contract.ClaimIntents(
+        entry=(
+            contract.ClaimIntent(
+                kind="hold_owned_title",
+                normalized_title=old_title,
+                owner_decision_number=target.num,
+            ),
+            contract.ClaimIntent(
+                kind="acquire_new_title",
+                normalized_title=new_title,
+                owner_decision_number=new_number,
+            ),
+            acquire_content,
+        ),
+        publication=(
+            contract.ClaimIntent(
+                kind="release_title_owner",
+                normalized_title=old_title,
+                owner_decision_number=target.num,
+            ),
+            contract.ClaimIntent(
+                kind="commit_title_owner",
+                normalized_title=new_title,
+                owner_decision_number=new_number,
+            ),
+            commit_content,
+        ),
+    )
+    return probes, intents
+
+
+def prepare_judgment_commit_impl(
+    payload_bytes: bytes,
+    approval_attestation: contract.ApprovalAttestation,
+    committed_generation: contract.CommittedGeneration,
+    expected_payload_digest: str | None = None,
+) -> contract.PreparedJudgmentCommit:
+    """Prepare immutable artifacts and semantic claim reads without I/O."""
+    payload_bytes = bytes(payload_bytes)
+    digest = contract._sha256(payload_bytes)
+    if expected_payload_digest is not None:
+        contract._validate_sha256(expected_payload_digest, field="expected_payload_digest")
+        if digest != expected_payload_digest:
+            raise contract.ApprovedPayloadDigestMismatch(
+                "expected payload digest does not match approved payload bytes."
+            )
+    payload = contract._parse_payload(payload_bytes)
+    if (
+        payload.base_generation_id != committed_generation.generation_id
+        or payload.base_decision_counter != committed_generation.decision_counter
+    ):
+        raise contract.ApprovedBaseStale(
+            "approved base generation and counter do not match the observed committed generation."
+        )
+    current, decisions, stems_by_number = contract._parse_committed_generation(
+        committed_generation
+    )
+    target, target_stem = contract._target(payload.content, decisions, stems_by_number)
+    questions_bytes = current.get("open-questions.md")
+    proposal = {
+        "title": payload.content.title,
+        "rationale": payload.content.rationale,
+        "rejected": [
+            {"alternative": value.alternative, "reason": value.reason}
+            for value in payload.content.rejected
+        ],
+        "confidence": payload.content.confidence,
+        "decision_type": payload.content.decision_type,
+        "reversibility": payload.content.reversibility,
+        "files_affected": list(payload.content.files_affected),
+        "resolves_questions": list(payload.content.resolves_questions),
+        "source": contract.DecisionSource.mcp.value,
+        "base_commit": None,
+    }
+    questions_file = (
+        contract.OpenQuestionsFile.parse(questions_bytes.decode("utf-8"))
+        if questions_bytes is not None and payload.content.resolves_questions
+        else None
+    )
+    request_rejection = contract.validate_proposal_request(
+        proposal,
+        operation=payload.content.operation,
+        questions_file=questions_file,
+    )
+    if request_rejection is not None:
+        raise contract.ProposalRejected(request_rejection)
+    evaluation = contract.evaluate_parsed_proposal(
+        proposal,
+        operation=payload.content.operation,
+        decisions=decisions,
+        existing_hashes=set(),
+        affected_number=target.num if target is not None else None,
+        enforce_claim_conflicts=False,
+    )
+    if isinstance(evaluation, contract.ProposeDecisionResult):
+        raise contract.ProposalRejected(evaluation)
+    effective_at, provenance = contract._provenance(payload, approval_attestation)
+    artifacts, snapshot, primary, result, assigned, new_counter, primary_model = (
+        contract._build_artifacts(
+            payload=payload,
+            provenance=provenance,
+            effective_at=effective_at,
+            generation=committed_generation,
+            current=current,
+            evaluation=evaluation,
+            target=target,
+            target_stem=target_stem,
+        )
+    )
+    probes, intents = contract._claim_contract(payload.content.operation, target, primary_model)
+    return contract.PreparedJudgmentCommit(
+        payload_bytes=payload_bytes,
+        payload_digest=digest,
+        payload=payload,
+        approval_attestation=approval_attestation,
+        base=contract.PreparedBase(
+            generation_id=committed_generation.generation_id,
+            decision_counter=committed_generation.decision_counter,
+            observed_manifest_digest=committed_generation.observed_manifest_digest,
+        ),
+        effective_at=effective_at,
+        decision_provenance=provenance,
+        assigned_decision_number=assigned,
+        new_decision_counter=new_counter,
+        planned_artifacts=artifacts,
+        snapshot=snapshot,
+        primary_decision=primary,
+        claim_probes=probes,
+        claim_intents=intents,
+        result_projection=contract._CommittedResultProjection.from_result(result),
+    )

--- a/packages/nauro-core/src/nauro_core/operations/commit_plan.py
+++ b/packages/nauro-core/src/nauro_core/operations/commit_plan.py
@@ -1,5 +1,7 @@
 """Pure two-phase planning for hosted judgment commits."""
 
+# ruff: noqa: F401
+
 from __future__ import annotations
 
 import hashlib
@@ -737,86 +739,23 @@ def canonical_judgment_payload_bytes(payload: Mapping[str, object]) -> bytes:
 
 
 def _reject_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
-    result: dict[str, object] = {}
-    for key, value in pairs:
-        if key in result:
-            raise CanonicalPayloadRejected(f"approved payload contains duplicate key {key!r}.")
-        result[key] = value
-    return result
+    from . import _commit_prepare
+
+    return _commit_prepare._reject_duplicate_keys_impl(pairs)
 
 
 def _parse_payload(payload_bytes: bytes) -> ApprovedPayload:
-    try:
-        text = payload_bytes.decode("utf-8")
-    except UnicodeDecodeError as exc:
-        raise CanonicalPayloadRejected("approved payload must be valid UTF-8.") from exc
-    try:
-        raw = json.loads(
-            text,
-            object_pairs_hook=_reject_duplicate_keys,
-            parse_constant=lambda value: (_ for _ in ()).throw(
-                CanonicalPayloadRejected(f"approved payload contains invalid number {value}.")
-            ),
-        )
-    except CanonicalPayloadRejected:
-        raise
-    except (json.JSONDecodeError, TypeError) as exc:
-        raise CanonicalPayloadRejected("approved payload must be valid JSON.") from exc
-    try:
-        payload = _PAYLOAD_ADAPTER.validate_python(raw)
-    except ValidationError as exc:
-        raise CanonicalPayloadRejected(f"approved payload is invalid: {exc}") from exc
-    try:
-        canonical = canonical_judgment_payload_bytes(payload.model_dump(mode="json"))
-    except UnicodeEncodeError as exc:
-        raise CanonicalPayloadRejected(
-            "approved payload cannot be serialized as canonical UTF-8 JSON."
-        ) from exc
-    if canonical != payload_bytes:
-        raise CanonicalPayloadRejected("approved payload bytes are not canonical JSON.")
-    return payload
+    from . import _commit_prepare
+
+    return _commit_prepare._parse_payload_impl(payload_bytes)
 
 
 def _parse_committed_generation(
     generation: CommittedGeneration,
 ) -> tuple[dict[str, bytes], list[Decision], dict[int, str]]:
-    artifact_bytes: dict[str, bytes] = {}
-    decisions: list[Decision] = []
-    stems_by_number: dict[int, str] = {}
-    for artifact in sorted(generation.artifacts, key=lambda value: value.path):
-        validate_protected_generation_path(artifact.path)
-        try:
-            text = artifact.content.decode("utf-8")
-        except UnicodeDecodeError as exc:
-            raise CommittedGenerationCorrupt(
-                f"committed artifact {artifact.path!r} is not valid UTF-8."
-            ) from exc
-        artifact_bytes[artifact.path] = bytes(artifact.content)
-        if not artifact.path.startswith("decisions/"):
-            continue
-        filename = artifact.path[len("decisions/") :]
-        try:
-            decision = parse_decision(text, filename)
-        except Exception as exc:
-            raise CommittedGenerationCorrupt(
-                f"committed decision {artifact.path!r} does not parse."
-            ) from exc
-        if decision.num <= 0:
-            raise CommittedGenerationCorrupt(
-                f"committed decision {artifact.path!r} has no positive number."
-            )
-        if decision.num in stems_by_number:
-            raise CommittedGenerationCorrupt(
-                f"committed generation contains duplicate decision number {decision.num}."
-            )
-        decisions.append(decision)
-        stems_by_number[decision.num] = filename.removesuffix(".md")
-    maximum = max(stems_by_number, default=0)
-    if maximum > generation.decision_counter:
-        raise CommittedGenerationCorrupt(
-            f"published decision number {maximum} exceeds counter {generation.decision_counter}."
-        )
-    return artifact_bytes, decisions, stems_by_number
+    from . import _commit_prepare
+
+    return _commit_prepare._parse_committed_generation_impl(generation)
 
 
 def _rejected_result(
@@ -824,16 +763,9 @@ def _rejected_result(
     operation: Literal["add", "update", "supersede"],
     assessment: str,
 ) -> ProposalRejected:
-    result_operation: Literal["add", "update", "supersede", "reject"]
-    result_operation = "reject" if tier == 1 else operation
-    return ProposalRejected(
-        ProposeDecisionResult(
-            status="rejected",
-            tier=tier,
-            operation=result_operation,
-            assessment=assessment,
-        )
-    )
+    from . import _commit_prepare
+
+    return _commit_prepare._rejected_result_impl(tier, operation, assessment)
 
 
 def _target(
@@ -841,49 +773,18 @@ def _target(
     decisions: list[Decision],
     stems_by_number: dict[int, str],
 ) -> tuple[Decision | None, str | None]:
-    if content.operation == "add":
-        return None, None
-    target_stem = content.affected_decision_id
-    assert target_stem is not None
-    target = next(
-        (decision for decision in decisions if stems_by_number[decision.num] == target_stem),
-        None,
-    )
-    if target is None:
-        raise _rejected_result(
-            1,
-            content.operation,
-            f"{content.operation} target {target_stem!r} not found in committed generation.",
-        )
-    return target, target_stem
+    from . import _commit_prepare
+
+    return _commit_prepare._target_impl(content, decisions, stems_by_number)
 
 
 def _provenance(
     payload: ApprovedPayload,
     attestation: ApprovalAttestation,
 ) -> tuple[str, DecisionProvenance | None]:
-    if isinstance(payload, HostedPreTeamApprovalPayloadV1):
-        if not isinstance(attestation, PreTeamApprovalAttestation):
-            raise ApprovalAttestationRejected(
-                "pre-team payload requires pre-team approval attestation."
-            )
-        return attestation.request_received_at, None
-    if not isinstance(attestation, TeamRatificationAttestation):
-        raise ApprovalAttestationRejected("team payload requires team ratification attestation.")
-    if payload.contributor_operation_id == attestation.ratification_action_id:
-        raise ApprovalAttestationRejected(
-            "team contributor_operation_id and ratification_action_id must be distinct."
-        )
-    return (
-        attestation.approved_at,
-        DecisionProvenance(
-            proposed_by=payload.proposed_by,
-            approved_by=attestation.approved_by,
-            approved_at=attestation.approved_at,
-            proposal_id=payload.proposal_id,
-            proposed_base_commit=payload.proposed_base_commit,
-        ),
-    )
+    from . import _commit_prepare
+
+    return _commit_prepare._provenance_impl(payload, attestation)
 
 
 def _derive_snapshot_bytes(
@@ -892,28 +793,13 @@ def _derive_snapshot_bytes(
     payload: ApprovedPayload,
     effective_at: str,
 ) -> bytes:
-    snapshot_files = {
-        artifact.path: artifact.content.decode("utf-8")
-        for artifact in artifacts
-        if is_hosted_snapshot_content_member(artifact.path)
-    }
-    title = payload.content.title or ""
-    trigger = {
-        "add": f"decision: {title}",
-        "update": "update: ",
-        "supersede": f"supersede: {title}",
-    }[payload.content.operation]
-    snapshot = serialize_snapshot(
-        timestamp=effective_at,
-        trigger=trigger,
-        files=dict(sorted(snapshot_files.items())),
+    from . import _commit_prepare
+
+    return _commit_prepare._derive_snapshot_bytes_impl(
+        artifacts,
+        payload=payload,
+        effective_at=effective_at,
     )
-    return json.dumps(
-        snapshot,
-        separators=(",", ":"),
-        ensure_ascii=False,
-        allow_nan=False,
-    ).encode("utf-8")
 
 
 def _build_artifacts(
@@ -935,97 +821,18 @@ def _build_artifacts(
     int,
     Decision,
 ]:
-    content = payload.content
-    decision_date = date.fromisoformat(effective_at[:10])
-    assigned = (
-        generation.decision_counter + 1 if content.operation in ("add", "supersede") else None
-    )
-    new_counter = generation.decision_counter + (1 if assigned is not None else 0)
-    planned = dict(current)
+    from . import _commit_prepare
 
-    rejected = tuple(
-        RejectedAlternative(name=item.alternative, reason=item.reason) for item in content.rejected
+    return _commit_prepare._build_artifacts_impl(
+        payload=payload,
+        provenance=provenance,
+        effective_at=effective_at,
+        generation=generation,
+        current=current,
+        evaluation=evaluation,
+        target=target,
+        target_stem=target_stem,
     )
-    if content.operation == "update":
-        assert target is not None and target_stem is not None
-        primary_model = append_decision_update(
-            target,
-            additional_rationale=content.rationale,
-            update_date=decision_date,
-            provenance=provenance,
-        )
-        primary_stem = target_stem
-        primary_path = f"decisions/{primary_stem}.md"
-        planned[primary_path] = format_decision(primary_model).encode("utf-8")
-        touched = [primary_stem]
-    else:
-        assert (
-            assigned is not None and content.title is not None and content.confidence is not None
-        )
-        primary_model = build_new_decision(
-            number=assigned,
-            decision_date=decision_date,
-            title=content.title,
-            rationale=content.rationale,
-            confidence=DecisionConfidence(content.confidence),
-            decision_type=DecisionType(content.decision_type) if content.decision_type else None,
-            reversibility=Reversibility(content.reversibility) if content.reversibility else None,
-            source=DecisionSource.mcp,
-            files_affected=content.files_affected,
-            rejected=rejected,
-            provenance=provenance,
-        )
-        if content.operation == "supersede":
-            assert target is not None and target_stem is not None
-            primary_model = attach_supersedes(primary_model, target.num)
-        primary_stem = (
-            f"{_decision_number_prefix(assigned)}{slugify_decision_title(content.title)}"
-        )
-        primary_path = f"decisions/{primary_stem}.md"
-        planned[primary_path] = format_decision(primary_model).encode("utf-8")
-        touched = [primary_stem]
-        if content.operation == "supersede":
-            assert target is not None and target_stem is not None
-            old_path = f"decisions/{target_stem}.md"
-            planned[old_path] = format_decision(mark_superseded(target, assigned)).encode("utf-8")
-            touched.append(target_stem)
-
-    questions_path = "open-questions.md"
-    questions_body = planned.get(questions_path, b"").decode("utf-8")
-    resolution = resolve_questions_content(
-        questions_body,
-        question_ids=content.resolves_questions,
-        decision_number=primary_model.num,
-        resolved_date=decision_date,
-    )
-    if content.resolves_questions:
-        planned[questions_path] = resolution.content.encode("utf-8")
-
-    result = ProposeDecisionResult(
-        status="confirmed",
-        tier=2,
-        operation=content.operation,
-        assessment=evaluation.assessment,
-        similar_decisions=list(evaluation.similar_decisions),
-        decision_id=primary_stem,
-        touched_decisions=touched,
-        resolved_questions=list(resolution.resolved_ids),
-        relocated_ids=resolution.relocated_ids or None,
-        skipped_prose_ids=resolution.skipped_prose_ids or None,
-    )
-    artifacts = tuple(
-        PlannedArtifact(path=path, content=body) for path, body in sorted(planned.items())
-    )
-    snapshot = PlannedSnapshot(
-        content=_derive_snapshot_bytes(artifacts, payload=payload, effective_at=effective_at)
-    )
-    primary_bytes = planned[primary_path]
-    primary = PrimaryDecision(
-        decision_id=primary_stem,
-        path=primary_path,
-        sha256=_sha256(primary_bytes),
-    )
-    return artifacts, snapshot, primary, result, assigned, new_counter, primary_model
 
 
 def _claim_contract(
@@ -1033,131 +840,9 @@ def _claim_contract(
     target: Decision | None,
     primary: Decision,
 ) -> tuple[tuple[ClaimProbe, ...], ClaimIntents]:
-    new_number = primary.num
-    new_title = normalize_title(primary.title)
-    content_hash = compute_hash(primary.title, primary.rationale)
-    content_probe = AbsentContentClaimProbe(content_hash=content_hash)
-    acquire_content = ClaimIntent(kind="acquire_new_content_hash", content_hash=content_hash)
-    commit_content = ClaimIntent(kind="commit_content_hash", content_hash=content_hash)
-    if operation == "add":
-        probes: tuple[ClaimProbe, ...] = (
-            AbsentTitleClaimProbe(normalized_title=new_title),
-            content_probe,
-        )
-        intents = ClaimIntents(
-            entry=(
-                ClaimIntent(
-                    kind="acquire_new_title",
-                    normalized_title=new_title,
-                    owner_decision_number=new_number,
-                ),
-                acquire_content,
-            ),
-            publication=(
-                ClaimIntent(
-                    kind="commit_title_owner",
-                    normalized_title=new_title,
-                    owner_decision_number=new_number,
-                ),
-                commit_content,
-            ),
-        )
-        return probes, intents
-    assert target is not None
-    old_title = normalize_title(target.title)
-    if operation == "update":
-        probes = (
-            OwnedTitleClaimProbe(
-                normalized_title=old_title,
-                expected_owner_decision_number=target.num,
-            ),
-            content_probe,
-        )
-        intents = ClaimIntents(
-            entry=(
-                ClaimIntent(
-                    kind="hold_owned_title",
-                    normalized_title=old_title,
-                    owner_decision_number=target.num,
-                ),
-                acquire_content,
-            ),
-            publication=(
-                ClaimIntent(
-                    kind="retain_title_owner",
-                    normalized_title=old_title,
-                    owner_decision_number=target.num,
-                ),
-                commit_content,
-            ),
-        )
-        return probes, intents
-    if new_title == old_title:
-        probes = (
-            OwnedTitleClaimProbe(
-                normalized_title=old_title,
-                expected_owner_decision_number=target.num,
-            ),
-            content_probe,
-        )
-        intents = ClaimIntents(
-            entry=(
-                ClaimIntent(
-                    kind="acquire_title_transfer",
-                    normalized_title=old_title,
-                    from_owner_decision_number=target.num,
-                    to_owner_decision_number=new_number,
-                ),
-                acquire_content,
-            ),
-            publication=(
-                ClaimIntent(
-                    kind="transfer_title_owner",
-                    normalized_title=old_title,
-                    from_owner_decision_number=target.num,
-                    to_owner_decision_number=new_number,
-                ),
-                commit_content,
-            ),
-        )
-        return probes, intents
-    probes = (
-        OwnedTitleClaimProbe(
-            normalized_title=old_title,
-            expected_owner_decision_number=target.num,
-        ),
-        AbsentTitleClaimProbe(normalized_title=new_title),
-        content_probe,
-    )
-    intents = ClaimIntents(
-        entry=(
-            ClaimIntent(
-                kind="hold_owned_title",
-                normalized_title=old_title,
-                owner_decision_number=target.num,
-            ),
-            ClaimIntent(
-                kind="acquire_new_title",
-                normalized_title=new_title,
-                owner_decision_number=new_number,
-            ),
-            acquire_content,
-        ),
-        publication=(
-            ClaimIntent(
-                kind="release_title_owner",
-                normalized_title=old_title,
-                owner_decision_number=target.num,
-            ),
-            ClaimIntent(
-                kind="commit_title_owner",
-                normalized_title=new_title,
-                owner_decision_number=new_number,
-            ),
-            commit_content,
-        ),
-    )
-    return probes, intents
+    from . import _commit_prepare
+
+    return _commit_prepare._claim_contract_impl(operation, target, primary)
 
 
 def prepare_judgment_commit(
@@ -1167,204 +852,47 @@ def prepare_judgment_commit(
     expected_payload_digest: str | None = None,
 ) -> PreparedJudgmentCommit:
     """Prepare immutable artifacts and semantic claim reads without I/O."""
-    payload_bytes = bytes(payload_bytes)
-    digest = _sha256(payload_bytes)
-    if expected_payload_digest is not None:
-        _validate_sha256(expected_payload_digest, field="expected_payload_digest")
-        if digest != expected_payload_digest:
-            raise ApprovedPayloadDigestMismatch(
-                "expected payload digest does not match approved payload bytes."
-            )
-    payload = _parse_payload(payload_bytes)
-    if (
-        payload.base_generation_id != committed_generation.generation_id
-        or payload.base_decision_counter != committed_generation.decision_counter
-    ):
-        raise ApprovedBaseStale(
-            "approved base generation and counter do not match the observed committed generation."
-        )
-    current, decisions, stems_by_number = _parse_committed_generation(committed_generation)
-    target, target_stem = _target(payload.content, decisions, stems_by_number)
-    questions_bytes = current.get("open-questions.md")
-    proposal = {
-        "title": payload.content.title,
-        "rationale": payload.content.rationale,
-        "rejected": [
-            {"alternative": value.alternative, "reason": value.reason}
-            for value in payload.content.rejected
-        ],
-        "confidence": payload.content.confidence,
-        "decision_type": payload.content.decision_type,
-        "reversibility": payload.content.reversibility,
-        "files_affected": list(payload.content.files_affected),
-        "resolves_questions": list(payload.content.resolves_questions),
-        "source": DecisionSource.mcp.value,
-        "base_commit": None,
-    }
-    questions_file = (
-        OpenQuestionsFile.parse(questions_bytes.decode("utf-8"))
-        if questions_bytes is not None and payload.content.resolves_questions
-        else None
-    )
-    request_rejection = validate_proposal_request(
-        proposal,
-        operation=payload.content.operation,
-        questions_file=questions_file,
-    )
-    if request_rejection is not None:
-        raise ProposalRejected(request_rejection)
-    evaluation = evaluate_parsed_proposal(
-        proposal,
-        operation=payload.content.operation,
-        decisions=decisions,
-        existing_hashes=set(),
-        affected_number=target.num if target is not None else None,
-        enforce_claim_conflicts=False,
-    )
-    if isinstance(evaluation, ProposeDecisionResult):
-        raise ProposalRejected(evaluation)
-    effective_at, provenance = _provenance(payload, approval_attestation)
-    artifacts, snapshot, primary, result, assigned, new_counter, primary_model = _build_artifacts(
-        payload=payload,
-        provenance=provenance,
-        effective_at=effective_at,
-        generation=committed_generation,
-        current=current,
-        evaluation=evaluation,
-        target=target,
-        target_stem=target_stem,
-    )
-    probes, intents = _claim_contract(payload.content.operation, target, primary_model)
-    return PreparedJudgmentCommit(
-        payload_bytes=payload_bytes,
-        payload_digest=digest,
-        payload=payload,
-        approval_attestation=approval_attestation,
-        base=PreparedBase(
-            generation_id=committed_generation.generation_id,
-            decision_counter=committed_generation.decision_counter,
-            observed_manifest_digest=committed_generation.observed_manifest_digest,
-        ),
-        effective_at=effective_at,
-        decision_provenance=provenance,
-        assigned_decision_number=assigned,
-        new_decision_counter=new_counter,
-        planned_artifacts=artifacts,
-        snapshot=snapshot,
-        primary_decision=primary,
-        claim_probes=probes,
-        claim_intents=intents,
-        result_projection=_CommittedResultProjection.from_result(result),
+    from . import _commit_prepare
+
+    return _commit_prepare.prepare_judgment_commit_impl(
+        payload_bytes,
+        approval_attestation,
+        committed_generation,
+        expected_payload_digest,
     )
 
 
 def _probe_key(probe: ClaimProbe) -> tuple[str, str]:
-    if isinstance(probe, AbsentContentClaimProbe):
-        return ("content", probe.content_hash)
-    return ("title", probe.normalized_title)
+    from . import _commit_finalize
+
+    return _commit_finalize._probe_key_impl(probe)
 
 
 def _observation_key(observation: ClaimObservation) -> tuple[str, str]:
-    if isinstance(
-        observation,
-        (
-            AbsentContentClaimObservation,
-            CommittedContentClaimObservation,
-            UnavailableContentClaimObservation,
-        ),
-    ):
-        return ("content", observation.content_hash)
-    return ("title", observation.normalized_title)
+    from . import _commit_finalize
+
+    return _commit_finalize._observation_key_impl(observation)
 
 
 def _validate_observation(probe: ClaimProbe, observation: ClaimObservation) -> None:
-    if isinstance(
-        observation, (UnavailableTitleClaimObservation, UnavailableContentClaimObservation)
-    ):
-        raise ClaimUnavailable(f"claim {_observation_key(observation)!r} is {observation.reason}.")
-    if isinstance(probe, AbsentTitleClaimProbe):
-        if isinstance(observation, AbsentTitleClaimObservation):
-            return
-        if isinstance(observation, CommittedTitleClaimObservation):
-            raise TitleClaimConflict(
-                "normalized title is already owned by decision "
-                f"{observation.owner_decision_number}."
-            )
-    elif isinstance(probe, OwnedTitleClaimProbe):
-        if isinstance(observation, CommittedTitleClaimObservation) and (
-            observation.owner_decision_number == probe.expected_owner_decision_number
-        ):
-            return
-        raise MismatchedClaimObservation(
-            "owned title claim does not match the expected committed owner."
-        )
-    elif isinstance(observation, AbsentContentClaimObservation):
-        return
-    elif isinstance(observation, CommittedContentClaimObservation):
-        raise ContentClaimConflict("content hash is already present in decision history.")
-    raise MismatchedClaimObservation("claim observation does not match its prepared probe.")
+    from . import _commit_finalize
+
+    return _commit_finalize._validate_observation_impl(probe, observation)
 
 
 def _artifact_inventory(prepared: PreparedJudgmentCommit) -> dict[str, object]:
-    descriptors = [
-        {"length": artifact.length, "path": artifact.path, "sha256": artifact.sha256}
-        for artifact in prepared.planned_artifacts
-    ]
-    inventory = {"artifacts": descriptors, "schema": "nauro.artifact_inventory.v1"}
-    inventory_bytes = canonical_judgment_payload_bytes(inventory)
-    return {
-        "artifact_count": len(descriptors),
-        "digest": _sha256(inventory_bytes),
-        "schema": "nauro.artifact_inventory.v1",
-        "total_byte_count": sum(descriptor["length"] for descriptor in descriptors),
-    }
+    from . import _commit_finalize
+
+    return _commit_finalize._artifact_inventory_impl(prepared)
 
 
 def _plan_record(
     prepared: PreparedJudgmentCommit,
     observations: tuple[ClaimObservation, ...],
 ) -> bytes:
-    content = prepared.payload.content
-    provenance = (
-        {
-            "approved_at": prepared.decision_provenance.approved_at,
-            "approved_by": prepared.decision_provenance.approved_by,
-            "proposal_id": prepared.decision_provenance.proposal_id,
-            "proposed_base_commit": prepared.decision_provenance.proposed_base_commit,
-            "proposed_by": prepared.decision_provenance.proposed_by,
-        }
-        if prepared.decision_provenance is not None
-        else None
-    )
-    record = {
-        "affected_decision_id": content.affected_decision_id,
-        "approval_mode": prepared.payload.approval_mode,
-        "approval": prepared.approval_attestation.model_dump(mode="json"),
-        "artifact_inventory": _artifact_inventory(prepared),
-        "base": prepared.base.model_dump(mode="json"),
-        "claim_plan": {
-            "entry": [value.model_dump(mode="json") for value in prepared.claim_intents.entry],
-            "observations": [value.model_dump(mode="json") for value in observations],
-            "probes": [value.model_dump(mode="json") for value in prepared.claim_probes],
-            "publication": [
-                value.model_dump(mode="json") for value in prepared.claim_intents.publication
-            ],
-        },
-        "committed_result": prepared.committed_result.model_dump(mode="json"),
-        "decision_provenance": provenance,
-        "new_decision_counter": prepared.new_decision_counter,
-        "operation": content.operation,
-        "payload_digest": prepared.payload_digest,
-        "payload_schema": prepared.payload.payload_schema,
-        "primary_decision": prepared.primary_decision.model_dump(mode="json"),
-        "record_schema": "nauro.judgment_commit.plan_record.v1",
-        "snapshot": {
-            "length": prepared.snapshot.length,
-            "sha256": prepared.snapshot.sha256,
-        },
-        "transform_version": prepared.transformation_version,
-    }
-    return canonical_judgment_payload_bytes(record)
+    from . import _commit_finalize
+
+    return _commit_finalize._plan_record_impl(prepared, observations)
 
 
 def finalize_judgment_commit(
@@ -1372,36 +900,6 @@ def finalize_judgment_commit(
     claim_observations: Sequence[ClaimObservation | Mapping[str, object]],
 ) -> JudgmentCommitPlan:
     """Validate claim observations and finalize the storage-neutral plan."""
-    parsed: list[ClaimObservation] = []
-    for raw in claim_observations:
-        try:
-            parsed.append(_OBSERVATION_ADAPTER.validate_python(raw))
-        except ValidationError as exc:
-            raise MalformedClaimObservation("claim observation is malformed.") from exc
-    observed_by_key: dict[tuple[str, str], ClaimObservation] = {}
-    for observation in parsed:
-        key = _observation_key(observation)
-        if key in observed_by_key:
-            raise DuplicateClaimObservation(f"duplicate claim observation for {key!r}.")
-        observed_by_key[key] = observation
-    probe_keys = {_probe_key(probe) for probe in prepared.claim_probes}
-    extra = set(observed_by_key) - probe_keys
-    if extra:
-        raise UnexpectedClaimObservation(f"unexpected claim observation(s): {sorted(extra)!r}.")
-    missing = probe_keys - set(observed_by_key)
-    if missing:
-        raise MissingClaimObservation(f"missing claim observation(s): {sorted(missing)!r}.")
-    ordered = tuple(observed_by_key[_probe_key(probe)] for probe in prepared.claim_probes)
-    for probe, observation in zip(prepared.claim_probes, ordered, strict=True):
-        _validate_observation(probe, observation)
-    claim_plan = FinalizedClaimPlan(
-        entry=prepared.claim_intents.entry,
-        publication=prepared.claim_intents.publication,
-    )
-    record_bytes = _plan_record(prepared, ordered)
-    return JudgmentCommitPlan(
-        prepared=prepared,
-        validated_claim_observations=ordered,
-        claim_plan=claim_plan,
-        plan_record_bytes=record_bytes,
-    )
+    from . import _commit_finalize
+
+    return _commit_finalize.finalize_judgment_commit_impl(prepared, claim_observations)

--- a/packages/nauro-core/tests/operations/test_commit_plan.py
+++ b/packages/nauro-core/tests/operations/test_commit_plan.py
@@ -815,3 +815,772 @@ def test_final_plan_constructor_rejects_tampered_record_bytes() -> None:
     fields["plan_record_bytes"] = b"{}"
     with pytest.raises(ValidationError, match="plan record bytes"):
         plan.__class__(**fields)
+
+
+_FACADE_NAME_MANIFEST = (
+    "AbsentContentClaimObservation",
+    "AbsentContentClaimProbe",
+    "AbsentTitleClaimObservation",
+    "AbsentTitleClaimProbe",
+    "Annotated",
+    "ApprovalAttestation",
+    "ApprovalAttestationRejected",
+    "ApprovedBaseStale",
+    "ApprovedPayload",
+    "ApprovedPayloadDigestMismatch",
+    "BaseModel",
+    "CanonicalPayloadRejected",
+    "ClaimIntent",
+    "ClaimIntents",
+    "ClaimObservation",
+    "ClaimObservationError",
+    "ClaimProbe",
+    "ClaimUnavailable",
+    "CommittedArtifact",
+    "CommittedContentClaimObservation",
+    "CommittedGeneration",
+    "CommittedGenerationCorrupt",
+    "CommittedTitleClaimObservation",
+    "ConfigDict",
+    "ContentClaimConflict",
+    "Decision",
+    "DecisionConfidence",
+    "DecisionProvenance",
+    "DecisionSource",
+    "DecisionType",
+    "DuplicateClaimObservation",
+    "ErrorPayload",
+    "Field",
+    "FinalizedClaimPlan",
+    "HostedPreTeamApprovalPayloadV1",
+    "IdentifierKind",
+    "JudgmentCommitError",
+    "JudgmentCommitPlan",
+    "JudgmentContent",
+    "Literal",
+    "MAX_RATIONALE_LENGTH",
+    "MAX_TITLE_LENGTH",
+    "MalformedClaimObservation",
+    "Mapping",
+    "MismatchedClaimObservation",
+    "MissingClaimObservation",
+    "OpenQuestionsFile",
+    "OwnedTitleClaimProbe",
+    "PlannedArtifact",
+    "PlannedSnapshot",
+    "PreTeamApprovalAttestation",
+    "PreparedBase",
+    "PreparedJudgmentCommit",
+    "PrimaryDecision",
+    "ProposalEvaluation",
+    "ProposalRejected",
+    "ProposeDecisionResult",
+    "RejectedAlternative",
+    "RejectedSelection",
+    "RelatedDecision",
+    "Reversibility",
+    "Sequence",
+    "StrictInt",
+    "StrictStr",
+    "TeamProposalPayloadV1",
+    "TeamRatificationAttestation",
+    "TitleClaimConflict",
+    "TypeAdapter",
+    "TypeAlias",
+    "UnavailableContentClaimObservation",
+    "UnavailableTitleClaimObservation",
+    "UnexpectedClaimObservation",
+    "ValidationError",
+    "_CommittedResultProjection",
+    "_FrozenModel",
+    "_ImmutableResultList",
+    "_OBSERVATION_ADAPTER",
+    "_PAYLOAD_ADAPTER",
+    "_SHA256_HEX_LENGTH",
+    "_artifact_inventory",
+    "_build_artifacts",
+    "_claim_contract",
+    "_decision_number_prefix",
+    "_derive_snapshot_bytes",
+    "_observation_key",
+    "_parse_committed_generation",
+    "_parse_payload",
+    "_plan_record",
+    "_probe_key",
+    "_provenance",
+    "_reject_duplicate_keys",
+    "_rejected_result",
+    "_sha256",
+    "_target",
+    "_validate_normalized_title",
+    "_validate_observation",
+    "_validate_sha256",
+    "annotations",
+    "append_decision_update",
+    "attach_supersedes",
+    "build_new_decision",
+    "canonical_judgment_payload_bytes",
+    "compute_hash",
+    "computed_field",
+    "date",
+    "evaluate_parsed_proposal",
+    "field_validator",
+    "finalize_judgment_commit",
+    "format_decision",
+    "hashlib",
+    "is_hosted_snapshot_content_member",
+    "json",
+    "mark_superseded",
+    "model_validator",
+    "normalize_title",
+    "parse_decision",
+    "prepare_judgment_commit",
+    "resolve_questions_content",
+    "serialize_snapshot",
+    "slugify_decision_title",
+    "validate_commit_sha",
+    "validate_identifier",
+    "validate_proposal_request",
+    "validate_protected_generation_path",
+    "validate_utc_timestamp",
+)
+
+_FACADE_DEFINED_CLASSES = (
+    "AbsentContentClaimObservation",
+    "AbsentContentClaimProbe",
+    "AbsentTitleClaimObservation",
+    "AbsentTitleClaimProbe",
+    "ApprovalAttestationRejected",
+    "ApprovedBaseStale",
+    "ApprovedPayloadDigestMismatch",
+    "CanonicalPayloadRejected",
+    "ClaimIntent",
+    "ClaimIntents",
+    "ClaimObservationError",
+    "ClaimUnavailable",
+    "CommittedArtifact",
+    "CommittedContentClaimObservation",
+    "CommittedGeneration",
+    "CommittedGenerationCorrupt",
+    "CommittedTitleClaimObservation",
+    "ContentClaimConflict",
+    "DuplicateClaimObservation",
+    "FinalizedClaimPlan",
+    "HostedPreTeamApprovalPayloadV1",
+    "JudgmentCommitError",
+    "JudgmentCommitPlan",
+    "JudgmentContent",
+    "MalformedClaimObservation",
+    "MismatchedClaimObservation",
+    "MissingClaimObservation",
+    "OwnedTitleClaimProbe",
+    "PlannedArtifact",
+    "PlannedSnapshot",
+    "PreTeamApprovalAttestation",
+    "PreparedBase",
+    "PreparedJudgmentCommit",
+    "PrimaryDecision",
+    "ProposalRejected",
+    "RejectedSelection",
+    "TeamProposalPayloadV1",
+    "TeamRatificationAttestation",
+    "TitleClaimConflict",
+    "UnavailableContentClaimObservation",
+    "UnavailableTitleClaimObservation",
+    "UnexpectedClaimObservation",
+    "_CommittedResultProjection",
+    "_FrozenModel",
+    "_ImmutableResultList",
+)
+
+_FACADE_DEFINED_FUNCTIONS = (
+    "_artifact_inventory",
+    "_build_artifacts",
+    "_claim_contract",
+    "_derive_snapshot_bytes",
+    "_observation_key",
+    "_parse_committed_generation",
+    "_parse_payload",
+    "_plan_record",
+    "_probe_key",
+    "_provenance",
+    "_reject_duplicate_keys",
+    "_rejected_result",
+    "_sha256",
+    "_target",
+    "_validate_normalized_title",
+    "_validate_observation",
+    "_validate_sha256",
+    "canonical_judgment_payload_bytes",
+    "finalize_judgment_commit",
+    "prepare_judgment_commit",
+)
+
+_MOVED_FUNCTION_METADATA = {
+    "_reject_duplicate_keys": ("(pairs: 'list[tuple[str, object]]') -> 'dict[str, object]'", None),
+    "_parse_payload": ("(payload_bytes: 'bytes') -> 'ApprovedPayload'", None),
+    "_parse_committed_generation": (
+        "(generation: 'CommittedGeneration') -> "
+        "'tuple[dict[str, bytes], list[Decision], dict[int, str]]'",
+        None,
+    ),
+    "_rejected_result": (
+        "(tier: 'int', operation: \"Literal['add', 'update', 'supersede']\", "
+        "assessment: 'str') -> 'ProposalRejected'",
+        None,
+    ),
+    "_target": (
+        "(content: 'JudgmentContent', decisions: 'list[Decision]', "
+        "stems_by_number: 'dict[int, str]') -> 'tuple[Decision | None, str | None]'",
+        None,
+    ),
+    "_provenance": (
+        "(payload: 'ApprovedPayload', attestation: 'ApprovalAttestation') -> "
+        "'tuple[str, DecisionProvenance | None]'",
+        None,
+    ),
+    "_derive_snapshot_bytes": (
+        "(artifacts: 'tuple[PlannedArtifact, ...]', *, payload: 'ApprovedPayload', "
+        "effective_at: 'str') -> 'bytes'",
+        None,
+    ),
+    "_build_artifacts": (
+        "(*, payload: 'ApprovedPayload', provenance: 'DecisionProvenance | None', "
+        "effective_at: 'str', generation: 'CommittedGeneration', current: 'dict[str, bytes]', "
+        "evaluation: 'ProposalEvaluation', target: 'Decision | None', "
+        "target_stem: 'str | None') -> 'tuple[tuple[PlannedArtifact, ...], PlannedSnapshot, "
+        "PrimaryDecision, ProposeDecisionResult, int | None, int, Decision]'",
+        None,
+    ),
+    "_claim_contract": (
+        "(operation: 'str', target: 'Decision | None', primary: 'Decision') -> "
+        "'tuple[tuple[ClaimProbe, ...], ClaimIntents]'",
+        None,
+    ),
+    "prepare_judgment_commit": (
+        "(payload_bytes: 'bytes', approval_attestation: 'ApprovalAttestation', "
+        "committed_generation: 'CommittedGeneration', expected_payload_digest: 'str | None' = "
+        "None) -> 'PreparedJudgmentCommit'",
+        "Prepare immutable artifacts and semantic claim reads without I/O.",
+    ),
+    "_probe_key": ("(probe: 'ClaimProbe') -> 'tuple[str, str]'", None),
+    "_observation_key": (
+        "(observation: 'ClaimObservation') -> 'tuple[str, str]'",
+        None,
+    ),
+    "_validate_observation": (
+        "(probe: 'ClaimProbe', observation: 'ClaimObservation') -> 'None'",
+        None,
+    ),
+    "_artifact_inventory": (
+        "(prepared: 'PreparedJudgmentCommit') -> 'dict[str, object]'",
+        None,
+    ),
+    "_plan_record": (
+        "(prepared: 'PreparedJudgmentCommit', observations: "
+        "'tuple[ClaimObservation, ...]') -> 'bytes'",
+        None,
+    ),
+    "finalize_judgment_commit": (
+        "(prepared: 'PreparedJudgmentCommit', claim_observations: "
+        "'Sequence[ClaimObservation | Mapping[str, object]]') -> 'JudgmentCommitPlan'",
+        "Validate claim observations and finalize the storage-neutral plan.",
+    ),
+}
+
+
+def _observations_for(prepared):
+    import nauro_core.operations.commit_plan as contract
+
+    observations = []
+    for probe in prepared.claim_probes:
+        if isinstance(probe, contract.AbsentTitleClaimProbe):
+            observations.append(
+                contract.AbsentTitleClaimObservation(normalized_title=probe.normalized_title)
+            )
+        elif isinstance(probe, contract.OwnedTitleClaimProbe):
+            observations.append(
+                contract.CommittedTitleClaimObservation(
+                    normalized_title=probe.normalized_title,
+                    owner_decision_number=probe.expected_owner_decision_number,
+                )
+            )
+        else:
+            observations.append(
+                contract.AbsentContentClaimObservation(content_hash=probe.content_hash)
+            )
+    return observations
+
+
+def test_commit_plan_facade_manifest_and_module_identity_are_stable() -> None:
+    import inspect
+
+    import nauro_core.operations.commit_plan as contract
+    from nauro_core.operations import _commit_finalize, _commit_prepare
+
+    assert tuple(sorted(name for name in vars(contract) if not name.startswith("__"))) == (
+        _FACADE_NAME_MANIFEST
+    )
+    for name in _FACADE_DEFINED_CLASSES + _FACADE_DEFINED_FUNCTIONS:
+        assert getattr(contract, name).__module__ == contract.__name__
+    for private_module in (_commit_prepare, _commit_finalize):
+        assert not [
+            name
+            for name, value in vars(private_module).items()
+            if inspect.isclass(value) and value.__module__ == private_module.__name__
+        ]
+
+
+def test_commit_plan_moved_function_metadata_is_stable() -> None:
+    import inspect
+
+    import nauro_core.operations.commit_plan as contract
+
+    actual = {
+        name: (
+            str(inspect.signature(getattr(contract, name))),
+            inspect.getdoc(getattr(contract, name)),
+        )
+        for name in _MOVED_FUNCTION_METADATA
+    }
+    assert actual == _MOVED_FUNCTION_METADATA
+
+
+def test_commit_plan_representative_pickle_identity_is_stable() -> None:
+    import pickle
+
+    import nauro_core.operations.commit_plan as contract
+
+    values = (
+        contract.PreparedJudgmentCommit,
+        contract.JudgmentCommitPlan,
+        contract.CanonicalPayloadRejected,
+        contract.prepare_judgment_commit,
+        contract.finalize_judgment_commit,
+    )
+    for value in values:
+        assert pickle.loads(pickle.dumps(value)) is value
+
+
+def _contract_json_value(value):
+    import enum
+    import math
+
+    if value is None or isinstance(value, (bool, int, str)):
+        return value
+    if isinstance(value, float):
+        assert math.isfinite(value)
+        return value
+    if isinstance(value, bytes):
+        return {"kind": "bytes", "hex": value.hex()}
+    if isinstance(value, enum.Enum):
+        return {
+            "kind": "enum",
+            "type": f"{type(value).__module__}.{type(value).__qualname__}",
+            "value": _contract_json_value(value.value),
+        }
+    if isinstance(value, (list, tuple)):
+        return [_contract_json_value(item) for item in value]
+    if isinstance(value, dict):
+        assert all(isinstance(key, str) for key in value)
+        return {key: _contract_json_value(value[key]) for key in sorted(value)}
+    if isinstance(value, type):
+        return {"kind": "type", "module": value.__module__, "qualname": value.__qualname__}
+    raise AssertionError(f"unsupported contract value type: {type(value).__name__}")
+
+
+def _contract_annotation_metadata(value):
+    from annotated_types import Ge, Gt, Le, Lt, MaxLen, MinLen, MultipleOf
+    from pydantic.fields import FieldInfo
+    from pydantic.types import Strict
+
+    if isinstance(value, FieldInfo):
+        return {"kind": "field_info", "state": _contract_field_info_state(value)}
+    constraint_types = (
+        (Strict, "strict", "strict"),
+        (Gt, "gt", "gt"),
+        (Ge, "ge", "ge"),
+        (Lt, "lt", "lt"),
+        (Le, "le", "le"),
+        (MinLen, "min_length", "min_length"),
+        (MaxLen, "max_length", "max_length"),
+        (MultipleOf, "multiple_of", "multiple_of"),
+    )
+    for metadata_type, kind, attribute in constraint_types:
+        if isinstance(value, metadata_type):
+            return {"kind": kind, "value": _contract_json_value(getattr(value, attribute))}
+    raise AssertionError(f"unsupported annotation metadata: {type(value).__name__}")
+
+
+def _contract_alias(value):
+    from pydantic.aliases import AliasChoices, AliasPath
+
+    if isinstance(value, str):
+        return value
+    if isinstance(value, AliasPath):
+        return {"kind": "path", "path": [_contract_json_value(item) for item in value.path]}
+    if isinstance(value, AliasChoices):
+        return {
+            "kind": "choices",
+            "choices": [_contract_alias(choice) for choice in value.choices],
+        }
+    raise AssertionError(f"unsupported field alias: {type(value).__name__}")
+
+
+def _contract_field_info_state(field):
+    metadata = [_contract_annotation_metadata(value) for value in field.metadata]
+    metadata.sort(
+        key=lambda value: json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            allow_nan=False,
+        )
+    )
+    state = {
+        "metadata": metadata,
+    }
+    if field.discriminator is not None:
+        assert isinstance(field.discriminator, str)
+        state["discriminator"] = field.discriminator
+    for name in ("alias", "validation_alias", "serialization_alias"):
+        value = getattr(field, name)
+        if value is not None:
+            state[name] = _contract_alias(value)
+    return state
+
+
+def _contract_annotation(annotation):
+    import types
+    from typing import Annotated, Any, Literal, Union, get_args, get_origin
+
+    if annotation is Any:
+        return {"kind": "any"}
+    if annotation is None:
+        return {"kind": "none"}
+    origin = get_origin(annotation)
+    arguments = get_args(annotation)
+    if origin is Annotated:
+        return {
+            "kind": "annotated",
+            "annotation": _contract_annotation(arguments[0]),
+            "metadata": [_contract_annotation_metadata(value) for value in arguments[1:]],
+        }
+    if origin is Literal:
+        return {
+            "kind": "literal",
+            "values": [_contract_json_value(value) for value in arguments],
+        }
+    if origin in (types.UnionType, Union):
+        return {
+            "kind": "union",
+            "members": [_contract_annotation(value) for value in arguments],
+        }
+    if origin is not None:
+        return {
+            "kind": "generic",
+            "origin": _contract_annotation(origin),
+            "arguments": [_contract_annotation(value) for value in arguments],
+        }
+    if isinstance(annotation, type):
+        return {
+            "kind": "type",
+            "module": annotation.__module__,
+            "qualname": annotation.__qualname__,
+        }
+    if annotation is Ellipsis:
+        return {"kind": "ellipsis"}
+    raise AssertionError(f"unsupported contract annotation: {type(annotation).__name__}")
+
+
+def _contract_default(field):
+    if field.is_required():
+        return {"kind": "required"}
+    if field.default_factory is not None:
+        factory = field.default_factory
+        return {
+            "kind": "factory",
+            "module": factory.__module__,
+            "qualname": factory.__qualname__,
+        }
+    return {"kind": "value", "value": _contract_json_value(field.default)}
+
+
+def _facade_model_contract_projection(contract):
+    from typing import get_type_hints
+
+    from pydantic import BaseModel
+
+    config_keys = (
+        "extra",
+        "from_attributes",
+        "frozen",
+        "populate_by_name",
+        "strict",
+        "use_enum_values",
+        "validate_assignment",
+        "validate_by_alias",
+        "validate_by_name",
+        "validate_default",
+    )
+    models = []
+    for name, model in sorted(vars(contract).items()):
+        if not (
+            isinstance(model, type)
+            and issubclass(model, BaseModel)
+            and model.__module__ == contract.__name__
+        ):
+            continue
+        type_hints = get_type_hints(model, include_extras=True)
+        models.append(
+            {
+                "name": name,
+                "module": model.__module__,
+                "fields": [
+                    {
+                        "name": field_name,
+                        "annotation": _contract_annotation(type_hints[field_name]),
+                        "field_info": _contract_field_info_state(field),
+                        "required": field.is_required(),
+                        "default": _contract_default(field),
+                    }
+                    for field_name, field in model.model_fields.items()
+                ],
+                "model_config": {
+                    key: _contract_json_value(model.model_config[key])
+                    for key in config_keys
+                    if key in model.model_config
+                },
+            }
+        )
+    return models
+
+
+def test_commit_plan_facade_model_contract_digest_is_stable() -> None:
+    import nauro_core.operations.commit_plan as contract
+
+    projection = _facade_model_contract_projection(contract)
+    projection_bytes = json.dumps(
+        projection,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+    assert len(projection) == 28
+    models = {model["name"]: model for model in projection}
+    content_fields = {field["name"]: field for field in models["JudgmentContent"]["fields"]}
+    rationale = content_fields["rationale"]
+    assert rationale["annotation"] == {
+        "kind": "annotated",
+        "annotation": {"kind": "type", "module": "builtins", "qualname": "str"},
+        "metadata": [{"kind": "strict", "value": True}],
+    }
+    generation_fields = {field["name"]: field for field in models["CommittedGeneration"]["fields"]}
+    counter = generation_fields["decision_counter"]
+    assert counter["annotation"] == {
+        "kind": "annotated",
+        "annotation": {"kind": "type", "module": "builtins", "qualname": "int"},
+        "metadata": [{"kind": "strict", "value": True}],
+    }
+    assert {"kind": "strict", "value": True} in counter["field_info"]["metadata"]
+    assert {"kind": "ge", "value": 0} in counter["field_info"]["metadata"]
+    prepared_fields = {
+        field["name"]: field for field in models["PreparedJudgmentCommit"]["fields"]
+    }
+    payload = prepared_fields["payload"]
+    assert payload["field_info"]["discriminator"] == "payload_schema"
+    assert payload["annotation"]["kind"] == "annotated"
+    assert payload["annotation"]["annotation"]["kind"] == "union"
+    assert payload["annotation"]["metadata"] == [
+        {
+            "kind": "field_info",
+            "state": {"metadata": [], "discriminator": "payload_schema"},
+        }
+    ]
+    assert hashlib.sha256(projection_bytes).hexdigest() == (
+        "762393c65fc7098fb5835077de6a23815160845e02a5dd2ad9c2986bf0a8440a"
+    )
+
+
+@pytest.mark.parametrize("operation", ["add", "supersede"])
+def test_private_implementation_matches_facade_for_two_phase_plans(operation: str) -> None:
+    import nauro_core.operations.commit_plan as contract
+    from nauro_core.operations import _commit_finalize, _commit_prepare
+
+    if operation == "add":
+        generation = _generation(("project.md", b"# Test\n"), counter=4)
+        payload = _preteam_payload(generation)
+    else:
+        existing = _decision(3, "Existing decision")
+        generation = _generation(existing, counter=8)
+        target = existing[0].removeprefix("decisions/").removesuffix(".md")
+        payload = _preteam_payload(
+            generation,
+            operation="supersede",
+            target=target,
+            title="Replacement decision",
+        )
+    attestation = _preteam_attestation()
+    facade_prepared = contract.prepare_judgment_commit(payload, attestation, generation)
+    private_prepared = _commit_prepare.prepare_judgment_commit_impl(
+        payload,
+        attestation,
+        generation,
+    )
+
+    assert private_prepared == facade_prepared
+    assert private_prepared.payload_bytes == facade_prepared.payload_bytes
+    assert private_prepared.payload_digest == facade_prepared.payload_digest
+    assert private_prepared.planned_artifacts == facade_prepared.planned_artifacts
+    assert private_prepared.snapshot == facade_prepared.snapshot
+    assert private_prepared.claim_probes == facade_prepared.claim_probes
+    assert private_prepared.claim_intents == facade_prepared.claim_intents
+    assert private_prepared.committed_result == facade_prepared.committed_result
+
+    observations = _observations_for(facade_prepared)
+    facade_plan = contract.finalize_judgment_commit(
+        facade_prepared,
+        list(reversed(observations)),
+    )
+    private_plan = _commit_finalize.finalize_judgment_commit_impl(
+        private_prepared,
+        list(reversed(observations)),
+    )
+
+    assert private_plan == facade_plan
+    assert private_plan.validated_claim_observations == tuple(observations)
+    assert private_plan.claim_plan == facade_plan.claim_plan
+    assert private_plan.plan_record_bytes == facade_plan.plan_record_bytes
+    assert private_plan.plan_record_digest == facade_plan.plan_record_digest
+    assert private_plan.committed_result == facade_plan.committed_result
+
+
+def test_prepare_validation_precedence_survives_delegation(monkeypatch) -> None:
+    import nauro_core.operations.commit_plan as contract
+
+    generation = _generation(("project.md", b"# Test\n"), counter=2)
+    with pytest.raises(ApprovedPayloadDigestMismatch):
+        contract.prepare_judgment_commit(
+            b"not-json",
+            _preteam_attestation(),
+            generation,
+            expected_payload_digest="f" * 64,
+        )
+
+    raw = json.loads(_preteam_payload(generation))
+    raw["base_generation_id"] = PROPOSAL_ID
+    monkeypatch.setattr(
+        contract,
+        "_parse_committed_generation",
+        lambda value: pytest.fail("committed generation parsed before stale-base rejection"),
+    )
+    with pytest.raises(ApprovedBaseStale):
+        contract.prepare_judgment_commit(
+            canonical_judgment_payload_bytes(raw),
+            _preteam_attestation(),
+            generation,
+        )
+
+
+def test_finalize_validation_precedence_survives_delegation() -> None:
+    import nauro_core.operations.commit_plan as contract
+
+    generation = _generation(("project.md", b"# Test\n"))
+    prepared = contract.prepare_judgment_commit(
+        _preteam_payload(generation),
+        _preteam_attestation(),
+        generation,
+    )
+    title = prepared.claim_probes[0].normalized_title
+    content_hash = prepared.claim_probes[1].content_hash
+    title_observation = contract.AbsentTitleClaimObservation(normalized_title=title)
+    duplicate = [
+        title_observation,
+        title_observation,
+        contract.AbsentTitleClaimObservation(normalized_title="extra"),
+    ]
+
+    with pytest.raises(MalformedClaimObservation):
+        contract.finalize_judgment_commit(
+            prepared,
+            [title_observation, title_observation, {"kind": "wrong"}],
+        )
+    with pytest.raises(DuplicateClaimObservation):
+        contract.finalize_judgment_commit(prepared, duplicate)
+    with pytest.raises(UnexpectedClaimObservation):
+        contract.finalize_judgment_commit(
+            prepared,
+            [contract.AbsentTitleClaimObservation(normalized_title="extra")],
+        )
+    with pytest.raises(ClaimUnavailable):
+        contract.finalize_judgment_commit(
+            prepared,
+            [
+                contract.UnavailableTitleClaimObservation(
+                    normalized_title=title,
+                    reason="reserved",
+                ),
+                contract.CommittedContentClaimObservation(content_hash=content_hash),
+            ],
+        )
+    with pytest.raises(TitleClaimConflict):
+        contract.finalize_judgment_commit(
+            prepared,
+            [
+                contract.CommittedTitleClaimObservation(
+                    normalized_title=title,
+                    owner_decision_number=7,
+                ),
+                contract.UnavailableContentClaimObservation(
+                    content_hash=content_hash,
+                    reason="reserved",
+                ),
+            ],
+        )
+
+
+@pytest.mark.parametrize(
+    "module_order",
+    [
+        (
+            "nauro_core.operations.commit_plan",
+            "nauro_core.operations._commit_prepare",
+            "nauro_core.operations._commit_finalize",
+        ),
+        (
+            "nauro_core.operations._commit_prepare",
+            "nauro_core.operations._commit_finalize",
+            "nauro_core.operations.commit_plan",
+        ),
+    ],
+)
+def test_commit_plan_import_order_is_cycle_free_in_clean_subprocess(
+    module_order: tuple[str, ...],
+) -> None:
+    import importlib
+    import os
+    import subprocess
+    import sys
+
+    code = (
+        "import importlib, pickle\n"
+        f"modules = [importlib.import_module(name) for name in {module_order!r}]\n"
+        "contract = importlib.import_module('nauro_core.operations.commit_plan')\n"
+        "assert contract.PreparedJudgmentCommit.__module__ == contract.__name__\n"
+        "assert pickle.loads(pickle.dumps(contract.prepare_judgment_commit)) is "
+        "contract.prepare_judgment_commit\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=os.getcwd(),
+        env=os.environ.copy(),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert importlib.import_module("nauro_core.operations.commit_plan").PreparedJudgmentCommit is (
+        PreparedJudgmentCommit
+    )


### PR DESCRIPTION
## Why

The judgment-commit contract module combined stable contract definitions with preparation and finalization algorithms. Separating those algorithms makes each implementation area easier to review while preserving the existing contract identity and behavior.

## What changed

- Kept exceptions, models, validators, serializers, and stable callable names in `commit_plan`.
- Replaced moved function bodies with lazy facade wrappers.
- Moved preparation logic to `_commit_prepare`.
- Moved finalization logic to `_commit_finalize`.
- Kept private implementations dependent on facade-owned models, exceptions, adapters, and helper lookup.
- Added regression coverage for facade names, original type annotations, normalized public field metadata, signatures, module identity, pickle identity, import order, behavior parity, and validation precedence.

## Test plan

- Run the focused judgment-commit suite.
- Run all `nauro-core` and relevant local `nauro` tests.
- Run Ruff, import contracts, public-contract, consistency, and diff checks.
- Build both distribution wheels.
- Verify wheel contents, both import orders, pickle identity, and the installed-wheel stdio smoke test.

## Risk / what to review

The main risk is contract drift during the mechanical move. Review the lazy wrapper boundaries and facade-based helper lookup. Tests pin all 125 facade names, the stable contract projection for 28 models, strict annotations, public field constraints and discriminators, callable metadata, failure precedence, exact two-phase outputs, and installed-wheel identity.

## Deferred

This change does not add public exports, server consumers, dependency injection, behavior changes, or performance work.
