### PR TITLE
Write store files atomically

### DIFF
--- a/packages/nauro/src/nauro/store/_atomic.py
+++ b/packages/nauro/src/nauro/store/_atomic.py
@@ -2,10 +2,11 @@
 
 The single tmp-write-then-``os.replace`` primitive used by the control-plane
 JSON writers (``registry.json``, ``config.json``, per-repo ``config.json``), by
-the graph command for its rendered HTML, and by the sync pull for the remote
-bytes it lands. Durability scope is atomic-replace only: the rename is atomic on
-a single filesystem, so a reader never observes a partially written target.
-There is deliberately no ``fsync`` — that matches every existing call site, and
+``FilesystemStore.write_file`` for every store file, by the graph command for
+its rendered HTML, and by the sync pull for the remote bytes it lands.
+Durability scope is atomic-replace only: the rename is atomic on a single
+filesystem, so a reader never observes a partially written target. There is
+deliberately no ``fsync`` — that matches every existing call site, and
 crash-durability is an explicit non-goal here.
 
 The text and bytes entry points differ only in how they fill the tmp file. Both

--- a/packages/nauro/src/nauro/store/filesystem_store.py
+++ b/packages/nauro/src/nauro/store/filesystem_store.py
@@ -2,7 +2,8 @@
 
 Adapts the existing ``~/.nauro/projects/<name>/`` layout to the kernel's
 :class:`~nauro_core.operations.Store` protocol. Writes hold a per-target
