### PR TITLE
Read only the recent active tail for context levels 0 and 1 and listings

### DIFF
--- a/packages/nauro-core/src/nauro_core/operations/decision_lookup.py
+++ b/packages/nauro-core/src/nauro_core/operations/decision_lookup.py
@@ -11,9 +11,10 @@ here rather than inside either operation module.
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterator
 from typing import NamedTuple
 
-from nauro_core.decision_model import Decision, parse_decision
+from nauro_core.decision_model import Decision, DecisionStatus, parse_decision
 from nauro_core.operations.store import Store
 from nauro_core.parsing import (
     _decision_filename,
@@ -51,9 +52,17 @@ def scan_decision_records(
 
     Results follow :func:`sort_stems_by_number`; parse failures never raise.
     """
+    stems = sort_stems_by_number(store.list_decisions())
+    records, failures = _parse_stems(store, stems)
+    return records, failures, stems
+
+
+def _parse_stems(
+    store: Store, stems: list[str]
+) -> tuple[list[ScannedDecision], list[ParseFailure]]:
+    """Read and parse ``stems`` in the given order, skipping missing and unparseable files."""
     records: list[ScannedDecision] = []
     failures: list[ParseFailure] = []
-    stems = sort_stems_by_number(store.list_decisions())
     bodies = store.read_decisions(stems)
     for stem in stems:
         body = bodies.get(stem)
@@ -65,7 +74,7 @@ def scan_decision_records(
         except Exception as exc:
             logger.debug("Skipping unparseable decision file: %s.md", stem)
             failures.append(ParseFailure(stem=stem, error=str(exc)))
-    return records, failures, stems
+    return records, failures
 
 
 def scan_decisions(store: Store) -> tuple[list[Decision], list[ParseFailure]]:
@@ -84,6 +93,44 @@ def parse_all_decisions(store: Store) -> list[Decision]:
     """
     parsed, _ = scan_decisions(store)
     return parsed
+
+
+# Tail-walk batch size: one bulk read per batch, and a batch grows past this
+# size rather than split a run of stems that share one number.
+_TAIL_WALK_BATCH = 32
+
+
+def parse_recent_active_decisions(store: Store, count: int) -> list[Decision]:
+    """Parse the newest active decisions, walking down from the highest number and
+    stopping once ``count`` are in hand. Returns them in corpus order, so any
+    projection of the full active scan that keeps only its tail is unchanged.
+    """
+    stems = sort_stems_by_number(store.list_decisions())
+    if any(extract_decision_number(stem) is None for stem in stems):
+        return [d for d in parse_all_decisions(store) if d.status is DecisionStatus.active]
+    active: list[Decision] = []
+    if count <= 0:
+        return active
+    for batch in _tail_batches(stems):
+        records, _ = _parse_stems(store, batch)
+        active[:0] = [r.decision for r in records if r.decision.status is DecisionStatus.active]
+        if len(active) >= count:
+            break
+    return active
+
+
+def _tail_batches(stems: list[str]) -> Iterator[list[str]]:
+    """Yield ``stems`` from the end in ascending-order batches of roughly
+    ``_TAIL_WALK_BATCH``, never splitting stems that share one decision number.
+    """
+    end = len(stems)
+    while end > 0:
+        start = max(end - _TAIL_WALK_BATCH, 0)
+        boundary_num = extract_decision_number(stems[start])
+        while start > 0 and extract_decision_number(stems[start - 1]) == boundary_num:
+            start -= 1
+        yield stems[start:end]
+        end = start
 
 
 def parse_decision_or_none(body: str, filename: str) -> Decision | None:

--- a/packages/nauro-core/src/nauro_core/operations/get_context.py
+++ b/packages/nauro-core/src/nauro_core/operations/get_context.py
@@ -15,6 +15,9 @@ outside the kernel's storage protocol.
 from __future__ import annotations
 
 from nauro_core.constants import (
+    L0_DECISIONS_SUMMARY_LIMIT,
+    L1_DECISIONS_LIMIT,
+    L1_DECISIONS_SUMMARY_LIMIT,
     OPEN_QUESTIONS_MD,
     PROJECT_MD,
     STACK_MD,
@@ -23,7 +26,11 @@ from nauro_core.constants import (
     STATE_MD,
 )
 from nauro_core.context import build_l0, build_l1, build_l2
-from nauro_core.operations.decision_lookup import parse_all_decisions
+from nauro_core.decision_model import Decision
+from nauro_core.operations.decision_lookup import (
+    parse_all_decisions,
+    parse_recent_active_decisions,
+)
 from nauro_core.operations.results import ErrorPayload, GetContextResult
 from nauro_core.operations.store import Store
 
@@ -34,6 +41,13 @@ _BUILDERS = {
     0: build_l0,
     1: build_l1,
     2: build_l2,
+}
+
+# Levels 0 and 1 render only the newest active decisions, so they read just
+# that tail; level 2 renders the whole corpus.
+_RECENT_ACTIVE_COUNTS = {
+    0: L0_DECISIONS_SUMMARY_LIMIT,
+    1: L1_DECISIONS_LIMIT + L1_DECISIONS_SUMMARY_LIMIT,
 }
 
 
@@ -88,5 +102,13 @@ def get_context(store: Store, level: int) -> GetContextResult:
         )
 
     files = _load_context_files(store, level)
-    decisions = parse_all_decisions(store)
+    decisions = _load_decisions(store, level)
     return GetContextResult(content=builder(files, decisions))
+
+
+def _load_decisions(store: Store, level: int) -> list[Decision]:
+    """Parse the decisions ``level`` renders: the recent active tail, or everything."""
+    count = _RECENT_ACTIVE_COUNTS.get(level)
+    if count is None:
+        return parse_all_decisions(store)
+    return parse_recent_active_decisions(store, count)

--- a/packages/nauro-core/src/nauro_core/operations/list_decisions.py
+++ b/packages/nauro-core/src/nauro_core/operations/list_decisions.py
@@ -15,8 +15,10 @@ rationale stays inspectable.
 
 from __future__ import annotations
 
-from nauro_core.decision_model import DecisionStatus
-from nauro_core.operations.decision_lookup import parse_all_decisions
+from nauro_core.operations.decision_lookup import (
+    parse_all_decisions,
+    parse_recent_active_decisions,
+)
 from nauro_core.operations.results import DecisionSummary, ListDecisionsResult
 from nauro_core.operations.store import Store
 
@@ -30,10 +32,10 @@ def list_decisions(
 
     ``include_superseded`` retains ``superseded`` rows; the default drops them.
     """
-    decisions = parse_all_decisions(store)
-
-    if not include_superseded:
-        decisions = [d for d in decisions if d.status is DecisionStatus.active]
+    if include_superseded:
+        decisions = parse_all_decisions(store)
+    else:
+        decisions = parse_recent_active_decisions(store, max(limit, 0))
 
     decisions.sort(key=lambda d: d.num, reverse=True)
 

--- a/packages/nauro-core/tests/operations/test_recent_active_tail_walk.py
+++ b/packages/nauro-core/tests/operations/test_recent_active_tail_walk.py
@@ -1,0 +1,123 @@
+"""The bounded tail walk behind ``get_context`` L0 and L1 and ``list_decisions``
+must project exactly what the full scan projects, on a store built to break it:
+duplicate numbers straddling a batch boundary, superseded runs, an unparseable
+file, and a stem with no number that forces the full-scan fallback.
+"""
+
+from __future__ import annotations
+
+from conftest import _seed_decision
+
+from nauro_core.context import build_l0, build_l1
+from nauro_core.decision_model import DecisionStatus
+from nauro_core.operations import InMemoryStore, get_context, list_decisions
+from nauro_core.operations.decision_lookup import (
+    _TAIL_WALK_BATCH,
+    _tail_batches,
+    parse_all_decisions,
+    parse_recent_active_decisions,
+)
+from nauro_core.operations.get_context import _load_context_files
+
+
+class RecordingStore(InMemoryStore):
+    """Counts the stems each bulk read asks for."""
+
+    def __init__(self, decisions: dict[str, str]) -> None:
+        super().__init__(decisions=decisions)
+        self.read_batches: list[list[str]] = []
+
+    def read_decisions(self, stems: list[str]) -> dict[str, str | None]:
+        self.read_batches.append(list(stems))
+        return super().read_decisions(stems)
+
+
+def _adversarial_decisions(total: int) -> dict[str, str]:
+    """``total`` numbered decisions where every fifth one is superseded, the number
+    at the first batch boundary is carried by three stems, and one file is corrupt."""
+    decisions: dict[str, str] = {}
+    boundary = total - _TAIL_WALK_BATCH
+    for num in range(1, total + 1):
+        status = DecisionStatus.superseded if num % 5 == 0 else DecisionStatus.active
+        stem, body = _seed_decision(num, f"Decision {num}", status=status)
+        decisions[stem] = body
+        if num == boundary:
+            for suffix in ("aardvark", "zebra"):
+                dup_stem, dup_body = _seed_decision(
+                    num, f"Twin {suffix}", stem=f"{num:03d}-{suffix}"
+                )
+                decisions[dup_stem] = dup_body
+    corrupt_stem, _ = _seed_decision(total - 2, "Corrupt", stem=f"{total - 2:03d}-corrupt")
+    decisions[corrupt_stem] = "---\nnot: [valid\n---\n# broken\n"
+    return decisions
+
+
+def _reference_active(store: InMemoryStore) -> list:
+    return [d for d in parse_all_decisions(store) if d.status is DecisionStatus.active]
+
+
+def test_tail_batches_never_split_a_number_group() -> None:
+    stems = sorted(_adversarial_decisions(80))
+    batches = list(_tail_batches(stems))
+    assert [s for batch in reversed(batches) for s in batch] == stems
+    for earlier, later in zip(batches[1:], batches[:-1], strict=True):
+        assert earlier[-1][:3] != later[0][:3]
+
+
+def test_recent_active_matches_the_full_scan_tail_and_reads_less() -> None:
+    store = RecordingStore(_adversarial_decisions(80))
+    reference = _reference_active(store)
+    store.read_batches.clear()
+    recent = parse_recent_active_decisions(store, 10)
+    assert len(recent) >= 10
+    assert [d.num for d in recent] == [d.num for d in reference[-len(recent) :]]
+    assert [d.title for d in recent] == [d.title for d in reference[-len(recent) :]]
+    read = sum(len(batch) for batch in store.read_batches)
+    assert read < len(store.list_decisions())
+
+
+def test_recent_active_covers_the_boundary_group_when_the_walk_stops_on_it() -> None:
+    total = 80
+    store = RecordingStore(_adversarial_decisions(total))
+    boundary = total - _TAIL_WALK_BATCH
+    reference = _reference_active(store)
+    count = sum(1 for d in reference if d.num > boundary)
+    recent = parse_recent_active_decisions(store, count + 1)
+    assert [d.num for d in recent] == [d.num for d in reference[-len(recent) :]]
+    assert sum(1 for d in recent if d.num == boundary) == 3
+
+
+def test_recent_active_with_more_than_the_store_holds_returns_all_active() -> None:
+    store = RecordingStore(_adversarial_decisions(40))
+    recent = parse_recent_active_decisions(store, 1000)
+    assert [d.num for d in recent] == [d.num for d in _reference_active(store)]
+
+
+def test_unnumbered_stem_falls_back_to_the_full_scan() -> None:
+    decisions = _adversarial_decisions(60)
+    _, body = _seed_decision(7, "Unnumbered carrier")
+    decisions["notes-without-a-number"] = body
+    store = RecordingStore(decisions)
+    reference = _reference_active(store)
+    store.read_batches.clear()
+    recent = parse_recent_active_decisions(store, 10)
+    assert [d.title for d in recent] == [d.title for d in reference]
+    assert len(store.read_batches) == 1
+    assert len(store.read_batches[0]) == len(store.list_decisions())
+
+
+def test_context_levels_and_listing_match_the_full_scan() -> None:
+    for total in (5, 33, 80, 130):
+        store = InMemoryStore(decisions=_adversarial_decisions(total))
+        full = parse_all_decisions(store)
+        files = _load_context_files(store, 1)
+        assert get_context(store, 0).content == build_l0(files, full)
+        assert get_context(store, 1).content == build_l1(files, full)
+        for limit in (0, 1, 7, 20, 500):
+            expected = sorted(
+                (d for d in full if d.status is DecisionStatus.active),
+                key=lambda d: d.num,
+                reverse=True,
+            )[:limit]
+            got = list_decisions(store, limit=limit).decisions
+            assert [(r.number, r.title) for r in got] == [(d.num, d.title) for d in expected]


### PR DESCRIPTION
## Why

`get_context` L0 and L1 and `list_decisions` render only the newest ten to twenty active decisions but parsed every file in the store. Status is in each file's frontmatter and the number derives from the filename, so walking the sorted stems from the top and stopping once enough active decisions are in hand yields the same projection from a fraction of the reads. Second of four read-path latency PRs.

## What changed

`parse_recent_active_decisions` in `decision_lookup.py` walks the number-sorted stems from the highest down in bulk-read batches (so the cloud transport keeps its fan-out) and returns the active tail in corpus order. `get_context` uses it for levels 0 and 1; `list_decisions` uses it unless `include_superseded` is set. Level 2 and superseded listings still scan everything. The parse-failure skip guard moved into a shared helper.

Two rules keep the walk exact: a batch never splits a run of stems sharing one number (the listing's stable sort orders such twins by stem, so a cut inside the run would pick the wrong ones), and a store with any unnumbered stem falls back to the full scan.

## Test plan

- New adversarial-store test: twins straddling the batch boundary, superseded runs, a corrupt file, an unnumbered stem, and an equivalence sweep of L0, L1 and listings against the full scan over several store sizes and limits.
- Both suites, ruff check and format, docstring budget and single-sourced checks pass.
- All ten MCP tool outputs byte-identical before and after on a 556-decision scratch store.

Warm p50 on that store (ms): get_context L0 154 to 13, L1 158 to 13, list_decisions 155 to 16. Files read per L0 call: 556 to 32.

## Risk / what to review

The hosted server consumes these operations through nauro-core, so its S3 store now sees one or two 32-stem bulk reads instead of one 556-stem read; fewer round trips in every realistic store shape, but not re-measured there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
