### PR TITLE
Stage and audit generation roots under the replica control directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
       - run: >-
           uv run --no-sync --package nauro pytest
           packages/nauro/tests/test_generation_authority.py
+          packages/nauro/tests/test_generation_installation.py
           packages/nauro/tests/test_replica_control.py
           packages/nauro/tests/test_sync/test_generation_acquisition.py
           packages/nauro/tests/test_sync/test_replica_control_excluded.py

--- a/packages/nauro/src/nauro/store/generation_installation.py
+++ b/packages/nauro/src/nauro/store/generation_installation.py
@@ -1,0 +1,322 @@
+"""Stage and audit immutable generation roots under the replica control directory."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import secrets
+import shutil
+import stat
+from contextlib import suppress
+from dataclasses import dataclass
+from pathlib import Path
+
+from nauro.store._atomic import atomic_write_bytes, is_tmp_sibling
+from nauro.store.generation_authority import GenerationAuthorityError
+from nauro.store.generation_projection import (
+    GenerationProjectionTarget,
+    VerifiedGenerationProjection,
+)
+from nauro.store.replica_control import (
+    _READ_FLAGS,
+    _REPLICA_CONTROL_ROOT_NAME,
+    _is_link_or_reparse,
+    _validate_managed_path,
+    _validate_store_path,
+)
+from nauro.sync._path_diagnostics import _escape_path_for_display
+
+_GENERATIONS_DIR = "generations"
+_STAGING_DIR = "staging"
+_STORE_DIR = "store"
+_MANIFEST_NAME = "manifest.json"
+_ROOT_KEY_HEX = 32
+_STAGING_TOKEN_BYTES = 8
+_NOT_DIRECTORY = "The generation root component is not a directory."
+_LAYOUT_FAILED = "The generation root layout could not be prepared."
+
+
+class GenerationInstallError(GenerationAuthorityError):
+    code = "generation_install_failed"
+
+
+class GenerationRootDivergedError(GenerationAuthorityError):
+    code = "generation_root_diverged"
+
+
+@dataclass(frozen=True)
+class GenerationRootAudit:
+    manifest_digest: str
+    artifact_count: int
+    byte_total: int
+
+
+@dataclass(frozen=True)
+class StagedGenerationRoot:
+    target: GenerationProjectionTarget
+    root_key: str
+    root_path: Path
+    staging_path: Path
+    audit: GenerationRootAudit
+
+
+@dataclass(frozen=True)
+class _GenerationLayout:
+    control_root: Path
+    actor: Path
+    generations: Path
+    staging_dir: Path
+    root_key: str
+    root_path: Path
+
+
+def _root_key(target: GenerationProjectionTarget) -> str:
+    identity = target.identity
+    facts = {
+        "generation_id": identity.generation_id,
+        "projection_class": identity.projection_class,
+        "projection_scope_id": identity.projection_scope_id,
+    }
+    encoded = json.dumps(facts, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()[:_ROOT_KEY_HEX]
+
+
+def _layout(store_path: Path, target: GenerationProjectionTarget) -> _GenerationLayout:
+    identity = target.identity
+    control_root = store_path / _REPLICA_CONTROL_ROOT_NAME
+    version = f"v{identity.store_format_version}"
+    actor = control_root / version / "actors" / identity.installed_for_user_id
+    generations = actor / _GENERATIONS_DIR
+    root_key = _root_key(target)
+    return _GenerationLayout(
+        control_root, actor, generations, actor / _STAGING_DIR, root_key, generations / root_key
+    )
+
+
+def _probe(path: Path) -> os.stat_result:
+    try:
+        return os.lstat(path)
+    except OSError as exc:
+        raise GenerationInstallError(_LAYOUT_FAILED) from exc
+
+
+def _create_component(store_path: Path, path: Path) -> os.stat_result:
+    try:
+        os.mkdir(path)
+    except FileExistsError:
+        pass
+    except OSError as exc:
+        raise GenerationInstallError(_LAYOUT_FAILED) from exc
+    _validate_managed_path(store_path, path)
+    return _probe(path)
+
+
+def _ensure_directory(store_path: Path, path: Path) -> None:
+    _validate_managed_path(store_path, path)
+    current = store_path
+    for part in path.relative_to(store_path).parts:
+        current = current / part
+        try:
+            metadata = os.lstat(current)
+        except FileNotFoundError:
+            metadata = _create_component(store_path, current)
+        except OSError as exc:
+            raise GenerationInstallError(_LAYOUT_FAILED) from exc
+        if not stat.S_ISDIR(metadata.st_mode):
+            raise GenerationInstallError(_NOT_DIRECTORY)
+
+
+def _create_staging(store_path: Path, layout: _GenerationLayout) -> Path:
+    while True:
+        token = secrets.token_hex(_STAGING_TOKEN_BYTES)
+        staging = layout.staging_dir / f"{layout.root_key}-{token}"
+        try:
+            os.mkdir(staging)
+        except FileExistsError:
+            continue
+        except OSError as exc:
+            raise GenerationInstallError(_LAYOUT_FAILED) from exc
+        _validate_managed_path(store_path, staging)
+        if not stat.S_ISDIR(_probe(staging).st_mode):
+            raise GenerationInstallError(_NOT_DIRECTORY)
+        return staging
+
+
+def _discard_staging(staging: Path) -> None:
+    shutil.rmtree(staging, ignore_errors=True)
+    with suppress(OSError):
+        os.lstat(staging)
+
+
+def _stage_tree(store_path: Path, staging: Path, projection: VerifiedGenerationProjection) -> None:
+    _ensure_directory(store_path, staging / _STORE_DIR)
+    entries = [(f"{_STORE_DIR}/{item.path}", item.content) for item in projection.artifacts]
+    entries.append((_MANIFEST_NAME, projection.manifest_json))
+    for relative, content in entries:
+        target = staging / relative
+        _ensure_directory(store_path, target.parent)
+        _validate_managed_path(store_path, target)
+        try:
+            atomic_write_bytes(target, content)
+        except OSError as exc:
+            _discard_staging(staging)
+            raise GenerationInstallError(
+                f"The generation artifact could not be staged: {relative}."
+            ) from exc
+
+
+def _expected_entries(
+    projection: VerifiedGenerationProjection,
+) -> tuple[dict[str, int], set[str]]:
+    files = {_MANIFEST_NAME: len(projection.manifest_json)}
+    directories = {_STORE_DIR}
+    for artifact in projection.artifacts:
+        relative = f"{_STORE_DIR}/{artifact.path}"
+        files[relative] = len(artifact.content)
+        parts = relative.split("/")
+        directories.update("/".join(parts[:depth]) for depth in range(1, len(parts)))
+    return files, directories
+
+
+def _walk_tree(
+    directory: Path, files: dict[str, int], directories: set[str]
+) -> dict[str, tuple[int, int]]:
+    # The sync admission walker is not reused here: it admits a link whose target is a
+    # regular file inside the store, and this audit must refuse every link.
+    observed: dict[str, tuple[int, int]] = {}
+    seen: set[str] = set()
+    frames = [""]
+    while frames:
+        prefix = frames.pop()
+        try:
+            with os.scandir(directory / prefix) as entries:
+                children = [(entry.name, entry.path) for entry in entries]
+        except OSError as exc:
+            display = _escape_path_for_display(prefix or ".")
+            raise GenerationInstallError(f"The generation root is unreadable: {display}.") from exc
+        for name, native in children:
+            relative = f"{prefix}/{name}" if prefix else name
+            display = _escape_path_for_display(relative)
+            try:
+                metadata = os.stat(native, follow_symlinks=False)
+            except OSError as exc:
+                raise GenerationInstallError(
+                    f"The generation root is unreadable: {display}."
+                ) from exc
+            if _is_link_or_reparse(metadata):
+                raise GenerationInstallError(f"The generation root holds a link: {display}.")
+            if is_tmp_sibling(name):
+                raise GenerationInstallError(
+                    f"The generation root holds a partial write: {display}."
+                )
+            is_directory = stat.S_ISDIR(metadata.st_mode)
+            if not is_directory and not stat.S_ISREG(metadata.st_mode):
+                raise GenerationInstallError(
+                    f"The generation root holds an irregular entry: {display}."
+                )
+            if relative not in (directories if is_directory else files):
+                raise GenerationInstallError(
+                    f"The generation root holds an unexpected entry: {display}."
+                )
+            if is_directory:
+                seen.add(relative)
+                frames.append(relative)
+                continue
+            if metadata.st_nlink > 1:
+                raise GenerationInstallError(f"The generation root holds a linked file: {display}.")
+            observed[relative] = (metadata.st_dev, metadata.st_ino)
+    for relative in sorted(directories | files.keys()):
+        if relative not in seen and relative not in observed:
+            raise GenerationInstallError(f"The generation root is missing an entry: {relative}.")
+    return observed
+
+
+def _read_expected(path: Path, length: int, identity: tuple[int, int], display: str) -> bytes:
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(path, _READ_FLAGS)
+        opened = os.fstat(descriptor)
+        if (
+            _is_link_or_reparse(opened)
+            or not stat.S_ISREG(opened.st_mode)
+            or (opened.st_dev, opened.st_ino) != identity
+        ):
+            raise GenerationInstallError(f"The generation root changed during audit: {display}.")
+        content = bytearray()
+        while len(content) <= length:
+            chunk = os.read(descriptor, length + 1 - len(content))
+            if not chunk:
+                break
+            content += chunk
+        return bytes(content)
+    except OSError as exc:
+        raise GenerationInstallError(f"The generation root is unreadable: {display}.") from exc
+    finally:
+        if descriptor is not None:
+            with suppress(OSError):
+                os.close(descriptor)
+
+
+def audit_generation_tree(
+    directory: Path, projection: VerifiedGenerationProjection
+) -> GenerationRootAudit:
+    files, directories = _expected_entries(projection)
+    observed = _walk_tree(directory, files, directories)
+    manifest = _read_expected(
+        directory / _MANIFEST_NAME,
+        files[_MANIFEST_NAME],
+        observed[_MANIFEST_NAME],
+        _escape_path_for_display(_MANIFEST_NAME),
+    )
+    manifest_digest = hashlib.sha256(manifest).hexdigest()
+    if (
+        manifest != projection.manifest_json
+        or manifest_digest != projection.target.identity.manifest_digest
+    ):
+        raise GenerationInstallError("The generation root manifest diverges.")
+    byte_total = len(manifest)
+    for artifact in projection.artifacts:
+        relative = f"{_STORE_DIR}/{artifact.path}"
+        content = _read_expected(
+            directory / relative,
+            files[relative],
+            observed[relative],
+            _escape_path_for_display(relative),
+        )
+        if hashlib.sha256(content).hexdigest() != projection.manifest.artifacts[artifact.path]:
+            raise GenerationInstallError(f"The generation artifact diverges: {artifact.path}.")
+        byte_total += len(content)
+    return GenerationRootAudit(manifest_digest, len(projection.artifacts), byte_total)
+
+
+def stage_generation_root(projection: VerifiedGenerationProjection) -> StagedGenerationRoot:
+    if type(projection) is not VerifiedGenerationProjection:
+        raise GenerationInstallError("Generation installation requires a verified projection.")
+    store_path = _validate_store_path(projection.target.binding)
+    layout = _layout(store_path, projection.target)
+    for directory in (
+        layout.control_root,
+        layout.actor.parent.parent,
+        layout.actor.parent,
+        layout.actor,
+        layout.generations,
+        layout.staging_dir,
+    ):
+        _ensure_directory(store_path, directory)
+    staging = _create_staging(store_path, layout)
+    _stage_tree(store_path, staging, projection)
+    try:
+        audit = audit_generation_tree(staging, projection)
+    except GenerationInstallError:
+        _discard_staging(staging)
+        raise
+    return StagedGenerationRoot(
+        projection.target, layout.root_key, layout.root_path, staging, audit
+    )
+
+
+__all__ = (
+    "GenerationInstallError GenerationRootAudit GenerationRootDivergedError "
+    "StagedGenerationRoot audit_generation_tree stage_generation_root"
+).split()

--- a/packages/nauro/tests/test_generation_installation.py
+++ b/packages/nauro/tests/test_generation_installation.py
@@ -1,0 +1,466 @@
+from __future__ import annotations
+
+import ast
+import hashlib
+import json
+import os
+import shutil
+import stat
+import subprocess
+import sys
+from dataclasses import FrozenInstanceError, fields
+from inspect import signature
+from pathlib import Path
+
+import pytest
+
+from nauro.store import generation_installation as installation
+from nauro.store import replica_control
+from nauro.store.generation_authority import FlatProjectAuthority, GenerationAuthorityError
+from nauro.store.generation_installation import (
+    GenerationInstallError,
+    GenerationRootAudit,
+    GenerationRootDivergedError,
+    StagedGenerationRoot,
+    audit_generation_tree,
+    stage_generation_root,
+)
+from nauro.store.generation_projection import (
+    GenerationProjectionIdentity,
+    GenerationProjectionTarget,
+    VerifiedGenerationProjection,
+    verify_generation_projection,
+)
+from nauro.store.registry import get_store_path_v2
+from nauro.store.replica_control import (
+    ReplicaControlReadError,
+    _is_link_or_reparse,
+    locked_replica_control_snapshot,
+)
+from nauro.store.resolution import ResolvedProjectBinding
+from nauro.templates.scaffolds import scaffold_project_store
+from tests.test_sync.conftest import entry_names
+
+POSIX_ONLY = pytest.mark.skipif(sys.platform == "win32", reason="POSIX filename semantics")
+LINK_KINDS = ["symlink", "junction"]
+PROJECT_ID = "01KQ6AZGNA0B3QBF67NBXP3S45"
+GENERATION_ID = "01K11111111111111111111111"
+USER_ID = "01K33333333333333333333333"
+SCOPE_ID = "a" * 64
+COMMITTED_AT = "2999-12-31T23:59:59.999999Z"
+ROOT_KEY = "868847269e6f3c829a569ad5d6655bd5"
+CODE = "generation_install_failed"
+ACTOR = f".replica/v1/actors/{USER_ID}"
+COMPONENTS = {
+    ".replica": ".replica",
+    "v1": ".replica/v1",
+    "actors": ".replica/v1/actors",
+    "actor": ACTOR,
+    "generations": f"{ACTOR}/generations",
+    "staging": f"{ACTOR}/staging",
+}
+ARTIFACTS = {
+    "decisions/001-x.md": b"# 001\n",
+    "context/brief.md": b"# Brief\n",
+    "questions-provenance.json": b"{}",
+}
+FORBIDDEN_IMPORTS = set(
+    (
+        "httpx nauro.sync.remote nauro.sync.pull nauro.sync.state nauro.sync.hooks nauro.sync.merge"
+    ).split()
+)
+SINGLE_CALLER_NAMES = (
+    "_walk_store_files _prepare_store_root _admit_native_path _classify_sync_path".split()
+)
+NOT_DIRECTORY = "The generation root component is not a directory."
+
+
+def _link(link: Path, target: Path, kind: str) -> None:
+    if kind == "junction":
+        subprocess.run(
+            ["cmd", "/c", "mklink", "/J", str(link), str(target)],
+            check=True,
+            capture_output=True,
+        )
+        return
+    link.symlink_to(target, target_is_directory=True)
+
+
+def _require_link_kind(kind: str) -> None:
+    if (kind == "junction") != (sys.platform == "win32"):
+        pytest.skip(f"{kind} is not this platform's directory link")
+
+
+@pytest.fixture
+def store() -> Path:
+    path = get_store_path_v2(PROJECT_ID)
+    scaffold_project_store("nauro", path)
+    return path
+
+
+def _actor(store: Path) -> Path:
+    return store / ".replica" / "v1" / "actors" / USER_ID
+
+
+def _manifest(artifacts: dict[str, bytes], scope_id: str = SCOPE_ID) -> bytes:
+    body = {
+        "project_id": PROJECT_ID,
+        "store_format_version": 1,
+        "generation_id": GENERATION_ID,
+        "projection_class": "contributor_plus",
+        "projection_scope_id": scope_id,
+        "artifacts": {path: hashlib.sha256(body).hexdigest() for path, body in artifacts.items()},
+    }
+    return json.dumps(body, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode()
+
+
+def _projection(artifacts: dict[str, bytes] | None = None) -> VerifiedGenerationProjection:
+    artifacts = ARTIFACTS if artifacts is None else artifacts
+    manifest = _manifest(artifacts)
+    binding = ResolvedProjectBinding(
+        get_store_path_v2(PROJECT_ID), PROJECT_ID, "Nauro", "cloud", "https://mcp.nauro.ai"
+    )
+    identity = GenerationProjectionIdentity(
+        project_id=PROJECT_ID,
+        store_format_version=1,
+        generation_id=GENERATION_ID,
+        manifest_digest=hashlib.sha256(manifest).hexdigest(),
+        committed_at=COMMITTED_AT,
+        installed_for_user_id=USER_ID,
+        projection_class="contributor_plus",
+        projection_scope_id=SCOPE_ID,
+    )
+    target = GenerationProjectionTarget(binding, identity)
+    return verify_generation_projection(
+        target, manifest_json=manifest, artifacts=tuple(artifacts.items())
+    )
+
+
+def _tree(root: Path) -> list[str]:
+    found, frames = [], [root]
+    while frames:
+        with os.scandir(frames.pop()) as entries:
+            for entry in entries:
+                found.append(Path(entry.path).relative_to(root).as_posix())
+                metadata = entry.stat(follow_symlinks=False)
+                if stat.S_ISDIR(metadata.st_mode) and not _is_link_or_reparse(metadata):
+                    frames.append(Path(entry.path))
+    return sorted(found)
+
+
+def _fails(message: str, call) -> GenerationInstallError:
+    with pytest.raises(GenerationInstallError) as raised:
+        call()
+    assert (type(raised.value), raised.value.code) == (GenerationInstallError, CODE)
+    assert str(raised.value) == message
+    return raised.value
+
+
+def test_layout_spellings_and_flat_authority(store: Path) -> None:
+    before = entry_names(store)
+    projection = _projection()
+    staged = stage_generation_root(projection)
+    actor = _actor(store)
+    assert staged.root_key == ROOT_KEY
+    assert staged.root_path == actor / "generations" / ROOT_KEY
+    assert staged.staging_path.parent == actor / "staging"
+    prefix, _, token = staged.staging_path.name.partition("-")
+    assert (prefix, len(token), set(token) <= set("0123456789abcdef")) == (ROOT_KEY, 16, True)
+    assert entry_names(store) == before | {".replica"}
+    assert entry_names(store / ".replica") == {"v1"}
+    assert entry_names(store / ".replica" / "v1") == {"actors"}
+    assert entry_names(store / ".replica" / "v1" / "actors") == {USER_ID}
+    assert entry_names(actor) == {"generations", "staging"}
+    assert entry_names(actor / "generations") == set()
+    assert entry_names(actor / "staging") == {staged.staging_path.name}
+    assert staged.target == projection.target
+    with locked_replica_control_snapshot(
+        projection.target.binding, active_user_id=USER_ID, active_projection_scope_id=SCOPE_ID
+    ) as snapshot:
+        assert snapshot.authority == FlatProjectAuthority(projection.target.binding)
+    _fails(
+        "Generation installation requires a verified projection.",
+        lambda: stage_generation_root(object()),
+    )
+
+
+def test_staging_name_retries_on_collision(store: Path, monkeypatch) -> None:
+    real, tokens = installation.secrets.token_hex, iter(["0" * 16, "1" * 16])
+    monkeypatch.setattr(installation.secrets, "token_hex", lambda n: next(tokens, None) or real(n))
+    planted = _actor(store) / "staging" / f"{ROOT_KEY}-{'0' * 16}"
+    planted.mkdir(parents=True)
+    staged = stage_generation_root(_projection())
+    assert staged.staging_path.name == f"{ROOT_KEY}-{'1' * 16}"
+    assert entry_names(planted.parent) == {planted.name, staged.staging_path.name}
+
+
+@pytest.mark.parametrize("kind", LINK_KINDS)
+@pytest.mark.parametrize("name", list(COMPONENTS))
+def test_linked_component_is_refused_before_creation(store, tmp_path, kind, name) -> None:
+    _require_link_kind(kind)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "victim.md").write_bytes(b"victim\n")
+    component = store / COMPONENTS[name]
+    component.parent.mkdir(parents=True, exist_ok=True)
+    if name == "staging":
+        (component.parent / "generations").mkdir()
+    _link(component, outside, kind)
+    before = (_tree(outside), _tree(store))
+    with pytest.raises(ReplicaControlReadError) as raised:
+        stage_generation_root(_projection())
+    assert raised.value.code == "generation_control_unavailable"
+    assert (_tree(outside), _tree(store)) == before
+
+
+@pytest.mark.parametrize("name", [".replica", "actors"])
+def test_regular_file_component_is_refused(store: Path, name: str) -> None:
+    component = store / COMPONENTS[name]
+    component.parent.mkdir(parents=True, exist_ok=True)
+    component.write_bytes(b"file\n")
+    before = _tree(store)
+    _fails(NOT_DIRECTORY, lambda: stage_generation_root(_projection()))
+    assert _tree(store) == before
+
+
+@pytest.mark.parametrize("kind", LINK_KINDS)
+def test_staged_link_is_refused_before_any_write(store, tmp_path, kind) -> None:
+    _require_link_kind(kind)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    hand = _actor(store) / "staging" / f"{ROOT_KEY}-{'0' * 16}"
+    (hand / "store").mkdir(parents=True)
+    _link(hand / "store" / "decisions", outside, kind)
+    before = _tree(outside)
+    with pytest.raises(ReplicaControlReadError):
+        installation._ensure_directory(store, hand / "store" / "decisions")
+    assert _tree(outside) == before
+
+
+@pytest.mark.parametrize("artifacts", [ARTIFACTS, {}], ids=["three", "empty"])
+def test_staged_tree_matches_projection_exactly(store: Path, artifacts) -> None:
+    projection = _projection(artifacts)
+    staged = stage_generation_root(projection)
+    expected = {f"store/{path}": content for path, content in artifacts.items()}
+    expected["manifest.json"] = projection.manifest_json
+    directories = {"store"} | {
+        f"store/{path.rpartition('/')[0]}" for path in artifacts if "/" in path
+    }
+    assert _tree(staged.staging_path) == sorted(expected.keys() | directories)
+    assert {
+        relative: (staged.staging_path / relative).read_bytes() for relative in expected
+    } == expected
+    assert staged.audit == GenerationRootAudit(
+        projection.target.identity.manifest_digest,
+        len(artifacts),
+        sum(len(content) for content in expected.values()),
+    )
+
+
+def _row(mutation: str, message: str, *marks):
+    return pytest.param(mutation, message, id=mutation, marks=marks)
+
+
+AUDIT_ROWS = [
+    _row("extra-file", "The generation root holds an unexpected entry: store/extra.md."),
+    _row("extra-dir", "The generation root holds an unexpected entry: store/extra."),
+    _row("missing", "The generation root is missing an entry: store/context/brief.md."),
+    _row("byte", "The generation artifact diverges: decisions/001-x.md."),
+    _row("symlink", "The generation root holds a link: store/context/brief.md.", POSIX_ONLY),
+    _row("junction", "The generation root holds a link: store/context."),
+    _row(
+        "hard-link",
+        "The generation root holds a linked file: store/decisions/001-x.md.",
+        POSIX_ONLY,
+    ),
+    _row("fifo", "The generation root holds an irregular entry: manifest.json.", POSIX_ONLY),
+    _row(
+        "tmp", "The generation root holds a partial write: store/.project.md.0123456789abcdef.tmp."
+    ),
+    _row("manifest-byte", "The generation root manifest diverges."),
+    _row("manifest-scope", "The generation root manifest diverges."),
+]
+
+
+@pytest.mark.parametrize(("mutation", "message"), AUDIT_ROWS)
+def test_audit_refuses_each_mutation(store, tmp_path, monkeypatch, mutation: str, message: str):
+    if mutation in LINK_KINDS:
+        _require_link_kind(mutation)
+    projection = _projection()
+    staging = stage_generation_root(projection).staging_path
+    if mutation == "extra-file":
+        (staging / "store" / "extra.md").write_bytes(b"extra\n")
+    elif mutation == "extra-dir":
+        (staging / "store" / "extra").mkdir()
+    elif mutation == "missing":
+        (staging / "store" / "context" / "brief.md").unlink()
+    elif mutation == "byte":
+        (staging / "store" / "decisions" / "001-x.md").write_bytes(b"# 002\n")
+    elif mutation == "symlink":
+        victim = staging / "store" / "context" / "brief.md"
+        victim.unlink()
+        victim.symlink_to(staging / "store" / "decisions" / "001-x.md")
+    elif mutation == "junction":
+        shutil.rmtree(staging / "store" / "context")
+        _link(staging / "store" / "context", staging / "store" / "decisions", "junction")
+    elif mutation == "hard-link":
+        os.link(staging / "store" / "decisions" / "001-x.md", tmp_path / "alias.md")
+    elif mutation == "fifo":
+        (staging / "manifest.json").unlink()
+        os.mkfifo(staging / "manifest.json")
+        real_open = os.open
+
+        def guarded_open(path, *args, **kwargs):
+            if Path(path) == staging / "manifest.json":
+                pytest.fail("opened the fifo")
+            return real_open(path, *args, **kwargs)
+
+        monkeypatch.setattr(installation.os, "open", guarded_open)
+    elif mutation == "tmp":
+        (staging / "store" / ".project.md.0123456789abcdef.tmp").write_bytes(b"")
+    elif mutation == "manifest-byte":
+        raw = bytearray(projection.manifest_json)
+        raw[-1] ^= 1
+        (staging / "manifest.json").write_bytes(bytes(raw))
+    else:
+        (staging / "manifest.json").write_bytes(_manifest(ARTIFACTS, "b" * 64))
+    _fails(message, lambda: audit_generation_tree(staging, projection))
+
+
+def test_access_order_probes_before_every_creation_and_write(store: Path, monkeypatch) -> None:
+    events: list[tuple[str, Path]] = []
+    real_lstat, real_mkdir, real_path_mkdir = os.lstat, os.mkdir, Path.mkdir
+    real_write, real_audit = installation.atomic_write_bytes, installation.audit_generation_tree
+
+    def lstat(path, *args, **kwargs):
+        events.append(("lstat", Path(path)))
+        return real_lstat(path, *args, **kwargs)
+
+    def mkdir(path, *args, **kwargs):
+        real_mkdir(path, *args, **kwargs)
+        events.append(("mkdir", Path(path)))
+
+    def path_mkdir(self, mode=0o777, parents=False, exist_ok=False):
+        if parents:
+            try:
+                real_lstat(self)
+            except FileNotFoundError:
+                pytest.fail(f"mkdir(parents=True) over absent {self}")
+        return real_path_mkdir(self, mode, parents, exist_ok)
+
+    def write(path, content):
+        events.append(("write", Path(path)))
+        real_write(path, content)
+
+    def audit(directory, projection):
+        events.append(("audit", directory))
+        return real_audit(directory, projection)
+
+    monkeypatch.setattr(installation.os, "lstat", lstat)
+    monkeypatch.setattr(installation.os, "mkdir", mkdir)
+    monkeypatch.setattr(Path, "mkdir", path_mkdir)
+    monkeypatch.setattr(installation, "atomic_write_bytes", write)
+    monkeypatch.setattr(installation, "audit_generation_tree", audit)
+    staging = stage_generation_root(_projection()).staging_path
+    actor, control = _actor(store), store / ".replica"
+    assert [path for kind, path in events if kind == "mkdir"] == [
+        control,
+        control / "v1",
+        control / "v1" / "actors",
+        actor,
+        actor / "generations",
+        actor / "staging",
+        staging,
+        staging / "store",
+        staging / "store" / "context",
+        staging / "store" / "decisions",
+    ]
+    assert [path for kind, path in events if kind == "write"] == [
+        staging / "store" / "context" / "brief.md",
+        staging / "store" / "decisions" / "001-x.md",
+        staging / "store" / "questions-provenance.json",
+        staging / "manifest.json",
+    ]
+    assert events.index(("lstat", control)) < events.index(("mkdir", control))
+    for index, (kind, path) in enumerate(events):
+        if kind == "mkdir":
+            later = events[index + 1 :]
+            assert ("lstat", path) in later, path
+            probe = later.index(("lstat", path))
+            assert not any(k == "mkdir" and path in p.parents for k, p in later[:probe]), path
+        elif kind == "write":
+            assert ("lstat", path.parent) in events[:index], path
+    assert events[-1] == ("audit", staging)
+
+
+def test_write_failure_discards_staging_and_names_the_artifact(store: Path, monkeypatch) -> None:
+    real_write, calls = installation.atomic_write_bytes, []
+
+    def write(path, content):
+        calls.append(path)
+        if len(calls) == 2:
+            raise OSError("disk full")
+        real_write(path, content)
+
+    monkeypatch.setattr(installation, "atomic_write_bytes", write)
+    _fails(
+        "The generation artifact could not be staged: store/decisions/001-x.md.",
+        lambda: stage_generation_root(_projection()),
+    )
+    actor = _actor(store)
+    assert (entry_names(actor / "staging"), entry_names(actor / "generations")) == (set(), set())
+
+
+@pytest.mark.parametrize("failure", ["typed", "crash"])
+def test_audit_failure_discards_only_on_typed_refusal(store: Path, monkeypatch, failure: str):
+    def is_tmp_sibling(name: str) -> bool:
+        if failure == "crash":
+            raise RuntimeError("walk interrupted")
+        return True
+
+    monkeypatch.setattr(installation, "is_tmp_sibling", is_tmp_sibling)
+    actor = _actor(store)
+    if failure == "typed":
+        with pytest.raises(GenerationInstallError, match="holds a partial write"):
+            stage_generation_root(_projection())
+        assert entry_names(actor / "staging") == set()
+    else:
+        with pytest.raises(RuntimeError, match="walk interrupted"):
+            stage_generation_root(_projection())
+        (survivor,) = entry_names(actor / "staging")
+        assert "store/questions-provenance.json" in _tree(actor / "staging" / survivor)
+    assert entry_names(actor / "generations") == set()
+
+
+def test_module_is_dormant_and_private(store: Path, monkeypatch) -> None:
+    source = Path(installation.__file__).read_text(encoding="utf-8")
+    imported: set[str] = set()
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            imported.add(node.module or "")
+    assert imported.isdisjoint(FORBIDDEN_IMPORTS)
+    assert not [name for name in SINGLE_CALLER_NAMES if name in source]
+    assert list(signature(stage_generation_root).parameters) == ["projection"]
+    assert [item.name for item in fields(StagedGenerationRoot)] == (
+        "target root_key root_path staging_path audit".split()
+    )
+    assert [item.name for item in fields(GenerationRootAudit)] == (
+        "manifest_digest artifact_count byte_total".split()
+    )
+    assert issubclass(GenerationRootDivergedError, GenerationAuthorityError)
+    assert GenerationRootDivergedError.code == "generation_root_diverged"
+    real_replace = os.replace
+
+    def replace(source, destination, *args, **kwargs):
+        if os.path.isdir(source):
+            pytest.fail(f"directory rename {source}")
+        return real_replace(source, destination, *args, **kwargs)
+
+    monkeypatch.setattr(installation.os, "replace", replace)
+    for name in ("locked_replica_control_snapshot", "_native_control_lock"):
+        monkeypatch.setattr(replica_control, name, lambda *_a, **_k: pytest.fail("lock path"))
+    staged = stage_generation_root(_projection())
+    with pytest.raises(FrozenInstanceError):
+        staged.root_key = "x"


### PR DESCRIPTION
## Why

The client can now acquire and verify a generation projection in memory, but nothing on main writes anything under the replica control directory, so a verified projection has nowhere to land. The sync admission series made every legacy surface ignore the control root, which is what makes creating it safe. This slice is the first writer: it lays out the actor's versioned control directory, stages the whole projection into a fresh sibling directory, and re-audits every byte from disk. It publishes nothing and selects nothing; publication under the control lock, reuse and divergence, and the stale-staging sweep follow in the next slice, and the authority marker and pointer after that.

## What changed

- New `nauro/store/generation_installation.py`. One public staging entry takes a verified projection and nothing else. It validates the store path, then creates `.replica/v<format>/actors/<user>/generations` and `.../staging` one component at a time, proving each component link-free and reparse-free with a non-following probe before it is created or written through and again after creation; it never creates parents across unproven components.
- The projection is written into a fresh random staging directory beside `generations/`, artifacts in path order through the existing atomic writer with each parent proven first, and the exact envelope bytes as `manifest.json` last. A write failure removes the staging directory and raises a typed error.
- A non-following audit walks the staged tree with explicit frames, refuses links, reparse points, hard-linked files, partial-write siblings, unexpected or irregular entries, and missing entries, opens each expected file without following links, checks the file identity against the walk, and recomputes every digest and the manifest bytes. Only an audited staging directory is returned.
- The root name binds generation, class, and scope as a 32-hex digest, so the longest decision artifact path stays inside the default Windows path limit; the marker, pointer, lease, and tombstone spellings are documented and not created.
- New `tests/test_generation_installation.py`: layout goldens, containment rows for every component and link kind, staging and audit tables, an access-order table, failure rows, and dormancy rows. The file joins the three-OS generation control CI job.

## Test plan

- Focused: `uv run --no-sync --package nauro pytest packages/nauro/tests/test_generation_installation.py packages/nauro/tests/test_replica_control.py packages/nauro/tests/test_generation_projection.py packages/nauro/tests/test_generation_authority.py packages/nauro/tests/test_atomic.py packages/nauro/tests/test_sync/test_replica_control_excluded.py packages/nauro/tests/test_sync/test_pull_admission.py packages/nauro/tests/test_sync/test_read_admission.py packages/nauro/tests/test_sync/test_restore_admission.py -q`
  - 492 passed, 20 skipped (28 passed and 8 junction rows skipped in the new file)
- `uv run --no-sync --package nauro pytest packages/nauro/tests/ --ignore=packages/nauro/tests/cross_surface -q`
  - 3,362 passed, 20 skipped
- `uv run --no-sync ruff check packages/ benchmarks/ scripts/` and `uv run --no-sync ruff format --check packages/ benchmarks/ scripts/`
- `uv run --no-sync --package nauro mypy --config-file packages/nauro/pyproject.toml packages/nauro/src/nauro/store/generation_installation.py` with no errors
- Run the single-source, docstring-budget, and server JSON version repository guards.
- Verify the three-file scope and 789 changed lines against the 800-line ceiling; the control reader, the admission layer, the atomic writer, and the verifier are untouched.
- Mutation rows name the assertion that fails when the pre-create probe, the audit's link check, the hard-link check, or the digest comparison is removed.
- Windows and macOS evidence comes from the CI jobs on this PR; local runs are macOS only. Junction rows are CI-only evidence.

## Risk / what to review

- Ordering: validate the store path, probe, create, re-probe, write, audit; the audit is the last event before the staged root is returned.
- The atomic writer creates parents on its own, so containment rests on every parent being proven and created first; the access-order rows pin that.
- The audit deliberately does not reuse the sync admission walker, which admits an in-store link to a regular file.
- Nothing this slice writes is selectable: no marker, pointer, or lease exists, and flat authority remains selected after every staging.
- The audit walk probes entries with a non-following `os.stat` on the entry path rather than the directory entry's own stat, because Windows reports zero file identity from directory entries and the descriptor identity check would never match there.
- A typed audit refusal removes the staging directory; an untyped crash leaves it for the sweep that lands with publication, so a crash never deletes evidence. A crash leaves at most empty layout directories under the control root and one staging directory.
- The audit refuses a regular file with more than one link, so an outside alias cannot change an audited tree later.

## Deferred

Publication of the staged root under the replica control lock, reuse of an identical root and typed refusal of a divergent one, the stale-staging sweep, and the coexistence rows against the legacy surfaces (next slice); the authority marker and the actor pointer; leases and cleanup; pointer-selected reads; refresh and pointer compare-and-swap; write routing by authority; the compatible release; the one-project cutover.
