### PR TITLE
Detect duplicate decision identity claims

### DIFF
--- a/packages/nauro-core/src/nauro_core/doctor.py
+++ b/packages/nauro-core/src/nauro_core/doctor.py
@@ -1,12 +1,12 @@
 """Deterministic store-integrity diagnosis for ``nauro doctor``.
 
 ``diagnose_store`` reads a store through the :class:`Store` protocol and reports
-four blocking defects: unparseable decision files, dangling supersession refs,
-supersession cycles over both ref directions, and status contradictions.
+six blocking defects: unparseable files, dangling refs, cycles, contradictions,
+duplicate decision numbers, and duplicate normalized active titles.
 
 Alongside those it reports one repairable defect, the supersede backref orphan,
 and advisory unknown frontmatter keys. :attr:`StoreDiagnosis.is_clean` is bound
-to the blocking four only: an orphan is a recoverable half-write surfaced
+to the blocking six only: an orphan is a recoverable half-write surfaced
 through :attr:`StoreDiagnosis.has_repairable_defects` and closed by the gated
 ``nauro repair``, and tolerated unknown keys are accepted by design.
 
@@ -24,9 +24,10 @@ from typing import Literal
 from pydantic import BaseModel, ConfigDict, Field
 
 from nauro_core.decision_model import Decision, DecisionStatus
-from nauro_core.operations.decision_lookup import scan_decisions
+from nauro_core.operations.decision_lookup import ScannedDecision, scan_decision_records
 from nauro_core.operations.store import Store
 from nauro_core.parsing import extract_decision_number
+from nauro_core.validation import normalize_title
 
 RefField = Literal["supersedes", "superseded_by"]
 
@@ -105,6 +106,33 @@ class UnknownFrontmatterKeys(BaseModel):
     keys: tuple[str, ...]
 
 
+class DuplicateDecisionNumber(BaseModel):
+    """Every decision-file stem carrying one duplicated extracted number."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    number: int
+    stems: tuple[str, ...]
+
+
+class DecisionFileCarrier(BaseModel):
+    """One parsed decision's number and on-disk carrier stem."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    number: int
+    stem: str
+
+
+class DuplicateActiveTitle(BaseModel):
+    """Parsed active decisions sharing one canonical normalized title."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    normalized_title: str
+    carriers: tuple[DecisionFileCarrier, ...]
+
+
 class StoreDiagnosis(BaseModel):
     """The full result of :func:`diagnose_store`. Every list is sorted."""
 
@@ -114,6 +142,8 @@ class StoreDiagnosis(BaseModel):
     dangling_refs: list[DanglingRef] = Field(default_factory=list)
     cycles: list[SupersessionCycle] = Field(default_factory=list)
     contradictions: list[StatusContradiction] = Field(default_factory=list)
+    duplicate_numbers: list[DuplicateDecisionNumber] = Field(default_factory=list)
+    duplicate_active_titles: list[DuplicateActiveTitle] = Field(default_factory=list)
     supersede_orphans: list[SupersedeOrphan] = Field(default_factory=list)
     unknown_frontmatter_keys: list[UnknownFrontmatterKeys] = Field(default_factory=list)
 
