### PR TITLE
Clarify Nauro interview questions

### DIFF
--- a/.agents/skills/nauro-interview/SKILL.md
+++ b/.agents/skills/nauro-interview/SKILL.md
@@ -69,11 +69,17 @@ Keep routine orientation, fact finding, the dependency tree, the coverage ledger
 
 Select at most three prerequisite-ready material questions for each round. Use one question when only one is ready. Do not ask downstream questions early. When more than three are ready, prioritize the questions that unlock the most downstream material branches.
 
-Number questions continuously across the interview, starting at 1. A question keeps its number until it is answered. A direct follow-up receives the next unused number. Never reuse a number. Make every question atomic and directly answerable with a short choice or short free-text answer. Use compact options when the answer space is finite.
+Number questions continuously across the interview, starting at 1. A question keeps its number until it is answered. A direct follow-up receives the next unused number. Never reuse a number. Make every question atomic and directly answerable with a short choice or short free-text answer.
 
-Show the numbered question and a concise recommendation. Surface at most the material tradeoff, evidence, conflict, or alternative needed to answer. Do not attach a routine dossier to each question.
+Present every question in this stable three-part form:
 
-Every question must include a recommendation. In Elicit mode, when the user's rationale is unknown, recommend an answer shape, such as a constraint plus one example. Never invent the user's rationale. When evidence cannot support a substantive choice, recommend deferring the choice or preserving it as unresolved. State the material tradeoff between waiting and deciding under uncertainty. Do not present an agent recommendation as project authority. The user owns every choice.
+1. `<continuous number>. <short decision label>`
+2. A direct question that names every finite choice.
+3. `Recommendation: <concrete answer>. <concise rationale>`
+
+Surface at most the material tradeoff, evidence, conflict, or alternative needed to answer. Do not attach a routine dossier to each question.
+
+Every question must include a recommendation. Every substantive recommendation starts with the concrete recommended answer and then gives concise rationale. Use answer-shape guidance only when repository evidence and active project judgment cannot support a substantive recommendation without inventing a user-owned choice or rationale. Never invent the user's rationale. Treat `defer` and `preserve unresolved` as concrete advisory recommendations when evidence is insufficient, and state the material tradeoff between waiting and deciding under uncertainty. Every recommendation remains advisory. The user owns every choice.
 
 End every round with an instantiated concise reply cue using the question numbers in that batch. Use exactly this form: `Reply: 4: <answer>; 5: <answer>. Answer any subset.` Replace `4` and `5` with the batch's actual question numbers, include each batch question once, and do not add other text to the cue. Then wait for the user's reply. Do not answer a user-owned choice on the user's behalf.
 

--- a/.claude/skills/nauro-interview/SKILL.md
+++ b/.claude/skills/nauro-interview/SKILL.md
@@ -69,11 +69,17 @@ Keep routine orientation, fact finding, the dependency tree, the coverage ledger
 
 Select at most three prerequisite-ready material questions for each round. Use one question when only one is ready. Do not ask downstream questions early. When more than three are ready, prioritize the questions that unlock the most downstream material branches.
 
-Number questions continuously across the interview, starting at 1. A question keeps its number until it is answered. A direct follow-up receives the next unused number. Never reuse a number. Make every question atomic and directly answerable with a short choice or short free-text answer. Use compact options when the answer space is finite.
+Number questions continuously across the interview, starting at 1. A question keeps its number until it is answered. A direct follow-up receives the next unused number. Never reuse a number. Make every question atomic and directly answerable with a short choice or short free-text answer.
 
-Show the numbered question and a concise recommendation. Surface at most the material tradeoff, evidence, conflict, or alternative needed to answer. Do not attach a routine dossier to each question.
+Present every question in this stable three-part form:
 
-Every question must include a recommendation. In Elicit mode, when the user's rationale is unknown, recommend an answer shape, such as a constraint plus one example. Never invent the user's rationale. When evidence cannot support a substantive choice, recommend deferring the choice or preserving it as unresolved. State the material tradeoff between waiting and deciding under uncertainty. Do not present an agent recommendation as project authority. The user owns every choice.
+1. `<continuous number>. <short decision label>`
+2. A direct question that names every finite choice.
+3. `Recommendation: <concrete answer>. <concise rationale>`
+
+Surface at most the material tradeoff, evidence, conflict, or alternative needed to answer. Do not attach a routine dossier to each question.
+
+Every question must include a recommendation. Every substantive recommendation starts with the concrete recommended answer and then gives concise rationale. Use answer-shape guidance only when repository evidence and active project judgment cannot support a substantive recommendation without inventing a user-owned choice or rationale. Never invent the user's rationale. Treat `defer` and `preserve unresolved` as concrete advisory recommendations when evidence is insufficient, and state the material tradeoff between waiting and deciding under uncertainty. Every recommendation remains advisory. The user owns every choice.
 
 End every round with an instantiated concise reply cue using the question numbers in that batch. Use exactly this form: `Reply: 4: <answer>; 5: <answer>. Answer any subset.` Replace `4` and `5` with the batch's actual question numbers, include each batch question once, and do not add other text to the cue. Then wait for the user's reply. Do not answer a user-owned choice on the user's behalf.
 

