### PR TITLE
Remove dead legacy-sync symbols and unwrap unreachable import guards

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/sync.py
+++ b/packages/nauro/src/nauro/cli/commands/sync.py
@@ -22,10 +22,6 @@ from nauro.templates.agents_md_regen import warn_then_regen
 if TYPE_CHECKING:
     from nauro.sync.pull import PullReport
 
-# Names retained for callers/tests that import the push helper from this
-# command module; the implementation now lives in ``nauro.sync.push``.
-_push_to_cloud = push_store_to_cloud
-
 
 def sync(
     message: str = typer.Option("", "--message", "-m", help="Sync message stored in the snapshot."),
@@ -66,7 +62,7 @@ def sync(
             bridge_sink=bridge_outcomes,
         )
 
-        pushed = _push_to_cloud(project_key, store_path, session=session)
+        pushed = push_store_to_cloud(project_key, store_path, session=session)
 
     if pulled.origin_aborted:
         typer.echo(

--- a/packages/nauro/src/nauro/sync/hooks.py
+++ b/packages/nauro/src/nauro/sync/hooks.py
@@ -53,11 +53,8 @@ def pull_before_session(project_id: str, store_path: Path) -> int:
     if not is_cloud_project(project_id):
         return 0
 
-    try:
-        from nauro.sync.lock import HOOK_SYNC_LOCK_TIMEOUT, SyncLockTimeoutError
-        from nauro.sync.pull import run_pull
-    except ImportError:
-        return 0
+    from nauro.sync.lock import HOOK_SYNC_LOCK_TIMEOUT, SyncLockTimeoutError
+    from nauro.sync.pull import run_pull
 
     try:
         # The merged count only: session start has no exit code to carry a
@@ -91,13 +88,10 @@ def push_after_write(project_id: str, store_path: Path) -> PushReport:
     if not is_cloud_project(project_id):
         return PushReport()
 
-    try:
-        from nauro.auth import AuthRefreshError
-        from nauro.sync.lock import HOOK_SYNC_LOCK_TIMEOUT, SyncLockTimeoutError
-        from nauro.sync.push import push_changed_files
-        from nauro.sync.remote import PresignError
-    except ImportError:
-        return PushReport(failed=("sync import",))
+    from nauro.auth import AuthRefreshError
+    from nauro.sync.lock import HOOK_SYNC_LOCK_TIMEOUT, SyncLockTimeoutError
+    from nauro.sync.push import push_changed_files
+    from nauro.sync.remote import PresignError
 
     try:
         return push_changed_files(project_id, store_path, lock_timeout=HOOK_SYNC_LOCK_TIMEOUT)

--- a/packages/nauro/src/nauro/sync/remote.py
+++ b/packages/nauro/src/nauro/sync/remote.py
@@ -127,47 +127,6 @@ class TransferBoundaryError(PresignError):
         )
 
 
-class PresignTransferError(TransferBoundaryError):
-    """Compatibility constructor for callers that used the old GET error."""
-
-    def __init__(
-        self,
-        action: str,
-        *,
-        status: int | None = None,
-        transport: bool = False,
-        detail: str = "",
-    ) -> None:
-        del detail
-        operation = TransferOperation.PUT if "PUT" in action else TransferOperation.GET
-        if status is not None:
-            classification = classify_status(status, operation=operation)
-        elif transport:
-            classification = FaultClassification(
-                TransportFaultKind.CONNECT_ERROR,
-                RetryClassification.TRANSIENT,
-                WriteOutcome.NOT_WRITTEN
-                if operation is TransferOperation.PUT
-                else WriteOutcome.NOT_APPLICABLE,
-            )
-        else:
-            classification = FaultClassification(
-                TransportFaultKind.INVALID_URL,
-                RetryClassification.PERMANENT,
-                WriteOutcome.NOT_WRITTEN
-                if operation is TransferOperation.PUT
-                else WriteOutcome.NOT_APPLICABLE,
-            )
-        super().__init__(
-            operation=operation,
-            origin="invalid-origin",
-            status=status,
-            kind=classification.kind,
-            retry=classification.retry,
-            write_outcome=classification.write_outcome,
-        )
-
-
 @dataclass(frozen=True)
 class FetchedObject:
     body: bytes
@@ -312,14 +271,6 @@ class TransferSession:
     def close(self) -> None:
         if self._owned:
             self.client.close()
-
-    def is_tripped(self, url_or_origin: str) -> bool:
-        origin = (
-            url_or_origin
-            if "://" in url_or_origin and "/" not in url_or_origin.partition("://")[2]
-            else canonical_origin(url_or_origin)
-        )
-        return origin in self._tripped_origins
 
     def trip(self, url: str) -> None:
         self._tripped_origins.add(canonical_origin(url))
@@ -603,7 +554,6 @@ __all__ = [
     "FetchedObject",
     "PRESIGN_BATCH_LIMIT",
     "PresignError",
-    "PresignTransferError",
     "PresignedUrl",
     "PutResult",
     "RetryClassification",

--- a/packages/nauro/tests/test_recovery_resume.py
+++ b/packages/nauro/tests/test_recovery_resume.py
@@ -13,18 +13,41 @@ from filelock import FileLock
 from nauro.store import recovery
 from nauro.store.recovery import RecoveryError, RestoreBusyError, restore_cloud_store
 from nauro.sync import transfer
-from nauro.sync.remote import FetchedObject, PresignTransferError
+from nauro.sync.remote import (
+    FetchedObject,
+    RetryClassification,
+    TransferBoundaryError,
+    TransferOperation,
+    TransportFaultKind,
+    WriteOutcome,
+    classify_status,
+)
 from nauro.sync.state import SYNC_STATE_FILE
 from nauro.templates.scaffolds import scaffold_project_store
 from tests.test_recovery import PID, _decision_bytes, _store_files
 
 
-def _http_fault(status: int) -> PresignTransferError:
-    return PresignTransferError("Presigned GET", status=status, detail="refused")
+def _http_fault(status: int) -> TransferBoundaryError:
+    classification = classify_status(status, operation=TransferOperation.GET)
+    return TransferBoundaryError(
+        operation=TransferOperation.GET,
+        origin="invalid-origin",
+        status=status,
+        kind=classification.kind,
+        retry=classification.retry,
+        write_outcome=classification.write_outcome,
+    )
 
 
-def _transport_fault() -> PresignTransferError:
-    return PresignTransferError("Presigned GET", transport=True, detail="connection reset")
+def _transport_fault() -> TransferBoundaryError:
+    return TransferBoundaryError(
+        operation=TransferOperation.GET,
+        origin="invalid-origin",
+        status=None,
+        kind=TransportFaultKind.CONNECT_ERROR,
+        retry=RetryClassification.TRANSIENT,
+        write_outcome=WriteOutcome.NOT_APPLICABLE,
+    )
 
 
 class _Cloud:

--- a/packages/nauro/tests/test_sync/test_post_restore_sync.py
+++ b/packages/nauro/tests/test_sync/test_post_restore_sync.py
@@ -29,7 +29,12 @@ from nauro.store.repo_config import save_repo_config
 from nauro.sync.merge import CONFLICT_BACKUP_DIR, should_skip
 from nauro.sync.pull import PullReport, run_pull
 from nauro.sync.quarantine import list_quarantine_backups
-from nauro.sync.remote import FetchedObject, PresignTransferError
+from nauro.sync.remote import (
+    FetchedObject,
+    TransferBoundaryError,
+    TransferOperation,
+    classify_status,
+)
 from nauro.sync.state import SYNC_STATE_FILE, load_state
 from nauro.templates.scaffolds import scaffold_project_store
 from tests.test_sync.conftest import (
@@ -44,6 +49,18 @@ from tests.test_sync.conftest import (
 runner = CliRunner()
 
 _DECISION = "decisions/042-a-ruling.md"
+
+
+def _gone_fault() -> TransferBoundaryError:
+    classification = classify_status(404, operation=TransferOperation.GET)
+    return TransferBoundaryError(
+        operation=TransferOperation.GET,
+        origin="invalid-origin",
+        status=404,
+        kind=classification.kind,
+        retry=classification.retry,
+        write_outcome=classification.write_outcome,
+    )
 
 
 def _scaffolded_bytes(root: Path) -> dict[str, bytes]:
@@ -245,7 +262,7 @@ class TestSeededState:
         assert should_skip(SYNC_STATE_FILE)
 
     def test_a_restore_that_fails_before_install_leaves_no_state(self, remote, store):
-        remote.faults[_DECISION] = PresignTransferError("Presigned GET", status=404, detail="gone")
+        remote.faults[_DECISION] = _gone_fault()
 
         with pytest.raises(RecoveryError):
             restore_cloud_store(CLOUD_PID, store)
@@ -256,7 +273,7 @@ class TestSeededState:
         assert not (staging / SYNC_STATE_FILE).exists()
 
     def test_a_resumed_restore_seeds_every_installed_file(self, remote, store):
-        remote.faults[_DECISION] = PresignTransferError("Presigned GET", status=404, detail="gone")
+        remote.faults[_DECISION] = _gone_fault()
         with pytest.raises(RecoveryError):
             restore_cloud_store(CLOUD_PID, store)
         staged_first = set(remote.fetched)

--- a/packages/nauro/tests/test_sync/test_sync_command.py
+++ b/packages/nauro/tests/test_sync/test_sync_command.py
@@ -48,7 +48,7 @@ class TestSyncPullBeforePush:
             return PushReport()
 
         monkeypatch.setattr(sync_mod, "_pull_from_cloud", mock_pull)
-        monkeypatch.setattr(sync_mod, "_push_to_cloud", mock_push)
+        monkeypatch.setattr(sync_mod, "push_store_to_cloud", mock_push)
 
         result = runner.invoke(app, ["sync"])
         assert result.exit_code == 0
@@ -115,7 +115,7 @@ class TestSyncExitCode:
             ),
         )
         monkeypatch.setattr(sync_mod, "is_cloud_project", lambda _project: True)
-        monkeypatch.setattr(sync_mod, "_push_to_cloud", lambda *_args, **_kwargs: PushReport())
+        monkeypatch.setattr(sync_mod, "push_store_to_cloud", lambda *_args, **_kwargs: PushReport())
 
         result = runner.invoke(app, ["sync"])
 
@@ -138,7 +138,7 @@ class TestSyncExitCode:
             return PushReport()
 
         monkeypatch.setattr(sync_mod, "_pull_from_cloud", mock_pull)
-        monkeypatch.setattr(sync_mod, "_push_to_cloud", mock_push)
+        monkeypatch.setattr(sync_mod, "push_store_to_cloud", mock_push)
 
         result = runner.invoke(app, ["sync"])
 
@@ -159,7 +159,7 @@ class TestSyncExitCode:
         self._stub_pull(monkeypatch, PullReport(refused=1))
         monkeypatch.setattr(
             sync_mod,
-            "_push_to_cloud",
+            "push_store_to_cloud",
             lambda *_args, **_kwargs: PushReport(failed=("transport",)),
         )
 

--- a/packages/nauro/tests/test_sync/test_sync_presign.py
+++ b/packages/nauro/tests/test_sync/test_sync_presign.py
@@ -23,6 +23,7 @@ import pytest
 from nauro_core.constants import MAX_BRIEF_BYTES
 
 from nauro.store.config import save_config
+from nauro.sync.remote import TransferBoundaryError, TransferOperation, classify_status
 from nauro.sync.state import (
     FileState,
     SyncState,
@@ -50,7 +51,7 @@ def _seed_token(access_token: str = "tok_orig", refresh_token: str = "refresh_or
 
 
 class TestModeDetection:
-    """Routing predicates for ``_pull_from_cloud`` / ``_push_to_cloud``:
+    """Routing predicates for ``_pull_from_cloud`` / ``push_store_to_cloud``:
 
     * cloud-mode + Auth0 token       → presign
     * cloud-mode without a token     → warn + return False (push), 0 (pull)
@@ -80,9 +81,9 @@ class TestModeDetection:
         store = _scaffolded_cloud_project("strandedproj", tmp_path)
         save_config({})
 
-        from nauro.cli.commands.sync import _push_to_cloud
+        from nauro.sync.push import push_store_to_cloud
 
-        ok = _push_to_cloud(store.name, store)
+        ok = push_store_to_cloud(store.name, store)
         assert ok.is_complete is False
 
     def test_stale_legacy_config_keys_load_cleanly(self, tmp_path, monkeypatch):
@@ -449,9 +450,9 @@ class TestPushViaPresign:
             patch.object(remote.httpx.Client, "post", side_effect=fake_post) as mock_post,
             patch.object(remote.httpx.Client, "put", return_value=put_response) as mock_put,
         ):
-            from nauro.cli.commands.sync import _push_to_cloud
+            from nauro.sync.push import push_store_to_cloud
 
-            ok = _push_to_cloud(cloud_store.name, cloud_store)
+            ok = push_store_to_cloud(cloud_store.name, cloud_store)
 
         assert ok.is_complete is True
         # Presign payload carries project_id + a single PUT op for the modified path.
@@ -582,9 +583,9 @@ class TestPushViaPresign:
             patch.object(remote.httpx.Client, "post", side_effect=fake_post) as mock_post,
             patch.object(remote.httpx.Client, "put", return_value=put_response),
         ):
-            from nauro.cli.commands.sync import _push_to_cloud
+            from nauro.sync.push import push_store_to_cloud
 
-            ok = _push_to_cloud(cloud_store.name, cloud_store)
+            ok = push_store_to_cloud(cloud_store.name, cloud_store)
 
         assert ok.is_complete is True
         # The in-cap brief is presigned; the over-cap one is excluded entirely.
@@ -628,9 +629,9 @@ class TestPushViaPresign:
             patch.object(remote.httpx.Client, "post", side_effect=fake_post) as mock_post,
             patch.object(remote.httpx.Client, "put", return_value=put_response),
         ):
-            from nauro.cli.commands.sync import _push_to_cloud
+            from nauro.sync.push import push_store_to_cloud
 
-            ok = _push_to_cloud(cloud_store.name, cloud_store)
+            ok = push_store_to_cloud(cloud_store.name, cloud_store)
 
         assert ok.is_complete is True
         pushed = {op["path"] for op in mock_post.call_args.kwargs["json"]["operations"]}
@@ -647,9 +648,9 @@ class TestPushViaPresign:
             patch.object(remote.httpx.Client, "post") as mock_post,
             patch.object(remote.httpx.Client, "put") as mock_put,
         ):
