### PR TITLE
Close the docstring budget baseline: trim the last 9 overruns

### DIFF
--- a/packages/nauro-core/src/nauro_core/context.py
+++ b/packages/nauro-core/src/nauro_core/context.py
@@ -48,12 +48,9 @@ _STACK_ITEM_TRUNCATION_MARKER = '... [item truncated - full text: get_raw_file("
 
 
 def _is_stack_heading(line: str) -> bool:
-    """An ATX heading line: 1-6 ``#`` at column zero, then space, tab, or
-    end of line.
-
-    A hash-tag word like ``#python`` is ordinary prose, not a heading —
-    without the follow-character rule one such line would flip the whole
-    file into structured mode and discard its prose paragraphs.
+    """An ATX heading line: 1-6 ``#`` at column zero, then a space, a tab, or
+    end of line. A hash-tag word like ``#python`` is ordinary prose, never a
+    heading.
     """
     marker_length = len(line) - len(line.lstrip("#"))
     if not 1 <= marker_length <= 6:
@@ -62,13 +59,9 @@ def _is_stack_heading(line: str) -> bool:
 
 
 def _is_first_level_list_item(line: str) -> bool:
-    """A first-level Markdown list item: a list marker at column zero.
-
-    Matches the unordered markers (``-``, ``*``, ``+``) and ordered markers
-    (a 1-9 digit number followed by ``.`` or ``)``), each followed by a
-    space. Indented (nested) list items and continuation lines never
-    match — the projection carries the inventory skeleton, not nested
-    rationale prose.
+    """A first-level Markdown list item, its marker at column zero: ``- ``, ``* ``, or
+    ``+ ``, or one to nine digit characters then ``.`` or ``)`` then a space. Indented
+    (nested) items and continuation lines never match.
     """
     if line.startswith(("- ", "* ", "+ ")):
         return True
@@ -81,11 +74,9 @@ def _is_first_level_list_item(line: str) -> bool:
 
 
 def _fence_delimiter(line: str) -> tuple[str, int, str] | None:
-    """Split a potential code-fence line into ``(char, run, rest)``.
-
-    A fence delimiter is a run of at least three backticks or tildes
-    indented at most three spaces; ``rest`` is whatever follows the run
-    (the info string on an opener; must be blank on a closer).
+    """Split a potential code-fence line into ``(char, run, rest)``, or ``None``: a run
+    of at least three backticks or tildes indented at most three spaces, with ``rest``
+    whatever follows the run.
     """
     stripped = line.lstrip(" ")
     if len(line) - len(stripped) > 3:
@@ -100,16 +91,9 @@ def _fence_delimiter(line: str) -> tuple[str, int, str] | None:
 
 
 def _lines_outside_fences(lines: list[str]) -> list[str]:
-    """Drop fenced code-block lines before item detection.
-
-    Tracks the basic CommonMark fence rule: a fence opens on a run of at
-    least three backticks or tildes indented at most three spaces (a
-    backtick fence's info string may not itself contain a backtick — such
-    a line is ordinary text; tilde info strings may), and closes only on a
-    matching-or-longer run of the same character with nothing else on the
-    line; an unclosed fence runs to end of file. The delimiters and
-    everything between them drop out, and each elided fence leaves one
-    blank line so paragraphs never merge across it.
+    """Drop fenced code, leaving one blank line per fence so paragraphs never merge. A backtick
+    opener with a backtick in its info string is plain text (tilde info strings may); a fence
+    closes only on a matching run at least as long then only whitespace, else runs to end of file.
     """
     outside: list[str] = []
     fence: tuple[str, int] | None = None
@@ -273,13 +257,9 @@ def _resolve_state(files: dict[str, str]) -> str | None:
 
 
 def _strip_leading_current_header(assembled: str) -> str:
