### PR TITLE
Verify authenticated judgment transport responses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
           packages/nauro/src/nauro/sync/generation_acquisition.py
           packages/nauro/src/nauro/store/submission_records.py
           packages/nauro/src/nauro/sync/judgment_submission.py
+          packages/nauro/src/nauro/sync/judgment_transport.py
+          packages/nauro/src/nauro/auth.py
           packages/nauro/src/nauro/sync/merge.py
           scripts/check_ruff_budget.py
       - run: python scripts/check_single_sourced.py packages/nauro/src

--- a/packages/nauro/src/nauro/auth.py
+++ b/packages/nauro/src/nauro/auth.py
@@ -23,6 +23,7 @@ import threading
 import time
 from collections.abc import Callable, Mapping
 from contextlib import suppress
+from dataclasses import dataclass, field
 
 import filelock
 import httpx
@@ -192,7 +193,13 @@ def _read_active_config() -> bytes:
                 os.close(descriptor)
 
 
-def read_active_user_id() -> str:
+@dataclass(frozen=True)
+class ActiveCredentials:
+    user_id: str
+    access_token: str = field(repr=False)
+
+
+def read_active_credentials() -> ActiveCredentials:
     raw = _read_active_config()
 
     def object_from_pairs(pairs: list[tuple[str, object]]) -> dict[str, object]:
@@ -216,9 +223,15 @@ def read_active_user_id() -> str:
         token, user_id = auth.get("access_token"), auth.get("user_id")
         if type(token) is not str or not token or type(user_id) is not str or not user_id:
             raise ValueError("invalid authentication state")
-        return validate_identifier(IdentifierKind.ulid, user_id, field="auth.user_id")
+        return ActiveCredentials(
+            validate_identifier(IdentifierKind.ulid, user_id, field="auth.user_id"), token
+        )
     except (UnicodeError, json.JSONDecodeError, ValueError, TypeError, RecursionError) as exc:
         raise ActiveUserReadError(_NO_ACTIVE_ACCOUNT) from exc
+
+
+def read_active_user_id() -> str:
+    return read_active_credentials().user_id
 
 
 def load_access_token() -> str | None:
@@ -407,4 +420,7 @@ def decode_jwt_payload(token: str) -> dict:
     if padding != 4:
         payload_b64 += "=" * padding
     payload_bytes = base64.urlsafe_b64decode(payload_b64)
-    return json.loads(payload_bytes)
+    payload = json.loads(payload_bytes)
+    if not isinstance(payload, dict):
+        raise ValueError("JWT payload must be an object")
+    return payload

