### PR TITLE
Harden generation control validation

### DIFF
--- a/packages/nauro/src/nauro/store/generation_authority.py
+++ b/packages/nauro/src/nauro/store/generation_authority.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from typing import Literal
 
@@ -14,6 +15,31 @@ from nauro.store.resolution import ResolvedProjectBinding
 
 _CONTROL_SCHEMA_VERSION = 1
 _STRICT_MODEL_CONFIG = pyd.ConfigDict(extra="forbid", frozen=True, strict=True)
+
+
+class _DuplicateJsonKeyError(ValueError):
+    pass
+
+
+def _object_without_duplicates(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise _DuplicateJsonKeyError(key)
+        result[key] = value
+    return result
+
+
+def _invalid_json_constant(value: str) -> object:
+    raise ValueError(f"invalid JSON constant: {value}")
+
+
+def _load_strict_json(raw: str | bytes) -> object:
+    return json.loads(
+        raw,
+        object_pairs_hook=_object_without_duplicates,
+        parse_constant=_invalid_json_constant,
+    )
 
 
 class GenerationAuthorityError(ValueError):
@@ -129,12 +155,6 @@ class InstalledGenerationPointer(GenerationProjectionIdentity):
             raise ValueError("unsupported generation control schema")
         return value
 
-    @pyd.model_validator(mode="after")
-    def _valid_install_order(self) -> InstalledGenerationPointer:
-        if self.installed_at < self.committed_at:
-            raise ValueError("installed_at cannot precede committed_at")
-        return self
-
 
 @dataclass(frozen=True)
 class FlatProjectAuthority:
@@ -167,8 +187,15 @@ def _parse_marker(raw: str | bytes) -> GenerationAuthorityMarker:
     if type(raw) not in (str, bytes):
         raise GenerationControlCorruptError("The generation authority marker is invalid.")
     try:
-        return GenerationAuthorityMarker.model_validate_json(raw)
-    except (pyd.ValidationError, ValueError, TypeError) as exc:
+        return GenerationAuthorityMarker.model_validate(_load_strict_json(raw))
+    except (
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+        _DuplicateJsonKeyError,
+        pyd.ValidationError,
+        ValueError,
+        TypeError,
+    ) as exc:
         raise GenerationControlCorruptError("The generation authority marker is invalid.") from exc
 
 
@@ -176,8 +203,15 @@ def _parse_pointer(raw: str | bytes) -> InstalledGenerationPointer:
     if type(raw) not in (str, bytes):
         raise GenerationControlCorruptError("The installed generation pointer is invalid.")
     try:
-        return InstalledGenerationPointer.model_validate_json(raw)
-    except (pyd.ValidationError, ValueError, TypeError) as exc:
+        return InstalledGenerationPointer.model_validate(_load_strict_json(raw))
+    except (
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+        _DuplicateJsonKeyError,
+        pyd.ValidationError,
+        ValueError,
+        TypeError,
+    ) as exc:
         raise GenerationControlCorruptError("The installed generation pointer is invalid.") from exc
 
 

--- a/packages/nauro/tests/test_generation_authority.py
+++ b/packages/nauro/tests/test_generation_authority.py
@@ -150,6 +150,22 @@ def test_marker_rejects_non_json_input_type() -> None:
         )
 
 
+def test_marker_rejects_duplicate_json_keys() -> None:
+    duplicate = _marker().replace(
+        '"schema_version": 1',
+        '"schema_version": 2, "schema_version": 1',
+    )
+
+    with pytest.raises(GenerationControlCorruptError):
+        select_project_authority(
+            _binding(),
+            marker_json=duplicate,
+            pointer_json=_pointer(),
+            active_user_id=USER_ID,
+            active_projection_scope_id=PROJECTION_SCOPE_ID,
+        )
+
+
 def test_unsupported_marker_format_requires_client_upgrade_before_pointer_read() -> None:
     with pytest.raises(ClientUpgradeRequiredError) as raised:
         select_project_authority(
@@ -246,7 +262,6 @@ def test_pointer_must_be_one_strict_closed_json_object(raw: str | bytes) -> None
         ("committed_at", "2026-09-02T01:02:03Z"),
         ("committed_at", "2026-99-02T01:02:03.000004Z"),
         ("installed_at", "2026-09-02T01:03:04.00005Z"),
-        ("installed_at", "2026-09-02T01:02:02.999999Z"),
         ("installed_state_id", "state-1"),
         ("installed_for_user_id", "user-1"),
         ("projection_class", "owner"),
@@ -274,6 +289,35 @@ def test_pointer_rejects_non_json_input_type() -> None:
             active_user_id=USER_ID,
             active_projection_scope_id=PROJECTION_SCOPE_ID,
         )
+
+
+def test_pointer_rejects_duplicate_json_keys() -> None:
+    duplicate = _pointer().replace(
+        f'"installed_for_user_id": "{USER_ID}"',
+        (f'"installed_for_user_id": "{OTHER_USER_ID}", "installed_for_user_id": "{USER_ID}"'),
+    )
+
+    with pytest.raises(GenerationControlCorruptError):
+        select_project_authority(
+            _binding(),
+            marker_json=_marker(),
+            pointer_json=duplicate,
+            active_user_id=USER_ID,
+            active_projection_scope_id=PROJECTION_SCOPE_ID,
+        )
+
+
+def test_pointer_does_not_compare_server_and_local_clocks() -> None:
+    result = select_project_authority(
+        _binding(),
+        marker_json=_marker(),
+        pointer_json=_pointer(installed_at="2026-09-02T01:02:02.999999Z"),
+        active_user_id=USER_ID,
+        active_projection_scope_id=PROJECTION_SCOPE_ID,
+    )
+
+    assert isinstance(result, GenerationProjectAuthority)
+    assert result.pointer.installed_at == "2026-09-02T01:02:02.999999Z"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Why

Generation control JSON must have one unambiguous meaning. The parser accepted duplicate keys by keeping the last value, and it compared timestamps from independent server and local clocks.

## What changed

- Reject duplicate object keys and non-standard JSON constants before marker or pointer validation.
- Keep strict closed-field validation for both control records.
- Stop ordering the server `committed_at` value against the local `installed_at` clock.

## Test plan

- 54 focused authority-selection tests passed.
- 2,933 package tests passed, with 10 skipped.
- Ruff check and format check passed.
- Targeted Mypy check passed.

## Risk / what to review

Review the JSON rejection boundary and confirm that removing the cross-clock ordering leaves each timestamp's canonical shape validation intact.

## Deferred

Generation-root installation remains in the next stacked slice.