-    """Drop a leading ``# Current State`` header line from assembled state.
-
-    state_current.md carries its own ``# Current State`` header. L0 wraps the
-    state under its own ``## Current State`` section header, so without this the
-    payload (and the generated AGENTS.md) shows a stuttered ``## Current State``
-    immediately followed by ``# Current State``. Only the header line is removed;
-    the body and any footer are preserved.
+    """Drop a leading ``# Current State`` header line and the blank lines after
+    it from assembled state, returning the remainder stripped of outer
+    whitespace.
     """
     lines = assembled.strip().split("\n")
     if lines and lines[0].strip() == "# Current State":

--- a/packages/nauro/src/nauro/store/resolution.py
+++ b/packages/nauro/src/nauro/store/resolution.py
@@ -131,17 +131,9 @@ class DisconnectedProject:
 
 
 def _resolve_repo_config_from_cwd(start: Path | None) -> tuple[dict, Path] | None:
-    """Walk up from ``start`` for ``.nauro/config.json`` and load it.
-
-    Returns ``(config, repo_root)`` or ``None`` when no config is found or the
-    config is unreadable. Both ``RepoConfigSchemaError`` (schema mismatch, or a
-    corrupt-JSON error the reader remaps to it) and ``OSError`` (an unreadable
-    file) degrade to ``None`` so a resolution failure surfaces the no-project
-    fallback rather than crashing the transport. A config path that traverses
-    a symlink (a symlinked ``.nauro`` directory or ``config.json``) degrades
-    to ``None`` the same way: a cloned repo is untrusted content, and a
-    pre-planted link must not let attacker-chosen content select which
-    project a command operates on.
+    """Walk up from ``start`` for ``.nauro/config.json`` and return ``(config, repo_root)``.
+    Returns ``None`` for a missing config, on ``RepoConfigSchemaError`` or ``OSError`` from
+    the config read, and for a symlinked ``.nauro`` or ``config.json``, whose refusal is logged.
     """
     config_path = find_repo_config(start=start)
     if config_path is None:

--- a/packages/nauro/src/nauro/sync/pull.py
+++ b/packages/nauro/src/nauro/sync/pull.py
@@ -188,12 +188,9 @@ class _Manifest:
 
 
 def _parse_manifest(rows: list[dict], reporter: Reporter) -> _Manifest:
-    """Parse the manifest into typed entries plus the path and number views.
-
-    The path set answers "could the server already hold this local file?" for
-    the collision classifier, so it spans every entry, including the ones
-    triage skips. The number set reserves the decision numbers the server holds
-    so a local renumber never mints onto one.
+    """Parse the manifest: invalid rows are warned via ``reporter`` and counted in
+    ``unreadable_rows``; ``paths`` spans every retained entry, even ones triage skips;
+    ``decision_numbers`` reserves server-held numbers so a local renumber never mints onto one.
     """
     entries: list[_ManifestEntry] = []
     unreadable = 0

--- a/packages/nauro/src/nauro/sync/transfer.py
+++ b/packages/nauro/src/nauro/sync/transfer.py
@@ -104,19 +104,9 @@ _T = TypeVar("_T")
 
 
 def download_with_retry(path: str, urls: UrlSource, fetch: Callable[[str], _T]) -> _T:
-    """Download one object, retrying transient faults and one stale URL.
-
-    A re-mint is a credential refresh, not a network fault, so it resets the
-    transient budget instead of spending from it: the URL that failed and the
-    URL that replaces it are different requests, and the second one has to be
-    able to ride out a dropped connection too. The total stays bounded because
-    ``reminted`` is a one-time latch - at worst a full budget before the mint
-    and a full budget after it, then the second refusal falls through as
-    permanent.
-
-    Raises:
-        ~nauro.sync.remote.PresignError: the last failure, once the fault is
-            permanent or the attempt budget is spent.
+    """Download ``path``, retrying transient faults up to the attempt budget with jittered backoff;
+    the first expired-candidate fault earns a budget-resetting re-mint (at most two budgets), later
+    ones raise. Raises the last ``PresignError`` once the fault is permanent or the budget spent.
     """
     failures = 0
     reminted = False

