### PR TITLE
Fence generation refresh commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
           packages/nauro/tests/test_replica_control.py
           packages/nauro/tests/test_generation_installation.py
           packages/nauro/tests/test_generation_lease.py
+          packages/nauro/tests/test_generation_refresh.py
           packages/nauro/tests/test_generation_store.py
           -v --tb=short
 

--- a/packages/nauro/src/nauro/store/generation_authority.py
+++ b/packages/nauro/src/nauro/store/generation_authority.py
@@ -247,17 +247,16 @@ def _active_projection_scope_id(value: str | None) -> str:
     return value
 
 
-def select_project_authority(
+def _select_actor_generation_authority(
     binding: ResolvedProjectBinding,
     *,
     marker_json: str | bytes | None,
     pointer_json: str | bytes | None,
-    active_user_id: str | None = None,
-    active_projection_scope_id: str | None = None,
-) -> ProjectAuthority:
-    """Select flat or generation authority from one validated project binding."""
+    active_user_id: str | None,
+) -> GenerationProjectAuthority:
+    """Select an actor-bound generation without requiring the prior scope to match."""
     if marker_json is None:
-        return FlatProjectAuthority(binding)
+        raise RefreshRequiredError("The project has not selected generation authority.")
     if binding.mode != "cloud":
         raise GenerationControlCorruptError(
             "A local-only project cannot select hosted generation authority."
@@ -280,15 +279,48 @@ def select_project_authority(
         raise GenerationControlCorruptError("The installed pointer belongs to another project.")
     if pointer.store_format_version != marker.store_format_version:
         raise GenerationControlCorruptError("The generation marker and pointer formats differ.")
-
     if current_user_id != pointer.installed_for_user_id:
         raise ReplicaActorMismatchError("The installed replica belongs to another account.")
-
-    current_scope_id = _active_projection_scope_id(active_projection_scope_id)
-    if current_scope_id != pointer.projection_scope_id:
-        raise RefreshRequiredError("The installed replica requires a fresh authorization view.")
-
     return GenerationProjectAuthority(binding=binding, marker=marker, pointer=pointer)
+
+
+def select_generation_refresh_base(
+    binding: ResolvedProjectBinding,
+    *,
+    marker_json: str | bytes | None,
+    pointer_json: str | bytes | None,
+    active_user_id: str | None,
+) -> InstalledGenerationPointer:
+    """Return an actor-bound pointer as a refresh fence, never as read authority."""
+    return _select_actor_generation_authority(
+        binding,
+        marker_json=marker_json,
+        pointer_json=pointer_json,
+        active_user_id=active_user_id,
+    ).pointer
+
+
+def select_project_authority(
+    binding: ResolvedProjectBinding,
+    *,
+    marker_json: str | bytes | None,
+    pointer_json: str | bytes | None,
+    active_user_id: str | None = None,
+    active_projection_scope_id: str | None = None,
+) -> ProjectAuthority:
+    """Select flat or generation authority from one validated project binding."""
+    if marker_json is None:
+        return FlatProjectAuthority(binding)
+    authority = _select_actor_generation_authority(
+        binding,
+        marker_json=marker_json,
+        pointer_json=pointer_json,
+        active_user_id=active_user_id,
+    )
+    current_scope_id = _active_projection_scope_id(active_projection_scope_id)
+    if current_scope_id != authority.pointer.projection_scope_id:
+        raise RefreshRequiredError("The installed replica requires a fresh authorization view.")
+    return authority
 
 
 __all__ = [
@@ -305,5 +337,6 @@ __all__ = [
     "RefreshRequiredError",
     "ReplicaActorMismatchError",
     "projection_identity_from_pointer",
+    "select_generation_refresh_base",
     "select_project_authority",
 ]

--- a/packages/nauro/src/nauro/store/generation_installation.py
+++ b/packages/nauro/src/nauro/store/generation_installation.py
@@ -14,14 +14,12 @@ import pydantic as pyd
 from nauro.store._atomic import atomic_write_bytes
 from nauro.store.generation_authority import (
     GENERATION_CONTROL_SCHEMA_VERSION,
-    FlatProjectAuthority,
     GenerationAuthorityError,
-    GenerationProjectAuthority,
     GenerationProjectionIdentity,
     InstalledGenerationPointer,
     RefreshRequiredError,
     projection_identity_from_pointer,
-    select_project_authority,
+    select_generation_refresh_base,
 )
 from nauro.store.generation_projection import VerifiedGenerationProjection
 from nauro.store.replica_control import (
@@ -36,12 +34,25 @@ from nauro.store.repo_config import generate_ulid
 _LEASE_CREATE_FLAGS = (
     os.O_CREAT | os.O_EXCL | os.O_WRONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_BINARY", 0)
 )
+_NO_ACTIVE_REPLACEMENT = object()
 
 
 class GenerationInstallationError(GenerationAuthorityError):
     """A verified generation could not be installed safely."""
 
     code = "generation_install_failed"
+
+
+class GenerationRefreshError(GenerationAuthorityError):
+    """A generation refresh could not preserve its local base-pointer fence."""
+
+    code = "generation_refresh_failed"
+
+
+class GenerationRefreshConflictError(GenerationRefreshError):
+    """The local generation pointer changed after a refresh was prepared."""
+
+    code = "generation_refresh_conflict"
 
 
 def _installed_at() -> str:
@@ -227,42 +238,39 @@ def _current_pointer(
     marker_json: bytes | None,
     pointer_json: bytes | None,
 ) -> InstalledGenerationPointer | None:
+    if marker_json is None:
+        return None
     try:
-        authority = select_project_authority(
+        return select_generation_refresh_base(
             projection.target.binding,
             marker_json=marker_json,
             pointer_json=pointer_json,
             active_user_id=projection.target.identity.installed_for_user_id,
-            active_projection_scope_id=projection.target.identity.projection_scope_id,
         )
     except RefreshRequiredError:
-        if pointer_json is None:
-            return None
-        try:
-            return InstalledGenerationPointer.model_validate_json(pointer_json)
-        except pyd.ValidationError as exc:
-            raise GenerationInstallationError(
-                "The current generation pointer cannot be revalidated."
-            ) from exc
-    if isinstance(authority, FlatProjectAuthority):
         return None
-    if isinstance(authority, GenerationProjectAuthority):
-        return authority.pointer
-    raise GenerationInstallationError("The current generation authority is unsupported.")
 
 
-def _is_same_or_refuse_replacement(
+def _same_or_validate_replacement(
     current: InstalledGenerationPointer | None,
     target: GenerationProjectionIdentity,
+    expected_current: InstalledGenerationPointer | object,
 ) -> bool:
-    if current is None:
-        return False
-    current_identity = projection_identity_from_pointer(current)
-    if current_identity == target:
-        return True
-    raise GenerationInstallationError(
-        "Replacing an active generation requires a fresh refresh commit."
-    )
+    if current is not None:
+        current_identity = projection_identity_from_pointer(current)
+        if current_identity == target:
+            return True
+    if expected_current is _NO_ACTIVE_REPLACEMENT:
+        if current is None:
+            return False
+        raise GenerationInstallationError(
+            "Replacing an active generation requires a fresh refresh commit."
+        )
+    if current != expected_current:
+        raise GenerationRefreshConflictError(
+            "The local generation changed after this refresh was prepared."
+        )
+    return False
 
 
 def _build_pointer(
@@ -282,12 +290,12 @@ def _build_pointer(
         ) from exc
 
 
-def install_verified_generation(
+def _install_verified_generation(
     projection: VerifiedGenerationProjection,
     *,
+    expected_current: InstalledGenerationPointer | object,
     lock_timeout: float = -1,
 ) -> InstalledGenerationPointer:
-    """Install a verified projection and publish its local pointer last."""
     if type(projection) is not VerifiedGenerationProjection:
         raise GenerationInstallationError("Generation installation requires verified bytes.")
     layout = ReplicaControlLayout(projection.target.binding.store_path)
@@ -304,9 +312,10 @@ def install_verified_generation(
                 snapshot.marker_json,
                 snapshot.pointer_json,
             )
-            same_identity = _is_same_or_refuse_replacement(
+            same_identity = _same_or_validate_replacement(
                 current,
                 projection.target.identity,
+                expected_current,
             )
             root = layout.generation_root(projection.target.identity)
             manifest = layout.generation_manifest(projection.target.identity)
@@ -334,7 +343,37 @@ def install_verified_generation(
         _discard_staging(staging)
 
 
+def install_verified_generation(
+    projection: VerifiedGenerationProjection,
+    *,
+    lock_timeout: float = -1,
+) -> InstalledGenerationPointer:
+    """Install an initial or dormant verified projection and publish its pointer last."""
+    return _install_verified_generation(
+        projection,
+        expected_current=_NO_ACTIVE_REPLACEMENT,
+        lock_timeout=lock_timeout,
+    )
+
+
+def _install_verified_generation_refresh(
+    projection: VerifiedGenerationProjection,
+    expected_current: InstalledGenerationPointer,
+    *,
+    lock_timeout: float = -1,
+) -> InstalledGenerationPointer:
+    if type(expected_current) is not InstalledGenerationPointer:
+        raise GenerationRefreshError("Generation refresh requires a validated base pointer.")
+    return _install_verified_generation(
+        projection,
+        expected_current=expected_current,
+        lock_timeout=lock_timeout,
+    )
+
+
 __all__ = [
     "GenerationInstallationError",
+    "GenerationRefreshConflictError",
+    "GenerationRefreshError",
     "install_verified_generation",
 ]

--- a/packages/nauro/src/nauro/store/generation_refresh.py
+++ b/packages/nauro/src/nauro/store/generation_refresh.py
@@ -1,0 +1,131 @@
+"""Prepared local compare-and-swap commits for verified generation refreshes."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import InitVar, dataclass, field
+
+from nauro.store.generation_authority import (
+    InstalledGenerationPointer,
+    select_generation_refresh_base,
+)
+from nauro.store.generation_installation import (
+    GenerationRefreshConflictError,
+    GenerationRefreshError,
+    _install_verified_generation_refresh,
+)
+from nauro.store.generation_projection import (
+    GenerationProjectionTarget,
+    VerifiedGenerationProjection,
+    verify_generation_projection,
+)
+from nauro.store.replica_control import locked_replica_control_snapshot
+
+_PREPARED_TOKEN = object()
+_VERIFIED_TOKEN = object()
+
+
+@dataclass(frozen=True, eq=False)
+class PreparedGenerationRefresh:
+    """An authenticated target fenced to the exact local pointer seen at entry."""
+
+    target: GenerationProjectionTarget = field(repr=False)
+    base_pointer: InstalledGenerationPointer = field(repr=False)
+    _construction_token: InitVar[object]
+
+    def __post_init__(self, _construction_token: object) -> None:
+        if (
+            _construction_token is not _PREPARED_TOKEN
+            or type(self.target) is not GenerationProjectionTarget
+            or type(self.base_pointer) is not InstalledGenerationPointer
+        ):
+            raise GenerationRefreshError(
+                "Generation refreshes must be prepared from lock-held control state."
+            )
+
+
+@dataclass(frozen=True, eq=False)
+class VerifiedGenerationRefresh:
+    """A prepared refresh bound to its fully verified projection bytes."""
+
+    prepared: PreparedGenerationRefresh = field(repr=False)
+    projection: VerifiedGenerationProjection = field(repr=False)
+    _construction_token: InitVar[object]
+
+    def __post_init__(self, _construction_token: object) -> None:
+        if (
+            _construction_token is not _VERIFIED_TOKEN
+            or type(self.prepared) is not PreparedGenerationRefresh
+            or type(self.projection) is not VerifiedGenerationProjection
+            or self.projection.target != self.prepared.target
+        ):
+            raise GenerationRefreshError(
+                "Verified refresh bytes do not match their prepared target."
+            )
+
+
+def prepare_generation_refresh(
+    target: GenerationProjectionTarget,
+    *,
+    lock_timeout: float = -1,
+) -> PreparedGenerationRefresh:
+    """Bind authenticated server target facts to the current local pointer."""
+    if type(target) is not GenerationProjectionTarget:
+        raise GenerationRefreshError(
+            "Generation refresh preparation requires an authenticated target."
+        )
+    with locked_replica_control_snapshot(
+        target.binding,
+        active_user_id=target.identity.installed_for_user_id,
+        timeout=lock_timeout,
+    ) as snapshot:
+        base_pointer = select_generation_refresh_base(
+            target.binding,
+            marker_json=snapshot.marker_json,
+            pointer_json=snapshot.pointer_json,
+            active_user_id=target.identity.installed_for_user_id,
+        )
+        return PreparedGenerationRefresh(target, base_pointer, _PREPARED_TOKEN)
+
+
+def verify_generation_refresh(
+    prepared: PreparedGenerationRefresh,
+    *,
+    manifest_json: bytes,
+    artifacts: Sequence[tuple[str, bytes]],
+) -> VerifiedGenerationRefresh:
+    """Verify downloaded projection bytes against one prepared refresh target."""
+    if type(prepared) is not PreparedGenerationRefresh:
+        raise GenerationRefreshError("Generation refresh verification requires a prepared target.")
+    projection = verify_generation_projection(
+        prepared.target,
+        manifest_json=manifest_json,
+        artifacts=artifacts,
+    )
+    return VerifiedGenerationRefresh(prepared, projection, _VERIFIED_TOKEN)
+
+
+def install_generation_refresh(
+    refresh: VerifiedGenerationRefresh,
+    *,
+    lock_timeout: float = -1,
+) -> InstalledGenerationPointer:
+    """Commit verified bytes only if the prepared local pointer is still current."""
+    if type(refresh) is not VerifiedGenerationRefresh:
+        raise GenerationRefreshError("Generation refresh installation requires verified bytes.")
+    return _install_verified_generation_refresh(
+        refresh.projection,
+        refresh.prepared.base_pointer,
+        lock_timeout=lock_timeout,
+    )
+
+
+__all__ = [
+    "GenerationRefreshConflictError",
+    "GenerationRefreshError",
+    "PreparedGenerationRefresh",
+    "VerifiedGenerationRefresh",
+    "install_generation_refresh",
+    "prepare_generation_refresh",
+    "verify_generation_refresh",
+]

--- a/packages/nauro/tests/test_generation_refresh.py
+++ b/packages/nauro/tests/test_generation_refresh.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from nauro.store.generation_authority import (
+    GenerationProjectionIdentity,
+    InstalledGenerationPointer,
+    RefreshRequiredError,
+)
+from nauro.store.generation_installation import install_verified_generation
+from nauro.store.generation_projection import (
+    GenerationProjectionTarget,
+    VerifiedGenerationProjection,
+    verify_generation_projection,
+)
+from nauro.store.generation_refresh import (
+    GenerationRefreshConflictError,
+    GenerationRefreshError,
+    PreparedGenerationRefresh,
+    VerifiedGenerationRefresh,
+    install_generation_refresh,
+    prepare_generation_refresh,
+    verify_generation_refresh,
+)
+from nauro.store.generation_store import leased_generation_store
+from nauro.store.replica_control import ReplicaControlLayout
+from nauro.store.resolution import ResolvedProjectBinding
+
+PROJECT_ID = "01KQ6AZGNA0B3QBF67NBXP3S45"
+GENERATION_ONE = "01K11111111111111111111111"
+GENERATION_TWO = "01K22222222222222222222222"
+GENERATION_THREE = "01K33333333333333333333333"
+USER_ID = "01K44444444444444444444444"
+SCOPE_ONE = "a" * 64
+SCOPE_TWO = "b" * 64
+COMMITTED_ONE = "2026-09-02T01:00:00.000000Z"
+COMMITTED_TWO = "2026-09-02T02:00:00.000000Z"
+COMMITTED_THREE = "2026-09-02T00:00:00.000000Z"
+
+
+def _binding(tmp_path: Path) -> ResolvedProjectBinding:
+    store = tmp_path / PROJECT_ID
+    store.mkdir()
+    return ResolvedProjectBinding(
+        store_path=store,
+        project_id=PROJECT_ID,
+        display_name="Nauro",
+        mode="cloud",
+        server_url="https://mcp.nauro.ai",
+    )
+
+
+def _projection(
+    binding: ResolvedProjectBinding,
+    *,
+    generation_id: str,
+    projection_scope_id: str,
+    committed_at: str,
+    project_body: bytes,
+) -> VerifiedGenerationProjection:
+    artifacts = {
+        "project.md": project_body,
+        "decisions/001-first.md": b"# 1 - First\n",
+    }
+    manifest_json = json.dumps(
+        {
+            "project_id": PROJECT_ID,
+            "store_format_version": 1,
+            "generation_id": generation_id,
+            "projection_class": "contributor_plus",
+            "projection_scope_id": projection_scope_id,
+            "artifacts": {
+                path: hashlib.sha256(content).hexdigest() for path, content in artifacts.items()
+            },
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+    identity = GenerationProjectionIdentity(
+        project_id=PROJECT_ID,
+        store_format_version=1,
+        generation_id=generation_id,
+        manifest_digest=hashlib.sha256(manifest_json).hexdigest(),
+        committed_at=committed_at,
+        installed_for_user_id=USER_ID,
+        projection_class="contributor_plus",
+        projection_scope_id=projection_scope_id,
+    )
+    return verify_generation_projection(
+        GenerationProjectionTarget(binding=binding, identity=identity),
+        manifest_json=manifest_json,
+        artifacts=list(artifacts.items()),
+    )
+
+
+def _initial_projection(binding: ResolvedProjectBinding) -> VerifiedGenerationProjection:
+    return _projection(
+        binding,
+        generation_id=GENERATION_ONE,
+        projection_scope_id=SCOPE_ONE,
+        committed_at=COMMITTED_ONE,
+        project_body=b"# Initial\n",
+    )
+
+
+def _activate(projection: VerifiedGenerationProjection) -> ReplicaControlLayout:
+    install_verified_generation(projection)
+    layout = ReplicaControlLayout(projection.target.binding.store_path)
+    layout.authority_marker.parent.mkdir(parents=True, exist_ok=True)
+    layout.authority_marker.write_bytes(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "authority": "generation",
+                "project_id": PROJECT_ID,
+                "store_format_version": 1,
+            }
+        ).encode()
+    )
+    return layout
+
+
+def _verified_refresh(
+    prepared: PreparedGenerationRefresh,
+    projection: VerifiedGenerationProjection,
+) -> VerifiedGenerationRefresh:
+    return verify_generation_refresh(
+        prepared,
+        manifest_json=projection.manifest_json,
+        artifacts=[(artifact.path, artifact.content) for artifact in projection.artifacts],
+    )
+
+
+def _installed_pointer(layout: ReplicaControlLayout) -> InstalledGenerationPointer:
+    return InstalledGenerationPointer.model_validate_json(
+        layout.actor_pointer(USER_ID).read_bytes()
+    )
+
+
+def test_refresh_replaces_the_exact_prepared_base(tmp_path: Path) -> None:
+    binding = _binding(tmp_path)
+    initial = _initial_projection(binding)
+    layout = _activate(initial)
+    target = _projection(
+        binding,
+        generation_id=GENERATION_TWO,
+        projection_scope_id=SCOPE_ONE,
+        committed_at=COMMITTED_TWO,
+        project_body=b"# Refreshed\n",
+    )
+
+    prepared = prepare_generation_refresh(target.target)
+    installed = install_generation_refresh(_verified_refresh(prepared, target))
+
+    assert installed.generation_id == GENERATION_TWO
+    assert _installed_pointer(layout) == installed
+    with leased_generation_store(
+        binding,
+        active_user_id=USER_ID,
+        active_projection_scope_id=SCOPE_ONE,
+    ) as store:
+        assert store.read_file("project.md") == "# Refreshed\n"
+
+
+def test_competing_refresh_cannot_replace_a_changed_base(tmp_path: Path) -> None:
+    binding = _binding(tmp_path)
+    initial = _initial_projection(binding)
+    layout = _activate(initial)
+    second = _projection(
+        binding,
+        generation_id=GENERATION_TWO,
+        projection_scope_id=SCOPE_ONE,
+        committed_at=COMMITTED_TWO,
+        project_body=b"# Second\n",
+    )
+    third = _projection(
+        binding,
+        generation_id=GENERATION_THREE,
+        projection_scope_id=SCOPE_ONE,
+        committed_at=COMMITTED_THREE,
+        project_body=b"# Third\n",
+    )
+    second_refresh = _verified_refresh(prepare_generation_refresh(second.target), second)
+    third_refresh = _verified_refresh(prepare_generation_refresh(third.target), third)
+
+    installed = install_generation_refresh(third_refresh)
+    with pytest.raises(GenerationRefreshConflictError) as raised:
+        install_generation_refresh(second_refresh)
+
+    assert raised.value.code == "generation_refresh_conflict"
+    assert isinstance(raised.value, GenerationRefreshError)
+    assert _installed_pointer(layout) == installed
+    assert installed.generation_id == GENERATION_THREE
+    assert not layout.generation_root(second.target.identity).exists()
+
+
+def test_refresh_fence_rejects_pointer_aba(tmp_path: Path) -> None:
+    binding = _binding(tmp_path)
+    initial = _initial_projection(binding)
+    layout = _activate(initial)
+    second = _projection(
+        binding,
+        generation_id=GENERATION_TWO,
+        projection_scope_id=SCOPE_ONE,
+        committed_at=COMMITTED_TWO,
+        project_body=b"# Second\n",
+    )
+    third = _projection(
+        binding,
+        generation_id=GENERATION_THREE,
+        projection_scope_id=SCOPE_ONE,
+        committed_at=COMMITTED_THREE,
+        project_body=b"# Third\n",
+    )
+    stale = _verified_refresh(prepare_generation_refresh(second.target), second)
+
+    install_generation_refresh(_verified_refresh(prepare_generation_refresh(third.target), third))
+    returned = install_generation_refresh(
+        _verified_refresh(prepare_generation_refresh(initial.target), initial)
+    )
+
+    assert returned.generation_id == GENERATION_ONE
+    assert returned.installed_state_id != stale.prepared.base_pointer.installed_state_id
+    with pytest.raises(GenerationRefreshConflictError):
+        install_generation_refresh(stale)
+    assert _installed_pointer(layout) == returned
+
+
+def test_same_target_refreshes_converge_idempotently(tmp_path: Path) -> None:
+    binding = _binding(tmp_path)
+    initial = _initial_projection(binding)
+    _activate(initial)
+    target = _projection(
+        binding,
+        generation_id=GENERATION_TWO,
+        projection_scope_id=SCOPE_ONE,
+        committed_at=COMMITTED_TWO,
+        project_body=b"# Refreshed\n",
+    )
+    first = _verified_refresh(prepare_generation_refresh(target.target), target)
+    second = _verified_refresh(prepare_generation_refresh(target.target), target)
+
+    first_pointer = install_generation_refresh(first)
+    second_pointer = install_generation_refresh(second)
+
+    assert second_pointer == first_pointer
+
+
+def test_scope_refresh_does_not_wait_for_old_generation_readers(tmp_path: Path) -> None:
+    binding = _binding(tmp_path)
+    initial = _initial_projection(binding)
+    _activate(initial)
+    target = _projection(
+        binding,
+        generation_id=GENERATION_TWO,
+        projection_scope_id=SCOPE_TWO,
+        committed_at=COMMITTED_TWO,
+        project_body=b"# New scope\n",
+    )
+    refresh = _verified_refresh(prepare_generation_refresh(target.target), target)
+
+    with leased_generation_store(
+        binding,
+        active_user_id=USER_ID,
+        active_projection_scope_id=SCOPE_ONE,
+    ) as old_store:
+        installed = install_generation_refresh(refresh)
+        assert installed.projection_scope_id == SCOPE_TWO
+        assert old_store.read_file("project.md") == "# Initial\n"
+
+    with leased_generation_store(
+        binding,
+        active_user_id=USER_ID,
+        active_projection_scope_id=SCOPE_TWO,
+    ) as new_store:
+        assert new_store.read_file("project.md") == "# New scope\n"
+
+
+def test_refresh_capabilities_cannot_be_constructed_directly(tmp_path: Path) -> None:
+    binding = _binding(tmp_path)
+    initial = _initial_projection(binding)
+    layout = _activate(initial)
+    target = _projection(
+        binding,
+        generation_id=GENERATION_TWO,
+        projection_scope_id=SCOPE_ONE,
+        committed_at=COMMITTED_TWO,
+        project_body=b"# Refreshed\n",
+    )
+    base = _installed_pointer(layout)
+
+    with pytest.raises(GenerationRefreshError, match="lock-held"):
+        PreparedGenerationRefresh(target.target, base, object())
+
+    prepared = prepare_generation_refresh(target.target)
+    with pytest.raises(GenerationRefreshError, match="do not match"):
+        VerifiedGenerationRefresh(prepared, target, object())
+
+
+def test_refresh_requires_active_generation_authority(tmp_path: Path) -> None:
+    binding = _binding(tmp_path)
+    initial = _initial_projection(binding)
+    install_verified_generation(initial)
+    target = _projection(
+        binding,
+        generation_id=GENERATION_TWO,
+        projection_scope_id=SCOPE_ONE,
+        committed_at=COMMITTED_TWO,
+        project_body=b"# Refreshed\n",
+    )
+
+    with pytest.raises(RefreshRequiredError, match="has not selected"):
+        prepare_generation_refresh(target.target)


### PR DESCRIPTION
## Why

Two verified refreshes can finish out of order. Without a local commit fence, an older refresh could replace a generation installed by a newer refresh. Generation IDs and timestamps do not provide a safe ordering rule.

## What changed

- Prepare each refresh from the exact actor pointer read under the replica-control lock.
- Bind verified projection bytes to that prepared target.
- Replace the pointer only when the full prepared base still matches, including `installed_state_id`.
- Preserve idempotent convergence when another refresh already installed the exact target.
- Permit an authorization-scope refresh while existing readers keep their old generation lease.
- Run the refresh tests in the focused Linux, macOS, and Windows job.

## Test plan

- Focused generation suite: 181 passed.
- Full `packages/nauro/tests` suite: 2,979 passed, 10 skipped.
- Ruff, Mypy, docstring budget, single-source guard, and workflow YAML validation passed.

## Risk / what to review

- A stale base conflicts before the final root, manifest, lease, or pointer is published.
- Exact base equality includes the local install-state ID, which closes pointer ABA.
- The actor-only selector returns a refresh fence. It does not grant read authority without an exact active scope.

## Deferred

Network pagination and download limits, replica status, cleanup and tombstones, migration orchestration, runtime routing, and authority activation remain out of scope.
