### PR TITLE
Acquire and verify generation projections in memory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
           uv run --no-sync --package nauro pytest
           packages/nauro/tests/test_generation_authority.py
           packages/nauro/tests/test_replica_control.py
+          packages/nauro/tests/test_sync/test_generation_acquisition.py
           packages/nauro/tests/test_sync/test_replica_control_excluded.py
           packages/nauro/tests/test_sync/test_push_admission.py
           packages/nauro/tests/test_sync/test_pull_admission.py

--- a/packages/nauro/src/nauro/sync/generation_acquisition.py
+++ b/packages/nauro/src/nauro/sync/generation_acquisition.py
@@ -1,0 +1,327 @@
+"""Memory-only acquisition of one verified hosted generation projection."""
+
+from __future__ import annotations
+
+import base64
+from functools import partial
+
+import httpx
+import pydantic as pyd
+from nauro_core.identifiers import IdentifierKind, validate_identifier
+
+from nauro.auth import with_token_refresh
+from nauro.store.generation_authority import (
+    ClientUpgradeRequiredError,
+    GenerationAuthorityError,
+    RefreshRequiredError,
+    ReplicaActorMismatchError,
+)
+from nauro.store.generation_projection import (
+    GenerationProjectionIdentity,
+    GenerationProjectionTarget,
+    VerifiedGenerationProjection,
+    _parse_manifest,
+    _strict_json_preflight,
+    verify_generation_projection,
+)
+from nauro.store.resolution import ResolvedProjectBinding
+from nauro.sync.remote import (
+    _DEFAULT_API_TIMEOUT,
+    _DEFAULT_TRANSFER_TIMEOUT,
+    PRESIGN_BATCH_LIMIT,
+    TransferBoundaryError,
+    TransferOperation,
+    TransferSession,
+    _get,
+    _invalid_response,
+    _post,
+    _status_error,
+    canonical_origin,
+    classify_status,
+    operation_session,
+    resolve_api_url,
+)
+from nauro.sync.transfer import download_with_retry
+
+_PROJECTION_ROUTE = "/generations/projection"
+_PRESIGN_ROUTE = "/generations/presign"
+_MAX_PROJECTION_RESPONSE_BYTES = 8 * 1024 * 1024
+_MAX_ARTIFACT_BYTES = 4 * 1024 * 1024
+_MAX_PROJECTION_BYTES = 64 * 1024 * 1024
+_MAX_ACQUISITION_ATTEMPTS = 3
+_STRICT = pyd.ConfigDict(extra="forbid", frozen=True, strict=True)
+_PARSE_FAILURES = (pyd.ValidationError, ValueError, TypeError, RecursionError)
+_NO_ACTOR = "Generation acquisition requires the active account's user id."
+_OTHER_ACCOUNT = "The generation projection was issued for another account."
+_SUPERSEDED = "The committed generation advanced during acquisition."
+_UPGRADE_REQUIRED = "This hosted store format requires another client version."
+
+
+class GenerationAcquisitionError(GenerationAuthorityError):
+    code = "generation_acquisition_failed"
+
+
+class GenerationSupersededError(GenerationAuthorityError):
+    code = "generation_superseded"
+
+
+class LegacyStoreAuthorityError(GenerationAuthorityError):
+    code = "legacy_store_authority"
+
+
+class _ProjectionResponse(pyd.BaseModel):
+    model_config = _STRICT
+    projection: GenerationProjectionIdentity
+    manifest_base64: pyd.StrictStr
+
+
+class _PresignEntry(pyd.BaseModel):
+    model_config = _STRICT
+    path: pyd.StrictStr
+    url: pyd.StrictStr
+
+
+class _PresignResponse(pyd.BaseModel):
+    model_config = _STRICT
+    projection: GenerationProjectionIdentity
+    urls: tuple[_PresignEntry, ...]
+    expires_at: pyd.StrictStr
+
+
+def _mapped_refusal(response: httpx.Response) -> GenerationAuthorityError | None:
+    if response.status_code != 409:
+        return None
+    try:
+        body = response.json()
+    except ValueError:
+        return None
+    error = body.get("error") if isinstance(body, dict) else None
+    if error == "client_upgrade_required":
+        return ClientUpgradeRequiredError(_UPGRADE_REQUIRED)
+    if error == "legacy_store_authority":
+        return LegacyStoreAuthorityError("The project is not on generation authority.")
+    if error == "generation_superseded":
+        return GenerationSupersededError(_SUPERSEDED)
+    return None
+
+
+def _api_response(
+    session: TransferSession, endpoint: str, operation: TransferOperation, **request: object
+) -> httpx.Response:
+    send = _get if operation is TransferOperation.MANIFEST else _post
+
+    def call(token: str) -> httpx.Response:
+        response: httpx.Response = send(
+            session,
+            endpoint,
+            operation,
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=_DEFAULT_API_TIMEOUT,
+            **request,
+        )
+        return response
+
+    response = with_token_refresh(call, client=session.client)
+    if response.status_code == 200:
+        return response
+    # Typed refusals are mapped ahead of the status classifier because a
+    # permanent MANIFEST or PRESIGN status trips the origin and would block
+    # the restart that a superseded generation needs.
+    refusal = _mapped_refusal(response)
+    if refusal is not None:
+        raise refusal
+    raise _status_error(session, endpoint, operation, response.status_code)
+
+
+def _fetch_projection(
+    session: TransferSession, api_url: str, binding: ResolvedProjectBinding, user_id: str
+) -> tuple[GenerationProjectionTarget, bytes]:
+    response = _api_response(
+        session,
+        api_url + _PROJECTION_ROUTE,
+        TransferOperation.MANIFEST,
+        params={"project_id": binding.project_id},
+    )
+    if len(response.content) > _MAX_PROJECTION_RESPONSE_BYTES:
+        raise GenerationAcquisitionError("The generation projection response exceeds the size cap.")
+    try:
+        _strict_json_preflight(response.content)
+        parsed = _ProjectionResponse.model_validate_json(response.content)
+    except _PARSE_FAILURES:
+        parsed = None
+    if parsed is None:
+        raise GenerationAcquisitionError("The generation projection response is malformed.")
+    target = GenerationProjectionTarget(binding, parsed.projection)
+    if target.identity.installed_for_user_id != user_id:
+        raise ReplicaActorMismatchError(_OTHER_ACCOUNT)
+    carrier = parsed.manifest_base64
+    try:
+        envelope = base64.b64decode(carrier, validate=True)
+    except ValueError:
+        envelope = None
+    if envelope is None or base64.b64encode(envelope) != carrier.encode("ascii"):
+        raise GenerationAcquisitionError("The generation manifest carrier is not canonical base64.")
+    return target, envelope
+
+
+def _compare_identity(
+    first: GenerationProjectionIdentity, page: GenerationProjectionIdentity
+) -> None:
+    if page.generation_id != first.generation_id:
+        raise GenerationSupersededError(_SUPERSEDED)
+    if page.installed_for_user_id != first.installed_for_user_id:
+        raise ReplicaActorMismatchError(_OTHER_ACCOUNT)
+    if page.model_dump() != first.model_dump():
+        raise RefreshRequiredError("The authorization view changed during acquisition.")
+
+
+def _presign(
+    session: TransferSession,
+    api_url: str,
+    identity: GenerationProjectionIdentity,
+    paths: tuple[str, ...],
+) -> dict[str, str]:
+    endpoint = api_url + _PRESIGN_ROUTE
+    response = _api_response(
+        session,
+        endpoint,
+        TransferOperation.PRESIGN,
+        json={
+            "project_id": identity.project_id,
+            "generation_id": identity.generation_id,
+            "paths": list(paths),
+        },
+    )
+    try:
+        _strict_json_preflight(response.content)
+        page = _PresignResponse.model_validate_json(response.content)
+    except _PARSE_FAILURES:
+        page = None
+    if page is None:
+        raise _invalid_response(session, endpoint, TransferOperation.PRESIGN, response.status_code)
+    _compare_identity(identity, page.projection)
+    returned = tuple(entry.path for entry in page.urls)
+    if len(set(returned)) != len(returned) or set(returned) != set(paths):
+        raise GenerationAcquisitionError(
+            "The presign response does not match the requested artifact set."
+        )
+    if any(not entry.url.startswith("https://") for entry in page.urls):
+        raise GenerationAcquisitionError("Presigned URLs must use https.")
+    return {entry.path: entry.url for entry in page.urls}
+
+
+class _PageUrls:
+    def __init__(
+        self,
+        session: TransferSession,
+        api_url: str,
+        identity: GenerationProjectionIdentity,
+        paths: tuple[str, ...],
+    ) -> None:
+        self._session = session
+        self._api_url = api_url
+        self._identity = identity
+        self._outstanding = list(paths)
+        self._urls = _presign(session, api_url, identity, paths)
+
+    def url_for(self, path: str) -> str:
+        return self._urls[path]
+
+    def remint(self) -> None:
+        outstanding = tuple(self._outstanding)
+        self._urls = _presign(self._session, self._api_url, self._identity, outstanding)
+
+    def done(self, path: str) -> None:
+        self._outstanding.remove(path)
+
+
+def _fetch_artifact(session: TransferSession, path: str, url: str) -> bytes:
+    session.guard(url, TransferOperation.GET)
+    oversize = f"The generation artifact exceeds the size cap: {path}."
+    chunks: list[bytes] = []
+    error: TransferBoundaryError | None = None
+    try:
+        with session.client.stream("GET", url, timeout=_DEFAULT_TRANSFER_TIMEOUT) as response:
+            if response.status_code != 200:
+                fault = classify_status(response.status_code, operation=TransferOperation.GET)
+                raise TransferBoundaryError(
+                    operation=TransferOperation.GET,
+                    origin=canonical_origin(url),
+                    kind=fault.kind,
+                    retry=fault.retry,
+                    write_outcome=fault.write_outcome,
+                    status=response.status_code,
+                )
+            declared = response.headers.get("Content-Length", "")
+            if declared.isascii() and declared.isdigit() and int(declared) > _MAX_ARTIFACT_BYTES:
+                raise GenerationAcquisitionError(oversize)
+            received = 0
+            for chunk in response.iter_bytes():
+                received += len(chunk)
+                if received > _MAX_ARTIFACT_BYTES:
+                    raise GenerationAcquisitionError(oversize)
+                chunks.append(chunk)
+    except (GenerationAuthorityError, TransferBoundaryError):
+        raise
+    except Exception as exc:
+        error = session.boundary_error(url, TransferOperation.GET, exc)
+    if error is not None:
+        raise error from None
+    return b"".join(chunks)
+
+
+def _acquire_once(
+    session: TransferSession, api_url: str, binding: ResolvedProjectBinding, user_id: str
+) -> VerifiedGenerationProjection:
+    target, envelope = _fetch_projection(session, api_url, binding, user_id)
+    manifest = _parse_manifest(target, envelope)
+    paths = tuple(manifest.artifacts)
+    bodies: list[tuple[str, bytes]] = []
+    total = 0
+    for start in range(0, len(paths), PRESIGN_BATCH_LIMIT):
+        chunk = paths[start : start + PRESIGN_BATCH_LIMIT]
+        page = _PageUrls(session, api_url, target.identity, chunk)
+        for path in chunk:
+            body = download_with_retry(path, page, partial(_fetch_artifact, session, path))
+            if total + len(body) > _MAX_PROJECTION_BYTES:
+                raise GenerationAcquisitionError(
+                    "The generation projection exceeds the total size cap."
+                )
+            total += len(body)
+            bodies.append((path, body))
+            page.done(path)
+    return verify_generation_projection(target, manifest_json=envelope, artifacts=tuple(bodies))
+
+
+def acquire_generation_projection(
+    binding: ResolvedProjectBinding,
+    *,
+    active_user_id: str | None,
+    session: TransferSession | None = None,
+) -> VerifiedGenerationProjection:
+    if binding.mode != "cloud":
+        raise GenerationAcquisitionError("Generation acquisition requires a cloud project binding.")
+    if type(active_user_id) is not str:
+        raise ReplicaActorMismatchError(_NO_ACTOR)
+    try:
+        user_id = validate_identifier(IdentifierKind.ulid, active_user_id, field="active_user_id")
+    except ValueError as exc:
+        raise ReplicaActorMismatchError(_NO_ACTOR) from exc
+    with operation_session(session) as active:
+        api_url = resolve_api_url()
+        attempts = 0
+        while True:
+            attempts += 1
+            try:
+                return _acquire_once(active, api_url, binding, user_id)
+            except GenerationSupersededError:
+                if attempts >= _MAX_ACQUISITION_ATTEMPTS:
+                    raise
+
+
+__all__ = [
+    "GenerationAcquisitionError",
+    "GenerationSupersededError",
+    "LegacyStoreAuthorityError",
+    "acquire_generation_projection",
+]

