### PR TITLE
Memoize decision parses across calls on unchanged bodies

### DIFF
--- a/packages/nauro-core/src/nauro_core/decision_model.py
+++ b/packages/nauro-core/src/nauro_core/decision_model.py
@@ -95,11 +95,11 @@ class RejectedAlternative(BaseModel):
 
 
 class Decision(BaseModel):
-    """Parsed, validated representation of a decision markdown file.
-
-    Frontmatter fields round-trip through YAML; ``num``, ``title``, ``rationale``,
-    ``body`` and ``content`` are derived by the parser. ``extra="allow"`` captures
-    unknown frontmatter keys in ``model_extra`` and preserves them on format.
+    """Parsed, validated decision file. Frontmatter fields round-trip through
+    YAML; ``num``, ``title``, ``rationale``, ``body`` and ``content`` are derived by
+    the parser; ``extra="allow"`` keeps unknown frontmatter keys in ``model_extra``.
+    Store scans share instances across calls: derive changes with ``model_copy``
+    and never mutate an instance or its lists in place.
     """
 
     model_config = ConfigDict(extra="allow", validate_assignment=True)

--- a/packages/nauro-core/src/nauro_core/operations/decision_lookup.py
+++ b/packages/nauro-core/src/nauro_core/operations/decision_lookup.py
@@ -25,6 +25,13 @@ from nauro_core.parsing import (
 
 logger = logging.getLogger("nauro_core.operations.decision_lookup")
 
+# Parsed decisions kept across calls in a long-lived process, keyed by stem and
+# holding the exact body text each one was parsed from. A hit needs the freshly
+# read body to equal the stored one, so an edit, a restore or a same-size swap
+# is a miss; a parse failure is never stored. The Decision objects handed out
+# are shared: callers derive changes with ``model_copy`` and never mutate them.
+_PARSED_BY_STEM: dict[str, tuple[str, Decision]] = {}
+
 
 class ParseFailure(NamedTuple):
     """A decision file that did not round-trip through the v2 parser.
