### PR TITLE
Publish staged generation roots under the replica control lock

### DIFF
--- a/packages/nauro/src/nauro/store/generation_installation.py
+++ b/packages/nauro/src/nauro/store/generation_installation.py
@@ -8,6 +8,7 @@ import os
 import secrets
 import shutil
 import stat
+import time
 from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
@@ -20,8 +21,10 @@ from nauro.store.generation_projection import (
 )
 from nauro.store.replica_control import (
     _READ_FLAGS,
+    _REPLICA_CONTROL_LOCK_NAME,
     _REPLICA_CONTROL_ROOT_NAME,
     _is_link_or_reparse,
+    _native_control_lock,
     _validate_managed_path,
     _validate_store_path,
 )
@@ -35,6 +38,9 @@ _ROOT_KEY_HEX = 32
 _STAGING_TOKEN_BYTES = 8
 _NOT_DIRECTORY = "The generation root component is not a directory."
 _LAYOUT_FAILED = "The generation root layout could not be prepared."
+_PUBLISH_FAILED = "The generation root could not be published."
+_OCCUPIED = "The generation root is occupied by a non-directory entry."
+_STALE_STAGING_SECONDS = 3600
 
 
 class GenerationInstallError(GenerationAuthorityError):
@@ -59,6 +65,15 @@ class StagedGenerationRoot:
     root_path: Path
     staging_path: Path
     audit: GenerationRootAudit
+
+
+@dataclass(frozen=True)
+class InstalledGenerationRoot:
+    target: GenerationProjectionTarget
+    root_key: str
+    root_path: Path
+    audit: GenerationRootAudit
+    reused: bool
 
 
 @dataclass(frozen=True)
@@ -290,7 +305,9 @@ def audit_generation_tree(
     return GenerationRootAudit(manifest_digest, len(projection.artifacts), byte_total)
 
 
-def stage_generation_root(projection: VerifiedGenerationProjection) -> StagedGenerationRoot:
+def _prepare_layout(
+    projection: VerifiedGenerationProjection,
+) -> tuple[Path, _GenerationLayout]:
     if type(projection) is not VerifiedGenerationProjection:
         raise GenerationInstallError("Generation installation requires a verified projection.")
     store_path = _validate_store_path(projection.target.binding)
@@ -304,6 +321,12 @@ def stage_generation_root(projection: VerifiedGenerationProjection) -> StagedGen
         layout.staging_dir,
     ):
         _ensure_directory(store_path, directory)
+    return store_path, layout
+
+
+def _stage(
+    store_path: Path, layout: _GenerationLayout, projection: VerifiedGenerationProjection
+) -> StagedGenerationRoot:
     staging = _create_staging(store_path, layout)
     _stage_tree(store_path, staging, projection)
     try:
@@ -316,7 +339,98 @@ def stage_generation_root(projection: VerifiedGenerationProjection) -> StagedGen
     )
 
 