--- a/packages/nauro/tests/test_sync/test_generation_acquisition.py
+++ b/packages/nauro/tests/test_sync/test_generation_acquisition.py
@@ -1,0 +1,470 @@
+from __future__ import annotations
+
+import ast
+import base64
+import hashlib
+import json
+import os
+import ssl
+from pathlib import Path
+
+import httpx
+import pytest
+
+from nauro.store.generation_authority import (
+    ClientUpgradeRequiredError,
+    RefreshRequiredError,
+    ReplicaActorMismatchError,
+)
+from nauro.store.generation_projection import GenerationProjectionVerificationError
+from nauro.store.resolution import ResolvedProjectBinding
+from nauro.sync import generation_acquisition as acquisition
+from nauro.sync import transfer
+from nauro.sync.generation_acquisition import (
+    GenerationAcquisitionError,
+    GenerationSupersededError,
+    LegacyStoreAuthorityError,
+    acquire_generation_projection,
+)
+from nauro.sync.remote import TransferBoundaryError, TransferSession
+from tests.conftest import seed_auth_config
+
+PROJECT_ID = "01KQ6AZGNA0B3QBF67NBXP3S45"
+GENERATION_ID = "01K11111111111111111111111"
+USER_ID = "01K33333333333333333333333"
+OTHER_USER_ID = "01K44444444444444444444444"
+SCOPE_ID = "a" * 64
+COMMITTED_AT = "2999-12-31T23:59:59.999999Z"
+SIDECAR = "questions-provenance.json"
+GOLDEN_ARTIFACTS = {"project.md": b"# Project\n"}
+GOLDEN_ENVELOPE = (
+    b'{"artifacts":{"project.md":'
+    b'"aef277fb6a70a89681a85e1b6d23f44ee2a6cc58490f9f5c95fc99db6d2d3542"},'
+    b'"generation_id":"01K11111111111111111111111",'
+    b'"project_id":"01KQ6AZGNA0B3QBF67NBXP3S45",'
+    b'"projection_class":"contributor_plus",'
+    b'"projection_scope_id":"' + b"a" * 64 + b'","store_format_version":1}'
+)
+GOLDEN_DIGEST = "32c59ab83e93cb28ea902441e86ce4ae125091ab79328d563a5a7f0eab0be967"
+THREE_ARTIFACTS = {"state.md": b"# State\n", "project.md": b"# Project\n", SIDECAR: b"{}"}
+BINDING = ResolvedProjectBinding(Path("store"), PROJECT_ID, "Nauro", "cloud", "https://api.test")
+LOCAL_BINDING = ResolvedProjectBinding(Path("store"), PROJECT_ID, "Nauro", "local", None)
+PROJECTION = ("GET", "api.test/generations/projection")
+PRESIGN = ("POST", "api.test/generations/presign")
+EXCLUDED_MODULES = frozenset({"replica_control", "state", "pull", "hooks"})
+LEGACY_409 = {"error": "legacy_store_authority"}
+
+
+def _json(status: int, payload: dict) -> httpx.Response:
+    return httpx.Response(status, content=json.dumps(payload).encode("utf-8"))
+
+
+def _decisions(count: int) -> dict[str, bytes]:
+    return {f"decisions/{number:03d}.md": f"# {number}\n".encode() for number in range(count)}
+
+
+class _Body(httpx.SyncByteStream):
+    def __init__(self, chunks: list[bytes]) -> None:
+        self.chunks, self.pulled = chunks, 0
+
+    def __iter__(self):
+        for chunk in self.chunks:
+            self.pulled += 1
+            yield chunk
+
+
+class FakeServer:
+    def __init__(self, artifacts=None, *, projection_class: str = "contributor_plus") -> None:
+        self.artifacts = dict(GOLDEN_ARTIFACTS if artifacts is None else artifacts)
+        self.projection_class = projection_class
+        self.generation_id = GENERATION_ID
+        self.identity_override: dict[str, object] = {}
+        self.projection_hook = self.presign_hook = self.object_hook = None
+        self.requests: list[tuple[str, str, object, str | None]] = []
+        self.counts = {"projection": 0, "presign": 0, "object": 0}
+        client = httpx.Client(transport=httpx.MockTransport(self.handle))
+        self.session = TransferSession(client=client)
+
+    def envelope(self) -> bytes:
+        body = {
+            "project_id": PROJECT_ID,
+            "store_format_version": 1,
+            "generation_id": self.generation_id,
+            "projection_class": self.projection_class,
+            "projection_scope_id": SCOPE_ID,
+            "artifacts": {
+                path: hashlib.sha256(content).hexdigest()
+                for path, content in self.artifacts.items()
+            },
+        }
+        text = json.dumps(body, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+        return text.encode("utf-8")
+
+    def identity(self) -> dict[str, object]:
+        return {
+            "project_id": PROJECT_ID,
+            "store_format_version": 1,
+            "generation_id": self.generation_id,
+            "manifest_digest": hashlib.sha256(self.envelope()).hexdigest(),
+            "committed_at": COMMITTED_AT,
+            "installed_for_user_id": USER_ID,
+            "projection_class": self.projection_class,
+            "projection_scope_id": SCOPE_ID,
+        } | self.identity_override
+
+    def calls(self) -> list[tuple[str, str]]:
+        return [(method, route) for method, route, _body, _bearer in self.requests]
+
+    def presign_bodies(self) -> list[dict]:
+        return [body for _method, route, body, _bearer in self.requests if route == PRESIGN[1]]
+
+    def handle(self, request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content) if request.content else None
+        route = f"{request.url.host}{request.url.path}"
+        self.requests.append((request.method, route, body, request.headers.get("Authorization")))
+        if request.url.host == "objects.test":
+            return self._object(request.url.path)
+        if request.url.path == "/oauth/token":
+            return _json(200, {"access_token": "tok_new"})
+        if request.url.path == "/generations/projection":
+            self.counts["projection"] += 1
+            carrier = base64.b64encode(self.envelope()).decode("ascii")
+            payload = {"projection": self.identity(), "manifest_base64": carrier}
+            return self._reply(self.projection_hook, self.counts["projection"], payload)
+        assert request.url.path == "/generations/presign"
+        self.counts["presign"] += 1
+        if body["generation_id"] != self.generation_id:
+            return _json(409, {"error": "generation_superseded"})
+        mint, base = self.counts["presign"], f"https://objects.test/{self.generation_id}"
+        urls = [{"path": path, "url": f"{base}/{path}?mint={mint}"} for path in body["paths"]]
+        payload = {"projection": self.identity(), "urls": urls, "expires_at": COMMITTED_AT}
+        return self._reply(self.presign_hook, mint, payload)
+
+    def _reply(self, hook, count: int, payload: dict) -> httpx.Response:
+        reply = payload if hook is None else hook(count, payload)
+        return reply if isinstance(reply, httpx.Response) else _json(200, reply)
+
+    def _object(self, url_path: str) -> httpx.Response:
+        self.counts["object"] += 1
+        _generation, _slash, path = url_path.lstrip("/").partition("/")
+        reply = None if self.object_hook is None else self.object_hook(self.counts["object"], path)
+        return httpx.Response(200, content=self.artifacts[path]) if reply is None else reply
+
+
+def _supersede(server: FakeServer, _payload: dict | None = None) -> httpx.Response:
+    server.generation_id = f"01K{server.counts['presign']:023d}"
+    return _json(409, {"error": "generation_superseded", "current_generation_id": "advanced"})
+
+
+def _moved_page(server: FakeServer, payload: dict) -> dict:
+    _supersede(server)
+    payload["projection"]["generation_id"] = server.generation_id
+    return payload
+
+
+def acquire(server: FakeServer, binding=BINDING, user_id: str | None = USER_ID):
+    return acquire_generation_projection(binding, active_user_id=user_id, session=server.session)
+
+
+@pytest.fixture(autouse=True)
+def _environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    seed_auth_config(variant="sync")
+    monkeypatch.setenv("NAURO_API_URL", "https://api.test")
+    monkeypatch.setenv("NAURO_AUTH0_DOMAIN", "api.test")
+    monkeypatch.setenv("NAURO_AUTH0_CLIENT_ID", "test-client")
+    monkeypatch.setattr(transfer, "pause", lambda _seconds: None)
+
+
+def test_happy_path_orders_projection_presign_then_sorted_gets() -> None:
+    server = FakeServer(THREE_ARTIFACTS)
+    proof = acquire(server)
+    gets = [("GET", f"objects.test/{GENERATION_ID}/{path}") for path in sorted(THREE_ARTIFACTS)]
+    assert server.calls() == [PROJECTION, PRESIGN, *gets]
+    assert server.presign_bodies() == [
+        {"project_id": PROJECT_ID, "generation_id": GENERATION_ID, "paths": sorted(THREE_ARTIFACTS)}
+    ]
+    assert {artifact.path: artifact.content for artifact in proof.artifacts} == THREE_ARTIFACTS
+    assert proof.target.identity.model_dump() == server.identity()
+    assert proof.target.binding == BINDING and proof.manifest_json == server.envelope()
+
+
+def test_golden_envelope_bytes_and_digest_are_pinned() -> None:
+    server = FakeServer()
+    assert server.envelope() == GOLDEN_ENVELOPE and len(GOLDEN_ENVELOPE) == 334
+    assert hashlib.sha256(GOLDEN_ENVELOPE).hexdigest() == GOLDEN_DIGEST
+    proof = acquire(server)
+    assert proof.manifest_json == GOLDEN_ENVELOPE
+    assert proof.target.identity.manifest_digest == GOLDEN_DIGEST
+
+
+@pytest.mark.parametrize(
+    ("binding", "user_id", "error"),
+    [
+        (BINDING, None, ReplicaActorMismatchError),
+        (BINDING, "user", ReplicaActorMismatchError),
+        (LOCAL_BINDING, USER_ID, GenerationAcquisitionError),
+    ],
+)
+def test_bad_binding_or_actor_is_refused_before_any_request(binding, user_id, error) -> None:
+    server = FakeServer()
+    with pytest.raises(error):
+        acquire(server, binding, user_id)
+    assert server.calls() == []
+
+
+def test_echoed_actor_must_equal_the_login_recorded_user() -> None:
+    # Without the actor check the run proceeds to presign and the calls assertion fails.
+    server = FakeServer()
+    server.identity_override = {"installed_for_user_id": OTHER_USER_ID}
+    with pytest.raises(ReplicaActorMismatchError, match="issued for another account"):
+        acquire(server)
+    assert server.calls() == [PROJECTION]
+
+
+@pytest.mark.parametrize("kind", ["format", "409"])
+def test_unsupported_format_raises_client_upgrade_required_before_presign(kind: str) -> None:
+    server = FakeServer()
+    if kind == "format":
+        server.identity_override = {"store_format_version": 2}
+    else:
+        server.projection_hook = lambda _n, _p: _json(409, {"error": "client_upgrade_required"})
+    with pytest.raises(ClientUpgradeRequiredError):
+        acquire(server)
+    assert server.calls() == [PROJECTION]
+
+
+def test_legacy_authority_refusal_is_typed_and_leaves_the_origin_open() -> None:
+    server = FakeServer()
+    server.projection_hook = lambda n, p: _json(409, LEGACY_409) if n == 1 else p
+    with pytest.raises(LegacyStoreAuthorityError):
+        acquire(server)
+    acquire(server)
+    assert server.counts["projection"] == 2
+
+
+def test_wrong_manifest_digest_is_refused_before_presign() -> None:
+    # Without the digest check the envelope parses and the raises assertion fails.
+    server = FakeServer()
+    server.identity_override = {"manifest_digest": "b" * 64}
+    with pytest.raises(GenerationProjectionVerificationError, match="digest diverges"):
+        acquire(server)
+    assert server.calls() == [PROJECTION]
+
+
+@pytest.mark.parametrize("kind", ["padding", "alphabet", "bom", "duplicate", "nan", "oversize"])
+def test_bad_carrier_or_malformed_body_is_refused_before_presign(kind: str, monkeypatch) -> None:
+    server = FakeServer()
+    if kind == "oversize":
+        monkeypatch.setattr(acquisition, "_MAX_PROJECTION_RESPONSE_BYTES", 16)
+
+    def hook(_n: int, payload: dict) -> dict | httpx.Response:
+        carrier = payload["manifest_base64"]
+        assert carrier.endswith("fQ==")
+        if kind == "padding":
+            payload["manifest_base64"] = carrier[:-4] + "fR=="
+        elif kind == "alphabet":
+            payload["manifest_base64"] = carrier[:-4] + "f!=="
+        text = json.dumps(payload)
+        if kind == "bom":
+            return httpx.Response(200, content=b"\xef\xbb\xbf" + text.encode("utf-8"))
+        if kind == "duplicate":
+            text = text.replace('"manifest_base64":', '"manifest_base64": "x", "manifest_base64":')
+        if kind == "nan":
+            text = text.replace('"store_format_version": 1', '"store_format_version": NaN')
+        return httpx.Response(200, content=text.encode("utf-8"))
+
+    server.projection_hook = hook
+    with pytest.raises(GenerationAcquisitionError):
+        acquire(server)
+    assert server.calls() == [PROJECTION]
+
+
+def test_viewer_envelope_listing_the_sidecar_is_refused_before_presign() -> None:
+    server = FakeServer(THREE_ARTIFACTS, projection_class="viewer")
+    with pytest.raises(GenerationProjectionVerificationError, match="Viewer generation"):
+        acquire(server)
+    assert server.calls() == [PROJECTION]
+
+
+@pytest.mark.parametrize("kind", ["extra", "missing", "unrequested", "http"])
+def test_presign_reply_must_cover_exactly_the_requested_paths_over_https(kind: str) -> None:
+    server = FakeServer(THREE_ARTIFACTS)
+
+    def hook(_n: int, payload: dict) -> dict:
+        urls = payload["urls"]
+        if kind == "extra":
+            urls.append(dict(urls[0]))
+        elif kind == "missing":
+            urls.pop()
+        elif kind == "unrequested":
+            urls[0]["path"] = "stack.md"
+        else:
+            urls[0]["url"] = "http://" + urls[0]["url"].removeprefix("https://")
+        return payload
+
+    server.presign_hook = hook
+    with pytest.raises(GenerationAcquisitionError):
+        acquire(server)
+    assert server.counts["object"] == 0
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "error"),
+    [
+        ("projection_scope_id", "b" * 64, RefreshRequiredError),
+        ("projection_class", "viewer", RefreshRequiredError),
+        ("installed_for_user_id", OTHER_USER_ID, ReplicaActorMismatchError),
+    ],
+)
+def test_moved_fact_on_page_two_is_refused_without_page_two_gets(field, value, error) -> None:
+    # Without the actor branch the actor row raises RefreshRequiredError; without the eight-fact
+    # comparison page two downloads. Either way the raises assertion fails.
+    server = FakeServer(_decisions(201))
+
+    def hook(n: int, payload: dict) -> dict:
+        if n == 2:
+            payload["projection"][field] = value
+        return payload
+
+    server.presign_hook = hook
+    with pytest.raises(error):
+        acquire(server)
+    assert (server.counts["presign"], server.counts["object"]) == (2, 200)
+
+
+@pytest.mark.parametrize("advance", [_supersede, _moved_page], ids=["409", "200"])
+def test_generation_advance_on_presign_restarts_once_and_completes(advance) -> None:
+    # Without the generation branch the 200 row raises RefreshRequiredError at acquire.
+    server = FakeServer(THREE_ARTIFACTS)
+    server.presign_hook = lambda n, p: advance(server, p) if n == 1 else p
+    proof = acquire(server)
+    assert server.counts["projection"] == 2
+    assert proof.target.identity.generation_id == server.generation_id != GENERATION_ID
+    assert proof.manifest_json == server.envelope()
+
+
+def test_generation_advancing_on_every_pass_raises_after_three_projection_calls() -> None:
+    server = FakeServer(THREE_ARTIFACTS)
+    server.presign_hook = lambda _n, _p: _supersede(server)
+    with pytest.raises(GenerationSupersededError):
+        acquire(server)
+    assert (server.counts["projection"], server.counts["object"]) == (3, 0)
+
+
+def test_expired_get_remints_only_the_outstanding_paths_of_the_page() -> None:
+    server = FakeServer(THREE_ARTIFACTS)
+    server.object_hook = lambda n, path: httpx.Response(403) if (n, path) == (2, SIDECAR) else None
+    proof = acquire(server)
+    bodies = server.presign_bodies()
+    assert [body["paths"] for body in bodies] == [sorted(THREE_ARTIFACTS), [SIDECAR, "state.md"]]
+    assert {body["generation_id"] for body in bodies} == {GENERATION_ID}
+    assert server.counts["object"] == 4 and len(proof.artifacts) == 3
+
+
+def test_second_expiry_on_the_same_path_is_permanent() -> None:
+    server = FakeServer(THREE_ARTIFACTS)
+    server.object_hook = lambda _n, path: httpx.Response(403) if path == SIDECAR else None
+    with pytest.raises(TransferBoundaryError) as caught:
+        acquire(server)
+    assert caught.value.status == 403 and server.counts["presign"] == 2
+
+
+def test_remint_that_returns_a_moved_generation_restarts() -> None:
+    server = FakeServer(THREE_ARTIFACTS)
+    server.object_hook = lambda n, _path: httpx.Response(403) if n == 1 else None
+    server.presign_hook = lambda n, p: _supersede(server) if n == 2 else p
+    proof = acquire(server)
+    assert server.counts["projection"] == 2
+    assert proof.target.identity.generation_id == server.generation_id != GENERATION_ID
+
+
+@pytest.mark.parametrize(("failures", "succeeds"), [(1, True), (4, False)])
+def test_transient_get_faults_retry_within_the_budget(failures: int, succeeds: bool) -> None:
+    server = FakeServer()
+    server.object_hook = lambda n, _path: httpx.Response(503) if n <= failures else None
+    if succeeds:
+        assert acquire(server).artifacts[0].content == b"# Project\n"
+    else:
+        with pytest.raises(TransferBoundaryError) as caught:
+            acquire(server)
+        assert caught.value.status == 503
+    assert server.counts["object"] == failures + int(succeeds)
+
+
+def test_declared_oversize_artifact_is_refused_before_the_body_is_read() -> None:
+    # Without the Content-Length cap the body streams and the pulled assertion fails.
+    server = FakeServer()
+    body = _Body([b"x"])
+    declared = {"Content-Length": str(4 * 1024 * 1024 + 1)}
+    server.object_hook = lambda _n, _path: httpx.Response(200, headers=declared, stream=body)
+    with pytest.raises(GenerationAcquisitionError, match="size cap: project.md"):
+        acquire(server)
+    assert (body.pulled, server.counts["object"]) == (0, 1)
+
+
+def test_streamed_oversize_artifact_is_refused_mid_stream() -> None:
+    # Without the running-total cap all six chunks stream and the pulled assertion fails.
+    server = FakeServer()
+    body = _Body([b"x" * (1024 * 1024)] * 6)
+    server.object_hook = lambda _n, _path: httpx.Response(200, stream=body)
+    with pytest.raises(GenerationAcquisitionError, match="size cap: project.md"):
+        acquire(server)
+    assert (body.pulled, server.counts["object"]) == (5, 1)
+
+
+def test_total_cap_refuses_before_the_second_body_is_kept(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Without the total cap all three downloads complete and the raises assertion fails.
+    monkeypatch.setattr(acquisition, "_MAX_PROJECTION_BYTES", 11)
+    server = FakeServer(THREE_ARTIFACTS)
+    with pytest.raises(GenerationAcquisitionError, match="total size cap"):
+        acquire(server)
+    assert server.counts["object"] == 2
+
+
+def test_certificate_failure_trips_the_object_origin_for_the_session() -> None:
+    server = FakeServer()
+
+    def hook(n: int, _path: str) -> None:
+        if n == 1:
+            raise httpx.ConnectError("connect failed") from ssl.SSLCertVerificationError("cert")
+
+    server.object_hook = hook
+    with pytest.raises(TransferBoundaryError) as first:
+        acquire(server)
+    with pytest.raises(TransferBoundaryError) as second:
+        acquire(server)
+    assert first.value.kind.value == "tls-certificate"
+    assert second.value.kind.value == "origin-aborted"
+    assert (server.counts["object"], server.counts["projection"]) == (1, 2)
+
+
+def test_first_401_refreshes_the_token_and_retries_with_the_new_bearer() -> None:
+    server = FakeServer()
+    server.projection_hook = lambda n, p: httpx.Response(401) if n == 1 else p
+    acquire(server)
+    assert server.calls()[:3] == [PROJECTION, ("POST", "api.test/oauth/token"), PROJECTION]
+    bearers = [bearer for _m, route, _b, bearer in server.requests if route == PROJECTION[1]]
+    assert bearers == ["Bearer tok_orig", "Bearer tok_new"]
+    assert not BINDING.store_path.exists()
+
+
+def test_acquisition_touches_no_disk_control_state_or_sync_state(monkeypatch) -> None:
+    def forbidden(*_args: object, **_kwargs: object) -> None:
+        pytest.fail("generation acquisition must stay in memory")
+
+    server = FakeServer(THREE_ARTIFACTS)
+    monkeypatch.setattr("nauro.store.replica_control.locked_replica_control_snapshot", forbidden)
+    monkeypatch.setattr(Path, "write_bytes", forbidden)
+    monkeypatch.setattr(Path, "mkdir", forbidden)
+    monkeypatch.setattr(os, "replace", forbidden)
+    monkeypatch.setattr("nauro.sync.state.save_state", forbidden)
+    assert len(acquire(server).artifacts) == 3
+    imported: set[str] = set()
+    for node in ast.walk(ast.parse(Path(acquisition.__file__).read_text(encoding="utf-8"))):
+        if isinstance(node, ast.ImportFrom):
+            imported.add(node.module or "")
+            if node.module in ("nauro.sync", "nauro.store"):
+                imported.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.Import):
+            imported.update(alias.name for alias in node.names)
+    assert not {name for name in imported if name.rsplit(".", 1)[-1] in EXCLUDED_MODULES}


