### PR TITLE
Clarify Cursor README onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,11 @@ cd your-repo
 nauro adopt --with-skills --with-subagents
 ```
 
-Restart your agent, then invoke `/nauro-adopt` in Claude Code or `$nauro-adopt` in Codex. The skill reads the repo, asks about missing rationale, and seeds the project record. The optional flags also install the gated `nauro-ship-task` workflow and its four workflow agents.
+Restart, then seed the store with `/nauro-adopt` in Claude Code, `$nauro-adopt` in Codex, or `@nauro-adopt` in Cursor Agent chat.
+
+Plain adopt installs `nauro-adopt`. `--with-skills` adds `nauro-ship-task`, `nauro-context`, `nauro-loop`, and `nauro-interview`. `--with-subagents` adds four workflow agents for Claude Code and Codex. Cursor receives the skill rules, but Nauro does not install workflow-agent definitions for Cursor.
+
+On a new machine, run `nauro setup cursor`, then restart Cursor. Commit `.nauro/config.json` and shared `.cursor/rules/nauro-*.mdc`, not the gitignored, machine-local `.cursor/mcp.json`. Cursor Cloud Agents need separate MCP configuration at `cursor.com/agents`.
 
 Run `nauro status` to check MCP, skills, and workflow agents. Run `nauro doctor` to check the project store.
 

--- a/packages/nauro/README.md
+++ b/packages/nauro/README.md
@@ -68,7 +68,13 @@ If a small repo plus a reliable AGENTS.md or CLAUDE.md keeps agents oriented, Na
 
 For real-project setup (`nauro init` / `nauro adopt`), cross-surface access, MCP tool reference, and architecture details, see the [main project README](https://github.com/nauro-ai/nauro#readme). Don't run `nauro setup` from `/tmp/nauro-demo`; that would wire the throwaway demo into your MCP client.
 
-For full Claude Code and Codex onboarding, run `nauro adopt --with-skills --with-subagents`. This installs the gated `nauro-ship-task` workflow and Nauro's bundled planner, executor, reviewer, and tech-lead agents into `~/.claude/agents/` and `~/.codex/agents/`. Re-running the command refreshes Nauro-owned workflow files and saves differing copies as backups. It leaves third-party skills and agents untouched. Pass `--force-overwrite` only when you do not want backups.
+For cross-surface onboarding, run `nauro adopt --with-skills --with-subagents`. Plain adopt installs `nauro-adopt`. `--with-skills` adds `nauro-ship-task`, `nauro-context`, `nauro-loop`, and `nauro-interview`. `--with-subagents` adds Nauro's planner, executor, reviewer, and tech-lead agents for Claude Code and Codex. Cursor receives the skill rules, but Nauro does not install workflow-agent definitions for Cursor.
+
+Restart, then seed the store with `/nauro-adopt` in Claude Code, `$nauro-adopt` in Codex, or `@nauro-adopt` in Cursor Agent chat. On a new machine, run `nauro setup cursor`, then restart Cursor. Commit `.nauro/config.json` and shared `.cursor/rules/nauro-*.mdc`, not the gitignored, machine-local `.cursor/mcp.json`.
+
+Cursor Cloud Agents need separate MCP configuration at `cursor.com/agents`. If you use Nauro's hosted connector there, link and sync the project first.
+
+Re-running onboarding refreshes Nauro-owned workflow files and saves differing copies as backups. It leaves third-party skills and agents untouched. Pass `--force-overwrite` only when you do not want backups.
 
 ## Why Nauro?
 

--- a/packages/nauro/tests/test_distribution_copy.py
+++ b/packages/nauro/tests/test_distribution_copy.py
@@ -29,6 +29,14 @@ COMPACT_DESCRIPTION = (
 
 README_PATHS = ("README.md", "packages/nauro/README.md")
 
+BUNDLED_SKILL_NAMES = (
+    "nauro-adopt",
+    "nauro-ship-task",
+    "nauro-context",
+    "nauro-loop",
+    "nauro-interview",
+)
+
 PUBLIC_COPY_PATHS = (
     *README_PATHS,
     "packages/nauro/pyproject.toml",
@@ -54,6 +62,18 @@ def test_readmes_carry_headline_support_line_and_fit_boundary() -> None:
         assert HEADLINE in text, relative
         assert SUPPORT_LINE in text, relative
         assert FIT_BOUNDARY in text, relative
+
+
+def test_readmes_carry_cursor_and_skill_onboarding_contract() -> None:
+    for relative in README_PATHS:
+        text = (ROOT / relative).read_text(encoding="utf-8")
+        assert "@nauro-adopt" in text, relative
+        assert "nauro setup cursor" in text, relative
+        assert ".cursor/mcp.json" in text, relative
+        assert "cursor.com/agents" in text, relative
+        assert "does not install workflow-agent definitions for Cursor" in text, relative
+        for skill_name in BUNDLED_SKILL_NAMES:
+            assert skill_name in text, (relative, skill_name)
 
 
 def test_compact_description_contract_across_distribution_surfaces() -> None:


### PR DESCRIPTION
## Why

The repository and PyPI READMEs omit Cursor's adoption invocation, per-machine MCP setup, Cloud Agent distinction, and the complete bundled skill set.

## What changed

- Document Cursor adoption through `@nauro-adopt`.
- List all five bundled skills, including `nauro-interview`.
- Explain per-machine Cursor setup and portable files.
- Clarify the Cursor workflow-agent and Cloud Agent boundaries.
- Add a semantic test that keeps both READMEs aligned.

## Test plan

- `uv run pytest packages/nauro/tests/test_distribution_copy.py packages/nauro/tests/test_onboarding_inventories.py -q` (13 passed)
- `uv run ruff check packages/nauro/tests/test_distribution_copy.py` (passed)
- `git diff --check` (passed)
