### PR TITLE
Release nauro 1.16.0 and nauro-core 1.14.1

### DIFF
--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro-core"
-version = "1.14.0"
+version = "1.14.1"
 description = "Shared pure-Python logic for Nauro: parsing, validation, context assembly, constants."
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro"
-version = "1.15.0"
+version = "1.16.0"
 description = "Human-approved project judgment and current state for connected AI agents, surfaced before work."
 readme = "README.md"
 license = "Apache-2.0"
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "nauro-core>=1.14.0,<2",
+    "nauro-core>=1.14.1,<2",
     "typer>=0.9",
     "httpx>=0.24",
     "mcp>=1.0,<2",

--- a/server.json
+++ b/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Nauro-AI/nauro",
     "source": "github"
   },
-  "version": "1.15.0",
+  "version": "1.16.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "nauro",
-      "version": "1.15.0",
+      "version": "1.16.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -936,7 +936,7 @@ wheels = [
 
 [[package]]
 name = "nauro"
-version = "1.15.0"
+version = "1.16.0"
 source = { editable = "packages/nauro" }
 dependencies = [
     { name = "filelock" },
@@ -978,7 +978,7 @@ provides-extras = ["dev", "embeddings"]
 
 [[package]]
 name = "nauro-core"
-version = "1.14.0"
+version = "1.14.1"
 source = { editable = "packages/nauro-core" }
 dependencies = [
     { name = "bm25s" },


### PR DESCRIPTION
## Version moves

- nauro: 1.15.0 -> 1.16.0
- nauro-core: 1.14.0 -> 1.14.1
- nauro now requires nauro-core >= 1.14.1, < 2
- server.json follows the nauro version

## What ships

**nauro** (12 PRs since 1.15.0): the additive Nauro interview workflow and rendered Claude Code, Cursor, and Codex surfaces; removal of unused internal shims, aliases, and helpers; prose-budget cleanup.

**nauro-core** (7 PRs since 1.14.0): internal compatibility, dead-symbol, and prose cleanup. The curated public API is unchanged.

## Checks

- check_server_json_version, check_single_sourced, uv lock --check, and both locked Python 3.12 syncs pass locally.

## After merge

- Tag the squash commit as nauro-core-v1.14.1 first, wait for PyPI index propagation, then tag it as nauro-v1.16.0. The tags trigger the trusted-publish workflows.
