### PR TITLE
Route raw-file reads and backup listings through sync path admission

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,7 @@ jobs:
           packages/nauro/tests/test_sync/test_replica_control_excluded.py
           packages/nauro/tests/test_sync/test_push_admission.py
           packages/nauro/tests/test_sync/test_pull_admission.py
+          packages/nauro/tests/test_sync/test_read_admission.py
           packages/nauro/tests/test_sync/test_restore_admission.py -v --tb=short
 
   test-sync-path-admission-windows-python310:
@@ -86,6 +87,7 @@ jobs:
           packages/nauro/tests/test_sync/test_replica_control_excluded.py
           packages/nauro/tests/test_sync/test_push_admission.py
           packages/nauro/tests/test_sync/test_pull_admission.py
+          packages/nauro/tests/test_sync/test_read_admission.py
           packages/nauro/tests/test_sync/test_restore_admission.py -v --tb=short
 
   distribution:

--- a/packages/nauro/src/nauro/cli/commands/sync.py
+++ b/packages/nauro/src/nauro/cli/commands/sync.py
@@ -237,17 +237,14 @@ def _show_status(project_flag: str | None) -> None:
             if len(plan.unsafe) > 5:
                 typer.echo(f"    ... and {len(plan.unsafe) - 5} more")
 
-    from nauro.sync.merge import CONFLICT_BACKUP_DIR
-    from nauro.sync.quarantine import list_quarantine_backups, unresolved_quarantines
+    from nauro.sync.quarantine import (
+        list_conflict_backup_files,
+        list_quarantine_backups,
+        unresolved_quarantines,
+    )
 
-    quarantined = unresolved_quarantines(store_path, state)
-    if quarantined:
-        typer.echo(f"  Quarantined decision-number collisions: {len(quarantined)}")
-        for item in quarantined:
-            typer.echo(f"    - {item.label} (remote copy: {item.backup_path.name})")
-
-    backup_dir = store_path / CONFLICT_BACKUP_DIR
-    if backup_dir.exists():
+    try:
+        quarantined = unresolved_quarantines(store_path, state)
         # Quarantine backups live in the same directory but are already
         # reported above; counting them again would double-report one event.
         # A tmp sibling stranded by a kill mid-write is not a backup at all,
@@ -255,8 +252,17 @@ def _show_status(project_flag: str | None) -> None:
         quarantine_names = {item.backup_path.name for item in list_quarantine_backups(store_path)}
         backups = [
             path
-            for path in backup_dir.iterdir()
+            for path in list_conflict_backup_files(store_path)
             if path.name not in quarantine_names and not is_tmp_sibling(path.name)
         ]
-        if backups:
-            typer.echo(f"  Conflict backups: {len(backups)}")
+    except OSError:
+        # An unlistable backup directory is `nauro status`'s report to make;
+        # this two-state view stays quiet rather than claiming there are none.
+        return
+
+    if quarantined:
+        typer.echo(f"  Quarantined decision-number collisions: {len(quarantined)}")
+        for item in quarantined:
+            typer.echo(f"    - {item.label} (remote copy: {item.backup_path.name})")
+    if backups:
+        typer.echo(f"  Conflict backups: {len(backups)}")

--- a/packages/nauro/src/nauro/mcp/tools.py
+++ b/packages/nauro/src/nauro/mcp/tools.py
@@ -10,8 +10,9 @@ from __future__ import annotations
 import functools
 import inspect
 import logging
