### PR TITLE
Retire find_snapshot_near_date; port corruption tests to the diff resolver

### DIFF
--- a/packages/nauro-core/src/nauro_core/operations/diff_since_last_session.py
+++ b/packages/nauro-core/src/nauro_core/operations/diff_since_last_session.py
@@ -3,7 +3,7 @@
 Cross-transport implementation: CLI, local stdio MCP, and remote HTTP MCP
 all call this function with the same arguments and receive the same
 :class:`DiffSinceLastSessionResult`. Snapshot discovery (``list_snapshots``,
-``load_snapshot``, ``find_snapshot_near_date``) sits outside the locked
+``load_snapshot``, ``resolve_diff_snapshots``) sits outside the locked
 Store protocol; the adapter assembles the baseline/latest snapshot dicts
 and threads them in.
 

--- a/packages/nauro-core/tests/operations/test_diff_since_last_session.py
+++ b/packages/nauro-core/tests/operations/test_diff_since_last_session.py
@@ -4,7 +4,7 @@ Each test seeds an ``InMemoryStore`` (the kernel does not touch it for
 this operation, but the locked signature still takes it) and synthesises
 snapshot dicts inline. Surface-level wiring tests live in the consumer
 package — snapshot discovery (``list_snapshots`` / ``load_snapshot`` /
-``find_snapshot_near_date``) sits outside the locked Store protocol and
+``resolve_diff_snapshots``) sits outside the locked Store protocol and
 the kernel must never import it.
 """
 
@@ -325,7 +325,7 @@ def _kernel_imports() -> set[str]:
 
 def test_kernel_does_not_import_snapshot_discovery() -> None:
     imported = _kernel_imports()
-    forbidden = {"list_snapshots", "load_snapshot", "find_snapshot_near_date"}
+    forbidden = {"list_snapshots", "load_snapshot", "resolve_diff_snapshots"}
     assert forbidden.isdisjoint(imported), (
         f"kernel imports snapshot discovery primitives: {forbidden & imported}; "
         "those live in the adapter, not the kernel."

--- a/packages/nauro/src/nauro/store/snapshot.py
+++ b/packages/nauro/src/nauro/store/snapshot.py
@@ -235,21 +235,6 @@ def _nearest_at_or_before(metas: list[_SnapshotMeta], target: datetime) -> _Snap
     return candidates[-1] if candidates else dated[0][1]
 
 
-def find_snapshot_near_date(store_path: Path, target: datetime) -> dict | None:
-    """Return metadata for the newest snapshot at or before ``target``.
-
-    Falls back to the oldest snapshot when none predates it, ``None`` when none exist.
-    """
-    snapshots_dir = store_path / SNAPSHOTS_DIR
-    if not snapshots_dir.exists():
-        return None
-
-    best = _nearest_at_or_before(_scan_snapshots(snapshots_dir), target)
-    if best is None:
-        return None
-    return {"version": best.version, "timestamp": best.raw_timestamp}
-
-
 def list_snapshots(store_path: Path) -> list[dict]:
     """Return snapshot metadata without file contents, most recent first."""
     snapshots_dir = store_path / SNAPSHOTS_DIR

--- a/packages/nauro/tests/test_log_diff.py
+++ b/packages/nauro/tests/test_log_diff.py
@@ -16,8 +16,8 @@ from nauro.mcp.tools import tool_diff_since_last_session
 from nauro.store.filesystem_store import FilesystemStore
 from nauro.store.snapshot import (
     capture_snapshot,
-    find_snapshot_near_date,
     load_snapshot,
+    resolve_diff_snapshots,
 )
 from nauro.templates.scaffolds import scaffold_project_store
 from tests._writer_compat import append_decision
@@ -411,42 +411,6 @@ def timed_store(store: Path) -> Path:
     return store
 
 
-# --- find_snapshot_near_date tests ---
-
-
-class TestFindSnapshotNearDate:
-    def test_finds_exact_match(self, timed_store: Path):
-        target = datetime.now(timezone.utc) - timedelta(days=7)
-        result = find_snapshot_near_date(timed_store, target)
-        assert result is not None
-        assert result["version"] == 2
-
-    def test_finds_nearest_before(self, timed_store: Path):
-        # 10 days ago — should pick v001 (14 days ago), not v002 (7 days ago)
-        target = datetime.now(timezone.utc) - timedelta(days=10)
-        result = find_snapshot_near_date(timed_store, target)
-        assert result is not None
-        assert result["version"] == 1
-
-    def test_falls_back_to_oldest(self, timed_store: Path):
-        # 30 days ago — nothing that old, should return oldest (v001)
-        target = datetime.now(timezone.utc) - timedelta(days=30)
-        result = find_snapshot_near_date(timed_store, target)
-        assert result is not None
-        assert result["version"] == 1
-
-    def test_no_snapshots(self, store: Path):
-        result = find_snapshot_near_date(store, datetime.now(timezone.utc))
-        assert result is None
-
-    def test_target_in_future(self, timed_store: Path):
-        # Future target — should pick latest (v003)
-        target = datetime.now(timezone.utc) + timedelta(days=1)
-        result = find_snapshot_near_date(timed_store, target)
-        assert result is not None
-        assert result["version"] == 3
-
-
 # --- Time-based diff_since_last_session tests ---
 
 
@@ -537,28 +501,28 @@ class TestCorruptSnapshotTimestamp:
         # The latest snapshot is always kept.
         assert _snapshot_file(store, 3).exists()
 
-    def test_find_snapshot_near_date_ignores_bad_timestamp(self, timed_store: Path):
-        """find_snapshot_near_date resolves among the valid snapshots and
-        ignores one whose timestamp cannot be parsed."""
+    def test_days_resolution_ignores_bad_timestamp(self, timed_store: Path):
+        """Day-range baseline matching skips a snapshot whose timestamp cannot
+        be parsed; latest selection is unaffected."""
         # timed_store: v001 14d ago, v002 7d ago, v003 now.
         _corrupt_timestamp(timed_store, 2)
 
-        # Target 7 days ago: v002 would have matched exactly, but it is now
-        # unparseable, so the nearest valid snapshot at/before the target is
-        # v001 (14 days ago).
-        target = datetime.now(timezone.utc) - timedelta(days=7)
-        result = find_snapshot_near_date(timed_store, target)
-        assert result is not None
-        assert result["version"] == 1
+        # days=7 would have matched v002 exactly, but it is now unparseable,
+        # so the nearest valid snapshot at/before the cutoff is v001.
+        baseline, latest, cutoff = resolve_diff_snapshots(timed_store, days=7)
+        assert baseline is not None and baseline["version"] == 1
+        assert latest is not None and latest["version"] == 3
+        assert cutoff is not None
 
-    def test_find_snapshot_near_date_all_bad_returns_none(self, timed_store: Path):
-        """When every snapshot has an unparseable timestamp, the scan resolves
-        to no candidates and returns None."""
+    def test_days_resolution_all_bad_timestamps_degrades_gracefully(self, timed_store: Path):
+        """When every snapshot has an unparseable timestamp, resolution yields
+        no pair and the rendered diff degrades to the no-snapshots message."""
         for version in (1, 2, 3):
             _corrupt_timestamp(timed_store, version)
 
-        result = find_snapshot_near_date(timed_store, datetime.now(timezone.utc))
-        assert result is None
+        assert resolve_diff_snapshots(timed_store, days=7) == (None, None, None)
+        result = diff_since_last_session(timed_store, days=7)
+        assert "No snapshots" in result
 
     def test_capture_snapshot_all_bad_does_not_crash(self, store: Path):
         """capture_snapshot prunes after writing; with only bad-timestamp

