### PR TITLE
Make Nauro interviews compact and dependency-aware

### DIFF
--- a/.agents/skills/nauro-interview/SKILL.md
+++ b/.agents/skills/nauro-interview/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: nauro-interview
-description: Interview the user to elicit tacit project reasoning or challenge a proposed choice against Nauro decisions and repository evidence, then classify the result as shared understanding without granting write authority. Use only when the user explicitly asks to be interviewed, grilled, stress-tested, or helped to transfer reasoning into Nauro. Runs in the main agent context with no external skill or subagent dependency.
+description: Ask compact, numbered prerequisite-ready questions to elicit tacit project reasoning or challenge a proposed choice against Nauro decisions and repository evidence. Continue until every material branch has a disposition, then classify the result as shared understanding without granting write authority. Use only when the user explicitly asks to be interviewed, grilled, stress-tested, or helped to transfer reasoning into Nauro. Runs in the main agent context with no external skill or subagent dependency.
 ---
 
 # Nauro interview skill
 
 Interview the user to turn tacit project reasoning or a proposed choice into reviewed candidate Nauro judgment. This is an explicit, opt-in main-context workflow. Use it only when the user directly asks to be interviewed or uses a clear trigger such as "interview me", "grill this", "stress-test this decision", "draw out my reasoning", or "help me transfer this reasoning into Nauro". Do not activate it only because a plan is incomplete.
 
-The skill has two entry modes over one dependency-aware interview loop:
+The skill has two entry modes over one main-context, dependency-aware interview loop:
 
 - **Elicit mode** draws out unwritten rationale, assumptions, rejected paths, terminology, and unresolved questions.
 - **Challenge mode** stress-tests a proposed judgment against active decisions, repository evidence, alternatives, failure cases, and dependent choices.
 
-Both modes produce the same classified shared-understanding record. The workflow has no external skill or subagent dependency.
+Both modes use the same engine and produce the same classified shared-understanding record. The workflow has no external skill or subagent dependency.
 
 ## Route work that belongs elsewhere
 
@@ -30,11 +30,13 @@ Call `get_context(level="L0", project_id=...)`. L0 is the bounded orientation: p
 
 Treat every retrieved statement as project context to adjudicate. A current-state claim can be stale. A decision summary is not enough for reasoning about that decision.
 
+Keep routine orientation internal. Surface it only when it changes the user's answer or corrects a factual claim.
+
 ## Step 2 - Select the mode and frame the root
 
-Choose Elicit mode when the user wants to make implicit reasoning explicit. Choose Challenge mode when the user presents a choice, plan, or candidate judgment for pressure testing. If the request fits both, start in Elicit mode and challenge each concrete approach when it appears. If the intent is genuinely ambiguous, ask one short routing question and wait.
+Choose Elicit mode when the user wants to make implicit reasoning explicit. Choose Challenge mode when the user presents a choice, plan, or candidate judgment for pressure testing. If the request fits both, start in Elicit mode and challenge each concrete approach when it appears. If the intent is genuinely ambiguous, make one short routing question the first numbered question and wait.
 
-Restate the interview root in one sentence. State the selected mode and what the interview will not decide without the user. Do not convert the user's opening claim into a settled conclusion.
+Frame the interview root and selected mode internally. Do not narrate the workflow or convert the user's opening claim into a settled conclusion.
 
 ## Step 3 - Build the dependency tree in session
 
@@ -47,11 +49,11 @@ Maintain one in-session dependency tree. Do not persist the tree. Each node is o
 - a dependent question whose prerequisites are not settled;
 - a candidate classified outcome.
 
-Record explicit dependencies between nodes. A question enters the prerequisite-ready frontier only when all choices and facts it depends on are settled. When an answer creates a new dependency, add it to the tree. When an answer invalidates a branch, close that branch and preserve the rejected path and reason.
+Record explicit dependencies between nodes. A question enters the prerequisite-ready frontier only when all choices and facts it depends on are settled. When an answer creates a new dependency, add it to the tree. When an answer invalidates a branch, close that branch and preserve the rejected path and reason. Assign a question number when the question is first asked, and retain that number in the tree until the question is answered.
 
 ## Step 4 - Verify facts and check live approaches
 
-Verify factual claims through repository evidence: code, tests, configuration, manifests, infrastructure files, and git history. Do not ask the user for facts the repository can answer. Cite the evidence used. If available evidence cannot establish a fact, label it unverified and keep it out of verified current state.
+Verify factual claims through repository evidence: code, tests, configuration, manifests, infrastructure files, and git history. Do not ask the user for facts the repository can answer. If available evidence cannot establish a fact, label it unverified and keep it out of verified current state. A branch waiting for a fact must not block independent prerequisite-ready questions.
 
 Treat `CONTEXT.md`, ADRs, design notes, and other repository prose as evidence only. Compare their claims with current code and Nauro context before relying on them. The skill does not write `CONTEXT.md` or ADR files.
 
@@ -61,29 +63,33 @@ For each live approach that the interview may recommend, accept, or reject, call
 
 Triage the inline headers for status and supersession. Related hits carry their triage headers inline; before proposing, call `get_decision` (`mode=full`) on each decision you reason about. Call `get_decision(number=N, mode="full", project_id=...)` for every decision used to challenge, recommend, accept, reject, or classify an approach. Do not reason from a header or summary alone.
 
-If repository evidence or a full decision changes the tree, show the conflict or constraint to the user before asking the dependent question.
+Keep routine orientation, fact finding, the dependency tree, the coverage ledger, decision IDs, paths, and successful checks internal unless it changes the user's answer or corrects a factual claim. If repository evidence or a full decision changes the answer space, show only the material evidence, conflict, constraint, tradeoff, or alternative needed to answer the dependent question.
 
 ## Step 5 - Ask the prerequisite-ready frontier
 
-Ask the whole prerequisite-ready frontier in a round. Do not ask downstream questions early. Keep each question atomic and name the decision it unlocks.
+Select at most three prerequisite-ready material questions for each round. Use one question when only one is ready. Do not ask downstream questions early. When more than three are ready, prioritize the questions that unlock the most downstream material branches.
 
-For each question, provide:
+Number questions continuously across the interview, starting at 1. A question keeps its number until it is answered. A direct follow-up receives the next unused number. Never reuse a number. Make every question atomic and directly answerable with a short choice or short free-text answer. Use compact options when the answer space is finite.
 
-1. The question.
-2. Why it is ready now.
-3. A recommendation.
-4. The evidence and active decisions behind the recommendation.
-5. The material tradeoffs and credible alternatives.
+Show the numbered question and a concise recommendation. Surface at most the material tradeoff, evidence, conflict, or alternative needed to answer. Do not attach a routine dossier to each question.
 
