### PR TITLE
Reject ambiguous project binding JSON

### DIFF
--- a/packages/nauro/src/nauro/store/resolution.py
+++ b/packages/nauro/src/nauro/store/resolution.py
@@ -15,6 +15,7 @@ Resolution order:
 
 from __future__ import annotations
 
+import json
 import logging
 from dataclasses import dataclass
 from pathlib import Path
@@ -241,6 +242,21 @@ class _StrictRepoConfig(pyd.BaseModel):
         return self
 
 
+def _strict_json_preflight(raw: str) -> None:
+    def object_from_pairs(pairs: list[tuple[str, object]]) -> dict[str, object]:
+        result: dict[str, object] = {}
+        for key, value in pairs:
+            if key in result:
+                raise ValueError("duplicate JSON object key")
+            result[key] = value
+        return result
+
+    def reject_constant(_value: str) -> None:
+        raise ValueError("non-finite JSON constant")
+
+    json.loads(raw, object_pairs_hook=object_from_pairs, parse_constant=reject_constant)
+
+
 def _strict_registry_entries(
     target_id: str | None,
     target_cfg: _StrictRepoConfig | None,
@@ -251,6 +267,10 @@ def _strict_registry_entries(
     try:
         raw = path.read_text(encoding="utf-8")
     except (OSError, UnicodeError) as exc:
+        raise StoreResolutionError("Registry is malformed or unreadable.") from exc
+    try:
+        _strict_json_preflight(raw)
+    except (ValueError, TypeError, RecursionError) as exc:
         raise StoreResolutionError("Registry is malformed or unreadable.") from exc
     try:
         return _StrictRegistrySnapshot.model_validate_json(raw)
@@ -295,6 +315,10 @@ def _strict_repo_config_from_cwd(start: Path) -> _StrictRepoConfig | None:
     try:
         raw = config_path.read_text(encoding="utf-8")
     except (OSError, UnicodeError) as exc:
+        raise StoreResolutionError(f"Repo config at {config_path} is invalid.") from exc
+    try:
+        _strict_json_preflight(raw)
+    except (ValueError, TypeError, RecursionError) as exc:
         raise StoreResolutionError(f"Repo config at {config_path} is invalid.") from exc
     try:
         return _StrictRepoConfig.model_validate_json(raw)

--- a/packages/nauro/tests/test_resolution_v2.py
+++ b/packages/nauro/tests/test_resolution_v2.py
@@ -253,6 +253,106 @@ def test_resolve_project_binding_reads_one_registry_snapshot(tmp_path, monkeypat
     assert reads == 1
 
 
+def _assert_strict_resolution_error(call, message):
+    from nauro.store.resolution import StoreResolutionError
+
+    with pytest.raises(StoreResolutionError) as exc:
+        call()
+    assert type(exc.value) is StoreResolutionError
+    assert str(exc.value) == message
+
+
+@pytest.mark.parametrize(
+    "template",
+    [
+        '{"schema_version":1,"schema_version":2,"projects":PROJECTS}',
+        '{"schema_version":2,"projects":[],"projects":PROJECTS}',
+        '{"schema_version":2,"projects":{"PID":{},"PID":ENTRY}}',
+        (
+            '{"schema_version":2,"projects":{"PID":{"n\\u0061me":"../bad",'
+            '"name":"Pareto","mode":"local","repo_paths":[REPO]}}}'
+        ),
+    ],
+    ids=["schema-version", "projects", "project-id", "escaped-entry-field"],
+)
+def test_binding_rejects_duplicate_registry_keys(tmp_path, nauro_home, template):
+    from nauro.store.resolution import resolve_project_binding
+
+    pid, repo, _store = _binding_state(tmp_path, nauro_home)
+    entry = json.dumps({"name": "Pareto", "mode": "local", "repo_paths": [str(repo.resolve())]})
+    projects = f'{{"{pid}": {entry}}}'
+    raw = (
+        template.replace("PID", pid)
+        .replace("ENTRY", entry)
+        .replace("PROJECTS", projects)
+        .replace("REPO", json.dumps(str(repo.resolve())))
+    )
+    (nauro_home / REGISTRY_FILENAME).write_text(raw)
+    _assert_strict_resolution_error(
+        lambda: resolve_project_binding(pid, repo),
+        "Registry is malformed or unreadable.",
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "duplicate"),
+    [
+        ("mode", '"mode": "cloud", "mode": "local"'),
+        ("id", '"id": "invalid", "id": "01KQ6AZGNA0B3QBF67NBXP3S45"'),
+    ],
+    ids=["mode", "id"],
+)
+def test_binding_rejects_duplicate_repo_config_keys(tmp_path, nauro_home, field, duplicate):
+    from nauro.store.resolution import resolve_project_binding
+
+    pid, repo, _store = _binding_state(tmp_path, nauro_home)
+    config_path = repo / REPO_CONFIG_DIR / REPO_CONFIG_FILENAME
+    raw = config_path.read_text()
+    config_path.write_text(raw.replace(f'"{field}": "{json.loads(raw)[field]}"', duplicate))
+    _assert_strict_resolution_error(
+        lambda: resolve_project_binding(pid, repo),
+        f"Repo config at {config_path} is invalid.",
+    )
+
+
+@pytest.mark.parametrize("constant", ["NaN", "Infinity", "-Infinity"])
+@pytest.mark.parametrize("boundary", ["registry", "repo-config"])
+def test_binding_rejects_nonfinite_json_constants(tmp_path, nauro_home, constant, boundary):
+    from nauro.store.resolution import resolve_project_binding
+
+    pid, repo, _store = _binding_state(tmp_path, nauro_home)
+    if boundary == "registry":
+        path = nauro_home / REGISTRY_FILENAME
+        message = "Registry is malformed or unreadable."
+    else:
+        path = repo / REPO_CONFIG_DIR / REPO_CONFIG_FILENAME
+        message = f"Repo config at {path} is invalid."
+    path.write_text(path.read_text().replace('"name": "Pareto"', f'"name": {constant}'))
+    _assert_strict_resolution_error(lambda: resolve_project_binding(pid, repo), message)
+
+
+@pytest.mark.parametrize("error_type", [TypeError, RecursionError])
+@pytest.mark.parametrize("boundary", ["registry", "repo-config"])
+def test_binding_maps_json_preflight_failures(
+    tmp_path, monkeypatch, nauro_home, error_type, boundary
+):
+    from nauro.store import resolution
+
+    pid, repo, _store = _binding_state(tmp_path, nauro_home)
+    config_path = repo / REPO_CONFIG_DIR / REPO_CONFIG_FILENAME
+    if boundary == "registry":
+        config_path.unlink()
+        message = "Registry is malformed or unreadable."
+    else:
+        message = f"Repo config at {config_path} is invalid."
+
+    def fail_preflight(_raw):
+        raise error_type("parser failure")
+
+    monkeypatch.setattr(resolution, "_strict_json_preflight", fail_preflight, raising=False)
+    _assert_strict_resolution_error(lambda: resolution.resolve_project_binding(pid, repo), message)
+
+
 @pytest.mark.parametrize(
     ("config_patch", "entry_patch"),
     [


### PR DESCRIPTION
## Why

The JSON parser admitted duplicate object keys and non-finite constants before project-binding schema validation. Duplicate keys could hide contradictory registry or repository config fields through last-key-wins behavior. The strict resolver must reject ambiguous or non-standard input before it reads identity or binding data.

## What changed

- Added a standard-library JSON preflight that rejects duplicate decoded keys at any depth and rejects `NaN`, `Infinity`, and `-Infinity`.
- Preserved Pydantic JSON-mode validation as authoritative and kept the existing registry and repository config error boundaries.
- Added hostile-input tests for nested and escaped duplicate keys, non-finite constants, parser failures, and exact error types and messages. Existing tests continue to prove one registry read and unchanged legacy behavior.

## Test plan

- `uv run --no-sync --package nauro pytest packages/nauro/tests/test_resolution_v2.py -v --tb=short`, 93 passed.
- `uv run --no-sync --package nauro pytest packages/nauro/tests/ --ignore=packages/nauro/tests/cross_surface -v --tb=short`, 2,814 passed.
- `uv run --no-sync --package nauro ruff check packages/ benchmarks/ scripts/`
- `uv run --no-sync --package nauro ruff format --check packages/ benchmarks/ scripts/`
- Repository single-source, docstring-budget, and server-version guards passed.

## Risk / what to review

Confirm that the preflight result remains discarded, Pydantic JSON mode remains authoritative, and only preflight parser failures map to the stable boundary errors.

## Deferred

This change does not activate the strict resolver or change legacy resolution behavior.
