### PR TITLE
Persist judgment identity and exclude private submission records

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
           packages/nauro/src/nauro/store/replica_control.py
           packages/nauro/src/nauro/store/generation_installation.py
           packages/nauro/src/nauro/sync/generation_acquisition.py
+          packages/nauro/src/nauro/store/submission_records.py
+          packages/nauro/src/nauro/sync/judgment_submission.py
           scripts/check_ruff_budget.py
       - run: python scripts/check_single_sourced.py packages/nauro/src
       - run: python scripts/check_docstring_budget.py packages/nauro/src packages/nauro-core/src

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
           packages/nauro/src/nauro/sync/generation_acquisition.py
           packages/nauro/src/nauro/store/submission_records.py
           packages/nauro/src/nauro/sync/judgment_submission.py
+          packages/nauro/src/nauro/sync/merge.py
           scripts/check_ruff_budget.py
       - run: python scripts/check_single_sourced.py packages/nauro/src
       - run: python scripts/check_docstring_budget.py packages/nauro/src packages/nauro-core/src
@@ -84,6 +85,7 @@ jobs:
           packages/nauro/tests/test_generation_installation.py
           packages/nauro/tests/test_replica_control.py
           packages/nauro/tests/test_sync/test_generation_acquisition.py
+          packages/nauro/tests/test_sync/test_submission_records_excluded.py
           packages/nauro/tests/test_sync/test_replica_control_excluded.py
           packages/nauro/tests/test_sync/test_push_admission.py
           packages/nauro/tests/test_sync/test_pull_admission.py
@@ -99,6 +101,7 @@ jobs:
       - run: uv sync --locked --package nauro --all-extras --python 3.10
       - run: >-
           uv run --no-sync --package nauro pytest
+          packages/nauro/tests/test_sync/test_submission_records_excluded.py
           packages/nauro/tests/test_sync/test_replica_control_excluded.py
           packages/nauro/tests/test_sync/test_push_admission.py
           packages/nauro/tests/test_sync/test_pull_admission.py

--- a/packages/nauro/src/nauro/store/submission_records.py
+++ b/packages/nauro/src/nauro/store/submission_records.py
@@ -35,6 +35,7 @@ from nauro.auth import read_active_user_id
 from nauro.store.home import nauro_home
 
 Digest = Annotated[StrictStr, Field(min_length=64, max_length=64, pattern="[0-9a-f]{64}")]
+SUBMISSION_RECORDS_DIR = "submission-records"
 _MAX_RECORD_BYTES = 2 * 1024 * 1024
 
 
@@ -177,7 +178,7 @@ def _ensure_directory(path: Path) -> None:
 def _scope_directory(project_id: str, user_id: str) -> Path:
     validate_identifier(IdentifierKind.ulid, project_id, field="project_id")
     validate_identifier(IdentifierKind.ulid, user_id, field="user_id")
-    return nauro_home() / "submission-records" / project_id / user_id
+    return nauro_home() / SUBMISSION_RECORDS_DIR / project_id / user_id
 
 
 def _record_path(scope: SubmissionScope) -> Path:

--- a/packages/nauro/src/nauro/store/submission_records.py
+++ b/packages/nauro/src/nauro/store/submission_records.py
@@ -1,0 +1,317 @@
+"""Durable, actor-bound judgment submissions outside the project sync root."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import stat
+import tempfile
+import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Annotated, Literal
+
+from filelock import BaseFileLock, FileLock, UnixFileLock, WindowsFileLock
+from nauro_core.identifiers import IdentifierKind, validate_identifier
+from nauro_core.operations.commit_plan import (
+    HostedPreTeamApprovalPayloadV1,
+    canonical_judgment_payload_bytes,
+)
+from nauro_core.provenance import validate_utc_timestamp
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    StrictInt,
+    StrictStr,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
+
+from nauro.auth import read_active_user_id
+from nauro.store.home import nauro_home
+
+Digest = Annotated[StrictStr, Field(min_length=64, max_length=64, pattern="[0-9a-f]{64}")]
+_MAX_RECORD_BYTES = 2 * 1024 * 1024
+
+
+class SubmissionRecordError(RuntimeError):
+    """A local submission cannot be read or durably stored."""
+
+
+class SubmissionRecordCorruptError(SubmissionRecordError):
+    """A stored submission fails its format or identity checks."""
+
+
+class SubmissionActorMismatchError(SubmissionRecordError):
+    """The active account does not own the saved operation."""
+
+
+def require_submission_actor(user_id: str) -> None:
+    if read_active_user_id() != user_id:
+        raise SubmissionActorMismatchError("The active account does not own this submission.")
+
+
+class _ClosedModel(BaseModel):
+    model_config = ConfigDict(
+        frozen=True,
+        extra="forbid",
+        strict=True,
+        hide_input_in_errors=True,
+        revalidate_instances="always",
+    )
+
+
+class SubmissionScope(_ClosedModel):
+    project_id: StrictStr
+    user_id: StrictStr
+    operation_kind: Literal["judgment_commit"] = "judgment_commit"
+    operation_id: StrictStr
+
+    @field_validator("project_id", "user_id")
+    @classmethod
+    def _ulid(cls, value: str) -> str:
+        return validate_identifier(IdentifierKind.ulid, value, field="submission_scope")
+
+    @field_validator("operation_id")
+    @classmethod
+    def _operation_id(cls, value: str) -> str:
+        return validate_identifier(IdentifierKind.operation_id, value, field="operation_id")
+
+
+class JudgmentTransportResult(_ClosedModel):
+    """Adapter-verified evidence, not an HTTP response or public wire schema."""
+
+    scope: SubmissionScope
+    payload_digest: Digest
+    status: Literal["absent", "pending", "committed", "stale", "expired", "disposed", "conflict"]
+    receipt_json: StrictStr | None = None
+
+    @model_validator(mode="after")
+    def _receipt(self) -> JudgmentTransportResult:
+        if self.status == "committed":
+            if not self.receipt_json:
+                raise ValueError("a committed result requires verified receipt bytes")
+        elif self.receipt_json is not None:
+            raise ValueError("only a committed result carries a receipt")
+        return self
+
+
+class JudgmentSubmission(_ClosedModel):
+    schema_version: StrictInt = Field(ge=1, le=1, default=1)
+    scope: SubmissionScope
+    created_at: StrictStr
+    approved_payload: StrictStr
+    payload_digest: Digest
+    phase: Literal["prepared", "uncertain", "resolved"]
+    result: JudgmentTransportResult | None = None
+
+    @field_validator("created_at")
+    @classmethod
+    def _timestamp(cls, value: str) -> str:
+        return validate_utc_timestamp(value, field="created_at")
+
+    @model_validator(mode="after")
+    def _bindings(self) -> JudgmentSubmission:
+        payload = HostedPreTeamApprovalPayloadV1.model_validate_json(
+            self.payload_bytes, strict=True
+        )
+        if canonical_judgment_payload_bytes(payload.model_dump(mode="json")) != self.payload_bytes:
+            raise ValueError("the approved payload must retain its canonical bytes")
+        if hashlib.sha256(self.payload_bytes).hexdigest() != self.payload_digest:
+            raise ValueError("the payload digest does not bind the approved bytes")
+        if self.phase == "resolved":
+            if self.result is None or self.result.status in {"absent", "pending"}:
+                raise ValueError("a resolved submission requires a terminal result")
+            if self.result.scope != self.scope or self.result.payload_digest != self.payload_digest:
+                raise ValueError("the result does not bind the submission")
+        elif self.result is not None:
+            raise ValueError("an unresolved submission cannot carry a terminal result")
+        return self
+
+    @property
+    def payload_bytes(self) -> bytes:
+        return self.approved_payload.encode("utf-8")
+
+
+class _StoredSubmission(_ClosedModel):
+    record: JudgmentSubmission
+    digest: Digest
+
+    @model_validator(mode="after")
+    def _integrity(self) -> _StoredSubmission:
+        encoded = self.record.model_dump_json().encode()
+        if hashlib.sha256(encoded).hexdigest() != self.digest:
+            raise ValueError("the stored submission digest does not bind its record")
+        return self
+
+
+def _directory_sync(path: Path) -> None:
+    fd = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def _ensure_directory(path: Path) -> None:
+    if path.parent != path:
+        _ensure_directory(path.parent)
+    try:
+        mode = path.lstat().st_mode
+    except FileNotFoundError:
+        try:
+            path.mkdir(mode=0o700)
+        except FileExistsError:
+            if not stat.S_ISDIR(path.lstat().st_mode):
+                raise SubmissionRecordError("The submission directory is not a directory.")
+    else:
+        if not stat.S_ISDIR(mode):
+            raise SubmissionRecordError("The submission directory is not a directory.")
+    _directory_sync(path.parent)
+
+
+def _scope_directory(project_id: str, user_id: str) -> Path:
+    validate_identifier(IdentifierKind.ulid, project_id, field="project_id")
+    validate_identifier(IdentifierKind.ulid, user_id, field="user_id")
+    return nauro_home() / "submission-records" / project_id / user_id
+
+
+def _record_path(scope: SubmissionScope) -> Path:
+    key = hashlib.sha256(scope.model_dump_json().encode()).hexdigest()
+    return _scope_directory(scope.project_id, scope.user_id) / f"{key}.json"
+
+
+def _read(path: Path) -> JudgmentSubmission | None:
+    try:
+        fd = os.open(
+            path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+        )
+    except FileNotFoundError:
+        return None
+    try:
+        with os.fdopen(fd, "rb") as handle:
+            if not stat.S_ISREG(os.fstat(handle.fileno()).st_mode):
+                raise SubmissionRecordCorruptError("The submission record is not a regular file.")
+            encoded = handle.read(_MAX_RECORD_BYTES + 1)
+        if len(encoded) > _MAX_RECORD_BYTES:
+            raise SubmissionRecordCorruptError("The submission record exceeds its size bound.")
+        stored = _StoredSubmission.model_validate_json(encoded, strict=True)
+        if stored.model_dump_json().encode() != encoded:
+            raise SubmissionRecordCorruptError("The submission record encoding is invalid.")
+        return stored.record
+    except (ValidationError, UnicodeError) as exc:
+        raise SubmissionRecordCorruptError("The submission record is malformed.") from exc
+
+
+def read_submission(scope: SubmissionScope) -> JudgmentSubmission | None:
+    """Distinguish a missing record from unreadable or corrupt evidence."""
+    require_submission_actor(scope.user_id)
+    record = _read(_record_path(scope))
+    if record is not None and record.scope != scope:
+        raise SubmissionRecordCorruptError("The submission belongs to another scope.")
+    return record
+
+
+def list_submissions(project_id: str, user_id: str) -> tuple[JudgmentSubmission, ...]:
+    """Discover recoverable identities after a process exits before returning an ID."""
+    require_submission_actor(user_id)
+    directory = _scope_directory(project_id, user_id)
+    try:
+        entries = os.scandir(directory)
+    except FileNotFoundError:
+        return ()
+    records = []
+    with entries:
+        for entry in entries:
+            if entry.name.endswith(".json"):
+                record = _read(Path(entry.path))
+                if record is None or _record_path(record.scope) != Path(entry.path):
+                    raise SubmissionRecordCorruptError(
+                        "The submission path does not bind its scope."
+                    )
+                records.append(record)
+    return tuple(sorted(records, key=lambda record: (record.created_at, record.scope.operation_id)))
+
+
+@contextmanager
+def submission_lock(scope: SubmissionScope) -> Iterator[None]:
+    """Serialize one item's durable transitions and transport calls."""
+    require_submission_actor(scope.user_id)
+    path = _record_path(scope)
+    _ensure_directory(path.parent)
+    lock: BaseFileLock = FileLock(str(path.with_suffix(".lock")), timeout=0, mode=0o600)
+    if type(lock) not in (UnixFileLock, WindowsFileLock):
+        raise SubmissionRecordError("Native submission locking is unavailable.")
+    with lock:
+        if type(lock) not in (UnixFileLock, WindowsFileLock):
+            raise SubmissionRecordError("Native submission locking is unavailable.")
+        _directory_sync(path.parent)
+        yield
+
+
+def _write(record: JudgmentSubmission) -> None:
+    path = _record_path(record.scope)
+    stored = _StoredSubmission(
+        record=record, digest=hashlib.sha256(record.model_dump_json().encode()).hexdigest()
+    )
+    encoded = stored.model_dump_json().encode()
+    if len(encoded) > _MAX_RECORD_BYTES:
+        raise SubmissionRecordError("The submission record exceeds its size bound.")
+    fd, name = tempfile.mkstemp(prefix=".submission-", dir=path.parent)
+    temporary = Path(name)
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(encoded)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+        _directory_sync(path.parent)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def prepare_submission(
+    project_id: str, user_id: str, approved_payload: bytes
+) -> JudgmentSubmission:
+    """Persist one explicitly approved operation before any network access."""
+    require_submission_actor(user_id)
+    record = JudgmentSubmission(
+        scope=SubmissionScope(
+            project_id=project_id, user_id=user_id, operation_id=uuid.uuid4().hex
+        ),
+        created_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+        approved_payload=approved_payload.decode("utf-8"),
+        payload_digest=hashlib.sha256(approved_payload).hexdigest(),
+        phase="prepared",
+    )
+    with submission_lock(record.scope):
+        if read_submission(record.scope) is not None:
+            raise SubmissionRecordError("The generated submission identity already exists.")
+        _write(record)
+    return record
+
+
+def mark_uncertain(record: JudgmentSubmission) -> JudgmentSubmission:
+    """Persist send intent while the caller holds the submission lock."""
+    if read_submission(record.scope) != record:
+        raise SubmissionRecordError("The saved submission changed before its transition.")
+    updated = JudgmentSubmission.model_validate({**record.model_dump(), "phase": "uncertain"})
+    _write(updated)
+    return updated
+
+
+def record_result(
+    record: JudgmentSubmission, result: JudgmentTransportResult
+) -> JudgmentSubmission:
+    """Persist terminal evidence while the caller holds the submission lock."""
+    if read_submission(record.scope) != record:
+        raise SubmissionRecordError("The saved submission changed before its transition.")
+    updated = JudgmentSubmission.model_validate(
+        {**record.model_dump(), "phase": "resolved", "result": result}
+    )
+    _write(updated)
+    return updated

