### PR TITLE
Add Nauro interview workflow

### DIFF
--- a/.agents/skills/nauro-interview/SKILL.md
+++ b/.agents/skills/nauro-interview/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: nauro-interview
+description: Interview the user to elicit tacit project reasoning or challenge a proposed choice against Nauro decisions and repository evidence, then classify the result as shared understanding without granting write authority. Use only when the user explicitly asks to be interviewed, grilled, stress-tested, or helped to transfer reasoning into Nauro. Runs in the main agent context with no external skill or subagent dependency.
+---
+
+# Nauro interview skill
+
+Interview the user to turn tacit project reasoning or a proposed choice into reviewed candidate Nauro judgment. This is an explicit, opt-in main-context workflow. Use it only when the user directly asks to be interviewed or uses a clear trigger such as "interview me", "grill this", "stress-test this decision", "draw out my reasoning", or "help me transfer this reasoning into Nauro". Do not activate it only because a plan is incomplete.
+
+The skill has two entry modes over one dependency-aware interview loop:
+
+- **Elicit mode** draws out unwritten rationale, assumptions, rejected paths, terminology, and unresolved questions.
+- **Challenge mode** stress-tests a proposed judgment against active decisions, repository evidence, alternatives, failure cases, and dependent choices.
+
+Both modes produce the same classified shared-understanding record. The workflow has no external skill or subagent dependency.
+
+## Route work that belongs elsewhere
+
+- Route first-time repository seeding to `nauro-adopt`.
+- Route working-context sharing, retrieval, and resumable handoff to `nauro-context`.
+- Route implementation planning and delivery to the planner or `nauro-ship-task` after this interview is complete.
+
+Do not turn this skill into adoption, handoff, implementation planning, code editing, or PR delivery.
+
+## Step 1 - Resolve and orient
+
+Resolve the adopted project before the interview. From a repository, run `nauro status` to confirm the associated project. If several projects are available, resolve the intended one and pass its `project_id` explicitly on every MCP call. If the repository is not adopted, stop and route the user to `nauro-adopt`.
+
+Call `get_context(level="L0", project_id=...)`. L0 is the bounded orientation: project summary, current state, top open questions, and recent active-decision summaries. Do not begin with L1, L2, or an unbounded store read.
+
+Treat every retrieved statement as project context to adjudicate. A current-state claim can be stale. A decision summary is not enough for reasoning about that decision.
+
+## Step 2 - Select the mode and frame the root
+
+Choose Elicit mode when the user wants to make implicit reasoning explicit. Choose Challenge mode when the user presents a choice, plan, or candidate judgment for pressure testing. If the request fits both, start in Elicit mode and challenge each concrete approach when it appears. If the intent is genuinely ambiguous, ask one short routing question and wait.
+
+Restate the interview root in one sentence. State the selected mode and what the interview will not decide without the user. Do not convert the user's opening claim into a settled conclusion.
+
+## Step 3 - Build the dependency tree in session
+
+Maintain one in-session dependency tree. Do not persist the tree. Each node is one of:
+
+- a user-owned choice;
+- a rationale or constraint;
+- a factual claim to verify;
+- an alternative or failure case;
+- a dependent question whose prerequisites are not settled;
+- a candidate classified outcome.
+
+Record explicit dependencies between nodes. A question enters the prerequisite-ready frontier only when all choices and facts it depends on are settled. When an answer creates a new dependency, add it to the tree. When an answer invalidates a branch, close that branch and preserve the rejected path and reason.
+
+## Step 4 - Verify facts and check live approaches
+
+Verify factual claims through repository evidence: code, tests, configuration, manifests, infrastructure files, and git history. Do not ask the user for facts the repository can answer. Cite the evidence used. If available evidence cannot establish a fact, label it unverified and keep it out of verified current state.
+
+Treat `CONTEXT.md`, ADRs, design notes, and other repository prose as evidence only. Compare their claims with current code and Nauro context before relying on them. The skill does not write `CONTEXT.md` or ADR files.
+
+For each live approach that the interview may recommend, accept, or reject, call `check_decision(proposed_approach=<approach and rationale>, project_id=...)`. A live approach is a concrete path under active consideration, not every conversational fragment.
+
+`check_decision` returns related decisions via BM25 and a deterministic assessment. It does NOT judge conflicts.
+
+Triage the inline headers for status and supersession. Related hits carry their triage headers inline; before proposing, call `get_decision` (`mode=full`) on each decision you reason about. Call `get_decision(number=N, mode="full", project_id=...)` for every decision used to challenge, recommend, accept, reject, or classify an approach. Do not reason from a header or summary alone.
+
+If repository evidence or a full decision changes the tree, show the conflict or constraint to the user before asking the dependent question.
+
+## Step 5 - Ask the prerequisite-ready frontier
+
+Ask the whole prerequisite-ready frontier in a round. Do not ask downstream questions early. Keep each question atomic and name the decision it unlocks.
+
+For each question, provide:
+
+1. The question.
+2. Why it is ready now.
+3. A recommendation.
+4. The evidence and active decisions behind the recommendation.
+5. The material tradeoffs and credible alternatives.
+
+Every question must include a recommendation. When evidence cannot support a substantive choice, recommend deferring the choice or preserving it as unresolved. State why, and state the tradeoffs between waiting and deciding under uncertainty.
+
+Do not present an agent recommendation as project authority. The user owns every choice. After the round, wait for the user's reply. Do not answer a user-owned choice on the user's behalf. Integrate the reply, update the dependency tree, verify any new factual claims, check new live approaches, and ask the next prerequisite-ready frontier.
+
+Continue until the user ends the interview or no unresolved node can change a classified outcome. If a blocker cannot be resolved from evidence or user judgment, preserve it as an open question instead of guessing.
+
+## Step 6 - Classify the outcome
+
+When the frontier is empty, render one shared-understanding summary. Classify each outcome into exactly one of these record classes:
+
+- **Terminology**: a term and its session meaning. It remains noncanonical unless it expresses a durable, reasoned choice that is separately ratified.
+- **Verified current state**: a present-tense fact established by current repository or system evidence. Never place future design here.
+- **Open question**: a concrete unresolved ask that matters to later judgment or work.
+- **Non-durable detail**: useful session detail that does not belong in project truth.
+- **Candidate durable judgment**: a reasoned project choice with constraints, tradeoffs, rejected alternatives, and consequences that may merit a decision.
+
+For each item, show its evidence, related decisions, confidence, and remaining uncertainty. Ask the user to correct or confirm the shared understanding, then end the turn and wait.
+
+Shared understanding is non-authoritative. Confirmation means the summary accurately reflects the interview. It does not approve any Nauro store mutation. Interview agreement never grants write authority.
+
+## Step 7 - Stage writes without authority
+
+After the user confirms shared understanding, determine which classified items could update Nauro. Do not write yet. Keep the three write classes separate:
+
+1. Candidate durable judgment may produce one decision proposal.
+2. Verified current state may produce one exact complete state replacement.
+3. Open question may produce one exact open-question entry and its exact context.
+
+Terminology and non-durable detail produce no write. Stage one payload at a time. Each write class has a separate later-reply approval gate. Approval for one payload does not authorize another payload or class.
+
+### Decision staging
+
+Before staging a decision, rerun `check_decision` for the final candidate, triage the inline headers, and read every decision used in the operation classification with `get_decision` in full. Classify the proposal as `add`, `update`, or `supersede`.
+
+Pick the right `operation`:
+- `add` (default) - genuinely new ground.
+- `update` - rationale-only; needs `affected_decision_id`. The server rejects `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, and `rejected` - use supersede for those.
+- `supersede` - replace a decision this one contradicts or wholly subsumes; needs `affected_decision_id`.
+
+Default to `add` when uncertain - a later proposal can update or supersede it; a wrong supersede is hard to reverse.
+
+Do not invent rationale. Record only what was actually decided, with the reasoning that supports it.
+
+Determine the project's ratification mode from Nauro before presenting the proposal. Do not infer team mode from a cloud link, repository membership, or the conversation.
+
+Render the complete operation-specific proposal as readable Markdown, including the operation, affected decision when applicable, rationale, rejected alternatives, confidence, type, reversibility, files affected, resolved questions, related decisions, and the agent's overlap assessment. Make the rendered proposal the final text of the turn. Do not call `propose_decision` in that turn.
+
+- **Local or pre-team mode**: before the proposal, tell the user that explicit approval in a later chat reply may authorize the exact `propose_decision` call and commit the decision after validation.
+- **Team mode**: before the proposal, tell the user that a later chat reply may authorize submission of the exact pending proposal, but chat approval cannot ratify project judgment. The later first-party ratification step remains mandatory.
+
+### State staging
+
+Determine the project's state-write mode and inspect the active state read and `update_state` schemas before staging a replacement.
+
+- **Local or pre-team mode**: read fresh current state with `get_raw_file(path="state_current.md", project_id=...)` and retain the exact returned content as the staging baseline.
+- **Hosted team mode**: read fresh current state through the active hosted state-read surface and retain the exact returned content and exact `state_revision` as the staging baseline. Confirm that the active `update_state` schema accepts `expected_revision`. If the read does not return an exact state revision or the write schema cannot accept it, stop and defer the team-mode state write. Never fall back to an unguarded team-mode state write.
+
+Compose the complete short structured-Markdown replacement that preserves every still-current fact, adds the newly verified state, and removes obsolete state. `update_state` replaces the current narrative with this body and archives the prior body.
+
+Render the exact complete replacement body with its evidence. In hosted team mode, also show the exact baseline `state_revision`. Tell the user that approval must come in a later reply, end the turn, and do not call `update_state` in that turn. A summary confirmation is not state-write approval. The skill must never stage or submit a partial state delta.
+
+### Open-question staging
+
+Render the exact open-question entry and exact context as they would be passed to `flag_question`. Tell the user that approval must come in a later reply, end the turn, and do not call `flag_question` in that turn. A summary confirmation is not question-write approval.
+
+## Step 8 - Recheck, write once, and stop on drift
+
+When the user's later reply explicitly approves the exact staged payload, recheck it before any write or pending submission:
+
+- For a decision, rerun `check_decision`, triage the headers, and read in full every decision used in reasoning. If the related set, status, supersession, operation, or assessment changed, render the revised complete proposal and require fresh approval from another later reply.
+- For state in local or pre-team mode, reread `state_current.md` immediately before writing with `get_raw_file(path="state_current.md", project_id=...)` and compare the exact returned content with the staging baseline. Any intervening state change invalidates the approval. Recompose the complete replacement from the new current state, render it, and require fresh approval from another later reply. Re-verify the present-tense facts. If the exact replacement body must change for any other reason, render the changed body and require fresh approval.
+- For state in hosted team mode, reread current state through the same hosted state-read surface immediately before writing and compare both the exact content and exact revision with the approved baseline. Any intervening content or revision change invalidates the approval. Recompose the complete replacement from the new current state, render it with the new baseline revision, and require fresh approval from another later reply. Re-verify the present-tense facts. If the exact replacement body must change for any other reason, render the changed body and require fresh approval. If the required revision read or guarded write is unavailable, stop and defer the team-mode state write.
+- For an open question, recheck the current open-question record and related decisions. If the exact open-question entry or context must change, render the changed payload and require fresh approval from another later reply.
+
+Changed overlap or changed payload means the prior approval is stale. Never stretch approval to cover a modified write.
+
+If the approved payload remains exact, follow its authority path.
+
+For a decision in local or pre-team mode, make only the approved operation-specific call:
+
+- Add: `propose_decision(project_id=..., title=..., rationale=..., operation="add", rejected=..., confidence=..., decision_type=..., reversibility=..., files_affected=..., resolves_questions=...)`
+- Update: `propose_decision(project_id=..., rationale=..., operation="update", affected_decision_id=...)`
+- Supersede: `propose_decision(project_id=..., title=..., rationale=..., operation="supersede", affected_decision_id=..., rejected=..., confidence=..., decision_type=..., reversibility=..., files_affected=..., resolves_questions=...)`
+
+In team mode, submit the same exact operation-specific content through `propose_decision` as a pending proposal. Report the returned pending result or secure review link. Canonical ratification requires an authenticated first-party web action bound to the exact proposal revision and digest. Do not claim that the chat reply committed the decision.
+
+For the other write classes, make only the approved call:
+
+- State in local or pre-team mode: `update_state(delta=<exact approved complete replacement body>, project_id=...)`
+- State in hosted team mode: call `update_state` with `delta` set to the exact approved complete replacement body, `project_id` set to the resolved project, and `expected_revision` set to the exact approved baseline `state_revision`.
+- Question: `flag_question(question=<exact approved question>, context=<exact approved context>, project_id=...)`
+
+Capture and report the tool result. Do not assume that approval means the write succeeded. If another staged item remains, present it through its own separate later-reply approval gate.
+
+## Rules
+
+- The interview runs in the main agent context and waits after every question round.
+- The dependency tree is session state, not project truth.
+- Verify facts from repository or system evidence. Ask the user for judgment and rationale, not discoverable facts.
+- Check every live approach against Nauro decisions. Read every decision used in reasoning in full.
+- Existing `CONTEXT.md` and ADR content is evidence only. Never edit or generate those files in this workflow.
+- Shared-understanding confirmation is never write approval.
+- Decision proposals, state replacements, and open-question entries use separate exact-payload gates and explicit approval from a later user reply. In team mode, that reply authorizes pending proposal submission only.
+- State approval covers one complete replacement body derived from one exact current-state baseline. In hosted team mode, the baseline includes both exact content and exact revision, and the write supplies that revision as `expected_revision`. It never covers a partial delta or a replacement derived after an intervening content or revision change.
+- Team-mode project judgment becomes canonical only through authenticated first-party web ratification of the exact proposal revision and digest.
+- Recheck before every write or pending submission. Any changed overlap, operation, evidence, or payload requires fresh approval.
+- On any tool error, evidence conflict, or surprise, stop and surface it to the user. Do not recover silently.

--- a/.claude/skills/nauro-interview/SKILL.md
+++ b/.claude/skills/nauro-interview/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: nauro-interview
+description: Interview the user to elicit tacit project reasoning or challenge a proposed choice against Nauro decisions and repository evidence, then classify the result as shared understanding without granting write authority. Use only when the user explicitly asks to be interviewed, grilled, stress-tested, or helped to transfer reasoning into Nauro. Runs in the main agent context with no external skill or subagent dependency.
+---
+
+# Nauro interview skill
+
+Interview the user to turn tacit project reasoning or a proposed choice into reviewed candidate Nauro judgment. This is an explicit, opt-in main-context workflow. Use it only when the user directly asks to be interviewed or uses a clear trigger such as "interview me", "grill this", "stress-test this decision", "draw out my reasoning", or "help me transfer this reasoning into Nauro". Do not activate it only because a plan is incomplete.
+
+The skill has two entry modes over one dependency-aware interview loop:
+
+- **Elicit mode** draws out unwritten rationale, assumptions, rejected paths, terminology, and unresolved questions.
+- **Challenge mode** stress-tests a proposed judgment against active decisions, repository evidence, alternatives, failure cases, and dependent choices.
+
+Both modes produce the same classified shared-understanding record. The workflow has no external skill or subagent dependency.
+
+## Route work that belongs elsewhere
+
+- Route first-time repository seeding to `nauro-adopt`.
+- Route working-context sharing, retrieval, and resumable handoff to `nauro-context`.
+- Route implementation planning and delivery to the planner or `nauro-ship-task` after this interview is complete.
+
+Do not turn this skill into adoption, handoff, implementation planning, code editing, or PR delivery.
+
+## Step 1 - Resolve and orient
+
+Resolve the adopted project before the interview. From a repository, run `nauro status` to confirm the associated project. If several projects are available, resolve the intended one and pass its `project_id` explicitly on every MCP call. If the repository is not adopted, stop and route the user to `nauro-adopt`.
+
+Call `get_context(level="L0", project_id=...)`. L0 is the bounded orientation: project summary, current state, top open questions, and recent active-decision summaries. Do not begin with L1, L2, or an unbounded store read.
+
+Treat every retrieved statement as project context to adjudicate. A current-state claim can be stale. A decision summary is not enough for reasoning about that decision.
+
+## Step 2 - Select the mode and frame the root
+
+Choose Elicit mode when the user wants to make implicit reasoning explicit. Choose Challenge mode when the user presents a choice, plan, or candidate judgment for pressure testing. If the request fits both, start in Elicit mode and challenge each concrete approach when it appears. If the intent is genuinely ambiguous, ask one short routing question and wait.
+
+Restate the interview root in one sentence. State the selected mode and what the interview will not decide without the user. Do not convert the user's opening claim into a settled conclusion.
+
+## Step 3 - Build the dependency tree in session
+
+Maintain one in-session dependency tree. Do not persist the tree. Each node is one of:
+
+- a user-owned choice;
+- a rationale or constraint;
+- a factual claim to verify;
+- an alternative or failure case;
+- a dependent question whose prerequisites are not settled;
+- a candidate classified outcome.
+
+Record explicit dependencies between nodes. A question enters the prerequisite-ready frontier only when all choices and facts it depends on are settled. When an answer creates a new dependency, add it to the tree. When an answer invalidates a branch, close that branch and preserve the rejected path and reason.
+
+## Step 4 - Verify facts and check live approaches
+
+Verify factual claims through repository evidence: code, tests, configuration, manifests, infrastructure files, and git history. Do not ask the user for facts the repository can answer. Cite the evidence used. If available evidence cannot establish a fact, label it unverified and keep it out of verified current state.
+
+Treat `CONTEXT.md`, ADRs, design notes, and other repository prose as evidence only. Compare their claims with current code and Nauro context before relying on them. The skill does not write `CONTEXT.md` or ADR files.
+
+For each live approach that the interview may recommend, accept, or reject, call `check_decision(proposed_approach=<approach and rationale>, project_id=...)`. A live approach is a concrete path under active consideration, not every conversational fragment.
+
+`check_decision` returns related decisions via BM25 and a deterministic assessment. It does NOT judge conflicts.
+
+Triage the inline headers for status and supersession. Related hits carry their triage headers inline; before proposing, call `get_decision` (`mode=full`) on each decision you reason about. Call `get_decision(number=N, mode="full", project_id=...)` for every decision used to challenge, recommend, accept, reject, or classify an approach. Do not reason from a header or summary alone.
+
+If repository evidence or a full decision changes the tree, show the conflict or constraint to the user before asking the dependent question.
+
+## Step 5 - Ask the prerequisite-ready frontier
+
+Ask the whole prerequisite-ready frontier in a round. Do not ask downstream questions early. Keep each question atomic and name the decision it unlocks.
+
+For each question, provide:
+
+1. The question.
+2. Why it is ready now.
+3. A recommendation.
+4. The evidence and active decisions behind the recommendation.
+5. The material tradeoffs and credible alternatives.
+
+Every question must include a recommendation. When evidence cannot support a substantive choice, recommend deferring the choice or preserving it as unresolved. State why, and state the tradeoffs between waiting and deciding under uncertainty.
+
+Do not present an agent recommendation as project authority. The user owns every choice. After the round, wait for the user's reply. Do not answer a user-owned choice on the user's behalf. Integrate the reply, update the dependency tree, verify any new factual claims, check new live approaches, and ask the next prerequisite-ready frontier.
+
+Continue until the user ends the interview or no unresolved node can change a classified outcome. If a blocker cannot be resolved from evidence or user judgment, preserve it as an open question instead of guessing.
+
+## Step 6 - Classify the outcome
+
+When the frontier is empty, render one shared-understanding summary. Classify each outcome into exactly one of these record classes:
+
+- **Terminology**: a term and its session meaning. It remains noncanonical unless it expresses a durable, reasoned choice that is separately ratified.
+- **Verified current state**: a present-tense fact established by current repository or system evidence. Never place future design here.
+- **Open question**: a concrete unresolved ask that matters to later judgment or work.
+- **Non-durable detail**: useful session detail that does not belong in project truth.
+- **Candidate durable judgment**: a reasoned project choice with constraints, tradeoffs, rejected alternatives, and consequences that may merit a decision.
+
+For each item, show its evidence, related decisions, confidence, and remaining uncertainty. Ask the user to correct or confirm the shared understanding, then end the turn and wait.
+
+Shared understanding is non-authoritative. Confirmation means the summary accurately reflects the interview. It does not approve any Nauro store mutation. Interview agreement never grants write authority.
+
+## Step 7 - Stage writes without authority
+
+After the user confirms shared understanding, determine which classified items could update Nauro. Do not write yet. Keep the three write classes separate:
+
+1. Candidate durable judgment may produce one decision proposal.
+2. Verified current state may produce one exact complete state replacement.
+3. Open question may produce one exact open-question entry and its exact context.
+
+Terminology and non-durable detail produce no write. Stage one payload at a time. Each write class has a separate later-reply approval gate. Approval for one payload does not authorize another payload or class.
+
+### Decision staging
+
+Before staging a decision, rerun `check_decision` for the final candidate, triage the inline headers, and read every decision used in the operation classification with `get_decision` in full. Classify the proposal as `add`, `update`, or `supersede`.
+
+Pick the right `operation`:
+- `add` (default) - genuinely new ground.
+- `update` - rationale-only; needs `affected_decision_id`. The server rejects `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, and `rejected` - use supersede for those.
+- `supersede` - replace a decision this one contradicts or wholly subsumes; needs `affected_decision_id`.
+
+Default to `add` when uncertain - a later proposal can update or supersede it; a wrong supersede is hard to reverse.
+
+Do not invent rationale. Record only what was actually decided, with the reasoning that supports it.
+
+Determine the project's ratification mode from Nauro before presenting the proposal. Do not infer team mode from a cloud link, repository membership, or the conversation.
+
+Render the complete operation-specific proposal as readable Markdown, including the operation, affected decision when applicable, rationale, rejected alternatives, confidence, type, reversibility, files affected, resolved questions, related decisions, and the agent's overlap assessment. Make the rendered proposal the final text of the turn. Do not call `propose_decision` in that turn.
+
+- **Local or pre-team mode**: before the proposal, tell the user that explicit approval in a later chat reply may authorize the exact `propose_decision` call and commit the decision after validation.
+- **Team mode**: before the proposal, tell the user that a later chat reply may authorize submission of the exact pending proposal, but chat approval cannot ratify project judgment. The later first-party ratification step remains mandatory.
+
+### State staging
+
+Determine the project's state-write mode and inspect the active state read and `update_state` schemas before staging a replacement.
+
+- **Local or pre-team mode**: read fresh current state with `get_raw_file(path="state_current.md", project_id=...)` and retain the exact returned content as the staging baseline.
+- **Hosted team mode**: read fresh current state through the active hosted state-read surface and retain the exact returned content and exact `state_revision` as the staging baseline. Confirm that the active `update_state` schema accepts `expected_revision`. If the read does not return an exact state revision or the write schema cannot accept it, stop and defer the team-mode state write. Never fall back to an unguarded team-mode state write.
+
+Compose the complete short structured-Markdown replacement that preserves every still-current fact, adds the newly verified state, and removes obsolete state. `update_state` replaces the current narrative with this body and archives the prior body.
+
+Render the exact complete replacement body with its evidence. In hosted team mode, also show the exact baseline `state_revision`. Tell the user that approval must come in a later reply, end the turn, and do not call `update_state` in that turn. A summary confirmation is not state-write approval. The skill must never stage or submit a partial state delta.
+
+### Open-question staging
+
+Render the exact open-question entry and exact context as they would be passed to `flag_question`. Tell the user that approval must come in a later reply, end the turn, and do not call `flag_question` in that turn. A summary confirmation is not question-write approval.
+
+## Step 8 - Recheck, write once, and stop on drift
+
+When the user's later reply explicitly approves the exact staged payload, recheck it before any write or pending submission:
+
+- For a decision, rerun `check_decision`, triage the headers, and read in full every decision used in reasoning. If the related set, status, supersession, operation, or assessment changed, render the revised complete proposal and require fresh approval from another later reply.
+- For state in local or pre-team mode, reread `state_current.md` immediately before writing with `get_raw_file(path="state_current.md", project_id=...)` and compare the exact returned content with the staging baseline. Any intervening state change invalidates the approval. Recompose the complete replacement from the new current state, render it, and require fresh approval from another later reply. Re-verify the present-tense facts. If the exact replacement body must change for any other reason, render the changed body and require fresh approval.
+- For state in hosted team mode, reread current state through the same hosted state-read surface immediately before writing and compare both the exact content and exact revision with the approved baseline. Any intervening content or revision change invalidates the approval. Recompose the complete replacement from the new current state, render it with the new baseline revision, and require fresh approval from another later reply. Re-verify the present-tense facts. If the exact replacement body must change for any other reason, render the changed body and require fresh approval. If the required revision read or guarded write is unavailable, stop and defer the team-mode state write.
+- For an open question, recheck the current open-question record and related decisions. If the exact open-question entry or context must change, render the changed payload and require fresh approval from another later reply.
+
+Changed overlap or changed payload means the prior approval is stale. Never stretch approval to cover a modified write.
+
+If the approved payload remains exact, follow its authority path.
+
+For a decision in local or pre-team mode, make only the approved operation-specific call:
+
+- Add: `propose_decision(project_id=..., title=..., rationale=..., operation="add", rejected=..., confidence=..., decision_type=..., reversibility=..., files_affected=..., resolves_questions=...)`
+- Update: `propose_decision(project_id=..., rationale=..., operation="update", affected_decision_id=...)`
+- Supersede: `propose_decision(project_id=..., title=..., rationale=..., operation="supersede", affected_decision_id=..., rejected=..., confidence=..., decision_type=..., reversibility=..., files_affected=..., resolves_questions=...)`
+
+In team mode, submit the same exact operation-specific content through `propose_decision` as a pending proposal. Report the returned pending result or secure review link. Canonical ratification requires an authenticated first-party web action bound to the exact proposal revision and digest. Do not claim that the chat reply committed the decision.
+
+For the other write classes, make only the approved call:
+
+- State in local or pre-team mode: `update_state(delta=<exact approved complete replacement body>, project_id=...)`
+- State in hosted team mode: call `update_state` with `delta` set to the exact approved complete replacement body, `project_id` set to the resolved project, and `expected_revision` set to the exact approved baseline `state_revision`.
+- Question: `flag_question(question=<exact approved question>, context=<exact approved context>, project_id=...)`
+
+Capture and report the tool result. Do not assume that approval means the write succeeded. If another staged item remains, present it through its own separate later-reply approval gate.
+
+## Rules
+
+- The interview runs in the main agent context and waits after every question round.
+- The dependency tree is session state, not project truth.
+- Verify facts from repository or system evidence. Ask the user for judgment and rationale, not discoverable facts.
+- Check every live approach against Nauro decisions. Read every decision used in reasoning in full.
+- Existing `CONTEXT.md` and ADR content is evidence only. Never edit or generate those files in this workflow.
+- Shared-understanding confirmation is never write approval.
+- Decision proposals, state replacements, and open-question entries use separate exact-payload gates and explicit approval from a later user reply. In team mode, that reply authorizes pending proposal submission only.
+- State approval covers one complete replacement body derived from one exact current-state baseline. In hosted team mode, the baseline includes both exact content and exact revision, and the write supplies that revision as `expected_revision`. It never covers a partial delta or a replacement derived after an intervening content or revision change.
+- Team-mode project judgment becomes canonical only through authenticated first-party web ratification of the exact proposal revision and digest.
+- Recheck before every write or pending submission. Any changed overlap, operation, evidence, or payload requires fresh approval.
+- On any tool error, evidence conflict, or surprise, stop and surface it to the user. Do not recover silently.

