### PR TITLE
Add deterministic report submission planning

### DIFF
--- a/packages/nauro-core/src/nauro_core/operations/results.py
+++ b/packages/nauro-core/src/nauro_core/operations/results.py
@@ -5,7 +5,8 @@ shape responses from typed attributes rather than loosely-typed dicts.
 ``RelatedDecision`` and ``ErrorPayload`` are shared submodels reused by
 multiple operations; per-operation ``Result`` models live alongside.
 
-The plan-returning operations (``update_stack``, ``share_context``) are
+The plan-returning operations (``update_stack``, ``share_context``,
+``submit_report``) are
 executed by the hosted server, so their outcome models — the accepted,
 conflict, and workflow shapes at the bottom of this module — are defined
 here as the cross-surface contract even though the kernel never
@@ -16,7 +17,9 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from nauro_core.identifiers import IdentifierKind, validate_identifier
 
 
 class RelatedDecision(BaseModel):
@@ -317,6 +320,36 @@ class ShareContextAccepted(BaseModel):
     event_id: str
     content_digest: str
     receipt_id: str
+
+
+class SubmitReportAccepted(BaseModel):
+    """Committed outcome of an original hosted ``submit_report`` operation."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", strict=True)
+
+    status: Literal["accepted"] = "accepted"
+    report_id: str
+    event_id: str
+    body_digest: str
+    receipt_id: str
+
+    @field_validator("report_id", "event_id", "receipt_id")
+    @classmethod
+    def _ulids(cls, value: str, info) -> str:
+        return validate_identifier(IdentifierKind.ulid, value, field=info.field_name)
+
+    @field_validator("body_digest")
+    @classmethod
+    def _body_digest(cls, value: str) -> str:
+        if len(value) != 64 or any(char not in "0123456789abcdef" for char in value):
+            raise ValueError("body_digest must be a lowercase SHA-256 digest.")
+        return value
+
+    @model_validator(mode="after")
+    def _original_identity(self) -> SubmitReportAccepted:
+        if self.report_id != self.event_id:
+            raise ValueError("report_id must equal event_id for an original report.")
+        return self
 
 
 class SlugConflict(BaseModel):

--- a/packages/nauro-core/src/nauro_core/operations/submit_report.py
+++ b/packages/nauro-core/src/nauro_core/operations/submit_report.py
@@ -1,0 +1,66 @@
+"""Deterministic planning for original report submission."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, model_validator
+
+from nauro_core.operations.planning import PlanRejected, canonical_payload_bytes
+
+MAX_REPORT_BODY_BYTES = 51_200
+
+
+class SubmitReportPlan(BaseModel):
+    """Frozen identity and exact body bytes for an original report."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    operation: Literal["submit_report"] = "submit_report"
+    body: str
+    body_bytes: bytes
+    body_digest: str
+    payload_bytes: bytes
+
+    @model_validator(mode="after")
+    def _validate_derivations(self) -> SubmitReportPlan:
+        try:
+            body_bytes = self.body.encode("utf-8")
+        except UnicodeEncodeError:
+            raise ValueError("body is not valid UTF-8-encodable text.") from None
+        if self.body_bytes != body_bytes:
+            raise ValueError("body_bytes must equal the exact UTF-8 encoding of body.")
+        if self.body_digest != hashlib.sha256(body_bytes).hexdigest():
+            raise ValueError("body_digest must equal the SHA-256 digest of body_bytes.")
+        if self.payload_bytes != canonical_payload_bytes(
+            {"body": self.body, "operation": "submit_report"}
+        ):
+            raise ValueError("payload_bytes must equal the canonical submit_report payload.")
+        return self
+
+
+def submit_report(body: str) -> SubmitReportPlan:
+    """Validate an exact original report body into a frozen execution plan."""
+    if not isinstance(body, str):
+        raise TypeError("body must be str.")
+    if body == "":
+        raise PlanRejected("body is empty.")
+    if "\x00" in body:
+        raise PlanRejected("body contains a NUL character.")
+    try:
+        body_bytes = body.encode("utf-8")
+    except UnicodeEncodeError:
+        raise PlanRejected("body is not valid UTF-8-encodable text.") from None
+    if len(body_bytes) > MAX_REPORT_BODY_BYTES:
+        raise PlanRejected(
+            f"body exceeds the {MAX_REPORT_BODY_BYTES}-byte report cap "
+            f"(got {len(body_bytes)} bytes)."
+        )
+
+    return SubmitReportPlan(
+        body=body,
+        body_bytes=body_bytes,
+        body_digest=hashlib.sha256(body_bytes).hexdigest(),
+        payload_bytes=canonical_payload_bytes({"body": body, "operation": "submit_report"}),
+    )

--- a/packages/nauro-core/tests/operations/test_submit_report.py
+++ b/packages/nauro-core/tests/operations/test_submit_report.py
@@ -1,0 +1,214 @@
+"""Contract tests for deterministic original report submission planning."""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+import json
+from typing import Literal
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+import nauro_core
+import nauro_core.operations as operations
+import nauro_core.operations.submit_report as submit_report_module
+from nauro_core.mcp_tools import ALL_TOOLS, HOSTED_TOOLS
+from nauro_core.operations.planning import PlanRejected, canonical_payload_bytes
+from nauro_core.operations.submit_report import (
+    MAX_REPORT_BODY_BYTES,
+    SubmitReportPlan,
+    submit_report,
+)
+
+BODY = "Café\nReady ✅"
+
+
+def _plan(body: str = BODY) -> SubmitReportPlan:
+    return submit_report(body)
+
+
+class TestPublicShape:
+    def test_signature_is_exact(self) -> None:
+        signature = inspect.signature(submit_report)
+        assert list(signature.parameters) == ["body"]
+        assert signature.parameters["body"].kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+        assert signature.parameters["body"].annotation == "str"
+        assert signature.return_annotation == "SubmitReportPlan"
+
+    def test_report_body_cap_is_exact(self) -> None:
+        assert MAX_REPORT_BODY_BYTES == 51_200
+
+    def test_plan_is_frozen_closed_pydantic_model(self) -> None:
+        assert issubclass(SubmitReportPlan, BaseModel)
+        assert SubmitReportPlan.model_config["frozen"] is True
+        assert SubmitReportPlan.model_config["extra"] == "forbid"
+
+        plan = _plan()
+        with pytest.raises(ValidationError):
+            plan.body = "changed"
+        with pytest.raises(ValidationError):
+            SubmitReportPlan(**plan.model_dump(), unexpected=True)
+
+    def test_plan_field_order_and_annotations(self) -> None:
+        assert list(SubmitReportPlan.model_fields) == [
+            "operation",
+            "body",
+            "body_bytes",
+            "body_digest",
+            "payload_bytes",
+        ]
+        assert SubmitReportPlan.model_fields["operation"].annotation == Literal["submit_report"]
+        assert SubmitReportPlan.model_fields["body"].annotation is str
+        assert SubmitReportPlan.model_fields["body_bytes"].annotation is bytes
+        assert SubmitReportPlan.model_fields["body_digest"].annotation is str
+        assert SubmitReportPlan.model_fields["payload_bytes"].annotation is bytes
+
+    def test_new_names_do_not_enter_curated_exports(self) -> None:
+        names = {"submit_report", "SubmitReportPlan", "SubmitReportAccepted"}
+        assert names.isdisjoint(nauro_core.__all__)
+        assert names.isdisjoint(operations.__all__)
+
+    def test_no_request_or_rejection_models_exist(self) -> None:
+        assert not hasattr(submit_report_module, "SubmitReportRequest")
+        assert not hasattr(submit_report_module, "SubmitReportRejected")
+        assert not hasattr(submit_report_module, "ReportRejectionCode")
+
+    def test_tool_registries_do_not_include_submit_report(self) -> None:
+        assert "submit_report" not in {spec["name"] for spec in ALL_TOOLS}
+        assert "submit_report" not in {spec["name"] for spec in HOSTED_TOOLS}
+
+
+class TestAcceptedPlan:
+    def test_exact_body_derivations(self) -> None:
+        plan = _plan()
+        body_bytes = BODY.encode("utf-8")
+        assert plan.operation == "submit_report"
+        assert plan.body == BODY
+        assert plan.body_bytes == body_bytes
+        assert plan.body_digest == hashlib.sha256(body_bytes).hexdigest()
+        assert plan.payload_bytes == canonical_payload_bytes(
+            {"body": BODY, "operation": "submit_report"}
+        )
+
+    def test_canonical_unicode_example_is_exact(self) -> None:
+        plan = _plan()
+        assert plan.body_bytes == b"Caf\xc3\xa9\nReady \xe2\x9c\x85"
+        assert plan.body_digest == (
+            "59fdb52f865222408638e32c80d4308fa01f69b4ced44f375978e616c9d6c55c"
+        )
+        assert plan.payload_bytes == (
+            b'{"body":"Caf\xc3\xa9\\nReady \xe2\x9c\x85","operation":"submit_report"}'
+        )
+        assert hashlib.sha256(plan.payload_bytes).hexdigest() == (
+            "47114a619d4ffe921ae9e18222fa6055103e02d545e8913fe9e54771c948cc9a"
+        )
+
+    def test_exact_ascii_byte_cap_is_accepted(self) -> None:
+        plan = _plan("x" * MAX_REPORT_BODY_BYTES)
+        assert len(plan.body_bytes) == MAX_REPORT_BODY_BYTES
+
+    def test_exact_four_byte_code_point_cap_is_accepted(self) -> None:
+        plan = _plan("😀" * 12_800)
+        assert len(plan.body_bytes) == MAX_REPORT_BODY_BYTES
+
+    def test_whitespace_only_body_is_preserved(self) -> None:
+        plan = _plan(" \t\r\n")
+        assert plan.body == " \t\r\n"
+        assert plan.body_bytes == b" \t\r\n"
+
+
+class TestRejection:
+    @pytest.mark.parametrize(
+        "body, reason",
+        [
+            ("", "body is empty."),
+            ("body\x00", "body contains a NUL character."),
+            ("body\ud800", "body is not valid UTF-8-encodable text."),
+            (
+                "x" * (MAX_REPORT_BODY_BYTES + 1),
+                "body exceeds the 51200-byte report cap (got 51201 bytes).",
+            ),
+        ],
+    )
+    def test_exact_reason(self, body: str, reason: str) -> None:
+        with pytest.raises(PlanRejected) as excinfo:
+            _plan(body)
+        assert excinfo.value.reason == reason
+
+    def test_nul_precedes_utf8_encoding(self) -> None:
+        with pytest.raises(PlanRejected) as excinfo:
+            _plan("\x00\ud800")
+        assert excinfo.value.reason == "body contains a NUL character."
+
+    def test_utf8_encoding_precedes_byte_limit(self) -> None:
+        with pytest.raises(PlanRejected) as excinfo:
+            _plan("\ud800" + "x" * (MAX_REPORT_BODY_BYTES + 1))
+        assert excinfo.value.reason == "body is not valid UTF-8-encodable text."
+
+    def test_four_byte_code_point_over_cap_names_encoded_size(self) -> None:
+        with pytest.raises(PlanRejected) as excinfo:
+            _plan("😀" * 12_801)
+        assert excinfo.value.reason == (
+            "body exceeds the 51200-byte report cap (got 51204 bytes)."
+        )
+
+    def test_non_string_is_programming_error(self) -> None:
+        with pytest.raises(TypeError) as excinfo:
+            submit_report(b"body")  # type: ignore[arg-type]
+        assert not isinstance(excinfo.value, PlanRejected)
+
+
+class TestIdentity:
+    def test_equal_bodies_produce_equal_plan_identity(self) -> None:
+        first = _plan()
+        second = _plan()
+        assert first.body_bytes == second.body_bytes
+        assert first.body_digest == second.body_digest
+        assert first.payload_bytes == second.payload_bytes
+
+    @pytest.mark.parametrize(
+        "first, second",
+        [
+            ("body", "body\n"),
+            ("body ", "body"),
+            ("line\r\n", "line\n"),
+            ("Café", "Cafe\u0301"),
+        ],
+    )
+    def test_any_body_byte_change_changes_identity(self, first: str, second: str) -> None:
+        first_plan = _plan(first)
+        second_plan = _plan(second)
+        assert first_plan.body_bytes != second_plan.body_bytes
+        assert first_plan.body_digest != second_plan.body_digest
+        assert first_plan.payload_bytes != second_plan.payload_bytes
+
+    def test_payload_contains_only_operation_and_body(self) -> None:
+        plan = _plan()
+        assert json.loads(plan.payload_bytes) == {
+            "body": BODY,
+            "operation": "submit_report",
+        }
+        assert set(json.loads(plan.payload_bytes)) == {"body", "operation"}
+
+
+class TestDirectConstruction:
+    @pytest.mark.parametrize(
+        "field, replacement",
+        [
+            ("body_bytes", b"different"),
+            ("body_digest", "0" * 64),
+            ("payload_bytes", b"{}"),
+        ],
+    )
+    def test_rejects_divergent_derived_fact(self, field: str, replacement: object) -> None:
+        values = _plan().model_dump()
+        values[field] = replacement
+        with pytest.raises(ValidationError):
+            SubmitReportPlan(**values)
+
+    def test_rejects_non_submit_report_operation(self) -> None:
+        values = _plan().model_dump()
+        values["operation"] = "update_stack"
+        with pytest.raises(ValidationError):
+            SubmitReportPlan(**values)

--- a/packages/nauro-core/tests/operations/test_workflow_results.py
+++ b/packages/nauro-core/tests/operations/test_workflow_results.py
@@ -1,6 +1,7 @@
 """Kernel tests for the hosted typed-operation outcome models.
 