--- a/.cursor/rules/nauro-interview.mdc
+++ b/.cursor/rules/nauro-interview.mdc
@@ -69,11 +69,17 @@ Keep routine orientation, fact finding, the dependency tree, the coverage ledger
 
 Select at most three prerequisite-ready material questions for each round. Use one question when only one is ready. Do not ask downstream questions early. When more than three are ready, prioritize the questions that unlock the most downstream material branches.
 
-Number questions continuously across the interview, starting at 1. A question keeps its number until it is answered. A direct follow-up receives the next unused number. Never reuse a number. Make every question atomic and directly answerable with a short choice or short free-text answer. Use compact options when the answer space is finite.
+Number questions continuously across the interview, starting at 1. A question keeps its number until it is answered. A direct follow-up receives the next unused number. Never reuse a number. Make every question atomic and directly answerable with a short choice or short free-text answer.
 
-Show the numbered question and a concise recommendation. Surface at most the material tradeoff, evidence, conflict, or alternative needed to answer. Do not attach a routine dossier to each question.
+Present every question in this stable three-part form:
 
-Every question must include a recommendation. In Elicit mode, when the user's rationale is unknown, recommend an answer shape, such as a constraint plus one example. Never invent the user's rationale. When evidence cannot support a substantive choice, recommend deferring the choice or preserving it as unresolved. State the material tradeoff between waiting and deciding under uncertainty. Do not present an agent recommendation as project authority. The user owns every choice.
+1. `<continuous number>. <short decision label>`
+2. A direct question that names every finite choice.
+3. `Recommendation: <concrete answer>. <concise rationale>`
+
+Surface at most the material tradeoff, evidence, conflict, or alternative needed to answer. Do not attach a routine dossier to each question.
+
+Every question must include a recommendation. Every substantive recommendation starts with the concrete recommended answer and then gives concise rationale. Use answer-shape guidance only when repository evidence and active project judgment cannot support a substantive recommendation without inventing a user-owned choice or rationale. Never invent the user's rationale. Treat `defer` and `preserve unresolved` as concrete advisory recommendations when evidence is insufficient, and state the material tradeoff between waiting and deciding under uncertainty. Every recommendation remains advisory. The user owns every choice.
 
 End every round with an instantiated concise reply cue using the question numbers in that batch. Use exactly this form: `Reply: 4: <answer>; 5: <answer>. Answer any subset.` Replace `4` and `5` with the batch's actual question numbers, include each batch question once, and do not add other text to the cue. Then wait for the user's reply. Do not answer a user-owned choice on the user's behalf.
 

--- a/packages/nauro/src/nauro/skills/interview_body.md
+++ b/packages/nauro/src/nauro/skills/interview_body.md
@@ -67,11 +67,17 @@ Keep routine orientation, fact finding, the dependency tree, the coverage ledger
 
 Select at most three prerequisite-ready material questions for each round. Use one question when only one is ready. Do not ask downstream questions early. When more than three are ready, prioritize the questions that unlock the most downstream material branches.
 
-Number questions continuously across the interview, starting at 1. A question keeps its number until it is answered. A direct follow-up receives the next unused number. Never reuse a number. Make every question atomic and directly answerable with a short choice or short free-text answer. Use compact options when the answer space is finite.
+Number questions continuously across the interview, starting at 1. A question keeps its number until it is answered. A direct follow-up receives the next unused number. Never reuse a number. Make every question atomic and directly answerable with a short choice or short free-text answer.
 
-Show the numbered question and a concise recommendation. Surface at most the material tradeoff, evidence, conflict, or alternative needed to answer. Do not attach a routine dossier to each question.
+Present every question in this stable three-part form:
 
