### PR TITLE
Add cross-platform generation leases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,18 @@ jobs:
       - run: uv sync --locked --package nauro --all-extras --python ${{ matrix.python-version }}
       - run: uv run --no-sync --package nauro pytest packages/nauro/tests/ --ignore=packages/nauro/tests/cross_surface -v --tb=short
 
+  test-generation-leases:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v6
+      - run: uv python install 3.12
+      - run: uv sync --locked --package nauro --extra dev --python 3.12
+      - run: uv run --no-sync --package nauro python -m pytest packages/nauro/tests/test_generation_lease.py -v --tb=short
+
   distribution:
     runs-on: ubuntu-latest
     steps:

--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "httpx>=0.24",
     "mcp>=1.0,<2",
     "filelock>=3.20.3",
+    "portalocker[win32]>=4.2,<5",
     "tomli>=2.0; python_version<'3.11'",
     "tomlkit>=0.13.2",
 ]

--- a/packages/nauro/src/nauro/store/generation_lease.py
+++ b/packages/nauro/src/nauro/store/generation_lease.py
@@ -1,0 +1,183 @@
+"""Cross-platform lifetime locks for installed generation roots."""
+
+from __future__ import annotations
+
+import os
+import stat
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import BinaryIO, Literal, cast
+
+from portalocker import AlreadyLocked, LockException, LockFlags, lock, unlock
+
+from nauro.store.generation_authority import (
+    GenerationAuthorityError,
+    GenerationProjectionIdentity,
+)
+from nauro.store.replica_control import (
+    ReplicaControlLayout,
+    ReplicaControlReadError,
+    _refuse_symlinks,
+)
+
+_LEASE_OPEN_FLAGS = (
+    os.O_RDWR
+    | getattr(os, "O_CLOEXEC", 0)
+    | getattr(os, "O_BINARY", 0)
+    | getattr(os, "O_NOFOLLOW", 0)
+)
+_LeaseKind = Literal["read", "cleanup"]
+
+
+class GenerationLeaseError(GenerationAuthorityError):
+    """An installed generation lease could not preserve lifetime safety."""
+
+
+class GenerationLeaseBusyError(GenerationLeaseError):
+    """A conflicting generation lease is held by another reader or cleanup."""
+
+    code = "generation_lease_busy"
+
+
+class GenerationLeaseUnavailableError(GenerationLeaseError):
+    """The platform or local lease evidence cannot provide the required lock."""
+
+    code = "generation_lease_unavailable"
+
+
+def _lease_path(
+    layout: ReplicaControlLayout,
+    identity: GenerationProjectionIdentity,
+) -> Path:
+    if (
+        type(layout) is not ReplicaControlLayout
+        or type(identity) is not GenerationProjectionIdentity
+    ):
+        raise GenerationLeaseUnavailableError("Generation leases require validated control state.")
+    path = layout.generation_lease(identity)
+    try:
+        _refuse_symlinks(layout.store_path, (path,))
+    except ReplicaControlReadError as exc:
+        raise GenerationLeaseUnavailableError("The generation lease path is unsafe.") from exc
+    return path
+
+
+def _open_lease(path: Path) -> BinaryIO:
+    try:
+        observed = path.lstat()
+    except OSError as exc:
+        raise GenerationLeaseUnavailableError("The generation lease is unavailable.") from exc
+    if not stat.S_ISREG(observed.st_mode) or observed.st_size != 0:
+        raise GenerationLeaseUnavailableError("The generation lease is not an empty regular file.")
+
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(path, _LEASE_OPEN_FLAGS)
+        opened = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or opened.st_size != 0
+            or (opened.st_dev, opened.st_ino) != (observed.st_dev, observed.st_ino)
+        ):
+            raise GenerationLeaseUnavailableError("The generation lease changed during open.")
+        handle = cast(BinaryIO, os.fdopen(descriptor, "r+b", buffering=0, closefd=True))
+        descriptor = None
+        return handle
+    except GenerationLeaseUnavailableError:
+        raise
+    except OSError as exc:
+        raise GenerationLeaseUnavailableError("The generation lease could not be opened.") from exc
+    finally:
+        if descriptor is not None:
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+
+
+def _acquire(handle: BinaryIO, kind: _LeaseKind) -> None:
+    flags = LockFlags.SHARED if kind == "read" else LockFlags.EXCLUSIVE
+    try:
+        lock(handle, flags | LockFlags.NON_BLOCKING)
+    except AlreadyLocked as exc:
+        raise GenerationLeaseBusyError("A conflicting generation lease is active.") from exc
+    except (ImportError, LockException, OSError, RuntimeError) as exc:
+        raise GenerationLeaseUnavailableError(
+            "The required generation lease is unavailable on this platform."
+        ) from exc
+
+
+def _release(handle: BinaryIO) -> None:
+    error: BaseException | None = None
+    try:
+        unlock(handle)
+    except (ImportError, LockException, OSError, RuntimeError) as exc:
+        error = exc
+    try:
+        handle.close()
+    except OSError as exc:
+        if error is None:
+            error = exc
+    if error is not None:
+        raise GenerationLeaseUnavailableError(
+            "The generation lease could not be released."
+        ) from error
+
+
+@contextmanager
+def _generation_lease(
+    layout: ReplicaControlLayout,
+    identity: GenerationProjectionIdentity,
+    kind: _LeaseKind,
+) -> Iterator[None]:
+    handle = _open_lease(_lease_path(layout, identity))
+    try:
+        _acquire(handle, kind)
+    except BaseException:
+        try:
+            handle.close()
+        except OSError:
+            pass
+        raise
+    body_failed = False
+    try:
+        yield
+    except BaseException:
+        body_failed = True
+        raise
+    finally:
+        try:
+            _release(handle)
+        except GenerationLeaseUnavailableError:
+            if not body_failed:
+                raise
+
+
+@contextmanager
+def generation_read_lease(
+    layout: ReplicaControlLayout,
+    identity: GenerationProjectionIdentity,
+) -> Iterator[None]:
+    """Hold a nonblocking shared lease for one complete generation read."""
+    with _generation_lease(layout, identity, "read"):
+        yield
+
+
+@contextmanager
+def generation_cleanup_lease(
+    layout: ReplicaControlLayout,
+    identity: GenerationProjectionIdentity,
+) -> Iterator[None]:
+    """Hold the nonblocking exclusive lease required before root cleanup."""
+    with _generation_lease(layout, identity, "cleanup"):
+        yield
+
+
+__all__ = [
+    "GenerationLeaseBusyError",
+    "GenerationLeaseError",
+    "GenerationLeaseUnavailableError",
+    "generation_cleanup_lease",
+    "generation_read_lease",
+]

