### PR TITLE
Verify actor-scoped generation projections

### DIFF
--- a/packages/nauro/src/nauro/store/generation_authority.py
+++ b/packages/nauro/src/nauro/store/generation_authority.py
@@ -86,19 +86,16 @@ class GenerationAuthorityMarker(pyd.BaseModel):
         return value
 
 
-class InstalledGenerationPointer(pyd.BaseModel):
-    """The actor-bound pointer for one verified installed generation."""
+class GenerationProjectionIdentity(pyd.BaseModel):
+    """Server-authenticated identity of one actor-scoped generation projection."""
 
     model_config = _STRICT_MODEL_CONFIG
 
-    schema_version: pyd.StrictInt
     project_id: pyd.StrictStr
     store_format_version: pyd.StrictInt = pyd.Field(ge=1)
     generation_id: pyd.StrictStr
     manifest_digest: pyd.StrictStr
     committed_at: pyd.StrictStr
-    installed_at: pyd.StrictStr
-    installed_state_id: pyd.StrictStr
     installed_for_user_id: pyd.StrictStr
     projection_class: Literal["viewer", "contributor_plus"]
     projection_scope_id: pyd.StrictStr
@@ -106,14 +103,24 @@ class InstalledGenerationPointer(pyd.BaseModel):
     _validate_ulids = pyd.field_validator(
         "project_id",
         "generation_id",
-        "installed_state_id",
         "installed_for_user_id",
     )(_ulid)
     _validate_digests = pyd.field_validator(
         "manifest_digest",
         "projection_scope_id",
     )(_sha256)
-    _validate_timestamps = pyd.field_validator("committed_at", "installed_at")(_timestamp)
+    _validate_committed_at = pyd.field_validator("committed_at")(_timestamp)
+
+
+class InstalledGenerationPointer(GenerationProjectionIdentity):
+    """The actor-bound pointer for one verified installed generation."""
+
+    schema_version: pyd.StrictInt
+    installed_at: pyd.StrictStr
+    installed_state_id: pyd.StrictStr
+
+    _validate_installed_state_id = pyd.field_validator("installed_state_id")(_ulid)
+    _validate_installed_at = pyd.field_validator("installed_at")(_timestamp)
 
     @pyd.field_validator("schema_version")
     @classmethod
