### PR TITLE
Add deterministic update_state planning

### DIFF
--- a/packages/nauro-core/src/nauro_core/constants.py
+++ b/packages/nauro-core/src/nauro_core/constants.py
@@ -201,6 +201,7 @@ STACK_DOC_CHAR_LIMIT = 40_000
 # UTF-8 bytes; a missing file carries this literal token instead. The shape
 # lives in nauro_core.identifiers as the stack_revision kind.
 STACK_REVISION_ABSENT = "absent"
+STATE_REVISION_ABSENT = "absent"
 
 # ── L1 stack projection bounds ──
 # Automatic context gets a bound independent of both the document cap above

--- a/packages/nauro-core/src/nauro_core/identifiers.py
+++ b/packages/nauro-core/src/nauro_core/identifiers.py
@@ -11,8 +11,8 @@ is always whole-value, so a trailing newline never passes.
   underscores, at most 64 characters; server-owned closed vocabularies.
 - ``audit_target_id``: 1 to 128 printable ASCII characters, never free text.
 - ``brief_slug``: 1 to 120 lowercase letters and digits, internal hyphens only.
-- ``stack_revision``: a lowercase 64-character SHA-256 hex digest, or the
-  literal absent token.
+- ``stack_revision``: a lowercase 64-character SHA-256 hex digest, or the absent token.
+- ``state_revision``: a lowercase 64-character SHA-256 hex digest, or the absent token.
 """
 
 from __future__ import annotations
@@ -21,7 +21,11 @@ import re
 from dataclasses import dataclass
 from enum import Enum
 
-from nauro_core.constants import BRIEF_SLUG_MAX_LENGTH, STACK_REVISION_ABSENT
+from nauro_core.constants import (
+    BRIEF_SLUG_MAX_LENGTH,
+    STACK_REVISION_ABSENT,
+    STATE_REVISION_ABSENT,
+)
 
 
 class IdentifierKind(str, Enum):
@@ -31,6 +35,7 @@ class IdentifierKind(str, Enum):
     audit_target_id = "audit_target_id"
     brief_slug = "brief_slug"
     stack_revision = "stack_revision"
+    state_revision = "state_revision"
 
 
 @dataclass(frozen=True)
@@ -63,6 +68,11 @@ _SHAPES: dict[IdentifierKind, _Shape] = {
         re.compile(rf"[0-9a-f]{{64}}|{STACK_REVISION_ABSENT}"),
         f"a lowercase 64-character SHA-256 hex digest or the literal "
         f"token {STACK_REVISION_ABSENT!r}",
+    ),
+    IdentifierKind.state_revision: _Shape(
+        re.compile(rf"[0-9a-f]{{64}}|{STATE_REVISION_ABSENT}"),
+        f"a lowercase 64-character SHA-256 hex digest or the literal "
+        f"token {STATE_REVISION_ABSENT!r}",
     ),
 }
 

--- a/packages/nauro-core/src/nauro_core/operations/results.py
+++ b/packages/nauro-core/src/nauro_core/operations/results.py
@@ -291,6 +291,16 @@ class StackRevisionConflict(BaseModel):
     current_revision: str
 
 
+class StateRevisionConflict(BaseModel):
+    """A supplied state revision did not match the observed state_current.md bytes."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    status: Literal["stale_revision"] = "stale_revision"
+    expected_revision: str
+    current_revision: str
+
+
 class ShareContextAccepted(BaseModel):
     """Committed outcome of a hosted ``share_context`` operation.
 

--- a/packages/nauro-core/src/nauro_core/operations/update_state.py
+++ b/packages/nauro-core/src/nauro_core/operations/update_state.py
@@ -14,16 +14,311 @@ format is identical across surfaces.
 
 from __future__ import annotations
 
+import hashlib
+from datetime import datetime, timezone
+from typing import Literal, cast
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
 from nauro_core.constants import (
+    MAX_DELTA_LENGTH,
     STATE_CURRENT_FILENAME,
     STATE_HISTORY_FILENAME,
     STATE_LEGACY_FILENAME,
     STATE_OVERLAP_MIN_KEYWORDS,
     STATE_OVERLAP_STOP_WORDS,
+    STATE_REVISION_ABSENT,
 )
-from nauro_core.operations.results import UpdateStateResult
+from nauro_core.identifiers import IdentifierKind, InvalidIdentifier, validate_identifier
+from nauro_core.operations.planning import PlanRejected, canonical_payload_bytes
+from nauro_core.operations.results import (
+    StateRevisionConflict,
+    UpdateStateResult,
+)
 from nauro_core.operations.store import Store
-from nauro_core.state import migrate_legacy_state, prepare_state_update
+from nauro_core.state import (
+    _format_state_timestamp,
+    _prepare_state_update_at,
+    migrate_legacy_state,
+    prepare_state_update,
+)
+from nauro_core.validation import check_content_length
+
+
+def compute_state_revision(content: bytes | None) -> str:
+    """Return the exact-byte SHA-256 state revision or the absent token."""
+    if content is None:
+        return STATE_REVISION_ABSENT
+    return hashlib.sha256(content).hexdigest()
+
+
+def _copy_bytes(value: object, *, field: str) -> bytes:
+    if not isinstance(value, (bytes, bytearray, memoryview)):
+        raise TypeError(f"{field} must be bytes.")
+    return memoryview(value).tobytes()
+
+
+def _copy_optional_bytes(value: object, *, field: str) -> bytes | None:
+    if value is None:
+        return None
+    return _copy_bytes(value, field=field)
+
+
+def _normalize_updated_at(value: datetime | None) -> datetime | None:
+    if value is None:
+        return None
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError("updated_at must be timezone-aware.")
+    return value.astimezone(timezone.utc)
+
+
+class StateFileEffect(BaseModel):
+    """One exact observation and its optional replacement write."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    observed_bytes: bytes | None
+    replacement_bytes: bytes | None
+
+    @field_validator("observed_bytes", "replacement_bytes", mode="before")
+    @classmethod
+    def _copy_content(cls, value: object, info) -> bytes | None:
+        return _copy_optional_bytes(value, field=info.field_name)
+
+    @property
+    def observed_revision(self) -> str:
+        return compute_state_revision(self.observed_bytes)
+
+    @property
+    def replacement_revision(self) -> str | None:
+        if self.replacement_bytes is None:
+            return None
+        return compute_state_revision(self.replacement_bytes)
+
+    @property
+    def resulting_revision(self) -> str:
+        replacement_revision = self.replacement_revision
+        if replacement_revision is not None:
+            return replacement_revision
+        return self.observed_revision
+
+
+class UpdateStatePlan(BaseModel):
+    """Immutable state observations, terminal outcome, and replacement effects."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    delta: str
+    expected_revision: str | None
+    state_current_effect: StateFileEffect
+    state_history_effect: StateFileEffect
+    legacy_state_bytes: bytes | None
+    updated_at: datetime | None
+    result: UpdateStateResult | StateRevisionConflict
+    payload_bytes: bytes
+
+    @field_validator("legacy_state_bytes", mode="before")
+    @classmethod
+    def _copy_legacy_state(cls, value: object) -> bytes | None:
+        return _copy_optional_bytes(value, field="legacy_state_bytes")
+
+    @field_validator("payload_bytes", mode="before")
+    @classmethod
+    def _copy_payload(cls, value: object) -> bytes:
+        return _copy_bytes(value, field="payload_bytes")
+
+    @field_validator("updated_at")
+    @classmethod
+    def _normalize_time(cls, value: datetime | None) -> datetime | None:
+        return _normalize_updated_at(value)
+
+    @property
+    def operation(self) -> Literal["update_state"]:
+        return "update_state"
+
+    @property
+    def source(self) -> Literal["current", "legacy", "missing"]:
+        if self.state_current_effect.observed_bytes is not None:
+            return "current"
+        if self.legacy_state_bytes is not None:
+            return "legacy"
+        return "missing"
+
+    @property
+    def state_timestamp(self) -> str | None:
+        if self.updated_at is None:
+            return None
+        return _format_state_timestamp(self.updated_at)
+
+    @property
+    def source_revision(self) -> str:
+        if self.state_current_effect.observed_bytes is not None:
+            return compute_state_revision(self.state_current_effect.observed_bytes)
+        return compute_state_revision(self.legacy_state_bytes)
+
+    @property
+    def previous_revision(self) -> str:
+        return self.state_current_effect.observed_revision
+
+    @property
+    def new_revision(self) -> str:
+        return self.state_current_effect.resulting_revision
+
+    @property
+    def previous_history_revision(self) -> str:
+        return self.state_history_effect.observed_revision
+
+    @property
+    def new_history_revision(self) -> str:
+        return self.state_history_effect.resulting_revision
+
+
+class _StateUpdateInputs(BaseModel):
+    """Copied exact observations and normalized server time for planning."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    state_current_bytes: bytes | None
+    state_history_bytes: bytes | None
+    legacy_state_bytes: bytes | None
+    updated_at: datetime
+
+    @field_validator(
+        "state_current_bytes",
+        "state_history_bytes",
+        "legacy_state_bytes",
+        mode="before",
+    )
+    @classmethod
+    def _copy_observation(cls, value: object, info) -> bytes | None:
+        return _copy_optional_bytes(value, field=info.field_name)
+
+    @field_validator("updated_at")
+    @classmethod
+    def _normalize_time(cls, value: datetime) -> datetime:
+        normalized = _normalize_updated_at(value)
+        if normalized is None:
+            raise ValueError("updated_at must be timezone-aware.")
+        return normalized
+
+
+def plan_state_update(
+    *,
+    delta: str,
+    state_current_bytes: bytes | None,
+    state_history_bytes: bytes | None,
+    legacy_state_bytes: bytes | None,
+    updated_at: datetime,
+    expected_revision: str | None = None,
+) -> UpdateStatePlan:
+    """Plan exact state replacements without I/O or clock access."""
+    length_error = check_content_length(delta, "Delta", MAX_DELTA_LENGTH)
+    if length_error is not None:
+        raise PlanRejected(length_error)
+    try:
+        delta.encode("utf-8")
+    except UnicodeEncodeError:
+        raise PlanRejected("delta is not valid UTF-8-encodable text.") from None
+
+    if expected_revision is not None:
+        try:
+            validate_identifier(
+                IdentifierKind.state_revision,
+                expected_revision,
+                field="expected_revision",
+            )
+        except InvalidIdentifier as exc:
+            raise PlanRejected(str(exc)) from None
+
+    if updated_at.tzinfo is None or updated_at.utcoffset() is None:
+        raise ValueError("updated_at must be timezone-aware.")
+
+    inputs = _StateUpdateInputs(
+        state_current_bytes=state_current_bytes,
+        state_history_bytes=state_history_bytes,
+        legacy_state_bytes=legacy_state_bytes,
+        updated_at=updated_at,
+    )
+    payload_bytes = canonical_payload_bytes(
+        {
+            "delta": delta,
+            "expected_revision": expected_revision,
+            "operation": "update_state",
+        }
+    )
+    current_effect = StateFileEffect(
+        observed_bytes=inputs.state_current_bytes,
+        replacement_bytes=None,
+    )
+    history_effect = StateFileEffect(
+        observed_bytes=inputs.state_history_bytes,
+        replacement_bytes=None,
+    )
+
+    if expected_revision is not None and expected_revision != current_effect.observed_revision:
+        return UpdateStatePlan(
+            delta=delta,
+            expected_revision=expected_revision,
+            state_current_effect=current_effect,
+            state_history_effect=history_effect,
+            legacy_state_bytes=inputs.legacy_state_bytes,
+            updated_at=None,
+            result=StateRevisionConflict(
+                expected_revision=expected_revision,
+                current_revision=current_effect.observed_revision,
+            ),
+            payload_bytes=payload_bytes,
+        )
+
+    if inputs.state_current_bytes is None and inputs.legacy_state_bytes is None:
+        return UpdateStatePlan(
+            delta=delta,
+            expected_revision=expected_revision,
+            state_current_effect=current_effect,
+            state_history_effect=history_effect,
+            legacy_state_bytes=None,
+            updated_at=None,
+            result=UpdateStateResult(status="noop"),
+            payload_bytes=payload_bytes,
+        )
+
+    using_legacy = inputs.state_current_bytes is None
+    selected_bytes = cast(
+        bytes,
+        inputs.legacy_state_bytes if using_legacy else inputs.state_current_bytes,
+    )
+    selected_content = selected_bytes.decode("utf-8")
+    if using_legacy:
+        selected_content = migrate_legacy_state(selected_content).current_content
+
+    warning = None if using_legacy else _overlap_warning(delta, selected_content)
+    prepared = _prepare_state_update_at(delta, selected_content, inputs.updated_at)
+    current_effect = StateFileEffect(
+        observed_bytes=inputs.state_current_bytes,
+        replacement_bytes=prepared.current_content.encode("utf-8"),
+    )
+
+    if prepared.history_entry is not None:
+        history_content = (
+            ""
+            if inputs.state_history_bytes is None
+            else inputs.state_history_bytes.decode("utf-8")
+        )
+        history_effect = StateFileEffect(
+            observed_bytes=inputs.state_history_bytes,
+            replacement_bytes=(history_content + prepared.history_entry).encode("utf-8"),
+        )
+
+    return UpdateStatePlan(
+        delta=delta,
+        expected_revision=expected_revision,
+        state_current_effect=current_effect,
+        state_history_effect=history_effect,
+        legacy_state_bytes=inputs.legacy_state_bytes,
+        updated_at=inputs.updated_at,
+        result=UpdateStateResult(status="ok", warning=warning),
+        payload_bytes=payload_bytes,
+    )
 
 
 def update_state(store: Store, delta: str) -> UpdateStateResult:

--- a/packages/nauro-core/src/nauro_core/state.py
+++ b/packages/nauro-core/src/nauro_core/state.py
@@ -40,7 +40,12 @@ class StateUpdateResult:
 
 def _utc_timestamp() -> str:
     """Return current UTC time as ISO 8601 with minute precision."""
-    return datetime.now(timezone.utc).strftime(_TIMESTAMP_FORMAT)
+    return _format_state_timestamp(datetime.now(timezone.utc))
+
+
+def _format_state_timestamp(updated_at: datetime) -> str:
+    """Format an explicit time for state files at UTC minute precision."""
+    return updated_at.astimezone(timezone.utc).strftime(_TIMESTAMP_FORMAT)
 
 
 def _strip_current_header_footer(content: str) -> str:
@@ -57,13 +62,12 @@ def _strip_current_header_footer(content: str) -> str:
     return "\n".join(stripped).strip()
 
 
-def prepare_state_update(new_state: str, current_content: str | None) -> StateUpdateResult:
-    """Prepare a state update for the split state files; pure, zero I/O. Takes the new
-    state text and the current ``state_current.md`` content (``None`` when it does
-    not exist) and returns the new body plus an optional history entry.
-    """
-    timestamp = _utc_timestamp()
-
+def _prepare_state_update_with_timestamp(
+    new_state: str,
+    current_content: str | None,
+    timestamp: str,
+) -> StateUpdateResult:
+    """Format one state update with an explicit minute timestamp."""
     new_current = (
         f"{_CURRENT_STATE_HEADER}\n\n{new_state}\n\n"
         f"{_LAST_UPDATED_PREFIX}{timestamp}{_LAST_UPDATED_SUFFIX}\n"
@@ -76,6 +80,24 @@ def prepare_state_update(new_state: str, current_content: str | None) -> StateUp
             history_entry = f"## {timestamp}\n\n{old_body}\n\n---\n"
 
     return StateUpdateResult(current_content=new_current, history_entry=history_entry)
+
+
+def _prepare_state_update_at(
+    new_state: str,
+    current_content: str | None,
+    updated_at: datetime,
+) -> StateUpdateResult:
+    """Prepare a state update at an explicit time without reading the clock."""
+    return _prepare_state_update_with_timestamp(
+        new_state,
+        current_content,
+        _format_state_timestamp(updated_at),
+    )
+
+
+def prepare_state_update(new_state: str, current_content: str | None) -> StateUpdateResult:
+    """Prepare a state update for the split state files with the current UTC time."""
+    return _prepare_state_update_with_timestamp(new_state, current_content, _utc_timestamp())
 
 
 def migrate_legacy_state(legacy_content: str) -> StateUpdateResult:

--- a/packages/nauro-core/tests/operations/test_operations_update_state.py
+++ b/packages/nauro-core/tests/operations/test_operations_update_state.py
@@ -28,6 +28,20 @@ from nauro_core.operations import (
 )
 
 
+class RecordingStore:
+    def __init__(self, files: dict[str, str]) -> None:
+        self.files = dict(files)
+        self.calls: list[tuple[str, str, str | None]] = []
+
+    def read_file(self, path: str) -> str | None:
+        self.calls.append(("read", path, None))
+        return self.files.get(path)
+
+    def write_file(self, path: str, content: str) -> None:
+        self.calls.append(("write", path, content))
+        self.files[path] = content
+
+
 def test_returns_result_type() -> None:
     result = update_state(InMemoryStore(), "anything")
     assert isinstance(result, UpdateStateResult)
@@ -96,6 +110,41 @@ def test_legacy_state_only_migrates_to_state_current() -> None:
     history = store.read_file(STATE_HISTORY_FILENAME)
     assert history is not None
     assert "Legacy content" in history
+
+
+def test_legacy_write_order_and_lazy_history_read_remain_unchanged() -> None:
+    legacy = "# State\n\nLegacy body\n"
+    store = RecordingStore({STATE_LEGACY_FILENAME: legacy})
+    with patch("nauro_core.state._utc_timestamp", return_value="2026-04-08T15:30Z"):
+        result = update_state(store, "New body")
+
+    assert result.status == "ok"
+    assert store.calls == [
+        ("read", STATE_CURRENT_FILENAME, None),
+        ("read", STATE_LEGACY_FILENAME, None),
+        ("write", STATE_CURRENT_FILENAME, legacy),
+        (
+            "write",
+            STATE_CURRENT_FILENAME,
+            "# Current State\n\nNew body\n\n*Last updated: 2026-04-08T15:30Z*\n",
+        ),
+        ("read", STATE_HISTORY_FILENAME, None),
+        (
+            "write",
+            STATE_HISTORY_FILENAME,
+            "## 2026-04-08T15:30Z\n\n# State\n\nLegacy body\n\n---\n",
+        ),
+    ]
+
+
+def test_noop_keeps_history_read_lazy() -> None:
+    store = RecordingStore({STATE_HISTORY_FILENAME: "unread"})
+    result = update_state(store, "New body")
+    assert result.status == "noop"
+    assert store.calls == [
+        ("read", STATE_CURRENT_FILENAME, None),
+        ("read", STATE_LEGACY_FILENAME, None),
+    ]
 
 
 def test_history_accumulates_across_repeated_writes() -> None:

--- a/packages/nauro-core/tests/operations/test_update_state_plan.py
+++ b/packages/nauro-core/tests/operations/test_update_state_plan.py
@@ -1,0 +1,489 @@
+"""Contract tests for deterministic ``update_state`` planning."""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+import nauro_core
+import nauro_core.operations as operations
+from nauro_core.constants import (
+    MAX_DELTA_LENGTH,
+    STATE_REVISION_ABSENT,
+)
+from nauro_core.operations import InMemoryStore, update_state
+from nauro_core.operations.planning import PlanRejected, canonical_payload_bytes
+from nauro_core.operations.results import StateRevisionConflict, UpdateStateResult
+from nauro_core.operations.update_state import (
+    StateFileEffect,
+    UpdateStatePlan,
+    compute_state_revision,
+    plan_state_update,
+)
+
+UPDATED_AT = datetime(2026, 8, 19, 7, 37, 59, tzinfo=timezone.utc)
+CURRENT = b"# Current State\n\n- Task one\n"
+HISTORY = b"## 2026-08-18T10:00Z\n\n- Earlier task\n\n---\n"
+DELTA = "Task two"
+
+
+def _plan(**overrides: object) -> UpdateStatePlan:
+    arguments: dict[str, object] = {
+        "delta": DELTA,
+        "state_current_bytes": CURRENT,
+        "state_history_bytes": HISTORY,
+        "legacy_state_bytes": None,
+        "updated_at": UPDATED_AT,
+        "expected_revision": None,
+    }
+    arguments.update(overrides)
+    return plan_state_update(**arguments)  # type: ignore[arg-type]
+
+
+class TestPublicShape:
+    def test_signature_is_keyword_only_and_exact(self) -> None:
+        signature = inspect.signature(plan_state_update)
+        assert list(signature.parameters) == [
+            "delta",
+            "state_current_bytes",
+            "state_history_bytes",
+            "legacy_state_bytes",
+            "updated_at",
+            "expected_revision",
+        ]
+        assert all(
+            parameter.kind is inspect.Parameter.KEYWORD_ONLY
+            for parameter in signature.parameters.values()
+        )
+        assert signature.parameters["expected_revision"].default is None
+        assert signature.return_annotation == "UpdateStatePlan"
+
+    @pytest.mark.parametrize("model", [StateFileEffect, UpdateStatePlan])
+    def test_models_are_frozen_closed_pydantic_models(self, model: type[BaseModel]) -> None:
+        assert issubclass(model, BaseModel)
+        assert model.model_config["frozen"] is True
+        assert model.model_config["extra"] == "forbid"
+
+    def test_effect_field_order_and_annotations(self) -> None:
+        assert list(StateFileEffect.model_fields) == ["observed_bytes", "replacement_bytes"]
+        assert StateFileEffect.__annotations__ == {
+            "observed_bytes": "bytes | None",
+            "replacement_bytes": "bytes | None",
+        }
+
+    def test_plan_field_order_and_annotations(self) -> None:
+        assert list(UpdateStatePlan.model_fields) == [
+            "delta",
+            "expected_revision",
+            "state_current_effect",
+            "state_history_effect",
+            "legacy_state_bytes",
+            "updated_at",
+            "result",
+            "payload_bytes",
+        ]
+        assert UpdateStatePlan.__annotations__ == {
+            "delta": "str",
+            "expected_revision": "str | None",
+            "state_current_effect": "StateFileEffect",
+            "state_history_effect": "StateFileEffect",
+            "legacy_state_bytes": "bytes | None",
+            "updated_at": "datetime | None",
+            "result": "UpdateStateResult | StateRevisionConflict",
+            "payload_bytes": "bytes",
+        }
+
+    def test_derived_properties_are_not_fields_or_dump_keys(self) -> None:
+        plan = _plan()
+        derived = {
+            "operation",
+            "source",
+            "state_timestamp",
+            "source_revision",
+            "previous_revision",
+            "new_revision",
+            "previous_history_revision",
+            "new_history_revision",
+        }
+        assert derived.isdisjoint(UpdateStatePlan.model_fields)
+        assert derived.isdisjoint(plan.model_dump(mode="python"))
+
+    def test_new_names_do_not_enter_curated_exports(self) -> None:
+        names = {
+            "plan_state_update",
+            "UpdateStatePlan",
+            "StateFileEffect",
+            "compute_state_revision",
+        }
+        assert names.isdisjoint(nauro_core.__all__)
+        assert names.isdisjoint(operations.__all__)
+
+    def test_models_are_frozen_and_reject_extra_fields(self) -> None:
+        effect = StateFileEffect(observed_bytes=b"old", replacement_bytes=b"new")
+        with pytest.raises(ValidationError):
+            effect.observed_bytes = b"changed"
+        with pytest.raises(ValidationError):
+            StateFileEffect(
+                observed_bytes=b"old",
+                replacement_bytes=b"new",
+                unexpected=True,
+            )
+
+        plan = _plan()
+        with pytest.raises(ValidationError):
+            plan.delta = "changed"
+        with pytest.raises(ValidationError):
+            UpdateStatePlan(**plan.model_dump(), unexpected=True)
+
+    def test_plan_model_copies_bytes_and_normalizes_time(self) -> None:
+        baseline = _plan()
+        legacy = bytearray(b"legacy")
+        payload = bytearray(b"payload")
+        offset = timezone(timedelta(hours=9))
+        plan = UpdateStatePlan(
+            **{
+                **baseline.model_dump(),
+                "legacy_state_bytes": legacy,
+                "updated_at": datetime(2026, 8, 19, 16, 37, tzinfo=offset),
+                "payload_bytes": payload,
+            }
+        )
+
+        legacy[:] = b"xxxxxx"
+        payload[:] = b"xxxxxxx"
+
+        assert plan.legacy_state_bytes == b"legacy"
+        assert plan.payload_bytes == b"payload"
+        assert plan.updated_at == datetime(2026, 8, 19, 7, 37, tzinfo=timezone.utc)
+
+
+class TestStateFileEffect:
+    def test_revisions_derive_from_exact_bytes(self) -> None:
+        effect = StateFileEffect(observed_bytes=b"old\n", replacement_bytes=b"new\n")
+        assert effect.observed_revision == hashlib.sha256(b"old\n").hexdigest()
+        assert effect.replacement_revision == hashlib.sha256(b"new\n").hexdigest()
+        assert effect.resulting_revision == effect.replacement_revision
+
+    def test_no_replacement_means_no_write(self) -> None:
+        effect = StateFileEffect(observed_bytes=b"old", replacement_bytes=None)
+        assert effect.replacement_revision is None
+        assert effect.resulting_revision == effect.observed_revision
+
+    def test_absent_observation_without_replacement_stays_absent(self) -> None:
+        effect = StateFileEffect(observed_bytes=None, replacement_bytes=None)
+        assert effect.observed_revision == STATE_REVISION_ABSENT
+        assert effect.replacement_revision is None
+        assert effect.resulting_revision == STATE_REVISION_ABSENT
+
+    def test_mutable_inputs_are_copied(self) -> None:
+        observed = bytearray(b"old")
+        replacement = bytearray(b"new")
+        effect = StateFileEffect(
+            observed_bytes=observed,
+            replacement_bytes=replacement,
+        )
+
+        observed[:] = b"xxx"
+        replacement[:] = b"yyy"
+
+        assert effect.observed_bytes == b"old"
+        assert effect.replacement_bytes == b"new"
+        assert isinstance(effect.observed_bytes, bytes)
+        assert isinstance(effect.replacement_bytes, bytes)
+
+
+class TestRevisionAndPayload:
+    def test_revision_is_exact_sha256_or_absent(self) -> None:
+        assert compute_state_revision(None) == STATE_REVISION_ABSENT
+        assert compute_state_revision(b"state") == hashlib.sha256(b"state").hexdigest()
+        assert compute_state_revision(b"state") != compute_state_revision(b"state\n")
+
+    def test_payload_identity_is_exact(self) -> None:
+        plan = _plan(expected_revision="ab" * 32)
+        assert plan.payload_bytes == canonical_payload_bytes(
+            {
+                "delta": DELTA,
+                "expected_revision": "ab" * 32,
+                "operation": "update_state",
+            }
+        )
+
+    def test_payload_includes_null_expected_revision(self) -> None:
+        plan = _plan()
+        assert plan.payload_bytes == canonical_payload_bytes(
+            {
+                "delta": DELTA,
+                "expected_revision": None,
+                "operation": "update_state",
+            }
+        )
+
+    def test_observations_and_time_do_not_change_payload_identity(self) -> None:
+        first = _plan()
+        second = _plan(
+            state_current_bytes=b"different",
+            state_history_bytes=None,
+            legacy_state_bytes=b"ignored",
+            updated_at=UPDATED_AT + timedelta(days=1),
+        )
+        assert first.payload_bytes == second.payload_bytes
+
+    def test_expected_revision_changes_payload_identity(self) -> None:
+        assert _plan().payload_bytes != _plan(expected_revision="ab" * 32).payload_bytes
+
+
+class TestPlanningOutcomes:
+    def test_planner_copies_all_observed_bytes(self) -> None:
+        current = bytearray(CURRENT)
+        history = bytearray(HISTORY)
+        legacy = bytearray(b"ignored legacy")
+        plan = _plan(
+            state_current_bytes=current,
+            state_history_bytes=history,
+            legacy_state_bytes=legacy,
+        )
+
+        current[:] = b"x" * len(current)
+        history[:] = b"x" * len(history)
+        legacy[:] = b"x" * len(legacy)
+
+        assert plan.state_current_effect.observed_bytes == CURRENT
+        assert plan.state_history_effect.observed_bytes == HISTORY
+        assert plan.legacy_state_bytes == b"ignored legacy"
+
+    def test_current_source_plans_exact_final_replacements(self) -> None:
+        plan = _plan()
+        assert plan.operation == "update_state"
+        assert plan.source == "current"
+        assert plan.state_timestamp == "2026-08-19T07:37Z"
+        assert plan.updated_at == UPDATED_AT
+        assert plan.result == UpdateStateResult(status="ok")
+        assert plan.state_current_effect.observed_bytes == CURRENT
+        assert plan.state_current_effect.replacement_bytes == (
+            b"# Current State\n\nTask two\n\n*Last updated: 2026-08-19T07:37Z*\n"
+        )
+        assert plan.state_history_effect.observed_bytes == HISTORY
+        assert plan.state_history_effect.replacement_bytes == (
+            HISTORY + b"## 2026-08-19T07:37Z\n\n- Task one\n\n---\n"
+        )
+        assert plan.previous_revision == compute_state_revision(CURRENT)
+        assert plan.new_revision == compute_state_revision(
+            plan.state_current_effect.replacement_bytes
+        )
+        assert plan.previous_history_revision == compute_state_revision(HISTORY)
+        assert plan.new_history_revision == compute_state_revision(
+            plan.state_history_effect.replacement_bytes
+        )
+
+    def test_offset_time_is_normalized_to_utc_before_minute_formatting(self) -> None:
+        offset = timezone(timedelta(hours=9))
+        plan = _plan(updated_at=datetime(2026, 8, 19, 16, 37, 59, tzinfo=offset))
+        assert plan.updated_at == UPDATED_AT
+        assert plan.updated_at is not None
+        assert plan.updated_at.tzinfo is timezone.utc
+        assert plan.state_timestamp == "2026-08-19T07:37Z"
+
+    def test_overlap_warning_keeps_first_matching_line_and_exact_wording(self) -> None:
+        current = (
+            b"# Current State\n\n"
+            b"- Implemented OAuth login flow with PKCE\n"
+            b"- Implemented OAuth backup flow with PKCE\n"
+        )
+        plan = _plan(
+            delta="Implemented OAuth refresh logic with PKCE",
+            state_current_bytes=current,
+        )
+        assert plan.result == UpdateStateResult(
+            status="ok",
+            warning=(
+                "State update shares keywords with existing entry: "
+                "- Implemented OAuth login flow with PKCE"
+            ),
+        )
+
+    def test_current_wins_and_malformed_unselected_legacy_is_ignored(self) -> None:
+        plan = _plan(legacy_state_bytes=b"\xff")
+        assert plan.source == "current"
+        assert plan.legacy_state_bytes == b"\xff"
+        assert plan.result.status == "ok"
+
+    def test_legacy_source_suppresses_warning_and_is_not_deleted(self) -> None:
+        legacy = b"# State\n\n- Implemented OAuth login flow with PKCE\n"
+        plan = _plan(
+            delta="Implemented OAuth refresh logic with PKCE",
+            state_current_bytes=None,
+            legacy_state_bytes=legacy,
+        )
+        assert plan.source == "legacy"
+        assert plan.result == UpdateStateResult(status="ok")
+        assert plan.legacy_state_bytes == legacy
+        assert plan.state_current_effect.observed_bytes is None
+        assert plan.state_current_effect.replacement_bytes == (
+            b"# Current State\n\nImplemented OAuth refresh logic with PKCE\n\n"
+            b"*Last updated: 2026-08-19T07:37Z*\n"
+        )
+        assert plan.state_history_effect.replacement_bytes == (
+            HISTORY
+            + b"## 2026-08-19T07:37Z\n\n# State\n\n"
+            + b"- Implemented OAuth login flow with PKCE\n\n---\n"
+        )
+
+    def test_legacy_source_revision_differs_from_observed_current_revision(self) -> None:
+        legacy = b"# State\n\nLegacy state\n"
+        plan = _plan(state_current_bytes=None, legacy_state_bytes=legacy)
+        assert plan.source_revision == compute_state_revision(legacy)
+        assert plan.previous_revision == STATE_REVISION_ABSENT
+        assert plan.source_revision != plan.previous_revision
+
+    def test_empty_stripped_prior_skips_history_write_and_decode(self) -> None:
+        empty_current = b"# Current State\n\n\n\n*Last updated: 2026-08-18T10:00Z*\n"
+        plan = _plan(
+            state_current_bytes=empty_current,
+            state_history_bytes=b"\xff",
+        )
+        assert plan.result.status == "ok"
+        assert plan.state_history_effect.observed_bytes == b"\xff"
+        assert plan.state_history_effect.replacement_bytes is None
+        assert plan.new_history_revision == compute_state_revision(b"\xff")
+
+    def test_noop_retains_observations_and_payload_without_replacements(self) -> None:
+        plan = _plan(
+            state_current_bytes=None,
+            state_history_bytes=b"\xff",
+            legacy_state_bytes=None,
+        )
+        assert plan.source == "missing"
+        assert plan.source_revision == STATE_REVISION_ABSENT
+        assert plan.result == UpdateStateResult(status="noop")
+        assert plan.updated_at is None
+        assert plan.state_timestamp is None
+        assert plan.state_current_effect == StateFileEffect(
+            observed_bytes=None,
+            replacement_bytes=None,
+        )
+        assert plan.state_history_effect == StateFileEffect(
+            observed_bytes=b"\xff",
+            replacement_bytes=None,
+        )
+        assert plan.payload_bytes == canonical_payload_bytes(
+            {"delta": DELTA, "expected_revision": None, "operation": "update_state"}
+        )
+
+    def test_stale_revision_wins_over_corrupt_observations(self) -> None:
+        current = b"\xff"
+        plan = _plan(
+            state_current_bytes=current,
+            state_history_bytes=b"\xff",
+            legacy_state_bytes=b"\xff",
+            expected_revision=STATE_REVISION_ABSENT,
+        )
+        assert plan.result == StateRevisionConflict(
+            expected_revision=STATE_REVISION_ABSENT,
+            current_revision=compute_state_revision(current),
+        )
+        assert plan.source == "current"
+        assert plan.updated_at is None
+        assert plan.state_current_effect.replacement_bytes is None
+        assert plan.state_history_effect.replacement_bytes is None
+
+    def test_expected_revision_binds_observed_current_not_legacy_source(self) -> None:
+        legacy = b"legacy"
+        plan = _plan(
+            state_current_bytes=None,
+            legacy_state_bytes=legacy,
+            expected_revision=compute_state_revision(legacy),
+        )
+        assert plan.result == StateRevisionConflict(
+            expected_revision=compute_state_revision(legacy),
+            current_revision=STATE_REVISION_ABSENT,
+        )
+        assert plan.source_revision == compute_state_revision(legacy)
+        assert plan.previous_revision == STATE_REVISION_ABSENT
+
+
+class TestValidationOrder:
+    def test_delta_length_precedes_utf8_validation(self) -> None:
+        with pytest.raises(PlanRejected) as excinfo:
+            _plan(delta="\ud800" * (MAX_DELTA_LENGTH + 1), expected_revision="bad")
+        assert excinfo.value.reason == (
+            f"Delta exceeds maximum length of {MAX_DELTA_LENGTH} characters "
+            f"(got {MAX_DELTA_LENGTH + 1})."
+        )
+
+    def test_delta_utf8_precedes_expected_revision_validation(self) -> None:
+        with pytest.raises(PlanRejected) as excinfo:
+            _plan(delta="\ud800", expected_revision="bad")
+        assert excinfo.value.reason == "delta is not valid UTF-8-encodable text."
+
+    def test_expected_revision_precedes_timestamp_awareness(self) -> None:
+        with pytest.raises(PlanRejected) as excinfo:
+            _plan(expected_revision="bad", updated_at=datetime(2026, 8, 19))
+        assert "expected_revision" in excinfo.value.reason
+
+    def test_naive_timestamp_raises_exact_value_error(self) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            _plan(updated_at=datetime(2026, 8, 19))
+        assert str(excinfo.value) == "updated_at must be timezone-aware."
+
+    def test_offsetless_timestamp_raises_exact_value_error(self) -> None:
+        class Offsetless(timezone.__base__):
+            def utcoffset(self, dt):
+                return None
+
+            def dst(self, dt):
+                return None
+
+        with pytest.raises(ValueError) as excinfo:
+            _plan(updated_at=datetime(2026, 8, 19, tzinfo=Offsetless()))
+        assert str(excinfo.value) == "updated_at must be timezone-aware."
+
+    def test_selected_current_utf8_failure_propagates(self) -> None:
+        with pytest.raises(UnicodeDecodeError):
+            _plan(state_current_bytes=b"\xff")
+
+    def test_selected_legacy_utf8_failure_propagates(self) -> None:
+        with pytest.raises(UnicodeDecodeError):
+            _plan(state_current_bytes=None, legacy_state_bytes=b"\xff")
+
+    def test_required_history_utf8_failure_propagates(self) -> None:
+        with pytest.raises(UnicodeDecodeError):
+            _plan(state_history_bytes=b"\xff")
+
+    def test_empty_and_nul_delta_are_preserved(self) -> None:
+        empty = _plan(delta="")
+        nul = _plan(delta="a\x00b")
+        assert b"\n\n\n\n*Last updated:" in empty.state_current_effect.replacement_bytes
+        assert b"a\x00b" in nul.state_current_effect.replacement_bytes
+
+
+class TestLocalParity:
+    def test_current_path_matches_existing_store_operation_byte_for_byte(self) -> None:
+        store = InMemoryStore(
+            files={
+                "state_current.md": CURRENT.decode(),
+                "state_history.md": HISTORY.decode(),
+            }
+        )
+        with patch("nauro_core.state._utc_timestamp", return_value="2026-08-19T07:37Z"):
+            local_result = update_state(store, DELTA)
+
+        plan = _plan()
+        assert plan.result == local_result
+        assert (
+            plan.state_current_effect.replacement_bytes
+            == store.read_file("state_current.md").encode()
+        )
+        assert (
+            plan.state_history_effect.replacement_bytes
+            == store.read_file("state_history.md").encode()
+        )
+
+    def test_planner_does_not_read_the_clock(self) -> None:
+        with patch("nauro_core.state._utc_timestamp", side_effect=AssertionError("clock read")):
+            plan = _plan()
+        assert plan.state_timestamp == "2026-08-19T07:37Z"

--- a/packages/nauro-core/tests/operations/test_workflow_results.py
+++ b/packages/nauro-core/tests/operations/test_workflow_results.py
@@ -14,6 +14,7 @@ from nauro_core.operations.results import (
     ShareContextAccepted,
     SlugConflict,
     StackRevisionConflict,
+    StateRevisionConflict,
     UpdateStackAccepted,
     WorkflowExpired,
     WorkflowInProgress,
@@ -97,6 +98,33 @@ class TestStackRevisionConflict:
             conflict.current_revision = "absent"
         with pytest.raises(ValidationError):
             StackRevisionConflict(
+                expected_revision=REVISION,
+                current_revision="absent",
+                unexpected_field="value",
+            )
+
+
+class TestStateRevisionConflict:
+    def test_dump_shape(self) -> None:
+        conflict = StateRevisionConflict(
+            expected_revision=REVISION,
+            current_revision="absent",
+        )
+        assert conflict.model_dump(mode="json") == {
+            "status": "stale_revision",
+            "expected_revision": REVISION,
+            "current_revision": "absent",
+        }
+
+    def test_frozen_and_closed(self) -> None:
+        conflict = StateRevisionConflict(
+            expected_revision=REVISION,
+            current_revision="0" * 64,
+        )
+        with pytest.raises(ValidationError):
+            conflict.current_revision = "absent"
+        with pytest.raises(ValidationError):
+            StateRevisionConflict(
                 expected_revision=REVISION,
                 current_revision="absent",
                 unexpected_field="value",

--- a/packages/nauro-core/tests/snapshots/hosted_consumer_contract_v1.json
+++ b/packages/nauro-core/tests/snapshots/hosted_consumer_contract_v1.json
@@ -222,7 +222,8 @@
         "server_token",
         "audit_target_id",
         "brief_slug",
-        "stack_revision"
+        "stack_revision",
+        "state_revision"
       ],
       "module": "nauro_core.identifiers",
       "qualname": "IdentifierKind"

--- a/packages/nauro-core/tests/test_identifiers.py
+++ b/packages/nauro-core/tests/test_identifiers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from nauro_core.constants import STATE_REVISION_ABSENT
 from nauro_core.identifiers import (
     IdentifierKind,
     InvalidIdentifier,
@@ -21,6 +22,7 @@ VALID_BY_KIND = {
     IdentifierKind.audit_target_id: "target-1",
     IdentifierKind.brief_slug: "auth-cutover-2",
     IdentifierKind.stack_revision: "0" * 64,
+    IdentifierKind.state_revision: "f" * 64,
 }
 
 
@@ -213,6 +215,41 @@ class TestStackRevision:
 
     def test_rejects_non_str(self) -> None:
         assert not is_identifier(IdentifierKind.stack_revision, None)
+
+
+class TestStateRevision:
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "0" * 64,
+            "f" * 64,
+            "0123456789abcdef" * 4,
+            STATE_REVISION_ABSENT,
+        ],
+    )
+    def test_accepts(self, value: str) -> None:
+        assert is_identifier(IdentifierKind.state_revision, value)
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "",
+            "0" * 63,
+            "0" * 65,
+            "A" * 64,
+            "0123456789ABCDEF" * 4,
+            "g" * 64,
+            "ABSENT",
+            "Absent",
+            "absent ",
+            "present",
+        ],
+    )
+    def test_rejects(self, value: str) -> None:
+        assert not is_identifier(IdentifierKind.state_revision, value)
+
+    def test_rejects_non_str(self) -> None:
+        assert not is_identifier(IdentifierKind.state_revision, None)
 
 
 class TestTrailingNewline:

--- a/packages/nauro-core/tests/test_state.py
+++ b/packages/nauro-core/tests/test_state.py
@@ -1,10 +1,12 @@
 """Tests for nauro_core.state — split state file logic."""
 
 import re
+from datetime import datetime, timezone
 from unittest.mock import patch
 
 from nauro_core.state import (
     StateUpdateResult,
+    _prepare_state_update_at,
     _strip_current_header_footer,
     assemble_state_for_context,
     migrate_legacy_state,
@@ -77,6 +79,18 @@ class TestPrepareStateUpdate:
             assert "2026-04-08T15:30Z" in result.current_content
             assert result.history_entry is not None
             assert "2026-04-08T15:30Z" in result.history_entry
+
+    def test_explicit_time_helper_uses_one_utc_minute_timestamp(self):
+        old = "# Current State\n\nOld\n\n*Last updated: 2026-04-01T10:00Z*\n"
+        result = _prepare_state_update_at(
+            "new",
+            old,
+            datetime(2026, 4, 8, 15, 30, 59, tzinfo=timezone.utc),
+        )
+        assert result.current_content == (
+            "# Current State\n\nnew\n\n*Last updated: 2026-04-08T15:30Z*\n"
+        )
+        assert result.history_entry == "## 2026-04-08T15:30Z\n\nOld\n\n---\n"
 
 
 class TestMigrateLegacyState:


### PR DESCRIPTION
## Why

Hosted state publication needs to derive the same state bytes as the local `update_state` operation. It must do this without duplicating formatting rules or including observed storage state in idempotency identity.

## What changed

- Add a frozen direct-submodule `plan_state_update` contract with exact-byte observations, replacement effects, derived revisions, canonical payload bytes, and typed stale-revision outcomes.
- Single-source explicit UTC minute formatting while preserving current, history, legacy, warning, and local write behavior.
- Add the state revision token and identifier shape. Keep the curated top-level exports and local tool surfaces unchanged.
- Pin byte parity, validation order, immutability, defensive copies, revision semantics, payload identity, legacy precedence, and consumer-contract shape.

## Test plan

- `uv run --no-sync ruff check packages/nauro-core/src packages/nauro-core/tests`
- `uv run --no-sync ruff format --check packages/nauro-core/src packages/nauro-core/tests`
- `python scripts/check_docstring_budget.py packages/nauro/src packages/nauro-core/src`
- Regenerated and verified the hosted-consumer contract snapshot
- Full `nauro-core` suite: 1809 passed
- Update-state parity, cross-surface, and public-contract suite: 11 passed, 1 skipped
- Full local `nauro` suite: 2663 passed
- Import-linter: 2 contracts kept
- Built the `nauro-core` wheel

## Risk / what to review

Review the fixed validation order, especially stale-revision precedence over malformed observed bytes. Also review the distinction between the selected legacy source revision and the absent observed `state_current.md` revision.

## Deferred

This change adds no hosted consumer, publication coordinator, ToolSpec, route, release, dependency bump, migration, deployment activation, application work, or report integration.
