### PR TITLE
Publish installed generation control state

### DIFF
--- a/packages/nauro/src/nauro/store/generation_authority.py
+++ b/packages/nauro/src/nauro/store/generation_authority.py
@@ -17,6 +17,12 @@ _CONTROL_SCHEMA_VERSION = 1
 _STRICT_MODEL_CONFIG = pyd.ConfigDict(extra="forbid", frozen=True, strict=True)
 
 
+def _canonical_control_bytes(model: pyd.BaseModel) -> bytes:
+    return json.dumps(
+        model.model_dump(), sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    ).encode("utf-8")
+
+
 class GenerationAuthorityError(ValueError):
     """Base class for generation authority selection failures."""
 
@@ -86,6 +92,9 @@ class GenerationAuthorityMarker(pyd.BaseModel):
             raise ValueError("unsupported generation control schema")
         return value
 
+    def canonical_bytes(self) -> bytes:
+        return _canonical_control_bytes(self)
+
 
 class InstalledGenerationPointer(pyd.BaseModel):
     """The actor-bound pointer for one verified installed generation."""
@@ -122,6 +131,9 @@ class InstalledGenerationPointer(pyd.BaseModel):
         if value != _CONTROL_SCHEMA_VERSION:
             raise ValueError("unsupported generation control schema")
         return value
+
+    def canonical_bytes(self) -> bytes:
+        return _canonical_control_bytes(self)
 
 
 @dataclass(frozen=True)
@@ -160,6 +172,7 @@ class _PendingGenerationAuthority:
 
 def _strict_json_preflight(raw: str | bytes) -> None:
     text = raw.decode("utf-8") if type(raw) is bytes else raw
+    assert type(text) is str
     if text.startswith("\ufeff"):
         raise ValueError("JSON byte order marks are not allowed")
 

--- a/packages/nauro/src/nauro/store/generation_installation.py
+++ b/packages/nauro/src/nauro/store/generation_installation.py
@@ -11,23 +11,39 @@ import stat
 import time
 from contextlib import suppress
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 
 from nauro.store._atomic import atomic_write_bytes, is_tmp_sibling
-from nauro.store.generation_authority import GenerationAuthorityError
+from nauro.store.generation_authority import (
+    FlatProjectAuthority,
+    GenerationAuthorityError,
+    GenerationAuthorityMarker,
+    GenerationControlCorruptError,
+    GenerationProjectAuthority,
+    InstalledGenerationPointer,
+    _select_marker_authority,
+    select_project_authority,
+)
 from nauro.store.generation_projection import (
     GenerationProjectionTarget,
+    GenerationProjectionVerificationError,
     VerifiedGenerationProjection,
+    _parse_manifest,
+    _target_parts,
 )
 from nauro.store.replica_control import (
     _READ_FLAGS,
     _REPLICA_CONTROL_LOCK_NAME,
     _REPLICA_CONTROL_ROOT_NAME,
+    ReplicaControlReadError,
     _is_link_or_reparse,
     _native_control_lock,
+    _read_optional_file,
     _validate_managed_path,
     _validate_store_path,
 )
+from nauro.store.repo_config import generate_ulid
 from nauro.sync._path_diagnostics import _escape_path_for_display
 
 _GENERATIONS_DIR = "generations"
@@ -41,6 +57,14 @@ _LAYOUT_FAILED = "The generation root layout could not be prepared."
 _PUBLISH_FAILED = "The generation root could not be published."
 _OCCUPIED = "The generation root is occupied by a non-directory entry."
 _STALE_STAGING_SECONDS = 3600
+_AUTHORITY_MARKER_NAME = "authority.json"
+_POINTER_NAME = "pointer.json"
+_INSTALLED_FIELDS = frozenset({"target", "root_key", "root_path", "audit", "reused"})
+_AUDIT_FIELDS = frozenset({"manifest_digest", "artifact_count", "byte_total"})
+_TARGET_POINTER_FIELDS = (
+    "project_id store_format_version generation_id manifest_digest committed_at "
+    "installed_for_user_id projection_class projection_scope_id"
+).split()
 
 
 class GenerationInstallError(GenerationAuthorityError):
@@ -49,6 +73,10 @@ class GenerationInstallError(GenerationAuthorityError):
 
 class GenerationRootDivergedError(GenerationAuthorityError):
     code = "generation_root_diverged"
+
+
+class GenerationControlPublicationError(GenerationAuthorityError):
+    code = "generation_control_publication_failed"
 
 
 @dataclass(frozen=True)
@@ -429,8 +457,430 @@ def install_generation_root(
     )
 
 
