### PR TITLE
Remove stdio test-seam aliases; retarget tests to canonical names

### DIFF
--- a/packages/nauro-core/tests/test_constants.py
+++ b/packages/nauro-core/tests/test_constants.py
@@ -210,13 +210,13 @@ class TestMcpInstructions:
         assert "list_decisions" not in MCP_INSTRUCTIONS_STATIC
 
     def test_local_and_remote_share_static_tail(self) -> None:
-        """The local stdio server delivers MCP_INSTRUCTIONS verbatim; the
-        remote server composes MCP_INSTRUCTIONS_STATIC into a per-user
-        payload. Both draw from the same static tail, so the two surfaces
-        cannot silently drift. The alias pins that single source."""
+        """The local stdio server delivers MCP_INSTRUCTIONS_STATIC verbatim;
+        the remote server composes it into a per-user payload. Both draw
+        from the same static tail, so the two surfaces cannot silently
+        drift. The alias pins that single source."""
         assert MCP_INSTRUCTIONS == MCP_INSTRUCTIONS_STATIC
         remote = build_remote_instructions(MCP_INSTRUCTIONS_STATIC, [])
-        assert remote.endswith(MCP_INSTRUCTIONS)
+        assert remote.endswith(MCP_INSTRUCTIONS_STATIC)
 
     def test_inline_header_fragment_present_and_bounded(self) -> None:
         """The inline-header sentence is spliced into the static block and

--- a/packages/nauro/src/nauro/mcp/stdio_server.py
+++ b/packages/nauro/src/nauro/mcp/stdio_server.py
@@ -24,14 +24,9 @@ from typing import Annotated, Any, Literal
 from mcp.server import FastMCP
 from mcp.server.fastmcp import Context
 from mcp.types import CallToolResult, TextContent, ToolAnnotations
-from nauro_core.constants import MCP_INSTRUCTIONS
+from nauro_core.constants import MCP_INSTRUCTIONS_STATIC
 from nauro_core.mcp_tools import ToolSpec, get_tool_spec
 from nauro_core.operations import ErrorPayload
-
-# Back-compat re-export — tests patch the registry through this name. It is
-# the same dict object nauro.mcp.rendering renders from, so an in-place patch
-# here reaches the shared render step.
-from nauro_core.renderers import RENDERERS as _RENDERERS  # noqa: F401
 from nauro_core.renderers import disconnected_reason_code
 from pydantic import Field
 
@@ -64,7 +59,7 @@ from nauro.store.resolution import (
 )
 
 logger = logging.getLogger("nauro.stdio")
-mcp = FastMCP("nauro", instructions=MCP_INSTRUCTIONS, log_level="WARNING")
+mcp = FastMCP("nauro", instructions=MCP_INSTRUCTIONS_STATIC, log_level="WARNING")
 # FastMCP does not forward a version to the underlying low-level server, which
 # otherwise reports the mcp framework version in the initialize response. Set
 # the nauro package version so connecting clients see the release in use.
@@ -118,18 +113,13 @@ def _param_desc(tool_name: str, param: str) -> str:
     return props[param]["description"]
 
 
-# Back-compat re-export — tests import this symbol from this module.
-# The resolution logic itself lives in nauro.store.resolution.
-_resolve_store = resolve_store
-
-
 def _resolve_or_error(project_id, cwd) -> tuple[Path | None, dict | None]:
     """Return ``(store_path, None)``, translating only ``StoreResolutionError``
     and its subclasses to ``(None, error_dict)``: the no-project welcome screen,
     the disconnected diagnostic with recovery fields, or the resolution error text.
     """
     try:
-        return _resolve_store(project_id, cwd), None
+        return resolve_store(project_id, cwd), None
     except NoProjectError:
         return None, {"store": "local", "status": "error", "guidance": WELCOME_NO_PROJECT}
     except DisconnectedProjectError as exc:

--- a/packages/nauro/tests/test_flag_question_parity.py
+++ b/packages/nauro/tests/test_flag_question_parity.py
@@ -317,7 +317,7 @@ class TestStdioNamesEveryStatus:
         """The store-missing race: resolution succeeded, then the store went."""
         pid, _store_path = seeded_repo
         vanished = tmp_path / "vanished-store"
-        monkeypatch.setattr(stdio_module, "_resolve_store", lambda *_a, **_kw: vanished)
+        monkeypatch.setattr(stdio_module, "resolve_store", lambda *_a, **_kw: vanished)
 
         stdio_string = stdio_flag_question(question="Should we ship X?", project_id=pid)
 
@@ -329,7 +329,7 @@ class TestStdioNamesEveryStatus:
     ):
         pid, _store_path = seeded_repo
         vanished = tmp_path / "vanished-store"
-        monkeypatch.setattr(stdio_module, "_resolve_store", lambda *_a, **_kw: vanished)
+        monkeypatch.setattr(stdio_module, "resolve_store", lambda *_a, **_kw: vanished)
 
         stdio_string = stdio_flag_question(resolved_by="D42", targets=["Q1"], project_id=pid)
 

--- a/packages/nauro/tests/test_resolution_v2.py
+++ b/packages/nauro/tests/test_resolution_v2.py
@@ -1,7 +1,7 @@
 """Tests for the v2 project-resolution flow used by every CLI command.
 
 The CLI's ``resolve_target_project`` and the local MCP servers'
