### PR TITLE
Add deterministic question resolution seam

### DIFF
--- a/packages/nauro-core/src/nauro_core/__init__.py
+++ b/packages/nauro-core/src/nauro_core/__init__.py
@@ -231,6 +231,15 @@ from nauro_core.protocol import (
 from nauro_core.protocol import (
     substitute_protocol_fragments as substitute_protocol_fragments,
 )
+from nauro_core.question_resolution import (
+    QuestionResolutionOutcome as QuestionResolutionOutcome,
+)
+from nauro_core.question_resolution import (
+    ResolutionDecisionDocument as ResolutionDecisionDocument,
+)
+from nauro_core.question_resolution import (
+    resolve_question_document as resolve_question_document,
+)
 from nauro_core.questions import (
     Block as Block,
 )
@@ -372,6 +381,10 @@ __all__ = [
     "CHECK_DECISION_RETURNS",
     "GET_DECISION_BEFORE_PROPOSING",
     "NO_INVENT_RATIONALE",
+    # Deterministic question resolution.
+    "QuestionResolutionOutcome",
+    "ResolutionDecisionDocument",
+    "resolve_question_document",
     # Identity.
     "sanitize_sub",
     # Valid decision types.

--- a/packages/nauro-core/src/nauro_core/mcp_tools.py
+++ b/packages/nauro-core/src/nauro_core/mcp_tools.py
@@ -438,6 +438,11 @@ FLAG_QUESTION: ToolSpec = {
         "is stamped resolved and, when prose-safe, moved below "
         "`## Resolved`.\n"
         "\n"
+        "Before resolving, read the cited decision. Verify that it is active "
+        "and answers each question's operative ask; shared terms or topic "
+        "overlap are not sufficient. A bulk close-out requires a complete "
+        "question census and the recorded session-decision procedure.\n"
+        "\n"
         "Pass exactly one of `question` or `resolved_by`."
     ),
     "annotations": {**_WRITE_ANNOTATIONS, "idempotentHint": False},

--- a/packages/nauro-core/src/nauro_core/operations/flag_question.py
+++ b/packages/nauro-core/src/nauro_core/operations/flag_question.py
@@ -20,14 +20,16 @@ from __future__ import annotations
 from datetime import datetime, timezone
 
 from nauro_core.constants import OPEN_QUESTIONS_DEFAULT_BODY, OPEN_QUESTIONS_MD
-from nauro_core.operations.decision_lookup import find_decision_stem_by_num
 from nauro_core.operations.results import ErrorPayload, FlagQuestionResult
 from nauro_core.operations.store import Store
-from nauro_core.parsing import extract_decision_number
 from nauro_core.question_append import (
     allocate_question_number,
     compose_question_entry,
     insert_question_entry,
+)
+from nauro_core.question_resolution import (
+    ResolutionDecisionDocument,
+    resolve_question_document,
 )
 from nauro_core.questions import (
     EntryBlock,
@@ -40,8 +42,6 @@ from nauro_core.questions import (
 # Private alias kept for one release: a deployed consumer still imports this
 # name. New code reads OPEN_QUESTIONS_DEFAULT_BODY from nauro_core directly.
 _DEFAULT_FILE_BODY = OPEN_QUESTIONS_DEFAULT_BODY
-
-_FRESHNESS_CAVEAT = "This reads the working copy, only as fresh as the most recent pull."
 
 
 def flag_question(
@@ -74,8 +74,8 @@ def flag_question(
         resolved_by: A decision identifier (``D123``, ``123``,
             ``decision-123`` …). When set, the call resolves the
             ``targets`` entries against that decision instead of
-            appending. The number must resolve to a decision that exists
-            in the store.
+            appending. The number must resolve to an active decision that
+            exists in the store.
 
     Returns:
         :class:`FlagQuestionResult`. On the append success path
@@ -185,57 +185,25 @@ def _resolve(
     targets: list[str],
     resolved_by: str,
 ) -> FlagQuestionResult:
-    """Stamp the ``targets`` entries as resolved by ``resolved_by`` in place. Every id
-    must exist as a single entry and ``resolved_by`` must name a decision in the
-    store; a bad, missing or ambiguous id rejects the whole call without writing.
-    """
-    num = extract_decision_number(resolved_by)
-    if num is None:
-        return _reject(
-            f"resolved_by {resolved_by!r} is not a decision identifier "
-            "(expected a form like D123, 123, or decision-123)."
-        )
-
-    if find_decision_stem_by_num(store, num) is None:
-        return _reject(
-            f"resolved_by names decision D{num}, which does not exist in the store. "
-            f"{_FRESHNESS_CAVEAT}"
-        )
-
-    if not targets:
-        return _reject("resolved_by requires at least one id in targets to resolve.")
-
+    """Capture store inputs, run the pure resolver, and persist changed bytes."""
+    stems = store.list_decisions()
+    bodies = store.read_decisions(stems)
+    documents = tuple(
+        ResolutionDecisionDocument(stem=stem, content=body.encode("utf-8"))
+        for stem in stems
+        if (body := bodies.get(stem)) is not None
+    )
     content = store.read_file(OPEN_QUESTIONS_MD) or _DEFAULT_FILE_BODY
-    parsed = OpenQuestionsFile.parse(content)
-
-    ambiguous = parsed.ambiguous_ids
-    requested_ambiguous = [t for t in targets if t in ambiguous]
-    if requested_ambiguous:
-        return _reject(
-            "targets contains ambiguous id(s) matching more than one entry: "
-            + ", ".join(repr(t) for t in dict.fromkeys(requested_ambiguous))
-            + ". Disambiguate before resolving."
-        )
-
-    entry_ids = {b.entry.id for b in parsed.blocks if isinstance(b, EntryBlock)}
-    missing = [t for t in targets if t not in entry_ids]
-    if missing:
-        return _reject(
-            "targets contains id(s) not present in open-questions.md: "
-            + ", ".join(repr(t) for t in dict.fromkeys(missing))
-            + f". {_FRESHNESS_CAVEAT}"
-        )
-
-    result = parsed.resolve(
-        ids=targets,
-        decision_num=num,
-        date=datetime.now(timezone.utc).date(),
+    outcome = resolve_question_document(
+        open_questions_bytes=content.encode("utf-8"),
+        decision_documents=documents,
+        targets=targets,
+        resolved_by=resolved_by,
+        resolution_date=datetime.now(timezone.utc).date(),
     )
-    normalized = result.file.normalize()
-    store.write_file(OPEN_QUESTIONS_MD, normalized.file.format())
-    return FlagQuestionResult(
-        status="ok",
-        num=None,
-        relocated_ids=normalized.relocated_ids or None,
-        skipped_prose_ids=normalized.skipped_prose_ids or None,
-    )
+    if outcome.updated_open_questions_bytes is not None:
+        store.write_file(
+            OPEN_QUESTIONS_MD,
+            outcome.updated_open_questions_bytes.decode("utf-8"),
+        )
+    return outcome.result

--- a/packages/nauro-core/src/nauro_core/question_resolution.py
+++ b/packages/nauro-core/src/nauro_core/question_resolution.py
@@ -1,0 +1,170 @@
+"""Deterministic question-resolution seam for local and hosted callers.
+
+Callers capture exact decision and open-question bytes before invocation.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import date
+
+from nauro_core.constants import OPEN_QUESTIONS_DEFAULT_BODY
+from nauro_core.decision_model import DecisionStatus, parse_decision
+from nauro_core.operations.results import ErrorPayload, FlagQuestionResult
+from nauro_core.parsing import extract_decision_number
+from nauro_core.questions import (
+    EntryBlock,
+    InvalidQuestionIdentifier,
+    OpenQuestionsFile,
+    format_question_id,
+    parse_question_id,
+)
+
+
+@dataclass(frozen=True)
+class ResolutionDecisionDocument:
+    """An exact decision artifact captured by the caller."""
+
+    stem: str
+    content: bytes
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "content", bytes(self.content))
+
+
+@dataclass(frozen=True)
+class QuestionResolutionOutcome:
+    """The existing result envelope plus the exact effects of resolution."""
+
+    result: FlagQuestionResult
+    updated_open_questions_bytes: bytes | None
+    resolved_question_ids: tuple[str, ...]
+
+
+def resolve_question_document(
+    *,
+    open_questions_bytes: bytes | None,
+    decision_documents: Sequence[ResolutionDecisionDocument],
+    targets: Sequence[str],
+    resolved_by: str,
+    resolution_date: date,
+) -> QuestionResolutionOutcome:
+    """Resolve questions from immutable inputs without I/O or clock access."""
+    source_bytes = open_questions_bytes
+    if source_bytes is None:
+        source_bytes = OPEN_QUESTIONS_DEFAULT_BODY.encode("utf-8")
+    content = source_bytes.decode("utf-8")
+
+    decision_num = extract_decision_number(resolved_by)
+    if decision_num is None:
+        return _rejected(
+            f"resolved_by {resolved_by!r} is not a decision identifier "
+            "(expected a form like D123, 123, or decision-123)."
+        )
+
+    matching = tuple(
+        document
+        for document in decision_documents
+        if extract_decision_number(document.stem) == decision_num
+    )
+    if not matching:
+        return _rejected(
+            f"resolved_by names decision D{decision_num}, which does not exist "
+            "in the captured decision set."
+        )
+    if len(matching) != 1:
+        return _rejected(
+            f"resolved_by names decision D{decision_num}, but the captured "
+            "decision set contains duplicate-number artifacts."
+        )
+
+    document = matching[0]
+    try:
+        decision_body = document.content.decode("utf-8")
+    except UnicodeDecodeError:
+        return _rejected(f"Decision D{decision_num} is not valid UTF-8.")
+
+    try:
+        decision = parse_decision(decision_body, f"{document.stem}.md")
+    except ValueError:
+        return _rejected(f"Decision D{decision_num} is malformed.")
+
+    if decision.num != decision_num:
+        return _rejected(f"Decision artifact {document.stem!r} does not parse as D{decision_num}.")
+    if decision.status is not DecisionStatus.active:
+        return _rejected(f"Decision D{decision_num} is not active.")
+
+    canonical_targets = _canonical_question_targets(targets)
+    if not canonical_targets:
+        return _rejected("resolved_by requires at least one id in targets to resolve.")
+
+    parsed = OpenQuestionsFile.parse(content)
+    ambiguous = parsed.ambiguous_ids
+    requested_ambiguous = [target for target in canonical_targets if target in ambiguous]
+    if requested_ambiguous:
+        return _rejected(
+            "targets contains ambiguous id(s) matching more than one entry: "
+            + ", ".join(repr(target) for target in dict.fromkeys(requested_ambiguous))
+            + ". Disambiguate before resolving."
+        )
+
+    entries_by_id: dict[str, EntryBlock] = {}
+    for block in parsed.blocks:
+        if isinstance(block, EntryBlock):
+            entries_by_id.setdefault(block.entry.id, block)
+
+    missing = [target for target in canonical_targets if target not in entries_by_id]
+    if missing:
+        return _rejected(
+            "targets contains id(s) not present in open-questions.md: "
+            + ", ".join(repr(target) for target in dict.fromkeys(missing))
+            + "."
+        )
+
+    requested_unique = tuple(dict.fromkeys(canonical_targets))
+    resolved_question_ids = tuple(
+        target for target in requested_unique if entries_by_id[target].entry.resolved_by is None
+    )
+    resolved = parsed.resolve(
+        ids=list(requested_unique),
+        decision_num=decision_num,
+        date=resolution_date,
+    )
+    normalized = resolved.file.normalize()
+    updated_bytes = normalized.file.format().encode("utf-8")
+
+    result = FlagQuestionResult(
+        status="ok",
+        num=None,
+        relocated_ids=normalized.relocated_ids or None,
+        skipped_prose_ids=normalized.skipped_prose_ids or None,
+    )
+    return QuestionResolutionOutcome(
+        result=result,
+        updated_open_questions_bytes=updated_bytes,
+        resolved_question_ids=resolved_question_ids,
+    )
+
+
+def _canonical_question_targets(targets: Sequence[str]) -> list[str]:
+    canonical: list[str] = []
+    for target in targets:
+        try:
+            number = parse_question_id(target)
+        except InvalidQuestionIdentifier:
+            canonical.append(target)
+        else:
+            canonical.append(format_question_id(number))
+    return canonical
+
+
+def _rejected(reason: str) -> QuestionResolutionOutcome:
+    return QuestionResolutionOutcome(
+        result=FlagQuestionResult(
+            status="rejected",
+            error=ErrorPayload(kind="rejected", reason=reason),
+        ),
+        updated_open_questions_bytes=None,
+        resolved_question_ids=(),
+    )

--- a/packages/nauro-core/tests/hosted_consumer_symbols.txt
+++ b/packages/nauro-core/tests/hosted_consumer_symbols.txt
@@ -3,6 +3,8 @@
 nauro_core.DECISION_HASHES_FILE
 nauro_core.HOSTED_STORE_FORMAT_VERSION
 nauro_core.MCP_INSTRUCTIONS_STATIC
+nauro_core.QuestionResolutionOutcome
+nauro_core.ResolutionDecisionDocument
 nauro_core.build_remote_instructions
 nauro_core.compute_hash
 nauro_core.constants.BRIEF_SLUG_MAX_LENGTH
@@ -115,6 +117,7 @@ nauro_core.questions.parse_question_id
 nauro_core.questions.validate_legacy_question_id
 nauro_core.questions.validate_question_id
 nauro_core.renderers.RENDERERS
+nauro_core.resolve_question_document
 nauro_core.sanitize_sub
 nauro_core.serialize_snapshot
 nauro_core.state.prepare_state_update

--- a/packages/nauro-core/tests/operations/test_operations_flag_question.py
+++ b/packages/nauro-core/tests/operations/test_operations_flag_question.py
@@ -291,7 +291,26 @@ def _open_q1_q5_seed() -> str:
 
 
 def _decisions(*nums: int) -> dict[str, str]:
-    return {f"{n:03d}-some-decision": f"# Decision {n}\n" for n in nums}
+    return {
+        f"{n:03d}-some-decision": (
+            "---\n"
+            "date: 2026-08-18\n"
+            "version: 1\n"
+            "status: active\n"
+            "confidence: high\n"
+            "decision_type: pattern\n"
+            "reversibility: easy\n"
+            "source: mcp\n"
+            "files_affected: []\n"
+            "supersedes: null\n"
+            "superseded_by: null\n"
+            "---\n\n"
+            f"# {n:03d} \u2014 Decision {n}\n\n"
+            "## Decision\n\n"
+            "Resolve the named question.\n"
+        )
+        for n in nums
+    }
 
 
 def test_resolve_relocates_target_below_divider_and_returns_ok() -> None:
@@ -375,6 +394,31 @@ def test_resolve_already_resolved_id_is_idempotent_ok() -> None:
     assert after == before
 
 
+def test_resolve_no_op_preserves_successful_write() -> None:
+    class WriteCountingStore(InMemoryStore):
+        writes = 0
+
+        def write_file(self, path: str, content: str) -> None:
+            self.writes += 1
+            super().write_file(path, content)
+
+    seed = (
+        "# Open Questions\n\n"
+        "## Resolved\n\n"
+        "- [Resolved by D41 on 2026-05-20] [Q5] already resolved\n"
+    )
+    store = WriteCountingStore(
+        decisions=_decisions(42),
+        files={OPEN_QUESTIONS_MD: seed},
+    )
+
+    result = flag_question(store, targets=["Q5"], resolved_by="D42")
+
+    assert result.status == "ok"
+    assert store.writes == 1
+    assert store.read_file(OPEN_QUESTIONS_MD) == seed
+
+
 def test_resolve_heals_pre_existing_stray_whole_file_scope() -> None:
     """Whole-file scope: resolving Q1 also relocates a pre-existing stray Q9
     that was stamped resolved earlier but never moved below the divider."""
@@ -422,6 +466,29 @@ def test_resolve_missing_decision_rejects_naming_number() -> None:
     content = store.read_file(OPEN_QUESTIONS_MD)
     assert content is not None
     assert "- [Q5] also still open" in content
+
+
+def test_resolve_superseded_decision_rejects_without_write() -> None:
+    body = (
+        _decisions(42)["042-some-decision"]
+        .replace(
+            "status: active\n",
+            "status: superseded\n",
+        )
+        .replace("superseded_by: null\n", 'superseded_by: "43"\n')
+    )
+    store = InMemoryStore(
+        decisions={"042-some-decision": body},
+        files={OPEN_QUESTIONS_MD: _open_q1_q5_seed()},
+    )
+    before = store.read_file(OPEN_QUESTIONS_MD)
+
+    result = flag_question(store, targets=["Q5"], resolved_by="D42")
+
+    assert result.status == "rejected"
+    assert result.error is not None
+    assert "not active" in result.error.reason
+    assert store.read_file(OPEN_QUESTIONS_MD) == before
 
 
 def test_resolve_unknown_target_rejects_whole_call_naming_id() -> None:
@@ -499,7 +566,7 @@ def test_resolve_missing_decision_reason_mentions_freshness() -> None:
     result = flag_question(store, targets=["Q5"], resolved_by="D99")
     assert result.status == "rejected"
     assert result.error is not None
-    assert "pull" in result.error.reason.lower()
+    assert "captured decision set" in result.error.reason.lower()
 
 
 def test_resolve_uses_utc_now_date() -> None:

--- a/packages/nauro-core/tests/snapshots/hosted_consumer_contract_v1.json
+++ b/packages/nauro-core/tests/snapshots/hosted_consumer_contract_v1.json
@@ -13,6 +13,31 @@
       "kind": "value",
       "type": "str"
     },
+    "nauro_core.QuestionResolutionOutcome": {
+      "bases": [
+        "builtins.object"
+      ],
+      "fields": [
+        "result",
+        "updated_open_questions_bytes",
+        "resolved_question_ids"
+      ],
+      "kind": "class",
+      "module": "nauro_core.question_resolution",
+      "qualname": "QuestionResolutionOutcome"
+    },
+    "nauro_core.ResolutionDecisionDocument": {
+      "bases": [
+        "builtins.object"
+      ],
+      "fields": [
+        "stem",
+        "content"
+      ],
+      "kind": "class",
+      "module": "nauro_core.question_resolution",
+      "qualname": "ResolutionDecisionDocument"
+    },
     "nauro_core.build_remote_instructions": {
       "kind": "function",
       "module": "nauro_core.instructions",
@@ -1031,6 +1056,12 @@
       "kind": "value",
       "len": 8,
       "type": "dict"
+    },
+    "nauro_core.resolve_question_document": {
+      "kind": "function",
+      "module": "nauro_core.question_resolution",
+      "qualname": "resolve_question_document",
+      "signature": "(*, open_questions_bytes: bytes | None, decision_documents: Sequence[ResolutionDecisionDocument], targets: Sequence[str], resolved_by: str, resolution_date: date) -> QuestionResolutionOutcome"
     },
     "nauro_core.sanitize_sub": {
       "kind": "function",

--- a/packages/nauro-core/tests/test_mcp_tools.py
+++ b/packages/nauro-core/tests/test_mcp_tools.py
@@ -143,6 +143,14 @@ class TestLookup:
         composed = f"before `propose_decision`: {APPROVAL_BEFORE_PROPOSE}"
         assert composed in get_tool_spec("check_decision")["description"]
 
+    def test_flag_question_carries_resolution_verification_contract(self) -> None:
+        description = get_tool_spec("flag_question")["description"]
+        assert "Verify that it is active" in description
+        assert "operative ask" in description
+        assert "shared terms or topic overlap are not sufficient" in description
+        assert "complete question census" in description
+        assert "recorded session-decision procedure" in description
+
 
 class TestGetContextLevel:
     """Regression: level must be the string enum, not int, to match remote."""

--- a/packages/nauro-core/tests/test_question_resolution.py
+++ b/packages/nauro-core/tests/test_question_resolution.py
@@ -1,0 +1,217 @@
+"""Tests for the deterministic question-resolution seam."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from nauro_core.question_resolution import (
+    QuestionResolutionOutcome,
+    ResolutionDecisionDocument,
+    resolve_question_document,
+)
+
+RESOLUTION_DATE = date(2026, 8, 18)
+
+
+def _decision(
+    num: int,
+    *,
+    status: str = "active",
+    superseded_by: str = "null",
+    stem: str | None = None,
+) -> ResolutionDecisionDocument:
+    resolved_stem = stem or f"{num:03d}-decision-{num}"
+    content = (
+        "---\n"
+        "date: 2026-08-18\n"
+        "version: 1\n"
+        f"status: {status}\n"
+        "confidence: high\n"
+        "decision_type: pattern\n"
+        "reversibility: easy\n"
+        "source: mcp\n"
+        "files_affected: []\n"
+        "supersedes: null\n"
+        f"superseded_by: {superseded_by}\n"
+        "---\n\n"
+        f"# {num:03d} \u2014 Decision {num}\n\n"
+        "## Decision\n\n"
+        "Resolve the named question.\n"
+    )
+    return ResolutionDecisionDocument(stem=resolved_stem, content=content.encode())
+
+
+def _resolve(
+    content: str,
+    *,
+    decisions: tuple[ResolutionDecisionDocument, ...] | None = None,
+    targets: tuple[str, ...] = ("Q5",),
+    resolved_by: str = "D42",
+) -> QuestionResolutionOutcome:
+    return resolve_question_document(
+        open_questions_bytes=content.encode(),
+        decision_documents=(_decision(42),) if decisions is None else decisions,
+        targets=targets,
+        resolved_by=resolved_by,
+        resolution_date=RESOLUTION_DATE,
+    )
+
+
+def test_resolves_and_reports_only_actual_transition() -> None:
+    outcome = _resolve("# Open Questions\n\n- [Q1] open\n- [Q5] target\n")
+
+    assert outcome.result.status == "ok"
+    assert outcome.result.relocated_ids == ("Q5",)
+    assert outcome.resolved_question_ids == ("Q5",)
+    assert outcome.updated_open_questions_bytes is not None
+    updated = outcome.updated_open_questions_bytes.decode()
+    assert "[Resolved by D42 on 2026-08-18] [Q5] target" in updated
+
+
+def test_different_decision_no_op_does_not_report_requested_anchor() -> None:
+    content = (
+        "# Open Questions\n\n"
+        "## Resolved\n\n"
+        "- [Resolved by D41 on 2026-08-17] [Q5] already closed\n"
+    )
+    outcome = _resolve(content)
+
+    assert outcome.result.status == "ok"
+    assert outcome.resolved_question_ids == ()
+    assert outcome.updated_open_questions_bytes == content.encode()
+
+
+def test_normalization_only_reports_empty_resolution_effect() -> None:
+    content = (
+        "# Open Questions\n\n"
+        "- [Resolved by D41 on 2026-08-17] [Q5] stray\n"
+        "- [Q9] open\n\n"
+        "## Resolved\n"
+    )
+    outcome = _resolve(content)
+
+    assert outcome.result.status == "ok"
+    assert outcome.result.relocated_ids == ("Q5",)
+    assert outcome.resolved_question_ids == ()
+    assert outcome.updated_open_questions_bytes is not None
+    updated = outcome.updated_open_questions_bytes.decode()
+    assert "Resolved by D41" in updated
+    assert "Resolved by D42" not in updated
+
+
+def test_duplicate_targets_report_one_actual_transition() -> None:
+    outcome = _resolve(
+        "# Open Questions\n\n- [Q17] target\n",
+        targets=("Q017", "Q17", "Q017"),
+    )
+
+    assert outcome.resolved_question_ids == ("Q17",)
+    assert outcome.result.relocated_ids == ("Q17",)
+    assert outcome.updated_open_questions_bytes is not None
+    assert b"[Q17] target" in outcome.updated_open_questions_bytes
+
+
+def test_legacy_timestamp_identity_is_preserved() -> None:
+    legacy_id = "2026-04-30 10:00 UTC"
+    outcome = _resolve(
+        f"# Open Questions\n\n- [{legacy_id}] target\n",
+        targets=(legacy_id,),
+    )
+
+    assert outcome.resolved_question_ids == (legacy_id,)
+    assert outcome.updated_open_questions_bytes is not None
+    assert f"[{legacy_id}] target" in outcome.updated_open_questions_bytes.decode()
+
+
+@pytest.mark.parametrize(
+    ("decisions", "reason"),
+    [
+        ((), "does not exist"),
+        ((_decision(42), _decision(42, stem="042-duplicate")), "duplicate-number"),
+        ((_decision(42, status="superseded", superseded_by='"43"'),), "not active"),
+        ((ResolutionDecisionDocument(stem="042-bad", content=b"not markdown"),), "malformed"),
+        ((ResolutionDecisionDocument(stem="042-bad", content=b"\xff"),), "UTF-8"),
+    ],
+)
+def test_invalid_decision_evidence_rejects_without_effects(
+    decisions: tuple[ResolutionDecisionDocument, ...],
+    reason: str,
+) -> None:
+    outcome = _resolve(
+        "# Open Questions\n\n- [Q5] target\n",
+        decisions=decisions,
+    )
+
+    assert outcome.result.status == "rejected"
+    assert outcome.result.error is not None
+    assert reason in outcome.result.error.reason
+    assert outcome.updated_open_questions_bytes is None
+    assert outcome.resolved_question_ids == ()
+
+
+def test_malformed_resolved_by_rejects_without_effects() -> None:
+    outcome = _resolve(
+        "# Open Questions\n\n- [Q5] target\n",
+        resolved_by="not-a-decision",
+    )
+
+    assert outcome.result.status == "rejected"
+    assert outcome.updated_open_questions_bytes is None
+    assert outcome.resolved_question_ids == ()
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "# Open Questions\n\n- [Q1] other\n",
+        "# Open Questions\n\n- [Q5] first\n- [Q005] second\n",
+    ],
+)
+def test_invalid_target_set_rejects_without_effects(content: str) -> None:
+    outcome = _resolve(content)
+
+    assert outcome.result.status == "rejected"
+    assert outcome.updated_open_questions_bytes is None
+    assert outcome.resolved_question_ids == ()
+
+
+@pytest.mark.parametrize(
+    ("decisions", "targets", "resolved_by"),
+    [
+        ((_decision(42),), ("Q5",), "D42"),
+        ((), (), "not-a-decision"),
+    ],
+)
+def test_invalid_open_question_utf8_raises_without_an_outcome(
+    decisions: tuple[ResolutionDecisionDocument, ...],
+    targets: tuple[str, ...],
+    resolved_by: str,
+) -> None:
+    with pytest.raises(UnicodeDecodeError):
+        resolve_question_document(
+            open_questions_bytes=b"\xff",
+            decision_documents=decisions,
+            targets=targets,
+            resolved_by=resolved_by,
+            resolution_date=RESOLUTION_DATE,
+        )
+
+
+def test_same_inputs_produce_same_outcome() -> None:
+    content = "# Open Questions\n\n- [Q5] target\n"
+
+    first = _resolve(content)
+    second = _resolve(content)
+
+    assert first == second
+
+
+def test_decision_document_copies_mutable_input() -> None:
+    content = bytearray(_decision(42).content)
+    document = ResolutionDecisionDocument(stem="042-decision", content=content)
+
+    content[0] = ord("x")
+
+    assert document.content.startswith(b"---")

--- a/packages/nauro/tests/conftest.py
+++ b/packages/nauro/tests/conftest.py
@@ -136,6 +136,19 @@ def seed_decisions_into(store_path: Path, *decisions: Decision) -> None:
         (decisions_dir / f"{d.num:03d}-{slug}.md").write_text(format_decision(d))
 
 
+def active_decision_markdown(num: int, title: str) -> str:
+    """Return a minimal decision body that parses as active v2."""
+    return (
+        "---\n"
+        "date: 2026-08-18\n"
+        "confidence: high\n"
+        "---\n\n"
+        f"# {num:03d} \u2014 {title}\n\n"
+        "## Decision\n\n"
+        "Test rationale.\n"
+    )
+
+
 def write_decision_file(store: Path, num: int, slug: str, content: str) -> None:
     """Write raw ``content`` to ``store/decisions/NNN-slug.md`` verbatim.
 

--- a/packages/nauro/tests/cross_surface/test_flag_question_cross_surface.py
+++ b/packages/nauro/tests/cross_surface/test_flag_question_cross_surface.py
@@ -37,6 +37,7 @@ from nauro.store.filesystem_store import FilesystemStore  # noqa: E402
 from tests.conftest import (  # noqa: E402
     CROSS_SURFACE_PROJECT_ID,
     CROSS_SURFACE_USER_ID,
+    active_decision_markdown,
     moto_s3_bucket,
 )
 from tests.cross_surface.conftest import _dump  # noqa: E402
@@ -96,7 +97,7 @@ def test_repeated_writes_match_across_stores(both_stores):
 def _seed_resolvable(fs_store: FilesystemStore, cloud: CloudStore) -> None:
     seed = "# Open Questions\n\n- [Q1] needs a decision\n"
     _seed_open_questions(fs_store, cloud, seed)
-    decision = "# Decision 42\n"
+    decision = active_decision_markdown(42, "Some decision")
     fs_store.write_file("decisions/042-some-decision.md", decision)
     cloud.write_file("decisions/042-some-decision.md", decision)
 

--- a/packages/nauro/tests/snapshots/public_contract_v1.json
+++ b/packages/nauro/tests/snapshots/public_contract_v1.json
@@ -1702,6 +1702,8 @@
     "OPEN_QUESTIONS_DEFAULT_BODY",
     "OPEN_QUESTIONS_MD",
     "PROJECT_MD",
+    "QuestionResolutionOutcome",
+    "ResolutionDecisionDocument",
     "SNAPSHOTS_DIR",
     "SNAPSHOT_SCHEMA_VERSION",
     "STACK_MD",
@@ -1721,6 +1723,7 @@
     "format_decision",
     "normalize_title",
     "parse_decision",
+    "resolve_question_document",
     "sanitize_sub",
     "serialize_snapshot"
   ],

--- a/packages/nauro/tests/test_flag_question_parity.py
+++ b/packages/nauro/tests/test_flag_question_parity.py
@@ -30,7 +30,7 @@ from nauro.mcp import stdio_server as stdio_module
 from nauro.mcp import tools as mcp_tools
 from nauro.mcp.stdio_server import flag_question as stdio_flag_question
 from nauro.mcp.tools import tool_flag_question
-from tests.conftest import register_v2_repo
+from tests.conftest import active_decision_markdown, register_v2_repo
 
 
 @pytest.fixture(autouse=True)
@@ -122,7 +122,7 @@ def _seed_resolvable(store_path, q_id: str = "Q1") -> None:
     )
     decisions = store_path / "decisions"
     decisions.mkdir(exist_ok=True)
-    (decisions / "042-some-decision.md").write_text("# Decision 42\n")
+    (decisions / "042-some-decision.md").write_text(active_decision_markdown(42, "Some decision"))
 
 
 def test_resolve_ok_matches_across_tool_and_cli(seeded_repo):

--- a/packages/nauro/tests/test_post_commit.py
+++ b/packages/nauro/tests/test_post_commit.py
@@ -21,6 +21,7 @@ from nauro.store.post_commit import AncillaryStep, run_post_commit
 from nauro.store.registry import register_project_v2
 from nauro.sync.push import PushReport
 from nauro.templates.scaffolds import scaffold_project_store
+from tests.conftest import active_decision_markdown
 
 SNAPSHOTS = "snapshots"
 
@@ -283,7 +284,7 @@ def test_degraded_push_reaches_the_flag_question_resolve_envelope(
     )
     decisions = adapter_store / "decisions"
     decisions.mkdir(exist_ok=True)
-    (decisions / "042-caching.md").write_text("# 042 — Caching\n")
+    (decisions / "042-caching.md").write_text(active_decision_markdown(42, "Caching"))
 
     def _boom(_store_path: Path) -> None:
         raise RuntimeError("S3 credentials expired")

--- a/packages/nauro/tests/test_write_command_autogen.py
+++ b/packages/nauro/tests/test_write_command_autogen.py
@@ -35,7 +35,7 @@ from nauro.mcp import tools as mcp_tools
 from nauro.store import post_commit as post_commit_module
 from tests._ansi import strip_ansi
 from tests._writer_compat import append_decision
-from tests.conftest import register_v2_repo
+from tests.conftest import active_decision_markdown, register_v2_repo
 
 runner = CliRunner()
 
@@ -399,7 +399,7 @@ def _seed_resolvable(store_path: Path) -> None:
     (store_path / "open-questions.md").write_text("# Open Questions\n\n- [Q1] needs a decision\n")
     decisions = store_path / "decisions"
     decisions.mkdir(exist_ok=True)
-    (decisions / "042-some-decision.md").write_text("# Decision 42\n")
+    (decisions / "042-some-decision.md").write_text(active_decision_markdown(42, "Some decision"))
 
 
 class TestFlagQuestionArgumentShapes:


### PR DESCRIPTION
## Why

Question resolution needs one deterministic, I/O-free seam for local and hosted callers. Durable consumers must record actual resolution effects and must reject inactive decision anchors.

## What changed

- Add a public resolver that accepts exact captured bytes, parses the selected decision artifact, requires active status, and reports newly resolved question ids separately.
- Return exact formatted bytes for every success, including byte-identical no-ops. Corrupt open-question bytes raise before semantic resolution.
- Route the local `flag_question` resolve path through the seam while preserving its result envelope and successful write behavior.
- Add caller guidance for operative-ask verification and the bulk census procedure.
- Freeze the three new public exports and the hosted-consumer contract.
- Add focused effect, corruption, parity, and compatibility tests.

## Test plan

- Focused question-resolution and flag-question tests: 111 passed.
- Full `nauro-core` suite: 1,747 passed.
- Full `nauro` scope: 2,663 passed.
- Ruff passed.
- Public and hosted-consumer contract checks passed.
- Single-source and diff checks passed.
- Independent contract review returned GREEN.

## Risk / what to review

Review the boundary between semantic rejection and corrupt committed bytes. Confirm that no-op success returns the original bytes, reports no new resolutions, and keeps the local successful write.

## Deferred

This PR adds no hosted production consumer. Server integration must wait for this PR's exact merged commit SHA and remain dormant until its separate review.
