### PR TITLE
Order decisions numerically past 999

### DIFF
--- a/packages/nauro-core/src/nauro_core/operations/decision_lookup.py
+++ b/packages/nauro-core/src/nauro_core/operations/decision_lookup.py
@@ -19,6 +19,7 @@ from nauro_core.parsing import (
     _decision_filename,
     _decision_number_prefix,
     extract_decision_number,
+    sort_stems_by_number,
 )
 
 logger = logging.getLogger("nauro_core.operations.decision_lookup")
@@ -47,17 +48,16 @@ def scan_decisions(store: Store) -> tuple[list[Decision], list[ParseFailure]]:
     than raising. :func:`parse_all_decisions` consumes only the parsed list;
     ``doctor`` consumes both.
 
-    Bodies are fetched in one bulk :meth:`Store.read_decisions` call, but the
-    scan still reasserts :meth:`Store.list_decisions` order: it iterates the
-    stem list (not the returned mapping, which carries no ordering guarantee)
-    so the parsed list follows ``list_decisions`` verbatim. That ordering is
-    load-bearing — BM25 ranking breaks ties by corpus position, so a stable
-    parse order keeps retrieval byte-identical. No filtering is applied here;
-    callers that need a status or seed filter apply it after the scan returns.
+    The parsed list is ordered by :func:`sort_stems_by_number`, not by the
+    lexicographic order :meth:`Store.list_decisions` returns and not by the
+    bulk-read mapping, which carries no ordering guarantee. Callers downstream
+    read list position as chronology and BM25 breaks ranking ties by corpus
+    position, so this is the one place that order is set. No filtering is
+    applied here; callers that need a status or seed filter apply it after.
     """
     parsed: list[Decision] = []
     failures: list[ParseFailure] = []
-    stems = store.list_decisions()
+    stems = sort_stems_by_number(store.list_decisions())
     bodies = store.read_decisions(stems)
     for stem in stems:
         body = bodies.get(stem)

--- a/packages/nauro-core/src/nauro_core/operations/store.py
+++ b/packages/nauro-core/src/nauro_core/operations/store.py
@@ -42,6 +42,10 @@ class Store(Protocol):
         The list is sorted in lexicographic order. Stems map 1:1 to decision
         files under the canonical ``decisions/`` directory; callers reach
         the body via :meth:`read_decision`.
+
+        Lexicographic order is not chronological order: a caller that reads
+        list position as recency orders the stems through
+        :func:`~nauro_core.parsing.sort_stems_by_number` first.
         """
         ...
 

--- a/packages/nauro-core/src/nauro_core/parsing.py
+++ b/packages/nauro-core/src/nauro_core/parsing.py
@@ -8,6 +8,7 @@ state/stack/questions parsing, and snippet extraction.
 from __future__ import annotations
 
 import re
+from collections.abc import Iterable
 
 from nauro_core.constants import DECISIONS_DIR, PROJECT_MD_SCAFFOLD_BODY, STACK_EMPTY_MARKER
 
@@ -175,6 +176,22 @@ def extract_decision_number(identifier: str) -> int | None:
             return None
         break
     return int(leading) if leading else None
+
+
+def sort_stems_by_number(stems: Iterable[str]) -> list[str]:
+    """Order decision file stems by number ascending, then by stem.
+
+    Stems carrying no number sort last, lexicographically among themselves.
+    """
+    return sorted(stems, key=_stem_order_key)
+
+
+def _stem_order_key(stem: str) -> tuple[int, int, str]:
+    """Sort key for :func:`sort_stems_by_number`: numbered stems first, by number."""
+    num = extract_decision_number(stem)
+    if num is None:
+        return (1, 0, stem)
+    return (0, num, stem)
 
 
 # Body reference prefixes, lowercased. ``extract_decision_number`` accepts the

--- a/packages/nauro-core/tests/operations/test_decision_lookup.py
+++ b/packages/nauro-core/tests/operations/test_decision_lookup.py
@@ -162,3 +162,40 @@ def test_scan_decisions_clean_store_has_no_failures() -> None:
     parsed, failures = scan_decisions(store)
     assert [d.num for d in parsed] == [1]
     assert failures == []
