### PR TITLE
Resolve the nauro home path in one module

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/config.py
+++ b/packages/nauro/src/nauro/cli/commands/config.py
@@ -7,12 +7,8 @@ plus cleanup: list / get / unset, no generic ``set``.
 
 import typer
 
-from nauro.store.config import (
-    _config_file,
-    get_config,
-    load_config,
-    unset_config,
-)
+from nauro.store.config import get_config, load_config, unset_config
+from nauro.store.home import config_file
 
 config_app = typer.Typer(help="Inspect and remove Nauro configuration.")
 
@@ -75,7 +71,7 @@ def config_unset(
     """Remove a configuration value."""
     if unset_config(key):
         typer.echo(f"Removed {key}")
-        typer.echo(f"  Config: {_config_file()}")
+        typer.echo(f"  Config: {config_file()}")
     else:
         typer.echo(f"{key}: (not set)")
         raise typer.Exit(code=1)

--- a/packages/nauro/src/nauro/cli/commands/hook.py
+++ b/packages/nauro/src/nauro/cli/commands/hook.py
@@ -22,7 +22,8 @@ import typer
 from nauro_core import MCP_INSTRUCTIONS_STATIC
 
 from nauro.cli._codex_hooks import _CODEX_HOOK_EVENTS
-from nauro.constants import DECISIONS_DIR, DEFAULT_NAURO_HOME, NAURO_HOME_ENV
+from nauro.constants import DECISIONS_DIR
+from nauro.store.home import nauro_home
 
 hook_app = typer.Typer(help="Client-side advisory hooks for AI coding agents.")
 
@@ -422,8 +423,7 @@ def _format_block(hits: list[dict]) -> str:
 
 
 def _hook_state_dir() -> Path:
-    nauro_home = Path(os.environ.get(NAURO_HOME_ENV, Path.home() / DEFAULT_NAURO_HOME))
-    return nauro_home / "hook-state"
+    return nauro_home() / "hook-state"
 
 
 def _session_state_file(session_id: str) -> Path | None:

--- a/packages/nauro/src/nauro/store/config.py
+++ b/packages/nauro/src/nauro/store/config.py
@@ -1,7 +1,7 @@
 """User configuration — manages ~/.nauro/config.json.
 
 Stores user-level settings such as authentication and retrieval preferences.
-Respects NAURO_HOME env var override (defaults to ~/.nauro/).
+The file path comes from ``nauro.store.home``.
 """
 
 import json
@@ -13,25 +13,15 @@ from pathlib import Path
 
 from filelock import FileLock
 
-from nauro.constants import (
-    CONFIG_FILENAME,
-    DEFAULT_NAURO_HOME,
-    NAURO_EMBEDDINGS_ENV,
-    NAURO_HOME_ENV,
-)
+from nauro.constants import NAURO_EMBEDDINGS_ENV
 from nauro.store._atomic import atomic_write_text
-from nauro.store.registry import _ensure_nauro_home
+from nauro.store.home import config_file, ensure_nauro_home
 
 logger = logging.getLogger("nauro.config")
 
 # Config key for the optional embedding retrieval augmenter. The env var
-# NAURO_EMBEDDINGS overrides it, mirroring the NAURO_HOME precedence.
+# NAURO_EMBEDDINGS overrides it, mirroring the home-path precedence.
 _EMBEDDINGS_CONFIG_KEY = "search.embeddings"
-
-
-def _config_file() -> Path:
-    nauro_home = Path(os.environ.get(NAURO_HOME_ENV, Path.home() / DEFAULT_NAURO_HOME))
-    return nauro_home / CONFIG_FILENAME
 
 
 @contextmanager
@@ -45,8 +35,8 @@ def _config_lock(timeout: float = -1):
     ``filelock.Timeout`` on expiry so a stuck holder cannot block a caller
     indefinitely.
     """
-    lock_path = _config_file().with_suffix(".lock")
-    _ensure_nauro_home()  # lock_path.parent is the home dir; create it owner-only
+    lock_path = config_file().with_suffix(".lock")
+    ensure_nauro_home()  # lock_path.parent is the home dir; create it owner-only
     with FileLock(str(lock_path), timeout=timeout):
         yield
 
@@ -104,7 +94,7 @@ def load_config() -> dict:
     before returning {} so a subsequent save cannot silently destroy any
     recoverable content.
     """
-    cf = _config_file()
+    cf = config_file()
     if cf.exists():
         try:
             data = json.loads(cf.read_text())
@@ -120,7 +110,7 @@ def load_config() -> dict:
 
 def save_config(data: dict) -> None:
     """Write config.json atomically (write-to-tmp + rename). Restricts to owner-only (0o600)."""
-    cf = _config_file()
+    cf = config_file()
     atomic_write_text(cf, json.dumps(data, indent=2) + "\n", mode=0o600)
 
 
@@ -153,7 +143,7 @@ def unset_config(key: str) -> bool:
 def resolve_embeddings_flag() -> bool:
     """Resolve whether embedding-augmented retrieval is enabled.
 
-    Precedence (mirrors NAURO_HOME): the ``NAURO_EMBEDDINGS`` env var wins when
+    Precedence (mirrors the home path): the ``NAURO_EMBEDDINGS`` env var wins when
     set; otherwise the ``search.embeddings`` config key is consulted; otherwise
     the default is OFF. Env and config both accept the same truthy tokens
     (``"1"``, ``"true"``, ``"yes"``, ``"on"``, case-insensitive) and a native

--- a/packages/nauro/src/nauro/store/home.py
+++ b/packages/nauro/src/nauro/store/home.py
@@ -1,0 +1,57 @@
+"""The Nauro home directory and the top-level paths inside it.
+
+This module is the only place the home path is spelled: callers resolve
+``~/.nauro`` or ``$NAURO_HOME`` through ``nauro_home``. The home holds the auth
+token and the whole project store, so it is kept owner-only. Nothing outside the
+standard library and ``nauro.constants`` is imported, so any module can use it.
+"""
+
+import logging
+import os
+from pathlib import Path
+
+from nauro.constants import (
+    CONFIG_FILENAME,
+    DEFAULT_NAURO_HOME,
+    NAURO_HOME_ENV,
+    PROJECTS_DIR,
+    REGISTRY_FILENAME,
+)
+
+logger = logging.getLogger("nauro.store.home")
+
+
+def nauro_home() -> Path:
+    """Return the Nauro home: ``$NAURO_HOME`` when set, else ``~/.nauro``."""
+    return Path(os.environ.get(NAURO_HOME_ENV, Path.home() / DEFAULT_NAURO_HOME))
+
+
+def registry_file() -> Path:
+    """Return the path of the project registry in the Nauro home."""
+    return nauro_home() / REGISTRY_FILENAME
+
+
+def projects_dir() -> Path:
+    """Return the path of the project store root in the Nauro home."""
+    return nauro_home() / PROJECTS_DIR
+
+
+def config_file() -> Path:
+    """Return the path of the user config file in the Nauro home."""
+    return nauro_home() / CONFIG_FILENAME
+
+
+def ensure_nauro_home() -> Path:
+    """Create the Nauro home at ``0o700`` and return it.
+
+    A home left group- or other-accessible by an older build is tightened in place.
+    """
+    home = nauro_home()
+    home.mkdir(mode=0o700, parents=True, exist_ok=True)
+    try:
+        if (home.stat().st_mode & 0o077) != 0:
+            home.chmod(0o700)
+    except OSError as exc:
+        # Best-effort tightening; a real failure surfaces at the caller's next write.
+        logger.debug("Could not tighten %s to 0o700: %s", home, exc)
+    return home

--- a/packages/nauro/src/nauro/store/registry.py
+++ b/packages/nauro/src/nauro/store/registry.py
@@ -11,13 +11,10 @@ The registry is keyed by project_id (ULID) and tracks ``name``, ``mode``,
 The retired name-keyed schema_version 1 shape is no longer readable:
 ``load_registry_v2`` rejects it with a manual-migration hint, and read
 paths degrade to an empty registry.
-
-Respects NAURO_HOME env var override (defaults to ~/.nauro/).
 """
 
 import json
 import logging
-import os
 import shutil
 from contextlib import contextmanager
 from pathlib import Path
@@ -28,17 +25,14 @@ from pydantic import BaseModel, ConfigDict, StrictStr, ValidationError, model_va
 
 from nauro.constants import (
     DECISIONS_DIR,
-    DEFAULT_NAURO_HOME,
-    NAURO_HOME_ENV,
     PROJECT_MD,
-    PROJECTS_DIR,
-    REGISTRY_FILENAME,
     REGISTRY_SCHEMA_VERSION_V1,
     REGISTRY_SCHEMA_VERSION_V2,
     REPO_CONFIG_MODE_CLOUD,
     REPO_CONFIG_MODE_LOCAL,
 )
 from nauro.store._atomic import atomic_write_text
+from nauro.store.home import ensure_nauro_home, projects_dir, registry_file
 from nauro.store.repo_config import generate_ulid
 
 logger = logging.getLogger("nauro.registry")
@@ -99,44 +93,10 @@ def validate_registry_entry_v2(project_id: str, raw_entry: object) -> RegistryEn
 @contextmanager
 def _registry_lock():
     """Exclusive file lock on registry.json for atomic read-modify-write."""
-    lock_path = _registry_file().with_suffix(".lock")
-    _ensure_nauro_home()  # lock_path.parent is the home dir; create it owner-only
+    lock_path = registry_file().with_suffix(".lock")
+    ensure_nauro_home()  # lock_path.parent is the home dir; create it owner-only
     with FileLock(lock_path):
         yield
-
-
-def _nauro_home() -> Path:
-    return Path(os.environ.get(NAURO_HOME_ENV, Path.home() / DEFAULT_NAURO_HOME))
-
-
-def _registry_file() -> Path:
-    return _nauro_home() / REGISTRY_FILENAME
-
-
-def _projects_dir() -> Path:
-    return _nauro_home() / PROJECTS_DIR
-
-
-def _ensure_nauro_home() -> Path:
-    """Create the Nauro home dir (``~/.nauro`` or ``$NAURO_HOME``) owner-only.
-
-    The home holds the auth token (``config.json``) and the full project store,
-    so it must not be group/other-accessible. New installs are created at
-    ``0o700``; a home created at the umask default by an older build is tightened
-    in place. Deeper paths are created under the returned home with
-    ``parents=True`` after this call, so the home never transits a wider mode.
-    """
-    home = _nauro_home()
-    home.mkdir(mode=0o700, parents=True, exist_ok=True)
-    try:
-        if (home.stat().st_mode & 0o077) != 0:
-            home.chmod(0o700)
-    except OSError as exc:
-        # Best-effort tightening of a pre-existing wide dir; a real failure
-        # surfaces at the FileLock that follows. Log for diagnosis on locked-down
-        # hosts rather than masking it entirely.
-        logger.debug("Could not tighten %s to 0o700: %s", home, exc)
-    return home
 
 
 # ── v2 registry (id-keyed) ───────────────────────────────────────────────────
@@ -163,7 +123,7 @@ def load_registry_v2() -> dict:
             one-time manual migration is required) or any other unknown
             version.
     """
-    rf = _registry_file()
+    rf = registry_file()
     if not rf.exists():
         return {"projects": {}, "schema_version": REGISTRY_SCHEMA_VERSION_V2}
 
@@ -204,7 +164,7 @@ def save_registry_v2(data: dict) -> None:
             f"save_registry_v2 refuses to write schema_version="
             f"{data['schema_version']!r}; expected {REGISTRY_SCHEMA_VERSION_V2}."
         )
-    rf = _registry_file()
+    rf = registry_file()
     atomic_write_text(rf, json.dumps(data, indent=2) + "\n")
 
 
@@ -258,7 +218,7 @@ def get_store_path_v2(project_id: str) -> Path:
     the projects root. It rejects only escapes, not the full ULID alphabet, so
     contained non-canonical ids (e.g. test fixtures) are left alone.
     """
