### PR TITLE
Clarify README setup and the optional Pennykeep demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Keep your project's direction in human hands as agents do more of the work.
 
-Nauro records the project decisions you approve, including their reasons and rejected alternatives. It brings relevant decisions into later agent sessions so you do not have to explain them again. Project scope, current state, and open questions travel with that record.
+Nauro records the project decisions you approve, including their reasons and rejected alternatives. It brings those reasons into later agent sessions.
 
 **Status:** Stable (1.x).
 
@@ -20,23 +20,21 @@ Nauro records the project decisions you approve, including their reasons and rej
 
 https://github.com/user-attachments/assets/f75ede99-db11-4460-bc09-801c86df1e19
 
-*A real Codex session, then a Claude session in Pareto, Nauro's development mock project, showing project judgment across agent sessions.*
+*A Codex session, then a Claude session in Pareto, Nauro's development mock project.*
 
 ## Is Nauro a fit?
 
-Nauro is intended for longer-lived work where context can decay across sessions, tools, repositories, machines, or repeated handoffs. If a small repo plus a reliable `AGENTS.md` or `CLAUDE.md` keeps agents oriented, Nauro may be more than you need.
+Nauro supports longer-lived work across sessions, tools, and handoffs. If a small repo plus a reliable AGENTS.md or CLAUDE.md keeps agents oriented, Nauro may be more than you need.
 
-Nauro surfaces prior judgment for the agent to assess. Retrieval is advisory. New or revised judgment requires your explicit approval. Local use needs no account, and the record is plain Markdown on your machine. Cloud sync and remote MCP access are optional. Nauro sends no product analytics.
+Retrieval is advisory. New or revised decisions require your explicit approval. Local use needs no account; the record is plain Markdown on your machine. Cloud sync is optional. Nauro sends no product analytics.
 
 ## Get started
 
-Choose the desktop app for guided setup on macOS, or install the CLI to work from your shell.
-
 ### Desktop app (macOS)
 
-The free app walks you through installing the CLI, connecting your agents, and adopting or attaching a project. It also provides a read-only viewer for the project record: timeline, map, list, activity, and docs.
+The free app installs the CLI, connects agents, and sets up a project. Its read-only viewer shows the project record.
 