--- a/packages/nauro/src/nauro/sync/judgment_transport.py
+++ b/packages/nauro/src/nauro/sync/judgment_transport.py
@@ -1,0 +1,183 @@
+"""Dormant authenticated transport for durable judgment submissions."""
+
+from __future__ import annotations
+
+import json
+from typing import Literal
+
+import httpx
+from nauro_core.identifiers import IdentifierKind, validate_identifier
+from nauro_core.provenance import validate_utc_timestamp
+from pydantic import BaseModel, ConfigDict, Field, StrictInt, StrictStr, field_validator
+
+from nauro.auth import read_active_credentials
+from nauro.store.submission_records import (
+    Digest,
+    JudgmentSubmission,
+    JudgmentTransportResult,
+    SubmissionActorMismatchError,
+    SubmissionRecordError,
+    SubmissionScope,
+    require_submission_actor,
+)
+
+
+class JudgmentTransportError(SubmissionRecordError):
+    """The authenticated transport did not establish a bound operation result."""
+
+
+class _ClosedModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+
+class _ReceiptDetails(_ClosedModel):
+    decision_counter: StrictInt = Field(ge=1)
+    fencing_token: StrictInt = Field(ge=1)
+    manifest_digest: Digest
+    plan_record_digest: Digest
+    saga_id: StrictStr
+    snapshot_digest: Digest
+    snapshot_key: StrictStr
+
+    @field_validator("saga_id")
+    @classmethod
+    def _saga_id(cls, value: str) -> str:
+        return validate_identifier(IdentifierKind.ulid, value, field="saga_id")
+
+
+class _JudgmentReceipt(_ClosedModel):
+    receipt_id: StrictStr
+    operation_kind: Literal["judgment_commit"]
+    operation_id: StrictStr
+    result: Literal["committed"]
+    committed_at: StrictStr
+    artifact_digest: Digest
+    generation_id: StrictStr
+    target_kind: Literal["decision"]
+    target_id: StrictStr
+    details: _ReceiptDetails
+
+    @field_validator("receipt_id", "generation_id")
+    @classmethod
+    def _ulid(cls, value: str) -> str:
+        return validate_identifier(IdentifierKind.ulid, value, field="receipt_identity")
+
+    @field_validator("committed_at")
+    @classmethod
+    def _timestamp(cls, value: str) -> str:
+        return validate_utc_timestamp(value, field="committed_at")
+
+    @field_validator("target_id")
+    @classmethod
+    def _target(cls, value: str) -> str:
+        return validate_identifier(IdentifierKind.audit_target_id, value, field="target_id")
+
+
+def _unique_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result = dict(pairs)
+    if len(result) != len(pairs):
+        raise ValueError("duplicate JSON key")
+    return result
+
+
+class _Response(JudgmentTransportResult):
+    version: StrictInt = Field(ge=1, le=1)
+
+
+def verify_judgment_response(
+    raw: bytes, scope: SubmissionScope, payload_digest: str
+) -> JudgmentTransportResult:
+    try:
+        if len(raw) > 64 * 1024:
+            raise ValueError("response exceeds byte limit")
+        parsed = json.loads(raw.decode("utf-8"), object_pairs_hook=_unique_object)
+        result = _Response.model_validate(parsed)
+        if result.scope != scope or result.payload_digest != payload_digest:
+            raise ValueError("response binding mismatch")
+        if result.receipt_json is not None:
+            _verify_receipt(result.receipt_json, scope)
+        return JudgmentTransportResult.model_validate(result.model_dump(exclude={"version"}))
+    except (ValueError, TypeError, RecursionError) as exc:
+        raise JudgmentTransportError("The server response did not verify.") from exc
+
+
+def _verify_receipt(receipt_json: str, scope: SubmissionScope) -> None:
+    if len(receipt_json.encode("utf-8")) > 8192:
+        raise ValueError("receipt exceeds byte limit")
+    receipt = _JudgmentReceipt.model_validate_json(receipt_json, strict=True)
+    canonical = json.dumps(
+        receipt.model_dump(mode="json"), sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    )
+    if canonical != receipt_json or receipt.operation_id != scope.operation_id:
+        raise ValueError("receipt identity or canonical bytes differ")
+    if receipt.artifact_digest != receipt.details.manifest_digest:
+        raise ValueError("receipt manifest differs")
+    snapshot_key = f"generations/{scope.project_id}/{receipt.generation_id}/snapshot.json"
+    if receipt.details.snapshot_key != snapshot_key:
+        raise ValueError("receipt snapshot differs")
+
+
+class HttpJudgmentTransport:
+    """Use one caller-owned client and a trusted origin without automatic retries."""
+
+    def __init__(self, base_url: str, client: httpx.Client) -> None:
+        url = httpx.URL(base_url)
+        if (
+            url.scheme != "https"
+            or not url.host
+            or url.userinfo
+            or url.query
+            or url.fragment
+            or url.path not in {"", "/"}
+        ):
+            raise JudgmentTransportError("Judgment transport requires a trusted HTTPS origin.")
+        self._base_url = str(url).rstrip("/")
+        self._client = client
+
+    def _request(
+        self, route: str, scope: SubmissionScope, digest: str, payload: str | None = None
+    ) -> JudgmentTransportResult:
+        credentials = read_active_credentials()
+        if credentials.user_id != scope.user_id:
+            raise SubmissionActorMismatchError("The active account does not own this submission.")
+        body: dict[str, object] = {
+            "version": 1,
+            "project_id": scope.project_id,
+            "expected_user_id": scope.user_id,
+            "operation_id": scope.operation_id,
+            "payload_digest": digest,
+        }
+        if payload is not None:
+            body["approved_payload"] = payload
+        try:
+            with self._client.stream(
+                "POST",
+                self._base_url + route,
+                json=body,
+                headers={"Authorization": f"Bearer {credentials.access_token}"},
+                timeout=25,
+                follow_redirects=False,
+            ) as response:
+                if response.status_code != 200:
+                    raise JudgmentTransportError("The server did not return an operation result.")
+                raw = bytearray()
+                for chunk in response.iter_bytes():
+                    raw.extend(chunk)
+                    if len(raw) > 64 * 1024:
+                        raise JudgmentTransportError("The server response exceeds the byte limit.")
+        except httpx.HTTPError as exc:
+            raise JudgmentTransportError(
+                "The operation result is unknown. Look up its identity."
+            ) from exc
+        require_submission_actor(scope.user_id)
+        return verify_judgment_response(bytes(raw), scope, digest)
+
+    def submit(self, record: JudgmentSubmission) -> JudgmentTransportResult:
+        record = JudgmentSubmission.model_validate(record)
+        return self._request(
+            "/judgments/submit", record.scope, record.payload_digest, record.approved_payload
+        )
+
+    def lookup(self, scope: SubmissionScope, payload_digest: str) -> JudgmentTransportResult:
+        scope = SubmissionScope.model_validate(scope)
+        return self._request("/judgments/lookup", scope, payload_digest)

