### PR TITLE
Install Interview through opt-in skills

### DIFF
--- a/docs/adopt-prompt.md
+++ b/docs/adopt-prompt.md
@@ -12,8 +12,8 @@ nauro adopt --name <your-project-name>
 
 That registers the project, wires MCP across surfaces, and installs the
 `nauro-adopt` skill. (The session skill `nauro-context`, the workflow skill
-`nauro-ship-task`, and the loop skill `nauro-loop` are opt-in via
-`nauro adopt --with-skills`.) Once that has
+`nauro-ship-task`, the loop skill `nauro-loop`, and the interview skill
+`nauro-interview` are opt-in via `nauro adopt --with-skills`.) Once that has
 run, you can use the prompt below from any connected chat surface to seed the
 project's store with context.
 

--- a/packages/nauro/src/nauro/cli/commands/adopt.py
+++ b/packages/nauro/src/nauro/cli/commands/adopt.py
@@ -382,7 +382,7 @@ def adopt(
         "--with-skills",
         help=(
             "Install Nauro's bundled opt-in skills "
-            "(nauro-ship-task, nauro-context, nauro-loop) alongside the "
+            "(nauro-ship-task, nauro-context, nauro-loop, nauro-interview) alongside the "
             "always-installed nauro-adopt skill. Independent of --with-subagents."
         ),
     ),

--- a/packages/nauro/src/nauro/cli/commands/setup.py
+++ b/packages/nauro/src/nauro/cli/commands/setup.py
@@ -204,7 +204,7 @@ def all_(
         "--with-skills",
         help=(
             "Install Nauro's bundled opt-in skills "
-            "(nauro-ship-task, nauro-context, nauro-loop) alongside the "
+            "(nauro-ship-task, nauro-context, nauro-loop, nauro-interview) alongside the "
             "always-installed nauro-adopt skill. Independent of --with-subagents."
         ),
     ),