-    projects_root = _projects_dir()
+    projects_root = projects_dir()
     store_path = projects_root / project_id
     try:
         store_path.resolve().relative_to(projects_root.resolve())

--- a/packages/nauro/src/nauro/store/repo_config.py
+++ b/packages/nauro/src/nauro/store/repo_config.py
@@ -17,15 +17,11 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import secrets
 import time
 from pathlib import Path
 
 from nauro.constants import (
-    CONFIG_FILENAME,
-    DEFAULT_NAURO_HOME,
-    NAURO_HOME_ENV,
     REPO_CONFIG_DIR,
     REPO_CONFIG_FILENAME,
     REPO_CONFIG_MODE_CLOUD,
@@ -33,6 +29,7 @@ from nauro.constants import (
     REPO_CONFIG_SCHEMA_VERSION,
 )
 from nauro.store._atomic import atomic_write_text
+from nauro.store.home import config_file
 from nauro.store.write_safety import find_symlink
 
 logger = logging.getLogger("nauro.repo_config")
@@ -67,16 +64,6 @@ class RepoConfigSymlinkError(Exception):
     """Raised when a repo config write would traverse a symlink in the checkout."""
 
 
-def _global_config_file() -> Path:
-    """Path of the global config. Mirrors ``registry._nauro_home()``.
-
-    Not imported from registry because registry imports this module;
-    the resolution must stay in lockstep with it.
-    """
-    home = Path(os.environ.get(NAURO_HOME_ENV, Path.home() / DEFAULT_NAURO_HOME))
-    return home / CONFIG_FILENAME
-
-
 def collides_with_global_config(repo_root: Path) -> bool:
     """True when ``repo_root``'s config path is Nauro's global config file.
 
@@ -85,7 +72,7 @@ def collides_with_global_config(repo_root: Path) -> bool:
     and settings. Writing a repo config there would
     replace those settings, so writers must refuse the path.
     """
-    return repo_config_path(repo_root).resolve() == _global_config_file().resolve()
+    return repo_config_path(repo_root).resolve() == config_file().resolve()
 
 
 def generate_ulid() -> str:

--- a/packages/nauro/tests/test_config_lock.py
+++ b/packages/nauro/tests/test_config_lock.py
@@ -13,16 +13,16 @@ import pytest
 from filelock import FileLock, Timeout
 
 from nauro.store.config import (
-    _config_file,
     config_transaction,
     load_config,
     save_config,
     set_config,
 )
+from nauro.store.home import config_file
 
 
 def _lock_path():
-    return _config_file().with_suffix(".lock")
+    return config_file().with_suffix(".lock")
 
 
 def test_lock_is_held_during_body_and_released_after(tmp_path):
@@ -122,18 +122,18 @@ def test_transaction_preserves_owner_only_permissions(tmp_path):
     with config_transaction() as data:
         data["auth"] = {"access_token": "tok"}
 
-    config_path = _config_file()
+    config_path = config_file()
     assert oct(config_path.stat().st_mode & 0o777) == "0o600"
 
 
 def test_failed_body_leaves_disk_unchanged(tmp_path):
     """A body that raises skips the save — the file is byte-identical."""
     save_config({"auth": {"access_token": "tok"}})
-    before = _config_file().read_bytes()
+    before = config_file().read_bytes()
 
     with pytest.raises(RuntimeError):
         with config_transaction() as data:
             data["auth"] = {"access_token": "mutated"}
             raise RuntimeError("boom")
 
-    assert _config_file().read_bytes() == before
+    assert config_file().read_bytes() == before

--- a/packages/nauro/tests/test_registry.py
+++ b/packages/nauro/tests/test_registry.py
@@ -7,6 +7,7 @@ from typer.testing import CliRunner
 
 from nauro.cli.main import app
 from nauro.store import registry
+from nauro.store.home import projects_dir
 from nauro.store.repo_config import load_repo_config
 from nauro.templates.scaffolds import scaffold_project_store
 
@@ -261,7 +262,7 @@ def test_load_registry_v2_non_dict_returns_empty(tmp_path, monkeypatch):
 def test_get_store_path_v2_accepts_valid_ulid(tmp_path, monkeypatch):
     """A canonical ULID maps to the id-keyed directory under the projects dir."""
     pid = "01KQ6AZGNA0B3QBF67NBXP3S45"
-    assert registry.get_store_path_v2(pid) == registry._projects_dir() / pid
+    assert registry.get_store_path_v2(pid) == projects_dir() / pid
 
 
 @pytest.mark.parametrize("evil", ["../../../../etc", "../escape", "/etc"])
@@ -281,28 +282,4 @@ def test_get_store_path_v2_allows_contained_non_canonical_id(tmp_path, monkeypat
     test-fixture ids) is still returned. This guard rejects escapes, not the
     full ULID alphabet — keeping it from breaking non-escaping callers."""
     pid = "01TESTPROJECT00000000000"
-    assert registry.get_store_path_v2(pid) == registry._projects_dir() / pid
-
-
-# --- nauro home directory permissions ---
-
-
-def test_ensure_nauro_home_creates_owner_only(tmp_path, monkeypatch):
-    """A fresh Nauro home is created at 0o700 so the token and store are not
-    readable by other accounts on a shared host."""
-    home = tmp_path / "fresh_home"
-    monkeypatch.setenv("NAURO_HOME", str(home))
-    created = registry._ensure_nauro_home()
-    assert created == home
-    assert oct(home.stat().st_mode & 0o777) == "0o700"
-
-
-def test_ensure_nauro_home_tightens_existing_wide_dir(tmp_path, monkeypatch):
-    """A home left group/other-accessible by an older build is tightened to
-    owner-only in place."""
-    home = tmp_path / "wide_home"
-    home.mkdir()
-    home.chmod(0o755)
-    monkeypatch.setenv("NAURO_HOME", str(home))
-    registry._ensure_nauro_home()
-    assert (home.stat().st_mode & 0o077) == 0
+    assert registry.get_store_path_v2(pid) == projects_dir() / pid

--- a/packages/nauro/tests/test_stdio_server.py
+++ b/packages/nauro/tests/test_stdio_server.py
@@ -236,9 +236,9 @@ class TestWelcomeDisambiguation:
         keeps the welcome screen. This asserts the narrowing of the
         onboarding case didn't lose the legitimate trigger."""
         # Drop the registry so no project can resolve from cwd or by name.
-        from nauro.store.registry import _registry_file
+        from nauro.store.home import registry_file
 
-        _registry_file().write_text('{"projects": {}, "schema_version": 2}\n')
+        registry_file().write_text('{"projects": {}, "schema_version": 2}\n')
         rendered = _rendered(get_raw_file(path="project.md"))
         assert "Welcome to Nauro" in rendered
 

--- a/packages/nauro/tests/test_store_home.py
+++ b/packages/nauro/tests/test_store_home.py
@@ -1,0 +1,52 @@
+"""Tests for nauro.store.home — the single resolution of the Nauro home path."""
+
+from pathlib import Path
+
+from nauro.store.home import (
+    config_file,
+    ensure_nauro_home,
+    nauro_home,
+    projects_dir,
+    registry_file,
+)
+
+
+def test_env_var_overrides_the_home(tmp_path, monkeypatch):
+    """``NAURO_HOME`` wins over the default location."""
+    override = tmp_path / "elsewhere"
+    monkeypatch.setenv("NAURO_HOME", str(override))
+    assert nauro_home() == override
+
+
+def test_default_home_is_dot_nauro_under_the_user_home(tmp_path, monkeypatch):
+    """Without the env var the home is ``~/.nauro``."""
+    monkeypatch.delenv("NAURO_HOME", raising=False)
+    assert nauro_home() == Path.home() / ".nauro"
+
+
+def test_ensure_creates_the_home_owner_only(tmp_path, monkeypatch):
+    """A fresh home is created at 0o700 so the token and store stay private."""
+    home = tmp_path / "fresh_home"
+    monkeypatch.setenv("NAURO_HOME", str(home))
+    assert ensure_nauro_home() == home
+    assert oct(home.stat().st_mode & 0o777) == "0o700"
+
+
+def test_ensure_keeps_an_existing_home_and_tightens_it(tmp_path, monkeypatch):
+    """An existing home keeps its contents; a group/other-accessible mode is fixed."""
+    home = tmp_path / "wide_home"
+    home.mkdir()
+    home.chmod(0o755)
+    (home / "config.json").write_text("{}")
+    monkeypatch.setenv("NAURO_HOME", str(home))
+    ensure_nauro_home()
+    assert (home / "config.json").read_text() == "{}"
+    assert (home.stat().st_mode & 0o077) == 0
+
+
+def test_named_paths_are_children_of_the_home(tmp_path, monkeypatch):
+    """Every named path resolves under the active home."""
+    home = tmp_path / "home_root"
+    monkeypatch.setenv("NAURO_HOME", str(home))
+    for path in (registry_file(), projects_dir(), config_file()):
+        assert path.parent == home

--- a/scripts/docstring_budget_baseline.txt
+++ b/scripts/docstring_budget_baseline.txt
@@ -443,7 +443,6 @@ packages/nauro/src/nauro/store/recovery.py::_seed_sync_state
 packages/nauro/src/nauro/store/recovery.py::_sweep_legacy_staging
 packages/nauro/src/nauro/store/recovery.py::restore_cloud_store
 packages/nauro/src/nauro/store/recovery.py::scaffold_empty_store
-packages/nauro/src/nauro/store/registry.py::_ensure_nauro_home
 packages/nauro/src/nauro/store/registry.py::_load_registry_v2_or_empty
 packages/nauro/src/nauro/store/registry.py::_validate_project_name
 packages/nauro/src/nauro/store/registry.py::add_repo_v2
@@ -457,7 +456,6 @@ packages/nauro/src/nauro/store/registry.py::remove_repo_v2
 packages/nauro/src/nauro/store/registry.py::rename_project_id_v2
 packages/nauro/src/nauro/store/registry.py::save_registry_v2
 packages/nauro/src/nauro/store/registry.py::suggest_project_for_path
-packages/nauro/src/nauro/store/repo_config.py::_global_config_file
 packages/nauro/src/nauro/store/repo_config.py::_is_valid_ulid
 packages/nauro/src/nauro/store/repo_config.py::collides_with_global_config
 packages/nauro/src/nauro/store/repo_config.py::find_repo_config


### PR DESCRIPTION
## Why

The `~/.nauro` path was resolved in 4 places. The registry, the user config, the repo config and the hook state directory each read the `NAURO_HOME` environment variable and each fell back to `~/.nauro`. A change to the rule had to be made 4 times, and a miss gave 2 different homes in 1 process.

The user config also imported a private helper from the registry across module boundaries. The repo config documented a cycle as the reason it could not import the registry, but the cycle was never broken.

## What changed

Added `packages/nauro/src/nauro/store/home.py`. It is the only place the home path is spelled. It exports 5 functions: `nauro_home`, `ensure_nauro_home`, `registry_file`, `projects_dir` and `config_file`. It imports only the standard library and `nauro.constants`, so any module can import it without a cycle.

Deleted the 4 duplicate implementations. All callers in `src` now import from `nauro.store.home`. Deleted the cross-module private import in `store/config.py`. Removed the stale cycle note from `store/repo_config.py`.

`cli/commands/hook.py` builds its `hook-state/` directory from `nauro_home()`. The directory name stays in the hook module because it is hook state, not store state.

Tests import the public names. No underscore aliases were left behind. No test patched a private home function, so no patch target moved. The fixtures already set the `NAURO_HOME` environment variable.

## Test plan

Added `packages/nauro/tests/test_store_home.py` with 5 tests. It covers the environment override, the default `~/.nauro`, creation at 0o700, an existing home that keeps its contents and gets tightened, and the 3 named paths as children of the home.

Moved the 2 home permission tests out of `test_registry.py`, because the function they test now lives in `store/home.py`.

`pytest packages/nauro/tests` gives 2663 passed and 10 skipped. `pytest packages/nauro-core/tests` gives 1633 passed. `ruff check` and `ruff format --check` are clean. The docstring budget guard exits 0 with 0 new and 0 stale entries. 2 baseline entries were removed for the 2 deleted functions.

## Risk

Low. Behavior is identical. The paths, the environment override, the permission bits and the lock file locations do not change. The move is mechanical and the test suites cover every caller.

## Deferred

`cli/commands/adopt.py` builds `repo_root / ".nauro" / "config.json"` in 2 places. That path is the repo-local config, not the home, and `store/repo_config.py:repo_config_path` already builds it from constants. This is a separate duplicate and is out of scope here.

`_config_lock` stays in `store/config.py`. It now calls `ensure_nauro_home` from the new module.