-Every question must include a recommendation. In Elicit mode, when the user's rationale is unknown, recommend an answer shape, such as a constraint plus one example. Never invent the user's rationale. When evidence cannot support a substantive choice, recommend deferring the choice or preserving it as unresolved. State the material tradeoff between waiting and deciding under uncertainty. Do not present an agent recommendation as project authority. The user owns every choice.
+1. `<continuous number>. <short decision label>`
+2. A direct question that names every finite choice.
+3. `Recommendation: <concrete answer>. <concise rationale>`
+
+Surface at most the material tradeoff, evidence, conflict, or alternative needed to answer. Do not attach a routine dossier to each question.
+
+Every question must include a recommendation. Every substantive recommendation starts with the concrete recommended answer and then gives concise rationale. Use answer-shape guidance only when repository evidence and active project judgment cannot support a substantive recommendation without inventing a user-owned choice or rationale. Never invent the user's rationale. Treat `defer` and `preserve unresolved` as concrete advisory recommendations when evidence is insufficient, and state the material tradeoff between waiting and deciding under uncertainty. Every recommendation remains advisory. The user owns every choice.
 
 End every round with an instantiated concise reply cue using the question numbers in that batch. Use exactly this form: `Reply: 4: <answer>; 5: <answer>. Answer any subset.` Replace `4` and `5` with the batch's actual question numbers, include each batch question once, and do not add other text to the cue. Then wait for the user's reply. Do not answer a user-owned choice on the user's behalf.
 

--- a/packages/nauro/tests/test_skills_drift.py
+++ b/packages/nauro/tests/test_skills_drift.py
@@ -466,7 +466,7 @@ def test_load_interview_body_preserves_deliberation_boundary():
     assert "recommendation" in body
     assert "tradeoffs" in body
     assert "Every question must include a recommendation" in body
-    assert "recommend deferring the choice or preserving it as unresolved" in body
+    assert "Treat `defer` and `preserve unresolved` as concrete advisory recommendations" in body
     assert "wait for the user's reply" in body
     for outcome_class in (
         "Terminology",
@@ -491,8 +491,28 @@ def test_interview_body_asks_compact_bounded_numbered_rounds():
     assert "keeps its number until it is answered" in body
     assert "next unused number" in body
     assert "atomic and directly answerable with a short choice or short free-text answer" in body
-    assert "Use compact options when the answer space is finite" in body
     assert "Use exactly this form: `Reply: 4: <answer>; 5: <answer>. Answer any subset.`" in body
+
+
+def test_interview_body_presents_labeled_direct_answer_first_questions():
+    body = load_interview_body()
+
+    for presentation_part in (
+        "`<continuous number>. <short decision label>`",
+        "A direct question that names every finite choice",
+        "`Recommendation: <concrete answer>. <concise rationale>`",
+    ):
+        assert presentation_part in body
+    assert "Every substantive recommendation starts with the concrete recommended answer" in body
+    assert "repository evidence and active project judgment cannot support" in body
+    assert "without inventing a user-owned choice or rationale" in body
+    assert "Treat `defer` and `preserve unresolved` as concrete advisory recommendations" in body
+    assert "Every recommendation remains advisory" in body
+    for superseded_rule in (
+        "Use compact options when the answer space is finite",
+        "when the user's rationale is unknown, recommend an answer shape",
+    ):
+        assert superseded_rule not in body
 
 
 def test_interview_body_advances_dependencies_without_repetition():
@@ -519,7 +539,7 @@ def test_interview_body_advances_dependencies_without_repetition():
 def test_interview_body_keeps_routine_work_internal_and_recommendations_bounded():
     body = load_interview_body()
 
-    assert "recommend an answer shape" in body
+    assert "Use answer-shape guidance only" in body
     assert "Never invent the user's rationale" in body
     assert "routine orientation" in body
     assert "fact finding" in body


### PR DESCRIPTION
## Why

Compact Interview rounds could still hide the exact choice from the user. Each question needs a clear label, explicit finite choices, and an answer-first recommendation.

## What changed

- Require a stable three-part question format: continuous number and decision label, direct question, and concrete answer-first recommendation.
- Limit answer-shape guidance to cases where evidence cannot support a substantive recommendation without inventing user-owned judgment.
- Preserve defer and unresolved outcomes as concrete advisory recommendations.
- Add positive and negative contract assertions and regenerate the Claude Code, Codex, and Cursor skill files.

## Test plan

- Focused Interview drift: 188 passed.
- Protocol drift: 89 passed.
- Interview installation parity: 2 passed, 50 deselected.
- Full Nauro suite: 2,739 passed, 10 skipped.
- Ruff check passed. Ruff format check confirmed 368 files already formatted.
- Single-source, docstring-budget, and server-version checks passed.
- Generated Interview files matched `render_skill()` byte-for-byte. `git diff --check` passed.
- Wheel build succeeded for `nauro-1.17.0-py3-none-any.whl`.

## Deferred

Run live acceptance separately. If the same clarity failure recurs, decide the follow-up separately. This PR does not redesign the interview engine or batching.