+
+
+# ── scan order is numeric, not lexicographic ──
+
+
+def _four_digit_store() -> InMemoryStore:
+    """A store whose stems span 3 and 4 digits."""
+    return InMemoryStore(
+        decisions={
+            f"{num:03d}-decision-{num}": _decision_body(num, f"Decision {num}")
+            for num in (998, 999, 1000, 1001)
+        }
+    )
+
+
+def test_scan_decisions_orders_past_999_by_number() -> None:
+    store = _four_digit_store()
+    # Sanity: the protocol order disagrees, so the assertion below has teeth.
+    assert store.list_decisions()[-1] == "999-decision-999"
+    parsed, failures = scan_decisions(store)
+    assert [d.num for d in parsed] == [998, 999, 1000, 1001]
+    assert failures == []
+
+
+def test_parse_all_decisions_orders_past_999_by_number() -> None:
+    assert [d.num for d in parse_all_decisions(_four_digit_store())] == [998, 999, 1000, 1001]
+
+
+def test_scan_order_on_three_digit_store_equals_lexicographic_order() -> None:
+    stems = ["001-alpha", "010-bravo", "042-charlie", "099-delta", "999-echo"]
+    store = InMemoryStore(
+        decisions={
+            stem: _decision_body(int(stem[:3]), stem.split("-", 1)[1].title()) for stem in stems
+        }
+    )
+    parsed, _ = scan_decisions(store)
+    assert [d.num for d in parsed] == [int(stem[:3]) for stem in sorted(stems)]

--- a/packages/nauro-core/tests/operations/test_get_context.py
+++ b/packages/nauro-core/tests/operations/test_get_context.py
@@ -212,3 +212,44 @@ def test_no_last_synced_trailer_in_l0_content() -> None:
     # The italic trailer ``*Last synced: <value>*`` is appended by the
     # transport adapter; the kernel content must not carry it.
     assert "\n\n*Last synced:" not in result.content
+
+
+# ── recency past decision 999 ──
+
+
+def _store_past_999() -> InMemoryStore:
+    """A store whose newest decision is 1001."""
+    decisions = {}
+    for num in (998, 999, 1000, 1001):
+        body = format_decision(
+            Decision(
+                num=num,
+                title=f"Decision {num}",
+                rationale=f"Rationale for decision {num}.",
+                confidence=DecisionConfidence.medium,
+                status=DecisionStatus.active,
+                date=date(2026, 1, 1),
+            )
+        )
+        decisions[f"{num:03d}-decision-{num}"] = body
+    return InMemoryStore(files={"project.md": "# Project\n\nGoal.\n"}, decisions=decisions)
+
+
+def test_l0_recent_decisions_leads_with_the_newest_past_999() -> None:
+    result = get_context(_store_past_999(), 0)
+    assert result.content is not None
+    summary = result.content.split("## Recent Decisions\n", 1)[1]
+    assert [line.split(" ")[1] for line in summary.strip().splitlines()] == [
+        "D1001",
+        "D1000",
+        "D999",
+        "D998",
+    ]
+
+
+def test_l1_decisions_lead_with_the_newest_past_999() -> None:
+    result = get_context(_store_past_999(), 1)
+    assert result.content is not None
+    body = result.content.split("## Decisions\n\n", 1)[1]
+    positions = [body.index(f"Decision {num}") for num in (1001, 1000, 999, 998)]
+    assert positions == sorted(positions)

--- a/packages/nauro-core/tests/operations/test_list_decisions.py
+++ b/packages/nauro-core/tests/operations/test_list_decisions.py
@@ -145,3 +145,9 @@ def test_store_field_absent_from_result_model_dump() -> None:
     result = list_decisions(InMemoryStore())
     dumped = result.model_dump(mode="json")
     assert "store" not in dumped
+
+
+def test_rows_lead_with_the_newest_decision_past_999() -> None:
+    seeds = (_seed_decision(num, f"Decision {num}") for num in (998, 999, 1000, 1001))
+    result = list_decisions(_store_with(*seeds))
+    assert [row.number for row in result.decisions] == [1001, 1000, 999, 998]

--- a/packages/nauro-core/tests/test_parsing.py
+++ b/packages/nauro-core/tests/test_parsing.py
@@ -18,6 +18,7 @@ from nauro_core.parsing import (
     is_ascii_decimal,
     is_scaffold_project_md,
     scan_decision_references,
+    sort_stems_by_number,
     strip_leading_h1,
 )
 
@@ -284,6 +285,34 @@ class TestDecisionNumberFormatters:
     @pytest.mark.parametrize("num", _FORMATTER_NUMBERS)
     def test_decision_number_prefix_matches_inline(self, num: int) -> None:
         assert _decision_number_prefix(num) == f"{num:03d}-"