-            from nauro.cli.commands.sync import _push_to_cloud
+            from nauro.sync.push import push_store_to_cloud
 
-            ok = _push_to_cloud(cloud_store.name, cloud_store)
+            ok = push_store_to_cloud(cloud_store.name, cloud_store)
 
         assert ok.is_complete is True
         mock_post.assert_not_called()
@@ -682,9 +683,9 @@ class TestPushViaPresign:
             patch.object(remote.httpx.Client, "post", side_effect=fake_post) as mock_post,
             patch.object(remote.httpx.Client, "put", return_value=put_response),
         ):
-            from nauro.cli.commands.sync import _push_to_cloud
+            from nauro.sync.push import push_store_to_cloud
 
-            ok = _push_to_cloud(cloud_store.name, cloud_store)
+            ok = push_store_to_cloud(cloud_store.name, cloud_store)
 
         assert ok.is_complete is True
         # Initial 401 + retry against /sync/presign, plus one /oauth/token refresh.
@@ -783,32 +784,41 @@ class TestPresignedGetFailures:
         assert caught.value.transport is False
 
 
+def _get_status_fault(status: int) -> TransferBoundaryError:
+    classification = classify_status(status, operation=TransferOperation.GET)
+    return TransferBoundaryError(
+        operation=TransferOperation.GET,
+        origin="invalid-origin",
+        status=status,
+        kind=classification.kind,
+        retry=classification.retry,
+        write_outcome=classification.write_outcome,
+    )
+
+
 class TestTransferPolicy:
     """Classification decides what a retry may promise."""
 
     @pytest.mark.parametrize("status", [429, 500, 502, 503, 504])
     def test_overload_statuses_are_transient(self, status):