### PR DESCRIPTION
## Why

The client has a projection verifier with no producer: nothing can ask a hosted project for the actor-scoped projection of its current committed generation, and nothing can hand exact bytes to that verifier. This slice adds the acquisition leg as a dormant module. It fetches the projection facts and envelope, binds the whole acquisition to one generation, actor, and authorization scope, downloads every artifact under size caps through the shared transfer session and retry policy, and returns a verified projection held in memory. Nothing installs, nothing is written to disk or control state, and no legacy sync surface changes. The server side lands in a companion pull request on the hosted server; the two are pinned to each other by one golden envelope fixture.

## What changed

- New `nauro/sync/generation_acquisition.py`. One public entry takes a cloud project binding, the login-recorded user id, and an optional transfer session. It refuses a local binding or a missing user id before any request.
- The projection reply is size-capped, strict-JSON preflighted, and parsed into the existing strict identity model. The echoed actor must equal the local user id before any presign is requested, the envelope carrier must be canonical base64, and the envelope bytes are verified against the server-stated digest, canonical form, binding, and viewer sidecar rule before a single URL is asked for.
- Presign pages of at most 200 paths must repeat all eight projection facts. A moved generation restarts the acquisition, at most three passes; a moved actor is an actor mismatch; any other change is a refresh requirement. The typed 409 refusals are mapped ahead of the status classifier so a permanent API status does not trip the origin circuit and block the restart.
- Downloads stream through the shared session with the existing retry policy. An expired presign re-mints only the outstanding paths of its page. Per-artifact and total size caps are enforced on the declared length before the body and on the running total while streaming; cap refusals are typed outside the retry policy and never retried. Every body is recomputed against the envelope digest by the existing verifier.
- New `tests/test_sync/test_generation_acquisition.py`: a fake server on one `httpx.MockTransport` serving both the API and the object origin, the shared golden envelope fixture, and rows for actor, digest, carrier, viewer sidecar, page comparison, restart, re-mint, transient, cap, TLS, token refresh, and memory-only behavior. The file joins the three-OS generation control CI job.