+
+
+class TestSortStemsByNumber:
+    def test_four_digit_stem_sorts_after_three_digit_stems(self) -> None:
+        stems = ["100-a", "1000-d", "101-b", "999-c"]
+        assert sort_stems_by_number(stems) == ["100-a", "101-b", "999-c", "1000-d"]
+
+    def test_three_digit_store_keeps_lexicographic_order(self) -> None:
+        stems = ["007-g", "001-a", "042-e", "999-z", "003-c"]
+        assert sort_stems_by_number(stems) == sorted(stems)
+
+    def test_stems_sharing_a_number_keep_lexicographic_order(self) -> None:
+        stems = ["005-zulu", "005-alpha", "004-x"]
+        assert sort_stems_by_number(stems) == ["004-x", "005-alpha", "005-zulu"]
+
+    def test_unnumbered_stems_sort_after_numbered_ones(self) -> None:
+        stems = ["notes", "-orphan", "0100-a", "010-b"]
+        assert sort_stems_by_number(stems) == ["010-b", "0100-a", "-orphan", "notes"]
+
+    def test_repeated_stem_is_stable(self) -> None:
+        stems = ["002-b", "001-a", "002-b"]
+        assert sort_stems_by_number(stems) == ["001-a", "002-b", "002-b"]
+
+    def test_accepts_any_iterable(self) -> None:
+        assert sort_stems_by_number(s for s in ("1000-d", "999-c")) == ["999-c", "1000-d"]
+
+    def test_empty_input_returns_empty_list(self) -> None:
+        assert sort_stems_by_number([]) == []
 
 
 class TestDecisionFilenameFormatters:

--- a/packages/nauro/src/nauro/store/reader.py
+++ b/packages/nauro/src/nauro/store/reader.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from nauro_core import parse_decision
 from nauro_core.decision_model import Decision
+from nauro_core.parsing import sort_stems_by_number
 
 from nauro.constants import DECISIONS_DIR
 
@@ -24,13 +25,17 @@ def read_text_lenient(path: Path) -> str:
 
 
 def _list_decisions(store_path: Path) -> list[Decision]:
-    """Parse all decision files, return ``Decision`` objects sorted by number."""
+    """Parse all decision files, return ``Decision`` objects sorted by number.
+
+    The order is :func:`sort_stems_by_number`, not a sort on the filenames.
+    """
     decisions_dir = store_path / DECISIONS_DIR
     if not decisions_dir.exists():
         return []
 
+    by_stem = {f.stem: f for f in decisions_dir.glob("*.md")}
     results: list[Decision] = []
-    for f in sorted(decisions_dir.glob("*.md")):
-        content = read_text_lenient(f)
-        results.append(parse_decision(content, f.name))
+    for stem in sort_stems_by_number(by_stem):
+        path = by_stem[stem]
+        results.append(parse_decision(read_text_lenient(path), path.name))
     return results

--- a/packages/nauro/src/nauro/store/validator.py
+++ b/packages/nauro/src/nauro/store/validator.py
@@ -123,17 +123,17 @@ def validate_store(store_path: Path) -> list[str]:
                 f"{PROJECT_MD_TOKEN_WARN:,} - move detail to stack.md or decisions"
             )
 
-    # Check decision numbering is sequential with no gaps
+    # Check decision numbering is sequential with no gaps, over the min..max
+    # span of the numbers themselves — filename order is not number order.
     decisions_dir = store_path / DECISIONS_DIR
     if decisions_dir.exists():
-        numbers = []
-        for f in sorted(decisions_dir.glob("*.md")):
+        numbers = set()
+        for f in decisions_dir.glob("*.md"):
             n = extract_decision_number(f.name)
             if n is not None:
-                numbers.append(n)
+                numbers.add(n)
         if numbers:
-            expected = list(range(numbers[0], numbers[-1] + 1))
-            missing = set(expected) - set(numbers)
+            missing = set(range(min(numbers), max(numbers) + 1)) - numbers
             if missing:
                 warnings.append(f"Decision numbering gap: missing {sorted(missing)}")
 