+def _publication_failure() -> GenerationControlPublicationError:
+    return GenerationControlPublicationError("The generation control state could not be published.")
+
+
+def _exact_state(
+    value: object, expected_type: type[object], fields: frozenset[str]
+) -> dict[str, object]:
+    try:
+        state = object.__getattribute__(value, "__dict__")
+    except (AttributeError, TypeError):
+        state = None
+    if (
+        type(value) is not expected_type
+        or type(state) is not dict
+        or not all(type(key) is str for key in state)
+        or set(state) != fields
+    ):
+        raise _publication_failure()
+    return state
+
+
+def _rebuild_installed_root(value: object) -> InstalledGenerationRoot:
+    state = _exact_state(value, InstalledGenerationRoot, _INSTALLED_FIELDS)
+    try:
+        binding, identity = _target_parts(state["target"])
+    except GenerationProjectionVerificationError as exc:
+        raise _publication_failure() from exc
+    target = GenerationProjectionTarget(binding, identity)
+    audit_state = _exact_state(state["audit"], GenerationRootAudit, _AUDIT_FIELDS)
+    digest = audit_state["manifest_digest"]
+    count = audit_state["artifact_count"]
+    total = audit_state["byte_total"]
+    root_key = state["root_key"]
+    root_path = state["root_path"]
+    reused = state["reused"]
+    if (
+        type(digest) is not str
+        or type(count) is not int
+        or count < 0
+        or type(total) is not int
+        or total < 0
+        or type(root_key) is not str
+        or type(root_path) is not type(Path())
+        or type(reused) is not bool
+    ):
+        raise _publication_failure()
+    return InstalledGenerationRoot(
+        target, root_key, root_path, GenerationRootAudit(digest, count, total), reused
+    )
+
+
+def _derive_publication(value: object) -> tuple[InstalledGenerationRoot, Path, _GenerationLayout]:
+    installed = _rebuild_installed_root(value)
+    store_path = _validate_store_path(installed.target.binding)
+    layout = _layout(store_path, installed.target)
+    if installed.root_key != layout.root_key or installed.root_path != layout.root_path:
+        raise _publication_failure()
+    return installed, store_path, layout
+
+
+def _require_directory(store_path: Path, path: Path, *, root: bool = False) -> None:
+    _validate_managed_path(store_path, path)
+    try:
+        metadata = os.lstat(path)
+    except FileNotFoundError:
+        if root:
+            raise GenerationRootDivergedError("The generation root is missing.") from None
+        raise ReplicaControlReadError("Replica control path metadata is unavailable.") from None
+    except OSError as exc:
+        raise ReplicaControlReadError("Replica control path metadata is unavailable.") from exc
+    if _is_link_or_reparse(metadata):
+        raise ReplicaControlReadError("Replica control paths cannot contain links.")
+    if not stat.S_ISDIR(metadata.st_mode):
+        if root:
+            raise GenerationRootDivergedError(_OCCUPIED)
+        raise ReplicaControlReadError("Replica control path is not a plain directory.")
+
+
+def _validate_lock_path(store_path: Path, path: Path, *, required: bool) -> None:
+    _validate_managed_path(store_path, path)
+    try:
+        metadata = os.lstat(path)
+    except FileNotFoundError:
+        if not required:
+            return
+        raise ReplicaControlReadError("Replica control lock is unavailable.") from None
+    except OSError as exc:
+        raise ReplicaControlReadError("Replica control lock is unavailable.") from exc
+    if (
+        _is_link_or_reparse(metadata)
+        or not stat.S_ISREG(metadata.st_mode)
+        or metadata.st_nlink != 1
+    ):
+        raise ReplicaControlReadError("Replica control lock path is unsafe.")
+
+
+def _reprove_publication_paths(
+    installed: InstalledGenerationRoot,
+    store_path: Path,
+    layout: _GenerationLayout,
+    lock_path: Path,
+) -> None:
+    _validate_store_path(installed.target.binding)
+    _validate_lock_path(store_path, lock_path, required=True)
+    for directory in (
+        layout.control_root,
+        layout.actor.parent.parent,
+        layout.actor.parent,
+        layout.actor,
+        layout.generations,
+    ):
+        _require_directory(store_path, directory)
+    _require_directory(store_path, layout.root_path, root=True)
+
+
+def _read_control_file(store_path: Path, path: Path) -> bytes | None:
+    _require_directory(store_path, path.parent)
+    _validate_managed_path(store_path, path)
+    try:
+        before = os.lstat(path)
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        raise ReplicaControlReadError("Replica control file metadata is unavailable.") from exc
+    if before.st_nlink != 1:
+        raise ReplicaControlReadError("Replica control file is not a bounded regular file.")
+    content = _read_optional_file(path)
+    try:
+        after = os.lstat(path)
+    except OSError as exc:
+        raise ReplicaControlReadError("Replica control file changed during read.") from exc
+    if (
+        _is_link_or_reparse(after)
+        or not stat.S_ISREG(after.st_mode)
+        or after.st_nlink != 1
+        or (after.st_dev, after.st_ino, after.st_size)
+        != (before.st_dev, before.st_ino, before.st_size)
+    ):
+        raise ReplicaControlReadError("Replica control file changed during read.")
+    return content
+
+
+def _installed_file(path: Path, display: str) -> tuple[tuple[int, int], int]:
+    try:
+        metadata = os.lstat(path)
+    except FileNotFoundError:
+        raise GenerationInstallError(
+            f"The generation root is missing an entry: {display}."
+        ) from None
+    except OSError as exc:
+        raise GenerationInstallError(f"The generation root is unreadable: {display}.") from exc
+    if _is_link_or_reparse(metadata):
+        raise GenerationInstallError(f"The generation root holds a link: {display}.")
+    if not stat.S_ISREG(metadata.st_mode):
+        raise GenerationInstallError(f"The generation root holds an irregular entry: {display}.")
+    if metadata.st_nlink > 1:
+        raise GenerationInstallError(f"The generation root holds a linked file: {display}.")
+    return (metadata.st_dev, metadata.st_ino), metadata.st_size
+
+
+def _stream_digest(
+    path: Path,
+    identity: tuple[int, int],
+    size: int,
+    expected: str,
+    display: str,
+    mismatch: str,
+) -> int:
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(path, _READ_FLAGS)
+        opened = os.fstat(descriptor)
+        if (
+            _is_link_or_reparse(opened)
+            or not stat.S_ISREG(opened.st_mode)
+            or opened.st_nlink != 1
+            or (opened.st_dev, opened.st_ino) != identity
+            or opened.st_size != size
+        ):
+            raise GenerationInstallError(f"The generation root changed during audit: {display}.")
+        hashed, total = hashlib.sha256(), 0
+        while chunk := os.read(descriptor, 64 * 1024):
+            hashed.update(chunk)
+            total += len(chunk)
+        finished = os.fstat(descriptor)
+        if (
+            _is_link_or_reparse(finished)
+            or not stat.S_ISREG(finished.st_mode)
+            or finished.st_nlink != 1
+            or (finished.st_dev, finished.st_ino) != identity
+            or finished.st_size != size
+            or total != size
+        ):
+            raise GenerationInstallError(f"The generation root changed during audit: {display}.")
+        if hashed.hexdigest() != expected:
+            raise GenerationInstallError(mismatch)
+        return total
+    except OSError as exc:
+        raise GenerationInstallError(f"The generation root is unreadable: {display}.") from exc
+    finally:
+        if descriptor is not None:
+            with suppress(OSError):
+                os.close(descriptor)
+
+
+def _audit_installed_root(
+    store_path: Path, layout: _GenerationLayout, installed: InstalledGenerationRoot
+) -> str:
+    _require_directory(store_path, layout.root_path, root=True)
+    try:
+        manifest_path = layout.root_path / _MANIFEST_NAME
+        manifest_identity, manifest_size = _installed_file(manifest_path, _MANIFEST_NAME)
+        _stream_digest(
+            manifest_path,
+            manifest_identity,
+            manifest_size,
+            installed.target.identity.manifest_digest,
+            _MANIFEST_NAME,
+            "The generation root manifest diverges.",
+        )
+        manifest_json = _read_expected(
+            manifest_path, manifest_size, manifest_identity, _MANIFEST_NAME
+        )
+        if len(manifest_json) != manifest_size or _installed_file(
+            manifest_path, _MANIFEST_NAME
+        ) != (manifest_identity, manifest_size):
+            raise GenerationInstallError("The generation root changed during audit: manifest.json.")
+        manifest = _parse_manifest(installed.target, manifest_json)
+        files = {_MANIFEST_NAME: len(manifest_json)}
+        directories = {_STORE_DIR}
+        for artifact in manifest.artifacts:
+            relative = f"{_STORE_DIR}/{artifact}"
+            files[relative] = 0
+            parts = relative.split("/")
+            directories.update("/".join(parts[:depth]) for depth in range(1, len(parts)))
+        observed = _walk_tree(layout.root_path, files, directories)
+        if observed[_MANIFEST_NAME] != manifest_identity:
+            raise GenerationInstallError("The generation root changed during audit: manifest.json.")
+        byte_total = len(manifest_json)
+        for artifact, digest in manifest.artifacts.items():
+            relative = f"{_STORE_DIR}/{artifact}"
+            display = _escape_path_for_display(artifact)
+            identity, size = _installed_file(layout.root_path / relative, display)
+            if identity != observed[relative]:
+                raise GenerationInstallError(
+                    f"The generation root changed during audit: {display}."
+                )
+            byte_total += _stream_digest(
+                layout.root_path / relative,
+                identity,
+                size,
+                digest,
+                display,
+                f"The generation artifact diverges: {display}.",
+            )
+        audit = GenerationRootAudit(
+            installed.target.identity.manifest_digest, len(manifest.artifacts), byte_total
+        )
+    except (GenerationInstallError, GenerationProjectionVerificationError) as exc:
+        raise GenerationRootDivergedError(str(exc)) from None
+    if audit != installed.audit:
+        raise _publication_failure()
+    return manifest.committed_at
+
+
+def _expected_marker(target: GenerationProjectionTarget) -> GenerationAuthorityMarker:
+    identity = target.identity
+    return GenerationAuthorityMarker.model_validate(
+        {
+            "schema_version": 1,
+            "authority": "generation",
+            "project_id": identity.project_id,
+            "store_format_version": identity.store_format_version,
+        }
+    )
+
+
+def _require_target(
+    authority: GenerationProjectAuthority, target: GenerationProjectionTarget
+) -> None:
+    pointer, identity = authority.pointer, target.identity
+    if any(getattr(pointer, field) != getattr(identity, field) for field in _TARGET_POINTER_FIELDS):
+        raise _publication_failure()
+
+
+def _select_exact(
+    target: GenerationProjectionTarget, marker_json: bytes, pointer_json: bytes | None
+) -> GenerationProjectAuthority:
+    selected = select_project_authority(
+        target.binding,
+        marker_json=marker_json,
+        pointer_json=pointer_json,
+        active_user_id=target.identity.installed_for_user_id,
+        active_projection_scope_id=target.identity.projection_scope_id,
+    )
+    if not isinstance(selected, GenerationProjectAuthority):
+        raise _publication_failure()
+    if (
+        marker_json != selected.marker.canonical_bytes()
+        or pointer_json != selected.pointer.canonical_bytes()
+    ):
+        raise GenerationControlCorruptError("Generation control state is not canonical.")
+    _require_target(selected, target)
+    return selected
+
+
+def _read_active_marker(target: GenerationProjectionTarget, marker_json: bytes) -> None:
+    selected = _select_marker_authority(
+        target.binding,
+        marker_json=marker_json,
+        active_user_id=target.identity.installed_for_user_id,
+    )
+    if (
+        isinstance(selected, FlatProjectAuthority)
+        or marker_json != selected.marker.canonical_bytes()
+    ):
+        raise GenerationControlCorruptError("The generation authority marker is not canonical.")
+
+
+def _final_selection(
+    target: GenerationProjectionTarget,
+    store_path: Path,
+    marker_path: Path,
+    pointer_path: Path,
+    marker_bytes: bytes,
+    pointer_bytes: bytes,
+    failure: Exception | None = None,
+) -> GenerationProjectAuthority:
+    observed_marker = _read_control_file(store_path, marker_path)
+    if observed_marker is None:
+        raise _publication_failure() from failure
+    _read_active_marker(target, observed_marker)
+    observed_pointer = _read_control_file(store_path, pointer_path)
+    selected = _select_exact(target, observed_marker, observed_pointer)
+    if observed_marker != marker_bytes or observed_pointer != pointer_bytes:
+        raise _publication_failure()
+    return selected
+
+
+def publish_generation_control(
+    installed: InstalledGenerationRoot, *, timeout: float = -1
+) -> GenerationProjectAuthority:
+    initial, store_path, layout = _derive_publication(installed)
+    lock_path = store_path / _REPLICA_CONTROL_LOCK_NAME
+    _validate_lock_path(store_path, lock_path, required=False)
+    marker_path = layout.control_root / _AUTHORITY_MARKER_NAME
+    pointer_path = layout.actor / _POINTER_NAME
+    with _native_control_lock(store_path, lock_path, timeout):
+        locked, locked_store, locked_layout = _derive_publication(installed)
+        if locked != initial or locked_store != store_path or locked_layout != layout:
+            raise _publication_failure()
+        _reprove_publication_paths(locked, store_path, layout, lock_path)
+        marker_json = _read_control_file(store_path, marker_path)
+        if marker_json is not None:
+            _read_active_marker(locked.target, marker_json)
+            pointer_json = _read_control_file(store_path, pointer_path)
+            selected = _select_exact(locked.target, marker_json, pointer_json)
+            _audit_installed_root(store_path, layout, locked)
+            return selected
+
+        target = locked.target
+        identity = target.identity
+        marker = _expected_marker(target)
+        marker_bytes = marker.canonical_bytes()
+        dormant = _read_control_file(store_path, pointer_path)
+        pointer: InstalledGenerationPointer | None = None
+        if dormant is not None:
+            try:
+                pointer = _select_exact(target, marker_bytes, dormant).pointer
+            except GenerationAuthorityError:
+                pointer = None
+        committed_at = _audit_installed_root(store_path, layout, locked)
+        if pointer is None:
+            pointer = InstalledGenerationPointer.model_validate(
+                {
+                    "schema_version": 1,
+                    **{
+                        field: committed_at if field == "committed_at" else getattr(identity, field)
+                        for field in _TARGET_POINTER_FIELDS
+                    },
+                    "installed_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                    "installed_state_id": generate_ulid(),
+                }
+            )
+            pointer_bytes = pointer.canonical_bytes()
+            _require_directory(store_path, pointer_path.parent)
+            if _read_control_file(store_path, marker_path) is not None:
+                raise _publication_failure()
+            try:
+                atomic_write_bytes(pointer_path, pointer_bytes)
+            except Exception as exc:
+                raise _publication_failure() from exc
+        else:
+            pointer_bytes = pointer.canonical_bytes()
+        observed_pointer = _read_control_file(store_path, pointer_path)
+        if observed_pointer != pointer_bytes:
+            raise _publication_failure()
+        _select_exact(target, marker_bytes, observed_pointer)
+        _reprove_publication_paths(locked, store_path, layout, lock_path)
+        observed_pointer = _read_control_file(store_path, pointer_path)
+        if observed_pointer != pointer_bytes:
+            raise _publication_failure()
+        _select_exact(target, marker_bytes, observed_pointer)
+        if _read_control_file(store_path, marker_path) is not None:
+            raise _publication_failure()
+        failure = None
+        try:
+            atomic_write_bytes(marker_path, marker_bytes)
+        except Exception as exc:
+            failure = exc
+        return _final_selection(
+            target,
+            store_path,
+            marker_path,
+            pointer_path,
+            marker_bytes,
+            pointer_bytes,
+            failure,
+        )
+
+
 __all__ = (
-    "GenerationInstallError GenerationRootAudit GenerationRootDivergedError "
-    "InstalledGenerationRoot StagedGenerationRoot audit_generation_tree "
-    "install_generation_root stage_generation_root"
+    "GenerationControlPublicationError GenerationInstallError GenerationRootAudit "
+    "GenerationRootDivergedError InstalledGenerationRoot StagedGenerationRoot "
+    "audit_generation_tree install_generation_root publish_generation_control "
+    "stage_generation_root"
 ).split()