+def stage_generation_root(projection: VerifiedGenerationProjection) -> StagedGenerationRoot:
+    store_path, layout = _prepare_layout(projection)
+    return _stage(store_path, layout, projection)
+
+
+def _lstat_optional(path: Path) -> os.stat_result | None:
+    try:
+        return os.lstat(path)
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        raise GenerationInstallError(_LAYOUT_FAILED) from exc
+
+
+def _sweep_stale_staging(staging_dir: Path) -> None:
+    try:
+        with os.scandir(staging_dir) as entries:
+            listed = [(entry.path, entry.stat(follow_symlinks=False)) for entry in entries]
+    except OSError:
+        return
+    cutoff = time.time() - _STALE_STAGING_SECONDS
+    for native, metadata in listed:
+        if _is_link_or_reparse(metadata) or not stat.S_ISDIR(metadata.st_mode):
+            continue
+        if metadata.st_mtime < cutoff:
+            _discard_staging(Path(native))
+
+
+def _rename_into_place(staging: Path, root_path: Path) -> None:
+    try:
+        os.replace(staging, root_path)
+        metadata = os.lstat(root_path)
+    except OSError as exc:
+        raise GenerationInstallError(_PUBLISH_FAILED) from exc
+    if _is_link_or_reparse(metadata) or not stat.S_ISDIR(metadata.st_mode):
+        raise GenerationInstallError(_PUBLISH_FAILED)
+
+
+def _publish_or_reuse(
+    store_path: Path,
+    layout: _GenerationLayout,
+    staged: StagedGenerationRoot | None,
+    projection: VerifiedGenerationProjection,
+    lock_path: Path,
+    timeout: float,
+) -> tuple[GenerationRootAudit, bool]:
+    with _native_control_lock(store_path, lock_path, timeout):
+        _validate_managed_path(store_path, layout.root_path)
+        if staged is not None:
+            _validate_managed_path(store_path, staged.staging_path)
+        metadata = _lstat_optional(layout.root_path)
+        if metadata is None:
+            if staged is None:
+                raise GenerationInstallError(_PUBLISH_FAILED)
+            _rename_into_place(staged.staging_path, layout.root_path)
+            return staged.audit, False
+        if not stat.S_ISDIR(metadata.st_mode):
+            raise GenerationRootDivergedError(_OCCUPIED)
+        try:
+            return audit_generation_tree(layout.root_path, projection), True
+        except GenerationInstallError as exc:
+            raise GenerationRootDivergedError(str(exc)) from None
+
+
+def install_generation_root(
+    projection: VerifiedGenerationProjection, *, timeout: float = -1
+) -> InstalledGenerationRoot:
+    store_path, layout = _prepare_layout(projection)
+    lock_path = store_path / _REPLICA_CONTROL_LOCK_NAME
+    _validate_managed_path(store_path, lock_path)
+    _sweep_stale_staging(layout.staging_dir)
+    _validate_managed_path(store_path, layout.root_path)
+    staged: StagedGenerationRoot | None = None
+    if _lstat_optional(layout.root_path) is None:
+        staged = _stage(store_path, layout, projection)
+    try:
+        audit, reused = _publish_or_reuse(
+            store_path, layout, staged, projection, lock_path, timeout
+        )
+    except GenerationAuthorityError:
+        if staged is not None:
+            _discard_staging(staged.staging_path)
+        raise
+    if reused and staged is not None:
+        _discard_staging(staged.staging_path)
+    return InstalledGenerationRoot(
+        projection.target, layout.root_key, layout.root_path, audit, reused
+    )
+
+
 __all__ = (
     "GenerationInstallError GenerationRootAudit GenerationRootDivergedError "
-    "StagedGenerationRoot audit_generation_tree stage_generation_root"
+    "InstalledGenerationRoot StagedGenerationRoot audit_generation_tree "
+    "install_generation_root stage_generation_root"
 ).split()

--- a/packages/nauro/tests/test_generation_installation.py
+++ b/packages/nauro/tests/test_generation_installation.py
@@ -8,12 +8,16 @@ import shutil
 import stat
 import subprocess
 import sys
+import time
+from contextlib import contextmanager
 from dataclasses import FrozenInstanceError, fields
 from inspect import signature
 from pathlib import Path
 
 import pytest
+from filelock import FileLock
 
+from nauro.mcp.tools import tool_get_raw_file
 from nauro.store import generation_installation as installation
 from nauro.store import replica_control
 from nauro.store.generation_authority import FlatProjectAuthority, GenerationAuthorityError
