### PR TITLE
Capture verified installed generations under the control lock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
           packages/nauro/src/nauro/store/generation_authority.py
           packages/nauro/src/nauro/store/replica_control.py
           packages/nauro/src/nauro/store/generation_installation.py
+          packages/nauro/src/nauro/store/generation_read.py
           packages/nauro/src/nauro/sync/generation_acquisition.py
           packages/nauro/src/nauro/store/submission_records.py
           packages/nauro/src/nauro/sync/judgment_submission.py
@@ -85,6 +86,7 @@ jobs:
           packages/nauro/tests/test_auth.py
           packages/nauro/tests/test_generation_authority.py
           packages/nauro/tests/test_generation_installation.py
+          packages/nauro/tests/test_generation_read.py
           packages/nauro/tests/test_replica_control.py
           packages/nauro/tests/test_sync/test_generation_acquisition.py
           packages/nauro/tests/test_sync/test_submission_records_excluded.py

--- a/packages/nauro/src/nauro/store/generation_read.py
+++ b/packages/nauro/src/nauro/store/generation_read.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from nauro.store.generation_authority import GenerationAuthorityError, GenerationProjectAuthority
+from nauro.store.generation_installation import (
+    GenerationInstallError,
+    _installed_file,
+    _layout,
+    _read_expected,
+    _require_directory,
+    audit_generation_tree,
+)
+from nauro.store.generation_projection import (
+    GenerationProjectionIdentity,
+    GenerationProjectionTarget,
+    GenerationProjectionVerificationError,
+    VerifiedGenerationProjection,
+    _parse_manifest,
+    verify_generation_projection,
+)
+from nauro.store.replica_control import _validate_managed_path, locked_replica_control_snapshot
+from nauro.store.resolution import ResolvedProjectBinding
+
+_MAX_MANIFEST_BYTES = 8 * 1024 * 1024
+_MAX_ARTIFACT_BYTES = 4 * 1024 * 1024
+_MAX_CAPTURE_BYTES = 64 * 1024 * 1024
+
+
+class GenerationReadError(GenerationAuthorityError):
+    code = "generation_read_unavailable"
+
+
+def _capture_file(store_path: Path, path: Path, limit: int) -> bytes:
+    _validate_managed_path(store_path, path)
+    identity, size = _installed_file(path, "selected artifact")
+    if size > limit:
+        raise GenerationReadError("The selected generation exceeds the capture limit.")
+    content = _read_expected(path, size, identity, "selected artifact")
+    _validate_managed_path(store_path, path)
+    if len(content) != size or _installed_file(path, "selected artifact") != (identity, size):
+        raise GenerationReadError("The selected generation changed during capture.")
+    return content
+
+
+def _capture(authority: GenerationProjectAuthority) -> VerifiedGenerationProjection:
+    pointer = authority.pointer
+    identity = GenerationProjectionIdentity.model_validate(
+        {name: getattr(pointer, name) for name in GenerationProjectionIdentity.model_fields}
+    )
+    target = GenerationProjectionTarget(authority.binding, identity)
+    store_path = target.binding.store_path
+    root = _layout(store_path, target).root_path
+    _require_directory(store_path, root, root=True)
+    manifest_json = _capture_file(
+        store_path, root / "manifest.json", min(_MAX_MANIFEST_BYTES, _MAX_CAPTURE_BYTES)
+    )
+    manifest = _parse_manifest(target, manifest_json)
+    total = len(manifest_json)
+    artifacts = []
+    for path in sorted(manifest.artifacts):
+        content = _capture_file(
+            store_path, root / "store" / path, min(_MAX_ARTIFACT_BYTES, _MAX_CAPTURE_BYTES - total)
+        )
+        artifacts.append((path, content))
+        total += len(content)
+    projection = verify_generation_projection(
+        target, manifest_json=manifest_json, artifacts=tuple(artifacts)
+    )
+    audit_generation_tree(root, projection)
+    return projection
+
+
+def read_installed_generation(
+    binding: ResolvedProjectBinding,
+    *,
+    active_user_id: str | None,
+    active_projection_scope_id: str | None,
+    timeout: float = -1,
+) -> VerifiedGenerationProjection:
+    """Capture one complete immutable projection under its replica control lock."""
+    with locked_replica_control_snapshot(
+        binding,
+        active_user_id=active_user_id,
+        active_projection_scope_id=active_projection_scope_id,
+        timeout=timeout,
+    ) as snapshot:
+        authority = snapshot.authority
+        if not isinstance(authority, GenerationProjectAuthority):
+            raise GenerationReadError("The project has no installed generation authority.")
+        try:
+            projection = _capture(authority)
+        except (GenerationInstallError, GenerationProjectionVerificationError) as exc:
+            raise GenerationReadError("The installed generation cannot be verified.") from exc
+        if snapshot.reread_authority() != authority:
+            raise GenerationReadError("The selected generation changed during capture.")
+        return projection
+
+
+__all__ = ["GenerationReadError", "read_installed_generation"]