-        from nauro.sync.remote import PresignTransferError
         from nauro.sync.transfer import TransferFault, classify_fault
 
-        fault = classify_fault(PresignTransferError("Presigned GET", status=status))
+        fault = classify_fault(_get_status_fault(status))
 
         assert fault is TransferFault.TRANSIENT
 
     @pytest.mark.parametrize("status", [400, 404, 409, 418])
     def test_an_unnamed_status_is_permanent(self, status):
-        from nauro.sync.remote import PresignTransferError
         from nauro.sync.transfer import TransferFault, classify_fault
 
-        fault = classify_fault(PresignTransferError("Presigned GET", status=status))
+        fault = classify_fault(_get_status_fault(status))
 
         assert fault is TransferFault.PERMANENT
 
     def test_a_refusal_is_an_expiry_candidate(self):
-        from nauro.sync.remote import PresignTransferError
         from nauro.sync.transfer import TransferFault, classify_fault
 
-        fault = classify_fault(PresignTransferError("Presigned GET", status=403))
+        fault = classify_fault(_get_status_fault(403))
 
         assert fault is TransferFault.EXPIRED_CANDIDATE
 


### PR DESCRIPTION
## Why

Four pieces of the legacy sync surface no longer earn their keep: a compatibility error constructor only tests still used, a circuit query nothing called, two import guards that cannot fire, and a call alias. Removing the compatibility constructor completes the transfer-fault classification consolidation it was bridging.

