### PR TITLE
Add installed authorization view contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
       - run: uv sync --locked --package nauro --all-extras --python 3.12
       - run: >-
           uv run --no-sync --package nauro pytest
+          packages/nauro/tests/test_auth.py
           packages/nauro/tests/test_generation_authority.py
           packages/nauro/tests/test_generation_installation.py
           packages/nauro/tests/test_replica_control.py

--- a/packages/nauro/src/nauro/auth.py
+++ b/packages/nauro/src/nauro/auth.py
@@ -18,14 +18,18 @@ from __future__ import annotations
 import base64
 import json
 import os
+import stat
 import threading
 import time
 from collections.abc import Callable, Mapping
+from contextlib import suppress
 
 import filelock
 import httpx
+from nauro_core.identifiers import IdentifierKind, validate_identifier
 
 from nauro.store.config import _config_lock, config_transaction, load_config
+from nauro.store.home import config_file
 
 # Public OAuth identifiers — safe to ship; not secrets. Do not strip.
 DEFAULT_AUTH0_DOMAIN = "dev-q1kuoa1a154u26iw.us.auth0.com"
@@ -42,6 +46,10 @@ class AuthRefreshError(Exception):
     """Raised when an Auth0 refresh-token exchange fails."""
 
 
+class ActiveUserReadError(ValueError):
+    code = "auth_state_unavailable"
+
+
 RATE_LIMITED_MESSAGE = (
     "Auth0 is rate-limiting logins right now. Wait a few seconds and re-run 'nauro auth login'."
 )