--- a/packages/nauro/tests/test_decision_order_past_999.py
+++ b/packages/nauro/tests/test_decision_order_past_999.py
@@ -1,0 +1,85 @@
+"""Decision order on a filesystem store whose stems span 3 and 4 digits."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+from nauro_core.decision_model import (
+    Decision,
+    DecisionConfidence,
+    DecisionStatus,
+    format_decision,
+)
+from nauro_core.operations import get_context
+
+from nauro.constants import DECISIONS_DIR
+from nauro.mcp.payloads import build_l0_payload
+from nauro.store.filesystem_store import FilesystemStore
+from nauro.store.reader import _list_decisions
+from nauro.store.validator import validate_store
+
+FOUR_DIGIT_NUMBERS = (998, 999, 1000, 1001)
+
+
+def _decision_body(num: int) -> str:
+    return format_decision(
+        Decision(
+            num=num,
+            title=f"Decision {num}",
+            rationale=f"Rationale for the {num}th decision.",
+            confidence=DecisionConfidence.medium,
+            status=DecisionStatus.active,
+            date=date(2026, 1, 1),
+        )
+    )
+
+
+@pytest.fixture
+def store_past_999(tmp_path: Path) -> Path:
+    """A store whose newest decision is 1001."""
+    store_path = tmp_path / "project"
+    decisions_dir = store_path / DECISIONS_DIR
+    decisions_dir.mkdir(parents=True)
+    (store_path / "project.md").write_text("# Project\n\nGoal: ship it.\n", encoding="utf-8")
+    for num in FOUR_DIGIT_NUMBERS:
+        path = decisions_dir / f"{num:03d}-decision-{num}.md"
+        path.write_text(_decision_body(num), encoding="utf-8")
+    return store_path
+
+
+def test_filenames_really_disagree_with_number_order(store_past_999: Path) -> None:
+    """Sanity check: name order and number order disagree in this store."""
+    names = sorted(p.name for p in (store_past_999 / DECISIONS_DIR).glob("*.md"))
+    assert names[-1] == "999-decision-999.md"
+
+
+def test_reader_lists_decisions_in_number_order(store_past_999: Path) -> None:
+    assert [d.num for d in _list_decisions(store_past_999)] == list(FOUR_DIGIT_NUMBERS)
+
+
+def test_l0_recent_decisions_leads_with_the_newest(store_past_999: Path) -> None:
+    summary = build_l0_payload(store_past_999).split("## Recent Decisions\n", 1)[1]
+    assert [line.split(" ")[1] for line in summary.strip().splitlines()] == [
+        "D1001",
+        "D1000",
+        "D999",
+        "D998",
+    ]
+
+
+def test_l1_decisions_lead_with_the_newest(store_past_999: Path) -> None:
+    result = get_context(FilesystemStore(store_past_999), 1)
+    assert result.content is not None
+    body = result.content.split("## Decisions\n\n", 1)[1]
+    positions = [body.index(f"Decision {num}") for num in reversed(FOUR_DIGIT_NUMBERS)]
+    assert positions == sorted(positions)
+
+
+def test_numbering_gap_check_spans_min_to_max_not_first_to_last_name(
+    store_past_999: Path,
+) -> None:
+    """998..1001 is a contiguous run, so no gap is reported for it."""
+    gaps = [w for w in validate_store(store_past_999) if "numbering gap" in w]
+    assert gaps == []


### PR DESCRIPTION
## Why

Decision files are named `{num:03d}-slug`. A lexicographic sort puts `1000-x` between `100-x` and `101-x`. Several readers use list position as chronology. On a store with 1000 or more decisions, those readers silently drop the newest decision.

The affected readers are the L0 and L1 "Recent Decisions" windows, the store reader listing that `nauro log` prints, and the decision numbering-gap check. This store has 534 decisions today, so the defect is not yet live.

## What changed

1. New function `sort_stems_by_number` in `nauro_core.parsing`. It orders stems by decision number ascending. The stem breaks ties. A stem with no number sorts last.
2. The guarded scan `scan_decisions` now orders its stems through that function. All kernel consumers get numeric order from this one place.
3. `nauro.store.reader._list_decisions` uses the same order. Its docstring already promised number order.
4. The numbering-gap check in `nauro.store.validator` measures the span from the lowest number to the highest number, not from the first filename to the last filename.
5. The `Store.list_decisions` protocol docstring says that lexicographic order is not chronological order. The contract and the filename padding do not change.

BM25 retrieval breaks ranking ties by corpus position. The stem tiebreaker keeps the parse order identical to the old order on any store below decision 1000, so retrieval results do not move. A test pins this.

## Test plan

- 13 new tests in nauro-core and 5 in nauro.
- A store holding decisions 998, 999, 1000 and 1001 returns them in numeric order from `scan_decisions`, `parse_all_decisions` and the reader.
- The same store shows 1001 first in L0, in L1 and in `list_decisions`.
- A store where every stem has 3 digits parses in exactly lexicographic order. This is the guard for BM25 tie-breaks.
- Unit tests cover ties, unnumbered stems and stability.
- Full suites pass: nauro-core 1631 passed, nauro 2640 passed and 10 skipped. Ruff check and ruff format are clean.

## Risk

Low. The order changes only on a store that has passed decision 999. No store has. The public API of `nauro_core` is unchanged, so the frozen 1.0 contract snapshot is untouched. The only behavior change below decision 1000 is for a decision file whose name starts with a character that sorts before a digit. Such a file now sorts after the numbered files instead of before them.

## Deferred

- `FilesystemStore.list_decisions` still returns lexicographic order, as its protocol contract requires. Callers order it themselves.
- Filename padding stays at 3 digits. A wider pad would rename every existing file.
- The `get_raw_file` miss hint still anchors each subdirectory on its lexicographically last file. That is the ratified hint contract. Past decision 999 the anchor is no longer the newest decision. That change needs its own ruling and is not made here.
- The remote MCP server has its own `Store` implementation in a separate repo. It inherits the fix only if it calls the kernel scan. That check is owed before the next hosted deploy.
