### PR TITLE
Trim rationale-narrating comment essays to contract lines

### DIFF
--- a/packages/nauro-core/src/nauro_core/validation.py
+++ b/packages/nauro-core/src/nauro_core/validation.py
@@ -28,23 +28,8 @@ from nauro_core.search import Bm25Hit, bm25_retrieve
 TIER2_TOP_K = 5
 
 
-# bm25s's default English stopword list is minimal (~30 tokens: a, an, and,
-# are, as, at, be, but, by, for, if, in, into, is, it, no, not, of, on, or,
-# ...). It omits common action verbs that appear in virtually every Nauro
-# decision title ("Use Postgres", "Use Redis", "Use FastAPI", etc.), so a
-# fresh proposal shares the stem ``use`` with most existing decisions and
-# gets a nonzero BM25 score, surfacing as a near-neighbour on almost every
-# call. Extending the list with ``use`` collapses those false-positive
-# matches to score 0 (already filtered by bm25_retrieve).
-#
-# This list is intentionally minimal: only tokens with observed false
-# positives are added, not a speculative blanket of generic verbs. Add
-# more only when a concrete failure case justifies it, and add a test to
-# lock the case in.
-#
-# Built lazily (module __getattr__ below) so importing the package does not
-# pull the bm25s/numpy stack; idle MCP server processes never search. Cached
-# so every access shares one list object, matching the old module constant.
+# Extend only for an observed false-positive stem, with a test locking the case.
+# Lazy via module __getattr__ so package import does not pull the bm25s/numpy stack.
 @lru_cache(maxsize=1)
 def _tier2_stopwords() -> list[str]:
     from bm25s.stopwords import STOPWORDS_EN
@@ -58,17 +43,8 @@ def __getattr__(name: str) -> list[str]:
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-# The scaffold-seeded "Initial project setup" decision is Nauro's own
-# bookkeeping — it records that the store was initialized, not a choice the
-# user made. It should not gate validation of user-authored proposals.
-# Including it in the tier-2 corpus causes every new proposal sharing even
-# one weak stem (e.g. "store", "use") with the template text to escalate,
-# defeating tier 2's purpose as a cheap pre-filter.
-#
-# Identified by the conventional num+title pair written by the scaffold
-# template. This is a convention match, not a fuzzy heuristic: the title is
-# hardcoded in the scaffold and the scaffold is the only path that produces
-# a ``num == 1`` decision with this exact title.
+# Must match the title the scaffold template hardcodes; detection is the
+# num == 1 + title convention.
 _SCAFFOLD_SEED_TITLE = "Initial project setup"
 
 

--- a/packages/nauro/src/nauro/cli/integrations/agents.py
+++ b/packages/nauro/src/nauro/cli/integrations/agents.py
@@ -24,20 +24,6 @@ def _agent_target(surface: str, name: str) -> Path:
     raise ValueError(f"unknown surface: {surface!r}")
 
 
