### PR TITLE
Release nauro 1.17.0

### DIFF
--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro"
-version = "1.16.0"
+version = "1.17.0"
 description = "Human-approved project judgment and current state for connected AI agents, surfaced before work."
 readme = "README.md"
 license = "Apache-2.0"

--- a/server.json
+++ b/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Nauro-AI/nauro",
     "source": "github"
   },
-  "version": "1.16.0",
+  "version": "1.17.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "nauro",
-      "version": "1.16.0",
+      "version": "1.17.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -936,7 +936,7 @@ wheels = [
 
 [[package]]
 name = "nauro"
-version = "1.16.0"
+version = "1.17.0"
 source = { editable = "packages/nauro" }
 dependencies = [
     { name = "filelock" },


### PR DESCRIPTION
## Why

Release the additive program-routing workflow merged after nauro 1.16.0.

## What ships

- Bump nauro from 1.16.0 to 1.17.0.
- Ship typed Delivery and Interview routing, target-surface fresh-task handoffs, terminal program handbacks, and explicit coordinator rotation.
- Keep nauro-core at 1.14.1 because it has no unreleased source changes.

## Release changes

- Update the nauro package version.
- Keep both server.json version fields locked to the package version.
- Regenerate uv.lock.

## Test plan

- `python3 scripts/check_server_json_version.py`: passed.
- `python3 scripts/check_single_sourced.py packages/nauro/src`: passed.
- `uv lock --check`: passed.
- `uv sync --locked --package nauro-core --all-extras --python 3.12`: passed.
- `uv sync --locked --package nauro --all-extras --python 3.12`: passed.
- `git diff --check`: passed.

## Post-merge

After separate publish approval, create `nauro-v1.17.0` at the squash-merge commit and push that tag. The tag publishes nauro to PyPI and server.json to the MCP registry. Create the GitHub Release only after both publish jobs succeed.
