### PR TITLE
Keep the BM25 index across calls while the corpus text is unchanged

### DIFF
--- a/packages/nauro-core/src/nauro_core/search.py
+++ b/packages/nauro-core/src/nauro_core/search.py
@@ -1,7 +1,8 @@
 """BM25 search over decisions.
 
-Builds an in-memory BM25 index per call using bm25s + PyStemmer.
-Index text per decision: title + rationale + rejected-alternative names.
+Builds an in-memory BM25 index with bm25s + PyStemmer, kept across calls while
+the indexed text is unchanged. Index text per decision: title + rationale +
+rejected-alternative names.
 
 Rejected names are indexed because they carry the vocabulary of paths the
 project declined — the bridge for two conflict classes the title+rationale
@@ -16,7 +17,7 @@ declined path's identity).
 from __future__ import annotations
 
 from functools import lru_cache
-from typing import TypedDict
+from typing import Any, TypedDict
 
 from nauro_core.decision_model import Decision, DecisionStatus
 from nauro_core.parsing import _first_sentence_snippet, extract_relevance_snippet
@@ -64,6 +65,34 @@ def _index_text(d: Decision) -> str:
     return f"{d.title} {d.rationale} {names}" if names else f"{d.title} {d.rationale}"
 
 
+# Built indexes kept across calls in a long-lived process, one per stopword
+# setting, each holding the exact corpus text it was built from. A hit needs
+# the corpus rebuilt from the current decisions to equal that text, so any
+# edit, supersession or removal rebuilds. Retrieval never mutates the index.
+_INDEX_BY_STOPWORDS: dict[str | tuple[str, ...], tuple[tuple[str, ...], Any]] = {}
+
+
+def _indexed(corpus: list[str], stopwords: str | list[str]) -> Any:
+    """Return a bm25s retriever over ``corpus``, reusing the last one built for
+    ``stopwords`` when the corpus text is unchanged.
+    """
+    key = stopwords if isinstance(stopwords, str) else tuple(stopwords)
+    text = tuple(corpus)
+    cached = _INDEX_BY_STOPWORDS.get(key)
+    if cached is not None and cached[0] == text:
+        return cached[1]
+
+    import bm25s
+
+    # show_progress=False: bm25s defaults to True; the tqdm output is invisible
+    # in MCP server stderr but pollutes the `nauro check-decision` CLI surface.
+    tokens = bm25s.tokenize(corpus, stopwords=stopwords, stemmer=_stemmer(), show_progress=False)
+    retriever = bm25s.BM25()
+    retriever.index(tokens, show_progress=False)
+    _INDEX_BY_STOPWORDS[key] = (text, retriever)
+    return retriever
+
+
 def bm25_search(
     decisions: list[Decision],
     query: str,
@@ -78,13 +107,7 @@ def bm25_search(
 
     import bm25s
 
-    corpus = [_index_text(d) for d in decisions]
-    # show_progress=False — bm25s defaults to True; the tqdm output is invisible
-    # in MCP server stderr but pollutes the `nauro check-decision` CLI surface.
-    corpus_tokens = bm25s.tokenize(corpus, stopwords="en", stemmer=_stemmer(), show_progress=False)
-
-    retriever = bm25s.BM25()
-    retriever.index(corpus_tokens, show_progress=False)
+    retriever = _indexed([_index_text(d) for d in decisions], "en")
 
     # Clamp k into [0, N]: bm25s/numpy argpartition raises ValueError on a
     # negative k, which a negative limit would otherwise pass straight through.
@@ -137,13 +160,7 @@ def bm25_retrieve(
 
     import bm25s
 
-    corpus = [_index_text(d) for d in active]
-    corpus_tokens = bm25s.tokenize(
-        corpus, stopwords=stopwords, stemmer=_stemmer(), show_progress=False
-    )
-
-    retriever = bm25s.BM25()
-    retriever.index(corpus_tokens, show_progress=False)
+    retriever = _indexed([_index_text(d) for d in active], stopwords)
 
     k = min(top_k, len(active))
     query_tokens = bm25s.tokenize(

--- a/packages/nauro-core/tests/test_search_index_cache.py
+++ b/packages/nauro-core/tests/test_search_index_cache.py
@@ -1,0 +1,92 @@
+"""The cross-call BM25 index cache in ``search`` must be invisible to callers:
+every call ranks exactly as a freshly built index would, across edits,
+supersession, removal and restoration, and the two stopword settings never
+serve each other's index.
+"""
+
+from __future__ import annotations
+
+from conftest import make_decision
+
+from nauro_core.decision_model import DecisionStatus
+from nauro_core.search import _INDEX_BY_STOPWORDS, bm25_retrieve, bm25_search
+
+EXTENDED = ["en", "decision", "approach"]
+
+
+def _corpus() -> list:
+    return [
+        make_decision(1, "Use Auth0 for authentication", "Auth0 handles JWT validation."),
+        make_decision(2, "Chose Memcached for session state", "Simpler than Redis for caching."),
+        make_decision(3, "Use FastAPI for MCP server", "Async support and OpenAPI docs."),
+        make_decision(
+            4, "Defer multi-repo sync", "Single-repo scope for now.", status="superseded"
+        ),
+    ]
+
+
+def _fresh_search(decisions, query, limit=10):
+    _INDEX_BY_STOPWORDS.clear()
+    return bm25_search(decisions, query, limit)
+
+
+def _fresh_retrieve(decisions, query, stopwords="en"):
+    _INDEX_BY_STOPWORDS.clear()
+    return bm25_retrieve(decisions, query, top_k=5, stopwords=stopwords)
+
+
+def test_unchanged_corpus_reuses_the_index() -> None:
+    _INDEX_BY_STOPWORDS.clear()
+    decisions = _corpus()
+    bm25_search(decisions, "auth")
+    first = _INDEX_BY_STOPWORDS["en"][1]
+    bm25_search(decisions, "caching")
+    assert _INDEX_BY_STOPWORDS["en"][1] is first
+
+
+def test_every_corpus_change_ranks_like_a_fresh_index() -> None:
+    queries = ["Auth0 JWT", "Redis caching", "FastAPI Lambda", "multi-repo sync", "nothing here"]
+    decisions = _corpus()
+    _INDEX_BY_STOPWORDS.clear()
+    for query in queries:
+        assert bm25_search(decisions, query) == _fresh_search(decisions, query)
+
+    decisions[1] = decisions[1].model_copy(update={"rationale": "Now about Auth0 JWT validation."})
+    for query in queries:
+        assert bm25_search(decisions, query) == _fresh_search(decisions, query)
+
+    decisions[0] = decisions[0].model_copy(
+        update={"status": DecisionStatus.superseded, "superseded_by": "9"}
+    )
+    for query in queries:
+        assert bm25_retrieve(decisions, query) == _fresh_retrieve(decisions, query)
+
+    removed = decisions.pop(2)
+    for query in queries:
+        assert bm25_search(decisions, query) == _fresh_search(decisions, query)
+
+    decisions.insert(2, removed)
+    for query in queries:
+        assert bm25_search(decisions, query) == _fresh_search(decisions, query)
+        assert bm25_retrieve(decisions, query) == _fresh_retrieve(decisions, query)
+
+
+def test_stopword_settings_keep_separate_indexes() -> None:
+    _INDEX_BY_STOPWORDS.clear()
+    decisions = _corpus()
+    plain = bm25_retrieve(decisions, "decision approach Auth0", stopwords="en")
+    extended = bm25_retrieve(decisions, "decision approach Auth0", stopwords=EXTENDED)
+    assert set(_INDEX_BY_STOPWORDS) == {"en", tuple(EXTENDED)}
+    assert plain == _fresh_retrieve(decisions, "decision approach Auth0", "en")
+    assert extended == _fresh_retrieve(decisions, "decision approach Auth0", EXTENDED)
+
+
+def test_search_and_active_only_retrieve_do_not_share_a_stale_corpus() -> None:
+    _INDEX_BY_STOPWORDS.clear()
+    decisions = _corpus()
+    assert bm25_search(decisions, "multi-repo sync") == _fresh_search(decisions, "multi-repo sync")
+    assert bm25_retrieve(decisions, "multi-repo sync") == _fresh_retrieve(
+        decisions, "multi-repo sync"
+    )
+    assert bm25_retrieve(decisions, "multi-repo sync") == []
+    assert bm25_search(decisions, "multi-repo sync")[0]["number"] == 4


### PR DESCRIPTION
## Why

`check_decision` and `search_decisions` rebuilt the corpus text, tokenized it with the stemmer and indexed a fresh bm25s retriever on every call although only the query changes between calls. Fourth of four read-path latency PRs.

## What changed

`search.py` keeps the built retriever across calls, one per stopword setting, together with the exact tuple of corpus strings it was built from. A hit requires the corpus rebuilt from the current decisions to equal that tuple, so any edit, supersession, removal or reorder rebuilds, and the two callers with different stopword lists and active-versus-full corpora never serve each other's index. bm25s retrieval does not mutate the retriever, so the shared index is read-only. Scoring is untouched.

## Test plan

- New tests: index reuse on an unchanged corpus; edit, supersede, remove and restore all rank like a fresh index; separate slots per stopword setting; the all-decisions and active-only corpora never cross-serve.
- Both suites, ruff check and format, docstring budget and single-sourced checks pass.
- All ten MCP tool outputs byte-identical before and after on a 556-decision scratch store.

Paired same-process A/B on that store, this PR alone (ms): check_decision 217 to 155, search_decisions 216 to 155. Stacked with the other three PRs: check_decision 218 to 14, search_decisions 218 to 14, get_context L0 154 to 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
