### PR TITLE
Route restore and the decision corpus through sync path admission

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,8 @@ jobs:
           packages/nauro/tests/test_replica_control.py
           packages/nauro/tests/test_sync/test_replica_control_excluded.py
           packages/nauro/tests/test_sync/test_push_admission.py
-          packages/nauro/tests/test_sync/test_pull_admission.py -v --tb=short
+          packages/nauro/tests/test_sync/test_pull_admission.py
+          packages/nauro/tests/test_sync/test_restore_admission.py -v --tb=short
 
   test-sync-path-admission-windows-python310:
     runs-on: windows-latest
@@ -84,7 +85,8 @@ jobs:
           uv run --no-sync --package nauro pytest
           packages/nauro/tests/test_sync/test_replica_control_excluded.py
           packages/nauro/tests/test_sync/test_push_admission.py
-          packages/nauro/tests/test_sync/test_pull_admission.py -v --tb=short
+          packages/nauro/tests/test_sync/test_pull_admission.py
+          packages/nauro/tests/test_sync/test_restore_admission.py -v --tb=short
 
   distribution:
     runs-on: ubuntu-latest

--- a/packages/nauro/src/nauro/store/recovery.py
+++ b/packages/nauro/src/nauro/store/recovery.py
@@ -32,10 +32,30 @@ from nauro.constants import DECISIONS_DIR, PROJECT_MD
 from nauro.store._atomic import atomic_write_bytes
 from nauro.store.filesystem_store import FilesystemStore
 from nauro.store.registry import bind_project_store_v2, get_store_path_v2
+from nauro.store.replica_control import (
+    _REPLICA_CONTROL_LOCK_NAME,
+    _REPLICA_CONTROL_ROOT_NAME,
+)
 from nauro.store.repo_config import load_repo_config
 from nauro.store.resolution import RepoResolution
+from nauro.sync._path_diagnostics import (
+    _escape_path_for_display,
+    _MissingPathPolicy,
+    _NativeKind,
+    _PathClass,
+    _PreparedStoreRoot,
+    _StoreRootPreparationError,
+    _unsafe_reason_text,
+)
 from nauro.sync.cloud_projects import CloudProjectError, list_projects
 from nauro.sync.etag import content_md5
+from nauro.sync.merge import (
+    _admit_native_path,
+    _classify_sync_path,
+    _is_link_or_reparse,
+    _prepare_store_root,
+    _walk_store_files,
+)
 from nauro.sync.remote import (
     PRESIGN_BATCH_LIMIT,
     PresignError,
@@ -213,7 +233,37 @@ def _validate_restored_store(store_path: Path) -> None:
         )
 
 
+def _present_nofollow(path: Path) -> bool:
+    """True when something occupies ``path``, following nothing.
+
+    Unreadable metadata counts as present: nothing may install over it.
+    """
+    try:
+        os.lstat(path)
+    except FileNotFoundError:
+        return False
+    except OSError:
+        return True
+    return True
+
+
+def _links_elsewhere(path: Path) -> bool:
+    """True when ``path`` is a link, a junction, or an entry that cannot be inspected.
+
+    ``Path.is_symlink`` answers False for a junction, which no caller here survives.
+    """
+    try:
+        metadata = os.lstat(path)
+    except FileNotFoundError:
+        return False
+    except OSError:
+        return True
+    return _is_link_or_reparse(metadata)
+
+
 def _destination_is_available(destination: Path) -> bool:
+    if _links_elsewhere(destination):
+        return False
     if not destination.exists():
         return True
     if not destination.is_dir():
@@ -391,6 +441,20 @@ def _discard(path: Path) -> None:
         path.unlink(missing_ok=True)
 
 
+def _remove_control_entry(control: Path) -> None:
+    """Remove one control entry at the staging root without following it."""
+    if _links_elsewhere(control):
+        # unlink drops a symlink, rmdir drops a junction, and neither descends
+        # into whatever the entry points at.
+        with suppress(OSError):
+            os.unlink(control)
+        if _present_nofollow(control):
+            with suppress(OSError):
+                os.rmdir(control)
+        return
+    _discard(control)
+
+
 def _sweep_legacy_staging(project_id: str, parent: Path) -> None:
     """Remove staging directories a killed pre-resume run stranded.
 
@@ -405,6 +469,10 @@ def _open_staging(staging: Path) -> None:
 
     Only a directory a restore can resume from may occupy the path, so a file goes.
     """
+    # Discarding a link here would delete through it, and staging it would put
+    # every later write and the install rename on the other side.
+    if _links_elsewhere(staging):
+        raise RecoveryError("The restore staging area is unavailable.")
     if staging.exists() and not (staging.is_dir() and not staging.is_symlink()):
         _discard(staging)
     try:
@@ -414,19 +482,34 @@ def _open_staging(staging: Path) -> None:
 
 
 def _fetch_manifest_entries(
-    project_id: str, session: TransferSession
-) -> dict[str, CloudManifestEntry]:
-    """Return the remote record's files, keyed by store-relative path."""
+    project_id: str, session: TransferSession, reporter: Reporter
+) -> tuple[dict[str, CloudManifestEntry], int]:
+    """Return the remote record's installable files and the count it refused."""
     try:
         rows = fetch_manifest(project_id, session=session)
     except (AuthRefreshError, PresignError) as exc:
         raise RecoveryError(f"Cloud manifest fetch failed: {exc}") from exc
     entries: dict[str, CloudManifestEntry] = {}
+    seen: set[str] = set()
+    skipped = 0
     for entry in _parse_manifest(rows):
-        if entry.path in entries:
+        if entry.path in seen:
             raise RecoveryError(f"Duplicate cloud manifest path: {entry.path!r}.")
+        seen.add(entry.path)
+        admission = _classify_sync_path(entry.path)
+        if admission.path_class is _PathClass.RESERVED_CONTROL:
+            continue
+        if admission.path_class is _PathClass.UNSAFE:
+            reason = admission.reason
+            assert reason is not None
+            reporter.warn(
+                f"skipping manifest entry {_escape_path_for_display(entry.path)}: "
+                f"{_unsafe_reason_text(reason)}"
+            )
+            skipped += 1
+            continue
         entries[entry.path] = entry
-    return entries
+    return entries, skipped
 
 
 class StagedFile(BaseModel):
@@ -446,10 +529,16 @@ class StagingLedger(BaseModel):
     files: dict[str, StagedFile] = Field(default_factory=dict)
 
 
-def _prune_empty_directories(staging: Path) -> None:
+def _prune_empty_directories(staging: Path, candidates: set[Path]) -> None:
     """Drop directories the audit emptied, so no phantom directory installs."""