@@ -21,8 +25,10 @@ from nauro.store.generation_installation import (
     GenerationInstallError,
     GenerationRootAudit,
     GenerationRootDivergedError,
+    InstalledGenerationRoot,
     StagedGenerationRoot,
     audit_generation_tree,
+    install_generation_root,
     stage_generation_root,
 )
 from nauro.store.generation_projection import (
@@ -33,13 +39,22 @@ from nauro.store.generation_projection import (
 )
 from nauro.store.registry import get_store_path_v2
 from nauro.store.replica_control import (
+    ReplicaControlBusyError,
     ReplicaControlReadError,
     _is_link_or_reparse,
     locked_replica_control_snapshot,
 )
 from nauro.store.resolution import ResolvedProjectBinding
+from nauro.sync import merge
+from nauro.sync.corpus import DecisionCorpus
+from nauro.sync.pull import PullReport
 from nauro.templates.scaffolds import scaffold_project_store
-from tests.test_sync.conftest import entry_names
+from tests.test_sync.conftest import (
+    _scaffolded_cloud_project,
+    _seed_token,
+    entry_names,
+    pull_report,
+)
 
 POSIX_ONLY = pytest.mark.skipif(sys.platform == "win32", reason="POSIX filename semantics")
 LINK_KINDS = ["symlink", "junction"]
@@ -73,6 +88,10 @@ SINGLE_CALLER_NAMES = (
     "_walk_store_files _prepare_store_root _admit_native_path _classify_sync_path".split()
 )
 NOT_DIRECTORY = "The generation root component is not a directory."
+DIVERGED = "generation_root_diverged"
+LOCK_NAME = ".replica-control.lock"
+OCCUPIED = "The generation root is occupied by a non-directory entry."
+PUBLISH_FAILED = "The generation root could not be published."
 
 
 def _link(link: Path, target: Path, kind: str) -> None:
@@ -154,6 +173,34 @@ def _fails(message: str, call) -> GenerationInstallError:
     assert (type(raised.value), raised.value.code) == (GenerationInstallError, CODE)
     assert str(raised.value) == message
     return raised.value
+
+
+def _diverges(message: str, call) -> None:
+    with pytest.raises(GenerationRootDivergedError) as raised:
+        call()
+    assert (type(raised.value), raised.value.code) == (GenerationRootDivergedError, DIVERGED)
+    assert str(raised.value) == message
+
+
+def _generations(store: Path) -> Path:
+    return _actor(store) / "generations"
+
+
+def _staging(store: Path) -> Path:
+    return _actor(store) / "staging"
+
+
+def _bytes(root: Path) -> dict[str, bytes]:
+    return {
+        relative: (root / relative).read_bytes()
+        for relative in _tree(root)
+        if stat.S_ISREG(os.lstat(root / relative).st_mode)
+    }
+
+
+def _age(path: Path, seconds: float) -> None:
+    moment = time.time() - seconds
+    os.utime(path, (moment, moment))
 
 
 def test_layout_spellings_and_flat_authority(store: Path) -> None:
@@ -282,48 +329,52 @@ AUDIT_ROWS = [
 ]
 
 
+def _mutate(tree: Path, mutation: str, projection, tmp_path: Path, monkeypatch) -> None:
+    if mutation == "extra-file":
+        (tree / "store" / "extra.md").write_bytes(b"extra\n")
+    elif mutation == "extra-dir":
+        (tree / "store" / "extra").mkdir()
+    elif mutation == "missing":
+        (tree / "store" / "context" / "brief.md").unlink()
+    elif mutation == "byte":
+        (tree / "store" / "decisions" / "001-x.md").write_bytes(b"# 002\n")
+    elif mutation == "symlink":
+        victim = tree / "store" / "context" / "brief.md"
+        victim.unlink()
+        victim.symlink_to(tree / "store" / "decisions" / "001-x.md")
+    elif mutation == "junction":
+        shutil.rmtree(tree / "store" / "context")
+        _link(tree / "store" / "context", tree / "store" / "decisions", "junction")
+    elif mutation == "hard-link":
+        os.link(tree / "store" / "decisions" / "001-x.md", tmp_path / "alias.md")
+    elif mutation == "fifo":
+        (tree / "manifest.json").unlink()
+        os.mkfifo(tree / "manifest.json")
+        real_open = os.open
+
+        def guarded_open(path, *args, **kwargs):
+            if Path(path) == tree / "manifest.json":
+                pytest.fail("opened the fifo")
+            return real_open(path, *args, **kwargs)
+
+        monkeypatch.setattr(installation.os, "open", guarded_open)
+    elif mutation == "tmp":
+        (tree / "store" / ".project.md.0123456789abcdef.tmp").write_bytes(b"")
+    elif mutation == "manifest-byte":
+        raw = bytearray(projection.manifest_json)
+        raw[-1] ^= 1
+        (tree / "manifest.json").write_bytes(bytes(raw))
+    else:
+        (tree / "manifest.json").write_bytes(_manifest(ARTIFACTS, "b" * 64))
+
+
 @pytest.mark.parametrize(("mutation", "message"), AUDIT_ROWS)
 def test_audit_refuses_each_mutation(store, tmp_path, monkeypatch, mutation: str, message: str):
     if mutation in LINK_KINDS:
         _require_link_kind(mutation)
     projection = _projection()
     staging = stage_generation_root(projection).staging_path
-    if mutation == "extra-file":
-        (staging / "store" / "extra.md").write_bytes(b"extra\n")
-    elif mutation == "extra-dir":
-        (staging / "store" / "extra").mkdir()
-    elif mutation == "missing":
-        (staging / "store" / "context" / "brief.md").unlink()
-    elif mutation == "byte":
-        (staging / "store" / "decisions" / "001-x.md").write_bytes(b"# 002\n")
-    elif mutation == "symlink":
-        victim = staging / "store" / "context" / "brief.md"
-        victim.unlink()
-        victim.symlink_to(staging / "store" / "decisions" / "001-x.md")
-    elif mutation == "junction":
-        shutil.rmtree(staging / "store" / "context")
-        _link(staging / "store" / "context", staging / "store" / "decisions", "junction")
-    elif mutation == "hard-link":
-        os.link(staging / "store" / "decisions" / "001-x.md", tmp_path / "alias.md")
-    elif mutation == "fifo":
-        (staging / "manifest.json").unlink()
-        os.mkfifo(staging / "manifest.json")
-        real_open = os.open
-
-        def guarded_open(path, *args, **kwargs):
-            if Path(path) == staging / "manifest.json":
-                pytest.fail("opened the fifo")
-            return real_open(path, *args, **kwargs)
-
-        monkeypatch.setattr(installation.os, "open", guarded_open)
-    elif mutation == "tmp":
-        (staging / "store" / ".project.md.0123456789abcdef.tmp").write_bytes(b"")
-    elif mutation == "manifest-byte":
-        raw = bytearray(projection.manifest_json)
-        raw[-1] ^= 1
-        (staging / "manifest.json").write_bytes(bytes(raw))
-    else:
-        (staging / "manifest.json").write_bytes(_manifest(ARTIFACTS, "b" * 64))
+    _mutate(staging, mutation, projection, tmp_path, monkeypatch)
     _fails(message, lambda: audit_generation_tree(staging, projection))
 
 
@@ -461,6 +512,359 @@ def test_module_is_dormant_and_private(store: Path, monkeypatch) -> None:
     monkeypatch.setattr(installation.os, "replace", replace)
     for name in ("locked_replica_control_snapshot", "_native_control_lock"):
         monkeypatch.setattr(replica_control, name, lambda *_a, **_k: pytest.fail("lock path"))
+    monkeypatch.setattr(
+        installation, "_native_control_lock", lambda *_a, **_k: pytest.fail("lock path")
+    )
     staged = stage_generation_root(_projection())
     with pytest.raises(FrozenInstanceError):
         staged.root_key = "x"
+
+
+def test_publish_then_reuse_without_writing(store: Path, monkeypatch) -> None:
+    before = entry_names(store)
+    projection = _projection()
+    root = _generations(store) / ROOT_KEY
+    expected = {f"store/{path}": content for path, content in ARTIFACTS.items()}
+    expected["manifest.json"] = projection.manifest_json
+    installed = install_generation_root(projection)
+    audit = GenerationRootAudit(
+        projection.target.identity.manifest_digest,
+        len(ARTIFACTS),
+        sum(len(content) for content in expected.values()),
+    )
+    assert installed == InstalledGenerationRoot(projection.target, ROOT_KEY, root, audit, False)
+    assert _tree(root) == sorted(expected.keys() | {"store", "store/context", "store/decisions"})
+    assert _bytes(root) == expected
+    assert (entry_names(_staging(store)), entry_names(_generations(store))) == (set(), {ROOT_KEY})
+    assert entry_names(store) - {LOCK_NAME} == before | {".replica"}
+    monkeypatch.setattr(installation, "atomic_write_bytes", lambda *_a: pytest.fail("wrote"))
+    again = install_generation_root(projection)
+    assert again == InstalledGenerationRoot(projection.target, ROOT_KEY, root, audit, True)
+    assert _bytes(root) == expected
+    assert (entry_names(_staging(store)), entry_names(_generations(store))) == (set(), {ROOT_KEY})
+    _fails(
+        "Generation installation requires a verified projection.",
+        lambda: install_generation_root(object()),
+    )
+
+
+@pytest.mark.parametrize(("mutation", "message"), AUDIT_ROWS)
+def test_divergent_root_is_refused_in_place(store, tmp_path, monkeypatch, mutation, message):
+    if mutation in LINK_KINDS:
+        _require_link_kind(mutation)
+    projection = _projection()
+    root = install_generation_root(projection).root_path
+    _mutate(root, mutation, projection, tmp_path, monkeypatch)
+    before = _bytes(root)
+    monkeypatch.setattr(installation, "atomic_write_bytes", lambda *_a: pytest.fail("wrote"))
+    _diverges(message, lambda: install_generation_root(projection))
+    assert _bytes(root) == before
+    assert (entry_names(_staging(store)), entry_names(_generations(store))) == (set(), {ROOT_KEY})
+
+
+def test_root_path_occupied_by_a_file_is_refused_and_kept(store: Path) -> None:
+    root = _generations(store) / ROOT_KEY
+    root.parent.mkdir(parents=True)
+    root.write_bytes(b"file\n")
+    _diverges(OCCUPIED, lambda: install_generation_root(_projection()))
+    assert (root.read_bytes(), entry_names(_staging(store))) == (b"file\n", set())
+
+
+@pytest.mark.parametrize("kind", [*LINK_KINDS, "dangling"])
+def test_linked_root_path_is_refused_before_any_kind_check(store, tmp_path, kind) -> None:
+    _require_link_kind("symlink" if kind == "dangling" else kind)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "victim.md").write_bytes(b"victim\n")
+    root = _generations(store) / ROOT_KEY
+    _staging(store).mkdir(parents=True)
+    root.parent.mkdir()
+    if kind == "dangling":
+        root.symlink_to(outside / "absent")
+    else:
+        _link(root, outside, kind)
+    before = (_tree(outside), _tree(store))
+    with pytest.raises(ReplicaControlReadError) as raised:
+        install_generation_root(_projection())
+    assert raised.value.code == "generation_control_unavailable"
+    assert (_tree(outside), _tree(store)) == before
+
+
+@pytest.mark.parametrize("kind", LINK_KINDS)
+def test_absent_probe_sees_a_dangling_link_as_present(tmp_path: Path, kind: str) -> None:
+    _require_link_kind(kind)
+    assert installation._lstat_optional(tmp_path / "absent") is None
+    target = tmp_path / "target"
+    target.mkdir()
+    dangling = tmp_path / "dangling"
+    _link(dangling, target, kind)
+    target.rmdir()
+    assert not dangling.exists()
+    metadata = installation._lstat_optional(dangling)
+    assert metadata is not None and _is_link_or_reparse(metadata)
+
+
+def _plant(store: Path, divergent: bool) -> dict[str, bytes]:
+    (name,) = entry_names(_staging(store))
+    root = _generations(store) / ROOT_KEY
+    shutil.copytree(_staging(store) / name, root)
+    if divergent:
+        (root / "store" / "decisions" / "001-x.md").write_bytes(b"# 002\n")
+    return _bytes(root)
+
+
+def _wrap_lock(monkeypatch, before_yield, events: list[str] | None = None) -> None:
+    real = installation._native_control_lock
+
+    @contextmanager
+    def wrapped(store_path, path, timeout):
+        with real(store_path, path, timeout):
+            if events is not None:
+                events.append("lock")
+            before_yield()
+            yield
+        if events is not None:
+            events.append("release")
+
+    monkeypatch.setattr(installation, "_native_control_lock", wrapped)
+
+
+@pytest.mark.parametrize("divergent", [False, True], ids=["identical", "divergent"])
+def test_root_planted_under_the_lock_is_audited_never_replaced(store, monkeypatch, divergent):
+    projection = _projection()
+    planted: dict[str, bytes] = {}
+    _wrap_lock(monkeypatch, lambda: planted.update(_plant(store, divergent)))
+    if divergent:
+        message = "The generation artifact diverges: decisions/001-x.md."
+        _diverges(message, lambda: install_generation_root(projection))
+    else:
+        assert install_generation_root(projection).reused is True
+    assert _bytes(_generations(store) / ROOT_KEY) == planted
+    assert (entry_names(_staging(store)), entry_names(_generations(store))) == (set(), {ROOT_KEY})
+
+
+@pytest.mark.parametrize("kind", LINK_KINDS)
+def test_root_link_planted_under_the_lock_is_refused(store, tmp_path, monkeypatch, kind):
+    _require_link_kind(kind)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "victim.md").write_bytes(b"victim\n")
+    root = _generations(store) / ROOT_KEY
+    planted: dict[str, os.stat_result] = {}
+
+    def plant() -> None:
+        assert len(entry_names(_staging(store))) == 1
+        _link(root, outside, kind)
+        planted["metadata"] = os.lstat(root)
+
+    real_replace = os.replace
+
+    def replace(source, destination, *args, **kwargs):
+        if os.path.isdir(source):
+            pytest.fail(f"directory rename {source}")
+        return real_replace(source, destination, *args, **kwargs)
+
+    before = _tree(outside)
+    monkeypatch.setattr(installation.os, "replace", replace)
+    _wrap_lock(monkeypatch, plant)
+    with pytest.raises(ReplicaControlReadError) as raised:
+        install_generation_root(_projection())
+    assert raised.value.code == "generation_control_unavailable"
+    assert os.lstat(root) == planted["metadata"]
+    assert _is_link_or_reparse(os.lstat(root))
+    assert root.samefile(outside)
+    assert _tree(outside) == before
+    assert entry_names(_staging(store)) == set()
+
+
+def test_publish_failure_removes_staging_and_publishes_nothing(store: Path, monkeypatch) -> None:
+    real = os.replace
+
+    def replace(source, destination, *args, **kwargs):
+        if os.path.isdir(source):
+            raise OSError("rename refused")
+        return real(source, destination, *args, **kwargs)
+
+    monkeypatch.setattr(installation.os, "replace", replace)
+    _fails(PUBLISH_FAILED, lambda: install_generation_root(_projection()))
+    assert (entry_names(_staging(store)), entry_names(_generations(store))) == (set(), set())
+
+
+def test_busy_control_lock_publishes_nothing(store: Path) -> None:
+    with FileLock(str(store / LOCK_NAME)):
+        with pytest.raises(ReplicaControlBusyError) as raised:
+            install_generation_root(_projection(), timeout=0.1)
+    assert raised.value.code == "generation_control_busy"
+    assert (entry_names(_staging(store)), entry_names(_generations(store))) == (set(), set())
+
+
+@pytest.mark.parametrize("planted", [False, True], ids=["publish", "planted"])
+def test_publication_order(store: Path, monkeypatch, planted: bool) -> None:
+    events: list[str] = []
+    root, staging_dir = _generations(store) / ROOT_KEY, _staging(store)
+    real_lstat, real_mkdir, real_replace, real_rmtree = (
+        os.lstat,
+        os.mkdir,
+        os.replace,
+        shutil.rmtree,
+    )
+    real_write, real_audit = installation.atomic_write_bytes, installation.audit_generation_tree
+
+    def lstat(path, *args, **kwargs):
+        if Path(path) == root:
+            events.append("probe")
+        return real_lstat(path, *args, **kwargs)
+
+    def mkdir(path, *args, **kwargs):
+        if staging_dir in Path(path).parents:
+            events.append("create")
+        return real_mkdir(path, *args, **kwargs)
+
+    def write(path, content):
+        events.append("write")
+        real_write(path, content)
+
+    def audit(directory, projection):
+        events.append("audit:root" if directory == root else "audit:staging")
+        return real_audit(directory, projection)
+
+    def replace(source, destination, *args, **kwargs):
+        if os.path.isdir(source):
+            events.append("rename")
+        return real_replace(source, destination, *args, **kwargs)
+
+    def rmtree(path, *args, **kwargs):
+        events.append("remove")
+        return real_rmtree(path, *args, **kwargs)
+
+    monkeypatch.setattr(installation.os, "lstat", lstat)
+    monkeypatch.setattr(installation.os, "mkdir", mkdir)
+    monkeypatch.setattr(installation.os, "replace", replace)
+    monkeypatch.setattr(installation.shutil, "rmtree", rmtree)
+    monkeypatch.setattr(installation, "atomic_write_bytes", write)
+    monkeypatch.setattr(installation, "audit_generation_tree", audit)
+    _wrap_lock(monkeypatch, (lambda: _plant(store, False)) if planted else (lambda: None), events)
+    assert install_generation_root(_projection()).reused is planted
+    if planted:
+        expected = "probe create write audit:staging lock audit:root release remove".split()
+        assert "rename" not in events
+    else:
+        expected = "probe create write audit:staging lock rename release".split()
+        assert "remove" not in events
+    positions = [events.index(kind) for kind in expected]
+    assert positions == sorted(positions), events
+
+
+SWEEP_ROWS = [
+    pytest.param(
+        entry,
+        kind,
+        id=f"{entry}-{kind}" if kind else entry,
+        marks=POSIX_ONLY if entry == "fifo" else (),
+    )
+    for entry, kind in [
+        ("stale", None),
+        ("fresh", None),
+        ("file", None),
+        ("fifo", None),
+        ("link", "symlink"),
+        ("link", "junction"),
+        ("holding-link", "symlink"),
+        ("holding-link", "junction"),
+    ]
+]
+
+
+@pytest.mark.parametrize(("entry", "kind"), SWEEP_ROWS)
+def test_sweep_removes_only_stale_plain_directories(store, tmp_path, monkeypatch, entry, kind):
+    if kind is not None:
+        _require_link_kind(kind)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "victim.md").write_bytes(b"victim\n")
+    stale = _staging(store) / f"{ROOT_KEY}-{'0' * 16}"
+    if entry in ("link", "file", "fifo"):
+        stale.parent.mkdir(parents=True)
+        if entry == "link":
+            _link(stale, outside, kind)
+        elif entry == "file":
+            stale.write_bytes(b"stray\n")
+        else:
+            os.mkfifo(stale)
+        monkeypatch.setattr(installation.shutil, "rmtree", lambda *_a, **_k: pytest.fail("rmtree"))
+    else:
+        (stale / "store").mkdir(parents=True)
+        if entry == "holding-link":
+            _link(stale / "store" / "context", outside, kind)
+    if entry == "link":
+        planted_mtime = os.lstat(stale).st_mtime
+        monkeypatch.setattr(installation.time, "time", lambda: planted_mtime + 7200)
+    else:
+        _age(stale, 600 if entry == "fresh" else 7200)
+    before = _tree(outside)
+    assert install_generation_root(_projection()).reused is False
+    survivors = {stale.name} if entry in ("fresh", "file", "fifo", "link") else set()
+    assert entry_names(_staging(store)) == survivors
+    assert _tree(outside) == before
+
+
+def test_sweep_and_reuse_never_list_generations(store: Path, monkeypatch) -> None:
+    real, generations = os.scandir, _generations(store)
+
+    def scandir(path=".", *args, **kwargs):
+        if Path(path) == generations:
+            pytest.fail("listed generations")
+        return real(path, *args, **kwargs)
+
+    monkeypatch.setattr(installation.os, "scandir", scandir)
+    assert [install_generation_root(_projection()).reused for _ in range(2)] == [False, True]
+
+
+def _without_reason(envelope: dict) -> dict:
+    shape = dict(envelope)
+    shape["error"] = {key: value for key, value in shape["error"].items() if key != "reason"}
+    return shape
+
+
+def test_installed_root_coexists_with_legacy_surfaces(tmp_path: Path) -> None:
+    store = _scaffolded_cloud_project("nauro", tmp_path, PROJECT_ID)
+    _seed_token()
+    assert store == get_store_path_v2(PROJECT_ID)
+    (store / "context").mkdir(exist_ok=True)
+    projection = _projection()
+    root = install_generation_root(projection).root_path
+    before = _bytes(root)
+    walked = [
+        entry.raw_relative_path
+        for entry in merge._walk_store_files(merge._prepare_store_root(store))
+    ]
+    assert walked
+    assert not [path for path in walked if Path(path).parts[0].casefold() == ".replica"]
+    envelope = tool_get_raw_file(store, f"{ACTOR}/generations/{ROOT_KEY}/manifest.json")
+    assert _without_reason(envelope) == _without_reason(
+        tool_get_raw_file(store, "does-not-exist.md")
+    )
+    assert not [name for name in envelope["available_files"] if ".replica" in name.casefold()]
+    report, reporter = pull_report(
+        store, [("context/note.md", b"note\n"), (".replica/authority.json", b"x")]
+    )
+    assert (report, reporter.warns) == (PullReport(merged=1), [])
+    assert (store / "context" / "note.md").read_bytes() == b"note\n"
+    assert entry_names(store / ".replica") == {"v1"}
+    assert _bytes(root) == before
+    assert DecisionCorpus.scan(store).usable is True
+    with locked_replica_control_snapshot(
+        projection.target.binding, active_user_id=USER_ID, active_projection_scope_id=SCOPE_ID
+    ) as snapshot:
+        assert snapshot.authority == FlatProjectAuthority(projection.target.binding)
+
+
+def test_installer_is_dormant_and_private(store: Path, monkeypatch) -> None:
+    assert list(signature(install_generation_root).parameters) == ["projection", "timeout"]
+    assert [item.name for item in fields(InstalledGenerationRoot)] == (
+        "target root_key root_path audit reused".split()
+    )
+    monkeypatch.setattr("nauro.sync.state.save_state", lambda *_a, **_k: pytest.fail("state"))
+    installed = install_generation_root(_projection())
+    with pytest.raises(FrozenInstanceError):
+        installed.reused = True


