### PR TITLE
Defer the BM25 search stack to first search call

### DIFF
--- a/benchmarks/retrieval_bench.py
+++ b/benchmarks/retrieval_bench.py
@@ -61,7 +61,7 @@ from _stats import (
     wilson_lower,
 )
 from nauro_core.decision_model import Decision, DecisionStatus, parse_decision
-from nauro_core.operations.check_decision import _CHECK_DECISION_STOPWORDS
+from nauro_core.operations.check_decision import _check_decision_stopwords
 from nauro_core.parsing import first_sentence_end
 from nauro_core.search import union_retrieve
 
@@ -526,7 +526,7 @@ def run_conflict_catching(
                 candidates,
                 query,
                 top_k=len(candidates),
-                stopwords=_CHECK_DECISION_STOPWORDS,
+                stopwords=_check_decision_stopwords(),
                 use_embeddings=False,
             )
             rank = rank_of(t, ranked)
@@ -540,7 +540,7 @@ def run_conflict_catching(
                     candidates,
                     query,
                     top_k=TOP_K,
-                    stopwords=_CHECK_DECISION_STOPWORDS,
+                    stopwords=_check_decision_stopwords(),
                     use_embeddings=True,
                 )
                 bucket["union_pool_catch"] += t in [h["number"] for h in pool]
@@ -622,7 +622,7 @@ def run_artifact_regime(decisions: dict[int, Decision], events: list[dict]) -> d
             candidates,
             art["query"],
             top_k=len(candidates),
-            stopwords=_CHECK_DECISION_STOPWORDS,
+            stopwords=_check_decision_stopwords(),
             use_embeddings=False,
         )
         top_hit = ranked[0] if ranked else None
@@ -720,7 +720,7 @@ def _probe_g(active: list[Decision], by_num: dict[int, Decision], query: str) ->
         active,
         envelope,
         top_k=len(active),
-        stopwords=_CHECK_DECISION_STOPWORDS,
+        stopwords=_check_decision_stopwords(),
         use_embeddings=False,
     )
     top_hit = ranked[0] if ranked else None
@@ -812,7 +812,7 @@ def run_batteries(decisions: dict[int, Decision]) -> dict:
             active,
             production_envelope(proposal),
             top_k=TOP_K,
-            stopwords=_CHECK_DECISION_STOPWORDS,
+            stopwords=_check_decision_stopwords(),
             use_embeddings=False,
         )
         novel_top1.append(hits[0]["similarity"] if hits else 0.0)
@@ -823,7 +823,7 @@ def run_batteries(decisions: dict[int, Decision]) -> dict:
             active,
             production_envelope(query),
             top_k=TOP_K,
-            stopwords=_CHECK_DECISION_STOPWORDS,
+            stopwords=_check_decision_stopwords(),
             use_embeddings=False,
         )
         off_domain[query] = len(hits)