-Every question must include a recommendation. When evidence cannot support a substantive choice, recommend deferring the choice or preserving it as unresolved. State why, and state the tradeoffs between waiting and deciding under uncertainty.
+Every question must include a recommendation. In Elicit mode, when the user's rationale is unknown, recommend an answer shape, such as a constraint plus one example. Never invent the user's rationale. When evidence cannot support a substantive choice, recommend deferring the choice or preserving it as unresolved. State the material tradeoff between waiting and deciding under uncertainty. Do not present an agent recommendation as project authority. The user owns every choice.
 
-Do not present an agent recommendation as project authority. The user owns every choice. After the round, wait for the user's reply. Do not answer a user-owned choice on the user's behalf. Integrate the reply, update the dependency tree, verify any new factual claims, check new live approaches, and ask the next prerequisite-ready frontier.
+End every round with an instantiated concise reply cue using the question numbers in that batch. Use exactly this form: `Reply: 4: <answer>; 5: <answer>. Answer any subset.` Replace `4` and `5` with the batch's actual question numbers, include each batch question once, and do not add other text to the cue. Then wait for the user's reply. Do not answer a user-owned choice on the user's behalf.
 
-Continue until the user ends the interview or no unresolved node can change a classified outcome. If a blocker cannot be resolved from evidence or user judgment, preserve it as an open question instead of guessing.
+Integrate each reply without rehashing settled answers. Preserve each unanswered ready question with its original number. Recompute dependencies after every partial answer, verify new factual claims, check new live approaches, and unlock every newly valid branch. Never repeat a settled question. Ask the next valid batch without asking permission. Do not ask permission to continue.
+
+Press any vague, contradictory, conditional, slogan-like, or incomplete answer with a direct follow-up for the missing condition, threshold, example, rejected path, failure case, consequence, or reversal trigger. Give that follow-up the next unused number.
+
+Continue until the user stops or every material branch has a disposition. If a blocker cannot be resolved from evidence or user judgment, preserve it as an open question instead of guessing.
 
 ## Step 6 - Classify the outcome
 
-When the frontier is empty, render one shared-understanding summary. Classify each outcome into exactly one of these record classes:
+Before completion, audit the internal coverage ledger for outcome, rationale, constraints, terminology, assumptions, alternatives and rejected paths, consequences, unresolved choices, and material failure cases. In Challenge mode, also audit disconfirming evidence and reversal triggers. Add a prerequisite-ready question for every material gap.
+
+Give every material branch one disposition: settled, verified, rejected with a reason, or explicitly preserved as unresolved. Say `Interview complete` only after every material branch has one of those dispositions. If the user stops early, label the interview incomplete and list only the material unresolved branches.
+
+When the audit passes, render one shared-understanding summary. Classify each outcome into exactly one of these existing record classes:
 
 - **Terminology**: a term and its session meaning. It remains noncanonical unless it expresses a durable, reasoned choice that is separately ratified.
 - **Verified current state**: a present-tense fact established by current repository or system evidence. Never place future design here.
@@ -91,13 +97,15 @@ When the frontier is empty, render one shared-understanding summary. Classify ea
 - **Non-durable detail**: useful session detail that does not belong in project truth.
 - **Candidate durable judgment**: a reasoned project choice with constraints, tradeoffs, rejected alternatives, and consequences that may merit a decision.
 
-For each item, show its evidence, related decisions, confidence, and remaining uncertainty. Ask the user to correct or confirm the shared understanding, then end the turn and wait.
+Render only the nonempty record classes. Include evidence, related decisions, confidence, or uncertainty only when it materially affects the shared understanding. Ask once for correction or confirmation, then end the turn and wait.
 
 Shared understanding is non-authoritative. Confirmation means the summary accurately reflects the interview. It does not approve any Nauro store mutation. Interview agreement never grants write authority.
 
 ## Step 7 - Stage writes without authority
 
-After the user confirms shared understanding, determine which classified items could update Nauro. Do not write yet. Keep the three write classes separate:
+Enter this step only if the user explicitly asked to transfer, save, or record the result. Completing the interview does not stage a write. Confirming the shared-understanding summary does not stage a write. Without explicit transfer intent, stop after confirmation.
+
+After both explicit transfer intent and shared-understanding confirmation, determine which classified items could update Nauro. Do not write yet. Keep the three write classes separate:
 
 1. Candidate durable judgment may produce one decision proposal.
 2. Verified current state may produce one exact complete state replacement.
@@ -173,9 +181,11 @@ Capture and report the tool result. Do not assume that approval means the write 
 
 - The interview runs in the main agent context and waits after every question round.
 - The dependency tree is session state, not project truth.
+- The coverage ledger stays internal and is not project truth.
 - Verify facts from repository or system evidence. Ask the user for judgment and rationale, not discoverable facts.
 - Check every live approach against Nauro decisions. Read every decision used in reasoning in full.
 - Existing `CONTEXT.md` and ADR content is evidence only. Never edit or generate those files in this workflow.
+- Interview completion and summary confirmation do not stage or authorize a write. Staging requires explicit transfer, save, or record intent.
 - Shared-understanding confirmation is never write approval.
 - Decision proposals, state replacements, and open-question entries use separate exact-payload gates and explicit approval from a later user reply. In team mode, that reply authorizes pending proposal submission only.
 - State approval covers one complete replacement body derived from one exact current-state baseline. In hosted team mode, the baseline includes both exact content and exact revision, and the write supplies that revision as `expected_revision`. It never covers a partial delta or a replacement derived after an intervening content or revision change.

--- a/.claude/skills/nauro-interview/SKILL.md
+++ b/.claude/skills/nauro-interview/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: nauro-interview
-description: Interview the user to elicit tacit project reasoning or challenge a proposed choice against Nauro decisions and repository evidence, then classify the result as shared understanding without granting write authority. Use only when the user explicitly asks to be interviewed, grilled, stress-tested, or helped to transfer reasoning into Nauro. Runs in the main agent context with no external skill or subagent dependency.
+description: Ask compact, numbered prerequisite-ready questions to elicit tacit project reasoning or challenge a proposed choice against Nauro decisions and repository evidence. Continue until every material branch has a disposition, then classify the result as shared understanding without granting write authority. Use only when the user explicitly asks to be interviewed, grilled, stress-tested, or helped to transfer reasoning into Nauro. Runs in the main agent context with no external skill or subagent dependency.
 ---
 
 # Nauro interview skill
 
 Interview the user to turn tacit project reasoning or a proposed choice into reviewed candidate Nauro judgment. This is an explicit, opt-in main-context workflow. Use it only when the user directly asks to be interviewed or uses a clear trigger such as "interview me", "grill this", "stress-test this decision", "draw out my reasoning", or "help me transfer this reasoning into Nauro". Do not activate it only because a plan is incomplete.
 