--- a/packages/nauro/src/nauro/sync/judgment_submission.py
+++ b/packages/nauro/src/nauro/sync/judgment_submission.py
@@ -1,0 +1,117 @@
+"""Dormant send and lookup coordination for durable local judgment identities."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Protocol
+
+from nauro.store.submission_records import (
+    JudgmentSubmission,
+    JudgmentTransportResult,
+    SubmissionRecordError,
+    SubmissionScope,
+    mark_uncertain,
+    read_submission,
+    record_result,
+    require_submission_actor,
+    submission_lock,
+)
+
+
+class JudgmentTransport(Protocol):
+    """Authenticate the saved actor and verify remote evidence before returning a result."""
+
+    def submit(self, record: JudgmentSubmission) -> JudgmentTransportResult: ...
+
+    def lookup(self, scope: SubmissionScope, payload_digest: str) -> JudgmentTransportResult: ...
+
+
+class SubmissionRecoveryRequiredError(SubmissionRecordError):
+    """An uncertain operation requires lookup before another send."""
+
+
+class SubmissionRetryExpiredError(SubmissionRecordError):
+    """The original operation is outside its permitted resend horizon."""
+
+
+class SubmissionProtocolError(SubmissionRecordError):
+    """Transport evidence does not bind the saved operation."""
+
+
+def _load(scope: SubmissionScope) -> JudgmentSubmission:
+    require_submission_actor(scope.user_id)
+    record = read_submission(scope)
+    if record is None:
+        raise SubmissionRecordError("The saved submission is missing.")
+    require_submission_actor(scope.user_id)
+    return record
+
+
+def _require_retry_window(record: JudgmentSubmission) -> None:
+    created = datetime.fromisoformat(record.created_at.replace("Z", "+00:00"))
+    elapsed = datetime.now(timezone.utc) - created
+    if not timedelta(0) <= elapsed <= timedelta(hours=24):
+        raise SubmissionRetryExpiredError("The original submission is outside the retry horizon.")
+
+
+def _accept(record: JudgmentSubmission, result: JudgmentTransportResult) -> JudgmentTransportResult:
+    result = JudgmentTransportResult.model_validate(result)
+    if result.scope != record.scope or result.payload_digest != record.payload_digest:
+        raise SubmissionProtocolError("The transport result does not bind the saved submission.")
+    if result.status == "pending" and record.phase == "prepared":
+        mark_uncertain(record)
+    if result.status not in {"absent", "pending"}:
+        record_result(record, result)
+    require_submission_actor(record.scope.user_id)
+    return result
+
+
+def _send(record: JudgmentSubmission, transport: JudgmentTransport) -> JudgmentTransportResult:
+    _require_retry_window(record)
+    uncertain = mark_uncertain(record)
+    require_submission_actor(record.scope.user_id)
+    _require_retry_window(record)
+    result = transport.submit(uncertain)
+    if result.status == "absent":
+        raise SubmissionProtocolError("A send cannot return an absent lookup result.")
+    return _accept(uncertain, result)
+
+
+def submit_judgment(
+    scope: SubmissionScope, transport: JudgmentTransport
+) -> JudgmentTransportResult:
+    """Send a prepared item once; uncertain sends require explicit recovery."""
+    require_submission_actor(scope.user_id)
+    with submission_lock(scope):
+        record = _load(scope)
+        if record.result is not None:
+            return record.result
+        if record.phase != "prepared":
+            raise SubmissionRecoveryRequiredError("Resolve the original operation before retrying.")
+        return _send(record, transport)
+
+
+def recover_judgment(
+    scope: SubmissionScope, transport: JudgmentTransport
+) -> JudgmentTransportResult:
+    """Look up the original operation without submitting any payload."""
+    require_submission_actor(scope.user_id)
+    with submission_lock(scope):
+        record = _load(scope)
+        if record.result is not None:
+            return record.result
+        result = transport.lookup(scope, record.payload_digest)
+        return _accept(record, result)
+
+
+def retry_judgment(scope: SubmissionScope, transport: JudgmentTransport) -> JudgmentTransportResult:
+    """Resend identical bytes only after lookup proves absence and the horizon permits it."""
+    require_submission_actor(scope.user_id)
+    with submission_lock(scope):
+        record = _load(scope)
+        if record.result is not None:
+            return record.result
+        result = _accept(record, transport.lookup(scope, record.payload_digest))
+        if result.status != "absent":
+            return result
+        return _send(record, transport)

--- a/packages/nauro/src/nauro/sync/merge.py
+++ b/packages/nauro/src/nauro/sync/merge.py
@@ -25,6 +25,7 @@ from nauro.store.replica_control import (
     _REPLICA_CONTROL_ROOT_NAME,
 )
 from nauro.store.store_lock import DIR_LOCK_NAME, RMW_LOCK_SUFFIX
+from nauro.store.submission_records import SUBMISSION_RECORDS_DIR
 from nauro.sync._path_diagnostics import (
     _MissingPathPolicy,
     _NativeKind,
@@ -147,6 +148,8 @@ def _classify_component_path(
         return _unsafe(raw_identity, reason)
     if not view.semantic_components:
         return _unsafe(raw_identity, _UnsafeReason.EMPTY_PATH)
+    if SUBMISSION_RECORDS_DIR in view.semantic_components:
+        return _classified(raw_identity, _PathClass.RESERVED_CONTROL)
     if view.semantic_components[0] in {
         _REPLICA_CONTROL_ROOT_NAME.casefold(),
         _REPLICA_CONTROL_LOCK_NAME.casefold(),
@@ -557,6 +560,9 @@ def normalize_rel(relative_path: str) -> str:
 def should_skip(relative_path: str) -> bool:
     """Return True if this file should never be synced."""
     normalized = normalize_rel(relative_path)
+    admission = _classify_sync_path(relative_path)
+    if admission.path_class is _PathClass.RESERVED_CONTROL:
+        return True
     if normalized in NEVER_SYNC:
         return True
     if normalized.split("/", 1)[0].startswith(SPOOL_DIR_PREFIX):

--- a/packages/nauro/tests/test_judgment_submission.py
+++ b/packages/nauro/tests/test_judgment_submission.py
@@ -1,0 +1,419 @@
+"""Local submission durability and recovery across process boundaries."""
+
+from __future__ import annotations
+
+import errno
+import json
+import stat
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from unittest.mock import Mock
+
+import pytest
+from nauro_core.operations.commit_plan import canonical_judgment_payload_bytes
+
+from nauro.store import submission_records as records
+from nauro.sync import judgment_submission as submission
+
+PROJECT = "01K00000000000000000000001"
+USER = "01K00000000000000000000002"
+OTHER = "01K00000000000000000000003"
+
+
+def _payload():
+    return canonical_judgment_payload_bytes(
+        {
+            "payload_schema": "nauro.judgment_commit.pre_team.v1",
+            "approval_mode": "pre_team_session",
+            "base_generation_id": "01K00000000000000000000000",
+            "base_decision_counter": 4,
+            "proposed_base_commit": None,
+            "content": {
+                "operation": "add",
+                "affected_decision_id": None,
+                "title": "Durable identity",
+                "rationale": "Retain one identity and exact bytes across process restart.",
+                "rejected": [],
+                "confidence": "high",
+                "decision_type": None,
+                "reversibility": None,
+                "files_affected": [],
+                "resolves_questions": [],
+            },
+        }
+    )
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    root = tmp_path.resolve() / "client"
+    root.mkdir()
+    monkeypatch.setenv("NAURO_HOME", str(root))
+    (root / "config.json").write_text(
+        json.dumps({"auth": {"user_id": USER, "access_token": "synthetic-test-token"}})
+    )
+    return root
+
+
+def _prepared():
+    return records.prepare_submission(PROJECT, USER, _payload())
+
+
+def _result(record, status="committed"):
+    return records.JudgmentTransportResult(
+        scope=record.scope,
+        payload_digest=record.payload_digest,
+        status=status,
+        receipt_json='{"receipt_id":"synthetic-receipt"}' if status == "committed" else None,
+    )
+
+
+def test_record_is_private_and_outside_sync_root(home):
+    record = _prepared()
+    path = records._record_path(record.scope)
+    assert path.is_relative_to(home / "submission-records")
+    assert path.stat().st_mode & 0o777 == 0o600
+    assert not (home / "projects").exists()
+    assert records.read_submission(record.scope) == record
+    assert records.list_submissions(PROJECT, USER) == (record,)
+    assert record.payload_bytes == _payload()
+
+
+def test_new_approval_gets_distinct_identity_for_identical_bytes(home):
+    first, second = _prepared(), _prepared()
+    assert first.scope.operation_id != second.scope.operation_id
+    assert first.payload_digest == second.payload_digest
+    assert len(records.list_submissions(PROJECT, USER)) == 2
+
+
+def test_send_observes_durable_uncertain_state(home, monkeypatch):
+    record = _prepared()
+    events = []
+    real_sync = records.os.fsync
+
+    def fsync(fd):
+        real_sync(fd)
+        events.append("sync")
+
+    def send(saved):
+        assert saved.phase == "uncertain"
+        assert records.read_submission(record.scope) == saved
+        assert events[-2:] == ["sync", "sync"]
+        events.append("send")
+        return _result(saved)
+
+    monkeypatch.setattr(records.os, "fsync", fsync)
+    transport = Mock(submit=Mock(side_effect=send))
+    result = submission.submit_judgment(record.scope, transport)
+    assert result == _result(record)
+    assert records.read_submission(record.scope).phase == "resolved"
+    assert events[-2:] == ["sync", "sync"]
+    assert events.count("send") == 1
+
+
+def test_fsync_failure_prevents_send_and_preserves_record(home, monkeypatch):
+    record = _prepared()
+    transport = Mock()
+
+    real_sync = records.os.fsync
+
+    def fail(fd):
+        if stat.S_ISREG(records.os.fstat(fd).st_mode):
+            raise OSError(errno.ENOSPC, "synthetic disk full")
+        real_sync(fd)
+
+    monkeypatch.setattr(records.os, "fsync", fail)
+    with pytest.raises(OSError) as error:
+        submission.submit_judgment(record.scope, transport)
+    assert error.value.errno == errno.ENOSPC
+    transport.submit.assert_not_called()
+    assert records.read_submission(record.scope) == record
+
+
+def test_directory_sync_failure_after_replace_cannot_trigger_send(home, monkeypatch):
+    record = _prepared()
+    real_write = records.os.replace
+
+    def replaced_then_fail(source, target):
+        real_write(source, target)
+        monkeypatch.setattr(
+            records, "_directory_sync", Mock(side_effect=OSError(errno.EIO, "sync"))
+        )
+
+    monkeypatch.setattr(records.os, "replace", replaced_then_fail)
+    transport = Mock()
+    with pytest.raises(OSError) as error:
+        submission.submit_judgment(record.scope, transport)
+    assert error.value.errno == errno.EIO
+    assert records.read_submission(record.scope).phase == "uncertain"
+    transport.submit.assert_not_called()
+
+
+def test_dropped_response_requires_lookup_and_replays_exact_receipt(home):
+    record = _prepared()
+    transport = Mock(submit=Mock(side_effect=ConnectionError("lost response")))
+    with pytest.raises(ConnectionError):
+        submission.submit_judgment(record.scope, transport)
+    with pytest.raises(submission.SubmissionRecoveryRequiredError):
+        submission.submit_judgment(record.scope, transport)
+    assert transport.submit.call_count == 1
+    transport.lookup.return_value = _result(record)
+    assert submission.recover_judgment(record.scope, transport) == _result(record)
+    transport.lookup.assert_called_once_with(record.scope, record.payload_digest)
+    assert submission.submit_judgment(record.scope, transport) == _result(record)
+    assert transport.submit.call_count == 1
+
+
+@pytest.mark.parametrize("status", ["absent", "pending"])
+def test_nonterminal_lookup_never_resends_or_resolves(home, status):
+    record = _prepared()
+    transport = Mock(lookup=Mock(return_value=_result(record, status)))
+    assert submission.recover_judgment(record.scope, transport).status == status
+    assert records.read_submission(record.scope).phase == (
+        "uncertain" if status == "pending" else "prepared"
+    )
+    transport.submit.assert_not_called()
+
+
+def test_explicit_retry_looks_up_before_resending_original_bytes(home):
+    record = _prepared()
+    transport = Mock()
+    transport.lookup.return_value = _result(record, "absent")
+    transport.submit.return_value = _result(record)
+    assert submission.retry_judgment(record.scope, transport) == _result(record)
+    assert [call[0] for call in transport.mock_calls] == ["lookup", "submit"]
+    sent = transport.submit.call_args.args[0]
+    assert sent.scope == record.scope
+    assert sent.payload_bytes == record.payload_bytes
+
+
+@pytest.mark.parametrize("status", ["stale", "expired", "disposed", "conflict", "pending"])
+def test_retry_does_not_send_after_non_absent_lookup(home, status):
+    record = _prepared()
+    transport = Mock(lookup=Mock(return_value=_result(record, status)))
+    assert submission.retry_judgment(record.scope, transport).status == status
+    transport.submit.assert_not_called()
+
+
+def test_expired_item_can_recover_but_cannot_resend(home):
+    record = _prepared()
+    expired = records.JudgmentSubmission.model_validate(
+        {
+            **record.model_dump(),
+            "created_at": (datetime.now(timezone.utc) - timedelta(hours=25)).strftime(
+                "%Y-%m-%dT%H:%M:%S.%fZ"
+            ),
+        }
+    )
+    records._write(expired)
+    transport = Mock(lookup=Mock(return_value=_result(record, "absent")))
+    with pytest.raises(submission.SubmissionRetryExpiredError):
+        submission.retry_judgment(record.scope, transport)
+    transport.submit.assert_not_called()
+    transport.lookup.return_value = _result(record)
+    assert submission.recover_judgment(record.scope, transport) == _result(record)
+
+
+def test_actor_change_blocks_read_listing_and_send(home):
+    record = _prepared()
+    (home / "config.json").write_text(
+        json.dumps({"auth": {"user_id": OTHER, "access_token": "synthetic-test-token"}})
+    )
+    transport = Mock()
+    for action in (
+        lambda: records.read_submission(record.scope),
+        lambda: records.list_submissions(PROJECT, USER),
+        lambda: submission.submit_judgment(record.scope, transport),
+        lambda: records.prepare_submission(PROJECT, USER, _payload()),
+    ):
+        with pytest.raises(records.SubmissionActorMismatchError):
+            action()
+    transport.submit.assert_not_called()
+
+
+def test_cross_bound_result_is_not_recorded(home):
+    record = _prepared()
+    wrong = _result(record).model_copy(update={"payload_digest": "0" * 64})
+    transport = Mock(submit=Mock(return_value=wrong))
+    with pytest.raises(submission.SubmissionProtocolError):
+        submission.submit_judgment(record.scope, transport)
+    assert records.read_submission(record.scope).phase == "uncertain"
+
+
+@pytest.mark.parametrize("damage", ["digest", "duplicate", "truncated", "scope"])
+def test_corrupt_record_is_not_missing_or_sent(home, damage):
+    record = _prepared()
+    path = records._record_path(record.scope)
+    encoded = path.read_bytes()
+    if damage == "duplicate":
+        encoded = b'{"phase":"prepared",' + encoded[1:]
+    elif damage == "truncated":
+        encoded = encoded[:-1]
+    else:
+        raw = json.loads(encoded)
+        if damage == "digest":
+            raw["record"]["payload_digest"] = "0" * 64
+        else:
+            raw["record"]["scope"]["project_id"] = OTHER
+        encoded = json.dumps(raw, separators=(",", ":")).encode()
+    path.write_bytes(encoded)
+    transport = Mock()
+    with pytest.raises(records.SubmissionRecordCorruptError):
+        submission.submit_judgment(record.scope, transport)
+    transport.submit.assert_not_called()
+    assert path.read_bytes() == encoded
+
+
+def test_per_item_lock_excludes_another_process(home):
+    record = _prepared()
+    program = """
+import sys
+from nauro.store.submission_records import SubmissionScope, submission_lock
+from filelock import Timeout
+scope = SubmissionScope.model_validate_json(sys.argv[1])
+try:
+    with submission_lock(scope):
+        raise SystemExit(2)
+except Timeout:
+    raise SystemExit(7)
+"""
+    with records.submission_lock(record.scope):
+        child = subprocess.run(
+            [sys.executable, "-c", program, record.scope.model_dump_json()],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    assert child.returncode == 7, child.stderr
+
+
+def test_restart_discovers_original_identity_after_process_exit_during_send(home):
+    program = """
+import os, sys
+from nauro.store.submission_records import prepare_submission
+from nauro.sync.judgment_submission import submit_judgment
+record = prepare_submission(sys.argv[1], sys.argv[2], bytes.fromhex(sys.argv[3]))
+class DroppedResponse:
+    def submit(self, saved):
+        os._exit(17)
+submit_judgment(record.scope, DroppedResponse())
+"""
+    first = subprocess.run(
+        [sys.executable, "-c", program, PROJECT, USER, _payload().hex()],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    assert first.returncode == 17, first.stderr
+    (saved,) = records.list_submissions(PROJECT, USER)
+    assert saved.phase == "uncertain"
+    assert saved.payload_bytes == _payload()
+    transport = Mock(lookup=Mock(return_value=_result(saved)))
+    assert submission.recover_judgment(saved.scope, transport) == _result(saved)
+    transport.submit.assert_not_called()
+
+
+def test_receipt_corruption_is_not_replayed_from_local_storage(home):
+    record = _prepared()
+    transport = Mock(submit=Mock(return_value=_result(record)))
+    submission.submit_judgment(record.scope, transport)
+    path = records._record_path(record.scope)
+    raw = json.loads(path.read_bytes())
+    raw["record"]["result"]["receipt_json"] = '{"receipt_id":"wrong-receipt"}'
+    path.write_text(json.dumps(raw, separators=(",", ":")))
+    with pytest.raises(records.SubmissionRecordCorruptError):
+        submission.recover_judgment(record.scope, transport)
+    transport.lookup.assert_not_called()
+
+
+def test_permission_failure_is_not_absence(home, monkeypatch):
+    record = _prepared()
+    original_open = records.os.open
+    target = records._record_path(record.scope)
+
+    def denied(path, flags, *args, **kwargs):
+        if path == target:
+            raise PermissionError(errno.EACCES, "synthetic access refusal")
+        return original_open(path, flags, *args, **kwargs)
+
+    monkeypatch.setattr(records.os, "open", denied)
+    transport = Mock()
+    with pytest.raises(PermissionError) as error:
+        submission.recover_judgment(record.scope, transport)
+    assert error.value.errno == errno.EACCES
+    transport.lookup.assert_not_called()
+
+
+def test_failed_result_persistence_keeps_recovery_possible(home, monkeypatch):
+    record = _prepared()
+    transport = Mock(submit=Mock(return_value=_result(record)))
+    write = records._write
+
+    def fail_completion(updated):
+        if updated.phase == "resolved":
+            raise OSError(errno.ENOSPC, "synthetic full disk")
+        write(updated)
+
+    monkeypatch.setattr(records, "_write", fail_completion)
+    with pytest.raises(OSError) as error:
+        submission.submit_judgment(record.scope, transport)
+    assert error.value.errno == errno.ENOSPC
+    assert records.read_submission(record.scope).phase == "uncertain"
+    monkeypatch.setattr(records, "_write", write)
+    transport.lookup.return_value = _result(record)
+    assert submission.recover_judgment(record.scope, transport) == _result(record)
+    assert transport.submit.call_count == 1
+
+
+def test_stale_local_observation_cannot_reset_a_resolved_item(home):
+    record = _prepared()
+    transport = Mock(submit=Mock(return_value=_result(record)))
+    submission.submit_judgment(record.scope, transport)
+    with records.submission_lock(record.scope):
+        with pytest.raises(records.SubmissionRecordError, match="changed"):
+            records.mark_uncertain(record)
+    assert records.read_submission(record.scope).phase == "resolved"
+
+
+def test_soft_lock_is_refused_before_send(home, monkeypatch):
+    from filelock import SoftFileLock
+
+    record = _prepared()
+    monkeypatch.setattr(records, "FileLock", SoftFileLock)
+    transport = Mock()
+    with pytest.raises(records.SubmissionRecordError, match="Native submission locking"):
+        submission.submit_judgment(record.scope, transport)
+    transport.submit.assert_not_called()
+
+
+def test_missing_record_never_becomes_a_new_submission(home):
+    scope = records.SubmissionScope(project_id=PROJECT, user_id=USER, operation_id="missing")
+    assert records.read_submission(scope) is None
+    transport = Mock()
+    with pytest.raises(records.SubmissionRecordError, match="missing"):
+        submission.recover_judgment(scope, transport)
+    transport.lookup.assert_not_called()
+    transport.submit.assert_not_called()
+
+
+def test_noncanonical_approval_cannot_create_a_record(home):
+    with pytest.raises(ValueError):
+        records.prepare_submission(PROJECT, USER, _payload() + b"\n")
+    assert records.list_submissions(PROJECT, USER) == ()
+
+
+def test_submission_coordinator_has_no_production_caller():
+    import ast
+    from pathlib import Path
+
+    root = Path(submission.__file__).parents[1]
+    callers = []
+    for path in root.rglob("*.py"):
+        if path == Path(submission.__file__):
+            continue
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module == "nauro.sync.judgment_submission":
+                callers.append(path.relative_to(root).as_posix())
+    assert callers == []

--- a/packages/nauro/tests/test_sync/test_pull_admission.py
+++ b/packages/nauro/tests/test_sync/test_pull_admission.py
@@ -60,6 +60,11 @@ UNUSABLE = pull_module._DECISIONS_UNUSABLE_TEXT
 AUTHORITY = f"{_REPLICA_CONTROL_ROOT_NAME}/authority.json"
 
 RESERVED_ROWS = [
+    "submission-records/record.json",
+    "context/SUBMISSION-RECORDS/record.json",
+    " submission-records. /record.json",
+    "submission-records:stream/record.json",
+    "submission-records\\record.json",
     AUTHORITY,
     _REPLICA_CONTROL_LOCK_NAME,
     ".REPLICA/x",

--- a/packages/nauro/tests/test_sync/test_submission_records_excluded.py
+++ b/packages/nauro/tests/test_sync/test_submission_records_excluded.py
@@ -1,0 +1,45 @@
+"""Private submission records cannot enter raw sync."""
+
+from pathlib import Path
+
+import pytest
+
+from nauro.sync import merge
+from nauro.sync._path_diagnostics import _PathClass
+from nauro.sync.push import plan_push
+from nauro.sync.state import SyncState
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "submission-records",
+        "./submission-records/record.json",
+        "submission-records/record.json",
+        "SUBMISSION-RECORDS/record.json",
+        " submission-records. /record.json",
+        "submission-records:stream/record.json",
+        "submission-records\\record.json",
+        "context/submission-records/record.json",
+    ],
+)
+def test_record_aliases_are_reserved(path: str) -> None:
+    assert merge._classify_sync_path(path).path_class is _PathClass.RESERVED_CONTROL
+    assert merge.should_skip(path) is True
+
+
+@pytest.mark.parametrize("path", ["context/note.md", "submission-records.md", "poetry.lock"])
+def test_ordinary_files_remain_syncable(path: str) -> None:
+    assert merge.should_skip(path) is False
+
+
+def test_push_prunes_copied_records_and_links(tmp_path: Path) -> None:
+    store = tmp_path / "store"
+    records = store / "context" / "submission-records"
+    records.mkdir(parents=True)
+    (records / "record.json").write_text("private approval")
+    (store / "note.md").write_text("public note")
+    (store / "record-link.json").symlink_to(records / "record.json")
+    plan = plan_push(store, SyncState())
+    assert [item.relative_path for item in plan.candidates] == ["note.md"]
+    assert plan.unsafe == ()


### PR DESCRIPTION
## Why

A lost judgment response must not cause a second operation. The client needs a durable identity and the exact approved payload before transport can send anything.

## What changed

- Persist actor-bound submission records outside the project sync root, with checksums, private files, native item locks and explicit durability barriers.
- Add dormant submit, lookup and explicit retry coordination. Persist uncertainty before sending; retain the original identity and bytes after a lost response; persist terminal evidence before returning it.
- Exclude the reserved submission-record component and its aliases from generic sync paths, including copied trees.
- Add targeted typing and tests for persistence failures, account changes, process exit, recovery and path admission.

## Test plan

- [All 17 CI jobs passed](https://github.com/Nauro-AI/nauro/actions/runs/33976042065), including Python 3.10 through 3.14 client/core suites and platform generation checks.

- Lint, formatting, targeted typing, source-risk, single-source and docstring checks passed.
- Exact candidate: 228 affected client and core tests passed; 10 platform-specific cases skipped.
- Explicit cross-repository bridge and exclusion checks: 46 passed without skips. A server commit followed by a dropped response recovers through lookup in a new client process; another restart reuses the exact receipt without another submit or storage mutation.
- Combined code review and rebase comparison found no blocking defect or patch change.

## Risk / what to review

Review the file-sync, replacement and directory-sync sequence, the fresh reads under the item lock, and the distinction between absent and uncertain outcomes. The internal transport protocol requires an adapter that authenticates the saved actor and verifies remote receipts. Checksums detect corruption; they do not authenticate a server response. The quality gate counts findings and does not replace design review.

## Deferred

Concurrent writing remains incomplete and production activation is unchanged. This coordinator has no production caller. Authenticated transport and receipt verification remain separate. Windows durability, power-loss behavior, cloud retry identity and hosted latency are unproven. The cross-repository bridge uses synthetic identity and a test-only envelope. Matching server exclusions and the restart integration test will follow after this PR merges.
