### PR TITLE
Add canonical question provenance codec

### DIFF
--- a/packages/nauro-core/src/nauro_core/operations/flag_question.py
+++ b/packages/nauro-core/src/nauro_core/operations/flag_question.py
@@ -29,7 +29,13 @@ from nauro_core.question_append import (
     compose_question_entry,
     insert_question_entry,
 )
-from nauro_core.questions import EntryBlock, OpenQuestionsFile
+from nauro_core.questions import (
+    EntryBlock,
+    InvalidQuestionIdentifier,
+    OpenQuestionsFile,
+    format_question_id,
+    parse_question_id,
+)
 
 # Private alias kept for one release: a deployed consumer still imports this
 # name. New code reads OPEN_QUESTIONS_DEFAULT_BODY from nauro_core directly.
@@ -79,6 +85,7 @@ def flag_question(
         specific failure; no write occurs.
     """
     del context  # adapter composes context into question; kernel sees one body.
+    canonical_targets = _canonical_question_targets(targets or [])
 
     has_question = question is not None and question.strip() != ""
     if resolved_by is not None:
@@ -87,7 +94,7 @@ def flag_question(
                 "Pass either question (to append a new flag) or resolved_by "
                 "(to resolve existing entries), not both."
             )
-        return _resolve(store, targets or [], resolved_by)
+        return _resolve(store, canonical_targets, resolved_by)
 
     if not has_question:
         return _reject(
@@ -99,8 +106,8 @@ def flag_question(
     content = store.read_file(OPEN_QUESTIONS_MD) or _DEFAULT_FILE_BODY
     parsed = OpenQuestionsFile.parse(content)
 
-    if targets:
-        rejection = _short_circuit_if_resolved(parsed, targets)
+    if canonical_targets:
+        rejection = _short_circuit_if_resolved(parsed, canonical_targets)
         if rejection is not None:
             return rejection
 
@@ -111,6 +118,18 @@ def flag_question(
     return FlagQuestionResult(status="ok", num=next_num)
 
 
+def _canonical_question_targets(targets: list[str]) -> list[str]:
+    canonical: list[str] = []
+    for target in targets:
+        try:
+            number = parse_question_id(target)
+        except InvalidQuestionIdentifier:
+            canonical.append(target)
+        else:
+            canonical.append(format_question_id(number))
+    return canonical
+
+
 def _short_circuit_if_resolved(
     parsed: OpenQuestionsFile,
     targets: list[str],
@@ -119,6 +138,15 @@ def _short_circuit_if_resolved(
     working copy only, so it is best-effort: a stale local copy missing a fresh
     remote resolution falls through to the normal append path.
     """
+    ambiguous = parsed.ambiguous_ids
+    requested_ambiguous = [target for target in targets if target in ambiguous]
+    if requested_ambiguous:
+        return _reject(
+            "targets contains ambiguous id(s) matching more than one entry: "
+            + ", ".join(repr(target) for target in dict.fromkeys(requested_ambiguous))
+            + ". The flag was not appended."
+        )
+
     entries_by_id: dict[str, EntryBlock] = {}
     for block in parsed.blocks:
         if isinstance(block, EntryBlock):

--- a/packages/nauro-core/src/nauro_core/question_append.py
+++ b/packages/nauro-core/src/nauro_core/question_append.py
@@ -10,7 +10,7 @@ pure — the caller reads and writes the file bytes.
 
 from __future__ import annotations
 
-from nauro_core.questions import OpenQuestionsFile
+from nauro_core.questions import OpenQuestionsFile, format_question_id
 
 
 def allocate_question_number(parsed: OpenQuestionsFile) -> int:
@@ -23,7 +23,7 @@ def allocate_question_number(parsed: OpenQuestionsFile) -> int:
 
 def compose_question_entry(num: int, body: str) -> str:
     """Compose the canonical single-line entry for *body* under ``Q{num}``."""
-    return f"- [Q{num}] {body}"
+    return f"- [{format_question_id(num)}] {body}"
 
 
 def insert_question_entry(content: str, entry: str) -> str:

--- a/packages/nauro-core/src/nauro_core/question_provenance.py
+++ b/packages/nauro-core/src/nauro_core/question_provenance.py
@@ -1,0 +1,370 @@
+"""Strict immutable codec for the questions-provenance.json sidecar."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from types import MappingProxyType
+from typing import ClassVar, Literal
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    StrictStr,
+    ValidationError,
+    field_serializer,
+    field_validator,
+    model_validator,
+)
+
+from nauro_core.identifiers import IdentifierKind, validate_identifier
+from nauro_core.provenance import validate_utc_timestamp
+from nauro_core.questions import (
+    InvalidLegacyQuestionIdentifier,
+    InvalidQuestionIdentifier,
+    validate_legacy_question_id,
+    validate_question_id,
+)
+
+QUESTION_PROVENANCE_SCHEMA_VERSION = 1
+
+
+class QuestionProvenanceError(ValueError):
+    """Base class for closed question-provenance codec failures."""
+
+    classification: ClassVar[str]
+
+    def __init__(self, message: str) -> None:
+        self.classification = type(self).classification
+        super().__init__(message)
+
+
+class QuestionProvenanceInvalidUtf8(QuestionProvenanceError):
+    classification = "question_provenance_invalid_utf8"
+
+
+class QuestionProvenanceMalformedJson(QuestionProvenanceError):
+    classification = "question_provenance_json_malformed"
+
+
+class QuestionProvenanceDuplicateKey(QuestionProvenanceError):
+    classification = "question_provenance_duplicate_key"
+
+
+class QuestionProvenanceVersionUnsupported(QuestionProvenanceError):
+    classification = "question_provenance_version_unsupported"
+
+
+class QuestionProvenanceSchemaInvalid(QuestionProvenanceError):
+    classification = "question_provenance_schema_invalid"
+
+
+class QuestionProvenanceNoncanonical(QuestionProvenanceError):
+    classification = "question_provenance_noncanonical"
+
+
+class QuestionProvenanceConflict(QuestionProvenanceError):
+    classification = "question_provenance_conflict"
+
+
+class QuestionProvenanceLegacyMissing(QuestionProvenanceConflict):
+    classification = "question_provenance_legacy_missing"
+
+
+class QuestionProvenanceRecord(BaseModel):
+    """Immutable actor, time, and event provenance for one question."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    actor_id: StrictStr
+    created_at: StrictStr
+    event_id: StrictStr
+
+    @field_validator("actor_id")
+    @classmethod
+    def actor_id_is_ulid(cls, value: str) -> str:
+        return validate_identifier(IdentifierKind.ulid, value, field="actor_id")
+
+    @field_validator("created_at")
+    @classmethod
+    def created_at_is_utc(cls, value: str) -> str:
+        return validate_utc_timestamp(value, field="created_at")
+
+    @field_validator("event_id")
+    @classmethod
+    def event_id_is_ulid(cls, value: str) -> str:
+        return validate_identifier(IdentifierKind.ulid, value, field="event_id")
+
+
+class LegacyQuestionProvenanceRecord(QuestionProvenanceRecord):
+    """Immutable legacy provenance with its optional canonical Q-form alias."""
+
+    current_question_id: StrictStr | None
+
+    @field_validator("current_question_id")
+    @classmethod
+    def current_id_is_canonical(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return validate_question_id(value, field="current_question_id")
+
+
+class QuestionProvenanceDocument(BaseModel):
+    """Immutable schema-1 question-provenance projection."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    schema_version: Literal[1]
+    by_question_id: Mapping[str, QuestionProvenanceRecord]
+    by_legacy_id: Mapping[str, LegacyQuestionProvenanceRecord]
+
+    @field_validator("schema_version", mode="before")
+    @classmethod
+    def schema_version_is_integer_one(cls, value: object) -> object:
+        if type(value) is not int or value != QUESTION_PROVENANCE_SCHEMA_VERSION:
+            raise ValueError("schema_version must be integer 1")
+        return value
+
+    @model_validator(mode="after")
+    def validate_and_freeze_maps(self) -> QuestionProvenanceDocument:
+        question_records = dict(self.by_question_id)
+        legacy_records = dict(self.by_legacy_id)
+
+        for question_id in question_records:
+            validate_question_id(question_id, field="by_question_id key")
+        for legacy_id in legacy_records:
+            validate_legacy_question_id(legacy_id, field="by_legacy_id key")
+
+        for legacy_record in legacy_records.values():
+            current_id = legacy_record.current_question_id
+            if current_id is None:
+                continue
+            question_record = question_records.get(current_id)
+            if question_record is None or not _same_provenance(question_record, legacy_record):
+                raise ValueError("legacy alias must reference an equal question provenance record")
+
+        object.__setattr__(self, "by_question_id", MappingProxyType(question_records))
+        object.__setattr__(self, "by_legacy_id", MappingProxyType(legacy_records))
+        return self
+
+    @field_serializer("by_question_id", "by_legacy_id")
+    def serialize_mapping(self, value: Mapping[str, BaseModel]) -> dict[str, object]:
+        return {key: record.model_dump(mode="json") for key, record in value.items()}
+
+
+class QuestionProvenanceMutation(BaseModel):
+    """Immutable result of an insertion, migration, or replay."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    status: Literal["inserted", "migrated", "replayed"]
+    document: QuestionProvenanceDocument
+
+
+def parse_question_provenance(data: bytes) -> QuestionProvenanceDocument:
+    """Parse exact canonical schema-1 bytes into an immutable document."""
+    if not isinstance(data, bytes):
+        raise QuestionProvenanceMalformedJson("question provenance input must be bytes")
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise QuestionProvenanceInvalidUtf8(
+            "question provenance input must be valid UTF-8"
+        ) from exc
+    try:
+        raw = json.loads(
+            text,
+            object_pairs_hook=_reject_duplicate_keys,
+            parse_constant=_reject_json_constant,
+        )
+    except QuestionProvenanceError:
+        raise
+    except (ValueError, TypeError, RecursionError) as exc:
+        raise QuestionProvenanceMalformedJson(
+            "question provenance input must be valid JSON"
+        ) from exc
+    if not isinstance(raw, dict):
+        raise QuestionProvenanceMalformedJson("question provenance root must be an object")
+
+    version = raw.get("schema_version")
+    if type(version) is int and version != QUESTION_PROVENANCE_SCHEMA_VERSION:
+        raise QuestionProvenanceVersionUnsupported(
+            "question provenance schema version is unsupported"
+        )
+
+    try:
+        document = QuestionProvenanceDocument.model_validate(raw)
+    except (ValidationError, InvalidQuestionIdentifier, InvalidLegacyQuestionIdentifier) as exc:
+        raise QuestionProvenanceSchemaInvalid(
+            "question provenance document violates schema 1"
+        ) from exc
+
+    if serialize_question_provenance(document) != data:
+        raise QuestionProvenanceNoncanonical(
+            "question provenance input is not canonical schema-1 JSON"
+        )
+    return document
+
+
+def serialize_question_provenance(document: QuestionProvenanceDocument) -> bytes:
+    """Serialize an immutable document to exact canonical schema-1 bytes."""
+    if not isinstance(document, QuestionProvenanceDocument):
+        raise QuestionProvenanceSchemaInvalid(
+            "question provenance value must be a QuestionProvenanceDocument"
+        )
+    value = _document_value(document)
+    return (
+        json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            allow_nan=False,
+        ).encode("utf-8")
+        + b"\n"
+    )
+
+
+def insert_question_provenance(
+    document: QuestionProvenanceDocument,
+    *,
+    question_id: str,
+    provenance: QuestionProvenanceRecord,
+) -> QuestionProvenanceMutation:
+    """Insert one canonical Q-form record, replay identically, or refuse conflict."""
+    _require_document(document)
+    _require_record(provenance)
+    try:
+        canonical_id = validate_question_id(question_id, field="question_id")
+    except InvalidQuestionIdentifier as exc:
+        raise QuestionProvenanceSchemaInvalid(
+            "question_id must be a canonical unpadded Q-form"
+        ) from exc
+
+    existing = document.by_question_id.get(canonical_id)
+    if existing is not None:
+        if existing == provenance:
+            return QuestionProvenanceMutation(status="replayed", document=document)
+        raise QuestionProvenanceConflict("question provenance record already differs")
+
+    question_records = dict(document.by_question_id)
+    question_records[canonical_id] = provenance
+    updated = QuestionProvenanceDocument(
+        schema_version=QUESTION_PROVENANCE_SCHEMA_VERSION,
+        by_question_id=question_records,
+        by_legacy_id=document.by_legacy_id,
+    )
+    return QuestionProvenanceMutation(status="inserted", document=updated)
+
+
+def migrate_legacy_question_provenance(
+    document: QuestionProvenanceDocument,
+    *,
+    legacy_id: str,
+    current_question_id: str,
+) -> QuestionProvenanceMutation:
+    """Bind retained legacy provenance to one derived canonical Q-form record."""
+    _require_document(document)
+    try:
+        validated_legacy_id = validate_legacy_question_id(legacy_id)
+        canonical_id = validate_question_id(current_question_id, field="current_question_id")
+    except (InvalidLegacyQuestionIdentifier, InvalidQuestionIdentifier) as exc:
+        raise QuestionProvenanceSchemaInvalid(
+            "legacy migration identifiers violate the provenance schema"
+        ) from exc
+
+    legacy = document.by_legacy_id.get(validated_legacy_id)
+    if legacy is None:
+        raise QuestionProvenanceLegacyMissing("legacy question provenance is absent")
+    if legacy.current_question_id not in (None, canonical_id):
+        raise QuestionProvenanceConflict("legacy provenance already names another question")
+
+    derived = QuestionProvenanceRecord(
+        actor_id=legacy.actor_id,
+        created_at=legacy.created_at,
+        event_id=legacy.event_id,
+    )
+    existing = document.by_question_id.get(canonical_id)
+    if existing is not None and existing != derived:
+        raise QuestionProvenanceConflict("canonical question provenance already differs")
+    if existing == derived and legacy.current_question_id == canonical_id:
+        return QuestionProvenanceMutation(status="replayed", document=document)
+
+    question_records = dict(document.by_question_id)
+    question_records[canonical_id] = derived
+    legacy_records = dict(document.by_legacy_id)
+    legacy_records[validated_legacy_id] = legacy.model_copy(
+        update={"current_question_id": canonical_id}
+    )
+    updated = QuestionProvenanceDocument(
+        schema_version=QUESTION_PROVENANCE_SCHEMA_VERSION,
+        by_question_id=question_records,
+        by_legacy_id=legacy_records,
+    )
+    return QuestionProvenanceMutation(status="migrated", document=updated)
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise QuestionProvenanceDuplicateKey(
+                "question provenance input contains a duplicate object key"
+            )
+        result[key] = value
+    return result
+
+
+def _reject_json_constant(value: str) -> object:
+    raise QuestionProvenanceMalformedJson(
+        "question provenance input contains an invalid JSON number"
+    )
+
+
+def _same_provenance(
+    question: QuestionProvenanceRecord,
+    legacy: LegacyQuestionProvenanceRecord,
+) -> bool:
+    return (
+        question.actor_id == legacy.actor_id
+        and question.created_at == legacy.created_at
+        and question.event_id == legacy.event_id
+    )
+
+
+def _record_value(record: QuestionProvenanceRecord) -> dict[str, str]:
+    return {
+        "actor_id": record.actor_id,
+        "created_at": record.created_at,
+        "event_id": record.event_id,
+    }
+
+
+def _document_value(document: QuestionProvenanceDocument) -> dict[str, object]:
+    legacy_values: dict[str, object] = {}
+    for legacy_id, record in document.by_legacy_id.items():
+        value: dict[str, object] = _record_value(record)
+        value["current_question_id"] = record.current_question_id
+        legacy_values[legacy_id] = value
+    return {
+        "schema_version": document.schema_version,
+        "by_question_id": {
+            question_id: _record_value(record)
+            for question_id, record in document.by_question_id.items()
+        },
+        "by_legacy_id": legacy_values,
+    }
+
+
+def _require_document(document: object) -> QuestionProvenanceDocument:
+    if not isinstance(document, QuestionProvenanceDocument):
+        raise QuestionProvenanceSchemaInvalid("document must be a QuestionProvenanceDocument")
+    return document
+
+
+def _require_record(provenance: object) -> QuestionProvenanceRecord:
+    if not isinstance(provenance, QuestionProvenanceRecord) or isinstance(
+        provenance, LegacyQuestionProvenanceRecord
+    ):
+        raise QuestionProvenanceSchemaInvalid("provenance must be a QuestionProvenanceRecord")
+    return provenance

--- a/packages/nauro-core/src/nauro_core/questions.py
+++ b/packages/nauro-core/src/nauro_core/questions.py
@@ -22,7 +22,7 @@ from datetime import date as _date
 from datetime import datetime
 from typing import Annotated, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, model_validator
 
 from nauro_core.constants import POINTER_FLAG_PREFIXES, QUESTION_ENTRY_CHAR_BUDGET
 from nauro_core.parsing import is_ascii_decimal
@@ -36,6 +36,86 @@ _RESOLVED_PREFIX_SEP = " on "
 # Appended to over-budget entry text by :func:`truncate_entry_text` so a
 # capped payload never silently hides content.
 QUESTION_TRUNCATION_POINTER = '... [truncated - full text: get_raw_file("open-questions.md")]'
+
+
+class InvalidQuestionIdentifier(ValueError):
+    """A question identifier is not valid for the requested boundary."""
+
+    def __init__(self, field: str, requirement: str) -> None:
+        self.field = field
+        super().__init__(f"{field} must be {requirement}.")
+
+
+class InvalidLegacyQuestionIdentifier(ValueError):
+    """A legacy question identifier is not in its permanent exact grammar."""
+
+    def __init__(self, field: str) -> None:
+        self.field = field
+        super().__init__(f"{field} must use valid YYYY-MM-DD HH:MM UTC form.")
+
+
+def format_question_id(number: object, *, field: str = "question_number") -> str:
+    """Return the canonical unpadded Q-form for a positive integer."""
+    if isinstance(number, bool) or not isinstance(number, int) or number < 1:
+        raise InvalidQuestionIdentifier(field, "a positive integer")
+    return "Q" + _format_positive_ascii_decimal(number)
+
+
+def parse_question_id(value: object, *, field: str = "question_id") -> int:
+    """Return the numeric identity of a compatible Q-form input."""
+    if not isinstance(value, str) or len(value) < 2 or value[0] != "Q":
+        raise InvalidQuestionIdentifier(field, "Q followed by positive ASCII decimal digits")
+    digits = value[1:]
+    if not is_ascii_decimal(digits):
+        raise InvalidQuestionIdentifier(field, "Q followed by positive ASCII decimal digits")
+    number = 0
+    for digit in digits:
+        number = number * 10 + ord(digit) - ord("0")
+    if number < 1:
+        raise InvalidQuestionIdentifier(field, "Q followed by positive ASCII decimal digits")
+    return number
+
+
+def _format_positive_ascii_decimal(number: int) -> str:
+    chunks: list[int] = []
+    while number:
+        number, remainder = divmod(number, 1_000_000_000)
+        chunks.append(remainder)
+    head = str(chunks.pop())
+    return head + "".join(f"{chunk:09d}" for chunk in reversed(chunks))
+
+
+def validate_question_id(value: object, *, field: str = "question_id") -> str:
+    """Return a canonical unpadded Q-form or raise."""
+    number = parse_question_id(value, field=field)
+    canonical = format_question_id(number, field=field)
+    if value != canonical:
+        raise InvalidQuestionIdentifier(field, "a canonical unpadded Q-form")
+    return canonical
+
+
+def validate_legacy_question_id(
+    value: object,
+    *,
+    field: str = "legacy_question_id",
+) -> str:
+    """Return an exact calendar-valid legacy timestamp identifier or raise."""
+    if not isinstance(value, str) or len(value) != 20:
+        raise InvalidLegacyQuestionIdentifier(field)
+    if value[4] != "-" or value[7] != "-" or value[10] != " ":
+        raise InvalidLegacyQuestionIdentifier(field)
+    if value[13] != ":" or value[16:] != " UTC":
+        raise InvalidLegacyQuestionIdentifier(field)
+    digits = (value[0:4], value[5:7], value[8:10], value[11:13], value[14:16])
+    if not all(is_ascii_decimal(part) for part in digits):
+        raise InvalidLegacyQuestionIdentifier(field)
+    try:
+        parsed = datetime.strptime(value, _TIMESTAMP_FMT)
+    except ValueError as exc:
+        raise InvalidLegacyQuestionIdentifier(field) from exc
+    if parsed.strftime(_TIMESTAMP_FMT) != value:
+        raise InvalidLegacyQuestionIdentifier(field)
+    return value
 
 
 def truncate_entry_text(text: str) -> str:
@@ -72,6 +152,7 @@ class QuestionEntry(BaseModel):
     body: str
     continuation: list[str] = Field(default_factory=list)
     resolved_by: ResolvedRef | None = None
+    _source_question_id: str | None = PrivateAttr(default=None)
 
     @model_validator(mode="after")
     def exactly_one_id(self) -> QuestionEntry:
@@ -85,9 +166,13 @@ class QuestionEntry(BaseModel):
     @property
     def id(self) -> str:
         if self.num is not None:
-            return f"Q{self.num}"
+            return format_question_id(self.num)
         assert self.timestamp is not None  # exactly_one_id validator
         return self.timestamp.strftime(_TIMESTAMP_FMT)
+
+    @property
+    def _render_id(self) -> str:
+        return self._source_question_id or self.id
 
     @property
     def is_discovery_pointer(self) -> bool:
@@ -103,10 +188,10 @@ class QuestionEntry(BaseModel):
             ref = self.resolved_by
             head = (
                 f"- [Resolved by D{ref.decision_num} on {ref.date.isoformat()}] "
-                f"[{self.id}] {self.body}"
+                f"[{self._render_id}] {self.body}"
             )
         else:
-            head = f"- [{self.id}] {self.body}"
+            head = f"- [{self._render_id}] {self.body}"
         return [head, *self.continuation]
 
 
@@ -426,8 +511,13 @@ class OpenQuestionsFile(BaseModel):
         for b in self.blocks:
             if isinstance(b, EntryBlock):
                 known.add(b.entry.id)
+                if b.entry._source_question_id is not None:
+                    known.add(b.entry._source_question_id)
             elif isinstance(b, TripleHashBlock) and b.embedded_id is not None:
                 known.add(b.embedded_id)
+                number = _parse_q_id(b.embedded_id)
+                if number is not None:
+                    known.add(format_question_id(number))
         return known
 
     @property
@@ -437,10 +527,19 @@ class OpenQuestionsFile(BaseModel):
         Legacy timestamp ids can collide within a minute, so a boundary can reject first.
         """
         counts: dict[str, int] = {}
+        aliases: dict[str, set[str]] = {}
         for b in self.blocks:
             if isinstance(b, EntryBlock):
-                counts[b.entry.id] = counts.get(b.entry.id, 0) + 1
-        return {k: v for k, v in counts.items() if v > 1}
+                canonical_id = b.entry.id
+                counts[canonical_id] = counts.get(canonical_id, 0) + 1
+                aliases.setdefault(canonical_id, set()).add(canonical_id)
+                if b.entry._source_question_id is not None:
+                    aliases[canonical_id].add(b.entry._source_question_id)
+        ambiguous: dict[str, int] = {}
+        for canonical_id, count in counts.items():
+            if count > 1:
+                ambiguous.update({alias: count for alias in sorted(aliases[canonical_id])})
+        return ambiguous
 
     def resolve(
         self,
@@ -463,7 +562,7 @@ class OpenQuestionsFile(BaseModel):
         if not ids:
             return ResolveResult(file=self, moved_ids=(), unknown_ids=())
 
-        requested = list(dict.fromkeys(ids))
+        requested = list(dict.fromkeys(_canonicalize_question_reference(value) for value in ids))
         ambiguous_map = self.ambiguous_ids
         ambiguous_requested = tuple(i for i in requested if i in ambiguous_map)
         if ambiguous_requested:
@@ -535,7 +634,11 @@ class OpenQuestionsFile(BaseModel):
                 )
                 new_blocks.append(EntryBlock(entry=new_entry))
                 renames.append(
-                    MigrationRename(old_id=old_id, new_id=f"Q{next_num}", logged=logged)
+                    MigrationRename(
+                        old_id=old_id,
+                        new_id=format_question_id(next_num),
+                        logged=logged,
+                    )
                 )
                 next_num += 1
             else:
@@ -719,8 +822,9 @@ def _parse_entry(lines: list[str], start: int) -> tuple[QuestionEntry | None, in
     timestamp: datetime | None = None
     if num is None:
         try:
+            validate_legacy_question_id(id_str)
             timestamp = datetime.strptime(id_str, _TIMESTAMP_FMT)
-        except ValueError:
+        except (InvalidLegacyQuestionIdentifier, ValueError):
             return None, 1
 
     continuation: list[str] = []
@@ -729,16 +833,16 @@ def _parse_entry(lines: list[str], start: int) -> tuple[QuestionEntry | None, in
         continuation.append(lines[j])
         j += 1
 
-    return (
-        QuestionEntry(
-            num=num,
-            timestamp=timestamp,
-            body=body,
-            continuation=continuation,
-            resolved_by=resolved_ref,
-        ),
-        j - start,
+    entry = QuestionEntry(
+        num=num,
+        timestamp=timestamp,
+        body=body,
+        continuation=continuation,
+        resolved_by=resolved_ref,
     )
+    if num is not None:
+        entry._source_question_id = id_str
+    return entry, j - start
 
 
 def _parse_q_id(text: str) -> int | None:
@@ -746,15 +850,17 @@ def _parse_q_id(text: str) -> int | None:
 
     Mirrors ``QuestionEntry``'s ``ge=1`` bound, so ``[Q0]`` degrades to unparsable.
     """
-    if len(text) < 2 or text[0] != "Q":
+    try:
+        return parse_question_id(text)
+    except InvalidQuestionIdentifier:
         return None
-    digits = text[1:]
-    if not is_ascii_decimal(digits):
-        return None
-    num = int(digits)
-    if num < 1:
-        return None
-    return num
+
+
+def _canonicalize_question_reference(value: str) -> str:
+    try:
+        return format_question_id(parse_question_id(value))
+    except InvalidQuestionIdentifier:
+        return value
 
 
 def _parse_resolved_prefix(text: str) -> ResolvedRef | None:
@@ -789,8 +895,8 @@ def _extract_embedded_id(line: str) -> str | None:
         if _parse_q_id(candidate) is not None:
             return candidate
         try:
-            datetime.strptime(candidate, _TIMESTAMP_FMT)
+            validate_legacy_question_id(candidate)
             return candidate
-        except ValueError:
+        except InvalidLegacyQuestionIdentifier:
             start = line.find("[", end + 1)
     return None

--- a/packages/nauro-core/tests/operations/test_operations_flag_question.py
+++ b/packages/nauro-core/tests/operations/test_operations_flag_question.py
@@ -167,6 +167,43 @@ def test_targets_pointing_at_resolved_entry_short_circuits() -> None:
     assert store.read_file(OPEN_QUESTIONS_MD) == before
 
 
+@pytest.mark.parametrize(
+    ("entry_id", "target"),
+    [("Q17", "Q017"), ("Q017", "Q17")],
+)
+def test_resolved_entry_short_circuits_through_either_q_spelling(
+    entry_id: str,
+    target: str,
+) -> None:
+    seed = f"# Open Questions\n\n- [Resolved by D42 on 2026-05-20] [{entry_id}] already resolved\n"
+    store = InMemoryStore(files={OPEN_QUESTIONS_MD: seed})
+    before = store.read_file(OPEN_QUESTIONS_MD)
+    result = flag_question(store, "duplicate", targets=[target])
+    assert result.status == "rejected"
+    assert result.error is not None
+    assert "Q17 is already resolved by D42" in result.error.reason
+    assert store.read_file(OPEN_QUESTIONS_MD) == before
+
+
+@pytest.mark.parametrize("target", ["Q017", "Q17"])
+def test_append_refuses_ambiguous_q_identity_when_resolved_entry_is_second(
+    target: str,
+) -> None:
+    seed = (
+        "# Open Questions\n\n"
+        "- [Q017] open first\n"
+        "- [Resolved by D42 on 2026-05-20] [Q17] resolved second\n"
+    )
+    store = InMemoryStore(files={OPEN_QUESTIONS_MD: seed})
+    before = store.read_file(OPEN_QUESTIONS_MD)
+    result = flag_question(store, "duplicate", targets=[target])
+    assert result.status == "rejected"
+    assert result.error is not None
+    assert "ambiguous" in result.error.reason
+    assert "Q17" in result.error.reason
+    assert store.read_file(OPEN_QUESTIONS_MD) == before
+
+
 def test_targets_pointing_at_open_entry_appends_normally() -> None:
     seed = "# Open Questions\n\n- [Q1] still open\n- [Q5] also still open\n"
     store = InMemoryStore(files={OPEN_QUESTIONS_MD: seed})
@@ -275,6 +312,28 @@ def test_resolve_relocates_target_below_divider_and_returns_ok() -> None:
     q5_line = next(line for line in content.split("\n") if "[Q5]" in line)
     assert q5_line.startswith("- [Resolved by D42 on ")
     assert content.index("[Q1] still open") < content.index("## Resolved") < content.index("[Q5]")
+
+
+@pytest.mark.parametrize(
+    ("entry_id", "target"),
+    [("Q17", "Q017"), ("Q017", "Q17")],
+)
+def test_resolve_accepts_either_q_spelling_and_preserves_source(
+    entry_id: str,
+    target: str,
+) -> None:
+    seed = f"# Open Questions\n\n- [{entry_id}] open\n"
+    store = InMemoryStore(
+        decisions=_decisions(42),
+        files={OPEN_QUESTIONS_MD: seed},
+    )
+    result = flag_question(store, targets=[target], resolved_by="D42")
+    assert result.status == "ok"
+    assert result.relocated_ids == ("Q17",)
+    content = store.read_file(OPEN_QUESTIONS_MD)
+    assert content is not None
+    assert f"[{entry_id}] open" in content
+    assert "[Resolved by D42 on " in content
 
 
 def test_resolve_does_not_append_a_question() -> None:
@@ -394,6 +453,38 @@ def test_resolve_ambiguous_target_rejects_naming_id() -> None:
     assert result.status == "rejected"
     assert result.error is not None
     assert "2026-04-30 10:00 UTC" in result.error.reason
+
+
+@pytest.mark.parametrize("target", ["Q17", "Q017"])
+def test_resolve_rejects_padded_and_unpadded_duplicate_through_either_spelling(
+    target: str,
+) -> None:
+    seed = "# Open Questions\n\n- [Q017] padded\n- [Q17] canonical\n"
+    store = InMemoryStore(
+        decisions=_decisions(42),
+        files={OPEN_QUESTIONS_MD: seed},
+    )
+    before = store.read_file(OPEN_QUESTIONS_MD)
+    result = flag_question(store, targets=[target], resolved_by="D42")
+    assert result.status == "rejected"
+    assert result.error is not None
+    assert "Q17" in result.error.reason
+    assert store.read_file(OPEN_QUESTIONS_MD) == before
+
+
+def test_resolve_legacy_timestamp_id_is_unchanged() -> None:
+    legacy_id = "2026-04-30 10:00 UTC"
+    seed = f"# Open Questions\n\n- [{legacy_id}] legacy open\n"
+    store = InMemoryStore(
+        decisions=_decisions(42),
+        files={OPEN_QUESTIONS_MD: seed},
+    )
+    result = flag_question(store, targets=[legacy_id], resolved_by="D42")
+    assert result.status == "ok"
+    assert result.relocated_ids == (legacy_id,)
+    content = store.read_file(OPEN_QUESTIONS_MD)
+    assert content is not None
+    assert f"[{legacy_id}] legacy open" in content
 
 
 def test_resolve_with_no_targets_rejects() -> None:

--- a/packages/nauro-core/tests/test_question_append.py
+++ b/packages/nauro-core/tests/test_question_append.py
@@ -8,12 +8,14 @@ behavior, these pin the helpers' own contract.
 
 from __future__ import annotations
 
+import pytest
+
 from nauro_core.question_append import (
     allocate_question_number,
     compose_question_entry,
     insert_question_entry,
 )
-from nauro_core.questions import OpenQuestionsFile
+from nauro_core.questions import InvalidQuestionIdentifier, OpenQuestionsFile
 
 
 class TestAllocateQuestionNumber:
@@ -53,6 +55,11 @@ class TestComposeQuestionEntry:
     def test_pointer_body_composes_identically(self) -> None:
         body = "BRIEF: context/auth-cutover.md - the auth cutover plan"
         assert compose_question_entry(3, body) == f"- [Q3] {body}"
+
+    @pytest.mark.parametrize("number", [0, -1, True])
+    def test_rejects_non_positive_integer_number(self, number) -> None:
+        with pytest.raises(InvalidQuestionIdentifier):
+            compose_question_entry(number, "Question?")
 
 
 class TestInsertQuestionEntry:

--- a/packages/nauro-core/tests/test_question_provenance.py
+++ b/packages/nauro-core/tests/test_question_provenance.py
@@ -1,0 +1,502 @@
+"""Tests for the immutable question-provenance sidecar codec."""
+
+from __future__ import annotations
+
+import ast
+import json
+from datetime import date
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from pydantic import ValidationError
+
+from nauro_core.question_provenance import (
+    LegacyQuestionProvenanceRecord,
+    QuestionProvenanceConflict,
+    QuestionProvenanceDocument,
+    QuestionProvenanceDuplicateKey,
+    QuestionProvenanceInvalidUtf8,
+    QuestionProvenanceMalformedJson,
+    QuestionProvenanceMutation,
+    QuestionProvenanceNoncanonical,
+    QuestionProvenanceRecord,
+    QuestionProvenanceSchemaInvalid,
+    QuestionProvenanceVersionUnsupported,
+    insert_question_provenance,
+    migrate_legacy_question_provenance,
+    parse_question_provenance,
+    serialize_question_provenance,
+)
+from nauro_core.questions import OpenQuestionsFile
+
+ACTOR_ID = "0" + "A" * 25
+EVENT_ID = "1" + "B" * 25
+CREATED_AT = "2026-08-18T00:01:02.000003Z"
+LEGACY_ID = "2026-05-12 20:18 UTC"
+
+
+def _record() -> QuestionProvenanceRecord:
+    return QuestionProvenanceRecord(
+        actor_id=ACTOR_ID,
+        created_at=CREATED_AT,
+        event_id=EVENT_ID,
+    )
+
+
+def _legacy(*, current_question_id: str | None = None) -> LegacyQuestionProvenanceRecord:
+    return LegacyQuestionProvenanceRecord(
+        actor_id=ACTOR_ID,
+        created_at=CREATED_AT,
+        event_id=EVENT_ID,
+        current_question_id=current_question_id,
+    )
+
+
+def _empty_document() -> QuestionProvenanceDocument:
+    return QuestionProvenanceDocument(schema_version=1, by_question_id={}, by_legacy_id={})
+
+
+def _canonical(value: object) -> bytes:
+    return (
+        json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode(
+            "utf-8"
+        )
+        + b"\n"
+    )
+
+
+class TestCanonicalCodec:
+    def test_empty_document_has_exact_canonical_bytes(self):
+        document = _empty_document()
+        assert serialize_question_provenance(document) == (
+            b'{"by_legacy_id":{},"by_question_id":{},"schema_version":1}\n'
+        )
+
+    def test_nested_maps_and_fields_are_sorted_with_raw_unicode(self):
+        actor = "0" + "C" * 25
+        document = QuestionProvenanceDocument(
+            schema_version=1,
+            by_question_id={
+                "Q17": QuestionProvenanceRecord(
+                    actor_id=actor,
+                    created_at=CREATED_AT,
+                    event_id=EVENT_ID,
+                ),
+                "Q2": _record(),
+            },
+            by_legacy_id={},
+        )
+        encoded = serialize_question_provenance(document)
+        assert encoded.index(b'"Q17"') < encoded.index(b'"Q2"')
+        assert b": " not in encoded
+        assert encoded.endswith(b"\n")
+        assert not encoded.endswith(b"\n\n")
+
+    def test_migrated_alias_has_exact_canonical_bytes(self):
+        document = QuestionProvenanceDocument(
+            schema_version=1,
+            by_question_id={"Q1": _record()},
+            by_legacy_id={LEGACY_ID: _legacy(current_question_id="Q1")},
+        )
+        assert serialize_question_provenance(document) == (
+            b'{"by_legacy_id":{"2026-05-12 20:18 UTC":{"actor_id":"'
+            + ACTOR_ID.encode()
+            + b'","created_at":"2026-08-18T00:01:02.000003Z",'
+            + b'"current_question_id":"Q1","event_id":"'
+            + EVENT_ID.encode()
+            + b'"}},"by_question_id":{"Q1":{"actor_id":"'
+            + ACTOR_ID.encode()
+            + b'","created_at":"2026-08-18T00:01:02.000003Z","event_id":"'
+            + EVENT_ID.encode()
+            + b'"}},"schema_version":1}\n'
+        )
+
+    def test_parse_and_serialize_are_deterministic(self):
+        data = _canonical(
+            {
+                "schema_version": 1,
+                "by_question_id": {
+                    "Q1": {
+                        "actor_id": ACTOR_ID,
+                        "created_at": CREATED_AT,
+                        "event_id": EVENT_ID,
+                    }
+                },
+                "by_legacy_id": {},
+            }
+        )
+        first = parse_question_provenance(data)
+        second = parse_question_provenance(serialize_question_provenance(first))
+        assert first == second
+        assert serialize_question_provenance(second) == data
+
+    @pytest.mark.parametrize(
+        "data",
+        [
+            b'{"by_legacy_id": {},"by_question_id":{},"schema_version":1}\n',
+            b'{"schema_version":1,"by_question_id":{},"by_legacy_id":{}}\n',
+            b'{"by_legacy_id":{},"by_question_id":{},"schema_version":1}',
+            b'{"by_legacy_id":{},"by_question_id":{},"schema_version":1}\n\n',
+        ],
+    )
+    def test_semantically_valid_noncanonical_bytes_reject(self, data):
+        with pytest.raises(QuestionProvenanceNoncanonical) as exc_info:
+            parse_question_provenance(data)
+        assert exc_info.value.classification == "question_provenance_noncanonical"
+
+
+class TestParseFailures:
+    def test_invalid_utf8_has_closed_classification(self):
+        with pytest.raises(QuestionProvenanceInvalidUtf8) as exc_info:
+            parse_question_provenance(b"\xff")
+        assert exc_info.value.classification == "question_provenance_invalid_utf8"
+
+    @pytest.mark.parametrize("data", [b"{\n", b"[]\n", b'{"schema_version":NaN}\n'])
+    def test_malformed_json_or_root_rejects(self, data):
+        with pytest.raises(QuestionProvenanceMalformedJson):
+            parse_question_provenance(data)
+
+    def test_oversized_json_integer_has_malformed_classification(self):
+        data = b'{"schema_version":' + b"1" * 5000 + b"}\n"
+        with pytest.raises(QuestionProvenanceMalformedJson) as exc_info:
+            parse_question_provenance(data)
+        assert exc_info.value.classification == "question_provenance_json_malformed"
+
+    def test_json_recursion_error_has_malformed_classification(self):
+        with (
+            patch("nauro_core.question_provenance.json.loads", side_effect=RecursionError),
+            pytest.raises(QuestionProvenanceMalformedJson) as exc_info,
+        ):
+            parse_question_provenance(b"{}\n")
+        assert exc_info.value.classification == "question_provenance_json_malformed"
+
+    def test_parsed_nested_wrong_shape_has_schema_classification(self):
+        data = _canonical({"schema_version": 1, "by_question_id": [[0]], "by_legacy_id": {}})
+        with pytest.raises(QuestionProvenanceSchemaInvalid) as exc_info:
+            parse_question_provenance(data)
+        assert exc_info.value.classification == "question_provenance_schema_invalid"
+
+    @pytest.mark.parametrize(
+        "data",
+        [
+            b'{"schema_version":1,"schema_version":1,"by_question_id":{},"by_legacy_id":{}}\n',
+            b'{"schema_version":1,"by_question_id":{"Q1":{},"Q1":{}},"by_legacy_id":{}}\n',
+            (
+                b'{"schema_version":1,"by_question_id":{},"by_legacy_id":'
+                b'{"2026-05-12 20:18 UTC":{},"2026-05-12 20:18 UTC":{}}}\n'
+            ),
+            b'{"schema_version":1,"by_question_id":{"Q1":{"actor_id":"x","actor_id":"x","created_at":"x","event_id":"x"}},"by_legacy_id":{}}\n',
+        ],
+    )
+    def test_duplicate_keys_reject_at_every_object_level(self, data):
+        with pytest.raises(QuestionProvenanceDuplicateKey) as exc_info:
+            parse_question_provenance(data)
+        assert exc_info.value.classification == "question_provenance_duplicate_key"
+
+    def test_unsupported_version_has_exact_classification(self):
+        data = _canonical({"schema_version": 2, "by_question_id": {}, "by_legacy_id": {}})
+        with pytest.raises(QuestionProvenanceVersionUnsupported) as exc_info:
+            parse_question_provenance(data)
+        assert exc_info.value.classification == "question_provenance_version_unsupported"
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            {"schema_version": True, "by_question_id": {}, "by_legacy_id": {}},
+            {
+                "schema_version": 1,
+                "by_question_id": {},
+                "by_legacy_id": {},
+                "extra": None,
+            },
+            {"schema_version": 1, "by_question_id": {}},
+            {"schema_version": 1, "by_question_id": [], "by_legacy_id": {}},
+            {
+                "schema_version": 1,
+                "by_question_id": {
+                    "Q1": {
+                        "actor_id": ACTOR_ID,
+                        "created_at": CREATED_AT,
+                        "event_id": EVENT_ID,
+                        "extra": "x",
+                    }
+                },
+                "by_legacy_id": {},
+            },
+        ],
+    )
+    def test_closed_schema_rejects_unknown_missing_and_wrong_fields(self, value):
+        with pytest.raises(QuestionProvenanceSchemaInvalid) as exc_info:
+            parse_question_provenance(_canonical(value))
+        assert exc_info.value.classification == "question_provenance_schema_invalid"
+
+    @pytest.mark.parametrize(
+        ("question_id", "actor_id", "created_at", "event_id"),
+        [
+            ("Q01", ACTOR_ID, CREATED_AT, EVENT_ID),
+            ("Q1", "8" + "A" * 25, CREATED_AT, EVENT_ID),
+            ("Q1", ACTOR_ID, "2026-08-18T00:01:02Z", EVENT_ID),
+            ("Q1", ACTOR_ID, CREATED_AT, "I" * 26),
+        ],
+    )
+    def test_shared_validators_reject_invalid_q_actor_time_and_event(
+        self, question_id, actor_id, created_at, event_id
+    ):
+        value = {
+            "schema_version": 1,
+            "by_question_id": {
+                question_id: {
+                    "actor_id": actor_id,
+                    "created_at": created_at,
+                    "event_id": event_id,
+                }
+            },
+            "by_legacy_id": {},
+        }
+        with pytest.raises(QuestionProvenanceSchemaInvalid):
+            parse_question_provenance(_canonical(value))
+
+    @pytest.mark.parametrize(
+        ("legacy_id", "current_question_id"),
+        [("2026-5-12 20:18 UTC", None), (LEGACY_ID, "Q01")],
+    )
+    def test_legacy_keys_and_alias_targets_use_shared_validators(
+        self, legacy_id, current_question_id
+    ):
+        value = {
+            "schema_version": 1,
+            "by_question_id": {},
+            "by_legacy_id": {
+                legacy_id: {
+                    "actor_id": ACTOR_ID,
+                    "created_at": CREATED_AT,
+                    "event_id": EVENT_ID,
+                    "current_question_id": current_question_id,
+                }
+            },
+        }
+        with pytest.raises(QuestionProvenanceSchemaInvalid):
+            parse_question_provenance(_canonical(value))
+
+    def test_alias_requires_matching_question_record(self):
+        value = {
+            "schema_version": 1,
+            "by_question_id": {},
+            "by_legacy_id": {
+                LEGACY_ID: {
+                    "actor_id": ACTOR_ID,
+                    "created_at": CREATED_AT,
+                    "event_id": EVENT_ID,
+                    "current_question_id": "Q1",
+                }
+            },
+        }
+        with pytest.raises(QuestionProvenanceSchemaInvalid):
+            parse_question_provenance(_canonical(value))
+
+    def test_alias_requires_equal_question_provenance(self):
+        value = {
+            "schema_version": 1,
+            "by_question_id": {
+                "Q1": {
+                    "actor_id": "0" + "C" * 25,
+                    "created_at": CREATED_AT,
+                    "event_id": EVENT_ID,
+                }
+            },
+            "by_legacy_id": {
+                LEGACY_ID: {
+                    "actor_id": ACTOR_ID,
+                    "created_at": CREATED_AT,
+                    "event_id": EVENT_ID,
+                    "current_question_id": "Q1",
+                }
+            },
+        }
+        with pytest.raises(QuestionProvenanceSchemaInvalid):
+            parse_question_provenance(_canonical(value))
+
+
+class TestImmutability:
+    def test_models_and_nested_mappings_are_immutable_and_copied(self):
+        records = {"Q1": _record()}
+        document = QuestionProvenanceDocument(
+            schema_version=1,
+            by_question_id=records,
+            by_legacy_id={},
+        )
+        records.clear()
+        assert tuple(document.by_question_id) == ("Q1",)
+        with pytest.raises(TypeError):
+            document.by_question_id["Q2"] = _record()  # type: ignore[index]
+        with pytest.raises(ValidationError):
+            document.schema_version = 2  # type: ignore[misc]
+        with pytest.raises(ValidationError):
+            document.by_question_id["Q1"].actor_id = ACTOR_ID  # type: ignore[misc]
+
+    def test_model_dump_serializes_frozen_maps(self):
+        document = QuestionProvenanceDocument(
+            schema_version=1,
+            by_question_id={"Q1": _record()},
+            by_legacy_id={},
+        )
+        assert document.model_dump(mode="json") == {
+            "schema_version": 1,
+            "by_question_id": {
+                "Q1": {
+                    "actor_id": ACTOR_ID,
+                    "created_at": CREATED_AT,
+                    "event_id": EVENT_ID,
+                }
+            },
+            "by_legacy_id": {},
+        }
+
+
+class TestInsertion:
+    def test_insert_then_exact_replay(self):
+        inserted = insert_question_provenance(
+            _empty_document(), question_id="Q1", provenance=_record()
+        )
+        assert inserted == QuestionProvenanceMutation(
+            status="inserted",
+            document=inserted.document,
+        )
+        assert inserted.document.by_question_id["Q1"] == _record()
+
+        replayed = insert_question_provenance(
+            inserted.document, question_id="Q1", provenance=_record()
+        )
+        assert replayed.status == "replayed"
+        assert replayed.document is inserted.document
+
+    def test_padded_provenance_key_rejects(self):
+        with pytest.raises(QuestionProvenanceSchemaInvalid):
+            insert_question_provenance(_empty_document(), question_id="Q01", provenance=_record())
+
+    def test_divergent_duplicate_refuses(self):
+        inserted = insert_question_provenance(
+            _empty_document(), question_id="Q1", provenance=_record()
+        )
+        divergent = QuestionProvenanceRecord(
+            actor_id="0" + "C" * 25,
+            created_at=CREATED_AT,
+            event_id=EVENT_ID,
+        )
+        with pytest.raises(QuestionProvenanceConflict) as exc_info:
+            insert_question_provenance(inserted.document, question_id="Q1", provenance=divergent)
+        assert exc_info.value.classification == "question_provenance_conflict"
+
+
+class TestLegacyMigration:
+    def test_migration_derives_record_and_retains_alias(self):
+        document = QuestionProvenanceDocument(
+            schema_version=1,
+            by_question_id={},
+            by_legacy_id={LEGACY_ID: _legacy()},
+        )
+        result = migrate_legacy_question_provenance(
+            document, legacy_id=LEGACY_ID, current_question_id="Q1"
+        )
+        assert result.status == "migrated"
+        assert result.document.by_question_id["Q1"] == _record()
+        assert result.document.by_legacy_id[LEGACY_ID] == _legacy(current_question_id="Q1")
+
+        replayed = migrate_legacy_question_provenance(
+            result.document, legacy_id=LEGACY_ID, current_question_id="Q1"
+        )
+        assert replayed.status == "replayed"
+        assert replayed.document is result.document
+
+    def test_migration_completes_alias_when_equal_question_record_exists(self):
+        document = QuestionProvenanceDocument(
+            schema_version=1,
+            by_question_id={"Q1": _record()},
+            by_legacy_id={LEGACY_ID: _legacy()},
+        )
+        result = migrate_legacy_question_provenance(
+            document, legacy_id=LEGACY_ID, current_question_id="Q1"
+        )
+        assert result.status == "migrated"
+        assert result.document.by_legacy_id[LEGACY_ID].current_question_id == "Q1"
+
+    def test_migration_rejects_missing_legacy_record(self):
+        with pytest.raises(QuestionProvenanceConflict) as exc_info:
+            migrate_legacy_question_provenance(
+                _empty_document(), legacy_id=LEGACY_ID, current_question_id="Q1"
+            )
+        assert exc_info.value.classification == "question_provenance_legacy_missing"
+
+    def test_migration_rejects_different_existing_alias(self):
+        document = QuestionProvenanceDocument(
+            schema_version=1,
+            by_question_id={"Q2": _record()},
+            by_legacy_id={LEGACY_ID: _legacy(current_question_id="Q2")},
+        )
+        with pytest.raises(QuestionProvenanceConflict):
+            migrate_legacy_question_provenance(
+                document, legacy_id=LEGACY_ID, current_question_id="Q1"
+            )
+
+    def test_migration_rejects_divergent_existing_question_record(self):
+        divergent = QuestionProvenanceRecord(
+            actor_id="0" + "C" * 25,
+            created_at=CREATED_AT,
+            event_id=EVENT_ID,
+        )
+        document = QuestionProvenanceDocument(
+            schema_version=1,
+            by_question_id={"Q1": divergent},
+            by_legacy_id={LEGACY_ID: _legacy()},
+        )
+        with pytest.raises(QuestionProvenanceConflict):
+            migrate_legacy_question_provenance(
+                document, legacy_id=LEGACY_ID, current_question_id="Q1"
+            )
+
+
+class TestPreservationAndIsolation:
+    def test_resolution_does_not_change_provenance_bytes(self):
+        document = QuestionProvenanceDocument(
+            schema_version=1,
+            by_question_id={"Q1": _record()},
+            by_legacy_id={},
+        )
+        before = serialize_question_provenance(document)
+        questions = OpenQuestionsFile.parse("# Open Questions\n\n- [Q1] one\n")
+        questions.resolve(["Q1"], 7, date(2026, 8, 18))
+        assert serialize_question_provenance(document) == before
+
+    def test_codec_has_no_storage_or_network_imports(self):
+        source_path = Path(__file__).parents[1] / "src/nauro_core/question_provenance.py"
+        tree = ast.parse(source_path.read_text(encoding="utf-8"))
+        forbidden = {"boto3", "botocore", "httpx", "requests", "socket", "urllib"}
+        roots = {
+            alias.name.split(".", 1)[0]
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Import)
+            for alias in node.names
+        }
+        roots.update(
+            node.module.split(".", 1)[0]
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ImportFrom) and node.module
+        )
+        assert roots.isdisjoint(forbidden)
+
+    def test_nauro_package_has_no_production_consumer(self):
+        package_root = Path(__file__).parents[2] / "nauro/src"
+        consumers: list[str] = []
+        for path in package_root.rglob("*.py"):
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.ImportFrom) and node.module == (
+                    "nauro_core.question_provenance"
+                ):
+                    consumers.append(str(path.relative_to(package_root)))
+                if isinstance(node, ast.Import) and any(
+                    alias.name == "nauro_core.question_provenance" for alias in node.names
+                ):
+                    consumers.append(str(path.relative_to(package_root)))
+        assert consumers == []