@@ -54,6 +61,7 @@ def scan_decision_records(
     """
     stems = sort_stems_by_number(store.list_decisions())
     records, failures = _parse_stems(store, stems)
+    _forget_unlisted(stems)
     return records, failures, stems
 
 
@@ -69,12 +77,32 @@ def _parse_stems(
         if body is None:
             continue
         try:
-            decision = parse_decision(body, _decision_filename(stem))
+            decision = _parse_memoized(stem, body)
             records.append(ScannedDecision(stem=stem, decision=decision))
         except Exception as exc:
             logger.debug("Skipping unparseable decision file: %s.md", stem)
             failures.append(ParseFailure(stem=stem, error=str(exc)))
     return records, failures
+
+
+def _parse_memoized(stem: str, body: str) -> Decision:
+    """Return the parsed decision for ``body``, reusing the last parse of ``stem``
+    when the body is unchanged. Raises whatever ``parse_decision`` raises.
+    """
+    cached = _PARSED_BY_STEM.get(stem)
+    if cached is not None and cached[0] == body:
+        return cached[1]
+    decision = parse_decision(body, _decision_filename(stem))
+    _PARSED_BY_STEM[stem] = (body, decision)
+    return decision
+
+
+def _forget_unlisted(stems: list[str]) -> None:
+    """Drop memoized parses for stems the store no longer lists."""
+    listed = set(stems)
+    for stem in list(_PARSED_BY_STEM):
+        if stem not in listed:
+            _PARSED_BY_STEM.pop(stem, None)
 
 
 def scan_decisions(store: Store) -> tuple[list[Decision], list[ParseFailure]]:
@@ -108,6 +136,7 @@ def parse_recent_active_decisions(store: Store, count: int) -> list[Decision]:
     stems = sort_stems_by_number(store.list_decisions())
     if any(extract_decision_number(stem) is None for stem in stems):
         return [d for d in parse_all_decisions(store) if d.status is DecisionStatus.active]
+    _forget_unlisted(stems)
     active: list[Decision] = []
     if count <= 0:
         return active

--- a/packages/nauro-core/tests/operations/test_parse_memo.py
+++ b/packages/nauro-core/tests/operations/test_parse_memo.py
@@ -1,0 +1,96 @@
+"""The cross-call parse memo in ``decision_lookup`` must be invisible to callers:
+every scan returns what a fresh parse of the current bodies would, across edits,
+same-size swaps, corruption, deletion, addition and restoration.
+"""
+
+from __future__ import annotations
+
+import pytest
+from conftest import _seed_decision, _store_with
+
+from nauro_core.decision_model import parse_decision
+from nauro_core.operations.decision_lookup import (
+    _PARSED_BY_STEM,
+    scan_decision_records,
+)
+from nauro_core.parsing import _decision_filename, _decision_path
+
+
+@pytest.fixture(autouse=True)
+def _empty_memo():
+    _PARSED_BY_STEM.clear()
+    yield
+    _PARSED_BY_STEM.clear()
+
+
+def _fresh(store) -> list[dict]:
+    return [
+        parse_decision(store.read_decision(stem), _decision_filename(stem)).model_dump()
+        for stem in sorted(store.list_decisions())
+        if _parses(store.read_decision(stem), stem)
+    ]
+
+
+def _parses(body: str, stem: str) -> bool:
+    try:
+        parse_decision(body, _decision_filename(stem))
+    except Exception:
+        return False
+    return True
+
+
+def _scanned(store) -> list[dict]:
+    records, _failures, _stems = scan_decision_records(store)
+    return [r.decision.model_dump() for r in records]
+
+
+def test_unchanged_bodies_reuse_the_parsed_object() -> None:
+    store = _store_with(_seed_decision(1, "One"), _seed_decision(2, "Two"))
+    first, _, _ = scan_decision_records(store)
+    second, _, _ = scan_decision_records(store)
+    assert [r.decision for r in first] == [r.decision for r in second]
+    assert all(a.decision is b.decision for a, b in zip(first, second, strict=True))
+
+
+def test_every_kind_of_change_between_calls_is_seen() -> None:
+    one_stem, one_body = _seed_decision(1, "One")
+    two_stem, two_body = _seed_decision(2, "Two")
+    store = _store_with((one_stem, one_body), (two_stem, two_body))
+    assert _scanned(store) == _fresh(store)
+
+    edited = one_body.replace("Test rationale.", "Edited rationale.")
+    store.write_file(_decision_path(one_stem), edited)
+    assert _scanned(store) == _fresh(store)
+    assert _scanned(store)[0]["rationale"].startswith("Edited")
+
+    swapped = edited.replace("Edited rationale.", "Edited rationalE.")
+    store.write_file(_decision_path(one_stem), swapped)
+    assert len(swapped) == len(edited)
+    assert _scanned(store) == _fresh(store)
+
+    store.write_file(_decision_path(two_stem), "---\nnot: [valid\n---\n# broken\n")
+    records, failures, _ = scan_decision_records(store)
+    assert [f.stem for f in failures] == [two_stem]
+    assert two_stem in _PARSED_BY_STEM
+    assert _PARSED_BY_STEM[two_stem][0] == two_body
+    assert [r.decision.model_dump() for r in records] == _fresh(store)
+
+    store.write_file(_decision_path(two_stem), two_body)
+    assert _scanned(store) == _fresh(store)
+
+    store.delete_file(_decision_path(two_stem))
+    assert _scanned(store) == _fresh(store)
+    assert two_stem not in _PARSED_BY_STEM
+
+    three_stem, three_body = _seed_decision(3, "Three")
+    store.write_file(_decision_path(three_stem), three_body)
+    assert _scanned(store) == _fresh(store)
+    assert set(_PARSED_BY_STEM) == {one_stem, three_stem}
+
+
+def test_a_failing_parse_is_never_stored() -> None:
+    stem = "005-broken"
+    store = _store_with((stem, "---\nnot: [valid\n---\n# broken\n"))
+    _records, failures, _ = scan_decision_records(store)
+    assert [f.stem for f in failures] == [stem]
+    assert stem not in _PARSED_BY_STEM


### PR DESCRIPTION
## Why

Every read tool re-parsed all decision files on every call although the stdio server is long-lived and the files rarely change between an agent's calls. Third of four read-path latency PRs; stacked on the tail-walk PR because both touch the shared parse helper.

## What changed

`decision_lookup.py` keeps the parsed `Decision` for each stem across calls together with the exact body text it came from. A hit requires the freshly read body to equal the stored one: each call still lists and reads the store, so an edit, a restore or a same-size swap is seen, a parse failure is never stored, and stems the store no longer lists are dropped. The first call in a process is unchanged.

Scan results now share `Decision` instances across calls. Every writer in nauro-core, nauro and the hosted server derives changes with `model_copy`; the model docstring records the rule. Freezing the model was not chosen because it carries `validate_assignment` for consumers.

## Test plan

- New tests: identity reuse on unchanged bodies; edit, same-size swap, corruption, restore, delete and add between calls all match a fresh parse; failures never stored.
- Both suites, ruff check and format, docstring budget and single-sourced checks pass.
- Grepped nauro-core, nauro and the hosted server for in-place mutation of scanned decisions: none.
- All ten MCP tool outputs byte-identical before and after on a 556-decision scratch store.

Warm p50 on that store, this PR alone on main (ms): get_context L0 154 to 14, check_decision 218 to 79, search_decisions 218 to 75, L2 399 to 260.

## Risk / what to review

A warm hosted container serving several projects cannot bleed a parse across projects (a hit needs the identical body), but eviction against the current listing means it holds one project's corpus at a time. Performance note only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