## What changed

- `nauro/sync/remote.py`: deleted `PresignTransferError` (and its `__all__` entry) and `TransferSession.is_tripped`. The circuit itself (`trip`, `guard`, `boundary_error`) and `PresignError`, a live catch target, are untouched.
- The seven test sites that constructed `PresignTransferError` now build `TransferBoundaryError` through the production `classify_status`, so the transfer-policy tests keep pinning status -> classification end to end instead of asserting hand-frozen literals against themselves. The transport-fault helper hand-freezes the connect-error trio exactly as the deleted constructor did; no production derivation exists for it.
- `nauro/sync/hooks.py`: unwrapped the two `except ImportError` guards. The hooks module and its only callers already require the guarded packages at import time, so no importable install could reach the guards. Imports stay function-local; all four runtime exception handlers are unchanged.
- `nauro/cli/commands/sync.py`: deleted the `_push_to_cloud` alias; the call site reads `push_store_to_cloud` directly, and the test seams patch or import that name.

One thing to note: `PresignTransferError` was listed in `remote.py`'s module `__all__`. That module-level export was never part of the package's public promise (the versioned promise covers the CLI, the stdio MCP contract, and the store format), and a sweep of every known external consumer found zero references to `nauro.sync`. If you depend on it downstream, object here.

## Test plan

- Collected counts unchanged after migration: 26 / 6 / 39 in the three migrated files, 21 in the sync-command file.
- Full suites green: nauro (2648 passed, 10 skipped), nauro-core (1861 passed).
- `ruff check` and `ruff format --check` clean; docstring ratchet reports zero over-budget and zero new.
- Grep gate: zero remaining references to `PresignTransferError`, `is_tripped`, or `_push_to_cloud`.