--- a/packages/nauro-core/tests/test_questions.py
+++ b/packages/nauro-core/tests/test_questions.py
@@ -10,6 +10,8 @@ from nauro_core.questions import (
     QUESTION_TRUNCATION_POINTER,
     EntryBlock,
     HeaderBlock,
+    InvalidLegacyQuestionIdentifier,
+    InvalidQuestionIdentifier,
     MigrationRename,
     NormalizeResult,
     OpenQuestionsFile,
@@ -18,7 +20,11 @@ from nauro_core.questions import (
     ResolvedRef,
     TripleHashBlock,
     UnparsableBlock,
+    format_question_id,
+    parse_question_id,
     truncate_entry_text,
+    validate_legacy_question_id,
+    validate_question_id,
 )
 
 
@@ -561,6 +567,69 @@ class TestQuestionEntryIdValidator:
         assert entry.render() == ["- [Resolved by D7 on 2026-05-19] [Q42] qbody"]
 
 
+class TestQuestionIdentifierSeam:
+    def test_validate_accepts_only_canonical_unpadded_form(self):
+        assert validate_question_id("Q17") == "Q17"
+        with pytest.raises(InvalidQuestionIdentifier):
+            validate_question_id("Q017")
+
+    def test_parse_accepts_padded_compatibility_form(self):
+        assert parse_question_id("Q17") == 17
+        assert parse_question_id("Q017") == 17
+
+    def test_format_emits_canonical_unpadded_form(self):
+        assert format_question_id(17) == "Q17"
+
+    def test_parse_and_format_have_no_identifier_width_limit(self):
+        canonical = "Q1" + "0" * 4999
+        padded = "Q000" + canonical[1:]
+        number = parse_question_id(padded)
+        assert format_question_id(number) == canonical
+        assert validate_question_id(canonical) == canonical
+        with pytest.raises(InvalidQuestionIdentifier):
+            validate_question_id(padded)
+
+    @pytest.mark.parametrize(
+        "value",
+        ["Q0", "Q", "Q-1", "Q1.0", "Q 1", " Q1", "Q1 ", "Q\u0661", 1, None],
+    )
+    def test_parse_rejects_invalid_values(self, value):
+        with pytest.raises(InvalidQuestionIdentifier):
+            parse_question_id(value)
+
+    @pytest.mark.parametrize("value", [0, -1, True, "17", None])
+    def test_format_rejects_non_positive_integer_values(self, value):
+        with pytest.raises(InvalidQuestionIdentifier):
+            format_question_id(value)
+
+    def test_question_errors_do_not_echo_rejected_values(self):
+        rejected = "Qsecret"
+        with pytest.raises(InvalidQuestionIdentifier) as exc_info:
+            validate_question_id(rejected, field="question_key")
+        assert rejected not in str(exc_info.value)
+        assert exc_info.value.field == "question_key"
+
+    def test_validate_legacy_question_id_accepts_exact_calendar_value(self):
+        value = "2026-05-12 20:18 UTC"
+        assert validate_legacy_question_id(value) == value
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "2026-5-12 20:18 UTC",
+            "2026-05-12 2:18 UTC",
+            "2026-02-30 20:18 UTC",
+            "2026-05-12 20:18 UTC ",
+            "2026-05-12T20:18 UTC",
+            "2026-05-12 20:18Z",
+            20260512,
+        ],
+    )
+    def test_validate_legacy_question_id_rejects_noncanonical_values(self, value):
+        with pytest.raises(InvalidLegacyQuestionIdentifier):
+            validate_legacy_question_id(value)
+
+
 class TestParseQForm:
     def test_parse_q_form_open(self):
         content = "# Open Questions\n\n- [Q1] new id body\n"