--- a/packages/nauro/src/nauro/templates/agents_md.py
+++ b/packages/nauro/src/nauro/templates/agents_md.py
@@ -330,10 +330,9 @@ def remove_generated_agents_md(repo_path: Path) -> str | None:
 
 
 def parse_preserved_sections(agents_md_path: Path) -> PreservedSections:
-    """Parse ``## Skills`` and ``# Manual`` sections from an existing AGENTS.md.
-
-    Both sections are preserved across regen. ``order`` records source-
-    appearance order so regen re-emits them in the same order the user had.
+    """Parse the ``## Skills`` and ``# Manual`` sections preserved across regen;
+    ``order`` records source-appearance order so regen re-emits them in the
+    same order the user had. A missing file yields an empty ``PreservedSections``.
     """
     if not agents_md_path.exists():
         return PreservedSections()

--- a/scripts/docstring_budget_baseline.txt
+++ b/scripts/docstring_budget_baseline.txt
@@ -1,11 +1,2 @@
 # Docstring budget baseline: pre-existing overruns, one <path>::<qualname> per line.
 # This list may only shrink. Fix the docstring and delete the entry.
-packages/nauro-core/src/nauro_core/context.py::_fence_delimiter
-packages/nauro-core/src/nauro_core/context.py::_is_first_level_list_item
-packages/nauro-core/src/nauro_core/context.py::_is_stack_heading
-packages/nauro-core/src/nauro_core/context.py::_lines_outside_fences
-packages/nauro-core/src/nauro_core/context.py::_strip_leading_current_header
-packages/nauro/src/nauro/store/resolution.py::_resolve_repo_config_from_cwd
-packages/nauro/src/nauro/sync/pull.py::_parse_manifest
-packages/nauro/src/nauro/sync/transfer.py::download_with_retry
-packages/nauro/src/nauro/templates/agents_md.py::parse_preserved_sections


### PR DESCRIPTION
## Why

The docstring prose budget has been swept slice by slice; nine baseline entries
remained. This closer trims them to the 3-line contract and empties the
baseline, so the CI ratchet holds at zero recorded debt from here.

## What changed

- Trimmed the last 9 baselined docstrings: five context-assembly helpers in
  nauro-core, plus repo-config resolution, sync manifest parsing, download
  retry, and AGENTS.md section parsing in nauro, each re-verified against its
  body.
- The trims bake in accuracy corrections the old prose missed: the ordered-list
  marker cap is a digit-count cap (one to nine digit characters), not a value
  cap; the fence opener/closer semantics belong to the fence-tracking walker,
  not the delimiter splitter; the manifest path view covers retained entries
  only (empty-path rows validate but are silently dropped); the retry docstring
  states the one-time budget-resetting re-mint latch instead of hardcoding an
  attempt count.
- The baseline file is now header-only. The entries that tripped the
  docstring-longer-than-body restructure signal are resolved by the trims
  themselves; no split or rename was warranted.

## Test plan

- Budget checker (CI invocation): `0 over-budget docstring(s), 0 baselined,
  0 new, 0 stale.`, exit 0.
- Byte-identity probes against a seeded scratch fixture store: get-context
  default and L0/L1/L2, get-raw-file hit and miss, diff-since-last-session
  default and `--days 7`; all outputs byte-identical before and after (the only
  masked bytes are the `--days` request timestamp, which embeds capture time).
- AGENTS.md preservation probe: regen before and after the edit with seeded
  `## Skills` and `# Manual` content; byte-identical.
- Pinning suites (context, resolution, pull manifest, transfer retry, AGENTS.md
  preservation, budget ratchet): 426 passed.
- Full suites: 4528 passed, 10 skipped. `ruff check` and `ruff format --check`
  clean.