-The skill has two entry modes over one dependency-aware interview loop:
+The skill has two entry modes over one main-context, dependency-aware interview loop:
 
 - **Elicit mode** draws out unwritten rationale, assumptions, rejected paths, terminology, and unresolved questions.
 - **Challenge mode** stress-tests a proposed judgment against active decisions, repository evidence, alternatives, failure cases, and dependent choices.
 
-Both modes produce the same classified shared-understanding record. The workflow has no external skill or subagent dependency.
+Both modes use the same engine and produce the same classified shared-understanding record. The workflow has no external skill or subagent dependency.
 
 ## Route work that belongs elsewhere
 
@@ -30,11 +30,13 @@ Call `get_context(level="L0", project_id=...)`. L0 is the bounded orientation: p
 
 Treat every retrieved statement as project context to adjudicate. A current-state claim can be stale. A decision summary is not enough for reasoning about that decision.
 
+Keep routine orientation internal. Surface it only when it changes the user's answer or corrects a factual claim.
+
 ## Step 2 - Select the mode and frame the root
 
-Choose Elicit mode when the user wants to make implicit reasoning explicit. Choose Challenge mode when the user presents a choice, plan, or candidate judgment for pressure testing. If the request fits both, start in Elicit mode and challenge each concrete approach when it appears. If the intent is genuinely ambiguous, ask one short routing question and wait.
+Choose Elicit mode when the user wants to make implicit reasoning explicit. Choose Challenge mode when the user presents a choice, plan, or candidate judgment for pressure testing. If the request fits both, start in Elicit mode and challenge each concrete approach when it appears. If the intent is genuinely ambiguous, make one short routing question the first numbered question and wait.
 
-Restate the interview root in one sentence. State the selected mode and what the interview will not decide without the user. Do not convert the user's opening claim into a settled conclusion.
+Frame the interview root and selected mode internally. Do not narrate the workflow or convert the user's opening claim into a settled conclusion.
 
 ## Step 3 - Build the dependency tree in session
 
@@ -47,11 +49,11 @@ Maintain one in-session dependency tree. Do not persist the tree. Each node is o
 - a dependent question whose prerequisites are not settled;
 - a candidate classified outcome.
 
-Record explicit dependencies between nodes. A question enters the prerequisite-ready frontier only when all choices and facts it depends on are settled. When an answer creates a new dependency, add it to the tree. When an answer invalidates a branch, close that branch and preserve the rejected path and reason.
+Record explicit dependencies between nodes. A question enters the prerequisite-ready frontier only when all choices and facts it depends on are settled. When an answer creates a new dependency, add it to the tree. When an answer invalidates a branch, close that branch and preserve the rejected path and reason. Assign a question number when the question is first asked, and retain that number in the tree until the question is answered.
 
 ## Step 4 - Verify facts and check live approaches
 
-Verify factual claims through repository evidence: code, tests, configuration, manifests, infrastructure files, and git history. Do not ask the user for facts the repository can answer. Cite the evidence used. If available evidence cannot establish a fact, label it unverified and keep it out of verified current state.
+Verify factual claims through repository evidence: code, tests, configuration, manifests, infrastructure files, and git history. Do not ask the user for facts the repository can answer. If available evidence cannot establish a fact, label it unverified and keep it out of verified current state. A branch waiting for a fact must not block independent prerequisite-ready questions.
 
 Treat `CONTEXT.md`, ADRs, design notes, and other repository prose as evidence only. Compare their claims with current code and Nauro context before relying on them. The skill does not write `CONTEXT.md` or ADR files.
 
@@ -61,29 +63,33 @@ For each live approach that the interview may recommend, accept, or reject, call
 
 Triage the inline headers for status and supersession. Related hits carry their triage headers inline; before proposing, call `get_decision` (`mode=full`) on each decision you reason about. Call `get_decision(number=N, mode="full", project_id=...)` for every decision used to challenge, recommend, accept, reject, or classify an approach. Do not reason from a header or summary alone.
 
-If repository evidence or a full decision changes the tree, show the conflict or constraint to the user before asking the dependent question.
+Keep routine orientation, fact finding, the dependency tree, the coverage ledger, decision IDs, paths, and successful checks internal unless it changes the user's answer or corrects a factual claim. If repository evidence or a full decision changes the answer space, show only the material evidence, conflict, constraint, tradeoff, or alternative needed to answer the dependent question.
 
 ## Step 5 - Ask the prerequisite-ready frontier
 
-Ask the whole prerequisite-ready frontier in a round. Do not ask downstream questions early. Keep each question atomic and name the decision it unlocks.
+Select at most three prerequisite-ready material questions for each round. Use one question when only one is ready. Do not ask downstream questions early. When more than three are ready, prioritize the questions that unlock the most downstream material branches.
 
-For each question, provide:
+Number questions continuously across the interview, starting at 1. A question keeps its number until it is answered. A direct follow-up receives the next unused number. Never reuse a number. Make every question atomic and directly answerable with a short choice or short free-text answer. Use compact options when the answer space is finite.
 
-1. The question.
-2. Why it is ready now.
-3. A recommendation.
-4. The evidence and active decisions behind the recommendation.
-5. The material tradeoffs and credible alternatives.
+Show the numbered question and a concise recommendation. Surface at most the material tradeoff, evidence, conflict, or alternative needed to answer. Do not attach a routine dossier to each question.
 
-Every question must include a recommendation. When evidence cannot support a substantive choice, recommend deferring the choice or preserving it as unresolved. State why, and state the tradeoffs between waiting and deciding under uncertainty.
+Every question must include a recommendation. In Elicit mode, when the user's rationale is unknown, recommend an answer shape, such as a constraint plus one example. Never invent the user's rationale. When evidence cannot support a substantive choice, recommend deferring the choice or preserving it as unresolved. State the material tradeoff between waiting and deciding under uncertainty. Do not present an agent recommendation as project authority. The user owns every choice.
 
-Do not present an agent recommendation as project authority. The user owns every choice. After the round, wait for the user's reply. Do not answer a user-owned choice on the user's behalf. Integrate the reply, update the dependency tree, verify any new factual claims, check new live approaches, and ask the next prerequisite-ready frontier.
+End every round with an instantiated concise reply cue using the question numbers in that batch. Use exactly this form: `Reply: 4: <answer>; 5: <answer>. Answer any subset.` Replace `4` and `5` with the batch's actual question numbers, include each batch question once, and do not add other text to the cue. Then wait for the user's reply. Do not answer a user-owned choice on the user's behalf.
 
-Continue until the user ends the interview or no unresolved node can change a classified outcome. If a blocker cannot be resolved from evidence or user judgment, preserve it as an open question instead of guessing.
+Integrate each reply without rehashing settled answers. Preserve each unanswered ready question with its original number. Recompute dependencies after every partial answer, verify new factual claims, check new live approaches, and unlock every newly valid branch. Never repeat a settled question. Ask the next valid batch without asking permission. Do not ask permission to continue.
+
+Press any vague, contradictory, conditional, slogan-like, or incomplete answer with a direct follow-up for the missing condition, threshold, example, rejected path, failure case, consequence, or reversal trigger. Give that follow-up the next unused number.
+
+Continue until the user stops or every material branch has a disposition. If a blocker cannot be resolved from evidence or user judgment, preserve it as an open question instead of guessing.
 
 ## Step 6 - Classify the outcome
 
