### PR TITLE
Gate decision work on a usable decisions directory

### DIFF
--- a/packages/nauro/src/nauro/sync/corpus.py
+++ b/packages/nauro/src/nauro/sync/corpus.py
@@ -183,6 +183,7 @@ class DecisionCorpus:
     """The decision store as one sync run sees it, kept current by its writer."""
 
     store_path: Path
+    usable: bool = True
     _files: dict[str, DecisionFile] = field(default_factory=dict)
     _irregular: tuple[IrregularEntry, ...] = ()
     _irregular_names: frozenset[str] = frozenset()
@@ -198,23 +199,30 @@ class DecisionCorpus:
         try:
             root = _prepare_store_root(store_path)
         except _StoreRootPreparationError:
+            corpus.usable = False
             return corpus
         corpus._root = root
         admitted = _admit_native_path(
             root, DECISIONS_DIR, missing=_MissingPathPolicy.OPTIONAL_FIXED_LEAF
         )
         if admitted.path_class is _PathClass.UNSAFE:
+            corpus.usable = False
             logger.warning(_UNUSABLE_DECISIONS)
             return corpus
-        if admitted.path_class is not _PathClass.ORDINARY or not admitted.exists:
+        if admitted.path_class is not _PathClass.ORDINARY:
+            corpus.usable = False
+            return corpus
+        if not admitted.exists:
             return corpus
         if admitted.native_kind is not _NativeKind.DIRECTORY:
+            corpus.usable = False
             return corpus
         directory = store_path / DECISIONS_DIR
         # Admission follows links, so an ordinary directory result can still be
         # a link into another admitted directory; listing one would rename and
         # rewrite files on the other side.
         if not _is_plain_directory(directory):
+            corpus.usable = False
             logger.warning(_UNUSABLE_DECISIONS)
             return corpus
         names: set[str] = set()
@@ -223,6 +231,7 @@ class DecisionCorpus:
             with os.scandir(directory) as listing:
                 entries = sorted(listing, key=lambda entry: entry.name)
         except (FileNotFoundError, NotADirectoryError):
+            corpus.usable = False
             return corpus
         for entry in entries:
             named = _classify_sync_path(f"{DECISIONS_DIR}/{entry.name}")

--- a/packages/nauro/src/nauro/sync/pull.py
+++ b/packages/nauro/src/nauro/sync/pull.py
@@ -107,6 +107,7 @@ class _RemoteFile:
 
     rel: str
     etag: str
+    decision_domain: bool = False
 
 
 @dataclass(frozen=True)
@@ -121,6 +122,7 @@ class _AdoptedFile:
     rel: str
     etag: str
     local_sha256: str
+    decision_domain: bool = False
 
 
 @dataclass(frozen=True)
@@ -247,9 +249,28 @@ class _Worklists:
     conflicts: list[_RemoteFile] = field(default_factory=list)
     adopted: list[_AdoptedFile] = field(default_factory=list)
     skipped_permanent: int = 0
+    decisions_usable: bool = True
+    refused_decisions: int = 0
+    ignored_decisions: int = 0
 
     def all_files(self) -> list[_RemoteFile]:
         return self.decisions + self.pulls + self.conflicts
+
+    def drop_decision_domain(self, store_path: Path) -> int:
+        """Remove every decision-domain row still queued for a write; return how many."""
+
+        # Re-derived against the store as it is now: the rescan runs exactly
+        # when decisions/ may have changed since triage.
+        def in_domain(item: _RemoteFile | _AdoptedFile) -> bool:
+            return (
+                item.decision_domain or resolve_destination(store_path, item.rel).inside_decisions
+            )
+
+        before = len(self.pulls) + len(self.conflicts) + len(self.adopted)
+        self.pulls = [item for item in self.pulls if not in_domain(item)]
+        self.conflicts = [item for item in self.conflicts if not in_domain(item)]
+        self.adopted = [item for item in self.adopted if not in_domain(item)]
+        return before - (len(self.pulls) + len(self.conflicts) + len(self.adopted))
 
 
 @dataclass(frozen=True)
@@ -316,6 +337,7 @@ class _Route(Enum):
 
     ignore = auto()
     unusable = auto()
+    refuse = auto()
     gate = auto()
     install = auto()
     adopt = auto()
@@ -343,6 +365,7 @@ class _Routing:
 
     route: _Route
     local_sha256: str = ""
+    decision_domain: bool = False
 
 
 def _display(rel: str) -> str:
@@ -389,6 +412,7 @@ def _route_entry(
     reporter: Reporter,
     *,
     root: _PreparedStoreRoot | None = None,
+    decisions_usable: bool = True,
 ) -> _Routing:
     """Decide what one manifest entry needs, naming the ones it refuses.
     The unchanged-remote shortcut needs the local file present, so a deleted tracked
@@ -403,37 +427,52 @@ def _route_entry(
         reporter.warn(f"skipping suspicious manifest entry {rel!r}")
         return _Routing(_Route.unusable)
 
+    # Domain membership is decided apart from the route: a tracked decision the
+    # gate exempts is still decision work, and an unusable decisions/ must
+    # refuse it before any of the reads below, whatever treatment the rest of
+    # this function would give it.
+    domain = _is_decision_path(rel)
     result = _destination_admitted(store_path, rel, reporter, root=root)
     if result is _PathClass.RESERVED_CONTROL:
         return _Routing(_Route.ignore)
     if result is _PathClass.UNSAFE:
-        return _Routing(_Route.unusable)
+        # A row unsafe by its own spelling never installs; one unsafe only
+        # because of what decisions/ is on disk installs once that is repaired.
+        lexically_sound = _classify_sync_path(rel).path_class is _PathClass.ORDINARY
+        if domain and not decisions_usable and lexically_sound:
+            return _Routing(_Route.refuse, decision_domain=True)
+        return _Routing(_Route.unusable, decision_domain=domain)
 
     destination = resolve_destination(store_path, rel)
+    domain = domain or destination.inside_decisions
+    if domain and not decisions_usable:
+        return _Routing(_Route.refuse, decision_domain=True)
     if not destination.inside_store:
         reporter.warn(f"skipping manifest entry {rel!r}: it resolves outside the store")
-        return _Routing(_Route.unusable)
+        return _Routing(_Route.unusable, decision_domain=domain)
     if _is_canonical_snapshot_path(rel):
         return _Routing(_Route.ignore)
 
     local_file = store_path / rel
     local_exists = local_file.exists()
     if local_exists and not file_changed_remotely(entry.etag, rel, state):
-        return _Routing(_Route.ignore)
+        # An unchanged decision is still decision work the rescan must be able
+        # to count, should decisions/ stop being usable before the lock.
+        return _Routing(_Route.ignore, decision_domain=domain)
 
     if needs_decision_gate(rel, destination, state):
-        return _Routing(_Route.gate)
+        return _Routing(_Route.gate, decision_domain=True)
     if destination.is_directory:
         # Nothing a manifest names as a file may land on a directory: the
         # local-change probe below would hash it and raise.
         reporter.warn(
             f"skipping manifest entry {rel!r}: it resolves to the directory {destination.path}"
         )
-        return _Routing(_Route.unusable)
+        return _Routing(_Route.unusable, decision_domain=domain)
     if not local_exists:
         # A file the user deleted is not a conflict: a conflict protects local
         # content and there is none.
-        return _Routing(_Route.install)
+        return _Routing(_Route.install, decision_domain=domain)
     comparison = compare_local_file(local_file, entry.etag)
     if comparison.match is ContentMatch.matches:
         # The two sides are the same file. Recording that is the whole of the
@@ -441,14 +480,14 @@ def _route_entry(
         # from the cloud, or a push that crashed before its state save, would
         # otherwise re-answer this question on every pull forever. The digest
         # travels with the verdict, from the read that reached it.
-        return _Routing(_Route.adopt, comparison.sha256)
+        return _Routing(_Route.adopt, comparison.sha256, decision_domain=domain)
     if file_changed_locally(store_path, rel, state):
         # Reaching here with a local file means the remote moved too, so both
         # sides have content the other does not - whether or not sync state
         # tracks the file. An untracked one used to match no list at all and be
         # dropped in silence, which lost the remote version without a backup.
-        return _Routing(_Route.conflict)
-    return _Routing(_Route.install)
+        return _Routing(_Route.conflict, decision_domain=domain)
+    return _Routing(_Route.install, decision_domain=domain)
 
 
 def _triage(
@@ -465,20 +504,37 @@ def _triage(
     """
     work = _Worklists()
     listing = DecisionCorpus.scan(store_path)
+    work.decisions_usable = listing.usable
     contested: list[_RemoteFile] = []
     for entry in manifest.entries:
-        routing = _route_entry(store_path, entry, state, reporter, root=root)
+        routing = _route_entry(
+            store_path,
+            entry,
+            state,
+            reporter,
+            root=root,
+            decisions_usable=work.decisions_usable,
+        )
         route = routing.route
         if route is _Route.ignore:
+            if routing.decision_domain:
+                work.ignored_decisions += 1
+            continue
+        if route is _Route.refuse:
+            # Counted as work left behind, not as permanently skipped: the row
+            # installs once decisions/ is repaired, so the run must not sign off.
+            work.refused_decisions += 1
             continue
         if route is _Route.unusable:
             work.skipped_permanent += 1
             continue
         if route is _Route.adopt:
-            work.adopted.append(_AdoptedFile(entry.path, entry.etag, routing.local_sha256))
+            work.adopted.append(
+                _AdoptedFile(entry.path, entry.etag, routing.local_sha256, routing.decision_domain)
+            )
             continue
 
-        item = _RemoteFile(entry.path, entry.etag)
+        item = _RemoteFile(entry.path, entry.etag, routing.decision_domain)
         if route is _Route.gate:
             number = extract_decision_number(_decision_name(entry.path))
             claimed = number is not None and bool(listing.holders(number))