@@ -592,6 +661,20 @@ class TestParseQForm:
             "- [Resolved by D7 on 2026-05-19] [Q2] resolved q\n"
         )
         assert OpenQuestionsFile.parse(content).format() == content
+
+    def test_padded_q_form_round_trips_with_canonical_typed_id(self):
+        content = "# Open Questions\n\n- [Q017] padded source spelling\n"
+        file = OpenQuestionsFile.parse(content)
+        assert file.open_ids == ["Q17"]
+        assert file.format() == content
+
+    def test_padded_q_form_adds_source_and_canonical_known_aliases(self):
+        file = OpenQuestionsFile.parse("# Open Questions\n\n- [Q017] padded\n")
+        assert file.known_question_ids == {"Q17", "Q017"}
+
+    def test_padded_triple_hash_id_adds_source_and_canonical_known_aliases(self):
+        file = OpenQuestionsFile.parse("# Open Questions\n\n### [Q017] Padded topic\nbody\n")
+        assert file.known_question_ids == {"Q17", "Q017"}
 
     def test_non_ascii_q_number_is_not_an_entry(self):
         """A non-ASCII id is not an entry this file could have written.
@@ -713,6 +796,21 @@ class TestResolveQForm:
         result = file.resolve(["Q1", "2026-05-12 20:18 UTC"], 7, date(2026, 5, 19))
         assert set(result.moved_ids) == {"Q1", "2026-05-12 20:18 UTC"}
 
+    @pytest.mark.parametrize("requested", ["Q17", "Q017"])
+    def test_resolve_padded_source_by_either_alias_returns_canonical_id(self, requested):
+        file = OpenQuestionsFile.parse("# Open Questions\n\n- [Q017] padded\n")
+        result = file.resolve([requested], 7, date(2026, 5, 19))
+        assert result.moved_ids == ("Q17",)
+        assert result.unknown_ids == ()
+        assert result.ambiguous_ids == ()
+        assert "[Resolved by D7 on 2026-05-19] [Q017] padded" in result.file.format()
+
+    def test_unknown_padded_input_is_reported_canonically(self):
+        file = OpenQuestionsFile.parse("# Open Questions\n\n- [Q1] one\n")
+        result = file.resolve(["Q017"], 7, date(2026, 5, 19))
+        assert result.moved_ids == ()
+        assert result.unknown_ids == ("Q17",)
+
 
 class TestResolveRejectsAmbiguous:
     """Same-minute timestamp collision must not silently move both