-# Subagents are rendered from canonical bodies in nauro.agents and written into
-# the user's surface directories: ``~/.claude/agents/`` for Claude Code and
-# ``~/.codex/agents/`` for Codex.
-# Unlike skills, agents are namespaced (``nauro-*``) and opt-in. The
-# ``nauro-`` namespace is bundle-owned: on install, the current bundle
-# wins, so a published body change (e.g. dropping a removed MCP tool) actually
-# reaches users who installed an earlier version. A pre-existing
-# A bundled agent file that differs from the current render is refreshed; its
-# prior content is stashed to a sibling ``.bak`` so the rare hand-customization is
-# recoverable. ``force_overwrite=True`` skips the ``.bak`` and overwrites in
-# place. User-authored files without the ``nauro-`` prefix (e.g. a personal
-# ``~/.claude/agents/planner.md``) are never touched.
-
-
 def materialize_agents(
     surface: str,
     *,

--- a/packages/nauro/src/nauro/cli/integrations/skills.py
+++ b/packages/nauro/src/nauro/cli/integrations/skills.py
@@ -12,19 +12,9 @@ from nauro.store.write_safety import (
     find_symlink,
 )
 
-# Skills are rendered from canonical bodies in nauro.skills and written into
-# the user's surface directories. Claude Code and Codex skills are user-global;
-# Cursor skills ship per-project (Cursor's "User Rules" live in the IDE
-# Settings UI, not a file path).
-#
-# ``SKILL_NAMES`` is the always-installed set — the core onboarding skill.
-# ``OPT_IN_SKILL_NAMES`` is materialized only when the caller passes
-# ``with_skills=True``. ``nauro-ship-task`` references the bundled ``@nauro-*``
-# subagents and is opt-in for that reason, so the ``--with-subagents`` notice
-# stays scoped to it. ``nauro-loop`` dispatches ``/nauro-ship-task``
-# byte-for-byte, so it carries the same subagent dependency transitively.
-# ``nauro-context`` composes only existing MCP tools (plus the agent's own
-# filesystem write) with no subagent dependency, so it carries no such notice.
+# Cursor has no user-global skills path (its User Rules live in the IDE Settings UI);
+# Cursor skills ship per-project.
+# SKILL_NAMES always installs; OPT_IN_SKILL_NAMES only when the caller passes with_skills=True.
 
 SKILL_NAMES: tuple[str, ...] = ("nauro-adopt",)
 OPT_IN_SKILL_NAMES: tuple[str, ...] = ("nauro-ship-task", "nauro-context", "nauro-loop")

--- a/packages/nauro/src/nauro/demo/__init__.py
+++ b/packages/nauro/src/nauro/demo/__init__.py
@@ -60,21 +60,9 @@ def _decision(
 
 
 # ── Demo decisions ──
-#
-# The first seven carry the product's foundational choices at the shared
-# 2026-03-15 date. Decisions 8 through 13 add two supersession structures,
-# dated across the project's timeline so the graph's timeline and lineage
-# views both read:
-#
-#   Consolidation fan: decision 13 (one ordered transaction pipeline) retires
-#   three earlier per-screen approaches (8 inline category guessing, 9 per-screen
-#   amount formatting, 10 dashboard-only de-duplication). It carries a scalar
-#   supersedes pointing at the earliest of the three (8); all three flip to
-#   superseded and carry superseded_by pointing back at 13. This mirrors the
-#   on-disk shape that propose_decision's supersede path writes.
-#
-#   Short chain: decision 11 (calendar-month budget periods) is superseded by
-#   decision 12 (pay-cycle budget periods), a two-step lineage.
+# Decisions 8-13 form two supersession structures the graph views and tests depend on: a fan
+# (13 supersedes 8; 8, 9, 10 all carry superseded_by 13, matching propose_decision's on-disk
+# supersede shape) and a chain (11 -> 12).
 
 DEMO_DECISIONS: list[Decision] = [
     _decision(

--- a/packages/nauro/src/nauro/store/registry.py
+++ b/packages/nauro/src/nauro/store/registry.py
@@ -100,15 +100,6 @@ def _registry_lock():
 
 
 # ── v2 registry (id-keyed) ───────────────────────────────────────────────────
-#
-# v2 uses a project_id (ULID) primary key and tracks ``mode`` plus an
-# optional ``server_url`` per project.
-#
-# v2 is a strict loader: it refuses to read a v1 registry and tells the user
-# to run the one-time manual migration documented in the release notes.
-# Auto-migration is intentionally out of scope — solo-founder scale, single
-# existing project, three shell commands beat code that needs idempotency,
-# directory renames, and adopt-existing-config fallbacks.
 
 
 def load_registry_v2() -> dict:


### PR DESCRIPTION
## Why

Six comment blocks across five files had grown into essays narrating rationale and history: observed failures, rejected alternatives, and why-this-was-added stories. That material lives in the decision store, commit messages, and PR bodies; a comment earns its place only where the code cannot say it. This is the final slice of the comment-and-docstring cleanup series.

## What changed

Comment bytes only, per the audited sentence tables:

- `nauro_core/validation.py`: the stopwords essay (17 lines) reduces to two contract lines, the extension policy and the lazy `__getattr__` import invariant; the scaffold-seed essay (11 lines) reduces to the cross-module coupling fact that the constant must match the scaffold template's hardcoded title.
- `store/registry.py`: the v2 registry essay dies; every sentence restated the model fields, the loader docstring, or a rejected alternative. The section divider stays.
- `cli/integrations/agents.py`: the subagent essay dies whole, including a dangling "A pre-existing" sentence fragment left by an earlier edit; everything it said lives in the function docstring and the code.
- `cli/integrations/skills.py`: reduces to two contract facts, that Cursor has no user-global skills path (its User Rules live in the IDE Settings UI) and the `SKILL_NAMES` / `OPT_IN_SKILL_NAMES` install semantics.
- `demo/__init__.py`: the demo-decisions essay reduces to the divider plus a three-line map of the two supersession structures (fan and chain) that the graph views and tests depend on.

The load-bearing contract comment blocks elsewhere (constants, hooks, stdio server, merge, autogen) are deliberately untouched.

## Test plan

- AST equality proof: `ast.dump(ast.parse(...))` for all five files is byte-identical before and after the edit, so no docstring, code, or test bytes moved.
- Full suites: nauro-core 1861 passed; nauro 2648 passed, 10 skipped. Collected counts unchanged.
- `ruff check` and `ruff format --check` clean.
- Docstring-budget ratchet: 0 over-budget, 0 baselined, 0 new, 0 stale.
- `git diff --stat` names exactly the five trimmed files; the keep-list files show zero diff.