--- a/packages/nauro/tests/test_generation_read.py
+++ b/packages/nauro/tests/test_generation_read.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import ast
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from nauro.store import generation_installation as installation
+from nauro.store import generation_read as reader
+from nauro.store.generation_authority import RefreshRequiredError, ReplicaActorMismatchError
+from nauro.store.generation_read import GenerationReadError, read_installed_generation
+from tests.test_generation_installation import (
+    ARTIFACTS,
+    OTHER_STATE_ID,
+    SCOPE_ID,
+    USER_ID,
+    _actor,
+    _projection,
+)
+
+
+@pytest.fixture
+def installed(monkeypatch):
+    projection = _projection()
+    projection.target.binding.store_path.mkdir(parents=True)
+    monkeypatch.setattr(installation, "read_active_user_id", lambda: USER_ID)
+    root = installation.install_generation_root(projection)
+    authority = installation.publish_generation_control(root)
+    return projection, root, authority
+
+
+def _read(projection, **kwargs):
+    return read_installed_generation(
+        projection.target.binding,
+        active_user_id=kwargs.get("user", USER_ID),
+        active_projection_scope_id=kwargs.get("scope", SCOPE_ID),
+        timeout=0,
+    )
+
+
+def test_capture_preserves_exact_bytes_after_disk_and_pointer_changes(installed):
+    projection, root, authority = installed
+    captured = _read(projection)
+    assert captured.target == projection.target
+    assert captured.manifest_json == projection.manifest_json
+    assert {a.path: a.content for a in captured.artifacts} == ARTIFACTS
+    (root.root_path / "store/decisions/001-x.md").write_bytes(b"changed")
+    pointer = authority.pointer.model_copy(update={"installed_state_id": OTHER_STATE_ID})
+    (_actor(projection.target.binding.store_path) / "pointer.json").write_bytes(
+        pointer.canonical_bytes()
+    )
+    assert captured.artifacts_by_path["decisions/001-x.md"].content == b"# 001\n"
+    with pytest.raises(TypeError):
+        captured.artifacts_by_path["extra"] = captured.artifacts[0]
+
+
+@pytest.mark.parametrize("defect", ["missing", "corrupt", "extra", "directory", "hardlink"])
+def test_capture_refuses_invalid_root(installed, defect, tmp_path):
+    projection, root, _ = installed
+    artifact = root.root_path / "store/decisions/001-x.md"
+    if defect == "missing":
+        artifact.unlink()
+    elif defect == "corrupt":
+        artifact.write_bytes(b"wrong")
+    elif defect == "extra":
+        (root.root_path / "store/extra.md").write_bytes(b"extra")
+    elif defect == "directory":
+        artifact.unlink()
+        artifact.mkdir()
+    else:
+        (tmp_path / "linked").hardlink_to(artifact)
+    with pytest.raises(GenerationReadError) as raised:
+        _read(projection)
+    assert raised.value.code == "generation_read_unavailable"
+
+
+@pytest.mark.parametrize(
+    "limit", ["_MAX_MANIFEST_BYTES", "_MAX_ARTIFACT_BYTES", "_MAX_CAPTURE_BYTES"]
+)
+def test_capture_refuses_oversized_content(installed, monkeypatch, limit):
+    projection, _, _ = installed
+    monkeypatch.setattr(reader, limit, 1)
+    with pytest.raises(GenerationReadError, match="capture limit"):
+        _read(projection)
+
+
+def test_capture_refuses_pointer_change_before_return(installed, monkeypatch):
+    projection, _, authority = installed
+    original = reader._capture
+
+    def capture(selected):
+        result = original(selected)
+        pointer = authority.pointer.model_copy(update={"installed_state_id": OTHER_STATE_ID})
+        (_actor(projection.target.binding.store_path) / "pointer.json").write_bytes(
+            pointer.canonical_bytes()
+        )
+        return result
+
+    monkeypatch.setattr(reader, "_capture", capture)
+    with pytest.raises(GenerationReadError, match="changed during capture"):
+        _read(projection)
+
+
+def test_capture_keeps_actor_and_scope_refusals_distinct(installed):
+    projection, _, _ = installed
+    with pytest.raises(ReplicaActorMismatchError):
+        _read(projection, user=None)
+    with pytest.raises(RefreshRequiredError):
+        _read(projection, scope="b" * 64)
+
+
+def test_capture_refuses_flat_authority(installed):
+    projection, _, _ = installed
+    with pytest.raises(GenerationReadError, match="no installed generation"):
+        read_installed_generation(
+            replace(projection.target.binding, mode="local", server_url=None),
+            active_user_id=USER_ID,
+            active_projection_scope_id=SCOPE_ID,
+        )
+
+
+def test_capture_has_no_runtime_consumers():
+    root = Path(reader.__file__).parents[1]
+    consumers = []
+    for path in root.rglob("*.py"):
+        for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+            if isinstance(node, ast.ImportFrom) and node.module == "nauro.store.generation_read":
+                consumers.append(path.relative_to(root).as_posix())
+    assert consumers == []
+
+
+def test_capture_refuses_a_replaced_file(installed, monkeypatch):
+    projection, root, _ = installed
+    original = reader._read_expected
+    artifact = root.root_path / "store/decisions/001-x.md"
+
+    def read(path, length, identity, display):
+        result = original(path, length, identity, display)
+        if path == artifact:
+            replacement = artifact.with_suffix(".replacement")
+            replacement.write_bytes(result)
+            replacement.replace(artifact)
+        return result
+
+    monkeypatch.setattr(reader, "_read_expected", read)
+    with pytest.raises(GenerationReadError, match="changed during capture"):
+        _read(projection)
+
+
+def test_capture_holds_control_lock_through_verification(installed, monkeypatch):
+    from nauro.store.replica_control import ReplicaControlBusyError, locked_replica_control_snapshot
+
+    projection, _, _ = installed
+    original = reader._capture
+
+    def capture(authority):
+        with pytest.raises(ReplicaControlBusyError):
+            with locked_replica_control_snapshot(
+                authority.binding,
+                active_user_id=USER_ID,
+                active_projection_scope_id=SCOPE_ID,
+                timeout=0,
+            ):
+                pass
+        return original(authority)
+
+    monkeypatch.setattr(reader, "_capture", capture)
+    assert _read(projection).manifest_json == projection.manifest_json
+    with locked_replica_control_snapshot(
+        projection.target.binding,
+        active_user_id=USER_ID,
+        active_projection_scope_id=SCOPE_ID,
+        timeout=0,
+    ) as snapshot:
+        assert snapshot.authority.pointer.generation_id == projection.target.identity.generation_id
+
+
+def test_capture_refuses_linked_artifact(installed, tmp_path):
+    from nauro.store.replica_control import ReplicaControlReadError
+
+    projection, root, _ = installed
+    artifact = root.root_path / "store/decisions/001-x.md"
+    outside = tmp_path / "outside.md"
+    outside.write_bytes(artifact.read_bytes())
+    artifact.unlink()
+    try:
+        artifact.symlink_to(outside)
+    except OSError:
+        pytest.skip("platform does not permit test symlinks")
+    with pytest.raises(ReplicaControlReadError) as raised:
+        _read(projection)
+    assert raised.value.code == "generation_control_unavailable"


### PR DESCRIPTION
## Why

A local generation read needs one complete snapshot whose bytes remain stable after the actor pointer changes.

## What changed

Add a dormant installed-generation capture function. It selects actor and scope under the existing control lock, bounds and verifies the canonical manifest and artifacts, audits exact root membership, and rejects a changed pointer before returning captured bytes. Include its tests in the existing Linux, macOS, and Windows matrix and its module in targeted typing.

## Test plan

739 affected tests passed, with 77 platform-specific skips. All three explicit cross-repository recovery and alias checks passed without skips. Changed-file lint, formatting, targeted typing, source-risk, single-source, and docstring checks passed.

## Risk / what to review

Review lock ownership, the final pointer comparison, capture limits, and file identity checks. Full capture and the installation audit hold the control lock and read the tree twice. Runtime latency is not established. Artifact bytes are immutable; existing metadata model behavior is unchanged.

## Deferred

Concurrent writing remains incomplete. Store routing, lazy reads, pointer-safe refresh, hosted read integration, and production timing remain open. This function has no runtime consumer. Production activation, durable formats, cleanup, and deployment are unchanged.