--- a/packages/nauro/tests/test_snapshot_corruption.py
+++ b/packages/nauro/tests/test_snapshot_corruption.py
@@ -15,8 +15,8 @@ from nauro.cli.main import app
 from nauro.store.registry import register_project_v2
 from nauro.store.snapshot import (
     capture_snapshot,
-    find_snapshot_near_date,
     list_snapshots,
+    resolve_diff_snapshots,
 )
 from nauro.templates.scaffolds import scaffold_project_store
 
@@ -47,14 +47,15 @@ def test_list_snapshots_skips_corrupt(tmp_path: Path):
     assert versions == {1, 2}  # the two corrupt files are skipped, no crash
 
 
-def test_find_snapshot_near_date_skips_corrupt(tmp_path: Path):
+def test_days_resolution_skips_corrupt(tmp_path: Path):
     store_path = _store_with_two_snapshots(tmp_path)
     _snap(store_path, 3).write_text("not json at all")
-    from datetime import datetime, timezone
 
-    # Must not raise on the corrupt v003.
-    result = find_snapshot_near_date(store_path, datetime.now(timezone.utc))
-    assert result is not None and result["version"] in {1, 2}
+    # Must not raise on the corrupt v003; its body is excluded from the scan
+    # entirely, so it can never become the latest snapshot either.
+    baseline, latest, _cutoff = resolve_diff_snapshots(store_path, days=0)
+    assert baseline is not None and baseline["version"] in {1, 2}
+    assert latest is not None and latest["version"] == 2
 
 
 def test_capture_survives_corrupt_snapshot(tmp_path: Path):