### PR DESCRIPTION
## Why

The previous slice stages a verified generation projection under the actor's control directory and audits it, but stops short of a root that anything could later select. This slice publishes: under the one native replica control lock it renames the audited staging directory onto an absent root path in a single step, reuses a root that already holds byte-identical content, refuses one that diverges without ever overwriting or deleting it, and sweeps stale staging directories. It also proves that every legacy sync and read surface keeps ignoring the control root once real material lives there. The module is dormant: no code on main calls it. No marker, pointer, or lease is written, so flat authority stays selected after every installation; the marker and pointer land in the next slice.

## What changed

- `install_generation_root` in `nauro/store/generation_installation.py`: validates the store path, prepares the layout and the lock path with the same one-component-at-a-time containment as staging, sweeps stale staging directories, proves the root path link-free (a live or dangling link there is refused before anything else) and decides whether it is absent by a non-following probe, stages only when it is absent, then takes the replica control lock. Under the lock it re-proves both paths, publishes by one `os.replace` onto the absent root and checks the result is a plain directory, or audits a present root in place and returns it as reused when identical or refuses it as diverged when not. A link at the root path is refused before any kind check. Nothing under `generations/` is ever unlinked, renamed away, or rewritten.
- The sweep lists only the actor's `staging/` directory, removes only plain directories older than one hour, re-probes after removal, and never names `generations/`, the pointer, or the lease directory.
- The result carries the target, root key, root path, audit facts, and whether the root was reused, and nothing an installer must not mint.
- Tests: publish and reuse, divergence per kind including hard-linked files, a race planted under the lock, lock contention, the sweep's kind and age filters, an event-order row, dormancy rows, and coexistence rows that run the admission walker, the raw-file miss envelope, a legacy pull with a control-root row, the decision corpus scan, and the control reader against a store holding an installed root.

