### PR TITLE
Add dormant sync path-admission foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,19 @@ jobs:
       - run: >-
           uv run --no-sync --package nauro pytest
           packages/nauro/tests/test_generation_authority.py
-          packages/nauro/tests/test_replica_control.py -v --tb=short
+          packages/nauro/tests/test_replica_control.py
+          packages/nauro/tests/test_sync/test_replica_control_excluded.py -v --tb=short
+
+  test-sync-path-admission-windows-python310:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v6
+      - run: uv python install 3.10
+      - run: uv sync --locked --package nauro --all-extras --python 3.10
+      - run: >-
+          uv run --no-sync --package nauro pytest
+          packages/nauro/tests/test_sync/test_replica_control_excluded.py -v --tb=short
 
   distribution:
     runs-on: ubuntu-latest

--- a/packages/nauro/src/nauro/store/replica_control.py
+++ b/packages/nauro/src/nauro/store/replica_control.py
@@ -28,6 +28,8 @@ from nauro.store.resolution import ResolvedProjectBinding
 
 _MAX_CONTROL_FILE_BYTES = 16 * 1024
 _EXPIRED_MESSAGE = "Replica control snapshot is no longer lock-bound."
+_REPLICA_CONTROL_ROOT_NAME = ".replica"
+_REPLICA_CONTROL_LOCK_NAME = ".replica-control.lock"
 _READ_FLAGS = sum(
     getattr(os, name, 0)
     for name in ("O_RDONLY", "O_CLOEXEC", "O_BINARY", "O_NOFOLLOW", "O_NONBLOCK")
@@ -248,8 +250,8 @@ def locked_replica_control_snapshot(
         lock = nullcontext()
     else:
         store_path = _validate_store_path(binding)
-        control_lock = store_path / ".replica-control.lock"
-        control_root = store_path / ".replica"
+        control_lock = store_path / _REPLICA_CONTROL_LOCK_NAME
+        control_root = store_path / _REPLICA_CONTROL_ROOT_NAME
         authority_marker = control_root / "authority.json"
         _validate_managed_path(store_path, control_lock)
         lock = _native_control_lock(store_path, control_lock, timeout)

--- a/packages/nauro/src/nauro/sync/_path_diagnostics.py
+++ b/packages/nauro/src/nauro/sync/_path_diagnostics.py
@@ -1,0 +1,153 @@
+"""Private result types for sync path admission."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum, auto
+from pathlib import Path
+
+
+class _PathClass(Enum):
+    ORDINARY = auto()
+    RESERVED_CONTROL = auto()
+    UNSAFE = auto()
+
+
+class _UnsafeReason(Enum):
+    RAW_ABSOLUTE = auto()
+    RAW_ROOTED = auto()
+    RAW_DRIVE = auto()
+    RAW_UNC = auto()
+    RAW_DEVICE = auto()
+    RAW_PARENT = auto()
+    EMPTY_PATH = auto()
+    FOLDED_EMPTY = auto()
+    FOLDED_DOT = auto()
+    FOLDED_PARENT = auto()
+    OUTSIDE_STORE = auto()
+    OBSERVATION_LOST = auto()
+    WINDOWS_NAME_LOOKUP_FAILED = auto()
+    METADATA_UNAVAILABLE = auto()
+    LINK_TARGET_UNREADABLE = auto()
+    UNSUPPORTED_REPARSE = auto()
+    LINK_LOOP = auto()
+    LINK_HOP_LIMIT = auto()
+    NON_DIRECTORY_PARENT = auto()
+
+
+class _MissingPathPolicy(Enum):
+    OBSERVED = auto()
+    OPTIONAL_FIXED_LEAF = auto()
+    CREATE_DESTINATION = auto()
+
+
+class _NativeKind(Enum):
+    DIRECTORY = auto()
+    REGULAR_FILE = auto()
+    IRREGULAR = auto()
+
+
+@dataclass(frozen=True)
+class _SemanticPathView:
+    raw_identity: str
+    exact_components: tuple[str, ...]
+    semantic_components: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class _PathAdmission:
+    path_class: _PathClass
+    raw_identity: str
+    exists: bool | None = None
+    missing_policy: _MissingPathPolicy | None = None
+    native_kind: _NativeKind | None = None
+    reason: _UnsafeReason | None = None
+
+    def __post_init__(self) -> None:
+        if self.path_class is _PathClass.UNSAFE:
+            if self.reason is None:
+                raise ValueError("An unsafe path requires a reason.")
+        elif self.reason is not None:
+            raise ValueError("Only an unsafe path can have a reason.")
+        if self.native_kind is not None and not (
+            self.path_class is _PathClass.ORDINARY and self.exists is True
+        ):
+            raise ValueError("Only an existing ordinary path can have a native kind.")
+        if self.exists is False and self.missing_policy is None:
+            raise ValueError("An absent path requires a missing policy.")
+
+
+@dataclass(frozen=True)
+class _PreparedStoreRoot:
+    configured_root: Path
+    canonical_root: Path
+    native_anchor: str
+    canonical_parts: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class _SafeWalkEntry:
+    native_path: Path
+    raw_relative_path: str
+    admission: _PathAdmission
+
+
+class _StoreRootPreparationError(Exception):
+    def __init__(self) -> None:
+        super().__init__("The Store root is unavailable.")
+
+
+_REASON_TEXT = {
+    _UnsafeReason.RAW_ABSOLUTE: "The path is absolute.",
+    _UnsafeReason.RAW_ROOTED: "The path is rooted.",
+    _UnsafeReason.RAW_DRIVE: "The path uses drive syntax.",
+    _UnsafeReason.RAW_UNC: "The path uses UNC syntax.",
+    _UnsafeReason.RAW_DEVICE: "The path uses device syntax.",
+    _UnsafeReason.RAW_PARENT: "The path contains a parent component.",
+    _UnsafeReason.EMPTY_PATH: "The path has no usable component.",
+    _UnsafeReason.FOLDED_EMPTY: "A path component normalizes to empty.",
+    _UnsafeReason.FOLDED_DOT: "A path component normalizes to dot.",
+    _UnsafeReason.FOLDED_PARENT: "A path component normalizes to parent.",
+    _UnsafeReason.OUTSIDE_STORE: "The path resolves outside the Store root.",
+    _UnsafeReason.OBSERVATION_LOST: "The path changed after it was observed.",
+    _UnsafeReason.WINDOWS_NAME_LOOKUP_FAILED: "The Windows long-name lookup failed.",
+    _UnsafeReason.METADATA_UNAVAILABLE: "Path metadata is unavailable.",
+    _UnsafeReason.LINK_TARGET_UNREADABLE: "The link target is unavailable.",
+    _UnsafeReason.UNSUPPORTED_REPARSE: "The path uses an unsupported reparse point.",
+    _UnsafeReason.LINK_LOOP: "The path contains a link loop.",
+    _UnsafeReason.LINK_HOP_LIMIT: "The path exceeds the link hop limit.",
+    _UnsafeReason.NON_DIRECTORY_PARENT: ("A non-directory path has a remaining component."),
+}
+
+
+def _unsafe_reason_text(reason: _UnsafeReason) -> str:
+    return _REASON_TEXT[reason]
+
+
+def _escape_path_for_display(raw_path: str) -> str:
+    escaped: list[str] = []
+    for character in raw_path:
+        value = ord(character)
+        if character == " ":
+            escaped.append(r"\x20")
+        elif character == "\n":
+            escaped.append(r"\n")
+        elif character == "\r":
+            escaped.append(r"\r")
+        elif character == "\\":
+            escaped.append(r"\\")
+        elif character == "'":
+            escaped.append(r"\x27")
+        elif character == '"':
+            escaped.append(r"\x22")
+        elif value < 0x20 or value == 0x7F:
+            escaped.append(f"\\x{value:02X}")
+        elif 0xDC80 <= value <= 0xDCFF:
+            escaped.append(f"\\x{value - 0xDC00:02X}")
+        elif 0xD800 <= value <= 0xDFFF:
+            escaped.append(f"\\u{value:04X}")
+        elif value > 0x7F:
+            escaped.extend(f"\\x{byte:02X}" for byte in character.encode("utf-8"))
+        else:
+            escaped.append(character)
+    return "".join(escaped)

--- a/packages/nauro/src/nauro/sync/_windows_long_names.py
+++ b/packages/nauro/src/nauro/sync/_windows_long_names.py
@@ -1,0 +1,43 @@
+"""Private Windows long-name lookup for sync path admission."""
+
+from __future__ import annotations
+
+import ctypes
+import os
+import sys
+from pathlib import Path
+
+_ERROR_FILE_NOT_FOUND = 2
+_ERROR_PATH_NOT_FOUND = 3
+_INITIAL_BUFFER_SIZE = 260
+
+
+def _get_long_path_name(path: str, buffer: ctypes.Array[ctypes.c_wchar], size: int) -> int:
+    # get_last_error() reads a ctypes-private copy that only a use_last_error
+    # handle refreshes, so ctypes.windll would report a stale error code.
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)  # type: ignore[attr-defined]
+    function = kernel32.GetLongPathNameW
+    function.argtypes = [ctypes.c_wchar_p, ctypes.c_wchar_p, ctypes.c_uint32]
+    function.restype = ctypes.c_uint32
+    return int(function(path, buffer, size))
+
+
+def _existing_long_component(parent: Path, native_component: str) -> str | None:
+    if sys.platform != "win32":
+        return native_component
+
+    exact_path = os.fspath(parent / native_component)
+    size = _INITIAL_BUFFER_SIZE
+    while True:
+        buffer = ctypes.create_unicode_buffer(size)
+        ctypes.set_last_error(0)
+        length = _get_long_path_name(exact_path, buffer, size)
+        if length == 0:
+            error = ctypes.get_last_error()
+            if error in {_ERROR_FILE_NOT_FOUND, _ERROR_PATH_NOT_FOUND}:
+                return None
+            raise OSError(error, "Windows long-name lookup failed")
+        if length >= size:
+            size = length + 1
+            continue
+        return Path(buffer.value).name

--- a/packages/nauro/src/nauro/sync/merge.py
+++ b/packages/nauro/src/nauro/sync/merge.py
@@ -5,14 +5,38 @@ how to merge or which version wins.
 """
 
 import logging
+import ntpath
+import os
+import stat
+import sys
+from collections import deque
+from collections.abc import Iterator
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum, auto
 from pathlib import Path
+from typing import Any
 
 from nauro.graph import DEFAULT_GRAPH_FILENAME
 from nauro.store._atomic import atomic_write_bytes, is_tmp_sibling
 from nauro.store.journal import JOURNAL_DIR
+from nauro.store.replica_control import (
+    _REPLICA_CONTROL_LOCK_NAME,
+    _REPLICA_CONTROL_ROOT_NAME,
+)
 from nauro.store.store_lock import DIR_LOCK_NAME, RMW_LOCK_SUFFIX
+from nauro.sync._path_diagnostics import (
+    _MissingPathPolicy,
+    _NativeKind,
+    _PathAdmission,
+    _PathClass,
+    _PreparedStoreRoot,
+    _SafeWalkEntry,
+    _SemanticPathView,
+    _StoreRootPreparationError,
+    _UnsafeReason,
+)
+from nauro.sync._windows_long_names import _existing_long_component
 
 logger = logging.getLogger("nauro.sync")
 
@@ -49,6 +73,477 @@ NEVER_SYNC = (".sync-state.json", DEFAULT_GRAPH_FILENAME)
 # store. The suffixes are deliberately narrow (``.md.lock``, not ``.lock``) so
 # a legitimate store file such as ``context/poetry.lock`` still syncs.
 LOCK_ARTIFACT_SUFFIXES = (".md.lock", ".json.lock", RMW_LOCK_SUFFIX)
+
+_MAX_NATIVE_LINK_HOPS = 40
+_TRAILING_SEPARATOR = object()
+
+
+@dataclass(frozen=True)
+class _ResolvedNative:
+    path: Path
+    component: str | None
+    kind: _NativeKind
+
+
+def _unsafe(raw_identity: str, reason: _UnsafeReason) -> _PathAdmission:
+    return _PathAdmission(_PathClass.UNSAFE, raw_identity, reason=reason)
+
+
+def _classified(raw_identity: str, path_class: _PathClass) -> _PathAdmission:
+    return _PathAdmission(path_class, raw_identity)
+
+
+def _fold_semantic_component(component: str) -> tuple[str | None, _UnsafeReason | None]:
+    base = component.split(":", 1)[0]
+    # Windows trims any trailing run of spaces and periods together, so the
+    # fold must reach a fixpoint over the set rather than strip each once.
+    trimmed = base.lstrip(" ").rstrip(" .")
+    if not trimmed:
+        spaced = base.strip(" ")
+        if spaced == ".":
+            return None, _UnsafeReason.FOLDED_DOT
+        if spaced == "..":
+            return None, _UnsafeReason.FOLDED_PARENT
+        return None, _UnsafeReason.FOLDED_EMPTY
+    folded = trimmed.casefold()
+    if folded == ".":
+        return None, _UnsafeReason.FOLDED_DOT
+    if folded == "..":
+        return None, _UnsafeReason.FOLDED_PARENT
+    return folded, None
+
+
+def _normalize_component_path(
+    exact_components: tuple[str, ...] | list[str],
+    *,
+    raw_identity: str = "",
+) -> tuple[_SemanticPathView, _UnsafeReason | None]:
+    semantic: list[str] = []
+    for native_component in exact_components:
+        for component in native_component.replace("\\", "/").split("/"):
+            if not component:
+                continue
+            folded, reason = _fold_semantic_component(component)
+            if reason is not None:
+                return (
+                    _SemanticPathView(raw_identity, tuple(exact_components), tuple(semantic)),
+                    reason,
+                )
+            assert folded is not None
+            semantic.append(folded)
+    return (
+        _SemanticPathView(raw_identity, tuple(exact_components), tuple(semantic)),
+        None,
+    )
+
+
+def _classify_component_path(
+    exact_components: tuple[str, ...] | list[str],
+    *,
+    raw_identity: str,
+) -> _PathAdmission:
+    view, reason = _normalize_component_path(exact_components, raw_identity=raw_identity)
+    if reason is not None:
+        return _unsafe(raw_identity, reason)
+    if not view.semantic_components:
+        return _unsafe(raw_identity, _UnsafeReason.EMPTY_PATH)
+    if view.semantic_components[0] in {
+        _REPLICA_CONTROL_ROOT_NAME.casefold(),
+        _REPLICA_CONTROL_LOCK_NAME.casefold(),
+    }:
+        return _classified(raw_identity, _PathClass.RESERVED_CONTROL)
+    return _classified(raw_identity, _PathClass.ORDINARY)
+
+
+def _sync_input_failure(raw_path: str) -> _UnsafeReason | None:
+    folded = raw_path.replace("/", "\\").casefold()
+    if folded.startswith(("\\\\?\\", "\\??\\", "\\\\.\\", "\\device\\")):
+        return _UnsafeReason.RAW_DEVICE
+    if raw_path.startswith(("\\\\", "//")):
+        return _UnsafeReason.RAW_UNC
+    if ntpath.splitdrive(raw_path)[0]:
+        return _UnsafeReason.RAW_DRIVE
+    if raw_path.startswith("/"):
+        return _UnsafeReason.RAW_ABSOLUTE
+    if raw_path.startswith("\\"):
+        return _UnsafeReason.RAW_ROOTED
+    components = raw_path.replace("\\", "/").split("/")
+    if ".." in components:
+        return _UnsafeReason.RAW_PARENT
+    return None
+
+
+def _classify_sync_path(raw_relative_path: str) -> _PathAdmission:
+    reason = _sync_input_failure(raw_relative_path)
+    if reason is not None:
+        return _unsafe(raw_relative_path, reason)
+    components = [
+        component
+        for component in raw_relative_path.replace("\\", "/").split("/")
+        if component not in {"", "."}
+    ]
+    return _classify_component_path(components, raw_identity=raw_relative_path)
+
+
+def _prepare_store_root(configured_root: Path) -> _PreparedStoreRoot:
+    try:
+        canonical_root = configured_root.resolve(strict=True)
+        if not canonical_root.is_absolute() or not canonical_root.is_dir():
+            raise OSError
+        anchor = canonical_root.anchor
+        anchor_parts = Path(anchor).parts
+        canonical_parts = canonical_root.parts[len(anchor_parts) :]
+        return _PreparedStoreRoot(
+            configured_root=configured_root,
+            canonical_root=canonical_root,
+            native_anchor=anchor,
+            canonical_parts=canonical_parts,
+        )
+    except (OSError, RuntimeError, ValueError):
+        raise _StoreRootPreparationError() from None
+
+
+def _native_relative_parts(raw_path: str) -> tuple[list[str | object], bool]:
+    parts: list[str | object]
+    if sys.platform == "win32":
+        trailing = raw_path.endswith(("\\", "/"))
+        parts = [part for part in raw_path.replace("/", "\\").split("\\") if part]
+    else:
+        trailing = raw_path.endswith("/")
+        parts = [part for part in raw_path.split("/") if part]
+    if trailing:
+        parts.append(_TRAILING_SEPARATOR)
+    return parts, trailing
+
+
+def _normalized_windows_target(target: str) -> tuple[str | None, _UnsafeReason | None]:
+    folded = target.casefold()
+    for prefix in ("\\\\?\\unc\\", "\\??\\unc\\"):
+        if folded.startswith(prefix):
+            return "\\\\" + target[len(prefix) :], None
+    for prefix in ("\\\\?\\", "\\??\\"):
+        if folded.startswith(prefix):
+            remainder = target[len(prefix) :]
+            if remainder.casefold().startswith("volume{"):
+                return None, _UnsafeReason.UNSUPPORTED_REPARSE
+            if ntpath.splitdrive(remainder)[0]:
+                return remainder, None
+            return None, _UnsafeReason.UNSUPPORTED_REPARSE
+    if folded.startswith(("\\\\.\\", "\\device\\")):
+        return None, _UnsafeReason.UNSUPPORTED_REPARSE
+    return target, None
+
+
+def _absolute_target_suffix(
+    target: str, store_root: _PreparedStoreRoot
+) -> tuple[list[str] | None, _UnsafeReason | None, bool]:
+    if sys.platform == "win32":
+        target, reason = _normalized_windows_target(target)
+        if reason is not None or target is None:
+            return None, reason, False
+        drive, remainder = ntpath.splitdrive(target)
+        rooted = remainder.startswith(("\\", "/"))
+        if not drive and rooted:
+            return None, _UnsafeReason.OUTSIDE_STORE, False
+        if drive and not rooted:
+            return None, _UnsafeReason.OUTSIDE_STORE, False
+        if not drive:
+            parts = [part for part in target.replace("/", "\\").split("\\") if part]
+            return parts, None, False
+        root_drive = ntpath.splitdrive(store_root.native_anchor)[0]
+        if ntpath.normcase(drive) != ntpath.normcase(root_drive):
+            return None, _UnsafeReason.OUTSIDE_STORE, True
+        parts = [part for part in remainder.replace("/", "\\").split("\\") if part]
+    else:
+        if not target.startswith("/"):
+            return [part for part in target.split("/") if part], None, False
+        parts = [part for part in target.split("/") if part]
+
+    prefix = store_root.canonical_parts
+    if len(parts) < len(prefix) or tuple(parts[: len(prefix)]) != prefix:
+        return None, _UnsafeReason.OUTSIDE_STORE, True
+    return parts[len(prefix) :], None, True
+
+
+def _metadata_kind(metadata: Any) -> _NativeKind:
+    if stat.S_ISDIR(metadata.st_mode):
+        return _NativeKind.DIRECTORY
+    if stat.S_ISREG(metadata.st_mode):
+        return _NativeKind.REGULAR_FILE
+    return _NativeKind.IRREGULAR
+
+
+def _is_link_or_reparse(metadata: Any) -> bool:
+    attributes = getattr(metadata, "st_file_attributes", 0)
+    reparse = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+    return stat.S_ISLNK(metadata.st_mode) or bool(attributes & reparse)
+
+
+def _is_supported_link(metadata: Any) -> bool:
+    if stat.S_ISLNK(metadata.st_mode):
+        return True
+    tag = getattr(metadata, "st_reparse_tag", None)
+    return tag in {
+        getattr(stat, "IO_REPARSE_TAG_SYMLINK", 0xA000000C),
+        getattr(stat, "IO_REPARSE_TAG_MOUNT_POINT", 0xA0000003),
+    }
+
+
+def _missing_admission(
+    *,
+    raw_identity: str,
+    missing: _MissingPathPolicy,
+    stack: list[_ResolvedNative],
+    absent_component: str,
+    pending: deque[str | object],
+) -> _PathAdmission:
+    if missing is _MissingPathPolicy.OBSERVED:
+        return _unsafe(raw_identity, _UnsafeReason.OBSERVATION_LOST)
+    if missing is _MissingPathPolicy.OPTIONAL_FIXED_LEAF:
+        if pending:
+            return _unsafe(raw_identity, _UnsafeReason.OBSERVATION_LOST)
+        return _PathAdmission(
+            _PathClass.ORDINARY,
+            raw_identity,
+            exists=False,
+            missing_policy=missing,
+        )
+
+    semantic = [entry.component for entry in stack[1:] if entry.component is not None]
+    semantic.append(absent_component)
+    while pending:
+        component = pending.popleft()
+        if component is _TRAILING_SEPARATOR:
+            continue
+        assert isinstance(component, str)
+        if component == ".":
+            continue
+        if component == "..":
+            return _unsafe(raw_identity, _UnsafeReason.FOLDED_PARENT)
+        semantic.append(component)
+        classified = _classify_component_path(semantic, raw_identity=raw_identity)
+        if classified.path_class is not _PathClass.ORDINARY:
+            return classified
+    return _PathAdmission(
+        _PathClass.ORDINARY,
+        raw_identity,
+        exists=False,
+        missing_policy=missing,
+    )
+
+
+def _admit_native_path(
+    store_root: _PreparedStoreRoot,
+    raw_relative_path: str,
+    *,
+    missing: _MissingPathPolicy,
+) -> _PathAdmission:
+    initial = _classify_sync_path(raw_relative_path)
+    if initial.path_class is not _PathClass.ORDINARY:
+        return initial
+    if "\x00" in raw_relative_path:
+        return _unsafe(raw_relative_path, _UnsafeReason.METADATA_UNAVAILABLE)
+    pending_list, _ = _native_relative_parts(raw_relative_path)
+    pending: deque[str | object] = deque(pending_list)
+    stack = [_ResolvedNative(store_root.canonical_root, None, _NativeKind.DIRECTORY)]
+    followed_links: set[tuple[int, int, str]] = set()
+    link_hops = 0
+
+    while pending:
+        if stack[-1].kind is not _NativeKind.DIRECTORY:
+            return _unsafe(raw_relative_path, _UnsafeReason.NON_DIRECTORY_PARENT)
+        component = pending.popleft()
+        if component is _TRAILING_SEPARATOR or component == ".":
+            continue
+        assert isinstance(component, str)
+        if component == "..":
+            if len(stack) == 1:
+                return _unsafe(raw_relative_path, _UnsafeReason.OUTSIDE_STORE)
+            stack.pop()
+            continue
+
+        exact_components = [
+            entry.component for entry in stack[1:] if entry.component is not None
+        ] + [component]
+        lexical = _classify_component_path(exact_components, raw_identity=raw_relative_path)
+        if lexical.path_class is not _PathClass.ORDINARY:
+            return lexical
+        parent = stack[-1].path
+        try:
+            long_component = _existing_long_component(parent, component)
+        except (OSError, ValueError):
+            return _unsafe(raw_relative_path, _UnsafeReason.WINDOWS_NAME_LOOKUP_FAILED)
+        if long_component is None:
+            return _missing_admission(
+                raw_identity=raw_relative_path,
+                missing=missing,
+                stack=stack,
+                absent_component=component,
+                pending=pending,
+            )
+        long_components = [
+            entry.component for entry in stack[1:] if entry.component is not None
+        ] + [long_component]
+        admitted_name = _classify_component_path(long_components, raw_identity=raw_relative_path)
+        if admitted_name.path_class is not _PathClass.ORDINARY:
+            return admitted_name
+
+        candidate = parent / component
+        try:
+            metadata = os.lstat(candidate)
+        except FileNotFoundError:
+            return _missing_admission(
+                raw_identity=raw_relative_path,
+                missing=missing,
+                stack=stack,
+                absent_component=component,
+                pending=pending,
+            )
+        except (OSError, ValueError):
+            return _unsafe(raw_relative_path, _UnsafeReason.METADATA_UNAVAILABLE)
+
+        if not _is_link_or_reparse(metadata):
+            stack.append(_ResolvedNative(candidate, long_component, _metadata_kind(metadata)))
+            continue
+        if not _is_supported_link(metadata):
+            return _unsafe(raw_relative_path, _UnsafeReason.UNSUPPORTED_REPARSE)
+        identity = (metadata.st_dev, metadata.st_ino, os.fspath(candidate))
+        if identity in followed_links:
+            return _unsafe(raw_relative_path, _UnsafeReason.LINK_LOOP)
+        followed_links.add(identity)
+        link_hops += 1
+        if link_hops > _MAX_NATIVE_LINK_HOPS:
+            return _unsafe(raw_relative_path, _UnsafeReason.LINK_HOP_LIMIT)
+        try:
+            target = os.readlink(candidate)
+        except (OSError, ValueError):
+            return _unsafe(raw_relative_path, _UnsafeReason.LINK_TARGET_UNREADABLE)
+        target_parts, reason, absolute = _absolute_target_suffix(target, store_root)
+        if reason is not None or target_parts is None:
+            return _unsafe(raw_relative_path, reason or _UnsafeReason.OUTSIDE_STORE)
+        if absolute:
+            stack = [_ResolvedNative(store_root.canonical_root, None, _NativeKind.DIRECTORY)]
+        target_pending: list[str | object] = list(target_parts)
+        if target.endswith(("/", "\\")):
+            target_pending.append(_TRAILING_SEPARATOR)
+        pending.extendleft(reversed(target_pending))
+
+    final = stack[-1]
+    return _PathAdmission(
+        _PathClass.ORDINARY,
+        raw_relative_path,
+        exists=True,
+        missing_policy=missing,
+        native_kind=final.kind,
+    )
+
+
+def _walk_unsafe(
+    native_path: Path, raw_relative_path: str, reason: _UnsafeReason
+) -> _SafeWalkEntry:
+    return _SafeWalkEntry(native_path, raw_relative_path, _unsafe(raw_relative_path, reason))
+
+
+def _list_directory(directory: Path) -> list[os.DirEntry[str]] | None:
+    try:
+        with os.scandir(directory) as listing:
+            return list(listing)
+    except (OSError, ValueError):
+        return None
+
+
+def _walk_store_files(store_root: _PreparedStoreRoot) -> Iterator[_SafeWalkEntry]:
+    # Explicit frames rather than generator recursion, so a deep tree cannot
+    # raise RecursionError out of the walk.
+    frames: list[tuple[Path, tuple[str, ...], deque[os.DirEntry[str]]]] = []
+
+    def enter(directory: Path, relative_parts: tuple[str, ...]) -> _SafeWalkEntry | None:
+        entries = _list_directory(directory)
+        if entries is None:
+            raw_directory = os.path.join(*relative_parts) if relative_parts else ""
+            return _walk_unsafe(directory, raw_directory, _UnsafeReason.METADATA_UNAVAILABLE)
+        frames.append((directory, relative_parts, deque(entries)))
+        return None
+
+    blocked = enter(store_root.canonical_root, ())
+    if blocked is not None:
+        yield blocked
+        return
+    while frames:
+        directory, relative_parts, entries = frames[-1]
+        if not entries:
+            frames.pop()
+            continue
+        entry = entries.popleft()
+        parts = (*relative_parts, entry.name)
+        raw_relative = os.path.join(*parts)
+        lexical = _classify_component_path(parts, raw_identity=raw_relative)
+        if lexical.path_class is _PathClass.RESERVED_CONTROL:
+            continue
+        if lexical.path_class is _PathClass.UNSAFE:
+            yield _SafeWalkEntry(Path(entry.path), raw_relative, lexical)
+            continue
+        try:
+            long_component = _existing_long_component(directory, entry.name)
+        except (OSError, ValueError):
+            yield _walk_unsafe(
+                Path(entry.path), raw_relative, _UnsafeReason.WINDOWS_NAME_LOOKUP_FAILED
+            )
+            continue
+        if long_component is None:
+            yield _walk_unsafe(Path(entry.path), raw_relative, _UnsafeReason.OBSERVATION_LOST)
+            continue
+        long_parts = (*relative_parts, long_component)
+        named = _classify_component_path(long_parts, raw_identity=raw_relative)
+        if named.path_class is _PathClass.RESERVED_CONTROL:
+            continue
+        if named.path_class is _PathClass.UNSAFE:
+            yield _SafeWalkEntry(Path(entry.path), raw_relative, named)
+            continue
+        try:
+            direct = entry.stat(follow_symlinks=False)
+        except FileNotFoundError:
+            yield _walk_unsafe(Path(entry.path), raw_relative, _UnsafeReason.OBSERVATION_LOST)
+            continue
+        except (OSError, ValueError):
+            yield _walk_unsafe(Path(entry.path), raw_relative, _UnsafeReason.METADATA_UNAVAILABLE)
+            continue
+        if _is_link_or_reparse(direct):
+            admission = _admit_native_path(
+                store_root, raw_relative, missing=_MissingPathPolicy.OBSERVED
+            )
+            if admission.path_class is _PathClass.RESERVED_CONTROL:
+                continue
+            if admission.path_class is _PathClass.UNSAFE:
+                yield _SafeWalkEntry(Path(entry.path), raw_relative, admission)
+                continue
+            try:
+                followed = entry.stat(follow_symlinks=True)
+            except FileNotFoundError:
+                yield _walk_unsafe(Path(entry.path), raw_relative, _UnsafeReason.OBSERVATION_LOST)
+                continue
+            except (OSError, ValueError):
+                yield _walk_unsafe(
+                    Path(entry.path), raw_relative, _UnsafeReason.METADATA_UNAVAILABLE
+                )
+                continue
+            if _metadata_kind(followed) is _NativeKind.REGULAR_FILE:
+                yield _SafeWalkEntry(Path(entry.path), raw_relative, admission)
+            continue
+        kind = _metadata_kind(direct)
+        admission = _PathAdmission(
+            _PathClass.ORDINARY,
+            raw_relative,
+            exists=True,
+            missing_policy=_MissingPathPolicy.OBSERVED,
+            native_kind=kind,
+        )
+        if kind is _NativeKind.REGULAR_FILE:
+            yield _SafeWalkEntry(Path(entry.path), raw_relative, admission)
+        elif kind is _NativeKind.DIRECTORY:
+            blocked = enter(Path(entry.path), parts)
+            if blocked is not None:
+                yield blocked
 
 
 def normalize_rel(relative_path: str) -> str:

--- a/packages/nauro/tests/test_sync/test_replica_control_excluded.py
+++ b/packages/nauro/tests/test_sync/test_replica_control_excluded.py
@@ -1,0 +1,964 @@
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import sys
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from nauro.store.replica_control import (
+    _REPLICA_CONTROL_LOCK_NAME,
+    _REPLICA_CONTROL_ROOT_NAME,
+)
+from nauro.sync import _windows_long_names as long_names
+from nauro.sync import merge
+from nauro.sync._path_diagnostics import (
+    _escape_path_for_display,
+    _MissingPathPolicy,
+    _NativeKind,
+    _PathClass,
+    _StoreRootPreparationError,
+    _unsafe_reason_text,
+    _UnsafeReason,
+)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (".replica", _PathClass.RESERVED_CONTROL),
+        (".replica/authority.json", _PathClass.RESERVED_CONTROL),
+        (".replica\\authority.json", _PathClass.RESERVED_CONTROL),
+        (" .RePlIcA. :stream/authority.json", _PathClass.RESERVED_CONTROL),
+        (".replica-control.lock", _PathClass.RESERVED_CONTROL),
+        (".replica-control.lock\\child", _PathClass.RESERVED_CONTROL),
+        (".replica .", _PathClass.RESERVED_CONTROL),
+        (".replica. .", _PathClass.RESERVED_CONTROL),
+        (".replica-control.lock .", _PathClass.RESERVED_CONTROL),
+        (".replica-control.lock. . ", _PathClass.RESERVED_CONTROL),
+        (".replica ./authority.json", _PathClass.RESERVED_CONTROL),
+        (".replica2/file", _PathClass.ORDINARY),
+        (".replica-control.lock.bak", _PathClass.ORDINARY),
+        ("context/.replica/file", _PathClass.ORDINARY),
+        ("context/.replica-control.lock", _PathClass.ORDINARY),
+        ("context/replica-notes.md", _PathClass.ORDINARY),
+    ],
+)
+def test_semantic_control_aliases(raw: str, expected: _PathClass) -> None:
+    assert merge._classify_sync_path(raw).path_class is expected
+
+
+@pytest.mark.parametrize(
+    ("raw", "reason"),
+    [
+        ("", _UnsafeReason.EMPTY_PATH),
+        ("/absolute", _UnsafeReason.RAW_ABSOLUTE),
+        ("\\rooted", _UnsafeReason.RAW_ROOTED),
+        ("C:relative", _UnsafeReason.RAW_DRIVE),
+        ("C:\\absolute", _UnsafeReason.RAW_DRIVE),
+        ("\\\\server\\share\\file", _UnsafeReason.RAW_UNC),
+        ("\\\\?\\C:\\file", _UnsafeReason.RAW_DEVICE),
+        ("//?/C:/file", _UnsafeReason.RAW_DEVICE),
+        ("\\\\?/C:/file", _UnsafeReason.RAW_DEVICE),
+        ("//./C:/file", _UnsafeReason.RAW_DEVICE),
+        ("\\\\./C:/file", _UnsafeReason.RAW_DEVICE),
+        ("../file", _UnsafeReason.RAW_PARENT),
+        ("context/../file", _UnsafeReason.RAW_PARENT),
+        ("context/ .. ", _UnsafeReason.FOLDED_PARENT),
+        ("context/ . ", _UnsafeReason.FOLDED_DOT),
+        ("context/. .", _UnsafeReason.FOLDED_EMPTY),
+        ("context/ :stream", _UnsafeReason.FOLDED_EMPTY),
+    ],
+)
+def test_hostile_sync_paths_are_unsafe(raw: str, reason: _UnsafeReason) -> None:
+    admission = merge._classify_sync_path(raw)
+    assert (admission.path_class, admission.reason) == (_PathClass.UNSAFE, reason)
+    assert admission.raw_identity == raw
+
+
+def test_later_unsafe_component_wins_over_reserved_prefix() -> None:
+    admission = merge._classify_sync_path(".replica/context/ :stream")
+    assert (admission.path_class, admission.reason) == (
+        _PathClass.UNSAFE,
+        _UnsafeReason.FOLDED_EMPTY,
+    )
+
+
+def test_shared_control_names() -> None:
+    assert (_REPLICA_CONTROL_ROOT_NAME, _REPLICA_CONTROL_LOCK_NAME) == (
+        ".replica",
+        ".replica-control.lock",
+    )
+
+
+def test_reason_text_is_closed_and_fixed() -> None:
+    expected = {
+        _UnsafeReason.RAW_ABSOLUTE: "The path is absolute.",
+        _UnsafeReason.RAW_ROOTED: "The path is rooted.",
+        _UnsafeReason.RAW_DRIVE: "The path uses drive syntax.",
+        _UnsafeReason.RAW_UNC: "The path uses UNC syntax.",
+        _UnsafeReason.RAW_DEVICE: "The path uses device syntax.",
+        _UnsafeReason.RAW_PARENT: "The path contains a parent component.",
+        _UnsafeReason.EMPTY_PATH: "The path has no usable component.",
+        _UnsafeReason.FOLDED_EMPTY: "A path component normalizes to empty.",
+        _UnsafeReason.FOLDED_DOT: "A path component normalizes to dot.",
+        _UnsafeReason.FOLDED_PARENT: "A path component normalizes to parent.",
+        _UnsafeReason.OUTSIDE_STORE: "The path resolves outside the Store root.",
+        _UnsafeReason.OBSERVATION_LOST: "The path changed after it was observed.",
+        _UnsafeReason.WINDOWS_NAME_LOOKUP_FAILED: "The Windows long-name lookup failed.",
+        _UnsafeReason.METADATA_UNAVAILABLE: "Path metadata is unavailable.",
+        _UnsafeReason.LINK_TARGET_UNREADABLE: "The link target is unavailable.",
+        _UnsafeReason.UNSUPPORTED_REPARSE: "The path uses an unsupported reparse point.",
+        _UnsafeReason.LINK_LOOP: "The path contains a link loop.",
+        _UnsafeReason.LINK_HOP_LIMIT: "The path exceeds the link hop limit.",
+        _UnsafeReason.NON_DIRECTORY_PARENT: ("A non-directory path has a remaining component."),
+    }
+    assert {reason: _unsafe_reason_text(reason) for reason in _UnsafeReason} == expected
+
+
+def test_display_escape_is_one_line_ascii() -> None:
+    raw = "space name\n\r\x1b'\"\\café\x00\x7f"
+    escaped = _escape_path_for_display(raw)
+    assert escaped == ("space\\x20name\\n\\r\\x1B\\x27\\x22\\\\caf\\xC3\\xA9\\x00\\x7F")
+    assert escaped.isascii()
+    assert not set("\n\r\x1b") & set(escaped)
+
+
+def test_display_escape_round_trips_surrogateescaped_byte() -> None:
+    assert _escape_path_for_display("name-\udcff") == "name-\\xFF"
+
+
+def test_prepare_store_root_retains_configured_and_canonical_paths(
+    tmp_path: Path, monkeypatch
+) -> None:
+    store = tmp_path / "store"
+    store.mkdir()
+    monkeypatch.chdir(tmp_path)
+    prepared = merge._prepare_store_root(Path("store"))
+    assert prepared.configured_root == Path("store")
+    assert not prepared.configured_root.is_absolute()
+    assert prepared.canonical_root == store.resolve()
+    assert prepared.canonical_root.is_absolute()
+
+
+@pytest.mark.parametrize("kind", ["missing", "file"])
+def test_prepare_store_root_has_fixed_suppressed_failure(tmp_path: Path, kind: str) -> None:
+    root = tmp_path / "root"
+    if kind == "file":
+        root.write_text("not a directory")
+    with pytest.raises(_StoreRootPreparationError) as raised:
+        merge._prepare_store_root(root)
+    assert str(raised.value) == "The Store root is unavailable."
+    assert raised.value.__cause__ is None
+    assert str(root) not in str(raised.value)
+
+
+def test_classifier_is_dormant() -> None:
+    sync_dir = Path(merge.__file__).parent
+    for source in sync_dir.glob("*.py"):
+        if source.name in {"merge.py", "_path_diagnostics.py", "_windows_long_names.py"}:
+            continue
+        text = source.read_text()
+        assert "_classify_sync_path" not in text
+        assert "_admit_native_path" not in text
+        assert "_walk_store_files" not in text
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX literal filename semantics")
+def test_posix_literal_control_alias_stops_before_metadata(tmp_path: Path, monkeypatch) -> None:
+    store = tmp_path / "store"
+    store.mkdir()
+    alias = store / ".replica\\child"
+    alias.write_text("control")
+    prepared = merge._prepare_store_root(store)
+    real_lstat = merge.os.lstat
+
+    def guarded_lstat(path: os.PathLike[str] | str):
+        if Path(path) == alias:
+            pytest.fail("reserved alias metadata")
+        return real_lstat(path)
+
+    monkeypatch.setattr(merge.os, "lstat", guarded_lstat)
+    result = merge._admit_native_path(prepared, alias.name, missing=_MissingPathPolicy.OBSERVED)
+    assert result.path_class is _PathClass.RESERVED_CONTROL
+
+
+@pytest.mark.parametrize(
+    ("raw", "path_class", "reason"),
+    [
+        ("./project.md", _PathClass.ORDINARY, None),
+        ("context//notes.md/", _PathClass.ORDINARY, None),
+        ("context\\\\notes.md\\", _PathClass.ORDINARY, None),
+        (" .replica /pointer.json", _PathClass.RESERVED_CONTROL, None),
+        (".REPLICA.../pointer.json", _PathClass.RESERVED_CONTROL, None),
+        (".replica:stream/pointer.json", _PathClass.RESERVED_CONTROL, None),
+        (".replica-control.lock :ads", _PathClass.RESERVED_CONTROL, None),
+        ("context/.", _PathClass.ORDINARY, None),
+        ("context/...", _PathClass.UNSAFE, _UnsafeReason.FOLDED_EMPTY),
+        ("context/  ", _PathClass.UNSAFE, _UnsafeReason.FOLDED_EMPTY),
+        ("context/.. ", _PathClass.UNSAFE, _UnsafeReason.FOLDED_PARENT),
+        ("context/. ", _PathClass.UNSAFE, _UnsafeReason.FOLDED_DOT),
+    ],
+)
+def test_semantic_normalization_table(
+    raw: str, path_class: _PathClass, reason: _UnsafeReason | None
+) -> None:
+    admission = merge._classify_sync_path(raw)
+    assert (admission.path_class, admission.reason) == (path_class, reason)
+
+
+def test_component_normalizer_expands_both_separators_without_changing_identity() -> None:
+    exact = ("context", "notes\\draft:stream")
+    view, reason = merge._normalize_component_path(exact, raw_identity="raw\\identity")
+    assert reason is None
+    assert view.raw_identity == "raw\\identity"
+    assert view.exact_components == exact
+    assert view.semantic_components == ("context", "notes", "draft")
+
+
+def test_admission_results_are_immutable_and_validate_invariants() -> None:
+    result = merge._classify_sync_path("project.md")
+    with pytest.raises(FrozenInstanceError):
+        result.raw_identity = "changed"
+    with pytest.raises(ValueError, match="unsafe path requires"):
+        merge._PathAdmission(_PathClass.UNSAFE, "raw")
+    with pytest.raises(ValueError, match="Only an unsafe"):
+        merge._PathAdmission(_PathClass.ORDINARY, "raw", reason=_UnsafeReason.METADATA_UNAVAILABLE)
+
+
+def test_optional_fixed_leaf_and_observed_missing(tmp_path: Path) -> None:
+    store = tmp_path / "store"
+    store.mkdir()
+    prepared = merge._prepare_store_root(store)
+    optional = merge._admit_native_path(
+        prepared, "new.json", missing=_MissingPathPolicy.OPTIONAL_FIXED_LEAF
+    )
+    observed = merge._admit_native_path(prepared, "new.json", missing=_MissingPathPolicy.OBSERVED)
+    assert (
+        optional.path_class,
+        optional.exists,
+        optional.missing_policy,
+        optional.native_kind,
+    ) == (
+        _PathClass.ORDINARY,
+        False,
+        _MissingPathPolicy.OPTIONAL_FIXED_LEAF,
+        None,
+    )
+    assert (observed.path_class, observed.reason) == (
+        _PathClass.UNSAFE,
+        _UnsafeReason.OBSERVATION_LOST,
+    )
+
+
+def test_optional_fixed_leaf_rejects_missing_intermediate(tmp_path: Path) -> None:
+    store = tmp_path / "store"
+    store.mkdir()
+    result = merge._admit_native_path(
+        merge._prepare_store_root(store),
+        os.path.join("missing", "leaf.json"),
+        missing=_MissingPathPolicy.OPTIONAL_FIXED_LEAF,
+    )
+    assert (result.path_class, result.reason) == (
+        _PathClass.UNSAFE,
+        _UnsafeReason.OBSERVATION_LOST,
+    )
+
+
+def test_create_destination_stops_probing_after_first_absence(tmp_path: Path, monkeypatch) -> None:
+    store = tmp_path / "store"
+    store.mkdir()
+    prepared = merge._prepare_store_root(store)
+    real_adapter = merge._existing_long_component
+    real_lstat = merge.os.lstat
+    operations: list[tuple[str, str]] = []
+
+    def probing_adapter(parent: Path, component: str) -> str | None:
+        operations.append(("adapter", component))
+        return real_adapter(parent, component)
+
+    def probing_lstat(path: os.PathLike[str] | str):
+        operations.append(("lstat", Path(path).name))
+        return real_lstat(path)
+
+    monkeypatch.setattr(merge, "_existing_long_component", probing_adapter)
+    monkeypatch.setattr(merge.os, "lstat", probing_lstat)
+    result = merge._admit_native_path(
+        prepared,
+        os.path.join("missing", "child", "new.md"),
+        missing=_MissingPathPolicy.CREATE_DESTINATION,
+    )
+    assert (result.path_class, result.exists, result.missing_policy) == (
+        _PathClass.ORDINARY,
+        False,
+        _MissingPathPolicy.CREATE_DESTINATION,
+    )
+    if sys.platform == "win32":
+        expected = [("adapter", "missing")]
+    else:
+        expected = [("adapter", "missing"), ("lstat", "missing")]
+    assert operations == expected
+    assert not {name for _, name in operations} & {"child", "new.md"}
+
+
+@pytest.mark.parametrize(
+    ("raw", "path_class", "reason"),
+    [
+        (" .replica. /child/new.md", _PathClass.RESERVED_CONTROL, None),
+        ("missing/ :stream/new.md", _PathClass.UNSAFE, _UnsafeReason.FOLDED_EMPTY),
+        ("missing/ .. /new.md", _PathClass.UNSAFE, _UnsafeReason.FOLDED_PARENT),
+    ],
+)
+def test_lexical_precheck_rejects_reserved_or_unsafe_suffix_before_access(
+    tmp_path: Path,
+    monkeypatch,
+    raw: str,
+    path_class: _PathClass,
+    reason: _UnsafeReason | None,
+) -> None:
+    store = tmp_path / "store"
+    store.mkdir()
+    prepared = merge._prepare_store_root(store)
+    monkeypatch.setattr(merge.os, "lstat", lambda *_: pytest.fail("metadata access"))
+    result = merge._admit_native_path(prepared, raw, missing=_MissingPathPolicy.CREATE_DESTINATION)
+    assert (result.path_class, result.reason) == (path_class, reason)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlink semantics")
+@pytest.mark.parametrize(
+    ("target", "reason"),
+    [
+        ("missing/..", _UnsafeReason.FOLDED_PARENT),
+        ("missing/ :stream/new.md", _UnsafeReason.FOLDED_EMPTY),
+    ],
+)
+def test_create_destination_rejects_link_inserted_suffix_after_absence(
+    tmp_path: Path, monkeypatch, target: str, reason: _UnsafeReason
+) -> None:
+    store = tmp_path / "store"
+    store.mkdir()
+    (store / "link").symlink_to(target)
+    prepared = merge._prepare_store_root(store)
+    real_adapter = merge._existing_long_component
+    real_lstat = merge.os.lstat
+    absent = store / "missing"
+
+    def guarded_adapter(parent: Path, component: str) -> str | None:
+        if parent == absent or absent in parent.parents:
+            pytest.fail("adapter under the absent component")
+        if component in {" :stream", "new.md", ".."}:
+            pytest.fail("adapter on the inserted suffix")
+        assert component in {"link", "missing"}
+        return real_adapter(parent, component)
+
+    def guarded_lstat(path: os.PathLike[str] | str):
+        if absent in Path(path).parents:
+            pytest.fail("metadata under the absent component")
+        return real_lstat(path)
+
+    monkeypatch.setattr(merge, "_existing_long_component", guarded_adapter)
+    monkeypatch.setattr(merge.os, "lstat", guarded_lstat)
+    result = merge._admit_native_path(
+        prepared, "link", missing=_MissingPathPolicy.CREATE_DESTINATION
+    )
+    assert (result.path_class, result.reason) == (_PathClass.UNSAFE, reason)
+
+
+def test_create_destination_skips_raw_dot_after_first_absence(tmp_path: Path) -> None:
+    store = tmp_path / "store"
+    store.mkdir()
+    result = merge._admit_native_path(
+        merge._prepare_store_root(store),
+        "missing/./new.md",
+        missing=_MissingPathPolicy.CREATE_DESTINATION,
+    )
+    assert (result.path_class, result.exists) == (_PathClass.ORDINARY, False)
+
+
+@pytest.mark.parametrize(
+    "missing", [_MissingPathPolicy.OBSERVED, _MissingPathPolicy.CREATE_DESTINATION]
+)
+def test_embedded_nul_is_unsafe_without_access(
+    tmp_path: Path, monkeypatch, missing: _MissingPathPolicy
+) -> None:
+    store = tmp_path / "store"
+    store.mkdir()
+    prepared = merge._prepare_store_root(store)
+    monkeypatch.setattr(merge.os, "lstat", lambda *_: pytest.fail("metadata access"))
+    monkeypatch.setattr(merge, "_existing_long_component", lambda *_: pytest.fail("adapter access"))
+    result = merge._admit_native_path(prepared, "nul\x00name", missing=missing)
+    assert (result.path_class, result.reason) == (
+        _PathClass.UNSAFE,
+        _UnsafeReason.METADATA_UNAVAILABLE,
+    )
+
+
+def test_returned_long_name_is_classified_before_metadata(tmp_path: Path, monkeypatch) -> None:
+    store = tmp_path / "store"
+    store.mkdir()
+    prepared = merge._prepare_store_root(store)
+    monkeypatch.setattr(
+        merge,
+        "_existing_long_component",
+        lambda _parent, component: (
+            _REPLICA_CONTROL_ROOT_NAME if component == "REPLIC~1" else component
+        ),
+    )
+    monkeypatch.setattr(merge.os, "lstat", lambda *_: pytest.fail("metadata access"))
+    result = merge._admit_native_path(
+        prepared, "REPLIC~1/pointer.json", missing=_MissingPathPolicy.OBSERVED
+    )
+    assert result.path_class is _PathClass.RESERVED_CONTROL
+
+
+@pytest.mark.parametrize("raw", [".replica/pointer.json", "context/ :stream"])
+def test_adapter_not_called_for_reserved_or_unsafe_component(
+    tmp_path: Path, monkeypatch, raw: str
+) -> None:
+    store = tmp_path / "store"
+    store.mkdir()
+    prepared = merge._prepare_store_root(store)
+    monkeypatch.setattr(merge, "_existing_long_component", lambda *_: pytest.fail("adapter access"))
+    monkeypatch.setattr(merge.os, "lstat", lambda *_: pytest.fail("metadata access"))
+    result = merge._admit_native_path(prepared, raw, missing=_MissingPathPolicy.OBSERVED)
+    assert result.path_class is not _PathClass.ORDINARY
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlink semantics")
+def test_adapter_not_called_for_target_inserted_control_component(
+    tmp_path: Path, monkeypatch
+) -> None:
+    store = tmp_path / "store"
+    store.mkdir()
+    (store / "alias").symlink_to(f"{_REPLICA_CONTROL_ROOT_NAME}/pointer.json")
+    prepared = merge._prepare_store_root(store)
+
+    def guarded_adapter(_parent: Path, component: str) -> str:
+        if component == _REPLICA_CONTROL_ROOT_NAME:
+            pytest.fail("adapter access on control component")
+        return component
+
+    monkeypatch.setattr(merge, "_existing_long_component", guarded_adapter)
+    result = merge._admit_native_path(prepared, "alias", missing=_MissingPathPolicy.OBSERVED)
+    assert result.path_class is _PathClass.RESERVED_CONTROL
+
+
+def test_create_destination_rejects_existing_non_directory_parent(tmp_path: Path) -> None:
+    store = tmp_path / "store"
+    store.mkdir()
+    (store / "file").write_text("content")
+    result = merge._admit_native_path(
+        merge._prepare_store_root(store),
+        os.path.join("file", "child"),
+        missing=_MissingPathPolicy.CREATE_DESTINATION,
+    )
+    assert (result.path_class, result.reason) == (
+        _PathClass.UNSAFE,
+        _UnsafeReason.NON_DIRECTORY_PARENT,
+    )
+
+
+def test_native_kinds_and_trailing_separator(tmp_path: Path) -> None:
+    store = tmp_path / "store"
+    store.mkdir()
+    (store / "directory").mkdir()
+    (store / "file").write_text("content")
+    prepared = merge._prepare_store_root(store)
+    directory = merge._admit_native_path(prepared, "directory", missing=_MissingPathPolicy.OBSERVED)
+    regular = merge._admit_native_path(prepared, "file", missing=_MissingPathPolicy.OBSERVED)
+    trailing = merge._admit_native_path(
+        prepared, f"file{os.sep}", missing=_MissingPathPolicy.OBSERVED
+    )
+    assert directory.native_kind is _NativeKind.DIRECTORY
+    assert regular.native_kind is _NativeKind.REGULAR_FILE
+    assert trailing.reason is _UnsafeReason.NON_DIRECTORY_PARENT
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlink semantics")
+def test_link_target_into_each_control_root_stops_before_target_metadata(
+    tmp_path: Path, monkeypatch
+) -> None:
+    store = tmp_path / "store"
+    store.mkdir()
+    targets = [store / _REPLICA_CONTROL_ROOT_NAME, store / _REPLICA_CONTROL_LOCK_NAME]
+    targets[0].mkdir()
+    targets[1].write_text("lock")
+    for index, target in enumerate(targets):
+        (store / f"alias-{index}").symlink_to(target, target_is_directory=target.is_dir())
+    prepared = merge._prepare_store_root(store)
+    real_lstat = merge.os.lstat
+
+    def guarded_lstat(path: os.PathLike[str] | str):
+        if Path(path) in targets:
+            pytest.fail("control target metadata")
+        return real_lstat(path)
+
+    monkeypatch.setattr(merge.os, "lstat", guarded_lstat)
+    for index in range(2):
+        result = merge._admit_native_path(
+            prepared, f"alias-{index}", missing=_MissingPathPolicy.OBSERVED
+        )
+        assert result.path_class is _PathClass.RESERVED_CONTROL
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlink semantics")
+def test_absolute_outside_link_stops_before_outside_metadata(tmp_path: Path, monkeypatch) -> None:
+    store = tmp_path / "store"
+    outside = tmp_path / "store-evil"
+    store.mkdir()
+    outside.mkdir()
+    (outside / "secret").write_text("secret")
+    (store / "alias").symlink_to(outside / "secret")
+    prepared = merge._prepare_store_root(store)
+    real_lstat = merge.os.lstat
+
+    def guarded_lstat(path: os.PathLike[str] | str):
+        if outside in Path(path).parents or Path(path) == outside:
+            pytest.fail("outside metadata")
+        return real_lstat(path)
+
+    monkeypatch.setattr(merge.os, "lstat", guarded_lstat)
+    result = merge._admit_native_path(prepared, "alias", missing=_MissingPathPolicy.OBSERVED)
+    assert (result.path_class, result.reason) == (
+        _PathClass.UNSAFE,
+        _UnsafeReason.OUTSIDE_STORE,
+    )
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlink semantics")
+def test_native_link_resolution_expands_before_parent(tmp_path: Path) -> None:
+    store = tmp_path / "store"
+    store.mkdir()
+    (store / _REPLICA_CONTROL_ROOT_NAME / "subdir").mkdir(parents=True)
+    (store / "a").symlink_to(f"{_REPLICA_CONTROL_ROOT_NAME}/subdir")
+    (store / "x").symlink_to("a/../secret")
+    result = merge._admit_native_path(
+        merge._prepare_store_root(store), "x", missing=_MissingPathPolicy.OBSERVED
+    )
+    assert result.path_class is _PathClass.RESERVED_CONTROL
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlink semantics")
+def test_native_link_parent_cannot_pop_above_store(tmp_path: Path) -> None:
+    store = tmp_path / "store"
+    outside = tmp_path / "outside"
+    store.mkdir()
+    outside.mkdir()
+    (store / "a").symlink_to("../outside/subdir")
+    (store / "x").symlink_to("a/../secret")
+    result = merge._admit_native_path(
+        merge._prepare_store_root(store), "x", missing=_MissingPathPolicy.OBSERVED
+    )
+    assert result.reason is _UnsafeReason.OUTSIDE_STORE
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlink semantics")
+def test_nested_link_to_file_rejects_remaining_components(tmp_path: Path) -> None:
+    store = tmp_path / "store"
+    store.mkdir()
+    (store / "file").write_text("content")
+    (store / "inner").symlink_to("file")
+    (store / "outer").symlink_to("inner/child")
+    result = merge._admit_native_path(
+        merge._prepare_store_root(store), "outer", missing=_MissingPathPolicy.OBSERVED
+    )
+    assert result.reason is _UnsafeReason.NON_DIRECTORY_PARENT
+
+
+def test_unsupported_reparse_point_is_rejected_before_readlink(tmp_path: Path, monkeypatch) -> None:
+    store = tmp_path / "store"
+    (store / "cloud").mkdir(parents=True)
+    prepared = merge._prepare_store_root(store)
+    reparse = SimpleNamespace(
+        st_mode=stat.S_IFDIR,
+        st_file_attributes=0x400,
+        st_reparse_tag=0x80000017,
+        st_dev=0,
+        st_ino=0,
+    )
+    monkeypatch.setattr(merge.os, "lstat", lambda *_: reparse)
+    monkeypatch.setattr(
+        merge.os, "readlink", lambda *_: pytest.fail("readlink on unsupported reparse")
+    )
+    result = merge._admit_native_path(prepared, "cloud", missing=_MissingPathPolicy.OBSERVED)
+    assert (result.path_class, result.reason) == (
+        _PathClass.UNSAFE,
+        _UnsafeReason.UNSUPPORTED_REPARSE,
+    )
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlink semantics")
+def test_unreadable_link_target_is_rejected(tmp_path: Path, monkeypatch) -> None:
+    store = tmp_path / "store"
+    store.mkdir()
+    (store / "link").symlink_to("target")
+    prepared = merge._prepare_store_root(store)
+
+    def failing_readlink(*_: object) -> str:
+        raise OSError("sentinel readlink detail")
+
+    monkeypatch.setattr(merge.os, "readlink", failing_readlink)
+    result = merge._admit_native_path(prepared, "link", missing=_MissingPathPolicy.OBSERVED)
+    assert result.reason is _UnsafeReason.LINK_TARGET_UNREADABLE
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlink semantics")
+def test_link_loop_and_hop_limit(tmp_path: Path) -> None:
+    store = tmp_path / "store"
+    store.mkdir()
+    (store / "loop-a").symlink_to("loop-b")
+    (store / "loop-b").symlink_to("loop-a")
+    prepared = merge._prepare_store_root(store)
+    loop = merge._admit_native_path(prepared, "loop-a", missing=_MissingPathPolicy.OBSERVED)
+    assert loop.reason is _UnsafeReason.LINK_LOOP
+
+    (store / "target").write_text("target")
+    for index in range(41, 0, -1):
+        target = "target" if index == 41 else f"hop-{index + 1}"
+        (store / f"hop-{index}").symlink_to(target)
+    at_limit = merge._admit_native_path(prepared, "hop-2", missing=_MissingPathPolicy.OBSERVED)
+    over_limit = merge._admit_native_path(prepared, "hop-1", missing=_MissingPathPolicy.OBSERVED)
+    assert at_limit.path_class is _PathClass.ORDINARY
+    assert over_limit.reason is _UnsafeReason.LINK_HOP_LIMIT
+
+
+def _prepared_windows_root(*parts: str, anchor: str = "C:\\"):
+    return merge._PreparedStoreRoot(
+        configured_root=Path("configured"),
+        canonical_root=Path("canonical"),
+        native_anchor=anchor,
+        canonical_parts=parts,
+    )
+
+
+@pytest.mark.parametrize(
+    ("target", "parts", "reason", "absolute"),
+    [
+        ("C:\\Store\\child", ["child"], None, True),
+        ("C:\\store\\child", None, _UnsafeReason.OUTSIDE_STORE, True),
+        ("C:\\StoreEvil\\child", None, _UnsafeReason.OUTSIDE_STORE, True),
+        ("D:\\Store\\child", None, _UnsafeReason.OUTSIDE_STORE, True),
+        ("C:relative", None, _UnsafeReason.OUTSIDE_STORE, False),
+        ("\\rooted", None, _UnsafeReason.OUTSIDE_STORE, False),
+        ("\\\\?\\C:\\Store\\child", ["child"], None, True),
+        ("\\??\\C:\\Store\\child", ["child"], None, True),
+        ("\\\\?\\Volume{abc}\\child", None, _UnsafeReason.UNSUPPORTED_REPARSE, False),
+        ("\\Device\\HarddiskVolume1\\child", None, _UnsafeReason.UNSUPPORTED_REPARSE, False),
+    ],
+)
+def test_windows_target_anchor_and_exact_component_comparison(
+    monkeypatch,
+    target: str,
+    parts: list[str] | None,
+    reason: _UnsafeReason | None,
+    absolute: bool,
+) -> None:
+    monkeypatch.setattr(merge.sys, "platform", "win32")
+    assert merge._absolute_target_suffix(target, _prepared_windows_root("Store")) == (
+        parts,
+        reason,
+        absolute,
+    )
+
+
+def test_windows_unc_target_routing(monkeypatch) -> None:
+    monkeypatch.setattr(merge.sys, "platform", "win32")
+    root = _prepared_windows_root("Root", anchor="\\\\server\\share\\")
+    assert merge._absolute_target_suffix("\\\\SERVER\\SHARE\\Root\\file", root) == (
+        ["file"],
+        None,
+        True,
+    )
+    assert merge._absolute_target_suffix("\\\\server\\other\\Root\\file", root)[1] is (
+        _UnsafeReason.OUTSIDE_STORE
+    )
+    assert merge._absolute_target_suffix("\\\\?\\UNC\\server\\share\\Root\\file", root) == (
+        ["file"],
+        None,
+        True,
+    )
+
+
+def test_long_name_adapter_is_noop_off_windows(tmp_path: Path) -> None:
+    if sys.platform != "win32":
+        assert long_names._existing_long_component(tmp_path, "Exact:Name") == "Exact:Name"
+
+
+def test_long_name_adapter_grows_buffer(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(long_names.sys, "platform", "win32")
+    monkeypatch.setattr(long_names.ctypes, "set_last_error", lambda _: None, raising=False)
+    calls: list[int] = []
+
+    def fake_lookup(path: str, buffer, size: int) -> int:
+        calls.append(size)
+        if len(calls) == 1:
+            return 400
+        buffer.value = os.fspath(tmp_path / "LongName.txt")
+        return len(buffer.value)
+
+    monkeypatch.setattr(long_names, "_get_long_path_name", fake_lookup)
+    assert long_names._existing_long_component(tmp_path, "LONGNA~1.TXT") == "LongName.txt"
+    assert calls == [260, 401]
+
+
+def test_long_name_adapter_uses_last_error_handle(monkeypatch, tmp_path: Path) -> None:
+    recorded: dict[str, object] = {}
+
+    class _FakeKernel32:
+        def __init__(self, name: str, **kwargs: object) -> None:
+            recorded["name"] = name
+            recorded.update(kwargs)
+
+        def __getattr__(self, _name: str):
+            def lookup(_path: str, buffer, _size: int) -> int:
+                buffer.value = os.fspath(tmp_path / "Long.txt")
+                return len(buffer.value)
+
+            return lookup
+
+    monkeypatch.setattr(long_names.sys, "platform", "win32")
+    monkeypatch.setattr(long_names.ctypes, "WinDLL", _FakeKernel32, raising=False)
+    monkeypatch.setattr(long_names.ctypes, "set_last_error", lambda _: None, raising=False)
+    assert long_names._existing_long_component(tmp_path, "LONG~1.TXT") == "Long.txt"
+    assert (recorded["name"], recorded.get("use_last_error")) == ("kernel32", True)
+
+
+@pytest.mark.parametrize("error", [2, 3])
+def test_long_name_adapter_maps_only_confirmed_not_found(monkeypatch, tmp_path, error) -> None:
+    monkeypatch.setattr(long_names.sys, "platform", "win32")
+    monkeypatch.setattr(long_names.ctypes, "set_last_error", lambda _: None, raising=False)
+    monkeypatch.setattr(long_names.ctypes, "get_last_error", lambda: error, raising=False)
+    monkeypatch.setattr(long_names, "_get_long_path_name", lambda *_: 0)
+    assert long_names._existing_long_component(tmp_path, "missing") is None
+
+
+def test_long_name_adapter_raises_other_errors_without_embedding_them(
+    monkeypatch, tmp_path
+) -> None:
+    monkeypatch.setattr(long_names.sys, "platform", "win32")
+    monkeypatch.setattr(long_names.ctypes, "set_last_error", lambda _: None, raising=False)
+    monkeypatch.setattr(long_names.ctypes, "get_last_error", lambda: 5, raising=False)
+    monkeypatch.setattr(long_names, "_get_long_path_name", lambda *_: 0)
+    with pytest.raises(OSError):
+        long_names._existing_long_component(tmp_path, "sentinel-secret")
+    assert _unsafe_reason_text(_UnsafeReason.WINDOWS_NAME_LOOKUP_FAILED) == (
+        "The Windows long-name lookup failed."
+    )
+
+
+class _EntryProxy:
+    def __init__(self, entry: os.DirEntry[str], *, forbid_follow: bool = False) -> None:
+        self._entry = entry
+        self.name = entry.name
+        self.path = entry.path
+        self.calls: list[bool] = []
+        self._forbid_follow = forbid_follow
+
+    def stat(self, *, follow_symlinks: bool = True):
+        self.calls.append(follow_symlinks)
+        if follow_symlinks and self._forbid_follow:
+            pytest.fail("following metadata before admission")
+        return self._entry.stat(follow_symlinks=follow_symlinks)
+
+    def is_file(self, *args, **kwargs):
+        pytest.fail("is_file called")
+
+    def is_dir(self, *args, **kwargs):
+        pytest.fail("is_dir called")
+
+
+class _Listing:
+    def __init__(self, entries: list[_EntryProxy]) -> None:
+        self.entries = entries
+
+    def __enter__(self):
+        return self
+
+    def __iter__(self):
+        return iter(self.entries)
+
+    def __exit__(self, *_):
+        return False
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlink semantics")
+def test_walker_prunes_control_links_before_following_or_descent(
+    tmp_path: Path, monkeypatch
+) -> None:
+    store = tmp_path / "store"
+    store.mkdir()
+    (store / _REPLICA_CONTROL_ROOT_NAME).mkdir()
+    (store / _REPLICA_CONTROL_LOCK_NAME).write_text("lock")
+    (store / "root-link").symlink_to(store / _REPLICA_CONTROL_ROOT_NAME, True)
+    (store / "lock-link").symlink_to(store / _REPLICA_CONTROL_LOCK_NAME)
+    with os.scandir(store) as listing:
+        proxies = [
+            _EntryProxy(entry, forbid_follow=entry.name.endswith("-link")) for entry in listing
+        ]
+    real_scandir = merge.os.scandir
+
+    def guarded_scandir(path: os.PathLike[str] | str):
+        if Path(path) == store:
+            return _Listing(proxies)
+        if Path(path).name in {_REPLICA_CONTROL_ROOT_NAME, _REPLICA_CONTROL_LOCK_NAME}:
+            pytest.fail("control descent")
+        return real_scandir(path)
+
+    monkeypatch.setattr(merge.os, "scandir", guarded_scandir)
+    assert list(merge._walk_store_files(merge._prepare_store_root(store))) == []
+    link_proxies = [entry for entry in proxies if entry.name.endswith("-link")]
+    assert [entry.calls for entry in link_proxies] == [[False], [False]]
+
+
+def test_walker_yields_files_and_prunes_reserved_entries(tmp_path: Path) -> None:
+    store = tmp_path / "store"
+    store.mkdir()
+    (store / "file.md").write_text("file")
+    (store / "context").mkdir()
+    (store / "context" / "note.md").write_text("note")
+    (store / _REPLICA_CONTROL_ROOT_NAME).mkdir()
+    (store / _REPLICA_CONTROL_ROOT_NAME / "secret").write_text("secret")
+    (store / _REPLICA_CONTROL_LOCK_NAME).write_text("lock")
+    results = list(merge._walk_store_files(merge._prepare_store_root(store)))
+    assert {entry.raw_relative_path for entry in results} == {
+        "file.md",
+        os.path.join("context", "note.md"),
+    }
+    assert all(entry.admission.native_kind is _NativeKind.REGULAR_FILE for entry in results)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX literal filename semantics")
+def test_walker_prunes_literal_backslash_alias_before_metadata(tmp_path: Path, monkeypatch) -> None:
+    store = tmp_path / "store"
+    store.mkdir()
+    alias = store / ".replica\\secret"
+    alias.write_text("secret")
+    with os.scandir(store) as listing:
+        proxy = _EntryProxy(next(iter(listing)))
+    monkeypatch.setattr(merge.os, "scandir", lambda *_: _Listing([proxy]))
+    assert list(merge._walk_store_files(merge._prepare_store_root(store))) == []
+    assert proxy.calls == []
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlink semantics")
+def test_walker_keeps_file_link_and_skips_directory_link(tmp_path: Path) -> None:
+    store = tmp_path / "store"
+    store.mkdir()
+    (store / "target.txt").write_text("target")
+    (store / "directory").mkdir()
+    (store / "directory" / "nested.txt").write_text("nested")
+    (store / "file-link").symlink_to("target.txt")
+    (store / "dir-link").symlink_to("directory", True)
+    results = list(merge._walk_store_files(merge._prepare_store_root(store)))
+    names = {entry.raw_relative_path for entry in results}
+    assert {"target.txt", "file-link", os.path.join("directory", "nested.txt")} == names
+    assert "dir-link" not in names
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows normalizes the unsafe name away")
+def test_walker_yields_unsafe_entry_once_and_prunes(tmp_path: Path) -> None:
+    store = tmp_path / "store"
+    store.mkdir()
+    unsafe = store / " .. "
+    unsafe.mkdir()
+    (unsafe / "hidden").write_text("hidden")
+    results = list(merge._walk_store_files(merge._prepare_store_root(store)))
+    assert len(results) == 1
+    assert results[0].raw_relative_path == " .. "
+    assert results[0].admission.reason is _UnsafeReason.FOLDED_PARENT
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX fifo semantics")
+def test_walker_skips_irregular_file(tmp_path: Path) -> None:
+    store = tmp_path / "store"
+    store.mkdir()
+    os.mkfifo(store / "pipe")
+    (store / "file.md").write_text("file")
+    results = list(merge._walk_store_files(merge._prepare_store_root(store)))
+    assert {entry.raw_relative_path for entry in results} == {"file.md"}
+
+
+def test_walker_survives_deep_tree_without_recursion(tmp_path: Path, monkeypatch) -> None:
+    store = tmp_path / "store"
+    store.mkdir()
+    depth = 1200
+
+    def fake_scandir(path: os.PathLike[str] | str):
+        level = len(Path(path).relative_to(store).parts)
+        if level < depth:
+            name, mode = "d", stat.S_IFDIR
+        else:
+            name, mode = "leaf.md", stat.S_IFREG
+        entry = SimpleNamespace(
+            name=name,
+            path=os.fspath(Path(path) / name),
+            stat=lambda follow_symlinks=True: SimpleNamespace(st_mode=mode),
+        )
+        return _Listing([entry])
+
+    monkeypatch.setattr(merge.os, "scandir", fake_scandir)
+    monkeypatch.setattr(merge, "_existing_long_component", lambda _parent, name: name)
+    results = list(merge._walk_store_files(merge._prepare_store_root(store)))
+    assert [entry.raw_relative_path for entry in results] == [
+        os.path.join(*(["d"] * depth), "leaf.md")
+    ]
+    assert results[0].admission.native_kind is _NativeKind.REGULAR_FILE
+
+
+def test_walker_yields_unscannable_directory_once(tmp_path: Path, monkeypatch) -> None:
+    store = tmp_path / "store"
+    blocked = store / "blocked"
+    blocked.mkdir(parents=True)
+    real_scandir = merge.os.scandir
+
+    def guarded_scandir(path: os.PathLike[str] | str):
+        if Path(path) == blocked:
+            raise OSError("sentinel filesystem detail")
+        return real_scandir(path)
+
+    monkeypatch.setattr(merge.os, "scandir", guarded_scandir)
+    results = list(merge._walk_store_files(merge._prepare_store_root(store)))
+    assert len(results) == 1
+    assert results[0].native_path == blocked
+    assert results[0].admission.reason is _UnsafeReason.METADATA_UNAVAILABLE
+    assert "sentinel" not in _unsafe_reason_text(results[0].admission.reason)
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows junction coverage")
+def test_real_windows_junction_into_control_is_reserved(tmp_path: Path) -> None:
+    store = tmp_path / "store"
+    target = store / _REPLICA_CONTROL_ROOT_NAME
+    junction = store / "junction"
+    target.mkdir(parents=True)
+    subprocess.run(
+        ["cmd", "/c", "mklink", "/J", os.fspath(junction), os.fspath(target)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    result = merge._admit_native_path(
+        merge._prepare_store_root(store), "junction", missing=_MissingPathPolicy.OBSERVED
+    )
+    assert result.path_class is _PathClass.RESERVED_CONTROL
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows 8.3 alias coverage")
+def test_real_windows_short_name_is_classified_from_returned_alias(tmp_path: Path) -> None:
+    import ctypes
+
+    directory = tmp_path / "Long Foundation Directory"
+    directory.mkdir()
+    buffer = ctypes.create_unicode_buffer(32768)
+    length = ctypes.windll.kernel32.GetShortPathNameW(  # type: ignore[attr-defined]
+        os.fspath(directory), buffer, len(buffer)
+    )
+    if not length:
+        pytest.fail("GetShortPathNameW failed")
+    if Path(buffer.value).name == directory.name:
+        pytest.skip("Windows did not provide a distinct 8.3 alias")
+    alias = Path(buffer.value).name
+    assert long_names._existing_long_component(directory.parent, alias) == directory.name


### PR DESCRIPTION
## Why

Legacy sync scans the whole Store as one mutable file tree and has no shared boundary that decides whether a path is ordinary content, local replica control state, or unsafe before it reads metadata, walks a directory, or writes. Control state must never be uploaded, overwritten by a pull, or staged by restore, and a hostile or accidental name must fail closed without leaking OS detail. This slice adds that boundary as a dormant foundation so later push, status, pull, and restore work can share one classifier.

## What changed

- Name the replica control root and lock once in `replica_control.py` and reuse the constants.
- Add package-private path admission in `sync/merge.py`: a shared component normalizer, a sync-input classifier, trusted Store-root preparation, a component-ordered resolver for symlinks and junctions, three missing-path policies, and a safe `os.scandir` walker.
- Classify before any lookup, metadata, listing, or content access. Reserved paths stop silently, including case, ADS, leading-space, trailing-space and period, composed, separator-expanded, and link-target aliases. Unsafe paths return one reason from a closed set with fixed text and a one-line ASCII display escape.
- Add `_path_diagnostics.py` (result types, reasons, escape) and `_windows_long_names.py` (a stdlib ctypes long-name adapter with correct last-error handling).
- Extend CI so the new tests run on Ubuntu, macOS, and Windows, plus a Windows Python 3.10 job.
- No production caller. Existing sync, replica-control, lock, and conflict behavior is unchanged.

## Test plan

- `uv run --no-sync --package nauro pytest packages/nauro/tests/test_sync/test_replica_control_excluded.py packages/nauro/tests/test_replica_control.py packages/nauro/tests/test_sync/test_merge.py -q`
  - 172 passed, 2 skipped
- `uv run --no-sync --package nauro pytest packages/nauro/tests/ --ignore=packages/nauro/tests/cross_surface -q`
  - 3,144 passed, 2 skipped
- `uv run --no-sync ruff check packages/ benchmarks/ scripts/` and `uv run --no-sync ruff format --check packages/ benchmarks/ scripts/`
- `uv run --no-sync --package nauro mypy --config-file packages/nauro/pyproject.toml packages/nauro/src/nauro` with no errors in the new modules
- Run the single-source, docstring-budget, and server JSON version repository guards.
- Verify the six-file scope, 1,675 changed lines against the approved 2,100 ceiling, and the dormant import boundary by grep and by test.
- Windows and macOS evidence comes from the CI jobs on this PR; local runs are macOS only.

## Risk / what to review

- Ordering: every long-name lookup, lstat, readlink, scandir, and following stat must sit after classification. Access-order tests cover the resolver, the missing-path policies, and the walker.
- Windows behavior (long-name lookup and last-error handling, junction target prefixes, 8.3 alias reclassification) is covered by mocks plus real-Windows tests that only run in CI.
- The guarantee covers stable pre-planted names, links, and junctions. It does not defend against mutation between checks. Hard links, bind mounts, and mount aliases are unsupported. Descriptor-relative no-follow I/O is the later upgrade path.

## Deferred

Push, status, link, pull, fixed-path, restore, and cleanup integration; projection download; installation; pointers; leases; routing; migration; release; activation.