@@ -123,7 +153,14 @@ class StoreDiagnosis(BaseModel):
 
         Unknown frontmatter keys are advisory and orphans repairable, so neither counts.
         """
-        return not (self.unparseable or self.dangling_refs or self.cycles or self.contradictions)
+        return not (
+            self.unparseable
+            or self.dangling_refs
+            or self.cycles
+            or self.contradictions
+            or self.duplicate_numbers
+            or self.duplicate_active_titles
+        )
 
     @property
     def has_repairable_defects(self) -> bool:
@@ -133,7 +170,8 @@ class StoreDiagnosis(BaseModel):
 
 def diagnose_store(store: Store) -> StoreDiagnosis:
     """Diagnose store-integrity defects. Pure; reads only through ``store``."""
-    parsed, failures = scan_decisions(store)
+    records, failures, stems = scan_decision_records(store)
+    parsed = [record.decision for record in records]
 
     # Existence is on-disk stems, not parsed nums: a present-but-unparseable
     # file still counts as existing, so a ref to it is reported once (as
@@ -141,9 +179,7 @@ def diagnose_store(store: Store) -> StoreDiagnosis:
     # the set) are kept because the orphan check needs to know a number is
     # carried by exactly one file before it names that file repairable.
     stem_counts = Counter(
-        num
-        for stem in store.list_decisions()
-        if (num := extract_decision_number(stem)) is not None
+        num for stem in stems if (num := extract_decision_number(stem)) is not None
     )
     existing_numbers = set(stem_counts)
     by_num = _index_by_num(parsed)
@@ -155,6 +191,8 @@ def diagnose_store(store: Store) -> StoreDiagnosis:
     dangling_refs = _dangling_refs(parsed, existing_numbers)
     cycles = _cycles(parsed)
     contradictions = _contradictions(parsed, by_num, existing_numbers)
+    duplicate_numbers = _duplicate_numbers(stems)
+    duplicate_active_titles = _duplicate_active_titles(records)
     supersede_orphans = _supersede_orphans(parsed, by_num, stem_counts, cycles)
     unknown_frontmatter_keys = _unknown_frontmatter_keys(parsed)
 
@@ -163,9 +201,46 @@ def diagnose_store(store: Store) -> StoreDiagnosis:
         dangling_refs=dangling_refs,
         cycles=cycles,
         contradictions=contradictions,
+        duplicate_numbers=duplicate_numbers,
+        duplicate_active_titles=duplicate_active_titles,
         supersede_orphans=supersede_orphans,
         unknown_frontmatter_keys=unknown_frontmatter_keys,
     )
+
+
+def _duplicate_numbers(stems: list[str]) -> list[DuplicateDecisionNumber]:
+    """Group every carrier stem for each duplicated extracted number."""
+    by_number: dict[int, list[str]] = {}
+    for stem in stems:
+        number = extract_decision_number(stem)
+        if number is not None:
+            by_number.setdefault(number, []).append(stem)
+    return [
+        DuplicateDecisionNumber(number=number, stems=tuple(sorted(carriers)))
+        for number, carriers in sorted(by_number.items())
+        if len(carriers) > 1
+    ]
+
+
+def _duplicate_active_titles(records: list[ScannedDecision]) -> list[DuplicateActiveTitle]:
+    """Group parsed active carriers by the canonical normalized title."""
+    by_title: dict[str, list[DecisionFileCarrier]] = {}
+    for record in records:
+        decision = record.decision
+        if decision.status is not DecisionStatus.active:
+            continue
+        normalized_title = normalize_title(decision.title)
+        by_title.setdefault(normalized_title, []).append(
+            DecisionFileCarrier(number=decision.num, stem=record.stem)
+        )
+    return [
+        DuplicateActiveTitle(
+            normalized_title=normalized_title,
+            carriers=tuple(sorted(carriers, key=lambda row: (row.number, row.stem))),
+        )
+        for normalized_title, carriers in sorted(by_title.items())
+        if len(carriers) > 1
+    ]
 
 
 def _unknown_frontmatter_keys(parsed: list[Decision]) -> list[UnknownFrontmatterKeys]:
@@ -181,7 +256,7 @@ def _unknown_frontmatter_keys(parsed: list[Decision]) -> list[UnknownFrontmatter
 def _index_by_num(parsed: list[Decision]) -> dict[int, Decision]:
     """Map each decision number to its parsed decision, first stem in scan order wins.
 