@@ -243,6 +250,7 @@ __all__ = [
     "GenerationAuthorityError",
     "GenerationAuthorityMarker",
     "GenerationControlCorruptError",
+    "GenerationProjectionIdentity",
     "GenerationProjectAuthority",
     "InstalledGenerationPointer",
     "ProjectAuthority",

--- a/packages/nauro/src/nauro/store/generation_projection.py
+++ b/packages/nauro/src/nauro/store/generation_projection.py
@@ -1,0 +1,315 @@
+"""Verification of downloaded hosted-generation projection bytes."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from types import MappingProxyType
+
+import pydantic as pyd
+from nauro_core.constants import HOSTED_STORE_FORMAT_VERSION
+from nauro_core.identifiers import IdentifierKind, validate_identifier
+from nauro_core.protected_generation_membership import (
+    InvalidGenerationPath,
+    validate_protected_generation_path,
+)
+
+from nauro.store.generation_authority import (
+    ClientUpgradeRequiredError,
+    GenerationAuthorityError,
+    GenerationProjectionIdentity,
+)
+from nauro.store.resolution import ResolvedProjectBinding
+
+_STRICT_MODEL_CONFIG = pyd.ConfigDict(extra="forbid", frozen=True, strict=True)
+
+
+class GenerationProjectionVerificationError(GenerationAuthorityError):
+    """Downloaded generation bytes do not match their committed authority."""
+
+    code = "generation_verification_failed"
+
+
+@dataclass(frozen=True)
+class GenerationProjectionTarget:
+    """Authenticated server facts that a downloaded projection must satisfy."""
+
+    binding: ResolvedProjectBinding
+    identity: GenerationProjectionIdentity
+
+    def __post_init__(self) -> None:
+        if type(self.binding) is not ResolvedProjectBinding or self.binding.mode != "cloud":
+            raise GenerationProjectionVerificationError(
+                "Generation projection targets require a validated cloud binding."
+            )
+        if type(self.identity) is not GenerationProjectionIdentity:
+            raise GenerationProjectionVerificationError(
+                "Generation projection targets require a validated projection identity."
+            )
+        if self.identity.project_id != self.binding.project_id:
+            raise GenerationProjectionVerificationError(
+                "The generation projection belongs to another project."
+            )
+        if self.identity.store_format_version != HOSTED_STORE_FORMAT_VERSION:
+            raise ClientUpgradeRequiredError(
+                "The generation projection uses an unsupported store format."
+            )
+
+
+def _ulid(value: str, info: pyd.ValidationInfo) -> str:
+    field_name = info.field_name
+    if field_name is None:
+        raise ValueError("identifier validator requires a model field")
+    return validate_identifier(IdentifierKind.ulid, value, field=field_name)
+
+
+def _sha256(value: str, info: pyd.ValidationInfo) -> str:
+    if len(value) != 64 or any(character not in "0123456789abcdef" for character in value):
+        raise ValueError(f"{info.field_name} must be a lowercase SHA-256 digest")
+    return value
+
+
+class GenerationProjectionManifest(pyd.BaseModel):
+    """Canonical actor-scope binding envelope for one generation projection."""
+
+    model_config = _STRICT_MODEL_CONFIG
+
+    project_id: pyd.StrictStr
+    store_format_version: pyd.StrictInt = pyd.Field(ge=1)
+    generation_id: pyd.StrictStr
+    projection_class: pyd.StrictStr
+    projection_scope_id: pyd.StrictStr
+    artifacts: Mapping[pyd.StrictStr, pyd.StrictStr]
+
+    _validate_ids = pyd.field_validator("project_id", "generation_id")(_ulid)
+    _validate_projection_scope_id = pyd.field_validator("projection_scope_id")(_sha256)
+
+    @pyd.field_validator("projection_class")
+    @classmethod
+    def _validate_projection_class(cls, value: str) -> str:
+        if value not in ("viewer", "contributor_plus"):
+            raise ValueError("projection_class is unsupported")
+        return value
+
+    @pyd.field_validator("artifacts")
+    @classmethod
+    def _validate_artifacts(
+        cls,
+        value: Mapping[str, str],
+    ) -> Mapping[str, str]:
+        validated: dict[str, str] = {}
+        for path, digest in value.items():
+            try:
+                canonical_path = validate_protected_generation_path(path)
+            except InvalidGenerationPath as exc:
+                raise ValueError("manifest contains an invalid protected path") from exc
+            if len(digest) != 64 or any(
+                character not in "0123456789abcdef" for character in digest
+            ):
+                raise ValueError(f"artifacts[{canonical_path}] must be a lowercase SHA-256 digest")
+            validated[canonical_path] = digest
+        return MappingProxyType(validated)
+
+    def canonical_bytes(self) -> bytes:
+        """Return the one persisted JSON representation of this manifest."""
+        return json.dumps(
+            {
+                "project_id": self.project_id,
+                "store_format_version": self.store_format_version,
+                "generation_id": self.generation_id,
+                "projection_class": self.projection_class,
+                "projection_scope_id": self.projection_scope_id,
+                "artifacts": dict(self.artifacts),
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        ).encode("utf-8")
+
+
+@dataclass(frozen=True)
+class VerifiedGenerationArtifact:
+    """One protected artifact with a digest derived from its exact bytes."""
+
+    path: str
+    content: bytes
+    digest: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if type(self.path) is not str or type(self.content) is not bytes:
+            raise GenerationProjectionVerificationError(
+                "Generation artifacts require exact string paths and byte content."
+            )
+        try:
+            path = validate_protected_generation_path(self.path)
+        except InvalidGenerationPath as exc:
+            raise GenerationProjectionVerificationError(
+                "The generation contains an invalid protected artifact path."
+            ) from exc
+        object.__setattr__(self, "path", path)
+        object.__setattr__(self, "digest", hashlib.sha256(self.content).hexdigest())
+
+
+class _DuplicateJsonKeyError(ValueError):
+    pass
+
+
+def _object_without_duplicates(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise _DuplicateJsonKeyError(key)
+        result[key] = value
+    return result
+
+
+def _invalid_json_constant(value: str) -> object:
+    raise ValueError(f"invalid JSON constant: {value}")
+
+
+def _parse_manifest(
+    target: GenerationProjectionTarget,
+    manifest_json: bytes,
+) -> GenerationProjectionManifest:
+    if type(manifest_json) is not bytes:
+        raise GenerationProjectionVerificationError("The generation manifest must be exact bytes.")
+    if hashlib.sha256(manifest_json).hexdigest() != target.identity.manifest_digest:
+        raise GenerationProjectionVerificationError("The generation manifest digest diverges.")
+    try:
+        parsed: object = json.loads(
+            manifest_json.decode("utf-8"),
+            object_pairs_hook=_object_without_duplicates,
+            parse_constant=_invalid_json_constant,
+        )
+        manifest = GenerationProjectionManifest.model_validate(parsed)
+    except (
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+        _DuplicateJsonKeyError,
+        pyd.ValidationError,
+        TypeError,
+        ValueError,
+    ) as exc:
+        raise GenerationProjectionVerificationError(
+            "The generation manifest is malformed."
+        ) from exc
+    try:
+        canonical_manifest = manifest.canonical_bytes()
+    except (TypeError, ValueError, UnicodeEncodeError) as exc:
+        raise GenerationProjectionVerificationError(
+            "The generation manifest is malformed."
+        ) from exc
+    if canonical_manifest != manifest_json:
+        raise GenerationProjectionVerificationError("The generation manifest is not canonical.")
+    expected_binding = (
+        target.binding.project_id,
+        target.identity.store_format_version,
+        target.identity.generation_id,
+        target.identity.projection_class,
+        target.identity.projection_scope_id,
+    )
+    manifest_binding = (
+        manifest.project_id,
+        manifest.store_format_version,
+        manifest.generation_id,
+        manifest.projection_class,
+        manifest.projection_scope_id,
+    )
+    if manifest_binding != expected_binding:
+        raise GenerationProjectionVerificationError(
+            "The generation manifest does not match the installed projection binding."
+        )
+    return manifest
+
+
+@dataclass(frozen=True)
+class VerifiedGenerationProjection:
+    """A complete actor-bound projection verified against committed authority."""
+
+    target: GenerationProjectionTarget
+    manifest_json: bytes
+    artifacts: tuple[VerifiedGenerationArtifact, ...]
+    manifest: GenerationProjectionManifest = field(init=False)
+
+    def __post_init__(self) -> None:
+        if type(self.target) is not GenerationProjectionTarget:
+            raise GenerationProjectionVerificationError(
+                "Generation verification requires a validated projection target."
+            )
+        manifest = _parse_manifest(self.target, self.manifest_json)
+        if type(self.artifacts) is not tuple:
+            raise GenerationProjectionVerificationError("The generation artifact set is malformed.")
+        artifacts = self.artifacts
+        if any(type(artifact) is not VerifiedGenerationArtifact for artifact in artifacts):
+            raise GenerationProjectionVerificationError("The generation artifact set is malformed.")
+        paths = tuple(artifact.path for artifact in artifacts)
+        if len(paths) != len(set(paths)):
+            raise GenerationProjectionVerificationError(
+                "The generation contains duplicate artifact paths."
+            )
+        by_path = {artifact.path: artifact for artifact in artifacts}
+        if set(by_path) != set(manifest.artifacts):
+            raise GenerationProjectionVerificationError(
+                "The generation artifact set differs from the manifest."
+            )
+        for path, expected_digest in manifest.artifacts.items():
+            if by_path[path].digest != expected_digest:
+                raise GenerationProjectionVerificationError(
+                    f"The generation artifact digest diverges: {path}."
+                )
+        object.__setattr__(self, "artifacts", tuple(by_path[path] for path in sorted(by_path)))
+        object.__setattr__(self, "manifest", manifest)
+
+    @property
+    def project_id(self) -> str:
+        return self.target.binding.project_id
+
+    @property
+    def generation_id(self) -> str:
+        return self.manifest.generation_id
+
+    @property
+    def manifest_digest(self) -> str:
+        return self.target.identity.manifest_digest
+
+    @property
+    def total_bytes(self) -> int:
+        return sum(len(artifact.content) for artifact in self.artifacts)
+
+
+def verify_generation_projection(
+    target: GenerationProjectionTarget,
+    *,
+    manifest_json: bytes,
+    artifacts: Sequence[tuple[str, bytes]],
+) -> VerifiedGenerationProjection:
+    """Verify exact downloaded bytes without reading the network or local store."""
+    verified_artifacts: list[VerifiedGenerationArtifact] = []
+    try:
+        for entry in artifacts:
+            if type(entry) is not tuple or len(entry) != 2:
+                raise TypeError("artifact entry must be a path and content tuple")
+            verified_artifacts.append(VerifiedGenerationArtifact(entry[0], entry[1]))
+    except GenerationProjectionVerificationError:
+        raise
+    except (TypeError, ValueError) as exc:
+        raise GenerationProjectionVerificationError(
+            "The generation artifact set is malformed."
+        ) from exc
+    return VerifiedGenerationProjection(
+        target=target,
+        manifest_json=manifest_json,
+        artifacts=tuple(verified_artifacts),
+    )
+
+
+__all__ = [
+    "GenerationProjectionManifest",
+    "GenerationProjectionTarget",
+    "GenerationProjectionVerificationError",
+    "VerifiedGenerationArtifact",
+    "VerifiedGenerationProjection",
+    "verify_generation_projection",
+]

--- a/packages/nauro/tests/test_generation_authority.py
+++ b/packages/nauro/tests/test_generation_authority.py
@@ -12,6 +12,7 @@ from nauro.store.generation_authority import (
     FlatProjectAuthority,
     GenerationControlCorruptError,
     GenerationProjectAuthority,
+    GenerationProjectionIdentity,
     RefreshRequiredError,
     ReplicaActorMismatchError,
     select_project_authority,
@@ -340,6 +341,7 @@ def test_valid_generation_selection_retains_all_bound_facts() -> None:
     )
 
     assert isinstance(result, GenerationProjectAuthority)
+    assert isinstance(result.pointer, GenerationProjectionIdentity)
     assert result.kind == "hosted_generation"
     assert result.binding is binding
     assert result.marker.project_id == PROJECT_ID

--- a/packages/nauro/tests/test_generation_projection.py
+++ b/packages/nauro/tests/test_generation_projection.py
@@ -1,0 +1,454 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+
+import pydantic as pyd
+import pytest
+
+from nauro.store.generation_authority import (
+    ClientUpgradeRequiredError,
+    GenerationProjectionIdentity,
+)
+from nauro.store.generation_projection import (
+    GenerationProjectionManifest,
+    GenerationProjectionTarget,
+    GenerationProjectionVerificationError,
+    VerifiedGenerationArtifact,
+    VerifiedGenerationProjection,
+    verify_generation_projection,
+)
+from nauro.store.resolution import ResolvedProjectBinding
+
+PROJECT_ID = "01KQ6AZGNA0B3QBF67NBXP3S45"
+OTHER_PROJECT_ID = "01K00000000000000000000000"
+GENERATION_ID = "01K11111111111111111111111"
+OTHER_GENERATION_ID = "01K22222222222222222222222"
+USER_ID = "01K44444444444444444444444"
+PROJECTION_SCOPE_ID = "a" * 64
+
+
+def _manifest_object(
+    *,
+    project_id: object = PROJECT_ID,
+    store_format_version: object = 1,
+    generation_id: object = GENERATION_ID,
+    projection_class: object = "contributor_plus",
+    projection_scope_id: object = PROJECTION_SCOPE_ID,
+    artifacts: object | None = None,
+    extra: dict[str, object] | None = None,
+) -> dict[str, object]:
+    body: dict[str, object] = {
+        "project_id": project_id,
+        "store_format_version": store_format_version,
+        "generation_id": generation_id,
+        "projection_class": projection_class,
+        "projection_scope_id": projection_scope_id,
+        "artifacts": (
+            {"project.md": hashlib.sha256(b"# Project\n").hexdigest()}
+            if artifacts is None
+            else artifacts
+        ),
+    }
+    if extra:
+        body.update(extra)
+    return body
+
+
+def _canonical_manifest(**changes: object) -> bytes:
+    return json.dumps(
+        _manifest_object(**changes),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode()
+
+
+def _target(
+    manifest_json: bytes,
+    *,
+    binding: ResolvedProjectBinding | None = None,
+    **changes: object,
+) -> GenerationProjectionTarget:
+    if binding is None:
+        binding = ResolvedProjectBinding(
+            store_path=Path("store"),
+            project_id=PROJECT_ID,
+            display_name="Nauro",
+            mode="cloud",
+            server_url="https://mcp.nauro.ai",
+        )
+    values: dict[str, object] = {
+        "project_id": PROJECT_ID,
+        "store_format_version": 1,
+        "generation_id": GENERATION_ID,
+        "manifest_digest": hashlib.sha256(manifest_json).hexdigest(),
+        "committed_at": "2026-09-02T01:02:03.000004Z",
+        "installed_for_user_id": USER_ID,
+        "projection_class": "contributor_plus",
+        "projection_scope_id": PROJECTION_SCOPE_ID,
+    }
+    values.update(changes)
+    identity = GenerationProjectionIdentity(**values)  # type: ignore[arg-type]
+    return GenerationProjectionTarget(binding=binding, identity=identity)
+
+
+def test_projection_target_binds_validated_cloud_and_server_facts() -> None:
+    manifest_json = _canonical_manifest()
+
+    target = _target(manifest_json)
+
+    assert target.binding.project_id == PROJECT_ID
+    assert target.identity.store_format_version == 1
+    assert target.identity.generation_id == GENERATION_ID
+    assert target.identity.manifest_digest == hashlib.sha256(manifest_json).hexdigest()
+    assert target.identity.installed_for_user_id == USER_ID
+    assert target.identity.projection_scope_id == PROJECTION_SCOPE_ID
+    with pytest.raises(FrozenInstanceError):
+        target.identity = target.identity
+    with pytest.raises(pyd.ValidationError):
+        target.identity.generation_id = OTHER_GENERATION_ID
+
+
+def test_projection_target_rejects_unsupported_store_format() -> None:
+    with pytest.raises(ClientUpgradeRequiredError):
+        _target(_canonical_manifest(), store_format_version=2)
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"generation_id": "generation-1"},
+        {"manifest_digest": "A" * 64},
+        {"manifest_digest": "a" * 63},
+        {"committed_at": "2026-09-02T01:02:03Z"},
+        {"installed_for_user_id": "user-1"},
+        {"projection_class": "owner"},
+        {"projection_scope_id": "A" * 64},
+        {"projection_scope_id": "a" * 65},
+        {"generation_id": False},
+        {"store_format_version": False},
+        {"store_format_version": 0},
+    ],
+)
+def test_projection_identity_rejects_malformed_facts(changes: dict[str, object]) -> None:
+    with pytest.raises(pyd.ValidationError):
+        _target(_canonical_manifest(), **changes)
+
+
+def test_projection_target_cross_binds_project_identity() -> None:
+    with pytest.raises(GenerationProjectionVerificationError, match="another project"):
+        _target(_canonical_manifest(), project_id=OTHER_PROJECT_ID)
+
+
+def test_projection_target_requires_cloud_binding() -> None:
+    binding = ResolvedProjectBinding(
+        store_path=Path("store"),
+        project_id=PROJECT_ID,
+        display_name="Nauro",
+        mode="local",
+        server_url=None,
+    )
+
+    with pytest.raises(GenerationProjectionVerificationError, match="cloud binding"):
+        _target(_canonical_manifest(), binding=binding)
+
+
+def test_verifies_exact_projection_and_sorts_artifacts() -> None:
+    project = b"# Project\n"
+    state = b"# State\n"
+    manifest_json = _canonical_manifest(
+        artifacts={
+            "state_current.md": hashlib.sha256(state).hexdigest(),
+            "project.md": hashlib.sha256(project).hexdigest(),
+        }
+    )
+
+    projection = verify_generation_projection(
+        _target(manifest_json),
+        manifest_json=manifest_json,
+        artifacts=[("state_current.md", state), ("project.md", project)],
+    )
+
+    assert projection.project_id == PROJECT_ID
+    assert projection.generation_id == GENERATION_ID
+    assert projection.manifest_digest == hashlib.sha256(manifest_json).hexdigest()
+    assert projection.manifest.canonical_bytes() == manifest_json
+    assert [artifact.path for artifact in projection.artifacts] == [
+        "project.md",
+        "state_current.md",
+    ]
+    assert projection.total_bytes == len(project) + len(state)
+
+
+def test_empty_born_current_projection_is_valid() -> None:
+    manifest_json = _canonical_manifest(artifacts={})
+
+    projection = verify_generation_projection(
+        _target(manifest_json),
+        manifest_json=manifest_json,
+        artifacts=[],
+    )
+
+    assert projection.artifacts == ()
+    assert projection.total_bytes == 0
+
+
+def test_manifest_digest_must_match_committed_pointer() -> None:
+    expected = _canonical_manifest()
+    divergent = expected.replace(b"project.md", b"state.md")
+
+    with pytest.raises(GenerationProjectionVerificationError, match="digest diverges"):
+        verify_generation_projection(
+            _target(expected),
+            manifest_json=divergent,
+            artifacts=[],
+        )
+
+
+@pytest.mark.parametrize(
+    "manifest_json",
+    [
+        json.dumps(_manifest_object(), sort_keys=False).encode(),
+        json.dumps(_manifest_object(), sort_keys=True, indent=2).encode(),
+        _canonical_manifest() + b"\n",
+    ],
+)
+def test_manifest_bytes_must_use_canonical_json(manifest_json: bytes) -> None:
+    with pytest.raises(GenerationProjectionVerificationError, match="not canonical"):
+        verify_generation_projection(
+            _target(manifest_json),
+            manifest_json=manifest_json,
+            artifacts=[("project.md", b"# Project\n")],
+        )
+
+
+def test_manifest_rejects_duplicate_json_keys() -> None:
+    canonical = _canonical_manifest().decode()
+    duplicate = canonical.replace(
+        f'"generation_id":"{GENERATION_ID}"',
+        f'"generation_id":"{OTHER_GENERATION_ID}","generation_id":"{GENERATION_ID}"',
+    ).encode()
+
+    with pytest.raises(GenerationProjectionVerificationError, match="malformed"):
+        verify_generation_projection(
+            _target(duplicate),
+            manifest_json=duplicate,
+            artifacts=[("project.md", b"# Project\n")],
+        )
+
+
+def test_manifest_rejects_unencodable_json_strings() -> None:
+    body = _manifest_object(artifacts={"decisions/\ud800.md": "b" * 64})
+    manifest_json = json.dumps(body, sort_keys=True, separators=(",", ":")).encode()
+
+    with pytest.raises(GenerationProjectionVerificationError, match="malformed"):
+        verify_generation_projection(
+            _target(manifest_json),
+            manifest_json=manifest_json,
+            artifacts=[],
+        )
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"generation_id": False},
+        {"generation_id": GENERATION_ID.lower()},
+        {"project_id": False},
+        {"store_format_version": False},
+        {"store_format_version": 0},
+        {"projection_class": False},
+        {"projection_class": "owner"},
+        {"projection_scope_id": False},
+        {"projection_scope_id": "A" * 64},
+        {"projection_scope_id": "a" * 65},
+        {"artifacts": []},
+        {"artifacts": {"project.md": "B" * 64}},
+        {"artifacts": {"project.md": "b" * 63}},
+        {"extra": {"schema_version": 1}},
+    ],
+)
+def test_manifest_fields_are_strict_and_closed(changes: dict[str, object]) -> None:
+    manifest_json = _canonical_manifest(**changes)
+
+    with pytest.raises(GenerationProjectionVerificationError, match="malformed"):
+        verify_generation_projection(
+            _target(manifest_json),
+            manifest_json=manifest_json,
+            artifacts=[],
+        )
+
+
+@pytest.mark.parametrize(
+    "artifacts",
+    [
+        {"../project.md": "b" * 64},
+        {"unknown.md": "b" * 64},
+        {"decisions/nested/001-bad.md": "b" * 64},
+    ],
+)
+def test_manifest_paths_use_shared_protected_membership(
+    artifacts: dict[str, str],
+) -> None:
+    manifest_json = _canonical_manifest(artifacts=artifacts)
+
+    with pytest.raises(GenerationProjectionVerificationError, match="malformed"):
+        verify_generation_projection(
+            _target(manifest_json),
+            manifest_json=manifest_json,
+            artifacts=[],
+        )
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"project_id": OTHER_PROJECT_ID},
+        {"store_format_version": 2},
+        {"generation_id": OTHER_GENERATION_ID},
+        {"projection_class": "viewer"},
+        {"projection_scope_id": "b" * 64},
+    ],
+)
+def test_manifest_must_cross_bind_to_installed_projection(
+    changes: dict[str, object],
+) -> None:
+    manifest_json = _canonical_manifest(**changes)
+
+    with pytest.raises(GenerationProjectionVerificationError, match="projection binding"):
+        verify_generation_projection(
+            _target(manifest_json),
+            manifest_json=manifest_json,
+            artifacts=[("project.md", b"# Project\n")],
+        )
+
+
+@pytest.mark.parametrize(
+    "artifacts",
+    [
+        [],
+        [("project.md", b"# Project\n"), ("state.md", b"# State\n")],
+    ],
+)
+def test_downloaded_artifact_set_must_equal_manifest(
+    artifacts: list[tuple[str, bytes]],
+) -> None:
+    manifest_json = _canonical_manifest()
+
+    with pytest.raises(GenerationProjectionVerificationError, match="differs"):
+        verify_generation_projection(
+            _target(manifest_json),
+            manifest_json=manifest_json,
+            artifacts=artifacts,
+        )
+
+
+def test_downloaded_artifact_paths_must_be_unique() -> None:
+    manifest_json = _canonical_manifest()
+
+    with pytest.raises(GenerationProjectionVerificationError, match="duplicate"):
+        verify_generation_projection(
+            _target(manifest_json),
+            manifest_json=manifest_json,
+            artifacts=[
+                ("project.md", b"# Project\n"),
+                ("project.md", b"# Project\n"),
+            ],
+        )
+
+
+def test_downloaded_artifact_digest_must_match_manifest() -> None:
+    manifest_json = _canonical_manifest()
+
+    with pytest.raises(GenerationProjectionVerificationError, match="project.md"):
+        verify_generation_projection(
+            _target(manifest_json),
+            manifest_json=manifest_json,
+            artifacts=[("project.md", b"divergent")],
+        )
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [
+        ("unknown.md", b"content"),
+        ("../project.md", b"content"),
+        ("project.md", bytearray(b"content")),
+        ["project.md", b"content"],
+        ("project.md",),
+    ],
+)
+def test_downloaded_artifacts_require_exact_safe_entries(entry: object) -> None:
+    manifest_json = _canonical_manifest()
+
+    with pytest.raises(GenerationProjectionVerificationError):
+        verify_generation_projection(
+            _target(manifest_json),
+            manifest_json=manifest_json,
+            artifacts=[entry],  # type: ignore[list-item]
+        )
+
+
+def test_manifest_requires_exact_bytes() -> None:
+    manifest_json = _canonical_manifest()
+
+    with pytest.raises(GenerationProjectionVerificationError, match="exact bytes"):
+        verify_generation_projection(
+            _target(manifest_json),
+            manifest_json=manifest_json.decode(),  # type: ignore[arg-type]
+            artifacts=[("project.md", b"# Project\n")],
+        )
+
+
+def test_verified_projection_and_nested_values_are_frozen() -> None:
+    content = b"# Project\n"
+    manifest_json = _canonical_manifest()
+    projection = verify_generation_projection(
+        _target(manifest_json),
+        manifest_json=manifest_json,
+        artifacts=[("project.md", content)],
+    )
+
+    with pytest.raises(FrozenInstanceError):
+        projection.manifest_json = b"{}"
+    with pytest.raises(FrozenInstanceError):
+        projection.artifacts[0].content = b"changed"
+    with pytest.raises(TypeError):
+        projection.manifest.artifacts["project.md"] = "c" * 64
+    with pytest.raises(pyd.ValidationError):
+        projection.manifest.generation_id = OTHER_GENERATION_ID
+
+
+def test_direct_projection_construction_revalidates_all_inputs() -> None:
+    manifest_json = _canonical_manifest()
+    target = _target(manifest_json)
+    artifact = VerifiedGenerationArtifact("project.md", b"divergent")
+
+    with pytest.raises(GenerationProjectionVerificationError, match="digest diverges"):
+        VerifiedGenerationProjection(
+            target=target,
+            manifest_json=manifest_json,
+            artifacts=(artifact,),
+        )
+
+    with pytest.raises(GenerationProjectionVerificationError, match="malformed"):
+        VerifiedGenerationProjection(
+            target=target,
+            manifest_json=manifest_json,
+            artifacts=[artifact],  # type: ignore[arg-type]
+        )
+
+
+def test_manifest_model_canonicalizes_without_mutable_artifact_map() -> None:
+    manifest_json = _canonical_manifest()
+    projection = verify_generation_projection(
+        _target(manifest_json),
+        manifest_json=manifest_json,
+        artifacts=[("project.md", b"# Project\n")],
+    )
+
+    assert isinstance(projection.manifest, GenerationProjectionManifest)
+    assert projection.manifest.canonical_bytes() == manifest_json


### PR DESCRIPTION
## Why

A hosted client must verify the role-appropriate, actor-scoped projection before it installs a generation. The installed pointer cannot serve as proof for a generation that has not been installed yet.

## What changed

- Extract a shared projection identity used by both refresh targets and installed pointers.
- Add a strict canonical projection manifest that binds project, store format, generation, projection class, and authorization scope.
- Reject duplicate JSON keys, noncanonical bytes, unknown protected paths, divergent manifests, and incomplete or extra artifact sets.
- Derive every artifact digest from exact bytes and return one frozen, path-sorted verified projection.

This slice performs no network request, disk installation, pointer replacement, or runtime activation.

## Test plan

- 210 focused binding, authority, control-snapshot, and projection-verification tests passed.
- 2,931 package tests passed, with 10 skipped.
- Ruff check and format check passed.
- Targeted Mypy checks passed.

## Risk / what to review

Review the projection-manifest serialization, the pre-install target boundary, and the exact cross-binding between identity, manifest, and artifact bytes.

## Deferred

The authenticated refresh transport, bounded downloads, generation-root installation, pointer replacement, lifetime leases, migration, runtime wiring, and activation remain separate slices.
