### PR TITLE
Lease pointer-selected generation reads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,13 @@ jobs:
       - uses: astral-sh/setup-uv@v6
       - run: uv python install 3.12
       - run: uv sync --locked --package nauro --extra dev --python 3.12
-      - run: uv run --no-sync --package nauro python -m pytest packages/nauro/tests/test_generation_lease.py -v --tb=short
+      - run: >-
+          uv run --no-sync --package nauro python -m pytest
+          packages/nauro/tests/test_replica_control.py
+          packages/nauro/tests/test_generation_installation.py
+          packages/nauro/tests/test_generation_lease.py
+          packages/nauro/tests/test_generation_store.py
+          -v --tb=short
 
   distribution:
     runs-on: ubuntu-latest

--- a/packages/nauro/src/nauro/store/generation_authority.py
+++ b/packages/nauro/src/nauro/store/generation_authority.py
@@ -156,6 +156,19 @@ class InstalledGenerationPointer(GenerationProjectionIdentity):
         return value
 
 
+def projection_identity_from_pointer(
+    pointer: InstalledGenerationPointer,
+) -> GenerationProjectionIdentity:
+    """Return the server-authenticated identity fields from a validated pointer."""
+    if type(pointer) is not InstalledGenerationPointer:
+        raise GenerationControlCorruptError("The installed generation pointer is invalid.")
+    values = {
+        field_name: getattr(pointer, field_name)
+        for field_name in GenerationProjectionIdentity.model_fields
+    }
+    return GenerationProjectionIdentity.model_validate(values)
+
+
 @dataclass(frozen=True)
 class FlatProjectAuthority:
     """A local-only or pre-epoch hosted flat store."""
@@ -291,5 +304,6 @@ __all__ = [
     "ProjectAuthority",
     "RefreshRequiredError",
     "ReplicaActorMismatchError",
+    "projection_identity_from_pointer",
     "select_project_authority",
 ]

--- a/packages/nauro/src/nauro/store/generation_installation.py
+++ b/packages/nauro/src/nauro/store/generation_installation.py
@@ -20,11 +20,14 @@ from nauro.store.generation_authority import (
     GenerationProjectionIdentity,
     InstalledGenerationPointer,
     RefreshRequiredError,
+    projection_identity_from_pointer,
     select_project_authority,
 )
 from nauro.store.generation_projection import VerifiedGenerationProjection
 from nauro.store.replica_control import (
     ReplicaControlLayout,
+    ReplicaControlReadError,
+    _is_link_like,
     _refuse_symlinks,
     locked_replica_control_snapshot,
 )
@@ -49,14 +52,6 @@ def _new_install_state_id() -> str:
     return generate_ulid()
 
 