-When the frontier is empty, render one shared-understanding summary. Classify each outcome into exactly one of these record classes:
+Before completion, audit the internal coverage ledger for outcome, rationale, constraints, terminology, assumptions, alternatives and rejected paths, consequences, unresolved choices, and material failure cases. In Challenge mode, also audit disconfirming evidence and reversal triggers. Add a prerequisite-ready question for every material gap.
+
+Give every material branch one disposition: settled, verified, rejected with a reason, or explicitly preserved as unresolved. Say `Interview complete` only after every material branch has one of those dispositions. If the user stops early, label the interview incomplete and list only the material unresolved branches.
+
+When the audit passes, render one shared-understanding summary. Classify each outcome into exactly one of these existing record classes:
 
 - **Terminology**: a term and its session meaning. It remains noncanonical unless it expresses a durable, reasoned choice that is separately ratified.
 - **Verified current state**: a present-tense fact established by current repository or system evidence. Never place future design here.
@@ -91,13 +97,15 @@ When the frontier is empty, render one shared-understanding summary. Classify ea
 - **Non-durable detail**: useful session detail that does not belong in project truth.
 - **Candidate durable judgment**: a reasoned project choice with constraints, tradeoffs, rejected alternatives, and consequences that may merit a decision.
 
-For each item, show its evidence, related decisions, confidence, and remaining uncertainty. Ask the user to correct or confirm the shared understanding, then end the turn and wait.
+Render only the nonempty record classes. Include evidence, related decisions, confidence, or uncertainty only when it materially affects the shared understanding. Ask once for correction or confirmation, then end the turn and wait.
 
 Shared understanding is non-authoritative. Confirmation means the summary accurately reflects the interview. It does not approve any Nauro store mutation. Interview agreement never grants write authority.
 
 ## Step 7 - Stage writes without authority
 
-After the user confirms shared understanding, determine which classified items could update Nauro. Do not write yet. Keep the three write classes separate:
+Enter this step only if the user explicitly asked to transfer, save, or record the result. Completing the interview does not stage a write. Confirming the shared-understanding summary does not stage a write. Without explicit transfer intent, stop after confirmation.
+
+After both explicit transfer intent and shared-understanding confirmation, determine which classified items could update Nauro. Do not write yet. Keep the three write classes separate:
 
 1. Candidate durable judgment may produce one decision proposal.
 2. Verified current state may produce one exact complete state replacement.
@@ -173,9 +181,11 @@ Capture and report the tool result. Do not assume that approval means the write 
 
 - The interview runs in the main agent context and waits after every question round.
 - The dependency tree is session state, not project truth.
+- The coverage ledger stays internal and is not project truth.
 - Verify facts from repository or system evidence. Ask the user for judgment and rationale, not discoverable facts.
 - Check every live approach against Nauro decisions. Read every decision used in reasoning in full.
 - Existing `CONTEXT.md` and ADR content is evidence only. Never edit or generate those files in this workflow.
+- Interview completion and summary confirmation do not stage or authorize a write. Staging requires explicit transfer, save, or record intent.
 - Shared-understanding confirmation is never write approval.
 - Decision proposals, state replacements, and open-question entries use separate exact-payload gates and explicit approval from a later user reply. In team mode, that reply authorizes pending proposal submission only.
 - State approval covers one complete replacement body derived from one exact current-state baseline. In hosted team mode, the baseline includes both exact content and exact revision, and the write supplies that revision as `expected_revision`. It never covers a partial delta or a replacement derived after an intervening content or revision change.

--- a/.cursor/rules/nauro-interview.mdc
+++ b/.cursor/rules/nauro-interview.mdc
@@ -1,5 +1,5 @@
 ---
-description: Interview the user to elicit tacit project reasoning or challenge a proposed choice against Nauro decisions and repository evidence, then classify the result as shared understanding without granting write authority. Use only when the user explicitly asks to be interviewed, grilled, stress-tested, or helped to transfer reasoning into Nauro. Runs in the main agent context with no external skill or subagent dependency.
+description: Ask compact, numbered prerequisite-ready questions to elicit tacit project reasoning or challenge a proposed choice against Nauro decisions and repository evidence. Continue until every material branch has a disposition, then classify the result as shared understanding without granting write authority. Use only when the user explicitly asks to be interviewed, grilled, stress-tested, or helped to transfer reasoning into Nauro. Runs in the main agent context with no external skill or subagent dependency.
 alwaysApply: false
 ---
 
@@ -7,12 +7,12 @@ alwaysApply: false
 
 Interview the user to turn tacit project reasoning or a proposed choice into reviewed candidate Nauro judgment. This is an explicit, opt-in main-context workflow. Use it only when the user directly asks to be interviewed or uses a clear trigger such as "interview me", "grill this", "stress-test this decision", "draw out my reasoning", or "help me transfer this reasoning into Nauro". Do not activate it only because a plan is incomplete.
 
-The skill has two entry modes over one dependency-aware interview loop:
+The skill has two entry modes over one main-context, dependency-aware interview loop:
 
 - **Elicit mode** draws out unwritten rationale, assumptions, rejected paths, terminology, and unresolved questions.
 - **Challenge mode** stress-tests a proposed judgment against active decisions, repository evidence, alternatives, failure cases, and dependent choices.
 
-Both modes produce the same classified shared-understanding record. The workflow has no external skill or subagent dependency.
+Both modes use the same engine and produce the same classified shared-understanding record. The workflow has no external skill or subagent dependency.
 
 ## Route work that belongs elsewhere
 
@@ -30,11 +30,13 @@ Call `get_context(level="L0", project_id=...)`. L0 is the bounded orientation: p
 
 Treat every retrieved statement as project context to adjudicate. A current-state claim can be stale. A decision summary is not enough for reasoning about that decision.
 
+Keep routine orientation internal. Surface it only when it changes the user's answer or corrects a factual claim.
+
 ## Step 2 - Select the mode and frame the root
 
-Choose Elicit mode when the user wants to make implicit reasoning explicit. Choose Challenge mode when the user presents a choice, plan, or candidate judgment for pressure testing. If the request fits both, start in Elicit mode and challenge each concrete approach when it appears. If the intent is genuinely ambiguous, ask one short routing question and wait.
+Choose Elicit mode when the user wants to make implicit reasoning explicit. Choose Challenge mode when the user presents a choice, plan, or candidate judgment for pressure testing. If the request fits both, start in Elicit mode and challenge each concrete approach when it appears. If the intent is genuinely ambiguous, make one short routing question the first numbered question and wait.
 