-    Duplicate numbers are a separate anomaly this command does not report.
+    Duplicate numbers are reported separately and never resolved here.
     """
     by_num: dict[int, Decision] = {}
     for d in parsed:

--- a/packages/nauro-core/src/nauro_core/operations/decision_lookup.py
+++ b/packages/nauro-core/src/nauro_core/operations/decision_lookup.py
@@ -37,12 +37,21 @@ class ParseFailure(NamedTuple):
     error: str
 
 
-def scan_decisions(store: Store) -> tuple[list[Decision], list[ParseFailure]]:
-    """Read every decision, returning the parsed set and the parse failures: a body
-    that fails the v2 parser is recorded as a :class:`ParseFailure`, never raised.
-    The parsed list is ordered by :func:`sort_stems_by_number` and is unfiltered.
+class ScannedDecision(NamedTuple):
+    """A parsed decision paired with its on-disk carrier stem."""
+
+    stem: str
+    decision: Decision
+
+
+def scan_decision_records(
+    store: Store,
+) -> tuple[list[ScannedDecision], list[ParseFailure], list[str]]:
+    """Read every decision once, preserving parsed carrier stems and the full stem set.
+
+    Results follow :func:`sort_stems_by_number`; parse failures never raise.
     """
-    parsed: list[Decision] = []
+    records: list[ScannedDecision] = []
     failures: list[ParseFailure] = []
     stems = sort_stems_by_number(store.list_decisions())
     bodies = store.read_decisions(stems)
@@ -51,11 +60,21 @@ def scan_decisions(store: Store) -> tuple[list[Decision], list[ParseFailure]]:
         if body is None:
             continue
         try:
-            parsed.append(parse_decision(body, _decision_filename(stem)))
+            decision = parse_decision(body, _decision_filename(stem))
+            records.append(ScannedDecision(stem=stem, decision=decision))
         except Exception as exc:
             logger.debug("Skipping unparseable decision file: %s.md", stem)
             failures.append(ParseFailure(stem=stem, error=str(exc)))
-    return parsed, failures
+    return records, failures, stems
+
+
+def scan_decisions(store: Store) -> tuple[list[Decision], list[ParseFailure]]:
+    """Read every decision, returning the parsed set and parse failures.
+
+    The parsed list is ordered by :func:`sort_stems_by_number` and is unfiltered.
+    """
+    records, failures, _ = scan_decision_records(store)
+    return [record.decision for record in records], failures
 
 
 def parse_all_decisions(store: Store) -> list[Decision]:

--- a/packages/nauro-core/tests/operations/test_decision_lookup.py
+++ b/packages/nauro-core/tests/operations/test_decision_lookup.py
@@ -25,6 +25,7 @@ from nauro_core.operations.decision_lookup import (
     ParseFailure,
     find_decision_stem_by_num,
     parse_all_decisions,
+    scan_decision_records,
     scan_decisions,
 )
 
@@ -144,6 +145,25 @@ def test_scan_decisions_returns_parsed_and_failures() -> None:
     assert isinstance(failure, ParseFailure)
     assert failure.stem == "002-broken"
     assert failure.error
+
+
+def test_scan_decision_records_preserves_stem_associations_and_full_stem_set() -> None:
+    store = InMemoryStore(
+        decisions={
+            "010-zeta": _decision_body(10, "Zeta"),
+            "005-broken": "not a decision file",
+            "010-alpha": _decision_body(10, "Alpha"),
+        }
+    )
+
+    records, failures, stems = scan_decision_records(store)
+
+    assert stems == ["005-broken", "010-alpha", "010-zeta"]
+    assert [(record.stem, record.decision.num) for record in records] == [
+        ("010-alpha", 10),
+        ("010-zeta", 10),
+    ]
+    assert [(failure.stem, bool(failure.error)) for failure in failures] == [("005-broken", True)]
 
 
 def test_parse_all_decisions_matches_scan_parsed_half() -> None:

--- a/packages/nauro-core/tests/snapshots/hosted_consumer_contract_v1.json
+++ b/packages/nauro-core/tests/snapshots/hosted_consumer_contract_v1.json
@@ -189,6 +189,8 @@
         "contradictions": "list[nauro_core.doctor.StatusContradiction]",
         "cycles": "list[nauro_core.doctor.SupersessionCycle]",
         "dangling_refs": "list[nauro_core.doctor.DanglingRef]",