## Test plan

- `uv run --no-sync --package nauro pytest packages/nauro/tests/test_sync/test_generation_acquisition.py packages/nauro/tests/test_generation_projection.py packages/nauro/tests/test_generation_authority.py packages/nauro/tests/test_sync/test_transport_session.py packages/nauro/tests/test_sync/test_sync_presign.py packages/nauro/tests/test_auth_refresh.py -q`
  - 320 passed (38 in the new file)
- `uv run --no-sync --package nauro pytest packages/nauro/tests/ --ignore=packages/nauro/tests/cross_surface -q`
  - 3,334 passed, 12 skipped
- `uv run --no-sync ruff check packages/ benchmarks/ scripts/` and `uv run --no-sync ruff format --check packages/ benchmarks/ scripts/`
- `uv run --no-sync --package nauro mypy --config-file packages/nauro/pyproject.toml packages/nauro/src/nauro/sync/generation_acquisition.py` with no errors
- Run the single-source, docstring-budget, and server JSON version repository guards.
- Verify the three-file scope and 798 changed lines against the 800-line ceiling; the transport, retry, verifier, authority, and control modules are untouched.
- The memory-only row fails the run if the control snapshot, any path write, any directory creation, any rename, or the sync-state save is reached. Mutation rows name the assertion that fails when the actor check, the digest check, the page comparison, or the caps are removed.
- Windows and macOS evidence comes from the CI jobs on this PR; local runs are macOS only.

