### PR TITLE
Release nauro 1.18.0

### DIFF
--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro"
-version = "1.17.0"
+version = "1.18.0"
 description = "Human-approved project judgment and current state for connected AI agents, surfaced before work."
 readme = "README.md"
 license = "Apache-2.0"

--- a/server.json
+++ b/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Nauro-AI/nauro",
     "source": "github"
   },
-  "version": "1.17.0",
+  "version": "1.18.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "nauro",
-      "version": "1.17.0",
+      "version": "1.18.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -936,7 +936,7 @@ wheels = [
 
 [[package]]
 name = "nauro"
-version = "1.17.0"
+version = "1.18.0"
 source = { editable = "packages/nauro" }
 dependencies = [
     { name = "filelock" },


### PR DESCRIPTION
## Why

The latest workflow improvements are merged but are not available in the published Nauro package.

## What changed

- Release Nauro 1.18.0 with direct-user workflow authority and fresh-task Program delivery.
- Include opt-in Interview installation, completion-driven questioning, clearer choices, answer-first recommendations, and visible markers.
- Keep nauro-core at 1.14.1 because its shippable source is unchanged.

## Test plan

- Full Nauro suite: 2,739 passed, 10 skipped.
- Locked environments synced for Nauro and nauro-core.
- The Nauro wheel built and passed the installed-package stdio MCP smoke test with fresh dependency resolution.
- Ruff check, Ruff format, import-linter, server-version, single-source, lockfile, and diff checks passed.

## Post-merge

After separate publish approval, tag the squash-merge commit as `nauro-v1.18.0`, verify the PyPI and MCP registry publication workflows, and create the GitHub release.
