### PR TITLE
Trim nauro-core tail and two nauro docstrings to the code prose budget

### DIFF
--- a/packages/nauro-core/src/nauro_core/operations/planning.py
+++ b/packages/nauro-core/src/nauro_core/operations/planning.py
@@ -1,19 +1,18 @@
 """Shared plumbing for plan-returning kernel operations.
 
-A second operation convention lives beside the Store-writing operations in
-this package. Store-writing operations (``flag_question``, ``update_state``,
-…) execute their own reads and writes through the ``Store`` protocol.
-Plan-returning operations (``update_stack``, ``share_context``) write
-nothing: the kernel validates the submitted payload, deterministically
-derives every artifact path, digest, and precondition, and returns a frozen
-plan model; the hosted server owns observation, claims, and storage
-execution. The kernel's only concurrency vocabulary is content digests and
-the absent token — storage-layer tokens such as S3 ETags never enter the
-kernel.
+Two operation conventions live in this package. Store-writing operations
+execute their own reads and writes through the ``Store`` protocol.
+Plan-returning operations (``update_stack``, ``share_context``,
+``submit_report``, and the hosted plan path of ``update_state``, which
+stays Store-writing locally) write nothing: the kernel validates the
+payload, deterministically derives every artifact path, digest, and
+precondition, and returns a frozen plan; the hosted server owns
+observation, claims, and storage execution. The kernel's concurrency
+vocabulary is content digests and the absent token, never storage-layer
+tokens such as S3 ETags.
 
-This module carries the pieces both plan-returning operations share: the
-typed Tier-1 rejection and the canonical payload-byte encoding that
-single-sources the idempotency digest input.
+This module carries the shared typed Tier-1 rejection and the canonical
+payload-byte encoding that single-sources the idempotency digest input.
 """
 
 from __future__ import annotations