-FileLock; reads are unlocked.
+FileLock and land atomically through :mod:`nauro.store._atomic`; reads are
+unlocked.
 """
 
 from __future__ import annotations
@@ -12,6 +13,7 @@ from pathlib import Path
 from filelock import FileLock
 from nauro_core.constants import DECISIONS_DIR
 
+from nauro.store._atomic import atomic_write_text
 from nauro.store.reader import read_text_lenient
 
 
@@ -74,13 +76,15 @@ class FilesystemStore:
     # the same num because they raced between list/write) are caught and
     # repaired on the next sync-pull.
     def write_file(self, path: str, content: str) -> None:
+        """Replace ``path`` atomically: readers see old bytes or new bytes, never a mix."""
         # Fail loud on an out-of-store path: silently dropping or redirecting a
         # write would corrupt the store, so a traversal path is an error.
         target = self._resolve_within(path)
+        # Ahead of the lock, because the lock file is a sibling of the target.
         target.parent.mkdir(parents=True, exist_ok=True)
         lock = target.with_name(target.name + ".lock")
         with FileLock(str(lock)):
-            target.write_text(content, encoding="utf-8")
+            atomic_write_text(target, content)
 
     def delete_file(self, path: str) -> None:
         try:

--- a/packages/nauro/tests/test_store.py
+++ b/packages/nauro/tests/test_store.py
@@ -5,12 +5,19 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
+from nauro_core.constants import (
+    DECISIONS_DIR,
+    OPEN_QUESTIONS_MD,
+    STATE_CURRENT_FILENAME,
+)
 from nauro_core.operations import flag_question as _flag_question_op
 from nauro_core.operations import update_state as _update_state_op
 from typer.testing import CliRunner
 
 from nauro.cli.main import app
 from nauro.constants import SNAPSHOTS_DIR
+from nauro.store import _atomic
+from nauro.store._atomic import is_tmp_sibling
 from nauro.store.filesystem_store import FilesystemStore
 from nauro.store.reader import _list_decisions
 from nauro.store.snapshot import capture_snapshot, list_snapshots, load_snapshot
@@ -881,3 +888,82 @@ def test_filesystem_store_read_file_returns_none_on_traversal(tmp_path):
     secret = tmp_path / "secret.md"
     secret.write_text("top secret")
     assert FilesystemStore(store_root).read_file("../secret.md") is None
+
+
+# --- FilesystemStore atomic writes ---
+
+
+def _tmp_siblings(directory: Path) -> list[str]:
+    """Names in ``directory`` that ``_atomic`` could have minted as tmp files."""
+    return [p.name for p in directory.iterdir() if is_tmp_sibling(p.name)]
+
+
+def test_filesystem_store_write_file_keeps_old_bytes_when_the_write_dies(tmp_path, monkeypatch):
+    """A write that fails partway leaves the previous file whole.
+
+    This is the reason the store writes atomically: a truncating write killed
+    halfway leaves a shortened judgment file that still parses, and the next
+    sync pushes it as the truth.
+    """
+    store_root = tmp_path / "store"
+    store_root.mkdir()
+    target = store_root / OPEN_QUESTIONS_MD
+    target.write_text("# Open Questions\n\n- [Q001] Everything that was here before?\n")
+    before = target.read_bytes()
+
+    def boom(src, dst):
+        raise OSError(28, "No space left on device")
+
+    monkeypatch.setattr(_atomic.os, "replace", boom)
+    with pytest.raises(OSError):
+        FilesystemStore(store_root).write_file(OPEN_QUESTIONS_MD, "short")
+
+    assert target.read_bytes() == before
+    assert _tmp_siblings(store_root) == []
+
+
+def test_filesystem_store_write_file_creates_fresh_file_without_strays(tmp_path):
+    """A first write lands the content and leaves no tmp sibling behind."""
+    store_root = tmp_path / "store"
+    store = FilesystemStore(store_root)
+    store.write_file(f"{DECISIONS_DIR}/042-atomic-writes.md", "# 042. Atomic writes\n")
+
+    decisions_dir = store_root / DECISIONS_DIR
+    assert (decisions_dir / "042-atomic-writes.md").read_text() == "# 042. Atomic writes\n"
+    assert _tmp_siblings(decisions_dir) == []
+
+
+def test_filesystem_store_list_decisions_skips_a_stranded_tmp_sibling(tmp_path, monkeypatch):
+    """A tmp sibling stranded in ``decisions/`` is never listed as a decision.
+
+    A kill between the tmp write and the rename leaves a complete-looking file
+    under the tmp name. It must not glob as ``*.md``, or the store would read
+    and push a decision the writer never committed.
+    """
+    store_root = tmp_path / "store"
+    store = FilesystemStore(store_root)
+    store.write_file(f"{DECISIONS_DIR}/001-committed.md", "# 001. Committed\n")
+
+    # Drop the rename, not the write: exactly what a signal between the two
+    # leaves on disk, under the real minted tmp name.
+    monkeypatch.setattr(_atomic, "_replace", lambda tmp, path, final_mode: None)
+    store.write_file(f"{DECISIONS_DIR}/002-interrupted.md", "# 002. Interrupted\n")
+
+    decisions_dir = store_root / DECISIONS_DIR
+    assert len(_tmp_siblings(decisions_dir)) == 1
+    assert not (decisions_dir / "002-interrupted.md").exists()
+    assert store.list_decisions() == ["001-committed"]
+
+
+def test_filesystem_store_write_file_preserves_permission_bits(tmp_path):
+    """An existing file's mode survives the replace; the tmp's owner-only
+    creation mode must not leak onto a store file."""
+    store_root = tmp_path / "store"
+    store_root.mkdir()
+    target = store_root / STATE_CURRENT_FILENAME
+    target.write_text("# Current State\n")
+    target.chmod(0o640)
+
+    FilesystemStore(store_root).write_file(STATE_CURRENT_FILENAME, "# Current State\n\n- New\n")
+
+    assert oct(target.stat().st_mode & 0o777) == "0o640"


### PR DESCRIPTION
## Why

`FilesystemStore.write_file` ended in a plain `write_text` under the per-target `FileLock`. A plain write truncates the target before it writes the new bytes. If the write stops in the middle, the file on disk is shorter than both the old version and the new version. That shortened file is still valid Markdown, so every reader accepts it. The next sync then pushes it as the truth.

All judgment files go through this 1 function: each decision file, `open-questions.md`, `state_current.md` and `state_history.md`. The repo already has the atomic primitive that prevents this. The control-plane JSON writers, the graph command and the sync pull all use it. The store did not.

## What changed

`write_file` now writes through `atomic_write_text`. That primitive writes to a temporary sibling file and then renames it over the target. A reader sees the complete old bytes or the complete new bytes. It never sees a mix.

The per-target `FileLock` stays. The parent directory is still created before the lock, because the lock file is a sibling of the target.

The call uses the default mode, so an existing file keeps its permission bits and a new file gets the same bits a plain write gives it. The bytes on disk are the same as before for every write that completes.

The docstrings now state the guarantee. The `_atomic` module docstring also lists the store writes as a caller.

## Test plan

4 tests were added to `packages/nauro/tests/test_store.py`:

1. A failed rename leaves the previous file byte-identical and leaves no temporary sibling.
2. A first write creates the file with the content and leaves no temporary sibling.
3. A temporary sibling stranded in `decisions/` is not listed by `list_decisions`.
4. An existing file keeps its permission bits across a write.

Full suites: 2639 passed and 10 skipped for `nauro`, 1618 passed for `nauro-core`. `ruff check` and `ruff format --check` are both clean.

## Risk

Low. The change is 1 line in the write path plus documentation. The primitive is already used elsewhere in the same package and has its own test file.

The rename is atomic only inside 1 filesystem. The store directory is 1 tree, so this holds.

The sync layer already knows the temporary sibling name shape. It skips those files and removes strays, so a stranded file from a killed write is never pushed.

## Deferred

Crash durability is out of scope. There is no `fsync`, which matches every other caller of the primitive. A power loss can still lose a completed write that the operating system has not yet flushed.
