### PR TITLE
Read generation control under one native lock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,21 @@ jobs:
       - run: uv sync --locked --package nauro --all-extras --python ${{ matrix.python-version }}
       - run: uv run --no-sync --package nauro pytest packages/nauro/tests/ --ignore=packages/nauro/tests/cross_surface -v --tb=short
 
+  test-generation-control-platforms:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v6
+      - run: uv python install 3.12
+      - run: uv sync --locked --package nauro --all-extras --python 3.12
+      - run: >-
+          uv run --no-sync --package nauro pytest
+          packages/nauro/tests/test_generation_authority.py
+          packages/nauro/tests/test_replica_control.py -v --tb=short
+
   distribution:
     runs-on: ubuntu-latest
     steps:

--- a/packages/nauro/pyproject.toml
+++ b/packages/nauro/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "typer>=0.9",
     "httpx>=0.24",
     "mcp>=1.0,<2",
-    "filelock>=3.20.3",
+    "filelock>=3.29.5",
     "tomli>=2.0; python_version<'3.11'",
     "tomlkit>=0.13.2",
 ]

--- a/packages/nauro/src/nauro/store/generation_authority.py
+++ b/packages/nauro/src/nauro/store/generation_authority.py
@@ -151,6 +151,13 @@ class GenerationProjectAuthority:
 ProjectAuthority = FlatProjectAuthority | GenerationProjectAuthority
 
 
+@dataclass(frozen=True)
+class _PendingGenerationAuthority:
+    binding: ResolvedProjectBinding
+    marker: GenerationAuthorityMarker
+    active_user_id: str
+
+
 def _strict_json_preflight(raw: str | bytes) -> None:
     text = raw.decode("utf-8") if type(raw) is bytes else raw
     if text.startswith("\ufeff"):
@@ -211,15 +218,12 @@ def _active_projection_scope_id(value: str | None) -> str:
     return value
 
 
-def select_project_authority(
+def _select_marker_authority(
     binding: ResolvedProjectBinding,
     *,
     marker_json: str | bytes | None,
-    pointer_json: str | bytes | None,
-    active_user_id: str | None = None,
-    active_projection_scope_id: str | None = None,
-) -> ProjectAuthority:
-    """Select flat or generation authority from one validated project binding."""
+    active_user_id: str | None,
+) -> FlatProjectAuthority | _PendingGenerationAuthority:
     if marker_json is None:
         return FlatProjectAuthority(binding)
     if binding.mode != "cloud":