@@ -543,6 +599,9 @@ def _run_pull_locked(
     state = load_state(store_path)
     work = _triage(store_path, manifest, state, reporter, root=root)
     tally = _Tally(skipped_permanent=manifest.unreadable_rows + work.skipped_permanent)
+    if not work.decisions_usable:
+        reporter.warn(_DECISIONS_UNUSABLE_TEXT)
+        tally.refused += work.refused_decisions
 
     planned = work.all_files()
     backup = _admit_native_path(
@@ -567,8 +626,9 @@ def _run_pull_locked(
         tally.refused += len(planned)
         return _report_tally(tally, reporter)
 
-    # Flipped the moment the decision lock is held, which is the moment this run
-    # can start changing the store. Everything before it - the manifest, the
+    # Flipped the moment the decision lock is held, or the moment generic work
+    # begins on a run that skipped decision work: from then on this run can
+    # change the store. Everything before it - the manifest, the
     # triage, the presign, the transfers, the wait for the lock - leaves the
     # store exactly as it found it, and a failure there must not rewrite sync
     # state: a state file that failed to parse loads as empty, and persisting
@@ -579,26 +639,41 @@ def _run_pull_locked(
         # the lock must not span a transfer. It is spooled to disk rather than
         # held: a manifest is server-supplied input, and its total size is not a
         # number this process gets to be surprised by.
-        with _spool(store_path) as spool:
-            gated = _spool_batch(urls, work.decisions, reporter, spool, session, tally)
-            with decision_lock(store_path, lock_timeout):
-                mutating = True
-                corpus = DecisionCorpus.scan(store_path)
-                with _guarded_step(DECISIONS_DIR, _COMPLETION_FAILURE_DETAIL, reporter, tally):
-                    _report_completion(corpus, reporter)
-                for item in work.decisions:
-                    transfer = gated.get(item.rel)
-                    if transfer is None:
-                        # No URL, or a fetch that failed - both already warned
-                        # about, and both counted here rather than where they
-                        # happened so one absent decision is counted once.
-                        tally.refused += 1
-                        continue
-                    with _guarded_step(item.rel, _WRITE_FAILURE_DETAIL, reporter, tally):
-                        _apply_decision(
-                            corpus, transfer, state, manifest, reporter, tally, root=root
+        if work.decisions_usable:
+            with _spool(store_path) as spool:
+                gated = _spool_batch(urls, work.decisions, reporter, spool, session, tally)
+                with decision_lock(store_path, lock_timeout):
+                    mutating = True
+                    corpus = DecisionCorpus.scan(store_path)
+                    # The lock's mkdir already ran against whatever decisions/ became after
+                    # the triage scan, the stated concurrent-mutation limit; the write is refused.
+                    if not corpus.usable:
+                        reporter.warn(_DECISIONS_UNUSABLE_TEXT)
+                        tally.refused += (
+                            len(work.decisions)
+                            + work.drop_decision_domain(store_path)
+                            + work.ignored_decisions
                         )
+                    else:
+                        with _guarded_step(
+                            DECISIONS_DIR, _COMPLETION_FAILURE_DETAIL, reporter, tally
+                        ):
+                            _report_completion(corpus, reporter)
+                        for item in work.decisions:
+                            transfer = gated.get(item.rel)
+                            if transfer is None:
+                                # No URL, or a fetch that failed - both already
+                                # warned about, and both counted here rather than
+                                # where they happened so one absent decision is
+                                # counted once.
+                                tally.refused += 1
+                                continue
+                            with _guarded_step(item.rel, _WRITE_FAILURE_DETAIL, reporter, tally):
+                                _apply_decision(
+                                    corpus, transfer, state, manifest, reporter, tally, root=root
+                                )
 
+        mutating = True
         for adopted in work.adopted:
             # No fetch, no write, and no second read of the file: these already
             # hold the bytes the server published, and triage kept the digest
@@ -688,6 +763,9 @@ _WRITE_FAILURE_DETAIL = (
 _NO_URL_DETAIL = (
     "{rel}: the server minted no download URL for it, so this run could not fetch it. "
     "It stays for the next sync."
+)
+_DECISIONS_UNUSABLE_TEXT = (
+    "pull skipped decision work: the decisions directory is not usable this run"
 )
 _COMPLETION_FAILURE_DETAIL = (
     "the pass that finishes an interrupted renumber could not write here ({error}), so "

--- a/packages/nauro/tests/test_sync/test_pull_admission.py
+++ b/packages/nauro/tests/test_sync/test_pull_admission.py
@@ -2,18 +2,24 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
+import shutil
+import subprocess
 import sys
 import time
+from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import patch
 
+import httpx
 import pytest
 import typer
 
-from nauro.cli.commands.sync import _pull_via_presign
+from nauro.cli.commands.sync import _pull_via_presign, _unfinished_pull_detail
+from nauro.constants import DECISIONS_DIR
 from nauro.store.replica_control import (
     _REPLICA_CONTROL_LOCK_NAME,
     _REPLICA_CONTROL_ROOT_NAME,
@@ -25,26 +31,32 @@ from nauro.sync._path_diagnostics import (
     _StoreRootPreparationError,
 )
 from nauro.sync.collisions import DecisionOutcome, DecisionVerdict
-from nauro.sync.corpus import DecisionCorpus
+from nauro.sync.corpus import _UNUSABLE_DECISIONS, DecisionCorpus
 from nauro.sync.hooks import pull_before_session
 from nauro.sync.merge import CONFLICT_BACKUP_DIR
 from nauro.sync.pull import PullReport, _Transfer, run_pull
 from nauro.sync.state import SYNC_STATE_FILE, FileState, SyncState, load_state, save_state
 from tests.test_sync.conftest import (
     CLOUD_PID,
+    _manifest,
+    _presign,
     _RecordingReporter,
     _scaffolded_cloud_project,
     _seed_token,
     decision_bytes,
     entry_names,
     pull_report,
+    track,
 )
 
 POSIX_ONLY = pytest.mark.skipif(sys.platform == "win32", reason="POSIX filename semantics")
+LINK_KINDS = ["symlink", "junction"]
 
 ROOT_TEXT = "The Store root is unavailable."
 OUTSIDE_TEXT = "The path resolves outside the Store root."
 NOTE = "context/note.md"
+DECISION_ROW = f"{DECISIONS_DIR}/003-x.md"
+UNUSABLE = pull_module._DECISIONS_UNUSABLE_TEXT
 AUTHORITY = f"{_REPLICA_CONTROL_ROOT_NAME}/authority.json"
 
 RESERVED_ROWS = [
@@ -74,7 +86,7 @@ def store(tmp_path):
     return store
 
 
-def _run(store, entries, *, reporter=None):
+def _run(store, entries, *, reporter=None, etags=None):
     """Run one pull, also returning the paths it asked the server to presign."""
     operations: list[str] = []
     real = pull_module.request_presigned_urls
@@ -84,8 +96,13 @@ def _run(store, entries, *, reporter=None):
         return real(project_id, ops, session=session)
 
     with patch.object(pull_module, "request_presigned_urls", spy):
-        report, reporter = pull_report(store, entries, reporter=reporter)
+        report, reporter = pull_report(store, entries, reporter=reporter, etags=etags)
     return report, reporter, operations
+
+
+def _md5_etag(body: bytes) -> str:
+    """The S3-style ETag of ``body``, which makes a local copy an adoption."""
+    return f'"{hashlib.md5(body, usedforsecurity=False).hexdigest()}"'
 
 
 def _control_entries(store) -> set[str]:
@@ -135,6 +152,70 @@ def _forbid_target(monkeypatch, target: Path) -> None:
 
     monkeypatch.setattr(Path, "read_bytes", read_bytes)
     monkeypatch.setattr(pull_module, "atomic_write_bytes", write)
+
+
+def _link(link: Path, target: Path, kind: str) -> None:
+    """Point ``link`` at ``target`` as a symlink or as a Windows junction."""
+    if kind == "junction":
+        subprocess.run(
+            ["cmd", "/c", "mklink", "/J", str(link), str(target)],
+            check=True,
+            capture_output=True,
+        )
+        return
+    link.symlink_to(target, target_is_directory=True)
+
+
+def _require_link_kind(kind: str) -> None:
+    if (kind == "junction") != (sys.platform == "win32"):
+        pytest.skip(f"{kind} is not this platform's directory link")
+
+
+def _link_decisions(store: Path, target: str, kind: str = "symlink") -> None:
+    """Replace ``decisions/`` with a directory link at ``target``."""
+    shutil.rmtree(store / DECISIONS_DIR)
+    _link(store / DECISIONS_DIR, store / target, kind)
+
+
+def _alias_decisions(store: Path, kind: str = "symlink") -> Path:
+    """Link ``decisions/`` at a directory no other manifest row resolves into."""
+    aliased = store / "aliased"
+    aliased.mkdir()
+    _link_decisions(store, "aliased", kind)
+    return aliased
+
+
+def _fail(name: str):
+    """A stand-in that fails the test if the pull calls ``name``."""
+
+    def refuse(*args, **kwargs):
+        pytest.fail(f"called {name}")
+
+    return refuse
+
+
+@contextmanager
+def _fake_server(entries):
+    """Serve exactly ``entries`` over the presign transport."""
+    bodies = dict(entries)
+    manifest = _manifest(
+        [
+            {"path": rel, "etag": f'"{rel}-v1"', "size": len(body), "last_modified": "x"}
+            for rel, body in entries
+        ]
+    )
+    presigned = _presign([{"verb": "GET", "path": rel} for rel, _body in entries])
+
+    def fake_get(url, **kwargs):
+        if "/sync/manifest" in url:
+            return manifest
+        return httpx.Response(200, content=bodies[url.split("/GET/", 1)[1]])
+
+    with (
+        patch("nauro.sync.remote.httpx.Client.get", side_effect=fake_get),
+        patch("nauro.sync.remote.httpx.Client.post", return_value=presigned),
+    ):
+        yield
 
 
 @pytest.fixture()
@@ -633,3 +714,384 @@ def test_a_decision_destination_swapped_for_an_outside_link_is_refused(
     assert reporter.warns == [f"refusing to write {rel}: {OUTSIDE_TEXT}"]
     with open(target, "rb") as handle:
         assert handle.read() == b"untouched\n"
+
+
+# --- decision-gating table ---
+
+
+GATED_ROWS = [(NOTE, b"note\n"), (DECISION_ROW, decision_bytes(3, "Remote"))]
+
+
+@pytest.mark.parametrize("kind", LINK_KINDS)
+def test_a_decisions_link_over_context_refuses_every_row_it_aliases(store, kind):
+    _require_link_kind(kind)
+    _link_decisions(store, "context", kind)
+
+    report, reporter, operations = _run(store, GATED_ROWS)
+
+    # The link puts context/ inside the decisions root, so the generic row is
+    # gated too: both rows are decision work this run refuses.
+    assert report == PullReport(refused=2)
+    assert report.left_work_behind is True
+    assert reporter.warns == [UNUSABLE]
+    assert operations == []
+    assert entry_names(store / "context") == set()
+    assert set(load_state(store).files) == set()
+
+
+@pytest.mark.parametrize("kind", LINK_KINDS)
+def test_a_linked_decisions_directory_refuses_the_decision_row_alone(store, kind):
+    _require_link_kind(kind)
+    aliased = _alias_decisions(store, kind)
+
+    report, reporter, operations = _run(store, GATED_ROWS)
+
+    assert report == PullReport(merged=1, refused=1)
+    assert report.left_work_behind is True
+    assert reporter.warns == [UNUSABLE]
+    assert operations == [NOTE]
+    assert entry_names(aliased) == set()
+    assert entry_names(store / "context") == {"note.md"}
+    assert set(load_state(store).files) == {NOTE}
+
+
+@pytest.mark.parametrize("kind", LINK_KINDS)
+def test_a_tracked_decision_is_refused_through_a_linked_decisions_directory(store, kind):
+    _require_link_kind(kind)
+    aliased = _alias_decisions(store, kind)
+    local = decision_bytes(3, "Local")
+    (aliased / "003-x.md").write_bytes(local)
+    track(store, DECISION_ROW)
+
+    monkeypatch = pytest.MonkeyPatch()
+    try:
+        _forbid_target(monkeypatch, aliased / "003-x.md")
+        monkeypatch.setattr(pull_module, "compare_local_file", _fail("compare_local_file"))
+        monkeypatch.setattr(pull_module, "file_changed_locally", _fail("file_changed_locally"))
+        report, reporter, operations = _run(store, GATED_ROWS)
+    finally:
+        monkeypatch.undo()
+
+    # Tracked and present, so the decision gate would exempt the row and route
+    # it as an install; the domain check refuses it before the reads that
+    # decision would need.
+    assert report == PullReport(merged=1, refused=1)
+    assert reporter.warns == [UNUSABLE]
+    assert operations == [NOTE]
+    assert entry_names(aliased) == {"003-x.md"}
+    assert (aliased / "003-x.md").read_bytes() == local
+    assert set(load_state(store).files) == {NOTE, DECISION_ROW}
+
+
+@POSIX_ONLY
+def test_unchanged_tracked_decisions_still_count_as_work_left_behind(store):
+    aliased = _alias_decisions(store)
+    rows = [(DECISION_ROW, decision_bytes(3, "Same")), (f"{DECISIONS_DIR}/004-y.md", b"same\n")]
+    for rel, body in rows:
+        (aliased / rel.partition("/")[2]).write_bytes(body)
+        track(store, rel)
+    stamp_before = load_state(store).last_full_sync
+
+    # Every etag matches sync state, so each row would be ignored as unchanged;
+    # an unusable decisions/ still owes them to the next run.
+    report, reporter, operations = _run(store, rows, etags={rel: '"pushed"' for rel, _ in rows})
+
+    assert report == PullReport(refused=2)
+    assert report.left_work_behind is True
+    assert reporter.warns == [UNUSABLE]
+    assert operations == []
+    assert load_state(store).last_full_sync == stamp_before
+
+
+@POSIX_ONLY
+def test_a_decision_row_unsafe_by_its_own_spelling_stays_permanently_skipped(store):
+    _alias_decisions(store)
+    hostile = f"{DECISIONS_DIR}/ :stream"
+
+    report, reporter, operations = _run(store, [(NOTE, b"note\n"), (hostile, b"x\n")])
+
+    # The folded-empty component can never install, repaired directory or not,
+    # so it is not work left behind.
+    assert report == PullReport(merged=1, skipped_permanent=1)
+    assert reporter.warns.count(UNUSABLE) == 1
+    assert operations == [NOTE]
+
+
+def test_a_regular_file_at_the_decisions_directory_refuses_the_decision_row(store):
+    shutil.rmtree(store / DECISIONS_DIR)
+    (store / DECISIONS_DIR).write_text("not a directory", encoding="utf-8")
+    stamp_before = load_state(store).last_full_sync
+
+    report, reporter, operations = _run(store, GATED_ROWS)
+
+    # Refused, not permanently skipped: the row installs once decisions/ is
+    # repaired, so the run leaves work behind and does not stamp a full sync.
+    assert report == PullReport(merged=1, refused=1)
+    assert report.left_work_behind is True
+    assert reporter.warns.count(UNUSABLE) == 1
+    assert operations == [NOTE]
+    assert (store / DECISIONS_DIR).read_text(encoding="utf-8") == "not a directory"
+    assert set(load_state(store).files) == {NOTE}
+    assert load_state(store).last_full_sync == stamp_before
+
+
+@POSIX_ONLY
+def test_decisions_linked_at_the_control_root_refuses_decision_work(store):
+    control = store / _REPLICA_CONTROL_ROOT_NAME
+    control.mkdir()
+    (control / "authority.json").write_text("{}", encoding="utf-8")
+    _link_decisions(store, _REPLICA_CONTROL_ROOT_NAME)
+
+    report, reporter, operations = _run(store, GATED_ROWS)
+
+    assert report == PullReport(merged=1)
+    assert reporter.warns == [UNUSABLE]
+    assert operations == [NOTE]
+    assert entry_names(control) == {"authority.json"}
+    assert (store / NOTE).read_bytes() == b"note\n"
+
+
+# --- absent-decisions table ---
+
+
+def test_an_absent_decisions_directory_still_installs_a_decision(store):
+    shutil.rmtree(store / DECISIONS_DIR)
+
+    report, reporter, operations = _run(store, [(DECISION_ROW, decision_bytes(3, "Remote"))])
+
+    assert report == PullReport(merged=1)
+    assert reporter.warns == []
+    assert operations == [DECISION_ROW]
+    assert (store / DECISIONS_DIR).is_dir()
+    assert entry_names(store / DECISIONS_DIR) - {".lock"} == {"003-x.md"}
+
+
+# --- gated access-order table ---
+
+
+@POSIX_ONLY
+def test_nothing_locks_classifies_or_writes_through_a_linked_decisions_directory(
+    store, monkeypatch
+):
+    aliased = _alias_decisions(store)
+    _forbid_target(monkeypatch, aliased / "003-x.md")
+    monkeypatch.setattr(pull_module, "decision_lock", _fail("decision_lock"))
+    monkeypatch.setattr(pull_module, "run_completion_pass", _fail("run_completion_pass"))
+    monkeypatch.setattr(pull_module, "classify_decision", _fail("classify_decision"))
+
+    report, reporter, operations = _run(store, GATED_ROWS)
+
+    assert report == PullReport(merged=1, refused=1)
+    assert reporter.warns == [UNUSABLE]
+    assert operations == [NOTE]
+    assert entry_names(aliased) == set()
+    assert entry_names(store / "context") == {"note.md"}
+
+
+# --- rescan table ---
+
+
+def test_a_decisions_directory_unusable_inside_the_lock_is_refused_there(store, monkeypatch):
+    real_scan = DecisionCorpus.scan
+    scans: list[Path] = []
+
+    class _Rescanned:
+        @staticmethod
+        def scan(store_path):
+            corpus = real_scan(store_path)
+            scans.append(store_path)
+            if len(scans) > 1:
+                corpus.usable = False
+            return corpus
+
+    monkeypatch.setattr(pull_module, "DecisionCorpus", _Rescanned)
+    monkeypatch.setattr(pull_module, "run_completion_pass", _fail("run_completion_pass"))
+    monkeypatch.setattr(pull_module, "classify_decision", _fail("classify_decision"))
+
+    report, reporter, operations = _run(store, GATED_ROWS)
+
+    assert report == PullReport(merged=1, refused=1)
+    assert reporter.warns == [UNUSABLE]
+    assert operations == [DECISION_ROW, NOTE]
+    assert entry_names(store / DECISIONS_DIR) - {".lock"} == {"001-initial-setup.md"}
+    assert set(load_state(store).files) == {NOTE}
+
+
+def _rescan_unusable(monkeypatch, *, before_rescan=None):
+    """Make the in-lock corpus scan report an unusable decisions/."""
+    real_scan = DecisionCorpus.scan
+    scans: list[Path] = []
+
+    class _Rescanned:
+        @staticmethod
+        def scan(store_path):
+            scans.append(store_path)
+            if len(scans) > 1 and before_rescan is not None:
+                before_rescan()
+            corpus = real_scan(store_path)
+            if len(scans) > 1:
+                corpus.usable = False
+            return corpus
+
+    monkeypatch.setattr(pull_module, "DecisionCorpus", _Rescanned)
+    monkeypatch.setattr(pull_module, "run_completion_pass", _fail("run_completion_pass"))
+
+
+@pytest.mark.parametrize("queue", ["pulls", "conflicts", "adopted"])
+def test_a_tracked_decision_in_any_queue_is_refused_by_the_rescan(store, monkeypatch, queue):
+    local = decision_bytes(3, "Local")
+    (store / DECISION_ROW).write_bytes(local)
+    track(store, DECISION_ROW)
+    remote = decision_bytes(3, "Remote")
+    etags = {}
+    if queue == "conflicts":
+        (store / DECISION_ROW).write_bytes(decision_bytes(3, "Edited"))
+    elif queue == "adopted":
+        remote = local
+        etags[DECISION_ROW] = _md5_etag(local)
+    _rescan_unusable(monkeypatch)
+
+    report, reporter, operations = _run(
+        store, [(NOTE, b"note\n"), (DECISION_ROW, remote)], etags=etags
+    )
+
+    # Queued as a plain install, a conflict, or an adoption at triage; the
+    # rescan pulls it back out of that queue before anything is written or
+    # recorded.
+    assert report == PullReport(merged=1, refused=1)
+    assert reporter.warns == [UNUSABLE]
+    assert operations == ([NOTE] if queue == "adopted" else [NOTE, DECISION_ROW])
+    assert (store / DECISION_ROW).read_bytes() == (
+        decision_bytes(3, "Edited") if queue == "conflicts" else local
+    )
+    assert load_state(store).files[DECISION_ROW].remote_etag == '"pushed"'
+    assert set(load_state(store).files) == {NOTE, DECISION_ROW}
+
+
+@POSIX_ONLY
+def test_unchanged_decisions_count_when_the_directory_is_replaced_before_the_lock(
+    store, monkeypatch
+):
+    rows = [(DECISION_ROW, decision_bytes(3, "Same")), (f"{DECISIONS_DIR}/004-y.md", b"same\n")]
+    for rel, body in rows:
+        (store / rel).write_bytes(body)
+        track(store, rel)
+    stamp_before = load_state(store).last_full_sync
+
+    def plant():
+        shutil.rmtree(store / DECISIONS_DIR)
+        (store / "empty").mkdir()
+        (store / DECISIONS_DIR).symlink_to("empty", target_is_directory=True)
+
+    _rescan_unusable(monkeypatch, before_rescan=plant)
+
+    report, reporter, operations = _run(store, rows, etags={rel: '"pushed"' for rel, _ in rows})
+
+    # Both rows were ignored as unchanged at triage and so held nothing to drop;
+    # the counter still owes them to the next run, so no full sync is stamped
+    # over decisions that are no longer present locally.
+    assert report == PullReport(refused=2)
+    assert report.left_work_behind is True
+    assert reporter.warns == [UNUSABLE]
+    assert operations == []
+    assert entry_names(store / "empty") == set()
+    assert set(load_state(store).files) == {rel for rel, _ in rows}
+    assert load_state(store).last_full_sync == stamp_before
+
+
+def test_unchanged_decisions_leave_a_usable_run_exactly_as_before(store):
+    rows = [(DECISION_ROW, decision_bytes(3, "Same")), (f"{DECISIONS_DIR}/004-y.md", b"same\n")]
+    for rel, body in rows:
+        (store / rel).write_bytes(body)
+        track(store, rel)
+    stamp_before = load_state(store).last_full_sync
+
+    report, reporter, operations = _run(store, rows, etags={rel: '"pushed"' for rel, _ in rows})
+
+    assert report == PullReport()
+    assert report.left_work_behind is False
+    assert reporter.warns == []
+    assert operations == []
+    stamp_after = load_state(store).last_full_sync
+    assert stamp_after and stamp_after != stamp_before
+
+
+@POSIX_ONLY
+def test_a_link_planted_between_triage_and_the_lock_drops_the_rows_it_now_covers(
+    store, monkeypatch
+):
+    stamp_before = load_state(store).last_full_sync
+
+    def plant():
+        shutil.rmtree(store / DECISIONS_DIR)
+        (store / DECISIONS_DIR).symlink_to("context", target_is_directory=True)
+
+    _rescan_unusable(monkeypatch, before_rescan=plant)
+
+    report, reporter, operations = _run(store, GATED_ROWS)
+
+    # context/note.md was a plain pull at triage; now it resolves inside the
+    # decisions root, so the rescan drops it with the gated row.
+    assert report == PullReport(refused=2)
+    assert report.left_work_behind is True
+    assert reporter.warns == [UNUSABLE]
+    assert operations == [DECISION_ROW, NOTE]
+    assert entry_names(store / "context") == set()
+    assert set(load_state(store).files) == set()
+    assert load_state(store).last_full_sync == stamp_before
+
+
+def test_a_landed_decision_is_recorded_when_a_later_classification_fails(store, monkeypatch):
+    second = f"{DECISIONS_DIR}/004-y.md"
+    real_classify = pull_module.classify_decision
+
+    def classify(corpus, rel, content, state, paths):
+        if rel == second:
+            raise RuntimeError("classifier fault")
+        return real_classify(corpus, rel, content, state, paths)
+
+    monkeypatch.setattr(pull_module, "classify_decision", classify)
+    rows = [(DECISION_ROW, decision_bytes(3, "Remote")), (second, decision_bytes(4, "Remote"))]
+
+    with _fake_server(rows), pytest.raises(RuntimeError, match="classifier fault"):
+        run_pull(CLOUD_PID, store, _RecordingReporter())
+
+    # The first decision landed under the lock before the fault, so its state
+    # is saved on the way out rather than lost with the run.
+    assert (store / DECISION_ROW).read_bytes() == decision_bytes(3, "Remote")
+    assert DECISION_ROW in load_state(store).files
+    assert not (store / second).exists()
+
+
+# --- gated surface table ---
+
+
+@POSIX_ONLY
+def test_the_cli_pull_reports_the_gated_decision_and_leaves_work_behind(store, capsys):
+    _alias_decisions(store)
+
+    with _fake_server(GATED_ROWS):
+        report = _pull_via_presign(CLOUD_PID, store)
+
+    captured = capsys.readouterr()
+    assert report == PullReport(merged=1, refused=1)
+    assert captured.err.count(f"  {UNUSABLE}\n") == 1
+    assert "Left 1 item(s) for the next sync" in captured.out
+    assert _unfinished_pull_detail(report) == "1 remote file(s) were not written this sync"
+
+
+@POSIX_ONLY
+def test_the_session_hook_returns_the_merged_count_and_logs_the_gate(store, caplog):
+    aliased = _alias_decisions(store)
+
+    with caplog.at_level(logging.WARNING, logger="nauro.sync"), _fake_server(GATED_ROWS):
+        assert pull_before_session(CLOUD_PID, store) == 1
+
+    # The corpus names the unusable directory once and the pull names the
+    # skipped work once; nothing else reaches the log.
+    assert [record.getMessage() for record in caplog.records] == [
+        _UNUSABLE_DECISIONS,
+        f"sync pull: {UNUSABLE}",
+    ]
+    assert entry_names(aliased) == set()
+    assert entry_names(store / "context") == {"note.md"}

--- a/packages/nauro/tests/test_sync/test_restore_admission.py
+++ b/packages/nauro/tests/test_sync/test_restore_admission.py
@@ -28,6 +28,7 @@ from nauro.store.replica_control import (
 from nauro.store.repo_config import save_repo_config
 from nauro.sync import corpus as corpus_module
 from nauro.sync import merge as merge_module
+from nauro.sync import pull as pull_module
 from nauro.sync._path_diagnostics import (
     _escape_path_for_display,
     _StoreRootPreparationError,
@@ -608,7 +609,7 @@ def test_a_pull_over_a_linked_decisions_directory_writes_nothing(tmp_path, monke
     )
 
     assert report.merged == 0
-    # The pull's decision lock still lands here through the link; it is the one
-    # known stray, so the filter must not absorb a second.
-    assert entry_names(control) == {"003-x.md", ".lock"}
+    assert report.refused == 0
+    assert _reporter.warns == [pull_module._DECISIONS_UNUSABLE_TEXT]
+    assert entry_names(control) == {"003-x.md"}
     assert (control / "003-x.md").read_bytes() == decision_bytes(3, "X")


### PR DESCRIPTION
## Why

The corpus slice (#511) made the decision listing refuse a `decisions/` that is a link, a junction, a file, reserved, or unsafe, but the pull still treated an empty corpus as an empty store. It took the decision lock, whose setup creates `decisions/.lock` through whatever `decisions/` points at, so a linked `decisions/` put a lock file inside the link target. Worse, with `decisions/` linked to an ordinary in-Store directory, a remote decision row was presigned, fetched, classified against the empty corpus, passed the write barrier as an ordinary in-Store target, and was written through the link. This slice makes the pull refuse decision work whenever the corpus is not usable, before presign and before the lock. It is the last activation blocker before creating local control state.

## What changed

- The decision corpus exposes whether its directory is usable. An absent `decisions/` counts as usable, because the pull may create it; a link, junction, file, reserved, unsafe, or non-plain directory, or an unusable Store root, does not. Listing, warnings, and the empty-corpus returns are otherwise unchanged.
- The pull reads that flag from its pre-lock scan. When the directory is not usable, every row in the decision domain, whether named under `decisions/` or resolving inside the decisions root, and whatever route it would otherwise take (install, adopt, conflict, or the decision gate), is counted refused and dropped from every worklist before any presign, fetch, or local read; the decision lock is never taken; the completion pass and rescan are skipped; generic rows proceed under the existing barriers. One fixed warning names the reason, the report carries the refused count, and the run exits through the existing "left work behind" path.
- The refusal happens inside routing, right after admission and destination resolution and before the local compare, so a tracked decision is never read through a linked directory, and an unchanged tracked row is counted as refused work rather than silently ignored.
- The rescan inside the lock re-checks usability and re-resolves every queued row against the current directory, so a directory that became a link between the scan and the lock drops both the rows flagged at triage and any row whose destination now falls inside it, without a write, and also counts the unchanged tracked decisions that triage had nothing to do for, so the run reports work left behind and does not stamp a full sync. The lock's setup has already touched it at that point, which is the stated concurrent-mutation limit; the lock module is unchanged.
- A gated run still saves the sync state its generic writes changed, and a usable run keeps saving state for decision writes that landed before a later failure, as before.
- A `decisions/` that is a regular file now counts its decision rows as work left behind, so the run exits 2 and does not stamp a full sync, where it used to report the rows as permanently skipped and exit 0.
- Nothing is deleted. Restore, reads, listings, push, and the admission foundation are unchanged.

## Test plan

- Focused set: `uv run --no-sync --package nauro pytest packages/nauro/tests/test_sync/test_pull_admission.py packages/nauro/tests/test_sync/test_restore_admission.py packages/nauro/tests/test_sync/test_pull.py packages/nauro/tests/test_sync/test_collisions.py packages/nauro/tests/test_sync/test_sync_lock.py packages/nauro/tests/test_sync/test_hooks.py packages/nauro/tests/test_sync/test_sync_command.py packages/nauro/tests/test_sync/test_replica_control_excluded.py -q`
  - 460 passed, 9 skipped (the skips are junction and POSIX-only rows)
- `uv run --no-sync --package nauro pytest packages/nauro/tests/ --ignore=packages/nauro/tests/cross_surface -q`
  - 3,296 passed, 12 skipped
- `uv run --no-sync ruff check packages/ benchmarks/ scripts/` and `uv run --no-sync ruff format --check packages/ benchmarks/ scripts/`
- `uv run --no-sync --package nauro mypy --config-file packages/nauro/pyproject.toml packages/nauro/src/nauro` with no new errors in the changed modules
- Run the single-source, docstring-budget, and server JSON version repository guards.
- Verify the four-file scope and 632 changed lines against the 800-line ceiling. No new test file, so the existing three-OS and Windows jobs already run both extended files.
- Access-order rows monkeypatch the real lock, completion pass, and classifier to fail, with the through-link write path guarded, so a regression that locks, classifies, or writes through a linked `decisions/` fails.
- Windows and macOS evidence comes from the CI jobs on this PR; local runs are macOS only. The junction row is CI-only evidence.

## Risk / what to review

- Ordering: the gate runs in triage, under the sync lock but before the conflict-backup gate, presign, spool, and the decision lock.
- Behavior change: a pull over an unusable `decisions/` refuses its decision rows, skips completion, and exits 2 where it used to take the lock through the link and could write through it. A run with no decision rows still warns once when the directory is unusable.
- Where a link makes another directory resolve inside the decisions root (for example `decisions` linked to `context`), rows under that directory are decision work by destination and are refused with the rest; one test pins that directly, and a second fixture with the link at a dedicated directory pins that unrelated generic rows still install.
- Documented residual inside the concurrent-mutation window: if `decisions/` is swapped for a link to another directory between the pre-lock scan and the lock, rows flagged, queued, or ignored as decision work at triage are all counted and refused, but an unchanged ordinary row under that other directory, which only became decision work by the swap, is not, so that run can still stamp a full sync. No read or write is involved. The next pull refuses the directory at triage.
- The kernel decision write lock used by the write tools still creates its lock file through a link; it lives outside this program and is superseded by generation write routing.
- On the CLI, the corpus module's own warning about an unusable decisions directory reaches stderr through Python's last-resort logging handler beside the pull's fixed warning, so an operator sees two differently worded lines for one condition. Texts are unchanged for other callers; folding them into one is a later cleanup.

## Deferred

The kernel's own read and write resolution and enumeration in nauro-core; the fixed-name reads in the tools module; cleanup of stranded sync-state entries under reserved paths; tombstones; and the cutover runway: projection download, verified root installation, pointer publication, leases, pointer-selected reads, viewer named-read denial, refresh with an independently current actor, pointer compare-and-swap, write routing by authority, compatible release, corpus reverification, generation zero, the one-project cutover, and resuming writes and sync.