-The plan-returning operations (``update_stack``, ``share_context``) are
+The plan-returning operations (``update_stack``, ``share_context``,
+``submit_report``) are
 executed by the hosted server; these models are the cross-surface outcome
 contract it returns. Pinned here because the shapes ship in nauro-core.
 """
@@ -15,6 +16,7 @@ from nauro_core.operations.results import (
     SlugConflict,
     StackRevisionConflict,
     StateRevisionConflict,
+    SubmitReportAccepted,
     UpdateStackAccepted,
     WorkflowExpired,
     WorkflowInProgress,
@@ -41,6 +43,17 @@ def _share_context_accepted() -> ShareContextAccepted:
         content_digest=REVISION,
         receipt_id=ULID,
     )
+
+
+def _submit_report_accepted(**overrides: object) -> SubmitReportAccepted:
+    values: dict[str, object] = {
+        "report_id": ULID,
+        "event_id": ULID,
+        "body_digest": REVISION,
+        "receipt_id": ULID,
+    }
+    values.update(overrides)
+    return SubmitReportAccepted(**values)
 
 
 class TestUpdateStackAccepted:
@@ -155,6 +168,64 @@ class TestShareContextAccepted:
                 receipt_id=ULID,
                 unexpected_field="value",
             )
+
+
+class TestSubmitReportAccepted:
+    def test_exact_field_order_and_dump_shape(self) -> None:
+        assert list(SubmitReportAccepted.model_fields) == [
+            "status",
+            "report_id",
+            "event_id",
+            "body_digest",
+            "receipt_id",
+        ]
+        assert _submit_report_accepted().model_dump(mode="json") == {
+            "status": "accepted",
+            "report_id": ULID,
+            "event_id": ULID,
+            "body_digest": REVISION,
+            "receipt_id": ULID,
+        }
+
+    def test_model_is_strict_frozen_and_closed(self) -> None:
+        assert SubmitReportAccepted.model_config["strict"] is True
+        result = _submit_report_accepted()
+        with pytest.raises(ValidationError):
+            result.report_id = "01KQ6AZGNA0B3QBF67NBXP3S46"
+        with pytest.raises(ValidationError):
+            _submit_report_accepted(unexpected_field="value")
+        with pytest.raises(ValidationError):
+            _submit_report_accepted(body_digest=123)
+
+    def test_status_is_fixed(self) -> None:
+        with pytest.raises(ValidationError):
+            _submit_report_accepted(status="ok")
+
+    @pytest.mark.parametrize("field", ["report_id", "event_id", "receipt_id"])
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "",
+            "01KQ6AZGNA0B3QBF67NBXP3S4I",
+            "81KQ6AZGNA0B3QBF67NBXP3S45",
+            "01kq6azgna0b3qbf67nbxp3s45",
+        ],
+    )
+    def test_all_ids_must_be_ulids(self, field: str, value: str) -> None:
+        with pytest.raises(ValidationError):
+            _submit_report_accepted(**{field: value})
+
+    @pytest.mark.parametrize(
+        "body_digest",
+        ["ab" * 31, "ab" * 33, "AB" * 32, "ag" * 32],
+    )
+    def test_body_digest_must_be_lowercase_sha256(self, body_digest: str) -> None:
+        with pytest.raises(ValidationError):
+            _submit_report_accepted(body_digest=body_digest)
+
+    def test_original_report_id_equals_event_id(self) -> None:
+        with pytest.raises(ValidationError):
+            _submit_report_accepted(event_id="01KQ6AZGNA0B3QBF67NBXP3S46")
 
 
 class TestSlugConflict:


### PR DESCRIPTION
## Why

Hosted original report submission needs a deterministic core contract before the server owns idempotency, authorization, and storage. The core must preserve exact body bytes and keep all execution facts server-derived.

## What changed

- Add `submit_report(body)` with exact UTF-8 body preservation, pinned Tier-1 rejection reasons, and a 51,200-byte report limit.
- Add a frozen plan that validates its body bytes, SHA-256 digest, and canonical payload bytes on direct construction.
- Add `SubmitReportAccepted` with strict ULID, digest, and original report identity validation.
- Keep the contract in direct submodules with no exports, tools, consumers, routes, or storage work.
- Add exact contract, validation-order, byte-identity, boundary, and result-model tests.

## Test plan

- Focused operation and result tests: 67 passed.
- Full `nauro-core` suite: 1,859 passed.
- `nauro` regression suite excluding `cross_surface`: 2,663 passed.
- Ruff check and format check passed.
- Single-source, docstring-budget, and import-contract guards passed.
- The `nauro-core` wheel built successfully.
- Public and hosted-consumer contract snapshots remained unchanged.

## Risk / what to review

Review the pinned rejection order and text, exact-byte identity behavior, and direct-construction validation. No transport or storage code consumes this contract yet.

## Deferred

Server idempotency, authorization, storage, receipts, audit, routes, ToolSpec, CLI, UI, migration, release, and activation remain separate work.
