### PR TITLE
Support credential-gated uploads and push-only sync

### DIFF
--- a/packages/nauro/src/nauro/cli/commands/sync.py
+++ b/packages/nauro/src/nauro/cli/commands/sync.py
@@ -31,6 +31,9 @@ def sync(
         help="Target project name. Overrides cwd resolution.",
     ),
     status: bool = typer.Option(False, "--status", help="Show sync status."),
+    push_only: bool = typer.Option(
+        False, "--push-only", help="Push local changes without pulling remote files."
+    ),
 ) -> None:
     """Capture a snapshot and regenerate AGENTS.md in each associated repo, pulling before pushing
     when cloud sync is configured. The only command that overwrites an unmanaged AGENTS.md, and
@@ -46,7 +49,13 @@ def sync(
     trigger = message or "manual sync"
 
     with operation_session() as session:
-        pulled = _pull_from_cloud(project_key, store_path, session=session)
+        from nauro.sync.pull import PullReport
+
+        pulled = (
+            PullReport()
+            if push_only
+            else _pull_from_cloud(project_key, store_path, session=session)
+        )
 
         version = capture_snapshot(store_path, trigger=trigger)
 

--- a/packages/nauro/src/nauro/sync/remote.py
+++ b/packages/nauro/src/nauro/sync/remote.py
@@ -450,6 +450,13 @@ def request_presigned_urls(
         return []
     api_url = resolve_api_url()
     endpoint = f"{api_url}/sync/presign"
+    from nauro.sync.writer_credential import writer_headers
+
+    upload_headers = (
+        writer_headers(project_id, api_url)
+        if any(op.get("verb") == "PUT" for op in operations)
+        else {}
+    )
     all_urls: list[dict[str, Any]] = []
     with operation_session(session) as active:
         for start in range(0, len(operations), PRESIGN_BATCH_LIMIT):
@@ -461,7 +468,7 @@ def request_presigned_urls(
                     endpoint,
                     TransferOperation.PRESIGN,
                     json={"project_id": project_id, "operations": chunk},
-                    headers={"Authorization": f"Bearer {token}"},
+                    headers={"Authorization": f"Bearer {token}", **upload_headers},
                     timeout=_DEFAULT_API_TIMEOUT,
                 )
 

--- a/packages/nauro/src/nauro/sync/writer_credential.py
+++ b/packages/nauro/src/nauro/sync/writer_credential.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import stat
+from pathlib import Path
+
+
+def writer_headers(project_id: str, api_url: str) -> dict[str, str]:
+    filename = os.environ.get("NAURO_WRITER_CREDENTIAL_FILE")
+    if not filename:
+        return {}
+    try:
+        with Path(filename).open() as handle:
+            info = os.fstat(handle.fileno())
+            if not stat.S_ISREG(info.st_mode) or info.st_mode & 0o077:
+                raise ValueError
+            credential = json.load(handle)
+        if (
+            not isinstance(credential, dict)
+            or set(credential) != {"project_id", "api_url", "token"}
+            or not all(isinstance(value, str) for value in credential.values())
+            or not re.fullmatch(r"[0-9a-f]{64}", credential["token"])
+        ):
+            raise ValueError
+        if credential["project_id"] != project_id:
+            return {}
+        if credential["api_url"].rstrip("/") != api_url.rstrip("/"):
+            raise ValueError
+        return {"X-Nauro-Writer-Token": credential["token"]}
+    except (OSError, ValueError, TypeError, KeyError):
+        from nauro.sync.remote import PresignError
+
+        raise PresignError("Writer credential is unavailable or invalid.") from None

--- a/packages/nauro/tests/snapshots/public_contract_v1.json
+++ b/packages/nauro/tests/snapshots/public_contract_v1.json
@@ -1556,6 +1556,17 @@
           {
             "default": false,
             "flags": [
+              "--push-only"
+            ],
+            "is_flag": true,
+            "kind": "option",
+            "name": "push_only",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "default": false,
+            "flags": [
               "--status"
             ],
             "is_flag": true,

--- a/packages/nauro/tests/test_sync/test_sync_command.py
+++ b/packages/nauro/tests/test_sync/test_sync_command.py
@@ -559,3 +559,17 @@ class TestLinkCloudRefusesWithoutAuth:
         assert result.exit_code == 1, combined
         assert "Cannot link 'blockedlink' to the cloud" in combined
         assert "Run 'nauro auth login'" in combined
+
+
+def test_push_only_skips_pull_and_reports_failure(project_store):
+    from nauro.cli.commands import sync as sync_mod
+
+    for report, expected in [(PushReport(), 0), (PushReport(failed=("upload",)), 1)]:
+        with (
+            patch.object(sync_mod, "_pull_from_cloud") as pull,
+            patch.object(sync_mod, "push_store_to_cloud", return_value=report) as push,
+        ):
+            result = runner.invoke(app, ["sync", "--push-only"])
+        assert result.exit_code == expected, result.output
+        pull.assert_not_called()
+        push.assert_called_once()

--- a/packages/nauro/tests/test_sync/test_writer_credential.py
+++ b/packages/nauro/tests/test_sync/test_writer_credential.py
@@ -1,0 +1,75 @@
+import json
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from nauro.sync.remote import PresignError, request_presigned_urls
+from nauro.sync.writer_credential import writer_headers
+from tests.conftest import seed_auth_config
+
+PROJECT = "01KQ6AZGNA0B3QBF67NBXP3S45"
+API = "https://mcp.nauro.ai"
+TOKEN = "a" * 64
+
+
+@pytest.fixture
+def credential(tmp_path, monkeypatch):
+    path = tmp_path / "writer.json"
+    path.write_text(json.dumps({"project_id": PROJECT, "api_url": API, "token": TOKEN}))
+    path.chmod(0o600)
+    monkeypatch.setenv("NAURO_WRITER_CREDENTIAL_FILE", str(path))
+    return path
+
+
+def test_project_and_origin_binding(credential):
+    assert writer_headers(PROJECT, API) == {"X-Nauro-Writer-Token": TOKEN}
+    assert writer_headers("another-project", API) == {}
+    with pytest.raises(PresignError, match="Writer credential is unavailable or invalid"):
+        writer_headers(PROJECT, "https://other.example")
+
+
+@pytest.mark.parametrize("failure", ["missing", "permissions", "malformed"])
+def test_invalid_credential_does_not_reach_http(credential, failure):
+    if failure == "missing":
+        credential.unlink()
+    elif failure == "permissions":
+        credential.chmod(0o644)
+    else:
+        credential.write_text(TOKEN)
+    with patch("nauro.sync.remote.httpx.Client.post") as post:
+        with pytest.raises(PresignError) as error:
+            request_presigned_urls(PROJECT, [{"verb": "PUT", "path": "project.md"}])
+    post.assert_not_called()
+    assert str(error.value) == "Writer credential is unavailable or invalid."
+
+
+@pytest.mark.parametrize("verb", ["PUT", "GET"])
+def test_header_only_on_upload_presign_and_auth_retry(credential, verb):
+    seed_auth_config(variant="sync")
+    attempts = []
+
+    def refresh(call, **kwargs):
+        call("old-access-token")
+        return call("new-access-token")
+
+    def post(url, **kwargs):
+        attempts.append(kwargs["headers"])
+        return httpx.Response(200, json={"urls": []})
+
+    with (
+        patch("nauro.sync.remote.resolve_api_url", return_value=API),
+        patch("nauro.sync.remote.with_token_refresh", side_effect=refresh),
+        patch("nauro.sync.remote.httpx.Client.post", side_effect=post),
+    ):
+        assert request_presigned_urls(PROJECT, [{"verb": verb, "path": "project.md"}]) == []
+    extra = {"X-Nauro-Writer-Token": TOKEN} if verb == "PUT" else {}
+    assert attempts == [
+        {"Authorization": "Bearer old-access-token", **extra},
+        {"Authorization": "Bearer new-access-token", **extra},
+    ]
+
+
+def test_unconfigured_client_keeps_legacy_transport(monkeypatch):
+    monkeypatch.delenv("NAURO_WRITER_CREDENTIAL_FILE", raising=False)
+    assert writer_headers(PROJECT, API) == {}

--- a/packages/nauro/tests/test_write_command_autogen.py
+++ b/packages/nauro/tests/test_write_command_autogen.py
@@ -435,3 +435,33 @@ class TestFlagQuestionArgumentShapes:
         envelope = json.loads(result.stdout)
         assert envelope["status"] == "ok"
         assert "[Resolved by D42 on " in (store_path / "open-questions.md").read_text()
+
+
+def test_cli_and_mcp_hold_allocation_lock(seeded_repo, monkeypatch):
+    import filelock
+
+    _pid, store_path, _repo = seeded_repo
+    original = mcp_tools._propose_decision_op
+    checked = []
+
+    def locked_operation(*args, **kwargs):
+        contender = filelock.FileLock(str(store_path / "decisions" / ".lock"))
+        with pytest.raises(filelock.Timeout):
+            contender.acquire(timeout=0)
+        checked.append(kwargs["title"])
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(mcp_tools, "_propose_decision_op", locked_operation)
+    result = runner.invoke(
+        app, ["propose-decision", "Keep allocation serialized.", "--title", "First allocation"]
+    )
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout)["status"] == "confirmed"
+    result = mcp_tools.tool_propose_decision(
+        store_path, title="Second allocation", rationale="Keep allocation serialized."
+    )
+    assert result["status"] == "confirmed"
+    assert checked == ["First allocation", "Second allocation"]
+    assert sorted(
+        int(path.name.split("-", 1)[0]) for path in (store_path / "decisions").glob("*.md")
+    ) == [1, 2, 3]


### PR DESCRIPTION
## Why

The designated local writer needs to upload while the server refuses pulls and hosted writes. Normal sync attempts a pull first and reports that refusal.

## What changed

Load an optional private writer credential bound to the project and API URL, and send it only on upload presign requests. Add `sync --push-only` and its additive CLI contract entry. Pin allocation-lock coverage through both CLI and MCP adapters.

## Test plan

108 focused client tests passed, covering credentials, sync, startup hooks, allocation, write commands, and the public contract. Ruff lint and formatting and diff checks passed. Staging and live acceptance have not run.

## Risk / what to review

Requires the companion server control to enforce exclusivity. Unconfigured clients retain legacy transport and receive server refusals on protected projects. Pull refusal also blocks reconciliation of ambiguous uploads; the operator procedure requires pausing and checking parity before retrying. The credential must stay on the designated machine, outside synced files. No release or activation is included.

Companion PR: https://github.com/Nauro-AI/mcp-server/pull/179