@@ -234,24 +238,59 @@ def select_project_authority(
         raise ClientUpgradeRequiredError(
             "This hosted store format requires another client version."
         )
+    return _PendingGenerationAuthority(
+        binding=binding,
+        marker=marker,
+        active_user_id=_active_user_id(active_user_id),
+    )
 
-    current_user_id = _active_user_id(active_user_id)
+
+def _select_generation_pointer(
+    pending: _PendingGenerationAuthority,
+    *,
+    pointer_json: str | bytes | None,
+    active_projection_scope_id: str | None,
+) -> GenerationProjectAuthority:
     if pointer_json is None:
         raise RefreshRequiredError("The active account has no installed generation pointer.")
 
     pointer = _parse_pointer(pointer_json)
+    marker = pending.marker
+    binding = pending.binding
     if pointer.project_id != marker.project_id or pointer.project_id != binding.project_id:
         raise GenerationControlCorruptError("The installed pointer belongs to another project.")
     if pointer.store_format_version != marker.store_format_version:
         raise GenerationControlCorruptError("The generation marker and pointer formats differ.")
-    if current_user_id != pointer.installed_for_user_id:
+    if pending.active_user_id != pointer.installed_for_user_id:
         raise ReplicaActorMismatchError("The installed replica belongs to another account.")
 
     current_scope_id = _active_projection_scope_id(active_projection_scope_id)
     if current_scope_id != pointer.projection_scope_id:
         raise RefreshRequiredError("The installed replica requires a fresh authorization view.")
-
     return GenerationProjectAuthority(binding=binding, marker=marker, pointer=pointer)
+
+
+def select_project_authority(
+    binding: ResolvedProjectBinding,
+    *,
+    marker_json: str | bytes | None,
+    pointer_json: str | bytes | None,
+    active_user_id: str | None = None,
+    active_projection_scope_id: str | None = None,
+) -> ProjectAuthority:
+    """Select flat or generation authority from one validated project binding."""
+    selected = _select_marker_authority(
+        binding,
+        marker_json=marker_json,
+        active_user_id=active_user_id,
+    )
+    if isinstance(selected, FlatProjectAuthority):
+        return selected
+    return _select_generation_pointer(
+        selected,
+        pointer_json=pointer_json,
+        active_projection_scope_id=active_projection_scope_id,
+    )
 
 
 __all__ = [

--- a/packages/nauro/src/nauro/store/replica_control.py
+++ b/packages/nauro/src/nauro/store/replica_control.py
@@ -1,0 +1,312 @@
+"""Lock-held authority reads for local hosted-replica control state."""
+
+from __future__ import annotations
+
+import os
+import stat
+import sys
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager, nullcontext, suppress
+from dataclasses import dataclass, field
+from pathlib import Path
+from threading import Lock
+from typing import Any
+
+from filelock import FileLock, SoftFileLock, Timeout, UnixFileLock, WindowsFileLock
+from nauro_core.constants import HOSTED_STORE_FORMAT_VERSION
+
+from nauro.store.generation_authority import (
+    FlatProjectAuthority,
+    GenerationAuthorityError,
+    ProjectAuthority,
+    _PendingGenerationAuthority,
+    _select_generation_pointer,
+    _select_marker_authority,
+)
+from nauro.store.registry import get_store_path_v2
+from nauro.store.resolution import ResolvedProjectBinding
+
+_MAX_CONTROL_FILE_BYTES = 16 * 1024
+_EXPIRED_MESSAGE = "Replica control snapshot is no longer lock-bound."
+_READ_FLAGS = sum(
+    getattr(os, name, 0)
+    for name in ("O_RDONLY", "O_CLOEXEC", "O_BINARY", "O_NOFOLLOW", "O_NONBLOCK")
+)
+_ANCHOR_FLAGS = sum(
+    getattr(os, name, 0)
+    for name in ("O_RDWR", "O_CREAT", "O_CLOEXEC", "O_BINARY", "O_NOFOLLOW", "O_NONBLOCK")
+)
+
+
+class ReplicaControlReadError(GenerationAuthorityError):
+    """Replica control state cannot be read safely."""
+
+    code = "generation_control_unavailable"
+
+
+class ReplicaControlBusyError(GenerationAuthorityError):
+    """Another process holds the replica control lock."""
+
+    code = "generation_control_busy"
+
+
+@dataclass(frozen=True)
+class ReplicaControlSnapshot:
+    """Resolved authority and its exact lock-held control bytes."""
+
+    authority: ProjectAuthority
+    marker_json: bytes | None
+    pointer_json: bytes | None
+    _reread: Callable[[], ProjectAuthority] = field(repr=False, compare=False)
+
+    def reread_authority(self) -> ProjectAuthority:
+        """Resolve the bound actor pointer again while the original lock is held."""
+        return self._reread()
+
+
+def _actor_pointer(control_root: Path, pending: _PendingGenerationAuthority) -> Path:
+    version = f"v{HOSTED_STORE_FORMAT_VERSION}"
+    return control_root / version / "actors" / pending.active_user_id / "pointer.json"
+
+
+def _is_link_or_reparse(metadata: Any) -> bool:
+    attributes = getattr(metadata, "st_file_attributes", 0)
+    reparse = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+    return stat.S_ISLNK(metadata.st_mode) or bool(attributes & reparse)
+
+
+def _validate_store_path(binding: ResolvedProjectBinding) -> Path:
+    path = binding.store_path
+    try:
+        managed = path == get_store_path_v2(binding.project_id)
+        canonical = path.name == binding.project_id and (
+            managed or path.is_absolute() and str(path.resolve(strict=False)) == str(path)
+        )
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise ReplicaControlReadError("The project store path is unavailable.") from exc
+    if not canonical:
+        raise ReplicaControlReadError("The project store path is not canonical.")
+
+    current = Path() if managed else Path(path.anchor)
+    for part in (path,) if managed else path.parts[1:]:
+        current /= part
+        try:
+            metadata = os.lstat(current)
+        except OSError as exc:
+            raise ReplicaControlReadError("The project store path is unavailable.") from exc
+        if _is_link_or_reparse(metadata):
+            raise ReplicaControlReadError("Replica control paths cannot contain links.")
+    if not stat.S_ISDIR(metadata.st_mode):
+        raise ReplicaControlReadError("The project store is not a directory.")
+    return path
+
+
+def _validate_managed_path(store_path: Path, path: Path) -> None:
+    try:
+        parts = path.relative_to(store_path).parts
+    except ValueError as exc:
+        raise ReplicaControlReadError("Replica control path escaped the project store.") from exc
+    current = store_path
+    for part in ("", *parts):
+        current /= part
+        try:
+            metadata = os.lstat(current)
+        except FileNotFoundError:
+            return
+        except OSError as exc:
+            raise ReplicaControlReadError("Replica control path metadata is unavailable.") from exc
+        if _is_link_or_reparse(metadata):
+            raise ReplicaControlReadError("Replica control paths cannot contain links.")
+
+
+def _read_optional_file(path: Path) -> bytes | None:
+    try:
+        observed = os.lstat(path)
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        raise ReplicaControlReadError("Replica control file metadata is unavailable.") from exc
+    if (
+        _is_link_or_reparse(observed)
+        or not stat.S_ISREG(observed.st_mode)
+        or observed.st_size > _MAX_CONTROL_FILE_BYTES
+    ):
+        raise ReplicaControlReadError("Replica control file is not a bounded regular file.")
+
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(path, _READ_FLAGS)
+        opened = os.fstat(descriptor)
+        if (
+            _is_link_or_reparse(opened)
+            or not stat.S_ISREG(opened.st_mode)
+            or (opened.st_dev, opened.st_ino) != (observed.st_dev, observed.st_ino)
+            or opened.st_size > _MAX_CONTROL_FILE_BYTES
+        ):
+            raise ReplicaControlReadError("Replica control file changed during open.")
+        content = os.read(descriptor, _MAX_CONTROL_FILE_BYTES + 1)
+        finished = os.fstat(descriptor)
+        if (
+            _is_link_or_reparse(finished)
+            or not stat.S_ISREG(finished.st_mode)
+            or len(content) > _MAX_CONTROL_FILE_BYTES
+            or (finished.st_dev, finished.st_ino) != (opened.st_dev, opened.st_ino)
+            or finished.st_size != opened.st_size
+            or len(content) != finished.st_size
+        ):
+            raise ReplicaControlReadError("Replica control file changed during read.")
+        return content
+    except OSError as exc:
+        raise ReplicaControlReadError("Replica control file is unreadable.") from exc
+    finally:
+        if descriptor is not None:
+            with suppress(OSError):
+                os.close(descriptor)
+
+
+def _new_native_lock(path: Path, timeout: float):
+    lock = FileLock(str(path), timeout=timeout)
+    if isinstance(lock, SoftFileLock) or type(lock) not in (UnixFileLock, WindowsFileLock):
+        raise ReplicaControlReadError("Native replica control locking is unavailable.")
+    return lock
+
+
+def _open_lock_anchor(path: Path) -> int | None:
+    if sys.platform != "win32":
+        return None
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(path, _ANCHOR_FLAGS, 0o666)
+        opened, observed = os.fstat(descriptor), os.lstat(path)
+        if (
+            _is_link_or_reparse(opened)
+            or _is_link_or_reparse(observed)
+            or not stat.S_ISREG(opened.st_mode)
+            or (opened.st_dev, opened.st_ino) != (observed.st_dev, observed.st_ino)
+        ):
+            raise ReplicaControlReadError("Replica control lock path is unsafe.")
+        return descriptor
+    except (ReplicaControlReadError, OSError) as exc:
+        if descriptor is not None:
+            with suppress(OSError):
+                os.close(descriptor)
+        if isinstance(exc, ReplicaControlReadError):
+            raise
+        raise ReplicaControlReadError("Replica control lock is unavailable.") from exc
+
+
+@contextmanager
+def _native_control_lock(store_path: Path, path: Path, timeout: float) -> Iterator[None]:
+    lock = _new_native_lock(path, timeout)
+    anchor = _open_lock_anchor(path)
+    acquired = False
+    primary: BaseException | None = None
+    try:
+        try:
+            lock.acquire()
+        except Timeout as exc:
+            raise ReplicaControlBusyError("Replica control state is busy.") from exc
+        except (OSError, RuntimeError) as exc:
+            raise ReplicaControlReadError("Replica control lock is unavailable.") from exc
+        acquired = True
+        if isinstance(lock, SoftFileLock) or type(lock) not in (UnixFileLock, WindowsFileLock):
+            raise ReplicaControlReadError("Native replica control locking is unavailable.")
+        yield
+    except BaseException as exc:
+        primary = exc
+        raise
+    finally:
+        failure: BaseException | None = None
+        if acquired:
+            try:
+                lock.release()
+                _validate_managed_path(store_path, path)
+                metadata = os.lstat(path)
+                if _is_link_or_reparse(metadata) or not stat.S_ISREG(metadata.st_mode):
+                    raise ReplicaControlReadError("Replica control lock path is unsafe.")
+            except BaseException as exc:
+                failure = exc
+        if anchor is not None:
+            try:
+                os.close(anchor)
+            except BaseException as exc:
+                failure = failure or exc
+        if failure is not None and primary is None:
+            raise ReplicaControlReadError("Replica control lock release failed.") from failure
+
+
+@contextmanager
+def locked_replica_control_snapshot(
+    binding: ResolvedProjectBinding,
+    *,
+    active_user_id: str | None,
+    active_projection_scope_id: str | None,
+    timeout: float = -1,
+) -> Iterator[ReplicaControlSnapshot]:
+    """Yield resolved control state while holding its stable native project lock."""
+    if binding.mode == "local":
+        lock = nullcontext()
+    else:
+        store_path = _validate_store_path(binding)
+        control_lock = store_path / ".replica-control.lock"
+        control_root = store_path / ".replica"
+        authority_marker = control_root / "authority.json"
+        _validate_managed_path(store_path, control_lock)
+        lock = _native_control_lock(store_path, control_lock, timeout)
+    with lock:
+        pointer_path = None
+        if binding.mode == "local":
+            authority, marker_json, pointer_json = FlatProjectAuthority(binding), None, None
+        else:
+            _validate_managed_path(store_path, authority_marker)
+            marker_json = _read_optional_file(authority_marker)
+            selected = _select_marker_authority(
+                binding, marker_json=marker_json, active_user_id=active_user_id
+            )
+            if isinstance(selected, FlatProjectAuthority):
+                authority, pointer_json = selected, None
+            else:
+                pointer_path = _actor_pointer(control_root, selected)
+                _validate_managed_path(store_path, pointer_path)
+                pointer_json = _read_optional_file(pointer_path)
+                authority = _select_generation_pointer(
+                    selected,
+                    pointer_json=pointer_json,
+                    active_projection_scope_id=active_projection_scope_id,
+                )
+
+        active, guard = True, Lock()
+
+        def reread() -> ProjectAuthority:
+            with guard:
+                if not active:
+                    raise ReplicaControlReadError(_EXPIRED_MESSAGE)
+                if pointer_path is None:
+                    return authority
+                _validate_managed_path(store_path, pointer_path)
+                return _select_generation_pointer(
+                    selected,
+                    pointer_json=_read_optional_file(pointer_path),
+                    active_projection_scope_id=active_projection_scope_id,
+                )
+
+        try:
+            yield ReplicaControlSnapshot(authority, marker_json, pointer_json, reread)
+        finally:
+            interruption: BaseException | None = None
+            while active:
+                try:
+                    with guard:
+                        active = False
+                except BaseException as exc:
+                    interruption = interruption or exc
+            if interruption is not None:
+                raise interruption
+
+
+__all__ = [
+    "ReplicaControlBusyError",
+    "ReplicaControlReadError",
+    "ReplicaControlSnapshot",
+    "locked_replica_control_snapshot",
+]

--- a/packages/nauro/tests/test_generation_authority.py
+++ b/packages/nauro/tests/test_generation_authority.py
@@ -355,6 +355,7 @@ def test_unsupported_marker_format_wins_before_actor_and_pointer_handling() -> N
 
     assert type(raised.value) is ClientUpgradeRequiredError
     assert raised.value.code == "client_upgrade_required"
+    assert str(raised.value) == "This hosted store format requires another client version."
 
 
 @pytest.mark.parametrize(
@@ -376,12 +377,14 @@ def test_generation_selection_requires_exact_matching_active_actor(
 
 
 def test_actor_mismatch_wins_before_pointer_handling() -> None:
-    with pytest.raises(ReplicaActorMismatchError):
+    with pytest.raises(ReplicaActorMismatchError) as raised:
         _select(
             marker_json=_marker(),
             pointer_json=HostileStr("not-json"),
             active_user_id=HostileStr(USER_ID),
         )
+
+    assert str(raised.value) == "The installed replica does not match an active account."
 
 
 def test_valid_actor_without_pointer_requires_refresh() -> None:
@@ -390,6 +393,7 @@ def test_valid_actor_without_pointer_requires_refresh() -> None:
 
     assert type(raised.value) is RefreshRequiredError
     assert raised.value.code == "refresh_required"
+    assert str(raised.value) == "The active account has no installed generation pointer."
 
 
 @pytest.mark.parametrize(
@@ -453,6 +457,7 @@ def test_pointer_actor_must_match_the_valid_active_actor() -> None:
 
     assert type(raised.value) is ReplicaActorMismatchError
     assert raised.value.code == "replica_actor_mismatch"
+    assert str(raised.value) == "The installed replica belongs to another account."
 
 
 @pytest.mark.parametrize(
@@ -478,6 +483,7 @@ def test_generation_selection_requires_exact_matching_authorization_scope(
 
     assert type(raised.value) is RefreshRequiredError
     assert raised.value.code == "refresh_required"
+    assert str(raised.value) == "The installed replica requires a fresh authorization view."
 
 
 def test_pointer_does_not_compare_server_and_local_clocks() -> None:

--- a/packages/nauro/tests/test_replica_control.py
+++ b/packages/nauro/tests/test_replica_control.py
@@ -1,0 +1,406 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+import threading
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from filelock import FileLock, SoftFileLock, Timeout
+
+from nauro.store import replica_control as control
+from nauro.store.generation_authority import (
+    ClientUpgradeRequiredError,
+    FlatProjectAuthority,
+    GenerationControlCorruptError,
+    RefreshRequiredError,
+    ReplicaActorMismatchError,
+)
+from nauro.store.replica_control import (
+    ReplicaControlBusyError,
+    ReplicaControlReadError,
+    locked_replica_control_snapshot,
+)
+from nauro.store.resolution import ResolvedProjectBinding
+
+PROJECT_ID = "01KQ6AZGNA0B3QBF67NBXP3S45"
+USER_ID = "01K33333333333333333333333"
+SCOPE_ID = "b" * 64
+BOUNDARY_IDS = "store lock root marker actor pointer".split()
+
+
+class HostileStr(str):
+    def __str__(self) -> str:
+        raise AssertionError("hostile string was converted")
+
+
+def _binding(path: Path, mode="cloud") -> ResolvedProjectBinding:
+    path.mkdir(parents=True)
+    url = "https://mcp.nauro.ai" if mode == "cloud" else None
+    return ResolvedProjectBinding(path, PROJECT_ID, "Nauro", mode, url)
+
+
+def _marker(**changes: object) -> bytes:
+    value: dict[str, object] = {
+        "schema_version": 1,
+        "authority": "generation",
+        "project_id": PROJECT_ID,
+        "store_format_version": 1,
+    }
+    return json.dumps(value | changes).encode()
+
+
+def _pointer(**changes: object) -> bytes:
+    value: dict[str, object] = {
+        "schema_version": 1,
+        "project_id": PROJECT_ID,
+        "store_format_version": 1,
+        "generation_id": "01K11111111111111111111111",
+        "manifest_digest": "a" * 64,
+        "committed_at": "2026-09-02T01:02:03.000004Z",
+        "installed_at": "2026-09-02T01:03:04.000005Z",
+        "installed_state_id": "01K22222222222222222222222",
+        "installed_for_user_id": USER_ID,
+        "projection_class": "contributor_plus",
+        "projection_scope_id": SCOPE_ID,
+    }
+    return json.dumps(value | changes).encode()
+
+
+def _layout(path: Path):
+    return SimpleNamespace(
+        control_lock=path / ".replica-control.lock",
+        control_root=path / ".replica",
+        authority_marker=path / ".replica/authority.json",
+    )
+
+
+def _pointer_path(path: Path) -> Path:
+    return path / ".replica" / "v1" / "actors" / USER_ID / "pointer.json"
+
+
+def _write_control(path: Path, marker: bytes | None = None, pointer: bytes | None = None):
+    marker, pointer = marker or _marker(), pointer or _pointer()
+    layout = _layout(path)
+    layout.control_root.mkdir()
+    layout.authority_marker.write_bytes(marker)
+    _pointer_path(path).parent.mkdir(parents=True)
+    _pointer_path(path).write_bytes(pointer)
+    return marker, pointer
+
+
+def _locked(binding: ResolvedProjectBinding, **changes: object):
+    options: dict[str, object] = dict(active_user_id=USER_ID, active_projection_scope_id=SCOPE_ID)
+    options.update(changes)
+    return locked_replica_control_snapshot(binding, **options)  # type: ignore[arg-type]
+
+
+def _assert_error(binding: ResolvedProjectBinding, error, **kw):
+    with pytest.raises(error) as raised, _locked(binding, **kw):
+        pass
+    assert (type(raised.value), raised.value.code) == (error, error.code)
+
+
+def test_local_mode_performs_no_lock_or_control_io(tmp_path, monkeypatch):
+    binding = _binding(tmp_path / PROJECT_ID, "local")
+    monkeypatch.setattr(control, "_validate_store_path", lambda *_: pytest.fail("path I/O"))
+    monkeypatch.setattr(control, "_new_native_lock", lambda *_: pytest.fail("lock I/O"))
+    with _locked(binding, active_user_id=HostileStr(USER_ID)) as snapshot:
+        assert snapshot.authority == FlatProjectAuthority(binding)
+        assert (snapshot.marker_json, snapshot.pointer_json) == (None, None)
+    assert not any(path.exists() for path in vars(_layout(binding.store_path)).values())
+
+
+def test_absent_marker_ignores_a_poisoned_dormant_pointer(tmp_path, monkeypatch):
+    binding = _binding(tmp_path / PROJECT_ID)
+    pointer = _pointer_path(binding.store_path)
+    pointer.parent.mkdir(parents=True)
+    _symlink(pointer, tmp_path / "outside")
+    monkeypatch.setattr(control, "_actor_pointer", lambda *_: pytest.fail("pointer path"))
+    with _locked(binding) as snapshot:
+        assert snapshot.authority == FlatProjectAuthority(binding)
+        assert (snapshot.marker_json, snapshot.pointer_json) == (None, None)
+
+
+@pytest.mark.parametrize(
+    ("marker", "actor", "error", "pointer_allowed"),
+    [
+        (b"not-json", USER_ID, GenerationControlCorruptError, False),
+        (_marker(project_id="01K" + "0" * 23), USER_ID, GenerationControlCorruptError, False),
+        (_marker(store_format_version=2), USER_ID, ClientUpgradeRequiredError, False),
+        (_marker(), HostileStr(USER_ID), ReplicaActorMismatchError, False),
+        (_marker(), USER_ID, RefreshRequiredError, True),
+    ],
+)
+def test_control_failure_order(tmp_path, monkeypatch, marker, actor, error, pointer_allowed):
+    binding = _binding(tmp_path / PROJECT_ID)
+    _layout(binding.store_path).control_root.mkdir()
+    _layout(binding.store_path).authority_marker.write_bytes(marker)
+    if not pointer_allowed:
+        monkeypatch.setattr(control, "_actor_pointer", lambda *_: pytest.fail("pointer path"))
+    _assert_error(binding, error, active_user_id=actor)
+
+
+def test_snapshot_retains_exact_bytes_and_immutable_complete_authority(tmp_path: Path) -> None:
+    binding = _binding(tmp_path / PROJECT_ID)
+    marker, pointer = _write_control(binding.store_path, _marker() + b"\n", _pointer() + b"\n")
+    with _locked(binding) as snapshot:
+        assert (snapshot.marker_json, snapshot.pointer_json) == (marker, pointer)
+        assert snapshot.authority.pointer.model_dump() == json.loads(pointer)
+        assert not vars(snapshot).keys() & {"_active", "_guard"}
+        with pytest.raises(FrozenInstanceError):
+            snapshot.pointer_json = b"{}"
+
+
+def test_reread_holds_lock_until_complete_and_expires_after_exit(tmp_path, monkeypatch):
+    binding = _binding(tmp_path / PROJECT_ID)
+    _write_control(binding.store_path)
+    real_guard, interrupted = threading.Lock(), threading.Event()
+    interruption = KeyboardInterrupt("exit interrupted")
+
+    class InterruptingLock:
+        def __enter__(self):
+            if real_guard.locked() and not interrupted.is_set():
+                interrupted.set()
+                raise interruption
+            real_guard.acquire()
+
+        def __exit__(self, *_):
+            real_guard.release()
+
+    monkeypatch.setattr(control, "Lock", InterruptingLock)
+    snapshot = (manager := _locked(binding)).__enter__()
+    entered, proceed, exited = (threading.Event() for _ in range(3))
+
+    def paused_read(path: Path, read=control._read_optional_file):
+        entered.set()
+        assert proceed.wait(5)
+        return read(path)
+
+    monkeypatch.setattr(control, "_actor_pointer", lambda *_: pytest.fail("new path"))
+    monkeypatch.setattr(control, "_read_optional_file", paused_read)
+    result, observed = [], []
+    rereader = threading.Thread(target=lambda: result.append(snapshot.reread_authority()))
+
+    def observe_exit() -> None:
+        try:
+            assert interrupted.wait(5)
+            observed.append(not exited.wait(0.1))
+            observed.append(_assert_error(binding, ReplicaControlBusyError, timeout=0) is None)
+        finally:
+            proceed.set()
+
+    observer = threading.Thread(target=observe_exit)
+    rereader.start()
+    assert entered.wait(5)
+    observer.start()
+    with pytest.raises(KeyboardInterrupt) as raised:
+        manager.__exit__(None, None, None)
+    exited.set()
+    rereader.join(5)
+    observer.join(5)
+    assert (result, observed) == ([snapshot.authority], [True, True])
+    assert raised.value is interruption
+    path = _layout(binding.store_path).control_lock
+    assert path.is_file()
+    with FileLock(str(path), timeout=0):
+        pass
+    for reread in (snapshot.reread_authority, snapshot._reread):
+        with pytest.raises(ReplicaControlReadError) as raised:
+            reread()
+        assert raised.value.code == "generation_control_unavailable"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="fcntl inode identity test")
+def test_waiter_and_contender_share_the_stable_lock_inode(tmp_path: Path) -> None:
+    import fcntl
+
+    binding = _binding(tmp_path / PROJECT_ID)
+    path = _layout(binding.store_path).control_lock
+    ready, released, acquired, done = (threading.Event() for _ in range(4))
+
+    def waiter() -> None:
+        descriptor = os.open(path, os.O_RDWR)
+        ready.set()
+        released.wait()
+        fcntl.flock(descriptor, fcntl.LOCK_EX)
+        acquired.set()
+        done.wait()
+        fcntl.flock(descriptor, fcntl.LOCK_UN)
+        os.close(descriptor)
+
+    thread = threading.Thread(target=waiter)
+    try:
+        with _locked(binding):
+            thread.start()
+            assert ready.wait(5)
+            released.set()
+        assert acquired.wait(5)
+        with pytest.raises(Timeout):
+            FileLock(str(path)).acquire(timeout=0)
+    finally:
+        released.set()
+        done.set()
+        thread.join(5)
+    assert not thread.is_alive()
+
+
+class _AcquireFailure:
+    def acquire(self) -> None:
+        raise OSError("acquire failed")
+
+
+def _broken_release_lock(path: Path, timeout: float):
+    lock = FileLock(str(path), timeout=timeout)
+    release = lock.release
+
+    def fail(force: bool = False) -> None:
+        release(force=force)
+        if not force:
+            raise OSError("release failed")
+
+    lock.release = fail  # type: ignore[method-assign]
+    return lock
+
+
+def test_lock_acquire_and_release_failures_are_typed(tmp_path, monkeypatch):
+    binding = _binding(tmp_path / PROJECT_ID)
+    monkeypatch.setattr(control, "FileLock", SoftFileLock)
+    _assert_error(binding, ReplicaControlReadError)
+    _layout(binding.store_path).control_lock.touch()
+    seen = []
+    fallback = SimpleNamespace(acquire=lambda: seen.append(1), release=lambda: None)
+    monkeypatch.setattr(control, "_new_native_lock", lambda *_: fallback)
+    _assert_error(binding, ReplicaControlReadError)
+    assert seen == [1]
+    monkeypatch.setattr(control, "_new_native_lock", lambda *_: _AcquireFailure())
+    _assert_error(binding, ReplicaControlReadError)
+    monkeypatch.setattr(control, "_new_native_lock", _broken_release_lock)
+    _assert_error(binding, ReplicaControlReadError)
+    with pytest.raises(RuntimeError, match="caller failed"), _locked(binding):
+        raise RuntimeError("caller failed")
+
+
+def _symlink(link: Path, target: Path, directory: bool = False) -> None:
+    try:
+        link.symlink_to(target, target_is_directory=directory)
+    except OSError:
+        pytest.skip("link creation is unavailable")
+
+
+@pytest.mark.parametrize("kind", ["link", "reparse"])
+@pytest.mark.parametrize("target", range(6), ids=BOUNDARY_IDS)
+def test_managed_boundaries_reject_links_and_reparse(tmp_path, monkeypatch, kind, target):
+    home = tmp_path / "managed"
+    monkeypatch.setenv("NAURO_HOME", str(home))
+    store = home / "projects" / PROJECT_ID
+    store.parent.mkdir(parents=True)
+    store.mkdir()
+    binding = ResolvedProjectBinding(store, PROJECT_ID, "Nauro", "cloud", "https://mcp.nauro.ai")
+    layout, pointer = _layout(store), _pointer_path(store)
+    boundary = (store, *vars(layout).values(), pointer.parent, pointer)[target]
+    if kind == "reparse":
+        _write_control(store)
+        layout.control_lock.touch()
+        original = os.lstat
+
+        def lstat(path):
+            metadata = original(path)
+            if Path(path) == boundary:
+                return SimpleNamespace(st_mode=metadata.st_mode, st_file_attributes=0x400)
+            return metadata
+
+        monkeypatch.setattr(control.os, "lstat", lstat)
+    else:
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "file").write_bytes(_pointer())
+        if target == 0:
+            store.rmdir()
+        elif target >= 3:
+            boundary.parent.mkdir(parents=True)
+        if target >= 4:
+            layout.authority_marker.write_bytes(_marker())
+        directory = target in {0, 2, 4}
+        _symlink(boundary, outside if directory else outside / "file", directory)
+    with pytest.raises(ReplicaControlReadError) as raised, _locked(binding):
+        pass
+    assert raised.value.code == "generation_control_unavailable"
+
+
+@pytest.mark.parametrize("home", ["relative", "linked"])
+def test_store_path_rules(tmp_path, monkeypatch, home):
+    monkeypatch.chdir(tmp_path)
+    if home == "linked":
+        Path("target").mkdir()
+        _symlink(Path(home), Path("target"), True)
+    monkeypatch.setenv("NAURO_HOME", home)
+    binding = _binding(control.get_store_path_v2(PROJECT_ID))
+    with _locked(binding) as snapshot:
+        assert snapshot.authority == FlatProjectAuthority(binding)
+    expected = tmp_path / "managed" / PROJECT_ID
+    monkeypatch.setattr(control, "get_store_path_v2", lambda _: expected)
+    for path in [
+        Path(PROJECT_ID),
+        tmp_path / "wrong",
+        tmp_path / "parent/../" / PROJECT_ID,
+        expected.parent / "nested" / PROJECT_ID,
+    ]:
+        binding = ResolvedProjectBinding(path, PROJECT_ID, "Nauro", "cloud", "https://mcp.nauro.ai")
+        with pytest.raises(ReplicaControlReadError), _locked(binding):
+            pass
+
+
+@pytest.mark.parametrize("kind", ["limit", "large", "directory", "fifo"])
+def test_control_files_are_bounded_and_regular(tmp_path: Path, kind: str) -> None:
+    if kind == "fifo" and not hasattr(os, "mkfifo"):
+        pytest.skip("FIFO creation is unavailable")
+    binding = _binding(tmp_path / PROJECT_ID)
+    layout, marker = _layout(binding.store_path), _marker()
+    layout.control_root.mkdir()
+    if kind in {"limit", "large"}:
+        size = 16 * 1024 + (kind == "large")
+        layout.authority_marker.write_bytes(marker + b" " * (size - len(marker)))
+    elif kind == "directory":
+        layout.authority_marker.mkdir()
+    else:
+        os.mkfifo(layout.authority_marker)
+    error = RefreshRequiredError if kind == "limit" else ReplicaControlReadError
+    with pytest.raises(error), _locked(binding):
+        pass
+
+
+@pytest.mark.parametrize(
+    "operation", ["metadata", "open", "open-replace", "read-replace", "read", "flags"]
+)
+def test_control_io_and_replacement_failures_are_typed(tmp_path, monkeypatch, operation):
+    path = tmp_path / "control.json"
+    path.write_bytes(b"{}")
+    if operation == "flags":
+        for name in ("O_NONBLOCK", "O_NOFOLLOW"):
+            assert control._READ_FLAGS & getattr(os, name, 0) == getattr(os, name, 0)
+        return
+    if operation == "metadata":
+        monkeypatch.setattr(control.os, "lstat", lambda _: (_ for _ in ()).throw(OSError()))
+    elif operation == "open":
+        monkeypatch.setattr(control.os, "open", lambda *_: (_ for _ in ()).throw(OSError()))
+    elif "replace" in operation:
+        original, calls = os.fstat, 0
+
+        def fstat(fd: int):
+            nonlocal calls
+            calls += 1
+            values, attributes = original(fd).__reduce__()[1]
+            values = list(values)
+            values[1] += calls == (1 if operation == "open-replace" else 2)
+            return os.stat_result(values, attributes)
+
+        monkeypatch.setattr(control.os, "fstat", fstat)
+    else:
+        monkeypatch.setattr(control.os, "read", lambda *_: (_ for _ in ()).throw(OSError()))
+    with pytest.raises(ReplicaControlReadError) as raised:
+        control._read_optional_file(path)
+    assert raised.value.code == "generation_control_unavailable"

--- a/uv.lock
+++ b/uv.lock
@@ -961,7 +961,7 @@ embeddings = [
 
 [package.metadata]
 requires-dist = [
-    { name = "filelock", specifier = ">=3.20.3" },
+    { name = "filelock", specifier = ">=3.29.5" },
     { name = "hatchling", marker = "extra == 'dev'" },
     { name = "httpx", specifier = ">=0.24" },
     { name = "mcp", specifier = ">=1.0,<2" },


### PR DESCRIPTION
## Why

Hosted generation selection needs one lock-held view of the marker, active actor, installed pointer, and authorization scope before a future store consumer can rely on permanent generations.

## What changed

- Split authority selection into package-private marker and pointer stages while preserving the public one-shot selector and its typed errors.
- Added a dormant reader that resolves immutable authority and retains exact control bytes under one stable native project lock.
- Kept snapshot lifetime state inside the guarded reread callback. Context exit waits for in-flight rereads and completes invalidation before propagating an interruption, so method and direct callback invocations expire before native lock release.
- Preserved configured ancestors for the exact managed default while rejecting linked or reparse-point store leaves and control descendants. External stores remain absolute, canonical, and link-free.
- Bounded control-file reads and rejected nonregular files, oversize input, unsupported lock fallbacks, and identity or size changes during open and read.
- Raised the `filelock` floor to 3.29.5 and added focused Python 3.12 coverage on Linux, macOS, and Windows.

## Test plan

- Focused generation-authority and replica-control tests.
- Repeated cross-thread lock-lifetime and stable-inode tests.
- Full `nauro` test suite, excluding `cross_surface`.
- Ruff check and format check.
- Single-source, docstring-budget, server-version, lockfile, workflow, wheel, source-distribution, public-surface, dormancy, diff, whitespace, and change-budget validation.

## Risk / what to review

Review native lock persistence and release-error masking on Windows, safe invalidation during an interrupted context exit, exact actor-path binding for rereads, and the managed-versus-external path distinction. The managed default deliberately permits its configured ancestor chain. The path checks do not claim descriptor-relative protection against an ancestor replaced concurrently after validation. This slice remains dormant and has no production consumer.

## Deferred

Store callers, leases, projection verification, installation, refresh, migration, release, and activation remain out of scope. Legacy sync still does not exclude `.replica-control.lock` or `.replica/**`; those exclusions must land before any caller can create control state.
