### PR TITLE
Release nauro 1.19.0 and nauro-core 1.16.0

### DIFF
--- a/packages/nauro-core/pyproject.toml
+++ b/packages/nauro-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro-core"
-version = "1.15.0"
+version = "1.16.0"
 description = "Shared pure-Python logic for Nauro: parsing, validation, context assembly, constants."
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nauro"
-version = "1.18.1"
+version = "1.19.0"
 description = "What every agent should know. Keep your project's direction in human hands as agents do more of the work."
 readme = "README.md"
 license = "Apache-2.0"
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "nauro-core>=1.15.0,<2",
+    "nauro-core>=1.16.0,<2",
     "typer>=0.9",
     "httpx>=0.24",
     "mcp>=1.0,<2",

--- a/server.json
+++ b/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Nauro-AI/nauro",
     "source": "github"
   },
-  "version": "1.18.1",
+  "version": "1.19.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "nauro",
-      "version": "1.18.1",
+      "version": "1.19.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -936,7 +936,7 @@ wheels = [
 
 [[package]]
 name = "nauro"
-version = "1.18.1"
+version = "1.19.0"
 source = { editable = "packages/nauro" }
 dependencies = [
     { name = "filelock" },
@@ -978,7 +978,7 @@ provides-extras = ["dev", "embeddings"]
 
 [[package]]
 name = "nauro-core"
-version = "1.15.0"
+version = "1.16.0"
 source = { editable = "packages/nauro-core" }
 dependencies = [
     { name = "bm25s" },


### PR DESCRIPTION
## Why

The duplicate decision identity detector is merged but is not yet available through published packages. Prepare matched core and CLI versions so installed clients and restore consumers can receive it.

## What changed

- Set `nauro-core` to `1.16.0`.
- Set `nauro` to `1.19.0` and require `nauro-core>=1.16.0,<2`.
- Keep `server.json` and the workspace lockfile in version lockstep.

## Test plan

- Regenerated the lockfile offline and confirmed that only the two workspace versions changed.
- Passed 1,868 `nauro-core` tests and 2,763 `nauro` tests.
- Passed hosted-consumer and public-contract tests.
- Passed lint, format, source, docstring-budget, server-manifest, and import-contract guards.
- Built exactly two wheels and verified clean locked installation, package metadata, installed-module provenance, diagnosis fields, stdio operation, and SHA-256 hashes.

## Risk / what to review

This release is prepared from current main and includes the existing experimental Cursor workflow wiring. A one-release exception permits the current project-level Cursor MCP wiring and native workflow agents in `nauro 1.19.0` only. Any later release with the project wiring still present requires fresh explicit approval. The required global `~/.cursor/mcp.json` correction remains outside this PR.

Publication order is mandatory. `nauro-core 1.16.0` must publish before `nauro 1.19.0` because the CLI requires `nauro-core>=1.16.0,<2`.

## Deferred

Tags, package publication, MCP registry publication, deployment, downstream server uptake, store repair, and migration remain separately gated. External Claude plugin synchronization, plus Grok plugin synchronization and validation, also remain separate follow-up work.