--- a/packages/nauro/src/nauro/store/generation_projection.py
+++ b/packages/nauro/src/nauro/store/generation_projection.py
@@ -26,7 +26,10 @@ _IDENTITY_FIELDS = frozenset(
     "installed_for_user_id projection_class projection_scope_id".split()
 )
 _TARGET_FIELDS = frozenset({"binding", "identity"})
-_BOUND = "project_id store_format_version generation_id projection_class projection_scope_id"
+_BOUND = (
+    "project_id store_format_version generation_id committed_at projection_class "
+    "projection_scope_id"
+)
 _BINDING_FIELDS = frozenset({"store_path", "project_id", "display_name", "mode", "server_url"})
 _BAD_TARGET = "Generation verification requires a validated projection target."
 _BAD_IDENTITY = "Generation projection targets require a validated projection identity."
@@ -181,6 +184,7 @@ class GenerationProjectionManifest(pyd.BaseModel):
     project_id: pyd.StrictStr
     store_format_version: pyd.StrictInt = pyd.Field(ge=1)
     generation_id: pyd.StrictStr
+    committed_at: pyd.StrictStr
     projection_class: Literal["viewer", "contributor_plus"]
     projection_scope_id: pyd.StrictStr
     artifacts: Mapping[pyd.StrictStr, pyd.StrictStr]
@@ -188,6 +192,7 @@ class GenerationProjectionManifest(pyd.BaseModel):
     _exact_types = pyd.field_validator("*", mode="before")(_exact)
     _validate_ulids = pyd.field_validator("project_id", "generation_id")(_ulid)
     _validate_scope = pyd.field_validator("projection_scope_id")(_digest)
+    _validate_timestamp = pyd.field_validator("committed_at")(_timestamp)
 
     @pyd.field_validator("artifacts")
     @classmethod

--- a/packages/nauro/tests/test_generation_authority.py
+++ b/packages/nauro/tests/test_generation_authority.py
@@ -109,6 +109,37 @@ def _select(
     )
 
 
