### PR TITLE
Select hosted generation authority

### DIFF
--- a/packages/nauro/src/nauro/store/generation_authority.py
+++ b/packages/nauro/src/nauro/store/generation_authority.py
@@ -1,0 +1,251 @@
+"""Strict local authority selection for hosted generation replicas."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import pydantic as pyd
+from nauro_core.constants import HOSTED_STORE_FORMAT_VERSION
+from nauro_core.identifiers import IdentifierKind, validate_identifier
+from nauro_core.provenance import validate_utc_timestamp
+
+from nauro.store.resolution import ResolvedProjectBinding
+
+_CONTROL_SCHEMA_VERSION = 1
+_STRICT_MODEL_CONFIG = pyd.ConfigDict(extra="forbid", frozen=True, strict=True)
+
+
+class GenerationAuthorityError(ValueError):
+    """Base class for generation authority selection failures."""
+
+    code: str
+
+
+class GenerationControlCorruptError(GenerationAuthorityError):
+    """Generation control evidence is malformed or cross-bound."""
+
+    code = "generation_control_corrupt"
+
+
+class ClientUpgradeRequiredError(GenerationAuthorityError):
+    """The selected hosted store format is not supported by this client."""
+
+    code = "client_upgrade_required"
+
+
+class ReplicaActorMismatchError(GenerationAuthorityError):
+    """The installed replica belongs to a different or unavailable actor."""
+
+    code = "replica_actor_mismatch"
+
+
+class RefreshRequiredError(GenerationAuthorityError):
+    """The active authorization view does not match the installed projection."""
+
+    code = "refresh_required"
+
+
+def _ulid(value: str, info: pyd.ValidationInfo) -> str:
+    field = info.field_name
+    if field is None:
+        raise ValueError("identifier validator requires a model field")
+    return validate_identifier(IdentifierKind.ulid, value, field=field)
+
+
+def _sha256(value: str, info: pyd.ValidationInfo) -> str:
+    if len(value) != 64 or any(char not in "0123456789abcdef" for char in value):
+        raise ValueError(f"{info.field_name} must be a lowercase SHA-256 digest")
+    return value
+
+
+def _timestamp(value: str, info: pyd.ValidationInfo) -> str:
+    field = info.field_name
+    if field is None:
+        raise ValueError("timestamp validator requires a model field")
+    return validate_utc_timestamp(value, field=field)
+
+
+class GenerationAuthorityMarker(pyd.BaseModel):
+    """The immutable local marker that selects generation authority."""
+
+    model_config = _STRICT_MODEL_CONFIG
+
+    schema_version: pyd.StrictInt
+    authority: Literal["generation"]
+    project_id: pyd.StrictStr
+    store_format_version: pyd.StrictInt = pyd.Field(ge=1)
+
+    _validate_project_id = pyd.field_validator("project_id")(_ulid)
+
+    @pyd.field_validator("schema_version")
+    @classmethod
+    def _supported_schema(cls, value: int) -> int:
+        if value != _CONTROL_SCHEMA_VERSION:
+            raise ValueError("unsupported generation control schema")
+        return value
+
+
+class InstalledGenerationPointer(pyd.BaseModel):
+    """The actor-bound pointer for one verified installed generation."""
+
+    model_config = _STRICT_MODEL_CONFIG
+
+    schema_version: pyd.StrictInt
+    project_id: pyd.StrictStr
+    store_format_version: pyd.StrictInt = pyd.Field(ge=1)
+    generation_id: pyd.StrictStr
+    manifest_digest: pyd.StrictStr
+    committed_at: pyd.StrictStr
+    installed_at: pyd.StrictStr
+    installed_state_id: pyd.StrictStr
+    installed_for_user_id: pyd.StrictStr
+    projection_class: Literal["viewer", "contributor_plus"]
+    projection_scope_id: pyd.StrictStr
+
+    _validate_ulids = pyd.field_validator(
+        "project_id",
+        "generation_id",
+        "installed_state_id",
+        "installed_for_user_id",
+    )(_ulid)
+    _validate_digests = pyd.field_validator(
+        "manifest_digest",
+        "projection_scope_id",
+    )(_sha256)
+    _validate_timestamps = pyd.field_validator("committed_at", "installed_at")(_timestamp)
+
+    @pyd.field_validator("schema_version")
+    @classmethod
+    def _supported_schema(cls, value: int) -> int:
+        if value != _CONTROL_SCHEMA_VERSION:
+            raise ValueError("unsupported generation control schema")
+        return value
+
+    @pyd.model_validator(mode="after")
+    def _valid_install_order(self) -> InstalledGenerationPointer:
+        if self.installed_at < self.committed_at:
+            raise ValueError("installed_at cannot precede committed_at")
+        return self
+
+
+@dataclass(frozen=True)
+class FlatProjectAuthority:
+    """A local-only or pre-epoch hosted flat store."""
+
+    binding: ResolvedProjectBinding
+
+    @property
+    def kind(self) -> Literal["local", "hosted_legacy"]:
+        return "local" if self.binding.mode == "local" else "hosted_legacy"
+
+
+@dataclass(frozen=True)
+class GenerationProjectAuthority:
+    """A validated actor-bound hosted generation selection."""
+
+    binding: ResolvedProjectBinding
+    marker: GenerationAuthorityMarker
+    pointer: InstalledGenerationPointer
+
+    @property
+    def kind(self) -> Literal["hosted_generation"]:
+        return "hosted_generation"
+
+
+ProjectAuthority = FlatProjectAuthority | GenerationProjectAuthority
+
+
+def _parse_marker(raw: str | bytes) -> GenerationAuthorityMarker:
+    if type(raw) not in (str, bytes):
+        raise GenerationControlCorruptError("The generation authority marker is invalid.")
+    try:
+        return GenerationAuthorityMarker.model_validate_json(raw)
+    except (pyd.ValidationError, ValueError, TypeError) as exc:
+        raise GenerationControlCorruptError("The generation authority marker is invalid.") from exc
+
+
+def _parse_pointer(raw: str | bytes) -> InstalledGenerationPointer:
+    if type(raw) not in (str, bytes):
+        raise GenerationControlCorruptError("The installed generation pointer is invalid.")
+    try:
+        return InstalledGenerationPointer.model_validate_json(raw)
+    except (pyd.ValidationError, ValueError, TypeError) as exc:
+        raise GenerationControlCorruptError("The installed generation pointer is invalid.") from exc
+
+
+def _active_user_id(value: str | None) -> str:
+    try:
+        return validate_identifier(IdentifierKind.ulid, value, field="active_user_id")
+    except ValueError as exc:
+        raise ReplicaActorMismatchError(
+            "The installed replica does not match an active account."
+        ) from exc
+
+
+def _active_projection_scope_id(value: str | None) -> str:
+    if (
+        not isinstance(value, str)
+        or len(value) != 64
+        or any(char not in "0123456789abcdef" for char in value)
+    ):
+        raise RefreshRequiredError("The installed replica requires a fresh authorization view.")
+    return value
+
+
+def select_project_authority(
+    binding: ResolvedProjectBinding,
+    *,
+    marker_json: str | bytes | None,
+    pointer_json: str | bytes | None,
+    active_user_id: str | None = None,
+    active_projection_scope_id: str | None = None,
+) -> ProjectAuthority:
+    """Select flat or generation authority from one validated project binding."""
+    if marker_json is None:
+        return FlatProjectAuthority(binding)
+    if binding.mode != "cloud":
+        raise GenerationControlCorruptError(
+            "A local-only project cannot select hosted generation authority."
+        )
+
+    marker = _parse_marker(marker_json)
+    if marker.project_id != binding.project_id:
+        raise GenerationControlCorruptError("The generation marker belongs to another project.")
+    if marker.store_format_version != HOSTED_STORE_FORMAT_VERSION:
+        raise ClientUpgradeRequiredError(
+            "This hosted store format requires another client version."
+        )
+    if pointer_json is None:
+        raise GenerationControlCorruptError("The generation marker has no installed pointer.")
+
+    pointer = _parse_pointer(pointer_json)
+    if pointer.project_id != marker.project_id or pointer.project_id != binding.project_id:
+        raise GenerationControlCorruptError("The installed pointer belongs to another project.")
+    if pointer.store_format_version != marker.store_format_version:
+        raise GenerationControlCorruptError("The generation marker and pointer formats differ.")
+
+    current_user_id = _active_user_id(active_user_id)
+    if current_user_id != pointer.installed_for_user_id:
+        raise ReplicaActorMismatchError("The installed replica belongs to another account.")
+
+    current_scope_id = _active_projection_scope_id(active_projection_scope_id)
+    if current_scope_id != pointer.projection_scope_id:
+        raise RefreshRequiredError("The installed replica requires a fresh authorization view.")
+
+    return GenerationProjectAuthority(binding=binding, marker=marker, pointer=pointer)
+
+
+__all__ = [
+    "ClientUpgradeRequiredError",
+    "FlatProjectAuthority",
+    "GenerationAuthorityError",
+    "GenerationAuthorityMarker",
+    "GenerationControlCorruptError",
+    "GenerationProjectAuthority",
+    "InstalledGenerationPointer",
+    "ProjectAuthority",
+    "RefreshRequiredError",
+    "ReplicaActorMismatchError",
+    "select_project_authority",
+]

--- a/packages/nauro/src/nauro/store/generation_authority.py
+++ b/packages/nauro/src/nauro/store/generation_authority.py
@@ -216,8 +216,10 @@ def select_project_authority(
         raise ClientUpgradeRequiredError(
             "This hosted store format requires another client version."
         )
+
+    current_user_id = _active_user_id(active_user_id)
     if pointer_json is None:
-        raise GenerationControlCorruptError("The generation marker has no installed pointer.")
+        raise RefreshRequiredError("The active account has no installed generation pointer.")
 
     pointer = _parse_pointer(pointer_json)
     if pointer.project_id != marker.project_id or pointer.project_id != binding.project_id:
@@ -225,7 +227,6 @@ def select_project_authority(
     if pointer.store_format_version != marker.store_format_version:
         raise GenerationControlCorruptError("The generation marker and pointer formats differ.")
 
-    current_user_id = _active_user_id(active_user_id)
     if current_user_id != pointer.installed_for_user_id:
         raise ReplicaActorMismatchError("The installed replica belongs to another account.")
 

--- a/packages/nauro/src/nauro/store/resolution.py
+++ b/packages/nauro/src/nauro/store/resolution.py
@@ -18,9 +18,21 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal, NamedTuple
+from typing import Annotated, Literal, NamedTuple
 
+import pydantic as pyd
+from nauro_core.identifiers import (
+    IdentifierKind,
+    is_identifier,
+    validate_identifier,
+)
+
+from nauro.constants import (
+    REGISTRY_SCHEMA_VERSION_V2,
+    REPO_CONFIG_SCHEMA_VERSION,
+)
 from nauro.onboarding import disconnected_project_guidance
+from nauro.store.home import registry_file
 from nauro.store.registry import (
     RegistryEntryV2,
     StoreBindingError,
@@ -108,6 +120,17 @@ class RepoResolution(NamedTuple):
     display_name: str
 
 
+@dataclass(frozen=True)
+class ResolvedProjectBinding:
+    """A validated local or cloud project binding."""
+
+    store_path: Path
+    project_id: str
+    display_name: str
+    mode: Literal["local", "cloud"]
+    server_url: str | None
+
+
 DisconnectedReason = Literal[
     "not_connected_on_this_machine",
     "connected_record_missing",
@@ -128,6 +151,208 @@ class DisconnectedProject:
     reason_code: DisconnectedReason
     recovery_actions: tuple[RecoveryAction, ...]
     guidance: str
+
+
+def _canonical_project_name(value: str) -> str:
+    if (
+        value != value.strip()
+        or not value
+        or len(value) > 100
+        or "/" in value
+        or "\\" in value
+        or ".." in value
+        or any(not char.isprintable() for char in value)
+    ):
+        raise ValueError("project name is not canonical")
+    return value
+
+
+def _canonical_project_id(value: str) -> str:
+    return validate_identifier(IdentifierKind.ulid, value, field="project_id")
+
+
+_CanonicalProjectName = Annotated[pyd.StrictStr, pyd.AfterValidator(_canonical_project_name)]
+_CanonicalProjectId = Annotated[pyd.StrictStr, pyd.AfterValidator(_canonical_project_id)]
+_RegistrySchemaVersion = Annotated[
+    pyd.StrictInt,
+    pyd.Field(ge=REGISTRY_SCHEMA_VERSION_V2, le=REGISTRY_SCHEMA_VERSION_V2),
+]
+_RepoConfigSchemaVersion = Annotated[
+    pyd.StrictInt,
+    pyd.Field(ge=REPO_CONFIG_SCHEMA_VERSION, le=REPO_CONFIG_SCHEMA_VERSION),
+]
+_STRICT_MODEL_CONFIG = pyd.ConfigDict(extra="forbid", frozen=True, strict=True)
+
+
+class _StrictRegistryEntry(RegistryEntryV2):
+    model_config = _STRICT_MODEL_CONFIG
+
+    name: _CanonicalProjectName
+
+    @pyd.field_validator("repo_paths")
+    @classmethod
+    def _validate_repo_paths(cls, values: tuple[str, ...]) -> tuple[str, ...]:
+        for value in values:
+            candidate = Path(value)
+            try:
+                resolved = candidate.resolve(strict=False)
+            except (OSError, RuntimeError) as exc:
+                raise ValueError("repo path is not canonical") from exc
+            if (
+                not value
+                or not candidate.is_absolute()
+                or str(candidate) != value
+                or resolved != candidate
+            ):
+                raise ValueError("repo path is not canonical")
+        return values
+
+
+class _StrictRegistrySnapshot(pyd.BaseModel):
+    model_config = _STRICT_MODEL_CONFIG
+
+    schema_version: _RegistrySchemaVersion
+    projects: dict[_CanonicalProjectId, _StrictRegistryEntry]
+
+    @pyd.model_validator(mode="after")
+    def _validate_project_map(self) -> _StrictRegistrySnapshot:
+        path_owners: dict[str, str] = {}
+        for project_id, entry in self.projects.items():
+            for repo_path in entry.repo_paths:
+                owner = path_owners.setdefault(repo_path, project_id)
+                if owner != project_id:
+                    raise ValueError("registry repo path has multiple project owners")
+        return self
+
+
+class _StrictRepoConfig(pyd.BaseModel):
+    model_config = _STRICT_MODEL_CONFIG
+
+    schema_version: _RepoConfigSchemaVersion
+    mode: Literal["local", "cloud"]
+    id: _CanonicalProjectId
+    name: _CanonicalProjectName
+    server_url: pyd.StrictStr | None = None
+
+    @pyd.model_validator(mode="after")
+    def _validate_cloud_server(self) -> _StrictRepoConfig:
+        if self.mode == "cloud" and not (self.server_url or "").strip():
+            raise ValueError("cloud repo config requires a nonempty server URL")
+        return self
+
+
+def _strict_registry_entries(
+    target_id: str | None,
+    target_cfg: _StrictRepoConfig | None,
+) -> _StrictRegistrySnapshot:
+    path = registry_file()
+    if not path.exists():
+        return _StrictRegistrySnapshot(schema_version=REGISTRY_SCHEMA_VERSION_V2, projects={})
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as exc:
+        raise StoreResolutionError("Registry is malformed or unreadable.") from exc
+    try:
+        return _StrictRegistrySnapshot.model_validate_json(raw)
+    except pyd.ValidationError as exc:
+        errors = exc.errors(include_input=False)
+        if (
+            target_id is not None
+            and bool(errors)
+            and all(tuple(error["loc"][:2]) == ("projects", target_id) for error in errors)
+            and is_identifier(IdentifierKind.ulid, target_id)
+        ):
+            cfg = target_cfg or _StrictRepoConfig(
+                schema_version=REPO_CONFIG_SCHEMA_VERSION,
+                id=target_id,
+                name=target_id,
+                mode="local",
+            )
+            raise DisconnectedProjectError(
+                _disconnected(cfg, "connected_record_invalid", get_store_path_v2(target_id))
+            ) from exc
+        if any(error["type"] == "json_invalid" for error in errors):
+            message = "Registry is malformed or unreadable."
+        elif any(error["loc"] and error["loc"][0] == "schema_version" for error in errors):
+            message = "Registry has an invalid schema."
+        elif any(tuple(error["loc"]) == ("projects",) for error in errors):
+            message = "Registry has an invalid projects map."
+        elif any(error["loc"] and error["loc"][0] == "projects" for error in errors):
+            message = "Registry entry is invalid."
+        else:
+            message = "Registry must be a valid JSON object."
+        raise StoreResolutionError(message) from exc
+
+
+def _strict_repo_config_from_cwd(start: Path) -> _StrictRepoConfig | None:
+    config_path = find_repo_config(start=start)
+    if config_path is None:
+        return None
+    repo_root = config_path.parent.parent
+    refusal = find_symlink(repo_root, ".nauro/config.json")
+    if refusal is not None:
+        raise StoreResolutionError(refusal.message)
+    try:
+        raw = config_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as exc:
+        raise StoreResolutionError(f"Repo config at {config_path} is invalid.") from exc
+    try:
+        return _StrictRepoConfig.model_validate_json(raw)
+    except pyd.ValidationError as exc:
+        fields = {error["loc"][0] for error in exc.errors(include_input=False) if error["loc"]}
+        if "schema_version" in fields:
+            message = f"Repo config at {config_path} has an invalid schema."
+        elif fields.intersection({"id", "name"}):
+            message = f"Repo config at {config_path} has an invalid identity."
+        else:
+            message = f"Repo config at {config_path} is invalid."
+        raise StoreResolutionError(message) from exc
+
+
+def _resolved_binding(
+    project_id: str,
+    entry: _StrictRegistryEntry,
+    cfg: _StrictRepoConfig | None = None,
+) -> ResolvedProjectBinding:
+    if cfg is None:
+        cfg = _StrictRepoConfig(
+            schema_version=REPO_CONFIG_SCHEMA_VERSION,
+            id=project_id,
+            name=entry.name,
+            mode=entry.mode,
+            server_url=entry.server_url,
+        )
+    configured_server = cfg.server_url
+    conflict = (
+        entry.name != cfg.name
+        or entry.mode != cfg.mode
+        or (
+            entry.mode == "local"
+            and (configured_server is not None or entry.server_url is not None)
+        )
+        or (entry.mode == "cloud" and entry.server_url != configured_server)
+    )
+    if conflict:
+        raise DisconnectedProjectError(
+            _disconnected(
+                cfg,
+                "connected_binding_conflict",
+                _store_path_hint(entry, project_id),
+            )
+        )
+    try:
+        store_path = resolve_registered_store_path_v2(project_id, registry_entry=entry)
+    except StoreBindingError as exc:
+        raise DisconnectedProjectError(
+            _disconnected(cfg, exc.reason_code, _store_path_hint(entry, project_id))
+        ) from exc
+    return ResolvedProjectBinding(
+        store_path=store_path,
+        project_id=project_id,
+        display_name=cfg.name,
+        mode=entry.mode,
+        server_url=entry.server_url,
+    )
 
 
 def _resolve_repo_config_from_cwd(start: Path | None) -> tuple[dict, Path] | None:
@@ -163,15 +388,22 @@ def _recovery_actions(
 
 
 def _disconnected(
-    cfg: dict,
+    cfg: dict | _StrictRepoConfig,
     reason_code: DisconnectedReason,
     store_path: Path,
 ) -> DisconnectedProject:
-    mode = cfg["mode"]
+    if isinstance(cfg, _StrictRepoConfig):
+        mode = cfg.mode
+        project_id = cfg.id
+        display_name = cfg.name
+    else:
+        mode = cfg["mode"]
+        project_id = cfg["id"]
+        display_name = cfg.get("name") or project_id
     return DisconnectedProject(
         store_path=store_path,
-        project_id=cfg["id"],
-        display_name=cfg.get("name") or cfg["id"],
+        project_id=project_id,
+        display_name=display_name,
         mode=mode,
         reason_code=reason_code,
         recovery_actions=_recovery_actions(mode, reason_code),
@@ -299,6 +531,82 @@ def _store_path_or_raise(connection: RepoResolution | DisconnectedProject) -> Pa
     return connection.store_path
 
 
+def resolve_project_binding(
+    project_id: str | None,
+    cwd: str | Path | None,
+) -> ResolvedProjectBinding:
+    """Resolve and validate a local or cloud project binding."""
+    cwd_path = Path(cwd) if cwd else Path.cwd()
+    cfg = _strict_repo_config_from_cwd(cwd_path)
+    target_id = cfg.id if cfg is not None else project_id
+    entries = _strict_registry_entries(target_id, cfg).projects
+
+    if cfg is not None:
+        config_id = cfg.id
+        entry = entries.get(config_id)
+        if (
+            project_id
+            and project_id != config_id
+            and (project_id in entries or entry is None or entry.name != project_id)
+        ):
+            raise ProjectIdMismatchError(
+                f"Supplied project_id {project_id!r} does not match the "
+                f"repo config id {config_id!r} in {cwd_path}."
+            )
+        if entry is None:
+            raise DisconnectedProjectError(
+                _disconnected(
+                    cfg,
+                    "not_connected_on_this_machine",
+                    get_store_path_v2(config_id),
+                )
+            )
+        return _resolved_binding(config_id, entry, cfg)
+
+    if project_id:
+        entry = entries.get(project_id)
+        if entry is not None:
+            return _resolved_binding(project_id, entry)
+        name_matches = [(pid, entry) for pid, entry in entries.items() if entry.name == project_id]
+        if len(name_matches) == 1:
+            return _resolved_binding(*name_matches[0])
+        if len(name_matches) > 1:
+            raise MultipleProjectsError(
+                f"Multiple v2 projects named {project_id!r}; pass an "
+                "unambiguous project_id (ULID) instead of the name."
+            )
+        raise ProjectNotFoundError(
+            f"No project named or keyed {project_id!r} found in the "
+            "registry. Run 'nauro init <name>' to create it, or check "
+            "NAURO_HOME if you expected an existing project."
+        )
+
+    if cwd:
+        resolved_cwd = cwd_path.resolve()
+        path_matches = {
+            pid: entry
+            for pid, entry in entries.items()
+            if any(
+                resolved_cwd == Path(repo_path) or Path(repo_path) in resolved_cwd.parents
+                for repo_path in entry.repo_paths
+            )
+        }
+        if len(path_matches) == 1:
+            pid, entry = next(iter(path_matches.items()))
+            return _resolved_binding(pid, entry)
+        if len(path_matches) > 1:
+            raise MultipleProjectsError(
+                f"Multiple v2 projects match cwd {str(cwd_path)!r}; pass an "
+                "unambiguous project_id (ULID) instead."
+            )
+
+    raise NoProjectError(
+        "No Nauro project found. Run 'nauro init <name>' in the current "
+        "directory to create one, or pass 'project_id' / 'cwd' to point at "
+        "an existing project."
+    )
+
+
 def resolve_store(project_id: str | None, cwd: str | Path | None) -> Path:
     """Resolve a ``(project_id, cwd)`` pair to a store path.
 