+        "duplicate_active_titles": "list[nauro_core.doctor.DuplicateActiveTitle]",
+        "duplicate_numbers": "list[nauro_core.doctor.DuplicateDecisionNumber]",
         "supersede_orphans": "list[nauro_core.doctor.SupersedeOrphan]",
         "unknown_frontmatter_keys": "list[nauro_core.doctor.UnknownFrontmatterKeys]",
         "unparseable": "list[nauro_core.doctor.UnparseableDecision]"

--- a/packages/nauro-core/tests/test_doctor.py
+++ b/packages/nauro-core/tests/test_doctor.py
@@ -27,6 +27,7 @@ def _stem(num: int, slug: str = "decision") -> str:
 def _body(
     num: int,
     *,
+    title: str | None = None,
     status: DecisionStatus = DecisionStatus.active,
     supersedes: str | None = None,
     superseded_by: str | None = None,
@@ -40,7 +41,7 @@ def _body(
             supersedes=supersedes,
             superseded_by=superseded_by,
             num=num,
-            title=f"Decision {num}",
+            title=title if title is not None else f"Decision {num}",
             rationale=f"Rationale for decision {num}.",
         )
     )
@@ -57,6 +58,86 @@ def test_unparseable_file_reported_with_stem_and_error() -> None:
     assert row.stem == _stem(1)
     assert row.error
     assert diagnosis.is_clean is False
+
+
+# ── Duplicate decision numbers ──
+
+
+def test_duplicate_numbers_include_every_carrier_stem_in_order() -> None:
+    store = InMemoryStore(
+        decisions={
+            _stem(20, "zeta"): _body(20, title="Later title"),
+            _stem(5, "beta"): _body(5, title="Beta title"),
+            _stem(20, "alpha"): "this carrier does not parse",
+            _stem(5, "alpha"): _body(5, title="Alpha title"),
+        }
+    )
+
+    diagnosis = diagnose_store(store)
+
+    assert [(row.number, row.stems) for row in diagnosis.duplicate_numbers] == [
+        (5, (_stem(5, "alpha"), _stem(5, "beta"))),
+        (20, (_stem(20, "alpha"), _stem(20, "zeta"))),
+    ]
+    assert [row.stem for row in diagnosis.unparseable] == [_stem(20, "alpha")]
+    assert diagnosis.is_clean is False
+
+
+# ── Duplicate active titles ──
+
+
+def test_duplicate_active_titles_use_canonical_normalization_and_order_carriers() -> None:
+    store = InMemoryStore(
+        decisions={
+            _stem(30, "zeta"): _body(30, title="  Use   FastAPI  "),
+            _stem(10, "alpha"): _body(10, title="use fastapi"),
+        }
+    )
+
+    diagnosis = diagnose_store(store)
+
+    assert len(diagnosis.duplicate_active_titles) == 1
+    duplicate = diagnosis.duplicate_active_titles[0]
+    assert duplicate.normalized_title == "use fastapi"
+    assert [(carrier.number, carrier.stem) for carrier in duplicate.carriers] == [
+        (10, _stem(10, "alpha")),
+        (30, _stem(30, "zeta")),
+    ]
+    assert diagnosis.is_clean is False
+
+
+def test_duplicate_active_titles_ignore_superseded_and_unparseable_carriers() -> None:
+    store = InMemoryStore(
+        decisions={
+            _stem(10, "active"): _body(10, title="Use FastAPI"),
+            _stem(20, "superseded"): _body(
+                20,
+                title="use fastapi",
+                status=DecisionStatus.superseded,
+                superseded_by="30",
+            ),
+            _stem(30, "replacement"): _body(30, title="Use Starlette"),
+            _stem(40, "broken"): "# 040 — USE FASTAPI",
+        }
+    )
+
+    diagnosis = diagnose_store(store)
+
+    assert diagnosis.duplicate_active_titles == []
+    assert [row.stem for row in diagnosis.unparseable] == [_stem(40, "broken")]
+
+
+def test_title_similarity_beyond_normalization_is_not_a_duplicate() -> None:
+    store = InMemoryStore(
+        decisions={
+            _stem(10): _body(10, title="Use FastAPI"),
+            _stem(20): _body(20, title="Use FastAPI for the API"),
+        }
+    )
+
+    diagnosis = diagnose_store(store)
+
+    assert diagnosis.duplicate_active_titles == []
 
 
 # ── Dangling refs ──