-Restate the interview root in one sentence. State the selected mode and what the interview will not decide without the user. Do not convert the user's opening claim into a settled conclusion.
+Frame the interview root and selected mode internally. Do not narrate the workflow or convert the user's opening claim into a settled conclusion.
 
 ## Step 3 - Build the dependency tree in session
 
@@ -47,11 +49,11 @@ Maintain one in-session dependency tree. Do not persist the tree. Each node is o
 - a dependent question whose prerequisites are not settled;
 - a candidate classified outcome.
 
-Record explicit dependencies between nodes. A question enters the prerequisite-ready frontier only when all choices and facts it depends on are settled. When an answer creates a new dependency, add it to the tree. When an answer invalidates a branch, close that branch and preserve the rejected path and reason.
+Record explicit dependencies between nodes. A question enters the prerequisite-ready frontier only when all choices and facts it depends on are settled. When an answer creates a new dependency, add it to the tree. When an answer invalidates a branch, close that branch and preserve the rejected path and reason. Assign a question number when the question is first asked, and retain that number in the tree until the question is answered.
 
 ## Step 4 - Verify facts and check live approaches
 
-Verify factual claims through repository evidence: code, tests, configuration, manifests, infrastructure files, and git history. Do not ask the user for facts the repository can answer. Cite the evidence used. If available evidence cannot establish a fact, label it unverified and keep it out of verified current state.
+Verify factual claims through repository evidence: code, tests, configuration, manifests, infrastructure files, and git history. Do not ask the user for facts the repository can answer. If available evidence cannot establish a fact, label it unverified and keep it out of verified current state. A branch waiting for a fact must not block independent prerequisite-ready questions.
 
 Treat `CONTEXT.md`, ADRs, design notes, and other repository prose as evidence only. Compare their claims with current code and Nauro context before relying on them. The skill does not write `CONTEXT.md` or ADR files.
 
@@ -61,29 +63,33 @@ For each live approach that the interview may recommend, accept, or reject, call
 
 Triage the inline headers for status and supersession. Related hits carry their triage headers inline; before proposing, call `get_decision` (`mode=full`) on each decision you reason about. Call `get_decision(number=N, mode="full", project_id=...)` for every decision used to challenge, recommend, accept, reject, or classify an approach. Do not reason from a header or summary alone.
 
-If repository evidence or a full decision changes the tree, show the conflict or constraint to the user before asking the dependent question.
+Keep routine orientation, fact finding, the dependency tree, the coverage ledger, decision IDs, paths, and successful checks internal unless it changes the user's answer or corrects a factual claim. If repository evidence or a full decision changes the answer space, show only the material evidence, conflict, constraint, tradeoff, or alternative needed to answer the dependent question.
 
 ## Step 5 - Ask the prerequisite-ready frontier
 
-Ask the whole prerequisite-ready frontier in a round. Do not ask downstream questions early. Keep each question atomic and name the decision it unlocks.
+Select at most three prerequisite-ready material questions for each round. Use one question when only one is ready. Do not ask downstream questions early. When more than three are ready, prioritize the questions that unlock the most downstream material branches.
 
-For each question, provide:
+Number questions continuously across the interview, starting at 1. A question keeps its number until it is answered. A direct follow-up receives the next unused number. Never reuse a number. Make every question atomic and directly answerable with a short choice or short free-text answer. Use compact options when the answer space is finite.
 
-1. The question.
-2. Why it is ready now.
-3. A recommendation.
-4. The evidence and active decisions behind the recommendation.
-5. The material tradeoffs and credible alternatives.
+Show the numbered question and a concise recommendation. Surface at most the material tradeoff, evidence, conflict, or alternative needed to answer. Do not attach a routine dossier to each question.
 
-Every question must include a recommendation. When evidence cannot support a substantive choice, recommend deferring the choice or preserving it as unresolved. State why, and state the tradeoffs between waiting and deciding under uncertainty.
+Every question must include a recommendation. In Elicit mode, when the user's rationale is unknown, recommend an answer shape, such as a constraint plus one example. Never invent the user's rationale. When evidence cannot support a substantive choice, recommend deferring the choice or preserving it as unresolved. State the material tradeoff between waiting and deciding under uncertainty. Do not present an agent recommendation as project authority. The user owns every choice.
 
-Do not present an agent recommendation as project authority. The user owns every choice. After the round, wait for the user's reply. Do not answer a user-owned choice on the user's behalf. Integrate the reply, update the dependency tree, verify any new factual claims, check new live approaches, and ask the next prerequisite-ready frontier.
+End every round with an instantiated concise reply cue using the question numbers in that batch. Use exactly this form: `Reply: 4: <answer>; 5: <answer>. Answer any subset.` Replace `4` and `5` with the batch's actual question numbers, include each batch question once, and do not add other text to the cue. Then wait for the user's reply. Do not answer a user-owned choice on the user's behalf.
 
-Continue until the user ends the interview or no unresolved node can change a classified outcome. If a blocker cannot be resolved from evidence or user judgment, preserve it as an open question instead of guessing.
+Integrate each reply without rehashing settled answers. Preserve each unanswered ready question with its original number. Recompute dependencies after every partial answer, verify new factual claims, check new live approaches, and unlock every newly valid branch. Never repeat a settled question. Ask the next valid batch without asking permission. Do not ask permission to continue.
+
+Press any vague, contradictory, conditional, slogan-like, or incomplete answer with a direct follow-up for the missing condition, threshold, example, rejected path, failure case, consequence, or reversal trigger. Give that follow-up the next unused number.
+
+Continue until the user stops or every material branch has a disposition. If a blocker cannot be resolved from evidence or user judgment, preserve it as an open question instead of guessing.
 
 ## Step 6 - Classify the outcome
 
-When the frontier is empty, render one shared-understanding summary. Classify each outcome into exactly one of these record classes:
+Before completion, audit the internal coverage ledger for outcome, rationale, constraints, terminology, assumptions, alternatives and rejected paths, consequences, unresolved choices, and material failure cases. In Challenge mode, also audit disconfirming evidence and reversal triggers. Add a prerequisite-ready question for every material gap.
+
+Give every material branch one disposition: settled, verified, rejected with a reason, or explicitly preserved as unresolved. Say `Interview complete` only after every material branch has one of those dispositions. If the user stops early, label the interview incomplete and list only the material unresolved branches.
+
+When the audit passes, render one shared-understanding summary. Classify each outcome into exactly one of these existing record classes:
 
 - **Terminology**: a term and its session meaning. It remains noncanonical unless it expresses a durable, reasoned choice that is separately ratified.
 - **Verified current state**: a present-tense fact established by current repository or system evidence. Never place future design here.
