### PR TITLE
Route legacy push through sync path admission

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,8 @@ jobs:
           uv run --no-sync --package nauro pytest
           packages/nauro/tests/test_generation_authority.py
           packages/nauro/tests/test_replica_control.py
-          packages/nauro/tests/test_sync/test_replica_control_excluded.py -v --tb=short
+          packages/nauro/tests/test_sync/test_replica_control_excluded.py
+          packages/nauro/tests/test_sync/test_push_admission.py -v --tb=short
 
   test-sync-path-admission-windows-python310:
     runs-on: windows-latest
@@ -80,7 +81,8 @@ jobs:
       - run: uv sync --locked --package nauro --all-extras --python 3.10
       - run: >-
           uv run --no-sync --package nauro pytest
-          packages/nauro/tests/test_sync/test_replica_control_excluded.py -v --tb=short
+          packages/nauro/tests/test_sync/test_replica_control_excluded.py
+          packages/nauro/tests/test_sync/test_push_admission.py -v --tb=short
 
   distribution:
     runs-on: ubuntu-latest

--- a/packages/nauro/src/nauro/cli/commands/link.py
+++ b/packages/nauro/src/nauro/cli/commands/link.py
@@ -143,12 +143,18 @@ def link(
     # failure must not roll back the promotion, so we warn and exit 0 and
     # let the user retry the upload with 'nauro sync'.
     from nauro.auth import AuthRefreshError
+    from nauro.sync._path_diagnostics import _StoreRootPreparationError
     from nauro.sync.lock import SyncLockTimeoutError
     from nauro.sync.remote import PresignError
 
     try:
         pushed = push_changed_files(cloud_id, new_store)
-    except (AuthRefreshError, PresignError, SyncLockTimeoutError) as exc:
+    except (
+        AuthRefreshError,
+        PresignError,
+        SyncLockTimeoutError,
+        _StoreRootPreparationError,
+    ) as exc:
         typer.echo(
             f"  Warning: linked, but the initial cloud push failed ({exc}).\n"
             "  Run 'nauro sync' to upload the project store.",

--- a/packages/nauro/src/nauro/cli/commands/sync.py
+++ b/packages/nauro/src/nauro/cli/commands/sync.py
@@ -200,6 +200,7 @@ def _show_status(project_flag: str | None) -> None:
             raise
         return
 
+    from nauro.sync._path_diagnostics import _StoreRootPreparationError
     from nauro.sync.push import plan_push
     from nauro.sync.state import load_state
 
@@ -210,12 +211,13 @@ def _show_status(project_flag: str | None) -> None:
     typer.echo(f"  Last successful sync: {state.last_full_sync or 'never'}")
 
     try:
-        pending_local = [
-            candidate.relative_path for candidate in plan_push(store_path, state).candidates
-        ]
+        plan = plan_push(store_path, state)
+    except _StoreRootPreparationError as exc:
+        typer.echo(f"  Pending local changes: unknown ({exc})")
     except OSError as exc:
         typer.echo(f"  Pending local changes: unknown (store scan failed: {exc})")
     else:
+        pending_local = [candidate.relative_path for candidate in plan.candidates]
         if pending_local:
             typer.echo(f"  Pending local changes: {len(pending_local)}")
             for p in pending_local[:5]:
@@ -224,6 +226,12 @@ def _show_status(project_flag: str | None) -> None:
                 typer.echo(f"    ... and {len(pending_local) - 5} more")
         else:
             typer.echo("  Pending local changes: none")
+        if plan.unsafe:
+            typer.echo(f"  Unsafe paths skipped: {len(plan.unsafe)}")
+            for skipped in plan.unsafe[:5]:
+                typer.echo(f"    - {skipped.display}: {skipped.reason}")
+            if len(plan.unsafe) > 5:
+                typer.echo(f"    ... and {len(plan.unsafe) - 5} more")
 
     from nauro.sync.merge import CONFLICT_BACKUP_DIR
     from nauro.sync.quarantine import list_quarantine_backups, unresolved_quarantines

--- a/packages/nauro/src/nauro/sync/hooks.py
+++ b/packages/nauro/src/nauro/sync/hooks.py
@@ -89,6 +89,7 @@ def push_after_write(project_id: str, store_path: Path) -> PushReport:
         return PushReport()
 
     from nauro.auth import AuthRefreshError
+    from nauro.sync._path_diagnostics import _StoreRootPreparationError
     from nauro.sync.lock import HOOK_SYNC_LOCK_TIMEOUT, SyncLockTimeoutError
     from nauro.sync.push import push_changed_files
     from nauro.sync.remote import PresignError
@@ -106,6 +107,9 @@ def push_after_write(project_id: str, store_path: Path) -> PushReport:
     except PresignError as exc:
         logger.warning("sync push: presign request failed: %s", exc)
         return PushReport(failed=("transport",))
+    except _StoreRootPreparationError as exc:
+        logger.warning("sync push: %s", exc)
+        return PushReport(failed=("store root",))
     except Exception:
         logger.exception("sync push: unexpected failure for %s", project_id)
         return PushReport(failed=("unexpected failure",))

--- a/packages/nauro/src/nauro/sync/push.py
+++ b/packages/nauro/src/nauro/sync/push.py
@@ -23,8 +23,19 @@ from nauro_core.constants import MAX_BRIEF_BYTES
 
 from nauro.auth import AuthRefreshError, load_access_token
 from nauro.store.registry import is_cloud_project
+from nauro.sync._path_diagnostics import (
+    _escape_path_for_display,
+    _PathClass,
+    _StoreRootPreparationError,
+    _unsafe_reason_text,
+)
 from nauro.sync.lock import CLI_SYNC_LOCK_TIMEOUT, SyncLockTimeoutError, sync_lock
-from nauro.sync.merge import CONFLICT_BACKUP_DIR, should_skip
+from nauro.sync.merge import (
+    CONFLICT_BACKUP_DIR,
+    _prepare_store_root,
+    _walk_store_files,
+    should_skip,
+)
 from nauro.sync.remote import (
     PresignError,
     RetryClassification,
@@ -55,9 +66,16 @@ class OversizedBrief:
 
 
 @dataclass(frozen=True)
+class SkippedUnsafePath:
+    display: str
+    reason: str
+
+
+@dataclass(frozen=True)
 class PushPlan:
     candidates: tuple[PushCandidate, ...]
     oversized_briefs: tuple[OversizedBrief, ...]
+    unsafe: tuple[SkippedUnsafePath, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -100,13 +118,25 @@ def plan_push(store_path: Path, state: SyncState) -> PushPlan:
     """Select existing local files that the legacy PUT path can send."""
     candidates: list[PushCandidate] = []
     oversized_briefs: list[OversizedBrief] = []
-    for local_file in store_path.rglob("*"):
-        if not local_file.is_file():
+    unsafe: list[SkippedUnsafePath] = []
+    root = _prepare_store_root(store_path)
+    for entry in _walk_store_files(root):
+        admission = entry.admission
+        if admission.path_class is _PathClass.UNSAFE:
+            reason = admission.reason
+            if reason is not None:
+                # The walker reports an unscannable Store root as itself, with
+                # an empty relative path.
+                raw = entry.raw_relative_path
+                unsafe.append(
+                    SkippedUnsafePath(
+                        _escape_path_for_display(raw) if raw else "(Store root)",
+                        _unsafe_reason_text(reason),
+                    )
+                )
             continue
-        try:
-            rel = str(local_file.relative_to(store_path))
-        except ValueError:
-            continue
+        rel = entry.raw_relative_path
+        local_file = entry.native_path
         if should_skip(rel) or rel.startswith(CONFLICT_BACKUP_DIR) or rel.startswith("__pycache__"):
             continue
 
@@ -121,7 +151,7 @@ def plan_push(store_path: Path, state: SyncState) -> PushPlan:
         file_state = state.files.get(rel)
         if file_state is None or file_state.local_sha256 != local_sha:
             candidates.append(PushCandidate(rel, local_sha, local_file))
-    return PushPlan(tuple(candidates), tuple(oversized_briefs))
+    return PushPlan(tuple(candidates), tuple(oversized_briefs), tuple(unsafe))
 
 
 def push_store_to_cloud(
@@ -146,6 +176,9 @@ def push_store_to_cloud(
     except SyncLockTimeoutError as exc:
         typer.echo(f"  Warning: {exc}", err=True)
         return PushReport(failed=("sync lock",))
+    except _StoreRootPreparationError as exc:
+        typer.echo(f"  Warning: cloud push failed ({exc})", err=True)
+        return PushReport(failed=("store root",))
     except AuthRefreshError as exc:
         typer.echo(f"  {exc}", err=True)
         return PushReport(failed=("authentication",))
@@ -168,6 +201,9 @@ def push_changed_files(
     session: TransferSession | None = None,
 ) -> PushReport:
     """Upload changed files and checkpoint each verified result."""
+    # The sync lock creates its parent directory, so an unusable Store root is
+    # refused here, before the lock can recreate or trip over it.
+    _prepare_store_root(store_path)
     with operation_session(session) as active:
         with sync_lock(store_path, lock_timeout):
             return _push_changed_files_locked(project_id, store_path, active)
@@ -188,6 +224,8 @@ def _push_changed_files_locked(
             "It stays on your machine; trim it under the cap and re-sync to share it.",
             err=True,
         )
+    for item in plan.unsafe:
+        typer.echo(f"  Warning: {item.display} was not pushed: {item.reason}", err=True)
     planned = tuple(candidate.relative_path for candidate in plan.candidates)
     if not plan.candidates:
         save_state(store_path, state)
@@ -391,6 +429,7 @@ __all__ = [
     "PushCandidate",
     "PushPlan",
     "PushReport",
+    "SkippedUnsafePath",
     "plan_push",
     "push_changed_files",
     "push_store_to_cloud",

--- a/packages/nauro/tests/test_sync/test_push_admission.py
+++ b/packages/nauro/tests/test_sync/test_push_admission.py
@@ -1,0 +1,638 @@
+"""Legacy push enumerates the Store only through the sync path-admission walker."""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+from typer.testing import CliRunner
+
+from nauro.cli.main import app
+from nauro.store import registry
+from nauro.store.config import save_config
+from nauro.store.registry import register_project_v2
+from nauro.store.replica_control import (
+    _REPLICA_CONTROL_LOCK_NAME,
+    _REPLICA_CONTROL_ROOT_NAME,
+)
+from nauro.sync import cloud_projects, remote
+from nauro.sync import merge as merge_module
+from nauro.sync import push as push_module
+from nauro.sync._path_diagnostics import _StoreRootPreparationError
+from nauro.sync.hooks import push_after_write
+from nauro.sync.lock import SYNC_LOCK_FILE
+from nauro.sync.push import (
+    OversizedBrief,
+    PushReport,
+    SkippedUnsafePath,
+    plan_push,
+    push_changed_files,
+    push_store_to_cloud,
+)
+from nauro.sync.state import FileState, SyncState, compute_sha256, load_state, save_state
+from nauro.templates.scaffolds import scaffold_project_store
+from tests.conftest import seed_auth_config
+from tests.test_sync.conftest import CLOUD_PID, _scaffolded_cloud_project, track
+
+POSIX_ONLY = pytest.mark.skipif(sys.platform == "win32", reason="POSIX filename semantics")
+ROOT_TEXT = "The Store root is unavailable."
+OUTSIDE_TEXT = "The path resolves outside the Store root."
+PARENT_TEXT = "A path component normalizes to parent."
+METADATA_TEXT = "Path metadata is unavailable."
+OBSERVED_TEXT = "The path changed after it was observed."
+NOTE_KEY = os.path.join("context", "note.md")
+runner = CliRunner()
+
+
+def _plain_store(tmp_path: Path) -> Path:
+    store = tmp_path / "store"
+    (store / "context").mkdir(parents=True)
+    (store / "context" / "note.md").write_text("note\n")
+    return store
+
+
+def _cloud_store(tmp_path: Path, name: str = "pushadm") -> Path:
+    store = _scaffolded_cloud_project(name, tmp_path, project_id=CLOUD_PID)
+    seed_auth_config(variant="sync")
+    return store
+
+
+def _track_all(store: Path) -> None:
+    for path in store.rglob("*"):
+        if path.is_file() and not path.is_symlink():
+            track(store, str(path.relative_to(store)))
+
+
+def _presign_post(url, **kwargs):
+    operations = kwargs["json"]["operations"]
+    return httpx.Response(
+        200,
+        json={
+            "urls": [
+                {
+                    "verb": op["verb"],
+                    "path": op["path"],
+                    "url": f"https://s3.example/PUT/{op['path']}",
+                    "expires_at": "2026-05-29T13:00:00Z",
+                }
+                for op in operations
+            ]
+        },
+        request=httpx.Request("POST", url),
+    )
+
+
+def _ok_put():
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = 200
+    response.headers = {"ETag": '"e_pushed"'}
+    return response
+
+
+def _run_push(store: Path) -> tuple[PushReport, list[str]]:
+    with (
+        patch.object(remote.httpx.Client, "post", side_effect=_presign_post) as post,
+        patch.object(remote.httpx.Client, "put", return_value=_ok_put()),
+    ):
+        report = push_changed_files(CLOUD_PID, store)
+    put_paths = [
+        op["path"] for call in post.call_args_list for op in call.kwargs["json"]["operations"]
+    ]
+    return report, put_paths
+
+
+def _is_reserved(path: Path) -> bool:
+    for part in path.parts:
+        folded = part.split(":", 1)[0].strip(" ").rstrip(" .").casefold()
+        if folded in {_REPLICA_CONTROL_ROOT_NAME, _REPLICA_CONTROL_LOCK_NAME}:
+            return True
+    return False
+
+
+def _guard_access(monkeypatch, forbidden) -> None:
+    real_stat, real_read, real_sha = Path.stat, Path.read_bytes, push_module.compute_sha256
+
+    def check(path) -> None:
+        if forbidden(Path(path)):
+            pytest.fail(f"accessed {path}")
+
+    def stat(self, *args, **kwargs):
+        check(self)
+        return real_stat(self, *args, **kwargs)
+
+    def read_bytes(self):
+        check(self)
+        return real_read(self)
+
+    def sha(path):
+        check(path)
+        return real_sha(path)
+
+    monkeypatch.setattr(Path, "stat", stat)
+    monkeypatch.setattr(Path, "read_bytes", read_bytes)
+    monkeypatch.setattr(push_module, "compute_sha256", sha)
+
+
+# --- plan table ---
+
+
+@pytest.mark.parametrize(
+    "reserved",
+    [
+        _REPLICA_CONTROL_ROOT_NAME,
+        ".Replica",
+        f" {_REPLICA_CONTROL_ROOT_NAME}",
+        pytest.param(f"{_REPLICA_CONTROL_ROOT_NAME}.", marks=POSIX_ONLY),
+        pytest.param(f"{_REPLICA_CONTROL_ROOT_NAME} ", marks=POSIX_ONLY),
+        pytest.param(f"{_REPLICA_CONTROL_ROOT_NAME}:stream", marks=POSIX_ONLY),
+    ],
+)
+def test_reserved_root_aliases_never_become_candidates(tmp_path: Path, reserved: str) -> None:
+    store = _plain_store(tmp_path)
+    (store / reserved / "pointer").mkdir(parents=True)
+    (store / reserved / "authority.json").write_text("{}")
+    (store / reserved / "pointer" / "actor.json").write_text("{}")
+    plan = plan_push(store, SyncState())
+    assert [c.relative_path for c in plan.candidates] == [NOTE_KEY]
+    assert plan.unsafe == ()
+
+
+@pytest.mark.parametrize(
+    "reserved",
+    [
+        _REPLICA_CONTROL_LOCK_NAME,
+        ".Replica-Control.LOCK",
+        f" {_REPLICA_CONTROL_LOCK_NAME}",
+        pytest.param(f"{_REPLICA_CONTROL_LOCK_NAME}.", marks=POSIX_ONLY),
+        pytest.param(f"{_REPLICA_CONTROL_LOCK_NAME}\\child", marks=POSIX_ONLY),
+    ],
+)
+def test_reserved_lock_aliases_never_become_candidates(tmp_path: Path, reserved: str) -> None:
+    store = _plain_store(tmp_path)
+    (store / reserved).write_text("lock")
+    plan = plan_push(store, SyncState())
+    assert [c.relative_path for c in plan.candidates] == [NOTE_KEY]
+    assert plan.unsafe == ()
+
+
+def test_ordinary_keys_and_exclusions_are_unchanged(tmp_path: Path) -> None:
+    store = tmp_path / "store"
+    (store / "context").mkdir(parents=True)
+    (store / "stack.md").write_text("stack\n")
+    (store / "context" / "new.md").write_text("new\n")
+    (store / "context" / "draft.md.lock").write_text("lock\n")
+    (store / "journal").mkdir()
+    (store / "journal" / "events.jsonl").write_text("{}\n")
+    (store / ".pull-spool-dead").mkdir()
+    (store / ".pull-spool-dead" / "000000").write_text("scratch\n")
+    (store / ".conflict-backup").mkdir()
+    (store / ".conflict-backup" / "loser.md").write_text("backup\n")
+    (store / "__pycache__").mkdir()
+    (store / "__pycache__" / "x.pyc").write_text("pyc\n")
+    (store / "nauro-graph.html").write_text("generated\n")
+    (store / ".sync-state.json").write_text("{}\n")
+    (store / "deleted.md").write_text("gone\n")
+    state = SyncState()
+    state.files["deleted.md"] = FileState(
+        local_sha256=compute_sha256(store / "deleted.md"),
+        remote_etag='"synced"',
+        last_sync="2026-05-16T00:00:00Z",
+    )
+    (store / "deleted.md").unlink()
+    plan = plan_push(store, state)
+    assert sorted(c.relative_path for c in plan.candidates) == sorted(
+        ["stack.md", os.path.join("context", "new.md")]
+    )
+    assert plan.oversized_briefs == ()
+    assert plan.unsafe == ()
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="oversized detection keys on the POSIX 'context/' prefix",
+)
+def test_oversized_brief_is_reported_and_never_a_candidate(tmp_path: Path) -> None:
+    store = _plain_store(tmp_path)
+    size = push_module.MAX_BRIEF_BYTES + 1
+    (store / "context" / "big.md").write_text("x" * size)
+    plan = plan_push(store, SyncState())
+    assert plan.oversized_briefs == (OversizedBrief(os.path.join("context", "big.md"), size),)
+    assert [c.relative_path for c in plan.candidates] == [NOTE_KEY]
+    assert plan.unsafe == ()
+
+
+def test_plan_push_never_uses_rglob(tmp_path: Path, monkeypatch) -> None:
+    store = _plain_store(tmp_path)
+    monkeypatch.setattr(Path, "rglob", lambda *args, **kwargs: pytest.fail("rglob"))
+    assert [c.relative_path for c in plan_push(store, SyncState()).candidates] == [NOTE_KEY]
+
+
+# --- access-order table ---
+
+
+def test_push_never_reads_reserved_paths(tmp_path: Path, monkeypatch) -> None:
+    store = _cloud_store(tmp_path)
+    (store / _REPLICA_CONTROL_ROOT_NAME).mkdir()
+    (store / _REPLICA_CONTROL_ROOT_NAME / "authority.json").write_text("{}")
+    (store / _REPLICA_CONTROL_LOCK_NAME).write_text("lock")
+    (store / "stack.md").write_text("changed\n")
+    _guard_access(monkeypatch, _is_reserved)
+    captured: list[list[dict]] = []
+
+    def fake_presign(project_id, operations, **_kwargs):
+        captured.append(operations)
+        return []
+
+    with patch("nauro.sync.remote.request_presigned_urls", side_effect=fake_presign):
+        report = push_changed_files(CLOUD_PID, store)
+
+    paths = [op["path"] for ops in captured for op in ops]
+    assert "stack.md" in paths
+    assert not any(_is_reserved(Path(path)) for path in paths)
+    assert report.planned == tuple(paths)
+
+
+@POSIX_ONLY
+def test_push_never_reads_control_or_outside_link_targets(tmp_path: Path, monkeypatch) -> None:
+    store = _cloud_store(tmp_path)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secret").write_text("secret\n")
+    (store / _REPLICA_CONTROL_ROOT_NAME).mkdir()
+    (store / _REPLICA_CONTROL_ROOT_NAME / "authority.json").write_text("{}")
+    (store / "alias").symlink_to(store / _REPLICA_CONTROL_ROOT_NAME / "authority.json")
+    (store / "evil").symlink_to(outside / "secret")
+    _track_all(store)
+    _guard_access(
+        monkeypatch,
+        lambda path: _is_reserved(path) or path == outside or outside in path.parents,
+    )
+
+    with patch("nauro.sync.remote.request_presigned_urls", side_effect=AssertionError):
+        report = push_changed_files(CLOUD_PID, store)
+
+    assert report == PushReport()
+
+
+# --- link table ---
+
+
+@POSIX_ONLY
+def test_link_entries_follow_admission(tmp_path: Path) -> None:
+    store = _plain_store(tmp_path)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secret").write_text("secret\n")
+    (store / _REPLICA_CONTROL_ROOT_NAME).mkdir()
+    (store / _REPLICA_CONTROL_ROOT_NAME / "authority.json").write_text("{}")
+    (store / _REPLICA_CONTROL_LOCK_NAME).write_text("lock")
+    (store / "file-link").symlink_to("context/note.md")
+    (store / "root-link").symlink_to(f"{_REPLICA_CONTROL_ROOT_NAME}/authority.json")
+    (store / "lock-link").symlink_to(_REPLICA_CONTROL_LOCK_NAME)
+    (store / "evil").symlink_to(outside / "secret")
+    (store / "dir-link").symlink_to("context", target_is_directory=True)
+    (store / "dangling").symlink_to("missing")
+    plan = plan_push(store, SyncState())
+    assert sorted(c.relative_path for c in plan.candidates) == [NOTE_KEY, "file-link"]
+    assert len(plan.unsafe) == 2
+    assert set(plan.unsafe) == {
+        SkippedUnsafePath("dangling", OBSERVED_TEXT),
+        SkippedUnsafePath("evil", OUTSIDE_TEXT),
+    }
+
+
+# --- unsafe table ---
+
+
+@POSIX_ONLY
+def test_unsafe_directory_is_reported_once_and_never_pushed(tmp_path: Path, capsys) -> None:
+    store = _cloud_store(tmp_path)
+    _track_all(store)
+    hostile = store / " .. "
+    hostile.mkdir()
+    (hostile / "hidden").write_text("hidden\n")
+    (store / "stack.md").write_text("changed\n")
+
+    report, put_paths = _run_push(store)
+
+    assert report.is_complete and report.planned == ("stack.md",)
+    assert put_paths == ["stack.md"]
+    warnings = [line for line in capsys.readouterr().err.splitlines() if "not pushed" in line]
+    assert warnings == [f"  Warning: \\x20..\\x20 was not pushed: {PARENT_TEXT}"]
+
+
+def test_unscannable_directory_is_reported_once_and_never_pushed(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    store = _cloud_store(tmp_path)
+    _track_all(store)
+    blocked = store / "blocked"
+    blocked.mkdir()
+    (blocked / "hidden").write_text("hidden\n")
+    real_scandir = merge_module.os.scandir
+
+    def guarded_scandir(path):
+        if Path(path) == blocked:
+            raise OSError("sentinel filesystem detail")
+        return real_scandir(path)
+
+    monkeypatch.setattr(merge_module.os, "scandir", guarded_scandir)
+
+    report, put_paths = _run_push(store)
+
+    assert report == PushReport()
+    assert put_paths == []
+    err = capsys.readouterr().err
+    assert err.splitlines() == [f"  Warning: blocked was not pushed: {METADATA_TEXT}"]
+    assert "sentinel" not in err
+
+
+def test_unscannable_store_root_is_reported_as_the_root(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    store = _cloud_store(tmp_path)
+    _track_all(store)
+    canonical = store.resolve()
+    real_scandir = merge_module.os.scandir
+
+    def guarded_scandir(path):
+        if Path(path) == canonical:
+            raise OSError("sentinel filesystem detail")
+        return real_scandir(path)
+
+    monkeypatch.setattr(merge_module.os, "scandir", guarded_scandir)
+    plan = plan_push(store, load_state(store))
+    assert plan.candidates == ()
+    assert plan.unsafe == (SkippedUnsafePath("(Store root)", METADATA_TEXT),)
+
+    report, put_paths = _run_push(store)
+
+    assert report == PushReport()
+    assert put_paths == []
+    err = capsys.readouterr().err
+    assert err.splitlines() == [f"  Warning: (Store root) was not pushed: {METADATA_TEXT}"]
+    assert "sentinel" not in err
+
+
+# --- root table ---
+
+BAD_ROOTS = ["file", "missing"]
+
+
+def _bad_root(tmp_path: Path, condition: str) -> Path:
+    root = tmp_path / "bad-store"
+    if condition == "file":
+        root.write_text("not a directory")
+    return root
+
+
+def _assert_root_untouched(root: Path, condition: str) -> None:
+    if condition == "missing":
+        assert not root.exists()
+    else:
+        assert root.is_file()
+    assert not (root / SYNC_LOCK_FILE).is_file()
+
+
+def _assert_no_leak(text: str, path: Path) -> None:
+    assert str(path) not in text
+    assert path.name not in text
+    for marker in ("Errno", "No such file", "Not a directory", "File exists"):
+        assert marker not in text
+
+
+@pytest.mark.parametrize("condition", BAD_ROOTS)
+def test_plan_push_raises_fixed_error_for_bad_root(tmp_path: Path, condition: str) -> None:
+    root = _bad_root(tmp_path, condition)
+    with pytest.raises(_StoreRootPreparationError) as raised:
+        plan_push(root, SyncState())
+    assert str(raised.value) == ROOT_TEXT
+    _assert_root_untouched(root, condition)
+
+
+@pytest.mark.parametrize("condition", BAD_ROOTS)
+def test_push_changed_files_refuses_bad_root_before_the_lock(
+    tmp_path: Path, condition: str
+) -> None:
+    _cloud_store(tmp_path)
+    root = _bad_root(tmp_path, condition)
+    with (
+        patch("nauro.sync.remote.request_presigned_urls", side_effect=AssertionError),
+        pytest.raises(_StoreRootPreparationError) as raised,
+    ):
+        push_changed_files(CLOUD_PID, root)
+    assert str(raised.value) == ROOT_TEXT
+    _assert_root_untouched(root, condition)
+
+
+@pytest.mark.parametrize("condition", BAD_ROOTS)
+def test_push_store_to_cloud_reports_store_root(tmp_path: Path, capsys, condition: str) -> None:
+    _cloud_store(tmp_path)
+    root = _bad_root(tmp_path, condition)
+    with patch("nauro.sync.remote.request_presigned_urls", side_effect=AssertionError):
+        report = push_store_to_cloud(CLOUD_PID, root)
+    assert report == PushReport(failed=("store root",))
+    captured = capsys.readouterr()
+    assert captured.err.splitlines() == [f"  Warning: cloud push failed ({ROOT_TEXT})"]
+    _assert_no_leak(captured.out + captured.err, root)
+    _assert_root_untouched(root, condition)
+
+
+@pytest.mark.parametrize("condition", BAD_ROOTS)
+def test_push_after_write_reports_store_root_without_raising(
+    tmp_path: Path, caplog, capsys, condition: str
+) -> None:
+    _cloud_store(tmp_path)
+    root = _bad_root(tmp_path, condition)
+    with caplog.at_level(logging.WARNING, logger="nauro.sync"):
+        report = push_after_write(CLOUD_PID, root)
+    assert report == PushReport(failed=("store root",))
+    assert f"sync push: {ROOT_TEXT}" in caplog.text
+    captured = capsys.readouterr()
+    _assert_no_leak(caplog.text + captured.out + captured.err, root)
+    _assert_root_untouched(root, condition)
+
+
+@pytest.mark.parametrize("condition", BAD_ROOTS)
+def test_link_cloud_exits_without_traceback_on_bad_store_root(
+    tmp_path: Path, monkeypatch, condition: str
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    seed_auth_config()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("NAURO_API_URL", "https://example.test")
+    assert runner.invoke(app, ["init", "linkproj"]).exit_code == 0
+    local_id, _entry = registry.find_projects_by_name_v2("linkproj")[0]
+    store = registry.get_store_path_v2(local_id)
+    shutil.rmtree(store)
+    if condition == "file":
+        store.write_text("not a directory")
+
+    with (
+        patch.object(cloud_projects.httpx, "request", side_effect=AssertionError),
+        patch.object(remote.httpx.Client, "post", side_effect=AssertionError),
+    ):
+        result = runner.invoke(app, ["link", "--cloud"])
+
+    # link resolves the registered project before it reaches the shared push,
+    # so a bad Store root is refused there and the promotion never starts.
+    assert result.exit_code == 1, result.output
+    assert isinstance(result.exception, SystemExit)
+    assert "nauro reconnect" in result.output
+    _assert_no_leak(result.output, store)
+    assert registry.get_project_v2(local_id) is not None
+    assert registry.get_project_v2(CLOUD_PID) is None
+
+
+# --- state table ---
+
+
+def test_reserved_state_entries_are_left_untouched(tmp_path: Path) -> None:
+    store = _cloud_store(tmp_path)
+    _track_all(store)
+    reserved_key = os.path.join(_REPLICA_CONTROL_ROOT_NAME, "authority.json")
+    seeded = FileState(
+        local_sha256="0" * 64, remote_etag='"stale"', last_sync="2026-01-01T00:00:00Z"
+    )
+    state = load_state(store)
+    state.files[reserved_key] = seeded
+    save_state(store, state)
+    (store / _REPLICA_CONTROL_ROOT_NAME).mkdir()
+    (store / _REPLICA_CONTROL_ROOT_NAME / "authority.json").write_text("{}")
+    (store / "context").mkdir(exist_ok=True)
+    (store / "context" / "new.md").write_text("new\n")
+
+    report, put_paths = _run_push(store)
+
+    new_key = os.path.join("context", "new.md")
+    assert report.is_complete and report.verified == (new_key,)
+    assert put_paths == [new_key]
+    after = load_state(store)
+    assert after.files[reserved_key] == seeded
+    assert after.files[new_key].remote_etag == '"e_pushed"'
+
+
+# --- status table ---
+
+
+def _status_store(tmp_path: Path, monkeypatch) -> Path:
+    _pid, store = register_project_v2("statusproj", [tmp_path])
+    scaffold_project_store("statusproj", store)
+    save_config({"auth": {"sub": "auth0|test", "access_token": "tok", "refresh_token": "refresh"}})
+    monkeypatch.chdir(tmp_path)
+    return store
+
+
+def test_status_hides_reserved_and_lists_unscannable(tmp_path: Path, monkeypatch) -> None:
+    store = _status_store(tmp_path, monkeypatch)
+    _track_all(store)
+    (store / _REPLICA_CONTROL_ROOT_NAME).mkdir()
+    (store / _REPLICA_CONTROL_ROOT_NAME / "authority.json").write_text("{}")
+    (store / _REPLICA_CONTROL_LOCK_NAME).write_text("lock")
+    blocked = store / "blocked"
+    blocked.mkdir()
+    real_scandir = merge_module.os.scandir
+
+    def guarded_scandir(path):
+        if Path(path) == blocked:
+            raise OSError("sentinel filesystem detail")
+        return real_scandir(path)
+
+    monkeypatch.setattr(merge_module.os, "scandir", guarded_scandir)
+    result = runner.invoke(app, ["sync", "--status"])
+
+    assert result.exit_code == 0, result.output
+    assert "Pending local changes: none" in result.output
+    assert "Unsafe paths skipped: 1" in result.output
+    assert f"    - blocked: {METADATA_TEXT}" in result.output
+    assert "replica" not in result.output
+    assert "sentinel" not in result.output
+
+
+def test_status_lists_the_store_root_when_unscannable(tmp_path: Path, monkeypatch) -> None:
+    store = _status_store(tmp_path, monkeypatch)
+    canonical = store.resolve()
+    real_scandir = merge_module.os.scandir
+
+    def guarded_scandir(path):
+        if Path(path) == canonical:
+            raise OSError("sentinel filesystem detail")
+        return real_scandir(path)
+
+    monkeypatch.setattr(merge_module.os, "scandir", guarded_scandir)
+    result = runner.invoke(app, ["sync", "--status"])
+
+    assert result.exit_code == 0, result.output
+    assert "  Unsafe paths skipped: 1" in result.output
+    assert f"    - (Store root): {METADATA_TEXT}" in result.output
+    assert "sentinel" not in result.output
+
+
+@POSIX_ONLY
+def test_status_caps_unsafe_lines_at_five(tmp_path: Path, monkeypatch) -> None:
+    store = _status_store(tmp_path, monkeypatch)
+    _track_all(store)
+    for name in (" .. ", ".. ", ". ", " . ", "...", "  "):
+        (store / name).mkdir()
+    result = runner.invoke(app, ["sync", "--status"])
+
+    assert result.exit_code == 0, result.output
+    assert "Unsafe paths skipped: 6" in result.output
+    listed = [line for line in result.output.splitlines() if line.startswith("    - ")]
+    assert len(listed) == 5
+    assert all(line.endswith(f": {PARENT_TEXT}") or ": A path component" in line for line in listed)
+    assert "    ... and 1 more" in result.output
+    assert " " not in "".join(line[6:].split(": ")[0] for line in listed)
+
+
+def test_status_reports_fixed_unknown_line_for_bad_root(tmp_path: Path, monkeypatch) -> None:
+    store = _status_store(tmp_path, monkeypatch)
+    (store / ".conflict-backup").mkdir()
+    (store / ".conflict-backup" / "loser.md").write_text("backup\n")
+    monkeypatch.setattr(
+        push_module, "_prepare_store_root", MagicMock(side_effect=_StoreRootPreparationError())
+    )
+    result = runner.invoke(app, ["sync", "--status"])
+
+    assert result.exit_code == 0, result.output
+    assert f"  Pending local changes: unknown ({ROOT_TEXT})" in result.output
+    assert "Conflict backups: 1" in result.output
+    assert str(store) not in result.output.split("Pending local changes", 1)[1]
+
+
+# --- hook table ---
+
+
+def test_hook_push_skips_reserved_and_unsafe_through_the_shared_plan(
+    tmp_path: Path, monkeypatch
+) -> None:
+    store = _cloud_store(tmp_path)
+    _track_all(store)
+    (store / _REPLICA_CONTROL_ROOT_NAME).mkdir()
+    (store / _REPLICA_CONTROL_ROOT_NAME / "authority.json").write_text("{}")
+    (store / "stack.md").write_text("changed\n")
+    blocked = store / "blocked"
+    blocked.mkdir()
+    real_scandir = merge_module.os.scandir
+
+    def guarded_scandir(path):
+        if Path(path) == blocked:
+            raise OSError("sentinel filesystem detail")
+        return real_scandir(path)
+
+    monkeypatch.setattr(merge_module.os, "scandir", guarded_scandir)
+    with (
+        patch.object(remote.httpx.Client, "post", side_effect=_presign_post) as post,
+        patch.object(remote.httpx.Client, "put", return_value=_ok_put()),
+    ):
+        report = push_after_write(CLOUD_PID, store)
+
+    assert report.is_complete and report.verified == ("stack.md",)
+    ops = [op["path"] for call in post.call_args_list for op in call.kwargs["json"]["operations"]]
+    assert ops == ["stack.md"]

--- a/packages/nauro/tests/test_sync/test_replica_control_excluded.py
+++ b/packages/nauro/tests/test_sync/test_replica_control_excluded.py
@@ -157,15 +157,19 @@ def test_prepare_store_root_has_fixed_suppressed_failure(tmp_path: Path, kind: s
     assert str(root) not in str(raised.value)
 
 
-def test_classifier_is_dormant() -> None:
-    sync_dir = Path(merge.__file__).parent
-    for source in sync_dir.glob("*.py"):
-        if source.name in {"merge.py", "_path_diagnostics.py", "_windows_long_names.py"}:
-            continue
+def test_admission_has_exactly_one_enumerating_caller() -> None:
+    src_root = Path(merge.__file__).parents[2]
+    allowed = {
+        "_walk_store_files": {"sync/merge.py", "sync/push.py"},
+        "_prepare_store_root": {"sync/merge.py", "sync/push.py"},
+        "_admit_native_path": {"sync/merge.py"},
+        "_classify_sync_path": {"sync/merge.py"},
+    }
+    for source in src_root.rglob("*.py"):
+        relative = source.relative_to(src_root / "nauro").as_posix()
         text = source.read_text()
-        assert "_classify_sync_path" not in text
-        assert "_admit_native_path" not in text
-        assert "_walk_store_files" not in text
+        for name, owners in allowed.items():
+            assert name not in text or relative in owners, (name, relative)
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX literal filename semantics")

--- a/packages/nauro/tests/test_sync/test_replica_control_excluded.py
+++ b/packages/nauro/tests/test_sync/test_replica_control_excluded.py
@@ -167,7 +167,7 @@ def test_admission_has_exactly_one_enumerating_caller() -> None:
     }
     for source in src_root.rglob("*.py"):
         relative = source.relative_to(src_root / "nauro").as_posix()
-        text = source.read_text()
+        text = source.read_text(encoding="utf-8")
         for name, owners in allowed.items():
             assert name not in text or relative in owners, (name, relative)
 


### PR DESCRIPTION
## Why

Legacy push enumerated the whole Store with `rglob` and followed file symlinks, so a local control file, an alias of one, or a link to control or outside content would be hashed, read, presigned, and uploaded as ordinary content. The admission layer merged in #508 was dormant. This is its first production caller: the shared push plan now enumerates through the admission walker, so replica control state never enters a push and unsafe paths are skipped without access and reported with fixed text.

## What changed

- `plan_push` enumerates through `_walk_store_files` over a prepared Store root instead of `rglob`. Reserved control paths, their aliases, and their link targets never reach `should_skip`, hashing, reads, presign, PUT, sync-state, or status output. Existing exclusions, the sync-state key form, and the transport loop are unchanged.
- `PushPlan` gains `unsafe`, a tuple of `SkippedUnsafePath(display, reason)` carrying only the escaped display form and the fixed reason text. Push warns once per entry on stderr and keeps them out of the report, so `nauro sync` still exits 0 for them, the same loud-skip shape oversized briefs already use.
- `push_changed_files` prepares the Store root before taking the sync lock, so a missing or non-directory root is refused with a fixed message before the lock can create anything. `push_store_to_cloud`, the post-write hook, `link --cloud`, and `sync --status` each handle the typed error with fixed wording and no path leak.
- `sync --status` never shows reserved entries and lists unsafe entries as `Unsafe paths skipped: N`, capped at five lines.
- Sync-state entries recorded under reserved paths are left untouched and nothing is deleted locally or remotely.
- CI runs the new tests on Ubuntu, macOS, and Windows, plus the Windows Python 3.10 job.

## Test plan

- `uv run --no-sync --package nauro pytest packages/nauro/tests/test_sync/test_push_admission.py packages/nauro/tests/test_sync/test_replica_control_excluded.py packages/nauro/tests/test_sync/test_sync_presign.py packages/nauro/tests/test_sync/test_sync_status.py packages/nauro/tests/test_sync/test_hooks.py packages/nauro/tests/test_sync/test_journal_excluded.py packages/nauro/tests/test_link_cloud.py -q`
  - 222 passed, 2 skipped
- `uv run --no-sync --package nauro pytest packages/nauro/tests/ --ignore=packages/nauro/tests/cross_surface -q`
  - 3,180 passed, 2 skipped
- `uv run --no-sync ruff check packages/ benchmarks/ scripts/` and `uv run --no-sync ruff format --check packages/ benchmarks/ scripts/`
- `uv run --no-sync --package nauro mypy --config-file packages/nauro/pyproject.toml packages/nauro/src/nauro` with no new errors in the changed modules
- Run the single-source, docstring-budget, and server JSON version repository guards.
- Verify the seven-file scope, 745 changed lines against the 800-line ceiling, and that the admission layer has exactly one enumerating caller.
- Windows and macOS evidence comes from the CI jobs on this PR; local runs are macOS only.

## Risk / what to review

- Ordering: root preparation before the lock, classification before every access. Access-order tests patch the real access points (`compute_sha256`, `Path.read_bytes`, `Path.stat`, `Path.rglob`) so a regression that reads a reserved path fails.
- Behavior change for ordinary users: unreadable subtrees and entries that vanish mid-scan now produce one warning line each where `rglob` skipped them silently. Candidate order changed from `rglob` order to the walker's depth-first order; nothing depends on it beyond presentation.
- Oversized-brief detection still keys on a `context/` prefix over native paths, a pre-existing gap on Windows left unchanged here.

## Deferred

Pull, fixed-path, restore, and cleanup integration; `get_raw_file` dot-path denial; cleanup of stranded sync-state entries under reserved paths; projection download, installation, pointers, leases, routing, migration, release, and activation.