## Risk / what to review

- Ordering: actor and digest checks run before the first presign; the 409 mapping runs before the status classifier; caps run before the body is kept.
- Both directions of the stale-versus-fresh hazard across pages and re-mints: a reply that moved generation, actor, or scope is refused typed, never merged.
- Caps are fixed at 4 MiB per artifact, 64 MiB total, and 8 MiB for the projection reply; raising one is a decision, not a tweak.
- The module imports private helpers from the transport and verifier modules rather than widening their public surface; the modules themselves are unchanged.
- A malformed 200 presign body raises the transport invalid-response boundary error and trips the API origin for the session, matching the legacy presign precedent, while a malformed projection body raises the typed acquisition error; a malformed body is not a superseded generation, so no restart is blocked.
- A 401 during acquisition goes through the shared token refresh, which persists the rotated credential to the auth config as every hosted call does; the memory-only guarantee covers the Store, control state, sync state, and projection bytes, not the auth config.
- No released client calls this module.

## Deferred

The envelope model stays duplicated between client and server under one golden fixture, and the generation calls reuse the legacy manifest and presign operation names, until the compatible client release. The installer is the next slice. Also deferred: installation of verified roots under trusted-root containment, marker and pointer publication, leases, pointer-selected reads, viewer named-read denial across the read surfaces, refresh with an independently current actor, pointer compare-and-swap, write routing by authority, the compatible release that moves the envelope model into the shared core, corpus reverification, generation zero, the one-project cutover, and resuming writes and sync.