@@ -198,6 +279,8 @@ def test_clean_store_yields_empty_diagnosis() -> None:
     assert diagnosis.dangling_refs == []
     assert diagnosis.cycles == []
     assert diagnosis.contradictions == []
+    assert diagnosis.duplicate_numbers == []
+    assert diagnosis.duplicate_active_titles == []
 
 
 def test_deterministic_ordering() -> None:
@@ -217,6 +300,35 @@ def test_deterministic_ordering() -> None:
         _stem(30, "zeta"),
     ]
     assert [(r.source, r.target) for r in diagnosis.dangling_refs] == [(5, 800), (20, 900)]
+
+
+class _ScanCountingStore(InMemoryStore):
+    def __init__(self, decisions: dict[str, str]) -> None:
+        super().__init__(decisions=decisions)
+        self.list_calls = 0
+        self.bulk_read_calls = 0
+
+    def list_decisions(self) -> list[str]:
+        self.list_calls += 1
+        return super().list_decisions()
+
+    def read_decisions(self, stems: list[str]) -> dict[str, str | None]:
+        self.bulk_read_calls += 1
+        return super().read_decisions(stems)
+
+
+def test_diagnosis_uses_one_guarded_store_scan() -> None:
+    store = _ScanCountingStore(
+        decisions={
+            _stem(1): _body(1, title="Use FastAPI"),
+            _stem(2): _body(2, title="use fastapi"),
+        }
+    )
+
+    diagnose_store(store)
+
+    assert store.list_calls == 1
+    assert store.bulk_read_calls == 1
 
 
 # ── Supersede backref orphans (repairable, non-blocking) ──

