### PR TITLE
Release nauro 1.18.1 and nauro-core 1.15.0

### DIFF
--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro-core"
-version = "1.14.1"
+version = "1.15.0"
 description = "Shared pure-Python logic for Nauro: parsing, validation, context assembly, constants."
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro"
-version = "1.18.0"
+version = "1.18.1"
 description = "Human Controlled Project Truth: Keep your project's direction in human hands as agents do more of the work."
 readme = "README.md"
 license = "Apache-2.0"
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "nauro-core>=1.14.1,<2",
+    "nauro-core>=1.15.0,<2",
     "typer>=0.9",
     "httpx>=0.24",
     "mcp>=1.0,<2",

--- a/server.json
+++ b/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Nauro-AI/nauro",
     "source": "github"
   },
-  "version": "1.18.0",
+  "version": "1.18.1",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "nauro",
-      "version": "1.18.0",
+      "version": "1.18.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -936,7 +936,7 @@ wheels = [
 
 [[package]]
 name = "nauro"
-version = "1.18.0"
+version = "1.18.1"
 source = { editable = "packages/nauro" }
 dependencies = [
     { name = "filelock" },
@@ -978,7 +978,7 @@ provides-extras = ["dev", "embeddings"]
 
 [[package]]
 name = "nauro-core"
-version = "1.14.1"
+version = "1.15.0"
 source = { editable = "packages/nauro-core" }
 dependencies = [
     { name = "bm25s" },


### PR DESCRIPTION
## Why

`nauro-core` has an unreleased additive hosted `create_project` ToolSpec, and `nauro` has unreleased Human Controlled Project Truth distribution copy. The paired release keeps `nauro`'s minimum core dependency aligned with the new core package.

## What changed

- Release `nauro-core` 1.15.0 with the hosted-only `create_project` ToolSpec. The local CLI and stdio tool registry are unchanged.
- Release `nauro` 1.18.1 with the updated PyPI, CLI help, package README, and MCP Registry copy.
- Raise the `nauro-core` dependency floor to `>=1.15.0,<2`, update both `server.json` version fields, and relock the workspace.
- Keep the `mcp-server` adapter and hosted activation out of scope.

## Test plan

- `python3 scripts/check_server_json_version.py`
- `python3 scripts/check_single_sourced.py packages/nauro/src`
- `uv lock --check`
- `uv sync --locked --package nauro-core --all-extras --python 3.12`
- `uv sync --locked --package nauro --all-extras --python 3.12`
- `git diff --check`

All checks passed.

## Post-merge publish

- Create both annotated tags at the squash-merge commit.
- Push `nauro-core-v1.15.0` first and wait for the files to reach the PyPI Simple API.
- Push `nauro-v1.18.1`, then verify the PyPI and MCP Registry publish jobs and create both GitHub Releases.