--- a/packages/nauro-core/src/nauro_core/__init__.py
+++ b/packages/nauro-core/src/nauro_core/__init__.py
@@ -319,9 +319,6 @@ from nauro_core.state import (
     prepare_state_update as prepare_state_update,
 )
 from nauro_core.validation import (
-    TIER2_STOPWORDS as TIER2_STOPWORDS,
-)
-from nauro_core.validation import (
     TIER2_TOP_K as TIER2_TOP_K,
 )
 from nauro_core.validation import (
@@ -412,3 +409,13 @@ __all__ = [
     "STATE_CURRENT_FILENAME",
     "STATE_HISTORY_FILENAME",
 ]
+
+
+def __getattr__(name: str) -> list[str]:
+    # TIER2_STOPWORDS resolves lazily: building it imports the bm25s/numpy
+    # stack, which package import must not pay.
+    if name == "TIER2_STOPWORDS":
+        from nauro_core.validation import TIER2_STOPWORDS
+
+        return TIER2_STOPWORDS
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/packages/nauro-core/src/nauro_core/operations/check_decision.py
+++ b/packages/nauro-core/src/nauro_core/operations/check_decision.py
@@ -10,7 +10,7 @@ shared by construction.
 
 from __future__ import annotations
 
-from bm25s.stopwords import STOPWORDS_EN
+from functools import lru_cache
 
 from nauro_core.constants import (
     LEXICAL_RANK_CAVEAT,
@@ -31,12 +31,19 @@ from nauro_core.parsing import _decision_label, extract_decision_number
 from nauro_core.search import union_retrieve
 from nauro_core.validation import check_content_length, is_scaffold_seed
 
+
 # Extended stopword list for ``check_decision`` retrieval. Mirrors the
 # tier-2 ``TIER2_STOPWORDS`` curation: bm25s's default English list omits
 # common action verbs that appear in almost every decision title, so adding
 # ``"use"`` collapses the false-positive matches that otherwise surface as
-# near-neighbours on every call.
-_CHECK_DECISION_STOPWORDS = [*list(STOPWORDS_EN), "use"]
+# near-neighbours on every call. Built lazily so importing the operations
+# package does not pull the bm25s/numpy stack; cached so every call shares
+# one list object.
+@lru_cache(maxsize=1)
+def _check_decision_stopwords() -> list[str]:
+    from bm25s.stopwords import STOPWORDS_EN
+
+    return [*STOPWORDS_EN, "use"]
 
 
 def check_decision(
@@ -74,7 +81,7 @@ def check_decision(
         decisions,
         query_text,
         top_k=5,
-        stopwords=_CHECK_DECISION_STOPWORDS,
+        stopwords=_check_decision_stopwords(),
         use_embeddings=use_embeddings,
     )
     if not hits:

--- a/packages/nauro-core/src/nauro_core/search.py
+++ b/packages/nauro-core/src/nauro_core/search.py
@@ -15,15 +15,21 @@ declined path's identity).
 
 from __future__ import annotations
 
+from functools import lru_cache
 from typing import TypedDict
-
-import bm25s
-import Stemmer
 
 from nauro_core.decision_model import Decision, DecisionStatus
 from nauro_core.parsing import _first_sentence_snippet, extract_relevance_snippet
 
-_stemmer = Stemmer.Stemmer("english")
+
+# bm25s and Stemmer (and numpy underneath) are imported on first search call,
+# never at module import: the package init pulls this module into every
+# consumer, and idle MCP server processes must not pay the BM25 stack.
+@lru_cache(maxsize=1)
+def _stemmer():
+    import Stemmer
+
+    return Stemmer.Stemmer("english")
 
 
 # Two distinct result shapes, deliberately not unified. Module-private (not in
@@ -70,10 +76,12 @@ def bm25_search(
     if not decisions or not query or not query.strip():
         return []
 
+    import bm25s
+
     corpus = [_index_text(d) for d in decisions]
     # show_progress=False — bm25s defaults to True; the tqdm output is invisible
     # in MCP server stderr but pollutes the `nauro check-decision` CLI surface.
-    corpus_tokens = bm25s.tokenize(corpus, stopwords="en", stemmer=_stemmer, show_progress=False)
+    corpus_tokens = bm25s.tokenize(corpus, stopwords="en", stemmer=_stemmer(), show_progress=False)
 
     retriever = bm25s.BM25()
     retriever.index(corpus_tokens, show_progress=False)
@@ -83,7 +91,7 @@ def bm25_search(
     k = max(0, min(limit, len(decisions)))
     if k == 0:
         return []
-    query_tokens = bm25s.tokenize([query], stopwords="en", stemmer=_stemmer, show_progress=False)
+    query_tokens = bm25s.tokenize([query], stopwords="en", stemmer=_stemmer(), show_progress=False)
     results, scores = retriever.retrieve(query_tokens, k=k, show_progress=False)
 
     query_words = query.strip().split()
@@ -127,9 +135,11 @@ def bm25_retrieve(
     if not active or not query_text or not query_text.strip():
         return []
 
+    import bm25s
+
     corpus = [_index_text(d) for d in active]
     corpus_tokens = bm25s.tokenize(
-        corpus, stopwords=stopwords, stemmer=_stemmer, show_progress=False
+        corpus, stopwords=stopwords, stemmer=_stemmer(), show_progress=False
     )
 
     retriever = bm25s.BM25()
@@ -137,7 +147,7 @@ def bm25_retrieve(
 
     k = min(top_k, len(active))
     query_tokens = bm25s.tokenize(
-        [query_text], stopwords=stopwords, stemmer=_stemmer, show_progress=False
+        [query_text], stopwords=stopwords, stemmer=_stemmer(), show_progress=False
     )
     results, scores = retriever.retrieve(query_tokens, k=k, show_progress=False)
 

--- a/packages/nauro-core/src/nauro_core/validation.py
+++ b/packages/nauro-core/src/nauro_core/validation.py
@@ -8,8 +8,7 @@ in by callers.
 from __future__ import annotations
 
 import hashlib
-
-from bm25s.stopwords import STOPWORDS_EN
+from functools import lru_cache
 
 from nauro_core.constants import (
     MIN_RATIONALE_LENGTH,
@@ -28,6 +27,7 @@ from nauro_core.search import Bm25Hit, bm25_retrieve
 # validation outcome on either.
 TIER2_TOP_K = 5
 
+
 # bm25s's default English stopword list is minimal (~30 tokens: a, an, and,
 # are, as, at, be, but, by, for, if, in, into, is, it, no, not, of, on, or,
 # ...). It omits common action verbs that appear in virtually every Nauro
@@ -41,7 +41,22 @@ TIER2_TOP_K = 5
 # positives are added, not a speculative blanket of generic verbs. Add
 # more only when a concrete failure case justifies it, and add a test to
 # lock the case in.
-TIER2_STOPWORDS = [*list(STOPWORDS_EN), "use"]
+#
+# Built lazily (module __getattr__ below) so importing the package does not
+# pull the bm25s/numpy stack; idle MCP server processes never search. Cached
+# so every access shares one list object, matching the old module constant.
+@lru_cache(maxsize=1)
+def _tier2_stopwords() -> list[str]:
+    from bm25s.stopwords import STOPWORDS_EN
+
+    return [*STOPWORDS_EN, "use"]
+
+
+def __getattr__(name: str) -> list[str]:
+    if name == "TIER2_STOPWORDS":
+        return _tier2_stopwords()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 # The scaffold-seeded "Initial project setup" decision is Nauro's own
 # bookkeeping — it records that the store was initialized, not a choice the
@@ -104,7 +119,7 @@ def check_bm25_similarity(
         candidates,
         proposal_text,
         top_k=top_k,
-        stopwords=stopwords if stopwords is not None else TIER2_STOPWORDS,
+        stopwords=stopwords if stopwords is not None else _tier2_stopwords(),
     )
     if not related:
         return ("auto_confirm", [])

--- a/packages/nauro-core/tests/test_lazy_imports.py
+++ b/packages/nauro-core/tests/test_lazy_imports.py
@@ -1,0 +1,49 @@
+"""Importing nauro_core must not pull the BM25 search stack.
+
+bm25s, Stemmer, and numpy load on the first search call only; a consumer
+that never searches never pays their import.
+"""
+
+import json
+import subprocess
+import sys
+
+from conftest import make_decision
+
+_SEARCH_STACK = ("bm25s", "Stemmer", "numpy")
+
+
+def test_package_import_defers_search_stack():
+    probe = (
+        "import json, sys\n"
+        "import nauro_core\n"
+        "import nauro_core.constants\n"
+        "import nauro_core.operations\n"
+        "import nauro_core.search\n"
+        "import nauro_core.validation\n"
+        f"print(json.dumps({{m: m in sys.modules for m in {_SEARCH_STACK!r}}}))\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", probe], capture_output=True, text=True, check=True
+    )
+    assert json.loads(result.stdout) == {m: False for m in _SEARCH_STACK}
+
+
+def test_first_search_call_loads_stack_and_ranks():
+    from nauro_core.search import bm25_search
+
+    decisions = [
+        make_decision(1, "Use Auth0 for authentication", "Auth0 handles JWT validation."),
+        make_decision(2, "Chose Memcached for session state", "Simpler than Redis here."),
+    ]
+    results = bm25_search(decisions, "Auth0 JWT")
+    assert [r["number"] for r in results] == [1]
+    assert all(m in sys.modules for m in _SEARCH_STACK)
+
+
+def test_tier2_stopwords_resolves_lazily_from_both_surfaces():
+    import nauro_core
+    import nauro_core.validation
+
+    assert "use" in nauro_core.TIER2_STOPWORDS
+    assert nauro_core.validation.TIER2_STOPWORDS == nauro_core.TIER2_STOPWORDS

--- a/packages/nauro/tests/test_retrieval_bench_smoke.py
+++ b/packages/nauro/tests/test_retrieval_bench_smoke.py
@@ -152,7 +152,7 @@ def test_fire_predicate_schema_valid() -> None:
         candidates,
         sample["query"],
         top_k=len(candidates),
-        stopwords=bench._CHECK_DECISION_STOPWORDS,
+        stopwords=bench._check_decision_stopwords(),
         use_embeddings=False,
     )
     top_hit = ranked[0] if ranked else None


### PR DESCRIPTION
## What this changes

- Importing any nauro_core module loaded bm25s, PyStemmer, and numpy through the package init. Idle MCP server processes and each CLI start paid this cost.
- The search functions and the stopword-list builders now import bm25s inside the function, at first use. The public TIER2_STOPWORDS name resolves through a module __getattr__ on both surfaces. The list content does not change.
- The stopword-list builders are cached, so every access shares one list object, the same identity behavior the old module constants had.
- The retrieval benchmark and its smoke test call the new stopword function.

## Measured effect

- The stdio server import drops from 76 MB to 65 MB of resident memory, and the package import is about 95 ms faster.
- The first search call in a process pays a one-time 135 ms for the deferred imports. Later calls are unchanged.

## Tests

- A subprocess test asserts that a package import does not load bm25s, PyStemmer, or numpy.
- Tests assert that search results and the stopword list are unchanged, and the hosted-consumer contract test passes.
- Both package suites pass. Ruff check and format are clean.