@@ -91,13 +97,15 @@ When the frontier is empty, render one shared-understanding summary. Classify ea
 - **Non-durable detail**: useful session detail that does not belong in project truth.
 - **Candidate durable judgment**: a reasoned project choice with constraints, tradeoffs, rejected alternatives, and consequences that may merit a decision.
 
-For each item, show its evidence, related decisions, confidence, and remaining uncertainty. Ask the user to correct or confirm the shared understanding, then end the turn and wait.
+Render only the nonempty record classes. Include evidence, related decisions, confidence, or uncertainty only when it materially affects the shared understanding. Ask once for correction or confirmation, then end the turn and wait.
 
 Shared understanding is non-authoritative. Confirmation means the summary accurately reflects the interview. It does not approve any Nauro store mutation. Interview agreement never grants write authority.
 
 ## Step 7 - Stage writes without authority
 
-After the user confirms shared understanding, determine which classified items could update Nauro. Do not write yet. Keep the three write classes separate:
+Enter this step only if the user explicitly asked to transfer, save, or record the result. Completing the interview does not stage a write. Confirming the shared-understanding summary does not stage a write. Without explicit transfer intent, stop after confirmation.
+
+After both explicit transfer intent and shared-understanding confirmation, determine which classified items could update Nauro. Do not write yet. Keep the three write classes separate:
 
 1. Candidate durable judgment may produce one decision proposal.
 2. Verified current state may produce one exact complete state replacement.
@@ -173,9 +181,11 @@ Capture and report the tool result. Do not assume that approval means the write 
 
 - The interview runs in the main agent context and waits after every question round.
 - The dependency tree is session state, not project truth.
+- The coverage ledger stays internal and is not project truth.
 - Verify facts from repository or system evidence. Ask the user for judgment and rationale, not discoverable facts.
 - Check every live approach against Nauro decisions. Read every decision used in reasoning in full.
 - Existing `CONTEXT.md` and ADR content is evidence only. Never edit or generate those files in this workflow.
+- Interview completion and summary confirmation do not stage or authorize a write. Staging requires explicit transfer, save, or record intent.
 - Shared-understanding confirmation is never write approval.
 - Decision proposals, state replacements, and open-question entries use separate exact-payload gates and explicit approval from a later user reply. In team mode, that reply authorizes pending proposal submission only.
 - State approval covers one complete replacement body derived from one exact current-state baseline. In hosted team mode, the baseline includes both exact content and exact revision, and the write supplies that revision as `expected_revision`. It never covers a partial delta or a replacement derived after an intervening content or revision change.

--- a/packages/nauro/src/nauro/skills/__init__.py
+++ b/packages/nauro/src/nauro/skills/__init__.py
@@ -196,12 +196,13 @@ SKILL_DESCRIPTIONS: dict[str, str] = {
         "as a narrow process-state exception. Installed by `nauro adopt --with-skills`."
     ),
     "nauro-interview": (
-        "Interview the user to elicit tacit project reasoning or challenge a proposed "
-        "choice against Nauro decisions and repository evidence, then classify the "
-        "result as shared understanding without granting write authority. Use only "
-        "when the user explicitly asks to be interviewed, grilled, stress-tested, or "
-        "helped to transfer reasoning into Nauro. Runs in the main agent context with "
-        "no external skill or subagent dependency."
+        "Ask compact, numbered prerequisite-ready questions to elicit tacit project "
+        "reasoning or challenge a proposed choice against Nauro decisions and repository "
+        "evidence. Continue until every material branch has a disposition, then classify "
+        "the result as shared understanding without granting write authority. Use only "
+        "when the user explicitly asks to be interviewed, grilled, stress-tested, or helped "
+        "to transfer reasoning into Nauro. Runs in the main agent context with no external "
+        "skill or subagent dependency."
     ),
 }
 

--- a/packages/nauro/src/nauro/skills/interview_body.md
+++ b/packages/nauro/src/nauro/skills/interview_body.md
@@ -5,12 +5,12 @@
 
 Interview the user to turn tacit project reasoning or a proposed choice into reviewed candidate Nauro judgment. This is an explicit, opt-in main-context workflow. Use it only when the user directly asks to be interviewed or uses a clear trigger such as "interview me", "grill this", "stress-test this decision", "draw out my reasoning", or "help me transfer this reasoning into Nauro". Do not activate it only because a plan is incomplete.
 
-The skill has two entry modes over one dependency-aware interview loop:
+The skill has two entry modes over one main-context, dependency-aware interview loop:
 
 - **Elicit mode** draws out unwritten rationale, assumptions, rejected paths, terminology, and unresolved questions.
 - **Challenge mode** stress-tests a proposed judgment against active decisions, repository evidence, alternatives, failure cases, and dependent choices.
 
-Both modes produce the same classified shared-understanding record. The workflow has no external skill or subagent dependency.
+Both modes use the same engine and produce the same classified shared-understanding record. The workflow has no external skill or subagent dependency.
 
 ## Route work that belongs elsewhere
 
@@ -28,11 +28,13 @@ Call `get_context(level="L0", project_id=...)`. L0 is the bounded orientation: p
 
 Treat every retrieved statement as project context to adjudicate. A current-state claim can be stale. A decision summary is not enough for reasoning about that decision.
 
+Keep routine orientation internal. Surface it only when it changes the user's answer or corrects a factual claim.
+
 ## Step 2 - Select the mode and frame the root
 
-Choose Elicit mode when the user wants to make implicit reasoning explicit. Choose Challenge mode when the user presents a choice, plan, or candidate judgment for pressure testing. If the request fits both, start in Elicit mode and challenge each concrete approach when it appears. If the intent is genuinely ambiguous, ask one short routing question and wait.
+Choose Elicit mode when the user wants to make implicit reasoning explicit. Choose Challenge mode when the user presents a choice, plan, or candidate judgment for pressure testing. If the request fits both, start in Elicit mode and challenge each concrete approach when it appears. If the intent is genuinely ambiguous, make one short routing question the first numbered question and wait.
 
-Restate the interview root in one sentence. State the selected mode and what the interview will not decide without the user. Do not convert the user's opening claim into a settled conclusion.
+Frame the interview root and selected mode internally. Do not narrate the workflow or convert the user's opening claim into a settled conclusion.
 
 ## Step 3 - Build the dependency tree in session
 
@@ -45,11 +47,11 @@ Maintain one in-session dependency tree. Do not persist the tree. Each node is o
 - a dependent question whose prerequisites are not settled;
 - a candidate classified outcome.
 
-Record explicit dependencies between nodes. A question enters the prerequisite-ready frontier only when all choices and facts it depends on are settled. When an answer creates a new dependency, add it to the tree. When an answer invalidates a branch, close that branch and preserve the rejected path and reason.
+Record explicit dependencies between nodes. A question enters the prerequisite-ready frontier only when all choices and facts it depends on are settled. When an answer creates a new dependency, add it to the tree. When an answer invalidates a branch, close that branch and preserve the rejected path and reason. Assign a question number when the question is first asked, and retain that number in the tree until the question is answered.
 
 ## Step 4 - Verify facts and check live approaches
 