--- a/.cursor/rules/nauro-interview.mdc
+++ b/.cursor/rules/nauro-interview.mdc
@@ -1,0 +1,184 @@
+---
+description: Interview the user to elicit tacit project reasoning or challenge a proposed choice against Nauro decisions and repository evidence, then classify the result as shared understanding without granting write authority. Use only when the user explicitly asks to be interviewed, grilled, stress-tested, or helped to transfer reasoning into Nauro. Runs in the main agent context with no external skill or subagent dependency.
+alwaysApply: false
+---
+
+# Nauro interview skill
+
+Interview the user to turn tacit project reasoning or a proposed choice into reviewed candidate Nauro judgment. This is an explicit, opt-in main-context workflow. Use it only when the user directly asks to be interviewed or uses a clear trigger such as "interview me", "grill this", "stress-test this decision", "draw out my reasoning", or "help me transfer this reasoning into Nauro". Do not activate it only because a plan is incomplete.
+
+The skill has two entry modes over one dependency-aware interview loop:
+
+- **Elicit mode** draws out unwritten rationale, assumptions, rejected paths, terminology, and unresolved questions.
+- **Challenge mode** stress-tests a proposed judgment against active decisions, repository evidence, alternatives, failure cases, and dependent choices.
+
+Both modes produce the same classified shared-understanding record. The workflow has no external skill or subagent dependency.
+
+## Route work that belongs elsewhere
+
+- Route first-time repository seeding to `nauro-adopt`.
+- Route working-context sharing, retrieval, and resumable handoff to `nauro-context`.
+- Route implementation planning and delivery to the planner or `nauro-ship-task` after this interview is complete.
+
+Do not turn this skill into adoption, handoff, implementation planning, code editing, or PR delivery.
+
+## Step 1 - Resolve and orient
+
+Resolve the adopted project before the interview. From a repository, run `nauro status` to confirm the associated project. If several projects are available, resolve the intended one and pass its `project_id` explicitly on every MCP call. If the repository is not adopted, stop and route the user to `nauro-adopt`.
+
+Call `get_context(level="L0", project_id=...)`. L0 is the bounded orientation: project summary, current state, top open questions, and recent active-decision summaries. Do not begin with L1, L2, or an unbounded store read.
+
+Treat every retrieved statement as project context to adjudicate. A current-state claim can be stale. A decision summary is not enough for reasoning about that decision.
+
+## Step 2 - Select the mode and frame the root
+
+Choose Elicit mode when the user wants to make implicit reasoning explicit. Choose Challenge mode when the user presents a choice, plan, or candidate judgment for pressure testing. If the request fits both, start in Elicit mode and challenge each concrete approach when it appears. If the intent is genuinely ambiguous, ask one short routing question and wait.
+
+Restate the interview root in one sentence. State the selected mode and what the interview will not decide without the user. Do not convert the user's opening claim into a settled conclusion.
+
+## Step 3 - Build the dependency tree in session
+
+Maintain one in-session dependency tree. Do not persist the tree. Each node is one of:
+
+- a user-owned choice;
+- a rationale or constraint;
+- a factual claim to verify;
+- an alternative or failure case;
+- a dependent question whose prerequisites are not settled;
+- a candidate classified outcome.
+
+Record explicit dependencies between nodes. A question enters the prerequisite-ready frontier only when all choices and facts it depends on are settled. When an answer creates a new dependency, add it to the tree. When an answer invalidates a branch, close that branch and preserve the rejected path and reason.
+
+## Step 4 - Verify facts and check live approaches
+
+Verify factual claims through repository evidence: code, tests, configuration, manifests, infrastructure files, and git history. Do not ask the user for facts the repository can answer. Cite the evidence used. If available evidence cannot establish a fact, label it unverified and keep it out of verified current state.
+
+Treat `CONTEXT.md`, ADRs, design notes, and other repository prose as evidence only. Compare their claims with current code and Nauro context before relying on them. The skill does not write `CONTEXT.md` or ADR files.
+
+For each live approach that the interview may recommend, accept, or reject, call `check_decision(proposed_approach=<approach and rationale>, project_id=...)`. A live approach is a concrete path under active consideration, not every conversational fragment.
+
+`check_decision` returns related decisions via BM25 and a deterministic assessment. It does NOT judge conflicts.
+
+Triage the inline headers for status and supersession. Related hits carry their triage headers inline; before proposing, call `get_decision` (`mode=full`) on each decision you reason about. Call `get_decision(number=N, mode="full", project_id=...)` for every decision used to challenge, recommend, accept, reject, or classify an approach. Do not reason from a header or summary alone.
+
+If repository evidence or a full decision changes the tree, show the conflict or constraint to the user before asking the dependent question.
+
+## Step 5 - Ask the prerequisite-ready frontier
+
+Ask the whole prerequisite-ready frontier in a round. Do not ask downstream questions early. Keep each question atomic and name the decision it unlocks.
+
+For each question, provide:
+
+1. The question.
+2. Why it is ready now.
+3. A recommendation.
+4. The evidence and active decisions behind the recommendation.
+5. The material tradeoffs and credible alternatives.
+
+Every question must include a recommendation. When evidence cannot support a substantive choice, recommend deferring the choice or preserving it as unresolved. State why, and state the tradeoffs between waiting and deciding under uncertainty.
+
+Do not present an agent recommendation as project authority. The user owns every choice. After the round, wait for the user's reply. Do not answer a user-owned choice on the user's behalf. Integrate the reply, update the dependency tree, verify any new factual claims, check new live approaches, and ask the next prerequisite-ready frontier.
+
+Continue until the user ends the interview or no unresolved node can change a classified outcome. If a blocker cannot be resolved from evidence or user judgment, preserve it as an open question instead of guessing.
+
+## Step 6 - Classify the outcome
+
+When the frontier is empty, render one shared-understanding summary. Classify each outcome into exactly one of these record classes:
+
+- **Terminology**: a term and its session meaning. It remains noncanonical unless it expresses a durable, reasoned choice that is separately ratified.
+- **Verified current state**: a present-tense fact established by current repository or system evidence. Never place future design here.
+- **Open question**: a concrete unresolved ask that matters to later judgment or work.
+- **Non-durable detail**: useful session detail that does not belong in project truth.
+- **Candidate durable judgment**: a reasoned project choice with constraints, tradeoffs, rejected alternatives, and consequences that may merit a decision.
+
+For each item, show its evidence, related decisions, confidence, and remaining uncertainty. Ask the user to correct or confirm the shared understanding, then end the turn and wait.
+
+Shared understanding is non-authoritative. Confirmation means the summary accurately reflects the interview. It does not approve any Nauro store mutation. Interview agreement never grants write authority.
+
+## Step 7 - Stage writes without authority
+
+After the user confirms shared understanding, determine which classified items could update Nauro. Do not write yet. Keep the three write classes separate:
+
+1. Candidate durable judgment may produce one decision proposal.
+2. Verified current state may produce one exact complete state replacement.
+3. Open question may produce one exact open-question entry and its exact context.
+
+Terminology and non-durable detail produce no write. Stage one payload at a time. Each write class has a separate later-reply approval gate. Approval for one payload does not authorize another payload or class.
+
+### Decision staging
+
+Before staging a decision, rerun `check_decision` for the final candidate, triage the inline headers, and read every decision used in the operation classification with `get_decision` in full. Classify the proposal as `add`, `update`, or `supersede`.
+
+Pick the right `operation`:
+- `add` (default) - genuinely new ground.
+- `update` - rationale-only; needs `affected_decision_id`. The server rejects `title`, `confidence`, `decision_type`, `reversibility`, `files_affected`, and `rejected` - use supersede for those.
+- `supersede` - replace a decision this one contradicts or wholly subsumes; needs `affected_decision_id`.
+
+Default to `add` when uncertain - a later proposal can update or supersede it; a wrong supersede is hard to reverse.
+
+Do not invent rationale. Record only what was actually decided, with the reasoning that supports it.
+
+Determine the project's ratification mode from Nauro before presenting the proposal. Do not infer team mode from a cloud link, repository membership, or the conversation.
+
+Render the complete operation-specific proposal as readable Markdown, including the operation, affected decision when applicable, rationale, rejected alternatives, confidence, type, reversibility, files affected, resolved questions, related decisions, and the agent's overlap assessment. Make the rendered proposal the final text of the turn. Do not call `propose_decision` in that turn.
+
+- **Local or pre-team mode**: before the proposal, tell the user that explicit approval in a later chat reply may authorize the exact `propose_decision` call and commit the decision after validation.
+- **Team mode**: before the proposal, tell the user that a later chat reply may authorize submission of the exact pending proposal, but chat approval cannot ratify project judgment. The later first-party ratification step remains mandatory.
+
+### State staging
+
+Determine the project's state-write mode and inspect the active state read and `update_state` schemas before staging a replacement.
+
+- **Local or pre-team mode**: read fresh current state with `get_raw_file(path="state_current.md", project_id=...)` and retain the exact returned content as the staging baseline.
+- **Hosted team mode**: read fresh current state through the active hosted state-read surface and retain the exact returned content and exact `state_revision` as the staging baseline. Confirm that the active `update_state` schema accepts `expected_revision`. If the read does not return an exact state revision or the write schema cannot accept it, stop and defer the team-mode state write. Never fall back to an unguarded team-mode state write.
+
+Compose the complete short structured-Markdown replacement that preserves every still-current fact, adds the newly verified state, and removes obsolete state. `update_state` replaces the current narrative with this body and archives the prior body.
+
+Render the exact complete replacement body with its evidence. In hosted team mode, also show the exact baseline `state_revision`. Tell the user that approval must come in a later reply, end the turn, and do not call `update_state` in that turn. A summary confirmation is not state-write approval. The skill must never stage or submit a partial state delta.
+
+### Open-question staging
+
+Render the exact open-question entry and exact context as they would be passed to `flag_question`. Tell the user that approval must come in a later reply, end the turn, and do not call `flag_question` in that turn. A summary confirmation is not question-write approval.
+
+## Step 8 - Recheck, write once, and stop on drift
+
+When the user's later reply explicitly approves the exact staged payload, recheck it before any write or pending submission:
+
+- For a decision, rerun `check_decision`, triage the headers, and read in full every decision used in reasoning. If the related set, status, supersession, operation, or assessment changed, render the revised complete proposal and require fresh approval from another later reply.
+- For state in local or pre-team mode, reread `state_current.md` immediately before writing with `get_raw_file(path="state_current.md", project_id=...)` and compare the exact returned content with the staging baseline. Any intervening state change invalidates the approval. Recompose the complete replacement from the new current state, render it, and require fresh approval from another later reply. Re-verify the present-tense facts. If the exact replacement body must change for any other reason, render the changed body and require fresh approval.
+- For state in hosted team mode, reread current state through the same hosted state-read surface immediately before writing and compare both the exact content and exact revision with the approved baseline. Any intervening content or revision change invalidates the approval. Recompose the complete replacement from the new current state, render it with the new baseline revision, and require fresh approval from another later reply. Re-verify the present-tense facts. If the exact replacement body must change for any other reason, render the changed body and require fresh approval. If the required revision read or guarded write is unavailable, stop and defer the team-mode state write.
+- For an open question, recheck the current open-question record and related decisions. If the exact open-question entry or context must change, render the changed payload and require fresh approval from another later reply.
+
+Changed overlap or changed payload means the prior approval is stale. Never stretch approval to cover a modified write.
+
+If the approved payload remains exact, follow its authority path.
+
+For a decision in local or pre-team mode, make only the approved operation-specific call:
+
+- Add: `propose_decision(project_id=..., title=..., rationale=..., operation="add", rejected=..., confidence=..., decision_type=..., reversibility=..., files_affected=..., resolves_questions=...)`
+- Update: `propose_decision(project_id=..., rationale=..., operation="update", affected_decision_id=...)`
+- Supersede: `propose_decision(project_id=..., title=..., rationale=..., operation="supersede", affected_decision_id=..., rejected=..., confidence=..., decision_type=..., reversibility=..., files_affected=..., resolves_questions=...)`
+
+In team mode, submit the same exact operation-specific content through `propose_decision` as a pending proposal. Report the returned pending result or secure review link. Canonical ratification requires an authenticated first-party web action bound to the exact proposal revision and digest. Do not claim that the chat reply committed the decision.
+
+For the other write classes, make only the approved call:
+
+- State in local or pre-team mode: `update_state(delta=<exact approved complete replacement body>, project_id=...)`
+- State in hosted team mode: call `update_state` with `delta` set to the exact approved complete replacement body, `project_id` set to the resolved project, and `expected_revision` set to the exact approved baseline `state_revision`.
+- Question: `flag_question(question=<exact approved question>, context=<exact approved context>, project_id=...)`
+
+Capture and report the tool result. Do not assume that approval means the write succeeded. If another staged item remains, present it through its own separate later-reply approval gate.
+
+## Rules
+
+- The interview runs in the main agent context and waits after every question round.
+- The dependency tree is session state, not project truth.
+- Verify facts from repository or system evidence. Ask the user for judgment and rationale, not discoverable facts.
+- Check every live approach against Nauro decisions. Read every decision used in reasoning in full.
+- Existing `CONTEXT.md` and ADR content is evidence only. Never edit or generate those files in this workflow.
+- Shared-understanding confirmation is never write approval.
+- Decision proposals, state replacements, and open-question entries use separate exact-payload gates and explicit approval from a later user reply. In team mode, that reply authorizes pending proposal submission only.
+- State approval covers one complete replacement body derived from one exact current-state baseline. In hosted team mode, the baseline includes both exact content and exact revision, and the write supplies that revision as `expected_revision`. It never covers a partial delta or a replacement derived after an intervening content or revision change.
+- Team-mode project judgment becomes canonical only through authenticated first-party web ratification of the exact proposal revision and digest.
+- Recheck before every write or pending submission. Any changed overlap, operation, evidence, or payload requires fresh approval.
+- On any tool error, evidence conflict, or surprise, stop and surface it to the user. Do not recover silently.

