### PR TITLE
Remove four unreferenced internal symbols

### DIFF
--- a/packages/nauro-core/src/nauro_core/constants.py
+++ b/packages/nauro-core/src/nauro_core/constants.py
@@ -141,7 +141,6 @@ POINTER_FLAG_PREFIXES: tuple[str, ...] = tuple(POINTER_PREFIX_BY_KIND.values())
 # A brief slug is 1 to 120 lowercase ASCII letters, digits, and internal
 # hyphens; it maps only to context/<slug>.md. The shape itself lives in
 # nauro_core.identifiers as the brief_slug kind.
-BRIEF_SLUG_MIN_LENGTH = 1
 BRIEF_SLUG_MAX_LENGTH = 120
 
 # ── Stack empty marker ──

--- a/packages/nauro-core/src/nauro_core/operations/_in_memory_store.py
+++ b/packages/nauro-core/src/nauro_core/operations/_in_memory_store.py
@@ -27,20 +27,20 @@ class InMemoryStore:
         self._files: dict[str, str] = dict(files or {})
 
     def read_file(self, path: str) -> str | None:
-        stem = _decision_stem(path)
+        stem = _stem_from_decision_path(path)
         if stem is not None and stem in self._decisions:
             return self._decisions[stem]
         return self._files.get(path)
 
     def write_file(self, path: str, content: str) -> None:
-        stem = _decision_stem(path)
+        stem = _stem_from_decision_path(path)
         if stem is not None:
             self._decisions[stem] = content
             return
         self._files[path] = content
 
     def delete_file(self, path: str) -> None:
-        stem = _decision_stem(path)
+        stem = _stem_from_decision_path(path)
         if stem is not None:
             self._decisions.pop(stem, None)
             return
@@ -57,8 +57,3 @@ class InMemoryStore:
         # self._decisions directly: subclasses that instrument read_decision
         # (e.g. the scan-counting double) must see one call per stem.
         return {stem: self.read_decision(stem) for stem in stems}
-
-
-def _decision_stem(path: str) -> str | None:
-    """Return the decision file stem when ``path`` targets ``decisions/*.md``."""
-    return _stem_from_decision_path(path)

--- a/packages/nauro-core/src/nauro_core/operations/flag_question.py
+++ b/packages/nauro-core/src/nauro_core/operations/flag_question.py
@@ -29,14 +29,12 @@ from nauro_core.question_append import (
 )
 from nauro_core.question_resolution import (
     ResolutionDecisionDocument,
+    _canonical_question_targets,
     resolve_question_document,
 )
 from nauro_core.questions import (
     EntryBlock,
-    InvalidQuestionIdentifier,
     OpenQuestionsFile,
-    format_question_id,
-    parse_question_id,
 )
 
 
@@ -112,18 +110,6 @@ def flag_question(
     store.write_file(OPEN_QUESTIONS_MD, insert_question_entry(content, entry))
 
     return FlagQuestionResult(status="ok", num=next_num)
-
-
-def _canonical_question_targets(targets: list[str]) -> list[str]:
-    canonical: list[str] = []
-    for target in targets:
-        try:
-            number = parse_question_id(target)
-        except InvalidQuestionIdentifier:
-            canonical.append(target)
-        else:
-            canonical.append(format_question_id(number))
-    return canonical
 
 
 def _short_circuit_if_resolved(

--- a/packages/nauro-core/tests/test_parsing.py
+++ b/packages/nauro-core/tests/test_parsing.py
@@ -332,7 +332,8 @@ class TestDecisionFilenameFormatters:
 
 
 def _old_decision_stem(path: str) -> str | None:
-    """Reference copy of the former ``_in_memory_store._decision_stem`` logic."""
+    """Reference copy of the original decision-stem logic, pinned against
+    ``_stem_from_decision_path`` by :class:`TestStemFromDecisionPath`."""
     prefix = f"{DECISIONS_DIR}/"
     if not path.startswith(prefix):
         return None

--- a/packages/nauro/src/nauro/store/post_commit.py
+++ b/packages/nauro/src/nauro/store/post_commit.py
@@ -68,10 +68,6 @@ class PostCommitOutcome(BaseModel):
     updated_repos: tuple[Path, ...] = ()
 
     @property
-    def is_degraded(self) -> bool:
-        return bool(self.degraded)
-
-    @property
     def warnings(self) -> tuple[str, ...]:
         """One line per degraded step, in the order the steps ran."""
         return tuple(item.warning for item in self.degraded)

--- a/packages/nauro/tests/test_post_commit.py
+++ b/packages/nauro/tests/test_post_commit.py
@@ -44,7 +44,6 @@ def test_clean_run_reports_no_degradation_and_the_regenerated_repos(tmp_path: Pa
         regenerate_agents_md=True,
     )
 
-    assert outcome.is_degraded is False
     assert outcome.degraded == ()
     assert outcome.warnings == ()
     assert outcome.updated_repos == (repo,)
@@ -156,7 +155,7 @@ def test_warn_channel_is_threaded_into_the_regeneration(tmp_path: Path) -> None:
 
     outcome = run_post_commit(store_path, regenerate_agents_md=True, warn=warnings.append)
 
-    assert outcome.is_degraded is False
+    assert outcome.degraded == ()
     assert any("repo path does not exist" in line for line in warnings)
 
 


### PR DESCRIPTION
## Why

Four internal symbols had zero references outside their definitions and only added indirection: an unused constant, a pass-through wrapper, a byte-for-byte duplicated helper, and a property restating a boolean cast. No observable surface is touched.

## What changed

- `constants.py`: removed `BRIEF_SLUG_MIN_LENGTH` (the slug shape lives in `nauro_core.identifiers`).
- `_in_memory_store.py`: removed the `_decision_stem` wrapper; call sites use `_stem_from_decision_path` directly, and the reference-copy docstring in `test_parsing.py` no longer names the removed wrapper.
- `flag_question.py`: removed the local duplicate of `_canonical_question_targets` in favor of the canonical copy in `question_resolution`, plus the imports that only served it.
- `post_commit.py`: removed `PostCommitOutcome.is_degraded`; the two test assertions check the `degraded` field directly.

## Test plan

Both suites green: nauro-core 1861 passed, nauro 2667 passed / 10 skipped. `ruff check` and `ruff format --check` clean.
