### PR TITLE
Report omitted L0 questions and refresh README positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,12 @@
-
-
-
-
 # Nauro
 
-[![PyPI](https://img.shields.io/pypi/v/nauro.svg)](https://pypi.org/project/nauro/) [![Python](https://img.shields.io/pypi/pyversions/nauro.svg)](https://pypi.org/project/nauro/) [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
+[![PyPI](https://img.shields.io/pypi/v/nauro.svg)](https://pypi.org/project/nauro/) [![CI](https://github.com/Nauro-AI/nauro/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/Nauro-AI/nauro/actions/workflows/ci.yml) [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 
-**Give your agents the context code leaves out.**
+**The decision system for building software with AI.**
 
-Nauro keeps current state, open questions, and human-approved project judgment in one record, ready for every agent you connect.
+Nauro gives connected agents human-approved project judgment and current state before they plan or change work.
 
-The record combines project scope, state, open questions, and the rationale behind decisions. Nauro surfaces the relevant slice before work, then carries approved judgment and reported progress into later sessions and connected tools.
+Before work, Nauro surfaces the relevant part of that record. Approved judgment and reported progress carry into later sessions and connected tools.
 
 **Status:** Stable (1.x). Semantic versioning covers the CLI, local stdio MCP contract, on-disk store format, and curated `nauro-core` import API. Cloud sync and hosted MCP are versioned separately.
 
@@ -47,17 +43,17 @@ cd your-repo
 nauro adopt --with-skills --with-subagents
 ```
 
-Restart your agent, then invoke `/nauro-adopt` in Claude Code or `$nauro-adopt` in Codex. The skill reads project documentation and code, asks you about missing rationale, and seeds the project record without inventing decisions. The same onboarding command also installs the gated `nauro-ship-task` workflow and its planner, executor, reviewer, and tech-lead agents for both surfaces.
+Restart your agent, then invoke `/nauro-adopt` in Claude Code or `$nauro-adopt` in Codex. The skill reads the repo, asks about missing rationale, and seeds the project record. The optional flags also install the gated `nauro-ship-task` workflow and its four workflow agents.
 
-Run `nauro status` to verify MCP plus the installed skills and workflow agents. Run `nauro doctor` to check the project store itself. Re-running the onboarding command refreshes Nauro-owned workflow files and keeps recoverable backups of differing copies. It never migrates or changes third-party skills.
+Run `nauro status` to check MCP, skills, and workflow agents. Run `nauro doctor` to check the project store.
 
-Nauro surfaces prior judgment for the agent to assess. Retrieval is advisory and never blocks a change. New or revised judgment is written only after your explicit approval. Local use needs no account. The local record is plain Markdown that you own. Cloud sync and remote MCP access are optional. Nauro sends no product analytics.
+Nauro surfaces prior judgment for the agent to assess. Retrieval is advisory. New or revised judgment requires your explicit approval. Local use needs no account, and the record is plain Markdown on your machine. Cloud sync and remote MCP access are optional. Nauro sends no product analytics.
 
-Adoption, setup, and incidental regeneration preserve an unmanaged `AGENTS.md` and warn. `nauro sync` is the sole explicit overwrite path. A `# Manual` section survives replacement.
+Nauro preserves an existing `AGENTS.md` unless you explicitly run `nauro sync`. A `# Manual` section survives replacement.
 
 ## Desktop app (macOS)
 
-A free, read-only viewer over the project record: timeline, map, list, activity, docs. First launch sets up the CLI.
+A free, read-only viewer for the project record: timeline, map, list, activity, and docs. First launch installs the CLI, connects your agents, and adopts or attaches a project.
 
 https://github.com/user-attachments/assets/e23d3d7f-2d5b-4ce4-be18-fcaff74e7973
 

--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro-core"
-version = "1.11.0"
+version = "1.12.0"
 description = "Shared pure-Python logic for Nauro: parsing, validation, context assembly, constants."
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/nauro-core/src/nauro_core/context.py
+++ b/packages/nauro-core/src/nauro_core/context.py
@@ -280,13 +280,13 @@ def _render_open_questions(
 
 
 def _render_l0_open_questions(content: str) -> str:
-    """Render the L0 open-questions body: top 3 genuine entries, no trailer."""
+    """Render the L0 open-questions body with its capped omission report."""
     if not content.strip():
         return ""
     return _render_open_questions(
         OpenQuestionsFile.parse(content),
         L0_QUESTIONS_LIMIT,
-        include_omission_trailer=False,
+        include_omission_trailer=True,
     )
 
 

--- a/packages/nauro-core/tests/test_context.py
+++ b/packages/nauro-core/tests/test_context.py
@@ -4,6 +4,7 @@ from datetime import date as _date
 from datetime import datetime, timedelta, timezone
 
 from nauro_core.constants import (
+    L0_QUESTIONS_LIMIT,
     PROJECT_MD_SCAFFOLD_BODY,
     QUESTION_ENTRY_CHAR_BUDGET,
     STACK_AUTO_CHAR_BUDGET,
@@ -354,8 +355,8 @@ class TestBuildL2:
         # Every project/stack/questions string L1 surfaces must also appear in
         # the full dump, and L2 must additionally carry superseded decisions
         # and the nested stack rationale L1's bounded projection drops.
-        # L1's omission trailer and age-nudge lines are projection annotations,
-        # not store content, so they are absent from L2 (same as L0's today).
+        # L0/L1 omission trailers and age-nudge lines are projection annotations,
+        # not store content, so they are absent from L2.
         l1 = build_l1(FULL_FILES, DECISIONS)
         l2 = build_l2(FULL_FILES, DECISIONS)
         for marker in (
@@ -438,7 +439,7 @@ class TestBuildL0OpenQuestionsAgeProjection:
         assert self._PROJECTION_PREFIX not in result
 
     def test_only_first_three_open_entries_render(self):
-        # Honours L0_QUESTIONS_LIMIT (3). The fourth open entry is dropped
+        # Honours L0_QUESTIONS_LIMIT (3). The fourth open entry is omitted
         # even when older than 30 days; the projection doesn't expand the cap.
         today = self._today()
         content = (
@@ -454,6 +455,10 @@ class TestBuildL0OpenQuestionsAgeProjection:
         assert "second?" in result
         assert "third?" in result
         assert "fourth?" not in result
+        assert (
+            '(+1 more open questions — see get_raw_file("open-questions.md") '
+            "for the full file, including resolved history)"
+        ) in result
 
     def test_resolved_entries_skipped_in_l0(self):
         # Entries physically under ## Resolved (position-based partition)
@@ -551,8 +556,8 @@ class TestBuildL0DiscoveryPointerExclusion:
         assert "SELECT:" not in result
 
     def test_pointer_does_not_consume_limit_slot(self):
-        # With limit = 3, three genuine questions plus two pointers should all
-        # three genuine questions appear (pointers do not count toward the cap).
+        # The three pointers consume no slots, and the trailer counts only the
+        # fourth genuine question omitted beyond the cap.
         content = (
             "# Open Questions\n"
             "\n"
@@ -562,6 +567,7 @@ class TestBuildL0DiscoveryPointerExclusion:
             "- [Q4] RESUME: context/b.md — pointer two\n"
             "- [Q5] Third genuine question?\n"
             "- [Q6] Fourth genuine question — should be cut by limit?\n"
+            "- [Q7] SELECT: context/c.md — pointer three\n"
         )
         result = build_l0(self._files(content), [])
         assert "First genuine question?" in result
@@ -570,6 +576,11 @@ class TestBuildL0DiscoveryPointerExclusion:
         assert "Fourth genuine question" not in result
         assert "BRIEF:" not in result
         assert "RESUME:" not in result
+        assert "SELECT:" not in result
+        assert (
+            '(+1 more open questions — see get_raw_file("open-questions.md") '
+            "for the full file, including resolved history)"
+        ) in result
 
     def test_pointer_free_file_unaffected(self):
         content = (
@@ -732,12 +743,36 @@ class TestBuildL1OpenQuestionsProjection:
         assert "(open 45 days; consider closing or deferring)" in result
         assert "Stale at L1?" in result
 
-    def test_l0_never_carries_trailer(self):
-        # The trailer is an L1 annotation only; L0 output stays byte-stable
-        # (the surface parity baseline pins L0 bytes).
-        content = "# Open Questions\n\n" + self._genuine(12)
+    def test_l0_cap_enforced_with_exact_trailer(self):
+        content = "# Open Questions\n\n" + self._genuine(5)
         result = build_l0(self._files(content), [])
-        assert "more open questions" not in result
+
+        assert L0_QUESTIONS_LIMIT == 3
+        for i in range(1, 4):
+            assert f"Genuine question {i}?" in result
+        assert "Genuine question 4?" not in result
+        assert "Genuine question 5?" not in result
+        assert self._TRAILER_2 in result
+        assert result.count("more open questions") == 1
+
+    def test_l0_trailer_absent_at_or_below_cap(self):
+        for count in (L0_QUESTIONS_LIMIT - 1, L0_QUESTIONS_LIMIT):
+            content = "# Open Questions\n\n" + self._genuine(count)
+            result = build_l0(self._files(content), [])
+
+            assert f"Genuine question {count}?" in result
+            assert "more open questions" not in result
+
+    def test_l0_and_l1_use_identical_trailer_for_same_omitted_count(self):
+        l0 = build_l0(
+            self._files("# Open Questions\n\n" + self._genuine(L0_QUESTIONS_LIMIT + 2)),
+            [],
+        )
+        l1 = build_l1(self._files("# Open Questions\n\n" + self._genuine(12)), [])
+
+        l0_trailer = next(line for line in l0.splitlines() if line.startswith("(+"))
+        l1_trailer = next(line for line in l1.splitlines() if line.startswith("(+"))
+        assert l0_trailer == l1_trailer == self._TRAILER_2
 
 
 class TestQuestionEntryCharBudget:

--- a/packages/nauro/README.md
+++ b/packages/nauro/README.md
@@ -1,8 +1,8 @@
 # Nauro
 
-Give your agents the context code leaves out.
+The decision system for building software with AI.
 
-Nauro keeps current state, open questions, and human-approved project judgment in one record, ready for every agent you connect.
+Nauro gives connected agents human-approved project judgment and current state before they plan or change work.
 
 Nauro keeps a living project record. It combines project scope, current state, and open questions with human-approved project judgment: intent, goals, decisions, rationale, tradeoffs, and rejected paths. Project judgment is the human-ratified part of the record; context is the relevant slice of the record an agent receives for the work in front of it. Works with Claude, Perplexity, Cursor, Codex, and any MCP client.
 

--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "nauro-core>=1.11.0,<2",
+    "nauro-core>=1.12.0,<2",
     "typer>=0.9",
     "httpx>=0.24",
     "mcp>=1.0,<2",

--- a/packages/nauro/tests/test_agents_md.py
+++ b/packages/nauro/tests/test_agents_md.py
@@ -333,6 +333,31 @@ def test_sync_agents_md_truncates_over_budget_question_like_l0(tmp_path: Path, m
     assert "UNIQUE-TAIL-MARKER" not in content
 
 
+def test_sync_agents_md_carries_l0_question_omission_trailer(tmp_path: Path, monkeypatch):
+    from nauro.store.registry import register_project_v2
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _pid, store = register_project_v2("myproj", [repo])
+    scaffold_project_store("myproj", store)
+    questions = "".join(f"- [Q{i}] Genuine question {i}?\n" for i in range(1, 6))
+    (store / "open-questions.md").write_text("# Open Questions\n\n" + questions)
+    monkeypatch.chdir(repo)
+
+    result = runner.invoke(app, ["sync"])
+    assert result.exit_code == 0
+
+    content = (repo / "AGENTS.md").read_text()
+    assert "Genuine question 1?" in content
+    assert "Genuine question 3?" in content
+    assert "Genuine question 4?" not in content
+    assert "Genuine question 5?" not in content
+    assert (
+        '(+2 more open questions — see get_raw_file("open-questions.md") '
+        "for the full file, including resolved history)"
+    ) in content
+
+
 def test_sync_multi_repo(tmp_path: Path, monkeypatch):
     from nauro.store.registry import register_project_v2
 

--- a/packages/nauro/tests/test_distribution_copy.py
+++ b/packages/nauro/tests/test_distribution_copy.py
@@ -13,11 +13,11 @@ except ModuleNotFoundError:
 
 ROOT = Path(__file__).resolve().parents[3]
 
-HEADLINE = "Give your agents the context code leaves out."
+HEADLINE = "The decision system for building software with AI."
 
 SUPPORT_LINE = (
-    "Nauro keeps current state, open questions, and human-approved project judgment "
-    "in one record, ready for every agent you connect."
+    "Nauro gives connected agents human-approved project judgment and current state "
+    "before they plan or change work."
 )
 
 FIT_BOUNDARY = (

--- a/packages/nauro/tests/test_get_context_parity.py
+++ b/packages/nauro/tests/test_get_context_parity.py
@@ -24,12 +24,14 @@ from datetime import date
 from pathlib import Path
 
 import pytest
+from nauro_core.constants import L0_QUESTIONS_LIMIT
 from nauro_core.decision_model import (
     Decision,
     DecisionConfidence,
     DecisionStatus,
     format_decision,
 )
+from nauro_core.questions import OpenQuestionsFile
 from nauro_core.renderers import RENDERERS
 
 from nauro.constants import REPO_CONFIG_MODE_LOCAL
@@ -243,5 +245,8 @@ def _seed_baseline_store(store_path: Path) -> None:
 def test_l0_content_matches_main_byte_for_byte(tmp_path):
     store_path = tmp_path / "store"
     _seed_baseline_store(store_path)
+    questions = OpenQuestionsFile.parse((store_path / "open-questions.md").read_text())
+
+    assert len(questions.genuine_open_entries) < L0_QUESTIONS_LIMIT
     envelope = tool_get_context(store_path, 0)
     assert envelope["content"] == _BASELINE_L0

--- a/uv.lock
+++ b/uv.lock
@@ -989,7 +989,7 @@ provides-extras = ["dev", "embeddings"]
 
 [[package]]
 name = "nauro-core"
-version = "1.11.0"
+version = "1.12.0"
 source = { editable = "packages/nauro-core" }
 dependencies = [
     { name = "bm25s" },


### PR DESCRIPTION
## Why

L0 caps open questions at three but did not report how many genuine questions it omitted. This could make bounded context look complete. The public README copy also led with context instead of Nauro's decision-system position, and its badges did not show build health.

## What changed

- Add an exact omission trailer when L0 excludes genuine open questions.
- Keep discovery pointers out of both the L0 limit and omission count.
- Cover core rendering, generated AGENTS.md output, and byte-stable baseline assumptions.
- Bump nauro-core to 1.12.0 and update the CLI dependency floor.
- Refresh the root and package README headline, support copy, CI badge, onboarding text, and desktop app description.

## Test plan

- `PYTHONPATH=packages/nauro/src:packages/nauro-core/src .venv/bin/pytest packages/nauro-core/tests/test_context.py packages/nauro/tests/test_agents_md.py packages/nauro/tests/test_get_context_parity.py packages/nauro/tests/test_distribution_copy.py -q`
- Result: 157 passed.
- `git diff --check origin/main...HEAD`

## Risk / what to review

The L0 payload changes only when more than three genuine open questions exist. Review the exact omitted count, discovery-pointer exclusion, and the nauro-core version boundary.