--- a/packages/nauro/src/nauro/skills/__init__.py
+++ b/packages/nauro/src/nauro/skills/__init__.py
@@ -22,7 +22,13 @@ from typing import Literal
 from nauro_core.protocol import substitute_protocol_fragments
 
 Surface = Literal["claude_code", "cursor", "codex"]
-SkillName = Literal["nauro-adopt", "nauro-ship-task", "nauro-context", "nauro-loop"]
+SkillName = Literal[
+    "nauro-adopt",
+    "nauro-ship-task",
+    "nauro-context",
+    "nauro-loop",
+    "nauro-interview",
+]
 
 _SHIP_TASK_PREREQUISITES_TOKEN = "<!-- surface:SHIP_TASK_PREREQUISITES -->"
 
@@ -127,6 +133,14 @@ SKILL_DESCRIPTIONS: dict[str, str] = {
         "an empty mine and at a hard per-session ceiling. Installed by `nauro "
         "adopt --with-skills`."
     ),
+    "nauro-interview": (
+        "Interview the user to elicit tacit project reasoning or challenge a proposed "
+        "choice against Nauro decisions and repository evidence, then classify the "
+        "result as shared understanding without granting write authority. Use only "
+        "when the user explicitly asks to be interviewed, grilled, stress-tested, or "
+        "helped to transfer reasoning into Nauro. Runs in the main agent context with "
+        "no external skill or subagent dependency."
+    ),
 }
 
 