--- a/packages/nauro/src/nauro/cli/commands/doctor.py
+++ b/packages/nauro/src/nauro/cli/commands/doctor.py
@@ -1,9 +1,10 @@
 """nauro doctor — report deterministic store-integrity defects.
 
 Reads the local store and reports structural defects in the decision set:
-unparseable decision files, dangling or cyclic supersession refs, and status
-contradictions. Report-only, and it exits 0 whether or not it finds defects,
-because a defect is information for the user, not a failed command.
+unparseable decision files, dangling or cyclic supersession refs, status
+contradictions, duplicate decision numbers, and duplicate active titles.
+Report-only, and it exits 0 whether or not it finds defects, because a defect
+is information for the user, not a failed command.
 
 Supersede backref orphans get their own section and their own count: they are
 repairable rather than blocking, and the section names ``nauro repair``.
@@ -84,6 +85,24 @@ def _render_report(diagnosis: StoreDiagnosis) -> list[str]:
             lines.append(f"  {row.stem}: {row.error}")
         lines.append("")
 
+    if diagnosis.duplicate_numbers:
+        lines.append(f"Duplicate decision numbers ({len(diagnosis.duplicate_numbers)}):")
+        for row in diagnosis.duplicate_numbers:
+            carriers = ", ".join(f"decisions/{stem}.md" for stem in row.stems)
+            lines.append(f"  {_label(row.number)}: {carriers}")
+        lines.append("")
+
+    if diagnosis.duplicate_active_titles:
+        lines.append(
+            f"Duplicate active decision titles ({len(diagnosis.duplicate_active_titles)}):"
+        )
+        for row in diagnosis.duplicate_active_titles:
+            carriers = ", ".join(
+                f"{_label(carrier.number)} decisions/{carrier.stem}.md" for carrier in row.carriers
+            )
+            lines.append(f"  {row.normalized_title!r}: {carriers}")
+        lines.append("")
+
     if diagnosis.dangling_refs:
         lines.append(f"Dangling supersession refs ({len(diagnosis.dangling_refs)}):")
         for ref in diagnosis.dangling_refs:
@@ -126,6 +145,8 @@ def _render_report(diagnosis: StoreDiagnosis) -> list[str]:
         + len(diagnosis.dangling_refs)
         + len(diagnosis.cycles)
         + len(diagnosis.contradictions)
+        + len(diagnosis.duplicate_numbers)
+        + len(diagnosis.duplicate_active_titles)
     )
     lines.append(f"Found {total} defect(s).")
     lines.extend(_render_repairable_total(diagnosis))

--- a/packages/nauro/tests/test_cli_doctor.py
+++ b/packages/nauro/tests/test_cli_doctor.py
@@ -28,13 +28,18 @@ def _new_store(tmp_path: Path, name: str = "docproj") -> Path:
     return store
 
 
-def _decision_md(num: int, *, supersedes: str | None = None) -> str:
+def _decision_md(
+    num: int,
+    *,
+    title: str | None = None,
+    supersedes: str | None = None,
+) -> str:
     return format_decision(
         Decision(
             date="2026-03-15",
             confidence="high",
             num=num,
-            title=f"Decision {num}",
+            title=title if title is not None else f"Decision {num}",
             rationale=f"Rationale for decision {num}.",
             supersedes=supersedes,
         )
@@ -61,6 +66,35 @@ def test_defective_store_exits_zero_and_renders_defects(tmp_path: Path) -> None:
     assert "Dangling supersession refs" in result.stdout
     assert "D11" in result.stdout
     assert "D999" in result.stdout
+
+
+def test_duplicate_number_renders_exact_carrier_paths_and_counts_group(tmp_path: Path) -> None:
+    store = _new_store(tmp_path)
+    write_decision_file(store, 10, "zeta", _decision_md(10, title="Zeta"))
+    write_decision_file(store, 10, "alpha", _decision_md(10, title="Alpha"))
+
+    result = runner.invoke(app, ["doctor", "--project", "docproj"])
+
+    assert result.exit_code == 0
+    assert "Duplicate decision numbers (1):" in result.stdout
+    assert "D10: decisions/010-alpha.md, decisions/010-zeta.md" in result.stdout
+    assert "Found 1 defect(s)." in result.stdout
+
+
+def test_duplicate_active_title_renders_numbered_carriers_and_counts_group(
+    tmp_path: Path,
+) -> None:
+    store = _new_store(tmp_path)
+    write_decision_file(store, 30, "zeta", _decision_md(30, title="  Use   FastAPI  "))
+    write_decision_file(store, 10, "alpha", _decision_md(10, title="use fastapi"))
+
+    result = runner.invoke(app, ["doctor", "--project", "docproj"])
+
+    assert result.exit_code == 0
+    assert "Duplicate active decision titles (1):" in result.stdout
+    assert "use fastapi" in result.stdout
+    assert "D10 decisions/010-alpha.md, D30 decisions/030-zeta.md" in result.stdout
+    assert "Found 1 defect(s)." in result.stdout
 
 
 def test_unknown_frontmatter_key_renders_advisory_on_clean_store(tmp_path: Path) -> None:
@@ -100,7 +134,7 @@ def test_supersede_orphan_renders_its_own_section_and_repair_remedy(tmp_path: Pa
 
 def test_clean_store_report_is_unchanged_by_the_orphan_section(tmp_path: Path) -> None:
     store = _new_store(tmp_path)
-    write_decision_file(store, 1, "settled", _decision_md(1))
+    write_decision_file(store, 2, "settled", _decision_md(2))
 
     result = runner.invoke(app, ["doctor", "--project", "docproj"])
 

--- a/packages/nauro/tests/test_recovery.py
+++ b/packages/nauro/tests/test_recovery.py
@@ -306,13 +306,18 @@ def test_restore_cloud_store_rejects_malformed_presign_result(tmp_path, monkeypa
     assert list(staging.iterdir()) == []
 
 
-def _decision_bytes(num: int, *, supersedes: str | None = None) -> bytes:
+def _decision_bytes(
+    num: int,
+    *,
+    title: str | None = None,
+    supersedes: str | None = None,
+) -> bytes:
     return format_decision(
         Decision(
             date="2026-03-15",
             confidence="high",
             num=num,
-            title=f"Decision {num}",
+            title=title if title is not None else f"Decision {num}",
             rationale=f"Rationale for decision {num}.",
             supersedes=supersedes,
         )
@@ -355,4 +360,34 @@ def test_restore_cloud_store_rejects_damaged_decision_graph(tmp_path, monkeypatc
     assert not destination.exists()
     # The whole record downloaded and still failed validation. Resuming would
     # rebuild the same bad store, so staging is discarded for a clean restart.
+    assert not _staging(destination).exists()
+
+
+def test_restore_cloud_store_rejects_duplicate_decision_numbers(tmp_path, monkeypatch):
+    source = tmp_path / "source"
+    files = _store_files(source)
+    files["decisions/019-alpha.md"] = _decision_bytes(19, title="Alpha")
+    files["decisions/019-beta.md"] = _decision_bytes(19, title="Beta")
+    _mock_remote(monkeypatch, files)
+    destination = tmp_path / "projects" / PID
+
+    with pytest.raises(RecoveryError, match="integrity"):
+        restore_cloud_store(PID, destination)
+
+    assert not destination.exists()
+    assert not _staging(destination).exists()
+
+
+def test_restore_cloud_store_rejects_duplicate_active_titles(tmp_path, monkeypatch):
+    source = tmp_path / "source"
+    files = _store_files(source)
+    files["decisions/019-first.md"] = _decision_bytes(19, title="Use FastAPI")
+    files["decisions/020-second.md"] = _decision_bytes(20, title="  use   fastapi  ")
+    _mock_remote(monkeypatch, files)
+    destination = tmp_path / "projects" / PID
+
+    with pytest.raises(RecoveryError, match="integrity"):
+        restore_cloud_store(PID, destination)
+
+    assert not destination.exists()
     assert not _staging(destination).exists()


### PR DESCRIPTION
## Why

Doctor could mark a decision corpus as clean when several files claimed one decision number or several active decisions claimed one normalized title. Cloud recovery trusts that result, so it could install an ambiguous store.

## What changed

- Preserve decision carrier stems during the existing single guarded scan.
- Report duplicate decision numbers with every carrier path.
- Report duplicate normalized active titles with each decision number and carrier path.
- Treat both finding groups as blocking integrity defects.
- Keep supersede orphans repairable and unknown frontmatter advisory.
- Cover CLI rendering and cloud recovery refusal.
- Update the hosted consumer contract for the two additive diagnosis fields.

## Test plan

- `pytest packages/nauro-core/tests/ -q`, 1,868 passed
- `pytest packages/nauro/tests/ --ignore=packages/nauro/tests/cross_surface -q`, 2,763 passed
- `pytest packages/nauro-core/tests/test_hosted_consumer_contract.py -q`, 2 passed
- `ruff check packages/ benchmarks/ scripts/`
- `ruff format --check packages/ benchmarks/ scripts/`
- `python scripts/check_docstring_budget.py packages/nauro/src packages/nauro-core/src`

## Risk / what to review

`StoreDiagnosis` gains two additive fields. The hosted consumer snapshot changed only for those field annotations. Review the deterministic grouping and carrier ordering.

## Deferred

This change detects and blocks ambiguous stores. It does not repair, renumber, allocate, sync, or migrate decisions.