+import sys
 from collections.abc import Callable
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import TYPE_CHECKING, Any
 
 from nauro_core.constants import (
@@ -78,6 +79,20 @@ from nauro.store.snapshot import (
     resolve_diff_snapshots,
 )
 from nauro.store.store_lock import store_write_lock
+from nauro.sync._path_diagnostics import (
+    _MissingPathPolicy,
+    _NativeKind,
+    _PathClass,
+    _PreparedStoreRoot,
+    _StoreRootPreparationError,
+    _UnsafeReason,
+)
+from nauro.sync.merge import (
+    _admit_native_path,
+    _classify_sync_path,
+    _prepare_store_root,
+    _walk_store_files,
+)
 
 if TYPE_CHECKING:
     from nauro.sync.push import PushReport
@@ -661,6 +676,8 @@ def _flag_question_resolve(
 # Composed adapter-locally rather than exported from nauro-core: the fixed
 # ordering is a hint-presentation concern of this surface, not a new public
 # store-format constant.
+_ROOT_UNAVAILABLE = "The Store root is unavailable."
+
 _CANONICAL_ROOT_FILES: tuple[str, ...] = (
     PROJECT_MD,
     STATE_CURRENT_FILENAME,
@@ -670,22 +687,39 @@ _CANONICAL_ROOT_FILES: tuple[str, ...] = (
 )
 
 
-def _available_files_hint(store_path: Path, cap: int = 20) -> list[str]:
+def _available_files_hint(
+    store_path: Path, cap: int = 20, *, root: _PreparedStoreRoot | None = None
+) -> list[str]:
     """Ordered miss-envelope ``available_files``: canonical roots in fixed order, remaining root
     markdown ascending, per-dir anchors ascending plus multi-file ``<dir>/ (N files)`` roll-ups;
     no ``snapshots/`` or dot-dirs. The cap applies after ordering, so roots are not crowded out."""
+    try:
+        prepared = root if root is not None else _prepare_store_root(store_path)
+    except _StoreRootPreparationError:
+        return []
     root_files: set[str] = set()
     subdir_files: dict[str, list[str]] = {}
-    for f in store_path.rglob("*.md"):
-        rel = f.relative_to(store_path)
-        if any(part.startswith(".") for part in rel.parts):
+    # The admission walker prunes control paths and never descends a directory
+    # link, so a hint entry is always an ordinary file the caller may fetch.
+    for entry in _walk_store_files(prepared):
+        if entry.admission.path_class is not _PathClass.ORDINARY:
             continue
-        if rel.parts[0] == SNAPSHOTS_DIR:
+        if entry.admission.native_kind is not _NativeKind.REGULAR_FILE:
             continue
-        if len(rel.parts) == 1:
-            root_files.add(rel.name)
+        rel = Path(entry.raw_relative_path).as_posix()
+        # Matched rather than compared, so the suffix folds case exactly where
+        # the platform's own filename matching does.
+        if not PurePath(rel).match("*.md"):
+            continue
+        parts = rel.split("/")
+        if any(part.startswith(".") for part in parts):
+            continue
+        if parts[0] == SNAPSHOTS_DIR:
+            continue
+        if len(parts) == 1:
+            root_files.add(parts[0])
         else:
-            subdir_files.setdefault(rel.parts[0], []).append(str(rel))
+            subdir_files.setdefault(parts[0], []).append(rel)
 
     entries: list[str] = [name for name in _CANONICAL_ROOT_FILES if name in root_files]
     entries.extend(sorted(root_files - set(_CANONICAL_ROOT_FILES)))
@@ -697,6 +731,35 @@ def _available_files_hint(store_path: Path, cap: int = 20) -> list[str]:
     return entries[:cap]
 
 
+def _collapsed_request(path: str) -> str | None:
+    """The request with dot and parent components folded away, None when it escapes."""
+    # Backslash is a separator only where the filesystem says so: folding it on
+    # POSIX would rewrite a literal name into a different file.
+    normalized = path.replace("\\", "/") if sys.platform == "win32" else path
+    components: list[str] = []
+    for component in normalized.split("/"):
+        if component in {"", "."}:
+            continue
+        if component == "..":
+            if not components:
+                return None
+            components.pop()
+            continue
+        components.append(component)
+    return "/".join(components)
+
+
+def _miss_envelope(store_path: Path, path: str, root: _PreparedStoreRoot) -> dict:
+    """The kernel's miss envelope, composed without touching ``path`` on disk."""
+    return {
+        "store": "local",
+        "error": ErrorPayload(kind="error", reason=f"File not found: {path}").model_dump(
+            mode="json", exclude_none=True
+        ),
+        "available_files": _available_files_hint(store_path, root=root),
+    }
+
+
 @_stamp_identity
 def tool_get_raw_file(store_path: Path, path: str) -> dict:
     """Return raw content of any file in the project store."""
@@ -704,31 +767,48 @@ def tool_get_raw_file(store_path: Path, path: str) -> dict:
     if guidance:
         return {"store": "local", "status": "error", "guidance": guidance}
 
-    # Adapter-side traversal check. Distinct from the kernel-side
-    # file-not-found case so callers get a clear "Invalid path" signal
-    # before any Store I/O. ``.resolve()`` is inside the guard because it
-    # itself raises ValueError on a path with an embedded NUL — same clean
-    # "Invalid path" rejection, not a raw traceback.
     try:
-        resolved = (store_path / path).resolve()
-        resolved.relative_to(store_path.resolve())
-    except ValueError:
-        return {
-            "store": "local",
-            "error": {"kind": "error", "reason": f"Invalid path: {path}"},
-        }
+        root = _prepare_store_root(store_path)
+    except _StoreRootPreparationError:
+        return {"store": "local", "error": {"kind": "error", "reason": _ROOT_UNAVAILABLE}}
 
-    result = _get_raw_file_op(FilesystemStore(store_path), path)
-    envelope: dict = {"store": "local", **result.model_dump(mode="json", exclude_none=True)}
+    # Classified as a string, then admitted on disk, before any resolve, stat
+    # or read: local control state answers like a miss rather than reporting
+    # whether it is there, and an unsafe path is refused before it is touched.
+    invalid = {"store": "local", "error": {"kind": "error", "reason": f"Invalid path: {path}"}}
+    spelling = _classify_sync_path(path)
+    if spelling.path_class is _PathClass.UNSAFE and spelling.reason is not _UnsafeReason.RAW_PARENT:
+        return invalid
 
-    # On miss, build the "available files" hint locally — file
-    # enumeration outside the decisions/ directory is outside the
-    # Store protocol's locked surface. Cap at 20 entries so the miss
-    # envelope stays bounded for stores with many markdown files.
+    # A parent component folds away here instead of resolving on disk, so an
+    # alias spelling keeps reading the file it names while a link earlier in
+    # that spelling is never traversed.
+    collapsed = _collapsed_request(path)
+    if collapsed is None:
+        return invalid
+
+    lexical = _classify_sync_path(collapsed)
+    if lexical.path_class is _PathClass.UNSAFE:
+        return invalid
+    if lexical.path_class is _PathClass.RESERVED_CONTROL:
+        return _miss_envelope(store_path, path, root)
+
+    admission = _admit_native_path(root, collapsed, missing=_MissingPathPolicy.CREATE_DESTINATION)
+    if admission.path_class is _PathClass.UNSAFE:
+        return invalid
+    if admission.path_class is _PathClass.RESERVED_CONTROL:
+        return _miss_envelope(store_path, path, root)
+    if admission.native_kind is not _NativeKind.REGULAR_FILE:
+        return _miss_envelope(store_path, path, root)
+
+    result = _get_raw_file_op(FilesystemStore(store_path), collapsed)
+
+    # The file can still go away between admission and the read, and that miss
+    # echoes the caller's own spelling rather than the collapsed one.
     if result.error is not None:
-        envelope["available_files"] = _available_files_hint(store_path)
+        return _miss_envelope(store_path, path, root)
 
-    return envelope
+    return {"store": "local", **result.model_dump(mode="json", exclude_none=True)}
 
 
 @_stamp_identity

--- a/packages/nauro/src/nauro/sync/quarantine.py
+++ b/packages/nauro/src/nauro/sync/quarantine.py
@@ -17,12 +17,27 @@ file for real.
 from __future__ import annotations
 
 import hashlib
+import os
+import stat
 import string
 from dataclasses import dataclass
 from pathlib import Path
 
+from nauro.sync._path_diagnostics import (
+    _MissingPathPolicy,
+    _NativeKind,
+    _PathClass,
+    _StoreRootPreparationError,
+)
 from nauro.sync.collisions import is_canonical_decision_path
-from nauro.sync.merge import CONFLICT_BACKUP_DIR, write_backup
+from nauro.sync.corpus import _is_plain_directory
+from nauro.sync.merge import (
+    CONFLICT_BACKUP_DIR,
+    _admit_native_path,
+    _classify_sync_path,
+    _prepare_store_root,
+    write_backup,
+)
 from nauro.sync.state import SyncState, load_state
 
 _BACKUP_PREFIX = "number-collision-"
@@ -176,15 +191,56 @@ def _parse_backup_name(name: str) -> tuple[str, str] | None:
     return keys[1], decoded
 
 
+def list_conflict_backup_files(store_path: Path) -> list[Path]:
+    """Every regular file directly inside the admitted backup directory, sorted by name."""
+    try:
+        root = _prepare_store_root(store_path)
+    except _StoreRootPreparationError:
+        return []
+    directory = store_path / CONFLICT_BACKUP_DIR
+    # Absence is decided by the node itself, following nothing: admission
+    # answers "absent" for a link whose target is gone, and that link is
+    # present, unlistable, and must not read as "no backups".
+    try:
+        os.lstat(directory)
+    except FileNotFoundError:
+        return []
+    except OSError:
+        raise OSError(f"{directory} cannot be listed") from None
+    admitted = _admit_native_path(
+        root, CONFLICT_BACKUP_DIR, missing=_MissingPathPolicy.OPTIONAL_FIXED_LEAF
+    )
+    # Something occupies the path but may not be listed. Callers report an
+    # unlistable directory as a failure, never as "no backups", so this raises
+    # where the listing it replaced raised.
+    if admitted.path_class is not _PathClass.ORDINARY or not admitted.exists:
+        raise OSError(f"{directory} cannot be listed")
+    if admitted.native_kind is not _NativeKind.DIRECTORY:
+        raise OSError(f"{directory} is not a directory")
+    # Admission answers for the path a link may point at; the listing itself
+    # follows nothing, so the directory has to be plain in its own right.
+    if not _is_plain_directory(directory):
+        raise OSError(f"{directory} is not a plain directory")
+    with os.scandir(directory) as listing:
+        entries = sorted(listing, key=lambda entry: entry.name)
+    files: list[Path] = []
+    for entry in entries:
+        named = _classify_sync_path(f"{CONFLICT_BACKUP_DIR}/{entry.name}")
+        if named.path_class is _PathClass.UNSAFE:
+            continue
+        try:
+            metadata = entry.stat(follow_symlinks=False)
+        except OSError:
+            continue
+        if stat.S_ISREG(metadata.st_mode):
+            files.append(Path(entry.path))
+    return files
+
+
 def list_quarantine_backups(store_path: Path) -> list[QuarantinedCollision]:
     """Every quarantine backup on disk, resolved or not, sorted by remote path."""
-    backup_dir = store_path / CONFLICT_BACKUP_DIR
-    if not backup_dir.is_dir():
-        return []
     found = []
-    for entry in backup_dir.iterdir():
-        if not entry.is_file():
-            continue
+    for entry in list_conflict_backup_files(store_path):
         parsed = _parse_backup_name(entry.name)
         if parsed is not None:
             digest, remote_path = parsed
@@ -212,6 +268,7 @@ def unresolved_quarantines(
 __all__ = [
     "QuarantinedCollision",
     "backup_name",
+    "list_conflict_backup_files",
     "list_quarantine_backups",
     "quarantine_key",
     "save_quarantine_backup",

--- a/packages/nauro/tests/test_sync/test_read_admission.py
+++ b/packages/nauro/tests/test_sync/test_read_admission.py
@@ -1,0 +1,563 @@
+"""Path admission on the read and listing surfaces.
+
+The raw-file read classifies and admits before any resolve, stat or read, the
+miss hint enumerates through the admission walker, and the conflict-backup
+listing runs over one admitted plain directory. Calls the tool layer directly;
+nothing here starts the stdio server.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from nauro_core.renderers import RENDERERS
+from typer.testing import CliRunner
+
+from nauro.cli.main import app
+from nauro.mcp import tools as tools_module
+from nauro.mcp.tools import tool_get_raw_file
+from nauro.store import filesystem_store
+from nauro.store.config import save_config
+from nauro.store.registry import register_project_v2
+from nauro.store.replica_control import (
+    _REPLICA_CONTROL_LOCK_NAME,
+    _REPLICA_CONTROL_ROOT_NAME,
+)
+from nauro.sync import merge as merge_module
+from nauro.sync import quarantine as quarantine_module
+from nauro.sync._path_diagnostics import _StoreRootPreparationError
+from nauro.sync.merge import CONFLICT_BACKUP_DIR, write_backup
+from nauro.sync.quarantine import (
+    list_conflict_backup_files,
+    list_quarantine_backups,
+    save_quarantine_backup,
+    unresolved_quarantines,
+)
+from nauro.templates.scaffolds import scaffold_project_store
+
+runner = CliRunner()
+
+POSIX_ONLY = pytest.mark.skipif(sys.platform == "win32", reason="POSIX filename semantics")
+LINK_KINDS = ["symlink", "junction"]
+UPPERCASE_SUFFIX_ROW = pytest.param(
+    "NOTE.MD",
+    marks=pytest.mark.skipif(
+        sys.platform != "win32", reason="only Windows matches a filename suffix case-insensitively"
+    ),
+)
+
+MISSING = "does-not-exist.md"
+ROOT_UNAVAILABLE = "The Store root is unavailable."
+PROJECT_BODY = "# project\n"
+QUESTIONS_BODY = "# open questions\n"
+ALPHA_BODY = "alpha\n"
+
+ESCAPING_ROWS = ["../../etc/passwd", "../x", "a/../../x"]
+
+CANONICAL_ROOTS = (
+    "project.md",
+    "state_current.md",
+    "state_history.md",
+    "stack.md",
+    "open-questions.md",
+)
+
+ORDINARY_HINT = [
+    *CANONICAL_ROOTS,
+    "context/omega.md",
+    "context/ (2 files)",
+    "decisions/021-decision-21.md",
+    "decisions/ (21 files)",
+]
+
+RESERVED_ROWS = [
+    f"{_REPLICA_CONTROL_ROOT_NAME}/authority.json",
+    _REPLICA_CONTROL_LOCK_NAME,
+    " .REPLICA. /x",
+    ".replica:ads/x",
+]
+
+UNSAFE_ROWS = [
+    "C:x",
+    "C:../x",
+    "\\\\server\\share\\x",
+    "\\\\server\\share\\..\\x",
+    "context/ :stream",
+    "../../etc/passwd",
+    "foo\x00bar",
+]
+
+
+def _store(tmp_path: Path) -> Path:
+    """A small store carrying one real control file."""
+    store = tmp_path / "store"
+    store.mkdir()
+    (store / "project.md").write_text(PROJECT_BODY, encoding="utf-8")
+    (store / "open-questions.md").write_text(QUESTIONS_BODY, encoding="utf-8")
+    context = store / "context"
+    context.mkdir()
+    (context / "alpha.md").write_text(ALPHA_BODY, encoding="utf-8")
+    control = store / _REPLICA_CONTROL_ROOT_NAME
+    control.mkdir()
+    (control / "authority.json").write_text("{}\n", encoding="utf-8")
+    return store
+
+
+def _crowded_store(tmp_path: Path) -> Path:
+    """The hint-ordering fixture, plus control and backup content to prune."""
+    store = tmp_path / "store"
+    store.mkdir()
+    for name in CANONICAL_ROOTS:
+        (store / name).write_text(f"# {name}\n", encoding="utf-8")
+    context = store / "context"
+    context.mkdir()
+    (context / "alpha.md").write_text("alpha\n", encoding="utf-8")
+    (context / "omega.md").write_text("omega\n", encoding="utf-8")
+    snapshots = store / "snapshots"
+    snapshots.mkdir()
+    (snapshots / "stray.md").write_text("stray\n", encoding="utf-8")
+    decisions = store / "decisions"
+    decisions.mkdir()
+    for num in range(1, 22):
+        (decisions / f"{num:03d}-decision-{num}.md").write_text(
+            f"# Decision {num}\n", encoding="utf-8"
+        )
+    control = store / _REPLICA_CONTROL_ROOT_NAME
+    control.mkdir()
+    (control / "notes.md").write_text("control\n", encoding="utf-8")
+    backup = store / CONFLICT_BACKUP_DIR
+    backup.mkdir()
+    (backup / "state_current.md").write_text("backup\n", encoding="utf-8")
+    return store
+
+
+def _scaffold(name: str = "readproj", *, repo: Path) -> Path:
+    _pid, store = register_project_v2(name, [repo])
+    scaffold_project_store(name, store)
+    return store
+
+
+def _status_store(tmp_path: Path, monkeypatch) -> Path:
+    """A registered, authenticated project whose status output is readable."""
+    store = _scaffold(repo=tmp_path)
+    save_config(
+        {
+            "auth": {
+                "sub": "auth0|test",
+                "access_token": "tok_orig",
+                "refresh_token": "refresh_orig",
+            }
+        }
+    )
+    monkeypatch.chdir(tmp_path)
+    return store
+
+
+def _link(link: Path, target: Path, kind: str) -> None:
+    """Point ``link`` at ``target`` as a symlink or as a Windows junction."""
+    if kind == "junction":
+        subprocess.run(
+            ["cmd", "/c", "mklink", "/J", str(link), str(target)],
+            check=True,
+            capture_output=True,
+        )
+        return
+    link.symlink_to(target, target_is_directory=True)
+
+
+def _require_link_kind(kind: str) -> None:
+    if (kind == "junction") != (sys.platform == "win32"):
+        pytest.skip(f"{kind} is not this platform's directory link")
+
+
+def _control_roots(store: Path) -> tuple[Path, Path]:
+    return (store / _REPLICA_CONTROL_ROOT_NAME, store / _REPLICA_CONTROL_LOCK_NAME)
+
+
+def _names_control(value: str) -> bool:
+    """True when the last component folds to a reserved control name."""
+    base = os.path.basename(value).split(":", 1)[0]
+    folded = base.lstrip(" ").rstrip(" .").casefold()
+    return folded in {_REPLICA_CONTROL_ROOT_NAME.casefold(), _REPLICA_CONTROL_LOCK_NAME.casefold()}
+
+
+def _forbid_access(monkeypatch, *roots: Path, exact: bool = False) -> None:
+    """Fail the test if anything stats or reads under one of ``roots``."""
+    real_lstat = merge_module.os.lstat
+    real_read_bytes = Path.read_bytes
+    real_read_text = filesystem_store.read_text_lenient
+    # Spelled comparison, not realpath: resolving inside the stat guard would
+    # call the patched lstat again and recurse.
+    spelled = {str(root) for root in roots} | {os.path.realpath(root) for root in roots}
+
+    def check(value) -> None:
+        target = os.fspath(value)
+        under = any(
+            target.startswith(f"{root}{os.sep}") or (exact and target == root) for root in spelled
+        )
+        # An alias spelling names the same control node without living under
+        # its path, so the name decides too.
+        if under or (exact and _names_control(target)):
+            pytest.fail(f"reached {value!r}")
+
+    def read_check(value) -> None:
+        # Reads resolve first: a read through a link would not be spelled
+        # under any forbidden root.
+        resolved = os.path.realpath(value)
+        if any(resolved == root or resolved.startswith(f"{root}{os.sep}") for root in spelled):
+            pytest.fail(f"read {value!r}")
+        check(value)
+
+    def guarded_lstat(path, *args, **kwargs):
+        check(path)
+        return real_lstat(path, *args, **kwargs)
+
+    def read_bytes(self):
+        read_check(self)
+        return real_read_bytes(self)
+
+    def read_text_lenient(path):
+        read_check(path)
+        return real_read_text(path)
+
+    monkeypatch.setattr(merge_module.os, "lstat", guarded_lstat)
+    monkeypatch.setattr(Path, "read_bytes", read_bytes)
+    monkeypatch.setattr(filesystem_store, "read_text_lenient", read_text_lenient)
+
+
+class _GuardedEntry:
+    """A directory entry whose ``stat`` fails the test for one forbidden name."""
+
+    def __init__(self, entry, forbidden: str) -> None:
+        self._entry = entry
+        self._forbidden = forbidden
+
+    @property
+    def name(self) -> str:
+        return self._entry.name
+
+    @property
+    def path(self) -> str:
+        return self._entry.path
+
+    def stat(self, **kwargs):
+        if self._entry.name == self._forbidden:
+            pytest.fail(f"stat {self._entry.name!r}")
+        return self._entry.stat(**kwargs)
+
+
+def _forbid_entry_stat(monkeypatch, directory: Path, forbidden: str) -> None:
+    real_scandir = os.scandir
+
+    @contextmanager
+    def scandir(path):
+        with real_scandir(path) as listing:
+            entries = list(listing)
+        if Path(path) == directory:
+            yield [_GuardedEntry(entry, forbidden) for entry in entries]
+        else:
+            yield entries
+
+    monkeypatch.setattr(quarantine_module.os, "scandir", scandir)
+
+
+def _assert_unlistable(store: Path) -> None:
+    """Every backup surface reports a failure, and neither command claims none."""
+    for listing in (list_conflict_backup_files, list_quarantine_backups, unresolved_quarantines):
+        with pytest.raises(OSError):
+            listing(store)
+    status = runner.invoke(app, ["status"])
+    assert status.exit_code == 0, status.output
+    assert "Quarantined decision-number collisions: could not be read" in status.output
+    quiet = runner.invoke(app, ["sync", "--status"])
+    assert quiet.exit_code == 0, quiet.output
+    assert "Conflict backups" not in quiet.output
+    assert "Quarantined decision-number collisions" not in quiet.output
+
+
+def _without_reason(envelope: dict) -> dict:
+    """The envelope with the path-bearing reason dropped, for key-for-key equality."""
+    shape = dict(envelope)
+    shape["error"] = {key: value for key, value in shape["error"].items() if key != "reason"}
+    return shape
+
+
+class TestRawFileRows:
+    @pytest.mark.parametrize("row", RESERVED_ROWS)
+    def test_reserved_path_answers_exactly_like_a_miss(self, tmp_path, monkeypatch, row):
+        store = _store(tmp_path)
+        _forbid_access(monkeypatch, *_control_roots(store), exact=True)
+        reserved = tool_get_raw_file(store, row)
+        missing = tool_get_raw_file(store, MISSING)
+        assert reserved["error"]["reason"] == f"File not found: {row}"
+        assert missing["error"]["reason"] == f"File not found: {MISSING}"
+        assert _without_reason(reserved) == _without_reason(missing)
+        assert "project.md" in reserved["available_files"]
+
+    @pytest.mark.parametrize("row", UNSAFE_ROWS)
+    def test_unsafe_path_keeps_the_existing_refusal(self, tmp_path, monkeypatch, row):
+        store = _store(tmp_path)
+        _forbid_access(monkeypatch, store)
+        envelope = tool_get_raw_file(store, row)
+        assert envelope["error"] == {"kind": "error", "reason": f"Invalid path: {row}"}
+        assert "available_files" not in envelope
+        assert "content" not in envelope
+
+    def test_ordinary_file_still_reads(self, tmp_path):
+        store = _store(tmp_path)
+        envelope = tool_get_raw_file(store, "project.md")
+        assert envelope["content"] == PROJECT_BODY
+        assert "error" not in envelope
+
+    @pytest.mark.parametrize("row", ["context", "context/"])
+    def test_directory_answers_like_a_miss(self, tmp_path, row):
+        store = _store(tmp_path)
+        envelope = tool_get_raw_file(store, row)
+        assert envelope["error"]["reason"] == f"File not found: {row}"
+        assert _without_reason(envelope) == _without_reason(tool_get_raw_file(store, MISSING))
+
+
+class TestCollapseRows:
+    def test_parent_component_reads_the_file_it_names(self, tmp_path):
+        store = _store(tmp_path)
+        envelope = tool_get_raw_file(store, "context/../open-questions.md")
+        assert envelope["content"] == QUESTIONS_BODY
+        assert "error" not in envelope
+
+    @pytest.mark.parametrize(
+        ("row", "body"), [("./project.md", PROJECT_BODY), ("context/./alpha.md", ALPHA_BODY)]
+    )
+    def test_dot_component_reads_the_file_it_names(self, tmp_path, row, body):
+        assert tool_get_raw_file(_store(tmp_path), row)["content"] == body
+
+    @pytest.mark.parametrize("row", ESCAPING_ROWS)
+    def test_escaping_spelling_is_refused_untouched(self, tmp_path, monkeypatch, row):
+        store = _store(tmp_path)
+        _forbid_access(monkeypatch, store)
+        envelope = tool_get_raw_file(store, row)
+        assert envelope["error"] == {"kind": "error", "reason": f"Invalid path: {row}"}
+        assert "available_files" not in envelope
+
+    @POSIX_ONLY
+    def test_collapse_never_traverses_a_link_in_the_spelling(self, tmp_path, monkeypatch):
+        store = _store(tmp_path)
+        (store / "alias").symlink_to(store / _REPLICA_CONTROL_ROOT_NAME, target_is_directory=True)
+        _forbid_access(monkeypatch, *_control_roots(store), exact=True)
+        assert tool_get_raw_file(store, "alias/../project.md")["content"] == PROJECT_BODY
+        envelope = tool_get_raw_file(store, "alias/../authority.json")
+        assert envelope["error"]["reason"] == "File not found: alias/../authority.json"
+        assert _without_reason(envelope) == _without_reason(tool_get_raw_file(store, MISSING))
+
+
+class TestLinkRows:
+    @POSIX_ONLY
+    def test_alias_to_control_answers_like_a_miss(self, tmp_path, monkeypatch):
+        store = _store(tmp_path)
+        (store / "alias").symlink_to(store / _REPLICA_CONTROL_ROOT_NAME / "authority.json")
+        _forbid_access(monkeypatch, *_control_roots(store), exact=True)
+        envelope = tool_get_raw_file(store, "alias")
+        assert envelope["error"]["reason"] == "File not found: alias"
+        assert _without_reason(envelope) == _without_reason(tool_get_raw_file(store, MISSING))
+
+    @POSIX_ONLY
+    def test_alias_out_of_store_is_refused(self, tmp_path, monkeypatch):
+        store = _store(tmp_path)
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "secret").write_text("secret\n", encoding="utf-8")
+        (store / "escape").symlink_to(outside / "secret")
+        _forbid_access(monkeypatch, outside, exact=True)
+        envelope = tool_get_raw_file(store, "escape")
+        assert envelope["error"] == {"kind": "error", "reason": "Invalid path: escape"}
+        assert "available_files" not in envelope
+
+    @POSIX_ONLY
+    def test_link_to_an_in_store_file_still_reads(self, tmp_path):
+        store = _store(tmp_path)
+        (store / "inlink").symlink_to(store / "project.md")
+        assert tool_get_raw_file(store, "inlink")["content"] == PROJECT_BODY
+
+    @pytest.mark.parametrize("kind", LINK_KINDS)
+    def test_directory_link_into_control_answers_like_a_miss(self, tmp_path, monkeypatch, kind):
+        _require_link_kind(kind)
+        store = _store(tmp_path)
+        _link(store / "ctrl", store / _REPLICA_CONTROL_ROOT_NAME, kind)
+        _forbid_access(monkeypatch, *_control_roots(store), exact=True)
+        envelope = tool_get_raw_file(store, "ctrl/authority.json")
+        assert envelope["error"]["reason"] == "File not found: ctrl/authority.json"
+        assert _without_reason(envelope) == _without_reason(tool_get_raw_file(store, MISSING))
+
+
+class TestRootRows:
+    def test_unavailable_root_is_reported_without_reading(self, tmp_path, monkeypatch):
+        store = _store(tmp_path)
+        _forbid_access(monkeypatch, store)
+
+        def raise_unavailable(configured_root: Path):
+            raise _StoreRootPreparationError()
+
+        monkeypatch.setattr(tools_module, "_prepare_store_root", raise_unavailable)
+        envelope = tool_get_raw_file(store, "project.md")
+        assert envelope["store"] == "local"
+        assert envelope["error"] == {"kind": "error", "reason": ROOT_UNAVAILABLE}
+        assert "available_files" not in envelope
+        assert "content" not in envelope
+
+    def test_store_path_that_is_a_file_reports_and_renders_the_same(self, tmp_path):
+        store = tmp_path / "store"
+        store.write_text("not a directory", encoding="utf-8")
+        envelope = tool_get_raw_file(store, "project.md")
+        assert envelope["error"] == {"kind": "error", "reason": ROOT_UNAVAILABLE}
+        assert "available_files" not in envelope
+        assert RENDERERS["get_raw_file"](envelope) == f"Error: {ROOT_UNAVAILABLE}"
+
+
+class TestHintRows:
+    def test_hint_keeps_the_ordering_contract_and_prunes_control(self, tmp_path):
+        available = tool_get_raw_file(_crowded_store(tmp_path), MISSING)["available_files"]
+        assert available == ORDINARY_HINT
+        assert not any(entry.startswith(".") for entry in available)
+        assert all("\\" not in entry for entry in available)
+
+    @POSIX_ONLY
+    def test_hint_skips_folded_names_and_directory_links(self, tmp_path):
+        store = _crowded_store(tmp_path)
+        alias = store / " .replica. "
+        alias.mkdir()
+        (alias / "x.md").write_text("control\n", encoding="utf-8")
+        folded = store / " .. "
+        folded.mkdir()
+        (folded / "x.md").write_text("folded\n", encoding="utf-8")
+        (store / "ctx-link").symlink_to(store / "context", target_is_directory=True)
+
+        available = tool_get_raw_file(store, MISSING)["available_files"]
+        assert available == ORDINARY_HINT
+        assert not any("replica" in entry for entry in available)
+        assert not any(entry.startswith(" ") for entry in available)
+        assert not any(entry.startswith("ctx-link") for entry in available)
+
+    @pytest.mark.parametrize("name", ["note.md", UPPERCASE_SUFFIX_ROW])
+    def test_hint_names_markdown_the_platform_matches(self, tmp_path, name):
+        store = tmp_path / "store"
+        (store / "context").mkdir(parents=True)
+        (store / "project.md").write_text(PROJECT_BODY, encoding="utf-8")
+        (store / "context" / name).write_text("note\n", encoding="utf-8")
+        assert f"context/{name}" in tool_get_raw_file(store, MISSING)["available_files"]
+
+    def test_hint_never_enumerates_with_rglob(self, tmp_path, monkeypatch):
+        store = _crowded_store(tmp_path)
+
+        def forbidden(self, *args, **kwargs):
+            pytest.fail(f"rglob {self!r}")
+
+        monkeypatch.setattr(Path, "rglob", forbidden)
+        assert tool_get_raw_file(store, MISSING)["available_files"] == ORDINARY_HINT
+
+
+class TestBackupRows:
+    def test_ordinary_backups_are_listed_and_counted(self, tmp_path, monkeypatch):
+        store = _status_store(tmp_path, monkeypatch)
+        save_quarantine_backup(store, "decisions/003-remote.md", b"remote body\n", '"etag"')
+        write_backup(store, "20260810T000000Z-project.md", b"losing side\n")
+
+        quarantined = list_quarantine_backups(store)
+        assert [item.remote_path for item in quarantined] == ["decisions/003-remote.md"]
+        assert {path.name for path in list_conflict_backup_files(store)} == {
+            quarantined[0].backup_path.name,
+            "20260810T000000Z-project.md",
+        }
+
+        result = runner.invoke(app, ["sync", "--status"])
+        assert result.exit_code == 0, result.output
+        assert "Quarantined decision-number collisions: 1" in result.output
+        assert "Conflict backups: 1" in result.output
+
+    @POSIX_ONLY
+    def test_dangling_backup_link_is_reported_unlistable(self, tmp_path, monkeypatch):
+        store = _status_store(tmp_path, monkeypatch)
+        (store / CONFLICT_BACKUP_DIR).symlink_to(tmp_path / "missing-target")
+        _assert_unlistable(store)
+
+    def test_missing_backup_directory_lists_nothing(self, tmp_path, monkeypatch):
+        store = _status_store(tmp_path, monkeypatch)
+        assert list_conflict_backup_files(store) == []
+        assert list_quarantine_backups(store) == []
+
+        result = runner.invoke(app, ["sync", "--status"])
+        assert result.exit_code == 0, result.output
+        assert "Conflict backups" not in result.output
+
+    @pytest.mark.parametrize("kind", LINK_KINDS)
+    def test_linked_backup_directory_is_reported_unlistable(self, tmp_path, monkeypatch, kind):
+        _require_link_kind(kind)
+        store = _status_store(tmp_path, monkeypatch)
+        save_quarantine_backup(store, "decisions/003-remote.md", b"remote body\n", '"etag"')
+        outside = tmp_path / "outside"
+        (store / CONFLICT_BACKUP_DIR).rename(outside)
+        _link(store / CONFLICT_BACKUP_DIR, outside, kind)
+        _forbid_access(monkeypatch, outside, exact=True)
+        _assert_unlistable(store)
+
+    @POSIX_ONLY
+    def test_unreadable_backup_directory_is_reported_unlistable(self, tmp_path, monkeypatch):
+        store = _status_store(tmp_path, monkeypatch)
+        save_quarantine_backup(store, "decisions/003-remote.md", b"remote body\n", '"etag"')
+        directory = store / CONFLICT_BACKUP_DIR
+        directory.chmod(0o000)
+        try:
+            _assert_unlistable(store)
+        finally:
+            directory.chmod(0o700)
+
+    def test_backup_path_that_is_a_file_is_reported_unlistable(self, tmp_path, monkeypatch):
+        store = _status_store(tmp_path, monkeypatch)
+        (store / CONFLICT_BACKUP_DIR).write_text("not a directory", encoding="utf-8")
+        _assert_unlistable(store)
+
+    @POSIX_ONLY
+    def test_linked_entry_inside_the_directory_is_not_counted(self, tmp_path, monkeypatch):
+        store = _status_store(tmp_path, monkeypatch)
+        write_backup(store, "20260810T000000Z-project.md", b"losing side\n")
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        victim = outside / "victim.md"
+        victim.write_text("victim\n", encoding="utf-8")
+        (store / CONFLICT_BACKUP_DIR / "20260811T000000Z-linked.md").symlink_to(victim)
+
+        assert {path.name for path in list_conflict_backup_files(store)} == {
+            "20260810T000000Z-project.md"
+        }
+
+        result = runner.invoke(app, ["sync", "--status"])
+        assert result.exit_code == 0, result.output
+        assert "Conflict backups: 1" in result.output
+
+    @POSIX_ONLY
+    def test_folded_entry_is_skipped_before_its_stat(self, tmp_path, monkeypatch):
+        store = _status_store(tmp_path, monkeypatch)
+        write_backup(store, "20260810T000000Z-project.md", b"losing side\n")
+        directory = store / CONFLICT_BACKUP_DIR
+        (directory / " .. ").write_text("trap\n", encoding="utf-8")
+        _forbid_entry_stat(monkeypatch, directory, " .. ")
+
+        assert {path.name for path in list_conflict_backup_files(store)} == {
+            "20260810T000000Z-project.md"
+        }
+
+    def test_orphaned_tmp_sibling_is_still_not_counted(self, tmp_path, monkeypatch):
+        from nauro.store import _atomic
+
+        store = _status_store(tmp_path, monkeypatch)
+        with patch.object(_atomic.os, "replace", lambda src, dst: None):
+            write_backup(store, "20260810T000000Z-project.md", b"losing side\n")
+        assert list_conflict_backup_files(store) != []
+
+        result = runner.invoke(app, ["sync", "--status"])
+        assert result.exit_code == 0, result.output
+        assert "Conflict backups" not in result.output

--- a/packages/nauro/tests/test_sync/test_replica_control_excluded.py
+++ b/packages/nauro/tests/test_sync/test_replica_control_excluded.py
@@ -160,25 +160,37 @@ def test_prepare_store_root_has_fixed_suppressed_failure(tmp_path: Path, kind: s
 def test_admission_has_exactly_one_enumerating_caller() -> None:
     src_root = Path(merge.__file__).parents[2]
     allowed = {
-        "_walk_store_files": {"sync/merge.py", "sync/push.py", "sync/pull.py", "store/recovery.py"},
+        "_walk_store_files": {
+            "sync/merge.py",
+            "sync/push.py",
+            "sync/pull.py",
+            "store/recovery.py",
+            "mcp/tools.py",
+        },
         "_prepare_store_root": {
             "sync/merge.py",
             "sync/push.py",
             "sync/pull.py",
             "sync/corpus.py",
+            "sync/quarantine.py",
             "store/recovery.py",
+            "mcp/tools.py",
         },
         "_admit_native_path": {
             "sync/merge.py",
             "sync/pull.py",
             "sync/corpus.py",
+            "sync/quarantine.py",
             "store/recovery.py",
+            "mcp/tools.py",
         },
         "_classify_sync_path": {
             "sync/merge.py",
             "sync/pull.py",
             "sync/corpus.py",
+            "sync/quarantine.py",
             "store/recovery.py",
+            "mcp/tools.py",
         },
     }
     for source in src_root.rglob("*.py"):


### PR DESCRIPTION
## Why

`get_raw_file` is the one remote-facing read of the Store. Its adapter guard resolved the requested path and checked containment, which let a request for `.replica/authority.json`, any alias, or a link into the control root through to the kernel read, and the resolve itself walked link targets before anything was classified. The miss-path hint enumerated with `rglob`, which follows directory links and could name a control path. The quarantine list and the status count listed the conflict-backup directory with `iterdir`, which follows a linked directory and stats links inside it. This slice routes the read and listing surfaces through the admission layer merged in #508 through #511.

## What changed

- `get_raw_file` classifies the requested path as a string and admits it on disk under a prepared Store root before any resolve, stat, or read. A reserved path, or a link into the control root, answers exactly like a missing file, so existence never leaks. An unsafe path is refused with the existing invalid-path text. Only an existing ordinary regular file reaches the kernel read. The old resolve guard is gone. Dot and parent components are collapsed lexically, with no filesystem access, before classification, so `context/../open-questions.md` keeps reaching `open-questions.md` while a spelling that escapes the root, or an absolute, rooted, drive, UNC, device, or NUL path, is refused with the same text. Because admission and the read both see the collapsed path, a link earlier in the original spelling is never traversed.
- The available-files hint enumerates through the admission walker: reserved entries are pruned, unsafe entries skipped, directory links not descended, and the existing ordering, roll-up, and cap rules are unchanged on a POSIX-form path. The markdown suffix is matched the way the running platform matches filenames, so the Windows hint keeps its case-insensitive reach.
- One shared helper lists the conflict-backup directory only after admission as a plain non-link directory, with every entry classified before a non-following stat and only regular files returned. The quarantine list and the status count both call it. An absent backup directory lists nothing; absence is decided by a non-following probe, so a dangling link counts as present. A present but unlistable one (unreadable, linked, junctioned, dangling, or replaced by a file) surfaces as a listing failure, so `nauro status` keeps reporting collisions as unreadable rather than as none, while `sync --status` prints no backup line and exits 0.
- An unusable Store root returns a fixed error envelope with no hint and no path text.
- Nothing is deleted. The corpus, pull, lock, and admission foundation are unchanged.

## Test plan

- Focused set: `uv run --no-sync --package nauro pytest packages/nauro/tests/test_sync/test_read_admission.py packages/nauro/tests/test_get_raw_file_miss_hint.py packages/nauro/tests/test_get_raw_file_parity.py packages/nauro/tests/test_mcp.py packages/nauro/tests/test_sync/test_sync_status.py packages/nauro/tests/test_sync/test_sync_command.py packages/nauro/tests/test_sync/test_collisions.py packages/nauro/tests/test_sync/test_pull.py packages/nauro/tests/test_sync/test_replica_control_excluded.py -q`
  - 500 passed, 5 skipped (the skips are junction and uppercase-suffix rows, which run only on Windows)
- `uv run --no-sync --package nauro pytest packages/nauro/tests/ --ignore=packages/nauro/tests/cross_surface -q`
  - 3,277 passed, 9 skipped
- `uv run --no-sync ruff check packages/ benchmarks/ scripts/` and `uv run --no-sync ruff format --check packages/ benchmarks/ scripts/`
- `uv run --no-sync --package nauro mypy --config-file packages/nauro/pyproject.toml packages/nauro/src/nauro` with no new errors in the changed modules
- Run the single-source, docstring-budget, and server JSON version repository guards.
- Verify the six-file scope, 824 changed lines against the 850-line ceiling the owner granted for this slice (the default is 800; the extra room went to the listing-failure contract, the dangling-link probe, and their tests), and that the admission layer's callers are exactly merge, push, pull, recovery, corpus, tools, and quarantine.
- The parity and miss-hint test files are untouched and still pass, which proves the invalid-path and miss envelopes are byte-identical to before.
- Windows and macOS evidence comes from the CI jobs on this PR; local runs are macOS only. This is the first file to exercise the MCP tool layer on Windows CI; it calls the tool function directly and never the stdio server.

## Risk / what to review

- Ordering in the read: classification, root preparation, admission, then the kernel read. Access-order tests patch the real access points (`merge.os.lstat`, `Path.read_bytes`, `read_text_lenient`, `Path.rglob`, a proxied `os.scandir`) so a regression that probes or reads a reserved path fails.
- Existence non-leak: the envelope for a reserved path must equal the envelope for a missing file key for key, apart from the requested path in the reason. The tests compare them directly.
- Behavior change: a parent component is now collapsed lexically rather than resolved on disk, so `alias/../project.md` reads the root `project.md` even when `alias` is a link elsewhere; the old guard followed the link first. The hint no longer descends directory symlinks. A symlink entry inside the backup directory is no longer counted.
- A link to an in-Store ordinary regular file stays readable, matching the questions-file rule from #511; it can be retargeted between admission and the kernel read, the stated concurrent-mutation limit.
- The invalid-path reason still echoes the caller's own path, including control characters, because the cross-surface parity contract pins that text; an escaped display form is a later contract revision.
- The kernel read operation still resolves and reads on its own after admission; this slice fences the adapter, not the kernel.
- An empty or dot-only request now returns the invalid-path text with an empty echo where it used to return a miss with the hint; plan-conformant, noted here because it is the most plausible accidental call.
- Pre-existing and untouched: an admitted but unreadable ordinary file still raises out of the kernel read, and a backup filename carrying undecodable bytes still breaks the backup name parser. Both predate this change and belong with the kernel hardening.

## Deferred

Decision-work gating for a linked or unusable `decisions/` (the pull's decision lock still lands its lock file through a link; next slice, with the corpus and pull); the kernel's own read and write resolution and enumeration in nauro-core; the fixed-name reads in the tools module; cleanup of stranded sync-state entries under reserved paths; tombstones; projection download, installation, pointers, leases, routing, migration, release, and activation.