--- a/packages/nauro/tests/test_judgment_transport.py
+++ b/packages/nauro/tests/test_judgment_transport.py
@@ -1,0 +1,291 @@
+"""Client transport refuses unbound evidence and preserves uncertain records."""
+
+import json
+
+import httpx
+import pytest
+
+from nauro.auth import read_active_credentials
+from nauro.store.submission_records import read_submission
+from nauro.sync.judgment_submission import recover_judgment, submit_judgment
+from nauro.sync.judgment_transport import (
+    HttpJudgmentTransport,
+    JudgmentTransportError,
+    verify_judgment_response,
+)
+from tests.test_judgment_submission import OTHER, USER, _prepared, home
+
+__all__ = ["home"]
+
+
+def _response(record, **changes):
+    body = {
+        "version": 1,
+        "scope": record.scope.model_dump(),
+        "payload_digest": record.payload_digest,
+        "status": "absent",
+        "receipt_json": None,
+    }
+    body.update(changes)
+    return json.dumps(body).encode()
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"version": True},
+        {"version": 2},
+        {"unexpected": "field"},
+        {"payload_digest": "a" * 64},
+        {"status": "committed"},
+        {"receipt_json": "{}"},
+        {"status": "missing"},
+    ],
+)
+def test_response_binding_fails_closed(home, changes):
+    record = _prepared()
+    with pytest.raises(JudgmentTransportError):
+        verify_judgment_response(_response(record, **changes), record.scope, record.payload_digest)
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("user_id", OTHER),
+        ("project_id", OTHER),
+        ("operation_id", "other-operation"),
+        ("operation_kind", "update_state"),
+    ],
+)
+def test_response_scope_must_match(home, field, value):
+    record = _prepared()
+    scope = {**record.scope.model_dump(), field: value}
+    with pytest.raises(JudgmentTransportError):
+        verify_judgment_response(
+            _response(record, scope=scope), record.scope, record.payload_digest
+        )
+
+
+@pytest.mark.parametrize("raw", [b'{"version":1,"version":1}', b"NaN", b"\xff", b" " * 65537])
+def test_malformed_response_refused(home, raw):
+    record = _prepared()
+    with pytest.raises(JudgmentTransportError):
+        verify_judgment_response(raw, record.scope, record.payload_digest)
+
+
+@pytest.mark.parametrize("status", [301, 307, 401, 403, 404, 409, 429, 500, 503])
+def test_http_failure_does_not_resend_or_resolve(home, status):
+    record = _prepared()
+    requests = []
+
+    def handle(request):
+        requests.append(request)
+        return httpx.Response(status, headers={"Location": "https://other.example/"})
+
+    with httpx.Client(transport=httpx.MockTransport(handle), follow_redirects=True) as client:
+        transport = HttpJudgmentTransport("https://example.test", client)
+        with pytest.raises(JudgmentTransportError):
+            submit_judgment(record.scope, transport)
+    assert len(requests) == 1
+    assert read_submission(record.scope).phase == "uncertain"
+    assert requests[0].headers["Authorization"] == "Bearer synthetic-test-token"
+    assert json.loads(requests[0].content)["approved_payload"] == record.approved_payload
+
+
+def test_lost_response_is_followed_only_by_lookup(home):
+    record = _prepared()
+    requests = []
+
+    def handle(request):
+        requests.append(request)
+        if request.url.path == "/judgments/submit":
+            raise httpx.ReadError("lost response")
+        return httpx.Response(200, content=_response(record, status="pending"))
+
+    with httpx.Client(transport=httpx.MockTransport(handle)) as client:
+        transport = HttpJudgmentTransport("https://example.test", client)
+        with pytest.raises(JudgmentTransportError):
+            submit_judgment(record.scope, transport)
+        assert recover_judgment(record.scope, transport).status == "pending"
+    assert [request.url.path for request in requests] == ["/judgments/submit", "/judgments/lookup"]
+    assert "approved_payload" not in json.loads(requests[1].content)
+    assert read_submission(record.scope).phase == "uncertain"
+
+
+@pytest.mark.parametrize(
+    "origin",
+    [
+        "http://example.test",
+        "https://user:secret@example.test",
+        "https://example.test/path",
+        "https://example.test/?token=x",
+        "https://example.test/#fragment",
+    ],
+)
+def test_unsafe_origin_refused(origin):
+    with httpx.Client() as client, pytest.raises(JudgmentTransportError):
+        HttpJudgmentTransport(origin, client)
+
+
+def test_credentials_bind_actor_and_token_from_one_read(home):
+    credentials = read_active_credentials()
+    assert credentials.user_id == USER
+    assert credentials.access_token == "synthetic-test-token"
+    assert "synthetic-test-token" not in repr(credentials)
+
+
+def _receipt(record):
+    generation = "01K00000000000000000000009"
+    return {
+        "receipt_id": generation,
+        "operation_kind": "judgment_commit",
+        "operation_id": record.scope.operation_id,
+        "result": "committed",
+        "committed_at": "2026-09-05T00:00:00.000000Z",
+        "artifact_digest": "a" * 64,
+        "generation_id": generation,
+        "target_kind": "decision",
+        "target_id": "005-durable-identity",
+        "details": {
+            "decision_counter": 5,
+            "fencing_token": 1,
+            "manifest_digest": "a" * 64,
+            "plan_record_digest": "b" * 64,
+            "saga_id": generation,
+            "snapshot_digest": "c" * 64,
+            "snapshot_key": f"generations/{record.scope.project_id}/{generation}/snapshot.json",
+        },
+    }
+
+
+def _encoded_receipt(value):
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def test_exact_canonical_receipt_is_retained(home):
+    record = _prepared()
+    receipt = _encoded_receipt(_receipt(record))
+    result = verify_judgment_response(
+        _response(record, status="committed", receipt_json=receipt),
+        record.scope,
+        record.payload_digest,
+    )
+    assert result.receipt_json == receipt
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("operation_id", "other-operation"),
+        ("operation_kind", "update_state"),
+        ("result", "accepted"),
+        ("artifact_digest", "b" * 64),
+        ("generation_id", "01K00000000000000000000008"),
+        ("target_kind", "question"),
+        ("receipt_id", "invalid"),
+        ("committed_at", "yesterday"),
+        ("extra", "unexpected"),
+    ],
+)
+def test_receipt_fields_are_bound(home, field, value):
+    record = _prepared()
+    receipt = {**_receipt(record), field: value}
+    with pytest.raises(JudgmentTransportError):
+        verify_judgment_response(
+            _response(record, status="committed", receipt_json=_encoded_receipt(receipt)),
+            record.scope,
+            record.payload_digest,
+        )
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("decision_counter", True),
+        ("decision_counter", "5"),
+        ("fencing_token", 0),
+        ("snapshot_key", "generations/other/snapshot.json"),
+        ("saga_id", "invalid"),
+        ("manifest_digest", "b" * 64),
+        ("plan_record_digest", "invalid"),
+        ("extra", "unexpected"),
+    ],
+)
+def test_receipt_details_are_validated(home, field, value):
+    record = _prepared()
+    receipt = _receipt(record)
+    receipt["details"][field] = value
+    with pytest.raises(JudgmentTransportError):
+        verify_judgment_response(
+            _response(record, status="committed", receipt_json=_encoded_receipt(receipt)),
+            record.scope,
+            record.payload_digest,
+        )
+
+
+@pytest.mark.parametrize("kind", ["duplicate", "whitespace", "oversize"])
+def test_receipt_encoding_is_exact(home, kind):
+    record = _prepared()
+    receipt = _encoded_receipt(_receipt(record))
+    if kind == "duplicate":
+        receipt = receipt.replace(
+            '"result":"committed"', '"result":"committed","result":"committed"'
+        )
+    elif kind == "whitespace":
+        receipt += " "
+    else:
+        receipt += " " * 8192
+    with pytest.raises(JudgmentTransportError):
+        verify_judgment_response(
+            _response(record, status="committed", receipt_json=receipt),
+            record.scope,
+            record.payload_digest,
+        )
+
+
+def test_wrong_account_cannot_send(home):
+    from nauro.store.submission_records import SubmissionActorMismatchError
+
+    record = _prepared()
+    (home / "config.json").write_text(
+        json.dumps({"auth": {"user_id": OTHER, "access_token": "other-token"}})
+    )
+    requests = []
+    with httpx.Client(
+        transport=httpx.MockTransport(lambda request: requests.append(request))
+    ) as client:
+        transport = HttpJudgmentTransport("https://example.test", client)
+        with pytest.raises(SubmissionActorMismatchError):
+            transport.submit(record)
+    assert requests == []
+
+
+def test_nonobject_jwt_payload_is_rejected():
+    import base64
+
+    from nauro.auth import decode_jwt_payload
+
+    body = base64.urlsafe_b64encode(b"[]").decode().rstrip("=")
+    with pytest.raises(ValueError, match="JWT payload must be an object"):
+        decode_jwt_payload(f"header.{body}.signature")
+
+
+def test_account_switch_during_request_leaves_result_unresolved(home):
+    from nauro.store.submission_records import SubmissionActorMismatchError
+
+    record = _prepared()
+    original = (home / "config.json").read_bytes()
+
+    def handle(request):
+        assert request.headers["Authorization"] == "Bearer synthetic-test-token"
+        (home / "config.json").write_text(
+            json.dumps({"auth": {"user_id": OTHER, "access_token": "other-token"}})
+        )
+        return httpx.Response(200, content=_response(record, status="pending"))
+
+    with httpx.Client(transport=httpx.MockTransport(handle)) as client:
+        transport = HttpJudgmentTransport("https://example.test", client)
+        with pytest.raises(SubmissionActorMismatchError):
+            submit_judgment(record.scope, transport)
+    (home / "config.json").write_bytes(original)
+    assert read_submission(record.scope).phase == "uncertain"


