### PR TITLE
Read replica control under one lock

### DIFF
--- a/packages/nauro/src/nauro/store/replica_control.py
+++ b/packages/nauro/src/nauro/store/replica_control.py
@@ -1,0 +1,186 @@
+"""Lock-held reads of local hosted-replica control state."""
+
+from __future__ import annotations
+
+import os
+import stat
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+
+from filelock import FileLock, Timeout
+from nauro_core.constants import HOSTED_STORE_FORMAT_VERSION
+from nauro_core.identifiers import IdentifierKind, is_identifier, validate_identifier
+
+from nauro.store.generation_authority import GenerationAuthorityError
+from nauro.store.resolution import ResolvedProjectBinding
+
+_CONTROL_DIRECTORY = ".replica"
+_CONTROL_LOCK_FILE = ".replica-control.lock"
+_AUTHORITY_MARKER_FILE = "authority.json"
+_ACTORS_DIRECTORY = "actors"
+_POINTER_FILE = "pointer.json"
+_MAX_CONTROL_FILE_BYTES = 16 * 1024
+_READ_FLAGS = (
+    os.O_RDONLY
+    | getattr(os, "O_CLOEXEC", 0)
+    | getattr(os, "O_BINARY", 0)
+    | getattr(os, "O_NOFOLLOW", 0)
+)
+
+
+class ReplicaControlReadError(GenerationAuthorityError):
+    """Replica control state cannot be read safely."""
+
+    code = "generation_control_unavailable"
+
+
+class ReplicaControlBusyError(GenerationAuthorityError):
+    """Another process holds the replica control lock."""
+
+    code = "generation_control_busy"
+
+
+@dataclass(frozen=True)
+class ReplicaControlLayout:
+    """Stable paths for one project's versioned replica control state."""
+
+    store_path: Path
+
+    @property
+    def control_lock(self) -> Path:
+        return self.store_path / _CONTROL_LOCK_FILE
+
+    @property
+    def control_root(self) -> Path:
+        return self.store_path / _CONTROL_DIRECTORY
+
+    @property
+    def authority_marker(self) -> Path:
+        return self.control_root / _AUTHORITY_MARKER_FILE
+
+    @property
+    def version_root(self) -> Path:
+        return self.control_root / f"v{HOSTED_STORE_FORMAT_VERSION}"
+
+    def actor_pointer(self, user_id: str) -> Path:
+        canonical = validate_identifier(IdentifierKind.ulid, user_id, field="user_id")
+        return self.version_root / _ACTORS_DIRECTORY / canonical / _POINTER_FILE
+
+
+@dataclass(frozen=True)
+class ReplicaControlSnapshot:
+    """Exact marker and active-actor pointer bytes read under one lock."""
+
+    marker_json: bytes | None
+    pointer_json: bytes | None
+
+
+def _refuse_symlinks(store_path: Path, paths: tuple[Path, ...]) -> None:
+    for path in paths:
+        try:
+            relative = path.relative_to(store_path)
+        except ValueError as exc:
+            raise ReplicaControlReadError(
+                "Replica control path escaped the project store."
+            ) from exc
+        current = store_path
+        for part in relative.parts:
+            current /= part
+            try:
+                is_link = current.is_symlink()
+            except OSError as exc:
+                raise ReplicaControlReadError(
+                    "Replica control path metadata is unavailable."
+                ) from exc
+            if is_link:
+                raise ReplicaControlReadError("Replica control paths cannot contain symlinks.")
+
+
+def _read_optional_file(path: Path) -> bytes | None:
+    try:
+        observed = path.lstat()
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        raise ReplicaControlReadError("Replica control file metadata is unavailable.") from exc
+    if not stat.S_ISREG(observed.st_mode) or observed.st_size > _MAX_CONTROL_FILE_BYTES:
+        raise ReplicaControlReadError("Replica control file is not a bounded regular file.")
+
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(path, _READ_FLAGS)
+        opened = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or (opened.st_dev, opened.st_ino) != (observed.st_dev, observed.st_ino)
+            or opened.st_size > _MAX_CONTROL_FILE_BYTES
+        ):
+            raise ReplicaControlReadError("Replica control file changed during open.")
+        with os.fdopen(descriptor, "rb", closefd=True) as handle:
+            descriptor = None
+            content = handle.read(_MAX_CONTROL_FILE_BYTES + 1)
+            finished = os.fstat(handle.fileno())
+        if (
+            len(content) > _MAX_CONTROL_FILE_BYTES
+            or (finished.st_dev, finished.st_ino) != (opened.st_dev, opened.st_ino)
+            or finished.st_size != opened.st_size
+            or len(content) != finished.st_size
+        ):
+            raise ReplicaControlReadError("Replica control file changed during read.")
+        return content
+    except ReplicaControlReadError:
+        raise
+    except OSError as exc:
+        raise ReplicaControlReadError("Replica control file is unreadable.") from exc
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+
+
+@contextmanager
+def locked_replica_control_snapshot(
+    binding: ResolvedProjectBinding,
+    *,
+    active_user_id: str | None,
+    timeout: float = -1,
+) -> Iterator[ReplicaControlSnapshot]:
+    """Yield exact control bytes while holding the project control lock."""
+    if binding.mode == "local":
+        yield ReplicaControlSnapshot(marker_json=None, pointer_json=None)
+        return
+
+    layout = ReplicaControlLayout(binding.store_path)
+    _refuse_symlinks(binding.store_path, (layout.control_lock,))
+    lock = FileLock(str(layout.control_lock), timeout=timeout)
+    try:
+        lock.acquire()
+    except Timeout as exc:
+        raise ReplicaControlBusyError("Replica control state is busy.") from exc
+    except OSError as exc:
+        raise ReplicaControlReadError("Replica control lock is unavailable.") from exc
+    try:
+        _refuse_symlinks(binding.store_path, (layout.authority_marker,))
+        marker_json = _read_optional_file(layout.authority_marker)
+        pointer_json = None
+        if marker_json is not None and is_identifier(IdentifierKind.ulid, active_user_id):
+            assert isinstance(active_user_id, str)
+            pointer = layout.actor_pointer(active_user_id)
+            _refuse_symlinks(binding.store_path, (pointer,))
+            pointer_json = _read_optional_file(pointer)
+        yield ReplicaControlSnapshot(
+            marker_json=marker_json,
+            pointer_json=pointer_json,
+        )
+    finally:
+        lock.release()
+
+
+__all__ = [
+    "ReplicaControlBusyError",
+    "ReplicaControlLayout",
+    "ReplicaControlReadError",
+    "ReplicaControlSnapshot",
+    "locked_replica_control_snapshot",
+]

