### PR TITLE
Install verified generation roots

### DIFF
--- a/packages/nauro/src/nauro/store/generation_authority.py
+++ b/packages/nauro/src/nauro/store/generation_authority.py
@@ -13,7 +13,7 @@ from nauro_core.provenance import validate_utc_timestamp
 
 from nauro.store.resolution import ResolvedProjectBinding
 
-_CONTROL_SCHEMA_VERSION = 1
+GENERATION_CONTROL_SCHEMA_VERSION = 1
 _STRICT_MODEL_CONFIG = pyd.ConfigDict(extra="forbid", frozen=True, strict=True)
 
 
@@ -107,7 +107,7 @@ class GenerationAuthorityMarker(pyd.BaseModel):
     @pyd.field_validator("schema_version")
     @classmethod
     def _supported_schema(cls, value: int) -> int:
-        if value != _CONTROL_SCHEMA_VERSION:
+        if value != GENERATION_CONTROL_SCHEMA_VERSION:
             raise ValueError("unsupported generation control schema")
         return value
 
@@ -151,7 +151,7 @@ class InstalledGenerationPointer(GenerationProjectionIdentity):
     @pyd.field_validator("schema_version")
     @classmethod
     def _supported_schema(cls, value: int) -> int:
-        if value != _CONTROL_SCHEMA_VERSION:
+        if value != GENERATION_CONTROL_SCHEMA_VERSION:
             raise ValueError("unsupported generation control schema")
         return value
 