+def test_control_models_emit_exact_canonical_bytes() -> None:
+    marker = GenerationAuthorityMarker.model_validate_json(_marker())
+    pointer = InstalledGenerationPointer.model_validate_json(_pointer())
+
+    marker_bytes = (
+        b'{"authority":"generation","project_id":"01KQ6AZGNA0B3QBF67NBXP3S45",'
+        b'"schema_version":1,"store_format_version":1}'
+    )
+    pointer_bytes = (
+        b'{"committed_at":"2026-09-02T01:02:03.000004Z",'
+        b'"generation_id":"01K11111111111111111111111",'
+        b'"installed_at":"2026-09-02T01:03:04.000005Z",'
+        b'"installed_for_user_id":"01K33333333333333333333333",'
+        b'"installed_state_id":"01K22222222222222222222222",'
+        b'"manifest_digest":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",'
+        b'"project_id":"01KQ6AZGNA0B3QBF67NBXP3S45",'
+        b'"projection_class":"contributor_plus",'
+        b'"projection_scope_id":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",'
+        b'"schema_version":1,"store_format_version":1}'
+    )
+
+    assert marker.canonical_bytes() == marker_bytes
+    assert pointer.canonical_bytes() == pointer_bytes
+    assert not marker_bytes.endswith(b"\n")
+    assert not pointer_bytes.endswith(b"\n")
+    selected = _select(marker_json=marker_bytes, pointer_json=pointer_bytes)
+    assert isinstance(selected, GenerationProjectAuthority)
+    assert selected.marker.canonical_bytes() == marker_bytes
+    assert selected.pointer.canonical_bytes() == pointer_bytes
+
+
 def _assert_corrupt(
     *,
     boundary: Literal["marker", "pointer"],

--- a/packages/nauro/tests/test_generation_installation.py
+++ b/packages/nauro/tests/test_generation_installation.py
@@ -10,18 +10,26 @@ import subprocess
 import sys
 import time
 from contextlib import contextmanager
-from dataclasses import FrozenInstanceError, fields
+from dataclasses import FrozenInstanceError, fields, replace
+from datetime import datetime, timezone
 from inspect import signature
 from pathlib import Path
 
 import pytest
 from filelock import FileLock
 
-from nauro.mcp.tools import tool_get_raw_file
+from nauro.mcp.tools import tool_check_decision, tool_get_raw_file
 from nauro.store import generation_installation as installation
 from nauro.store import replica_control
-from nauro.store.generation_authority import FlatProjectAuthority, GenerationAuthorityError
+from nauro.store.generation_authority import (
+    FlatProjectAuthority,
+    GenerationAuthorityError,
+    GenerationControlCorruptError,
+    GenerationProjectAuthority,
+    InstalledGenerationPointer,
+)
 from nauro.store.generation_installation import (
+    GenerationControlPublicationError,
     GenerationInstallError,
     GenerationRootAudit,
     GenerationRootDivergedError,
@@ -29,6 +37,7 @@ from nauro.store.generation_installation import (
     StagedGenerationRoot,
     audit_generation_tree,
     install_generation_root,
+    publish_generation_control,
     stage_generation_root,
 )
 from nauro.store.generation_projection import (
@@ -48,6 +57,7 @@ from nauro.store.resolution import ResolvedProjectBinding
 from nauro.sync import merge
 from nauro.sync.corpus import DecisionCorpus
 from nauro.sync.pull import PullReport
+from nauro.sync.quarantine import list_conflict_backup_files, list_quarantine_backups
 from nauro.templates.scaffolds import scaffold_project_store
 from tests.test_sync.conftest import (
     _scaffolded_cloud_project,
@@ -63,6 +73,10 @@ GENERATION_ID = "01K11111111111111111111111"
 USER_ID = "01K33333333333333333333333"
 SCOPE_ID = "a" * 64
 COMMITTED_AT = "2999-12-31T23:59:59.999999Z"
+OTHER_COMMITTED_AT = "2998-12-31T23:59:59.999999Z"
+INSTALLED_AT = "2026-09-04T01:02:03.000004Z"
+INSTALLED_STATE_ID = "01K22222222222222222222222"
+OTHER_STATE_ID = "01K44444444444444444444444"
 ROOT_KEY = "868847269e6f3c829a569ad5d6655bd5"
 CODE = "generation_install_failed"
 ACTOR = f".replica/v1/actors/{USER_ID}"
@@ -121,11 +135,16 @@ def _actor(store: Path) -> Path:
     return store / ".replica" / "v1" / "actors" / USER_ID
 
 
-def _manifest(artifacts: dict[str, bytes], scope_id: str = SCOPE_ID) -> bytes:
+def _manifest(
+    artifacts: dict[str, bytes],
+    scope_id: str = SCOPE_ID,
+    committed_at: str = COMMITTED_AT,
+) -> bytes:
     body = {
         "project_id": PROJECT_ID,
         "store_format_version": 1,
         "generation_id": GENERATION_ID,
+        "committed_at": committed_at,
         "projection_class": "contributor_plus",
         "projection_scope_id": scope_id,
         "artifacts": {path: hashlib.sha256(body).hexdigest() for path, body in artifacts.items()},
@@ -133,9 +152,11 @@ def _manifest(artifacts: dict[str, bytes], scope_id: str = SCOPE_ID) -> bytes:
     return json.dumps(body, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode()
 
 
-def _projection(artifacts: dict[str, bytes] | None = None) -> VerifiedGenerationProjection:
+def _projection(
+    artifacts: dict[str, bytes] | None = None, *, committed_at: str = COMMITTED_AT
+) -> VerifiedGenerationProjection:
     artifacts = ARTIFACTS if artifacts is None else artifacts
-    manifest = _manifest(artifacts)
+    manifest = _manifest(artifacts, committed_at=committed_at)
     binding = ResolvedProjectBinding(
         get_store_path_v2(PROJECT_ID), PROJECT_ID, "Nauro", "cloud", "https://mcp.nauro.ai"
     )
@@ -144,7 +165,7 @@ def _projection(artifacts: dict[str, bytes] | None = None) -> VerifiedGeneration
         store_format_version=1,
         generation_id=GENERATION_ID,
         manifest_digest=hashlib.sha256(manifest).hexdigest(),
-        committed_at=COMMITTED_AT,
+        committed_at=committed_at,
         installed_for_user_id=USER_ID,
         projection_class="contributor_plus",
         projection_scope_id=SCOPE_ID,
@@ -196,6 +217,67 @@ def _bytes(root: Path) -> dict[str, bytes]:
         for relative in _tree(root)
         if stat.S_ISREG(os.lstat(root / relative).st_mode)
     }
+
+
+def _control_files(store: Path) -> tuple[Path, Path]:
+    return store / ".replica" / "authority.json", _actor(store) / "pointer.json"
+
+
+def _guard_occupant(kind: str) -> None:
+    if kind in LINK_KINDS:
+        _require_link_kind(kind)
+    if sys.platform == "win32" and kind in ("dangling", "fifo", "unreadable"):
+        pytest.skip(f"{kind} is a POSIX proof")
+
+
+def _plant_occupant(path: Path, kind: str, outside: Path) -> None:
+    if kind == "missing":
+        return
+    if kind in LINK_KINDS:
+        _link(path, outside, kind)
+    elif kind == "dangling":
+        path.symlink_to(outside / "gone", target_is_directory=True)
+    elif kind == "hardlink":
+        os.link(outside / "victim", path)
+    elif kind == "directory":
+        path.mkdir()
+    elif kind == "fifo":
+        os.mkfifo(path)
+    else:
+        path.write_bytes(b"x" * (16 * 1024 + 1) if kind == "oversized" else b"occupant")
+        if kind == "unreadable":
+            path.chmod(0)
+
+
+def _fingerprint(path: Path) -> tuple[int, int, int, int] | None:
+    if not os.path.lexists(path):
+        return None
+    value = os.lstat(path)
+    return value.st_mode, value.st_ino, value.st_nlink, value.st_size
+
+
+def _pointer_bytes(projection: VerifiedGenerationProjection, **changes: object) -> bytes:
+    identity = projection.target.identity
+    body: dict[str, object] = {
+        "schema_version": 1,
+        **{field: getattr(identity, field) for field in installation._TARGET_POINTER_FIELDS},
+        "installed_at": INSTALLED_AT,
+        "installed_state_id": OTHER_STATE_ID,
+    }
+    body.update(changes)
+    return InstalledGenerationPointer(**body).canonical_bytes()
+
+
+class _FailDateTime:
+    @classmethod
+    def now(cls, _tz=None):
+        pytest.fail("publication acquired a new clock value")
+
+
+def _forbid_publication_effects(monkeypatch) -> None:
+    monkeypatch.setattr(installation, "atomic_write_bytes", lambda *_a: pytest.fail("wrote"))
+    monkeypatch.setattr(installation, "datetime", _FailDateTime)
+    monkeypatch.setattr(installation, "generate_ulid", lambda: pytest.fail("minted"))
 
 
 def _age(path: Path, seconds: float) -> None:
@@ -615,16 +697,21 @@ def _plant(store: Path, divergent: bool) -> dict[str, bytes]:
 
 def _wrap_lock(monkeypatch, before_yield, events: list[str] | None = None) -> None:
     real = installation._native_control_lock
+    calls = 0
 
     @contextmanager
     def wrapped(store_path, path, timeout):
+        nonlocal calls
+        calls += 1
+        if calls != 1:
+            pytest.fail("publication acquired a second native lock")
         with real(store_path, path, timeout):
             if events is not None:
-                events.append("lock")
+                events.append("lock-entered")
             before_yield()
             yield
         if events is not None:
-            events.append("release")
+            events.append("lock-released")
 
     monkeypatch.setattr(installation, "_native_control_lock", wrapped)
 
@@ -746,10 +833,12 @@ def test_publication_order(store: Path, monkeypatch, planted: bool) -> None:
     _wrap_lock(monkeypatch, (lambda: _plant(store, False)) if planted else (lambda: None), events)
     assert install_generation_root(_projection()).reused is planted
     if planted:
-        expected = "probe create write audit:staging lock audit:root release remove".split()
+        expected = (
+            "probe create write audit:staging lock-entered audit:root lock-released remove".split()
+        )
         assert "rename" not in events
     else:
-        expected = "probe create write audit:staging lock rename release".split()
+        expected = "probe create write audit:staging lock-entered rename lock-released".split()
         assert "remove" not in events
     positions = [events.index(kind) for kind in expected]
     assert positions == sorted(positions), events
@@ -832,7 +921,9 @@ def test_installed_root_coexists_with_legacy_surfaces(tmp_path: Path) -> None:
     assert store == get_store_path_v2(PROJECT_ID)
     (store / "context").mkdir(exist_ok=True)
     projection = _projection()
-    root = install_generation_root(projection).root_path
+    installed = install_generation_root(projection)
+    root = installed.root_path
+    authority = publish_generation_control(installed)
     before = _bytes(root)
     walked = [
         entry.raw_relative_path
@@ -850,13 +941,16 @@ def test_installed_root_coexists_with_legacy_surfaces(tmp_path: Path) -> None:
     )
     assert (report, reporter.warns) == (PullReport(merged=1), [])
     assert (store / "context" / "note.md").read_bytes() == b"note\n"
-    assert entry_names(store / ".replica") == {"v1"}
+    assert entry_names(store / ".replica") == {"authority.json", "v1"}
     assert _bytes(root) == before
     assert DecisionCorpus.scan(store).usable is True
+    assert list_conflict_backup_files(store) == []
+    assert list_quarantine_backups(store) == []
+    assert ".replica" not in json.dumps(tool_check_decision(store, "Keep project intent stable"))
     with locked_replica_control_snapshot(
         projection.target.binding, active_user_id=USER_ID, active_projection_scope_id=SCOPE_ID
     ) as snapshot:
-        assert snapshot.authority == FlatProjectAuthority(projection.target.binding)
+        assert snapshot.authority == authority
 
 
 def test_installer_is_dormant_and_private(store: Path, monkeypatch) -> None:
@@ -864,7 +958,587 @@ def test_installer_is_dormant_and_private(store: Path, monkeypatch) -> None:
     assert [item.name for item in fields(InstalledGenerationRoot)] == (
         "target root_key root_path audit reused".split()
     )
+    assert list(signature(publish_generation_control).parameters) == ["installed", "timeout"]
+    assert "locked_replica_control_snapshot" not in Path(installation.__file__).read_text()
+    for path in Path(installation.__file__).parents[2].rglob("*.py"):
+        if path != Path(installation.__file__):
+            assert "publish_generation_control(" not in path.read_text(encoding="utf-8")
     monkeypatch.setattr("nauro.sync.state.save_state", lambda *_a, **_k: pytest.fail("state"))
     installed = install_generation_root(_projection())
     with pytest.raises(FrozenInstanceError):
         installed.reused = True
+
+
+@pytest.mark.parametrize("state", ["absent", "malformed", "noncanonical", "divergent"])
+def test_control_publication_mints_after_lock_and_audit_before_ordered_writes(
+    store: Path, monkeypatch, state: str
+) -> None:
+    projection = _projection()
+    installed = install_generation_root(projection)
+    marker, pointer_path = _control_files(store)
+    if state != "absent":
+        raw = _pointer_bytes(projection)
+        if state == "malformed":
+            raw = b"{"
+        elif state == "noncanonical":
+            raw = json.dumps(json.loads(raw)).encode()
+        elif state == "divergent":
+            raw = _pointer_bytes(projection, generation_id="01K55555555555555555555555")
+        pointer_path.write_bytes(raw)
+    events: list[str] = []
+    real_audit = installation._audit_installed_root
+    real_stream = installation._stream_digest
+    real_parse = installation._parse_manifest
+    real_read = installation._read_control_file
+    real_write = installation.atomic_write_bytes
+    real_select = installation.select_project_authority
+    real_mkdir = Path.mkdir
+
+    def audit(*args):
+        result = real_audit(*args)
+        assert result == COMMITTED_AT
+        events.append("audit-complete")
+        return result
+
+    def stream(*args):
+        result = real_stream(*args)
+        if args[4] == "manifest.json":
+            events.append("manifest-digest-verified")
+        return result
+
+    def parse(*args):
+        assert events[-1] == "manifest-digest-verified"
+        result = real_parse(*args)
+        events.append("manifest-committed-at-bound")
+        return result
+
+    def read(store_path, path):
+        result = real_read(store_path, path)
+        if "marker-write" in events and path in (marker, pointer_path):
+            events.append("marker-read" if path == marker else "final-read")
+        elif path == pointer_path and "pointer-write" in events:
+            events.append("pointer-read")
+        return result
+
+    def write(path, content):
+        event = "pointer-write" if path == pointer_path else "marker-write"
+        if event == "marker-write":
+            assert "pointer-read" in events and "select" in events
+        events.append(event)
+        real_write(path, content)
+
+    def mint() -> str:
+        assert events.count("lock-entered") == 1
+        assert events.count("audit-complete") == 1
+        assert "pointer-write" not in events
+        events.append("ulid")
+        return INSTALLED_STATE_ID
+
+    def select(*args, **kwargs):
+        if "marker-write" in events:
+            events.append("final-select")
+        elif "pointer-write" in events:
+            events.append("select")
+        return real_select(*args, **kwargs)
+
+    class Clock(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            assert tz is timezone.utc
+            assert events.count("lock-entered") == 1
+            assert events.count("audit-complete") == 1
+            assert "pointer-write" not in events
+            events.append("clock")
+            return cls(2026, 9, 4, 1, 2, 3, 4, tzinfo=tz)
+
+    def mkdir(self, mode=0o777, parents=False, exist_ok=False):
+        if self in (pointer_path.parent, marker.parent) and parents:
+            metadata = os.lstat(self)
+            assert stat.S_ISDIR(metadata.st_mode) and not _is_link_or_reparse(metadata)
+            events.append("pointer-parent" if self == pointer_path.parent else "marker-parent")
+        return real_mkdir(self, mode, parents, exist_ok)
+
+    _wrap_lock(monkeypatch, lambda: None, events)
+    monkeypatch.setattr(installation, "_audit_installed_root", audit)
+    monkeypatch.setattr(installation, "_stream_digest", stream)
+    monkeypatch.setattr(installation, "_parse_manifest", parse)
+    monkeypatch.setattr(installation, "_read_control_file", read)
+    monkeypatch.setattr(installation, "atomic_write_bytes", write)
+    monkeypatch.setattr(installation, "generate_ulid", mint, raising=False)
+    monkeypatch.setattr(installation, "datetime", Clock)
+    monkeypatch.setattr(installation, "select_project_authority", select)
+    monkeypatch.setattr(Path, "mkdir", mkdir)
+    monkeypatch.setattr(
+        replica_control,
+        "locked_replica_control_snapshot",
+        lambda *_a, **_k: pytest.fail("publication nested a locked snapshot"),
+    )
+
+    authority = installation.publish_generation_control(installed)
+
+    assert (authority.pointer.installed_at, authority.pointer.installed_state_id) == (
+        INSTALLED_AT,
+        INSTALLED_STATE_ID,
+    )
+    assert events.count("lock-entered") == events.count("audit-complete") == 1
+    assert events.count("clock") == events.count("ulid") == 1
+    proof_order = "manifest-digest-verified manifest-committed-at-bound audit-complete".split()
+    assert [events.index(item) for item in proof_order] == sorted(map(events.index, proof_order))
+    assert events.index("audit-complete") < events.index("clock") < events.index("pointer-write")
+    assert events.index("audit-complete") < events.index("ulid") < events.index("pointer-write")
+    order = (
+        "pointer-write pointer-read select marker-write marker-read final-read final-select".split()
+    )
+    assert [events.index(item) for item in order] == sorted(map(events.index, order))
+    assert events.count("pointer-parent") == events.count("marker-parent") == 1
+
+
+def test_matching_dormant_pointer_is_reused_without_mint_or_rewrite(
+    store: Path, monkeypatch
+) -> None:
+    projection = _projection()
+    installed = install_generation_root(projection)
+    marker, pointer = _control_files(store)
+    dormant = _pointer_bytes(projection)
+    pointer.write_bytes(dormant)
+    real_write = installation.atomic_write_bytes
+
+    def write(path, content):
+        if path == pointer:
+            pytest.fail("pointer rewritten")
+        real_write(path, content)
+
+    events: list[str] = []
+    _wrap_lock(monkeypatch, lambda: None, events)
+    monkeypatch.setattr(installation, "atomic_write_bytes", write)
+    monkeypatch.setattr(installation, "generate_ulid", lambda: pytest.fail("minted"))
+    monkeypatch.setattr(installation, "datetime", _FailDateTime)
+    authority = publish_generation_control(installed)
+    assert (pointer.read_bytes(), marker.read_bytes()) == (
+        dormant,
+        authority.marker.canonical_bytes(),
+    )
+    assert authority.pointer.installed_state_id == OTHER_STATE_ID
+    assert events == ["lock-entered", "lock-released"]
+
+
+def test_active_repeat_reaudits_without_mint_or_write(store: Path, monkeypatch) -> None:
+    installed = install_generation_root(_projection())
+    expected = publish_generation_control(installed)
+    events: list[str] = []
+    _wrap_lock(monkeypatch, lambda: None, events)
+    _forbid_publication_effects(monkeypatch)
+    assert publish_generation_control(installed) == expected
+    assert events == ["lock-entered", "lock-released"]
+
+
+@pytest.mark.parametrize("branch", ["absent", "dormant-replacement", "active"])
+def test_changed_only_target_commit_time_fails_before_publication_effects(
+    store: Path, monkeypatch, branch: str
+) -> None:
+    projection = _projection()
+    installed = install_generation_root(projection)
+    marker, pointer = _control_files(store)
+    if branch == "dormant-replacement":
+        pointer.write_bytes(b"{")
+    elif branch == "active":
+        publish_generation_control(installed)
+        pointer.write_bytes(_pointer_bytes(projection, committed_at=OTHER_COMMITTED_AT))
+    identity = installed.target.identity.model_copy(update={"committed_at": OTHER_COMMITTED_AT})
+    target = GenerationProjectionTarget(installed.target.binding, identity)
+    forged = replace(installed, target=target)
+    before = tuple(path.read_bytes() if path.exists() else None for path in (marker, pointer))
+    _forbid_publication_effects(monkeypatch)
+
+    _diverges(
+        "The generation manifest does not match the projection target.",
+        lambda: publish_generation_control(forged),
+    )
+
+    assert (
+        tuple(path.read_bytes() if path.exists() else None for path in (marker, pointer)) == before
+    )
+
+
+def test_same_root_with_another_bound_commit_time_is_not_reused(store: Path) -> None:
+    original = install_generation_root(_projection())
+    changed = _projection(committed_at=OTHER_COMMITTED_AT)
+    assert installation._root_key(changed.target) == original.root_key
+    _diverges(
+        "The generation root manifest diverges.",
+        lambda: install_generation_root(changed),
+    )
+    assert (original.root_path / "manifest.json").read_bytes() == _projection().manifest_json
+
+
+def test_pre_binding_installed_manifest_fails_closed_without_migration(
+    store: Path, monkeypatch
+) -> None:
+    projection = _projection()
+    installed = install_generation_root(projection)
+    manifest_path = installed.root_path / "manifest.json"
+    body = json.loads(projection.manifest_json)
+    body.pop("committed_at")
+    old_manifest = json.dumps(body, sort_keys=True, separators=(",", ":")).encode()
+    manifest_path.write_bytes(old_manifest)
+    old_digest = hashlib.sha256(old_manifest).hexdigest()
+    identity = installed.target.identity.model_copy(update={"manifest_digest": old_digest})
+    target = GenerationProjectionTarget(installed.target.binding, identity)
+    audit = replace(
+        installed.audit,
+        manifest_digest=old_digest,
+        byte_total=installed.audit.byte_total - len(projection.manifest_json) + len(old_manifest),
+    )
+    forged = replace(installed, target=target, audit=audit)
+    before = _bytes(installed.root_path)
+    _forbid_publication_effects(monkeypatch)
+
+    _diverges("The generation manifest is malformed.", lambda: publish_generation_control(forged))
+
+    assert _bytes(installed.root_path) == before
+    assert all(not os.path.lexists(path) for path in _control_files(store))
+
+
+@pytest.mark.parametrize(
+    "case",
+    "root-key root-path audit-digest audit-count audit-total reused-type target-subclass "
+    "target-partial target-extra binding-malformed identity-malformed identity-stale".split(),
+)
+def test_forged_installed_root_is_rederived_or_rejected(
+    store: Path, tmp_path: Path, monkeypatch, case: str
+) -> None:
+    installed = install_generation_root(_projection())
+    completed, real_stream = [], installation._stream_digest
+
+    def stream(*args):
+        result = real_stream(*args)
+        completed.append(args[4])
+        return result
+
+    monkeypatch.setattr(installation, "_stream_digest", stream)
+    target = installed.target
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "victim").write_bytes(b"victim")
+    if case == "root-key":
+        forged = replace(installed, root_key="0" * 32)
+    elif case == "root-path":
+        forged = replace(installed, root_path=outside)
+    elif case.startswith("audit-"):
+        field = {"audit-digest": "manifest_digest", "audit-count": "artifact_count"}.get(
+            case, "byte_total"
+        )
+        value = "b" * 64 if field == "manifest_digest" else getattr(installed.audit, field) + 1
+        forged = replace(installed, audit=replace(installed.audit, **{field: value}))
+    elif case == "reused-type":
+        forged = replace(installed, reused=1)
+    else:
+        if case == "target-subclass":
+
+            class TargetSubclass(GenerationProjectionTarget):
+                pass
+
+            bad_target = object.__new__(TargetSubclass)
+        else:
+            bad_target = object.__new__(GenerationProjectionTarget)
+        if case != "target-partial":
+            binding = target.binding
+            if case == "binding-malformed":
+                binding = replace(binding, project_id=1)
+            update = {"project_id": 1} if case == "identity-malformed" else {}
+            if case == "identity-stale":
+                update = {"generation_id": "01K55555555555555555555555"}
+            identity = target.identity.model_copy(update=update)
+            object.__setattr__(bad_target, "binding", binding)
+            object.__setattr__(bad_target, "identity", identity)
+            if case == "target-extra":
+                object.__setattr__(bad_target, "extra", True)
+        forged = replace(installed, target=bad_target)
+    _forbid_publication_effects(monkeypatch)
+    with pytest.raises(GenerationControlPublicationError) as raised:
+        publish_generation_control(forged)
+    assert raised.value.code == "generation_control_publication_failed"
+    assert _control_files(store)[0].exists() is False
+    assert (outside / "victim").read_bytes() == b"victim"
+    if case.startswith("audit-"):
+        assert completed == ["manifest.json", *sorted(ARTIFACTS)]
+
+
+def test_valid_reused_flag_is_irrelevant(tmp_path: Path, monkeypatch) -> None:
+    fixed = datetime.fromisoformat(INSTALLED_AT.replace("Z", "+00:00"))
+    real_read, real_write = installation._read_control_file, installation.atomic_write_bytes
+
+    def run(reused: bool):
+        monkeypatch.setenv("NAURO_HOME", str(tmp_path / str(reused)))
+        monkeypatch.setattr(installation, "atomic_write_bytes", real_write)
+        local_store, projection = get_store_path_v2(PROJECT_ID), _projection()
+        scaffold_project_store("nauro", local_store)
+        installed = install_generation_root(projection)
+        installed = install_generation_root(projection) if reused else installed
+        assert installed.reused is reused
+        seen = []
+        clock = type("Clock", (), {"now": classmethod(lambda *_a: seen.append("clock") or fixed)})
+        ids = iter([INSTALLED_STATE_ID])
+        monkeypatch.setattr(installation, "datetime", clock)
+        monkeypatch.setattr(installation, "generate_ulid", lambda: seen.append("ulid") or next(ids))
+
+        def read(store_path, path):
+            seen.append(("read", path.relative_to(local_store).as_posix()))
+            return real_read(store_path, path)
+
+        def write(path, content):
+            seen.append(("write", path.relative_to(local_store).as_posix()))
+            real_write(path, content)
+
+        monkeypatch.setattr(installation, "_read_control_file", read)
+        monkeypatch.setattr(installation, "atomic_write_bytes", write)
+        authority = publish_generation_control(installed)
+        control = tuple(path.read_bytes() for path in _control_files(local_store))
+        expected = authority.marker.canonical_bytes(), authority.pointer.canonical_bytes()
+        assert control == expected
+        assert control[1] == _pointer_bytes(projection, installed_state_id=INSTALLED_STATE_ID)
+        return control, seen, type(authority)
+
+    assert run(False) == run(True)
+
+
+def test_installed_proof_changed_while_waiting_is_rejected(store: Path, monkeypatch) -> None:
+    installed = install_generation_root(_projection())
+    _wrap_lock(monkeypatch, lambda: object.__setattr__(installed, "root_key", "0" * 32))
+    _forbid_publication_effects(monkeypatch)
+    with pytest.raises(GenerationControlPublicationError):
+        publish_generation_control(installed)
+    assert _control_files(store)[0].exists() is False
+
+
+def test_control_publication_refuses_a_busy_native_lock(store: Path) -> None:
+    installed = install_generation_root(_projection())
+    with FileLock(str(store / LOCK_NAME)):
+        with pytest.raises(ReplicaControlBusyError) as raised:
+            publish_generation_control(installed, timeout=0.1)
+    assert raised.value.code == "generation_control_busy"
+    assert all(not os.path.lexists(path) for path in _control_files(store))
+
+
+@pytest.mark.parametrize("timing", ["before", "locked"])
+@pytest.mark.parametrize("boundary", ["lock", "pointer", "marker"])
+@pytest.mark.parametrize(
+    "kind",
+    "symlink dangling junction hardlink directory fifo oversized unreadable".split(),
+)
+def test_control_publication_preserves_unsafe_control_occupants(
+    store: Path, tmp_path: Path, monkeypatch, boundary: str, kind: str, timing: str
+) -> None:
+    if boundary == "lock" and timing == "locked":
+        pytest.skip("leaf timing applies to pointer and marker")
+    if boundary == "lock" and kind in {"dangling", "fifo", "oversized"}:
+        pytest.skip("not a lock occupant row")
+    _guard_occupant(kind)
+    projection = _projection()
+    installed = install_generation_root(projection)
+    marker, pointer = _control_files(store)
+    path = {"lock": store / LOCK_NAME, "pointer": pointer, "marker": marker}[boundary]
+    if boundary == "lock":
+        path.unlink()
+    if boundary == "marker":
+        pointer.write_bytes(b"keep")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "victim").write_bytes(b"victim")
+    planted = []
+
+    def plant() -> None:
+        _plant_occupant(path, kind, outside)
+        planted.append(_fingerprint(path))
+
+    plant() if timing == "before" else _wrap_lock(monkeypatch, plant)
+    _forbid_publication_effects(monkeypatch)
+    with pytest.raises(ReplicaControlReadError) as raised:
+        publish_generation_control(installed)
+    assert raised.value.code == "generation_control_unavailable"
+    assert _fingerprint(path) == planted[0]
+    assert (outside / "victim").read_bytes() == b"victim"
+    if boundary == "marker":
+        assert pointer.read_bytes() == b"keep"
+    else:
+        assert not os.path.lexists(marker)
+
+
+@pytest.mark.parametrize("timing", ["before", "locked"])
+@pytest.mark.parametrize("kind", ["missing", "file", "symlink", "junction", "fifo"])
+@pytest.mark.parametrize(
+    "boundary",
+    "store control version actors actor generations root pointer-parent marker-parent".split(),
+)
+def test_control_publication_refuses_path_substitution(
+    store: Path, tmp_path: Path, monkeypatch, boundary: str, kind: str, timing: str
+) -> None:
+    _guard_occupant(kind)
+    if sys.platform == "win32" and timing == "locked" and boundary == "store":
+        pytest.skip("Windows holds the lock path open")
+    projection = _projection()
+    installed = install_generation_root(projection)
+    marker, pointer = _control_files(store)
+    pointer.write_bytes(_pointer_bytes(projection))
+    actor = _actor(store)
+    path = {
+        "store": store,
+        "control": store / ".replica",
+        "version": store / ".replica" / "v1",
+        "actors": actor.parent,
+        "actor": actor,
+        "generations": actor / "generations",
+        "root": installed.root_path,
+        "pointer-parent": pointer.parent,
+        "marker-parent": marker.parent,
+    }[boundary]
+    backup = tmp_path / "original"
+    saved_pointer = backup / pointer.relative_to(path) if pointer.is_relative_to(path) else pointer
+    saved_marker = backup / marker.relative_to(path) if marker.is_relative_to(path) else marker
+
+    def substitute() -> None:
+        path.rename(backup)
+        (backup / "victim").write_bytes(b"victim")
+        _plant_occupant(path, kind, backup)
+
+    if timing == "before":
+        substitute()
+    else:
+        _wrap_lock(monkeypatch, substitute)
+    _forbid_publication_effects(monkeypatch)
+    with pytest.raises((ReplicaControlReadError, GenerationRootDivergedError)) as raised:
+        publish_generation_control(installed)
+    root_occupant = boundary == "root" and kind in {"missing", "file", "fifo"}
+    assert raised.value.code == (DIVERGED if root_occupant else "generation_control_unavailable")
+    assert _fingerprint(path) is None if kind == "missing" else _fingerprint(path) is not None
+    assert saved_pointer.read_bytes() == _pointer_bytes(projection)
+    assert not os.path.lexists(saved_marker)
+    assert (backup / "victim").read_bytes() == b"victim"
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("project_id", "01K00000000000000000000000"),
+        ("store_format_version", 2),
+        ("generation_id", "01K55555555555555555555555"),
+        ("manifest_digest", "b" * 64),
+        ("committed_at", "2998-12-31T23:59:59.999999Z"),
+        ("installed_for_user_id", "01K44444444444444444444444"),
+        ("projection_class", "viewer"),
+        ("projection_scope_id", "b" * 64),
+    ],
+)
+def test_active_target_mismatch_never_mutates(
+    store: Path, monkeypatch, field: str, value: object
+) -> None:
+    projection = _projection()
+    installed = install_generation_root(projection)
+    publish_generation_control(installed)
+    marker, pointer = _control_files(store)
+    pointer.write_bytes(_pointer_bytes(projection, **{field: value}))
+    before = marker.read_bytes(), pointer.read_bytes()
+    monkeypatch.setattr(installation, "atomic_write_bytes", lambda *_a: pytest.fail("wrote"))
+    with pytest.raises(GenerationAuthorityError):
+        publish_generation_control(installed)
+    assert (marker.read_bytes(), pointer.read_bytes()) == before
+
+
+@pytest.mark.parametrize(
+    "state", ["ptr-none", "ptr-bad", "ptr-spaced", "marker-bad", "marker-spaced", "marker-v2"]
+)
+def test_active_incomplete_or_noncanonical_state_fails_closed(
+    store: Path, monkeypatch, state: str
+) -> None:
+    projection = _projection()
+    installed = install_generation_root(projection)
+    authority = publish_generation_control(installed)
+    marker, pointer = _control_files(store)
+    if state == "ptr-none":
+        pointer.unlink()
+    elif state == "ptr-bad":
+        pointer.write_bytes(b"{")
+    elif state == "ptr-spaced":
+        pointer.write_bytes(json.dumps(authority.pointer.model_dump()).encode())
+    elif state == "marker-bad":
+        marker.write_bytes(b"{")
+    elif state == "marker-spaced":
+        marker.write_bytes(json.dumps(authority.marker.model_dump()).encode())
+    else:
+        body = authority.marker.model_dump()
+        body["store_format_version"] = 2
+        marker.write_bytes(json.dumps(body, separators=(",", ":")).encode())
+    before = (marker.read_bytes(), pointer.read_bytes() if pointer.exists() else None)
+    monkeypatch.setattr(installation, "atomic_write_bytes", lambda *_a: pytest.fail("wrote"))
+    with pytest.raises(GenerationAuthorityError):
+        publish_generation_control(installed)
+    assert (marker.read_bytes(), pointer.read_bytes() if pointer.exists() else None) == before
+
+
+@pytest.mark.parametrize("branch", ["absent", "dormant", "active"])
+@pytest.mark.parametrize(("mutation", "message"), AUDIT_ROWS)
+def test_control_publication_reaudits_every_installed_byte(
+    store, tmp_path, monkeypatch, mutation, message, branch
+) -> None:
+    projection = _projection()
+    installed = install_generation_root(projection)
+    marker, pointer = _control_files(store)
+    if branch == "dormant":
+        pointer.write_bytes(_pointer_bytes(projection))
+    elif branch == "active":
+        publish_generation_control(installed)
+    before = tuple(path.read_bytes() if path.exists() else None for path in (marker, pointer))
+    if mutation in LINK_KINDS:
+        _require_link_kind(mutation)
+    _mutate(installed.root_path, mutation, projection, tmp_path, monkeypatch)
+    _forbid_publication_effects(monkeypatch)
+    _diverges(message, lambda: publish_generation_control(installed))
+    assert (
+        tuple(path.read_bytes() if path.exists() else None for path in (marker, pointer)) == before
+    )
+
+
+@pytest.mark.parametrize(
+    "outcome", ["pointer-fails", "marker-fails", "marker-landed", "marker-corrupt"]
+)
+def test_control_publication_resolves_crash_visible_boundaries(
+    store: Path, monkeypatch, outcome: str
+) -> None:
+    projection = _projection()
+    installed = install_generation_root(projection)
+    marker, pointer = _control_files(store)
+    real_write = installation.atomic_write_bytes
+
+    def write(path, content):
+        if path == pointer and outcome == "pointer-fails":
+            raise OSError("pointer outcome")
+        if path == marker:
+            if outcome == "marker-fails":
+                raise OSError("marker outcome")
+            if outcome == "marker-corrupt":
+                path.write_bytes(b"{")
+                raise OSError("marker outcome")
+            if outcome == "marker-landed":
+                real_write(path, content)
+                raise OSError("marker outcome")
+        real_write(path, content)
+
+    monkeypatch.setattr(installation, "atomic_write_bytes", write)
+    if outcome == "marker-landed":
+        assert isinstance(publish_generation_control(installed), GenerationProjectAuthority)
+    else:
+        expected = (
+            GenerationControlCorruptError
+            if outcome == "marker-corrupt"
+            else GenerationControlPublicationError
+        )
+        with pytest.raises(expected):
+            publish_generation_control(installed)
+    if outcome in ("pointer-fails", "marker-fails"):
+        assert marker.exists() is False
+        with locked_replica_control_snapshot(
+            projection.target.binding,
+            active_user_id=USER_ID,
+            active_projection_scope_id=SCOPE_ID,
+        ) as snapshot:
+            assert isinstance(snapshot.authority, FlatProjectAuthority)

--- a/packages/nauro/tests/test_generation_projection.py
+++ b/packages/nauro/tests/test_generation_projection.py
@@ -85,7 +85,8 @@ def _identity_values(raw: bytes, **changes: object) -> dict[str, object]:
 def _manifest_object(**changes: object) -> dict[str, object]:
     body: dict[str, object] = {
         "project_id": PROJECT_ID, "store_format_version": 1,
-        "generation_id": GENERATION_ID, "projection_class": "contributor_plus",
+        "generation_id": GENERATION_ID, "committed_at": COMMITTED_AT,
+        "projection_class": "contributor_plus",
         "projection_scope_id": SCOPE_ID,
         "artifacts": {"project.md": hashlib.sha256(CONTENT).hexdigest()},
     }
@@ -133,7 +134,7 @@ def test_exact_public_fields_and_valid_target_bound_projection() -> None:
         "installed_for_user_id projection_class projection_scope_id".split()
     )
     assert set(GenerationProjectionManifest.model_fields) == set(
-        "project_id store_format_version generation_id projection_class "
+        "project_id store_format_version generation_id committed_at projection_class "
         "projection_scope_id artifacts".split()
     )
     assert [item.name for item in fields(GenerationProjectionTarget)] == ["binding", "identity"]
@@ -142,6 +143,7 @@ def test_exact_public_fields_and_valid_target_bound_projection() -> None:
         PROJECT_ID,
         GENERATION_ID,
     )
