### PR TITLE
Route legacy pull through sync path admission

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,8 @@ jobs:
           packages/nauro/tests/test_generation_authority.py
           packages/nauro/tests/test_replica_control.py
           packages/nauro/tests/test_sync/test_replica_control_excluded.py
-          packages/nauro/tests/test_sync/test_push_admission.py -v --tb=short
+          packages/nauro/tests/test_sync/test_push_admission.py
+          packages/nauro/tests/test_sync/test_pull_admission.py -v --tb=short
 
   test-sync-path-admission-windows-python310:
     runs-on: windows-latest
@@ -82,7 +83,8 @@ jobs:
       - run: >-
           uv run --no-sync --package nauro pytest
           packages/nauro/tests/test_sync/test_replica_control_excluded.py
-          packages/nauro/tests/test_sync/test_push_admission.py -v --tb=short
+          packages/nauro/tests/test_sync/test_push_admission.py
+          packages/nauro/tests/test_sync/test_pull_admission.py -v --tb=short
 
   distribution:
     runs-on: ubuntu-latest

--- a/packages/nauro/src/nauro/cli/commands/sync.py
+++ b/packages/nauro/src/nauro/cli/commands/sync.py
@@ -162,6 +162,7 @@ def _pull_via_presign(
     Fails loud when another sync holds the store lock: skipping the pull would push stale
     content over whatever the other run is landing.
     """
+    from nauro.sync._path_diagnostics import _StoreRootPreparationError
     from nauro.sync.lock import SyncLockTimeoutError
     from nauro.sync.pull import run_pull
 
@@ -170,6 +171,9 @@ def _pull_via_presign(
         return run_pull(project_id, store_path, _EchoReporter(), session=session)
     except SyncLockTimeoutError as exc:
         typer.echo(f"Error: {exc}. Try again once it finishes.", err=True)
+        raise typer.Exit(code=1) from exc
+    except _StoreRootPreparationError as exc:
+        typer.echo(f"Error: pull skipped ({exc})", err=True)
         raise typer.Exit(code=1) from exc
 
 

--- a/packages/nauro/src/nauro/sync/hooks.py
+++ b/packages/nauro/src/nauro/sync/hooks.py
@@ -53,6 +53,7 @@ def pull_before_session(project_id: str, store_path: Path) -> int:
     if not is_cloud_project(project_id):
         return 0
 
+    from nauro.sync._path_diagnostics import _StoreRootPreparationError
     from nauro.sync.lock import HOOK_SYNC_LOCK_TIMEOUT, SyncLockTimeoutError
     from nauro.sync.pull import run_pull
 
@@ -69,6 +70,9 @@ def pull_before_session(project_id: str, store_path: Path) -> int:
         # Contention is an ordinary outcome here, not a failure: the other
         # process is doing this same work, and session start never waits.
         logger.info("sync pull: skipped, %s", exc)
+        return 0
+    except _StoreRootPreparationError as exc:
+        logger.warning("sync pull: %s", exc)
         return 0
     except Exception:
         # A genuinely unexpected error must not escape session startup.

--- a/packages/nauro/src/nauro/sync/pull.py
+++ b/packages/nauro/src/nauro/sync/pull.py
@@ -34,6 +34,15 @@ from pydantic import BaseModel, ConfigDict, ValidationError
 from nauro.auth import AuthRefreshError
 from nauro.constants import DECISIONS_DIR, SNAPSHOTS_DIR
 from nauro.store._atomic import atomic_write_bytes, is_tmp_sibling
+from nauro.sync._path_diagnostics import (
+    _escape_path_for_display,
+    _MissingPathPolicy,
+    _NativeKind,
+    _PathAdmission,
+    _PathClass,
+    _PreparedStoreRoot,
+    _unsafe_reason_text,
+)
 from nauro.sync.collisions import (
     DecisionOutcome,
     DecisionVerdict,
@@ -49,8 +58,13 @@ from nauro.sync.corpus import DecisionCorpus, SkipReason
 from nauro.sync.etag import ContentMatch, compare_local_file
 from nauro.sync.lock import CLI_SYNC_LOCK_TIMEOUT, decision_lock, sync_lock
 from nauro.sync.merge import (
+    CONFLICT_BACKUP_DIR,
     SPOOL_DIR_PREFIX,
     Side,
+    _admit_native_path,
+    _classify_sync_path,
+    _prepare_store_root,
+    _walk_store_files,
     normalize_rel,
     resolve_conflict,
     should_skip,
@@ -331,8 +345,50 @@ class _Routing:
     local_sha256: str = ""
 
 
+def _display(rel: str) -> str:
+    return _escape_path_for_display(rel)
+
+
+def _destination_admitted(
+    store_path: Path,
+    rel: str,
+    reporter: Reporter,
+    *,
+    root: _PreparedStoreRoot | None = None,
+    verb: str = "skipping manifest entry",
+) -> _PathAdmission | _PathClass:
+    prepared = root or _prepare_store_root(store_path)
+
+    def refuse(admission: _PathAdmission) -> _PathClass:
+        reason = admission.reason
+        assert reason is not None
+        reporter.warn(f"{verb} {_display(rel)}: {_unsafe_reason_text(reason)}")
+        return _PathClass.UNSAFE
+
+    lexical = _classify_sync_path(rel)
+    if lexical.path_class is _PathClass.RESERVED_CONTROL:
+        return _PathClass.RESERVED_CONTROL
+    if lexical.path_class is _PathClass.UNSAFE:
+        return refuse(lexical)
+
+    admission = _admit_native_path(prepared, rel, missing=_MissingPathPolicy.CREATE_DESTINATION)
+    if admission.path_class is _PathClass.RESERVED_CONTROL:
+        return _PathClass.RESERVED_CONTROL
+    if admission.path_class is _PathClass.UNSAFE:
+        return refuse(admission)
+    if admission.native_kind is _NativeKind.IRREGULAR:
+        reporter.warn(f"{verb} {_display(rel)}: it resolves to a special file")
+        return _PathClass.UNSAFE
+    return admission
+
+
 def _route_entry(
-    store_path: Path, entry: _ManifestEntry, state: SyncState, reporter: Reporter
+    store_path: Path,
+    entry: _ManifestEntry,
+    state: SyncState,
+    reporter: Reporter,
+    *,
+    root: _PreparedStoreRoot | None = None,
 ) -> _Routing:
     """Decide what one manifest entry needs, naming the ones it refuses.
     The unchanged-remote shortcut needs the local file present, so a deleted tracked
@@ -345,6 +401,12 @@ def _route_entry(
     # currently trusted — drop suspicious entries before they hit disk.
     if ".." in Path(rel).parts or rel.startswith("/"):
         reporter.warn(f"skipping suspicious manifest entry {rel!r}")
+        return _Routing(_Route.unusable)
+
+    result = _destination_admitted(store_path, rel, reporter, root=root)
+    if result is _PathClass.RESERVED_CONTROL:
+        return _Routing(_Route.ignore)
+    if result is _PathClass.UNSAFE:
         return _Routing(_Route.unusable)
 
     destination = resolve_destination(store_path, rel)
@@ -394,6 +456,8 @@ def _triage(
     manifest: _Manifest,
     state: SyncState,
     reporter: Reporter,
+    *,
+    root: _PreparedStoreRoot | None = None,
 ) -> _Worklists:
     """Split the manifest into gated decision writes, clean pulls, and conflicts.
 
@@ -403,7 +467,7 @@ def _triage(
     listing = DecisionCorpus.scan(store_path)
     contested: list[_RemoteFile] = []
     for entry in manifest.entries:
-        routing = _route_entry(store_path, entry, state, reporter)
+        routing = _route_entry(store_path, entry, state, reporter, root=root)
         route = routing.route
         if route is _Route.ignore:
             continue
@@ -440,6 +504,9 @@ def run_pull(
     Returns a :class:`PullReport` carrying any transport failure, never an empty
     success; exceeding ``lock_timeout`` on either lock raises ``SyncLockTimeoutError``.
     """
+    # The sync lock creates its parent directory, so an unusable Store root is
+    # refused here, before the lock's mkdir can recreate or trip over it.
+    _prepare_store_root(store_path)
     with operation_session(session) as active:
         with sync_lock(store_path, lock_timeout):
             return _run_pull_locked(project_id, store_path, reporter, lock_timeout, active)
@@ -452,7 +519,8 @@ def _run_pull_locked(
     lock_timeout: float,
     session: TransferSession,
 ) -> PullReport:
-    _sweep_interrupted_writes(store_path, reporter)
+    root = _prepare_store_root(store_path)
+    _sweep_interrupted_writes(store_path, reporter, root=root)
 
     # A run that could not read the file list did not sync anything and cannot
     # say how much it missed. It reports that plainly rather than as a count of
@@ -473,10 +541,24 @@ def _run_pull_locked(
 
     manifest = _parse_manifest(rows, reporter)
     state = load_state(store_path)
-    work = _triage(store_path, manifest, state, reporter)
+    work = _triage(store_path, manifest, state, reporter, root=root)
     tally = _Tally(skipped_permanent=manifest.unreadable_rows + work.skipped_permanent)
 
     planned = work.all_files()
+    backup = _admit_native_path(
+        root, CONFLICT_BACKUP_DIR, missing=_MissingPathPolicy.CREATE_DESTINATION
+    )
+    if backup.path_class is not _PathClass.ORDINARY or backup.native_kind not in (
+        None,
+        _NativeKind.DIRECTORY,
+    ):
+        detail = ""
+        if backup.reason is not None:
+            detail = f" ({_unsafe_reason_text(backup.reason)})"
+        reporter.warn(f"pull skipped: the conflict backup directory is not usable{detail}")
+        tally.refused += len(planned)
+        return _report_tally(tally, reporter)
+
     urls = _presign(project_id, planned, reporter, session, tally)
     if urls is None:
         # The request failed as a whole, so every file it was for stays where
@@ -513,7 +595,9 @@ def _run_pull_locked(
                         tally.refused += 1
                         continue
                     with _guarded_step(item.rel, _WRITE_FAILURE_DETAIL, reporter, tally):
-                        _apply_decision(corpus, transfer, state, manifest, reporter, tally)
+                        _apply_decision(
+                            corpus, transfer, state, manifest, reporter, tally, root=root
+                        )
 
         for adopted in work.adopted:
             # No fetch, no write, and no second read of the file: these already
@@ -524,7 +608,7 @@ def _run_pull_locked(
 
         for transfer in _stream(urls, work.pulls, reporter, tally, session):
             with _guarded_step(transfer.rel, _WRITE_FAILURE_DETAIL, reporter, tally):
-                if _generic_write_allowed(store_path, transfer, state, reporter):
+                if _generic_write_allowed(store_path, transfer, state, reporter, root=root):
                     target = store_path / transfer.rel
                     atomic_write_bytes(target, transfer.content)
                     update_file_state(state, transfer.rel, compute_sha256(target), transfer.etag)
@@ -534,7 +618,7 @@ def _run_pull_locked(
 
         for transfer in _stream(urls, work.conflicts, reporter, tally, session):
             with _guarded_step(transfer.rel, _WRITE_FAILURE_DETAIL, reporter, tally):
-                if _generic_write_allowed(store_path, transfer, state, reporter):
+                if _generic_write_allowed(store_path, transfer, state, reporter, root=root):
                     _resolve_and_record(
                         store_path, transfer, state, _conflict_side(transfer.rel, state)
                     )
@@ -633,16 +717,25 @@ def _guarded_step(subject: str, detail: str, reporter: Reporter, tally: _Tally) 
 _STRANDED_TMP_MIN_AGE_SECONDS = 60.0
 
 
-def _sweep_interrupted_writes(store_path: Path, reporter: Reporter) -> int:
+def _sweep_interrupted_writes(
+    store_path: Path, reporter: Reporter, *, root: _PreparedStoreRoot | None = None
+) -> int:
     """Remove the tmp siblings killed writes stranded, and say how many.
 
-    Runs first and never raises: hygiene must not cost the caller the sync it asked for.
+    Raises the typed Store-root error only when given no prepared root and an unusable root.
     """
     cutoff = time.time() - _STRANDED_TMP_MIN_AGE_SECONDS
     removed = 0
     try:
-        for path in store_path.rglob("*"):
-            if not is_tmp_sibling(path.name) or not path.is_file():
+        for entry in _walk_store_files(root or _prepare_store_root(store_path)):
+            admission = entry.admission
+            if (
+                admission.path_class is not _PathClass.ORDINARY
+                or admission.native_kind is not _NativeKind.REGULAR_FILE
+            ):
+                continue
+            path = entry.native_path
+            if not is_tmp_sibling(path.name):
                 continue
             try:
                 if path.stat().st_mtime > cutoff:
@@ -825,12 +918,22 @@ def _report_completion(corpus: DecisionCorpus, reporter: Reporter) -> None:
 
 
 def _generic_write_allowed(
-    store_path: Path, transfer: _Transfer, state: SyncState, reporter: Reporter
+    store_path: Path,
+    transfer: _Transfer,
+    state: SyncState,
+    reporter: Reporter,
+    *,
+    root: _PreparedStoreRoot | None = None,
 ) -> bool:
     """Refuse an untyped write that would land somewhere it may not.
 
     The last check before bytes hit disk, asking the same question the planner asked.
     """
+    result = _destination_admitted(
+        store_path, transfer.rel, reporter, root=root, verb="refusing to write"
+    )
+    if isinstance(result, _PathClass):
+        return False
     destination = resolve_destination(store_path, transfer.rel)
     if not destination.inside_store:
         reporter.warn(
@@ -865,8 +968,15 @@ def _resolve_and_record(
 ) -> None:
     """Apply the conflict policy for one path and record the result."""
     local_file = store_path / transfer.rel
+    # This spelling picks the merge policy and names the backup, so it escapes
+    # injectively: a lossy one would let a remote row claim a set-union name or
+    # overwrite another row's backup.
     merged_content = resolve_conflict(
-        store_path, local_file, transfer.content, transfer.rel, keeps=keeps
+        store_path,
+        local_file,
+        transfer.content,
+        transfer.rel.replace("%", "%25").replace("\\", "%5C"),
+        keeps=keeps,
     )
     atomic_write_bytes(local_file, merged_content)
     update_file_state(state, transfer.rel, compute_sha256(local_file), transfer.etag)
@@ -879,6 +989,8 @@ def _apply_decision(
     manifest: _Manifest,
     reporter: Reporter,
     tally: _Tally,
+    *,
+    root: _PreparedStoreRoot | None = None,
 ) -> None:
     """Classify one untracked remote decision and act on the verdict.
 
@@ -936,10 +1048,26 @@ def _apply_decision(
         # The local decision stays, whatever sync state says about the path: the
         # file on disk is byte-unchanged, so the corpus still describes it and
         # the number it holds does not move underneath this batch.
+        if isinstance(
+            _destination_admitted(
+                store_path, transfer.rel, reporter, root=root, verb="refusing to write"
+            ),
+            _PathClass,
+        ):
+            tally.skipped_permanent += 1
+            return
         _resolve_and_record(store_path, transfer, state, Side.local)
         tally.merged += 1
         return
 
+    if isinstance(
+        _destination_admitted(
+            store_path, transfer.rel, reporter, root=root, verb="refusing to write"
+        ),
+        _PathClass,
+    ):
+        tally.skipped_permanent += 1
+        return
     target = store_path / transfer.rel
     atomic_write_bytes(target, transfer.content)
     update_file_state(state, transfer.rel, compute_sha256(target), transfer.etag)

--- a/packages/nauro/tests/test_sync/test_pull.py
+++ b/packages/nauro/tests/test_sync/test_pull.py
@@ -1196,7 +1196,7 @@ class TestWriteBarrier:
 
         assert merged == 0
         assert (outside / "victim.md").read_bytes() == b"untouched\n"
-        assert any("outside the store" in warning for warning in reporter.warns)
+        assert any("outside the Store root" in warning for warning in reporter.warns)
 
     def test_ordinary_files_are_unaffected(self, collision_store):
         merged, reporter = pull(
@@ -2203,16 +2203,13 @@ class TestStrandedTmpSiblings:
         the walk at any time: the store is one other processes write into.
         """
         stranded = self._strand(collision_store / "stack.md", b"# Stack\n", age_seconds=600)
-        real_rglob = Path.rglob
+        real_walk = pull_module._walk_store_files
 
-        def break_partway(self, *args, **kwargs):
-            if self != collision_store:
-                yield from real_rglob(self, *args, **kwargs)
-                return
-            yield stranded
+        def break_partway(root):
+            yield next(e for e in real_walk(root) if e.native_path == stranded)
             raise OSError(5, "Input/output error")
 
-        monkeypatch.setattr(pull_module.Path, "rglob", break_partway)
+        monkeypatch.setattr(pull_module, "_walk_store_files", break_partway)
 
         merged, reporter = pull(
             collision_store, [("decisions/020-remote.md", decision_bytes(20, "Remote"))]

--- a/packages/nauro/tests/test_sync/test_pull_admission.py
+++ b/packages/nauro/tests/test_sync/test_pull_admission.py
@@ -1,0 +1,607 @@
+"""Legacy pull routes every manifest row through the sync path-admission layer."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import typer
+
+from nauro.cli.commands.sync import _pull_via_presign
+from nauro.store.replica_control import (
+    _REPLICA_CONTROL_LOCK_NAME,
+    _REPLICA_CONTROL_ROOT_NAME,
+)
+from nauro.sync import merge as merge_module
+from nauro.sync import pull as pull_module
+from nauro.sync._path_diagnostics import (
+    _escape_path_for_display,
+    _StoreRootPreparationError,
+)
+from nauro.sync.collisions import DecisionOutcome, DecisionVerdict
+from nauro.sync.corpus import DecisionCorpus
+from nauro.sync.hooks import pull_before_session
+from nauro.sync.merge import CONFLICT_BACKUP_DIR
+from nauro.sync.pull import PullReport, _Transfer, run_pull
+from nauro.sync.state import SYNC_STATE_FILE, FileState, SyncState, load_state, save_state
+from tests.test_sync.conftest import (
+    CLOUD_PID,
+    _RecordingReporter,
+    _scaffolded_cloud_project,
+    _seed_token,
+    decision_bytes,
+    entry_names,
+    pull_report,
+)
+
+POSIX_ONLY = pytest.mark.skipif(sys.platform == "win32", reason="POSIX filename semantics")
+
+ROOT_TEXT = "The Store root is unavailable."
+OUTSIDE_TEXT = "The path resolves outside the Store root."
+NOTE = "context/note.md"
+AUTHORITY = f"{_REPLICA_CONTROL_ROOT_NAME}/authority.json"
+
+RESERVED_ROWS = [
+    AUTHORITY,
+    _REPLICA_CONTROL_LOCK_NAME,
+    ".REPLICA/x",
+    " .replica. /x",
+    ".replica:ads/x",
+    ".replica\\x",
+    f"{_REPLICA_CONTROL_LOCK_NAME}/child",
+]
+
+UNSAFE_ROWS = [
+    ("C:\\x", "The path uses drive syntax."),
+    ("\\\\server\\share\\x", "The path uses UNC syntax."),
+    ("context/ :stream", "A path component normalizes to empty."),
+    ("context/nul\x00name", "Path metadata is unavailable."),
+]
+
+
+@pytest.fixture()
+def store(tmp_path):
+    """A scaffolded cloud-mode store with a token, ready for ``run_pull``."""
+    store = _scaffolded_cloud_project("pulladmission", tmp_path, project_id=CLOUD_PID)
+    _seed_token()
+    (store / "context").mkdir(exist_ok=True)
+    return store
+
+
+def _run(store, entries, *, reporter=None):
+    """Run one pull, also returning the paths it asked the server to presign."""
+    operations: list[str] = []
+    real = pull_module.request_presigned_urls
+
+    def spy(project_id, ops, *, session=None):
+        operations.extend(op["path"] for op in ops)
+        return real(project_id, ops, session=session)
+
+    with patch.object(pull_module, "request_presigned_urls", spy):
+        report, reporter = pull_report(store, entries, reporter=reporter)
+    return report, reporter, operations
+
+
+def _control_entries(store) -> set[str]:
+    return {name for name in entry_names(store) if name.casefold().startswith(".replica")}
+
+
+def _is_reserved(value) -> bool:
+    for part in str(value).replace("\\", "/").split("/"):
+        folded = part.split(":", 1)[0].strip(" ").rstrip(" .").casefold()
+        if folded in {_REPLICA_CONTROL_ROOT_NAME, _REPLICA_CONTROL_LOCK_NAME}:
+            return True
+    return False
+
+
+def _strand(path: Path, *, age_seconds: float = 600.0) -> Path:
+    """Leave a tmp sibling of ``path`` behind, as a killed write would."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    orphan = path.parent / f".{path.name}.{'ab' * 8}.tmp"
+    orphan.write_bytes(b"half a write\n")
+    stranded_at = time.time() - age_seconds
+    os.utime(orphan, (stranded_at, stranded_at))
+    return orphan
+
+
+def _plant(store: Path, rel: str, body: bytes) -> None:
+    """Leave untracked local content, so a differing remote row conflicts."""
+    path = store / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(body)
+
+
+def _forbid_target(monkeypatch, target: Path) -> None:
+    """Fail the test if ``target`` is read or written."""
+    real_read = Path.read_bytes
+    real_write = pull_module.atomic_write_bytes
+    resolved = os.path.realpath(target)
+
+    def read_bytes(self):
+        if os.path.realpath(self) == resolved:
+            pytest.fail(f"read {self}")
+        return real_read(self)
+
+    def write(path, content):
+        if os.path.realpath(path) == resolved:
+            pytest.fail(f"wrote {path}")
+        return real_write(path, content)
+
+    monkeypatch.setattr(Path, "read_bytes", read_bytes)
+    monkeypatch.setattr(pull_module, "atomic_write_bytes", write)
+
+
+@pytest.fixture()
+def forbid_control_access(monkeypatch):
+    """Fail the test if anything reaches a reserved control path."""
+    real_lstat = merge_module.os.lstat
+    real_stat = Path.stat
+    real_read = Path.read_bytes
+    real_compare = pull_module.compare_local_file
+    real_resolve = pull_module.resolve_destination
+
+    def check(value) -> None:
+        if _is_reserved(value):
+            pytest.fail(f"reached {value!r}")
+
+    def lstat(path, *args, **kwargs):
+        check(path)
+        return real_lstat(path, *args, **kwargs)
+
+    def stat(self, *args, **kwargs):
+        check(self)
+        return real_stat(self, *args, **kwargs)
+
+    def read_bytes(self):
+        check(self)
+        return real_read(self)
+
+    def compare(local_file, etag):
+        check(local_file)
+        return real_compare(local_file, etag)
+
+    def resolve(store_path, rel):
+        check(rel)
+        return real_resolve(store_path, rel)
+
+    monkeypatch.setattr(merge_module.os, "lstat", lstat)
+    monkeypatch.setattr(Path, "stat", stat)
+    monkeypatch.setattr(Path, "read_bytes", read_bytes)
+    monkeypatch.setattr(pull_module, "compare_local_file", compare)
+    monkeypatch.setattr(pull_module, "resolve_destination", resolve)
+
+
+# --- manifest table ---
+
+
+def test_reserved_manifest_rows_install_nothing_and_say_nothing(store):
+    entries = [(NOTE, b"note\n")] + [(row, b"control\n") for row in RESERVED_ROWS]
+
+    report, reporter, operations = _run(store, entries)
+
+    assert report == PullReport(merged=1)
+    assert operations == [NOTE]
+    assert (store / NOTE).read_bytes() == b"note\n"
+    assert _control_entries(store) == set()
+    assert set(load_state(store).files) == {NOTE}
+    assert reporter.warns == []
+
+
+@pytest.mark.parametrize("row, reason", UNSAFE_ROWS)
+def test_unsafe_manifest_rows_are_refused_before_the_network(store, row, reason):
+    report, reporter, operations = _run(store, [(NOTE, b"note\n"), (row, b"remote\n")])
+
+    assert report == PullReport(merged=1, skipped_permanent=1)
+    assert operations == [NOTE]
+    assert reporter.warns == [f"skipping manifest entry {_escape_path_for_display(row)}: {reason}"]
+    assert (store / NOTE).read_bytes() == b"note\n"
+    assert set(load_state(store).files) == {NOTE}
+
+
+def test_a_rooted_row_is_still_refused_by_the_traversal_guard(store):
+    report, reporter, operations = _run(store, [(NOTE, b"note\n"), ("//?/C:/x", b"remote\n")])
+
+    assert report == PullReport(merged=1, skipped_permanent=1)
+    assert operations == [NOTE]
+    assert any("suspicious manifest entry" in warning for warning in reporter.warns)
+
+
+def test_the_refusal_names_the_escaped_display_form(store):
+    _report, reporter, _operations = _run(store, [("context/ :stream", b"remote\n")])
+
+    assert reporter.warns == [
+        "skipping manifest entry context/\\x20:stream: A path component normalizes to empty."
+    ]
+
+
+# --- access-order table ---
+
+
+def test_no_reserved_path_is_named_probed_or_read_while_routing(store, forbid_control_access):
+    entries = [(NOTE, b"note\n")] + [(row, b"control\n") for row in RESERVED_ROWS]
+
+    report, reporter, operations = _run(store, entries)
+
+    assert report == PullReport(merged=1)
+    assert operations == [NOTE]
+    assert reporter.warns == []
+
+
+def test_the_sweep_never_walks_the_store_with_rglob(store, monkeypatch):
+    def refuse(self, *args, **kwargs):
+        pytest.fail(f"rglob on {self}")
+
+    monkeypatch.setattr(pull_module.Path, "rglob", refuse)
+
+    report, _reporter, _operations = _run(store, [(NOTE, b"note\n")])
+
+    assert report == PullReport(merged=1)
+
+
+# --- link table ---
+
+
+@POSIX_ONLY
+def test_a_link_aliasing_the_control_root_installs_nothing(store):
+    control = store / _REPLICA_CONTROL_ROOT_NAME
+    control.mkdir()
+    (control / "authority.json").write_text("{}", encoding="utf-8")
+    (store / "alias").symlink_to(_REPLICA_CONTROL_ROOT_NAME)
+
+    report, reporter, operations = _run(store, [("alias/authority.json", b"remote\n")])
+
+    assert report == PullReport()
+    assert operations == []
+    assert reporter.warns == []
+    assert (control / "authority.json").read_text(encoding="utf-8") == "{}"
+    assert load_state(store).files == {}
+
+
+@POSIX_ONLY
+def test_a_link_out_of_the_store_is_refused_with_the_fixed_reason(store, tmp_path):
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "victim.md").write_bytes(b"untouched\n")
+    (store / "escape").symlink_to(outside)
+
+    report, reporter, operations = _run(store, [("escape/victim.md", b"overwritten\n")])
+
+    assert report == PullReport(skipped_permanent=1)
+    assert operations == []
+    assert reporter.warns == [f"skipping manifest entry escape/victim.md: {OUTSIDE_TEXT}"]
+    assert (outside / "victim.md").read_bytes() == b"untouched\n"
+
+
+@POSIX_ONLY
+def test_the_write_barrier_refuses_a_late_control_link_silently(store):
+    (store / _REPLICA_CONTROL_ROOT_NAME).mkdir()
+    (store / "late").symlink_to(_REPLICA_CONTROL_ROOT_NAME)
+    reporter = _RecordingReporter()
+
+    allowed = pull_module._generic_write_allowed(
+        store,
+        _Transfer(rel="late/authority.json", etag='"e"', _body=b"remote\n"),
+        SyncState(),
+        reporter,
+    )
+
+    assert allowed is False
+    assert reporter.warns == []
+    assert entry_names(store / _REPLICA_CONTROL_ROOT_NAME) == set()
+
+
+@POSIX_ONLY
+def test_a_backup_directory_linked_at_the_control_root_refuses_the_run(store):
+    (store / _REPLICA_CONTROL_ROOT_NAME).mkdir()
+    (store / CONFLICT_BACKUP_DIR).symlink_to(_REPLICA_CONTROL_ROOT_NAME)
+    entries = [(NOTE, b"note\n"), ("decisions/020-remote.md", decision_bytes(20, "Remote"))]
+
+    report, reporter, operations = _run(store, entries)
+
+    assert report == PullReport(refused=2)
+    assert operations == []
+    assert reporter.warns == ["pull skipped: the conflict backup directory is not usable"]
+    assert not (store / NOTE).exists()
+    assert entry_names(store / _REPLICA_CONTROL_ROOT_NAME) == set()
+
+
+@POSIX_ONLY
+def test_a_backup_directory_linked_outside_the_store_names_the_reason(store):
+    (store / CONFLICT_BACKUP_DIR).symlink_to(Path("..") / "outside")
+    entries = [(NOTE, b"note\n"), ("context/other.md", b"other\n")]
+
+    report, reporter, operations = _run(store, entries)
+
+    assert report == PullReport(refused=2)
+    assert operations == []
+    assert reporter.warns == [
+        f"pull skipped: the conflict backup directory is not usable ({OUTSIDE_TEXT})"
+    ]
+    assert not (store / NOTE).exists()
+
+
+def test_a_backup_directory_that_is_a_regular_file_refuses_the_run(store):
+    (store / CONFLICT_BACKUP_DIR).write_text("not a directory", encoding="utf-8")
+
+    report, reporter, operations = _run(store, [(NOTE, b"note\n")])
+
+    assert report == PullReport(refused=1)
+    assert operations == []
+    assert reporter.warns == ["pull skipped: the conflict backup directory is not usable"]
+    assert not (store / NOTE).exists()
+
+
+# --- destination table ---
+
+
+def test_an_existing_directory_keeps_the_legacy_refusal(store):
+    (store / "context" / "folder").mkdir(parents=True)
+
+    report, reporter, operations = _run(store, [("context/folder", b"remote\n")])
+
+    assert report == PullReport(skipped_permanent=1)
+    assert operations == []
+    assert any("it resolves to the directory" in warning for warning in reporter.warns)
+
+
+@POSIX_ONLY
+def test_a_special_file_destination_is_refused_and_never_hashed(store, monkeypatch):
+    os.mkfifo(store / "context" / "pipe.md")
+
+    def refuse(local_file, etag):
+        pytest.fail(f"hashed {local_file}")
+
+    monkeypatch.setattr(pull_module, "compare_local_file", refuse)
+
+    report, reporter, operations = _run(store, [("context/pipe.md", b"remote\n")])
+
+    assert report == PullReport(skipped_permanent=1)
+    assert operations == []
+    assert reporter.warns == [
+        "skipping manifest entry context/pipe.md: it resolves to a special file"
+    ]
+
+
+# --- sweep table ---
+
+
+def test_stale_tmp_siblings_under_the_store_and_the_backups_are_removed(store):
+    in_store = _strand(store / "stack.md")
+    in_backups = _strand(store / CONFLICT_BACKUP_DIR / "losing-side.md")
+
+    _report, reporter, _operations = _run(store, [])
+
+    assert not in_store.exists()
+    assert not in_backups.exists()
+    assert "Cleaned 2 interrupted write(s)" in reporter.infos
+
+
+def test_a_stale_tmp_sibling_under_the_control_root_survives_unread(store, forbid_control_access):
+    orphan = _strand(store / _REPLICA_CONTROL_ROOT_NAME / "authority.json")
+
+    _report, reporter, _operations = _run(store, [])
+
+    assert os.listdir(store / _REPLICA_CONTROL_ROOT_NAME) == [orphan.name]
+    assert not any("interrupted write" in line for line in reporter.infos)
+
+
+@POSIX_ONLY
+def test_a_tmp_sibling_named_link_into_the_control_root_survives_unread(
+    store, forbid_control_access
+):
+    control = store / _REPLICA_CONTROL_ROOT_NAME
+    control.mkdir()
+    target = control / "authority.json"
+    target.write_text("{}", encoding="utf-8")
+    link = store / f".authority.json.{'ab' * 8}.tmp"
+    link.symlink_to(Path(_REPLICA_CONTROL_ROOT_NAME) / "authority.json")
+
+    _report, reporter, _operations = _run(store, [])
+
+    assert link.name in os.listdir(store)
+    assert os.readlink(link) == os.path.join(_REPLICA_CONTROL_ROOT_NAME, "authority.json")
+    with open(target, encoding="utf-8") as handle:
+        assert handle.read() == "{}"
+    assert not any("interrupted write" in line for line in reporter.infos)
+
+
+def test_an_unscannable_subdirectory_is_skipped_without_a_warning(store):
+    locked = store / "context" / "locked"
+    locked.mkdir(parents=True)
+    locked.chmod(0o000)
+    try:
+        report, reporter, _operations = _run(store, [(NOTE, b"note\n")])
+    finally:
+        locked.chmod(0o755)
+
+    assert report == PullReport(merged=1)
+    assert reporter.warns == []
+
+
+# --- root table ---
+
+
+def test_a_missing_root_is_refused_before_any_lock(tmp_path):
+    missing = tmp_path / "gone"
+
+    with pytest.raises(_StoreRootPreparationError) as raised:
+        run_pull(CLOUD_PID, missing, _RecordingReporter())
+
+    assert str(raised.value) == ROOT_TEXT
+    assert not missing.exists()
+
+
+def test_a_regular_file_root_is_refused_before_any_lock(tmp_path):
+    root = tmp_path / "file-root"
+    root.write_text("store", encoding="utf-8")
+
+    with pytest.raises(_StoreRootPreparationError):
+        run_pull(CLOUD_PID, root, _RecordingReporter())
+
+    assert root.read_text(encoding="utf-8") == "store"
+    assert list(tmp_path.iterdir()) == [root]
+
+
+def test_the_cli_pull_reports_the_typed_refusal_and_exits_one(tmp_path, capsys):
+    missing = tmp_path / "gone"
+
+    with pytest.raises(typer.Exit) as raised:
+        _pull_via_presign(CLOUD_PID, missing)
+
+    assert raised.value.exit_code == 1
+    captured = capsys.readouterr()
+    assert captured.err == f"Error: pull skipped ({ROOT_TEXT})\n"
+    assert str(missing) not in captured.out + captured.err
+
+
+def test_the_session_hook_logs_the_typed_refusal_and_returns_zero(tmp_path, caplog):
+    _scaffolded_cloud_project("pullhook", tmp_path, project_id=CLOUD_PID)
+    _seed_token()
+    missing = tmp_path / "gone"
+
+    with caplog.at_level(logging.WARNING, logger="nauro.sync"):
+        assert pull_before_session(CLOUD_PID, missing) == 0
+
+    assert [record.getMessage() for record in caplog.records] == [f"sync pull: {ROOT_TEXT}"]
+    assert all(record.exc_info is None for record in caplog.records)
+    assert str(missing) not in caplog.text
+
+
+# --- state table ---
+
+
+def test_a_sync_state_entry_under_a_reserved_path_is_left_untouched(store):
+    seeded = FileState(
+        local_sha256="a" * 64, remote_etag='"seeded"', last_sync="2026-08-10T00:00:00Z"
+    )
+    state = load_state(store)
+    state.files[AUTHORITY] = seeded
+    save_state(store, state)
+    before = json.loads((store / SYNC_STATE_FILE).read_text(encoding="utf-8"))["files"][AUTHORITY]
+
+    report, _reporter, _operations = _run(store, [(NOTE, b"note\n"), (AUTHORITY, b"remote\n")])
+
+    after = json.loads((store / SYNC_STATE_FILE).read_text(encoding="utf-8"))["files"]
+    assert report == PullReport(merged=1)
+    assert after[AUTHORITY] == before
+    assert set(after) == {AUTHORITY, NOTE}
+
+
+# --- conflict-backup naming table ---
+
+
+CONFLICTS = {
+    "state\\history.md": b"local history\n",
+    "context\\victim.md": b"local victim\n",
+    "context_victim.md": b"local sibling\n",
+}
+
+
+def test_conflicting_rows_back_up_under_distinct_flat_names(store):
+    for rel, body in CONFLICTS.items():
+        _plant(store, rel, body)
+    before = entry_names(store)
+
+    report, _reporter, _operations = _run(
+        store, [(rel, b"remote " + body) for rel, body in CONFLICTS.items()]
+    )
+
+    backups = list((store / CONFLICT_BACKUP_DIR).iterdir())
+    assert report == PullReport(merged=3)
+    assert len({path.name for path in backups}) == 3
+    assert all(path.is_file() for path in backups)
+    assert not any("\\" in path.name or "/" in path.name for path in backups)
+    assert sorted(path.read_bytes() for path in backups) == sorted(CONFLICTS.values())
+    # A set-union merge writes no backup and keeps both sides, so the remote
+    # bytes alone prove the union policy was not selected for this row.
+    assert (store / "state\\history.md").read_bytes() == b"remote local history\n"
+    assert entry_names(store) - before <= {
+        CONFLICT_BACKUP_DIR,
+        SYNC_STATE_FILE,
+        f"{SYNC_STATE_FILE}.lock",
+    }
+
+
+def test_an_append_only_conflict_still_set_unions_without_a_backup(store):
+    rel = "state_history.md"
+    _plant(store, rel, b"## History\n\nlocal entry\n")
+
+    report, _reporter, _operations = _run(store, [(rel, b"## History\n\nremote entry\n")])
+
+    merged = (store / rel).read_bytes()
+    assert report == PullReport(merged=1)
+    assert b"local entry" in merged and b"remote entry" in merged
+    assert not (store / CONFLICT_BACKUP_DIR).exists()
+
+
+# --- decision write-barrier table ---
+
+
+@POSIX_ONLY
+def test_a_decision_destination_swapped_for_a_control_link_is_dropped_silently(store, monkeypatch):
+    control = store / _REPLICA_CONTROL_ROOT_NAME
+    control.mkdir()
+    target = control / "authority.json"
+    target.write_text("{}", encoding="utf-8")
+    rel = "decisions/900-remote.md"
+    corpus = DecisionCorpus.scan(store)
+    (store / rel).symlink_to(Path("..") / _REPLICA_CONTROL_ROOT_NAME / "authority.json")
+    _forbid_target(monkeypatch, target)
+    reporter = _RecordingReporter()
+    tally = pull_module._Tally()
+
+    pull_module._apply_decision(
+        corpus,
+        _Transfer(rel=rel, etag='"e"', _body=decision_bytes(900, "Remote")),
+        SyncState(),
+        pull_module._Manifest((), frozenset(), frozenset()),
+        reporter,
+        tally,
+    )
+
+    assert tally.skipped_permanent == 1
+    assert tally.merged == 0
+    assert reporter.warns == []
+    with open(target, encoding="utf-8") as handle:
+        assert handle.read() == "{}"
+
+
+@POSIX_ONLY
+def test_a_decision_destination_swapped_for_an_outside_link_is_refused(
+    store, tmp_path, monkeypatch
+):
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    target = outside / "victim.md"
+    target.write_bytes(b"untouched\n")
+    rel = "decisions/901-remote.md"
+    (store / rel).symlink_to(target)
+    monkeypatch.setattr(
+        pull_module,
+        "classify_decision",
+        lambda *args: DecisionVerdict(DecisionOutcome.resolve_conflict, (store / rel,)),
+    )
+    _forbid_target(monkeypatch, target)
+    reporter = _RecordingReporter()
+    tally = pull_module._Tally()
+
+    pull_module._apply_decision(
+        DecisionCorpus.scan(store),
+        _Transfer(rel=rel, etag='"e"', _body=decision_bytes(901, "Remote")),
+        SyncState(),
+        pull_module._Manifest((), frozenset(), frozenset()),
+        reporter,
+        tally,
+    )
+
+    assert tally.skipped_permanent == 1
+    assert tally.merged == 0
+    assert reporter.warns == [f"refusing to write {rel}: {OUTSIDE_TEXT}"]
+    with open(target, "rb") as handle:
+        assert handle.read() == b"untouched\n"

--- a/packages/nauro/tests/test_sync/test_replica_control_excluded.py
+++ b/packages/nauro/tests/test_sync/test_replica_control_excluded.py
@@ -160,10 +160,10 @@ def test_prepare_store_root_has_fixed_suppressed_failure(tmp_path: Path, kind: s
 def test_admission_has_exactly_one_enumerating_caller() -> None:
     src_root = Path(merge.__file__).parents[2]
     allowed = {
-        "_walk_store_files": {"sync/merge.py", "sync/push.py"},
-        "_prepare_store_root": {"sync/merge.py", "sync/push.py"},
-        "_admit_native_path": {"sync/merge.py"},
-        "_classify_sync_path": {"sync/merge.py"},
+        "_walk_store_files": {"sync/merge.py", "sync/push.py", "sync/pull.py"},
+        "_prepare_store_root": {"sync/merge.py", "sync/push.py", "sync/pull.py"},
+        "_admit_native_path": {"sync/merge.py", "sync/pull.py"},
+        "_classify_sync_path": {"sync/merge.py", "sync/pull.py"},
     }
     for source in src_root.rglob("*.py"):
         relative = source.relative_to(src_root / "nauro").as_posix()


### PR DESCRIPTION
## Why

Legacy pull trusted the server manifest as a list of installable relative paths. A row named `.replica/authority.json` or `.replica-control.lock`, any case, space, period, or ADS alias of those names, or an ordinary-looking row whose on-disk parent is a symlink into the control root passed every existing check, was fetched, and was written. The interrupted-write sweep walked the whole store with `rglob`, including the control root, and unlinked there. This slice makes the pull direction consume the admission layer merged in #508 and first used by push in #509, so remote input can never name, probe, or write local control state, and unsafe rows are refused before any network or disk step with fixed diagnostics.

## What changed

- Every manifest row is classified as a string and its destination admitted on disk under a prepared Store root before `resolve_destination`, comparison, presign, fetch, or write. Reserved rows and targets are ignored silently; unsafe rows are refused with a fixed reason and an escaped display form and counted as permanent skips, so the report stays complete and unrelated rows still install.
- Final admission repeats at the generic write barrier and before both decision writes, so a destination that became a link into the control root after triage is refused rather than written through.
- The conflict-backup directory is admitted once per run before presign. A run whose backup directory is reserved, unsafe, or not a directory refuses its planned rows with one fixed warning and exits through the existing unfinished-pull path instead of writing into whatever the directory points at.
- The interrupted-write sweep enumerates through the admission walker, unlinks only ordinary regular temp siblings, never touches reserved paths, and no longer descends through directory symlinks.
- `run_pull` prepares the Store root before taking the sync lock, so a missing or non-directory root is refused with a fixed message before the lock can create anything. The SessionStart hook and the CLI pull handle the typed error with fixed wording and no path leak.
- Sync-state entries recorded under reserved paths are left untouched. Nothing is deleted beyond the pre-existing temp-sibling sweep.
- Restore, raw-file reads, the decision corpus scan, and cleanup listings are unchanged and follow in later slices.

## Test plan

- Focused set: `uv run --no-sync --package nauro pytest packages/nauro/tests/test_sync/test_pull_admission.py packages/nauro/tests/test_sync/test_pull.py packages/nauro/tests/test_sync/test_replica_control_excluded.py packages/nauro/tests/test_sync/test_push_admission.py packages/nauro/tests/test_sync/test_sync_command.py packages/nauro/tests/test_sync/test_hooks.py packages/nauro/tests/test_sync/test_post_restore_sync.py packages/nauro/tests/test_sync/test_sync_lock.py -q`
  - 370 passed, 2 skipped
- `uv run --no-sync --package nauro pytest packages/nauro/tests/ --ignore=packages/nauro/tests/cross_surface -q`
  - 3,210 passed, 2 skipped
- `uv run --no-sync ruff check packages/ benchmarks/ scripts/` and `uv run --no-sync ruff format --check packages/ benchmarks/ scripts/`
- `uv run --no-sync --package nauro mypy --config-file packages/nauro/pyproject.toml packages/nauro/src/nauro` with no errors in the changed modules
- Run the single-source, docstring-budget, and server JSON version repository guards.
- Verify the seven-file scope, 796 changed lines against the 800-line ceiling, and that the admission layer's enumerating callers are exactly merge, push, and pull.
- Mutation checks: removing the routing admission fails 11 of the new tests, neutering the backup gate fails 2, deleting either decision-write barrier fails 1, and reverting the backup-name escape to either a lossy flatten or raw pass-through fails 1.
- Windows and macOS evidence comes from the CI jobs on this PR; local runs are macOS only.

## Risk / what to review

- Ordering at every write site: admission before `resolve_destination`, again at the write barrier, again before both decision writes. Access-order tests patch the real access points (`merge.os.lstat`, `Path.stat`, `Path.read_bytes`, `compare_local_file`, `resolve_destination`, `Path.rglob`) so a regression that touches a reserved path fails.
- Conflict-backup names are derived from the manifest row. The row spelling handed to the conflict resolver is escaped injectively (`%` to `%25`, then `\` to `%5C`) so a row cannot create a nested directory under the backup folder on Windows, cannot select the set-union policy by spelling a member name with a backslash, and cannot collide with another row's backup name; the backup is always a distinct direct child.
- Pre-existing and untouched here: the conflict resolver itself still maps `/` to `_` when naming a backup, so `context/victim.md` and a literal `context_victim.md` conflicting in the same second share a backup name. Not remote-selectable in a new way by this change; belongs to the next slice with the resolver.
- The backslash backup test only has teeth on Windows, where a backslash is a separator; the two Windows CI jobs are the evidence for it, a green macOS run is not. A row containing a colon still yields an alternate-data-stream backup name on Windows; it stays inside the admitted backup directory and reaches no control state.
- Behavior change for an unusable conflict-backup directory: whole-run refusal with exit 2 where today the run writes through it.
- If a destination becomes a link into the control root between triage and a decision write, the write is refused and counted as a permanent skip without a warning line. That window is the concurrent-mutation limit the admission layer states; stable pre-planted names, links, and junctions are covered, mutation between checks is not.
- The pre-existing traversal guard still runs first, so a device-prefixed or parent-traversal row is reported with the legacy text, which quotes the raw row, rather than the admission reason. Both refuse before any access.
- Decision renumber and canonicalize still rename local files under `decisions/` without admitting that directory; the corpus scan that feeds them moves to the next slice together with restore.
- A manifest key containing a backslash is admitted and written under its literal name on POSIX, as today; admission preserves exact native identity and does not resolve that pre-existing divergence.

## Deferred

Restore and the decision corpus scan (next slice); `get_raw_file`, the available-files hint, and quarantine and backup listings (the slice after); cleanup of stranded sync-state entries under reserved paths; projection download, installation, pointers, leases, routing, migration, release, and activation.