## Test plan

- Focused: `uv run --no-sync --package nauro pytest packages/nauro/tests/test_generation_installation.py packages/nauro/tests/test_replica_control.py packages/nauro/tests/test_generation_projection.py packages/nauro/tests/test_generation_authority.py packages/nauro/tests/test_atomic.py packages/nauro/tests/test_sync/test_replica_control_excluded.py packages/nauro/tests/test_sync/test_pull_admission.py packages/nauro/tests/test_sync/test_read_admission.py packages/nauro/tests/test_sync/test_restore_admission.py -q`
  - 523 passed, 26 skipped (59 passed and 14 platform-specific rows skipped in the installer file)
- `uv run --no-sync --package nauro pytest packages/nauro/tests/ --ignore=packages/nauro/tests/cross_surface -q`
  - 3,393 passed, 26 skipped
- `uv run --no-sync ruff check packages/ benchmarks/ scripts/` and `uv run --no-sync ruff format --check packages/ benchmarks/ scripts/`
- `uv run --no-sync --package nauro mypy --config-file packages/nauro/pyproject.toml packages/nauro/src/nauro/store/generation_installation.py` with no errors
- Run the single-source, docstring-budget, and server JSON version repository guards.
- Verify the two-file scope and 566 changed lines against the 800-line ceiling; the control reader, the lock helper, the admission layer, the atomic writer, and the verifier are untouched.
- Mutation rows name the assertion that fails when the pre-lock root-path validation or the pre-probe is removed, when the under-lock root-path validation is removed, when the in-place audit is removed, when the lock is removed, or when the sweep's kind or age filter is removed; the absent probe's non-following behavior is pinned at the unit level.
- Windows and macOS evidence comes from the CI jobs on this PR; local runs are macOS only. Junction rows and the Windows rename semantics are CI-only evidence.