@@ -359,9 +667,11 @@ __all__ = [
     "ProjectIdMismatchError",
     "ProjectNotFoundError",
     "RepoResolution",
+    "ResolvedProjectBinding",
     "StoreMissingError",
     "StoreResolutionError",
     "resolve_from_cwd",
+    "resolve_project_binding",
     "resolve_registered_project",
     "resolve_store",
     "resolve_via_repo_config",

--- a/packages/nauro/tests/test_generation_authority.py
+++ b/packages/nauro/tests/test_generation_authority.py
@@ -1,0 +1,347 @@
+from __future__ import annotations
+
+import json
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+
+import pydantic as pyd
+import pytest
+
+from nauro.store.generation_authority import (
+    ClientUpgradeRequiredError,
+    FlatProjectAuthority,
+    GenerationControlCorruptError,
+    GenerationProjectAuthority,
+    RefreshRequiredError,
+    ReplicaActorMismatchError,
+    select_project_authority,
+)
+from nauro.store.resolution import ResolvedProjectBinding
+
+PROJECT_ID = "01KQ6AZGNA0B3QBF67NBXP3S45"
+OTHER_PROJECT_ID = "01K00000000000000000000000"
+GENERATION_ID = "01K11111111111111111111111"
+INSTALL_STATE_ID = "01K22222222222222222222222"
+USER_ID = "01K33333333333333333333333"
+OTHER_USER_ID = "01K44444444444444444444444"
+MANIFEST_DIGEST = "a" * 64
+PROJECTION_SCOPE_ID = "b" * 64
+OTHER_PROJECTION_SCOPE_ID = "c" * 64
+COMMITTED_AT = "2026-09-02T01:02:03.000004Z"
+INSTALLED_AT = "2026-09-02T01:03:04.000005Z"
+
+
+def _binding(
+    *,
+    mode: str = "cloud",
+    project_id: str = PROJECT_ID,
+) -> ResolvedProjectBinding:
+    return ResolvedProjectBinding(
+        store_path=Path("store"),
+        project_id=project_id,
+        display_name="Nauro",
+        mode=mode,  # type: ignore[arg-type]
+        server_url="https://mcp.nauro.ai" if mode == "cloud" else None,
+    )
+
+
+def _marker(**changes: object) -> str:
+    raw: dict[str, object] = {
+        "schema_version": 1,
+        "authority": "generation",
+        "project_id": PROJECT_ID,
+        "store_format_version": 1,
+    }
+    raw.update(changes)
+    return json.dumps(raw)
+
+
+def _pointer(**changes: object) -> str:
+    raw: dict[str, object] = {
+        "schema_version": 1,
+        "project_id": PROJECT_ID,
+        "store_format_version": 1,
+        "generation_id": GENERATION_ID,
+        "manifest_digest": MANIFEST_DIGEST,
+        "committed_at": COMMITTED_AT,
+        "installed_at": INSTALLED_AT,
+        "installed_state_id": INSTALL_STATE_ID,
+        "installed_for_user_id": USER_ID,
+        "projection_class": "contributor_plus",
+        "projection_scope_id": PROJECTION_SCOPE_ID,
+    }
+    raw.update(changes)
+    return json.dumps(raw)
+
+
+@pytest.mark.parametrize("mode", ["local", "cloud"])
+def test_absent_marker_selects_flat_authority_and_ignores_dormant_pointer(mode: str) -> None:
+    binding = _binding(mode=mode)
+
+    result = select_project_authority(
+        binding,
+        marker_json=None,
+        pointer_json="not-json",
+    )
+
+    assert result == FlatProjectAuthority(binding)
+    assert result.kind == ("local" if mode == "local" else "hosted_legacy")
+
+
+def test_local_project_refuses_generation_marker() -> None:
+    with pytest.raises(GenerationControlCorruptError) as raised:
+        select_project_authority(
+            _binding(mode="local"),
+            marker_json=_marker(),
+            pointer_json=_pointer(),
+            active_user_id=USER_ID,
+            active_projection_scope_id=PROJECTION_SCOPE_ID,
+        )
+
+    assert raised.value.code == "generation_control_corrupt"
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "",
+        "[]",
+        "{}",
+        b"\xff",
+        json.dumps(
+            {
+                "schema_version": 1,
+                "authority": "generation",
+                "project_id": PROJECT_ID,
+                "store_format_version": 1,
+                "extra": True,
+            }
+        ),
+        _marker(schema_version=False),
+        _marker(schema_version=2),
+        _marker(authority="legacy"),
+        _marker(project_id=PROJECT_ID.lower()),
+        _marker(store_format_version=False),
+        _marker(store_format_version=0),
+    ],
+)
+def test_marker_must_be_one_strict_closed_json_object(raw: str | bytes) -> None:
+    with pytest.raises(GenerationControlCorruptError) as raised:
+        select_project_authority(
+            _binding(),
+            marker_json=raw,
+            pointer_json=_pointer(),
+            active_user_id=USER_ID,
+            active_projection_scope_id=PROJECTION_SCOPE_ID,
+        )
+
+    assert raised.value.code == "generation_control_corrupt"
+
+
+def test_marker_rejects_non_json_input_type() -> None:
+    with pytest.raises(GenerationControlCorruptError):
+        select_project_authority(
+            _binding(),
+            marker_json={"authority": "generation"},  # type: ignore[arg-type]
+            pointer_json=_pointer(),
+            active_user_id=USER_ID,
+            active_projection_scope_id=PROJECTION_SCOPE_ID,
+        )
+
+
+def test_unsupported_marker_format_requires_client_upgrade_before_pointer_read() -> None:
+    with pytest.raises(ClientUpgradeRequiredError) as raised:
+        select_project_authority(
+            _binding(),
+            marker_json=_marker(store_format_version=2),
+            pointer_json="not-json",
+        )
+
+    assert raised.value.code == "client_upgrade_required"
+
+
+def test_marker_must_match_bound_project() -> None:
+    with pytest.raises(GenerationControlCorruptError):
+        select_project_authority(
+            _binding(),
+            marker_json=_marker(project_id=OTHER_PROJECT_ID),
+            pointer_json=_pointer(project_id=OTHER_PROJECT_ID),
+            active_user_id=USER_ID,
+            active_projection_scope_id=PROJECTION_SCOPE_ID,
+        )
+
+
+def test_active_marker_requires_pointer() -> None:
+    with pytest.raises(GenerationControlCorruptError):
+        select_project_authority(
+            _binding(),
+            marker_json=_marker(),
+            pointer_json=None,
+            active_user_id=USER_ID,
+            active_projection_scope_id=PROJECTION_SCOPE_ID,
+        )
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "",
+        "[]",
+        "{}",
+        b"\xff",
+        json.dumps(
+            {
+                "schema_version": 1,
+                "project_id": PROJECT_ID,
+                "store_format_version": 1,
+                "generation_id": GENERATION_ID,
+                "manifest_digest": MANIFEST_DIGEST,
+                "committed_at": COMMITTED_AT,
+                "installed_at": INSTALLED_AT,
+                "installed_state_id": INSTALL_STATE_ID,
+                "installed_for_user_id": USER_ID,
+                "projection_class": "contributor_plus",
+                "projection_scope_id": PROJECTION_SCOPE_ID,
+                "extra": True,
+            }
+        ),
+    ],
+)
+def test_pointer_must_be_one_strict_closed_json_object(raw: str | bytes) -> None:
+    with pytest.raises(GenerationControlCorruptError):
+        select_project_authority(
+            _binding(),
+            marker_json=_marker(),
+            pointer_json=raw,
+            active_user_id=USER_ID,
+            active_projection_scope_id=PROJECTION_SCOPE_ID,
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("schema_version", False),
+        ("schema_version", 2),
+        ("project_id", PROJECT_ID.lower()),
+        ("store_format_version", False),
+        ("store_format_version", 0),
+        ("generation_id", "generation-1"),
+        ("manifest_digest", "A" * 64),
+        ("manifest_digest", "a" * 63),
+        ("committed_at", "2026-09-02T01:02:03Z"),
+        ("committed_at", "2026-99-02T01:02:03.000004Z"),
+        ("installed_at", "2026-09-02T01:03:04.00005Z"),
+        ("installed_at", "2026-09-02T01:02:02.999999Z"),
+        ("installed_state_id", "state-1"),
+        ("installed_for_user_id", "user-1"),
+        ("projection_class", "owner"),
+        ("projection_scope_id", "B" * 64),
+        ("projection_scope_id", "b" * 65),
+    ],
+)
+def test_pointer_fields_are_strict_and_canonical(field: str, value: object) -> None:
+    with pytest.raises(GenerationControlCorruptError):
+        select_project_authority(
+            _binding(),
+            marker_json=_marker(),
+            pointer_json=_pointer(**{field: value}),
+            active_user_id=USER_ID,
+            active_projection_scope_id=PROJECTION_SCOPE_ID,
+        )
+
+
+def test_pointer_rejects_non_json_input_type() -> None:
+    with pytest.raises(GenerationControlCorruptError):
+        select_project_authority(
+            _binding(),
+            marker_json=_marker(),
+            pointer_json={"project_id": PROJECT_ID},  # type: ignore[arg-type]
+            active_user_id=USER_ID,
+            active_projection_scope_id=PROJECTION_SCOPE_ID,
+        )
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"project_id": OTHER_PROJECT_ID},
+        {"store_format_version": 2},
+    ],
+)
+def test_pointer_must_cross_bind_to_marker_and_project(changes: dict[str, object]) -> None:
+    with pytest.raises(GenerationControlCorruptError):
+        select_project_authority(
+            _binding(),
+            marker_json=_marker(),
+            pointer_json=_pointer(**changes),
+            active_user_id=USER_ID,
+            active_projection_scope_id=PROJECTION_SCOPE_ID,
+        )
+
+
+@pytest.mark.parametrize("active_user_id", [None, "user-1", OTHER_USER_ID])
+def test_generation_selection_requires_matching_active_actor(
+    active_user_id: str | None,
+) -> None:
+    with pytest.raises(ReplicaActorMismatchError) as raised:
+        select_project_authority(
+            _binding(),
+            marker_json=_marker(),
+            pointer_json=_pointer(),
+            active_user_id=active_user_id,
+            active_projection_scope_id=PROJECTION_SCOPE_ID,
+        )
+
+    assert raised.value.code == "replica_actor_mismatch"
+
+
+@pytest.mark.parametrize(
+    "active_scope",
+    [None, "scope-1", "B" * 64, OTHER_PROJECTION_SCOPE_ID],
+)
+def test_generation_selection_requires_matching_authorization_scope(
+    active_scope: str | None,
+) -> None:
+    with pytest.raises(RefreshRequiredError) as raised:
+        select_project_authority(
+            _binding(),
+            marker_json=_marker(),
+            pointer_json=_pointer(),
+            active_user_id=USER_ID,
+            active_projection_scope_id=active_scope,
+        )
+
+    assert raised.value.code == "refresh_required"
+
+
+def test_valid_generation_selection_retains_all_bound_facts() -> None:
+    binding = _binding()
+
+    result = select_project_authority(
+        binding,
+        marker_json=_marker(),
+        pointer_json=_pointer(),
+        active_user_id=USER_ID,
+        active_projection_scope_id=PROJECTION_SCOPE_ID,
+    )
+
+    assert isinstance(result, GenerationProjectAuthority)
+    assert result.kind == "hosted_generation"
+    assert result.binding is binding
+    assert result.marker.project_id == PROJECT_ID
+    assert result.marker.store_format_version == 1
+    assert result.pointer.project_id == PROJECT_ID
+    assert result.pointer.generation_id == GENERATION_ID
+    assert result.pointer.manifest_digest == MANIFEST_DIGEST
+    assert result.pointer.committed_at == COMMITTED_AT
+    assert result.pointer.installed_at == INSTALLED_AT
+    assert result.pointer.installed_state_id == INSTALL_STATE_ID
+    assert result.pointer.installed_for_user_id == USER_ID
+    assert result.pointer.projection_class == "contributor_plus"
+    assert result.pointer.projection_scope_id == PROJECTION_SCOPE_ID
+
+    with pytest.raises(pyd.ValidationError):
+        result.pointer.generation_id = OTHER_PROJECT_ID
+    with pytest.raises(FrozenInstanceError):
+        result.binding = _binding(project_id=OTHER_PROJECT_ID)

