### PR TITLE
Add visual markers to Nauro interviews

### DIFF
--- a/.agents/skills/nauro-interview/SKILL.md
+++ b/.agents/skills/nauro-interview/SKILL.md
@@ -71,11 +71,15 @@ Select at most three prerequisite-ready material questions for each round. Use o
 
 Number questions continuously across the interview, starting at 1. A question keeps its number until it is answered. A direct follow-up receives the next unused number. Never reuse a number. Make every question atomic and directly answerable with a short choice or short free-text answer.
 
-Present every question in this stable three-part form:
+Begin every active question round with exactly `◆ Nauro Interview`. Place it once before the first question. Do not add the mode, round count, progress, evidence, or paths.
 
-1. `<continuous number>. <short decision label>`
-2. A direct question that names every finite choice.
-3. `Recommendation: <concrete answer>. <concise rationale>`
+Present every question block in this exact form:
+
+`❓ **Q<n>** - **<short decision label>**: <direct question>`
+
+`➡️ **Recommendation: <concrete answer>.** <concise rationale>`
+
+A direct question must name every finite choice. The `Q` prefix is presentation only. The underlying number remains continuous and stable across unanswered questions and follow-ups. When a round contains multiple questions, place `---` only between question blocks. Never place it after the final question block.
 
 Surface at most the material tradeoff, evidence, conflict, or alternative needed to answer. Do not attach a routine dossier to each question.
 

--- a/.claude/skills/nauro-interview/SKILL.md
+++ b/.claude/skills/nauro-interview/SKILL.md
@@ -71,11 +71,15 @@ Select at most three prerequisite-ready material questions for each round. Use o
 
 Number questions continuously across the interview, starting at 1. A question keeps its number until it is answered. A direct follow-up receives the next unused number. Never reuse a number. Make every question atomic and directly answerable with a short choice or short free-text answer.
 
-Present every question in this stable three-part form:
+Begin every active question round with exactly `◆ Nauro Interview`. Place it once before the first question. Do not add the mode, round count, progress, evidence, or paths.
 
-1. `<continuous number>. <short decision label>`
-2. A direct question that names every finite choice.
-3. `Recommendation: <concrete answer>. <concise rationale>`
+Present every question block in this exact form:
+
+`❓ **Q<n>** - **<short decision label>**: <direct question>`
+
+`➡️ **Recommendation: <concrete answer>.** <concise rationale>`
+
+A direct question must name every finite choice. The `Q` prefix is presentation only. The underlying number remains continuous and stable across unanswered questions and follow-ups. When a round contains multiple questions, place `---` only between question blocks. Never place it after the final question block.
 
 Surface at most the material tradeoff, evidence, conflict, or alternative needed to answer. Do not attach a routine dossier to each question.
 

--- a/.cursor/rules/nauro-interview.mdc
+++ b/.cursor/rules/nauro-interview.mdc
@@ -71,11 +71,15 @@ Select at most three prerequisite-ready material questions for each round. Use o
 
 Number questions continuously across the interview, starting at 1. A question keeps its number until it is answered. A direct follow-up receives the next unused number. Never reuse a number. Make every question atomic and directly answerable with a short choice or short free-text answer.
 
-Present every question in this stable three-part form:
+Begin every active question round with exactly `◆ Nauro Interview`. Place it once before the first question. Do not add the mode, round count, progress, evidence, or paths.
 
-1. `<continuous number>. <short decision label>`
-2. A direct question that names every finite choice.
-3. `Recommendation: <concrete answer>. <concise rationale>`
+Present every question block in this exact form:
+
+`❓ **Q<n>** - **<short decision label>**: <direct question>`
+
+`➡️ **Recommendation: <concrete answer>.** <concise rationale>`
+
+A direct question must name every finite choice. The `Q` prefix is presentation only. The underlying number remains continuous and stable across unanswered questions and follow-ups. When a round contains multiple questions, place `---` only between question blocks. Never place it after the final question block.
 
 Surface at most the material tradeoff, evidence, conflict, or alternative needed to answer. Do not attach a routine dossier to each question.
 

--- a/packages/nauro/src/nauro/skills/interview_body.md
+++ b/packages/nauro/src/nauro/skills/interview_body.md
@@ -69,11 +69,15 @@ Select at most three prerequisite-ready material questions for each round. Use o
 
 Number questions continuously across the interview, starting at 1. A question keeps its number until it is answered. A direct follow-up receives the next unused number. Never reuse a number. Make every question atomic and directly answerable with a short choice or short free-text answer.
 
-Present every question in this stable three-part form:
+Begin every active question round with exactly `◆ Nauro Interview`. Place it once before the first question. Do not add the mode, round count, progress, evidence, or paths.
 
-1. `<continuous number>. <short decision label>`
-2. A direct question that names every finite choice.
-3. `Recommendation: <concrete answer>. <concise rationale>`
+Present every question block in this exact form:
+
+`❓ **Q<n>** - **<short decision label>**: <direct question>`
+
+`➡️ **Recommendation: <concrete answer>.** <concise rationale>`
+
+A direct question must name every finite choice. The `Q` prefix is presentation only. The underlying number remains continuous and stable across unanswered questions and follow-ups. When a round contains multiple questions, place `---` only between question blocks. Never place it after the final question block.
 
 Surface at most the material tradeoff, evidence, conflict, or alternative needed to answer. Do not attach a routine dossier to each question.
 

--- a/packages/nauro/tests/test_skills_drift.py
+++ b/packages/nauro/tests/test_skills_drift.py
@@ -497,12 +497,14 @@ def test_interview_body_asks_compact_bounded_numbered_rounds():
 def test_interview_body_presents_labeled_direct_answer_first_questions():
     body = load_interview_body()
 
-    for presentation_part in (
-        "`<continuous number>. <short decision label>`",
-        "A direct question that names every finite choice",
-        "`Recommendation: <concrete answer>. <concise rationale>`",
-    ):
-        assert presentation_part in body
+    assert "Begin every active question round with exactly `◆ Nauro Interview`" in body
+    assert "`❓ **Q<n>** - **<short decision label>**: <direct question>`" in body
+    assert "`➡️ **Recommendation: <concrete answer>.** <concise rationale>`" in body
+    assert "A direct question must name every finite choice" in body
+    assert "place `---` only between question blocks" in body
+    assert "Never place it after the final question block" in body
+    assert "The `Q` prefix is presentation only" in body
+    assert "Do not add the mode, round count, progress, evidence, or paths" in body
     assert "Every substantive recommendation starts with the concrete recommended answer" in body
     assert "repository evidence and active project judgment cannot support" in body
     assert "without inventing a user-owned choice or rationale" in body


### PR DESCRIPTION
## Why

Nauro Interview rounds can blend into ordinary conversation. Frequent, stable markers make the active workflow and each decision point clear without adding progress narration.

## What changed

- Add a compact `◆ Nauro Interview` identity to every active question round.
- Mark each question with `❓ **Q<n>**` and each answer-first recommendation with `➡️`.
- Place separators only between multiple question blocks.
- Pin the exact presentation grammar in drift tests and regenerate the Claude Code, Codex, and Cursor skill files.

## Test plan

- Interview drift: 188 passed.
- Protocol drift: 89 passed.
- Interview installation parity: 2 passed, 50 deselected.
- Full Nauro suite: 2,739 passed, 10 skipped.
- Ruff check and format check passed.
- Single-source, docstring-budget, server-version, generated-byte-parity, and diff checks passed.
- The Nauro wheel built successfully.
