### PR TITLE
Release nauro 1.15.0 and nauro-core 1.14.0

### DIFF
--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro-core"
-version = "1.13.0"
+version = "1.14.0"
 description = "Shared pure-Python logic for Nauro: parsing, validation, context assembly, constants."
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro"
-version = "1.14.1"
+version = "1.15.0"
 description = "Human-approved project judgment and current state for connected AI agents, surfaced before work."
 readme = "README.md"
 license = "Apache-2.0"
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "nauro-core>=1.12.0,<2",
+    "nauro-core>=1.14.0,<2",
     "typer>=0.9",
     "httpx>=0.24",
     "mcp>=1.0,<2",

--- a/server.json
+++ b/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Nauro-AI/nauro",
     "source": "github"
   },
-  "version": "1.14.1",
+  "version": "1.15.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "nauro",
-      "version": "1.14.1",
+      "version": "1.15.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -945,7 +945,7 @@ wheels = [
 
 [[package]]
 name = "nauro"
-version = "1.14.1"
+version = "1.15.0"
 source = { editable = "packages/nauro" }
 dependencies = [
     { name = "filelock" },
@@ -989,7 +989,7 @@ provides-extras = ["dev", "embeddings"]
 
 [[package]]
 name = "nauro-core"
-version = "1.13.0"
+version = "1.14.0"
 source = { editable = "packages/nauro-core" }
 dependencies = [
     { name = "bm25s" },


### PR DESCRIPTION
## Version moves

- nauro: 1.14.1 -> 1.15.0
- nauro-core: 1.13.0 -> 1.14.0
- nauro now requires nauro-core >= 1.14.0, < 2
- server.json follows the nauro version

## What ships

**nauro** (26 PRs since 1.14.1): snapshot retention now uses the age ladder alone with a validated scan and the v1000 rollover fix; the L0 context payload reports omitted open questions; decisions order numerically past 999; store files write atomically; auth domain logic lives in one module; the store home path resolves in one module; docstrings cut to the prose budget; deterministic judgment-commit preparation and approval provenance.

**nauro-core** (6 PRs since 1.13.0): report-submission planning operation; deterministic update_state planning; question-resolution seam; hosted question provenance import guards; the BM25 search stack defers to the first search call.

## Checks

- check_server_json_version, check_single_sourced, uv lock --check, and both locked syncs pass locally.

## After merge

- Tag the squash commit as nauro-v1.15.0 and nauro-core-v1.14.0; the tags trigger the trusted-publish workflows.
