### PR TITLE
Parse plain decision frontmatter with the libyaml loader

### DIFF
--- a/packages/nauro-core/src/nauro_core/decision_model.py
+++ b/packages/nauro-core/src/nauro_core/decision_model.py
@@ -18,6 +18,7 @@ deterministic representation in an already-canonical file.
 from __future__ import annotations
 
 import re
+import string
 from datetime import date as _date
 from enum import Enum
 
@@ -279,6 +280,62 @@ _FM_OPEN_FENCE = "---\n"
 _FM_CLOSE_FENCE = "\n---\n"
 _H1_FORMAT = "# {num:03d} \u2014 {title}"
 
+# libyaml parses the frontmatter several times faster than the pure-Python
+# scanner, but the two disagree on exotic input (a tab in a plain scalar, a
+# colon inside a flow sequence, a lone surrogate escape). Only a block made of
+# plain ``key: value``, ``key:`` and ``- item`` lines over a closed character
+# set takes the fast loader; anything else takes the pure loader, so store
+# validity and parsed values never depend on which loader the install carries.
+_FAST_YAML_LOADER = getattr(yaml, "CSafeLoader", yaml.SafeLoader)
+_PLAIN_KEY_CHARS = string.ascii_lowercase + string.digits + "_"
+_PLAIN_VALUE_CHARS = string.ascii_letters + string.digits + " -_./:~(),+"
+
+
+def _load_frontmatter_mapping(frontmatter_block: str) -> object:
+    """Parse a frontmatter block with the fast loader when it is plain enough for
+    both loaders to agree, else with the pure loader. Raises ``yaml.YAMLError``.
+    """
+    loader = _FAST_YAML_LOADER if _is_plain_block(frontmatter_block) else yaml.SafeLoader
+    return yaml.load(frontmatter_block, Loader=loader)
+
+
+def _is_plain_block(block: str) -> bool:
+    """True when every line is a plain ``key: value``, ``key:`` or ``- item`` line."""
+    for line in block.split("\n"):
+        if line == "":
+            continue
+        if line.startswith("- "):
+            if not _is_plain_value(line[2:]):
+                return False
+            continue
+        key, colon, rest = line.partition(":")
+        if not colon or not key or key.strip(_PLAIN_KEY_CHARS):
+            return False
+        if rest and (rest[0] != " " or not _is_plain_value(rest[1:])):
+            return False
+    return True
+
+
+def _is_plain_value(value: str) -> bool:
+    """True for ``[]``, a single-quoted run of plain characters, or an unquoted run
+    that no loader could read as a comment, a nested key or a sequence item.
+    """
+    if value in ("", "[]"):
+        return True
+    if value[0] == "'":
+        inner = value[1:-1]
+        return (
+            len(value) >= 2
+            and value[-1] == "'"
+            and "'" not in inner
+            and not inner.strip(_PLAIN_VALUE_CHARS)
+        )
+    if value.strip(_PLAIN_VALUE_CHARS):
+        return False
+    if value[0] == " " or value[-1] in " :" or ": " in value:
+        return False
+    return not (value[0] == "-" and value[1:2] in ("", " "))
+
 
 def parse_decision(text: str, filename: str) -> Decision:
     """Parse a decision markdown file into a validated ``Decision``: strict on
@@ -288,7 +345,7 @@ def parse_decision(text: str, filename: str) -> Decision:
     frontmatter_block, body = _split_frontmatter(text, filename)
 
     try:
-        metadata = yaml.safe_load(frontmatter_block)
+        metadata = _load_frontmatter_mapping(frontmatter_block)
     except yaml.YAMLError as e:
         raise ValueError(f"{filename}: invalid YAML frontmatter: {e}") from e
 

--- a/packages/nauro-core/tests/test_decision_model.py
+++ b/packages/nauro-core/tests/test_decision_model.py
@@ -18,8 +18,10 @@ from __future__ import annotations
 from datetime import date
 
 import pytest
+import yaml
 from pydantic import ValidationError
 
+from nauro_core import decision_model
 from nauro_core.decision_model import (
     Decision,
     DecisionConfidence,
@@ -1040,3 +1042,91 @@ class TestApprovalProvenance:
     def test_partial_group_rejects(self) -> None:
         with pytest.raises(ValidationError, match="partial approval provenance"):
             _minimal_decision(proposed_by="01K00000000000000000000002")
+
+
+# ── Frontmatter loader parity ──
+
+
+def _with_frontmatter(*lines: str) -> str:
+    return (
+        "---\n"
+        + "".join(f"{line}\n" for line in lines)
+        + "---\n\n"
+        + "# 001 \u2014 Loader parity\n\n"
+        + "## Decision\n\nSomething.\n"
+    )
+
+
+# Blocks where libyaml and the pure loader disagree on their own: a tab in a
+# plain scalar, a colon inside a flow sequence, a lone surrogate escape.
+DIVERGENT_BLOCKS = [
+    _with_frontmatter("date: 2026-04-01", "confidence:\thigh"),
+    _with_frontmatter("date: 2026-04-01", "confidence: high", "files_affected: [a:]"),
+    _with_frontmatter("date: 2026-04-01", "confidence: high", 'note: "\\uD800"'),
+]
+
+
+def _outcome(text: str) -> object:
+    try:
+        return parse_decision(text, "001-test.md").model_dump()
+    except (ValueError, ValidationError) as exc:
+        return type(exc)
+
+
+class TestFrontmatterLoaderParity:
+    """Whatever the install's loader, a decision parses to the same values or fails
+    with the same error, because only plain blocks reach the fast loader."""
+
+    @pytest.mark.parametrize("text,filename", ALL_FIXTURES)
+    def test_fixtures_take_the_fast_path_and_agree_with_the_pure_loader(
+        self, text: str, filename: str, monkeypatch
+    ) -> None:
+        block, _body = _split_frontmatter(text, filename)
+        assert decision_model._is_plain_block(block)
+        fast = parse_decision(text, filename).model_dump()
+        monkeypatch.setattr(decision_model, "_FAST_YAML_LOADER", yaml.SafeLoader)
+        assert parse_decision(text, filename).model_dump() == fast
+
+    @pytest.mark.parametrize("text", DIVERGENT_BLOCKS)
+    def test_divergent_blocks_are_routed_past_the_fast_loader(
+        self, text: str, monkeypatch
+    ) -> None:
+        block, _body = _split_frontmatter(text, "001-test.md")
+        assert not decision_model._is_plain_block(block)
+        with_fast = _outcome(text)
+        monkeypatch.setattr(decision_model, "_FAST_YAML_LOADER", yaml.SafeLoader)
+        assert _outcome(text) == with_fast
+
+    @pytest.mark.skipif(not yaml.__with_libyaml__, reason="libyaml not bound")
+    @pytest.mark.parametrize("text", DIVERGENT_BLOCKS)
+    def test_routing_is_load_bearing_on_this_install(self, text: str) -> None:
+        """Handed straight to libyaml, each block parses differently from the pure loader."""
+        block, _body = _split_frontmatter(text, "001-test.md")
+
+        def load(loader: type) -> object:
+            try:
+                return yaml.load(block, Loader=loader)
+            except yaml.YAMLError as exc:
+                return type(exc).__name__
+
+        assert load(yaml.CSafeLoader) != load(yaml.SafeLoader)
+
+    @pytest.mark.parametrize(
+        "value",
+        ["[]", "''", "'70'", "2026-08-05T10:11:12Z", "src/a b.py", "a:b", "-1", "x (y), z~"],
+    )
+    def test_plain_values(self, value: str) -> None:
+        assert decision_model._is_plain_block(f"key: {value}")
+        assert decision_model._is_plain_block(f"- {value}")
+
+    @pytest.mark.parametrize(
+        "value",
+        ["[a]", "a: b", "a:", " a", "a ", "- a", "-", "a #b", "'it''s'", '"a"', "a?", "\\", "é"],
+    )
+    def test_values_outside_the_plain_grammar(self, value: str) -> None:
+        assert not decision_model._is_plain_block(f"key: {value}")
+        assert not decision_model._is_plain_block(f"- {value}")
+
+    @pytest.mark.parametrize("line", ["Key: a", "a b: c", "key:a", "  key: a", "key", "? key"])
+    def test_lines_outside_the_plain_grammar(self, line: str) -> None:
+        assert not decision_model._is_plain_block(line)


### PR DESCRIPTION
## Why

Decision frontmatter was parsed with PyYAML's pure-Python scanner although libyaml is bound in every supported install. That is about 100 ms of every corpus scan on a 550-decision store, paid on cold starts, on the single-shot CLI and on every read tool. First of four read-path latency PRs from the 2026-09-05 audit.

## What changed

`parse_decision` loads a frontmatter block with `CSafeLoader` when the block is plain: only `key: value`, `key:` and `- item` lines over a closed character set. Anything else, and every install without libyaml, takes `SafeLoader` as before. The two loaders disagree on exotic input in both directions (a tab in a plain scalar, a colon inside a flow sequence, a lone surrogate escape), so the positive grammar is what keeps store validity and parsed values independent of the install. Every canonical file the writer emits is plain.

## Test plan

- New tests: fixtures take the fast path and agree with the pure loader; three divergent blocks are routed past it and behave identically under both; a guard proves each block diverges when handed straight to libyaml; the plain grammar is pinned per value and per line.
- Both suites, ruff check and format, docstring budget and single-sourced checks pass.
- Fuzzed 3.8 million generated blocks that pass the grammar: zero divergences between loaders. All 556 real decision files take the fast path and parse identically under both loaders.
- All ten MCP tool outputs byte-identical before and after on a 556-decision scratch store.

Warm p50 on that store (ms): get_context L0 154 to 46, L1 158 to 45, list_decisions 155 to 49, check_decision 218 to 109, search_decisions 218 to 118, L2 399 to 267.

## Risk / what to review

Error text for malformed frontmatter now depends on the loader (libyaml messages omit the source snippet). Nothing in the repo matches on that text beyond the `invalid YAML` prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