+    assert proof.manifest.committed_at == COMMITTED_AT
 
 
 # fmt: off
@@ -342,7 +344,8 @@ def test_invalid_path_and_lone_surrogate_fail_as_malformed_manifest() -> None:
 
 @pytest.mark.parametrize("changes", [
     {"project_id": OTHER_PROJECT_ID}, {"store_format_version": 2},
-    {"generation_id": "01K22222222222222222222222"}, {"projection_class": "viewer"},
+    {"generation_id": "01K22222222222222222222222"},
+    {"committed_at": "2998-12-31T23:59:59.999999Z"}, {"projection_class": "viewer"},
     {"projection_scope_id": "b" * 64},
 ])
 def test_envelope_must_match_target(changes: dict[str, object]) -> None:
@@ -367,6 +370,8 @@ def test_d501_role_seam_precedes_artifact_handling() -> None:
 
 @pytest.mark.parametrize("changes", [
     {"project_id": False}, {"store_format_version": False}, {"projection_class": False},
+    {"committed_at": False}, {"committed_at": "2026-09-02T01:02:03Z"},
+    {"committed_at": StrSub(COMMITTED_AT)},
     {"artifacts": []}, {"artifacts": type("DictSubclass", (dict,), {})({"project.md": "b" * 64})},
     {"artifacts": {StrSub("project.md"): "b" * 64}},
     {"artifacts": {"project.md": StrSub("b" * 64)}}, {"snapshot_digest": "b" * 64},

--- a/packages/nauro/tests/test_sync/test_generation_acquisition.py
+++ b/packages/nauro/tests/test_sync/test_generation_acquisition.py
@@ -40,12 +40,13 @@ GOLDEN_ARTIFACTS = {"project.md": b"# Project\n"}
 GOLDEN_ENVELOPE = (
     b'{"artifacts":{"project.md":'
     b'"aef277fb6a70a89681a85e1b6d23f44ee2a6cc58490f9f5c95fc99db6d2d3542"},'
+    b'"committed_at":"2999-12-31T23:59:59.999999Z",'
     b'"generation_id":"01K11111111111111111111111",'
     b'"project_id":"01KQ6AZGNA0B3QBF67NBXP3S45",'
     b'"projection_class":"contributor_plus",'
     b'"projection_scope_id":"' + b"a" * 64 + b'","store_format_version":1}'
 )
-GOLDEN_DIGEST = "32c59ab83e93cb28ea902441e86ce4ae125091ab79328d563a5a7f0eab0be967"
+GOLDEN_DIGEST = "94f488a870f6549bea395828dc077a46023cd8fc36667e4f4c65ce0d471298cd"
 THREE_ARTIFACTS = {"state.md": b"# State\n", "project.md": b"# Project\n", SIDECAR: b"{}"}
 BINDING = ResolvedProjectBinding(Path("store"), PROJECT_ID, "Nauro", "cloud", "https://api.test")
 LOCAL_BINDING = ResolvedProjectBinding(Path("store"), PROJECT_ID, "Nauro", "local", None)
@@ -78,6 +79,7 @@ class FakeServer:
         self.artifacts = dict(GOLDEN_ARTIFACTS if artifacts is None else artifacts)
         self.projection_class = projection_class
         self.generation_id = GENERATION_ID
+        self.manifest_committed_at: str | None = COMMITTED_AT
         self.identity_override: dict[str, object] = {}
         self.projection_hook = self.presign_hook = self.object_hook = None
         self.requests: list[tuple[str, str, object, str | None]] = []
@@ -90,6 +92,7 @@ class FakeServer:
             "project_id": PROJECT_ID,
             "store_format_version": 1,
             "generation_id": self.generation_id,
+            "committed_at": self.manifest_committed_at,
             "projection_class": self.projection_class,
             "projection_scope_id": SCOPE_ID,
             "artifacts": {
@@ -97,6 +100,8 @@ class FakeServer:
                 for path, content in self.artifacts.items()
             },
         }
+        if self.manifest_committed_at is None:
+            body.pop("committed_at")
         text = json.dumps(body, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
         return text.encode("utf-8")
 
@@ -190,11 +195,29 @@ def test_happy_path_orders_projection_presign_then_sorted_gets() -> None:
 
 def test_golden_envelope_bytes_and_digest_are_pinned() -> None:
     server = FakeServer()
-    assert server.envelope() == GOLDEN_ENVELOPE and len(GOLDEN_ENVELOPE) == 334
+    assert server.envelope() == GOLDEN_ENVELOPE and len(GOLDEN_ENVELOPE) == 379
     assert hashlib.sha256(GOLDEN_ENVELOPE).hexdigest() == GOLDEN_DIGEST
     proof = acquire(server)
     assert proof.manifest_json == GOLDEN_ENVELOPE
     assert proof.target.identity.manifest_digest == GOLDEN_DIGEST
+
+
+@pytest.mark.parametrize(
+    "manifest_committed_at",
+    [None, "2998-12-31T23:59:59.999999Z"],
+    ids=["current-six-field-server", "divergent-time"],
+)
+def test_manifest_commit_time_is_bound_before_presign(manifest_committed_at) -> None:
+    server = FakeServer()
+    server.manifest_committed_at = manifest_committed_at
+    if manifest_committed_at is None:
+        assert len(server.envelope()) == 334
+        assert hashlib.sha256(server.envelope()).hexdigest() == (
+            "32c59ab83e93cb28ea902441e86ce4ae125091ab79328d563a5a7f0eab0be967"
+        )
+    with pytest.raises(GenerationProjectionVerificationError):
+        acquire(server)
+    assert server.calls() == [PROJECTION]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Why

The client could install a verified immutable generation root, but it had no local transaction that established actor-bound generation authority without exposing an incomplete crash state. The installed manifest also did not bind the server commit time, so a forged caller-carried timestamp could reach the authoritative pointer.

## What changed

- Bind `committed_at` in the strict canonical generation manifest and verify it against the projection identity before presign or artifact download.
- Reaudit the complete installed generation under the native control lock and source the pointer commit time from the digest-covered manifest.
- Establish the complete actor pointer before creating the immutable authority marker.
- Reuse matching dormant and active state without reminting. Replace only a bounded malformed, noncanonical, or divergent dormant pointer while the marker is absent. Refuse unsafe occupants and every active mismatch without mutation.
- Keep the writer dormant. No CLI, MCP, sync, read, write, deployment, or release caller is added.

## Test plan

- `uv run --no-sync --package nauro pytest packages/nauro/tests/test_generation_projection.py packages/nauro/tests/test_sync/test_generation_acquisition.py packages/nauro/tests/test_generation_installation.py packages/nauro/tests/test_generation_authority.py -v --tb=short`
- `uv run --no-sync --package nauro pytest packages/nauro/tests/test_generation_installation.py packages/nauro/tests/test_generation_authority.py packages/nauro/tests/test_generation_projection.py packages/nauro/tests/test_replica_control.py packages/nauro/tests/test_atomic.py packages/nauro/tests/test_sync/test_generation_acquisition.py packages/nauro/tests/test_sync/test_replica_control_excluded.py packages/nauro/tests/test_sync/test_push_admission.py packages/nauro/tests/test_sync/test_pull_admission.py packages/nauro/tests/test_sync/test_read_admission.py packages/nauro/tests/test_sync/test_restore_admission.py -v --tb=short`
- `uv run --no-sync --package nauro pytest packages/nauro/tests/ --ignore=packages/nauro/tests/cross_surface -v --tb=short`
- Ruff check and format check
- Mypy on the changed source modules
- Single-source, docstring-budget, and server-version guards

## Risk / what to review

The manifest change is intentionally breaking while this path remains dormant. The current six-field server envelope fails before presign, and pre-change installed manifests fail closed. A separate compatible server update is required before staging, deployment, cutover, or release.

Atomic replacement prevents partial-file observation. It does not prove file or directory fsync ordering across power loss. Windows junction and reparse behavior remains subject to the platform CI jobs.

## Deferred

Pointer-selected reads, refresh and full-pointer compare-and-swap, authority-routed writes, server envelope compatibility, leases, cleanup, legacy-root migration, deployment, release, cutover, and activation remain separate work.