@@ -81,15 +82,16 @@ def test_capture_survives_corrupt_older_snapshot_during_prune(tmp_path: Path):
     assert not list(store_path.glob("snapshots/*.tmp"))
 
 
-def test_bad_timestamp_snapshot_skipped_by_date_search_and_prune(tmp_path: Path):
+def test_bad_timestamp_snapshot_skipped_by_days_resolution_and_prune(tmp_path: Path):
     store_path = _store_with_two_snapshots(tmp_path)
     # Valid JSON with a version but an unparseable timestamp: the timestamp-
-    # parsing paths (find_snapshot_near_date, prune) must skip it, not raise.
+    # parsing paths (day-range diff resolution, prune) must skip it, not raise.
     _snap(store_path, 3).write_text('{"version": 3, "timestamp": "not-a-date"}')
-    from datetime import datetime, timezone
 
-    result = find_snapshot_near_date(store_path, datetime.now(timezone.utc))
-    assert result is not None and result["version"] in {1, 2}
+    # An undated snapshot never date-matches as baseline yet stays the latest.
+    baseline, latest, _cutoff = resolve_diff_snapshots(store_path, days=0)
+    assert baseline is not None and baseline["version"] in {1, 2}
+    assert latest is not None and latest["version"] == 3
 
     # capture runs prune, which parses every timestamp — must not raise.
     version = capture_snapshot(store_path, trigger="after-bad-ts")
@@ -105,10 +107,10 @@ def test_naive_timestamp_snapshot_treated_as_undated(tmp_path: Path):
     # fromisoformat accepts a timezone-naive value, but a naive datetime cannot
     # compare against the UTC-aware prune cutoffs — it must count as undated.
     _snap(store_path, 3).write_text('{"version": 3, "timestamp": "2026-01-01T00:00:00"}')
-    from datetime import datetime, timezone
 
-    result = find_snapshot_near_date(store_path, datetime.now(timezone.utc))
-    assert result is not None and result["version"] in {1, 2}
+    baseline, latest, _cutoff = resolve_diff_snapshots(store_path, days=0)
+    assert baseline is not None and baseline["version"] in {1, 2}
+    assert latest is not None and latest["version"] == 3
 
     version = capture_snapshot(store_path, trigger="after-naive-ts")
     assert version == 4


### PR DESCRIPTION
## Why

`find_snapshot_near_date` has zero production callers: day-range diff resolution
lives in `resolve_diff_snapshots`, which uses the same scan and at-or-before
primitives directly. The wrapper's only remaining job was keeping corruption-skip
test coverage pointed at a path no user-facing command runs.

## What changed

- Deleted the helper and its dedicated test class. Every behavior the class
  pinned (exact match, at-or-before over nearest-absolute, oldest fallback,
  empty store, future target) is already asserted by the time-based
  diff-since-last-session tests through the production path.
- Ported the five corruption-skip tests to assert directly against
  `resolve_diff_snapshots`. Two semantics are newly pinned: an undated snapshot
  (unparseable or naive timestamp) never date-matches as baseline yet stays
  latest-eligible, and a corrupt body is excluded from the scan so it can never
  become latest. The all-bad case also pins the rendered graceful degradation.
- The kernel import guard's forbidden set and both module docstrings now name
  the live discovery symbol instead of the deleted one.

Selection, anchor, cutoff, and prune semantics are untouched.

## Test plan

- Collected counts: test_log_diff.py 43 -> 38 (the deleted class; ports are 1:1),
  test_snapshot_corruption.py 8 -> 8, core test_diff_since_last_session.py 26 -> 26.
- Fixture-store probe (v001 backdated 14d, v002 corrupt timestamp, v003 now):
  day-range adapter output before vs after is byte-identical modulo the
  request-cutoff timestamp in the anchor line.
- Full suites green: nauro 2648 passed / 10 skipped, nauro-core 1861 passed.
- `ruff check` and `ruff format --check` clean; docstring budget checker reports
  all zeros against the empty baseline.