--- a/packages/nauro/src/nauro/cli/integrations/skills.py
+++ b/packages/nauro/src/nauro/cli/integrations/skills.py
@@ -17,7 +17,12 @@ from nauro.store.write_safety import (
 # SKILL_NAMES always installs; OPT_IN_SKILL_NAMES only when the caller passes with_skills=True.
 
 SKILL_NAMES: tuple[str, ...] = ("nauro-adopt",)
-OPT_IN_SKILL_NAMES: tuple[str, ...] = ("nauro-ship-task", "nauro-context", "nauro-loop")
+OPT_IN_SKILL_NAMES: tuple[str, ...] = (
+    "nauro-ship-task",
+    "nauro-context",
+    "nauro-loop",
+    "nauro-interview",
+)
 
 
 def _claude_skill_dir() -> Path:

--- a/packages/nauro/tests/test_cli_status.py
+++ b/packages/nauro/tests/test_cli_status.py
@@ -89,7 +89,7 @@ def test_status_reports_current_skills_and_agents_on_both_surfaces(tmp_path, mon
     result = runner.invoke(app, ["status"])
 
     assert result.exit_code == 0
-    assert "Skills        active (Claude 4/4; Codex 4/4)" in result.output
+    assert "Skills        active (Claude 5/5; Codex 5/5)" in result.output
     assert "Workflow      active (Claude 4/4; Codex 4/4)" in result.output
 
 
@@ -124,7 +124,7 @@ def test_status_reports_stale_skill_without_legacy_copy(tmp_path, monkeypatch):
     result = runner.invoke(app, ["status"])
 
     assert result.exit_code == 0
-    assert "Skills        BROKEN - Claude 4/4; Codex 3/4" in result.output
+    assert "Skills        BROKEN - Claude 5/5; Codex 4/5" in result.output
     assert "differ from this release; run 'nauro setup all --with-skills'" in result.output
 
 
@@ -157,7 +157,24 @@ def test_status_partial_optin_skills_prompt_completion(tmp_path, monkeypatch):
 
     assert result.exit_code == 0
     assert (
-        "Skills        partial (Claude 4/4; Codex 1/4) - "
+        "Skills        partial (Claude 5/5; Codex 1/5) - "
+        "run 'nauro setup all --with-skills'" in result.output
+    )
+
+
+def test_status_prior_release_skills_prompt_refresh_on_both_surfaces(tmp_path, monkeypatch):
+    """A prior four-skill install is partial on both surfaces until refreshed."""
+    _setup_project(tmp_path, monkeypatch)
+    _install_workflow_artifacts()
+    home = tmp_path / "home"
+    (home / ".claude" / "skills" / "nauro-interview" / "SKILL.md").unlink()
+    (home / ".agents" / "skills" / "nauro-interview" / "SKILL.md").unlink()
+
+    result = runner.invoke(app, ["status"])
+
+    assert result.exit_code == 0
+    assert (
+        "Skills        partial (Claude 4/5; Codex 4/5) - "
         "run 'nauro setup all --with-skills'" in result.output
     )
 

--- a/packages/nauro/tests/test_onboarding_inventories.py
+++ b/packages/nauro/tests/test_onboarding_inventories.py
@@ -132,6 +132,7 @@ def test_adopt_with_skills_and_subagents_inventory(tmp_path: Path, monkeypatch):
         | {
             ".agents/skills/nauro-adopt/SKILL.md",
             ".agents/skills/nauro-context/SKILL.md",
+            ".agents/skills/nauro-interview/SKILL.md",
             ".agents/skills/nauro-loop/SKILL.md",
             ".agents/skills/nauro-ship-task/SKILL.md",
             ".claude/agents/nauro-executor.md",
@@ -140,6 +141,7 @@ def test_adopt_with_skills_and_subagents_inventory(tmp_path: Path, monkeypatch):
             ".claude/agents/nauro-tech-lead.md",
             ".claude/skills/nauro-adopt/SKILL.md",
             ".claude/skills/nauro-context/SKILL.md",
+            ".claude/skills/nauro-interview/SKILL.md",
             ".claude/skills/nauro-loop/SKILL.md",
             ".claude/skills/nauro-ship-task/SKILL.md",
             ".codex/agents/nauro-executor.toml",
@@ -150,6 +152,7 @@ def test_adopt_with_skills_and_subagents_inventory(tmp_path: Path, monkeypatch):
             "repo/.cursor/mcp.json",
             "repo/.cursor/rules/nauro-adopt.mdc",
             "repo/.cursor/rules/nauro-context.mdc",
+            "repo/.cursor/rules/nauro-interview.mdc",
             "repo/.cursor/rules/nauro-loop.mdc",
             "repo/.cursor/rules/nauro-ship-task.mdc",
             "repo/.gitignore",

--- a/packages/nauro/tests/test_setup_characterization.py
+++ b/packages/nauro/tests/test_setup_characterization.py
@@ -373,6 +373,7 @@ class TestSetupAllTranscripts:
             "  wrote {TMP}/.claude/skills/nauro-ship-task/SKILL.md\n"
             "  wrote {TMP}/.claude/skills/nauro-context/SKILL.md\n"
             "  wrote {TMP}/.claude/skills/nauro-loop/SKILL.md\n"
+            "  wrote {TMP}/.claude/skills/nauro-interview/SKILL.md\n"
             "  installed {TMP}/.claude/agents/nauro-planner.md\n"
             "  installed {TMP}/.claude/agents/nauro-executor.md\n"
             "  installed {TMP}/.claude/agents/nauro-reviewer.md\n"
@@ -383,11 +384,13 @@ class TestSetupAllTranscripts:
             "  wrote {TMP}/repo/.cursor/rules/nauro-ship-task.mdc\n"
             "  wrote {TMP}/repo/.cursor/rules/nauro-context.mdc\n"
             "  wrote {TMP}/repo/.cursor/rules/nauro-loop.mdc\n"
+            "  wrote {TMP}/repo/.cursor/rules/nauro-interview.mdc\n"
             "Codex: wrote nauro to {TMP}/.codex/config.toml\n"
             "  wrote {TMP}/.agents/skills/nauro-adopt/SKILL.md\n"
             "  wrote {TMP}/.agents/skills/nauro-ship-task/SKILL.md\n"
             "  wrote {TMP}/.agents/skills/nauro-context/SKILL.md\n"
             "  wrote {TMP}/.agents/skills/nauro-loop/SKILL.md\n"
+            "  wrote {TMP}/.agents/skills/nauro-interview/SKILL.md\n"
             "  installed {TMP}/.codex/agents/nauro-planner.toml\n"
             "  installed {TMP}/.codex/agents/nauro-executor.toml\n"
             "  installed {TMP}/.codex/agents/nauro-reviewer.toml\n"
@@ -512,16 +515,19 @@ class TestSetupAllTranscripts:
             "  wrote {TMP}/.claude/skills/nauro-ship-task/SKILL.md\n"
             "  wrote {TMP}/.claude/skills/nauro-context/SKILL.md\n"
             "  wrote {TMP}/.claude/skills/nauro-loop/SKILL.md\n"
+            "  wrote {TMP}/.claude/skills/nauro-interview/SKILL.md\n"
             "  {TMP}/repo: wrote nauro to .cursor/mcp.json\n"
             "  wrote {TMP}/repo/.cursor/rules/nauro-adopt.mdc\n"
             "  wrote {TMP}/repo/.cursor/rules/nauro-ship-task.mdc\n"
             "  wrote {TMP}/repo/.cursor/rules/nauro-context.mdc\n"
             "  wrote {TMP}/repo/.cursor/rules/nauro-loop.mdc\n"
+            "  wrote {TMP}/repo/.cursor/rules/nauro-interview.mdc\n"
             "Codex: wrote nauro to {TMP}/.codex/config.toml\n"
             "  wrote {TMP}/.agents/skills/nauro-adopt/SKILL.md\n"
             "  wrote {TMP}/.agents/skills/nauro-ship-task/SKILL.md\n"
             "  wrote {TMP}/.agents/skills/nauro-context/SKILL.md\n"
             "  wrote {TMP}/.agents/skills/nauro-loop/SKILL.md\n"
+            "  wrote {TMP}/.agents/skills/nauro-interview/SKILL.md\n"
             "  {TMP}/repo: regenerated AGENTS.md\n"
             + _bridge_line()
             + "\n"
@@ -722,12 +728,13 @@ class TestSetupAllTranscripts:
         # opt-in skills in both skill roots, their Cursor rules, and all subagents.
         for root in (".claude/skills", ".agents/skills"):
             names = {p.name for p in (tmp_path / root).iterdir()}
-            assert names == {"nauro-ship-task", "nauro-context", "nauro-loop"}
+            assert names == {"nauro-ship-task", "nauro-context", "nauro-loop", "nauro-interview"}
         rule_names = {p.name for p in (tmp_path / "repo" / ".cursor" / "rules").iterdir()}
         assert rule_names == {
             "nauro-ship-task.mdc",
             "nauro-context.mdc",
             "nauro-loop.mdc",
+            "nauro-interview.mdc",
         }
         agent_names = {p.name for p in (tmp_path / ".claude" / "agents").iterdir()}
         assert agent_names == {
@@ -770,6 +777,7 @@ class TestSetupAllTranscripts:
             "  removed {TMP}/.claude/skills/nauro-ship-task/SKILL.md\n"
             "  removed {TMP}/.claude/skills/nauro-context/SKILL.md\n"
             "  removed {TMP}/.claude/skills/nauro-loop/SKILL.md\n"
+            "  removed {TMP}/.claude/skills/nauro-interview/SKILL.md\n"
             "  removed {TMP}/.claude/agents/nauro-planner.md\n"
             "  removed {TMP}/.claude/agents/nauro-executor.md\n"
             "  removed {TMP}/.claude/agents/nauro-reviewer.md\n"
@@ -780,11 +788,13 @@ class TestSetupAllTranscripts:
             "  removed {TMP}/repo/.cursor/rules/nauro-ship-task.mdc\n"
             "  removed {TMP}/repo/.cursor/rules/nauro-context.mdc\n"
             "  removed {TMP}/repo/.cursor/rules/nauro-loop.mdc\n"
+            "  removed {TMP}/repo/.cursor/rules/nauro-interview.mdc\n"
             "Codex: removed nauro from {TMP}/.codex/config.toml\n"
             "  removed {TMP}/.agents/skills/nauro-adopt/SKILL.md\n"
             "  removed {TMP}/.agents/skills/nauro-ship-task/SKILL.md\n"
             "  removed {TMP}/.agents/skills/nauro-context/SKILL.md\n"
             "  removed {TMP}/.agents/skills/nauro-loop/SKILL.md\n"
+            "  removed {TMP}/.agents/skills/nauro-interview/SKILL.md\n"
             "  removed {TMP}/.codex/agents/nauro-planner.toml\n"
             "  removed {TMP}/.codex/agents/nauro-executor.toml\n"
             "  removed {TMP}/.codex/agents/nauro-reviewer.toml\n"
@@ -920,6 +930,7 @@ class TestCommandIdempotency:
             "  unchanged {TMP}/.claude/skills/nauro-ship-task/SKILL.md\n"
             "  unchanged {TMP}/.claude/skills/nauro-context/SKILL.md\n"
             "  unchanged {TMP}/.claude/skills/nauro-loop/SKILL.md\n"
+            "  unchanged {TMP}/.claude/skills/nauro-interview/SKILL.md\n"
             "  unchanged {TMP}/.claude/agents/nauro-planner.md\n"
             "  unchanged {TMP}/.claude/agents/nauro-executor.md\n"
             "  unchanged {TMP}/.claude/agents/nauro-reviewer.md\n"
@@ -930,11 +941,13 @@ class TestCommandIdempotency:
             "  unchanged {TMP}/repo/.cursor/rules/nauro-ship-task.mdc\n"
             "  unchanged {TMP}/repo/.cursor/rules/nauro-context.mdc\n"
             "  unchanged {TMP}/repo/.cursor/rules/nauro-loop.mdc\n"
+            "  unchanged {TMP}/repo/.cursor/rules/nauro-interview.mdc\n"
             "Codex: nauro already configured in {TMP}/.codex/config.toml\n"
             "  unchanged {TMP}/.agents/skills/nauro-adopt/SKILL.md\n"
             "  unchanged {TMP}/.agents/skills/nauro-ship-task/SKILL.md\n"
             "  unchanged {TMP}/.agents/skills/nauro-context/SKILL.md\n"
             "  unchanged {TMP}/.agents/skills/nauro-loop/SKILL.md\n"
+            "  unchanged {TMP}/.agents/skills/nauro-interview/SKILL.md\n"
             "  unchanged {TMP}/.codex/agents/nauro-planner.toml\n"
             "  unchanged {TMP}/.codex/agents/nauro-executor.toml\n"
             "  unchanged {TMP}/.codex/agents/nauro-reviewer.toml\n"

--- a/packages/nauro/tests/test_setup_extended.py
+++ b/packages/nauro/tests/test_setup_extended.py
@@ -751,6 +751,9 @@ def test_setup_all_default_does_not_install_ship_task(tmp_path: Path, monkeypatc
     assert not (tmp_path / ".claude" / "skills" / "nauro-loop" / "SKILL.md").exists()
     assert not (tmp_path / ".agents" / "skills" / "nauro-loop" / "SKILL.md").exists()
     assert not (repo / ".cursor" / "rules" / "nauro-loop.mdc").exists()
+    assert not (tmp_path / ".claude" / "skills" / "nauro-interview" / "SKILL.md").exists()
+    assert not (tmp_path / ".agents" / "skills" / "nauro-interview" / "SKILL.md").exists()
+    assert not (repo / ".cursor" / "rules" / "nauro-interview.mdc").exists()
 
 
 def test_setup_all_with_skills_installs_ship_task_everywhere(tmp_path: Path, monkeypatch):
@@ -936,6 +939,35 @@ def test_setup_all_with_skills_installs_loop_everywhere(tmp_path: Path, monkeypa
     assert not cursor.exists()
 
 
+def test_setup_all_with_skills_installs_interview_everywhere(tmp_path: Path, monkeypatch):
+    """``--with-skills`` installs and removes byte-equal Interview artifacts."""
+    from nauro.skills import render_skill
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    _, store_path = register_project_v2("myproj", [repo])
+    scaffold_project_store("myproj", store_path)
+    monkeypatch.chdir(repo)
+
+    install = runner.invoke(app, ["setup", "all", "--with-skills"])
+    assert install.exit_code == 0, install.output
+
+    claude = tmp_path / ".claude" / "skills" / "nauro-interview" / "SKILL.md"
+    codex = tmp_path / ".agents" / "skills" / "nauro-interview" / "SKILL.md"
+    cursor = repo / ".cursor" / "rules" / "nauro-interview.mdc"
+    assert claude.read_text(encoding="utf-8") == render_skill("claude_code", "nauro-interview")
+    assert codex.read_text(encoding="utf-8") == render_skill("codex", "nauro-interview")
+    assert cursor.read_text(encoding="utf-8") == render_skill("cursor", "nauro-interview")
+
+    remove = runner.invoke(app, ["setup", "all", "--remove", "--with-skills"])
+    assert remove.exit_code == 0, remove.output
+
+    assert not claude.exists()
+    assert not codex.exists()
+    assert not cursor.exists()
+
+
 def test_setup_all_with_skills_and_subagents_suppresses_notice(tmp_path: Path, monkeypatch):
     """When both flags are passed, no notice — prerequisites met."""
     monkeypatch.setenv("HOME", str(tmp_path))
@@ -950,7 +982,7 @@ def test_setup_all_with_skills_and_subagents_suppresses_notice(tmp_path: Path, m
     assert "nauro-ship-task references the bundled @nauro-* subagents" not in result.output
 
 
-def test_setup_all_remove_without_with_skills_leaves_ship_task_intact(tmp_path: Path, monkeypatch):
+def test_setup_all_remove_without_with_skills_leaves_interview_intact(tmp_path: Path, monkeypatch):
     """If the user installed ``--with-skills`` and removes without the flag,
     the opt-in skill files persist — the remove path mirrors the install path's
     name set so partial cleanups are explicit, not silent."""
@@ -962,13 +994,13 @@ def test_setup_all_remove_without_with_skills_leaves_ship_task_intact(tmp_path: 
     monkeypatch.chdir(repo)
 
     runner.invoke(app, ["setup", "all", "--with-skills"])
-    claude = tmp_path / ".claude" / "skills" / "nauro-ship-task" / "SKILL.md"
+    claude = tmp_path / ".claude" / "skills" / "nauro-interview" / "SKILL.md"
     assert claude.is_file()
 
     remove = runner.invoke(app, ["setup", "all", "--remove"])  # no --with-skills
     assert remove.exit_code == 0, remove.output
 
-    # nauro-adopt is cleared (the always-installed set), nauro-ship-task is not.
+    # nauro-adopt is cleared (the always-installed set), nauro-interview is not.
     assert not (tmp_path / ".claude" / "skills" / "nauro-adopt" / "SKILL.md").exists()
     assert claude.is_file()
 


### PR DESCRIPTION
## Why

The existing opt-in workflow should install the approved Interview artifact across all supported agent surfaces. Older four-skill installations should also become visibly incomplete until users refresh them.

## What changed

- Added `nauro-interview` to the shared opt-in skill inventory for Claude Code, Codex, and Cursor.
- Named Interview in the `adopt` and `setup all` help and the adoption documentation.
- Updated installation, removal, onboarding inventory, transcript, rerun, and status coverage.
- Kept plain setup and adoption behavior unchanged. The three checked-in Interview renders are unchanged.

## Test plan

- Focused setup, characterization, onboarding inventory, and status suites: 123 passed.
- Skill-render and protocol-drift suites: 276 passed.
- Full CI-configured Nauro suite: 2,738 passed.
- Cross-surface suite: 10 skipped because the private cloud-store package was unavailable.
- Ruff check and format checks passed.
- Single-source, docstring-budget, server-version, import-boundary, diff, and wheel-build checks passed.

## Risk / what to review

Confirm the prior-release `4/5` status on both user surfaces, byte-equal installation at all three destinations, and the difference between flagged and unflagged removal.