-Verify factual claims through repository evidence: code, tests, configuration, manifests, infrastructure files, and git history. Do not ask the user for facts the repository can answer. Cite the evidence used. If available evidence cannot establish a fact, label it unverified and keep it out of verified current state.
+Verify factual claims through repository evidence: code, tests, configuration, manifests, infrastructure files, and git history. Do not ask the user for facts the repository can answer. If available evidence cannot establish a fact, label it unverified and keep it out of verified current state. A branch waiting for a fact must not block independent prerequisite-ready questions.
 
 Treat `CONTEXT.md`, ADRs, design notes, and other repository prose as evidence only. Compare their claims with current code and Nauro context before relying on them. The skill does not write `CONTEXT.md` or ADR files.
 
@@ -59,29 +61,33 @@ For each live approach that the interview may recommend, accept, or reject, call
 
 Triage the inline headers for status and supersession. <!-- protocol:GET_DECISION_BEFORE_PROPOSING --> Call `get_decision(number=N, mode="full", project_id=...)` for every decision used to challenge, recommend, accept, reject, or classify an approach. Do not reason from a header or summary alone.
 
-If repository evidence or a full decision changes the tree, show the conflict or constraint to the user before asking the dependent question.
+Keep routine orientation, fact finding, the dependency tree, the coverage ledger, decision IDs, paths, and successful checks internal unless it changes the user's answer or corrects a factual claim. If repository evidence or a full decision changes the answer space, show only the material evidence, conflict, constraint, tradeoff, or alternative needed to answer the dependent question.
 
 ## Step 5 - Ask the prerequisite-ready frontier
 
-Ask the whole prerequisite-ready frontier in a round. Do not ask downstream questions early. Keep each question atomic and name the decision it unlocks.
+Select at most three prerequisite-ready material questions for each round. Use one question when only one is ready. Do not ask downstream questions early. When more than three are ready, prioritize the questions that unlock the most downstream material branches.
 
-For each question, provide:
+Number questions continuously across the interview, starting at 1. A question keeps its number until it is answered. A direct follow-up receives the next unused number. Never reuse a number. Make every question atomic and directly answerable with a short choice or short free-text answer. Use compact options when the answer space is finite.
 
-1. The question.
-2. Why it is ready now.
-3. A recommendation.
-4. The evidence and active decisions behind the recommendation.
-5. The material tradeoffs and credible alternatives.
+Show the numbered question and a concise recommendation. Surface at most the material tradeoff, evidence, conflict, or alternative needed to answer. Do not attach a routine dossier to each question.
 
-Every question must include a recommendation. When evidence cannot support a substantive choice, recommend deferring the choice or preserving it as unresolved. State why, and state the tradeoffs between waiting and deciding under uncertainty.
+Every question must include a recommendation. In Elicit mode, when the user's rationale is unknown, recommend an answer shape, such as a constraint plus one example. Never invent the user's rationale. When evidence cannot support a substantive choice, recommend deferring the choice or preserving it as unresolved. State the material tradeoff between waiting and deciding under uncertainty. Do not present an agent recommendation as project authority. The user owns every choice.
 
-Do not present an agent recommendation as project authority. The user owns every choice. After the round, wait for the user's reply. Do not answer a user-owned choice on the user's behalf. Integrate the reply, update the dependency tree, verify any new factual claims, check new live approaches, and ask the next prerequisite-ready frontier.
+End every round with an instantiated concise reply cue using the question numbers in that batch. Use exactly this form: `Reply: 4: <answer>; 5: <answer>. Answer any subset.` Replace `4` and `5` with the batch's actual question numbers, include each batch question once, and do not add other text to the cue. Then wait for the user's reply. Do not answer a user-owned choice on the user's behalf.
 
-Continue until the user ends the interview or no unresolved node can change a classified outcome. If a blocker cannot be resolved from evidence or user judgment, preserve it as an open question instead of guessing.
+Integrate each reply without rehashing settled answers. Preserve each unanswered ready question with its original number. Recompute dependencies after every partial answer, verify new factual claims, check new live approaches, and unlock every newly valid branch. Never repeat a settled question. Ask the next valid batch without asking permission. Do not ask permission to continue.
+
+Press any vague, contradictory, conditional, slogan-like, or incomplete answer with a direct follow-up for the missing condition, threshold, example, rejected path, failure case, consequence, or reversal trigger. Give that follow-up the next unused number.
+
+Continue until the user stops or every material branch has a disposition. If a blocker cannot be resolved from evidence or user judgment, preserve it as an open question instead of guessing.
 
 ## Step 6 - Classify the outcome
 
-When the frontier is empty, render one shared-understanding summary. Classify each outcome into exactly one of these record classes:
+Before completion, audit the internal coverage ledger for outcome, rationale, constraints, terminology, assumptions, alternatives and rejected paths, consequences, unresolved choices, and material failure cases. In Challenge mode, also audit disconfirming evidence and reversal triggers. Add a prerequisite-ready question for every material gap.
+
+Give every material branch one disposition: settled, verified, rejected with a reason, or explicitly preserved as unresolved. Say `Interview complete` only after every material branch has one of those dispositions. If the user stops early, label the interview incomplete and list only the material unresolved branches.
+
+When the audit passes, render one shared-understanding summary. Classify each outcome into exactly one of these existing record classes:
 
 - **Terminology**: a term and its session meaning. It remains noncanonical unless it expresses a durable, reasoned choice that is separately ratified.
 - **Verified current state**: a present-tense fact established by current repository or system evidence. Never place future design here.
@@ -89,13 +95,15 @@ When the frontier is empty, render one shared-understanding summary. Classify ea
 - **Non-durable detail**: useful session detail that does not belong in project truth.
 - **Candidate durable judgment**: a reasoned project choice with constraints, tradeoffs, rejected alternatives, and consequences that may merit a decision.
 
-For each item, show its evidence, related decisions, confidence, and remaining uncertainty. Ask the user to correct or confirm the shared understanding, then end the turn and wait.
+Render only the nonempty record classes. Include evidence, related decisions, confidence, or uncertainty only when it materially affects the shared understanding. Ask once for correction or confirmation, then end the turn and wait.
 
 Shared understanding is non-authoritative. Confirmation means the summary accurately reflects the interview. It does not approve any Nauro store mutation. Interview agreement never grants write authority.
 
 ## Step 7 - Stage writes without authority
 