@@ -759,6 +857,17 @@ class TestResolveRejectsAmbiguous:
         result = file.resolve(["Q1", "2026-05-12 20:18 UTC"], 7, date(2026, 5, 19))
         assert result.ambiguous_ids == ("2026-05-12 20:18 UTC",)
         assert result.moved_ids == ()
+        assert result.file.format() == before
+
+    @pytest.mark.parametrize("requested", ["Q17", "Q017"])
+    def test_padded_and_unpadded_entries_are_one_ambiguous_identity(self, requested):
+        file = OpenQuestionsFile.parse("# Open Questions\n\n- [Q017] padded\n- [Q17] canonical\n")
+        before = file.format()
+        assert file.ambiguous_ids == {"Q17": 2, "Q017": 2}
+        result = file.resolve([requested], 7, date(2026, 5, 19))
+        assert result.ambiguous_ids == ("Q17",)
+        assert result.moved_ids == ()
+        assert result.unknown_ids == ()
         assert result.file.format() == before
 
 


### PR DESCRIPTION
## Why

Question IDs need one canonical unpadded spelling for newly emitted values and provenance keys, while existing padded Markdown must stay byte-identical and resolvable. Team question attribution also needs a strict shared codec before any hosted consumer is activated.

## What changed

- Added shared question-ID parsing, validation, and formatting. Writers emit unpadded IDs, compatible parsing accepts padded Markdown, and formatting preserves untouched source spelling.
- Made question membership, ambiguity checks, append short-circuits, and resolution treat padded and unpadded spellings as one numeric identity while returning canonical typed IDs.
- Added immutable schema-1 question-provenance models and canonical JSON parsing, serialization, insertion, replay, conflict, and legacy migration behavior.
- Kept the codec free of storage, network, route, and hosted production consumers.

## Test plan

- `pytest packages/nauro-core/tests/ -q`, 1,726 passed
- `pytest packages/nauro/tests/ --ignore=packages/nauro/tests/cross_surface -q`, 2,663 passed
- Public and hosted-consumer contract tests passed
- Ruff, import-linter, single-source, docstring-budget, server.json, and diff checks passed

## Risk / what to review

Review the boundary between preserved Markdown spelling and canonical typed identity. Also review duplicate-key rejection, exact canonical bytes, immutable nested mappings, and legacy alias equality during migration.

## Deferred

Hosted storage, routes, dependency-floor changes, generation publication, and production consumers remain separate work.