-def _identity_from_pointer(pointer: InstalledGenerationPointer) -> GenerationProjectionIdentity:
-    values = {
-        field_name: getattr(pointer, field_name)
-        for field_name in GenerationProjectionIdentity.model_fields
-    }
-    return GenerationProjectionIdentity.model_validate(values)
-
-
 def _pointer_bytes(pointer: InstalledGenerationPointer) -> bytes:
     return json.dumps(
         pointer.model_dump(),
@@ -75,7 +70,11 @@ def _expected_directories(projection: VerifiedGenerationProjection) -> set[str]:
 
 
 def _audit_root(root: Path, projection: VerifiedGenerationProjection) -> None:
-    if root.is_symlink() or not root.is_dir():
+    try:
+        unsafe_root = _is_link_like(root)
+    except ReplicaControlReadError as exc:
+        raise GenerationInstallationError("The generation root metadata is unavailable.") from exc
+    if unsafe_root or not root.is_dir():
         raise GenerationInstallationError("The generation root is not a regular directory.")
     expected_files = {artifact.path: artifact.content for artifact in projection.artifacts}
     expected_directories = _expected_directories(projection)
@@ -83,8 +82,16 @@ def _audit_root(root: Path, projection: VerifiedGenerationProjection) -> None:
     try:
         for path in root.rglob("*"):
             relative = path.relative_to(root).as_posix()
-            if path.is_symlink():
-                raise GenerationInstallationError("The generation root contains a symlink.")
+            try:
+                unsafe_path = _is_link_like(path)
+            except ReplicaControlReadError as exc:
+                raise GenerationInstallationError(
+                    "The generation root path metadata is unavailable."
+                ) from exc
+            if unsafe_path:
+                raise GenerationInstallationError(
+                    "The generation root contains a link or reparse point."
+                )
             if path.is_dir():
                 if relative not in expected_directories:
                     raise GenerationInstallationError(
@@ -110,11 +117,11 @@ def _audit_root(root: Path, projection: VerifiedGenerationProjection) -> None:
 
 def _discard_staging(path: Path) -> None:
     try:
-        if path.is_symlink():
+        if _is_link_like(path):
             path.unlink()
         elif path.exists():
             shutil.rmtree(path)
-    except OSError:
+    except (OSError, ReplicaControlReadError):
         pass
 
 
@@ -250,7 +257,7 @@ def _is_same_or_refuse_replacement(
 ) -> bool:
     if current is None:
         return False
-    current_identity = _identity_from_pointer(current)
+    current_identity = projection_identity_from_pointer(current)
     if current_identity == target:
         return True
     raise GenerationInstallationError(

--- a/packages/nauro/src/nauro/store/generation_projection.py
+++ b/packages/nauro/src/nauro/store/generation_projection.py
@@ -169,10 +169,15 @@ def _invalid_json_constant(value: str) -> object:
     raise ValueError(f"invalid JSON constant: {value}")
 
 
-def _parse_manifest(
+def verify_generation_projection_manifest(
     target: GenerationProjectionTarget,
     manifest_json: bytes,
 ) -> GenerationProjectionManifest:
+    """Verify one canonical manifest against authenticated projection identity."""
+    if type(target) is not GenerationProjectionTarget:
+        raise GenerationProjectionVerificationError(
+            "Generation verification requires a validated projection target."
+        )
     if type(manifest_json) is not bytes:
         raise GenerationProjectionVerificationError("The generation manifest must be exact bytes.")
     if hashlib.sha256(manifest_json).hexdigest() != target.identity.manifest_digest:
@@ -238,7 +243,7 @@ class VerifiedGenerationProjection:
             raise GenerationProjectionVerificationError(
                 "Generation verification requires a validated projection target."
             )
-        manifest = _parse_manifest(self.target, self.manifest_json)
+        manifest = verify_generation_projection_manifest(self.target, self.manifest_json)
         if type(self.artifacts) is not tuple:
             raise GenerationProjectionVerificationError("The generation artifact set is malformed.")
         artifacts = self.artifacts
@@ -312,4 +317,5 @@ __all__ = [
     "VerifiedGenerationArtifact",
     "VerifiedGenerationProjection",
     "verify_generation_projection",
+    "verify_generation_projection_manifest",
 ]

--- a/packages/nauro/src/nauro/store/generation_store.py
+++ b/packages/nauro/src/nauro/store/generation_store.py
@@ -1,0 +1,346 @@
+"""Read-only Store access to one pointer-selected hosted generation."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import stat
+from collections.abc import Iterator
+from contextlib import ExitStack, contextmanager
+from dataclasses import InitVar, dataclass, field
+from pathlib import Path
+
+from nauro_core.constants import DECISIONS_DIR
+from nauro_core.protected_generation_membership import (
+    InvalidGenerationPath,
+    validate_protected_generation_path,
+)
+
+from nauro.store.generation_authority import (
+    GenerationAuthorityError,
+    GenerationProjectAuthority,
+    projection_identity_from_pointer,
+    select_project_authority,
+)
+from nauro.store.generation_lease import generation_read_lease
+from nauro.store.generation_projection import (
+    GenerationProjectionManifest,
+    GenerationProjectionTarget,
+    verify_generation_projection_manifest,
+)
+from nauro.store.replica_control import (
+    ReplicaControlLayout,
+    ReplicaControlReadError,
+    _is_link_like,
+    _refuse_symlinks,
+    locked_replica_control_snapshot,
+)
+from nauro.store.resolution import ResolvedProjectBinding
+
+_READ_FLAGS = (
+    os.O_RDONLY
+    | getattr(os, "O_CLOEXEC", 0)
+    | getattr(os, "O_BINARY", 0)
+    | getattr(os, "O_NOFOLLOW", 0)
+)
+_STORE_CONSTRUCTION_TOKEN = object()
+
+
+class GenerationStoreError(GenerationAuthorityError):
+    """A pointer-selected generation cannot satisfy the Store contract."""
+
+
+class GenerationStoreUnavailableError(GenerationStoreError):
+    """Generation bytes or control state cannot support a safe read."""
+
+    code = "generation_store_unavailable"
+
+
+class GenerationStoreReadOnlyError(GenerationStoreError):
+    """A protected hosted generation cannot be changed through the file Store."""
+
+    code = "generation_store_read_only"
+
+
+def _read_digest_bound_file(
+    containment_root: Path,
+    path: Path,
+    expected_digest: str,
+    *,
+    label: str,
+) -> bytes:
+    try:
+        unsafe_root = _is_link_like(containment_root)
+    except ReplicaControlReadError as exc:
+        raise GenerationStoreUnavailableError(
+            f"The generation {label} containment root is unsafe."
+        ) from exc
+    if unsafe_root or not containment_root.is_dir():
+        raise GenerationStoreUnavailableError(f"The generation {label} containment root is unsafe.")
+    try:
+        _refuse_symlinks(containment_root, (path,))
+        observed = path.lstat()
+    except ReplicaControlReadError as exc:
+        raise GenerationStoreUnavailableError(f"The generation {label} path is unsafe.") from exc
+    except OSError as exc:
+        raise GenerationStoreUnavailableError(f"The generation {label} is unavailable.") from exc
+    if not stat.S_ISREG(observed.st_mode):
+        raise GenerationStoreUnavailableError(f"The generation {label} is not a regular file.")
+
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(path, _READ_FLAGS)
+        opened = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or (opened.st_dev, opened.st_ino) != (observed.st_dev, observed.st_ino)
+            or opened.st_size != observed.st_size
+        ):
+            raise GenerationStoreUnavailableError(f"The generation {label} changed during open.")
+        with os.fdopen(descriptor, "rb", closefd=True) as handle:
+            descriptor = None
+            content = handle.read(opened.st_size + 1)
+            finished = os.fstat(handle.fileno())
+        if (
+            len(content) != opened.st_size
+            or (finished.st_dev, finished.st_ino) != (opened.st_dev, opened.st_ino)
+            or finished.st_size != opened.st_size
+        ):
+            raise GenerationStoreUnavailableError(f"The generation {label} changed during read.")
+    except GenerationStoreUnavailableError:
+        raise
+    except (OSError, OverflowError, ValueError) as exc:
+        raise GenerationStoreUnavailableError(f"The generation {label} could not be read.") from exc
+    finally:
+        if descriptor is not None:
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+    if hashlib.sha256(content).hexdigest() != expected_digest:
+        raise GenerationStoreUnavailableError(f"The generation {label} digest diverges.")
+    return content
+
+
+def _expected_directories(manifest: GenerationProjectionManifest) -> set[str]:
+    directories: set[str] = set()
+    for artifact_path in manifest.artifacts:
+        parts = artifact_path.split("/")[:-1]
+        for index in range(1, len(parts) + 1):
+            directories.add("/".join(parts[:index]))
+    return directories
+
+
+def _audit_root_membership(root: Path, manifest: GenerationProjectionManifest) -> None:
+    expected_files = set(manifest.artifacts)
+    expected_directories = _expected_directories(manifest)
+    observed_files: set[str] = set()
+    try:
+        for path in root.rglob("*"):
+            relative = path.relative_to(root).as_posix()
+            try:
+                unsafe_path = _is_link_like(path)
+            except ReplicaControlReadError as exc:
+                raise GenerationStoreUnavailableError(
+                    "The selected generation path metadata is unavailable."
+                ) from exc
+            if unsafe_path:
+                raise GenerationStoreUnavailableError(
+                    "The selected generation contains a link or reparse point."
+                )
+            if path.is_dir():
+                if relative not in expected_directories:
+                    raise GenerationStoreUnavailableError(
+                        "The selected generation contains an unexpected directory."
+                    )
+                continue
+            if not path.is_file() or relative not in expected_files:
+                raise GenerationStoreUnavailableError(
+                    "The selected generation contains an unexpected file."
+                )
+            observed_files.add(relative)
+    except GenerationStoreUnavailableError:
+        raise
+    except (OSError, RuntimeError) as exc:
+        raise GenerationStoreUnavailableError(
+            "The selected generation cannot be enumerated safely."
+        ) from exc
+    if observed_files != expected_files:
+        raise GenerationStoreUnavailableError("The selected generation is incomplete.")
+
+
+@dataclass(frozen=True, eq=False)
+class LeasedGenerationStore:
+    """A read-only Store valid only inside its lifetime-lease context."""
+
+    _root: Path = field(repr=False)
+    _manifest: GenerationProjectionManifest = field(repr=False)
+    _construction_token: InitVar[object]
+    _closed: bool = field(default=False, init=False, repr=False)
+
+    def __post_init__(self, _construction_token: object) -> None:
+        if _construction_token is not _STORE_CONSTRUCTION_TOKEN:
+            raise GenerationStoreUnavailableError(
+                "Generation stores must be opened through their lifetime-lease context."
+            )
+
+    def _require_open(self) -> None:
+        if self._closed:
+            raise GenerationStoreUnavailableError("The generation read lease has ended.")
+
+    def _read_canonical(self, path: str) -> str | None:
+        self._require_open()
+        expected_digest = self._manifest.artifacts.get(path)
+        if expected_digest is None:
+            return None
+        content = _read_digest_bound_file(
+            self._root,
+            self._root / path,
+            expected_digest,
+            label=f"artifact {path}",
+        )
+        return content.decode("utf-8", errors="replace")
+
+    def read_file(self, path: str) -> str | None:
+        try:
+            canonical = validate_protected_generation_path(path)
+        except InvalidGenerationPath as exc:
+            raise GenerationStoreUnavailableError(
+                "The requested path is outside the protected generation."
+            ) from exc
+        return self._read_canonical(canonical)
+
+    def write_file(self, path: str, content: str) -> None:
+        self._require_open()
+        raise GenerationStoreReadOnlyError(
+            "Hosted generation files require a named typed operation."
+        )
+
+    def delete_file(self, path: str) -> None:
+        self._require_open()
+        raise GenerationStoreReadOnlyError(
+            "Hosted generation files require a named typed operation."
+        )
+
+    def list_decisions(self) -> list[str]:
+        self._require_open()
+        prefix = f"{DECISIONS_DIR}/"
+        suffix = ".md"
+        return sorted(
+            path[len(prefix) : -len(suffix)]
+            for path in self._manifest.artifacts
+            if path.startswith(prefix) and path.endswith(suffix)
+        )
+
+    def read_decision(self, file_stem: str) -> str | None:
+        return self.read_file(f"{DECISIONS_DIR}/{file_stem}.md")
+
+    def read_decisions(self, stems: list[str]) -> dict[str, str | None]:
+        self._require_open()
+        return {stem: self.read_decision(stem) for stem in stems}
+
+    def _close(self) -> None:
+        object.__setattr__(self, "_closed", True)
+
+
+def _require_generation_authority(
+    binding: ResolvedProjectBinding,
+    *,
+    marker_json: bytes | None,
+    pointer_json: bytes | None,
+    active_user_id: str,
+    active_projection_scope_id: str,
+) -> GenerationProjectAuthority:
+    authority = select_project_authority(
+        binding,
+        marker_json=marker_json,
+        pointer_json=pointer_json,
+        active_user_id=active_user_id,
+        active_projection_scope_id=active_projection_scope_id,
+    )
+    if not isinstance(authority, GenerationProjectAuthority):
+        raise GenerationStoreUnavailableError(
+            "The project has not selected hosted generation authority."
+        )
+    return authority
+
+
+@contextmanager
+def leased_generation_store(
+    binding: ResolvedProjectBinding,
+    *,
+    active_user_id: str,
+    active_projection_scope_id: str,
+) -> Iterator[LeasedGenerationStore]:
+    """Yield one pointer-bound Store while its shared lifetime lease is held."""
+    if type(binding) is not ResolvedProjectBinding:
+        raise GenerationStoreUnavailableError("Generation reads require a validated binding.")
+    layout = ReplicaControlLayout(binding.store_path)
+    with ExitStack() as lifetime_leases:
+        with locked_replica_control_snapshot(
+            binding,
+            active_user_id=active_user_id,
+        ) as snapshot:
+            initial = _require_generation_authority(
+                binding,
+                marker_json=snapshot.marker_json,
+                pointer_json=snapshot.pointer_json,
+                active_user_id=active_user_id,
+                active_projection_scope_id=active_projection_scope_id,
+            )
+            identity = projection_identity_from_pointer(initial.pointer)
+            root = layout.generation_root(identity)
+            manifest_path = layout.generation_manifest(identity)
+            try:
+                _refuse_symlinks(binding.store_path, (root, manifest_path))
+            except ReplicaControlReadError as exc:
+                raise GenerationStoreUnavailableError(
+                    "The selected generation paths are unsafe."
+                ) from exc
+            lifetime_leases.enter_context(generation_read_lease(layout, identity))
+            current = _require_generation_authority(
+                binding,
+                marker_json=snapshot.marker_json,
+                pointer_json=snapshot.reread_pointer(),
+                active_user_id=active_user_id,
+                active_projection_scope_id=active_projection_scope_id,
+            )
+            if current.pointer != initial.pointer:
+                raise GenerationStoreUnavailableError(
+                    "The generation pointer changed while acquiring its read lease."
+                )
+
+        try:
+            _refuse_symlinks(binding.store_path, (root, manifest_path))
+            unsafe_root = _is_link_like(root)
+        except ReplicaControlReadError as exc:
+            raise GenerationStoreUnavailableError(
+                "The selected generation paths are unsafe."
+            ) from exc
+        if unsafe_root or not root.is_dir():
+            raise GenerationStoreUnavailableError(
+                "The selected generation root is not a regular directory."
+            )
+        manifest_json = _read_digest_bound_file(
+            binding.store_path,
+            manifest_path,
+            identity.manifest_digest,
+            label="manifest",
+        )
+        target = GenerationProjectionTarget(binding=binding, identity=identity)
+        manifest = verify_generation_projection_manifest(target, manifest_json)
+        _audit_root_membership(root, manifest)
+        store = LeasedGenerationStore(root, manifest, _STORE_CONSTRUCTION_TOKEN)
+        try:
+            yield store
+        finally:
+            store._close()
+
+
+__all__ = [
+    "GenerationStoreError",
+    "GenerationStoreReadOnlyError",
+    "GenerationStoreUnavailableError",
+    "LeasedGenerationStore",
+    "leased_generation_store",
+]

--- a/packages/nauro/src/nauro/store/replica_control.py
+++ b/packages/nauro/src/nauro/store/replica_control.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import os
 import stat
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from filelock import FileLock, Timeout
@@ -111,6 +111,31 @@ class ReplicaControlSnapshot:
 
     marker_json: bytes | None
     pointer_json: bytes | None
+    _reread_pointer: Callable[[], bytes | None] | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+
+    def reread_pointer(self) -> bytes | None:
+        """Read the active pointer again while the originating lock remains held."""
+        if self._reread_pointer is None:
+            raise ReplicaControlReadError(
+                "The replica pointer can only be reread under its control lock."
+            )
+        return self._reread_pointer()
+
+
+def _is_link_like(path: Path) -> bool:
+    try:
+        observed = path.lstat()
+    except FileNotFoundError:
+        return False
+    except OSError as exc:
+        raise ReplicaControlReadError("Replica control path metadata is unavailable.") from exc
+    reparse_flag = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0)
+    file_attributes = getattr(observed, "st_file_attributes", 0)
+    return stat.S_ISLNK(observed.st_mode) or bool(reparse_flag and file_attributes & reparse_flag)
 
 
 def _refuse_symlinks(store_path: Path, paths: tuple[Path, ...]) -> None:
@@ -124,14 +149,10 @@ def _refuse_symlinks(store_path: Path, paths: tuple[Path, ...]) -> None:
         current = store_path
         for part in relative.parts:
             current /= part
-            try:
-                is_link = current.is_symlink()
-            except OSError as exc:
+            if _is_link_like(current):
                 raise ReplicaControlReadError(
-                    "Replica control path metadata is unavailable."
-                ) from exc
-            if is_link:
-                raise ReplicaControlReadError("Replica control paths cannot contain symlinks.")
+                    "Replica control paths cannot contain links or reparse points."
+                )
 
 
 def _read_optional_file(path: Path) -> bytes | None:
@@ -200,16 +221,32 @@ def locked_replica_control_snapshot(
         _refuse_symlinks(binding.store_path, (layout.authority_marker,))
         marker_json = _read_optional_file(layout.authority_marker)
         pointer_json = None
+        pointer: Path | None = None
         if marker_json is not None and is_identifier(IdentifierKind.ulid, active_user_id):
             assert isinstance(active_user_id, str)
             pointer = layout.actor_pointer(active_user_id)
             _refuse_symlinks(binding.store_path, (pointer,))
             pointer_json = _read_optional_file(pointer)
+
+        active = True
+
+        def reread_pointer() -> bytes | None:
+            if not active:
+                raise ReplicaControlReadError(
+                    "The replica pointer can only be reread under its control lock."
+                )
+            if pointer is None:
+                return None
+            _refuse_symlinks(binding.store_path, (pointer,))
+            return _read_optional_file(pointer)
+
         yield ReplicaControlSnapshot(
             marker_json=marker_json,
             pointer_json=pointer_json,
+            _reread_pointer=reread_pointer,
         )
     finally:
+        active = False
         lock.release()
 
 

--- a/packages/nauro/tests/test_generation_store.py
+++ b/packages/nauro/tests/test_generation_store.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from contextlib import contextmanager
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+
+import pytest
+from filelock import FileLock, Timeout
+from nauro_core.operations.store import Store
+
+import nauro.store.generation_store as generation_store
+from nauro.store.generation_authority import GenerationProjectionIdentity
+from nauro.store.generation_installation import install_verified_generation
+from nauro.store.generation_lease import (
+    GenerationLeaseBusyError,
+    generation_cleanup_lease,
+)
+from nauro.store.generation_projection import (
+    GenerationProjectionTarget,
+    VerifiedGenerationProjection,
+    verify_generation_projection,
+)
+from nauro.store.generation_store import (
+    GenerationStoreReadOnlyError,
+    GenerationStoreUnavailableError,
+    LeasedGenerationStore,
+    leased_generation_store,
+)
+from nauro.store.replica_control import ReplicaControlLayout
+from nauro.store.resolution import ResolvedProjectBinding
+
+PROJECT_ID = "01KQ6AZGNA0B3QBF67NBXP3S45"
+GENERATION_ID = "01K11111111111111111111111"
+USER_ID = "01K22222222222222222222222"
+OTHER_INSTALL_STATE_ID = "01K33333333333333333333333"
+PROJECTION_SCOPE_ID = "a" * 64
+COMMITTED_AT = "2026-09-02T01:02:03.000004Z"
+
+
+def _binding(tmp_path: Path) -> ResolvedProjectBinding:
+    store = tmp_path / PROJECT_ID
+    store.mkdir()
+    return ResolvedProjectBinding(
+        store_path=store,
+        project_id=PROJECT_ID,
+        display_name="Nauro",
+        mode="cloud",
+        server_url="https://mcp.nauro.ai",
+    )
+
+
+def _projection(
+    tmp_path: Path,
+    *,
+    contents: dict[str, bytes] | None = None,
+) -> VerifiedGenerationProjection:
+    binding = _binding(tmp_path)
+    artifact_bytes = contents or {
+        "project.md": b"# Project\n",
+        "decisions/002-second.md": b"# 2 - Second\n",
+        "decisions/001-first.md": b"# 1 - First\n",
+    }
+    manifest_json = json.dumps(
+        {
+            "project_id": PROJECT_ID,
+            "store_format_version": 1,
+            "generation_id": GENERATION_ID,
+            "projection_class": "contributor_plus",
+            "projection_scope_id": PROJECTION_SCOPE_ID,
+            "artifacts": {
+                path: hashlib.sha256(content).hexdigest()
+                for path, content in artifact_bytes.items()
+            },
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+    identity = GenerationProjectionIdentity(
+        project_id=PROJECT_ID,
+        store_format_version=1,
+        generation_id=GENERATION_ID,
+        manifest_digest=hashlib.sha256(manifest_json).hexdigest(),
+        committed_at=COMMITTED_AT,
+        installed_for_user_id=USER_ID,
+        projection_class="contributor_plus",
+        projection_scope_id=PROJECTION_SCOPE_ID,
+    )
+    return verify_generation_projection(
+        GenerationProjectionTarget(binding=binding, identity=identity),
+        manifest_json=manifest_json,
+        artifacts=list(artifact_bytes.items()),
+    )
+
+
+def _activate(projection: VerifiedGenerationProjection) -> ReplicaControlLayout:
+    install_verified_generation(projection)
+    layout = ReplicaControlLayout(projection.target.binding.store_path)
+    layout.authority_marker.parent.mkdir(parents=True, exist_ok=True)
+    layout.authority_marker.write_bytes(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "authority": "generation",
+                "project_id": PROJECT_ID,
+                "store_format_version": 1,
+            }
+        ).encode()
+    )
+    return layout
+
+
+def _open_store(projection: VerifiedGenerationProjection):
+    return leased_generation_store(
+        projection.target.binding,
+        active_user_id=USER_ID,
+        active_projection_scope_id=PROJECTION_SCOPE_ID,
+    )
+
+
+def test_store_holds_only_the_generation_lease_for_its_lifetime(tmp_path: Path) -> None:
+    projection = _projection(tmp_path)
+    layout = _activate(projection)
+    retained = None
+
+    with _open_store(projection) as store:
+        retained = store
+        assert isinstance(store, Store)
+        assert store.read_file("project.md") == "# Project\n"
+        assert store.list_decisions() == ["001-first", "002-second"]
+        assert store.read_decisions(["002-second", "001-first"]) == {
+            "002-second": "# 2 - Second\n",
+            "001-first": "# 1 - First\n",
+        }
+        with pytest.raises(FrozenInstanceError):
+            store._root = tmp_path
+        with FileLock(str(layout.control_lock), timeout=0):
+            pass
+        with pytest.raises(GenerationLeaseBusyError):
+            with generation_cleanup_lease(layout, projection.target.identity):
+                pass
+
+    assert retained is not None
+    with pytest.raises(GenerationStoreUnavailableError, match="lease has ended"):
+        retained.read_file("project.md")
+    with generation_cleanup_lease(layout, projection.target.identity):
+        pass
+
+
+def test_store_is_read_only_and_rejects_nonprotected_paths(tmp_path: Path) -> None:
+    projection = _projection(tmp_path)
+    layout = _activate(projection)
+    project = layout.generation_root(projection.target.identity) / "project.md"
+
+    with _open_store(projection) as store:
+        assert store.read_file("stack.md") is None
+        with pytest.raises(GenerationStoreUnavailableError, match="outside"):
+            store.read_file("snapshots/v001.json")
+        with pytest.raises(GenerationStoreReadOnlyError) as write_error:
+            store.write_file("project.md", "changed")
+        with pytest.raises(GenerationStoreReadOnlyError):
+            store.delete_file("project.md")
+
+    assert write_error.value.code == "generation_store_read_only"
+    assert project.read_bytes() == b"# Project\n"
+
+
+def test_store_cannot_be_constructed_without_a_lifetime_lease(tmp_path: Path) -> None:
+    projection = _projection(tmp_path)
+
+    with pytest.raises(GenerationStoreUnavailableError, match="lifetime-lease context"):
+        LeasedGenerationStore(
+            projection.target.binding.store_path,
+            projection.manifest,
+            object(),
+        )
+
+
+def test_manifest_tampering_blocks_store_creation(tmp_path: Path) -> None:
+    projection = _projection(tmp_path)
+    layout = _activate(projection)
+    layout.generation_manifest(projection.target.identity).write_bytes(b"{}")
+
+    with pytest.raises(GenerationStoreUnavailableError, match="manifest digest"):
+        with _open_store(projection):
+            pass
+
+
+def test_artifact_tampering_fails_at_the_read_boundary(tmp_path: Path) -> None:
+    projection = _projection(tmp_path)
+    layout = _activate(projection)
+    root = layout.generation_root(projection.target.identity)
+    (root / "project.md").write_bytes(b"changed")
+
+    with _open_store(projection) as store:
+        with pytest.raises(GenerationStoreUnavailableError, match="digest diverges"):
+            store.read_file("project.md")
+
+
+def test_unmanifested_material_blocks_store_creation(tmp_path: Path) -> None:
+    projection = _projection(tmp_path)
+    layout = _activate(projection)
+    root = layout.generation_root(projection.target.identity)
+    (root / "extra.md").write_bytes(b"extra")
+
+    with pytest.raises(GenerationStoreUnavailableError, match="unexpected file"):
+        with _open_store(projection):
+            pass
+
+
+def test_symlinked_artifact_blocks_store_creation(tmp_path: Path) -> None:
+    projection = _projection(tmp_path)
+    layout = _activate(projection)
+    root = layout.generation_root(projection.target.identity)
+    project = root / "project.md"
+    project.unlink()
+    outside = tmp_path / "outside.md"
+    outside.write_bytes(b"# Project\n")
+    try:
+        project.symlink_to(outside)
+    except OSError:
+        pytest.skip("platform does not permit test symlinks")
+
+    with pytest.raises(GenerationStoreUnavailableError, match="link or reparse"):
+        with _open_store(projection):
+            pass
+
+
+def test_pointer_change_after_lease_acquisition_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    projection = _projection(tmp_path)
+    layout = _activate(projection)
+    original = generation_store.generation_read_lease
+
+    @contextmanager
+    def mutate_pointer(
+        active_layout: ReplicaControlLayout,
+        identity: GenerationProjectionIdentity,
+    ):
+        with original(active_layout, identity):
+            with pytest.raises(Timeout):
+                FileLock(str(active_layout.control_lock)).acquire(timeout=0)
+            pointer_path = active_layout.actor_pointer(USER_ID)
+            pointer = json.loads(pointer_path.read_bytes())
+            pointer["installed_state_id"] = OTHER_INSTALL_STATE_ID
+            pointer_path.write_bytes(json.dumps(pointer).encode())
+            yield
+
+    monkeypatch.setattr(generation_store, "generation_read_lease", mutate_pointer)
+
+    with pytest.raises(GenerationStoreUnavailableError, match="pointer changed"):
+        with _open_store(projection):
+            pass
+
+    with generation_cleanup_lease(layout, projection.target.identity):
+        pass
+
+
+def test_absent_authority_marker_does_not_open_generation_store(tmp_path: Path) -> None:
+    projection = _projection(tmp_path)
+    install_verified_generation(projection)
+
+    with pytest.raises(GenerationStoreUnavailableError, match="has not selected"):
+        with _open_store(projection):
+            pass

--- a/packages/nauro/tests/test_replica_control.py
+++ b/packages/nauro/tests/test_replica_control.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import json
+import stat
 from dataclasses import FrozenInstanceError
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Literal
 
 import pytest
@@ -17,6 +19,7 @@ from nauro.store.replica_control import (
     ReplicaControlLayout,
     ReplicaControlReadError,
     ReplicaControlSnapshot,
+    _refuse_symlinks,
     locked_replica_control_snapshot,
 )
 from nauro.store.resolution import ResolvedProjectBinding
@@ -139,6 +142,23 @@ def test_snapshot_reads_exact_marker_and_active_actor_pointer(tmp_path: Path) ->
             FileLock(str(layout.control_lock)).acquire(timeout=0)
 
 
+def test_pointer_reread_is_available_only_while_control_lock_is_held(tmp_path: Path) -> None:
+    binding = _binding(tmp_path / PROJECT_ID)
+    layout = ReplicaControlLayout(binding.store_path)
+    marker, pointer = _write_control(layout)
+    changed = json.loads(pointer)
+    changed["installed_state_id"] = "01K44444444444444444444444"
+    changed_pointer = json.dumps(changed).encode()
+
+    with locked_replica_control_snapshot(binding, active_user_id=USER_ID) as snapshot:
+        assert snapshot.marker_json == marker
+        layout.actor_pointer(USER_ID).write_bytes(changed_pointer)
+        assert snapshot.reread_pointer() == changed_pointer
+
+    with pytest.raises(ReplicaControlReadError, match="under its control lock"):
+        snapshot.reread_pointer()
+
+
 def test_snapshot_bytes_feed_strict_authority_selection(tmp_path: Path) -> None:
     binding = _binding(tmp_path / PROJECT_ID)
     layout = ReplicaControlLayout(binding.store_path)
@@ -224,6 +244,32 @@ def test_control_snapshot_refuses_symlink_components(tmp_path: Path, target: str
             pass
 
     assert raised.value.code == "generation_control_unavailable"
+
+
+def test_control_paths_refuse_windows_reparse_points(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = tmp_path / PROJECT_ID
+    target = store / ".replica"
+    target.mkdir(parents=True)
+    path_type = type(target)
+    original_lstat = path_type.lstat
+    reparse_flag = 0x400
+
+    def marked_lstat(path: Path):
+        if path == target:
+            return SimpleNamespace(
+                st_mode=stat.S_IFDIR,
+                st_file_attributes=reparse_flag,
+            )
+        return original_lstat(path)
+
+    monkeypatch.setattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", reparse_flag, raising=False)
+    monkeypatch.setattr(path_type, "lstat", marked_lstat)
+
+    with pytest.raises(ReplicaControlReadError, match="reparse"):
+        _refuse_symlinks(store, (target / "authority.json",))
 
 
 @pytest.mark.parametrize("kind", ["marker_directory", "marker_large", "pointer_large"])


### PR DESCRIPTION
## Why

A hosted read must stay on the generation selected at its start. It must not release the control lock until it holds that generation's lifetime lease and has proved that the actor pointer did not change.

## What changed

- Let a lock-held replica snapshot reread its active actor pointer only while the originating control lock remains held.
- Resolve the validated actor and authorization scope, acquire that generation's shared lease, reread and revalidate the pointer, then release the control lock while retaining the lease.
- Add a lease-bound read-only Store that verifies the canonical manifest, exact root membership, and each artifact digest before returning text.
- Reject all file mutations, nonprotected paths, retained adapters after lease exit, symlinks, and Windows reparse points.
- Extend the focused Linux, macOS, and Windows job to cover control, installation, lease, and leased Store behavior.

The adapter is dormant. No CLI, MCP, migration, refresh, or cleanup caller uses it yet.

## Test plan

- Focused authority, control, projection, installation, lease, and Store tests: 174 passed.
- Full package suite: 2,972 passed, 10 skipped.
- Ruff format and check, docstring budget, single-source guard, Mypy, and workflow YAML validation passed.

## Risk / what to review

Review control-lock and lifetime-lease ordering, the second pointer validation, manifest and artifact identity checks, capability closure after context exit, and Windows reparse-point refusal.

## Deferred

Runtime authority routing, authenticated refresh replacement, cleanup and tombstoning, migration orchestration, activation, and legacy-path shutdown.
