### PR TITLE
Collect two overdue compat shims

### DIFF
--- a/packages/nauro-core/src/nauro_core/operations/flag_question.py
+++ b/packages/nauro-core/src/nauro_core/operations/flag_question.py
@@ -39,10 +39,6 @@ from nauro_core.questions import (
     parse_question_id,
 )
 
-# Private alias kept for one release: a deployed consumer still imports this
-# name. New code reads OPEN_QUESTIONS_DEFAULT_BODY from nauro_core directly.
-_DEFAULT_FILE_BODY = OPEN_QUESTIONS_DEFAULT_BODY
-
 
 def flag_question(
     store: Store,
@@ -103,7 +99,7 @@ def flag_question(
         )
 
     assert question is not None  # narrowed by has_question above.
-    content = store.read_file(OPEN_QUESTIONS_MD) or _DEFAULT_FILE_BODY
+    content = store.read_file(OPEN_QUESTIONS_MD) or OPEN_QUESTIONS_DEFAULT_BODY
     parsed = OpenQuestionsFile.parse(content)
 
     if canonical_targets:
@@ -193,7 +189,7 @@ def _resolve(
         for stem in stems
         if (body := bodies.get(stem)) is not None
     )
-    content = store.read_file(OPEN_QUESTIONS_MD) or _DEFAULT_FILE_BODY
+    content = store.read_file(OPEN_QUESTIONS_MD) or OPEN_QUESTIONS_DEFAULT_BODY
     outcome = resolve_question_document(
         open_questions_bytes=content.encode("utf-8"),
         decision_documents=documents,

--- a/packages/nauro-core/src/nauro_core/protocol.py
+++ b/packages/nauro-core/src/nauro_core/protocol.py
@@ -54,10 +54,6 @@ APPROVAL_BEFORE_PROPOSE = (
     "validation."
 )
 
-# Compat alias for consumers pinned to pre-1.6.0 nauro-core; excluded from
-# __all__. Remove once every in-repo import moves to the public name.
-_APPROVAL_BEFORE_PROPOSE = APPROVAL_BEFORE_PROPOSE
-
 _PROPOSAL_VISIBILITY_DETAIL = (
     "Never pair the draft with an approval prompt (AskUserQuestion) in the "
     "same turn - text before a tool call may never render. Prompt only once "

--- a/packages/nauro-core/tests/test_constants.py
+++ b/packages/nauro-core/tests/test_constants.py
@@ -106,12 +106,6 @@ class TestOpenQuestionsDefaultBody:
         assert nauro_core.OPEN_QUESTIONS_DEFAULT_BODY == OPEN_QUESTIONS_DEFAULT_BODY
         assert "OPEN_QUESTIONS_DEFAULT_BODY" in nauro_core.__all__
 
-    def test_kernel_private_alias_still_resolves(self):
-        # Retained for one release: a deployed consumer imports the private name.
-        from nauro_core.operations.flag_question import _DEFAULT_FILE_BODY
-
-        assert _DEFAULT_FILE_BODY == OPEN_QUESTIONS_DEFAULT_BODY
-
 
 class TestValidValues:
     def test_valid_confidences_non_empty(self):

--- a/packages/nauro-core/tests/test_protocol.py
+++ b/packages/nauro-core/tests/test_protocol.py
@@ -54,16 +54,12 @@ class TestFragmentAnchors:
         assert "stay internal" in _PROPOSAL_VISIBILITY_DETAIL
         assert "raw JSON only" in _PROPOSAL_VISIBILITY_DETAIL
 
-    def test_approval_fragment_public_name_and_compat_alias(self) -> None:
-        """The approval fragment is public API (re-exported for downstream
-        composition); the underscore name survives only as a compat alias
-        for consumers pinned to pre-1.6.0 nauro-core."""
+    def test_approval_fragment_is_public_api(self) -> None:
+        """The approval fragment is public API, re-exported for downstream composition."""
         import nauro_core
 
         assert "APPROVAL_BEFORE_PROPOSE" in protocol.__all__
         assert "APPROVAL_BEFORE_PROPOSE" in nauro_core.__all__
-        assert "_APPROVAL_BEFORE_PROPOSE" not in protocol.__all__
-        assert protocol._APPROVAL_BEFORE_PROPOSE is protocol.APPROVAL_BEFORE_PROPOSE
         assert nauro_core.APPROVAL_BEFORE_PROPOSE is protocol.APPROVAL_BEFORE_PROPOSE
         # Neither approval fragment is a markdown-substitution token.
         assert "APPROVAL_BEFORE_PROPOSE" not in CANONICAL_FRAGMENTS

--- a/packages/nauro/tests/test_agents_md.py
+++ b/packages/nauro/tests/test_agents_md.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 from nauro_core.constants import MCP_INSTRUCTIONS_STATIC
-from nauro_core.protocol import _APPROVAL_BEFORE_PROPOSE
+from nauro_core.protocol import APPROVAL_BEFORE_PROPOSE
 from typer.testing import CliRunner
 
 from nauro.cli.main import app
@@ -49,10 +49,10 @@ def test_generate_includes_behavioral_instructions():
     # session can still reach `nauro propose-decision` (single-call commit)
     # via shell.
     anchored_boundary = (
-        f"Before `propose_decision` (or `nauro propose-decision`): {_APPROVAL_BEFORE_PROPOSE}"
+        f"Before `propose_decision` (or `nauro propose-decision`): {APPROVAL_BEFORE_PROPOSE}"
     )
     assert result.count(anchored_boundary) == 1
-    assert result.count(_APPROVAL_BEFORE_PROPOSE) == 1
+    assert result.count(APPROVAL_BEFORE_PROPOSE) == 1
     assert "advisory conflict checks" not in result
 
 


### PR DESCRIPTION
## Why

2 private compat aliases outlived their windows. `_APPROVAL_BEFORE_PROPOSE` in `nauro_core/protocol.py` existed for consumers pinned to pre-1.6.0 nauro-core. Every consumer floor is now at 1.13.0 or higher. Its only remaining importer was 1 in-repo test. `_DEFAULT_FILE_BODY` in `nauro_core/operations/flag_question.py` was kept for 1 release for a deployed consumer. That consumer no longer imports it in production code. Only its test suite does, and a companion change there removes that import.

## What changed

- Deleted the `_APPROVAL_BEFORE_PROPOSE` alias. `packages/nauro/tests/test_agents_md.py` imports the public `APPROVAL_BEFORE_PROPOSE` instead.
- Deleted the `_DEFAULT_FILE_BODY` alias. The 2 internal reads in `flag_question.py` use the public `OPEN_QUESTIONS_DEFAULT_BODY` directly.
- Retired the 2 tests that pinned the aliases while they lived, and kept the public-API assertions they carried.

Neither name is in `nauro_core.__all__`, the public contract snapshot, or the hosted-consumer manifest.

## Test plan

- nauro-core: 1861 passed.
- nauro: 2667 passed, 10 skipped.
- `ruff check` and `ruff format --check`: clean.
- Docstring budget guard: 142 baselined, 0 new, 0 stale.
- `grep -rn '_DEFAULT_FILE_BODY\|_APPROVAL_BEFORE_PROPOSE' packages/` returns nothing.

## Risk

Low. Both names were private, excluded from every contract surface, and unused by production code anywhere. The hosted server's test suite imports `_DEFAULT_FILE_BODY`; that repo pins nauro-core by git rev, so its CI sees this removal only at its next rev bump, and the companion test change lands before that.

## Deferred

Nothing.