-    for path in sorted(staging.rglob("*"), reverse=True):
-        if path.is_dir() and not path.is_symlink() and next(path.iterdir(), None) is None:
+    pruned: set[Path] = set()
+    for candidate in candidates:
+        path = candidate
+        while path != staging and staging in path.parents:
+            pruned.add(path)
+            path = path.parent
+    for path in sorted(pruned, key=lambda item: len(item.parts), reverse=True):
+        with suppress(OSError):
             path.rmdir()
 
 
@@ -465,6 +554,7 @@ class _StagingArea:
     path: Path
     ledger_path: Path
     ledger: StagingLedger
+    root: _PreparedStoreRoot
 
     def audit(self, entries: dict[str, CloudManifestEntry]) -> set[str]:
         """Return the staged paths a resume may keep, deleting every other one.
@@ -472,17 +562,26 @@ class _StagingArea:
         An unrecorded file, a rotated remote, local damage, or a non-regular file goes.
         """
         kept: set[str] = set()
+        emptied: set[Path] = set()
+        # Restore removes only what the walker yields inside this staging
+        # directory, the two control names at its root, its own ledger and lock
+        # beside the destination, and the legacy staging directories the sweep
+        # collects. Nothing outside staging is unlinked, and no path reached
+        # through a link is touched.
         try:
-            for path in sorted(self.path.rglob("*")):
-                if path.is_dir() and not path.is_symlink():
+            for staged in _walk_store_files(self.root):
+                if staged.admission.path_class is _PathClass.UNSAFE:
+                    _discard(staged.native_path)
+                    emptied.add(staged.native_path.parent)
                     continue
-                relative = path.relative_to(self.path).as_posix()
+                relative = Path(staged.raw_relative_path).as_posix()
                 entry = entries.get(relative)
-                if entry is not None and self._still_good(path, relative, entry):
+                if entry is not None and self._still_good(staged.native_path, relative, entry):
                     kept.add(relative)
                     continue
