### PR TITLE
Plan legacy migration preservation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,7 @@ jobs:
           packages/nauro/tests/test_generation_lease.py
           packages/nauro/tests/test_generation_cleanup.py
           packages/nauro/tests/test_generation_migration_assessment.py
+          packages/nauro/tests/test_generation_migration_plan.py
           packages/nauro/tests/test_generation_refresh.py
           packages/nauro/tests/test_generation_store.py
           -v --tb=short

--- a/packages/nauro/src/nauro/store/generation_migration_plan.py
+++ b/packages/nauro/src/nauro/store/generation_migration_plan.py
@@ -1,0 +1,297 @@
+"""Immutable preservation plans for legacy hosted-store migration."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import InitVar, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Literal
+
+from nauro_core.identifiers import IdentifierKind, validate_identifier
+
+from nauro.store.generation_authority import GenerationAuthorityError
+from nauro.store.generation_migration_assessment import (
+    LegacyFileStamp,
+    LegacyMigrationAssessment,
+)
+from nauro.store.repo_config import generate_ulid
+
+LegacySourceClass = Literal["identical", "divergent", "local_only", "snapshot"]
+LegacyDisposition = Literal["legacy_backup", "quarantine"]
+LegacyRecoveryKind = Literal[
+    "archive_only",
+    "restore_only",
+    "typed_resubmission",
+    "preserved_unsupported",
+]
+LegacyRecoveryRoute = Literal[
+    "flag_question",
+    "project_frame",
+    "propose_decision",
+    "share_context",
+    "update_stack",
+    "update_state",
+]
+
+_PLAN_SCHEMA_VERSION = 1
+_PLAN_TOKEN = object()
+_TYPED_TOP_LEVEL_ROUTES: dict[str, tuple[LegacyRecoveryRoute, ...]] = {
+    "open-questions.md": ("flag_question", "propose_decision"),
+    "project.md": ("project_frame",),
+    "stack.md": ("update_stack",),
+    "state.md": ("update_state",),
+    "state_current.md": ("update_state",),
+}
+
+
+class LegacyMigrationPlanError(GenerationAuthorityError):
+    """A legacy preservation plan could not be derived without ambiguity."""
+
+    code = "legacy_migration_plan_failed"
+
+
+@dataclass(frozen=True, order=True)
+class LegacyMigrationPlanEntry:
+    """One exact legacy file move and its post-migration recovery classification."""
+
+    source_path: str
+    destination_path: str
+    size: int
+    sha256: str
+    source_class: LegacySourceClass
+    disposition: LegacyDisposition
+    recovery_kind: LegacyRecoveryKind
+    recovery_routes: tuple[LegacyRecoveryRoute, ...]
+    offer_export: bool
+
+
+@dataclass(frozen=True, eq=False)
+class LegacyMigrationPlan:
+    """A no-I/O preservation plan bound to one exact legacy assessment."""
+
+    assessment: LegacyMigrationAssessment = field(repr=False)
+    migration_id: str
+    created_at: str
+    backup_directory_name: str
+    entries: tuple[LegacyMigrationPlanEntry, ...]
+    manifest_json: bytes = field(repr=False)
+    plan_digest: str
+    _construction_token: InitVar[object]
+
+    def __post_init__(self, _construction_token: object) -> None:
+        if (
+            _construction_token is not _PLAN_TOKEN
+            or type(self.assessment) is not LegacyMigrationAssessment
+            or type(self.entries) is not tuple
+            or any(type(entry) is not LegacyMigrationPlanEntry for entry in self.entries)
+            or type(self.manifest_json) is not bytes
+            or hashlib.sha256(self.manifest_json).hexdigest() != self.plan_digest
+        ):
+            raise LegacyMigrationPlanError(
+                "Legacy migration plans must come from a verified assessment."
+            )
+
+    @property
+    def backup_root(self) -> Path:
+        return (
+            self.assessment.projection.target.binding.store_path.parent / self.backup_directory_name
+        )
+
+    @property
+    def quarantine_entries(self) -> tuple[LegacyMigrationPlanEntry, ...]:
+        return tuple(entry for entry in self.entries if entry.disposition == "quarantine")
+
+    @property
+    def backup_entries(self) -> tuple[LegacyMigrationPlanEntry, ...]:
+        return tuple(entry for entry in self.entries if entry.disposition == "legacy_backup")
+
+
+def _validate_assessment(assessment: LegacyMigrationAssessment) -> None:
+    if type(assessment) is not LegacyMigrationAssessment:
+        raise LegacyMigrationPlanError("Legacy migration planning requires an assessment.")
+    if not assessment.ready_for_backup:
+        raise LegacyMigrationPlanError(
+            "Legacy migration planning requires settled pending and unsupported paths."
+        )
+    if type(assessment.protected_files) is not tuple or any(
+        type(stamp) is not LegacyFileStamp for stamp in assessment.protected_files
+    ):
+        raise LegacyMigrationPlanError("The assessed protected inventory is malformed.")
+    protected = {stamp.path: stamp for stamp in assessment.protected_files}
+    if len(protected) != len(assessment.protected_files):
+        raise LegacyMigrationPlanError("The assessed protected inventory is malformed.")
+    classes = (
+        set(assessment.identical_paths),
+        set(assessment.divergent_paths),
+        set(assessment.local_only_paths),
+    )
+    if any(classes[left] & classes[right] for left in range(3) for right in range(left + 1, 3)):
+        raise LegacyMigrationPlanError("The assessed protected classifications overlap.")
+    if set().union(*classes) != set(protected):
+        raise LegacyMigrationPlanError("The assessed protected classifications are incomplete.")
+
+    server = {artifact.path: artifact.digest for artifact in assessment.projection.artifacts}
+    identical = {
+        path for path in set(protected) & set(server) if protected[path].sha256 == server[path]
+    }
+    divergent = set(protected) & set(server) - identical
+    local_only = set(protected) - set(server)
+    server_only = set(server) - set(protected)
+    expected = (identical, divergent, local_only, server_only)
+    observed = (
+        set(assessment.identical_paths),
+        set(assessment.divergent_paths),
+        set(assessment.local_only_paths),
+        set(assessment.server_only_paths),
+    )
+    if observed != expected:
+        raise LegacyMigrationPlanError("The assessed protected classifications diverge.")
+    if type(assessment.snapshot_files) is not tuple or any(
+        type(stamp) is not LegacyFileStamp or not stamp.path.startswith("snapshots/")
+        for stamp in assessment.snapshot_files
+    ):
+        raise LegacyMigrationPlanError("The assessed snapshot inventory is malformed.")
+    if len({stamp.path for stamp in assessment.snapshot_files}) != len(assessment.snapshot_files):
+        raise LegacyMigrationPlanError("The assessed snapshot inventory is malformed.")
+
+
+def _migration_identity() -> tuple[str, str, str]:
+    observed = datetime.now(timezone.utc)
+    created_at = observed.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+    filename_time = observed.strftime("%Y%m%dT%H%M%S%fZ")
+    try:
+        migration_id = validate_identifier(
+            IdentifierKind.ulid,
+            generate_ulid(),
+            field="migration_id",
+        )
+    except ValueError as exc:
+        raise LegacyMigrationPlanError("The migration identity could not be derived.") from exc
+    return migration_id, created_at, filename_time
+
+
+def _recovery_routes(path: str) -> tuple[LegacyRecoveryRoute, ...]:
+    top_level = _TYPED_TOP_LEVEL_ROUTES.get(path)
+    if top_level is not None:
+        return top_level
+    if path.startswith("context/"):
+        return ("share_context",)
+    if path.startswith("decisions/"):
+        return ("propose_decision",)
+    return ()
+
+
+def _protected_entry(
+    stamp: LegacyFileStamp,
+    source_class: Literal["identical", "divergent", "local_only"],
+) -> LegacyMigrationPlanEntry:
+    if source_class == "identical":
+        return LegacyMigrationPlanEntry(
+            stamp.path,
+            f"legacy/{stamp.path}",
+            stamp.size,
+            stamp.sha256,
+            source_class,
+            "legacy_backup",
+            "restore_only",
+            (),
+            False,
+        )
+    routes = _recovery_routes(stamp.path)
+    return LegacyMigrationPlanEntry(
+        stamp.path,
+        f"quarantine/{stamp.path}",
+        stamp.size,
+        stamp.sha256,
+        source_class,
+        "quarantine",
+        "typed_resubmission" if routes else "preserved_unsupported",
+        routes,
+        not routes,
+    )
+
+
+def _snapshot_entry(stamp: LegacyFileStamp) -> LegacyMigrationPlanEntry:
+    return LegacyMigrationPlanEntry(
+        stamp.path,
+        f"legacy/{stamp.path}",
+        stamp.size,
+        stamp.sha256,
+        "snapshot",
+        "legacy_backup",
+        "archive_only",
+        (),
+        True,
+    )
+
+
+def _entry_payload(entry: LegacyMigrationPlanEntry) -> dict[str, object]:
+    return {
+        "source_path": entry.source_path,
+        "destination_path": entry.destination_path,
+        "size": entry.size,
+        "sha256": entry.sha256,
+        "source_class": entry.source_class,
+        "disposition": entry.disposition,
+        "recovery_kind": entry.recovery_kind,
+        "recovery_routes": entry.recovery_routes,
+        "offer_export": entry.offer_export,
+    }
+
+
+def prepare_legacy_migration_plan(
+    assessment: LegacyMigrationAssessment,
+) -> LegacyMigrationPlan:
+    """Bind every assessed legacy byte to backup or timestamped quarantine."""
+    _validate_assessment(assessment)
+    migration_id, created_at, filename_time = _migration_identity()
+    project_id = assessment.projection.project_id
+    backup_name = f"legacy-backup-{project_id}-{filename_time}-{migration_id}"
+    classes: dict[str, Literal["identical", "divergent", "local_only"]] = {
+        **{path: "identical" for path in assessment.identical_paths},
+        **{path: "divergent" for path in assessment.divergent_paths},
+        **{path: "local_only" for path in assessment.local_only_paths},
+    }
+    entries = tuple(
+        sorted(
+            [_protected_entry(stamp, classes[stamp.path]) for stamp in assessment.protected_files]
+            + [_snapshot_entry(stamp) for stamp in assessment.snapshot_files]
+        )
+    )
+    payload = {
+        "schema_version": _PLAN_SCHEMA_VERSION,
+        "migration_id": migration_id,
+        "created_at": created_at,
+        "backup_directory_name": backup_name,
+        "project_id": project_id,
+        "assessment_capture_digest": assessment.capture_digest,
+        "projection": assessment.projection.target.identity.model_dump(),
+        "server_only_paths": assessment.server_only_paths,
+        "entries": [_entry_payload(entry) for entry in entries],
+    }
+    manifest_json = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    return LegacyMigrationPlan(
+        assessment=assessment,
+        migration_id=migration_id,
+        created_at=created_at,
+        backup_directory_name=backup_name,
+        entries=entries,
+        manifest_json=manifest_json,
+        plan_digest=hashlib.sha256(manifest_json).hexdigest(),
+        _construction_token=_PLAN_TOKEN,
+    )
+
+
+__all__ = [
+    "LegacyMigrationPlan",
+    "LegacyMigrationPlanEntry",
+    "LegacyMigrationPlanError",
+    "prepare_legacy_migration_plan",
+]

--- a/packages/nauro/tests/test_generation_migration_plan.py
+++ b/packages/nauro/tests/test_generation_migration_plan.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+import nauro.store.generation_migration_plan as migration_plan
+from nauro.store.generation_authority import GenerationProjectionIdentity
+from nauro.store.generation_migration_assessment import (
+    LegacyMigrationAssessment,
+    assess_legacy_migration,
+)
+from nauro.store.generation_migration_plan import (
+    LegacyMigrationPlan,
+    LegacyMigrationPlanEntry,
+    LegacyMigrationPlanError,
+    prepare_legacy_migration_plan,
+)
+from nauro.store.generation_projection import (
+    GenerationProjectionTarget,
+    VerifiedGenerationProjection,
+    verify_generation_projection,
+)
+from nauro.store.resolution import ResolvedProjectBinding
+
+PROJECT_ID = "01KQ6AZGNA0B3QBF67NBXP3S45"
+GENERATION_ID = "01K11111111111111111111111"
+USER_ID = "01K33333333333333333333333"
+MIGRATION_ID = "01K44444444444444444444444"
+PROJECTION_SCOPE_ID = "a" * 64
+
+
+def _binding(tmp_path: Path) -> ResolvedProjectBinding:
+    store = tmp_path / "projects" / PROJECT_ID
+    store.mkdir(parents=True)
+    return ResolvedProjectBinding(
+        store_path=store,
+        project_id=PROJECT_ID,
+        display_name="Nauro",
+        mode="cloud",
+        server_url="https://mcp.nauro.ai",
+    )
+
+
+def _projection(
+    binding: ResolvedProjectBinding,
+    artifacts: dict[str, bytes],
+) -> VerifiedGenerationProjection:
+    manifest_json = json.dumps(
+        {
+            "project_id": PROJECT_ID,
+            "store_format_version": 1,
+            "generation_id": GENERATION_ID,
+            "projection_class": "contributor_plus",
+            "projection_scope_id": PROJECTION_SCOPE_ID,
+            "artifacts": {
+                path: hashlib.sha256(content).hexdigest() for path, content in artifacts.items()
+            },
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+    identity = GenerationProjectionIdentity(
+        project_id=PROJECT_ID,
+        store_format_version=1,
+        generation_id=GENERATION_ID,
+        manifest_digest=hashlib.sha256(manifest_json).hexdigest(),
+        committed_at="2026-09-02T01:00:00.000000Z",
+        installed_for_user_id=USER_ID,
+        projection_class="contributor_plus",
+        projection_scope_id=PROJECTION_SCOPE_ID,
+    )
+    return verify_generation_projection(
+        GenerationProjectionTarget(binding=binding, identity=identity),
+        manifest_json=manifest_json,
+        artifacts=list(artifacts.items()),
+    )
+
+
+def _write(store: Path, relative: str, content: bytes) -> None:
+    path = store / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+
+
+def _assessment(tmp_path: Path) -> tuple[ResolvedProjectBinding, LegacyMigrationAssessment]:
+    binding = _binding(tmp_path)
+    local = {
+        "project.md": b"# Project\n",
+        "state_current.md": b"# Local state\n",
+        "state_history.md": b"# Local history\n",
+        "stack.md": b"# Local stack\n",
+        "open-questions.md": b"# Local questions\n",
+        "questions-provenance.json": b"{}\n",
+        "decisions/001-one.md": b"# D1: One\n",
+        "decisions/002-two.md": b"# D2: Two\n",
+        "context/auth-cutover-2.md": b"# Brief\n",
+    }
+    for path, content in local.items():
+        _write(binding.store_path, path, content)
+    _write(binding.store_path, "snapshots/incident.json", b'{"incident":true}\n')
+    projection = _projection(
+        binding,
+        {
+            "project.md": b"# Server project\n",
+            "state_current.md": b"# Server state\n",
+            "state.md": b"# Server legacy state\n",
+            "decisions/001-one.md": local["decisions/001-one.md"],
+        },
+    )
+    return binding, assess_legacy_migration(projection)
+
+
+def _entry(plan: LegacyMigrationPlan, path: str) -> LegacyMigrationPlanEntry:
+    return next(entry for entry in plan.entries if entry.source_path == path)
+
+
+def test_plan_binds_every_assessed_byte_to_backup_or_quarantine(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    binding, assessment = _assessment(tmp_path)
+    monkeypatch.setattr(migration_plan, "generate_ulid", lambda: MIGRATION_ID)
+
+    plan = prepare_legacy_migration_plan(assessment)
+
+    assert set(plan.entries) == set(plan.backup_entries) | set(plan.quarantine_entries)
+    assert set(plan.backup_entries).isdisjoint(plan.quarantine_entries)
+    assert {entry.source_path for entry in plan.entries} == {
+        *(stamp.path for stamp in assessment.protected_files),
+        *(stamp.path for stamp in assessment.snapshot_files),
+    }
+    assert _entry(plan, "decisions/001-one.md").destination_path == ("legacy/decisions/001-one.md")
+    assert _entry(plan, "decisions/001-one.md").recovery_kind == "restore_only"
+    assert _entry(plan, "project.md").destination_path == "quarantine/project.md"
+    assert _entry(plan, "project.md").recovery_routes == ("project_frame",)
+    assert _entry(plan, "state_current.md").destination_path == ("quarantine/state_current.md")
+    assert _entry(plan, "state_current.md").recovery_routes == ("update_state",)
+    assert _entry(plan, "stack.md").recovery_routes == ("update_stack",)
+    assert _entry(plan, "open-questions.md").recovery_routes == (
+        "flag_question",
+        "propose_decision",
+    )
+    assert _entry(plan, "decisions/002-two.md").recovery_routes == ("propose_decision",)
+    assert _entry(plan, "context/auth-cutover-2.md").recovery_routes == ("share_context",)
+    assert _entry(plan, "questions-provenance.json").recovery_kind == ("preserved_unsupported")
+    assert _entry(plan, "questions-provenance.json").offer_export is True
+    assert _entry(plan, "state_history.md").recovery_kind == "preserved_unsupported"
+    assert _entry(plan, "state_history.md").offer_export is True
+    assert _entry(plan, "snapshots/incident.json").source_class == "snapshot"
+    assert _entry(plan, "snapshots/incident.json").recovery_kind == "archive_only"
+    assert _entry(plan, "snapshots/incident.json").offer_export is True
+    assert _entry(plan, "snapshots/incident.json").destination_path == (
+        "legacy/snapshots/incident.json"
+    )
+    assert plan.backup_root.parent == binding.store_path.parent
+    assert plan.backup_root != binding.store_path
+    assert not plan.backup_root.exists()
+
+
+def test_plan_manifest_is_canonical_and_binds_projection_and_capture(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, assessment = _assessment(tmp_path)
+    monkeypatch.setattr(migration_plan, "generate_ulid", lambda: MIGRATION_ID)
+
+    plan = prepare_legacy_migration_plan(assessment)
+    manifest = json.loads(plan.manifest_json)
+
+    assert (
+        json.dumps(
+            manifest,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        ).encode()
+        == plan.manifest_json
+    )
+    assert manifest["schema_version"] == 1
+    assert manifest["project_id"] == PROJECT_ID
+    assert manifest["migration_id"] == MIGRATION_ID
+    assert manifest["assessment_capture_digest"] == assessment.capture_digest
+    assert manifest["projection"] == assessment.projection.target.identity.model_dump()
+    assert manifest["server_only_paths"] == ["state.md"]
+    assert hashlib.sha256(plan.manifest_json).hexdigest() == plan.plan_digest
+    assert "/" not in plan.backup_directory_name
+    assert "\\" not in plan.backup_directory_name
+    assert str(tmp_path).encode() not in plan.manifest_json
+
+
+def test_plan_rejects_unsettled_assessment(tmp_path: Path) -> None:
+    binding = _binding(tmp_path)
+    _write(binding.store_path, "project.md", b"# Project\n")
+    _write(binding.store_path, ".project.md.0123456789abcdef.tmp", b"pending")
+    assessment = assess_legacy_migration(_projection(binding, {"project.md": b"# Project\n"}))
+
+    with pytest.raises(LegacyMigrationPlanError, match="settled pending") as raised:
+        prepare_legacy_migration_plan(assessment)
+
+    assert raised.value.code == "legacy_migration_plan_failed"
+
+
+def test_plan_requires_exact_assessment() -> None:
+    with pytest.raises(LegacyMigrationPlanError) as raised:
+        prepare_legacy_migration_plan(object())  # type: ignore[arg-type]
+
+    assert raised.value.code == "legacy_migration_plan_failed"
+
+
+def test_plan_rejects_invalid_derived_migration_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, assessment = _assessment(tmp_path)
+    monkeypatch.setattr(migration_plan, "generate_ulid", lambda: "migration")
+
+    with pytest.raises(LegacyMigrationPlanError, match="identity") as raised:
+        prepare_legacy_migration_plan(assessment)
+
+    assert raised.value.code == "legacy_migration_plan_failed"
+
+
+def test_plan_cannot_be_constructed_without_preparation(tmp_path: Path) -> None:
+    _, assessment = _assessment(tmp_path)
+
+    with pytest.raises(LegacyMigrationPlanError) as raised:
+        LegacyMigrationPlan(
+            assessment=assessment,
+            migration_id=MIGRATION_ID,
+            created_at="2026-09-02T01:00:00.000000Z",
+            backup_directory_name="legacy-backup",
+            entries=(),
+            manifest_json=b"{}",
+            plan_digest=hashlib.sha256(b"{}").hexdigest(),
+            _construction_token=object(),
+        )
+
+    assert raised.value.code == "legacy_migration_plan_failed"


### PR DESCRIPTION
## Why

Migration must decide the recovery destination for every assessed legacy byte before any file moves. That decision must remain bound to the verified server projection and the exact local capture.

## What changed

- Add an immutable, no-I/O preservation plan derived from the migration assessment.
- Send identical protected files to the legacy backup and divergent or local-only files to timestamped quarantine.
- Preserve legacy snapshots as archive-only evidence outside the future generation root.
- Bind supported recovery routes for project frame, state, stack, questions, decisions, and shared context.
- Mark paths without a supported route as preserved but unsupported, with export offered.
- Emit canonical manifest bytes that bind the projection identity, assessment digest, file stamps, dispositions, destinations, migration identity, and creation time.
- Derive a safe sibling backup directory without creating it.
- Run the plan tests in the cross-platform generation job.

This PR performs no filesystem mutation, backup, quarantine, installation, or activation. It is stacked on #502.

## Test plan

- `202 passed` in the generation and replica-control safety set.
- `3000 passed, 10 skipped` in the full Nauro package suite.
- Full Ruff formatting and lint, Mypy, the docstring budget, the single-source guard, workflow YAML parsing, and diff checks pass.

## Deferred

Legacy local-control and derived-artifact preservation, durable freeze evidence, file movement and crash recovery, projection installation, authority activation, derived-file regeneration, and runtime routing remain separate slices.