@@ -51,6 +59,13 @@ RATE_LIMITED_MESSAGE = (
 _RETRY_AFTER_CEILING_SECONDS = 10.0
 # Fixed backoff per attempt when Retry-After is absent or unparseable.
 _DEFAULT_BACKOFF_SECONDS = (1.0, 2.0)
+_MAX_ACTIVE_AUTH_BYTES = 64 * 1024
+_ACTIVE_AUTH_READ_FLAGS = sum(
+    getattr(os, name, 0)
+    for name in ("O_RDONLY", "O_CLOEXEC", "O_BINARY", "O_NOFOLLOW", "O_NONBLOCK")
+)
+_NO_ACTIVE_ACCOUNT = "No active account is available."
+_AUTH_STATE_UNAVAILABLE = "The active authentication state is unavailable."
 
 
 def _retry_after_seconds(response: httpx.Response, attempt: int) -> float:
@@ -120,6 +135,90 @@ def resolve_auth_config(
         or DEFAULT_AUTH0_AUDIENCE
     )
     return domain, client_id, api_url, audience
+
+
+def _auth_file_state(metadata: os.stat_result) -> tuple[int, int, int, int, int, bool]:
+    attributes = getattr(metadata, "st_file_attributes", 0)
+    reparse = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+    if stat.S_ISLNK(metadata.st_mode) or bool(attributes & reparse):
+        return 0, 0, 0, 0, 0, True
+    return (
+        stat.S_IFMT(metadata.st_mode),
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_size,
+        metadata.st_nlink,
+        False,
+    )
+
+
+def _read_active_config() -> bytes:
+    path = config_file()
+    try:
+        observed = os.lstat(path)
+    except FileNotFoundError:
+        raise ActiveUserReadError(_NO_ACTIVE_ACCOUNT) from None
+    except OSError as exc:
+        raise ActiveUserReadError(_AUTH_STATE_UNAVAILABLE) from exc
+    state = _auth_file_state(observed)
+    if state[0] != stat.S_IFREG or state[3] > _MAX_ACTIVE_AUTH_BYTES or state[4] != 1 or state[5]:
+        raise ActiveUserReadError(_AUTH_STATE_UNAVAILABLE)
+
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(path, _ACTIVE_AUTH_READ_FLAGS)
+        if _auth_file_state(os.fstat(descriptor)) != state:
+            raise ActiveUserReadError(_AUTH_STATE_UNAVAILABLE)
+        content = bytearray()
+        while len(content) <= _MAX_ACTIVE_AUTH_BYTES:
+            chunk = os.read(descriptor, min(8192, _MAX_ACTIVE_AUTH_BYTES + 1 - len(content)))
+            if not chunk:
+                break
+            content.extend(chunk)
+        if _auth_file_state(os.fstat(descriptor)) != state or len(content) != state[3]:
+            raise ActiveUserReadError(_AUTH_STATE_UNAVAILABLE)
+        try:
+            final = os.lstat(path)
+        except OSError as exc:
+            raise ActiveUserReadError(_AUTH_STATE_UNAVAILABLE) from exc
+        if _auth_file_state(final) != state:
+            raise ActiveUserReadError(_AUTH_STATE_UNAVAILABLE)
+        return bytes(content)
+    except OSError as exc:
+        raise ActiveUserReadError(_AUTH_STATE_UNAVAILABLE) from exc
+    finally:
+        if descriptor is not None:
+            with suppress(OSError):
+                os.close(descriptor)
+
+
+def read_active_user_id() -> str:
+    raw = _read_active_config()
+
+    def object_from_pairs(pairs: list[tuple[str, object]]) -> dict[str, object]:
+        result = dict(pairs)
+        if len(result) != len(pairs):
+            raise ValueError("duplicate JSON object key")
+        return result
+
+    try:
+        text = raw.decode("utf-8")
+        if text.startswith("\ufeff"):
+            raise ValueError("JSON byte order marks are not allowed")
+        config = json.loads(
+            text,
+            object_pairs_hook=object_from_pairs,
+            parse_constant=lambda _value: (_ for _ in ()).throw(ValueError()),
+        )
+        if type(config) is not dict or type(config.get("auth")) is not dict:
+            raise ValueError("invalid authentication state")
+        auth = config["auth"]
+        token, user_id = auth.get("access_token"), auth.get("user_id")
+        if type(token) is not str or not token or type(user_id) is not str or not user_id:
+            raise ValueError("invalid authentication state")
+        return validate_identifier(IdentifierKind.ulid, user_id, field="auth.user_id")
+    except (UnicodeError, json.JSONDecodeError, ValueError, TypeError, RecursionError) as exc:
+        raise ActiveUserReadError(_NO_ACTIVE_ACCOUNT) from exc
 
 
 def load_access_token() -> str | None:

--- a/packages/nauro/src/nauro/store/generation_authority.py
+++ b/packages/nauro/src/nauro/store/generation_authority.py
@@ -136,6 +136,45 @@ class InstalledGenerationPointer(pyd.BaseModel):
         return _canonical_control_bytes(self)
 
 
+class InstalledAuthorizationView(pyd.BaseModel):
+    """The authenticated authorization view installed beside a generation pointer."""
+
+    model_config = _STRICT_MODEL_CONFIG
+
+    schema_version: pyd.StrictInt
+    project_id: pyd.StrictStr
+    store_format_version: pyd.StrictInt = pyd.Field(ge=1)
+    generation_id: pyd.StrictStr
+    manifest_digest: pyd.StrictStr
+    committed_at: pyd.StrictStr
+    installed_state_id: pyd.StrictStr
+    installed_for_user_id: pyd.StrictStr
+    projection_class: Literal["viewer", "contributor_plus"]
+    projection_scope_id: pyd.StrictStr
+
+    _validate_ulids = pyd.field_validator(
+        "project_id",
+        "generation_id",
+        "installed_state_id",
+        "installed_for_user_id",
+    )(_ulid)
+    _validate_digests = pyd.field_validator(
+        "manifest_digest",
+        "projection_scope_id",
+    )(_sha256)
+    _validate_timestamp = pyd.field_validator("committed_at")(_timestamp)
+
+    @pyd.field_validator("schema_version")
+    @classmethod
+    def _supported_schema(cls, value: int) -> int:
+        if value != _CONTROL_SCHEMA_VERSION:
+            raise ValueError("unsupported authorization view schema")
+        return value
+
+    def canonical_bytes(self) -> bytes:
+        return _canonical_control_bytes(self)
+
+
 @dataclass(frozen=True)
 class FlatProjectAuthority:
     """A local-only or pre-epoch hosted flat store."""
@@ -208,6 +247,20 @@ def _parse_pointer(raw: str | bytes) -> InstalledGenerationPointer:
         return InstalledGenerationPointer.model_validate_json(raw)
     except (pyd.ValidationError, ValueError, TypeError, RecursionError) as exc:
         raise GenerationControlCorruptError("The installed generation pointer is invalid.") from exc
+
+
+def _parse_authorization_view(raw: str | bytes) -> InstalledAuthorizationView:
+    if type(raw) not in (str, bytes):
+        raise GenerationControlCorruptError("The installed authorization view is invalid.")
+    try:
+        _strict_json_preflight(raw)
+        view = InstalledAuthorizationView.model_validate_json(raw)
+        encoded = raw if isinstance(raw, bytes) else raw.encode("utf-8")
+        if encoded != view.canonical_bytes():
+            raise ValueError("authorization view bytes are not canonical")
+        return view
+    except (pyd.ValidationError, ValueError, TypeError, RecursionError) as exc:
+        raise GenerationControlCorruptError("The installed authorization view is invalid.") from exc
 
 
 def _active_user_id(value: str | None) -> str:
@@ -313,6 +366,7 @@ __all__ = [
     "GenerationAuthorityMarker",
     "GenerationControlCorruptError",
     "GenerationProjectAuthority",
+    "InstalledAuthorizationView",
     "InstalledGenerationPointer",
     "ProjectAuthority",
     "RefreshRequiredError",

--- a/packages/nauro/src/nauro/store/replica_control.py
+++ b/packages/nauro/src/nauro/store/replica_control.py
@@ -18,7 +18,9 @@ from nauro_core.constants import HOSTED_STORE_FORMAT_VERSION
 from nauro.store.generation_authority import (
     FlatProjectAuthority,
     GenerationAuthorityError,
+    InstalledAuthorizationView,
     ProjectAuthority,
+    _parse_authorization_view,
     _PendingGenerationAuthority,
     _select_generation_pointer,
     _select_marker_authority,
@@ -69,6 +71,11 @@ class ReplicaControlSnapshot:
 def _actor_pointer(control_root: Path, pending: _PendingGenerationAuthority) -> Path:
     version = f"v{HOSTED_STORE_FORMAT_VERSION}"
     return control_root / version / "actors" / pending.active_user_id / "pointer.json"
+
+
+def _actor_authorization_view(control_root: Path, pending: _PendingGenerationAuthority) -> Path:
+    version = f"v{pending.marker.store_format_version}"
+    return control_root / version / "actors" / pending.active_user_id / "authorization-view.json"
 
 
 def _is_link_or_reparse(metadata: Any) -> bool:
@@ -131,6 +138,7 @@ def _read_optional_file(path: Path) -> bytes | None:
     if (
         _is_link_or_reparse(observed)
         or not stat.S_ISREG(observed.st_mode)
+        or observed.st_nlink != 1
         or observed.st_size > _MAX_CONTROL_FILE_BYTES
     ):
         raise ReplicaControlReadError("Replica control file is not a bounded regular file.")
@@ -142,7 +150,9 @@ def _read_optional_file(path: Path) -> bytes | None:
         if (
             _is_link_or_reparse(opened)
             or not stat.S_ISREG(opened.st_mode)
+            or opened.st_nlink != 1
             or (opened.st_dev, opened.st_ino) != (observed.st_dev, observed.st_ino)
+            or opened.st_size != observed.st_size
             or opened.st_size > _MAX_CONTROL_FILE_BYTES
         ):
             raise ReplicaControlReadError("Replica control file changed during open.")
@@ -151,10 +161,23 @@ def _read_optional_file(path: Path) -> bytes | None:
         if (
             _is_link_or_reparse(finished)
             or not stat.S_ISREG(finished.st_mode)
+            or finished.st_nlink != 1
             or len(content) > _MAX_CONTROL_FILE_BYTES
             or (finished.st_dev, finished.st_ino) != (opened.st_dev, opened.st_ino)
             or finished.st_size != opened.st_size
             or len(content) != finished.st_size
+        ):
+            raise ReplicaControlReadError("Replica control file changed during read.")
+        try:
+            final = os.lstat(path)
+        except OSError as exc:
+            raise ReplicaControlReadError("Replica control file changed during read.") from exc
+        if (
+            _is_link_or_reparse(final)
+            or not stat.S_ISREG(final.st_mode)
+            or final.st_nlink != 1
+            or (final.st_dev, final.st_ino, final.st_size)
+            != (observed.st_dev, observed.st_ino, observed.st_size)
         ):
             raise ReplicaControlReadError("Replica control file changed during read.")
         return content
@@ -164,6 +187,19 @@ def _read_optional_file(path: Path) -> bytes | None:
         if descriptor is not None:
             with suppress(OSError):
                 os.close(descriptor)
+
+
+def _read_actor_authorization_view(
+    pending: _PendingGenerationAuthority,
+) -> tuple[bytes | None, InstalledAuthorizationView | None]:
+    store_path = _validate_store_path(pending.binding)
+    control_root = store_path / _REPLICA_CONTROL_ROOT_NAME
+    path = _actor_authorization_view(control_root, pending)
+    _validate_managed_path(store_path, path)
+    raw = _read_optional_file(path)
+    if raw is None:
+        return None, None
+    return raw, _parse_authorization_view(raw)
 
 
 def _new_native_lock(path: Path, timeout: float):

--- a/packages/nauro/tests/test_auth.py
+++ b/packages/nauro/tests/test_auth.py
@@ -2,6 +2,9 @@
 
 import base64
 import json
+import os
+import stat
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import httpx
@@ -9,7 +12,8 @@ import pytest
 from nauro_core import sanitize_sub
 from typer.testing import CliRunner
 
-from nauro.auth import decode_jwt_payload
+from nauro import auth as auth_domain
+from nauro.auth import ActiveUserReadError, decode_jwt_payload, read_active_user_id
 from nauro.cli.commands import auth as auth_module
 from nauro.cli.commands.auth import (
     _CallbackHandler,
@@ -17,8 +21,10 @@ from nauro.cli.commands.auth import (
 )
 from nauro.cli.main import app
 from nauro.store.config import load_config, save_config
+from nauro.store.home import config_file
 
 runner = CliRunner()
+USER_ID = "01K33333333333333333333333"
 
 
 def _json_bytes(value: object) -> bytes:
@@ -31,6 +37,106 @@ def _make_jwt(payload: dict) -> str:
     body = base64.urlsafe_b64encode(json.dumps(payload).encode()).rstrip(b"=").decode()
     sig = base64.urlsafe_b64encode(b"fakesig").rstrip(b"=").decode()
     return f"{header}.{body}.{sig}"
+
+
+def _active_config(raw: bytes | None = None) -> None:
+    path = config_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    value = raw or json.dumps({"auth": {"access_token": "token", "user_id": USER_ID}}).encode()
+    path.write_bytes(value)
+
+
+def _assert_active_error(message: str) -> None:
+    with pytest.raises(ActiveUserReadError) as raised:
+        read_active_user_id()
+    assert type(raised.value) is ActiveUserReadError
+    assert (raised.value.code, str(raised.value)) == ("auth_state_unavailable", message)
+
+
+def test_active_user_reader_returns_strict_server_user_id(monkeypatch) -> None:
+    _active_config()
+    read = os.read
+    monkeypatch.setattr(auth_domain.os, "read", lambda fd, size: read(fd, min(size, 7)))
+    assert read_active_user_id() == USER_ID
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        None,
+        b"not-json",
+        b"[]",
+        b"\xef\xbb\xbf{}",
+        b'{"a":1,"\\u0061":2}',
+        b'{"number":NaN}',
+        json.dumps({"auth": {"access_token": "token", "sanitized_sub": USER_ID}}).encode(),
+        json.dumps({"auth": {"access_token": "", "user_id": USER_ID}}).encode(),
+        json.dumps({"auth": {"access_token": "token", "user_id": USER_ID.lower()}}).encode(),
+    ],
+)
+def test_active_user_reader_rejects_missing_or_invalid_state_without_effects(tmp_path, raw) -> None:
+    if raw is not None:
+        _active_config(raw)
+    before = {path.name: path.read_bytes() for path in tmp_path.iterdir() if path.is_file()}
+    _assert_active_error("No active account is available.")
+    assert {path.name: path.read_bytes() for path in tmp_path.iterdir() if path.is_file()} == before
+
+
+@pytest.mark.parametrize(
+    ("index", "value"),
+    [
+        (0, stat.S_IFLNK),
+        (0, stat.S_IFDIR),
+        (0, stat.S_IFIFO),
+        (0, stat.S_IFCHR),
+        (0, stat.S_IFSOCK),
+        (3, 2),
+        (6, 64 * 1024 + 1),
+        (None, None),
+    ],
+)
+def test_active_user_reader_rejects_unsafe_config_occupants(monkeypatch, index, value) -> None:
+    _active_config()
+    metadata = os.lstat(config_file())
+    if index is None:
+        changed = SimpleNamespace(st_mode=metadata.st_mode, st_file_attributes=0x400)
+    else:
+        values, attributes = metadata.__reduce__()[1]
+        values = list(values)
+        values[index] = value
+        changed = os.stat_result(values, attributes)
+    monkeypatch.setattr(auth_domain.os, "lstat", lambda _: changed)
+    _assert_active_error("The active authentication state is unavailable.")
+
+
+@pytest.mark.parametrize(
+    ("api", "at"),
+    [("fstat", 1), ("fstat", 2), ("lstat", 2)],
+)
+def test_active_user_reader_rejects_unstable_or_irregular_reads(monkeypatch, api, at) -> None:
+    _active_config()
+    original, calls = getattr(os, api), 0
+
+    def changed(*args):
+        nonlocal calls
+        calls += 1
+        value = original(*args)
+        if calls != at:
+            return value
+        values, attributes = value.__reduce__()[1]
+        values = list(values)
+        values[1] += 1
+        return os.stat_result(values, attributes)
+
+    monkeypatch.setattr(auth_domain.os, api, changed)
+
+    _assert_active_error("The active authentication state is unavailable.")
+
+
+def test_active_user_reader_rejects_partial_input(monkeypatch) -> None:
+    _active_config()
+    monkeypatch.setattr(auth_domain.os, "read", MagicMock(side_effect=[b"{", b""]))
+    _assert_active_error("The active authentication state is unavailable.")
 
 
 # --- sanitize_sub wiring ---
@@ -518,6 +624,7 @@ class TestAuthLogout:
         assert result.exit_code == 0
         assert "Not authenticated" in result.output
 
+    @pytest.mark.skipif(os.name == "nt", reason="Windows does not enforce POSIX modes")
     def test_config_permissions(self, tmp_path, monkeypatch):
         """Config file should have restricted permissions (0o600) after auth write."""
         import os

--- a/packages/nauro/tests/test_generation_authority.py
+++ b/packages/nauro/tests/test_generation_authority.py
@@ -15,6 +15,7 @@ from nauro.store.generation_authority import (
     GenerationAuthorityMarker,
     GenerationControlCorruptError,
     GenerationProjectAuthority,
+    InstalledAuthorizationView,
     InstalledGenerationPointer,
     RefreshRequiredError,
     ReplicaActorMismatchError,
@@ -92,6 +93,23 @@ def _pointer(**changes: object) -> str:
     return json.dumps(raw)
 
 
+def _authorization_view(**changes: object) -> bytes:
+    raw: dict[str, object] = {
+        "schema_version": 1,
+        "project_id": PROJECT_ID,
+        "store_format_version": 1,
+        "generation_id": GENERATION_ID,
+        "manifest_digest": MANIFEST_DIGEST,
+        "committed_at": COMMITTED_AT,
+        "installed_state_id": INSTALL_STATE_ID,
+        "installed_for_user_id": USER_ID,
+        "projection_class": "contributor_plus",
+        "projection_scope_id": PROJECTION_SCOPE_ID,
+    }
+    raw.update(changes)
+    return json.dumps(raw, sort_keys=True, separators=(",", ":")).encode()
+
+
 def _select(
     *,
     marker_json: str | bytes | None = None,
@@ -138,6 +156,72 @@ def test_control_models_emit_exact_canonical_bytes() -> None:
     assert isinstance(selected, GenerationProjectAuthority)
     assert selected.marker.canonical_bytes() == marker_bytes
     assert selected.pointer.canonical_bytes() == pointer_bytes
+
+
+def test_authorization_view_has_exact_canonical_frozen_contract() -> None:
+    raw = _authorization_view()
+    view = generation_authority._parse_authorization_view(raw)
+
+    assert type(view) is InstalledAuthorizationView
+    assert view.canonical_bytes() == raw
+    assert view.model_dump() == json.loads(raw)
+    assert not raw.startswith(b"\xef\xbb\xbf") and not raw.endswith(b"\n")
+    with pytest.raises(pyd.ValidationError):
+        view.generation_id = OTHER_PROJECT_ID
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        {},
+        pytest.param(HostileStr(_authorization_view().decode()), id="hostile-str"),
+        b"not-json",
+        b"[]",
+        b"\xff",
+        ("[" * 1100 + "0" + "]" * 1100).encode(),
+        b"\xef\xbb\xbf" + _authorization_view(),
+        _authorization_view() + b"\n",
+        _authorization_view().replace(b'"schema_version":1', b'"schema_version":1.0'),
+        _authorization_view().replace(b'"schema_version":1', b'"schema_version":2'),
+        _authorization_view().replace(b'"schema_version":1', b'"schema_version":1,"extra":1'),
+        _authorization_view().replace(
+            b'"schema_version":1', b'"schema_version":2,"schema_\\u0076ersion":1'
+        ),
+        _authorization_view().replace(b'"schema_version":1', b'"schema_version":NaN'),
+        _authorization_view(project_id=PROJECT_ID.lower()),
+        _authorization_view(store_format_version=0),
+        _authorization_view(generation_id="generation-1"),
+        _authorization_view(manifest_digest="A" * 64),
+        _authorization_view(committed_at="2026-09-02T01:02:03Z"),
+        _authorization_view(installed_state_id="state-1"),
+        _authorization_view(installed_for_user_id="user-1"),
+        _authorization_view(projection_class="owner"),
+        _authorization_view(projection_scope_id="B" * 64),
+    ],
+)
+def test_authorization_view_rejects_noncanonical_or_invalid_input(raw: object) -> None:
+    with pytest.raises(GenerationControlCorruptError) as raised:
+        generation_authority._parse_authorization_view(raw)  # type: ignore[arg-type]
+
+    assert (type(raised.value), raised.value.code, str(raised.value)) == (
+        GenerationControlCorruptError,
+        "generation_control_corrupt",
+        "The installed authorization view is invalid.",
+    )
+
+
+@pytest.mark.parametrize("error_type", [ValueError, TypeError, RecursionError])
+def test_authorization_view_hides_parser_failures(monkeypatch, error_type) -> None:
+    monkeypatch.setattr(
+        generation_authority,
+        "_strict_json_preflight",
+        lambda _raw: (_ for _ in ()).throw(error_type("secret parser detail")),
+    )
+
+    with pytest.raises(GenerationControlCorruptError) as raised:
+        generation_authority._parse_authorization_view(_authorization_view())
+
+    assert str(raised.value) == "The installed authorization view is invalid."
 
 
 def _assert_corrupt(

--- a/packages/nauro/tests/test_replica_control.py
+++ b/packages/nauro/tests/test_replica_control.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import stat
 import sys
 import threading
 from dataclasses import FrozenInstanceError
@@ -18,6 +19,8 @@ from nauro.store.generation_authority import (
     GenerationControlCorruptError,
     RefreshRequiredError,
     ReplicaActorMismatchError,
+    _parse_marker,
+    _PendingGenerationAuthority,
 )
 from nauro.store.replica_control import (
     ReplicaControlBusyError,
@@ -82,6 +85,20 @@ def _pointer_path(path: Path) -> Path:
     return path / ".replica" / "v1" / "actors" / USER_ID / "pointer.json"
 
 
+def _view_path(path: Path) -> Path:
+    return path / ".replica" / "v1" / "actors" / USER_ID / "authorization-view.json"
+
+
+def _pending(binding: ResolvedProjectBinding) -> _PendingGenerationAuthority:
+    return _PendingGenerationAuthority(binding, _parse_marker(_marker()), USER_ID)
+
+
+def _view() -> bytes:
+    value = json.loads(_pointer())
+    del value["installed_at"]
+    return json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+
+
 def _write_control(path: Path, marker: bytes | None = None, pointer: bytes | None = None):
     marker, pointer = marker or _marker(), pointer or _pointer()
     layout = _layout(path)
@@ -108,6 +125,7 @@ def test_local_mode_performs_no_lock_or_control_io(tmp_path, monkeypatch):
     binding = _binding(tmp_path / PROJECT_ID, "local")
     monkeypatch.setattr(control, "_validate_store_path", lambda *_: pytest.fail("path I/O"))
     monkeypatch.setattr(control, "_new_native_lock", lambda *_: pytest.fail("lock I/O"))
+    monkeypatch.setattr(control, "_read_actor_authorization_view", lambda *_: pytest.fail("view"))
     with _locked(binding, active_user_id=HostileStr(USER_ID)) as snapshot:
         assert snapshot.authority == FlatProjectAuthority(binding)
         assert (snapshot.marker_json, snapshot.pointer_json) == (None, None)
@@ -120,9 +138,125 @@ def test_absent_marker_ignores_a_poisoned_dormant_pointer(tmp_path, monkeypatch)
     pointer.parent.mkdir(parents=True)
     _symlink(pointer, tmp_path / "outside")
     monkeypatch.setattr(control, "_actor_pointer", lambda *_: pytest.fail("pointer path"))
+    monkeypatch.setattr(control, "_read_actor_authorization_view", lambda *_: pytest.fail("view"))
     with _locked(binding) as snapshot:
         assert snapshot.authority == FlatProjectAuthority(binding)
         assert (snapshot.marker_json, snapshot.pointer_json) == (None, None)
+
+
+def test_actor_authorization_view_path_and_read_contract(tmp_path: Path) -> None:
+    binding = _binding(tmp_path / PROJECT_ID)
+    pending = _pending(binding)
+    path = _view_path(binding.store_path)
+
+    assert (
+        control._actor_authorization_view(_layout(binding.store_path).control_root, pending) == path
+    )
+    assert control._read_actor_authorization_view(pending) == (None, None)
+    assert not path.exists() and not path.parent.exists()
+    path.parent.mkdir(parents=True)
+    raw = _view()
+    path.write_bytes(raw)
+
+    exact, parsed = control._read_actor_authorization_view(pending)
+    assert exact == raw
+    assert parsed is not None and parsed.canonical_bytes() == raw
+
+
+def test_actor_authorization_view_rejects_malformed_bytes(tmp_path: Path) -> None:
+    binding = _binding(tmp_path / PROJECT_ID)
+    path = _view_path(binding.store_path)
+    path.parent.mkdir(parents=True)
+    path.write_bytes(b"{}")
+
+    with pytest.raises(GenerationControlCorruptError) as raised:
+        control._read_actor_authorization_view(_pending(binding))
+    assert str(raised.value) == "The installed authorization view is invalid."
+
+
+@pytest.mark.parametrize("target", ["marker", "pointer", "carrier"])
+def test_control_readers_reject_hard_links(tmp_path: Path, target: str) -> None:
+    binding = _binding(tmp_path / PROJECT_ID)
+    _write_control(binding.store_path)
+    path = {
+        "marker": _layout(binding.store_path).authority_marker,
+        "pointer": _pointer_path(binding.store_path),
+        "carrier": _view_path(binding.store_path),
+    }[target]
+    if target == "carrier":
+        path.write_bytes(_view())
+    os.link(path, tmp_path / "second-link")
+
+    with pytest.raises(ReplicaControlReadError) as raised:
+        if target == "carrier":
+            control._read_actor_authorization_view(_pending(binding))
+        else:
+            with _locked(binding):
+                pass
+    assert (raised.value.code, str(raised.value)) == (
+        "generation_control_unavailable",
+        "Replica control file is not a bounded regular file.",
+    )
+
+
+@pytest.mark.parametrize(
+    "kind", ["symlink", "directory", "fifo", "oversized", "reparse", "device", "socket"]
+)
+def test_authorization_view_rejects_unsafe_occupants(tmp_path, monkeypatch, kind) -> None:
+    binding = _binding(tmp_path / PROJECT_ID)
+    path = _view_path(binding.store_path)
+    path.parent.mkdir(parents=True)
+    if kind == "directory":
+        path.mkdir()
+    elif kind == "fifo":
+        if not hasattr(os, "mkfifo"):
+            pytest.skip("FIFO creation is unavailable")
+        os.mkfifo(path)
+    elif kind == "symlink":
+        _symlink(path, tmp_path / "outside")
+    else:
+        path.write_bytes(b"x" * (16 * 1024 + 1) if kind == "oversized" else _view())
+        if kind != "oversized":
+            real_lstat = os.lstat
+
+            def lstat(candidate):
+                value = real_lstat(candidate)
+                if Path(candidate) == path:
+                    mode = {"device": stat.S_IFCHR, "socket": stat.S_IFSOCK}.get(
+                        kind, value.st_mode
+                    )
+                    return SimpleNamespace(
+                        st_mode=mode,
+                        st_file_attributes=0x400 if kind == "reparse" else 0,
+                    )
+                return value
+
+            monkeypatch.setattr(control.os, "lstat", lstat)
+
+    with pytest.raises(ReplicaControlReadError):
+        control._read_actor_authorization_view(_pending(binding))
+
+
+def test_control_reader_rejects_final_path_replacement(tmp_path, monkeypatch) -> None:
+    path = tmp_path / "control.json"
+    path.write_bytes(b"{}")
+    real_lstat, calls = os.lstat, 0
+
+    def lstat(candidate):
+        nonlocal calls
+        calls += 1
+        value = real_lstat(candidate)
+        if calls == 2:
+            values, attributes = value.__reduce__()[1]
+            values = list(values)
+            values[1] += 1
+            return os.stat_result(values, attributes)
+        return value
+
+    monkeypatch.setattr(control.os, "lstat", lstat)
+    with pytest.raises(ReplicaControlReadError) as raised:
+        control._read_optional_file(path)
+    assert str(raised.value) == "Replica control file changed during read."
 
 
 @pytest.mark.parametrize(
@@ -374,7 +508,18 @@ def test_control_files_are_bounded_and_regular(tmp_path: Path, kind: str) -> Non
 
 
 @pytest.mark.parametrize(
-    "operation", ["metadata", "open", "open-replace", "read-replace", "read", "flags"]
+    "operation",
+    [
+        "metadata",
+        "open",
+        "open-replace",
+        "read-replace",
+        "open-link",
+        "read-link",
+        "short",
+        "read",
+        "flags",
+    ],
 )
 def test_control_io_and_replacement_failures_are_typed(tmp_path, monkeypatch, operation):
     path = tmp_path / "control.json"
@@ -387,18 +532,22 @@ def test_control_io_and_replacement_failures_are_typed(tmp_path, monkeypatch, op
         monkeypatch.setattr(control.os, "lstat", lambda _: (_ for _ in ()).throw(OSError()))
     elif operation == "open":
         monkeypatch.setattr(control.os, "open", lambda *_: (_ for _ in ()).throw(OSError()))
-    elif "replace" in operation:
+    elif "replace" in operation or "link" in operation:
         original, calls = os.fstat, 0
+        field = 3 if "link" in operation else 1
+        target = 1 if operation.startswith("open") else 2
 
         def fstat(fd: int):
             nonlocal calls
             calls += 1
             values, attributes = original(fd).__reduce__()[1]
             values = list(values)
-            values[1] += calls == (1 if operation == "open-replace" else 2)
+            values[field] += calls == target
             return os.stat_result(values, attributes)
 
         monkeypatch.setattr(control.os, "fstat", fstat)
+    elif operation == "short":
+        monkeypatch.setattr(control.os, "read", lambda *_: b"{")
     else:
         monkeypatch.setattr(control.os, "read", lambda *_: (_ for _ in ()).throw(OSError()))
     with pytest.raises(ReplicaControlReadError) as raised:


### PR DESCRIPTION
## Why

Pointer-selected generation reads need independent evidence for the active local actor and installed authorization scope before routing can be enabled. This change adds those read-only evidence contracts without activating generation reads.

## What changed

- Add a side-effect-free active-user reader with strict auth-state and filesystem identity validation.
- Add the canonical installed authorization-view codec and a derived replica-control reader.
- Harden optional control-file reads against hard links, irregular entries, partial reads, and final-path replacement.
- Add auth-reader coverage to the generation-control platform CI job.

## Test plan

- Focused auth and generation-control tests: 617 passed, 53 skipped.
- Full `packages/nauro/tests` suite excluding `cross_surface`: 3642 passed, 63 skipped.
- Ruff check and format, changed-source mypy baseline comparison, import contracts, repository guards, and local wheel builds passed.

## Risk / what to review

Review the descriptor and final-path identity checks, the strict canonical JSON boundary, and the retained user-global parent symlink policy.

## Deferred

Authorization-view publication, selector consumption, generation-read routing, activation, cleanup, leases, and Store mutation remain out of scope.