-``_resolve_store`` share the same priority order: explicit ``--project``
+``resolve_store`` share the same priority order: explicit ``--project``
 flag → cwd ``.nauro/config.json`` walk-up → registry matched by repo
 path. These tests pin that behavior end-to-end so a regression cannot
 silently flip the precedence.
@@ -29,7 +29,7 @@ from nauro.constants import (
     REPO_CONFIG_FILENAME,
     REPO_CONFIG_SCHEMA_VERSION,
 )
-from nauro.mcp.stdio_server import _resolve_store
+from nauro.mcp.stdio_server import resolve_store
 from nauro.store import registry
 from nauro.store.repo_config import load_repo_config, save_repo_config
 from nauro.templates.scaffolds import scaffold_project_store
@@ -148,13 +148,13 @@ def test_duplicate_name_disambiguation_shows_full_ulid(tmp_path, monkeypatch, ca
     assert pid_b in err
 
 
-# ── stdio _resolve_store mirrors the same precedence ─────────────────────────
+# ── stdio resolve_store mirrors the same precedence ─────────────────────────
 
 
 def test_stdio_resolve_uses_repo_config_when_no_project_passed(tmp_path, monkeypatch):
     cloud_pid, repo_root = _post_migration_state(tmp_path, monkeypatch)
     monkeypatch.chdir(repo_root)
-    store = _resolve_store(None, None)
+    store = resolve_store(None, None)
     assert store == tmp_path / "projects" / cloud_pid
 
 
@@ -163,7 +163,7 @@ def test_stdio_resolve_mismatched_project_id_errors(tmp_path, monkeypatch):
     _cloud_pid, repo_root = _post_migration_state(tmp_path, monkeypatch)
     monkeypatch.chdir(repo_root)
     with pytest.raises(ValueError, match="does not match"):
-        _resolve_store("01KZZZZZZZZZZZZZZZZZZZZZZZ", str(repo_root))
+        resolve_store("01KZZZZZZZZZZZZZZZZZZZZZZZ", str(repo_root))
 
 
 def test_stdio_resolve_no_repo_no_project_errors(tmp_path, monkeypatch):
@@ -174,13 +174,13 @@ def test_stdio_resolve_no_repo_no_project_errors(tmp_path, monkeypatch):
     from nauro.store.resolution import NoProjectError
 
     with pytest.raises(NoProjectError, match="No Nauro project found"):
-        _resolve_store(None, None)
+        resolve_store(None, None)
 
 
 def test_stdio_resolve_explicit_id_matching_config(tmp_path, monkeypatch):
     cloud_pid, repo_root = _post_migration_state(tmp_path, monkeypatch)
     monkeypatch.chdir(repo_root)
-    store = _resolve_store(cloud_pid, str(repo_root))
+    store = resolve_store(cloud_pid, str(repo_root))
     assert store == tmp_path / "projects" / cloud_pid
 
 
@@ -253,7 +253,7 @@ def test_stdio_resolve_corrupt_config_raises_no_project(tmp_path, monkeypatch, c
     monkeypatch.chdir(repo_root)
 
     with pytest.raises(NoProjectError, match="No Nauro project found"):
-        _resolve_store(None, None)
+        resolve_store(None, None)
 
 
 def test_get_context_does_not_crash_transport_on_corrupt_config(tmp_path, monkeypatch):
@@ -264,7 +264,7 @@ def test_get_context_does_not_crash_transport_on_corrupt_config(tmp_path, monkey
     escape the resolver and propagate out of the tool. This pins the wrapper's
     try/except that converts the resolution failure into a returned
     CallToolResult, coverage the two parametrized tests above do not reach
-    because they stop at _resolve_store raising.
+    because they stop at resolve_store raising.
     """
     from mcp.types import CallToolResult
 
@@ -494,7 +494,7 @@ def test_v1_shaped_registry_reaches_welcome_screen(tmp_path, monkeypatch):
     monkeypatch.chdir(repo)
 
     with pytest.raises(NoProjectError, match="No Nauro project found"):
-        _resolve_store(None, None)
+        resolve_store(None, None)
 
 
 @pytest.mark.parametrize("raw_store_path", [42, "", None])
@@ -617,7 +617,7 @@ def test_resolve_store_raises_typed_disconnected_error(tmp_path, monkeypatch):
     save_repo_config(repo, {"mode": "local", "id": pid, "name": "Pareto"})
 
     with pytest.raises(DisconnectedProjectError) as exc:
-        _resolve_store(None, repo)
+        resolve_store(None, repo)
 
     assert exc.value.state.reason_code == "not_connected_on_this_machine"
 
@@ -715,7 +715,7 @@ def test_stdio_resolve_welcome_on_oserror_reading_repo_config(tmp_path, monkeypa
 
     Before the shared tier-1 helper caught OSError alongside
     RepoConfigSchemaError, an unreadable ``.nauro/config.json`` let the OSError
-    escape ``_resolve_store`` and crash the tool call. Now it reaches the same
+    escape ``resolve_store`` and crash the tool call. Now it reaches the same
     NoProjectError the genuine no-project case surfaces as the welcome screen.
     """
     from nauro.store import resolution
@@ -735,7 +735,7 @@ def test_stdio_resolve_welcome_on_oserror_reading_repo_config(tmp_path, monkeypa
     monkeypatch.chdir(repo_root)
 
     with pytest.raises(NoProjectError, match="No Nauro project found"):
-        _resolve_store(None, None)
+        resolve_store(None, None)
 
 
 # ── integration: two projects coexist post-migration ─────────────────────────

--- a/packages/nauro/tests/test_stdio_renderer_wrap.py
+++ b/packages/nauro/tests/test_stdio_renderer_wrap.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import pytest
 from mcp.types import CallToolResult, TextContent
 from nauro_core.operations import flag_question as _flag_question_op
+from nauro_core.renderers import RENDERERS
 
 from nauro.mcp.stdio_server import (
     check_decision,
@@ -254,12 +255,11 @@ class TestErrorAndFallbackPaths:
         """If a renderer raises unexpectedly, the wrapper must not lose
         the response; it falls back to a single JSON block so programmatic
         consumers still get a parseable envelope."""
-        import nauro.mcp.stdio_server as stdio_mod
 
         def explode(_result):
             raise RuntimeError("renderer kaboom")
 
-        monkeypatch.setitem(stdio_mod._RENDERERS, "list_decisions", explode)
+        monkeypatch.setitem(RENDERERS, "list_decisions", explode)
         result = list_decisions(project_id="blockshape")
         blocks = result.content
         assert len(blocks) == 1

--- a/packages/nauro/tests/test_stdio_server.py
+++ b/packages/nauro/tests/test_stdio_server.py
@@ -18,13 +18,13 @@ from nauro_core.operations import flag_question as _flag_question_op
 
 from nauro.mcp.stdio_server import (
     _pull_on_startup,
-    _resolve_store,
     check_decision,
     flag_question,
     get_context,
     get_raw_file,
     mcp,
     propose_decision,
+    resolve_store,
     update_state,
 )
 from nauro.store.filesystem_store import FilesystemStore
@@ -67,13 +67,13 @@ def store(tmp_path: Path, monkeypatch) -> Path:
 
 class TestResolveStore:
     def test_resolve_by_project_name(self, store: Path):
-        result = _resolve_store("testproj", None)
+        result = resolve_store("testproj", None)
         assert result == store
 
     def test_resolve_by_cwd(self, store: Path, tmp_path: Path):
         repo_dir = tmp_path / "repo"
         repo_dir.mkdir(exist_ok=True)
-        result = _resolve_store(None, str(repo_dir))
+        result = resolve_store(None, str(repo_dir))
         assert result == store
 
     def test_raises_on_unknown_project(self, store: Path):
@@ -82,7 +82,7 @@ class TestResolveStore:
         from nauro.store.resolution import ProjectNotFoundError
 
         with pytest.raises(ProjectNotFoundError, match="registry"):
-            _resolve_store("nonexistent", None)
+            resolve_store("nonexistent", None)
 
     def test_raises_on_no_project_or_cwd(self, store: Path):
         # NoProjectError is reserved for the genuinely-no-project case.
@@ -90,7 +90,7 @@ class TestResolveStore:
         from nauro.store.resolution import NoProjectError
 
         with pytest.raises(NoProjectError, match="No Nauro project found"):
-            _resolve_store(None, None)
+            resolve_store(None, None)
 
 
 class TestGetContext:

--- a/packages/nauro/tests/test_update_state_parity.py
+++ b/packages/nauro/tests/test_update_state_parity.py
@@ -253,7 +253,7 @@ class TestStdioNamesEveryStatus:
         """The store-missing race: resolution succeeded, then the store went."""
         pid, _store_path = seeded_repo
         vanished = tmp_path / "vanished-store"
-        monkeypatch.setattr(stdio_module, "_resolve_store", lambda *_a, **_kw: vanished)
+        monkeypatch.setattr(stdio_module, "resolve_store", lambda *_a, **_kw: vanished)
 
         stdio_string = stdio_update_state(delta="Shipped the stdio surface", project_id=pid)
 


### PR DESCRIPTION
## Why

stdio_server.py carried two module-local back-compat aliases kept only so old tests resolve: `_resolve_store` bound to the canonical resolver, and a `noqa` re-export of the shared renderer registry. They existed only as test seams, teaching tests to patch a non-canonical name and suppressing a real lint signal.

## What changed

Both aliases are deleted. The internal call site uses the already-imported `resolve_store`, the 20 test references are retargeted to the canonical seams (patches rebind `nauro.mcp.stdio_server.resolve_store`, the name the call site reads; the renderer patch targets `nauro_core.renderers.RENDERERS` directly), and the stdio server now imports the static instructions constant directly. The back-compat `MCP_INSTRUCTIONS` alias itself stays for released consumers, with its equality test intact.

## Test plan

- Handshake byte-diff probe: initialize + tools/list responses captured before and after (sorted re-dump), diff empty, including the initialize `instructions` field and the full tool-list surface.
- Full suites: nauro 2648 passed, 10 skipped; nauro-core 1861 passed. Collected counts unchanged before vs. after (zero delta, both suites).
- Grep gate: no `_resolve_store` / `_RENDERERS` references remain outside hook.py's unrelated `_resolve_store_path`.
- `ruff check` and `ruff format --check` clean, including the freed `noqa: F401` site; docstring ratchet all zeros.
