### PR TITLE
Preserve validated project bindings

### DIFF
--- a/packages/nauro/src/nauro/store/resolution.py
+++ b/packages/nauro/src/nauro/store/resolution.py
@@ -18,9 +18,21 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal, NamedTuple
+from typing import Annotated, Literal, NamedTuple
 
+import pydantic as pyd
+from nauro_core.identifiers import (
+    IdentifierKind,
+    is_identifier,
+    validate_identifier,
+)
+
+from nauro.constants import (
+    REGISTRY_SCHEMA_VERSION_V2,
+    REPO_CONFIG_SCHEMA_VERSION,
+)
 from nauro.onboarding import disconnected_project_guidance
+from nauro.store.home import registry_file
 from nauro.store.registry import (
     RegistryEntryV2,
     StoreBindingError,
@@ -108,6 +120,17 @@ class RepoResolution(NamedTuple):
     display_name: str
 
 
+@dataclass(frozen=True)
+class ResolvedProjectBinding:
+    """A validated local or cloud project binding."""
+
+    store_path: Path
+    project_id: str
+    display_name: str
+    mode: Literal["local", "cloud"]
+    server_url: str | None
+
+
 DisconnectedReason = Literal[
     "not_connected_on_this_machine",
     "connected_record_missing",
@@ -128,6 +151,208 @@ class DisconnectedProject:
     reason_code: DisconnectedReason
     recovery_actions: tuple[RecoveryAction, ...]
     guidance: str
+
+
+def _canonical_project_name(value: str) -> str:
+    if (
+        value != value.strip()
+        or not value
+        or len(value) > 100
+        or "/" in value
+        or "\\" in value
+        or ".." in value
+        or any(not char.isprintable() for char in value)
+    ):
+        raise ValueError("project name is not canonical")
+    return value
+
+
+def _canonical_project_id(value: str) -> str:
+    return validate_identifier(IdentifierKind.ulid, value, field="project_id")
+
+
+_CanonicalProjectName = Annotated[pyd.StrictStr, pyd.AfterValidator(_canonical_project_name)]
+_CanonicalProjectId = Annotated[pyd.StrictStr, pyd.AfterValidator(_canonical_project_id)]
+_RegistrySchemaVersion = Annotated[
+    pyd.StrictInt,
+    pyd.Field(ge=REGISTRY_SCHEMA_VERSION_V2, le=REGISTRY_SCHEMA_VERSION_V2),
+]
+_RepoConfigSchemaVersion = Annotated[
+    pyd.StrictInt,
+    pyd.Field(ge=REPO_CONFIG_SCHEMA_VERSION, le=REPO_CONFIG_SCHEMA_VERSION),
+]
+_STRICT_MODEL_CONFIG = pyd.ConfigDict(extra="forbid", frozen=True, strict=True)
+
+
+class _StrictRegistryEntry(RegistryEntryV2):
+    model_config = _STRICT_MODEL_CONFIG
+
+    name: _CanonicalProjectName
+
+    @pyd.field_validator("repo_paths")
+    @classmethod
+    def _validate_repo_paths(cls, values: tuple[str, ...]) -> tuple[str, ...]:
+        for value in values:
+            candidate = Path(value)
+            try:
+                resolved = candidate.resolve(strict=False)
+            except (OSError, RuntimeError) as exc:
+                raise ValueError("repo path is not canonical") from exc
+            if (
+                not value
+                or not candidate.is_absolute()
+                or str(candidate) != value
+                or resolved != candidate
+            ):
+                raise ValueError("repo path is not canonical")
+        return values
+
+
+class _StrictRegistrySnapshot(pyd.BaseModel):
+    model_config = _STRICT_MODEL_CONFIG
+
+    schema_version: _RegistrySchemaVersion
+    projects: dict[_CanonicalProjectId, _StrictRegistryEntry]
+
+    @pyd.model_validator(mode="after")
+    def _validate_project_map(self) -> _StrictRegistrySnapshot:
+        path_owners: dict[str, str] = {}
+        for project_id, entry in self.projects.items():
+            for repo_path in entry.repo_paths:
+                owner = path_owners.setdefault(repo_path, project_id)
+                if owner != project_id:
+                    raise ValueError("registry repo path has multiple project owners")
+        return self
+
+
+class _StrictRepoConfig(pyd.BaseModel):
+    model_config = _STRICT_MODEL_CONFIG
+
+    schema_version: _RepoConfigSchemaVersion
+    mode: Literal["local", "cloud"]
+    id: _CanonicalProjectId
+    name: _CanonicalProjectName
+    server_url: pyd.StrictStr | None = None
+
+    @pyd.model_validator(mode="after")
+    def _validate_cloud_server(self) -> _StrictRepoConfig:
+        if self.mode == "cloud" and not (self.server_url or "").strip():
+            raise ValueError("cloud repo config requires a nonempty server URL")
+        return self
+
+
+def _strict_registry_entries(
+    target_id: str | None,
+    target_cfg: _StrictRepoConfig | None,
+) -> _StrictRegistrySnapshot:
+    path = registry_file()
+    if not path.exists():
+        return _StrictRegistrySnapshot(schema_version=REGISTRY_SCHEMA_VERSION_V2, projects={})
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as exc:
+        raise StoreResolutionError("Registry is malformed or unreadable.") from exc
+    try:
+        return _StrictRegistrySnapshot.model_validate_json(raw)
+    except pyd.ValidationError as exc:
+        errors = exc.errors(include_input=False)
+        if (
+            target_id is not None
+            and bool(errors)
+            and all(tuple(error["loc"][:2]) == ("projects", target_id) for error in errors)
+            and is_identifier(IdentifierKind.ulid, target_id)
+        ):
+            cfg = target_cfg or _StrictRepoConfig(
+                schema_version=REPO_CONFIG_SCHEMA_VERSION,
+                id=target_id,
+                name=target_id,
+                mode="local",
+            )
+            raise DisconnectedProjectError(
+                _disconnected(cfg, "connected_record_invalid", get_store_path_v2(target_id))
+            ) from exc
+        if any(error["type"] == "json_invalid" for error in errors):
+            message = "Registry is malformed or unreadable."
+        elif any(error["loc"] and error["loc"][0] == "schema_version" for error in errors):
+            message = "Registry has an invalid schema."
+        elif any(tuple(error["loc"]) == ("projects",) for error in errors):
+            message = "Registry has an invalid projects map."
+        elif any(error["loc"] and error["loc"][0] == "projects" for error in errors):
+            message = "Registry entry is invalid."
+        else:
+            message = "Registry must be a valid JSON object."
+        raise StoreResolutionError(message) from exc
+
+
+def _strict_repo_config_from_cwd(start: Path) -> _StrictRepoConfig | None:
+    config_path = find_repo_config(start=start)
+    if config_path is None:
+        return None
+    repo_root = config_path.parent.parent
+    refusal = find_symlink(repo_root, ".nauro/config.json")
+    if refusal is not None:
+        raise StoreResolutionError(refusal.message)
+    try:
+        raw = config_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as exc:
+        raise StoreResolutionError(f"Repo config at {config_path} is invalid.") from exc
+    try:
+        return _StrictRepoConfig.model_validate_json(raw)
+    except pyd.ValidationError as exc:
+        fields = {error["loc"][0] for error in exc.errors(include_input=False) if error["loc"]}
+        if "schema_version" in fields:
+            message = f"Repo config at {config_path} has an invalid schema."
+        elif fields.intersection({"id", "name"}):
+            message = f"Repo config at {config_path} has an invalid identity."
+        else:
+            message = f"Repo config at {config_path} is invalid."
+        raise StoreResolutionError(message) from exc
+
+
+def _resolved_binding(
+    project_id: str,
+    entry: _StrictRegistryEntry,
+    cfg: _StrictRepoConfig | None = None,
+) -> ResolvedProjectBinding:
+    if cfg is None:
+        cfg = _StrictRepoConfig(
+            schema_version=REPO_CONFIG_SCHEMA_VERSION,
+            id=project_id,
+            name=entry.name,
+            mode=entry.mode,
+            server_url=entry.server_url,
+        )
+    configured_server = cfg.server_url
+    conflict = (
+        entry.name != cfg.name
+        or entry.mode != cfg.mode
+        or (
+            entry.mode == "local"
+            and (configured_server is not None or entry.server_url is not None)
+        )
+        or (entry.mode == "cloud" and entry.server_url != configured_server)
+    )
+    if conflict:
+        raise DisconnectedProjectError(
+            _disconnected(
+                cfg,
+                "connected_binding_conflict",
+                _store_path_hint(entry, project_id),
+            )
+        )
+    try:
+        store_path = resolve_registered_store_path_v2(project_id, registry_entry=entry)
+    except StoreBindingError as exc:
+        raise DisconnectedProjectError(
+            _disconnected(cfg, exc.reason_code, _store_path_hint(entry, project_id))
+        ) from exc
+    return ResolvedProjectBinding(
+        store_path=store_path,
+        project_id=project_id,
+        display_name=cfg.name,
+        mode=entry.mode,
+        server_url=entry.server_url,
+    )
 
 
 def _resolve_repo_config_from_cwd(start: Path | None) -> tuple[dict, Path] | None:
@@ -163,15 +388,22 @@ def _recovery_actions(
 
 
 def _disconnected(
-    cfg: dict,
+    cfg: dict | _StrictRepoConfig,
     reason_code: DisconnectedReason,
     store_path: Path,
 ) -> DisconnectedProject:
-    mode = cfg["mode"]
+    if isinstance(cfg, _StrictRepoConfig):
+        mode = cfg.mode
+        project_id = cfg.id
+        display_name = cfg.name
+    else:
+        mode = cfg["mode"]
+        project_id = cfg["id"]
+        display_name = cfg.get("name") or project_id
     return DisconnectedProject(
         store_path=store_path,
-        project_id=cfg["id"],
-        display_name=cfg.get("name") or cfg["id"],
+        project_id=project_id,
+        display_name=display_name,
         mode=mode,
         reason_code=reason_code,
         recovery_actions=_recovery_actions(mode, reason_code),
@@ -299,6 +531,82 @@ def _store_path_or_raise(connection: RepoResolution | DisconnectedProject) -> Pa
     return connection.store_path
 
 
+def resolve_project_binding(
+    project_id: str | None,
+    cwd: str | Path | None,
+) -> ResolvedProjectBinding:
+    """Resolve and validate a local or cloud project binding."""
+    cwd_path = Path(cwd) if cwd else Path.cwd()
+    cfg = _strict_repo_config_from_cwd(cwd_path)
+    target_id = cfg.id if cfg is not None else project_id
+    entries = _strict_registry_entries(target_id, cfg).projects
+
+    if cfg is not None:
+        config_id = cfg.id
+        entry = entries.get(config_id)
+        if (
+            project_id
+            and project_id != config_id
+            and (project_id in entries or entry is None or entry.name != project_id)
+        ):
+            raise ProjectIdMismatchError(
+                f"Supplied project_id {project_id!r} does not match the "
+                f"repo config id {config_id!r} in {cwd_path}."
+            )
+        if entry is None:
+            raise DisconnectedProjectError(
+                _disconnected(
+                    cfg,
+                    "not_connected_on_this_machine",
+                    get_store_path_v2(config_id),
+                )
+            )
+        return _resolved_binding(config_id, entry, cfg)
+
+    if project_id:
+        entry = entries.get(project_id)
+        if entry is not None:
+            return _resolved_binding(project_id, entry)
+        name_matches = [(pid, entry) for pid, entry in entries.items() if entry.name == project_id]
+        if len(name_matches) == 1:
+            return _resolved_binding(*name_matches[0])
+        if len(name_matches) > 1:
+            raise MultipleProjectsError(
+                f"Multiple v2 projects named {project_id!r}; pass an "
+                "unambiguous project_id (ULID) instead of the name."
+            )
+        raise ProjectNotFoundError(
+            f"No project named or keyed {project_id!r} found in the "
+            "registry. Run 'nauro init <name>' to create it, or check "
+            "NAURO_HOME if you expected an existing project."
+        )
+
+    if cwd:
+        resolved_cwd = cwd_path.resolve()
+        path_matches = {
+            pid: entry
+            for pid, entry in entries.items()
+            if any(
+                resolved_cwd == Path(repo_path) or Path(repo_path) in resolved_cwd.parents
+                for repo_path in entry.repo_paths
+            )
+        }
+        if len(path_matches) == 1:
+            pid, entry = next(iter(path_matches.items()))
+            return _resolved_binding(pid, entry)
+        if len(path_matches) > 1:
+            raise MultipleProjectsError(
+                f"Multiple v2 projects match cwd {str(cwd_path)!r}; pass an "
+                "unambiguous project_id (ULID) instead."
+            )
+
+    raise NoProjectError(
+        "No Nauro project found. Run 'nauro init <name>' in the current "
+        "directory to create one, or pass 'project_id' / 'cwd' to point at "
+        "an existing project."
+    )
+
+
 def resolve_store(project_id: str | None, cwd: str | Path | None) -> Path:
     """Resolve a ``(project_id, cwd)`` pair to a store path.
 
@@ -359,9 +667,11 @@ __all__ = [
     "ProjectIdMismatchError",
     "ProjectNotFoundError",
     "RepoResolution",
+    "ResolvedProjectBinding",
     "StoreMissingError",
     "StoreResolutionError",
     "resolve_from_cwd",
+    "resolve_project_binding",
     "resolve_registered_project",
     "resolve_store",
     "resolve_via_repo_config",

--- a/packages/nauro/tests/test_resolution_v2.py
+++ b/packages/nauro/tests/test_resolution_v2.py
@@ -184,6 +184,345 @@ def test_stdio_resolve_explicit_id_matching_config(tmp_path, monkeypatch):
     assert store == tmp_path / "projects" / cloud_pid
 
 
+# ── dormant strict project-binding resolution ────────────────────────────────
+
+
+def _binding_state(
+    tmp_path,
+    nauro_home,
+    *,
+    name="Pareto",
+    config_patch=None,
+    entry_patch=None,
+):
+    pid = "01KQ6AZGNA0B3QBF67NBXP3S45"
+    repo = tmp_path / "binding-repo"
+    repo.mkdir()
+    store = nauro_home / "projects" / pid
+    scaffold_project_store(name, store)
+    entry = {"name": name, "mode": "local", "repo_paths": [str(repo.resolve())]}
+    entry.update(entry_patch or {})
+    registry.save_registry_v2(
+        {"schema_version": REGISTRY_SCHEMA_VERSION_V2, "projects": {pid: entry}}
+    )
+    config = {"mode": "local", "id": pid, "name": name}
+    config.update(config_patch or {})
+    save_repo_config(repo, config)
+    return pid, repo, store
+
+
+@pytest.mark.parametrize(("mode", "url"), [("local", None), ("cloud", "https://mcp.nauro.ai/mcp/")])
+def test_resolve_project_binding_returns_validated_binding(
+    tmp_path, monkeypatch, nauro_home, mode, url
+):
+    from nauro.store.resolution import ResolvedProjectBinding, resolve_project_binding
+
+    patch = {"mode": mode}
+    if url is not None:
+        patch["server_url"] = url
+    pid, repo, store = _binding_state(tmp_path, nauro_home, config_patch=patch, entry_patch=patch)
+
+    result = resolve_project_binding(pid, repo)
+
+    assert result == ResolvedProjectBinding(
+        store_path=store,
+        project_id=pid,
+        display_name="Pareto",
+        mode=mode,
+        server_url=url,
+    )
+
+
+def test_resolve_project_binding_reads_one_registry_snapshot(tmp_path, monkeypatch, nauro_home):
+    from nauro.store.resolution import resolve_project_binding
+
+    pid, repo, _store = _binding_state(tmp_path, nauro_home)
+    registry_path = nauro_home / REGISTRY_FILENAME
+    path_type = type(registry_path)
+    original_read = path_type.read_text
+    reads = 0
+
+    def counted_read(path, *args, **kwargs):
+        nonlocal reads
+        if path == registry_path:
+            reads += 1
+        return original_read(path, *args, **kwargs)
+
+    monkeypatch.setattr(path_type, "read_text", counted_read)
+    resolve_project_binding(pid, repo)
+    assert reads == 1
+
+
+@pytest.mark.parametrize(
+    ("config_patch", "entry_patch"),
+    [
+        ({"server_url": "https://mcp.nauro.ai/mcp"}, {}),
+        ({}, {"server_url": "https://mcp.nauro.ai/mcp"}),
+        ({}, {"mode": "cloud", "server_url": "https://mcp.nauro.ai/mcp"}),
+        ({"mode": "cloud", "server_url": "https://mcp.nauro.ai/mcp"}, {}),
+        (
+            {"mode": "cloud", "server_url": "https://mcp.nauro.ai/mcp"},
+            {"mode": "cloud", "server_url": "https://mcp.nauro.ai/mcp/"},
+        ),
+    ],
+)
+def test_resolve_project_binding_rejects_mode_or_url_conflict(
+    tmp_path, monkeypatch, nauro_home, config_patch, entry_patch
+):
+    from nauro.store.resolution import DisconnectedProjectError, resolve_project_binding
+
+    _pid, repo, _store = _binding_state(
+        tmp_path, nauro_home, config_patch=config_patch, entry_patch=entry_patch
+    )
+
+    with pytest.raises(DisconnectedProjectError) as exc:
+        resolve_project_binding(None, repo)
+
+    assert exc.value.state.reason_code == "connected_binding_conflict"
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("raw", "not-json"),
+        ("schema_version", 999),
+        ("schema_version", 2.0),
+        ("schema_version", True),
+        ("projects", None),
+        ("projects", []),
+    ],
+    ids=["malformed-json", "unknown-schema", "float-schema", "bool-schema", "null-map", "list-map"],
+)
+def test_resolve_project_binding_rejects_malformed_or_unknown_registry(
+    tmp_path, monkeypatch, nauro_home, field, value
+):
+    from nauro.store.resolution import StoreResolutionError, resolve_project_binding
+
+    pid, repo, _store = _binding_state(tmp_path, nauro_home)
+    registry_path = nauro_home / REGISTRY_FILENAME
+    if field == "raw":
+        registry_path.write_text("not-json\n")
+    else:
+        data = json.loads(registry_path.read_text())
+        data[field] = value
+        registry_path.write_text(json.dumps(data))
+
+    with pytest.raises(StoreResolutionError) as exc:
+        resolve_project_binding(pid, repo)
+    assert type(exc.value) is StoreResolutionError
+
+
+def test_resolve_project_binding_prioritizes_global_registry_error(
+    tmp_path, monkeypatch, nauro_home
+):
+    from nauro.store.resolution import StoreResolutionError, resolve_project_binding
+
+    pid, repo, _store = _binding_state(tmp_path, nauro_home)
+    registry_path = nauro_home / REGISTRY_FILENAME
+    data = json.loads(registry_path.read_text())
+    data["schema_version"] = 999
+    data["projects"][pid]["name"] = "../bad"
+    registry_path.write_text(json.dumps(data))
+
+    with pytest.raises(StoreResolutionError) as exc:
+        resolve_project_binding(pid, repo)
+    assert type(exc.value) is StoreResolutionError
+
+
+def test_resolve_project_binding_rejects_unreadable_registry(tmp_path, monkeypatch, nauro_home):
+    from nauro.store.resolution import StoreResolutionError, resolve_project_binding
+
+    pid, repo, _store = _binding_state(tmp_path, nauro_home)
+    registry_path = nauro_home / REGISTRY_FILENAME
+    path_type = type(registry_path)
+    original_read = path_type.read_text
+
+    def unreadable(path, *args, **kwargs):
+        if path == registry_path:
+            raise OSError("unreadable")
+        return original_read(path, *args, **kwargs)
+
+    monkeypatch.setattr(path_type, "read_text", unreadable)
+    with pytest.raises(StoreResolutionError) as exc:
+        resolve_project_binding(pid, repo)
+    assert type(exc.value) is StoreResolutionError
+
+
+@pytest.mark.parametrize(
+    ("config_patch", "remove_registry"),
+    [
+        ({"schema_version": True}, False),
+        ({"schema_version": 1.0}, False),
+        ({"id": "81KQ6AZGNA0B3QBF67NBXP3S45"}, True),
+        ({"name": "../bad"}, True),
+    ],
+    ids=["bool-schema", "float-schema", "invalid-id", "invalid-name"],
+)
+def test_binding_rejects_invalid_config_boundary(
+    tmp_path, nauro_home, config_patch, remove_registry
+):
+    from nauro.store.resolution import StoreResolutionError, resolve_project_binding
+
+    pid, repo, _store = _binding_state(tmp_path, nauro_home, config_patch=config_patch)
+    if remove_registry:
+        (nauro_home / REGISTRY_FILENAME).unlink()
+
+    with pytest.raises(StoreResolutionError) as exc:
+        resolve_project_binding(pid, repo)
+    assert type(exc.value) is StoreResolutionError
+
+
+@pytest.mark.parametrize(
+    ("case", "value"),
+    [
+        ("repo_path", ""),
+        ("repo_path", "binding-repo"),
+        ("repo_path", "lexical"),
+        pytest.param(
+            "repo_path", "symlink", marks=pytest.mark.skipif(os.name == "nt", reason="symlink")
+        ),
+        ("name", ""),
+        ("name", "../bad"),
+        ("name", "bad\nname"),
+        ("mode", "unknown"),
+        ("project_id", "local-project"),
+    ],
+)
+def test_resolve_project_binding_rejects_invalid_registry_entry(
+    tmp_path, monkeypatch, nauro_home, case, value
+):
+    from nauro.store.resolution import StoreResolutionError, resolve_project_binding
+
+    pid, repo, _store = _binding_state(tmp_path, nauro_home)
+    data = registry.load_registry_v2()
+    entry = data["projects"][pid]
+    (repo / REPO_CONFIG_DIR / REPO_CONFIG_FILENAME).unlink()
+    handle, cwd = pid, None
+    if case == "repo_path":
+        handle, cwd = None, repo
+        if value == "lexical":
+            value = str(repo / ".." / repo.name)
+        elif value == "symlink":
+            link = tmp_path / "repo-link"
+            link.symlink_to(repo, target_is_directory=True)
+            value = str(link)
+        entry["repo_paths"] = [value]
+    elif case == "project_id":
+        data["projects"][value] = data["projects"].pop(pid)
+        scaffold_project_store("Pareto", nauro_home / "projects" / value)
+        handle = value
+    else:
+        entry[case] = value
+    registry.save_registry_v2(data)
+
+    with pytest.raises(StoreResolutionError):
+        resolve_project_binding(handle, cwd)
+
+
+def test_resolve_project_binding_prefers_exact_key_over_display_name(
+    tmp_path, monkeypatch, nauro_home
+):
+    from nauro.store.resolution import ProjectIdMismatchError, resolve_project_binding
+
+    other_pid = "01KQ6AZGNA0B3QBF67NBXP3S46"
+    _pid, repo, _store = _binding_state(tmp_path, nauro_home, name=other_pid)
+    data = registry.load_registry_v2()
+    scaffold_project_store("Other", nauro_home / "projects" / other_pid)
+    data["projects"][other_pid] = {"name": "Other", "mode": "local", "repo_paths": []}
+    registry.save_registry_v2(data)
+
+    with pytest.raises(ProjectIdMismatchError):
+        resolve_project_binding(other_pid, repo)
+
+
+def test_resolve_project_binding_rejects_cross_project_path_owner(
+    tmp_path, monkeypatch, nauro_home
+):
+    from nauro.store.resolution import StoreResolutionError, resolve_project_binding
+
+    pid, repo, _store = _binding_state(tmp_path, nauro_home)
+    other_pid = "01KQ6AZGNA0B3QBF67NBXP3S46"
+    data = registry.load_registry_v2()
+    scaffold_project_store("Other", nauro_home / "projects" / other_pid)
+    data["projects"][other_pid] = {
+        "name": "Other",
+        "mode": "local",
+        "repo_paths": [str(repo.resolve())],
+    }
+    registry.save_registry_v2(data)
+
+    with pytest.raises(StoreResolutionError) as exc:
+        resolve_project_binding(pid, repo)
+    assert type(exc.value) is StoreResolutionError
+
+
+def test_resolve_project_binding_rejects_nested_cwd_matches(tmp_path, monkeypatch, nauro_home):
+    from nauro.store.resolution import MultipleProjectsError, resolve_project_binding
+
+    _pid, repo, _store = _binding_state(tmp_path, nauro_home)
+    (repo / REPO_CONFIG_DIR / REPO_CONFIG_FILENAME).unlink()
+    nested = repo / "nested"
+    nested.mkdir()
+    other_pid = "01KQ6AZGNA0B3QBF67NBXP3S46"
+    data = registry.load_registry_v2()
+    scaffold_project_store("Other", nauro_home / "projects" / other_pid)
+    data["projects"][other_pid] = {
+        "name": "Other",
+        "mode": "local",
+        "repo_paths": [str(nested.resolve())],
+    }
+    registry.save_registry_v2(data)
+
+    with pytest.raises(MultipleProjectsError):
+        resolve_project_binding(None, nested)
+
+
+def test_resolve_project_binding_preserves_empty_and_unknown_errors(
+    tmp_path, monkeypatch, nauro_home
+):
+    from nauro.store.resolution import (
+        NoProjectError,
+        ProjectNotFoundError,
+        resolve_project_binding,
+    )
+
+    with pytest.raises(NoProjectError):
+        resolve_project_binding(None, None)
+    with pytest.raises(ProjectNotFoundError):
+        resolve_project_binding("missing", None)
+
+
+def test_resolve_project_binding_preserves_duplicate_name_error(tmp_path, monkeypatch, nauro_home):
+    from nauro.store.resolution import MultipleProjectsError, resolve_project_binding
+
+    _pid, repo, _store = _binding_state(tmp_path, nauro_home)
+    (repo / REPO_CONFIG_DIR / REPO_CONFIG_FILENAME).unlink()
+    other_pid = "01KQ6AZGNA0B3QBF67NBXP3S46"
+    data = registry.load_registry_v2()
+    scaffold_project_store("Pareto", nauro_home / "projects" / other_pid)
+    data["projects"][other_pid] = {"name": "Pareto", "mode": "local", "repo_paths": []}
+    registry.save_registry_v2(data)
+
+    with pytest.raises(MultipleProjectsError):
+        resolve_project_binding("Pareto", None)
+
+
+def test_legacy_resolve_store_does_not_use_strict_binding_resolver(
+    tmp_path, monkeypatch, nauro_home
+):
+    from nauro.store import resolution
+
+    cloud = {"mode": "cloud", "server_url": "https://mcp.nauro.ai/mcp"}
+    pid, repo, store = _binding_state(tmp_path, nauro_home, config_patch=cloud, entry_patch=cloud)
+    monkeypatch.setattr(
+        resolution,
+        "_strict_registry_entries",
+        lambda: pytest.fail("legacy resolution must not call the dormant resolver"),
+    )
+
+    assert resolve_store(pid, repo) == store
+
+
 # ── corrupt repo config degrades gracefully (no transport crash) ─────────────
 
 


### PR DESCRIPTION
## Why

Store resolution currently reduces a project to its local path. The generation client needs the validated project identity, display name, local or cloud mode, and server URL at the same boundary.

## What changed

- Add a frozen resolved binding without changing existing resolver callers.
- Validate the complete registry from one snapshot and reject malformed entries, ambiguous path ownership, and repo-to-registry conflicts.
- Preserve the existing typed disconnected and lookup failures.

## Test plan

- 77 focused resolution tests passed.
- All 2,798 nauro package tests passed.
- Ruff check, Ruff format check, and git diff check passed.

## Deferred

No runtime caller uses the new resolver yet. Generation selection, installation, sync, migration, and activation remain separate changes.