--- a/packages/nauro/tests/test_generation_lease.py
+++ b/packages/nauro/tests/test_generation_lease.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import multiprocessing
+from pathlib import Path
+from threading import Event
+from typing import Protocol
+
+import pytest
+
+import nauro.store.generation_lease as generation_lease
+from nauro.store.generation_authority import GenerationProjectionIdentity
+from nauro.store.generation_lease import (
+    GenerationLeaseBusyError,
+    GenerationLeaseUnavailableError,
+    generation_cleanup_lease,
+    generation_read_lease,
+)
+from nauro.store.replica_control import ReplicaControlLayout
+
+PROJECT_ID = "01KQ6AZGNA0B3QBF67NBXP3S45"
+GENERATION_ID = "01K11111111111111111111111"
+USER_ID = "01K22222222222222222222222"
+PROJECTION_SCOPE_ID = "a" * 64
+
+
+class _ReadyEvent(Protocol):
+    def set(self) -> None: ...
+
+
+def _identity() -> GenerationProjectionIdentity:
+    return GenerationProjectionIdentity(
+        project_id=PROJECT_ID,
+        store_format_version=1,
+        generation_id=GENERATION_ID,
+        manifest_digest="b" * 64,
+        committed_at="2026-09-02T01:02:03.000004Z",
+        installed_for_user_id=USER_ID,
+        projection_class="contributor_plus",
+        projection_scope_id=PROJECTION_SCOPE_ID,
+    )
+
+
+def _layout(tmp_path: Path) -> tuple[ReplicaControlLayout, GenerationProjectionIdentity]:
+    identity = _identity()
+    layout = ReplicaControlLayout(tmp_path / PROJECT_ID)
+    lease = layout.generation_lease(identity)
+    lease.parent.mkdir(parents=True)
+    lease.write_bytes(b"")
+    return layout, identity
+
+
+def _hold_read_lease(store_path: str, ready: _ReadyEvent) -> None:
+    layout = ReplicaControlLayout(Path(store_path))
+    with generation_read_lease(layout, _identity()):
+        ready.set()
+        Event().wait()
+
+
+def test_shared_read_leases_coexist_and_block_cleanup(tmp_path: Path) -> None:
+    layout, identity = _layout(tmp_path)
+
+    with generation_read_lease(layout, identity):
+        with generation_read_lease(layout, identity):
+            with pytest.raises(GenerationLeaseBusyError) as raised:
+                with generation_cleanup_lease(layout, identity):
+                    pass
+
+    assert raised.value.code == "generation_lease_busy"
+    with generation_cleanup_lease(layout, identity):
+        pass
+
+
+def test_cleanup_lease_blocks_readers_and_other_cleanup(tmp_path: Path) -> None:
+    layout, identity = _layout(tmp_path)
+
+    with generation_cleanup_lease(layout, identity):
+        with pytest.raises(GenerationLeaseBusyError):
+            with generation_read_lease(layout, identity):
+                pass
+        with pytest.raises(GenerationLeaseBusyError):
+            with generation_cleanup_lease(layout, identity):
+                pass
+
+
+@pytest.mark.parametrize("defect", ["missing", "nonempty", "directory", "symlink"])
+def test_lease_evidence_must_be_an_empty_regular_file(tmp_path: Path, defect: str) -> None:
+    layout, identity = _layout(tmp_path)
+    lease = layout.generation_lease(identity)
+    lease.unlink()
+    if defect == "nonempty":
+        lease.write_bytes(b"occupied")
+    elif defect == "directory":
+        lease.mkdir()
+    elif defect == "symlink":
+        outside = tmp_path / "outside.lock"
+        outside.write_bytes(b"")
+        try:
+            lease.symlink_to(outside)
+        except OSError:
+            pytest.skip("platform does not permit test symlinks")
+
+    with pytest.raises(GenerationLeaseUnavailableError) as raised:
+        with generation_read_lease(layout, identity):
+            pass
+
+    assert raised.value.code == "generation_lease_unavailable"
+
+
+def test_backend_failure_is_typed_and_closes_the_handle(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    layout, identity = _layout(tmp_path)
+    observed = None
+
+    def fail_backend(handle: object, flags: object) -> None:
+        nonlocal observed
+        observed = handle
+        raise ImportError("shared locks unavailable")
+
+    monkeypatch.setattr(generation_lease, "lock", fail_backend)
+
+    with pytest.raises(GenerationLeaseUnavailableError):
+        with generation_read_lease(layout, identity):
+            pass
+
+    assert observed is not None
+    assert observed.closed
+
+
+def test_body_failure_is_preserved_and_releases_the_lease(tmp_path: Path) -> None:
+    layout, identity = _layout(tmp_path)
+
+    with pytest.raises(RuntimeError, match="body failed"):
+        with generation_read_lease(layout, identity):
+            raise RuntimeError("body failed")
+
+    with generation_cleanup_lease(layout, identity):
+        pass
+
+
+def test_process_exit_releases_lifetime_lease(tmp_path: Path) -> None:
+    layout, identity = _layout(tmp_path)
+    context = multiprocessing.get_context("spawn")
+    ready = context.Event()
+    process = context.Process(target=_hold_read_lease, args=(str(layout.store_path), ready))
+    process.start()
+    try:
+        assert ready.wait(10)
+        with pytest.raises(GenerationLeaseBusyError):
+            with generation_cleanup_lease(layout, identity):
+                pass
+    finally:
+        process.terminate()
+        process.join(10)
+        if process.is_alive():
+            process.kill()
+            process.join(10)
+
+    assert not process.is_alive()
+    with generation_cleanup_lease(layout, identity):
+        pass

--- a/uv.lock
+++ b/uv.lock
@@ -943,6 +943,7 @@ dependencies = [
     { name = "httpx" },
     { name = "mcp" },
     { name = "nauro-core" },
+    { name = "portalocker", extra = ["win32"] },
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "tomlkit" },
     { name = "typer" },
@@ -968,6 +969,7 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0" },
     { name = "nauro-core", editable = "packages/nauro-core" },
     { name = "nauro-core", extras = ["embeddings"], marker = "extra == 'embeddings'", editable = "packages/nauro-core" },
+    { name = "portalocker", extras = ["win32"], specifier = ">=4.2,<5" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0" },
@@ -1252,6 +1254,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "portalocker"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/8e/27672cd2dde9d2345ead0352146a401be4ec0af132be86ca7a2db24afb09/portalocker-4.3.0.tar.gz", hash = "sha256:69bf8e46769d66eb0a23219b9550253d2c3b5f03400202a2333784c1e6395e32", size = 263582, upload-time = "2026-08-25T18:05:20.267Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/76/57be9bb352b3f91c80671a7b7ce2cd51f99ad324c89df82a098df9b9e609/portalocker-4.3.0-py3-none-any.whl", hash = "sha256:aa91709ccfc322b8225171392d64a2f9fc833f15f5ab741cfba6d3fba285ce31", size = 129554, upload-time = "2026-08-25T18:05:18.64Z" },
+]
+
+[package.optional-dependencies]
+win32 = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

Installed generation readers need a shared OS lifetime lock, while cleanup needs a nonblocking exclusive lock. The existing lock dependency provides only exclusive locks and cannot satisfy that contract on every supported CLI platform.

## What changed

- Add a narrow Portalocker-backed lease primitive with true shared locks on Windows through the `win32` extra.
- Validate the empty lease sidecar before opening it, reject symlinks and changed file identity, and fail closed when the backend is unavailable.
- Keep both read and cleanup acquisition nonblocking, with explicit unlock and close.
- Add process-level contention and crash-release tests.
- Add one focused CI job for Linux, macOS, and Windows.

The primitive is dormant. No reader, cleanup path, migration, or runtime route calls it yet.

## Test plan

- Lease tests: 9 passed.
- Wider generation suite: 240 passed.
- Full package suite: 2,961 passed, 10 skipped.
- Ruff format and check, docstring budget, single-source guard, Mypy, lockfile resolution, and workflow YAML validation passed.

## Risk / what to review

Review file identity validation, lock acquisition and release on each platform, nonblocking contention mapping, and process-exit release. The new platform matrix will run when this stacked change reaches a pull request targeting `main`.

## Deferred

The pointer-resolve and reread protocol, the leased Store adapter, cleanup and tombstoning, authenticated refresh replacement, migration activation, and runtime wiring.