### PR DESCRIPTION
## Why

Durable submission identity is not enough to accept a remote result. The client needs an authenticated transport boundary that checks the operation binding and preserves the exact verified receipt after an uncertain send.

## What changed

- Add an unused HTTPS judgment adapter for explicit submit and lookup, with redirect refusal and no adapter-level resend or token-refresh loop.
- Read the expected actor and bearer token from one config observation; reject an account change before accepting the response.
- Validate the closed response, scope, payload digest and canonical judgment receipt, including manifest and snapshot bindings. Bound response and receipt bytes.
- Add transport failure and receipt-tampering tests and include the affected code in typing checks.

## Test plan

- [All 17 CI jobs passed](https://github.com/Nauro-AI/nauro/actions/runs/34001440601), including Python 3.10 through 3.14 client/core suites and platform generation checks.

- 146 affected client auth, identity, transport and consumer-contract tests passed without skips.
- Explicit paired-server validation: 739 tests passed without skips, including local TLS, real JWT signature verification, dropped commit response, fresh-process recovery and exact receipt replay. Alias conformance also ran with the candidate client interpreter.
- Lint, formatting, targeted typing, source-risk, single-source and docstring checks passed. Combined review and commit comparison found no blocking defect or patch change.

## Risk / what to review

This is a new trust boundary. Review actor checks, origin restrictions, response binding and canonical receipt parsing together. The caller supplies the HTTP client and must configure trusted TLS and suitable transport/auth behavior. Client checks complement server verification; they are not a signature or independent proof of the audit event.

## Deferred

Concurrent writing remains incomplete and production activation is unchanged. The adapter has no production caller. The paired server router remains unregistered and will follow in a separate PR after this one merges. Public route compatibility, worker recovery, canonical refresh, Windows durability, cloud MCP identity and hosted timing remain open. The local TLS test does not prove deployed authentication or production p99 latency.