@@ -283,6 +283,7 @@ __all__ = [
     "FlatProjectAuthority",
     "GenerationAuthorityError",
     "GenerationAuthorityMarker",
+    "GENERATION_CONTROL_SCHEMA_VERSION",
     "GenerationControlCorruptError",
     "GenerationProjectionIdentity",
     "GenerationProjectAuthority",

--- a/packages/nauro/src/nauro/store/generation_installation.py
+++ b/packages/nauro/src/nauro/store/generation_installation.py
@@ -1,0 +1,333 @@
+"""Crash-safe local installation of verified hosted-generation projections."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import stat
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pydantic as pyd
+
+from nauro.store._atomic import atomic_write_bytes
+from nauro.store.generation_authority import (
+    GENERATION_CONTROL_SCHEMA_VERSION,
+    FlatProjectAuthority,
+    GenerationAuthorityError,
+    GenerationProjectAuthority,
+    GenerationProjectionIdentity,
+    InstalledGenerationPointer,
+    RefreshRequiredError,
+    select_project_authority,
+)
+from nauro.store.generation_projection import VerifiedGenerationProjection
+from nauro.store.replica_control import (
+    ReplicaControlLayout,
+    _refuse_symlinks,
+    locked_replica_control_snapshot,
+)
+from nauro.store.repo_config import generate_ulid
+
+_LEASE_CREATE_FLAGS = (
+    os.O_CREAT | os.O_EXCL | os.O_WRONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_BINARY", 0)
+)
+
+
+class GenerationInstallationError(GenerationAuthorityError):
+    """A verified generation could not be installed safely."""
+
+    code = "generation_install_failed"
+
+
+def _installed_at() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+def _new_install_state_id() -> str:
+    return generate_ulid()
+
+
+def _identity_from_pointer(pointer: InstalledGenerationPointer) -> GenerationProjectionIdentity:
+    values = {
+        field_name: getattr(pointer, field_name)
+        for field_name in GenerationProjectionIdentity.model_fields
+    }
+    return GenerationProjectionIdentity.model_validate(values)
+
+
+def _pointer_bytes(pointer: InstalledGenerationPointer) -> bytes:
+    return json.dumps(
+        pointer.model_dump(),
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def _expected_directories(projection: VerifiedGenerationProjection) -> set[str]:
+    directories: set[str] = set()
+    for artifact in projection.artifacts:
+        parts = artifact.path.split("/")[:-1]
+        for index in range(1, len(parts) + 1):
+            directories.add("/".join(parts[:index]))
+    return directories
+
+
+def _audit_root(root: Path, projection: VerifiedGenerationProjection) -> None:
+    if root.is_symlink() or not root.is_dir():
+        raise GenerationInstallationError("The generation root is not a regular directory.")
+    expected_files = {artifact.path: artifact.content for artifact in projection.artifacts}
+    expected_directories = _expected_directories(projection)
+    observed_files: set[str] = set()
+    try:
+        for path in root.rglob("*"):
+            relative = path.relative_to(root).as_posix()
+            if path.is_symlink():
+                raise GenerationInstallationError("The generation root contains a symlink.")
+            if path.is_dir():
+                if relative not in expected_directories:
+                    raise GenerationInstallationError(
+                        "The generation root contains an unexpected directory."
+                    )
+                continue
+            if not path.is_file() or relative not in expected_files:
+                raise GenerationInstallationError(
+                    "The generation root contains an unexpected file."
+                )
+            if path.read_bytes() != expected_files[relative]:
+                raise GenerationInstallationError(
+                    f"The installed generation artifact diverges: {relative}."
+                )
+            observed_files.add(relative)
+    except GenerationInstallationError:
+        raise
+    except OSError as exc:
+        raise GenerationInstallationError("The generation root is unreadable.") from exc
+    if observed_files != set(expected_files):
+        raise GenerationInstallationError("The generation root is incomplete.")
+
+
+def _discard_staging(path: Path) -> None:
+    try:
+        if path.is_symlink():
+            path.unlink()
+        elif path.exists():
+            shutil.rmtree(path)
+    except OSError:
+        pass
+
+
+def _stage_projection(
+    layout: ReplicaControlLayout,
+    projection: VerifiedGenerationProjection,
+    install_state_id: str,
+) -> Path:
+    staging = layout.staging_root(projection.target.identity, install_state_id)
+    _refuse_symlinks(layout.store_path, (staging,))
+    try:
+        staging.mkdir(parents=True, exist_ok=False)
+    except OSError as exc:
+        raise GenerationInstallationError("The generation staging root is unavailable.") from exc
+    try:
+        for artifact in projection.artifacts:
+            destination = staging / artifact.path
+            _refuse_symlinks(layout.store_path, (destination,))
+            atomic_write_bytes(destination, artifact.content)
+        _audit_root(staging, projection)
+        return staging
+    except BaseException:
+        _discard_staging(staging)
+        raise
+
+
+def _publish_root(
+    layout: ReplicaControlLayout,
+    staging: Path,
+    projection: VerifiedGenerationProjection,
+) -> Path:
+    root = layout.generation_root(projection.target.identity)
+    _refuse_symlinks(layout.store_path, (root,))
+    if root.exists() or root.is_symlink():
+        _audit_root(root, projection)
+        return root
+    try:
+        root.parent.mkdir(parents=True, exist_ok=True)
+        staging.rename(root)
+    except OSError as exc:
+        raise GenerationInstallationError("The generation root could not be published.") from exc
+    _audit_root(root, projection)
+    return root
+
+
+def _ensure_exact_file(path: Path, content: bytes, *, label: str) -> None:
+    if path.exists() or path.is_symlink():
+        if path.is_symlink() or not path.is_file():
+            raise GenerationInstallationError(f"The generation {label} is not a regular file.")
+        try:
+            existing = path.read_bytes()
+        except OSError as exc:
+            raise GenerationInstallationError(f"The generation {label} is unreadable.") from exc
+        if existing != content:
+            raise GenerationInstallationError(f"The generation {label} diverges.")
+        return
+    try:
+        atomic_write_bytes(path, content)
+        if path.read_bytes() != content:
+            raise GenerationInstallationError(f"The generation {label} diverges after write.")
+    except GenerationInstallationError:
+        raise
+    except OSError as exc:
+        raise GenerationInstallationError(f"The generation {label} could not be written.") from exc
+
+
+def _replace_pointer(path: Path, content: bytes) -> None:
+    if path.is_symlink() or (path.exists() and not path.is_file()):
+        raise GenerationInstallationError("The generation pointer is not a regular file.")
+    try:
+        atomic_write_bytes(path, content)
+        if path.read_bytes() != content:
+            raise GenerationInstallationError("The generation pointer diverges after write.")
+    except GenerationInstallationError:
+        raise
+    except OSError as exc:
+        raise GenerationInstallationError("The generation pointer could not be written.") from exc
+
+
+def _ensure_lease(path: Path) -> None:
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        descriptor = os.open(path, _LEASE_CREATE_FLAGS, 0o600)
+    except FileExistsError:
+        try:
+            observed = path.lstat()
+        except OSError as exc:
+            raise GenerationInstallationError("The generation lease is unreadable.") from exc
+        if not stat.S_ISREG(observed.st_mode) or observed.st_size != 0:
+            raise GenerationInstallationError("The generation lease is not an empty regular file.")
+        return
+    except OSError as exc:
+        raise GenerationInstallationError("The generation lease could not be created.") from exc
+    else:
+        try:
+            os.close(descriptor)
+        except OSError as exc:
+            raise GenerationInstallationError("The generation lease could not be closed.") from exc
+
+
+def _current_pointer(
+    projection: VerifiedGenerationProjection,
+    marker_json: bytes | None,
+    pointer_json: bytes | None,
+) -> InstalledGenerationPointer | None:
+    try:
+        authority = select_project_authority(
+            projection.target.binding,
+            marker_json=marker_json,
+            pointer_json=pointer_json,
+            active_user_id=projection.target.identity.installed_for_user_id,
+            active_projection_scope_id=projection.target.identity.projection_scope_id,
+        )
+    except RefreshRequiredError:
+        if pointer_json is None:
+            return None
+        try:
+            return InstalledGenerationPointer.model_validate_json(pointer_json)
+        except pyd.ValidationError as exc:
+            raise GenerationInstallationError(
+                "The current generation pointer cannot be revalidated."
+            ) from exc
+    if isinstance(authority, FlatProjectAuthority):
+        return None
+    if isinstance(authority, GenerationProjectAuthority):
+        return authority.pointer
+    raise GenerationInstallationError("The current generation authority is unsupported.")
+
+
+def _is_same_or_refuse_replacement(
+    current: InstalledGenerationPointer | None,
+    target: GenerationProjectionIdentity,
+) -> bool:
+    if current is None:
+        return False
+    current_identity = _identity_from_pointer(current)
+    if current_identity == target:
+        return True
+    raise GenerationInstallationError(
+        "Replacing an active generation requires a fresh refresh commit."
+    )
+
+
+def _build_pointer(
+    projection: VerifiedGenerationProjection,
+    install_state_id: str,
+) -> InstalledGenerationPointer:
+    try:
+        return InstalledGenerationPointer(
+            **projection.target.identity.model_dump(),
+            schema_version=GENERATION_CONTROL_SCHEMA_VERSION,
+            installed_at=_installed_at(),
+            installed_state_id=install_state_id,
+        )
+    except pyd.ValidationError as exc:
+        raise GenerationInstallationError(
+            "The installed generation pointer could not be derived."
+        ) from exc
+
+
+def install_verified_generation(
+    projection: VerifiedGenerationProjection,
+    *,
+    lock_timeout: float = -1,
+) -> InstalledGenerationPointer:
+    """Install a verified projection and publish its local pointer last."""
+    if type(projection) is not VerifiedGenerationProjection:
+        raise GenerationInstallationError("Generation installation requires verified bytes.")
+    layout = ReplicaControlLayout(projection.target.binding.store_path)
+    install_state_id = _new_install_state_id()
+    staging = _stage_projection(layout, projection, install_state_id)
+    try:
+        with locked_replica_control_snapshot(
+            projection.target.binding,
+            active_user_id=projection.target.identity.installed_for_user_id,
+            timeout=lock_timeout,
+        ) as snapshot:
+            current = _current_pointer(
+                projection,
+                snapshot.marker_json,
+                snapshot.pointer_json,
+            )
+            same_identity = _is_same_or_refuse_replacement(
+                current,
+                projection.target.identity,
+            )
+            root = layout.generation_root(projection.target.identity)
+            manifest = layout.generation_manifest(projection.target.identity)
+            lease = layout.generation_lease(projection.target.identity)
+            pointer_path = layout.actor_pointer(projection.target.identity.installed_for_user_id)
+            _refuse_symlinks(
+                layout.store_path,
+                (root, manifest, lease, pointer_path),
+            )
+            _publish_root(layout, staging, projection)
+            _ensure_exact_file(
+                manifest,
+                projection.manifest_json,
+                label="manifest",
+            )
+            _ensure_lease(lease)
+            if same_identity:
+                assert current is not None
+                return current
+            pointer = _build_pointer(projection, install_state_id)
+            pointer_json = _pointer_bytes(pointer)
+            _replace_pointer(pointer_path, pointer_json)
+            return pointer
+    finally:
+        _discard_staging(staging)
+
+
+__all__ = [
+    "GenerationInstallationError",
+    "install_verified_generation",
+]

--- a/packages/nauro/src/nauro/store/replica_control.py
+++ b/packages/nauro/src/nauro/store/replica_control.py
@@ -13,7 +13,10 @@ from filelock import FileLock, Timeout
 from nauro_core.constants import HOSTED_STORE_FORMAT_VERSION
 from nauro_core.identifiers import IdentifierKind, is_identifier, validate_identifier
 
-from nauro.store.generation_authority import GenerationAuthorityError
+from nauro.store.generation_authority import (
+    GenerationAuthorityError,
+    GenerationProjectionIdentity,
+)
 from nauro.store.resolution import ResolvedProjectBinding
 
 _CONTROL_DIRECTORY = ".replica"
@@ -21,6 +24,11 @@ _CONTROL_LOCK_FILE = ".replica-control.lock"
 _AUTHORITY_MARKER_FILE = "authority.json"
 _ACTORS_DIRECTORY = "actors"
 _POINTER_FILE = "pointer.json"
+_PROJECTIONS_DIRECTORY = "projections"
+_GENERATIONS_DIRECTORY = "generations"
+_MANIFESTS_DIRECTORY = "manifests"
+_LEASES_DIRECTORY = "leases"
+_STAGING_DIRECTORY = "staging"
 _MAX_CONTROL_FILE_BYTES = 16 * 1024
 _READ_FLAGS = (
     os.O_RDONLY
@@ -67,6 +75,34 @@ class ReplicaControlLayout:
     def actor_pointer(self, user_id: str) -> Path:
         canonical = validate_identifier(IdentifierKind.ulid, user_id, field="user_id")
         return self.version_root / _ACTORS_DIRECTORY / canonical / _POINTER_FILE
+
+    def projection_root(self, identity: GenerationProjectionIdentity) -> Path:
+        if type(identity) is not GenerationProjectionIdentity:
+            raise ValueError("projection identity must be validated")
+        actor_root = self.actor_pointer(identity.installed_for_user_id).parent
+        return actor_root / _PROJECTIONS_DIRECTORY / identity.projection_scope_id
+
+    def generation_root(self, identity: GenerationProjectionIdentity) -> Path:
+        return self.projection_root(identity) / _GENERATIONS_DIRECTORY / identity.generation_id
+
+    def generation_manifest(self, identity: GenerationProjectionIdentity) -> Path:
+        filename = f"{identity.generation_id}.json"
+        return self.projection_root(identity) / _MANIFESTS_DIRECTORY / filename
+
+    def generation_lease(self, identity: GenerationProjectionIdentity) -> Path:
+        return self.projection_root(identity) / _LEASES_DIRECTORY / f"{identity.generation_id}.lock"
+
+    def staging_root(
+        self,
+        identity: GenerationProjectionIdentity,
+        install_state_id: str,
+    ) -> Path:
+        canonical_state = validate_identifier(
+            IdentifierKind.ulid,
+            install_state_id,
+            field="install_state_id",
+        )
+        return self.projection_root(identity) / _STAGING_DIRECTORY / canonical_state
 
 
 @dataclass(frozen=True)

--- a/packages/nauro/tests/test_generation_installation.py
+++ b/packages/nauro/tests/test_generation_installation.py
@@ -1,0 +1,373 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+from filelock import FileLock, Timeout
+
+import nauro.store.generation_installation as installation
+from nauro.store.generation_authority import (
+    GenerationControlCorruptError,
+    GenerationProjectionIdentity,
+    InstalledGenerationPointer,
+    select_project_authority,
+)
+from nauro.store.generation_installation import (
+    GenerationInstallationError,
+    install_verified_generation,
+)
+from nauro.store.generation_projection import (
+    GenerationProjectionTarget,
+    VerifiedGenerationProjection,
+    verify_generation_projection,
+)
+from nauro.store.replica_control import (
+    ReplicaControlLayout,
+    ReplicaControlReadError,
+)
+from nauro.store.resolution import ResolvedProjectBinding
+
+PROJECT_ID = "01KQ6AZGNA0B3QBF67NBXP3S45"
+GENERATION_ID = "01K11111111111111111111111"
+OTHER_GENERATION_ID = "01K22222222222222222222222"
+INSTALL_STATE_ID = "01K33333333333333333333333"
+OTHER_INSTALL_STATE_ID = "01K44444444444444444444444"
+USER_ID = "01K55555555555555555555555"
+PROJECTION_SCOPE_ID = "a" * 64
+OTHER_PROJECTION_SCOPE_ID = "b" * 64
+COMMITTED_AT = "2026-09-02T01:02:03.000004Z"
+NEWER_COMMITTED_AT = "2026-09-02T02:02:03.000004Z"
+INSTALLED_AT = "2026-09-02T03:02:03.000004Z"
+
+
+@pytest.fixture(autouse=True)
+def _fixed_install_facts(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(installation, "_new_install_state_id", lambda: INSTALL_STATE_ID)
+    monkeypatch.setattr(installation, "_installed_at", lambda: INSTALLED_AT)
+
+
+def _binding(tmp_path: Path) -> ResolvedProjectBinding:
+    store = tmp_path / PROJECT_ID
+    store.mkdir()
+    return ResolvedProjectBinding(
+        store_path=store,
+        project_id=PROJECT_ID,
+        display_name="Nauro",
+        mode="cloud",
+        server_url="https://mcp.nauro.ai",
+    )
+
+
+def _projection(
+    tmp_path: Path,
+    *,
+    binding: ResolvedProjectBinding | None = None,
+    generation_id: str = GENERATION_ID,
+    projection_scope_id: str = PROJECTION_SCOPE_ID,
+    committed_at: str = COMMITTED_AT,
+    contents: dict[str, bytes] | None = None,
+) -> VerifiedGenerationProjection:
+    bound = binding or _binding(tmp_path)
+    artifact_bytes = contents or {
+        "project.md": b"# Project\n",
+        "decisions/001-use-postgres.md": b"# 1 - Use Postgres\n",
+    }
+    manifest_json = json.dumps(
+        {
+            "project_id": PROJECT_ID,
+            "store_format_version": 1,
+            "generation_id": generation_id,
+            "projection_class": "contributor_plus",
+            "projection_scope_id": projection_scope_id,
+            "artifacts": {
+                path: hashlib.sha256(content).hexdigest()
+                for path, content in artifact_bytes.items()
+            },
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+    identity = GenerationProjectionIdentity(
+        project_id=PROJECT_ID,
+        store_format_version=1,
+        generation_id=generation_id,
+        manifest_digest=hashlib.sha256(manifest_json).hexdigest(),
+        committed_at=committed_at,
+        installed_for_user_id=USER_ID,
+        projection_class="contributor_plus",
+        projection_scope_id=projection_scope_id,
+    )
+    return verify_generation_projection(
+        GenerationProjectionTarget(binding=bound, identity=identity),
+        manifest_json=manifest_json,
+        artifacts=list(artifact_bytes.items()),
+    )
+
+
+def _marker() -> bytes:
+    return json.dumps(
+        {
+            "schema_version": 1,
+            "authority": "generation",
+            "project_id": PROJECT_ID,
+            "store_format_version": 1,
+        }
+    ).encode()
+
+
+def _activate_marker(layout: ReplicaControlLayout) -> None:
+    layout.authority_marker.parent.mkdir(parents=True, exist_ok=True)
+    layout.authority_marker.write_bytes(_marker())
+
+
+def test_layout_and_install_keep_control_outside_generation_root(tmp_path: Path) -> None:
+    projection = _projection(tmp_path)
+    layout = ReplicaControlLayout(projection.target.binding.store_path)
+    identity = projection.target.identity
+
+    pointer = install_verified_generation(projection)
+
+    projection_root = layout.version_root / "actors" / USER_ID / "projections" / PROJECTION_SCOPE_ID
+    assert layout.projection_root(identity) == projection_root
+    assert layout.generation_root(identity) == projection_root / "generations" / GENERATION_ID
+    assert layout.generation_manifest(identity) == (
+        projection_root / "manifests" / f"{GENERATION_ID}.json"
+    )
+    assert layout.generation_lease(identity) == (
+        projection_root / "leases" / f"{GENERATION_ID}.lock"
+    )
+    root = layout.generation_root(identity)
+    assert (root / "project.md").read_bytes() == b"# Project\n"
+    assert (root / "decisions" / "001-use-postgres.md").is_file()
+    assert layout.generation_manifest(identity).read_bytes() == projection.manifest_json
+    assert layout.generation_lease(identity).read_bytes() == b""
+    assert not layout.authority_marker.exists()
+    assert not layout.staging_root(identity, INSTALL_STATE_ID).exists()
+    assert pointer.installed_state_id == INSTALL_STATE_ID
+    assert pointer.installed_at == INSTALLED_AT
+    stored = InstalledGenerationPointer.model_validate_json(
+        layout.actor_pointer(USER_ID).read_bytes()
+    )
+    assert stored == pointer
+    assert (
+        select_project_authority(
+            projection.target.binding,
+            marker_json=None,
+            pointer_json=layout.actor_pointer(USER_ID).read_bytes(),
+        ).kind
+        == "hosted_legacy"
+    )
+
+
+def test_pointer_is_written_last_under_the_control_lock(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    projection = _projection(tmp_path)
+    layout = ReplicaControlLayout(projection.target.binding.store_path)
+    pointer_path = layout.actor_pointer(USER_ID)
+    writes: list[Path] = []
+    original = installation.atomic_write_bytes
+
+    def observed_write(path: Path, content: bytes) -> None:
+        writes.append(path)
+        if path == pointer_path:
+            with pytest.raises(Timeout):
+                FileLock(str(layout.control_lock)).acquire(timeout=0)
+        original(path, content)
+
+    monkeypatch.setattr(installation, "atomic_write_bytes", observed_write)
+
+    install_verified_generation(projection)
+
+    assert writes[-1] == pointer_path
+
+
+def test_pointer_failure_leaves_reusable_unpointed_generation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    projection = _projection(tmp_path)
+    layout = ReplicaControlLayout(projection.target.binding.store_path)
+    pointer_path = layout.actor_pointer(USER_ID)
+    original = installation.atomic_write_bytes
+
+    def fail_pointer(path: Path, content: bytes) -> None:
+        if path == pointer_path:
+            raise OSError("pointer failure")
+        original(path, content)
+
+    monkeypatch.setattr(installation, "atomic_write_bytes", fail_pointer)
+    with pytest.raises(GenerationInstallationError, match="pointer could not"):
+        install_verified_generation(projection)
+
+    assert layout.generation_root(projection.target.identity).is_dir()
+    assert not pointer_path.exists()
+    monkeypatch.setattr(installation, "atomic_write_bytes", original)
+    assert install_verified_generation(projection).generation_id == GENERATION_ID
+
+
+def test_staged_bytes_are_reverified_before_publication(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    projection = _projection(tmp_path)
+    layout = ReplicaControlLayout(projection.target.binding.store_path)
+    original = installation.atomic_write_bytes
+
+    def corrupt_artifact(path: Path, content: bytes) -> None:
+        original(path, b"corrupt" if path.name == "project.md" else content)
+
+    monkeypatch.setattr(installation, "atomic_write_bytes", corrupt_artifact)
+    with pytest.raises(GenerationInstallationError, match="artifact diverges"):
+        install_verified_generation(projection)
+
+    assert not layout.generation_root(projection.target.identity).exists()
+    assert not layout.actor_pointer(USER_ID).exists()
+    assert not layout.staging_root(projection.target.identity, INSTALL_STATE_ID).exists()
+
+
+@pytest.mark.parametrize("defect", ["artifact", "extra", "manifest", "lease"])
+def test_existing_generation_material_is_immutable(tmp_path: Path, defect: str) -> None:
+    projection = _projection(tmp_path)
+    layout = ReplicaControlLayout(projection.target.binding.store_path)
+    install_verified_generation(projection)
+    identity = projection.target.identity
+    if defect == "artifact":
+        (layout.generation_root(identity) / "project.md").write_bytes(b"changed")
+    elif defect == "extra":
+        (layout.generation_root(identity) / "extra.md").write_bytes(b"extra")
+    elif defect == "manifest":
+        layout.generation_manifest(identity).write_bytes(b"{}")
+    else:
+        layout.generation_lease(identity).write_bytes(b"not-empty")
+
+    with pytest.raises(GenerationInstallationError):
+        install_verified_generation(projection)
+
+
+def test_corrupt_marker_blocks_install_before_pointer_publication(tmp_path: Path) -> None:
+    projection = _projection(tmp_path)
+    layout = ReplicaControlLayout(projection.target.binding.store_path)
+    layout.authority_marker.parent.mkdir(parents=True)
+    layout.authority_marker.write_bytes(b"not-json")
+
+    with pytest.raises(GenerationControlCorruptError):
+        install_verified_generation(projection)
+
+    assert not layout.generation_root(projection.target.identity).exists()
+    assert not layout.actor_pointer(USER_ID).exists()
+
+
+def test_absent_marker_allows_replacing_dormant_pointer(tmp_path: Path) -> None:
+    projection = _projection(tmp_path)
+    layout = ReplicaControlLayout(projection.target.binding.store_path)
+    pointer_path = layout.actor_pointer(USER_ID)
+    pointer_path.parent.mkdir(parents=True)
+    pointer_path.write_bytes(b"dormant-invalid")
+
+    installed = install_verified_generation(projection)
+
+    assert InstalledGenerationPointer.model_validate_json(pointer_path.read_bytes()) == installed
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"generation_id": OTHER_GENERATION_ID, "committed_at": NEWER_COMMITTED_AT},
+        {"projection_scope_id": OTHER_PROJECTION_SCOPE_ID},
+    ],
+)
+def test_active_pointer_refuses_unproved_replacement(
+    tmp_path: Path,
+    changes: dict[str, str],
+) -> None:
+    binding = _binding(tmp_path)
+    current = _projection(
+        tmp_path,
+        binding=binding,
+        generation_id=GENERATION_ID,
+        committed_at=COMMITTED_AT,
+    )
+    layout = ReplicaControlLayout(binding.store_path)
+    _activate_marker(layout)
+    install_verified_generation(current)
+    target = _projection(
+        tmp_path,
+        binding=binding,
+        **changes,
+    )
+
+    with pytest.raises(GenerationInstallationError, match="refresh commit"):
+        install_verified_generation(target)
+
+    stored = InstalledGenerationPointer.model_validate_json(
+        layout.actor_pointer(USER_ID).read_bytes()
+    )
+    assert stored.generation_id == GENERATION_ID
+    assert stored.projection_scope_id == PROJECTION_SCOPE_ID
+    assert not layout.generation_root(target.target.identity).exists()
+
+
+def test_same_active_identity_reuses_installed_pointer(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    projection = _projection(tmp_path)
+    layout = ReplicaControlLayout(projection.target.binding.store_path)
+    _activate_marker(layout)
+    first = install_verified_generation(projection)
+    monkeypatch.setattr(
+        installation,
+        "_new_install_state_id",
+        lambda: OTHER_INSTALL_STATE_ID,
+    )
+
+    second = install_verified_generation(projection)
+
+    assert second == first
+    assert not layout.staging_root(projection.target.identity, OTHER_INSTALL_STATE_ID).exists()
+
+
+def test_local_clock_skew_does_not_invalidate_install(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    projection = _projection(tmp_path, committed_at=NEWER_COMMITTED_AT)
+    monkeypatch.setattr(
+        installation,
+        "_installed_at",
+        lambda: "2026-09-02T01:00:00.000000Z",
+    )
+
+    pointer = install_verified_generation(projection)
+
+    assert pointer.installed_at < pointer.committed_at
+
+
+@pytest.mark.parametrize("target_name", ["staging", "root", "manifest", "lease", "pointer"])
+def test_install_refuses_symlinked_control_paths(tmp_path: Path, target_name: str) -> None:
+    projection = _projection(tmp_path)
+    layout = ReplicaControlLayout(projection.target.binding.store_path)
+    identity = projection.target.identity
+    targets = {
+        "staging": layout.staging_root(identity, INSTALL_STATE_ID),
+        "root": layout.generation_root(identity),
+        "manifest": layout.generation_manifest(identity),
+        "lease": layout.generation_lease(identity),
+        "pointer": layout.actor_pointer(USER_ID),
+    }
+    target = targets[target_name]
+    target.parent.mkdir(parents=True, exist_ok=True)
+    outside = tmp_path / ("outside-dir" if target_name in ("staging", "root") else "outside")
+    if target_name in ("staging", "root"):
+        outside.mkdir()
+        target.symlink_to(outside, target_is_directory=True)
+    else:
+        outside.write_bytes(b"outside")
+        target.symlink_to(outside)
+
+    with pytest.raises(ReplicaControlReadError):
+        install_verified_generation(projection)


### PR DESCRIPTION
## Why\n\nA verified hosted projection must be completely installed before its actor pointer can select it. Migration preparation must also remain dormant until authority activation.\n\n## What changed\n\n- Add actor and authorization-scope-bound paths for generation roots, manifests, lease sidecars, and staging.\n- Stage and re-audit exact projection bytes, publish immutable material under the replica-control lock, and write the actor pointer last.\n- Reuse an identical installation after a crash and refuse replacement of a different active generation without a future authenticated refresh commit.\n- Leave the authority marker untouched, so legacy authority remains selected.\n\n## Test plan\n\n- Focused resolution, authority, control, projection, and installation tests: 231 passed.\n- Full package suite: 2,952 passed, 10 skipped.\n- Ruff format and check, docstring budget, and Mypy passed.\n\n## Risk / what to review\n\nReview crash points, pointer-last ordering, immutable material reuse, symlink refusal, and refusal before publishing an unproved active replacement.\n\n## Deferred\n\nAuthenticated refresh replacement and its freshness contract, the cross-platform lifetime-lock backend, transport limits, migration activation, and runtime wiring.