@@ -181,6 +195,12 @@ def load_loop_body() -> str:
     return substitute_protocol_fragments(_strip_template_header(raw))
 
 
+def load_interview_body() -> str:
+    """Return the ``nauro-interview`` skill body with protocol fragments resolved."""
+    raw = resources.files(__package__).joinpath("interview_body.md").read_text(encoding="utf-8")
+    return substitute_protocol_fragments(_strip_template_header(raw))
+
+
 def _load_body(surface: str, skill_name: str) -> str:
     if skill_name == "nauro-adopt":
         return load_adopt_body()
@@ -190,6 +210,8 @@ def _load_body(surface: str, skill_name: str) -> str:
         return load_context_body()
     if skill_name == "nauro-loop":
         return load_loop_body()
+    if skill_name == "nauro-interview":
+        return load_interview_body()
     raise ValueError(f"unknown skill: {skill_name!r}")
 
 
@@ -219,6 +241,7 @@ __all__ = [
     "Surface",
     "load_adopt_body",
     "load_context_body",
+    "load_interview_body",
     "load_loop_body",
     "load_ship_task_body",
     "render_skill",

--- a/packages/nauro/src/nauro/skills/interview_body.md
+++ b/packages/nauro/src/nauro/skills/interview_body.md
@@ -1,0 +1,179 @@
+<!-- Source template. The dogfood files under .claude/, .cursor/, .agents/
+     are the rendered surface. Surface frontmatter is added by render_skill(). -->
+
+# Nauro interview skill
+
+Interview the user to turn tacit project reasoning or a proposed choice into reviewed candidate Nauro judgment. This is an explicit, opt-in main-context workflow. Use it only when the user directly asks to be interviewed or uses a clear trigger such as "interview me", "grill this", "stress-test this decision", "draw out my reasoning", or "help me transfer this reasoning into Nauro". Do not activate it only because a plan is incomplete.
+
+The skill has two entry modes over one dependency-aware interview loop:
+
+- **Elicit mode** draws out unwritten rationale, assumptions, rejected paths, terminology, and unresolved questions.
+- **Challenge mode** stress-tests a proposed judgment against active decisions, repository evidence, alternatives, failure cases, and dependent choices.
+
+Both modes produce the same classified shared-understanding record. The workflow has no external skill or subagent dependency.
+
+## Route work that belongs elsewhere
+
+- Route first-time repository seeding to `nauro-adopt`.
+- Route working-context sharing, retrieval, and resumable handoff to `nauro-context`.
+- Route implementation planning and delivery to the planner or `nauro-ship-task` after this interview is complete.
+
+Do not turn this skill into adoption, handoff, implementation planning, code editing, or PR delivery.
+
+## Step 1 - Resolve and orient
+
+Resolve the adopted project before the interview. From a repository, run `nauro status` to confirm the associated project. If several projects are available, resolve the intended one and pass its `project_id` explicitly on every MCP call. If the repository is not adopted, stop and route the user to `nauro-adopt`.
+
+Call `get_context(level="L0", project_id=...)`. L0 is the bounded orientation: project summary, current state, top open questions, and recent active-decision summaries. Do not begin with L1, L2, or an unbounded store read.
+
+Treat every retrieved statement as project context to adjudicate. A current-state claim can be stale. A decision summary is not enough for reasoning about that decision.
+
+## Step 2 - Select the mode and frame the root
+
+Choose Elicit mode when the user wants to make implicit reasoning explicit. Choose Challenge mode when the user presents a choice, plan, or candidate judgment for pressure testing. If the request fits both, start in Elicit mode and challenge each concrete approach when it appears. If the intent is genuinely ambiguous, ask one short routing question and wait.
+
+Restate the interview root in one sentence. State the selected mode and what the interview will not decide without the user. Do not convert the user's opening claim into a settled conclusion.
+
+## Step 3 - Build the dependency tree in session
+
+Maintain one in-session dependency tree. Do not persist the tree. Each node is one of:
+
+- a user-owned choice;
+- a rationale or constraint;
+- a factual claim to verify;
+- an alternative or failure case;
+- a dependent question whose prerequisites are not settled;
+- a candidate classified outcome.
+
+Record explicit dependencies between nodes. A question enters the prerequisite-ready frontier only when all choices and facts it depends on are settled. When an answer creates a new dependency, add it to the tree. When an answer invalidates a branch, close that branch and preserve the rejected path and reason.
+
+## Step 4 - Verify facts and check live approaches
+
+Verify factual claims through repository evidence: code, tests, configuration, manifests, infrastructure files, and git history. Do not ask the user for facts the repository can answer. Cite the evidence used. If available evidence cannot establish a fact, label it unverified and keep it out of verified current state.
+
+Treat `CONTEXT.md`, ADRs, design notes, and other repository prose as evidence only. Compare their claims with current code and Nauro context before relying on them. The skill does not write `CONTEXT.md` or ADR files.
+
+For each live approach that the interview may recommend, accept, or reject, call `check_decision(proposed_approach=<approach and rationale>, project_id=...)`. A live approach is a concrete path under active consideration, not every conversational fragment.
+
+<!-- protocol:CHECK_DECISION_RETURNS -->
+
+Triage the inline headers for status and supersession. <!-- protocol:GET_DECISION_BEFORE_PROPOSING --> Call `get_decision(number=N, mode="full", project_id=...)` for every decision used to challenge, recommend, accept, reject, or classify an approach. Do not reason from a header or summary alone.
+
+If repository evidence or a full decision changes the tree, show the conflict or constraint to the user before asking the dependent question.
+
+## Step 5 - Ask the prerequisite-ready frontier
+
+Ask the whole prerequisite-ready frontier in a round. Do not ask downstream questions early. Keep each question atomic and name the decision it unlocks.
+
+For each question, provide:
+
+1. The question.
+2. Why it is ready now.
+3. A recommendation.
+4. The evidence and active decisions behind the recommendation.
+5. The material tradeoffs and credible alternatives.
+
+Every question must include a recommendation. When evidence cannot support a substantive choice, recommend deferring the choice or preserving it as unresolved. State why, and state the tradeoffs between waiting and deciding under uncertainty.
+
+Do not present an agent recommendation as project authority. The user owns every choice. After the round, wait for the user's reply. Do not answer a user-owned choice on the user's behalf. Integrate the reply, update the dependency tree, verify any new factual claims, check new live approaches, and ask the next prerequisite-ready frontier.
+
+Continue until the user ends the interview or no unresolved node can change a classified outcome. If a blocker cannot be resolved from evidence or user judgment, preserve it as an open question instead of guessing.
+
+## Step 6 - Classify the outcome
+
+When the frontier is empty, render one shared-understanding summary. Classify each outcome into exactly one of these record classes:
+
+- **Terminology**: a term and its session meaning. It remains noncanonical unless it expresses a durable, reasoned choice that is separately ratified.
+- **Verified current state**: a present-tense fact established by current repository or system evidence. Never place future design here.
+- **Open question**: a concrete unresolved ask that matters to later judgment or work.
+- **Non-durable detail**: useful session detail that does not belong in project truth.
+- **Candidate durable judgment**: a reasoned project choice with constraints, tradeoffs, rejected alternatives, and consequences that may merit a decision.
+
+For each item, show its evidence, related decisions, confidence, and remaining uncertainty. Ask the user to correct or confirm the shared understanding, then end the turn and wait.
+
+Shared understanding is non-authoritative. Confirmation means the summary accurately reflects the interview. It does not approve any Nauro store mutation. Interview agreement never grants write authority.
+
+## Step 7 - Stage writes without authority
+
+After the user confirms shared understanding, determine which classified items could update Nauro. Do not write yet. Keep the three write classes separate:
+
+1. Candidate durable judgment may produce one decision proposal.
+2. Verified current state may produce one exact complete state replacement.
+3. Open question may produce one exact open-question entry and its exact context.
+
+Terminology and non-durable detail produce no write. Stage one payload at a time. Each write class has a separate later-reply approval gate. Approval for one payload does not authorize another payload or class.
+
+### Decision staging
+
+Before staging a decision, rerun `check_decision` for the final candidate, triage the inline headers, and read every decision used in the operation classification with `get_decision` in full. Classify the proposal as `add`, `update`, or `supersede`.
+
+<!-- protocol:PROPOSE_DECISION_OPERATIONS -->
+
+<!-- protocol:UPDATE_SUPERSEDE_CARE -->
+
+<!-- protocol:NO_INVENT_RATIONALE -->
+
+Determine the project's ratification mode from Nauro before presenting the proposal. Do not infer team mode from a cloud link, repository membership, or the conversation.
+
+Render the complete operation-specific proposal as readable Markdown, including the operation, affected decision when applicable, rationale, rejected alternatives, confidence, type, reversibility, files affected, resolved questions, related decisions, and the agent's overlap assessment. Make the rendered proposal the final text of the turn. Do not call `propose_decision` in that turn.
+
+- **Local or pre-team mode**: before the proposal, tell the user that explicit approval in a later chat reply may authorize the exact `propose_decision` call and commit the decision after validation.
+- **Team mode**: before the proposal, tell the user that a later chat reply may authorize submission of the exact pending proposal, but chat approval cannot ratify project judgment. The later first-party ratification step remains mandatory.
+
+### State staging
+
+Determine the project's state-write mode and inspect the active state read and `update_state` schemas before staging a replacement.
+
+- **Local or pre-team mode**: read fresh current state with `get_raw_file(path="state_current.md", project_id=...)` and retain the exact returned content as the staging baseline.
+- **Hosted team mode**: read fresh current state through the active hosted state-read surface and retain the exact returned content and exact `state_revision` as the staging baseline. Confirm that the active `update_state` schema accepts `expected_revision`. If the read does not return an exact state revision or the write schema cannot accept it, stop and defer the team-mode state write. Never fall back to an unguarded team-mode state write.
+
+Compose the complete short structured-Markdown replacement that preserves every still-current fact, adds the newly verified state, and removes obsolete state. `update_state` replaces the current narrative with this body and archives the prior body.
+
+Render the exact complete replacement body with its evidence. In hosted team mode, also show the exact baseline `state_revision`. Tell the user that approval must come in a later reply, end the turn, and do not call `update_state` in that turn. A summary confirmation is not state-write approval. The skill must never stage or submit a partial state delta.
+
+### Open-question staging
+
+Render the exact open-question entry and exact context as they would be passed to `flag_question`. Tell the user that approval must come in a later reply, end the turn, and do not call `flag_question` in that turn. A summary confirmation is not question-write approval.
+
+## Step 8 - Recheck, write once, and stop on drift
+
+When the user's later reply explicitly approves the exact staged payload, recheck it before any write or pending submission:
+
+- For a decision, rerun `check_decision`, triage the headers, and read in full every decision used in reasoning. If the related set, status, supersession, operation, or assessment changed, render the revised complete proposal and require fresh approval from another later reply.
+- For state in local or pre-team mode, reread `state_current.md` immediately before writing with `get_raw_file(path="state_current.md", project_id=...)` and compare the exact returned content with the staging baseline. Any intervening state change invalidates the approval. Recompose the complete replacement from the new current state, render it, and require fresh approval from another later reply. Re-verify the present-tense facts. If the exact replacement body must change for any other reason, render the changed body and require fresh approval.
+- For state in hosted team mode, reread current state through the same hosted state-read surface immediately before writing and compare both the exact content and exact revision with the approved baseline. Any intervening content or revision change invalidates the approval. Recompose the complete replacement from the new current state, render it with the new baseline revision, and require fresh approval from another later reply. Re-verify the present-tense facts. If the exact replacement body must change for any other reason, render the changed body and require fresh approval. If the required revision read or guarded write is unavailable, stop and defer the team-mode state write.
+- For an open question, recheck the current open-question record and related decisions. If the exact open-question entry or context must change, render the changed payload and require fresh approval from another later reply.
+
+Changed overlap or changed payload means the prior approval is stale. Never stretch approval to cover a modified write.
+
+If the approved payload remains exact, follow its authority path.
+
+For a decision in local or pre-team mode, make only the approved operation-specific call:
+
+- Add: `propose_decision(project_id=..., title=..., rationale=..., operation="add", rejected=..., confidence=..., decision_type=..., reversibility=..., files_affected=..., resolves_questions=...)`
+- Update: `propose_decision(project_id=..., rationale=..., operation="update", affected_decision_id=...)`
+- Supersede: `propose_decision(project_id=..., title=..., rationale=..., operation="supersede", affected_decision_id=..., rejected=..., confidence=..., decision_type=..., reversibility=..., files_affected=..., resolves_questions=...)`
+
+In team mode, submit the same exact operation-specific content through `propose_decision` as a pending proposal. Report the returned pending result or secure review link. Canonical ratification requires an authenticated first-party web action bound to the exact proposal revision and digest. Do not claim that the chat reply committed the decision.
+
+For the other write classes, make only the approved call:
+
+- State in local or pre-team mode: `update_state(delta=<exact approved complete replacement body>, project_id=...)`
+- State in hosted team mode: call `update_state` with `delta` set to the exact approved complete replacement body, `project_id` set to the resolved project, and `expected_revision` set to the exact approved baseline `state_revision`.
+- Question: `flag_question(question=<exact approved question>, context=<exact approved context>, project_id=...)`
+
+Capture and report the tool result. Do not assume that approval means the write succeeded. If another staged item remains, present it through its own separate later-reply approval gate.
+
+## Rules
+
+- The interview runs in the main agent context and waits after every question round.
+- The dependency tree is session state, not project truth.
+- Verify facts from repository or system evidence. Ask the user for judgment and rationale, not discoverable facts.
+- Check every live approach against Nauro decisions. Read every decision used in reasoning in full.
+- Existing `CONTEXT.md` and ADR content is evidence only. Never edit or generate those files in this workflow.
+- Shared-understanding confirmation is never write approval.
+- Decision proposals, state replacements, and open-question entries use separate exact-payload gates and explicit approval from a later user reply. In team mode, that reply authorizes pending proposal submission only.
+- State approval covers one complete replacement body derived from one exact current-state baseline. In hosted team mode, the baseline includes both exact content and exact revision, and the write supplies that revision as `expected_revision`. It never covers a partial delta or a replacement derived after an intervening content or revision change.
+- Team-mode project judgment becomes canonical only through authenticated first-party web ratification of the exact proposal revision and digest.
+- Recheck before every write or pending submission. Any changed overlap, operation, evidence, or payload requires fresh approval.
+- On any tool error, evidence conflict, or surprise, stop and surface it to the user. Do not recover silently.

--- a/packages/nauro/tests/_skill_surfaces.py
+++ b/packages/nauro/tests/_skill_surfaces.py
@@ -17,6 +17,7 @@ from nauro_core import MCP_INSTRUCTIONS_STATIC
 from nauro.skills import (
     load_adopt_body,
     load_context_body,
+    load_interview_body,
     load_loop_body,
     load_ship_task_body,
 )
@@ -32,6 +33,7 @@ SKILL_SURFACES: dict[str, Callable[[], str]] = {
     "adopt_body.md": load_adopt_body,
     "ship_task_body.md": load_ship_task_body,
     "context_body.md": load_context_body,
+    "interview_body.md": load_interview_body,
     "loop_body.md": load_loop_body,
     "MCP_INSTRUCTIONS_STATIC": lambda: MCP_INSTRUCTIONS_STATIC,
     "docs/adopt-prompt.md": load_docs_adopt_prompt,

--- a/packages/nauro/tests/test_protocol_drift.py
+++ b/packages/nauro/tests/test_protocol_drift.py
@@ -21,7 +21,7 @@ from nauro_core import (
 )
 from nauro_core.protocol import protocol_tokens_in
 
-from nauro.skills import load_adopt_body, render_skill
+from nauro.skills import load_adopt_body, load_interview_body, render_skill
 from tests._skill_surfaces import REPO_ROOT, load_docs_adopt_prompt
 
 # Per-surface fragment manifest. Each rendered surface must contain every
@@ -30,6 +30,11 @@ from tests._skill_surfaces import REPO_ROOT, load_docs_adopt_prompt
 # stay out of this map — silence is allowed, divergence is not.
 SURFACE_FRAGMENTS: dict[str, list[str]] = {
     "adopt": [
+        CHECK_DECISION_RETURNS,
+        GET_DECISION_BEFORE_PROPOSING,
+        NO_INVENT_RATIONALE,
+    ],
+    "interview": [
         CHECK_DECISION_RETURNS,
         GET_DECISION_BEFORE_PROPOSING,
         NO_INVENT_RATIONALE,
@@ -68,6 +73,10 @@ def _adopt_rendered() -> str:
     return render_skill("claude_code", "nauro-adopt")
 
 
+def _interview_rendered() -> str:
+    return render_skill("claude_code", "nauro-interview")
+
+
 def _propose_decision_spec_text() -> str:
     """Flatten the propose_decision ToolSpec into a single string so the
     retired-paraphrase scan covers titles, top-level descriptions, and every
@@ -80,7 +89,7 @@ def _propose_decision_spec_text() -> str:
     return json.dumps(get_tool_spec("propose_decision"), ensure_ascii=False)
 
 
-_RENDERED_LOADERS = {"adopt": _adopt_rendered}
+_RENDERED_LOADERS = {"adopt": _adopt_rendered, "interview": _interview_rendered}
 
 
 @pytest.mark.parametrize(
@@ -128,7 +137,13 @@ def test_adopt_body_mentions_operation_anchor(anchor: str) -> None:
     [
         (s, k)
         for s in ("claude_code", "cursor", "codex")
-        for k in ("nauro-adopt", "nauro-ship-task", "nauro-context", "nauro-loop")
+        for k in (
+            "nauro-adopt",
+            "nauro-ship-task",
+            "nauro-context",
+            "nauro-loop",
+            "nauro-interview",
+        )
     ],
 )
 def test_rendered_skill_has_no_protocol_tokens(surface: str, skill: str) -> None:
@@ -140,6 +155,7 @@ def test_rendered_skill_has_no_protocol_tokens(surface: str, skill: str) -> None
 
 def test_loaders_have_no_protocol_tokens() -> None:
     assert protocol_tokens_in(load_adopt_body()) == []
+    assert protocol_tokens_in(load_interview_body()) == []
 
 
 def test_docs_adopt_prompt_has_no_protocol_tokens() -> None:
@@ -153,7 +169,13 @@ def test_docs_adopt_prompt_has_no_protocol_tokens() -> None:
 # Source templates: only known tokens allowed (catches typos at the source)
 # ─────────────────────────────────────────────────────────────────────────────
 
-SOURCE_TEMPLATE_FILES = ("adopt_body.md", "ship_task_body.md", "context_body.md", "loop_body.md")
+SOURCE_TEMPLATE_FILES = (
+    "adopt_body.md",
+    "ship_task_body.md",
+    "context_body.md",
+    "loop_body.md",
+    "interview_body.md",
+)
 
 
 @pytest.mark.parametrize("template_filename", SOURCE_TEMPLATE_FILES)
@@ -189,6 +211,9 @@ DISTRIBUTION_FILES = (
     ".claude/skills/nauro-loop/SKILL.md",
     ".cursor/rules/nauro-loop.mdc",
     ".agents/skills/nauro-loop/SKILL.md",
+    ".claude/skills/nauro-interview/SKILL.md",
+    ".cursor/rules/nauro-interview.mdc",
+    ".agents/skills/nauro-interview/SKILL.md",
     "docs/adopt-prompt.md",
 )
 

--- a/packages/nauro/tests/test_skills_drift.py
+++ b/packages/nauro/tests/test_skills_drift.py
@@ -17,6 +17,7 @@ from nauro_core.constants import MAX_BRIEF_BYTES, MAX_DELTA_LENGTH
 from nauro.skills import (
     load_adopt_body,
     load_context_body,
+    load_interview_body,
     load_loop_body,
     load_ship_task_body,
     render_skill,
@@ -182,6 +183,113 @@ def test_load_loop_body_returns_canonical_bytes():
     # No leaked template syntax.
     assert "<!--" not in body
     assert "{{" not in body
+
+
+def test_load_interview_body_preserves_deliberation_boundary():
+    body = load_interview_body()
+
+    assert body.endswith("\n")
+    assert not body.endswith("\n\n")
+    assert 1000 < len(body) < 25000
+    assert "Elicit mode" in body
+    assert "Challenge mode" in body
+    assert "dependency-aware interview loop" in body
+    assert 'get_context(level="L0"' in body
+    assert "check_decision" in body
+    assert "get_decision" in body
+    assert "prerequisite-ready frontier" in body
+    assert "recommendation" in body
+    assert "tradeoffs" in body
+    assert "Every question must include a recommendation" in body
+    assert "recommend deferring the choice or preserving it as unresolved" in body
+    assert "wait for the user's reply" in body
+    for outcome_class in (
+        "Terminology",
+        "Verified current state",
+        "Open question",
+        "Non-durable detail",
+        "Candidate durable judgment",
+    ):
+        assert outcome_class in body
+    assert "Shared understanding is non-authoritative" in body
+    assert "evidence only" in body
+    assert "does not write `CONTEXT.md` or ADR files" in body
+
+
+def test_interview_body_requires_separate_later_reply_for_each_write_class():
+    body = load_interview_body()
+
+    assert "separate later-reply approval gate" in body
+    assert "propose_decision" in body
+    assert "update_state" in body
+    assert "flag_question" in body
+    assert body.count('get_raw_file(path="state_current.md", project_id=...)') == 2
+    assert "complete short structured-Markdown replacement" in body
+    assert "never stage or submit a partial state delta" in body
+    assert "reread `state_current.md` immediately before" in body
+    assert "intervening state change invalidates the approval" in body
+    assert "archives the prior body" in body
+    assert "exact open-question entry" in body
+    assert "fresh approval" in body
+    assert "changed overlap" in body
+    assert "Interview agreement never grants write authority" in body
+
+
+def test_interview_body_guards_team_state_writes_with_exact_revision():
+    body = load_interview_body()
+
+    assert "exact returned content and exact `state_revision`" in body
+    assert "both the exact content and exact revision" in body
+    assert "expected_revision` set to the exact approved baseline `state_revision`" in body
+    assert "stop and defer the team-mode state write" in body
+    assert "Never fall back to an unguarded team-mode state write" in body
+    assert (
+        "State in local or pre-team mode: "
+        "`update_state(delta=<exact approved complete replacement body>, project_id=...)`" in body
+    )
+
+
+def test_interview_body_separates_team_ratification_from_chat_approval():
+    body = load_interview_body()
+
+    assert "Local or pre-team mode" in body
+    assert "Team mode" in body
+    assert "chat approval cannot ratify project judgment" in body
+    assert "pending proposal" in body
+    assert "authenticated first-party web action" in body
+    assert "exact proposal revision and digest" in body
+    assert "Do not claim that the chat reply committed the decision" in body
+
+
+def test_interview_body_preserves_explicit_triggers_and_routes_other_work():
+    body = load_interview_body()
+
+    for trigger in (
+        "interview me",
+        "grill this",
+        "stress-test this decision",
+        "draw out my reasoning",
+        "help me transfer this reasoning into Nauro",
+    ):
+        assert trigger in body
+    assert "nauro-adopt" in body
+    assert "nauro-context" in body
+    assert "nauro-ship-task" in body
+    assert "no external skill or subagent dependency" in body
+
+
+def test_render_skill_interview_frontmatter():
+    claude = render_skill("claude_code", "nauro-interview")
+    assert claude.startswith("---\nname: nauro-interview\n")
+    assert "description:" in claude.split("\n---\n", 1)[0]
+    assert claude.split("\n---\n", 1)[1].lstrip("\n") == load_interview_body()
+
+    cursor = render_skill("cursor", "nauro-interview")
+    frontmatter = cursor.split("\n---\n", 1)[0]
+    assert "description:" in frontmatter
+    assert "alwaysApply: false" in frontmatter
+    assert "name:" not in frontmatter
+    assert cursor.split("\n---\n", 1)[1].lstrip("\n") == load_interview_body()
 
 
 def test_render_skill_claude_code_loop_frontmatter():
@@ -432,6 +540,9 @@ DOGFOOD_FILES = [
     (".claude/skills/nauro-loop/SKILL.md", "claude_code", "nauro-loop"),
     (".cursor/rules/nauro-loop.mdc", "cursor", "nauro-loop"),
     (".agents/skills/nauro-loop/SKILL.md", "codex", "nauro-loop"),
+    (".claude/skills/nauro-interview/SKILL.md", "claude_code", "nauro-interview"),
+    (".cursor/rules/nauro-interview.mdc", "cursor", "nauro-interview"),
+    (".agents/skills/nauro-interview/SKILL.md", "codex", "nauro-interview"),
 ]
 
 


### PR DESCRIPTION
## Why

Agents need an explicit way to draw out and stress-test project judgment against repository evidence and active Nauro decisions. Interview agreement must remain separate from authority to change project truth.

## What changed

Added the canonical `nauro-interview` skill and rendered it for Claude Code, Codex, and Cursor.

The workflow provides Elicit and Challenge modes through one dependency-aware interview loop. It verifies factual claims from repository evidence, checks live approaches against active decisions, reads each decision used in reasoning in full, and asks prerequisite-ready questions with recommendations and tradeoffs.

The workflow classifies shared understanding without treating it as authoritative. It stages decisions, complete state replacements, and open questions behind separate later-reply approval gates. Team decision proposals still require authenticated first-party ratification.

State writes preserve replacement semantics. Local and pre-team writes recheck exact current content. Hosted team writes also bind the approved baseline revision through `expected_revision`. The workflow defers the write if the active hosted surface cannot provide both revision-aware reading and guarded writing.

## Test plan

- `PYTHONPATH="$PWD/packages/nauro/src:$PWD/packages/nauro-core/src" uv run pytest packages/nauro/tests/test_skills_drift.py packages/nauro/tests/test_protocol_drift.py packages/nauro/tests/test_skill_tool_signatures.py -q`
  - 294 passed
- `PYTHONPATH="$PWD/packages/nauro/src:$PWD/packages/nauro-core/src" uv run pytest packages/nauro/tests/test_update_state_parity.py packages/nauro-core/tests/operations/test_commit_plan.py packages/nauro-core/tests/operations/test_update_state_plan.py -q`
  - 95 passed
- From the sibling `mcp-server` checkout, with `NAURO_CHECKOUT` set to this PR checkout:
  - `PYTHONPATH="$PWD/src:$NAURO_CHECKOUT/packages/nauro-core/src" uv run pytest tests/test_update_state_publication.py -q`
  - 79 passed
- `uv build --package nauro --wheel`
  - Passed, with `nauro/skills/interview_body.md` included
- `uv run ruff check packages/`
  - Passed
- `uv run ruff format --check packages/`
  - 360 files already formatted
- `PYTHONPATH="$PWD/packages/nauro/src:$PWD/packages/nauro-core/src" uv run pytest packages/nauro-core/tests/ -x -q`
  - 1861 passed
- `PYTHONPATH="$PWD/packages/nauro/src:$PWD/packages/nauro-core/src" uv run pytest packages/nauro/tests/ -x -q`
  - 2689 passed, 10 skipped

## Risk / what to review

Review the boundary between local or pre-team writes and hosted team writes. In particular, verify the complete-replacement approval gate, exact content and revision recheck, and hard defer when the hosted guarded-write contract is unavailable.

## Deferred

This change does not activate or install the skill through adoption or setup flows. It also does not expose the hosted revision-aware state contract through the MCP router.