## Risk / what to review

- Ordering: prepare and prove the layout, sweep, probe, stage, then lock, re-prove, rename or audit, release, then remove leftover staging.
- The rename targets an absent path only, because a directory cannot be renamed onto an existing directory on Windows and a rename onto an empty directory swaps silently on POSIX.
- Two installers of the same actor serialize on the control lock; the loser audits the winner's root and reuses or refuses. A foreign process that ignores the lock is outside the guarantee.
- Three named staging write-path windows remain: between the chain proof and a deeper directory creation, between the parent proof and the atomic write, and between the audit and the rename. The sweep also has validation-to-listing and observed-metadata-to-removal gaps. Each requires a concurrent local writer, which the filesystem write-safety contract scopes out; descriptor-relative I/O is its recorded upgrade path.
- A root that was present at the pre-probe and absent under the lock is refused typed rather than staged under the lock, so the one control lock never covers a projection-sized write; a re-run stages afresh. After staging completes, every typed publication refusal, including a busy lock, removes the staging directory best-effort. A failure during staging or an untyped crash can leave a staging directory for the sweep.
- A divergent existing root is left in place, not repaired; repair is manual until cleanup ships.
- The one-hour sweep threshold is a policy, not a proof.

## Deferred

The authority marker and the actor pointer (next slice); leases and cleanup with tombstones; pointer-selected reads; refresh and pointer compare-and-swap; write routing by authority; the compatible release; the one-project cutover.