-[Download for macOS (Apple silicon)](https://github.com/Nauro-AI/nauro-app-releases/releases/latest/download/Nauro-macOS-arm64.dmg), signed and notarized. See the [desktop app guide](https://nauro.ai/docs/desktop-app) for setup details.
+[Download for macOS (Apple silicon)](https://github.com/Nauro-AI/nauro-app-releases/releases/latest/download/Nauro-macOS-arm64.dmg), signed and notarized. [Setup guide](https://nauro.ai/docs/desktop-app).
 
 <details>
 <summary>Watch the desktop app tour</summary>
@@ -51,17 +49,17 @@ https://github.com/user-attachments/assets/e23d3d7f-2d5b-4ce4-be18-fcaff74e7973
 uv tool install nauro
 ```
 
-Install `uv` with `curl -LsSf https://astral.sh/uv/install.sh | sh` on macOS or Linux, or use the [Windows instructions](https://docs.astral.sh/uv/getting-started/installation/). With Python 3.10 or newer, `pipx install nauro` also works.
+[Install uv](https://docs.astral.sh/uv/getting-started/installation/), or use `pipx install nauro` with Python 3.10 or newer.
 
 ## Try the demo (optional)
 
-Pennykeep is the fictional budgeting app bundled with Nauro.
+Pennykeep is the bundled fictional budgeting app.
 
 - **Request:** Replace envelope budgeting with spending charts to simplify onboarding.
-- **Prior decision:** In the fictional tester history, passive tracking did not help users control spending. The team accepted more setup effort so users assign income before spending.
-- **Effect on the plan:** An agent could suggest simpler envelope setup or ask whether to revisit the budgeting model.
+- **Prior decision:** In the fictional tester history, passive tracking did not help users control spending. The team accepted extra setup so users assign income before spending.
+- **Possible plan:** Simplify envelope setup, or ask whether to revisit the budgeting model.
 
-Try this example without an account or agent setup. With the CLI installed, run these commands in a temporary directory on macOS or Linux:
+No account or agent setup required. On macOS or Linux:
 
 ```bash
 mkdir -p /tmp/nauro-demo && cd /tmp/nauro-demo
@@ -69,34 +67,28 @@ nauro init --demo
 nauro check-decision "Replace envelope budgeting with a passive spending tracker and charts"
 ```
 
-Look for **Envelope budgeting method** in the related decisions. The command retrieves the prior reasoning; it does not run an agent or change the recorded decision.
-
-See the [demo guide](https://nauro.ai/docs/quickstart#demo) for PowerShell commands and more ways to explore the sample. Keep agent setup in your own repository.
+Look for **Envelope budgeting method** in the related decisions. This retrieves prior reasoning; it does not run an agent or change decisions. [PowerShell and demo guide](https://nauro.ai/docs/quickstart#demo).
 
 ## Use it on your repo
 
-For CLI setup, enter your repository and run:
+For CLI setup:
 
 ```bash
 cd your-repo
 nauro adopt --with-skills --with-subagents
 ```
 
-If the desktop wizard already adopted your repository, continue with the agent step below.
+Skip this command if the desktop wizard already adopted your repository. Restart your agent, then run `/nauro-adopt` in Claude Code, `$nauro-adopt` in Codex, or `@nauro-adopt` in Cursor. Review the proposed project record.
 
-Restart your agent, then run `/nauro-adopt` in Claude Code, `$nauro-adopt` in Codex, or `@nauro-adopt` in Cursor Agent chat. The agent reviews the repository and helps you build its project record. Review proposed decisions and approve only those that reflect your intent.
+Approve one existing decision you want future sessions to remember. Start a fresh session and ask about a task where it matters. Check how the agent uses the reason.
 
-For a first useful result, choose one existing decision you want future sessions to remember. After approving its record, start a fresh agent session and ask about a task where that decision matters. Check that the agent finds the reason and explains how it affects the approach.
+Run `nauro status` to check the connection. See [agent workflows](https://nauro.ai/docs/agents-and-skills) and [setup details](https://nauro.ai/docs/quickstart).
 
-Run `nauro status` to check the connection. See the [agent and skill guide](https://nauro.ai/docs/agents-and-skills) for optional workflows and the [setup guide](https://nauro.ai/docs/quickstart) for agent-specific configuration and troubleshooting.
-
-Nauro preserves an existing `AGENTS.md` unless you explicitly run `nauro sync`. A `# Manual` section survives replacement.
+An existing `AGENTS.md` is preserved unless you run `nauro sync`. Its `# Manual` section survives replacement.
 
 ## Documentation
 
-Read the [documentation](https://nauro.ai/docs) for concepts, command references, storage, and cloud access.
-
-Semantic versioning covers the CLI, local stdio MCP contract, on-disk store format, and curated `nauro-core` import API. Cloud sync and hosted MCP are versioned separately.
+[Documentation](https://nauro.ai/docs) covers commands, storage, and cloud access. Semantic versioning covers the CLI, local stdio MCP contract, store format, and curated `nauro-core` API. Cloud sync and hosted MCP are versioned separately.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -12,17 +12,56 @@
 
 Keep your project's direction in human hands as agents do more of the work.
 
-Before work, Nauro surfaces relevant parts of that record. Approved judgment and reported progress carry into later sessions and connected tools.
+Nauro records the project decisions you approve, including their reasons and rejected alternatives. It brings relevant decisions into later agent sessions so you do not have to explain them again. Project scope, current state, and open questions travel with that record.
 
-**Status:** Stable (1.x). Semantic versioning covers the CLI, local stdio MCP contract, on-disk store format, and curated `nauro-core` import API. Cloud sync and hosted MCP are versioned separately.
+**Status:** Stable (1.x).
+
+## Why project history matters
+
+Pennykeep, the fictional budgeting app bundled with Nauro, helps users assign income to category envelopes before they spend it.
+
+Imagine asking an agent:
+
+> Simplify onboarding by replacing envelope budgeting with a passive spending tracker and charts.
+
+That could be a reasonable product change. But Pennykeep's recorded decision, **Envelope budgeting method**, explains why the team chose its current approach. In the fictional tester history, people who only saw past spending kept overspending. Assigning money before spending helped them change their behavior. The team accepted more setup effort to support that goal.
+
+Nauro can surface that decision before the agent plans the change. An illustrative response would be:
+
+> Pennykeep chose upfront allocation because passive tracking did not help its testers control spending. I suggest simplifying envelope setup while keeping allocation. Removing it would change the product's budgeting model and needs your approval.
+
+The useful context is the project's reason for choosing an approach. A later session can use it, and you can still decide to change it.
 
 ## See it in practice
 
 https://github.com/user-attachments/assets/f75ede99-db11-4460-bc09-801c86df1e19
 
-*A real Codex session, then a Claude session in Pareto, Nauro's development mock project.*
+*A real Codex session, then a Claude session in Pareto, Nauro's development mock project, showing project judgment across agent sessions.*
 
-## Install
+## Is Nauro a fit?
+
+Nauro is intended for longer-lived work where context can decay across sessions, tools, repositories, machines, or repeated handoffs. If a small repo plus a reliable `AGENTS.md` or `CLAUDE.md` keeps agents oriented, Nauro may be more than you need.
+
+Nauro surfaces prior judgment for the agent to assess. Retrieval is advisory. New or revised judgment requires your explicit approval. Local use needs no account, and the record is plain Markdown on your machine. Cloud sync and remote MCP access are optional. Nauro sends no product analytics.
+
+## Get started
+
+Choose the desktop app for guided setup on macOS, or install the CLI to work from your shell.
+
+### Desktop app (macOS)
+
+The free app walks you through installing the CLI, connecting your agents, and adopting or attaching a project. It also provides a read-only viewer for the project record: timeline, map, list, activity, and docs.
+
+[Download for macOS (Apple silicon)](https://github.com/Nauro-AI/nauro-app-releases/releases/latest/download/Nauro-macOS-arm64.dmg), signed and notarized. See the [desktop app guide](https://nauro.ai/docs/desktop-app) for setup details.
+
+<details>
+<summary>Watch the desktop app tour</summary>
+
+https://github.com/user-attachments/assets/e23d3d7f-2d5b-4ce4-be18-fcaff74e7973
+
+</details>
+
+### CLI
 
 ```bash
 uv tool install nauro
@@ -30,54 +69,44 @@ uv tool install nauro
 
 Install `uv` with `curl -LsSf https://astral.sh/uv/install.sh | sh` on macOS or Linux, or use the [Windows instructions](https://docs.astral.sh/uv/getting-started/installation/). With Python 3.10 or newer, `pipx install nauro` also works.
 
-## Try the demo
+## Try the demo (optional)
 
-Pennykeep, the bundled demo, needs no account or agent setup:
+Try the Pennykeep example above without an account or agent setup. With the CLI installed, run these commands in a temporary directory on macOS or Linux:
 
 ```bash
 mkdir -p /tmp/nauro-demo && cd /tmp/nauro-demo
 nauro init --demo
-nauro check-decision "Store dollar amounts as decimal numbers"
+nauro check-decision "Replace envelope budgeting with a passive spending tracker and charts"
 ```
 
-The top result is `D001`, **Amounts stored in integer cents, never floating point**. Its rationale explains why floating point makes money totals drift.
+Look for **Envelope budgeting method** in the related decisions. Its rationale explains the tradeoff between simpler onboarding and assigning money before spending. This command retrieves prior decisions; an agent uses that context to assess a plan. It does not run an agent or change the recorded decision.
+
+See the [demo guide](https://nauro.ai/docs/quickstart#demo) for PowerShell commands and more ways to explore the sample. Keep agent setup in your own repository.
 
 ## Use it on your repo
+
+For CLI setup, enter your repository and run:
 
 ```bash
 cd your-repo
 nauro adopt --with-skills --with-subagents
 ```
 
-Restart, then seed the store with `/nauro-adopt` in Claude Code, `$nauro-adopt` in Codex, or `@nauro-adopt` in Cursor Agent chat.
+If the desktop wizard already adopted your repository, continue with the agent step below.
 
-Plain adopt installs `nauro-adopt`. `--with-skills` adds `nauro-ship-task`, `nauro-context`, `nauro-loop`, and `nauro-interview`. `--with-subagents` adds four workflow agents for Claude Code, Cursor, and Codex. Cursor stores its native project agents under `.cursor/agents/`.
+Restart your agent, then run `/nauro-adopt` in Claude Code, `$nauro-adopt` in Codex, or `@nauro-adopt` in Cursor Agent chat. The agent reviews the repository and helps you build its project record. Review proposed decisions and approve only those that reflect your intent.
 
-Cursor runs `nauro-ship-task` natively. `nauro-loop` Program Delivery stays on hold.
+For a first useful result, choose one existing decision you want future sessions to remember. After approving its record, start a fresh agent session and ask about a task where that decision matters. Check that the agent finds the reason and explains how it affects the approach.
 
-On a new machine, run `nauro setup cursor`, then restart Cursor. Commit `.nauro/config.json`, `.cursor/rules/nauro-*.mdc`, and `.cursor/agents/nauro-*.md`, not the gitignored, machine-local `.cursor/mcp.json`. Cursor Cloud Agents need separate MCP configuration at `cursor.com/agents`.
-
-Run `nauro status` to check MCP, skills, and workflow agents. Run `nauro doctor` to check the project store.
-
-Nauro surfaces prior judgment for the agent to assess. Retrieval is advisory. New or revised judgment requires your explicit approval. Local use needs no account, and the record is plain Markdown on your machine. Cloud sync and remote MCP access are optional. Nauro sends no product analytics.
+Run `nauro status` to check the connection. See the [agent and skill guide](https://nauro.ai/docs/agents-and-skills) for optional workflows and the [setup guide](https://nauro.ai/docs/quickstart) for agent-specific configuration and troubleshooting.
 
 Nauro preserves an existing `AGENTS.md` unless you explicitly run `nauro sync`. A `# Manual` section survives replacement.
 
-## Desktop app (macOS)
+## Documentation
 
-A free, read-only viewer for the project record: timeline, map, list, activity, and docs. First launch installs the CLI, connects your agents, and adopts or attaches a project.
+Read the [documentation](https://nauro.ai/docs) for concepts, command references, storage, and cloud access.
 
-https://github.com/user-attachments/assets/e23d3d7f-2d5b-4ce4-be18-fcaff74e7973
-
-[Download for macOS (Apple silicon)](https://github.com/Nauro-AI/nauro-app-releases/releases/latest/download/Nauro-macOS-arm64.dmg), signed and notarized.
-
-## Fit
-
-If a small repo plus a reliable AGENTS.md or CLAUDE.md keeps agents oriented, Nauro may be more than you need.
-
-Nauro is intended for longer-lived work where context can decay across sessions, tools, repositories, machines, or repeated handoffs.
-
-Read the [documentation](https://nauro.ai/docs) for setup variants, concepts, command references, storage, and cloud access.
+Semantic versioning covers the CLI, local stdio MCP contract, on-disk store format, and curated `nauro-core` import API. Cloud sync and hosted MCP are versioned separately.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -16,22 +16,6 @@ Nauro records the project decisions you approve, including their reasons and rej
 
 **Status:** Stable (1.x).
 
-## Why project history matters
-
-Pennykeep, the fictional budgeting app bundled with Nauro, helps users assign income to category envelopes before they spend it.
-
-Imagine asking an agent:
-
-> Simplify onboarding by replacing envelope budgeting with a passive spending tracker and charts.
-
-That could be a reasonable product change. But Pennykeep's recorded decision, **Envelope budgeting method**, explains why the team chose its current approach. In the fictional tester history, people who only saw past spending kept overspending. Assigning money before spending helped them change their behavior. The team accepted more setup effort to support that goal.
-
-Nauro can surface that decision before the agent plans the change. An illustrative response would be:
-
-> Pennykeep chose upfront allocation because passive tracking did not help its testers control spending. I suggest simplifying envelope setup while keeping allocation. Removing it would change the product's budgeting model and needs your approval.
-
-The useful context is the project's reason for choosing an approach. A later session can use it, and you can still decide to change it.
-
 ## See it in practice
 
 https://github.com/user-attachments/assets/f75ede99-db11-4460-bc09-801c86df1e19
@@ -71,7 +55,13 @@ Install `uv` with `curl -LsSf https://astral.sh/uv/install.sh | sh` on macOS or 
 
 ## Try the demo (optional)
 
-Try the Pennykeep example above without an account or agent setup. With the CLI installed, run these commands in a temporary directory on macOS or Linux:
+Pennykeep is the fictional budgeting app bundled with Nauro.
+
+- **Request:** Replace envelope budgeting with spending charts to simplify onboarding.
+- **Prior decision:** In the fictional tester history, passive tracking did not help users control spending. The team accepted more setup effort so users assign income before spending.
+- **Effect on the plan:** An agent could suggest simpler envelope setup or ask whether to revisit the budgeting model.
+
+Try this example without an account or agent setup. With the CLI installed, run these commands in a temporary directory on macOS or Linux:
 
 ```bash
 mkdir -p /tmp/nauro-demo && cd /tmp/nauro-demo
@@ -79,7 +69,7 @@ nauro init --demo
 nauro check-decision "Replace envelope budgeting with a passive spending tracker and charts"
 ```
 
-Look for **Envelope budgeting method** in the related decisions. Its rationale explains the tradeoff between simpler onboarding and assigning money before spending. This command retrieves prior decisions; an agent uses that context to assess a plan. It does not run an agent or change the recorded decision.
+Look for **Envelope budgeting method** in the related decisions. The command retrieves the prior reasoning; it does not run an agent or change the recorded decision.
 
 See the [demo guide](https://nauro.ai/docs/quickstart#demo) for PowerShell commands and more ways to explore the sample. Keep agent setup in your own repository.
 

--- a/packages/nauro/README.md
+++ b/packages/nauro/README.md
@@ -17,46 +17,35 @@ Nauro keeps a living project record. It combines project scope, current state, a
 
 The markdown store, context summaries, BM25 retrieval, advisory checks, and optional sync support this loop. They do not replace your judgment or silently change project truth.
 
+## Why project history matters
+
+Pennykeep is the fictional budgeting app bundled with Nauro. Suppose an agent is asked to simplify onboarding by replacing envelope budgeting with a passive spending tracker and charts.
+
+The recorded decision, **Envelope budgeting method**, explains the tradeoff. In the fictional tester history, people who only saw past spending kept overspending. Assigning income before spending helped them change their behavior. The team accepted more setup effort to support that goal.
+
+With that context, an agent can suggest simpler envelope setup or ask you whether to revisit the budgeting model. This is an illustrative outcome, not a recorded agent response.
+
 ## Install
 
 ```bash
-uv tool install nauro     # uv fetches its own Python — nothing else needed
+uv tool install nauro
 ```
 
 No `uv`? Install it with `curl -LsSf https://astral.sh/uv/install.sh | sh` (macOS/Linux) or the [PowerShell line](https://docs.astral.sh/uv/getting-started/installation/) on Windows. Already on Python 3.10+? `pipx install nauro` (or `pip install nauro`) works too.
 
 ## Quickstart
 
-See a prior decision in about 30 seconds. No account, MCP wiring, or restart required:
+Try the Pennykeep example without an account or agent setup. On macOS or Linux:
 
 ```bash
 mkdir -p /tmp/nauro-demo && cd /tmp/nauro-demo
 nauro init --demo
-nauro check-decision "Store dollar amounts as decimal numbers"
+nauro check-decision "Replace envelope budgeting with a passive spending tracker and charts"
 ```
 
-`nauro init --demo` also generates `AGENTS.md` in the current directory so a coding agent can load the Nauro preflight and demo context before its first task. If the repo already has a hand-authored `AGENTS.md`, Nauro warns and leaves it unchanged.
+Look for **Envelope budgeting method** in the related decisions. Its rationale explains why the team accepted more onboarding effort to help users plan spending. The command retrieves prior decisions; it does not run an agent or change the recorded decision.
 
-You'll see a JSON envelope with the related decisions and a deterministic assessment, e.g.:
-
-```json
-{
-  "store": "local",
-  "related_decisions": [
-    {
-      "id": "decision-001",
-      "title": "Amounts stored in integer cents, never floating point",
-      "score": 8.462,
-      "status": "active",
-      "date": "2026-03-15",
-      "rationale_preview": "Every monetary amount (transactions, budgets, balances) is stored as an integer number of cents and formatted to dollars only for display..."
-    }
-  ],
-  "assessment": "Found 5 related decisions. Top match: D001 \"Amounts stored in integer cents, never floating point\"..."
-}
-```
-
-The demo project ruled out storing money as floating-point dollars because binary floating point cannot represent a value like 0.10 exactly, so totals accumulate rounding error and a balance that should read 0.00 shows -0.01. This protective example isolates Nauro's retrieval mechanism: it brings a recorded constraint into the proposal flow before an agent can re-propose the rejected field.
+See the [demo guide](https://nauro.ai/docs/quickstart#demo) for PowerShell commands and more ways to explore the sample.
 
 If a small repo plus a reliable AGENTS.md or CLAUDE.md keeps agents oriented, Nauro may be more than you need. Nauro is designed for context that must persist across longer histories, sessions, tools, repos, machines, or repeated handoffs.
 
@@ -84,7 +73,7 @@ Nauro supports a human-ratified project-judgment loop. It captures what you deci
 
 No model judges your decisions. The check uses deterministic keyword retrieval (BM25), is advisory, and never blocks a change. Agents draft additions, updates, and supersessions; you explicitly approve each one before `propose_decision` commits it in one call.
 
-`check_decision` returns the related prior decisions (the `related_decisions` list shown above) so the agent can weigh them before proposing; Nauro ranks by keyword relevance and does not judge the proposal. On the approved `propose_decision` call, near-matches surface as advisory `similar_decisions`, and a clean proposal commits in one call. What you approve in one tool, every connected agent inherits; for example, a decision recorded in Claude Code is available later in Perplexity. The store is plain markdown in a folder you own. Run it fully locally with no account; cloud sync is opt-in.
+`check_decision` returns the related prior decisions (the `related_decisions` list in the response) so the agent can weigh them before proposing; Nauro ranks by keyword relevance and does not judge the proposal. On the approved `propose_decision` call, near-matches surface as advisory `similar_decisions`, and a clean proposal commits in one call. What you approve in one tool, every connected agent inherits; for example, a decision recorded in Claude Code is available later in Perplexity. The store is plain markdown in a folder you own. Run it fully locally with no account; cloud sync is opt-in.
 
 ## Hosted allowance
 

--- a/packages/nauro/README.md
+++ b/packages/nauro/README.md
@@ -17,14 +17,6 @@ Nauro keeps a living project record. It combines project scope, current state, a
 
 The markdown store, context summaries, BM25 retrieval, advisory checks, and optional sync support this loop. They do not replace your judgment or silently change project truth.
 
-## Why project history matters
-
-Pennykeep is the fictional budgeting app bundled with Nauro. Suppose an agent is asked to simplify onboarding by replacing envelope budgeting with a passive spending tracker and charts.
-
-The recorded decision, **Envelope budgeting method**, explains the tradeoff. In the fictional tester history, people who only saw past spending kept overspending. Assigning income before spending helped them change their behavior. The team accepted more setup effort to support that goal.
-
-With that context, an agent can suggest simpler envelope setup or ask you whether to revisit the budgeting model. This is an illustrative outcome, not a recorded agent response.
-
 ## Install
 
 ```bash
@@ -33,9 +25,15 @@ uv tool install nauro
 
 No `uv`? Install it with `curl -LsSf https://astral.sh/uv/install.sh | sh` (macOS/Linux) or the [PowerShell line](https://docs.astral.sh/uv/getting-started/installation/) on Windows. Already on Python 3.10+? `pipx install nauro` (or `pip install nauro`) works too.
 
-## Quickstart
+## Try the demo (optional)
 
-Try the Pennykeep example without an account or agent setup. On macOS or Linux:
+Pennykeep is the fictional budgeting app bundled with Nauro.
+
+- **Request:** Replace envelope budgeting with spending charts to simplify onboarding.
+- **Prior decision:** In the fictional tester history, passive tracking did not help users control spending. The team accepted more setup effort so users assign income before spending.
+- **Effect on the plan:** An agent could suggest simpler envelope setup or ask whether to revisit the budgeting model.
+
+Try this example without an account or agent setup. On macOS or Linux:
 
 ```bash
 mkdir -p /tmp/nauro-demo && cd /tmp/nauro-demo
@@ -43,7 +41,7 @@ nauro init --demo
 nauro check-decision "Replace envelope budgeting with a passive spending tracker and charts"
 ```
 
-Look for **Envelope budgeting method** in the related decisions. Its rationale explains why the team accepted more onboarding effort to help users plan spending. The command retrieves prior decisions; it does not run an agent or change the recorded decision.
+Look for **Envelope budgeting method** in the related decisions. The command retrieves the prior reasoning; it does not run an agent or change the recorded decision.
 
 See the [demo guide](https://nauro.ai/docs/quickstart#demo) for PowerShell commands and more ways to explore the sample.
 

--- a/packages/nauro/src/nauro/demo/__init__.py
+++ b/packages/nauro/src/nauro/demo/__init__.py
@@ -200,20 +200,22 @@ DEMO_DECISIONS: list[Decision] = [
         DecisionConfidence.medium,
         DecisionType.pattern,
         Reversibility.moderate,
-        "The core model is envelope budgeting: every dollar of income is assigned to a "
-        "named category envelope before it is spent, and spending draws down a specific "
-        "envelope. The alternative, showing people where their money went after the "
-        "fact, is easier to build and easier to sell, but a rear-view report does not "
-        "change behavior. Committing each dollar in advance is what turns a tracker "
-        "into a budget.",
+        "Every dollar of income is assigned to a named category envelope before it is "
+        "spent, and spending draws down that envelope. This adds setup effort during "
+        "onboarding. In this fictional project's tester history, people who only saw "
+        "charts of past spending kept overspending; people who assigned money in "
+        "advance changed their spending. The team chose envelope budgeting to help "
+        "users plan what they can spend, accepting the extra allocation step. Simplify "
+        "that step when improving onboarding. Replacing it with a passive spending "
+        "tracker would require revisiting this product choice.",
         [
             RejectedAlternative(
                 name="Passive spending tracker",
                 reason=(
-                    "Categorizing past transactions into charts is lower-friction and demos "
-                    "well, but it answers 'where did it go?' rather than 'what is this for?'. "
-                    "Testers who only saw past spend kept overspending; the ones who had to "
-                    "assign money up front changed what they did."
+                    "Past-spending charts need less onboarding because users do not assign "
+                    "income before spending. In the fictional tester history, that simpler "
+                    "flow did not help users control spending. The team accepted more "
+                    "setup effort to keep the focus on planning future spending."
                 ),
             ),
         ],

--- a/packages/nauro/tests/test_distribution_copy.py
+++ b/packages/nauro/tests/test_distribution_copy.py
@@ -52,8 +52,7 @@ def test_root_readme_stays_within_first_use_scope() -> None:
     assert "nauro init --demo" in readme
     assert (
         'nauro check-decision "Replace envelope budgeting '
-        'with a passive spending tracker and charts"'
-        in readme
+        'with a passive spending tracker and charts"' in readme
     )
     assert "Envelope budgeting method" in readme
     assert readme.index("## See it in practice") < readme.index("## Try the demo (optional)")

--- a/packages/nauro/tests/test_distribution_copy.py
+++ b/packages/nauro/tests/test_distribution_copy.py
@@ -50,8 +50,13 @@ def test_root_readme_stays_within_first_use_scope() -> None:
     assert 400 <= len(readme.split()) <= 520
     assert "uv tool install nauro" in readme
     assert "nauro init --demo" in readme
-    assert 'nauro check-decision "Store dollar amounts as decimal numbers"' in readme
-    assert "D001" in readme
+    assert (
+        'nauro check-decision "Replace envelope budgeting with a passive spending tracker and charts"'
+        in readme
+    )
+    assert "Envelope budgeting method" in readme
+    assert readme.index("## See it in practice") < readme.index("## Try the demo (optional)")
+    assert readme.index("## Try the demo (optional)") < readme.index("Pennykeep")
     assert "nauro adopt" in readme
     assert "/nauro-adopt" in readme
 
@@ -68,6 +73,13 @@ def test_readmes_carry_cursor_and_skill_onboarding_contract() -> None:
     for relative in README_PATHS:
         text = (ROOT / relative).read_text(encoding="utf-8")
         assert "@nauro-adopt" in text, relative
+        assert "nauro adopt --with-skills --with-subagents" in text, relative
+        assert "/nauro-adopt" in text, relative
+        assert "$nauro-adopt" in text, relative
+        if relative == "README.md":
+            assert "https://nauro.ai/docs/agents-and-skills" in text
+            assert "https://nauro.ai/docs/quickstart" in text
+            continue
         assert "nauro setup cursor" in text, relative
         assert ".cursor/mcp.json" in text, relative
         assert "cursor.com/agents" in text, relative

--- a/packages/nauro/tests/test_distribution_copy.py
+++ b/packages/nauro/tests/test_distribution_copy.py
@@ -51,7 +51,8 @@ def test_root_readme_stays_within_first_use_scope() -> None:
     assert "uv tool install nauro" in readme
     assert "nauro init --demo" in readme
     assert (
-        'nauro check-decision "Replace envelope budgeting with a passive spending tracker and charts"'
+        'nauro check-decision "Replace envelope budgeting '
+        'with a passive spending tracker and charts"'
         in readme
     )
     assert "Envelope budgeting method" in readme


### PR DESCRIPTION
## Why

Readers need a clear explanation of Nauro and a simple setup path. The previous money-storage demo showed general programming advice rather than a project's reason for choosing an approach.

## What changed

Keep the product explanation and agent-session video first. Group desktop and CLI setup, move fit and ownership information earlier, and link detailed setup guidance.

Keep Pennykeep in the optional demo section, with a short request, prior decision, and possible effect on the plan. Use its envelope-budgeting tradeoff in both README demo commands and clarify the bundled decision's rationale. The tester history is fictional and the agent outcome is illustrative. Give real-repository onboarding a concrete first-use goal. Keep the root README within its existing 520-word limit and update copy tests for the new demo and setup links.

## Test plan

Passed static checks for Python syntax, all 13 demo decisions, matching README queries, code fences, and documentation targets in the local site source. Checked that Pennykeep first appears in the optional demo section of both READMEs. `git diff --check` passed. Five read-only distribution-copy tests passed locally, including all three checks that failed in the earlier CI run. Runtime retrieval was not run because Nauro execution is paused in this workspace; the example makes no ranking claim.

