### PR TITLE
Assess legacy migration against verified generations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,7 @@ jobs:
           packages/nauro/tests/test_generation_installation.py
           packages/nauro/tests/test_generation_lease.py
           packages/nauro/tests/test_generation_cleanup.py
+          packages/nauro/tests/test_generation_migration_assessment.py
           packages/nauro/tests/test_generation_refresh.py
           packages/nauro/tests/test_generation_store.py
           -v --tb=short

--- a/packages/nauro/src/nauro/store/generation_migration_assessment.py
+++ b/packages/nauro/src/nauro/store/generation_migration_assessment.py
@@ -20,6 +20,7 @@ from nauro.store.replica_control import (
     _refuse_symlinks,
     locked_replica_control_snapshot,
 )
+from nauro.sync.merge import SPOOL_DIR_PREFIX
 
 _READ_FLAGS = (
     os.O_RDONLY
@@ -188,7 +189,7 @@ def _protected_inventory(
     for entry in root_entries:
         if is_protected_generation_member(entry.name):
             files.append(_stamp_file(store_path, entry))
-        elif is_tmp_sibling(entry.name):
+        elif is_tmp_sibling(entry.name) or entry.name.startswith(SPOOL_DIR_PREFIX):
             pending.append(entry.name)
 
     for directory in _PROTECTED_DIRECTORIES:

--- a/packages/nauro/src/nauro/store/generation_migration_assessment.py
+++ b/packages/nauro/src/nauro/store/generation_migration_assessment.py
@@ -1,0 +1,335 @@
+"""Read-only assessment of a legacy flat store against a verified generation."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import stat
+from dataclasses import InitVar, dataclass, field
+from pathlib import Path
+
+from nauro_core.protected_generation_membership import is_protected_generation_member
+
+from nauro.store._atomic import is_tmp_sibling
+from nauro.store.generation_authority import GenerationAuthorityError
+from nauro.store.generation_projection import VerifiedGenerationProjection
+from nauro.store.replica_control import (
+    ReplicaControlReadError,
+    _is_link_like,
+    _refuse_symlinks,
+    locked_replica_control_snapshot,
+)
+
+_READ_FLAGS = (
+    os.O_RDONLY
+    | getattr(os, "O_CLOEXEC", 0)
+    | getattr(os, "O_BINARY", 0)
+    | getattr(os, "O_NONBLOCK", 0)
+    | getattr(os, "O_NOFOLLOW", 0)
+)
+_READ_CHUNK_BYTES = 1024 * 1024
+_PROTECTED_DIRECTORIES = ("context", "decisions")
+_SNAPSHOTS_DIRECTORY = "snapshots"
+_ASSESSMENT_TOKEN = object()
+
+
+class LegacyMigrationAssessmentError(GenerationAuthorityError):
+    """A legacy store could not be assessed without ambiguous local evidence."""
+
+    code = "legacy_migration_assessment_failed"
+
+
+@dataclass(frozen=True, order=True)
+class LegacyFileStamp:
+    """One safely read legacy file represented by path, size, and SHA-256."""
+
+    path: str
+    size: int
+    sha256: str
+
+
+@dataclass(frozen=True, eq=False)
+class LegacyMigrationAssessment:
+    """One verified projection compared with one read-only legacy inventory."""
+
+    projection: VerifiedGenerationProjection = field(repr=False)
+    protected_files: tuple[LegacyFileStamp, ...]
+    snapshot_files: tuple[LegacyFileStamp, ...]
+    identical_paths: tuple[str, ...]
+    divergent_paths: tuple[str, ...]
+    local_only_paths: tuple[str, ...]
+    server_only_paths: tuple[str, ...]
+    pending_paths: tuple[str, ...]
+    unsupported_paths: tuple[str, ...]
+    capture_digest: str
+    _construction_token: InitVar[object]
+
+    def __post_init__(self, _construction_token: object) -> None:
+        if (
+            _construction_token is not _ASSESSMENT_TOKEN
+            or type(self.projection) is not VerifiedGenerationProjection
+        ):
+            raise LegacyMigrationAssessmentError(
+                "Legacy migration assessments must come from a local store scan."
+            )
+
+    @property
+    def ready_for_backup(self) -> bool:
+        return not self.pending_paths and not self.unsupported_paths
+
+    @property
+    def nonidentical_local_paths(self) -> tuple[str, ...]:
+        return tuple(sorted((*self.divergent_paths, *self.local_only_paths)))
+
+
+def _container_entries(path: Path, *, required: bool, label: str) -> tuple[Path, ...]:
+    try:
+        observed = path.lstat()
+    except FileNotFoundError:
+        if required:
+            raise LegacyMigrationAssessmentError(f"The legacy {label} is missing.") from None
+        return ()
+    except OSError as exc:
+        raise LegacyMigrationAssessmentError(f"The legacy {label} is unavailable.") from exc
+    try:
+        unsafe = _is_link_like(path)
+    except ReplicaControlReadError as exc:
+        raise LegacyMigrationAssessmentError(f"The legacy {label} is unsafe.") from exc
+    if unsafe or not stat.S_ISDIR(observed.st_mode):
+        raise LegacyMigrationAssessmentError(f"The legacy {label} is not a regular directory.")
+    try:
+        return tuple(sorted(path.iterdir(), key=lambda entry: entry.name))
+    except OSError as exc:
+        raise LegacyMigrationAssessmentError(f"The legacy {label} cannot be enumerated.") from exc
+
+
+def _stat_signature(observed: os.stat_result) -> tuple[int, int, int, int, int]:
+    return (
+        observed.st_dev,
+        observed.st_ino,
+        observed.st_size,
+        observed.st_mtime_ns,
+        observed.st_ctime_ns,
+    )
+
+
+def _stamp_file(store_path: Path, path: Path) -> LegacyFileStamp:
+    try:
+        relative = path.relative_to(store_path).as_posix()
+        _refuse_symlinks(store_path, (path,))
+        observed = path.lstat()
+        unsafe = _is_link_like(path)
+    except (OSError, ValueError, ReplicaControlReadError) as exc:
+        raise LegacyMigrationAssessmentError("A legacy file path is unsafe.") from exc
+    if unsafe or not stat.S_ISREG(observed.st_mode):
+        raise LegacyMigrationAssessmentError(f"The legacy file is not regular: {relative}.")
+
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(path, _READ_FLAGS)
+        opened = os.fstat(descriptor)
+        if not stat.S_ISREG(opened.st_mode) or _stat_signature(opened) != _stat_signature(observed):
+            raise LegacyMigrationAssessmentError(
+                f"The legacy file changed during open: {relative}."
+            )
+        digest = hashlib.sha256()
+        total = 0
+        with os.fdopen(descriptor, "rb", closefd=True) as handle:
+            descriptor = None
+            while chunk := handle.read(_READ_CHUNK_BYTES):
+                digest.update(chunk)
+                total += len(chunk)
+            finished = os.fstat(handle.fileno())
+        if total != opened.st_size or _stat_signature(finished) != _stat_signature(opened):
+            raise LegacyMigrationAssessmentError(
+                f"The legacy file changed during read: {relative}."
+            )
+        rebound = path.lstat()
+        if _is_link_like(path) or _stat_signature(rebound) != _stat_signature(opened):
+            raise LegacyMigrationAssessmentError(
+                f"The legacy file changed during read: {relative}."
+            )
+    except LegacyMigrationAssessmentError:
+        raise
+    except OSError as exc:
+        raise LegacyMigrationAssessmentError(f"The legacy file is unreadable: {relative}.") from exc
+    finally:
+        if descriptor is not None:
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+    return LegacyFileStamp(relative, total, digest.hexdigest())
+
+
+def _entry_kind(path: Path) -> tuple[bool, bool]:
+    try:
+        observed = path.lstat()
+        return _is_link_like(path), stat.S_ISREG(observed.st_mode)
+    except (OSError, ReplicaControlReadError) as exc:
+        raise LegacyMigrationAssessmentError("A legacy inventory entry is unavailable.") from exc
+
+
+def _is_persistent_lock(relative: str, name: str) -> bool:
+    if name == ".lock":
+        return True
+    suffix = ".lock"
+    return name.endswith(suffix) and is_protected_generation_member(relative[: -len(suffix)])
+
+
+def _protected_inventory(
+    store_path: Path,
+    root_entries: tuple[Path, ...],
+) -> tuple[tuple[LegacyFileStamp, ...], tuple[str, ...], tuple[str, ...]]:
+    files: list[LegacyFileStamp] = []
+    pending: list[str] = []
+    unsupported: list[str] = []
+    for entry in root_entries:
+        if is_protected_generation_member(entry.name):
+            files.append(_stamp_file(store_path, entry))
+        elif is_tmp_sibling(entry.name):
+            pending.append(entry.name)
+
+    for directory in _PROTECTED_DIRECTORIES:
+        container = store_path / directory
+        for entry in _container_entries(container, required=False, label=f"{directory} directory"):
+            relative = f"{directory}/{entry.name}"
+            unsafe, regular = _entry_kind(entry)
+            if unsafe:
+                raise LegacyMigrationAssessmentError(
+                    f"The legacy {directory} directory contains a link: {relative}."
+                )
+            if is_protected_generation_member(relative):
+                files.append(_stamp_file(store_path, entry))
+            elif is_tmp_sibling(entry.name):
+                pending.append(relative)
+            elif _is_persistent_lock(relative, entry.name) and regular:
+                continue
+            else:
+                unsupported.append(relative)
+    return tuple(sorted(files)), tuple(sorted(pending)), tuple(sorted(unsupported))
+
+
+def _snapshot_inventory(
+    store_path: Path,
+) -> tuple[tuple[LegacyFileStamp, ...], tuple[str, ...], tuple[str, ...]]:
+    files: list[LegacyFileStamp] = []
+    pending: list[str] = []
+    unsupported: list[str] = []
+    snapshots = store_path / _SNAPSHOTS_DIRECTORY
+    for entry in _container_entries(snapshots, required=False, label="snapshot directory"):
+        relative = f"{_SNAPSHOTS_DIRECTORY}/{entry.name}"
+        unsafe, regular = _entry_kind(entry)
+        if unsafe:
+            raise LegacyMigrationAssessmentError(
+                f"The legacy snapshot directory contains a link: {relative}."
+            )
+        if entry.name == ".lock" and regular:
+            continue
+        if is_tmp_sibling(entry.name):
+            pending.append(relative)
+        elif regular:
+            files.append(_stamp_file(store_path, entry))
+        else:
+            unsupported.append(relative)
+    return tuple(sorted(files)), tuple(sorted(pending)), tuple(sorted(unsupported))
+
+
+def _capture_digest(
+    projection: VerifiedGenerationProjection,
+    protected: tuple[LegacyFileStamp, ...],
+    snapshots: tuple[LegacyFileStamp, ...],
+    pending: tuple[str, ...],
+    unsupported: tuple[str, ...],
+) -> str:
+    def stamp_payload(stamp: LegacyFileStamp) -> dict[str, str | int]:
+        return {
+            "path": stamp.path,
+            "size": stamp.size,
+            "sha256": stamp.sha256,
+        }
+
+    payload = {
+        "schema_version": 1,
+        "projection": projection.target.identity.model_dump(),
+        "protected": [stamp_payload(stamp) for stamp in protected],
+        "snapshots": [stamp_payload(stamp) for stamp in snapshots],
+        "pending": pending,
+        "unsupported": unsupported,
+    }
+    canonical = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def assess_legacy_migration(
+    projection: VerifiedGenerationProjection,
+    *,
+    lock_timeout: float = -1,
+) -> LegacyMigrationAssessment:
+    """Compare one pre-epoch flat store with verified server projection bytes."""
+    if type(projection) is not VerifiedGenerationProjection:
+        raise LegacyMigrationAssessmentError(
+            "Legacy migration assessment requires a verified projection."
+        )
+    binding = projection.target.binding
+    with locked_replica_control_snapshot(
+        binding,
+        active_user_id=projection.target.identity.installed_for_user_id,
+        timeout=lock_timeout,
+    ) as control:
+        if control.marker_json is not None:
+            raise LegacyMigrationAssessmentError(
+                "Legacy migration assessment requires absent generation authority."
+            )
+        root_entries = _container_entries(binding.store_path, required=True, label="store")
+        protected, protected_pending, protected_unsupported = _protected_inventory(
+            binding.store_path,
+            root_entries,
+        )
+        snapshots, snapshot_pending, snapshot_unsupported = _snapshot_inventory(binding.store_path)
+
+    local_by_path = {stamp.path: stamp for stamp in protected}
+    server_by_path = {artifact.path: artifact.digest for artifact in projection.artifacts}
+    shared = set(local_by_path) & set(server_by_path)
+    identical = tuple(
+        sorted(path for path in shared if local_by_path[path].sha256 == server_by_path[path])
+    )
+    divergent = tuple(sorted(shared - set(identical)))
+    local_only = tuple(sorted(set(local_by_path) - set(server_by_path)))
+    server_only = tuple(sorted(set(server_by_path) - set(local_by_path)))
+    pending = tuple(sorted((*protected_pending, *snapshot_pending)))
+    unsupported = tuple(sorted((*protected_unsupported, *snapshot_unsupported)))
+    capture_digest = _capture_digest(
+        projection,
+        protected,
+        snapshots,
+        pending,
+        unsupported,
+    )
+    return LegacyMigrationAssessment(
+        projection=projection,
+        protected_files=protected,
+        snapshot_files=snapshots,
+        identical_paths=identical,
+        divergent_paths=divergent,
+        local_only_paths=local_only,
+        server_only_paths=server_only,
+        pending_paths=pending,
+        unsupported_paths=unsupported,
+        capture_digest=capture_digest,
+        _construction_token=_ASSESSMENT_TOKEN,
+    )
+
+
+__all__ = [
+    "LegacyFileStamp",
+    "LegacyMigrationAssessment",
+    "LegacyMigrationAssessmentError",
+    "assess_legacy_migration",
+]

--- a/packages/nauro/tests/test_generation_migration_assessment.py
+++ b/packages/nauro/tests/test_generation_migration_assessment.py
@@ -137,6 +137,7 @@ def test_assessment_surfaces_pending_and_unsupported_entries(tmp_path: Path) -> 
     store = binding.store_path
     _write(store, "project.md", b"# Project\n")
     _write(store, ".project.md.0123456789abcdef.tmp", b"pending")
+    (store / ".pull-spool-interrupted").mkdir()
     _write(store, "decisions/.002-two.md.0123456789abcdef.tmp", b"pending")
     _write(store, "decisions/bad.txt", b"unsupported")
     _write(store, "context/bad.txt", b"unsupported")
@@ -148,6 +149,7 @@ def test_assessment_surfaces_pending_and_unsupported_entries(tmp_path: Path) -> 
 
     assert assessment.pending_paths == (
         ".project.md.0123456789abcdef.tmp",
+        ".pull-spool-interrupted",
         "decisions/.002-two.md.0123456789abcdef.tmp",
         "snapshots/.snapshot.json.0123456789abcdef.tmp",
     )

--- a/packages/nauro/tests/test_generation_migration_assessment.py
+++ b/packages/nauro/tests/test_generation_migration_assessment.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from nauro.store.generation_authority import GenerationProjectionIdentity
+from nauro.store.generation_migration_assessment import (
+    LegacyMigrationAssessment,
+    LegacyMigrationAssessmentError,
+    assess_legacy_migration,
+)
+from nauro.store.generation_projection import (
+    GenerationProjectionTarget,
+    VerifiedGenerationProjection,
+    verify_generation_projection,
+)
+from nauro.store.resolution import ResolvedProjectBinding
+
+PROJECT_ID = "01KQ6AZGNA0B3QBF67NBXP3S45"
+GENERATION_ID = "01K11111111111111111111111"
+USER_ID = "01K33333333333333333333333"
+PROJECTION_SCOPE_ID = "a" * 64
+
+
+def _binding(tmp_path: Path) -> ResolvedProjectBinding:
+    store = tmp_path / PROJECT_ID
+    store.mkdir()
+    return ResolvedProjectBinding(
+        store_path=store,
+        project_id=PROJECT_ID,
+        display_name="Nauro",
+        mode="cloud",
+        server_url="https://mcp.nauro.ai",
+    )
+
+
+def _projection(
+    binding: ResolvedProjectBinding,
+    artifacts: dict[str, bytes],
+) -> VerifiedGenerationProjection:
+    manifest_json = json.dumps(
+        {
+            "project_id": PROJECT_ID,
+            "store_format_version": 1,
+            "generation_id": GENERATION_ID,
+            "projection_class": "contributor_plus",
+            "projection_scope_id": PROJECTION_SCOPE_ID,
+            "artifacts": {
+                path: hashlib.sha256(content).hexdigest() for path, content in artifacts.items()
+            },
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+    identity = GenerationProjectionIdentity(
+        project_id=PROJECT_ID,
+        store_format_version=1,
+        generation_id=GENERATION_ID,
+        manifest_digest=hashlib.sha256(manifest_json).hexdigest(),
+        committed_at="2026-09-02T01:00:00.000000Z",
+        installed_for_user_id=USER_ID,
+        projection_class="contributor_plus",
+        projection_scope_id=PROJECTION_SCOPE_ID,
+    )
+    return verify_generation_projection(
+        GenerationProjectionTarget(binding=binding, identity=identity),
+        manifest_json=manifest_json,
+        artifacts=list(artifacts.items()),
+    )
+
+
+def _write(store: Path, relative: str, content: bytes) -> None:
+    path = store / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+
+
+def test_assessment_classifies_protected_paths_and_stamps_snapshots(tmp_path: Path) -> None:
+    binding = _binding(tmp_path)
+    store = binding.store_path
+    local = {
+        "project.md": b"# Project\n",
+        "state_current.md": b"# Local state\n",
+        "stack.md": b"# Local stack\n",
+        "decisions/001-one.md": b"# D1: One\n",
+        "context/auth-cutover-2.md": b"# Brief\n",
+    }
+    for path, content in local.items():
+        _write(store, path, content)
+    _write(store, "project.md.lock", b"")
+    _write(store, "decisions/.lock", b"")
+    _write(store, "decisions/001-one.md.lock", b"")
+    _write(store, "context/.lock", b"")
+    _write(store, "context/auth-cutover-2.md.lock", b"")
+    snapshot = b'{"captured":true}\n'
+    _write(store, "snapshots/2026-09-02.json", snapshot)
+    _write(store, "snapshots/.lock", b"")
+    projection = _projection(
+        binding,
+        {
+            "project.md": local["project.md"],
+            "state_current.md": b"# Server state\n",
+            "open-questions.md": b"# Questions\n",
+            "decisions/001-one.md": local["decisions/001-one.md"],
+        },
+    )
+
+    assessment = assess_legacy_migration(projection)
+
+    assert assessment.identical_paths == ("decisions/001-one.md", "project.md")
+    assert assessment.divergent_paths == ("state_current.md",)
+    assert assessment.local_only_paths == ("context/auth-cutover-2.md", "stack.md")
+    assert assessment.server_only_paths == ("open-questions.md",)
+    assert assessment.nonidentical_local_paths == (
+        "context/auth-cutover-2.md",
+        "stack.md",
+        "state_current.md",
+    )
+    assert assessment.pending_paths == ()
+    assert assessment.unsupported_paths == ()
+    assert assessment.ready_for_backup is True
+    assert tuple(stamp.path for stamp in assessment.protected_files) == tuple(sorted(local))
+    assert assessment.snapshot_files[0].path == "snapshots/2026-09-02.json"
+    assert assessment.snapshot_files[0].size == len(snapshot)
+    assert assessment.snapshot_files[0].sha256 == hashlib.sha256(snapshot).hexdigest()
+    assert len(assessment.capture_digest) == 64
+    assert not (store / ".replica").exists()
+    assert {path: (store / path).read_bytes() for path in local} == local
+
+
+def test_assessment_surfaces_pending_and_unsupported_entries(tmp_path: Path) -> None:
+    binding = _binding(tmp_path)
+    store = binding.store_path
+    _write(store, "project.md", b"# Project\n")
+    _write(store, ".project.md.0123456789abcdef.tmp", b"pending")
+    _write(store, "decisions/.002-two.md.0123456789abcdef.tmp", b"pending")
+    _write(store, "decisions/bad.txt", b"unsupported")
+    _write(store, "context/bad.txt", b"unsupported")
+    _write(store, "snapshots/.snapshot.json.0123456789abcdef.tmp", b"pending")
+    (store / "snapshots" / "nested").mkdir()
+    projection = _projection(binding, {"project.md": b"# Project\n"})
+
+    assessment = assess_legacy_migration(projection)
+
+    assert assessment.pending_paths == (
+        ".project.md.0123456789abcdef.tmp",
+        "decisions/.002-two.md.0123456789abcdef.tmp",
+        "snapshots/.snapshot.json.0123456789abcdef.tmp",
+    )
+    assert assessment.unsupported_paths == (
+        "context/bad.txt",
+        "decisions/bad.txt",
+        "snapshots/nested",
+    )
+    assert assessment.ready_for_backup is False
+
+
+def test_assessment_refuses_linked_protected_file_without_reading_outside(
+    tmp_path: Path,
+) -> None:
+    binding = _binding(tmp_path)
+    outside = tmp_path / "outside.md"
+    outside.write_bytes(b"retain")
+    linked = binding.store_path / "project.md"
+    try:
+        linked.symlink_to(outside)
+    except OSError:
+        pytest.skip("platform does not permit test symlinks")
+    projection = _projection(binding, {"project.md": b"retain"})
+
+    with pytest.raises(LegacyMigrationAssessmentError) as raised:
+        assess_legacy_migration(projection)
+
+    assert raised.value.code == "legacy_migration_assessment_failed"
+    assert outside.read_bytes() == b"retain"
+
+
+def test_assessment_refuses_generation_marker(tmp_path: Path) -> None:
+    binding = _binding(tmp_path)
+    _write(binding.store_path, "project.md", b"# Project\n")
+    _write(binding.store_path, ".replica/authority.json", b"{}")
+    projection = _projection(binding, {"project.md": b"# Project\n"})
+
+    with pytest.raises(
+        LegacyMigrationAssessmentError,
+        match="requires absent generation authority",
+    ) as raised:
+        assess_legacy_migration(projection)
+
+    assert raised.value.code == "legacy_migration_assessment_failed"
+
+
+def test_assessment_capture_is_repeatable_and_changes_with_legacy_bytes(tmp_path: Path) -> None:
+    binding = _binding(tmp_path)
+    project = binding.store_path / "project.md"
+    project.write_bytes(b"# Project\n")
+    projection = _projection(binding, {"project.md": b"# Project\n"})
+
+    first = assess_legacy_migration(projection)
+    second = assess_legacy_migration(projection)
+    project.write_bytes(b"# Changed\n")
+    changed = assess_legacy_migration(projection)
+
+    assert second.capture_digest == first.capture_digest
+    assert changed.capture_digest != first.capture_digest
+    assert changed.divergent_paths == ("project.md",)
+
+
+def test_assessment_detects_atomic_replacement_during_file_read(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    binding = _binding(tmp_path)
+    project = binding.store_path / "project.md"
+    project.write_bytes(b"# Project\n")
+    projection = _projection(binding, {"project.md": b"# Project\n"})
+    original_lstat = Path.lstat
+    calls = 0
+
+    def replace_before_rebound(path: Path) -> os.stat_result:
+        nonlocal calls
+        if path == project:
+            calls += 1
+            if calls == 4:
+                replacement = project.with_suffix(".replacement")
+                replacement.write_bytes(b"# Changed\n")
+                replacement.replace(project)
+        return original_lstat(path)
+
+    monkeypatch.setattr(Path, "lstat", replace_before_rebound)
+
+    with pytest.raises(LegacyMigrationAssessmentError, match="changed during read"):
+        assess_legacy_migration(projection)
+
+
+def test_assessment_cannot_be_constructed_without_scan(tmp_path: Path) -> None:
+    binding = _binding(tmp_path)
+    projection = _projection(binding, {"project.md": b"# Project\n"})
+
+    with pytest.raises(LegacyMigrationAssessmentError) as raised:
+        LegacyMigrationAssessment(
+            projection=projection,
+            protected_files=(),
+            snapshot_files=(),
+            identical_paths=(),
+            divergent_paths=(),
+            local_only_paths=(),
+            server_only_paths=(),
+            pending_paths=(),
+            unsupported_paths=(),
+            capture_digest="0" * 64,
+            _construction_token=object(),
+        )
+
+    assert raised.value.code == "legacy_migration_assessment_failed"
+
+
+def test_assessment_requires_exact_verified_projection() -> None:
+    with pytest.raises(LegacyMigrationAssessmentError) as raised:
+        assess_legacy_migration(object())  # type: ignore[arg-type]
+
+    assert raised.value.code == "legacy_migration_assessment_failed"


### PR DESCRIPTION
## Why

A legacy hosted store needs an exact, fail-closed comparison with a verified server projection before backup, quarantine, or generation activation. The client had no bounded assessment for this migration boundary.

## What changed

- Add an immutable assessment that compares protected legacy paths with verified projection digests.
- Stream SHA-256 over protected files and legacy snapshots, and detect files replaced during capture.
- Classify identical, divergent, local-only, and server-only paths.
- Surface interrupted temporary files and unsupported entries before later mutation.
- Ignore persistent lock sidecars, reject links and reparse points, and require an absent generation marker while holding replica control.
- Run the assessment tests in the cross-platform generation job.

The assessment changes no protected or snapshot bytes. It does not copy, move, delete, install, or activate store state.

This PR is stacked on #501.

## Test plan

- `196 passed` in the generation and replica-control safety set.
- `2993 passed, 10 skipped` in the full Nauro package suite.
- Ruff, Mypy, the docstring budget, the single-source guard, workflow YAML parsing, and diff checks pass.

## Deferred

Pending-write settlement, quarantine guidance, recoverable backup, initial generation installation, atomic authority activation, derived-file regeneration, and runtime routing remain separate slices.