--- a/packages/nauro-core/src/nauro_core/operations/propose_decision.py
+++ b/packages/nauro-core/src/nauro_core/operations/propose_decision.py
@@ -74,13 +74,11 @@ from nauro_core.validation import (
 
 @dataclass(frozen=True)
 class _QuestionResolveOutcome:
-    """Result of stamping (and self-healing) ``resolves_questions`` entries.
-
-    ``resolved_ids`` are the ids whose ``resolved_by`` ended set;
-    ``relocated_ids`` / ``skipped_prose_ids`` come from the post-stamp
-    ``normalize`` step and feed the propose result's observability fields.
-    Internal to the propose write path — carried in the execute tuple so the
-    error branches (which never relocate) can return an empty instance.
+    """Outcome of stamping ``resolves_questions`` entries. ``resolved_ids`` are the
+    requested ids whose ``resolved_by`` ended set, already-resolved targets included;
+    ``relocated_ids`` and ``skipped_prose_ids`` come from the post-stamp ``normalize``
+    step and feed the propose result's observability fields. Error branches return
+    an empty instance.
     """
 
     resolved_ids: tuple[str, ...] = ()
@@ -181,12 +179,9 @@ def propose_decision(
 
 
 def _write_decision_direct(store: Store, proposal: dict) -> str:
-    """Write a proposal as a new decision and return the resulting decision id.
-
-    Private helper shared by the validated ``propose_decision`` write path
-    and CLI write paths (``nauro note``) that bypass the validation
-    pipeline. Updates the in-store hash index after a successful write so
-    subsequent Tier 1 checks catch exact duplicates.
+    """Write *proposal* as a new decision and return its file stem. Shared by the
+    validated pipeline and the CLI bypass writers (``nauro note``, ``nauro import``);
+    updates the hash index so later Tier 1 checks catch exact duplicates.
     """
     next_num = _next_decision_num(store)
     title = proposal.get("title", "Untitled")
@@ -262,16 +257,9 @@ def _execute_operation(
     proposal: dict,
     affected_decision_id: str | None,
 ) -> tuple[str | None, str, tuple[str, ...], _QuestionResolveOutcome, ErrorPayload | None]:
-    """Execute the validated operation against the store.
-
-    Returns:
-        ``(decision_id, actual_operation, touched, resolve_outcome, error)``.
-        ``touched`` enumerates the decision file stems the kernel rewrote —
-        used by the adapter to drive AGENTS.md regen. ``resolve_outcome``
-        carries the resolved / relocated / prose-skipped question ids from the
-        ``resolves_questions`` ingestion (empty on the error branches, which
-        never relocate). On the supersede half-state path ``decision_id`` is
-        the newly-written decision and ``error`` names the un-flipped old id.
+    """Return ``(decision_id, actual_operation, touched, resolve_outcome, error)``.
+    ``touched`` lists every rewritten decision stem (drives adapter AGENTS.md regen);
+    half-state errors leave completed writes standing with ``resolve_outcome`` empty.
     """
     if operation == "supersede" and affected_decision_id:
         return _do_supersede(store, proposal, affected_decision_id)

--- a/packages/nauro-core/src/nauro_core/operations/results.py
+++ b/packages/nauro-core/src/nauro_core/operations/results.py
@@ -23,17 +23,10 @@ from nauro_core.identifiers import IdentifierKind, validate_identifier
 
 
 class RelatedDecision(BaseModel):
-    """A decision surfaced by retrieval as related to a proposed approach.
-
-    The canonical retrieval-hit shape: enriched with the triage-header
-    fields (status, date, type, confidence, supersession refs) and a
-    rationale lede so any transport can render the same hit without
-    re-fetching the underlying decision body.
-
-    ``decision_type``, ``confidence``, ``supersedes``, and
-    ``superseded_by`` stay optional so hits whose decision omits those
-    frontmatter fields still serialize; the adapter's ``exclude_none=True``
-    template choice drops the keys when they are unset (the
+    """The canonical retrieval-hit shape: triage-header fields plus a rationale
+    lede, sparing a re-fetch of the decision body at render time. Optional
+    fields stay ``None``-able so hits missing frontmatter still serialize;
+    adapters' ``exclude_none=True`` drops unset keys (the
     :class:`DecisionSummary`/:class:`SearchHit` key-omission contract).
     """
 
@@ -54,10 +47,9 @@ class RelatedDecision(BaseModel):
 class ErrorPayload(BaseModel):
     """Structured error envelope returned on rejection or operation failure.
 
-    ``kind`` discriminates between caller-fixable rejections (input over
-    length, malformed argument) and operation-side failures. ``guidance``
-    carries an onboarding string when the rejection has a remedial action
-    the caller can take.
+    ``kind`` discriminates caller-fixable rejections (input over length,
+    malformed argument) from operation-side failures; ``guidance`` carries
+    remedial onboarding text when one exists.
     """
 
     model_config = ConfigDict(frozen=True, extra="forbid")
@@ -69,15 +61,10 @@ class ErrorPayload(BaseModel):
 
 class CheckDecisionResult(BaseModel):
     """Return shape for :func:`nauro_core.operations.check_decision`.
-
-    ``assessment`` is declared first so the takeaway leads the serialized
-    payload (Pydantic ``model_dump`` preserves declaration order), matching
-    the rendered block's takeaway-first order. On the success path it carries
-    the deterministic human-readable summary and ``related_decisions``
-    contains zero or more :class:`RelatedDecision` hits. On the rejection
-    path ``error`` is populated; ``assessment`` stays empty and
-    ``related_decisions`` stays empty. ``store`` is not part of the model;
-    transport adapters add it back at serialization time.
+    ``assessment`` is declared first so the takeaway leads the serialized payload
+    (``model_dump`` preserves declaration order). Success populates ``assessment``
+    and zero or more ``related_decisions``; rejection populates ``error`` and leaves
+    both empty; ``store`` is adapter-added at serialization time.
     """
 
     model_config = ConfigDict(frozen=True, extra="forbid")

--- a/packages/nauro-core/src/nauro_core/question_append.py
+++ b/packages/nauro-core/src/nauro_core/question_append.py
@@ -27,11 +27,9 @@ def compose_question_entry(num: int, body: str) -> str:
 
 
 def insert_question_entry(content: str, entry: str) -> str:
-    """Return *content* with *entry* inserted directly after the H1 header.
-
-    Skips blank lines and leading HTML comments below the first top-level
-    ``# `` header so the on-disk format stays byte-identical across
-    surfaces; a file without a header inserts at line two.
+    """Return *content* with *entry* inserted after the first ``# `` header,
+    skipping blank lines and leading HTML comments below it; a header-less
+    file applies the same skip from line two.
     """
     lines = content.split("\n")
     insert_idx = 1

--- a/packages/nauro/src/nauro/cli/commands/status.py
+++ b/packages/nauro/src/nauro/cli/commands/status.py
@@ -48,12 +48,9 @@ def _format_time_ago(iso_timestamp: str) -> str:
 
 
 def _count_remote_decisions(project_id: str) -> int | None:
-    """Count decisions in the remote store via the manifest endpoint.
-
-    Returns None when the manifest fetch fails. Callers must gate on
-    auth + cloud-mode before invoking this — the function does not
-    re-check, and a failed call against the wrong endpoint is the
-    caller's bug.
+    """Count remote manifest entries whose path starts with ``decisions/`` and
+    ends with ``.md``; ``None`` on any fetch failure. Callers must gate on auth
+    and cloud-mode first; this function does not re-check.
     """
     try:
         from nauro.sync.remote import PresignError, fetch_manifest

--- a/packages/nauro/src/nauro/mcp/stdio_server.py
+++ b/packages/nauro/src/nauro/mcp/stdio_server.py
@@ -124,14 +124,9 @@ _resolve_store = resolve_store
 
 
 def _resolve_or_error(project_id, cwd) -> tuple[Path | None, dict | None]:
-    """Resolve a store path, or translate a resolution failure to an error dict.
-
-    Every tool wrapper shares this preamble: on success it returns
-    ``(store_path, None)``; on failure it returns ``(None, error_dict)`` where
-    the dict carries the transport-appropriate guidance — the welcome screen for
-    the genuine no-project case, the specific diagnostic otherwise. Each wrapper
-    routes the dict to its own output shape (renderer envelope, dict, or the
-    guidance string).
+    """Return ``(store_path, None)``, translating only ``StoreResolutionError``
+    and its subclasses to ``(None, error_dict)``: the no-project welcome screen,
+    the disconnected diagnostic with recovery fields, or the resolution error text.
     """
     try:
         return _resolve_store(project_id, cwd), None

--- a/packages/nauro/tests/snapshots/check_decision_schema.json
+++ b/packages/nauro/tests/snapshots/check_decision_schema.json
@@ -3,7 +3,7 @@
     "$defs": {
       "ErrorPayload": {
         "additionalProperties": false,
-        "description": "Structured error envelope returned on rejection or operation failure.\n\n``kind`` discriminates between caller-fixable rejections (input over\nlength, malformed argument) and operation-side failures. ``guidance``\ncarries an onboarding string when the rejection has a remedial action\nthe caller can take.",
+        "description": "Structured error envelope returned on rejection or operation failure.\n\n``kind`` discriminates caller-fixable rejections (input over length,\nmalformed argument) from operation-side failures; ``guidance`` carries\nremedial onboarding text when one exists.",
         "properties": {
           "guidance": {
             "anyOf": [
@@ -39,7 +39,7 @@
       },
       "RelatedDecision": {
         "additionalProperties": false,
-        "description": "A decision surfaced by retrieval as related to a proposed approach.\n\nThe canonical retrieval-hit shape: enriched with the triage-header\nfields (status, date, type, confidence, supersession refs) and a\nrationale lede so any transport can render the same hit without\nre-fetching the underlying decision body.\n\n``decision_type``, ``confidence``, ``supersedes``, and\n``superseded_by`` stay optional so hits whose decision omits those\nfrontmatter fields still serialize; the adapter's ``exclude_none=True``\ntemplate choice drops the keys when they are unset (the\n:class:`DecisionSummary`/:class:`SearchHit` key-omission contract).",
+        "description": "The canonical retrieval-hit shape: triage-header fields plus a rationale\nlede, sparing a re-fetch of the decision body at render time. Optional\nfields stay ``None``-able so hits missing frontmatter still serialize;\nadapters' ``exclude_none=True`` drops unset keys (the\n:class:`DecisionSummary`/:class:`SearchHit` key-omission contract).",
         "properties": {
           "confidence": {
             "anyOf": [
@@ -127,7 +127,7 @@
       }
     },
     "additionalProperties": false,
-    "description": "Return shape for :func:`nauro_core.operations.check_decision`.\n\n``assessment`` is declared first so the takeaway leads the serialized\npayload (Pydantic ``model_dump`` preserves declaration order), matching\nthe rendered block's takeaway-first order. On the success path it carries\nthe deterministic human-readable summary and ``related_decisions``\ncontains zero or more :class:`RelatedDecision` hits. On the rejection\npath ``error`` is populated; ``assessment`` stays empty and\n``related_decisions`` stays empty. ``store`` is not part of the model;\ntransport adapters add it back at serialization time.",
+    "description": "Return shape for :func:`nauro_core.operations.check_decision`.\n``assessment`` is declared first so the takeaway leads the serialized payload\n(``model_dump`` preserves declaration order). Success populates ``assessment``\nand zero or more ``related_decisions``; rejection populates ``error`` and leaves\nboth empty; ``store`` is adapter-added at serialization time.",
     "properties": {
       "assessment": {
         "default": "",
@@ -158,7 +158,7 @@
   },
   "RelatedDecision": {
     "additionalProperties": false,
-    "description": "A decision surfaced by retrieval as related to a proposed approach.\n\nThe canonical retrieval-hit shape: enriched with the triage-header\nfields (status, date, type, confidence, supersession refs) and a\nrationale lede so any transport can render the same hit without\nre-fetching the underlying decision body.\n\n``decision_type``, ``confidence``, ``supersedes``, and\n``superseded_by`` stay optional so hits whose decision omits those\nfrontmatter fields still serialize; the adapter's ``exclude_none=True``\ntemplate choice drops the keys when they are unset (the\n:class:`DecisionSummary`/:class:`SearchHit` key-omission contract).",
+    "description": "The canonical retrieval-hit shape: triage-header fields plus a rationale\nlede, sparing a re-fetch of the decision body at render time. Optional\nfields stay ``None``-able so hits missing frontmatter still serialize;\nadapters' ``exclude_none=True`` drops unset keys (the\n:class:`DecisionSummary`/:class:`SearchHit` key-omission contract).",
     "properties": {
       "confidence": {
         "anyOf": [

--- a/scripts/docstring_budget_baseline.txt
+++ b/scripts/docstring_budget_baseline.txt
@@ -5,18 +5,9 @@ packages/nauro-core/src/nauro_core/context.py::_is_first_level_list_item
 packages/nauro-core/src/nauro_core/context.py::_is_stack_heading
 packages/nauro-core/src/nauro_core/context.py::_lines_outside_fences
 packages/nauro-core/src/nauro_core/context.py::_strip_leading_current_header
-packages/nauro-core/src/nauro_core/operations/planning.py::<module>
-packages/nauro-core/src/nauro_core/operations/propose_decision.py::_QuestionResolveOutcome
-packages/nauro-core/src/nauro_core/operations/propose_decision.py::_execute_operation
-packages/nauro-core/src/nauro_core/operations/propose_decision.py::_write_decision_direct
-packages/nauro-core/src/nauro_core/operations/results.py::CheckDecisionResult
-packages/nauro-core/src/nauro_core/operations/results.py::ErrorPayload
-packages/nauro-core/src/nauro_core/operations/results.py::RelatedDecision
-packages/nauro-core/src/nauro_core/question_append.py::insert_question_entry
 packages/nauro/src/nauro/auth.py::_exchange_refresh_token
 packages/nauro/src/nauro/auth.py::load_access_token
 packages/nauro/src/nauro/auth.py::resolve_auth_config
-packages/nauro/src/nauro/cli/commands/status.py::_count_remote_decisions
 packages/nauro/src/nauro/cli/integrations/claude_bridge.py::_active_lines
 packages/nauro/src/nauro/cli/integrations/claude_bridge.py::_fence_marker
 packages/nauro/src/nauro/cli/integrations/claude_bridge.py::_has_live_import
@@ -24,7 +15,6 @@ packages/nauro/src/nauro/cli/integrations/claude_bridge.py::_strip_inline_code
 packages/nauro/src/nauro/cli/utils.py::_available_project_names
 packages/nauro/src/nauro/cli/utils.py::_resolve_project_entry
 packages/nauro/src/nauro/cli/utils.py::_v2_registry_or_empty
-packages/nauro/src/nauro/mcp/stdio_server.py::_resolve_or_error
 packages/nauro/src/nauro/store/config.py::_config_lock
 packages/nauro/src/nauro/store/config.py::load_config
 packages/nauro/src/nauro/store/config.py::resolve_embeddings_flag


### PR DESCRIPTION
## Why

The code prose budget (3-line function, 5-line class, 15-line module docstrings) is enforced by a CI ratchet against a baseline that may only shrink. This slice clears the nauro-core tail (propose_decision kernel, results models, question_append, planning) plus two nauro singletons (the stdio resolve helper and the status remote count).

## What changed

- 10 baselined docstrings trimmed to budget, each re-verified against its body; their 10 baseline entries are deleted in the same commit. The baseline held 41 entries, not the 42 the sweep spec counted (the header line itself contains the `::` pattern); 31 remain.
- Two trims are accuracy fixes, not just compression: the execute-tuple docstring dropped its false claim that the supersede half-state path always returns the new decision id (the read-back failure branch returns None, with the new id only in `touched`), and the planning module docstring now names all four plan-returning consumers (update_stack, share_context, submit_report, and update_state's hosted plan path) with update_state staying Store-writing locally.
- The check_decision schema snapshot regenerated: Pydantic embeds class docstrings as JSON-schema descriptions, so the trimmed results models changed description strings only. No field, default, or required-marker churn.
- Restructure signals observed and deferred, per the sweep method: `_execute_operation`'s docstring still outweighs its body, and `_QuestionResolveOutcome` carries a multi-line docstring on a 3-field dataclass.

## Test plan

- `python3 scripts/check_docstring_budget.py packages/nauro/src packages/nauro-core/src` prints `31 over-budget docstring(s), 31 baselined, 0 new, 0 stale.`, exit 0.
- Full suites: nauro-core 1861 passed; nauro 2667 passed, 10 skipped (covers the kernel write-path and results pins, question_append, the planning consumers, stdio resolution, the three status suites, and the protocol-drift guard unmodified).
- Hosted-consumer contract test passes with zero snapshot churn.
- `ruff check` and `ruff format --check` clean.
- `nauro status` captured before and after: identical except the wall-clock "minutes ago" string.
