### PR TITLE
Adopt Human Controlled Project Truth copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="docs/images/nauro-wordmark-dark.svg" alt="Nauro" width="180">
 </p>
 
-<p align="center"><strong>The decision system for building software with AI.</strong></p>
+<p align="center"><strong>Human Controlled Project Truth</strong></p>
 
 <p align="center">
   <a href="https://pypi.org/project/nauro/"><img alt="PyPI" src="https://img.shields.io/pypi/v/nauro.svg"></a>
@@ -10,7 +10,7 @@
   <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache%202.0-blue.svg"></a>
 </p>
 
-Nauro gives connected agents human-approved project judgment and current state before they plan or change work.
+Keep your project's direction in human hands as agents do more of the work.
 
 Before work, Nauro surfaces the relevant part of that record. Approved judgment and reported progress carry into later sessions and connected tools.
 

--- a/packages/nauro/README.md
+++ b/packages/nauro/README.md
@@ -1,8 +1,8 @@
 # Nauro
 
-The decision system for building software with AI.
+Human Controlled Project Truth
 
-Nauro gives connected agents human-approved project judgment and current state before they plan or change work.
+Keep your project's direction in human hands as agents do more of the work.
 
 Nauro keeps a living project record. It combines project scope, current state, and open questions with human-approved project judgment: intent, goals, decisions, rationale, tradeoffs, and rejected paths. Project judgment is the human-ratified part of the record; context is the relevant slice of the record an agent receives for the work in front of it. Works with Claude, Perplexity, Cursor, Codex, and any MCP client.
 

--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "nauro"
 version = "1.18.0"
-description = "Human-approved project judgment and current state for connected AI agents, surfaced before work."
+description = "Human Controlled Project Truth: Keep your project's direction in human hands as agents do more of the work."
 readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.10"

--- a/packages/nauro/src/nauro/cli/main.py
+++ b/packages/nauro/src/nauro/cli/main.py
@@ -25,8 +25,8 @@ def _version_callback(value: bool) -> None:
 app = typer.Typer(
     name="nauro",
     help=(
-        "Human-approved project judgment and current state for connected AI agents, "
-        "surfaced before work."
+        "Human Controlled Project Truth: Keep your project's direction in human hands "
+        "as agents do more of the work."
     ),
     no_args_is_help=True,
     rich_markup_mode=None,
@@ -45,8 +45,8 @@ def main(
         help="Show version and exit.",
     ),
 ) -> None:
-    """Human-approved project judgment and current state for connected AI agents,
-    surfaced before work.
+    """Human Controlled Project Truth: Keep your project's direction in human hands
+    as agents do more of the work.
     """
 
 

--- a/packages/nauro/tests/test_cli.py
+++ b/packages/nauro/tests/test_cli.py
@@ -20,8 +20,8 @@ def test_app_shows_help():
     assert "nauro" in result.output.lower()
     normalized = " ".join(strip_ansi(result.output).split())
     assert (
-        "Human-approved project judgment and current state for connected AI agents, "
-        "surfaced before work." in normalized
+        "Human Controlled Project Truth: Keep your project's direction in human hands "
+        "as agents do more of the work." in normalized
     )
     assert "doctrine once" not in result.output
 

--- a/packages/nauro/tests/test_distribution_copy.py
+++ b/packages/nauro/tests/test_distribution_copy.py
@@ -13,12 +13,9 @@ except ModuleNotFoundError:
 
 ROOT = Path(__file__).resolve().parents[3]
 
-HEADLINE = "The decision system for building software with AI."
+HEADLINE = "Human Controlled Project Truth"
 
-SUPPORT_LINE = (
-    "Nauro gives connected agents human-approved project judgment and current state "
-    "before they plan or change work."
-)
+SUPPORT_LINE = "Keep your project's direction in human hands as agents do more of the work."
 
 FIT_BOUNDARY = (
     "If a small repo plus a reliable AGENTS.md or CLAUDE.md keeps agents oriented, "
@@ -26,8 +23,8 @@ FIT_BOUNDARY = (
 )
 
 COMPACT_DESCRIPTION = (
-    "Human-approved project judgment and current state for connected AI agents, "
-    "surfaced before work."
+    "Human Controlled Project Truth: Keep your project's direction in human hands as "
+    "agents do more of the work."
 )
 
 README_PATHS = ("README.md", "packages/nauro/README.md")
@@ -59,16 +56,27 @@ def test_readmes_carry_headline_support_line_and_fit_boundary() -> None:
         assert FIT_BOUNDARY in text, relative
 
 
-def test_compact_description_identical_across_distribution_surfaces() -> None:
+def test_compact_description_contract_across_distribution_surfaces() -> None:
     pyproject = tomllib.loads((ROOT / "packages/nauro/pyproject.toml").read_text(encoding="utf-8"))
     server = json.loads((ROOT / "server.json").read_text(encoding="utf-8"))
     assert pyproject["project"]["description"] == COMPACT_DESCRIPTION
-    assert server["description"] == COMPACT_DESCRIPTION
 
     from nauro.cli.main import app
 
     assert app.info.help is not None
     assert app.info.help.startswith(COMPACT_DESCRIPTION)
+    assert server["title"] == "Nauro"
+    assert server["description"] == HEADLINE
+    assert len(server["description"]) <= 100
+    assert {
+        surface
+        for surface, description in {
+            "pypi": pyproject["project"]["description"],
+            "cli": app.info.help,
+            "mcp_registry": server["description"],
+        }.items()
+        if description != COMPACT_DESCRIPTION
+    } == {"mcp_registry"}
 
 
 def test_public_copy_uses_us_judgment_spelling() -> None:

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "ai.nauro/nauro",
   "title": "Nauro",
-  "description": "Human-approved project judgment and current state for connected AI agents, surfaced before work.",
+  "description": "Human Controlled Project Truth",
   "websiteUrl": "https://nauro.ai",
   "repository": {
     "url": "https://github.com/Nauro-AI/nauro",


### PR DESCRIPTION
## Why

The previous decision-system positioning could imply that Nauro makes decisions for the user. It also reduced the product to one record primitive when Nauro carries the broader governed project record.

## What changed

- Lead both distribution READMEs with `Human Controlled Project Truth` and the shared supporting line.
- Align PyPI metadata and top-level CLI help with the exact combined description.
- Keep the MCP Registry title as `Nauro` and use the headline-only description within its 100-character limit.
- Pin the headline, supporting line, fit boundary, CLI help, and sole registry exception in tests.

## Test plan

- `uv sync --locked --package nauro --all-extras --python 3.12`
- Focused distribution and CLI tests, 6 passed
- Full package suite excluding cross-surface tests, 2,739 passed
- Ruff check and format check
- Single-source, docstring-budget, and registry-version checks
- Wheel build and metadata inspection
- `git diff --check`

## Risk / what to review

The MCP Registry is the sole compact-copy exception. Its description uses the exact headline because the combined description exceeds the registry's 100-character limit.
