### PR TITLE
Release nauro-core 1.13.0

### DIFF
--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro-core"
-version = "1.12.0"
+version = "1.13.0"
 description = "Shared pure-Python logic for Nauro: parsing, validation, context assembly, constants."
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -989,7 +989,7 @@ provides-extras = ["dev", "embeddings"]
 
 [[package]]
 name = "nauro-core"
-version = "1.12.0"
+version = "1.13.0"
 source = { editable = "packages/nauro-core" }
 dependencies = [
     { name = "bm25s" },


### PR DESCRIPTION
## Why

The hosted server needs the merged public question-provenance API. The current `nauro-core` 1.12.0 wheel predates that API, so downstream CI cannot import it.

## What changed

- Bump `nauro-core` from 1.12.0 to 1.13.0 and update `uv.lock`.
- Release canonical question-ID handling and the schema-1 question-provenance codec.
- Include numeric decision ordering past 999 and behavior-neutral core docstring reductions merged since 1.12.0.

## Test plan

- `uv lock --check`
- `uv sync --locked --package nauro-core --all-extras --python 3.12`
- `uv sync --locked --package nauro --all-extras --python 3.12`
- `pytest packages/nauro-core/tests -q`, 1,727 passed
- Ruff check and format check passed
- Import-linter kept both contracts
- Built `nauro_core-1.13.0-py3-none-any.whl`

## Deferred

After this PR merges and the publish gate is approved, push `nauro-core-v1.13.0`, verify PyPI, then update the hosted server dependency floor and generated dependency artifacts.