--- a/packages/nauro/tests/test_generation_authority.py
+++ b/packages/nauro/tests/test_generation_authority.py
@@ -171,8 +171,19 @@ def test_marker_must_match_bound_project() -> None:
         )
 
 
-def test_active_marker_requires_pointer() -> None:
-    with pytest.raises(GenerationControlCorruptError):
+def test_active_marker_without_account_reports_actor_mismatch_before_pointer() -> None:
+    with pytest.raises(ReplicaActorMismatchError) as raised:
+        select_project_authority(
+            _binding(),
+            marker_json=_marker(),
+            pointer_json=None,
+        )
+
+    assert raised.value.code == "replica_actor_mismatch"
+
+
+def test_active_account_without_pointer_requires_refresh() -> None:
+    with pytest.raises(RefreshRequiredError) as raised:
         select_project_authority(
             _binding(),
             marker_json=_marker(),
@@ -180,6 +191,8 @@ def test_active_marker_requires_pointer() -> None:
             active_user_id=USER_ID,
             active_projection_scope_id=PROJECTION_SCOPE_ID,
         )
+
+    assert raised.value.code == "refresh_required"
 
 
 @pytest.mark.parametrize(

--- a/packages/nauro/tests/test_resolution_v2.py
+++ b/packages/nauro/tests/test_resolution_v2.py
@@ -184,6 +184,345 @@ def test_stdio_resolve_explicit_id_matching_config(tmp_path, monkeypatch):
     assert store == tmp_path / "projects" / cloud_pid
 
 
+# ── dormant strict project-binding resolution ────────────────────────────────
+
+
+def _binding_state(
+    tmp_path,
+    nauro_home,
+    *,
+    name="Pareto",
+    config_patch=None,
+    entry_patch=None,
+):
+    pid = "01KQ6AZGNA0B3QBF67NBXP3S45"
+    repo = tmp_path / "binding-repo"
+    repo.mkdir()
+    store = nauro_home / "projects" / pid
+    scaffold_project_store(name, store)
+    entry = {"name": name, "mode": "local", "repo_paths": [str(repo.resolve())]}
+    entry.update(entry_patch or {})
+    registry.save_registry_v2(
+        {"schema_version": REGISTRY_SCHEMA_VERSION_V2, "projects": {pid: entry}}
+    )
+    config = {"mode": "local", "id": pid, "name": name}
+    config.update(config_patch or {})
+    save_repo_config(repo, config)
+    return pid, repo, store
+
+
+@pytest.mark.parametrize(("mode", "url"), [("local", None), ("cloud", "https://mcp.nauro.ai/mcp/")])
+def test_resolve_project_binding_returns_validated_binding(
+    tmp_path, monkeypatch, nauro_home, mode, url
+):
+    from nauro.store.resolution import ResolvedProjectBinding, resolve_project_binding
+
+    patch = {"mode": mode}
+    if url is not None:
+        patch["server_url"] = url
+    pid, repo, store = _binding_state(tmp_path, nauro_home, config_patch=patch, entry_patch=patch)
+
+    result = resolve_project_binding(pid, repo)
+
+    assert result == ResolvedProjectBinding(
+        store_path=store,
+        project_id=pid,
+        display_name="Pareto",
+        mode=mode,
+        server_url=url,
+    )
+
+
+def test_resolve_project_binding_reads_one_registry_snapshot(tmp_path, monkeypatch, nauro_home):
+    from nauro.store.resolution import resolve_project_binding
+
+    pid, repo, _store = _binding_state(tmp_path, nauro_home)
+    registry_path = nauro_home / REGISTRY_FILENAME
+    path_type = type(registry_path)
+    original_read = path_type.read_text
+    reads = 0
+
+    def counted_read(path, *args, **kwargs):
+        nonlocal reads
+        if path == registry_path:
+            reads += 1
+        return original_read(path, *args, **kwargs)
+
+    monkeypatch.setattr(path_type, "read_text", counted_read)
+    resolve_project_binding(pid, repo)
+    assert reads == 1
+
+
+@pytest.mark.parametrize(
+    ("config_patch", "entry_patch"),
+    [
+        ({"server_url": "https://mcp.nauro.ai/mcp"}, {}),
+        ({}, {"server_url": "https://mcp.nauro.ai/mcp"}),
+        ({}, {"mode": "cloud", "server_url": "https://mcp.nauro.ai/mcp"}),
+        ({"mode": "cloud", "server_url": "https://mcp.nauro.ai/mcp"}, {}),
+        (
+            {"mode": "cloud", "server_url": "https://mcp.nauro.ai/mcp"},
+            {"mode": "cloud", "server_url": "https://mcp.nauro.ai/mcp/"},
+        ),
+    ],
+)
+def test_resolve_project_binding_rejects_mode_or_url_conflict(
+    tmp_path, monkeypatch, nauro_home, config_patch, entry_patch
+):
+    from nauro.store.resolution import DisconnectedProjectError, resolve_project_binding
+
+    _pid, repo, _store = _binding_state(
+        tmp_path, nauro_home, config_patch=config_patch, entry_patch=entry_patch
+    )
+
+    with pytest.raises(DisconnectedProjectError) as exc:
+        resolve_project_binding(None, repo)
+
+    assert exc.value.state.reason_code == "connected_binding_conflict"
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("raw", "not-json"),
+        ("schema_version", 999),
+        ("schema_version", 2.0),
+        ("schema_version", True),
+        ("projects", None),
+        ("projects", []),
+    ],
+    ids=["malformed-json", "unknown-schema", "float-schema", "bool-schema", "null-map", "list-map"],
+)
+def test_resolve_project_binding_rejects_malformed_or_unknown_registry(
+    tmp_path, monkeypatch, nauro_home, field, value
+):
+    from nauro.store.resolution import StoreResolutionError, resolve_project_binding
+
+    pid, repo, _store = _binding_state(tmp_path, nauro_home)
+    registry_path = nauro_home / REGISTRY_FILENAME
+    if field == "raw":
+        registry_path.write_text("not-json\n")
+    else:
+        data = json.loads(registry_path.read_text())
+        data[field] = value
+        registry_path.write_text(json.dumps(data))
+
+    with pytest.raises(StoreResolutionError) as exc:
+        resolve_project_binding(pid, repo)
+    assert type(exc.value) is StoreResolutionError
+
+
+def test_resolve_project_binding_prioritizes_global_registry_error(
+    tmp_path, monkeypatch, nauro_home
+):
+    from nauro.store.resolution import StoreResolutionError, resolve_project_binding
+
+    pid, repo, _store = _binding_state(tmp_path, nauro_home)
+    registry_path = nauro_home / REGISTRY_FILENAME
+    data = json.loads(registry_path.read_text())
+    data["schema_version"] = 999
+    data["projects"][pid]["name"] = "../bad"
+    registry_path.write_text(json.dumps(data))
+
+    with pytest.raises(StoreResolutionError) as exc:
+        resolve_project_binding(pid, repo)
+    assert type(exc.value) is StoreResolutionError
+
+
+def test_resolve_project_binding_rejects_unreadable_registry(tmp_path, monkeypatch, nauro_home):
+    from nauro.store.resolution import StoreResolutionError, resolve_project_binding
+
+    pid, repo, _store = _binding_state(tmp_path, nauro_home)
+    registry_path = nauro_home / REGISTRY_FILENAME
+    path_type = type(registry_path)
+    original_read = path_type.read_text
+
+    def unreadable(path, *args, **kwargs):
+        if path == registry_path:
+            raise OSError("unreadable")
+        return original_read(path, *args, **kwargs)
+
+    monkeypatch.setattr(path_type, "read_text", unreadable)
+    with pytest.raises(StoreResolutionError) as exc:
+        resolve_project_binding(pid, repo)
+    assert type(exc.value) is StoreResolutionError
+
+
+@pytest.mark.parametrize(
+    ("config_patch", "remove_registry"),
+    [
+        ({"schema_version": True}, False),
+        ({"schema_version": 1.0}, False),
+        ({"id": "81KQ6AZGNA0B3QBF67NBXP3S45"}, True),
+        ({"name": "../bad"}, True),
+    ],
+    ids=["bool-schema", "float-schema", "invalid-id", "invalid-name"],
+)
+def test_binding_rejects_invalid_config_boundary(
+    tmp_path, nauro_home, config_patch, remove_registry
+):
+    from nauro.store.resolution import StoreResolutionError, resolve_project_binding
+
+    pid, repo, _store = _binding_state(tmp_path, nauro_home, config_patch=config_patch)
+    if remove_registry:
+        (nauro_home / REGISTRY_FILENAME).unlink()
+
+    with pytest.raises(StoreResolutionError) as exc:
+        resolve_project_binding(pid, repo)
+    assert type(exc.value) is StoreResolutionError
+
+
+@pytest.mark.parametrize(
+    ("case", "value"),
+    [
+        ("repo_path", ""),
+        ("repo_path", "binding-repo"),
+        ("repo_path", "lexical"),
+        pytest.param(
+            "repo_path", "symlink", marks=pytest.mark.skipif(os.name == "nt", reason="symlink")
+        ),
+        ("name", ""),
+        ("name", "../bad"),
+        ("name", "bad\nname"),
+        ("mode", "unknown"),
+        ("project_id", "local-project"),
+    ],
+)
+def test_resolve_project_binding_rejects_invalid_registry_entry(
+    tmp_path, monkeypatch, nauro_home, case, value
+):
+    from nauro.store.resolution import StoreResolutionError, resolve_project_binding
+
+    pid, repo, _store = _binding_state(tmp_path, nauro_home)
+    data = registry.load_registry_v2()
+    entry = data["projects"][pid]
+    (repo / REPO_CONFIG_DIR / REPO_CONFIG_FILENAME).unlink()
+    handle, cwd = pid, None
+    if case == "repo_path":
+        handle, cwd = None, repo
+        if value == "lexical":
+            value = str(repo / ".." / repo.name)
+        elif value == "symlink":
+            link = tmp_path / "repo-link"
+            link.symlink_to(repo, target_is_directory=True)
+            value = str(link)
+        entry["repo_paths"] = [value]
+    elif case == "project_id":
+        data["projects"][value] = data["projects"].pop(pid)
+        scaffold_project_store("Pareto", nauro_home / "projects" / value)
+        handle = value
+    else:
+        entry[case] = value
+    registry.save_registry_v2(data)
+
+    with pytest.raises(StoreResolutionError):
+        resolve_project_binding(handle, cwd)
+
+
+def test_resolve_project_binding_prefers_exact_key_over_display_name(
+    tmp_path, monkeypatch, nauro_home
+):
+    from nauro.store.resolution import ProjectIdMismatchError, resolve_project_binding
+
+    other_pid = "01KQ6AZGNA0B3QBF67NBXP3S46"
+    _pid, repo, _store = _binding_state(tmp_path, nauro_home, name=other_pid)
+    data = registry.load_registry_v2()
+    scaffold_project_store("Other", nauro_home / "projects" / other_pid)
+    data["projects"][other_pid] = {"name": "Other", "mode": "local", "repo_paths": []}
+    registry.save_registry_v2(data)
+
+    with pytest.raises(ProjectIdMismatchError):
+        resolve_project_binding(other_pid, repo)
+
+
+def test_resolve_project_binding_rejects_cross_project_path_owner(
+    tmp_path, monkeypatch, nauro_home
+):
+    from nauro.store.resolution import StoreResolutionError, resolve_project_binding
+
+    pid, repo, _store = _binding_state(tmp_path, nauro_home)
+    other_pid = "01KQ6AZGNA0B3QBF67NBXP3S46"
+    data = registry.load_registry_v2()
+    scaffold_project_store("Other", nauro_home / "projects" / other_pid)
+    data["projects"][other_pid] = {
+        "name": "Other",
+        "mode": "local",
+        "repo_paths": [str(repo.resolve())],
+    }
+    registry.save_registry_v2(data)
+
+    with pytest.raises(StoreResolutionError) as exc:
+        resolve_project_binding(pid, repo)
+    assert type(exc.value) is StoreResolutionError
+
+
+def test_resolve_project_binding_rejects_nested_cwd_matches(tmp_path, monkeypatch, nauro_home):
+    from nauro.store.resolution import MultipleProjectsError, resolve_project_binding
+
+    _pid, repo, _store = _binding_state(tmp_path, nauro_home)
+    (repo / REPO_CONFIG_DIR / REPO_CONFIG_FILENAME).unlink()
+    nested = repo / "nested"
+    nested.mkdir()
+    other_pid = "01KQ6AZGNA0B3QBF67NBXP3S46"
+    data = registry.load_registry_v2()
+    scaffold_project_store("Other", nauro_home / "projects" / other_pid)
+    data["projects"][other_pid] = {
+        "name": "Other",
+        "mode": "local",
+        "repo_paths": [str(nested.resolve())],
+    }
+    registry.save_registry_v2(data)
+
+    with pytest.raises(MultipleProjectsError):
+        resolve_project_binding(None, nested)
+
+
+def test_resolve_project_binding_preserves_empty_and_unknown_errors(
+    tmp_path, monkeypatch, nauro_home
+):
+    from nauro.store.resolution import (
+        NoProjectError,
+        ProjectNotFoundError,
+        resolve_project_binding,
+    )
+
+    with pytest.raises(NoProjectError):
+        resolve_project_binding(None, None)
+    with pytest.raises(ProjectNotFoundError):
+        resolve_project_binding("missing", None)
+
+
+def test_resolve_project_binding_preserves_duplicate_name_error(tmp_path, monkeypatch, nauro_home):
+    from nauro.store.resolution import MultipleProjectsError, resolve_project_binding
+
+    _pid, repo, _store = _binding_state(tmp_path, nauro_home)
+    (repo / REPO_CONFIG_DIR / REPO_CONFIG_FILENAME).unlink()
+    other_pid = "01KQ6AZGNA0B3QBF67NBXP3S46"
+    data = registry.load_registry_v2()
+    scaffold_project_store("Pareto", nauro_home / "projects" / other_pid)
+    data["projects"][other_pid] = {"name": "Pareto", "mode": "local", "repo_paths": []}
+    registry.save_registry_v2(data)
+
+    with pytest.raises(MultipleProjectsError):
+        resolve_project_binding("Pareto", None)
+
+
+def test_legacy_resolve_store_does_not_use_strict_binding_resolver(
+    tmp_path, monkeypatch, nauro_home
+):
+    from nauro.store import resolution
+
+    cloud = {"mode": "cloud", "server_url": "https://mcp.nauro.ai/mcp"}
+    pid, repo, store = _binding_state(tmp_path, nauro_home, config_patch=cloud, entry_patch=cloud)
+    monkeypatch.setattr(
+        resolution,
+        "_strict_registry_entries",
+        lambda: pytest.fail("legacy resolution must not call the dormant resolver"),
+    )
+
+    assert resolve_store(pid, repo) == store
+
+
 # ── corrupt repo config degrades gracefully (no transport crash) ─────────────
 
 


### PR DESCRIPTION
## Why

A hosted client needs one fail-closed boundary between the legacy flat store and an installed generation. Marker presence, project identity, format support, actor identity, and authorization scope must agree before generation bytes can become authoritative.

## What changed

- Add strict immutable codecs for the generation authority marker and installed pointer.
- Keep local-only and pre-epoch hosted projects on flat authority when the marker is absent.
- Reject unsupported formats, partial or malformed control evidence, cross-project pointers, stale actors, and stale authorization scopes with typed error codes.
- Classify an absent active account as replica_actor_mismatch and a valid account without an installed pointer as refresh_required.
- Preserve every pointer fact required for later generation installation and read routing.

## Test plan

- 52 focused authority-selection tests passed.
- The combined 129 binding and authority tests passed.
- All 2,850 nauro package tests passed.
- Ruff check, Ruff format check, Mypy, and git diff check passed.

## Deferred

This is a dormant pure selection boundary. Control-directory I/O, lock-held reads, authenticated actor and scope derivation, generation installation, sync, migration, and activation remain separate changes.