-                path.unlink(missing_ok=True)
-            _prune_empty_directories(self.path)
+                staged.native_path.unlink(missing_ok=True)
+                emptied.add(staged.native_path.parent)
+            _prune_empty_directories(self.root.canonical_root, emptied)
         except OSError as exc:
             raise RecoveryError(
                 f"Could not audit the partial restore at {self.path}: {exc}"
@@ -509,8 +608,23 @@ class _StagingArea:
 
         The record trails the write, so a kill costs a re-download, never false trust.
         """
+        admission = _admit_native_path(
+            self.root, relative, missing=_MissingPathPolicy.CREATE_DESTINATION
+        )
+        if admission.path_class is not _PathClass.ORDINARY or (
+            admission.exists and admission.native_kind is not _NativeKind.REGULAR_FILE
+        ):
+            if admission.reason is not None:
+                text = _unsafe_reason_text(admission.reason)
+            elif admission.path_class is _PathClass.RESERVED_CONTROL:
+                text = "reserved path"
+            else:
+                text = "it resolves to a special file"
+            raise RecoveryError(
+                f"Could not stage cloud file {_escape_path_for_display(relative)}: {text}"
+            )
         try:
-            atomic_write_bytes(self.path / relative, content)
+            atomic_write_bytes(self.root.canonical_root / relative, content)
         except OSError as exc:
             raise RecoveryError(f"Could not stage cloud file {relative}: {exc}") from exc
         self.ledger.files[relative] = StagedFile(
@@ -548,6 +662,23 @@ def _open_staging_area(project_id: str, destination: Path, reporter: Reporter) -
     staging = _staging_path(project_id, destination)
     ledger_path = _ledger_path(project_id, destination)
     _open_staging(staging)
+    try:
+        root = _prepare_store_root(staging)
+    except _StoreRootPreparationError:
+        raise RecoveryError("The restore staging area is unavailable.") from None
+    warned = False
+    for name in (_REPLICA_CONTROL_ROOT_NAME, _REPLICA_CONTROL_LOCK_NAME):
+        control = staging / name
+        if not _present_nofollow(control):
+            continue
+        _remove_control_entry(control)
+        if _present_nofollow(control):
+            raise RecoveryError(
+                "The restore staging area held local control state that could not be removed."
+            )
+        if not warned:
+            warned = True
+            reporter.warn("The restore staging area held local control state; it was discarded.")
     ledger = StagingLedger()
     if ledger_path.exists():
         try:
@@ -557,7 +688,7 @@ def _open_staging_area(project_id: str, destination: Path, reporter: Reporter) -
                 f"The record of the partial restore could not be read ({exc}); "
                 "every staged file will be downloaded again."
             )
-    return _StagingArea(staging, ledger_path, ledger)
+    return _StagingArea(staging, ledger_path, ledger, root)
 
 
 def _human_bytes(total: int) -> str:
@@ -695,6 +826,8 @@ def restore_cloud_store(
         and destination.resolve(strict=False) != destination
     ):
         raise RecoveryError(f"Restore destination must be canonical and absolute: {destination}.")
+    if _links_elsewhere(destination):
+        raise RecoveryError(f"Refusing to restore onto a link at the destination: {destination}.")
     if not _destination_is_available(destination):
         raise RecoveryError(f"Refusing to overwrite nonempty destination: {destination}.")
 
@@ -712,7 +845,7 @@ def restore_cloud_store(
 
         _sweep_legacy_staging(project_id, destination.parent)
         with operation_session() as session:
-            entries = _fetch_manifest_entries(project_id, session)
+            entries, skipped = _fetch_manifest_entries(project_id, session, surface)
             if not entries:
                 # A record that is not there cannot complete a partial restore,
                 # so nothing is kept to resume toward.
@@ -764,6 +897,8 @@ def restore_cloud_store(
             raise
         _discard(area.ledger_path)
         surface.info(f"Restored {len(entries)} files.")
+        if skipped:
+            surface.info(f"Skipped {skipped} manifest entries this restore cannot install.")
         return destination
 
 

--- a/packages/nauro/src/nauro/sync/corpus.py
+++ b/packages/nauro/src/nauro/sync/corpus.py
@@ -17,6 +17,7 @@ claims its number: no proof about a symlink would survive the write it authorize
 
 from __future__ import annotations
 
+import logging
 import os
 from dataclasses import dataclass, field
 from enum import Enum
@@ -27,7 +28,25 @@ from nauro_core.questions import EntryBlock, OpenQuestionsFile
 
 from nauro.constants import DECISIONS_DIR, OPEN_QUESTIONS_MD
 from nauro.store.reader import read_text_lenient
+from nauro.sync._path_diagnostics import (
+    _MissingPathPolicy,
+    _NativeKind,
+    _PathClass,
+    _PreparedStoreRoot,
+    _StoreRootPreparationError,
+)
 from nauro.sync.headings import heading_line_number, heading_number
+from nauro.sync.merge import (
+    _admit_native_path,
+    _classify_sync_path,
+    _is_link_or_reparse,
+    _metadata_kind,
+    _prepare_store_root,
+)
+
+logger = logging.getLogger("nauro.sync")
+
+_UNUSABLE_DECISIONS = "The decisions directory is not usable this run."
 
 # Reading a store file can fail on content (a malformed decision) or on the
 # filesystem (a permission change mid-run). Neither may abort a sync: both mean
@@ -142,6 +161,7 @@ class SkipReason(str, Enum):
 
     not_a_regular_file = "not-a-regular-file"
     unreadable_name = "unreadable-name"
+    unsafe_name = "unsafe-name"
 
 
 @dataclass(frozen=True)
@@ -169,12 +189,34 @@ class DecisionCorpus:
     _names: frozenset[str] = frozenset()
     _references: ReferenceIndex | None = None
     _questions: tuple[frozenset[int], bool] | None = None
+    _root: _PreparedStoreRoot | None = None
 
     @classmethod
     def scan(cls, store_path: Path) -> DecisionCorpus:
         """List ``decisions/`` without reading a single file."""
         corpus = cls(store_path=store_path)
+        try:
+            root = _prepare_store_root(store_path)
+        except _StoreRootPreparationError:
+            return corpus
+        corpus._root = root
+        admitted = _admit_native_path(
+            root, DECISIONS_DIR, missing=_MissingPathPolicy.OPTIONAL_FIXED_LEAF
+        )
+        if admitted.path_class is _PathClass.UNSAFE:
+            logger.warning(_UNUSABLE_DECISIONS)
+            return corpus
+        if admitted.path_class is not _PathClass.ORDINARY or not admitted.exists:
+            return corpus
+        if admitted.native_kind is not _NativeKind.DIRECTORY:
+            return corpus
         directory = store_path / DECISIONS_DIR
+        # Admission follows links, so an ordinary directory result can still be
+        # a link into another admitted directory; listing one would rename and
+        # rewrite files on the other side.
+        if not _is_plain_directory(directory):
+            logger.warning(_UNUSABLE_DECISIONS)
+            return corpus
         names: set[str] = set()
         irregular: list[IrregularEntry] = []
         try:
@@ -183,6 +225,16 @@ class DecisionCorpus:
         except (FileNotFoundError, NotADirectoryError):
             return corpus
         for entry in entries:
+            named = _classify_sync_path(f"{DECISIONS_DIR}/{entry.name}")
+            if named.path_class is _PathClass.UNSAFE:
+                irregular.append(
+                    IrregularEntry(
+                        name=entry.name,
+                        number=extract_decision_number(entry.name),
+                        reason=SkipReason.unsafe_name,
+                    )
+                )
+                continue
             # Case-folded, so a file the store's own readers cannot see is at
             # least visible here: it still occupies its number and its name is
             # still a case variant of something the server may send.
@@ -289,7 +341,14 @@ class DecisionCorpus:
 
     def _question_references(self) -> tuple[frozenset[int], bool]:
         if self._questions is None:
-            self._questions = _read_question_references(self.store_path)
+            root = self._root
+            if root is None:
+                try:
+                    root = _prepare_store_root(self.store_path)
+                except _StoreRootPreparationError:
+                    return frozenset(), False
+                self._root = root
+            self._questions = _read_question_references(self.store_path, root)
         return self._questions
 
     # ── Mutation notices ───────────────────────────────────────────────────
@@ -316,11 +375,27 @@ class DecisionCorpus:
         self._references = None
 
 
-def _read_question_references(store_path: Path) -> tuple[frozenset[int], bool]:
+def _is_plain_directory(path: Path) -> bool:
+    """True when ``path`` is a directory in its own right, following nothing."""
+    try:
+        metadata = os.lstat(path)
+    except OSError:
+        return False
+    return not _is_link_or_reparse(metadata) and _metadata_kind(metadata) is _NativeKind.DIRECTORY
+
+
+def _read_question_references(
+    store_path: Path, root: _PreparedStoreRoot
+) -> tuple[frozenset[int], bool]:
     """Decision numbers named as question resolutions, and whether that is known."""
-    path = store_path / OPEN_QUESTIONS_MD
-    if not path.is_file():
+    admitted = _admit_native_path(
+        root, OPEN_QUESTIONS_MD, missing=_MissingPathPolicy.OPTIONAL_FIXED_LEAF
+    )
+    if admitted.path_class is _PathClass.ORDINARY and not admitted.exists:
         return frozenset(), True
+    if admitted.native_kind is not _NativeKind.REGULAR_FILE:
+        return frozenset(), False
+    path = store_path / OPEN_QUESTIONS_MD
     try:
         parsed = OpenQuestionsFile.parse(read_text_lenient(path))
     except PARSE_FAILURES:

--- a/packages/nauro/src/nauro/sync/merge.py
+++ b/packages/nauro/src/nauro/sync/merge.py
@@ -593,7 +593,7 @@ def write_backup(project_path: Path, backup_name: str, content: bytes) -> Path:
 def _save_conflict_backup(project_path: Path, relative_path: str, content: bytes) -> Path:
     """Save the losing version to .conflict-backup/."""
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-    filename = relative_path.replace("/", "_")
+    filename = relative_path.replace("%", "%25").replace("/", "%2F").replace("\\", "%5C")
     return write_backup(project_path, f"{timestamp}-{filename}", content)
 
 

--- a/packages/nauro/src/nauro/sync/pull.py
+++ b/packages/nauro/src/nauro/sync/pull.py
@@ -881,6 +881,11 @@ _SKIP_DETAIL: dict[SkipReason, str] = {
         "back any remote decision claiming its number. Rename it to the lowercase "
         "suffix so it becomes a decision again."
     ),
+    SkipReason.unsafe_name: (
+        "its name is not a safe path - it reads as a parent, a drive, or an empty "
+        "component. Nauro never reads or changes it, and holds back any remote "
+        "decision claiming its number. Rename it to a plain '.md' filename."
+    ),
 }
 
 
@@ -968,14 +973,14 @@ def _resolve_and_record(
 ) -> None:
     """Apply the conflict policy for one path and record the result."""
     local_file = store_path / transfer.rel
-    # This spelling picks the merge policy and names the backup, so it escapes
-    # injectively: a lossy one would let a remote row claim a set-union name or
-    # overwrite another row's backup.
+    # The raw path picks the merge policy and names the conflict log; the
+    # injective escape that turns it into one backup filename lives beside the
+    # naming in merge.py.
     merged_content = resolve_conflict(
         store_path,
         local_file,
         transfer.content,
-        transfer.rel.replace("%", "%25").replace("\\", "%5C"),
+        transfer.rel,
         keeps=keeps,
     )
     atomic_write_bytes(local_file, merged_content)

--- a/packages/nauro/tests/test_sync/test_pull_admission.py
+++ b/packages/nauro/tests/test_sync/test_pull_admission.py
@@ -528,6 +528,34 @@ def test_conflicting_rows_back_up_under_distinct_flat_names(store):
     }
 
 
+RESOLVER_ROWS = {
+    "context/victim.md": b"local victim\n",
+    "context_victim.md": b"local sibling\n",
+}
+
+
+def test_a_nested_row_and_its_flat_sibling_back_up_under_distinct_names(store, caplog):
+    for rel, body in RESOLVER_ROWS.items():
+        _plant(store, rel, body)
+
+    with caplog.at_level(logging.WARNING, logger="nauro.sync"):
+        report, _reporter, _operations = _run(
+            store, [(rel, b"remote " + body) for rel, body in RESOLVER_ROWS.items()]
+        )
+
+    backups = list((store / CONFLICT_BACKUP_DIR).iterdir())
+    assert report == PullReport(merged=2)
+    assert len({path.name for path in backups}) == 2
+    assert all(path.is_file() for path in backups)
+    assert not any("\\" in path.name or "/" in path.name for path in backups)
+    assert sorted(path.read_bytes() for path in backups) == sorted(RESOLVER_ROWS.values())
+    assert [
+        record.getMessage()
+        for record in caplog.records
+        if "context/victim.md" in record.getMessage()
+    ]
+
+
 def test_an_append_only_conflict_still_set_unions_without_a_backup(store):
     rel = "state_history.md"
     _plant(store, rel, b"## History\n\nlocal entry\n")

--- a/packages/nauro/tests/test_sync/test_replica_control_excluded.py
+++ b/packages/nauro/tests/test_sync/test_replica_control_excluded.py
@@ -160,10 +160,26 @@ def test_prepare_store_root_has_fixed_suppressed_failure(tmp_path: Path, kind: s
 def test_admission_has_exactly_one_enumerating_caller() -> None:
     src_root = Path(merge.__file__).parents[2]
     allowed = {
-        "_walk_store_files": {"sync/merge.py", "sync/push.py", "sync/pull.py"},
-        "_prepare_store_root": {"sync/merge.py", "sync/push.py", "sync/pull.py"},
-        "_admit_native_path": {"sync/merge.py", "sync/pull.py"},
-        "_classify_sync_path": {"sync/merge.py", "sync/pull.py"},
+        "_walk_store_files": {"sync/merge.py", "sync/push.py", "sync/pull.py", "store/recovery.py"},
+        "_prepare_store_root": {
+            "sync/merge.py",
+            "sync/push.py",
+            "sync/pull.py",
+            "sync/corpus.py",
+            "store/recovery.py",
+        },
+        "_admit_native_path": {
+            "sync/merge.py",
+            "sync/pull.py",
+            "sync/corpus.py",
+            "store/recovery.py",
+        },
+        "_classify_sync_path": {
+            "sync/merge.py",
+            "sync/pull.py",
+            "sync/corpus.py",
+            "store/recovery.py",
+        },
     }
     for source in src_root.rglob("*.py"):
         relative = source.relative_to(src_root / "nauro").as_posix()

--- a/packages/nauro/tests/test_sync/test_restore_admission.py
+++ b/packages/nauro/tests/test_sync/test_restore_admission.py
@@ -1,0 +1,614 @@
+"""Cloud restore and the decision corpus route every path through admission."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from nauro.cli.main import app
+from nauro.constants import DECISIONS_DIR, OPEN_QUESTIONS_MD, PROJECT_MD
+from nauro.store import recovery
+from nauro.store.recovery import RecoveryError, restore_cloud_store
+from nauro.store.registry import get_store_path_v2
+from nauro.store.replica_control import (
+    _REPLICA_CONTROL_LOCK_NAME,
+    _REPLICA_CONTROL_ROOT_NAME,
+)
+from nauro.store.repo_config import save_repo_config
+from nauro.sync import corpus as corpus_module
+from nauro.sync import merge as merge_module
+from nauro.sync._path_diagnostics import (
+    _escape_path_for_display,
+    _StoreRootPreparationError,
+)
+from nauro.sync.corpus import DecisionCorpus, IrregularEntry, SkipReason
+from nauro.sync.remote import FetchedObject
+from nauro.sync.state import SYNC_STATE_FILE
+from nauro.templates.scaffolds import scaffold_project_store
+from tests.test_sync.conftest import (
+    CLOUD_PID,
+    _RecordingReporter,
+    _scaffolded_cloud_project,
+    _seed_token,
+    decision_bytes,
+    entry_names,
+    pull_report,
+)
+
+POSIX_ONLY = pytest.mark.skipif(sys.platform == "win32", reason="POSIX filename semantics")
+LINK_KINDS = ["symlink", "junction"]
+
+PID = "01KQ6AZGNA0B3QBF67NBXP3S45"
+NOTE = "context/note.md"
+CONTROL_DISCARDED = "The restore staging area held local control state; it was discarded."
+STAGING_UNAVAILABLE = "The restore staging area is unavailable."
+UNUSABLE_DECISIONS = "The decisions directory is not usable this run."
+
+RESERVED_ROWS = [
+    f"{_REPLICA_CONTROL_ROOT_NAME}/authority.json",
+    _REPLICA_CONTROL_LOCK_NAME,
+    ".REPLICA/x",
+    " .replica. /x",
+    ".replica:ads/x",
+]
+
+UNSAFE_ROWS = {
+    "C:x": "The path uses drive syntax.",
+    "context/ :stream": "A path component normalizes to empty.",
+}
+
+
+def _staging(destination: Path) -> Path:
+    """The fixed staging directory a restore of ``destination`` resumes from."""
+    return destination.parent / f".{PID}.restore"
+
+
+def _store_files(root: Path) -> dict[str, bytes]:
+    """Scaffold a store and return its files, keyed by store-relative path."""
+    scaffold_project_store("nauro", root)
+    return {
+        path.relative_to(root).as_posix(): path.read_bytes()
+        for path in root.rglob("*")
+        if path.is_file()
+    }
+
+
+class _Cloud:
+    """A remote record behind the restore's three network calls, recording each."""
+
+    def __init__(self, files: dict[str, bytes]) -> None:
+        self.files = files
+        self.presigned: list[str] = []
+        self.fetched: list[str] = []
+
+    def install(self, monkeypatch) -> None:
+        monkeypatch.setattr(recovery, "fetch_manifest", self.manifest)
+        monkeypatch.setattr(recovery, "request_presigned_urls", self.presign)
+        monkeypatch.setattr(recovery, "fetch_via_presigned_url", self.fetch)
+
+    def manifest(self, _project_id: str, **_kwargs) -> list[dict]:
+        return [
+            {
+                "path": path,
+                "etag": f'"{hashlib.md5(content).hexdigest()}"',
+                "size": len(content),
+                "sha256": hashlib.sha256(content).hexdigest(),
+            }
+            for path, content in sorted(self.files.items())
+        ]
+
+    def presign(self, _project_id: str, operations: list[dict[str, str]], **_kwargs) -> list[dict]:
+        self.presigned.extend(operation["path"] for operation in operations)
+        expires = datetime.now(timezone.utc) + timedelta(seconds=900)
+        return [
+            {
+                "verb": "GET",
+                "path": operation["path"],
+                "url": f"memory://{operation['path']}",
+                "expires_at": expires.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            }
+            for operation in operations
+        ]
+
+    def fetch(self, url: str, **_kwargs) -> FetchedObject:
+        path = url.removeprefix("memory://")
+        self.fetched.append(path)
+        body = self.files[path]
+        return FetchedObject(body, f'"{hashlib.md5(body).hexdigest()}"')
+
+
+def _remote(tmp_path: Path, monkeypatch, extra: dict[str, bytes]):
+    """A scaffolded remote record plus ``extra`` rows, ready to restore."""
+    files = _store_files(tmp_path / "source")
+    cloud = _Cloud({**files, **extra})
+    cloud.install(monkeypatch)
+    return files, cloud, tmp_path / "projects" / PID, _RecordingReporter()
+
+
+def _installed(destination: Path) -> dict[str, bytes]:
+    return {
+        path.relative_to(destination).as_posix(): path.read_bytes()
+        for path in destination.rglob("*")
+        if path.is_file()
+    }
+
+
+def _read(path: Path) -> bytes:
+    with open(path, "rb") as handle:
+        return handle.read()
+
+
+def _is_reserved(value) -> bool:
+    for part in str(value).replace("\\", "/").split("/"):
+        folded = part.split(":", 1)[0].strip(" ").rstrip(" .").casefold()
+        if folded in {_REPLICA_CONTROL_ROOT_NAME, _REPLICA_CONTROL_LOCK_NAME}:
+            return True
+    return False
+
+
+def _forbid(monkeypatch, matches, *, inspect: bool = False) -> None:
+    """Fail the test when a restore reads, writes, or inspects a path ``matches`` accepts."""
+    real_read = Path.read_bytes
+    real_write = recovery.atomic_write_bytes
+    real_lstat = merge_module.os.lstat
+
+    def check(value) -> None:
+        if matches(Path(value)):
+            pytest.fail(f"reached {value!r}")
+
+    def read_bytes(self):
+        check(self)
+        return real_read(self)
+
+    def write(path, content):
+        check(path)
+        return real_write(path, content)
+
+    def guarded_lstat(path, *args, **kwargs):
+        check(path)
+        return real_lstat(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_bytes", read_bytes)
+    monkeypatch.setattr(recovery, "atomic_write_bytes", write)
+    if inspect:
+        monkeypatch.setattr(merge_module.os, "lstat", guarded_lstat)
+
+
+def _link(link: Path, target: Path, kind: str) -> None:
+    """Point ``link`` at ``target`` as a symlink or as a Windows junction."""
+    if kind == "junction":
+        subprocess.run(
+            ["cmd", "/c", "mklink", "/J", str(link), str(target)],
+            check=True,
+            capture_output=True,
+        )
+        return
+    link.symlink_to(target, target_is_directory=True)
+
+
+def _require_link_kind(kind: str) -> None:
+    if (kind == "junction") != (sys.platform == "win32"):
+        pytest.skip(f"{kind} is not this platform's directory link")
+
+
+def _outside_with_victim(tmp_path: Path) -> Path:
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "victim.md").write_bytes(b"victim\n")
+    return outside
+
+
+def _bare_store(tmp_path: Path) -> Path:
+    store = tmp_path / "store"
+    store.mkdir()
+    (store / PROJECT_MD).write_bytes(b"# project\n")
+    return store
+
+
+def _forbid_read(monkeypatch, *targets: Path) -> None:
+    """Fail the test if the corpus reads one of ``targets``."""
+    real_read = corpus_module.read_text_lenient
+    resolved = {os.path.realpath(target) for target in targets}
+
+    def read_text_lenient(path: Path) -> str:
+        if os.path.realpath(path) in resolved:
+            pytest.fail(f"read {path}")
+        return real_read(path)
+
+    monkeypatch.setattr(corpus_module, "read_text_lenient", read_text_lenient)
+
+
+def _forbid_scandir(monkeypatch, target: Path) -> None:
+    """Fail the test if the corpus lists ``target``."""
+    real_scandir = corpus_module.os.scandir
+
+    def scandir(path):
+        if os.path.realpath(path) == os.path.realpath(target):
+            pytest.fail(f"listed {path}")
+        return real_scandir(path)
+
+    monkeypatch.setattr(corpus_module.os, "scandir", scandir)
+
+
+def test_reserved_manifest_rows_are_never_presigned_or_installed(tmp_path, monkeypatch):
+    files, cloud, destination, reporter = _remote(
+        tmp_path, monkeypatch, {row: b"control\n" for row in RESERVED_ROWS}
+    )
+
+    restore_cloud_store(PID, destination, reporter)
+
+    installed = _installed(destination)
+    assert installed.pop(SYNC_STATE_FILE)
+    assert installed == files
+    assert not [name for name in entry_names(destination) if _is_reserved(name)]
+    assert sorted(cloud.presigned) == sorted(files)
+    assert sorted(cloud.fetched) == sorted(files)
+    state = json.loads((destination / SYNC_STATE_FILE).read_text(encoding="utf-8"))
+    assert set(state["files"]) == set(files)
+    assert reporter.warns == []
+    assert f"Restored {len(files)} files." in reporter.infos
+    assert not any(message.startswith("Skipped") for message in reporter.infos)
+
+
+def test_unsafe_manifest_rows_are_named_once_and_counted(tmp_path, monkeypatch):
+    files, cloud, destination, reporter = _remote(
+        tmp_path, monkeypatch, {row: b"payload\n" for row in UNSAFE_ROWS}
+    )
+
+    restore_cloud_store(PID, destination, reporter)
+
+    assert reporter.warns == [
+        f"skipping manifest entry {_escape_path_for_display(row)}: {reason}"
+        for row, reason in sorted(UNSAFE_ROWS.items())
+    ]
+    assert sorted(cloud.presigned) == sorted(files)
+    assert f"Restored {len(files)} files." in reporter.infos
+    assert "Skipped 2 manifest entries this restore cannot install." in reporter.infos
+
+
+@pytest.mark.parametrize("kind", ["file", "directory", "symlink", "junction"])
+@pytest.mark.parametrize("name", [_REPLICA_CONTROL_ROOT_NAME, _REPLICA_CONTROL_LOCK_NAME])
+def test_control_state_in_staging_is_removed_without_following(tmp_path, monkeypatch, name, kind):
+    if kind in LINK_KINDS:
+        _require_link_kind(kind)
+    _files, _cloud, destination, reporter = _remote(tmp_path, monkeypatch, {})
+    outside = _outside_with_victim(tmp_path)
+    control = _staging(destination) / name
+    control.parent.mkdir(parents=True)
+    if kind == "file":
+        control.write_bytes(b"control\n")
+    elif kind == "directory":
+        control.mkdir()
+        (control / "authority.json").write_bytes(b"{}\n")
+    else:
+        _link(control, outside, kind)
+
+    restore_cloud_store(PID, destination, reporter)
+
+    assert not [entry for entry in entry_names(destination) if _is_reserved(entry)]
+    assert reporter.warns == [CONTROL_DISCARDED]
+    assert entry_names(outside) == {"victim.md"}
+
+
+def test_control_state_that_cannot_be_removed_stops_the_restore(tmp_path, monkeypatch):
+    _files, cloud, destination, reporter = _remote(tmp_path, monkeypatch, {})
+    control = _staging(destination) / _REPLICA_CONTROL_LOCK_NAME
+    control.parent.mkdir(parents=True)
+    control.write_bytes(b"control\n")
+    monkeypatch.setattr(recovery, "_remove_control_entry", lambda _control: None)
+
+    with pytest.raises(RecoveryError) as raised:
+        restore_cloud_store(PID, destination, reporter)
+
+    assert str(raised.value) == (
+        "The restore staging area held local control state that could not be removed."
+    )
+    assert cloud.presigned == []
+    assert not destination.exists()
+
+
+@pytest.mark.parametrize("kind", LINK_KINDS)
+def test_a_linked_staging_path_is_refused(tmp_path, monkeypatch, kind):
+    _require_link_kind(kind)
+    _files, cloud, destination, reporter = _remote(tmp_path, monkeypatch, {})
+    outside = _outside_with_victim(tmp_path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    _link(_staging(destination), outside, kind)
+
+    with pytest.raises(RecoveryError) as raised:
+        restore_cloud_store(PID, destination, reporter)
+
+    assert str(raised.value) == STAGING_UNAVAILABLE
+    assert cloud.presigned == []
+    assert entry_names(outside) == {"victim.md"}
+
+
+def test_an_unrecorded_staged_file_is_unlinked(tmp_path, monkeypatch):
+    files, _cloud, destination, reporter = _remote(tmp_path, monkeypatch, {})
+    staging = _staging(destination)
+    (staging / "context").mkdir(parents=True)
+    (staging / "context" / "stray.md").write_bytes(b"stray\n")
+
+    restore_cloud_store(PID, destination, reporter)
+
+    installed = _installed(destination)
+    assert installed.pop(SYNC_STATE_FILE)
+    assert installed == files
+    assert "context" not in entry_names(destination)
+
+
+@POSIX_ONLY
+def test_a_directory_link_in_staging_deletes_nothing_outside_it(tmp_path, monkeypatch):
+    _files, _cloud, destination, reporter = _remote(tmp_path, monkeypatch, {})
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "victim.md").write_bytes(b"victim\n")
+    staging = _staging(destination)
+    staging.mkdir(parents=True)
+    (staging / "escape").symlink_to(outside, target_is_directory=True)
+
+    restore_cloud_store(PID, destination, reporter)
+
+    assert (outside / "victim.md").read_bytes() == b"victim\n"
+    assert entry_names(outside) == {"victim.md"}
+    assert "escape" not in entry_names(destination)
+
+
+@POSIX_ONLY
+def test_a_staged_file_link_is_discarded_and_downloaded_again(tmp_path, monkeypatch):
+    _files, _cloud, destination, reporter = _remote(tmp_path, monkeypatch, {NOTE: b"note\n"})
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    secret = outside / "secret"
+    secret.write_bytes(b"secret\n")
+    staging = _staging(destination)
+    (staging / NOTE).parent.mkdir(parents=True)
+    (staging / NOTE).symlink_to(secret)
+    _forbid(monkeypatch, lambda path: os.path.realpath(path) == os.path.realpath(secret))
+
+    restore_cloud_store(PID, destination, reporter)
+
+    assert _read(destination / NOTE) == b"note\n"
+    assert not (destination / NOTE).is_symlink()
+    assert _read(secret) == b"secret\n"
+
+
+def test_a_restore_reaches_no_reserved_path_and_no_linked_target(tmp_path, monkeypatch):
+    files, _cloud, destination, reporter = _remote(
+        tmp_path, monkeypatch, {row: b"control\n" for row in RESERVED_ROWS}
+    )
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "victim.md").write_bytes(b"victim\n")
+    staging = _staging(destination)
+    staging.mkdir(parents=True)
+    if sys.platform != "win32":
+        (staging / "escape").symlink_to(outside, target_is_directory=True)
+    # The two fixed control names at the staging root are the one probe the
+    # restore is entitled to make, and it makes it without following them.
+    probes = {
+        str(staging / _REPLICA_CONTROL_ROOT_NAME),
+        str(staging / _REPLICA_CONTROL_LOCK_NAME),
+    }
+    _forbid(
+        monkeypatch,
+        lambda path: (
+            str(path) not in probes
+            and (_is_reserved(path) or path == outside or outside in path.parents)
+        ),
+        inspect=True,
+    )
+
+    restore_cloud_store(PID, destination, reporter)
+
+    assert _read(outside / "victim.md") == b"victim\n"
+    assert entry_names(destination) == {Path(name).parts[0] for name in files} | {SYNC_STATE_FILE}
+
+
+def test_a_restore_never_enumerates_with_rglob(tmp_path, monkeypatch):
+    files, _cloud, destination, reporter = _remote(tmp_path, monkeypatch, {})
+
+    def rglob(self, _pattern):
+        pytest.fail(f"rglob {self}")
+
+    monkeypatch.setattr(Path, "rglob", rglob)
+
+    restore_cloud_store(PID, destination, reporter)
+
+    assert (destination / PROJECT_MD).read_bytes() == files[PROJECT_MD]
+
+
+def test_an_unusable_staging_root_is_refused_before_presign(tmp_path, monkeypatch):
+    _files, cloud, destination, reporter = _remote(tmp_path, monkeypatch, {})
+
+    def unavailable(_path):
+        raise _StoreRootPreparationError()
+
+    monkeypatch.setattr(recovery, "_prepare_store_root", unavailable)
+
+    with pytest.raises(RecoveryError) as raised:
+        restore_cloud_store(PID, destination, reporter)
+
+    assert str(raised.value) == STAGING_UNAVAILABLE
+    assert raised.value.__cause__ is None
+    assert cloud.presigned == []
+
+
+@pytest.mark.parametrize("kind", LINK_KINDS)
+def test_a_linked_destination_is_refused_before_any_network_call(tmp_path, monkeypatch, kind):
+    _require_link_kind(kind)
+
+    def explode(_project_id, **_kwargs):
+        raise AssertionError("network must not run")
+
+    monkeypatch.setattr(recovery, "fetch_manifest", explode)
+    destination = get_store_path_v2(PID)
+    target = destination.parent / "victim"
+    target.mkdir(parents=True)
+    (target / "keep.md").write_bytes(b"keep\n")
+    _link(destination, target, kind)
+
+    with pytest.raises(RecoveryError) as raised:
+        restore_cloud_store(PID, destination)
+
+    assert str(raised.value) == (
+        f"Refusing to restore onto a link at the destination: {destination}."
+    )
+    assert (target / "keep.md").read_bytes() == b"keep\n"
+    assert entry_names(target) == {"keep.md"}
+
+
+def test_reconnect_reports_an_unusable_staging_root_and_exits_one(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    save_repo_config(
+        repo,
+        {"mode": "cloud", "id": PID, "name": "nauro", "server_url": "https://example.test"},
+    )
+    monkeypatch.chdir(repo)
+    _Cloud(_store_files(tmp_path / "source")).install(monkeypatch)
+
+    def unavailable(_path):
+        raise _StoreRootPreparationError()
+
+    monkeypatch.setattr(recovery, "_prepare_store_root", unavailable)
+    with patch("nauro.cli.commands.reconnect.require_cloud_membership", return_value="nauro"):
+        result = CliRunner().invoke(app, ["reconnect"], input="restore\n")
+
+    assert result.exit_code == 1
+    assert f"Error: {STAGING_UNAVAILABLE}" in result.output
+
+
+def test_a_real_decisions_directory_lists_its_regular_files(tmp_path):
+    store = _bare_store(tmp_path)
+    (store / DECISIONS_DIR).mkdir()
+    (store / DECISIONS_DIR / "003-x.md").write_bytes(decision_bytes(3, "X"))
+    (store / DECISIONS_DIR / "notes.txt").write_bytes(b"skip\n")
+
+    corpus = DecisionCorpus.scan(store)
+
+    assert {entry.name for entry in corpus.files} == {"003-x.md"}
+    assert corpus.irregular == ()
+    assert corpus.claimed_numbers() == frozenset({3})
+
+
+@POSIX_ONLY
+@pytest.mark.parametrize(
+    ("target", "warnings"),
+    [
+        # A reserved target is classified before anything is inspected, so it
+        # stays silent; the other two are refused on their own metadata.
+        (f"{_REPLICA_CONTROL_ROOT_NAME}/{DECISIONS_DIR}", []),
+        ("context", [UNUSABLE_DECISIONS]),
+        ("../outside", [UNUSABLE_DECISIONS]),
+    ],
+)
+def test_a_linked_decisions_directory_lists_nothing(
+    tmp_path, monkeypatch, caplog, target, warnings
+):
+    store = _bare_store(tmp_path)
+    listed = tmp_path / "outside" if target.startswith("..") else store / target
+    listed.mkdir(parents=True)
+    (listed / "003-x.md").write_bytes(decision_bytes(3, "X"))
+    (store / DECISIONS_DIR).symlink_to(target, target_is_directory=True)
+    _forbid_scandir(monkeypatch, listed)
+
+    with caplog.at_level(logging.WARNING, logger="nauro.sync"):
+        corpus = DecisionCorpus.scan(store)
+
+    assert corpus.files == ()
+    assert corpus.irregular == ()
+    assert [record.getMessage() for record in caplog.records] == warnings
+
+
+@POSIX_ONLY
+def test_an_unsafe_decision_name_is_listed_but_never_read(tmp_path):
+    store = _bare_store(tmp_path)
+    (store / DECISIONS_DIR).mkdir()
+    (store / DECISIONS_DIR / "..\\x.md").write_bytes(decision_bytes(3, "X"))
+
+    corpus = DecisionCorpus.scan(store)
+
+    assert corpus.irregular == (
+        IrregularEntry(name="..\\x.md", number=None, reason=SkipReason.unsafe_name),
+    )
+    assert corpus.files == ()
+    assert not corpus.has_name("..\\x.md")
+
+
+@POSIX_ONLY
+def test_a_linked_questions_file_is_unreadable_and_never_read(tmp_path, monkeypatch):
+    store = _bare_store(tmp_path)
+    (store / DECISIONS_DIR).mkdir()
+    control = store / _REPLICA_CONTROL_ROOT_NAME
+    control.mkdir()
+    target = control / "x"
+    target.write_bytes(b"- [Q1] question\n")
+    (store / OPEN_QUESTIONS_MD).symlink_to(Path(_REPLICA_CONTROL_ROOT_NAME) / "x")
+    _forbid_read(monkeypatch, target, store / OPEN_QUESTIONS_MD)
+
+    index = DecisionCorpus.scan(store).references()
+
+    assert index.questions_readable is False
+    assert index.verifiable is False
+    assert index.question_refs == frozenset()
+
+
+@POSIX_ONLY
+def test_a_pull_reports_an_unsafe_decision_name_without_reading_it(tmp_path, monkeypatch):
+    store = _scaffolded_cloud_project("unsafename", tmp_path, project_id=CLOUD_PID)
+    _seed_token()
+    unsafe = store / DECISIONS_DIR / "..\\x.md"
+    unsafe.write_bytes(decision_bytes(3, "X"))
+    _forbid_read(monkeypatch, unsafe)
+
+    report, reporter = pull_report(store, [("notes.md", b"note\n")])
+
+    assert report.merged == 1
+    assert [warning for warning in reporter.warns if "..\\x.md" in warning] == [
+        "decisions/..\\x.md: its name is not a safe path - it reads as a parent, a drive, "
+        "or an empty component. Nauro never reads or changes it, and holds back any remote "
+        "decision claiming its number. Rename it to a plain '.md' filename."
+    ]
+
+
+@POSIX_ONLY
+def test_a_pull_over_a_linked_decisions_directory_writes_nothing(tmp_path, monkeypatch):
+    store = _scaffolded_cloud_project("restoreadmission", tmp_path, project_id=CLOUD_PID)
+    _seed_token()
+    shutil.rmtree(store / DECISIONS_DIR)
+    control = store / _REPLICA_CONTROL_ROOT_NAME
+    control.mkdir()
+    (control / "003-x.md").write_bytes(decision_bytes(3, "X"))
+    (store / DECISIONS_DIR).symlink_to(_REPLICA_CONTROL_ROOT_NAME, target_is_directory=True)
+    _forbid_read(monkeypatch, control / "003-x.md")
+    real_replace = os.replace
+
+    def replace(source, target):
+        landing = Path(os.path.realpath(target))
+        if landing == control or control in landing.parents:
+            pytest.fail(f"renamed onto {target}")
+        return real_replace(source, target)
+
+    monkeypatch.setattr(os, "replace", replace)
+
+    report, _reporter = pull_report(
+        store, [(f"{DECISIONS_DIR}/003-x.md", decision_bytes(3, "Remote"))]
+    )
+
+    assert report.merged == 0
+    # The pull's decision lock still lands here through the link; it is the one
+    # known stray, so the filter must not absorb a second.
+    assert entry_names(control) == {"003-x.md", ".lock"}
+    assert (control / "003-x.md").read_bytes() == decision_bytes(3, "X")


### PR DESCRIPTION
## Why

Cloud restore trusted the manifest once its validator had rejected absolute, parent, and backslash forms. A row named `.replica/authority.json` or `.replica-control.lock`, or any case, space, period, or ADS alias, passed that check and was presigned, downloaded, staged, seeded into sync-state, and installed by the final rename. The staging audit walked staging with `rglob`, which descends through a directory symlink, so a link planted in staging deleted files outside it. The decision corpus listed `decisions/` with `os.scandir`, which follows a symlinked directory, so a link from `decisions/` into the control root let a pull rename files there. The conflict resolver still named backups with a lossy `/` to `_` map. This slice routes restore and the corpus through the admission layer merged in #508, #509, and #510, and makes backup naming injective.

## What changed

- Every restore manifest row is classified before presign, download, staging, ledger, sync-state, or install. Reserved rows are skipped silently; unsafe rows warn with a fixed reason and an escaped display form, are counted, and the restore proceeds with the rest.
- The staging directory is prepared as a trusted root and every staged write is admitted under it. The staging audit enumerates only through the admission walker and deletes only what the walker yields; empty-directory pruning no longer lists or descends. The two exact control names at the staging root are detected without following links and discarded before install.
- A destination that is a symlink is refused with a fixed message before any network call.
- The decision corpus lists `decisions/` only after admitting it as an ordinary non-link directory, records an unsafe filename as an irregular entry instead of reading it, and reads `open-questions.md` only after admitting it as an ordinary regular file. A linked `decisions/` yields an empty corpus, so that pull writes no decision.
- Conflict-backup names encode `%`, `/`, and `\` injectively at the naming site, so two distinct rows can no longer share a backup name; the pull passes the raw path again so policy selection and the conflict log name the real file.
- Restore deletes nothing outside its own staging directory and its own ledger and lock beside the destination.

## Test plan

- Focused set: `uv run --no-sync --package nauro pytest packages/nauro/tests/test_sync/test_restore_admission.py packages/nauro/tests/test_recovery.py packages/nauro/tests/test_recovery_resume.py packages/nauro/tests/test_sync/test_collisions.py packages/nauro/tests/test_sync/test_merge.py packages/nauro/tests/test_sync/test_pull_admission.py packages/nauro/tests/test_sync/test_pull.py packages/nauro/tests/test_sync/test_replica_control_excluded.py -q`
  - 466 passed, 6 skipped (the skips are the junction rows, which run only on Windows)
- `uv run --no-sync --package nauro pytest packages/nauro/tests/ --ignore=packages/nauro/tests/cross_surface -q`
  - 3,237 passed, 6 skipped
- `uv run --no-sync ruff check packages/ benchmarks/ scripts/` and `uv run --no-sync ruff format --check packages/ benchmarks/ scripts/`
- `uv run --no-sync --package nauro mypy --config-file packages/nauro/pyproject.toml packages/nauro/src/nauro` with no new errors in the changed modules
- Run the single-source, docstring-budget, and server JSON version repository guards.
- Verify the eight-file scope, 939 changed lines against the 950-line ceiling the owner granted for this slice (the default is 800; the extra room went to junction detection, verified removal, and their tests), and that the admission layer's callers are exactly merge, push, pull, recovery, and corpus.
- Windows and macOS evidence comes from the CI jobs on this PR; local runs are macOS only.

## Risk / what to review

- Ordering: classification before presign, root preparation before any staged write, admission before each write, walker-only audit before any unlink. Access-order tests patch the real access points so a regression that reads or deletes through a link fails.
- Links are detected with a non-following stat and the foundation's reparse check, not `is_symlink`, so Windows junctions at the staging path, at the destination, or at `decisions/` are refused the same way as POSIX symlinks. Removal of the two control names from staging is verified with a second non-following stat; an entry that survives removal aborts the restore before install.
- Accepted limit: directory links, junctions, and irregular files planted inside restore's own staging by a local writer survive the audit and ride the install rename. That writer already holds write access to the destination's parent. The two control names are the one case closed explicitly.
- Behavior change: backup names encode `/` as `%2F`, so a backup of `context/note.md` is `<timestamp>-context%2Fnote.md`.
- The staged tree is still handed to the core store diagnoser, which enumerates raw; after this slice it holds only admitted files plus the withheld leftovers above.
- Existing restore messages that carry the local staging or destination path are unchanged; they name user-owned local paths on pre-existing branches.

## Deferred

The pull's decision lock file is still created at the `decisions/` path without admission, so with a linked `decisions/` a lock file lands inside the link target even though nothing there is listed, read, written, or renamed; the lock path moves with the remaining reads and listings. `get_raw_file` and the available-files hint; quarantine and conflict-backup listings; cleanup of stranded sync-state entries under reserved paths; the core store enumeration used by the diagnoser; projection download, installation, pointers, leases, routing, migration, release, and activation.