--- a/packages/nauro/tests/test_replica_control.py
+++ b/packages/nauro/tests/test_replica_control.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+import json
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+from typing import Literal
+
+import pytest
+from filelock import FileLock, Timeout
+
+from nauro.store.generation_authority import (
+    GenerationProjectAuthority,
+    select_project_authority,
+)
+from nauro.store.replica_control import (
+    ReplicaControlBusyError,
+    ReplicaControlLayout,
+    ReplicaControlReadError,
+    ReplicaControlSnapshot,
+    locked_replica_control_snapshot,
+)
+from nauro.store.resolution import ResolvedProjectBinding
+
+PROJECT_ID = "01KQ6AZGNA0B3QBF67NBXP3S45"
+GENERATION_ID = "01K11111111111111111111111"
+INSTALL_STATE_ID = "01K22222222222222222222222"
+USER_ID = "01K33333333333333333333333"
+MANIFEST_DIGEST = "a" * 64
+PROJECTION_SCOPE_ID = "b" * 64
+
+
+def _binding(
+    store_path: Path,
+    *,
+    mode: Literal["local", "cloud"] = "cloud",
+) -> ResolvedProjectBinding:
+    store_path.mkdir()
+    return ResolvedProjectBinding(
+        store_path=store_path,
+        project_id=PROJECT_ID,
+        display_name="Nauro",
+        mode=mode,
+        server_url="https://mcp.nauro.ai" if mode == "cloud" else None,
+    )
+
+
+def _marker() -> bytes:
+    return json.dumps(
+        {
+            "schema_version": 1,
+            "authority": "generation",
+            "project_id": PROJECT_ID,
+            "store_format_version": 1,
+        }
+    ).encode()
+
+
+def _pointer() -> bytes:
+    return json.dumps(
+        {
+            "schema_version": 1,
+            "project_id": PROJECT_ID,
+            "store_format_version": 1,
+            "generation_id": GENERATION_ID,
+            "manifest_digest": MANIFEST_DIGEST,
+            "committed_at": "2026-09-02T01:02:03.000004Z",
+            "installed_at": "2026-09-02T01:03:04.000005Z",
+            "installed_state_id": INSTALL_STATE_ID,
+            "installed_for_user_id": USER_ID,
+            "projection_class": "contributor_plus",
+            "projection_scope_id": PROJECTION_SCOPE_ID,
+        }
+    ).encode()
+
+
+def _write_control(layout: ReplicaControlLayout) -> tuple[bytes, bytes]:
+    marker = _marker()
+    pointer = _pointer()
+    layout.authority_marker.parent.mkdir(parents=True)
+    layout.authority_marker.write_bytes(marker)
+    pointer_file = layout.actor_pointer(USER_ID)
+    pointer_file.parent.mkdir(parents=True)
+    pointer_file.write_bytes(pointer)
+    return marker, pointer
+
+
+def test_layout_uses_one_stable_lock_and_versioned_actor_pointer(tmp_path: Path) -> None:
+    store = tmp_path / PROJECT_ID
+    layout = ReplicaControlLayout(store)
+
+    assert layout.control_lock == store / ".replica-control.lock"
+    assert layout.control_root == store / ".replica"
+    assert layout.authority_marker == store / ".replica" / "authority.json"
+    assert layout.version_root == store / ".replica" / "v1"
+    assert layout.actor_pointer(USER_ID) == (
+        store / ".replica" / "v1" / "actors" / USER_ID / "pointer.json"
+    )
+
+
+@pytest.mark.parametrize("user_id", ["", "../actor", "user-1", PROJECT_ID.lower()])
+def test_actor_pointer_rejects_noncanonical_user_id(tmp_path: Path, user_id: str) -> None:
+    with pytest.raises(ValueError):
+        ReplicaControlLayout(tmp_path).actor_pointer(user_id)
+
+
+def test_local_project_does_not_touch_replica_control(tmp_path: Path) -> None:
+    binding = _binding(tmp_path / PROJECT_ID, mode="local")
+    layout = ReplicaControlLayout(binding.store_path)
+
+    with locked_replica_control_snapshot(binding, active_user_id=None) as snapshot:
+        assert snapshot == ReplicaControlSnapshot(marker_json=None, pointer_json=None)
+
+    assert not layout.control_lock.exists()
+    assert not layout.control_root.exists()
+
+
+def test_cloud_legacy_snapshot_holds_lock_and_returns_absence(tmp_path: Path) -> None:
+    binding = _binding(tmp_path / PROJECT_ID)
+    layout = ReplicaControlLayout(binding.store_path)
+
+    with locked_replica_control_snapshot(binding, active_user_id=None) as snapshot:
+        assert snapshot == ReplicaControlSnapshot(marker_json=None, pointer_json=None)
+        contender = FileLock(str(layout.control_lock))
+        with pytest.raises(Timeout):
+            contender.acquire(timeout=0)
+
+    with FileLock(str(layout.control_lock), timeout=0):
+        pass
+
+
+def test_snapshot_reads_exact_marker_and_active_actor_pointer(tmp_path: Path) -> None:
+    binding = _binding(tmp_path / PROJECT_ID)
+    layout = ReplicaControlLayout(binding.store_path)
+    marker, pointer = _write_control(layout)
+
+    with locked_replica_control_snapshot(binding, active_user_id=USER_ID) as snapshot:
+        assert snapshot == ReplicaControlSnapshot(marker_json=marker, pointer_json=pointer)
+        with pytest.raises(Timeout):
+            FileLock(str(layout.control_lock)).acquire(timeout=0)
+
+
+def test_snapshot_bytes_feed_strict_authority_selection(tmp_path: Path) -> None:
+    binding = _binding(tmp_path / PROJECT_ID)
+    layout = ReplicaControlLayout(binding.store_path)
+    _write_control(layout)
+
+    with locked_replica_control_snapshot(binding, active_user_id=USER_ID) as snapshot:
+        authority = select_project_authority(
+            binding,
+            marker_json=snapshot.marker_json,
+            pointer_json=snapshot.pointer_json,
+            active_user_id=USER_ID,
+            active_projection_scope_id=PROJECTION_SCOPE_ID,
+        )
+
+    assert isinstance(authority, GenerationProjectAuthority)
+    assert authority.pointer.generation_id == GENERATION_ID
+
+
+def test_absent_marker_does_not_inspect_dormant_pointer(tmp_path: Path) -> None:
+    binding = _binding(tmp_path / PROJECT_ID)
+    layout = ReplicaControlLayout(binding.store_path)
+    pointer = layout.actor_pointer(USER_ID)
+    pointer.parent.mkdir(parents=True)
+    outside = tmp_path / "outside.json"
+    outside.write_text("not-json")
+    pointer.symlink_to(outside)
+
+    with locked_replica_control_snapshot(binding, active_user_id=USER_ID) as snapshot:
+        assert snapshot == ReplicaControlSnapshot(marker_json=None, pointer_json=None)
+
+
+def test_invalid_active_user_does_not_form_or_read_pointer_path(tmp_path: Path) -> None:
+    binding = _binding(tmp_path / PROJECT_ID)
+    layout = ReplicaControlLayout(binding.store_path)
+    layout.authority_marker.parent.mkdir(parents=True)
+    marker = _marker()
+    layout.authority_marker.write_bytes(marker)
+
+    with locked_replica_control_snapshot(binding, active_user_id="../actor") as snapshot:
+        assert snapshot == ReplicaControlSnapshot(marker_json=marker, pointer_json=None)
+
+
+def test_active_marker_allows_missing_actor_pointer_snapshot(tmp_path: Path) -> None:
+    binding = _binding(tmp_path / PROJECT_ID)
+    layout = ReplicaControlLayout(binding.store_path)
+    layout.authority_marker.parent.mkdir(parents=True)
+    marker = _marker()
+    layout.authority_marker.write_bytes(marker)
+
+    with locked_replica_control_snapshot(binding, active_user_id=USER_ID) as snapshot:
+        assert snapshot == ReplicaControlSnapshot(marker_json=marker, pointer_json=None)
+
+
+@pytest.mark.parametrize("target", ["lock", "root", "marker", "actor", "pointer"])
+def test_control_snapshot_refuses_symlink_components(tmp_path: Path, target: str) -> None:
+    binding = _binding(tmp_path / PROJECT_ID)
+    layout = ReplicaControlLayout(binding.store_path)
+    outside_file = tmp_path / "outside.json"
+    outside_file.write_bytes(_marker())
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+
+    if target == "lock":
+        layout.control_lock.symlink_to(outside_file)
+    elif target == "root":
+        layout.control_root.symlink_to(outside_dir, target_is_directory=True)
+    elif target == "marker":
+        layout.control_root.mkdir()
+        layout.authority_marker.symlink_to(outside_file)
+    else:
+        layout.authority_marker.parent.mkdir(parents=True)
+        layout.authority_marker.write_bytes(_marker())
+        pointer = layout.actor_pointer(USER_ID)
+        pointer.parent.parent.mkdir(parents=True)
+        if target == "actor":
+            pointer.parent.symlink_to(outside_dir, target_is_directory=True)
+        else:
+            pointer.parent.mkdir()
+            pointer.symlink_to(outside_file)
+
+    with pytest.raises(ReplicaControlReadError) as raised:
+        with locked_replica_control_snapshot(binding, active_user_id=USER_ID):
+            pass
+
+    assert raised.value.code == "generation_control_unavailable"
+
+
+@pytest.mark.parametrize("kind", ["marker_directory", "marker_large", "pointer_large"])
+def test_control_files_must_be_bounded_regular_files(tmp_path: Path, kind: str) -> None:
+    binding = _binding(tmp_path / PROJECT_ID)
+    layout = ReplicaControlLayout(binding.store_path)
+    layout.control_root.mkdir()
+    if kind == "marker_directory":
+        layout.authority_marker.mkdir()
+    else:
+        layout.authority_marker.write_bytes(
+            b"x" * (16 * 1024 + 1) if kind == "marker_large" else _marker()
+        )
+        if kind == "pointer_large":
+            pointer = layout.actor_pointer(USER_ID)
+            pointer.parent.mkdir(parents=True)
+            pointer.write_bytes(b"x" * (16 * 1024 + 1))
+
+    with pytest.raises(ReplicaControlReadError):
+        with locked_replica_control_snapshot(binding, active_user_id=USER_ID):
+            pass
+
+
+def test_busy_control_lock_has_typed_failure(tmp_path: Path) -> None:
+    binding = _binding(tmp_path / PROJECT_ID)
+    layout = ReplicaControlLayout(binding.store_path)
+
+    with FileLock(str(layout.control_lock)):
+        with pytest.raises(ReplicaControlBusyError) as raised:
+            with locked_replica_control_snapshot(binding, active_user_id=None, timeout=0):
+                pass
+
+    assert raised.value.code == "generation_control_busy"
+
+
+def test_caller_exception_is_not_reclassified_as_control_failure(tmp_path: Path) -> None:
+    binding = _binding(tmp_path / PROJECT_ID)
+
+    with pytest.raises(OSError, match="caller failure"):
+        with locked_replica_control_snapshot(binding, active_user_id=None):
+            raise OSError("caller failure")
+
+
+def test_control_snapshot_is_frozen() -> None:
+    snapshot = ReplicaControlSnapshot(marker_json=b"{}", pointer_json=None)
+
+    with pytest.raises(FrozenInstanceError):
+        snapshot.pointer_json = b"{}"


### PR DESCRIPTION
## Why

Hosted generation authority needs the marker and active actor pointer from one coherent local control view. A refresh or migration must not let a reader combine control state from different moments.

## What changed

- Add one stable replica-control lock and a versioned per-actor pointer layout.
- Read exact marker and pointer bytes under that lock, and keep the lock held through the caller scope.
- Leave local-only projects untouched and ignore dormant pointers while the authority marker is absent.
- Reject symlinked, non-regular, oversized, or replaced control files with typed failures.

This slice adds no runtime caller and does not activate generation authority.

## Test plan

- 152 focused binding, authority, and control-snapshot tests passed.
- 2,873 package tests passed, with 10 skipped.
- Ruff check and format check passed.
- Targeted Mypy check passed.

## Risk / what to review

Review the lock lifetime, marker-first read order, per-actor path validation, and file identity checks.

## Deferred

Per-generation shared lifetime leases, manifest verification, installation, refresh, migration, local-control path exclusion, runtime wiring, and activation remain separate slices.