-After the user confirms shared understanding, determine which classified items could update Nauro. Do not write yet. Keep the three write classes separate:
+Enter this step only if the user explicitly asked to transfer, save, or record the result. Completing the interview does not stage a write. Confirming the shared-understanding summary does not stage a write. Without explicit transfer intent, stop after confirmation.
+
+After both explicit transfer intent and shared-understanding confirmation, determine which classified items could update Nauro. Do not write yet. Keep the three write classes separate:
 
 1. Candidate durable judgment may produce one decision proposal.
 2. Verified current state may produce one exact complete state replacement.
@@ -168,9 +176,11 @@ Capture and report the tool result. Do not assume that approval means the write 
 
 - The interview runs in the main agent context and waits after every question round.
 - The dependency tree is session state, not project truth.
+- The coverage ledger stays internal and is not project truth.
 - Verify facts from repository or system evidence. Ask the user for judgment and rationale, not discoverable facts.
 - Check every live approach against Nauro decisions. Read every decision used in reasoning in full.
 - Existing `CONTEXT.md` and ADR content is evidence only. Never edit or generate those files in this workflow.
+- Interview completion and summary confirmation do not stage or authorize a write. Staging requires explicit transfer, save, or record intent.
 - Shared-understanding confirmation is never write approval.
 - Decision proposals, state replacements, and open-question entries use separate exact-payload gates and explicit approval from a later user reply. In team mode, that reply authorizes pending proposal submission only.
 - State approval covers one complete replacement body derived from one exact current-state baseline. In hosted team mode, the baseline includes both exact content and exact revision, and the write supplies that revision as `expected_revision`. It never covers a partial delta or a replacement derived after an intervening content or revision change.

--- a/packages/nauro/tests/test_skills_drift.py
+++ b/packages/nauro/tests/test_skills_drift.py
@@ -481,6 +481,88 @@ def test_load_interview_body_preserves_deliberation_boundary():
     assert "does not write `CONTEXT.md` or ADR files" in body
 
 
+def test_interview_body_asks_compact_bounded_numbered_rounds():
+    body = load_interview_body()
+
+    assert "at most three prerequisite-ready material questions" in body
+    assert "Use one question when only one is ready" in body
+    assert "unlock the most downstream material branches" in body
+    assert "Number questions continuously across the interview, starting at 1" in body
+    assert "keeps its number until it is answered" in body
+    assert "next unused number" in body
+    assert "atomic and directly answerable with a short choice or short free-text answer" in body
+    assert "Use compact options when the answer space is finite" in body
+    assert "Use exactly this form: `Reply: 4: <answer>; 5: <answer>. Answer any subset.`" in body
+
+
+def test_interview_body_advances_dependencies_without_repetition():
+    body = load_interview_body()
+
+    assert "Preserve each unanswered ready question with its original number" in body
+    assert "Recompute dependencies after every partial answer" in body
+    assert "Never repeat a settled question" in body
+    assert "Do not ask permission to continue" in body
+    assert "must not block independent prerequisite-ready questions" in body
+    assert "vague, contradictory, conditional, slogan-like, or incomplete" in body
+    for missing_detail in (
+        "condition",
+        "threshold",
+        "example",
+        "rejected path",
+        "failure case",
+        "consequence",
+        "reversal trigger",
+    ):
+        assert missing_detail in body
+
+
+def test_interview_body_keeps_routine_work_internal_and_recommendations_bounded():
+    body = load_interview_body()
+
+    assert "recommend an answer shape" in body
+    assert "Never invent the user's rationale" in body
+    assert "routine orientation" in body
+    assert "fact finding" in body
+    assert "dependency tree" in body
+    assert "coverage ledger" in body
+    assert "unless it changes the user's answer or corrects a factual claim" in body
+    assert "For each question, provide:" not in body
+    assert "Why it is ready now" not in body
+
+
+def test_interview_body_audits_coverage_and_branch_dispositions():
+    body = load_interview_body()
+
+    for coverage_class in (
+        "outcome",
+        "rationale",
+        "constraints",
+        "terminology",
+        "assumptions",
+        "alternatives and rejected paths",
+        "consequences",
+        "unresolved choices",
+        "material failure cases",
+    ):
+        assert coverage_class in body
+    assert "disconfirming evidence and reversal triggers" in body
+    assert "`Interview complete` only after every material branch" in body
+    assert (
+        "settled, verified, rejected with a reason, or explicitly preserved as unresolved" in body
+    )
+    assert "label the interview incomplete" in body
+    assert "only the material unresolved branches" in body
+    assert "Render only the nonempty record classes" in body
+
+
+def test_interview_body_never_stages_writes_from_completion_or_confirmation():
+    body = load_interview_body()
+
+    assert "explicitly asked to transfer, save, or record the result" in body
+    assert "Completing the interview does not stage a write" in body
+    assert "Confirming the shared-understanding summary does not stage a write" in body
+
+
 def test_interview_body_requires_separate_later_reply_for_each_write_class():
     body = load_interview_body()
 
@@ -547,6 +629,7 @@ def test_render_skill_interview_frontmatter():
     claude = render_skill("claude_code", "nauro-interview")
     assert claude.startswith("---\nname: nauro-interview\n")
     assert "description:" in claude.split("\n---\n", 1)[0]
+    assert "compact, numbered prerequisite-ready questions" in claude.split("\n---\n", 1)[0]
     assert claude.split("\n---\n", 1)[1].lstrip("\n") == load_interview_body()
 
     cursor = render_skill("cursor", "nauro-interview")


### PR DESCRIPTION
## Why

Nauro Interview asked the whole ready question frontier and attached a five-part dossier to every question. This made rounds slower to answer and exposed process details that did not change the user's choice.

## What changed

- Limit each round to at most three compact, numbered, prerequisite-ready questions.
- Preserve question numbers across partial answers, unlock dependent questions as prerequisites settle, and follow up on vague or incomplete answers.
- Keep routine fact finding and workflow state internal, audit material coverage before completion, and report early stops as incomplete.
- Keep shared-understanding confirmation non-authoritative. Stage writes only after explicit transfer, save, or record intent.
- Regenerate the Claude Code, Codex, and Cursor skill surfaces from the canonical body.

## Test plan

- `pytest packages/nauro/tests/test_skills_drift.py packages/nauro/tests/test_protocol_drift.py packages/nauro/tests/test_skill_tool_signatures.py packages/nauro-core/tests/test_protocol.py -q` (377 passed)
- `pytest packages/nauro/tests --ignore=packages/nauro/tests/cross_surface -q` (2,736 passed)
- `ruff check .` (passed)
- `ruff format --check .` (368 files already formatted)
- `uv build --package nauro --wheel` (passed)
- Four fresh-agent transcript evaluations for Elicit, Challenge, partial-answer, and early-stop scenarios (passed)

## Risk / what to review

The behavior is instruction-driven. Review the question-number lifecycle, partial-answer reconciliation, completion audit, and no-write boundary.

## Deferred

Opt-in installer activation, help text, documentation, and install round-trip coverage remain a separate follow-up.
