### PR TITLE
Remove dead setup skill-codec shims and port their symlink-safety tests

### DIFF
--- a/packages/nauro/src/nauro/cli/integrations/legacy.py
+++ b/packages/nauro/src/nauro/cli/integrations/legacy.py
@@ -9,10 +9,6 @@ from nauro.constants import CLAUDE_MD, NAURO_BLOCK_END, NAURO_BLOCK_START
 from nauro.store.reader import read_text_lenient
 from nauro.store.write_safety import find_symlink
 
-# Legacy markers — kept for removal of old CLAUDE.md blocks during --remove.
-CLAUDE_MD_START = NAURO_BLOCK_START
-CLAUDE_MD_END = NAURO_BLOCK_END
-
 
 def _remove_claude_md(repo_path: Path) -> LegacyOutcome | None:
     """Remove a legacy Nauro block from CLAUDE.md if present.
@@ -27,11 +23,11 @@ def _remove_claude_md(repo_path: Path) -> LegacyOutcome | None:
         return None
 
     content = read_text_lenient(claude_md)
-    if CLAUDE_MD_START not in content:
+    if NAURO_BLOCK_START not in content:
         return None
 
-    before = content[: content.index(CLAUDE_MD_START)]
-    after = content[content.index(CLAUDE_MD_END) + len(CLAUDE_MD_END) :]
+    before = content[: content.index(NAURO_BLOCK_START)]
+    after = content[content.index(NAURO_BLOCK_END) + len(NAURO_BLOCK_END) :]
     remaining = (before + after).strip()
 
     if not remaining:

--- a/packages/nauro/src/nauro/cli/integrations/skills.py
+++ b/packages/nauro/src/nauro/cli/integrations/skills.py
@@ -44,16 +44,6 @@ def _skill_refusal(target: Path, repo: Path | None) -> SymlinkRefusal | UserSyml
     return find_symlink(repo, target.relative_to(repo).as_posix())
 
 
-def _materialize_skill_file(target: Path, content: str) -> SkillOutcome:
-    """Write an arbitrary user-scope skill file for compatibility callers."""
-    refusal = find_file_symlink(target)
-    if refusal is not None:
-        return SkillOutcome(SkillKind.REFUSED_SYMLINK, target=target, refusal=refusal)
-    target.parent.mkdir(parents=True, exist_ok=True)
-    target.write_text(content, encoding="utf-8")
-    return SkillOutcome(SkillKind.WROTE, target=target)
-
-
 def _install_bundled_skill(
     target: Path,
     bundled: str,
@@ -122,26 +112,6 @@ def _remove_bundled_skill(
         parent.rmdir()
         parent = parent.parent
     return SkillOutcome(SkillKind.REMOVED, target=target, repo=repo)
-
-
-def _remove_skill_file(target: Path, *, stop_above: Path) -> SkillOutcome:
-    """Remove an arbitrary skill file, for codec callers that already picked the target.
-    Bundle teardown uses ``_remove_bundled_skill`` instead, which preserves modified Nauro files.
-    """
-    refusal = find_file_symlink(target)
-    if refusal is not None:
-        return SkillOutcome(SkillKind.REFUSED_SYMLINK, target=target, refusal=refusal)
-    if not target.is_file():
-        return SkillOutcome(SkillKind.ABSENT, target=target)
-    target.unlink()
-    stop_resolved = stop_above.resolve()
-    parent = target.parent
-    while parent.is_dir() and not any(parent.iterdir()):
-        if parent.resolve() == stop_resolved:
-            break
-        parent.rmdir()
-        parent = parent.parent
-    return SkillOutcome(SkillKind.REMOVED, target=target)
 
 
 def _migrate_legacy_codex_skill(name: str) -> SkillOutcome | None:

--- a/packages/nauro/tests/test_claude_bridge.py
+++ b/packages/nauro/tests/test_claude_bridge.py
@@ -29,10 +29,10 @@ from nauro.cli.integrations.claude_bridge import (
     ensure_claude_bridge,
     remove_claude_bridge,
 )
-from nauro.cli.integrations.legacy import CLAUDE_MD_END, CLAUDE_MD_START, _remove_claude_md
+from nauro.cli.integrations.legacy import _remove_claude_md
 from nauro.cli.integrations.outcomes import BridgeKind
 from nauro.cli.main import app
-from nauro.constants import CLAUDE_BRIDGE_MARKER, CLAUDE_MD
+from nauro.constants import CLAUDE_BRIDGE_MARKER, CLAUDE_MD, NAURO_BLOCK_END, NAURO_BLOCK_START
 from nauro.mcp.tools import tool_propose_decision
 from nauro.store.registry import register_project_v2
 from nauro.store.repo_config import save_repo_config
@@ -440,13 +440,13 @@ def test_legacy_block_stripped_then_treated_as_foreign_unbridged(tmp_path: Path,
     save_repo_config(repo, {"mode": "local", "id": pid, "name": "proj"})
     monkeypatch.chdir(repo)
     original_remainder = "# My project\n\nKeep this.\n"
-    _write(repo, f"{original_remainder}\n{CLAUDE_MD_START}\nold block\n{CLAUDE_MD_END}\n")
+    _write(repo, f"{original_remainder}\n{NAURO_BLOCK_START}\nold block\n{NAURO_BLOCK_END}\n")
 
     result = runner.invoke(app, ["setup", "claude-code"])
     assert result.exit_code == 0
 
     content = (repo / CLAUDE_MD).read_text(encoding="utf-8")
-    assert CLAUDE_MD_START not in content
+    assert NAURO_BLOCK_START not in content
     assert "# My project" in content
     assert "Keep this." in content
     # The remainder has no import and no bridge marker: it stays foreign and is

--- a/packages/nauro/tests/test_setup.py
+++ b/packages/nauro/tests/test_setup.py
@@ -11,9 +11,9 @@ from nauro.cli.integrations.claude_bridge import BridgeState as _BridgeState
 from nauro.cli.integrations.claude_bridge import detect_bridge_state
 from nauro.cli.integrations.codex_config import _configure_codex
 from nauro.cli.integrations.json_mcp import _configure_mcp, recorded_mcp_commands
-from nauro.cli.integrations.legacy import CLAUDE_MD_END, CLAUDE_MD_START
 from nauro.cli.integrations.outcomes import CodexConfigKind, JsonMcpKind
 from nauro.cli.main import app
+from nauro.constants import NAURO_BLOCK_END, NAURO_BLOCK_START
 from nauro.store.registry import register_project_v2
 from nauro.store.repo_config import save_repo_config
 from nauro.templates.scaffolds import scaffold_project_store
@@ -254,14 +254,16 @@ class TestLegacyCleanup:
     def test_removes_legacy_block_from_claude_md(self, tmp_path: Path, monkeypatch):
         """Setup removes legacy Nauro block from CLAUDE.md."""
         repos = _setup_project(tmp_path, monkeypatch)
-        content = f"# My Project\n\nKeep this.\n\n{CLAUDE_MD_START}\nold block\n{CLAUDE_MD_END}\n"
+        content = (
+            f"# My Project\n\nKeep this.\n\n{NAURO_BLOCK_START}\nold block\n{NAURO_BLOCK_END}\n"
+        )
         (repos[0] / "CLAUDE.md").write_text(content)
 
         result = runner.invoke(app, ["setup", "claude-code", "--project", "testproj"])
         assert result.exit_code == 0
 
         cleaned = (repos[0] / "CLAUDE.md").read_text()
-        assert CLAUDE_MD_START not in cleaned
+        assert NAURO_BLOCK_START not in cleaned
         assert "# My Project" in cleaned
         assert "Keep this." in cleaned
         assert "Legacy cleanup" in result.output
@@ -270,12 +272,12 @@ class TestLegacyCleanup:
         """A CLAUDE.md that was only a legacy block is stripped, then the fresh
         bridge is written in its place (the file is absent between the two steps)."""
         repos = _setup_project(tmp_path, monkeypatch)
-        content = f"{CLAUDE_MD_START}\nold block\n{CLAUDE_MD_END}\n"
+        content = f"{NAURO_BLOCK_START}\nold block\n{NAURO_BLOCK_END}\n"
         (repos[0] / "CLAUDE.md").write_text(content)
 
         result = runner.invoke(app, ["setup", "claude-code", "--project", "testproj"])
         assert result.exit_code == 0
-        assert CLAUDE_MD_START not in (repos[0] / "CLAUDE.md").read_text()
+        assert NAURO_BLOCK_START not in (repos[0] / "CLAUDE.md").read_text()
         assert detect_bridge_state(repos[0]) is _BridgeState.OWNED
 
 
@@ -341,7 +343,7 @@ class TestSymlinkRefusal:
 
     def test_legacy_cleanup_refuses_symlinked_claude_md(self, tmp_path: Path, monkeypatch):
         repos = _setup_project(tmp_path, monkeypatch)
-        content = f"{CLAUDE_MD_START}\nold block\n{CLAUDE_MD_END}\n"
+        content = f"{NAURO_BLOCK_START}\nold block\n{NAURO_BLOCK_END}\n"
         outside = tmp_path / "outside.md"
         outside.write_text(content)
         (repos[0] / "CLAUDE.md").symlink_to(outside)

--- a/packages/nauro/tests/test_setup_extended.py
+++ b/packages/nauro/tests/test_setup_extended.py
@@ -20,7 +20,7 @@ from nauro.cli.integrations.outcomes import (
     JsonMcpKind,
     SkillKind,
 )
-from nauro.cli.integrations.skills import materialize_skills_cursor_for_repo
+from nauro.cli.integrations.skills import _remove_bundled_skill, materialize_skills_cursor_for_repo
 from nauro.cli.main import app
 from nauro.store.registry import register_project_v2
 from nauro.templates.scaffolds import scaffold_project_store
@@ -370,30 +370,26 @@ def test_setup_all_remove_clears_everything(tmp_path: Path, monkeypatch):
     assert not (tmp_path / ".agents" / "skills" / "nauro-adopt" / "SKILL.md").exists()
 
 
-def test_remove_skill_file_does_not_walk_above_base(tmp_path: Path):
-    """``_remove_skill_file`` must stop at ``stop_above`` — never delete the surface root."""
-    from nauro.cli.integrations.skills import _remove_skill_file
-
+def test_remove_bundled_skill_does_not_walk_above_base(tmp_path: Path):
+    """``_remove_bundled_skill`` must stop at ``stop_above`` - never delete the surface root."""
     base = tmp_path / ".claude" / "skills"
     skill_dir = base / "nauro-adopt"
     skill_dir.mkdir(parents=True)
     target = skill_dir / "SKILL.md"
     target.write_text("body")
 
-    outcome = _remove_skill_file(target, stop_above=base)
+    outcome = _remove_bundled_skill(target, "body", stop_above=base)
 
     assert outcome.kind is SkillKind.REMOVED
     assert not target.exists()
-    assert not skill_dir.exists()  # subdir was empty → pruned
+    assert not skill_dir.exists()  # subdir was empty - pruned
     assert base.is_dir()  # base preserved
     assert base.parent.is_dir()  # ~/.claude preserved
     assert base.parent.parent.is_dir()  # tmp_path preserved
 
 
-def test_remove_skill_file_preserves_sibling_skills(tmp_path: Path):
+def test_remove_bundled_skill_preserves_sibling_skills(tmp_path: Path):
     """If `~/.claude/skills/` has other skills, removing nauro must not touch them."""
-    from nauro.cli.integrations.skills import _remove_skill_file
-
     base = tmp_path / ".claude" / "skills"
     nauro_skill = base / "nauro-adopt" / "SKILL.md"
     other_skill = base / "user-other" / "SKILL.md"
@@ -402,7 +398,7 @@ def test_remove_skill_file_preserves_sibling_skills(tmp_path: Path):
     other_skill.parent.mkdir(parents=True)
     other_skill.write_text("user-other")
 
-    outcome = _remove_skill_file(nauro_skill, stop_above=base)
+    outcome = _remove_bundled_skill(nauro_skill, "nauro", stop_above=base)
 
     assert outcome.kind is SkillKind.REMOVED
     assert not nauro_skill.exists()

--- a/packages/nauro/tests/test_setup_user_write_safety.py
+++ b/packages/nauro/tests/test_setup_user_write_safety.py
@@ -30,7 +30,7 @@ from nauro.cli.integrations.outcomes import (
     CodexConfigKind,
     SkillKind,
 )
-from nauro.cli.integrations.skills import _materialize_skill_file, _remove_skill_file
+from nauro.cli.integrations.skills import _install_bundled_skill, _remove_bundled_skill
 from nauro.cli.nauro_command import _find_nauro_command
 
 if sys.version_info >= (3, 11):
@@ -375,7 +375,7 @@ def test_skill_add_refuses_symlinked_target(tmp_path: Path):
     target.parent.mkdir(parents=True)
     target.symlink_to(real)
 
-    line = _materialize_skill_file(target, "new body")
+    line = _install_bundled_skill(target, "new body", force_overwrite=False)
 
     assert line.kind is SkillKind.REFUSED_SYMLINK
     assert target.is_symlink()
@@ -391,7 +391,7 @@ def test_skill_remove_refuses_symlinked_target(tmp_path: Path):
     target.parent.mkdir(parents=True)
     target.symlink_to(real)
 
-    line = _remove_skill_file(target, stop_above=base)
+    line = _remove_bundled_skill(target, "original", stop_above=base)
 
     assert line.kind is SkillKind.REFUSED_SYMLINK
     assert target.is_symlink()
@@ -406,7 +406,7 @@ def test_skill_writes_through_symlinked_parent_dir(tmp_path: Path):
     base.symlink_to(real_dir, target_is_directory=True)
     target = base / "nauro-adopt" / "SKILL.md"
 
-    line = _materialize_skill_file(target, "body")
+    line = _install_bundled_skill(target, "body", force_overwrite=False)
 
     assert line.kind is SkillKind.WROTE
     assert line.target == target


### PR DESCRIPTION
## Why

Two dead compatibility shims in the setup skill codec (`_materialize_skill_file`,
`_remove_skill_file`) had zero src callers, but their 5 tests were the only direct
coverage of the skill symlink-safety invariants. The live bundled paths enforce the
same invariants through the same shared guards, so the coverage moves to what
production runs.

## What changed

- Deleted the two shims; the shared write-safety guards stay, used by the surviving
  helpers.
- Ported the 5 tests in place to `_install_bundled_skill` / `_remove_bundled_skill`
  with the same fixtures and assertions. One precision note: the
  write-through-symlinked-parent test pins a deliberate allowance (`WROTE`), not a
  refusal, so dotfile-manager layouts with a symlinked parent directory keep working;
  the port keeps pinning that. The `_remove_bundled_skill` ports pass a bundled body
  equal to the on-disk fixture content so its content-identity precondition is
  satisfied and each test still exercises its original invariant (the
  preserve-modified branch keeps its own existing coverage).
- Deleted the `CLAUDE_MD_START`/`CLAUDE_MD_END` aliases in the legacy cleanup module;
  it and its tests use `NAURO_BLOCK_START`/`NAURO_BLOCK_END` directly.

## Test plan

- 200 passed across the five setup test files (26/51/39/54/30 collected, unchanged);
  whole nauro suite green with collected count identical to base (delta zero).
- Byte-identity probe: init + setup claude-code + legacy-block seed + setup --remove
  against a fixed scratch HOME, run before and after the change; transcripts and
  sha256 manifests diff to zero.
- `ruff check` and `ruff format --check` clean; docstring-budget ratchet unchanged.
